### PR TITLE
[UT] drop mv after test done to avoid unexpected mv refresh activity

### DIFF
--- a/fe/fe-core/src/test/java/com/starrocks/server/LocalMetaStoreTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/server/LocalMetaStoreTest.java
@@ -141,6 +141,8 @@ public class LocalMetaStoreTest {
 
         LocalMetastore localMetastore = connectContext.getGlobalStateMgr().getLocalMetastore();
         localMetastore.getPartitionIdToStorageMediumMap();
+        // Clean test.mv1, avoid its refreshment affecting other cases in this testsuite.
+        starRocksAssert.dropMaterializedView("test.mv1");
     }
 
     @Test


### PR DESCRIPTION
Why I'm doing:

What I'm doing:

Fixes #issue

`com.starrocks.server.LocalMetaStoreTest.testCreateTableIfNotExists` is affected by the mv refresh job. Fix it by clean the mv after its test done.

```
Missing 1 invocation to:
com.starrocks.server.LocalMetastore#getDb(10004L)
   on mock instance: com.starrocks.server.LocalMetastore@62a83d4b
Caused by: Missing invocations
    at com.starrocks.server.LocalMetastore.getDb(LocalMetastore.java)
    at com.starrocks.server.GlobalStateMgr.getDb(GlobalStateMgr.java:2798)
    at com.starrocks.catalog.BaseTableInfo.getDb(BaseTableInfo.java:211)
    at com.starrocks.scheduler.PartitionBasedMvRefreshProcessor.refreshExternalTable(PartitionBasedMvRefreshProcessor.java:622)
    at com.starrocks.scheduler.PartitionBasedMvRefreshProcessor.doMvRefresh(PartitionBasedMvRefreshProcessor.java:238)
    at com.starrocks.scheduler.PartitionBasedMvRefreshProcessor.processTaskRun(PartitionBasedMvRefreshProcessor.java:210)
    at com.starrocks.scheduler.TaskRun.executeTaskRun(TaskRun.java:233)
    at com.starrocks.scheduler.TaskRunExecutor.lambda$executeTaskRun$0(TaskRunExecutor.java:52)
    at java.base/java.lang.Thread.run(Thread.java:829)
```

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [X] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [X] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [X] I have checked the version labels which the pr will be auto-backported to the target branch
  - [X] 3.2
  - [X] 3.1
  - [ ] 3.0
  - [ ] 2.5
