### PR TITLE
[UT] Revert "[Feature] Split storage test into separate file (#37634)"

### DIFF
--- a/be/test/CMakeLists.txt
+++ b/be/test/CMakeLists.txt
@@ -1,25 +1,4 @@
-# Copyright 2021-present StarRocks, Inc. All rights reserved.
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     https://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-
-#[[
-Currently, the unit tests for be are divided into two executable files: 
-starrocks_test_part1 and starrocks_test_part2. 
-When we try to perform all the tests with one executable file, 
-the binary size of the code exceeds the limit, which leads to linkage errors.
-]]
-
-set(EXEC_FILES_PART1
+set(EXEC_FILES
         ./agent/agent_task_test.cpp
         ./agent/master_info_test.cpp
         ./column/array_column_test.cpp
@@ -43,6 +22,13 @@ set(EXEC_FILES_PART1
         ./common/status_test.cpp
         ./common/tracer_test.cpp
         ./common/uri_test.cpp
+        ./fs/fs_broker_test.cpp
+        ./fs/fs_hdfs_test.cpp
+        ./fs/fs_posix_test.cpp
+        ./fs/fs_memory_test.cpp
+        ./fs/fs_s3_test.cpp
+        ./fs/fs_test.cpp
+        ./fs/output_stream_wrapper_test.cpp
         ./exec/column_value_range_test.cpp
         ./exec/es/es_query_builder_test.cpp
         ./exec/es/es_scan_reader_test.cpp
@@ -193,119 +179,6 @@ set(EXEC_FILES_PART1
         ./http/metrics_action_test.cpp
         ./http/stream_load_test.cpp
         ./http/transaction_stream_load_test.cpp
-        ./runtime/buffer_control_block_test.cpp
-        ./runtime/data_stream_mgr_test.cpp
-        ./runtime/datetime_value_test.cpp
-        ./runtime/decimalv2_value_test.cpp
-        ./runtime/decimalv3_test.cpp
-        ./runtime/external_scan_context_mgr_test.cpp
-        ./runtime/fragment_mgr_test.cpp
-        ./runtime/int128_arithmetic_ops_test.cpp
-        ./runtime/kafka_consumer_pipe_test.cpp
-        ./runtime/lake_tablets_channel_test.cpp
-        ./runtime/large_int_value_test.cpp
-        ./runtime/load_channel_test.cpp
-        ./runtime/memory/mem_chunk_allocator_test.cpp
-        ./runtime/memory/system_allocator_test.cpp
-        ./runtime/memory/memory_resource_test.cpp
-        ./runtime/mem_pool_test.cpp
-        ./runtime/result_queue_mgr_test.cpp
-        #./runtime/routine_load_task_executor_test.cpp
-        ./runtime/small_file_mgr_test.cpp
-        ./runtime/snapshot_loader_test.cpp
-        ./runtime/stream_load_pipe_test.cpp
-        ./runtime/string_value_test.cpp
-        ./runtime/type_descriptor_test.cpp
-        ./runtime/type_descriptor_test.cpp
-        ./runtime/user_function_cache_test.cpp
-        ./runtime/sorted_chunks_merger_test.cpp
-        ./runtime/merge_cascade_test.cpp
-        ./runtime/memory_scratch_sink_test_issue_8676.cpp
-        ./runtime/memory_scratch_sink_test.cpp
-        ./runtime/command_executor_test.cpp
-        ./runtime/exec_env_test.cpp
-        ./serde/column_array_serde_test.cpp
-        ./serde/protobuf_serde_test.cpp
-        ./types/bitmap_value_test.cpp
-        ./simd/batch_run_counter_test.cpp
-        ./simd/simd_test.cpp
-        ./simd/simd_selector_test.cpp
-        ./simd/simd_mulselector_test.cpp
-        ./util/phmap_test.cpp
-        ./util/aes_util_test.cpp
-        ./util/await_test.cpp
-        ./util/bitmap_test.cpp
-        ./util/bit_stream_utils_test.cpp
-        ./util/bit_util_test.cpp
-        ./util/block_compression_test.cpp
-        ./util/blocking_queue_test.cpp
-        ./util/brpc_stub_cache_test.cpp
-        ./util/bthreads/future_test.cpp
-        ./util/bthreads/promise_test.cpp
-        ./util/bthreads/semaphore_test.cpp
-        ./util/bthreads/shared_mutex_test.cpp
-        ./util/bthreads/shared_future_test.cpp
-        ./util/c_string_test.cpp
-        ./util/cidr_test.cpp
-        ./util/coding_test.cpp
-        ./util/core_local_test.cpp
-        ./util/countdown_latch_test.cpp
-        ./util/crc32c_test.cpp
-        ./util/dynamic_cache_test.cpp
-        ./util/exception_stack_test.cpp
-        ./util/fail_point_test.cpp
-        ./util/faststring_test.cpp
-        ./util/file_util_test.cpp
-        ./util/filesystem_util_test.cpp
-        ./util/frame_of_reference_coding_test.cpp
-        ./util/json_util_test.cpp
-        ./util/md5_test.cpp
-        ./util/monotime_test.cpp
-        ./util/mysql_row_buffer_test.cpp
-        ./util/new_metrics_test.cpp
-        ./util/parse_util_test.cpp
-        ./util/path_trie_test.cpp
-        ./util/path_util_test.cpp
-        ./util/priority_queue_test.cpp
-        ./util/rle_encoding_test.cpp
-        ./util/runtime_profile_test.cpp
-        ./util/scoped_cleanup_test.cpp
-        ./util/string_parser_test.cpp
-        ./util/string_util_test.cpp
-        ./util/tdigest_test.cpp
-        ./util/thread_test.cpp
-        ./util/trace_test.cpp
-        ./util/uid_util_test.cpp
-        ./util/utf8_check_test.cpp
-        ./util/int96_test.cpp
-        ./util/bit_packing_test.cpp
-        ./util/gc_helper_test.cpp
-        ./util/lru_cache_test.cpp
-        ./util/arrow/starrocks_column_to_arrow_test.cpp
-        ./util/starrocks_metrics_test.cpp
-        ./util/system_metrics_test.cpp
-        ./util/ratelimit_test.cpp
-        ./util/cpu_usage_info_test.cpp
-        ./util/timezone_utils_test.cpp
-        ./util/concurrent_limiter_test.cpp
-        ./util/stack_trace_mutex_test.cpp
-        ./gutil/cpu_test.cc
-        ./gutil/sysinfo-test.cc
-        ./service/lake_service_test.cpp
-        )
-
-if (USE_AVX2)
-    set(EXEC_FILES ${EXEC_FILES_PART1} ./column/avx_numeric_column_test.cpp)
-endif ()
-
-set(EXEC_FILES_PART2
-        ./fs/fs_broker_test.cpp
-        ./fs/fs_hdfs_test.cpp
-        ./fs/fs_posix_test.cpp
-        ./fs/fs_memory_test.cpp
-        ./fs/fs_s3_test.cpp
-        ./fs/fs_test.cpp
-        ./fs/output_stream_wrapper_test.cpp
         ./io/array_input_stream_test.cpp
         ./io/compressed_input_stream_test.cpp
         ./io/fd_output_stream_test.cpp
@@ -432,6 +305,105 @@ set(EXEC_FILES_PART2
         ./storage/get_use_pk_index_test.cpp
         ./storage/meta_reader_test.cpp
         ./storage/dictionary_cache_manager_test.cpp
+        ./runtime/buffer_control_block_test.cpp
+        ./runtime/data_stream_mgr_test.cpp
+        ./runtime/datetime_value_test.cpp
+        ./runtime/decimalv2_value_test.cpp
+        ./runtime/decimalv3_test.cpp
+        ./runtime/external_scan_context_mgr_test.cpp
+        ./runtime/fragment_mgr_test.cpp
+        ./runtime/int128_arithmetic_ops_test.cpp
+        ./runtime/kafka_consumer_pipe_test.cpp
+        ./runtime/lake_tablets_channel_test.cpp
+        ./runtime/large_int_value_test.cpp
+        ./runtime/load_channel_test.cpp
+        ./runtime/memory/mem_chunk_allocator_test.cpp
+        ./runtime/memory/system_allocator_test.cpp
+        ./runtime/memory/memory_resource_test.cpp
+        ./runtime/mem_pool_test.cpp
+        ./runtime/result_queue_mgr_test.cpp
+        #./runtime/routine_load_task_executor_test.cpp
+        ./runtime/small_file_mgr_test.cpp
+        ./runtime/snapshot_loader_test.cpp
+        ./runtime/stream_load_pipe_test.cpp
+        ./runtime/string_value_test.cpp
+        ./runtime/type_descriptor_test.cpp
+        ./runtime/type_descriptor_test.cpp
+        ./runtime/user_function_cache_test.cpp
+        ./runtime/sorted_chunks_merger_test.cpp
+        ./runtime/merge_cascade_test.cpp
+        ./runtime/memory_scratch_sink_test_issue_8676.cpp
+        ./runtime/memory_scratch_sink_test.cpp
+        ./runtime/command_executor_test.cpp
+        ./runtime/exec_env_test.cpp
+        ./serde/column_array_serde_test.cpp
+        ./serde/protobuf_serde_test.cpp
+        ./types/bitmap_value_test.cpp
+        ./simd/batch_run_counter_test.cpp
+        ./simd/simd_test.cpp
+        ./simd/simd_selector_test.cpp
+        ./simd/simd_mulselector_test.cpp
+        ./util/phmap_test.cpp
+        ./util/aes_util_test.cpp
+        ./util/await_test.cpp
+        ./util/bitmap_test.cpp
+        ./util/bit_stream_utils_test.cpp
+        ./util/bit_util_test.cpp
+        ./util/block_compression_test.cpp
+        ./util/blocking_queue_test.cpp
+        ./util/brpc_stub_cache_test.cpp
+        ./util/bthreads/future_test.cpp
+        ./util/bthreads/promise_test.cpp
+        ./util/bthreads/semaphore_test.cpp
+        ./util/bthreads/shared_mutex_test.cpp
+        ./util/bthreads/shared_future_test.cpp
+        ./util/c_string_test.cpp
+        ./util/cidr_test.cpp
+        ./util/coding_test.cpp
+        ./util/core_local_test.cpp
+        ./util/countdown_latch_test.cpp
+        ./util/crc32c_test.cpp
+        ./util/dynamic_cache_test.cpp
+        ./util/exception_stack_test.cpp
+        ./util/fail_point_test.cpp
+        ./util/faststring_test.cpp
+        ./util/file_util_test.cpp
+        ./util/filesystem_util_test.cpp
+        ./util/frame_of_reference_coding_test.cpp
+        ./util/json_util_test.cpp
+        ./util/md5_test.cpp
+        ./util/monotime_test.cpp
+        ./util/mysql_row_buffer_test.cpp
+        ./util/new_metrics_test.cpp
+        ./util/parse_util_test.cpp
+        ./util/path_trie_test.cpp
+        ./util/path_util_test.cpp
+        ./util/priority_queue_test.cpp
+        ./util/rle_encoding_test.cpp
+        ./util/runtime_profile_test.cpp
+        ./util/scoped_cleanup_test.cpp
+        ./util/string_parser_test.cpp
+        ./util/string_util_test.cpp
+        ./util/tdigest_test.cpp
+        ./util/thread_test.cpp
+        ./util/trace_test.cpp
+        ./util/uid_util_test.cpp
+        ./util/utf8_check_test.cpp
+        ./util/int96_test.cpp
+        ./util/bit_packing_test.cpp
+        ./util/gc_helper_test.cpp
+        ./util/lru_cache_test.cpp
+        ./util/arrow/starrocks_column_to_arrow_test.cpp
+        ./util/starrocks_metrics_test.cpp
+        ./util/system_metrics_test.cpp
+        ./util/ratelimit_test.cpp
+        ./util/cpu_usage_info_test.cpp
+        ./util/timezone_utils_test.cpp
+        ./util/concurrent_limiter_test.cpp
+        ./util/stack_trace_mutex_test.cpp
+        ./gutil/cpu_test.cc
+        ./gutil/sysinfo-test.cc
+        ./service/lake_service_test.cpp
         ./storage/compaction_parallelization_test.cpp
         ./storage/lake/persistent_index_memtable_test.cpp
         ./storage/lake/lake_persistent_index_test.cpp
@@ -439,31 +411,24 @@ set(EXEC_FILES_PART2
         )
 
 if ("${WITH_STARCACHE}" STREQUAL "ON" OR "${WITH_CACHELIB}" STREQUAL "ON")
-    list(APPEND EXEC_FILES_PART2 ./block_cache/block_cache_test.cpp)
-    list(APPEND EXEC_FILES_PART2 ./io/cache_input_stream_test.cpp)
+    list(APPEND EXEC_FILES ./block_cache/block_cache_test.cpp)
+    list(APPEND EXEC_FILES ./io/cache_input_stream_test.cpp)
 endif ()
 
 if ("${USE_STAROS}" STREQUAL "ON")
-    list(APPEND EXEC_FILES_PART2 ./fs/fs_starlet_test.cpp)
-    list(APPEND EXEC_FILES_PART2 ./storage/lake/local_pk_index_manager_test.cpp)
+    list(APPEND EXEC_FILES ./fs/fs_starlet_test.cpp)
+    list(APPEND EXEC_FILES ./storage/lake/local_pk_index_manager_test.cpp)
 endif ()
 
-add_library(starrocks_test_objs_part1 OBJECT ${EXEC_FILES_PART1})
-SET_TARGET_PROPERTIES(starrocks_test_objs_part1 PROPERTIES COMPILE_FLAGS "-fno-access-control")
-add_executable(starrocks_test_part1 test_main.cpp $<TARGET_OBJECTS:starrocks_test_objs_part1>)
+if (USE_AVX2)
+    set(EXEC_FILES ${EXEC_FILES} ./column/avx_numeric_column_test.cpp)
+endif ()
 
-add_library(starrocks_test_objs_part2 OBJECT ${EXEC_FILES_PART2})
-SET_TARGET_PROPERTIES(starrocks_test_objs_part2 PROPERTIES COMPILE_FLAGS "-fno-access-control")
-add_executable(starrocks_test_part2 test_main.cpp $<TARGET_OBJECTS:starrocks_test_objs_part2>)
+add_library(starrocks_test_objs OBJECT ${EXEC_FILES})
+SET_TARGET_PROPERTIES(starrocks_test_objs PROPERTIES COMPILE_FLAGS "-fno-access-control")
+add_executable(starrocks_test test_main.cpp $<TARGET_OBJECTS:starrocks_test_objs>)
 
-TARGET_LINK_LIBRARIES(starrocks_test_part1 ${TEST_LINK_LIBS})
-TARGET_LINK_LIBRARIES(starrocks_test_part2 ${TEST_LINK_LIBS})
-
-# starrocks_test_part1" and "starrocks_test_part2" are two large binary files that 
-# may cause OOM error during parallel linking in CI. 
-# The "add_dependencies" function can force "starrocks_test_part2" to compile 
-# in series after "starrocks_test_part1", thereby avoiding OOM incidents.
-add_dependencies(starrocks_test_part2 starrocks_test_part1)
+TARGET_LINK_LIBRARIES(starrocks_test ${TEST_LINK_LIBS})
 
 # =================================================
 # test cases must be compiled as a standalone binary

--- a/run-be-ut.sh
+++ b/run-be-ut.sh
@@ -263,9 +263,8 @@ if [ -d ${STARROCKS_TEST_BINARY_DIR}/util/test_data ]; then
 fi
 cp -r ${STARROCKS_HOME}/be/test/util/test_data ${STARROCKS_TEST_BINARY_DIR}/util/
 
-test_files=`find ${STARROCKS_TEST_BINARY_DIR} -type f -perm -111 -name "*test*" \
-    | grep -v starrocks_test_part1 \
-    | grep -v starrocks_test_part2 \
+test_files=`find ${STARROCKS_TEST_BINARY_DIR} -type f -perm -111 -name "*test" \
+    | grep -v starrocks_test \
     | grep -v bench_test \
     | grep -e "$TEST_MODULE" `
 
@@ -273,18 +272,14 @@ echo "[INFO] gtest_filter: $TEST_NAME"
 # run cases in starrocks_test in parallel if has gtest-parallel script.
 # reference: https://github.com/google/gtest-parallel
 if [[ $TEST_MODULE == '.*'  || $TEST_MODULE == 'starrocks_test' ]]; then
-  echo "Run test: ${STARROCKS_TEST_BINARY_DIR}/starrocks_test_part1 ${STARROCKS_TEST_BINARY_DIR}/starrocks_test_part2"
+  echo "Run test: ${STARROCKS_TEST_BINARY_DIR}/starrocks_test"
   if [ ${DRY_RUN} -eq 0 ]; then
     if [ -x "${GTEST_PARALLEL}" ]; then
-        ${GTEST_PARALLEL} ${STARROCKS_TEST_BINARY_DIR}/starrocks_test_part1 \
-            --gtest_filter=${TEST_NAME} \
-            --serialize_test_cases ${GTEST_PARALLEL_OPTIONS}
-        ${GTEST_PARALLEL} ${STARROCKS_TEST_BINARY_DIR}/starrocks_test_part2 \
+        ${GTEST_PARALLEL} ${STARROCKS_TEST_BINARY_DIR}/starrocks_test \
             --gtest_filter=${TEST_NAME} \
             --serialize_test_cases ${GTEST_PARALLEL_OPTIONS}
     else
-        ${STARROCKS_TEST_BINARY_DIR}/starrocks_test_part1 $GTEST_OPTIONS --gtest_filter=${TEST_NAME}
-        ${STARROCKS_TEST_BINARY_DIR}/starrocks_test_part2 $GTEST_OPTIONS --gtest_filter=${TEST_NAME}
+        ${STARROCKS_TEST_BINARY_DIR}/starrocks_test $GTEST_OPTIONS --gtest_filter=${TEST_NAME}
     fi
   fi
 fi


### PR DESCRIPTION
* merge the test binary back into one, reduce link time cost

This reverts commit 7146d59759777e52a5e3f345de9d353d3b4c8ac9.

Why I'm doing:

What I'm doing:

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [X] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [X] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [X] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
