### PR TITLE
[Enhancement] Refine the priv check for be_tablets and show tablet

### DIFF
--- a/be/src/exec/schema_scanner/schema_be_tablets_scanner.cpp
+++ b/be/src/exec/schema_scanner/schema_be_tablets_scanner.cpp
@@ -25,6 +25,19 @@
 
 namespace starrocks {
 
+namespace {
+    std::set<int64_t> get_authorized_table_ids(const TGetTablesConfigResponse &_tables_config_response) {
+        std::set<int64_t> authorized_table_ids;
+        for (const auto &v: _tables_config_response.tables_config_infos) {
+            if (v.__isset.table_id) {
+                authorized_table_ids.insert(v.table_id);
+            }
+        }
+
+        return authorized_table_ids;
+    }
+} // namespace
+
 SchemaScanner::ColumnDesc SchemaBeTabletsScanner::_s_columns[] = {
         {"BE_ID", TYPE_BIGINT, sizeof(int64_t), false},
         {"TABLE_ID", TYPE_BIGINT, sizeof(int64_t), false},
@@ -54,11 +67,42 @@ SchemaBeTabletsScanner::SchemaBeTabletsScanner()
 SchemaBeTabletsScanner::~SchemaBeTabletsScanner() = default;
 
 Status SchemaBeTabletsScanner::start(RuntimeState* state) {
+    if (!_is_init) {
+        return Status::InternalError("used before initialized.");
+    }
+    TAuthInfo auth_info;
+    if (nullptr != _param->db) {
+        auth_info.__set_pattern(*(_param->db));
+    }
+    if (nullptr != _param->current_user_ident) {
+        auth_info.__set_current_user_ident(*(_param->current_user_ident));
+    } else {
+        if (nullptr != _param->user) {
+            auth_info.__set_user(*(_param->user));
+        }
+        if (nullptr != _param->user_ip) {
+            auth_info.__set_user_ip(*(_param->user_ip));
+        }
+    }
+    TGetTablesConfigRequest tables_config_req;
+    tables_config_req.__set_auth_info(auth_info);
+
+    if (nullptr != _param->ip && 0 != _param->port) {
+        RETURN_IF_ERROR(SchemaHelper::get_tables_config(*(_param->ip), _param->port, tables_config_req,
+                                                        &_tables_config_response));
+    } else {
+        return Status::InternalError("IP or port doesn't exists");
+    }
+    // we only show tablets when the user has any privilege on the corresponding table
+    // first get the table ids on which the current user has privilege
+    auto authorized_table_ids = get_authorized_table_ids(_tables_config_response);
+
     auto o_id = get_backend_id();
     _be_id = o_id.has_value() ? o_id.value() : -1;
     _infos.clear();
     auto manager = StorageEngine::instance()->tablet_manager();
-    manager->get_tablets_basic_infos(_param->table_id, _param->partition_id, _param->tablet_id, _infos);
+    manager->get_tablets_basic_infos(_param->table_id, _param->partition_id, _param->tablet_id, _infos,
+                                     authorized_table_ids);
     LOG(INFO) << strings::Substitute("get_tablets_basic_infos table_id:$0 partition:$1 tablet:$2 #info:$3",
                                      _param->table_id, _param->partition_id, _param->tablet_id, _infos.size());
     _cur_idx = 0;

--- a/be/src/exec/schema_scanner/schema_be_tablets_scanner.cpp
+++ b/be/src/exec/schema_scanner/schema_be_tablets_scanner.cpp
@@ -26,9 +26,9 @@
 namespace starrocks {
 
 namespace {
-std::set<int64_t> get_authorized_table_ids(const TGetTablesConfigResponse &_tables_config_response) {
+std::set<int64_t> get_authorized_table_ids(const TGetTablesConfigResponse& _tables_config_response) {
     std::set<int64_t> authorized_table_ids;
-    for (const auto &v: _tables_config_response.tables_config_infos) {
+    for (const auto& v : _tables_config_response.tables_config_infos) {
         if (v.__isset.table_id) {
             authorized_table_ids.insert(v.table_id);
         }

--- a/be/src/exec/schema_scanner/schema_be_tablets_scanner.cpp
+++ b/be/src/exec/schema_scanner/schema_be_tablets_scanner.cpp
@@ -26,16 +26,16 @@
 namespace starrocks {
 
 namespace {
-    std::set<int64_t> get_authorized_table_ids(const TGetTablesConfigResponse &_tables_config_response) {
-        std::set<int64_t> authorized_table_ids;
-        for (const auto &v: _tables_config_response.tables_config_infos) {
-            if (v.__isset.table_id) {
-                authorized_table_ids.insert(v.table_id);
-            }
+std::set<int64_t> get_authorized_table_ids(const TGetTablesConfigResponse &_tables_config_response) {
+    std::set<int64_t> authorized_table_ids;
+    for (const auto &v: _tables_config_response.tables_config_infos) {
+        if (v.__isset.table_id) {
+            authorized_table_ids.insert(v.table_id);
         }
-
-        return authorized_table_ids;
     }
+
+    return authorized_table_ids;
+}
 } // namespace
 
 SchemaScanner::ColumnDesc SchemaBeTabletsScanner::_s_columns[] = {

--- a/be/src/exec/schema_scanner/schema_be_tablets_scanner.cpp
+++ b/be/src/exec/schema_scanner/schema_be_tablets_scanner.cpp
@@ -102,7 +102,7 @@ Status SchemaBeTabletsScanner::start(RuntimeState* state) {
     _infos.clear();
     auto manager = StorageEngine::instance()->tablet_manager();
     manager->get_tablets_basic_infos(_param->table_id, _param->partition_id, _param->tablet_id, _infos,
-                                     authorized_table_ids);
+                                     &authorized_table_ids);
     LOG(INFO) << strings::Substitute("get_tablets_basic_infos table_id:$0 partition:$1 tablet:$2 #info:$3",
                                      _param->table_id, _param->partition_id, _param->tablet_id, _infos.size());
     _cur_idx = 0;

--- a/be/src/exec/schema_scanner/schema_be_tablets_scanner.h
+++ b/be/src/exec/schema_scanner/schema_be_tablets_scanner.h
@@ -59,6 +59,8 @@ private:
     std::vector<TabletBasicInfo> _infos;
     size_t _cur_idx{0};
     static SchemaScanner::ColumnDesc _s_columns[];
+
+    TGetTablesConfigResponse _tables_config_response;
 };
 
 } // namespace starrocks

--- a/be/src/exec/schema_scanner/schema_fe_tablet_schedules_scanner.cpp
+++ b/be/src/exec/schema_scanner/schema_fe_tablet_schedules_scanner.cpp
@@ -67,6 +67,9 @@ Status SchemaFeTabletSchedulesScanner::start(RuntimeState* state) {
     if (_param->limit > 0) {
         request.__set_limit(_param->limit);
     }
+    if (nullptr != _param->current_user_ident) {
+        request.__set_current_user_ident(*(_param->current_user_ident));
+    }
     if (nullptr != _param->ip && 0 != _param->port) {
         RETURN_IF_ERROR(SchemaHelper::get_tablet_schedules(*(_param->ip), _param->port, request, &response));
         _infos.swap(response.tablet_schedules);

--- a/be/src/script/script.cpp
+++ b/be/src/script/script.cpp
@@ -277,7 +277,7 @@ public:
     static std::shared_ptr<TabletBasicInfo> get_tablet_info(int64_t tablet_id) {
         std::vector<TabletBasicInfo> tablet_infos;
         auto manager = StorageEngine::instance()->tablet_manager();
-        manager->get_tablets_basic_infos(-1, -1, tablet_id, tablet_infos);
+        manager->get_tablets_basic_infos(-1, -1, tablet_id, tablet_infos, nullptr);
         if (tablet_infos.empty()) {
             return nullptr;
         } else {
@@ -288,7 +288,7 @@ public:
     static std::vector<TabletBasicInfo> get_tablet_infos(int64_t table_id, int64_t partition_id) {
         std::vector<TabletBasicInfo> tablet_infos;
         auto manager = StorageEngine::instance()->tablet_manager();
-        manager->get_tablets_basic_infos(table_id, partition_id, -1, tablet_infos);
+        manager->get_tablets_basic_infos(table_id, partition_id, -1, tablet_infos, nullptr);
         return tablet_infos;
     }
 

--- a/be/src/storage/tablet_manager.cpp
+++ b/be/src/storage/tablet_manager.cpp
@@ -1522,7 +1522,7 @@ void TabletManager::get_tablets_by_partition(int64_t partition_id, std::vector<T
 
 void TabletManager::get_tablets_basic_infos(int64_t table_id, int64_t partition_id, int64_t tablet_id,
                                             std::vector<TabletBasicInfo>& tablet_infos,
-                                            std::set<int64_t> &authorized_table_ids) {
+                                            std::set<int64_t>& authorized_table_ids) {
     if (tablet_id != -1) {
         auto tablet = get_tablet(tablet_id, true, nullptr);
         if (tablet) {

--- a/be/src/storage/tablet_manager.cpp
+++ b/be/src/storage/tablet_manager.cpp
@@ -1521,7 +1521,8 @@ void TabletManager::get_tablets_by_partition(int64_t partition_id, std::vector<T
 }
 
 void TabletManager::get_tablets_basic_infos(int64_t table_id, int64_t partition_id, int64_t tablet_id,
-                                            std::vector<TabletBasicInfo>& tablet_infos) {
+                                            std::vector<TabletBasicInfo>& tablet_infos,
+                                            std::set<int64_t> &authorized_table_ids) {
     if (tablet_id != -1) {
         auto tablet = get_tablet(tablet_id, true, nullptr);
         if (tablet) {
@@ -1551,7 +1552,9 @@ void TabletManager::get_tablets_basic_infos(int64_t table_id, int64_t partition_
             std::shared_lock rlock(shard.lock);
             for (auto& itr : shard.tablet_map) {
                 auto& tablet = itr.second;
-                if (table_id == -1 || tablet->tablet_meta()->table_id() == table_id) {
+                auto table_id_in_meta = tablet->tablet_meta()->table_id();
+                if ((table_id == -1 || table_id_in_meta == table_id) &&
+                    authorized_table_ids.find(table_id_in_meta) != authorized_table_ids.end()) {
                     auto& info = tablet_infos.emplace_back();
                     tablet->get_basic_info(info);
                 }

--- a/be/src/storage/tablet_manager.cpp
+++ b/be/src/storage/tablet_manager.cpp
@@ -1522,7 +1522,7 @@ void TabletManager::get_tablets_by_partition(int64_t partition_id, std::vector<T
 
 void TabletManager::get_tablets_basic_infos(int64_t table_id, int64_t partition_id, int64_t tablet_id,
                                             std::vector<TabletBasicInfo>& tablet_infos,
-                                            std::set<int64_t>& authorized_table_ids) {
+                                            std::set<int64_t>* authorized_table_ids) {
     if (tablet_id != -1) {
         auto tablet = get_tablet(tablet_id, true, nullptr);
         if (tablet) {
@@ -1554,7 +1554,8 @@ void TabletManager::get_tablets_basic_infos(int64_t table_id, int64_t partition_
                 auto& tablet = itr.second;
                 auto table_id_in_meta = tablet->tablet_meta()->table_id();
                 if ((table_id == -1 || table_id_in_meta == table_id) &&
-                    authorized_table_ids.find(table_id_in_meta) != authorized_table_ids.end()) {
+                    (authorized_table_ids != nullptr &&
+                     authorized_table_ids->find(table_id_in_meta) != authorized_table_ids->end())) {
                     auto& info = tablet_infos.emplace_back();
                     tablet->get_basic_info(info);
                 }

--- a/be/src/storage/tablet_manager.h
+++ b/be/src/storage/tablet_manager.h
@@ -192,7 +192,8 @@ public:
     void get_tablets_by_partition(int64_t partition_id, std::vector<TabletInfo>& tablet_infos);
 
     void get_tablets_basic_infos(int64_t table_id, int64_t partition_id, int64_t tablet_id,
-                                 std::vector<TabletBasicInfo>& tablet_infos);
+                                 std::vector<TabletBasicInfo> &tablet_infos,
+                                 std::set<int64_t> &authorized_table_ids);
 
     std::vector<TabletAndScore> pick_tablets_to_do_pk_index_major_compaction();
 

--- a/be/src/storage/tablet_manager.h
+++ b/be/src/storage/tablet_manager.h
@@ -192,7 +192,7 @@ public:
     void get_tablets_by_partition(int64_t partition_id, std::vector<TabletInfo>& tablet_infos);
 
     void get_tablets_basic_infos(int64_t table_id, int64_t partition_id, int64_t tablet_id,
-                                 std::vector<TabletBasicInfo> &tablet_infos, std::set<int64_t> &authorized_table_ids);
+                                 std::vector<TabletBasicInfo>& tablet_infos, std::set<int64_t>& authorized_table_ids);
 
     std::vector<TabletAndScore> pick_tablets_to_do_pk_index_major_compaction();
 

--- a/be/src/storage/tablet_manager.h
+++ b/be/src/storage/tablet_manager.h
@@ -192,7 +192,7 @@ public:
     void get_tablets_by_partition(int64_t partition_id, std::vector<TabletInfo>& tablet_infos);
 
     void get_tablets_basic_infos(int64_t table_id, int64_t partition_id, int64_t tablet_id,
-                                 std::vector<TabletBasicInfo>& tablet_infos, std::set<int64_t>& authorized_table_ids);
+                                 std::vector<TabletBasicInfo>& tablet_infos, std::set<int64_t>* authorized_table_ids);
 
     std::vector<TabletAndScore> pick_tablets_to_do_pk_index_major_compaction();
 

--- a/be/src/storage/tablet_manager.h
+++ b/be/src/storage/tablet_manager.h
@@ -192,8 +192,7 @@ public:
     void get_tablets_by_partition(int64_t partition_id, std::vector<TabletInfo>& tablet_infos);
 
     void get_tablets_basic_infos(int64_t table_id, int64_t partition_id, int64_t tablet_id,
-                                 std::vector<TabletBasicInfo> &tablet_infos,
-                                 std::set<int64_t> &authorized_table_ids);
+                                 std::vector<TabletBasicInfo> &tablet_infos, std::set<int64_t> &authorized_table_ids);
 
     std::vector<TabletAndScore> pick_tablets_to_do_pk_index_major_compaction();
 

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/system/SystemTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/system/SystemTable.java
@@ -64,7 +64,8 @@ public class SystemTable extends Table {
     }
 
     public boolean requireOperatePrivilege() {
-        return SystemTable.isBeSchemaTable(getName()) || SystemTable.isFeSchemaTable(getName());
+        return (SystemTable.isBeSchemaTable(getName()) || SystemTable.isFeSchemaTable(getName())) &&
+                !getName().equals("be_tablets") && !getName().equals("fe_tablet_schedules");
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/clone/TabletSchedCtx.java
+++ b/fe/fe-core/src/main/java/com/starrocks/clone/TabletSchedCtx.java
@@ -1243,7 +1243,7 @@ public class TabletSchedCtx implements Comparable<TabletSchedCtx> {
         Locker locker = new Locker();
         try {
             locker.lockDatabase(db, LockType.READ);
-            Table table = db.getTable(tabletId);
+            Table table = db.getTable(tblId);
             if (table == null) {
                 return true;
             } else {

--- a/fe/fe-core/src/main/java/com/starrocks/clone/TabletSchedCtx.java
+++ b/fe/fe-core/src/main/java/com/starrocks/clone/TabletSchedCtx.java
@@ -48,6 +48,7 @@ import com.starrocks.catalog.OlapTable;
 import com.starrocks.catalog.Partition;
 import com.starrocks.catalog.Replica;
 import com.starrocks.catalog.Replica.ReplicaState;
+import com.starrocks.catalog.Table;
 import com.starrocks.clone.DiskAndTabletLoadReBalancer.BalanceType;
 import com.starrocks.clone.SchedException.Status;
 import com.starrocks.clone.TabletScheduler.PathSlot;
@@ -58,7 +59,11 @@ import com.starrocks.common.util.TimeUtils;
 import com.starrocks.common.util.concurrent.lock.LockType;
 import com.starrocks.common.util.concurrent.lock.Locker;
 import com.starrocks.persist.ReplicaPersistInfo;
+import com.starrocks.privilege.AccessDeniedException;
+import com.starrocks.privilege.PrivilegeType;
 import com.starrocks.server.GlobalStateMgr;
+import com.starrocks.sql.analyzer.Authorizer;
+import com.starrocks.sql.ast.UserIdentity;
 import com.starrocks.system.Backend;
 import com.starrocks.system.SystemInfoService;
 import com.starrocks.task.AgentTaskQueue;
@@ -1222,6 +1227,41 @@ public class TabletSchedCtx implements Comparable<TabletSchedCtx> {
         result.setClone_duration(copyTimeMs / 1000.0);
         result.setError_msg(errMsg);
         return result;
+    }
+
+    public boolean checkPrivForCurrUser(UserIdentity currentUser) {
+        // For backward compatibility
+        if (currentUser == null) {
+            return true;
+        }
+
+        Database db = GlobalStateMgr.getCurrentState().getDb(dbId);
+        if (db == null) {
+            return true;
+        }
+
+        try {
+            db.readLock();
+            Table table = db.getTable(tabletId);
+            if (table == null) {
+                return true;
+            } else {
+                // if user has 'OPERATE' privilege, can see this tablet, for backward compatibility
+                try {
+                    Authorizer.checkSystemAction(currentUser, null, PrivilegeType.OPERATE);
+                    return true;
+                } catch (AccessDeniedException ae) {
+                    try {
+                        Authorizer.checkAnyActionOnTableLikeObject(currentUser, null, db.getFullName(), table);
+                        return true;
+                    } catch (AccessDeniedException e) {
+                        return false;
+                    }
+                }
+            }
+        } finally {
+            db.readUnlock();
+        }
     }
 
     /*

--- a/fe/fe-core/src/main/java/com/starrocks/clone/TabletSchedCtx.java
+++ b/fe/fe-core/src/main/java/com/starrocks/clone/TabletSchedCtx.java
@@ -1240,8 +1240,9 @@ public class TabletSchedCtx implements Comparable<TabletSchedCtx> {
             return true;
         }
 
+        Locker locker = new Locker();
         try {
-            db.readLock();
+            locker.lockDatabase(db, LockType.READ);
             Table table = db.getTable(tabletId);
             if (table == null) {
                 return true;
@@ -1260,7 +1261,7 @@ public class TabletSchedCtx implements Comparable<TabletSchedCtx> {
                 }
             }
         } finally {
-            db.readUnlock();
+            locker.unLockDatabase(db, LockType.READ);
         }
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/common/proc/LocalTabletsProcDir.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/proc/LocalTabletsProcDir.java
@@ -144,14 +144,14 @@ public class LocalTabletsProcDir implements ProcDirInterface {
                         String metaUrl;
                         String compactionUrl;
                         if (backend != null) {
-                            metaUrl = String.format("http://%s:%s/api/meta/header/%d",
+                            metaUrl = String.format("http://%s:%d/api/meta/header/%d",
                                     hideIpPort ? "*" : backend.getHost(),
-                                    hideIpPort ? "*" : backend.getHttpPort(),
+                                    hideIpPort ? 0 : backend.getHttpPort(),
                                     tabletId);
                             compactionUrl = String.format(
-                                    "http://%s:%s/api/compaction/show?tablet_id=%d",
+                                    "http://%s:%d/api/compaction/show?tablet_id=%d",
                                     hideIpPort ? "*" : backend.getHost(),
-                                    hideIpPort ? "*" : backend.getHttpPort(),
+                                    hideIpPort ? 0 : backend.getHttpPort(),
                                     tabletId);
                         } else {
                             metaUrl = "N/A";

--- a/fe/fe-core/src/main/java/com/starrocks/common/proc/LocalTabletsProcDir.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/proc/LocalTabletsProcDir.java
@@ -93,7 +93,8 @@ public class LocalTabletsProcDir implements ProcDirInterface {
         throw new AnalysisException("Title name[" + columnName + "] does not exist");
     }
 
-    public List<List<Comparable>> fetchComparableResult(long version, long backendId, Replica.ReplicaState state) {
+    public List<List<Comparable>> fetchComparableResult(long version, long backendId, Replica.ReplicaState state,
+                                                        Boolean hideIpPort) {
         Preconditions.checkNotNull(db);
         Preconditions.checkNotNull(index);
         Preconditions.checkState(table.isOlapTableOrMaterializedView());
@@ -107,30 +108,8 @@ public class LocalTabletsProcDir implements ProcDirInterface {
             for (Tablet tablet : index.getTablets()) {
                 LocalTablet localTablet = (LocalTablet) tablet;
                 long tabletId = tablet.getId();
-                if (localTablet.getImmutableReplicas().size() == 0) {
-                    List<Comparable> tabletInfo = new ArrayList<Comparable>();
-                    tabletInfo.add(tabletId);
-                    tabletInfo.add(-1); // replica id
-                    tabletInfo.add(-1); // backend id
-                    tabletInfo.add(-1); // schema hash
-                    tabletInfo.add(-1); // version
-                    tabletInfo.add(0); // version hash
-                    tabletInfo.add(-1); // lst success version
-                    tabletInfo.add(0); // lst success version hash
-                    tabletInfo.add(-1); // lst failed version
-                    tabletInfo.add(0); // lst failed version hash
-                    tabletInfo.add(-1); // lst failed time
-                    tabletInfo.add(-1); // data size
-                    tabletInfo.add(-1); // row count
-                    tabletInfo.add(FeConstants.NULL_STRING); // state
-                    tabletInfo.add(-1); // lst consistency check time
-                    tabletInfo.add(-1); // check version
-                    tabletInfo.add(0); // check version hash
-                    tabletInfo.add(-1); // version count
-                    tabletInfo.add(-1); // path hash
-                    tabletInfo.add(FeConstants.NULL_STRING); // meta url
-                    tabletInfo.add(FeConstants.NULL_STRING); // compaction status
-
+                if (localTablet.getImmutableReplicas().isEmpty()) {
+                    List<Comparable> tabletInfo = createTabletInfo(tabletId);
                     tabletInfos.add(tabletInfo);
                 } else {
                     for (Replica replica : localTablet.getImmutableReplicas()) {
@@ -165,14 +144,14 @@ public class LocalTabletsProcDir implements ProcDirInterface {
                         String metaUrl;
                         String compactionUrl;
                         if (backend != null) {
-                            metaUrl = String.format("http://%s:%d/api/meta/header/%d",
-                                    backend.getHost(),
-                                    backend.getHttpPort(),
+                            metaUrl = String.format("http://%s:%s/api/meta/header/%d",
+                                    hideIpPort ? "*" : backend.getHost(),
+                                    hideIpPort ? "*" : backend.getHttpPort(),
                                     tabletId);
                             compactionUrl = String.format(
-                                    "http://%s:%d/api/compaction/show?tablet_id=%d",
-                                    backend.getHost(),
-                                    backend.getHttpPort(),
+                                    "http://%s:%s/api/compaction/show?tablet_id=%d",
+                                    hideIpPort ? "*" : backend.getHost(),
+                                    hideIpPort ? "*" : backend.getHttpPort(),
                                     tabletId);
                         } else {
                             metaUrl = "N/A";
@@ -191,8 +170,34 @@ public class LocalTabletsProcDir implements ProcDirInterface {
         return tabletInfos;
     }
 
+    private static List<Comparable> createTabletInfo(long tabletId) {
+        List<Comparable> tabletInfo = new ArrayList<Comparable>();
+        tabletInfo.add(tabletId);
+        tabletInfo.add(-1); // replica id
+        tabletInfo.add(-1); // backend id
+        tabletInfo.add(-1); // schema hash
+        tabletInfo.add(-1); // version
+        tabletInfo.add(0); // version hash
+        tabletInfo.add(-1); // lst success version
+        tabletInfo.add(0); // lst success version hash
+        tabletInfo.add(-1); // lst failed version
+        tabletInfo.add(0); // lst failed version hash
+        tabletInfo.add(-1); // lst failed time
+        tabletInfo.add(-1); // data size
+        tabletInfo.add(-1); // row count
+        tabletInfo.add(FeConstants.NULL_STRING); // state
+        tabletInfo.add(-1); // lst consistency check time
+        tabletInfo.add(-1); // check version
+        tabletInfo.add(0); // check version hash
+        tabletInfo.add(-1); // version count
+        tabletInfo.add(-1); // path hash
+        tabletInfo.add(FeConstants.NULL_STRING); // meta url
+        tabletInfo.add(FeConstants.NULL_STRING); // compaction status
+        return tabletInfo;
+    }
+
     private List<List<Comparable>> fetchComparableResult() {
-        return fetchComparableResult(-1, -1, null);
+        return fetchComparableResult(-1, -1, null, false);
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/common/proc/ReplicasProcNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/proc/ReplicasProcNode.java
@@ -36,9 +36,18 @@ package com.starrocks.common.proc;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import com.starrocks.catalog.Database;
+import com.starrocks.catalog.InternalCatalog;
+import com.starrocks.catalog.OlapTable;
 import com.starrocks.catalog.Replica;
+import com.starrocks.common.Pair;
 import com.starrocks.common.util.TimeUtils;
+import com.starrocks.privilege.AccessDeniedException;
+import com.starrocks.privilege.ObjectType;
+import com.starrocks.privilege.PrivilegeType;
+import com.starrocks.qe.ConnectContext;
 import com.starrocks.server.GlobalStateMgr;
+import com.starrocks.sql.analyzer.Authorizer;
 import com.starrocks.system.Backend;
 
 import java.util.Arrays;
@@ -58,18 +67,42 @@ public class ReplicasProcNode implements ProcNodeInterface {
             .add("CompactionStatus").add("IsErrorState")
             .build();
 
-    private long tabletId;
-    private List<Replica> replicas;
+    private final long tabletId;
+    private final List<Replica> replicas;
+    private final Database db;
+    private final OlapTable table;
 
     public ReplicasProcNode(long tabletId, List<Replica> replicas) {
+        this.db = null;
+        this.table = null;
+        this.tabletId = tabletId;
+        this.replicas = replicas;
+    }
+
+    public ReplicasProcNode(Database db, OlapTable table, long tabletId, List<Replica> replicas) {
+        this.db = db;
+        this.table = table;
         this.tabletId = tabletId;
         this.replicas = replicas;
     }
 
     @Override
     public ProcResult fetchResult() {
-        ImmutableMap<Long, Backend> backendMap = GlobalStateMgr.getCurrentState().getNodeMgr().getClusterInfo().getIdToBackend();
+        Boolean hideIpPort = false;
+        if (db != null && table != null) {
+            Pair<Boolean, Boolean> privResult = Authorizer.checkPrivForShowTablet(
+                    ConnectContext.get(), db.getFullName(), table);
+            if (!privResult.first) {
+                ConnectContext connectContext = ConnectContext.get();
+                AccessDeniedException.reportAccessDenied(
+                        InternalCatalog.DEFAULT_INTERNAL_CATALOG_NAME,
+                        connectContext.getCurrentUserIdentity(), connectContext.getCurrentRoleIds(),
+                        PrivilegeType.ANY.name(), ObjectType.TABLE.name(), null);
+            }
+            hideIpPort = privResult.second;
+        }
 
+        ImmutableMap<Long, Backend> backendMap = GlobalStateMgr.getCurrentState().getNodeMgr().getClusterInfo().getIdToBackend();
         BaseProcResult result = new BaseProcResult();
         result.setNames(TITLE_NAMES);
         for (Replica replica : replicas) {
@@ -78,13 +111,13 @@ public class ReplicasProcNode implements ProcNodeInterface {
             Backend backend = backendMap.get(replica.getBackendId());
             if (backend != null) {
                 metaUrl = String.format("http://%s:%d/api/meta/header/%d",
-                        backend.getHost(),
-                        backend.getHttpPort(),
+                        hideIpPort ? "*" : backend.getHost(),
+                        hideIpPort ? 0 : backend.getHttpPort(),
                         tabletId);
                 compactionUrl = String.format(
                         "http://%s:%d/api/compaction/show?tablet_id=%d&schema_hash=%d",
-                        backend.getHost(),
-                        backend.getHttpPort(),
+                        hideIpPort ? "*" : backend.getHost(),
+                        hideIpPort ? 0 : backend.getHttpPort(),
                         tabletId,
                         replica.getSchemaHash());
             } else {

--- a/fe/fe-core/src/main/java/com/starrocks/qe/ShowExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/ShowExecutor.java
@@ -282,7 +282,7 @@ public class ShowExecutor {
         metadataMgr = GlobalStateMgr.getCurrentState().getMetadataMgr();
     }
 
-    public ShowResultSet execute() throws AnalysisException, DdlException, AccessDeniedException {
+    public ShowResultSet execute() throws AnalysisException, DdlException {
         if (stmt instanceof ShowMaterializedViewsStmt) {
             handleShowMaterializedView();
         } else if (stmt instanceof ShowAuthorStmt) {
@@ -1862,7 +1862,7 @@ public class ShowExecutor {
         resultSet = new ShowResultSet(showStmt.getMetaData(), rows);
     }
 
-    private void handleShowTablet() throws AnalysisException, AccessDeniedException {
+    private void handleShowTablet() throws AnalysisException {
         ShowTabletStmt showStmt = (ShowTabletStmt) stmt;
         List<List<String>> rows = Lists.newArrayList();
 
@@ -1901,7 +1901,10 @@ public class ShowExecutor {
                     tableName = table.getName();
                     Pair<Boolean, Boolean> privResult = Authorizer.checkPrivForShowTablet(connectContext, dbName, table);
                     if (!privResult.first) {
-                        throw new AccessDeniedException(
+                        // TODO(yiming): Refactor it, throw AccessDeniedException. We throw RuntimeException here,
+                        //  because the caller of this method is not prepared to handle AccessDeniedException,
+                        //  and change the it will incur a lot of chain modification.
+                        throw new RuntimeException(
                                 ErrorReport.reportCommon(null, ErrorCode.ERR_SPECIFIC_ACCESS_DENIED_ERROR,
                                         "ANY ON TABLE/MV OBJECT"));
                     }
@@ -1975,7 +1978,8 @@ public class ShowExecutor {
                 Pair<Boolean, Boolean> privResult = Authorizer.checkPrivForShowTablet(
                         connectContext, db.getFullName(), table);
                 if (!privResult.first) {
-                    throw new AccessDeniedException(
+                    // TODO(yiming): Refactor it, throw AccessDeniedException.
+                    throw new RuntimeException(
                             ErrorReport.reportCommon(null, ErrorCode.ERR_SPECIFIC_ACCESS_DENIED_ERROR,
                                     "ANY ON TABLE/MV OBJECT"));
                 }

--- a/fe/fe-core/src/main/java/com/starrocks/qe/ShowExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/ShowExecutor.java
@@ -1901,12 +1901,10 @@ public class ShowExecutor {
                     tableName = table.getName();
                     Pair<Boolean, Boolean> privResult = Authorizer.checkPrivForShowTablet(connectContext, dbName, table);
                     if (!privResult.first) {
-                        // TODO(yiming): Refactor it, throw AccessDeniedException. We throw RuntimeException here,
-                        //  because the caller of this method is not prepared to handle AccessDeniedException,
-                        //  and change the it will incur a lot of chain modification.
-                        throw new RuntimeException(
-                                ErrorReport.reportCommon(null, ErrorCode.ERR_SPECIFIC_ACCESS_DENIED_ERROR,
-                                        "ANY ON TABLE/MV OBJECT"));
+                        AccessDeniedException.reportAccessDenied(
+                                InternalCatalog.DEFAULT_INTERNAL_CATALOG_NAME,
+                                connectContext.getCurrentUserIdentity(), connectContext.getCurrentRoleIds(),
+                                PrivilegeType.ANY.name(), ObjectType.TABLE.name(), null);
                     }
 
                     OlapTable olapTable = (OlapTable) table;
@@ -1978,10 +1976,10 @@ public class ShowExecutor {
                 Pair<Boolean, Boolean> privResult = Authorizer.checkPrivForShowTablet(
                         connectContext, db.getFullName(), table);
                 if (!privResult.first) {
-                    // TODO(yiming): Refactor it, throw AccessDeniedException.
-                    throw new RuntimeException(
-                            ErrorReport.reportCommon(null, ErrorCode.ERR_SPECIFIC_ACCESS_DENIED_ERROR,
-                                    "ANY ON TABLE/MV OBJECT"));
+                    AccessDeniedException.reportAccessDenied(
+                            InternalCatalog.DEFAULT_INTERNAL_CATALOG_NAME,
+                            connectContext.getCurrentUserIdentity(), connectContext.getCurrentRoleIds(),
+                            PrivilegeType.ANY.name(), ObjectType.TABLE.name(), null);
                 }
                 Boolean hideIpPort = privResult.second;
 

--- a/fe/fe-core/src/main/java/com/starrocks/qe/StmtExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/StmtExecutor.java
@@ -1512,7 +1512,7 @@ public class StmtExecutor {
     }
 
     // Process show statement
-    private void handleShow() throws IOException, AnalysisException, DdlException, AccessDeniedException {
+    private void handleShow() throws IOException, AnalysisException, DdlException {
         ShowExecutor executor = new ShowExecutor(context, (ShowStmt) parsedStmt);
         ShowResultSet resultSet = executor.execute();
         if (resultSet == null) {

--- a/fe/fe-core/src/main/java/com/starrocks/qe/StmtExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/StmtExecutor.java
@@ -1512,7 +1512,7 @@ public class StmtExecutor {
     }
 
     // Process show statement
-    private void handleShow() throws IOException, AnalysisException, DdlException {
+    private void handleShow() throws IOException, AnalysisException, DdlException, AccessDeniedException {
         ShowExecutor executor = new ShowExecutor(context, (ShowStmt) parsedStmt);
         ShowResultSet resultSet = executor.execute();
         if (resultSet == null) {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/Authorizer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/Authorizer.java
@@ -24,6 +24,7 @@ import com.starrocks.catalog.Function;
 import com.starrocks.catalog.InternalCatalog;
 import com.starrocks.catalog.Table;
 import com.starrocks.common.Config;
+import com.starrocks.common.Pair;
 import com.starrocks.privilege.AccessControlProvider;
 import com.starrocks.privilege.AccessController;
 import com.starrocks.privilege.AccessDeniedException;
@@ -384,5 +385,29 @@ public class Authorizer {
     public static Expr getRowAccessPolicy(ConnectContext currentUser, TableName tableName) {
         String catalog = tableName.getCatalog() == null ? InternalCatalog.DEFAULT_INTERNAL_CATALOG_NAME : tableName.getCatalog();
         return getInstance().getAccessControlOrDefault(catalog).getRowAccessPolicy(currentUser, tableName);
+    }
+
+    /**
+     * check privilege for `show tablet` statement
+     * if current user has 'OPERATE' privilege, it will result all the result
+     * otherwise it will only return to the user on which it has any privilege on the corresponding table
+     *
+     * @return `Pair.first` means that whether user can see this tablet, `Pair.second` means
+     * whether we need to hide the ip and port in the returned result
+     */
+    public static Pair<Boolean, Boolean> checkPrivForShowTablet(ConnectContext context, String dbName, Table table) {
+        UserIdentity currentUser = context.getCurrentUserIdentity();
+        // if user has 'OPERATE' privilege, can see this tablet, for backward compatibility
+        try {
+            Authorizer.checkSystemAction(currentUser, null, PrivilegeType.OPERATE);
+            return new Pair<>(true, false);
+        } catch (AccessDeniedException ae) {
+            try {
+                Authorizer.checkAnyActionOnTableLikeObject(currentUser, null, dbName, table);
+                return new Pair<>(true, true);
+            } catch (AccessDeniedException e) {
+                return new Pair<>(false, true);
+            }
+        }
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AuthorizerStmtVisitor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AuthorizerStmtVisitor.java
@@ -217,7 +217,7 @@ import java.util.regex.Pattern;
 public class AuthorizerStmtVisitor extends AstVisitor<Void, ConnectContext> {
     // For show tablet detail command, if user has any privilege on the corresponding table, user can run it
     // TODO(yiming): match "/dbs", not only show tablet detail cmd, need to change privilege check for other proc node
-    private static final Pattern showTabletDetailCmdPattern =
+    private static final Pattern SHOW_TABLET_DETAIL_CMD_PATTERN =
             Pattern.compile("/dbs/\\d+/\\d+/partitions/\\d+/\\d+/\\d+/?");
 
     public AuthorizerStmtVisitor() {
@@ -1921,7 +1921,7 @@ public class AuthorizerStmtVisitor extends AstVisitor<Void, ConnectContext> {
     @Override
     public Void visitShowProcStmt(ShowProcStmt statement, ConnectContext context) {
         try {
-            if (!showTabletDetailCmdPattern.matcher(statement.getPath()).matches()) {
+            if (!SHOW_TABLET_DETAIL_CMD_PATTERN.matcher(statement.getPath()).matches()) {
                 Authorizer.checkSystemAction(context.getCurrentUserIdentity(), context.getCurrentRoleIds(),
                         PrivilegeType.OPERATE);
             }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AuthorizerStmtVisitor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AuthorizerStmtVisitor.java
@@ -212,8 +212,12 @@ import com.starrocks.sql.ast.pipe.ShowPipeStmt;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.regex.Pattern;
 
 public class AuthorizerStmtVisitor extends AstVisitor<Void, ConnectContext> {
+    // For show tablet detail command, if user has any privilege on the corresponding table, user can run it
+    // TODO(yiming): match "/dbs", not only show tablet detail cmd, need to change privilege check for other proc node
+    private static final Pattern showTabletDetailCmdPattern = Pattern.compile("/dbs/\\d+/\\d+/partitions/\\d+/\\d+/\\d+/?");
 
     public AuthorizerStmtVisitor() {
     }
@@ -286,9 +290,24 @@ public class AuthorizerStmtVisitor extends AstVisitor<Void, ConnectContext> {
     void checkSelectTableAction(ConnectContext context, Map<TableName, Relation> allTouchedTables) {
         for (Map.Entry<TableName, Relation> tableToBeChecked : allTouchedTables.entrySet()) {
             TableName tableName = tableToBeChecked.getKey();
+<<<<<<< HEAD
             Table table;
             if (tableToBeChecked.getValue() instanceof TableRelation) {
                 table = ((TableRelation) tableToBeChecked.getValue()).getTable();
+=======
+            Table table = tableToBeChecked.getValue();
+
+            if (table instanceof View) {
+                Authorizer.checkViewAction(context.getCurrentUserIdentity(), context.getCurrentRoleIds(),
+                        tableName, PrivilegeType.SELECT);
+
+            } else if (table instanceof SystemTable && ((SystemTable) table).requireOperatePrivilege()) {
+                Authorizer.checkSystemAction(context.getCurrentUserIdentity(), context.getCurrentRoleIds(),
+                        PrivilegeType.OPERATE);
+            } else if (table.isMaterializedView()) {
+                Authorizer.checkMaterializedViewAction(context.getCurrentUserIdentity(), context.getCurrentRoleIds(),
+                        tableName, PrivilegeType.SELECT);
+>>>>>>> ed501fa03e ([Enhancement] Refine the priv check for be_tablets and show tablet)
             } else {
                 table = ((ViewRelation) tableToBeChecked.getValue()).getView();
             }
@@ -1770,14 +1789,7 @@ public class AuthorizerStmtVisitor extends AstVisitor<Void, ConnectContext> {
 
     @Override
     public Void visitShowTabletStatement(ShowTabletStmt statement, ConnectContext context) {
-        try {
-            Authorizer.checkSystemAction(context.getCurrentUserIdentity(), context.getCurrentRoleIds(), PrivilegeType.OPERATE);
-        } catch (AccessDeniedException e) {
-            AccessDeniedException.reportAccessDenied(
-                    InternalCatalog.DEFAULT_INTERNAL_CATALOG_NAME,
-                    context.getCurrentUserIdentity(), context.getCurrentRoleIds(),
-                    PrivilegeType.OPERATE.name(), ObjectType.SYSTEM.name(), null);
-        }
+        // Privilege is checked in execution logic, see `ShowExecutor#handleShowTablet()` for details.
         return null;
     }
 
@@ -1922,6 +1934,7 @@ public class AuthorizerStmtVisitor extends AstVisitor<Void, ConnectContext> {
 
     @Override
     public Void visitShowProcStmt(ShowProcStmt statement, ConnectContext context) {
+<<<<<<< HEAD
         try {
             Authorizer.checkSystemAction(context.getCurrentUserIdentity(), context.getCurrentRoleIds(), PrivilegeType.OPERATE);
         } catch (AccessDeniedException e) {
@@ -1929,6 +1942,11 @@ public class AuthorizerStmtVisitor extends AstVisitor<Void, ConnectContext> {
                     InternalCatalog.DEFAULT_INTERNAL_CATALOG_NAME,
                     context.getCurrentUserIdentity(), context.getCurrentRoleIds(),
                     PrivilegeType.OPERATE.name(), ObjectType.SYSTEM.name(), null);
+=======
+        if (!showTabletDetailCmdPattern.matcher(statement.getPath()).matches()) {
+            Authorizer.checkSystemAction(context.getCurrentUserIdentity(), context.getCurrentRoleIds(),
+                    PrivilegeType.OPERATE);
+>>>>>>> ed501fa03e ([Enhancement] Refine the priv check for be_tablets and show tablet)
         }
         return null;
     }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AuthorizerStmtVisitor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AuthorizerStmtVisitor.java
@@ -217,7 +217,8 @@ import java.util.regex.Pattern;
 public class AuthorizerStmtVisitor extends AstVisitor<Void, ConnectContext> {
     // For show tablet detail command, if user has any privilege on the corresponding table, user can run it
     // TODO(yiming): match "/dbs", not only show tablet detail cmd, need to change privilege check for other proc node
-    private static final Pattern showTabletDetailCmdPattern = Pattern.compile("/dbs/\\d+/\\d+/partitions/\\d+/\\d+/\\d+/?");
+    private static final Pattern showTabletDetailCmdPattern =
+            Pattern.compile("/dbs/\\d+/\\d+/partitions/\\d+/\\d+/\\d+/?");
 
     public AuthorizerStmtVisitor() {
     }
@@ -290,24 +291,9 @@ public class AuthorizerStmtVisitor extends AstVisitor<Void, ConnectContext> {
     void checkSelectTableAction(ConnectContext context, Map<TableName, Relation> allTouchedTables) {
         for (Map.Entry<TableName, Relation> tableToBeChecked : allTouchedTables.entrySet()) {
             TableName tableName = tableToBeChecked.getKey();
-<<<<<<< HEAD
             Table table;
             if (tableToBeChecked.getValue() instanceof TableRelation) {
                 table = ((TableRelation) tableToBeChecked.getValue()).getTable();
-=======
-            Table table = tableToBeChecked.getValue();
-
-            if (table instanceof View) {
-                Authorizer.checkViewAction(context.getCurrentUserIdentity(), context.getCurrentRoleIds(),
-                        tableName, PrivilegeType.SELECT);
-
-            } else if (table instanceof SystemTable && ((SystemTable) table).requireOperatePrivilege()) {
-                Authorizer.checkSystemAction(context.getCurrentUserIdentity(), context.getCurrentRoleIds(),
-                        PrivilegeType.OPERATE);
-            } else if (table.isMaterializedView()) {
-                Authorizer.checkMaterializedViewAction(context.getCurrentUserIdentity(), context.getCurrentRoleIds(),
-                        tableName, PrivilegeType.SELECT);
->>>>>>> ed501fa03e ([Enhancement] Refine the priv check for be_tablets and show tablet)
             } else {
                 table = ((ViewRelation) tableToBeChecked.getValue()).getView();
             }
@@ -1934,19 +1920,16 @@ public class AuthorizerStmtVisitor extends AstVisitor<Void, ConnectContext> {
 
     @Override
     public Void visitShowProcStmt(ShowProcStmt statement, ConnectContext context) {
-<<<<<<< HEAD
         try {
-            Authorizer.checkSystemAction(context.getCurrentUserIdentity(), context.getCurrentRoleIds(), PrivilegeType.OPERATE);
+            if (!showTabletDetailCmdPattern.matcher(statement.getPath()).matches()) {
+                Authorizer.checkSystemAction(context.getCurrentUserIdentity(), context.getCurrentRoleIds(),
+                        PrivilegeType.OPERATE);
+            }
         } catch (AccessDeniedException e) {
             AccessDeniedException.reportAccessDenied(
                     InternalCatalog.DEFAULT_INTERNAL_CATALOG_NAME,
                     context.getCurrentUserIdentity(), context.getCurrentRoleIds(),
                     PrivilegeType.OPERATE.name(), ObjectType.SYSTEM.name(), null);
-=======
-        if (!showTabletDetailCmdPattern.matcher(statement.getPath()).matches()) {
-            Authorizer.checkSystemAction(context.getCurrentUserIdentity(), context.getCurrentRoleIds(),
-                    PrivilegeType.OPERATE);
->>>>>>> ed501fa03e ([Enhancement] Refine the priv check for be_tablets and show tablet)
         }
         return null;
     }

--- a/fe/fe-core/src/test/java/com/starrocks/common/proc/LocalTabletsProcDirTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/common/proc/LocalTabletsProcDirTest.java
@@ -123,7 +123,7 @@ public class LocalTabletsProcDirTest {
 
         // Check
         LocalTabletsProcDir tabletsProcDir = new LocalTabletsProcDir(db, table, index);
-        List<List<Comparable>> result = tabletsProcDir.fetchComparableResult(-1, -1, null);
+        List<List<Comparable>> result = tabletsProcDir.fetchComparableResult(-1, -1, null, false);
         System.out.println(result);
         Assert.assertEquals(3, result.size());
         Assert.assertEquals((long) result.get(0).get(0), tablet1Id);

--- a/gensrc/thrift/FrontendService.thrift
+++ b/gensrc/thrift/FrontendService.thrift
@@ -1415,6 +1415,7 @@ struct TGetTabletScheduleRequest {
     4: optional string type
     5: optional string state
     6: optional i64 limit
+    7: optional Types.TUserIdentity current_user_ident
 }
 
 struct TGetTabletScheduleResponse {


### PR DESCRIPTION
Why I'm doing:
The original execution of `show tablet` and query on `information_schema.be_tablets`
needs OPERATE privilege, which is unreasonable.

What I'm doing:
If user has any privilege on corresponding table of the tablet, user can query that tablet,
but hide the ip:port unless user has OPERATE privilege.

Fixes #SR-19525

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [x] 3.1
  - [ ] 3.0
  - [ ] 2.5
