### PR TITLE
[BugFix] fix asan stack-use-after-scope

### DIFF
--- a/be/src/storage/tablet_updates.cpp
+++ b/be/src/storage/tablet_updates.cpp
@@ -385,16 +385,16 @@ size_t TabletUpdates::data_size() const {
         LOG_EVERY_N(WARNING, 10) << "data_size() some rowset stats not found tablet=" << _tablet.tablet_id()
                                  << " rowset=" << err_rowsets;
     }
-    int64_t pindex_size = 0;
-    int64_t col_size = 0;
-    Status st = _get_extra_file_size(&pindex_size, &col_size);
-    if (!st.ok()) {
+    auto size_st = _get_extra_file_size();
+    if (!size_st.ok()) {
         // Ignore error status here, because we don't to break up tablet report because of get extra file size failure.
         // So just print error log and keep going.
         LOG(ERROR) << "get extra file size in primary table fail, tablet_id: " << _tablet.tablet_id()
-                   << " status: " << st;
+                   << " status: " << size_st.status();
+        return total_size;
+    } else {
+        return total_size + (*size_st).pindex_size + (*size_st).col_size;
     }
-    return total_size + pindex_size + col_size;
 }
 
 size_t TabletUpdates::num_rows() const {
@@ -450,16 +450,16 @@ std::pair<int64_t, int64_t> TabletUpdates::num_rows_and_data_size() const {
         LOG_EVERY_N(WARNING, 10) << "data_size() some rowset stats not found tablet=" << _tablet.tablet_id()
                                  << " rowset=" << err_rowsets;
     }
-    int64_t pindex_size = 0;
-    int64_t col_size = 0;
-    Status st = _get_extra_file_size(&pindex_size, &col_size);
-    if (!st.ok()) {
+    auto size_st = _get_extra_file_size();
+    if (!size_st.ok()) {
         // Ignore error status here, because we don't to break up tablet report because of get extra file size failure.
         // So just print error log and keep going.
         LOG(ERROR) << "get extra file size in primary table fail, tablet_id: " << _tablet.tablet_id()
-                   << " status: " << st;
+                   << " status: " << size_st.status();
+        return {total_row, total_size};
+    } else {
+        return {total_row, total_size + (*size_st).pindex_size + (*size_st).col_size};
     }
-    return {total_row, total_size + pindex_size + col_size};
 }
 
 size_t TabletUpdates::num_rowsets() const {
@@ -2941,22 +2941,20 @@ size_t TabletUpdates::_get_rowset_num_deletes(const Rowset& rowset) {
     return num_dels;
 }
 
-Status TabletUpdates::_get_extra_file_size(int64_t* pindex_size, int64_t* col_size) const {
-    std::filesystem::path tablet_path(_tablet.schema_hash_path().c_str());
+StatusOr<ExtraFileSize> TabletUpdates::_get_extra_file_size() const {
+    std::string tablet_path_str = _tablet.schema_hash_path();
+    std::filesystem::path tablet_path(tablet_path_str.c_str());
+    ExtraFileSize ef_size;
     try {
         for (const auto& entry : std::filesystem::directory_iterator(tablet_path)) {
             if (entry.is_regular_file()) {
                 std::string filename = entry.path().filename().string();
 
                 if (filename.starts_with("index.l")) {
-                    if (pindex_size != nullptr) {
-                        *pindex_size += std::filesystem::file_size(entry);
-                    }
+                    ef_size.pindex_size += std::filesystem::file_size(entry);
                 } else if (filename.ends_with(".cols")) {
                     // TODO skip the expired cols file
-                    if (col_size != nullptr) {
-                        *col_size += std::filesystem::file_size(entry);
-                    }
+                    ef_size.col_size += std::filesystem::file_size(entry);
                 }
             }
         }
@@ -2970,7 +2968,7 @@ Status TabletUpdates::_get_extra_file_size(int64_t* pindex_size, int64_t* col_si
         std::string err_msg = "Iterate dir " + tablet_path.string() + " Unknown exception occurred.";
         return Status::InternalError(err_msg);
     }
-    return Status::OK();
+    return ef_size;
 }
 
 void TabletUpdates::get_tablet_info_extra(TTabletInfo* info) {
@@ -3016,14 +3014,15 @@ void TabletUpdates::get_tablet_info_extra(TTabletInfo* info) {
         LOG_EVERY_N(WARNING, 10) << "get_tablet_info_extra() some rowset stats not found tablet=" << _tablet.tablet_id()
                                  << " rowset=" << err_rowsets;
     }
-    int64_t pindex_size = 0;
-    int64_t col_size = 0;
-    Status st = _get_extra_file_size(&pindex_size, &col_size);
-    if (!st.ok()) {
+    auto size_st = _get_extra_file_size();
+
+    if (!size_st.ok()) {
         // Ignore error status here, because we don't to break up tablet report because of get extra file size failure.
         // So just print error log and keep going.
         LOG(ERROR) << "get extra file size in primary table fail, tablet_id: " << _tablet.tablet_id()
-                   << " status: " << st;
+                   << " status: " << size_st.status();
+    } else {
+        total_size += (*size_st).pindex_size + (*size_st).col_size;
     }
     info->__set_version(version);
     info->__set_min_readable_version(min_readable_version);
@@ -3031,7 +3030,7 @@ void TabletUpdates::get_tablet_info_extra(TTabletInfo* info) {
     info->__set_version_miss(has_pending);
     info->__set_version_count(version_count);
     info->__set_row_count(total_row);
-    info->__set_data_size(total_size + pindex_size + col_size);
+    info->__set_data_size(total_size);
     info->__set_is_error_state(_error);
     info->__set_max_rowset_creation_time(max_rowset_creation_time());
 }
@@ -4099,15 +4098,14 @@ void TabletUpdates::get_basic_info_extra(TabletBasicInfo& info) {
         info.index_mem = index_entry->size();
         index_cache.release(index_entry);
     }
-    int64_t pindex_size = 0;
-    auto st = _get_extra_file_size(&pindex_size, nullptr);
-    if (!st.ok()) {
+    auto size_st = _get_extra_file_size();
+    if (!size_st.ok()) {
         // Ignore error status here, because we don't to break up get basic info because of get pk index disk usage failure.
         // So just print error log and keep going.
         LOG(ERROR) << "get persistent index disk usage fail, tablet_id: " << _tablet.tablet_id()
-                   << ", error: " << st.message();
+                   << ", error: " << size_st.status();
     } else {
-        info.index_disk_usage = pindex_size;
+        info.index_disk_usage = (*size_st).pindex_size;
     }
 }
 

--- a/be/src/storage/tablet_updates.h
+++ b/be/src/storage/tablet_updates.h
@@ -72,6 +72,11 @@ struct CompactionInfo {
     uint32_t output = UINT32_MAX;
 };
 
+struct ExtraFileSize {
+    int64_t pindex_size = 0;
+    int64_t col_size = 0;
+};
+
 struct EditVersionInfo {
     EditVersion version;
     int64_t creation_time;
@@ -454,7 +459,7 @@ private:
 
     std::timed_mutex* get_index_lock() { return &_index_lock; }
 
-    Status _get_extra_file_size(int64_t* pindex_size, int64_t* col_size) const;
+    StatusOr<ExtraFileSize> _get_extra_file_size() const;
 
 private:
     Tablet& _tablet;


### PR DESCRIPTION
Why I'm doing:
Fix BE asan :
```
Crash Log: 
==3062==ERROR: AddressSanitizer: stack-use-after-scope on address 0x7fc5fa540f40 at pc 0x00000a2fbc2c bp 0x7fc5fa540f10 sp 0x7fc5fa5406c0
WRITE of size 144 at 0x7fc5fa540f40 thread T323
    #0 0xa2fbc2b in __interceptor___xstat ../../.././libsanitizer/sanitizer_common/sanitizer_common_interceptors.inc:6533
    #1 0x17e9cf4b in stat /usr/include/sys/stat.h:456
    #2 0x17e9cf4b in do_stat<std::filesystem::file_size(const std::filesystem::__cxx11::path&, std::error_code&)::<lambda(const auto:1&)>, std::filesystem::file_size(const std::filesystem::__cxx11::path&, std::error_code&)::S> ../../../.././libstdc++-v3/src/c++17/fs_ops.cc:931
    #3 0x17e9cf4b in std::filesystem::file_size(std::filesystem::__cxx11::path const&, std::error_code&) ../../../.././libstdc++-v3/src/c++17/fs_ops.cc:956
    #4 0x17e9d017 in std::filesystem::file_size(std::filesystem::__cxx11::path const&) ../../../.././libstdc++-v3/src/c++17/fs_ops.cc:917
    #5 0x109f6ce9 in starrocks::TabletUpdates::_get_extra_file_size(long*, long*) const /root/starrocks/be/src/storage/tablet_updates.cpp:2824
    #6 0x109f89be in starrocks::TabletUpdates::get_tablet_info_extra(starrocks::TTabletInfo*) /root/starrocks/be/src/storage/tablet_updates.cpp:2892
    #7 0x108888c9 in starrocks::Tablet::build_tablet_report_info(starrocks::TTabletInfo*) /root/starrocks/be/src/storage/tablet.cpp:1426
```


## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [x] 3.1
  - [ ] 3.0
  - [ ] 2.5
