### PR TITLE
[Enhancement] Aborting transaction supports carrying finished tablets info to help clean dirty data for shared-data mode (backport #39834)

### DIFF
--- a/be/src/runtime/stream_load/stream_load_executor.cpp
+++ b/be/src/runtime/stream_load/stream_load_executor.cpp
@@ -196,8 +196,9 @@ Status StreamLoadExecutor::commit_txn(StreamLoadContext* ctx) {
     request.txnId = ctx->txn_id;
     request.sync = true;
     request.commitInfos = std::move(ctx->commit_infos);
-    request.failInfos = std::move(ctx->fail_infos);
     request.__isset.commitInfos = true;
+    request.failInfos = std::move(ctx->fail_infos);
+    request.__isset.failInfos = true;
     request.__set_thrift_rpc_timeout_ms(config::txn_commit_rpc_timeout_ms);
 
     // set attachment if has
@@ -279,8 +280,9 @@ Status StreamLoadExecutor::prepare_txn(StreamLoadContext* ctx) {
     request.txnId = ctx->txn_id;
     request.sync = true;
     request.commitInfos = std::move(ctx->commit_infos);
-    request.failInfos = std::move(ctx->fail_infos);
     request.__isset.commitInfos = true;
+    request.failInfos = std::move(ctx->fail_infos);
+    request.__isset.failInfos = true;
     request.__set_thrift_rpc_timeout_ms(config::txn_commit_rpc_timeout_ms);
 
     // set attachment if has
@@ -321,7 +323,10 @@ Status StreamLoadExecutor::rollback_txn(StreamLoadContext* ctx) {
     request.db = ctx->db;
     request.tbl = ctx->table;
     request.txnId = ctx->txn_id;
+    request.commitInfos = std::move(ctx->commit_infos);
+    request.__isset.commitInfos = true;
     request.failInfos = std::move(ctx->fail_infos);
+    request.__isset.failInfos = true;
     request.__set_reason(ctx->status.get_error_msg());
 
     // set attachment if has

--- a/fe/fe-core/src/main/java/com/starrocks/lake/compaction/CompactionJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/lake/compaction/CompactionJob.java
@@ -44,6 +44,10 @@ public class CompactionJob {
         this.startTs = System.currentTimeMillis();
     }
 
+    Database getDb() {
+        return db;
+    }
+
     public long getTxnId() {
         return txnId;
     }

--- a/fe/fe-core/src/main/java/com/starrocks/lake/compaction/CompactionScheduler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/lake/compaction/CompactionScheduler.java
@@ -49,6 +49,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
@@ -154,7 +155,7 @@ public class CompactionScheduler extends Daemon {
                     job.finish();
                     failHistory.offer(CompactionRecord.build(job, errorMsg));
                     compactionManager.enableCompactionAfter(partition, MIN_COMPACTION_INTERVAL_MS_ON_FAILURE);
-                    abortTransactionIgnoreException(partition.getDbId(), job.getTxnId(), errorMsg);
+                    abortTransactionIgnoreException(job, errorMsg);
                     continue;
                 }
             }
@@ -198,11 +199,13 @@ public class CompactionScheduler extends Daemon {
         }
     }
 
-    private void abortTransactionIgnoreException(long dbId, long txnId, String reason) {
+    private void abortTransactionIgnoreException(CompactionJob job, String reason) {
         try {
-            transactionMgr.abortTransaction(dbId, txnId, reason);
+            List<TabletCommitInfo> finishedTablets = job.buildTabletCommitInfo();
+            transactionMgr.abortTransaction(job.getDb().getId(), job.getTxnId(), reason, finishedTablets,
+                    Collections.emptyList(), null);
         } catch (UserException ex) {
-            LOG.error("Fail to abort txn " + txnId, ex);
+            LOG.error("Fail to abort txn " + job.getTxnId(), ex);
         }
     }
 
@@ -308,7 +311,7 @@ public class CompactionScheduler extends Daemon {
             LOG.error(e);
             partition.setMinRetainVersion(0);
             nextCompactionInterval = MIN_COMPACTION_INTERVAL_MS_ON_FAILURE;
-            abortTransactionIgnoreError(db.getId(), txnId, e.getMessage());
+            abortTransactionIgnoreError(job, e.getMessage());
             job.finish();
             failHistory.offer(CompactionRecord.build(job, e.getMessage()));
             return null;
@@ -398,9 +401,11 @@ public class CompactionScheduler extends Daemon {
         job.setCommitTs(System.currentTimeMillis());
     }
 
-    private void abortTransactionIgnoreError(long dbId, long txnId, String reason) {
+    private void abortTransactionIgnoreError(CompactionJob job, String reason) {
         try {
-            transactionMgr.abortTransaction(dbId, txnId, reason);
+            List<TabletCommitInfo> finishedTablets = job.buildTabletCommitInfo();
+            transactionMgr.abortTransaction(job.getDb().getId(), job.getTxnId(), reason, finishedTablets,
+                    Collections.emptyList(), null);
         } catch (UserException ex) {
             LOG.error(ex);
         }

--- a/fe/fe-core/src/main/java/com/starrocks/lake/delete/LakeDeleteJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/lake/delete/LakeDeleteJob.java
@@ -49,9 +49,11 @@ import com.starrocks.sql.ast.DeleteStmt;
 import com.starrocks.system.ComputeNode;
 import com.starrocks.system.SystemInfoService;
 import com.starrocks.transaction.TabletCommitInfo;
+import com.starrocks.transaction.TabletFailInfo;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.Future;
@@ -183,6 +185,13 @@ public class LakeDeleteJob extends DeleteJob {
 
     @Override
     public boolean commitImpl(Database db, long timeoutMs) throws UserException {
+        return GlobalStateMgr.getCurrentState().getGlobalTransactionMgr()
+                .commitAndPublishTransaction(db, getTransactionId(), getTabletCommitInfos(), getTabletFailInfos(),
+                        timeoutMs);
+    }
+
+    @Override
+    protected List<TabletCommitInfo> getTabletCommitInfos() {
         List<TabletCommitInfo> tabletCommitInfos = Lists.newArrayList();
         for (Map.Entry<Long, List<Long>> entry : beToTablets.entrySet()) {
             long backendId = entry.getKey();
@@ -190,9 +199,11 @@ public class LakeDeleteJob extends DeleteJob {
                 tabletCommitInfos.add(new TabletCommitInfo(tabletId, backendId));
             }
         }
+        return tabletCommitInfos;
+    }
 
-        return GlobalStateMgr.getCurrentGlobalTransactionMgr()
-                .commitAndPublishTransaction(db, getTransactionId(), tabletCommitInfos, Lists.newArrayList(),
-                        timeoutMs);
+    @Override
+    protected List<TabletFailInfo> getTabletFailInfos() {
+        return Collections.emptyList();
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/leader/LeaderImpl.java
+++ b/fe/fe-core/src/main/java/com/starrocks/leader/LeaderImpl.java
@@ -1292,8 +1292,11 @@ public class LeaderImpl {
         }
 
         try {
-            GlobalStateMgr.getCurrentGlobalTransactionMgr().abortTransaction(
-                    request.getDb_id(), request.getTxn_id(), request.getError_msg());
+            GlobalStateMgr.getCurrentState().getGlobalTransactionMgr().abortTransaction(
+                    request.getDb_id(), request.getTxn_id(), request.getError_msg(),
+                    TabletCommitInfo.fromThrift(request.getCommit_infos()),
+                    TabletFailInfo.fromThrift(request.getFail_infos()),
+                    TxnCommitAttachment.fromThrift(request.getCommit_attachment()));
         } catch (Exception e) {
             LOG.warn("abort remote txn failed, txn_id: {}", request.getTxn_id(), e);
             TStatus status = new TStatus(TStatusCode.INTERNAL_ERROR);

--- a/fe/fe-core/src/main/java/com/starrocks/load/DeleteJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/DeleteJob.java
@@ -45,6 +45,8 @@ import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.sql.ast.DeleteStmt;
 import com.starrocks.transaction.AbstractTxnStateChangeCallback;
 import com.starrocks.transaction.GlobalTransactionMgr;
+import com.starrocks.transaction.TabletCommitInfo;
+import com.starrocks.transaction.TabletFailInfo;
 import com.starrocks.transaction.TransactionAlreadyCommitException;
 import com.starrocks.transaction.TransactionState;
 import com.starrocks.transaction.TransactionStatus;
@@ -133,7 +135,8 @@ public abstract class DeleteJob extends AbstractTxnStateChangeCallback {
 
         GlobalTransactionMgr globalTransactionMgr = GlobalStateMgr.getCurrentGlobalTransactionMgr();
         try {
-            globalTransactionMgr.abortTransaction(getDeleteInfo().getDbId(), getTransactionId(), reason);
+            globalTransactionMgr.abortTransaction(getDeleteInfo().getDbId(), getTransactionId(), reason,
+                    getTabletCommitInfos(), getTabletFailInfos(), null);
         } catch (TransactionAlreadyCommitException e) {
             return false;
         } catch (Exception e) {
@@ -149,6 +152,10 @@ public abstract class DeleteJob extends AbstractTxnStateChangeCallback {
      * A UserException thrown if both commit and publish failed.
      */
     public abstract boolean commitImpl(Database db, long timeoutMs) throws UserException;
+
+    protected abstract List<TabletCommitInfo> getTabletCommitInfos();
+
+    protected abstract List<TabletFailInfo> getTabletFailInfos();
 
     public void commit(Database db, long timeoutMs) throws DdlException, QueryStateException {
         TransactionStatus status = TransactionStatus.UNKNOWN;

--- a/fe/fe-core/src/main/java/com/starrocks/load/OlapDeleteJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/OlapDeleteJob.java
@@ -69,10 +69,12 @@ import com.starrocks.thrift.TTaskType;
 import com.starrocks.transaction.GlobalTransactionMgr;
 import com.starrocks.transaction.InsertTxnCommitAttachment;
 import com.starrocks.transaction.TabletCommitInfo;
+import com.starrocks.transaction.TabletFailInfo;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
 import java.util.Collection;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -102,7 +104,7 @@ public class OlapDeleteJob extends DeleteJob {
     }
 
     @Override
-    @java.lang.SuppressWarnings("squid:S2142")  // allow catch InterruptedException
+    @java.lang.SuppressWarnings("squid:S2142") // allow catch InterruptedException
     public void run(DeleteStmt stmt, Database db, Table table, List<Partition> partitions)
             throws DdlException, QueryStateException {
         Preconditions.checkState(table.isOlapTable());
@@ -373,6 +375,13 @@ public class OlapDeleteJob extends DeleteJob {
     public boolean commitImpl(Database db, long timeoutMs) throws UserException {
         long transactionId = getTransactionId();
         GlobalTransactionMgr globalTransactionMgr = GlobalStateMgr.getCurrentGlobalTransactionMgr();
+        return globalTransactionMgr.commitAndPublishTransaction(db, transactionId, getTabletCommitInfos(),
+                getTabletFailInfos(), timeoutMs,
+                new InsertTxnCommitAttachment());
+    }
+
+    @Override
+    protected List<TabletCommitInfo> getTabletCommitInfos() {
         List<TabletCommitInfo> tabletCommitInfos = Lists.newArrayList();
         TabletInvertedIndex invertedIndex = GlobalStateMgr.getCurrentInvertedIndex();
         for (TabletDeleteInfo tDeleteInfo : getTabletDeleteInfo()) {
@@ -386,8 +395,11 @@ public class OlapDeleteJob extends DeleteJob {
                 tabletCommitInfos.add(new TabletCommitInfo(tabletId, replica.getBackendId()));
             }
         }
-        return globalTransactionMgr.commitAndPublishTransaction(db, transactionId, tabletCommitInfos,
-                Lists.newArrayList(), timeoutMs,
-                new InsertTxnCommitAttachment());
+        return tabletCommitInfos;
+    }
+
+    @Override
+    protected List<TabletFailInfo> getTabletFailInfos() {
+        return Collections.emptyList();
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/load/loadv2/BulkLoadJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/loadv2/BulkLoadJob.java
@@ -236,6 +236,16 @@ public abstract class BulkLoadJob extends LoadJob {
     }
 
     @Override
+    protected List<TabletCommitInfo> getTabletCommitInfos() {
+        return commitInfos;
+    }
+
+    @Override
+    protected List<TabletFailInfo> getTabletFailInfos() {
+        return failInfos;
+    }
+
+    @Override
     public void onTaskFailed(long taskId, FailMsg failMsg) {
         writeLock();
         try {

--- a/fe/fe-core/src/main/java/com/starrocks/load/loadv2/InsertLoadJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/loadv2/InsertLoadJob.java
@@ -47,6 +47,7 @@ import com.starrocks.catalog.Table;
 import com.starrocks.catalog.system.SystemTable;
 import com.starrocks.common.Config;
 import com.starrocks.common.MetaNotFoundException;
+import com.starrocks.common.NotImplementedException;
 import com.starrocks.common.UserException;
 import com.starrocks.load.EtlJobType;
 import com.starrocks.load.FailMsg;
@@ -55,12 +56,15 @@ import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.server.WarehouseManager;
 import com.starrocks.thrift.TLoadJobType;
 import com.starrocks.thrift.TReportExecStatusParams;
+import com.starrocks.transaction.TabletCommitInfo;
+import com.starrocks.transaction.TabletFailInfo;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
 import java.io.DataInput;
 import java.io.DataOutput;
 import java.io.IOException;
+import java.util.List;
 import java.util.Set;
 
 /**
@@ -247,6 +251,16 @@ public class InsertLoadJob extends LoadJob {
         } else {
             return true;
         }
+    }
+
+    @Override
+    protected List<TabletCommitInfo> getTabletCommitInfos() {
+        throw new RuntimeException(new NotImplementedException("Not implemented"));
+    }
+
+    @Override
+    protected List<TabletFailInfo> getTabletFailInfos() {
+        throw new RuntimeException(new NotImplementedException("Not implemented"));
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/load/loadv2/LoadJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/loadv2/LoadJob.java
@@ -83,6 +83,8 @@ import com.starrocks.thrift.TUniqueId;
 import com.starrocks.transaction.AbstractTxnStateChangeCallback;
 import com.starrocks.transaction.BeginTransactionException;
 import com.starrocks.transaction.TableCommitInfo;
+import com.starrocks.transaction.TabletCommitInfo;
+import com.starrocks.transaction.TabletFailInfo;
 import com.starrocks.transaction.TransactionException;
 import com.starrocks.transaction.TransactionState;
 import org.apache.logging.log4j.LogManager;
@@ -346,6 +348,10 @@ public abstract class LoadJob extends AbstractTxnStateChangeCallback implements 
      * @return
      */
     public abstract Set<String> getTableNames(boolean noThrow) throws MetaNotFoundException;
+
+    protected abstract List<TabletCommitInfo> getTabletCommitInfos();
+
+    protected abstract List<TabletFailInfo> getTabletFailInfos();
 
     // return true if the corresponding transaction is done(COMMITTED, FINISHED, CANCELLED)
     public boolean isTxnDone() {
@@ -660,7 +666,9 @@ public abstract class LoadJob extends AbstractTxnStateChangeCallback implements 
                         .add("transaction_id", transactionId)
                         .add("msg", "begin to abort txn")
                         .build());
-                GlobalStateMgr.getCurrentGlobalTransactionMgr().abortTransaction(dbId, transactionId, failMsg.getMsg());
+                GlobalStateMgr.getCurrentState().getGlobalTransactionMgr()
+                        .abortTransaction(dbId, transactionId, failMsg.getMsg(),
+                                getTabletCommitInfos(), getTabletFailInfos(), null);
             } catch (UserException e) {
                 LOG.warn(new LogBuilder(LogKey.LOAD_JOB, id)
                         .add("transaction_id", transactionId)

--- a/fe/fe-core/src/main/java/com/starrocks/load/streamload/StreamLoadTask.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/streamload/StreamLoadTask.java
@@ -876,8 +876,8 @@ public class StreamLoadTask extends AbstractTxnStateChangeCallback
         }
         try {
             if (txnId != -1L) {
-                GlobalStateMgr.getCurrentGlobalTransactionMgr().abortTransaction(
-                        dbId, txnId, reason);
+                GlobalStateMgr.getCurrentState().getGlobalTransactionMgr().abortTransaction(
+                        dbId, txnId, reason, Coordinator.getCommitInfos(coord), Coordinator.getFailInfos(coord), null);
             } else {
                 writeLock();
                 for (int i = 0; i < channelNum; i++) {

--- a/fe/fe-core/src/main/java/com/starrocks/qe/Coordinator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/Coordinator.java
@@ -107,6 +107,8 @@ import com.starrocks.thrift.TTabletFailInfo;
 import com.starrocks.thrift.TUniqueId;
 import com.starrocks.thrift.TUnit;
 import com.starrocks.thrift.TWorkGroup;
+import com.starrocks.transaction.TabletCommitInfo;
+import com.starrocks.transaction.TabletFailInfo;
 import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.LogManager;
@@ -539,8 +541,16 @@ public class Coordinator {
         return commitInfos;
     }
 
+    public static List<TabletCommitInfo> getCommitInfos(Coordinator coord) {
+        return coord == null ? Collections.emptyList() : TabletCommitInfo.fromThrift(coord.getCommitInfos());
+    }
+
     public List<TTabletFailInfo> getFailInfos() {
         return failInfos;
+    }
+
+    public static List<TabletFailInfo> getFailInfos(Coordinator coord) {
+        return coord == null ? Collections.emptyList() : TabletFailInfo.fromThrift(coord.getFailInfos());
     }
 
     public List<TSinkCommitInfo> getSinkCommitInfos() {

--- a/fe/fe-core/src/main/java/com/starrocks/qe/StmtExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/StmtExecutor.java
@@ -1795,7 +1795,10 @@ public class StmtExecutor {
                                 externalTable.getSourceTableDbId(), transactionId,
                                 externalTable.getSourceTableHost(),
                                 externalTable.getSourceTablePort(),
-                                TransactionCommitFailedException.FILTER_DATA_IN_STRICT_MODE + ", tracking sql = " + trackingSql
+                                TransactionCommitFailedException.FILTER_DATA_IN_STRICT_MODE + ", tracking sql = " +
+                                        trackingSql,
+                                coord == null ? Collections.emptyList() : coord.getCommitInfos(),
+                                coord == null ? Collections.emptyList() : coord.getFailInfos()
                         );
                     } else if (targetTable instanceof SystemTable || targetTable instanceof IcebergTable) {
                         // schema table does not need txn
@@ -1803,9 +1806,9 @@ public class StmtExecutor {
                         GlobalStateMgr.getCurrentGlobalTransactionMgr().abortTransaction(
                                 database.getId(),
                                 transactionId,
-                                TransactionCommitFailedException.FILTER_DATA_IN_STRICT_MODE + ", tracking sql = " + trackingSql,
-                                TabletFailInfo.fromThrift(coord.getFailInfos())
-                        );
+                                TransactionCommitFailedException.FILTER_DATA_IN_STRICT_MODE + ", tracking sql = " +
+                                        trackingSql,
+                                Coordinator.getCommitInfos(coord), Coordinator.getFailInfos(coord), null);
                     }
                     context.getState().setError("Insert has filtered data in strict mode, txn_id = " + transactionId +
                             " tracking sql = " + trackingSql);
@@ -1824,7 +1827,8 @@ public class StmtExecutor {
                     if (!(targetTable instanceof SystemTable || targetTable instanceof IcebergTable)) {
                         // schema table and iceberg table does not need txn
                         GlobalStateMgr.getCurrentGlobalTransactionMgr().abortTransaction(
-                                database.getId(), transactionId, errorMsg);
+                                database.getId(), transactionId, errorMsg,
+                                Coordinator.getCommitInfos(coord), Coordinator.getFailInfos(coord), null);
                     }
                     context.getState().setOk();
                     insertError = true;
@@ -1905,12 +1909,14 @@ public class StmtExecutor {
                             externalTable.getSourceTableDbId(), transactionId,
                             externalTable.getSourceTableHost(),
                             externalTable.getSourceTablePort(),
-                            errMsg);
+                            errMsg,
+                            coord == null ? Collections.emptyList() : coord.getCommitInfos(),
+                            coord == null ? Collections.emptyList() : coord.getFailInfos());
                 } else {
                     GlobalStateMgr.getCurrentGlobalTransactionMgr().abortTransaction(
                             database.getId(), transactionId,
                             errMsg,
-                            coord == null ? Lists.newArrayList() : TabletFailInfo.fromThrift(coord.getFailInfos()));
+                            Coordinator.getCommitInfos(coord), Coordinator.getFailInfos(coord), null);
                 }
             } catch (Exception abortTxnException) {
                 // just print a log if abort txn failed. This failure do not need to pass to user.

--- a/fe/fe-core/src/main/java/com/starrocks/replication/ReplicationJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/replication/ReplicationJob.java
@@ -32,6 +32,7 @@ import com.starrocks.common.Config;
 import com.starrocks.common.DuplicatedRequestException;
 import com.starrocks.common.LabelAlreadyUsedException;
 import com.starrocks.common.MetaNotFoundException;
+import com.starrocks.common.Pair;
 import com.starrocks.common.UserException;
 import com.starrocks.common.util.UUIDUtil;
 import com.starrocks.persist.gson.GsonPostProcessable;
@@ -648,6 +649,33 @@ public class ReplicationJob implements GsonPostProcessable {
     }
 
     private void commitTransaction() throws UserException {
+        Pair<List<TabletCommitInfo>, List<TabletFailInfo>> tabletsCommitInfo = getTabletsCommitInfo();
+
+        Map<Long, Long> partitionVersions = Maps.newHashMap();
+        for (PartitionInfo partitionInfo : partitionInfos.values()) {
+            partitionVersions.put(partitionInfo.getPartitionId(), partitionInfo.getSrcVersion());
+        }
+        ReplicationTxnCommitAttachment attachment = new ReplicationTxnCommitAttachment(partitionVersions);
+
+        GlobalStateMgr.getServingState().getGlobalTransactionMgr().commitTransaction(databaseId,
+                transactionId, tabletsCommitInfo.first, tabletsCommitInfo.second, attachment);
+    }
+
+    private void abortTransaction(String reason) {
+        Pair<List<TabletCommitInfo>, List<TabletFailInfo>> tabletsCommitInfo = getTabletsCommitInfo();
+
+        try {
+            GlobalStateMgr.getServingState().getGlobalTransactionMgr().abortTransaction(databaseId, transactionId,
+                    reason, tabletsCommitInfo.first, tabletsCommitInfo.second, null);
+        } catch (Exception e) {
+            LOG.warn("Abort transaction failed, ignore, database id: {}, table id: {}, transaction id: {}, ",
+                    databaseId, tableId, transactionId, e);
+        }
+
+        removeRunningTasks();
+    }
+
+    private Pair<List<TabletCommitInfo>, List<TabletFailInfo>> getTabletsCommitInfo() {
         List<TabletCommitInfo> tabletCommitInfos = Lists.newArrayList();
         List<TabletFailInfo> tabletFailInfos = Lists.newArrayList();
         for (AgentTask task : finishedTasks.values()) {
@@ -657,27 +685,7 @@ public class ReplicationJob implements GsonPostProcessable {
                 tabletCommitInfos.add(new TabletCommitInfo(task.getTabletId(), task.getBackendId()));
             }
         }
-
-        Map<Long, Long> partitionVersions = Maps.newHashMap();
-        for (PartitionInfo partitionInfo : partitionInfos.values()) {
-            partitionVersions.put(partitionInfo.getPartitionId(), partitionInfo.getSrcVersion());
-        }
-        ReplicationTxnCommitAttachment attachment = new ReplicationTxnCommitAttachment(partitionVersions);
-
-        GlobalStateMgr.getServingState().getGlobalTransactionMgr().commitTransaction(databaseId,
-                transactionId, tabletCommitInfos, tabletFailInfos, attachment);
-    }
-
-    private void abortTransaction(String reason) {
-        try {
-            GlobalStateMgr.getServingState().getGlobalTransactionMgr().abortTransaction(databaseId, transactionId,
-                    reason);
-        } catch (Exception e) {
-            LOG.warn("Abort transaction failed, ignore, database id: {}, table id: {}, transaction id: {}, ",
-                    databaseId, tableId, transactionId, e);
-        }
-
-        removeRunningTasks();
+        return Pair.create(tabletCommitInfos, tabletFailInfos);
     }
 
     private boolean isTransactionAborted() {

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/TxnBasedEpochCoordinator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/TxnBasedEpochCoordinator.java
@@ -160,7 +160,8 @@ class TxnBasedEpochCoordinator implements EpochCoordinator {
         long txnId = epoch.getTxnId();
         String failReason = "";
         try {
-            GlobalStateMgr.getCurrentGlobalTransactionMgr().abortTransaction(dbId, txnId, failReason);
+            GlobalStateMgr.getCurrentState().getGlobalTransactionMgr().abortTransaction(dbId, txnId, failReason,
+                    epoch.getCommitInfos(), epoch.getFailedInfos(), null);
             epoch.onFailed();
         } catch (UserException e) {
             LOG.warn("Abort transaction failed: {}", txnId);

--- a/fe/fe-core/src/main/java/com/starrocks/service/FrontendServiceImpl.java
+++ b/fe/fe-core/src/main/java/com/starrocks/service/FrontendServiceImpl.java
@@ -1505,6 +1505,8 @@ public class FrontendServiceImpl implements FrontendService.Iface {
         long dbId = db.getId();
         GlobalStateMgr.getCurrentGlobalTransactionMgr().abortTransaction(dbId, request.getTxnId(),
                 request.isSetReason() ? request.getReason() : "system cancel",
+                TabletCommitInfo.fromThrift(request.getCommitInfos()),
+                TabletFailInfo.fromThrift(request.getFailInfos()),
                 TxnCommitAttachment.fromThrift(request.getTxnCommitAttachment()));
 
         TxnCommitAttachment attachment = TxnCommitAttachment.fromThrift(request.txnCommitAttachment);

--- a/fe/fe-core/src/main/java/com/starrocks/transaction/DatabaseTransactionMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/transaction/DatabaseTransactionMgr.java
@@ -81,6 +81,7 @@ import java.io.IOException;
 import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.Comparator;
 import java.util.Iterator;
 import java.util.List;
@@ -1192,17 +1193,22 @@ public class DatabaseTransactionMgr {
 
     public void abortTransaction(long transactionId, String reason, TxnCommitAttachment txnCommitAttachment)
             throws UserException {
-        abortTransaction(transactionId, true, reason, txnCommitAttachment, Lists.newArrayList());
+        abortTransaction(transactionId, true, reason, txnCommitAttachment,
+                Collections.emptyList(), Collections.emptyList());
     }
 
     public void abortTransaction(long transactionId, String reason,
-                                 TxnCommitAttachment txnCommitAttachment, List<TabletFailInfo> failedTablets)
+                                 TxnCommitAttachment txnCommitAttachment,
+                                 List<TabletCommitInfo> finishedTablets,
+                                 List<TabletFailInfo> failedTablets)
             throws UserException {
-        abortTransaction(transactionId, true, reason, txnCommitAttachment, failedTablets);
+        abortTransaction(transactionId, true, reason, txnCommitAttachment, finishedTablets, failedTablets);
     }
 
     public void abortTransaction(long transactionId, boolean abortPrepared, String reason,
-                                 TxnCommitAttachment txnCommitAttachment, List<TabletFailInfo> failedTablets)
+                                 TxnCommitAttachment txnCommitAttachment,
+                                 List<TabletCommitInfo> finishedTablets,
+                                 List<TabletFailInfo> failedTablets)
             throws UserException {
         if (transactionId < 0) {
             LOG.info("transaction id is {}, less than 0, maybe this is an old type load job, ignore abort operation",
@@ -1253,7 +1259,7 @@ public class DatabaseTransactionMgr {
             }
             TransactionStateListener listener = stateListenerFactory.create(this, table);
             if (listener != null) {
-                listener.postAbort(transactionState, failedTablets);
+                listener.postAbort(transactionState, finishedTablets, failedTablets);
             }
         }
     }

--- a/fe/fe-core/src/main/java/com/starrocks/transaction/GlobalTransactionMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/transaction/GlobalTransactionMgr.java
@@ -62,6 +62,7 @@ import com.starrocks.thrift.TCommitRemoteTxnResponse;
 import com.starrocks.thrift.TNetworkAddress;
 import com.starrocks.thrift.TStatusCode;
 import com.starrocks.thrift.TTabletCommitInfo;
+import com.starrocks.thrift.TTabletFailInfo;
 import com.starrocks.thrift.TTransactionStatus;
 import com.starrocks.thrift.TUniqueId;
 import com.starrocks.transaction.TransactionState.LoadJobSourceType;
@@ -76,6 +77,7 @@ import java.io.DataOutput;
 import java.io.DataOutputStream;
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
@@ -240,7 +242,9 @@ public class GlobalTransactionMgr implements Writable {
 
     // abort transaction in remote StarRocks cluster
     public void abortRemoteTransaction(long dbId, long transactionId,
-                                       String host, int port, String errorMsg)
+                                       String host, int port, String errorMsg,
+                                       List<TTabletCommitInfo> tabletCommitInfos,
+                                       List<TTabletFailInfo> tabletFailInfos)
             throws AbortTransactionException {
 
         TNetworkAddress addr = new TNetworkAddress(host, port);
@@ -248,6 +252,8 @@ public class GlobalTransactionMgr implements Writable {
         request.setDb_id(dbId);
         request.setTxn_id(transactionId);
         request.setError_msg(errorMsg);
+        request.setCommit_infos(tabletCommitInfos);
+        request.setFail_infos(tabletFailInfos);
         TAbortRemoteTxnResponse response;
         try {
             response = FrontendServiceProxy.call(addr,
@@ -506,24 +512,28 @@ public class GlobalTransactionMgr implements Writable {
     }
 
     public void abortTransaction(long dbId, long transactionId, String reason) throws UserException {
-        abortTransaction(dbId, transactionId, reason, Lists.newArrayList());
+        abortTransaction(dbId, transactionId, reason, Collections.emptyList());
     }
 
     public void abortTransaction(long dbId, long transactionId, String reason, List<TabletFailInfo> failedTablets)
             throws UserException {
-        abortTransaction(dbId, transactionId, reason, failedTablets, null);
+        abortTransaction(dbId, transactionId, reason, Collections.emptyList(), failedTablets, null);
     }
 
     public void abortTransaction(Long dbId, Long transactionId, String reason, TxnCommitAttachment txnCommitAttachment)
             throws UserException {
-        abortTransaction(dbId, transactionId, reason, Lists.newArrayList(), txnCommitAttachment);
+        abortTransaction(dbId, transactionId, reason, Collections.emptyList(), Collections.emptyList(),
+                txnCommitAttachment);
     }
 
-    public void abortTransaction(long dbId, long transactionId, String reason, List<TabletFailInfo> failedTablets,
+    public void abortTransaction(long dbId, long transactionId, String reason,
+                                 List<TabletCommitInfo> finishedTablets,
+                                 List<TabletFailInfo> failedTablets,
                                  TxnCommitAttachment txnCommitAttachment)
             throws UserException {
         DatabaseTransactionMgr dbTransactionMgr = getDatabaseTransactionMgr(dbId);
-        dbTransactionMgr.abortTransaction(transactionId, reason, txnCommitAttachment, failedTablets);
+        dbTransactionMgr.abortTransaction(transactionId, true, reason, txnCommitAttachment,
+                finishedTablets, failedTablets);
     }
 
     // for http cancel stream load api
@@ -885,7 +895,7 @@ public class GlobalTransactionMgr implements Writable {
             try {
                 DatabaseTransactionMgr dbTransactionMgr = getDatabaseTransactionMgr(txnInfo.first);
                 dbTransactionMgr.abortTransaction(txnInfo.second, false, "coordinate BE is down", null,
-                        Lists.newArrayList());
+                        Collections.emptyList(), Collections.emptyList());
             } catch (UserException e) {
                 LOG.warn("Abort txn on coordinate BE {} failed, msg={}", coordinateHost, e.getMessage());
             }

--- a/fe/fe-core/src/main/java/com/starrocks/transaction/LakeTableTxnStateListener.java
+++ b/fe/fe-core/src/main/java/com/starrocks/transaction/LakeTableTxnStateListener.java
@@ -201,7 +201,12 @@ public class LakeTableTxnStateListener implements TransactionStateListener {
     }
 
     @Override
-    public void postAbort(TransactionState txnState, List<TabletFailInfo> failedTablets) {
+    public void postAbort(TransactionState txnState, List<TabletCommitInfo> finishedTablets,
+            List<TabletFailInfo> failedTablets) {
+        // If a transaction is prepared then aborted, the commit infos in txn state may be already assigned
+        if (!finishedTablets.isEmpty()) {
+            txnState.setTabletCommitInfos(finishedTablets);
+        }
         if (CollectionUtils.isEmpty(txnState.getTabletCommitInfos())) {
             abortTxnSkipCleanup(txnState);
         } else {
@@ -212,10 +217,7 @@ public class LakeTableTxnStateListener implements TransactionStateListener {
 
     private void abortTxnSkipCleanup(TransactionState txnState) {
         List<Long> txnIds = Collections.singletonList(txnState.getTransactionId());
-        List<TxnTypePB> txnTypes = Collections.singletonList(
-                txnState.getSourceType() == TransactionState.LoadJobSourceType.REPLICATION
-                        ? TxnTypePB.TXN_REPLICATION
-                        : TxnTypePB.TXN_NORMAL);
+        List<TxnTypePB> txnTypes = Collections.singletonList(txnState.getTxnTypePB());
         List<ComputeNode> nodes = getAllAliveNodes();
         for (ComputeNode node : nodes) { // Send abortTxn() request to all nodes
             AbortTxnRequest request = new AbortTxnRequest();
@@ -230,13 +232,14 @@ public class LakeTableTxnStateListener implements TransactionStateListener {
 
     private void abortTxnWithCleanup(TransactionState txnState) {
         List<Long> txnIds = Collections.singletonList(txnState.getTransactionId());
-        List<TxnTypePB> txnTypes = Collections.singletonList(
-                txnState.getSourceType() == TransactionState.LoadJobSourceType.REPLICATION
-                        ? TxnTypePB.TXN_REPLICATION
-                        : TxnTypePB.TXN_NORMAL);
+        List<TxnTypePB> txnTypes = Collections.singletonList(txnState.getTxnTypePB());
         Map<Long, List<Long>> tabletGroup = new HashMap<>();
         for (TabletCommitInfo info : txnState.getTabletCommitInfos()) {
             tabletGroup.computeIfAbsent(info.getBackendId(), k -> Lists.newArrayList()).add(info.getTabletId());
+        }
+        Map<Long, ComputeNode> allNodes = new HashMap<>();
+        for (ComputeNode node : getAllAliveNodes()) {
+            allNodes.put(node.getId(), node);
         }
         for (Map.Entry<Long, List<Long>> entry : tabletGroup.entrySet()) {
             ComputeNode node = getAliveNode(entry.getKey());
@@ -248,6 +251,17 @@ public class LakeTableTxnStateListener implements TransactionStateListener {
             request.txnTypes = txnTypes;
             request.tabletIds = entry.getValue();
             request.skipCleanup = false;
+
+            sendAbortTxnRequestIgnoreResponse(request, node);
+            allNodes.remove(node.getId());
+        }
+        // Send abortTxn() request to rest nodes
+        for (ComputeNode node : allNodes.values()) {
+            AbortTxnRequest request = new AbortTxnRequest();
+            request.txnIds = txnIds;
+            request.txnTypes = txnTypes;
+            request.skipCleanup = true;
+            request.tabletIds = null; // unused when skipCleanup is true
 
             sendAbortTxnRequestIgnoreResponse(request, node);
         }

--- a/fe/fe-core/src/main/java/com/starrocks/transaction/OlapTableTxnStateListener.java
+++ b/fe/fe-core/src/main/java/com/starrocks/transaction/OlapTableTxnStateListener.java
@@ -300,7 +300,8 @@ public class OlapTableTxnStateListener implements TransactionStateListener {
     }
 
     @Override
-    public void postAbort(TransactionState txnState, List<TabletFailInfo> failedTablets) {
+    public void postAbort(TransactionState txnState, List<TabletCommitInfo> finishedTablets,
+            List<TabletFailInfo> failedTablets) {
         txnState.clearAutomaticPartitionSnapshot();
         Database db = GlobalStateMgr.getCurrentState().getDb(txnState.getDbId());
         if (db != null) {

--- a/fe/fe-core/src/main/java/com/starrocks/transaction/TabletCommitInfo.java
+++ b/fe/fe-core/src/main/java/com/starrocks/transaction/TabletCommitInfo.java
@@ -93,6 +93,9 @@ public class TabletCommitInfo implements Writable {
     @NotNull
     public static List<TabletCommitInfo> fromThrift(List<TTabletCommitInfo> tTabletCommitInfos) {
         List<TabletCommitInfo> commitInfos = Lists.newArrayList();
+        if (tTabletCommitInfos == null) {
+            return commitInfos;
+        }
         for (TTabletCommitInfo tTabletCommitInfo : tTabletCommitInfos) {
             if (tTabletCommitInfo.isSetInvalid_dict_cache_columns()) {
                 commitInfos.add(new TabletCommitInfo(tTabletCommitInfo.getTabletId(),

--- a/fe/fe-core/src/main/java/com/starrocks/transaction/TransactionState.java
+++ b/fe/fe-core/src/main/java/com/starrocks/transaction/TransactionState.java
@@ -53,6 +53,7 @@ import com.starrocks.common.io.Text;
 import com.starrocks.common.io.Writable;
 import com.starrocks.metric.MetricRepo;
 import com.starrocks.persist.gson.GsonUtils;
+import com.starrocks.proto.TxnTypePB;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.service.FrontendOptions;
 import com.starrocks.system.Backend;
@@ -766,6 +767,10 @@ public class TransactionState implements Writable {
 
     public TTxnType getTxnType() {
         return sourceType == LoadJobSourceType.REPLICATION ? TTxnType.TXN_REPLICATION : TTxnType.TXN_NORMAL;
+    }
+
+    public TxnTypePB getTxnTypePB() {
+        return sourceType == LoadJobSourceType.REPLICATION ? TxnTypePB.TXN_REPLICATION : TxnTypePB.TXN_NORMAL;
     }
 
     public Map<Long, PublishVersionTask> getPublishVersionTasks() {

--- a/fe/fe-core/src/main/java/com/starrocks/transaction/TransactionStateListener.java
+++ b/fe/fe-core/src/main/java/com/starrocks/transaction/TransactionStateListener.java
@@ -36,5 +36,6 @@ public interface TransactionStateListener {
     // This method is called by the FE master after changed the TransactionState to ABORTED and *AFTER* released the writer
     // lock of the DatabaseTransactionMgr.
     // It's *unsafe* to access mutable fields of txnState inside this function.
-    void postAbort(TransactionState txnState, List<TabletFailInfo> failedTablets);
+    void postAbort(TransactionState txnState, List<TabletCommitInfo> finishedTablets,
+            List<TabletFailInfo> failedTablets);
 }

--- a/gensrc/thrift/FrontendService.thrift
+++ b/gensrc/thrift/FrontendService.thrift
@@ -839,6 +839,7 @@ struct TLoadTxnRollbackRequest {
     9: optional i64 auth_code
     10: optional TTxnCommitAttachment txnCommitAttachment
     11: optional list<Types.TTabletFailInfo> failInfos
+    12: optional list<Types.TTabletCommitInfo> commitInfos
 }
 
 struct TGetLoadTxnStatusResult {
@@ -1149,6 +1150,9 @@ struct TAbortRemoteTxnRequest {
     2: optional i64 db_id
     3: optional string error_msg
     4: optional TAuthenticateParams auth_info
+    5: optional list<Types.TTabletCommitInfo> commit_infos
+    6: optional TTxnCommitAttachment commit_attachment
+    7: optional list<Types.TTabletFailInfo> fail_infos
 }
 
 struct TAbortRemoteTxnResponse {


### PR DESCRIPTION
## Why I'm doing:
When transaction is aborted, the data in finished tablets is not cleaned in shared-data mode.

## What I'm doing:
Use finished tablets info to clean the dirty data in finished tablets when transaction is aborted.

Backport of pr: https://github.com/StarRocks/starrocks/pull/39834

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [x] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5

