### PR TITLE
[BugFix] Fix array<string> use local dict-optimization

### DIFF
--- a/be/src/storage/rowset/array_column_iterator.cpp
+++ b/be/src/storage/rowset/array_column_iterator.cpp
@@ -353,7 +353,7 @@ Status ArrayColumnIterator::fetch_dict_codes_by_rowid(const rowid_t* rowids, siz
 }
 
 Status ArrayColumnIterator::decode_dict_codes(const int32_t* codes, size_t size, Column* words) {
-    return _element_iterator->decode_dict_codes(codes, size, words);
+    return Status::NotSupported("ArrayColumn don't support local low-cardinality dict optimization");
 }
 
 } // namespace starrocks

--- a/be/src/storage/rowset/column_decoder.cpp
+++ b/be/src/storage/rowset/column_decoder.cpp
@@ -90,6 +90,7 @@ Status ColumnDecoder::_encode_array_to_global_id(Column* datas, Column* codes) {
         auto* array_column = down_cast<ArrayColumn*>(nullable_column->data_column().get());
         auto* lowcard_array_column = down_cast<ArrayColumn*>(lowcard_nullcolumn->data_column().get());
 
+        lowcard_nullcolumn->set_has_null(nullable_column->has_null());
         lowcard_nullcolumn->null_column()->swap_column(*nullable_column->null_column());
         lowcard_array_column->offsets_column()->swap_column(*array_column->offsets_column());
         return _encode_string_to_global_id(array_column->elements_column().get(),

--- a/be/src/storage/rowset/segment_iterator.cpp
+++ b/be/src/storage/rowset/segment_iterator.cpp
@@ -1293,6 +1293,9 @@ StatusOr<uint16_t> SegmentIterator::_filter_by_expr_predicates(Chunk* chunk, vec
 }
 
 inline bool SegmentIterator::_can_using_dict_code(const FieldPtr& field) const {
+    if (field->type()->type() == TYPE_ARRAY) {
+        return false;
+    }
     if (_opts.predicates.find(field->id()) != _opts.predicates.end()) {
         return _predicate_need_rewrite[field->id()];
     } else {

--- a/test/lib/choose_cases.py
+++ b/test/lib/choose_cases.py
@@ -178,7 +178,7 @@ class ChooseCase(object):
         tmp_res = []
 
         while line_id < len(f_lines):
-            line_content = f_lines[line_id].rstrip("\n")
+            line_content = f_lines[line_id].rstrip("\n").strip();
 
             if line_content == "" or (line_content.startswith("--") and not line_content.startswith(NAME_FLAG)):
                 # invalid line

--- a/test/sql/test_low_cardinality/R/test_low_cardinality_array
+++ b/test/sql/test_low_cardinality/R/test_low_cardinality_array
@@ -308,11 +308,11 @@ insert into s2 select * from s2;
 -- !result
 [UC] analyze full table s1;
 -- result:
-test_db_d0bcea9a9d5011eeb1ca00163e04d4c2.s1	analyze	status	OK
+test_db_a96cd192be7211ee849200163e04d4c2.s1	analyze	status	OK
 -- !result
 [UC] analyze full table s2;
 -- result:
-test_db_d0bcea9a9d5011eeb1ca00163e04d4c2.s2	analyze	status	OK
+test_db_a96cd192be7211ee849200163e04d4c2.s2	analyze	status	OK
 -- !result
 function: wait_global_dict_ready('a1', 's1')
 -- result:
@@ -402,4 +402,162 @@ select lower(x1), upper(MIN(HEX(x2))) from (select a1[1] x1, array_max(a2) x2 fr
 -- result:
 anhui	5457
 beijing	5457
+-- !result
+-- name: test_low_array_with_dict_predicate
+CREATE TABLE `s3` (
+  `v1` bigint(20) NULL COMMENT "",
+  `v2` int(11) NULL COMMENT "",
+  `v3` string NULL COMMENT "",
+  `a1` array<varchar(65533)> NULL COMMENT "",
+  `a2` array<varchar(65533)> NULL COMMENT ""
+) ENGINE=OLAP
+DUPLICATE KEY(`v1`)
+COMMENT "OLAP"
+DISTRIBUTED BY HASH(`v1`) BUCKETS 10
+PROPERTIES (
+"replication_num" = "1",
+"in_memory" = "false",
+"enable_persistent_index" = "false",
+"replicated_storage" = "false",
+"light_schema_change" = "true",
+"compression" = "LZ4"
+);
+-- result:
+-- !result
+insert into s3 values
+(28222, 724, "BJ", ['Hubei', 'Ningxia', 'Sichuan', 'Zhejiang'], ['HK', 'BJ', 'GD', 'GS', 'LN']),
+(28231, 607, "SH", ['Yunnan', 'Inner Mongolia', 'Taiwan', 'Hunan'], ['JL', 'HUN', 'GZ', 'XJ', 'GZ']),
+(28316, 275, "GY", ['Anhui', 'Yunnan', 'Hainan', 'Heilongjiang', 'Hunan'], ['CQ', 'TW']),
+(28352, 371, "AH", ['Jiangsu', 'Guangdong', 'Taiwan', 'Zhejiang', 'Jilin'], ['XZ', 'QH', 'NX']),
+(28221, 241, "MO", ['Hong Kong', 'Zhejiang', 'Heilongjiang', 'Henan'], ['XZ', 'HLJ', 'AH', 'MO']),
+(28257, 447, "JS", ['Fujian', 'Jiangsu', 'Macao', 'Ningxia'], ['JS', 'GD', 'QH']),
+(28244, 834, "GD", ['Qinghai', 'Heilongjiang'], ['TJ', 'AH', 'HI']),
+(28350, 930, "QH", ['Shaanxi', 'Guangdong'], ['XJ', 'HUB', 'TW', 'HUN']),
+(28328, 495, "ZJ", ['Qinghai', 'Inner Mongolia'], ['GD', 'ZJ', 'JL', 'GS']),
+(28401, 307, "JL", ['Shandong', 'Guangxi', 'Xinjiang', 'Anhui', 'Ningxia'], ['NMG', 'ZJ', 'TW', 'HUN', 'HEN']),
+(28329, 729, "GS", ['Fujian', 'Henan', 'Chongqing', 'Zhejiang'], ['AH', 'SN', 'YN', 'CQ', 'HLJ']),
+(28342, 788, "TW", ['Qinghai', 'Jilin', 'Zhejiang'], ['HUB', 'HUB', 'HUB', 'JL']),
+(28341, 985, "HK", ['Sichuan', 'Heilongjiang', 'Shanghai', 'Tianjin'], ['XJ', 'HEN', 'XZ', 'TJ', 'AH']),
+(28389, 447, "LN", ['Hubei', 'Shandong', 'Macao', 'Liaoning', 'Guangdong'], ['JX', 'ZJ', 'SX', 'SC']),
+(28348, 349, "SX", ['Hebei', 'Hong Kong', 'Macao', 'Guangxi'], ['JX', 'XZ', 'ZJ']),
+(28220, 848, "BJ", ['Sichuan', 'Tianjin', 'Sichuan', 'Beijing', 'Xinjiang'], ['GD', 'CQ', 'HUN', 'HK', 'AH']),
+(28415, 286, "SH", ['Taiwan', 'Hong Kong', 'Fujian'], ['XZ', 'LN']),
+(28201, 171, "GY", ['Macao', 'Hubei', 'Liaoning', 'Shanghai'], ['HK', 'SN', 'HEN', 'GX', 'TW']),
+(28256, 501, "AH", ['Xinjiang', 'Hong Kong', 'Jilin'], ['ZJ', 'HUN', 'HUN', 'JX', 'SC']),
+(28250, 318, "MO", ['Heilongjiang', 'Macao', 'Hubei', 'Inner Mongolia', 'Tianjin'], ['HLJ', 'HEN']),
+(28204, 737, "JS", ['Taiwan', 'Hainan'], ['SC', 'QH', 'SH']),
+(28307, 246, "GD", ['Beijing', 'Jiangxi', 'Guizhou', 'Shaanxi'], ['SX', 'HEB', 'TW']),
+(28401, 774, "QH", ['Yunnan', 'Taiwan', 'Hunan', 'Inner Mongolia', 'Jiangsu'], ['SN', 'JS']),
+(28293, 964, "ZJ", ['Qinghai', 'Hubei', 'Hubei'], ['GX', 'HLJ', 'GD', 'AH', 'HK']),
+(28200, 302, "JL", ['Henan', 'Chongqing', 'Ningxia', 'Tibet', 'Yunnan'], ['JL', 'BJ']),
+(28212, 307, "GS", ['Jiangxi', 'Shanxi', 'Liaoning', 'Hunan'], ['TW', 'SH']),
+(28403, 874, "TW", ['Sichuan', 'Shanghai', 'Hubei', 'Chongqing'], ['MO', 'HLJ', 'SN', 'LN']),
+(28377, 723, "HK", ['Inner Mongolia', 'Gansu', 'Jiangsu'], ['YN', 'YN', 'ZJ']),
+(28320, 201, "LN", ['Shanghai', 'Shanghai', 'Guangxi'], ['JS', 'YN', 'TW', 'GZ', 'ZJ']),
+(28338, 692, "SX", ['Hainan', 'Zhejiang', 'Shanghai', 'Xinjiang', 'Henan'], ['SC', 'GS', 'SX', 'GZ', 'GD']),
+(28288, 909, "BJ", ['Fujian', 'Shandong', 'Shanxi', 'Qinghai', 'Tianjin'], ['GZ', 'HEB', 'XJ']),
+(28413, 665, "SH", ['Tianjin', 'Hunan', 'Taiwan'], ['HK', 'CQ', 'SD']),
+(28200, 947, "GY", ['Hunan', 'Henan'], ['FJ', 'MO', 'HEB', 'JL']),
+(28351, 414, "AH", ['Sichuan', 'Guangdong'], ['XZ', 'ZJ', 'ZJ', 'GS', 'SD']),
+(28278, 865, "MO", ['Shaanxi', 'Shandong', 'Gansu'], ['GZ', 'NX', 'HLJ']),
+(28424, 944, "JS", ['Liaoning', 'Chongqing', 'Jiangsu'], ['GS', 'GX', 'SH', 'GX']),
+(28329, 371, "GD", ['Inner Mongolia', 'Shandong'], ['XJ', 'NX']),
+(28388, 901, "QH", ['Gansu', 'Hong Kong', 'Chongqing', 'Beijing'], ['SH', 'JS']),
+(28233, 472, "ZJ", ['Chongqing', 'Guangdong', 'Hebei', 'Hebei'], ['XJ', 'YN', 'HEB', 'SD']),
+(28411, 373, "JL", ['Hong Kong', 'Jiangsu', 'Tibet', 'Yunnan', 'Fujian'], ['JX', 'FJ', 'FJ', 'HK', 'JL']),
+(28353, 693, "GS", ['Sichuan', 'Fujian', 'Tibet', 'Taiwan', 'Zhejiang'], ['CQ', 'SH', 'AH', 'YN']),
+(28222, 655, "TW", ['Guangxi', 'Taiwan', 'Macao', 'Tibet', 'Ningxia'], ['YN', 'HUB', 'CQ', 'SD', 'SX']),
+(28377, 233, "HK", ['Jilin', 'Guizhou', 'Taiwan', 'Macao', 'Yunnan'], ['SC', 'CQ', 'SD', 'SH', 'JL']),
+(28404, 666, "LN", ['Guizhou', 'Shandong', 'Fujian'], ['SX', 'HEB']),
+(28391, 140, "SX", ['Taiwan', 'Macao', 'Taiwan', 'Shanghai', 'Inner Mongolia'], ['AH', 'FJ', 'HEN', 'SN', 'HK']),
+(28347, 495, "HN", ['Qinghai', 'Gansu', 'Gansu', 'Guangdong'], ['HUB', 'HUN', 'LN', 'TJ']),
+(28327, 269, "SD", ['Hainan', 'Guangdong', 'Jilin'], ['SC', 'GD', 'SD', 'ZJ', 'ZJ']),
+(28263, 864, "AH", ['Yunnan', 'Jiangxi', 'Fujian'], ['SC', 'HI', 'HUB', 'SN', 'SX']),
+(28235, 711, "YN", ['Hainan', 'Hainan', 'Yunnan', 'Liaoning', 'Anhui'], ['HUN', 'SD']);
+-- result:
+-- !result
+insert into s3 select * from s3;
+-- result:
+-- !result
+insert into s3 select * from s3;
+-- result:
+-- !result
+insert into s3 select * from s3;
+-- result:
+-- !result
+insert into s3 select * from s3;
+-- result:
+-- !result
+insert into s3 select * from s3;
+-- result:
+-- !result
+insert into s3 select * from s3;
+-- result:
+-- !result
+insert into s3 select * from s3;
+-- result:
+-- !result
+[UC] analyze full table s3;
+-- result:
+test_db_a96d329abe7211ee9c5d00163e04d4c2.s3	analyze	status	OK
+-- !result
+function: wait_global_dict_ready('a1', 's3')
+-- result:
+
+-- !result
+function: wait_global_dict_ready('a2', 's3')
+-- result:
+
+-- !result
+select * from s3 order by v1 limit 2;
+-- result:
+28200	947	GY	["Hunan","Henan"]	["FJ","MO","HEB","JL"]
+28200	302	JL	["Henan","Chongqing","Ningxia","Tibet","Yunnan"]	["JL","BJ"]
+-- !result
+select * from s3 where a1[1] = 'Jiangsu' and v3 = "BJ" order by v1 limit 2;
+-- result:
+-- !result
+select * from s3 where a1[1] = 'Jiangsu' and a2[2] = 'GD' and v3 > "AH" order by v1 limit 2;
+-- result:
+-- !result
+select array_length(a1), array_max(a2), array_min(a1), array_distinct(a1), array_sort(a2),
+       reverse(a1), array_slice(a2, 2, 4), cardinality(a2)
+from s3 where a1[1] = 'Jiangsu' and a2[2] = 'GD' and v3 = "MO" order by v1 limit 2;
+-- result:
+-- !result
+select array_length(a1), array_max(a2), array_min(a1), array_distinct(a1), array_sort(a2),
+       reverse(a1), array_slice(a2, 2, 4), cardinality(a2)
+from s3 where a1[1] = 'Jiangsu' or a2[2] = 'GD' order by v1 limit 2;
+-- result:
+4	QH	Fujian	["Fujian","Jiangsu","Macao","Ningxia"]	["GD","JS","QH"]	["Ningxia","Macao","Jiangsu","Fujian"]	["GD","QH"]	3
+4	QH	Fujian	["Fujian","Jiangsu","Macao","Ningxia"]	["GD","JS","QH"]	["Ningxia","Macao","Jiangsu","Fujian"]	["GD","QH"]	3
+-- !result
+select count(a1[2]) from s3 where v3 = "GS"; 
+
+
+select /*+SET_VAR(cbo_enable_low_cardinality_optimize=false, low_cardinality_optimize_v2=false)*/ * from s3 order by v1 limit 2;
+-- result:
+384
+-- !result
+select /*+SET_VAR(cbo_enable_low_cardinality_optimize=false, low_cardinality_optimize_v2=false)*/ * from s3 where a1[1] = 'Jiangsu' and v3 = "BJ" order by v1 limit 2;
+-- result:
+-- !result
+select /*+SET_VAR(cbo_enable_low_cardinality_optimize=false, low_cardinality_optimize_v2=false)*/ * from s3 where a1[1] = 'Jiangsu' and a2[2] = 'GD' and v3 > "AH" order by v1 limit 2;
+-- result:
+-- !result
+select /*+SET_VAR(cbo_enable_low_cardinality_optimize=false, low_cardinality_optimize_v2=false)*/ array_length(a1), array_max(a2), array_min(a1), array_distinct(a1), array_sort(a2),
+       reverse(a1), array_slice(a2, 2, 4), cardinality(a2)
+from s3 where a1[1] = 'Jiangsu' and a2[2] = 'GD' and v3 = "MO" order by v1 limit 2;
+-- result:
+-- !result
+select /*+SET_VAR(cbo_enable_low_cardinality_optimize=false, low_cardinality_optimize_v2=false)*/ array_length(a1), array_max(a2), array_min(a1), array_distinct(a1), array_sort(a2),
+       reverse(a1), array_slice(a2, 2, 4), cardinality(a2)
+from s3 where a1[1] = 'Jiangsu' or a2[2] = 'GD' order by v1 limit 2;
+-- result:
+4	QH	Fujian	["Fujian","Jiangsu","Macao","Ningxia"]	["GD","JS","QH"]	["Ningxia","Macao","Jiangsu","Fujian"]	["GD","QH"]	3
+4	QH	Fujian	["Fujian","Jiangsu","Macao","Ningxia"]	["GD","JS","QH"]	["Ningxia","Macao","Jiangsu","Fujian"]	["GD","QH"]	3
+-- !result
+select /*+SET_VAR(cbo_enable_low_cardinality_optimize=false, low_cardinality_optimize_v2=false)*/ count(a1[2]) from s3 where v3 = "GS"; 
+-- result:
+384
 -- !result

--- a/test/sql/test_low_cardinality/R/test_low_cardinality_array
+++ b/test/sql/test_low_cardinality/R/test_low_cardinality_array
@@ -308,11 +308,11 @@ insert into s2 select * from s2;
 -- !result
 [UC] analyze full table s1;
 -- result:
-test_db_a96cd192be7211ee849200163e04d4c2.s1	analyze	status	OK
+test_db_1333f808bf6811eea33e00163e04d4c2.s1	analyze	status	OK
 -- !result
 [UC] analyze full table s2;
 -- result:
-test_db_a96cd192be7211ee849200163e04d4c2.s2	analyze	status	OK
+test_db_1333f808bf6811eea33e00163e04d4c2.s2	analyze	status	OK
 -- !result
 function: wait_global_dict_ready('a1', 's1')
 -- result:
@@ -380,7 +380,7 @@ select array_max(s1.a2), array_distinct(s2.a1) from s1 join s2 on s1.v1 = s2.v1 
 JL	["Henan","Chongqing","Ningxia","Tibet","Yunnan"]
 MO	["Henan","Chongqing","Ningxia","Tibet","Yunnan"]
 -- !result
-select * from 
+select * from
 (select array_max(a1) x1 from s1) t1 join
 (select array_min(a1) x2 from s2) t2 on x1 = x2
 order by x1 limit 2;
@@ -499,7 +499,7 @@ insert into s3 select * from s3;
 -- !result
 [UC] analyze full table s3;
 -- result:
-test_db_ba84e764bf3811eeb48400163e04d4c2.s3	analyze	status	OK
+test_db_133557b6bf6811eeb52600163e04d4c2.s3	analyze	status	OK
 -- !result
 function: wait_global_dict_ready('a1', 's3')
 -- result:
@@ -532,7 +532,7 @@ from s3 where a1[1] = 'Jiangsu' or a2[2] = 'GD' order by v1 limit 2;
 4	QH	Fujian	["Fujian","Jiangsu","Macao","Ningxia"]	["GD","JS","QH"]	["Ningxia","Macao","Jiangsu","Fujian"]	["GD","QH"]	3
 4	QH	Fujian	["Fujian","Jiangsu","Macao","Ningxia"]	["GD","JS","QH"]	["Ningxia","Macao","Jiangsu","Fujian"]	["GD","QH"]	3
 -- !result
-select count(a1[2]) from s3 where v3 = "GS"; 
+select count(a1[2]) from s3 where v3 = "GS";
 -- result:
 384
 -- !result
@@ -559,7 +559,7 @@ from s3 where a1[1] = 'Jiangsu' or a2[2] = 'GD' order by v1 limit 2;
 4	QH	Fujian	["Fujian","Jiangsu","Macao","Ningxia"]	["GD","JS","QH"]	["Ningxia","Macao","Jiangsu","Fujian"]	["GD","QH"]	3
 4	QH	Fujian	["Fujian","Jiangsu","Macao","Ningxia"]	["GD","JS","QH"]	["Ningxia","Macao","Jiangsu","Fujian"]	["GD","QH"]	3
 -- !result
-select /*+SET_VAR(cbo_enable_low_cardinality_optimize=false, low_cardinality_optimize_v2=false)*/ count(a1[2]) from s3 where v3 = "GS"; 
+select /*+SET_VAR(cbo_enable_low_cardinality_optimize=false, low_cardinality_optimize_v2=false)*/ count(a1[2]) from s3 where v3 = "GS";
 -- result:
 384
 -- !result

--- a/test/sql/test_low_cardinality/R/test_low_cardinality_array
+++ b/test/sql/test_low_cardinality/R/test_low_cardinality_array
@@ -499,7 +499,7 @@ insert into s3 select * from s3;
 -- !result
 [UC] analyze full table s3;
 -- result:
-test_db_a96d329abe7211ee9c5d00163e04d4c2.s3	analyze	status	OK
+test_db_ba84e764bf3811eeb48400163e04d4c2.s3	analyze	status	OK
 -- !result
 function: wait_global_dict_ready('a1', 's3')
 -- result:
@@ -533,11 +533,13 @@ from s3 where a1[1] = 'Jiangsu' or a2[2] = 'GD' order by v1 limit 2;
 4	QH	Fujian	["Fujian","Jiangsu","Macao","Ningxia"]	["GD","JS","QH"]	["Ningxia","Macao","Jiangsu","Fujian"]	["GD","QH"]	3
 -- !result
 select count(a1[2]) from s3 where v3 = "GS"; 
-
-
-select /*+SET_VAR(cbo_enable_low_cardinality_optimize=false, low_cardinality_optimize_v2=false)*/ * from s3 order by v1 limit 2;
 -- result:
 384
+-- !result
+select /*+SET_VAR(cbo_enable_low_cardinality_optimize=false, low_cardinality_optimize_v2=false)*/ * from s3 order by v1 limit 2;
+-- result:
+28200	947	GY	["Hunan","Henan"]	["FJ","MO","HEB","JL"]
+28200	302	JL	["Henan","Chongqing","Ningxia","Tibet","Yunnan"]	["JL","BJ"]
 -- !result
 select /*+SET_VAR(cbo_enable_low_cardinality_optimize=false, low_cardinality_optimize_v2=false)*/ * from s3 where a1[1] = 'Jiangsu' and v3 = "BJ" order by v1 limit 2;
 -- result:

--- a/test/sql/test_low_cardinality/T/test_low_cardinality
+++ b/test/sql/test_low_cardinality/T/test_low_cardinality
@@ -635,7 +635,7 @@ SELECT
     SUBSTRING(lcd.c4, 3) AS substring_c4,
     TRIM(CONCAT(lcd.c4, ' - ', 'a')) AS trimmed,
     UPPER(lcd.c4) AS upper_c4,
-    IF(lcd.c3 IS NOT NULL, 'a', 'b') AS if_result,
+    IF(lcd.c3 IS NOT NULL, 'a', 'b') AS if_result
 FROM
     low_card_duplicate lcd
 group by

--- a/test/sql/test_low_cardinality/T/test_low_cardinality_array
+++ b/test/sql/test_low_cardinality/T/test_low_cardinality_array
@@ -439,10 +439,6 @@ from s3 where a1[1] = 'Jiangsu' or a2[2] = 'GD' order by v1 limit 2;
 
 select count(a1[2]) from s3 where v3 = "GS"; 
 
-<<<<<<< HEAD
-
-=======
->>>>>>> e511c083b0 ([BugFix] Fix array<string> use local dict-optimization)
 select /*+SET_VAR(cbo_enable_low_cardinality_optimize=false, low_cardinality_optimize_v2=false)*/ * from s3 order by v1 limit 2;
 
 select /*+SET_VAR(cbo_enable_low_cardinality_optimize=false, low_cardinality_optimize_v2=false)*/ * from s3 where a1[1] = 'Jiangsu' and v3 = "BJ" order by v1 limit 2;
@@ -457,7 +453,3 @@ select /*+SET_VAR(cbo_enable_low_cardinality_optimize=false, low_cardinality_opt
 from s3 where a1[1] = 'Jiangsu' or a2[2] = 'GD' order by v1 limit 2;
 
 select /*+SET_VAR(cbo_enable_low_cardinality_optimize=false, low_cardinality_optimize_v2=false)*/ count(a1[2]) from s3 where v3 = "GS"; 
-<<<<<<< HEAD
-=======
-
->>>>>>> e511c083b0 ([BugFix] Fix array<string> use local dict-optimization)

--- a/test/sql/test_low_cardinality/T/test_low_cardinality_array
+++ b/test/sql/test_low_cardinality/T/test_low_cardinality_array
@@ -337,3 +337,120 @@ select MAX(upper(a1[1])) from s1 group by a2[1] order by a2[1] limit 2;
 select lower(MAX(upper(a1[1]))) from s1 group by a2[1] order by a2[1] limit 2;
 
 select lower(x1), upper(MIN(HEX(x2))) from (select a1[1] x1, array_max(a2) x2 from s1) y group by x1 order by x1 limit 2;
+
+-- name: test_low_array_with_dict_predicate
+
+CREATE TABLE `s3` (
+  `v1` bigint(20) NULL COMMENT "",
+  `v2` int(11) NULL COMMENT "",
+  `v3` string NULL COMMENT "",
+  `a1` array<varchar(65533)> NULL COMMENT "",
+  `a2` array<varchar(65533)> NULL COMMENT ""
+) ENGINE=OLAP
+DUPLICATE KEY(`v1`)
+COMMENT "OLAP"
+DISTRIBUTED BY HASH(`v1`) BUCKETS 10
+PROPERTIES (
+"replication_num" = "1",
+"in_memory" = "false",
+"enable_persistent_index" = "false",
+"replicated_storage" = "false",
+"light_schema_change" = "true",
+"compression" = "LZ4"
+);
+
+insert into s3 values
+(28222, 724, "BJ", ['Hubei', 'Ningxia', 'Sichuan', 'Zhejiang'], ['HK', 'BJ', 'GD', 'GS', 'LN']),
+(28231, 607, "SH", ['Yunnan', 'Inner Mongolia', 'Taiwan', 'Hunan'], ['JL', 'HUN', 'GZ', 'XJ', 'GZ']),
+(28316, 275, "GY", ['Anhui', 'Yunnan', 'Hainan', 'Heilongjiang', 'Hunan'], ['CQ', 'TW']),
+(28352, 371, "AH", ['Jiangsu', 'Guangdong', 'Taiwan', 'Zhejiang', 'Jilin'], ['XZ', 'QH', 'NX']),
+(28221, 241, "MO", ['Hong Kong', 'Zhejiang', 'Heilongjiang', 'Henan'], ['XZ', 'HLJ', 'AH', 'MO']),
+(28257, 447, "JS", ['Fujian', 'Jiangsu', 'Macao', 'Ningxia'], ['JS', 'GD', 'QH']),
+(28244, 834, "GD", ['Qinghai', 'Heilongjiang'], ['TJ', 'AH', 'HI']),
+(28350, 930, "QH", ['Shaanxi', 'Guangdong'], ['XJ', 'HUB', 'TW', 'HUN']),
+(28328, 495, "ZJ", ['Qinghai', 'Inner Mongolia'], ['GD', 'ZJ', 'JL', 'GS']),
+(28401, 307, "JL", ['Shandong', 'Guangxi', 'Xinjiang', 'Anhui', 'Ningxia'], ['NMG', 'ZJ', 'TW', 'HUN', 'HEN']),
+(28329, 729, "GS", ['Fujian', 'Henan', 'Chongqing', 'Zhejiang'], ['AH', 'SN', 'YN', 'CQ', 'HLJ']),
+(28342, 788, "TW", ['Qinghai', 'Jilin', 'Zhejiang'], ['HUB', 'HUB', 'HUB', 'JL']),
+(28341, 985, "HK", ['Sichuan', 'Heilongjiang', 'Shanghai', 'Tianjin'], ['XJ', 'HEN', 'XZ', 'TJ', 'AH']),
+(28389, 447, "LN", ['Hubei', 'Shandong', 'Macao', 'Liaoning', 'Guangdong'], ['JX', 'ZJ', 'SX', 'SC']),
+(28348, 349, "SX", ['Hebei', 'Hong Kong', 'Macao', 'Guangxi'], ['JX', 'XZ', 'ZJ']),
+(28220, 848, "BJ", ['Sichuan', 'Tianjin', 'Sichuan', 'Beijing', 'Xinjiang'], ['GD', 'CQ', 'HUN', 'HK', 'AH']),
+(28415, 286, "SH", ['Taiwan', 'Hong Kong', 'Fujian'], ['XZ', 'LN']),
+(28201, 171, "GY", ['Macao', 'Hubei', 'Liaoning', 'Shanghai'], ['HK', 'SN', 'HEN', 'GX', 'TW']),
+(28256, 501, "AH", ['Xinjiang', 'Hong Kong', 'Jilin'], ['ZJ', 'HUN', 'HUN', 'JX', 'SC']),
+(28250, 318, "MO", ['Heilongjiang', 'Macao', 'Hubei', 'Inner Mongolia', 'Tianjin'], ['HLJ', 'HEN']),
+(28204, 737, "JS", ['Taiwan', 'Hainan'], ['SC', 'QH', 'SH']),
+(28307, 246, "GD", ['Beijing', 'Jiangxi', 'Guizhou', 'Shaanxi'], ['SX', 'HEB', 'TW']),
+(28401, 774, "QH", ['Yunnan', 'Taiwan', 'Hunan', 'Inner Mongolia', 'Jiangsu'], ['SN', 'JS']),
+(28293, 964, "ZJ", ['Qinghai', 'Hubei', 'Hubei'], ['GX', 'HLJ', 'GD', 'AH', 'HK']),
+(28200, 302, "JL", ['Henan', 'Chongqing', 'Ningxia', 'Tibet', 'Yunnan'], ['JL', 'BJ']),
+(28212, 307, "GS", ['Jiangxi', 'Shanxi', 'Liaoning', 'Hunan'], ['TW', 'SH']),
+(28403, 874, "TW", ['Sichuan', 'Shanghai', 'Hubei', 'Chongqing'], ['MO', 'HLJ', 'SN', 'LN']),
+(28377, 723, "HK", ['Inner Mongolia', 'Gansu', 'Jiangsu'], ['YN', 'YN', 'ZJ']),
+(28320, 201, "LN", ['Shanghai', 'Shanghai', 'Guangxi'], ['JS', 'YN', 'TW', 'GZ', 'ZJ']),
+(28338, 692, "SX", ['Hainan', 'Zhejiang', 'Shanghai', 'Xinjiang', 'Henan'], ['SC', 'GS', 'SX', 'GZ', 'GD']),
+(28288, 909, "BJ", ['Fujian', 'Shandong', 'Shanxi', 'Qinghai', 'Tianjin'], ['GZ', 'HEB', 'XJ']),
+(28413, 665, "SH", ['Tianjin', 'Hunan', 'Taiwan'], ['HK', 'CQ', 'SD']),
+(28200, 947, "GY", ['Hunan', 'Henan'], ['FJ', 'MO', 'HEB', 'JL']),
+(28351, 414, "AH", ['Sichuan', 'Guangdong'], ['XZ', 'ZJ', 'ZJ', 'GS', 'SD']),
+(28278, 865, "MO", ['Shaanxi', 'Shandong', 'Gansu'], ['GZ', 'NX', 'HLJ']),
+(28424, 944, "JS", ['Liaoning', 'Chongqing', 'Jiangsu'], ['GS', 'GX', 'SH', 'GX']),
+(28329, 371, "GD", ['Inner Mongolia', 'Shandong'], ['XJ', 'NX']),
+(28388, 901, "QH", ['Gansu', 'Hong Kong', 'Chongqing', 'Beijing'], ['SH', 'JS']),
+(28233, 472, "ZJ", ['Chongqing', 'Guangdong', 'Hebei', 'Hebei'], ['XJ', 'YN', 'HEB', 'SD']),
+(28411, 373, "JL", ['Hong Kong', 'Jiangsu', 'Tibet', 'Yunnan', 'Fujian'], ['JX', 'FJ', 'FJ', 'HK', 'JL']),
+(28353, 693, "GS", ['Sichuan', 'Fujian', 'Tibet', 'Taiwan', 'Zhejiang'], ['CQ', 'SH', 'AH', 'YN']),
+(28222, 655, "TW", ['Guangxi', 'Taiwan', 'Macao', 'Tibet', 'Ningxia'], ['YN', 'HUB', 'CQ', 'SD', 'SX']),
+(28377, 233, "HK", ['Jilin', 'Guizhou', 'Taiwan', 'Macao', 'Yunnan'], ['SC', 'CQ', 'SD', 'SH', 'JL']),
+(28404, 666, "LN", ['Guizhou', 'Shandong', 'Fujian'], ['SX', 'HEB']),
+(28391, 140, "SX", ['Taiwan', 'Macao', 'Taiwan', 'Shanghai', 'Inner Mongolia'], ['AH', 'FJ', 'HEN', 'SN', 'HK']),
+(28347, 495, "HN", ['Qinghai', 'Gansu', 'Gansu', 'Guangdong'], ['HUB', 'HUN', 'LN', 'TJ']),
+(28327, 269, "SD", ['Hainan', 'Guangdong', 'Jilin'], ['SC', 'GD', 'SD', 'ZJ', 'ZJ']),
+(28263, 864, "AH", ['Yunnan', 'Jiangxi', 'Fujian'], ['SC', 'HI', 'HUB', 'SN', 'SX']),
+(28235, 711, "YN", ['Hainan', 'Hainan', 'Yunnan', 'Liaoning', 'Anhui'], ['HUN', 'SD']);
+
+insert into s3 select * from s3;
+insert into s3 select * from s3;
+insert into s3 select * from s3;
+insert into s3 select * from s3;
+insert into s3 select * from s3;
+insert into s3 select * from s3;
+insert into s3 select * from s3;
+
+[UC] analyze full table s3;
+
+function: wait_global_dict_ready('a1', 's3')
+function: wait_global_dict_ready('a2', 's3')
+
+
+select * from s3 order by v1 limit 2;
+
+select * from s3 where a1[1] = 'Jiangsu' and v3 = "BJ" order by v1 limit 2;
+select * from s3 where a1[1] = 'Jiangsu' and a2[2] = 'GD' and v3 > "AH" order by v1 limit 2;
+
+select array_length(a1), array_max(a2), array_min(a1), array_distinct(a1), array_sort(a2),
+       reverse(a1), array_slice(a2, 2, 4), cardinality(a2)
+from s3 where a1[1] = 'Jiangsu' and a2[2] = 'GD' and v3 = "MO" order by v1 limit 2;
+
+select array_length(a1), array_max(a2), array_min(a1), array_distinct(a1), array_sort(a2),
+       reverse(a1), array_slice(a2, 2, 4), cardinality(a2)
+from s3 where a1[1] = 'Jiangsu' or a2[2] = 'GD' order by v1 limit 2;
+
+select count(a1[2]) from s3 where v3 = "GS"; 
+
+
+select /*+SET_VAR(cbo_enable_low_cardinality_optimize=false, low_cardinality_optimize_v2=false)*/ * from s3 order by v1 limit 2;
+
+select /*+SET_VAR(cbo_enable_low_cardinality_optimize=false, low_cardinality_optimize_v2=false)*/ * from s3 where a1[1] = 'Jiangsu' and v3 = "BJ" order by v1 limit 2;
+select /*+SET_VAR(cbo_enable_low_cardinality_optimize=false, low_cardinality_optimize_v2=false)*/ * from s3 where a1[1] = 'Jiangsu' and a2[2] = 'GD' and v3 > "AH" order by v1 limit 2;
+
+select /*+SET_VAR(cbo_enable_low_cardinality_optimize=false, low_cardinality_optimize_v2=false)*/ array_length(a1), array_max(a2), array_min(a1), array_distinct(a1), array_sort(a2),
+       reverse(a1), array_slice(a2, 2, 4), cardinality(a2)
+from s3 where a1[1] = 'Jiangsu' and a2[2] = 'GD' and v3 = "MO" order by v1 limit 2;
+
+select /*+SET_VAR(cbo_enable_low_cardinality_optimize=false, low_cardinality_optimize_v2=false)*/ array_length(a1), array_max(a2), array_min(a1), array_distinct(a1), array_sort(a2),
+       reverse(a1), array_slice(a2, 2, 4), cardinality(a2)
+from s3 where a1[1] = 'Jiangsu' or a2[2] = 'GD' order by v1 limit 2;
+
+select /*+SET_VAR(cbo_enable_low_cardinality_optimize=false, low_cardinality_optimize_v2=false)*/ count(a1[2]) from s3 where v3 = "GS"; 

--- a/test/sql/test_low_cardinality/T/test_low_cardinality_array
+++ b/test/sql/test_low_cardinality/T/test_low_cardinality_array
@@ -439,7 +439,10 @@ from s3 where a1[1] = 'Jiangsu' or a2[2] = 'GD' order by v1 limit 2;
 
 select count(a1[2]) from s3 where v3 = "GS"; 
 
+<<<<<<< HEAD
 
+=======
+>>>>>>> e511c083b0 ([BugFix] Fix array<string> use local dict-optimization)
 select /*+SET_VAR(cbo_enable_low_cardinality_optimize=false, low_cardinality_optimize_v2=false)*/ * from s3 order by v1 limit 2;
 
 select /*+SET_VAR(cbo_enable_low_cardinality_optimize=false, low_cardinality_optimize_v2=false)*/ * from s3 where a1[1] = 'Jiangsu' and v3 = "BJ" order by v1 limit 2;
@@ -454,3 +457,7 @@ select /*+SET_VAR(cbo_enable_low_cardinality_optimize=false, low_cardinality_opt
 from s3 where a1[1] = 'Jiangsu' or a2[2] = 'GD' order by v1 limit 2;
 
 select /*+SET_VAR(cbo_enable_low_cardinality_optimize=false, low_cardinality_optimize_v2=false)*/ count(a1[2]) from s3 where v3 = "GS"; 
+<<<<<<< HEAD
+=======
+
+>>>>>>> e511c083b0 ([BugFix] Fix array<string> use local dict-optimization)


### PR DESCRIPTION
Why I'm doing:

What I'm doing:

array<string> use local dict-optimization when global-dict optimization close

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5