### PR TITLE
[BugFix] Fix bug show columns does not filter by db

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/ShowColumnStmt.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/ShowColumnStmt.java
@@ -16,9 +16,13 @@
 package com.starrocks.sql.ast;
 
 import com.google.common.base.Strings;
+import com.starrocks.analysis.BinaryPredicate;
+import com.starrocks.analysis.BinaryType;
+import com.starrocks.analysis.CompoundPredicate;
 import com.starrocks.analysis.Expr;
 import com.starrocks.analysis.ExprSubstitutionMap;
 import com.starrocks.analysis.SlotRef;
+import com.starrocks.analysis.StringLiteral;
 import com.starrocks.analysis.TableName;
 import com.starrocks.catalog.Column;
 import com.starrocks.catalog.ScalarType;
@@ -165,7 +169,9 @@ public class ShowColumnStmt extends ShowStmt {
         }
 
         where = where.substitute(aliasMap);
-
+        where = new CompoundPredicate(CompoundPredicate.Operator.AND, where,
+                new BinaryPredicate(BinaryType.EQ, new SlotRef(TABLE_NAME, "TABLE_SCHEMA"),
+                        new StringLiteral(tableName.getDb())));
         return new QueryStatement(new SelectRelation(selectList, new TableRelation(TABLE_NAME),
                 where, null, null), this.origStmt);
     }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AnalyzeShowTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AnalyzeShowTest.java
@@ -117,7 +117,8 @@ public class AnalyzeShowTest {
                         "information_schema.COLUMNS.COLUMN_KEY AS Key, " +
                         "information_schema.COLUMNS.COLUMN_DEFAULT AS Default, " +
                         "information_schema.COLUMNS.EXTRA AS Extra " +
-                        "FROM information_schema.COLUMNS WHERE information_schema.COLUMNS.COLUMN_NAME = 'v1'",
+                        "FROM information_schema.COLUMNS WHERE (information_schema.COLUMNS.COLUMN_NAME = 'v1') " +
+                        "AND (information_schema.COLUMNS.TABLE_SCHEMA = 'test')",
                 AstToStringBuilder.toString(statement.toSelectStmt()));
     }
 

--- a/test/sql/test_show/R/test_show_column
+++ b/test/sql/test_show/R/test_show_column
@@ -1,0 +1,43 @@
+-- name: test_show_column
+create database test_show1;
+-- result:
+-- !result
+create database test_show2;
+-- result:
+-- !result
+use test_show1;
+-- result:
+-- !result
+CREATE TABLE site_access(
+    event_day DATE,
+    site_id INT DEFAULT '10',
+    city_code VARCHAR(100),
+    user_name VARCHAR(32) DEFAULT '',
+    pv BIGINT SUM DEFAULT '0'
+)
+DISTRIBUTED BY HASH(site_id)
+PROPERTIES (
+  "replication_num" = "1"
+);
+-- result:
+-- !result
+use test_show2;
+-- result:
+-- !result
+CREATE TABLE site_access(
+    event_day DATE,
+    site_id INT DEFAULT '10',
+    city_code VARCHAR(100),
+    user_name VARCHAR(32) DEFAULT '',
+    pv BIGINT SUM DEFAULT '0'
+)
+DISTRIBUTED BY HASH(site_id)
+PROPERTIES (
+  "replication_num" = "1"
+);
+-- result:
+-- !result
+show columns from site_access where Field='pv';
+-- result:
+pv	bigint	YES		0	
+-- !result

--- a/test/sql/test_show/T/test_show_column
+++ b/test/sql/test_show/T/test_show_column
@@ -1,0 +1,28 @@
+-- name: test_show_column
+create database test_show1;
+create database test_show2;
+use test_show1;
+CREATE TABLE site_access(
+    event_day DATE,
+    site_id INT DEFAULT '10',
+    city_code VARCHAR(100),
+    user_name VARCHAR(32) DEFAULT '',
+    pv BIGINT SUM DEFAULT '0'
+)
+DISTRIBUTED BY HASH(site_id)
+PROPERTIES (
+  "replication_num" = "1"
+);
+use test_show2;
+CREATE TABLE site_access(
+    event_day DATE,
+    site_id INT DEFAULT '10',
+    city_code VARCHAR(100),
+    user_name VARCHAR(32) DEFAULT '',
+    pv BIGINT SUM DEFAULT '0'
+)
+DISTRIBUTED BY HASH(site_id)
+PROPERTIES (
+  "replication_num" = "1"
+);
+show columns from site_access where Field='pv';


### PR DESCRIPTION
Why I'm doing:
show columns from xx whre does not filter based on db. If different DBs have the same table, many identical fields will appear, which is confusing.

What I'm doing:
This essence is converted into select information_schema.columns, and adding table_schema to filter out db is correct.

Fixes https://github.com/StarRocks/StarRocksTest/issues/5802

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [x] 3.1
  - [x] 3.0
  - [ ] 2.5
