### PR TITLE
[BugFix] Not ignore the leading space when parse delete predicate value

### DIFF
--- a/be/src/storage/delete_handler.cpp
+++ b/be/src/storage/delete_handler.cpp
@@ -217,12 +217,12 @@ bool DeleteHandler::parse_condition(const std::string& condition_str, TCondition
 
     try {
         // Condition string format
-        // eg:  condition_str="c1 = 1597751948193618247  and length(source)<1;\n;\n"
+        // eg:  condition_str="c1= 1597751948193618247  and length(source)<1;\n;\n"
         //  group1:  ([^\0=<>!\*]{1,64}) matches "c1"
         //  group2:  ((?:=)|(?:!=)|(?:>>)|(?:<<)|(?:>=)|(?:<=)|(?:\*=)|(?:IS)) matches  "="
-        //  group3:  ((?:[\s\S]+)?) matches "1597751948193618247  and length(source)<1;\n;\n"
+        //  group3:  ((?:[\s\S]+)?) matches " 1597751948193618247  and length(source)<1;\n;\n"
         const char* const CONDITION_STR_PATTERN =
-                R"(([^\0=<>!\*]{1,64})\s*((?:=)|(?:!=)|(?:>>)|(?:<<)|(?:>=)|(?:<=)|(?:\*=)|(?: IS ))\s*((?:[\s\S]+)?))";
+                R"(([^\0=<>!\*]{1,64})((?:=)|(?:!=)|(?:>>)|(?:<<)|(?:>=)|(?:<=)|(?:\*=)|(?: IS ))((?:[\s\S]+)?))";
         regex ex(CONDITION_STR_PATTERN);
         if (regex_match(condition_str, what, ex)) {
             if (condition_str.size() != what[0].str().size()) {

--- a/be/test/storage/delete_handler_test.cpp
+++ b/be/test/storage/delete_handler_test.cpp
@@ -196,6 +196,12 @@ void set_key_columns(TCreateTabletReq* request) {
     k13.__set_is_key(true);
     set_varchar_type(&k13, TPrimitiveType::CHAR, 64);
     request->tablet_schema.columns.push_back(k13);
+
+    TColumn k14;
+    k14.column_name = "k14";
+    k14.__set_is_key(true);
+    set_varchar_type(&k14, TPrimitiveType::VARCHAR, 64);
+    request->tablet_schema.columns.push_back(k14);
 }
 
 void set_default_create_tablet_request(TCreateTabletReq* request) {
@@ -330,24 +336,74 @@ TEST_F(TestDeleteConditionHandler, StoreCondSucceed) {
     condition.condition_values.emplace_back("3");
     conditions.push_back(condition);
 
+    condition.column_name = "k14";
+    condition.condition_op = "=";
+    condition.condition_values.clear();
+    condition.condition_values.emplace_back(" a");
+    conditions.push_back(condition);
+
     DeletePredicatePB del_pred;
     success_res = _delete_condition_handler.generate_delete_predicate(tablet->unsafe_tablet_schema_ref(), conditions,
                                                                       &del_pred);
     ASSERT_EQ(true, success_res.ok());
 
     // Verify that the filter criteria stored in the header are correct
-    ASSERT_EQ(size_t(6), del_pred.sub_predicates_size());
+    ASSERT_EQ(size_t(7), del_pred.sub_predicates_size());
     EXPECT_STREQ("k1=1", del_pred.sub_predicates(0).c_str());
     EXPECT_STREQ("k2>>3", del_pred.sub_predicates(1).c_str());
     EXPECT_STREQ("k3<=5", del_pred.sub_predicates(2).c_str());
     EXPECT_STREQ("k4 IS NULL", del_pred.sub_predicates(3).c_str());
     EXPECT_STREQ("k5=7", del_pred.sub_predicates(4).c_str());
     EXPECT_STREQ("k12!=9", del_pred.sub_predicates(5).c_str());
+    EXPECT_STREQ("k14= a", del_pred.sub_predicates(6).c_str());
 
     ASSERT_EQ(size_t(1), del_pred.in_predicates_size());
     ASSERT_FALSE(del_pred.in_predicates(0).is_not_in());
     EXPECT_STREQ("k13", del_pred.in_predicates(0).column_name().c_str());
     ASSERT_EQ(std::size_t(2), del_pred.in_predicates(0).values().size());
+
+    // Test parse_condition
+    condition.condition_values.clear();
+    ASSERT_TRUE(DeleteHandler::parse_condition(del_pred.sub_predicates(0), &condition));
+    EXPECT_STREQ("k1", condition.column_name.c_str());
+    EXPECT_STREQ("=", condition.condition_op.c_str());
+    EXPECT_STREQ("1", condition.condition_values[0].c_str());
+
+    condition.condition_values.clear();
+    ASSERT_TRUE(DeleteHandler::parse_condition(del_pred.sub_predicates(1), &condition));
+    EXPECT_STREQ("k2", condition.column_name.c_str());
+    EXPECT_STREQ(">>", condition.condition_op.c_str());
+    EXPECT_STREQ("3", condition.condition_values[0].c_str());
+
+    condition.condition_values.clear();
+    ASSERT_TRUE(DeleteHandler::parse_condition(del_pred.sub_predicates(2), &condition));
+    EXPECT_STREQ("k3", condition.column_name.c_str());
+    EXPECT_STREQ("<=", condition.condition_op.c_str());
+    EXPECT_STREQ("5", condition.condition_values[0].c_str());
+
+    condition.condition_values.clear();
+    ASSERT_TRUE(DeleteHandler::parse_condition(del_pred.sub_predicates(3), &condition));
+    EXPECT_STREQ("k4", condition.column_name.c_str());
+    EXPECT_STREQ("IS", condition.condition_op.c_str());
+    EXPECT_STREQ("NULL", condition.condition_values[0].c_str());
+
+    condition.condition_values.clear();
+    ASSERT_TRUE(DeleteHandler::parse_condition(del_pred.sub_predicates(4), &condition));
+    EXPECT_STREQ("k5", condition.column_name.c_str());
+    EXPECT_STREQ("=", condition.condition_op.c_str());
+    EXPECT_STREQ("7", condition.condition_values[0].c_str());
+
+    condition.condition_values.clear();
+    ASSERT_TRUE(DeleteHandler::parse_condition(del_pred.sub_predicates(5), &condition));
+    EXPECT_STREQ("k12", condition.column_name.c_str());
+    EXPECT_STREQ("!=", condition.condition_op.c_str());
+    EXPECT_STREQ("9", condition.condition_values[0].c_str());
+
+    condition.condition_values.clear();
+    ASSERT_TRUE(DeleteHandler::parse_condition(del_pred.sub_predicates(6), &condition));
+    EXPECT_STREQ("k14", condition.column_name.c_str());
+    EXPECT_STREQ("=", condition.condition_op.c_str());
+    EXPECT_STREQ(" a", condition.condition_values[0].c_str());
 }
 
 // empty string


### PR DESCRIPTION
Why I'm doing:
k1 is varchar key column, and delete from tbl where k1 = " a" success. 
the delete predicate will be parsed as k1 = "a" when quering, so the data is not really deleted.

What I'm doing:
parse the predicate value correctly.

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [x] 3.1
  - [x] 3.0
  - [x] 2.5
