### PR TITLE
[Enhancement] improve pk index major compaction strategy

### DIFF
--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -1060,7 +1060,7 @@ CONF_mInt64(max_allow_pindex_l2_num, "5");
 // Number of max major compaction threads
 CONF_mInt32(pindex_major_compaction_num_threads, "0");
 // Limit of major compaction per disk.
-CONF_mInt32(pindex_major_compaction_limit_per_disk, "2");
+CONF_mInt32(pindex_major_compaction_limit_per_disk, "1");
 // control the persistent index schedule compaction interval
 CONF_mInt64(pindex_major_compaction_schedule_interval_seconds, "15");
 // control the local persistent index in shared_data gc/evict interval

--- a/be/src/storage/persistent_index.cpp
+++ b/be/src/storage/persistent_index.cpp
@@ -4789,6 +4789,11 @@ Status PersistentIndex::major_compaction(Tablet* tablet) {
         _major_compaction_running.store(false);
         _cancel_major_compaction = false;
     });
+    // re-use config update_compaction_per_tablet_min_interval_seconds here to control pk index major compaction
+    if (UnixSeconds() - _latest_compaction_time <= config::update_compaction_per_tablet_min_interval_seconds) {
+        return Status::OK();
+    }
+    _latest_compaction_time = UnixSeconds();
     // merge all l2 files
     PersistentIndexMetaPB prev_index_meta;
     RETURN_IF_ERROR(

--- a/be/src/storage/persistent_index.h
+++ b/be/src/storage/persistent_index.h
@@ -911,6 +911,8 @@ private:
     std::atomic<bool> _major_compaction_running{false};
     // write amplification score, 0.0 means this index doesn't need major compaction
     std::atomic<double> _write_amp_score{0.0};
+    // Latest major compaction time. In second.
+    int64_t _latest_compaction_time = 0;
 };
 
 } // namespace starrocks


### PR DESCRIPTION
Why I'm doing:
Improve pk index major compaction strategy to reduce IO amplification.

What I'm doing:
1. Limit the major compaction frequency by config `update_compaction_per_tablet_min_interval_seconds`.
2. reduce config `pindex_major_compaction_limit_per_disk` to 1.

Test result:
Continue ingest into a `2.5G` tablet, and check the IO amplification caused by persistent index.
Before:
IO amplification : 23.9
After:
IO amplification : 8.19

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [x] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [x] 3.1
  - [x] 3.0
  - [x] 2.5
