### PR TITLE
[BugFix] mysql-connector must be excluded in release package (#40012)

### DIFF
--- a/fe/fe-core/pom.xml
+++ b/fe/fe-core/pom.xml
@@ -780,10 +780,11 @@ under the License.
             <artifactId>opentelemetry-exporter-jaeger</artifactId>
         </dependency>
 
-        <!-- https://mvnrepository.com/artifact/com.mysql/mysql-connector-j -->
+        <!-- https://mvnrepository.com/artifact/org.mariadb.jdbc/mariadb-java-client -->
         <dependency>
-            <groupId>com.mysql</groupId>
-            <artifactId>mysql-connector-j</artifactId>
+            <groupId>org.mariadb.jdbc</groupId>
+            <artifactId>mariadb-java-client</artifactId>
+            <scope>test</scope>
         </dependency>
 
         <!-- https://mvnrepository.com/artifact/org.postgresql/postgresql -->

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/JDBCTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/JDBCTable.java
@@ -272,6 +272,7 @@ public class JDBCTable extends Table {
         UNKNOWN,
         MYSQL,
         POSTGRES,
-        ORACLE
+        ORACLE,
+        MARIADB
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/connector/jdbc/JDBCMetadata.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/jdbc/JDBCMetadata.java
@@ -77,6 +77,8 @@ public class JDBCMetadata implements ConnectorMetadata {
             schemaResolver = new MysqlSchemaResolver();
         } else if (properties.get(JDBCResource.DRIVER_CLASS).toLowerCase().contains("postgresql")) {
             schemaResolver = new PostgresSchemaResolver();
+        } else if (properties.get(JDBCResource.DRIVER_CLASS).toLowerCase().contains("mariadb")) {
+            schemaResolver = new MysqlSchemaResolver();
         } else {
             LOG.warn("{} not support yet", properties.get(JDBCResource.DRIVER_CLASS));
             throw new StarRocksConnectorException(properties.get(JDBCResource.DRIVER_CLASS) + " not support yet");

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/MaterializedViewAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/MaterializedViewAnalyzer.java
@@ -116,7 +116,7 @@ public class MaterializedViewAnalyzer {
     private static final Logger LOG = LogManager.getLogger(MaterializedViewAnalyzer.class);
 
     private static final Set<JDBCTable.ProtocolType> SUPPORTED_JDBC_PARTITION_TYPE =
-            ImmutableSet.of(JDBCTable.ProtocolType.MYSQL);
+            ImmutableSet.of(JDBCTable.ProtocolType.MYSQL, JDBCTable.ProtocolType.MARIADB);
 
     private static final Set<Table.TableType> SUPPORTED_TABLE_TYPE =
             ImmutableSet.of(Table.TableType.OLAP,

--- a/fe/fe-core/src/test/java/com/starrocks/connector/jdbc/JDBCConnectorTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/jdbc/JDBCConnectorTest.java
@@ -29,8 +29,8 @@ public class JDBCConnectorTest {
     public void testProperties() {
         FeConstants.runningUnitTest = true;
         Map<String, String> properties = new HashMap<>();
-        properties.put(JDBCResource.DRIVER_CLASS, "com.mysql.cj.jdbc.Driver");
-        properties.put(JDBCResource.URI, "jdbc:mysql://127.0.0.1:3306");
+        properties.put(JDBCResource.DRIVER_CLASS, "org.mariadb.jdbc.Driver");
+        properties.put(JDBCResource.URI, "jdbc:mariadb://127.0.0.1:3306");
         properties.put(JDBCResource.USER, "root");
         properties.put(JDBCResource.PASSWORD, "123456");
         ConnectorContext context = new ConnectorContext("jdbcmysql", "jdbc", properties);

--- a/fe/fe-core/src/test/java/com/starrocks/connector/jdbc/JDBCMetaCacheTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/jdbc/JDBCMetaCacheTest.java
@@ -90,8 +90,8 @@ public class JDBCMetaCacheTest {
         columnResult.addColumn("IS_NULLABLE",
                 Arrays.asList("YES", "NO", "NO", "NO", "NO", "NO", "NO", "NO", "NO", "NO", "NO", "NO"));
         properties = new HashMap<>();
-        properties.put(DRIVER_CLASS, "com.mysql.cj.jdbc.Driver");
-        properties.put(JDBCResource.URI, "jdbc:mysql://127.0.0.1:3306");
+        properties.put(DRIVER_CLASS, "org.mariadb.jdbc.Driver");
+        properties.put(JDBCResource.URI, "jdbc:mariadb://127.0.0.1:3306");
         properties.put(JDBCResource.USER, "root");
         properties.put(JDBCResource.PASSWORD, "123456");
         properties.put(JDBCResource.CHECK_SUM, "xxxx");

--- a/fe/fe-core/src/test/java/com/starrocks/connector/jdbc/JDBCMetadataTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/jdbc/JDBCMetadataTest.java
@@ -80,8 +80,8 @@ public class JDBCMetadataTest {
         columnResult.addColumn("IS_NULLABLE",
                 Arrays.asList("YES", "NO", "NO", "NO", "NO", "NO", "NO", "NO", "NO", "NO", "NO", "NO", "NO", "NO", "NO"));
         properties = new HashMap<>();
-        properties.put(DRIVER_CLASS, "com.mysql.cj.jdbc.Driver");
-        properties.put(JDBCResource.URI, "jdbc:mysql://127.0.0.1:3306");
+        properties.put(DRIVER_CLASS, "org.mariadb.jdbc.Driver");
+        properties.put(JDBCResource.URI, "jdbc:mariadb://127.0.0.1:3306");
         properties.put(JDBCResource.USER, "root");
         properties.put(JDBCResource.PASSWORD, "123456");
         properties.put(JDBCResource.CHECK_SUM, "xxxx");
@@ -248,8 +248,8 @@ public class JDBCMetadataTest {
     @Test
     public void testCreateHikariDataSource() {
         properties = new HashMap<>();
-        properties.put(DRIVER_CLASS, "com.mysql.cj.jdbc.Driver");
-        properties.put(JDBCResource.URI, "jdbc:mysql://127.0.0.1:3306");
+        properties.put(DRIVER_CLASS, "org.mariadb.jdbc.Driver");
+        properties.put(JDBCResource.URI, "jdbc:mariadb://127.0.0.1:3306");
         properties.put(JDBCResource.USER, "root");
         properties.put(JDBCResource.PASSWORD, "123456");
         properties.put(JDBCResource.CHECK_SUM, "xxxx");

--- a/fe/fe-core/src/test/java/com/starrocks/connector/jdbc/MysqlSchemaResolverTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/jdbc/MysqlSchemaResolverTest.java
@@ -83,8 +83,8 @@ public class MysqlSchemaResolverTest {
         partitionsResult.addColumn("MODIFIED_TIME", Arrays.asList("2023-08-01 00:00:00"));
 
         properties = new HashMap<>();
-        properties.put(DRIVER_CLASS, "com.mysql.cj.jdbc.Driver");
-        properties.put(JDBCResource.URI, "jdbc:mysql://127.0.0.1:3306");
+        properties.put(DRIVER_CLASS, "org.mariadb.jdbc.Driver");
+        properties.put(JDBCResource.URI, "jdbc:mariadb://127.0.0.1:3306");
         properties.put(JDBCResource.USER, "root");
         properties.put(JDBCResource.PASSWORD, "123456");
         properties.put(JDBCResource.CHECK_SUM, "xxxx");

--- a/fe/fe-core/src/test/java/com/starrocks/pseudocluster/PseudoCluster.java
+++ b/fe/fe-core/src/test/java/com/starrocks/pseudocluster/PseudoCluster.java
@@ -56,7 +56,6 @@ import java.io.File;
 import java.io.IOException;
 import java.sql.Connection;
 import java.sql.SQLException;
-import java.sql.SQLSyntaxErrorException;
 import java.sql.Statement;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -97,7 +96,7 @@ public class PseudoCluster {
 
     static {
         try {
-            Class.forName("com.mysql.cj.jdbc.Driver").newInstance();
+            Class.forName("org.mariadb.jdbc.Driver").newInstance();
         } catch (Exception ex) {
             ex.printStackTrace();
         }
@@ -265,7 +264,7 @@ public class PseudoCluster {
     public ClusterConfig getConfig() {
         return config;
     }
-    
+
     public PseudoBackend getBackend(long beId) {
         String host = backendIdToHost.get(beId);
         if (host == null) {
@@ -327,8 +326,8 @@ public class PseudoCluster {
                     System.out.printf("runSql(%.3fs): %s\n", (end - start) / 1e9, sql);
                 }
                 break;
-            } catch (SQLSyntaxErrorException e) {
-                if (e.getMessage().startsWith("rpc failed, host")) {
+            } catch (SQLException e) {
+                if (e.getMessage().contains("rpc failed, host")) {
                     try {
                         Thread.sleep(1000);
                     } catch (InterruptedException ie) {
@@ -410,7 +409,7 @@ public class PseudoCluster {
 
         BasicDataSource dataSource = new BasicDataSource();
         dataSource.setUrl(
-                "jdbc:mysql://127.0.0.1:" + queryPort + "/?permitMysqlScheme" +
+                "jdbc:mariadb://127.0.0.1:" + queryPort + "/?permitMysqlScheme" +
                         "&usePipelineAuth=false&useBatchMultiSend=false&" +
                         "autoReconnect=true&failOverReadOnly=false&maxReconnects=10");
         dataSource.setUsername("root");

--- a/fe/fe-core/src/test/java/com/starrocks/pseudocluster/PseudoClusterTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/pseudocluster/PseudoClusterTest.java
@@ -117,7 +117,7 @@ public class PseudoClusterTest {
             stmt.execute("prepare stmt1 from select * from test where pk = ?");
             stmt.execute("prepare stmt3 from select 1");
             stmt.execute("set @i = 1");
-            stmt.executeUpdate("execute stmt1 using @i");
+            stmt.execute("execute stmt1 using @i");
             stmt.execute("execute stmt1 using @i");
             stmt.execute("execute stmt3");
             stmt.execute("select * from test where pk = ?", 1);
@@ -152,7 +152,7 @@ public class PseudoClusterTest {
             stmt.execute("prepare stmt1 from select * from test where pk = ?");
             stmt.execute("prepare stmt3 from select 1");
             stmt.execute("set @i = 1");
-            stmt.executeUpdate("execute stmt1 using @i");
+            stmt.execute("execute stmt1 using @i");
             stmt.execute("execute stmt1 using @i");
             stmt.execute("execute stmt3");
             stmt.execute("select * from test where pk = ?", 1);

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/ConnectorPlanTestBase.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/ConnectorPlanTestBase.java
@@ -309,8 +309,8 @@ public class ConnectorPlanTestBase extends PlanTestBase {
         Map<String, String> properties = Maps.newHashMap();
 
         properties.put(JDBCResource.TYPE, "jdbc");
-        properties.put(JDBCResource.DRIVER_CLASS, "com.mysql.cj.jdbc.Driver");
-        properties.put(JDBCResource.URI, "jdbc:mysql://127.0.0.1:3306");
+        properties.put(JDBCResource.DRIVER_CLASS, "org.mariadb.jdbc.Driver");
+        properties.put(JDBCResource.URI, "jdbc:mariadb://127.0.0.1:3306");
         properties.put(JDBCResource.USER, "root");
         properties.put(JDBCResource.PASSWORD, "123456");
         properties.put(JDBCResource.CHECK_SUM, "xxxx");

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/ExternalTableTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/ExternalTableTest.java
@@ -50,7 +50,7 @@ public class ExternalTableTest extends PlanTestBase {
     public void testKeyWordWhereCaluse() throws Exception {
         String sql = "select * from test.jdbc_key_words_test where `schema` = \"test\"";
         String plan = getFragmentPlan(sql);
-        assertContains(plan, "`schema` = 'test'");
+        assertContains(plan, "schema = 'test'");
     }
 
     @Test
@@ -185,8 +185,8 @@ public class ExternalTableTest extends PlanTestBase {
         String sql = "select * from test.jdbc_test where a > 10 and b < 'abc' limit 10";
         String plan = getFragmentPlan(sql);
         Assert.assertTrue(plan, plan.contains("0:SCAN JDBC\n" +
-                "     TABLE: `test_table`\n" +
-                "     QUERY: SELECT `a`, `b`, `c` FROM `test_table` WHERE (`a` > 10) AND (`b` < 'abc')\n" +
+                "     TABLE: test_table\n" +
+                "     QUERY: SELECT a, b, c FROM test_table WHERE (a > 10) AND (b < 'abc')\n" +
                 "     limit: 10"));
         sql = "select * from test.jdbc_test where a > 10 and length(b) < 20 limit 10";
         plan = getFragmentPlan(sql);
@@ -196,8 +196,8 @@ public class ExternalTableTest extends PlanTestBase {
                         "  |  limit: 10\n" +
                         "  |  \n" +
                         "  0:SCAN JDBC\n" +
-                        "     TABLE: `test_table`\n" +
-                        "     QUERY: SELECT `a`, `b`, `c` FROM `test_table` WHERE (`a` > 10)"));
+                        "     TABLE: test_table\n" +
+                        "     QUERY: SELECT a, b, c FROM test_table WHERE (a > 10)"));
 
     }
 
@@ -211,8 +211,8 @@ public class ExternalTableTest extends PlanTestBase {
                         "  |  group by: b\n" +
                         "  |  \n" +
                         "  0:SCAN JDBC\n" +
-                        "     TABLE: `test_table`\n" +
-                        "     QUERY: SELECT `a`, `b` FROM `test_table`"));
+                        "     TABLE: test_table\n" +
+                        "     QUERY: SELECT a, b FROM test_table"));
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/PlanTestBase.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/PlanTestBase.java
@@ -682,7 +682,7 @@ public class PlanTestBase extends PlanTestNoneDBBase {
                         "\"password\"=\"test_passwd\",\n" +
                         "\"driver_url\"=\"test_driver_url\",\n" +
                         "\"driver_class\"=\"test.driver.class\",\n" +
-                        "\"jdbc_uri\"=\"jdbc:mysql://127.0.0.1:3306\"\n" +
+                        "\"jdbc_uri\"=\"jdbc:mariadb://127.0.0.1:3306\"\n" +
                         ");")
                 .withTable("create external table test.jdbc_test\n" +
                         "(a int, b varchar(20), c float)\n" +

--- a/fe/pom.xml
+++ b/fe/pom.xml
@@ -703,11 +703,12 @@ under the License.
                 <scope>import</scope>
             </dependency>
 
-            <!-- https://mvnrepository.com/artifact/com.mysql/mysql-connector-j -->
+            <!-- https://mvnrepository.com/artifact/org.mariadb.jdbc/mariadb-java-client -->
             <dependency>
-                <groupId>com.mysql</groupId>
-                <artifactId>mysql-connector-j</artifactId>
-                <version>8.0.33</version>
+                <groupId>org.mariadb.jdbc</groupId>
+                <artifactId>mariadb-java-client</artifactId>
+                <version>3.3.2</version>
+                <scope>test</scope>
             </dependency>
 
             <!-- https://mvnrepository.com/artifact/org.postgresql/postgresql -->


### PR DESCRIPTION
GPL jar(mysql-connector) must be excluded in release package mysql-connector-j from 'compile' to 'test'

Why I'm doing:
mysql-connector must be excluded in release package

What I'm doing:
set mysql-connector's scope to test

Fixes #40012 

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
