### PR TITLE
[Enhancement] Try to use spark table column statistics if original hive table's column statistics does't exist

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/common/Config.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/Config.java
@@ -2088,6 +2088,12 @@ public class Config extends ConfigBase {
     public static boolean enable_refresh_hive_partitions_statistics = true;
 
     /**
+     * Enable reuse spark column statistics.
+     */
+    @ConfField(mutable = true)
+    public static boolean enable_reuse_spark_column_statistics = true;
+
+    /**
      * size of iceberg worker pool
      */
     @ConfField(mutable = true)

--- a/fe/fe-core/src/main/java/com/starrocks/connector/hive/HiveMetastore.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/hive/HiveMetastore.java
@@ -231,6 +231,16 @@ public class HiveMetastore implements IHiveMetastore {
                 .map(FieldSchema::getName)
                 .collect(toImmutableList());
         List<ColumnStatisticsObj> statisticsObjs = client.getTableColumnStats(dbName, tblName, dataColumns);
+        if (statisticsObjs.isEmpty()) {
+            // Try to use spark unpartitioned table column stats
+            try {
+                if (table.getParameters().keySet().stream().anyMatch(k -> k.startsWith("spark.sql.statistics.colStats."))) {
+                    statisticsObjs = HiveMetastoreApiConverter.getColStatsFromSparkParams(table);
+                }
+            } catch (Exception e) {
+                LOG.warn("Failed to get column stats from table [{}.{}]", dbName, tblName);
+            }
+        }
         Map<String, HiveColumnStats> columnStatistics =
                 HiveMetastoreApiConverter.toSinglePartitionColumnStats(statisticsObjs, totalRowNums);
         return new HivePartitionStats(commonStats, columnStatistics);

--- a/fe/fe-core/src/main/java/com/starrocks/connector/hive/HiveMetastore.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/hive/HiveMetastore.java
@@ -231,7 +231,7 @@ public class HiveMetastore implements IHiveMetastore {
                 .map(FieldSchema::getName)
                 .collect(toImmutableList());
         List<ColumnStatisticsObj> statisticsObjs = client.getTableColumnStats(dbName, tblName, dataColumns);
-        if (statisticsObjs.isEmpty()) {
+        if (statisticsObjs.isEmpty() && Config.enable_reuse_spark_column_statistics) {
             // Try to use spark unpartitioned table column stats
             try {
                 if (table.getParameters().keySet().stream().anyMatch(k -> k.startsWith("spark.sql.statistics.colStats."))) {

--- a/fe/fe-core/src/main/java/com/starrocks/connector/hive/HiveMetastoreApiConverter.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/hive/HiveMetastoreApiConverter.java
@@ -26,6 +26,7 @@ import com.starrocks.catalog.HiveTable;
 import com.starrocks.catalog.HiveView;
 import com.starrocks.catalog.HudiTable;
 import com.starrocks.catalog.Type;
+import com.starrocks.common.Config;
 import com.starrocks.common.Version;
 import com.starrocks.connector.CatalogConnector;
 import com.starrocks.connector.ColumnTypeConverter;
@@ -575,11 +576,11 @@ public class HiveMetastoreApiConverter {
 
     public static HiveCommonStats toHiveCommonStats(Map<String, String> params) {
         long numRows = getLongParam(ROW_COUNT, params);
-        if (numRows == -1) {
+        if (numRows == -1 && Config.enable_reuse_spark_column_statistics) {
             numRows = getLongParam("spark.sql.statistics.numRows", params);
         }
         long totalSize = getLongParam(TOTAL_SIZE, params);
-        if (totalSize == -1) {
+        if (totalSize == -1 && Config.enable_reuse_spark_column_statistics) {
             totalSize = getLongParam("spark.sql.statistics.totalSize", params);
         }
         return new HiveCommonStats(numRows, totalSize);

--- a/fe/fe-core/src/main/java/com/starrocks/connector/hive/HiveMetastoreApiConverter.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/hive/HiveMetastoreApiConverter.java
@@ -42,11 +42,21 @@ import com.starrocks.sql.common.StarRocksPlannerException;
 import org.apache.avro.Schema;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.hive.metastore.api.BooleanColumnStatsData;
+import org.apache.hadoop.hive.metastore.api.ColumnStatisticsData;
 import org.apache.hadoop.hive.metastore.api.ColumnStatisticsObj;
+import org.apache.hadoop.hive.metastore.api.Date;
+import org.apache.hadoop.hive.metastore.api.DateColumnStatsData;
+import org.apache.hadoop.hive.metastore.api.Decimal;
+import org.apache.hadoop.hive.metastore.api.DecimalColumnStatsData;
+import org.apache.hadoop.hive.metastore.api.DoubleColumnStatsData;
 import org.apache.hadoop.hive.metastore.api.FieldSchema;
+import org.apache.hadoop.hive.metastore.api.LongColumnStatsData;
 import org.apache.hadoop.hive.metastore.api.SerDeInfo;
 import org.apache.hadoop.hive.metastore.api.StorageDescriptor;
+import org.apache.hadoop.hive.metastore.api.StringColumnStatsData;
 import org.apache.hadoop.hive.metastore.api.Table;
+import org.apache.hadoop.hive.serde2.io.DateWritableV2;
 import org.apache.hudi.avro.HoodieAvroUtils;
 import org.apache.hudi.common.table.HoodieTableConfig;
 import org.apache.hudi.common.table.HoodieTableMetaClient;
@@ -55,12 +65,15 @@ import org.apache.hudi.common.util.Option;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
+import java.math.BigDecimal;
+import java.nio.ByteBuffer;
 import java.util.Arrays;
 import java.util.Base64;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -562,7 +575,13 @@ public class HiveMetastoreApiConverter {
 
     public static HiveCommonStats toHiveCommonStats(Map<String, String> params) {
         long numRows = getLongParam(ROW_COUNT, params);
+        if (numRows == -1) {
+            numRows = getLongParam("spark.sql.statistics.numRows", params);
+        }
         long totalSize = getLongParam(TOTAL_SIZE, params);
+        if (totalSize == -1) {
+            totalSize = getLongParam("spark.sql.statistics.totalSize", params);
+        }
         return new HiveCommonStats(numRows, totalSize);
     }
 
@@ -642,6 +661,116 @@ public class HiveMetastoreApiConverter {
             // ignore
         }
         return -1;
+    }
+
+    public static List<ColumnStatisticsObj> getColStatsFromSparkParams(org.apache.hadoop.hive.metastore.api.Table table) {
+        return table.getSd().getCols().stream()
+                .map(fieldSchema -> convertSparkColumnStatistics(fieldSchema, table.getParameters()))
+                .filter(Objects::nonNull)
+                .collect(Collectors.toList());
+    }
+
+    /**
+     * Refer to https://github.com/apache/hive/blob/rel/release-3.1.3/ql/src/java/org/apache/hadoop/hive/ql/exec/ColumnStatsUpdateTask.java#L77
+     */
+    public static ColumnStatisticsObj convertSparkColumnStatistics(FieldSchema fieldSchema, Map<String, String> parameters) {
+
+        String columnName = fieldSchema.getName();
+        String columnType = fieldSchema.getType().toLowerCase();
+        String colStatsPrefix = "spark.sql.statistics.colStats." + columnName + ".";
+        if (parameters.keySet().stream().noneMatch(k -> k.startsWith(colStatsPrefix))) {
+            // return early if no stats for this column
+            return null;
+        }
+        long distinctCount = Long.parseLong(parameters.get(colStatsPrefix + "distinctCount"));
+        long nullsCount = Long.parseLong(parameters.get(colStatsPrefix + "nullCount"));
+        ColumnStatisticsObj colStatsObj = new ColumnStatisticsObj();
+        colStatsObj.setColName(columnName);
+        colStatsObj.setColType(columnType);
+        ColumnStatisticsData colStatsData = new ColumnStatisticsData();
+        switch (columnType) {
+            case "long":
+            case "tinyint":
+            case "smallint":
+            case "int":
+            case "bigint":
+            case "timestamp":
+                LongColumnStatsData longColStats = new LongColumnStatsData();
+                longColStats.setNumNulls(nullsCount);
+                longColStats.setLowValue(Long.parseLong(parameters.get(colStatsPrefix + "min")));
+                longColStats.setHighValue(Long.parseLong(parameters.get(colStatsPrefix + "max")));
+                longColStats.setNumDVs(distinctCount);
+                colStatsData.setLongStats(longColStats);
+                break;
+            case "double":
+            case "float":
+                DoubleColumnStatsData doubleColStats = new DoubleColumnStatsData();
+                doubleColStats.setNumNulls(nullsCount);
+                doubleColStats.setLowValue(Double.parseDouble(parameters.get(colStatsPrefix + "min")));
+                doubleColStats.setHighValue(Double.parseDouble(parameters.get(colStatsPrefix + "max")));
+                doubleColStats.setNumDVs(distinctCount);
+                colStatsData.setDoubleStats(doubleColStats);
+                break;
+            case "string":
+            case "char":
+            case "varchar":
+                StringColumnStatsData stringColStats = new StringColumnStatsData();
+                stringColStats.setNumNulls(nullsCount);
+                stringColStats.setAvgColLen(Double.parseDouble(parameters.get(colStatsPrefix + "avgLen")));
+                stringColStats.setMaxColLen(Long.parseLong(parameters.get(colStatsPrefix + "maxLen")));
+                stringColStats.setNumDVs(distinctCount);
+                colStatsData.setStringStats(stringColStats);
+                break;
+            case "boolean":
+                BooleanColumnStatsData booleanColStats = new BooleanColumnStatsData();
+                booleanColStats.setNumNulls(nullsCount);
+                colStatsData.setBooleanStats(booleanColStats);
+                break;
+            case "decimal":
+                DecimalColumnStatsData decimalColStats = new DecimalColumnStatsData();
+                decimalColStats.setNumNulls(nullsCount);
+                BigDecimal lowVal = new BigDecimal(parameters.get(colStatsPrefix + "min"));
+                decimalColStats.setLowValue(getHiveDecimal(ByteBuffer.wrap(lowVal.unscaledValue().toByteArray()),
+                        (short) lowVal.scale()));
+                BigDecimal highVal = new BigDecimal(parameters.get(colStatsPrefix + "max"));
+                decimalColStats.setHighValue(getHiveDecimal(ByteBuffer.wrap(highVal.unscaledValue().toByteArray()),
+                        (short) highVal.scale()));
+                decimalColStats.setNumDVs(distinctCount);
+                colStatsData.setDecimalStats(decimalColStats);
+                break;
+            case "date":
+                DateColumnStatsData dateColStats = new DateColumnStatsData();
+                dateColStats.setNumNulls(nullsCount);
+                dateColStats.setLowValue(readDateValue(parameters.get(colStatsPrefix + "min")));
+                dateColStats.setHighValue(readDateValue(parameters.get(colStatsPrefix + "max")));
+                dateColStats.setNumDVs(distinctCount);
+                colStatsData.setDateStats(dateColStats);
+                break;
+            default:
+                LOG.warn("Unsupported column statistics type: {}", columnType);
+                return null;
+        }
+        colStatsObj.setStatsData(colStatsData);
+        return colStatsObj;
+    }
+
+    private static Decimal getHiveDecimal(ByteBuffer unscaled, short scale) {
+        return new Decimal(scale, unscaled);
+    }
+
+    /**
+     * Refer to https://github.com/apache/hive/blob/rel/release-3.1.3/ql/src/java/org/apache/hadoop/hive/ql/exec/ColumnStatsUpdateTask.java#L318
+     */
+    private static Date readDateValue(String dateStr) {
+        // try either yyyy-mm-dd, or integer representing days since epoch
+        try {
+            DateWritableV2 writableVal = new DateWritableV2(org.apache.hadoop.hive.common.type.Date.valueOf(dateStr));
+            return new Date(writableVal.getDays());
+        } catch (IllegalArgumentException err) {
+            // Fallback to integer parsing
+            LOG.debug("Reading date value as days since epoch: {}", dateStr);
+            return new Date(Long.parseLong(dateStr));
+        }
     }
 
 }


### PR DESCRIPTION
## Why I'm doing:
Some users would like spark to do some etl jobs, and they will use spark enging to analyze hive table to generate column statistics, which store in table parameters.

We can reuse spark's column statistics is original hive table's column statistics does't exist, and this can speed up query without regenerating column statistics.

## What I'm doing:

Fixes #40023

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
