### PR TITLE
[Enhancement] Make error message more clear of table function

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/TableFunctionTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/TableFunctionTable.java
@@ -236,7 +236,8 @@ public class TableFunctionTable extends Table {
             }
         } catch (UserException e) {
             LOG.error("parse files error", e);
-            throw new DdlException("failed to parse files", e);
+            String errorMsg = "failed to parse files. You may give a wrong url, please check it. " + path;
+            throw new DdlException(errorMsg, e);
         }
 
         if (fileStatuses.isEmpty()) {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/StorageAccessException.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/StorageAccessException.java
@@ -23,9 +23,11 @@ import org.apache.commons.lang.exception.ExceptionUtils;
  * Access remote storage(s3/gcs/oss/hdfs) exception
  */
 public class StorageAccessException extends RuntimeException {
+    private Throwable e;
 
     public StorageAccessException(Throwable e) {
         super(e);
+        this.e = e;
     }
 
     public Throwable getRootCause() {
@@ -43,7 +45,7 @@ public class StorageAccessException extends RuntimeException {
         } else if (rootCause instanceof DdlException) {
             builder.append("Error message: ").append(rootCause.getMessage());
         } else {
-            builder.append("Unknown error");
+            builder.append("Error message: ").append(e.getMessage());
         }
         // TODO: translate error message of other storage systems
         return builder.toString();


### PR DESCRIPTION
Why I'm doing:
If user set a wrong path URL, FE will complain like below. This is very misleading.
![image_1705999659015_0](https://github.com/StarRocks/starrocks/assets/45813655/6c2a2c23-cb2e-496a-8c92-682b4f2d024f)

What I'm doing:
Fix it. The error message will be like below:
![image_1706000238797_0](https://github.com/StarRocks/starrocks/assets/45813655/ad110d34-31ea-4f75-9e1d-d97add7e0b86)

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [x] 3.1
  - [ ] 3.0
  - [ ] 2.5
