### PR TITLE
[BugFix] Support nondeterministic function reuse

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/base/ColumnRefFactory.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/base/ColumnRefFactory.java
@@ -45,6 +45,11 @@ public class ColumnRefFactory {
     private final Map<ColumnRefOperator, Column> columnRefToColumns = Maps.newHashMap();
     private final Map<ColumnRefOperator, Table> columnRefToTable = Maps.newHashMap();
 
+    // introduced to used to get unique id for query,
+    // now used to identify nondeterministic function.
+    // do not reuse nextId because it will affect many UTs.
+    private int id = 1;
+
     public Map<ColumnRefOperator, Column> getColumnRefToColumns() {
         return columnRefToColumns;
     }
@@ -140,5 +145,9 @@ public class ColumnRefFactory {
 
     public Table getTableForColumn(int columnId) {
         return columnRefToTable.get(getColumnRef(columnId));
+    }
+
+    public int getNextUniqueId() {
+        return id++;
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/scalar/CallOperator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/scalar/CallOperator.java
@@ -55,6 +55,9 @@ public class CallOperator extends ScalarOperator {
     // Ignore nulls.
     private boolean ignoreNulls = false;
 
+    // for nonDeterministicFunctions, to reuse it in common exprs
+    private int id = 0;
+
     public CallOperator(String fnName, Type returnType, List<ScalarOperator> arguments) {
         this(fnName, returnType, arguments, null);
     }
@@ -120,6 +123,10 @@ public class CallOperator extends ScalarOperator {
 
     public void setRemovedDistinct(boolean removedDistinct) {
         this.removedDistinct = removedDistinct;
+    }
+
+    public void setId(int id) {
+        this.id = id;
     }
 
     public List<ScalarOperator> getDistinctChildren() {
@@ -219,7 +226,7 @@ public class CallOperator extends ScalarOperator {
 
     @Override
     public int hashCode() {
-        return Objects.hash(fnName, arguments, isDistinct);
+        return Objects.hash(fnName, arguments, isDistinct, id);
     }
 
     @Override
@@ -235,7 +242,8 @@ public class CallOperator extends ScalarOperator {
                 Objects.equals(fnName, other.fnName) &&
                 Objects.equals(type, other.type) &&
                 Objects.equals(arguments, other.arguments) &&
-                Objects.equals(fn, other.fn);
+                Objects.equals(fn, other.fn) &&
+                id == other.id;
     }
 
 
@@ -277,6 +285,7 @@ public class CallOperator extends ScalarOperator {
         operator.fnName = this.fnName;
         operator.isDistinct = this.isDistinct;
         operator.ignoreNulls = this.ignoreNulls;
+        operator.id = this.id;
         return operator;
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/ScalarOperatorsReuse.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/ScalarOperatorsReuse.java
@@ -314,7 +314,7 @@ public class ScalarOperatorsReuse {
             Set<ScalarOperator> operators = getOperatorsByDepth(depth, operatorsByDepth);
             isLambdaDependent = false;
             lambdaArguments.clear();
-            if (!isNonDeterministicFuncOrLambdaDependent(operator) && operators.contains(operator)) {
+            if (!isLambdaDependent(operator) && operators.contains(operator)) {
                 Set<ScalarOperator> commonOperators = getOperatorsByDepth(depth, commonOperatorsByDepth);
                 commonOperators.add(operator);
             }
@@ -349,6 +349,23 @@ public class ScalarOperatorsReuse {
         }
 
         @Override
+        public Integer visitCall(CallOperator scalarOperator, Void context) {
+            CallOperator callOperator = scalarOperator.cast();
+            if (FunctionSet.nonDeterministicFunctions.contains(callOperator.getFnName())) {
+                // try to reuse non deterministic function
+                // for example:
+                // select (rnd + 1) as rnd1, (rnd + 2) as rnd2 from (select rand() as rnd) sub
+                return collectCommonOperatorsByDepth(1, scalarOperator);
+            } else if (scalarOperator.getChildren().isEmpty()) {
+                // to keep the same logic as origin
+                return 0;
+            } else {
+                return collectCommonOperatorsByDepth(scalarOperator.getChildren().stream().map(argument ->
+                        argument.accept(this, context)).reduce(Math::max).map(m -> m + 1).orElse(1), scalarOperator);
+            }
+        }
+
+        @Override
         public Integer visitDictMappingOperator(DictMappingOperator scalarOperator, Void context) {
             return collectCommonOperatorsByDepth(1, scalarOperator);
         }
@@ -358,7 +375,7 @@ public class ScalarOperatorsReuse {
         // a lambda-dependent expressions also can't be reused if reuseLambdaDependentExpr is false.
         // For example, array_map(x->2x+1+2x,array),2x is lambda-dependent, so it can't be reused if
         // reuseLambdaDependentExpr is false, but array_map(x->2x+1+2x,array) can be reused if needed.
-        private boolean isNonDeterministicFuncOrLambdaDependent(ScalarOperator scalarOperator) {
+        private boolean isLambdaDependent(ScalarOperator scalarOperator) {
 
             if (hasLambdaFunction && !reuseLambdaDependentExpr) {
                 if (scalarOperator instanceof LambdaFunctionOperator) {
@@ -372,14 +389,8 @@ public class ScalarOperatorsReuse {
                 }
             }
 
-            if (scalarOperator instanceof CallOperator) {
-                String fnName = ((CallOperator) scalarOperator).getFnName();
-                if (FunctionSet.nonDeterministicFunctions.contains(fnName)) {
-                    return true;
-                }
-            }
             for (ScalarOperator child : scalarOperator.getChildren()) {
-                if (isNonDeterministicFuncOrLambdaDependent(child)) {
+                if (isLambdaDependent(child)) {
                     return true;
                 }
             }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/transformer/SqlToScalarOperatorTranslator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/transformer/SqlToScalarOperatorTranslator.java
@@ -674,6 +674,9 @@ public final class SqlToScalarOperatorTranslator {
                     node.getFn(),
                     node.getParams().isDistinct());
             callOperator.setHints(node.getHints());
+            if (FunctionSet.nonDeterministicFunctions.contains(node.getFnName().getFunction())) {
+                callOperator.setId(columnRefFactory.getNextUniqueId());
+            }
             return callOperator;
         }
 

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rewrite/ScalarOperatorsReuseRuleTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rewrite/ScalarOperatorsReuseRuleTest.java
@@ -1,0 +1,83 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.sql.optimizer.rewrite;
+
+import com.starrocks.sql.plan.PlanTestBase;
+import org.junit.Test;
+
+public class ScalarOperatorsReuseRuleTest extends PlanTestBase {
+    @Test
+    public void testRandReuse() throws Exception {
+        {
+            String query = "select (rnd + 1) as rnd1, (rnd + 2) as rnd2 from (select rand() as rnd) sub";
+            String plan = getFragmentPlan(query);
+            PlanTestBase.assertContains(plan, "1:Project\n" +
+                    "  |  <slot 3> : 5: rand + 1.0\n" +
+                    "  |  <slot 4> : 5: rand + 2.0\n" +
+                    "  |  common expressions:\n" +
+                    "  |  <slot 5> : rand()");
+        }
+
+        {
+            String query = "select rand() as rnd1, rand() as rnd2";
+            String plan = getFragmentPlan(query);
+            PlanTestBase.assertContains(plan, "1:Project\n" +
+                    "  |  <slot 2> : rand()\n" +
+                    "  |  <slot 3> : rand()");
+        }
+    }
+
+    @Test
+    public void testRandomReuse() throws Exception {
+        {
+            String query = "select (rnd + 1) as rnd1, (rnd + 2) as rnd2 from (select random() as rnd) sub";
+            String plan = getFragmentPlan(query);
+            PlanTestBase.assertContains(plan, "1:Project\n" +
+                    "  |  <slot 3> : 5: random + 1.0\n" +
+                    "  |  <slot 4> : 5: random + 2.0\n" +
+                    "  |  common expressions:\n" +
+                    "  |  <slot 5> : random()");
+        }
+
+        {
+            String query = "select random() as rnd1, random() as rnd2";
+            String plan = getFragmentPlan(query);
+            PlanTestBase.assertContains(plan, "1:Project\n" +
+                    "  |  <slot 2> : random()\n" +
+                    "  |  <slot 3> : random()");
+        }
+    }
+
+    @Test
+    public void testUUIDReuse() throws Exception {
+        {
+            String query = "select lower(id) as id1, upper(id) as id2 from (select uuid() as id) sub";
+            String plan = getFragmentPlan(query);
+            PlanTestBase.assertContains(plan, "1:Project\n" +
+                    "  |  <slot 3> : lower(5: uuid)\n" +
+                    "  |  <slot 4> : upper(5: uuid)\n" +
+                    "  |  common expressions:\n" +
+                    "  |  <slot 5> : uuid()");
+        }
+
+        {
+            String query = "select uuid() as id1, uuid() as id2";
+            String plan = getFragmentPlan(query);
+            PlanTestBase.assertContains(plan, "1:Project\n" +
+                    "  |  <slot 2> : uuid()\n" +
+                    "  |  <slot 3> : uuid()");
+        }
+    }
+}

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rewrite/ScalarOperatorsReuseTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rewrite/ScalarOperatorsReuseTest.java
@@ -28,6 +28,7 @@ import com.starrocks.sql.optimizer.operator.scalar.ScalarOperator;
 import com.starrocks.sql.optimizer.rule.tree.ScalarOperatorsReuse;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -172,7 +173,7 @@ public class ScalarOperatorsReuseTest {
         Map<Integer, Map<ScalarOperator, ColumnRefOperator>> commonSubScalarOperators =
                 ScalarOperatorsReuse.collectCommonSubScalarOperators(null, ImmutableList.of(add1, add2, add3, add4),
                         columnRefFactory, false);
-        assertTrue(commonSubScalarOperators.isEmpty());
+        Assert.assertFalse(commonSubScalarOperators.isEmpty());
     }
 
     @Test
@@ -196,7 +197,7 @@ public class ScalarOperatorsReuseTest {
         Map<Integer, Map<ScalarOperator, ColumnRefOperator>> commonSubScalarOperators =
                 ScalarOperatorsReuse.collectCommonSubScalarOperators(null, ImmutableList.of(add1, add2, add3, add4),
                         columnRefFactory, false);
-        assertEquals(2, commonSubScalarOperators.size());
+        assertEquals(3, commonSubScalarOperators.size());
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/SkewJoinTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/SkewJoinTest.java
@@ -146,12 +146,17 @@ public class SkewJoinTest extends PlanTestBase {
         String sql = "select struct_tbl.c0, struct_tbl.c2.a, t3.c2 from default_catalog.test.struct_tbl " +
                 "join[skew|test.struct_tbl.c1.a(1,2)] hive0.partitioned_db.t3 on c1.a = t3.c1 ";
         String sqlPlan = getFragmentPlan(sql);
-        assertCContains(sqlPlan, "  1:Project\n" +
+        assertCContains(sqlPlan, "1:Project\n" +
                 "  |  <slot 1> : 1: c0\n" +
-                "  |  <slot 10> : CASE WHEN 2: c1.a[true] IS NULL THEN round(rand() * 1000.0) WHEN 2: c1.a[true] " +
-                "IN (1, 2) THEN round(rand() * 1000.0) ELSE 0 END\n" +
+                "  |  <slot 10> : CASE WHEN 2: c1.a[true] IS NULL THEN 26: round " +
+                "WHEN 2: c1.a[true] IN (1, 2) THEN 26: round ELSE 0 END\n" +
                 "  |  <slot 19> : 2: c1.a[true]\n" +
-                "  |  <slot 21> : 3: c2.a[false]");
+                "  |  <slot 21> : 3: c2.a[false]\n" +
+                "  |  common expressions:\n" +
+                "  |  <slot 23> : 2: c1.a[true]\n" +
+                "  |  <slot 24> : rand()\n" +
+                "  |  <slot 25> : 24: rand * 1000.0\n" +
+                "  |  <slot 26> : round(25: multiply)");
     }
 
     @Test


### PR DESCRIPTION
Why I'm doing:
for the following sql
```
select (rnd + 1) as rnd1, (rnd + 2) as rnd2 from (select rand() as rnd) sub
```
rand will call twice, it does not reuse the rand() function.

What I'm doing:
reuse the nondeterministic function. now the plan will be:
```
PLAN FRAGMENT 0
 OUTPUT EXPRS:3: expr | 4: expr
  PARTITION: UNPARTITIONED

  RESULT SINK

  1:Project
  |  <slot 3> : 5: rand + 1.0
  |  <slot 4> : 5: rand + 2.0
  |  common expressions:
  |  <slot 5> : rand()
  |  
  0:UNION
     constant exprs: 
         NULL
```

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [x] 3.1
  - [x] 3.0
  - [x] 2.5
