### PR TITLE
[BugFix] Turn off query cache if PlanFragment with local shuffle interpolation (backport #39537)

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/planner/FragmentNormalizer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/FragmentNormalizer.java
@@ -195,6 +195,11 @@ public class FragmentNormalizer {
 
     public void normalize() {
         try {
+            // Fragments with local shuffle interpolation violate per-tablet computation of
+            // query cache. so turn down cache
+            if (fragment.isWithLocalShuffle()) {
+                setUncacheable(true);
+            }
             PlanNode topmostPlanNode = findMaximumNormalizableSubTree(fragment.getPlanRoot());
             if (!(topmostPlanNode instanceof AggregationNode) || selectedRangeMap.isEmpty()) {
                 return;


### PR DESCRIPTION
Why I'm doing:
In 2.5.x, Fragment with local shuffle interpolation(e.g. single BE optimization can generate such plan, bucket shuffle join,  colocate join, first-stage aggregation) can not guarantee per-tablet computation that is required by query cache, so in these situations, query cache can generate incorect answers.

What I'm doing:

Disable query cache when PlanFragment with local shuffle.
Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [x] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5

