### PR TITLE
[Enhancement] add be config enable_profile_for_external_plan

### DIFF
--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -1193,4 +1193,6 @@ CONF_mInt32(dictionary_cache_refresh_threadpool_size, "8");
 // Disable when pk_dump_interval_seconds <= 0
 CONF_mInt64(pk_dump_interval_seconds, "3600"); // 1 hour
 
+// whether enable query profile for queries initiated by spark or flink
+CONF_mBool(enable_profile_for_external_plan, "false");
 } // namespace starrocks::config

--- a/be/src/runtime/fragment_mgr.cpp
+++ b/be/src/runtime/fragment_mgr.cpp
@@ -936,6 +936,7 @@ Status FragmentMgr::exec_external_plan_fragment(const TScanOpenParams& params, c
     // For spark sql / flink sql, we dont use page cache.
     query_options.use_page_cache = false;
     query_options.use_column_pool = false;
+    query_options.enable_profile = config::enable_profile_for_external_plan;
     exec_fragment_params.__set_query_options(query_options);
     VLOG_ROW << "external exec_plan_fragment params is "
              << apache::thrift::ThriftDebugString(exec_fragment_params).c_str();


### PR DESCRIPTION
Why I'm doing:

The queries initiated by spark/flink don't enable query profile by default, some detailed profile metrics may be loss when we set pipeline_print_profile=true in be.conf

What I'm doing:

add a dynamic configuration to control whether enable query profile from external plan, its default value is false, keep the same as before.

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [x] 3.1
  - [x] 3.0
  - [x] 2.5
