### PR TITLE
[BugFix] Fix the issue of concurrent conflicts between automatic partition and schema change, prioritize the availability of ingestion as the top priority.

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/alter/MaterializedViewHandler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/MaterializedViewHandler.java
@@ -1048,6 +1048,10 @@ public class MaterializedViewHandler extends AlterHandler {
 
     @Override
     public void cancel(CancelStmt stmt) throws DdlException {
+        cancel(stmt, "user cancelled");
+    }
+
+    public void cancel(CancelStmt stmt, String reason) throws DdlException {
         CancelAlterTableStmt cancelAlterTableStmt = (CancelAlterTableStmt) stmt;
 
         String dbName = cancelAlterTableStmt.getDbName();
@@ -1099,7 +1103,7 @@ public class MaterializedViewHandler extends AlterHandler {
 
         // alter job v2's cancel must be called outside the database lock
         for (AlterJobV2 alterJobV2 : rollupJobV2List) {
-            alterJobV2.cancel("user cancelled");
+            alterJobV2.cancel(reason);
             if (alterJobV2.isDone()) {
                 onJobDone(alterJobV2);
             }

--- a/fe/fe-core/src/main/java/com/starrocks/alter/SchemaChangeHandler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/SchemaChangeHandler.java
@@ -2258,6 +2258,10 @@ public class SchemaChangeHandler extends AlterHandler {
 
     @Override
     public void cancel(CancelStmt stmt) throws DdlException {
+        cancel(stmt, "user cancelled");
+    }
+
+    public void cancel(CancelStmt stmt, String reason) throws DdlException {
         CancelAlterTableStmt cancelAlterTableStmt = (CancelAlterTableStmt) stmt;
 
         String dbName = cancelAlterTableStmt.getDbName();
@@ -2301,7 +2305,7 @@ public class SchemaChangeHandler extends AlterHandler {
         }
 
         // alter job v2's cancel must be called outside the database lock
-        if (!schemaChangeJobV2.cancel("user cancelled")) {
+        if (!schemaChangeJobV2.cancel(reason)) {
             throw new DdlException("Job can not be cancelled. State: " + schemaChangeJobV2.getJobState());
         }
     }

--- a/fe/fe-core/src/main/java/com/starrocks/server/LocalMetastore.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/LocalMetastore.java
@@ -3770,17 +3770,21 @@ public class LocalMetastore implements ConnectorMetadata {
      * used for handling CacnelAlterStmt (for client is the CANCEL ALTER
      * command). including SchemaChangeHandler and RollupHandler
      */
-    public void cancelAlter(CancelAlterTableStmt stmt) throws DdlException {
+    public void cancelAlter(CancelAlterTableStmt stmt, String reason) throws DdlException {
         if (stmt.getAlterType() == ShowAlterStmt.AlterType.ROLLUP) {
-            stateMgr.getRollupHandler().cancel(stmt);
+            stateMgr.getRollupHandler().cancel(stmt, reason);
         } else if (stmt.getAlterType() == ShowAlterStmt.AlterType.COLUMN
                 || stmt.getAlterType() == ShowAlterStmt.AlterType.OPTIMIZE) {
-            stateMgr.getSchemaChangeHandler().cancel(stmt);
+            stateMgr.getSchemaChangeHandler().cancel(stmt, reason);
         } else if (stmt.getAlterType() == ShowAlterStmt.AlterType.MATERIALIZED_VIEW) {
             stateMgr.getRollupHandler().cancelMV(stmt);
         } else {
             throw new DdlException("Cancel " + stmt.getAlterType() + " does not implement yet");
         }
+    }
+
+    public void cancelAlter(CancelAlterTableStmt stmt) throws DdlException {
+        cancelAlter(stmt, "user cancelled");
     }
 
     // entry of rename table operation

--- a/fe/fe-core/src/main/java/com/starrocks/service/FrontendServiceImpl.java
+++ b/fe/fe-core/src/main/java/com/starrocks/service/FrontendServiceImpl.java
@@ -142,10 +142,12 @@ import com.starrocks.sql.analyzer.AnalyzerUtils;
 import com.starrocks.sql.analyzer.Authorizer;
 import com.starrocks.sql.analyzer.SemanticException;
 import com.starrocks.sql.ast.AddPartitionClause;
+import com.starrocks.sql.ast.CancelAlterTableStmt;
 import com.starrocks.sql.ast.ListPartitionDesc;
 import com.starrocks.sql.ast.PartitionDesc;
 import com.starrocks.sql.ast.RangePartitionDesc;
 import com.starrocks.sql.ast.SetType;
+import com.starrocks.sql.ast.ShowAlterStmt;
 import com.starrocks.sql.ast.UserIdentity;
 import com.starrocks.sql.common.StarRocksPlannerException;
 import com.starrocks.system.Frontend;
@@ -2228,6 +2230,28 @@ public class FrontendServiceImpl implements FrontendService.Iface {
         GlobalStateMgr state = GlobalStateMgr.getCurrentState();
 
         try {
+            // ingestion is top priority, if schema change or rollup is running, cancel it
+            try {
+                if (olapTable.getState() == OlapTable.OlapTableState.ROLLUP) {
+                    LOG.info("cancel rollup for automatic create partition txn_id={}", request.getTxn_id());
+                    state.getLocalMetastore().cancelAlter(
+                            new CancelAlterTableStmt(
+                                    ShowAlterStmt.AlterType.ROLLUP,
+                                    new TableName(db.getFullName(), olapTable.getName())),
+                                    "conflict with expression partition");
+                }
+
+                if (olapTable.getState() == OlapTable.OlapTableState.SCHEMA_CHANGE) {
+                    LOG.info("cancel schema change for automatic create partition txn_id={}", request.getTxn_id());
+                    state.getLocalMetastore().cancelAlter(
+                            new CancelAlterTableStmt(
+                                    ShowAlterStmt.AlterType.COLUMN,
+                                    new TableName(db.getFullName(), olapTable.getName())),
+                                    "conflict with expression partition");
+                }
+            } catch (Exception e) {
+                LOG.warn("cancel schema change or rollup failed. error: {}", e.getMessage());
+            }
             state.getLocalMetastore().addPartitions(db, olapTable.getName(), addPartitionClause);
         } catch (Exception e) {
             LOG.warn(e);

--- a/fe/fe-core/src/test/java/com/starrocks/service/FrontendServiceImplTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/service/FrontendServiceImplTest.java
@@ -399,6 +399,66 @@ public class FrontendServiceImplTest {
     }
 
     @Test
+    public void testCreatePartitionWithSchemaChange() throws TException {
+        new MockUp<GlobalTransactionMgr>() {
+            @Mock
+            public TransactionState getTransactionState(long dbId, long transactionId) {
+                return new TransactionState();
+            }
+        };
+
+        Database db = GlobalStateMgr.getCurrentState().getDb("test");
+        Table table = db.getTable("site_access_day");
+        ((OlapTable) table).setState(OlapTable.OlapTableState.SCHEMA_CHANGE);
+
+        List<List<String>> partitionValues = Lists.newArrayList();
+        List<String> values = Lists.newArrayList();
+        values.add("1990-04-24");
+        partitionValues.add(values);
+
+        FrontendServiceImpl impl = new FrontendServiceImpl(exeEnv);
+        TCreatePartitionRequest request = new TCreatePartitionRequest();
+        request.setDb_id(db.getId());
+        request.setTable_id(table.getId());
+        request.setPartition_values(partitionValues);
+        TCreatePartitionResult partition = impl.createPartition(request);
+
+        Assert.assertEquals(TStatusCode.RUNTIME_ERROR, partition.getStatus().getStatus_code());
+        ((OlapTable) table).setState(OlapTable.OlapTableState.NORMAL);
+    }
+
+    @Test
+    public void testCreatePartitionWithRollup() throws TException {
+        new MockUp<GlobalTransactionMgr>() {
+            @Mock
+            public TransactionState getTransactionState(long dbId, long transactionId) {
+                return new TransactionState();
+            }
+        };
+
+        Database db = GlobalStateMgr.getCurrentState().getDb("test");
+        Table table = db.getTable("site_access_day");
+        ((OlapTable) table).setState(OlapTable.OlapTableState.ROLLUP);
+
+        List<List<String>> partitionValues = Lists.newArrayList();
+        List<String> values = Lists.newArrayList();
+        values.add("1990-04-24");
+        partitionValues.add(values);
+
+        FrontendServiceImpl impl = new FrontendServiceImpl(exeEnv);
+        TCreatePartitionRequest request = new TCreatePartitionRequest();
+        request.setDb_id(db.getId());
+        request.setTable_id(table.getId());
+        request.setPartition_values(partitionValues);
+        TCreatePartitionResult partition = impl.createPartition(request);
+
+        Assert.assertEquals(TStatusCode.RUNTIME_ERROR, partition.getStatus().getStatus_code());
+        ((OlapTable) table).setState(OlapTable.OlapTableState.NORMAL);
+    }
+
+
+
+    @Test
     public void testCreatePartitionExceedLimit() throws TException {
         Database db = GlobalStateMgr.getCurrentState().getDb("test");
         Table table = db.getTable("site_access_day");

--- a/test/sql/test_automatic_partition/R/test_automatic_partition
+++ b/test/sql/test_automatic_partition/R/test_automatic_partition
@@ -568,3 +568,74 @@ select * from ss;
 2002-01-08	2
 2002-01-09	2
 -- !result
+
+-- name: test_schema_change
+CREATE TABLE ss( event_day DATE, pv BIGINT, cc int) DUPLICATE KEY(event_day) PARTITION BY date_trunc('day', event_day) DISTRIBUTED BY HASH(event_day) BUCKETS 1 PROPERTIES("replication_num" = "1");
+-- result:
+-- !result
+insert into ss values('2002-01-01', 1, 2);
+-- result:
+-- !result
+insert into ss values('2002-01-02', 1, 2);
+-- result:
+-- !result
+alter table ss modify column cc INT AFTER event_day;
+-- result:
+-- !result
+insert into ss values('2002-01-03', 1, 2);
+-- result:
+-- !result
+select sleep(3);
+-- result:
+1
+-- !result
+insert into ss values('2002-01-04', 1, 2);
+-- result:
+-- !result
+select sleep(3);
+-- result:
+1
+-- !result
+insert into ss values('2002-01-05', 1, 2);
+-- result:
+-- !result
+select sleep(3);
+-- result:
+1
+-- !result
+insert into ss values('2002-01-06', 1, 2);
+-- result:
+-- !result
+select sleep(3);
+-- result:
+1
+-- !result
+insert into ss values('2002-01-07', 1, 2);
+-- result:
+-- !result
+select sleep(3);
+-- result:
+1
+-- !result
+insert into ss values('2002-01-08', 1, 2);
+-- result:
+-- !result
+select sleep(3);
+-- result:
+1
+-- !result
+function: wait_alter_table_not_pending()
+-- result:
+None
+-- !result
+select * from ss;
+-- result:
+2002-01-03	1	2
+2002-01-01	1	2
+2002-01-02	1	2
+2002-01-04	1	2
+2002-01-05	1	2
+2002-01-08	1	2
+2002-01-07	1	2
+2002-01-06	1	2
+-- !result

--- a/test/sql/test_automatic_partition/T/test_automatic_partition
+++ b/test/sql/test_automatic_partition/T/test_automatic_partition
@@ -179,3 +179,24 @@ insert into ss values('2002-01-07', 2);
 insert into ss values('2002-01-08', 2);
 insert into ss values('2002-01-09', 2);
 select * from ss;
+
+
+-- name: test_schema_change
+CREATE TABLE ss( event_day DATE, pv BIGINT, cc int) DUPLICATE KEY(event_day) PARTITION BY date_trunc('day', event_day) DISTRIBUTED BY HASH(event_day) BUCKETS 1 PROPERTIES("replication_num" = "1");
+insert into ss values('2002-01-01', 1, 2);
+insert into ss values('2002-01-02', 1, 2);
+alter table ss modify column cc INT AFTER event_day;
+insert into ss values('2002-01-03', 1, 2);
+select sleep(3);
+insert into ss values('2002-01-04', 1, 2);
+select sleep(3);
+insert into ss values('2002-01-05', 1, 2);
+select sleep(3);
+insert into ss values('2002-01-06', 1, 2);
+select sleep(3);
+insert into ss values('2002-01-07', 1, 2);
+select sleep(3);
+insert into ss values('2002-01-08', 1, 2);
+select sleep(3);
+function: wait_alter_table_not_pending()
+select * from ss;


### PR DESCRIPTION
## Why I'm doing:
ingestion with automatic partition will be failed when schema change job is running concurrently

## What I'm doing:
cancel schema change job to make sure ingestion with automatic partition is the top priority

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [x] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [x] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [x] 3.1
  - [x] 3.0
  - [ ] 2.5
