### PR TITLE
[Refactor] remove CHECK in primary key table

### DIFF
--- a/be/src/common/status.h
+++ b/be/src/common/status.h
@@ -413,6 +413,17 @@ struct StatusInstance {
         }                                     \
     } while (false)
 
+#define VA_ARGS_HELPER(fmt, ...) fmt " " #__VA_ARGS__
+
+#define RETURN_ERROR_IF_FALSE(condition, ...)                                       \
+    if (GOOGLE_PREDICT_BRANCH_NOT_TAKEN(!(condition))) {                            \
+        std::ostringstream oss;                                                     \
+        oss << "Check failed: " #condition ". " << VA_ARGS_HELPER("", __VA_ARGS__); \
+        std::string error_msg = oss.str();                                          \
+        LOG(ERROR) << error_msg;                                                    \
+        return Status::InternalError(error_msg);                                    \
+    }
+
 /// @brief Emit a warning if @c to_call returns a bad status.
 #define WARN_IF_ERROR(to_call, warning_prefix)                \
     do {                                                      \

--- a/be/src/storage/del_vector.cpp
+++ b/be/src/storage/del_vector.cpp
@@ -44,7 +44,7 @@ void DelVector::_add_dels(const std::vector<uint32_t>& dels) {
 
 void DelVector::add_dels_as_new_version(const std::vector<uint32_t>& dels, int64_t version,
                                         std::shared_ptr<DelVector>* pdelvec) const {
-    CHECK(this != pdelvec->get());
+    DCHECK(this != pdelvec->get());
     DelVectorPtr tmp(new DelVector());
     if (_roaring) {
         tmp->_roaring = std::make_unique<Roaring>(*_roaring);

--- a/be/src/storage/delta_column_group.cpp
+++ b/be/src/storage/delta_column_group.cpp
@@ -95,7 +95,7 @@ Status DeltaColumnGroup::load(int64_t version, const char* data, size_t length) 
         old_parsed = true;
     }
 
-    CHECK((parsed && !old_parsed) || (!parsed && old_parsed));
+    RETURN_ERROR_IF_FALSE((parsed && !old_parsed) || (!parsed && old_parsed));
 
     if (!parsed && old_parsed) {
         auto column_ids = dcg_pb.add_column_ids();

--- a/be/src/storage/kv_store.cpp
+++ b/be/src/storage/kv_store.cpp
@@ -39,6 +39,7 @@
 #include <vector>
 
 #include "common/logging.h"
+#include "common/statusor.h"
 #include "gutil/strings/substitute.h"
 #include "rocksdb/convenience.h"
 #include "rocksdb/db.h"
@@ -227,7 +228,8 @@ static std::string get_iterate_upper_bound(const std::string& prefix) {
 }
 
 Status KVStore::iterate(ColumnFamilyIndex column_family_index, const std::string& prefix,
-                        std::function<bool(std::string_view, std::string_view)> const& func, int64_t timeout_sec) {
+                        std::function<StatusOr<bool>(std::string_view, std::string_view)> const& func,
+                        int64_t timeout_sec) {
     int64_t t_start = MonotonicMillis();
     rocksdb::ColumnFamilyHandle* handle = _handles[column_family_index];
     auto opts = ReadOptions();
@@ -253,7 +255,7 @@ Status KVStore::iterate(ColumnFamilyIndex column_family_index, const std::string
             }
             std::string_view key(it->key().data(), it->key().size());
             std::string_view value(it->value().data(), it->value().size());
-            bool ret = func(key, value);
+            ASSIGN_OR_RETURN(bool ret, func(key, value));
             if (!ret) {
                 break;
             }
@@ -267,7 +269,7 @@ Status KVStore::iterate(ColumnFamilyIndex column_family_index, const std::string
             }
             std::string_view key(it->key().data(), it->key().size());
             std::string_view value(it->value().data(), it->value().size());
-            bool ret = func(key, value);
+            ASSIGN_OR_RETURN(bool ret, func(key, value));
             if (!ret) {
                 break;
             }
@@ -284,7 +286,7 @@ Status KVStore::iterate(ColumnFamilyIndex column_family_index, const std::string
 
 Status KVStore::iterate_range(ColumnFamilyIndex column_family_index, const std::string& lower_bound,
                               const std::string& upper_bound,
-                              std::function<bool(std::string_view, std::string_view)> const& func) {
+                              std::function<StatusOr<bool>(std::string_view, std::string_view)> const& func) {
     rocksdb::ColumnFamilyHandle* handle = _handles[column_family_index];
     rocksdb::Slice iter_upper(upper_bound);
     ReadOptions options;
@@ -294,7 +296,8 @@ Status KVStore::iterate_range(ColumnFamilyIndex column_family_index, const std::
     for (; it->Valid(); it->Next()) {
         std::string_view key(it->key().data(), it->key().size());
         std::string_view value(it->value().data(), it->value().size());
-        if (!func(key, value)) {
+        ASSIGN_OR_RETURN(bool ret, func(key, value));
+        if (!ret) {
             break;
         }
     }

--- a/be/src/storage/kv_store.h
+++ b/be/src/storage/kv_store.h
@@ -71,11 +71,12 @@ public:
     Status remove(ColumnFamilyIndex column_family_index, const std::string& key);
 
     Status iterate(ColumnFamilyIndex column_family_index, const std::string& prefix,
-                   std::function<bool(std::string_view, std::string_view)> const& func, int64_t timeout_sec = -1);
+                   std::function<StatusOr<bool>(std::string_view, std::string_view)> const& func,
+                   int64_t timeout_sec = -1);
 
     Status iterate_range(ColumnFamilyIndex column_family_index, const std::string& lower_bound,
                          const std::string& upper_bound,
-                         std::function<bool(std::string_view, std::string_view)> const& func);
+                         std::function<StatusOr<bool>(std::string_view, std::string_view)> const& func);
 
     const std::string& root_path() const { return _root_path; }
 

--- a/be/src/storage/lake/lake_local_persistent_index_tablet_loader.cpp
+++ b/be/src/storage/lake/lake_local_persistent_index_tablet_loader.cpp
@@ -68,7 +68,7 @@ Status LakeLocalPersistentIndexTabletLoader::rowset_iterator(
             return res.status();
         }
         auto& itrs = res.value();
-        CHECK(itrs.size() == rowset->num_segments()) << "itrs.size != num_segments";
+        RETURN_ERROR_IF_FALSE(itrs.size() == rowset->num_segments(), "itrs.size != num_segments");
         RETURN_IF_ERROR(handler(itrs, rowset->id()));
     }
 

--- a/be/src/storage/lake/lake_primary_index.cpp
+++ b/be/src/storage/lake/lake_primary_index.cpp
@@ -116,9 +116,7 @@ Status LakePrimaryIndex::_do_lake_load(TabletManager* tablet_mgr, const TabletMe
     std::unique_ptr<Column> pk_column;
     if (pk_columns.size() > 1) {
         // more than one key column
-        if (!PrimaryKeyEncoder::create_column(pkey_schema, &pk_column).ok()) {
-            CHECK(false) << "create column for primary key encoder failed";
-        }
+        RETURN_IF_ERROR(PrimaryKeyEncoder::create_column(pkey_schema, &pk_column));
     }
     vector<uint32_t> rowids;
     rowids.reserve(4096);
@@ -134,7 +132,7 @@ Status LakePrimaryIndex::_do_lake_load(TabletManager* tablet_mgr, const TabletMe
             return res.status();
         }
         auto& itrs = res.value();
-        CHECK(itrs.size() == rowset->num_segments()) << "itrs.size != num_segments";
+        RETURN_ERROR_IF_FALSE(itrs.size() == rowset->num_segments(), "itrs.size != num_segments");
         for (size_t i = 0; i < itrs.size(); i++) {
             auto itr = itrs[i].get();
             if (itr == nullptr) {

--- a/be/src/storage/lake/replication_txn_manager.cpp
+++ b/be/src/storage/lake/replication_txn_manager.cpp
@@ -274,10 +274,10 @@ Status ReplicationTxnManager::replicate_remote_snapshot(const TReplicateSnapshot
             return status;
         }
 
-        CHECK(((src_snapshot_info.incremental_snapshot &&
-                snapshot_meta.snapshot_type() == SnapshotTypePB::SNAPSHOT_TYPE_INCREMENTAL) ||
-               (!src_snapshot_info.incremental_snapshot &&
-                snapshot_meta.snapshot_type() == SnapshotTypePB::SNAPSHOT_TYPE_FULL)))
+        DCHECK(((src_snapshot_info.incremental_snapshot &&
+                 snapshot_meta.snapshot_type() == SnapshotTypePB::SNAPSHOT_TYPE_INCREMENTAL) ||
+                (!src_snapshot_info.incremental_snapshot &&
+                 snapshot_meta.snapshot_type() == SnapshotTypePB::SNAPSHOT_TYPE_FULL)))
                 << ", incremental_snapshot: " << src_snapshot_info.incremental_snapshot
                 << ", snapshot_type: " << SnapshotTypePB_Name(snapshot_meta.snapshot_type());
 

--- a/be/src/storage/lake/txn_log_applier.cpp
+++ b/be/src/storage/lake/txn_log_applier.cpp
@@ -239,7 +239,7 @@ private:
         }
 
         if (op_replication.txn_meta().incremental_snapshot()) {
-            CHECK(_new_version - _base_version == op_replication.op_writes_size())
+            DCHECK(_new_version - _base_version == op_replication.op_writes_size())
                     << ", base_version: " << _base_version << ", new_version: " << _new_version
                     << ", op_write_size: " << op_replication.op_writes_size();
             for (const auto& op_write : op_replication.op_writes()) {

--- a/be/src/storage/lake/update_compaction_state.cpp
+++ b/be/src/storage/lake/update_compaction_state.cpp
@@ -62,12 +62,12 @@ Status CompactionState::_load_segments(Rowset* rowset, const TabletSchemaCSPtr& 
     Schema pkey_schema = ChunkHelper::convert_schema(tablet_schema, pk_columns);
 
     std::unique_ptr<Column> pk_column;
-    CHECK(PrimaryKeyEncoder::create_column(pkey_schema, &pk_column, true).ok());
+    RETURN_IF_ERROR(PrimaryKeyEncoder::create_column(pkey_schema, &pk_column, true));
 
     if (_segment_iters.empty()) {
         ASSIGN_OR_RETURN(_segment_iters, rowset->get_each_segment_iterator(pkey_schema, &_stats));
     }
-    CHECK_EQ(_segment_iters.size(), rowset->num_segments());
+    RETURN_ERROR_IF_FALSE(_segment_iters.size() == rowset->num_segments());
 
     // only hold pkey, so can use larger chunk size
     auto chunk_shared_ptr = ChunkHelper::new_chunk(pkey_schema, config::vector_chunk_size);

--- a/be/src/storage/lake/update_manager.cpp
+++ b/be/src/storage/lake/update_manager.cpp
@@ -271,7 +271,7 @@ Status UpdateManager::_do_update_with_condition(Tablet* tablet, const TabletMeta
                                                 int32_t upsert_idx, int32_t condition_column,
                                                 const std::vector<ColumnUniquePtr>& upserts, PrimaryIndex& index,
                                                 int64_t tablet_id, DeletesMap* new_deletes) {
-    CHECK(condition_column >= 0);
+    RETURN_ERROR_IF_FALSE(condition_column >= 0);
     TRACE_COUNTER_SCOPE_LATENCY_US("do_update_latency_us");
     const auto& tablet_column = tablet_schema->column(condition_column);
     std::vector<uint32_t> read_column_ids;

--- a/be/src/storage/local_tablet_reader.cpp
+++ b/be/src/storage/local_tablet_reader.cpp
@@ -115,9 +115,7 @@ Status LocalTabletReader::multi_get(const Chunk& keys, const std::vector<uint32_
         pk_columns.push_back((uint32_t)i);
     }
     std::unique_ptr<Column> pk_column;
-    if (!PrimaryKeyEncoder::create_column(*tablet_schema->schema(), &pk_column).ok()) {
-        CHECK(false) << "create column for primary key encoder failed";
-    }
+    RETURN_IF_ERROR(PrimaryKeyEncoder::create_column(*tablet_schema->schema(), &pk_column));
     PrimaryKeyEncoder::encode(*tablet_schema->schema(), keys, 0, keys.num_rows(), pk_column.get());
 
     // search pks in pk index to get rowids

--- a/be/src/storage/persistent_index.h
+++ b/be/src/storage/persistent_index.h
@@ -436,7 +436,7 @@ public:
     uint64_t file_size() {
         if (_file != nullptr) {
             auto res = _file->get_size();
-            CHECK(res.ok()) << res.status(); // FIXME: no abort
+            DCHECK(res.ok()) << res.status(); // FIXME: no abort
             return *res;
         } else {
             return 0;

--- a/be/src/storage/persistent_index_tablet_loader.cpp
+++ b/be/src/storage/persistent_index_tablet_loader.cpp
@@ -80,7 +80,7 @@ Status PersistentIndexTabletLoader::rowset_iterator(
             return res.status();
         }
         auto& itrs = res.value();
-        CHECK(itrs.size() == rowset->num_segments()) << "itrs.size != num_segments";
+        RETURN_ERROR_IF_FALSE(itrs.size() == rowset->num_segments(), "itrs.size != num_segments");
         RETURN_IF_ERROR(handler(itrs, rowset->rowset_meta()->get_rowset_seg_id()));
     }
     return Status::OK();

--- a/be/src/storage/primary_index.cpp
+++ b/be/src/storage/primary_index.cpp
@@ -1114,9 +1114,7 @@ Status PrimaryIndex::_do_load(Tablet* tablet) {
     OlapReaderStatistics stats;
     std::unique_ptr<Column> pk_column;
     if (pk_columns.size() > 1) {
-        if (!PrimaryKeyEncoder::create_column(pkey_schema, &pk_column).ok()) {
-            CHECK(false) << "create column for primary key encoder failed";
-        }
+        RETURN_IF_ERROR(PrimaryKeyEncoder::create_column(pkey_schema, &pk_column));
     }
     // only hold pkey, so can use larger chunk size
     vector<uint32_t> rowids;
@@ -1132,7 +1130,7 @@ Status PrimaryIndex::_do_load(Tablet* tablet) {
         }
         auto& itrs = res.value();
         // TODO(cbl): auto close iterators on failure
-        CHECK(itrs.size() == rowset->num_segments()) << "itrs.size != num_segments";
+        RETURN_ERROR_IF_FALSE(itrs.size() == rowset->num_segments(), "itrs.size != num_segments");
         for (size_t i = 0; i < itrs.size(); i++) {
             auto itr = itrs[i].get();
             if (itr == nullptr) {
@@ -1208,7 +1206,7 @@ const Slice* PrimaryIndex::_build_persistent_keys(const Column& pks, uint32_t id
         const Slice* vkeys = reinterpret_cast<const Slice*>(pks.raw_data());
         return vkeys + idx_begin;
     } else {
-        CHECK(_key_size > 0);
+        DCHECK(_key_size > 0);
         const uint8_t* keys = pks.raw_data() + idx_begin * _key_size;
         for (size_t i = idx_begin; i < idx_end; i++) {
             key_slices->emplace_back(keys, _key_size);

--- a/be/src/storage/primary_key_dump.cpp
+++ b/be/src/storage/primary_key_dump.cpp
@@ -253,7 +253,7 @@ Status PrimaryKeyDump::_dump_segment_keys() {
             return res.status();
         }
         auto& itrs = res.value();
-        CHECK(itrs.size() == rowset.second->num_segments()) << "itrs.size != num_segments";
+        RETURN_ERROR_IF_FALSE(itrs.size() == rowset.second->num_segments(), "itrs.size != num_segments");
         for (size_t i = 0; i < itrs.size(); i++) {
             auto itr = itrs[i].get();
             if (itr == nullptr) {

--- a/be/src/storage/primary_key_encoder.h
+++ b/be/src/storage/primary_key_encoder.h
@@ -33,7 +33,6 @@ namespace starrocks {
 //   if this column is the last column: append directly
 //   if not: convert each 0x00 inside the string to 0x00 0x01,
 //           add a tailing 0x00 0x00, then append
-
 class PrimaryKeyEncoder {
 public:
     static bool is_supported(const Field& f);
@@ -62,7 +61,7 @@ public:
 
     static void encode(const Schema& schema, const Chunk& chunk, size_t offset, size_t len, Column* dest);
 
-    static void encode_sort_key(const Schema& schema, const Chunk& chunk, size_t offset, size_t len, Column* dest);
+    static Status encode_sort_key(const Schema& schema, const Chunk& chunk, size_t offset, size_t len, Column* dest);
 
     static void encode_selective(const Schema& schema, const Chunk& chunk, const uint32_t* indexes, size_t len,
                                  Column* dest);

--- a/be/src/storage/publish_version_manager.cpp
+++ b/be/src/storage/publish_version_manager.cpp
@@ -124,7 +124,7 @@ void PublishVersionManager::wait_publish_task_apply_finish(std::vector<TFinishTa
             _waitting_finish_task_requests[finish_task_requests[i].signature] = std::move(finish_task_requests[i]);
         }
     }
-    CHECK(has_pending_task());
+    DCHECK(has_pending_task());
 }
 
 void PublishVersionManager::update_tablet_version(TFinishTaskRequest& finish_task_request) {

--- a/be/src/storage/replication_txn_manager.cpp
+++ b/be/src/storage/replication_txn_manager.cpp
@@ -482,10 +482,10 @@ Status ReplicationTxnManager::replicate_remote_snapshot(const TReplicateSnapshot
             return status;
         }
 
-        CHECK(((src_snapshot_info.incremental_snapshot &&
-                snapshot_meta.snapshot_type() == SnapshotTypePB::SNAPSHOT_TYPE_INCREMENTAL) ||
-               (!src_snapshot_info.incremental_snapshot &&
-                snapshot_meta.snapshot_type() == SnapshotTypePB::SNAPSHOT_TYPE_FULL)))
+        DCHECK(((src_snapshot_info.incremental_snapshot &&
+                 snapshot_meta.snapshot_type() == SnapshotTypePB::SNAPSHOT_TYPE_INCREMENTAL) ||
+                (!src_snapshot_info.incremental_snapshot &&
+                 snapshot_meta.snapshot_type() == SnapshotTypePB::SNAPSHOT_TYPE_FULL)))
                 << ", incremental_snapshot: " << src_snapshot_info.incremental_snapshot
                 << ", snapshot_type: " << SnapshotTypePB_Name(snapshot_meta.snapshot_type());
 

--- a/be/src/storage/rowset_column_update_state.cpp
+++ b/be/src/storage/rowset_column_update_state.cpp
@@ -185,7 +185,7 @@ Status RowsetColumnUpdateState::_prepare_partial_update_states(Tablet* tablet, R
 
     if (_partial_update_states[start_idx].inited) {
         // assume that states between [start_idx, end_idx) should be inited
-        CHECK(_partial_update_states[end_idx - 1].inited);
+        RETURN_ERROR_IF_FALSE(_partial_update_states[end_idx - 1].inited);
         return Status::OK();
     }
 

--- a/be/src/storage/rowset_merger.cpp
+++ b/be/src/storage/rowset_merger.cpp
@@ -106,7 +106,8 @@ struct MergeEntry {
             if (encode_schema != nullptr) {
                 // need to encode
                 chunk_pk_column->reset_column();
-                PrimaryKeyEncoder::encode_sort_key(*encode_schema, *chunk, 0, chunk->num_rows(), chunk_pk_column.get());
+                RETURN_IF_ERROR(PrimaryKeyEncoder::encode_sort_key(*encode_schema, *chunk, 0, chunk->num_rows(),
+                                                                   chunk_pk_column.get()));
             } else {
                 // just use chunk's first column
                 chunk_pk_column = chunk->get_column_by_index(chunk->schema()->sort_key_idxes()[0]);

--- a/be/src/storage/rowset_update_state.cpp
+++ b/be/src/storage/rowset_update_state.cpp
@@ -108,7 +108,7 @@ Status RowsetUpdateState::_load_upserts(Rowset* rowset, uint32_t idx, Column* pk
         return res.status();
     }
     auto& itrs = res.value();
-    CHECK(itrs.size() == rowset->num_segments()) << "itrs.size != num_segments";
+    RETURN_ERROR_IF_FALSE(itrs.size() == rowset->num_segments(), "itrs.size != num_segments");
 
     // only hold pkey, so can use larger chunk size
     auto chunk_shared_ptr = ChunkHelper::new_chunk(pkey_schema, 4096);
@@ -130,7 +130,7 @@ Status RowsetUpdateState::_load_upserts(Rowset* rowset, uint32_t idx, Column* pk
                 PrimaryKeyEncoder::encode(pkey_schema, *chunk, 0, chunk->num_rows(), col.get());
             }
         }
-        CHECK(col->size() == num_rows) << "read segment: iter rows != num rows";
+        RETURN_ERROR_IF_FALSE(col->size() == num_rows, "read segment: iter rows != num rows");
     }
     for (const auto& itr : itrs) {
         itr->close();
@@ -157,9 +157,7 @@ Status RowsetUpdateState::_do_load(Tablet* tablet, Rowset* rowset) {
     }
     Schema pkey_schema = ChunkHelper::convert_schema(schema, pk_columns);
     std::unique_ptr<Column> pk_column;
-    if (!PrimaryKeyEncoder::create_column(pkey_schema, &pk_column).ok()) {
-        CHECK(false) << "create column for primary key encoder failed";
-    }
+    RETURN_IF_ERROR(PrimaryKeyEncoder::create_column(pkey_schema, &pk_column));
     // if rowset is partial rowset, we need to load rowset totally because we don't support load multiple load
     // for partial update so far
     bool ignore_mem_limit =
@@ -192,9 +190,7 @@ Status RowsetUpdateState::load_deletes(Rowset* rowset, uint32_t idx) {
     }
     Schema pkey_schema = ChunkHelper::convert_schema(schema, pk_columns);
     std::unique_ptr<Column> pk_column;
-    if (!PrimaryKeyEncoder::create_column(pkey_schema, &pk_column).ok()) {
-        CHECK(false) << "create column for primary key encoder failed";
-    }
+    RETURN_IF_ERROR(PrimaryKeyEncoder::create_column(pkey_schema, &pk_column));
     return _load_deletes(rowset, idx, pk_column.get());
 }
 
@@ -206,9 +202,7 @@ Status RowsetUpdateState::load_upserts(Rowset* rowset, uint32_t upsert_id) {
     }
     Schema pkey_schema = ChunkHelper::convert_schema(schema, pk_columns);
     std::unique_ptr<Column> pk_column;
-    if (!PrimaryKeyEncoder::create_column(pkey_schema, &pk_column, true).ok()) {
-        CHECK(false) << "create column for primary key encoder failed";
-    }
+    RETURN_IF_ERROR(PrimaryKeyEncoder::create_column(pkey_schema, &pk_column, true));
     return _load_upserts(rowset, upsert_id, pk_column.get());
 }
 
@@ -317,7 +311,7 @@ Status RowsetUpdateState::_prepare_partial_update_value_columns(Tablet* tablet, 
                 _partial_update_value_column_ids.emplace_back(cid);
             }
         }
-        CHECK(_partial_update_value_column_ids.size() > 0) << "no partial update value columns";
+        RETURN_ERROR_IF_FALSE(_partial_update_value_column_ids.size() > 0, "no partial update value columns");
         _partial_update_value_columns_schema =
                 ChunkHelper::convert_schema(tablet_schema, _partial_update_value_column_ids);
         auto res = rowset->get_segment_iterators2(_partial_update_value_columns_schema, tablet_schema, nullptr, 0,
@@ -670,11 +664,11 @@ std::ostream& operator<<(std::ostream& os, const std::vector<T>& vs) {
 static Status append_full_row_column(const Schema& tschema,
                                      const std::vector<uint32_t>& partial_update_value_column_ids,
                                      const std::vector<uint32_t>& read_column_ids, PartialUpdateState& state) {
-    CHECK(state.write_columns.size() == read_column_ids.size());
+    RETURN_ERROR_IF_FALSE(state.write_columns.size() == read_column_ids.size());
     size_t input_column_size = tschema.num_fields() - tschema.num_key_fields() - 1;
     LOG(INFO) << "partial_update_value_column_ids:" << partial_update_value_column_ids
               << " read_column_ids:" << read_column_ids << " input_column_size:" << input_column_size;
-    CHECK(partial_update_value_column_ids.size() + read_column_ids.size() == input_column_size);
+    RETURN_ERROR_IF_FALSE(partial_update_value_column_ids.size() + read_column_ids.size() == input_column_size);
     Columns columns(input_column_size); // all values columns
     for (size_t i = 0; i < partial_update_value_column_ids.size(); ++i) {
         columns[partial_update_value_column_ids[i] - tschema.num_key_fields()] =

--- a/be/src/storage/storage_engine.cpp
+++ b/be/src/storage/storage_engine.cpp
@@ -1040,7 +1040,7 @@ Status StorageEngine::_start_trash_sweep(double* usage) {
     }
 
     // clear expire incremental rowset, move deleted tablet to trash
-    CHECK(_tablet_manager->start_trash_sweep().ok());
+    RETURN_IF_ERROR(_tablet_manager->start_trash_sweep());
 
     // clean rubbish transactions
     _clean_unused_txns();

--- a/be/src/storage/tablet_meta_manager.cpp
+++ b/be/src/storage/tablet_meta_manager.cpp
@@ -850,10 +850,10 @@ Status TabletMetaManager::rowset_iterate(DataDir* store, TTabletId tablet_id, co
     put_fixed64_le(&prefix, BigEndian::FromHost64(tablet_id));
 
     return store->get_meta()->iterate(META_COLUMN_FAMILY_INDEX, prefix,
-                                      [&](std::string_view key, std::string_view value) -> bool {
+                                      [&](std::string_view key, std::string_view value) -> StatusOr<bool> {
                                           bool parse_ok = false;
                                           auto rowset_meta = std::make_shared<RowsetMeta>(value, &parse_ok);
-                                          CHECK(parse_ok) << "Corrupted rowset meta";
+                                          RETURN_ERROR_IF_FALSE(parse_ok, "Corrupted rowset meta");
                                           return func(std::move(rowset_meta));
                                       });
 }
@@ -1219,19 +1219,20 @@ Status TabletMetaManager::scan_delta_column_group(KVStore* meta, TTabletId table
                                                   DeltaColumnGroupList* dcgs) {
     std::string lower = encode_delta_column_group_key(tablet_id, segment_id, end_version);
     std::string upper = encode_delta_column_group_key(tablet_id, segment_id, begin_version);
-    auto st = meta->iterate_range(META_COLUMN_FAMILY_INDEX, lower, upper,
-                                  [&](std::string_view key, std::string_view value) -> bool {
-                                      TTabletId dummy;
-                                      uint32_t dummy_segment_id;
-                                      int64_t decode_version;
-                                      decode_delta_column_group_key(key, &dummy, &dummy_segment_id, &decode_version);
-                                      CHECK(segment_id == dummy_segment_id);
-                                      DeltaColumnGroupPtr dcg_ptr = std::make_shared<DeltaColumnGroup>();
-                                      CHECK(dcg_ptr->load(decode_version, value.data(), value.size()).ok());
-                                      CHECK(dcgs != nullptr);
-                                      dcgs->push_back(std::move(dcg_ptr));
-                                      return true;
-                                  });
+    auto st = meta->iterate_range(
+            META_COLUMN_FAMILY_INDEX, lower, upper,
+            [&](std::string_view key, std::string_view value) -> StatusOr<bool> {
+                TTabletId dummy;
+                uint32_t dummy_segment_id;
+                int64_t decode_version;
+                decode_delta_column_group_key(key, &dummy, &dummy_segment_id, &decode_version);
+                RETURN_ERROR_IF_FALSE(segment_id == dummy_segment_id);
+                DeltaColumnGroupPtr dcg_ptr = std::make_shared<DeltaColumnGroup>();
+                RETURN_ERROR_IF_FALSE(dcg_ptr->load(decode_version, value.data(), value.size()).ok());
+                RETURN_ERROR_IF_FALSE(dcgs != nullptr);
+                dcgs->push_back(std::move(dcg_ptr));
+                return true;
+            });
     if (!st.ok()) {
         LOG(WARNING) << "fail to iterate rocksdb delvecs. tablet_id=" << tablet_id;
         return st;
@@ -1245,7 +1246,8 @@ Status TabletMetaManager::scan_delta_column_group(KVStore* meta, TTabletId table
     std::string lower = encode_delta_column_group_key(tablet_id, rowsetid, segment_id, end_version);
     std::string upper = encode_delta_column_group_key(tablet_id, rowsetid, segment_id, begin_version);
     auto st = meta->iterate_range(
-            META_COLUMN_FAMILY_INDEX, lower, upper, [&](std::string_view key, std::string_view value) -> bool {
+            META_COLUMN_FAMILY_INDEX, lower, upper,
+            [&](std::string_view key, std::string_view value) -> StatusOr<bool> {
                 TTabletId dummy;
                 uint32_t dummy_segment_id;
                 int64_t decode_version;
@@ -1254,11 +1256,11 @@ Status TabletMetaManager::scan_delta_column_group(KVStore* meta, TTabletId table
                 rowsetid_string = rowsetid.to_string();
                 rowsetid_string.resize(64, ' ');
                 decode_delta_column_group_key(key, &dummy, &dummy_rowsetid_string, &dummy_segment_id, &decode_version);
-                CHECK(segment_id == dummy_segment_id);
-                CHECK(rowsetid_string == dummy_rowsetid_string);
+                RETURN_ERROR_IF_FALSE(segment_id == dummy_segment_id);
+                RETURN_ERROR_IF_FALSE(rowsetid_string == dummy_rowsetid_string);
                 DeltaColumnGroupPtr dcg_ptr = std::make_shared<DeltaColumnGroup>();
-                CHECK(dcg_ptr->load(decode_version, value.data(), value.size()).ok());
-                CHECK(dcgs != nullptr);
+                RETURN_ERROR_IF_FALSE(dcg_ptr->load(decode_version, value.data(), value.size()).ok());
+                RETURN_ERROR_IF_FALSE(dcgs != nullptr);
                 dcgs->push_back(std::move(dcg_ptr));
                 return true;
             });
@@ -1274,18 +1276,19 @@ Status TabletMetaManager::scan_tablet_delta_column_group(KVStore* meta, TTabletI
                                                          DeltaColumnGroupList* dcgs) {
     std::string lower = encode_delta_column_group_key(tablet_id, 0, INT64_MAX);
     std::string upper = encode_delta_column_group_key(tablet_id, UINT32_MAX, INT64_MAX);
-    auto st = meta->iterate_range(META_COLUMN_FAMILY_INDEX, lower, upper,
-                                  [&](std::string_view key, std::string_view value) -> bool {
-                                      TTabletId dummy;
-                                      uint32_t dummy_segment_id;
-                                      int64_t decode_version;
-                                      decode_delta_column_group_key(key, &dummy, &dummy_segment_id, &decode_version);
-                                      DeltaColumnGroupPtr dcg_ptr = std::make_shared<DeltaColumnGroup>();
-                                      CHECK(dcg_ptr->load(decode_version, value.data(), value.size()).ok());
-                                      CHECK(dcgs != nullptr);
-                                      dcgs->push_back(std::move(dcg_ptr));
-                                      return true;
-                                  });
+    auto st = meta->iterate_range(
+            META_COLUMN_FAMILY_INDEX, lower, upper,
+            [&](std::string_view key, std::string_view value) -> StatusOr<bool> {
+                TTabletId dummy;
+                uint32_t dummy_segment_id;
+                int64_t decode_version;
+                decode_delta_column_group_key(key, &dummy, &dummy_segment_id, &decode_version);
+                DeltaColumnGroupPtr dcg_ptr = std::make_shared<DeltaColumnGroup>();
+                RETURN_ERROR_IF_FALSE(dcg_ptr->load(decode_version, value.data(), value.size()).ok());
+                RETURN_ERROR_IF_FALSE(dcgs != nullptr);
+                dcgs->push_back(std::move(dcg_ptr));
+                return true;
+            });
     if (!st.ok()) {
         LOG(WARNING) << "fail to iterate rocksdb delvecs. tablet_id=" << tablet_id;
         return st;
@@ -1297,18 +1300,19 @@ Status TabletMetaManager::scan_tablet_delta_column_group_by_segment(KVStore* met
                                                                     std::map<uint32_t, DeltaColumnGroupList>* dcgs) {
     std::string lower = encode_delta_column_group_key(tablet_id, 0, INT64_MAX);
     std::string upper = encode_delta_column_group_key(tablet_id, UINT32_MAX, INT64_MAX);
-    auto st = meta->iterate_range(META_COLUMN_FAMILY_INDEX, lower, upper,
-                                  [&](std::string_view key, std::string_view value) -> bool {
-                                      TTabletId dummy;
-                                      uint32_t segment_id;
-                                      int64_t decode_version;
-                                      decode_delta_column_group_key(key, &dummy, &segment_id, &decode_version);
-                                      DeltaColumnGroupPtr dcg_ptr = std::make_shared<DeltaColumnGroup>();
-                                      CHECK(dcg_ptr->load(decode_version, value.data(), value.size()).ok());
-                                      CHECK(dcgs != nullptr);
-                                      (*dcgs)[segment_id].push_back(std::move(dcg_ptr));
-                                      return true;
-                                  });
+    auto st = meta->iterate_range(
+            META_COLUMN_FAMILY_INDEX, lower, upper,
+            [&](std::string_view key, std::string_view value) -> StatusOr<bool> {
+                TTabletId dummy;
+                uint32_t segment_id;
+                int64_t decode_version;
+                decode_delta_column_group_key(key, &dummy, &segment_id, &decode_version);
+                DeltaColumnGroupPtr dcg_ptr = std::make_shared<DeltaColumnGroup>();
+                RETURN_ERROR_IF_FALSE(dcg_ptr->load(decode_version, value.data(), value.size()).ok());
+                RETURN_ERROR_IF_FALSE(dcgs != nullptr);
+                (*dcgs)[segment_id].push_back(std::move(dcg_ptr));
+                return true;
+            });
     if (!st.ok()) {
         LOG(WARNING) << "fail to iterate rocksdb delvecs. tablet_id=" << tablet_id;
         return st;
@@ -1788,7 +1792,7 @@ Status TabletMetaManager::pending_rowset_iterate(DataDir* store, TTabletId table
     put_fixed64_le(&prefix, BigEndian::FromHost64(tablet_id));
 
     return store->get_meta()->iterate(
-            META_COLUMN_FAMILY_INDEX, prefix, [&](std::string_view key, std::string_view value) -> bool {
+            META_COLUMN_FAMILY_INDEX, prefix, [&](std::string_view key, std::string_view value) -> StatusOr<bool> {
                 TTabletId tid = -1;
                 int64_t version = -1;
                 if (!decode_meta_pending_rowset_key(key, &tid, &version)) {

--- a/be/src/storage/tablet_meta_manager.h
+++ b/be/src/storage/tablet_meta_manager.h
@@ -141,7 +141,7 @@ public:
     static Status pending_rowset_commit(DataDir* store, TTabletId tablet_id, int64_t version,
                                         const RowsetMetaPB& rowset, const string& rowset_meta_key);
 
-    using PendingRowsetIterateFunc = std::function<bool(int64_t version, std::string_view rowset_meta_data)>;
+    using PendingRowsetIterateFunc = std::function<StatusOr<bool>(int64_t version, std::string_view rowset_meta_data)>;
     static Status pending_rowset_iterate(DataDir* store, TTabletId tablet_id, const PendingRowsetIterateFunc& func);
 
     // On success, store a pointer to `RowsetMeta` in |*meta| and return OK status.

--- a/be/src/storage/tablet_reader.cpp
+++ b/be/src/storage/tablet_reader.cpp
@@ -161,9 +161,7 @@ Status TabletReader::_init_collector_for_pk_index_read() {
                                                         num_pk_eq_predicates, tablet_schema->num_key_columns()));
     }
     std::unique_ptr<Column> pk_column;
-    if (!PrimaryKeyEncoder::create_column(*tablet_schema->schema(), &pk_column).ok()) {
-        CHECK(false) << "create column for primary key encoder failed tablet_id:" << _tablet->tablet_id();
-    }
+    RETURN_IF_ERROR(PrimaryKeyEncoder::create_column(*tablet_schema->schema(), &pk_column));
     PrimaryKeyEncoder::encode(*tablet_schema->schema(), *keys, 0, keys->num_rows(), pk_column.get());
 
     // get rowid using pk index


### PR DESCRIPTION
Why I'm doing:
There are many `CHECK` in primary key table code, and it's not robust.

What I'm doing:
Remove `CHECK` in primary key table code.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [x] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
