### PR TITLE
[Enhancement] support array_distinct(array_agg(col)) to array_agg_distinct(col)

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
@@ -457,6 +457,8 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
     }
     public static final String FOLLOWER_QUERY_FORWARD_MODE = "follower_query_forward_mode";
 
+    public static final String ENABLE_ARRAY_DISTINCT_AFTER_AGG_OPT = "enable_array_distinct_after_agg_opt";
+
     public enum MaterializedViewRewriteMode {
         DISABLE,            // disable materialized view rewrite
         DEFAULT,            // default, choose the materialized view or not by cost optimizer
@@ -1645,6 +1647,9 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
     public boolean isCboDecimalCastStringStrict() {
         return cboDecimalCastStringStrict;
     }
+
+    @VarAttr(name = ENABLE_ARRAY_DISTINCT_AFTER_AGG_OPT)
+    private boolean enableArrayDistinctAfterAggOpt = true;
 
     public String getCboEqBaseType() {
         return cboEqBaseType;
@@ -3150,6 +3155,10 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
 
     public void setEnableStrictOrderBy(boolean enableStrictOrderBy) {
         this.enableStrictOrderBy = enableStrictOrderBy;
+    }
+
+    public boolean getEnableArrayDistinctAfterAggOpt() {
+        return  enableArrayDistinctAfterAggOpt;
     }
 
     // Serialize to thrift object

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/Optimizer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/Optimizer.java
@@ -37,6 +37,7 @@ import com.starrocks.sql.optimizer.rule.implementation.OlapScanImplementationRul
 import com.starrocks.sql.optimizer.rule.join.ReorderJoinRule;
 import com.starrocks.sql.optimizer.rule.mv.MaterializedViewRule;
 import com.starrocks.sql.optimizer.rule.transformation.ApplyExceptionRule;
+import com.starrocks.sql.optimizer.rule.transformation.ArrayDistinctAfterAggRule;
 import com.starrocks.sql.optimizer.rule.transformation.ConvertToEqualForNullRule;
 import com.starrocks.sql.optimizer.rule.transformation.DeriveRangeJoinPredicateRule;
 import com.starrocks.sql.optimizer.rule.transformation.ForceCTEReuseRule;
@@ -368,6 +369,7 @@ public class Optimizer {
         // @todo: resolve recursive optimization question:
         //  MergeAgg -> PruneColumn -> PruneEmptyWindow -> MergeAgg/Project -> PruneColumn...
         ruleRewriteIterative(tree, rootTaskContext, new MergeTwoAggRule());
+
         rootTaskContext.setRequiredColumns(requiredColumns.clone());
         ruleRewriteOnlyOnce(tree, rootTaskContext, RuleSetType.PRUNE_COLUMNS);
 
@@ -471,6 +473,10 @@ public class Optimizer {
         ruleRewriteOnlyOnce(tree, rootTaskContext, new GroupByCountDistinctRewriteRule());
 
         ruleRewriteOnlyOnce(tree, rootTaskContext, new DeriveRangeJoinPredicateRule());
+
+        if (sessionVariable.getEnableArrayDistinctAfterAggOpt()) {
+            ruleRewriteOnlyOnce(tree, rootTaskContext, new ArrayDistinctAfterAggRule());
+        }
 
         return tree.getInputs().get(0);
     }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/RuleType.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/RuleType.java
@@ -174,6 +174,7 @@ public enum RuleType {
     TF_SKEW_JOIN_OPTIMIZE_RULE,
 
     TF_CONVERT_TO_EQUAL_FOR_NULL_RULE,
+    TF_ARRAY_DISTINCT_AFTER_AGG,
 
     // The following are implementation rules:
     IMP_OLAP_LSCAN_TO_PSCAN,

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/ArrayDistinctAfterAggRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/ArrayDistinctAfterAggRule.java
@@ -34,6 +34,14 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+/*      project(array_distinct)           project
+ *                |               =>         |
+ *      Aggregation(array_agg)            Aggregation(array_agg_distinct)
+ *
+ * project may have projection use result of array_agg in array_distinct or in an expr like
+ * array_length(array_distinct(array_agg(a))), this rule check all the projection and predicate,
+ *  if all of them use the array_agg's result with array_distinct that we can just do array_agg_distinct.
+ */
 public class ArrayDistinctAfterAggRule extends TransformationRule {
     public ArrayDistinctAfterAggRule() {
         super(RuleType.TF_ARRAY_DISTINCT_AFTER_AGG, Pattern.create(OperatorType.LOGICAL_PROJECT)

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/ArrayDistinctAfterAggRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/ArrayDistinctAfterAggRule.java
@@ -1,0 +1,175 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.sql.optimizer.rule.transformation;
+
+import com.google.common.collect.Lists;
+import com.starrocks.analysis.Expr;
+import com.starrocks.catalog.Function;
+import com.starrocks.catalog.FunctionSet;
+import com.starrocks.sql.optimizer.OptExpression;
+import com.starrocks.sql.optimizer.OptimizerContext;
+import com.starrocks.sql.optimizer.operator.OperatorType;
+import com.starrocks.sql.optimizer.operator.Projection;
+import com.starrocks.sql.optimizer.operator.logical.LogicalAggregationOperator;
+import com.starrocks.sql.optimizer.operator.pattern.Pattern;
+import com.starrocks.sql.optimizer.operator.scalar.CallOperator;
+import com.starrocks.sql.optimizer.operator.scalar.ColumnRefOperator;
+import com.starrocks.sql.optimizer.operator.scalar.ScalarOperator;
+import com.starrocks.sql.optimizer.operator.scalar.ScalarOperatorVisitor;
+import com.starrocks.sql.optimizer.rule.RuleType;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public class ArrayDistinctAfterAggRule extends TransformationRule {
+    public ArrayDistinctAfterAggRule() {
+        super(RuleType.TF_ARRAY_DISTINCT_AFTER_AGG, Pattern.create(OperatorType.LOGICAL_AGGR, OperatorType.PATTERN_LEAF));
+    }
+
+    @Override
+    public boolean check(OptExpression input, OptimizerContext context) {
+        LogicalAggregationOperator aggregate = (LogicalAggregationOperator) input.getOp();
+        return aggregate.getAggregations().values().stream().anyMatch(x -> x.getFnName().equals(FunctionSet.ARRAY_AGG))
+                && aggregate.getProjection() != null;
+    }
+
+    private boolean checkScalarOp(ColumnRefOperator col, ScalarOperator op) {
+        if (!op.getColumnRefs().contains(col)) {
+            return true;
+        }
+        ScalarOperatorVisitor<Boolean, Void> visitor = new ScalarOperatorVisitor<Boolean, Void>() {
+            @Override
+            public Boolean visit(ScalarOperator scalarOperator, Void context) {
+                for (ScalarOperator child : scalarOperator.getChildren()) {
+                    if (child.getColumnRefs().contains(col)) {
+                        boolean ret = child.accept(this, null);
+                        if (!ret) {
+                            return false;
+                        }
+                    }
+                }
+                return true;
+            }
+
+            @Override
+            public Boolean visitVariableReference(ColumnRefOperator columnRefOperator, Void context) {
+                return !columnRefOperator.equals(col);
+            }
+
+            @Override
+            public Boolean visitCall(CallOperator callOperator, Void context) {
+                if (callOperator.getFnName().equals(FunctionSet.ARRAY_DISTINCT)) {
+                    return callOperator.getArguments().size() == 1 && callOperator.getArguments().get(0).equals(col);
+                } else {
+                    return visit(callOperator, null);
+                }
+            }
+        };
+
+        return op.accept(visitor, null);
+    }
+
+    private boolean checkAllUseOfArrayAggResultHasDistinct(ColumnRefOperator colRef, LogicalAggregationOperator agg) {
+        for (Map.Entry<ColumnRefOperator, ScalarOperator> entry : agg.getProjection().getColumnRefMap().entrySet()) {
+            if (!checkScalarOp(colRef, entry.getValue())) {
+                return false;
+            }
+        }
+        if (agg.getPredicate() != null) {
+            return checkScalarOp(colRef, agg.getPredicate());
+        }
+        return true;
+    }
+
+    private ScalarOperator rewriteScalarOp(ColumnRefOperator oldCol, ColumnRefOperator newCol, ScalarOperator op) {
+        if (!op.getColumnRefs().contains(oldCol)) {
+            return op;
+        }
+
+        ScalarOperatorVisitor<ScalarOperator, Void> visitor = new ScalarOperatorVisitor<ScalarOperator, Void>() {
+            @Override
+            public ScalarOperator visit(ScalarOperator scalarOperator, Void context) {
+                List<ScalarOperator> children = Lists.newArrayList(scalarOperator.getChildren());
+                for (int i = 0; i < children.size(); ++i) {
+                    ScalarOperator child = children.get(i);
+                    if (child.getColumnRefs().contains(oldCol)) {
+                        scalarOperator.setChild(i, scalarOperator.getChild(i).accept(this, null));
+                    }
+                }
+                return scalarOperator;
+            }
+
+            @Override
+            public ScalarOperator visitCall(CallOperator call, Void context) {
+                if (call.getFnName().equals(FunctionSet.ARRAY_DISTINCT)
+                        && call.getArguments().size() == 1
+                        && call.getArguments().get(0).equals(oldCol)) {
+                    return newCol;
+                }
+                return visit(call, null);
+            }
+        };
+
+        return op.accept(visitor, null);
+    }
+
+    private void rewriteProject(ColumnRefOperator oldCol, ColumnRefOperator newCol,
+                                            LogicalAggregationOperator agg) {
+        Map<ColumnRefOperator, ScalarOperator> newColumnRefMap = new HashMap<>();
+        for (Map.Entry<ColumnRefOperator, ScalarOperator> entry : agg.getProjection().getColumnRefMap().entrySet()) {
+            newColumnRefMap.put(entry.getKey(), rewriteScalarOp(oldCol, newCol, entry.getValue()));
+        }
+        Map<ColumnRefOperator, ScalarOperator> newCommonSubOperatorMap = new HashMap<>();
+        for (Map.Entry<ColumnRefOperator, ScalarOperator> entry : agg.getProjection().getCommonSubOperatorMap().entrySet()) {
+            newCommonSubOperatorMap.put(entry.getKey(), rewriteScalarOp(oldCol, newCol, entry.getValue()));
+        }
+        Projection newProject = new Projection(newColumnRefMap, newCommonSubOperatorMap);
+        agg.setProjection(newProject);
+    }
+
+    @Override
+    public List<OptExpression> transform(OptExpression input, OptimizerContext context) {
+        LogicalAggregationOperator aggregate = (LogicalAggregationOperator) input.getOp();
+
+        ScalarOperator newPredicate = aggregate.getPredicate();
+
+        Map<ColumnRefOperator, CallOperator> replaceMap = new HashMap<>();
+        for (Map.Entry<ColumnRefOperator, CallOperator> entry : aggregate.getAggregations().entrySet()) {
+            if (entry.getValue().getFnName().equals(FunctionSet.ARRAY_AGG) &&
+                    checkAllUseOfArrayAggResultHasDistinct(entry.getKey(), aggregate)) {
+                Function oldFn = entry.getValue().getFunction();
+                Function newFn = Expr.getBuiltinFunction(FunctionSet.ARRAY_AGG_DISTINCT, oldFn.getArgs(),
+                        Function.CompareMode.IS_NONSTRICT_SUPERTYPE_OF);
+                CallOperator newCall = new CallOperator(newFn.getFunctionName().getFunction(), newFn.getReturnType(),
+                        entry.getValue().getArguments(), newFn);
+                ColumnRefOperator oldCol = entry.getKey();
+                ColumnRefOperator newCol = new ColumnRefOperator(
+                        oldCol.getId(), oldCol.getType(), newFn.functionName(), oldCol.isNullable());
+                replaceMap.put(newCol, newCall);
+                rewriteProject(oldCol, newCol, aggregate);
+                if (newPredicate != null) {
+                    rewriteScalarOp(oldCol, newCol, newPredicate);
+                }
+            } else {
+                replaceMap.put(entry.getKey(), entry.getValue());
+            }
+        }
+
+        LogicalAggregationOperator newAggOp = LogicalAggregationOperator.builder().withOperator(aggregate)
+                .setAggregations(replaceMap).setPredicate(newPredicate).build();
+        return Lists.newArrayList(OptExpression.create(newAggOp, input.getInputs()));
+    }
+}

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/ArrayDistinctAfterAggTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/ArrayDistinctAfterAggTest.java
@@ -1,0 +1,53 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.sql.plan;
+
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+public class ArrayDistinctAfterAggTest extends PlanTestBase {
+    @BeforeClass
+    public static void beforeClass() throws Exception {
+        PlanTestBase.beforeClass();
+    }
+
+    @Test
+    public void testArrayDistinctAfterAgg() throws Exception {
+        String sql = "select array_distinct(array_agg(v2)) from t0 group by v1";
+        String sqlPlan = getFragmentPlan(sql);
+        assertCContains(sqlPlan, "array_agg_distinct");
+
+        sql = "select array_length(array_distinct(array_agg(v2))) from t0 group by v1";
+        sqlPlan = getFragmentPlan(sql);
+        assertCContains(sqlPlan, "array_agg_distinct");
+    }
+
+    @Test
+    public void testArrayDistinctAfterAggWithPredicate() throws Exception {
+        String sql = "select array_distinct(array_agg(v2)) from t0 group by v1 having " +
+                "array_length(array_distinct(array_agg(v2))) > 1";
+        String sqlPlan = getFragmentPlan(sql);
+        assertCContains(sqlPlan, "array_agg_distinct");
+
+        sql = "select array_length(array_distinct(array_agg(v2))) from t0 group by v1 having " +
+                "array_length(array_distinct(array_agg(v2))) > 1";
+        sqlPlan = getFragmentPlan(sql);
+        assertCContains(sqlPlan, "array_agg_distinct");
+
+        sql = "select array_distinct(array_agg(v2)) from t0 group by v1 having array_length(array_agg(v2)) > 1";
+        sqlPlan = getFragmentPlan(sql);
+        assertNotContains(sqlPlan, "array_agg_distinct");
+    }
+}


### PR DESCRIPTION
Why I'm doing:
array_agg_distinct use much less memory than array_distinct(array_agg)

What I'm doing:

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [x] 3.1
  - [ ] 3.0
  - [ ] 2.5
