### PR TITLE
[Enhancement] Avoid to register metrics for each HttpServerHandler

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/http/HttpServerHandlerMetrics.java
+++ b/fe/fe-core/src/main/java/com/starrocks/http/HttpServerHandlerMetrics.java
@@ -1,0 +1,49 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.http;
+
+import com.codahale.metrics.Histogram;
+import com.starrocks.metric.LongCounterMetric;
+import com.starrocks.metric.Metric;
+
+import static com.starrocks.http.HttpMetricRegistry.HTTP_CONNECTIONS_NUM;
+import static com.starrocks.http.HttpMetricRegistry.HTTP_HANDLING_REQUESTS_NUM;
+import static com.starrocks.http.HttpMetricRegistry.HTTP_REQUEST_HANDLE_LATENCY_MS;
+
+/** Metrics for {@link HttpServerHandler}. */
+public class HttpServerHandlerMetrics {
+
+    /** An instance shared by all HttpServerHandlers. */
+    private static final HttpServerHandlerMetrics INSTANCE = new HttpServerHandlerMetrics();
+
+    public final LongCounterMetric httpConnectionsNum;
+    public final LongCounterMetric handlingRequestsNum;
+    public final Histogram requestHandleLatencyMs;
+
+    private HttpServerHandlerMetrics() {
+        HttpMetricRegistry httpMetricRegistry = HttpMetricRegistry.getInstance();
+        this.httpConnectionsNum = new LongCounterMetric(HTTP_CONNECTIONS_NUM,
+                Metric.MetricUnit.NOUNIT, "the number of established http connections currently");
+        httpMetricRegistry.registerCounter(httpConnectionsNum);
+        this.handlingRequestsNum = new LongCounterMetric(HTTP_HANDLING_REQUESTS_NUM, Metric.MetricUnit.NOUNIT,
+                "the number of http requests that is being handled");
+        httpMetricRegistry.registerCounter(handlingRequestsNum);
+        this.requestHandleLatencyMs = httpMetricRegistry.registerHistogram(HTTP_REQUEST_HANDLE_LATENCY_MS);
+    }
+
+    public static HttpServerHandlerMetrics getInstance() {
+        return INSTANCE;
+    }
+}


### PR DESCRIPTION
Why I'm doing:
we introduced some http metrics in #38280 where some metrics will be registered for each request in HttpServerHandler. This is not necessary. 

What I'm doing:
register these metrics in HttpServer only once

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [X] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [X] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
