### PR TITLE
[BugFix] channel failure leads load stuck (branch-2.5) (backport #39908)

### DIFF
--- a/be/src/exec/tablet_sink.cpp
+++ b/be/src/exec/tablet_sink.cpp
@@ -1366,6 +1366,8 @@ Status OlapTableSink::try_close(RuntimeState* state) {
                     err_st = st;
                     this->mark_as_failed(ch);
                 }
+            } else {
+                ch->cancel(Status::Cancelled("channel failed"));
             }
             if (this->has_intolerable_failure()) {
                 intolerable_failure = true;
@@ -1382,6 +1384,8 @@ Status OlapTableSink::try_close(RuntimeState* state) {
                         err_st = st;
                         index_channel->mark_as_failed(ch);
                     }
+                } else {
+                    ch->cancel(Status::Cancelled("channel failed"));
                 }
                 if (index_channel->has_intolerable_failure()) {
                     intolerable_failure = true;


### PR DESCRIPTION
This is a backport of  #39908 to branch-3.5.
---
Why I'm doing:
After the node channel is failed, the channel would not be closed in `TabletSinkSender::try_close()`, and  `TabletSinkSender::is_close_done()` would never return true. In this way, the broker load job would be stuck.
What I'm doing:
In `TabletSinkSender::try_close()`, we cancel failed node channel explicitly.

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [x] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [x] 3.1
  - [x] 3.0
  - [x] 2.5


