### PR TITLE
[BugFix] remove backquote of field name in struct

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/connector/ColumnTypeConverter.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/ColumnTypeConverter.java
@@ -735,13 +735,14 @@ public class ColumnTypeConverter {
         Matcher matcher = Pattern.compile(ARRAY_PATTERN).matcher(typeStr.toLowerCase(Locale.ROOT));
         Type itemType;
         if (matcher.find()) {
-            if (fromHiveTypeToArrayType(matcher.group(1)).equals(Type.UNKNOWN_TYPE)) {
+            Type innerType = fromHiveType(matcher.group(1));
+            if (Type.UNKNOWN_TYPE.equals(innerType)) {
                 itemType = Type.UNKNOWN_TYPE;
             } else {
-                itemType = new ArrayType(fromHiveTypeToArrayType(matcher.group(1)));
+                itemType = new ArrayType(innerType);
             }
         } else {
-            itemType = fromHiveType(typeStr);
+            throw new StarRocksConnectorException("Failed to get ArrayType at " + typeStr);
         }
         return itemType;
     }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AstToStringBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AstToStringBuilder.java
@@ -78,6 +78,7 @@ import com.starrocks.catalog.RangePartitionInfo;
 import com.starrocks.catalog.Table;
 import com.starrocks.catalog.View;
 import com.starrocks.common.Pair;
+import com.starrocks.common.util.ParseUtil;
 import com.starrocks.common.util.PrintableMap;
 import com.starrocks.common.util.PropertyAnalyzer;
 import com.starrocks.common.util.WriteQuorum;
@@ -146,6 +147,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.StringJoiner;
 import java.util.stream.Collectors;
 
 import static com.starrocks.catalog.FunctionSet.IGNORE_NULL_WINDOW_FUNCTION;
@@ -161,11 +163,11 @@ import static java.util.stream.Collectors.toList;
  */
 public class AstToStringBuilder {
     public static String toString(ParseNode expr) {
-        return toString(expr, true);
+        return new AST2StringBuilderVisitor().visit(expr);
     }
 
-    public static String toString(ParseNode expr, boolean addFunctionDbName) {
-        return new AST2StringBuilderVisitor(addFunctionDbName).visit(expr);
+    public static String getAliasName(ParseNode expr, boolean addFunctionDbName, boolean withBackquote) {
+        return new AST2StringBuilderVisitor(addFunctionDbName, withBackquote).visit(expr);
     }
 
     public static class AST2StringBuilderVisitor extends AstVisitor<String, Void> {
@@ -174,12 +176,16 @@ public class AstToStringBuilder {
         // when you just want to a function name as its alias set it false
         protected boolean addFunctionDbName;
 
+        // when you want to get a legal expr name with backquote set it false
+        protected boolean withBackquote;
+
         public AST2StringBuilderVisitor() {
-            this(true);
+            this(true, true);
         }
 
-        public AST2StringBuilderVisitor(boolean addFunctionDbName) {
+        public AST2StringBuilderVisitor(boolean addFunctionDbName, boolean withBackquote) {
             this.addFunctionDbName = addFunctionDbName;
+            this.withBackquote = withBackquote;
         }
 
         // ------------------------------------------- Privilege Statement -------------------------------------------------
@@ -1028,7 +1034,16 @@ public class AstToStringBuilder {
 
         @Override
         public String visitSubfieldExpr(SubfieldExpr node, Void context) {
-            return String.format("%s.%s", visit(node.getChild(0)), Joiner.on('.').join(node.getFieldNames()));
+            StringJoiner joiner = new StringJoiner(".");
+            for (String field : node.getFieldNames()) {
+                if (withBackquote) {
+                    joiner.add(ParseUtil.backquote(field));
+                } else {
+                    joiner.add(field);
+                }
+
+            }
+            return String.format("%s.%s", visit(node.getChild(0)), joiner);
         }
 
         public String visitGroupingFunctionCall(GroupingFunctionCallExpr node, Void context) {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AstToStringBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AstToStringBuilder.java
@@ -176,7 +176,8 @@ public class AstToStringBuilder {
         // when you just want to a function name as its alias set it false
         protected boolean addFunctionDbName;
 
-        // when you want to get a legal expr name with backquote set it false
+        // when you want to get an expr name with backquote set it true
+        // when you just want to get the real expr name set it false
         protected boolean withBackquote;
 
         public AST2StringBuilderVisitor() {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/SelectAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/SelectAnalyzer.java
@@ -257,7 +257,7 @@ public class SelectAnalyzer {
                             true, item.getExpr().isNullable()));
                 }
 
-                // outputExprInOrderByScope is used to record which expressions in outputExpressioskn are to be
+                // outputExprInOrderByScope is used to record which expressions in outputExpression are to be
                 // recorded in the first level of OrderByScope (order by expressions can refer to columns in output)
                 // Which columns satisfy the condition?
                 // 1. An expression of type SlotRef.

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/SelectAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/SelectAnalyzer.java
@@ -241,7 +241,8 @@ public class SelectAnalyzer {
                 if (item.getExpr() instanceof SlotRef) {
                     name = item.getAlias() == null ? ((SlotRef) item.getExpr()).getColumnName() : item.getAlias();
                 } else {
-                    name = item.getAlias() == null ? AstToStringBuilder.toString(item.getExpr(), false) : item.getAlias();
+                    name = item.getAlias() == null ?
+                            AstToStringBuilder.getAliasName(item.getExpr(), false, false) : item.getAlias();
                 }
 
                 analyzeExpression(item.getExpr(), analyzeState, scope);
@@ -256,7 +257,7 @@ public class SelectAnalyzer {
                             true, item.getExpr().isNullable()));
                 }
 
-                // outputExprInOrderByScope is used to record which expressions in outputExpression are to be
+                // outputExprInOrderByScope is used to record which expressions in outputExpressioskn are to be
                 // recorded in the first level of OrderByScope (order by expressions can refer to columns in output)
                 // Which columns satisfy the condition?
                 // 1. An expression of type SlotRef.

--- a/fe/fe-core/src/main/java/com/starrocks/sql/parser/AstBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/parser/AstBuilder.java
@@ -7096,7 +7096,9 @@ public class AstBuilder extends StarRocksBaseVisitor<ParseNode> {
         List<StarRocksParser.SubfieldDescContext> subfields =
                 context.subfieldDescs().subfieldDesc();
         for (StarRocksParser.SubfieldDescContext type : subfields) {
-            fields.add(new StructField(type.identifier().getText(), getType(type.type()), null));
+            Identifier fieldIdentifier = (Identifier) visit(type.identifier());
+            String fieldName = fieldIdentifier.getValue();
+            fields.add(new StructField(fieldName, getType(type.type()), null));
         }
 
         return new StructType(fields);

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/StructTypePlanTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/StructTypePlanTest.java
@@ -45,6 +45,10 @@ public class StructTypePlanTest extends PlanTestBase {
                 "c3 struct<c3_sub1 array<struct<c3_sub1_sub1 int, c3_sub1_sub2 int>>, c3_sub2 int>) " +
                 "duplicate key(c1) distributed by hash(c1) buckets 1 " +
                 "properties('replication_num'='1');");
+        starRocksAssert.withTable("create table index_struct_nest(c1 int,\n" +
+                "index_struct array<struct<`index` bigint(20), char_col varchar(1048576)>>)\n" +
+                "duplicate key(c1) distributed by hash(c1) buckets 1\n" +
+                "properties('replication_num'='1')");
         FeConstants.runningUnitTest = false;
     }
 
@@ -67,6 +71,11 @@ public class StructTypePlanTest extends PlanTestBase {
         sql = "select c2 from test1 union all select c2_0 from test1";
         plan = getFragmentPlan(sql);
         assertContains(plan, "CAST(3: c2 AS struct<a int(11), b varchar(10)>)");
+
+        sql = "select index_struct[1].`index` from index_struct_nest";
+        plan = getFragmentPlan(sql);
+        assertContains(plan, "1:Project\n" +
+                "  |  <slot 3> : 2: index_struct[1].index[true]");
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/utframe/UtFrameUtils.java
+++ b/fe/fe-core/src/test/java/com/starrocks/utframe/UtFrameUtils.java
@@ -605,7 +605,8 @@ public class UtFrameUtils {
                                     connectContext.getSessionVariable().getSqlMode()).get(0);
                     com.starrocks.sql.analyzer.Analyzer.analyze(viewStatement, connectContext);
                 } catch (Exception e) {
-                    System.out.println(e.getMessage());
+                    System.out.println("invalid view def: " + createTableStmt.getInlineViewDef()
+                            + "\nError msg:"  + e.getMessage());
                     throw e;
                 }
             } catch (SemanticException | AnalysisException e) {

--- a/test/sql/test_hive/R/test_hive_sink
+++ b/test/sql/test_hive/R/test_hive_sink
@@ -1,27 +1,21 @@
 -- name: test_hive_sink
 create external catalog hive_sink_test_${uuid0} PROPERTIES ("type"="hive", "hive.metastore.uris"="${hive_metastore_uris}");
 -- result:
-[]
 -- !result
 set catalog hive_sink_test_${uuid0};
 -- result:
-[]
 -- !result
 create database hive_db_${uuid0};
 -- result:
-[]
 -- !result
 use hive_db_${uuid0};
 -- result:
-[]
 -- !result
 create table t1 (k1 int, k2 int, k3 date, k4 smallint) partition by (k3, k4);
 -- result:
-[]
 -- !result
 insert into t1 select 999,888,'9999-12-03', 3;
 -- result:
-[]
 -- !result
 select * from t1;
 -- result:
@@ -37,17 +31,31 @@ select * from t1;
 -- !result
 drop table t1 force;
 -- result:
-[]
+-- !result
+CREATE TABLE struct_index (
+date varchar(1048576) NULL COMMENT "",
+hash varchar(1048576) NULL COMMENT "",
+input struct<`index` bigint(20), value double> NULL COMMENT "",
+outputs array<struct<`index` bigint(20), value double>> NULL COMMENT ""
+);
+-- result:
+-- !result
+insert into struct_index values ('20210101', '123', row(1,1.1), [row(1,1.1)]);
+-- result:
+-- !result
+select /*+ set_var(enable_prune_complex_types = false) */ outputs[1].`index`, input.`index` from struct_index;
+-- result:
+1	1
+-- !result
+drop table struct_index force;
+-- result:
 -- !result
 drop database hive_db_${uuid0};
 -- result:
-[]
 -- !result
 drop catalog hive_sink_test_${uuid0};
 -- result:
-[]
 -- !result
 set catalog default_catalog;
 -- result:
-[]
 -- !result

--- a/test/sql/test_hive/T/test_hive_sink
+++ b/test/sql/test_hive/T/test_hive_sink
@@ -10,6 +10,20 @@ select * from t1;
 insert into t1 values( 999,888,'9999-12-03', 3),( 999,888,'9999-12-33', 3);
 select * from t1;
 drop table t1 force;
+
+CREATE TABLE struct_index (
+date varchar(1048576) NULL COMMENT "",
+hash varchar(1048576) NULL COMMENT "",
+input struct<`index` bigint(20), value double> NULL COMMENT "",
+outputs array<struct<`index` bigint(20), value double>> NULL COMMENT ""
+);
+
+desc struct_index;
+
+insert into struct_index values ('20210101', '123', row(1,1.1), [row(1,1.1)]);
+select /*+ set_var(enable_prune_complex_types = false) */ outputs[1].`index`, input.`index` from struct_index;
+drop table struct_index force;
+
 drop database hive_db_${uuid0};
 drop catalog hive_sink_test_${uuid0};
 set catalog default_catalog;


### PR DESCRIPTION
Why I'm doing:
Field name in struct type with a reserved word cannot be processed correctly.

What I'm doing:
Remove the backquote we extract filed name in AstBuilder. 
Add backquote back when ast to string sql for field name in struct type, but not add backquote when we generate the name in `Field` of a `Scope`.

Also found a bug https://github.com/StarRocks/starrocks/issues/39743

Fixes #issue
https://github.com/StarRocks/starrocks/issues/39237
## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [x] 3.1
  - [x] 3.0
  - [ ] 2.5
