### PR TITLE
[BugFix] Fix semi-type prune column bug

### DIFF
--- a/be/src/storage/rowset/segment_iterator.cpp
+++ b/be/src/storage/rowset/segment_iterator.cpp
@@ -1548,7 +1548,7 @@ Status SegmentIterator::_decode_dict_codes(ScanContext* ctx) {
         const FieldPtr& f = decode_schema.field(i);
         const ColumnId cid = f->id();
         if (!ctx->_is_dict_column[i] || ctx->_skip_dict_decode_indexes[i]) {
-            ctx->_dict_chunk->get_column_by_index(i)->swap_column(*ctx->_read_chunk->get_column_by_index(i));
+            ctx->_dict_chunk->get_column_by_index(i).swap(ctx->_read_chunk->get_column_by_index(i));
         } else {
             ColumnPtr& dict_codes = ctx->_read_chunk->get_column_by_index(i);
             ColumnPtr& dict_values = ctx->_dict_chunk->get_column_by_index(i);

--- a/test/sql/test_semi/R/test_prune
+++ b/test/sql/test_semi/R/test_prune
@@ -85,8 +85,8 @@ select map_size(m1), map_keys(m1) from sc3;
 select map_values(m1), map_keys(m1) from sc3;
 -- result:
 [12,22]	[1,2]
-[11,21]	[1,2]
 [13,23]	[1,2]
+[11,21]	[1,2]
 -- !result
 select map_size(m1) from sc3 where m1[1] = 12;
 -- result:
@@ -107,8 +107,8 @@ select cardinality(m1) from sc3 where m1[1] = 12;
 select m2[1].c, array_length(m2[2].b) from sc3;
 -- result:
 12	3
-11	3
 13	3
+11	3
 -- !result
 select m2[1].c, array_length(m2[2].b) from sc3 where m2[1] = row(11, [111, 221, 331]);
 -- result:
@@ -127,8 +127,8 @@ select s1.s2[1].a from sc3;
 select s1.s2[1].a, s1.s3[1], s1.s4.f from sc3;
 -- result:
 1	12	2
-1	11	1
 1	13	3
+1	11	1
 -- !result
 select s1.s2[1].a, s1.s3[1], s1.s4.f from sc3 where s1.s2 = [row(1,3), row(2,3)];
 -- result:
@@ -146,4 +146,175 @@ select v1 from sc3 where a1[1] not in (select tt.v1 from sc3 as tt where false);
 2
 1
 3
+-- !result
+CREATE TABLE `scs3` (
+  `v1` bigint(20) NULL COMMENT "",
+  `str` string NULL COMMENT "",
+  `a1` ARRAY<INT> NULL,
+  `a2` ARRAY<STRUCT<a INT, b INT>> NULL,
+  `m1` MAP<INT, INT> NULL,
+  `m2` MAP<INT, STRUCT<c INT, b ARRAY<INT>>> NULL,
+  `s1` STRUCT<s1 int, s2 ARRAY<STRUCT<a int, b int>>, s3 MAP<INT, INT>, s4 Struct<e INT, f INT>>
+) ENGINE=OLAP
+DUPLICATE KEY(`v1`)
+COMMENT "OLAP"
+DISTRIBUTED BY HASH(`v1`) BUCKETS 3
+PROPERTIES (
+"replication_num" = "1",
+"in_memory" = "false",
+"enable_persistent_index" = "false",
+"replicated_storage" = "true",
+"compression" = "LZ4"
+);
+-- result:
+-- !result
+insert into scs3 values (1, "aa", [1,2,3],[row(1,11),row(2,21),row(3,31)], map{1:11, 2:21}, map{1:row(11, [111, 221, 331]), 2:row(22, [221, 221, 331])}, row(1, [row(1,1), row(2,1)], map{1:11, 2:21}, row(1,1)));
+-- result:
+-- !result
+insert into scs3 values (2, "bb", [2,2,3],[row(1,12),row(2,22),row(3,32)], map{1:12, 2:22}, map{1:row(12, [112, 222, 332]), 2:row(22, [222, 222, 332])}, row(1, [row(1,2), row(2,2)], map{1:12, 2:22}, row(1,2)));
+-- result:
+-- !result
+insert into scs3 values (3, "cc", [3,2,3],[row(1,13),row(2,23),row(3,33)], map{1:13, 2:23}, map{1:row(13, [113, 223, 333]), 2:row(22, [223, 223, 333])}, row(1, [row(1,3), row(2,3)], map{1:13, 2:23}, row(1,3)));
+-- result:
+-- !result
+insert into scs3 values (4, "dd", [4,2,3],[row(1,13),row(2,23),row(3,33)], map{1:13, 2:23}, map{1:row(13, [113, 223, 333]), 2:row(22, [223, 223, 333])}, row(1, [row(1,3), row(2,3)], map{1:13, 2:23}, row(1,3)));
+-- result:
+-- !result
+insert into scs3 values (5, "ee", [5,2,3],[row(1,13),row(2,23),row(3,33)], map{1:13, 2:23}, map{1:row(13, [113, 223, 333]), 2:row(22, [223, 223, 333])}, row(1, [row(1,3), row(2,3)], map{1:13, 2:23}, row(1,3)));
+-- result:
+-- !result
+insert into scs3 values (6, "ff", [6,2,3],[row(1,13),row(2,23),row(3,33)], map{1:13, 2:23}, map{1:row(13, [113, 223, 333]), 2:row(22, [223, 223, 333])}, row(1, [row(1,3), row(2,3)], map{1:13, 2:23}, row(1,3)));
+-- result:
+-- !result
+insert into scs3 values (7, "gg", [7,2,3],[row(1,13),row(2,23),row(3,33)], map{1:13, 2:23}, map{1:row(13, [113, 223, 333]), 2:row(22, [223, 223, 333])}, row(1, [row(1,3), row(2,3)], map{1:13, 2:23}, row(1,3)));
+-- result:
+-- !result
+insert into scs3 values (8, "hh", [8,2,3],[row(1,13),row(2,23),row(3,33)], map{1:13, 2:23}, map{1:row(13, [113, 223, 333]), 2:row(22, [223, 223, 333])}, row(1, [row(1,3), row(2,3)], map{1:13, 2:23}, row(1,3)));
+-- result:
+-- !result
+insert into scs3 values (9, "ii", [9,2,3],[row(1,13),row(2,23),row(3,33)], map{1:13, 2:23}, map{1:row(13, [113, 223, 333]), 2:row(22, [223, 223, 333])}, row(1, [row(1,3), row(2,3)], map{1:13, 2:23}, row(1,3)));
+-- result:
+-- !result
+insert into scs3 values (10, "kk" ,[10,2,3],[row(1,13),row(2,23),row(3,33)], map{1:13, 2:23}, map{1:row(13, [113, 223, 333]), 2:row(22, [223, 223, 333])}, row(1, [row(1,3), row(2,3)], map{1:13, 2:23}, row(1,3)));
+-- result:
+-- !result
+insert into scs3 select * from scs3;
+-- result:
+-- !result
+insert into scs3 select * from scs3;
+-- result:
+-- !result
+insert into scs3 select * from scs3;
+-- result:
+-- !result
+insert into scs3 select * from scs3;
+-- result:
+-- !result
+insert into scs3 select * from scs3;
+-- result:
+-- !result
+insert into scs3 select * from scs3;
+-- result:
+-- !result
+insert into scs3 select * from scs3;
+-- result:
+-- !result
+insert into scs3 select * from scs3;
+-- result:
+-- !result
+insert into scs3 select * from scs3;
+-- result:
+-- !result
+insert into scs3 select * from scs3;
+-- result:
+-- !result
+insert into scs3 select * from scs3;
+-- result:
+-- !result
+insert into scs3 select * from scs3;
+-- result:
+-- !result
+select a1, v1 from scs3 where str = "aa" order by v1 limit 2;
+-- result:
+[1,2,3]	1
+[1,2,3]	1
+-- !result
+select array_length(a1), a2[1].a  from scs3 where str = "aa" order by v1 limit 2;
+-- result:
+3	1
+3	1
+-- !result
+select map_size(m1), s1.s2[1].a, s1.s3[1], s1.s4.f from scs3 where str = "aa" order by v1 limit 2;
+-- result:
+2	1	11	1
+2	1	11	1
+-- !result
+select a1, a2[1] from scs3 where str in ("aa", "bb") order by v1 limit 2;
+-- result:
+[1,2,3]	{"a":1,"b":11}
+[1,2,3]	{"a":1,"b":11}
+-- !result
+select array_length(a1), a2[1].a  from scs3 where str in ("aa", "bb", "cc") order by v1 limit 2;
+-- result:
+3	1
+3	1
+-- !result
+select map_size(m1), s1.s2[1].a, s1.s3[1], s1.s4.f from scs3 where str in ("aa", "bb", "cc") order by v1 limit 2;
+-- result:
+2	1	11	1
+2	1	11	1
+-- !result
+select a1, s1.s3 from scs3 where str in ("aa", "bb", "cc", "dd", "ee", "ff") order by v1 limit 2;
+-- result:
+[1,2,3]	{1:11,2:21}
+[1,2,3]	{1:11,2:21}
+-- !result
+select array_length(a1), a2[1].a  from scs3 where str in ("aa", "bb", "cc", "gg", "kk") order by v1 limit 2;
+-- result:
+3	1
+3	1
+-- !result
+select map_size(m1), s1.s2[1].a, s1.s3[1], s1.s4.f from scs3 where str in ("aa", "bb", "ii", "cc") order by v1 limit 2;
+-- result:
+2	1	11	1
+2	1	11	1
+-- !result
+select a1, m1 from scs3 where str = "aa" and a1[2] = 2 order by v1 limit 2;
+-- result:
+[1,2,3]	{1:11,2:21}
+[1,2,3]	{1:11,2:21}
+-- !result
+select array_length(a1), a2[1].a  from scs3 where str = "aa" and s1.s1 > 2 order by v1 limit 2;
+-- result:
+-- !result
+select map_size(m1), s1.s2[1].a, s1.s3[1], s1.s4.f from scs3 where str = "aa" and m1[2] > 0 order by v1 limit 2;
+-- result:
+2	1	11	1
+2	1	11	1
+-- !result
+select a1, m1 from scs3 where str = "aa" and a1[2] = 2 order by v1 limit 2;
+-- result:
+[1,2,3]	{1:11,2:21}
+[1,2,3]	{1:11,2:21}
+-- !result
+select array_length(a1), a2[1].a  from scs3 where str = "aa" and s1.s1 > 2 order by v1 limit 2;
+-- result:
+-- !result
+select map_size(m1), s1.s2[1].a, s1.s3[1], s1.s4.f from scs3 where str = "aa" and m1[2] > 0 order by v1 limit 2;
+-- result:
+2	1	11	1
+2	1	11	1
+-- !result
+select a1, m1 from scs3 where str >= "aa" and a1[2] = 2 order by v1 limit 2;
+-- result:
+[1,2,3]	{1:11,2:21}
+[1,2,3]	{1:11,2:21}
+-- !result
+select array_length(a1), a2[1].a  from scs3 where str <= "gg" and s1.s1 > 2 order by v1 limit 2;
+-- result:
+-- !result
+select map_size(m1), s1.s2[1].a, s1.s3[1], s1.s4.f from scs3 where str != "aa" and m1[2] > 0 order by v1 limit 2;
+-- result:
+2	1	12	2
+2	1	12	2
 -- !result

--- a/test/sql/test_semi/T/test_prune
+++ b/test/sql/test_semi/T/test_prune
@@ -51,3 +51,73 @@ select s1.s2[1].a, s1.s3[1], s1.s4.f from sc3 where s1.s2[2].a = 3;
 select s1.s2[1].a, s1.s3[1], s1.s4.f from sc3 where s1.s3[2] = 22;
 
 select v1 from sc3 where a1[1] not in (select tt.v1 from sc3 as tt where false);
+
+--name: test_prune_with_dict_column @system
+CREATE TABLE `scs3` (
+  `v1` bigint(20) NULL COMMENT "",
+  `str` string NULL COMMENT "",
+  `a1` ARRAY<INT> NULL,
+  `a2` ARRAY<STRUCT<a INT, b INT>> NULL,
+  `m1` MAP<INT, INT> NULL,
+  `m2` MAP<INT, STRUCT<c INT, b ARRAY<INT>>> NULL,
+  `s1` STRUCT<s1 int, s2 ARRAY<STRUCT<a int, b int>>, s3 MAP<INT, INT>, s4 Struct<e INT, f INT>>
+) ENGINE=OLAP
+DUPLICATE KEY(`v1`)
+COMMENT "OLAP"
+DISTRIBUTED BY HASH(`v1`) BUCKETS 3
+PROPERTIES (
+"replication_num" = "1",
+"in_memory" = "false",
+"enable_persistent_index" = "false",
+"replicated_storage" = "true",
+"compression" = "LZ4"
+);
+
+
+insert into scs3 values (1, "aa", [1,2,3],[row(1,11),row(2,21),row(3,31)], map{1:11, 2:21}, map{1:row(11, [111, 221, 331]), 2:row(22, [221, 221, 331])}, row(1, [row(1,1), row(2,1)], map{1:11, 2:21}, row(1,1)));
+insert into scs3 values (2, "bb", [2,2,3],[row(1,12),row(2,22),row(3,32)], map{1:12, 2:22}, map{1:row(12, [112, 222, 332]), 2:row(22, [222, 222, 332])}, row(1, [row(1,2), row(2,2)], map{1:12, 2:22}, row(1,2)));
+insert into scs3 values (3, "cc", [3,2,3],[row(1,13),row(2,23),row(3,33)], map{1:13, 2:23}, map{1:row(13, [113, 223, 333]), 2:row(22, [223, 223, 333])}, row(1, [row(1,3), row(2,3)], map{1:13, 2:23}, row(1,3)));
+insert into scs3 values (4, "dd", [4,2,3],[row(1,13),row(2,23),row(3,33)], map{1:13, 2:23}, map{1:row(13, [113, 223, 333]), 2:row(22, [223, 223, 333])}, row(1, [row(1,3), row(2,3)], map{1:13, 2:23}, row(1,3)));
+insert into scs3 values (5, "ee", [5,2,3],[row(1,13),row(2,23),row(3,33)], map{1:13, 2:23}, map{1:row(13, [113, 223, 333]), 2:row(22, [223, 223, 333])}, row(1, [row(1,3), row(2,3)], map{1:13, 2:23}, row(1,3)));
+insert into scs3 values (6, "ff", [6,2,3],[row(1,13),row(2,23),row(3,33)], map{1:13, 2:23}, map{1:row(13, [113, 223, 333]), 2:row(22, [223, 223, 333])}, row(1, [row(1,3), row(2,3)], map{1:13, 2:23}, row(1,3)));
+insert into scs3 values (7, "gg", [7,2,3],[row(1,13),row(2,23),row(3,33)], map{1:13, 2:23}, map{1:row(13, [113, 223, 333]), 2:row(22, [223, 223, 333])}, row(1, [row(1,3), row(2,3)], map{1:13, 2:23}, row(1,3)));
+insert into scs3 values (8, "hh", [8,2,3],[row(1,13),row(2,23),row(3,33)], map{1:13, 2:23}, map{1:row(13, [113, 223, 333]), 2:row(22, [223, 223, 333])}, row(1, [row(1,3), row(2,3)], map{1:13, 2:23}, row(1,3)));
+insert into scs3 values (9, "ii", [9,2,3],[row(1,13),row(2,23),row(3,33)], map{1:13, 2:23}, map{1:row(13, [113, 223, 333]), 2:row(22, [223, 223, 333])}, row(1, [row(1,3), row(2,3)], map{1:13, 2:23}, row(1,3)));
+insert into scs3 values (10, "kk" ,[10,2,3],[row(1,13),row(2,23),row(3,33)], map{1:13, 2:23}, map{1:row(13, [113, 223, 333]), 2:row(22, [223, 223, 333])}, row(1, [row(1,3), row(2,3)], map{1:13, 2:23}, row(1,3)));
+
+insert into scs3 select * from scs3;
+insert into scs3 select * from scs3;
+insert into scs3 select * from scs3;
+insert into scs3 select * from scs3;
+insert into scs3 select * from scs3;
+insert into scs3 select * from scs3;
+insert into scs3 select * from scs3;
+insert into scs3 select * from scs3;
+insert into scs3 select * from scs3;
+insert into scs3 select * from scs3;
+insert into scs3 select * from scs3;
+insert into scs3 select * from scs3;
+
+select a1, v1 from scs3 where str = "aa" order by v1 limit 2;
+select array_length(a1), a2[1].a  from scs3 where str = "aa" order by v1 limit 2;
+select map_size(m1), s1.s2[1].a, s1.s3[1], s1.s4.f from scs3 where str = "aa" order by v1 limit 2;
+
+select a1, a2[1] from scs3 where str in ("aa", "bb") order by v1 limit 2;
+select array_length(a1), a2[1].a  from scs3 where str in ("aa", "bb", "cc") order by v1 limit 2;
+select map_size(m1), s1.s2[1].a, s1.s3[1], s1.s4.f from scs3 where str in ("aa", "bb", "cc") order by v1 limit 2;
+
+select a1, s1.s3 from scs3 where str in ("aa", "bb", "cc", "dd", "ee", "ff") order by v1 limit 2;
+select array_length(a1), a2[1].a  from scs3 where str in ("aa", "bb", "cc", "gg", "kk") order by v1 limit 2;
+select map_size(m1), s1.s2[1].a, s1.s3[1], s1.s4.f from scs3 where str in ("aa", "bb", "ii", "cc") order by v1 limit 2;
+
+select a1, m1 from scs3 where str = "aa" and a1[2] = 2 order by v1 limit 2;
+select array_length(a1), a2[1].a  from scs3 where str = "aa" and s1.s1 > 2 order by v1 limit 2;
+select map_size(m1), s1.s2[1].a, s1.s3[1], s1.s4.f from scs3 where str = "aa" and m1[2] > 0 order by v1 limit 2;
+
+select a1, m1 from scs3 where str = "aa" and a1[2] = 2 order by v1 limit 2;
+select array_length(a1), a2[1].a  from scs3 where str = "aa" and s1.s1 > 2 order by v1 limit 2;
+select map_size(m1), s1.s2[1].a, s1.s3[1], s1.s4.f from scs3 where str = "aa" and m1[2] > 0 order by v1 limit 2;
+
+select a1, m1 from scs3 where str >= "aa" and a1[2] = 2 order by v1 limit 2;
+select array_length(a1), a2[1].a  from scs3 where str <= "gg" and s1.s1 > 2 order by v1 limit 2;
+select map_size(m1), s1.s2[1].a, s1.s3[1], s1.s4.f from scs3 where str != "aa" and m1[2] > 0 order by v1 limit 2;


### PR DESCRIPTION
Why I'm doing:

What I'm doing:

semi-type prune column will replace `NullableColumn` to `ConstantColumn` in column_iterator

in storage, will use `_dict_chunk` (NullableColumn)  to swap with `_read_chunk` (ConstantColumn) when the predicate use dict-optimization, the trigger crash

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
