### PR TITLE
[Enhancement] Add thread pool metrics

### DIFF
--- a/be/src/agent/agent_server.cpp
+++ b/be/src/agent/agent_server.cpp
@@ -174,8 +174,7 @@ void AgentServer::Impl::init_or_die() {
         BUILD_DYNAMIC_TASK_THREAD_POOL("publish_version", MIN_TRANSACTION_PUBLISH_WORKER_COUNT,
                                        max_publish_version_worker_count, DEFAULT_DYNAMIC_THREAD_POOL_QUEUE_SIZE,
                                        _thread_pool_publish_version);
-        REGISTER_GAUGE_STARROCKS_METRIC(publish_version_queue_count,
-                                        [this]() { return _thread_pool_publish_version->num_queued_tasks(); });
+        REGISTER_THREAD_POOL_METRICS(publish_version, _thread_pool_publish_version);
 #endif
 
         BUILD_DYNAMIC_TASK_THREAD_POOL("drop", 1, config::drop_tablet_worker_count, std::numeric_limits<int>::max(),

--- a/be/src/storage/persistent_index_compaction_manager.cpp
+++ b/be/src/storage/persistent_index_compaction_manager.cpp
@@ -37,8 +37,7 @@ Status PersistentIndexCompactionManager::init() {
                             .set_min_threads(1)
                             .set_max_threads(max_pk_index_compaction_thread_cnt)
                             .build(&_worker_thread_pool));
-    REGISTER_GAUGE_STARROCKS_METRIC(pk_index_compaction_queue_count,
-                                    [this]() { return _worker_thread_pool->num_queued_tasks(); });
+    REGISTER_THREAD_POOL_METRICS(pk_index_compaction, _worker_thread_pool);
 
     return Status::OK();
 }

--- a/be/src/storage/storage_engine.cpp
+++ b/be/src/storage/storage_engine.cpp
@@ -221,28 +221,21 @@ Status StorageEngine::_open(const EngineOptions& options) {
 
     _async_delta_writer_executor =
             std::make_unique<bthreads::ThreadPoolExecutor>(thread_pool.release(), kTakesOwnership);
-    REGISTER_GAUGE_STARROCKS_METRIC(async_delta_writer_queue_count, [this]() {
-        return static_cast<bthreads::ThreadPoolExecutor*>(_async_delta_writer_executor.get())
-                ->get_thread_pool()
-                ->num_queued_tasks();
-    })
+    REGISTER_THREAD_POOL_METRICS(
+            async_delta_writer,
+            static_cast<bthreads::ThreadPoolExecutor*>(_async_delta_writer_executor.get())->get_thread_pool());
 
     _memtable_flush_executor = std::make_unique<MemTableFlushExecutor>();
     RETURN_IF_ERROR_WITH_WARN(_memtable_flush_executor->init(dirs), "init MemTableFlushExecutor failed");
-    REGISTER_GAUGE_STARROCKS_METRIC(memtable_flush_queue_count, [this]() {
-        return _memtable_flush_executor->get_thread_pool()->num_queued_tasks();
-    })
+    REGISTER_THREAD_POOL_METRICS(memtable_flush, _memtable_flush_executor->get_thread_pool());
 
     _segment_flush_executor = std::make_unique<SegmentFlushExecutor>();
     RETURN_IF_ERROR_WITH_WARN(_segment_flush_executor->init(dirs), "init SegmentFlushExecutor failed");
-    REGISTER_GAUGE_STARROCKS_METRIC(segment_flush_queue_count,
-                                    [this]() { return _segment_flush_executor->get_thread_pool()->num_queued_tasks(); })
+    REGISTER_THREAD_POOL_METRICS(segment_flush, _segment_flush_executor->get_thread_pool());
 
     _segment_replicate_executor = std::make_unique<SegmentReplicateExecutor>();
     RETURN_IF_ERROR_WITH_WARN(_segment_replicate_executor->init(dirs), "init SegmentReplicateExecutor failed");
-    REGISTER_GAUGE_STARROCKS_METRIC(segment_replicate_queue_count, [this]() {
-        return _segment_replicate_executor->get_thread_pool()->num_queued_tasks();
-    })
+    REGISTER_THREAD_POOL_METRICS(segment_replicate, _segment_replicate_executor->get_thread_pool());
 
     RETURN_IF_ERROR_WITH_WARN(_replication_txn_manager->init(dirs), "init ReplicationTxnManager failed");
 

--- a/be/src/storage/update_manager.cpp
+++ b/be/src/storage/update_manager.cpp
@@ -97,8 +97,7 @@ Status UpdateManager::init() {
         max_thread_cnt = config::transaction_apply_worker_count;
     }
     RETURN_IF_ERROR(ThreadPoolBuilder("update_apply").set_max_threads(max_thread_cnt).build(&_apply_thread_pool));
-    REGISTER_GAUGE_STARROCKS_METRIC(update_apply_queue_count,
-                                    [this]() { return _apply_thread_pool->num_queued_tasks(); });
+    REGISTER_THREAD_POOL_METRICS(update_apply, _apply_thread_pool);
 
     int max_get_thread_cnt =
             config::get_pindex_worker_count > max_thread_cnt ? config::get_pindex_worker_count : max_thread_cnt * 2;

--- a/be/src/util/starrocks_metrics.h
+++ b/be/src/util/starrocks_metrics.h
@@ -67,6 +67,25 @@ private:
     StarRocksMetrics::instance()->metrics()->register_hook(                                               \
             #name, [&]() { StarRocksMetrics::instance()->name.set_value(func()); });
 
+#define METRICS_DEFINE_THREAD_POOL(threadpool_name)                                             \
+    METRIC_DEFINE_UINT_GAUGE(threadpool_name##_threadpool_size, MetricUnit::NOUNIT);            \
+    METRIC_DEFINE_UINT_GAUGE(threadpool_name##_executed_tasks_total, MetricUnit::NOUNIT);       \
+    METRIC_DEFINE_UINT_GAUGE(threadpool_name##_pending_time_ns_total, MetricUnit::NANOSECONDS); \
+    METRIC_DEFINE_UINT_GAUGE(threadpool_name##_execute_time_ns_total, MetricUnit::NANOSECONDS); \
+    METRIC_DEFINE_UINT_GAUGE(threadpool_name##_queue_count, MetricUnit::NOUNIT)
+
+#define REGISTER_THREAD_POOL_METRICS(name, threadpool)                                                           \
+    do {                                                                                                         \
+        REGISTER_GAUGE_STARROCKS_METRIC(name##_threadpool_size, [this]() { return threadpool->max_threads(); })  \
+        REGISTER_GAUGE_STARROCKS_METRIC(name##_executed_tasks_total,                                             \
+                                        [this]() { return threadpool->total_executed_tasks(); })                 \
+        REGISTER_GAUGE_STARROCKS_METRIC(name##_pending_time_ns_total,                                            \
+                                        [this]() { return threadpool->total_pending_time_ns(); })                \
+        REGISTER_GAUGE_STARROCKS_METRIC(name##_execute_time_ns_total,                                            \
+                                        [this]() { return threadpool->total_execute_time_ns(); })                \
+        REGISTER_GAUGE_STARROCKS_METRIC(name##_queue_count, [this]() { return threadpool->num_queued_tasks(); }) \
+    } while (false)
+
 class StarRocksMetrics {
 public:
     // query execution
@@ -278,14 +297,14 @@ public:
     METRIC_DEFINE_UINT_GAUGE(brpc_endpoint_stub_count, MetricUnit::NOUNIT);
     METRIC_DEFINE_UINT_GAUGE(tablet_writer_count, MetricUnit::NOUNIT);
 
-    // queue task count of thread pool
-    METRIC_DEFINE_UINT_GAUGE(publish_version_queue_count, MetricUnit::NOUNIT);
-    METRIC_DEFINE_UINT_GAUGE(async_delta_writer_queue_count, MetricUnit::NOUNIT);
-    METRIC_DEFINE_UINT_GAUGE(memtable_flush_queue_count, MetricUnit::NOUNIT);
-    METRIC_DEFINE_UINT_GAUGE(segment_replicate_queue_count, MetricUnit::NOUNIT);
-    METRIC_DEFINE_UINT_GAUGE(segment_flush_queue_count, MetricUnit::NOUNIT);
-    METRIC_DEFINE_UINT_GAUGE(update_apply_queue_count, MetricUnit::NOUNIT);
-    METRIC_DEFINE_UINT_GAUGE(pk_index_compaction_queue_count, MetricUnit::NOUNIT);
+    // thread pool metrics
+    METRICS_DEFINE_THREAD_POOL(publish_version);
+    METRICS_DEFINE_THREAD_POOL(async_delta_writer);
+    METRICS_DEFINE_THREAD_POOL(memtable_flush);
+    METRICS_DEFINE_THREAD_POOL(segment_replicate);
+    METRICS_DEFINE_THREAD_POOL(segment_flush);
+    METRICS_DEFINE_THREAD_POOL(update_apply);
+    METRICS_DEFINE_THREAD_POOL(pk_index_compaction);
 
     METRIC_DEFINE_UINT_GAUGE(load_rpc_threadpool_size, MetricUnit::NOUNIT);
 

--- a/be/src/util/threadpool.cpp
+++ b/be/src/util/threadpool.cpp
@@ -557,6 +557,7 @@ void ThreadPool::dispatch_thread() {
 
         l.unlock();
 
+        MonoTime start_time = MonoTime::Now();
         // Execute the task
         task.runnable->run();
         current_thread->inc_finished_tasks();
@@ -568,6 +569,12 @@ void ThreadPool::dispatch_thread() {
         // In the worst case, the destructor might even try to do something
         // with this threadpool, and produce a deadlock.
         task.runnable.reset();
+        MonoTime finish_time = MonoTime::Now();
+
+        _total_executed_tasks << 1;
+        _total_pending_time_ns << start_time.GetDeltaSince(task.submit_time).ToNanoseconds();
+        _total_execute_time_ns << finish_time.GetDeltaSince(start_time).ToNanoseconds();
+
         l.lock();
         _last_active_timestamp = MonoTime::Now();
 

--- a/be/src/util/threadpool.h
+++ b/be/src/util/threadpool.h
@@ -34,6 +34,7 @@
 
 #pragma once
 
+#include <bvar/bvar.h>
 #include <fmt/format.h>
 
 #include <atomic>
@@ -248,6 +249,15 @@ public:
 
     int max_threads() const { return _max_threads.load(std::memory_order_acquire); }
 
+    // Use bvar as the counter, and should not be called frequently.
+    int64_t total_executed_tasks() const { return _total_executed_tasks.get_value(); }
+
+    // Use bvar as the counter, and should not be called frequently.
+    int64_t total_pending_time_ns() const { return _total_pending_time_ns.get_value(); }
+
+    // Use bvar as the counter, and should not be called frequently.
+    int64_t total_execute_time_ns() const { return _total_execute_time_ns.get_value(); }
+
 private:
     friend class ThreadPoolBuilder;
     friend class ThreadPoolToken;
@@ -371,6 +381,15 @@ private:
 
     // ExecutionMode::CONCURRENT token used by the pool for tokenless submission.
     std::unique_ptr<ThreadPoolToken> _tokenless;
+
+    // Total number of tasks that have finished
+    bvar::Adder<int64_t> _total_executed_tasks;
+
+    // Total time in nanoseconds that tasks pending in the queue.
+    bvar::Adder<int64_t> _total_pending_time_ns;
+
+    // Total time in nanoseconds to execute tasks.
+    bvar::Adder<int64_t> _total_execute_time_ns;
 
     ThreadPool(const ThreadPool&) = delete;
     const ThreadPool& operator=(const ThreadPool&) = delete;

--- a/be/test/util/starrocks_metrics_test.cpp
+++ b/be/test/util/starrocks_metrics_test.cpp
@@ -303,11 +303,11 @@ TEST_F(StarRocksMetricsTest, PageCacheMetrics) {
 }
 
 void assert_threadpool_metrics_register(const std::string& pool_name, MetricRegistry* instance) {
-    ASSERT_NE(nullptr, instance->get_metric(pool_name + "_threadpool_size"));
-    ASSERT_NE(nullptr, instance->get_metric(pool_name + "_total_pending_time_ns"));
-    ASSERT_NE(nullptr, instance->get_metric(pool_name + "_total_execute_time_ns"));
-    ASSERT_NE(nullptr, instance->get_metric(pool_name + "_total_executed_tasks"));
-    ASSERT_NE(nullptr, instance->get_metric(pool_name + "_queue_count"));
+    ASSERT_TRUE(instance->get_metric(pool_name + "_threadpool_size") != nullptr);
+    ASSERT_TRUE(instance->get_metric(pool_name + "_executed_tasks_total") != nullptr);
+    ASSERT_TRUE(instance->get_metric(pool_name + "_pending_time_ns_total") != nullptr);
+    ASSERT_TRUE(instance->get_metric(pool_name + "_execute_time_ns_total") != nullptr);
+    ASSERT_TRUE(instance->get_metric(pool_name + "_queue_count") != nullptr);
 }
 
 TEST_F(StarRocksMetricsTest, test_metrics_register) {
@@ -321,7 +321,6 @@ TEST_F(StarRocksMetricsTest, test_metrics_register) {
     ASSERT_NE(nullptr, instance->get_metric("segment_flush_duration_us"));
     ASSERT_NE(nullptr, instance->get_metric("segment_flush_io_time_us"));
     ASSERT_NE(nullptr, instance->get_metric("segment_flush_bytes_total"));
-    assert_threadpool_metrics_register("publish_version", instance);
     assert_threadpool_metrics_register("async_delta_writer", instance);
     assert_threadpool_metrics_register("memtable_flush", instance);
     assert_threadpool_metrics_register("segment_replicate", instance);

--- a/be/test/util/starrocks_metrics_test.cpp
+++ b/be/test/util/starrocks_metrics_test.cpp
@@ -302,6 +302,14 @@ TEST_F(StarRocksMetricsTest, PageCacheMetrics) {
     ASSERT_STREQ(std::to_string(cache->get_capacity()).c_str(), capacity_metric->to_string().c_str());
 }
 
+void assert_threadpool_metrics_register(const std::string& pool_name, MetricRegistry* instance) {
+    ASSERT_NE(nullptr, instance->get_metric(pool_name + "_threadpool_size"));
+    ASSERT_NE(nullptr, instance->get_metric(pool_name + "_total_pending_time_ns"));
+    ASSERT_NE(nullptr, instance->get_metric(pool_name + "_total_execute_time_ns"));
+    ASSERT_NE(nullptr, instance->get_metric(pool_name + "_total_executed_tasks"));
+    ASSERT_NE(nullptr, instance->get_metric(pool_name + "_queue_count"));
+}
+
 TEST_F(StarRocksMetricsTest, test_metrics_register) {
     auto instance = StarRocksMetrics::instance()->metrics();
     ASSERT_NE(nullptr, instance->get_metric("memtable_flush_total"));
@@ -313,6 +321,13 @@ TEST_F(StarRocksMetricsTest, test_metrics_register) {
     ASSERT_NE(nullptr, instance->get_metric("segment_flush_duration_us"));
     ASSERT_NE(nullptr, instance->get_metric("segment_flush_io_time_us"));
     ASSERT_NE(nullptr, instance->get_metric("segment_flush_bytes_total"));
+    assert_threadpool_metrics_register("publish_version", instance);
+    assert_threadpool_metrics_register("async_delta_writer", instance);
+    assert_threadpool_metrics_register("memtable_flush", instance);
+    assert_threadpool_metrics_register("segment_replicate", instance);
+    assert_threadpool_metrics_register("segment_flush", instance);
+    assert_threadpool_metrics_register("update_apply", instance);
+    assert_threadpool_metrics_register("pk_index_compaction", instance);
 }
 
 } // namespace starrocks


### PR DESCRIPTION
## Why I'm doing:
There are many thread pools in BE, such as delta writer, memtable flush, segment flush, publish version. But there is not enough metrics to monitor the status of these pools, such as the max threads in the pool, how busy the thread pool is. These metrics are helpful for analyzing problems and tuning.

## What I'm doing:
Add following metrics for a thread pool
* `threadpool_size`: the maximum number of threads. With this metrics, there is no need to ask users for their configurations
* `executed_tasks_total`: the total number of tasks that have run. It reflects the load by calculating `rate(executed_tasks_total[interval])` in prometheus. If the pool is busy suddenly, we can know whether the load increased.
* `execute_time_ns_total`: total time to run tasks. It has two purposes
    * reflects how busy the pool is. We can calculate thread pool usage by `rate(execute_time_ns_total)[interval] / 1000000000 / threadpool_size * 100` in prometheus. If it's nearly close to 100%, the pool is very busy, and maybe should increase `threadpool_size`
    * reflects the average time to run a task, which can be calculated by `rate(execute_time_ns_total[interval]) / rate(total_task_num[interval])` in prometheus. We can then estimate whether the time is valid
* `pending_time_ns_total`: total time that tasks wait for run in the queue. Pending in the queue is part of the lifecycle of a task. Lightweight tasks may take much time from submitted to finished because of pending too much time. We can identify this case by calculating average pending time `rate(pending_time_ns_total[interval]) / rate(executed_tasks_total[interval])`

Currently only add metrics for thread pools related to load including delta writer, memtable flush, segment flush, publish version. Other pools can be added as needed later.

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [X] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
