### PR TITLE
[Feature] support spill to remote storage

### DIFF
--- a/be/src/exec/CMakeLists.txt
+++ b/be/src/exec/CMakeLists.txt
@@ -288,6 +288,7 @@ set(EXEC_FILES
     spill/file_block_manager.cpp
     spill/hybird_block_manager.cpp
     spill/operator_mem_resource_manager.cpp
+    spill/query_spill_manager.cpp
     stream/state/mem_state_table.cpp
     stream/aggregate/agg_state_data.cpp
     stream/aggregate/agg_group_state.cpp

--- a/be/src/exec/aggregate/aggregate_blocking_node.cpp
+++ b/be/src/exec/aggregate/aggregate_blocking_node.cpp
@@ -180,11 +180,8 @@ pipeline::OpFactories AggregateBlockingNode::_decompose_to_pipeline(pipeline::Op
     using namespace pipeline;
 
     auto workgroup = context->fragment_context()->workgroup();
-    auto executor = std::make_shared<spill::IOTaskExecutor>(
-            ExecEnv::GetInstance()->scan_executor(), ExecEnv::GetInstance()->connector_scan_executor(), workgroup);
     auto degree_of_parallelism = context->source_operator(ops_with_sink)->degree_of_parallelism();
-    auto spill_channel_factory =
-            std::make_shared<SpillProcessChannelFactory>(degree_of_parallelism, std::move(executor));
+    auto spill_channel_factory = std::make_shared<SpillProcessChannelFactory>(degree_of_parallelism);
     if (std::is_same_v<SinkFactory, SpillableAggregateBlockingSinkOperatorFactory>) {
         context->interpolate_spill_process(id(), spill_channel_factory, degree_of_parallelism);
     }

--- a/be/src/exec/aggregate/aggregate_blocking_node.cpp
+++ b/be/src/exec/aggregate/aggregate_blocking_node.cpp
@@ -180,7 +180,8 @@ pipeline::OpFactories AggregateBlockingNode::_decompose_to_pipeline(pipeline::Op
     using namespace pipeline;
 
     auto workgroup = context->fragment_context()->workgroup();
-    auto executor = std::make_shared<spill::IOTaskExecutor>(ExecEnv::GetInstance()->scan_executor(), workgroup);
+    auto executor = std::make_shared<spill::IOTaskExecutor>(
+            ExecEnv::GetInstance()->scan_executor(), ExecEnv::GetInstance()->connector_scan_executor(), workgroup);
     auto degree_of_parallelism = context->source_operator(ops_with_sink)->degree_of_parallelism();
     auto spill_channel_factory =
             std::make_shared<SpillProcessChannelFactory>(degree_of_parallelism, std::move(executor));

--- a/be/src/exec/aggregate/distinct_blocking_node.cpp
+++ b/be/src/exec/aggregate/distinct_blocking_node.cpp
@@ -135,11 +135,8 @@ pipeline::OpFactories DistinctBlockingNode::_decompose_to_pipeline(pipeline::OpF
     using namespace pipeline;
 
     auto workgroup = context->fragment_context()->workgroup();
-    auto executor = std::make_shared<spill::IOTaskExecutor>(
-            ExecEnv::GetInstance()->scan_executor(), ExecEnv::GetInstance()->connector_scan_executor(), workgroup);
     auto degree_of_parallelism = context->source_operator(ops_with_sink)->degree_of_parallelism();
-    auto spill_channel_factory =
-            std::make_shared<SpillProcessChannelFactory>(degree_of_parallelism, std::move(executor));
+    auto spill_channel_factory = std::make_shared<SpillProcessChannelFactory>(degree_of_parallelism);
     if (std::is_same_v<SinkFactory, SpillableAggregateDistinctBlockingSinkOperatorFactory>) {
         context->interpolate_spill_process(id(), spill_channel_factory, degree_of_parallelism);
     }

--- a/be/src/exec/aggregate/distinct_blocking_node.cpp
+++ b/be/src/exec/aggregate/distinct_blocking_node.cpp
@@ -135,7 +135,8 @@ pipeline::OpFactories DistinctBlockingNode::_decompose_to_pipeline(pipeline::OpF
     using namespace pipeline;
 
     auto workgroup = context->fragment_context()->workgroup();
-    auto executor = std::make_shared<spill::IOTaskExecutor>(ExecEnv::GetInstance()->scan_executor(), workgroup);
+    auto executor = std::make_shared<spill::IOTaskExecutor>(
+            ExecEnv::GetInstance()->scan_executor(), ExecEnv::GetInstance()->connector_scan_executor(), workgroup);
     auto degree_of_parallelism = context->source_operator(ops_with_sink)->degree_of_parallelism();
     auto spill_channel_factory =
             std::make_shared<SpillProcessChannelFactory>(degree_of_parallelism, std::move(executor));

--- a/be/src/exec/aggregator.cpp
+++ b/be/src/exec/aggregator.cpp
@@ -562,7 +562,6 @@ Status Aggregator::_reset_state(RuntimeState* state, bool reset_sink_complete) {
 }
 
 Status Aggregator::spill_aggregate_data(RuntimeState* state, std::function<StatusOr<ChunkPtr>()> chunk_provider) {
-    auto io_executor = this->spill_channel()->io_executor();
     auto spiller = this->spiller();
     auto spill_channel = this->spill_channel();
 
@@ -570,8 +569,8 @@ Status Aggregator::spill_aggregate_data(RuntimeState* state, std::function<Statu
         auto chunk_with_st = chunk_provider();
         if (chunk_with_st.ok()) {
             if (!chunk_with_st.value()->is_empty()) {
-                RETURN_IF_ERROR(spiller->spill(state, chunk_with_st.value(), *io_executor,
-                                               TRACKER_WITH_SPILLER_GUARD(state, spiller)));
+                RETURN_IF_ERROR(
+                        spiller->spill(state, chunk_with_st.value(), TRACKER_WITH_SPILLER_GUARD(state, spiller)));
             }
         } else if (chunk_with_st.status().is_end_of_file()) {
             // chunk_provider return eos means provider has output all data from hash_map/hash_set.

--- a/be/src/exec/aggregator.h
+++ b/be/src/exec/aggregator.h
@@ -380,9 +380,7 @@ public:
     const SpillProcessChannelPtr spill_channel() const { return _spill_channel; }
     void set_spill_channel(SpillProcessChannelPtr channel) { _spill_channel = std::move(channel); }
 
-    auto& io_executor() { return *spill_channel()->io_executor(); }
-
-    [[nodiscard]] Status spill_aggregate_data(RuntimeState* state, std::function<StatusOr<ChunkPtr>()> chunk_provider);
+    Status spill_aggregate_data(RuntimeState* state, std::function<StatusOr<ChunkPtr>()> chunk_provider);
 
     bool has_pending_data() const { return _spiller != nullptr && _spiller->has_pending_data(); }
     bool has_pending_restore() const { return _spiller != nullptr && !_spiller->restore_finished(); }

--- a/be/src/exec/chunks_sorter.h
+++ b/be/src/exec/chunks_sorter.h
@@ -117,8 +117,6 @@ public:
 
     void set_spill_channel(SpillProcessChannelPtr channel) { _spill_channel = std::move(channel); }
     const SpillProcessChannelPtr& spill_channel() { return _spill_channel; }
-    auto& io_executor() { return *spill_channel()->io_executor(); }
-
     // Append a Chunk for sort.
     [[nodiscard]] virtual Status update(RuntimeState* state, const ChunkPtr& chunk) = 0;
     // Finish seeding Chunk, and get sorted data with top OFFSET rows have been skipped.

--- a/be/src/exec/cross_join_node.cpp
+++ b/be/src/exec/cross_join_node.cpp
@@ -586,7 +586,8 @@ std::vector<std::shared_ptr<pipeline::OperatorFactory>> CrossJoinNode::_decompos
 
     size_t num_right_partitions = context->source_operator(right_ops)->degree_of_parallelism();
     auto workgroup = context->fragment_context()->workgroup();
-    auto executor = std::make_shared<spill::IOTaskExecutor>(ExecEnv::GetInstance()->scan_executor(), workgroup);
+    auto executor = std::make_shared<spill::IOTaskExecutor>(
+            ExecEnv::GetInstance()->scan_executor(), ExecEnv::GetInstance()->connector_scan_executor(), workgroup);
     auto spill_process_factory_ptr =
             std::make_shared<SpillProcessChannelFactory>(num_right_partitions, std::move(executor));
     context_params.spill_process_factory_ptr = spill_process_factory_ptr;

--- a/be/src/exec/cross_join_node.cpp
+++ b/be/src/exec/cross_join_node.cpp
@@ -586,10 +586,7 @@ std::vector<std::shared_ptr<pipeline::OperatorFactory>> CrossJoinNode::_decompos
 
     size_t num_right_partitions = context->source_operator(right_ops)->degree_of_parallelism();
     auto workgroup = context->fragment_context()->workgroup();
-    auto executor = std::make_shared<spill::IOTaskExecutor>(
-            ExecEnv::GetInstance()->scan_executor(), ExecEnv::GetInstance()->connector_scan_executor(), workgroup);
-    auto spill_process_factory_ptr =
-            std::make_shared<SpillProcessChannelFactory>(num_right_partitions, std::move(executor));
+    auto spill_process_factory_ptr = std::make_shared<SpillProcessChannelFactory>(num_right_partitions);
     context_params.spill_process_factory_ptr = spill_process_factory_ptr;
 
     auto cross_join_context = std::make_shared<NLJoinContext>(std::move(context_params));

--- a/be/src/exec/hash_join_node.cpp
+++ b/be/src/exec/hash_join_node.cpp
@@ -454,10 +454,7 @@ pipeline::OpFactories HashJoinNode::_decompose_to_pipeline(pipeline::PipelineBui
     size_t num_right_partitions = context->source_operator(rhs_operators)->degree_of_parallelism();
 
     auto workgroup = context->fragment_context()->workgroup();
-    auto executor = std::make_shared<spill::IOTaskExecutor>(
-            ExecEnv::GetInstance()->scan_executor(), ExecEnv::GetInstance()->connector_scan_executor(), workgroup);
-    auto build_side_spill_channel_factory =
-            std::make_shared<SpillProcessChannelFactory>(num_right_partitions, std::move(executor));
+    auto build_side_spill_channel_factory = std::make_shared<SpillProcessChannelFactory>(num_right_partitions);
 
     if (runtime_state()->enable_spill() && runtime_state()->enable_hash_join_spill() &&
         std::is_same_v<HashJoinBuilderFactory, SpillableHashJoinBuildOperatorFactory>) {

--- a/be/src/exec/hash_join_node.cpp
+++ b/be/src/exec/hash_join_node.cpp
@@ -454,7 +454,8 @@ pipeline::OpFactories HashJoinNode::_decompose_to_pipeline(pipeline::PipelineBui
     size_t num_right_partitions = context->source_operator(rhs_operators)->degree_of_parallelism();
 
     auto workgroup = context->fragment_context()->workgroup();
-    auto executor = std::make_shared<spill::IOTaskExecutor>(ExecEnv::GetInstance()->scan_executor(), workgroup);
+    auto executor = std::make_shared<spill::IOTaskExecutor>(
+            ExecEnv::GetInstance()->scan_executor(), ExecEnv::GetInstance()->connector_scan_executor(), workgroup);
     auto build_side_spill_channel_factory =
             std::make_shared<SpillProcessChannelFactory>(num_right_partitions, std::move(executor));
 

--- a/be/src/exec/hash_joiner.cpp
+++ b/be/src/exec/hash_joiner.cpp
@@ -182,8 +182,7 @@ Status HashJoiner::append_chunk_to_ht(const ChunkPtr& chunk) {
 
 Status HashJoiner::append_chunk_to_spill_buffer(RuntimeState* state, const ChunkPtr& chunk) {
     update_build_rows(chunk->num_rows());
-    auto io_executor = spill_channel()->io_executor();
-    RETURN_IF_ERROR(spiller()->spill(state, chunk, *io_executor, TRACKER_WITH_SPILLER_GUARD(state, spiller())));
+    RETURN_IF_ERROR(spiller()->spill(state, chunk, TRACKER_WITH_SPILLER_GUARD(state, spiller())));
     return Status::OK();
 }
 
@@ -192,8 +191,7 @@ Status HashJoiner::append_spill_task(RuntimeState* state, std::function<StatusOr
     while (!spiller()->is_full()) {
         auto chunk_st = spill_task();
         if (chunk_st.ok()) {
-            RETURN_IF_ERROR(spiller()->spill(state, chunk_st.value(), io_executor(),
-                                             TRACKER_WITH_SPILLER_GUARD(state, spiller())));
+            RETURN_IF_ERROR(spiller()->spill(state, chunk_st.value(), TRACKER_WITH_SPILLER_GUARD(state, spiller())));
         } else if (chunk_st.status().is_end_of_file()) {
             return Status::OK();
         } else {

--- a/be/src/exec/hash_joiner.h
+++ b/be/src/exec/hash_joiner.h
@@ -259,7 +259,6 @@ public:
     void set_spill_channel(SpillProcessChannelPtr channel) { _spill_channel = std::move(channel); }
     const auto& spiller() { return _spiller; }
     const SpillProcessChannelPtr& spill_channel() { return _spill_channel; }
-    auto& io_executor() { return *spill_channel()->io_executor(); }
     void set_spill_strategy(spill::SpillStrategy strategy) { _spill_strategy = strategy; }
     spill::SpillStrategy spill_strategy() { return _spill_strategy; }
 

--- a/be/src/exec/pipeline/aggregate/spillable_aggregate_blocking_sink_operator.cpp
+++ b/be/src/exec/pipeline/aggregate/spillable_aggregate_blocking_sink_operator.cpp
@@ -297,6 +297,7 @@ Status SpillableAggregateBlockingSinkOperatorFactory::prepare(RuntimeState* stat
     _spill_options->name = "agg-blocking-spill";
     _spill_options->plan_node_id = _plan_node_id;
     _spill_options->encode_level = state->spill_encode_level();
+    _spill_options->wg = state->fragment_ctx()->workgroup();
 
     return Status::OK();
 }

--- a/be/src/exec/pipeline/aggregate/spillable_aggregate_blocking_source_operator.cpp
+++ b/be/src/exec/pipeline/aggregate/spillable_aggregate_blocking_source_operator.cpp
@@ -120,9 +120,7 @@ StatusOr<ChunkPtr> SpillableAggregateBlockingSourceOperator::_pull_spilled_chunk
 
     if (!_aggregator->is_spilled_eos()) {
         DCHECK(_accumulator.need_input());
-        auto executor = _aggregator->spill_channel()->io_executor();
-        ASSIGN_OR_RETURN(auto chunk,
-                         spiller->restore(state, *executor, TRACKER_WITH_SPILLER_READER_GUARD(state, spiller)));
+        ASSIGN_OR_RETURN(auto chunk, spiller->restore(state, TRACKER_WITH_SPILLER_READER_GUARD(state, spiller)));
         if (chunk->is_empty()) {
             return chunk;
         }

--- a/be/src/exec/pipeline/aggregate/spillable_aggregate_distinct_blocking_operator.cpp
+++ b/be/src/exec/pipeline/aggregate/spillable_aggregate_distinct_blocking_operator.cpp
@@ -147,6 +147,7 @@ Status SpillableAggregateDistinctBlockingSinkOperatorFactory::prepare(RuntimeSta
     _spill_options->name = "agg-distinct-blocking-spill";
     _spill_options->plan_node_id = _plan_node_id;
     _spill_options->encode_level = state->spill_encode_level();
+    _spill_options->wg = state->fragment_ctx()->workgroup();
 
     return Status::OK();
 }

--- a/be/src/exec/pipeline/fragment_executor.cpp
+++ b/be/src/exec/pipeline/fragment_executor.cpp
@@ -283,7 +283,7 @@ Status FragmentExecutor::_prepare_runtime_state(ExecEnv* exec_env, const Unified
                 DescriptorTbl::create(runtime_state, obj_pool, t_desc_tbl, &desc_tbl, runtime_state->chunk_size()));
     }
     runtime_state->set_desc_tbl(desc_tbl);
-
+    RETURN_IF_ERROR(_query_ctx->init_spill_manager(query_options));
     return Status::OK();
 }
 

--- a/be/src/exec/pipeline/hashjoin/spillable_hash_join_build_operator.cpp
+++ b/be/src/exec/pipeline/hashjoin/spillable_hash_join_build_operator.cpp
@@ -93,13 +93,12 @@ Status SpillableHashJoinBuildOperator::set_finishing(RuntimeState* state) {
         _join_builder->spiller()->cancel();
     }
 
-    auto flush_function = [this](RuntimeState* state, auto io_executor) {
+    auto flush_function = [this](RuntimeState* state) {
         auto& spiller = _join_builder->spiller();
-        return spiller->flush(state, *io_executor, TRACKER_WITH_SPILLER_GUARD(state, spiller));
+        return spiller->flush(state, TRACKER_WITH_SPILLER_GUARD(state, spiller));
     };
 
-    auto io_executor = _join_builder->spill_channel()->io_executor();
-    auto set_call_back_function = [this](RuntimeState* state, auto io_executor) {
+    auto set_call_back_function = [this](RuntimeState* state) {
         auto& spiller = _join_builder->spiller();
         return spiller->set_flush_all_call_back(
                 [this]() {
@@ -107,13 +106,13 @@ Status SpillableHashJoinBuildOperator::set_finishing(RuntimeState* state) {
                     _join_builder->enter_probe_phase();
                     return Status::OK();
                 },
-                state, *io_executor, TRACKER_WITH_SPILLER_GUARD(state, spiller));
+                state, TRACKER_WITH_SPILLER_GUARD(state, spiller));
     };
 
     WARN_IF_ERROR(publish_runtime_filters(state),
                   fmt::format("spillable hash join operator of query {} publish runtime filter failed, ignore it...",
                               print_id(state->query_id())));
-    SpillProcessTasksBuilder task_builder(state, io_executor);
+    SpillProcessTasksBuilder task_builder(state);
     task_builder.then(flush_function).finally(set_call_back_function);
 
     RETURN_IF_ERROR(_join_builder->spill_channel()->execute(task_builder));

--- a/be/src/exec/pipeline/hashjoin/spillable_hash_join_build_operator.cpp
+++ b/be/src/exec/pipeline/hashjoin/spillable_hash_join_build_operator.cpp
@@ -103,6 +103,7 @@ Status SpillableHashJoinBuildOperator::set_finishing(RuntimeState* state) {
         auto& spiller = _join_builder->spiller();
         return spiller->set_flush_all_call_back(
                 [this]() {
+                    LOG(INFO) << "hash join build done";
                     _is_finished = true;
                     _join_builder->enter_probe_phase();
                     return Status::OK();
@@ -248,6 +249,7 @@ Status SpillableHashJoinBuildOperatorFactory::prepare(RuntimeState* state) {
     _spill_options->name = "hash-join-build";
     _spill_options->plan_node_id = _plan_node_id;
     _spill_options->encode_level = state->spill_encode_level();
+    _spill_options->wg = state->fragment_ctx()->workgroup();
     // TODO: Our current adaptive dop for non-broadcast functions will also result in a build hash_joiner corresponding to multiple prob hash_join prober.
     //
     _spill_options->read_shared =

--- a/be/src/exec/pipeline/hashjoin/spillable_hash_join_build_operator.cpp
+++ b/be/src/exec/pipeline/hashjoin/spillable_hash_join_build_operator.cpp
@@ -103,7 +103,6 @@ Status SpillableHashJoinBuildOperator::set_finishing(RuntimeState* state) {
         auto& spiller = _join_builder->spiller();
         return spiller->set_flush_all_call_back(
                 [this]() {
-                    LOG(INFO) << "hash join build done";
                     _is_finished = true;
                     _join_builder->enter_probe_phase();
                     return Status::OK();

--- a/be/src/exec/pipeline/hashjoin/spillable_hash_join_probe_operator.cpp
+++ b/be/src/exec/pipeline/hashjoin/spillable_hash_join_probe_operator.cpp
@@ -315,7 +315,6 @@ Status SpillableHashJoinProbeOperator::_load_all_partition_build_side(RuntimeSta
         auto io_task = workgroup::ScanTask(_join_builder->spiller()->options().wg.get(), std::move(task),
                                            std::move(yield_func));
         RETURN_IF_ERROR(_executor->submit(std::move(io_task)));
-        // RETURN_IF_ERROR(_executor->submit(std::move(task)));
     }
     return Status::OK();
 }

--- a/be/src/exec/pipeline/hashjoin/spillable_hash_join_probe_operator.cpp
+++ b/be/src/exec/pipeline/hashjoin/spillable_hash_join_probe_operator.cpp
@@ -48,8 +48,6 @@ Status SpillableHashJoinProbeOperator::prepare(RuntimeState* state) {
             "SpillProberPeakMemoryUsage", TUnit::BYTES, RuntimeProfile::Counter::create_strategy(TUnit::BYTES));
     RETURN_IF_ERROR(_probe_spiller->prepare(state));
     auto wg = state->fragment_ctx()->workgroup();
-    _executor = std::make_shared<spill::IOTaskExecutor>(ExecEnv::GetInstance()->scan_executor(),
-                                                        ExecEnv::GetInstance()->connector_scan_executor(), wg);
     return Status::OK();
 }
 
@@ -106,7 +104,7 @@ bool SpillableHashJoinProbeOperator::has_output() const {
             } else if (!_current_reader[i]->has_restore_task()) {
                 // if trigger_restore returns error, should record this status and return it in pull_chunk
                 _update_status(_current_reader[i]->trigger_restore(
-                        runtime_state(), *_executor,
+                        runtime_state(),
                         RESOURCE_TLS_MEMTRACER_GUARD(runtime_state(), std::weak_ptr(_current_reader[i]))));
                 if (!_status().ok()) {
                     return true;
@@ -201,7 +199,6 @@ Status SpillableHashJoinProbeOperator::_push_probe_chunk(RuntimeState* state, co
         res->fnv_hash(hash_values.data(), 0, num_rows);
     }
 
-    auto& executor = _join_builder->io_executor();
     auto partition_processer = [&chunk, this, state, &hash_values](spill::SpilledPartition* probe_partition,
                                                                    const std::vector<uint32_t>& selection, int32_t from,
                                                                    int32_t size) {
@@ -234,7 +231,7 @@ Status SpillableHashJoinProbeOperator::_push_probe_chunk(RuntimeState* state, co
         }
         probe_partition->num_rows += size;
     };
-    RETURN_IF_ERROR(_probe_spiller->partitioned_spill(state, chunk, hash_column.get(), partition_processer, executor,
+    RETURN_IF_ERROR(_probe_spiller->partitioned_spill(state, chunk, hash_column.get(), partition_processer,
                                                       TRACKER_WITH_SPILLER_GUARD(state, _probe_spiller)));
 
     return Status::OK();
@@ -261,8 +258,8 @@ Status SpillableHashJoinProbeOperator::_load_partition_build_side(workgroup::Yie
                 return Status::Cancelled("cancelled");
             }
 
-            RETURN_IF_ERROR(reader->trigger_restore(state, SyncTaskExecutor{}, MemTrackerGuard(tls_mem_tracker)));
-            auto chunk_st = reader->restore(state, SyncTaskExecutor{}, MemTrackerGuard(tls_mem_tracker));
+            RETURN_IF_ERROR(reader->trigger_restore<spill::SyncTaskExecutor>(state, MemTrackerGuard(tls_mem_tracker)));
+            auto chunk_st = reader->restore<spill::SyncTaskExecutor>(state, MemTrackerGuard(tls_mem_tracker));
 
             if (chunk_st.ok() && chunk_st.value() != nullptr && !chunk_st.value()->is_empty()) {
                 int64_t old_mem_usage = hash_table_mem_usage;
@@ -309,10 +306,10 @@ Status SpillableHashJoinProbeOperator::_load_all_partition_build_side(RuntimeSta
                 }
             }
         };
-        auto yield_func = [&](workgroup::ScanTask&& task) { _executor->force_submit(std::move(task)); };
+        auto yield_func = [&](workgroup::ScanTask&& task) { spill::IOTaskExecutor::force_submit(std::move(task)); };
         auto io_task = workgroup::ScanTask(_join_builder->spiller()->options().wg.get(), std::move(task),
                                            std::move(yield_func));
-        RETURN_IF_ERROR(_executor->submit(std::move(io_task)));
+        RETURN_IF_ERROR(spill::IOTaskExecutor::submit(std::move(io_task)));
     }
     return Status::OK();
 }
@@ -357,11 +354,11 @@ Status SpillableHashJoinProbeOperator::_restore_probe_partition(RuntimeState* st
         if (_probe_read_eofs[i]) continue;
         if (!_current_reader[i]->has_restore_task()) {
             RETURN_IF_ERROR(_current_reader[i]->trigger_restore(
-                    state, *_executor, RESOURCE_TLS_MEMTRACER_GUARD(state, std::weak_ptr(_current_reader[i]))));
+                    state, RESOURCE_TLS_MEMTRACER_GUARD(state, std::weak_ptr(_current_reader[i]))));
         }
         if (_current_reader[i]->has_output_data()) {
             auto chunk_st = _current_reader[i]->restore(
-                    state, *_executor, RESOURCE_TLS_MEMTRACER_GUARD(state, std::weak_ptr(_current_reader[i])));
+                    state, RESOURCE_TLS_MEMTRACER_GUARD(state, std::weak_ptr(_current_reader[i])));
             if (chunk_st.ok() && chunk_st.value() && !chunk_st.value()->is_empty()) {
                 RETURN_IF_ERROR(_probers[i]->push_probe_chunk(state, std::move(chunk_st.value())));
             } else if (chunk_st.status().is_end_of_file()) {

--- a/be/src/exec/pipeline/hashjoin/spillable_hash_join_probe_operator.h
+++ b/be/src/exec/pipeline/hashjoin/spillable_hash_join_probe_operator.h
@@ -94,7 +94,7 @@ private:
     Status _load_all_partition_build_side(RuntimeState* state);
 
     Status _load_partition_build_side(workgroup::YieldContext& ctx, RuntimeState* state,
-                                      const std::shared_ptr<spill::SpillerReader>& reader, size_t idx, int* yield);
+                                      const std::shared_ptr<spill::SpillerReader>& reader, size_t idx);
 
     void _update_status(Status&& status) const;
 

--- a/be/src/exec/pipeline/hashjoin/spillable_hash_join_probe_operator.h
+++ b/be/src/exec/pipeline/hashjoin/spillable_hash_join_probe_operator.h
@@ -133,7 +133,6 @@ private:
     mutable std::mutex _mutex;
     mutable Status _operator_status;
 
-    std::shared_ptr<spill::IOTaskExecutor> _executor;
     bool _need_post_probe = false;
 };
 

--- a/be/src/exec/pipeline/nljoin/nljoin_context.cpp
+++ b/be/src/exec/pipeline/nljoin/nljoin_context.cpp
@@ -40,8 +40,7 @@ Status NJJoinBuildInputChannel::add_chunk(ChunkPtr build_chunk) {
     return Status::OK();
 }
 
-Status NJJoinBuildInputChannel::add_chunk_to_spill_buffer(RuntimeState* state, ChunkPtr build_chunk,
-                                                          spill::IOTaskExecutor& executor) {
+Status NJJoinBuildInputChannel::add_chunk_to_spill_buffer(RuntimeState* state, ChunkPtr build_chunk) {
     if (build_chunk == nullptr || build_chunk->is_empty()) {
         return Status::OK();
     }
@@ -49,7 +48,7 @@ Status NJJoinBuildInputChannel::add_chunk_to_spill_buffer(RuntimeState* state, C
     _num_rows += build_chunk->num_rows();
     RETURN_IF_ERROR(_accumulator.push(std::move(build_chunk)));
     if (auto chunk = _accumulator.pull()) {
-        RETURN_IF_ERROR(_spiller->spill(state, chunk, executor, TRACKER_WITH_SPILLER_GUARD(state, _spiller)));
+        RETURN_IF_ERROR(_spiller->spill(state, chunk, TRACKER_WITH_SPILLER_GUARD(state, _spiller)));
     }
 
     return Status::OK();
@@ -68,16 +67,16 @@ void NJJoinBuildInputChannel::close() {
     _spiller.reset();
 }
 
-Status SpillableNLJoinChunkStream::prefetch(RuntimeState* state, spill::IOTaskExecutor& executor) {
-    return _reader->trigger_restore(state, executor, RESOURCE_TLS_MEMTRACER_GUARD(state, std::weak_ptr(_reader)));
+Status SpillableNLJoinChunkStream::prefetch(RuntimeState* state) {
+    return _reader->trigger_restore(state, RESOURCE_TLS_MEMTRACER_GUARD(state, std::weak_ptr(_reader)));
 }
 
 bool SpillableNLJoinChunkStream::has_output() {
     return _reader && _reader->has_output_data();
 }
 
-StatusOr<ChunkPtr> SpillableNLJoinChunkStream::get_next(RuntimeState* state, spill::IOTaskExecutor& executor) {
-    return _reader->restore(state, executor, RESOURCE_TLS_MEMTRACER_GUARD(state, std::weak_ptr(_reader)));
+StatusOr<ChunkPtr> SpillableNLJoinChunkStream::get_next(RuntimeState* state) {
+    return _reader->restore(state, RESOURCE_TLS_MEMTRACER_GUARD(state, std::weak_ptr(_reader)));
 }
 
 Status SpillableNLJoinChunkStream::reset(RuntimeState* state, spill::Spiller* dummy_spiller) {

--- a/be/src/exec/pipeline/nljoin/nljoin_context.h
+++ b/be/src/exec/pipeline/nljoin/nljoin_context.h
@@ -60,8 +60,7 @@ public:
     const std::shared_ptr<spill::Spiller>& spiller() { return _spiller; }
     bool has_spilled() { return _spiller && _spiller->spilled(); }
 
-    [[nodiscard]] Status add_chunk_to_spill_buffer(RuntimeState* state, ChunkPtr build_chunk,
-                                                   spill::IOTaskExecutor& executor);
+    Status add_chunk_to_spill_buffer(RuntimeState* state, ChunkPtr build_chunk);
 
     void finalize();
 
@@ -103,12 +102,12 @@ public:
             : _build_chunks(std::move(build_chunks)), _spillers(std::move(spillers)) {}
 
     // prefetch next chunk from spiller
-    Status prefetch(RuntimeState* state, spill::IOTaskExecutor& executor);
+    Status prefetch(RuntimeState* state);
 
     bool has_output();
 
     // return EOF if all data has been read
-    StatusOr<ChunkPtr> get_next(RuntimeState* state, spill::IOTaskExecutor& executor);
+    StatusOr<ChunkPtr> get_next(RuntimeState* state);
 
     // reset stream
     Status reset(RuntimeState* state, spill::Spiller* dummy_spiller);

--- a/be/src/exec/pipeline/nljoin/spillable_nljoin_build_operator.cpp
+++ b/be/src/exec/pipeline/nljoin/spillable_nljoin_build_operator.cpp
@@ -52,7 +52,6 @@ bool SpillableNLJoinBuildOperator::is_finished() const {
 }
 
 Status SpillableNLJoinBuildOperator::set_finishing(RuntimeState* state) {
-    auto& executor = *_spill_channel->io_executor();
     auto spiller = _spill_channel->spiller();
 
     if (!spiller->spilled()) {
@@ -61,7 +60,7 @@ Status SpillableNLJoinBuildOperator::set_finishing(RuntimeState* state) {
         return Status::OK();
     }
 
-    RETURN_IF_ERROR(spiller->flush(state, executor, TRACKER_WITH_SPILLER_GUARD(state, spiller)));
+    RETURN_IF_ERROR(spiller->flush(state, TRACKER_WITH_SPILLER_GUARD(state, spiller)));
     RETURN_IF_ERROR(spiller->set_flush_all_call_back(
             [&, state]() {
                 RETURN_IF_ERROR(_cross_join_context->finish_one_right_sinker(_driver_sequence, state));
@@ -69,7 +68,7 @@ Status SpillableNLJoinBuildOperator::set_finishing(RuntimeState* state) {
                 _spill_channel->set_finishing();
                 return Status::OK();
             },
-            state, executor, TRACKER_WITH_SPILLER_GUARD(state, spiller)));
+            state, TRACKER_WITH_SPILLER_GUARD(state, spiller)));
 
     return Status::OK();
 }
@@ -79,8 +78,7 @@ Status SpillableNLJoinBuildOperator::push_chunk(RuntimeState* state, const Chunk
         RETURN_IF_ERROR(NLJoinBuildOperator::push_chunk(state, chunk));
     } else {
         // TODO: process auto spill mode
-        RETURN_IF_ERROR(_cross_join_context->input_channel(_driver_sequence)
-                                .add_chunk_to_spill_buffer(state, chunk, *_spill_channel->io_executor()));
+        RETURN_IF_ERROR(_cross_join_context->input_channel(_driver_sequence).add_chunk_to_spill_buffer(state, chunk));
     }
     return Status::OK();
 }

--- a/be/src/exec/pipeline/nljoin/spillable_nljoin_build_operator.cpp
+++ b/be/src/exec/pipeline/nljoin/spillable_nljoin_build_operator.cpp
@@ -98,6 +98,7 @@ Status SpillableNLJoinBuildOperatorFactory::prepare(RuntimeState* state) {
     _spill_options->plan_node_id = _plan_node_id;
     _spill_options->read_shared = true;
     _spill_options->encode_level = state->spill_encode_level();
+    _spill_options->wg = state->fragment_ctx()->workgroup();
 
     return Status::OK();
 }

--- a/be/src/exec/pipeline/nljoin/spillable_nljoin_probe_operator.cpp
+++ b/be/src/exec/pipeline/nljoin/spillable_nljoin_probe_operator.cpp
@@ -173,7 +173,7 @@ Status SpillableNLJoinProbeOperator::set_finished(RuntimeState* state) {
 StatusOr<ChunkPtr> SpillableNLJoinProbeOperator::pull_chunk(RuntimeState* state) {
     TRACE_SPILL_LOG << "pull_chunk:" << _driver_sequence;
     if (_prober.probe_finished() || _build_chunk == nullptr || _build_chunk->is_empty()) {
-        auto chunk_st = _chunk_stream->get_next(state, _executor());
+        auto chunk_st = _chunk_stream->get_next(state);
         if (chunk_st.status().is_end_of_file()) {
             _prober.reset();
             _set_current_build_probe_finished(true);
@@ -208,7 +208,7 @@ Status SpillableNLJoinProbeOperator::push_chunk(RuntimeState* state, const Chunk
     _set_current_build_probe_finished(false);
     RETURN_IF_ERROR(_prober.push_probe_chunk(chunk));
     RETURN_IF_ERROR(_chunk_stream->reset(state, _spiller.get()));
-    RETURN_IF_ERROR(_chunk_stream->prefetch(state, _executor()));
+    RETURN_IF_ERROR(_chunk_stream->prefetch(state));
     return Status::OK();
 }
 
@@ -216,10 +216,6 @@ void SpillableNLJoinProbeOperator::_init_chunk_stream() const {
     if (_chunk_stream == nullptr) {
         _chunk_stream = _cross_join_context->builder().build_stream();
     }
-}
-
-spill::IOTaskExecutor& SpillableNLJoinProbeOperator::_executor() {
-    return *_cross_join_context->spill_channel_factory()->executor();
 }
 
 void SpillableNLJoinProbeOperatorFactory::_init_row_desc() {

--- a/be/src/exec/pipeline/nljoin/spillable_nljoin_probe_operator.cpp
+++ b/be/src/exec/pipeline/nljoin/spillable_nljoin_probe_operator.cpp
@@ -20,6 +20,7 @@
 
 #include "common/statusor.h"
 #include "exec/spill/common.h"
+#include "exec/spill/options.h"
 #include "exec/spill/spiller_factory.h"
 
 namespace starrocks::pipeline {
@@ -125,7 +126,9 @@ Status SpillableNLJoinProbeOperator::prepare(RuntimeState* state) {
     _accumulator.set_desired_size(state->chunk_size());
     RETURN_IF_ERROR(_prober.prepare(state, _unique_metrics.get()));
     _spill_factory = std::make_shared<spill::SpillerFactory>();
-    _spiller = _spill_factory->create({});
+    spill::SpilledOptions opts;
+    opts.wg = state->fragment_ctx()->workgroup();
+    _spiller = _spill_factory->create(opts);
     _spiller->set_metrics(spill::SpillProcessMetrics(_unique_metrics.get(), state->mutable_total_spill_bytes()));
     _cross_join_context->incr_prober();
     return Status::OK();

--- a/be/src/exec/pipeline/nljoin/spillable_nljoin_probe_operator.h
+++ b/be/src/exec/pipeline/nljoin/spillable_nljoin_probe_operator.h
@@ -128,7 +128,6 @@ public:
     // TODO: implements reset_state
 private:
     void _init_chunk_stream() const;
-    spill::IOTaskExecutor& _executor();
     // current build finish
     bool _is_current_build_probe_finished() const { return _current_build_probe_finished; }
     void _set_current_build_probe_finished(bool build_finished) { _current_build_probe_finished = build_finished; }

--- a/be/src/exec/pipeline/query_context.cpp
+++ b/be/src/exec/pipeline/query_context.cpp
@@ -162,6 +162,15 @@ MemTracker* QueryContext::operator_mem_tracker(int32_t plan_node_id) {
     return mem_tracker.get();
 }
 
+Status QueryContext::init_spill_manager(const TQueryOptions& query_options) {
+    Status st;
+    std::call_once(_init_spill_manager_once, [this, &st, &query_options]() {
+        _spill_manager = std::make_unique<spill::QuerySpillManager>(_query_id);
+        st = _spill_manager->init_block_manager(query_options);
+    });
+    return st;
+}
+
 Status QueryContext::init_query_once(workgroup::WorkGroup* wg, bool enable_group_level_query_queue) {
     Status st = Status::OK();
     if (wg != nullptr) {

--- a/be/src/exec/pipeline/query_context.cpp
+++ b/be/src/exec/pipeline/query_context.cpp
@@ -183,8 +183,6 @@ Status QueryContext::init_query_once(workgroup::WorkGroup* wg, bool enable_group
             } else {
                 st = maybe_token.status();
             }
-
-            _spill_manager = std::make_unique<spill::QuerySpillManager>(_query_id);
         });
     }
 

--- a/be/src/exec/pipeline/query_context.h
+++ b/be/src/exec/pipeline/query_context.h
@@ -162,6 +162,7 @@ public:
 
     MemTracker* operator_mem_tracker(int32_t plan_node_id);
 
+    Status init_spill_manager(const TQueryOptions& query_options);
     Status init_query_once(workgroup::WorkGroup* wg, bool enable_group_level_query_queue);
     /// Release the workgroup token only once to avoid double-free.
     /// This method should only be invoked while the QueryContext is still valid,
@@ -263,6 +264,7 @@ private:
 
     std::once_flag _init_query_once;
     int64_t _query_begin_time = 0;
+    std::once_flag _init_spill_manager_once;
     std::atomic<int64_t> _total_cpu_cost_ns = 0;
     std::atomic<int64_t> _total_scan_rows_num = 0;
     std::atomic<int64_t> _total_scan_bytes = 0;

--- a/be/src/exec/pipeline/sort/spillable_partition_sort_sink_operator.cpp
+++ b/be/src/exec/pipeline/sort/spillable_partition_sort_sink_operator.cpp
@@ -140,6 +140,8 @@ Status SpillablePartitionSortSinkOperatorFactory::prepare(RuntimeState* state) {
     _spill_options->name = "local-sort-spill";
     _spill_options->plan_node_id = _plan_node_id;
     _spill_options->encode_level = state->spill_encode_level();
+    _spill_options->wg = state->fragment_ctx()->workgroup();
+
     return Status::OK();
 }
 

--- a/be/src/exec/pipeline/spill_process_operator.cpp
+++ b/be/src/exec/pipeline/spill_process_operator.cpp
@@ -48,8 +48,8 @@ StatusOr<ChunkPtr> SpillProcessOperator::pull_chunk(RuntimeState* state) {
         auto chunk = chunk_st.value();
         if (chunk != nullptr && !chunk->is_empty()) {
             auto& spiller = _channel->spiller();
-            RETURN_IF_ERROR(spiller->spill(state, std::move(chunk_st.value()), *_channel->io_executor(),
-                                           TRACKER_WITH_SPILLER_GUARD(state, spiller)));
+            RETURN_IF_ERROR(
+                    spiller->spill(state, std::move(chunk_st.value()), TRACKER_WITH_SPILLER_GUARD(state, spiller)));
         }
     } else if (chunk_st.status().is_end_of_file()) {
         _channel->current_task().reset();

--- a/be/src/exec/spill/block_manager.h
+++ b/be/src/exec/spill/block_manager.h
@@ -23,15 +23,7 @@
 
 namespace starrocks::spill {
 
-class BlockReader {
-public:
-    virtual ~BlockReader() = default;
-    // read exacly the specified length of data from Block,
-    // if the Block has reached the end, should return EndOfFile status
-    virtual Status read_fully(void* data, int64_t count) = 0;
-
-    virtual std::string debug_string() = 0;
-};
+class BlockReader;
 
 // Block represents a continuous storage space and is the smallest storage unit of flush and restore in spill task.
 // Block only supports append writing and sequential reading, and neither writing nor reading of Block is guaranteed to be thread-safe.
@@ -60,8 +52,25 @@ protected:
 
 using BlockPtr = std::shared_ptr<Block>;
 
+class BlockReader {
+public:
+    BlockReader(const Block* block) : _block(block) {}
+    virtual ~BlockReader() = default;
+    // read exacly the specified length of data from Block,
+    // if the Block has reached the end, should return EndOfFile status
+    virtual Status read_fully(void* data, int64_t count) = 0;
+
+    virtual std::string debug_string() = 0;
+
+    virtual const Block* block() const = 0;
+
+protected:
+    const Block* _block = nullptr;
+};
+
 struct AcquireBlockOptions {
     TUniqueId query_id;
+    TUniqueId fragment_instance_id;
     int32_t plan_node_id;
     std::string name;
     bool direct_io = false;

--- a/be/src/exec/spill/dir_manager.cpp
+++ b/be/src/exec/spill/dir_manager.cpp
@@ -101,7 +101,7 @@ Status DirManager::init(const std::string& spill_dirs) {
     return Status::OK();
 }
 
-StatusOr<Dir*> DirManager::acquire_writable_dir(const AcquireDirOptions& opts) {
+StatusOr<DirPtr> DirManager::acquire_writable_dir(const AcquireDirOptions& opts) {
     // for the case of multiple dirs, we randomly select one as the start
     // and then try one by one until we find the first one that meets the capacity requirements.
     size_t start_idx = 0;
@@ -112,7 +112,7 @@ StatusOr<Dir*> DirManager::acquire_writable_dir(const AcquireDirOptions& opts) {
     for (size_t i = 0; i < _dirs.size(); i++) {
         size_t idx = (start_idx + i) % _dirs.size();
         if (_dirs[idx]->inc_size(opts.data_size)) {
-            return _dirs[idx].get();
+            return _dirs[idx];
         }
     }
     return Status::CapacityLimitExceed("no writable spill storage directories");

--- a/be/src/exec/spill/dir_manager.h
+++ b/be/src/exec/spill/dir_manager.h
@@ -52,10 +52,12 @@ public:
     void dec_size(int64_t value) { _current_size -= value; }
 
     int64_t get_max_size() const { return _max_size; }
+    void set_cloud_conf(std::shared_ptr<TCloudConfiguration> cloud_conf) { _cloud_conf = std::move(cloud_conf); }
 
 private:
     std::string _dir;
     std::shared_ptr<FileSystem> _fs;
+    std::shared_ptr<TCloudConfiguration> _cloud_conf;
     int64_t _max_size;
     std::atomic<int64_t> _current_size = 0;
 };
@@ -72,14 +74,12 @@ struct AcquireDirOptions {
 class DirManager {
 public:
     DirManager() = default;
-#ifdef BE_TEST
     DirManager(const std::vector<DirPtr>& dirs) : _dirs(dirs) {}
-#endif
     ~DirManager() = default;
 
     Status init(const std::string& spill_dirs);
 
-    StatusOr<Dir*> acquire_writable_dir(const AcquireDirOptions& opts);
+    StatusOr<DirPtr> acquire_writable_dir(const AcquireDirOptions& opts);
 
 private:
     bool is_same_disk(const std::string& path1, const std::string& path2) {

--- a/be/src/exec/spill/dir_manager.h
+++ b/be/src/exec/spill/dir_manager.h
@@ -33,6 +33,8 @@ public:
     Dir(std::string dir, std::shared_ptr<FileSystem> fs, int64_t max_dir_size)
             : _dir(std::move(dir)), _fs(fs), _max_size(max_dir_size) {}
 
+    virtual ~Dir() = default;
+
     FileSystem* fs() const { return _fs.get(); }
     std::string dir() const { return _dir; }
 
@@ -53,6 +55,8 @@ public:
 
     int64_t get_max_size() const { return _max_size; }
 
+    virtual bool is_remote() const { return false; }
+
 protected:
     std::string _dir;
     std::shared_ptr<FileSystem> _fs;
@@ -61,14 +65,18 @@ protected:
 };
 using DirPtr = std::shared_ptr<Dir>;
 
-class RemoteDir: public Dir {
+class RemoteDir : public Dir {
 public:
-    RemoteDir(std::string dir, std::shared_ptr<FileSystem> fs, std::shared_ptr<TCloudConfiguration> cloud_conf, int64_t max_dir_size):
-        Dir(std::move(dir), std::move(fs), max_dir_size), _cloud_conf(std::move(cloud_conf)) {}
+    RemoteDir(std::string dir, std::shared_ptr<FileSystem> fs, std::shared_ptr<TCloudConfiguration> cloud_conf,
+              int64_t max_dir_size)
+            : Dir(std::move(dir), std::move(fs), max_dir_size), _cloud_conf(std::move(cloud_conf)) {}
+    ~RemoteDir() override = default;
+
+    bool is_remote() const override { return true; }
+
 private:
     std::shared_ptr<TCloudConfiguration> _cloud_conf;
 };
-
 
 struct AcquireDirOptions {
     // @TOOD(silverbullet233): support more properties when acquiring dir, such as the preference of dir selection

--- a/be/src/exec/spill/dir_manager.h
+++ b/be/src/exec/spill/dir_manager.h
@@ -52,16 +52,23 @@ public:
     void dec_size(int64_t value) { _current_size -= value; }
 
     int64_t get_max_size() const { return _max_size; }
-    void set_cloud_conf(std::shared_ptr<TCloudConfiguration> cloud_conf) { _cloud_conf = std::move(cloud_conf); }
 
-private:
+protected:
     std::string _dir;
     std::shared_ptr<FileSystem> _fs;
-    std::shared_ptr<TCloudConfiguration> _cloud_conf;
     int64_t _max_size;
     std::atomic<int64_t> _current_size = 0;
 };
 using DirPtr = std::shared_ptr<Dir>;
+
+class RemoteDir: public Dir {
+public:
+    RemoteDir(std::string dir, std::shared_ptr<FileSystem> fs, std::shared_ptr<TCloudConfiguration> cloud_conf, int64_t max_dir_size):
+        Dir(std::move(dir), std::move(fs), max_dir_size), _cloud_conf(std::move(cloud_conf)) {}
+private:
+    std::shared_ptr<TCloudConfiguration> _cloud_conf;
+};
+
 
 struct AcquireDirOptions {
     // @TOOD(silverbullet233): support more properties when acquiring dir, such as the preference of dir selection

--- a/be/src/exec/spill/executor.h
+++ b/be/src/exec/spill/executor.h
@@ -23,6 +23,7 @@
 #include "exec/pipeline/query_context.h"
 #include "exec/workgroup/scan_executor.h"
 #include "exec/workgroup/scan_task_queue.h"
+#include "exec/workgroup/work_group_fwd.h"
 #include "gen_cpp/Types_types.h"
 #include "runtime/current_thread.h"
 #include "runtime/mem_tracker.h"
@@ -90,22 +91,78 @@ private:
     mutable MemTracker* old_tracker = nullptr;
 };
 
+struct SpillIOTaskContext {
+    bool use_local_io_executor = true;
+};
+using SpillIOTaskContextPtr = std::shared_ptr<SpillIOTaskContext>;
+
 struct IOTaskExecutor {
-    workgroup::ScanExecutor* pool;
+    workgroup::ScanExecutor* local_io_executor;
+    workgroup::ScanExecutor* remote_io_executor;
     workgroup::WorkGroupPtr wg;
 
-    IOTaskExecutor(workgroup::ScanExecutor* pool_, workgroup::WorkGroupPtr wg_) : pool(pool_), wg(std::move(wg_)) {}
+    IOTaskExecutor(workgroup::ScanExecutor* local_io_executor, workgroup::ScanExecutor* remote_io_executor,
+                   workgroup::WorkGroupPtr wg)
+            : local_io_executor(local_io_executor), remote_io_executor(remote_io_executor), wg(std::move(wg)) {}
 
+    // remove this
     template <class Func>
     Status submit(Func&& func) {
         workgroup::ScanTask task(wg.get(), func);
+        DCHECK(false) << "should not use";
+        // get context
+        return Status::OK();
+    }
+
+    Status submit(workgroup::ScanTask task) {
+        const auto& task_ctx = task.get_work_context();
+        bool use_local_io_executor = true;
+        if (task_ctx.task_context_data.has_value()) {
+            auto io_ctx = std::any_cast<SpillIOTaskContextPtr>(task_ctx.task_context_data);
+            use_local_io_executor = io_ctx->use_local_io_executor;
+        }
+        // @TODO
+        auto* pool = use_local_io_executor ? local_io_executor : remote_io_executor;
         if (pool->submit(std::move(task))) {
             return Status::OK();
         } else {
             return Status::InternalError("offer task failed");
         }
     }
+    void force_submit(workgroup::ScanTask task) {
+        const auto& task_ctx = task.get_work_context();
+        auto io_ctx = std::any_cast<SpillIOTaskContextPtr>(task_ctx.task_context_data);
+        auto* pool = io_ctx->use_local_io_executor ? local_io_executor : remote_io_executor;
+        pool->force_submit(std::move(task));
+    }
 };
+
+// struct IOTaskExecutor {
+//     workgroup::ScanExecutor* pool;
+//     workgroup::WorkGroupPtr wg;
+
+//     IOTaskExecutor(workgroup::ScanExecutor* pool_, workgroup::WorkGroupPtr wg_) : pool(pool_), wg(std::move(wg_)) {}
+
+//     template <class Func>
+//     Status submit(Func&& func) {
+//         workgroup::ScanTask task(wg.get(), func);
+//         if (pool->submit(std::move(task))) {
+//             return Status::OK();
+//         } else {
+//             return Status::InternalError("offer task failed");
+//         }
+//     }
+//     Status submit(workgroup::ScanTask task) {
+//         if (pool->submit(std::move(task))) {
+//             return Status::OK();
+//         } else {
+//             return Status::InternalError("offer task failed");
+//         }
+//     }
+//     void force_submit(workgroup::ScanTask task) {
+//         pool->force_submit(std::move(task));
+//     }
+// };
 
 struct SyncTaskExecutor {
     template <class Func>
@@ -116,6 +173,15 @@ struct SyncTaskExecutor {
         } while (!yield_ctx.is_finished());
         return Status::OK();
     }
+
+    Status submit(workgroup::ScanTask task) {
+        do {
+            task.run();
+        } while (!task.is_finished());
+        return Status::OK();
+    }
+
+    void force_submit(workgroup::ScanTask task) { (void)submit(std::move(task)); }
 };
 
 #define BREAK_IF_YIELD(wg, yield, time_spent_ns)                                                \

--- a/be/src/exec/spill/file_block_manager.cpp
+++ b/be/src/exec/spill/file_block_manager.cpp
@@ -24,10 +24,11 @@
 namespace starrocks::spill {
 class FileBlockContainer {
 public:
-    FileBlockContainer(Dir* dir, const TUniqueId& query_id, int32_t plan_node_id, std::string plan_node_name,
-                       uint64_t id)
+    FileBlockContainer(DirPtr dir, const TUniqueId& query_id, const TUniqueId& fragment_instance_id,
+                       int32_t plan_node_id, std::string plan_node_name, uint64_t id)
             : _dir(dir),
               _query_id(query_id),
+              _fragment_instance_id(fragment_instance_id),
               _plan_node_id(plan_node_id),
               _plan_node_name(std::move(plan_node_name)),
               _id(id) {}
@@ -45,7 +46,7 @@ public:
 
     Status close();
 
-    Dir* dir() const { return _dir; }
+    Dir* dir() const { return _dir.get(); }
     int32_t plan_node_id() const { return _plan_node_id; }
     std::string plan_node_name() const { return _plan_node_name; }
 
@@ -54,7 +55,8 @@ public:
         return _writable_file->size();
     }
     std::string path() const {
-        return fmt::format("{}/{}/{}-{}-{}", _dir->dir(), print_id(_query_id), _plan_node_name, _plan_node_id, _id);
+        return fmt::format("{}/{}/{}-{}-{}-{}", _dir->dir(), print_id(_query_id), print_id(_fragment_instance_id),
+                           _plan_node_name, _plan_node_id, _id);
     }
     std::string parent_path() const { return fmt::format("{}/{}", _dir->dir(), print_id(_query_id)); }
     uint64_t id() const { return _id; }
@@ -65,12 +67,13 @@ public:
 
     StatusOr<std::unique_ptr<io::InputStreamWrapper>> get_readable();
 
-    static StatusOr<FileBlockContainerPtr> create(Dir* dir, TUniqueId query_id, int32_t plan_node_id,
-                                                  const std::string& plan_node_name, uint64_t id);
+    static StatusOr<FileBlockContainerPtr> create(DirPtr dir, TUniqueId query_id, TUniqueId fragment_instance_id,
+                                                  int32_t plan_node_id, const std::string& plan_node_name, uint64_t id);
 
 private:
-    Dir* _dir;
+    DirPtr _dir;
     TUniqueId _query_id;
+    TUniqueId _fragment_instance_id;
     int32_t _plan_node_id;
     std::string _plan_node_name;
     uint64_t _id;
@@ -113,24 +116,27 @@ StatusOr<std::unique_ptr<io::InputStreamWrapper>> FileBlockContainer::get_readab
     return f;
 }
 
-StatusOr<FileBlockContainerPtr> FileBlockContainer::create(Dir* dir, TUniqueId query_id, int32_t plan_node_id,
+StatusOr<FileBlockContainerPtr> FileBlockContainer::create(DirPtr dir, TUniqueId query_id,
+                                                           TUniqueId fragment_instance_id, int32_t plan_node_id,
                                                            const std::string& plan_node_name, uint64_t id) {
-    auto container = std::make_shared<FileBlockContainer>(dir, query_id, plan_node_id, plan_node_name, id);
+    auto container =
+            std::make_shared<FileBlockContainer>(dir, query_id, fragment_instance_id, plan_node_id, plan_node_name, id);
     RETURN_IF_ERROR(container->open());
     return container;
 }
 
 class FileBlockReader final : public BlockReader {
 public:
-    FileBlockReader(const Block* block) : _block(block), _length(block->size()) {}
+    FileBlockReader(const Block* block) : BlockReader(block), _length(block->size()) {}
     ~FileBlockReader() override = default;
 
     Status read_fully(void* data, int64_t count) override;
 
     std::string debug_string() override { return _block->debug_string(); }
 
+    const Block* block() const override { return _block; }
+
 private:
-    const Block* _block = nullptr;
     std::unique_ptr<io::InputStreamWrapper> _readable;
     size_t _length = 0;
     size_t _offset = 0;
@@ -207,7 +213,8 @@ StatusOr<BlockPtr> FileBlockManager::acquire_block(const AcquireBlockOptions& op
     AcquireDirOptions acquire_dir_opts;
     acquire_dir_opts.data_size = opts.block_size;
     ASSIGN_OR_RETURN(auto dir, _dir_mgr->acquire_writable_dir(acquire_dir_opts));
-    ASSIGN_OR_RETURN(auto block_container, get_or_create_container(dir, opts.plan_node_id, opts.name));
+    ASSIGN_OR_RETURN(auto block_container,
+                     get_or_create_container(dir, opts.fragment_instance_id, opts.plan_node_id, opts.name));
     return std::make_shared<FileBlock>(block_container);
 }
 
@@ -220,15 +227,16 @@ Status FileBlockManager::release_block(const BlockPtr& block) {
     return Status::OK();
 }
 
-StatusOr<FileBlockContainerPtr> FileBlockManager::get_or_create_container(Dir* dir, int32_t plan_node_id,
+StatusOr<FileBlockContainerPtr> FileBlockManager::get_or_create_container(DirPtr dir, TUniqueId fragment_instance_id,
+                                                                          int32_t plan_node_id,
                                                                           const std::string& plan_node_name) {
     TRACE_SPILL_LOG << "get_or_create_container at dir: " << dir->dir() << ", plan node:" << plan_node_id << ", "
                     << plan_node_name;
     uint64_t id = _next_container_id++;
     std::string container_dir = dir->dir() + "/" + print_id(_query_id);
     RETURN_IF_ERROR(dir->fs()->create_dir_if_missing(container_dir));
-    ASSIGN_OR_RETURN(auto block_container,
-                     FileBlockContainer::create(dir, _query_id, plan_node_id, plan_node_name, id));
+    ASSIGN_OR_RETURN(auto block_container, FileBlockContainer::create(dir, _query_id, fragment_instance_id,
+                                                                      plan_node_id, plan_node_name, id));
     RETURN_IF_ERROR(block_container->open());
     return block_container;
 }

--- a/be/src/exec/spill/file_block_manager.cpp
+++ b/be/src/exec/spill/file_block_manager.cpp
@@ -215,7 +215,9 @@ StatusOr<BlockPtr> FileBlockManager::acquire_block(const AcquireBlockOptions& op
     ASSIGN_OR_RETURN(auto dir, _dir_mgr->acquire_writable_dir(acquire_dir_opts));
     ASSIGN_OR_RETURN(auto block_container,
                      get_or_create_container(dir, opts.fragment_instance_id, opts.plan_node_id, opts.name));
-    return std::make_shared<FileBlock>(block_container);
+    auto res = std::make_shared<FileBlock>(block_container);
+    res->set_is_remote(dir->is_remote());
+    return res;
 }
 
 Status FileBlockManager::release_block(const BlockPtr& block) {

--- a/be/src/exec/spill/file_block_manager.h
+++ b/be/src/exec/spill/file_block_manager.h
@@ -43,8 +43,8 @@ public:
 
 private:
     // @TODO(silverbullet233): some information is needed to uniquely identify each BE
-    StatusOr<FileBlockContainerPtr> get_or_create_container(Dir* dir, int32_t plan_node_id,
-                                                            const std::string& plan_node_name);
+    StatusOr<FileBlockContainerPtr> get_or_create_container(DirPtr dir, TUniqueId fragment_instance_id,
+                                                            int32_t plan_node_id, const std::string& plan_node_name);
 
     TUniqueId _query_id;
     std::atomic<uint64_t> _next_container_id = 0;

--- a/be/src/exec/spill/hybird_block_manager.cpp
+++ b/be/src/exec/spill/hybird_block_manager.cpp
@@ -38,9 +38,11 @@ void HyBirdBlockManager::close() {
 }
 
 StatusOr<BlockPtr> HyBirdBlockManager::acquire_block(const AcquireBlockOptions& opts) {
-    auto local_block = _local_block_manager->acquire_block(opts);
-    if (local_block.ok()) {
-        return local_block;
+    if (rand() % 10 < 2) {
+        auto local_block = _local_block_manager->acquire_block(opts);
+        if (local_block.ok()) {
+            return local_block;
+        }
     }
     ASSIGN_OR_RETURN(auto remote_block, _remote_block_manager->acquire_block(opts));
     remote_block->set_is_remote(true);

--- a/be/src/exec/spill/hybird_block_manager.cpp
+++ b/be/src/exec/spill/hybird_block_manager.cpp
@@ -51,7 +51,6 @@ StatusOr<BlockPtr> HyBirdBlockManager::acquire_block(const AcquireBlockOptions& 
         }
     }
     ASSIGN_OR_RETURN(auto remote_block, _remote_block_manager->acquire_block(opts));
-    remote_block->set_is_remote(true);
     return remote_block;
 }
 

--- a/be/src/exec/spill/input_stream.cpp
+++ b/be/src/exec/spill/input_stream.cpp
@@ -272,7 +272,7 @@ StatusOr<ChunkUniquePtr> UnorderedInputStream::get_next(workgroup::YieldContext&
         }
         auto& block = _input_blocks[_current_idx];
         if (!(block->is_remote() ^ io_ctx->use_local_io_executor)) {
-            TRACE_SPILL_LOG << fmt::format("block[{}], use local[{}], yield", block->debug_string(),
+            TRACE_SPILL_LOG << fmt::format("block[{}], use_local_io_executor[{}], should yield", block->debug_string(),
                                            io_ctx->use_local_io_executor);
             io_ctx->use_local_io_executor = !block->is_remote();
             return Status::Yield();

--- a/be/src/exec/spill/input_stream.cpp
+++ b/be/src/exec/spill/input_stream.cpp
@@ -30,25 +30,30 @@ namespace starrocks::spill {
 
 static const int chunk_buffer_max_size = 2;
 
-Status YieldableRestoreTask::do_read(workgroup::YieldContext& ctx, SerdeContext& context) {
+Status YieldableRestoreTask::do_read(workgroup::YieldContext& yield_ctx, SerdeContext& context) {
     size_t num_eos = 0;
-    ctx.total_yield_point_cnt = _sub_stream.size();
-    auto wg = ctx.wg;
-    while (ctx.yield_point < ctx.total_yield_point_cnt) {
+    yield_ctx.total_yield_point_cnt = _sub_stream.size();
+    auto wg = yield_ctx.wg;
+    while (yield_ctx.yield_point < yield_ctx.total_yield_point_cnt) {
         {
-            SCOPED_RAW_TIMER(&ctx.time_spent_ns);
-            size_t i = ctx.yield_point++;
+            SCOPED_RAW_TIMER(&yield_ctx.time_spent_ns);
+            size_t i = yield_ctx.yield_point;
             if (!_sub_stream[i]->eof()) {
                 DCHECK(_sub_stream[i]->enable_prefetch());
-                auto status = _sub_stream[i]->prefetch(context);
-                if (!status.ok() && !status.is_end_of_file()) {
+                auto status = _sub_stream[i]->prefetch(yield_ctx, context);
+                if (!status.ok() && !status.is_end_of_file() && !status.is_yield()) {
                     return status;
                 }
+                if (status.is_yield()) {
+                    yield_ctx.need_yield = true;
+                    return Status::OK();
+                }
             }
+            yield_ctx.yield_point++;
             num_eos += _sub_stream[i]->eof();
         }
 
-        BREAK_IF_YIELD(wg, &ctx.need_yield, ctx.time_spent_ns);
+        BREAK_IF_YIELD(wg, &yield_ctx.need_yield, yield_ctx.time_spent_ns);
     }
 
     if (num_eos == _sub_stream.size()) {
@@ -69,7 +74,7 @@ public:
 
     ~UnionAllSpilledInputStream() override = default;
 
-    StatusOr<ChunkUniquePtr> get_next(SerdeContext& ctx) override;
+    StatusOr<ChunkUniquePtr> get_next(workgroup::YieldContext& yield_ctx, SerdeContext& ctx) override;
 
     void get_io_stream(std::vector<SpillInputStream*>* io_stream) override {
         for (auto& stream : _streams) {
@@ -92,9 +97,10 @@ private:
     std::vector<InputStreamPtr> _streams;
 };
 
-StatusOr<ChunkUniquePtr> UnionAllSpilledInputStream::get_next(SerdeContext& context) {
+StatusOr<ChunkUniquePtr> UnionAllSpilledInputStream::get_next(workgroup::YieldContext& yield_ctx,
+                                                              SerdeContext& context) {
     if (_current_process_idx < _streams.size()) {
-        auto chunk_st = _streams[_current_process_idx]->get_next(context);
+        auto chunk_st = _streams[_current_process_idx]->get_next(yield_ctx, context);
         if (chunk_st.ok()) {
             return std::move(chunk_st.value());
         }
@@ -112,7 +118,7 @@ StatusOr<ChunkUniquePtr> UnionAllSpilledInputStream::get_next(SerdeContext& cont
 class RawChunkInputStream final : public SpillInputStream {
 public:
     RawChunkInputStream(std::vector<ChunkPtr> chunks, Spiller* spiller) : _chunks(std::move(chunks)) {}
-    StatusOr<ChunkUniquePtr> get_next(SerdeContext& ctx) override;
+    StatusOr<ChunkUniquePtr> get_next(workgroup::YieldContext& yield_ctx, SerdeContext& ctx) override;
 
     bool is_ready() override { return true; };
     void close() override{};
@@ -123,7 +129,7 @@ private:
     DECLARE_RACE_DETECTOR(detect_get_next)
 };
 
-StatusOr<ChunkUniquePtr> RawChunkInputStream::get_next(SerdeContext& context) {
+StatusOr<ChunkUniquePtr> RawChunkInputStream::get_next(workgroup::YieldContext& yield_ctx, SerdeContext& context) {
     RACE_DETECT(detect_get_next, var1);
     if (read_idx >= _chunks.size()) {
         return Status::EndOfFile("eos");
@@ -159,7 +165,7 @@ public:
     // if the InputStream is in the eof state, it also needs to return true to driver ChunkSortCursor into the stage of obtaining data.
     bool has_chunk() { return !_chunk_buffer.empty() || eof(); }
 
-    StatusOr<ChunkUniquePtr> get_next(SerdeContext& ctx) override;
+    StatusOr<ChunkUniquePtr> get_next(workgroup::YieldContext& yield_ctx, SerdeContext& ctx) override;
     bool is_ready() override { return has_chunk(); }
     void close() override {}
 
@@ -167,7 +173,7 @@ public:
 
     void get_io_stream(std::vector<SpillInputStream*>* io_stream) override { io_stream->emplace_back(this); }
 
-    Status prefetch(SerdeContext& ctx) override;
+    Status prefetch(workgroup::YieldContext& yield_ctx, SerdeContext& ctx) override;
 
     StatusOr<ChunkUniquePtr> read_from_buffer();
 
@@ -202,15 +208,15 @@ StatusOr<ChunkUniquePtr> BufferedInputStream::read_from_buffer() {
     return res;
 }
 
-StatusOr<ChunkUniquePtr> BufferedInputStream::get_next(SerdeContext& ctx) {
+StatusOr<ChunkUniquePtr> BufferedInputStream::get_next(workgroup::YieldContext& yield_ctx, SerdeContext& ctx) {
     if (has_chunk()) {
         return read_from_buffer();
     }
     CHECK(!_is_prefetching);
-    return _input_stream->get_next(ctx);
+    return _input_stream->get_next(yield_ctx, ctx);
 }
 
-Status BufferedInputStream::prefetch(SerdeContext& ctx) {
+Status BufferedInputStream::prefetch(workgroup::YieldContext& yield_ctx, SerdeContext& ctx) {
     if (is_buffer_full() || eof()) {
         return Status::OK();
     }
@@ -221,7 +227,7 @@ Status BufferedInputStream::prefetch(SerdeContext& ctx) {
     }
     DeferOp defer([this]() { _release(); });
 
-    auto res = _input_stream->get_next(ctx);
+    auto res = _input_stream->get_next(yield_ctx, ctx);
     if (res.ok()) {
         COUNTER_ADD(_spiller->metrics().input_stream_peak_memory_usage, res.value()->memory_usage());
         _chunk_buffer.put(std::move(res.value()));
@@ -239,7 +245,7 @@ public:
             : _input_blocks(std::move(input_blocks)), _serde(std::move(serde)) {}
     ~UnorderedInputStream() override = default;
 
-    StatusOr<ChunkUniquePtr> get_next(SerdeContext& ctx) override;
+    StatusOr<ChunkUniquePtr> get_next(workgroup::YieldContext& yield_ctx, SerdeContext& ctx) override;
 
     bool is_ready() override { return false; }
 
@@ -253,16 +259,25 @@ private:
     DECLARE_RACE_DETECTOR(detect_get_next)
 };
 
-StatusOr<ChunkUniquePtr> UnorderedInputStream::get_next(SerdeContext& ctx) {
+StatusOr<ChunkUniquePtr> UnorderedInputStream::get_next(workgroup::YieldContext& yield_ctx, SerdeContext& ctx) {
     RACE_DETECT(detect_get_next, var1);
     if (_current_idx >= _input_blocks.size()) {
         return Status::EndOfFile("end of reading spilled UnorderedInputStream");
     }
+    auto io_ctx = std::any_cast<SpillIOTaskContextPtr>(yield_ctx.task_context_data);
 
     while (true) {
         if (_current_reader == nullptr) {
             _current_reader = _input_blocks[_current_idx]->get_reader();
         }
+        auto& block = _input_blocks[_current_idx];
+        if (!(block->is_remote() ^ io_ctx->use_local_io_executor)) {
+            TRACE_SPILL_LOG << fmt::format("block[{}], use local[{}], yield", block->debug_string(),
+                                           io_ctx->use_local_io_executor);
+            io_ctx->use_local_io_executor = !block->is_remote();
+            return Status::Yield();
+        }
+
         auto res = _serde->deserialize(ctx, _current_reader.get());
         if (res.status().is_end_of_file()) {
             _input_blocks[_current_idx].reset();
@@ -295,7 +310,7 @@ public:
 
     Status init(SerdePtr serde, const SortExecExprs* sort_exprs, const SortDescs* descs, Spiller* spiller);
 
-    StatusOr<ChunkUniquePtr> get_next(SerdeContext& ctx) override;
+    StatusOr<ChunkUniquePtr> get_next(workgroup::YieldContext& yield_ctx, SerdeContext& ctx) override;
 
     void get_io_stream(std::vector<SpillInputStream*>* io_stream) override {
         for (auto& stream : _input_streams) {
@@ -336,7 +351,8 @@ Status OrderedInputStream::init(SerdePtr serde, const SortExecExprs* sort_exprs,
             }
             // @TODO(silverbullet233): reuse ctx
             SerdeContext ctx;
-            auto res = input_stream->get_next(ctx);
+            workgroup::YieldContext mock_ctx;
+            auto res = input_stream->get_next(mock_ctx, ctx);
             if (!res.status().ok()) {
                 if (!res.status().is_end_of_file()) {
                     _status.update(res.status());
@@ -354,7 +370,7 @@ Status OrderedInputStream::init(SerdePtr serde, const SortExecExprs* sort_exprs,
     return Status::OK();
 }
 
-StatusOr<ChunkUniquePtr> OrderedInputStream::get_next(SerdeContext& ctx) {
+StatusOr<ChunkUniquePtr> OrderedInputStream::get_next(workgroup::YieldContext& yield_ctx, SerdeContext& ctx) {
     ChunkUniquePtr chunk;
     bool should_exit = false;
     std::atomic_bool eos = false;
@@ -370,6 +386,7 @@ StatusOr<ChunkUniquePtr> OrderedInputStream::get_next(SerdeContext& ctx) {
 }
 
 StatusOr<InputStreamPtr> BlockGroup::as_unordered_stream(const SerdePtr& serde, Spiller* spiller) {
+    std::partition(_blocks.begin(), _blocks.end(), [](const BlockPtr& block) { return !block->is_remote(); });
     auto stream = std::make_shared<UnorderedInputStream>(_blocks, serde);
     return std::make_shared<BufferedInputStream>(chunk_buffer_max_size, std::move(stream), spiller);
 }
@@ -379,6 +396,7 @@ StatusOr<InputStreamPtr> BlockGroup::as_ordered_stream(RuntimeState* state, cons
     if (_blocks.empty()) {
         return as_unordered_stream(serde, spiller);
     }
+    std::partition(_blocks.begin(), _blocks.end(), [](const BlockPtr& block) { return !block->is_remote(); });
 
     auto stream = std::make_shared<OrderedInputStream>(_blocks, state);
     RETURN_IF_ERROR(stream->init(serde, sort_exprs, sort_descs, spiller));

--- a/be/src/exec/spill/input_stream.h
+++ b/be/src/exec/spill/input_stream.h
@@ -38,14 +38,16 @@ public:
     SpillInputStream() = default;
     virtual ~SpillInputStream() = default;
 
-    virtual StatusOr<ChunkUniquePtr> get_next(SerdeContext& ctx) = 0;
+    virtual StatusOr<ChunkUniquePtr> get_next(workgroup::YieldContext& yield_ctx, SerdeContext& ctx) = 0;
     virtual bool is_ready() = 0;
     virtual void close() = 0;
 
     virtual void get_io_stream(std::vector<SpillInputStream*>* io_stream) {}
 
     virtual bool enable_prefetch() const { return false; }
-    virtual Status prefetch(SerdeContext& ctx) { return Status::NotSupported("input stream doesn't support prefetch"); }
+    virtual Status prefetch(workgroup::YieldContext& yield_ctx, SerdeContext& ctx) {
+        return Status::NotSupported("input stream doesn't support prefetch");
+    }
 
     void mark_is_eof() { _eof = true; }
 

--- a/be/src/exec/spill/log_block_manager.cpp
+++ b/be/src/exec/spill/log_block_manager.cpp
@@ -257,7 +257,9 @@ StatusOr<BlockPtr> LogBlockManager::acquire_block(const AcquireBlockOptions& opt
 
     ASSIGN_OR_RETURN(auto block_container, get_or_create_container(dir, opts.fragment_instance_id, opts.plan_node_id,
                                                                    opts.name, opts.direct_io));
-    return std::make_shared<LogBlock>(block_container, block_container->size());
+    auto res = std::make_shared<LogBlock>(block_container, block_container->size());
+    res->set_is_remote(dir->is_remote());
+    return res;
 }
 
 Status LogBlockManager::release_block(const BlockPtr& block) {

--- a/be/src/exec/spill/log_block_manager.h
+++ b/be/src/exec/spill/log_block_manager.h
@@ -45,7 +45,7 @@ using LogBlockContainerPtr = std::shared_ptr<LogBlockContainer>;
 // so theoretically, the number of containers being written at the same time will be equivalent to the number of io threads
 class LogBlockManager : public BlockManager {
 public:
-    LogBlockManager(TUniqueId query_id);
+    LogBlockManager(TUniqueId query_id, DirManager* dir_mgr);
     ~LogBlockManager() override;
 
     Status open() override;
@@ -59,8 +59,9 @@ public:
 #endif
 
 private:
-    StatusOr<LogBlockContainerPtr> get_or_create_container(Dir* dir, int32_t plan_node_id,
-                                                           const std::string& plan_node_name, bool direct_io);
+    StatusOr<LogBlockContainerPtr> get_or_create_container(DirPtr dir, TUniqueId fragment_instance_id,
+                                                           int32_t plan_node_id, const std::string& plan_node_name,
+                                                           bool direct_io);
 
 private:
     typedef std::unordered_map<uint64_t, LogBlockContainerPtr> ContainerMap;
@@ -80,9 +81,7 @@ private:
     std::unordered_map<Dir*, std::shared_ptr<PlanNodeContainerMap>> _available_containers;
 
     std::vector<LogBlockContainerPtr> _full_containers;
-#ifdef BE_TEST
     DirManager* _dir_mgr = nullptr;
-#endif
     const static int64_t kDefaultMaxContainerBytes = 10L * 1024 * 1024 * 1024; // 10GB
 };
 } // namespace starrocks::spill

--- a/be/src/exec/spill/options.h
+++ b/be/src/exec/spill/options.h
@@ -20,6 +20,7 @@
 #include "exec/sort_exec_exprs.h"
 #include "exec/sorting/sorting.h"
 #include "exec/spill/block_manager.h"
+#include "exec/workgroup/work_group_fwd.h"
 
 namespace starrocks::spill {
 struct SpilledChunkBuildSchema {
@@ -94,6 +95,7 @@ struct SpilledOptions {
     int encode_level = 0;
 
     BlockManager* block_manager = nullptr;
+    workgroup::WorkGroupPtr wg;
 };
 
 // spill strategy

--- a/be/src/exec/spill/query_spill_manager.cpp
+++ b/be/src/exec/spill/query_spill_manager.cpp
@@ -38,20 +38,16 @@ Status QuerySpillManager::init_block_manager(const TQueryOptions& query_options)
         return Status::OK();
     }
     const auto& remote_storage_paths = query_options.spill_remote_storage_paths;
-    // const auto& remote_storage_conf = query_options.spill_remote_storage_conf;
-    // @TODO we should hold conf
-    LOG(INFO) << "remote storage conf: " << apache::thrift::ThriftDebugString(query_options.spill_remote_storage_conf);
     auto remote_storage_conf = std::make_shared<TCloudConfiguration>(query_options.spill_remote_storage_conf);
     // init remote block manager
     std::vector<std::shared_ptr<Dir>> remote_dirs;
     for (const auto& path : remote_storage_paths) {
         ASSIGN_OR_RETURN(auto fs, FileSystem::CreateUniqueFromString(path, FSOptions(remote_storage_conf.get())));
-        LOG(INFO) << "create fs for remote storage path: " << path << " success";
         RETURN_IF_ERROR(fs->create_dir_if_missing(path));
         auto dir = std::make_shared<Dir>(path, std::move(fs), INT64_MAX);
+        // @TODO make Dir to be a base class
         dir->set_cloud_conf(std::move(remote_storage_conf));
         remote_dirs.emplace_back(dir);
-        // remote_dirs.emplace_back(std::make_shared<Dir>(path, std::move(fs), remote_storage_conf, INT64_MAX));
     }
     _remote_dir_manager = std::make_unique<DirManager>(remote_dirs);
 
@@ -62,14 +58,11 @@ Status QuerySpillManager::init_block_manager(const TQueryOptions& query_options)
         return Status::OK();
     }
 
-    // @TODO hybird block manager, unifty log and file manager together?
     // init block manager
     auto local_block_manager = std::make_unique<LogBlockManager>(_uid, ExecEnv::GetInstance()->spill_dir_mgr());
     auto remote_block_manager = std::make_unique<FileBlockManager>(_uid, _remote_dir_manager.get());
     _block_manager =
             std::make_unique<HyBirdBlockManager>(_uid, std::move(local_block_manager), std::move(remote_block_manager));
-    // _block_manager = std::make_unique<FileBlockManager>(_uid, _remote_dir_manager.get());
-    // _block_manager = std::make_unique<LogBlockManager>(_uid);
 
     return Status::OK();
 }

--- a/be/src/exec/spill/query_spill_manager.cpp
+++ b/be/src/exec/spill/query_spill_manager.cpp
@@ -1,0 +1,76 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "exec/spill/query_spill_manager.h"
+
+#include <memory>
+
+#include "exec/spill/dir_manager.h"
+#include "exec/spill/file_block_manager.h"
+#include "exec/spill/hybird_block_manager.h"
+#include "exec/spill/log_block_manager.h"
+#include "runtime/exec_env.h"
+
+namespace starrocks::spill {
+
+Status QuerySpillManager::init_block_manager(const TQueryOptions& query_options) {
+    bool enable_spill_to_remote_storage =
+            query_options.__isset.enable_spill_to_remote_storage && query_options.enable_spill_to_remote_storage;
+    if (!enable_spill_to_remote_storage) {
+        _block_manager = std::make_unique<LogBlockManager>(_uid, ExecEnv::GetInstance()->spill_dir_mgr());
+        return Status::OK();
+    }
+    if (!query_options.__isset.spill_remote_storage_paths || !query_options.__isset.spill_remote_storage_conf) {
+        DCHECK(false) << "enable spill_to_remote_storage but spill_remote_storage_paths or spill_remote_storage_conf "
+                         "is not set";
+        _block_manager = std::make_unique<LogBlockManager>(_uid, ExecEnv::GetInstance()->spill_dir_mgr());
+        return Status::OK();
+    }
+    const auto& remote_storage_paths = query_options.spill_remote_storage_paths;
+    // const auto& remote_storage_conf = query_options.spill_remote_storage_conf;
+    // @TODO we should hold conf
+    LOG(INFO) << "remote storage conf: " << apache::thrift::ThriftDebugString(query_options.spill_remote_storage_conf);
+    auto remote_storage_conf = std::make_shared<TCloudConfiguration>(query_options.spill_remote_storage_conf);
+    // init remote block manager
+    std::vector<std::shared_ptr<Dir>> remote_dirs;
+    for (const auto& path : remote_storage_paths) {
+        ASSIGN_OR_RETURN(auto fs, FileSystem::CreateUniqueFromString(path, FSOptions(remote_storage_conf.get())));
+        LOG(INFO) << "create fs for remote storage path: " << path << " success";
+        RETURN_IF_ERROR(fs->create_dir_if_missing(path));
+        auto dir = std::make_shared<Dir>(path, std::move(fs), INT64_MAX);
+        dir->set_cloud_conf(std::move(remote_storage_conf));
+        remote_dirs.emplace_back(dir);
+        // remote_dirs.emplace_back(std::make_shared<Dir>(path, std::move(fs), remote_storage_conf, INT64_MAX));
+    }
+    _remote_dir_manager = std::make_unique<DirManager>(remote_dirs);
+
+    bool disable_spill_to_local_disk =
+            query_options.__isset.disable_spill_to_local_disk && query_options.disable_spill_to_local_disk;
+    if (disable_spill_to_local_disk) {
+        _block_manager = std::make_unique<FileBlockManager>(_uid, _remote_dir_manager.get());
+        return Status::OK();
+    }
+
+    // @TODO hybird block manager, unifty log and file manager together?
+    // init block manager
+    auto local_block_manager = std::make_unique<LogBlockManager>(_uid, ExecEnv::GetInstance()->spill_dir_mgr());
+    auto remote_block_manager = std::make_unique<FileBlockManager>(_uid, _remote_dir_manager.get());
+    _block_manager =
+            std::make_unique<HyBirdBlockManager>(_uid, std::move(local_block_manager), std::move(remote_block_manager));
+    // _block_manager = std::make_unique<FileBlockManager>(_uid, _remote_dir_manager.get());
+    // _block_manager = std::make_unique<LogBlockManager>(_uid);
+
+    return Status::OK();
+}
+} // namespace starrocks::spill

--- a/be/src/exec/spill/query_spill_manager.cpp
+++ b/be/src/exec/spill/query_spill_manager.cpp
@@ -14,6 +14,7 @@
 
 #include "exec/spill/query_spill_manager.h"
 
+#include <cstdint>
 #include <memory>
 
 #include "exec/spill/dir_manager.h"
@@ -44,9 +45,7 @@ Status QuerySpillManager::init_block_manager(const TQueryOptions& query_options)
     for (const auto& path : remote_storage_paths) {
         ASSIGN_OR_RETURN(auto fs, FileSystem::CreateUniqueFromString(path, FSOptions(remote_storage_conf.get())));
         RETURN_IF_ERROR(fs->create_dir_if_missing(path));
-        auto dir = std::make_shared<Dir>(path, std::move(fs), INT64_MAX);
-        // @TODO make Dir to be a base class
-        dir->set_cloud_conf(std::move(remote_storage_conf));
+        auto dir = std::make_shared<RemoteDir>(path, std::move(fs), remote_storage_conf, INT64_MAX);
         remote_dirs.emplace_back(dir);
     }
     _remote_dir_manager = std::make_unique<DirManager>(remote_dirs);

--- a/be/src/exec/spill/query_spill_manager.h
+++ b/be/src/exec/spill/query_spill_manager.h
@@ -27,7 +27,11 @@
 namespace starrocks::spill {
 class QuerySpillManager {
 public:
-    QuerySpillManager(const TUniqueId& uid) : _uid(uid) { _block_manager = std::make_unique<LogBlockManager>(uid); }
+    QuerySpillManager(const TUniqueId& uid) : _uid(uid) {
+        // _block_manager = std::make_unique<LogBlockManager>(uid);
+    }
+
+    Status init_block_manager(const TQueryOptions& query_options);
 
     void increase_spilling_operators() { _spilling_operators++; }
     void decrease_spilling_operators() { _spilling_operators--; }
@@ -42,6 +46,7 @@ public:
 private:
     TUniqueId _uid;
     std::unique_ptr<BlockManager> _block_manager;
+    std::unique_ptr<DirManager> _remote_dir_manager;
     std::atomic_size_t _spilling_operators = 0;
     size_t _spillable_operators = 0;
 };

--- a/be/src/exec/spill/query_spill_manager.h
+++ b/be/src/exec/spill/query_spill_manager.h
@@ -27,9 +27,7 @@
 namespace starrocks::spill {
 class QuerySpillManager {
 public:
-    QuerySpillManager(const TUniqueId& uid) : _uid(uid) {
-        // _block_manager = std::make_unique<LogBlockManager>(uid);
-    }
+    QuerySpillManager(const TUniqueId& uid) : _uid(uid) {}
 
     Status init_block_manager(const TQueryOptions& query_options);
 

--- a/be/src/exec/spill/spill_components.cpp
+++ b/be/src/exec/spill/spill_components.cpp
@@ -430,7 +430,7 @@ Status PartitionedSpillerWriter::spill_partition(workgroup::YieldContext& yield_
     auto block = partition->spill_writer->block();
     auto io_ctx = std::any_cast<PartitionedFlushContextPtr>(yield_ctx.task_context_data);
     if (!(block->is_remote() ^ io_ctx->use_local_io_executor)) {
-        LOG(INFO) << fmt::format("block[{}], use_local[{}], yield", block->debug_string(),
+        LOG(INFO) << fmt::format("block[{}], use_local_io_executor[{}], should yield", block->debug_string(),
                                  io_ctx->use_local_io_executor);
         io_ctx->use_local_io_executor = !block->is_remote();
         yield_ctx.need_yield = true;

--- a/be/src/exec/spill/spill_components.cpp
+++ b/be/src/exec/spill/spill_components.cpp
@@ -430,8 +430,8 @@ Status PartitionedSpillerWriter::spill_partition(workgroup::YieldContext& yield_
     auto block = partition->spill_writer->block();
     auto io_ctx = std::any_cast<PartitionedFlushContextPtr>(yield_ctx.task_context_data);
     if (!(block->is_remote() ^ io_ctx->use_local_io_executor)) {
-        LOG(INFO) << fmt::format("block[{}], use_local_io_executor[{}], should yield", block->debug_string(),
-                                 io_ctx->use_local_io_executor);
+        TRACE_SPILL_LOG << fmt::format("block[{}], use_local_io_executor[{}], should yield", block->debug_string(),
+                                       io_ctx->use_local_io_executor);
         io_ctx->use_local_io_executor = !block->is_remote();
         yield_ctx.need_yield = true;
         return Status::OK();

--- a/be/src/exec/spill/spill_components.cpp
+++ b/be/src/exec/spill/spill_components.cpp
@@ -631,11 +631,11 @@ Status PartitionedSpillerWriter::_split_partition(workgroup::YieldContext& yield
         while (true) {
             {
                 SCOPED_RAW_TIMER(&yield_ctx.time_spent_ns);
-                RETURN_IF_ERROR(reader->trigger_restore(_runtime_state, SyncTaskExecutor{}, EmptyMemGuard{}));
+                RETURN_IF_ERROR(reader->trigger_restore<SyncTaskExecutor>(_runtime_state, EmptyMemGuard{}));
                 if (!reader->has_output_data()) {
                     break;
                 }
-                ASSIGN_OR_RETURN(auto chunk, reader->restore(_runtime_state, SyncTaskExecutor{}, EmptyMemGuard{}));
+                ASSIGN_OR_RETURN(auto chunk, reader->restore<SyncTaskExecutor>(_runtime_state, EmptyMemGuard{}));
                 if (chunk->is_empty()) {
                     continue;
                 }

--- a/be/src/exec/spill/spill_components.h
+++ b/be/src/exec/spill/spill_components.h
@@ -179,7 +179,7 @@ public:
     Status yieldable_flush_task(workgroup::YieldContext& ctx, RuntimeState* state, const MemTablePtr& mem_table);
 
 public:
-    struct FlushContext {
+    struct FlushContext : public SpillIOTaskContext {
         BlockPtr block;
     };
     using FlushContextPtr = std::shared_ptr<FlushContext>;
@@ -298,7 +298,7 @@ public:
     int64_t mem_consumption() const { return _mem_tracker->consumption(); }
 
 public:
-    struct PartitionedFlushContext {
+    struct PartitionedFlushContext : public SpillIOTaskContext {
         // used in spill stage
         struct SpillStageContext {
             size_t processing_idx{};

--- a/be/src/exec/spill/spill_components.h
+++ b/be/src/exec/spill/spill_components.h
@@ -49,11 +49,11 @@ public:
         _stream = std::move(stream);
     }
 
-    template <class TaskExecutor, class MemGuard>
-    StatusOr<ChunkPtr> restore(RuntimeState* state, TaskExecutor&& executor, MemGuard&& guard);
+    template <class TaskExecutor = spill::IOTaskExecutor, class MemGuard>
+    StatusOr<ChunkPtr> restore(RuntimeState* state, MemGuard&& guard);
 
-    template <class TaskExecutor, class MemGuard>
-    [[nodiscard]] Status trigger_restore(RuntimeState* state, TaskExecutor&& executor, MemGuard&& guard);
+    template <class TaskExecutor = spill::IOTaskExecutor, class MemGuard>
+    Status trigger_restore(RuntimeState* state, MemGuard&& guard);
 
     bool has_output_data() { return _stream && _stream->is_ready(); }
 
@@ -147,10 +147,10 @@ public:
     }
 
     template <class TaskExecutor, class MemGuard>
-    Status spill(RuntimeState* state, const ChunkPtr& chunk, TaskExecutor&& executor, MemGuard&& guard);
+    Status spill(RuntimeState* state, const ChunkPtr& chunk, MemGuard&& guard);
 
     template <class TaskExecutor, class MemGuard>
-    Status flush(RuntimeState* state, TaskExecutor&& executor, MemGuard&& guard);
+    Status flush(RuntimeState* state, MemGuard&& guard);
 
     void prepare(RuntimeState* state) override;
 
@@ -241,13 +241,13 @@ public:
     }
 
     template <class TaskExecutor, class MemGuard>
-    Status spill(RuntimeState* state, const ChunkPtr& chunk, TaskExecutor&& executor, MemGuard&& guard);
+    Status spill(RuntimeState* state, const ChunkPtr& chunk, MemGuard&& guard);
 
     template <class TaskExecutor, class MemGuard>
-    Status flush(RuntimeState* state, bool is_final_flush, TaskExecutor&& executor, MemGuard&& guard);
+    Status flush(RuntimeState* state, bool is_final_flush, MemGuard&& guard);
 
     template <class TaskExecutor, class MemGuard>
-    Status flush_if_full(RuntimeState* state, TaskExecutor&& executor, MemGuard&& guard);
+    Status flush_if_full(RuntimeState* state, MemGuard&& guard);
 
     void get_spill_partitions(std::vector<const SpillPartitionInfo*>* partitions) override;
 

--- a/be/src/exec/spill/spiller.cpp
+++ b/be/src/exec/spill/spiller.cpp
@@ -105,7 +105,9 @@ SpillProcessMetrics::SpillProcessMetrics(RuntimeProfile* profile, std::atomic_in
 
 Status Spiller::prepare(RuntimeState* state) {
     _chunk_builder.chunk_schema() = std::make_shared<SpilledChunkBuildSchema>();
+#ifndef BE_TEST
     DCHECK(_opts.wg != nullptr) << "workgroup must be set";
+#endif
 
     ASSIGN_OR_RETURN(_serde, Serde::create_serde(this));
 

--- a/be/src/exec/spill/spiller.h
+++ b/be/src/exec/spill/spiller.h
@@ -58,16 +58,24 @@ public:
     RuntimeProfile::Counter* flush_timer = nullptr;
     // disk io time during flush
     RuntimeProfile::Counter* write_io_timer = nullptr;
+    RuntimeProfile::Counter* local_write_io_timer = nullptr;
+    RuntimeProfile::Counter* remote_write_io_timer = nullptr;
     // time spent to restore data from Spiller, which includes the time to try to get data from buffer and drive the next prefetch
     RuntimeProfile::Counter* restore_from_buffer_timer = nullptr;
     // disk io time during restore
     RuntimeProfile::Counter* read_io_timer = nullptr;
+    RuntimeProfile::Counter* local_read_io_timer = nullptr;
+    RuntimeProfile::Counter* remote_read_io_timer = nullptr;
     // the number of rows restored from Spiller
     RuntimeProfile::Counter* restore_rows = nullptr;
     // data bytes flushed to disk
     RuntimeProfile::Counter* flush_bytes = nullptr;
+    RuntimeProfile::Counter* local_flush_bytes = nullptr;
+    RuntimeProfile::Counter* remote_flush_bytes = nullptr;
     // data bytes restored from disk
     RuntimeProfile::Counter* restore_bytes = nullptr;
+    RuntimeProfile::Counter* local_restore_bytes = nullptr;
+    RuntimeProfile::Counter* remote_restore_bytes = nullptr;
     // time spent to serialize data before flush it to disk
     RuntimeProfile::Counter* serialize_timer = nullptr;
     // time spent to deserialize data after read it from disk
@@ -94,6 +102,8 @@ public:
 
     // the number of blocks created
     RuntimeProfile::Counter* block_count = nullptr;
+    RuntimeProfile::Counter* local_block_count = nullptr;
+    RuntimeProfile::Counter* remote_block_count = nullptr;
     // flush/restore task count
     RuntimeProfile::Counter* flush_io_task_count = nullptr;
     RuntimeProfile::HighWaterMarkCounter* peak_flush_io_task_count = nullptr;

--- a/be/src/exec/spill/spiller.hpp
+++ b/be/src/exec/spill/spiller.hpp
@@ -28,13 +28,14 @@
 #include "exec/spill/serde.h"
 #include "exec/spill/spill_components.h"
 #include "exec/spill/spiller.h"
+#include "exec/workgroup/work_group_fwd.h"
 #include "storage/chunk_helper.h"
 #include "util/defer_op.h"
 #include "util/runtime_profile.h"
 
 namespace starrocks::spill {
 template <class TaskExecutor, class MemGuard>
-Status Spiller::spill(RuntimeState* state, const ChunkPtr& chunk, TaskExecutor&& executor, MemGuard&& guard) {
+Status Spiller::spill(RuntimeState* state, const ChunkPtr& chunk, MemGuard&& guard) {
     SCOPED_TIMER(_metrics.append_data_timer);
     RETURN_IF_ERROR(task_status());
     DCHECK(!chunk->is_empty());
@@ -51,15 +52,15 @@ Status Spiller::spill(RuntimeState* state, const ChunkPtr& chunk, TaskExecutor&&
     }
 
     if (_opts.init_partition_nums > 0) {
-        return _writer->as<PartitionedSpillerWriter*>()->spill(state, chunk, executor, guard);
+        return _writer->as<PartitionedSpillerWriter*>()->spill<TaskExecutor>(state, chunk, guard);
     } else {
-        return _writer->as<RawSpillerWriter*>()->spill(state, chunk, executor, guard);
+        return _writer->as<RawSpillerWriter*>()->spill<TaskExecutor>(state, chunk, guard);
     }
 }
 
-template <class Processer, class TaskExecutor, class MemGuard>
+template <class TaskExecutor, class Processer, class MemGuard>
 Status Spiller::partitioned_spill(RuntimeState* state, const ChunkPtr& chunk, SpillHashColumn* hash_column,
-                                  Processer&& processer, TaskExecutor&& executor, MemGuard&& guard) {
+                                  Processer&& processer, MemGuard&& guard) {
     SCOPED_TIMER(_metrics.append_data_timer);
     RETURN_IF_ERROR(task_status());
     DCHECK(!chunk->is_empty());
@@ -79,39 +80,39 @@ Status Spiller::partitioned_spill(RuntimeState* state, const ChunkPtr& chunk, Sp
         writer->process_partition_data(chunk, indexs, std::forward<Processer>(processer));
     }
     COUNTER_SET(_metrics.partition_writer_peak_memory_usage, writer->mem_consumption());
-    RETURN_IF_ERROR(writer->flush_if_full(state, executor, guard));
+    RETURN_IF_ERROR(writer->flush_if_full<TaskExecutor>(state, guard));
     return Status::OK();
 }
 
 template <class TaskExecutor, class MemGuard>
-Status Spiller::flush(RuntimeState* state, TaskExecutor&& executor, MemGuard&& guard) {
+Status Spiller::flush(RuntimeState* state, MemGuard&& guard) {
     RETURN_IF_ERROR(task_status());
     if (_opts.init_partition_nums > 0) {
-        return _writer->as<PartitionedSpillerWriter*>()->flush(state, true, executor, guard);
+        return _writer->as<PartitionedSpillerWriter*>()->flush<TaskExecutor>(state, true, guard);
     } else {
-        return _writer->as<RawSpillerWriter*>()->flush(state, executor, guard);
+        return _writer->as<RawSpillerWriter*>()->flush<TaskExecutor>(state, guard);
     }
 }
 
 template <class TaskExecutor, class MemGuard>
-StatusOr<ChunkPtr> Spiller::restore(RuntimeState* state, TaskExecutor&& executor, MemGuard&& guard) {
+StatusOr<ChunkPtr> Spiller::restore(RuntimeState* state, MemGuard&& guard) {
     RETURN_IF_ERROR(task_status());
 
-    ASSIGN_OR_RETURN(auto chunk, _reader->restore(state, executor, guard));
+    ASSIGN_OR_RETURN(auto chunk, _reader->restore<TaskExecutor>(state, guard));
     chunk->check_or_die();
     _restore_read_rows += chunk->num_rows();
 
-    RETURN_IF_ERROR(trigger_restore(state, std::forward<TaskExecutor>(executor), std::forward<MemGuard>(guard)));
+    RETURN_IF_ERROR(trigger_restore<TaskExecutor>(state, std::forward<MemGuard>(guard)));
     return chunk;
 }
 
 template <class TaskExecutor, class MemGuard>
-Status Spiller::trigger_restore(RuntimeState* state, TaskExecutor&& executor, MemGuard&& guard) {
-    return _reader->trigger_restore(state, executor, guard);
+Status Spiller::trigger_restore(RuntimeState* state, MemGuard&& guard) {
+    return _reader->trigger_restore<TaskExecutor>(state, guard);
 }
 
 template <class TaskExecutor, class MemGuard>
-Status RawSpillerWriter::spill(RuntimeState* state, const ChunkPtr& chunk, TaskExecutor&& executor, MemGuard&& guard) {
+Status RawSpillerWriter::spill(RuntimeState* state, const ChunkPtr& chunk, MemGuard&& guard) {
     if (_mem_table == nullptr) {
         _mem_table = _acquire_mem_table_from_pool();
         DCHECK(_mem_table != nullptr);
@@ -120,14 +121,14 @@ Status RawSpillerWriter::spill(RuntimeState* state, const ChunkPtr& chunk, TaskE
     RETURN_IF_ERROR(_mem_table->append(chunk));
 
     if (_mem_table->is_full()) {
-        return flush(state, std::forward<TaskExecutor>(executor), std::forward<MemGuard>(guard));
+        return flush<TaskExecutor>(state, std::forward<MemGuard>(guard));
     }
 
     return Status::OK();
 }
 
 template <class TaskExecutor, class MemGuard>
-Status RawSpillerWriter::flush(RuntimeState* state, TaskExecutor&& executor, MemGuard&& guard) {
+Status RawSpillerWriter::flush(RuntimeState* state, MemGuard&& guard) {
     MemTablePtr captured_mem_table;
     {
         std::lock_guard l(_mutex);
@@ -186,20 +187,21 @@ Status RawSpillerWriter::flush(RuntimeState* state, TaskExecutor&& executor, Mem
 
         return Status::OK();
     };
-    auto yield_func = [&](workgroup::ScanTask&& task) { executor.force_submit(std::move(task)); };
+
+    auto yield_func = [&](workgroup::ScanTask&& task) { TaskExecutor::force_submit(std::move(task)); };
     auto io_task = workgroup::ScanTask(_spiller->options().wg.get(), std::move(task), std::move(yield_func));
-    RETURN_IF_ERROR(executor.submit(std::move(io_task)));
+    RETURN_IF_ERROR(TaskExecutor::submit(std::move(io_task)));
     COUNTER_UPDATE(_spiller->metrics().flush_io_task_count, 1);
     COUNTER_SET(_spiller->metrics().peak_flush_io_task_count, _running_flush_tasks);
     return Status::OK();
 }
 
 template <class TaskExecutor, class MemGuard>
-StatusOr<ChunkPtr> SpillerReader::restore(RuntimeState* state, TaskExecutor&& executor, MemGuard&& guard) {
+StatusOr<ChunkPtr> SpillerReader::restore(RuntimeState* state, MemGuard&& guard) {
     SCOPED_TIMER(_spiller->metrics().restore_from_buffer_timer);
     workgroup::YieldContext mock_ctx;
     ASSIGN_OR_RETURN(auto chunk, _stream->get_next(mock_ctx, _spill_read_ctx));
-    RETURN_IF_ERROR(trigger_restore(state, std::forward<TaskExecutor>(executor), std::forward<MemGuard>(guard)));
+    RETURN_IF_ERROR(trigger_restore<TaskExecutor>(state, std::forward<MemGuard>(guard)));
     _read_rows += chunk->num_rows();
     COUNTER_UPDATE(_spiller->metrics().restore_rows, chunk->num_rows());
     TRACE_SPILL_LOG << "restore rows: " << chunk->num_rows() << ", total restored: " << _read_rows << ", " << this;
@@ -207,7 +209,7 @@ StatusOr<ChunkPtr> SpillerReader::restore(RuntimeState* state, TaskExecutor&& ex
 }
 
 template <class TaskExecutor, class MemGuard>
-Status SpillerReader::trigger_restore(RuntimeState* state, TaskExecutor&& executor, MemGuard&& guard) {
+Status SpillerReader::trigger_restore(RuntimeState* state, MemGuard&& guard) {
     if (_stream == nullptr) {
         return Status::OK();
     }
@@ -253,11 +255,11 @@ Status SpillerReader::trigger_restore(RuntimeState* state, TaskExecutor&& execut
         };
         auto yield_func = [&](workgroup::ScanTask&& task) {
             auto ctx = std::any_cast<SpillIOTaskContextPtr>(task.get_work_context().task_context_data);
-            executor.force_submit(std::move(task));
+            TaskExecutor::force_submit(std::move(task));
         };
         auto io_task =
                 workgroup::ScanTask(_spiller->options().wg.get(), std::move(restore_task), std::move(yield_func));
-        RETURN_IF_ERROR(executor.submit(std::move(io_task)));
+        RETURN_IF_ERROR(TaskExecutor::submit(std::move(io_task)));
         COUNTER_UPDATE(_spiller->metrics().restore_io_task_count, 1);
         COUNTER_SET(_spiller->metrics().peak_flush_io_task_count, _running_restore_tasks);
     }
@@ -265,8 +267,7 @@ Status SpillerReader::trigger_restore(RuntimeState* state, TaskExecutor&& execut
 }
 
 template <class TaskExecutor, class MemGuard>
-Status PartitionedSpillerWriter::spill(RuntimeState* state, const ChunkPtr& chunk, TaskExecutor&& executor,
-                                       MemGuard&& guard) {
+Status PartitionedSpillerWriter::spill(RuntimeState* state, const ChunkPtr& chunk, MemGuard&& guard) {
     DCHECK(!chunk->is_empty());
     DCHECK(!is_full());
 
@@ -289,22 +290,21 @@ Status PartitionedSpillerWriter::spill(RuntimeState* state, const ChunkPtr& chun
 
     DCHECK_EQ(_spiller->spilled_append_rows(), _partition_rows());
 
-    RETURN_IF_ERROR(flush_if_full(state, executor, guard));
+    RETURN_IF_ERROR(flush_if_full<TaskExecutor>(state, guard));
 
     return Status::OK();
 }
 
 template <class TaskExecutor, class MemGuard>
-Status PartitionedSpillerWriter::flush_if_full(RuntimeState* state, TaskExecutor&& executor, MemGuard&& guard) {
+Status PartitionedSpillerWriter::flush_if_full(RuntimeState* state, MemGuard&& guard) {
     if (_mem_tracker->consumption() > options().spill_mem_table_bytes_size) {
-        return flush(state, false, executor, guard);
+        return flush<TaskExecutor>(state, false, guard);
     }
     return Status::OK();
 }
 
 template <class TaskExecutor, class MemGuard>
-Status PartitionedSpillerWriter::flush(RuntimeState* state, bool is_final_flush, TaskExecutor&& executor,
-                                       MemGuard&& guard) {
+Status PartitionedSpillerWriter::flush(RuntimeState* state, bool is_final_flush, MemGuard&& guard) {
     std::vector<SpilledPartition*> splitting_partitions, spilling_partitions;
     RETURN_IF_ERROR(_choose_partitions_to_flush(is_final_flush, splitting_partitions, spilling_partitions));
 
@@ -348,9 +348,9 @@ Status PartitionedSpillerWriter::flush(RuntimeState* state, bool is_final_flush,
         }
         return Status::OK();
     };
-    auto yield_func = [&](workgroup::ScanTask&& task) { executor.force_submit(std::move(task)); };
+    auto yield_func = [&](workgroup::ScanTask&& task) { TaskExecutor::force_submit(std::move(task)); };
     auto io_task = workgroup::ScanTask(_spiller->options().wg.get(), std::move(task), std::move(yield_func));
-    RETURN_IF_ERROR(executor.submit(std::move(io_task)));
+    RETURN_IF_ERROR(TaskExecutor::submit(std::move(io_task)));
     COUNTER_UPDATE(_spiller->metrics().flush_io_task_count, 1);
     COUNTER_SET(_spiller->metrics().peak_flush_io_task_count, _running_flush_tasks);
 

--- a/be/src/exec/spillable_chunks_sorter_full_sort.cpp
+++ b/be/src/exec/spillable_chunks_sorter_full_sort.cpp
@@ -36,7 +36,7 @@ Status SpillableChunksSorterFullSort::update(RuntimeState* state, const ChunkPtr
     bool first_time_spill = _spiller->spilled_append_rows() == 0;
     CHECK(!_spill_channel->has_task());
 
-    RETURN_IF_ERROR(_spiller->spill(state, chunk, io_executor(), TRACKER_WITH_SPILLER_GUARD(state, _spiller)));
+    RETURN_IF_ERROR(_spiller->spill(state, chunk, TRACKER_WITH_SPILLER_GUARD(state, _spiller)));
 
     if (first_time_spill) {
         auto process_task = _spill_process_task();
@@ -44,8 +44,8 @@ Status SpillableChunksSorterFullSort::update(RuntimeState* state, const ChunkPtr
             auto chunk_st = process_task();
             if (chunk_st.ok()) {
                 if (!chunk_st.value()->is_empty()) {
-                    RETURN_IF_ERROR(_spiller->spill(state, chunk_st.value(), io_executor(),
-                                                    TRACKER_WITH_SPILLER_GUARD(state, _spiller)));
+                    RETURN_IF_ERROR(
+                            _spiller->spill(state, chunk_st.value(), TRACKER_WITH_SPILLER_GUARD(state, _spiller)));
                 }
             } else if (chunk_st.status().is_end_of_file()) {
                 return Status::OK();
@@ -66,14 +66,14 @@ Status SpillableChunksSorterFullSort::do_done(RuntimeState* state) {
 
     if (_sorted_chunks.empty() && _unsorted_chunk == nullptr && _staging_unsorted_chunks.empty()) {
         // force flush
-        RETURN_IF_ERROR(_spiller->flush(state, io_executor(), TRACKER_WITH_SPILLER_GUARD(state, _spiller)));
+        RETURN_IF_ERROR(_spiller->flush(state, TRACKER_WITH_SPILLER_GUARD(state, _spiller)));
     } else {
         // TODO: avoid sort multi times
         // spill sorted chunks
         auto spill_process_task = _spill_process_task();
         _spill_channel->add_spill_task({std::move(spill_process_task)});
         std::function<StatusOr<ChunkPtr>()> flush_task = [this, state]() -> StatusOr<ChunkPtr> {
-            RETURN_IF_ERROR(_spiller->flush(state, io_executor(), TRACKER_WITH_SPILLER_GUARD(state, _spiller)));
+            RETURN_IF_ERROR(_spiller->flush(state, TRACKER_WITH_SPILLER_GUARD(state, _spiller)));
             return Status::EndOfFile("eos");
         };
         _spill_channel->add_spill_task({std::move(flush_task)});
@@ -158,7 +158,7 @@ std::function<StatusOr<ChunkPtr>()> SpillableChunksSorterFullSort::_spill_proces
 }
 
 Status SpillableChunksSorterFullSort::_get_result_from_spiller(ChunkPtr* chunk, bool* eos) {
-    auto chunk_st = _spiller->restore(_state, io_executor(), TRACKER_WITH_SPILLER_GUARD(_state, _spiller));
+    auto chunk_st = _spiller->restore(_state, TRACKER_WITH_SPILLER_GUARD(_state, _spiller));
     if (chunk_st.status().is_end_of_file()) {
         *eos = true;
     }

--- a/be/src/exec/topn_node.cpp
+++ b/be/src/exec/topn_node.cpp
@@ -291,10 +291,7 @@ std::vector<std::shared_ptr<pipeline::OperatorFactory>> TopNNode::_decompose_to_
     // TODO: avoid create spill channel when when disable spill
 
     auto workgroup = context->fragment_context()->workgroup();
-    auto executor = std::make_shared<spill::IOTaskExecutor>(
-            ExecEnv::GetInstance()->scan_executor(), ExecEnv::GetInstance()->connector_scan_executor(), workgroup);
-    auto spill_channel_factory =
-            std::make_shared<SpillProcessChannelFactory>(degree_of_parallelism, std::move(executor));
+    auto spill_channel_factory = std::make_shared<SpillProcessChannelFactory>(degree_of_parallelism);
 
     // spill process operator
     if (runtime_state()->enable_spill() && runtime_state()->enable_sort_spill() && _limit < 0 && !is_partition_topn) {

--- a/be/src/exec/topn_node.cpp
+++ b/be/src/exec/topn_node.cpp
@@ -291,7 +291,8 @@ std::vector<std::shared_ptr<pipeline::OperatorFactory>> TopNNode::_decompose_to_
     // TODO: avoid create spill channel when when disable spill
 
     auto workgroup = context->fragment_context()->workgroup();
-    auto executor = std::make_shared<spill::IOTaskExecutor>(ExecEnv::GetInstance()->scan_executor(), workgroup);
+    auto executor = std::make_shared<spill::IOTaskExecutor>(
+            ExecEnv::GetInstance()->scan_executor(), ExecEnv::GetInstance()->connector_scan_executor(), workgroup);
     auto spill_channel_factory =
             std::make_shared<SpillProcessChannelFactory>(degree_of_parallelism, std::move(executor));
 

--- a/be/src/exec/workgroup/scan_executor.cpp
+++ b/be/src/exec/workgroup/scan_executor.cpp
@@ -89,4 +89,8 @@ bool ScanExecutor::submit(ScanTask task) {
     return _task_queue->try_offer(std::move(task));
 }
 
+void ScanExecutor::force_submit(ScanTask task) {
+    _task_queue->force_put(std::move(task));
+}
+
 } // namespace starrocks::workgroup

--- a/be/src/exec/workgroup/scan_executor.h
+++ b/be/src/exec/workgroup/scan_executor.h
@@ -37,6 +37,8 @@ public:
 
     bool submit(ScanTask task);
 
+    void force_submit(ScanTask task);
+
 private:
     void worker_thread();
 

--- a/be/src/exec/workgroup/scan_task_queue.h
+++ b/be/src/exec/workgroup/scan_task_queue.h
@@ -53,7 +53,6 @@ struct YieldContext {
         task_context_data.reset();
     }
 
-    // @TODO
     std::any task_context_data;
     size_t yield_point{};
     size_t total_yield_point_cnt{};

--- a/be/test/io/spill_test.cpp
+++ b/be/test/io/spill_test.cpp
@@ -17,6 +17,7 @@
 #include <algorithm>
 #include <chrono>
 #include <filesystem>
+#include <future>
 #include <iterator>
 #include <memory>
 #include <thread>
@@ -52,6 +53,7 @@
 #include "gen_cpp/Types_types.h"
 #include "runtime/mem_tracker.h"
 #include "runtime/runtime_state.h"
+#include "storage/olap_define.h"
 #include "testutil/assert.h"
 #include "types/logical_type.h"
 #include "util/defer_op.h"
@@ -144,36 +146,27 @@ public:
 };
 
 struct SyncExecutor {
-    Status submit(workgroup::ScanTask task) {
+    static Status submit(workgroup::ScanTask task) {
         do {
             task.run();
         } while (!task.is_finished());
         return Status::OK();
     }
-    void force_submit(workgroup::ScanTask task) { (void)submit(std::move(task)); }
+    static void force_submit(workgroup::ScanTask task) { (void)submit(std::move(task)); }
 };
 
 struct ASyncExecutor {
     using ExecFunction = std::function<void(workgroup::YieldContext&)>;
 
-    Status submit(workgroup::ScanTask task) {
-        _threads.emplace_back([task = std::move(task)]() mutable {
+    static Status submit(workgroup::ScanTask task) {
+        (void)std::async([task = std::move(task)]() mutable {
             do {
                 task.run();
             } while (!task.is_finished());
         });
         return Status::OK();
     }
-    void force_submit(workgroup::ScanTask task) { (void)submit(std::move(task)); }
-    ~ASyncExecutor() {
-        for (auto& thread : _threads) {
-            thread.join();
-        }
-    }
-
-private:
-    std::vector<std::unique_ptr<workgroup::YieldContext>> _ctxs;
-    std::vector<std::thread> _threads;
+    static void force_submit(workgroup::ScanTask task) { (void)submit(std::move(task)); }
 };
 
 using SpillProcessMetrics = spill::SpillProcessMetrics;
@@ -245,33 +238,32 @@ struct SpillerCaller {
     SpillerCaller(spill::Spiller* spiller) : _spiller(spiller) {}
 
     template <class TaskExecutor, class MemGuard>
-    Status spill(RuntimeState* state, const ChunkPtr& chunk, TaskExecutor&& executor, MemGuard&& guard) {
+    Status spill(RuntimeState* state, const ChunkPtr& chunk, MemGuard&& guard) {
         if (_spiller->_chunk_builder.chunk_schema()->empty()) {
             _spiller->_chunk_builder.chunk_schema()->set_schema(chunk);
         }
-        return _spiller->_writer->as<Writer>()->spill(state, chunk, std::forward<TaskExecutor>(executor),
-                                                      std::forward<MemGuard>(guard));
+        auto writer = _spiller->_writer->as<Writer>();
+        return writer->template spill<TaskExecutor>(state, chunk, std::forward<MemGuard>(guard));
     }
 
     template <class TaskExecutor, class MemGuard>
-    Status flush(RuntimeState* state, TaskExecutor&& executor, MemGuard&& guard) {
-        return _spiller->_writer->as<Writer>()->flush(state, std::forward<TaskExecutor>(executor),
-                                                      std::forward<MemGuard>(guard));
+    Status flush(RuntimeState* state, MemGuard&& guard) {
+        auto writer = _spiller->_writer->as<Writer>();
+        return writer->template flush<TaskExecutor>(state, std::forward<MemGuard>(guard));
     }
 
     template <class TaskExecutor, class MemGuard>
-    StatusOr<ChunkPtr> restore(RuntimeState* state, TaskExecutor&& executor, MemGuard&& guard) {
-        return _spiller->_reader->restore(state, std::forward<TaskExecutor>(executor), std::forward<MemGuard>(guard));
+    StatusOr<ChunkPtr> restore(RuntimeState* state, MemGuard&& guard) {
+        return _spiller->_reader->restore<TaskExecutor>(state, std::forward<MemGuard>(guard));
     }
 
     template <class TaskExecutor, class MemGuard>
-    Status trigger_restore(RuntimeState* state, TaskExecutor&& executor, MemGuard&& guard) {
+    Status trigger_restore(RuntimeState* state, MemGuard&& guard) {
         if (!acquire_once) {
             acquire_once = true;
             RETURN_IF_ERROR(_spiller->_acquire_input_stream(state));
         }
-        return _spiller->_reader->trigger_restore(state, std::forward<TaskExecutor>(executor),
-                                                  std::forward<MemGuard>(guard));
+        return _spiller->_reader->trigger_restore<TaskExecutor>(state, std::forward<MemGuard>(guard));
     }
 
     bool acquire_once = false;
@@ -344,11 +336,11 @@ TEST_F(SpillTest, unsorted_process) {
     {
         for (size_t i = 0; i < test_loop; ++i) {
             auto chunk = chunk_builder.gen(tuple, nullables);
-            ASSERT_OK(caller.spill(&dummy_rt_st, chunk, SyncExecutor{}, EmptyMemGuard{}));
+            ASSERT_OK(caller.spill<SyncExecutor>(&dummy_rt_st, chunk, EmptyMemGuard{}));
             ASSERT_OK(spiller->_spilled_task_status);
             holder.push_back(chunk);
         }
-        ASSERT_OK(caller.flush(&dummy_rt_st, SyncExecutor{}, EmptyMemGuard{}));
+        ASSERT_OK(caller.flush<SyncExecutor>(&dummy_rt_st, EmptyMemGuard{}));
     }
     size_t input_rows = 0;
     for (const auto& chunk : holder) {
@@ -358,9 +350,9 @@ TEST_F(SpillTest, unsorted_process) {
     // test restore
     {
         std::vector<ChunkPtr> restored;
-        ASSERT_OK(caller.trigger_restore(&dummy_rt_st, SyncExecutor{}, EmptyMemGuard{}));
+        ASSERT_OK(caller.trigger_restore<SyncExecutor>(&dummy_rt_st, EmptyMemGuard{}));
         for (size_t i = 0; i < test_loop; ++i) {
-            auto chunk_st = caller.restore(&dummy_rt_st, SyncExecutor{}, EmptyMemGuard{});
+            auto chunk_st = caller.restore<SyncExecutor>(&dummy_rt_st, EmptyMemGuard{});
             ASSERT_OK(chunk_st.status());
             ASSERT_OK(spiller->_spilled_task_status);
             if (chunk_st.value() != nullptr) {
@@ -368,7 +360,7 @@ TEST_F(SpillTest, unsorted_process) {
             }
         }
 
-        auto chunk_st = caller.restore(&dummy_rt_st, SyncExecutor{}, EmptyMemGuard{});
+        auto chunk_st = caller.restore<SyncExecutor>(&dummy_rt_st, EmptyMemGuard{});
         ASSERT_TRUE(chunk_st.status().is_end_of_file());
 
         size_t output_rows = 0;
@@ -380,11 +372,10 @@ TEST_F(SpillTest, unsorted_process) {
 
     // test 2
     {
-        ASyncExecutor executor;
         for (size_t i = 0; i < test_loop; ++i) {
             if (!spiller->is_full()) {
                 auto chunk = chunk_builder.gen(tuple, nullables);
-                ASSERT_OK(caller.spill(&dummy_rt_st, chunk, executor, EmptyMemGuard{}));
+                ASSERT_OK(caller.spill<ASyncExecutor>(&dummy_rt_st, chunk, EmptyMemGuard{}));
                 ASSERT_OK(spiller->_spilled_task_status);
             }
         }
@@ -463,21 +454,21 @@ TEST_F(SpillTest, order_by_process) {
         {
             for (size_t i = 0; i < test_loop; ++i) {
                 auto chunk = chunk_builder.gen(tuple, nullables);
-                ASSERT_OK(caller.spill(&dummy_rt_st, chunk, SyncExecutor{}, EmptyMemGuard{}));
+                ASSERT_OK(caller.spill<SyncExecutor>(&dummy_rt_st, chunk, EmptyMemGuard{}));
                 ASSERT_OK(spiller->_spilled_task_status);
                 holder.push_back(chunk);
                 contain_rows += chunk->num_rows();
             }
-            ASSERT_OK(caller.flush(&dummy_rt_st, SyncExecutor{}, EmptyMemGuard{}));
+            ASSERT_OK(caller.flush<SyncExecutor>(&dummy_rt_st, EmptyMemGuard{}));
         }
 
         std::vector<ChunkPtr> restored;
         size_t restored_rows = 0;
         {
-            ASSERT_OK(caller.trigger_restore(&dummy_rt_st, SyncExecutor{}, EmptyMemGuard{}));
+            ASSERT_OK(caller.trigger_restore<SyncExecutor>(&dummy_rt_st, EmptyMemGuard{}));
             ASSERT_TRUE(caller._spiller->has_output_data());
             for (size_t i = 0; i < test_loop; ++i) {
-                auto chunk_st = caller.restore(&dummy_rt_st, SyncExecutor{}, EmptyMemGuard{});
+                auto chunk_st = caller.restore<SyncExecutor>(&dummy_rt_st, EmptyMemGuard{});
                 ASSERT_OK(chunk_st.status());
                 ASSERT_OK(spiller->_spilled_task_status);
                 if (chunk_st.value() != nullptr) {
@@ -487,7 +478,7 @@ TEST_F(SpillTest, order_by_process) {
                 }
             }
 
-            auto chunk_st = caller.restore(&dummy_rt_st, SyncExecutor{}, EmptyMemGuard{});
+            auto chunk_st = caller.restore<SyncExecutor>(&dummy_rt_st, EmptyMemGuard{});
             ASSERT_TRUE(chunk_st.status().is_end_of_file());
         }
         ASSERT_EQ(contain_rows, restored_rows);
@@ -544,11 +535,11 @@ TEST_F(SpillTest, partition_process) {
             auto chunk = chunk_builder.gen(tuple, nullables);
             auto hash_column = spill::SpillHashColumn::create(chunk->num_rows());
             chunk->append_column(std::move(hash_column), -1);
-            ASSERT_OK(spiller->spill(&dummy_rt_st, chunk, SyncExecutor{}, EmptyMemGuard{}));
+            ASSERT_OK(spiller->spill<SyncExecutor>(&dummy_rt_st, chunk, EmptyMemGuard{}));
             ASSERT_OK(spiller->_spilled_task_status);
             holder.push_back(chunk);
         }
-        ASSERT_OK(spiller->flush(&dummy_rt_st, SyncExecutor{}, EmptyMemGuard{}));
+        ASSERT_OK(spiller->flush<SyncExecutor>(&dummy_rt_st, EmptyMemGuard{}));
     }
 }
 

--- a/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
@@ -47,9 +47,13 @@ import com.starrocks.common.util.CompressionUtils;
 import com.starrocks.common.util.TimeUtils;
 import com.starrocks.monitor.unit.TimeValue;
 import com.starrocks.qe.VariableMgr.VarAttr;
+import com.starrocks.server.GlobalStateMgr;
+import com.starrocks.server.StorageVolumeMgr;
 import com.starrocks.sql.analyzer.SemanticException;
 import com.starrocks.sql.common.QueryDebugOptions;
+import com.starrocks.storagevolume.StorageVolume;
 import com.starrocks.system.BackendCoreStat;
+import com.starrocks.thrift.TCloudConfiguration;
 import com.starrocks.thrift.TCompressionType;
 import com.starrocks.thrift.TOverflowMode;
 import com.starrocks.thrift.TPipelineProfileLevel;
@@ -165,6 +169,8 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
     public static final String MAX_PARALLEL_SCAN_INSTANCE_NUM = "max_parallel_scan_instance_num";
     public static final String ENABLE_INSERT_STRICT = "enable_insert_strict";
     public static final String ENABLE_SPILL = "enable_spill";
+    public static final String ENABLE_SPILL_TO_REMOTE_STORAGE = "enable_spill_to_remote_storage";
+    public static final String DISABLE_SPILL_TO_LOCAL_DISK = "disable_spill_to_local_disk";
     public static final String SPILLABLE_OPERATOR_MASK = "spillable_operator_mask";
     // spill mode: auto, force
     public static final String SPILL_MODE = "spill_mode";
@@ -545,6 +551,7 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
     // only used in test. spill_mode="RANDOM"
     public static final String SPILL_RAND_RATIO = "spill_rand_ratio";
     public static final String SPILL_ENCODE_LEVEL = "spill_encode_level";
+    public static final String SPILL_STORAGE_VOLUME = "spill_storage_volume";
 
     // full_sort_max_buffered_{rows,bytes} are thresholds that limits input size of partial_sort
     // in full sort.
@@ -948,6 +955,13 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
     @VariableMgr.VarAttr(name = ENABLE_SPILL)
     private boolean enableSpill = false;
 
+    @VariableMgr.VarAttr(name = ENABLE_SPILL_TO_REMOTE_STORAGE)
+    private boolean enableSpillToRemoteStorage = false;
+
+    @VariableMgr.VarAttr(name = DISABLE_SPILL_TO_LOCAL_DISK)
+    private boolean disableSpillToLocalDisk = false;
+
+
     // this is used to control which operators can spill, only meaningful when enable_spill=true
     // it uses a bit to identify whether the spill of each operator is in effect, 0 means no, 1 means yes
     // at present, only the lowest 4 bits are meaningful, corresponding to the four operators
@@ -987,6 +1001,9 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
     
     @VarAttr(name = SPILL_ENABLE_DIRECT_IO)
     private boolean spillEnableDirectIO = false;
+
+    @VarAttr(name = SPILL_STORAGE_VOLUME)
+    private String spillStorageVolume = "";
     
     @VarAttr(name = SPILL_RAND_RATIO, flag = VariableMgr.INVISIBLE)
     private double spillRandRatio = 0.1;
@@ -3272,6 +3289,20 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
             tResult.setEnable_agg_spill_preaggregation(enableAggSpillPreaggregation);
             tResult.setSpill_enable_direct_io(spillEnableDirectIO);
             tResult.setSpill_rand_ratio(spillRandRatio);
+            if (enableSpillToRemoteStorage && !spillStorageVolume.isEmpty()) {
+                // find storage volume config
+                GlobalStateMgr globalStateMgr = GlobalStateMgr.getCurrentState();
+                StorageVolumeMgr storageVolumeMgr = globalStateMgr.getStorageVolumeMgr();
+                StorageVolume sv = storageVolumeMgr.getStorageVolumeByName(spillStorageVolume);
+                if (sv != null) {
+                    tResult.setEnable_spill_to_remote_storage(true);
+                    tResult.setSpill_remote_storage_paths(sv.getLocations());
+                    TCloudConfiguration tCloudConfiguration = new TCloudConfiguration();
+                    sv.getCloudConfiguration().toThrift(tCloudConfiguration);
+                    tResult.setSpill_remote_storage_conf(tCloudConfiguration);
+                    tResult.setDisable_spill_to_local_disk(disableSpillToLocalDisk);
+                }
+            }
         }
 
         // Compression Type

--- a/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
@@ -59,6 +59,7 @@ import com.starrocks.thrift.TOverflowMode;
 import com.starrocks.thrift.TPipelineProfileLevel;
 import com.starrocks.thrift.TQueryOptions;
 import com.starrocks.thrift.TSpillMode;
+import com.starrocks.thrift.TSpillToRemoteStorageOptions;
 import com.starrocks.thrift.TTabletInternalParallelMode;
 import com.starrocks.thrift.TTimeUnit;
 import org.apache.commons.lang3.EnumUtils;
@@ -3296,11 +3297,13 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
                 StorageVolume sv = storageVolumeMgr.getStorageVolumeByName(spillStorageVolume);
                 if (sv != null) {
                     tResult.setEnable_spill_to_remote_storage(true);
-                    tResult.setSpill_remote_storage_paths(sv.getLocations());
+                    TSpillToRemoteStorageOptions options = new TSpillToRemoteStorageOptions();
+                    options.setRemote_storage_paths(sv.getLocations());
                     TCloudConfiguration tCloudConfiguration = new TCloudConfiguration();
                     sv.getCloudConfiguration().toThrift(tCloudConfiguration);
-                    tResult.setSpill_remote_storage_conf(tCloudConfiguration);
-                    tResult.setDisable_spill_to_local_disk(disableSpillToLocalDisk);
+                    options.setRemote_storage_conf(tCloudConfiguration);
+                    options.setDisable_spill_to_local_disk(disableSpillToLocalDisk);
+                    tResult.setSpill_to_remote_storage_options(options);
                 }
             }
         }

--- a/fe/fe-core/src/main/java/com/starrocks/storagevolume/StorageVolume.java
+++ b/fe/fe-core/src/main/java/com/starrocks/storagevolume/StorageVolume.java
@@ -147,6 +147,9 @@ public class StorageVolume implements Writable, GsonPostProcessable {
     public String getComment() {
         return comment;
     }
+    public List<String> getLocations() {
+        return locations;
+    }
 
     public String getType() {
         return svt.toString();

--- a/fe/fe-core/src/test/java/com/starrocks/sql/parser/ParserTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/parser/ParserTest.java
@@ -397,7 +397,7 @@ class ParserTest {
         assertContains(res, "{'disable_colocate_join', 'disable_join_reorder', 'disable_function_fold_constants'}");
 
         res = VariableMgr.findSimilarVarNames("SQL_AUTO_NULL");
-        assertContains(res, "{'SQL_AUTO_IS_NULL', 'sql_dialect', 'sql_mode_v2'}");
+        assertContains(res, "{'SQL_AUTO_IS_NULL', 'sql_dialect', 'spill_storage_volume'}");
 
         res = VariableMgr.findSimilarVarNames("pipeline");
         assertContains(res, "{'pipeline_dop', 'pipeline_sink_dop', 'pipeline_profile_level'}");

--- a/gensrc/thrift/InternalService.thrift
+++ b/gensrc/thrift/InternalService.thrift
@@ -276,9 +276,6 @@ struct TQueryOptions {
 
   117: optional bool enable_spill_to_remote_storage;
   118: optional TSpillToRemoteStorageOptions spill_to_remote_storage_options;
-  // 118: optional list<string> spill_remote_storage_paths;
-  // 119: optional CloudConfiguration.TCloudConfiguration spill_remote_storage_conf;
-  // 120: optional bool disable_spill_to_local_disk;
 }
 
 

--- a/gensrc/thrift/InternalService.thrift
+++ b/gensrc/thrift/InternalService.thrift
@@ -138,6 +138,12 @@ struct TQueryQueueOptions {
   2: optional bool enable_group_level_query_queue;
 }
 
+struct TSpillToRemoteStorageOptions {
+  1: optional list<string> remote_storage_paths;
+  2: optional CloudConfiguration.TCloudConfiguration remote_storage_conf;
+  3: optional bool disable_spill_to_local_disk;
+}
+
 // Query options with their respective defaults
 struct TQueryOptions {
   2: optional i32 max_errors = 0
@@ -269,9 +275,10 @@ struct TQueryOptions {
   116: optional string sql_dialect;
 
   117: optional bool enable_spill_to_remote_storage;
-  118: optional list<string> spill_remote_storage_paths;
-  119: optional CloudConfiguration.TCloudConfiguration spill_remote_storage_conf;
-  120: optional bool disable_spill_to_local_disk;
+  118: optional TSpillToRemoteStorageOptions spill_to_remote_storage_options;
+  // 118: optional list<string> spill_remote_storage_paths;
+  // 119: optional CloudConfiguration.TCloudConfiguration spill_remote_storage_conf;
+  // 120: optional bool disable_spill_to_local_disk;
 }
 
 

--- a/gensrc/thrift/InternalService.thrift
+++ b/gensrc/thrift/InternalService.thrift
@@ -46,6 +46,7 @@ include "Data.thrift"
 include "RuntimeProfile.thrift"
 include "WorkGroup.thrift"
 include "RuntimeFilter.thrift"
+include "CloudConfiguration.thrift"
 
 // constants for function version
 enum TFunctionVersion {
@@ -266,6 +267,11 @@ struct TQueryOptions {
   115: optional TTimeUnit big_query_profile_threshold_unit = TTimeUnit.SECOND;
   
   116: optional string sql_dialect;
+
+  117: optional bool enable_spill_to_remote_storage;
+  118: optional list<string> spill_remote_storage_paths;
+  119: optional CloudConfiguration.TCloudConfiguration spill_remote_storage_conf;
+  120: optional bool disable_spill_to_local_disk;
 }
 
 

--- a/test/sql/test_spill/R/test_spill_to_remote_storage
+++ b/test/sql/test_spill/R/test_spill_to_remote_storage
@@ -1,0 +1,188 @@
+-- name: test_spill_to_remote_storage @sequential
+CREATE STORAGE VOLUME "spill_test_${uuid0}" 
+TYPE = S3
+LOCATIONS = ("s3://${oss_bucket}/test_spill_${uuid0}/")
+PROPERTIES
+(
+    "aws.s3.region" = "${aws_region}",
+    "aws.s3.endpoint" = "${aws_sts_endpoint}",
+    "aws.s3.use_aws_sdk_default_behavior" = "false",
+    "aws.s3.use_instance_profile" = "false",
+    "aws.s3.access_key" = "${aws_ak}",
+    "aws.s3.secret_key" = "${aws_sk}"
+);
+-- result:
+-- !result
+create table t0 (
+    c0 INT,
+    c1 BIGINT
+) DUPLICATE KEY(c0) DISTRIBUTED BY HASH(c0) BUCKETS 1 PROPERTIES('replication_num' = '1');
+-- result:
+-- !result
+insert into t0 SELECT generate_series, 4096 - generate_series FROM TABLE(generate_series(1,  4096));
+-- result:
+-- !result
+insert into t0 select * from t0;
+-- result:
+-- !result
+create table t1 like t0;
+-- result:
+-- !result
+insert into t1 SELECT generate_series, 4096 - generate_series FROM TABLE(generate_series(4096,  8192));
+-- result:
+-- !result
+create table t3 like t0;
+-- result:
+-- !result
+insert into t3 SELECT generate_series, 40960 - generate_series FROM TABLE(generate_series(1,  40960));
+-- result:
+-- !result
+set enable_spill=true;
+-- result:
+-- !result
+set spill_mode='force';
+-- result:
+-- !result
+set pipeline_dop=1;
+-- result:
+-- !result
+set enable_spill_to_remote_storage=true;
+-- result:
+-- !result
+set spill_storage_volume="spill_test_${uuid0}";
+-- result:
+-- !result
+set disable_spill_to_local_disk=true;
+-- result:
+-- !result
+select count(l.c0), avg(l.c0), count(l.c1), count(l.c0), count(r.c1) from t0 l left join [broadcast] t1 r on l.c0 = r.c0 and l.c1 < r.c1;
+-- result:
+8192	2048.5	8192	8192	0
+-- !result
+select count(l.c0), avg(l.c0), count(l.c1) from t0 l left semi join [broadcast] t1 r on l.c0 = r.c0 and l.c1 < r.c1;
+-- result:
+0	None	0
+-- !result
+select count(l.c0), avg(l.c0), count(l.c1) from t0 l left semi join [broadcast] t1 r on l.c0 = r.c0 and l.c1 >= r.c1;
+-- result:
+2	4096.0	2
+-- !result
+select count(l.c0), avg(l.c0), count(l.c1) from t0 l left anti join [broadcast] t1 r on l.c0 = r.c0 and l.c1 >= r.c1;
+-- result:
+8190	2048.0	8190
+-- !result
+select count(r.c0), avg(r.c0), count(r.c1) from t0 l right semi join [bucket] t1 r on l.c0 = r.c0;
+-- result:
+1	4096.0	1
+-- !result
+select count(r.c0), avg(r.c0), count(r.c1) from t0 l right semi join [bucket] t1 r on l.c0 = r.c0 and l.c1 < r.c1;
+-- result:
+0	None	0
+-- !result
+select count(r.c0), avg(r.c0), count(r.c1) from t0 l right anti join [bucket] t1 r on l.c0 = r.c0 and l.c1 < r.c1;
+-- result:
+4097	6144.0	4097
+-- !result
+select count(l.c0), avg(l.c0), count(l.c1), count(l.c0), count(r.c1) from t0 l right join [bucket] t1 r on l.c0 = r.c0 and l.c1 < r.c1;
+-- result:
+0	None	0	0	4097
+-- !result
+select distinct c0, c1 from t3 order by 1, 2 limit 2;
+-- result:
+1	40959
+2	40958
+-- !result
+select count(*), max(tb.c0), min(tb.c1) from (select distinct c0, c1 from t3) tb;
+-- result:
+40960	40960	0
+-- !result
+select count(*) from (select distinct c0, c1 from t3 limit 100) tb;
+-- result:
+100
+-- !result
+select count(*), max(c0), min(c1) from (select c0, c1 from t3 group by c0, c1) tb;
+-- result:
+40960	40960	0
+-- !result
+select count(*), max(c0), min(sc1) from (select c0, sum(c1) as sc1 from t3 group by c0 having c0 > 100) tb;
+-- result:
+40860	40960	0
+-- !result
+select count(*), max(c0), min(sc1) from (select c0, sum(c1) as sc1 from t3 group by c0 having c0 > 100 limit 10) tb;
+-- result:
+10	110	40850
+-- !result
+select count(*), max(c0), min(sc1) from (select c0, sum(c1) as sc1 from t3 group by c0 limit 100) tb;
+-- result:
+100	100	40860
+-- !result
+set disable_spill_to_local_disk=false;
+-- result:
+-- !result
+admin enable failpoint 'force_allocate_remote_block' with 0.5 probability;
+-- result:
+-- !result
+select count(l.c0), avg(l.c0), count(l.c1), count(l.c0), count(r.c1) from t0 l left join [broadcast] t1 r on l.c0 = r.c0 and l.c1 < r.c1;
+-- result:
+8192	2048.5	8192	8192	0
+-- !result
+select count(l.c0), avg(l.c0), count(l.c1) from t0 l left semi join [broadcast] t1 r on l.c0 = r.c0 and l.c1 < r.c1;
+-- result:
+0	None	0
+-- !result
+select count(l.c0), avg(l.c0), count(l.c1) from t0 l left semi join [broadcast] t1 r on l.c0 = r.c0 and l.c1 >= r.c1;
+-- result:
+2	4096.0	2
+-- !result
+select count(l.c0), avg(l.c0), count(l.c1) from t0 l left anti join [broadcast] t1 r on l.c0 = r.c0 and l.c1 >= r.c1;
+-- result:
+8190	2048.0	8190
+-- !result
+select count(r.c0), avg(r.c0), count(r.c1) from t0 l right semi join [bucket] t1 r on l.c0 = r.c0;
+-- result:
+1	4096.0	1
+-- !result
+select count(r.c0), avg(r.c0), count(r.c1) from t0 l right semi join [bucket] t1 r on l.c0 = r.c0 and l.c1 < r.c1;
+-- result:
+0	None	0
+-- !result
+select count(r.c0), avg(r.c0), count(r.c1) from t0 l right anti join [bucket] t1 r on l.c0 = r.c0 and l.c1 < r.c1;
+-- result:
+4097	6144.0	4097
+-- !result
+select count(l.c0), avg(l.c0), count(l.c1), count(l.c0), count(r.c1) from t0 l right join [bucket] t1 r on l.c0 = r.c0 and l.c1 < r.c1;
+-- result:
+0	None	0	0	4097
+-- !result
+select distinct c0, c1 from t3 order by 1, 2 limit 2;
+-- result:
+1	40959
+2	40958
+-- !result
+select count(*), max(tb.c0), min(tb.c1) from (select distinct c0, c1 from t3) tb;
+-- result:
+40960	40960	0
+-- !result
+select count(*) from (select distinct c0, c1 from t3 limit 100) tb;
+-- result:
+100
+-- !result
+select count(*), max(c0), min(c1) from (select c0, c1 from t3 group by c0, c1) tb;
+-- result:
+40960	40960	0
+-- !result
+select count(*), max(c0), min(sc1) from (select c0, sum(c1) as sc1 from t3 group by c0 having c0 > 100) tb;
+-- result:
+40860	40960	0
+-- !result
+select count(*), max(c0), min(sc1) from (select c0, sum(c1) as sc1 from t3 group by c0 having c0 > 100 limit 10) tb;
+-- result:
+10	110	40850
+-- !result
+select count(*), max(c0), min(sc1) from (select c0, sum(c1) as sc1 from t3 group by c0 limit 100) tb;
+-- result:
+100	100	40860
+-- !result
+admin disable failpoint 'force_allocate_remote_block';
+-- result:
+-- !result

--- a/test/sql/test_spill/T/test_spill_to_remote_storage
+++ b/test/sql/test_spill/T/test_spill_to_remote_storage
@@ -1,0 +1,73 @@
+-- name: test_spill_to_remote_storage @sequential
+
+CREATE STORAGE VOLUME "spill_test_${uuid0}" 
+TYPE = S3
+LOCATIONS = ("s3://${oss_bucket}/test_spill_${uuid0}/")
+PROPERTIES
+(
+    "aws.s3.region" = "${aws_region}",
+    "aws.s3.endpoint" = "${aws_sts_endpoint}",
+    "aws.s3.use_aws_sdk_default_behavior" = "false",
+    "aws.s3.use_instance_profile" = "false",
+    "aws.s3.access_key" = "${aws_ak}",
+    "aws.s3.secret_key" = "${aws_sk}"
+);
+
+create table t0 (
+    c0 INT,
+    c1 BIGINT
+) DUPLICATE KEY(c0) DISTRIBUTED BY HASH(c0) BUCKETS 1 PROPERTIES('replication_num' = '1');
+insert into t0 SELECT generate_series, 4096 - generate_series FROM TABLE(generate_series(1,  4096));
+insert into t0 select * from t0;
+create table t1 like t0;
+insert into t1 SELECT generate_series, 4096 - generate_series FROM TABLE(generate_series(4096,  8192));
+create table t3 like t0;
+insert into t3 SELECT generate_series, 40960 - generate_series FROM TABLE(generate_series(1,  40960));
+
+set enable_spill=true;
+set spill_mode='force';
+set pipeline_dop=1;
+set enable_spill_to_remote_storage=true;
+set spill_storage_volume="spill_test_${uuid0}";
+
+
+set disable_spill_to_local_disk=true;
+
+select count(l.c0), avg(l.c0), count(l.c1), count(l.c0), count(r.c1) from t0 l left join [broadcast] t1 r on l.c0 = r.c0 and l.c1 < r.c1;
+select count(l.c0), avg(l.c0), count(l.c1) from t0 l left semi join [broadcast] t1 r on l.c0 = r.c0 and l.c1 < r.c1;
+select count(l.c0), avg(l.c0), count(l.c1) from t0 l left semi join [broadcast] t1 r on l.c0 = r.c0 and l.c1 >= r.c1;
+select count(l.c0), avg(l.c0), count(l.c1) from t0 l left anti join [broadcast] t1 r on l.c0 = r.c0 and l.c1 >= r.c1;
+select count(r.c0), avg(r.c0), count(r.c1) from t0 l right semi join [bucket] t1 r on l.c0 = r.c0;
+select count(r.c0), avg(r.c0), count(r.c1) from t0 l right semi join [bucket] t1 r on l.c0 = r.c0 and l.c1 < r.c1;
+select count(r.c0), avg(r.c0), count(r.c1) from t0 l right anti join [bucket] t1 r on l.c0 = r.c0 and l.c1 < r.c1;
+select count(l.c0), avg(l.c0), count(l.c1), count(l.c0), count(r.c1) from t0 l right join [bucket] t1 r on l.c0 = r.c0 and l.c1 < r.c1;
+
+select distinct c0, c1 from t3 order by 1, 2 limit 2;
+select count(*), max(tb.c0), min(tb.c1) from (select distinct c0, c1 from t3) tb;
+select count(*) from (select distinct c0, c1 from t3 limit 100) tb;
+select count(*), max(c0), min(c1) from (select c0, c1 from t3 group by c0, c1) tb;
+select count(*), max(c0), min(sc1) from (select c0, sum(c1) as sc1 from t3 group by c0 having c0 > 100) tb;
+select count(*), max(c0), min(sc1) from (select c0, sum(c1) as sc1 from t3 group by c0 having c0 > 100 limit 10) tb;
+select count(*), max(c0), min(sc1) from (select c0, sum(c1) as sc1 from t3 group by c0 limit 100) tb;
+
+
+set disable_spill_to_local_disk=false;
+admin enable failpoint 'force_allocate_remote_block' with 0.5 probability;
+
+select count(l.c0), avg(l.c0), count(l.c1), count(l.c0), count(r.c1) from t0 l left join [broadcast] t1 r on l.c0 = r.c0 and l.c1 < r.c1;
+select count(l.c0), avg(l.c0), count(l.c1) from t0 l left semi join [broadcast] t1 r on l.c0 = r.c0 and l.c1 < r.c1;
+select count(l.c0), avg(l.c0), count(l.c1) from t0 l left semi join [broadcast] t1 r on l.c0 = r.c0 and l.c1 >= r.c1;
+select count(l.c0), avg(l.c0), count(l.c1) from t0 l left anti join [broadcast] t1 r on l.c0 = r.c0 and l.c1 >= r.c1;
+select count(r.c0), avg(r.c0), count(r.c1) from t0 l right semi join [bucket] t1 r on l.c0 = r.c0;
+select count(r.c0), avg(r.c0), count(r.c1) from t0 l right semi join [bucket] t1 r on l.c0 = r.c0 and l.c1 < r.c1;
+select count(r.c0), avg(r.c0), count(r.c1) from t0 l right anti join [bucket] t1 r on l.c0 = r.c0 and l.c1 < r.c1;
+select count(l.c0), avg(l.c0), count(l.c1), count(l.c0), count(r.c1) from t0 l right join [bucket] t1 r on l.c0 = r.c0 and l.c1 < r.c1;
+
+select distinct c0, c1 from t3 order by 1, 2 limit 2;
+select count(*), max(tb.c0), min(tb.c1) from (select distinct c0, c1 from t3) tb;
+select count(*) from (select distinct c0, c1 from t3 limit 100) tb;
+select count(*), max(c0), min(c1) from (select c0, c1 from t3 group by c0, c1) tb;
+select count(*), max(c0), min(sc1) from (select c0, sum(c1) as sc1 from t3 group by c0 having c0 > 100) tb;
+select count(*), max(c0), min(sc1) from (select c0, sum(c1) as sc1 from t3 group by c0 having c0 > 100 limit 10) tb;
+select count(*), max(c0), min(sc1) from (select c0, sum(c1) as sc1 from t3 group by c0 limit 100) tb;
+admin disable failpoint 'force_allocate_remote_block';


### PR DESCRIPTION
Why I'm doing:

What I'm doing:


support spill to remote storage

Usage

before running a query, create a storage volume for spill and set some session variables like the following.

```sql
-- create storage volume for spill
CREATE STORAGE VOLUME spill_sv
TYPE = S3
LOCATIONS = ("s3://xxx")
PROPERTIES
(
    "aws.s3.region" = "xxx",
    "aws.s3.endpoint" = "xxx",
    "aws.s3.use_aws_sdk_default_behavior" = "false",
    "aws.s3.use_instance_profile" = "false",
    "aws.s3.access_key" = "xxxxxxxxxx",
    "aws.s3.secret_key" = "yyyyyyyyyy"
);
set enable_spill_to_remote_storage = true;
set spill_storage_volume='spill_sv';
```

Major changes:

1. add fragment_instance_id to the name of the spill file to avoid file name conflicts when multiple BE nodes of the same query write to remote storage.
2. In order to avoid local io and remote io interfering with each other, here we reuse connector_scan_executor to run remote io task. And the IOTaskExecutor is refactored to make it capable of managing the scheduling of the two thread pools.
3. The yield mechanism has been enhanced. Yield can also be triggered when it is found that the block type does not match the io thread pool. for example, when accessing the remote block in the local io thread pool, yield will be triggered to submit the task to the remote io thread pool.
4. adjust profile metrics to distinguish between local io and remote io

TODO
1. some performance optimizations
2. add a new variable to control the amount of data that can be spilled to the local disk for each query.
3. need to test on more types of storage volumes

## What type of PR is this:

- [ ] BugFix
- [x] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
