### PR TITLE
[Enhancement] The decimal creation type is consistent with the display type (backport #38639)

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/ArrayType.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/ArrayType.java
@@ -56,12 +56,12 @@ public class ArrayType extends Type {
     @Override
     public String toSql(int depth) {
         if (depth >= MAX_NESTING_DEPTH) {
-            return "array<...>";
+            return "ARRAY<...>";
         }
         if (itemType.isDecimalOfAnyVersion()) {
-            return String.format("array<%s>", itemType);
+            return String.format("ARRAY<%s>", itemType);
         } else {
-            return String.format("array<%s>", itemType.toSql(depth + 1));
+            return String.format("ARRAY<%s>", itemType.toSql(depth + 1));
         }
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/ArrayType.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/ArrayType.java
@@ -56,9 +56,13 @@ public class ArrayType extends Type {
     @Override
     public String toSql(int depth) {
         if (depth >= MAX_NESTING_DEPTH) {
-            return "ARRAY<...>";
+            return "array<...>";
         }
-        return String.format("ARRAY<%s>", itemType.toSql(depth + 1));
+        if (itemType.isDecimalOfAnyVersion()) {
+            return String.format("array<%s>", itemType);
+        } else {
+            return String.format("array<%s>", itemType.toSql(depth + 1));
+        }
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/ScalarType.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/ScalarType.java
@@ -553,13 +553,10 @@ public class ScalarType extends Type implements Cloneable {
                 }
                 break;
             case DECIMALV2:
-                stringBuilder.append("decimal").append("(").append(precision).append(", ").append(scale).append(")");
-                break;
             case DECIMAL32:
             case DECIMAL64:
             case DECIMAL128:
-                stringBuilder.append(type.toString().toLowerCase()).append("(").append(precision).append(", ")
-                        .append(scale).append(")");
+                stringBuilder.append("decimal").append("(").append(precision).append(", ").append(scale).append(")");
                 break;
             case BOOLEAN:
                 return "boolean";

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/scalar/CastOperator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/scalar/CastOperator.java
@@ -52,7 +52,11 @@ public class CastOperator extends CallOperator {
 
     @Override
     public String toString() {
-        return "cast(" + getChild(0).toString() + " as " + getType().toSql() + ")";
+        if (getType().isDecimalOfAnyVersion()) {
+            return "cast(" + getChild(0).toString() + " as " + getType() + ")";
+        } else {
+            return "cast(" + getChild(0).toString() + " as " + getType().toSql() + ")";
+        }
     }
 
     @Override

--- a/fe/fe-core/src/test/java/com/starrocks/catalog/CreateTableTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/CreateTableTest.java
@@ -544,7 +544,7 @@ public class CreateTableTest {
                 .getTable("aggregate_table_sum");
         String columns = table.getColumns().toString();
         System.out.println("columns = " + columns);
-        Assert.assertTrue(columns.contains("`sum_decimal` decimal128(38, 4) SUM"));
+        Assert.assertTrue(columns.contains("`sum_decimal` decimal(38, 4) SUM"));
         Assert.assertTrue(columns.contains("`sum_bigint` bigint(20) SUM "));
     }
 

--- a/fe/fe-core/src/test/java/com/starrocks/catalog/TypeTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/TypeTest.java
@@ -219,7 +219,7 @@ public class TypeTest {
         Object[][] testCases = new Object[][] {
                 {ScalarType.createType(PrimitiveType.BOOLEAN), "tinyint(1)"},
                 {ScalarType.createType(PrimitiveType.LARGEINT), "bigint(20) unsigned"},
-                {ScalarType.createDecimalV3NarrowestType(18, 4), "decimal64(18, 4)"},
+                {ScalarType.createDecimalV3NarrowestType(18, 4), "decimal(18, 4)"},
                 {new ArrayType(Type.INT), "array<int(11)>"},
                 {new MapType(Type.INT, Type.INT), "map<int(11),int(11)>"},
                 {new StructType(Lists.newArrayList(Type.INT)), "struct<int(11)>"},

--- a/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AST2StringBuilderTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AST2StringBuilderTest.java
@@ -127,7 +127,7 @@ public class AST2StringBuilderTest {
                 "@`var1` = cast (1 as tinyint(4))," +
                 "@`var2` = cast ('2020-01-01' as date)," +
                 "@`var3` = cast ('foo' as varchar)," +
-                "@`var4` = cast (1.23 as decimal32(3, 2))," +
+                "@`var4` = cast (1.23 as decimal(3, 2))," +
                 "@`select` = cast (7 as int(11))", AstToStringBuilder.toString(originStmt));
 
         statementBase = SqlParser.parse(

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/ArrayTypeTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/ArrayTypeTest.java
@@ -113,7 +113,7 @@ public class ArrayTypeTest extends PlanTestBase {
         plan = getFragmentPlan(sql);
         assertContains(plan, " array_concat(CAST(ARRAY<tinyint(4)>[1] AS ARRAY<VARCHAR>), " +
                 "CAST(ARRAY<tinyint(4)>[2] AS ARRAY<VARCHAR>), CAST(ARRAY<tinyint(4)>[1,2] AS ARRAY<VARCHAR>), " +
-                "ARRAY<varchar>['a'], ARRAY<varchar>['b'], CAST(ARRAY<decimal32(2, 1)>[1.1] AS ARRAY<VARCHAR>))");
+                "ARRAY<varchar>['a'], ARRAY<varchar>['b'], CAST(ARRAY<DECIMAL32(2,1)>[1.1] AS ARRAY<VARCHAR>))");
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/DecimalTypeTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/DecimalTypeTest.java
@@ -194,10 +194,10 @@ public class DecimalTypeTest extends PlanTestBase {
         try {
             String sql = "select array_agg(c_0_0) from tab0";
             String plan = getVerboseExplain(sql);
-            assertContains(plan, "array_agg[([16: array_agg, STRUCT<ARRAY<decimal128(26, 2)>>, true]); " +
+            assertContains(plan, "array_agg[([16: array_agg, STRUCT<ARRAY<DECIMAL128(26,2)>>, true]); " +
                     "args: DECIMAL128; result: ARRAY<DECIMAL128(26,2)>;");
             assertContains(plan, "array_agg[([1: c_0_0, DECIMAL128(26,2), false]); " +
-                    "args: DECIMAL128; result: STRUCT<ARRAY<decimal128(26, 2)>>;");
+                    "args: DECIMAL128; result: STRUCT<ARRAY<DECIMAL128(26,2)>>;");
         } finally {
             connectContext.getSessionVariable().setNewPlanerAggStage(stage);
         }

--- a/fe/fe-core/src/test/resources/sql/materialized-view/tpch-hive/q17.sql
+++ b/fe/fe-core/src/test/resources/sql/materialized-view/tpch-hive/q17.sql
@@ -20,7 +20,7 @@ where
 AGGREGATE ([GLOBAL] aggregate [{45: sum=sum(45: sum)}] group by [[]] having [null]
     EXCHANGE GATHER
         AGGREGATE ([LOCAL] aggregate [{45: sum=sum(6: l_extendedprice)}] group by [[]] having [null]
-            PREDICATE cast(5: l_quantity as decimal128(38, 9)) < multiply(0.2, 145: avg)
+            PREDICATE cast(5: l_quantity as DECIMAL128(38,9)) < multiply(0.2, 145: avg)
                 ANALYTIC ({145: avg=avg(5: l_quantity)} [17: p_partkey] [] )
                     TOP-N (order by [[17: p_partkey ASC NULLS FIRST]])
                         EXCHANGE SHUFFLE[17]

--- a/fe/fe-core/src/test/resources/sql/materialized-view/tpch-hive/q20.sql
+++ b/fe/fe-core/src/test/resources/sql/materialized-view/tpch-hive/q20.sql
@@ -41,7 +41,7 @@ TOP-N (order by [[2: s_name ASC NULLS FIRST]])
     TOP-N (order by [[2: s_name ASC NULLS FIRST]])
         RIGHT SEMI JOIN (join-predicate [13: ps_suppkey = 1: s_suppkey] post-join-predicate [null])
             EXCHANGE SHUFFLE[13]
-                INNER JOIN (join-predicate [12: ps_partkey = 28: l_partkey AND 13: ps_suppkey = 29: l_suppkey AND cast(14: ps_availqty as decimal128(38, 3)) > multiply(0.5, 43: sum)] post-join-predicate [null])
+                INNER JOIN (join-predicate [12: ps_partkey = 28: l_partkey AND 13: ps_suppkey = 29: l_suppkey AND cast(14: ps_availqty as DECIMAL128(38,3)) > multiply(0.5, 43: sum)] post-join-predicate [null])
                     LEFT SEMI JOIN (join-predicate [12: ps_partkey = 17: p_partkey] post-join-predicate [null])
                         EXCHANGE SHUFFLE[12]
                             SCAN (columns{12,13,14} predicate[13: ps_suppkey IS NOT NULL])

--- a/fe/fe-core/src/test/resources/sql/materialized-view/tpch-hive/q22.sql
+++ b/fe/fe-core/src/test/resources/sql/materialized-view/tpch-hive/q22.sql
@@ -46,7 +46,7 @@ TOP-N (order by [[29: substring ASC NULLS FIRST]])
                         EXCHANGE SHUFFLE[20]
                             SCAN (columns{20} predicate[null])
                         EXCHANGE SHUFFLE[1]
-                            INNER JOIN (join-predicate [cast(6: c_acctbal as decimal128(38, 8)) > 17: avg] post-join-predicate [null])
+                            INNER JOIN (join-predicate [cast(6: c_acctbal as DECIMAL128(38,8)) > 17: avg] post-join-predicate [null])
                                 SCAN (columns{1,5,6} predicate[substring(5: c_phone, 1, 2) IN (21, 28, 24, 32, 35, 34, 37)])
                                 EXCHANGE BROADCAST
                                     ASSERT LE 1

--- a/fe/fe-core/src/test/resources/sql/materialized-view/tpch/q17.sql
+++ b/fe/fe-core/src/test/resources/sql/materialized-view/tpch/q17.sql
@@ -21,7 +21,7 @@ where
 AGGREGATE ([GLOBAL] aggregate [{45: sum=sum(45: sum)}] group by [[]] having [null]
     EXCHANGE GATHER
         AGGREGATE ([LOCAL] aggregate [{45: sum=sum(7: l_extendedprice)}] group by [[]] having [null]
-            PREDICATE cast(6: l_quantity as decimal128(38, 9)) < multiply(0.2, 149: avg)
+            PREDICATE cast(6: l_quantity as DECIMAL128(38,9)) < multiply(0.2, 149: avg)
                 ANALYTIC ({149: avg=avg(6: l_quantity)} [17: p_partkey] [] )
                     TOP-N (order by [[17: p_partkey ASC NULLS FIRST]])
                         EXCHANGE SHUFFLE[17]

--- a/fe/fe-core/src/test/resources/sql/materialized-view/tpch/q20.sql
+++ b/fe/fe-core/src/test/resources/sql/materialized-view/tpch/q20.sql
@@ -45,7 +45,7 @@ TOP-N (order by [[2: s_name ASC NULLS FIRST]])
                 EXCHANGE BROADCAST
                     SCAN (table[nation] columns[8: n_nationkey, 9: n_name] predicate[9: n_name = ARGENTINA])
             EXCHANGE SHUFFLE[13]
-                INNER JOIN (join-predicate [12: ps_partkey = 30: l_partkey AND 13: ps_suppkey = 31: l_suppkey AND cast(14: ps_availqty as decimal128(38, 3)) > multiply(0.5, 43: sum)] post-join-predicate [null])
+                INNER JOIN (join-predicate [12: ps_partkey = 30: l_partkey AND 13: ps_suppkey = 31: l_suppkey AND cast(14: ps_availqty as DECIMAL128(38,3)) > multiply(0.5, 43: sum)] post-join-predicate [null])
                     LEFT SEMI JOIN (join-predicate [12: ps_partkey = 17: p_partkey] post-join-predicate [null])
                         SCAN (table[partsupp] columns[12: ps_partkey, 13: ps_suppkey, 14: ps_availqty] predicate[null])
                         EXCHANGE SHUFFLE[17]

--- a/fe/fe-core/src/test/resources/sql/materialized-view/tpch/q22.sql
+++ b/fe/fe-core/src/test/resources/sql/materialized-view/tpch/q22.sql
@@ -43,7 +43,7 @@ TOP-N (order by [[29: substring ASC NULLS FIRST]])
             EXCHANGE SHUFFLE[29]
                 AGGREGATE ([LOCAL] aggregate [{30: count=count(), 31: sum=sum(6: c_acctbal)}] group by [[29: substring]] having [null]
                     LEFT ANTI JOIN (join-predicate [1: c_custkey = 21: o_custkey] post-join-predicate [null])
-                        INNER JOIN (join-predicate [cast(6: c_acctbal as decimal128(38, 8)) > 17: avg] post-join-predicate [null])
+                        INNER JOIN (join-predicate [cast(6: c_acctbal as DECIMAL128(38,8)) > 17: avg] post-join-predicate [null])
                             SCAN (table[customer] columns[1: c_custkey, 5: c_phone, 6: c_acctbal] predicate[substring(5: c_phone, 1, 2) IN (21, 28, 24, 32, 35, 34, 37)])
                             EXCHANGE BROADCAST
                                 ASSERT LE 1

--- a/fe/fe-core/src/test/resources/sql/optimized-plan/constant-query.sql
+++ b/fe/fe-core/src/test/resources/sql/optimized-plan/constant-query.sql
@@ -27,7 +27,7 @@ RESULT SINK
 [sql]
 select * from t0 where v1 in (1.1, 2, null)
 [result]
-SCAN (columns[1: v1, 2: v2, 3: v3] predicate[cast(1: v1 as decimal128(20, 1)) IN (1.1, 2.0, null)])
+SCAN (columns[1: v1, 2: v2, 3: v3] predicate[cast(1: v1 as DECIMAL128(20,1)) IN (1.1, 2.0, null)])
 [end]
 
 [sql]


### PR DESCRIPTION
Why I'm doing:
When using the following statement to create a table
```
CREATE TABLE `testdecimal` (
  `obj_id` string NOT NULL COMMENT "",
  `lab_numr` decimal(38, 10) NULL COMMENT ""
) ENGINE=OLAP 
DUPLICATE KEY(`obj_id`)
COMMENT ""
DISTRIBUTED BY HASH(`obj_id`) BUCKETS 10 
PROPERTIES (
"replication_num" = "1",
"in_memory" = "false",
"storage_format" = "DEFAULT",
"enable_persistent_index" = "true"
);
```
Then after executing show create table
```
CREATE TABLE `testdecimal` (
  `obj_id` varchar(65533) NOT NULL COMMENT "客户ID",
  `lab_numr` decimal128(38, 10) NULL COMMENT "标签编号"
) ENGINE=OLAP 
DUPLICATE KEY(`obj_id`)
DISTRIBUTED BY HASH(`obj_id`) BUCKETS 10 
PROPERTIES (
"replication_num" = "1",
"in_memory" = "false",
"enable_persistent_index" = "true",
"replicated_storage" = "true",
"fast_schema_evolution" = "true",
"compression" = "LZ4"
);
```
decimal->decimal128
string->varchar(65533)

The decimal type is relatively stable now, so show create table should remain consistent, while string is just a syntactic sugar, so it should not be changed for the time being.

What I'm doing:
Keep the decimal the same as when created, and the string will not be modified.


## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [x] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5

