### PR TITLE
[Doc] Fix mv usage loop

### DIFF
--- a/docs/docusaurus/sidebars.json
+++ b/docs/docusaurus/sidebars.json
@@ -207,18 +207,7 @@
             "integrations/authenticate_to_gcs"
           ]
         },
-        {
-          "type": "category",
-          "label": "Data Lake",
-          "description": "Iceberg, Hive, Delta Lake, Hudi, etc.",
-          "link": {"type": "doc", "id": "integrations/data_lakes"},
-          "items": [
-             "data_source/catalog/hive_catalog",
-             "data_source/catalog/iceberg_catalog",
-             "data_source/catalog/hudi_catalog",
-             "data_source/catalog/deltalake_catalog"
-          ]
-        },
+        "integrations/data_lakes",
         {
           "type": "category",
           "label": "Streaming Data",
@@ -722,8 +711,8 @@
             "faq/Exporting_faq"
           ]
         },
-        "administration/privilege_faq",
-        "data_source/datalake_faq",
+        "faq/privilege",
+        "faq/datalake",
         "faq/Sql_faq",
         "faq/Dump_query",
         "faq/Others",
@@ -956,18 +945,7 @@
             "integrations/authenticate_to_gcs"
           ]
         },
-        {
-          "type": "category",
-          "label": "查询数据湖",
-          "description": "Iceberg、Hive、Delta Lake、Hudi 等",
-          "link": {"type": "doc", "id": "integrations/data_lakes"},
-          "items": [
-             "data_source/catalog/hive_catalog",
-             "data_source/catalog/iceberg_catalog",
-             "data_source/catalog/hudi_catalog",
-             "data_source/catalog/deltalake_catalog"
-          ]
-        },
+        "integrations/data_lakes",
         {
           "type": "category",
           "label": "实时导入",
@@ -1471,8 +1449,8 @@
             "faq/Exporting_faq"
           ]
         },
-        "administration/privilege_faq",
-        "data_source/datalake_faq",
+        "faq/privilege",
+        "faq/datalake",
         "faq/Sql_faq",
         "faq/Dump_query",
         "faq/Others",

--- a/docs/docusaurus/sidebars.json
+++ b/docs/docusaurus/sidebars.json
@@ -167,7 +167,11 @@
               "label": "Usage",
               "link": {"type": "doc", "id": "using_starrocks/usage/intro"},
               "items": [
-                "using_starrocks/usage/create"
+                "using_starrocks/usage/create",
+                "using_starrocks/usage/alter",
+                "using_starrocks/usage/drop",
+                "using_starrocks/usage/show",
+                "using_starrocks/troubleshooting_asynchronous_materialized_views"
               ]
             }
           ]
@@ -905,7 +909,11 @@
               "label": "Usage",
               "link": {"type": "doc", "id": "using_starrocks/usage/intro"},
               "items": [
-                "using_starrocks/usage/create"
+                "using_starrocks/usage/create",
+                "using_starrocks/usage/alter",
+                "using_starrocks/usage/drop",
+                "using_starrocks/usage/show",
+                "using_starrocks/troubleshooting_asynchronous_materialized_views"
               ]
             }
           ]

--- a/docs/docusaurus/sidebars.json
+++ b/docs/docusaurus/sidebars.json
@@ -165,14 +165,9 @@
             {
               "type": "category",
               "label": "Usage",
-              "link": {"type": "doc", "id": "cover_pages/mv_usage"},
-              "items": [ 
-                "sql-reference/sql-statements/data-definition/CREATE_MATERIALIZED_VIEW",
-                "sql-reference/sql-statements/data-definition/ALTER_MATERIALIZED_VIEW",
-                "sql-reference/sql-statements/data-definition/DROP_MATERIALIZED_VIEW",
-                "sql-reference/sql-statements/data-manipulation/SHOW_MATERIALIZED_VIEW",
-                "reference/information_schema/materialized_views",
-                "using_starrocks/troubleshooting_asynchronous_materialized_views"
+              "link": {"type": "doc", "id": "using_starrocks/usage/intro"},
+              "items": [
+                "using_starrocks/usage/create"
               ]
             }
           ]
@@ -919,14 +914,9 @@
             {
               "type": "category",
               "label": "Usage",
-              "link": {"type": "doc", "id": "cover_pages/mv_usage"},
-              "items": [ 
-                "sql-reference/sql-statements/data-definition/CREATE_MATERIALIZED_VIEW",
-                "sql-reference/sql-statements/data-definition/ALTER_MATERIALIZED_VIEW",
-                "sql-reference/sql-statements/data-definition/DROP_MATERIALIZED_VIEW",
-                "sql-reference/sql-statements/data-manipulation/SHOW_MATERIALIZED_VIEW",
-                "reference/information_schema/materialized_views",
-                "using_starrocks/troubleshooting_asynchronous_materialized_views"
+              "link": {"type": "doc", "id": "using_starrocks/usage/intro"},
+              "items": [
+                "using_starrocks/usage/create"
               ]
             }
           ]

--- a/docs/docusaurus/sidebars.json
+++ b/docs/docusaurus/sidebars.json
@@ -171,6 +171,7 @@
                 "using_starrocks/usage/alter",
                 "using_starrocks/usage/drop",
                 "using_starrocks/usage/show",
+                "using_starrocks/usage/information_schema-materialized_views",
                 "using_starrocks/troubleshooting_asynchronous_materialized_views"
               ]
             }
@@ -913,6 +914,7 @@
                 "using_starrocks/usage/alter",
                 "using_starrocks/usage/drop",
                 "using_starrocks/usage/show",
+                "using_starrocks/usage/information_schema-materialized_views",
                 "using_starrocks/troubleshooting_asynchronous_materialized_views"
               ]
             }

--- a/docs/en/faq/datalake.mdx
+++ b/docs/en/faq/datalake.mdx
@@ -1,0 +1,12 @@
+---
+displayed_sidebar: "English"
+sidebar_label: Datalake FAQ
+title: Datalake FAQ
+---
+<head>
+  <link rel="canonical" href="https://docs.starrocks.io/docs/data_source/datalake_faq/" />
+</head>
+
+import Content from '../data_source/datalake_faq.md';
+
+<Content />

--- a/docs/en/faq/privilege.mdx
+++ b/docs/en/faq/privilege.mdx
@@ -1,0 +1,12 @@
+---
+displayed_sidebar: "English"
+sidebar_label: Privilege FAQ
+title: Privilege FAQ
+---
+<head>
+  <link rel="canonical" href="https://docs.starrocks.io/docs/administration/privilege_faq/" />
+</head>
+
+import Content from '../administration/privilege_faq.md';
+
+<Content />

--- a/docs/en/integrations/data_lakes.mdx
+++ b/docs/en/integrations/data_lakes.mdx
@@ -47,8 +47,4 @@ Cache on the compute nodes is optional. If your compute nodes are spinning up an
 
 Try out a Docker based lakehouse. This [data lakehouse tutorial](../quick_start/iceberg.md) creates a data lake built with Iceberg and MinIO and connects StarRocks containers as the query engine. Load the provided dataset, or add your own.
 
----
-
-import DocCardList from '@theme/DocCardList';
-
-<DocCardList />
+More information is in the [Catalog docs](../data_source/catalog/catalog_intro.mdx).

--- a/docs/en/using_starrocks/usage/alter.mdx
+++ b/docs/en/using_starrocks/usage/alter.mdx
@@ -1,4 +1,5 @@
 ---
+displayed_sidebar: "English"
 sidebar_position: 1
 sidebar_label: ALTER
 title: ALTER MATERIALIZED VIEW

--- a/docs/en/using_starrocks/usage/alter.mdx
+++ b/docs/en/using_starrocks/usage/alter.mdx
@@ -1,0 +1,12 @@
+---
+sidebar_position: 1
+sidebar_label: ALTER
+title: ALTER MATERIALIZED VIEW
+---
+<head>
+  <link rel="canonical" href="https://docs.starrocks.io/sql-reference/sql-statements/data-definition/ALTER_MATERIALIZED_VIEW/" />
+</head>
+
+import Content from '../../sql-reference/sql-statements/data-definition/ALTER_MATERIALIZED_VIEW.md';
+
+<Content />

--- a/docs/en/using_starrocks/usage/create.mdx
+++ b/docs/en/using_starrocks/usage/create.mdx
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 1
+sidebar_position: 0
 sidebar_label: CREATE
 title: CREATE MATERIALIZED VIEW
 ---

--- a/docs/en/using_starrocks/usage/create.mdx
+++ b/docs/en/using_starrocks/usage/create.mdx
@@ -1,4 +1,5 @@
 ---
+displayed_sidebar: "English"
 sidebar_position: 0
 sidebar_label: CREATE
 title: CREATE MATERIALIZED VIEW

--- a/docs/en/using_starrocks/usage/create.mdx
+++ b/docs/en/using_starrocks/usage/create.mdx
@@ -1,0 +1,12 @@
+---
+sidebar_position: 1
+sidebar_label: CREATE
+title: CREATE MATERIALIZED VIEW
+---
+<head>
+  <link rel="canonical" href="https://docs.starrocks.io/sql-reference/sql-statements/data-definition/CREATE_MATERIALIZED_VIEW/" />
+</head>
+
+import Content from '../../sql-reference/sql-statements/data-definition/CREATE_MATERIALIZED_VIEW.md';
+
+<Content />

--- a/docs/en/using_starrocks/usage/drop.mdx
+++ b/docs/en/using_starrocks/usage/drop.mdx
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 1
+sidebar_position: 2
 sidebar_label: DROP
 title: DROP MATERIALIZED VIEW
 ---

--- a/docs/en/using_starrocks/usage/drop.mdx
+++ b/docs/en/using_starrocks/usage/drop.mdx
@@ -1,0 +1,12 @@
+---
+sidebar_position: 1
+sidebar_label: DROP
+title: DROP MATERIALIZED VIEW
+---
+<head>
+  <link rel="canonical" href="https://docs.starrocks.io/sql-reference/sql-statements/data-definition/DROP_MATERIALIZED_VIEW/" />
+</head>
+
+import Content from '../../sql-reference/sql-statements/data-definition/DROP_MATERIALIZED_VIEW.md';
+
+<Content />

--- a/docs/en/using_starrocks/usage/drop.mdx
+++ b/docs/en/using_starrocks/usage/drop.mdx
@@ -1,4 +1,5 @@
 ---
+displayed_sidebar: "English"
 sidebar_position: 2
 sidebar_label: DROP
 title: DROP MATERIALIZED VIEW

--- a/docs/en/using_starrocks/usage/information_schema-materialized_views.mdx
+++ b/docs/en/using_starrocks/usage/information_schema-materialized_views.mdx
@@ -1,0 +1,12 @@
+---
+displayed_sidebar: "English"
+sidebar_label: materialized_views
+title: materialized_views
+---
+<head>
+  <link rel="canonical" href="https://docs.starrocks.io/docs/reference/information_schema/materialized_views/" />
+</head>
+
+import Content from '../../reference/information_schema/materialized_views.md';
+
+<Content />

--- a/docs/en/using_starrocks/usage/information_schema-materialized_views.mdx
+++ b/docs/en/using_starrocks/usage/information_schema-materialized_views.mdx
@@ -1,5 +1,5 @@
 ---
-displayed_sidebar: "English"
+sidebar_position: 4
 sidebar_label: materialized_views
 title: materialized_views
 ---

--- a/docs/en/using_starrocks/usage/information_schema-materialized_views.mdx
+++ b/docs/en/using_starrocks/usage/information_schema-materialized_views.mdx
@@ -1,4 +1,5 @@
 ---
+displayed_sidebar: "English"
 sidebar_position: 4
 sidebar_label: materialized_views
 title: materialized_views

--- a/docs/en/using_starrocks/usage/intro.mdx
+++ b/docs/en/using_starrocks/usage/intro.mdx
@@ -2,7 +2,7 @@
 displayed_sidebar: "English"
 ---
 
-# 
+# Usage
 
 import DocCardList from '@theme/DocCardList';
 

--- a/docs/en/using_starrocks/usage/show.mdx
+++ b/docs/en/using_starrocks/usage/show.mdx
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 1
+sidebar_position: 3
 sidebar_label: SHOW
 title: SHOW MATERIALIZED VIEW
 ---

--- a/docs/en/using_starrocks/usage/show.mdx
+++ b/docs/en/using_starrocks/usage/show.mdx
@@ -1,4 +1,5 @@
 ---
+displayed_sidebar: "English"
 sidebar_position: 3
 sidebar_label: SHOW
 title: SHOW MATERIALIZED VIEW

--- a/docs/en/using_starrocks/usage/show.mdx
+++ b/docs/en/using_starrocks/usage/show.mdx
@@ -1,0 +1,12 @@
+---
+sidebar_position: 1
+sidebar_label: SHOW
+title: SHOW MATERIALIZED VIEW
+---
+<head>
+  <link rel="canonical" href="https://docs.starrocks.io/sql-reference/sql-statements/data-manipulation/SHOW_MATERIALIZED_VIEW/" />
+</head>
+
+import Content from '../../sql-reference/sql-statements/data-manipulation/SHOW_MATERIALIZED_VIEW.md';
+
+<Content />

--- a/docs/zh/faq/datalake.mdx
+++ b/docs/zh/faq/datalake.mdx
@@ -1,0 +1,12 @@
+---
+displayed_sidebar: "Chinese"
+sidebar_label: 数据湖相关 FAQ
+title: 数据湖相关 FAQ
+---
+<head>
+  <link rel="canonical" href="https://docs.starrocks.io/zh/docs/data_source/datalake_faq/" />
+</head>
+
+import Content from '../data_source/datalake_faq.md';
+
+<Content />

--- a/docs/zh/faq/privilege.mdx
+++ b/docs/zh/faq/privilege.mdx
@@ -1,0 +1,12 @@
+---
+displayed_sidebar: "Chinese"
+sidebar_label: 权限系统 FAQ
+title: 权限系统 FAQ
+---
+<head>
+  <link rel="canonical" href="https://docs.starrocks.io/zh/docs/administration/privilege_faq/" />
+</head>
+
+import Content from '../administration/privilege_faq.md';
+
+<Content />

--- a/docs/zh/integrations/data_lakes.mdx
+++ b/docs/zh/integrations/data_lakes.mdx
@@ -6,9 +6,3 @@ import DataLakeIntro from '../assets/commonMarkdown/datalakeIntro.md'
 # 数据湖分析
 
 <DataLakeIntro />
-
----
-
-import DocCardList from '@theme/DocCardList';
-
-<DocCardList />

--- a/docs/zh/using_starrocks/usage/alter.mdx
+++ b/docs/zh/using_starrocks/usage/alter.mdx
@@ -1,4 +1,5 @@
 ---
+displayed_sidebar: "Chinese"
 sidebar_position: 1
 sidebar_label: ALTER
 title: ALTER MATERIALIZED VIEW

--- a/docs/zh/using_starrocks/usage/alter.mdx
+++ b/docs/zh/using_starrocks/usage/alter.mdx
@@ -1,0 +1,12 @@
+---
+sidebar_position: 1
+sidebar_label: ALTER
+title: ALTER MATERIALIZED VIEW
+---
+<head>
+  <link rel="canonical" href="https://docs.starrocks.io/zh/sql-reference/sql-statements/data-definition/ALTER_MATERIALIZED_VIEW/" />
+</head>
+
+import Content from '../../sql-reference/sql-statements/data-definition/ALTER_MATERIALIZED_VIEW.md';
+
+<Content />

--- a/docs/zh/using_starrocks/usage/create.mdx
+++ b/docs/zh/using_starrocks/usage/create.mdx
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 1
+sidebar_position: 0
 sidebar_label: CREATE
 title: CREATE MATERIALIZED VIEW
 ---

--- a/docs/zh/using_starrocks/usage/create.mdx
+++ b/docs/zh/using_starrocks/usage/create.mdx
@@ -1,4 +1,5 @@
 ---
+displayed_sidebar: "Chinese"
 sidebar_position: 0
 sidebar_label: CREATE
 title: CREATE MATERIALIZED VIEW

--- a/docs/zh/using_starrocks/usage/create.mdx
+++ b/docs/zh/using_starrocks/usage/create.mdx
@@ -1,0 +1,12 @@
+---
+sidebar_position: 1
+sidebar_label: CREATE
+title: CREATE MATERIALIZED VIEW
+---
+<head>
+  <link rel="canonical" href="https://docs.starrocks.io/zh/sql-reference/sql-statements/data-definition/CREATE_MATERIALIZED_VIEW/" />
+</head>
+
+import Content from '../../sql-reference/sql-statements/data-definition/CREATE_MATERIALIZED_VIEW.md';
+
+<Content />

--- a/docs/zh/using_starrocks/usage/drop.mdx
+++ b/docs/zh/using_starrocks/usage/drop.mdx
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 1
+sidebar_position: 2
 sidebar_label: DROP
 title: DROP MATERIALIZED VIEW
 ---

--- a/docs/zh/using_starrocks/usage/drop.mdx
+++ b/docs/zh/using_starrocks/usage/drop.mdx
@@ -1,4 +1,5 @@
 ---
+displayed_sidebar: "Chinese"
 sidebar_position: 2
 sidebar_label: DROP
 title: DROP MATERIALIZED VIEW

--- a/docs/zh/using_starrocks/usage/drop.mdx
+++ b/docs/zh/using_starrocks/usage/drop.mdx
@@ -1,0 +1,12 @@
+---
+sidebar_position: 1
+sidebar_label: DROP
+title: DROP MATERIALIZED VIEW
+---
+<head>
+  <link rel="canonical" href="https://docs.starrocks.io/zh/sql-reference/sql-statements/data-definition/DROP_MATERIALIZED_VIEW/" />
+</head>
+
+import Content from '../../sql-reference/sql-statements/data-definition/DROP_MATERIALIZED_VIEW.md';
+
+<Content />

--- a/docs/zh/using_starrocks/usage/information_schema-materialized_views.mdx
+++ b/docs/zh/using_starrocks/usage/information_schema-materialized_views.mdx
@@ -1,4 +1,5 @@
 ---
+displayed_sidebar: "Chinese"
 sidebar_position: 4
 sidebar_label: materialized_views
 title: materialized_views

--- a/docs/zh/using_starrocks/usage/information_schema-materialized_views.mdx
+++ b/docs/zh/using_starrocks/usage/information_schema-materialized_views.mdx
@@ -1,0 +1,12 @@
+---
+sidebar_position: 4
+sidebar_label: materialized_views
+title: materialized_views
+---
+<head>
+  <link rel="canonical" href="https://docs.starrocks.io/zh/docs/reference/information_schema/materialized_views/" />
+</head>
+
+import Content from '../../reference/information_schema/materialized_views.md';
+
+<Content />

--- a/docs/zh/using_starrocks/usage/intro.mdx
+++ b/docs/zh/using_starrocks/usage/intro.mdx
@@ -2,7 +2,7 @@
 displayed_sidebar: "Chinese"
 ---
 
-# 
+# Usage
 
 import DocCardList from '@theme/DocCardList';
 

--- a/docs/zh/using_starrocks/usage/show.mdx
+++ b/docs/zh/using_starrocks/usage/show.mdx
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 1
+sidebar_position: 3
 sidebar_label: SHOW
 title: SHOW MATERIALIZED VIEW
 ---

--- a/docs/zh/using_starrocks/usage/show.mdx
+++ b/docs/zh/using_starrocks/usage/show.mdx
@@ -1,0 +1,12 @@
+---
+sidebar_position: 1
+sidebar_label: SHOW
+title: SHOW MATERIALIZED VIEW
+---
+<head>
+  <link rel="canonical" href="https://docs.starrocks.io/zh/sql-reference/sql-statements/data-manipulation/SHOW_MATERIALIZED_VIEW/" />
+</head>
+
+import Content from '../../sql-reference/sql-statements/data-manipulation/SHOW_MATERIALIZED_VIEW.md';
+
+<Content />

--- a/docs/zh/using_starrocks/usage/show.mdx
+++ b/docs/zh/using_starrocks/usage/show.mdx
@@ -1,4 +1,5 @@
 ---
+displayed_sidebar: "Chinese"
 sidebar_position: 3
 sidebar_label: SHOW
 title: SHOW MATERIALIZED VIEW


### PR DESCRIPTION

Reviewers: Please add the Chinese versions of the changes I made here. This will probably backport to 3.2. I doubt it will backport cleanly to 2.5, but please try after adding the Chinese versions of these files and merging.

The nav in the docs is sending readers all over the place. For example, when reading the FAQs, all of a sudden the reader is sent to another section of the docs. Same thing for MV use, all of a sudden the reader is deep in the SQL reference.

We should not have the same page in multiple spots in the sidebars file. If a page really needs to be in two places, then use this code:

```js
---
displayed_sidebar: "English"
sidebar_label: Datalake FAQ
title: Datalake FAQ
---
<head>
  <link rel="canonical" href="https://docs.starrocks.io/docs/data_source/datalake_faq/" />
</head>

import Content from '../data_source/datalake_faq.md';

<Content />
```

The above:
- creates a new page
- sets the canonical link for Google search to the original page (having the same content in two places reduces SEO)
- imports the original markdown content
- renders the content

In addition to the nav problems this prevents us from generating PDF docs.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [x] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [x] 2.5