### PR TITLE
[BugFix] fix left outer join to inner join bug and string not equal rewrite bug

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/Optimizer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/Optimizer.java
@@ -820,6 +820,9 @@ public class Optimizer {
         }
         context.getTaskScheduler().pushTask(new RewriteTreeTask(rootTaskContext, tree, rules, false));
         context.getTaskScheduler().executeTasks(rootTaskContext);
+        if (ruleSetType.equals(RuleSetType.PUSH_DOWN_PREDICATE)) {
+            context.reset();
+        }
     }
 
     private void ruleRewriteIterative(OptExpression tree, TaskContext rootTaskContext, Rule rule) {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/OptimizerContext.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/OptimizerContext.java
@@ -27,6 +27,7 @@ import com.starrocks.sql.common.ErrorType;
 import com.starrocks.sql.common.StarRocksPlannerException;
 import com.starrocks.sql.optimizer.base.ColumnRefFactory;
 import com.starrocks.sql.optimizer.dump.DumpInfo;
+import com.starrocks.sql.optimizer.operator.scalar.IsNullPredicateOperator;
 import com.starrocks.sql.optimizer.rule.RuleSet;
 import com.starrocks.sql.optimizer.rule.RuleType;
 import com.starrocks.sql.optimizer.task.SeriallyTaskScheduler;
@@ -67,6 +68,10 @@ public class OptimizerContext {
 
     private boolean isShortCircuit = false;
     private boolean inMemoPhase = false;
+
+    // Is not null predicate can be derived from inner join or semi join,
+    // which should be kept to be used to convert outer join into inner join.
+    private List<IsNullPredicateOperator> pushdownNotNullPredicates = Lists.newArrayList();
 
     @VisibleForTesting
     public OptimizerContext(Memo memo, ColumnRefFactory columnRefFactory) {
@@ -266,5 +271,18 @@ public class OptimizerContext {
 
     public boolean isInMemoPhase() {
         return this.inMemoPhase;
+    }
+
+    public List<IsNullPredicateOperator> getPushdownNotNullPredicates() {
+        return pushdownNotNullPredicates;
+    }
+
+    public void addPushdownNotNullPredicates(IsNullPredicateOperator notNullPredicate) {
+        pushdownNotNullPredicates.add(notNullPredicate);
+    }
+
+    // Should clear pushdownNotNullPredicates after each call of PUSH_DOWN_PREDICATE rule set
+    public void reset() {
+        pushdownNotNullPredicates.clear();
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/JoinPredicatePushdown.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/JoinPredicatePushdown.java
@@ -22,6 +22,7 @@ import com.starrocks.analysis.JoinOperator;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.sql.optimizer.JoinHelper;
 import com.starrocks.sql.optimizer.OptExpression;
+import com.starrocks.sql.optimizer.OptimizerContext;
 import com.starrocks.sql.optimizer.Utils;
 import com.starrocks.sql.optimizer.base.ColumnRefFactory;
 import com.starrocks.sql.optimizer.base.ColumnRefSet;
@@ -60,9 +61,12 @@ public class JoinPredicatePushdown {
     private List<ScalarOperator> rightPushDown;
     private boolean enableLeftRightOuterJoinEquivalenceDerive = true;
 
+    private final OptimizerContext optimizerContext;
+
     public JoinPredicatePushdown(
             OptExpression joinOptExpression, boolean isOnPredicate, boolean directToChild,
-            ColumnRefFactory columnRefFactory, boolean enableLeftRightOuterJoinEquivalenceDerive) {
+            ColumnRefFactory columnRefFactory, boolean enableLeftRightOuterJoinEquivalenceDerive,
+            OptimizerContext optimizerContext) {
         this.joinOptExpression = joinOptExpression;
         this.isOnPredicate = isOnPredicate;
         this.directToChild = directToChild;
@@ -70,6 +74,7 @@ public class JoinPredicatePushdown {
         this.enableLeftRightOuterJoinEquivalenceDerive = enableLeftRightOuterJoinEquivalenceDerive;
         this.leftPushDown = Lists.newArrayList();
         this.rightPushDown = Lists.newArrayList();
+        this.optimizerContext = optimizerContext;
     }
 
     public OptExpression pushdown(ScalarOperator predicateToPush) {
@@ -331,11 +336,23 @@ public class JoinPredicatePushdown {
         LogicalJoinOperator joinOp = ((LogicalJoinOperator) join.getOp());
 
         JoinOperator joinType = joinOp.getJoinType();
-        if ((joinType.isInnerJoin() || joinType.isRightSemiJoin()) && leftPushDown.isEmpty()) {
-            leftEQ.stream().map(c -> new IsNullPredicateOperator(true, c.clone(), true)).forEach(leftPushDown::add);
+        boolean isLeftEmpty = leftPushDown.isEmpty();
+        if (joinType.isInnerJoin() || joinType.isRightSemiJoin()) {
+            leftEQ.stream().map(c -> new IsNullPredicateOperator(true, c.clone(), true)).forEach(notNull -> {
+                optimizerContext.addPushdownNotNullPredicates(notNull);
+                if (isLeftEmpty) {
+                    leftPushDown.add(notNull);
+                }
+            });
         }
-        if ((joinType.isInnerJoin() || joinType.isLeftSemiJoin()) && rightPushDown.isEmpty()) {
-            rightEQ.stream().map(c -> new IsNullPredicateOperator(true, c.clone(), true)).forEach(rightPushDown::add);
+        boolean isRightEmpty = rightPushDown.isEmpty();
+        if (joinType.isInnerJoin() || joinType.isLeftSemiJoin()) {
+            rightEQ.stream().map(c -> new IsNullPredicateOperator(true, c.clone(), true)).forEach(notNull -> {
+                optimizerContext.addPushdownNotNullPredicates(notNull);
+                if (isRightEmpty) {
+                    rightPushDown.add(notNull);
+                }
+            });
         }
         joinOp.setHasDeriveIsNotNullPredicate(true);
     }
@@ -524,7 +541,8 @@ public class JoinPredicatePushdown {
         Set<ColumnRefOperator> rightOutputColumnOps = columnRefFactory.getColumnRefs(rightColumns);
 
         if (join.getJoinType().isLeftOuterJoin()) {
-            if (Utils.canEliminateNull(rightOutputColumnOps, predicateToPush)) {
+            if (Utils.canEliminateNull(rightOutputColumnOps, predicateToPush)
+                    || hasPushdownNotNull(rightOutputColumnOps, optimizerContext.getPushdownNotNullPredicates())) {
                 OptExpression newOpt = OptExpression.create(new LogicalJoinOperator.Builder().withOperator(join)
                                 .setJoinType(JoinOperator.INNER_JOIN)
                                 .build(),
@@ -532,7 +550,8 @@ public class JoinPredicatePushdown {
                 return newOpt;
             }
         } else if (join.getJoinType().isRightOuterJoin()) {
-            if (Utils.canEliminateNull(leftOutputColumnOps, predicateToPush)) {
+            if (Utils.canEliminateNull(leftOutputColumnOps, predicateToPush)
+                    || hasPushdownNotNull(leftOutputColumnOps, optimizerContext.getPushdownNotNullPredicates())) {
                 OptExpression newOpt = OptExpression.create(new LogicalJoinOperator.Builder().withOperator(join)
                                 .setJoinType(JoinOperator.INNER_JOIN)
                                 .build(),
@@ -568,5 +587,9 @@ public class JoinPredicatePushdown {
             }
         }
         return joinOpt;
+    }
+
+    private boolean hasPushdownNotNull(Set<ColumnRefOperator> outputColumnOps, List<IsNullPredicateOperator> pushdownNotNulls) {
+        return pushdownNotNulls.stream().anyMatch(p -> outputColumnOps.containsAll(p.getColumnRefs()));
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/ScalarOperatorRewriter.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/ScalarOperatorRewriter.java
@@ -60,6 +60,7 @@ public class ScalarOperatorRewriter {
             new ExtractCommonPredicateRule(),
             new ArithmeticCommutativeRule()
     );
+
     public static final List<ScalarOperatorRewriteRule> MV_SCALAR_REWRITE_RULES = DEFAULT_REWRITE_SCAN_PREDICATE_RULES.stream()
             .map(rule -> rule instanceof NormalizePredicateRule ? new MvNormalizePredicateRule() : rule)
             .collect(Collectors.toList());

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/PushDownJoinOnClauseRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/PushDownJoinOnClauseRule.java
@@ -50,7 +50,7 @@ public class PushDownJoinOnClauseRule extends TransformationRule {
         ScalarOperator on = join.getOnPredicate();
         JoinPredicatePushdown joinPredicatePushdown = new JoinPredicatePushdown(
                 input, true, false, context.getColumnRefFactory(),
-                context.isEnableLeftRightJoinEquivalenceDerive());
+                context.isEnableLeftRightJoinEquivalenceDerive(), context);
         OptExpression root = joinPredicatePushdown.pushdown(join.getOnPredicate());
         ((LogicalJoinOperator) root.getOp()).setHasPushDownJoinOnClause(true);
         if (root.getOp().equals(input.getOp()) && on.equals(join.getOnPredicate()) &&

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/PushDownPredicateJoinRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/PushDownPredicateJoinRule.java
@@ -41,7 +41,7 @@ public class PushDownPredicateJoinRule extends TransformationRule {
         OptExpression joinOpt = input.getInputs().get(0);
         JoinPredicatePushdown joinPredicatePushdown = new JoinPredicatePushdown(
                 joinOpt, false, false, context.getColumnRefFactory(),
-                context.isEnableLeftRightJoinEquivalenceDerive());
+                context.isEnableLeftRightJoinEquivalenceDerive(), context);
         return Lists.newArrayList(joinPredicatePushdown.pushdown(filter.getPredicate()));
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MaterializedViewRewriter.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MaterializedViewRewriter.java
@@ -1914,8 +1914,10 @@ public class MaterializedViewRewriter {
         // To ensure join's property is deduced which is needed in `predicate-push-down`, derive its logical property.
         deriveLogicalProperty(joinOptExpression);
         Preconditions.checkState(joinOptExpression.getOp() instanceof LogicalJoinOperator);
+        optimizerContext.reset();
         JoinPredicatePushdown joinPredicatePushdown = new JoinPredicatePushdown(joinOptExpression,
-                false, true, materializationContext.getQueryRefFactory(), true);
+                false, true, materializationContext.getQueryRefFactory(),
+                true, optimizerContext);
         return joinPredicatePushdown.pushdown(predicate);
     }
 

--- a/fe/fe-core/src/test/java/com/starrocks/planner/MaterializedViewTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/planner/MaterializedViewTest.java
@@ -5385,4 +5385,28 @@ public class MaterializedViewTest extends MaterializedViewTestBase {
                 " sum(salary) as total, count(salary)  as cnt\n" +
                 " from emps group by empid having sum(salary) > 10");
     }
+
+    @Test
+    public void testMultiLeftOuterJoin() {
+        {
+            String mv = "select t1a, t1b, v5, v8 " +
+                    "from test.test_all_type left outer join test.t1 on t1d = v4 " +
+                    "left outer join test.t2 on v5 = v7 where v9 = 10";
+            String query = "select t1a, t1b, v5, v8 " +
+                    "from test.test_all_type left outer join test.t1 on t1d = v4 " +
+                    "left outer join test.t2 on v5 = v7 where v9 = 10 and t1a != 'xxx'";
+            MVRewriteChecker checker = testRewriteOK(mv, query);
+            checker.contains("t1a != 'xxx'");
+        }
+
+        {
+            String mv = "select v1, v2, v3, v5, v8 " +
+                    "from test.t0 left outer join test.t1 on v1 = v4 " +
+                    "left outer join test.t2 on v5 = v7 where v9 = 10";
+            String query = "select v1, v2, v3, v5, v8 " +
+                    "from test.t0 left outer join test.t1 on v1 = v4 " +
+                    "left outer join test.t2 on v5 = v7 where v9 = 10 and v3 = 1";
+            testRewriteOK(mv, query);
+        }
+    }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rewrite/JoinPredicatePushdownTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rewrite/JoinPredicatePushdownTest.java
@@ -1,0 +1,118 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.sql.optimizer.rewrite;
+
+import com.starrocks.sql.plan.PlanTestBase;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+public class JoinPredicatePushdownTest extends PlanTestBase {
+    @BeforeClass
+    public static void beforeClass() throws Exception {
+        PlanTestBase.beforeClass();
+    }
+
+    @Test
+    public void testJoinPushdownCTE() throws Exception {
+        // enable cte reuse to trigger calling PUSH_DOWN_PREDICATE rule set twice
+        connectContext.getSessionVariable().setCboCteReuse(true);
+        String query = "with xxx1 as (\n" +
+                "with x as (select * from t1 join t2 where t1.v4 = t2.v7 )\n" +
+                "select x1.v6, x2.v7 \n" +
+                "from (select * from x where x.v5 = 1 ) x1 left outer join" +
+                " (select * from x where x.v8 = 2) x2 on x1.v4 = x2.v7)\n" +
+                "select * from xxx1 where xxx1.v6 = 2\n" +
+                "union \n" +
+                "select * from xxx1 where xxx1.v7 = 3";
+        String plan = getFragmentPlan(query);
+        // must has left outer join
+        PlanTestBase.assertContains(plan, "13:HASH JOIN\n" +
+                "  |  join op: LEFT OUTER JOIN (BROADCAST)\n" +
+                "  |  colocate: false, reason: \n" +
+                "  |  equal join conjunct: 7: v4 = 16: v7\n" +
+                "  |  other predicates: (16: v7 = 3) OR (9: v6 = 2)");
+    }
+
+    @Test
+    public void testMultiLeftOuterJoin2() throws Exception {
+        connectContext.getSessionVariable().setOptimizerExecuteTimeout(3000000);
+        connectContext.getSessionVariable().disableJoinReorder();
+        String query = "select x.v1 v11, x.v2 v21, x.v3 v31, sub2.v1 v12, sub2.v2 v22 from test.t0 x inner join" +
+                " (select v1, v2, v3, v4, v5, v8 " +
+                "from test.t0 left outer join (select * from test.t1 " +
+                "inner join test.t2 on v5 = v7) sub on v1 = v4) sub2 on x.v1 = sub2.v1";
+        String plan = getFragmentPlan(query);
+    }
+
+    @Test
+    public void testMultiLeftOuterJoin() throws Exception {
+        String query = "select v1, v2, v5, v8 " +
+                "from test.t0 left outer join test.t1 on v1 = v4 " +
+                "left outer join test.t2 on v5 = v7 where v9 = 10";
+        String plan = getFragmentPlan(query);
+        PlanTestBase.assertContains(plan, "3:HASH JOIN\n" +
+                "  |  join op: INNER JOIN (BROADCAST)\n" +
+                "  |  colocate: false, reason: \n" +
+                "  |  equal join conjunct: 1: v1 = 4: v4");
+        PlanTestBase.assertContains(plan, "8:HASH JOIN\n" +
+                "  |  join op: INNER JOIN (BROADCAST)\n" +
+                "  |  colocate: false, reason: \n" +
+                "  |  equal join conjunct: 5: v5 = 7: v7");
+
+        String query2 = "select v1, v2, v5, v8 " +
+                "from test.t0 left outer join test.t1 on v1 = v4 " +
+                "left outer join test.t2 on v5 = v7 where v9 = 10 and v3 = 1";
+        String plan2 = getFragmentPlan(query2);
+        PlanTestBase.assertContains(plan2, "9:HASH JOIN\n" +
+                "  |  join op: INNER JOIN (BROADCAST)\n" +
+                "  |  colocate: false, reason: \n" +
+                "  |  equal join conjunct: 5: v5 = 7: v7");
+        PlanTestBase.assertContains(plan2, "4:HASH JOIN\n" +
+                "  |  join op: INNER JOIN (BROADCAST)\n" +
+                "  |  colocate: false, reason: \n" +
+                "  |  equal join conjunct: 1: v1 = 4: v4");
+        PlanTestBase.assertNotContains(plan2, "LEFT OUTER JOIN");
+    }
+
+    @Test
+    public void testMultiRightOuterJoin() throws Exception {
+        String query = "select v1, v2, v5, v8 " +
+                "from test.t0 right outer join test.t1 on v1 = v4 " +
+                "right outer join test.t2 on v2 = v7 where v3 = 10";
+        String plan = getFragmentPlan(query);
+        PlanTestBase.assertContains(plan, "4:HASH JOIN\n" +
+                "  |  join op: INNER JOIN (BROADCAST)\n" +
+                "  |  colocate: false, reason: \n" +
+                "  |  equal join conjunct: 1: v1 = 4: v4");
+        PlanTestBase.assertContains(plan, "8:HASH JOIN\n" +
+                "  |  join op: INNER JOIN (BROADCAST)\n" +
+                "  |  colocate: false, reason: \n" +
+                "  |  equal join conjunct: 2: v2 = 7: v7");
+
+        String query2 = "select v1, v2, v5, v8 " +
+                "from test.t0 right outer join test.t1 on v1 = v4 " +
+                "right outer join test.t2 on v2 = v7 where v5 = 10";
+        String plan2 = getFragmentPlan(query2);
+        PlanTestBase.assertContains(plan2, "7:HASH JOIN\n" +
+                "  |  join op: INNER JOIN (BROADCAST)\n" +
+                "  |  colocate: false, reason: \n" +
+                "  |  equal join conjunct: 2: v2 = 7: v7");
+        PlanTestBase.assertContains(plan2, "3:HASH JOIN\n" +
+                "  |  join op: INNER JOIN (BROADCAST)\n" +
+                "  |  colocate: false, reason: \n" +
+                "  |  equal join conjunct: 1: v1 = 4: v4");
+        PlanTestBase.assertNotContains(plan2, "LEFT OUTER JOIN");
+    }
+}


### PR DESCRIPTION
Why I'm doing:
mv with string not equal predicate rewrite failed because converting left outer join to inner join failed.

What I'm doing:
Fix it by:
1. fix converting left outer join to inner join bug
2. fix query with string not equal predicate rewrite failed bug.

Fixes #39330 

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [x] 3.1
  - [x] 3.0
  - [x] 2.5
