### PR TITLE
[Enhancement] use jdbc connection pool in jdbc metadata

### DIFF
--- a/docs/en/administration/FE_configuration.md
+++ b/docs/en/administration/FE_configuration.md
@@ -1456,3 +1456,21 @@ DO NOT change run_mode after the cluster is deployed. Otherwise, the cluster fai
 
 - **Default:** TRUE
 - **Description:** Specifies whether to enable the feature that is used to periodically collect metrics. Valid values: `TRUE` and `FALSE`. `TRUE` specifies to enable this feature, and `FALSE` specifies to disable this feature.
+
+#### jdbc_connection_pool_size
+
+- **Default:** 8
+- **Description:** The maximum capacity of the JDBC Connection Pool when accessing the JDBC Catalog.
+
+
+#### jdbc_minimum_idle_connections
+
+- **Default:** 1
+- **Description:** The minimum number of idle connections in the JDBC Connection Pool when accessing the JDBC Catalog.
+
+
+#### jdbc_connection_idle_timeout_ms
+
+- **Default:** 600000
+- **Description:** When accessing the JDBC Catalog, connections exceeding this time are considered idle. Unit: Millisecond.
+

--- a/docs/zh/administration/FE_configuration.md
+++ b/docs/zh/administration/FE_configuration.md
@@ -1004,7 +1004,7 @@ Compaction Score 代表了一个表分区是否值得进行 Compaction 的评分
 - 含义：FE 节点上 MySQL 服务器的端口。
 - 默认值：9030
 
-#### mysql_service_nio_enabled  
+#### mysql_service_nio_enabled
 
 - 含义：是否开启 MySQL 服务器的异步 I/O 选项。
 - 默认值：TRUE
@@ -1099,7 +1099,7 @@ Compaction Score 代表了一个表分区是否值得进行 Compaction 的评分
 - 含义：允许回滚的最大事务数。
 - 默认值：100
 
-#### bdbje_replica_ack_timeout_second  
+#### bdbje_replica_ack_timeout_second
 
 - 含义：FE 所在 StarRocks 集群中，元数据从 Leader FE 写入到多个 Follower FE 时，Leader FE 等待足够多的 Follower FE 发送 ACK 消息的超时时间。当写入的元数据较多时，可能返回 ACK 的时间较长，进而导致等待超时。如果超时，会导致写元数据失败，FE 进程退出，此时可以适当地调大该参数取值。
 - 单位：秒
@@ -1144,7 +1144,7 @@ Compaction Score 代表了一个表分区是否值得进行 Compaction 的评分
 
 - 含义：导入作业的轮询间隔。
 - 单位：秒。
-- 默认值：5  
+- 默认值：5
 
 #### transaction_clean_interval_second
 
@@ -1241,7 +1241,7 @@ Compaction Score 代表了一个表分区是否值得进行 Compaction 的评分
 
 #### aws_s3_region
 
-- 含义：需访问的 S3 存储空间的地区，如 `us-west-2`。  
+- 含义：需访问的 S3 存储空间的地区，如 `us-west-2`。
 
 #### aws_s3_endpoint
 
@@ -1360,3 +1360,19 @@ Compaction Score 代表了一个表分区是否值得进行 Compaction 的评分
 
 - 含义：是否开启定期收集指标 (Metrics) 的功能。取值范围：`TRUE` 和 `FALSE`。`TRUE` 表示开该功能。`FALSE`表示关闭该功能。
 - 默认值：TRUE
+
+#### jdbc_connection_pool_size
+
+- 含义：访问JDBC Catalog, JDBC Connection Pool容量上限
+- 默认值：8
+
+#### jdbc_minimum_idle_connections
+
+- 含义：访问JDBC Catalog, JDBC Connection Pool中处于idle状态的最低数量
+- 默认值：1
+
+#### jdbc_connection_idle_timeout_ms
+
+- 含义：访问JDBC Catalog, 超过这个时间的连接被认为是idle状态
+- 单位：毫秒
+- 默认值：600000

--- a/fe/fe-core/pom.xml
+++ b/fe/fe-core/pom.xml
@@ -867,6 +867,12 @@ under the License.
             <version>0.7.2</version>
             <scope>test</scope>
         </dependency>
+
+        <dependency>
+            <groupId>com.zaxxer</groupId>
+            <artifactId>HikariCP</artifactId>
+            <version>${hikaricp.version}</version>
+        </dependency>
     </dependencies>
 
     <build>

--- a/fe/fe-core/src/main/java/com/starrocks/common/Config.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/Config.java
@@ -2790,4 +2790,14 @@ public class Config extends ConfigBase {
     // limit for the number of host disconnections in the last {black_host_history_sec} seconds
     @ConfField(mutable = true)
     public static long black_host_connect_failures_within_time = 5;
+
+
+    @ConfField(mutable = false)
+    public static int jdbc_connection_pool_size = 8;
+
+    @ConfField(mutable = false)
+    public static int jdbc_minimum_idle_connections = 1;
+
+    @ConfField(mutable = false)
+    public static int jdbc_connection_idle_timeout_ms = 600000;
 }

--- a/fe/fe-core/src/main/java/com/starrocks/connector/jdbc/JDBCMetadata.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/jdbc/JDBCMetadata.java
@@ -37,7 +37,6 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
 import java.sql.Connection;
-import java.sql.DriverManager;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.util.List;

--- a/fe/fe-core/src/main/java/com/starrocks/connector/jdbc/JDBCMetadata.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/jdbc/JDBCMetadata.java
@@ -60,6 +60,11 @@ public class JDBCMetadata implements ConnectorMetadata {
     private HikariDataSource dataSource;
 
     public JDBCMetadata(Map<String, String> properties, String catalogName) {
+        this(properties, catalogName, null);
+    }
+
+
+    public JDBCMetadata(Map<String, String> properties, String catalogName, HikariDataSource dataSource) {
         this.properties = properties;
         this.catalogName = catalogName;
         try {
@@ -76,6 +81,10 @@ public class JDBCMetadata implements ConnectorMetadata {
             LOG.warn("{} not support yet", properties.get(JDBCResource.DRIVER_CLASS));
             throw new StarRocksConnectorException(properties.get(JDBCResource.DRIVER_CLASS) + " not support yet");
         }
+        if (dataSource == null) {
+            dataSource = createHikariDataSource();
+        }
+        this.dataSource = dataSource;
         checkAndSetSupportPartitionInformation();
         createMetaAsyncCacheInstances(properties);
     }
@@ -96,7 +105,7 @@ public class JDBCMetadata implements ConnectorMetadata {
         }
     }
 
-    private void configHikariDataSource() {
+    private HikariDataSource createHikariDataSource() {
         HikariConfig config = new HikariConfig();
         config.setJdbcUrl(properties.get(JDBCResource.URI));
         config.setUsername(properties.get(JDBCResource.USER));
@@ -105,7 +114,7 @@ public class JDBCMetadata implements ConnectorMetadata {
         config.setMaximumPoolSize(Config.jdbc_connection_pool_size);
         config.setMinimumIdle(Config.jdbc_minimum_idle_connections);
         config.setIdleTimeout(Config.jdbc_connection_idle_timeout_ms);
-        dataSource = new HikariDataSource(config);
+        return new HikariDataSource(config);
     }
 
     public Connection getConnection() throws SQLException {

--- a/fe/fe-core/src/test/java/com/starrocks/connector/jdbc/JDBCMetaCacheTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/jdbc/JDBCMetaCacheTest.java
@@ -14,7 +14,6 @@
 
 package com.starrocks.connector.jdbc;
 
-
 import com.google.common.collect.Lists;
 import com.mockrunner.mock.jdbc.MockResultSet;
 import com.starrocks.catalog.Database;
@@ -34,7 +33,6 @@ import org.junit.Test;
 import org.junit.rules.ExpectedException;
 
 import java.sql.Connection;
-import java.sql.DriverManager;
 import java.sql.SQLException;
 import java.sql.Types;
 import java.util.Arrays;
@@ -110,7 +108,7 @@ public class JDBCMetaCacheTest {
                 minTimes = 0;
 
                 connection.getMetaData().getTables("test", null, null,
-                        new String[] { "TABLE", "VIEW" });
+                        new String[] {"TABLE", "VIEW"});
                 result = tableResult;
                 minTimes = 0;
 

--- a/fe/fe-core/src/test/java/com/starrocks/connector/jdbc/JDBCMetaCacheTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/jdbc/JDBCMetaCacheTest.java
@@ -23,6 +23,7 @@ import com.starrocks.catalog.JDBCTable;
 import com.starrocks.catalog.Table;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.utframe.UtFrameUtils;
+import com.zaxxer.hikari.HikariDataSource;
 import mockit.Expectations;
 import mockit.Mocked;
 import org.junit.Assert;
@@ -51,7 +52,7 @@ public class JDBCMetaCacheTest {
     public ExpectedException expectedEx = ExpectedException.none();
 
     @Mocked
-    DriverManager driverManager;
+    HikariDataSource dataSource;
 
     @Mocked
     Connection connection;
@@ -100,7 +101,7 @@ public class JDBCMetaCacheTest {
 
         new Expectations() {
             {
-                driverManager.getConnection(anyString, anyString, anyString);
+                dataSource.getConnection();
                 result = connection;
                 minTimes = 0;
 
@@ -131,7 +132,7 @@ public class JDBCMetaCacheTest {
     @Test
     public void testListDatabaseNames() {
         try {
-            JDBCMetadata jdbcMetadata = new JDBCMetadata(properties, "catalog");
+            JDBCMetadata jdbcMetadata = new JDBCMetadata(properties, "catalog", dataSource);
             dbResult.beforeFirst();
             List<String> result = jdbcMetadata.listDbNames();
             List<String> expectResult = Lists.newArrayList("test");
@@ -144,7 +145,7 @@ public class JDBCMetaCacheTest {
     @Test
     public void testGetDb() {
         try {
-            JDBCMetadata jdbcMetadata = new JDBCMetadata(properties, "catalog");
+            JDBCMetadata jdbcMetadata = new JDBCMetadata(properties, "catalog", dataSource);
             dbResult.beforeFirst();
             Database db = jdbcMetadata.getDb("test");
             Assert.assertEquals("test", db.getOriginName());
@@ -156,7 +157,7 @@ public class JDBCMetaCacheTest {
     @Test
     public void testListTableNames() {
         try {
-            JDBCMetadata jdbcMetadata = new JDBCMetadata(properties, "catalog");
+            JDBCMetadata jdbcMetadata = new JDBCMetadata(properties, "catalog", dataSource);
             List<String> result = jdbcMetadata.listTableNames("test");
             List<String> expectResult = Lists.newArrayList("tbl1", "tbl2", "tbl3");
             Assert.assertEquals(expectResult, result);
@@ -168,7 +169,7 @@ public class JDBCMetaCacheTest {
     @Test
     public void testGetTable() {
         try {
-            JDBCMetadata jdbcMetadata = new JDBCMetadata(properties, "catalog");
+            JDBCMetadata jdbcMetadata = new JDBCMetadata(properties, "catalog", dataSource);
             Table table = jdbcMetadata.getTable("test", "tbl1");
             Assert.assertTrue(table instanceof JDBCTable);
             Table table2 = jdbcMetadata.getTable("test", "tbl1");

--- a/fe/fe-core/src/test/java/com/starrocks/connector/jdbc/JDBCMetadataTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/jdbc/JDBCMetadataTest.java
@@ -245,4 +245,15 @@ public class JDBCMetadataTest {
         }
     }
 
+    @Test
+    public void testCreateHikariDataSource() {
+        properties = new HashMap<>();
+        properties.put(DRIVER_CLASS, "com.mysql.cj.jdbc.Driver");
+        properties.put(JDBCResource.URI, "jdbc:mysql://127.0.0.1:3306");
+        properties.put(JDBCResource.USER, "root");
+        properties.put(JDBCResource.PASSWORD, "123456");
+        properties.put(JDBCResource.CHECK_SUM, "xxxx");
+        properties.put(JDBCResource.DRIVER_URL, "xxxx");
+        new JDBCMetadata(properties, "catalog");
+    }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/connector/jdbc/MysqlSchemaResolverTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/jdbc/MysqlSchemaResolverTest.java
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-
 package com.starrocks.connector.jdbc;
 
 import com.google.common.collect.Lists;
@@ -25,6 +24,7 @@ import com.starrocks.common.DdlException;
 import com.starrocks.connector.PartitionUtil;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.utframe.UtFrameUtils;
+import com.zaxxer.hikari.HikariDataSource;
 import mockit.Expectations;
 import mockit.Mocked;
 import org.junit.Assert;
@@ -35,7 +35,6 @@ import org.junit.Test;
 import org.junit.rules.ExpectedException;
 
 import java.sql.Connection;
-import java.sql.DriverManager;
 import java.sql.PreparedStatement;
 import java.sql.SQLException;
 import java.util.Arrays;
@@ -46,7 +45,6 @@ import java.util.concurrent.ConcurrentHashMap;
 
 import static com.starrocks.catalog.JDBCResource.DRIVER_CLASS;
 
-
 public class MysqlSchemaResolverTest {
 
     private static ConnectContext connectContext;
@@ -55,7 +53,7 @@ public class MysqlSchemaResolverTest {
     public ExpectedException expectedEx = ExpectedException.none();
 
     @Mocked
-    DriverManager driverManager;
+    HikariDataSource dataSource;
 
     @Mocked
     Connection connection;
@@ -96,7 +94,7 @@ public class MysqlSchemaResolverTest {
 
         new Expectations() {
             {
-                driverManager.getConnection(anyString, anyString, anyString);
+                dataSource.getConnection();
                 result = connection;
                 minTimes = 0;
 
@@ -150,7 +148,7 @@ public class MysqlSchemaResolverTest {
     @Test
     public void testListPartitionNames() {
         try {
-            JDBCMetadata jdbcMetadata = new JDBCMetadata(properties, "catalog");
+            JDBCMetadata jdbcMetadata = new JDBCMetadata(properties, "catalog", dataSource);
             List<String> partitionNames = jdbcMetadata.listPartitionNames("test", "tbl1");
             Assert.assertFalse(partitionNames.isEmpty());
         } catch (Exception e) {
@@ -163,7 +161,7 @@ public class MysqlSchemaResolverTest {
     public void testListPartitionNamesWithCache() {
         try {
             JDBCCacheTestUtil.openCacheEnable(connectContext);
-            JDBCMetadata jdbcMetadata = new JDBCMetadata(properties, "catalog");
+            JDBCMetadata jdbcMetadata = new JDBCMetadata(properties, "catalog", dataSource);
             List<String> partitionNames = jdbcMetadata.listPartitionNames("test", "tbl1");
             Assert.assertFalse(partitionNames.isEmpty());
             List<String> partitionNamesWithCache = jdbcMetadata.listPartitionNames("test", "tbl1");
@@ -189,7 +187,7 @@ public class MysqlSchemaResolverTest {
                     minTimes = 0;
                 }
             };
-            JDBCMetadata jdbcMetadata = new JDBCMetadata(properties, "catalog");
+            JDBCMetadata jdbcMetadata = new JDBCMetadata(properties, "catalog", dataSource);
             List<String> partitionNames = jdbcMetadata.listPartitionNames("test", "tbl1");
             Assert.assertTrue(partitionNames.size() == 0);
         } catch (Exception e) {
@@ -201,7 +199,7 @@ public class MysqlSchemaResolverTest {
     @Test
     public void testListPartitionColumns() {
         try {
-            JDBCMetadata jdbcMetadata = new JDBCMetadata(properties, "catalog");
+            JDBCMetadata jdbcMetadata = new JDBCMetadata(properties, "catalog", dataSource);
             Integer size = jdbcMetadata.listPartitionColumns("test", "tbl1",
                     Arrays.asList(new Column("d", Type.VARCHAR))).size();
             Assert.assertTrue(size > 0);
@@ -221,7 +219,7 @@ public class MysqlSchemaResolverTest {
                     minTimes = 0;
                 }
             };
-            JDBCMetadata jdbcMetadata = new JDBCMetadata(properties, "catalog");
+            JDBCMetadata jdbcMetadata = new JDBCMetadata(properties, "catalog", dataSource);
             Integer size = jdbcMetadata.listPartitionColumns("test", "tbl1",
                     Arrays.asList(new Column("d", Type.VARCHAR))).size();
             Assert.assertTrue(size == 0);
@@ -234,7 +232,7 @@ public class MysqlSchemaResolverTest {
     @Test
     public void testGetPartitions() {
         try {
-            JDBCMetadata jdbcMetadata = new JDBCMetadata(properties, "catalog");
+            JDBCMetadata jdbcMetadata = new JDBCMetadata(properties, "catalog", dataSource);
             JDBCTable jdbcTable = new JDBCTable(100000, "tbl1", Arrays.asList(new Column("d", Type.VARCHAR)),
                     Arrays.asList(new Column("d", Type.VARCHAR)), "test", "catalog", properties);
             Integer size = jdbcMetadata.getPartitions(jdbcTable, Arrays.asList("20230810")).size();
@@ -249,7 +247,7 @@ public class MysqlSchemaResolverTest {
     public void testGetPartitionsWithCache() {
         try {
             JDBCCacheTestUtil.openCacheEnable(connectContext);
-            JDBCMetadata jdbcMetadata = new JDBCMetadata(properties, "catalog");
+            JDBCMetadata jdbcMetadata = new JDBCMetadata(properties, "catalog", dataSource);
             JDBCTable jdbcTable = new JDBCTable(100000, "tbl1", Arrays.asList(new Column("d", Type.VARCHAR)),
                     Arrays.asList(new Column("d", Type.VARCHAR)), "test", "catalog", properties);
             int size = jdbcMetadata.getPartitions(jdbcTable, Arrays.asList("20230810")).size();
@@ -269,7 +267,7 @@ public class MysqlSchemaResolverTest {
 
     @Test
     public void testGetPartitions_NonPartitioned() throws DdlException {
-        JDBCMetadata jdbcMetadata = new JDBCMetadata(properties, "catalog");
+        JDBCMetadata jdbcMetadata = new JDBCMetadata(properties, "catalog", dataSource);
         List<Column> columns = Arrays.asList(new Column("d", Type.VARCHAR));
         JDBCTable jdbcTable = new JDBCTable(100000, "tbl1", columns, Lists.newArrayList(),
                 "test", "catalog", properties);
@@ -289,7 +287,7 @@ public class MysqlSchemaResolverTest {
                     minTimes = 0;
                 }
             };
-            JDBCMetadata jdbcMetadata = new JDBCMetadata(properties, "catalog");
+            JDBCMetadata jdbcMetadata = new JDBCMetadata(properties, "catalog", dataSource);
             JDBCTable jdbcTable = new JDBCTable(100000, "tbl1", Arrays.asList(new Column("d", Type.VARCHAR)),
                     Arrays.asList(new Column("d", Type.VARCHAR)), "test", "catalog", properties);
             Integer size = jdbcMetadata.getPartitions(jdbcTable, Arrays.asList("20230810")).size();
@@ -315,7 +313,7 @@ public class MysqlSchemaResolverTest {
                     minTimes = 0;
                 }
             };
-            JDBCMetadata jdbcMetadata = new JDBCMetadata(properties, "catalog");
+            JDBCMetadata jdbcMetadata = new JDBCMetadata(properties, "catalog", dataSource);
             List<Column> columns = Arrays.asList(new Column("d", Type.VARCHAR));
             JDBCTable jdbcTable = new JDBCTable(100000, "tbl1", columns, Lists.newArrayList(),
                     "test", "catalog", properties);

--- a/fe/fe-core/src/test/java/com/starrocks/connector/jdbc/PostgresSchemaResolverTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/jdbc/PostgresSchemaResolverTest.java
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-
 package com.starrocks.connector.jdbc;
 
 import com.google.common.collect.Lists;
@@ -22,6 +21,7 @@ import com.starrocks.catalog.Database;
 import com.starrocks.catalog.JDBCResource;
 import com.starrocks.catalog.JDBCTable;
 import com.starrocks.catalog.Table;
+import com.zaxxer.hikari.HikariDataSource;
 import mockit.Expectations;
 import mockit.Mocked;
 import org.junit.Assert;
@@ -29,7 +29,6 @@ import org.junit.Before;
 import org.junit.Test;
 
 import java.sql.Connection;
-import java.sql.DriverManager;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Types;
@@ -40,7 +39,7 @@ import java.util.Map;
 
 public class PostgresSchemaResolverTest {
     @Mocked
-    DriverManager driverManager;
+    HikariDataSource dataSource;
 
     @Mocked
     Connection connection;
@@ -78,7 +77,7 @@ public class PostgresSchemaResolverTest {
     public void testListDatabaseNames() throws SQLException {
         new Expectations() {
             {
-                driverManager.getConnection(anyString, anyString, anyString);
+                dataSource.getConnection();
                 result = connection;
                 minTimes = 0;
 
@@ -88,7 +87,7 @@ public class PostgresSchemaResolverTest {
             }
         };
         try {
-            JDBCMetadata jdbcMetadata = new JDBCMetadata(properties, "catalog");
+            JDBCMetadata jdbcMetadata = new JDBCMetadata(properties, "catalog", dataSource);
             List<String> result = jdbcMetadata.listDbNames();
             List<String> expectResult = Lists.newArrayList("postgres", "template1", "test");
             Assert.assertEquals(expectResult, result);
@@ -101,7 +100,7 @@ public class PostgresSchemaResolverTest {
     public void testGetDb() throws SQLException {
         new Expectations() {
             {
-                driverManager.getConnection(anyString, anyString, anyString);
+                dataSource.getConnection();
                 result = connection;
                 minTimes = 0;
 
@@ -111,7 +110,7 @@ public class PostgresSchemaResolverTest {
             }
         };
         try {
-            JDBCMetadata jdbcMetadata = new JDBCMetadata(properties, "catalog");
+            JDBCMetadata jdbcMetadata = new JDBCMetadata(properties, "catalog", dataSource);
             Database db = jdbcMetadata.getDb("test");
             Assert.assertEquals("test", db.getOriginName());
         } catch (Exception e) {
@@ -123,7 +122,7 @@ public class PostgresSchemaResolverTest {
     public void testListTableNames() throws SQLException {
         new Expectations() {
             {
-                driverManager.getConnection(anyString, anyString, anyString);
+                dataSource.getConnection();
                 result = connection;
                 minTimes = 0;
 
@@ -138,7 +137,7 @@ public class PostgresSchemaResolverTest {
             }
         };
         try {
-            JDBCMetadata jdbcMetadata = new JDBCMetadata(properties, "catalog");
+            JDBCMetadata jdbcMetadata = new JDBCMetadata(properties, "catalog", dataSource);
             List<String> result = jdbcMetadata.listTableNames("test");
             List<String> expectResult = Lists.newArrayList("tbl1", "tbl2", "tbl3");
             Assert.assertEquals(expectResult, result);
@@ -151,7 +150,7 @@ public class PostgresSchemaResolverTest {
     public void testGetTable() throws SQLException {
         new Expectations() {
             {
-                driverManager.getConnection(anyString, anyString, anyString);
+                dataSource.getConnection();
                 result = connection;
                 minTimes = 0;
 
@@ -165,7 +164,7 @@ public class PostgresSchemaResolverTest {
             }
         };
         try {
-            JDBCMetadata jdbcMetadata = new JDBCMetadata(properties, "catalog");
+            JDBCMetadata jdbcMetadata = new JDBCMetadata(properties, "catalog", dataSource);
             Table table = jdbcMetadata.getTable("test", "tbl1");
             Assert.assertTrue(table instanceof JDBCTable);
             Assert.assertEquals("catalog.test.tbl1", table.getUUID());

--- a/fe/pom.xml
+++ b/fe/pom.xml
@@ -58,6 +58,7 @@ under the License.
         <sonar.organization>starrocks</sonar.organization>
         <sonar.host.url>https://sonarcloud.io</sonar.host.url>
         <odps.version>0.45.5-public</odps.version>
+        <hikaricp.version>3.4.5</hikaricp.version>
     </properties>
 
     <profiles>


### PR DESCRIPTION
> Why I'm doing:

Everytime we do some operation, we will create/destory connection, which is wasterful.

> What I'm doing:

Use jdbc connection pool to avoid frequent create/destroy connection.

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [x] 3.1
  - [ ] 3.0
  - [ ] 2.5