### PR TITLE
[BugFix] fix retrieve StorageVolume fail when replaying alter mv

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/alter/AlterJobMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/AlterJobMgr.java
@@ -290,7 +290,7 @@ public class AlterJobMgr {
             context.setCurrentUserIdentity(UserIdentity.ROOT);
             context.setCurrentRoleIds(Sets.newHashSet(PrivilegeBuiltinConstants.ROOT_ROLE_ID));
 
-            String createMvSql = materializedView.getMaterializedViewDdlStmt(false);
+            String createMvSql = materializedView.getMaterializedViewDdlStmt(false, isReplay);
             QueryStatement mvQueryStatement = null;
             try {
                 mvQueryStatement = recreateMVQuery(materializedView, context, createMvSql);

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/MaterializedView.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/MaterializedView.java
@@ -1060,6 +1060,10 @@ public class MaterializedView extends OlapTable implements GsonPreProcessable, G
     }
 
     public String getMaterializedViewDdlStmt(boolean simple) {
+        return getMaterializedViewDdlStmt(simple, false);
+    }
+
+    public String getMaterializedViewDdlStmt(boolean simple, boolean isReplay) {
         StringBuilder sb = new StringBuilder();
         sb.append("CREATE MATERIALIZED VIEW `").append(getName()).append("` (");
         List<String> colDef = Lists.newArrayList();
@@ -1168,7 +1172,10 @@ public class MaterializedView extends OlapTable implements GsonPreProcessable, G
                 sb.append("\"").append(value).append("\"");
             }
         }
-        if (!hasStorageMedium) {
+        // NOTE: why not append unique properties when replaying ?
+        // Actually we don't need any properties of MV when replaying, but only the schema information
+        // And in ShareData mode, the storage_volume property cannot be retrieved in the Checkpointer thread
+        if (!hasStorageMedium && !isReplay) {
             appendUniqueProperties(sb);
         }
 


### PR DESCRIPTION
Why I'm doing:
![image](https://github.com/StarRocks/starrocks/assets/96611012/86177f20-c8e6-4b76-9a71-305829835338)


What I'm doing:
- Avoid access the `StorageVolumeMgr` in Checkpointer thread when replaying `AlterMaterializedViewStatus`

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [x] 3.1
  - [ ] 3.0
  - [ ] 2.5
