### PR TITLE
[BugFix] fix table property replay incorrectly

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/TableProperty.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/TableProperty.java
@@ -300,6 +300,7 @@ public class TableProperty implements Writable, GsonPostProcessable {
         return this;
     }
 
+    // TODO: refactor the postProcessing code into listener-based instead of procedure-oriented
     public TableProperty buildMvProperties() {
         buildPartitionTTL();
         buildPartitionRefreshNumber();
@@ -308,6 +309,7 @@ public class TableProperty implements Writable, GsonPostProcessable {
         buildResourceGroup();
         buildConstraint();
         buildMvSortKeys();
+        buildQueryRewrite();
         return this;
     }
 
@@ -836,19 +838,14 @@ public class TableProperty implements Writable, GsonPostProcessable {
         buildPrimaryIndexCacheExpireSec();
         buildCompressionType();
         buildWriteQuorum();
-        buildPartitionTTL();
         buildPartitionLiveNumber();
-        buildAutoRefreshPartitionsLimit();
-        buildPartitionRefreshNumber();
-        buildExcludedTriggerTables();
         buildReplicatedStorage();
-        buildQueryRewrite();
         buildBucketSize();
         buildBinlogConfig();
         buildBinlogAvailableVersion();
-        buildConstraint();
         buildDataCachePartitionDuration();
         buildUseFastSchemaEvolution();
         buildStorageType();
+        buildMvProperties();
     }
 }


### PR DESCRIPTION
Why I'm doing:
- query_rewrite property doesn't get replayed on the follower node

What I'm doing:

TODO:
- Refactor the TableProperty replay code to make it more extensible and less buggy


Fixes #40055

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [x] 3.1
  - [x] 3.0
  - [x] 2.5
