### PR TITLE
[BugFix] fix create index on lakemv

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/alter/LakeTableAlterJobV2Builder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/LakeTableAlterJobV2Builder.java
@@ -21,12 +21,12 @@ import com.staros.proto.FileCacheInfo;
 import com.staros.proto.FilePathInfo;
 import com.starrocks.catalog.Column;
 import com.starrocks.catalog.MaterializedIndex;
+import com.starrocks.catalog.OlapTable;
 import com.starrocks.catalog.PhysicalPartition;
 import com.starrocks.catalog.Tablet;
 import com.starrocks.catalog.TabletMeta;
 import com.starrocks.common.DdlException;
 import com.starrocks.common.UserException;
-import com.starrocks.lake.LakeTable;
 import com.starrocks.lake.LakeTablet;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.thrift.TStorageMedium;
@@ -37,9 +37,12 @@ import java.util.Map;
 import java.util.stream.Collectors;
 
 public class LakeTableAlterJobV2Builder extends AlterJobV2Builder {
-    private final LakeTable table;
 
-    public LakeTableAlterJobV2Builder(LakeTable table) {
+    // The table could be either an LakeTable or LakeMaterializedView
+    private final OlapTable table;
+
+    public LakeTableAlterJobV2Builder(OlapTable table) {
+        Preconditions.checkArgument(table.isCloudNativeTableOrMaterializedView());
         this.table = table;
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/lake/LakeMaterializedView.java
+++ b/fe/fe-core/src/main/java/com/starrocks/lake/LakeMaterializedView.java
@@ -18,6 +18,8 @@ import com.google.common.base.Preconditions;
 import com.google.common.base.Strings;
 import com.staros.proto.FileCacheInfo;
 import com.staros.proto.FilePathInfo;
+import com.starrocks.alter.AlterJobV2Builder;
+import com.starrocks.alter.LakeTableAlterJobV2Builder;
 import com.starrocks.catalog.CatalogUtils;
 import com.starrocks.catalog.Column;
 import com.starrocks.catalog.DistributionInfo;
@@ -111,6 +113,11 @@ public class LakeMaterializedView extends MaterializedView {
     public Runnable delete(boolean replay) {
         onErase(replay);
         return replay ? null : new DeleteLakeTableTask(this);
+    }
+
+    @Override
+    public AlterJobV2Builder alterTable() {
+        return new LakeTableAlterJobV2Builder(this);
     }
 
     @Override


### PR DESCRIPTION
Why I'm doing:
- Create index on top of Lake MV doesn't work
- The `LakeMaterializedView` should override the `alterTable` method to get a `LakeAlterJobV2Builder`

What I'm doing:

TODO:
- Actually `LakeMaterializedView` needs to override all methods of `LakeTable` with almost same implementations, since it doesn't inherit the `LakeTable`, which is stupid.
- We should refactor it to an abstract class and share the implementation

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [x] 3.1
  - [ ] 3.0
  - [ ] 2.5
