### PR TITLE
[Enhancement] add materialized view switch: enable_query_rewrite

### DIFF
--- a/be/src/exec/schema_scanner/schema_materialized_views_scanner.cpp
+++ b/be/src/exec/schema_scanner/schema_materialized_views_scanner.cpp
@@ -49,6 +49,7 @@ SchemaScanner::ColumnDesc SchemaMaterializedViewsScanner::_s_tbls_columns[] = {
         {"TABLE_ROWS", TYPE_VARCHAR, sizeof(StringValue), false},
         {"MATERIALIZED_VIEW_DEFINITION", TYPE_VARCHAR, sizeof(StringValue), false},
         {"EXTRA_MESSAGE", TYPE_VARCHAR, sizeof(StringValue), false},
+        {"QUERY_REWRITE_STATUS", TYPE_VARCHAR, sizeof(StringValue), false},
 };
 
 SchemaMaterializedViewsScanner::SchemaMaterializedViewsScanner()
@@ -112,6 +113,7 @@ Status SchemaMaterializedViewsScanner::fill_chunk(ChunkPtr* chunk) {
             Slice(info.rows),
             Slice(info.text),
             Slice(info.extra_message),
+            Slice(info.query_rewrite_status)
     };
 
     for (const auto& [slot_id, index] : slot_id_map) {

--- a/be/src/exec/schema_scanner/schema_materialized_views_scanner.cpp
+++ b/be/src/exec/schema_scanner/schema_materialized_views_scanner.cpp
@@ -89,32 +89,30 @@ Status SchemaMaterializedViewsScanner::fill_chunk(ChunkPtr* chunk) {
     auto& slot_id_map = (*chunk)->get_slot_id_to_index_map();
     const TMaterializedViewStatus& info = _mv_results.materialized_views[_table_index];
     std::string db_name = SchemaHelper::extract_db_name(_db_result.dbs[_db_index - 1]);
-    DatumArray datum_array{
-            Slice(info.id),
-            Slice(db_name),
-            Slice(info.name),
-            Slice(info.refresh_type),
-            Slice(info.is_active),
-            Slice(info.inactive_reason),
-            Slice(info.partition_type),
-            Slice(info.task_id),
-            Slice(info.task_name),
-            Slice(info.last_refresh_start_time),
-            Slice(info.last_refresh_finished_time),
-            Slice(info.last_refresh_duration),
-            Slice(info.last_refresh_state),
-            Slice(info.last_refresh_force_refresh),
-            Slice(info.last_refresh_start_partition),
-            Slice(info.last_refresh_end_partition),
-            Slice(info.last_refresh_base_refresh_partitions),
-            Slice(info.last_refresh_mv_refresh_partitions),
-            Slice(info.last_refresh_error_code),
-            Slice(info.last_refresh_error_message),
-            Slice(info.rows),
-            Slice(info.text),
-            Slice(info.extra_message),
-            Slice(info.query_rewrite_status)
-    };
+    DatumArray datum_array{Slice(info.id),
+                           Slice(db_name),
+                           Slice(info.name),
+                           Slice(info.refresh_type),
+                           Slice(info.is_active),
+                           Slice(info.inactive_reason),
+                           Slice(info.partition_type),
+                           Slice(info.task_id),
+                           Slice(info.task_name),
+                           Slice(info.last_refresh_start_time),
+                           Slice(info.last_refresh_finished_time),
+                           Slice(info.last_refresh_duration),
+                           Slice(info.last_refresh_state),
+                           Slice(info.last_refresh_force_refresh),
+                           Slice(info.last_refresh_start_partition),
+                           Slice(info.last_refresh_end_partition),
+                           Slice(info.last_refresh_base_refresh_partitions),
+                           Slice(info.last_refresh_mv_refresh_partitions),
+                           Slice(info.last_refresh_error_code),
+                           Slice(info.last_refresh_error_message),
+                           Slice(info.rows),
+                           Slice(info.text),
+                           Slice(info.extra_message),
+                           Slice(info.query_rewrite_status)};
 
     for (const auto& [slot_id, index] : slot_id_map) {
         Column* column = (*chunk)->get_column_by_slot_id(slot_id).get();

--- a/fe/fe-core/src/main/java/com/starrocks/alter/AlterMVJobExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/AlterMVJobExecutor.java
@@ -143,6 +143,13 @@ public class AlterMVJobExecutor extends AlterJobExecutor {
             oldQueryRewriteConsistencyMode = TableProperty.analyzeQueryRewriteMode(propertyValue);
             properties.remove(PropertyAnalyzer.PROPERTIES_QUERY_REWRITE_CONSISTENCY);
         }
+        TableProperty.MVQueryRewriteSwitch queryRewriteSwitch =
+                materializedView.getTableProperty().getMvQueryRewriteSwitch();
+        if (properties.containsKey(PropertyAnalyzer.PROPERTY_MV_ENABLE_QUERY_REWRITE)) {
+            String value = properties.get(PropertyAnalyzer.PROPERTY_MV_ENABLE_QUERY_REWRITE);
+            queryRewriteSwitch = TableProperty.analyzeQueryRewriteSwitch(value);
+            properties.remove(PropertyAnalyzer.PROPERTY_MV_ENABLE_QUERY_REWRITE);
+        }
 
         if (!properties.isEmpty()) {
             if (propClone.containsKey(PropertyAnalyzer.PROPERTIES_COLOCATE_WITH)) {
@@ -164,6 +171,7 @@ public class AlterMVJobExecutor extends AlterJobExecutor {
             SetStmtAnalyzer.analyze(new SetStmt(setListItems), null);
         }
 
+        // TODO(murphy) refactor the code
         boolean isChanged = false;
         Map<String, String> curProp = materializedView.getTableProperty().getProperties();
         if (propClone.containsKey(PropertyAnalyzer.PROPERTIES_PARTITION_TTL) && ttlDuration != null &&
@@ -229,6 +237,12 @@ public class AlterMVJobExecutor extends AlterJobExecutor {
                     put(PropertyAnalyzer.PROPERTIES_QUERY_REWRITE_CONSISTENCY,
                             String.valueOf(oldQueryRewriteConsistencyMode));
             materializedView.getTableProperty().setQueryRewriteConsistencyMode(oldQueryRewriteConsistencyMode);
+            isChanged = true;
+        }
+        if (propClone.containsKey(PropertyAnalyzer.PROPERTY_MV_ENABLE_QUERY_REWRITE)) {
+            materializedView.getTableProperty().getProperties()
+                    .put(PropertyAnalyzer.PROPERTY_MV_ENABLE_QUERY_REWRITE, String.valueOf(queryRewriteSwitch));
+            materializedView.getTableProperty().setMvQueryRewriteSwitch(queryRewriteSwitch);
             isChanged = true;
         }
         DynamicPartitionUtil.registerOrRemovePartitionTTLTable(materializedView.getDbId(), materializedView);

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/MaterializedView.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/MaterializedView.java
@@ -437,6 +437,8 @@ public class MaterializedView extends OlapTable implements GsonPreProcessable, G
     @SerializedName(value = "queryOutputIndices")
     protected List<Integer> queryOutputIndices = Lists.newArrayList();
 
+    private boolean eligibleForQueryRewrite = true;
+
     public MaterializedView() {
         super(TableType.MATERIALIZED_VIEW);
         this.tableProperty = null;

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/MaterializedView.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/MaterializedView.java
@@ -75,6 +75,7 @@ import com.starrocks.sql.common.RangePartitionDiff;
 import com.starrocks.sql.common.SyncPartitionUtils;
 import com.starrocks.sql.common.UnsupportedException;
 import com.starrocks.sql.optimizer.CachingMvPlanContextBuilder;
+import com.starrocks.sql.optimizer.MvRewritePreprocessor;
 import com.starrocks.sql.optimizer.Utils;
 import com.starrocks.sql.parser.SqlParser;
 import com.starrocks.sql.plan.ExecPlan;
@@ -1726,6 +1727,18 @@ public class MaterializedView extends OlapTable implements GsonPreProcessable, G
             }
             info.setBucketNum(inferredBucketNum);
         }
+    }
+
+    /**
+     * Return the status and reason about query rewrite
+     */
+    public String getQueryRewriteStatus() {
+        Pair<Boolean, String> status =
+                MvRewritePreprocessor.isMVValidToRewriteQuery(ConnectContext.get(), this, true, Sets.newHashSet());
+        if (status.first) {
+            return "VALID";
+        }
+        return "INVALID: " + status.second;
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/MaterializedView.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/MaterializedView.java
@@ -437,8 +437,6 @@ public class MaterializedView extends OlapTable implements GsonPreProcessable, G
     @SerializedName(value = "queryOutputIndices")
     protected List<Integer> queryOutputIndices = Lists.newArrayList();
 
-    private boolean eligibleForQueryRewrite = true;
-
     public MaterializedView() {
         super(TableType.MATERIALIZED_VIEW);
         this.tableProperty = null;

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/TableProperty.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/TableProperty.java
@@ -121,6 +121,10 @@ public class TableProperty implements Writable, GsonPostProcessable {
         FALSE,      // disabled
         ;
 
+        public boolean isEnable() {
+            return TRUE == this || DEFAULT == this;
+        }
+
         public static MVQueryRewriteSwitch defaultValue() {
             return DEFAULT;
         }

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/TableProperty.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/TableProperty.java
@@ -112,6 +112,30 @@ public class TableProperty implements Writable, GsonPostProcessable {
         }
     }
 
+    /**
+     * The value for enable_query_rewrite variable
+     */
+    public enum MVQueryRewriteSwitch {
+        DEFAULT,    // default, no check but eligible for query rewrite
+        ENABLE,     // enabled, check the semantic and is eligible for query rewrite
+        DISABLE;    // disabled
+
+        public static MVQueryRewriteSwitch defaultValue() {
+            return DEFAULT;
+        }
+
+        public static MVQueryRewriteSwitch parse(String str) {
+            if (StringUtils.isEmpty(str)) {
+                return DEFAULT;
+            }
+            return EnumUtils.getEnumIgnoreCase(MVQueryRewriteSwitch.class, str);
+        }
+
+        public static String valueList() {
+            return Joiner.on(",").join(MVQueryRewriteSwitch.values());
+        }
+    }
+
     @SerializedName(value = "properties")
     private Map<String, String> properties;
 
@@ -150,6 +174,8 @@ public class TableProperty implements Writable, GsonPostProcessable {
     // Specify the query rewrite behaviour for external table
     private QueryRewriteConsistencyMode queryRewriteConsistencyMode =
             QueryRewriteConsistencyMode.defaultQueryRewriteConsistencyMode();
+
+    private MVQueryRewriteSwitch mvQueryRewriteSwitch = MVQueryRewriteSwitch.DEFAULT;
 
     private boolean isInMemory = false;
 
@@ -315,6 +341,7 @@ public class TableProperty implements Writable, GsonPostProcessable {
         buildConstraint();
         buildMvSortKeys();
         buildQueryRewrite();
+        buildMVQueryRewriteSwitch();
         return this;
     }
 
@@ -426,6 +453,23 @@ public class TableProperty implements Writable, GsonPostProcessable {
         } else {
             return Splitter.on(",").omitEmptyStrings().trimResults().splitToList(value);
         }
+    }
+
+    public TableProperty buildMVQueryRewriteSwitch() {
+        String value = properties.get(PropertyAnalyzer.PROPERTY_MV_ENABLE_QUERY_REWRITE);
+        this.mvQueryRewriteSwitch = MVQueryRewriteSwitch.parse(value);
+        return this;
+    }
+
+    public static MVQueryRewriteSwitch analyzeQueryRewriteSwitch(String value) {
+        MVQueryRewriteSwitch res = MVQueryRewriteSwitch.parse(value);
+        if (res == null) {
+            String valueList = MVQueryRewriteSwitch.valueList();
+            throw new SemanticException(
+                    PropertyAnalyzer.PROPERTY_MV_ENABLE_QUERY_REWRITE
+                            + " can only be " + valueList + " but got " + value);
+        }
+        return res;
     }
 
     public static QueryRewriteConsistencyMode analyzeQueryRewriteMode(String value) {
@@ -710,6 +754,14 @@ public class TableProperty implements Writable, GsonPostProcessable {
 
     public QueryRewriteConsistencyMode getQueryRewriteConsistencyMode() {
         return this.queryRewriteConsistencyMode;
+    }
+
+    public void setMvQueryRewriteSwitch(MVQueryRewriteSwitch value) {
+        this.mvQueryRewriteSwitch = value);
+    }
+
+    public MVQueryRewriteSwitch getMvQueryRewriteSwitch() {
+        return this.mvQueryRewriteSwitch;
     }
 
     public boolean isInMemory() {

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/TableProperty.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/TableProperty.java
@@ -117,8 +117,9 @@ public class TableProperty implements Writable, GsonPostProcessable {
      */
     public enum MVQueryRewriteSwitch {
         DEFAULT,    // default, no check but eligible for query rewrite
-        ENABLE,     // enabled, check the semantic and is eligible for query rewrite
-        DISABLE;    // disabled
+        TRUE,       // enabled, check the semantic and is eligible for query rewrite
+        FALSE,      // disabled
+        ;
 
         public static MVQueryRewriteSwitch defaultValue() {
             return DEFAULT;
@@ -757,7 +758,7 @@ public class TableProperty implements Writable, GsonPostProcessable {
     }
 
     public void setMvQueryRewriteSwitch(MVQueryRewriteSwitch value) {
-        this.mvQueryRewriteSwitch = value);
+        this.mvQueryRewriteSwitch = value;
     }
 
     public MVQueryRewriteSwitch getMvQueryRewriteSwitch() {

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/system/information/MaterializedViewsSystemTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/system/information/MaterializedViewsSystemTable.java
@@ -52,6 +52,7 @@ public class MaterializedViewsSystemTable {
                         .column("MATERIALIZED_VIEW_DEFINITION",
                                 ScalarType.createVarchar(MAX_FIELD_VARCHAR_LENGTH))
                         .column("EXTRA_MESSAGE", ScalarType.createVarchar(1024))
+                        .column("QUERY_REWRITE_STATUS", ScalarType.createVarcharType(64))
                         .build(), TSchemaTableType.SCH_MATERIALIZED_VIEWS);
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/common/util/PropertyAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/util/PropertyAnalyzer.java
@@ -197,6 +197,7 @@ public class PropertyAnalyzer {
     // -1: disable randomize, use current time as start
     // positive value: use [0, mv_randomize_start) as random interval
     public static final String PROPERTY_MV_RANDOMIZE_START = "mv_randomize_start";
+    public static final String PROPERTY_MV_ENABLE_QUERY_REWRITE = "enable_query_rewrite";
 
     /**
      * Materialized View sort keys

--- a/fe/fe-core/src/main/java/com/starrocks/qe/ShowExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/ShowExecutor.java
@@ -620,6 +620,7 @@ public class ShowExecutor {
             mvStatus.setText(mvTable.getMaterializedViewDdlStmt(true));
             // task run status
             mvStatus.setLastJobTaskRunStatus(taskTaskStatusJob);
+            mvStatus.setQueryRewriteStatus(mvTable.getQueryRewriteStatus());
             rowSets.add(mvStatus);
         }
 

--- a/fe/fe-core/src/main/java/com/starrocks/qe/ShowMaterializedViewStatus.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/ShowMaterializedViewStatus.java
@@ -55,6 +55,7 @@ public class ShowMaterializedViewStatus {
     private String partitionType;
     private long lastCheckTime;
     private String inactiveReason;
+    private String queryRewriteStatus;
     private List<TaskRunStatus> lastJobTaskRunStatus;
 
     /**
@@ -448,6 +449,13 @@ public class ShowMaterializedViewStatus {
         return status;
     }
 
+    public String getQueryRewriteStatus() {
+        return queryRewriteStatus;
+    }
+
+    public void setQueryRewriteStatus(String queryRewriteStatus) {
+        this.queryRewriteStatus = queryRewriteStatus;
+    }
 
     /**
      * Return the thrift of show materialized views command from be's request.
@@ -498,6 +506,9 @@ public class ShowMaterializedViewStatus {
         // extra message
         status.setExtra_message(refreshJobStatus.getExtraMessage() == null ? "" :
                 GsonUtils.GSON.toJson(refreshJobStatus.getExtraMessage()));
+
+        // query_rewrite_status
+        status.setQuery_rewrite_status(queryRewriteStatus);
 
         return status;
     }
@@ -563,6 +574,8 @@ public class ShowMaterializedViewStatus {
         // extra message
         addField(resultRow, refreshJobStatus.getExtraMessage() == null ? "" :
                 GsonUtils.GSON.toJson(refreshJobStatus.getExtraMessage()));
+        // query_rewrite_status
+        addField(resultRow, queryRewriteStatus);
 
         return resultRow;
     }

--- a/fe/fe-core/src/main/java/com/starrocks/server/LocalMetastore.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/LocalMetastore.java
@@ -3491,6 +3491,14 @@ public class LocalMetastore implements ConnectorMetadata {
                 colocateTableIndex.addTableToGroup(db, materializedView, colocateGroup,
                         materializedView.isCloudNativeMaterializedView());
             }
+
+            // enable_query_rewrite
+            if (properties.containsKey(PropertyAnalyzer.PROPERTY_MV_ENABLE_QUERY_REWRITE)) {
+                String str = properties.get(PropertyAnalyzer.PROPERTY_MV_ENABLE_QUERY_REWRITE);
+                TableProperty.MVQueryRewriteSwitch value = TableProperty.analyzeQueryRewriteSwitch(str);
+                materializedView.getTableProperty().setMvQueryRewriteSwitch(value);
+            }
+
             // lake storage info
             if (materializedView.isCloudNativeMaterializedView()) {
                 String volume = "";

--- a/fe/fe-core/src/main/java/com/starrocks/server/LocalMetastore.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/LocalMetastore.java
@@ -3496,6 +3496,9 @@ public class LocalMetastore implements ConnectorMetadata {
                 String str = properties.get(PropertyAnalyzer.PROPERTY_MV_ENABLE_QUERY_REWRITE);
                 TableProperty.MVQueryRewriteSwitch value = TableProperty.analyzeQueryRewriteSwitch(str);
                 materializedView.getTableProperty().setMvQueryRewriteSwitch(value);
+                materializedView.getTableProperty().getProperties().put(
+                        PropertyAnalyzer.PROPERTY_MV_ENABLE_QUERY_REWRITE, str);
+                properties.remove(PropertyAnalyzer.PROPERTY_MV_ENABLE_QUERY_REWRITE);
             }
 
             // lake storage info

--- a/fe/fe-core/src/main/java/com/starrocks/server/LocalMetastore.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/LocalMetastore.java
@@ -3496,7 +3496,6 @@ public class LocalMetastore implements ConnectorMetadata {
                 String str = properties.get(PropertyAnalyzer.PROPERTY_MV_ENABLE_QUERY_REWRITE);
                 TableProperty.MVQueryRewriteSwitch value = TableProperty.analyzeQueryRewriteSwitch(str);
                 materializedView.getTableProperty().setMvQueryRewriteSwitch(value);
-                properties.remove(PropertyAnalyzer.PROPERTY_MV_ENABLE_QUERY_REWRITE);
             }
 
             // lake storage info

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/MaterializedViewAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/MaterializedViewAnalyzer.java
@@ -137,10 +137,6 @@ public class MaterializedViewAnalyzer {
         new MaterializedViewAnalyzerVisitor().visit(stmt, session);
     }
 
-    public static void analyzeQueryRewriteAbility(StatementBase stmt, ConnectContext session) {
-
-    }
-
     public static Set<BaseTableInfo> getBaseTableInfos(QueryStatement queryStatement, boolean withCheck) {
         Set<BaseTableInfo> baseTableInfos = Sets.newHashSet();
         processBaseTables(queryStatement, baseTableInfos, withCheck);

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/MaterializedViewAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/MaterializedViewAnalyzer.java
@@ -137,6 +137,10 @@ public class MaterializedViewAnalyzer {
         new MaterializedViewAnalyzerVisitor().visit(stmt, session);
     }
 
+    public static void analyzeQueryRewriteAbility(StatementBase stmt, ConnectContext session) {
+
+    }
+
     public static Set<BaseTableInfo> getBaseTableInfos(QueryStatement queryStatement, boolean withCheck) {
         Set<BaseTableInfo> baseTableInfos = Sets.newHashSet();
         processBaseTables(queryStatement, baseTableInfos, withCheck);

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/ShowMaterializedViewsStmt.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/ShowMaterializedViewsStmt.java
@@ -64,6 +64,7 @@ public class ShowMaterializedViewsStmt extends ShowStmt {
                     .column("rows", ScalarType.createVarchar(50))
                     .column("text", ScalarType.createVarchar(1024))
                     .column("extra_message", ScalarType.createVarchar(1024))
+                    .column("query_rewrite_status", ScalarType.createVarchar(64))
                     .build();
 
     private static final Map<String, String> ALIAS_MAP = ImmutableMap.of(

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/MvRewritePreprocessor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/MvRewritePreprocessor.java
@@ -520,13 +520,13 @@ public class MvRewritePreprocessor {
             return Pair.create(false, message);
         }
         // if mv is a subset of query tables, it can be used for rewrite.
-        if (!queryTables.isEmpty() && !canMVRewriteIfMVHasExtraTables(connectContext, mv, queryTables)) {
+        if (CollectionUtils.isNotEmpty(queryTables) &&
+                !canMVRewriteIfMVHasExtraTables(connectContext, mv, queryTables)) {
             return Pair.create(false, "MV contains extra tables besides FK-PK");
         }
         // if mv is in plan cache(avoid building plan), check whether it's valid
         if (connectContext == null || connectContext.getSessionVariable().isEnableMaterializedViewPlanCache()) {
-            List<MvPlanContext> planContexts =
-                    force ?
+            List<MvPlanContext> planContexts = force ?
                             CachingMvPlanContextBuilder.getInstance().getPlanContext(mv, false) :
                             CachingMvPlanContextBuilder.getInstance().getPlanContextFromCacheIfPresent(mv);
             if (CollectionUtils.isEmpty(planContexts)) {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/MvRewritePreprocessor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/MvRewritePreprocessor.java
@@ -45,6 +45,7 @@ import com.starrocks.common.Config;
 import com.starrocks.common.Pair;
 import com.starrocks.common.profile.Timer;
 import com.starrocks.common.profile.Tracers;
+import com.starrocks.common.util.PropertyAnalyzer;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.qe.SessionVariable;
 import com.starrocks.server.GlobalStateMgr;
@@ -498,10 +499,14 @@ public class MvRewritePreprocessor {
         return true;
     }
 
-    private boolean isMVValidToRewriteQuery(MaterializedView mv,
-                                            Set<Table> queryTables) {
+    private boolean isMVValidToRewriteQuery(MaterializedView mv, Set<Table> queryTables) {
         if (!mv.isActive())  {
             logMVPrepare(connectContext, mv, "MV is not active: {}", mv.getName());
+            return false;
+        }
+        if (!mv.getTableProperty().getMvQueryRewriteSwitch().isEnable()) {
+            logMVPrepare(connectContext, mv, PropertyAnalyzer.PROPERTY_MV_ENABLE_QUERY_REWRITE + "=" +
+                    mv.getTableProperty().getMvQueryRewriteSwitch());
             return false;
         }
         // if mv is a subset of query tables, it can be used for rewrite.

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/MvRewritePreprocessor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/MvRewritePreprocessor.java
@@ -529,11 +529,8 @@ public class MvRewritePreprocessor {
             List<MvPlanContext> planContexts = force ?
                             CachingMvPlanContextBuilder.getInstance().getPlanContext(mv, false) :
                             CachingMvPlanContextBuilder.getInstance().getPlanContextFromCacheIfPresent(mv);
-            if (CollectionUtils.isEmpty(planContexts)) {
-                logMVPrepare(connectContext, "MV has no plan", mv.getName());
-                return Pair.create(false, "MV has no plan");
-            }
-            if (planContexts.stream().noneMatch(MvPlanContext::isValidMvPlan)) {
+            if (CollectionUtils.isNotEmpty(planContexts) &&
+                    planContexts.stream().noneMatch(MvPlanContext::isValidMvPlan)) {
                 logMVPrepare(connectContext, "MV {} has no valid plan from {} plan contexts",
                         mv.getName(), planContexts.size());
                 String message = planContexts.stream()

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/CreateMaterializedViewTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/CreateMaterializedViewTest.java
@@ -4464,6 +4464,21 @@ public class CreateMaterializedViewTest {
         Assert.assertTrue(valid.first);
 
         starRocksAssert.ddl("alter materialized view mv_enable set('enable_query_rewrite'='false') ");
+        Assert.assertEquals("CREATE MATERIALIZED VIEW `mv_enable` (`c_1_0`, `c_1_1`, `c_1_2`, `c_1_3`, " +
+                        "`c_1_4`, `c_1_5`, `c_1_6`, `c_1_7`, `c_1_8`, `c_1_9`, `c_1_10`, `c_1_11`, `c_1_12`)\n" +
+                        "DISTRIBUTED BY RANDOM\n" +
+                        "REFRESH ASYNC\n" +
+                        "PROPERTIES (\n" +
+                        "\"replicated_storage\" = \"true\",\n" +
+                        "\"replication_num\" = \"1\",\n" +
+                        "\"enable_query_rewrite\" = \"FALSE\",\n" +
+                        "\"storage_medium\" = \"HDD\"\n" +
+                        ")\n" +
+                        "AS SELECT `t1`.`c_1_0`, `t1`.`c_1_1`, `t1`.`c_1_2`, `t1`.`c_1_3`, `t1`.`c_1_4`, `t1`.`c_1_5`, " +
+                        "`t1`.`c_1_6`, `t1`.`c_1_7`, `t1`.`c_1_8`, `t1`.`c_1_9`, `t1`.`c_1_10`, `t1`.`c_1_11`, " +
+                        "`t1`.`c_1_12`\n" +
+                        "FROM `test`.`t1`;",
+                starRocksAssert.showCreateTable("show create table mv_enable"));
         valid = MvRewritePreprocessor.isMVValidToRewriteQuery(connectContext, mv, true, null);
         Assert.assertFalse(valid.first);
         Assert.assertEquals("enable_query_rewrite=FALSE", valid.second);

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/CreateMaterializedViewTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/CreateMaterializedViewTest.java
@@ -4388,4 +4388,63 @@ public class CreateMaterializedViewTest {
                 "AS\n" +
                 "SELECT id,name,str_to_map(CONCAT_WS(':',id,name),';',':') as mapvalue FROM sr_ods_test_table");
     }
+
+    @Test
+    public void testEnableQueryRewrite() throws Exception {
+        // default
+        starRocksAssert.withMaterializedView("create materialized view mv_invalid " +
+                "refresh async " +
+                "as select * from t1 limit 10");
+        starRocksAssert.dropMaterializedView("mv_invalid");
+
+        // disable
+        starRocksAssert.withMaterializedView("create materialized view mv_invalid " +
+                "refresh async " +
+                "properties('enable_query_rewrite' = 'false') " +
+                "as select * from t1 limit 10");
+        starRocksAssert.dropMaterializedView("mv_invalid");
+
+        // enable
+        starRocksAssert.withMaterializedView("create materialized view mv_invalid " +
+                "refresh async " +
+                "properties('enable_query_rewrite' = 'true') " +
+                "as select * from t1");
+        starRocksAssert.dropMaterializedView("mv_invalid");
+
+        // invalid operators
+        {
+            Exception e = Assert.assertThrows(SemanticException.class,
+                    () -> starRocksAssert.withMaterializedView("create materialized view mv_invalid " +
+                            "refresh async " +
+                            "properties('enable_query_rewrite' = 'true') " +
+                            "as select * from t1 limit 10"));
+            Assert.assertEquals("Getting analyzing error. Detail message: " +
+                    "The MV is not eligible for query rewrite: MV contains other operators besides " +
+                    "AGGREGATION/JOIN/SELECT/PROJECTION: LOGICAL_LIMIT.", e.getMessage());
+
+        }
+        {
+            Exception e = Assert.assertThrows(SemanticException.class,
+                    () -> starRocksAssert.withMaterializedView("create materialized view mv_invalid " +
+                            "refresh async " +
+                            "properties('enable_query_rewrite' = 'true') " +
+                            "as select row_number() over (partition by c_1_9) from t1"));
+            Assert.assertEquals("Getting analyzing error. Detail message: " +
+                    "The MV is not eligible for query rewrite: MV contains other operators besides " +
+                    "AGGREGATION/JOIN/SELECT/PROJECTION: LOGICAL_WINDOW.", e.getMessage());
+        }
+
+        // invalid structure
+        {
+            Exception e = Assert.assertThrows(SemanticException.class,
+                    () -> starRocksAssert.withMaterializedView("create materialized view mv_invalid " +
+                            "refresh async " +
+                            "properties('enable_query_rewrite' = 'true') " +
+                            "as select t1.c_1_9, r.cnt from t1 join" +
+                            " (select c_1_9, count(*) as cnt from t1 group by c_1_9) r " +
+                            " on t1.c_1_9 = r.c_1_9"));
+            Assert.assertEquals("Getting analyzing error. Detail message: " +
+                    "The MV is not eligible for query rewrite: MV is not SPJG structure.", e.getMessage());
+        }
+    }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/CreateMaterializedViewTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/CreateMaterializedViewTest.java
@@ -34,6 +34,7 @@ import com.starrocks.catalog.TableProperty;
 import com.starrocks.common.AnalysisException;
 import com.starrocks.common.Config;
 import com.starrocks.common.DdlException;
+import com.starrocks.common.Pair;
 import com.starrocks.common.util.DateUtils;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.qe.StmtExecutor;
@@ -52,6 +53,7 @@ import com.starrocks.sql.ast.DmlStmt;
 import com.starrocks.sql.ast.ExpressionPartitionDesc;
 import com.starrocks.sql.ast.RefreshSchemeClause;
 import com.starrocks.sql.ast.StatementBase;
+import com.starrocks.sql.optimizer.MvRewritePreprocessor;
 import com.starrocks.sql.optimizer.Utils;
 import com.starrocks.sql.plan.ConnectorPlanTestBase;
 import com.starrocks.sql.plan.ExecPlan;
@@ -4395,6 +4397,22 @@ public class CreateMaterializedViewTest {
         starRocksAssert.withMaterializedView("create materialized view mv_invalid " +
                 "refresh async " +
                 "as select * from t1 limit 10");
+        Assert.assertEquals(
+                "CREATE MATERIALIZED VIEW `mv_invalid` (`c_1_0`, `c_1_1`, `c_1_2`, `c_1_3`, `c_1_4`, " +
+                        "`c_1_5`, `c_1_6`, `c_1_7`, `c_1_8`, `c_1_9`, `c_1_10`, `c_1_11`, `c_1_12`)\n" +
+                        "DISTRIBUTED BY RANDOM\n" +
+                        "REFRESH ASYNC\n" +
+                        "PROPERTIES (\n" +
+                        "\"replicated_storage\" = \"true\",\n" +
+                        "\"replication_num\" = \"1\",\n" +
+                        "\"storage_medium\" = \"HDD\"\n" +
+                        ")\n" +
+                        "AS SELECT `t1`.`c_1_0`, `t1`.`c_1_1`, `t1`.`c_1_2`, `t1`.`c_1_3`, `t1`.`c_1_4`, `t1`.`c_1_5`, " +
+                        "`t1`.`c_1_6`, `t1`.`c_1_7`, `t1`.`c_1_8`, `t1`.`c_1_9`, `t1`.`c_1_10`, `t1`.`c_1_11`, " +
+                        "`t1`.`c_1_12`\n" +
+                        "FROM `test`.`t1` LIMIT 10;"
+                ,
+                starRocksAssert.showCreateTable("show create table mv_invalid"));
         starRocksAssert.dropMaterializedView("mv_invalid");
 
         // disable
@@ -4402,6 +4420,22 @@ public class CreateMaterializedViewTest {
                 "refresh async " +
                 "properties('enable_query_rewrite' = 'false') " +
                 "as select * from t1 limit 10");
+        Assert.assertEquals("CREATE MATERIALIZED VIEW `mv_invalid` " +
+                        "(`c_1_0`, `c_1_1`, `c_1_2`, `c_1_3`, `c_1_4`, `c_1_5`, `c_1_6`, `c_1_7`, `c_1_8`, `c_1_9`, " +
+                        "`c_1_10`, `c_1_11`, `c_1_12`)\n" +
+                        "DISTRIBUTED BY RANDOM\n" +
+                        "REFRESH ASYNC\n" +
+                        "PROPERTIES (\n" +
+                        "\"replicated_storage\" = \"true\",\n" +
+                        "\"replication_num\" = \"1\",\n" +
+                        "\"enable_query_rewrite\" = \"false\",\n" +
+                        "\"storage_medium\" = \"HDD\"\n" +
+                        ")\n" +
+                        "AS SELECT `t1`.`c_1_0`, `t1`.`c_1_1`, `t1`.`c_1_2`, `t1`.`c_1_3`, `t1`.`c_1_4`, `t1`.`c_1_5`, " +
+                        "`t1`.`c_1_6`, `t1`.`c_1_7`, `t1`.`c_1_8`, `t1`.`c_1_9`, `t1`.`c_1_10`, `t1`.`c_1_11`, " +
+                        "`t1`.`c_1_12`\n" +
+                        "FROM `test`.`t1` LIMIT 10;",
+                starRocksAssert.showCreateTable("show create table mv_invalid"));
         starRocksAssert.dropMaterializedView("mv_invalid");
 
         // enable
@@ -4409,9 +4443,30 @@ public class CreateMaterializedViewTest {
                 "refresh async " +
                 "properties('enable_query_rewrite' = 'true') " +
                 "as select * from t1");
-        starRocksAssert.query("select * from t1").explainContains("mv_enable");
+        Assert.assertEquals("CREATE MATERIALIZED VIEW `mv_enable` (`c_1_0`, `c_1_1`, `c_1_2`, `c_1_3`, " +
+                        "`c_1_4`, `c_1_5`, `c_1_6`, `c_1_7`, `c_1_8`, `c_1_9`, `c_1_10`, `c_1_11`, `c_1_12`)\n" +
+                        "DISTRIBUTED BY RANDOM\n" +
+                        "REFRESH ASYNC\n" +
+                        "PROPERTIES (\n" +
+                        "\"replicated_storage\" = \"true\",\n" +
+                        "\"replication_num\" = \"1\",\n" +
+                        "\"enable_query_rewrite\" = \"true\",\n" +
+                        "\"storage_medium\" = \"HDD\"\n" +
+                        ")\n" +
+                        "AS SELECT `t1`.`c_1_0`, `t1`.`c_1_1`, `t1`.`c_1_2`, `t1`.`c_1_3`, `t1`.`c_1_4`, `t1`.`c_1_5`, " +
+                        "`t1`.`c_1_6`, `t1`.`c_1_7`, `t1`.`c_1_8`, `t1`.`c_1_9`, `t1`.`c_1_10`, `t1`.`c_1_11`, " +
+                        "`t1`.`c_1_12`\n" +
+                        "FROM `test`.`t1`;",
+                starRocksAssert.showCreateTable("show create table mv_enable"));
+        starRocksAssert.refreshMV("refresh materialized view mv_enable with sync mode");
+        MaterializedView mv = starRocksAssert.getMv("test", "mv_enable");
+        Pair<Boolean, String> valid = MvRewritePreprocessor.isMVValidToRewriteQuery(connectContext, mv, true, null);
+        Assert.assertTrue(valid.first);
+
         starRocksAssert.ddl("alter materialized view mv_enable set('enable_query_rewrite'='false') ");
-        starRocksAssert.query("select * from t1").explainWithout("mv_enable");
+        valid = MvRewritePreprocessor.isMVValidToRewriteQuery(connectContext, mv, true, null);
+        Assert.assertFalse(valid.first);
+        Assert.assertEquals("enable_query_rewrite=FALSE", valid.second);
         starRocksAssert.dropMaterializedView("mv_enable");
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/ShowMaterializedViewTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/ShowMaterializedViewTest.java
@@ -114,7 +114,8 @@ public class ShowMaterializedViewTest {
                         "information_schema.materialized_views.last_refresh_error_message AS last_refresh_error_message, " +
                         "information_schema.materialized_views.TABLE_ROWS AS rows, " +
                         "information_schema.materialized_views.MATERIALIZED_VIEW_DEFINITION AS text, " +
-                        "information_schema.materialized_views.extra_message AS extra_message " +
+                        "information_schema.materialized_views.extra_message AS extra_message, " +
+                        "information_schema.materialized_views.query_rewrite_status AS query_rewrite_status " +
                         "FROM information_schema.materialized_views " +
                         "WHERE (information_schema.materialized_views.TABLE_SCHEMA = 'abc') AND (information_schema.materialized_views.TABLE_NAME = 'mv1')",
                 AstToStringBuilder.toString(stmt.toSelectStmt()));

--- a/fe/fe-core/src/test/java/com/starrocks/qe/ShowExecutorTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/qe/ShowExecutorTest.java
@@ -984,13 +984,14 @@ public class ShowExecutorTest {
         Assert.assertEquals("", resultSet.getString(12));
         Assert.assertEquals("false", resultSet.getString(13));
         System.out.println(resultSet.getResultRows());
-        for (int i = 14; i < mvSchemaTable.size() - 3; i++) {
+        for (int i = 14; i < mvSchemaTable.size() - 4; i++) {
             System.out.println(i);
             Assert.assertEquals("", resultSet.getString(i));
         }
-        Assert.assertEquals("10", resultSet.getString(mvSchemaTable.size() - 3));
-        Assert.assertEquals(expectedSqlText, resultSet.getString(mvSchemaTable.size() - 2));
-        Assert.assertEquals("", resultSet.getString(mvSchemaTable.size() - 1));
+        Assert.assertEquals("10", resultSet.getString(mvSchemaTable.size() - 4));
+        Assert.assertEquals(expectedSqlText, resultSet.getString(mvSchemaTable.size() - 3));
+        Assert.assertEquals("", resultSet.getString(mvSchemaTable.size() - 2));
+        Assert.assertEquals("VALID", resultSet.getString(mvSchemaTable.size() - 1));
         Assert.assertFalse(resultSet.next());
     }
 

--- a/fe/fe-core/src/test/java/com/starrocks/utframe/StarRocksAssert.java
+++ b/fe/fe-core/src/test/java/com/starrocks/utframe/StarRocksAssert.java
@@ -834,6 +834,10 @@ public class StarRocksAssert {
         return showExecutor.execute().getResultRows();
     }
 
+    public String showCreateTable(String sql) throws Exception {
+        return show(sql).get(0).get(1);
+    }
+
     public void ddl(String sql) throws Exception {
         DDLStmtExecutor.execute(UtFrameUtils.parseStmtWithNewParser(sql, ctx), ctx);
     }

--- a/gensrc/thrift/FrontendService.thrift
+++ b/gensrc/thrift/FrontendService.thrift
@@ -401,6 +401,7 @@ struct TMaterializedViewStatus {
     25: optional string inactive_reason
 
     26: optional string extra_message
+    27: optional string query_rewrite_status
 }
 
 struct TListPipesParams {

--- a/test/sql/test_materialized_view/R/test_query_rewrite_status
+++ b/test/sql/test_materialized_view/R/test_query_rewrite_status
@@ -1,0 +1,32 @@
+-- name: test_query_rewrite_status
+create database db_${uuid0};
+-- result:
+-- !result
+use db_${uuid0};
+-- result:
+-- !result
+create table t1(c1 int, c2 int, c3 int) ;
+-- result:
+-- !result
+create materialized view mv1 refresh manual as select * from t1;
+-- result:
+-- !result
+create materialized view mv2 refresh manual properties('enable_query_rewrite'='false') as select * from t1;
+-- result:
+-- !result
+create materialized view mv3 refresh manual as select c1, count(*) from t1 group by c1;
+-- result:
+-- !result
+alter materialized view mv3 inactive;
+-- result:
+-- !result
+create materialized view mv4 refresh manual as select c1, count(*) from t1 group by c1 limit 5;
+-- result:
+-- !result
+select table_name, query_rewrite_status from information_schema.materialized_views where TABLE_SCHEMA = 'db_${uuid0}' order by table_name;
+-- result:
+mv1	VALID
+mv2	INVALID: enable_query_rewrite=FALSE
+mv3	INVALID: MV is not active
+mv4	INVALID: no valid plan: MV contains non-SPJG operators(no view rewrite): LOGICAL_LIMIT
+-- !result

--- a/test/sql/test_materialized_view/T/test_query_rewrite_status
+++ b/test/sql/test_materialized_view/T/test_query_rewrite_status
@@ -1,0 +1,14 @@
+-- name: test_query_rewrite_status
+
+create database db_${uuid0};
+use db_${uuid0};
+
+create table t1(c1 int, c2 int, c3 int) ;
+
+create materialized view mv1 refresh manual as select * from t1;
+create materialized view mv2 refresh manual properties('enable_query_rewrite'='false') as select * from t1;
+create materialized view mv3 refresh manual as select c1, count(*) from t1 group by c1;
+alter materialized view mv3 inactive;
+create materialized view mv4 refresh manual as select c1, count(*) from t1 group by c1 limit 5;
+
+select table_name, query_rewrite_status from information_schema.materialized_views where TABLE_SCHEMA = 'db_${uuid0}' order by table_name;


### PR DESCRIPTION
Why I'm doing:
- In some cases, the MV is not intended for QueryWrite but only the ETL, it should be considered as rewrite candidate which would add extra cost

What I'm doing:
- Add a property `enable_query_rewrite` for MaterializedView
- Add field `query_rewrite_status` in the `information_schema.materialized_views` view

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
