### PR TITLE
[BugFix] Fix the problem of updating JDBC catalog MV partition meta incorrectly after MV refresh (#39699)

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/PartitionBasedMvRefreshProcessor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/PartitionBasedMvRefreshProcessor.java
@@ -2044,6 +2044,9 @@ public class PartitionBasedMvRefreshProcessor extends BaseTaskRunProcessor {
     private Map<String, MaterializedView.BasePartitionInfo> getSelectedPartitionInfos(Table table,
                                                                                       List<String> selectedPartitionNames,
                                                                                       BaseTableInfo baseTableInfo) {
+        // sort selectedPartitionNames before the for loop, otherwise the order of partition names may be
+        // different in selectedPartitionNames and partitions and will lead to infinite partition refresh.
+        Collections.sort(selectedPartitionNames);
         Map<String, MaterializedView.BasePartitionInfo> partitionInfos = Maps.newHashMap();
         List<com.starrocks.connector.PartitionInfo> partitions = GlobalStateMgr.
                 getCurrentState().getMetadataMgr().getPartitions(baseTableInfo.getCatalogName(), table,


### PR DESCRIPTION
Why I'm doing:
After the refresh of JDBC catalog partitioned MV, the partititon meta(lastRefreshTime) may be incorrect. That is because the partition order in selectedPartitionNames and partitions in function PartitionBasedMvRefreshProcessor::getSelectedPartitionInfos are not the same.

What I'm doing:
Sort selectedPartitionNames before the for loop. Since the partitions are obtained from the SQL and the SQL has "ORDER BY PARTITION_DESCRIPTION" so partitions have been sorted, so it is safe to sort selectedPartitionNames only.

Fixes issue #39699

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [x] 3.1
  - [ ] 3.0
  - [ ] 2.5
