### PR TITLE
[BugFix] Fix view rewrite when view contains non SPJG plan

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/MaterializedViewOptimizer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/MaterializedViewOptimizer.java
@@ -53,7 +53,7 @@ public class MaterializedViewOptimizer {
         }
         OptExpression mvPlan = plans.first;
         if (!MvUtils.isValidMVPlan(mvPlan)) {
-            return new MvPlanContext(false, MvUtils.getInvalidReason(mvPlan));
+            return new MvPlanContext(false, MvUtils.getInvalidReason(mvPlan, inlineView));
         }
         return new MvPlanContext(mvPlan, plans.second.getOutputColumn(), columnRefFactory);
     }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/MvRewritePreprocessor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/MvRewritePreprocessor.java
@@ -232,6 +232,7 @@ public class MvRewritePreprocessor {
             Set<Table> queryTables = MvUtils.getAllTables(queryOptExpression).stream().collect(Collectors.toSet());
             logMVParams(connectContext, queryTables);
 
+            QueryMaterializationContext queryMaterializationContext = new QueryMaterializationContext();
             try {
                 // 1. get related mvs for all input tables
                 Set<MaterializedView> relatedMVs = getRelatedMVs(queryTables, context.getOptimizerConfig().isRuleBased());
@@ -246,14 +247,17 @@ public class MvRewritePreprocessor {
                 prepareRelatedMVs(queryTables, mvWithPlanContexts);
 
                 // 5. process relate mvs with views
-                if (!mvWithPlanContexts.isEmpty() && connectContext.getSessionVariable().isEnableViewBasedMvRewrite()) {
-                    // if related mvs is empty, no need to process plans with view
-                    processPlanWithView(connectContext, logicalTree, queryColumnRefFactory, requiredColumns);
-                }
+                processPlanWithView(queryMaterializationContext, connectContext, logicalTree,
+                        queryColumnRefFactory, requiredColumns);
             } catch (Exception e) {
                 List<String> tableNames = queryTables.stream().map(Table::getName).collect(Collectors.toList());
                 logMVPrepare(connectContext, "Prepare query tables {} for mv failed:{}", tableNames, e.getMessage());
                 LOG.warn("Prepare query tables {} for mv failed", tableNames, e);
+            }
+
+            // add queryMaterializationContext into context
+            if (context.getCandidateMvs() != null && !context.getCandidateMvs().isEmpty()) {
+                context.setQueryMaterializationContext(queryMaterializationContext);
             }
         }
     }
@@ -271,6 +275,8 @@ public class MvRewritePreprocessor {
         logMVPrepare(connectContext, "  enable_experimental_mv: {}", Config.enable_experimental_mv);
         logMVPrepare(connectContext, "  enable_materialized_view_rewrite: {}",
                 sessionVariable.isEnableMaterializedViewRewrite());
+        logMVPrepare(connectContext, "  enable_view_based_mv_rewrite: {}",
+                sessionVariable.isEnableViewBasedMvRewrite());
         logMVPrepare(connectContext, "  enable_materialized_view_union_rewrite: {}",
                 sessionVariable.isEnableMaterializedViewUnionRewrite());
         logMVPrepare(connectContext, "  enable_materialized_view_view_delta_rewrite: {}",
@@ -315,10 +321,14 @@ public class MvRewritePreprocessor {
         logMVPrepare(connectContext, "---------------------------------");
     }
 
-    private void processPlanWithView(ConnectContext connectContext,
+    private void processPlanWithView(QueryMaterializationContext queryMaterializationContext,
+                                     ConnectContext connectContext,
                                      OptExpression logicOperatorTree,
                                      ColumnRefFactory columnRefFactory,
                                      ColumnRefSet requiredColumns) {
+        if (!connectContext.getSessionVariable().isEnableViewBasedMvRewrite()) {
+            return;
+        }
         List<LogicalViewScanOperator> viewScans = Lists.newArrayList();
         // process equivalent operator，construct logical plan with view
         OptExpression logicalPlanWithView = extractLogicalPlanWithView(logicOperatorTree, viewScans, columnRefFactory);
@@ -329,8 +339,8 @@ public class MvRewritePreprocessor {
         // optimize logical plan with view
         OptExpression optimizedPlan = optimizeViewPlan(
                 logicalPlanWithView, connectContext, requiredColumns, columnRefFactory);
-        context.setLogicalTreeWithView(optimizedPlan);
-        context.setViewScans(viewScans);
+        queryMaterializationContext.setLogicalTreeWithView(optimizedPlan);
+        queryMaterializationContext.setViewScans(viewScans);
     }
 
     private OptExpression optimizeViewPlan(OptExpression logicalTree,
@@ -437,7 +447,7 @@ public class MvRewritePreprocessor {
                 .collect(Collectors.toSet());
     }
 
-    private MvWithPlanContext getMVWithContext(MaterializedView mv) {
+    private List<MvWithPlanContext> getMVWithContext(MaterializedView mv) {
         if (!mv.isActive()) {
             logMVPrepare(connectContext, mv, "MV is not active: {}", mv.getName());
             return null;
@@ -450,15 +460,17 @@ public class MvRewritePreprocessor {
                     mv.getName());
             return null;
         }
-        for (MvPlanContext mvPlanContext : mvPlanContexts) {
+        List<MvWithPlanContext> mvWithPlanContexts = Lists.newArrayList();
+        for (int i = 0; i < mvPlanContexts.size(); i++) {
+            MvPlanContext mvPlanContext = mvPlanContexts.get(i);
             if (!mvPlanContext.isValidMvPlan()) {
-                logMVPrepare(connectContext, mv, "MV plan is not valid: "
-                        + mvPlanContext.getInvalidReason());
+                logMVPrepare(connectContext, mv, "MV plan is not valid({}/{}): {}",
+                        i, mvPlanContexts.size(), mvPlanContext.getInvalidReason());
                 continue;
             }
-            return new MvWithPlanContext(mv, mvPlanContext);
+            mvWithPlanContexts.add(new MvWithPlanContext(mv, mvPlanContext));
         }
-        return null;
+        return mvWithPlanContexts;
     }
 
     private boolean canMVRewriteIfMVHasExtraTables(MaterializedView mv,
@@ -496,10 +508,15 @@ public class MvRewritePreprocessor {
             return false;
         }
         // if mv is in plan cache(avoid building plan), check whether it's valid
-        List<MvPlanContext> planContexts = CachingMvPlanContextBuilder.getInstance().getPlanContextFromCacheIfPresent(mv);
-        if (planContexts != null && planContexts.stream().noneMatch(mvPlanContext -> mvPlanContext.isValidMvPlan())) {
-            logMVPrepare(connectContext, mv, "MV has not a valid plan: {}", mv.getName());
-            return false;
+        if (connectContext.getSessionVariable().isEnableMaterializedViewPlanCache()) {
+            List<MvPlanContext> planContexts = CachingMvPlanContextBuilder.getInstance()
+                    .getPlanContextFromCacheIfPresent(mv);
+            if (planContexts != null && !planContexts.isEmpty() &&
+                    planContexts.stream().noneMatch(mvPlanContext -> mvPlanContext.isValidMvPlan())) {
+                logMVPrepare(connectContext, "MV {} has not a valid plan from {} plan contexts",
+                        mv.getName(), planContexts.size());
+                return false;
+            }
         }
         return true;
     }
@@ -539,18 +556,18 @@ public class MvRewritePreprocessor {
                                                       OptExpression queryOptExpression) {
         // 1. filter mvs which is set by config: including/excluding mvs
         Set<MaterializedView> validMVs = getRelatedMVsByConfig(relatedMVs);
-        logMVPrepare(connectContext, "Choose {} mvs from {} after user config", validMVs.size(), relatedMVs.size());
+        logMVPrepare(connectContext, "Choose {}/{} mvs after user config", validMVs.size(), relatedMVs.size());
 
         // 2. choose all valid mvs and filter mvs that cannot be rewritten for the query
         validMVs = validMVs.stream()
                 .filter(mv -> isMVValidToRewriteQuery(mv, queryTables))
                 .collect(Collectors.toSet());
-        logMVPrepare(connectContext, "Choose {} valid mvs from {} after checking valid",
+        logMVPrepare(connectContext, "Choose {}/{} valid mvs after checking valid",
                 validMVs.size(), relatedMVs.size());
 
         // 3. choose max config related mvs for mv rewrite to avoid too much optimize time
         int maxRelatedMVsLimit = connectContext.getSessionVariable().getCboMaterializedViewRewriteRelatedMVsLimit();
-        if (maxRelatedMVsLimit < 1 && validMVs.size() <= maxRelatedMVsLimit) {
+        if (validMVs.size() <= maxRelatedMVsLimit) {
             return validMVs;
         }
         return chooseBestRelatedMVsByCorrelations(queryTables, validMVs, queryOptExpression, maxRelatedMVsLimit);
@@ -561,9 +578,9 @@ public class MvRewritePreprocessor {
         Set<MvWithPlanContext> mvWithPlanContexts = Sets.newHashSet();
         for (MaterializedView mv : validMVs) {
             try {
-                MvWithPlanContext mvWithPlanContext = getMVWithContext(mv);
+                List<MvWithPlanContext> mvWithPlanContext = getMVWithContext(mv);
                 if (mvWithPlanContext != null) {
-                    mvWithPlanContexts.add(mvWithPlanContext);
+                    mvWithPlanContexts.addAll(mvWithPlanContext);
                 }
             } catch (Exception e) {
                 logMVPrepare(connectContext, "Get mv plan context failed:{}", e.getMessage());

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/MvRewritePreprocessor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/MvRewritePreprocessor.java
@@ -109,7 +109,8 @@ public class MvRewritePreprocessor {
         return logicalTree;
     }
 
-    class MvWithPlanContext {
+    @VisibleForTesting
+    public class MvWithPlanContext {
         private final MaterializedView mv;
         private final MvPlanContext mvPlanContext;
         public MvWithPlanContext(MaterializedView mv, MvPlanContext mvPlanContext) {
@@ -573,7 +574,8 @@ public class MvRewritePreprocessor {
         return chooseBestRelatedMVsByCorrelations(queryTables, validMVs, queryOptExpression, maxRelatedMVsLimit);
     }
 
-    private Set<MvWithPlanContext> getMvWithPlanContext(Set<MaterializedView> validMVs) {
+    @VisibleForTesting
+    public Set<MvWithPlanContext> getMvWithPlanContext(Set<MaterializedView> validMVs) {
         // filter mvs which are active and have valid plans
         Set<MvWithPlanContext> mvWithPlanContexts = Sets.newHashSet();
         for (MaterializedView mv : validMVs) {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/OptExpression.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/OptExpression.java
@@ -240,7 +240,7 @@ public class OptExpression {
         String childHeadlinePrefix = detailPrefix + "->  ";
         String childDetailPrefix = detailPrefix + "    ";
         for (OptExpression input : inputs) {
-            sb.append(input.debugString(childHeadlinePrefix, childDetailPrefix, limitLine)).append("\n");
+            sb.append(input.debugString(childHeadlinePrefix, childDetailPrefix, limitLine));
         }
         return sb.toString();
     }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/Optimizer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/Optimizer.java
@@ -31,6 +31,7 @@ import com.starrocks.sql.optimizer.cost.CostEstimate;
 import com.starrocks.sql.optimizer.operator.Operator;
 import com.starrocks.sql.optimizer.operator.logical.LogicalOlapScanOperator;
 import com.starrocks.sql.optimizer.operator.logical.LogicalTreeAnchorOperator;
+import com.starrocks.sql.optimizer.operator.logical.LogicalViewScanOperator;
 import com.starrocks.sql.optimizer.rule.Rule;
 import com.starrocks.sql.optimizer.rule.RuleSetType;
 import com.starrocks.sql.optimizer.rule.implementation.OlapScanImplementationRule;
@@ -202,9 +203,9 @@ public class Optimizer {
         }
 
         memo.init(logicOperatorTree);
-        if (context.getLogicalTreeWithView() != null) {
+        if (context.getQueryMaterializationContext() != null) {
             // LogicalTreeWithView is logically equivalent to logicOperatorTree
-            addViewBasedPlanIntoMemo();
+            addViewBasedPlanIntoMemo(context.getQueryMaterializationContext().getLogicalTreeWithView());
         }
         OptimizerTraceUtil.log("after logical rewrite, root group:\n%s", memo.getRootGroup());
 
@@ -254,9 +255,12 @@ public class Optimizer {
         }
     }
 
-    private void addViewBasedPlanIntoMemo() {
+    private void addViewBasedPlanIntoMemo(OptExpression logicalTreeWithView) {
+        if (logicalTreeWithView == null) {
+            return;
+        }
         Memo memo = context.getMemo();
-        memo.copyIn(memo.getRootGroup(), context.getLogicalTreeWithView());
+        memo.copyIn(memo.getRootGroup(), logicalTreeWithView);
     }
 
     private void prepare(
@@ -276,9 +280,6 @@ public class Optimizer {
         // prepare related mvs if needed
         new MvRewritePreprocessor(connectContext, columnRefFactory,
                 context, logicOperatorTree, requiredColumns).prepare(logicOperatorTree);
-        if (context.getCandidateMvs() != null && !context.getCandidateMvs().isEmpty()) {
-            context.setQueryMaterializationContext(new QueryMaterializationContext());
-        }
     }
 
     private void pruneTables(OptExpression tree, TaskContext rootTaskContext, ColumnRefSet requiredColumns) {
@@ -461,8 +462,7 @@ public class Optimizer {
         ruleRewriteOnlyOnce(tree, rootTaskContext, SplitScanORToUnionRule.getInstance());
         ruleRewriteOnlyOnce(tree, rootTaskContext, new PushDownTopNBelowUnionRule());
 
-        // try view based mv rewrite first,
-        // then try normal mv rewrite rules
+        // try view based mv rewrite first, then try normal mv rewrite rules
         if (isEnableSingleViewMvRewrite()) {
             // view based mv rewrite for single view
             viewBasedMvRuleRewrite(tree, rootTaskContext);
@@ -499,26 +499,30 @@ public class Optimizer {
 
     // for single scan node, to make sure we can rewrite
     private void viewBasedMvRuleRewrite(OptExpression tree, TaskContext rootTaskContext) {
+        QueryMaterializationContext queryMaterializationContext = context.getQueryMaterializationContext();
+        Preconditions.checkArgument(queryMaterializationContext != null);
         try {
             OptimizerTraceUtil.logMVRewriteRule("VIEW_BASED_MV_REWRITE", "try VIEW_BASED_MV_REWRITE");
-            OptExpression treeWithView = context.getLogicalTreeWithView();
+            OptExpression treeWithView = queryMaterializationContext.getLogicalTreeWithView();
             // should add a LogicalTreeAnchorOperator for rewrite
             treeWithView = OptExpression.create(new LogicalTreeAnchorOperator(), treeWithView);
             deriveLogicalProperty(treeWithView);
             ruleRewriteIterative(treeWithView, rootTaskContext, RuleSetType.SINGLE_TABLE_MV_REWRITE);
             List<Operator> viewScanOperators = Lists.newArrayList();
             MvUtils.collectViewScanOperator(treeWithView, viewScanOperators);
-            if (viewScanOperators.size() < context.getViewScans().size()) {
+
+            List<LogicalViewScanOperator> mvViewScanOperators = queryMaterializationContext.getViewScans();
+            if (viewScanOperators.size() < mvViewScanOperators.size()) {
                 // replace original tree plan
                 tree.setChild(0, treeWithView.inputAt(0));
                 deriveLogicalProperty(tree);
                 if (!viewScanOperators.isEmpty()) {
                     // if there are view scan operator left, we should replace it back to original plans
-                    MvUtils.replaceLogicalViewScanOperator(tree, context.getViewScans());
+                    MvUtils.replaceLogicalViewScanOperator(tree, queryMaterializationContext);
                 }
                 OptimizerTraceUtil.logMVRewriteRule("VIEW_BASED_MV_REWRITE",
                         "original view scans size: {}, left view scans size: {}",
-                        context.getViewScans().size(), viewScanOperators.size());
+                        mvViewScanOperators.size(), viewScanOperators.size());
             }
             OptimizerTraceUtil.logMVRewriteRule("VIEW_BASED_MV_REWRITE", "VIEW_BASED_MV_REWRITE applied");
         } catch (Exception e) {
@@ -528,7 +532,8 @@ public class Optimizer {
     }
 
     private boolean isEnableSingleViewMvRewrite() {
-        return context.getLogicalTreeWithView() != null
+        return context.getQueryMaterializationContext() != null
+                && context.getQueryMaterializationContext().getLogicalTreeWithView() != null
                 && !optimizerConfig.isRuleSetTypeDisable(RuleSetType.SINGLE_TABLE_MV_REWRITE)
                 && !context.getCandidateMvs().isEmpty()
                 && context.getCandidateMvs().stream().anyMatch(MaterializationContext::isSingleTable)

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/OptimizerContext.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/OptimizerContext.java
@@ -27,7 +27,6 @@ import com.starrocks.sql.common.ErrorType;
 import com.starrocks.sql.common.StarRocksPlannerException;
 import com.starrocks.sql.optimizer.base.ColumnRefFactory;
 import com.starrocks.sql.optimizer.dump.DumpInfo;
-import com.starrocks.sql.optimizer.operator.logical.LogicalViewScanOperator;
 import com.starrocks.sql.optimizer.rule.RuleSet;
 import com.starrocks.sql.optimizer.rule.RuleType;
 import com.starrocks.sql.optimizer.task.SeriallyTaskScheduler;
@@ -62,15 +61,8 @@ public class OptimizerContext {
     private final Stopwatch optimizerTimer = Stopwatch.createStarted();
     private final Map<RuleType, Stopwatch> ruleWatchMap = Maps.newHashMap();
 
-    // used by view based mv rewrite
-    // query's logical plan with view
-    private OptExpression logicalTreeWithView;
-    // collect LogicalViewScanOperators
-    private List<LogicalViewScanOperator> viewScans;
-
     // QueryMaterializationContext is different from MaterializationContext that it keeps the context during the query
     // lifecycle instead of per materialized view.
-    // TODO: refactor materialized view's variables/contexts into this.
     private QueryMaterializationContext queryMaterializationContext;
 
     private boolean isShortCircuit = false;
@@ -243,22 +235,6 @@ public class OptimizerContext {
                 "2. try query again, " +
                 "3. enlarge new_planner_optimize_timeout session variable",
                 ErrorType.INTERNAL_ERROR);
-    }
-
-    public OptExpression getLogicalTreeWithView() {
-        return logicalTreeWithView;
-    }
-
-    public void setLogicalTreeWithView(OptExpression logicalTreeWithView) {
-        this.logicalTreeWithView = logicalTreeWithView;
-    }
-
-    public void setViewScans(List<LogicalViewScanOperator> viewScans) {
-        this.viewScans = viewScans;
-    }
-
-    public List<LogicalViewScanOperator> getViewScans() {
-        return viewScans;
     }
 
     public void setQueryMaterializationContext(QueryMaterializationContext queryMaterializationContext) {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/OptimizerTraceUtil.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/OptimizerTraceUtil.java
@@ -111,8 +111,8 @@ public class OptimizerTraceUtil {
                     sb.append(i).append(":").append(newExpressions.get(i).debugString());
                 }
             }
+            sb.append("\n");
             return sb.toString();
         });
     }
-
 }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/QueryMaterializationContext.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/QueryMaterializationContext.java
@@ -21,6 +21,7 @@ import com.github.benmanes.caffeine.cache.Caffeine;
 import com.starrocks.common.Config;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.sql.common.QueryDebugOptions;
+import com.starrocks.sql.optimizer.operator.logical.LogicalViewScanOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ScalarOperator;
 import com.starrocks.sql.optimizer.rewrite.ReplaceColumnRefRewriter;
 import com.starrocks.sql.optimizer.rewrite.ScalarOperatorRewriter;
@@ -28,6 +29,7 @@ import com.starrocks.sql.optimizer.rule.transformation.materialization.Predicate
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
+import java.util.List;
 import java.util.Set;
 
 /**
@@ -35,6 +37,12 @@ import java.util.Set;
  */
 public class QueryMaterializationContext {
     protected static final Logger LOG = LogManager.getLogger(QueryMaterializationContext.class);
+
+    // used by view based mv rewrite
+    // query's logical plan with view
+    private OptExpression logicalTreeWithView;
+    // collect LogicalViewScanOperators
+    private List<LogicalViewScanOperator> viewScans;
 
     // `mvQueryContextCache` is designed for a common cache which is used during the query's rewrite lifecycle, so can be
     // managed in a more unified mode. In the current situation, it's used in two ways:
@@ -88,6 +96,22 @@ public class QueryMaterializationContext {
                     .rewrite(predicate.clone(), ScalarOperatorRewriter.MV_SCALAR_REWRITE_RULES);
             return rewritten;
         });
+    }
+
+    public OptExpression getLogicalTreeWithView() {
+        return logicalTreeWithView;
+    }
+
+    public void setLogicalTreeWithView(OptExpression logicalTreeWithView) {
+        this.logicalTreeWithView = logicalTreeWithView;
+    }
+
+    public void setViewScans(List<LogicalViewScanOperator> viewScans) {
+        this.viewScans = viewScans;
+    }
+
+    public List<LogicalViewScanOperator> getViewScans() {
+        return viewScans;
     }
 
     // Invalidate all caches by hand to avoid memory allocation after query optimization.

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MaterializedViewRewriter.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MaterializedViewRewriter.java
@@ -1811,7 +1811,7 @@ public class MaterializedViewRewriter {
     protected OptExpression queryBasedRewrite(RewriteContext rewriteContext, ScalarOperator compensationPredicates,
                                               OptExpression queryExpression) {
         queryExpression = MvUtils.replaceLogicalViewScanOperator(queryExpression,
-                materializationContext.getOptimizerContext().getViewScans());
+                materializationContext.getOptimizerContext().getQueryMaterializationContext());
         if (queryExpression == null) {
             return null;
         }
@@ -1999,9 +1999,10 @@ public class MaterializedViewRewriter {
         Preconditions.checkState(partitionColumnRef != null);
         ColumnRewriter columnRewriter = new ColumnRewriter(rewriteContext);
         partitionColumnRef = columnRewriter.rewriteViewToQuery(partitionColumnRef).cast();
+
         // for view based mv rewrite, we should mapping the partition column to output column of view scan
-        if (optimizerContext.getViewScans() != null) {
-            for (LogicalViewScanOperator viewScanOperator : optimizerContext.getViewScans()) {
+        if (queryMaterializationContext.getViewScans() != null) {
+            for (LogicalViewScanOperator viewScanOperator : queryMaterializationContext.getViewScans()) {
                 Projection projection = viewScanOperator.getProjection();
                 if (viewScanOperator.getProjection() != null) {
                     for (Map.Entry<ColumnRefOperator, ScalarOperator> entry : projection.getColumnRefMap().entrySet()) {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/rule/BaseMaterializedViewRewriteRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/rule/BaseMaterializedViewRewriteRule.java
@@ -31,7 +31,6 @@ import com.starrocks.sql.optimizer.QueryMaterializationContext;
 import com.starrocks.sql.optimizer.base.ColumnRefFactory;
 import com.starrocks.sql.optimizer.operator.Operator;
 import com.starrocks.sql.optimizer.operator.logical.LogicalOlapScanOperator;
-import com.starrocks.sql.optimizer.operator.logical.LogicalViewScanOperator;
 import com.starrocks.sql.optimizer.operator.pattern.Pattern;
 import com.starrocks.sql.optimizer.operator.scalar.ConstantOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ScalarOperator;
@@ -70,8 +69,6 @@ public abstract class BaseMaterializedViewRewriteRule extends TransformationRule
             if ((table instanceof MaterializedView) && ((MaterializedView) (table)).getRefreshScheme().isSync()) {
                 return false;
             }
-        } else if (op instanceof LogicalViewScanOperator) {
-            return true;
         }
         if (input.getInputs().isEmpty()) {
             return true;

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/rule/BaseMaterializedViewRewriteRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/rule/BaseMaterializedViewRewriteRule.java
@@ -43,6 +43,7 @@ import com.starrocks.sql.optimizer.rule.transformation.materialization.Materiali
 import com.starrocks.sql.optimizer.rule.transformation.materialization.MvUtils;
 import com.starrocks.sql.optimizer.rule.transformation.materialization.PredicateSplit;
 import org.apache.commons.collections4.CollectionUtils;
+import org.apache.commons.lang3.exception.ExceptionUtils;
 
 import java.util.List;
 import java.util.Set;
@@ -95,8 +96,9 @@ public abstract class BaseMaterializedViewRewriteRule extends TransformationRule
         try {
             return doTransform(queryExpression, context);
         } catch (Exception e) {
+            String errMsg = ExceptionUtils.getMessage(e);
             // for mv rewrite rules, do not disturb query when exception.
-            logMVRewrite(context, this, "mv rewrite exception, exception message:{}", e.toString());
+            logMVRewrite(context, this, "mv rewrite exception, exception message:{}", errMsg);
             return Lists.newArrayList();
         }
     }

--- a/fe/fe-core/src/test/java/com/starrocks/planner/ViewBaseMvRewriteTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/planner/ViewBaseMvRewriteTest.java
@@ -2,6 +2,7 @@ package com.starrocks.planner;
 
 import com.starrocks.common.Config;
 import org.junit.AfterClass;
+import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
@@ -433,5 +434,21 @@ public class ViewBaseMvRewriteTest extends MaterializedViewTestBase {
         }
         starRocksAssert.dropView("view_1");
         starRocksAssert.dropView("view_2");
+    }
+
+    @Test
+    public void testViewWithInvalidPlan() {
+        String view = "create view invalid_view0 as select count(distinct cnt) as ndv from " +
+                "(select count(*) cnt from lineitem group by l_returnflag) t";
+        try {
+            starRocksAssert.withView(view);
+        } catch (Exception e) {
+            Assert.fail();
+        }
+        String sql = "create materialized view invalid_plan_mv distributed by random as select * from invalid_view0";
+        starRocksAssert.withMaterializedView(sql, () -> {
+            sql("select * from invalid_view0").contains("invalid_plan_mv");
+            sql("select * from invalid_view0 where ndv > 10").contains("invalid_plan_mv");
+        });
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/PlanTestNoneDBBase.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/PlanTestNoneDBBase.java
@@ -133,8 +133,11 @@ public class PlanTestNoneDBBase {
             StringBuilder sb = new StringBuilder();
             sb.append(first);
             sb.append(LOGICAL_PLAN_PREDICATE_PREFIX + "[");
-            String sorted = Arrays.stream(predicates.split(" AND ")).sorted().collect(Collectors.joining(" AND "));
-            sorted = Arrays.stream(sorted.split(" OR ")).sorted().collect(Collectors.joining(" OR "));
+            // FIXME: This is only used for normalize not for the final result.
+            String sorted = Arrays.stream(predicates.split(" AND "))
+                    .map(p -> Arrays.stream(p.split(" OR ")).sorted().collect(Collectors.joining(" OR ")))
+                    .sorted()
+                    .collect(Collectors.joining(" AND "));
             sb.append(sorted);
             sb.append("])");
             return sb.toString();


### PR DESCRIPTION
Why I'm doing:
1.  query as below cannot be rewritten by view rewite.
```
            // create view v1 as
            // select count(distinct cnt)
            // from
            //   (
            //      select c_city, count(*) as cnt
            //      from customer
            //      group by c_city
            //    ) t
```
2. https://github.com/StarRocks/starrocks/pull/39461 introduce a bug which only return one valid plan context instead of all valid plan contexts.

What I'm doing:

1. Treat agg nested with agg as invalid plan
```
         // Aggregate nested with aggregate is not supported yet.
            // eg:
            // create view v1 as
            // select count(distinct cnt)
            // from
            //   (
            //      select c_city, count(*) as cnt
            //      from customer
            //      group by c_city
            //    ) t
            if (level > 0) {
                return false;
            }
```
2. `getMvWithPlanContext ` will return all valid plans instead of any of them.
3. Refactor some codes.

Fixes https://github.com/StarRocks/StarRocksTest/issues/5873

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
