### PR TITLE
[BugFix] Check datacache memtacker before updating it to avoid visiting null pointer.

### DIFF
--- a/be/src/common/daemon.cpp
+++ b/be/src/common/daemon.cpp
@@ -175,14 +175,16 @@ void calculate_metrics(void* arg_this) {
         }
 
         // update datacache mem_tracker
-        auto datacache_mem_tracker = GlobalEnv::GetInstance()->datacache_mem_tracker();
         int64_t datacache_mem_bytes = 0;
-        BlockCache* block_cache = BlockCache::instance();
-        if (block_cache->is_initialized()) {
-            auto datacache_metrics = block_cache->cache_metrics();
-            datacache_mem_bytes = datacache_metrics.mem_used_bytes + datacache_metrics.meta_used_bytes;
+        auto datacache_mem_tracker = GlobalEnv::GetInstance()->datacache_mem_tracker();
+        if (datacache_mem_tracker) {
+            BlockCache* block_cache = BlockCache::instance();
+            if (block_cache->is_initialized()) {
+                auto datacache_metrics = block_cache->cache_metrics();
+                datacache_mem_bytes = datacache_metrics.mem_used_bytes + datacache_metrics.meta_used_bytes;
+            }
+            datacache_mem_tracker->set(datacache_mem_bytes);
         }
-        datacache_mem_tracker->set(datacache_mem_bytes);
 
         auto* mem_metrics = StarRocksMetrics::instance()->system_metrics()->memory_metrics();
 


### PR DESCRIPTION
Why I'm doing:
We update the datacache memtracker in a daemon thread. But sometimes when we start BE process, the thread proc may execute before the memtracker be registed, which will cause visiting null pointer.

What I'm doing:
Check the datacache memtracker before using it.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [x] 3.1
  - [ ] 3.0
  - [ ] 2.5
