### PR TITLE
[Enhancement] Support configuring HMS timeout param when creating hive/iceberg connector

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/connector/hive/HiveConnector.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/hive/HiveConnector.java
@@ -30,6 +30,7 @@ import java.util.Optional;
 public class HiveConnector implements Connector {
     public static final String HIVE_METASTORE_URIS = "hive.metastore.uris";
     public static final String HIVE_METASTORE_TYPE = "hive.metastore.type";
+    public static final String HIVE_METASTORE_TIMEOUT = "hive.metastore.timeout";
     private final Map<String, String> properties;
     private final String catalogName;
     private final HiveConnectorInternalMgr internalMgr;

--- a/fe/fe-core/src/main/java/com/starrocks/connector/hive/HiveMetaClient.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/hive/HiveMetaClient.java
@@ -46,6 +46,7 @@ import java.util.List;
 import java.util.Map;
 
 import static com.starrocks.common.profile.Tracers.Module.EXTERNAL;
+import static com.starrocks.connector.hive.HiveConnector.HIVE_METASTORE_TIMEOUT;
 import static com.starrocks.connector.hive.HiveConnector.HIVE_METASTORE_TYPE;
 import static com.starrocks.connector.hive.HiveConnector.HIVE_METASTORE_URIS;
 
@@ -78,8 +79,10 @@ public class HiveMetaClient {
         if (properties.containsKey(HIVE_METASTORE_URIS)) {
             conf.set(MetastoreConf.ConfVars.THRIFT_URIS.getHiveName(), properties.get(HIVE_METASTORE_URIS));
         }
-        conf.set(MetastoreConf.ConfVars.CLIENT_SOCKET_TIMEOUT.getHiveName(),
-                String.valueOf(Config.hive_meta_store_timeout_s));
+        String hmsTimeout = properties.containsKey(HIVE_METASTORE_TIMEOUT)
+                ? properties.get(HIVE_METASTORE_TIMEOUT)
+                : String.valueOf(Config.hive_meta_store_timeout_s);
+        conf.set(MetastoreConf.ConfVars.CLIENT_SOCKET_TIMEOUT.getHiveName(), hmsTimeout);
         return new HiveMetaClient(conf);
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/connector/hive/HiveMetaClient.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/hive/HiveMetaClient.java
@@ -79,9 +79,7 @@ public class HiveMetaClient {
         if (properties.containsKey(HIVE_METASTORE_URIS)) {
             conf.set(MetastoreConf.ConfVars.THRIFT_URIS.getHiveName(), properties.get(HIVE_METASTORE_URIS));
         }
-        String hmsTimeout = properties.containsKey(HIVE_METASTORE_TIMEOUT)
-                ? properties.get(HIVE_METASTORE_TIMEOUT)
-                : String.valueOf(Config.hive_meta_store_timeout_s);
+        String hmsTimeout = properties.getOrDefault(HIVE_METASTORE_TIMEOUT, String.valueOf(Config.hive_meta_store_timeout_s));
         conf.set(MetastoreConf.ConfVars.CLIENT_SOCKET_TIMEOUT.getHiveName(), hmsTimeout);
         return new HiveMetaClient(conf);
     }

--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergConnector.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergConnector.java
@@ -48,6 +48,7 @@ public class IcebergConnector implements Connector {
     @Deprecated
     public static final String ICEBERG_METASTORE_URIS = "iceberg.catalog.hive.metastore.uris";
     public static final String HIVE_METASTORE_URIS = "hive.metastore.uris";
+    public static final String HIVE_METASTORE_TIMEOUT = "hive.metastore.timeout";
     public static final String ICEBERG_CUSTOM_PROPERTIES_PREFIX = "iceberg.catalog.";
     private final Map<String, String> properties;
     private final HdfsEnvironment hdfsEnvironment;

--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/hive/IcebergHiveCatalog.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/hive/IcebergHiveCatalog.java
@@ -67,9 +67,7 @@ public class IcebergHiveCatalog implements IcebergCatalog {
     @VisibleForTesting
     public IcebergHiveCatalog(String name, Configuration conf, Map<String, String> properties) {
         this.conf = conf;
-        String hmsTimeout = properties.containsKey(HIVE_METASTORE_TIMEOUT)
-                ? properties.get(HIVE_METASTORE_TIMEOUT)
-                : String.valueOf(Config.hive_meta_store_timeout_s);
+        String hmsTimeout = properties.getOrDefault(HIVE_METASTORE_TIMEOUT, String.valueOf(Config.hive_meta_store_timeout_s));
         this.conf.set(MetastoreConf.ConfVars.CLIENT_SOCKET_TIMEOUT.getHiveName(), hmsTimeout);
         if (conf.get(METASTOREWAREHOUSE.varname) == null) {
             this.conf.set(METASTOREWAREHOUSE.varname, METASTOREWAREHOUSE.getDefaultValue());

--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/hive/IcebergHiveCatalog.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/hive/IcebergHiveCatalog.java
@@ -52,6 +52,7 @@ import java.util.Map;
 import java.util.stream.Collectors;
 
 import static com.starrocks.connector.ConnectorTableId.CONNECTOR_ID_GENERATOR;
+import static com.starrocks.connector.iceberg.IcebergConnector.HIVE_METASTORE_TIMEOUT;
 import static com.starrocks.connector.iceberg.IcebergConnector.HIVE_METASTORE_URIS;
 import static com.starrocks.connector.iceberg.IcebergConnector.ICEBERG_METASTORE_URIS;
 import static com.starrocks.connector.iceberg.IcebergMetadata.LOCATION_PROPERTY;
@@ -66,8 +67,10 @@ public class IcebergHiveCatalog implements IcebergCatalog {
     @VisibleForTesting
     public IcebergHiveCatalog(String name, Configuration conf, Map<String, String> properties) {
         this.conf = conf;
-        this.conf.set(MetastoreConf.ConfVars.CLIENT_SOCKET_TIMEOUT.getHiveName(),
-                String.valueOf(Config.hive_meta_store_timeout_s));
+        String hmsTimeout = properties.containsKey(HIVE_METASTORE_TIMEOUT)
+                ? properties.get(HIVE_METASTORE_TIMEOUT)
+                : String.valueOf(Config.hive_meta_store_timeout_s);
+        this.conf.set(MetastoreConf.ConfVars.CLIENT_SOCKET_TIMEOUT.getHiveName(), hmsTimeout);
         if (conf.get(METASTOREWAREHOUSE.varname) == null) {
             this.conf.set(METASTOREWAREHOUSE.varname, METASTOREWAREHOUSE.getDefaultValue());
         }


### PR DESCRIPTION
## Why I'm doing:

It's strange to make hms timeout configuration static on FE side, as this timeout is a frequently used parameter, users may want to configure different timeout value based on different connector.

I think it's good to configure the hms timeout when creating hive/icebeg connector.

## What I'm doing:
I want to make the hms timeout param configurable when creating connector. I added a new property `hive.metastore.timeout`. We can use it like this:
``` 
CREATE EXTERNAL CATALOG hiveconnector
PROPERTIES
(
"type" = "hive",
"hive.metastore.type" = "hive",
"hive.metastore.timeout" = "600",
"hive.metastore.uris" = "thrift://127.0.0.1:9083"
);
```

Fixes #39593

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
