### PR TITLE
[BugFix] align host nodes with max parallelism

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/qe/CoordinatorPreprocessor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/CoordinatorPreprocessor.java
@@ -690,6 +690,7 @@ public class CoordinatorPreprocessor {
                             hostSet.add(e.second);
                             recordUsedBackend(e.second, e.first);
                         });
+                        maxParallelism = hostSet.size() * fragment.getParallelExecNum();
                     }
                 }
 

--- a/fe/fe-core/src/main/java/com/starrocks/qe/CoordinatorPreprocessor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/CoordinatorPreprocessor.java
@@ -690,7 +690,13 @@ public class CoordinatorPreprocessor {
                             hostSet.add(e.second);
                             recordUsedBackend(e.second, e.first);
                         });
-                        maxParallelism = hostSet.size() * fragment.getParallelExecNum();
+
+                        // The adaptive choose nodes process may change the selected nodes number.
+                        // When enable pipeline engine but dop is not 0, We have to change the maxParallelism value
+                        // to ensure it keeps equal with the size of hostSet.
+                        if (usePipeline) {
+                            maxParallelism = hostSet.size();
+                        }
                     }
                 }
 

--- a/fe/fe-core/src/test/java/com/starrocks/qe/TPCDSCoordTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/qe/TPCDSCoordTest.java
@@ -86,7 +86,6 @@ public class TPCDSCoordTest extends TPCDSPlanTestBase {
         // 2 fragements to consumer filter(1)
         Assert.assertEquals(3, fragments.size());
 
-        System.out.println(plan);
         ExecPlan execPlan = UtFrameUtils.getPlanAndFragment(ctx, sql).second;
         Coordinator coord = new Coordinator(ctx, execPlan.getFragments(), execPlan.getScanNodes(),
                 execPlan.getDescTbl().toThrift());

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/DistributedEnvPlanTestBase.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/DistributedEnvPlanTestBase.java
@@ -140,9 +140,6 @@ public class DistributedEnvPlanTestBase extends PlanTestBase {
 
         OlapTable datesN = (OlapTable) globalStateMgr.getDb("test").getTable("dates_n");
         setTableStatistics(datesN, 2556);
-
-        UtFrameUtils.addMockBackend(10002);
-        UtFrameUtils.addMockBackend(10003);
     }
 
     @AfterClass

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/DistributedEnvPlanTestBase.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/DistributedEnvPlanTestBase.java
@@ -26,6 +26,9 @@ public class DistributedEnvPlanTestBase extends PlanTestBase {
     @BeforeClass
     public static void beforeClass() throws Exception {
         PlanTestBase.beforeClass();
+        UtFrameUtils.addMockBackend(10002);
+        UtFrameUtils.addMockBackend(10003);
+
         starRocksAssert.withTable("CREATE TABLE `lineorder_new_l` (\n" +
                 "  `LO_ORDERKEY` int(11) NOT NULL COMMENT \"\",\n" +
                 "  `LO_ORDERDATE` date NOT NULL COMMENT \"\",\n" +

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/DistributedEnvPlanWithCostTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/DistributedEnvPlanWithCostTest.java
@@ -17,16 +17,21 @@ package com.starrocks.sql.plan;
 import com.starrocks.catalog.OlapTable;
 import com.starrocks.catalog.Table;
 import com.starrocks.common.Config;
+import com.starrocks.common.ConfigBase;
 import com.starrocks.common.FeConstants;
 import com.starrocks.common.Pair;
 import com.starrocks.planner.AggregationNode;
 import com.starrocks.planner.PlanFragment;
+import com.starrocks.planner.PlanFragmentId;
 import com.starrocks.qe.ConnectContext;
+import com.starrocks.qe.Coordinator;
+import com.starrocks.qe.CoordinatorPreprocessor;
 import com.starrocks.sql.optimizer.OptExpression;
 import com.starrocks.sql.optimizer.OptimizerContext;
 import com.starrocks.sql.optimizer.rule.transformation.DeriveRangeJoinPredicateRule;
 import com.starrocks.sql.optimizer.statistics.ColumnStatistic;
 import com.starrocks.thrift.TExplainLevel;
+import com.starrocks.thrift.TUniqueId;
 import com.starrocks.utframe.UtFrameUtils;
 import mockit.Expectations;
 import mockit.Mock;
@@ -1588,5 +1593,45 @@ public class DistributedEnvPlanWithCostTest extends DistributedEnvPlanTestBase {
         String plan = getCostExplain(sql);
         assertCContains(plan, "C_NAME-->[-Infinity, Infinity, 0.0, 25.0, 600000.0] ESTIMATE",
                 "C_NATIONKEY-->[0.0, 24.0, 0.0, 4.0, 25.0] ESTIMATE");
+    }
+
+    @Test
+    public void testDecreaseNodesInPipeline() throws Exception {
+        ConfigBase.setMutableConfig("adaptive_choose_instances_threshold", "3");
+        connectContext.getSessionVariable().setChooseExecuteInstancesMode("auto");
+        connectContext.getSessionVariable().setPipelineDop(2);
+        connectContext.setExecutionId(new TUniqueId(0x33, 0x0));
+        String sql = "select count(*) from lineitem group by l_shipmode";
+        ExecPlan execPlan = getExecPlan(sql);
+        Coordinator coord = new Coordinator(connectContext, execPlan.getFragments(), execPlan.getScanNodes(),
+                execPlan.getDescTbl().toThrift());
+        coord.prepareExec();
+        PlanFragmentId botFragment = coord.getFragments().get(2).getFragmentId();
+        CoordinatorPreprocessor.FragmentExecParams params1 = coord.getFragmentExecParamsMap().get(botFragment);
+        Assert.assertEquals(3, params1.instanceExecParams.size());
+
+        PlanFragmentId exchangeFragment = coord.getFragments().get(1).getFragmentId();
+        CoordinatorPreprocessor.FragmentExecParams params2 = coord.getFragmentExecParamsMap().get(exchangeFragment);
+
+        // in pipeline engine, decrease nodes to 1. The instance exec param size should be 1.
+        Assert.assertEquals(1, params2.instanceExecParams.size());
+        Assert.assertEquals(1, params2.perExchNumSenders.size());
+
+        connectContext.getSessionVariable().setEnablePipelineEngine(false);
+        execPlan = getExecPlan(sql);
+        coord = new Coordinator(connectContext, execPlan.getFragments(), execPlan.getScanNodes(),
+                execPlan.getDescTbl().toThrift());
+        coord.prepareExec();
+        botFragment = coord.getFragments().get(2).getFragmentId();
+        params1 = coord.getFragmentExecParamsMap().get(botFragment);
+        Assert.assertEquals(3, params1.instanceExecParams.size());
+
+        exchangeFragment = coord.getFragments().get(1).getFragmentId();
+        params2 = coord.getFragmentExecParamsMap().get(exchangeFragment);
+
+        // not in pipeline engine, decrease nodes to 1. The instance exec param size also be 3.
+        Assert.assertEquals(3, params2.instanceExecParams.size());
+        Assert.assertEquals(1, params2.instanceExecParams.stream().map(e -> e.getHost()).collect(Collectors.toSet()).size());
+        Assert.assertEquals(1, params2.perExchNumSenders.size());
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/DistributedEnvPlanWithCostTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/DistributedEnvPlanWithCostTest.java
@@ -1602,6 +1602,7 @@ public class DistributedEnvPlanWithCostTest extends DistributedEnvPlanTestBase {
         connectContext.getSessionVariable().setPipelineDop(2);
         connectContext.setExecutionId(new TUniqueId(0x33, 0x0));
         String sql = "select count(*) from lineitem group by l_shipmode";
+        sql = "select count(*) from lineorder_new_l group by P_SIZE";
         ExecPlan execPlan = getExecPlan(sql);
         Coordinator coord = new Coordinator(connectContext, execPlan.getFragments(), execPlan.getScanNodes(),
                 execPlan.getDescTbl().toThrift());

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/MockTpchStatisticStorage.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/MockTpchStatisticStorage.java
@@ -15,6 +15,7 @@
 
 package com.starrocks.sql.plan;
 
+import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Maps;
 import com.starrocks.catalog.Database;
 import com.starrocks.catalog.OlapTable;
@@ -316,6 +317,8 @@ public class MockTpchStatisticStorage implements StatisticStorage {
         // S_COMMENT   VARCHAR(101)
         tableSupplier.put("s_comment", new ColumnStatistic(NEGATIVE_INFINITY, POSITIVE_INFINITY, 0, 101, 10000));
         tableStatistics.put("supplier", tableSupplier);
+
+        tableStatistics.put("lineorder_new_l", ImmutableMap.of("P_SIZE", new ColumnStatistic(1, 5, 0, 1, 5)));
     }
 
     @Override

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/PlanTestNoneDBBase.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/PlanTestNoneDBBase.java
@@ -81,15 +81,12 @@ public class PlanTestNoneDBBase {
         Config.tablet_sched_max_scheduling_tablets = -1;
         Config.alter_scheduler_interval_millisecond = 1;
         UtFrameUtils.createMinStarRocksCluster();
-
         // create connect context
         connectContext = UtFrameUtils.createDefaultCtx();
         starRocksAssert = new StarRocksAssert(connectContext);
         connectContext.getSessionVariable().setOptimizerExecuteTimeout(30000);
         FeConstants.enablePruneEmptyOutputScan = false;
         FeConstants.showJoinLocalShuffleInExplain = false;
-        UtFrameUtils.addMockBackend(10002);
-        UtFrameUtils.addMockBackend(10003);
     }
 
     public static void assertContains(String text, String... pattern) {

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/PlanTestNoneDBBase.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/PlanTestNoneDBBase.java
@@ -81,12 +81,15 @@ public class PlanTestNoneDBBase {
         Config.tablet_sched_max_scheduling_tablets = -1;
         Config.alter_scheduler_interval_millisecond = 1;
         UtFrameUtils.createMinStarRocksCluster();
+
         // create connect context
         connectContext = UtFrameUtils.createDefaultCtx();
         starRocksAssert = new StarRocksAssert(connectContext);
         connectContext.getSessionVariable().setOptimizerExecuteTimeout(30000);
         FeConstants.enablePruneEmptyOutputScan = false;
         FeConstants.showJoinLocalShuffleInExplain = false;
+        UtFrameUtils.addMockBackend(10002);
+        UtFrameUtils.addMockBackend(10003);
     }
 
     public static void assertContains(String text, String... pattern) {


### PR DESCRIPTION
Why I'm doing:
If host nodes are not equal with parallelism, it makes multiple fragment instances in one machine lead exchange be stuck. 

What I'm doing:
align host nodes with max parallelism

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5

