### PR TITLE
[BugFix] BE maybe crash when we restore from a old version snapshot

### DIFF
--- a/be/src/storage/rowset/rowset_meta.h
+++ b/be/src/storage/rowset/rowset_meta.h
@@ -234,10 +234,11 @@ public:
     // If not, perhaps `get_meta_pb_without_schema()` is enough.
     void get_full_meta_pb(RowsetMetaPB* rs_meta_pb) const {
         *rs_meta_pb = *_rowset_meta_pb;
-        rs_meta_pb->clear_tablet_schema();
-        TabletSchemaPB* ts_pb = rs_meta_pb->mutable_tablet_schema();
-        DCHECK(_schema != nullptr);
-        _schema->to_schema_pb(ts_pb);
+        if (_schema != nullptr) {
+            rs_meta_pb->clear_tablet_schema();
+            TabletSchemaPB* ts_pb = rs_meta_pb->mutable_tablet_schema();
+            _schema->to_schema_pb(ts_pb);
+        }
     }
 
     void get_tablet_schema_pb(TabletSchemaPB* tablet_schema_pb) {


### PR DESCRIPTION
Why I'm doing:
To reduce memory usage, we remove the `tablet_schema_pb` of `rowset_meta_pb` in memory and we will regenerate `tablet_schema_pb` from the `_schema`. However, the `_schema` of rowset maybe nullptr if restore from old version snapshot.

What I'm doing:
Fix the bug.

Fixes https://github.com/StarRocks/StarRocksTest/issues/5947

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
