### PR TITLE
[BugFix]only use def_level after loaded

### DIFF
--- a/be/src/formats/parquet/stored_column_reader.cpp
+++ b/be/src/formats/parquet/stored_column_reader.cpp
@@ -470,22 +470,21 @@ Status OptionalStoredColumnReader::_read_records_only(size_t* num_records, Colum
                 return Status::InternalError(
                         fmt::format("def levels need to parsed: {}, def levels parsed: {}", records_to_read, res_def));
             }
-        }
-
-        size_t i = 0;
-        while (i < records_to_read) {
-            size_t j = i;
-            bool is_null = _def_levels[j] < _field->max_def_level();
-            j++;
-            while (j < records_to_read && is_null == (_def_levels[j] < _field->max_def_level())) {
+            size_t i = 0;
+            while (i < records_to_read) {
+                size_t j = i;
+                bool is_null = _def_levels[j] < _field->max_def_level();
                 j++;
+                while (j < records_to_read && is_null == (_def_levels[j] < _field->max_def_level())) {
+                    j++;
+                }
+                if (is_null) {
+                    dst->append_nulls(j - i);
+                } else {
+                    RETURN_IF_ERROR(_reader->decode_values(j - i, content_type, dst));
+                }
+                i = j;
             }
-            if (is_null) {
-                dst->append_nulls(j - i);
-            } else {
-                RETURN_IF_ERROR(_reader->decode_values(j - i, content_type, dst));
-            }
-            i = j;
         }
 
         _num_values_left_in_cur_page -= records_to_read;


### PR DESCRIPTION
Why I'm doing:
bug introduced by #38465, but as default we won't use this old path, so we can't find out it with ut.

What I'm doing:
fix it, and make ut for both new path and old path.

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.2 manully #39605
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
