### PR TITLE
[Enhancement] implement table-based TaskRunHistory

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/alter/OptimizeJobV2.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/OptimizeJobV2.java
@@ -51,6 +51,7 @@ import com.starrocks.scheduler.persist.TaskRunStatus;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.sql.ast.OptimizeClause;
 import io.opentelemetry.api.trace.StatusCode;
+import org.apache.commons.collections.CollectionUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -345,14 +346,14 @@ public class OptimizeJobV2 extends AlterJobV2 implements GsonPostProcessable {
                 allFinished = false;
                 continue;
             }
-            TaskRunStatus status = GlobalStateMgr.getCurrentState().getTaskManager()
+            List<TaskRunStatus> status = GlobalStateMgr.getCurrentState().getTaskManager()
                     .getTaskRunManager().getTaskRunHistory().getTaskByName(rewriteTask.getName());
-            if (status == null) {
+            if (CollectionUtils.isEmpty(status)) {
                 allFinished = false;
                 continue;
             }
 
-            if (status.getState() == Constants.TaskRunState.FAILED) {
+            if (status.get(0).getState() == Constants.TaskRunState.FAILED) {
                 LOG.warn("optimize task {} failed", rewriteTask.getName());
                 rewriteTask.setOptimizeTaskState(Constants.TaskRunState.FAILED);
             }

--- a/fe/fe-core/src/main/java/com/starrocks/common/Config.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/Config.java
@@ -338,6 +338,9 @@ public class Config extends ConfigBase {
     @ConfField(mutable = true)
     public static int history_job_keep_max_second = 7 * 24 * 3600; // 7 days
 
+    @ConfField(mutable = true, comment = "Interval of TableKeeper daemon")
+    public static int table_keeper_interval_second = 30;
+
     /**
      * the transaction will be cleaned after transaction_clean_interval_second seconds if the transaction is visible or aborted
      * we should make this interval as short as possible and each clean cycle as soon as possible

--- a/fe/fe-core/src/main/java/com/starrocks/common/Config.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/Config.java
@@ -1088,6 +1088,9 @@ public class Config extends ConfigBase {
     @ConfField
     public static int max_task_runs_threads_num = 512;
 
+    @ConfField(mutable = true, comment = "Use the table-based task-run-history storage")
+    public static boolean use_table_based_task_run_history = false;
+
     /**
      * Default timeout of export jobs.
      */

--- a/fe/fe-core/src/main/java/com/starrocks/load/pipe/Pipe.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/pipe/Pipe.java
@@ -477,9 +477,9 @@ public class Pipe implements GsonPostProcessable {
             Constants.TaskRunState taskRunState = taskDesc.getFuture().get();
             if (taskRunState == Constants.TaskRunState.FAILED) {
                 TaskManager tm = GlobalStateMgr.getCurrentState().getTaskManager();
-                TaskRunStatus status = tm.getTaskRunHistory().getTaskByName(taskDesc.getUniqueTaskName());
-                if (status != null) {
-                    throw new DmlException("execution failed: " + status.getErrorMessage());
+                List<TaskRunStatus> status = tm.getTaskRunHistory().getTaskByName(taskDesc.getUniqueTaskName());
+                if (CollectionUtils.isNotEmpty(status)) {
+                    throw new DmlException("execution failed: " + status.get(0).getErrorMessage());
                 } else {
                     throw new DmlException("task failed with unknown status");
                 }

--- a/fe/fe-core/src/main/java/com/starrocks/load/pipe/filelist/RepoExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/pipe/filelist/RepoExecutor.java
@@ -82,7 +82,6 @@ public class RepoExecutor {
         try {
             ConnectContext context = createConnectContext();
 
-            // TODO: use json sink protocol, instead of statistic protocol
             StatementBase parsedStmt = SqlParser.parseOneWithStarRocksDialect(sql, context.getSessionVariable());
             ExecPlan execPlan = StatementPlanner.plan(parsedStmt, context, TResultSinkType.HTTP_PROTOCAL);
             StmtExecutor executor = new StmtExecutor(context, parsedStmt);
@@ -96,7 +95,7 @@ public class RepoExecutor {
             }
             return sqlResult.first;
         } catch (Exception e) {
-            LOG.error("Repo execute SQL failed {}", sql, e);
+            LOG.error("RepoExecutor execute SQL failed {}", sql, e);
             throw new SemanticException("execute sql failed: " + sql, e);
         } finally {
             ConnectContext.remove();
@@ -112,7 +111,7 @@ public class RepoExecutor {
             AuditLog.getInternalAudit().info("RepoExecutor execute DDL | SQL {}", sql);
             DDLStmtExecutor.execute(parsedStmt, context);
         } catch (Exception e) {
-            LOG.error("execute DDL error: {}", sql, e);
+            LOG.error("RepoExecutor execute DDL error: {}", sql, e);
             throw new RuntimeException(e);
         } finally {
             ConnectContext.remove();

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/TaskManager.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/TaskManager.java
@@ -41,7 +41,7 @@ import com.starrocks.persist.metablock.SRMetaBlockWriter;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.qe.ShowResultSet;
 import com.starrocks.qe.ShowResultSetMetaData;
-import com.starrocks.scheduler.history.MemBasedTaskRunHistory;
+import com.starrocks.scheduler.history.TaskRunHistory;
 import com.starrocks.scheduler.persist.TaskRunStatus;
 import com.starrocks.scheduler.persist.TaskRunStatusChange;
 import com.starrocks.scheduler.persist.TaskSchedule;
@@ -517,7 +517,7 @@ public class TaskManager implements MemoryTrackable {
         return taskRunManager;
     }
 
-    public MemBasedTaskRunHistory getTaskRunHistory() {
+    public TaskRunHistory getTaskRunHistory() {
         return taskRunManager.getTaskRunHistory();
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/TaskManager.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/TaskManager.java
@@ -893,8 +893,7 @@ public class TaskManager implements MemoryTrackable {
             return;
         }
         try {
-            List<String> historyToDelete = taskRunManager.getTaskRunHistory().gc();
-            LOG.info("remove run history:{}", historyToDelete);
+            taskRunManager.getTaskRunHistory().gc();
         } finally {
             taskRunManager.taskRunUnlock();
         }

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/TaskManager.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/TaskManager.java
@@ -183,10 +183,8 @@ public class TaskManager implements MemoryTrackable {
                     taskRun.getStatus().setErrorMessage("Fe abort the task");
                     taskRun.getStatus().setErrorCode(-1);
                     taskRun.getStatus().setState(Constants.TaskRunState.FAILED);
-                    taskRunManager.getTaskRunHistory().addHistory(taskRun.getStatus());
-                    TaskRunStatusChange statusChange = new TaskRunStatusChange(taskRun.getTaskId(), taskRun.getStatus(),
-                            Constants.TaskRunState.PENDING, Constants.TaskRunState.FAILED);
-                    GlobalStateMgr.getCurrentState().getEditLog().logUpdateTaskRun(statusChange);
+                    taskRunManager.addTaskRunHistory(taskRun, Constants.TaskRunState.PENDING,
+                            Constants.TaskRunState.FAILED);
                 }
                 pendingIter.remove();
             }
@@ -198,10 +196,8 @@ public class TaskManager implements MemoryTrackable {
                 taskRun.getStatus().setState(Constants.TaskRunState.FAILED);
                 taskRun.getStatus().setFinishTime(System.currentTimeMillis());
                 runningIter.remove();
-                taskRunManager.getTaskRunHistory().addHistory(taskRun.getStatus());
-                TaskRunStatusChange statusChange = new TaskRunStatusChange(taskRun.getTaskId(), taskRun.getStatus(),
-                        Constants.TaskRunState.RUNNING, Constants.TaskRunState.FAILED);
-                GlobalStateMgr.getCurrentState().getEditLog().logUpdateTaskRun(statusChange);
+                taskRunManager.addTaskRunHistory(taskRun, Constants.TaskRunState.RUNNING,
+                        Constants.TaskRunState.FAILED);
             }
         } finally {
             taskRunManager.taskRunUnlock();
@@ -736,14 +732,14 @@ public class TaskManager implements MemoryTrackable {
             // this will happen in build image
             case RUNNING:
                 status.setState(Constants.TaskRunState.FAILED);
-                taskRunManager.getTaskRunHistory().addHistory(status);
+                taskRunManager.getTaskRunHistory().addHistory(status, true);
                 break;
             case FAILED:
-                taskRunManager.getTaskRunHistory().addHistory(status);
+                taskRunManager.getTaskRunHistory().addHistory(status, true);
                 break;
             case SUCCESS:
                 status.setProgress(100);
-                taskRunManager.getTaskRunHistory().addHistory(status);
+                taskRunManager.getTaskRunHistory().addHistory(status, true);
                 break;
         }
     }
@@ -794,7 +790,7 @@ public class TaskManager implements MemoryTrackable {
                 status.setErrorMessage(statusChange.getErrorMessage());
                 status.setErrorCode(statusChange.getErrorCode());
                 status.setState(Constants.TaskRunState.FAILED);
-                taskRunManager.getTaskRunHistory().addHistory(status);
+                taskRunManager.getTaskRunHistory().addHistory(status, true);
             }
             if (taskRunQueue.size() == 0) {
                 taskRunManager.getPendingTaskRunMap().remove(taskId);
@@ -816,7 +812,7 @@ public class TaskManager implements MemoryTrackable {
                     status.setProgress(100);
                     status.setFinishTime(statusChange.getFinishTime());
                     status.setExtraMessage(statusChange.getExtraMessage());
-                    taskRunManager.getTaskRunHistory().addHistory(status);
+                    taskRunManager.getTaskRunHistory().addHistory(status, true);
                 }
             } else {
                 // Find the task status from history map.

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/TaskRun.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/TaskRun.java
@@ -301,6 +301,7 @@ public class TaskRun implements Comparable<TaskRun> {
 
     public TaskRunStatus initStatus(String queryId, Long createTime) {
         TaskRunStatus status = new TaskRunStatus();
+        status.setUseTableBasedHistory(Config.use_table_based_task_run_history);
         status.setQueryId(queryId);
         status.setTaskId(task.getId());
         status.setTaskName(task.getName());

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/TaskRunManager.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/TaskRunManager.java
@@ -27,6 +27,7 @@ import com.starrocks.memory.MemoryTrackable;
 import com.starrocks.persist.gson.GsonUtils;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.scheduler.history.MemBasedTaskRunHistory;
+import com.starrocks.scheduler.history.MergedTaskRunHistory;
 import com.starrocks.scheduler.history.TableBasedTaskRunHistory;
 import com.starrocks.scheduler.history.TaskRunHistory;
 import com.starrocks.scheduler.persist.TaskRunStatus;
@@ -57,8 +58,8 @@ public class TaskRunManager implements MemoryTrackable {
 
     // include SUCCESS/FAILED/CANCEL taskRun
     @Deprecated
-    private final TaskRunHistory memBasedTaskRunHistory = new MemBasedTaskRunHistory();
-    private final TaskRunHistory tableBasedTaskRunHistory = new TableBasedTaskRunHistory();
+    private final MemBasedTaskRunHistory memBasedTaskRunHistory = new MemBasedTaskRunHistory();
+    private final TableBasedTaskRunHistory tableBasedTaskRunHistory = new TableBasedTaskRunHistory();
 
     // Use to execute actual TaskRun
     private final TaskRunExecutor taskRunExecutor = new TaskRunExecutor();
@@ -292,12 +293,10 @@ public class TaskRunManager implements MemoryTrackable {
         return runningTaskRunMap;
     }
 
-    public boolean useTableBasedTaskRunHistory() {
-        return Config.use_table_based_task_run_history;
-    }
-
     public TaskRunHistory getTaskRunHistory() {
-        return Config.use_table_based_task_run_history ? tableBasedTaskRunHistory : memBasedTaskRunHistory;
+        return Config.use_table_based_task_run_history ?
+                new MergedTaskRunHistory(memBasedTaskRunHistory, tableBasedTaskRunHistory) :
+                memBasedTaskRunHistory;
     }
 
     public void addTaskRunHistory(TaskRun taskRun, Constants.TaskRunState fromState, Constants.TaskRunState toState) {

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/TaskRunManager.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/TaskRunManager.java
@@ -26,6 +26,7 @@ import com.starrocks.common.util.concurrent.QueryableReentrantLock;
 import com.starrocks.memory.MemoryTrackable;
 import com.starrocks.persist.gson.GsonUtils;
 import com.starrocks.qe.ConnectContext;
+import com.starrocks.scheduler.history.MemBasedTaskRunHistory;
 import com.starrocks.scheduler.persist.TaskRunStatus;
 import com.starrocks.scheduler.persist.TaskRunStatusChange;
 import com.starrocks.server.GlobalStateMgr;
@@ -53,7 +54,7 @@ public class TaskRunManager implements MemoryTrackable {
     private final Map<Long, TaskRun> runningTaskRunMap = Maps.newConcurrentMap();
 
     // include SUCCESS/FAILED/CANCEL taskRun
-    private final TaskRunHistory taskRunHistory = new TaskRunHistory();
+    private final MemBasedTaskRunHistory taskRunHistory = new MemBasedTaskRunHistory();
 
     // Use to execute actual TaskRun
     private final TaskRunExecutor taskRunExecutor = new TaskRunExecutor();
@@ -287,7 +288,7 @@ public class TaskRunManager implements MemoryTrackable {
         return runningTaskRunMap;
     }
 
-    public TaskRunHistory getTaskRunHistory() {
+    public MemBasedTaskRunHistory getTaskRunHistory() {
         return taskRunHistory;
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/TaskRunManager.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/TaskRunManager.java
@@ -336,7 +336,7 @@ public class TaskRunManager implements MemoryTrackable {
 
         return ImmutableMap.of("PendingTaskRun", validPendingCount,
                 "RunningTaskRun", (long) runningTaskRunMap.size(),
-                "HistoryTaskRun", taskRunHistory.getTaskRunCount());
+                "HistoryTaskRun", getTaskRunHistory().getTaskRunCount());
     }
   
     /**

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/TaskRunManager.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/TaskRunManager.java
@@ -201,7 +201,7 @@ public class TaskRunManager implements MemoryTrackable {
             if (future.isDone()) {
                 runningIterator.remove();
                 LOG.info("Task run is done from state RUNNING to {}, {}", taskRun.getStatus().getState(), taskRun);
-                getTaskRunHistory().addHistory(taskRun.getStatus());
+                getTaskRunHistory().addHistory(taskRun.getStatus(), false);
                 TaskRunStatusChange statusChange = new TaskRunStatusChange(taskRun.getTaskId(), taskRun.getStatus(),
                         Constants.TaskRunState.RUNNING, taskRun.getStatus().getState());
                 GlobalStateMgr.getCurrentState().getEditLog().logUpdateTaskRun(statusChange);
@@ -292,8 +292,19 @@ public class TaskRunManager implements MemoryTrackable {
         return runningTaskRunMap;
     }
 
+    public boolean useTableBasedTaskRunHistory() {
+        return Config.use_table_based_task_run_history;
+    }
+
     public TaskRunHistory getTaskRunHistory() {
         return Config.use_table_based_task_run_history ? tableBasedTaskRunHistory : memBasedTaskRunHistory;
+    }
+
+    public void addTaskRunHistory(TaskRun taskRun, Constants.TaskRunState fromState, Constants.TaskRunState toState) {
+        getTaskRunHistory().addHistory(taskRun.getStatus(), false);
+        TaskRunStatusChange statusChange =
+                new TaskRunStatusChange(taskRun.getTaskId(), taskRun.getStatus(), fromState, toState);
+        GlobalStateMgr.getCurrentState().getEditLog().logUpdateTaskRun(statusChange);
     }
 
     public long getPendingTaskRunCount() {

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/history/ITaskRunHistory.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/history/ITaskRunHistory.java
@@ -1,0 +1,40 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.scheduler.history;
+
+import com.starrocks.scheduler.persist.TaskRunStatus;
+
+import java.util.List;
+
+/**
+ * Record the history of all task-runs
+ */
+public interface ITaskRunHistory {
+
+    void addHistory(TaskRunStatus status);
+
+    List<TaskRunStatus> getTaskByName(String taskName);
+
+    TaskRunStatus getTask(String queryId);
+
+    /**
+     * @return removed TaskRunId in the history
+     */
+    List<String> gc();
+
+    List<TaskRunStatus> getAllHistory();
+
+    long getTaskRunCount();
+}

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/history/MemBasedTaskRunHistory.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/history/MemBasedTaskRunHistory.java
@@ -18,6 +18,7 @@ import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.starrocks.common.Config;
 import com.starrocks.scheduler.persist.TaskRunStatus;
+import com.starrocks.scheduler.persist.TaskRunStatusChange;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -50,11 +51,11 @@ public class MemBasedTaskRunHistory implements TaskRunHistory {
     }
 
     @Override
-    public TaskRunStatus getTask(String queryId) {
-        if (queryId == null) {
-            return null;
+    public void replayTaskRunChange(String queryId, TaskRunStatusChange change) {
+        TaskRunStatus run = historyTaskRunMap.get(queryId);
+        if (run != null) {
+            run.setExtraMessage(change.getExtraMessage());
         }
-        return historyTaskRunMap.get(queryId);
     }
 
     private void removeTask(String queryId) {
@@ -68,9 +69,9 @@ public class MemBasedTaskRunHistory implements TaskRunHistory {
     // Reserve historyTaskRunMap values to keep the last insert at the first.
     @Override
     public List<TaskRunStatus> getAllHistory() {
-        List<TaskRunStatus> historyRunStatus =
-                new ArrayList<>(historyTaskRunMap.values());
+        List<TaskRunStatus> historyRunStatus = new ArrayList<>(historyTaskRunMap.values());
         Collections.reverse(historyRunStatus);
+        historyRunStatus.forEach(x -> x.setUseTableBasedHistory(false));
         return historyRunStatus;
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/history/MemBasedTaskRunHistory.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/history/MemBasedTaskRunHistory.java
@@ -25,7 +25,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 
-public class MemBasedTaskRunHistory implements ITaskRunHistory {
+public class MemBasedTaskRunHistory implements TaskRunHistory {
     // Thread-Safe history map: QueryId -> TaskRunStatus
     // The same task-id may contain multi history task run status, so use query_id instead.
     private final Map<String, TaskRunStatus> historyTaskRunMap =
@@ -69,6 +69,7 @@ public class MemBasedTaskRunHistory implements ITaskRunHistory {
         return historyRunStatus;
     }
 
+    @Override
     public void forceGC() {
         List<TaskRunStatus> allHistory = getAllHistory();
         int startIndex = Math.min(allHistory.size(), Config.task_runs_max_history_number);

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/history/MemBasedTaskRunHistory.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/history/MemBasedTaskRunHistory.java
@@ -39,7 +39,7 @@ public class MemBasedTaskRunHistory implements TaskRunHistory {
             Collections.synchronizedMap(Maps.newLinkedHashMap());
 
     @Override
-    public void addHistory(TaskRunStatus status) {
+    public void addHistory(TaskRunStatus status, boolean isReplay) {
         historyTaskRunMap.put(status.getQueryId(), status);
         taskName2Status.put(status.getTaskName(), status);
     }

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/history/MemBasedTaskRunHistory.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/history/MemBasedTaskRunHistory.java
@@ -12,19 +12,20 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+package com.starrocks.scheduler.history;
 
-package com.starrocks.scheduler;
-
+import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.starrocks.common.Config;
 import com.starrocks.scheduler.persist.TaskRunStatus;
 
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 
-public class TaskRunHistory {
+public class MemBasedTaskRunHistory implements ITaskRunHistory {
     // Thread-Safe history map: QueryId -> TaskRunStatus
     // The same task-id may contain multi history task run status, so use query_id instead.
     private final Map<String, TaskRunStatus> historyTaskRunMap =
@@ -32,15 +33,18 @@ public class TaskRunHistory {
     private final Map<String, TaskRunStatus> taskName2Status =
             Collections.synchronizedMap(Maps.newLinkedHashMap());
 
+    @Override
     public void addHistory(TaskRunStatus status) {
         historyTaskRunMap.put(status.getQueryId(), status);
         taskName2Status.put(status.getTaskName(), status);
     }
 
-    public TaskRunStatus getTaskByName(String taskName) {
-        return taskName2Status.get(taskName);
+    @Override
+    public List<TaskRunStatus> getTaskByName(String taskName) {
+        return Lists.newArrayList(taskName2Status.get(taskName));
     }
 
+    @Override
     public TaskRunStatus getTask(String queryId) {
         if (queryId == null) {
             return null;
@@ -48,7 +52,7 @@ public class TaskRunHistory {
         return historyTaskRunMap.get(queryId);
     }
 
-    public void removeTask(String queryId) {
+    private void removeTask(String queryId) {
         if (queryId == null) {
             return;
         }
@@ -57,6 +61,7 @@ public class TaskRunHistory {
     }
 
     // Reserve historyTaskRunMap values to keep the last insert at the first.
+    @Override
     public List<TaskRunStatus> getAllHistory() {
         List<TaskRunStatus> historyRunStatus =
                 new ArrayList<>(historyTaskRunMap.values());
@@ -71,6 +76,26 @@ public class TaskRunHistory {
                 .forEach(taskRunStatus -> removeTask(taskRunStatus.getQueryId()));
     }
 
+    @Override
+    public List<String> gc() {
+        // only SUCCESS and FAILED in taskRunHistory
+        long currentTimeMs = System.currentTimeMillis();
+        List<TaskRunStatus> taskRunHistory = getAllHistory();
+        Iterator<TaskRunStatus> iterator = taskRunHistory.iterator();
+        List<String> historyToDelete = Lists.newArrayList();
+        while (iterator.hasNext()) {
+            TaskRunStatus taskRunStatus = iterator.next();
+            long expireTime = taskRunStatus.getExpireTime();
+            if (currentTimeMs > expireTime) {
+                historyToDelete.add(taskRunStatus.getQueryId());
+                removeTask(taskRunStatus.getQueryId());
+                iterator.remove();
+            }
+        }
+        return historyToDelete;
+    }
+
+    @Override
     public long getTaskRunCount() {
         return historyTaskRunMap.size();
     }

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/history/MemBasedTaskRunHistory.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/history/MemBasedTaskRunHistory.java
@@ -18,6 +18,8 @@ import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.starrocks.common.Config;
 import com.starrocks.scheduler.persist.TaskRunStatus;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -26,6 +28,9 @@ import java.util.List;
 import java.util.Map;
 
 public class MemBasedTaskRunHistory implements TaskRunHistory {
+
+    private static final Logger LOG = LogManager.getLogger(MemBasedTaskRunHistory.class);
+
     // Thread-Safe history map: QueryId -> TaskRunStatus
     // The same task-id may contain multi history task run status, so use query_id instead.
     private final Map<String, TaskRunStatus> historyTaskRunMap =
@@ -78,7 +83,7 @@ public class MemBasedTaskRunHistory implements TaskRunHistory {
     }
 
     @Override
-    public List<String> gc() {
+    public void gc() {
         // only SUCCESS and FAILED in taskRunHistory
         long currentTimeMs = System.currentTimeMillis();
         List<TaskRunStatus> taskRunHistory = getAllHistory();
@@ -93,7 +98,7 @@ public class MemBasedTaskRunHistory implements TaskRunHistory {
                 iterator.remove();
             }
         }
-        return historyToDelete;
+        LOG.info("[GC] remove run history:{}", historyToDelete);
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/history/MergedTaskRunHistory.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/history/MergedTaskRunHistory.java
@@ -1,0 +1,80 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.scheduler.history;
+
+import com.starrocks.common.Config;
+import com.starrocks.scheduler.persist.TaskRunStatus;
+import org.apache.commons.collections.ListUtils;
+
+import java.util.List;
+
+/**
+ * Merge MemBased and TableBased to make it backward compatible
+ */
+public class MergedTaskRunHistory implements TaskRunHistory {
+
+    private final MemBasedTaskRunHistory mem;
+    private final TableBasedTaskRunHistory table;
+
+    public MergedTaskRunHistory(MemBasedTaskRunHistory mem, TableBasedTaskRunHistory table) {
+        this.mem = mem;
+        this.table = table;
+    }
+
+    @Override
+    public void addHistory(TaskRunStatus status, boolean isReplay) {
+        if (Config.use_table_based_task_run_history) {
+            table.addHistory(status, isReplay);
+        } else {
+            mem.addHistory(status, isReplay);
+        }
+    }
+
+    @Override
+    public List<TaskRunStatus> getTaskByName(String taskName) {
+        return ListUtils.union(table.getTaskByName(taskName), mem.getTaskByName(taskName));
+    }
+
+    @Override
+    public TaskRunStatus getTask(String queryId) {
+        TaskRunStatus res = table.getTask(queryId);
+        if (res != null) {
+            return res;
+        }
+        return mem.getTask(queryId);
+    }
+
+    @Override
+    public void gc() {
+        mem.gc();
+        table.gc();
+    }
+
+    @Override
+    public void forceGC() {
+        mem.gc();
+        table.forceGC();
+    }
+
+    @Override
+    public List<TaskRunStatus> getAllHistory() {
+        return ListUtils.union(mem.getAllHistory(), table.getAllHistory());
+    }
+
+    @Override
+    public long getTaskRunCount() {
+        return mem.getTaskRunCount() + table.getTaskRunCount();
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/history/MergedTaskRunHistory.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/history/MergedTaskRunHistory.java
@@ -14,8 +14,8 @@
 
 package com.starrocks.scheduler.history;
 
-import com.starrocks.common.Config;
 import com.starrocks.scheduler.persist.TaskRunStatus;
+import com.starrocks.scheduler.persist.TaskRunStatusChange;
 import org.apache.commons.collections.ListUtils;
 
 import java.util.List;
@@ -35,7 +35,7 @@ public class MergedTaskRunHistory implements TaskRunHistory {
 
     @Override
     public void addHistory(TaskRunStatus status, boolean isReplay) {
-        if (Config.use_table_based_task_run_history) {
+        if (status.isUseTableBasedHistory()) {
             table.addHistory(status, isReplay);
         } else {
             mem.addHistory(status, isReplay);
@@ -48,12 +48,10 @@ public class MergedTaskRunHistory implements TaskRunHistory {
     }
 
     @Override
-    public TaskRunStatus getTask(String queryId) {
-        TaskRunStatus res = table.getTask(queryId);
-        if (res != null) {
-            return res;
+    public void replayTaskRunChange(String queryId, TaskRunStatusChange change) {
+        if (!change.isUseTableBasedHistory()) {
+            mem.replayTaskRunChange(queryId, change);
         }
-        return mem.getTask(queryId);
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/history/MergedTaskRunHistory.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/history/MergedTaskRunHistory.java
@@ -62,7 +62,7 @@ public class MergedTaskRunHistory implements TaskRunHistory {
 
     @Override
     public void forceGC() {
-        mem.gc();
+        mem.forceGC();
         table.forceGC();
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/history/TableBasedTaskRunHistory.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/history/TableBasedTaskRunHistory.java
@@ -81,11 +81,11 @@ public class TableBasedTaskRunHistory implements TaskRunHistory {
             "create_time, finish_time, expire_time, " +
             "history_content_json) " +
             "VALUES({1}, {2}, {3}, {4}, {5}, {6}, {7})";
-    private static final String SELECT_BY_TASK_NAME = "SELECT " + COLUMN_LIST + " FROM " + TABLE_FULL_NAME +
-            " WHERE task_name = {0}";
-    private static final String SELECT_BY_TASK_RUN_ID = "SELECT " + COLUMN_LIST + " FROM " + TABLE_FULL_NAME +
-            " WHERE task_run_id = {0}";
-    private static final String SELECT_ALL = "SELECT " + COLUMN_LIST + " FROM " + TABLE_FULL_NAME;
+    private static final String SELECT_BY_TASK_NAME =
+            "SELECT history_content_json FROM " + TABLE_FULL_NAME + " WHERE task_name = {0}";
+    private static final String SELECT_BY_TASK_RUN_ID =
+            "SELECT history_content_json FROM " + TABLE_FULL_NAME + " WHERE task_run_id = {0}";
+    private static final String SELECT_ALL = "SELECT history_content_json FROM " + TABLE_FULL_NAME;
     private static final String COUNT_TASK_RUNS = "SELECT count(*) as cnt FROM " + TABLE_FULL_NAME;
 
     public static TableKeeper createKeeper() {

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/history/TableBasedTaskRunHistory.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/history/TableBasedTaskRunHistory.java
@@ -14,7 +14,6 @@
 
 package com.starrocks.scheduler.history;
 
-import com.google.common.collect.Lists;
 import com.google.gson.JsonArray;
 import com.google.gson.JsonParser;
 import com.starrocks.common.FeConstants;
@@ -129,9 +128,8 @@ public class TableBasedTaskRunHistory implements TaskRunHistory {
     }
 
     @Override
-    public List<String> gc() {
+    public void gc() {
         // TableBasedHistory could do the gc by itself
-        return Lists.newArrayList();
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/history/TableBasedTaskRunHistory.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/history/TableBasedTaskRunHistory.java
@@ -19,6 +19,7 @@ import com.google.gson.JsonParser;
 import com.starrocks.common.util.DateUtils;
 import com.starrocks.load.pipe.filelist.RepoExecutor;
 import com.starrocks.scheduler.persist.TaskRunStatus;
+import com.starrocks.scheduler.persist.TaskRunStatusChange;
 import com.starrocks.statistic.StatsConstants;
 import com.starrocks.thrift.TResultBatch;
 import io.netty.buffer.ByteBuf;
@@ -80,8 +81,6 @@ public class TableBasedTaskRunHistory implements TaskRunHistory {
             "VALUES({1}, {2}, {3}, {4}, {5}, {6}, {7})";
     private static final String SELECT_BY_TASK_NAME =
             "SELECT history_content_json FROM " + TABLE_FULL_NAME + " WHERE task_name = {0}";
-    private static final String SELECT_BY_TASK_RUN_ID =
-            "SELECT history_content_json FROM " + TABLE_FULL_NAME + " WHERE task_run_id = {0}";
     private static final String SELECT_ALL = "SELECT history_content_json FROM " + TABLE_FULL_NAME;
     private static final String COUNT_TASK_RUNS = "SELECT count(*) as cnt FROM " + TABLE_FULL_NAME;
 
@@ -117,11 +116,7 @@ public class TableBasedTaskRunHistory implements TaskRunHistory {
     }
 
     @Override
-    public TaskRunStatus getTask(String queryId) {
-        final String sql = MessageFormat.format(SELECT_BY_TASK_RUN_ID, Strings.quote(queryId));
-        List<TResultBatch> batch = RepoExecutor.getInstance().executeDQL(sql);
-        List<TaskRunStatus> taskRuns = TaskRunStatus.fromResultBatch(batch);
-        return CollectionUtils.isEmpty(taskRuns) ? null : taskRuns.get(0);
+    public void replayTaskRunChange(String queryId, TaskRunStatusChange change) {
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/history/TableBasedTaskRunHistory.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/history/TableBasedTaskRunHistory.java
@@ -1,0 +1,153 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.scheduler.history;
+
+import com.google.common.collect.Lists;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
+import com.starrocks.common.util.DateUtils;
+import com.starrocks.load.pipe.filelist.RepoExecutor;
+import com.starrocks.scheduler.persist.TaskRunStatus;
+import com.starrocks.statistic.StatsConstants;
+import com.starrocks.thrift.TResultBatch;
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.Unpooled;
+import org.apache.commons.collections.CollectionUtils;
+import org.apache.logging.log4j.util.Strings;
+
+import java.nio.ByteBuffer;
+import java.nio.charset.Charset;
+import java.text.MessageFormat;
+import java.time.ZoneId;
+import java.util.List;
+
+/**
+ * History storage that leverage a regular starrocks table to store the data
+ */
+public class TableBasedTaskRunHistory implements ITaskRunHistory {
+
+    private final static String DATABASE_NAME = StatsConstants.STATISTICS_DB_NAME;
+    private final static String TABLE_NAME = "task_run_history";
+    private final static String TABLE_FULL_NAME = DATABASE_NAME + "." + TABLE_NAME;
+    private final static int TABLE_REPLICAS = 3;
+    private final static String CREATE_TABLE =
+            String.format("CREATE TABLE %s (" +
+                    // auto-increment id
+                    "id BIGINT NOT NULL auto_increment, " +
+
+                    // identifiers
+                    "task_id bigint NOT NULL, " +
+                    "task_run_id string NOT NULL, " +
+                    "task_name string NOT NULL, " +
+
+                    // times
+                    "create_time datetime NOT NULL, " +
+                    "finish_time datetime NOT NULL, " +
+                    "expire_time datetime NOT NULL, " +
+
+                    // content in JSON format
+                    "history_content_json JSON NOT NULL" +
+                    ")" +
+
+                    // properties
+                    "DUPLICATE KEY (task_id, create_time) " +
+                    "PARTITION BY RANGE(create_time) " +
+                    "DISTRIBUTED BY HASH(id) BUCKETS 8 " +
+                    "PROPERTIES(" +
+                    "'replication_num' = '%d'," +
+                    "'dynamic_partition.time_unit' = 'DAY', " +
+                    "'dynamic_partition.start' = '-3', " +
+                    "'dynamic_partition.end' = '3', " +
+                    "'dynamic_partition.prefix' = 'p' " +
+                    ") ", TABLE_NAME, 3);
+
+    private final static String COLUMN_LIST = "task_id, task_run_id, task_name, " +
+            "create_time, finish_time, expire_time, " +
+            "history_content_json ";
+    private final static String INSERT_SQL_TEMPLATE = "INSERT INTO {0} " +
+            "(task_id, task_run_id, task_name, " +
+            "create_time, finish_time, expire_time, " +
+            "history_content_json) " +
+            "VALUES({1}, '{2}', '{3}', {4}, {5}, {6}, '{7}')";
+    private final static String SELECT_BY_TASK_NAME = "SELECT " + COLUMN_LIST + " FROM " + TABLE_FULL_NAME +
+            " WHERE task_name = {0}";
+    private final static String SELECT_BY_TASK_RUN_ID = "SELECT " + COLUMN_LIST + " FROM " + TABLE_FULL_NAME +
+            " WHERE task_run_id = {0}";
+    private final static String COUNT_TASK_RUNS = "SELECT count(*) as cnt FROM " + TABLE_FULL_NAME;
+
+    public static TableKeeper createKeeper() {
+        return new TableKeeper(DATABASE_NAME, TABLE_NAME, CREATE_TABLE, 3);
+    }
+
+    @Override
+    public void addHistory(TaskRunStatus status) {
+        String createTime =
+                Strings.quote(DateUtils.formatTimeStampInMill(status.getCreateTime(), ZoneId.systemDefault()));
+        String finishTime =
+                Strings.quote(DateUtils.formatTimeStampInMill(status.getFinishTime(), ZoneId.systemDefault()));
+        String expireTime =
+                Strings.quote(DateUtils.formatTimeStampInMill(status.getExpireTime(), ZoneId.systemDefault()));
+
+        final String sql = MessageFormat.format(INSERT_SQL_TEMPLATE, TABLE_FULL_NAME,
+                status.getTaskId(), status.getStartTaskRunId(), status.getTaskName(),
+                createTime, finishTime, expireTime, status.toJSON());
+        RepoExecutor.getInstance().executeDML(sql);
+    }
+
+    @Override
+    public List<TaskRunStatus> getTaskByName(String taskName) {
+        final String sql = MessageFormat.format(SELECT_BY_TASK_NAME, Strings.quote(taskName));
+        List<TResultBatch> batch = RepoExecutor.getInstance().executeDQL(sql);
+        return TaskRunStatus.fromResultBatch(batch);
+    }
+
+    @Override
+    public TaskRunStatus getTask(String queryId) {
+        final String sql = MessageFormat.format(SELECT_BY_TASK_RUN_ID, Strings.quote(queryId));
+        List<TResultBatch> batch = RepoExecutor.getInstance().executeDQL(sql);
+        List<TaskRunStatus> taskRuns = TaskRunStatus.fromResultBatch(batch);
+        return CollectionUtils.isEmpty(taskRuns) ? null : taskRuns.get(0);
+    }
+
+    @Override
+    public List<String> gc() {
+        // TableBasedHistory could do the gc by itself
+        return Lists.newArrayList();
+    }
+
+    // TODO: don't return all history, which is very expensive
+    @Override
+    public List<TaskRunStatus> getAllHistory() {
+        return null;
+    }
+
+    @Override
+    public long getTaskRunCount() {
+        List<TResultBatch> batches = RepoExecutor.getInstance().executeDQL(COUNT_TASK_RUNS);
+        if (CollectionUtils.isNotEmpty(batches)) {
+            try {
+                ByteBuffer buffer = batches.get(0).getRows().get(0);
+                ByteBuf copied = Unpooled.copiedBuffer(buffer);
+                String jsonString = copied.toString(Charset.defaultCharset());
+                JsonObject obj = (JsonObject) JsonParser.parseString(jsonString);
+                return obj.get("cnt").getAsInt();
+            } catch (Exception e) {
+                throw new IllegalStateException("failed to parse json result: " + batches);
+            }
+        }
+        return 0;
+    }
+
+}

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/history/TableBasedTaskRunHistory.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/history/TableBasedTaskRunHistory.java
@@ -16,11 +16,9 @@ package com.starrocks.scheduler.history;
 
 import com.google.gson.JsonArray;
 import com.google.gson.JsonParser;
-import com.starrocks.common.FeConstants;
 import com.starrocks.common.util.DateUtils;
 import com.starrocks.load.pipe.filelist.RepoExecutor;
 import com.starrocks.scheduler.persist.TaskRunStatus;
-import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.statistic.StatsConstants;
 import com.starrocks.thrift.TResultBatch;
 import io.netty.buffer.ByteBuf;
@@ -92,9 +90,8 @@ public class TableBasedTaskRunHistory implements TaskRunHistory {
     }
 
     @Override
-    public void addHistory(TaskRunStatus status) {
-        // Only leader node needs to persist the history
-        if (!GlobalStateMgr.getCurrentState().isLeader() && !FeConstants.runningUnitTest) {
+    public void addHistory(TaskRunStatus status, boolean isReplay) {
+        if (isReplay) {
             return;
         }
 

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/history/TableKeeper.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/history/TableKeeper.java
@@ -109,6 +109,46 @@ public class TableKeeper {
                 databaseName, tableName, tableReplicas);
     }
 
+    public String getDatabaseName() {
+        return databaseName;
+    }
+
+    public String getTableName() {
+        return tableName;
+    }
+
+    public String getCreateTableSql() {
+        return createTableSql;
+    }
+
+    public int getTableReplicas() {
+        return tableReplicas;
+    }
+
+    public boolean isDatabaseExisted() {
+        return databaseExisted;
+    }
+
+    public boolean isTableExisted() {
+        return tableExisted;
+    }
+
+    public boolean isTableCorrected() {
+        return tableCorrected;
+    }
+
+    public void setDatabaseExisted(boolean databaseExisted) {
+        this.databaseExisted = databaseExisted;
+    }
+
+    public void setTableExisted(boolean tableExisted) {
+        this.tableExisted = tableExisted;
+    }
+
+    public void setTableCorrected(boolean tableCorrected) {
+        this.tableCorrected = tableCorrected;
+    }
+
     public static TableKeeperDaemon startDaemon() {
         return new TableKeeperDaemon();
     }

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/history/TableKeeper.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/history/TableKeeper.java
@@ -83,7 +83,7 @@ public class TableKeeper {
     }
 
     public boolean correctTable() {
-        int numBackends = GlobalStateMgr.getCurrentSystemInfo().getTotalBackendNumber();
+        int numBackends = GlobalStateMgr.getCurrentState().getNodeMgr().getClusterInfo().getTotalBackendNumber();
         int replica = GlobalStateMgr.getCurrentState()
                 .mayGetDb(databaseName)
                 .flatMap(db -> db.mayGetTable(tableName))

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/history/TableKeeper.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/history/TableKeeper.java
@@ -1,0 +1,147 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.scheduler.history;
+
+import com.google.common.collect.Lists;
+import com.starrocks.catalog.OlapTable;
+import com.starrocks.common.Config;
+import com.starrocks.common.UserException;
+import com.starrocks.common.util.FrontendDaemon;
+import com.starrocks.load.pipe.filelist.RepoExecutor;
+import com.starrocks.server.GlobalStateMgr;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import java.util.List;
+
+/**
+ * Keeper:
+ * 1. Create the table for the history storage
+ * 2. Cleanup stale history
+ */
+public class TableKeeper {
+
+    private final static Logger LOG = LogManager.getLogger(TableKeeper.class);
+
+    private final String databaseName;
+    private final String tableName;
+    private final String createTableSql;
+    private final int tableReplicas;
+
+    private boolean databaseExisted = false;
+    private boolean tableExisted = false;
+    private boolean tableCorrected = false;
+
+    public TableKeeper(String database, String table, String createTable, int expectedReplicas) {
+        this.databaseName = database;
+        this.tableName = table;
+        this.createTableSql = createTable;
+        this.tableReplicas = expectedReplicas;
+    }
+
+    public synchronized void run() {
+        try {
+            if (!databaseExisted) {
+                databaseExisted = checkDatabaseExists();
+                if (!databaseExisted) {
+                    LOG.warn("database not exists: " + databaseName);
+                    return;
+                }
+            }
+            if (!tableExisted) {
+                createTable();
+                LOG.info("table created: " + tableName);
+                tableExisted = true;
+            }
+            if (!tableCorrected && correctTable()) {
+                LOG.info("table corrected: " + tableName);
+                tableCorrected = true;
+            }
+        } catch (Exception e) {
+            LOG.error("error happens in Keeper: {}", e.getMessage(), e);
+        }
+    }
+
+    public boolean checkDatabaseExists() {
+        return GlobalStateMgr.getCurrentState().getDb(databaseName) != null;
+    }
+
+    public void createTable() throws UserException {
+        RepoExecutor.getInstance().executeDDL(createTableSql);
+    }
+
+    public boolean correctTable() {
+        int numBackends = GlobalStateMgr.getCurrentSystemInfo().getTotalBackendNumber();
+        int replica = GlobalStateMgr.getCurrentState()
+                .mayGetDb(databaseName)
+                .flatMap(db -> db.mayGetTable(tableName))
+                .map(tbl -> ((OlapTable) tbl).getPartitionInfo().getMinReplicationNum())
+                .orElse((short) 1);
+        if (numBackends < tableReplicas) {
+            LOG.info("not enough backends in the cluster, expected {} but got {}",
+                    tableReplicas, numBackends);
+            return false;
+        }
+        if (replica < tableReplicas) {
+            String sql = alterTableReplicas();
+            RepoExecutor.getInstance().executeDDL(sql);
+        } else {
+            LOG.info("table {} already has {} replicas, no need to alter replication_num",
+                    tableName, replica);
+        }
+        return true;
+    }
+
+    private String alterTableReplicas() {
+        return String.format("ALTER TABLE %s.%s SET ('replication_num'='%d')",
+                databaseName, tableName, tableReplicas);
+    }
+
+    public static TableKeeperDaemon startDaemon() {
+        return new TableKeeperDaemon();
+    }
+
+    /**
+     * The daemon thread running the TableKeeper
+     */
+    public static class TableKeeperDaemon extends FrontendDaemon {
+
+        private final List<TableKeeper> keeperList = Lists.newArrayList();
+
+        TableKeeperDaemon() {
+            super("TableKeeper", Config.table_keeper_interval_second * 1000L);
+
+            keeperList.add(TableBasedTaskRunHistory.createKeeper());
+            // TODO: add FileListPipeRepo
+            // TODO: add statistic table
+        }
+
+        @Override
+        protected void runAfterCatalogReady() {
+            if (!GlobalStateMgr.getCurrentState().isLeader()) {
+                return;
+            }
+            setInterval(Config.table_keeper_interval_second * 1000L);
+
+            for (TableKeeper keeper : keeperList) {
+                try {
+                    keeper.run();
+                } catch (Exception e) {
+                    LOG.warn("error in TableKeeper: ", e);
+                }
+            }
+        }
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/history/TableKeeper.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/history/TableKeeper.java
@@ -33,7 +33,7 @@ import java.util.List;
  */
 public class TableKeeper {
 
-    private final static Logger LOG = LogManager.getLogger(TableKeeper.class);
+    private static final Logger LOG = LogManager.getLogger(TableKeeper.class);
 
     private final String databaseName;
     private final String tableName;

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/history/TaskRunHistory.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/history/TaskRunHistory.java
@@ -21,7 +21,7 @@ import java.util.List;
 /**
  * Record the history of all task-runs
  */
-public interface ITaskRunHistory {
+public interface TaskRunHistory {
 
     void addHistory(TaskRunStatus status);
 
@@ -33,6 +33,8 @@ public interface ITaskRunHistory {
      * @return removed TaskRunId in the history
      */
     List<String> gc();
+
+    void forceGC();
 
     List<TaskRunStatus> getAllHistory();
 

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/history/TaskRunHistory.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/history/TaskRunHistory.java
@@ -15,6 +15,7 @@
 package com.starrocks.scheduler.history;
 
 import com.starrocks.scheduler.persist.TaskRunStatus;
+import com.starrocks.scheduler.persist.TaskRunStatusChange;
 
 import java.util.List;
 
@@ -27,7 +28,7 @@ public interface TaskRunHistory {
 
     List<TaskRunStatus> getTaskByName(String taskName);
 
-    TaskRunStatus getTask(String queryId);
+    void replayTaskRunChange(String queryId, TaskRunStatusChange change);
 
     /**
      * @return removed TaskRunId in the history

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/history/TaskRunHistory.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/history/TaskRunHistory.java
@@ -23,7 +23,7 @@ import java.util.List;
  */
 public interface TaskRunHistory {
 
-    void addHistory(TaskRunStatus status);
+    void addHistory(TaskRunStatus status, boolean isReplay);
 
     List<TaskRunStatus> getTaskByName(String taskName);
 

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/history/TaskRunHistory.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/history/TaskRunHistory.java
@@ -32,7 +32,7 @@ public interface TaskRunHistory {
     /**
      * @return removed TaskRunId in the history
      */
-    List<String> gc();
+    void gc();
 
     void forceGC();
 

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/persist/TaskRunStatus.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/persist/TaskRunStatus.java
@@ -391,13 +391,26 @@ public class TaskRunStatus implements Writable {
         return GsonUtils.GSON.fromJson(json, TaskRunStatus.class);
     }
 
+    static class TaskRunStatusJSONRecord {
+        /**
+         * Only one item in the array, like:
+         * { data: [ {TaskRunStatus} ] }
+         */
+        @SerializedName("data")
+        public List<TaskRunStatus> data;
+
+        public static TaskRunStatusJSONRecord fromJson(String json) {
+            return GsonUtils.GSON.fromJson(json, TaskRunStatusJSONRecord.class);
+        }
+    }
+
     public static List<TaskRunStatus> fromResultBatch(List<TResultBatch> batches) {
         List<TaskRunStatus> res = new ArrayList<>();
         for (TResultBatch batch : ListUtils.emptyIfNull(batches)) {
             for (ByteBuffer buffer : batch.getRows()) {
                 ByteBuf copied = Unpooled.copiedBuffer(buffer);
                 String jsonString = copied.toString(Charset.defaultCharset());
-                res.add(TaskRunStatus.fromJson(jsonString));
+                res.addAll(ListUtils.emptyIfNull(TaskRunStatusJSONRecord.fromJson(jsonString).data));
             }
         }
         return res;

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/persist/TaskRunStatus.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/persist/TaskRunStatus.java
@@ -115,6 +115,9 @@ public class TaskRunStatus implements Writable {
     @SerializedName("properties")
     private volatile Map<String, String> properties;
 
+    @SerializedName("useTableBasedHistory")
+    private boolean useTableBasedHistory = false;
+
     public TaskRunStatus() {
     }
 
@@ -281,6 +284,14 @@ public class TaskRunStatus implements Writable {
         } else {
             // do nothing
         }
+    }
+
+    public boolean isUseTableBasedHistory() {
+        return useTableBasedHistory;
+    }
+
+    public void setUseTableBasedHistory(boolean value) {
+        this.useTableBasedHistory = value;
     }
 
     public long getProcessStartTime() {

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/persist/TaskRunStatus.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/persist/TaskRunStatus.java
@@ -23,11 +23,19 @@ import com.starrocks.common.io.Text;
 import com.starrocks.common.io.Writable;
 import com.starrocks.persist.gson.GsonUtils;
 import com.starrocks.scheduler.Constants;
+import com.starrocks.thrift.TResultBatch;
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.Unpooled;
 import org.apache.commons.collections.MapUtils;
+import org.apache.commons.collections4.ListUtils;
 
 import java.io.DataInput;
 import java.io.DataOutput;
 import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.charset.Charset;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Map;
 
 public class TaskRunStatus implements Writable {
@@ -373,5 +381,25 @@ public class TaskRunStatus implements Writable {
                 ", mergeRedundant=" + mergeRedundant +
                 ", extraMessage=" + getExtraMessage() +
                 '}';
+    }
+
+    public String toJSON() {
+        return GsonUtils.GSON.toJson(this);
+    }
+
+    public static TaskRunStatus fromJson(String json) {
+        return GsonUtils.GSON.fromJson(json, TaskRunStatus.class);
+    }
+
+    public static List<TaskRunStatus> fromResultBatch(List<TResultBatch> batches) {
+        List<TaskRunStatus> res = new ArrayList<>();
+        for (TResultBatch batch : ListUtils.emptyIfNull(batches)) {
+            for (ByteBuffer buffer : batch.getRows()) {
+                ByteBuf copied = Unpooled.copiedBuffer(buffer);
+                String jsonString = copied.toString(Charset.defaultCharset());
+                res.add(TaskRunStatus.fromJson(jsonString));
+            }
+        }
+        return res;
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/persist/TaskRunStatusChange.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/persist/TaskRunStatusChange.java
@@ -16,6 +16,7 @@
 package com.starrocks.scheduler.persist;
 
 import com.google.gson.annotations.SerializedName;
+import com.starrocks.common.Config;
 import com.starrocks.common.io.Text;
 import com.starrocks.common.io.Writable;
 import com.starrocks.persist.gson.GsonUtils;
@@ -51,6 +52,15 @@ public class TaskRunStatusChange implements Writable {
     @SerializedName("extraMessage")
     private String extraMessage;
 
+    /**
+     * To make it compatible when turning on the TableBasedHistory
+     * on: only write edit-log but not record in the MemBasedHistory
+     * off: write edit-log and record in MemBasedHistory
+     * default: off
+     */
+    @SerializedName("useTableBasedHistory")
+    private boolean useTableBasedHistory = false;
+
     public TaskRunStatusChange(long taskId, TaskRunStatus status,
                                Constants.TaskRunState fromStatus,
                                Constants.TaskRunState toStatus) {
@@ -64,6 +74,7 @@ public class TaskRunStatusChange implements Writable {
             errorMessage = status.getErrorMessage();
         }
         this.extraMessage = status.getExtraMessage();
+        this.useTableBasedHistory = Config.use_table_based_task_run_history;
     }
 
     public long getTaskId() {
@@ -128,6 +139,14 @@ public class TaskRunStatusChange implements Writable {
 
     public void setExtraMessage(String extraMessage) {
         this.extraMessage = extraMessage;
+    }
+
+    public boolean isUseTableBasedHistory() {
+        return useTableBasedHistory;
+    }
+
+    public void setUseTableBasedHistory(boolean useTableBasedHistory) {
+        this.useTableBasedHistory = useTableBasedHistory;
     }
 
     public static TaskRunStatusChange read(DataInput in) throws IOException {

--- a/fe/fe-core/src/main/java/com/starrocks/server/GlobalStateMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/GlobalStateMgr.java
@@ -1002,6 +1002,7 @@ public class GlobalStateMgr {
 
             // 6. start task cleaner thread
             createTaskCleaner();
+            createTableKeeper();
 
             // 7. init starosAgent
             if (RunMode.isSharedDataMode() && !starOSAgent.init(null)) {

--- a/fe/fe-core/src/main/java/com/starrocks/server/GlobalStateMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/GlobalStateMgr.java
@@ -1153,6 +1153,8 @@ public class GlobalStateMgr {
 
             isReady.set(true);
 
+            restoreLeaderStates();
+
             String msg = "leader finished to replay journal, can write now.";
             Util.stdoutWithTime(msg);
             LOG.info(msg);
@@ -1249,9 +1251,6 @@ public class GlobalStateMgr {
         updateDbUsedDataQuotaDaemon.start();
         statisticsMetaManager.start();
         statisticAutoCollector.start();
-        taskManager.start();
-        taskCleaner.start();
-        tableKeeper.start();
         mvMVJobExecutor.start();
         pipeListener.start();
         pipeScheduler.start();
@@ -1272,6 +1271,15 @@ public class GlobalStateMgr {
         }
 
         replicationMgr.start();
+    }
+
+    /**
+     * Restore leader states, which need to wait for all threads ready and be able to write FE
+     */
+    private void restoreLeaderStates() {
+        tableKeeper.start();
+        taskManager.start();
+        taskCleaner.start();
     }
 
     // start threads that should run on all FE

--- a/fe/fe-core/src/main/java/com/starrocks/server/GlobalStateMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/GlobalStateMgr.java
@@ -177,6 +177,7 @@ import com.starrocks.replication.ReplicationMgr;
 import com.starrocks.rpc.FrontendServiceProxy;
 import com.starrocks.scheduler.MVActiveChecker;
 import com.starrocks.scheduler.TaskManager;
+import com.starrocks.scheduler.history.TableKeeper;
 import com.starrocks.scheduler.mv.MVJobExecutor;
 import com.starrocks.scheduler.mv.MaterializedViewMgr;
 import com.starrocks.sql.ast.RefreshTableStmt;
@@ -285,6 +286,7 @@ public class GlobalStateMgr {
     private FrontendDaemon labelCleaner; // To clean old LabelInfo, ExportJobInfos
     private FrontendDaemon txnTimeoutChecker; // To abort timeout txns
     private FrontendDaemon taskCleaner;   // To clean expire Task/TaskRun
+    private FrontendDaemon tableKeeper; // Maintain internal tables
     private JournalWriter journalWriter; // leader only: write journal log
     private Daemon replayer;
     private Daemon timePrinter;
@@ -1581,6 +1583,13 @@ public class GlobalStateMgr {
                 doTaskBackgroundJob();
             }
         };
+    }
+
+    /**
+     * Table keeper daemon
+     */
+    public void createTableKeeper() {
+        tableKeeper = TableKeeper.startDaemon();
     }
 
     public void createTxnTimeoutChecker() {

--- a/fe/fe-core/src/main/java/com/starrocks/server/GlobalStateMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/GlobalStateMgr.java
@@ -1250,6 +1250,7 @@ public class GlobalStateMgr {
         statisticAutoCollector.start();
         taskManager.start();
         taskCleaner.start();
+        tableKeeper.start();
         mvMVJobExecutor.start();
         pipeListener.start();
         pipeScheduler.start();

--- a/fe/fe-core/src/test/java/com/starrocks/scheduler/TaskManagerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/scheduler/TaskManagerTest.java
@@ -433,7 +433,7 @@ public class TaskManagerTest {
             TaskRunStatus taskRunStatus = new TaskRunStatus();
             taskRunStatus.setQueryId("test" + i);
             taskRunStatus.setTaskName("test" + i);
-            taskRunManager.getTaskRunHistory().addHistory(taskRunStatus);
+            taskRunManager.getTaskRunHistory().addHistory(taskRunStatus, false);
         }
         Config.task_runs_max_history_number = 20;
         taskRunManager.getTaskRunHistory().forceGC();
@@ -448,7 +448,7 @@ public class TaskManagerTest {
             TaskRunStatus taskRunStatus = new TaskRunStatus();
             taskRunStatus.setQueryId("test" + i);
             taskRunStatus.setTaskName("test" + i);
-            taskRunManager.getTaskRunHistory().addHistory(taskRunStatus);
+            taskRunManager.getTaskRunHistory().addHistory(taskRunStatus, false);
         }
         Config.task_runs_max_history_number = 20;
         taskRunManager.getTaskRunHistory().forceGC();

--- a/fe/fe-core/src/test/java/com/starrocks/scheduler/history/TableBasedTaskRunHistoryTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/scheduler/history/TableBasedTaskRunHistoryTest.java
@@ -46,12 +46,12 @@ class TableBasedTaskRunHistoryTest {
     public void testTaskRunStatusSerialization() {
         TaskRunStatus status = new TaskRunStatus();
         String json = status.toJSON();
-        assertEquals("{\"taskId\":0,\"createTime\":0,\"finishTime\":0,\"processStartTime\":0," +
-                "\"state\":\"PENDING\",\"progress\":0,\"errorCode\":0,\"expireTime\":0,\"priority\":0," +
-                "\"mergeRedundant\":false,\"source\":\"CTAS\",\"mvExtraMessage\":" +
-                "{\"forceRefresh\":false,\"mvPartitionsToRefresh\":[],\"refBasePartitionsToRefreshMap\":{}," +
-                "\"basePartitionsToRefreshMap\":{},\"executeOption\":{\"priority\":0,\"isMergeRedundant\":false," +
-                "\"isManual\":false,\"isSync\":false,\"isReplay\":false}}}", json);
+        assertEquals("{\"taskId\":0,\"createTime\":0,\"expireTime\":0,\"priority\":0,\"mergeRedundant\":false," +
+                        "\"source\":\"CTAS\",\"errorCode\":0,\"finishTime\":0,\"processStartTime\":0,\"state\":\"PENDING\"," +
+                        "\"progress\":0,\"mvExtraMessage\":{\"forceRefresh\":false,\"mvPartitionsToRefresh\":[]," +
+                        "\"refBasePartitionsToRefreshMap\":{},\"basePartitionsToRefreshMap\":{},\"executeOption\":" +
+                        "{\"priority\":0,\"isMergeRedundant\":false,\"isManual\":false,\"isSync\":false,\"isReplay\":false}}}",
+                json);
 
         TaskRunStatus b = TaskRunStatus.fromJson(json);
         assertEquals(status.toJSON(), b.toJSON());
@@ -61,18 +61,16 @@ class TableBasedTaskRunHistoryTest {
     public void testCRUD(@Mocked RepoExecutor repo) {
         new Expectations() {
             {
-                repo.executeDML(
-                        "INSERT INTO _statistics_.task_run_history (task_id, task_run_id, task_name, create_time, " +
-                                "finish_time, expire_time, history_content_json) VALUES(0, 'aaa', 't1', " +
-                                "'1970-01-01 08:00:00', '1970-01-01 08:00:00', '1970-01-01 08:00:00', " +
-                                "'{\"startTaskRunId\":\"aaa\",\"taskId\":0,\"taskName\":\"t1\",\"createTime\":0," +
-                                "\"finishTime\":0,\"processStartTime\":0,\"state\":\"PENDING\",\"progress\":0," +
-                                "\"errorCode\":0,\"expireTime\":0,\"priority\":0,\"mergeRedundant\":false," +
-                                "\"source\":\"CTAS\",\"mvExtraMessage\":{\"forceRefresh\":false,\"mvPartitionsToRefresh\":" +
-                                "[],\"refBasePartitionsToRefreshMap\":{},\"basePartitionsToRefreshMap\":{}," +
-                                "\"executeOption\":{\"priority\":0,\"isMergeRedundant\":false,\"isManual\":false," +
-                                "\"isSync\":false,\"isReplay\":false}}}')");
-
+                repo.executeDML("INSERT INTO _statistics_.task_run_history (task_id, task_run_id, task_name, " +
+                        "create_time, finish_time, expire_time, history_content_json) VALUES(0, 'aaa', 't1', " +
+                        "'1970-01-01 08:00:00', '1970-01-01 08:00:00', '1970-01-01 08:00:00', " +
+                        "'{\"startTaskRunId\":\"aaa\",\"taskId\":0,\"taskName\":\"t1\",\"createTime\":0," +
+                        "\"expireTime\":0,\"priority\":0,\"mergeRedundant\":false,\"source\":\"CTAS\"," +
+                        "\"errorCode\":0,\"finishTime\":0,\"processStartTime\":0,\"state\":\"PENDING\",\"progress\":0," +
+                        "\"mvExtraMessage\":{\"forceRefresh\":false,\"mvPartitionsToRefresh\":[]," +
+                        "\"refBasePartitionsToRefreshMap\":{},\"basePartitionsToRefreshMap\":{},\"executeOption\":" +
+                        "{\"priority\":0,\"isMergeRedundant\":false,\"isManual\":false,\"isSync\":false," +
+                        "\"isReplay\":false}}}')");
             }
         };
 
@@ -80,7 +78,7 @@ class TableBasedTaskRunHistoryTest {
         TaskRunStatus status = new TaskRunStatus();
         status.setStartTaskRunId("aaa");
         status.setTaskName("t1");
-        history.addHistory(status);
+        history.addHistory(status, false);
 
         // getTaskByName
         new Expectations() {

--- a/fe/fe-core/src/test/java/com/starrocks/scheduler/history/TableBasedTaskRunHistoryTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/scheduler/history/TableBasedTaskRunHistoryTest.java
@@ -1,0 +1,152 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.scheduler.history;
+
+import com.google.common.collect.Lists;
+import com.starrocks.common.FeConstants;
+import com.starrocks.load.pipe.filelist.RepoExecutor;
+import com.starrocks.scheduler.persist.TaskRunStatus;
+import com.starrocks.statistic.StatsConstants;
+import com.starrocks.system.SystemInfoService;
+import com.starrocks.thrift.TResultBatch;
+import mockit.Expectations;
+import mockit.Mock;
+import mockit.MockUp;
+import mockit.Mocked;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import java.nio.ByteBuffer;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class TableBasedTaskRunHistoryTest {
+
+    @BeforeAll
+    public static void beforeAll() {
+        FeConstants.runningUnitTest = true;
+    }
+
+    @Test
+    public void testTaskRunStatusSerialization() {
+        TaskRunStatus status = new TaskRunStatus();
+        String json = status.toJSON();
+        assertEquals("{\"taskId\":0,\"createTime\":0,\"finishTime\":0,\"processStartTime\":0," +
+                "\"state\":\"PENDING\",\"progress\":0,\"errorCode\":0,\"expireTime\":0,\"priority\":0," +
+                "\"mergeRedundant\":false,\"source\":\"CTAS\",\"mvExtraMessage\":" +
+                "{\"forceRefresh\":false,\"mvPartitionsToRefresh\":[],\"refBasePartitionsToRefreshMap\":{}," +
+                "\"basePartitionsToRefreshMap\":{},\"executeOption\":{\"priority\":0,\"isMergeRedundant\":false," +
+                "\"isManual\":false,\"isSync\":false,\"isReplay\":false}}}", json);
+
+        TaskRunStatus b = TaskRunStatus.fromJson(json);
+        assertEquals(status.toJSON(), b.toJSON());
+    }
+
+    @Test
+    public void testCRUD(@Mocked RepoExecutor repo) {
+        new Expectations() {{
+            repo.executeDML(
+                    "INSERT INTO _statistics_.task_run_history (task_id, task_run_id, task_name, create_time, " +
+                            "finish_time, expire_time, history_content_json) VALUES(0, 'aaa', 't1', " +
+                            "'1970-01-01 08:00:00', '1970-01-01 08:00:00', '1970-01-01 08:00:00', " +
+                            "'{\"startTaskRunId\":\"aaa\",\"taskId\":0,\"taskName\":\"t1\",\"createTime\":0," +
+                            "\"finishTime\":0,\"processStartTime\":0,\"state\":\"PENDING\",\"progress\":0," +
+                            "\"errorCode\":0,\"expireTime\":0,\"priority\":0,\"mergeRedundant\":false," +
+                            "\"source\":\"CTAS\",\"mvExtraMessage\":{\"forceRefresh\":false,\"mvPartitionsToRefresh\":" +
+                            "[],\"refBasePartitionsToRefreshMap\":{},\"basePartitionsToRefreshMap\":{}," +
+                            "\"executeOption\":{\"priority\":0,\"isMergeRedundant\":false,\"isManual\":false," +
+                            "\"isSync\":false,\"isReplay\":false}}}')");
+
+        }};
+
+        TableBasedTaskRunHistory history = new TableBasedTaskRunHistory();
+        TaskRunStatus status = new TaskRunStatus();
+        status.setStartTaskRunId("aaa");
+        status.setTaskName("t1");
+        history.addHistory(status);
+
+        // getTaskByName
+        new Expectations() {{
+            repo.executeDQL("SELECT task_id, task_run_id, task_name, create_time, finish_time, expire_time, " +
+                    "history_content_json  FROM _statistics_.task_run_history WHERE task_name = 't1'");
+        }};
+        history.getTaskByName("t1");
+
+        // getTask
+        new Expectations() {{
+            repo.executeDQL("SELECT task_id, task_run_id, task_name, create_time, finish_time, expire_time, " +
+                    "history_content_json  FROM _statistics_.task_run_history WHERE task_run_id = 't1'");
+        }};
+        history.getTask("t1");
+
+        // getAllHistory
+        new Expectations() {{
+            repo.executeDQL("SELECT task_id, task_run_id, task_name, create_time, finish_time, expire_time, " +
+                    "history_content_json  FROM _statistics_.task_run_history");
+        }};
+        history.getAllHistory();
+
+        // getTaskRunCount
+        TResultBatch batch = new TResultBatch();
+        batch.setRows(Lists.newArrayList(ByteBuffer.wrap("[123]".getBytes())));
+        List<TResultBatch> resultBatch = Lists.newArrayList(batch);
+        new Expectations() {{
+            repo.executeDQL("SELECT count(*) as cnt FROM _statistics_.task_run_history");
+            result = resultBatch;
+        }};
+        assertEquals(123, history.getTaskRunCount());
+    }
+
+    @Test
+    public void testKeeper(@Mocked RepoExecutor repo) {
+        TableKeeper keeper = TableBasedTaskRunHistory.createKeeper();
+        assertEquals(StatsConstants.STATISTICS_DB_NAME, keeper.getDatabaseName());
+        assertEquals(TableBasedTaskRunHistory.TABLE_NAME, keeper.getTableName());
+        assertEquals(TableBasedTaskRunHistory.CREATE_TABLE, keeper.getCreateTableSql());
+        assertEquals(TableBasedTaskRunHistory.TABLE_REPLICAS, keeper.getTableReplicas());
+
+        // database not exists
+        new Expectations() {{
+            keeper.checkDatabaseExists();
+            result = false;
+        }};
+        keeper.run();
+        assertFalse(keeper.isDatabaseExisted());
+
+        // create table
+        keeper.setDatabaseExisted(true);
+        new Expectations() {{
+            repo.executeDDL(
+                    "CREATE TABLE task_run_history (id BIGINT NOT NULL auto_increment, task_id bigint NOT NULL, task_run_id string NOT NULL, task_name string NOT NULL, create_time datetime NOT NULL, finish_time datetime NOT NULL, expire_time datetime NOT NULL, history_content_json JSON NOT NULL)PRIMARY KEY (task_id, task_run_id) PARTITION BY RANGE(create_time) DISTRIBUTED BY HASH(id) BUCKETS 8 PROPERTIES('replication_num' = '1','dynamic_partition.time_unit' = 'DAY', 'dynamic_partition.start' = '-7', 'dynamic_partition.end' = '3', 'dynamic_partition.prefix' = 'p' ) ");
+        }};
+        keeper.run();
+        assertTrue(keeper.isTableExisted());
+        assertFalse(keeper.isTableCorrected());
+
+        new MockUp<SystemInfoService>() {
+            @Mock
+            public int getTotalBackendNumber() {
+                return 3;
+            }
+        };
+        // correct table replicas
+        keeper.run();
+        assertTrue(keeper.isTableCorrected());
+    }
+
+}

--- a/fe/fe-core/src/test/java/com/starrocks/scheduler/history/TableBasedTaskRunHistoryTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/scheduler/history/TableBasedTaskRunHistoryTest.java
@@ -59,20 +59,22 @@ class TableBasedTaskRunHistoryTest {
 
     @Test
     public void testCRUD(@Mocked RepoExecutor repo) {
-        new Expectations() {{
-            repo.executeDML(
-                    "INSERT INTO _statistics_.task_run_history (task_id, task_run_id, task_name, create_time, " +
-                            "finish_time, expire_time, history_content_json) VALUES(0, 'aaa', 't1', " +
-                            "'1970-01-01 08:00:00', '1970-01-01 08:00:00', '1970-01-01 08:00:00', " +
-                            "'{\"startTaskRunId\":\"aaa\",\"taskId\":0,\"taskName\":\"t1\",\"createTime\":0," +
-                            "\"finishTime\":0,\"processStartTime\":0,\"state\":\"PENDING\",\"progress\":0," +
-                            "\"errorCode\":0,\"expireTime\":0,\"priority\":0,\"mergeRedundant\":false," +
-                            "\"source\":\"CTAS\",\"mvExtraMessage\":{\"forceRefresh\":false,\"mvPartitionsToRefresh\":" +
-                            "[],\"refBasePartitionsToRefreshMap\":{},\"basePartitionsToRefreshMap\":{}," +
-                            "\"executeOption\":{\"priority\":0,\"isMergeRedundant\":false,\"isManual\":false," +
-                            "\"isSync\":false,\"isReplay\":false}}}')");
+        new Expectations() {
+            {
+                repo.executeDML(
+                        "INSERT INTO _statistics_.task_run_history (task_id, task_run_id, task_name, create_time, " +
+                                "finish_time, expire_time, history_content_json) VALUES(0, 'aaa', 't1', " +
+                                "'1970-01-01 08:00:00', '1970-01-01 08:00:00', '1970-01-01 08:00:00', " +
+                                "'{\"startTaskRunId\":\"aaa\",\"taskId\":0,\"taskName\":\"t1\",\"createTime\":0," +
+                                "\"finishTime\":0,\"processStartTime\":0,\"state\":\"PENDING\",\"progress\":0," +
+                                "\"errorCode\":0,\"expireTime\":0,\"priority\":0,\"mergeRedundant\":false," +
+                                "\"source\":\"CTAS\",\"mvExtraMessage\":{\"forceRefresh\":false,\"mvPartitionsToRefresh\":" +
+                                "[],\"refBasePartitionsToRefreshMap\":{},\"basePartitionsToRefreshMap\":{}," +
+                                "\"executeOption\":{\"priority\":0,\"isMergeRedundant\":false,\"isManual\":false," +
+                                "\"isSync\":false,\"isReplay\":false}}}')");
 
-        }};
+            }
+        };
 
         TableBasedTaskRunHistory history = new TableBasedTaskRunHistory();
         TaskRunStatus status = new TaskRunStatus();
@@ -81,33 +83,41 @@ class TableBasedTaskRunHistoryTest {
         history.addHistory(status);
 
         // getTaskByName
-        new Expectations() {{
-            repo.executeDQL("SELECT history_content_json " +
-                    "FROM _statistics_.task_run_history WHERE task_name = 't1'");
-        }};
+        new Expectations() {
+            {
+                repo.executeDQL("SELECT history_content_json " +
+                        "FROM _statistics_.task_run_history WHERE task_name = 't1'");
+            }
+        };
         history.getTaskByName("t1");
 
         // getTask
-        new Expectations() {{
-            repo.executeDQL("SELECT history_content_json " +
-                    "FROM _statistics_.task_run_history WHERE task_run_id = 't1'");
-        }};
+        new Expectations() {
+            {
+                repo.executeDQL("SELECT history_content_json " +
+                        "FROM _statistics_.task_run_history WHERE task_run_id = 't1'");
+            }
+        };
         history.getTask("t1");
 
         // getAllHistory
-        new Expectations() {{
-            repo.executeDQL("SELECT history_content_json FROM _statistics_.task_run_history");
-        }};
+        new Expectations() {
+            {
+                repo.executeDQL("SELECT history_content_json FROM _statistics_.task_run_history");
+            }
+        };
         history.getAllHistory();
 
         // getTaskRunCount
         TResultBatch batch = new TResultBatch();
         batch.setRows(Lists.newArrayList(ByteBuffer.wrap("[123]".getBytes())));
         List<TResultBatch> resultBatch = Lists.newArrayList(batch);
-        new Expectations() {{
-            repo.executeDQL("SELECT count(*) as cnt FROM _statistics_.task_run_history");
-            result = resultBatch;
-        }};
+        new Expectations() {
+            {
+                repo.executeDQL("SELECT count(*) as cnt FROM _statistics_.task_run_history");
+                result = resultBatch;
+            }
+        };
         assertEquals(123, history.getTaskRunCount());
     }
 
@@ -120,26 +130,30 @@ class TableBasedTaskRunHistoryTest {
         assertEquals(TableBasedTaskRunHistory.TABLE_REPLICAS, keeper.getTableReplicas());
 
         // database not exists
-        new Expectations() {{
-            keeper.checkDatabaseExists();
-            result = false;
-        }};
+        new Expectations() {
+            {
+                keeper.checkDatabaseExists();
+                result = false;
+            }
+        };
         keeper.run();
         assertFalse(keeper.isDatabaseExisted());
 
         // create table
         keeper.setDatabaseExisted(true);
-        new Expectations() {{
-            repo.executeDDL(
-                    "CREATE TABLE IF NOT EXISTS _statistics_.task_run_history (task_id bigint NOT NULL, " +
-                            "task_run_id string NOT NULL, create_time datetime NOT NULL, task_name string NOT NULL, " +
-                            "finish_time datetime NOT NULL, expire_time datetime NOT NULL, " +
-                            "history_content_json JSON NOT NULL)PRIMARY KEY (task_id, task_run_id, create_time) " +
-                            "PARTITION BY RANGE(create_time)() DISTRIBUTED BY HASH(task_id) BUCKETS 8 " +
-                            "PROPERTIES('replication_num' = '1','dynamic_partition.time_unit' = 'DAY', " +
-                            "'dynamic_partition.start' = '-7', 'dynamic_partition.end' = '3', " +
-                            "'dynamic_partition.prefix' = 'p' ) ");
-        }};
+        new Expectations() {
+            {
+                repo.executeDDL(
+                        "CREATE TABLE IF NOT EXISTS _statistics_.task_run_history (task_id bigint NOT NULL, " +
+                                "task_run_id string NOT NULL, create_time datetime NOT NULL, task_name string NOT NULL, " +
+                                "finish_time datetime NOT NULL, expire_time datetime NOT NULL, " +
+                                "history_content_json JSON NOT NULL)PRIMARY KEY (task_id, task_run_id, create_time) " +
+                                "PARTITION BY RANGE(create_time)() DISTRIBUTED BY HASH(task_id) BUCKETS 8 " +
+                                "PROPERTIES('replication_num' = '1','dynamic_partition.time_unit' = 'DAY', " +
+                                "'dynamic_partition.start' = '-7', 'dynamic_partition.end' = '3', " +
+                                "'dynamic_partition.prefix' = 'p' ) ");
+            }
+        };
         keeper.run();
         assertTrue(keeper.isTableExisted());
         assertFalse(keeper.isTableCorrected());

--- a/fe/fe-core/src/test/java/com/starrocks/scheduler/history/TableBasedTaskRunHistoryTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/scheduler/history/TableBasedTaskRunHistoryTest.java
@@ -132,7 +132,14 @@ class TableBasedTaskRunHistoryTest {
         keeper.setDatabaseExisted(true);
         new Expectations() {{
             repo.executeDDL(
-                    "CREATE TABLE task_run_history (id BIGINT NOT NULL auto_increment, task_id bigint NOT NULL, task_run_id string NOT NULL, task_name string NOT NULL, create_time datetime NOT NULL, finish_time datetime NOT NULL, expire_time datetime NOT NULL, history_content_json JSON NOT NULL)PRIMARY KEY (task_id, task_run_id) PARTITION BY RANGE(create_time) DISTRIBUTED BY HASH(id) BUCKETS 8 PROPERTIES('replication_num' = '1','dynamic_partition.time_unit' = 'DAY', 'dynamic_partition.start' = '-7', 'dynamic_partition.end' = '3', 'dynamic_partition.prefix' = 'p' ) ");
+                    "CREATE TABLE IF NOT EXISTS _statistics_.task_run_history (task_id bigint NOT NULL, " +
+                            "task_run_id string NOT NULL, create_time datetime NOT NULL, task_name string NOT NULL, " +
+                            "finish_time datetime NOT NULL, expire_time datetime NOT NULL, " +
+                            "history_content_json JSON NOT NULL)PRIMARY KEY (task_id, task_run_id, create_time) " +
+                            "PARTITION BY RANGE(create_time)() DISTRIBUTED BY HASH(task_id) BUCKETS 8 " +
+                            "PROPERTIES('replication_num' = '1','dynamic_partition.time_unit' = 'DAY', " +
+                            "'dynamic_partition.start' = '-7', 'dynamic_partition.end' = '3', " +
+                            "'dynamic_partition.prefix' = 'p' ) ");
         }};
         keeper.run();
         assertTrue(keeper.isTableExisted());

--- a/fe/fe-core/src/test/java/com/starrocks/scheduler/history/TableBasedTaskRunHistoryTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/scheduler/history/TableBasedTaskRunHistoryTest.java
@@ -82,22 +82,21 @@ class TableBasedTaskRunHistoryTest {
 
         // getTaskByName
         new Expectations() {{
-            repo.executeDQL("SELECT task_id, task_run_id, task_name, create_time, finish_time, expire_time, " +
-                    "history_content_json  FROM _statistics_.task_run_history WHERE task_name = 't1'");
+            repo.executeDQL("SELECT history_content_json " +
+                    "FROM _statistics_.task_run_history WHERE task_name = 't1'");
         }};
         history.getTaskByName("t1");
 
         // getTask
         new Expectations() {{
-            repo.executeDQL("SELECT task_id, task_run_id, task_name, create_time, finish_time, expire_time, " +
-                    "history_content_json  FROM _statistics_.task_run_history WHERE task_run_id = 't1'");
+            repo.executeDQL("SELECT history_content_json " +
+                    "FROM _statistics_.task_run_history WHERE task_run_id = 't1'");
         }};
         history.getTask("t1");
 
         // getAllHistory
         new Expectations() {{
-            repo.executeDQL("SELECT task_id, task_run_id, task_name, create_time, finish_time, expire_time, " +
-                    "history_content_json  FROM _statistics_.task_run_history");
+            repo.executeDQL("SELECT history_content_json FROM _statistics_.task_run_history");
         }};
         history.getAllHistory();
 

--- a/fe/fe-core/src/test/java/com/starrocks/scheduler/history/TableBasedTaskRunHistoryTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/scheduler/history/TableBasedTaskRunHistoryTest.java
@@ -89,15 +89,6 @@ class TableBasedTaskRunHistoryTest {
         };
         history.getTaskByName("t1");
 
-        // getTask
-        new Expectations() {
-            {
-                repo.executeDQL("SELECT history_content_json " +
-                        "FROM _statistics_.task_run_history WHERE task_run_id = 't1'");
-            }
-        };
-        history.getTask("t1");
-
         // getAllHistory
         new Expectations() {
             {


### PR DESCRIPTION
Why I'm doing:
- Now TaskRunHistory stores history in memory, which is inefficient and even dangerous

What I'm doing:
- Abstract the interface `TaskRunHistory`, along with two implementations `MemBasedTaskRunHistory` and `TableBasedTaskRunHistory`
- The `TablebasedTaskRunHistory` would store the data in a regular table called `_statistics_.task_run_history`
  - Keep 7 days of data, backboned with a dynamic-partitioned table
- The `MergeTaskRunHistory` to merge two history, to make it compatible when switch to new one
- The `TableKeeper` is responsible for creating this table

Compatibility:
- Introduce a switch `use_table_based_task_run_history` to control use which implementations. By default it's disabled
- After switching to the new one, the TableBased would be used, and `information_schema.task_runs` would return merged history
- Record whether use the TableHistory in each persisted `TaskRunStatus`, to avoid lost MemHistory

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [x] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
