### PR TITLE
[BugFix] Fix mv backup/restore when mv and base table are not in the same db

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/backup/mv/MVRestoreUpdater.java
+++ b/fe/fe-core/src/main/java/com/starrocks/backup/mv/MVRestoreUpdater.java
@@ -232,14 +232,12 @@ public class MVRestoreUpdater {
         return true;
     }
 
-    public static Pair<Boolean, Optional<MvId>> restoreBaseTableInfoIfRestored(
-            Database restoreDb,
-            MvRestoreContext mvRestoreContext,
-            MaterializedView mv,
-            MvBaseTableBackupInfo mvBaseTableBackupInfo,
-            BaseTableInfo baseTableInfo,
-            Map<TableName, TableName> remoteToLocalTableName,
-            List<BaseTableInfo> newBaseTableInfos) {
+    public static Pair<Boolean, Optional<MvId>> restoreBaseTableInfoIfRestored(MvRestoreContext mvRestoreContext,
+                                                                               MaterializedView mv,
+                                                                               MvBaseTableBackupInfo mvBaseTableBackupInfo,
+                                                                               BaseTableInfo baseTableInfo,
+                                                                               Map<TableName, TableName> remoteToLocalTableName,
+                                                                               List<BaseTableInfo> newBaseTableInfos) {
         String remoteDbName = baseTableInfo.getDbName();
         String remoteTableName = baseTableInfo.getTableName();
         TableName remoteDbTblName = new TableName(remoteDbName, remoteTableName);
@@ -250,9 +248,16 @@ public class MVRestoreUpdater {
             return Pair.create(false, Optional.empty());
         }
 
+        String localDbName = mvBaseTableBackupInfo.getLocalDbName();
+        Database db = GlobalStateMgr.getCurrentState().getDb(localDbName);
         String localTableName = mvBaseTableBackupInfo.getLocalTableName();
-        Table localTable = restoreDb.getTable(localTableName);
-        remoteToLocalTableName.put(remoteDbTblName, new TableName(restoreDb.getFullName(), localTableName));
+        if (db == null) {
+            LOG.warn("BaseTable(local) %s's db %s is not found, remote db/table: %s/%s",
+                    localTableName, localDbName, remoteDbName, remoteTableName);
+            return Pair.create(false, Optional.empty());
+        }
+        Table localTable = db.getTable(localTableName);
+        remoteToLocalTableName.put(remoteDbTblName, new TableName(db.getFullName(), localTableName));
         if (localTable == null) {
             LOG.warn("Materialized view {} can not find the base table {}, old base table name:{}",
                     mv.getName(), localTableName, remoteTableName);
@@ -260,14 +265,14 @@ public class MVRestoreUpdater {
         }
 
         // restore materialized view's associated base table's mvIds.
-        Optional<MvId> oldMvIdOpt = restoreBaseTable(mv, restoreDb, localTable, mvRestoreContext);
+        Optional<MvId> oldMvIdOpt = restoreBaseTable(mv, db, localTable, mvRestoreContext);
         // restore materialized view's version map if base table is also backed up and restore.
         Map<Long, Map<String, MaterializedView.BasePartitionInfo>> baseTableVisibleVersionMap =
                 mv.getRefreshScheme().getAsyncRefreshContext().getBaseTableVisibleVersionMap();
         restoreBaseTableVersionMap(baseTableVisibleVersionMap, localTable, mvBaseTableBackupInfo);
 
         // update base table info since materialized view's db or base table info may be changed.
-        BaseTableInfo newBaseTableInfo = new BaseTableInfo(restoreDb.getId(), restoreDb.getFullName(), localTableName,
+        BaseTableInfo newBaseTableInfo = new BaseTableInfo(db.getId(), db.getFullName(), localTableName,
                 localTable.getId());
         newBaseTableInfos.add(newBaseTableInfo);
         return Pair.create(true, oldMvIdOpt);

--- a/fe/fe-core/src/main/java/com/starrocks/backup/mv/MvBaseTableBackupInfo.java
+++ b/fe/fe-core/src/main/java/com/starrocks/backup/mv/MvBaseTableBackupInfo.java
@@ -18,14 +18,18 @@ import com.starrocks.backup.BackupJobInfo;
 
 public class MvBaseTableBackupInfo {
     private final BackupJobInfo.BackupTableInfo backupTableInfo;
+    private final String localDbName;
     private final String localTableName;
     private final long remoteTableId;
     private final long backupTime;
+
     public MvBaseTableBackupInfo(BackupJobInfo.BackupTableInfo backupTableInfo,
+                                 String localDbName,
                                  String localTableName,
                                  long remoteTableId,
                                  long backupTime) {
         this.backupTableInfo = backupTableInfo;
+        this.localDbName = localDbName;
         this.localTableName = localTableName;
         this.remoteTableId = remoteTableId;
         this.backupTime = backupTime;
@@ -45,5 +49,9 @@ public class MvBaseTableBackupInfo {
 
     public long getBackupTime() {
         return backupTime;
+    }
+
+    public String getLocalDbName() {
+        return this.localDbName;
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/backup/mv/MvRestoreContext.java
+++ b/fe/fe-core/src/main/java/com/starrocks/backup/mv/MvRestoreContext.java
@@ -77,9 +77,10 @@ public class MvRestoreContext {
         if (remoteTbl.getRelatedMaterializedViews() == null || remoteTbl.getRelatedMaterializedViews().isEmpty()) {
             return;
         }
+        String localDbName = jobInfo.dbName;
         String localTableName = jobInfo.getAliasByOriginNameIfSet(remoteTbl.getName());
         MvBaseTableBackupInfo mvBaseTableBackupInfo =
-                new MvBaseTableBackupInfo(backupTableInfo, localTableName, remoteTbl.getId(), jobInfo.backupTime);
+                new MvBaseTableBackupInfo(backupTableInfo, localDbName, localTableName, remoteTbl.getId(), jobInfo.backupTime);
         mvBaseTableToBackupTableInfo.put(new TableName(jobInfo.dbName, remoteTbl.getName()), mvBaseTableBackupInfo);
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/MaterializedView.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/MaterializedView.java
@@ -1817,7 +1817,7 @@ public class MaterializedView extends OlapTable implements GsonPreProcessable, G
                         "old base table name:%s", this.name, remoteDbTblName));
                 MvBaseTableBackupInfo mvBaseTableBackupInfo = mvBaseTableToBackupTableInfo.get(remoteDbTblName);
 
-                Pair<Boolean, Optional<MvId>> resetResult = restoreBaseTableInfoIfRestored(db, mvRestoreContext, this,
+                Pair<Boolean, Optional<MvId>> resetResult = restoreBaseTableInfoIfRestored(mvRestoreContext, this,
                         mvBaseTableBackupInfo, baseTableInfo, remoteToLocalTableName, newBaseTableInfos);
                 if (!resetResult.first) {
                     isSetInactive = true;

--- a/fe/fe-core/src/test/java/com/starrocks/backup/RestoreJobMaterializedViewTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/backup/RestoreJobMaterializedViewTest.java
@@ -463,16 +463,6 @@ public class RestoreJobMaterializedViewTest {
     @Test
     @Order(3)
     public void testMVRestore_TestMVWithBaseTable1() {
-        new Expectations() {
-            {
-                globalStateMgr.getCurrentState().getCatalogMgr().catalogExists("default_catalog");
-                result = true;
-
-                globalStateMgr.getCurrentState().getMetadataMgr().getDb("default_catalog", DB_NAME);
-                minTimes = 0;
-                result = db;
-            }
-        };
         // gen BackupJobInfo
         RestoreJob job = createRestoreJob(ImmutableList.of(TABLE_NAME, MATERIALIZED_VIEW_NAME));
         // backup & restore
@@ -483,16 +473,6 @@ public class RestoreJobMaterializedViewTest {
     @Test
     @Order(4)
     public void testMVRestore_TestMVWithBaseTable2() {
-        new Expectations() {
-            {
-                globalStateMgr.getCurrentState().getCatalogMgr().catalogExists("default_catalog");
-                result = true;
-
-                globalStateMgr.getCurrentState().getMetadataMgr().getDb("default_catalog", DB_NAME);
-                minTimes = 0;
-                result = db;
-            }
-        };
         // gen BackupJobInfo
         RestoreJob job = createRestoreJob(ImmutableList.of(MATERIALIZED_VIEW_NAME, TABLE_NAME));
         // backup & restore
@@ -503,16 +483,6 @@ public class RestoreJobMaterializedViewTest {
     @Test
     @Order(5)
     public void testMVRestore_TestMVWithBaseTable3() {
-        new Expectations() {
-            {
-                globalStateMgr.getCurrentState().getCatalogMgr().catalogExists("default_catalog");
-                result = true;
-
-                globalStateMgr.getCurrentState().getMetadataMgr().getDb("default_catalog", DB_NAME);
-                minTimes = 0;
-                result = db;
-            }
-        };
         // gen BackupJobInfo
         RestoreJob job1 = createRestoreJob(ImmutableList.of(TABLE_NAME));
         // backup & restore


### PR DESCRIPTION
Why I'm doing:

This is backport from https://github.com/StarRocks/starrocks/pull/39695.

and an another bugfix for this case: [#39407](https://github.com/StarRocks/starrocks/pull/39407)

Use the correct db when mv and base tables are not in the same db too.


What I'm doing:
- Store the base table's db name in the base table's restore stage.
- When MV restore, use the base table's db correctly.

TestCase:
- https://github.com/StarRocks/StarRocksTest/pull/5752/files

This case is unstable because mv maybe actived by the automatic activer backgroup.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
