### PR TITLE
[BugFix] Fix typo in batch publish

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/transaction/PublishVersionDaemon.java
+++ b/fe/fe-core/src/main/java/com/starrocks/transaction/PublishVersionDaemon.java
@@ -635,7 +635,7 @@ public class PublishVersionDaemon extends FrontendDaemon {
         long tableId = txnStateBatch.getTableId();
         List<TransactionState> states = txnStateBatch.getTransactionStates();
         // partitionId -> txnIdList
-        Map<Long, List<Long>> dirtyPartitons = new HashMap<>();
+        Map<Long, List<Long>> dirtyPartitions = new HashMap<>();
         // partitionId -> versionList
         Map<Long, List<Long>> partitionVersions = new HashMap<>();
         // partitionId -> transactionState
@@ -647,10 +647,10 @@ public class PublishVersionDaemon extends FrontendDaemon {
                     .getIdToPartitionCommitInfo();
             for (Map.Entry<Long, PartitionCommitInfo> item : partitionCommitInfoMap.entrySet()) {
 
-                if (!dirtyPartitons.containsKey(item.getKey())) {
-                    dirtyPartitons.put(item.getKey(), new ArrayList<>());
+                if (!dirtyPartitions.containsKey(item.getKey())) {
+                    dirtyPartitions.put(item.getKey(), new ArrayList<>());
                 }
-                List<Long> partitionCommitInfo = dirtyPartitons.get(item.getKey());
+                List<Long> partitionCommitInfo = dirtyPartitions.get(item.getKey());
                 partitionCommitInfo.add(state.getTransactionId());
 
                 if (!partitionVersions.containsKey(item.getKey())) {
@@ -685,7 +685,7 @@ public class PublishVersionDaemon extends FrontendDaemon {
 
         List<CompletableFuture<Boolean>> futureList = new ArrayList<>();
 
-        for (Map.Entry<Long, List<Long>> item : dirtyPartitons.entrySet()) {
+        for (Map.Entry<Long, List<Long>> item : dirtyPartitions.entrySet()) {
             Long partitionId = item.getKey();
 
             CompletableFuture<Boolean> future = CompletableFuture.supplyAsync(() -> {
@@ -718,7 +718,7 @@ public class PublishVersionDaemon extends FrontendDaemon {
                     }
 
                     // here create the job to drop txnLog, for the visibleVersion has been updated
-                    submitDeleteTxnLogJob(txnStateBatch, dirtyPartitons);
+                    submitDeleteTxnLogJob(txnStateBatch, dirtyPartitions);
                 } catch (UserException e) {
                     throw new RuntimeException(e);
                 }


### PR DESCRIPTION
Why I'm doing:
There is a typo in batch publish which names `dirtyPartition` to `dirtyPartiton`.
What I'm doing:
Fix typo in batch publish
Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
