### PR TITLE
[BugFix] Fix the problem of be exit being stuck due to BRPC.

### DIFF
--- a/be/src/exec/workgroup/scan_executor.cpp
+++ b/be/src/exec/workgroup/scan_executor.cpp
@@ -27,8 +27,9 @@ ScanExecutor::ScanExecutor(std::unique_ptr<ThreadPool> thread_pool, std::unique_
     }
 }
 
-ScanExecutor::~ScanExecutor() {
+void ScanExecutor::close() {
     _task_queue->close();
+    _thread_pool->shutdown();
 }
 
 void ScanExecutor::initialize(int num_threads) {

--- a/be/src/exec/workgroup/scan_executor.h
+++ b/be/src/exec/workgroup/scan_executor.h
@@ -29,9 +29,10 @@ class ScanExecutor {
 public:
     explicit ScanExecutor(std::unique_ptr<ThreadPool> thread_pool, std::unique_ptr<ScanTaskQueue> task_queue,
                           bool add_metrics = true);
-    virtual ~ScanExecutor();
+    virtual ~ScanExecutor() = default;
 
     void initialize(int32_t num_threads);
+    void close();
     void change_num_threads(int32_t num_threads);
 
     bool submit(ScanTask task);
@@ -43,7 +44,6 @@ private:
     std::unique_ptr<ScanTaskQueue> _task_queue;
     // _thread_pool must be placed after _task_queue, because worker threads in _thread_pool use _task_queue.
     std::unique_ptr<ThreadPool> _thread_pool;
-    std::atomic<int> _next_id = 0;
 };
 
 } // namespace starrocks::workgroup

--- a/be/src/runtime/exec_env.cpp
+++ b/be/src/runtime/exec_env.cpp
@@ -581,10 +581,6 @@ void ExecEnv::stop() {
         _automatic_partition_pool->shutdown();
     }
 
-    if (_query_rpc_pool) {
-        _query_rpc_pool->shutdown();
-    }
-
     if (_load_rpc_pool) {
         _load_rpc_pool->shutdown();
     }

--- a/be/src/runtime/exec_env.cpp
+++ b/be/src/runtime/exec_env.cpp
@@ -581,6 +581,10 @@ void ExecEnv::stop() {
         _automatic_partition_pool->shutdown();
     }
 
+    if (_query_rpc_pool) {
+        _query_rpc_pool->shutdown();
+    }
+
     if (_load_rpc_pool) {
         _load_rpc_pool->shutdown();
     }

--- a/be/src/runtime/exec_env.cpp
+++ b/be/src/runtime/exec_env.cpp
@@ -577,12 +577,48 @@ void ExecEnv::stop() {
         _agent_server->stop();
     }
 
+    if (_runtime_filter_worker) {
+        _runtime_filter_worker->close();
+    }
+
+    if (_profile_report_worker) {
+        _profile_report_worker->close();
+    }
+
     if (_automatic_partition_pool) {
         _automatic_partition_pool->shutdown();
     }
 
+    if (_query_rpc_pool) {
+        _query_rpc_pool->shutdown();
+    }
+
     if (_load_rpc_pool) {
         _load_rpc_pool->shutdown();
+    }
+
+    if (_scan_executor) {
+        _scan_executor->close();
+    }
+
+    if (_connector_scan_executor) {
+        _connector_scan_executor->close();
+    }
+
+    if (_thread_pool) {
+        _thread_pool->shutdown();
+    }
+
+    if (_query_context_mgr) {
+        _query_context_mgr->clear();
+    }
+
+    if (_result_mgr) {
+        _result_mgr->stop();
+    }
+
+    if (_stream_mgr) {
+        _stream_mgr->close();
     }
 
     if (_routine_load_task_executor) {
@@ -620,6 +656,7 @@ void ExecEnv::destroy() {
     SAFE_DELETE(_pipeline_prepare_pool);
     SAFE_DELETE(_pipeline_sink_io_pool);
     SAFE_DELETE(_query_rpc_pool);
+    _load_rpc_pool.reset();
     SAFE_DELETE(_scan_executor);
     SAFE_DELETE(_connector_scan_executor);
     SAFE_DELETE(_thread_pool);

--- a/be/src/runtime/profile_report_worker.cpp
+++ b/be/src/runtime/profile_report_worker.cpp
@@ -128,7 +128,7 @@ ProfileReportWorker::ProfileReportWorker(ExecEnv* env) : _thread([this] { execut
     Thread::set_thread_name(_thread, "profile_report");
 }
 
-ProfileReportWorker::~ProfileReportWorker() {
+void ProfileReportWorker::close() {
     _stop.store(true, std::memory_order_release);
     _thread.join();
 }

--- a/be/src/runtime/profile_report_worker.h
+++ b/be/src/runtime/profile_report_worker.h
@@ -65,8 +65,9 @@ struct PipeLineReportTaskKeyHasher {
 class ProfileReportWorker {
 public:
     ProfileReportWorker(ExecEnv* env);
-    ~ProfileReportWorker();
+    ~ProfileReportWorker() = default;
     void execute();
+    void close();
     Status register_non_pipeline_load(const TUniqueId& fragment_instance_id);
     void unregister_non_pipeline_load(const TUniqueId& fragment_instance_id);
 

--- a/be/src/runtime/result_buffer_mgr.cpp
+++ b/be/src/runtime/result_buffer_mgr.cpp
@@ -53,7 +53,7 @@ ResultBufferMgr::ResultBufferMgr() {
     });
 }
 
-ResultBufferMgr::~ResultBufferMgr() {
+void ResultBufferMgr::stop() {
     _is_stop = true;
     _cancel_thread->join();
 }

--- a/be/src/runtime/result_buffer_mgr.h
+++ b/be/src/runtime/result_buffer_mgr.h
@@ -55,24 +55,25 @@ class PUniqueId;
 class ResultBufferMgr {
 public:
     ResultBufferMgr();
-    ~ResultBufferMgr();
+    ~ResultBufferMgr() = default;
     // init Result Buffer Mgr, start cancel thread
-    [[nodiscard]] Status init();
+    Status init();
+    void stop();
     // create one result sender for this query_id
     // the returned sender do not need release
     // sender is not used when call cancel or unregister
-    [[nodiscard]] Status create_sender(const TUniqueId& query_id, int buffer_size,
+    Status create_sender(const TUniqueId& query_id, int buffer_size,
                                        std::shared_ptr<BufferControlBlock>* sender);
     // fetch data, used by RPC
-    [[nodiscard]] Status fetch_data(const TUniqueId& fragment_id, TFetchDataResult* result);
+    Status fetch_data(const TUniqueId& fragment_id, TFetchDataResult* result);
 
     void fetch_data(const PUniqueId& finst_id, GetResultBatchCtx* ctx);
 
     // cancel
-    [[nodiscard]] Status cancel(const TUniqueId& fragment_id);
+    Status cancel(const TUniqueId& fragment_id);
 
     // cancel one query at a future time.
-    [[nodiscard]] Status cancel_at_time(time_t cancel_time, const TUniqueId& query_id);
+    Status cancel_at_time(time_t cancel_time, const TUniqueId& query_id);
 
 private:
     typedef std::unordered_map<TUniqueId, std::shared_ptr<BufferControlBlock>> BufferMap;

--- a/be/src/runtime/result_buffer_mgr.h
+++ b/be/src/runtime/result_buffer_mgr.h
@@ -62,8 +62,7 @@ public:
     // create one result sender for this query_id
     // the returned sender do not need release
     // sender is not used when call cancel or unregister
-    Status create_sender(const TUniqueId& query_id, int buffer_size,
-                                       std::shared_ptr<BufferControlBlock>* sender);
+    Status create_sender(const TUniqueId& query_id, int buffer_size, std::shared_ptr<BufferControlBlock>* sender);
     // fetch data, used by RPC
     Status fetch_data(const TUniqueId& fragment_id, TFetchDataResult* result);
 

--- a/be/src/runtime/runtime_filter_worker.cpp
+++ b/be/src/runtime/runtime_filter_worker.cpp
@@ -521,6 +521,8 @@ RuntimeFilterWorker::RuntimeFilterWorker(ExecEnv* env) : _exec_env(env), _thread
     Thread::set_thread_name(_thread, "runtime_filter");
 }
 
+RuntimeFilterWorker::~RuntimeFilterWorker() = default;
+
 void RuntimeFilterWorker::close() {
     _queue.shutdown();
     _thread.join();

--- a/be/src/runtime/runtime_filter_worker.cpp
+++ b/be/src/runtime/runtime_filter_worker.cpp
@@ -521,7 +521,7 @@ RuntimeFilterWorker::RuntimeFilterWorker(ExecEnv* env) : _exec_env(env), _thread
     Thread::set_thread_name(_thread, "runtime_filter");
 }
 
-RuntimeFilterWorker::~RuntimeFilterWorker() {
+void RuntimeFilterWorker::close() {
     _queue.shutdown();
     _thread.join();
 }

--- a/be/src/runtime/runtime_filter_worker.h
+++ b/be/src/runtime/runtime_filter_worker.h
@@ -126,7 +126,7 @@ struct RuntimeFilterWorkerEvent;
 class RuntimeFilterWorker {
 public:
     RuntimeFilterWorker(ExecEnv* env);
-    ~RuntimeFilterWorker() = default;
+    ~RuntimeFilterWorker();
     void close();
     // open query for creating runtime filter merger.
     void open_query(const TUniqueId& query_id, const TQueryOptions& query_options, const TRuntimeFilterParams& params,

--- a/be/src/runtime/runtime_filter_worker.h
+++ b/be/src/runtime/runtime_filter_worker.h
@@ -126,7 +126,8 @@ struct RuntimeFilterWorkerEvent;
 class RuntimeFilterWorker {
 public:
     RuntimeFilterWorker(ExecEnv* env);
-    ~RuntimeFilterWorker();
+    ~RuntimeFilterWorker() = default;
+    void close();
     // open query for creating runtime filter merger.
     void open_query(const TUniqueId& query_id, const TQueryOptions& query_options, const TRuntimeFilterParams& params,
                     bool is_pipeline);

--- a/be/src/service/service_be/starrocks_be.cpp
+++ b/be/src/service/service_be/starrocks_be.cpp
@@ -276,24 +276,6 @@ void start_be(const std::vector<StorePath>& paths, bool as_cn) {
     brpc_server->Stop(0);
     thrift_server->stop();
 
-    http_server->join();
-    LOG(INFO) << process_name << " exit step " << exit_step++ << ": http server exit successfully";
-
-    // Should stop the query rpc pool first, otherwise brpc_server->join() will block
-    // becuase of the done->Run() will not execuete.
-    exec_env->query_rpc_pool()->shutdown();
-    LOG(INFO) << process_name << " exit step " << exit_step++ << ": query_rpc_pool shutdown successfully";
-
-    brpc_server->Join();
-    LOG(INFO) << process_name << " exit step " << exit_step++ << ": brpc server exit successfully";
-
-    thrift_server->join();
-    LOG(INFO) << process_name << " exit step " << exit_step++ << ": thrift server exit successfully";
-
-    http_server.reset();
-    brpc_server.reset();
-    thrift_server.reset();
-
     daemon->stop();
     daemon.reset();
     LOG(INFO) << process_name << " exit step " << exit_step++ << ": daemon threads exit successfully";
@@ -316,7 +298,22 @@ void start_be(const std::vector<StorePath>& paths, bool as_cn) {
     }
 #endif
 
+    http_server->join();
+    LOG(INFO) << process_name << " exit step " << exit_step++ << ": http server exit successfully";
+
+    brpc_server->Join();
+    LOG(INFO) << process_name << " exit step " << exit_step++ << ": brpc server exit successfully";
+
+    thrift_server->join();
+    LOG(INFO) << process_name << " exit step " << exit_step++ << ": thrift server exit successfully";
+
+    http_server.reset();
+    brpc_server.reset();
+    thrift_server.reset();
+
     exec_env->destroy();
+    LOG(INFO) << process_name << " exit step " << exit_step++ << ": exec env destroy successfully";
+
     delete storage_engine;
 
     // Unbind with MemTracker

--- a/be/src/service/service_be/starrocks_be.cpp
+++ b/be/src/service/service_be/starrocks_be.cpp
@@ -282,6 +282,7 @@ void start_be(const std::vector<StorePath>& paths, bool as_cn) {
     // Should stop the query rpc pool first, otherwise brpc_server->join() will block
     // becuase of the done->Run() will not execuete.
     exec_env->query_rpc_pool()->shutdown();
+    LOG(INFO) << process_name << " exit step " << exit_step++ << ": query_rpc_pool shutdown successfully";
 
     brpc_server->Join();
     LOG(INFO) << process_name << " exit step " << exit_step++ << ": brpc server exit successfully";

--- a/be/src/service/service_be/starrocks_be.cpp
+++ b/be/src/service/service_be/starrocks_be.cpp
@@ -279,6 +279,10 @@ void start_be(const std::vector<StorePath>& paths, bool as_cn) {
     http_server->join();
     LOG(INFO) << process_name << " exit step " << exit_step++ << ": http server exit successfully";
 
+    // Should stop the query rpc pool first, otherwise brpc_server->join() will block
+    // becuase of the done->Run() will not execuete.
+    exec_env->query_rpc_pool()->shutdown();
+
     brpc_server->Join();
     LOG(INFO) << process_name << " exit step " << exit_step++ << ": brpc server exit successfully";
 

--- a/be/src/service/service_be/starrocks_be.cpp
+++ b/be/src/service/service_be/starrocks_be.cpp
@@ -298,11 +298,6 @@ void start_be(const std::vector<StorePath>& paths, bool as_cn) {
     }
 #endif
 
-    exec_env->destroy();
-    LOG(INFO) << process_name << " exit step " << exit_step++ << ": exec env destroy successfully";
-
-    delete storage_engine;
-
     http_server->join();
     http_server.reset();
     LOG(INFO) << process_name << " exit step " << exit_step++ << ": http server exit successfully";
@@ -314,6 +309,11 @@ void start_be(const std::vector<StorePath>& paths, bool as_cn) {
     thrift_server->join();
     thrift_server.reset();
     LOG(INFO) << process_name << " exit step " << exit_step++ << ": thrift server exit successfully";
+
+    exec_env->destroy();
+    LOG(INFO) << process_name << " exit step " << exit_step++ << ": exec env destroy successfully";
+
+    delete storage_engine;
 
     // Unbind with MemTracker
     tls_mem_tracker = nullptr;

--- a/be/src/service/service_be/starrocks_be.cpp
+++ b/be/src/service/service_be/starrocks_be.cpp
@@ -298,22 +298,21 @@ void start_be(const std::vector<StorePath>& paths, bool as_cn) {
     }
 #endif
 
-    http_server.reset();
-    brpc_server.reset();
-    thrift_server.reset();
-
     exec_env->destroy();
     LOG(INFO) << process_name << " exit step " << exit_step++ << ": exec env destroy successfully";
 
     delete storage_engine;
 
     http_server->join();
+    http_server.reset();
     LOG(INFO) << process_name << " exit step " << exit_step++ << ": http server exit successfully";
 
     brpc_server->Join();
+    brpc_server.reset();
     LOG(INFO) << process_name << " exit step " << exit_step++ << ": brpc server exit successfully";
 
     thrift_server->join();
+    thrift_server.reset();
     LOG(INFO) << process_name << " exit step " << exit_step++ << ": thrift server exit successfully";
 
     // Unbind with MemTracker

--- a/be/src/service/service_be/starrocks_be.cpp
+++ b/be/src/service/service_be/starrocks_be.cpp
@@ -298,15 +298,6 @@ void start_be(const std::vector<StorePath>& paths, bool as_cn) {
     }
 #endif
 
-    http_server->join();
-    LOG(INFO) << process_name << " exit step " << exit_step++ << ": http server exit successfully";
-
-    brpc_server->Join();
-    LOG(INFO) << process_name << " exit step " << exit_step++ << ": brpc server exit successfully";
-
-    thrift_server->join();
-    LOG(INFO) << process_name << " exit step " << exit_step++ << ": thrift server exit successfully";
-
     http_server.reset();
     brpc_server.reset();
     thrift_server.reset();
@@ -315,6 +306,15 @@ void start_be(const std::vector<StorePath>& paths, bool as_cn) {
     LOG(INFO) << process_name << " exit step " << exit_step++ << ": exec env destroy successfully";
 
     delete storage_engine;
+
+    http_server->join();
+    LOG(INFO) << process_name << " exit step " << exit_step++ << ": http server exit successfully";
+
+    brpc_server->Join();
+    LOG(INFO) << process_name << " exit step " << exit_step++ << ": brpc server exit successfully";
+
+    thrift_server->join();
+    LOG(INFO) << process_name << " exit step " << exit_step++ << ": thrift server exit successfully";
 
     // Unbind with MemTracker
     tls_mem_tracker = nullptr;


### PR DESCRIPTION
Why I'm doing:

BrpcServer::Join() will wait all the Closure::done(), if the task is blocked by any reason, the join will be blocked, so we should stop the exec_env and storage engine first, and then call BrpcServer::Join(), and then destroy exec_env.

```
#0  0x00007f1422e26a35 in pthread_cond_wait@@GLIBC_2.3.2 () from /lib64/libpthread.so.0
#1  0x000000000a60d759 in butil::ConditionVariable::Wait (this=<optimized out>) at src/butil/synchronization/condition_variable_posix.cc:32
#2  0x000000000a6d49e0 in brpc::Acceptor::Join (this=0x7f13e2f41480) at src/brpc/acceptor.cpp:169
#3  0x000000000a6b210d in brpc::Server::Join (this=this@entry=0x7f13e2dbea00) at src/brpc/server.cpp:1147
#4  0x0000000008ad9a10 in starrocks::start_be (paths=..., as_cn=as_cn@entry=false) at /root/starrocks/be/src/service/service_be/starrocks_be.cpp:282
#5  0x0000000004e0fb68 in main (argc=<optimized out>, argv=<optimized out>) at /root/starrocks/be/src/service/starrocks_main.cpp:250
```

```
(gdb) p (*(*exec_env)._query_rpc_pool)._threads.threads
$5 = {<std::__cxx11::_List_base<boost::thread*, std::allocator<boost::thread*> >> = {_M_impl = {<std::allocator<std::_List_node<boost::thread*> >> = {<__gnu_cxx::new_allocator<std::_List_node<boost::thread*> >> = {<No data fields>}, <No data fields>}, 
      _M_node = {<std::__detail::_List_node_base> = {_M_next = 0x7f141a6753e0, _M_prev = 0x7f141a6756a0}, _M_size = 12}}}, <No data fields>}
```

```

template <typename T>
void PInternalServiceImplBase<T>::fetch_data(google::protobuf::RpcController* cntl_base,
                                             const PFetchDataRequest* request, PFetchDataResult* result,
                                             google::protobuf::Closure* done) {
    auto task = [=]() { this->_fetch_data(cntl_base, request, result, done); };
    if (!_exec_env->query_rpc_pool()->try_offer(std::move(task))) {
        ClosureGuard closure_guard(done);
        Status::ServiceUnavailable("submit fetch_data task failed").to_protobuf(result->mutable_status());
    }
}
```

What I'm doing:

Destroy exec_env and storage_engine first and then wait BrpcServer::join().

Step 1: Stop the brpc server to reject the new rpc request
Step 2: Stop exec env and storage engine
Step 3: BrpcServer::join

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [x] 3.1
  - [ ] 3.0
  - [ ] 2.5
