### PR TITLE
[Enhancement] Add enable_experimental_rowstore config

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/common/Config.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/Config.java
@@ -2293,6 +2293,9 @@ public class Config extends ConfigBase {
     // ***********************************************************
 
     @ConfField(mutable = true)
+    public static boolean enable_experimental_rowstore = false;
+
+    @ConfField(mutable = true)
     public static boolean enable_experimental_mv = true;
 
     /**

--- a/fe/fe-core/src/main/java/com/starrocks/common/util/PropertyAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/util/PropertyAnalyzer.java
@@ -555,7 +555,11 @@ public class PropertyAnalyzer {
             } else {
                 throw new AnalysisException(storageType + " for " + olapTable.getKeysType() + " table not supported");
             }
-
+            if (!Config.enable_experimental_rowstore &&
+                    (tStorageType == TStorageType.ROW || tStorageType == TStorageType.COLUMN_WITH_ROW)) {
+                throw new AnalysisException(storageType + " for " + olapTable.getKeysType() +
+                        " table not supported, enable it by setting `enable_experimental_rowstore` to true");
+            }
             properties.remove(PROPERTIES_STORAGE_TYPE);
         }
         return tStorageType;

--- a/fe/fe-core/src/test/java/com/starrocks/alter/AlterTableTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/alter/AlterTableTest.java
@@ -48,6 +48,7 @@ public class AlterTableTest {
         Config.dynamic_partition_enable = true;
         Config.dynamic_partition_check_interval_seconds = 1;
         Config.enable_strict_storage_medium_check = false;
+        Config.enable_experimental_rowstore = true;
         UtFrameUtils.createMinStarRocksCluster();
         // create connect context
         connectContext = UtFrameUtils.createDefaultCtx();

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/ShowCreateViewStmtTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/ShowCreateViewStmtTest.java
@@ -56,6 +56,7 @@ public class ShowCreateViewStmtTest {
         Config.alter_scheduler_interval_millisecond = 100;
         Config.dynamic_partition_enable = true;
         Config.dynamic_partition_check_interval_seconds = 1;
+        Config.enable_experimental_rowstore = true;
         UtFrameUtils.createMinStarRocksCluster();
 
         // create connect context

--- a/fe/fe-core/src/test/java/com/starrocks/catalog/CreateTableTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/CreateTableTest.java
@@ -72,6 +72,7 @@ public class CreateTableTest {
         UtFrameUtils.addMockBackend(10004);
         Config.enable_strict_storage_medium_check = true;
         Config.enable_auto_tablet_distribution = true;
+        Config.enable_experimental_rowstore = true;
         // create connect context
         connectContext = UtFrameUtils.createDefaultCtx();
         starRocksAssert = new StarRocksAssert(connectContext);
@@ -1714,6 +1715,30 @@ public class CreateTableTest {
                 ");";
 
         ExceptionChecker.expectThrowsNoException(() -> starRocksAssert.withTable(sql1));
+    }
+
+    @Test
+    public void testColumnWithRowExperimental() {
+        Config.enable_experimental_rowstore = false;
+        try {
+            StarRocksAssert starRocksAssert = new StarRocksAssert(connectContext);
+            starRocksAssert.useDatabase("test");
+            String sql1 = "CREATE TABLE test.dwd_column_with_row_experimental_test (\n" +
+                    "ship_id int(11) NOT NULL COMMENT \" \",\n" +
+                    "sub_ship_id bigint(20) NOT NULL COMMENT \"\" ,\n" +
+                    "address_code bigint(20) NOT NULL COMMENT \" \"\n" +
+                    ") ENGINE=OLAP\n" +
+                    "PRIMARY KEY(ship_id, sub_ship_id) COMMENT \"OLAP\"\n" +
+                    "DISTRIBUTED BY HASH(ship_id, sub_ship_id) " +
+                    "PROPERTIES (\n" +
+                    "\"replication_num\" = \"1\",\n" +
+                    "\"storage_type\" = \"column_with_row\"" +
+                    ");";
+
+            ExceptionChecker.expectThrows(DdlException.class, () -> starRocksAssert.withTable(sql1));
+        } finally {
+            Config.enable_experimental_rowstore = true;
+        }
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/pseudocluster/PseudoClusterTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/pseudocluster/PseudoClusterTest.java
@@ -21,6 +21,7 @@ import com.staros.proto.FileStoreInfo;
 import com.staros.proto.FileStoreType;
 import com.staros.proto.S3FileStoreInfo;
 import com.starrocks.common.AnalysisException;
+import com.starrocks.common.Config;
 import com.starrocks.lake.StarOSAgent;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.server.RunMode;
@@ -69,6 +70,7 @@ public class PseudoClusterTest {
 
     @Test
     public void testCreateColumnWithRowTable() throws Exception {
+        Config.enable_experimental_rowstore = true;
         Connection connection = PseudoCluster.getInstance().getQueryConnection();
         Statement stmt = connection.createStatement();
         try {

--- a/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AnalyzeTestUtil.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AnalyzeTestUtil.java
@@ -14,6 +14,7 @@
 
 package com.starrocks.sql.analyzer;
 
+import com.starrocks.common.Config;
 import com.starrocks.common.ErrorReportException;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.sql.ast.QueryStatement;
@@ -30,6 +31,7 @@ public class AnalyzeTestUtil {
     private static String DB_NAME = "test";
 
     public static void init() throws Exception {
+        Config.enable_experimental_rowstore = true;
         // create connect context
         UtFrameUtils.createMinStarRocksCluster();
         connectContext = UtFrameUtils.createDefaultCtx();

--- a/test/sql/test_column_with_row/R/test_column_with_row
+++ b/test/sql/test_column_with_row/R/test_column_with_row
@@ -1,4 +1,8 @@
 -- name: test_columm_with_row
+ADMIN SET FRONTEND CONFIG ("enable_experimental_rowstore" = "true");
+-- result:
+[]
+-- !result
 CREATE DATABASE IF NOT EXISTS demo;
 -- result:
 []

--- a/test/sql/test_column_with_row/R/test_column_with_row_partial_update
+++ b/test/sql/test_column_with_row/R/test_column_with_row_partial_update
@@ -1,4 +1,8 @@
 -- name: test_column_with_row_partial_update
+ADMIN SET FRONTEND CONFIG ("enable_experimental_rowstore" = "true");
+-- result:
+[]
+-- !result
 create database test_column_with_row_partial_update;
 -- result:
 []

--- a/test/sql/test_column_with_row/R/test_column_with_row_variable
+++ b/test/sql/test_column_with_row/R/test_column_with_row_variable
@@ -1,4 +1,8 @@
 -- name: test_column_with_row_variable
+ADMIN SET FRONTEND CONFIG ("enable_experimental_rowstore" = "true");
+-- result:
+[]
+-- !result
 DROP TABLE IF EXISTS t1_var;
 -- result:
 []

--- a/test/sql/test_column_with_row/T/test_column_with_row
+++ b/test/sql/test_column_with_row/T/test_column_with_row
@@ -1,4 +1,5 @@
 -- name: test_columm_with_row
+ADMIN SET FRONTEND CONFIG ("enable_experimental_rowstore" = "true");
 --创建行存表
 CREATE TABLE IF NOT EXISTS t1(
     k1 int,

--- a/test/sql/test_column_with_row/T/test_column_with_row_partial_update
+++ b/test/sql/test_column_with_row/T/test_column_with_row_partial_update
@@ -1,4 +1,5 @@
 -- name: test_column_with_row_partial_update
+ADMIN SET FRONTEND CONFIG ("enable_experimental_rowstore" = "true");
 create database test_column_with_row_partial_update;
 use test_column_with_row_partial_update;
 

--- a/test/sql/test_column_with_row/T/test_column_with_row_variable
+++ b/test/sql/test_column_with_row/T/test_column_with_row_variable
@@ -1,4 +1,5 @@
 -- name: test_column_with_row_variable
+ADMIN SET FRONTEND CONFIG ("enable_experimental_rowstore" = "true");
 --创建行存表
 DROP TABLE IF EXISTS t1_var;
 CREATE TABLE IF NOT EXISTS t1_var(


### PR DESCRIPTION
Why I'm doing:

Row store feature is not feature complete yet, make it experimental. 

What I'm doing:

Add a config `enable_experimental_rowstore` and default false, user need to set it to true to use the feature, so their realize this is an experimental feature.


## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
