### PR TITLE
[BugFix] Fix query trino view which not no contains db name failed

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/HiveView.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/HiveView.java
@@ -24,6 +24,7 @@ import com.starrocks.sql.common.ErrorType;
 import com.starrocks.sql.common.StarRocksPlannerException;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.apache.parquet.Strings;
 
 import java.util.List;
 
@@ -38,15 +39,18 @@ public class HiveView extends Table {
     }
 
     private final String catalogName;
+    private final String dbName;
     private final String inlineViewDef;
     private final Type viewType;
 
     public static final String PRESTO_VIEW_PREFIX = "/* Presto View: ";
     public static final String PRESTO_VIEW_SUFFIX = " */";
 
-    public HiveView(long id, String catalogName, String name, List<Column> schema, String definition, Type type) {
+    public HiveView(long id, String catalogName, String dbName, String name, List<Column> schema, String definition,
+                    Type type) {
         super(id, name, TableType.HIVE_VIEW, schema);
         this.catalogName = requireNonNull(catalogName, "Hive view catalog name is null");
+        this.dbName = requireNonNull(dbName, "Hive view db name is null");
         this.inlineViewDef = requireNonNull(definition, "Hive view text is null");
         this.viewType = requireNonNull(type, "Hive view type is null");
     }
@@ -102,6 +106,9 @@ public class HiveView extends Table {
         List<TableRelation> tableRelations = AnalyzerUtils.collectTableRelations(queryStatement);
         for (TableRelation tableRelation : tableRelations) {
             tableRelation.getName().setCatalog(catalogName);
+            if (Strings.isNullOrEmpty(tableRelation.getName().getDb())) {
+                tableRelation.getName().setDb(dbName);
+            }
         }
         return queryStatement;
     }

--- a/fe/fe-core/src/main/java/com/starrocks/connector/hive/HiveMetastoreApiConverter.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/hive/HiveMetastoreApiConverter.java
@@ -239,12 +239,12 @@ public class HiveMetastoreApiConverter {
                     TrinoViewDefinition.class);
             hiveViewText = trinoViewDefinition.getOriginalSql();
             hiveView = new HiveView(ConnectorTableId.CONNECTOR_ID_GENERATOR.getNextId().asInt(), catalogName,
-                    table.getTableName(), toFullSchemasForTrinoView(table, trinoViewDefinition), hiveViewText,
-                    HiveView.Type.Trino);
+                    table.getDbName(), table.getTableName(), toFullSchemasForTrinoView(table, trinoViewDefinition),
+                    hiveViewText, HiveView.Type.Trino);
         } else {
             hiveView = new HiveView(ConnectorTableId.CONNECTOR_ID_GENERATOR.getNextId().asInt(), catalogName,
-                    table.getTableName(), toFullSchemasForHiveTable(table), table.getViewExpandedText(),
-                    HiveView.Type.Hive);
+                    table.getDbName(), table.getTableName(), toFullSchemasForHiveTable(table),
+                    table.getViewExpandedText(), HiveView.Type.Hive);
         }
 
         try {

--- a/fe/fe-core/src/test/java/com/starrocks/connector/hive/HiveViewTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/hive/HiveViewTest.java
@@ -77,7 +77,8 @@ public class HiveViewTest extends PlanTestBase {
 
     @Test
     public void testHiveViewParseFail() throws Exception {
-        HiveView hiveView = new HiveView(1, "hive0", "test", null, "select\n" +
+        HiveView hiveView = new HiveView(1, "hive0", "testDb", "test", null,
+                "select\n" +
                  "    t1b,t1a\n" +
                  "from\n" +
                  "    test_all_type\n" +
@@ -91,6 +92,15 @@ public class HiveViewTest extends PlanTestBase {
     public void testQueryHiveViewWithTrinoSQLDialect() throws Exception {
         String sql = "select * from hive0.tpch.customer_alias_view where c_custkey = 1";
         connectContext.getSessionVariable().setSqlDialect("trino");
+        String sqlPlan = getFragmentPlan(sql);
+        assertContains(sqlPlan, "0:HdfsScanNode\n" +
+                "     TABLE: customer");
+    }
+
+    @Test
+    public void testQueryTrinoViewWithoutDb() throws Exception {
+        // test query trino view without db
+        String sql = "select * from hive0.tpch.customer_view_without_db where c_custkey = 1";
         String sqlPlan = getFragmentPlan(sql);
         assertContains(sqlPlan, "0:HdfsScanNode\n" +
                 "     TABLE: customer");

--- a/fe/fe-core/src/test/java/com/starrocks/connector/hive/MockedHiveMetadata.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/hive/MockedHiveMetadata.java
@@ -347,6 +347,13 @@ public class MockedHiveMetadata implements ConnectorMetadata {
                                   "(select * from tpch.customer)", "VIRTUAL_VIEW");
         HiveView view3 = HiveMetastoreApiConverter.toHiveView(hmsView3, MOCKED_HIVE_CATALOG_NAME);
         mockTables.put(hmsView3.getTableName(), new HiveTableInfo(view3));
+        // mock trino view which do not have db name
+        Table hmsView4 =
+                new Table("customer_view_without_db", "tpch", null, 0, 0, 0, sd, Lists.newArrayList(), Maps.newHashMap(), null,
+                        "select c_custkey,c_name, c_address, c_nationkey, c_phone, c_mktsegment, c_comment from customer",
+                        "VIRTUAL_VIEW");
+        HiveView view4 = HiveMetastoreApiConverter.toHiveView(hmsView4, MOCKED_HIVE_CATALOG_NAME);
+        mockTables.put(hmsView4.getTableName(), new HiveTableInfo(view4));
     }
 
     private static void mockSubfieldTable() {

--- a/fe/fe-core/src/test/java/com/starrocks/connector/trino/TrinoViewTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/trino/TrinoViewTest.java
@@ -68,6 +68,9 @@ public class TrinoViewTest {
             {
                 table.getViewOriginalText();
                 result = viewOriginalText;
+
+                table.getDbName();
+                result = "testDb";
             }
         };
 
@@ -106,6 +109,9 @@ public class TrinoViewTest {
             {
                 table.getViewOriginalText();
                 result = viewOriginalText;
+
+                table.getDbName();
+                result = "testDb";
             }
         };
 

--- a/fe/fe-core/src/test/java/com/starrocks/statistic/StatisticsCollectJobTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/statistic/StatisticsCollectJobTest.java
@@ -563,7 +563,7 @@ public class StatisticsCollectJobTest extends PlanTestNoneDBBase {
                         Maps.newHashMap(),
                         StatsConstants.ScheduleStatus.PENDING,
                         LocalDateTime.MIN));
-        Assert.assertEquals(27, jobs.size());
+        Assert.assertEquals(28, jobs.size());
     }
 
     @Test


### PR DESCRIPTION
Why I'm doing:
trino view could create like this 
```
create view v1 as 
select col1, col2 from t1
```
t1 do not contains db name, this will led to query failed because of  miss db name
What I'm doing:
set view v1 db name as table t1 default db name

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [x] 3.1
  - [ ] 3.0
  - [ ] 2.5
