### PR TITLE
[BugFix] Fix empty table output fragment data partition error (backport #25832)

### DIFF
--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/JoinTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/JoinTest.java
@@ -2785,4 +2785,27 @@ public class JoinTest extends PlanTestBase {
                 "  |  colocate: false, reason: \n" +
                 "  |  equal join conjunct: 7: concat = 8: concat");
     }
+
+    @Test
+    public void testTopFragmentOnComputeNode() throws Exception {
+        String sql = "select t0.v1 from t0 join[shuffle] t1 on t0.v2 = t1.v5";
+        String plan = getFragmentPlan(sql);
+        assertContains(plan, "PLAN FRAGMENT 0\n" +
+                " OUTPUT EXPRS:1: v1\n" +
+                "  PARTITION: HASH_PARTITIONED: 2: v2\n" +
+                "\n" +
+                "  RESULT SINK");
+        
+        try {
+            connectContext.getSessionVariable().setPreferComputeNode(true);
+            plan = getFragmentPlan(sql);
+            assertContains(plan, "PLAN FRAGMENT 0\n" +
+                    " OUTPUT EXPRS:1: v1\n" +
+                    "  PARTITION: UNPARTITIONED\n" +
+                    "\n" +
+                    "  RESULT SINK");
+        } finally {
+            connectContext.getSessionVariable().setPreferComputeNode(false);
+        }
+    }
 }


### PR DESCRIPTION

Fixes #issue

on empty table, the output fragment isn't `GATHER`, and Coordinator can't work well on compute-node mode, the parallelism of the output fragment is error

Should set the output fragment to `GATHER`

now:
```
MySQL td> explain  select * from t2 x1 join t2 x2 on x1.v2 = x2.v2;
+-----------------------------------------------------------------------------+
| Explain String                                                              |
+-----------------------------------------------------------------------------+
| PLAN FRAGMENT 0                                                             |
|  OUTPUT EXPRS:1: v1 | 2: v2 | 3: v3 | 4: v4 | 5: v1 | 6: v2 | 7: v3 | 8: v4 |
|   PARTITION: HASH_PARTITIONED: 2: v2                                        |
|                                                                             |
|   RESULT SINK                                                               |
|                                                                             |
|   4:HASH JOIN                                                               |
|   |  join op: INNER JOIN (PARTITIONED)                                      |
|   |  colocate: false, reason:                                               |
|   |  equal join conjunct: 2: v2 = 6: v2                                     |
|   |                                                                         |
|   |----3:EXCHANGE                                                           |
|   |                                                                         |
|   1:EXCHANGE                                                                |
|                                                                             |
| PLAN FRAGMENT 1                                                             |
|  OUTPUT EXPRS:                                                              |
|   PARTITION: RANDOM                                                         |
|                                                                             |
|   STREAM DATA SINK                                                          |
|     EXCHANGE ID: 03                                                         |
|     HASH_PARTITIONED: 6: v2                                                 |
|                                                                             |
|   2:OlapScanNode                                                            |
|      TABLE: t2                                                              |
|                                                                             |
| PLAN FRAGMENT 2                                                             |
|  OUTPUT EXPRS:                                                              |
|   PARTITION: RANDOM                                                         |
|                                                                             |
|   STREAM DATA SINK                                                          |
|     EXCHANGE ID: 01                                                         |
|     HASH_PARTITIONED: 2: v2                                                 |
|                                                                             |
|   0:OlapScanNode                                                            |
|      TABLE: t2                                                              |
+-----------------------------------------------------------------------------+
```

---------

Why I'm doing:

What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [x] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5

