### PR TITLE
[BugFix] fix not support force rewrite or to union

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/scalar/FilterSelectivityEvaluator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/scalar/FilterSelectivityEvaluator.java
@@ -143,6 +143,7 @@ public class FilterSelectivityEvaluator {
             } else if (left.isColumnRef() && right.isConstant()) {
                 selectRatio = estimateColumnToExprSelectRatio(columnStatistic, predicate);
             } else {
+                // TODO need to process left child is an expr contains only one col?
                 selectRatio = NON_SELECTIVITY;
             }
             return new ColumnFilter(selectRatio, column, predicate);

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/scalar/FilterSelectivityEvaluator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/scalar/FilterSelectivityEvaluator.java
@@ -140,10 +140,9 @@ public class FilterSelectivityEvaluator {
             if (left.isColumnRef() && right.isConstantRef()) {
                 selectRatio =
                         estimateColToConstSelectRatio(column, columnStatistic, predicate, (ConstantOperator) right);
-            } else if (left.isColumnRef()) {
+            } else if (left.isColumnRef() && right.isConstant()) {
                 selectRatio = estimateColumnToExprSelectRatio(columnStatistic, predicate);
             } else {
-                // TODO need to process left child is an expr contains only one col?
                 selectRatio = NON_SELECTIVITY;
             }
             return new ColumnFilter(selectRatio, column, predicate);
@@ -193,9 +192,15 @@ public class FilterSelectivityEvaluator {
                 case AND:
                     ColumnFilter leftChild = predicate.getChild(0).accept(this, null);
                     ColumnFilter rightChild = predicate.getChild(1).accept(this, null);
-                    // choose the child with smaller selectRation
-                    return leftChild.compareTo(rightChild) < 0 ? new ColumnFilter(leftChild.selectRatio, predicate) :
-                            new ColumnFilter(rightChild.selectRatio, predicate);
+                    double selectRatio;
+                    if (leftChild.getSelectRatio() < 1 && rightChild.getSelectRatio() < 1) {
+                        selectRatio = leftChild.selectRatio * rightChild.selectRatio;
+                    } else if (leftChild.compareTo(rightChild) < 0) {
+                        selectRatio = leftChild.selectRatio;
+                    } else {
+                        selectRatio = rightChild.selectRatio;
+                    }
+                    return new ColumnFilter(selectRatio, predicate);
 
                 default:
                     return new ColumnFilter(NON_SELECTIVITY, predicate);

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/SplitScanORToUnionRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/SplitScanORToUnionRule.java
@@ -93,7 +93,8 @@ public class SplitScanORToUnionRule extends TransformationRule {
                 scan.getColRefToColumnMetaMap());
         Statistics statistics = builder.setOutputRowCount(totalRowCount).build();
 
-        if (statistics.getComputeSize() <= context.getSessionVariable().getScanOrToUnionThreshold()) {
+        if (!isForceRewrite() &&
+                statistics.getComputeSize() <= context.getSessionVariable().getScanOrToUnionThreshold()) {
             return Lists.newArrayList();
         }
 
@@ -102,7 +103,7 @@ public class SplitScanORToUnionRule extends TransformationRule {
         List<ColumnFilter> columnFilters = selectivityEvaluator.evaluate();
 
         // already has a predicate can use index and late materialized to filter a large part of rows
-        if (columnFilters.get(0).getSelectRatio() < HIGH_SELECTIVITY) {
+        if (!isForceRewrite() && columnFilters.get(0).getSelectRatio() < HIGH_SELECTIVITY) {
             return Lists.newArrayList();
         }
 
@@ -142,7 +143,7 @@ public class SplitScanORToUnionRule extends TransformationRule {
         }
 
         int idx = -1;
-        double min  = NON_SELECTIVITY;
+        double min  = isForceRewrite() ? NON_SELECTIVITY + 1 : NON_SELECTIVITY;
 
         int childrenOfUnion = ConnectContext.get().getSessionVariable().getScanOrToUnionLimit();
 
@@ -213,7 +214,14 @@ public class SplitScanORToUnionRule extends TransformationRule {
     private boolean canBenefitFromSplit(double existSelectRatio, double splitMaxSelectRatio) {
         SessionVariable sessionVariable = ConnectContext.get().getSessionVariable();
         int childrenNumOfUnion = sessionVariable.getScanOrToUnionLimit();
+        if (isForceRewrite()) {
+            return true;
+        }
         existSelectRatio = Math.min(existSelectRatio, sessionVariable.getSelectRatioThreshold());
         return splitMaxSelectRatio < existSelectRatio / childrenNumOfUnion;
+    }
+
+    private boolean isForceRewrite() {
+        return ConnectContext.get().getSessionVariable().getSelectRatioThreshold() < 0;
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/SplitScanToUnionTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/SplitScanToUnionTest.java
@@ -67,8 +67,19 @@ class SplitScanToUnionTest extends DistributedEnvPlanTestBase {
     @Order(3)
     void testForceSplit() throws Exception {
         String sql = "select * from t0 where v1 = 1 or v2 = 2";
-        connectContext.getSessionVariable().setScanOrToUnionThreshold(1);
-        connectContext.getSessionVariable().setSelectRatioThreshold(100000);
+        connectContext.getSessionVariable().setSelectRatioThreshold(-1);
+        assertContains(getFragmentPlan(sql), "UNION");
+
+        sql = "select * from t0 where v1 > 1 and v1 < 3 or v1 >100000 and v1 < 100010 or v1 >200000 and v1 < 200010 " +
+                "or v1 > 400000 and v1 < 500010";
+        assertContains(getFragmentPlan(sql), "UNION");
+
+        sql = "select * from test_all_type where date_trunc('year', id_date) > '2021-01-01' " +
+                "and date_trunc('year', id_date) < '2022-01-01' or date_trunc('month', id_date) > '2020-06-01' and " +
+                "date_trunc('month', id_date) < '2021-01-01'";
+        assertContains(getFragmentPlan(sql), "UNION");
+
+        sql = "select * from t0 where v1 > v2 or v1 = 1";
         assertContains(getFragmentPlan(sql), "UNION");
     }
 
@@ -110,16 +121,17 @@ class SplitScanToUnionTest extends DistributedEnvPlanTestBase {
 
         sql = "select * from orders where (O_ORDERKEY < 1 and O_CLERK = 'a') or (O_COMMENT = 'c' and O_CUSTKEY <=> null)";
         arguments = Arguments.of(sql, ImmutableList.of("UNION",
-                "PREDICATES: 1: O_ORDERKEY < 1, 7: O_CLERK = 'a'",
-                "PREDICATES: 9: O_COMMENT = 'c', 2: O_CUSTKEY <=> NULL, NOT ((1: O_ORDERKEY < 1) AND (7: O_CLERK = 'a'))"));
+                "PREDICATES: 9: O_COMMENT = 'c', 2: O_CUSTKEY <=> NULL",
+                "PREDICATES: 1: O_ORDERKEY < 1, 7: O_CLERK = 'a', NOT ((9: O_COMMENT = 'c') AND (2: O_CUSTKEY <=> NULL))"));
         list.add(arguments);
 
         sql = "select * from orders where ((O_COMMENT = 'c' and O_CUSTKEY in (1, 100, 1000)) " +
                 "or (O_CLERK = 'a')) or (O_ORDERKEY in (200, 300))";
         arguments = Arguments.of(sql, ImmutableList.of("UNION",
-                "PREDICATES: 1: O_ORDERKEY IN (200, 300)",
-                "PREDICATES: 9: O_COMMENT = 'c', 2: O_CUSTKEY IN (1, 100, 1000), 1: O_ORDERKEY NOT IN",
-                "PREDICATES: 7: O_CLERK = 'a', 1: O_ORDERKEY NOT IN (200, 300), NOT"));
+                "PREDICATES: 9: O_COMMENT = 'c', 2: O_CUSTKEY IN (1, 100, 1000)",
+                "PREDICATES: 1: O_ORDERKEY IN (200, 300), NOT ((9: O_COMMENT = 'c') AND (2: O_CUSTKEY IN (1, 100, 1000)))",
+                "PREDICATES: 7: O_CLERK = 'a', NOT ((9: O_COMMENT = 'c') AND (2: O_CUSTKEY IN (1, 100, 1000))), " +
+                        "1: O_ORDERKEY NOT IN (200, 300)"));
         list.add(arguments);
 
         sql = "select max(p_type) from part where p_name = 'a' or p_size = 1 group by p_name";
@@ -179,6 +191,9 @@ class SplitScanToUnionTest extends DistributedEnvPlanTestBase {
         list.add(sql);
 
         sql = "select * from test_all_type where t1b in (1, 2, 3) or t1a in ('a', 'b', 'c')";
+        list.add(sql);
+
+        sql = "select max(p_type) from part where p_name = 'a' or p_name > p_size";
         list.add(sql);
 
         return list.stream().map(e -> Arguments.of(e));


### PR DESCRIPTION
Why I'm doing:
#25268 actually just support some force split scene because of lack statistics. Sometimes we need to force rewrite the or predicates in any case.

What I'm doing:
When select_ratio_threshold is a negative value, force split the or predicate.
Change the strategy about binary predicate and compound and predicate in `ColumnFilterEvaluator`.
- if the right argument in binary predicate is not a constant, set this predicate to NON_SELECTIVITY
- if both select ratio of the arguments of compound predicate are less than 1, use the product of the children as the result 

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [x] 3.1
  - [x] 3.0
  - [x] 2.5
