### PR TITLE
[BugFix] fix bug of null type to boolean type

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AnalyzerUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AnalyzerUtils.java
@@ -118,6 +118,7 @@ import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
@@ -1201,6 +1202,10 @@ public class AnalyzerUtils {
             }
         }
         return null;
+    }
+
+    public static Type[] replaceNullTypes2Booleans(Type[] types) {
+        return Arrays.stream(types).map(type -> replaceNullType2Boolean(type)).toArray(Type[]::new);
     }
 
     public static Type replaceNullType2Boolean(Type type) {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/PolymorphicFunctionAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/PolymorphicFunctionAnalyzer.java
@@ -37,7 +37,6 @@ import org.apache.logging.log4j.Logger;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
-import java.util.stream.Collectors;
 
 import static com.starrocks.sql.analyzer.AnalyzerUtils.replaceNullType2Boolean;
 

--- a/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AnalyzeExprTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AnalyzeExprTest.java
@@ -502,10 +502,11 @@ public class AnalyzeExprTest {
 
     @Test
     public void testAnalyseNullToBoolean() {
-        analyzeSuccess("select coalesce(map{to_date(\"2020-02-02 00:00:00\"):1}, map{})");
-        analyzeSuccess("select coalesce([to_date(\"2020-02-02 00:00:00\")], [])");
-        analyzeSuccess("select coalesce(row(to_date(\"2020-02-02 00:00:00\")), row())");
+//        analyzeSuccess("select coalesce(map{to_date(\"2020-02-02 00:00:00\"):1}, map{})");
+//        analyzeSuccess("select coalesce([to_date(\"2020-02-02 00:00:00\")], [])");
+        analyzeSuccess("select coalesce(struct(to_date(\"2020-02-02 00:00:00\")), NULL)");
         analyzeSuccess("select ifnull(map{to_date(\"2020-02-02 00:00:00\"):1}, map{})");
+        analyzeSuccess("select map_from_arrays([1, 2], NULL)");
     }
 
 }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AnalyzeExprTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AnalyzeExprTest.java
@@ -502,8 +502,8 @@ public class AnalyzeExprTest {
 
     @Test
     public void testAnalyseNullToBoolean() {
-//        analyzeSuccess("select coalesce(map{to_date(\"2020-02-02 00:00:00\"):1}, map{})");
-//        analyzeSuccess("select coalesce([to_date(\"2020-02-02 00:00:00\")], [])");
+        analyzeSuccess("select coalesce(map{to_date(\"2020-02-02 00:00:00\"):1}, map{})");
+        analyzeSuccess("select coalesce([to_date(\"2020-02-02 00:00:00\")], [])");
         analyzeSuccess("select coalesce(struct(to_date(\"2020-02-02 00:00:00\")), NULL)");
         analyzeSuccess("select ifnull(map{to_date(\"2020-02-02 00:00:00\"):1}, map{})");
         analyzeSuccess("select map_from_arrays([1, 2], NULL)");

--- a/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AnalyzeExprTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AnalyzeExprTest.java
@@ -503,6 +503,8 @@ public class AnalyzeExprTest {
     @Test
     public void testAnalyseNullToBoolean() {
         analyzeSuccess("select coalesce(map{to_date(\"2020-02-02 00:00:00\"):1}, map{})");
+        analyzeSuccess("select coalesce([to_date(\"2020-02-02 00:00:00\")], [])");
+        analyzeSuccess("select coalesce(row(to_date(\"2020-02-02 00:00:00\")), row())");
         analyzeSuccess("select ifnull(map{to_date(\"2020-02-02 00:00:00\"):1}, map{})");
     }
 

--- a/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AnalyzeExprTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AnalyzeExprTest.java
@@ -431,6 +431,7 @@ public class AnalyzeExprTest {
         analyzeSuccess("select map_concat(NULL)");
         analyzeSuccess("select map_concat(NULL,NULL)");
         analyzeSuccess("select map_concat(NULL,map{})");
+        analyzeSuccess("select map_concat(NULL,map{to_date(\"2020-02-02 00:00:00\"):2})");
 
         analyzeFail("select cardinality();");
         analyzeFail("select cardinality(map{},map{})");
@@ -497,6 +498,12 @@ public class AnalyzeExprTest {
         analyzeFail("select array_sortby('[a,b]','[1,2]')");
         analyzeFail("select array_sum('[1,2]')");
         analyzeFail("select array_to_bitmap('[1,2]')");
+    }
+
+    @Test
+    public void testAnalyseNullToBoolean() {
+        analyzeSuccess("select coalesce(map{to_date(\"2020-02-02 00:00:00\"):1}, map{})");
+        analyzeSuccess("select ifnull(map{to_date(\"2020-02-02 00:00:00\"):1}, map{})");
     }
 
 }


### PR DESCRIPTION
Why I'm doing:
[] will be translated into array[boolean] from NULL_TYPE in FE because BE don't know anything NULL_TYPE, but when use some function like coalesce, we need calculate coalesce's arguments' common super type and cast arguments into common super type, but array[boolean] don't have common super type with many types like array[datetime] , but array[null_type] have common super type with array[datetime]

What I'm doing:
1.change null into array[null]/map{null,null}/struct(null)
2.find common super type
3.change ervery null type into boolean type

Fixes #issue
fix https://github.com/StarRocks/starrocks/issues/39346

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
- [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [x] 3.1
  - [ ] 3.0
  - [ ] 2.5
