### PR TITLE
[BugFix] Fix prune subfield error

### DIFF
--- a/be/src/exec/pipeline/scan/olap_chunk_source.cpp
+++ b/be/src/exec/pipeline/scan/olap_chunk_source.cpp
@@ -305,7 +305,7 @@ Status OlapChunkSource::_init_column_access_paths(Schema* schema) {
         auto& root = path->path();
         int32_t index = _tablet->field_index_with_max_version(root);
         auto field = schema->get_field_by_name(root);
-        if (index >= 0) {
+        if (index >= 0 && field != nullptr) {
             auto res = path->convert_by_index(field.get(), index);
             // read whole data, doesn't effect query
             if (LIKELY(res.ok())) {
@@ -314,6 +314,8 @@ Status OlapChunkSource::_init_column_access_paths(Schema* schema) {
             } else {
                 LOG(WARNING) << "failed to convert column access path: " << res.status();
             }
+        } else {
+            LOG(WARNING) << "failed to find column in schema: " << root;
         }
     }
     _params.column_access_paths = &_column_access_paths;

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/ColumnAccessPath.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/ColumnAccessPath.java
@@ -72,6 +72,10 @@ public class ColumnAccessPath {
         return type;
     }
 
+    public String getPath() {
+        return path;
+    }
+
     public boolean onlyRoot() {
         return type == TAccessPathType.ROOT && children.isEmpty();
     }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/plan/PlanFragmentBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/plan/PlanFragmentBuilder.java
@@ -673,8 +673,12 @@ public class PlanFragmentBuilder {
                 return scan.getColumnAccessPaths();
             }
 
+            Set<String> checkNames = scan.getColRefToColumnMetaMap().keySet().stream().map(ColumnRefOperator::getName)
+                    .collect(Collectors.toSet());
             if (scan.getPredicate() == null) {
-                return scan.getColumnAccessPaths();
+                // remove path which has pruned
+                return scan.getColumnAccessPaths().stream().filter(p -> !checkNames.contains(p.getPath()))
+                        .collect(Collectors.toList());
             }
 
             SubfieldExpressionCollector collector = new SubfieldExpressionCollector(

--- a/fe/fe-core/src/main/java/com/starrocks/sql/plan/PlanFragmentBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/plan/PlanFragmentBuilder.java
@@ -677,7 +677,7 @@ public class PlanFragmentBuilder {
                     .collect(Collectors.toSet());
             if (scan.getPredicate() == null) {
                 // remove path which has pruned
-                return scan.getColumnAccessPaths().stream().filter(p -> !checkNames.contains(p.getPath()))
+                return scan.getColumnAccessPaths().stream().filter(p -> checkNames.contains(p.getPath()))
                         .collect(Collectors.toList());
             }
 

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/PruneComplexSubfieldTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/PruneComplexSubfieldTest.java
@@ -984,4 +984,21 @@ public class PruneComplexSubfieldTest extends PlanTestNoneDBBase {
         plan = getVerboseExplain(sql);
         assertNotContains(plan, "ColumnAccessPath");
     }
+
+    @Test
+    public void testSubfieldPathLose() throws Exception {
+        String sql = "select v1 from pc0 where a1[1] NOT IN (select t0.v1 from t0 where false)";
+        String plan = getVerboseExplain(sql);
+
+        assertContains(plan, "  RESULT SINK\n" +
+                "\n" +
+                "  1:Project\n" +
+                "  |  output columns:\n" +
+                "  |  1 <-> [1: v1, BIGINT, true]\n" +
+                "  |  cardinality: 1\n" +
+                "  |  \n" +
+                "  0:OlapScanNode\n" +
+                "     table: pc0, rollup: pc0");
+        assertNotContains(plan, "ColumnAccessPath");
+    }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/PruneComplexSubfieldTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/PruneComplexSubfieldTest.java
@@ -987,7 +987,7 @@ public class PruneComplexSubfieldTest extends PlanTestNoneDBBase {
 
     @Test
     public void testSubfieldPathLose() throws Exception {
-        String sql = "select v1 from pc0 where a1[1] NOT IN (select t0.v1 from t0 where false)";
+        String sql = "select v1 from pc0 where (a1 is not null) NOT IN (select t0.v1 from t0 where false)";
         String plan = getVerboseExplain(sql);
 
         assertContains(plan, "  RESULT SINK\n" +
@@ -999,6 +999,6 @@ public class PruneComplexSubfieldTest extends PlanTestNoneDBBase {
                 "  |  \n" +
                 "  0:OlapScanNode\n" +
                 "     table: pc0, rollup: pc0");
-        assertNotContains(plan, "ColumnAccessPath");
+        assertContains(plan, "ColumnAccessPath");
     }
 }

--- a/test/sql/test_semi/R/test_prune
+++ b/test/sql/test_semi/R/test_prune
@@ -141,3 +141,9 @@ select s1.s2[1].a, s1.s3[1], s1.s4.f from sc3 where s1.s3[2] = 22;
 -- result:
 1	12	2
 -- !result
+select v1 from sc3 where a1[1] not in (select tt.v1 from sc3 as tt where false);
+-- result:
+2
+1
+3
+-- !result

--- a/test/sql/test_semi/T/test_prune
+++ b/test/sql/test_semi/T/test_prune
@@ -50,3 +50,4 @@ select s1.s2[1].a, s1.s3[1], s1.s4.f from sc3 where s1.s2 = [row(1,3), row(2,3)]
 select s1.s2[1].a, s1.s3[1], s1.s4.f from sc3 where s1.s2[2].a = 3;
 select s1.s2[1].a, s1.s3[1], s1.s4.f from sc3 where s1.s3[2] = 22;
 
+select v1 from sc3 where a1[1] not in (select tt.v1 from sc3 as tt where false);


### PR DESCRIPTION
Why I'm doing:

What I'm doing:

```
MySQL g1> explain verbose SELECT c_0_4 
FROM t0
WHERE c_0_12[1] NOT IN (
          SELECT t0_6.c_0_4 
          FROM  t0 AS t0_6 
          WHERE FALSE)
+---------------------------------------------+
| Explain String                              |
+---------------------------------------------+
| RESOURCE GROUP: default_wg                  |
|                                             |
| PLAN FRAGMENT 0(F01)                        |
|   Output Exprs:5: c_0_4                     |
|   Input Partition: UNPARTITIONED            |
|   RESULT SINK                               |
|                                             |
|   2:EXCHANGE                                |
|      cardinality: 5                         |
|                                             |
| PLAN FRAGMENT 1(F00)                        |
|                                             |
|   Input Partition: RANDOM                   |
|   OutPut Partition: UNPARTITIONED           |
|   OutPut Exchange Id: 02                    |
|                                             |
|   1:Project                                 |
|   |  output columns:                        |
|   |  5 <-> [5: c_0_4, BOOLEAN, false]       |
|   |  cardinality: 5                         |
|   |                                         |
|   0:OlapScanNode                            |
|      table: t0, rollup: t0                  |
|      preAggregation: on                     |
|      partitionsRatio=1/31, tabletsRatio=3/3 |
|      tabletList=7519301,7519303,7519305     |
|      actualRows=5, avgRowSize=17.0          |
|      Pruned type: 13 <-> [ARRAY<INT>]       |
|      ColumnAccessPath: [/c_0_12/INDEX]      |
|      cardinality: 5                         |
+---------------------------------------------+
30 rows in set
Time: 0.022s
```

The query dones't use `c_0_12` but has subfield path, beause optimizer execute PruneSubfieldRule to generate c_0_12's ColumnAccessPath, and execute another rules to prune c_0_12 (like PruneEmptyNodeRule, will remove whole subquery).

so we will check the path in PlanFragmentBuilder and BE again

Fixes https://github.com/StarRocks/StarRocksTest/issues/5806

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
