### PR TITLE
[DO NOT MERGE] [feature][Issue 39849] add KEEP_SYMBOL to reserve symbols in starrocks_be

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -43,6 +43,10 @@ if [ -z $BUILD_TYPE ]; then
     export BUILD_TYPE=Release
 fi
 
+if [ -z $KEEP_SYMBOL ]; then
+    export KEEP_SYMBOL=false
+fi
+
 cd $STARROCKS_HOME
 if [ -z $STARROCKS_VERSION ]; then
     tag_name=$(git describe --tags --exact-match 2>/dev/null)
@@ -260,6 +264,7 @@ fi
 echo "Get params:
     BUILD_BE            -- $BUILD_BE
     BE_CMAKE_TYPE       -- $BUILD_TYPE
+    KEEP_SYMBOL         -- $KEEP_SYMBOL
     BUILD_FE            -- $BUILD_FE
     BUILD_SPARK_DPP     -- $BUILD_SPARK_DPP
     BUILD_HIVE_UDF      -- $BUILD_HIVE_UDF
@@ -490,7 +495,10 @@ if [ ${BUILD_BE} -eq 1 ]; then
     cp -r -p ${STARROCKS_THIRDPARTY}/installed/jemalloc/bin/jeprof ${STARROCKS_OUTPUT}/be/bin
     # format $BUILD_TYPE to lower case
     ibuildtype=`echo ${BUILD_TYPE} | tr 'A-Z' 'a-z'`
-    if [ "${ibuildtype}" == "release" ] ; then
+    # format KEEP_SYMBOL to lower case
+    ikeepsymbol=`echo ${KEEP_SYMBOL} | tr 'A-Z' 'a-z'`
+    # only when BUILD_TYPE=release AND KEEP_SYMBOL=false, the binary is stripped
+    if [ "${ibuildtype}" == "release" ] && [ "${ikeepsymbol}" == "false" ] ; then
         pushd ${STARROCKS_OUTPUT}/be/lib/ &>/dev/null
         BE_BIN=starrocks_be
         BE_BIN_DEBUGINFO=starrocks_be.debuginfo


### PR DESCRIPTION
> **Hold it temporally to verify with latest Datadog profile library.**

Why I'm doing:

Datadog profiling needs symbols in `starrocks_be` binary, see https://docs.datadoghq.com/profiler/profiler_troubleshooting/ddprof/#profiles-are-empty-or-sparse for more context.

What I'm doing:

Add an argument in  `build.sh`, with default value `false`. When it's set to `true`, symbols are not stripped even with `BUILD_TYPE=release`.

Similarly, change in `artifact.Dockerfile` would come seperately

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [x] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [x] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.2
  - [ ] 3.1
  - [x] 3.1-cs
  - [ ] 3.0
  - [ ] 2.5
