### PR TITLE
[BugFix]Fix paimon timestamp bug

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/connector/ColumnTypeConverter.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/ColumnTypeConverter.java
@@ -46,6 +46,7 @@ import org.apache.paimon.types.DecimalType;
 import org.apache.paimon.types.DoubleType;
 import org.apache.paimon.types.FloatType;
 import org.apache.paimon.types.IntType;
+import org.apache.paimon.types.LocalZonedTimestampType;
 import org.apache.paimon.types.RowType;
 import org.apache.paimon.types.SmallIntType;
 import org.apache.paimon.types.TimestampType;
@@ -547,6 +548,10 @@ public class ColumnTypeConverter {
         }
 
         public Type visit(TimestampType timestampType) {
+            return ScalarType.createType(PrimitiveType.DATETIME);
+        }
+
+        public Type visit(LocalZonedTimestampType timestampType) {
             return ScalarType.createType(PrimitiveType.DATETIME);
         }
 

--- a/fe/fe-core/src/test/java/com/starrocks/connector/paimon/PaimonColumnConverterTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/paimon/PaimonColumnConverterTest.java
@@ -29,6 +29,7 @@ import org.apache.paimon.types.DecimalType;
 import org.apache.paimon.types.DoubleType;
 import org.apache.paimon.types.FloatType;
 import org.apache.paimon.types.IntType;
+import org.apache.paimon.types.LocalZonedTimestampType;
 import org.apache.paimon.types.MapType;
 import org.apache.paimon.types.RowType;
 import org.apache.paimon.types.SmallIntType;
@@ -143,6 +144,13 @@ public class PaimonColumnConverterTest {
     @Test
     public void testConvertDatetime() {
         TimestampType paimonType = new TimestampType();
+        Type result = ColumnTypeConverter.fromPaimonType(paimonType);
+        Assert.assertEquals(result, Type.DATETIME);
+    }
+
+    @Test
+    public void testConvertLocalZonedDatetime() {
+        LocalZonedTimestampType paimonType = new LocalZonedTimestampType();
         Type result = ColumnTypeConverter.fromPaimonType(paimonType);
         Assert.assertEquals(result, Type.DATETIME);
     }

--- a/java-extensions/paimon-reader/src/main/java/com/starrocks/paimon/reader/PaimonColumnValue.java
+++ b/java-extensions/paimon-reader/src/main/java/com/starrocks/paimon/reader/PaimonColumnValue.java
@@ -153,6 +153,13 @@ public class PaimonColumnValue implements ColumnValue {
 
     @Override
     public LocalDateTime getDateTime(ColumnType.TypeValue type) {
-        return LocalDateTime.ofInstant(((Timestamp) fieldData).toInstant(), ZoneId.of(timeZone));
+        switch (dataType.getTypeRoot()) {
+            case TIMESTAMP_WITHOUT_TIME_ZONE:
+                return ((Timestamp) fieldData).toLocalDateTime();
+            case TIMESTAMP_WITH_LOCAL_TIME_ZONE:
+                return LocalDateTime.ofInstant(((Timestamp) fieldData).toInstant(), ZoneId.of(timeZone));
+            default:
+                throw new UnsupportedOperationException("Unsupported type: " + type);
+        }
     }
 }

--- a/java-extensions/paimon-reader/src/main/java/com/starrocks/paimon/reader/PaimonTypeUtils.java
+++ b/java-extensions/paimon-reader/src/main/java/com/starrocks/paimon/reader/PaimonTypeUtils.java
@@ -26,6 +26,7 @@ import org.apache.paimon.types.DecimalType;
 import org.apache.paimon.types.DoubleType;
 import org.apache.paimon.types.FloatType;
 import org.apache.paimon.types.IntType;
+import org.apache.paimon.types.LocalZonedTimestampType;
 import org.apache.paimon.types.MapType;
 import org.apache.paimon.types.RowType;
 import org.apache.paimon.types.SmallIntType;
@@ -101,6 +102,10 @@ public class PaimonTypeUtils {
         }
 
         public String visit(TimestampType timestampType) {
+            return "timestamp-millis";
+        }
+
+        public String visit(LocalZonedTimestampType timestampType) {
             return "timestamp-millis";
         }
 


### PR DESCRIPTION
Why I'm doing:

> Paimon timestamp have TIME_WITHOUT_TIME_ZONE and TIMESTAMP_WITHOUT_TIME_ZONE.
> TIMESTAMP_WITHOUT_TIME_ZONE type will adjust with session timezone

ref:https://nightlies.apache.org/flink/flink-docs-release-1.17/docs/dev/table/timezone/
What I'm doing:

> 1.Modify paimon jni reader about timestamp to adjust with session timezone when paimon timestamp without timezone and 
      not adjust when paimon timestamp with timezone
> 2.Support paimon timestamp without timezone type
Fixes #38861
**The PR just solve orc native reader and jni reader keep same/correct result when timestap with timezone**
 

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
