### PR TITLE
[BugFix] Fix wrong new version of publish version in replication transaction

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/replication/ReplicationJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/replication/ReplicationJob.java
@@ -778,8 +778,8 @@ public class ReplicationJob implements GsonPostProcessable {
         if (runningTasks.isEmpty() && finishedTasks.size() == taskNum) {
             return true;
         }
-        LOG.info("Replication job running tasks: {}, finished tasks: {}, transaction id: {}",
-                runningTasks.size(), finishedTasks.size(), transactionId);
+        LOG.info("Replication job state: {}, finished tasks: {}/{}, database id: {}, table id: {}, transaction id: {}",
+                state, finishedTasks.size(), taskNum, databaseId, tableId, transactionId);
         return false;
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/transaction/DatabaseTransactionMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/transaction/DatabaseTransactionMgr.java
@@ -66,6 +66,7 @@ import com.starrocks.metric.MetricRepo;
 import com.starrocks.persist.EditLog;
 import com.starrocks.persist.metablock.SRMetaBlockException;
 import com.starrocks.persist.metablock.SRMetaBlockWriter;
+import com.starrocks.replication.ReplicationTxnCommitAttachment;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.server.RunMode;
 import com.starrocks.sql.analyzer.FeNameFormat;
@@ -1131,7 +1132,13 @@ public class DatabaseTransactionMgr {
                             transactionState);
                     continue;
                 }
-                partitionCommitInfo.setVersion(partition.getNextVersion());
+                if (transactionState.getSourceType() == TransactionState.LoadJobSourceType.REPLICATION) {
+                    Map<Long, Long> partitionVersions = ((ReplicationTxnCommitAttachment) transactionState
+                            .getTxnCommitAttachment()).getPartitionVersions();
+                    partitionCommitInfo.setVersion(partitionVersions.get(partitionCommitInfo.getPartitionId()));
+                } else {
+                    partitionCommitInfo.setVersion(partition.getNextVersion());
+                }
                 partitionCommitInfo.setVersionTime(table.isCloudNativeTable() ? 0 : commitTs);
             }
         }

--- a/fe/fe-core/src/test/java/com/starrocks/replication/ReplicationJobTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/replication/ReplicationJobTest.java
@@ -61,6 +61,8 @@ public class ReplicationJobTest {
     private static Database db;
     private static OlapTable table;
     private static OlapTable srcTable;
+    private static Partition partition;
+    private static Partition srcPartition;
     private ReplicationJob job;
 
     @BeforeClass
@@ -79,8 +81,10 @@ public class ReplicationJobTest {
                 AnalyzeTestUtil.getConnectContext());
         StarRocksAssert.utCreateTableWithRetry(createTableStmt);
         table = (OlapTable) db.getTable("single_partition_duplicate_key");
-
         srcTable = DeepCopy.copyWithGson(table, OlapTable.class);
+
+        partition = table.getPartitions().iterator().next();
+        srcPartition = srcTable.getPartitions().iterator().next();
 
         new MockUp<AgentTaskExecutor>() {
             @Mock
@@ -92,10 +96,8 @@ public class ReplicationJobTest {
 
     @Before
     public void setUp() throws Exception {
-        Partition partition = table.getPartitions().iterator().next();
-        Partition srcPartition = srcTable.getPartitions().iterator().next();
         partition.updateVersionForRestore(10);
-        srcPartition.updateVersionForRestore(partition.getCommittedVersion() + 100);
+        srcPartition.updateVersionForRestore(100);
 
         job = new ReplicationJob(null, "test_token", db.getId(), table, srcTable,
                 GlobalStateMgr.getCurrentSystemInfo());
@@ -155,6 +157,8 @@ public class ReplicationJobTest {
 
         job.run();
         Assert.assertEquals(ReplicationJobState.COMMITTED, job.getState());
+
+        Assert.assertEquals(partition.getCommittedVersion(), srcPartition.getVisibleVersion());
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/replication/ReplicationMgrTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/replication/ReplicationMgrTest.java
@@ -61,6 +61,8 @@ public class ReplicationMgrTest {
     private static Database db;
     private static OlapTable table;
     private static OlapTable srcTable;
+    private static Partition partition;
+    private static Partition srcPartition;
     private ReplicationJob job;
     private ReplicationMgr replicationMgr;
 
@@ -81,8 +83,10 @@ public class ReplicationMgrTest {
         StarRocksAssert.utCreateTableWithRetry(createTableStmt);
 
         table = (OlapTable) db.getTable("single_partition_duplicate_key");
-
         srcTable = DeepCopy.copyWithGson(table, OlapTable.class);
+
+        partition = table.getPartitions().iterator().next();
+        srcPartition = srcTable.getPartitions().iterator().next();
 
         new MockUp<AgentTaskExecutor>() {
             @Mock
@@ -94,12 +98,11 @@ public class ReplicationMgrTest {
 
     @Before
     public void setUp() throws Exception {
-        Partition partition = table.getPartitions().iterator().next();
-        Partition srcPartition = srcTable.getPartitions().iterator().next();
         partition.updateVersionForRestore(10);
-        srcPartition.updateVersionForRestore(partition.getCommittedVersion() + 100);
+        srcPartition.updateVersionForRestore(100);
 
-        job = new ReplicationJob(null, "test_token", db.getId(), table, srcTable, GlobalStateMgr.getCurrentSystemInfo());
+        job = new ReplicationJob(null, "test_token", db.getId(), table, srcTable,
+                GlobalStateMgr.getCurrentSystemInfo());
         replicationMgr = new ReplicationMgr();
         replicationMgr.addReplicationJob(job);
     }
@@ -152,6 +155,8 @@ public class ReplicationMgrTest {
 
         replicationMgr.runAfterCatalogReady();
         Assert.assertEquals(ReplicationJobState.COMMITTED, job.getState());
+
+        Assert.assertEquals(partition.getCommittedVersion(), srcPartition.getVisibleVersion());
 
         replicationMgr.replayReplicationJob(job);
     }


### PR DESCRIPTION
Why I'm doing:
the new version of publish version in replication transaction is wrong after the refactor pr https://github.com/StarRocks/starrocks/pull/38932

What I'm doing:
fix wrong new version of publish version in replication transaction

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [x] 3.1
  - [ ] 3.0
  - [ ] 2.5
