### PR TITLE
[Enhancement][Cherry-Pick][Branch-3.1] Keeping the array/map's behavior is the same as Trino (backport #39965)

### DIFF
--- a/be/src/exprs/array_element_expr.cpp
+++ b/be/src/exprs/array_element_expr.cpp
@@ -14,6 +14,8 @@
 
 #include "exprs/array_element_expr.h"
 
+#include <gutil/strings/substitute.h>
+
 #include "column/array_column.h"
 #include "column/column_helper.h"
 #include "column/fixed_length_column.h"
@@ -24,7 +26,9 @@ namespace starrocks {
 
 class ArrayElementExpr final : public Expr {
 public:
-    explicit ArrayElementExpr(const TExprNode& node) : Expr(node) {}
+    explicit ArrayElementExpr(const TExprNode& node, const bool check_is_out_of_bounds) : Expr(node) {
+        _check_is_out_of_bounds = check_is_out_of_bounds;
+    }
 
     ArrayElementExpr(const ArrayElementExpr&) = default;
     ArrayElementExpr(ArrayElementExpr&&) = default;
@@ -47,6 +51,24 @@ public:
 
         const int32_t* subscripts = down_cast<Int32Column*>(get_data_column(arg1.get()))->get_data().data();
         const uint32_t* offsets = array_column->offsets_column()->get_data().data();
+
+        if (_check_is_out_of_bounds) {
+            uint32_t prev = offsets[0];
+            for (size_t i = 1; i <= num_rows; i++) {
+                uint32_t curr = offsets[i];
+                DCHECK_GE(curr, prev);
+                auto subscript = (uint32_t)subscripts[i - 1];
+                if (subscript == 0) {
+                    return Status::InvalidArgument("Array subscript start at 1");
+                }
+                if (subscript > (curr - prev)) {
+                    return Status::InvalidArgument(
+                            strings::Substitute("Array subscript must be less than or equal to array length: $0 > $1",
+                                                subscript, curr - prev));
+                }
+                prev = curr;
+            }
+        }
 
         std::vector<uint8_t> null_flags;
         raw::make_room(&null_flags, num_rows);
@@ -116,11 +138,16 @@ public:
 
 private:
     Column* get_data_column(Column* column) { return ColumnHelper::get_data_column(column); }
+    bool _check_is_out_of_bounds = false;
 };
 
 Expr* ArrayElementExprFactory::from_thrift(const TExprNode& node) {
     DCHECK_EQ(TExprNodeType::ARRAY_ELEMENT_EXPR, node.node_type);
-    return new ArrayElementExpr(node);
+    bool check_is_out_of_bounds = false;
+    if (node.__isset.check_is_out_of_bounds) {
+        check_is_out_of_bounds = node.check_is_out_of_bounds;
+    }
+    return new ArrayElementExpr(node, check_is_out_of_bounds);
 }
 
 } // namespace starrocks

--- a/fe/fe-core/src/main/java/com/starrocks/analysis/CollectionElementExpr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/analysis/CollectionElementExpr.java
@@ -43,26 +43,32 @@ import com.starrocks.thrift.TExprNodeType;
 
 public class CollectionElementExpr extends Expr {
 
-    public CollectionElementExpr(Expr expr, Expr subscript) {
+    // For trino and presto, access out of bound in map/array, it will throw error msg
+    private final boolean checkIsOutOfBounds;
+
+    public CollectionElementExpr(Expr expr, Expr subscript, boolean checkIsOutOfBounds) {
         super(NodePosition.ZERO);
         this.children.add(expr);
         this.children.add(subscript);
+        this.checkIsOutOfBounds = checkIsOutOfBounds;
     }
 
-    public CollectionElementExpr(Type type, Expr expr, Expr subscript) {
-        this(type, expr, subscript, NodePosition.ZERO);
+    public CollectionElementExpr(Type type, Expr expr, Expr subscript, boolean checkIsOutOfBounds) {
+        this(type, expr, subscript, checkIsOutOfBounds, NodePosition.ZERO);
     }
 
 
-    public CollectionElementExpr(Type type, Expr expr, Expr subscript, NodePosition pos) {
+    public CollectionElementExpr(Type type, Expr expr, Expr subscript, boolean checkIsOutOfBounds, NodePosition pos) {
         super(pos);
         this.type = type;
         this.children.add(expr);
         this.children.add(subscript);
+        this.checkIsOutOfBounds = checkIsOutOfBounds;
     }
 
     public CollectionElementExpr(CollectionElementExpr other) {
         super(other);
+        this.checkIsOutOfBounds = other.checkIsOutOfBounds;
     }
 
     @Override
@@ -83,6 +89,7 @@ public class CollectionElementExpr extends Expr {
         } else {
             msg.setNode_type(TExprNodeType.MAP_ELEMENT_EXPR);
         }
+        msg.setCheck_is_out_of_bounds(checkIsOutOfBounds);
     }
 
     @Override
@@ -102,5 +109,9 @@ public class CollectionElementExpr extends Expr {
             ret &= child.isSelfMonotonic();
         }
         return ret;
+    }
+
+    public boolean isCheckIsOutOfBounds() {
+        return checkIsOutOfBounds;
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/connector/parser/trino/AstBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/parser/trino/AstBuilder.java
@@ -669,7 +669,7 @@ public class AstBuilder extends AstVisitor<ParseNode, ParseTreeContext> {
     protected ParseNode visitSubscriptExpression(SubscriptExpression node, ParseTreeContext context) {
         Expr value = (Expr) visit(node.getBase(), context);
         Expr index = (Expr) visit(node.getIndex(), context);
-        return new CollectionElementExpr(value, index);
+        return new CollectionElementExpr(value, index, true);
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/connector/parser/trino/ComplexFunctionCallTransformer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/parser/trino/ComplexFunctionCallTransformer.java
@@ -83,7 +83,7 @@ public class ComplexFunctionCallTransformer {
             if (args.length != 2) {
                 throw new SemanticException("element_at function must have 2 arguments");
             }
-            return new CollectionElementExpr(args[0], args[1]);
+            return new CollectionElementExpr(args[0], args[1], false);
         } else if (functionName.equalsIgnoreCase("regexp_extract")) {
             // regexp_extract(string, pattern) -> regexp_extract(str, pattern, 0)
             FunctionCallExpr regexpExtractFunc = new FunctionCallExpr("regexp_extract",

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/scalar/CollectionElementOperator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/scalar/CollectionElementOperator.java
@@ -27,11 +27,18 @@ import static com.starrocks.sql.optimizer.operator.OperatorType.COLLECTION_ELEME
 
 public class CollectionElementOperator extends ScalarOperator {
     protected List<ScalarOperator> arguments = Lists.newArrayList();
+    private boolean isCheckOutOfBounds = false;
 
-    public CollectionElementOperator(Type type, ScalarOperator arrayOperator, ScalarOperator subscriptOperator) {
+    public CollectionElementOperator(Type type, ScalarOperator arrayOperator, ScalarOperator subscriptOperator,
+                                     boolean isCheckOutOfBounds) {
         super(COLLECTION_ELEMENT, type);
         this.arguments.add(arrayOperator);
         this.arguments.add(subscriptOperator);
+        this.isCheckOutOfBounds = isCheckOutOfBounds;
+    }
+
+    public boolean isCheckOutOfBounds() {
+        return isCheckOutOfBounds;
     }
 
     @Override
@@ -75,6 +82,7 @@ public class CollectionElementOperator extends ScalarOperator {
         List<ScalarOperator> newArguments = Lists.newArrayList();
         this.arguments.forEach(p -> newArguments.add(p.clone()));
         operator.arguments = newArguments;
+        operator.isCheckOutOfBounds = isCheckOutOfBounds;
         return operator;
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/BaseScalarOperatorShuttle.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/BaseScalarOperatorShuttle.java
@@ -61,8 +61,11 @@ public class BaseScalarOperatorShuttle extends ScalarOperatorVisitor<ScalarOpera
                 .put(ConstantOperator.class, (op, childOps) -> op)
                 .put(ColumnRefOperator.class, (op, childOps) -> op)
                 .put(ArrayOperator.class, (op, childOps) -> new ArrayOperator(op.getType(), op.isNullable(), childOps))
-                .put(CollectionElementOperator.class, (op, childOps) -> new CollectionElementOperator(op.getType(),
-                        childOps.get(0), childOps.get(1)))
+                .put(CollectionElementOperator.class, (op, childOps) -> {
+                    CollectionElementOperator collectionElementOperator = (CollectionElementOperator) op;
+                    return new CollectionElementOperator(op.getType(),
+                            childOps.get(0), childOps.get(1), collectionElementOperator.isCheckOutOfBounds());
+                })
                 .put(ArraySliceOperator.class, (op, childOps) -> new ArraySliceOperator(op.getType(), childOps))
                 .put(CallOperator.class, (op, childOps) -> {
                     CallOperator call = (CallOperator) op;

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/ScalarOperatorsReuse.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/ScalarOperatorsReuse.java
@@ -146,7 +146,8 @@ public class ScalarOperatorsReuse {
         public ScalarOperator visitCollectionElement(CollectionElementOperator elemOp, Void context) {
             ScalarOperator operator = new CollectionElementOperator(elemOp.getType(),
                     elemOp.getChild(0).accept(this, null),
-                    elemOp.getChild(1).accept(this, null));
+                    elemOp.getChild(1).accept(this, null),
+                    elemOp.isCheckOutOfBounds());
             return tryRewrite(operator);
         }
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/transformer/SqlToScalarOperatorTranslator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/transformer/SqlToScalarOperatorTranslator.java
@@ -347,7 +347,8 @@ public final class SqlToScalarOperatorTranslator {
             Preconditions.checkState(node.getChildren().size() == 2);
             ScalarOperator collectionOperator = visit(node.getChild(0), context.clone(node));
             ScalarOperator subscriptOperator = visit(node.getChild(1), context.clone(node));
-            return new CollectionElementOperator(node.getType(), collectionOperator, subscriptOperator);
+            return new CollectionElementOperator(node.getType(), collectionOperator, subscriptOperator,
+                    node.isCheckIsOutOfBounds());
         }
 
         @Override

--- a/fe/fe-core/src/main/java/com/starrocks/sql/parser/AstBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/parser/AstBuilder.java
@@ -5317,7 +5317,7 @@ public class AstBuilder extends StarRocksBaseVisitor<ParseNode> {
             if (params.size() != 2) {
                 throw new ParsingException(PARSER_ERROR_MSG.wrongNumOfArgs(functionName), pos);
             }
-            return new CollectionElementExpr(params.get(0), params.get(1));
+            return new CollectionElementExpr(params.get(0), params.get(1), false);
         }
 
         if (functionName.equals(FunctionSet.ISNULL)) {
@@ -5850,7 +5850,7 @@ public class AstBuilder extends StarRocksBaseVisitor<ParseNode> {
     public ParseNode visitCollectionSubscript(StarRocksParser.CollectionSubscriptContext context) {
         Expr value = (Expr) visit(context.value);
         Expr index = (Expr) visit(context.index);
-        return new CollectionElementExpr(value, index);
+        return new CollectionElementExpr(value, index, false);
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/sql/plan/ScalarOperatorToExpr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/plan/ScalarOperatorToExpr.java
@@ -193,7 +193,7 @@ public class ScalarOperatorToExpr {
         public Expr visitCollectionElement(CollectionElementOperator node, FormatterContext context) {
             CollectionElementExpr expr =
                     new CollectionElementExpr(node.getType(), buildExpr.build(node.getChild(0), context),
-                            buildExpr.build(node.getChild(1), context));
+                            buildExpr.build(node.getChild(1), context), node.isCheckOutOfBounds());
             hackTypeNull(expr);
             return expr;
         }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/ExpressionAnalyzerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/ExpressionAnalyzerTest.java
@@ -55,7 +55,7 @@ public class ExpressionAnalyzerTest extends PlanTestBase {
 
         IntLiteral sub = new IntLiteral(10);
 
-        CollectionElementExpr collectionElementExpr = new CollectionElementExpr(slot, sub);
+        CollectionElementExpr collectionElementExpr = new CollectionElementExpr(slot, sub, false);
         try {
             visitor.visitCollectionElementExpr(collectionElementExpr,
                     new Scope(RelationId.anonymous(), new RelationFields()));
@@ -64,7 +64,7 @@ public class ExpressionAnalyzerTest extends PlanTestBase {
         }
 
         StringLiteral subCast = new StringLiteral("10");
-        CollectionElementExpr collectionElementExpr1 = new CollectionElementExpr(slot, subCast);
+        CollectionElementExpr collectionElementExpr1 = new CollectionElementExpr(slot, subCast, false);
         try {
             visitor.visitCollectionElementExpr(collectionElementExpr1,
                     new Scope(RelationId.anonymous(), new RelationFields()));
@@ -73,7 +73,7 @@ public class ExpressionAnalyzerTest extends PlanTestBase {
         }
 
         StringLiteral subNoCast = new StringLiteral("aaa");
-        CollectionElementExpr collectionElementExpr2 = new CollectionElementExpr(slot, subNoCast);
+        CollectionElementExpr collectionElementExpr2 = new CollectionElementExpr(slot, subNoCast, false);
         Assert.assertThrows(SemanticException.class,
                 () -> visitor.visitCollectionElementExpr(collectionElementExpr2,
                         new Scope(RelationId.anonymous(), new RelationFields())));
@@ -83,7 +83,7 @@ public class ExpressionAnalyzerTest extends PlanTestBase {
         mapType = new MapType(keyTypeChar, valueTypeInt);
         slot.setType(mapType);
         StringLiteral subString = new StringLiteral("aaa");
-        CollectionElementExpr collectionElementExpr3 = new CollectionElementExpr(slot, subString);
+        CollectionElementExpr collectionElementExpr3 = new CollectionElementExpr(slot, subString, false);
         try {
             visitor.visitCollectionElementExpr(collectionElementExpr3,
                     new Scope(RelationId.anonymous(), new RelationFields()));
@@ -105,7 +105,7 @@ public class ExpressionAnalyzerTest extends PlanTestBase {
 
         IntLiteral sub = new IntLiteral(10);
 
-        CollectionElementExpr collectionElementExpr = new CollectionElementExpr(slot, sub);
+        CollectionElementExpr collectionElementExpr = new CollectionElementExpr(slot, sub, false);
         try {
             visitor.visitCollectionElementExpr(collectionElementExpr,
                     new Scope(RelationId.anonymous(), new RelationFields()));
@@ -114,13 +114,13 @@ public class ExpressionAnalyzerTest extends PlanTestBase {
         }
 
         StringLiteral subCast = new StringLiteral("10");
-        CollectionElementExpr collectionElementExpr1 = new CollectionElementExpr(slot, subCast);
+        CollectionElementExpr collectionElementExpr1 = new CollectionElementExpr(slot, subCast, false);
         Assert.assertThrows(SemanticException.class,
                 () -> visitor.visitCollectionElementExpr(collectionElementExpr1,
                         new Scope(RelationId.anonymous(), new RelationFields())));
 
         StringLiteral subNoCast = new StringLiteral("aaa");
-        CollectionElementExpr collectionElementExpr2 = new CollectionElementExpr(slot, subNoCast);
+        CollectionElementExpr collectionElementExpr2 = new CollectionElementExpr(slot, subNoCast, false);
         Assert.assertThrows(SemanticException.class,
                 () -> visitor.visitCollectionElementExpr(collectionElementExpr2,
                         new Scope(RelationId.anonymous(), new RelationFields())));
@@ -137,7 +137,7 @@ public class ExpressionAnalyzerTest extends PlanTestBase {
 
         IntLiteral sub = new IntLiteral(10);
 
-        CollectionElementExpr collectionElementExpr = new CollectionElementExpr(slot, sub);
+        CollectionElementExpr collectionElementExpr = new CollectionElementExpr(slot, sub, false);
         Assert.assertThrows(SemanticException.class,
                 () -> visitor.visitCollectionElementExpr(collectionElementExpr,
                         new Scope(RelationId.anonymous(), new RelationFields())));

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rewrite/BaseScalarOperatorShuttleTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rewrite/BaseScalarOperatorShuttleTest.java
@@ -84,7 +84,8 @@ class BaseScalarOperatorShuttleTest {
     @Test
     void visitCollectionElement() {
         ArrayOperator arrayOperator = new ArrayOperator(ARRAY_TINYINT, true, Lists.newArrayList(ConstantOperator.createInt(3)));
-        CollectionElementOperator operator = new CollectionElementOperator(STRING, arrayOperator, ConstantOperator.createInt(0));
+        CollectionElementOperator operator =
+                new CollectionElementOperator(STRING, arrayOperator, ConstantOperator.createInt(0), false);
         {
             ScalarOperator newOperator = shuttle.visitCollectionElement(operator, null);
             assertEquals(operator, newOperator);

--- a/gensrc/thrift/Exprs.thrift
+++ b/gensrc/thrift/Exprs.thrift
@@ -230,6 +230,9 @@ struct TExprNode {
   30: optional list<string> used_subfield_names;
   31: optional TBinaryLiteral binary_literal;
 
+  // used for CollectionElementAt
+  35: optional bool check_is_out_of_bounds
+
   // For vector query engine
   50: optional bool use_vectorized
   51: optional bool has_nullable_child

--- a/test/sql/test_trino_dialect/R/test_trino_dialect
+++ b/test/sql/test_trino_dialect/R/test_trino_dialect
@@ -1,0 +1,57 @@
+-- name: testTrinoDialect
+CREATE TABLE map_array_tbl
+    (c1 int,
+    c2 map<varchar(8), int>,
+    c3 array<int>)
+    PRIMARY KEY(c1)
+    DISTRIBUTED BY HASH(c1)
+    BUCKETS 1
+    PROPERTIES ("replication_num" = "1");
+-- result:
+-- !result
+insert into map_array_tbl values
+(1, map{"key1":1}, [1]),
+(2, map{"key1":5, "key2":6}, [1, 2]);
+-- result:
+-- !result
+select c2['key1'], c3[1] from map_array_tbl;
+-- result:
+1	1
+5	1
+-- !result
+select c2['not-existed'] from map_array_tbl;
+-- result:
+None
+None
+-- !result
+select c3[100] from map_array_tbl;
+-- result:
+None
+None
+-- !result
+select element_at(c2, 'not-existed'), element_at(c3, 100) from map_array_tbl;
+-- result:
+None	None
+None	None
+-- !result
+set sql_dialect='trino';
+-- result:
+-- !result
+select c2['key1'], c3[1] from map_array_tbl;
+-- result:
+1	1
+5	1
+-- !result
+select c2['not-existed'] from map_array_tbl;
+-- result:
+E: (1064, "Key not present in map: 'not-existed'")
+-- !result
+select c3[100] from map_array_tbl;
+-- result:
+E: (1064, 'Array subscript must be less than or equal to array length: 100 > 1')
+-- !result
+select element_at(c2, 'not-existed'), element_at(c3, 100) from map_array_tbl;
+-- result:
+None	None
+None	None
+-- !result

--- a/test/sql/test_trino_dialect/T/test_trino_dialect
+++ b/test/sql/test_trino_dialect/T/test_trino_dialect
@@ -1,0 +1,24 @@
+-- name: testTrinoDialect
+CREATE TABLE map_array_tbl
+    (c1 int,
+    c2 map<varchar(8), int>,
+    c3 array<int>)
+    PRIMARY KEY(c1)
+    DISTRIBUTED BY HASH(c1)
+    BUCKETS 1
+    PROPERTIES ("replication_num" = "1");
+
+insert into map_array_tbl values
+(1, map{"key1":1}, [1]),
+(2, map{"key1":5, "key2":6}, [1, 2]);
+
+select c2['key1'], c3[1] from map_array_tbl;
+select c2['not-existed'] from map_array_tbl;
+select c3[100] from map_array_tbl;
+select element_at(c2, 'not-existed'), element_at(c3, 100) from map_array_tbl;
+
+set sql_dialect='trino';
+select c2['key1'], c3[1] from map_array_tbl;
+select c2['not-existed'] from map_array_tbl;
+select c3[100] from map_array_tbl;
+select element_at(c2, 'not-existed'), element_at(c3, 100) from map_array_tbl;


### PR DESCRIPTION
cp from #39965

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [x] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5

