### PR TITLE
[Enhancement] auto generate pk dump when tablet in error state

### DIFF
--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -1188,4 +1188,8 @@ CONF_mBool(lake_enable_vertical_compaction_fill_data_cache, "false");
 CONF_mInt32(dictionary_cache_refresh_timeout_ms, "60000"); // 1 min
 CONF_mInt32(dictionary_cache_refresh_threadpool_size, "8");
 
+// Allowable intervals for continuous generation of pk dumps
+// Disable when pk_dump_interval_seconds <= 0
+CONF_mInt64(pk_dump_interval_seconds, "3600"); // 1 hour
+
 } // namespace starrocks::config

--- a/be/src/script/script.cpp
+++ b/be/src/script/script.cpp
@@ -349,7 +349,7 @@ public:
         return exec_whitelist(strings::Substitute("ls -al $0", tablet->schema_hash_path()));
     }
 
-    static std::string print_primary_key_dump(int64_t tablet_id) {
+    static std::string pk_dump(int64_t tablet_id) {
         auto tablet = get_tablet(tablet_id);
         if (!tablet) {
             return "tablet not found";
@@ -521,7 +521,7 @@ public:
             REG_STATIC_METHOD(StorageEngineRef, submit_manual_compaction_task_for_partition);
             REG_STATIC_METHOD(StorageEngineRef, submit_manual_compaction_task_for_tablet);
             REG_STATIC_METHOD(StorageEngineRef, get_manual_compaction_status);
-            REG_STATIC_METHOD(StorageEngineRef, print_primary_key_dump);
+            REG_STATIC_METHOD(StorageEngineRef, pk_dump);
             REG_STATIC_METHOD(StorageEngineRef, ls_tablet_dir);
         }
     }

--- a/be/src/storage/data_dir.cpp
+++ b/be/src/storage/data_dir.cpp
@@ -122,7 +122,7 @@ Status DataDir::init_persistent_index_dir() {
 }
 
 Status DataDir::_init_tmp_dir() {
-    std::string tmp_path = _path + TMP_PREFIX;
+    std::string tmp_path = get_tmp_path();
     auto st = _fs->create_dir_recursive(tmp_path);
     LOG_IF(ERROR, !st.ok()) << "failed to create temp directory " << tmp_path;
     return st;

--- a/be/src/storage/data_dir.h
+++ b/be/src/storage/data_dir.h
@@ -155,6 +155,8 @@ public:
 
     std::string get_replication_path() { return _path + REPLICATION_PREFIX; }
 
+    std::string get_tmp_path() { return _path + TMP_PREFIX; }
+
     // for test
     size_t get_all_check_dcg_files_cnt() const { return _all_check_dcg_files.size(); }
 

--- a/be/src/storage/primary_key_dump.cpp
+++ b/be/src/storage/primary_key_dump.cpp
@@ -47,6 +47,11 @@ PrimaryKeyDump::PrimaryKeyDump(const std::string& dump_filepath) {
     _partial_pindex_kvs = std::make_unique<PartialKVsPB>();
 }
 
+Status PrimaryKeyDump::dump_file_exist() {
+    ASSIGN_OR_RETURN(auto fs, FileSystem::CreateSharedFromString(_dump_filepath));
+    return fs->path_exists(_dump_filepath);
+}
+
 Status PrimaryKeyDump::init_dump_file() {
     ASSIGN_OR_RETURN(auto fs, FileSystem::CreateSharedFromString(_dump_filepath));
     WritableFileOptions wblock_opts{.sync_on_close = true, .mode = FileSystem::CREATE_OR_OPEN_WITH_TRUNCATE};

--- a/be/src/storage/primary_key_dump.cpp
+++ b/be/src/storage/primary_key_dump.cpp
@@ -37,7 +37,7 @@ namespace starrocks {
 
 PrimaryKeyDump::PrimaryKeyDump(Tablet* tablet) {
     _tablet = tablet;
-    _dump_filepath = tablet->schema_hash_path() + "/" + std::to_string(_tablet->tablet_id()) + ".pkdump";
+    _dump_filepath = tablet->data_dir()->get_tmp_path() + "/" + std::to_string(_tablet->tablet_id()) + ".pkdump";
     _partial_pindex_kvs = std::make_unique<PartialKVsPB>();
 }
 

--- a/be/src/storage/primary_key_dump.h
+++ b/be/src/storage/primary_key_dump.h
@@ -87,6 +87,10 @@ public:
             const std::function<void(const Chunk&)>& column_key_func,
             const std::function<void(const std::string&, const PartialKVsPB&)>& index_kvs_func);
 
+    std::string dump_filepath() const { return _dump_filepath; }
+
+    Status dump_file_exist();
+
 private:
     Status _dump_tablet_meta();
     Status _dump_rowset_meta();

--- a/be/src/storage/storage_engine.cpp
+++ b/be/src/storage/storage_engine.cpp
@@ -622,6 +622,8 @@ void StorageEngine::stop() {
 
     JOIN_THREAD(_pk_index_major_compaction_thread)
 
+    JOIN_THREAD(_pk_dump_thread);
+
 #ifdef USE_STAROS
     JOIN_THREAD(_local_pk_index_shared_data_gc_evict_thread)
 #endif

--- a/be/src/storage/storage_engine.h
+++ b/be/src/storage/storage_engine.h
@@ -350,6 +350,8 @@ private:
     // pk index major compaction function
     void* _pk_index_major_compaction_thread_callback(void* arg);
 
+    void* _pk_dump_thread_callback(void* arg);
+
 #ifdef USE_STAROS
     // local pk index of SHARED_DATA gc/evict function
     void* _local_pk_index_shared_data_gc_evict_thread_callback(void* arg);
@@ -425,6 +427,8 @@ private:
     std::vector<std::thread> _manual_compaction_threads;
     // thread to run pk index major compaction
     std::thread _pk_index_major_compaction_thread;
+    // thread to generate pk dump
+    std::thread _pk_dump_thread;
     // thread to gc/evict local pk index in sharded_data
     std::thread _local_pk_index_shared_data_gc_evict_thread;
 

--- a/be/src/storage/tablet_manager.cpp
+++ b/be/src/storage/tablet_manager.cpp
@@ -701,6 +701,27 @@ TabletSharedPtr TabletManager::find_best_tablet_to_compaction(CompactionType com
     return best_tablet;
 }
 
+Status TabletManager::generate_pk_dump_in_error_state() {
+    std::vector<TabletAndScore> pick_tablets;
+    // 1. pick primary key tablet
+    std::vector<TabletSharedPtr> tablet_ptr_list;
+    for (const auto& tablets_shard : _tablets_shards) {
+        std::shared_lock rlock(tablets_shard.lock);
+        for (const auto& [tablet_id, tablet_ptr] : tablets_shard.tablet_map) {
+            if (tablet_ptr->keys_type() != PRIMARY_KEYS) {
+                continue;
+            }
+
+            tablet_ptr_list.push_back(tablet_ptr);
+        }
+    }
+    // 2. generate pk dump if need
+    for (const auto& tablet_ptr : tablet_ptr_list) {
+        RETURN_IF_ERROR(tablet_ptr->updates()->generate_pk_dump());
+    }
+    return Status::OK();
+}
+
 // pick tablets to do primary index compaction
 std::vector<TabletAndScore> TabletManager::pick_tablets_to_do_pk_index_major_compaction() {
     std::vector<TabletAndScore> pick_tablets;

--- a/be/src/storage/tablet_manager.h
+++ b/be/src/storage/tablet_manager.h
@@ -196,6 +196,8 @@ public:
 
     std::vector<TabletAndScore> pick_tablets_to_do_pk_index_major_compaction();
 
+    Status generate_pk_dump_in_error_state();
+
 private:
     using TabletMap = std::unordered_map<int64_t, TabletSharedPtr>;
     using TabletSet = std::unordered_set<int64_t>;

--- a/be/src/storage/tablet_updates.h
+++ b/be/src/storage/tablet_updates.h
@@ -337,6 +337,8 @@ public:
 
     Status primary_index_dump(PrimaryKeyDump* dump, PrimaryIndexMultiLevelPB* dump_pb);
 
+    Status generate_pk_dump();
+
 private:
     friend class Tablet;
     friend class PrimaryIndex;

--- a/be/test/storage/tablet_updates_test.cpp
+++ b/be/test/storage/tablet_updates_test.cpp
@@ -751,7 +751,10 @@ void TabletUpdatesTest::test_pk_dump(size_t rowset_cnt) {
     {
         // dump primary key tablet
         PrimaryKeyDump dump(_tablet.get());
+        ASSERT_TRUE(dump.dump_filepath().length() > 0);
+        ASSERT_FALSE(dump.dump_file_exist().ok());
         ASSERT_TRUE(dump.dump().ok());
+        ASSERT_TRUE(dump.dump_file_exist().ok());
     }
     const std::string dump_filepath =
             _tablet->schema_hash_path() + "/" + std::to_string(_tablet->tablet_id()) + ".pkdump";

--- a/be/test/storage/tablet_updates_test.cpp
+++ b/be/test/storage/tablet_updates_test.cpp
@@ -748,16 +748,16 @@ TEST_F(TabletUpdatesTest, remove_expired_versions_with_persistent_index) {
 
 void TabletUpdatesTest::test_pk_dump(size_t rowset_cnt) {
     PrimaryKeyDumpPB dump_pb;
+    std::string dump_filepath;
     {
         // dump primary key tablet
         PrimaryKeyDump dump(_tablet.get());
+        dump_filepath = dump.dump_filepath();
         ASSERT_TRUE(dump.dump_filepath().length() > 0);
         ASSERT_FALSE(dump.dump_file_exist().ok());
         ASSERT_TRUE(dump.dump().ok());
         ASSERT_TRUE(dump.dump_file_exist().ok());
     }
-    const std::string dump_filepath =
-            _tablet->schema_hash_path() + "/" + std::to_string(_tablet->tablet_id()) + ".pkdump";
     {
         // read primary index dump
         starrocks::PrimaryKeyDumpPB dump_pb;


### PR DESCRIPTION
Why I'm doing:
In previous pr #38297 , we support dump pk tablet's all information for debug purpose. We can trigger pk dump by script cmd. And now I want to support auto pk dump when tablet is in error state.

What I'm doing:
1. Support auto generate pk dump when tablet in error state, add BE config `pk_dump_interval_seconds` to avoid generate too much dump files.
2. Change pk dump file path to `storage/tmp`.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [x] 3.1
  - [ ] 3.0
  - [ ] 2.5
