### PR TITLE
[BugFix] Fix query_profile http API XSS bug

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/http/action/QueryProfileAction.java
+++ b/fe/fe-core/src/main/java/com/starrocks/http/action/QueryProfileAction.java
@@ -42,6 +42,7 @@ import com.starrocks.http.BaseResponse;
 import com.starrocks.http.IllegalArgException;
 import io.netty.handler.codec.http.HttpMethod;
 import io.netty.handler.codec.http.HttpResponseStatus;
+import org.apache.commons.text.StringEscapeUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -68,8 +69,13 @@ public class QueryProfileAction extends WebBaseAction {
         if (Strings.isNullOrEmpty(queryId)) {
             response.appendContent("");
             response.appendContent("<p class=\"text-error\"> Must specify a query_id[]</p>");
+            getPageFooter(response.getContent());
+            writeResponse(request, response);
+            return;
         }
 
+        // HTML encode the queryId to prevent XSS
+        String encodedQueryId = StringEscapeUtils.escapeHtml4(queryId);
         String queryProfileStr = ProfileManager.getInstance().getProfile(queryId);
         if (queryProfileStr != null) {
             appendCopyButton(response.getContent());
@@ -77,7 +83,7 @@ public class QueryProfileAction extends WebBaseAction {
             getPageFooter(response.getContent());
             writeResponse(request, response);
         } else {
-            appendQueryProfile(response.getContent(), "query id " + queryId + " not found.");
+            appendQueryProfile(response.getContent(), "query id " + encodedQueryId + " not found.");
             getPageFooter(response.getContent());
             writeResponse(request, response, HttpResponseStatus.NOT_FOUND);
         }


### PR DESCRIPTION
Why I'm doing:
```
appendQueryProfile(response.getcontent(), yqure' id queryId + not found. );
```
This line has a XSS bug if queryid include some javascript code:

```
http://localhost:8030/query_profile?query_id=%3Cscript%3Ealert%281%29%3C%2Fscript%3E
```

What I'm doing:

Encode the queryId parameter to avoid the XSS bug

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [x] 3.1
  - [ ] 3.0
  - [ ] 2.5
