### PR TITLE
[Tool] Workflow create doc feedback issue

### DIFF
--- a/.github/workflows/weekly-docs-feedback.yml
+++ b/.github/workflows/weekly-docs-feedback.yml
@@ -1,0 +1,36 @@
+name: Reader feedback
+  # This workflow pulls reader feedback from PostHog
+  # and opens a GitHub issue with the last week of feedback.
+  # The issue will be labelled with `docs-feedback`
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 18 * * SUN'  # once a week on Sunday
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  grab_feedback_from_posthog:
+    name: Pull feedback using API
+    runs-on: ubuntu-latest
+    env:
+      POSTHOG_TOKEN: ${{ secrets.POSTHOG_PERSONAL_API_KEY }}
+    steps:
+      - name: Run script
+        run: |
+          curl --silent \
+            --header "Content-Type: application/json" \
+            --data '{ "query": { "kind": "HogQLQuery", "query": "SELECT now() - INTERVAL 7 DAY as start_time, timestamp, properties.page, properties.text, properties.sentiment from events WHERE properties.sentiment IS NOT NULL AND timestamp > start_time ORDER BY properties.sentiment ASC"}}' \
+            -H "Authorization: Bearer $POSTHOG_TOKEN" \
+            https://app.posthog.com/api/projects/48961/query | jq -r '.results | to_entries[] | "- [ ] \(.value[2])", "  feedback: \(.value[3])", "  Rating: \(.value[4])", "  timestamp: \(.value[1])"' > feedback.md
+
+      - name: Create issue from file
+        id: weekly-feedback-report
+        uses: peter-evans/create-issue-from-file@ceef9be92406ace67ab5421f66570acf213ec395
+        with:
+          title: Weekly documentation feedback from readers
+          content-filepath: ./feedback.md
+          labels: doc-feedback


### PR DESCRIPTION
New CI job that will create an issue once a week with feedback from doc readers. This widget at the bottom of doc pages:
<img width="989" alt="image" src="https://github.com/StarRocks/starrocks/assets/25182304/58e9fa09-ded9-495f-8fbf-5958ce6a4d47">

sends feedback to a service, and then once a week we pull the feedback so we can address confusing docs as reported by the readers.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [x] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
