### PR TITLE
[Enhancement] Check meta before executing load task

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/load/loadv2/LoadLoadingTask.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/loadv2/LoadLoadingTask.java
@@ -278,7 +278,8 @@ public class LoadLoadingTask extends LoadTask {
         }
 
         if (database.getTable(table.getId()) == null) {
-            throw new LoadException(String.format("table: %s-%d has been dropped", table.getName(), table.getId()));
+            throw new LoadException(String.format("table: %s-%d has been dropped from db: %s-%d",
+                    table.getName(), table.getId(), db.getFullName(), db.getId()));
         }
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/load/loadv2/LoadLoadingTask.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/loadv2/LoadLoadingTask.java
@@ -274,11 +274,11 @@ public class LoadLoadingTask extends LoadTask {
     private void checkMeta() throws LoadException {
         Database database = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(db.getId());
         if (database == null) {
-            throw new LoadException("db: " + db.getId() + " has been dropped");
+            throw new LoadException(String.format("db: %s-%d has been dropped", db.getFullName(), db.getId()));
         }
 
         if (database.getTable(table.getId()) == null) {
-            throw new LoadException("table: " + table.getId() + " has been dropped");
+            throw new LoadException(String.format("table: %s-%d has been dropped", table.getName(), table.getId()));
         }
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/load/loadv2/LoadLoadingTask.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/loadv2/LoadLoadingTask.java
@@ -56,6 +56,7 @@ import com.starrocks.qe.OriginStatement;
 import com.starrocks.qe.QeProcessorImpl;
 import com.starrocks.qe.SessionVariable;
 import com.starrocks.qe.scheduler.Coordinator;
+import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.sql.LoadPlanner;
 import com.starrocks.thrift.TBrokerFileStatus;
 import com.starrocks.thrift.TLoadJobType;
@@ -159,6 +160,8 @@ public class LoadLoadingTask extends LoadTask {
     }
 
     private void executeOnce() throws Exception {
+        checkMeta();
+
         // New one query id,
         Coordinator curCoordinator;
         curCoordinator = getCoordinatorFactory().createBrokerLoadScheduler(loadPlanner);
@@ -266,6 +269,17 @@ public class LoadLoadingTask extends LoadTask {
 
     private long getLeftTimeMs() {
         return jobDeadlineMs - System.currentTimeMillis();
+    }
+
+    private void checkMeta() throws LoadException {
+        Database database = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(db.getId());
+        if (database == null) {
+            throw new LoadException("db: " + db.getId() + " has been dropped");
+        }
+
+        if (database.getTable(table.getId()) == null) {
+            throw new LoadException("table: " + table.getId() + " has been dropped");
+        }
     }
 
     public static class Builder {

--- a/fe/fe-core/src/test/java/com/starrocks/load/loadv2/LoadLoadingTaskTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/load/loadv2/LoadLoadingTaskTest.java
@@ -14,6 +14,12 @@
 
 package com.starrocks.load.loadv2;
 
+import com.starrocks.catalog.CatalogIdGenerator;
+import com.starrocks.catalog.Database;
+import com.starrocks.catalog.KeysType;
+import com.starrocks.catalog.OlapTable;
+import com.starrocks.common.IdGenerator;
+import com.starrocks.common.LoadException;
 import com.starrocks.common.jmockit.Deencapsulation;
 import com.starrocks.server.GlobalStateMgr;
 import mockit.Expectations;
@@ -46,5 +52,41 @@ public class LoadLoadingTaskTest {
 
         LoadJob.JSONOptions realJSONOptions =  Deencapsulation.getField(task, "jsonOptions");
         Assert.assertEquals(jsonOptions, realJSONOptions);
+    }
+
+    @Test
+    public void testExecuteTaskWhenMetaDropped(@Mocked CatalogIdGenerator idGenerator) {
+        new Expectations() {
+            {
+                idGenerator.getNextId();
+                result = 1;
+                times = 1;
+            }};
+
+        Database database = new Database(10000L, "test");
+        OlapTable olapTable = new OlapTable(10001L, "tbl", null, KeysType.AGG_KEYS, null, null);
+        LoadLoadingTask loadLoadingTask = new LoadLoadingTask.Builder().setDb(database).setTable(olapTable).build();
+
+        // database not exist
+        boolean exceptionThrown = false;
+        try {
+            loadLoadingTask.executeTask();
+        } catch (Exception e) {
+            Assert.assertTrue(e instanceof LoadException);
+            exceptionThrown = true;
+        }
+
+        Assert.assertTrue(exceptionThrown);
+
+        // table not exist
+        exceptionThrown = false;
+        GlobalStateMgr.getCurrentState().getLocalMetastore().unprotectCreateDb(database);
+        try {
+            loadLoadingTask.executeTask();
+        } catch (Exception e) {
+            Assert.assertTrue(e instanceof LoadException);
+            exceptionThrown = true;
+        }
+        Assert.assertTrue(exceptionThrown);
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/load/loadv2/LoadLoadingTaskTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/load/loadv2/LoadLoadingTaskTest.java
@@ -18,7 +18,6 @@ import com.starrocks.catalog.CatalogIdGenerator;
 import com.starrocks.catalog.Database;
 import com.starrocks.catalog.KeysType;
 import com.starrocks.catalog.OlapTable;
-import com.starrocks.common.IdGenerator;
 import com.starrocks.common.LoadException;
 import com.starrocks.common.jmockit.Deencapsulation;
 import com.starrocks.server.GlobalStateMgr;


### PR DESCRIPTION
Why I'm doing:
LoadTask may wait for a long time before being executed. If the table is dropped during this period, the execution will report an error: Fail to get tablet. The error message needs to be optimized.

What I'm doing:
Check meta before executing LoadTask.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [x] 3.1
  - [x] 3.0
  - [x] 2.5
