### PR TITLE
[Enhancement] improve perf of dictionary (#40215)

### DIFF
--- a/be/src/exec/dictionary_cache_writer.cpp
+++ b/be/src/exec/dictionary_cache_writer.cpp
@@ -64,6 +64,10 @@ Status DictionaryCacheWriter::append_chunk(ChunkPtr chunk, std::atomic_bool* ter
         RETURN_IF_ERROR(DictionaryCacheWriter::ChunkUtil::check_chunk_has_null(*chunk.get()));
 
         if (_buffer_chunk == nullptr) {
+            chunk->reset_slot_id_to_index();
+            for (size_t i = 0; i < chunk->num_columns(); i++) {
+                chunk->set_slot_id_to_index(i + 1, i);
+            }
             _buffer_chunk = chunk->clone_empty_with_slot();
         }
         DCHECK(_buffer_chunk != nullptr);

--- a/be/src/exprs/dictionary_get_expr.cpp
+++ b/be/src/exprs/dictionary_get_expr.cpp
@@ -56,6 +56,7 @@ StatusOr<ColumnPtr> DictionaryGetExpr::evaluate_checked(ExprContext* context, Ch
         ColumnPtr key_column = columns[1 + i];
         key_chunk->update_column_by_index(key_column, i);
     }
+    value_chunk->reserve(size);
 
     // assign the value chunk
     RETURN_IF_ERROR(DictionaryCacheManager::probe_given_dictionary_cache(
@@ -65,7 +66,7 @@ StatusOr<ColumnPtr> DictionaryGetExpr::evaluate_checked(ExprContext* context, Ch
     auto fields = down_cast<StructColumn*>(struct_column.get())->fields_column();
     for (size_t i = 0; i < value_chunk->columns().size(); ++i) {
         auto column = value_chunk->columns()[i];
-        fields[i]->append(*column.get(), 0, column->size());
+        fields[i]->append(*column, 0, column->size());
     }
 
     return struct_column;

--- a/be/src/storage/dictionary_cache_manager.cpp
+++ b/be/src/storage/dictionary_cache_manager.cpp
@@ -74,7 +74,7 @@ Status DictionaryCacheManager::refresh(const PProcessDictionaryCacheRequest* req
     // dictionary_schema: col2, col3, col1, col4 (without nullable attribute)
     SchemaPtr dictionary_schema = ChunkHelper::convert_schema((schema->indexes()[0])->column_param->columns, col_names);
     DCHECK(dictionary_schema != nullptr);
-    std::vector<int> keys(dictionary_schema->fields().size(), 0);
+    std::vector<int> keys(dictionary_schema->fields().size(), 1);
     // remove the nullable attribute if necessary
     dictionary_schema = ChunkHelper::get_non_nullable_schema(dictionary_schema, &keys);
 
@@ -121,6 +121,11 @@ Status DictionaryCacheManager::refresh(const PProcessDictionaryCacheRequest* req
                             dict_id, txn_id));
     }
 
+    std::vector<uint8_t> value_encode_flags(chunk->num_rows(), 1);
+    if (DictionaryCacheUtil::get_encoded_type(*value_schema.get()) == TYPE_VARCHAR) {
+        DictionaryCacheUtil::precheck_value_encode(value_chunk.get(), value_encode_flags);
+    }
+
     auto encoded_value_column = DictionaryCacheUtil::encode_columns(*value_schema.get(), value_chunk.get());
     if (encoded_value_column == nullptr) {
         return Status::InternalError(
@@ -136,14 +141,16 @@ Status DictionaryCacheManager::refresh(const PProcessDictionaryCacheRequest* req
     // 4. refresh
     return _refresh_encoded_chunk(dict_id, txn_id, encoded_key_column.get(), encoded_value_column.get(),
                                   dictionary_schema, DictionaryCacheUtil::get_encoded_type(*key_schema.get()),
-                                  DictionaryCacheUtil::get_encoded_type(*value_schema.get()), memory_limit);
+                                  DictionaryCacheUtil::get_encoded_type(*value_schema.get()), memory_limit,
+                                  value_encode_flags);
 }
 
 Status DictionaryCacheManager::_refresh_encoded_chunk(DictionaryId dict_id, DictionaryCacheTxnId txn_id,
                                                       const Column* encoded_key_column,
                                                       const Column* encoded_value_column, const SchemaPtr& schema,
                                                       LogicalType key_encoded_type, LogicalType value_encoded_type,
-                                                      long memory_limit) {
+                                                      long memory_limit,
+                                                      const std::vector<uint8_t>& value_encode_flags) {
     DCHECK(key_encoded_type != TYPE_NONE);
     DCHECK(value_encoded_type != TYPE_NONE);
 
@@ -163,7 +170,7 @@ Status DictionaryCacheManager::_refresh_encoded_chunk(DictionaryId dict_id, Dict
         if (LIKELY(_mutable_dict_caches.find(dict_id) != _mutable_dict_caches.end() &&
                    _mutable_dict_caches[dict_id]->find(txn_id) != _mutable_dict_caches[dict_id]->end())) {
             if ((*_mutable_dict_caches[dict_id])[txn_id] == nullptr) {
-                auto p = DictionaryCacheUtil::create_dictionary_cache(
+                DictionaryCachePtr p = DictionaryCacheUtil::create_dictionary_cache(
                         std::pair<LogicalType, LogicalType>(key_encoded_type, value_encoded_type));
                 if (p == nullptr) {
                     return Status::InternalError("Invalid dictionary type");
@@ -189,10 +196,12 @@ Status DictionaryCacheManager::_refresh_encoded_chunk(DictionaryId dict_id, Dict
     DCHECK(encoded_value_column != nullptr);
     DCHECK(encoded_key_column->size() == encoded_value_column->size());
 
+    mutable_cache->lock().lock();
+    DeferOp op([&]() { mutable_cache->lock().unlock(); });
     for (size_t i = 0; i < encoded_key_column->size(); ++i) {
         auto key = encoded_key_column->get(i);
         auto value = encoded_value_column->get(i);
-        RETURN_IF_ERROR(mutable_cache->insert(key, value));
+        RETURN_IF_ERROR(mutable_cache->insert(key, value, value_encode_flags[i]));
     }
 
     if (mutable_cache->memory_usage() > memory_limit) {

--- a/be/src/storage/dictionary_cache_manager.cpp
+++ b/be/src/storage/dictionary_cache_manager.cpp
@@ -196,8 +196,7 @@ Status DictionaryCacheManager::_refresh_encoded_chunk(DictionaryId dict_id, Dict
     DCHECK(encoded_value_column != nullptr);
     DCHECK(encoded_key_column->size() == encoded_value_column->size());
 
-    mutable_cache->lock().lock();
-    DeferOp op([&]() { mutable_cache->lock().unlock(); });
+    std::lock_guard lg(mutable_cache->lock());
     for (size_t i = 0; i < encoded_key_column->size(); ++i) {
         auto key = encoded_key_column->get(i);
         auto value = encoded_value_column->get(i);

--- a/be/src/storage/dictionary_cache_manager.h
+++ b/be/src/storage/dictionary_cache_manager.h
@@ -21,32 +21,48 @@
 #include "column/chunk.h"
 #include "column/column.h"
 #include "column/datum.h"
+#include "common/compiler_util.h"
 #include "common/status.h"
 #include "exec/dictionary_cache_writer.h"
 #include "fmt/format.h"
 #include "service/internal_service.h"
 #include "storage/chunk_helper.h"
 #include "storage/primary_key_encoder.h"
-#include "storage/row_store_encoder_factory.h"
-#include "storage/row_store_encoder_simple.h"
-#include "util/faststring.h"
+#include "storage/type_traits.h"
 #include "util/phmap/phmap.h"
 #include "util/xxh3.h"
 
 namespace starrocks {
 
+#if defined(_MSC_VER) && (defined(_M_X64) || defined(_M_IX86))
+#include <mmintrin.h>
+#define PREFETCH_ADDR(addr) _mm_prefetch((const char*)(addr), _MM_HINT_T0)
+#elif defined(__GNUC__)
+#define PREFETCH_ADDR(addr) __builtin_prefetch(static_cast<const void*>(addr), 0 /* rw==read */, 3 /* locality */)
+#endif // __GNUC__
+
 enum DictionaryCacheEncoderType {
-    ROW_STORE_SIMPLE = 0,
+    PK_ENCODE = 0,
 };
 
 template <LogicalType logical_type>
 struct DictionaryCacheTypeTraits {
-    using CppType = typename RunTimeTypeTraits<logical_type>::CppType;
+    using CppType = typename CppTypeTraits<logical_type>::CppType;
 };
 
 template <>
 struct DictionaryCacheTypeTraits<TYPE_VARCHAR> {
-    using CppType = std::string;
+    using CppType = Slice;
+};
+
+template <>
+struct DictionaryCacheTypeTraits<TYPE_DATE> {
+    using CppType = int32_t;
+};
+
+template <>
+struct DictionaryCacheTypeTraits<TYPE_DATETIME> {
+    using CppType = int64_t;
 };
 
 template <LogicalType logical_type>
@@ -57,7 +73,7 @@ struct DictionaryCacheHashTraits {
 
 template <>
 struct DictionaryCacheHashTraits<TYPE_VARCHAR> {
-    inline size_t operator()(const std::string& v) const { return XXH3_64bits(v.data(), v.length()); }
+    inline size_t operator()(const Slice& v) const { return XXH3_64bits(v.data, v.size); }
 };
 
 class DictionaryCache {
@@ -65,70 +81,168 @@ public:
     DictionaryCache(DictionaryCacheEncoderType type) : _type(type) {}
     virtual ~DictionaryCache() = default;
 
-    virtual inline Status insert(const Datum& k, const Datum& v) = 0;
+    virtual inline Status insert(const Datum& k, const Datum& v, const uint8_t& flag) = 0;
 
-    virtual inline Status lookup(const Datum& k, Column* dest) = 0;
+    virtual inline Status lookup(Column* src, Column* dest, std::vector<uint8_t>& value_encode_flags) = 0;
 
     virtual inline size_t memory_usage() = 0;
+
+    virtual std::mutex& lock() = 0;
 
 protected:
     DictionaryCacheEncoderType _type;
 };
 
+class DictionaryCacheUtil;
 template <LogicalType KeyLogicalType, LogicalType ValueLogicalType>
 class DictionaryCacheImpl final : public DictionaryCache {
 public:
+    static constexpr uint8_t PREFETCHN = 8;
+
     DictionaryCacheImpl(DictionaryCacheEncoderType type) : DictionaryCache(type), _total_memory_useage(0) {}
     virtual ~DictionaryCacheImpl() override = default;
 
     using KeyCppType = typename DictionaryCacheTypeTraits<KeyLogicalType>::CppType;
     using ValueCppType = typename DictionaryCacheTypeTraits<ValueLogicalType>::CppType;
 
-    virtual inline Status insert(const Datum& k, const Datum& v) override {
-        KeyCppType key;
-        ValueCppType value;
-        _get<KeyCppType>(k, key);
-        _get<ValueCppType>(v, value);
-        auto r = _dictionary.insert({key, value});
-        if (!r.second) {
-            return Status::InternalError("duplicate key found when refreshing dictionary");
+    virtual inline Status insert(const Datum& k, const Datum& v, const uint8_t& flag) override {
+        switch (_type) {
+        case DictionaryCacheEncoderType::PK_ENCODE: {
+            KeyCppType key;
+            ValueCppType value;
+
+            // Memory structure for string type value:
+            //  Slice 1 -> |  buffer  |
+            //             |buffer size|
+            //  Slice 2 -> |  buffer  |
+            //             |buffer size|
+            //  Slice 3 -> |  buffer  |
+            //             |buffer size|
+            if constexpr (std::is_same_v<KeyCppType, Slice>) {
+                const Slice& input = k.get<KeyCppType>();
+                auto* buffer = reinterpret_cast<char*>(_pool.allocate(input.size));
+                RETURN_IF_UNLIKELY_NULL(buffer, Status::MemoryAllocFailed("alloc mem for dictionary failed"));
+                memcpy(buffer, input.data, input.size);
+                key.data = buffer;
+                key.size = input.size;
+            } else {
+                key = k.get<KeyCppType>();
+            }
+
+            if constexpr (std::is_same_v<ValueCppType, Slice>) {
+                const Slice& input = v.get<ValueCppType>();
+                size_t allocate_size = input.size + sizeof(uint8_t);
+                auto* buffer = reinterpret_cast<char*>(_pool.allocate(allocate_size));
+                RETURN_IF_UNLIKELY_NULL(buffer, Status::MemoryAllocFailed("alloc mem for dictionary failed"));
+                memcpy(buffer, &flag, sizeof(uint8_t));
+                buffer += sizeof(uint8_t);
+                memcpy(buffer, input.data, input.size);
+                value.data = buffer;
+                value.size = input.size;
+            } else {
+                value = v.get<ValueCppType>();
+            }
+
+            auto r = _dictionary.insert({key, value});
+            if (!r.second) {
+                return Status::InternalError("duplicate key found when refreshing dictionary");
+            }
+            _total_memory_useage.fetch_add(_get_element_memory_usage<KeyCppType, ValueCppType>(key, value));
+            return Status::OK();
         }
-        _total_memory_useage.fetch_add(_get_element_memory_usage<KeyCppType, ValueCppType>(key, value));
+        default:
+            return Status::InternalError("Unknow encoder for dictionary cache");
+        }
         return Status::OK();
     }
 
-    virtual inline Status lookup(const Datum& k, Column* dest) override {
-        KeyCppType key;
-        _get<KeyCppType>(k, key);
-        auto iter = _dictionary.find(key);
-        if (iter == _dictionary.end()) {
-            return Status::NotFound("key not found in dictionary cache");
+    virtual inline Status lookup(Column* src, Column* dest, std::vector<uint8_t>& value_encode_flags) override {
+        switch (_type) {
+        case DictionaryCacheEncoderType::PK_ENCODE: {
+            size_t size = src->size();
+            const auto* raw_data = reinterpret_cast<const KeyCppType*>(src->raw_data());
+
+            if (LIKELY(size >= 2 * PREFETCHN)) {
+                size_t beg_index = 0;
+                size_t loop = size / PREFETCHN;
+
+                // use interleaving style prefetch technique to accelerate lookup, basic idea:
+                // 1. prefetch N key
+                // 2. prefetch N value
+                // 3. actual lookup
+                size_t prefetch_hashes[PREFETCHN];
+                for (size_t i = 0; i < loop; i++) {
+                    beg_index = i * PREFETCHN;
+
+                    if constexpr (std::is_same_v<KeyCppType, Slice>) {
+                        for (size_t j = 0; j < PREFETCHN; j++) {
+                            PREFETCH_ADDR(&raw_data[beg_index + j]);
+                            PREFETCH_ADDR(raw_data[beg_index + j].data);
+                        }
+                    } else {
+                        if (LIKELY(i != loop - 1)) PREFETCH_ADDR(&raw_data[beg_index + PREFETCHN]);
+                        // ensure current N are cached
+                        (void)raw_data[beg_index];
+                    }
+
+                    for (size_t j = 0; j < PREFETCHN; j++) {
+                        prefetch_hashes[j] = DictionaryCacheHashTraits<KeyLogicalType>()(raw_data[beg_index + j]);
+                        _dictionary.prefetch_hash(prefetch_hashes[j]);
+                    }
+
+                    for (size_t j = 0; j < PREFETCHN; j++) {
+                        auto iter = _dictionary.find(raw_data[beg_index + j], prefetch_hashes[j]);
+                        if (iter == _dictionary.end()) {
+                            return Status::NotFound("key not found in dictionary cache");
+                        }
+                        dest->append_datum(*_get_datum(iter->second));
+                        if constexpr (std::is_same_v<ValueCppType, Slice>) {
+                            value_encode_flags[i] = *(reinterpret_cast<uint8_t*>(iter->second.data) - 1);
+                        }
+                    }
+                }
+
+                beg_index = loop * PREFETCHN;
+                for (size_t i = beg_index; i < size; i++) {
+                    auto iter = _dictionary.find(raw_data[i]);
+                    if (iter == _dictionary.end()) {
+                        return Status::NotFound("key not found in dictionary cache");
+                    }
+                    dest->append_datum(*_get_datum(iter->second));
+                    if constexpr (std::is_same_v<ValueCppType, Slice>) {
+                        value_encode_flags[i] = *(reinterpret_cast<uint8_t*>(iter->second.data) - 1);
+                    }
+                }
+            } else {
+                for (size_t i = 0; i < size; i++) {
+                    auto iter = _dictionary.find(raw_data[i]);
+                    if (iter == _dictionary.end()) {
+                        return Status::NotFound("key not found in dictionary cache");
+                    }
+                    dest->append_datum(*_get_datum(iter->second));
+                    if constexpr (std::is_same_v<ValueCppType, Slice>) {
+                        value_encode_flags[i] = *(reinterpret_cast<uint8_t*>(iter->second.data) - 1);
+                    }
+                }
+            }
+            break;
         }
-        dest->append_datum(*_get_datum(iter->second));
+        default:
+            return Status::InternalError("Unknow encoder for dictionary cache");
+        }
+
         return Status::OK();
     }
 
     virtual inline size_t memory_usage() override { return _total_memory_useage.load(); }
 
-private:
-    template <class CppType>
-    inline void _get(const Datum& d, CppType& v) {
-        switch (_type) {
-        case DictionaryCacheEncoderType::ROW_STORE_SIMPLE: {
-            v = d.get<Slice>().to_string();
-            break;
-        }
-        default:
-            break;
-        }
-        return;
-    }
+    virtual std::mutex& lock() override { return _lock; }
 
+private:
     inline std::shared_ptr<Datum> _get_datum(const ValueCppType& v) {
         switch (_type) {
-        case DictionaryCacheEncoderType::ROW_STORE_SIMPLE: {
-            static_assert(std::is_same_v<ValueCppType, std::string>);
-            return std::make_shared<Datum>(Slice(v));
+        case DictionaryCacheEncoderType::PK_ENCODE: {
+            return std::make_shared<Datum>(v);
         }
         default:
             break;
@@ -139,10 +253,20 @@ private:
     template <class KeyCppType, class ValueCppType>
     inline size_t _get_element_memory_usage(const KeyCppType& k, const ValueCppType& v) {
         switch (_type) {
-        case DictionaryCacheEncoderType::ROW_STORE_SIMPLE: {
-            static_assert(std::is_same_v<KeyCppType, std::string>);
-            static_assert(std::is_same_v<ValueCppType, std::string>);
-            return k.size() + v.size();
+        case DictionaryCacheEncoderType::PK_ENCODE: {
+            size_t size = 0;
+            if constexpr (std::is_same_v<KeyCppType, Slice>) {
+                size = k.size;
+            } else {
+                size = sizeof(KeyCppType);
+            }
+
+            if constexpr (std::is_same_v<ValueCppType, Slice>) {
+                size += v.size;
+            } else {
+                size += sizeof(ValueCppType);
+            }
+            return size;
         }
         default:
             break;
@@ -153,9 +277,11 @@ private:
     phmap::parallel_flat_hash_map<KeyCppType, ValueCppType, DictionaryCacheHashTraits<KeyLogicalType>,
                                   phmap::priv::hash_default_eq<KeyCppType>,
                                   phmap::priv::Allocator<phmap::priv::Pair<const KeyCppType, ValueCppType>>, 4,
-                                  std::shared_mutex, true>
+                                  phmap::NullMutex, true>
             _dictionary;
     std::atomic<size_t> _total_memory_useage;
+    std::mutex _lock;
+    MemPool _pool;
 };
 
 using DictionaryCachePtr = std::shared_ptr<DictionaryCache>;
@@ -167,16 +293,20 @@ public:
 
     // using primary key encoding function
     static std::unique_ptr<Column> encode_columns(const Schema& schema, const Chunk* chunk,
-                                                  const DictionaryCacheEncoderType& encoder_type = ROW_STORE_SIMPLE) {
+                                                  const DictionaryCacheEncoderType& encoder_type = PK_ENCODE) {
         switch (encoder_type) {
-        case ROW_STORE_SIMPLE: {
-            auto encoded_column = std::make_unique<BinaryColumn>();
-            auto encoder = RowStoreEncoderFactory::instance()->get_or_create_encoder(RowStoreEncoderType::SIMPLE);
-            auto st = encoder->encode_columns_to_full_row_column(schema, chunk->columns(), *encoded_column.get());
-            if (!st.ok()) {
-                break;
+        case PK_ENCODE: {
+            std::unique_ptr<Column> encoded_columns;
+            if (!PrimaryKeyEncoder::create_column(schema, &encoded_columns).ok()) {
+                std::stringstream ss;
+                ss << "create column for primary key encoder failed";
+                LOG(WARNING) << ss.str();
+                return nullptr;
             }
-            return encoded_column;
+            if (chunk->num_rows() > 0) {
+                PrimaryKeyEncoder::encode(schema, *chunk, 0, chunk->num_rows(), encoded_columns.get());
+            }
+            return encoded_columns;
         }
         default:
             break;
@@ -185,27 +315,11 @@ public:
     }
 
     static Status decode_columns(const Schema& schema, Column* column, Chunk* decoded_chunk,
-                                 const DictionaryCacheEncoderType& encoder_type = ROW_STORE_SIMPLE) {
+                                 std::vector<uint8_t>* value_encode_flags,
+                                 const DictionaryCacheEncoderType& encoder_type = PK_ENCODE) {
         switch (encoder_type) {
-        case ROW_STORE_SIMPLE: {
-            auto encoder = RowStoreEncoderFactory::instance()->get_or_create_encoder(RowStoreEncoderType::SIMPLE);
-            const auto binary_column = down_cast<BinaryColumn*>(column);
-            std::vector<uint32_t> column_ids(schema.fields().size());
-            std::iota(column_ids.begin(), column_ids.end(), 0);
-            std::vector<std::unique_ptr<Column>> columns;
-            for (size_t i = 0; i < schema.fields().size(); ++i) {
-                auto clone_column = decoded_chunk->get_column_by_index(i)->clone_empty();
-                columns.emplace_back(std::move(clone_column));
-            }
-
-            RETURN_IF_ERROR(encoder->decode_columns_from_full_row_column(schema, *binary_column, column_ids, &columns));
-
-            DCHECK(column->size() == columns[0]->size());
-            for (size_t i = 0; i < decoded_chunk->columns().size(); ++i) {
-                decoded_chunk->get_column_by_index(i).reset(columns[i].release());
-            }
-            DCHECK(decoded_chunk->num_rows() == column->size());
-            return Status::OK();
+        case PK_ENCODE: {
+            return PrimaryKeyEncoder::decode(schema, *column, 0, column->size(), decoded_chunk, value_encode_flags);
         }
         default:
             break;
@@ -213,15 +327,53 @@ public:
         return Status::InternalError("decode failed for dictionary");
     }
 
-    static LogicalType get_encoded_type(const Schema& schema,
-                                        const DictionaryCacheEncoderType& encoder_type = ROW_STORE_SIMPLE) {
-        switch (encoder_type) {
-        case ROW_STORE_SIMPLE: {
-            auto encoder = RowStoreEncoderFactory::instance()->get_or_create_encoder(RowStoreEncoderType::SIMPLE);
-            if (!encoder->is_supported(schema).ok()) {
+    // This function is used for precheck the string content for value columns.
+    // Check if it can use fast decoding method when lookup the dictionary cache.
+    static void precheck_value_encode(const Chunk* chunk, std::vector<uint8_t>& value_encode_flags) {
+        bool has_varchar = false;
+        for (const auto& f : chunk->schema()->fields()) {
+            if (f->type()->type() == TYPE_VARCHAR) {
+                has_varchar = true;
                 break;
             }
-            return TYPE_VARCHAR;
+        }
+
+        if (!has_varchar) {
+            return;
+        }
+
+        size_t size = chunk->num_rows();
+        for (int idx = 0; idx < chunk->num_columns(); idx++) {
+            if (chunk->schema()->fields()[idx]->type()->type() != TYPE_VARCHAR) {
+                continue;
+            }
+
+            const auto& src = chunk->get_column_by_index(idx);
+            const auto* raw_data = reinterpret_cast<const Slice*>(src->raw_data());
+            for (int i = 0; i < size; i++) {
+                bool contains_zero = false;
+                for (int j = 0; j < raw_data[i].size; j++) {
+                    if (raw_data[i][j] == '\0') {
+                        contains_zero = true;
+                        break;
+                    }
+                }
+                if (value_encode_flags[i] && contains_zero) {
+                    value_encode_flags[i] = 0;
+                }
+            }
+        }
+    }
+
+    static LogicalType get_encoded_type(const Schema& schema,
+                                        const DictionaryCacheEncoderType& encoder_type = PK_ENCODE) {
+        switch (encoder_type) {
+        case PK_ENCODE: {
+            std::vector<uint32_t> idxes;
+            for (size_t i = 0; i < schema.fields().size(); i++) {
+                idxes.push_back((uint32_t)i);
+            }
+            return PrimaryKeyEncoder::encoded_primary_key_type(schema, idxes);
         }
         default:
             break;
@@ -229,12 +381,106 @@ public:
         return TYPE_NONE;
     }
 
-    static DictionaryCachePtr create_dictionary_cache(
-            const std::pair<LogicalType, LogicalType>& type,
-            const DictionaryCacheEncoderType& encoder_type = ROW_STORE_SIMPLE) {
+    static DictionaryCachePtr create_dictionary_cache(const std::pair<LogicalType, LogicalType>& type,
+                                                      const DictionaryCacheEncoderType& encoder_type = PK_ENCODE) {
         switch (encoder_type) {
-        case ROW_STORE_SIMPLE: {
-            return std::make_shared<DictionaryCacheImpl<TYPE_VARCHAR, TYPE_VARCHAR>>(encoder_type);
+        case PK_ENCODE: {
+#define IF_TYPE(key_type, value_type)                 \
+    if (type == std::make_pair(key_type, value_type)) \
+    return std::make_shared<DictionaryCacheImpl<key_type, value_type>>(encoder_type)
+
+            IF_TYPE(TYPE_BOOLEAN, TYPE_BOOLEAN);
+            IF_TYPE(TYPE_BOOLEAN, TYPE_TINYINT);
+            IF_TYPE(TYPE_BOOLEAN, TYPE_SMALLINT);
+            IF_TYPE(TYPE_BOOLEAN, TYPE_INT);
+            IF_TYPE(TYPE_BOOLEAN, TYPE_BIGINT);
+            IF_TYPE(TYPE_BOOLEAN, TYPE_LARGEINT);
+            IF_TYPE(TYPE_BOOLEAN, TYPE_VARCHAR);
+            IF_TYPE(TYPE_BOOLEAN, TYPE_DATE);
+            IF_TYPE(TYPE_BOOLEAN, TYPE_DATETIME);
+
+            IF_TYPE(TYPE_TINYINT, TYPE_BOOLEAN);
+            IF_TYPE(TYPE_TINYINT, TYPE_TINYINT);
+            IF_TYPE(TYPE_TINYINT, TYPE_SMALLINT);
+            IF_TYPE(TYPE_TINYINT, TYPE_INT);
+            IF_TYPE(TYPE_TINYINT, TYPE_BIGINT);
+            IF_TYPE(TYPE_TINYINT, TYPE_LARGEINT);
+            IF_TYPE(TYPE_TINYINT, TYPE_VARCHAR);
+            IF_TYPE(TYPE_TINYINT, TYPE_DATE);
+            IF_TYPE(TYPE_TINYINT, TYPE_DATETIME);
+
+            IF_TYPE(TYPE_SMALLINT, TYPE_BOOLEAN);
+            IF_TYPE(TYPE_SMALLINT, TYPE_TINYINT);
+            IF_TYPE(TYPE_SMALLINT, TYPE_SMALLINT);
+            IF_TYPE(TYPE_SMALLINT, TYPE_INT);
+            IF_TYPE(TYPE_SMALLINT, TYPE_BIGINT);
+            IF_TYPE(TYPE_SMALLINT, TYPE_LARGEINT);
+            IF_TYPE(TYPE_SMALLINT, TYPE_VARCHAR);
+            IF_TYPE(TYPE_SMALLINT, TYPE_DATE);
+            IF_TYPE(TYPE_SMALLINT, TYPE_DATETIME);
+
+            IF_TYPE(TYPE_INT, TYPE_BOOLEAN);
+            IF_TYPE(TYPE_INT, TYPE_TINYINT);
+            IF_TYPE(TYPE_INT, TYPE_SMALLINT);
+            IF_TYPE(TYPE_INT, TYPE_INT);
+            IF_TYPE(TYPE_INT, TYPE_BIGINT);
+            IF_TYPE(TYPE_INT, TYPE_LARGEINT);
+            IF_TYPE(TYPE_INT, TYPE_VARCHAR);
+            IF_TYPE(TYPE_INT, TYPE_DATE);
+            IF_TYPE(TYPE_INT, TYPE_DATETIME);
+
+            IF_TYPE(TYPE_BIGINT, TYPE_BOOLEAN);
+            IF_TYPE(TYPE_BIGINT, TYPE_TINYINT);
+            IF_TYPE(TYPE_BIGINT, TYPE_SMALLINT);
+            IF_TYPE(TYPE_BIGINT, TYPE_INT);
+            IF_TYPE(TYPE_BIGINT, TYPE_BIGINT);
+            IF_TYPE(TYPE_BIGINT, TYPE_LARGEINT);
+            IF_TYPE(TYPE_BIGINT, TYPE_VARCHAR);
+            IF_TYPE(TYPE_BIGINT, TYPE_DATE);
+            IF_TYPE(TYPE_BIGINT, TYPE_DATETIME);
+
+            IF_TYPE(TYPE_LARGEINT, TYPE_BOOLEAN);
+            IF_TYPE(TYPE_LARGEINT, TYPE_TINYINT);
+            IF_TYPE(TYPE_LARGEINT, TYPE_SMALLINT);
+            IF_TYPE(TYPE_LARGEINT, TYPE_INT);
+            IF_TYPE(TYPE_LARGEINT, TYPE_BIGINT);
+            IF_TYPE(TYPE_LARGEINT, TYPE_LARGEINT);
+            IF_TYPE(TYPE_LARGEINT, TYPE_VARCHAR);
+            IF_TYPE(TYPE_LARGEINT, TYPE_DATE);
+            IF_TYPE(TYPE_LARGEINT, TYPE_DATETIME);
+
+            IF_TYPE(TYPE_VARCHAR, TYPE_BOOLEAN);
+            IF_TYPE(TYPE_VARCHAR, TYPE_TINYINT);
+            IF_TYPE(TYPE_VARCHAR, TYPE_SMALLINT);
+            IF_TYPE(TYPE_VARCHAR, TYPE_INT);
+            IF_TYPE(TYPE_VARCHAR, TYPE_BIGINT);
+            IF_TYPE(TYPE_VARCHAR, TYPE_LARGEINT);
+            IF_TYPE(TYPE_VARCHAR, TYPE_VARCHAR);
+            IF_TYPE(TYPE_VARCHAR, TYPE_DATE);
+            IF_TYPE(TYPE_VARCHAR, TYPE_DATETIME);
+
+            IF_TYPE(TYPE_DATE, TYPE_BOOLEAN);
+            IF_TYPE(TYPE_DATE, TYPE_TINYINT);
+            IF_TYPE(TYPE_DATE, TYPE_SMALLINT);
+            IF_TYPE(TYPE_DATE, TYPE_INT);
+            IF_TYPE(TYPE_DATE, TYPE_BIGINT);
+            IF_TYPE(TYPE_DATE, TYPE_LARGEINT);
+            IF_TYPE(TYPE_DATE, TYPE_VARCHAR);
+            IF_TYPE(TYPE_DATE, TYPE_DATE);
+            IF_TYPE(TYPE_DATE, TYPE_DATETIME);
+
+            IF_TYPE(TYPE_DATETIME, TYPE_BOOLEAN);
+            IF_TYPE(TYPE_DATETIME, TYPE_TINYINT);
+            IF_TYPE(TYPE_DATETIME, TYPE_SMALLINT);
+            IF_TYPE(TYPE_DATETIME, TYPE_INT);
+            IF_TYPE(TYPE_DATETIME, TYPE_BIGINT);
+            IF_TYPE(TYPE_DATETIME, TYPE_LARGEINT);
+            IF_TYPE(TYPE_DATETIME, TYPE_VARCHAR);
+            IF_TYPE(TYPE_DATETIME, TYPE_DATE);
+            IF_TYPE(TYPE_DATETIME, TYPE_DATETIME);
+
+#undef IF_TYPE
+            break;
         }
         default:
             break;
@@ -286,27 +532,25 @@ public:
         size_t size = key_chunk->num_rows();
 
         auto encoded_key_column = DictionaryCacheUtil::encode_columns(key_schema, key_chunk.get());
-
-        ChunkUniquePtr clone_value_chunk = value_chunk->clone_empty();
-        auto encoded_value_column = DictionaryCacheUtil::encode_columns(value_schema, clone_value_chunk.get());
+        auto encoded_value_column = DictionaryCacheUtil::encode_columns(value_schema, value_chunk.get());
 
         if (encoded_key_column == nullptr || encoded_value_column == nullptr) {
             return Status::InternalError("encode dictionary cache column failed when probing the dictionary cache");
         }
 
-        for (size_t i = 0; i < size; ++i) {
-            auto key = encoded_key_column->get(i);
-            RETURN_IF_ERROR(dictionary->lookup(key, encoded_value_column.get()));
-        }
+        std::vector<uint8_t> value_encode_flags(size, 1);
+        RETURN_IF_ERROR(dictionary->lookup(encoded_key_column.get(), encoded_value_column.get(), value_encode_flags));
         DCHECK(encoded_value_column->size() == size);
 
-        return DictionaryCacheUtil::decode_columns(value_schema, encoded_value_column.get(), value_chunk.get());
+        return DictionaryCacheUtil::decode_columns(value_schema, encoded_value_column.get(), value_chunk.get(),
+                                                   &value_encode_flags);
     }
 
 private:
     Status _refresh_encoded_chunk(DictionaryId dict_id, DictionaryCacheTxnId txn_id, const Column* encoded_key_column,
                                   const Column* encoded_value_column, const SchemaPtr& schema,
-                                  LogicalType key_encoded_type, LogicalType value_encoded_type, long memory_limit);
+                                  LogicalType key_encoded_type, LogicalType value_encoded_type, long memory_limit,
+                                  const std::vector<uint8_t>& value_encode_flags);
 
     // dictionary id -> DictionaryCache
     std::unordered_map<DictionaryId, DictionaryCachePtr> _dict_cache;

--- a/be/src/storage/dictionary_cache_manager.h
+++ b/be/src/storage/dictionary_cache_manager.h
@@ -129,6 +129,16 @@ public:
                 key = k.get<KeyCppType>();
             }
 
+            // Memory structure for string type value:
+            //             | fast decode flag |
+            //  Slice 1 -> |  buffer  |
+            //             |buffer size|
+            //             | fast decode flag |
+            //  Slice 2 -> |  buffer  |
+            //             |buffer size|
+            //             | fast decode flag |
+            //  Slice 3 -> |  buffer  |
+            //             |buffer size|
             if constexpr (std::is_same_v<ValueCppType, Slice>) {
                 const Slice& input = v.get<ValueCppType>();
                 size_t allocate_size = input.size + sizeof(uint8_t);

--- a/be/src/storage/primary_key_encoder.cpp
+++ b/be/src/storage/primary_key_encoder.cpp
@@ -217,25 +217,43 @@ inline void encode_slice(const Slice& s, std::string* dst, bool is_last) {
     }
 }
 
-inline Status decode_slice(Slice* src, std::string* dest, bool is_last) {
+inline Status decode_slice(Slice* src, std::string* dest, Slice* dest_fast, bool is_last, bool fast_decode) {
     if (is_last) {
-        dest->append(src->data, src->size);
+        if (!fast_decode) {
+            dest->append(src->data, src->size);
+        } else {
+            dest_fast->data = src->data;
+            dest_fast->size = src->size;
+        }
     } else {
-        auto* separator = static_cast<uint8_t*>(memmem(src->data, src->size, "\0\0", 2));
-        DCHECK(separator) << "bad encoded primary key, separator not found";
-        if (PREDICT_FALSE(separator == nullptr)) {
-            LOG(WARNING) << "bad encoded primary key, separator not found";
-            return Status::InvalidArgument("bad encoded primary key, separator not found");
-        }
-        auto* data = (uint8_t*)src->data;
-        int len = separator - data;
-        for (int i = 0; i < len; i++) {
-            if (i >= 1 && data[i - 1] == '\0' && data[i] == '\1') {
-                continue;
+        if (!fast_decode) {
+            auto* separator = static_cast<uint8_t*>(memmem(src->data, src->size, "\0\0", 2));
+            DCHECK(separator) << "bad encoded primary key, separator not found";
+            if (PREDICT_FALSE(separator == nullptr)) {
+                LOG(WARNING) << "bad encoded primary key, separator not found";
+                return Status::InvalidArgument("bad encoded primary key, separator not found");
             }
-            dest->push_back((char)data[i]);
+            auto* data = (uint8_t*)src->data;
+            int len = separator - data;
+            for (int i = 0; i < len; i++) {
+                if (i >= 1 && data[i - 1] == '\0' && data[i] == '\1') {
+                    continue;
+                }
+                dest->push_back((char)data[i]);
+            }
+            src->remove_prefix(len + 2);
+        } else {
+            void* separator = std::memchr(src->data, '\0', src->size);
+            DCHECK(separator) << "bad encoded primary key, separator not found";
+            if (PREDICT_FALSE(separator == nullptr)) {
+                LOG(WARNING) << "bad encoded primary key, separator not found";
+                return Status::InvalidArgument("bad encoded primary key, separator not found");
+            }
+
+            dest_fast->data = src->data;
+            dest_fast->size = (uint8_t*)separator - (uint8_t*)src->data;
+            src->remove_prefix(dest_fast->size + 2);
         }
-        src->remove_prefix(len + 2);
     }
     return Status::OK();
 }
@@ -651,7 +669,8 @@ bool PrimaryKeyEncoder::encode_exceed_limit(const Schema& schema, const Chunk& c
 }
 
 template <class T>
-Status decode_internal(const Schema& schema, const T& bkeys, size_t offset, size_t len, Chunk* dest) {
+Status decode_internal(const Schema& schema, const T& bkeys, size_t offset, size_t len, Chunk* dest,
+                       std::vector<uint8_t>* value_encode_flags) {
     const int ncol = schema.num_key_fields();
     for (int i = 0; i < len; i++) {
         Slice s = bkeys.get_slice(offset + i);
@@ -696,9 +715,16 @@ Status decode_internal(const Schema& schema, const T& bkeys, size_t offset, size
             } break;
             case TYPE_VARCHAR: {
                 auto& tc = down_cast<BinaryColumn&>(column);
-                std::string v;
-                RETURN_IF_ERROR(decode_slice(&s, &v, j + 1 == ncol));
-                tc.append(v);
+                bool fast_decode = value_encode_flags != nullptr ? (bool)((*value_encode_flags)[i]) : false;
+                if (!fast_decode) {
+                    std::string v;
+                    RETURN_IF_ERROR(decode_slice(&s, &v, nullptr, j + 1 == ncol, false));
+                    tc.append(v);
+                } else {
+                    Slice v;
+                    RETURN_IF_ERROR(decode_slice(&s, nullptr, &v, j + 1 == ncol, true));
+                    tc.append(v);
+                }
             } break;
             case TYPE_DATE: {
                 auto& tc = down_cast<DateColumn&>(column);
@@ -706,7 +732,7 @@ Status decode_internal(const Schema& schema, const T& bkeys, size_t offset, size
                 decode_integral(&s, &v._julian);
                 tc.append(v);
             } break;
-            case TYPE_DATETIME_V1: {
+            case TYPE_DATETIME: {
                 auto& tc = down_cast<TimestampColumn&>(column);
                 TimestampValue v;
                 decode_integral(&s, &v._timestamp);
@@ -720,7 +746,8 @@ Status decode_internal(const Schema& schema, const T& bkeys, size_t offset, size
     return Status::OK();
 }
 
-Status PrimaryKeyEncoder::decode(const Schema& schema, const Column& keys, size_t offset, size_t len, Chunk* dest) {
+Status PrimaryKeyEncoder::decode(const Schema& schema, const Column& keys, size_t offset, size_t len, Chunk* dest,
+                                 std::vector<uint8_t>* value_encode_flags) {
     if (schema.num_key_fields() == 1) {
         // simple decoding, src & dest should have same type
         dest->get_column_by_index(0)->append(keys, offset, len);
@@ -728,10 +755,10 @@ Status PrimaryKeyEncoder::decode(const Schema& schema, const Column& keys, size_
         CHECK(keys.is_binary() || keys.is_large_binary()) << "keys column should be binary";
         if (keys.is_binary()) {
             auto& bkeys = down_cast<const BinaryColumn&>(keys);
-            return decode_internal(schema, bkeys, offset, len, dest);
+            return decode_internal(schema, bkeys, offset, len, dest, value_encode_flags);
         } else {
             auto& bkeys = down_cast<const LargeBinaryColumn&>(keys);
-            return decode_internal(schema, bkeys, offset, len, dest);
+            return decode_internal(schema, bkeys, offset, len, dest, value_encode_flags);
         }
     }
     return Status::OK();

--- a/be/src/storage/primary_key_encoder.h
+++ b/be/src/storage/primary_key_encoder.h
@@ -70,7 +70,8 @@ public:
     static bool encode_exceed_limit(const Schema& schema, const Chunk& chunk, size_t offset, size_t len,
                                     size_t limit_size);
 
-    static Status decode(const Schema& schema, const Column& keys, size_t offset, size_t len, Chunk* dest);
+    static Status decode(const Schema& schema, const Column& keys, size_t offset, size_t len, Chunk* dest,
+                         std::vector<uint8_t>* value_encode_flags = nullptr);
 };
 
 } // namespace starrocks

--- a/fe/fe-core/src/main/java/com/starrocks/planner/DictionaryCacheSink.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/DictionaryCacheSink.java
@@ -140,17 +140,17 @@ public class DictionaryCacheSink extends DataSink {
         Map<String, SlotDescriptor> valueSlots = new HashMap();
 
         for (Column column : tbl.getBaseSchema()) {
-            if (!dictionary.getKeys().contains(column.getName()) && !dictionary.getValues().contains(column.getName())) {
-                currentSlotId++;
-                continue;
-            }
-            SlotDescriptor slotDescriptor = new SlotDescriptor(new SlotId(currentSlotId++), tupleDescriptor);
-            slotDescriptor.setColumn(column);
-            slotDescriptor.setIsMaterialized(true);
-
             if (dictionary.getKeys().contains(column.getName())) {
+                SlotDescriptor slotDescriptor = new SlotDescriptor(new SlotId(currentSlotId++), tupleDescriptor);
+                slotDescriptor.setColumn(column);
+                slotDescriptor.setIsMaterialized(true);
+
                 keySlots.put(column.getName(), slotDescriptor);
             } else if (dictionary.getValues().contains(column.getName())) {
+                SlotDescriptor slotDescriptor = new SlotDescriptor(new SlotId(currentSlotId++), tupleDescriptor);
+                slotDescriptor.setColumn(column);
+                slotDescriptor.setIsMaterialized(true);
+
                 valueSlots.put(column.getName(), slotDescriptor);
             }
         }


### PR DESCRIPTION
This pr introduces some performance optimizations about dictionaries:

Optimization 1:
Use primary key encoder to encode multiple column into a single one instead of row store encoder. Use primary key encoder is about `10X` faster than row store encoder.

Optimization 2:
Use phmap::NullMutex for phmap::parallel_flat_hash_map instead of std::shared_mutex. Dictionary cache become immutable hash_map after refreshing. It is safe to read without any lock. Use phmap::NullMutex instead of std::shared_mutex will get `4X` perf improvement for hash_map look up

Optimization 3:
Use prefetch technique to accelerate dictionary lookup. Here we use interleaving style prefetch technique to do it(prefetch key -> prefetch value -> actual lookup)

Optimization 4:
If key or value is string type, use Slices instead of std::string as type in dictionary. Sizeof(Slices) == 16 < sizeof(std::string) make the key/value more compact in memory. It is more cache friendly. At the same time, we save the actual string content into contiguous memory using mempool. It also more cache friendly if we read the actual string value.

Optimization 3 + Optimization 4 improve the lookup perf about `50%`

Optimization 5:
Currently, Primary key encoder will use \0 only to separate multiple columns if the original string value does not contain any \0. In this pr, we decode the columns using std::memchr only and prevent to compare the char one by one in this case. It make `4X` faster than the original decoding method.

Fixes #40215

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
