### PR TITLE
[Refactor] improve be ut & fix warn compile

### DIFF
--- a/be/src/storage/primary_key_dump.cpp
+++ b/be/src/storage/primary_key_dump.cpp
@@ -151,8 +151,7 @@ Status PrimaryKeyDump::_dump_dcg() {
 
 class PrimaryKeyChunkDumper {
 public:
-    PrimaryKeyChunkDumper(PrimaryKeyDump* dump, PrimaryKeyColumnPB* pk_column_pb)
-            : _dump(dump), _pk_column_pb(pk_column_pb) {}
+    PrimaryKeyChunkDumper(PrimaryKeyColumnPB* pk_column_pb) : _pk_column_pb(pk_column_pb) {}
     ~PrimaryKeyChunkDumper() { (void)fs::delete_file(_tmp_file); }
     Status init(const TabletSchemaCSPtr& tablet_schema, const std::string& tablet_path) {
         _tmp_file = tablet_path + "/PrimaryKeyChunkDumper_" + std::to_string(static_cast<int64_t>(pthread_self()));
@@ -180,7 +179,6 @@ public:
     }
 
 private:
-    PrimaryKeyDump* _dump;
     PrimaryKeyColumnPB* _pk_column_pb;
     std::unique_ptr<SegmentWriter> _writer;
     PagePointerPB _page;
@@ -258,7 +256,7 @@ Status PrimaryKeyDump::_dump_segment_keys() {
             }
             PrimaryKeyColumnPB pk_column_pb;
             pk_column_pb.set_segment_id(rowset.second->rowset_meta()->get_rowset_seg_id() + i);
-            PrimaryKeyChunkDumper dumper(this, &pk_column_pb);
+            PrimaryKeyChunkDumper dumper(&pk_column_pb);
             RETURN_IF_ERROR(dumper.init(pkey_tschema, _tablet->schema_hash_path()));
             while (true) {
                 chunk->reset();

--- a/be/test/storage/persistent_index_test.cpp
+++ b/be/test/storage/persistent_index_test.cpp
@@ -1936,7 +1936,7 @@ TEST_P(PersistentIndexTest, test_bloom_filter_for_pindex) {
 }
 
 TEST_P(PersistentIndexTest, test_multi_l2_tmp_l1) {
-    config::l0_max_mem_usage = 1024;
+    config::l0_max_mem_usage = 50;
     config::max_tmp_l1_num = 10;
     FileSystem* fs = FileSystem::Default();
     const std::string kPersistentIndexDir = "./PersistentIndexTest_test_multi_l2_tmp_l1";
@@ -1946,8 +1946,8 @@ TEST_P(PersistentIndexTest, test_multi_l2_tmp_l1) {
 
     using Key = std::string;
     PersistentIndexMetaPB index_meta;
-    const int N = 1000000;
-    const int wal_n = 200000;
+    const int N = 1000;
+    const int wal_n = 200;
     int64_t cur_version = 0;
     // insert
     vector<Key> keys(N);
@@ -2266,7 +2266,7 @@ TEST_P(PersistentIndexTest, test_multi_l2_not_tmp_l1_fixlen) {
 }
 
 TEST_P(PersistentIndexTest, test_multi_l2_delete) {
-    config::l0_max_mem_usage = 1024;
+    config::l0_max_mem_usage = 50;
     config::max_tmp_l1_num = 10;
     FileSystem* fs = FileSystem::Default();
     const std::string kPersistentIndexDir = "./PersistentIndexTest_test_multi_l2_delete";
@@ -2276,8 +2276,8 @@ TEST_P(PersistentIndexTest, test_multi_l2_delete) {
 
     using Key = std::string;
     PersistentIndexMetaPB index_meta;
-    const int N = 1000000;
-    const int DEL_N = 900000;
+    const int N = 1000;
+    const int DEL_N = 900;
     int64_t cur_version = 0;
     // insert
     vector<Key> keys(N);


### PR DESCRIPTION
Why I'm doing:
1. improve two be ut that will cost too much time.
2. fix compile warn:
```
[ 99%] Built target Exprs
/root/starrocks/be/src/storage/primary_key_dump.cpp:183:21: warning: private field '_dump' is not used [-Wunused-private-field]
    PrimaryKeyDump* _dump;
                    ^
1 warning generated.
```

What I'm doing:


## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [x] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [x] 3.1
  - [ ] 3.0
  - [ ] 2.5
