### PR TITLE
[UT] Disable os direct io in datacache unittest.

### DIFF
--- a/be/test/block_cache/block_cache_test.cpp
+++ b/be/test/block_cache/block_cache_test.cpp
@@ -37,7 +37,7 @@ protected:
 };
 
 TEST_F(BlockCacheTest, hybrid_cache) {
-    const std::string cache_dir = "./block_disk_cache1";
+    const std::string cache_dir = "./block_cache_hybrid_cache";
     ASSERT_TRUE(fs::create_directories(cache_dir).ok());
 
     std::unique_ptr<BlockCache> cache(new BlockCache);
@@ -49,11 +49,12 @@ TEST_F(BlockCacheTest, hybrid_cache) {
     options.disk_spaces.push_back({.path = cache_dir, .size = quota});
     options.block_size = block_size;
     options.max_concurrent_inserts = 100000;
+    options.enable_direct_io = false;
     options.engine = "starcache";
     Status status = cache->init(options);
     ASSERT_TRUE(status.ok());
 
-    const size_t batch_size = block_size - 1234;
+    const size_t batch_size = block_size;
     const size_t rounds = 10;
     const std::string cache_key = "test_file";
 
@@ -103,6 +104,7 @@ TEST_F(BlockCacheTest, write_with_overwrite_option) {
     options.mem_space_size = 5 * 1024 * 1024;
     options.block_size = block_size;
     options.max_concurrent_inserts = 100000;
+    options.enable_direct_io = false;
     options.engine = "starcache";
     Status status = cache->init(options);
     ASSERT_TRUE(status.ok());
@@ -142,11 +144,12 @@ TEST_F(BlockCacheTest, auto_create_disk_cache_path) {
     options.disk_spaces.push_back({.path = cache_dir, .size = quota});
     options.block_size = block_size;
     options.max_concurrent_inserts = 100000;
+    options.enable_direct_io = false;
     options.engine = "starcache";
     Status status = cache->init(options);
     ASSERT_TRUE(status.ok());
 
-    const size_t batch_size = block_size - 1234;
+    const size_t batch_size = block_size;
     const size_t rounds = 3;
     const std::string cache_key = "test_file";
 


### PR DESCRIPTION
Why I'm doing:
Current we use os pagecache by default in datacache disk io. So we disable direct io in its unittests.

What I'm doing:
Disable direct io in datacache unittests.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [x] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5

