### PR TITLE
[BugFix]Fix table privilege will lose when swap table

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/alter/AlterJobMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/AlterJobMgr.java
@@ -731,10 +731,12 @@ public class AlterJobMgr {
         db.dropTable(newTblName);
 
         // rename new table name to origin table name and add it to database
+        newTbl.setId(origTblId);
         newTbl.checkAndSetName(origTblName, false);
         db.registerTableUnlocked(newTbl);
 
         // rename origin table name to new table name and add it to database
+        origTable.setId(newTblId);
         origTable.checkAndSetName(newTblName, false);
         db.registerTableUnlocked(origTable);
 


### PR DESCRIPTION
Why I'm doing:

> Now, starrocks swap command will lose table privilege
> before swap
> ![image](https://github.com/StarRocks/starrocks/assets/105328124/2ed8befb-c719-4e24-8d8b-0e814056c8c6)
> After swap
> ![image](https://github.com/StarRocks/starrocks/assets/105328124/d02cb94d-8633-4981-bd31-7534d7e5b7de)
> 
> After [ ALTER TABLE a SWAP WITH b] table a lose privilege, add table b privilege

What I'm doing:

> When swap, not swap table id

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
