### PR TITLE
[Feature][Issue 39849] update BE/FE start shell to support Datadog profile

### DIFF
--- a/bin/start_backend.sh
+++ b/bin/start_backend.sh
@@ -192,7 +192,7 @@ if [ ${RUN_CN} -eq 1 ]; then
 fi
 
 # enable DD profile
-if [ ${DD_PROFILING_ENABLED} == "true" ] && [ -f "${STARROCKS_HOME}/datadog/ddprof" ]; then
+if [ ${ENABLE_DATADOG_PROFILE} == "true" ] && [ -f "${STARROCKS_HOME}/datadog/ddprof" ]; then
     START_BE_CMD="${STARROCKS_HOME}/datadog/ddprof -l debug ${START_BE_CMD}"
 fi
 

--- a/bin/start_backend.sh
+++ b/bin/start_backend.sh
@@ -191,6 +191,11 @@ if [ ${RUN_CN} -eq 1 ]; then
     LOG_FILE=${LOG_DIR}/cn.out
 fi
 
+# enable DD profile
+if [ ${DD_PROFILING_ENABLED} == "true" ] && [ -f "${STARROCKS_HOME}/datadog/ddprof" ]; then
+    START_BE_CMD="${STARROCKS_HOME}/datadog/ddprof -l debug ${START_BE_CMD}"
+fi
+
 if [ ${RUN_LOG_CONSOLE} -eq 1 ] ; then
     # force glog output to console (stderr)
     export GLOG_logtostderr=1

--- a/bin/start_fe.sh
+++ b/bin/start_fe.sh
@@ -151,7 +151,7 @@ if [ ${ENABLE_DEBUGGER} -eq 1 ]; then
 fi
 
 # add datadog profile settings when enabled
-if [ "${DD_PROFILING_ENABLED}" == "true" ] && [ -f "${STARROCKS_HOME}/datadog/dd-java-agent.jar" ]; then
+if [ "${ENABLE_DATADOG_PROFILE}" == "true" ] && [ -f "${STARROCKS_HOME}/datadog/dd-java-agent.jar" ]; then
     final_java_opt="-javaagent:${STARROCKS_HOME}/datadog/dd-java-agent.jar ${final_java_opt}"
 fi
 

--- a/bin/start_fe.sh
+++ b/bin/start_fe.sh
@@ -150,6 +150,11 @@ if [ ${ENABLE_DEBUGGER} -eq 1 ]; then
     echo "Start debugger with: $final_java_opt"
 fi
 
+# add datadog profile settings when enabled
+if [ "${DD_PROFILING_ENABLED}" == "true" ] && [ -f "${STARROCKS_HOME}/datadog/dd-java-agent.jar" ]; then
+    final_java_opt="-javaagent:${STARROCKS_HOME}/datadog/dd-java-agent.jar ${final_java_opt}"
+fi
+
 if [ ! -d $LOG_DIR ]; then
     mkdir -p $LOG_DIR
 fi


### PR DESCRIPTION
Why I'm doing:

See https://github.com/StarRocks/starrocks/issues/39849 for more context

What I'm doing:

* update `star_fe.sh` and `start_backend.sh` to enable Datadog profile when `DD_PROFILING_ENABLED:true`. 

*Note that the image update is coming in another PR shortly*

Fixes #issue

NA

## What type of PR is this:

- [ ] BugFix
- [x] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [] I have added test cases for my bug fix or my new feature
- [x] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [ ] 3.1-cs
  - [x] 3.1
  - [ ] 3.0
  - [ ] 2.5

----test plan----------
* Build images manually to check dd_lib files are in the image;
* deploy a starrocks cluster with the image, see profiling screenshot

#### FE compoennt
![Screenshot 2024-01-24 at 12 29 29 PM](https://github.com/StarRocks/starrocks/assets/2017944/168b944c-3093-4538-9121-2a6edbaa074e)

#### BE compoennt
![Screenshot 2024-01-24 at 9 51 25 PM](https://github.com/StarRocks/starrocks/assets/2017944/60694221-da8a-46c1-a8a2-fc447b9b7dd6)
