### PR TITLE
[BugFix] Fix streamload partialupdate failed on column with row

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/planner/StreamLoadPlanner.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/StreamLoadPlanner.java
@@ -138,7 +138,8 @@ public class StreamLoadPlanner {
             if (negative) {
                 throw new DdlException("Primary key table does not support negative load");
             }
-            if (destTable.hasRowStorageType() && streamLoadInfo.getPartialUpdateMode() != TPartialUpdateMode.ROW_MODE) {
+            if (destTable.hasRowStorageType() && streamLoadInfo.isPartialUpdate() &&
+                    streamLoadInfo.getPartialUpdateMode() != TPartialUpdateMode.ROW_MODE) {
                 throw new DdlException("column with row table only support row mode partial update");
             }
         } else {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/LoadPlanner.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/LoadPlanner.java
@@ -244,7 +244,8 @@ public class LoadPlanner {
         OlapTable olapDestTable = (OlapTable) destTable;
         List<Column> destColumns = Lists.newArrayList();
         if (isPrimaryKey && partialUpdate) {
-            if (((OlapTable) destTable).hasRowStorageType() && partialUpdateMode != TPartialUpdateMode.ROW_MODE) {
+            if (((OlapTable) destTable).hasRowStorageType() && partialUpdate &&
+                    partialUpdateMode != TPartialUpdateMode.ROW_MODE) {
                 throw new DdlException("column with row table only support row mode partial update");
             }
             if (this.etlJobType == EtlJobType.BROKER) {

--- a/fe/fe-core/src/test/java/com/starrocks/load/LoadPlannerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/load/LoadPlannerTest.java
@@ -32,6 +32,7 @@ import com.starrocks.catalog.Partition;
 import com.starrocks.catalog.ScalarType;
 import com.starrocks.catalog.Type;
 import com.starrocks.common.Config;
+import com.starrocks.common.DdlException;
 import com.starrocks.common.UserException;
 import com.starrocks.common.jmockit.Deencapsulation;
 import com.starrocks.common.util.TimeUtils;
@@ -446,6 +447,62 @@ public class LoadPlannerTest {
         Assert.assertEquals(1, nodes.size());
         TPlanNode tPlanNode = nodes.get(0);
         Assert.assertEquals(TPlanNodeType.FILE_SCAN_NODE, tPlanNode.node_type);
+    }
+
+    @Test
+    public void testColumnWithRowPartialUpdate(@Mocked GlobalStateMgr globalStateMgr,
+                                      @Mocked SystemInfoService systemInfoService,
+                                      @Injectable Database db, @Injectable OlapTable table) throws Exception {
+        new Expectations() {
+            {
+                table.getKeysType();
+                minTimes = 0;
+                result = KeysType.PRIMARY_KEYS;
+                table.hasRowStorageType();
+                result = true;
+            }
+        };
+
+        // column mappings
+        String sql = "LOAD LABEL label0 (DATA INFILE('path/k2=1/file1') INTO TABLE t2 FORMAT AS 'orc' (k1,k33,v) " +
+                "COLUMNS FROM PATH AS (k2) set (k3 = substr(k33,1,5))) WITH BROKER 'broker0'";
+        LoadStmt loadStmt = (LoadStmt) com.starrocks.sql.parser.SqlParser.parse(
+                sql, ctx.getSessionVariable().getSqlMode()).get(0);
+        List<Expr> columnMappingList = Deencapsulation.getField(loadStmt.getDataDescriptions().get(0),
+                "columnMappingList");
+
+        // file groups
+        List<BrokerFileGroup> fileGroups = Lists.newArrayList();
+        List<String> files = Lists.newArrayList("path/k2=1/file1");
+        List<String> columnNames = Lists.newArrayList("k1", "k33", "v");
+        DataDescription desc = new DataDescription("t2", null, files, columnNames,
+                null, null, "ORC", Lists.newArrayList("k2"),
+                false, columnMappingList, null, null);
+        Deencapsulation.invoke(desc, "analyzeColumns");
+        BrokerFileGroup brokerFileGroup = new BrokerFileGroup(desc);
+        Deencapsulation.setField(brokerFileGroup, "columnSeparator", "\t");
+        Deencapsulation.setField(brokerFileGroup, "rowDelimiter", "\n");
+        Deencapsulation.setField(brokerFileGroup, "fileFormat", "ORC");
+        brokerFileGroup.parse(db, desc);
+        fileGroups.add(brokerFileGroup);
+
+        // file status
+        List<List<TBrokerFileStatus>> fileStatusesList = Lists.newArrayList();
+        List<TBrokerFileStatus> fileStatusList = Lists.newArrayList();
+        fileStatusList.add(new TBrokerFileStatus("path/k2=1/file1", false, 268435456, true));
+        fileStatusesList.add(fileStatusList);
+
+        // plan
+        LoadPlanner planner = new LoadPlanner(jobId, loadId, txnId, db.getId(), table, strictMode,
+                timezone, timeoutS, startTime, true, ctx, sessionVariables, loadMemLimit, execMemLimit,
+                brokerDesc, fileGroups, fileStatusesList, 1);
+        planner.setPartialUpdateMode(TPartialUpdateMode.AUTO_MODE);
+        try {
+            planner.plan();
+            Assert.fail("No exception throws");
+        } catch (DdlException e) {
+            Assert.assertEquals("column with row table only support row mode partial update", e.getMessage());
+        }
     }
 
     @Test

--- a/test/sql/test_column_with_row/R/test_column_with_row
+++ b/test/sql/test_column_with_row/R/test_column_with_row
@@ -1,12 +1,82 @@
-count(*)
+-- name: test_columm_with_row
+CREATE DATABASE IF NOT EXISTS demo;
+-- result:
+[]
+-- !result
+DROP TABLE IF EXISTS demo.t1;
+-- result:
+[]
+-- !result
+CREATE TABLE IF NOT EXISTS demo.t1(
+                                      k1 int,
+                                      k2 int,
+                                      v1 varchar(16),
+    v2 DATE NOT NULL COMMENT "YYYY-MM-DD",
+    v3 TINYINT COMMENT "range [-128, 127]"
+    )
+    PRIMARY KEY (k1, k2)
+    distributed by hash(k1, k2)
+    PROPERTIES (
+                   "replication_num" = "1",
+                   "storage_type" = "column_with_row"
+               );
+-- result:
+[]
+-- !result
+INSERT INTO demo.t1(k1, k2, v1, v2, v3) VALUES
+                                            (1, 2, 'a', "2222-12-22", 33),
+                                            (1, 3, 'b', "2222-12-22", 34),
+                                            (1, 4, 'c', "2222-12-22", 35),
+                                            (2, 2, 'd', "2222-12-22", 36),
+                                            (2, 3, 'd', "2222-12-22", 37),
+                                            (3, 3, 'e', "2222-12-22", 100),
+                                            (4, 4, 'f', "2222-12-22", 101);
+-- result:
+[]
+-- !result
+SELECT count(*) FROM demo.t1;
+-- result:
 7
-k1	k2	v1	v2	v3
+-- !result
+SELECT * FROM demo.t1 order by k1, k2 limit 3;
+-- result:
 1	2	a	2222-12-22	33
 1	3	b	2222-12-22	34
 1	4	c	2222-12-22	35
-k2	sum(k1)
+-- !result
+SELECT k2, sum(k1) FROM demo.t1 group by k2 order by k2;
+-- result:
 2	3
 3	6
 4	5
-k1	k2	v1	v2	v3
+-- !result
+update demo.t1 set v1 = '5' where k1 = 3 and k2 = 3;
+-- result:
+[]
+-- !result
+select * from demo.t1 where k1 = 3 and k2 = 3;
+-- result:
 3	3	5	2222-12-22	100
+-- !result
+DELETE FROM demo.t1 WHERE k1 = 1 and k2 = 2;
+-- result:
+[]
+-- !result
+SELECT * from demo.t1 WHERE k1 = 1 and k2 = 2;
+-- result:
+-- !result
+DELETE FROM demo.t1 WHERE k1 = 1;
+-- result:
+[]
+-- !result
+SELECT * from demo.t1 WHERE k1 = 1;
+-- result:
+-- !result
+TRUNCATE TABLE demo.t1;
+-- result:
+[]
+-- !result
+DROP TABLE demo.t1 FORCE;
+-- result:
+[]
+-- !result

--- a/test/sql/test_column_with_row/R/test_column_with_row_partial_update
+++ b/test/sql/test_column_with_row/R/test_column_with_row_partial_update
@@ -1,1 +1,129 @@
-//TODO
+-- name: test_column_with_row_partial_update
+create database test_column_with_row_partial_update;
+-- result:
+[]
+-- !result
+use test_column_with_row_partial_update;
+-- result:
+[]
+-- !result
+DROP TABLE IF EXISTS tab1;
+-- result:
+[]
+-- !result
+DROP TABLE IF EXISTS tab2;
+-- result:
+[]
+-- !result
+CREATE table IF NOT EXISTS tab1 (
+          k1 INTEGER,
+          k2 VARCHAR(50),
+          v1 INTEGER,
+          v2 INTEGER,
+          v3 INTEGER,
+          v4 varchar(50),
+          v5 varchar(50)
+    )
+    ENGINE=OLAP
+    PRIMARY KEY(`k1`,`k2`)
+    DISTRIBUTED BY HASH(`k1`) BUCKETS 10
+    PROPERTIES (
+        "replication_num" = "1",
+        "storage_type" = "column_with_row"
+    );
+-- result:
+[]
+-- !result
+CREATE table IF NOT EXISTS tab2 (
+           k1 INTEGER,
+           v1 INTEGER,
+           v2 INTEGER,
+           v3 INTEGER
+     )
+     ENGINE=OLAP
+     PRIMARY KEY(`k1`)
+     DISTRIBUTED BY HASH(`k1`) BUCKETS 10
+     PROPERTIES (
+         "replication_num" = "1",
+         "storage_type" = "column_with_row"
+     );
+-- result:
+[]
+-- !result
+insert into tab1 values (100, "k2_100", 100, 100, 100, "v4_100", "v5_100");
+-- result:
+[]
+-- !result
+insert into tab1 values (200, "k2_200", 200, 200, 200, "v4_200", "v5_200");
+-- result:
+[]
+-- !result
+insert into tab1 values (300, "k3_300", 300, 300, 300, "v4_300", "v5_300");
+-- result:
+[]
+-- !result
+select * from tab1 order by k1, k2;
+-- result:
+100	k2_100	100	100	100	v4_100	v5_100
+200	k2_200	200	200	200	v4_200	v5_200
+300	k3_300	300	300	300	v4_300	v5_300
+-- !result
+insert into tab2 values (100, 100, 100, 100);
+-- result:
+[]
+-- !result
+insert into tab2 values (200, 200, 200, 200);
+-- result:
+[]
+-- !result
+insert into tab2 values (300, 300, 300, 300);
+-- result:
+[]
+-- !result
+select * from tab2 order by k1;
+-- result:
+100	100	100	100
+200	200	200	200
+300	300	300	300
+-- !result
+update tab1 set v5 = (select sum(tab2.v1) from tab2);
+-- result:
+E: (1064, 'Getting analyzing error. Detail message: must specify where clause to prevent full table update.')
+-- !result
+update tab1 set v5 = "v5_400" where k1 = 100;
+-- result:
+[]
+-- !result
+select * from tab1 order by k1, k2;
+-- result:
+100	k2_100	100	100	100	v4_100	v5_400
+200	k2_200	200	200	200	v4_200	v5_200
+300	k3_300	300	300	300	v4_300	v5_300
+-- !result
+shell: curl --location-trusted -u root: -T ${root_path}/lib/../common/data/stream_load/sr_partial_update_1.csv -XPUT -H partial_update:true -H label:cwr_stream_load_partial_update1 -H column_separator:, -H columns:k1,k2,v4,v3 ${url}/api/test_column_with_row_partial_update/tab1/_stream_load
+-- result:
+0
+{
+    "Status": "Fail",
+    "Message": "column with row table only support row mode partial update"
+}
+-- !result
+shell: curl --location-trusted -u root: -T ${root_path}/lib/../common/data/stream_load/sr_partial_update_1.csv -XPUT -H partial_update:true -H partial_update_mode:row -H label:cwr_stream_load_partial_update2 -H column_separator:, -H columns:k1,k2,v4,v3 ${url}/api/test_column_with_row_partial_update/tab1/_stream_load
+-- result:
+0
+{
+    "Status": "Success",
+    "Message": "OK"
+}
+-- !result
+select * from tab1 order by k1, k2;
+-- result:
+100	k2_100	100	100	111	v6_100	v5_400
+200	k2_200	200	200	200	v4_200	v5_200
+300	k3_300	300	300	300	v4_300	v5_300
+400	k2_400	None	None	222	v6_400	None
+-- !result
+drop database test_column_with_row_partial_update force;
+-- result:
+[]
+-- !result

--- a/test/sql/test_column_with_row/R/test_column_with_row_variable
+++ b/test/sql/test_column_with_row/R/test_column_with_row_variable
@@ -1,58 +1,57 @@
 -- name: test_column_with_row_variable
---创建行存表
-CREATE DATABASE IF NOT EXISTS demo;
+DROP TABLE IF EXISTS t1_var;
 -- result:
+[]
 -- !result
-DROP TABLE IF EXISTS demo.t1_var;
--- result:
--- !result
-CREATE TABLE IF NOT EXISTS demo.t1_var(
-                                      k1 int,
-                                      k2 int,
-                                      v1 char(20),
-                                      v2 varchar(20),
+CREATE TABLE IF NOT EXISTS t1_var(
+    k1 int,
+    k2 int,
+    v1 char(20),
+    v2 varchar(20),
     v3 DATE NOT NULL COMMENT "YYYY-MM-DD",
     v4 TINYINT COMMENT "range [-128, 127]"
-    )
-    PRIMARY KEY (k1, k2)
-    distributed by hash(k1, k2)
-    PROPERTIES (
-                   "replication_num" = "1",
-                   "storage_type" = "column_with_row"
-               );
+)
+PRIMARY KEY (k1, k2)
+distributed by hash(k1, k2)
+PROPERTIES (
+    "replication_num" = "1",
+    "storage_type" = "column_with_row"
+);
 -- result:
+[]
 -- !result
---插入
-INSERT INTO demo.t1_var(k1, k2, v1, v2, v3, v4) VALUES
-                                            (1, 2, 'a2222222', 'a2222222', "2222-12-22", 33),
-                                            (1, 3, 'b2222222', 'b2222222', "2222-12-22", 34),
-                                            (1, 4, 'c2222222', 'c2222222', "2222-12-22", 35),
-                                            (2, 2, 'd2222222', 'd2222222', "2222-12-22", 36),
-                                            (2, 3, 'd2222222', 'd2222222', "2222-12-22", 37),
-                                            (3, 3, 'e2222222', 'e2222222', "2222-12-22", 100),
-                                            (4, 4, 'f2222222', 'f2222222', "2222-12-22", 101);
+INSERT INTO t1_var(k1, k2, v1, v2, v3, v4) VALUES
+    (1, 2, 'a2222222', 'a2222222', "2222-12-22", 33),
+    (1, 3, 'b2222222', 'b2222222', "2222-12-22", 34),
+    (1, 4, 'c2222222', 'c2222222', "2222-12-22", 35),
+    (2, 2, 'd2222222', 'd2222222', "2222-12-22", 36),
+    (2, 3, 'd2222222', 'd2222222', "2222-12-22", 37),
+    (3, 3, 'e2222222', 'e2222222', "2222-12-22", 100),
+    (4, 4, 'f2222222', 'f2222222', "2222-12-22", 101);
 -- result:
+[]
 -- !result
---查询
 set enable_short_circuit = true;
 -- result:
+[]
 -- !result
-select length(v1), v1, v2, v3, v4 from demo.t1_var where k1 = 3 and k2 = 3;
+select length(v1), v1, v2, v3, v4 from t1_var where k1 = 3 and k2 = 3;
 -- result:
 8	e2222222	e2222222	2222-12-22	100
 -- !result
-select * from demo.t1_var where k1 = 3 and k2 = 3;
+select * from t1_var where k1 = 3 and k2 = 3;
 -- result:
 3	3	e2222222	e2222222	2222-12-22	100
 -- !result
 set enable_short_circuit = false;
 -- result:
+[]
 -- !result
---清空
-TRUNCATE TABLE demo.t1_var;
+TRUNCATE TABLE t1_var;
 -- result:
+[]
 -- !result
---drop表
-DROP TABLE demo.t1_var FORCE;
+DROP TABLE t1_var FORCE;
 -- result:
+[]
 -- !result

--- a/test/sql/test_column_with_row/T/test_column_with_row
+++ b/test/sql/test_column_with_row/T/test_column_with_row
@@ -1,42 +1,41 @@
+-- name: test_columm_with_row
 --创建行存表
-CREATE DATABASE IF NOT EXISTS demo;
-DROP TABLE IF EXISTS demo.t1;
-CREATE TABLE IF NOT EXISTS demo.t1(
-                                      k1 int,
-                                      k2 int,
-                                      v1 varchar(16),
+CREATE TABLE IF NOT EXISTS t1(
+    k1 int,
+    k2 int,
+    v1 varchar(16),
     v2 DATE NOT NULL COMMENT "YYYY-MM-DD",
     v3 TINYINT COMMENT "range [-128, 127]"
-    )
-    PRIMARY KEY (k1, k2)
-    distributed by hash(k1, k2)
-    PROPERTIES (
-                   "replication_num" = "1",
-                   "storage_type" = "column_with_row"
-               );
+)
+PRIMARY KEY (k1, k2)
+distributed by hash(k1, k2)
+PROPERTIES (
+    "replication_num" = "1",
+    "storage_type" = "column_with_row"
+);
 
 --插入
-INSERT INTO demo.t1(k1, k2, v1, v2, v3) VALUES
-                                            (1, 2, 'a', "2222-12-22", 33),
-                                            (1, 3, 'b', "2222-12-22", 34),
-                                            (1, 4, 'c', "2222-12-22", 35),
-                                            (2, 2, 'd', "2222-12-22", 36),
-                                            (2, 3, 'd', "2222-12-22", 37),
-                                            (3, 3, 'e', "2222-12-22", 100),
-                                            (4, 4, 'f', "2222-12-22", 101);
+INSERT INTO t1(k1, k2, v1, v2, v3) VALUES
+    (1, 2, 'a', "2222-12-22", 33),
+    (1, 3, 'b', "2222-12-22", 34),
+    (1, 4, 'c', "2222-12-22", 35),
+    (2, 2, 'd', "2222-12-22", 36),
+    (2, 3, 'd', "2222-12-22", 37),
+    (3, 3, 'e', "2222-12-22", 100),
+    (4, 4, 'f', "2222-12-22", 101);
 --查询
-SELECT count(*) FROM demo.t1;
-SELECT * FROM demo.t1 order by k1, k2 limit 3;
-SELECT k2, sum(k1) FROM demo.t1 group by k2 order by k2;
+SELECT count(*) FROM t1;
+SELECT * FROM t1 order by k1, k2 limit 3;
+SELECT k2, sum(k1) FROM t1 group by k2 order by k2;
 --更新
-update demo.t1 set v1 = '5' where k1 = 3 and k2 = 3;
-select * from demo.t1 where k1 = 3 and k2 = 3;
+update t1 set v1 = '5' where k1 = 3 and k2 = 3;
+select * from t1 where k1 = 3 and k2 = 3;
 --删除数据
-DELETE FROM demo.t1 WHERE k1 = 1 and k2 = 2; -- full key
-select * from demo.t1 WHERE k1 = 1 and k2 = 2; -- empty
-DELETE FROM demo.t1 WHERE k1 = 1; -- partial key, range update
-select * from demo.t1 WHERE k1 = 1;
+DELETE FROM t1 WHERE k1 = 1 and k2 = 2;
+SELECT * from t1 WHERE k1 = 1 and k2 = 2;
+DELETE FROM t1 WHERE k1 = 1;
+SELECT * from t1 WHERE k1 = 1;
 --清空
-TRUNCATE TABLE demo.t1;
+TRUNCATE TABLE t1;
 --drop表
-DROP TABLE demo.t1 FORCE;
+DROP TABLE t1 FORCE;

--- a/test/sql/test_column_with_row/T/test_column_with_row_partial_update
+++ b/test/sql/test_column_with_row/T/test_column_with_row_partial_update
@@ -1,3 +1,7 @@
+-- name: test_column_with_row_partial_update
+create database test_column_with_row_partial_update;
+use test_column_with_row_partial_update;
+
 DROP TABLE IF EXISTS tab1;
 DROP TABLE IF EXISTS tab2;
 
@@ -35,11 +39,19 @@ CREATE table IF NOT EXISTS tab2 (
 insert into tab1 values (100, "k2_100", 100, 100, 100, "v4_100", "v5_100");
 insert into tab1 values (200, "k2_200", 200, 200, 200, "v4_200", "v5_200");
 insert into tab1 values (300, "k3_300", 300, 300, 300, "v4_300", "v5_300");
-select * from tab1;
+select * from tab1 order by k1, k2;
 
 insert into tab2 values (100, 100, 100, 100);
 insert into tab2 values (200, 200, 200, 200);
 insert into tab2 values (300, 300, 300, 300);
-select * from tab2;
+select * from tab2 order by k1;
 
 update tab1 set v5 = (select sum(tab2.v1) from tab2);
+update tab1 set v5 = "v5_400" where k1 = 100;
+select * from tab1 order by k1, k2;
+
+shell: curl --location-trusted -u root: -T ${root_path}/lib/../common/data/stream_load/sr_partial_update_1.csv -XPUT -H partial_update:true -H label:cwr_stream_load_partial_update1 -H column_separator:, -H columns:k1,k2,v4,v3 ${url}/api/test_column_with_row_partial_update/tab1/_stream_load
+shell: curl --location-trusted -u root: -T ${root_path}/lib/../common/data/stream_load/sr_partial_update_1.csv -XPUT -H partial_update:true -H partial_update_mode:row -H label:cwr_stream_load_partial_update2 -H column_separator:, -H columns:k1,k2,v4,v3 ${url}/api/test_column_with_row_partial_update/tab1/_stream_load
+select * from tab1 order by k1, k2;
+
+drop database test_column_with_row_partial_update force;

--- a/test/sql/test_column_with_row/T/test_column_with_row_variable
+++ b/test/sql/test_column_with_row/T/test_column_with_row_variable
@@ -1,36 +1,36 @@
+-- name: test_column_with_row_variable
 --创建行存表
-CREATE DATABASE IF NOT EXISTS demo;
-DROP TABLE IF EXISTS demo.t1_var;
-CREATE TABLE IF NOT EXISTS demo.t1_var(
-                                      k1 int,
-                                      k2 int,
-                                      v1 char(20),
-                                      v2 varchar(20),
+DROP TABLE IF EXISTS t1_var;
+CREATE TABLE IF NOT EXISTS t1_var(
+    k1 int,
+    k2 int,
+    v1 char(20),
+    v2 varchar(20),
     v3 DATE NOT NULL COMMENT "YYYY-MM-DD",
     v4 TINYINT COMMENT "range [-128, 127]"
-    )
-    PRIMARY KEY (k1, k2)
-    distributed by hash(k1, k2)
-    PROPERTIES (
-                   "replication_num" = "1",
-                   "storage_type" = "column_with_row"
-               );
+)
+PRIMARY KEY (k1, k2)
+distributed by hash(k1, k2)
+PROPERTIES (
+    "replication_num" = "1",
+    "storage_type" = "column_with_row"
+);
 
 --插入
-INSERT INTO demo.t1_var(k1, k2, v1, v2, v3, v4) VALUES
-                                            (1, 2, 'a2222222', 'a2222222', "2222-12-22", 33),
-                                            (1, 3, 'b2222222', 'b2222222', "2222-12-22", 34),
-                                            (1, 4, 'c2222222', 'c2222222', "2222-12-22", 35),
-                                            (2, 2, 'd2222222', 'd2222222', "2222-12-22", 36),
-                                            (2, 3, 'd2222222', 'd2222222', "2222-12-22", 37),
-                                            (3, 3, 'e2222222', 'e2222222', "2222-12-22", 100),
-                                            (4, 4, 'f2222222', 'f2222222', "2222-12-22", 101);
+INSERT INTO t1_var(k1, k2, v1, v2, v3, v4) VALUES
+    (1, 2, 'a2222222', 'a2222222', "2222-12-22", 33),
+    (1, 3, 'b2222222', 'b2222222', "2222-12-22", 34),
+    (1, 4, 'c2222222', 'c2222222', "2222-12-22", 35),
+    (2, 2, 'd2222222', 'd2222222', "2222-12-22", 36),
+    (2, 3, 'd2222222', 'd2222222', "2222-12-22", 37),
+    (3, 3, 'e2222222', 'e2222222', "2222-12-22", 100),
+    (4, 4, 'f2222222', 'f2222222', "2222-12-22", 101);
 --查询
 set enable_short_circuit = true;
-select length(v1), v1, v2, v3, v4 from demo.t1_var where k1 = 3 and k2 = 3;
-select * from demo.t1_var where k1 = 3 and k2 = 3;
+select length(v1), v1, v2, v3, v4 from t1_var where k1 = 3 and k2 = 3;
+select * from t1_var where k1 = 3 and k2 = 3;
 set enable_short_circuit = false;
 --清空
-TRUNCATE TABLE demo.t1_var;
+TRUNCATE TABLE t1_var;
 --drop表
-DROP TABLE demo.t1_var FORCE;
+DROP TABLE t1_var FORCE;


### PR DESCRIPTION
Why I'm doing:
After #39200, column with row table cannot do stream load if partial_upate_mode is not row.

What I'm doing:
Fix it by only rejecting partialupdate=true and partial_upate_mode is not row requests.

Fixes #38946

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
