### PR TITLE
[Enhancement]Enhance datetime format

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/common/util/DateUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/util/DateUtils.java
@@ -91,19 +91,23 @@ public class DateUtils {
     private static final DateTimeFormatter STRICT_DATE_NO_SPLIT_FORMATTER =
             unixDatetimeStrictFormatter("%Y%m%e", true);
 
-    // isTwoDigit, withMs, withSplitT -> formatter
-    private static final DateTimeFormatter[][][] DATETIME_FORMATTERS = new DateTimeFormatter[2][2][2];
+    // isTwoDigit, withMs, withSplitT, withSec -> formatter
+    private static final DateTimeFormatter[][][][] DATETIME_FORMATTERS = new DateTimeFormatter[2][2][2][2];
 
     static {
-        // isTwoDigit, withMs, withSplitT -> formatter
-        DATETIME_FORMATTERS[0][0][0] = unixDatetimeStrictFormatter("%Y-%m-%e %H:%i:%s", false);
-        DATETIME_FORMATTERS[0][0][1] = unixDatetimeStrictFormatter("%Y-%m-%eT%H:%i:%s", false);
-        DATETIME_FORMATTERS[0][1][0] = unixDatetimeStrictFormatter("%Y-%m-%e %H:%i:%s.%f", false);
-        DATETIME_FORMATTERS[0][1][1] = unixDatetimeStrictFormatter("%Y-%m-%eT%H:%i:%s.%f", false);
-        DATETIME_FORMATTERS[1][0][0] = unixDatetimeStrictFormatter("%y-%m-%e %H:%i:%s", false);
-        DATETIME_FORMATTERS[1][0][1] = unixDatetimeStrictFormatter("%y-%m-%eT%H:%i:%s", false);
-        DATETIME_FORMATTERS[1][1][0] = unixDatetimeStrictFormatter("%y-%m-%e %H:%i:%s.%f", false);
-        DATETIME_FORMATTERS[1][1][1] = unixDatetimeStrictFormatter("%y-%m-%eT%H:%i:%s.%f", false);
+        // isTwoDigit, withMs, withSplitT, withSec -> formatter
+        DATETIME_FORMATTERS[0][0][0][0] = unixDatetimeStrictFormatter("%Y-%m-%e %H:%i", false);
+        DATETIME_FORMATTERS[0][0][0][1] = unixDatetimeStrictFormatter("%Y-%m-%e %H:%i:%s", false);
+        DATETIME_FORMATTERS[0][0][1][0] = unixDatetimeStrictFormatter("%Y-%m-%eT%H:%i", false);
+        DATETIME_FORMATTERS[0][0][1][1] = unixDatetimeStrictFormatter("%Y-%m-%eT%H:%i:%s", false);
+        DATETIME_FORMATTERS[0][1][0][1] = unixDatetimeStrictFormatter("%Y-%m-%e %H:%i:%s.%f", false);
+        DATETIME_FORMATTERS[0][1][1][1] = unixDatetimeStrictFormatter("%Y-%m-%eT%H:%i:%s.%f", false);
+        DATETIME_FORMATTERS[1][0][0][0] = unixDatetimeStrictFormatter("%y-%m-%e %H:%i", false);
+        DATETIME_FORMATTERS[1][0][0][1] = unixDatetimeStrictFormatter("%y-%m-%e %H:%i:%s", false);
+        DATETIME_FORMATTERS[1][0][1][0] = unixDatetimeStrictFormatter("%y-%m-%eT%H:%i", false);
+        DATETIME_FORMATTERS[1][0][1][1] = unixDatetimeStrictFormatter("%y-%m-%eT%H:%i:%s", false);
+        DATETIME_FORMATTERS[1][1][0][1] = unixDatetimeStrictFormatter("%y-%m-%e %H:%i:%s.%f", false);
+        DATETIME_FORMATTERS[1][1][1][1] = unixDatetimeStrictFormatter("%y-%m-%eT%H:%i:%s.%f", false);
     }
 
     public static String formatDateTimeUnix(LocalDateTime dateTime) {
@@ -128,9 +132,10 @@ public class DateUtils {
         if (str.contains(":")) {
             // datetime
             int isTwoDigit = str.split("-")[0].length() == 2 ? 1 : 0;
+            int withSec = str.split(":").length > 2 ? 1 : 0;
             int withMs = str.contains(".") ? 1 : 0;
             int withSplitT = str.contains("T") ? 1 : 0;
-            DateTimeFormatter formatter = DATETIME_FORMATTERS[isTwoDigit][withMs][withSplitT];
+            DateTimeFormatter formatter = DATETIME_FORMATTERS[isTwoDigit][withMs][withSplitT][withSec];
             return parseStringWithDefaultHSM(str, formatter);
         } else {
             // date

--- a/fe/fe-core/src/test/java/com/starrocks/common/util/DateUtilsTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/common/util/DateUtilsTest.java
@@ -67,6 +67,20 @@ public class DateUtilsTest {
                 long ts = Utils.getLongFromDateTime(lt2);
                 Assert.assertEquals(ts, 1682600771);
             }
+
+            {
+                String datetime1 = "2024-01-27T21:06";
+                LocalDateTime lt1 = DateUtils.parseStrictDateTime(datetime1);
+                Assert.assertEquals(lt1.toString(), "2024-01-27T21:06");
+                String datetime2 = "2024-01-27T21:06:00";
+                LocalDateTime lt2 = DateUtils.parseStrictDateTime(datetime2);
+                Assert.assertEquals(lt2.toString(), "2024-01-27T21:06");
+                Assert.assertEquals(Utils.getLongFromDateTime(lt1), Utils.getLongFromDateTime(lt2));
+                String datetime3 = "2024-01-27 21:06:01";
+                LocalDateTime lt3 = DateUtils.parseStrictDateTime(datetime3);
+                Assert.assertEquals(lt3.toString(), "2024-01-27T21:06:01");
+            }
+
         } catch (Exception e) {
             Assert.fail();
         }

--- a/test/sql/test_iceberg/R/test_iceberg_catalog_timestamp
+++ b/test/sql/test_iceberg/R/test_iceberg_catalog_timestamp
@@ -1,0 +1,29 @@
+-- name: test_iceberg_catalog_timestamp_type
+create external catalog ice_cat_${uuid0}
+properties
+(
+    "type" = "iceberg",
+    "iceberg.catalog.type" = "hive",
+    "hive.metastore.uris" = "${iceberg_catalog_hive_metastore_uris}"
+);
+set catalog ice_cat_${uuid0};
+create database ice_db_${uuid0};
+use ice_db_${uuid0};
+create table ice_tbl_${uuid0} (
+  col_str int,
+  col_int datetime
+);
+insert into ice_tbl_${uuid0} values (1, '2024-01-29 01:00:00'),(2, '2024-01-30 20:10:00'),(3,null);
+-- result:
+-- !result
+select * from ice_cat_${uuid0}.ice_db_${uuid0}.ice_tbl_${uuid0};
+-- result:
+1	2024-01-29 01:00:00
+2	2024-01-30 20:10:00
+3	None
+-- !result
+drop table ice_tbl_${uuid0} force;
+drop database ice_db_${uuid0};
+drop catalog ice_cat_${uuid0};
+-- result:
+-- !result

--- a/test/sql/test_iceberg/T/test_iceberg_catalog_timestamp
+++ b/test/sql/test_iceberg/T/test_iceberg_catalog_timestamp
@@ -1,0 +1,22 @@
+-- name: test_iceberg_catalog_timestamp_type
+create external catalog ice_cat_${uuid0}
+properties
+(
+    "type" = "iceberg",
+    "iceberg.catalog.type" = "hive",
+    "hive.metastore.uris" = "${iceberg_catalog_hive_metastore_uris}"
+);
+set catalog ice_cat_${uuid0};
+create database ice_db_${uuid0};
+use ice_db_${uuid0};
+create table ice_tbl_${uuid0} (
+  col_str int,
+  col_int datetime
+);
+insert into ice_tbl_${uuid0} values (1, '2024-01-29 01:00:00'),(2, '2024-01-30 20:10:00'),(3,null);
+
+select * from ice_cat_${uuid0}.ice_db_${uuid0}.ice_tbl_${uuid0};
+
+drop table ice_tbl_${uuid0} force;
+drop database ice_db_${uuid0};
+drop catalog ice_cat_${uuid0};


### PR DESCRIPTION
Why I'm doing:

> when iceberg table partition filed is timestamp and partitions value second is 0 , starrocks will throw [date literal [2024-01-24T10:10] is invalid] exception.Because starrocks DATETIME_FORMATTERS not support format [%Y-%m-%e %H:%i].

What I'm doing:

> Enhance datetime format

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [x] 3.1
  - [x] 3.0
  - [ ] 2.5
