### PR TITLE
[Enhancement] support common expression for dictionary_get (#40074)

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/ScalarOperatorsReuse.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/ScalarOperatorsReuse.java
@@ -32,6 +32,7 @@ import com.starrocks.sql.optimizer.operator.scalar.CollectionElementOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ColumnRefOperator;
 import com.starrocks.sql.optimizer.operator.scalar.CompoundPredicateOperator;
 import com.starrocks.sql.optimizer.operator.scalar.DictMappingOperator;
+import com.starrocks.sql.optimizer.operator.scalar.DictionaryGetOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ExistsPredicateOperator;
 import com.starrocks.sql.optimizer.operator.scalar.InPredicateOperator;
 import com.starrocks.sql.optimizer.operator.scalar.IsNullPredicateOperator;
@@ -39,6 +40,7 @@ import com.starrocks.sql.optimizer.operator.scalar.LambdaFunctionOperator;
 import com.starrocks.sql.optimizer.operator.scalar.LikePredicateOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ScalarOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ScalarOperatorVisitor;
+import com.starrocks.sql.optimizer.operator.scalar.SubfieldOperator;
 import com.starrocks.sql.optimizer.rewrite.scalar.NormalizePredicateRule;
 import com.starrocks.sql.optimizer.rewrite.scalar.ScalarOperatorRewriteRule;
 
@@ -237,6 +239,27 @@ public class ScalarOperatorsReuse {
             ScalarOperator operator = new LikePredicateOperator(predicate.getLikeType(),
                     predicate.getChildren().stream().map(argument -> argument.accept(this, null))
                             .toArray(ScalarOperator[]::new));
+            return tryRewrite(operator);
+        }
+
+        @Override
+        public ScalarOperator visitSubfield(SubfieldOperator predicate, Void context) {
+            // only rewrite subfield operator if and only if child is DictionaryGetOperator
+            if (predicate.getChild(0) instanceof DictionaryGetOperator) {
+                ScalarOperator operator = new SubfieldOperator(predicate.getChild(0).accept(this, null),
+                                predicate.getType(), predicate.getFieldNames(), predicate.getCopyFlag());
+                return tryRewrite(operator);
+            }
+            return predicate;
+        }
+
+        @Override
+        public ScalarOperator visitDictionaryGetOperator(DictionaryGetOperator predicate, Void context) {
+            ScalarOperator operator = new DictionaryGetOperator(
+                    predicate.getChildren().stream().map(
+                        argument -> argument.accept(this, null)).collect(Collectors.toList()),
+                            predicate.getType(), predicate.getDictionaryId(),
+                                predicate.getDictionaryTxnId(), predicate.getKeySize());
             return tryRewrite(operator);
         }
 

--- a/test/sql/test_dictionary/R/test_dictionary
+++ b/test/sql/test_dictionary/R/test_dictionary
@@ -1135,3 +1135,48 @@ DROP TABLE t_dictionary_generated_column_create_table_1;
 DROP TABLE t_dictionary_generated_column_create_table_2;
 -- result:
 -- !result
+-- name: test_dictionary_common_expression
+CREATE TABLE `t_dictionary_common_expression` (
+  `id1` BIGINT NOT NULL COMMENT "",
+  `id2` BIGINT NOT NULL COMMENT "",
+  `id3` BIGINT NOT NULL COMMENT "",
+  `id4` BIGINT NOT NULL COMMENT ""
+) ENGINE=OLAP
+PRIMARY KEY(`id1`)
+DISTRIBUTED BY HASH(`id1`) BUCKETS 1 
+PROPERTIES (
+"replication_num" = "1",
+"in_memory" = "false",
+"enable_persistent_index" = "false",
+"replicated_storage" = "true",
+"compression" = "LZ4"
+);
+-- result:
+-- !result
+INSERT INTO t_dictionary_common_expression VALUES (1,2,3,4);
+-- result:
+-- !result
+[UC]DROP DICTIONARY test_dictionary_common_expression;
+-- result:
+-- !result
+CREATE DICTIONARY test_dictionary_common_expression USING t_dictionary_common_expression (id1 KEY, id2 VALUE, id3 VALUE, id4 VALUE);
+-- result:
+-- !result
+function: wait_refresh_dictionary_finish("test_dictionary_common_expression", "FINISHED")
+-- result:
+None
+-- !result
+explain SELECT dictionary_get("test_dictionary_common_expression", id1)[1],dictionary_get("test_dictionary_common_expression", id1)[2],dictionary_get("test_dictionary_common_expression", id1)[3] FROM t_dictionary_common_expression;
+-- result:
+[REGEX]*common*
+-- !result
+SELECT dictionary_get("test_dictionary_common_expression", id1)[1],dictionary_get("test_dictionary_common_expression", id1)[2],dictionary_get("test_dictionary_common_expression", id1)[3] FROM t_dictionary_common_expression;
+-- result:
+2	3	4
+-- !result
+DROP DICTIONARY test_dictionary_common_expression;
+-- result:
+-- !result
+DROP TABLE t_dictionary_common_expression;
+-- result:
+-- !result

--- a/test/sql/test_dictionary/T/test_dictionary
+++ b/test/sql/test_dictionary/T/test_dictionary
@@ -523,3 +523,31 @@ PROPERTIES (
 DROP DICTIONARY test_dictionary_generated_column_create_table;
 DROP TABLE t_dictionary_generated_column_create_table_1;
 DROP TABLE t_dictionary_generated_column_create_table_2;
+
+-- name: test_dictionary_common_expression
+CREATE TABLE `t_dictionary_common_expression` (
+  `id1` BIGINT NOT NULL COMMENT "",
+  `id2` BIGINT NOT NULL COMMENT "",
+  `id3` BIGINT NOT NULL COMMENT "",
+  `id4` BIGINT NOT NULL COMMENT ""
+) ENGINE=OLAP
+PRIMARY KEY(`id1`)
+DISTRIBUTED BY HASH(`id1`) BUCKETS 1 
+PROPERTIES (
+"replication_num" = "1",
+"in_memory" = "false",
+"enable_persistent_index" = "false",
+"replicated_storage" = "true",
+"compression" = "LZ4"
+);
+
+INSERT INTO t_dictionary_common_expression VALUES (1,2,3,4);
+[UC]DROP DICTIONARY test_dictionary_common_expression;
+CREATE DICTIONARY test_dictionary_common_expression USING t_dictionary_common_expression (id1 KEY, id2 VALUE, id3 VALUE, id4 VALUE);
+function: wait_refresh_dictionary_finish("test_dictionary_common_expression", "FINISHED")
+
+explain SELECT dictionary_get("test_dictionary_common_expression", id1)[1],dictionary_get("test_dictionary_common_expression", id1)[2],dictionary_get("test_dictionary_common_expression", id1)[3] FROM t_dictionary_common_expression;
+SELECT dictionary_get("test_dictionary_common_expression", id1)[1],dictionary_get("test_dictionary_common_expression", id1)[2],dictionary_get("test_dictionary_common_expression", id1)[3] FROM t_dictionary_common_expression;
+
+DROP DICTIONARY test_dictionary_common_expression;
+DROP TABLE t_dictionary_common_expression;


### PR DESCRIPTION
Why I'm doing:
dictionary_get is a expression which query a dictionary cache using the corresponding key. The return value type for dictionary_get is STRUCT type. If we want to query the subfield of the result, we will query as following:

`SELECT dictionary_get("dict", key)[1],dictionary_get("dict", key)[2];`

In current implementation, dictionary_get does not support common expression which means that it lookup the cache twice. But this is stupid because we can get all value we need in a single lookup for the cache, so we should support common expression for dictionary_get to eliminate redundant lookup for the cache.

What I'm doing:
support common expression for dictionary_get

example:

```
MySQL [test]> EXPLAIN SELECT dictionary_get(test_dictionary_common_expression, id1)[1], dictionary_get(test_dictionary_common_expression, id1)[2], dictionary_get(test_dictionary_common_expression, id1)[3] FROM t_dictionary_common_expression; 
+-----------------------------------------------------------------------------+
| Explain String                                                              |
+-----------------------------------------------------------------------------+
| PLAN FRAGMENT 0                                                             |
|  OUTPUT EXPRS:5: expr | 6: expr | 7: expr                                   |
|   PARTITION: RANDOM                                                         |
|                                                                             |
|   RESULT SINK                                                               |
|                                                                             |
|   1:Project                                                                 |
|   |  <slot 5> : 8: expr.id2[false]                                          |
|   |  <slot 6> : 8: expr.id3[false]                                          |
|   |  <slot 7> : 8: expr.id4[false]                                          |
|   |  common expressions:                                                    |
|   |  <slot 8> : DICTIONARY_GET('test_dictionary_common_expression', 1: id1) |
|   |                                                                         |
|   0:OlapScanNode                                                            |
|      TABLE: t_dictionary_common_expression                                  |
|      PREAGGREGATION: ON                                                     |
|      partitions=1/1                                                         |
|      rollup: t_dictionary_common_expression                                 |
|      tabletRatio=1/1                                                        |
|      tabletList=12131                                                       |
|      cardinality=1                                                          |
|      avgRowSize=11.0                                                        |
+-----------------------------------------------------------------------------+
22 rows in set (0.01 sec)
```

Fixes #40074

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
