### PR TITLE
[BugFix] Tablet schema in rowset meta maybe null if we restore from old version snapshot

### DIFF
--- a/be/src/storage/tablet_meta.cpp
+++ b/be/src/storage/tablet_meta.cpp
@@ -302,10 +302,16 @@ void TabletMeta::init_from_pb(TabletMetaPB* ptablet_meta_pb) {
         if (rs_meta->has_delete_predicate()) {
             add_delete_predicate(rs_meta->delete_predicate(), rs_meta->version().first);
         }
+        if (!rs_meta->tablet_schema()) {
+            rs_meta->set_tablet_schema(_schema);
+        }
         _rs_metas.push_back(std::move(rs_meta));
     }
     for (auto& it : tablet_meta_pb.inc_rs_metas()) {
         auto rs_meta = std::make_shared<RowsetMeta>(it);
+        if (!rs_meta->tablet_schema()) {
+            rs_meta->set_tablet_schema(_schema);
+        }
         _inc_rs_metas.push_back(std::move(rs_meta));
     }
 


### PR DESCRIPTION
Why I'm doing:
Rowset meta will keep tablet schema to support fast schema evolution. However, if we dump a snapshot in old version and restore in new version, the rowset meta will lost tablet schema because the snapshot does not keep tablet schema in rowset meta.

What I'm doing:
Write a tablet schema to rowset meta when init tablet meta.

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
