### PR TITLE
[BugFix] Fix array/map's behavior in Trino mode

### DIFF
--- a/be/src/exprs/array_element_expr.cpp
+++ b/be/src/exprs/array_element_expr.cpp
@@ -61,7 +61,10 @@ public:
                 if (subscript == 0) {
                     return Status::InvalidArgument("Array subscript start at 1");
                 }
-                if (subscript > (curr - prev)) {
+
+                // if curr==prev, means this line is null
+                // in Trino, null row's any subscript is still null
+                if ((curr != prev) && (subscript > (curr - prev))) {
                     return Status::InvalidArgument(
                             strings::Substitute("Array subscript must be less than or equal to array length: $0 > $1",
                                                 subscript, curr - prev));

--- a/be/src/exprs/function_call_expr.cpp
+++ b/be/src/exprs/function_call_expr.cpp
@@ -134,7 +134,7 @@ StatusOr<ColumnPtr> VectorizedFunctionCallExpr::evaluate_checked(starrocks::Expr
     Columns args;
     args.reserve(_children.size());
     for (Expr* child : _children) {
-        ASSIGN_OR_RETURN(ColumnPtr column, context->evaluate(child, ptr));
+        ColumnPtr column = EVALUATE_NULL_IF_ERROR(context, child, ptr);
         args.emplace_back(column);
     }
 

--- a/be/src/exprs/function_call_expr.cpp
+++ b/be/src/exprs/function_call_expr.cpp
@@ -134,7 +134,7 @@ StatusOr<ColumnPtr> VectorizedFunctionCallExpr::evaluate_checked(starrocks::Expr
     Columns args;
     args.reserve(_children.size());
     for (Expr* child : _children) {
-        ColumnPtr column = EVALUATE_NULL_IF_ERROR(context, child, ptr);
+        ASSIGN_OR_RETURN(ColumnPtr column, context->evaluate(child, ptr));
         args.emplace_back(column);
     }
 

--- a/test/sql/test_trino_dialect/R/test_trino_dialect
+++ b/test/sql/test_trino_dialect/R/test_trino_dialect
@@ -15,31 +15,25 @@ insert into map_array_tbl values
 (3, null, null);
 -- result:
 -- !result
-select c2['key1'], c3[1] from map_array_tbl;
+select c2['key1'], c3[1] from map_array_tbl order by c1;
 -- result:
 1	1
 5	1
 None	None
 -- !result
-select c2['not-existed'] from map_array_tbl;
+select c2['not-existed'] from map_array_tbl order by c1;
 -- result:
 None
 None
 None
 -- !result
-select c3[100] from map_array_tbl;
+select c3[100] from map_array_tbl order by c1;
 -- result:
 None
 None
 None
 -- !result
-select concat(c3[1], c3[100]) from map_array_tbl;
--- result:
-None
-None
-None
--- !result
-select element_at(c2, 'not-existed'), element_at(c3, 100) from map_array_tbl;
+select element_at(c2, 'not-existed'), element_at(c3, 100) from map_array_tbl order by c1;
 -- result:
 None	None
 None	None
@@ -48,25 +42,21 @@ None	None
 set sql_dialect='trino';
 -- result:
 -- !result
-select c2['key1'], c3[1] from map_array_tbl;
+select c2['key1'], c3[1] from map_array_tbl order by c1;
 -- result:
 1	1
 5	1
 None	None
 -- !result
-select c2['not-existed'] from map_array_tbl;
+select c2['not-existed'] from map_array_tbl order by c1;
 -- result:
 E: (1064, "Key not present in map: 'not-existed'")
 -- !result
-select c3[100] from map_array_tbl;
+select c3[100] from map_array_tbl order by c1;
 -- result:
 E: (1064, 'Array subscript must be less than or equal to array length: 100 > 1')
 -- !result
-select concat(c3[1], c3[100]) from map_array_tbl;
--- result:
-E: (1064, 'Array subscript must be less than or equal to array length: 100 > 1')
--- !result
-select element_at(c2, 'not-existed'), element_at(c3, 100) from map_array_tbl;
+select element_at(c2, 'not-existed'), element_at(c3, 100) from map_array_tbl order by c1;
 -- result:
 None	None
 None	None

--- a/test/sql/test_trino_dialect/R/test_trino_dialect
+++ b/test/sql/test_trino_dialect/R/test_trino_dialect
@@ -11,16 +11,19 @@ CREATE TABLE map_array_tbl
 -- !result
 insert into map_array_tbl values
 (1, map{"key1":1}, [1]),
-(2, map{"key1":5, "key2":6}, [1, 2]);
+(2, map{"key1":5, "key2":6}, [1, 2]),
+(3, null, null);
 -- result:
 -- !result
 select c2['key1'], c3[1] from map_array_tbl;
 -- result:
 1	1
 5	1
+None	None
 -- !result
 select c2['not-existed'] from map_array_tbl;
 -- result:
+None
 None
 None
 -- !result
@@ -28,9 +31,17 @@ select c3[100] from map_array_tbl;
 -- result:
 None
 None
+None
+-- !result
+select concat(c3[1], c3[100]) from map_array_tbl;
+-- result:
+None
+None
+None
 -- !result
 select element_at(c2, 'not-existed'), element_at(c3, 100) from map_array_tbl;
 -- result:
+None	None
 None	None
 None	None
 -- !result
@@ -41,6 +52,7 @@ select c2['key1'], c3[1] from map_array_tbl;
 -- result:
 1	1
 5	1
+None	None
 -- !result
 select c2['not-existed'] from map_array_tbl;
 -- result:
@@ -50,8 +62,13 @@ select c3[100] from map_array_tbl;
 -- result:
 E: (1064, 'Array subscript must be less than or equal to array length: 100 > 1')
 -- !result
+select concat(c3[1], c3[100]) from map_array_tbl;
+-- result:
+E: (1064, 'Array subscript must be less than or equal to array length: 100 > 1')
+-- !result
 select element_at(c2, 'not-existed'), element_at(c3, 100) from map_array_tbl;
 -- result:
+None	None
 None	None
 None	None
 -- !result

--- a/test/sql/test_trino_dialect/T/test_trino_dialect
+++ b/test/sql/test_trino_dialect/T/test_trino_dialect
@@ -10,15 +10,18 @@ CREATE TABLE map_array_tbl
 
 insert into map_array_tbl values
 (1, map{"key1":1}, [1]),
-(2, map{"key1":5, "key2":6}, [1, 2]);
+(2, map{"key1":5, "key2":6}, [1, 2]),
+(3, null, null);
 
 select c2['key1'], c3[1] from map_array_tbl;
 select c2['not-existed'] from map_array_tbl;
 select c3[100] from map_array_tbl;
+select concat(c3[1], c3[100]) from map_array_tbl;
 select element_at(c2, 'not-existed'), element_at(c3, 100) from map_array_tbl;
 
 set sql_dialect='trino';
 select c2['key1'], c3[1] from map_array_tbl;
 select c2['not-existed'] from map_array_tbl;
 select c3[100] from map_array_tbl;
+select concat(c3[1], c3[100]) from map_array_tbl;
 select element_at(c2, 'not-existed'), element_at(c3, 100) from map_array_tbl;

--- a/test/sql/test_trino_dialect/T/test_trino_dialect
+++ b/test/sql/test_trino_dialect/T/test_trino_dialect
@@ -13,15 +13,13 @@ insert into map_array_tbl values
 (2, map{"key1":5, "key2":6}, [1, 2]),
 (3, null, null);
 
-select c2['key1'], c3[1] from map_array_tbl;
-select c2['not-existed'] from map_array_tbl;
-select c3[100] from map_array_tbl;
-select concat(c3[1], c3[100]) from map_array_tbl;
-select element_at(c2, 'not-existed'), element_at(c3, 100) from map_array_tbl;
+select c2['key1'], c3[1] from map_array_tbl order by c1;
+select c2['not-existed'] from map_array_tbl order by c1;
+select c3[100] from map_array_tbl order by c1;
+select element_at(c2, 'not-existed'), element_at(c3, 100) from map_array_tbl order by c1;
 
 set sql_dialect='trino';
-select c2['key1'], c3[1] from map_array_tbl;
-select c2['not-existed'] from map_array_tbl;
-select c3[100] from map_array_tbl;
-select concat(c3[1], c3[100]) from map_array_tbl;
-select element_at(c2, 'not-existed'), element_at(c3, 100) from map_array_tbl;
+select c2['key1'], c3[1] from map_array_tbl order by c1;
+select c2['not-existed'] from map_array_tbl order by c1;
+select c3[100] from map_array_tbl order by c1;
+select element_at(c2, 'not-existed'), element_at(c3, 100) from map_array_tbl order by c1;


### PR DESCRIPTION
Why I'm doing:
In Trino:
If map column's value is null, `map[any_key]` always returns null
If array column's value is null, `array[any_subscribe]` always returns null.

What I'm doing:
Previous pr: #39965
Keep same behavior as trino.

Fixes https://github.com/StarRocks/StarRocksTest/issues/5948

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [x] 3.1
  - [ ] 3.0
  - [ ] 2.5
