### PR TITLE
[Enhancement] Add cbo_materialized_view_rewrite_related_mvs_limit parameter to limit mv related mv number

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/MvPlanContext.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/MvPlanContext.java
@@ -17,6 +17,7 @@ package com.starrocks.catalog;
 import com.starrocks.sql.optimizer.OptExpression;
 import com.starrocks.sql.optimizer.base.ColumnRefFactory;
 import com.starrocks.sql.optimizer.operator.scalar.ColumnRefOperator;
+import com.starrocks.sql.optimizer.rule.transformation.materialization.MvUtils;
 
 import java.util.List;
 
@@ -41,6 +42,7 @@ public class MvPlanContext {
     // because we will not use other fields
     private boolean isValidMvPlan;
     private String invalidReason;
+    private final int mvScanOpNum;
 
     public MvPlanContext(boolean valid, String invalidReason) {
         this.logicalPlan = null;
@@ -48,6 +50,7 @@ public class MvPlanContext {
         this.refFactory = null;
         this.isValidMvPlan = valid;
         this.invalidReason = invalidReason;
+        this.mvScanOpNum = 0;
     }
 
     public MvPlanContext(
@@ -58,6 +61,7 @@ public class MvPlanContext {
         this.outputColumns = outputColumns;
         this.refFactory = refFactory;
         this.isValidMvPlan = true;
+        this.mvScanOpNum = MvUtils.getOlapScanNode(logicalPlan).size();
     }
 
     public OptExpression getLogicalPlan() {
@@ -78,5 +82,9 @@ public class MvPlanContext {
 
     public String getInvalidReason() {
         return invalidReason;
+    }
+
+    public int getMvScanOpNum() {
+        return mvScanOpNum;
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/OlapTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/OlapTable.java
@@ -2770,6 +2770,11 @@ public class OlapTable extends Table {
         return tableProperty.getForeignKeyConstraints();
     }
 
+    /**
+     * Return Whether MaterializedView has foreignKey constraints or not. MV's constraints come from table properties
+     * and is different from normal table.
+     */
+    @Override
     public boolean hasForeignKeyConstraints() {
         return tableProperty != null && tableProperty.getForeignKeyConstraints() != null &&
                 !tableProperty.getForeignKeyConstraints().isEmpty();

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/Table.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/Table.java
@@ -798,6 +798,10 @@ public class Table extends MetaObject implements Writable, GsonPostProcessable {
         return this.foreignKeyConstraints;
     }
 
+    public boolean hasForeignKeyConstraints() {
+        return this.foreignKeyConstraints != null && !this.foreignKeyConstraints.isEmpty();
+    }
+
     public synchronized List<Long> allocatePartitionIdByKey(List<PartitionKey> keys) {
         long size = partitionKeyToId.size();
         List<Long> ret = new ArrayList<>();

--- a/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
@@ -284,6 +284,8 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
             "cbo_materialized_view_rewrite_rule_output_limit";
     public static final String CBO_MATERIALIZED_VIEW_REWRITE_CANDIDATE_LIMIT =
             "cbo_materialized_view_rewrite_candidate_limit";
+    public static final String CBO_MATERIALIZED_VIEW_REWRITE_RELATED_MVS_LIMIT =
+            "cbo_materialized_view_rewrite_related_mvs_limit";
 
     public static final String CBO_MAX_REORDER_NODE_USE_EXHAUSTIVE = "cbo_max_reorder_node_use_exhaustive";
     public static final String CBO_ENABLE_DP_JOIN_REORDER = "cbo_enable_dp_join_reorder";
@@ -1468,6 +1470,12 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
      */
     @VarAttr(name = CBO_MATERIALIZED_VIEW_REWRITE_CANDIDATE_LIMIT, flag = VariableMgr.INVISIBLE)
     private int cboMaterializedViewRewriteCandidateLimit = 12;
+
+    /**
+     * Materialized view rewrite related mv limit: how many related MVs would be considered for rewrite to a query?
+     */
+    @VarAttr(name = CBO_MATERIALIZED_VIEW_REWRITE_RELATED_MVS_LIMIT, flag = VariableMgr.INVISIBLE)
+    private int cboMaterializedViewRewriteRelatedMVsLimit = 64;
 
     @VarAttr(name = QUERY_EXCLUDING_MV_NAMES, flag = VariableMgr.INVISIBLE)
     private String queryExcludingMVNames = "";
@@ -2848,6 +2856,14 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
 
     public void setCboMaterializedViewRewriteCandidateLimit(int limit) {
         this.cboMaterializedViewRewriteCandidateLimit = limit;
+    }
+
+    public int getCboMaterializedViewRewriteRelatedMVsLimit() {
+        return cboMaterializedViewRewriteRelatedMVsLimit;
+    }
+
+    public void setCboMaterializedViewRewriteRelatedMVsLimit(int cboMaterializedViewRewriteRelatedMVsLimit) {
+        this.cboMaterializedViewRewriteRelatedMVsLimit = cboMaterializedViewRewriteRelatedMVsLimit;
     }
 
     public String getQueryExcludingMVNames() {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/SetStmtAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/SetStmtAnalyzer.java
@@ -236,6 +236,23 @@ public class SetStmtAnalyzer {
             }
         }
 
+        // cbo_materialized_view_rewrite_candidate_limit
+        if (variable.equalsIgnoreCase(SessionVariable.CBO_MATERIALIZED_VIEW_REWRITE_CANDIDATE_LIMIT)) {
+            checkRangeIntVariable(resolvedExpression, SessionVariable.CBO_MATERIALIZED_VIEW_REWRITE_CANDIDATE_LIMIT,
+                    1, null);
+        }
+        // cbo_materialized_view_rewrite_rule_output_limit
+        if (variable.equalsIgnoreCase(SessionVariable.CBO_MATERIALIZED_VIEW_REWRITE_RULE_OUTPUT_LIMIT)) {
+            checkRangeIntVariable(resolvedExpression, SessionVariable.CBO_MATERIALIZED_VIEW_REWRITE_RULE_OUTPUT_LIMIT,
+                    1, null);
+        }
+        // cbo_materialized_view_rewrite_related_mvs_limit
+        if (variable.equalsIgnoreCase(SessionVariable.CBO_MATERIALIZED_VIEW_REWRITE_RELATED_MVS_LIMIT)) {
+            checkRangeIntVariable(resolvedExpression, SessionVariable.CBO_MATERIALIZED_VIEW_REWRITE_RELATED_MVS_LIMIT,
+                    1, null);
+        }
+
+
         var.setResolvedExpression(resolvedExpression);
     }
 
@@ -243,6 +260,21 @@ public class SetStmtAnalyzer {
         String value = resolvedExpression.getStringValue();
         try {
             long num = Long.parseLong(value);
+            if (min != null && num < min) {
+                throw new SemanticException(String.format("%s must be equal or greater than %d", field, min));
+            }
+            if (max != null && num > max) {
+                throw new SemanticException(String.format("%s must be equal or smaller than %d", field, max));
+            }
+        } catch (NumberFormatException ex) {
+            throw new SemanticException(field + " is not a number");
+        }
+    }
+
+    private static void checkRangeIntVariable(LiteralExpr resolvedExpression, String field, Integer min, Integer max) {
+        String value = resolvedExpression.getStringValue();
+        try {
+            int num = Integer.parseInt(value);
             if (min != null && num < min) {
                 throw new SemanticException(String.format("%s must be equal or greater than %d", field, min));
             }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/CachingMvPlanContextBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/CachingMvPlanContextBuilder.java
@@ -63,6 +63,13 @@ public class CachingMvPlanContextBuilder {
         }
     }
 
+    /**
+     * Get plan cache only if mv is present in the plan cache, otherwise null is returned.
+     */
+    public List<MvPlanContext> getPlanContextFromCacheIfPresent(MaterializedView mv) {
+        return mvPlanContextCache.getIfPresent(mv);
+    }
+
     private List<MvPlanContext> loadMvPlanContext(MaterializedView mv) {
         try {
             return MvPlanContextBuilder.getPlanContext(mv);

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvUtils.java
@@ -153,7 +153,7 @@ public class MvUtils {
                 logMVPrepare(connectContext, "Table/MaterializedView {} has related materialized views: {}",
                         table.getName(), mvIds);
                 newMvIds.addAll(mvIds);
-            } else {
+            } else if (currentLevel == 0) {
                 logMVPrepare(connectContext, "Table/MaterializedView {} has no related materialized views, " +
                                 "identifier:{}", table.getName(), table.getTableIdentifier());
             }
@@ -302,6 +302,9 @@ public class MvUtils {
     }
 
     public static List<LogicalOlapScanOperator> getOlapScanNode(OptExpression root) {
+        if (root == null) {
+            return Lists.newArrayList();
+        }
         List<LogicalOlapScanOperator> olapScanOperators = Lists.newArrayList();
         getOlapScanNode(root, olapScanOperators);
         return olapScanOperators;

--- a/fe/fe-core/src/test/java/com/starrocks/alter/SchemaChangeHandlerWithMVTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/alter/SchemaChangeHandlerWithMVTest.java
@@ -30,8 +30,10 @@ import com.starrocks.sql.ast.AlterTableStmt;
 import com.starrocks.sql.ast.DmlStmt;
 import com.starrocks.sql.ast.InsertStmt;
 import com.starrocks.sql.plan.ExecPlan;
+import com.starrocks.statistic.StatisticsMetaManager;
 import com.starrocks.utframe.StarRocksAssert;
 import com.starrocks.utframe.TestWithFeService;
+import com.starrocks.utframe.UtFrameUtils;
 import mockit.Mock;
 import mockit.MockUp;
 import org.apache.logging.log4j.LogManager;
@@ -75,6 +77,13 @@ public class SchemaChangeHandlerWithMVTest extends TestWithFeService {
         starRocksAssert = new StarRocksAssert(connectContext);
         starRocksAssert.withDatabase("test");
         starRocksAssert.useDatabase("test");
+
+        UtFrameUtils.setDefaultConfigForAsyncMVTest(connectContext);
+
+        if (!starRocksAssert.databaseExist("_statistics_")) {
+            StatisticsMetaManager m = new StatisticsMetaManager();
+            m.createStatisticsTablesForTest();
+        }
 
         new MockUp<StmtExecutor>() {
             @Mock

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/SetStmtTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/SetStmtTest.java
@@ -34,9 +34,11 @@
 
 package com.starrocks.analysis;
 
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
 import com.starrocks.catalog.Type;
 import com.starrocks.common.AnalysisException;
+import com.starrocks.common.Pair;
 import com.starrocks.common.UserException;
 import com.starrocks.mysql.privilege.Auth;
 import com.starrocks.mysql.privilege.MockedAuth;
@@ -315,6 +317,52 @@ public class SetStmtTest {
                 } catch (Exception e) {
                     Assert.fail();;
                 }
+            }
+        }
+    }
+
+    @Test
+    public void testCBOMaterializedViewRewriteLimit() {
+        // good
+        {
+            List<Pair<String, String>> goodCases = ImmutableList.of(
+                    Pair.create(SessionVariable.CBO_MATERIALIZED_VIEW_REWRITE_CANDIDATE_LIMIT, "1"),
+                    Pair.create(SessionVariable.CBO_MATERIALIZED_VIEW_REWRITE_RELATED_MVS_LIMIT, "1"),
+                    Pair.create(SessionVariable.CBO_MATERIALIZED_VIEW_REWRITE_RULE_OUTPUT_LIMIT, "1")
+            );
+            for (Pair<String, String> goodCase : goodCases) {
+                try {
+                    SystemVariable setVar = new SystemVariable(SetType.SESSION, goodCase.first,
+                            new StringLiteral(goodCase.second));
+                    SetStmtAnalyzer.analyze(new SetStmt(Lists.newArrayList(setVar)), ctx);
+                } catch (Exception e) {
+                    Assert.fail();;
+                }
+            }
+        }
+    }
+
+    // bad
+    {
+        List<Pair<String, String>> goodCases = ImmutableList.of(
+                Pair.create(SessionVariable.CBO_MATERIALIZED_VIEW_REWRITE_CANDIDATE_LIMIT, "-1"),
+                Pair.create(SessionVariable.CBO_MATERIALIZED_VIEW_REWRITE_CANDIDATE_LIMIT, "0"),
+                Pair.create(SessionVariable.CBO_MATERIALIZED_VIEW_REWRITE_CANDIDATE_LIMIT, "abc"),
+                Pair.create(SessionVariable.CBO_MATERIALIZED_VIEW_REWRITE_RELATED_MVS_LIMIT, "-1"),
+                Pair.create(SessionVariable.CBO_MATERIALIZED_VIEW_REWRITE_RELATED_MVS_LIMIT, "0"),
+                Pair.create(SessionVariable.CBO_MATERIALIZED_VIEW_REWRITE_RELATED_MVS_LIMIT, "abc"),
+                Pair.create(SessionVariable.CBO_MATERIALIZED_VIEW_REWRITE_RULE_OUTPUT_LIMIT, "-1"),
+                Pair.create(SessionVariable.CBO_MATERIALIZED_VIEW_REWRITE_RULE_OUTPUT_LIMIT, "0"),
+                Pair.create(SessionVariable.CBO_MATERIALIZED_VIEW_REWRITE_RULE_OUTPUT_LIMIT, "abc")
+        );
+        for (Pair<String, String> goodCase : goodCases) {
+            try {
+                SystemVariable setVar = new SystemVariable(SetType.SESSION, goodCase.first,
+                        new StringLiteral(goodCase.second));
+                SetStmtAnalyzer.analyze(new SetStmt(Lists.newArrayList(setVar)), ctx);
+                Assert.fail();;
+            } catch (Exception e) {
+                Assert.assertTrue(e instanceof SemanticException);
             }
         }
     }

--- a/fe/fe-core/src/test/java/com/starrocks/benchmark/MVPartitionCompensateOptBench.java
+++ b/fe/fe-core/src/test/java/com/starrocks/benchmark/MVPartitionCompensateOptBench.java
@@ -12,13 +12,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package com.starrocks.sql.optimizer.rule.transformation.materialization;
+package com.starrocks.benchmark;
 
 import com.carrotsearch.junitbenchmarks.BenchmarkOptions;
 import com.carrotsearch.junitbenchmarks.BenchmarkRule;
 import com.google.common.collect.ImmutableList;
 import com.starrocks.common.Pair;
 import com.starrocks.sql.common.QueryDebugOptions;
+import com.starrocks.sql.optimizer.rule.transformation.materialization.MvRewriteTestBase;
 import com.starrocks.sql.plan.PlanTestBase;
 import org.junit.Assert;
 import org.junit.BeforeClass;

--- a/fe/fe-core/src/test/java/com/starrocks/benchmark/MvPreProcessorWithSSBBench.java
+++ b/fe/fe-core/src/test/java/com/starrocks/benchmark/MvPreProcessorWithSSBBench.java
@@ -1,0 +1,169 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.benchmark;
+
+import com.carrotsearch.junitbenchmarks.BenchmarkOptions;
+import com.carrotsearch.junitbenchmarks.BenchmarkRule;
+import com.google.common.collect.Lists;
+import com.starrocks.common.FeConstants;
+import com.starrocks.planner.MaterializedViewTestBase;
+import com.starrocks.sql.plan.PlanTestBase;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Ignore;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TestRule;
+
+@Ignore
+public class MvPreProcessorWithSSBBench extends MaterializedViewTestBase {
+
+    private static final int MV_NUMS = 1000;
+    private static final int BENCHMARK_RUNS = 10;
+
+    @Rule
+    public TestRule mvPartitionCompensateBench = new BenchmarkRule();
+
+    @BeforeClass
+    public static void beforeClass() throws Exception {
+        FeConstants.USE_MOCK_DICT_MANAGER = true;
+        MaterializedViewTestBase.beforeClass();
+
+        starRocksAssert.useDatabase(MATERIALIZED_DB_NAME);
+
+        // create SSB tables
+        // put lineorder last because it depends on other tables for foreign key constraints
+        createTables("sql/ssb/", Lists.newArrayList("customer", "dates", "supplier", "part", "lineorder"));
+
+        // create lineorder_flat_mv
+        for (int i = 0; i < MV_NUMS; i++) {
+            String mv = String.format("CREATE MATERIALIZED VIEW lineorder_flat_mv_%s\n" +
+                    "DISTRIBUTED BY RANDOM\n" +
+                    "REFRESH DEFERRED MANUAL\n" +
+                    "AS SELECT\n" +
+                    "       l.LO_ORDERKEY AS LO_ORDERKEY,\n" +
+                    "       l.LO_LINENUMBER AS LO_LINENUMBER,\n" +
+                    "       l.LO_CUSTKEY AS LO_CUSTKEY,\n" +
+                    "       l.LO_PARTKEY AS LO_PARTKEY,\n" +
+                    "       l.LO_SUPPKEY AS LO_SUPPKEY,\n" +
+                    "       l.LO_ORDERDATE AS LO_ORDERDATE,\n" +
+                    "       l.LO_ORDERPRIORITY AS LO_ORDERPRIORITY,\n" +
+                    "       l.LO_SHIPPRIORITY AS LO_SHIPPRIORITY,\n" +
+                    "       l.LO_QUANTITY AS LO_QUANTITY,\n" +
+                    "       l.LO_EXTENDEDPRICE AS LO_EXTENDEDPRICE,\n" +
+                    "       l.LO_ORDTOTALPRICE AS LO_ORDTOTALPRICE,\n" +
+                    "       l.LO_DISCOUNT AS LO_DISCOUNT,\n" +
+                    "       l.LO_REVENUE AS LO_REVENUE,\n" +
+                    "       l.LO_SUPPLYCOST AS LO_SUPPLYCOST,\n" +
+                    "       l.LO_TAX AS LO_TAX,\n" +
+                    "       l.LO_COMMITDATE AS LO_COMMITDATE,\n" +
+                    "       l.LO_SHIPMODE AS LO_SHIPMODE,\n" +
+                    "       c.C_NAME AS C_NAME,\n" +
+                    "       c.C_ADDRESS AS C_ADDRESS,\n" +
+                    "       c.C_CITY AS C_CITY,\n" +
+                    "       c.C_NATION AS C_NATION,\n" +
+                    "       c.C_REGION AS C_REGION,\n" +
+                    "       c.C_PHONE AS C_PHONE,\n" +
+                    "       c.C_MKTSEGMENT AS C_MKTSEGMENT,\n" +
+                    "       s.S_NAME AS S_NAME,\n" +
+                    "       s.S_ADDRESS AS S_ADDRESS,\n" +
+                    "       s.S_CITY AS S_CITY,\n" +
+                    "       s.S_NATION AS S_NATION,\n" +
+                    "       s.S_REGION AS S_REGION,\n" +
+                    "       s.S_PHONE AS S_PHONE,\n" +
+                    "       p.P_NAME AS P_NAME,\n" +
+                    "       p.P_MFGR AS P_MFGR,\n" +
+                    "       p.P_CATEGORY AS P_CATEGORY,\n" +
+                    "       p.P_BRAND AS P_BRAND,\n" +
+                    "       p.P_COLOR AS P_COLOR,\n" +
+                    "       p.P_TYPE AS P_TYPE,\n" +
+                    "       p.P_SIZE AS P_SIZE,\n" +
+                    "       p.P_CONTAINER AS P_CONTAINER,\n" +
+                    "       d.d_date AS d_date,\n" +
+                    "       d.d_dayofweek AS d_dayofweek,\n" +
+                    "       d.d_month AS d_month,\n" +
+                    "       d.d_year AS d_year,\n" +
+                    "       d.d_yearmonthnum AS d_yearmonthnum,\n" +
+                    "       d.d_yearmonth AS d_yearmonth,\n" +
+                    "       d.d_daynuminweek AS d_daynuminweek,\n" +
+                    "       d.d_daynuminmonth AS d_daynuminmonth,\n" +
+                    "       d.d_daynuminyear AS d_daynuminyear,\n" +
+                    "       d.d_monthnuminyear AS d_monthnuminyear,\n" +
+                    "       d.d_weeknuminyear AS d_weeknuminyear,\n" +
+                    "       d.d_sellingseason AS d_sellingseason,\n" +
+                    "       d.d_lastdayinweekfl AS d_lastdayinweekfl,\n" +
+                    "       d.d_lastdayinmonthfl AS d_lastdayinmonthfl,\n" +
+                    "       d.d_holidayfl AS d_holidayfl,\n" +
+                    "       d.d_weekdayfl AS d_weekdayfl\n" +
+                    "   FROM lineorder AS l\n" +
+                    "            INNER JOIN customer AS c ON c.C_CUSTKEY = l.LO_CUSTKEY\n" +
+                    "            INNER JOIN supplier AS s ON s.S_SUPPKEY = l.LO_SUPPKEY\n" +
+                    "            INNER JOIN part AS p ON p.P_PARTKEY = l.LO_PARTKEY\n" +
+                    "            INNER JOIN dates AS d ON l.lo_orderdate = d.d_datekey;\n", i);
+            System.out.println("create table :" + i);
+            starRocksAssert.withMaterializedView(mv);
+        }
+
+        // no use plan cache to test mv prepare cost
+        connectContext.getSessionVariable().setEnableMaterializedViewPlanCache(false);
+    }
+
+    @AfterClass
+    public static void afterClass() {
+        for (int i = 0; i < MV_NUMS; i++) {
+            String mv = String.format("lineorder_flat_mv_%s", i);
+            try {
+                starRocksAssert.dropMaterializedView(mv);
+            } catch (Exception e) {
+                // ignore exception
+            }
+        }
+    }
+
+    @Test
+    @BenchmarkOptions(warmupRounds = 1, benchmarkRounds = BENCHMARK_RUNS)
+    // MvPreProcessorWithSSBBench.testPartitionPredicate: [measured 10 out of 11 rounds, threads: 1 (sequential)]
+    // round: 0.32 [+- 0.08], round.block: 0.00 [+- 0.00], round.gc: 0.00 [+- 0.00], GC.calls: 4, GC.time: 0.05,
+    // time.total: 4.40, time.warmup: 1.21, time.bench: 3.20
+    public void testPartitionPredicate1() throws Exception {
+        String query = "select sum(LO_EXTENDEDPRICE * LO_DISCOUNT) AS revenue\n" +
+                "from lineorder\n" +
+                "join dates on lo_orderdate = d_datekey\n" +
+                "where weekofyear(LO_ORDERDATE) = 6 AND LO_ORDERDATE >= 19940101 and LO_ORDERDATE <= 19941231\n" +
+                "and lo_discount between 5 and 7\n" +
+                "and lo_quantity between 26 and 35;";
+        String plan = getFragmentPlan(query);
+        PlanTestBase.assertContains(plan, "lineorder_flat_mv");
+    }
+
+    @Test
+    @BenchmarkOptions(warmupRounds = 1, benchmarkRounds = BENCHMARK_RUNS)
+    // MvPreProcessorWithSSBBench.testPartitionPredicate2: [measured 10 out of 11 rounds, threads: 1 (sequential)]
+    // round: 2.93 [+- 0.10], round.block: 0.00 [+- 0.00], round.gc: 0.00 [+- 0.00], GC.calls: 51, GC.time: 1.21,
+    // time.total: 33.49, time.warmup: 4.16, time.bench: 29.33
+    public void testPartitionPredicate2() throws Exception {
+        String query = "select sum(LO_EXTENDEDPRICE * LO_DISCOUNT) AS revenue\n" +
+                "from lineorder\n" +
+                "join dates on lo_orderdate = d_datekey\n" +
+                "where weekofyear(LO_ORDERDATE) = 6 AND LO_ORDERDATE >= 19940101 and LO_ORDERDATE <= 19941231\n" +
+                "and lo_discount between 5 and 7\n" +
+                "and lo_quantity between 26 and 35;";
+        int oldVal = connectContext.getSessionVariable().getCboMaterializedViewRewriteRelatedMVsLimit();
+        connectContext.getSessionVariable().setCboMaterializedViewRewriteRelatedMVsLimit(1000);
+        String plan = getFragmentPlan(query);
+        PlanTestBase.assertContains(plan, "lineorder_flat_mv");
+        connectContext.getSessionVariable().setCboMaterializedViewRewriteRelatedMVsLimit(oldVal);
+    }
+}

--- a/fe/fe-core/src/test/java/com/starrocks/benchmark/MvRewritePerfTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/benchmark/MvRewritePerfTest.java
@@ -12,13 +12,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package com.starrocks.sql.optimizer.rule.transformation.materialization;
+package com.starrocks.benchmark;
 
 import com.carrotsearch.junitbenchmarks.BenchmarkOptions;
 import com.carrotsearch.junitbenchmarks.BenchmarkRule;
 import com.starrocks.common.Config;
 import com.starrocks.qe.SessionVariable;
 import com.starrocks.sql.optimizer.CachingMvPlanContextBuilder;
+import com.starrocks.sql.optimizer.rule.transformation.materialization.MvRewriteTestBase;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Rule;
@@ -26,6 +27,8 @@ import org.junit.Test;
 import org.junit.rules.TestRule;
 
 public class MvRewritePerfTest extends MvRewriteTestBase {
+
+    private static final int MV_NUM = 40;
 
     @Rule
     public TestRule benchRun = new BenchmarkRule();
@@ -45,8 +48,8 @@ public class MvRewritePerfTest extends MvRewriteTestBase {
         cluster.runSql("test", "insert into t0 values(1, 1, 1), (2,2,2)");
         cluster.runSql("test", "insert into t1 values(1, 1, 1), (2,2,2)");
 
-        // 100 MV with same schema
-        for (int i = 0; i < 40; i++) {
+        // MV_NUM msv with same schema
+        for (int i = 0; i < MV_NUM; i++) {
             // join MV
             String joinMV = "mv_candidate_join_" + i;
             starRocksAssert.withRefreshedMaterializedView("create materialized view " + joinMV +
@@ -61,7 +64,7 @@ public class MvRewritePerfTest extends MvRewriteTestBase {
                     " group by t0.v1");
         }
 
-        LOG.info("prepared 40 materialized views");
+        LOG.info("prepared {} materialized views", MV_NUM);
     }
 
     @Before

--- a/fe/fe-core/src/test/java/com/starrocks/benchmark/NormalizePredicateBench.java
+++ b/fe/fe-core/src/test/java/com/starrocks/benchmark/NormalizePredicateBench.java
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package com.starrocks.sql.optimizer.rule.transformation.materialization;
+package com.starrocks.benchmark;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
@@ -26,6 +26,7 @@ import com.starrocks.sql.optimizer.operator.scalar.CompoundPredicateOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ConstantOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ScalarOperator;
 import com.starrocks.sql.optimizer.rewrite.ScalarOperatorRewriter;
+import com.starrocks.sql.optimizer.rule.transformation.materialization.MvUtils;
 import org.apache.commons.lang3.NotImplementedException;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.openjdk.jmh.annotations.Benchmark;

--- a/fe/fe-core/src/test/java/com/starrocks/benchmark/QueryDumpPlannerBenchTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/benchmark/QueryDumpPlannerBenchTest.java
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package com.starrocks.sql.optimizer.rule.transformation.materialization;
+package com.starrocks.benchmark;
 
 import com.carrotsearch.junitbenchmarks.BenchmarkOptions;
 import com.carrotsearch.junitbenchmarks.BenchmarkRule;
@@ -59,5 +59,4 @@ public class QueryDumpPlannerBenchTest extends ReplayFromDumpTestBase {
         connectContext.setThreadLocalInfo();
         UtFrameUtils.replaySql(connectContext, sql);
     }
-
 }

--- a/fe/fe-core/src/test/java/com/starrocks/benchmark/ViewBasedMvRewritePerfTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/benchmark/ViewBasedMvRewritePerfTest.java
@@ -12,12 +12,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package com.starrocks.sql.optimizer.rule.transformation.materialization;
+package com.starrocks.benchmark;
 
 import com.carrotsearch.junitbenchmarks.BenchmarkOptions;
 import com.carrotsearch.junitbenchmarks.BenchmarkRule;
 import com.starrocks.common.Config;
 import com.starrocks.sql.optimizer.CachingMvPlanContextBuilder;
+import com.starrocks.sql.optimizer.rule.transformation.materialization.MvRewriteTestBase;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Rule;
@@ -25,6 +26,8 @@ import org.junit.Test;
 import org.junit.rules.TestRule;
 
 public class ViewBasedMvRewritePerfTest extends MvRewriteTestBase {
+
+    private static final int MV_NUM = 4;
 
     @Rule
     public TestRule benchRun = new BenchmarkRule();
@@ -75,7 +78,7 @@ public class ViewBasedMvRewritePerfTest extends MvRewriteTestBase {
         starRocksAssert.withView("create view t2_view_1 as select v1, sum(v2) as total1 from t2 group by v1");
         starRocksAssert.withView("create view t2_view_2 as select v1, sum(v3) as total2 from t2 group by v1");
         // 40 MV with same schema
-        for (int i = 0; i < 40; i++) {
+        for (int i = 0; i < MV_NUM; i++) {
             // join MV
             String joinMV = "mv_candidate_join_" + i;
             starRocksAssert.withRefreshedMaterializedView("create materialized view " + joinMV +

--- a/fe/fe-core/src/test/java/com/starrocks/planner/MaterializedViewSSBTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/planner/MaterializedViewSSBTest.java
@@ -113,4 +113,19 @@ public class MaterializedViewSSBTest extends MaterializedViewTestBase {
         PlanTestBase.assertContains(plan, "lineorder_flat_mv");
         PlanTestBase.assertNotContains(plan, "LO_ORDERDATE <= 19950100");
     }
+
+    @Test
+    public void testPartitionPredicateWithRelatedMVsLimit() throws Exception {
+        int oldVal = connectContext.getSessionVariable().getCboMaterializedViewRewriteRelatedMVsLimit();
+        connectContext.getSessionVariable().setCboMaterializedViewRewriteRelatedMVsLimit(1);
+        String query = "select sum(LO_EXTENDEDPRICE * LO_DISCOUNT) AS revenue\n" +
+                "from lineorder\n" +
+                "join dates on lo_orderdate = d_datekey\n" +
+                "where weekofyear(LO_ORDERDATE) = 6 AND LO_ORDERDATE >= 19940101 and LO_ORDERDATE <= 19941231\n" +
+                "and lo_discount between 5 and 7\n" +
+                "and lo_quantity between 26 and 35;";
+        String plan = getFragmentPlan(query);
+        PlanTestBase.assertContains(plan, "lineorder_flat_mv");
+        connectContext.getSessionVariable().setCboMaterializedViewRewriteRelatedMVsLimit(oldVal);
+    }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/planner/MaterializedViewTestBase.java
+++ b/fe/fe-core/src/test/java/com/starrocks/planner/MaterializedViewTestBase.java
@@ -81,6 +81,9 @@ public class MaterializedViewTestBase extends PlanTestBase {
         ConnectorPlanTestBase.mockHiveCatalog(connectContext);
 
         new MockUp<MaterializedView>() {
+            /**
+             * {@link MaterializedView#getPartitionNamesToRefreshForMv(Set, boolean)}
+             */
             @Mock
             public boolean getPartitionNamesToRefreshForMv(Set<String> toRefreshPartitions,
                                                            boolean isQueryRewrite) {
@@ -89,6 +92,9 @@ public class MaterializedViewTestBase extends PlanTestBase {
         };
 
         new MockUp<UtFrameUtils>() {
+            /**
+             * {@link UtFrameUtils#isPrintPlanTableNames()}
+             */
             @Mock
             boolean isPrintPlanTableNames() {
                 return true;
@@ -96,6 +102,9 @@ public class MaterializedViewTestBase extends PlanTestBase {
         };
 
         new MockUp<PlanTestBase>() {
+            /**
+             * {@link com.starrocks.sql.plan.PlanTestNoneDBBase#isIgnoreExplicitColRefIds()}
+             */
             @Mock
             boolean isIgnoreExplicitColRefIds() {
                 return true;

--- a/fe/fe-core/src/test/java/com/starrocks/planner/ViewBaseMvRewriteTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/planner/ViewBaseMvRewriteTest.java
@@ -427,6 +427,7 @@ public class ViewBaseMvRewriteTest extends MaterializedViewTestBase {
                     "FROM view_1 v1\n" +
                     "JOIN view_2 v2 ON v1.l_partkey = v2.l_partkey\n" +
                     "AND v1.l_suppkey = v2.l_suppkey;";
+            setTracLogModule("MV");
             testRewriteOK(mv, query);
             starRocksAssert.dropMaterializedView("mv_2");
         }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvRewriteMultiTableJoinTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvRewriteMultiTableJoinTest.java
@@ -167,7 +167,7 @@ public class MvRewriteMultiTableJoinTest extends MvRewriteTestBase {
                     " order by p1.p1_col2\n" +
                     " limit 0, 100";
 
-            String plan = getFragmentPlan(query);
+            String plan = getFragmentPlan(query, "MV");
             PlanTestBase.assertContains(plan, "AGGREGATE");
             PlanTestBase.assertContains(plan, "test_mv2");
             PlanTestBase.assertContains(plan, "sum_p1_col4 >= 500000");

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvRewritePreprocessorTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvRewritePreprocessorTest.java
@@ -14,6 +14,7 @@
 
 package com.starrocks.sql.optimizer.rule.transformation.materialization;
 
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
 import com.starrocks.catalog.Column;
 import com.starrocks.catalog.MaterializedView;
@@ -21,7 +22,10 @@ import com.starrocks.catalog.Table;
 import com.starrocks.common.Pair;
 import com.starrocks.sql.ast.QueryStatement;
 import com.starrocks.sql.ast.StatementBase;
+import com.starrocks.sql.optimizer.CachingMvPlanContextBuilder;
 import com.starrocks.sql.optimizer.MaterializationContext;
+import com.starrocks.sql.optimizer.Memo;
+import com.starrocks.sql.optimizer.MvRewritePreprocessor;
 import com.starrocks.sql.optimizer.OptExpression;
 import com.starrocks.sql.optimizer.Optimizer;
 import com.starrocks.sql.optimizer.OptimizerConfig;
@@ -52,13 +56,17 @@ import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
+import java.util.Arrays;
 import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 public class MvRewritePreprocessorTest extends MvRewriteTestBase {
     @BeforeClass
     public static void before() throws Exception {
         starRocksAssert.useTable("t0");
-
+        starRocksAssert.useTable("t1");
+        starRocksAssert.useTable("t2");
     }
 
     private static class TimeoutRule extends Rule {
@@ -268,5 +276,175 @@ public class MvRewritePreprocessorTest extends MvRewriteTestBase {
             LogicalOlapScanOperator scanOperator = materializationContext3.getScanMvOperator();
             Assert.assertEquals(1, scanOperator.getSelectedPartitionId().size());
         }
+    }
+
+    private MvRewritePreprocessor buildMvProcessor(String query) {
+        ColumnRefFactory columnRefFactory = new ColumnRefFactory();
+        OptimizerConfig optimizerConfig = new OptimizerConfig();
+        OptimizerContext context = new OptimizerContext(new Memo(), columnRefFactory, connectContext, optimizerConfig);
+
+        try {
+            StatementBase stmt = UtFrameUtils.parseStmtWithNewParser(query, connectContext);
+            QueryStatement queryStatement = (QueryStatement) stmt;
+            LogicalPlan logicalPlan = new RelationTransformer(columnRefFactory, connectContext)
+                    .transformWithSelectLimit(queryStatement.getQueryRelation());
+            ColumnRefSet requiredColumns = new ColumnRefSet(logicalPlan.getOutputColumn());
+            OptExpression logicalTree = logicalPlan.getRoot();
+            MvRewritePreprocessor preprocessor = new MvRewritePreprocessor(connectContext, columnRefFactory,
+                    context, logicalTree, requiredColumns);
+            return preprocessor;
+        } catch (Exception e) {
+            return null;
+        }
+    }
+
+    // test without max related mvs limit
+    @Test
+    public void testChooseBestRelatedMVs1() {
+        List<String> mvs = ImmutableList.of(
+                // normal mv
+                "create materialized view mv_1 distributed by random as select k1, v1, v2 from t1;",
+                // with intersected tables
+                "create materialized view mv_2 distributed by random as select t1.k1, t1.v1, t1.v2, t0.v1 as v21 " +
+                        "from t1 join t0 on t1.k1=t0.v1;",
+                // invalid mv
+                "create materialized view mv_3 distributed by random as select k1, v1, v2 from t1 " +
+                        "union all select k1, v1, v2 from t1;",
+                // with intersected tables
+                "create materialized view mv_4 distributed by random as select t1.k1, t1.v1, t1.v2, t0.v1 as v21 " +
+                        "from t1 join t0 join t2 on t1.k1=t0.v1 and t1.k1=t2.v1;"
+        );
+
+        starRocksAssert.withMaterializedViews(mvs, (obj) -> {
+            // query 1
+            {
+                String query = "select k1, v1, v2 from t1";
+                MvRewritePreprocessor preprocessor = buildMvProcessor(query);
+                OptExpression logicalTree = preprocessor.getLogicalTree();
+
+                Set<Table> queryTables = MvUtils.getAllTables(logicalTree).stream().collect(Collectors.toSet());
+                Set<MaterializedView> relatedMVs = preprocessor.getRelatedMVs(queryTables, false);
+                Assert.assertTrue(relatedMVs.size() == 4);
+                // mv2 contains extra mvs.
+                Assert.assertTrue(containsMV(relatedMVs, "mv_1", "mv_2", "mv_3", "mv_4"));
+
+                Set<MaterializedView> validMVs = preprocessor.chooseBestRelatedMVs(queryTables, relatedMVs, logicalTree);
+                Assert.assertTrue(validMVs.size() == 2);
+                Assert.assertTrue(containsMV(validMVs, "mv_1", "mv_3"));
+
+                // if mv_3 is in the plan cache
+                MaterializedView mv3 = getMv("test", "mv_3");
+                CachingMvPlanContextBuilder.getInstance().getPlanContext(mv3, true);
+                validMVs = preprocessor.chooseBestRelatedMVs(queryTables, relatedMVs, logicalTree);
+                Assert.assertTrue(validMVs.size() == 1);
+                Assert.assertTrue(containsMV(validMVs, "mv_1"));
+            }
+
+            // query 2
+            {
+                String query = "select t1.k1, t1.v1, t1.v2, t0.v1 as v21 from t1 join t0 on t1.k1=t0.v1";
+                MvRewritePreprocessor preprocessor = buildMvProcessor(query);
+                OptExpression logicalTree = preprocessor.getLogicalTree();
+
+                Set<Table> queryTables = MvUtils.getAllTables(logicalTree).stream().collect(Collectors.toSet());
+                Set<MaterializedView> relatedMVs = preprocessor.getRelatedMVs(queryTables, false);
+                Assert.assertTrue(relatedMVs.size() == 4);
+                // mv2 contains extra mvs.
+                Assert.assertTrue(containsMV(relatedMVs, "mv_1", "mv_2", "mv_3", "mv_4"));
+
+                Set<MaterializedView> validMVs = preprocessor.chooseBestRelatedMVs(queryTables, relatedMVs, logicalTree);
+                Assert.assertTrue(validMVs.size() == 2);
+                Assert.assertTrue(containsMV(validMVs, "mv_1", "mv_2"));
+            }
+        });
+    }
+
+    @Test
+    public void testChooseBestRelatedMVs2() {
+        List<String> mvs = ImmutableList.of(
+                // normal mv
+                "create materialized view mv_1 distributed by random as select k1, v1, v2 from t1;",
+                // with intersected tables
+                "create materialized view mv_2 distributed by random as select t1.k1, t1.v1, t1.v2, t0.v1 as v21 " +
+                        "from t1 join t0 on t1.k1=t0.v1;",
+                // invalid mv
+                "create materialized view mv_3 distributed by random as select k1, v1, v2 from t1 " +
+                        "union all select k1, v1, v2 from t1;",
+                // with intersected tables
+                "create materialized view mv_4 distributed by random as select t1.k1, t1.v1, t1.v2, t0.v1 as v21 " +
+                        "from t1 join t0 join t2 on t1.k1=t0.v1 and t1.k1=t2.v1;"
+        );
+
+        int oldVal = connectContext.getSessionVariable().getCboMaterializedViewRewriteRelatedMVsLimit();
+        connectContext.getSessionVariable().setCboMaterializedViewRewriteRelatedMVsLimit(2);
+        starRocksAssert.withMaterializedViews(mvs, (obj) -> {
+            // query 1
+            {
+                String query = "select k1, v1, v2 from t1";
+                MvRewritePreprocessor preprocessor = buildMvProcessor(query);
+                OptExpression logicalTree = preprocessor.getLogicalTree();
+
+                Set<Table> queryTables = MvUtils.getAllTables(logicalTree).stream().collect(Collectors.toSet());
+                Set<MaterializedView> relatedMVs = preprocessor.getRelatedMVs(queryTables, false);
+                Assert.assertTrue(relatedMVs.size() == 4);
+                // mv2 contains extra mvs.
+                Assert.assertTrue(containsMV(relatedMVs, "mv_1", "mv_2", "mv_3", "mv_4"));
+
+                Set<MaterializedView> validMVs = preprocessor.chooseBestRelatedMVs(queryTables, relatedMVs, logicalTree);
+                Assert.assertTrue(validMVs.size() == 2);
+                Assert.assertTrue(containsMV(validMVs, "mv_1", "mv_3"));
+
+                connectContext.getSessionVariable().setCboMaterializedViewRewriteRelatedMVsLimit(1);
+                validMVs = preprocessor.chooseBestRelatedMVs(queryTables, relatedMVs, logicalTree);
+                Assert.assertTrue(validMVs.size() == 1);
+                Assert.assertTrue(containsMV(validMVs, "mv_1"));
+
+                // if mv_3 is in the plan cache
+                connectContext.getSessionVariable().setCboMaterializedViewRewriteRelatedMVsLimit(2);
+                MaterializedView mv3 = getMv("test", "mv_3");
+                CachingMvPlanContextBuilder.getInstance().getPlanContext(mv3, true);
+                validMVs = preprocessor.chooseBestRelatedMVs(queryTables, relatedMVs, logicalTree);
+                Assert.assertTrue(validMVs.size() == 1);
+                Assert.assertTrue(containsMV(validMVs, "mv_1"));
+            }
+
+            // query 2
+            {
+                String query = "select t1.k1, t1.v1, t1.v2, t0.v1 as v21 from t1 join t0 on t1.k1=t0.v1";
+                MvRewritePreprocessor preprocessor = buildMvProcessor(query);
+                OptExpression logicalTree = preprocessor.getLogicalTree();
+
+                Set<Table> queryTables = MvUtils.getAllTables(logicalTree).stream().collect(Collectors.toSet());
+                Set<MaterializedView> relatedMVs = preprocessor.getRelatedMVs(queryTables, false);
+                Assert.assertTrue(relatedMVs.size() == 4);
+                // mv2 contains extra mvs.
+                Assert.assertTrue(containsMV(relatedMVs, "mv_1", "mv_2", "mv_3", "mv_4"));
+
+                connectContext.getSessionVariable().setCboMaterializedViewRewriteRelatedMVsLimit(2);
+                Set<MaterializedView> validMVs = preprocessor.chooseBestRelatedMVs(queryTables, relatedMVs, logicalTree);
+                Assert.assertTrue(validMVs.size() == 2);
+                Assert.assertTrue(containsMV(validMVs, "mv_1", "mv_2"));
+
+                // set it to 1
+                connectContext.getSessionVariable().setCboMaterializedViewRewriteRelatedMVsLimit(1);
+                validMVs = preprocessor.chooseBestRelatedMVs(queryTables, relatedMVs, logicalTree);
+                Assert.assertTrue(validMVs.size() == 1);
+                Assert.assertTrue(containsMV(validMVs, "mv_2"));
+            }
+        });
+        connectContext.getSessionVariable().setCboMaterializedViewRewriteRelatedMVsLimit(oldVal);
+    }
+
+    private boolean containsMV(Set<MaterializedView> mvs, String... expects) {
+        Set<String> mvNames = mvs.stream().map(mv -> mv.getName()).collect(Collectors.toSet());
+        if (mvNames.size() != Arrays.stream(expects).count()) {
+            return false;
+        }
+        for (String exp : expects) {
+            if (!mvNames.contains(exp)) {
+                return false;
+            }
+        }
+        return true;
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvRewriteTestBase.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvRewriteTestBase.java
@@ -52,6 +52,7 @@ import com.starrocks.sql.optimizer.transformer.LogicalPlan;
 import com.starrocks.sql.optimizer.transformer.RelationTransformer;
 import com.starrocks.sql.parser.ParsingException;
 import com.starrocks.sql.plan.ExecPlan;
+import com.starrocks.sql.plan.PlanTestBase;
 import com.starrocks.thrift.TExplainLevel;
 import com.starrocks.utframe.StarRocksAssert;
 import com.starrocks.utframe.UtFrameUtils;
@@ -98,6 +99,16 @@ public class MvRewriteTestBase {
 
         // set default config for async mvs
         UtFrameUtils.setDefaultConfigForAsyncMVTest(connectContext);
+
+        new MockUp<PlanTestBase>() {
+            /**
+             * {@link com.starrocks.sql.plan.PlanTestNoneDBBase#isIgnoreExplicitColRefIds()}
+             */
+            @Mock
+            boolean isIgnoreExplicitColRefIds() {
+                return true;
+            }
+        };
 
         new MockUp<StmtExecutor>() {
             @Mock

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/PlanTestNoneDBBase.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/PlanTestNoneDBBase.java
@@ -15,6 +15,7 @@
 package com.starrocks.sql.plan;
 
 import com.google.common.base.Preconditions;
+import com.google.common.base.Strings;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.common.io.CharStreams;
@@ -103,8 +104,16 @@ public class PlanTestNoneDBBase {
     }
 
     public static void assertContains(String text, String... pattern) {
-        for (String s : pattern) {
-            Assert.assertTrue(text, text.contains(s));
+        if (isIgnoreExplicitColRefIds()) {
+            String ignoreExpect = normalizeLogicalPlan(text);
+            for (String actual : pattern) {
+                String ignoreActual = normalizeLogicalPlan(actual);
+                Assert.assertTrue(text, ignoreExpect.contains(ignoreActual));
+            }
+        }  else {
+            for (String s : pattern) {
+                Assert.assertTrue(text, text.contains(s));
+            }
         }
     }
 
@@ -236,6 +245,17 @@ public class PlanTestNoneDBBase {
         connectContext.setExecutionId(UUIDUtil.toTUniqueId(connectContext.getQueryId()));
         return UtFrameUtils.getPlanAndFragment(connectContext, sql).second.
                 getExplainString(TExplainLevel.NORMAL);
+    }
+
+    public String getFragmentPlan(String sql, String traceModule) throws Exception {
+        Pair<String, Pair<ExecPlan, String>> result =
+                UtFrameUtils.getFragmentPlanWithTrace(connectContext, sql, traceModule);
+        Pair<ExecPlan, String> execPlanWithQuery = result.second;
+        String traceLog = execPlanWithQuery.second;
+        if (!Strings.isNullOrEmpty(traceLog)) {
+            System.out.println(traceLog);
+        }
+        return execPlanWithQuery.first.getExplainString(TExplainLevel.NORMAL);
     }
 
     public String getLogicalFragmentPlan(String sql) throws Exception {
@@ -618,7 +638,7 @@ public class PlanTestNoneDBBase {
     /**
      * Whether ignore explicit column ref ids when checking the expected plans.
      */
-    protected boolean isIgnoreExplicitColRefIds() {
+    public static boolean isIgnoreExplicitColRefIds() {
         return false;
     }
 

--- a/fe/fe-core/src/test/java/com/starrocks/utframe/StarRocksAssert.java
+++ b/fe/fe-core/src/test/java/com/starrocks/utframe/StarRocksAssert.java
@@ -571,6 +571,48 @@ public class StarRocksAssert {
         return this;
     }
 
+    public StarRocksAssert withRefreshedMaterializedViews(List<String> sqls, ExceptionConsumer action) {
+        return withMaterializedViews(sqls, action, true);
+    }
+
+    public StarRocksAssert withMaterializedViews(List<String> sqls, ExceptionConsumer action) {
+        return withMaterializedViews(sqls, action, false);
+    }
+
+    /**
+     * Create mvs with using sqls and refresh it or not by {@code isRefresh}, and then do {@code action} after
+     * create it success.
+     */
+    private StarRocksAssert withMaterializedViews(List<String> sqls, ExceptionConsumer action, boolean isRefresh) {
+        List<String> mvNames = Lists.newArrayList();
+        try {
+            for (String sql : sqls) {
+                StatementBase stmt = UtFrameUtils.parseStmtWithNewParser(sql, ctx);
+                Preconditions.checkState(stmt instanceof CreateMaterializedViewStatement);
+                CreateMaterializedViewStatement createMaterializedViewStatement = (CreateMaterializedViewStatement) stmt;
+                String mvName = createMaterializedViewStatement.getTableName().getTbl();
+                System.out.println(sql);
+                mvNames.add(mvName);
+                withMaterializedView(sql, true, isRefresh);
+            }
+            action.accept(mvNames);
+        } catch (Exception e) {
+            Assert.fail();
+        } finally {
+            // Create mv may fail.
+            for (String mvName : mvNames) {
+                if (!Strings.isNullOrEmpty(mvName)) {
+                    try {
+                        dropMaterializedView(mvName);
+                    } catch (Exception e) {
+                        e.printStackTrace();
+                    }
+                }
+            }
+        }
+        return this;
+    }
+
     public StarRocksAssert withMaterializedView(String sql, ExceptionRunnable action) {
         String mvName = null;
         try {

--- a/fe/fe-core/src/test/resources/sql/materialized-view/tpch-hive/q1.sql
+++ b/fe/fe-core/src/test/resources/sql/materialized-view/tpch-hive/q1.sql
@@ -23,9 +23,9 @@ order by
 [result]
 TOP-N (order by [[9: l_returnflag ASC NULLS FIRST, 10: l_linestatus ASC NULLS FIRST]])
     TOP-N (order by [[9: l_returnflag ASC NULLS FIRST, 10: l_linestatus ASC NULLS FIRST]])
-        AGGREGATE ([GLOBAL] aggregate [{114: count=sum(114: count), 115: sum=sum(115: sum), 116: sum=sum(116: sum), 117: sum=sum(117: sum), 118: sum=sum(118: sum), 119: count=sum(119: count), 120: count=sum(120: count), 121: count=sum(121: count), 122: sum=sum(122: sum)}] group by [[29: l_returnflag, 30: l_linestatus]] having [null]
-            EXCHANGE SHUFFLE[29, 30]
-                AGGREGATE ([LOCAL] aggregate [{114: count=sum(36: count_discount), 115: sum=sum(31: sum_qty), 116: sum=sum(33: sum_base_price), 117: sum=sum(37: sum_disc_price), 118: sum=sum(38: sum_charge), 119: count=sum(39: count_order), 120: count=sum(32: count_qty), 121: count=sum(34: count_base_price), 122: sum=sum(35: sum_discount)}] group by [[29: l_returnflag, 30: l_linestatus]] having [null]
-                    SCAN (mv[lineitem_agg_mv1] columns[28: l_shipdate, 29: l_returnflag, 30: l_linestatus, 31: sum_qty, 32: count_qty, 33: sum_base_price, 34: count_base_price, 35: sum_discount, 36: count_discount, 37: sum_disc_price, 38: sum_charge, 39: count_order] predicate[28: l_shipdate <= 1998-12-01])
+        AGGREGATE ([GLOBAL] aggregate [{113: sum=sum(113: sum), 114: count=sum(114: count), 115: count=sum(115: count), 107: sum=sum(107: sum), 108: sum=sum(108: sum), 109: sum=sum(109: sum), 110: sum=sum(110: sum), 111: count=sum(111: count), 112: count=sum(112: count)}] group by [[92: l_returnflag, 93: l_linestatus]] having [null]
+            EXCHANGE SHUFFLE[92, 93]
+                AGGREGATE ([LOCAL] aggregate [{113: sum=sum(98: sum_discount), 114: count=sum(99: count_discount), 115: count=sum(102: count_order), 107: sum=sum(94: sum_qty), 108: sum=sum(96: sum_base_price), 109: sum=sum(100: sum_disc_price), 110: sum=sum(101: sum_charge), 111: count=sum(95: count_qty), 112: count=sum(97: count_base_price)}] group by [[92: l_returnflag, 93: l_linestatus]] having [null]
+                    SCAN (mv[lineitem_agg_mv1] columns[91: l_shipdate, 92: l_returnflag, 93: l_linestatus, 94: sum_qty, 95: count_qty, 96: sum_base_price, 97: count_base_price, 98: sum_discount, 99: count_discount, 100: sum_disc_price, 101: sum_charge, 102: count_order] predicate[91: l_shipdate <= 1998-12-01])
 [end]
 


### PR DESCRIPTION
Why I'm doing:
- MvProprecssor may cost too much time if there are too many related mvs for a query.

What I'm doing:
```
    /**
     * To avoid MvRewriteProcessor cost too much optimizer time, reduce all related mvs to a limited size.
     * <h3>Why to Choose The Best Related MVs Strategy</h3>
     *
     * <p>Why still to choose limited related mvs from all active mvs?</p>
     *
     * <p>1. optimizer time cost. Even there is MVPlanCache to reduce mv optimizer plan time, but it still may cost
     * too much time for mv preprocessor, because mv optimizer plan costs too much time because of cold start when
     * MVPlanCache has no cache, or MVPlanCache has exceeded limited capacity which is 1000 by default.</p>
     *
     * <p>2. check mv's freshness for each mv will cost too much time if there are too many mvs.</p>
     *
     * <h3>How to Choose The Best Related MVs Strategy</h3>
     * <p>
     *     Choose the best related mvs from all active mvs as following order:
     *     1. find the max intersected table num between mv and query which means it's better for rewrite.
     *     2. find the latest fresh mv which means its freshness is better.
     * </p>
     *
     * <h3>More Information</h3>
     * <p>
     *  NOTE: there are still some limitations about this ordering algorithm:
     *  1. consider repeated tables in one mv later which one table can be used repeatedly in one mv.
     *  2. consider random factor so can cache and use more mvs.
     * </p>
     */
```
Fixes https://github.com/StarRocks/starrocks/issues/38881


```
Before:
    // MvPreProcessorWithSSBBench.testPartitionPredicate2: [measured 10 out of 11 rounds, threads: 1 (sequential)]
    // round: 2.93 [+- 0.10], round.block: 0.00 [+- 0.00], round.gc: 0.00 [+- 0.00], GC.calls: 51, GC.time: 1.21,
    // time.total: 33.49, time.warmup: 4.16, time.bench: 29.33


After:
    // MvPreProcessorWithSSBBench.testPartitionPredicate: [measured 10 out of 11 rounds, threads: 1 (sequential)]
    // round: 0.32 [+- 0.08], round.block: 0.00 [+- 0.00], round.gc: 0.00 [+- 0.00], GC.calls: 4, GC.time: 0.05,
    // time.total: 4.40, time.warmup: 1.21, time.bench: 3.20



```

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [x] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [x] 3.1
  - [ ] 3.0
  - [ ] 2.5
