### PR TITLE
[Doc] Remove dict_mapping from Release notes

### DIFF
--- a/docs/en/release_notes/release-3.2.md
+++ b/docs/en/release_notes/release-3.2.md
@@ -113,7 +113,7 @@ Added the following functions:
 - hash function: xx_hash3_64
 - Aggregate functions: approx_top_k
 - Window functions: cume_dist, percent_rank and session_number
-- Utility functions: get_query_profile
+- Utility functions: get_query_profile and is_role_in_session
 
 #### Privileges and security
 

--- a/docs/en/release_notes/release-3.2.md
+++ b/docs/en/release_notes/release-3.2.md
@@ -113,7 +113,7 @@ Added the following functions:
 - hash function: xx_hash3_64
 - Aggregate functions: approx_top_k
 - Window functions: cume_dist, percent_rank and session_number
-- Utility functions: dict_mapping and get_query_profile
+- Utility functions: get_query_profile
 
 #### Privileges and security
 

--- a/docs/zh/release_notes/release-3.2.md
+++ b/docs/zh/release_notes/release-3.2.md
@@ -112,7 +112,7 @@ displayed_sidebar: "Chinese"
 - hash 函数：xx_hash3_64
 - 聚合函数：approx_top_k
 - 窗口函数：cume_dist、percent_rank、session_number
-- 工具函数：dict_mapping、get_query_profile、is_role_in_session
+- 工具函数：get_query_profile、is_role_in_session
 
 #### 权限
 


### PR DESCRIPTION
Why I'm doing:

What I'm doing:

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [x] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
