### PR TITLE
[Feature] Support tablet migration detection during replication transaction (backport #39207)

### DIFF
--- a/be/src/agent/agent_task.cpp
+++ b/be/src/agent/agent_task.cpp
@@ -173,6 +173,10 @@ void run_drop_tablet_task(const std::shared_ptr<DropTabletAgentTaskRequest>& age
                 StorageEngine::instance()->txn_manager()->get_tablet_related_txns(
                         drop_tablet_req.tablet_id, drop_tablet_req.schema_hash, dropped_tablet->tablet_uid(),
                         &partition_id, &transaction_ids);
+                if (transaction_ids.empty()) {
+                    StorageEngine::instance()->replication_txn_manager()->get_tablet_related_txns(
+                            drop_tablet_req.tablet_id, &transaction_ids);
+                }
             }
             if (!transaction_ids.empty()) {
                 std::stringstream ss;

--- a/be/src/agent/publish_version.cpp
+++ b/be/src/agent/publish_version.cpp
@@ -70,14 +70,8 @@ void run_publish_version_task(ThreadPoolToken* token, const TPublishVersionReque
     if (is_replication_txn) {
         std::vector<std::vector<TTabletId>> partitions(num_partition);
         for (size_t i = 0; i < publish_version_req.partition_version_infos.size(); i++) {
-            Status st = StorageEngine::instance()->replication_txn_manager()->get_txn_related_tablets(
+            StorageEngine::instance()->replication_txn_manager()->get_txn_related_tablets(
                     transaction_id, publish_version_req.partition_version_infos[i].partition_id, &partitions[i]);
-            if (!st.ok()) {
-                LOG(WARNING) << "failed to publish version for replication txn, get_txn_related_tablets failed: " << st
-                             << ", txn_id: " << transaction_id
-                             << ", partition_id: " << publish_version_req.partition_version_infos[i].partition_id;
-                return;
-            }
             num_active_tablet += partitions[i].size();
         }
 

--- a/be/src/storage/lake/replication_txn_manager.cpp
+++ b/be/src/storage/lake/replication_txn_manager.cpp
@@ -97,7 +97,7 @@ Status ReplicationTxnManager::remote_snapshot(const TRemoteSnapshotRequest& requ
         *incremental_snapshot = true;
         status = make_remote_snapshot(request, &missed_versions, nullptr, &src_backend, src_snapshot_path);
         if (!status.ok()) {
-            LOG(INFO) << "Fail to make incremental snapshot: " << status << ". switch to fully snapshot"
+            LOG(INFO) << "Failed to make incremental snapshot: " << status << ". switch to fully snapshot"
                       << ", txn_id: " << request.transaction_id << ", tablet_id: " << request.tablet_id
                       << ", src_tablet_id: " << request.src_tablet_id
                       << ", visible_version: " << request.visible_version
@@ -108,7 +108,7 @@ Status ReplicationTxnManager::remote_snapshot(const TRemoteSnapshotRequest& requ
     }
 
     if (!status.ok()) {
-        LOG(WARNING) << "Fail to make remote snapshot: " << status << ", txn_id: " << request.transaction_id
+        LOG(WARNING) << "Failed to make remote snapshot: " << status << ", txn_id: " << request.transaction_id
                      << ", tablet_id: " << request.tablet_id << ", src_tablet_id: " << request.src_tablet_id
                      << ", visible_version: " << request.visible_version
                      << ", snapshot_version: " << request.src_visible_version;
@@ -163,7 +163,7 @@ Status ReplicationTxnManager::replicate_snapshot(const TReplicateSnapshotRequest
 
         if (!status_or.ok()) {
             status = status_or.status();
-            LOG(WARNING) << "Fail to download snapshot from " << src_snapshot_info.backend.host << ":"
+            LOG(WARNING) << "Failed to download snapshot from " << src_snapshot_info.backend.host << ":"
                          << src_snapshot_info.backend.http_port << ":" << src_snapshot_info.snapshot_path << ", "
                          << status << ", txn_id: " << request.transaction_id << ", tablet_id: " << request.tablet_id
                          << ", src_tablet_id: " << request.src_tablet_id
@@ -235,7 +235,7 @@ StatusOr<TxnLogPtr> ReplicationTxnManager::replicate_remote_snapshot(const TRepl
         TabletMeta tablet_meta;
         auto status = tablet_meta.create_from_memory(header_file_content);
         if (!status.ok()) {
-            LOG(WARNING) << "Fail to parse remote snapshot header file: " << remote_header_file_name
+            LOG(WARNING) << "Failed to parse remote snapshot header file: " << remote_header_file_name
                          << ", content: " << header_file_content << ", " << status;
             return status;
         }
@@ -261,7 +261,7 @@ StatusOr<TxnLogPtr> ReplicationTxnManager::replicate_remote_snapshot(const TRepl
         SnapshotMeta snapshot_meta;
         auto status = snapshot_meta.parse_from_file(memory_file.get());
         if (!status.ok()) {
-            LOG(WARNING) << "Fail to parse remote snapshot meta file: " << snapshot_meta_file_name
+            LOG(WARNING) << "Failed to parse remote snapshot meta file: " << snapshot_meta_file_name
                          << ", content: " << snapshot_meta_content << ", " << status;
             return status;
         }

--- a/be/src/storage/replication_txn_manager.cpp
+++ b/be/src/storage/replication_txn_manager.cpp
@@ -81,23 +81,84 @@ static std::string get_tablet_snapshot_dir_path(DataDir* data_dir, TTransactionI
                        tablet_id);
 }
 
-static std::string get_tablet_txn_meta_file_path(DataDir* data_dir, TTransactionId transaction_id,
-                                                 TPartitionId partition_id, TTabletId tablet_id) {
-    return fmt::format("{}/{}/{}/{}/txn_meta", data_dir->get_replication_path(), transaction_id, partition_id,
-                       tablet_id);
-}
-
 static std::string get_tablet_txn_meta_file_path(const std::string& tablet_txn_dir_path) {
     return tablet_txn_dir_path + "txn_meta";
 }
 
+Status ReplicationTxnManager::init(const std::vector<starrocks::DataDir*>& data_dirs) {
+    std::lock_guard guard(_mutex);
+    for (DataDir* data_dir : data_dirs) {
+        std::string replication_path = data_dir->get_replication_path() + '/';
+        std::set<std::string> txn_dirs;
+        Status status = fs::list_dirs_files(replication_path, &txn_dirs, nullptr);
+        if (!status.ok()) {
+            if (status.is_not_found()) {
+                continue;
+            } else {
+                LOG(ERROR) << "Failed to list dir: " << replication_path << ", status: " << status;
+                return status;
+            }
+        }
+
+        for (const std::string& txn_dir : txn_dirs) {
+            int64_t transaction_id = ::atoll(txn_dir.c_str());
+            if (transaction_id == 0) {
+                LOG(WARNING) << "Ignore invalid txn dir: " << replication_path << txn_dir;
+                continue;
+            }
+
+            std::string txn_dir_path = replication_path + txn_dir + '/';
+            std::set<std::string> partition_dirs;
+            status = fs::list_dirs_files(txn_dir_path, &partition_dirs, nullptr);
+            if (!status.ok()) {
+                LOG(ERROR) << "Failed to list txn dir: " << txn_dir_path << ", status: " << status;
+                continue;
+            }
+
+            for (const std::string& partition_dir : partition_dirs) {
+                int64_t partition_id = ::atoll(partition_dir.c_str());
+                if (partition_id == 0) {
+                    LOG(WARNING) << "Ignore invalid partition dir: " << txn_dir_path << partition_dir;
+                    continue;
+                }
+
+                std::string partition_dir_path = txn_dir_path + partition_dir + '/';
+                std::set<std::string> tablet_dirs;
+                status = fs::list_dirs_files(partition_dir_path, &tablet_dirs, nullptr);
+                if (!status.ok()) {
+                    LOG(WARNING) << "Failed to list partition dir: " << partition_dir_path << ", status: " << status;
+                    continue;
+                }
+
+                for (const std::string& tablet_dir : tablet_dirs) {
+                    int64_t tablet_id = ::atoll(tablet_dir.c_str());
+                    if (tablet_id == 0) {
+                        LOG(WARNING) << "Ignore invalid tablet dir: " << partition_dir_path << tablet_dir;
+                        continue;
+                    }
+
+                    std::string tablet_dir_path = partition_dir_path + tablet_dir + '/';
+                    ReplicationTxnMetaPB txn_meta_pb;
+                    status = load_tablet_txn_meta(tablet_dir_path, txn_meta_pb);
+                    if (!status.ok()) {
+                        continue;
+                    }
+
+                    _transaction_map[transaction_id][partition_id].push_back(tablet_id);
+                    _tablet_map[tablet_id][transaction_id] = txn_meta_pb;
+                }
+            }
+        }
+    }
+    return Status::OK();
+}
+
 Status ReplicationTxnManager::remote_snapshot(const TRemoteSnapshotRequest& request, std::string* src_snapshot_path,
                                               bool* incremental_snapshot) {
-    ASSIGN_OR_RETURN(auto tablet, get_tablet(request.tablet_id));
+    ASSIGN_OR_RETURN(auto tablet, prepare_txn(request.transaction_id, request.partition_id, request.tablet_id));
 
     ReplicationTxnMetaPB txn_meta_pb;
-    Status status = load_tablet_txn_meta(tablet->data_dir(), request.transaction_id, request.partition_id,
-                                         request.tablet_id, txn_meta_pb);
+    Status status = load_tablet_txn_meta(request.transaction_id, request.tablet_id, txn_meta_pb);
     if (status.ok()) {
         if (txn_meta_pb.txn_state() >= ReplicationTxnStatePB::TXN_SNAPSHOTED &&
             txn_meta_pb.snapshot_version() == request.src_visible_version) {
@@ -136,7 +197,7 @@ Status ReplicationTxnManager::remote_snapshot(const TRemoteSnapshotRequest& requ
         *incremental_snapshot = true;
         status = make_remote_snapshot(request, &missed_versions, nullptr, &src_backend, src_snapshot_path);
         if (!status.ok()) {
-            LOG(INFO) << "Fail to make incremental snapshot: " << status << ", txn_id: " << request.transaction_id
+            LOG(INFO) << "Failed to make incremental snapshot: " << status << ", txn_id: " << request.transaction_id
                       << ", switch to fully snapshot. tablet_id: " << request.tablet_id
                       << ", src_tablet_id: " << request.src_tablet_id
                       << ", visible version: " << request.visible_version
@@ -147,7 +208,7 @@ Status ReplicationTxnManager::remote_snapshot(const TRemoteSnapshotRequest& requ
     }
 
     if (!status.ok()) {
-        LOG(WARNING) << "Fail to make remote snapshot: " << status << ", txn_id: " << request.transaction_id
+        LOG(WARNING) << "Failed to make remote snapshot: " << status << ", txn_id: " << request.transaction_id
                      << ", tablet_id: " << request.tablet_id << ", src_tablet_id: " << request.src_tablet_id
                      << ", visible_version: " << request.visible_version
                      << ", snapshot_version: " << request.src_visible_version;
@@ -177,8 +238,7 @@ Status ReplicationTxnManager::replicate_snapshot(const TReplicateSnapshotRequest
     ASSIGN_OR_RETURN(auto tablet, get_tablet(request.tablet_id));
 
     ReplicationTxnMetaPB txn_meta_pb;
-    Status status = load_tablet_txn_meta(tablet->data_dir(), request.transaction_id, request.partition_id,
-                                         request.tablet_id, txn_meta_pb);
+    Status status = load_tablet_txn_meta(request.transaction_id, request.tablet_id, txn_meta_pb);
     if (status.ok()) {
         if (txn_meta_pb.txn_state() >= ReplicationTxnStatePB::TXN_REPLICATED &&
             txn_meta_pb.snapshot_version() == request.src_visible_version) {
@@ -196,7 +256,7 @@ Status ReplicationTxnManager::replicate_snapshot(const TReplicateSnapshotRequest
     for (const auto& src_snapshot_info : request.src_snapshot_infos) {
         status = replicate_remote_snapshot(request, src_snapshot_info, tablet_snapshot_dir_path, tablet.get());
         if (!status.ok()) {
-            LOG(WARNING) << "Fail to download snapshot from " << src_snapshot_info.backend.host << ":"
+            LOG(WARNING) << "Failed to download snapshot from " << src_snapshot_info.backend.host << ":"
                          << src_snapshot_info.backend.http_port << ":" << src_snapshot_info.snapshot_path << ", "
                          << status << ", txn_id: " << request.transaction_id << ", tablet_id: " << request.tablet_id
                          << ", src_tablet_id: " << request.src_tablet_id
@@ -227,54 +287,56 @@ Status ReplicationTxnManager::replicate_snapshot(const TReplicateSnapshotRequest
     return status;
 }
 
-Status ReplicationTxnManager::get_txn_related_tablets(const TTransactionId transaction_id, TPartitionId partition_id,
-                                                      std::vector<TTabletId>* tablet_ids) {
-    for (DataDir* data_dir : StorageEngine::instance()->get_stores()) {
-        std::string txn_dir_path = get_txn_dir_path(data_dir, transaction_id);
-        std::string partition_dir_path = txn_dir_path + std::to_string(partition_id) + '/';
-        if (!fs::path_exist(partition_dir_path)) {
-            continue;
-        }
-
-        std::set<std::string> tablet_dirs;
-        Status status = fs::list_dirs_files(partition_dir_path, &tablet_dirs, nullptr);
-        if (!status.ok()) {
-            LOG(WARNING) << "Fail to list partition dir: " << partition_dir_path << ", " << status
-                         << ", txn_id: " << transaction_id;
-            return status;
-        }
-
-        for (const std::string& tablet_dir : tablet_dirs) {
-            TTabletId tablet_id = ::atoll(tablet_dir.c_str());
-            if (tablet_id == 0) {
-                LOG(WARNING) << "Invalid tablet dir name: " << tablet_dir << " in partition dir: " << partition_dir_path
-                             << ", txn_id: " << transaction_id;
-                return Status::InternalError("Invalid tablet dir name: " + tablet_dir);
-            }
-            tablet_ids->push_back(tablet_id);
-        }
+void ReplicationTxnManager::get_txn_related_tablets(const TTransactionId transaction_id, TPartitionId partition_id,
+                                                    std::vector<TTabletId>* tablet_ids) {
+    std::shared_lock guard(_mutex);
+    auto transaction_iter = _transaction_map.find(transaction_id);
+    if (transaction_iter == _transaction_map.end()) {
+        VLOG(3) << "Could not find txn for txn_id: " << transaction_id << ", partition_id: " << partition_id;
+        return;
     }
-    return Status::OK();
+
+    const auto& partition_map = transaction_iter->second;
+    auto partition_iter = partition_map.find(partition_id);
+    if (partition_iter == partition_map.end()) {
+        VLOG(3) << "Could not find partition for txn_id: " << transaction_id << ", partition_id: " << partition_id;
+        return;
+    }
+
+    for (const auto& tablet_id : partition_iter->second) {
+        tablet_ids->push_back(tablet_id);
+    }
+}
+
+void ReplicationTxnManager::get_tablet_related_txns(TTabletId tablet_id, std::set<TTransactionId>* transaction_ids) {
+    std::shared_lock guard(_mutex);
+    auto tablet_iter = _tablet_map.find(tablet_id);
+    if (tablet_iter == _tablet_map.end()) {
+        return;
+    }
+
+    for (const auto& [txn_id, txn_meta] : tablet_iter->second) {
+        transaction_ids->insert(txn_id);
+    }
 }
 
 Status ReplicationTxnManager::publish_txn(TTransactionId transaction_id, TPartitionId partition_id,
                                           const TabletSharedPtr& tablet, int64_t version) {
     ReplicationTxnMetaPB txn_meta_pb;
-    RETURN_IF_ERROR(
-            load_tablet_txn_meta(tablet->data_dir(), transaction_id, partition_id, tablet->tablet_id(), txn_meta_pb));
+    RETURN_IF_ERROR(load_tablet_txn_meta(transaction_id, tablet->tablet_id(), txn_meta_pb));
     if (txn_meta_pb.txn_state() == ReplicationTxnStatePB::TXN_PUBLISHED) {
         return Status::OK();
     }
 
     if (txn_meta_pb.txn_state() != ReplicationTxnStatePB::TXN_REPLICATED) {
-        LOG(WARNING) << "Fail to publish snapshot, invalid txn meta state, tablet_id: " << tablet->tablet_id()
+        LOG(WARNING) << "Failed to publish snapshot, invalid txn meta state, tablet_id: " << tablet->tablet_id()
                      << ", partition_id: " << partition_id << ", txn_id: " << transaction_id
                      << ", txn state: " << ReplicationTxnStatePB_Name(txn_meta_pb.txn_state());
         return Status::Corruption("Invalid txn meta state: " + ReplicationTxnStatePB_Name(txn_meta_pb.txn_state()));
     }
 
     if (txn_meta_pb.snapshot_version() != version) {
-        LOG(WARNING) << "Fail to publish snapshot, missmatched version, tablet_id: " << tablet->tablet_id()
+        LOG(WARNING) << "Failed to publish snapshot, missmatched version, tablet_id: " << tablet->tablet_id()
                      << ", partition_id: " << partition_id << ", txn_id: " << transaction_id << ", version: " << version
                      << ", snapshot version: " << txn_meta_pb.snapshot_version();
         return Status::Corruption("Missmatched version");
@@ -287,23 +349,48 @@ Status ReplicationTxnManager::publish_txn(TTransactionId transaction_id, TPartit
 }
 
 void ReplicationTxnManager::clear_expired_snapshots() {
-    int64_t min_active_txn_id = get_master_info().min_active_txn_id;
-
-    for (DataDir* data_dir : StorageEngine::instance()->get_stores()) {
-        std::string replication_path = data_dir->get_replication_path();
-        std::set<std::string> txn_dirs;
-        Status status = fs::list_dirs_files(replication_path, &txn_dirs, nullptr);
-        if (!status.ok()) {
-            continue;
-        }
-
-        for (const std::string& txn_dir : txn_dirs) {
-            int64_t txn_id = ::atoll(txn_dir.c_str());
-            if (txn_id != 0 && txn_id < min_active_txn_id) {
-                clear_txn_snapshots(txn_id);
+    std::vector<TTransactionId> expired_txns;
+    {
+        int64_t min_active_txn_id = get_master_info().min_active_txn_id;
+        std::shared_lock guard(_mutex);
+        for (const auto& [transaction_id, partiton_map] : _transaction_map) {
+            if (transaction_id < min_active_txn_id) {
+                expired_txns.push_back(transaction_id);
             }
         }
     }
+
+    for (auto transaction_id : expired_txns) {
+        clear_txn_snapshots(transaction_id);
+    }
+}
+
+StatusOr<TabletSharedPtr> ReplicationTxnManager::prepare_txn(TTransactionId transaction_id, TPartitionId partition_id,
+                                                             TTabletId tablet_id) {
+    ASSIGN_OR_RETURN(auto tablet, get_tablet(tablet_id));
+    while (true) {
+        std::shared_lock migration_rlock(tablet->get_migration_lock());
+        if (!tablet->is_migrating()) {
+            // maybe migration just finish, get the tablet again
+            ASSIGN_OR_RETURN(auto new_tablet, get_tablet(tablet_id));
+            if (tablet != new_tablet) {
+                tablet = new_tablet;
+                continue;
+            }
+        }
+
+        std::lock_guard push_lock(tablet->get_push_lock());
+
+        std::lock_guard guard(_mutex);
+        _transaction_map[transaction_id][partition_id].push_back(tablet_id);
+        ReplicationTxnMetaPB& saved_txn_meta = _tablet_map[tablet_id][transaction_id];
+        saved_txn_meta.set_txn_id(transaction_id);
+        saved_txn_meta.set_txn_state(ReplicationTxnStatePB::TXN_PREPARED);
+        saved_txn_meta.set_tablet_id(tablet_id);
+
+        break;
+    }
+    return tablet;
 }
 
 Status ReplicationTxnManager::make_remote_snapshot(const TRemoteSnapshotRequest& request,
@@ -340,7 +427,7 @@ Status ReplicationTxnManager::replicate_remote_snapshot(const TReplicateSnapshot
                                                         const TRemoteSnapshotInfo& src_snapshot_info,
                                                         const std::string& tablet_snapshot_dir_path, Tablet* tablet) {
     // Check local path exist, if exist, remove it, then create the dir
-    RETURN_IF_ERROR(fs::remove_all(tablet_snapshot_dir_path));
+    RETURN_IF_ERROR(ignore_not_found(fs::remove_all(tablet_snapshot_dir_path)));
     RETURN_IF_ERROR(fs::create_directories(tablet_snapshot_dir_path));
 
     TabletSchemaCSPtr source_schema;
@@ -354,7 +441,7 @@ Status ReplicationTxnManager::replicate_remote_snapshot(const TReplicateSnapshot
         TabletMeta tablet_meta;
         auto status = tablet_meta.create_from_memory(header_file_content);
         if (!status.ok()) {
-            LOG(WARNING) << "Fail to parse remote snapshot header file: " << remote_header_file_name
+            LOG(WARNING) << "Failed to parse remote snapshot header file: " << remote_header_file_name
                          << ", content: " << header_file_content << ", " << status;
             return status;
         }
@@ -372,7 +459,7 @@ Status ReplicationTxnManager::replicate_remote_snapshot(const TReplicateSnapshot
         SnapshotMeta snapshot_meta;
         auto status = snapshot_meta.parse_from_file(memory_file.get());
         if (!status.ok()) {
-            LOG(WARNING) << "Fail to parse remote snapshot meta file: " << snapshot_meta_file_name
+            LOG(WARNING) << "Failed to parse remote snapshot meta file: " << snapshot_meta_file_name
                          << ", content: " << snapshot_meta_content << ", " << status;
             return status;
         }
@@ -454,7 +541,7 @@ Status ReplicationTxnManager::convert_snapshot_for_none_primary(
     if (request.tablet_id != request.src_tablet_id) {
         auto status = fs::delete_file(src_header_file_path);
         if (!status.ok()) {
-            LOG(WARNING) << "Fail to delete file: " << src_header_file_path << ", " << status;
+            LOG(WARNING) << "Failed to delete file: " << src_header_file_path << ", " << status;
         }
     }
 
@@ -528,7 +615,7 @@ Status ReplicationTxnManager::publish_snapshot(Tablet* tablet, const string& sna
         TabletMeta cloned_tablet_meta;
         res = cloned_tablet_meta.create_from_file(header_file);
         if (!res.ok()) {
-            LOG(WARNING) << "Fail to load load tablet meta from " << header_file;
+            LOG(WARNING) << "Failed to load load tablet meta from " << header_file;
             break;
         }
 
@@ -537,7 +624,7 @@ Status ReplicationTxnManager::publish_snapshot(Tablet* tablet, const string& sna
         if (has_dcgs_snapshot_file) {
             res = DeltaColumnGroupListHelper::parse_snapshot(dcgs_snapshot_file, dcg_snapshot_pb);
             if (!res.ok()) {
-                LOG(WARNING) << "Fail to load load dcg snapshot from " << dcgs_snapshot_file;
+                LOG(WARNING) << "Failed to load load dcg snapshot from " << dcgs_snapshot_file;
                 break;
             }
         }
@@ -545,7 +632,7 @@ Status ReplicationTxnManager::publish_snapshot(Tablet* tablet, const string& sna
         std::set<std::string> clone_files;
         res = fs::list_dirs_files(snapshot_dir, nullptr, &clone_files);
         if (!res.ok()) {
-            LOG(WARNING) << "Fail to list directory " << snapshot_dir << ": " << res;
+            LOG(WARNING) << "Failed to list directory " << snapshot_dir << ": " << res;
             break;
         }
 
@@ -558,7 +645,7 @@ Status ReplicationTxnManager::publish_snapshot(Tablet* tablet, const string& sna
         std::string tablet_dir = tablet->schema_hash_path();
         res = fs::list_dirs_files(tablet_dir, nullptr, &local_files);
         if (!res.ok()) {
-            LOG(WARNING) << "Fail to list tablet directory " << tablet_dir << ": " << res;
+            LOG(WARNING) << "Failed to list tablet directory " << tablet_dir << ": " << res;
             break;
         }
 
@@ -574,7 +661,7 @@ Status ReplicationTxnManager::publish_snapshot(Tablet* tablet, const string& sna
             std::string to = strings::Substitute("$0/$1", tablet_dir, clone_file);
             res = FileSystem::Default()->link_file(from, to);
             if (!res.ok()) {
-                LOG(WARNING) << "Fail to link " << from << " to " << to << ": " << res;
+                LOG(WARNING) << "Failed to link " << from << " to " << to << ": " << res;
                 break;
             }
             linked_success_files.emplace_back(std::move(to));
@@ -818,55 +905,64 @@ Status ReplicationTxnManager::publish_full_meta(Tablet* tablet, TabletMeta* clon
 }
 
 void ReplicationTxnManager::clear_txn_snapshots(TTransactionId transaction_id) {
+    std::vector<ReplicationTxnMetaPB> txn_metas;
+    {
+        std::shared_lock guard(_mutex);
+        auto transaction_iter = _transaction_map.find(transaction_id);
+        if (transaction_iter == _transaction_map.end()) {
+            return;
+        }
+
+        for (const auto& [partition_id, tablets] : transaction_iter->second) {
+            for (const auto& tablet_id : tablets) {
+                auto tablet_iter = _tablet_map.find(tablet_id);
+                if (tablet_iter != _tablet_map.end()) {
+                    const auto& txn_map = tablet_iter->second;
+                    auto txn_iter = txn_map.find(transaction_id);
+                    if (txn_iter != txn_map.end()) {
+                        const auto& txn_meta = txn_iter->second;
+                        if (txn_meta.txn_state() != ReplicationTxnStatePB::TXN_PREPARED) {
+                            txn_metas.push_back(txn_meta);
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    for (const auto& txn_meta : txn_metas) {
+        const std::string& src_backend_host = txn_meta.src_backend_host();
+        int32_t src_backend_port = txn_meta.src_backend_port();
+        const std::string& src_snapshot_path = txn_meta.src_snapshot_path();
+        if (src_backend_host.empty() || src_backend_port == 0 || src_snapshot_path.empty()) {
+            continue;
+        }
+        (void)ReplicationUtils::release_remote_snapshot(src_backend_host, src_backend_port, src_snapshot_path);
+    }
+
     for (DataDir* data_dir : StorageEngine::instance()->get_stores()) {
         std::string txn_dir_path = get_txn_dir_path(data_dir, transaction_id);
-        if (!fs::path_exist(txn_dir_path)) {
-            continue;
-        }
-
-        std::set<std::string> partition_dirs;
-        Status status = fs::list_dirs_files(txn_dir_path, &partition_dirs, nullptr);
-        if (!status.ok()) {
-            LOG(WARNING) << "Fail to list txn dir: " << txn_dir_path << ", " << status
-                         << ", txn_id: " << transaction_id;
-            continue;
-        }
-
-        for (const std::string& partition_dir : partition_dirs) {
-            std::string partition_dir_path = txn_dir_path + partition_dir + '/';
-            std::set<std::string> tablet_dirs;
-            status = fs::list_dirs_files(partition_dir_path, &tablet_dirs, nullptr);
-            if (!status.ok()) {
-                LOG(WARNING) << "Fail to list partition dir: " << partition_dir_path << ", " << status
-                             << ", txn_id: " << transaction_id;
-                continue;
-            }
-
-            for (const std::string& tablet_dir : tablet_dirs) {
-                std::string tablet_dir_path = partition_dir_path + tablet_dir + '/';
-                ReplicationTxnMetaPB txn_meta_pb;
-                status = load_tablet_txn_meta(tablet_dir_path, txn_meta_pb);
-                if (!status.ok()) {
-                    continue;
-                }
-
-                const std::string& src_backend_host = txn_meta_pb.src_backend_host();
-                int32_t src_backend_port = txn_meta_pb.src_backend_port();
-                const std::string& src_snapshot_path = txn_meta_pb.src_snapshot_path();
-                if (src_backend_host.empty() || src_backend_port == 0 || src_snapshot_path.empty()) {
-                    continue;
-                }
-
-                (void)ReplicationUtils::release_remote_snapshot(src_backend_host, src_backend_port, src_snapshot_path);
-            }
-        }
-
-        status = fs::remove_all(txn_dir_path);
-        if (!status.ok()) {
-            LOG(WARNING) << "Fail to remove txn dir: " << txn_dir_path << ", " << status
-                         << ", txn_id: " << transaction_id;
-        } else {
+        auto status = fs::remove_all(txn_dir_path);
+        if (status.ok() || status.is_not_found()) {
             LOG(INFO) << "Removed txn dir: " << txn_dir_path << ", txn_id: " << transaction_id;
+        } else {
+            LOG(WARNING) << "Failed to remove txn dir: " << txn_dir_path << ", status: " << status
+                         << ", txn_id: " << transaction_id;
+            return;
+        }
+    }
+
+    {
+        std::lock_guard guard(_mutex);
+        _transaction_map.erase(transaction_id);
+        for (const auto& txn_meta : txn_metas) {
+            auto iter = _tablet_map.find(txn_meta.tablet_id());
+            if (iter != _tablet_map.end()) {
+                iter->second.erase(transaction_id);
+                if (iter->second.empty()) {
+                    _tablet_map.erase(iter);
+                }
+            }
         }
     }
 }
@@ -875,31 +971,37 @@ Status ReplicationTxnManager::save_tablet_txn_meta(DataDir* data_dir, TTransacti
                                                    TPartitionId partition_id, TTabletId tablet_id,
                                                    const ReplicationTxnMetaPB& txn_meta) {
     std::string tablet_txn_dir_path = get_tablet_txn_dir_path(data_dir, transaction_id, partition_id, tablet_id);
-    if (!fs::path_exist(tablet_txn_dir_path)) {
-        Status status = fs::create_directories(tablet_txn_dir_path);
-        if (!status.ok()) {
-            LOG(WARNING) << "Fail to create directory " << tablet_txn_dir_path << ", " << status
-                         << ", txn_id: " << transaction_id;
-            return status;
-        }
-    }
 
-    return save_tablet_txn_meta(tablet_txn_dir_path, txn_meta);
+    RETURN_IF_ERROR(save_tablet_txn_meta(tablet_txn_dir_path, txn_meta));
+
+    std::lock_guard guard(_mutex);
+    _transaction_map[transaction_id][partition_id].push_back(tablet_id);
+    _tablet_map[tablet_id][transaction_id].CopyFrom(txn_meta);
+
+    return Status::OK();
 }
 
 Status ReplicationTxnManager::save_tablet_txn_meta(const std::string& tablet_txn_dir_path,
                                                    const ReplicationTxnMetaPB& txn_meta) {
+    if (!fs::path_exist(tablet_txn_dir_path)) {
+        Status status = fs::create_directories(tablet_txn_dir_path);
+        if (!status.ok()) {
+            LOG(WARNING) << "Failed to create directory " << tablet_txn_dir_path << ", " << status;
+            return status;
+        }
+    }
+
     std::string tablet_txn_meta_file_path = get_tablet_txn_meta_file_path(tablet_txn_dir_path);
     std::string tmp_tablet_txn_meta_file_path = tablet_txn_meta_file_path + ".temp";
     ProtobufFileWithHeader file(tmp_tablet_txn_meta_file_path);
     Status status = file.save(txn_meta, true);
     if (!status.ok()) {
-        LOG(WARNING) << "Fail to save txn meta to " << tmp_tablet_txn_meta_file_path << ", " << status;
+        LOG(WARNING) << "Failed to save txn meta to " << tmp_tablet_txn_meta_file_path << ", " << status;
         return status;
     }
 
-    if (0 != rename(tmp_tablet_txn_meta_file_path.c_str(), tablet_txn_meta_file_path.c_str())) {
-        LOG(WARNING) << "Fail to rename txn meta file from " << tmp_tablet_txn_meta_file_path << " to "
+    if (0 != ::rename(tmp_tablet_txn_meta_file_path.c_str(), tablet_txn_meta_file_path.c_str())) {
+        LOG(WARNING) << "Failed to rename txn meta file from " << tmp_tablet_txn_meta_file_path << " to "
                      << tablet_txn_meta_file_path << ", " << strerror(errno);
         return Status::IOError(strerror(errno));
     }
@@ -907,32 +1009,42 @@ Status ReplicationTxnManager::save_tablet_txn_meta(const std::string& tablet_txn
     return Status::OK();
 }
 
-Status ReplicationTxnManager::load_tablet_txn_meta(DataDir* data_dir, TTransactionId transaction_id,
-                                                   TPartitionId partition_id, TTabletId tablet_id,
-                                                   ReplicationTxnMetaPB& txn_meta) {
-    std::string tablet_txn_meta_file_path =
-            get_tablet_txn_meta_file_path(data_dir, transaction_id, partition_id, tablet_id);
-    ProtobufFileWithHeader file(tablet_txn_meta_file_path);
-    return file.load(&txn_meta);
+Status ReplicationTxnManager::load_tablet_txn_meta(TTransactionId transaction_id, TTabletId tablet_id,
+                                                   ReplicationTxnMetaPB& txn_meta) const {
+    std::shared_lock guard(_mutex);
+
+    auto tablet_iter = _tablet_map.find(tablet_id);
+    if (tablet_iter == _tablet_map.end()) {
+        return Status::NotFound(fmt::format("Tablet: {} not found", tablet_id));
+    }
+
+    const auto& transaction_map = tablet_iter->second;
+    auto transaction_iter = transaction_map.find(transaction_id);
+    if (transaction_iter == transaction_map.end()) {
+        return Status::NotFound(fmt::format("Transaction: {} not found", transaction_id));
+    }
+
+    txn_meta.CopyFrom(transaction_iter->second);
+    return Status::OK();
 }
 
 Status ReplicationTxnManager::load_tablet_txn_meta(const std::string& tablet_txn_dir_path,
-                                                   ReplicationTxnMetaPB& txn_meta) {
+                                                   ReplicationTxnMetaPB& txn_meta) const {
     std::string tablet_txn_meta_file_path = get_tablet_txn_meta_file_path(tablet_txn_dir_path);
     ProtobufFileWithHeader file(tablet_txn_meta_file_path);
     Status status = file.load(&txn_meta);
     if (!status.ok()) {
-        LOG(WARNING) << "Fail to load txn meta from " << tablet_txn_meta_file_path << ", " << status;
+        LOG(WARNING) << "Failed to load txn meta from " << tablet_txn_meta_file_path << ", status: " << status;
     }
     return status;
 }
 
-StatusOr<TabletSharedPtr> ReplicationTxnManager::get_tablet(TTabletId tablet_id) {
+StatusOr<TabletSharedPtr> ReplicationTxnManager::get_tablet(TTabletId tablet_id) const {
     auto tablet_manager = StorageEngine::instance()->tablet_manager();
     std::string error_msg;
     auto tablet = tablet_manager->get_tablet(tablet_id, false, &error_msg);
     if (tablet == nullptr) {
-        LOG(WARNING) << "Cannot get tablet " << tablet_id << ", " << error_msg;
+        LOG(WARNING) << "Cannot get tablet " << tablet_id << ", error: " << error_msg;
         return Status::NotFound(error_msg);
     }
     return tablet;

--- a/be/src/storage/replication_txn_manager.h
+++ b/be/src/storage/replication_txn_manager.h
@@ -23,13 +23,17 @@ class ReplicationTxnManager {
 public:
     explicit ReplicationTxnManager() {}
 
+    Status init(const std::vector<starrocks::DataDir*>& data_dirs);
+
     Status remote_snapshot(const TRemoteSnapshotRequest& request, std::string* src_snapshot_path,
                            bool* incremental_snapshot);
 
     Status replicate_snapshot(const TReplicateSnapshotRequest& request);
 
-    Status get_txn_related_tablets(const TTransactionId transaction_id, TPartitionId partition_id,
-                                   std::vector<TTabletId>* tablet_ids);
+    void get_txn_related_tablets(TTransactionId transaction_id, TPartitionId partition_id,
+                                 std::vector<TTabletId>* tablet_ids);
+
+    void get_tablet_related_txns(TTabletId tablet_id, std::set<TTransactionId>* transaction_ids);
 
     Status publish_txn(TTransactionId transaction_id, TPartitionId partition_id, const TabletSharedPtr& tablet,
                        int64_t version);
@@ -41,6 +45,9 @@ public:
     DISALLOW_COPY_AND_MOVE(ReplicationTxnManager);
 
 private:
+    StatusOr<TabletSharedPtr> prepare_txn(TTransactionId transaction_id, TPartitionId partition_id,
+                                          TTabletId tablet_id);
+
     Status make_remote_snapshot(const TRemoteSnapshotRequest& request, const std::vector<Version>* missed_versions,
                                 const std::vector<int64_t>* missing_version_ranges, TBackend* src_backend,
                                 std::string* src_snapshot_path);
@@ -74,12 +81,17 @@ private:
 
     Status save_tablet_txn_meta(const std::string& tablet_txn_dir_path, const ReplicationTxnMetaPB& txn_meta);
 
-    Status load_tablet_txn_meta(DataDir* data_dir, TTransactionId transaction_id, TPartitionId partition_id,
-                                TTabletId tablet_id, ReplicationTxnMetaPB& txn_meta);
+    Status load_tablet_txn_meta(TTransactionId transaction_id, TTabletId tablet_id,
+                                ReplicationTxnMetaPB& txn_meta) const;
 
-    Status load_tablet_txn_meta(const std::string& tablet_txn_dir_path, ReplicationTxnMetaPB& txn_meta);
+    Status load_tablet_txn_meta(const std::string& tablet_txn_dir_path, ReplicationTxnMetaPB& txn_meta) const;
 
-    StatusOr<TabletSharedPtr> get_tablet(TTabletId tablet_id);
+    StatusOr<TabletSharedPtr> get_tablet(TTabletId tablet_id) const;
+
+private:
+    mutable std::shared_mutex _mutex;
+    std::unordered_map<TTransactionId, std::unordered_map<TPartitionId, std::vector<TTabletId>>> _transaction_map;
+    std::unordered_map<TTabletId, std::unordered_map<TTransactionId, ReplicationTxnMetaPB>> _tablet_map;
 };
 
 } // namespace starrocks

--- a/be/src/storage/storage_engine.cpp
+++ b/be/src/storage/storage_engine.cpp
@@ -238,6 +238,8 @@ Status StorageEngine::_open(const EngineOptions& options) {
         return _segment_replicate_executor->get_thread_pool()->num_queued_tasks();
     });
 
+    RETURN_IF_ERROR_WITH_WARN(_replication_txn_manager->init(dirs), "init ReplicationTxnManager failed");
+
     return Status::OK();
 }
 

--- a/be/src/storage/task/engine_storage_migration_task.cpp
+++ b/be/src/storage/task/engine_storage_migration_task.cpp
@@ -37,6 +37,7 @@
 #include <fmt/format.h>
 
 #include "runtime/exec_env.h"
+#include "storage/replication_txn_manager.h"
 #include "storage/snapshot_manager.h"
 #include "storage/tablet_meta_manager.h"
 #include "util/defer_op.h"
@@ -111,6 +112,9 @@ Status EngineStorageMigrationTask::_storage_migrate(TabletSharedPtr tablet) {
         std::set<int64_t> transaction_ids;
         StorageEngine::instance()->txn_manager()->get_tablet_related_txns(
                 _tablet_id, _schema_hash, tablet->tablet_uid(), &partition_id, &transaction_ids);
+        if (transaction_ids.empty()) {
+            StorageEngine::instance()->replication_txn_manager()->get_tablet_related_txns(_tablet_id, &transaction_ids);
+        }
         if (!transaction_ids.empty()) {
             LOG(WARNING) << "could not migration because has unfinished txns.";
             return Status::InternalError("could not migration because has unfinished txns.");
@@ -214,6 +218,9 @@ Status EngineStorageMigrationTask::_storage_migrate(TabletSharedPtr tablet) {
         std::set<int64_t> transaction_ids;
         StorageEngine::instance()->txn_manager()->get_tablet_related_txns(
                 _tablet_id, _schema_hash, tablet->tablet_uid(), &partition_id, &transaction_ids);
+        if (transaction_ids.empty()) {
+            StorageEngine::instance()->replication_txn_manager()->get_tablet_related_txns(_tablet_id, &transaction_ids);
+        }
         if (!transaction_ids.empty()) {
             LOG(WARNING) << "could not migration because has unfinished txns.";
             need_remove_new_path = true;

--- a/be/test/agent/agent_task_test.cpp
+++ b/be/test/agent/agent_task_test.cpp
@@ -57,7 +57,7 @@ public:
         status = StorageEngine::instance()->tablet_manager()->delete_shutdown_tablet(_src_tablet_id);
         EXPECT_TRUE(status.ok()) << status;
         status = fs::remove_all(config::storage_root_path);
-        EXPECT_TRUE(status.ok()) << status;
+        EXPECT_TRUE(status.ok() || status.is_not_found()) << status;
     }
 
     TCreateTabletReq get_create_tablet_request(int64_t tablet_id, int schema_hash, int64_t version) {

--- a/be/test/storage/lake/replication_txn_manager_test.cpp
+++ b/be/test/storage/lake/replication_txn_manager_test.cpp
@@ -84,7 +84,7 @@ public:
         status = StorageEngine::instance()->tablet_manager()->delete_shutdown_tablet(_src_tablet_id);
         EXPECT_TRUE(status.ok()) << status;
         status = fs::remove_all(config::storage_root_path);
-        EXPECT_TRUE(status.ok()) << status;
+        EXPECT_TRUE(status.ok() || status.is_not_found()) << status;
     }
 
     TCreateTabletReq get_create_tablet_req(int64_t tablet_id, int64_t version, int32_t schema_hash,

--- a/be/test/storage/replication_txn_manager_test.cpp
+++ b/be/test/storage/replication_txn_manager_test.cpp
@@ -65,7 +65,7 @@ public:
         status = StorageEngine::instance()->tablet_manager()->delete_shutdown_tablet(_src_tablet_id);
         EXPECT_TRUE(status.ok()) << status;
         status = fs::remove_all(config::storage_root_path);
-        EXPECT_TRUE(status.ok()) << status;
+        EXPECT_TRUE(status.ok() || status.is_not_found()) << status;
     }
 
     TabletSharedPtr create_tablet(int64_t tablet_id, int64_t version, int32_t schema_hash,

--- a/gensrc/proto/types.proto
+++ b/gensrc/proto/types.proto
@@ -109,7 +109,7 @@ enum TxnTypePB {
  }
 
  enum ReplicationTxnStatePB {
-     TXN_INVALID = 0;
+     TXN_PREPARED = 0;
      TXN_SNAPSHOTED = 1;
      TXN_REPLICATED = 2;
      TXN_PUBLISHED = 3;


### PR DESCRIPTION
Why I'm doing: Replication transaction cannot deal with tablet migration.
What I'm doing:
Support tablet migration detection during replication transaction

backport of pr https://github.com/StarRocks/starrocks/pull/39207

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [x] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [x] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5

