### PR TITLE
[Enhancement] Make primary key does not support concurrent key applying as vlog

### DIFF
--- a/be/src/service/service_be/lake_service.cpp
+++ b/be/src/service/service_be/lake_service.cpp
@@ -197,8 +197,13 @@ void LakeServiceImpl::publish_version(::google::protobuf::RpcController* control
                 response->mutable_compaction_scores()->insert({tablet_id, score});
             } else {
                 g_publish_version_failed_tasks << 1;
-                LOG(WARNING) << "Fail to publish version: " << res.status() << ". tablet_id=" << tablet_id
-                             << " txn_id=" << txns[0] << " version=" << new_version;
+                if (res.status().is_resource_busy()) {
+                    VLOG(2) << "Fail to publish version: " << res.status() << ". tablet_id=" << tablet_id
+                            << " txn_id=" << txns[0] << " version=" << new_version;
+                } else {
+                    LOG(WARNING) << "Fail to publish version: " << res.status() << ". tablet_id=" << tablet_id
+                                 << " txn_id=" << txns[0] << " version=" << new_version;
+                }
                 std::lock_guard l(response_mtx);
                 response->add_failed_tablets(tablet_id);
                 res.status().to_protobuf(response->mutable_status());

--- a/be/src/storage/lake/txn_log_applier.cpp
+++ b/be/src/storage/lake/txn_log_applier.cpp
@@ -63,7 +63,7 @@ public:
             _inited = true;
             return check_meta_version();
         } else {
-            return Status::InternalError("primary key does not support concurrent log applying");
+            return Status::ResourceBusy("primary key does not support concurrent log applying");
         }
     }
 


### PR DESCRIPTION
Why I'm doing:
If pk table publish slowly, log like `Fail to publish version: Internal error: primary key does not support concurrent log applying` will be printed. Some users think it is error, it is confused.
What I'm doing:
Use vlog for this log.
Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [x] 3.1
  - [ ] 3.0
  - [ ] 2.5
