### PR TITLE
[BugFix] Fix show materialized views final refresh state

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/qe/ShowMaterializedViewStatus.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/ShowMaterializedViewStatus.java
@@ -216,7 +216,7 @@ public class ShowMaterializedViewStatus {
         @SerializedName("priority")
         private int priority = Constants.TaskRunPriority.LOWEST.value();
         @SerializedName("lastTaskRunState")
-        private Constants.TaskRunState lastTaskRunState;
+        private Constants.TaskRunState lastTaskRunState = Constants.TaskRunState.PENDING;
 
         public boolean isManual() {
             return isManual;

--- a/fe/fe-core/src/main/java/com/starrocks/qe/ShowMaterializedViewStatus.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/ShowMaterializedViewStatus.java
@@ -215,6 +215,8 @@ public class ShowMaterializedViewStatus {
         private boolean isReplay = false;
         @SerializedName("priority")
         private int priority = Constants.TaskRunPriority.LOWEST.value();
+        @SerializedName("lastTaskRunState")
+        private Constants.TaskRunState lastTaskRunState;
 
         public boolean isManual() {
             return isManual;
@@ -254,6 +256,14 @@ public class ShowMaterializedViewStatus {
 
         public void setQueryIds(List<String> queryIds) {
             this.queryIds = queryIds;
+        }
+
+        public Constants.TaskRunState getLastTaskRunState() {
+            return lastTaskRunState;
+        }
+
+        public void setLastTaskRunState(Constants.TaskRunState lastTaskRunState) {
+            this.lastTaskRunState = lastTaskRunState;
         }
     }
 
@@ -375,6 +385,7 @@ public class ShowMaterializedViewStatus {
         List<String> queryIds = applyTaskRunStatusWith(x -> x.getQueryId());
         // queryIds
         extraMessage.setQueryIds(queryIds);
+        extraMessage.setLastTaskRunState(lastTaskRunStatus.getState());
         MVTaskRunExtraMessage firstTaskRunExtraMessage = firstTaskRunStatus.getMvTaskRunExtraMessage();
         if (firstTaskRunExtraMessage != null && firstTaskRunExtraMessage.getExecuteOption() != null) {
             ExecuteOption executeOption = firstTaskRunExtraMessage.getExecuteOption();

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/Constants.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/Constants.java
@@ -51,6 +51,10 @@ public class Constants {
         SUCCESS,
     }
 
+    public static boolean isFinishState(TaskRunState state) {
+        return state.equals(TaskRunState.SUCCESS) || state.equals(TaskRunState.FAILED);
+    }
+
     // Used to determine the scheduling order of Pending TaskRun to Running TaskRun
     // The bigger the priority, the higher the priority, the default value is LOWEST
     public enum TaskRunPriority {

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/persist/TaskRunStatus.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/persist/TaskRunStatus.java
@@ -15,6 +15,7 @@
 
 package com.starrocks.scheduler.persist;
 
+import com.google.common.base.Preconditions;
 import com.google.common.base.Strings;
 import com.google.gson.annotations.SerializedName;
 import com.starrocks.cluster.ClusterNamespace;
@@ -49,23 +50,6 @@ public class TaskRunStatus implements Writable {
     @SerializedName("createTime")
     private long createTime;
 
-    // task run success/fail time which this task run is finished
-    // NOTE: finishTime - createTime =
-    //          pending time in task queue  + process task time + other time
-    @SerializedName("finishTime")
-    private long finishTime;
-
-    // task run starts to process time
-    // NOTE: finishTime - processStartTime = process task run time(exclude pending time)
-    @SerializedName("processStartTime")
-    private long processStartTime;
-
-    @SerializedName("state")
-    private Constants.TaskRunState state = Constants.TaskRunState.PENDING;
-
-    @SerializedName("progress")
-    private int progress;
-
     @SerializedName("dbName")
     private String dbName;
 
@@ -78,12 +62,6 @@ public class TaskRunStatus implements Writable {
 
     @SerializedName("user")
     private String user;
-
-    @SerializedName("errorCode")
-    private int errorCode;
-
-    @SerializedName("errorMessage")
-    private String errorMessage;
 
     @SerializedName("expireTime")
     private long expireTime;
@@ -98,11 +76,36 @@ public class TaskRunStatus implements Writable {
     @SerializedName("source")
     private Constants.TaskSource source = Constants.TaskSource.CTAS;
 
+    //////////// Variables should be volatile which can be visited by multi threads ///////////
+
+    @SerializedName("errorCode")
+    private volatile int errorCode;
+
+    @SerializedName("errorMessage")
+    private volatile String errorMessage;
+
+    // task run success/fail time which this task run is finished
+    // NOTE: finishTime - createTime =
+    //          pending time in task queue  + process task time + other time
+    @SerializedName("finishTime")
+    private volatile long finishTime;
+
+    // task run starts to process time
+    // NOTE: finishTime - processStartTime = process task run time(exclude pending time)
+    @SerializedName("processStartTime")
+    private volatile long processStartTime = 0;
+
+    @SerializedName("state")
+    private volatile Constants.TaskRunState state = Constants.TaskRunState.PENDING;
+
+    @SerializedName("progress")
+    private volatile int progress;
+
     @SerializedName("mvExtraMessage")
-    private MVTaskRunExtraMessage mvTaskRunExtraMessage = new MVTaskRunExtraMessage();
+    private volatile MVTaskRunExtraMessage mvTaskRunExtraMessage = new MVTaskRunExtraMessage();
 
     @SerializedName("properties")
-    private Map<String, String> properties;
+    private volatile Map<String, String> properties;
 
     public TaskRunStatus() {
     }
@@ -297,13 +300,16 @@ public class TaskRunStatus implements Writable {
 
     public Constants.TaskRunState getLastRefreshState() {
         if (isRefreshFinished()) {
-            return Constants.TaskRunState.SUCCESS;
-        }
-
-        if (!state.equals(Constants.TaskRunState.FAILED)) {
-            return Constants.TaskRunState.RUNNING;
-        } else {
+            Preconditions.checkArgument(Constants.isFinishState(state),
+                    String.format("state %s must be finish state", state));
             return state;
+        } else {
+            // TODO: how to distinguish TaskRunStatus per partition.
+            if (processStartTime == 0) {
+                return state;
+            } else {
+                return Constants.TaskRunState.RUNNING;
+            }
         }
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/persist/TaskRunStatus.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/persist/TaskRunStatus.java
@@ -304,12 +304,9 @@ public class TaskRunStatus implements Writable {
                     String.format("state %s must be finish state", state));
             return state;
         } else {
+            // {@code processStartTime == 0} means taskRun have not been scheduled, its state should be pending.
             // TODO: how to distinguish TaskRunStatus per partition.
-            if (processStartTime == 0) {
-                return state;
-            } else {
-                return Constants.TaskRunState.RUNNING;
-            }
+            return processStartTime == 0 ? state : Constants.TaskRunState.RUNNING;
         }
     }
 

--- a/fe/fe-core/src/test/java/com/starrocks/scheduler/TaskTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/scheduler/TaskTest.java
@@ -29,4 +29,12 @@ public class TaskTest {
         Assert.assertEquals(Constants.TaskState.UNKNOWN, task.getState());
         Assert.assertEquals(Constants.TaskType.MANUAL, task.getType());
     }
+
+    @Test
+    public void testTaskRunState() {
+        Assert.assertFalse(Constants.isFinishState(Constants.TaskRunState.PENDING));
+        Assert.assertFalse(Constants.isFinishState(Constants.TaskRunState.RUNNING));
+        Assert.assertTrue(Constants.isFinishState(Constants.TaskRunState.FAILED));
+        Assert.assertTrue(Constants.isFinishState(Constants.TaskRunState.SUCCESS));
+    }
 }


### PR DESCRIPTION
Why I'm doing:

- ShowMaterializedViews display wrong final state when the refresh's state is failed.

What I'm doing:
- Change `getLastRefreshState` function as below:
```
    public Constants.TaskRunState getLastRefreshState() {
        if (isRefreshFinished()) {
            Preconditions.checkArgument(Constants.isFinishState(state),
                    String.format("state %s must be finish state", state));
            return state;
        } else {
            // {@code processStartTime == 0} means taskRun have not been scheduled, its state should be pending.
            // TODO: how to distinguish TaskRunStatus per partition.
            return processStartTime == 0 ? state : Constants.TaskRunState.RUNNING;
        }
    }
```
- For variables of TashRunStatus that will be updated in the refresh thread,  add `volatile` to avoid thread unsafe.
```
    //////////// Variables should be volatile which can be visited by multi threads ///////////

```

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
