### PR TITLE
[BugFix] recursive check base tables in the view when active mv

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/alter/Alter.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/Alter.java
@@ -76,7 +76,6 @@ import com.starrocks.scheduler.TaskManager;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.server.LocalMetastore;
 import com.starrocks.sql.analyzer.Analyzer;
-import com.starrocks.sql.analyzer.AnalyzerUtils;
 import com.starrocks.sql.analyzer.MaterializedViewAnalyzer;
 import com.starrocks.sql.analyzer.SemanticException;
 import com.starrocks.sql.analyzer.SetStmtAnalyzer;
@@ -360,8 +359,8 @@ public class Alter {
                         "\n\nCause an error: %s", materializedView.getName(), viewDefineSql, e.getMessage(), e);
             }
 
-            Map<TableName, Table> tableNameTableMap = AnalyzerUtils.collectAllConnectorTableAndView(mvQueryStatement);
-            List<BaseTableInfo> baseTableInfos = MaterializedViewAnalyzer.getBaseTableInfos(tableNameTableMap, !isReplay);
+            List<BaseTableInfo> baseTableInfos =
+                    MaterializedViewAnalyzer.processBaseTables(mvQueryStatement, !isReplay);
             materializedView.setBaseTableInfos(baseTableInfos);
             materializedView.getRefreshScheme().getAsyncRefreshContext().clearVisibleVersionMap();
             materializedView.onReload();

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/MaterializedViewAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/MaterializedViewAnalyzer.java
@@ -106,44 +106,6 @@ public class MaterializedViewAnalyzer {
         new MaterializedViewAnalyzerVisitor().visit(stmt, session);
     }
 
-    public static List<BaseTableInfo> getBaseTableInfos(Map<TableName, Table> tableNameTableMap, boolean withCheck) {
-        List<BaseTableInfo> baseTableInfos = Lists.newArrayList();
-
-        if (tableNameTableMap.isEmpty()) {
-            throw new SemanticException("Can not find base table in query statement");
-        }
-        for (Map.Entry<TableName, Table> entry : tableNameTableMap.entrySet()) {
-            TableName tableNameInfo = entry.getKey();
-            Table table = entry.getValue();
-            if (withCheck) {
-                Preconditions.checkState(table != null, "Materialized view base table is null");
-                if (!isSupportBasedOnTable(table)) {
-                    throw new SemanticException("Create materialized view do not support the table type: " +
-                            table.getType());
-                }
-                if (table instanceof MaterializedView && !((MaterializedView) table).isActive()) {
-                    throw new SemanticException(
-                            "Create materialized view from inactive materialized view: " + table.getName());
-                }
-                if (isExternalTableFromResource(table)) {
-                    throw new SemanticException(
-                            "Only supports creating materialized views based on the external table " +
-                                    "which created by catalog");
-                }
-            }
-            Database database = GlobalStateMgr.getCurrentState().getMetadataMgr().getDb(tableNameInfo.getCatalog(),
-                    tableNameInfo.getDb());
-            if (isInternalCatalog(tableNameInfo.getCatalog())) {
-                baseTableInfos.add(new BaseTableInfo(database.getId(), database.getFullName(),
-                        table.getId(), table.getName()));
-            } else {
-                baseTableInfos.add(new BaseTableInfo(tableNameInfo.getCatalog(),
-                        tableNameInfo.getDb(), table.getTableIdentifier()));
-            }
-        }
-        return baseTableInfos;
-    }
-
     private static boolean isSupportBasedOnTable(Table table) {
         return table instanceof OlapTable || table instanceof HiveTable || table instanceof HudiTable ||
                 table instanceof IcebergTable || table instanceof View;
@@ -163,6 +125,12 @@ public class MaterializedViewAnalyzer {
         } else {
             return true;
         }
+    }
+
+    public static List<BaseTableInfo> processBaseTables(QueryStatement queryStatement, boolean withCheck) {
+        List<BaseTableInfo> result = Lists.newArrayList();
+        MaterializedViewAnalyzerVisitor.processBaseTables(queryStatement, result, withCheck);
+        return result;
     }
 
     static class MaterializedViewAnalyzerVisitor extends AstVisitor<Void, ConnectContext> {
@@ -243,7 +211,7 @@ public class MaterializedViewAnalyzer {
                 throw new SemanticException("Can not find database:" + statement.getTableName().getDb());
             }
 
-            List<BaseTableInfo> baseTableInfos = getAndCheckBaseTables(queryStatement);
+            List<BaseTableInfo> baseTableInfos = getAndCheckBaseTables(queryStatement, true);
             // now do not support empty base tables
             // will be relaxed after test
             if (baseTableInfos.isEmpty()) {
@@ -295,36 +263,41 @@ public class MaterializedViewAnalyzer {
             return result;
         }
 
-        private List<BaseTableInfo> getAndCheckBaseTables(QueryStatement queryStatement) {
+        private static List<BaseTableInfo> getAndCheckBaseTables(QueryStatement queryStatement, boolean withCheck) {
             List<BaseTableInfo> baseTableInfos = Lists.newArrayList();
-            processBaseTables(queryStatement, baseTableInfos);
+            processBaseTables(queryStatement, baseTableInfos, withCheck);
             Set<BaseTableInfo> baseTableInfoSet = Sets.newHashSet(baseTableInfos);
             baseTableInfos.clear();
             baseTableInfos.addAll(baseTableInfoSet);
             return baseTableInfos;
         }
 
-        private void processBaseTables(QueryStatement queryStatement, List<BaseTableInfo> baseTableInfos) {
+        public static void processBaseTables(QueryStatement queryStatement,
+                                             List<BaseTableInfo> baseTableInfos,
+                                             boolean withCheck) {
             Map<TableName, Table> tableNameTableMap = AnalyzerUtils.collectAllConnectorTableAndView(queryStatement);
             tableNameTableMap.forEach((tableNameInfo, table) -> {
                 Preconditions.checkState(table != null, "Materialized view base table is null");
-                if (!isSupportBasedOnTable(table)) {
-                    throw new SemanticException("Create/Rebuild materialized view do not support the table type: "
-                            + table.getType());
-                }
-                if (table instanceof MaterializedView && !((MaterializedView) table).isActive()) {
-                    throw new SemanticException("Create/Rebuild materialized view from inactive materialized view: "
-                            + table.getName());
-                }
+                if (withCheck) {
+                    if (!isSupportBasedOnTable(table)) {
+                        throw new SemanticException("Create/Rebuild materialized view do not support the table type: "
+                                + table.getType());
+                    }
+                    if (table instanceof MaterializedView && !((MaterializedView) table).isActive()) {
+                        throw new SemanticException("Create/Rebuild materialized view from inactive materialized view: "
+                                + table.getName());
+                    }
 
-                if (table instanceof View) {
-                    return;
-                }
+                    if (table instanceof View) {
+                        return;
+                    }
 
-                if (isExternalTableFromResource(table)) {
-                    throw new SemanticException(
-                            "Only supports creating materialized views based on the external table " +
-                                    "which created by catalog");
+                    if (isExternalTableFromResource(table)) {
+                        throw new SemanticException(
+                                String.format("Only supports creating materialized views based on " +
+                                                "the external table created by catalog, but table type of %s is %s",
+                                        table.getName(), table.getType()));
+                    }
                 }
                 Database database = GlobalStateMgr.getCurrentState().getMetadataMgr().getDb(tableNameInfo.getCatalog(),
                         tableNameInfo.getDb());
@@ -336,17 +309,19 @@ public class MaterializedViewAnalyzer {
                             tableNameInfo.getDb(), table.getTableIdentifier()));
                 }
             });
-            processViews(queryStatement, baseTableInfos);
+            processViews(queryStatement, baseTableInfos, withCheck);
         }
 
-        private void processViews(QueryStatement queryStatement, List<BaseTableInfo> baseTableInfos) {
+        public static void processViews(QueryStatement queryStatement,
+                                        List<BaseTableInfo> baseTableInfos,
+                                        boolean withCheck) {
             List<ViewRelation> viewRelations = AnalyzerUtils.collectViewRelations(queryStatement);
             if (viewRelations.isEmpty()) {
                 return;
             }
             Set<ViewRelation> viewRelationSet = Sets.newHashSet(viewRelations);
             for (ViewRelation viewRelation : viewRelationSet) {
-                processBaseTables(viewRelation.getQueryStatement(), baseTableInfos);
+                processBaseTables(viewRelation.getQueryStatement(), baseTableInfos, withCheck);
             }
         }
 


### PR DESCRIPTION
Why I'm doing:
- `View` is not processed when activating mv
- Base tables in the view are not processed recursively 

What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5

