### PR TITLE
[BugFix] Fix bug dynamic partition date type does not support hour

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/DynamicPartitionProperty.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/DynamicPartitionProperty.java
@@ -38,6 +38,7 @@ import com.starrocks.analysis.TimestampArithmeticExpr.TimeUnit;
 import com.starrocks.common.FeConstants;
 import com.starrocks.common.util.DynamicPartitionUtil.StartOfDate;
 import com.starrocks.common.util.TimeUtils;
+import org.apache.arrow.util.VisibleForTesting;
 
 import java.util.Map;
 import java.util.TimeZone;
@@ -193,6 +194,11 @@ public class DynamicPartitionProperty {
         sb.deleteCharAt(sb.length() - 1);
         sb.append("}");
         return sb.toString();
+    }
+
+    @VisibleForTesting
+    public void setTimeUnit(String timeUnit) {
+        this.timeUnit = timeUnit;
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/DynamicPartitionProperty.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/DynamicPartitionProperty.java
@@ -34,11 +34,11 @@
 
 package com.starrocks.catalog;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.starrocks.analysis.TimestampArithmeticExpr.TimeUnit;
 import com.starrocks.common.FeConstants;
 import com.starrocks.common.util.DynamicPartitionUtil.StartOfDate;
 import com.starrocks.common.util.TimeUtils;
-import org.apache.arrow.util.VisibleForTesting;
 
 import java.util.Map;
 import java.util.TimeZone;

--- a/fe/fe-core/src/main/java/com/starrocks/clone/DynamicPartitionScheduler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/clone/DynamicPartitionScheduler.java
@@ -50,6 +50,7 @@ import com.starrocks.catalog.OlapTable;
 import com.starrocks.catalog.Partition;
 import com.starrocks.catalog.PartitionInfo;
 import com.starrocks.catalog.PartitionKey;
+import com.starrocks.catalog.PrimitiveType;
 import com.starrocks.catalog.RandomDistributionInfo;
 import com.starrocks.catalog.RangePartitionInfo;
 import com.starrocks.catalog.Table;
@@ -258,7 +259,7 @@ public class DynamicPartitionScheduler extends FrontendDaemon {
                         String.valueOf(dynamicPartitionProperty.getReplicationNum()));
             }
 
-            if (partitionColumn.getPrimitiveType().isDateType() &&
+            if (partitionColumn.getPrimitiveType() == PrimitiveType.DATE &&
                     dynamicPartitionProperty.getTimeUnit()
                             .equalsIgnoreCase(TimestampArithmeticExpr.TimeUnit.HOUR.toString())) {
                 throw new SemanticException("Date type partition does not support dynamic partitioning granularity of hour");

--- a/fe/fe-core/src/main/java/com/starrocks/clone/DynamicPartitionScheduler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/clone/DynamicPartitionScheduler.java
@@ -40,6 +40,7 @@ import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Range;
 import com.google.common.collect.Sets;
+import com.starrocks.analysis.TimestampArithmeticExpr;
 import com.starrocks.catalog.Column;
 import com.starrocks.catalog.Database;
 import com.starrocks.catalog.DistributionInfo;
@@ -256,6 +257,13 @@ public class DynamicPartitionScheduler extends FrontendDaemon {
                 partitionProperties.put("replication_num",
                         String.valueOf(dynamicPartitionProperty.getReplicationNum()));
             }
+
+            if (partitionColumn.getPrimitiveType().isDateType() &&
+                    dynamicPartitionProperty.getTimeUnit()
+                            .equalsIgnoreCase(TimestampArithmeticExpr.TimeUnit.HOUR.toString())) {
+                throw new SemanticException("Date type partition does not support dynamic partitioning granularity of hour");
+            }
+
             String partitionName = dynamicPartitionProperty.getPrefix() +
                     DynamicPartitionUtil.getFormattedPartitionName(dynamicPartitionProperty.getTimeZone(), prevBorder,
                             dynamicPartitionProperty.getTimeUnit());
@@ -405,20 +413,19 @@ public class DynamicPartitionScheduler extends FrontendDaemon {
                 return true;
             }
 
-            Column partitionColumn = rangePartitionInfo.getPartitionColumns().get(0);
-            String partitionFormat;
             try {
-                partitionFormat = DynamicPartitionUtil.getPartitionFormat(partitionColumn);
-            } catch (DdlException e) {
+                Column partitionColumn = rangePartitionInfo.getPartitionColumns().get(0);
+                String partitionFormat = DynamicPartitionUtil.getPartitionFormat(partitionColumn);
+                if (!skipAddPartition) {
+                    addPartitionClauses = getAddPartitionClause(db, olapTable, partitionColumn, partitionFormat);
+                }
+                dropPartitionClauses = getDropPartitionClause(db, olapTable, partitionColumn, partitionFormat);
+                tableName = olapTable.getName();
+            } catch (Exception e) {
+                LOG.warn("create or drop partition failed", e);
                 recordCreatePartitionFailedMsg(db.getOriginName(), olapTable.getName(), e.getMessage());
                 return false;
             }
-
-            if (!skipAddPartition) {
-                addPartitionClauses = getAddPartitionClause(db, olapTable, partitionColumn, partitionFormat);
-            }
-            dropPartitionClauses = getDropPartitionClause(db, olapTable, partitionColumn, partitionFormat);
-            tableName = olapTable.getName();
         } finally {
             locker.unLockDatabase(db, LockType.READ);
         }

--- a/fe/fe-core/src/main/java/com/starrocks/common/util/DynamicPartitionUtil.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/util/DynamicPartitionUtil.java
@@ -37,6 +37,7 @@ package com.starrocks.common.util;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Strings;
 import com.starrocks.analysis.Expr;
+import com.starrocks.analysis.TimestampArithmeticExpr;
 import com.starrocks.analysis.TimestampArithmeticExpr.TimeUnit;
 import com.starrocks.catalog.Column;
 import com.starrocks.catalog.DynamicPartitionProperty;
@@ -57,6 +58,7 @@ import com.starrocks.common.ErrorReport;
 import com.starrocks.common.FeConstants;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.sql.analyzer.FeNameFormat;
+import com.starrocks.sql.analyzer.SemanticException;
 import org.apache.commons.collections4.map.CaseInsensitiveMap;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -70,6 +72,7 @@ import java.time.format.DateTimeFormatter;
 import java.time.temporal.TemporalAdjusters;
 import java.util.Calendar;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.TimeZone;
 
@@ -245,6 +248,16 @@ public class DynamicPartitionUtil {
             }
             if (Strings.isNullOrEmpty(timeZone)) {
                 properties.put(DynamicPartitionProperty.TIME_ZONE, TimeUtils.getSystemTimeZone().getID());
+            }
+
+            if (timeUnit.equalsIgnoreCase(TimestampArithmeticExpr.TimeUnit.HOUR.toString())) {
+                List<Column> partitionColumns = partitionInfo.getPartitionColumns();
+                for (Column partitionColumn : partitionColumns) {
+                    if (partitionColumn.getPrimitiveType().isDateType()) {
+                        throw new SemanticException("Date type partition does not support dynamic partitioning" +
+                                " granularity of hour");
+                    }
+                }
             }
 
         }

--- a/fe/fe-core/src/main/java/com/starrocks/common/util/DynamicPartitionUtil.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/util/DynamicPartitionUtil.java
@@ -253,7 +253,7 @@ public class DynamicPartitionUtil {
             if (timeUnit.equalsIgnoreCase(TimestampArithmeticExpr.TimeUnit.HOUR.toString())) {
                 List<Column> partitionColumns = partitionInfo.getPartitionColumns();
                 for (Column partitionColumn : partitionColumns) {
-                    if (partitionColumn.getPrimitiveType().isDateType()) {
+                    if (partitionColumn.getPrimitiveType() == PrimitiveType.DATE) {
                         throw new SemanticException("Date type partition does not support dynamic partitioning" +
                                 " granularity of hour");
                     }

--- a/fe/fe-core/src/test/java/com/starrocks/catalog/CreateTableTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/CreateTableTest.java
@@ -507,6 +507,35 @@ public class CreateTableTest {
                         ")\n" +
                         "DISTRIBUTED BY HASH(k2) BUCKETS 32\n" +
                         "PROPERTIES ( \"replication_num\" = \"1\", \"abc\" = \"def\");"));
+
+        ExceptionChecker.expectThrowsWithMsg(SemanticException.class,
+                "Date type partition does not support dynamic partitioning granularity of hour",
+                () -> createTable("CREATE TABLE test.test_hour_partition2 (\n" +
+                        "  `event_day` date NULL COMMENT \"\",\n" +
+                        "  `site_id` int(11) NULL DEFAULT \"10\" COMMENT \"\",\n" +
+                        "  `city_code` varchar(100) NULL COMMENT \"\",\n" +
+                        "  `user_name` varchar(32) NULL DEFAULT \"\" COMMENT \"\",\n" +
+                        "  `pv` bigint(20) NULL DEFAULT \"0\" COMMENT \"\"\n" +
+                        ") ENGINE=OLAP \n" +
+                        "DUPLICATE KEY(`event_day`, `site_id`, `city_code`, `user_name`)\n" +
+                        "PARTITION BY RANGE(`event_day`)\n" +
+                        "()\n" +
+                        "DISTRIBUTED BY HASH(`event_day`, `site_id`) BUCKETS 32 \n" +
+                        "PROPERTIES (\n" +
+                        "\"replication_num\" = \"1\",\n" +
+                        "\"dynamic_partition.enable\" = \"true\",\n" +
+                        "\"dynamic_partition.time_unit\" = \"HOUR\",\n" +
+                        "\"dynamic_partition.time_zone\" = \"Asia/Shanghai\",\n" +
+                        "\"dynamic_partition.start\" = \"-1\",\n" +
+                        "\"dynamic_partition.end\" = \"10\",\n" +
+                        "\"dynamic_partition.prefix\" = \"p\",\n" +
+                        "\"dynamic_partition.buckets\" = \"3\",\n" +
+                        "\"dynamic_partition.history_partition_num\" = \"0\",\n" +
+                        "\"in_memory\" = \"false\",\n" +
+                        "\"storage_format\" = \"DEFAULT\",\n" +
+                        "\"enable_persistent_index\" = \"false\",\n" +
+                        "\"compression\" = \"LZ4\"\n" +
+                        ");"));
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/clone/DynamicPartitionSchedulerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/clone/DynamicPartitionSchedulerTest.java
@@ -17,6 +17,7 @@ package com.starrocks.clone;
 import com.google.common.collect.Range;
 import com.starrocks.catalog.Database;
 import com.starrocks.catalog.DistributionInfo;
+import com.starrocks.catalog.DynamicPartitionProperty;
 import com.starrocks.catalog.OlapTable;
 import com.starrocks.catalog.Partition;
 import com.starrocks.catalog.PartitionKey;
@@ -255,6 +256,53 @@ public class DynamicPartitionSchedulerTest {
             DistributionInfo distributionInfo = partition.getDistributionInfo();
             Assert.assertEquals(4, distributionInfo.getBucketNum());
         }
+    }
+
+    @Test
+    public void testPartitionColumnDateUseDynamicHour() throws Exception {
+        new MockUp<LocalDateTime>() {
+            @Mock
+            public LocalDateTime now() {
+                return  LocalDateTime.of(2023, 3, 30, 1, 1, 1);
+            }
+        };
+
+        starRocksAssert.withDatabase("test").useDatabase("test")
+                .withTable("CREATE TABLE `test_hour_partition2` (\n" +
+                        "  `event_day` date NULL COMMENT \"\",\n" +
+                        "  `site_id` int(11) NULL DEFAULT \"10\" COMMENT \"\",\n" +
+                        "  `city_code` varchar(100) NULL COMMENT \"\",\n" +
+                        "  `user_name` varchar(32) NULL DEFAULT \"\" COMMENT \"\",\n" +
+                        "  `pv` bigint(20) NULL DEFAULT \"0\" COMMENT \"\"\n" +
+                        ") ENGINE=OLAP \n" +
+                        "DUPLICATE KEY(`event_day`, `site_id`, `city_code`, `user_name`)\n" +
+                        "PARTITION BY RANGE(`event_day`)\n" +
+                        "()\n" +
+                        "DISTRIBUTED BY HASH(`event_day`, `site_id`) BUCKETS 32 \n" +
+                        "PROPERTIES (\n" +
+                        "\"replication_num\" = \"1\",\n" +
+                        "\"dynamic_partition.enable\" = \"true\",\n" +
+                        "\"dynamic_partition.time_unit\" = \"DAY\",\n" +
+                        "\"dynamic_partition.time_zone\" = \"Asia/Shanghai\",\n" +
+                        "\"dynamic_partition.start\" = \"-1\",\n" +
+                        "\"dynamic_partition.end\" = \"10\",\n" +
+                        "\"dynamic_partition.prefix\" = \"p\",\n" +
+                        "\"dynamic_partition.buckets\" = \"3\",\n" +
+                        "\"dynamic_partition.history_partition_num\" = \"0\",\n" +
+                        "\"in_memory\" = \"false\",\n" +
+                        "\"storage_format\" = \"DEFAULT\",\n" +
+                        "\"enable_persistent_index\" = \"false\",\n" +
+                        "\"compression\" = \"LZ4\"\n" +
+                        ");");
+
+        DynamicPartitionScheduler dynamicPartitionScheduler = GlobalStateMgr.getCurrentState()
+                .getDynamicPartitionScheduler();
+        Database db = GlobalStateMgr.getCurrentState().getDb("test");
+        OlapTable tbl = (OlapTable) db.getTable("test_hour_partition2");
+        DynamicPartitionProperty dynamicPartitionProperty = tbl.getTableProperty().getDynamicPartitionProperty();
+        dynamicPartitionProperty.setTimeUnit("HOUR");
+        boolean result = dynamicPartitionScheduler.executeDynamicPartitionForTable(db.getId(), tbl.getId());
+        Assert.assertFalse(result);
     }
 
 }


### PR DESCRIPTION
Why I'm doing:
Dynamic partitioning supports hour, but it does not consider that date type partitioning cannot be supported.

What I'm doing:
1. When creating a table, directly prevent such prompts from being created.
2. Provide friendly error prompts for stock creation.
3. Add a little more coverage for other issues that may go wrong.

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [x] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [x] 3.1
  - [x] 3.0
  - [x] 2.5
