### PR TITLE
[BugFix] Fix some bugs for mv metrics

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/http/rest/MetricsAction.java
+++ b/fe/fe-core/src/main/java/com/starrocks/http/rest/MetricsAction.java
@@ -141,7 +141,7 @@ public class MetricsAction extends RestBaseAction {
             UserIdentity currentUser = null;
             try {
                 ActionAuthorizationInfo authInfo = getAuthorizationInfo(request);
-                // Only check password and need admin root to collect table/mv level metrics.
+                // check user password and need admin root to collect table/mv level metrics.
                 currentUser = checkPassword(authInfo);
                 checkUserOwnsAdminRole(currentUser);
             } catch (AccessDeniedException e) {

--- a/fe/fe-core/src/main/java/com/starrocks/http/rest/MetricsAction.java
+++ b/fe/fe-core/src/main/java/com/starrocks/http/rest/MetricsAction.java
@@ -133,14 +133,8 @@ public class MetricsAction extends RestBaseAction {
     protected RequestParams parseRequestParams(BaseRequest request) {
         String withTableMetrics = request.getSingleParameter(WITH_TABLE_METRICS_PARAM);
         String withMaterializedViewsMetrics = request.getSingleParameter(WITH_MATERIALIZED_VIEW_METRICS_PARAM);
-        /*
-         * Collect tableMetrics and MVMetrics in minified way by default.
-         * Full metrics collection is only enabled when the following conditions are all satisfied
-         * - explicitly has `?with_table_metrics=all` or `?with_materialized_view_metrics=all`
-         * - the user must have sufficient privileges by checking the request auth info
-         */
-        boolean collectTableMetrics = COLLECT_MODE_METRICS_ALL.equalsIgnoreCase(withTableMetrics);
-        boolean collectMVMetrics = COLLECT_MODE_METRICS_ALL.equalsIgnoreCase(withMaterializedViewsMetrics);
+        boolean collectTableMetrics = !Strings.isNullOrEmpty(withTableMetrics);
+        boolean collectMVMetrics = !Strings.isNullOrEmpty(withMaterializedViewsMetrics);
 
         // check request authorization
         if (collectTableMetrics || collectMVMetrics) {

--- a/fe/fe-core/src/main/java/com/starrocks/http/rest/MetricsAction.java
+++ b/fe/fe-core/src/main/java/com/starrocks/http/rest/MetricsAction.java
@@ -157,7 +157,6 @@ public class MetricsAction extends RestBaseAction {
             UserIdentity currentUser = null;
             try {
                 ActionAuthorizationInfo authInfo = getAuthorizationInfo(request);
-                // check current user need admin root to collect table/mv level metrics.
                 currentUser = checkPassword(authInfo);
                 checkUserOwnsAdminRole(currentUser);
             } catch (AccessDeniedException e) {

--- a/fe/fe-core/src/main/java/com/starrocks/http/rest/MetricsAction.java
+++ b/fe/fe-core/src/main/java/com/starrocks/http/rest/MetricsAction.java
@@ -141,8 +141,9 @@ public class MetricsAction extends RestBaseAction {
             UserIdentity currentUser = null;
             try {
                 ActionAuthorizationInfo authInfo = getAuthorizationInfo(request);
-                // Only check password and no need admin root, otherwise the request privilege is too big.
+                // Only check password and need admin root to collect table/mv level metrics.
                 currentUser = checkPassword(authInfo);
+                checkUserOwnsAdminRole(currentUser);
             } catch (AccessDeniedException e) {
                 // disable Table related metrics collection due to AccessDenied
                 collectTableMetrics = false;

--- a/fe/fe-core/src/main/java/com/starrocks/http/rest/MetricsAction.java
+++ b/fe/fe-core/src/main/java/com/starrocks/http/rest/MetricsAction.java
@@ -35,6 +35,7 @@
 package com.starrocks.http.rest;
 
 import com.google.common.base.Strings;
+import com.google.common.collect.ImmutableSet;
 import com.starrocks.common.DdlException;
 import com.starrocks.http.ActionController;
 import com.starrocks.http.BaseRequest;
@@ -51,6 +52,8 @@ import io.netty.handler.codec.http.HttpMethod;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
+import java.util.Set;
+
 //fehost:port/metrics
 //fehost:port/metrics?type=core
 //fehost:port/metrics?type=json
@@ -64,6 +67,8 @@ public class MetricsAction extends RestBaseAction {
     protected static final String WITH_MATERIALIZED_VIEW_METRICS_PARAM = "with_materialized_view_metrics";
     protected static final String COLLECT_MODE_METRICS_MINIFIED = "minified";
     protected static final String COLLECT_MODE_METRICS_ALL = "all";
+    protected static final Set<String> SUPPORTED_COLLECT_METRIC_MODES =
+            ImmutableSet.of(COLLECT_MODE_METRICS_ALL, COLLECT_MODE_METRICS_MINIFIED);
     public static final String API_PATH = "/metrics";
 
     public MetricsAction(ActionController controller) {
@@ -130,24 +135,35 @@ public class MetricsAction extends RestBaseAction {
         sendResult(request, response);
     }
 
+    private boolean isCollectTableOrMVMetrics(String collectMode) {
+        if (Strings.isNullOrEmpty(collectMode)) {
+            return false;
+        }
+        return SUPPORTED_COLLECT_METRIC_MODES.stream().allMatch(m -> m.equalsIgnoreCase(collectMode));
+    }
+
+    private boolean isCollectTableOrMVMetricsMinifiedMode(String collectMode) {
+        return COLLECT_MODE_METRICS_MINIFIED.equalsIgnoreCase(collectMode);
+    }
+
     protected RequestParams parseRequestParams(BaseRequest request) {
         String withTableMetrics = request.getSingleParameter(WITH_TABLE_METRICS_PARAM);
         String withMaterializedViewsMetrics = request.getSingleParameter(WITH_MATERIALIZED_VIEW_METRICS_PARAM);
-        boolean collectTableMetrics = !Strings.isNullOrEmpty(withTableMetrics);
-        boolean collectMVMetrics = !Strings.isNullOrEmpty(withMaterializedViewsMetrics);
+        boolean isCollectTableMetrics = isCollectTableOrMVMetrics(withTableMetrics);
+        boolean isCollectMVMetrics = isCollectTableOrMVMetrics(withMaterializedViewsMetrics);
 
         // check request authorization
-        if (collectTableMetrics || collectMVMetrics) {
+        if (isCollectTableMetrics || isCollectMVMetrics) {
             UserIdentity currentUser = null;
             try {
                 ActionAuthorizationInfo authInfo = getAuthorizationInfo(request);
-                // check user password and need admin root to collect table/mv level metrics.
+                // check current user need admin root to collect table/mv level metrics.
                 currentUser = checkPassword(authInfo);
                 checkUserOwnsAdminRole(currentUser);
             } catch (AccessDeniedException e) {
                 // disable Table related metrics collection due to AccessDenied
-                collectTableMetrics = false;
-                collectMVMetrics = false;
+                isCollectTableMetrics = false;
+                isCollectMVMetrics = false;
                 LOG.warn("Auth failure when getting table level metrics, current user: {}, error msg: {}",
                         currentUser, e.getMessage());
             }
@@ -159,10 +175,9 @@ public class MetricsAction extends RestBaseAction {
          * - explicitly has `?with_table_metrics=all` or `?with_materialized_view_metrics=all`
          * - the user must have sufficient privileges by checking the request auth info
          */
-        boolean collectAllTableMetrics = COLLECT_MODE_METRICS_ALL.equalsIgnoreCase(withTableMetrics);
-        boolean collectAllMVMetrics = COLLECT_MODE_METRICS_ALL.equalsIgnoreCase(withMaterializedViewsMetrics);
-        boolean minifyTableMetrics = !collectAllTableMetrics;
-        boolean minifyMVMetrics = !collectAllMVMetrics;
-        return new RequestParams(collectTableMetrics, minifyTableMetrics, collectMVMetrics, minifyMVMetrics);
+        boolean isCollectTableMetricsMinifiedMode = isCollectTableOrMVMetricsMinifiedMode(withTableMetrics);
+        boolean isCollectMVMetricsMinifiedMode = isCollectTableOrMVMetricsMinifiedMode(withMaterializedViewsMetrics);
+        return new RequestParams(isCollectTableMetrics, isCollectTableMetricsMinifiedMode,
+                isCollectMVMetrics, isCollectMVMetricsMinifiedMode);
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/http/rest/MetricsAction.java
+++ b/fe/fe-core/src/main/java/com/starrocks/http/rest/MetricsAction.java
@@ -139,7 +139,7 @@ public class MetricsAction extends RestBaseAction {
         if (Strings.isNullOrEmpty(collectMode)) {
             return false;
         }
-        return SUPPORTED_COLLECT_METRIC_MODES.stream().allMatch(m -> m.equalsIgnoreCase(collectMode));
+        return SUPPORTED_COLLECT_METRIC_MODES.stream().anyMatch(m -> m.equalsIgnoreCase(collectMode));
     }
 
     private boolean isCollectTableOrMVMetricsMinifiedMode(String collectMode) {

--- a/fe/fe-core/src/main/java/com/starrocks/metric/MaterializedViewMetricsEntity.java
+++ b/fe/fe-core/src/main/java/com/starrocks/metric/MaterializedViewMetricsEntity.java
@@ -82,7 +82,7 @@ public final class MaterializedViewMetricsEntity {
     // the current materialized view's partition count, 0 if the materialized view is not partitioned
     public GaugeMetric<Integer> counterPartitionCount;
 
-    // histogram
+    // histogram(ms)
     // record the materialized view's refresh job duration only if it's refreshed successfully.
     public Histogram histRefreshJobDuration;
 

--- a/fe/fe-core/src/main/java/com/starrocks/metric/MaterializedViewMetricsRegistry.java
+++ b/fe/fe-core/src/main/java/com/starrocks/metric/MaterializedViewMetricsRegistry.java
@@ -79,10 +79,6 @@ public class MaterializedViewMetricsRegistry {
                         if (null == m.getValue()) {
                             continue;
                         }
-                        // GAUGE metrics is a bit heavy, skip it when in mini mode.
-                        if (Metric.MetricType.GAUGE == m.type) {
-                            continue;
-                        }
                         if (Metric.MetricType.COUNTER == m.type && ((Long) m.getValue()).longValue() == 0L) {
                             continue;
                         }
@@ -93,11 +89,17 @@ public class MaterializedViewMetricsRegistry {
                     visitor.visit(m);
                 }
             }
+        }
 
-            for (Map.Entry<String, Histogram> e : MaterializedViewMetricsRegistry.getInstance()
-                    .metricRegistry.getHistograms().entrySet()) {
-                visitor.visitHistogram(e.getKey(), e.getValue());
+        // Histogram metrics should only output once
+        for (Map.Entry<String, Histogram> e : MaterializedViewMetricsRegistry.getInstance()
+                .metricRegistry.getHistograms().entrySet()) {
+            if (minifyMetrics) {
+                if (e.getValue().getCount() == 0) {
+                    continue;
+                }
             }
+            visitor.visitHistogram(e.getKey(), e.getValue());
         }
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/http/MetricsActionTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/http/MetricsActionTest.java
@@ -64,9 +64,9 @@ public class MetricsActionTest {
             MetricsAction.RequestParams params = action.callParseRequestParams(request);
             Assert.assertNotNull(params);
             Assert.assertFalse(params.isCollectMVMetrics());
-            Assert.assertTrue(params.isMinifyMVMetrics());
+            Assert.assertFalse(params.isMinifyMVMetrics());
             Assert.assertFalse(params.isCollectTableMetrics());
-            Assert.assertTrue(params.isMinifyTableMetrics());
+            Assert.assertFalse(params.isMinifyTableMetrics());
         }
 
         // All default, want table_metrics, but no auth
@@ -83,7 +83,7 @@ public class MetricsActionTest {
             Assert.assertNotNull(params);
             // no auth should not access mv metrics
             Assert.assertFalse(params.isCollectMVMetrics());
-            Assert.assertTrue(params.isMinifyMVMetrics());
+            Assert.assertFalse(params.isMinifyMVMetrics());
             // no auth should not access table metrics
             Assert.assertFalse(params.isCollectTableMetrics());
             Assert.assertFalse(params.isMinifyTableMetrics());
@@ -103,7 +103,7 @@ public class MetricsActionTest {
             MetricsAction.RequestParams params = action.callParseRequestParams(request);
             Assert.assertNotNull(params);
             Assert.assertFalse(params.isCollectMVMetrics());
-            Assert.assertTrue(params.isMinifyMVMetrics());
+            Assert.assertFalse(params.isMinifyMVMetrics());
             Assert.assertTrue(params.isCollectTableMetrics());
             Assert.assertFalse(params.isMinifyTableMetrics());
         }
@@ -144,7 +144,7 @@ public class MetricsActionTest {
             Assert.assertFalse(params.isMinifyMVMetrics());
             // no auth should not access table metrics
             Assert.assertFalse(params.isCollectTableMetrics());
-            Assert.assertTrue(params.isMinifyTableMetrics());
+            Assert.assertFalse(params.isMinifyTableMetrics());
         }
 
         // All default, has query parameter, has auth, only with_materialized_view_metrics
@@ -163,7 +163,7 @@ public class MetricsActionTest {
             Assert.assertTrue(params.isCollectMVMetrics());
             Assert.assertFalse(params.isMinifyMVMetrics());
             Assert.assertFalse(params.isCollectTableMetrics());
-            Assert.assertTrue(params.isMinifyTableMetrics());
+            Assert.assertFalse(params.isMinifyTableMetrics());
         }
 
         // All default, has query parameter, has auth, only with_materialized_view_metrics
@@ -182,7 +182,7 @@ public class MetricsActionTest {
             Assert.assertTrue(params.isCollectMVMetrics());
             Assert.assertTrue(params.isMinifyMVMetrics());
             Assert.assertFalse(params.isCollectTableMetrics());
-            Assert.assertTrue(params.isMinifyTableMetrics());
+            Assert.assertFalse(params.isMinifyTableMetrics());
         }
 
         // All default, has query parameter, has auth, both with_table_metrics and with_materialized_view_metrics

--- a/fe/fe-core/src/test/java/com/starrocks/http/MetricsActionTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/http/MetricsActionTest.java
@@ -81,11 +81,12 @@ public class MetricsActionTest {
             };
             MetricsAction.RequestParams params = action.callParseRequestParams(request);
             Assert.assertNotNull(params);
+            // no auth should not access mv metrics
             Assert.assertFalse(params.isCollectMVMetrics());
             Assert.assertTrue(params.isMinifyMVMetrics());
-            // still minified way collecting table metrics
+            // no auth should not access table metrics
             Assert.assertFalse(params.isCollectTableMetrics());
-            Assert.assertTrue(params.isMinifyTableMetrics());
+            Assert.assertFalse(params.isMinifyTableMetrics());
         }
 
         // All default, has query parameter, has auth, only with_table_metrics
@@ -124,6 +125,83 @@ public class MetricsActionTest {
             Assert.assertFalse(params.isMinifyMVMetrics());
             Assert.assertTrue(params.isCollectTableMetrics());
             Assert.assertFalse(params.isMinifyTableMetrics());
+        }
+
+        // All default, want table_metrics, but no auth
+        {
+            BaseRequest request = buildBaseRequest("/metrics?with_materialized_view_metrics=all", false);
+            // expect check auth
+            new Expectations(request) {
+                {
+                    request.getAuthorizationHeader();
+                    minTimes = 1;
+                }
+            };
+            MetricsAction.RequestParams params = action.callParseRequestParams(request);
+            Assert.assertNotNull(params);
+            // no auth should not access mv metrics
+            Assert.assertFalse(params.isCollectMVMetrics());
+            Assert.assertFalse(params.isMinifyMVMetrics());
+            // no auth should not access table metrics
+            Assert.assertFalse(params.isCollectTableMetrics());
+            Assert.assertTrue(params.isMinifyTableMetrics());
+        }
+
+        // All default, has query parameter, has auth, only with_materialized_view_metrics
+        {
+            BaseRequest request = buildBaseRequest("/metrics?with_materialized_view_metrics=all", true);
+            // expect check auth
+            new Expectations(request) {
+                {
+                    // auth passed, retrieve the remote host from the request context
+                    request.getHostString();
+                    result = "127.0.0.1";
+                }
+            };
+            MetricsAction.RequestParams params = action.callParseRequestParams(request);
+            Assert.assertNotNull(params);
+            Assert.assertTrue(params.isCollectMVMetrics());
+            Assert.assertFalse(params.isMinifyMVMetrics());
+            Assert.assertFalse(params.isCollectTableMetrics());
+            Assert.assertTrue(params.isMinifyTableMetrics());
+        }
+
+        // All default, has query parameter, has auth, only with_materialized_view_metrics
+        {
+            BaseRequest request = buildBaseRequest("/metrics?with_materialized_view_metrics=minified", true);
+            // expect check auth
+            new Expectations(request) {
+                {
+                    // auth passed, retrieve the remote host from the request context
+                    request.getHostString();
+                    result = "127.0.0.1";
+                }
+            };
+            MetricsAction.RequestParams params = action.callParseRequestParams(request);
+            Assert.assertNotNull(params);
+            Assert.assertTrue(params.isCollectMVMetrics());
+            Assert.assertTrue(params.isMinifyMVMetrics());
+            Assert.assertFalse(params.isCollectTableMetrics());
+            Assert.assertTrue(params.isMinifyTableMetrics());
+        }
+
+        // All default, has query parameter, has auth, both with_table_metrics and with_materialized_view_metrics
+        {
+            BaseRequest request =
+                    buildBaseRequest("/metrics?with_table_metrics=minified&with_materialized_view_metrics=minified", true);
+            new Expectations(request) {
+                {
+                    // auth passed, retrieve the remote host from the request context
+                    request.getHostString();
+                    result = "127.0.0.1";
+                }
+            };
+            MetricsAction.RequestParams params = action.callParseRequestParams(request);
+            Assert.assertNotNull(params);
+            Assert.assertTrue(params.isCollectMVMetrics());
+            Assert.assertTrue(params.isMinifyMVMetrics());
+            Assert.assertTrue(params.isCollectTableMetrics());
+            Assert.assertTrue(params.isMinifyTableMetrics());
         }
     }
 }


### PR DESCRIPTION
Why I'm doing:
- Fix some bugs when using mv metrics

What I'm doing:
- to be better use for mv metrics


Usage

By default, materialized view's metrics are not collected because extra metrics will add some overload to your system and add extra collection time for metrics.
MaterializedView Metrics need to check HTTP request Authorization because those metrics will expose all materailzied views information. You need to add `Authorization` header in your HTTP GET request.
NOTE:  Normal users can request materialized view metrics, no need root/admin role.


HTTP
```
curl --user root: http://<fe ip>:<port>/metrics\?with_materialized_view_metrics\=all
```

Counter metrics:
```
starrocks_fe_mv_refresh_total_success_jobs{db_name="test_mv_async_backup_d765f0ae_b453_11ee_aab2_2586a6fea491", mv_name="mv1", mv_id="42879"} 1
starrocks_fe_mv_refresh_pending_jobs{db_name="test_mv_async_backup_d765f0ae_b453_11ee_aab2_2586a6fea491", mv_name="mv1", mv_id="42879"} 0
starrocks_fe_mv_refresh_running_jobs{db_name="test_mv_async_backup_d765f0ae_b453_11ee_aab2_2586a6fea491", mv_name="mv1", mv_id="42879"} 0
```

Guage metrics:
```
starrocks_fe_mv_row_count{db_name="test_backup_mv_4a8cb7e2_b502_11ee_aab2_2586a6fea491", mv_name="aggregate_table_with_null_mv1", mv_id="112970"} 65537
starrocks_fe_mv_storage_size{db_name="test_backup_mv_4a8cb7e2_b502_11ee_aab2_2586a6fea491", mv_name="aggregate_table_with_null_mv1", mv_id="112970"} 1352475
starrocks_fe_mv_inactive_state{db_name="test_backup_mv_4a8cb7e2_b502_11ee_aab2_2586a6fea491", mv_name="aggregate_table_with_null_mv1", mv_id="112970"} 0
```
Histogram metrics:
```
# HELP starrocks_fe_mv_refresh_duration_test_mv_async_backup_d765f0ae_b453_11ee_aab2_2586a6fea491_mv1 
# TYPE starrocks_fe_mv_refresh_duration_test_mv_async_backup_d765f0ae_b453_11ee_aab2_2586a6fea491_mv1 summary
starrocks_fe_mv_refresh_duration_test_mv_async_backup_d765f0ae_b453_11ee_aab2_2586a6fea491_mv1{quantile="0.75"} 6033.0
starrocks_fe_mv_refresh_duration_test_mv_async_backup_d765f0ae_b453_11ee_aab2_2586a6fea491_mv1{quantile="0.95"} 6033.0
starrocks_fe_mv_refresh_duration_test_mv_async_backup_d765f0ae_b453_11ee_aab2_2586a6fea491_mv1{quantile="0.98"} 6033.0
starrocks_fe_mv_refresh_duration_test_mv_async_backup_d765f0ae_b453_11ee_aab2_2586a6fea491_mv1{quantile="0.99"} 6033.0
starrocks_fe_mv_refresh_duration_test_mv_async_backup_d765f0ae_b453_11ee_aab2_2586a6fea491_mv1{quantile="0.999"} 6033.0
starrocks_fe_mv_refresh_duration_test_mv_async_backup_d765f0ae_b453_11ee_aab2_2586a6fea491_mv1_sum 6033.0
starrocks_fe_mv_refresh_duration_test_mv_async_backup_d765f0ae_b453_11ee_aab2_2586a6fea491_mv1_count 1
```

Prometheus

see: https://docs.starrocks.io/docs/administration/Monitor_and_Alert/#deployment
You can control this by changing your Prometheus config  like this:
```
# cat prometheus.yml
# my global config
global:
  scrape_interval:     15s # 全局的采集间隔，默认是 1m，这里设置为 15s
  evaluation_interval: 15s # 全局的规则触发间隔，默认是 1m，这里设置 15s


scrape_configs:
  # The job name is added as a label `job=<job_name>` to any timeseries scraped from this config.
  - job_name: 'dev' # 每一个集群称之为一个job，可以自定义名字作为StarRocks集群名
    metrics_path: '/metrics'    # 指定获取监控项目的Restful Api
    basic_auth:
      username: 'root'
      password: ''
    params:
      'with_table_metrics' : ['all']
      'with_materialized_view_metrics' : ['all']    # 指定获取监控项目的Restful Api

    static_configs:
      - targets: ['127.0.0.1:8131']
        labels:
          group: fe # 这里配置了 fe 的 group，该 group 中包含了 3 个 Frontends

      - targets: ['127.0.0.1:8141']
        labels:
          group: be # 这里配置了 be 的 group，该 group 中包含了 3 个 Backends
....

with_materialized_view_metrics can be:
- all: collect all metrics about materialized view
- minified : ignore metics which  is 0 and gauge metrics(which need check frontend meta each request)
```
Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [x] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [x] 3.1
  - [ ] 3.0
  - [ ] 2.5
