### PR TITLE
[Enhancement] In ORC reader, add partition and non-exist column after eval conjuncts

### DIFF
--- a/be/src/exec/hdfs_scanner.cpp
+++ b/be/src/exec/hdfs_scanner.cpp
@@ -166,7 +166,7 @@ Status HdfsScanner::get_next(RuntimeState* runtime_state, ChunkPtr* chunk) {
     RETURN_IF_ERROR(_runtime_state->check_mem_limit("get chunk from scanner"));
     Status status = do_get_next(runtime_state, chunk);
     if (status.ok()) {
-        if (!_scanner_params.conjunct_ctxs.empty() && _scanner_params.eval_conjunct_ctxs) {
+        if (!_scanner_params.conjunct_ctxs.empty()) {
             SCOPED_RAW_TIMER(&_app_stats.expr_filter_ns);
             RETURN_IF_ERROR(ExecNode::eval_conjuncts(_scanner_params.conjunct_ctxs, (*chunk).get()));
         }

--- a/be/src/exec/hdfs_scanner.h
+++ b/be/src/exec/hdfs_scanner.h
@@ -147,7 +147,6 @@ struct HdfsScannerParams {
     std::unordered_set<SlotId> slots_in_conjunct;
     // slot used by conjunct_ctxs
     std::unordered_set<SlotId> slots_of_mutli_slot_conjunct;
-    bool eval_conjunct_ctxs = true;
 
     // conjunct ctxs grouped by slot.
     std::unordered_map<SlotId, std::vector<ExprContext*>> conjunct_ctxs_by_slot;

--- a/be/src/exec/hdfs_scanner_orc.cpp
+++ b/be/src/exec/hdfs_scanner_orc.cpp
@@ -352,9 +352,6 @@ Status HdfsOrcScanner::do_open(RuntimeState* runtime_state) {
 
     // create orc reader for further reading.
     int src_slot_index = 0;
-    // we don't need to eval conjunct ctxs at outside any more
-    // we evaluate conjunct ctxs in `do_get_next`.
-    _scanner_params.eval_conjunct_ctxs = false;
     for (const auto& column : _scanner_ctx.materialized_columns) {
         auto col_name = OrcChunkReader::format_column_name(column.col_name, _scanner_ctx.case_sensitive);
         if (known_column_names.find(col_name) == known_column_names.end()) continue;
@@ -370,6 +367,16 @@ Status HdfsOrcScanner::do_open(RuntimeState* runtime_state) {
             // reserve room for later set in `OrcChunkReader`
             _lazy_load_ctx.active_load_orc_positions.emplace_back(0);
         }
+
+        // put materialized columns' conjunctions into _eval_conjunct_ctxs_by_materialized_slot
+        // for example, partition column's conjunctions will not put into _eval_conjunct_ctxs_by_materialized_slot
+        {
+            auto it = _scanner_params.conjunct_ctxs_by_slot.find(column.slot_id);
+            if (it != _scanner_params.conjunct_ctxs_by_slot.end()) {
+                _eval_conjunct_ctxs_by_materialized_slot.emplace(it->first, it->second);
+            }
+        }
+
         _src_slot_descriptors.emplace_back(column.slot_desc);
         src_slot_index++;
     }
@@ -429,9 +436,20 @@ Status HdfsOrcScanner::do_get_next(RuntimeState* runtime_state, ChunkPtr* chunk)
         return Status::EndOfFile("");
     }
 
+    ASSIGN_OR_RETURN(const size_t rows_read, _do_get_next(chunk));
+
+    DCHECK_EQ(rows_read, chunk->get()->num_rows());
+
+    _scanner_ctx.append_not_existed_columns_to_chunk(chunk, rows_read);
+    _scanner_ctx.append_or_update_partition_column_to_chunk(chunk, rows_read);
+
+    return Status::OK();
+}
+
+StatusOr<size_t> HdfsOrcScanner::_do_get_next(ChunkPtr* chunk) {
     ChunkPtr& ck = *chunk;
     // this infinite for loop is for retry.
-    for (;;) {
+    while (true) {
         orc::RowReader::ReadPosition position;
         size_t read_num_values = 0;
         bool has_used_dict_filter = false;
@@ -453,11 +471,11 @@ Status HdfsOrcScanner::do_get_next(RuntimeState* runtime_state, ChunkPtr* chunk)
             }
         }
 
-        size_t chunk_size = 0;
-        size_t init_chunk_size = 0;
+        size_t rows_read = 0;
+        size_t origin_rows_read = 0;
         if (_orc_reader->get_cvb_size() != 0) {
-            chunk_size = _orc_reader->get_cvb_size();
-            init_chunk_size = chunk_size;
+            rows_read = _orc_reader->get_cvb_size();
+            origin_rows_read = rows_read;
             {
                 StatusOr<ChunkPtr> ret;
                 SCOPED_RAW_TIMER(&_app_stats.column_convert_ns);
@@ -470,56 +488,48 @@ Status HdfsOrcScanner::do_get_next(RuntimeState* runtime_state, ChunkPtr* chunk)
                 *chunk = std::move(ret.value());
             }
 
-            // important to add columns before evaluation
-            // because ctxs_by_slot maybe refers to some non-existed slot or partition slot.
-            _scanner_ctx.append_not_existed_columns_to_chunk(chunk, chunk_size);
-            _scanner_ctx.append_or_update_partition_column_to_chunk(chunk, chunk_size);
             // do stats before we filter rows which does not match.
-            _app_stats.raw_rows_read += chunk_size;
-            _chunk_filter.assign(chunk_size, 1);
+            _app_stats.raw_rows_read += rows_read;
+            _chunk_filter.assign(rows_read, 1);
             {
                 SCOPED_RAW_TIMER(&_app_stats.expr_filter_ns);
-                for (auto& it : _scanner_ctx.conjunct_ctxs_by_slot) {
+                for (auto& it : _eval_conjunct_ctxs_by_materialized_slot) {
                     // do evaluation.
                     if (_orc_row_reader_filter->is_slot_evaluated(it.first)) {
                         continue;
                     }
-                    ASSIGN_OR_RETURN(chunk_size,
+                    ASSIGN_OR_RETURN(rows_read,
                                      ExecNode::eval_conjuncts_into_filter(it.second, ck.get(), &_chunk_filter));
-                    if (chunk_size == 0) {
+                    if (rows_read == 0) {
                         break;
                     }
                 }
-                if (chunk_size != 0) {
-                    ASSIGN_OR_RETURN(chunk_size, ExecNode::eval_conjuncts_into_filter(_scanner_params.conjunct_ctxs,
-                                                                                      ck.get(), &_chunk_filter));
-                }
             }
 
-            if (chunk_size != 0) {
+            if (rows_read != 0) {
                 ColumnHelper::merge_two_filters(row_delete_filter, &_chunk_filter, nullptr);
-                chunk_size = SIMD::count_nonzero(_chunk_filter);
+                rows_read = SIMD::count_nonzero(_chunk_filter);
             }
 
-            if (chunk_size != 0 && chunk_size != ck->num_rows()) {
+            if (rows_read != 0 && rows_read != ck->num_rows()) {
                 ck->filter(_chunk_filter);
             }
         }
-        ck->set_num_rows(chunk_size);
+        ck->set_num_rows(rows_read);
 
         if (!_orc_reader->has_lazy_load_context()) {
-            return Status::OK();
+            return rows_read;
         }
 
         // if has lazy load fields, skip it if chunk_size == 0
-        bool require_load_lazy_columns = chunk_size != 0;
+        bool require_load_lazy_columns = rows_read > 0;
         if (require_load_lazy_columns) {
             // still need to load lazy column
             _scanner_ctx.lazy_column_coalesce_counter->fetch_add(1, std::memory_order_relaxed);
         } else {
             // dont need to load lazy column
             _scanner_ctx.lazy_column_coalesce_counter->fetch_sub(1, std::memory_order_relaxed);
-            _app_stats.late_materialize_skip_rows += init_chunk_size;
+            _app_stats.late_materialize_skip_rows += origin_rows_read;
             continue;
         }
 
@@ -539,10 +549,9 @@ Status HdfsOrcScanner::do_get_next(RuntimeState* runtime_state, ChunkPtr* chunk)
             Chunk& ret_ck = *(ret.value());
             ck->merge(std::move(ret_ck));
         }
-        return Status::OK();
+        return rows_read;
     }
-    __builtin_unreachable();
-    return Status::OK();
+    return Status::InternalError("Unreachable code");
 }
 
 Status HdfsOrcScanner::do_init(RuntimeState* runtime_state, const HdfsScannerParams& scanner_params) {

--- a/be/src/exec/hdfs_scanner_orc.h
+++ b/be/src/exec/hdfs_scanner_orc.h
@@ -37,11 +37,17 @@ public:
     void disable_use_orc_sargs() { _use_orc_sargs = false; }
 
 private:
+    StatusOr<size_t> _do_get_next(ChunkPtr* chunk);
+
     // it means if we can skip this file without reading.
     // Normally it happens when we peek file column statistics,
     // and if we are sure there is no row matches, we can skip this file.
     // by skipping this file, we return EOF when client try to get chunk.
     bool _should_skip_file;
+
+    // hdfs_scanner_orc will only eval conjunctions in _eval_conjunct_ctxs_by_materialized_slot
+    // _eval_conjunct_ctxs_by_materialized_slot's slot must be existed in orc file
+    std::unordered_map<SlotId, std::vector<ExprContext*>> _eval_conjunct_ctxs_by_materialized_slot{};
 
     // disable orc search argument would be much easier for
     // writing unittest of customized filter


### PR DESCRIPTION
Why I'm doing:
Add partition column in a heavy operation in data lake, because most partition columns are string.
![gxlgxl_dictionary](https://github.com/StarRocks/starrocks/assets/18729228/4afe25c6-3a73-4ee7-a14b-aaafb6d56cb4)

If the user's predicates have greater selectivity, the cost of adding the partition column is unnecessary.

What I'm doing:

Add partition column after eval conjuncts.


## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
