### PR TITLE
[Feature][Cherry-Pick][Branch-3.1] Support int32 to datetime in parquet reader (backport #39808) (backport #39841)

### DIFF
--- a/be/src/formats/parquet/column_converter.cpp
+++ b/be/src/formats/parquet/column_converter.cpp
@@ -591,7 +591,7 @@ Status parquet::Int32ToDateTimeConverter::convert(const ColumnPtr& src, Column* 
         if (!src_null_data[i]) {
             int64_t day = src_data[i];
             TimestampValue ep;
-            ep.from_unix_second(day * 24 * 60 * 60, 0);
+            ep.from_unix_second(day * 24 * 60 * 60);
             dst_data[i].set_timestamp(ep.timestamp());
         }
     }

--- a/be/src/formats/parquet/column_converter.cpp
+++ b/be/src/formats/parquet/column_converter.cpp
@@ -40,7 +40,7 @@ namespace starrocks::parquet {
 // to match destination scale.
 enum class DecimalScaleType { kNoScale, kScaleUp, kScaleDown };
 
-class Int32ToDateConverter : public ColumnConverter {
+class Int32ToDateConverter final : public ColumnConverter {
 public:
     Int32ToDateConverter() = default;
     ~Int32ToDateConverter() override = default;
@@ -48,7 +48,15 @@ public:
     Status convert(const ColumnPtr& src, Column* dst) override;
 };
 
-class Int96ToDateTimeConverter : public ColumnConverter {
+class Int32ToDateTimeConverter final : public ColumnConverter {
+public:
+    Int32ToDateTimeConverter() = default;
+    ~Int32ToDateTimeConverter() override = default;
+
+    Status convert(const ColumnPtr& src, Column* dst) override;
+};
+
+class Int96ToDateTimeConverter final : public ColumnConverter {
 public:
     Int96ToDateTimeConverter() = default;
     ~Int96ToDateTimeConverter() override = default;
@@ -69,7 +77,7 @@ private:
     int _offset = 0;
 };
 
-class Int64ToDateTimeConverter : public ColumnConverter {
+class Int64ToDateTimeConverter final : public ColumnConverter {
 public:
     Int64ToDateTimeConverter() = default;
     ~Int64ToDateTimeConverter() override = default;
@@ -93,7 +101,7 @@ void convert_int_to_int(SourceType* __restrict__ src, DestType* __restrict__ dst
 
 // Support int => int and float => double
 template <typename SourceType, typename DestType>
-class NumericToNumericConverter : public ColumnConverter {
+class NumericToNumericConverter final : public ColumnConverter {
 public:
     NumericToNumericConverter() = default;
     ~NumericToNumericConverter() override = default;
@@ -123,7 +131,7 @@ public:
 };
 
 template <typename SourceType, LogicalType DestType>
-class PrimitiveToDecimalConverter : public ColumnConverter {
+class PrimitiveToDecimalConverter final : public ColumnConverter {
 public:
     using DestDecimalType = typename RunTimeTypeTraits<DestType>::CppType;
     using DestColumnType = typename RunTimeTypeTraits<DestType>::ColumnType;
@@ -184,7 +192,7 @@ private:
 // and for fixed length binary in parquet, string data is contiguous,
 // and that's why we can do memcpy 8 bytes without accessing invalid address.
 template <LogicalType DestType>
-class BinaryToDecimalConverter : public ColumnConverter {
+class BinaryToDecimalConverter final : public ColumnConverter {
 public:
     using DecimalType = typename RunTimeTypeTraits<DestType>::CppType;
     using ColumnType = typename RunTimeTypeTraits<DestType>::ColumnType;
@@ -357,6 +365,9 @@ Status ColumnConverterFactory::create_converter(const ParquetField& field, const
             break;
         case LogicalType::TYPE_DATE:
             *converter = std::make_unique<Int32ToDateConverter>();
+            break;
+        case LogicalType::TYPE_DATETIME:
+            *converter = std::make_unique<Int32ToDateTimeConverter>();
             break;
             // when decimal precision is greater than 27, precision may be lost in the following
             // process. However to handle most enviroment, we also make progress other than
@@ -554,6 +565,35 @@ Status parquet::Int32ToDateConverter::convert(const ColumnPtr& src, Column* dst)
     memcpy(dst_null_data.data(), src_null_data.data(), size);
     for (size_t i = 0; i < size; i++) {
         dst_data[i]._julian = src_data[i] + date::UNIX_EPOCH_JULIAN;
+    }
+    dst_nullable_column->set_has_null(src_nullable_column->has_null());
+    return Status::OK();
+}
+
+Status parquet::Int32ToDateTimeConverter::convert(const ColumnPtr& src, Column* dst) {
+    auto* src_nullable_column = ColumnHelper::as_raw_column<NullableColumn>(src);
+    // hive only support null column
+    // TODO: support not null
+    auto* dst_nullable_column = down_cast<NullableColumn*>(dst);
+    dst_nullable_column->resize_uninitialized(src_nullable_column->size());
+
+    auto* src_column = ColumnHelper::as_raw_column<FixedLengthColumn<int32_t>>(src_nullable_column->data_column());
+    auto* dst_column = ColumnHelper::as_raw_column<TimestampColumn>(dst_nullable_column->data_column());
+
+    auto& src_data = src_column->get_data();
+    auto& dst_data = dst_column->get_data();
+    auto& src_null_data = src_nullable_column->null_column()->get_data();
+    auto& dst_null_data = dst_nullable_column->null_column()->get_data();
+
+    size_t size = src_column->size();
+    for (size_t i = 0; i < size; i++) {
+        dst_null_data[i] = src_null_data[i];
+        if (!src_null_data[i]) {
+            int64_t day = src_data[i];
+            TimestampValue ep;
+            ep.from_unix_second(day * 24 * 60 * 60, 0);
+            dst_data[i].set_timestamp(ep.timestamp());
+        }
     }
     dst_nullable_column->set_has_null(src_nullable_column->has_null());
     return Status::OK();

--- a/be/test/formats/parquet/column_converter_test.cpp
+++ b/be/test/formats/parquet/column_converter_test.cpp
@@ -270,6 +270,17 @@ TEST_F(ColumnConverterTest, Int32Test) {
         }
     }
     {
+        const std::string col_name = "date";
+        {
+            const TypeDescriptor col_type = TypeDescriptor::from_logical_type(LogicalType::TYPE_DATE);
+            check(file_path, col_type, col_name, "[2023-04-25]", expected_rows);
+        }
+        {
+            const TypeDescriptor col_type = TypeDescriptor::from_logical_type(LogicalType::TYPE_DATETIME);
+            check(file_path, col_type, col_name, "[2023-04-25 00:00:00]", expected_rows);
+        }
+    }
+    {
         const std::string col_name = "decimal32";
         {
             const TypeDescriptor col_type = TypeDescriptor::from_logical_type(LogicalType::TYPE_DECIMAL, -1, 9, 2);


### PR DESCRIPTION
Why I'm doing:

What I'm doing:

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [x] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [x] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
