### PR TITLE
[Enhancement] Optimize UT for datacache to make it adapt to run in parallel.  (backport #39395)

### DIFF
--- a/be/test/io/cache_input_stream_test.cpp
+++ b/be/test/io/cache_input_stream_test.cpp
@@ -53,7 +53,7 @@ public:
     static void SetUpTestCase() {
         auto cache = BlockCache::instance();
         CacheOptions options;
-        options.mem_space_size = 100 * 1024 * 1024;
+        options.mem_space_size = 20 * 1024 * 1024;
         options.engine = "starcache";
         options.block_size = block_size;
         ASSERT_OK(cache->init(options));
@@ -90,7 +90,7 @@ public:
     static const int64_t block_size;
 };
 
-const int64_t CacheInputStreamTest::block_size = 1024 * 1024;
+const int64_t CacheInputStreamTest::block_size = 256 * 1024;
 
 TEST_F(CacheInputStreamTest, test_aligned_read) {
     const int64_t block_count = 3;


### PR DESCRIPTION
Why I'm doing:
The old unittest for datacache depend on the `ut_dir` directory, read cache files from it. However when testcases running in parallel, the `ut_dir` may be removed by other cases, which cause the test cases which still using it failed.

What I'm doing:
Create a unique directory for datacache in each testcase, and remove it when the case finished. 
Also, we reduce the memory and disk space required for its execution.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [x] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5

