### PR TITLE
[Enhancement] Delete pindex file when disable pindex

### DIFF
--- a/be/src/storage/persistent_index.cpp
+++ b/be/src/storage/persistent_index.cpp
@@ -5139,8 +5139,7 @@ Status PersistentIndex::delete_pindex_files() {
     auto cb = [&](std::string_view name) -> bool {
         std::string prefix = "index.";
         std::string full(name);
-        if (full.length() >= prefix.length() &&
-            full.compare(0, prefix.length(), prefix) == 0) {
+        if (full.length() >= prefix.length() && full.compare(0, prefix.length(), prefix) == 0) {
             std::string path = dir + "/" + full;
             VLOG(1) << "delete index file " << path;
             Status st = FileSystem::Default()->delete_file(path);

--- a/be/src/storage/persistent_index.cpp
+++ b/be/src/storage/persistent_index.cpp
@@ -5134,4 +5134,24 @@ Status PersistentIndex::pk_dump(PrimaryKeyDump* dump, PrimaryIndexMultiLevelPB* 
     return Status::OK();
 }
 
+Status PersistentIndex::delete_pindex_files() {
+    std::string dir = _path;
+    auto cb = [&](std::string_view name) -> bool {
+        std::string prefix = "index.";
+        std::string full(name);
+        if (full.length() >= prefix.length() &&
+            full.compare(0, prefix.length(), prefix) == 0) {
+            std::string path = dir + "/" + full;
+            VLOG(1) << "delete index file " << path;
+            Status st = FileSystem::Default()->delete_file(path);
+            if (!st.ok()) {
+                LOG(WARNING) << "delete index file: " << path << ", failed, status: " << st.to_string();
+                return false;
+            }
+        }
+        return true;
+    };
+    return FileSystem::Default()->iterate_dir(_path, cb);
+}
+
 } // namespace starrocks

--- a/be/src/storage/persistent_index.h
+++ b/be/src/storage/persistent_index.h
@@ -782,6 +782,7 @@ public:
     Status reset(Tablet* tablet, EditVersion version, PersistentIndexMetaPB* index_meta);
 
     void reset_cancel_major_compaction();
+    Status delete_pindex_files();
 
     static void modify_l2_versions(const std::vector<EditVersion>& input_l2_versions,
                                    const EditVersion& output_l2_version, PersistentIndexMetaPB& index_meta);

--- a/be/src/storage/primary_index.cpp
+++ b/be/src/storage/primary_index.cpp
@@ -27,6 +27,7 @@
 #include "storage/rowset/rowset.h"
 #include "storage/rowset/rowset_options.h"
 #include "storage/tablet.h"
+#include "storage/tablet_manager.h"
 #include "storage/tablet_reader.h"
 #include "storage/tablet_updates.h"
 #include "util/stack_util.h"
@@ -957,6 +958,16 @@ PrimaryIndex::~PrimaryIndex() {
         } else {
             LOG(INFO) << "primary index released table:" << _table_id << " tablet:" << _tablet_id
                       << " memory: " << memory_usage();
+        }
+    }
+    
+    TabletSharedPtr tablet = StorageEngine::instance()->tablet_manager()->get_tablet(_tablet_id);
+    if (tablet != nullptr) {
+        if (_persistent_index != nullptr && !tablet->get_enable_persistent_index()) {
+            auto st = _persistent_index->delete_pindex_file();
+            if (!st.ok()) {
+                LOG(ERROR) << "tablet:" << tablet->tablet_id() << " clear pindex failed:" << st;
+            }
         }
     }
 }

--- a/be/src/storage/primary_index.cpp
+++ b/be/src/storage/primary_index.cpp
@@ -964,7 +964,7 @@ PrimaryIndex::~PrimaryIndex() {
     TabletSharedPtr tablet = StorageEngine::instance()->tablet_manager()->get_tablet(_tablet_id);
     if (tablet != nullptr) {
         if (_persistent_index != nullptr && !tablet->get_enable_persistent_index()) {
-            auto st = _persistent_index->delete_pindex_file();
+            auto st = _persistent_index->delete_pindex_files();
             if (!st.ok()) {
                 LOG(ERROR) << "tablet:" << tablet->tablet_id() << " clear pindex failed:" << st;
             }

--- a/be/src/storage/primary_index.cpp
+++ b/be/src/storage/primary_index.cpp
@@ -960,7 +960,7 @@ PrimaryIndex::~PrimaryIndex() {
                       << " memory: " << memory_usage();
         }
     }
-    
+
     TabletSharedPtr tablet = StorageEngine::instance()->tablet_manager()->get_tablet(_tablet_id);
     if (tablet != nullptr) {
         if (_persistent_index != nullptr && !tablet->get_enable_persistent_index()) {

--- a/be/src/storage/storage_engine.cpp
+++ b/be/src/storage/storage_engine.cpp
@@ -136,6 +136,7 @@ StorageEngine::StorageEngine(const EngineOptions& options)
 StorageEngine::~StorageEngine() {
     // tablet manager need to destruct before set storage engine instance to nullptr because tablet may access storage
     // engine instance during their destruction.
+    _update_manager.reset();
     _tablet_manager.reset();
 #ifdef BE_TEST
     if (_s_instance == this) {


### PR DESCRIPTION
Why I'm doing:
If we disable persistent index for primary key table, the index files do not remove.

What I'm doing:
Remove index files when persistent index is disable.

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [x] 3.1
  - [ ] 3.0
  - [ ] 2.5
