### PR TITLE
[Doc] Update expression_partitioning.md

### DIFF
--- a/docs/en/table_design/expression_partitioning.md
+++ b/docs/en/table_design/expression_partitioning.md
@@ -132,6 +132,10 @@ partition_columns ::=
 
 ### Parameters
 
+:::note
+As of 3.1, only support partition by date_trunc() for date or datetime.
+:::
+
 | **Parameters**          | **Required** | **Description**                                                  |
 | ----------------------- | -------- | ------------------------------------------------------------ |
 | `partition_columns`     | YES      | The names of partition columns.<br/> <ul><li>The partition column values can be string (BINARY not supported), date or datetime, integer, and boolean values. The partition column allows `NULL` values.</li><li> Each partition can only contain data with the same value for a partition column. To include data with different values in a partition column in a partition, see [List partitioning](./list_partitioning.md).</li></ul> |


### PR DESCRIPTION
Update docs to say that `Currently, only support partition by date_trunc() for date or datetime.`

Why I'm doing:

What I'm doing:

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [x] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [x] 3.1
  - [x] 3.0
  - [x] 2.5
