### PR TITLE
[Refactor] Add retry in the broker load when timeout (backport #38183)

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/load/loadv2/BrokerLoadJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/loadv2/BrokerLoadJob.java
@@ -61,12 +61,15 @@ import com.starrocks.metric.TableMetricsEntity;
 import com.starrocks.metric.TableMetricsRegistry;
 import com.starrocks.persist.AlterLoadJobOperationLog;
 import com.starrocks.qe.ConnectContext;
+import com.starrocks.qe.Coordinator;
 import com.starrocks.qe.OriginStatement;
+import com.starrocks.qe.QeProcessorImpl;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.service.FrontendOptions;
 import com.starrocks.sql.ast.AlterLoadStmt;
 import com.starrocks.sql.ast.LoadStmt;
 import com.starrocks.sql.ast.UserIdentity;
+import com.starrocks.task.PriorityLeaderTask;
 import com.starrocks.thrift.TLoadJobType;
 import com.starrocks.thrift.TReportExecStatusParams;
 import com.starrocks.thrift.TUniqueId;
@@ -291,6 +294,67 @@ public class BrokerLoadJob extends BulkLoadJob {
         // Submit task outside the database lock, cause it may take a while if task queue is full.
         for (LoadTask loadTask : newLoadingTasks) {
             submitTask(GlobalStateMgr.getCurrentState().getLoadingLoadTaskScheduler(), loadTask);
+        }
+    }
+
+    @Override
+    public void afterAborted(TransactionState txnState, boolean txnOperated, String txnStatusChangeReason)
+            throws UserException {
+        if (!txnOperated) {
+            return;
+        }
+        writeLock();
+        try {
+            // check if job has been completed
+            if (isTxnDone()) {
+                LOG.warn(new LogBuilder(LogKey.LOAD_JOB, id)
+                        .add("state", state)
+                        .add("error_msg", "this task will be ignored when job is: " + state)
+                        .build());
+                return;
+            }
+            if (retryTime <= 0 || !txnStatusChangeReason.contains("timeout") || !isTimeout()) {
+                // record attachment in load job
+                unprotectUpdateLoadingStatus(txnState);
+                // cancel load job
+                unprotectedExecuteCancel(new FailMsg(FailMsg.CancelType.LOAD_RUN_FAIL, txnStatusChangeReason), true);
+                return;
+            }
+
+            retryTime--;
+            failMsg = new FailMsg(FailMsg.CancelType.TIMEOUT, txnStatusChangeReason);
+            LOG.warn("Retry timeout load jobs. job: {}, retryTime: {}", id, retryTime);
+            unprotectedClearTasksBeforeRetry(failMsg);
+            try {
+                state = JobState.PENDING;
+                unprotectedExecute();
+            } catch (Exception e) {
+                cancelJobWithoutCheck(new FailMsg(FailMsg.CancelType.ETL_RUN_FAIL, e.getMessage()), true, true);
+            }
+        } finally {
+            writeUnlock();
+        }
+    }
+
+    protected void unprotectedClearTasksBeforeRetry(FailMsg failMsg) {
+        // get load ids of all loading tasks, we will cancel their coordinator process later
+        List<TUniqueId> loadIds = Lists.newArrayList();
+        for (PriorityLeaderTask loadTask : idToTasks.values()) {
+            if (loadTask instanceof LoadLoadingTask) {
+                loadIds.add(((LoadLoadingTask) loadTask).getLoadId());
+            }
+        }
+        newLoadingTasks.clear();
+        reset();
+
+        // set failMsg
+        this.failMsg = failMsg;
+        // cancel all running coordinators, so that the scheduler's worker thread will be released
+        for (TUniqueId loadId : loadIds) {
+            Coordinator coordinator = QeProcessorImpl.INSTANCE.getCoordinator(loadId);
+            if (coordinator != null) {
+                coordinator.cancel();
+            }
         }
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/load/loadv2/BrokerLoadPendingTask.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/loadv2/BrokerLoadPendingTask.java
@@ -62,7 +62,6 @@ public class BrokerLoadPendingTask extends LoadTask {
                                  Map<FileGroupAggKey, List<BrokerFileGroup>> aggKeyToBrokerFileGroups,
                                  BrokerDesc brokerDesc) {
         super(loadTaskCallback, TaskType.PENDING, 0);
-        this.retryTime = 3;
         this.attachment = new BrokerPendingTaskAttachment(signature);
         this.aggKeyToBrokerFileGroups = aggKeyToBrokerFileGroups;
         this.brokerDesc = brokerDesc;

--- a/fe/fe-core/src/main/java/com/starrocks/load/loadv2/BulkLoadJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/loadv2/BulkLoadJob.java
@@ -45,7 +45,6 @@ import com.starrocks.catalog.Database;
 import com.starrocks.catalog.Table;
 import com.starrocks.common.DdlException;
 import com.starrocks.common.FeMetaVersion;
-import com.starrocks.common.LoadException;
 import com.starrocks.common.MetaNotFoundException;
 import com.starrocks.common.io.Text;
 import com.starrocks.common.util.LogBuilder;
@@ -72,7 +71,6 @@ import java.io.IOException;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.concurrent.RejectedExecutionException;
 
 /**
  * parent class of BrokerLoadJob and SparkLoadJob from load stmt
@@ -245,40 +243,10 @@ public abstract class BulkLoadJob extends LoadJob {
                         .build());
                 return;
             }
-            LoadTask loadTask = idToTasks.get(taskId);
-            if (loadTask == null) {
-                return;
-            }
-            if (loadTask.getRetryTime() <= 0) {
+
+            if (!failMsg.getMsg().contains("timeout")) {
                 unprotectedExecuteCancel(failMsg, true);
                 logFinalOperation();
-                return;
-            } else {
-                failMsg.setMsg("Still retrying, error: " + failMsg.getMsg());
-                unprotectUpdateFailMsg(failMsg);
-
-                // retry task
-                idToTasks.remove(loadTask.getSignature());
-                if (loadTask instanceof LoadLoadingTask) {
-                    loadingStatus.getLoadStatistic().removeLoad(((LoadLoadingTask) loadTask).getLoadId());
-                }
-                loadTask.updateRetryInfo();
-                idToTasks.put(loadTask.getSignature(), loadTask);
-                // load id will be added to loadStatistic when executing this task
-                try {
-                    if (loadTask.getTaskType() == LoadTask.TaskType.PENDING) {
-                        submitTask(GlobalStateMgr.getCurrentState().getPendingLoadTaskScheduler(), loadTask);
-                    } else if (loadTask.getTaskType() == LoadTask.TaskType.LOADING) {
-                        submitTask(GlobalStateMgr.getCurrentState().getLoadingLoadTaskScheduler(), loadTask);
-                    } else {
-                        throw new LoadException(String.format("Unknown load task type: %s. task id: %d, job id, %d",
-                                loadTask.getTaskType(), loadTask.getSignature(), id));
-                    }
-                } catch (RejectedExecutionException | LoadException e) {
-                    unprotectedExecuteCancel(failMsg, true);
-                    logFinalOperation();
-                    return;
-                }
             }
         } finally {
             writeUnlock();

--- a/fe/fe-core/src/main/java/com/starrocks/load/loadv2/LoadJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/loadv2/LoadJob.java
@@ -179,6 +179,8 @@ public abstract class LoadJob extends AbstractTxnStateChangeCallback implements 
     // this request id is only used for checking if a load begin request is a duplicate request.
     protected TUniqueId requestId;
 
+    protected int retryTime = 2; // retry time if timeout
+
     // only for persistence param. see readFields() for usage
     private boolean isJobTypeRead = false;
 
@@ -261,7 +263,20 @@ public abstract class LoadJob extends AbstractTxnStateChangeCallback implements 
         return createTimestamp + timeoutSecond * 1000;
     }
 
-    private boolean isTimeout() {
+    public void reset() {
+        if (ConnectContext.get() != null) {
+            ConnectContext.get().setStartTime();
+            this.createTimestamp = ConnectContext.get().getStartTime();
+        } else {
+            // only for test used
+            this.createTimestamp = System.currentTimeMillis();
+        }
+        idToTasks.clear();
+        finishedTaskIds.clear();
+        loadingStatus.setProgress(0);
+    }
+
+    public boolean isTimeout() {
         return System.currentTimeMillis() > getDeadlineMs();
     }
 
@@ -699,6 +714,7 @@ public abstract class LoadJob extends AbstractTxnStateChangeCallback implements 
         finishTimestamp = System.currentTimeMillis();
         GlobalStateMgr.getCurrentGlobalTransactionMgr().getCallbackFactory().removeCallback(id);
         state = JobState.FINISHED;
+        failMsg = null;
 
         if (MetricRepo.hasInit) {
             MetricRepo.COUNTER_LOAD_FINISHED.increase(1L);

--- a/fe/fe-core/src/main/java/com/starrocks/load/loadv2/LoadLoadingTask.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/loadv2/LoadLoadingTask.java
@@ -67,7 +67,6 @@ import org.apache.logging.log4j.Logger;
 
 import java.util.List;
 import java.util.Map;
-import java.util.UUID;
 
 public class LoadLoadingTask extends LoadTask {
     private static final Logger LOG = LogManager.getLogger(LoadLoadingTask.class);
@@ -116,7 +115,6 @@ public class LoadLoadingTask extends LoadTask {
         this.strictMode = strictMode;
         this.txnId = txnId;
         this.failMsg = new FailMsg(FailMsg.CancelType.LOAD_RUN_FAIL);
-        this.retryTime = 1; // load task retry does not satisfy transaction's atomic
         this.timezone = timezone;
         this.timeoutS = timeoutS;
         this.createTimestamp = createTimestamp;
@@ -153,9 +151,6 @@ public class LoadLoadingTask extends LoadTask {
 
     @Override
     protected void executeTask() throws Exception {
-        LOG.info("begin to execute loading task. load id: {} job: {}. db: {}, tbl: {}. left retry: {}",
-                DebugUtil.printId(loadId), callback.getCallbackId(), db.getOriginName(), table.getName(), retryTime);
-        retryTime--;
         executeOnce();
     }
 
@@ -280,18 +275,5 @@ public class LoadLoadingTask extends LoadTask {
 
     private long getLeftTimeMs() {
         return jobDeadlineMs - System.currentTimeMillis();
-    }
-
-    @Override
-    public void updateRetryInfo() {
-        super.updateRetryInfo();
-        UUID uuid = UUID.randomUUID();
-        this.loadId = new TUniqueId(uuid.getMostSignificantBits(), uuid.getLeastSignificantBits());
-
-        if (!Config.enable_pipeline_load) {
-            planner.updateLoadInfo(this.loadId);
-        } else {
-            loadPlanner.updateLoadInfo(this.loadId);
-        }
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/load/loadv2/LoadTask.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/loadv2/LoadTask.java
@@ -56,7 +56,6 @@ public abstract class LoadTask extends PriorityLeaderTask {
     protected LoadTaskCallback callback;
     protected TaskAttachment attachment;
     protected FailMsg failMsg = new FailMsg();
-    protected int retryTime = 1;
 
     public LoadTask(LoadTaskCallback callback, TaskType taskType, int priority) {
         super(priority);
@@ -104,16 +103,6 @@ public abstract class LoadTask extends PriorityLeaderTask {
      * @throws UserException task is failed
      */
     abstract void executeTask() throws Exception;
-
-    public int getRetryTime() {
-        return retryTime;
-    }
-
-    // Derived class may need to override this.
-    public void updateRetryInfo() {
-        this.retryTime--;
-        this.signature = GlobalStateMgr.getCurrentState().getNextId();
-    }
 
     public TaskType getTaskType() {
         return taskType;

--- a/fe/fe-core/src/main/java/com/starrocks/load/loadv2/SparkLoadPendingTask.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/loadv2/SparkLoadPendingTask.java
@@ -113,7 +113,6 @@ public class SparkLoadPendingTask extends LoadTask {
                                 Map<FileGroupAggKey, List<BrokerFileGroup>> aggKeyToBrokerFileGroups,
                                 SparkResource resource, BrokerDesc brokerDesc) {
         super(loadTaskCallback, TaskType.PENDING, LoadPriority.NORMAL_VALUE);
-        this.retryTime = 3;
         this.attachment = new SparkPendingTaskAttachment(signature);
         this.aggKeyToBrokerFileGroups = aggKeyToBrokerFileGroups;
         this.resource = resource;

--- a/fe/fe-core/src/test/java/com/starrocks/load/loadv2/BrokerLoadJobTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/load/loadv2/BrokerLoadJobTest.java
@@ -46,12 +46,14 @@ import com.starrocks.common.Config;
 import com.starrocks.common.DdlException;
 import com.starrocks.common.LoadException;
 import com.starrocks.common.MetaNotFoundException;
+import com.starrocks.common.UserException;
 import com.starrocks.common.jmockit.Deencapsulation;
 import com.starrocks.load.BrokerFileGroup;
 import com.starrocks.load.BrokerFileGroupAggInfo;
 import com.starrocks.load.BrokerFileGroupAggInfo.FileGroupAggKey;
 import com.starrocks.load.EtlJobType;
 import com.starrocks.load.EtlStatus;
+import com.starrocks.load.FailMsg;
 import com.starrocks.metric.MetricRepo;
 import com.starrocks.persist.EditLog;
 import com.starrocks.qe.ConnectContext;
@@ -63,6 +65,8 @@ import com.starrocks.task.LeaderTask;
 import com.starrocks.task.LeaderTaskExecutor;
 import com.starrocks.task.PriorityLeaderTask;
 import com.starrocks.task.PriorityLeaderTaskExecutor;
+import com.starrocks.thrift.TUniqueId;
+import com.starrocks.transaction.GlobalTransactionMgr;
 import com.starrocks.transaction.TransactionState;
 import mockit.Expectations;
 import mockit.Injectable;
@@ -329,6 +333,103 @@ public class BrokerLoadJobTest {
 
         Map<Long, LoadTask> idToTasks = Deencapsulation.getField(brokerLoadJob, "idToTasks");
         Assert.assertEquals(1, idToTasks.size());
+    }
+
+    @Test
+    public void testRetryJobAfterAborted(@Injectable TransactionState txnState,
+                                         @Injectable boolean txnOperated,
+                                         @Injectable String txnStatusChangeReason,
+                                         @Mocked LeaderTaskExecutor leaderTaskExecutor,
+                                         @Mocked GlobalTransactionMgr globalTransactionMgr) throws LoadException, UserException {
+        new Expectations() {
+            {
+                globalTransactionMgr.beginTransaction(anyLong, Lists.newArrayList(), anyString, (TUniqueId) any,
+                        (TransactionState.TxnCoordinator) any,
+                        (TransactionState.LoadJobSourceType) any, anyLong, anyLong);
+                leaderTaskExecutor.submit((LeaderTask) any);
+                minTimes = 0;
+                result = true;
+            }
+        };
+
+        GlobalStateMgr.getCurrentState().setEditLog(new EditLog(new ArrayBlockingQueue<>(100)));
+        new MockUp<EditLog>() {
+            @Mock
+            public void logSaveNextId(long nextId) {
+
+            }
+
+            @Mock
+            public void logEndLoadJob(LoadJobFinalOperation loadJobFinalOperation) {
+
+            }
+        };
+
+        new MockUp<LoadJob>() {
+            @Mock
+            public void unprotectUpdateLoadingStatus(TransactionState txnState) {
+
+            }
+        };
+
+        // test when retry limit has reached
+        BrokerLoadJob brokerLoadJob1 = new BrokerLoadJob();
+        brokerLoadJob1.retryTime = 0;
+        brokerLoadJob1.unprotectedExecuteJob();
+        txnOperated = true;
+        txnStatusChangeReason = "broker load job timeout";
+        brokerLoadJob1.afterAborted(txnState, txnOperated, txnStatusChangeReason);
+        Map<Long, LoadTask> idToTasks = Deencapsulation.getField(brokerLoadJob1, "idToTasks");
+        Assert.assertEquals(0, idToTasks.size());
+
+        // test normal retry after timeout
+        BrokerLoadJob brokerLoadJob2 = new BrokerLoadJob();
+        brokerLoadJob2.retryTime = 1;
+        brokerLoadJob2.unprotectedExecuteJob();
+        txnOperated = true;
+        txnStatusChangeReason = "broker load job timeout";
+        brokerLoadJob2.afterAborted(txnState, txnOperated, txnStatusChangeReason);
+        idToTasks = Deencapsulation.getField(brokerLoadJob2, "idToTasks");
+        Assert.assertEquals(1, idToTasks.size());
+
+        // test when txnOperated is false
+        BrokerLoadJob brokerLoadJob3 = new BrokerLoadJob();
+        brokerLoadJob3.retryTime = 1;
+        brokerLoadJob3.unprotectedExecuteJob();
+        txnOperated = false;
+        txnStatusChangeReason = "broker load job timeout";
+        brokerLoadJob3.afterAborted(txnState, txnOperated, txnStatusChangeReason);
+        idToTasks = Deencapsulation.getField(brokerLoadJob3, "idToTasks");
+        Assert.assertEquals(1, idToTasks.size());
+
+        // test when txn is finished
+        BrokerLoadJob brokerLoadJob4 = new BrokerLoadJob();
+        brokerLoadJob4.retryTime = 1;
+        brokerLoadJob4.unprotectedExecuteJob();
+        txnOperated = true;
+        txnStatusChangeReason = "broker load job timeout";
+        Deencapsulation.setField(brokerLoadJob4, "state", JobState.FINISHED);
+        brokerLoadJob4.afterAborted(txnState, txnOperated, txnStatusChangeReason);
+        idToTasks = Deencapsulation.getField(brokerLoadJob4, "idToTasks");
+        Assert.assertEquals(1, idToTasks.size());
+    }
+
+    @Test
+    public void testPendingTaskOnTaskFailed(@Injectable long taskId, @Injectable FailMsg failMsg) {
+        GlobalStateMgr.getCurrentState().setEditLog(new EditLog(new ArrayBlockingQueue<>(100)));
+        new MockUp<EditLog>() {
+            @Mock
+            public void logEndLoadJob(LoadJobFinalOperation loadJobFinalOperation) {
+
+            }
+        };
+
+        BrokerLoadJob brokerLoadJob = new BrokerLoadJob();
+        failMsg = new FailMsg(FailMsg.CancelType.LOAD_RUN_FAIL, "load_run_fail");
+        brokerLoadJob.onTaskFailed(taskId, failMsg);
+
+        Map<Long, LoadTask> idToTasks = Deencapsulation.getField(brokerLoadJob, "idToTasks");
+        Assert.assertEquals(0, idToTasks.size());
     }
 
     @Test


### PR DESCRIPTION
We have disable the broker load retry when timeout. If timeout, the retry is very useful. I add a retry in broker load. The retry job keep the same job_id, and a new different transaction_id. The timeout job will be retried two times.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [x] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [x] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [x] This is a backport pr

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
