### PR TITLE
[BugFix] decrease the cross join penalty factor in cost model

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/cost/CostModel.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/cost/CostModel.java
@@ -411,15 +411,13 @@ public class CostModel {
             double leftSize = leftStatistics.getOutputSize(context.getChildOutputColumns(0));
             double rightSize = rightStatistics.getOutputSize(context.getChildOutputColumns(1));
 
-            long crossJoinCostPenalty = ConnectContext.get().getSessionVariable().getCrossJoinCostPenalty();
-
             double cpuCost = StatisticUtils.multiplyOutputSize(StatisticUtils.multiplyOutputSize(leftSize, rightSize),
                     EXECUTE_COST_PENALTY);
             double memCost = StatisticUtils.multiplyOutputSize(rightSize, EXECUTE_COST_PENALTY * 100D);
 
 
             if (join.getJoinType().isCrossJoin()) {
-                cpuCost = StatisticUtils.multiplyOutputSize(cpuCost, crossJoinCostPenalty);
+                cpuCost = StatisticUtils.multiplyOutputSize(cpuCost, EXECUTE_COST_PENALTY);
             }
             // Right cross join could not be parallelized, so apply more punishment
             if (join.getJoinType().isRightJoin()) {


### PR DESCRIPTION
Why I'm doing:
The resource group relies on the final plancpucost value of the cost model to distinguish queries. A relative large cross join penalty factor in cross join may affect the final plancpucost result.

What I'm doing:
decrease the cross join penalty factor in cost model. 
Our join transformation rules avoid the occurrence of new cross joins in newly generated optExpression during the transformation process. Therefore, it is acceptable to decrease the cross join penalty factor in cost model.

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [x] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [x] 3.1
  - [x] 3.0
  - [ ] 2.5
