### PR TITLE
[Enhancement] Remove the size assert of je_nallocx

### DIFF
--- a/thirdparty/download-thirdparty.sh
+++ b/thirdparty/download-thirdparty.sh
@@ -427,6 +427,7 @@ fi
 cd $TP_SOURCE_DIR/$JEMALLOC_SOURCE
 if [ ! -f $PATCHED_MARK ] && [ $JEMALLOC_SOURCE = "jemalloc-5.3.0" ]; then
     patch -p0 < $TP_PATCH_DIR/jemalloc_hook.patch
+    patch -p0 < $TP_PATCH_DIR/jemalloc_nallocx.patch
     touch $PATCHED_MARK
 fi
 cd -

--- a/thirdparty/patches/jemalloc_nallocx.patch
+++ b/thirdparty/patches/jemalloc_nallocx.patch
@@ -1,0 +1,11 @@
+--- src/jemalloc.c  2022-05-07 02:29:14.000000000 +0800
++++ src/jemalloc.c  2024-01-17 16:13:16.063123457 +0800
+@@ -3960,8 +3960,6 @@ je_nallocx(size_t size, int flags) {
+    size_t usize;
+    tsdn_t *tsdn;
+
+-   assert(size != 0);
+-
+    if (unlikely(malloc_init())) {
+        LOG("core.nallocx.exit", "result: %zu", ZU(0));
+        return 0;


### PR DESCRIPTION
Why I'm doing:

If build with jemalloc-debug=true, BE will crash when using jni scanner.

```
<jemalloc>: src/jemalloc.c:3963: Failed assertion: "size != 0"
*** Aborted at 1705466978 (unix time) try "date -d @1705466978" if you are using GNU date ***
PC: @     0x7f823f35d387 __GI_raise
*** SIGABRT (@0x3f000009b9d) received by PID 39837 (TID 0x7f81c91f1700) from PID 39837; stack trace: ***
    @          0xfc71752 google::(anonymous namespace)::FailureSignalHandler()
    @     0x7f823f704630 (unknown)
    @     0x7f823f35d387 __GI_raise
    @     0x7f823f35ea78 __GI_abort
    @         0x1069970e jenallocx
    @          0xac64d60 malloc
    @     0x7f80c392529a getDiagnosticCommandArgumentInfoArray
    @     0x7f80c39257f2 Java_com_sun_management_internal_DiagnosticCommandImpl_getDiagnosticCommandInfo
    @     0x7f811bb6e197 (unknown)

```

Jni Diagnostic will use malloc(0)

  /* According to ISO C it is perfectly legal for malloc to return zero if called with a zero argument */

```
jobject getDiagnosticCommandArgumentInfoArray(JNIEnv *env, jstring command,
                                              int num_arg) {
  int i;
  jobject obj;
  jobjectArray result;
  dcmdArgInfo* dcmd_arg_info_array;
  jclass dcmdArgInfoCls;
  jclass arraysCls;
  jmethodID mid;
  jobject resultList;

  dcmd_arg_info_array = (dcmdArgInfo*) malloc(num_arg * sizeof(dcmdArgInfo));
  /* According to ISO C it is perfectly legal for malloc to return zero if called with a zero argument */
  if (dcmd_arg_info_array == NULL && num_arg != 0) {
    JNU_ThrowOutOfMemoryError(env, 0);
    return NULL;
  }
```

For jemalloc, malloc(0) is equivalent to malloc(1), the pr: https://github.com/jemalloc/jemalloc/pull/1341 already remove the size=0 assert for malloc, but the assert in nallocx is not removed.

What I'm doing:

```
#include <iostream>
#include <string>
#include <math.h>
#include <vector>
#include <array>
#include <memory>
#include <queue>
#include <atomic>
#include <mutex>
#include "jemalloc.h"

using namespace std;

int main() {
    void* ptr = je_malloc(0);
    std::cout << "MALLOC OK:" << ptr << std::endl;
    std::cout << "SIZE: " << jemalloc_usable_size(ptr) << std::endl;
    std::cout << "NALLOCX_SIZE: " << je_nallocx(0, 0) << std::endl;
    je_free(ptr);

    return 0;
}
```

g++ b.cpp -lpthread -ljemalloc -L./lib_debug

```
./a.out 
MALLOC OK:0x7efc9e408000
SIZE: 8
<jemalloc>: src/jemalloc.c:3963: Failed assertion: "size != 0"
```

Behavior after removal

```
./a.out 
MALLOC OK:0x7f095bc08000
SIZE: 8
NALLOCX_SIZE: 8
```

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
