### PR TITLE
[Feature] Support cache select for DataCache

### DIFF
--- a/be/src/agent/task_worker_pool.cpp
+++ b/be/src/agent/task_worker_pool.cpp
@@ -834,7 +834,7 @@ void* ReportDataCacheMetricsTaskWorkerPool::_worker_thread_callback(void* arg_th
         if (config::datacache_enable) {
             const BlockCache* cache = BlockCache::instance();
             const DataCacheMetrics& metrics = cache->cache_metrics();
-            t_metrics = DataCacheUtils::convertMetricsToThrift(metrics);
+            DataCacheUtils::set_metrics_from_thrift(t_metrics, metrics);
         } else {
             t_metrics.__set_status(TDataCacheStatus::DISABLED);
         }

--- a/be/src/agent/task_worker_pool.cpp
+++ b/be/src/agent/task_worker_pool.cpp
@@ -34,8 +34,6 @@
 
 #include "agent/task_worker_pool.h"
 
-#include <block_cache/block_cache.h>
-
 #include <atomic>
 #include <chrono>
 #include <condition_variable>
@@ -50,6 +48,8 @@
 #include "agent/report_task.h"
 #include "agent/resource_group_usage_recorder.h"
 #include "agent/task_signatures_manager.h"
+#include "block_cache/block_cache.h"
+#include "block_cache/datacache_utils.h"
 #include "common/status.h"
 #include "exec/pipeline/query_context.h"
 #include "exec/workgroup/work_group.h"
@@ -834,22 +834,7 @@ void* ReportDataCacheMetricsTaskWorkerPool::_worker_thread_callback(void* arg_th
         if (config::datacache_enable) {
             const BlockCache* cache = BlockCache::instance();
             const DataCacheMetrics& metrics = cache->cache_metrics();
-
-            switch (metrics.status) {
-            case starcache::CacheStatus::NORMAL:
-                t_metrics.__set_status(TDataCacheStatus::NORMAL);
-                break;
-            case starcache::CacheStatus::UPDATING:
-                t_metrics.__set_status(TDataCacheStatus::UPDATING);
-                break;
-            default:
-                t_metrics.__set_status(TDataCacheStatus::ABNORMAL);
-            }
-
-            t_metrics.__set_disk_quota_bytes(metrics.disk_quota_bytes);
-            t_metrics.__set_disk_used_bytes(metrics.disk_used_bytes);
-            t_metrics.__set_mem_quota_bytes(metrics.mem_quota_bytes);
-            t_metrics.__set_mem_used_bytes(metrics.mem_used_bytes);
+            t_metrics = DataCacheUtils::convertMetricsToThrift(metrics);
         } else {
             t_metrics.__set_status(TDataCacheStatus::DISABLED);
         }

--- a/be/src/block_cache/CMakeLists.txt
+++ b/be/src/block_cache/CMakeLists.txt
@@ -26,6 +26,7 @@ set(CACHE_FILES
   block_cache.cpp
   io_buffer.cpp
   cache_options.cpp
+  datacache_utils.cpp
 )
 
 if (${WITH_CACHELIB} STREQUAL "ON")

--- a/be/src/block_cache/datacache_utils.cpp
+++ b/be/src/block_cache/datacache_utils.cpp
@@ -15,9 +15,7 @@
 #include "block_cache/datacache_utils.h"
 
 namespace starrocks {
-TDataCacheMetrics DataCacheUtils::convertMetricsToThrift(const DataCacheMetrics& metrics) {
-    TDataCacheMetrics t_metrics{};
-
+void DataCacheUtils::set_metrics_from_thrift(TDataCacheMetrics& t_metrics, const DataCacheMetrics& metrics) {
     switch (metrics.status) {
     case starcache::CacheStatus::NORMAL:
         t_metrics.__set_status(TDataCacheStatus::NORMAL);
@@ -36,7 +34,6 @@ TDataCacheMetrics DataCacheUtils::convertMetricsToThrift(const DataCacheMetrics&
     t_metrics.__set_disk_used_bytes(metrics.disk_used_bytes);
     t_metrics.__set_mem_quota_bytes(metrics.mem_quota_bytes);
     t_metrics.__set_mem_used_bytes(metrics.mem_used_bytes);
-    return t_metrics;
 }
 
 } // namespace starrocks

--- a/be/src/block_cache/datacache_utils.cpp
+++ b/be/src/block_cache/datacache_utils.cpp
@@ -1,0 +1,42 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "block_cache/datacache_utils.h"
+
+namespace starrocks {
+TDataCacheMetrics DataCacheUtils::convertMetricsToThrift(const DataCacheMetrics& metrics) {
+    TDataCacheMetrics t_metrics{};
+
+    switch (metrics.status) {
+    case starcache::CacheStatus::NORMAL:
+        t_metrics.__set_status(TDataCacheStatus::NORMAL);
+        break;
+    case starcache::CacheStatus::UPDATING:
+        t_metrics.__set_status(TDataCacheStatus::UPDATING);
+        break;
+    case starcache::CacheStatus::LOADING:
+        t_metrics.__set_status(TDataCacheStatus::LOADING);
+        break;
+    default:
+        t_metrics.__set_status(TDataCacheStatus::ABNORMAL);
+    }
+
+    t_metrics.__set_disk_quota_bytes(metrics.disk_quota_bytes);
+    t_metrics.__set_disk_used_bytes(metrics.disk_used_bytes);
+    t_metrics.__set_mem_quota_bytes(metrics.mem_quota_bytes);
+    t_metrics.__set_mem_used_bytes(metrics.mem_used_bytes);
+    return t_metrics;
+}
+
+} // namespace starrocks

--- a/be/src/block_cache/datacache_utils.h
+++ b/be/src/block_cache/datacache_utils.h
@@ -21,7 +21,7 @@ namespace starrocks {
 
 class DataCacheUtils {
 public:
-    static TDataCacheMetrics convertMetricsToThrift(const DataCacheMetrics& metrics);
+    static void set_metrics_from_thrift(TDataCacheMetrics& t_metrics, const DataCacheMetrics& metrics);
 };
 
 } // namespace starrocks

--- a/be/src/block_cache/datacache_utils.h
+++ b/be/src/block_cache/datacache_utils.h
@@ -1,0 +1,27 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include "block_cache/kv_cache.h"
+#include "gen_cpp/DataCache_types.h"
+
+namespace starrocks {
+
+class DataCacheUtils {
+public:
+    static TDataCacheMetrics convertMetricsToThrift(const DataCacheMetrics& metrics);
+};
+
+} // namespace starrocks

--- a/be/src/exec/hdfs_scanner.cpp
+++ b/be/src/exec/hdfs_scanner.cpp
@@ -352,6 +352,7 @@ void HdfsScanner::update_counter() {
             _runtime_state->update_num_datacache_read_time_ns(stats.read_cache_ns);
             _runtime_state->update_num_datacache_write_bytes(stats.write_cache_bytes);
             _runtime_state->update_num_datacache_write_time_ns(stats.write_cache_ns);
+            _runtime_state->update_num_datacache_count(1);
         }
     }
     if (_shared_buffered_input_stream) {

--- a/be/src/exec/hdfs_scanner.cpp
+++ b/be/src/exec/hdfs_scanner.cpp
@@ -344,6 +344,15 @@ void HdfsScanner::update_counter() {
         COUNTER_UPDATE(profile->datacache_write_fail_bytes, stats.write_cache_fail_bytes);
         COUNTER_UPDATE(profile->datacache_read_block_buffer_counter, stats.read_block_buffer_count);
         COUNTER_UPDATE(profile->datacache_read_block_buffer_bytes, stats.read_block_buffer_bytes);
+
+        if (_runtime_state->query_options().__isset.query_type &&
+            _runtime_state->query_options().query_type == TQueryType::LOAD) {
+            // For load query type, we will update load datacache metrics, these metrics are retrived by cache select
+            _runtime_state->update_num_datacache_read_bytes(stats.read_cache_bytes);
+            _runtime_state->update_num_datacache_read_time_ns(stats.read_cache_ns);
+            _runtime_state->update_num_datacache_write_bytes(stats.write_cache_bytes);
+            _runtime_state->update_num_datacache_write_time_ns(stats.write_cache_ns);
+        }
     }
     if (_shared_buffered_input_stream) {
         COUNTER_UPDATE(profile->shared_buffered_shared_io_count, _shared_buffered_input_stream->shared_io_count());

--- a/be/src/exec/schema_scanner/schema_task_runs_scanner.cpp
+++ b/be/src/exec/schema_scanner/schema_task_runs_scanner.cpp
@@ -30,6 +30,7 @@ SchemaScanner::ColumnDesc SchemaTaskRunsScanner::_s_tbls_columns[] = {
         {"CREATE_TIME", TYPE_DATETIME, sizeof(DateTimeValue), true},
         {"FINISH_TIME", TYPE_DATETIME, sizeof(DateTimeValue), true},
         {"STATE", TYPE_VARCHAR, sizeof(StringValue), false},
+        {"CATALOG", TYPE_VARCHAR, sizeof(StringValue), false},
         {"DATABASE", TYPE_VARCHAR, sizeof(StringValue), false},
         {"DEFINITION", TYPE_VARCHAR, sizeof(StringValue), false},
         {"EXPIRE_TIME", TYPE_DATETIME, sizeof(StringValue), true},
@@ -135,29 +136,42 @@ Status SchemaTaskRunsScanner::fill_chunk(ChunkPtr* chunk) {
             break;
         }
         case 6: {
-            // DATABASE
+            // CATALOG
             {
                 ColumnPtr column = (*chunk)->get_column_by_slot_id(6);
+                std::string catalog_name = "default_catalog";
+                if (task_run_info.__isset.catalog) {
+                    catalog_name = task_run_info.catalog;
+                }
+                Slice value(catalog_name.c_str(), catalog_name.length());
+                fill_column_with_slot<TYPE_VARCHAR>(column.get(), (void*)&value);
+            }
+            break;
+        }
+        case 7: {
+            // DATABASE
+            {
+                ColumnPtr column = (*chunk)->get_column_by_slot_id(7);
                 const std::string* db_name = &task_run_info.database;
                 Slice value(db_name->c_str(), db_name->length());
                 fill_column_with_slot<TYPE_VARCHAR>(column.get(), (void*)&value);
             }
             break;
         }
-        case 7: {
+        case 8: {
             // DEFINITION
             {
-                ColumnPtr column = (*chunk)->get_column_by_slot_id(7);
+                ColumnPtr column = (*chunk)->get_column_by_slot_id(8);
                 const std::string* str = &task_run_info.definition;
                 Slice value(str->c_str(), str->length());
                 fill_column_with_slot<TYPE_VARCHAR>(column.get(), (void*)&value);
             }
             break;
         }
-        case 8: {
+        case 9: {
             // EXPIRE_TIME
             {
-                ColumnPtr column = (*chunk)->get_column_by_slot_id(8);
+                ColumnPtr column = (*chunk)->get_column_by_slot_id(9);
                 auto* nullable_column = down_cast<NullableColumn*>(column.get());
                 if (task_run_info.__isset.expire_time) {
                     int64_t expire_time = task_run_info.expire_time;
@@ -174,10 +188,10 @@ Status SchemaTaskRunsScanner::fill_chunk(ChunkPtr* chunk) {
             }
             break;
         }
-        case 9: {
+        case 10: {
             // ERROR_CODE
             {
-                ColumnPtr column = (*chunk)->get_column_by_slot_id(9);
+                ColumnPtr column = (*chunk)->get_column_by_slot_id(10);
                 if (task_run_info.__isset.error_code) {
                     int64_t value = task_run_info.error_code;
                     fill_column_with_slot<TYPE_BIGINT>(column.get(), (void*)&value);
@@ -187,10 +201,10 @@ Status SchemaTaskRunsScanner::fill_chunk(ChunkPtr* chunk) {
             }
             break;
         }
-        case 10: {
+        case 11: {
             // ERROR_MESSAGE
             {
-                ColumnPtr column = (*chunk)->get_column_by_slot_id(10);
+                ColumnPtr column = (*chunk)->get_column_by_slot_id(11);
                 if (task_run_info.__isset.error_message) {
                     const std::string* str = &task_run_info.error_message;
                     Slice value(str->c_str(), str->length());
@@ -202,10 +216,10 @@ Status SchemaTaskRunsScanner::fill_chunk(ChunkPtr* chunk) {
             }
             break;
         }
-        case 11: {
+        case 12: {
             // progress
             {
-                ColumnPtr column = (*chunk)->get_column_by_slot_id(11);
+                ColumnPtr column = (*chunk)->get_column_by_slot_id(12);
                 if (task_run_info.__isset.progress) {
                     const std::string* str = &task_run_info.progress;
                     Slice value(str->c_str(), str->length());
@@ -217,10 +231,10 @@ Status SchemaTaskRunsScanner::fill_chunk(ChunkPtr* chunk) {
             }
             break;
         }
-        case 12: {
+        case 13: {
             // extra_message
             {
-                ColumnPtr column = (*chunk)->get_column_by_slot_id(12);
+                ColumnPtr column = (*chunk)->get_column_by_slot_id(13);
                 if (task_run_info.__isset.extra_message) {
                     const std::string* str = &task_run_info.extra_message;
                     Slice value(str->c_str(), str->length());
@@ -232,10 +246,10 @@ Status SchemaTaskRunsScanner::fill_chunk(ChunkPtr* chunk) {
             }
             break;
         }
-        case 13: {
+        case 14: {
             // properties
             {
-                ColumnPtr column = (*chunk)->get_column_by_slot_id(13);
+                ColumnPtr column = (*chunk)->get_column_by_slot_id(14);
                 const std::string* str = &task_run_info.properties;
                 Slice value(str->c_str(), str->length());
                 fill_column_with_slot<TYPE_VARCHAR>(column.get(), (void*)&value);

--- a/be/src/exec/schema_scanner/schema_tasks_scanner.cpp
+++ b/be/src/exec/schema_scanner/schema_tasks_scanner.cpp
@@ -25,6 +25,7 @@ SchemaScanner::ColumnDesc SchemaTasksScanner::_s_tbls_columns[] = {
         {"TASK_NAME", TYPE_VARCHAR, sizeof(StringValue), false},
         {"CREATE_TIME", TYPE_DATETIME, sizeof(DateTimeValue), true},
         {"SCHEDULE", TYPE_VARCHAR, sizeof(StringValue), false},
+        {"CATALOG", TYPE_VARCHAR, sizeof(StringValue), false},
         {"DATABASE", TYPE_VARCHAR, sizeof(StringValue), false},
         {"DEFINITION", TYPE_VARCHAR, sizeof(StringValue), false},
         {"EXPIRE_TIME", TYPE_DATETIME, sizeof(StringValue), true},
@@ -53,10 +54,15 @@ Status SchemaTasksScanner::start(RuntimeState* state) {
 
 DatumArray SchemaTasksScanner::_build_row() {
     auto& task = _task_result.tasks.at(_task_index++);
+    if (!task.__isset.catalog) {
+        // Compatible for upgrades
+        task.catalog = "default_catalog";
+    }
     return {
             Slice(task.task_name),
             TimestampValue::create_from_unixtime(task.create_time, _runtime_state->timezone_obj()),
             Slice(task.schedule),
+            Slice(task.catalog),
             Slice(task.database),
             Slice(task.definition),
             TimestampValue::create_from_unixtime(task.expire_time, _runtime_state->timezone_obj()),

--- a/be/src/runtime/runtime_state.h
+++ b/be/src/runtime/runtime_state.h
@@ -37,14 +37,14 @@
 #include <atomic>
 #include <fstream>
 #include <memory>
-#include <sstream>
 #include <string>
 #include <string_view>
 #include <unordered_map>
 #include <vector>
 
+#include "block_cache/block_cache.h"
+#include "block_cache/datacache_utils.h"
 #include "cctz/time_zone.h"
-#include "common/constexpr.h"
 #include "common/global_types.h"
 #include "common/object_pool.h"
 #include "exec/pipeline/pipeline_fwd.h"
@@ -305,6 +305,41 @@ public:
         load_params->__set_filtered_rows(num_rows_load_filtered());
         load_params->__set_unselected_rows(num_rows_load_unselected());
         load_params->__set_source_scan_bytes(num_bytes_scan_from_source());
+
+        // Update datacache load metrics
+        if (config::datacache_enable) {
+            update_load_datacache_metrics(load_params);
+        }
+    }
+
+    void update_num_datacache_read_bytes(const int64_t read_bytes) {
+        _num_datacache_read_bytes.fetch_add(read_bytes, std::memory_order_relaxed);
+    }
+
+    void update_num_datacache_read_time_ns(const int64_t read_time) {
+        _num_datacache_read_time_ns.fetch_add(read_time, std::memory_order_relaxed);
+    }
+
+    void update_num_datacache_write_bytes(const int64_t write_bytes) {
+        _num_datacache_write_bytes.fetch_add(write_bytes, std::memory_order_relaxed);
+    }
+
+    void update_num_datacache_write_time_ns(const int64_t write_time) {
+        _num_datacache_write_time_ns.fetch_add(write_time, std::memory_order_relaxed);
+    }
+
+    void update_load_datacache_metrics(TReportExecStatusParams* load_params) const {
+        TLoadDataCacheMetrics metrics{};
+        metrics.__set_read_bytes(_num_datacache_read_bytes.load(std::memory_order_relaxed));
+        metrics.__set_read_time_ns(_num_datacache_read_time_ns.load(std::memory_order_relaxed));
+        metrics.__set_write_bytes(_num_datacache_write_bytes.load(std::memory_order_relaxed));
+        metrics.__set_write_time_ns(_num_datacache_write_time_ns.load(std::memory_order_relaxed));
+
+        const BlockCache* cache = BlockCache::instance();
+        const TDataCacheMetrics datacache_metrics = DataCacheUtils::convertMetricsToThrift(cache->cache_metrics());
+        metrics.__set_metrics(datacache_metrics);
+
+        load_params->__set_load_datacache_metrics(metrics);
     }
 
     std::atomic_int64_t* mutable_total_spill_bytes();
@@ -560,6 +595,12 @@ private:
     std::atomic<int64_t> _num_rows_load_filtered{0};     // unqualified rows
     std::atomic<int64_t> _num_rows_load_unselected{0};   // rows filtered by predicates
     std::atomic<int64_t> _num_bytes_scan_from_source{0}; // total bytes scan from source node
+
+    // datacache select metrics
+    std::atomic<int64_t> _num_datacache_read_bytes{0};
+    std::atomic<int64_t> _num_datacache_read_time_ns{0};
+    std::atomic<int64_t> _num_datacache_write_bytes{0};
+    std::atomic<int64_t> _num_datacache_write_time_ns{0};
 
     std::atomic<int64_t> _num_print_error_rows{0};
     std::atomic<int64_t> _num_log_rejected_rows{0}; // rejected rows

--- a/be/src/runtime/runtime_state.h
+++ b/be/src/runtime/runtime_state.h
@@ -328,12 +328,17 @@ public:
         _num_datacache_write_time_ns.fetch_add(write_time, std::memory_order_relaxed);
     }
 
+    void update_num_datacache_count(const int64_t count) {
+        _num_datacache_count.fetch_add(count, std::memory_order_relaxed);
+    }
+
     void update_load_datacache_metrics(TReportExecStatusParams* load_params) const {
         TLoadDataCacheMetrics metrics{};
         metrics.__set_read_bytes(_num_datacache_read_bytes.load(std::memory_order_relaxed));
         metrics.__set_read_time_ns(_num_datacache_read_time_ns.load(std::memory_order_relaxed));
         metrics.__set_write_bytes(_num_datacache_write_bytes.load(std::memory_order_relaxed));
         metrics.__set_write_time_ns(_num_datacache_write_time_ns.load(std::memory_order_relaxed));
+        metrics.__set_count(_num_datacache_count.load(std::memory_order_relaxed));
 
         const BlockCache* cache = BlockCache::instance();
         TDataCacheMetrics t_metrics{};
@@ -602,6 +607,7 @@ private:
     std::atomic<int64_t> _num_datacache_read_time_ns{0};
     std::atomic<int64_t> _num_datacache_write_bytes{0};
     std::atomic<int64_t> _num_datacache_write_time_ns{0};
+    std::atomic<int64_t> _num_datacache_count{0};
 
     std::atomic<int64_t> _num_print_error_rows{0};
     std::atomic<int64_t> _num_log_rejected_rows{0}; // rejected rows

--- a/be/src/runtime/runtime_state.h
+++ b/be/src/runtime/runtime_state.h
@@ -336,8 +336,9 @@ public:
         metrics.__set_write_time_ns(_num_datacache_write_time_ns.load(std::memory_order_relaxed));
 
         const BlockCache* cache = BlockCache::instance();
-        const TDataCacheMetrics datacache_metrics = DataCacheUtils::convertMetricsToThrift(cache->cache_metrics());
-        metrics.__set_metrics(datacache_metrics);
+        TDataCacheMetrics t_metrics{};
+        DataCacheUtils::set_metrics_from_thrift(t_metrics, cache->cache_metrics());
+        metrics.__set_metrics(t_metrics);
 
         load_params->__set_load_datacache_metrics(metrics);
     }

--- a/be/test/CMakeLists.txt
+++ b/be/test/CMakeLists.txt
@@ -435,6 +435,7 @@ set(EXEC_FILES
         ./storage/lake/lake_persistent_index_test.cpp
         ./storage/lake/replication_txn_manager_test.cpp
         ./storage/lake/persistent_index_sstable_test.cpp
+        ./block_cache/datacache_utils_test.cpp
         )
 
 if ("${WITH_STARCACHE}" STREQUAL "ON" OR "${WITH_CACHELIB}" STREQUAL "ON")

--- a/be/test/block_cache/datacache_utils_test.cpp
+++ b/be/test/block_cache/datacache_utils_test.cpp
@@ -1,0 +1,44 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "block_cache/datacache_utils.h"
+
+#include <gtest/gtest.h>
+
+#include "gen_cpp/DataCache_types.h"
+
+namespace starrocks {
+class DataCacheUtilsTest : public ::testing::Test {};
+
+TEST_F(DataCacheUtilsTest, test_set_metrics_from_thrift) {
+    TDataCacheMetrics t_metrics{};
+    DataCacheMetrics metrics{};
+    metrics.status = starcache::CacheStatus::NORMAL;
+    DataCacheUtils::set_metrics_from_thrift(t_metrics, metrics);
+    ASSERT_EQ(t_metrics.status, TDataCacheStatus::NORMAL);
+
+    metrics.status = starcache::CacheStatus::UPDATING;
+    DataCacheUtils::set_metrics_from_thrift(t_metrics, metrics);
+    ASSERT_EQ(t_metrics.status, TDataCacheStatus::UPDATING);
+
+    metrics.status = starcache::CacheStatus::LOADING;
+    DataCacheUtils::set_metrics_from_thrift(t_metrics, metrics);
+    ASSERT_EQ(t_metrics.status, TDataCacheStatus::LOADING);
+
+    metrics.status = starcache::CacheStatus::ABNORMAL;
+    DataCacheUtils::set_metrics_from_thrift(t_metrics, metrics);
+    ASSERT_EQ(t_metrics.status, TDataCacheStatus::ABNORMAL);
+}
+
+} // namespace starrocks

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/system/information/TaskRunsSystemTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/system/information/TaskRunsSystemTable.java
@@ -34,6 +34,7 @@ public class TaskRunsSystemTable {
                         .column("CREATE_TIME", ScalarType.createType(PrimitiveType.DATETIME))
                         .column("FINISH_TIME", ScalarType.createType(PrimitiveType.DATETIME))
                         .column("STATE", ScalarType.createVarchar(16))
+                        .column("CATALOG", ScalarType.createVarchar(64))
                         .column("DATABASE", ScalarType.createVarchar(64))
                         .column("DEFINITION", ScalarType.createVarchar(MAX_FIELD_VARCHAR_LENGTH))
                         .column("EXPIRE_TIME", ScalarType.createType(PrimitiveType.DATETIME))

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/system/information/TasksSystemTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/system/information/TasksSystemTable.java
@@ -32,6 +32,7 @@ public class TasksSystemTable {
                         .column("TASK_NAME", ScalarType.createVarchar(64))
                         .column("CREATE_TIME", ScalarType.createType(PrimitiveType.DATETIME))
                         .column("SCHEDULE", ScalarType.createVarchar(64))
+                        .column("CATALOG", ScalarType.createVarchar(64))
                         .column("DATABASE", ScalarType.createVarchar(64))
                         .column("DEFINITION", ScalarType.createVarchar(MAX_FIELD_VARCHAR_LENGTH))
                         .column("EXPIRE_TIME", ScalarType.createType(PrimitiveType.DATETIME))

--- a/fe/fe-core/src/main/java/com/starrocks/common/proc/BackendsProcDir.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/proc/BackendsProcDir.java
@@ -224,8 +224,8 @@ public class BackendsProcDir implements ProcDirInterface {
                 if (status != DataCacheMetrics.Status.DISABLED) {
                     backendInfo.add(String.format("Status: %s, DiskUsage: %s, MemUsage: %s",
                             dataCacheMetrics.get().getStatus(),
-                            dataCacheMetrics.get().getDiskUsage(),
-                            dataCacheMetrics.get().getMemUsage()));
+                            dataCacheMetrics.get().getDiskUsageStr(),
+                            dataCacheMetrics.get().getMemUsageStr()));
                 } else {
                     // DataCache is disabled
                     backendInfo.add(String.format("Status: %s", DataCacheMetrics.Status.DISABLED));

--- a/fe/fe-core/src/main/java/com/starrocks/datacache/DataCacheSelectExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/datacache/DataCacheSelectExecutor.java
@@ -43,6 +43,9 @@ public class DataCacheSelectExecutor {
         // force enable datacache and populate
         tmpSessionVariable.setEnableScanDataCache(true);
         tmpSessionVariable.setEnablePopulateDataCache(true);
+        // make sure all accessed data must be cached
+        tmpSessionVariable.setEnableDataCacheAsyncPopulateMode(false);
+        tmpSessionVariable.setEnableDataCacheIOAdaptor(false);
         connectContext.setSessionVariable(tmpSessionVariable);
 
         InsertStmt insertStmt = statement.getInsertStmt();

--- a/fe/fe-core/src/main/java/com/starrocks/datacache/DataCacheSelectExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/datacache/DataCacheSelectExecutor.java
@@ -1,0 +1,86 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.datacache;
+
+import com.google.common.base.Preconditions;
+import com.starrocks.common.UserException;
+import com.starrocks.qe.ConnectContext;
+import com.starrocks.qe.SessionVariable;
+import com.starrocks.qe.StmtExecutor;
+import com.starrocks.qe.scheduler.Coordinator;
+import com.starrocks.server.GlobalStateMgr;
+import com.starrocks.sql.ast.DataCacheSelectStatement;
+import com.starrocks.sql.ast.InsertStmt;
+import com.starrocks.system.Backend;
+import com.starrocks.system.SystemInfoService;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import java.util.Map;
+import java.util.Optional;
+
+public class DataCacheSelectExecutor {
+    private static final Logger LOG = LogManager.getLogger(DataCacheSelectExecutor.class);
+
+    public static Optional<DataCacheSelectMetrics> cacheSelect(DataCacheSelectStatement statement,
+                                                             ConnectContext connectContext) throws Exception {
+        // backup original session variable
+        SessionVariable sessionVariableBackup = connectContext.getSessionVariable();
+        // clone an new session variable
+        SessionVariable tmpSessionVariable = (SessionVariable) connectContext.getSessionVariable().clone();
+        // force enable datacache and populate
+        tmpSessionVariable.setEnableScanDataCache(true);
+        tmpSessionVariable.setEnablePopulateDataCache(true);
+        connectContext.setSessionVariable(tmpSessionVariable);
+
+        InsertStmt insertStmt = statement.getInsertStmt();
+        StmtExecutor stmtExecutor = new StmtExecutor(connectContext, insertStmt);
+        // register new StmtExecutor into current ConnectContext's StmtExecutor, so we can handle ctrl+c command
+        connectContext.getExecutor().registerSubStmtExecutor(stmtExecutor);
+        stmtExecutor.execute();
+
+        if (connectContext.getState().isError()) {
+            // throw exception if StmtExecutor execute failed
+            throw new UserException(connectContext.getState().getErrorMessage());
+        }
+
+        DataCacheSelectMetrics metrics = null;
+        Coordinator coordinator = stmtExecutor.getCoordinator();
+        Preconditions.checkNotNull(coordinator, "Coordinator can't be null");
+        coordinator.join(connectContext.getSessionVariable().getQueryTimeoutS());
+        if (coordinator.isDone()) {
+            metrics = stmtExecutor.getCoordinator().getDataCacheSelectMetrics();
+            if (metrics != null) {
+                // update backend's datacache metrics after cache select
+                updateBackendDataCacheMetrics(metrics);
+            }
+        }
+        // set original session variable
+        connectContext.setSessionVariable(sessionVariableBackup);
+        return Optional.ofNullable(metrics);
+    }
+
+    // update BE's datacache metrics after cache select
+    public static void updateBackendDataCacheMetrics(DataCacheSelectMetrics metrics) {
+        final SystemInfoService clusterInfoService = GlobalStateMgr.getCurrentState().getNodeMgr().getClusterInfo();
+        for (Map.Entry<Long, LoadDataCacheMetrics> metric : metrics.getBeMetrics().entrySet()) {
+            Backend backend = clusterInfoService.getBackend(metric.getKey());
+            if (backend == null) {
+                continue;
+            }
+            backend.updateDataCacheMetrics(metric.getValue().getLastDataCacheMetrics());
+        }
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/datacache/DataCacheSelectMetrics.java
+++ b/fe/fe-core/src/main/java/com/starrocks/datacache/DataCacheSelectMetrics.java
@@ -1,0 +1,151 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.datacache;
+
+import com.google.common.collect.Lists;
+import com.starrocks.catalog.Column;
+import com.starrocks.catalog.ScalarType;
+import com.starrocks.monitor.unit.ByteSizeValue;
+import com.starrocks.monitor.unit.TimeValue;
+import com.starrocks.qe.ShowResultSet;
+import com.starrocks.qe.ShowResultSetMetaData;
+import com.starrocks.server.GlobalStateMgr;
+import com.starrocks.system.Backend;
+import com.starrocks.system.SystemInfoService;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+
+public class DataCacheSelectMetrics {
+    private static final ShowResultSetMetaData SIMPLE_META_DATA = ShowResultSetMetaData.builder()
+            .addColumn(new Column("STATUS", ScalarType.createVarcharType()))
+            .addColumn(new Column("ALREADY_CACHED_SIZE", ScalarType.createVarcharType()))
+            .addColumn(new Column("WRITE_CACHE_SIZE", ScalarType.createVarcharType()))
+            .addColumn(new Column("WRITE_CACHE_TIME", ScalarType.createVarcharType()))
+            .addColumn(new Column("TOTAL_CACHE_USAGE", ScalarType.createVarcharType()))
+            .build();
+
+    private static final ShowResultSetMetaData VERBOSE_META_DATA = ShowResultSetMetaData.builder()
+            .addColumn(new Column("BE_IP", ScalarType.createVarcharType()))
+            .addColumn(new Column("STATUS", ScalarType.createVarcharType()))
+            .addColumn(new Column("ALREADY_CACHED_SIZE", ScalarType.createVarcharType()))
+            .addColumn(new Column("WRITE_CACHE_SIZE", ScalarType.createVarcharType()))
+            .addColumn(new Column("WRITE_CACHE_TIME", ScalarType.createVarcharType()))
+            .addColumn(new Column("TOTAL_CACHE_USAGE", ScalarType.createVarcharType()))
+            .build();
+
+    private final Map<Long, LoadDataCacheMetrics> beMetrics = new HashMap<>();
+
+    public void updateLoadDataCacheMetrics(long backendId, LoadDataCacheMetrics metrics) {
+        beMetrics.merge(backendId, metrics, LoadDataCacheMetrics::mergeMetrics);
+    }
+
+    public ShowResultSet getShowResultSet(boolean isVerbose) {
+        if (isVerbose) {
+            return getVerboseShowResultSet();
+        } else {
+            return getSimpleShowResultSet();
+        }
+    }
+
+    public Map<Long, LoadDataCacheMetrics> getBeMetrics() {
+        return beMetrics;
+    }
+
+    private ShowResultSet getVerboseShowResultSet() {
+        final SystemInfoService clusterInfoService = GlobalStateMgr.getCurrentState().getNodeMgr().getClusterInfo();
+        List<List<String>> rows = Lists.newArrayList();
+        for (Map.Entry<Long, LoadDataCacheMetrics> entry : beMetrics.entrySet()) {
+            List<String> row = Lists.newArrayList();
+            LoadDataCacheMetrics metrics = entry.getValue();
+
+            long backendId = entry.getKey();
+            Backend backend = clusterInfoService.getBackend(backendId);
+            if (backend == null) {
+                row.add("N/A");
+            } else {
+                row.add(backend.getIP());
+            }
+
+            row.add("SUCCESS");
+
+            row.add(metrics.getReadBytes().toString());
+            row.add(metrics.getWriteBytes().toString());
+            row.add(metrics.getWriteTimeNs().toString());
+            row.add(String.format("%.2f%%", metrics.getLastDataCacheMetrics().getCacheUsage() * 100));
+
+            rows.add(row);
+        }
+        return new ShowResultSet(VERBOSE_META_DATA, rows);
+    }
+
+    private ShowResultSet getSimpleShowResultSet() {
+        long alreadyCachedSize = 0;
+        long writeCacheSize = 0;
+        long writeCacheTime = 0;
+        long totalCacheSize = 0;
+        long totalUsedCacheSize = 0;
+
+        for (Map.Entry<Long, LoadDataCacheMetrics> entry : beMetrics.entrySet()) {
+            LoadDataCacheMetrics metrics = entry.getValue();
+            alreadyCachedSize += metrics.getReadBytes().getBytes();
+            writeCacheSize += metrics.getWriteBytes().getBytes();
+            writeCacheTime += metrics.getWriteTimeNs().getNanos();
+            totalCacheSize += metrics.getLastDataCacheMetrics().getDiskQuotaBytes().getBytes() +
+                    metrics.getLastDataCacheMetrics().getMemQuoteBytes().getBytes();
+            totalUsedCacheSize += metrics.getLastDataCacheMetrics().getDiskUsedBytes().getBytes() +
+                    metrics.getLastDataCacheMetrics().getMemUsedBytes().getBytes();
+        }
+
+        List<List<String>> rows = Lists.newArrayList();
+        List<String> row = Lists.newArrayList();
+        rows.add(row);
+
+        row.add("SUCCESS");
+        row.add(new ByteSizeValue(alreadyCachedSize).toString());
+        row.add(new ByteSizeValue(writeCacheSize).toString());
+        row.add(new TimeValue(writeCacheTime, TimeUnit.NANOSECONDS).toString());
+        row.add(String.format("%.2f%%", ((double) totalUsedCacheSize / totalCacheSize) * 100));
+        return new ShowResultSet(SIMPLE_META_DATA, rows);
+    }
+
+    @Override
+    public String toString() {
+        long alreadyCachedSize = 0;
+        long writeCacheSize = 0;
+        long writeCacheTime = 0;
+        long totalCacheSize = 0;
+        long totalUsedCacheSize = 0;
+
+        for (Map.Entry<Long, LoadDataCacheMetrics> entry : beMetrics.entrySet()) {
+            LoadDataCacheMetrics metrics = entry.getValue();
+            alreadyCachedSize += metrics.getReadBytes().getBytes();
+            writeCacheSize += metrics.getWriteBytes().getBytes();
+            writeCacheTime += metrics.getWriteTimeNs().getNanos();
+            totalCacheSize += metrics.getLastDataCacheMetrics().getDiskQuotaBytes().getBytes() +
+                    metrics.getLastDataCacheMetrics().getMemQuoteBytes().getBytes();
+            totalUsedCacheSize += metrics.getLastDataCacheMetrics().getDiskUsedBytes().getBytes() +
+                    metrics.getLastDataCacheMetrics().getMemUsedBytes().getBytes();
+        }
+
+        return String.format(
+                "AlreadyCachedSize: %s, WriteCacheSize: %s, WriteCacheTime: %s, TotalCacheUsage: %.2f%%",
+                new ByteSizeValue(alreadyCachedSize), new ByteSizeValue(writeCacheSize),
+                new TimeValue(writeCacheTime, TimeUnit.NANOSECONDS),
+                ((double) totalUsedCacheSize / totalCacheSize) * 100);
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/datacache/DataCacheSelectMetrics.java
+++ b/fe/fe-core/src/main/java/com/starrocks/datacache/DataCacheSelectMetrics.java
@@ -35,7 +35,7 @@ public class DataCacheSelectMetrics {
             .addColumn(new Column("STATUS", ScalarType.createVarcharType()))
             .addColumn(new Column("ALREADY_CACHED_SIZE", ScalarType.createVarcharType()))
             .addColumn(new Column("WRITE_CACHE_SIZE", ScalarType.createVarcharType()))
-            .addColumn(new Column("WRITE_CACHE_TIME", ScalarType.createVarcharType()))
+            .addColumn(new Column("AVG_WRITE_CACHE_TIME", ScalarType.createVarcharType()))
             .addColumn(new Column("TOTAL_CACHE_USAGE", ScalarType.createVarcharType()))
             .build();
 
@@ -118,7 +118,11 @@ public class DataCacheSelectMetrics {
         row.add("SUCCESS");
         row.add(new ByteSizeValue(alreadyCachedSize).toString());
         row.add(new ByteSizeValue(writeCacheSize).toString());
-        row.add(new TimeValue(writeCacheTime, TimeUnit.NANOSECONDS).toString());
+
+        // get avg write cache time
+        Double avgWriteCacheTime = Math.ceil((double) writeCacheTime / beMetrics.size());
+        row.add(new TimeValue(avgWriteCacheTime.longValue(), TimeUnit.NANOSECONDS).toString());
+
         row.add(String.format("%.2f%%", ((double) totalUsedCacheSize / totalCacheSize) * 100));
         return new ShowResultSet(SIMPLE_META_DATA, rows);
     }
@@ -142,10 +146,13 @@ public class DataCacheSelectMetrics {
                     metrics.getLastDataCacheMetrics().getMemUsedBytes().getBytes();
         }
 
+        // get avg write cache time
+        Double avgWriteCacheTime = Math.ceil((double) writeCacheTime / beMetrics.size());
+
         return String.format(
-                "AlreadyCachedSize: %s, WriteCacheSize: %s, WriteCacheTime: %s, TotalCacheUsage: %.2f%%",
+                "AlreadyCachedSize: %s, WriteCacheSize: %s, AvgWriteCacheTime: %s, TotalCacheUsage: %.2f%%",
                 new ByteSizeValue(alreadyCachedSize), new ByteSizeValue(writeCacheSize),
-                new TimeValue(writeCacheTime, TimeUnit.NANOSECONDS),
+                new TimeValue(avgWriteCacheTime.longValue(), TimeUnit.NANOSECONDS),
                 ((double) totalUsedCacheSize / totalCacheSize) * 100);
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/datacache/LoadDataCacheMetrics.java
+++ b/fe/fe-core/src/main/java/com/starrocks/datacache/LoadDataCacheMetrics.java
@@ -1,0 +1,102 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.datacache;
+
+import com.starrocks.monitor.unit.ByteSizeValue;
+import com.starrocks.monitor.unit.TimeValue;
+import com.starrocks.thrift.TLoadDataCacheMetrics;
+
+import java.util.concurrent.TimeUnit;
+
+public class LoadDataCacheMetrics {
+    private final ByteSizeValue readBytes;
+    private final TimeValue readTimeNs;
+    private final ByteSizeValue writeBytes;
+    private final TimeValue writeTimeNs;
+
+    private final DataCacheMetrics lastDataCacheMetrics;
+
+    private LoadDataCacheMetrics(ByteSizeValue readBytes, TimeValue readTimeNs, ByteSizeValue writeBytes,
+                                 TimeValue writeTimeNs,
+                                 DataCacheMetrics lastDataCacheMetrics) {
+        this.readBytes = readBytes;
+        this.readTimeNs = readTimeNs;
+        this.writeBytes = writeBytes;
+        this.writeTimeNs = writeTimeNs;
+        this.lastDataCacheMetrics = lastDataCacheMetrics;
+    }
+
+    public static LoadDataCacheMetrics mergeMetrics(LoadDataCacheMetrics before, LoadDataCacheMetrics now) {
+        ByteSizeValue mergedReadBytes =
+                new ByteSizeValue(before.getReadBytes().getBytes() + now.getReadBytes().getBytes());
+        TimeValue mergedReadTimeNs = new TimeValue(before.getReadTimeNs().nanos() + now.getReadTimeNs().nanos(),
+                TimeUnit.NANOSECONDS);
+        ByteSizeValue mergedWriteBytes =
+                new ByteSizeValue(before.getWriteBytes().getBytes() + now.getWriteBytes().getBytes());
+        TimeValue mergedWriteTimeNs =
+                new TimeValue(before.getWriteTimeNs().nanos() + now.getWriteTimeNs().nanos(), TimeUnit.NANOSECONDS);
+        return new LoadDataCacheMetrics(mergedReadBytes, mergedReadTimeNs, mergedWriteBytes, mergedWriteTimeNs,
+                now.getLastDataCacheMetrics());
+    }
+
+    public static LoadDataCacheMetrics buildFromThrift(TLoadDataCacheMetrics tLoadDataCacheMetrics) {
+        long readBytes = 0;
+        long readTimeNs = 0;
+        long writeBytes = 0;
+        long writeTimeNs = 0;
+        DataCacheMetrics dataCacheMetrics;
+        if (tLoadDataCacheMetrics.isSetRead_bytes()) {
+            readBytes = tLoadDataCacheMetrics.read_bytes;
+        }
+        if (tLoadDataCacheMetrics.isSetRead_time_ns()) {
+            readTimeNs = tLoadDataCacheMetrics.read_time_ns;
+        }
+        if (tLoadDataCacheMetrics.isSetWrite_bytes()) {
+            writeBytes = tLoadDataCacheMetrics.write_bytes;
+        }
+        if (tLoadDataCacheMetrics.isSetWrite_time_ns()) {
+            writeTimeNs = tLoadDataCacheMetrics.write_time_ns;
+        }
+
+        if (tLoadDataCacheMetrics.isSetMetrics()) {
+            dataCacheMetrics = DataCacheMetrics.buildFromThrift(tLoadDataCacheMetrics.metrics);
+        } else {
+            dataCacheMetrics = DataCacheMetrics.buildEmpty();
+        }
+
+        return new LoadDataCacheMetrics(new ByteSizeValue(readBytes), new TimeValue(readTimeNs, TimeUnit.NANOSECONDS),
+                new ByteSizeValue(writeBytes), new TimeValue(writeTimeNs, TimeUnit.NANOSECONDS), dataCacheMetrics);
+    }
+
+    public ByteSizeValue getReadBytes() {
+        return readBytes;
+    }
+
+    public TimeValue getReadTimeNs() {
+        return readTimeNs;
+    }
+
+    public ByteSizeValue getWriteBytes() {
+        return writeBytes;
+    }
+
+    public TimeValue getWriteTimeNs() {
+        return writeTimeNs;
+    }
+
+    public DataCacheMetrics getLastDataCacheMetrics() {
+        return lastDataCacheMetrics;
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/datacache/LoadDataCacheMetrics.java
+++ b/fe/fe-core/src/main/java/com/starrocks/datacache/LoadDataCacheMetrics.java
@@ -26,15 +26,19 @@ public class LoadDataCacheMetrics {
     private final ByteSizeValue writeBytes;
     private final TimeValue writeTimeNs;
 
+    // The number of metrics merged
+    private final long count;
+
     private final DataCacheMetrics lastDataCacheMetrics;
 
     private LoadDataCacheMetrics(ByteSizeValue readBytes, TimeValue readTimeNs, ByteSizeValue writeBytes,
-                                 TimeValue writeTimeNs,
+                                 TimeValue writeTimeNs, long count,
                                  DataCacheMetrics lastDataCacheMetrics) {
         this.readBytes = readBytes;
         this.readTimeNs = readTimeNs;
         this.writeBytes = writeBytes;
         this.writeTimeNs = writeTimeNs;
+        this.count = count;
         this.lastDataCacheMetrics = lastDataCacheMetrics;
     }
 
@@ -47,8 +51,9 @@ public class LoadDataCacheMetrics {
                 new ByteSizeValue(before.getWriteBytes().getBytes() + now.getWriteBytes().getBytes());
         TimeValue mergedWriteTimeNs =
                 new TimeValue(before.getWriteTimeNs().nanos() + now.getWriteTimeNs().nanos(), TimeUnit.NANOSECONDS);
+        long mergedCount = before.getCount() + now.getCount();
         return new LoadDataCacheMetrics(mergedReadBytes, mergedReadTimeNs, mergedWriteBytes, mergedWriteTimeNs,
-                now.getLastDataCacheMetrics());
+                mergedCount, now.getLastDataCacheMetrics());
     }
 
     public static LoadDataCacheMetrics buildFromThrift(TLoadDataCacheMetrics tLoadDataCacheMetrics) {
@@ -56,6 +61,7 @@ public class LoadDataCacheMetrics {
         long readTimeNs = 0;
         long writeBytes = 0;
         long writeTimeNs = 0;
+        long count = 0;
         DataCacheMetrics dataCacheMetrics;
         if (tLoadDataCacheMetrics.isSetRead_bytes()) {
             readBytes = tLoadDataCacheMetrics.read_bytes;
@@ -69,6 +75,9 @@ public class LoadDataCacheMetrics {
         if (tLoadDataCacheMetrics.isSetWrite_time_ns()) {
             writeTimeNs = tLoadDataCacheMetrics.write_time_ns;
         }
+        if (tLoadDataCacheMetrics.isSetCount()) {
+            count = tLoadDataCacheMetrics.count;
+        }
 
         if (tLoadDataCacheMetrics.isSetMetrics()) {
             dataCacheMetrics = DataCacheMetrics.buildFromThrift(tLoadDataCacheMetrics.metrics);
@@ -77,7 +86,7 @@ public class LoadDataCacheMetrics {
         }
 
         return new LoadDataCacheMetrics(new ByteSizeValue(readBytes), new TimeValue(readTimeNs, TimeUnit.NANOSECONDS),
-                new ByteSizeValue(writeBytes), new TimeValue(writeTimeNs, TimeUnit.NANOSECONDS), dataCacheMetrics);
+                new ByteSizeValue(writeBytes), new TimeValue(writeTimeNs, TimeUnit.NANOSECONDS), count, dataCacheMetrics);
     }
 
     public ByteSizeValue getReadBytes() {
@@ -94,6 +103,10 @@ public class LoadDataCacheMetrics {
 
     public TimeValue getWriteTimeNs() {
         return writeTimeNs;
+    }
+
+    public long getCount() {
+        return count;
     }
 
     public DataCacheMetrics getLastDataCacheMetrics() {

--- a/fe/fe-core/src/main/java/com/starrocks/qe/DefaultCoordinator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/DefaultCoordinator.java
@@ -53,6 +53,7 @@ import com.starrocks.common.util.AuditStatisticsUtil;
 import com.starrocks.common.util.DebugUtil;
 import com.starrocks.common.util.RuntimeProfile;
 import com.starrocks.connector.exception.RemoteFileNotFoundException;
+import com.starrocks.datacache.DataCacheSelectMetrics;
 import com.starrocks.mysql.MysqlCommand;
 import com.starrocks.planner.PlanFragment;
 import com.starrocks.planner.ResultSink;
@@ -1104,6 +1105,11 @@ public class DefaultCoordinator extends Coordinator {
     @Override
     public List<QueryStatisticsItem.FragmentInstanceInfo> getFragmentInstanceInfos() {
         return executionDAG.getFragmentInstanceInfos();
+    }
+
+    @Override
+    public DataCacheSelectMetrics getDataCacheSelectMetrics() {
+        return queryProfile.getDataCacheSelectMetrics();
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
@@ -2108,6 +2108,14 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
         this.enablePopulateDataCache = enablePopulateDataCache;
     }
 
+    public void setEnableDataCacheAsyncPopulateMode(boolean enableDataCacheAsyncPopulateMode) {
+        this.enableDataCacheAsyncPopulateMode = enableDataCacheAsyncPopulateMode;
+    }
+
+    public void setEnableDataCacheIOAdaptor(boolean enableDataCacheIOAdaptor) {
+        this.enableDataCacheIOAdaptor = enableDataCacheIOAdaptor;
+    }
+
     public boolean isCboUseDBLock() {
         return cboUseDBLock;
     }

--- a/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
@@ -2104,6 +2104,10 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
         this.enableScanDataCache = enableScanDataCache;
     }
 
+    public void setEnablePopulateDataCache(boolean enablePopulateDataCache) {
+        this.enablePopulateDataCache = enablePopulateDataCache;
+    }
+
     public boolean isCboUseDBLock() {
         return cboUseDBLock;
     }

--- a/fe/fe-core/src/main/java/com/starrocks/qe/StmtExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/StmtExecutor.java
@@ -875,6 +875,13 @@ public class StmtExecutor {
         subStmtExecutors.add(subStmtExecutor);
     }
 
+    public List<StmtExecutor> getSubStmtExecutors() {
+        if (subStmtExecutors == null) {
+            return Lists.newArrayList();
+        }
+        return subStmtExecutors;
+    }
+
     // Because this is called by other thread
     public void cancel(String cancelledMessage) {
         if (parsedStmt instanceof DeleteStmt && ((DeleteStmt) parsedStmt).shouldHandledByDeleteHandler()) {

--- a/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/Coordinator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/Coordinator.java
@@ -17,6 +17,7 @@ package com.starrocks.qe.scheduler;
 import com.starrocks.analysis.DescriptorTable;
 import com.starrocks.common.Status;
 import com.starrocks.common.util.RuntimeProfile;
+import com.starrocks.datacache.DataCacheSelectMetrics;
 import com.starrocks.planner.PlanFragment;
 import com.starrocks.planner.ScanNode;
 import com.starrocks.planner.StreamLoadPlanner;
@@ -199,6 +200,8 @@ public abstract class Coordinator {
     public abstract List<String> getRejectedRecordPaths();
 
     public abstract List<QueryStatisticsItem.FragmentInstanceInfo> getFragmentInstanceInfos();
+
+    public abstract DataCacheSelectMetrics getDataCacheSelectMetrics();
 
     // ------------------------------------------------------------------------------------
     // Methods for audit.

--- a/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/QueryRuntimeProfile.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/QueryRuntimeProfile.java
@@ -28,6 +28,8 @@ import com.starrocks.common.util.ProfileManager;
 import com.starrocks.common.util.ProfilingExecPlan;
 import com.starrocks.common.util.RuntimeProfile;
 import com.starrocks.common.util.concurrent.MarkedCountDownLatch;
+import com.starrocks.datacache.DataCacheSelectMetrics;
+import com.starrocks.datacache.LoadDataCacheMetrics;
 import com.starrocks.load.loadv2.LoadJob;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.qe.SessionVariable;
@@ -35,6 +37,7 @@ import com.starrocks.qe.scheduler.dag.FragmentInstanceExecState;
 import com.starrocks.qe.scheduler.dag.JobSpec;
 import com.starrocks.sql.plan.ExecPlan;
 import com.starrocks.task.LoadEtlTask;
+import com.starrocks.thrift.TLoadDataCacheMetrics;
 import com.starrocks.thrift.TReportExecStatusParams;
 import com.starrocks.thrift.TSinkCommitInfo;
 import com.starrocks.thrift.TTabletCommitInfo;
@@ -129,6 +132,9 @@ public class QueryRuntimeProfile {
     // Fields for external table sink
     // ------------------------------------------------------------------------------------
     private final List<TSinkCommitInfo> sinkCommitInfos = Lists.newArrayList();
+
+    // Fields for datacache
+    private final DataCacheSelectMetrics dataCacheSelectMetrics = new DataCacheSelectMetrics();
 
     public QueryRuntimeProfile(ConnectContext connectContext,
                                JobSpec jobSpec,
@@ -325,6 +331,15 @@ public class QueryRuntimeProfile {
         fragmentProfiles.forEach(RuntimeProfile::sortChildren);
     }
 
+    public void updateDataCacheSelectMetrics(long backendId, TLoadDataCacheMetrics tLoadDataCacheMetrics) {
+        LoadDataCacheMetrics loadDataCacheMetrics = LoadDataCacheMetrics.buildFromThrift(tLoadDataCacheMetrics);
+        dataCacheSelectMetrics.updateLoadDataCacheMetrics(backendId, loadDataCacheMetrics);
+    }
+
+    public DataCacheSelectMetrics getDataCacheSelectMetrics() {
+        return dataCacheSelectMetrics;
+    }
+
     public void updateLoadInformation(FragmentInstanceExecState execState, TReportExecStatusParams params) {
         if (params.isSetDelta_urls()) {
             deltaUrls.addAll(params.getDelta_urls());
@@ -349,6 +364,9 @@ public class QueryRuntimeProfile {
         }
         if (params.isSetSink_commit_infos()) {
             sinkCommitInfos.addAll(params.getSink_commit_infos());
+        }
+        if (params.isSetLoad_datacache_metrics()) {
+            updateDataCacheSelectMetrics(params.backend_id, params.load_datacache_metrics);
         }
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/Constants.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/Constants.java
@@ -40,6 +40,7 @@ public class Constants {
         MV,
         INSERT,
         PIPE,
+        DATACACHE_SELECT
     }
 
     // PENDING -> RUNNING -> FAILED

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/DataCacheSelectProcessor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/DataCacheSelectProcessor.java
@@ -1,0 +1,88 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.scheduler;
+
+import com.starrocks.common.UserException;
+import com.starrocks.common.profile.Tracers;
+import com.starrocks.datacache.DataCacheSelectExecutor;
+import com.starrocks.datacache.DataCacheSelectMetrics;
+import com.starrocks.qe.ConnectContext;
+import com.starrocks.qe.StmtExecutor;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.List;
+
+public class DataCacheSelectProcessor extends BaseTaskRunProcessor {
+    private static final Logger LOG = LogManager.getLogger(DataCacheSelectProcessor.class);
+
+    @Override
+    public void processTaskRun(TaskRunContext context) throws Exception {
+        StmtExecutor executor = null;
+        try {
+            ConnectContext ctx = context.getCtx();
+
+            // We need to reset catalog name in ConnectContext, because ctx's session variable was reset in TaskRun::executeTaskRun()
+            String catalogName = context.taskRun.getTask().getCatalogName();
+            ctx.setCurrentCatalog(catalogName);
+
+            ctx.getAuditEventBuilder().reset();
+            ctx.getAuditEventBuilder()
+                    .setTimestamp(System.currentTimeMillis())
+                    .setClientIp(context.getRemoteIp())
+                    .setUser(ctx.getQualifiedUser())
+                    .setCatalog(ctx.getCurrentCatalog())
+                    .setDb(ctx.getDatabase());
+
+            Tracers.register(ctx);
+            executor = ctx.executeSql(context.getDefinition());
+
+            if (ctx.getState().isError()) {
+                // throw exception if StmtExecutor execute failed
+                throw new UserException(ctx.getState().getErrorMessage());
+            }
+
+            // Cache select's metrics is held by sub StmtExecutor
+            DataCacheSelectMetrics metrics = getDataCacheSelectMetrics(executor);
+            DataCacheSelectExecutor.updateBackendDataCacheMetrics(metrics);
+            context.getStatus().setExtraMessage(metrics.toString());
+        } finally {
+            Tracers.close();
+            if (executor != null) {
+                auditAfterExec(context, executor.getParsedStmt(), executor.getQueryStatisticsForAuditLog());
+            } else {
+                // executor can be null if we encounter analysis error.
+                auditAfterExec(context, null, null);
+            }
+        }
+    }
+
+    @NotNull
+    private static DataCacheSelectMetrics getDataCacheSelectMetrics(StmtExecutor executor) throws UserException {
+        List<StmtExecutor> subExecutors = executor.getSubStmtExecutors();
+
+        if (subExecutors.size() != 1) {
+            throw new UserException("No sub executor in DataCache Select");
+        }
+
+        DataCacheSelectMetrics metrics = subExecutors.get(0).getCoordinator().getDataCacheSelectMetrics();
+
+        if (metrics == null) {
+            throw new UserException("Can't retrieve DataCache select metrics");
+        }
+        return metrics;
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/Task.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/Task.java
@@ -51,6 +51,9 @@ public class Task implements Writable {
     @SerializedName("createTime")
     private long createTime;
 
+    @SerializedName("catalogName")
+    private String catalogName;
+
     @SerializedName("dbName")
     private String dbName;
 
@@ -130,6 +133,14 @@ public class Task implements Writable {
 
     public void setCreateTime(long createTime) {
         this.createTime = createTime;
+    }
+
+    public String getCatalogName() {
+        return catalogName;
+    }
+
+    public void setCatalogName(String catalogName) {
+        this.catalogName = catalogName;
     }
 
     public String getDbName() {

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/TaskBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/TaskBuilder.java
@@ -70,6 +70,9 @@ public class TaskBuilder {
         } else if (submitTaskStmt.getCreateTableAsSelectStmt() != null) {
             taskNamePrefix = "ctas-";
             taskSource = Constants.TaskSource.CTAS;
+        } else if (submitTaskStmt.getDataCacheSelectStmt() != null) {
+            taskNamePrefix = "DataCacheSelect-";
+            taskSource = Constants.TaskSource.DATACACHE_SELECT;
         } else {
             throw new SemanticException("Submit task statement is not supported");
         }
@@ -79,6 +82,7 @@ public class TaskBuilder {
         Task task = new Task(taskName);
         task.setSource(taskSource);
         task.setCreateTime(System.currentTimeMillis());
+        task.setCatalogName(submitTaskStmt.getCatalogName());
         task.setDbName(submitTaskStmt.getDbName());
         task.setDefinition(submitTaskStmt.getSqlText());
         task.setProperties(submitTaskStmt.getProperties());

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/TaskRun.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/TaskRun.java
@@ -200,6 +200,7 @@ public class TaskRun implements Comparable<TaskRun> {
             runCtx.setParentConnectContext(parentRunCtx);
         }
         runCtx.setGlobalStateMgr(GlobalStateMgr.getCurrentState());
+        runCtx.setCurrentCatalog(task.getCatalogName());
         runCtx.setDatabase(task.getDbName());
         runCtx.setQualifiedUser(status.getUser());
         runCtx.setCurrentUserIdentity(UserIdentity.createAnalyzedUserIdentWithIp(status.getUser(), "%"));
@@ -311,6 +312,7 @@ public class TaskRun implements Comparable<TaskRun> {
             status.setCreateTime(createTime);
         }
         status.setUser(task.getCreateUser());
+        status.setCatalogName(task.getCatalogName());
         status.setDbName(task.getDbName());
         status.setPostRun(task.getPostRun());
         status.setExpireTime(System.currentTimeMillis() + Config.task_runs_ttl_second * 1000L);

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/TaskRunBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/TaskRunBuilder.java
@@ -50,6 +50,8 @@ public class TaskRunBuilder {
         taskRun.setType(getTaskType());
         if (task.getSource().equals(Constants.TaskSource.MV)) {
             taskRun.setProcessor(new PartitionBasedMvRefreshProcessor());
+        } else if (task.getSource().equals(Constants.TaskSource.DATACACHE_SELECT)) {
+            taskRun.setProcessor(new DataCacheSelectProcessor());
         } else {
             taskRun.setProcessor(new SqlTaskRunProcessor());
         }

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/persist/TaskRunStatus.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/persist/TaskRunStatus.java
@@ -50,6 +50,9 @@ public class TaskRunStatus implements Writable {
     @SerializedName("createTime")
     private long createTime;
 
+    @SerializedName("catalogName")
+    private String catalogName;
+
     @SerializedName("dbName")
     private String dbName;
 
@@ -103,6 +106,9 @@ public class TaskRunStatus implements Writable {
 
     @SerializedName("mvExtraMessage")
     private volatile MVTaskRunExtraMessage mvTaskRunExtraMessage = new MVTaskRunExtraMessage();
+
+    @SerializedName("dataCacheSelectExtraMessage")
+    private volatile String dataCacheSelectExtraMessage;
 
     @SerializedName("properties")
     private volatile Map<String, String> properties;
@@ -172,6 +178,14 @@ public class TaskRunStatus implements Writable {
 
     public void setProgress(int progress) {
         this.progress = progress;
+    }
+
+    public String getCatalogName() {
+        return catalogName;
+    }
+
+    public void setCatalogName(String catalogName) {
+        this.catalogName = catalogName;
     }
 
     public String getDbName() {
@@ -258,6 +272,8 @@ public class TaskRunStatus implements Writable {
     public String getExtraMessage() {
         if (source == Constants.TaskSource.MV) {
             return GsonUtils.GSON.toJson(mvTaskRunExtraMessage);
+        } else if (source == Constants.TaskSource.DATACACHE_SELECT) {
+            return dataCacheSelectExtraMessage;
         } else {
             return "";
         }
@@ -270,6 +286,8 @@ public class TaskRunStatus implements Writable {
         if (source == Constants.TaskSource.MV) {
             this.mvTaskRunExtraMessage =
                     GsonUtils.GSON.fromJson(extraMessage, MVTaskRunExtraMessage.class);
+        } else if (source == Constants.TaskSource.DATACACHE_SELECT) {
+            this.dataCacheSelectExtraMessage = extraMessage;
         } else {
             // do nothing
         }

--- a/fe/fe-core/src/main/java/com/starrocks/service/FrontendServiceImpl.java
+++ b/fe/fe-core/src/main/java/com/starrocks/service/FrontendServiceImpl.java
@@ -788,6 +788,7 @@ public class FrontendServiceImpl implements FrontendService.Iface {
                 scheduleStr += task.getSchedule();
             }
             info.setSchedule(scheduleStr);
+            info.setCatalog(task.getCatalogName());
             info.setDatabase(ClusterNamespace.getNameFromFullName(task.getDbName()));
             info.setDefinition(task.getDefinition());
             info.setExpire_time(task.getExpireTime() / 1000);
@@ -833,6 +834,7 @@ public class FrontendServiceImpl implements FrontendService.Iface {
             info.setCreate_time(status.getCreateTime() / 1000);
             info.setFinish_time(status.getFinishTime() / 1000);
             info.setState(status.getState().toString());
+            info.setCatalog(status.getCatalogName());
             info.setDatabase(ClusterNamespace.getNameFromFullName(status.getDbName()));
             try {
                 // NOTE: use task's definition to display task-run's definition here

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/Analyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/Analyzer.java
@@ -72,6 +72,7 @@ import com.starrocks.sql.ast.CreateTableAsSelectStmt;
 import com.starrocks.sql.ast.CreateTableLikeStmt;
 import com.starrocks.sql.ast.CreateTableStmt;
 import com.starrocks.sql.ast.CreateViewStmt;
+import com.starrocks.sql.ast.DataCacheSelectStatement;
 import com.starrocks.sql.ast.DeleteStmt;
 import com.starrocks.sql.ast.DescStorageVolumeStmt;
 import com.starrocks.sql.ast.DropCatalogStmt;
@@ -302,6 +303,8 @@ public class Analyzer {
             } else if (statement.getInsertStmt() != null) {
                 InsertStmt insertStmt = statement.getInsertStmt();
                 InsertAnalyzer.analyze(insertStmt, context);
+            } else if (statement.getDataCacheSelectStmt() != null) {
+                DataCacheStmtAnalyzer.analyze(statement.getDataCacheSelectStmt(), context);
             } else {
                 throw new SemanticException("Submit task statement is not supported");
             }
@@ -750,6 +753,12 @@ public class Analyzer {
 
         @Override
         public Void visitClearDataCacheRulesStatement(ClearDataCacheRulesStmt statement, ConnectContext context) {
+            DataCacheStmtAnalyzer.analyze(statement, context);
+            return null;
+        }
+
+        @Override
+        public Void visitDataCacheSelectStatement(DataCacheSelectStatement statement, ConnectContext context) {
             DataCacheStmtAnalyzer.analyze(statement, context);
             return null;
         }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AuthorizerStmtVisitor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AuthorizerStmtVisitor.java
@@ -104,6 +104,7 @@ import com.starrocks.sql.ast.CreateTableAsSelectStmt;
 import com.starrocks.sql.ast.CreateTableLikeStmt;
 import com.starrocks.sql.ast.CreateTableStmt;
 import com.starrocks.sql.ast.CreateViewStmt;
+import com.starrocks.sql.ast.DataCacheSelectStatement;
 import com.starrocks.sql.ast.DelBackendBlackListStmt;
 import com.starrocks.sql.ast.DelSqlBlackListStmt;
 import com.starrocks.sql.ast.DeleteStmt;
@@ -1974,9 +1975,18 @@ public class AuthorizerStmtVisitor implements AstVisitor<Void, ConnectContext> {
     public Void visitSubmitTaskStatement(SubmitTaskStmt statement, ConnectContext context) {
         if (statement.getCreateTableAsSelectStmt() != null) {
             visitCreateTableAsSelectStatement(statement.getCreateTableAsSelectStmt(), context);
+        } else if (statement.getDataCacheSelectStmt() != null) {
+            visitDataCacheSelectStatement(statement.getDataCacheSelectStmt(), context);
         } else {
             visitInsertStatement(statement.getInsertStmt(), context);
         }
+        return null;
+    }
+
+    @Override
+    public Void visitDataCacheSelectStatement(DataCacheSelectStatement statement, ConnectContext context) {
+        // check we have permission access source data
+        visitQueryStatement(statement.getInsertStmt().getQueryStatement(), context);
         return null;
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/TaskAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/TaskAnalyzer.java
@@ -31,6 +31,11 @@ import java.util.Map;
 public class TaskAnalyzer {
 
     public static void analyzeSubmitTaskStmt(SubmitTaskStmt submitTaskStmt, ConnectContext session) {
+        String catalogName = submitTaskStmt.getCatalogName();
+        if (Strings.isNullOrEmpty(catalogName)) {
+            catalogName = session.getCurrentCatalog();
+        }
+
         String dbName = submitTaskStmt.getDbName();
         if (Strings.isNullOrEmpty(dbName)) {
             dbName = session.getDatabase();
@@ -38,6 +43,7 @@ public class TaskAnalyzer {
                 ErrorReport.reportSemanticException(ErrorCode.ERR_NO_DB_ERROR);
             }
         }
+        submitTaskStmt.setCatalogName(catalogName);
         submitTaskStmt.setDbName(dbName);
         analyzeTaskProperties(submitTaskStmt.getProperties());
         analyzeTaskSchedule(submitTaskStmt.getSchedule());

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/AstVisitor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/AstVisitor.java
@@ -809,6 +809,10 @@ public interface AstVisitor<R, C> {
         return visitDDLStatement(statement, context);
     }
 
+    default R visitDataCacheSelectStatement(DataCacheSelectStatement statement, C context) {
+        return visitStatement(statement, context);
+    }
+
     // --------------------------------------- Export Statement --------------------------------------------------------
 
     default R visitExportStatement(ExportStmt statement, C context) {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/DataCacheSelectStatement.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/DataCacheSelectStatement.java
@@ -1,0 +1,51 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.sql.ast;
+
+import com.google.common.base.Preconditions;
+import com.starrocks.qe.OriginStatement;
+import com.starrocks.sql.analyzer.AstToSQLBuilder;
+import com.starrocks.sql.parser.NodePosition;
+
+import java.util.Map;
+
+public class DataCacheSelectStatement extends DdlStmt {
+
+    private final InsertStmt insertStmt;
+
+    private final Map<String, String> properties;
+
+
+    public DataCacheSelectStatement(InsertStmt insertStmt, Map<String, String> properties, NodePosition pos) {
+        super(pos);
+        this.insertStmt = insertStmt;
+        this.properties = properties;
+        Preconditions.checkNotNull(properties, "properties can't be null");
+        insertStmt.setOrigStmt(new OriginStatement("CACHE SELECT " + AstToSQLBuilder.toSQL(insertStmt.getQueryStatement())));
+    }
+
+    public InsertStmt getInsertStmt() {
+        return insertStmt;
+    }
+
+    public Map<String, String> getProperties() {
+        return properties;
+    }
+
+    @Override
+    public <R, C> R accept(AstVisitor<R, C> visitor, C context) {
+        return visitor.visitDataCacheSelectStatement(this, context);
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/SubmitTaskStmt.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/SubmitTaskStmt.java
@@ -23,6 +23,7 @@ import com.starrocks.sql.parser.NodePosition;
 import java.util.Map;
 
 public class SubmitTaskStmt extends DdlStmt {
+    private String catalogName;
 
     private String dbName;
 
@@ -36,6 +37,7 @@ public class SubmitTaskStmt extends DdlStmt {
     private TaskSchedule schedule;
 
     private CreateTableAsSelectStmt createTableAsSelectStmt;
+    private DataCacheSelectStatement dataCacheSelectStmt;
     private InsertStmt insertStmt;
 
     public SubmitTaskStmt(TaskName taskName, int sqlBeginIndex, CreateTableAsSelectStmt createTableAsSelectStmt,
@@ -47,12 +49,29 @@ public class SubmitTaskStmt extends DdlStmt {
         this.createTableAsSelectStmt = createTableAsSelectStmt;
     }
 
+    public SubmitTaskStmt(TaskName taskName, int sqlBeginIndex, DataCacheSelectStatement dataCacheSelectStatement,
+                          NodePosition pos) {
+        super(pos);
+        this.dbName = taskName.getDbName();
+        this.taskName = taskName.getName();
+        this.sqlBeginIndex = sqlBeginIndex;
+        this.dataCacheSelectStmt = dataCacheSelectStatement;
+    }
+
     public SubmitTaskStmt(TaskName taskName, int sqlBeginIndex, InsertStmt insertStmt, NodePosition pos) {
         super(pos);
         this.dbName = taskName.getDbName();
         this.taskName = taskName.getName();
         this.sqlBeginIndex = sqlBeginIndex;
         this.insertStmt = insertStmt;
+    }
+
+    public String getCatalogName() {
+        return catalogName;
+    }
+
+    public void setCatalogName(String catalogName) {
+        this.catalogName = catalogName;
     }
 
     public String getDbName() {
@@ -113,6 +132,10 @@ public class SubmitTaskStmt extends DdlStmt {
 
     public InsertStmt getInsertStmt() {
         return insertStmt;
+    }
+
+    public DataCacheSelectStatement getDataCacheSelectStmt() {
+        return dataCacheSelectStmt;
     }
 
     public void setInsertStmt(InsertStmt insertStmt) {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/parser/StarRocks.g4
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/parser/StarRocks.g4
@@ -279,6 +279,7 @@ statement
     | showDataCacheRulesStatement
     | dropDataCacheRuleStatement
     | clearDataCacheRulesStatement
+    | dataCacheSelectStatement
 
     // Export Statement
     | exportStatement
@@ -663,7 +664,7 @@ columnNameWithComment
 submitTaskStatement
     : SUBMIT TASK qualifiedName?
         taskClause*
-        AS (createTableAsSelectStatement | insertStatement )
+        AS (createTableAsSelectStatement | insertStatement | dataCacheSelectStatement)
     ;
 
 taskClause
@@ -1880,6 +1881,10 @@ dropDataCacheRuleStatement
 
 clearDataCacheRulesStatement
     : CLEAR DATACACHE RULES
+    ;
+
+dataCacheSelectStatement
+    : CACHE SELECT selectItem (',' selectItem)* FROM qualifiedName (WHERE where=expression)? properties?
     ;
 
 // ------------------------------------------- Export Statement --------------------------------------------------------

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/DataCacheStmtAnalyzerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/DataCacheStmtAnalyzerTest.java
@@ -18,6 +18,7 @@ import com.starrocks.datacache.DataCacheMgr;
 import com.starrocks.datacache.DataCacheRule;
 import com.starrocks.sql.analyzer.AnalyzeTestUtil;
 import com.starrocks.sql.ast.CreateDataCacheRuleStmt;
+import com.starrocks.sql.ast.DataCacheSelectStatement;
 import com.starrocks.sql.ast.QualifiedName;
 import com.starrocks.sql.plan.ConnectorPlanTestBase;
 import org.elasticsearch.common.collect.List;
@@ -108,5 +109,17 @@ public class DataCacheStmtAnalyzerTest {
         Optional<DataCacheRule> dataCacheRule = DataCacheMgr.getInstance().getCacheRule(stmt.getTarget());
         Assert.assertTrue(dataCacheRule.isPresent());
         Assert.assertEquals("[id = 0, target = hive0.datacache_db.multi_partition_table, predicates = `hive0`.`datacache_db`.`multi_partition_table`.`l_shipdate` > '2012-1-1', priority = -1, properties = NULL]", dataCacheRule.get().toString());
+    }
+
+    @Test
+    public void testCacheSelect() {
+        DataCacheSelectStatement stmt = (DataCacheSelectStatement) analyzeSuccess(
+                "cache select * from hive0.datacache_db.multi_partition_table");
+        Assert.assertEquals("black_hole_catalog.black_hole_db.black_hole_table",
+                stmt.getInsertStmt().getTableName().toString());
+        analyzeSuccess("cache select * from hive0.datacache_db.multi_partition_table where l_shipdate > '2012-1-1'");
+        analyzeFail("cache select * from hive0.datacache_db.not_existed");
+        analyzeFail("cache select * from default_catalog.test.t0",
+                "Currently cache select is only supported in external catalog");
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/datacache/DataCacheMetricsTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/datacache/DataCacheMetricsTest.java
@@ -33,7 +33,7 @@ public class DataCacheMetricsTest {
         tDataCacheMetrics.setMem_quota_bytes(1024 * 1024 * 1024);
         metrics = DataCacheMetrics.buildFromThrift(tDataCacheMetrics);
         Assert.assertEquals(DataCacheMetrics.Status.NORMAL, metrics.getStatus());
-        Assert.assertEquals("0.00GB/1.00GB", metrics.getDiskUsage());
-        Assert.assertEquals("0.00GB/1.00GB", metrics.getMemUsage());
+        Assert.assertEquals("0B/1GB", metrics.getDiskUsageStr());
+        Assert.assertEquals("0B/1GB", metrics.getMemUsageStr());
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/datacache/DataCacheSelectMetricsTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/datacache/DataCacheSelectMetricsTest.java
@@ -66,7 +66,7 @@ public class DataCacheSelectMetricsTest {
         be2.setRead_bytes(2 * megabyte);
         be2.setRead_time_ns(2 * second);
         be2.setWrite_bytes(2 * gigabyte);
-        be2.setWrite_time_ns(20 * second);
+        be2.setWrite_time_ns(35 * second);
 
         be2.setMetrics(dataCacheMetrics);
         LoadDataCacheMetrics be2Metrics = LoadDataCacheMetrics.buildFromThrift(be2);
@@ -75,18 +75,18 @@ public class DataCacheSelectMetricsTest {
         dataCacheSelectMetrics.updateLoadDataCacheMetrics(be2Id, be2Metrics);
 
         List<List<String>> rows = dataCacheSelectMetrics.getShowResultSet(false).getResultRows();
-        Assert.assertEquals("SUCCESS,3MB,3GB,30s,50.00%", String.join(",", rows.get(0)));
+        Assert.assertEquals("SUCCESS,3MB,3GB,22.5s,50.00%", String.join(",", rows.get(0)));
         rows = dataCacheSelectMetrics.getShowResultSet(true).getResultRows();
         for (List<String> row : rows) {
             if (row.get(0).equals("127.0.0.2")) {
                 Assert.assertEquals("127.0.0.2,SUCCESS,1MB,1GB,10s,50.00%", String.join(",", row));
             }
             if (row.get(0).equals("127.0.0.3")) {
-                Assert.assertEquals("127.0.0.3,SUCCESS,2MB,2GB,20s,50.00%", String.join(",", row));
+                Assert.assertEquals("127.0.0.3,SUCCESS,2MB,2GB,35s,50.00%", String.join(",", row));
             }
         }
 
-        Assert.assertEquals("AlreadyCachedSize: 3MB, WriteCacheSize: 3GB, WriteCacheTime: 30s, TotalCacheUsage: 50.00%",
+        Assert.assertEquals("AlreadyCachedSize: 3MB, WriteCacheSize: 3GB, AvgWriteCacheTime: 22.5s, TotalCacheUsage: 50.00%",
                 dataCacheSelectMetrics.toString());
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/datacache/DataCacheSelectMetricsTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/datacache/DataCacheSelectMetricsTest.java
@@ -86,7 +86,8 @@ public class DataCacheSelectMetricsTest {
             }
         }
 
-        Assert.assertEquals("AlreadyCachedSize: 3MB, AvgReadCacheTime: 1.5s, WriteCacheSize: 3GB, AvgWriteCacheTime: 22.5s, TotalCacheUsage: 50.00%",
-                dataCacheSelectMetrics.toString());
+        Assert.assertEquals(
+                "AlreadyCachedSize: 3MB, AvgReadCacheTime: 1.5s, WriteCacheSize: 3GB, AvgWriteCacheTime: 22.5s, " +
+                        "TotalCacheUsage: 50.00%", dataCacheSelectMetrics.toString());
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/datacache/DataCacheSelectMetricsTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/datacache/DataCacheSelectMetricsTest.java
@@ -1,0 +1,92 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.datacache;
+
+import com.starrocks.server.GlobalStateMgr;
+import com.starrocks.system.Backend;
+import com.starrocks.thrift.TDataCacheMetrics;
+import com.starrocks.thrift.TDataCacheStatus;
+import com.starrocks.thrift.TLoadDataCacheMetrics;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.List;
+
+public class DataCacheSelectMetricsTest {
+    private final long megabyte = 1024 * 1024L;
+    private final long gigabyte = 1024 * megabyte;
+
+    private final long second = 1000000000L;
+
+    private final long be1Id = 77778L;
+    private final long be2Id = 77779L;
+
+    @Before
+    public void setup() {
+        GlobalStateMgr.getCurrentState().getNodeMgr().getClusterInfo()
+                .addBackend(new Backend(be1Id, "127.0.0.2", 7777));
+        GlobalStateMgr.getCurrentState().getNodeMgr().getClusterInfo()
+                .addBackend(new Backend(be2Id, "127.0.0.3", 7777));
+    }
+
+    @Test
+    public void testCacheSelectMetrics() {
+        DataCacheSelectMetrics dataCacheSelectMetrics = new DataCacheSelectMetrics();
+
+        TLoadDataCacheMetrics be1 = new TLoadDataCacheMetrics();
+        be1.setRead_bytes(megabyte);
+        be1.setRead_time_ns(second);
+        be1.setWrite_bytes(gigabyte);
+        be1.setWrite_time_ns(10 * second);
+
+        TDataCacheMetrics dataCacheMetrics = new TDataCacheMetrics();
+        dataCacheMetrics.setMem_quota_bytes(gigabyte);
+        dataCacheMetrics.setDisk_quota_bytes(gigabyte);
+        dataCacheMetrics.setMem_used_bytes(gigabyte);
+        dataCacheMetrics.setDisk_used_bytes(0);
+        dataCacheMetrics.setStatus(TDataCacheStatus.NORMAL);
+
+        be1.setMetrics(dataCacheMetrics);
+        LoadDataCacheMetrics be1Metrics = LoadDataCacheMetrics.buildFromThrift(be1);
+
+        TLoadDataCacheMetrics be2 = new TLoadDataCacheMetrics();
+        be2.setRead_bytes(2 * megabyte);
+        be2.setRead_time_ns(2 * second);
+        be2.setWrite_bytes(2 * gigabyte);
+        be2.setWrite_time_ns(20 * second);
+
+        be2.setMetrics(dataCacheMetrics);
+        LoadDataCacheMetrics be2Metrics = LoadDataCacheMetrics.buildFromThrift(be2);
+
+        dataCacheSelectMetrics.updateLoadDataCacheMetrics(be1Id, be1Metrics);
+        dataCacheSelectMetrics.updateLoadDataCacheMetrics(be2Id, be2Metrics);
+
+        List<List<String>> rows = dataCacheSelectMetrics.getShowResultSet(false).getResultRows();
+        Assert.assertEquals("SUCCESS,3MB,3GB,30s,50.00%", String.join(",", rows.get(0)));
+        rows = dataCacheSelectMetrics.getShowResultSet(true).getResultRows();
+        for (List<String> row : rows) {
+            if (row.get(0).equals("127.0.0.2")) {
+                Assert.assertEquals("127.0.0.2,SUCCESS,1MB,1GB,10s,50.00%", String.join(",", row));
+            }
+            if (row.get(0).equals("127.0.0.3")) {
+                Assert.assertEquals("127.0.0.3,SUCCESS,2MB,2GB,20s,50.00%", String.join(",", row));
+            }
+        }
+
+        Assert.assertEquals("AlreadyCachedSize: 3MB, WriteCacheSize: 3GB, WriteCacheTime: 30s, TotalCacheUsage: 50.00%",
+                dataCacheSelectMetrics.toString());
+    }
+}

--- a/fe/fe-core/src/test/java/com/starrocks/datacache/DataCacheSelectMetricsTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/datacache/DataCacheSelectMetricsTest.java
@@ -28,9 +28,7 @@ import java.util.List;
 public class DataCacheSelectMetricsTest {
     private final long megabyte = 1024 * 1024L;
     private final long gigabyte = 1024 * megabyte;
-
     private final long second = 1000000000L;
-
     private final long be1Id = 77778L;
     private final long be2Id = 77779L;
 
@@ -51,6 +49,7 @@ public class DataCacheSelectMetricsTest {
         be1.setRead_time_ns(second);
         be1.setWrite_bytes(gigabyte);
         be1.setWrite_time_ns(10 * second);
+        be1.setCount(1);
 
         TDataCacheMetrics dataCacheMetrics = new TDataCacheMetrics();
         dataCacheMetrics.setMem_quota_bytes(gigabyte);
@@ -67,6 +66,7 @@ public class DataCacheSelectMetricsTest {
         be2.setRead_time_ns(2 * second);
         be2.setWrite_bytes(2 * gigabyte);
         be2.setWrite_time_ns(35 * second);
+        be2.setCount(1);
 
         be2.setMetrics(dataCacheMetrics);
         LoadDataCacheMetrics be2Metrics = LoadDataCacheMetrics.buildFromThrift(be2);
@@ -79,14 +79,14 @@ public class DataCacheSelectMetricsTest {
         rows = dataCacheSelectMetrics.getShowResultSet(true).getResultRows();
         for (List<String> row : rows) {
             if (row.get(0).equals("127.0.0.2")) {
-                Assert.assertEquals("127.0.0.2,SUCCESS,1MB,1GB,10s,50.00%", String.join(",", row));
+                Assert.assertEquals("127.0.0.2,SUCCESS,1MB,1s,1GB,10s,50.00%", String.join(",", row));
             }
             if (row.get(0).equals("127.0.0.3")) {
-                Assert.assertEquals("127.0.0.3,SUCCESS,2MB,2GB,35s,50.00%", String.join(",", row));
+                Assert.assertEquals("127.0.0.3,SUCCESS,2MB,2s,2GB,35s,50.00%", String.join(",", row));
             }
         }
 
-        Assert.assertEquals("AlreadyCachedSize: 3MB, WriteCacheSize: 3GB, AvgWriteCacheTime: 22.5s, TotalCacheUsage: 50.00%",
+        Assert.assertEquals("AlreadyCachedSize: 3MB, AvgReadCacheTime: 1.5s, WriteCacheSize: 3GB, AvgWriteCacheTime: 22.5s, TotalCacheUsage: 50.00%",
                 dataCacheSelectMetrics.toString());
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/datacache/LoadDataCacheMetricsTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/datacache/LoadDataCacheMetricsTest.java
@@ -1,0 +1,82 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.datacache;
+
+import com.starrocks.monitor.unit.ByteSizeValue;
+import com.starrocks.monitor.unit.TimeValue;
+import com.starrocks.thrift.TDataCacheMetrics;
+import com.starrocks.thrift.TDataCacheStatus;
+import com.starrocks.thrift.TLoadDataCacheMetrics;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.concurrent.TimeUnit;
+
+public class LoadDataCacheMetricsTest {
+
+    private final long megabyte = 1024 * 1024L;
+    private final long gigabyte = 1024 * megabyte;
+
+    private final long second = 1000000000L;
+
+    @Test
+    public void testCreateFromThrift() {
+        TLoadDataCacheMetrics tLoadDataCacheMetrics = new TLoadDataCacheMetrics();
+        tLoadDataCacheMetrics.setRead_bytes(megabyte);
+        tLoadDataCacheMetrics.setRead_time_ns(second);
+        tLoadDataCacheMetrics.setWrite_bytes(gigabyte);
+        tLoadDataCacheMetrics.setWrite_time_ns(10 * second);
+
+        LoadDataCacheMetrics metrics = LoadDataCacheMetrics.buildFromThrift(tLoadDataCacheMetrics);
+        Assert.assertEquals(new ByteSizeValue(megabyte), metrics.getReadBytes());
+        Assert.assertEquals(new ByteSizeValue(gigabyte), metrics.getWriteBytes());
+        Assert.assertEquals(new TimeValue(1, TimeUnit.SECONDS), metrics.getReadTimeNs());
+        Assert.assertEquals(new TimeValue(10, TimeUnit.SECONDS), metrics.getWriteTimeNs());
+    }
+
+    @Test
+    public void testMerge() {
+        TLoadDataCacheMetrics before = new TLoadDataCacheMetrics();
+        before.setRead_bytes(megabyte);
+        before.setRead_time_ns(second);
+        before.setWrite_bytes(gigabyte);
+        before.setWrite_time_ns(10 * second);
+
+        TLoadDataCacheMetrics after = new TLoadDataCacheMetrics();
+        after.setRead_bytes(megabyte);
+        after.setRead_time_ns(second);
+        after.setWrite_bytes(gigabyte);
+        after.setWrite_time_ns(10 * second);
+
+        TDataCacheMetrics dataCacheMetrics = new TDataCacheMetrics();
+        dataCacheMetrics.setMem_quota_bytes(gigabyte);
+        dataCacheMetrics.setDisk_quota_bytes(gigabyte);
+        dataCacheMetrics.setMem_used_bytes(0);
+        dataCacheMetrics.setDisk_used_bytes(0);
+        dataCacheMetrics.setStatus(TDataCacheStatus.NORMAL);
+
+        after.setMetrics(dataCacheMetrics);
+
+        LoadDataCacheMetrics beforeMetrics = LoadDataCacheMetrics.buildFromThrift(before);
+        LoadDataCacheMetrics afterMetrics = LoadDataCacheMetrics.buildFromThrift(after);
+        LoadDataCacheMetrics mergedMetrics = LoadDataCacheMetrics.mergeMetrics(beforeMetrics, afterMetrics);
+        Assert.assertEquals(new ByteSizeValue(2 * megabyte), mergedMetrics.getReadBytes());
+        Assert.assertEquals(new ByteSizeValue(2 * gigabyte), mergedMetrics.getWriteBytes());
+        Assert.assertEquals(new TimeValue(2, TimeUnit.SECONDS), mergedMetrics.getReadTimeNs());
+        Assert.assertEquals(new TimeValue(20, TimeUnit.SECONDS), mergedMetrics.getWriteTimeNs());
+        Assert.assertEquals("Status: Normal, DiskUsed: 0B, MemUsed: 0B, DiskQuota: 1GB, MemQuota: 1GB",
+                mergedMetrics.getLastDataCacheMetrics().toString());
+    }
+}

--- a/gensrc/thrift/DataCache.thrift
+++ b/gensrc/thrift/DataCache.thrift
@@ -23,7 +23,8 @@ enum TDataCacheStatus {
     DISABLED,
     NORMAL,
     UPDATING,
-    ABNORMAL
+    ABNORMAL,
+    LOADING
 }
 
 struct TDataCacheMetrics {
@@ -32,4 +33,12 @@ struct TDataCacheMetrics {
     3: optional i64 mem_used_bytes
     4: optional i64 disk_quota_bytes
     5: optional i64 disk_used_bytes
+}
+
+struct TLoadDataCacheMetrics {
+    1: optional i64 read_bytes;
+    2: optional i64 read_time_ns;
+    3: optional i64 write_bytes;
+    4: optional i64 write_time_ns;
+    5: optional TDataCacheMetrics metrics;
 }

--- a/gensrc/thrift/DataCache.thrift
+++ b/gensrc/thrift/DataCache.thrift
@@ -40,5 +40,7 @@ struct TLoadDataCacheMetrics {
     2: optional i64 read_time_ns;
     3: optional i64 write_bytes;
     4: optional i64 write_time_ns;
-    5: optional TDataCacheMetrics metrics;
+    // the number of metrics merged
+    5: optional i64 count;
+    6: optional TDataCacheMetrics metrics;
 }

--- a/gensrc/thrift/FrontendService.thrift
+++ b/gensrc/thrift/FrontendService.thrift
@@ -49,6 +49,7 @@ include "MasterService.thrift"
 include "AgentService.thrift"
 include "ResourceUsage.thrift"
 include "MVMaintenance.thrift"
+include "DataCache.thrift"
 
 // These are supporting structs for JniFrontend.java, which serves as the glue
 // between our C++ execution environment and the Java frontend.
@@ -486,6 +487,7 @@ struct TTaskInfo {
     5: optional string definition
     6: optional i64 expire_time
     7: optional string properties
+    8: optional string catalog
 }
 
 struct TGetTaskInfoResult {
@@ -507,6 +509,8 @@ struct TTaskRunInfo {
 
     12: optional string extra_message
     13: optional string properties
+
+    14: optional string catalog
 }
 
 struct TGetTaskRunInfoResult {
@@ -719,6 +723,8 @@ struct TReportExecStatusParams {
   27: optional string rejected_record_path
 
   28: optional RuntimeProfile.TRuntimeProfileTree load_channel_profile;
+
+  29: optional DataCache.TLoadDataCacheMetrics load_datacache_metrics
 }
 
 struct TAuditStatistics {

--- a/test/sql/test_datacache/R/test_datacache_select
+++ b/test/sql/test_datacache/R/test_datacache_select
@@ -1,0 +1,62 @@
+-- name: test_datacache_select
+create external catalog hive_datacache_test_${uuid0} PROPERTIES ("type"="hive", "hive.metastore.uris"="${hive_metastore_uris}");
+-- result:
+-- !result
+set catalog hive_datacache_test_${uuid0};
+-- result:
+-- !result
+create database cache_select_db_${uuid0};
+-- result:
+-- !result
+use cache_select_db_${uuid0};
+-- result:
+-- !result
+create table t1 (c1 string, c2 string);
+-- result:
+-- !result
+insert into t1 values ("hello", "world"), ("smith", "blossom");
+-- result:
+-- !result
+submit task cache_select as cache select * from t1;
+-- result:
+cache_select	SUBMITTED
+-- !result
+submit task cache_select_where as cache select c1 from t1 where c1="hello";
+-- result:
+cache_select_where	SUBMITTED
+-- !result
+select TASK_NAME, `SCHEDULE`, DEFINITION from default_catalog.information_schema.tasks where CATALOG='hive_datacache_test_${uuid0}' and `DATABASE`='cache_select_db_${uuid0}' order by TASK_NAME;
+-- result:
+cache_select	MANUAL	cache select * from t1;
+cache_select_where	MANUAL	cache select c1 from t1 where c1="hello";
+-- !result
+select sleep(mod(second(now()), 5) + 1);
+-- result:
+1
+-- !result
+select TASK_NAME, DEFINITION from default_catalog.information_schema.task_runs where CATALOG='hive_datacache_test_${uuid0}' and `DATABASE`='cache_select_db_${uuid0}' order by TASK_NAME;
+-- result:
+cache_select	cache select * from t1;
+cache_select_where	cache select c1 from t1 where c1="hello";
+-- !result
+drop task cache_select;
+-- result:
+-- !result
+drop task cache_select_where;
+-- result:
+-- !result
+select * from default_catalog.information_schema.tasks where catalog='hive_datacache_test_${uuid0}' and `DATABASE`='cache_select_db_${uuid0}';
+-- result:
+-- !result
+drop table t1 force;
+-- result:
+-- !result
+drop database cache_select_db_${uuid0};
+-- result:
+-- !result
+set catalog default_catalog;
+-- result:
+-- !result
+drop catalog hive_datacache_test_${uuid0};
+-- result:
+-- !result

--- a/test/sql/test_datacache/T/test_datacache_select
+++ b/test/sql/test_datacache/T/test_datacache_select
@@ -1,0 +1,35 @@
+-- name: test_datacache_select
+
+create external catalog hive_datacache_test_${uuid0} PROPERTIES ("type"="hive", "hive.metastore.uris"="${hive_metastore_uris}");
+
+set catalog hive_datacache_test_${uuid0};
+create database cache_select_db_${uuid0};
+use cache_select_db_${uuid0};
+
+create table t1 (c1 string, c2 string);
+insert into t1 values ("hello", "world"), ("smith", "blossom");
+
+submit task cache_select as cache select * from t1;
+submit task cache_select_where as cache select c1 from t1 where c1="hello";
+
+-- two task created
+select TASK_NAME, `SCHEDULE`, DEFINITION from default_catalog.information_schema.tasks where CATALOG='hive_datacache_test_${uuid0}' and `DATABASE`='cache_select_db_${uuid0}' order by TASK_NAME;
+
+-- make sure the task got refreshed
+select sleep(mod(second(now()), 5) + 1);
+
+-- two task run executed
+select TASK_NAME, DEFINITION from default_catalog.information_schema.task_runs where CATALOG='hive_datacache_test_${uuid0}' and `DATABASE`='cache_select_db_${uuid0}' order by TASK_NAME;
+
+drop task cache_select;
+drop task cache_select_where;
+
+-- no tasks any more
+select * from default_catalog.information_schema.tasks where catalog='hive_datacache_test_${uuid0}' and `DATABASE`='cache_select_db_${uuid0}';
+
+drop table t1 force;
+drop database cache_select_db_${uuid0};
+set catalog default_catalog;
+drop catalog hive_datacache_test_${uuid0};
+
+


### PR DESCRIPTION
Why I'm doing:
Support cache select and schedule by `submit task`

What I'm doing:
```sql
mysql> show backends\G
*************************** 1. row ***************************
            BackendId: 10004
                   IP: 172.26.92.227
        HeartbeatPort: 4450
               BePort: 4448
             HttpPort: 4449
             BrpcPort: 4451
        LastStartTime: 2024-03-28 15:35:05
        LastHeartbeat: 2024-03-28 15:47:22
                Alive: true
 SystemDecommissioned: false
ClusterDecommissioned: false
            TabletNum: 64
     DataUsedCapacity: 43.734 KB
        AvailCapacity: 439.754 GB
        TotalCapacity: 1.968 TB
              UsedPct: 78.18 %
       MaxDiskUsedPct: 78.18 %
               ErrMsg:
              Version: cache-select-1f334fc
               Status: {"lastSuccessReportTabletsTime":"2024-03-28 15:47:06"}
    DataTotalCapacity: 439.754 GB
          DataUsedPct: 0.00 %
             CpuCores: 104
    NumRunningQueries: 0
           MemUsedPct: 0.00 %
           CpuUsedPct: 0.0 %
     DataCacheMetrics: Status: Normal, DiskUsage: 0B/2GB, MemUsage: 6.6MB/30.4GB
             Location:
1 row in set (0.00 sec)

mysql> cache select * from lineorder where lo_orderdate=19930315;
+---------+---------------------+------------------+------------------+-------------------+
| STATUS  | ALREADY_CACHED_SIZE | WRITE_CACHE_SIZE | WRITE_CACHE_TIME | TOTAL_CACHE_USAGE |
+---------+---------------------+------------------+------------------+-------------------+
| SUCCESS | 49.8KB              | 6.5MB            | 3.6ms            | 0.03 %            |
+---------+---------------------+------------------+------------------+-------------------+
1 row in set (0.23 sec)


mysql> cache select * from lineorder properties("verbose"="true");
+---------------+---------+---------------------+------------------+------------------+-------------------+
| BE_IP         | STATUS  | ALREADY_CACHED_SIZE | WRITE_CACHE_SIZE | WRITE_CACHE_TIME | TOTAL_CACHE_USAGE |
+---------------+---------+---------------------+------------------+------------------+-------------------+
| 172.26.80.135 | SUCCESS | 66.4MB              | 5.2GB            | 4.6s             | 16.77 %           |
| 172.26.80.134 | SUCCESS | 66.6MB              | 5.1GB            | 4.9s             | 16.53 %           |
| 172.26.80.136 | SUCCESS | 57.8MB              | 4.8GB            | 4.2s             | 15.55 %           |
+---------------+---------+---------------------+------------------+------------------+-------------------+
3 rows in set (1 min 5.07 sec)

mysql> cache select lo_extendedprice from lineorder;
+---------+---------------------+------------------+------------------+-------------------+
| STATUS  | ALREADY_CACHED_SIZE | WRITE_CACHE_SIZE | WRITE_CACHE_TIME | TOTAL_CACHE_USAGE |
+---------+---------------------+------------------+------------------+-------------------+
| SUCCESS | 3.1GB               | 0B               | 0s               | 16.41 %           |
+---------+---------------------+------------------+------------------+-------------------+
1 row in set (2.31 sec)


mysql> cache select lo_extendedprice from lineorder properties("verbose"="true");
+---------------+---------+---------------------+------------------+------------------+-------------------+
| BE_IP         | STATUS  | ALREADY_CACHED_SIZE | WRITE_CACHE_SIZE | WRITE_CACHE_TIME | TOTAL_CACHE_USAGE |
+---------------+---------+---------------------+------------------+------------------+-------------------+
| 172.26.80.135 | SUCCESS | 1GB                 | 0B               | 0s               | 17.14 %           |
| 172.26.80.134 | SUCCESS | 1GB                 | 0B               | 0s               | 16.92 %           |
| 172.26.80.136 | SUCCESS | 1GB                 | 0B               | 0s               | 15.90 %           |
+---------------+---------+---------------------+------------------+------------------+-------------------+
3 rows in set (2.11 sec)

mysql> submit task as cache select lo_extendedprice from lineorder;
+------------------------------------------------------+-----------+
| TaskName                                             | Status    |
+------------------------------------------------------+-----------+
| DataCacheSelect-efb1fcfb-f0b5-11ee-859d-00163e1b63a5 | SUBMITTED |
+------------------------------------------------------+-----------+
1 row in set (0.03 sec)

mysql> SELECT * FROM default_catalog.INFORMATION_SCHEMA.tasks order by CREATE_TIME desc limit 1;
+------------------------------------------------------+---------------------+----------+---------------+----------------------------+----------------------------------------------+---------------------+------------+
| TASK_NAME                                            | CREATE_TIME         | SCHEDULE | CATALOG       | DATABASE                   | DEFINITION                                   | EXPIRE_TIME         | PROPERTIES |
+------------------------------------------------------+---------------------+----------+---------------+----------------------------+----------------------------------------------+---------------------+------------+
| DataCacheSelect-a7e0255c-f0b7-11ee-a53c-865ace43c879 | 2024-04-02 14:10:08 | MANUAL   | emr_hive_test | hive_ssb100g_partition_orc | cache select lo_extendedprice from lineorder | 2024-04-03 14:10:08 |            |
+------------------------------------------------------+---------------------+----------+---------------+----------------------------+----------------------------------------------+---------------------+------------+
1 row in set (0.13 sec)

mysql> SELECT * FROM default_catalog.INFORMATION_SCHEMA.task_runs limit 1;
+--------------------------------------+------------------------------------------------------+---------------------+---------------------+---------+---------------+----------------------------+----------------------------------------------+---------------------+------------+---------------+----------+----------------------------------------------------------------------------------------------------------------------------+------------+
| QUERY_ID                             | TASK_NAME                                            | CREATE_TIME         | FINISH_TIME         | STATE   | CATALOG       | DATABASE                   | DEFINITION                                   | EXPIRE_TIME         | ERROR_CODE | ERROR_MESSAGE | PROGRESS | EXTRA_MESSAGE                                                                                                              | PROPERTIES |
+--------------------------------------+------------------------------------------------------+---------------------+---------------------+---------+---------------+----------------------------+----------------------------------------------+---------------------+------------+---------------+----------+----------------------------------------------------------------------------------------------------------------------------+------------+
| a7e15dde-f0b7-11ee-a53c-865ace43c879 | DataCacheSelect-a7e0255c-f0b7-11ee-a53c-865ace43c879 | 2024-04-02 14:10:08 | 2024-04-02 14:11:14 | SUCCESS | emr_hive_test | hive_ssb100g_partition_orc | cache select lo_extendedprice from lineorder | 2024-04-03 14:10:08 |          0 | NULL          | 100%     | AlreadyCachedSize: 177.9MB, WriteCacheSize: 3.1GB, WriteCacheTime: 4.4s, TotalCacheSize: 32.4GB, TotalUsedCacheSize: 3.1GB |            |
+--------------------------------------+------------------------------------------------------+---------------------+---------------------+---------+---------------+----------------------------+----------------------------------------------+---------------------+------------+---------------+----------+----------------------------------------------------------------------------------------------------------------------------+------------+
1 row in set (0.04 sec)

mysql> submit task always_cache schedule every(interval 2 minute) as cache select lo_extendedprice from lineorder;
+--------------+-----------+
| TaskName     | Status    |
+--------------+-----------+
| always_cache | SUBMITTED |
+--------------+-----------+
1 row in set (0.03 sec)

mysql> SELECT * FROM default_catalog.INFORMATION_SCHEMA.tasks order by CREATE_TIME desc limit 1;

+--------------+---------------------+--------------------------------------------------------+---------------+----------------------------+----------------------------------------------+---------------------+------------+
| TASK_NAME    | CREATE_TIME         | SCHEDULE                                               | CATALOG       | DATABASE                   | DEFINITION                                   | EXPIRE_TIME         | PROPERTIES |
+--------------+---------------------+--------------------------------------------------------+---------------+----------------------------+----------------------------------------------+---------------------+------------+
| always_cache | 2024-04-02 14:13:37 | PERIODICAL START(2024-04-02T14:13:37) EVERY(2 MINUTES) | emr_hive_test | hive_ssb100g_partition_orc | cache select lo_extendedprice from lineorder | 1970-01-01 08:00:00 |            |
+--------------+---------------------+--------------------------------------------------------+---------------+----------------------------+----------------------------------------------+---------------------+------------+
1 row in set (8.42 sec)

mysql> SELECT * FROM default_catalog.INFORMATION_SCHEMA.task_runs limit 5;
+--------------------------------------+--------------+---------------------+---------------------+---------+---------------+----------------------------+----------------------------------------------+---------------------+------------+---------------+----------+---------------------------------------------------------------------------------------------------------------------+------------+
| QUERY_ID                             | TASK_NAME    | CREATE_TIME         | FINISH_TIME         | STATE   | CATALOG       | DATABASE                   | DEFINITION                                   | EXPIRE_TIME         | ERROR_CODE | ERROR_MESSAGE | PROGRESS | EXTRA_MESSAGE                                                                                                       | PROPERTIES |
+--------------------------------------+--------------+---------------------+---------------------+---------+---------------+----------------------------+----------------------------------------------+---------------------+------------+---------------+----------+---------------------------------------------------------------------------------------------------------------------+------------+
| 42a290c7-f0b9-11ee-a53c-865ace43c879 | always_cache | 2024-04-02 14:21:37 | 2024-04-02 14:21:48 | SUCCESS | emr_hive_test | hive_ssb100g_partition_orc | cache select lo_extendedprice from lineorder | 2024-04-03 14:21:37 |          0 | NULL          | 100%     | AlreadyCachedSize: 3.1GB, WriteCacheSize: 0B, WriteCacheTime: 0s, TotalCacheSize: 32.4GB, TotalUsedCacheSize: 3.1GB |            |
| fb1c04c4-f0b8-11ee-a53c-865ace43c879 | always_cache | 2024-04-02 14:19:37 | 2024-04-02 14:19:49 | SUCCESS | emr_hive_test | hive_ssb100g_partition_orc | cache select lo_extendedprice from lineorder | 2024-04-03 14:19:37 |          0 | NULL          | 100%     | AlreadyCachedSize: 3.1GB, WriteCacheSize: 0B, WriteCacheTime: 0s, TotalCacheSize: 32.4GB, TotalUsedCacheSize: 3.1GB |            |
| b3959fce-f0b8-11ee-a53c-865ace43c879 | always_cache | 2024-04-02 14:17:37 | 2024-04-02 14:18:38 | SUCCESS | emr_hive_test | hive_ssb100g_partition_orc | cache select lo_extendedprice from lineorder | 2024-04-03 14:17:37 |          0 | NULL          | 100%     | AlreadyCachedSize: 3.1GB, WriteCacheSize: 0B, WriteCacheTime: 0s, TotalCacheSize: 32.4GB, TotalUsedCacheSize: 3.1GB |            |
| 6c0f13ca-f0b8-11ee-a53c-865ace43c879 | always_cache | 2024-04-02 14:15:37 | 2024-04-02 14:16:41 | SUCCESS | emr_hive_test | hive_ssb100g_partition_orc | cache select lo_extendedprice from lineorder | 2024-04-03 14:15:37 |          0 | NULL          | 100%     | AlreadyCachedSize: 3.1GB, WriteCacheSize: 0B, WriteCacheTime: 0s, TotalCacheSize: 32.4GB, TotalUsedCacheSize: 3.1GB |            |
| 248bbc12-f0b8-11ee-a53c-865ace43c879 | always_cache | 2024-04-02 14:13:37 | 2024-04-02 14:14:57 | SUCCESS | emr_hive_test | hive_ssb100g_partition_orc | cache select lo_extendedprice from lineorder | 2024-04-03 14:13:37 |          0 | NULL          | 100%     | AlreadyCachedSize: 3.1GB, WriteCacheSize: 0B, WriteCacheTime: 0s, TotalCacheSize: 32.4GB, TotalUsedCacheSize: 3.1GB |            |
+--------------------------------------+--------------+---------------------+---------------------+---------+---------------+----------------------------+----------------------------------------------+---------------------+------------+---------------+----------+---------------------------------------------------------------------------------------------------------------------+------------+

mysql> submit task always_cache_slow properties("pipeline_dop"="1") schedule every(interval 1 minute) as cache select * from lineorder;
+-------------------+-----------+
| TaskName          | Status    |
+-------------------+-----------+
| always_cache_slow | SUBMITTED |
+-------------------+-----------+
1 row in set (0.01 sec)

mysql> select * from default_catalog.information_schema.tasks;
+------------------------------------------------------+---------------------+--------------------------------------------------------+---------------+----------------------------+------------------------------------------------+---------------------+----------------------+
| TASK_NAME                                            | CREATE_TIME         | SCHEDULE                                               | CATALOG       | DATABASE                   | DEFINITION                                     | EXPIRE_TIME         | PROPERTIES           |
+------------------------------------------------------+---------------------+--------------------------------------------------------+---------------+----------------------------+------------------------------------------------+---------------------+----------------------+
| always_cache_slow                                    | 2024-04-02 16:06:51 | PERIODICAL START(2024-04-02T16:06:51) EVERY(1 MINUTES) | emr_hive_test | hive_ssb100g_partition_orc | cache select * from lineorder                  | 1970-01-01 08:00:00 | ('pipeline_dop'='1') |
+------------------------------------------------------+---------------------+--------------------------------------------------------+---------------+----------------------------+------------------------------------------------+---------------------+----------------------+
1 rows in set (0.12 sec)
```

Submit task overall grammar #41827:
```sql
SUBMIT TASK <name> 
[SCHEDULE [START(<start>)] EVERY(INTERVAL <interval>) ]
[PROPERTIES(<properties>)]
AS <query>  
```

## Implementation
`LoadDataCacheMetrics`: Each PlanFragment reported load DataCache metrics
`DataCacheSelectMetrics`: Metrics about cache select, it will count all be's `LoadDataCacheMetrics`
`DataCacheMetrics`: DataCache metrics for each BE.
## What type of PR is this:

- [ ] BugFix
- [x] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [x] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [x] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
