### PR TITLE
[BugFix] Fix query trino view which not no contains db name failed (backport #39606)

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/HiveView.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/HiveView.java
@@ -24,6 +24,7 @@ import com.starrocks.sql.common.ErrorType;
 import com.starrocks.sql.common.StarRocksPlannerException;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.apache.parquet.Strings;
 
 import java.util.List;
 
@@ -38,15 +39,18 @@ public class HiveView extends Table {
     }
 
     private final String catalogName;
+    private final String dbName;
     private final String inlineViewDef;
     private final Type viewType;
 
     public static final String PRESTO_VIEW_PREFIX = "/* Presto View: ";
     public static final String PRESTO_VIEW_SUFFIX = " */";
 
-    public HiveView(long id, String catalogName, String name, List<Column> schema, String definition, Type type) {
+    public HiveView(long id, String catalogName, String dbName, String name, List<Column> schema, String definition,
+                    Type type) {
         super(id, name, TableType.HIVE_VIEW, schema);
         this.catalogName = requireNonNull(catalogName, "Hive view catalog name is null");
+        this.dbName = requireNonNull(dbName, "Hive view db name is null");
         this.inlineViewDef = requireNonNull(definition, "Hive view text is null");
         this.viewType = requireNonNull(type, "Hive view type is null");
     }
@@ -102,6 +106,9 @@ public class HiveView extends Table {
         List<TableRelation> tableRelations = AnalyzerUtils.collectTableRelations(queryStatement);
         for (TableRelation tableRelation : tableRelations) {
             tableRelation.getName().setCatalog(catalogName);
+            if (Strings.isNullOrEmpty(tableRelation.getName().getDb())) {
+                tableRelation.getName().setDb(dbName);
+            }
         }
         return queryStatement;
     }

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/HiveView.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/HiveView.java
@@ -14,7 +14,6 @@
 
 package com.starrocks.catalog;
 
-import com.google.common.base.Preconditions;
 import com.starrocks.analysis.ParseNode;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.qe.SessionVariable;
@@ -32,43 +31,74 @@ import static java.util.Objects.requireNonNull;
 
 public class HiveView extends Table {
     private static final Logger LOG = LogManager.getLogger(HiveView.class);
+
+    public enum Type {
+        Trino,
+        Hive
+    }
+
     private final String catalogName;
     private final String inlineViewDef;
+    private final Type viewType;
 
     public static final String PRESTO_VIEW_PREFIX = "/* Presto View: ";
     public static final String PRESTO_VIEW_SUFFIX = " */";
 
-    public HiveView(long id, String catalogName, String name, List<Column> schema, String definition) {
+    public HiveView(long id, String catalogName, String name, List<Column> schema, String definition, Type type) {
         super(id, name, TableType.HIVE_VIEW, schema);
         this.catalogName = requireNonNull(catalogName, "Hive view catalog name is null");
         this.inlineViewDef = requireNonNull(definition, "Hive view text is null");
+        this.viewType = requireNonNull(type, "Hive view type is null");
     }
 
-    public QueryStatement getQueryStatementWithSRParser() throws StarRocksPlannerException {
-        Preconditions.checkNotNull(inlineViewDef);
+    public QueryStatement getQueryStatementWithTrinoParser(SessionVariable sessionVariable)
+            throws StarRocksPlannerException {
+        sessionVariable.setSqlDialect("trino");
+        return getQueryStatementImpl(sessionVariable);
+    }
+
+    public QueryStatement getQueryStatementWithDefaultParser(SessionVariable sessionVariable)
+            throws StarRocksPlannerException {
+        return getQueryStatementImpl(sessionVariable);
+    }
+
+    private QueryStatement getQueryStatementImpl(SessionVariable sessionVariable) {
         ParseNode node;
-        SessionVariable sessionVariable = ConnectContext.get() != null ? ConnectContext.get().getSessionVariable()
-                : new SessionVariable();
         try {
             node = com.starrocks.sql.parser.SqlParser.parse(inlineViewDef, sessionVariable).get(0);
         } catch (Exception e) {
             LOG.warn("stmt is {}", inlineViewDef);
             LOG.warn("exception because: ", e);
-            throw new StarRocksPlannerException(
-                    String.format("Failed to parse view-definition statement of view: %s", name),
-                    ErrorType.INTERNAL_ERROR);
+            if (viewType == Type.Trino) {
+                // try to parse with starrocks sql dialect
+                sessionVariable.setSqlDialect("starrocks");
+                node = com.starrocks.sql.parser.SqlParser.parse(inlineViewDef, sessionVariable).get(0);
+            } else {
+                throw new StarRocksPlannerException(
+                        String.format("Failed to parse view-definition statement of view: %s", name),
+                        ErrorType.INTERNAL_ERROR);
+            }
         }
         // Make sure the view definition parses to a query statement.
         if (!(node instanceof QueryStatement)) {
             throw new StarRocksPlannerException(String.format("View definition of %s " +
                     "is not a query statement", name), ErrorType.INTERNAL_ERROR);
         }
-
         return (QueryStatement) node;
     }
 
     public QueryStatement getQueryStatement() throws StarRocksPlannerException {
-        QueryStatement queryStatement = getQueryStatementWithSRParser();
+        SessionVariable sessionVariable = ConnectContext.get() != null ? ConnectContext.get().getSessionVariable()
+                : new SessionVariable();
+        String sqlDialect = sessionVariable.getSqlDialect();
+        QueryStatement queryStatement;
+        if (viewType == Type.Trino) {
+            queryStatement = getQueryStatementWithTrinoParser(sessionVariable);
+        } else {
+            queryStatement = getQueryStatementWithDefaultParser(sessionVariable);
+        }
+        sessionVariable.setSqlDialect(sqlDialect);
+
         List<TableRelation> tableRelations = AnalyzerUtils.collectTableRelations(queryStatement);
         for (TableRelation tableRelation : tableRelations) {
             tableRelation.getName().setCatalog(catalogName);

--- a/fe/fe-core/src/main/java/com/starrocks/connector/hive/HiveMetastoreApiConverter.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/hive/HiveMetastoreApiConverter.java
@@ -144,14 +144,16 @@ public class HiveMetastoreApiConverter {
                     TrinoViewDefinition.class);
             hiveViewText = trinoViewDefinition.getOriginalSql();
             hiveView = new HiveView(ConnectorTableId.CONNECTOR_ID_GENERATOR.getNextId().asInt(), catalogName,
-                    table.getTableName(), toFullSchemasForTrinoView(table, trinoViewDefinition), hiveViewText);
+                    table.getTableName(), toFullSchemasForTrinoView(table, trinoViewDefinition), hiveViewText,
+                    HiveView.Type.Trino);
         } else {
             hiveView = new HiveView(ConnectorTableId.CONNECTOR_ID_GENERATOR.getNextId().asInt(), catalogName,
-                    table.getTableName(), toFullSchemasForHiveTable(table), table.getViewExpandedText());
+                    table.getTableName(), toFullSchemasForHiveTable(table), table.getViewExpandedText(),
+                    HiveView.Type.Hive);
         }
 
         try {
-            hiveView.getQueryStatementWithSRParser();
+            hiveView.getQueryStatement();
         } catch (StarRocksPlannerException e) {
             throw new StarRocksConnectorException("failed to parse hive view text", e);
         }

--- a/fe/fe-core/src/main/java/com/starrocks/connector/hive/HiveMetastoreApiConverter.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/hive/HiveMetastoreApiConverter.java
@@ -144,12 +144,12 @@ public class HiveMetastoreApiConverter {
                     TrinoViewDefinition.class);
             hiveViewText = trinoViewDefinition.getOriginalSql();
             hiveView = new HiveView(ConnectorTableId.CONNECTOR_ID_GENERATOR.getNextId().asInt(), catalogName,
-                    table.getTableName(), toFullSchemasForTrinoView(table, trinoViewDefinition), hiveViewText,
-                    HiveView.Type.Trino);
+                    table.getDbName(), table.getTableName(), toFullSchemasForTrinoView(table, trinoViewDefinition),
+                    hiveViewText, HiveView.Type.Trino);
         } else {
             hiveView = new HiveView(ConnectorTableId.CONNECTOR_ID_GENERATOR.getNextId().asInt(), catalogName,
-                    table.getTableName(), toFullSchemasForHiveTable(table), table.getViewExpandedText(),
-                    HiveView.Type.Hive);
+                    table.getDbName(), table.getTableName(), toFullSchemasForHiveTable(table),
+                    table.getViewExpandedText(), HiveView.Type.Hive);
         }
 
         try {

--- a/fe/fe-core/src/test/java/com/starrocks/connector/hive/HiveViewTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/hive/HiveViewTest.java
@@ -80,10 +80,10 @@ public class HiveViewTest extends PlanTestBase {
                  "    t1b,t1a\n" +
                  "from\n" +
                  "    test_all_type\n" +
-                 "    lateral view explode(split(t1a,',')) t1a");
+                 "    lateral view explode(split(t1a,',')) t1a", HiveView.Type.Hive);
         expectedException.expect(StarRocksPlannerException.class);
         expectedException.expectMessage("Failed to parse view-definition statement of view");
-        hiveView.getQueryStatementWithSRParser();
+        hiveView.getQueryStatement();
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/connector/hive/HiveViewTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/hive/HiveViewTest.java
@@ -76,7 +76,8 @@ public class HiveViewTest extends PlanTestBase {
 
     @Test
     public void testHiveViewParseFail() throws Exception {
-        HiveView hiveView = new HiveView(1, "hive0", "test", null, "select\n" +
+        HiveView hiveView = new HiveView(1, "hive0", "testDb", "test", null,
+                "select\n" +
                  "    t1b,t1a\n" +
                  "from\n" +
                  "    test_all_type\n" +
@@ -90,6 +91,15 @@ public class HiveViewTest extends PlanTestBase {
     public void testQueryHiveViewWithTrinoSQLDialect() throws Exception {
         String sql = "select * from hive0.tpch.customer_alias_view where c_custkey = 1";
         connectContext.getSessionVariable().setSqlDialect("trino");
+        String sqlPlan = getFragmentPlan(sql);
+        assertContains(sqlPlan, "0:HdfsScanNode\n" +
+                "     TABLE: customer");
+    }
+
+    @Test
+    public void testQueryTrinoViewWithoutDb() throws Exception {
+        // test query trino view without db
+        String sql = "select * from hive0.tpch.customer_view_without_db where c_custkey = 1";
         String sqlPlan = getFragmentPlan(sql);
         assertContains(sqlPlan, "0:HdfsScanNode\n" +
                 "     TABLE: customer");

--- a/fe/fe-core/src/test/java/com/starrocks/connector/hive/MockedHiveMetadata.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/hive/MockedHiveMetadata.java
@@ -330,6 +330,13 @@ public class MockedHiveMetadata implements ConnectorMetadata {
                                   "(select * from tpch.customer)", "VIRTUAL_VIEW");
         HiveView view3 = HiveMetastoreApiConverter.toHiveView(hmsView3, MOCKED_HIVE_CATALOG_NAME);
         mockTables.put(hmsView3.getTableName(), new HiveTableInfo(view3));
+        // mock trino view which do not have db name
+        Table hmsView4 =
+                new Table("customer_view_without_db", "tpch", null, 0, 0, 0, sd, Lists.newArrayList(), Maps.newHashMap(), null,
+                        "select c_custkey,c_name, c_address, c_nationkey, c_phone, c_mktsegment, c_comment from customer",
+                        "VIRTUAL_VIEW");
+        HiveView view4 = HiveMetastoreApiConverter.toHiveView(hmsView4, MOCKED_HIVE_CATALOG_NAME);
+        mockTables.put(hmsView4.getTableName(), new HiveTableInfo(view4));
     }
 
     private static void mockSubfieldTable() {

--- a/fe/fe-core/src/test/java/com/starrocks/connector/trino/TrinoViewTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/trino/TrinoViewTest.java
@@ -68,6 +68,9 @@ public class TrinoViewTest {
             {
                 table.getViewOriginalText();
                 result = viewOriginalText;
+
+                table.getDbName();
+                result = "testDb";
             }
         };
 
@@ -106,6 +109,9 @@ public class TrinoViewTest {
             {
                 table.getViewOriginalText();
                 result = viewOriginalText;
+
+                table.getDbName();
+                result = "testDb";
             }
         };
 


### PR DESCRIPTION
Why I'm doing:

What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [x] This is a backport pr

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5

