### PR TITLE
[BugFix] Use correct mv's db after mv restore

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/backup/RestoreJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/backup/RestoreJob.java
@@ -1449,7 +1449,7 @@ public class RestoreJob extends AbstractJob {
                     if (tbl instanceof OlapTable) {
                         OlapTable olapTable = (OlapTable) tbl;
                         try {
-                            olapTable.doAfterRestore(db, mvRestoreContext);
+                            olapTable.doAfterRestore(mvRestoreContext);
                         } catch (Exception e) {
                             // no throw exceptions
                             LOG.warn(String.format("rebuild olap table %s failed: ", olapTable.getName()), e);

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/MaterializedView.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/MaterializedView.java
@@ -1776,12 +1776,11 @@ public class MaterializedView extends OlapTable implements GsonPreProcessable, G
      * Post actions after restore. Rebuild the materialized view by using table name instead of table ids
      * because the table ids have changed since the restore.
      *
-     * @param db : the new database after restore.
      * @return : rebuild status, ok if success other error status.
      */
     @Override
-    public Status doAfterRestore(Database db, MvRestoreContext mvRestoreContext) throws DdlException {
-        super.doAfterRestore(db, mvRestoreContext);
+    public Status doAfterRestore(MvRestoreContext mvRestoreContext) throws DdlException {
+        super.doAfterRestore(mvRestoreContext);
 
         if (baseTableInfos == null) {
             setInactiveAndReason("base mv is not active: base info is null");
@@ -1789,6 +1788,11 @@ public class MaterializedView extends OlapTable implements GsonPreProcessable, G
                     String.format("Materialized view %s's base info is not found", this.name));
         }
 
+        Database db = GlobalStateMgr.getCurrentState().getDb(dbId);
+        if (db == null) {
+            return new Status(Status.ErrCode.NOT_FOUND,
+                    String.format("Materialized view %s's db {} is not found", this.name, this.dbId));
+        }
         List<BaseTableInfo> newBaseTableInfos = Lists.newArrayList();
 
         boolean isSetInactive = false;

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/MaterializedView.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/MaterializedView.java
@@ -1791,7 +1791,7 @@ public class MaterializedView extends OlapTable implements GsonPreProcessable, G
         Database db = GlobalStateMgr.getCurrentState().getDb(dbId);
         if (db == null) {
             return new Status(Status.ErrCode.NOT_FOUND,
-                    String.format("Materialized view %s's db {} is not found", this.name, this.dbId));
+                    String.format("Materialized view %s's db %s is not found", this.name, this.dbId));
         }
         List<BaseTableInfo> newBaseTableInfos = Lists.newArrayList();
 

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/OlapTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/OlapTable.java
@@ -828,7 +828,7 @@ public class OlapTable extends Table {
         return Status.OK;
     }
 
-    public Status doAfterRestore(Database db, MvRestoreContext mvRestoreContext) throws DdlException {
+    public Status doAfterRestore(MvRestoreContext mvRestoreContext) throws DdlException {
         if (relatedMaterializedViews == null || relatedMaterializedViews.isEmpty()) {
             return Status.OK;
         }
@@ -859,7 +859,7 @@ public class OlapTable extends Table {
             }
             MaterializedView mv = (MaterializedView) mvTable;
             // Do this no matter whether mv is active or not to restore version map for mv rewrite.
-            mv.doAfterRestore(db, mvRestoreContext);
+            mv.doAfterRestore(mvRestoreContext);
         }
         return Status.OK;
     }

--- a/fe/fe-core/src/test/java/com/starrocks/backup/BackupJobMaterializedViewTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/backup/BackupJobMaterializedViewTest.java
@@ -410,7 +410,8 @@ public class BackupJobMaterializedViewTest {
         tableRefs.add(new TableRef(new TableName(UnitTestUtil.DB_NAME, "unknown_tbl"), null));
         tableRefs.add(new TableRef(new TableName(UnitTestUtil.DB_NAME, "unknown_mv"), null));
 
-        job = new BackupJob("mv_label_abnormal", dbId, UnitTestUtil.DB_NAME, tableRefs, 13600 * 1000, globalStateMgr, repo.getId());
+        job = new BackupJob("mv_label_abnormal", dbId, UnitTestUtil.DB_NAME, tableRefs, 13600 * 1000,
+                globalStateMgr, repo.getId());
         job.run();
         Assert.assertEquals(Status.ErrCode.NOT_FOUND, job.getStatus().getErrCode());
         Assert.assertEquals(BackupJobState.CANCELLED, job.getState());

--- a/fe/fe-core/src/test/java/com/starrocks/backup/BackupJobMaterializedViewTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/backup/BackupJobMaterializedViewTest.java
@@ -410,7 +410,7 @@ public class BackupJobMaterializedViewTest {
         tableRefs.add(new TableRef(new TableName(UnitTestUtil.DB_NAME, "unknown_tbl"), null));
         tableRefs.add(new TableRef(new TableName(UnitTestUtil.DB_NAME, "unknown_mv"), null));
 
-        job = new BackupJob(MV_LABEL, dbId, UnitTestUtil.DB_NAME, tableRefs, 13600 * 1000, globalStateMgr, repo.getId());
+        job = new BackupJob("mv_label_abnormal", dbId, UnitTestUtil.DB_NAME, tableRefs, 13600 * 1000, globalStateMgr, repo.getId());
         job.run();
         Assert.assertEquals(Status.ErrCode.NOT_FOUND, job.getStatus().getErrCode());
         Assert.assertEquals(BackupJobState.CANCELLED, job.getState());


### PR DESCRIPTION
Why I'm doing:

`doAfterRestore` should not depend on the restoring db because this may cause some werid bugs.

What I'm doing:
- Remove db param in the `doAfterRestoe`, use mv's db as real db and not depends on the restoring db.

Fixes https://github.com/StarRocks/StarRocksTest/issues/5681
[#issue](https://github.com/StarRocks/StarRocksTest/pull/5752)

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
