### PR TITLE
[BugFix] Fixed publish version ends without doing anything in shared data mode

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/transaction/DatabaseTransactionMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/transaction/DatabaseTransactionMgr.java
@@ -1143,7 +1143,12 @@ public class DatabaseTransactionMgr {
                 } else {
                     partitionCommitInfo.setVersion(partition.getNextVersion());
                 }
-                partitionCommitInfo.setVersionTime(table.isCloudNativeTable() ? 0 : commitTs);
+                // versionTime has different meanings in shared data and shared nothing mode.
+                // In shared nothing mode, versionTime is the time when the transaction was
+                // committed, while in shared data mode, versionTime is the time when the
+                // transaction was successfully published. This is a design error due to
+                // carelessness, and should have been consistent here.
+                partitionCommitInfo.setVersionTime(table.isCloudNativeTableOrMaterializedView() ? 0 : commitTs);
             }
         }
 


### PR DESCRIPTION
In shared data mode, publish version relies on the value of the partition version time to determine whether the publish version task for a partition has succeeded, whereas previous implementations incorrectly set the version time to a positive number when committing a transaction for a materialized view, leading to the mistaken belief that the publish version task for that materialized view has succeeded.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [x] 3.1
  - [ ] 3.0
  - [ ] 2.5
