### PR TITLE
[BugFix] Cannot do vertical compaction for only one rowset input

### DIFF
--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -303,6 +303,10 @@ CONF_mBool(enable_lazy_delta_column_compaction, "true");
 CONF_mInt32(update_compaction_check_interval_seconds, "10");
 CONF_mInt32(update_compaction_num_threads_per_disk, "1");
 CONF_mInt32(update_compaction_per_tablet_min_interval_seconds, "120"); // 2min
+// using this config to adjust chunk size used in compaction for row store
+// if this value is 0, auto chunk size calculation algorithm will be used
+// set this value to none zero if auto algorithm isn't working well
+CONF_mInt32(update_compaction_chunk_size_for_row_store, "0");
 CONF_mInt64(max_update_compaction_num_singleton_deltas, "1000");
 CONF_mInt64(update_compaction_size_threshold, "268435456");
 CONF_mInt64(update_compaction_result_bytes, "1073741824");

--- a/be/src/storage/compaction_utils.cpp
+++ b/be/src/storage/compaction_utils.cpp
@@ -43,10 +43,9 @@ int32_t CompactionUtils::get_read_chunk_size(int64_t mem_limit, int32_t config_c
         int64_t avg_row_size = (total_mem_footprint + 1) / (total_num_rows + 1);
         // The result of the division operation be zero, so added one
         chunk_size = 1 + mem_limit / (source_num * avg_row_size + 1);
-    }
-
-    if (chunk_size > config_chunk_size) {
-        chunk_size = config_chunk_size;
+        if (chunk_size > config_chunk_size) {
+            chunk_size = config_chunk_size;
+        }
     }
     return (uint32_t)chunk_size;
 }

--- a/be/src/storage/rowset/rowset.cpp
+++ b/be/src/storage/rowset/rowset.cpp
@@ -677,7 +677,8 @@ Status Rowset::get_segment_iterators(const Schema& schema, const RowsetReadOptio
 StatusOr<std::vector<ChunkIteratorPtr>> Rowset::get_segment_iterators2(const Schema& schema,
                                                                        const TabletSchemaCSPtr& tablet_schema,
                                                                        KVStore* meta, int64_t version,
-                                                                       OlapReaderStatistics* stats, KVStore* dcg_meta) {
+                                                                       OlapReaderStatistics* stats, KVStore* dcg_meta,
+                                                                       size_t chunk_size) {
     RETURN_IF_ERROR(load());
 
     SegmentReadOptions seg_options;
@@ -690,6 +691,9 @@ StatusOr<std::vector<ChunkIteratorPtr>> Rowset::get_segment_iterators2(const Sch
     seg_options.tablet_schema = tablet_schema;
     seg_options.delvec_loader = std::make_shared<LocalDelvecLoader>(meta);
     seg_options.dcg_loader = std::make_shared<LocalDeltaColumnGroupLoader>(meta != nullptr ? meta : dcg_meta);
+    if (chunk_size > 0) {
+        seg_options.chunk_size = chunk_size;
+    }
 
     std::vector<ChunkIteratorPtr> seg_iterators(num_segments());
     TabletSegmentId tsid;

--- a/be/src/storage/rowset/rowset.h
+++ b/be/src/storage/rowset/rowset.h
@@ -188,7 +188,7 @@ public:
                                                                    const TabletSchemaCSPtr& tablet_schema,
                                                                    KVStore* meta, int64_t version,
                                                                    OlapReaderStatistics* stats,
-                                                                   KVStore* dcg_meta = nullptr);
+                                                                   KVStore* dcg_meta = nullptr, size_t chunk_size = 0);
 
     // only used for updatable tablets' rowset in column mode partial update
     // simply get iterators to iterate all rows without complex options like predicates

--- a/be/src/storage/rowset_merger.cpp
+++ b/be/src/storage/rowset_merger.cpp
@@ -23,6 +23,7 @@
 #include "storage/empty_iterator.h"
 #include "storage/merge_iterator.h"
 #include "storage/primary_key_encoder.h"
+#include "storage/rowset/column_reader.h"
 #include "storage/rowset/rowset_options.h"
 #include "storage/rowset/rowset_writer.h"
 #include "storage/tablet.h"
@@ -133,6 +134,32 @@ struct MergeEntryCmp {
     }
 };
 
+static int32_t calculate_chunk_size_for_column_group(const Schema& column_group_schema,
+                                                     const vector<RowsetSharedPtr>& rowsets) {
+    int64_t total_num_rows = 0;
+    int64_t total_mem_footprint = 0;
+    // TODO: using actual merge element count after fixing merge bug for non-overlapping rowset
+    int64_t total_input_segs = 0;
+    for (const auto& rowset : rowsets) {
+        total_num_rows += rowset->num_rows();
+        total_input_segs += rowset->num_segments();
+        const auto& segments = rowset->segments();
+        for (const auto& segment : segments) {
+            for (auto& field : column_group_schema.fields()) {
+                const auto* column_reader = segment->column_with_uid(field->uid());
+                if (column_reader == nullptr) {
+                    continue;
+                }
+                total_mem_footprint += column_reader->total_mem_footprint();
+            }
+        }
+    }
+    int32_t chunk_size =
+            CompactionUtils::get_read_chunk_size(config::compaction_memory_limit_per_worker, config::vector_chunk_size,
+                                                 total_num_rows, total_mem_footprint, total_input_segs);
+    return chunk_size;
+}
+
 // heap based rowset merger used for updatable tablet's compaction
 template <class T>
 class RowsetMergerImpl : public RowsetMerger {
@@ -226,8 +253,6 @@ public:
     Status do_merge(Tablet& tablet, const starrocks::TabletSchemaCSPtr& tablet_schema, int64_t version,
                     const Schema& schema, const vector<RowsetSharedPtr>& rowsets, RowsetWriter* writer,
                     const MergeConfig& cfg) override {
-        _chunk_size = cfg.chunk_size;
-
         size_t total_input_size = 0;
         size_t total_rows = 0;
         size_t total_chunk = 0;
@@ -235,18 +260,18 @@ public:
         vector<vector<uint32_t>> column_groups;
         MonotonicStopWatch timer;
         timer.start();
+        Status st;
         if (cfg.algorithm == VERTICAL_COMPACTION) {
             CompactionUtils::split_column_into_groups(schema.num_fields(), schema.sort_key_idxes(),
                                                       config::vertical_compaction_max_columns_per_group,
                                                       &column_groups);
-            RETURN_IF_ERROR(_do_merge_vertically(tablet, tablet_schema, version, rowsets, writer, cfg, column_groups,
-                                                 &total_input_size, &total_rows, &total_chunk, &stats));
+            st = _do_merge_vertically(tablet, tablet_schema, version, rowsets, writer, cfg, column_groups,
+                                      &total_input_size, &total_rows, &total_chunk, &stats);
         } else {
-            RETURN_IF_ERROR(_do_merge_horizontally(tablet, tablet_schema, version, schema, rowsets, writer, cfg,
-                                                   &total_input_size, &total_rows, &total_chunk, &stats));
+            st = _do_merge_horizontally(tablet, tablet_schema, version, schema, rowsets, writer, cfg, &total_input_size,
+                                        &total_rows, &total_chunk, &stats);
         }
         timer.stop();
-
         // update compaction metric
         float divided = 1000 * 1000 * 1000;
         StarRocksMetrics::instance()->update_compaction_task_cost_time_ns.set_value(timer.elapsed_time());
@@ -256,17 +281,23 @@ public:
         StarRocksMetrics::instance()->update_compaction_bytes_total.increment(total_input_size);
         StarRocksMetrics::instance()->update_compaction_outputs_total.increment(1);
         StarRocksMetrics::instance()->update_compaction_outputs_bytes_total.increment(writer->total_data_size());
-        LOG(INFO) << "compaction merge finished. tablet=" << tablet.tablet_id()
-                  << " #key=" << schema.sort_key_idxes().size()
-                  << " algorithm=" << CompactionUtils::compaction_algorithm_to_string(cfg.algorithm)
-                  << " column_group_size=" << column_groups.size() << " input("
-                  << "entry=" << _entries.size() << " rows=" << stats.raw_rows_read
-                  << " del=" << stats.rows_del_vec_filtered << " actual=" << stats.raw_rows_read
-                  << " bytes=" << PrettyPrinter::print(total_input_size, TUnit::BYTES) << ") output(rows=" << total_rows
-                  << " chunk=" << total_chunk
-                  << " bytes=" << PrettyPrinter::print(writer->total_data_size(), TUnit::BYTES)
-                  << ") duration: " << timer.elapsed_time() / 1000000 << "ms";
-        return Status::OK();
+        std::stringstream ss;
+        ss << "update compaction merge finished. tablet=" << tablet.tablet_id()
+           << " #key=" << schema.sort_key_idxes().size()
+           << " algorithm=" << CompactionUtils::compaction_algorithm_to_string(cfg.algorithm)
+           << " column_group_size=" << column_groups.size() << " chunk_size min:" << _min_chunk_size
+           << " max:" << _max_chunk_size << " input("
+           << "entry=" << _entries.size() << " rows=" << stats.raw_rows_read << " del=" << stats.rows_del_vec_filtered
+           << " actual=" << stats.raw_rows_read << " bytes=" << PrettyPrinter::print(total_input_size, TUnit::BYTES)
+           << ") output(rows=" << total_rows << " chunk=" << total_chunk
+           << " bytes=" << PrettyPrinter::print(writer->total_data_size(), TUnit::BYTES)
+           << ") duration: " << timer.elapsed_time() / 1000000 << "ms";
+        if (st.ok()) {
+            LOG(INFO) << ss.str();
+        } else {
+            LOG(WARNING) << ss.str() << ", err=" << st.message();
+        }
+        return st;
     }
 
 private:
@@ -284,6 +315,12 @@ private:
         } else if (schema.sort_key_idxes().size() == 1 && schema.field(schema.sort_key_idxes()[0])->is_nullable()) {
             sort_column = std::make_unique<BinaryColumn>();
         }
+        _chunk_size = calculate_chunk_size_for_column_group(schema, rowsets);
+        if (tablet.is_column_with_row_store() && config::update_compaction_chunk_size_for_row_store > 0) {
+            _chunk_size = config::update_compaction_chunk_size_for_row_store;
+        }
+        _min_chunk_size = std::min(_min_chunk_size, _chunk_size);
+        _max_chunk_size = std::max(_max_chunk_size, _chunk_size);
         std::vector<std::unique_ptr<vector<RowSourceMask>>> rowsets_source_masks;
         uint16_t order = 0;
         for (const auto& rowset : rowsets) {
@@ -292,7 +329,7 @@ private:
             MergeEntry<T>& entry = *_entries.back();
             entry.rowset_release_guard = std::make_unique<RowsetReleaseGuard>(rowset);
             auto res = rowset->get_segment_iterators2(schema, tablet_schema, tablet.data_dir()->get_meta(), version,
-                                                      stats);
+                                                      stats, nullptr, _chunk_size);
             if (!res.ok()) {
                 return res.status();
             }
@@ -452,6 +489,12 @@ private:
             iterators.reserve(rowsets.size());
             OlapReaderStatistics non_key_stats;
             Schema schema = ChunkHelper::convert_schema(tablet_schema, column_groups[i]);
+            _chunk_size = calculate_chunk_size_for_column_group(schema, rowsets);
+            if (tablet.is_column_with_row_store() && config::update_compaction_chunk_size_for_row_store > 0) {
+                _chunk_size = config::update_compaction_chunk_size_for_row_store;
+            }
+            _min_chunk_size = std::min(_min_chunk_size, _chunk_size);
+            _max_chunk_size = std::max(_max_chunk_size, _chunk_size);
             for (size_t j = 0; j < rowsets.size(); j++) {
                 const auto& rowset = rowsets[j];
                 RETURN_IF_ERROR(rowsets_mask_buffer[j]->flip_to_read());
@@ -459,7 +502,7 @@ private:
                 MergeEntry<T>& entry = *_entries.back();
                 entry.rowset_release_guard = std::make_unique<RowsetReleaseGuard>(rowset);
                 auto res = rowset->get_segment_iterators2(schema, tablet_schema, tablet.data_dir()->get_meta(), version,
-                                                          &non_key_stats);
+                                                          &non_key_stats, nullptr, _chunk_size);
                 if (!res.ok()) {
                     return res.status();
                 }
@@ -532,7 +575,11 @@ private:
         return Status::OK();
     }
 
-    size_t _chunk_size = 0;
+    int32_t _chunk_size = 0;
+    // chunk_size are constantly changing when doing vertical compaction, track the min and max value of
+    // _chunk_size and print them in log
+    int32_t _min_chunk_size = INT_MAX;
+    int32_t _max_chunk_size = INT_MIN;
     std::vector<std::unique_ptr<MergeEntry<T>>> _entries;
     using Heap = std::priority_queue<MergeEntry<T>*, std::vector<MergeEntry<T>*>, MergeEntryCmp<T>>;
     Heap _heap;

--- a/be/src/storage/rowset_merger.h
+++ b/be/src/storage/rowset_merger.h
@@ -21,7 +21,6 @@
 namespace starrocks {
 
 struct MergeConfig {
-    size_t chunk_size;
     CompactionAlgorithm algorithm = HORIZONTAL_COMPACTION;
 };
 

--- a/be/src/storage/tablet_updates.cpp
+++ b/be/src/storage/tablet_updates.cpp
@@ -1738,6 +1738,7 @@ Status TabletUpdates::_do_compaction(std::unique_ptr<CompactionInfo>* pinfo) {
     auto scope = IOProfiler::scope(IOProfiler::TAG_COMPACTION, _tablet.tablet_id());
     int64_t input_rowsets_size = 0;
     int64_t input_row_num = 0;
+    size_t num_segments = 0;
     auto info = (*pinfo).get();
     vector<RowsetSharedPtr> input_rowsets(info->inputs.size());
     {
@@ -1755,13 +1756,14 @@ Status TabletUpdates::_do_compaction(std::unique_ptr<CompactionInfo>* pinfo) {
                 input_rowsets[i] = itr->second;
                 input_rowsets_size += input_rowsets[i]->data_disk_size();
                 input_row_num += input_rowsets[i]->num_rows();
+                num_segments += input_rowsets[i]->num_segments();
             }
         }
     }
 
     auto cur_tablet_schema = CompactionUtils::rowset_with_max_schema_version(input_rowsets)->schema();
     CompactionAlgorithm algorithm = CompactionUtils::choose_compaction_algorithm(
-            cur_tablet_schema->num_columns(), config::vertical_compaction_max_columns_per_group, input_rowsets.size());
+            cur_tablet_schema->num_columns(), config::vertical_compaction_max_columns_per_group, num_segments);
 
     RowsetWriterContext context;
     context.rowset_id = StorageEngine::instance()->next_rowset_id();
@@ -1786,7 +1788,6 @@ Status TabletUpdates::_do_compaction(std::unique_ptr<CompactionInfo>* pinfo) {
         return Status::InternalError(ss.str());
     }
     MergeConfig cfg;
-    cfg.chunk_size = config::vector_chunk_size;
     cfg.algorithm = algorithm;
 
     // compaction task maybe failed if tablet is deleted

--- a/be/test/storage/rowset_merger_test.cpp
+++ b/be/test/storage/rowset_merger_test.cpp
@@ -225,8 +225,7 @@ TEST_F(RowsetMergerTest, horizontal_merge) {
     const int num_segment = 1 + rand() % max_segments;
     const int N = 500000 + rand() % 1000000;
     MergeConfig cfg;
-    cfg.chunk_size = 1000 + rand() % 2000;
-    LOG(INFO) << "merge test #rowset:" << num_segment << " #row:" << N << " chunk_size:" << cfg.chunk_size;
+    LOG(INFO) << "merge test #rowset:" << num_segment << " #row:" << N;
     vector<uint32_t> rssids(N);
     vector<vector<int64_t>> segments(num_segment);
     for (int i = 0; i < N; i++) {
@@ -274,7 +273,6 @@ TEST_F(RowsetMergerTest, vertical_merge) {
     const int num_segment = 2 + rand() % max_segments;
     const int N = 500000 + rand() % 1000000;
     MergeConfig cfg;
-    cfg.chunk_size = 1000 + rand() % 2000;
     cfg.algorithm = VERTICAL_COMPACTION;
     vector<uint32_t> rssids(N);
     vector<vector<int64_t>> segments(num_segment);
@@ -332,13 +330,11 @@ TEST_F(RowsetMergerTest, horizontal_merge_seq) {
     const int num_segment = 1 + rand() % max_segments;
     const int N = 500000 + rand() % 1000000;
     MergeConfig cfg;
-    cfg.chunk_size = 100 + rand() % 2000;
     // small size test
     //    const int num_segment = 3;
     //    const int N = 30;
     //    MergeConfig cfg;
-    //    cfg.chunk_size = 20;
-    LOG(INFO) << "seq merge test #rowset:" << num_segment << " #row:" << N << " chunk_size:" << cfg.chunk_size;
+    LOG(INFO) << "seq merge test #rowset:" << num_segment << " #row:" << N;
     vector<uint32_t> rssids(N);
     vector<vector<int64_t>> segments(num_segment);
     for (int i = 0; i < N; i++) {
@@ -385,7 +381,6 @@ TEST_F(RowsetMergerTest, vertical_merge_seq) {
     const int num_segment = 2 + rand() % max_segments;
     const int N = 500000 + rand() % 1000000;
     MergeConfig cfg;
-    cfg.chunk_size = 100 + rand() % 2000;
     cfg.algorithm = VERTICAL_COMPACTION;
     vector<uint32_t> rssids(N);
     vector<vector<int64_t>> segments(num_segment);


### PR DESCRIPTION
Why I'm doing:

Compactions are very easy to OOM for column with row table, it turn's out there is a bug in compaction algorithm selection, it currently considers rowset size as input size, but really should use segment size. As a result, when compaction only 1 rowset with 300 segments, vertical compaction is not used.

What I'm doing:

1. Using segment size as input size.
2. Introduce new config to adjust chunk size to reduce compaction memory used.

`update_compaction_chunk_size_for_row_store`

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
