### PR TITLE
[Enhancement] Add queuing latency in publish trace

### DIFF
--- a/be/src/service/service_be/lake_service.cpp
+++ b/be/src/service/service_be/lake_service.cpp
@@ -179,9 +179,11 @@ void LakeServiceImpl::publish_version(::google::protobuf::RpcController* control
             auto new_version = request->new_version();
             auto txns = std::span<const int64_t>(request->txn_ids().data(), request->txn_ids_size());
             auto commit_time = request->commit_time();
-            g_publish_tablet_version_queuing_latency << (run_ts - start_ts);
+            auto queuing_latency = run_ts - start_ts;
+            g_publish_tablet_version_queuing_latency << queuing_latency;
 
             TRACE_COUNTER_INCREMENT("tablet_id", tablet_id);
+            TRACE_COUNTER_INCREMENT("queuing_latency_us", queuing_latency);
 
             StatusOr<lake::TabletMetadataPtr> res;
             if (std::chrono::system_clock::now() < timeout_deadline) {


### PR DESCRIPTION
Why I'm doing:
It is hard to know the queuing latency in publish trace now.
What I'm doing:
Add queuing latency in publish trace
Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [x] 3.1
  - [ ] 3.0
  - [ ] 2.5
