### PR TITLE
[BugFix] Dictionary refresh maybe timeout if the dictionary object is huge (#39380)

### DIFF
--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -1173,7 +1173,7 @@ CONF_mInt64(lake_local_pk_index_unused_threshold_seconds, "86400"); // 1 day
 
 CONF_mBool(lake_enable_vertical_compaction_fill_data_cache, "false");
 
-CONF_Int32(dictionary_cache_refresh_timeout_ms, "60000"); // 1 min
-CONF_Int32(dictionary_cache_refresh_threadpool_size, "8");
+CONF_mInt32(dictionary_cache_refresh_timeout_ms, "60000"); // 1 min
+CONF_mInt32(dictionary_cache_refresh_threadpool_size, "8");
 
 } // namespace starrocks::config

--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -1173,4 +1173,7 @@ CONF_mInt64(lake_local_pk_index_unused_threshold_seconds, "86400"); // 1 day
 
 CONF_mBool(lake_enable_vertical_compaction_fill_data_cache, "false");
 
+CONF_Int32(dictionary_cache_refresh_timeout_ms, "60000"); // 1 min
+CONF_Int32(dictionary_cache_refresh_threadpool_size, "8");
+
 } // namespace starrocks::config

--- a/be/src/exec/dictionary_cache_writer.cpp
+++ b/be/src/exec/dictionary_cache_writer.cpp
@@ -170,7 +170,7 @@ Status DictionaryCacheWriter::_send_request(ChunkPB* pchunk, POlapTableSchemaPar
 
         auto& closure = closures[i];
         closure->ref();
-        closure->cntl.set_timeout_ms(60000);
+        closure->cntl.set_timeout_ms(config::dictionary_cache_refresh_timeout_ms);
         closure->cntl.ignore_eovercrowded();
 
         auto res = HttpBrpcStubCache::getInstance()->get_http_stub(nodes[i]);

--- a/be/src/exec/dictionary_cache_writer.h
+++ b/be/src/exec/dictionary_cache_writer.h
@@ -76,9 +76,10 @@ private:
     ChunkUniquePtr _buffer_chunk = nullptr;
     ChunkUniquePtr _immutable_buffer_chunk = nullptr;
 
-    static const long kChunkBufferLimit = 256 * 1024 * 1024; // 256MB
+    // control max size of chunk whether we should begin a refresh task
+    static const long kChunkBufferLimit = 16 * 1024 * 1024; // 16MB
     // control max memory useage in current writer
-    static const long kMaxMemoryUsageLimit = 2147483648; // 2GB
+    static const long kMaxMemoryUsageLimit = 256 * 1024 * 1024; // 256MB
 
     RuntimeState* _state = nullptr;
     starrocks::pipeline::FragmentContext* _fragment_ctx;

--- a/be/src/http/action/update_config_action.cpp
+++ b/be/src/http/action/update_config_action.cpp
@@ -130,6 +130,12 @@ Status UpdateConfigAction::update_config(const std::string& name, const std::str
                     config::update_memory_limit_percent);
 #endif
         });
+        _config_callback.emplace("dictionary_cache_refresh_threadpool_size", [&]() {
+            if (_exec_env->dictionary_cache_pool() != nullptr) {
+                (void)_exec_env->dictionary_cache_pool()->update_max_threads(
+                        config::dictionary_cache_refresh_threadpool_size);
+            }
+        });
         _config_callback.emplace("transaction_publish_version_worker_count", [&]() {
             auto thread_pool = ExecEnv::GetInstance()->agent_server()->get_thread_pool(TTaskType::PUBLISH_VERSION);
             (void)thread_pool->update_max_threads(

--- a/be/src/runtime/exec_env.cpp
+++ b/be/src/runtime/exec_env.cpp
@@ -382,8 +382,8 @@ Status ExecEnv::init(const std::vector<StorePath>& store_paths, bool as_cn) {
 
     RETURN_IF_ERROR(ThreadPoolBuilder("dictionary_cache") // thread pool for dictionary cache Sink
                             .set_min_threads(1)
-                            .set_max_threads(8)
-                            .set_max_queue_size(1000)
+                            .set_max_threads(config::dictionary_cache_refresh_threadpool_size)
+                            .set_max_queue_size(INT32_MAX) // unlimit queue size
                             .set_idle_timeout(MonoDelta::FromMilliseconds(2000))
                             .build(&_dictionary_cache_pool));
 


### PR DESCRIPTION
Why I'm doing:
If we refresh a dictionary cache using a huge dictionary table, refresh timeout may happen. The problem is that, we refresh 256MB chunk for a single chunk in a single refresh task. Each refresh task is executed concurrently. Since this chunk is relatively large, the respond time of a certain task's rpc request may be too long and cause a timeout.

What I'm doing:
1. Make refresh cache rpc timeout configable.
2. Make chunk smaller when it used for refresh task. Helps reduce rpc response time.
3. Make the refresh task thread pool size configable. By controlling concurrency, speed and task pressure can be balanced.
4. Unlimit the queue size of task thread pool. Because tasks are divided into smaller pieces, the number of tasks may increase.

Fixes #39380

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
