### PR TITLE
[BugFix] Fix repeated push of tablet id in replication transaction

### DIFF
--- a/be/src/storage/replication_txn_manager.h
+++ b/be/src/storage/replication_txn_manager.h
@@ -90,7 +90,8 @@ private:
 
 private:
     mutable std::shared_mutex _mutex;
-    std::unordered_map<TTransactionId, std::unordered_map<TPartitionId, std::vector<TTabletId>>> _transaction_map;
+    std::unordered_map<TTransactionId, std::unordered_map<TPartitionId, std::unordered_set<TTabletId>>>
+            _transaction_map;
     std::unordered_map<TTabletId, std::unordered_map<TTransactionId, ReplicationTxnMetaPB>> _tablet_map;
 };
 


### PR DESCRIPTION
Why I'm doing:
tablet id will be pushed repeatedly in replication transaction, causing repeated publishing.
What I'm doing:
avoid repeated push of tablet id in replication transaction

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [x] 3.1
  - [ ] 3.0
  - [ ] 2.5
