### PR TITLE
[Enhancement] Support analyze iceberg table with partition transform

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/IcebergTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/IcebergTable.java
@@ -170,6 +170,18 @@ public class IcebergTable extends Table {
         return allPartitionColumns;
     }
 
+    public PartitionField getPartitionField(String partitionColumnName) {
+        List<PartitionField> allPartitionFields = getNativeTable().spec().fields();
+        Schema schema = this.getNativeTable().schema();
+        for (PartitionField field : allPartitionFields) {
+            if (getPartitionSourceName(schema, field).equalsIgnoreCase(partitionColumnName)) {
+                return field;
+            }
+        }
+        return null;
+    }
+
+
     public long nextPartitionId() {
         return partitionIdGen.getAndIncrement();
     }

--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergPartitionTransform.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergPartitionTransform.java
@@ -25,6 +25,7 @@ public enum IcebergPartitionTransform {
     UNKNOWN;
 
     public static IcebergPartitionTransform fromString(String partitionTransform) {
+        partitionTransform = partitionTransform.replaceAll("\\[.*\\]$", "");
         try {
             return IcebergPartitionTransform.valueOf(partitionTransform.toUpperCase());
         } catch (IllegalArgumentException e) {

--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergPartitionUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergPartitionUtils.java
@@ -292,6 +292,7 @@ public class IcebergPartitionUtils {
         if (transform == IcebergPartitionTransform.IDENTITY) {
             return StatisticUtils.quoting(partitionColumn) + " = '" + partitionValue + "'";
         } else {
+            // transform is year, month, day, hour
             Type partitiopnColumnType = table.getColumn(partitionColumn).getType();
             Preconditions.checkState(partitiopnColumnType.isDateType(),
                     "Partition column %s type must be date or datetime", partitionColumn);

--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergPartitionUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergPartitionUtils.java
@@ -15,6 +15,7 @@
 package com.starrocks.connector.iceberg;
 
 import com.google.common.base.Objects;
+import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableSet;
 import com.starrocks.catalog.Column;
 import com.starrocks.catalog.IcebergTable;
@@ -22,6 +23,7 @@ import com.starrocks.catalog.Type;
 import com.starrocks.common.util.TimeUtils;
 import com.starrocks.connector.PartitionUtil;
 import com.starrocks.connector.exception.StarRocksConnectorException;
+import com.starrocks.statistic.StatisticUtils;
 import org.apache.iceberg.AddedRowsScanTask;
 import org.apache.iceberg.ChangelogOperation;
 import org.apache.iceberg.ChangelogScanTask;
@@ -232,6 +234,84 @@ public class IcebergPartitionUtils {
                 return PartitionUtil.DateTimeInterval.HOUR;
             default:
                 return PartitionUtil.DateTimeInterval.NONE;
+        }
+    }
+
+    public static boolean isSupportedConvertPartitionTransform(IcebergPartitionTransform transform) {
+        return transform == IcebergPartitionTransform.IDENTITY ||
+                transform == IcebergPartitionTransform.YEAR ||
+                transform == IcebergPartitionTransform.MONTH ||
+                transform == IcebergPartitionTransform.DAY ||
+                transform == IcebergPartitionTransform.HOUR;
+    }
+
+    public static LocalDateTime addDateTimeInterval(LocalDateTime dateTime, IcebergPartitionTransform transform) {
+        switch (transform) {
+            case YEAR:
+                return dateTime.plusYears(1);
+            case MONTH:
+                return dateTime.plusMonths(1);
+            case DAY:
+                return dateTime.plusDays(1);
+            case HOUR:
+                return dateTime.plusHours(1);
+            default:
+                throw new StarRocksConnectorException("Unsupported partition transform to add: %s", transform);
+        }
+    }
+
+    /**
+        convert partition value to predicate
+        eg.
+        partitionColumn: ts(date)
+        partitionValue: 2023  transform: year
+        return ts >= '2023-01-01' and ts < '2024-01-01'
+        partitionValue: 2023-01 transform: month
+        return ts >= '2023-01-01' and ts < '2023-02-01'
+        partitionValue: 2023-01-01  transform: day
+        return ts >= '2023-01-01' and ts < '2023-01-02'
+
+        partitionColumn: ts(datetime)   transform: year
+        partitionValue: 2023  transform: year
+        return ts >= '2023-01-01 00:00:00' and ts < '2024-01-01 00:00:00'
+        partitionValue: 2023-01 transform: month
+        return ts >= '2023-01-01 00:00:00' and ts < '2023-02-01 00:00:00'
+        partitionValue: 2023-01-01  transform: day
+        return ts >= '2023-01-01 00:00:00' and ts < '2023-01-02 00:00:00'
+        partitionValue: 2023-01-01-12  transform: hour
+        return ts >= '2023-01-01 12:00:00' and ts < '2023-01-01 13:00:00'
+    */
+    public static String convertPartitionFieldToPredicate(IcebergTable table, String partitionColumn,
+                                                          String partitionValue) {
+        PartitionField partitionField = table.getPartitionFiled(partitionColumn);
+        if (partitionField == null) {
+            throw new StarRocksConnectorException("Partition column %s not found in table %s.%s.%s",
+                    partitionColumn, table.getCatalogName(), table.getRemoteDbName(), table.getRemoteTableName());
+        }
+        IcebergPartitionTransform transform = IcebergPartitionTransform.fromString(partitionField.transform().toString());
+        if (transform == IcebergPartitionTransform.IDENTITY) {
+            return StatisticUtils.quoting(partitionColumn) + " = '" + partitionValue + "'";
+        } else {
+            Type partitiopnColumnType = table.getColumn(partitionColumn).getType();
+            Preconditions.checkState(partitiopnColumnType.isDateType(),
+                    "Partition column %s type must be date or datetime", partitionColumn);
+            String normalizedPartitionValue = normalizeTimePartitionName(partitionValue, partitionField,
+                    table.getNativeTable().schema(), partitiopnColumnType);
+
+            LocalDateTime startDateTime = null;
+            DateTimeFormatter dateTimeFormatter = null;
+            if (partitiopnColumnType.isDate()) {
+                dateTimeFormatter = DateTimeFormatter.ofPattern("yyyy-MM-dd");
+                startDateTime = LocalDate.parse(normalizedPartitionValue, dateTimeFormatter).atStartOfDay();
+            } else {
+                dateTimeFormatter = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss");
+                startDateTime = LocalDateTime.parse(normalizedPartitionValue, dateTimeFormatter);
+            }
+            LocalDateTime endDateTime = addDateTimeInterval(startDateTime, transform);
+            String endDateTimeStr = endDateTime.format(dateTimeFormatter);
+
+            return StatisticUtils.quoting(partitionColumn) + " >= '" + normalizedPartitionValue + "' and " +
+                    StatisticUtils.quoting(partitionColumn) + " < '" + endDateTimeStr + "'";
         }
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/statistic/ExternalFullStatisticsCollectJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/statistic/ExternalFullStatisticsCollectJob.java
@@ -198,7 +198,8 @@ public class ExternalFullStatisticsCollectJob extends StatisticsCollectJob {
         return builder.toString();
     }
 
-
+    // only iceberg table support partition transform
+    // now only support identity/year/month/day/hour transform
     boolean isSupportedPartitionTransform(String partitionColumn) {
         // only iceberg table support partition transform
         if (!table.isIcebergTable()) {

--- a/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/MockIcebergMetadata.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/MockIcebergMetadata.java
@@ -77,6 +77,11 @@ public class MockIcebergMetadata implements ConnectorMetadata {
     public static final String MOCKED_PARTITIONED_DAY_TABLE_NAME = "t0_day";
     public static final String MOCKED_PARTITIONED_HOUR_TABLE_NAME = "t0_hour";
     public static final String MOCKED_PARTITIONED_BUCKET_TABLE_NAME = "t0_bucket";
+    // partition table with transforms and partition column type is timestamp with timezone
+    public static final String MOCKED_PARTITIONED_YEAR_TZ_TABLE_NAME = "t0_year_tz";
+    public static final String MOCKED_PARTITIONED_MONTH_TZ_TABLE_NAME = "t0_month_tz";
+    public static final String MOCKED_PARTITIONED_DAY_TZ_TABLE_NAME = "t0_day_tz";
+    public static final String MOCKED_PARTITIONED_HOUR_TZ_TABLE_NAME = "t0_hour_tz";
 
     private static final List<String> PARTITION_TABLE_NAMES = ImmutableList.of(MOCKED_PARTITIONED_TABLE_NAME1,
             MOCKED_STRING_PARTITIONED_TABLE_NAME1, MOCKED_STRING_PARTITIONED_TABLE_NAME2,
@@ -85,7 +90,9 @@ public class MockIcebergMetadata implements ConnectorMetadata {
     private static final List<String> PARTITION_TRANSFORM_TABLE_NAMES =
             ImmutableList.of(MOCKED_PARTITIONED_YEAR_TABLE_NAME, MOCKED_PARTITIONED_MONTH_TABLE_NAME,
                     MOCKED_PARTITIONED_DAY_TABLE_NAME, MOCKED_PARTITIONED_HOUR_TABLE_NAME,
-                    MOCKED_PARTITIONED_BUCKET_TABLE_NAME);
+                    MOCKED_PARTITIONED_BUCKET_TABLE_NAME,
+                    MOCKED_PARTITIONED_YEAR_TZ_TABLE_NAME, MOCKED_PARTITIONED_MONTH_TZ_TABLE_NAME,
+                    MOCKED_PARTITIONED_DAY_TZ_TABLE_NAME, MOCKED_PARTITIONED_HOUR_TZ_TABLE_NAME);
 
     private static final List<String> PARTITION_NAMES_0 = Lists.newArrayList("date=2020-01-01",
             "date=2020-01-02",
@@ -218,9 +225,15 @@ public class MockIcebergMetadata implements ConnectorMetadata {
     }
 
     private static Schema getIcebergPartitionTransformSchema(String tblName) {
-        return new Schema(required(3, "id", Types.IntegerType.get()),
-                required(4, "data", Types.StringType.get()),
-                required(5, "ts", Types.TimestampType.withoutZone()));
+        if (tblName.endsWith("tz")) {
+            return new Schema(required(3, "id", Types.IntegerType.get()),
+                    required(4, "data", Types.StringType.get()),
+                    required(5, "ts", Types.TimestampType.withZone()));
+        } else {
+            return new Schema(required(3, "id", Types.IntegerType.get()),
+                    required(4, "data", Types.StringType.get()),
+                    required(5, "ts", Types.TimestampType.withoutZone()));
+        }
     }
 
     private static TestTables.TestTable getPartitionIdentityTable(String tblName, Schema schema) throws IOException {
@@ -284,6 +297,38 @@ public class MockIcebergMetadata implements ConnectorMetadata {
                                 + MOCKED_PARTITIONED_BUCKET_TABLE_NAME), MOCKED_PARTITIONED_BUCKET_TABLE_NAME,
                         schema, spec, 1);
             }
+            case MOCKED_PARTITIONED_YEAR_TZ_TABLE_NAME: {
+                PartitionSpec spec =
+                        PartitionSpec.builderFor(schema).year("ts").build();
+                return TestTables.create(
+                        new File(getStarRocksHome() + "/" + MOCKED_PARTITIONED_TRANSFORMS_DB_NAME + "/"
+                                + MOCKED_PARTITIONED_YEAR_TZ_TABLE_NAME), MOCKED_PARTITIONED_YEAR_TZ_TABLE_NAME,
+                        schema, spec, 1);
+            }
+            case MOCKED_PARTITIONED_MONTH_TZ_TABLE_NAME: {
+                PartitionSpec spec =
+                        PartitionSpec.builderFor(schema).month("ts").build();
+                return TestTables.create(
+                        new File(getStarRocksHome() + "/" + MOCKED_PARTITIONED_TRANSFORMS_DB_NAME + "/"
+                                + MOCKED_PARTITIONED_MONTH_TZ_TABLE_NAME), MOCKED_PARTITIONED_MONTH_TZ_TABLE_NAME,
+                        schema, spec, 1);
+            }
+            case MOCKED_PARTITIONED_DAY_TZ_TABLE_NAME: {
+                PartitionSpec spec =
+                        PartitionSpec.builderFor(schema).day("ts").build();
+                return TestTables.create(
+                        new File(getStarRocksHome() + "/" + MOCKED_PARTITIONED_TRANSFORMS_DB_NAME + "/"
+                                + MOCKED_PARTITIONED_DAY_TZ_TABLE_NAME), MOCKED_PARTITIONED_DAY_TZ_TABLE_NAME,
+                        schema, spec, 1);
+            }
+            case MOCKED_PARTITIONED_HOUR_TZ_TABLE_NAME: {
+                PartitionSpec spec =
+                        PartitionSpec.builderFor(schema).hour("ts").build();
+                return TestTables.create(
+                        new File(getStarRocksHome() + "/" + MOCKED_PARTITIONED_TRANSFORMS_DB_NAME + "/"
+                                + MOCKED_PARTITIONED_HOUR_TZ_TABLE_NAME), MOCKED_PARTITIONED_HOUR_TZ_TABLE_NAME,
+                        schema, spec, 1);
+            }
         }
         return null;
     }
@@ -291,15 +336,19 @@ public class MockIcebergMetadata implements ConnectorMetadata {
     public static List<String> getTransformTablePartitionNames(String tblName) {
         switch (tblName) {
             case MOCKED_PARTITIONED_YEAR_TABLE_NAME:
+            case MOCKED_PARTITIONED_YEAR_TZ_TABLE_NAME:
                 return Lists.newArrayList("ts_year=2019", "ts_year=2020",
                         "ts_year=2021", "ts_year=2022", "ts_year=2023");
             case MOCKED_PARTITIONED_MONTH_TABLE_NAME:
+            case MOCKED_PARTITIONED_MONTH_TZ_TABLE_NAME:
                 return Lists.newArrayList("ts_month=2022-01", "ts_month=2022-02",
                         "ts_month=2022-03", "ts_month=2022-04", "ts_month=2022-05");
             case MOCKED_PARTITIONED_DAY_TABLE_NAME:
+            case MOCKED_PARTITIONED_DAY_TZ_TABLE_NAME:
                 return Lists.newArrayList("ts_day=2022-01-01", "ts_day=2022-01-02",
                         "ts_day=2022-01-03", "ts_day=2022-01-04", "ts_day=2022-01-05");
             case MOCKED_PARTITIONED_HOUR_TABLE_NAME:
+            case MOCKED_PARTITIONED_HOUR_TZ_TABLE_NAME:
                 return Lists.newArrayList("ts_hour=2022-01-01-00", "ts_hour=2022-01-01-01",
                         "ts_hour=2022-01-01-02", "ts_hour=2022-01-01-03", "ts_hour=2022-01-01-04");
             case MOCKED_PARTITIONED_BUCKET_TABLE_NAME:

--- a/fe/fe-core/src/test/java/com/starrocks/statistic/StatisticsCollectJobTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/statistic/StatisticsCollectJobTest.java
@@ -1009,6 +1009,7 @@ public class StatisticsCollectJobTest extends PlanTestNoneDBBase {
         // test partition column type is timestamp with time zone
         String oldTimeZone = connectContext.getSessionVariable().getTimeZone();
         connectContext.getSessionVariable().setTimeZone("America/New_York");
+        connectContext.setThreadLocalInfo();
 
         table = connectContext.getGlobalStateMgr().getMetadataMgr().getTable("iceberg0", "partitioned_transforms_db",
                 "t0_year_tz");

--- a/fe/fe-core/src/test/java/com/starrocks/statistic/StatisticsCollectJobTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/statistic/StatisticsCollectJobTest.java
@@ -950,6 +950,121 @@ public class StatisticsCollectJobTest extends PlanTestNoneDBBase {
     }
 
     @Test
+    public void testIcebergPartitionTransformFullStatisticsBuildCollectSQLList() {
+        // test partition column type is timestamp without time zone
+        Database database = connectContext.getGlobalStateMgr().getMetadataMgr().getDb("iceberg0", "partitioned_transforms_db");
+        Table table = connectContext.getGlobalStateMgr().getMetadataMgr().getTable("iceberg0", "partitioned_transforms_db",
+                "t0_year");
+
+        ExternalFullStatisticsCollectJob collectJob = (ExternalFullStatisticsCollectJob)
+                StatisticsCollectJobFactory.buildExternalStatisticsCollectJob("iceberg0",
+                        database,
+                        table, null,
+                        Lists.newArrayList("id", "data", "ts"),
+                        StatsConstants.AnalyzeType.FULL,
+                        StatsConstants.ScheduleType.ONCE,
+                        Maps.newHashMap());
+        List<List<String>> collectSqlList = collectJob.buildCollectSQLList(1);
+        assertContains(collectSqlList.get(0).toString(), "`ts` >= '2019-01-01 00:00:00' and `ts` < '2020-01-01 00:00:00'");
+
+        table = connectContext.getGlobalStateMgr().getMetadataMgr().getTable("iceberg0", "partitioned_transforms_db",
+                "t0_month");
+        collectJob = (ExternalFullStatisticsCollectJob)
+                StatisticsCollectJobFactory.buildExternalStatisticsCollectJob("iceberg0",
+                        database,
+                        table, null,
+                        Lists.newArrayList("id", "data", "ts"),
+                        StatsConstants.AnalyzeType.FULL,
+                        StatsConstants.ScheduleType.ONCE,
+                        Maps.newHashMap());
+        collectSqlList = collectJob.buildCollectSQLList(1);
+        assertContains(collectSqlList.get(0).toString(), "ts` >= '2022-01-01 00:00:00' and `ts` < '2022-02-01 00:00:00'");
+
+        table = connectContext.getGlobalStateMgr().getMetadataMgr().getTable("iceberg0", "partitioned_transforms_db",
+                "t0_day");
+        collectJob = (ExternalFullStatisticsCollectJob)
+                StatisticsCollectJobFactory.buildExternalStatisticsCollectJob("iceberg0",
+                        database,
+                        table, null,
+                        Lists.newArrayList("id", "data", "ts"),
+                        StatsConstants.AnalyzeType.FULL,
+                        StatsConstants.ScheduleType.ONCE,
+                        Maps.newHashMap());
+        collectSqlList = collectJob.buildCollectSQLList(1);
+        assertContains(collectSqlList.get(0).toString(), "`ts` >= '2022-01-01 00:00:00' and `ts` < '2022-01-02 00:00:00'");
+
+        table = connectContext.getGlobalStateMgr().getMetadataMgr().getTable("iceberg0", "partitioned_transforms_db",
+                "t0_hour");
+        collectJob = (ExternalFullStatisticsCollectJob)
+                StatisticsCollectJobFactory.buildExternalStatisticsCollectJob("iceberg0",
+                        database,
+                        table, null,
+                        Lists.newArrayList("id", "data", "ts"),
+                        StatsConstants.AnalyzeType.FULL,
+                        StatsConstants.ScheduleType.ONCE,
+                        Maps.newHashMap());
+        collectSqlList = collectJob.buildCollectSQLList(1);
+        assertContains(collectSqlList.get(0).toString(), "`ts` >= '2022-01-01 00:00:00' and `ts` < '2022-01-01 01:00:00'");
+
+        // test partition column type is timestamp with time zone
+        String oldTimeZone = connectContext.getSessionVariable().getTimeZone();
+        connectContext.getSessionVariable().setTimeZone("America/New_York");
+
+        table = connectContext.getGlobalStateMgr().getMetadataMgr().getTable("iceberg0", "partitioned_transforms_db",
+                "t0_year_tz");
+        collectJob = (ExternalFullStatisticsCollectJob)
+                StatisticsCollectJobFactory.buildExternalStatisticsCollectJob("iceberg0",
+                        database,
+                        table, null,
+                        Lists.newArrayList("id", "data", "ts"),
+                        StatsConstants.AnalyzeType.FULL,
+                        StatsConstants.ScheduleType.ONCE,
+                        Maps.newHashMap());
+        collectSqlList = collectJob.buildCollectSQLList(1);
+        assertContains(collectSqlList.get(0).toString(), "`ts` >= '2018-12-31 19:00:00' and `ts` < '2019-12-31 19:00:00'");
+
+        table = connectContext.getGlobalStateMgr().getMetadataMgr().getTable("iceberg0", "partitioned_transforms_db",
+                "t0_month_tz");
+        collectJob = (ExternalFullStatisticsCollectJob)
+                StatisticsCollectJobFactory.buildExternalStatisticsCollectJob("iceberg0",
+                        database,
+                        table, null,
+                        Lists.newArrayList("id", "data", "ts"),
+                        StatsConstants.AnalyzeType.FULL,
+                        StatsConstants.ScheduleType.ONCE,
+                        Maps.newHashMap());
+        collectSqlList = collectJob.buildCollectSQLList(1);
+        assertContains(collectSqlList.get(0).toString(), "`ts` >= '2021-12-31 19:00:00' and `ts` < '2022-01-31 19:00:00'");
+
+        table = connectContext.getGlobalStateMgr().getMetadataMgr().getTable("iceberg0", "partitioned_transforms_db",
+                "t0_day_tz");
+        collectJob = (ExternalFullStatisticsCollectJob)
+                StatisticsCollectJobFactory.buildExternalStatisticsCollectJob("iceberg0",
+                        database,
+                        table, null,
+                        Lists.newArrayList("id", "data", "ts"),
+                        StatsConstants.AnalyzeType.FULL,
+                        StatsConstants.ScheduleType.ONCE,
+                        Maps.newHashMap());
+        collectSqlList = collectJob.buildCollectSQLList(1);
+        assertContains(collectSqlList.get(0).toString(), "`ts` >= '2021-12-31 19:00:00' and `ts` < '2022-01-01 19:00:00'");
+
+        table = connectContext.getGlobalStateMgr().getMetadataMgr().getTable("iceberg0", "partitioned_transforms_db",
+                "t0_hour_tz");
+        collectJob = (ExternalFullStatisticsCollectJob)
+                StatisticsCollectJobFactory.buildExternalStatisticsCollectJob("iceberg0",
+                        database,
+                        table, null,
+                        Lists.newArrayList("id", "data", "ts"),
+                        StatsConstants.AnalyzeType.FULL,
+                        StatsConstants.ScheduleType.ONCE,
+                        Maps.newHashMap());
+        collectSqlList = collectJob.buildCollectSQLList(1);
+        assertContains(collectSqlList.get(0).toString(), "`ts` >= '2021-12-31 19:00:00' and `ts` < '2021-12-31 20:00:00'");
+        connectContext.getSessionVariable().setTimeZone(oldTimeZone);
+    }
+
+    @Test
     public void testExcludeStatistics() {
         OlapTable table = (OlapTable) connectContext.getGlobalStateMgr()
                 .getDb("test").getTable("t0_stats_partition");

--- a/fe/fe-core/src/test/java/com/starrocks/statistic/StatisticsCollectJobTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/statistic/StatisticsCollectJobTest.java
@@ -20,6 +20,7 @@ import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
 import com.starrocks.catalog.Database;
+import com.starrocks.catalog.IcebergTable;
 import com.starrocks.catalog.InternalCatalog;
 import com.starrocks.catalog.OlapTable;
 import com.starrocks.catalog.Partition;
@@ -27,6 +28,7 @@ import com.starrocks.catalog.Table;
 import com.starrocks.common.Config;
 import com.starrocks.common.jmockit.Deencapsulation;
 import com.starrocks.connector.ConnectorTableColumnStats;
+import com.starrocks.connector.exception.StarRocksConnectorException;
 import com.starrocks.connector.iceberg.IcebergPartitionUtils;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.server.GlobalStateMgr;
@@ -39,12 +41,15 @@ import mockit.Expectations;
 import mockit.Mock;
 import mockit.MockUp;
 import org.apache.commons.lang3.StringUtils;
+import org.apache.iceberg.PartitionField;
 import org.apache.iceberg.Snapshot;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.ExpectedException;
 import org.junit.rules.TemporaryFolder;
 
 import java.time.Clock;
@@ -65,6 +70,9 @@ public class StatisticsCollectJobTest extends PlanTestNoneDBBase {
 
     @ClassRule
     public static TemporaryFolder temp = new TemporaryFolder();
+
+    @Rule
+    public ExpectedException expectedException = ExpectedException.none();
 
     @BeforeClass
     public static void beforeClass() throws Exception {
@@ -952,9 +960,11 @@ public class StatisticsCollectJobTest extends PlanTestNoneDBBase {
     @Test
     public void testIcebergPartitionTransformFullStatisticsBuildCollectSQLList() {
         // test partition column type is timestamp without time zone
-        Database database = connectContext.getGlobalStateMgr().getMetadataMgr().getDb("iceberg0", "partitioned_transforms_db");
-        Table table = connectContext.getGlobalStateMgr().getMetadataMgr().getTable("iceberg0", "partitioned_transforms_db",
-                "t0_year");
+        Database database =
+                connectContext.getGlobalStateMgr().getMetadataMgr().getDb("iceberg0", "partitioned_transforms_db");
+        Table table =
+                connectContext.getGlobalStateMgr().getMetadataMgr().getTable("iceberg0", "partitioned_transforms_db",
+                        "t0_year");
 
         ExternalFullStatisticsCollectJob collectJob = (ExternalFullStatisticsCollectJob)
                 StatisticsCollectJobFactory.buildExternalStatisticsCollectJob("iceberg0",
@@ -965,7 +975,8 @@ public class StatisticsCollectJobTest extends PlanTestNoneDBBase {
                         StatsConstants.ScheduleType.ONCE,
                         Maps.newHashMap());
         List<List<String>> collectSqlList = collectJob.buildCollectSQLList(1);
-        assertContains(collectSqlList.get(0).toString(), "`ts` >= '2019-01-01 00:00:00' and `ts` < '2020-01-01 00:00:00'");
+        assertContains(collectSqlList.get(0).toString(),
+                "`ts` >= '2019-01-01 00:00:00' and `ts` < '2020-01-01 00:00:00'");
 
         table = connectContext.getGlobalStateMgr().getMetadataMgr().getTable("iceberg0", "partitioned_transforms_db",
                 "t0_month");
@@ -978,7 +989,8 @@ public class StatisticsCollectJobTest extends PlanTestNoneDBBase {
                         StatsConstants.ScheduleType.ONCE,
                         Maps.newHashMap());
         collectSqlList = collectJob.buildCollectSQLList(1);
-        assertContains(collectSqlList.get(0).toString(), "ts` >= '2022-01-01 00:00:00' and `ts` < '2022-02-01 00:00:00'");
+        assertContains(collectSqlList.get(0).toString(),
+                "ts` >= '2022-01-01 00:00:00' and `ts` < '2022-02-01 00:00:00'");
 
         table = connectContext.getGlobalStateMgr().getMetadataMgr().getTable("iceberg0", "partitioned_transforms_db",
                 "t0_day");
@@ -991,7 +1003,8 @@ public class StatisticsCollectJobTest extends PlanTestNoneDBBase {
                         StatsConstants.ScheduleType.ONCE,
                         Maps.newHashMap());
         collectSqlList = collectJob.buildCollectSQLList(1);
-        assertContains(collectSqlList.get(0).toString(), "`ts` >= '2022-01-01 00:00:00' and `ts` < '2022-01-02 00:00:00'");
+        assertContains(collectSqlList.get(0).toString(),
+                "`ts` >= '2022-01-01 00:00:00' and `ts` < '2022-01-02 00:00:00'");
 
         table = connectContext.getGlobalStateMgr().getMetadataMgr().getTable("iceberg0", "partitioned_transforms_db",
                 "t0_hour");
@@ -1004,7 +1017,8 @@ public class StatisticsCollectJobTest extends PlanTestNoneDBBase {
                         StatsConstants.ScheduleType.ONCE,
                         Maps.newHashMap());
         collectSqlList = collectJob.buildCollectSQLList(1);
-        assertContains(collectSqlList.get(0).toString(), "`ts` >= '2022-01-01 00:00:00' and `ts` < '2022-01-01 01:00:00'");
+        assertContains(collectSqlList.get(0).toString(),
+                "`ts` >= '2022-01-01 00:00:00' and `ts` < '2022-01-01 01:00:00'");
 
         // test partition column type is timestamp with time zone
         String oldTimeZone = connectContext.getSessionVariable().getTimeZone();
@@ -1022,7 +1036,8 @@ public class StatisticsCollectJobTest extends PlanTestNoneDBBase {
                         StatsConstants.ScheduleType.ONCE,
                         Maps.newHashMap());
         collectSqlList = collectJob.buildCollectSQLList(1);
-        assertContains(collectSqlList.get(0).toString(), "`ts` >= '2018-12-31 19:00:00' and `ts` < '2019-12-31 19:00:00'");
+        assertContains(collectSqlList.get(0).toString(),
+                "`ts` >= '2018-12-31 19:00:00' and `ts` < '2019-12-31 19:00:00'");
 
         table = connectContext.getGlobalStateMgr().getMetadataMgr().getTable("iceberg0", "partitioned_transforms_db",
                 "t0_month_tz");
@@ -1035,7 +1050,8 @@ public class StatisticsCollectJobTest extends PlanTestNoneDBBase {
                         StatsConstants.ScheduleType.ONCE,
                         Maps.newHashMap());
         collectSqlList = collectJob.buildCollectSQLList(1);
-        assertContains(collectSqlList.get(0).toString(), "`ts` >= '2021-12-31 19:00:00' and `ts` < '2022-01-31 19:00:00'");
+        assertContains(collectSqlList.get(0).toString(),
+                "`ts` >= '2021-12-31 19:00:00' and `ts` < '2022-01-31 19:00:00'");
 
         table = connectContext.getGlobalStateMgr().getMetadataMgr().getTable("iceberg0", "partitioned_transforms_db",
                 "t0_day_tz");
@@ -1048,7 +1064,8 @@ public class StatisticsCollectJobTest extends PlanTestNoneDBBase {
                         StatsConstants.ScheduleType.ONCE,
                         Maps.newHashMap());
         collectSqlList = collectJob.buildCollectSQLList(1);
-        assertContains(collectSqlList.get(0).toString(), "`ts` >= '2021-12-31 19:00:00' and `ts` < '2022-01-01 19:00:00'");
+        assertContains(collectSqlList.get(0).toString(),
+                "`ts` >= '2021-12-31 19:00:00' and `ts` < '2022-01-01 19:00:00'");
 
         table = connectContext.getGlobalStateMgr().getMetadataMgr().getTable("iceberg0", "partitioned_transforms_db",
                 "t0_hour_tz");
@@ -1061,8 +1078,74 @@ public class StatisticsCollectJobTest extends PlanTestNoneDBBase {
                         StatsConstants.ScheduleType.ONCE,
                         Maps.newHashMap());
         collectSqlList = collectJob.buildCollectSQLList(1);
-        assertContains(collectSqlList.get(0).toString(), "`ts` >= '2021-12-31 19:00:00' and `ts` < '2021-12-31 20:00:00'");
+        assertContains(collectSqlList.get(0).toString(),
+                "`ts` >= '2021-12-31 19:00:00' and `ts` < '2021-12-31 20:00:00'");
         connectContext.getSessionVariable().setTimeZone(oldTimeZone);
+
+        // test partition transform is identity
+        database = connectContext.getGlobalStateMgr().getMetadataMgr().getDb("iceberg0", "partitioned_db");
+        table = connectContext.getGlobalStateMgr().getMetadataMgr().getTable("iceberg0", "partitioned_db",
+                "t1");
+        collectJob = (ExternalFullStatisticsCollectJob)
+                StatisticsCollectJobFactory.buildExternalStatisticsCollectJob("iceberg0",
+                        database,
+                        table, null,
+                        Lists.newArrayList("id", "data", "date"),
+                        StatsConstants.AnalyzeType.FULL,
+                        StatsConstants.ScheduleType.ONCE,
+                        Maps.newHashMap());
+        collectSqlList = collectJob.buildCollectSQLList(1);
+        assertContains(collectSqlList.get(0).toString(), "`date` = '2020-01-01'");
+    }
+
+    @Test
+    public void testExternalFullStatisticsBuildCollectSQLWithException1() {
+        // test partition transform is bucket
+        Database database =
+                connectContext.getGlobalStateMgr().getMetadataMgr().getDb("iceberg0", "partitioned_transforms_db");
+        Table table =
+                connectContext.getGlobalStateMgr().getMetadataMgr().getTable("iceberg0", "partitioned_transforms_db",
+                        "t0_bucket");
+        ExternalFullStatisticsCollectJob collectJob = (ExternalFullStatisticsCollectJob)
+                StatisticsCollectJobFactory.buildExternalStatisticsCollectJob("iceberg0",
+                        database,
+                        table, null,
+                        Lists.newArrayList("id", "data", "ts"),
+                        StatsConstants.AnalyzeType.FULL,
+                        StatsConstants.ScheduleType.ONCE,
+                        Maps.newHashMap());
+
+        expectedException.expect(StarRocksConnectorException.class);
+        expectedException.expectMessage("Partition transform BUCKET not supported to analyze, table: t0_bucket");
+        collectJob.buildCollectSQLList(1);
+    }
+
+    @Test
+    public void testExternalFullStatisticsBuildCollectSQLWithException2() {
+        // test partition field is null
+        Database database =
+                connectContext.getGlobalStateMgr().getMetadataMgr().getDb("iceberg0", "partitioned_db");
+        Table table =
+                connectContext.getGlobalStateMgr().getMetadataMgr().getTable("iceberg0", "partitioned_db",
+                        "t1");
+        ExternalFullStatisticsCollectJob collectJob = (ExternalFullStatisticsCollectJob)
+                StatisticsCollectJobFactory.buildExternalStatisticsCollectJob("iceberg0",
+                        database,
+                        table, null,
+                        Lists.newArrayList("id", "data", "date"),
+                        StatsConstants.AnalyzeType.FULL,
+                        StatsConstants.ScheduleType.ONCE,
+                        Maps.newHashMap());
+        new MockUp<IcebergTable>() {
+            @Mock
+            public PartitionField getPartitionFiled(String colName) {
+                return null;
+            }
+        };
+
+        expectedException.expect(StarRocksConnectorException.class);
+        expectedException.expectMessage("Partition column date not found in table iceberg0.partitioned_db.t1");
+        collectJob.buildCollectSQLList(1);
     }
 
     @Test


### PR DESCRIPTION
Why I'm doing:
Iceberg table with partition transform would not work normally
What I'm doing:
iceberg has partition transform like year/month/day/hour, so we need to map partition column to range with year/month/day/hour, eg. ts is partition column and type is date with year transform,  
origin predicate is **ts = '2022'**,
 but ts with year partition transform needs predicate 
**ts >= '2022-01-01' and ts < '2023-01-01';**
Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
