### PR TITLE
[Feature] support probe side subscribe pipeline finish event

### DIFF
--- a/be/src/exec/pipeline/adaptive/event.cpp
+++ b/be/src/exec/pipeline/adaptive/event.cpp
@@ -134,7 +134,7 @@ void CollectStatsSourceInitializeEvent::process(RuntimeState* state) {
 
 class DependsAllEvent final : public Event {
 public:
-    explicit DependsAllEvent(const std::vector<EventPtr>& events) : _events(events) {}
+    explicit DependsAllEvent(std::vector<EventPtr> events) : _events(std::move(events)) {}
 
     ~DependsAllEvent() override = default;
 

--- a/be/src/exec/pipeline/adaptive/event.h
+++ b/be/src/exec/pipeline/adaptive/event.h
@@ -46,6 +46,13 @@ public:
     std::string to_string() const;
     virtual std::string name() const { return "base_event"; }
 
+    bool need_wait_dependencies_finished() const { return _need_wait_dependencies_finished; }
+    void set_need_wait_dependencies_finished(bool need_wait_dependencies_finished) {
+        _need_wait_dependencies_finished = need_wait_dependencies_finished;
+    }
+
+    bool dependencies_finished() const { return _num_finished_dependencies.load() == _num_dependencies; }
+
 public:
     static EventPtr create_event();
     static EventPtr create_collect_stats_source_initialize_event(DriverExecutor* executor,
@@ -58,6 +65,8 @@ protected:
 
     std::atomic<bool> _finished{false};
     std::atomic<size_t> _num_finished_dependencies{0};
+
+    bool _need_wait_dependencies_finished{};
 };
 
 } // namespace starrocks::pipeline

--- a/be/src/exec/pipeline/pipeline_builder.cpp
+++ b/be/src/exec/pipeline/pipeline_builder.cpp
@@ -467,6 +467,11 @@ void PipelineBuilderContext::pop_dependent_pipeline() {
     _dependent_pipelines.pop_back();
 }
 
+void PipelineBuilderContext::subscribe_pipeline_event(Pipeline* pipeline, Event* event) {
+    pipeline->pipeline_event()->set_need_wait_dependencies_finished(true);
+    pipeline->pipeline_event()->add_dependency(event);
+}
+
 /// PipelineBuilder.
 Pipelines PipelineBuilder::build(const FragmentContext& fragment, ExecNode* exec_node) {
     pipeline::OpFactories operators = exec_node->decompose_to_pipeline(&_context);

--- a/be/src/exec/pipeline/pipeline_builder.h
+++ b/be/src/exec/pipeline/pipeline_builder.h
@@ -36,6 +36,11 @@ public:
 
     void add_pipeline(const OpFactories& operators) {
         _pipelines.emplace_back(std::make_shared<Pipeline>(next_pipe_id(), operators));
+        bool enable_wait_event = _fragment_context->runtime_state()->enable_wait_dependent_event();
+        if (enable_wait_event && !_dependent_pipelines.empty()) {
+            _pipelines.back()->pipeline_event();
+            subscribe_pipeline_event(_pipelines.back().get(), _dependent_pipelines.back()->pipeline_event());
+        }
     }
 
     OpFactories maybe_interpolate_local_broadcast_exchange(RuntimeState* state, int32_t plan_node_id,
@@ -137,6 +142,8 @@ public:
 
     void push_dependent_pipeline(const Pipeline* pipeline);
     void pop_dependent_pipeline();
+
+    void subscribe_pipeline_event(Pipeline* pipeline, Event* event);
 
 private:
     OpFactories _maybe_interpolate_local_passthrough_exchange(RuntimeState* state, int32_t plan_node_id,

--- a/be/src/exec/pipeline/pipeline_builder.h
+++ b/be/src/exec/pipeline/pipeline_builder.h
@@ -38,7 +38,6 @@ public:
         _pipelines.emplace_back(std::make_shared<Pipeline>(next_pipe_id(), operators));
         bool enable_wait_event = _fragment_context->runtime_state()->enable_wait_dependent_event();
         if (enable_wait_event && !_dependent_pipelines.empty()) {
-            _pipelines.back()->pipeline_event();
             subscribe_pipeline_event(_pipelines.back().get(), _dependent_pipelines.back()->pipeline_event());
         }
     }

--- a/be/src/exec/pipeline/pipeline_driver.cpp
+++ b/be/src/exec/pipeline/pipeline_driver.cpp
@@ -19,6 +19,7 @@
 
 #include "column/chunk.h"
 #include "common/statusor.h"
+#include "exec/pipeline/adaptive/event.h"
 #include "exec/pipeline/exchange/exchange_sink_operator.h"
 #include "exec/pipeline/pipeline_driver_executor.h"
 #include "exec/pipeline/scan/olap_scan_operator.h"
@@ -198,7 +199,7 @@ Status PipelineDriver::prepare(RuntimeState* runtime_state) {
     }
 
     // Driver has no dependencies always sets _all_dependencies_ready to true;
-    _all_dependencies_ready = _dependencies.empty();
+    _all_dependencies_ready = _dependencies.empty() && !_pipeline->pipeline_event()->need_wait_dependencies_finished();
     // Driver has no local rf to wait for completion always sets _all_local_rf_ready to true;
     _all_local_rf_ready = _local_rf_holders.empty();
     // Driver has no global rf to wait for completion always sets _all_global_rf_ready_or_timeout to true;
@@ -458,6 +459,17 @@ Status PipelineDriver::check_short_circuit() {
     return Status::OK();
 }
 
+bool PipelineDriver::dependencies_block() {
+    if (_all_dependencies_ready) {
+        return false;
+    }
+    auto pipline_event = _pipeline->pipeline_event();
+    _all_dependencies_ready =
+            std::all_of(_dependencies.begin(), _dependencies.end(), [](auto& dep) { return dep->is_ready(); }) &&
+            (!pipline_event->need_wait_dependencies_finished() || pipline_event->dependencies_finished());
+    return !_all_dependencies_ready;
+}
+
 bool PipelineDriver::need_report_exec_state() {
     if (is_finished()) {
         return false;
@@ -558,6 +570,9 @@ void PipelineDriver::_adjust_memory_usage(RuntimeState* state, MemTracker* track
     if (!state->enable_spill() || !mem_resource_mgr.releaseable()) return;
 
     if (UNLIKELY(state->spill_mode() == TSpillMode::RANDOM)) {
+        // random spill mode
+        // if the random number is less than the spill ratio, then convert to low-memory mode
+        // otherwise, do nothing
         static thread_local std::mt19937_64 generator{std::random_device{}()};
         static std::uniform_real_distribution<double> distribution(0.0, 1.0);
         if (distribution(generator) < state->spill_rand_ratio()) {

--- a/be/src/exec/pipeline/pipeline_driver.h
+++ b/be/src/exec/pipeline/pipeline_driver.h
@@ -318,14 +318,7 @@ public:
     bool pending_finish() { return _state == DriverState::PENDING_FINISH; }
     bool is_still_pending_finish() { return source_operator()->pending_finish() || sink_operator()->pending_finish(); }
     // return false if all the dependencies are ready, otherwise return true.
-    bool dependencies_block() {
-        if (_all_dependencies_ready) {
-            return false;
-        }
-        _all_dependencies_ready =
-                std::all_of(_dependencies.begin(), _dependencies.end(), [](auto& dep) { return dep->is_ready(); });
-        return !_all_dependencies_ready;
-    }
+    bool dependencies_block();
 
     // return false if all the local runtime filters are ready, otherwise return false.
     bool local_rf_block() {

--- a/be/src/runtime/runtime_state.h
+++ b/be/src/runtime/runtime_state.h
@@ -432,6 +432,9 @@ public:
     }
 
     bool is_jit_enabled() const { return _query_options.__isset.enable_jit && _query_options.enable_jit; }
+    bool enable_wait_dependent_event() const {
+        return _query_options.__isset.enable_wait_dependent_event && _query_options.enable_wait_dependent_event;
+    }
 
     std::string_view get_sql_dialect() const { return _query_options.sql_dialect; }
 

--- a/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
@@ -465,6 +465,8 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
     public static final String ENABLE_STRICT_ORDER_BY = "enable_strict_order_by";
     private static final String CBO_SPLIT_SCAN_PREDICATE_WITH_DATE = "enable_split_scan_predicate_with_date";
 
+    public static final String ENABLE_WAIT_DEPENDENT_EVENT = "enable_wait_dependent_event";
+
     // Flag to control whether to proxy follower's query statement to leader/follower.
     public enum FollowerQueryForwardMode {
         DEFAULT,    // proxy queries by the follower's replay progress (default)
@@ -1767,6 +1769,15 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
 
     @VarAttr(name = ENABLE_STRICT_ORDER_BY)
     private boolean enableStrictOrderBy = true;
+
+    // enable wait dependent event in plan fragment
+    // the operators will wait for the dependent event to be completed before executing
+    // all of the probe side operators will wait for the build side operators to complete.
+    // Scenarios where AGG is present in the probe side will reduce peak memory usage, 
+    // but in some cases will result in increased latency for individual queries.
+    // 
+    @VarAttr(name = ENABLE_WAIT_DEPENDENT_EVENT)
+    private boolean enableWaitDependentEvent = false;
 
     public void setFollowerQueryForwardMode(String mode) {
         this.followerForwardMode = mode;
@@ -3380,6 +3391,7 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
         tResult.setEnable_pipeline_level_shuffle(enablePipelineLevelShuffle);
         tResult.setEnable_hyperscan_vec(enableHyperscanVec);
         tResult.setEnable_jit(enableJit);
+        tResult.setEnable_wait_dependent_event(enableWaitDependentEvent);
         return tResult;
     }
 

--- a/gensrc/thrift/InternalService.thrift
+++ b/gensrc/thrift/InternalService.thrift
@@ -276,6 +276,8 @@ struct TQueryOptions {
 
   117: optional bool enable_spill_to_remote_storage;
   118: optional TSpillToRemoteStorageOptions spill_to_remote_storage_options;
+  
+  130: optional bool enable_wait_dependent_event = false;
 }
 
 

--- a/test/sql/test_multi_ops/R/test_depends_ops
+++ b/test/sql/test_multi_ops/R/test_depends_ops
@@ -1,0 +1,155 @@
+-- name: test_depends_ops
+set enable_wait_dependent_event = true;
+-- result:
+-- !result
+create table t0 (c0 INT, c1 BIGINT) DUPLICATE KEY(c0) DISTRIBUTED BY HASH(c0) BUCKETS 4 PROPERTIES('replication_num' = '1');
+-- result:
+-- !result
+insert into
+    t0
+SELECT
+    generate_series,
+    4096 - generate_series
+FROM
+    TABLE(generate_series(1, 4096));
+-- result:
+-- !result
+insert into
+    t0
+select
+    *
+from
+    t0;
+-- result:
+-- !result
+insert into
+    t0
+select
+    *
+from
+    t0;
+-- result:
+-- !result
+select
+    count(*)
+from
+    t0;
+-- result:
+16384
+-- !result
+with aggregated_table as (
+    select
+        trim(c0) as c0,
+        c1 as c1
+    from
+        t0
+    group by
+        1,
+        2
+)
+select
+    *
+from
+    aggregated_table l1
+    left join [shuffle] aggregated_table r1 on l1.c0 = r1.c0
+    and l1.c1 = r1.c1
+order by
+    1,
+    2,
+    3,
+    4 desc
+limit
+    10;
+-- result:
+1	4095	1	4095
+10	4086	10	4086
+100	3996	100	3996
+1000	3096	1000	3096
+1001	3095	1001	3095
+1002	3094	1002	3094
+1003	3093	1003	3093
+1004	3092	1004	3092
+1005	3091	1005	3091
+1006	3090	1006	3090
+-- !result
+with aggregated_table as (
+    select
+        trim(c0) as c0,
+        c1 as c1
+    from
+        t0
+    group by
+        1,
+        2
+)
+select
+    count(*)
+from
+    (
+        select
+            *
+        from
+            aggregated_table l1
+            left join [shuffle] aggregated_table r1 on l1.c0 = r1.c0
+            and l1.c1 = r1.c1
+            left join [shuffle] aggregated_table r2 on l1.c0 = r2.c0
+            and l1.c1 = r2.c1
+    ) tb;
+-- result:
+4096
+-- !result
+with aggregated_table as (
+    select
+        trim(c0) as c0,
+        c1 as c1
+    from
+        t0
+    group by
+        1,
+        2
+)
+select
+    sum(l1.c0),
+    sum(l1.c1),
+    sum(l1.c0),
+    sum(l1.c1)
+from
+    aggregated_table l1
+    left join [shuffle] aggregated_table r1 on l1.c0 = r1.c0
+    and l1.c1 = r1.c1
+    left join [shuffle] aggregated_table r2 on l1.c0 = r2.c0
+    and l1.c1 = r2.c1;
+-- result:
+8390656.0	8386560	8390656.0	8386560
+-- !result
+create view aggregated_table as
+select
+    trim(c0) as c0,
+    c1 as c1
+from
+    t0
+group by
+    1,
+    2;
+-- result:
+-- !result
+select l.c1, sum(l.c0) ,sum(r.c0) from aggregated_table l join aggregated_table r on l.c0 <= r.c0 and r.c0 < 10 group by 1 order by 2, 3 limit 10;
+-- result:
+4095	1.0	1.0
+-- !result
+select l.c1, l.c0 from aggregated_table l except select r.c1, r.c0 from aggregated_table r;
+-- result:
+-- !result
+select l.c1, l.c0 from aggregated_table l intersect select r.c1, r.c0 from aggregated_table r order by 1, 2 limit 10;
+-- result:
+0	4096
+1	4095
+2	4094
+3	4093
+4	4092
+5	4091
+6	4090
+7	4089
+8	4088
+9	4087
+-- !result

--- a/test/sql/test_multi_ops/T/test_depends_ops
+++ b/test/sql/test_multi_ops/T/test_depends_ops
@@ -1,0 +1,121 @@
+-- name: test_depends_ops
+set enable_wait_dependent_event = true;
+
+create table t0 (c0 INT, c1 BIGINT) DUPLICATE KEY(c0) DISTRIBUTED BY HASH(c0) BUCKETS 4 PROPERTIES('replication_num' = '1');
+
+insert into
+    t0
+SELECT
+    generate_series,
+    4096 - generate_series
+FROM
+    TABLE(generate_series(1, 4096));
+
+insert into
+    t0
+select
+    *
+from
+    t0;
+
+insert into
+    t0
+select
+    *
+from
+    t0;
+
+-- count rows
+select
+    count(*)
+from
+    t0;
+
+-- two aggregate table shuffle join
+with aggregated_table as (
+    select
+        trim(c0) as c0,
+        c1 as c1
+    from
+        t0
+    group by
+        1,
+        2
+)
+select
+    *
+from
+    aggregated_table l1
+    left join [shuffle] aggregated_table r1 on l1.c0 = r1.c0
+    and l1.c1 = r1.c1
+order by
+    1,
+    2,
+    3,
+    4 desc
+limit
+    10;
+
+-- three aggregate table shuffle join
+with aggregated_table as (
+    select
+        trim(c0) as c0,
+        c1 as c1
+    from
+        t0
+    group by
+        1,
+        2
+)
+select
+    count(*)
+from
+    (
+        select
+            *
+        from
+            aggregated_table l1
+            left join [shuffle] aggregated_table r1 on l1.c0 = r1.c0
+            and l1.c1 = r1.c1
+            left join [shuffle] aggregated_table r2 on l1.c0 = r2.c0
+            and l1.c1 = r2.c1
+    ) tb;
+
+-- three aggregate table shuffle join and sum
+with aggregated_table as (
+    select
+        trim(c0) as c0,
+        c1 as c1
+    from
+        t0
+    group by
+        1,
+        2
+)
+select
+    sum(l1.c0),
+    sum(l1.c1),
+    sum(l1.c0),
+    sum(l1.c1)
+from
+    aggregated_table l1
+    left join [shuffle] aggregated_table r1 on l1.c0 = r1.c0
+    and l1.c1 = r1.c1
+    left join [shuffle] aggregated_table r2 on l1.c0 = r2.c0
+    and l1.c1 = r2.c1;
+
+create view aggregated_table as
+select
+    trim(c0) as c0,
+    c1 as c1
+from
+    t0
+group by
+    1,
+    2;
+-- nest loop join
+select l.c1, sum(l.c0) ,sum(r.c0) from aggregated_table l join aggregated_table r on l.c0 <= r.c0 and r.c0 < 10 group by 1 order by 2, 3 limit 10;
+-- except operator
+select l.c1, l.c0 from aggregated_table l except select r.c1, r.c0 from aggregated_table r;
+-- intersect operator
+select l.c1, l.c0 from aggregated_table l intersect select r.c1, r.c0 from aggregated_table r order by 1, 2 limit 10;


### PR DESCRIPTION
Why I'm doing:
for such query:
```
select
    count(*)
from
    (
        select
            *
        from
            (
                select
                    trim(lo_orderkey) as lo_orderkey,
                    lo_linenumber
                from
                    lineorder l1
                where
                    lo_orderkey < 100000000
                group by
                    1,
                    2
            ) l1
            left join [shuffle] (
                select
                    trim(lo_orderkey) as lo_orderkey,
                    lo_linenumber
                from
                    lineorder l2
                where
                    lo_orderkey < 100000000
                group by
                    1,
                    2
            ) l2 on l1.lo_orderkey = l2.lo_orderkey
            and l1.lo_linenumber = l2.lo_linenumber
            left join [shuffle] (
                 select
                    trim(lo_orderkey) as lo_orderkey,
                    lo_linenumber
                from
                    lineorder l3
                where
                    lo_orderkey < 100000000
                group by
                    1,
                    2
            ) l3 on l1.lo_orderkey = l3.lo_orderkey
            and l1.lo_linenumber = l3.lo_linenumber
    ) tb;
```
![image](https://github.com/StarRocks/starrocks/assets/34912776/7f732b7f-65a0-487a-abd0-fd38afb5ca7e)
All build side operators are executed concurrently. This will cause our build peak memory 2 x Mem(AGG) + 2 x Mem(Join)

In fact, we could have done a sequential build of the pipeline build side, which would have reduced our memory to 2 x Mem(Join)

We need to support a pipeline scheduling mode that allows lower memory usage.

What I'm doing:

We subscribe to the operators of dependent pipelines at pipeline build time. these pipelines are only scheduled after the dependent pipeline is finished

baseline: PeakMemoryUsage: 28G
patched: PeakMemoryUsage: 19G (set enable_wait_dependent_event=true;)

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [x] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
