### PR TITLE
[BugFix] Fix bug partition by expr slot id is incorrect

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/planner/OlapTableSink.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/OlapTableSink.java
@@ -468,6 +468,7 @@ public class OlapTableSink extends DataSink {
                         Column column = slotDesc.getColumn();
                         if (column.getName().equalsIgnoreCase(slotRefs.get(0).getColumnName())) {
                             slotRefs.get(0).setDesc(slotDesc);
+                            break;
                         }
                     }
                     partitionParam.setPartition_exprs(Expr.treesToThrift(exprPartitionInfo.getPartitionExprs()));
@@ -487,6 +488,7 @@ public class OlapTableSink extends DataSink {
                         Column column = slotDesc.getColumn();
                         if (column.getName().equalsIgnoreCase(slotRefs.get(0).getColumnName())) {
                             slotRefs.get(0).setDesc(slotDesc);
+                            break;
                         }
                     }
                     partitionParam.setPartition_exprs(Expr.treesToThrift(expressionRangePartitionInfoV2.getPartitionExprs()));

--- a/fe/fe-core/src/main/java/com/starrocks/planner/OlapTableSink.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/OlapTableSink.java
@@ -476,7 +476,7 @@ public class OlapTableSink extends DataSink {
                     ExpressionRangePartitionInfoV2 expressionRangePartitionInfoV2 = (ExpressionRangePartitionInfoV2) rangePartitionInfo;
                     List<Expr> partitionExprs = expressionRangePartitionInfoV2.getPartitionExprs();
                     Preconditions.checkArgument(partitionExprs.size() == 1,
-                            "Number of partition expr is not 1 for automatic partition table, expr num="
+                            "Number of partition expr is not 1 for expression partition table, expr num="
                                     + partitionExprs.size());
                     Expr expr = partitionExprs.get(0);
                     List<SlotRef> slotRefs = Lists.newArrayList();

--- a/fe/fe-core/src/main/java/com/starrocks/planner/OlapTableSink.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/OlapTableSink.java
@@ -473,6 +473,22 @@ public class OlapTableSink extends DataSink {
                     partitionParam.setPartition_exprs(Expr.treesToThrift(exprPartitionInfo.getPartitionExprs()));
                 } else if (rangePartitionInfo instanceof ExpressionRangePartitionInfoV2) {
                     ExpressionRangePartitionInfoV2 expressionRangePartitionInfoV2 = (ExpressionRangePartitionInfoV2) rangePartitionInfo;
+                    List<Expr> partitionExprs = expressionRangePartitionInfoV2.getPartitionExprs();
+                    Preconditions.checkArgument(partitionExprs.size() == 1,
+                            "Number of partition expr is not 1 for automatic partition table, expr num="
+                                    + partitionExprs.size());
+                    Expr expr = partitionExprs.get(0);
+                    List<SlotRef> slotRefs = Lists.newArrayList();
+                    expr.collect(SlotRef.class, slotRefs);
+                    Preconditions.checkState(slotRefs.size() == 1);
+                    // default slot is table column slot, when there are some expr on column
+                    // the slot desc will change, so we need to reset the slot desc
+                    for (SlotDescriptor slotDesc : tupleDescriptor.getSlots()) {
+                        Column column = slotDesc.getColumn();
+                        if (column.getName().equalsIgnoreCase(slotRefs.get(0).getColumnName())) {
+                            slotRefs.get(0).setDesc(slotDesc);
+                        }
+                    }
                     partitionParam.setPartition_exprs(Expr.treesToThrift(expressionRangePartitionInfoV2.getPartitionExprs()));
                 }
                 break;

--- a/test/sql/test_partition_by_expr/R/test_expr_from_unixtime
+++ b/test/sql/test_partition_by_expr/R/test_expr_from_unixtime
@@ -168,3 +168,17 @@ START ("2021-01-01") END ("2021-01-10") EVERY (INTERVAL 1 DAY)
 -- result:
 E: (1064, 'Getting analyzing error from line 7, column 19 to line 7, column 47. Detail message: Unsupported partition expression from_unixtime_ms for column create_time type VARCHAR(100).')
 -- !result
+create table site_access_par_3 (
+`rowkey` string not null,
+`evernt_ts_col` BIGINT NOT NULL)
+ENGINE = OLAP
+PRIMARY KEY (`rowkey`, `evernt_ts_col`)
+PARTITION BY RANGE (FROM_UNIXTIME_MS(evernt_ts_col)) (
+START ("2023-12-30") END ("2024-01-05") EVERY (INTERVAL 1 DAY)
+)
+DISTRIBUTED BY HASH (`rowkey`) BUCKETS 1;
+-- result:
+-- !result
+insert INTO site_access_par_3 values ("2023-01-04", 1704077791000);
+-- result:
+-- !result

--- a/test/sql/test_partition_by_expr/T/test_expr_from_unixtime
+++ b/test/sql/test_partition_by_expr/T/test_expr_from_unixtime
@@ -88,3 +88,13 @@ CREATE TABLE partition_unixtime_ms (
 PARTITION BY RANGE(from_unixtime_ms(create_time))(
 START ("2021-01-01") END ("2021-01-10") EVERY (INTERVAL 1 DAY)
 );
+create table site_access_par_3 (
+`rowkey` string not null,
+`evernt_ts_col` BIGINT NOT NULL)
+ENGINE = OLAP
+PRIMARY KEY (`rowkey`, `evernt_ts_col`)
+PARTITION BY RANGE (FROM_UNIXTIME_MS(evernt_ts_col)) (
+START ("2023-12-30") END ("2024-01-05") EVERY (INTERVAL 1 DAY)
+)
+DISTRIBUTED BY HASH (`rowkey`) BUCKETS 1;
+insert INTO site_access_par_3 values ("2023-01-04", 1704077791000);


### PR DESCRIPTION
Why I'm doing:
If the partition is not in the first column, it is possible that the slot id is calculated incorrectly, causing be to receive the wrong partition column.

What I'm doing:
Calculate the correct partition column and pass it to be every time. Although this is not efficient, it can solve the problem quickly and there will be time for optimization later.

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
