### PR TITLE
[BugFix] Fix routine load job unable to automatically resume in shared_data mode

### DIFF
--- a/fe/fe-core/src/test/java/com/starrocks/lake/StarOSAgent2ndTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/lake/StarOSAgent2ndTest.java
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-
 package com.starrocks.lake;
 
 import com.google.common.collect.Lists;
@@ -213,7 +212,8 @@ public class StarOSAgent2ndTest {
         Deencapsulation.setField(starosAgent, "workerToBackend", workerToBackend);
 
         Assert.assertEquals(2, starosAgent.getPrimaryComputeNodeIdByShard(shardId));
-        UserException exception = Assert.assertThrows(UserException.class, () -> starosAgent.getPrimaryComputeNodeIdByShard(shardId));
+        UserException exception =
+                Assert.assertThrows(UserException.class, () -> starosAgent.getPrimaryComputeNodeIdByShard(shardId));
         Assert.assertEquals(InternalErrorCode.REPLICA_FEW_ERR, exception.getErrorCode());
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/lake/StarOSAgent2ndTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/lake/StarOSAgent2ndTest.java
@@ -26,6 +26,7 @@ import com.staros.proto.ShardInfo;
 import com.staros.proto.WorkerGroupDetailInfo;
 import com.staros.proto.WorkerInfo;
 import com.staros.proto.WorkerState;
+import com.starrocks.common.InternalErrorCode;
 import com.starrocks.common.UserException;
 import com.starrocks.common.jmockit.Deencapsulation;
 import com.starrocks.server.GlobalStateMgr;
@@ -168,6 +169,55 @@ public class StarOSAgent2ndTest {
             Assert.assertEquals(Lists.newArrayList(beId), starosAgent.getWorkersByWorkerGroup(0));
             GlobalStateMgr.getCurrentSystemInfo().dropComputeNode(cn);
             workerToBackend.clear();
+        }
+    }
+
+    @Test
+    public void testGetPrimaryComputeNodeIdByShard() throws StarClientException, UserException {
+        String workerHost = "127.0.0.1";
+        int workerStarletPort = 9070;
+        int workerHeartbeatPort = 9050;
+        long shardId = 10L;
+
+        WorkerInfo workerInfo = WorkerInfo.newBuilder()
+                .setIpPort(String.format("%s:%d", workerHost, workerStarletPort))
+                .setWorkerId(1L)
+                .setWorkerState(WorkerState.ON)
+                .putWorkerProperties("be_heartbeat_port", String.valueOf(workerHeartbeatPort))
+                .putWorkerProperties("be_brpc_port", "8060")
+                .build();
+
+        ReplicaInfo replica = ReplicaInfo.newBuilder()
+                .setReplicaRole(ReplicaRole.PRIMARY)
+                .setWorkerInfo(workerInfo.toBuilder().build())
+                .build();
+
+        ShardInfo shardInfo0 = ShardInfo.newBuilder().setShardId(shardId)
+                .addReplicaInfo(replica)
+                .build();
+
+        ShardInfo shardInfo1 = ShardInfo.newBuilder().setShardId(shardId)
+                .build();
+
+        new Expectations() {
+            {
+                client.getShardInfo("1", Lists.newArrayList(shardId), StarOSAgent.DEFAULT_WORKER_GROUP_ID);
+                minTimes = 0;
+                returns(Lists.newArrayList(shardInfo0), Lists.newArrayList(shardInfo1));
+            }
+        };
+
+        Deencapsulation.setField(starosAgent, "serviceId", "1");
+        Map<Long, Long> workerToBackend = Maps.newHashMap();
+        workerToBackend.put(1L, 2L);
+        Deencapsulation.setField(starosAgent, "workerToBackend", workerToBackend);
+
+        Assert.assertEquals(2, starosAgent.getPrimaryComputeNodeIdByShard(shardId));
+        try {
+            starosAgent.getPrimaryComputeNodeIdByShard(shardId);
+            Assert.fail("no exception");
+        } catch (UserException e) {
+            Assert.assertEquals(InternalErrorCode.REPLICA_FEW_ERR, e.getErrorCode());
         }
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/lake/StarOSAgent2ndTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/lake/StarOSAgent2ndTest.java
@@ -213,11 +213,7 @@ public class StarOSAgent2ndTest {
         Deencapsulation.setField(starosAgent, "workerToBackend", workerToBackend);
 
         Assert.assertEquals(2, starosAgent.getPrimaryComputeNodeIdByShard(shardId));
-        try {
-            starosAgent.getPrimaryComputeNodeIdByShard(shardId);
-            Assert.fail("no exception");
-        } catch (UserException e) {
-            Assert.assertEquals(InternalErrorCode.REPLICA_FEW_ERR, e.getErrorCode());
-        }
+        UserException exception = Assert.assertThrows(UserException.class, () -> starosAgent.getPrimaryComputeNodeIdByShard(shardId));
+        Assert.assertEquals(InternalErrorCode.REPLICA_FEW_ERR, exception.getErrorCode());
     }
 }


### PR DESCRIPTION

If BE stops, routine load task may catch UserException during load plan, and the job state will changed to PAUSED.

The job will automatically recover from PAUSED to RUNNING if the error code is REPLICA_FEW_ERR when all BEs become alive.

Why I'm doing:

What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [x] 3.1
  - [ ] 3.0
  - [ ] 2.5
