### PR TITLE
[UT] Fix the ut of ScanExecutorTest

### DIFF
--- a/be/test/exec/workgroup/scan_task_queue_test.cpp
+++ b/be/test/exec/workgroup/scan_task_queue_test.cpp
@@ -136,6 +136,7 @@ PARALLEL_TEST(ScanExecutorTest, test_yield) {
                       .set_max_queue_size(100)
                       .build(&thread_pool));
     auto executor = std::make_unique<ScanExecutor>(std::move(thread_pool), std::move(queue), false);
+    DeferOp op([&]() { executor->close(); });
     executor->initialize(4);
 
     std::promise<int> a;
@@ -188,8 +189,6 @@ PARALLEL_TEST(ScanExecutorTest, test_yield) {
     std::unique_lock lock(mutex);
     cv.wait(lock, [&]() { return submit_tasks == finished_tasks.load(); });
     ASSERT_EQ(submit_tasks, finished_tasks.load());
-
-    executor.reset();
 }
 
 } // namespace starrocks::workgroup


### PR DESCRIPTION
Why I'm doing:

The ut problem is introduced by the pr: https://github.com/StarRocks/starrocks/pull/39329.

Currently, we need to explicitly call ScanExecutor::close()

What I'm doing:

Explicitly call ScanExecutor::close()


## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [x] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
