### PR TITLE
[Enhancement]Use union_iterator to get data from non-overlapping rowset during pk compaction

### DIFF
--- a/be/src/storage/rowset_merger.cpp
+++ b/be/src/storage/rowset_merger.cpp
@@ -343,7 +343,6 @@ private:
                 } else {
                     entry.segment_itr = std::move(new_union_iterator(res.value()));
                 }
-                
             }
             if (sort_column) {
                 entry.encode_schema = &schema;


### PR DESCRIPTION
Why I'm doing:
We will generate a `heap_merge_iterator` or a `mask_merge_iterator` for each rowset during the compaction of primary key table, it will load a chunk for each segment which maybe cost a lot of memory. If a rowset is non-overlapping, `union_iterator` is enough.

What I'm doing:
Use union_iterator to get data from non-overlapping rowset during the compaction of primary key table.

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [x] 3.1
  - [x] 3.0
  - [ ] 2.5
