### PR TITLE
[BugFix] Fix audit log state not correct bug when the connection is broken

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/common/util/LogUtil.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/util/LogUtil.java
@@ -21,6 +21,7 @@ import com.starrocks.qe.ConnectContext;
 import com.starrocks.qe.QueryDetail;
 import com.starrocks.qe.QueryDetailQueue;
 import com.starrocks.server.GlobalStateMgr;
+import com.starrocks.service.FrontendOptions;
 
 import java.util.Arrays;
 import java.util.List;
@@ -47,6 +48,7 @@ public class LogUtil {
                 .setAuthorizedUser(ctx.getCurrentUserIdentity() == null
                         ? "null" : ctx.getCurrentUserIdentity().toString())
                 .setClientIp(ctx.getMysqlChannel().getRemoteHostPortString())
+                .setFeIp(FrontendOptions.getLocalHostAddress())
                 .setDb(authPacket == null ? "null" : authPacket.getDb())
                 .setState(ctx.getState().toString())
                 .setErrorCode(ctx.getState().getErrorMessage());

--- a/fe/fe-core/src/main/java/com/starrocks/mysql/nio/AcceptListener.java
+++ b/fe/fe-core/src/main/java/com/starrocks/mysql/nio/AcceptListener.java
@@ -108,6 +108,7 @@ public class AcceptListener implements ChannelListener<AcceptingChannel<StreamCo
                         // do not need to print log for this kind of exception.
                         // just clean up the context;
                         context.cleanup();
+                        context.getState().setError(e.getMessage());
                     } catch (Throwable e) {
                         if (e instanceof Error) {
                             LOG.error("connect processor exception because ", e);
@@ -116,6 +117,7 @@ public class AcceptListener implements ChannelListener<AcceptingChannel<StreamCo
                             LOG.warn("connect processor exception because ", e);
                         }
                         context.cleanup();
+                        context.getState().setError(e.getMessage());
                     } finally {
                         LogUtil.logConnectionInfoToAuditLogAndQueryQueue(context,
                                 result == null ? null : result.getAuthPacket());


### PR DESCRIPTION
Why I'm doing:
If the connection is broken in the negotiate period, the state printed in the audit log is ok, which is not correct.

What I'm doing:
Set the state to error if connection is broken.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [x] 3.1
  - [x] 3.0
  - [ ] 2.5
