### PR TITLE
[BugFix] Fix bug show columns does not filter by table

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/ShowColumnStmt.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/ShowColumnStmt.java
@@ -170,8 +170,11 @@ public class ShowColumnStmt extends ShowStmt {
 
         where = where.substitute(aliasMap);
         where = new CompoundPredicate(CompoundPredicate.Operator.AND, where,
-                new BinaryPredicate(BinaryType.EQ, new SlotRef(TABLE_NAME, "TABLE_SCHEMA"),
-                        new StringLiteral(tableName.getDb())));
+                new CompoundPredicate(CompoundPredicate.Operator.AND,
+                        new BinaryPredicate(BinaryType.EQ, new SlotRef(TABLE_NAME, "TABLE_NAME"),
+                                new StringLiteral(tableName.getTbl())),
+                        new BinaryPredicate(BinaryType.EQ, new SlotRef(TABLE_NAME, "TABLE_SCHEMA"),
+                                new StringLiteral(tableName.getDb()))));
         return new QueryStatement(new SelectRelation(selectList, new TableRelation(TABLE_NAME),
                 where, null, null), this.origStmt);
     }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AnalyzeShowTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AnalyzeShowTest.java
@@ -118,7 +118,8 @@ public class AnalyzeShowTest {
                         "information_schema.COLUMNS.COLUMN_DEFAULT AS Default, " +
                         "information_schema.COLUMNS.EXTRA AS Extra " +
                         "FROM information_schema.COLUMNS WHERE (information_schema.COLUMNS.COLUMN_NAME = 'v1') " +
-                        "AND (information_schema.COLUMNS.TABLE_SCHEMA = 'test')",
+                        "AND ((information_schema.COLUMNS.TABLE_NAME = 't1') " +
+                        "AND (information_schema.COLUMNS.TABLE_SCHEMA = 'test'))",
                 AstToStringBuilder.toString(statement.toSelectStmt()));
     }
 

--- a/test/sql/test_show/R/test_show_column
+++ b/test/sql/test_show/R/test_show_column
@@ -21,6 +21,19 @@ PROPERTIES (
 );
 -- result:
 -- !result
+CREATE TABLE site_access2(
+    event_day DATE,
+    site_id INT DEFAULT '10',
+    city_code VARCHAR(100),
+    user_name VARCHAR(32) DEFAULT '',
+    pv BIGINT SUM DEFAULT '0'
+)
+DISTRIBUTED BY HASH(site_id)
+PROPERTIES (
+  "replication_num" = "1"
+);
+-- result:
+-- !result
 use test_show2;
 -- result:
 -- !result

--- a/test/sql/test_show/T/test_show_column
+++ b/test/sql/test_show/T/test_show_column
@@ -13,6 +13,17 @@ DISTRIBUTED BY HASH(site_id)
 PROPERTIES (
   "replication_num" = "1"
 );
+CREATE TABLE site_access2(
+    event_day DATE,
+    site_id INT DEFAULT '10',
+    city_code VARCHAR(100),
+    user_name VARCHAR(32) DEFAULT '',
+    pv BIGINT SUM DEFAULT '0'
+)
+DISTRIBUTED BY HASH(site_id)
+PROPERTIES (
+  "replication_num" = "1"
+);
 use test_show2;
 CREATE TABLE site_access(
     event_day DATE,


### PR DESCRIPTION
Why I'm doing:
show columns from xx whre does not filter based on table. If same db different table have same column, many identical fields will appear, which is confusing.

What I'm doing:
This essence is converted into select information_schema.columns, and adding table_schema to filter out db is correct.

Fixes https://github.com/StarRocks/StarRocksTest/issues/5802

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [x] 3.1
  - [x] 3.0
  - [x] 2.5
