### PR TITLE
[Enhancement] Make routine load error msg more clear

### DIFF
--- a/be/src/service/internal_service.cpp
+++ b/be/src/service/internal_service.cpp
@@ -612,6 +612,11 @@ void PInternalServiceImplBase<T>::get_info(google::protobuf::RpcController* cont
 template <typename T>
 void PInternalServiceImplBase<T>::_get_info_impl(const PProxyRequest* request, PProxyResult* response,
                                                  google::protobuf::Closure* done, int timeout_ms) {
+    // If we use timeout specified by user directly, there will be an issue that librakafka connect to kafka broker
+    // time out, but the BE did not have the opportunity to send the error message back to the FE , and the timer on
+    // the FE side has already timed out. This mean that the FE cannot retrieve the event message from librdkafka.
+    // Therefore, here we are reducing the actual timeout threshold of librdkafka.
+    timeout_ms = timeout_ms * 0.8;
     ClosureGuard closure_guard(done);
 
     if (timeout_ms <= 0) {

--- a/fe/fe-core/src/main/java/com/starrocks/common/util/KafkaUtil.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/util/KafkaUtil.java
@@ -214,7 +214,8 @@ public class KafkaUtil {
                     try {
                         result = future.get(Config.routine_load_kafka_timeout_second, TimeUnit.SECONDS);
                     } catch (Exception e) {
-                        LOG.warn("failed to send proxy request to " + address + " err " + e.getMessage());
+                        LOG.warn("Error occurred during interaction between BE and Kafka broker. BE address " 
+                                    + address + " err " + e.getMessage());
                         // Jprotobuf-rpc-socket throws an ExecutionException when an exception occurs.
                         // We use the error message to identify the type of exception.
                         if (e.getMessage().contains("Ocurrs time out")) {
@@ -230,9 +231,9 @@ public class KafkaUtil {
                     }
                     TStatusCode code = TStatusCode.findByValue(result.status.statusCode);
                     if (code != TStatusCode.OK) {
-                        LOG.warn("failed to send proxy request to " + address + " err " + result.status.errorMsgs);
-                        throw new UserException(
-                                "failed to send proxy request to " + address + " err " + result.status.errorMsgs);
+                        LOG.warn("Error occurred during interaction between BE and Kafka broker. BE address " 
+                                    + address + " err " + result.status.errorMsgs);
+                        throw new UserException(result.status.errorMsgs.toString());
                     } else {
                         return result;
                     }
@@ -242,10 +243,11 @@ public class KafkaUtil {
                 Thread.currentThread().interrupt();
                 throw new LoadException("got interrupted exception when sending proxy request to " + address);
             } catch (Exception e) {
-                LOG.warn("failed to send proxy request to " + address + " err " + e.getMessage());
-                throw new LoadException("failed to send proxy request to " + address + " err " + e.getMessage());
+                LOG.warn("Error occurred during interaction between BE and Kafka broker. BE address " 
+                                    + address + " err " + e.getMessage());
+                throw new LoadException("Error occurred during interaction between BE and Kafka broker. BE address " 
+                                    + address + " err " + e.getMessage());
             }
         }
     }
 }
-


### PR DESCRIPTION
Why I'm doing:
When there is an error in the interaction between the BE and the Kafka broker, the current error message is very confusing for users. Users cannot determine the specific reason why the routine load job has been paused.
![image](https://github.com/StarRocks/starrocks/assets/45813655/71bd4fe0-3cd2-4c93-a224-a587e90cc449)


What I'm doing:
Expose librdkafka logs to users.
![image](https://github.com/StarRocks/starrocks/assets/45813655/94b4e7e5-ee92-4ec2-a8cd-ffb96056b716)







Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [x] 3.1
  - [ ] 3.0
  - [ ] 2.5
