### PR TITLE
[BugFix] disable jit const expr

### DIFF
--- a/be/src/exprs/expr.cpp
+++ b/be/src/exprs/expr.cpp
@@ -753,7 +753,7 @@ Status Expr::replace_compilable_exprs(Expr** expr, ObjectPool* pool) {
 }
 
 bool Expr::should_compile() const {
-    if (!is_compilable() || _children.empty()) {
+    if (!is_compilable() || _children.empty() || is_constant()) {
         return false;
     }
 

--- a/be/src/exprs/jit/jit_functions.cpp
+++ b/be/src/exprs/jit/jit_functions.cpp
@@ -195,7 +195,7 @@ Status JITFunction::generate_scalar_function_ir(ExprContext* context, llvm::Modu
     // values_last[counter] = result_value;
     // null_flags_last[counter] = result_null_flag;
     b.CreateStore(result.value, b.CreateInBoundsGEP(columns.back().value_type, columns.back().values, counter_phi));
-    if (!expr->is_constant() && expr->is_nullable()) {
+    if (expr->is_nullable()) {
         b.CreateStore(result.null_flag, b.CreateInBoundsGEP(b.getInt8Ty(), columns.back().null_flags, counter_phi));
     }
 

--- a/be/test/exprs/arithmetic_expr_test.cpp
+++ b/be/test/exprs/arithmetic_expr_test.cpp
@@ -442,16 +442,13 @@ TEST_F(VectorizedArithmeticExprTest, constConstAddExpr) {
     {
         ColumnPtr ptr = expr->evaluate(nullptr, nullptr);
 
-        ExprsTestHelper::verify_with_jit(ptr, expr.get(), &runtime_state, [](ColumnPtr const& ptr) {
-            ASSERT_TRUE(ptr->is_constant());
+        ASSERT_TRUE(ptr->is_constant());
+        auto v = std::static_pointer_cast<ConstColumn>(ptr)->data_column();
+        ASSERT_EQ(1, v->size());
 
-            auto v = std::static_pointer_cast<ConstColumn>(ptr)->data_column();
-            ASSERT_EQ(1, v->size());
-
-            for (int j = 0; j < v->size(); ++j) {
-                ASSERT_EQ(13, std::static_pointer_cast<Int32Column>(v)->get_data()[j]);
-            }
-        });
+        for (int j = 0; j < v->size(); ++j) {
+            ASSERT_EQ(13, std::static_pointer_cast<Int32Column>(v)->get_data()[j]);
+        }
     }
 }
 
@@ -536,20 +533,18 @@ TEST_F(VectorizedArithmeticExprTest, constBitNotExpr) {
         expr->_children.push_back(&col1);
         ColumnPtr ptr = expr->evaluate(nullptr, nullptr);
 
-        ExprsTestHelper::verify_with_jit(ptr, expr.get(), &runtime_state, [](ColumnPtr const& ptr) {
-            ASSERT_TRUE(ptr->is_constant());
+        ASSERT_TRUE(ptr->is_constant());
 
-            auto re = std::static_pointer_cast<ConstColumn>(ptr);
-            auto v = std::static_pointer_cast<Int32Column>(re->data_column());
+        auto re = std::static_pointer_cast<ConstColumn>(ptr);
+        auto v = std::static_pointer_cast<Int32Column>(re->data_column());
 
-            for (int j = 0; j < ptr->size(); ++j) {
-                ASSERT_EQ(~2, v->get_data()[j]);
-            }
+        for (int j = 0; j < ptr->size(); ++j) {
+            ASSERT_EQ(~2, v->get_data()[j]);
+        }
 
-            for (int j = 0; j < ptr->size(); ++j) {
-                ASSERT_FALSE(v->is_null(j));
-            }
-        });
+        for (int j = 0; j < ptr->size(); ++j) {
+            ASSERT_FALSE(v->is_null(j));
+        }
     }
 }
 
@@ -569,42 +564,36 @@ TEST_F(VectorizedArithmeticExprTest, constModExpr) {
     {
         ColumnPtr v1 = col1.evaluate(nullptr, nullptr);
 
-        ExprsTestHelper::verify_with_jit(v1, expr.get(), &runtime_state, [](ColumnPtr const& ptr) {
-            ASSERT_FALSE(ptr->is_nullable());
+        ASSERT_FALSE(v1->is_nullable());
 
-            for (int j = 0; j < ptr->size(); ++j) {
-                ASSERT_FALSE(ptr->is_null(j));
-            }
-        });
+        for (int j = 0; j < v1->size(); ++j) {
+            ASSERT_FALSE(v1->is_null(j));
+        }
 
         ColumnPtr v2 = col2.evaluate(nullptr, nullptr);
 
-        ExprsTestHelper::verify_with_jit(v2, expr.get(), &runtime_state, [](ColumnPtr const& ptr) {
-            ASSERT_FALSE(ptr->is_nullable());
-            ASSERT_TRUE(ptr->is_constant());
-            ASSERT_EQ(1, ptr->size());
-        });
+        ASSERT_FALSE(v2->is_nullable());
+        ASSERT_TRUE(v2->is_constant());
+        ASSERT_EQ(1, v2->size());
     }
 
     {
         ColumnPtr ptr = expr->evaluate(nullptr, nullptr);
 
-        ExprsTestHelper::verify_with_jit(ptr, expr.get(), &runtime_state, [](ColumnPtr const& ptr) {
-            ASSERT_FALSE(ptr->is_nullable());
-            ASSERT_TRUE(ptr->is_constant());
-            ASSERT_FALSE(ptr->is_numeric());
+        ASSERT_FALSE(ptr->is_nullable());
+        ASSERT_TRUE(ptr->is_constant());
+        ASSERT_FALSE(ptr->is_numeric());
 
-            auto v = std::static_pointer_cast<ConstColumn>(ptr);
-            ASSERT_EQ(1, v->size());
+        auto v = std::static_pointer_cast<ConstColumn>(ptr);
+        ASSERT_EQ(1, v->size());
 
-            for (int j = 0; j < v->size(); ++j) {
-                ASSERT_EQ(0, ColumnHelper::cast_to_raw<TYPE_BIGINT>(v->data_column())->get_data()[j]);
-            }
+        for (int j = 0; j < v->size(); ++j) {
+            ASSERT_EQ(0, ColumnHelper::cast_to_raw<TYPE_BIGINT>(v->data_column())->get_data()[j]);
+        }
 
-            for (int j = 0; j < v->size(); ++j) {
-                ASSERT_FALSE(v->is_null(j));
-            }
-        });
+        for (int j = 0; j < v->size(); ++j) {
+            ASSERT_FALSE(v->is_null(j));
+        }
     }
 }
 

--- a/test/sql/test_jit/R/test_arithmetic
+++ b/test/sql/test_jit/R/test_arithmetic
@@ -941,6 +941,10 @@ SELECT min(((1 / 1) % 1) * 1) from jit_basic;
 -- result:
 0.0
 -- !result
+SELECT min(((1 / 1) % 1) * null) from jit_basic;
+-- result:
+None
+-- !result
 DROP TABLE IF EXISTS `jit_basic`;
 -- result:
 -- !result

--- a/test/sql/test_jit/R/test_arithmetic
+++ b/test/sql/test_jit/R/test_arithmetic
@@ -925,6 +925,22 @@ select a.c_dis,b.c_largeint + a.c_bigint + b.c_int + a.c_smallint + b.c_tinyint 
 1	-170141183460469231722463931676881813381
 2	170141183460469231722463931676881813376
 -- !result
+SELECT (((1 / 1) % 1) * 1);
+-- result:
+0.0
+-- !result
+select 1+2 * null;
+-- result:
+None
+-- !result
+select 2/null;
+-- result:
+None
+-- !result
+SELECT min(((1 / 1) % 1) * 1) from jit_basic;
+-- result:
+0.0
+-- !result
 DROP TABLE IF EXISTS `jit_basic`;
 -- result:
 -- !result

--- a/test/sql/test_jit/T/test_arithmetic
+++ b/test/sql/test_jit/T/test_arithmetic
@@ -105,5 +105,5 @@ select 1+2 * null;
 select 2/null;
 
 SELECT min(((1 / 1) % 1) * 1) from jit_basic;
-
+SELECT min(((1 / 1) % 1) * null) from jit_basic;
 DROP TABLE IF EXISTS `jit_basic`;

--- a/test/sql/test_jit/T/test_arithmetic
+++ b/test/sql/test_jit/T/test_arithmetic
@@ -100,4 +100,10 @@ select a.c_dis,b.c_largeint + a.c_bigint + b.c_int + a.c_smallint + b.c_tinyint 
                 on b.c_largeint + b.c_bigint + b.c_int + b.c_smallint + b.c_tinyint = a.c_largeint + a.c_bigint + a.c_int + a.c_smallint + a.c_tinyint
                 order by 1;
 
+SELECT (((1 / 1) % 1) * 1);
+select 1+2 * null;
+select 2/null;
+
+SELECT min(((1 / 1) % 1) * 1) from jit_basic;
+
 DROP TABLE IF EXISTS `jit_basic`;


### PR DESCRIPTION
Why I'm doing:

What I'm doing:
disable jit const expr

Fixes https://github.com/StarRocks/StarRocksTest/issues/5945， https://github.com/StarRocks/StarRocksTest/issues/5884

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
