### PR TITLE
[Enhancement] Optimize compaction resource usage for cloud native primary table

### DIFF
--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -935,6 +935,7 @@ CONF_mInt64(lake_vacuum_retry_max_attempts, "5");
 CONF_mInt64(lake_vacuum_retry_min_delay_ms, "10");
 CONF_mBool(enable_primary_key_recover, "false");
 CONF_mBool(lake_enable_compaction_async_write, "false");
+CONF_mInt64(lake_pk_compaction_merge_rowset_delta, "5");
 
 CONF_mBool(dependency_librdkafka_debug_enable, "false");
 

--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -935,7 +935,7 @@ CONF_mInt64(lake_vacuum_retry_max_attempts, "5");
 CONF_mInt64(lake_vacuum_retry_min_delay_ms, "10");
 CONF_mBool(enable_primary_key_recover, "false");
 CONF_mBool(lake_enable_compaction_async_write, "false");
-CONF_mInt64(lake_pk_compaction_merge_rowset_delta, "5");
+CONF_mInt64(lake_pk_compaction_max_input_rowsets, "5");
 
 CONF_mBool(dependency_librdkafka_debug_enable, "false");
 

--- a/be/src/storage/lake/compaction_policy.cpp
+++ b/be/src/storage/lake/compaction_policy.cpp
@@ -187,10 +187,10 @@ StatusOr<std::vector<RowsetPtr>> PrimaryCompactionPolicy::pick_rowsets(
             std::max(config::update_compaction_result_bytes, compaction_data_size_threshold)) {
             break;
         }
-        // If calc_score is true, we skip `config::lake_pk_compaction_merge_rowset_delta` check,
-        // because `config::lake_pk_compaction_merge_rowset_delta` is only used to limit the number
+        // If calc_score is true, we skip `config::lake_pk_compaction_max_input_rowsets` check,
+        // because `config::lake_pk_compaction_max_input_rowsets` is only used to limit the number
         // of rowsets for real compaction merges
-        if (!calc_score && input_rowsets.size() >= config::lake_pk_compaction_merge_rowset_delta) {
+        if (!calc_score && input_rowsets.size() >= config::lake_pk_compaction_max_input_rowsets) {
             break;
         }
         rowset_queue.pop();

--- a/be/src/storage/lake/compaction_policy.cpp
+++ b/be/src/storage/lake/compaction_policy.cpp
@@ -133,7 +133,7 @@ public:
 
     StatusOr<std::vector<RowsetPtr>> pick_rowsets() override;
     StatusOr<std::vector<RowsetPtr>> pick_rowsets(const std::shared_ptr<const TabletMetadataPB>& tablet_metadata,
-                                                  std::vector<bool>* has_dels);
+                                                  bool calc_score, std::vector<bool>* has_dels);
 
 private:
     int64_t _get_data_size(const std::shared_ptr<const TabletMetadataPB>& tablet_metadata) {
@@ -146,11 +146,11 @@ private:
 };
 
 StatusOr<std::vector<RowsetPtr>> PrimaryCompactionPolicy::pick_rowsets() {
-    return pick_rowsets(_tablet_metadata, nullptr);
+    return pick_rowsets(_tablet_metadata, false, nullptr);
 }
 
 StatusOr<std::vector<RowsetPtr>> PrimaryCompactionPolicy::pick_rowsets(
-        const std::shared_ptr<const TabletMetadataPB>& tablet_metadata, std::vector<bool>* has_dels) {
+        const std::shared_ptr<const TabletMetadataPB>& tablet_metadata, bool calc_score, std::vector<bool>* has_dels) {
     std::vector<RowsetPtr> input_rowsets;
     UpdateManager* mgr = _tablet_mgr->update_mgr();
     std::priority_queue<RowsetCandidate> rowset_queue;
@@ -184,8 +184,13 @@ StatusOr<std::vector<RowsetPtr>> PrimaryCompactionPolicy::pick_rowsets(
         input_infos << input_rowsets.back()->id() << "|";
 
         if (cur_compaction_result_bytes >
-                    std::max(config::update_compaction_result_bytes, compaction_data_size_threshold) ||
-            input_rowsets.size() >= config::max_update_compaction_num_singleton_deltas) {
+            std::max(config::update_compaction_result_bytes, compaction_data_size_threshold)) {
+            break;
+        }
+        // If calc_score is true, we skip `config::lake_pk_compaction_merge_rowset_delta` check,
+        // because `config::lake_pk_compaction_merge_rowset_delta` is only used to limit the number
+        // of rowsets for real compaction merges
+        if (!calc_score && input_rowsets.size() >= config::lake_pk_compaction_merge_rowset_delta) {
             break;
         }
         rowset_queue.pop();
@@ -200,7 +205,7 @@ StatusOr<uint32_t> primary_compaction_score_by_policy(TabletManager* tablet_mgr,
                                                       const std::shared_ptr<const TabletMetadataPB>& metadata) {
     PrimaryCompactionPolicy policy(tablet_mgr, metadata);
     std::vector<bool> has_dels;
-    ASSIGN_OR_RETURN(auto pick_rowsets, policy.pick_rowsets(metadata, &has_dels));
+    ASSIGN_OR_RETURN(auto pick_rowsets, policy.pick_rowsets(metadata, true, &has_dels));
     uint32_t segment_num_score = 0;
     for (int i = 0; i < pick_rowsets.size(); i++) {
         const auto& pick_rowset = pick_rowsets[i];

--- a/be/test/storage/lake/primary_key_compaction_task_test.cpp
+++ b/be/test/storage/lake/primary_key_compaction_task_test.cpp
@@ -418,15 +418,15 @@ TEST_P(LakePrimaryKeyCompactionTest, test_compaction_policy) {
     ASSERT_EQ(kChunkSize * 3, read(version));
     ASSIGN_OR_ABORT(auto tablet_metadata, _tablet_mgr->get_tablet_metadata(tablet_id, version));
     ASSIGN_OR_ABORT(auto compaction_policy, CompactionPolicy::create(_tablet_mgr.get(), tablet_metadata));
-    config::lake_pk_compaction_merge_rowset_delta = 1000;
+    config::lake_pk_compaction_max_input_rowsets = 1000;
     ASSIGN_OR_ABORT(auto input_rowsets, compaction_policy->pick_rowsets());
     EXPECT_EQ(3, input_rowsets.size());
 
-    config::lake_pk_compaction_merge_rowset_delta = 2;
+    config::lake_pk_compaction_max_input_rowsets = 2;
     ASSIGN_OR_ABORT(auto input_rowsets2, compaction_policy->pick_rowsets());
     EXPECT_EQ(2, input_rowsets2.size());
 
-    config::lake_pk_compaction_merge_rowset_delta = 1;
+    config::lake_pk_compaction_max_input_rowsets = 1;
     ASSIGN_OR_ABORT(auto input_rowsets3, compaction_policy->pick_rowsets());
     EXPECT_EQ(1, input_rowsets3.size());
 }
@@ -484,7 +484,7 @@ TEST_P(LakePrimaryKeyCompactionTest, test_compaction_policy2) {
     }
     ASSERT_EQ(kChunkSize * 6, read(version));
 
-    config::lake_pk_compaction_merge_rowset_delta = 4;
+    config::lake_pk_compaction_max_input_rowsets = 4;
     ASSIGN_OR_ABORT(auto tablet_metadata, _tablet_mgr->get_tablet_metadata(tablet_id, version));
     ASSIGN_OR_ABORT(auto compaction_policy, CompactionPolicy::create(_tablet_mgr.get(), tablet_metadata));
     ASSIGN_OR_ABORT(auto input_rowsets, compaction_policy->pick_rowsets());
@@ -559,7 +559,7 @@ TEST_P(LakePrimaryKeyCompactionTest, test_compaction_policy3) {
     config::write_buffer_size = old_size;
     ASSERT_EQ(kChunkSize * 6, read(version));
 
-    config::lake_pk_compaction_merge_rowset_delta = 4;
+    config::lake_pk_compaction_max_input_rowsets = 4;
     ASSIGN_OR_ABORT(auto tablet_metadata, _tablet_mgr->get_tablet_metadata(tablet_id, version));
     ASSIGN_OR_ABORT(auto compaction_policy, CompactionPolicy::create(_tablet_mgr.get(), tablet_metadata));
     ASSIGN_OR_ABORT(auto input_rowsets, compaction_policy->pick_rowsets());
@@ -612,21 +612,21 @@ TEST_P(LakePrimaryKeyCompactionTest, test_compaction_score_by_policy) {
     ASSIGN_OR_ABORT(auto tablet_meta, _tablet_mgr->get_tablet_metadata(tablet_id, version));
 
     ASSIGN_OR_ABORT(auto compaction_policy, CompactionPolicy::create(_tablet_mgr.get(), tablet_meta));
-    config::lake_pk_compaction_merge_rowset_delta = 1000;
+    config::lake_pk_compaction_max_input_rowsets = 1000;
     ASSIGN_OR_ABORT(auto input_rowsets, compaction_policy->pick_rowsets());
     EXPECT_EQ(3, input_rowsets.size());
     EXPECT_EQ(3, compaction_score(_tablet_mgr.get(), tablet_meta));
 
-    config::lake_pk_compaction_merge_rowset_delta = 2;
+    config::lake_pk_compaction_max_input_rowsets = 2;
     ASSIGN_OR_ABORT(auto input_rowsets2, compaction_policy->pick_rowsets());
     EXPECT_EQ(2, input_rowsets2.size());
-    EXPECT_EQ(2, compaction_score(_tablet_mgr.get(), tablet_meta));
+    EXPECT_EQ(3, compaction_score(_tablet_mgr.get(), tablet_meta));
 
-    config::lake_pk_compaction_merge_rowset_delta = 1;
+    config::lake_pk_compaction_max_input_rowsets = 1;
     ASSIGN_OR_ABORT(auto input_rowsets3, compaction_policy->pick_rowsets());
     EXPECT_EQ(1, input_rowsets3.size());
-    EXPECT_EQ(1, compaction_score(_tablet_mgr.get(), tablet_meta));
-    config::lake_pk_compaction_merge_rowset_delta = 1000;
+    EXPECT_EQ(3, compaction_score(_tablet_mgr.get(), tablet_meta));
+    config::lake_pk_compaction_max_input_rowsets = 1000;
 }
 
 TEST_P(LakePrimaryKeyCompactionTest, test_compaction_sorted) {

--- a/be/test/storage/lake/primary_key_compaction_task_test.cpp
+++ b/be/test/storage/lake/primary_key_compaction_task_test.cpp
@@ -418,15 +418,15 @@ TEST_P(LakePrimaryKeyCompactionTest, test_compaction_policy) {
     ASSERT_EQ(kChunkSize * 3, read(version));
     ASSIGN_OR_ABORT(auto tablet_metadata, _tablet_mgr->get_tablet_metadata(tablet_id, version));
     ASSIGN_OR_ABORT(auto compaction_policy, CompactionPolicy::create(_tablet_mgr.get(), tablet_metadata));
-    config::max_update_compaction_num_singleton_deltas = 1000;
+    config::lake_pk_compaction_merge_rowset_delta = 1000;
     ASSIGN_OR_ABORT(auto input_rowsets, compaction_policy->pick_rowsets());
     EXPECT_EQ(3, input_rowsets.size());
 
-    config::max_update_compaction_num_singleton_deltas = 2;
+    config::lake_pk_compaction_merge_rowset_delta = 2;
     ASSIGN_OR_ABORT(auto input_rowsets2, compaction_policy->pick_rowsets());
     EXPECT_EQ(2, input_rowsets2.size());
 
-    config::max_update_compaction_num_singleton_deltas = 1;
+    config::lake_pk_compaction_merge_rowset_delta = 1;
     ASSIGN_OR_ABORT(auto input_rowsets3, compaction_policy->pick_rowsets());
     EXPECT_EQ(1, input_rowsets3.size());
 }
@@ -484,7 +484,7 @@ TEST_P(LakePrimaryKeyCompactionTest, test_compaction_policy2) {
     }
     ASSERT_EQ(kChunkSize * 6, read(version));
 
-    config::max_update_compaction_num_singleton_deltas = 4;
+    config::lake_pk_compaction_merge_rowset_delta = 4;
     ASSIGN_OR_ABORT(auto tablet_metadata, _tablet_mgr->get_tablet_metadata(tablet_id, version));
     ASSIGN_OR_ABORT(auto compaction_policy, CompactionPolicy::create(_tablet_mgr.get(), tablet_metadata));
     ASSIGN_OR_ABORT(auto input_rowsets, compaction_policy->pick_rowsets());
@@ -559,7 +559,7 @@ TEST_P(LakePrimaryKeyCompactionTest, test_compaction_policy3) {
     config::write_buffer_size = old_size;
     ASSERT_EQ(kChunkSize * 6, read(version));
 
-    config::max_update_compaction_num_singleton_deltas = 4;
+    config::lake_pk_compaction_merge_rowset_delta = 4;
     ASSIGN_OR_ABORT(auto tablet_metadata, _tablet_mgr->get_tablet_metadata(tablet_id, version));
     ASSIGN_OR_ABORT(auto compaction_policy, CompactionPolicy::create(_tablet_mgr.get(), tablet_metadata));
     ASSIGN_OR_ABORT(auto input_rowsets, compaction_policy->pick_rowsets());
@@ -612,21 +612,21 @@ TEST_P(LakePrimaryKeyCompactionTest, test_compaction_score_by_policy) {
     ASSIGN_OR_ABORT(auto tablet_meta, _tablet_mgr->get_tablet_metadata(tablet_id, version));
 
     ASSIGN_OR_ABORT(auto compaction_policy, CompactionPolicy::create(_tablet_mgr.get(), tablet_meta));
-    config::max_update_compaction_num_singleton_deltas = 1000;
+    config::lake_pk_compaction_merge_rowset_delta = 1000;
     ASSIGN_OR_ABORT(auto input_rowsets, compaction_policy->pick_rowsets());
     EXPECT_EQ(3, input_rowsets.size());
     EXPECT_EQ(3, compaction_score(_tablet_mgr.get(), tablet_meta));
 
-    config::max_update_compaction_num_singleton_deltas = 2;
+    config::lake_pk_compaction_merge_rowset_delta = 2;
     ASSIGN_OR_ABORT(auto input_rowsets2, compaction_policy->pick_rowsets());
     EXPECT_EQ(2, input_rowsets2.size());
     EXPECT_EQ(2, compaction_score(_tablet_mgr.get(), tablet_meta));
 
-    config::max_update_compaction_num_singleton_deltas = 1;
+    config::lake_pk_compaction_merge_rowset_delta = 1;
     ASSIGN_OR_ABORT(auto input_rowsets3, compaction_policy->pick_rowsets());
     EXPECT_EQ(1, input_rowsets3.size());
     EXPECT_EQ(1, compaction_score(_tablet_mgr.get(), tablet_meta));
-    config::max_update_compaction_num_singleton_deltas = 1000;
+    config::lake_pk_compaction_merge_rowset_delta = 1000;
 }
 
 TEST_P(LakePrimaryKeyCompactionTest, test_compaction_sorted) {


### PR DESCRIPTION
Why I'm doing:
We need a way that it can:
1. limit the number of rowsets per compaction merge, thus reducing resource usage
2. does not affect the real compaction score calculation results

What I'm doing:
1. Add new BE config `lake_pk_compaction_merge_rowset_delta`, to limit the number of rowsets per compaction merge.
2. Make sure this config won't affect compaction score calculation.

Test result:

Continuously ingest 7GB of data into a tablet and observe the time consumed by compaction before and after optimization:
Before: 
```
mysql> show proc '/compactions';
+----------------------------------------+-------+---------------------+---------------------+---------------------+-------+
| Partition                              | TxnID | StartTime           | CommitTime          | FinishTime          | Error |
+----------------------------------------+-------+---------------------+---------------------+---------------------+-------+
| test_pri_load.tbl_pk_withvarchar.10076 | 13    | 2024-01-20 07:25:14 | 2024-01-20 07:25:25 | 2024-01-20 07:25:32 | NULL  |
| test_pri_load.tbl_pk_withvarchar.10076 | 23    | 2024-01-20 07:26:03 | 2024-01-20 07:26:30 | 2024-01-20 07:26:41 | NULL  |
| test_pri_load.tbl_pk_withvarchar.10076 | 33    | 2024-01-20 07:26:54 | 2024-01-20 07:27:46 | 2024-01-20 07:28:03 | NULL  |
| test_pri_load.tbl_pk_withvarchar.10076 | 43    | 2024-01-20 07:28:03 | 2024-01-20 07:29:16 | 2024-01-20 07:29:39 | NULL  |
| test_pri_load.tbl_pk_withvarchar.10076 | 58    | 2024-01-20 07:29:39 | 2024-01-20 07:31:23 | 2024-01-20 07:31:56 | NULL  |
| test_pri_load.tbl_pk_withvarchar.10076 | 74    | 2024-01-20 07:31:57 | 2024-01-20 07:34:05 | 2024-01-20 07:34:50 | NULL  |
| test_pri_load.tbl_pk_withvarchar.10076 | 93    | 2024-01-20 07:34:50 | 2024-01-20 07:37:49 | 2024-01-20 07:38:52 | NULL  |
| test_pri_load.tbl_pk_withvarchar.10076 | 114   | 2024-01-20 07:38:52 | 2024-01-20 07:42:21 | 2024-01-20 07:43:26 | NULL  |
+----------------------------------------+-------+---------------------+---------------------+---------------------+-------+
```
The longest compaction task cost `5min`.

After:
```
mysql> show proc '/compactions';
+----------------------------------------+-------+---------------------+---------------------+---------------------+-------+
| Partition                              | TxnID | StartTime           | CommitTime          | FinishTime          | Error |
+----------------------------------------+-------+---------------------+---------------------+---------------------+-------+ 
| test_pri_load.tbl_pk_withvarchar.10101 | 130   | 2024-01-20 07:46:26 | 2024-01-20 07:46:33 | 2024-01-20 07:46:37 | NULL  |
| test_pri_load.tbl_pk_withvarchar.10101 | 135   | 2024-01-20 07:46:45 | 2024-01-20 07:46:52 | 2024-01-20 07:46:57 | NULL  |
| test_pri_load.tbl_pk_withvarchar.10101 | 140   | 2024-01-20 07:47:06 | 2024-01-20 07:47:13 | 2024-01-20 07:47:19 | NULL  |
| test_pri_load.tbl_pk_withvarchar.10101 | 145   | 2024-01-20 07:47:27 | 2024-01-20 07:47:33 | 2024-01-20 07:47:42 | NULL  |
| test_pri_load.tbl_pk_withvarchar.10101 | 150   | 2024-01-20 07:47:51 | 2024-01-20 07:47:58 | 2024-01-20 07:48:05 | NULL  |
...
| test_pri_load.tbl_pk_withvarchar.10101 | 204   | 2024-01-20 07:54:28 | 2024-01-20 07:54:35 | 2024-01-20 07:54:58 | NULL  |
| test_pri_load.tbl_pk_withvarchar.10101 | 209   | 2024-01-20 07:55:09 | 2024-01-20 07:55:24 | 2024-01-20 07:56:05 | NULL  |
| test_pri_load.tbl_pk_withvarchar.10101 | 216   | 2024-01-20 07:56:18 | 2024-01-20 07:56:26 | 2024-01-20 07:56:52 | NULL  |
| test_pri_load.tbl_pk_withvarchar.10101 | 221   | 2024-01-20 07:57:05 | 2024-01-20 07:57:24 | 2024-01-20 07:58:07 | NULL  |
| test_pri_load.tbl_pk_withvarchar.10101 | 227   | 2024-01-20 07:58:20 | 2024-01-20 07:58:27 | 2024-01-20 07:58:56 | NULL  |
| test_pri_load.tbl_pk_withvarchar.10101 | 232   | 2024-01-20 07:59:09 | 2024-01-20 07:59:24 | 2024-01-20 08:00:18 | NULL  |
...
| test_pri_load.tbl_pk_withvarchar.10101 | 245   | 2024-01-20 08:01:50 | 2024-01-20 08:02:07 | 2024-01-20 08:02:42 | NULL  |
```
The longest compaction task cost `1min`.

This test result shows that new compaction policy can reduce 80% compaction resource usage.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [x] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [x] 3.1
  - [ ] 3.0
  - [ ] 2.5
