### PR TITLE
[BugFix] fix stack use after scope when get extra file size

### DIFF
--- a/be/src/storage/tablet_updates.cpp
+++ b/be/src/storage/tablet_updates.cpp
@@ -2916,7 +2916,7 @@ size_t TabletUpdates::_get_rowset_num_deletes(const Rowset& rowset) {
 }
 
 Status TabletUpdates::_get_extra_file_size(int64_t* pindex_size, int64_t* col_size) const {
-    const std::string tablet_path = _tablet.schema_hash_path();
+    std::filesystem::path tablet_path(_tablet.schema_hash_path().c_str());
     try {
         for (const auto& entry : std::filesystem::directory_iterator(tablet_path)) {
             if (entry.is_regular_file()) {
@@ -2935,13 +2935,13 @@ Status TabletUpdates::_get_extra_file_size(int64_t* pindex_size, int64_t* col_si
             }
         }
     } catch (const std::filesystem::filesystem_error& ex) {
-        std::string err_msg = "Iterate dir " + tablet_path + " Filesystem error: " + ex.what();
+        std::string err_msg = "Iterate dir " + tablet_path.string() + " Filesystem error: " + ex.what();
         return Status::InternalError(err_msg);
     } catch (const std::exception& ex) {
-        std::string err_msg = "Iterate dir " + tablet_path + " Standard error: " + ex.what();
+        std::string err_msg = "Iterate dir " + tablet_path.string() + " Standard error: " + ex.what();
         return Status::InternalError(err_msg);
     } catch (...) {
-        std::string err_msg = "Iterate dir " + tablet_path + " Unknown exception occurred.";
+        std::string err_msg = "Iterate dir " + tablet_path.string() + " Unknown exception occurred.";
         return Status::InternalError(err_msg);
     }
     return Status::OK();

--- a/be/test/storage/tablet_updates_test.cpp
+++ b/be/test/storage/tablet_updates_test.cpp
@@ -351,6 +351,10 @@ void TabletUpdatesTest::test_writeread(bool enable_persistent_index) {
     ASSERT_EQ(N, read_tablet(_tablet, 3));
     ASSERT_EQ(N, read_tablet(_tablet, 2));
     ASSERT_TRUE(read_with_cancel(_tablet, 4).is_cancelled());
+
+    // get tablet info
+    TTabletInfo tablet_info;
+    _tablet->updates()->get_tablet_info_extra(&tablet_info);
 }
 
 TEST_F(TabletUpdatesTest, writeread) {


### PR DESCRIPTION
Why I'm doing:
When in ASAN mode, we find that BE crash because stack use after scope:
```
==2519==ERROR: AddressSanitizer: stack-use-after-scope on address 0x7f655d1a9750 at pc 0x00000ac2e06b bp 0x7f655d1a95f0 sp 0x7f655d1a95e8
READ of size 8 at 0x7f655d1a9750 thread T4331
   #0 0xac2e06a in std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >::length() const /opt/rh/gcc-toolset-10/root/usr/include/c++/10.3.0/bits/basic_string.h:908
   #1 0xad8aab2 in std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >::reserve(unsigned long) /opt/rh/gcc-toolset-10/root/usr/include/c++/10.3.0/bits/basic_string.tcc:284
   #2 0x1af62f3a in std::filesystem::__cxx11::path::operator=(std::filesystem::__cxx11::path const&) ../../../.././libstdc++-v3/src/c++17/fs_path.cc:457
   #3 0x1af53f8c in std::filesystem::__cxx11::_Dir::_Dir(std::filesystem::__cxx11::path const&, bool, std::error_code&) ../../../.././libstdc++-v3/src/c++17/fs_dir.cc:51
   #4 0x1af53f8c in std::filesystem::__cxx11::directory_iterator::directory_iterator(std::filesystem::__cxx11::path const&, std::filesystem::directory_options, std::error_code*) ../../../.././libstdc++-v3/src/c++17/fs_dir.cc:135
   #5 0xafaf18f in std::filesystem::__cxx11::directory_iterator::directory_iterator(std::filesystem::__cxx11::path const&) /opt/rh/gcc-toolset-10/root/usr/include/c++/10.3.0/bits/fs_dir.h:387
   #6 0x1323a519 in starrocks::TabletUpdates::_get_extra_file_size(long*, long*) const /root/celerdata/be/src/storage/tablet_updates.cpp:2888
```

What I'm doing:


## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [x] 3.1
  - [ ] 3.0
  - [ ] 2.5
