### PR TITLE
[Doc] move strict mode into parent dir

### DIFF
--- a/docs/docusaurus/sidebars.json
+++ b/docs/docusaurus/sidebars.json
@@ -105,12 +105,7 @@
         "loading/Load_to_Primary_Key_tables",
         "loading/Etl_in_loading",
         "loading/loading_tools",
-        {
-          "type": "category",
-          "label": "Concepts",
-          "link": {"type": "doc", "id": "loading/load_concept/strict_mode"},
-          "items": [ "loading/load_concept/strict_mode" ]
-        }
+        "loading/load_concept/strict_mode"
       ]
     },
     {
@@ -864,12 +859,7 @@
         "loading/Load_to_Primary_Key_tables",
         "loading/Etl_in_loading",
         "loading/loading_tools",
-        {
-          "type": "category",
-          "label": "概念介绍",
-          "link": {"type": "doc", "id": "loading/load_concept/strict_mode"},
-          "items": [ "loading/load_concept/strict_mode" ]
-        }
+        "loading/load_concept/strict_mode"
       ]
     },
     {


### PR DESCRIPTION
There is a loop in nav for the loading/concepts folder. Since there is only one concept doc, there is no need for a folder.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [x] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [x] 3.1
  - [x] 3.0
  - [x] 2.5