### PR TITLE
[Feature] The parse_datetime function throws an exception when parsing fails in trino mode

### DIFF
--- a/be/src/exprs/time_functions.cpp
+++ b/be/src/exprs/time_functions.cpp
@@ -1962,6 +1962,11 @@ StatusOr<ColumnPtr> TimeFunctions::parse_jodatime(FunctionContext* context, cons
 
             DateTimeValue date_time_value;
             if (!formatter->parse(str, &date_time_value)) {
+                if (context->state() && context->state()->get_sql_dialect() == "trino") {
+                    std::string_view format_str =
+                            ColumnHelper::get_const_value<TYPE_VARCHAR>(context->get_constant_column(1));
+                    return Status::InvalidArgument(fmt::format("Invalid format '{}' for '{}'", format_str, str));
+                }
                 result.append_null();
             } else {
                 TimestampValue ts = TimestampValue::create(

--- a/be/src/runtime/runtime_state.h
+++ b/be/src/runtime/runtime_state.h
@@ -433,6 +433,8 @@ public:
 
     bool is_jit_enabled() const { return _query_options.__isset.enable_jit && _query_options.enable_jit; }
 
+    std::string_view get_sql_dialect() const { return _query_options.sql_dialect; }
+
 private:
     // Set per-query state.
     void _init(const TUniqueId& fragment_instance_id, const TQueryOptions& query_options,

--- a/be/test/exprs/time_functions_test.cpp
+++ b/be/test/exprs/time_functions_test.cpp
@@ -30,6 +30,7 @@
 #include "exprs/anyval_util.h"
 #include "exprs/function_context.h"
 #include "exprs/mock_vectorized_expr.h"
+#include "gen_cpp/InternalService_types.h"
 #include "runtime/datetime_value.h"
 #include "runtime/runtime_state.h"
 #include "runtime/time_types.h"
@@ -2238,6 +2239,84 @@ TEST_F(TimeFunctionsTest, jodatime_format) {
         ASSERT_EQ(1, result->size());
         auto v = ColumnHelper::cast_to<TYPE_VARCHAR>(result);
         ASSERT_EQ(Slice("abcd 202006"), v->get_data()[0]);
+    }
+}
+
+TEST_F(TimeFunctionsTest, trino_str_to_jodatime) {
+    TQueryOptions query_option;
+    query_option.__set_sql_dialect("trino");
+    RuntimeState state(TUniqueId(), query_option, TQueryGlobals(), nullptr);
+    FunctionContext* ctx = FunctionContext::create_test_context();
+    ctx->set_runtime_state(&state);
+    auto ptr = std::unique_ptr<FunctionContext>(ctx);
+
+    {
+        auto dt_col = ColumnHelper::create_const_column<TYPE_VARCHAR>(Slice("2024-01-01 12:34:56"), 1);
+        auto fmt_col = ColumnHelper::create_const_column<TYPE_VARCHAR>(Slice("yyyy-MM-dd HH:mm:ss.S"), 1);
+
+        Columns columns;
+        columns.emplace_back(dt_col);
+        columns.emplace_back(fmt_col);
+        ctx->set_constant_columns(columns);
+        TimeFunctions::parse_joda_prepare(ctx, FunctionContext::FunctionStateScope::FRAGMENT_LOCAL);
+        StatusOr<ColumnPtr> result = TimeFunctions::parse_jodatime(ctx, columns);
+        TimeFunctions::parse_joda_close(ctx, FunctionContext::FunctionStateScope::FRAGMENT_LOCAL);
+        ASSERT_FALSE(result.ok());
+        ASSERT_EQ(result.status().message(), "Invalid format 'yyyy-MM-dd HH:mm:ss.S' for '2024-01-01 12:34:56'");
+    }
+
+    {
+        auto expect = TimestampValue::create(2023, 12, 21, 12, 34, 56);
+        auto dt_col = ColumnHelper::create_const_column<TYPE_VARCHAR>(Slice("2023-12-21 12:34:56"), 1);
+        auto fmt_col = ColumnHelper::create_const_column<TYPE_VARCHAR>(Slice("yyyy-MM-dd HH:mm:ss"), 1);
+
+        Columns columns;
+        columns.emplace_back(dt_col);
+        columns.emplace_back(fmt_col);
+        ctx->set_constant_columns(columns);
+        TimeFunctions::parse_joda_prepare(ctx, FunctionContext::FunctionStateScope::FRAGMENT_LOCAL);
+        StatusOr<ColumnPtr> result = TimeFunctions::parse_jodatime(ctx, columns);
+        TimeFunctions::parse_joda_close(ctx, FunctionContext::FunctionStateScope::FRAGMENT_LOCAL);
+        ASSERT_TRUE(result.ok());
+        auto v = ColumnHelper::as_column<ConstColumn>(result.value());
+        auto datetime_value = v->get(0).get_timestamp();
+        ASSERT_EQ(expect, datetime_value);
+    }
+
+    {
+        auto expect = TimestampValue::create(2023, 12, 21, 12, 34, 56);
+        auto dt_col = ColumnHelper::create_const_column<TYPE_VARCHAR>(Slice("21/December/23 12:34:56"), 1);
+        auto fmt_col = ColumnHelper::create_const_column<TYPE_VARCHAR>(Slice("dd/MMMM/yy HH:mm:ss"), 1);
+
+        Columns columns;
+        columns.emplace_back(dt_col);
+        columns.emplace_back(fmt_col);
+        ctx->set_constant_columns(columns);
+        TimeFunctions::parse_joda_prepare(ctx, FunctionContext::FunctionStateScope::FRAGMENT_LOCAL);
+        StatusOr<ColumnPtr> result = TimeFunctions::parse_jodatime(ctx, columns);
+        TimeFunctions::parse_joda_close(ctx, FunctionContext::FunctionStateScope::FRAGMENT_LOCAL);
+        ASSERT_TRUE(result.ok());
+        auto v = ColumnHelper::as_column<ConstColumn>(result.value());
+        auto datetime_value = v->get(0).get_timestamp();
+        ASSERT_EQ(expect, datetime_value);
+    }
+
+    {
+        auto expect = TimestampValue::create(2023, 12, 21, 12, 34, 56, 123);
+        auto dt_col = ColumnHelper::create_const_column<TYPE_VARCHAR>(Slice("21/December/23 12:34:56.000123"), 1);
+        auto fmt_col = ColumnHelper::create_const_column<TYPE_VARCHAR>(Slice("dd/MMMM/yy HH:mm:ss.SSSSSS"), 1);
+
+        Columns columns;
+        columns.emplace_back(dt_col);
+        columns.emplace_back(fmt_col);
+        ctx->set_constant_columns(columns);
+        TimeFunctions::parse_joda_prepare(ctx, FunctionContext::FunctionStateScope::FRAGMENT_LOCAL);
+        StatusOr<ColumnPtr> result = TimeFunctions::parse_jodatime(ctx, columns);
+        TimeFunctions::parse_joda_close(ctx, FunctionContext::FunctionStateScope::FRAGMENT_LOCAL);
+        ASSERT_TRUE(result.ok());
+        auto v = ColumnHelper::as_column<ConstColumn>(result.value());
+        auto datetime_value = v->get(0).get_timestamp();
+        ASSERT_EQ(expect, datetime_value);
     }
 }
 

--- a/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
@@ -3198,6 +3198,7 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
         TQueryOptions tResult = new TQueryOptions();
         tResult.setMem_limit(maxExecMemByte);
         tResult.setQuery_mem_limit(queryMemLimit);
+        tResult.setSql_dialect(sqlDialect.toLowerCase());
 
         // Avoid integer overflow
         tResult.setQuery_timeout(Math.min(Integer.MAX_VALUE / 1000, queryTimeoutS));

--- a/gensrc/thrift/InternalService.thrift
+++ b/gensrc/thrift/InternalService.thrift
@@ -264,6 +264,8 @@ struct TQueryOptions {
   114: optional bool enable_jit = false;
 
   115: optional TTimeUnit big_query_profile_threshold_unit = TTimeUnit.SECOND;
+  
+  116: optional string sql_dialect;
 }
 
 


### PR DESCRIPTION
Why I'm doing:

In presto, if there is a problem with the format of parse_datetime, an error will be reported, but in StarRocks, it only returns a NULL. This brings certain difficulties to the migration from presto to StarRocks

What I'm doing:

Pass sql_dialect to be, then judge and throw exception in udf

## What type of PR is this:

- [ ] BugFix
- [x] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [x] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
