### PR TITLE
[Enhancement] parallel prepare  metadata

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/IcebergTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/IcebergTable.java
@@ -400,6 +400,11 @@ public class IcebergTable extends Table {
     }
 
     @Override
+    public boolean supportPreCollectMetadata() {
+        return true;
+    }
+
+    @Override
     public int hashCode() {
         return com.google.common.base.Objects.hashCode(getCatalogName(), remoteDbName, getTableIdentifier());
     }

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/Table.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/Table.java
@@ -777,6 +777,10 @@ public class Table extends MetaObject implements Writable, GsonPostProcessable {
         return false;
     }
 
+    public boolean supportPreCollectMetadata() {
+        return false;
+    }
+
     public boolean hasUniqueConstraints() {
         List<UniqueConstraint> uniqueConstraint = getUniqueConstraints();
         return uniqueConstraint != null;

--- a/fe/fe-core/src/main/java/com/starrocks/common/profile/Tracers.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/profile/Tracers.java
@@ -70,6 +70,11 @@ public class Tracers {
         tracers.allTracer[1] = new TracerImpl(Stopwatch.createStarted(), new TimeWatcher(), new VarTracer(), logTracer);
     }
 
+    // for record metrics in parallel
+    public static Tracers get() {
+        return THREAD_LOCAL.get();
+    }
+
     public static void init(ConnectContext context, Mode mode, String moduleStr) {
         Tracers tracers = THREAD_LOCAL.get();
         boolean enableProfile =
@@ -168,6 +173,10 @@ public class Tracers {
 
     public static void record(Module module, String name, String value) {
         Tracers tracers = THREAD_LOCAL.get();
+        tracers.tracer(module, Mode.VARS).record(name, value);
+    }
+
+    public static void record(Tracers tracers, Module module, String name, String value) {
         tracers.tracer(module, Mode.VARS).record(name, value);
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/connector/CatalogConnectorMetadata.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/CatalogConnectorMetadata.java
@@ -26,6 +26,7 @@ import com.starrocks.common.DdlException;
 import com.starrocks.common.MetaNotFoundException;
 import com.starrocks.common.Pair;
 import com.starrocks.common.UserException;
+import com.starrocks.common.profile.Tracers;
 import com.starrocks.connector.informationschema.InformationSchemaMetadata;
 import com.starrocks.credential.CloudConfiguration;
 import com.starrocks.sql.ast.AddPartitionClause;
@@ -126,6 +127,11 @@ public class CatalogConnectorMetadata implements ConnectorMetadata {
     public List<RemoteFileInfo> getRemoteFileInfos(Table table, List<PartitionKey> partitionKeys, long snapshotId,
                                                    ScalarOperator predicate, List<String> fieldNames, long limit) {
         return normal.getRemoteFileInfos(table, partitionKeys, snapshotId, predicate, fieldNames, limit);
+    }
+
+    @Override
+    public boolean prepareMetadata(MetaPreparationItem item, Tracers tracers) {
+        return normal.prepareMetadata(item, tracers);
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/connector/ConnectorMetadata.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/ConnectorMetadata.java
@@ -26,6 +26,7 @@ import com.starrocks.common.DdlException;
 import com.starrocks.common.MetaNotFoundException;
 import com.starrocks.common.Pair;
 import com.starrocks.common.UserException;
+import com.starrocks.common.profile.Tracers;
 import com.starrocks.connector.exception.StarRocksConnectorException;
 import com.starrocks.credential.CloudConfiguration;
 import com.starrocks.sql.ast.AddPartitionClause;
@@ -171,6 +172,10 @@ public interface ConnectorMetadata {
                                           ScalarOperator predicate,
                                           long limit) {
         return Statistics.builder().build();
+    }
+
+    default boolean prepareMetadata(MetaPreparationItem item, Tracers tracers) {
+        return true;
     }
 
     default List<PartitionKey> getPrunedPartitions(Table table, ScalarOperator predicate, long limit) {

--- a/fe/fe-core/src/main/java/com/starrocks/connector/MetaPreparationItem.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/MetaPreparationItem.java
@@ -1,0 +1,52 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.connector;
+
+import com.starrocks.catalog.Table;
+import com.starrocks.sql.optimizer.operator.scalar.ScalarOperator;
+
+public class MetaPreparationItem {
+    private final Table table;
+    private final ScalarOperator predicate;
+    private final long limit;
+
+    public MetaPreparationItem(Table table, ScalarOperator predicate, long limit) {
+        this.table = table;
+        this.predicate = predicate;
+        this.limit = limit;
+    }
+
+    public Table getTable() {
+        return table;
+    }
+
+    public ScalarOperator getPredicate() {
+        return predicate;
+    }
+
+    public long getLimit() {
+        return limit;
+    }
+
+    @Override
+    public String toString() {
+        final StringBuilder sb = new StringBuilder("MetaPreparationItem{");
+        sb.append("table=").append(table);
+        sb.append(", predicate=").append(predicate);
+        sb.append(", limit=").append(limit);
+        sb.append('}');
+        return sb.toString();
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergMetadata.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergMetadata.java
@@ -34,6 +34,7 @@ import com.starrocks.common.profile.Timer;
 import com.starrocks.common.profile.Tracers;
 import com.starrocks.connector.ConnectorMetadata;
 import com.starrocks.connector.HdfsEnvironment;
+import com.starrocks.connector.MetaPreparationItem;
 import com.starrocks.connector.PartitionInfo;
 import com.starrocks.connector.PartitionUtil;
 import com.starrocks.connector.RemoteFileDesc;
@@ -142,6 +143,7 @@ public class IcebergMetadata implements ConnectorMetadata {
     private final Map<String, Database> databases = new ConcurrentHashMap<>();
     private final Map<IcebergFilter, List<FileScanTask>> splitTasks = new ConcurrentHashMap<>();
     private final Set<IcebergFilter> scannedTables = new HashSet<>();
+    private final Set<IcebergFilter> preparedTables = ConcurrentHashMap.newKeySet();
 
     // FileScanTaskSchema -> Pair<schema_string, partition_string>
     private final Map<FileScanTaskSchema, Pair<String, String>> fileScanTaskSchemas = new ConcurrentHashMap<>();
@@ -398,10 +400,36 @@ public class IcebergMetadata implements ConnectorMetadata {
         return partitions.build();
     }
 
+    @Override
+    public boolean prepareMetadata(MetaPreparationItem item, Tracers tracers) {
+        IcebergFilter key;
+        IcebergTable icebergTable;
+        icebergTable = (IcebergTable) item.getTable();
+        String dbName = icebergTable.getRemoteDbName();
+        String tableName = icebergTable.getRemoteTableName();
+        Optional<Snapshot> snapshot = icebergTable.getSnapshot();
+        if (snapshot.isEmpty()) {
+            return true;
+        }
+
+        key = IcebergFilter.of(dbName, tableName, snapshot.get().snapshotId(), item.getPredicate());
+        if (!preparedTables.add(key)) {
+            return true;
+        }
+
+        triggerIcebergPlanFilesIfNeeded(key, icebergTable, item.getPredicate(), item.getLimit(), tracers);
+        return true;
+    }
+
     private void triggerIcebergPlanFilesIfNeeded(IcebergFilter key, IcebergTable table, ScalarOperator predicate, long limit) {
+        triggerIcebergPlanFilesIfNeeded(key, table, predicate, limit, null);
+    }
+
+    private void triggerIcebergPlanFilesIfNeeded(IcebergFilter key, IcebergTable table, ScalarOperator predicate,
+                                                 long limit, Tracers tracers) {
         if (!scannedTables.contains(key)) {
             try (Timer ignored = Tracers.watchScope(EXTERNAL, "ICEBERG.processSplit." + key)) {
-                collectTableStatisticsAndCacheIcebergSplit(table, predicate, limit);
+                collectTableStatisticsAndCacheIcebergSplit(table, predicate, limit, tracers);
             }
         }
     }
@@ -480,7 +508,7 @@ public class IcebergMetadata implements ConnectorMetadata {
         return partitionKeys;
     }
 
-    private void collectTableStatisticsAndCacheIcebergSplit(Table table, ScalarOperator predicate, long limit) {
+    private void collectTableStatisticsAndCacheIcebergSplit(Table table, ScalarOperator predicate, long limit, Tracers tracers) {
         IcebergTable icebergTable = (IcebergTable) table;
         Optional<Snapshot> snapshot = icebergTable.getSnapshot();
         // empty table
@@ -595,10 +623,18 @@ public class IcebergMetadata implements ConnectorMetadata {
 
         Optional<ScanReport> metrics = metricsReporter.getReporter(catalogName, dbName, tableName, snapshotId, icebergPredicate);
 
-        metrics.ifPresent(metric ->
-                Tracers.record(Tracers.Module.EXTERNAL, "ICEBERG.ScanMetrics." +
-                                metric.tableName() + "["  + icebergPredicate + "]",
-                        metric.scanMetrics().toString()));
+        if (metrics.isPresent()) {
+            Tracers.Module module = Tracers.Module.EXTERNAL;
+            String name = "ICEBERG.ScanMetrics." + metrics.get().tableName() + "["  + icebergPredicate + "]";
+            String value = metrics.get().scanMetrics().toString();
+            if (tracers == null) {
+                Tracers.record(module, name, value);
+            } else {
+                synchronized (this) {
+                    Tracers.record(tracers, module, name, value);
+                }
+            }
+        }
 
         splitTasks.put(key, icebergScanTasks);
         scannedTables.add(key);

--- a/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
@@ -319,6 +319,9 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
 
     public static final String CBO_USE_DB_LOCK = "cbo_use_lock_db";
     public static final String CBO_PREDICATE_SUBFIELD_PATH = "cbo_enable_predicate_subfield_path";
+    public static final String CBO_PREPARE_METADATA_THREAD_POOL_SIZE = "cbo_prepare_metadata_thread_pool_size";
+
+    public static final String CBO_ENABLE_PARALLEL_PREPARE_METADATA = "enable_parallel_prepare_metadata";
 
     public static final String SKEW_JOIN_RAND_RANGE = "skew_join_rand_range";
 
@@ -1627,6 +1630,28 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
 
     @VarAttr(name = CROSS_JOIN_COST_PENALTY, flag = VariableMgr.INVISIBLE)
     private long crossJoinCostPenalty = 1000000;
+
+    @VarAttr(name = CBO_PREPARE_METADATA_THREAD_POOL_SIZE)
+    private int prepareMetadataPoolSize = 16;
+
+    @VarAttr(name = CBO_ENABLE_PARALLEL_PREPARE_METADATA)
+    private boolean enableParallelPrepareMetadata = false;
+
+    public int getPrepareMetadataPoolSize() {
+        return prepareMetadataPoolSize;
+    }
+
+    public void setPrepareMetadataPoolSize(int prepareMetadataPoolSize) {
+        this.prepareMetadataPoolSize = prepareMetadataPoolSize;
+    }
+
+    public boolean enableParallelPrepareMetadata() {
+        return enableParallelPrepareMetadata;
+    }
+
+    public void setEnableParallelPrepareMetadata(boolean enableParallelPrepareMetadata) {
+        this.enableParallelPrepareMetadata = enableParallelPrepareMetadata;
+    }
 
     public String getHiveTempStagingDir() {
         return hiveTempStagingDir;

--- a/fe/fe-core/src/main/java/com/starrocks/server/MetadataMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/MetadataMgr.java
@@ -39,11 +39,13 @@ import com.starrocks.common.FeConstants;
 import com.starrocks.common.MetaNotFoundException;
 import com.starrocks.common.Pair;
 import com.starrocks.common.UserException;
+import com.starrocks.common.profile.Tracers;
 import com.starrocks.connector.CatalogConnector;
 import com.starrocks.connector.ConnectorMetadata;
 import com.starrocks.connector.ConnectorMgr;
 import com.starrocks.connector.ConnectorTableColumnStats;
 import com.starrocks.connector.ConnectorTblMetaInfoMgr;
+import com.starrocks.connector.MetaPreparationItem;
 import com.starrocks.connector.PartitionInfo;
 import com.starrocks.connector.RemoteFileInfo;
 import com.starrocks.connector.exception.StarRocksConnectorException;
@@ -139,13 +141,17 @@ public class MetadataMgr {
         return Optional.empty();
     }
 
+    public Optional<ConnectorMetadata> getOptionalMetadata(String catalogName) {
+        Optional<String> queryId = getOptionalQueryID();
+        return getOptionalMetadata(queryId, catalogName);
+    }
 
     /** get ConnectorMetadata by catalog name
      * if catalog is null or empty will return localMetastore
      * @param catalogName catalog's name
      * @return ConnectorMetadata
      */
-    public Optional<ConnectorMetadata> getOptionalMetadata(String catalogName) {
+    public Optional<ConnectorMetadata> getOptionalMetadata(Optional<String> queryId, String catalogName) {
         if (Strings.isNullOrEmpty(catalogName) || CatalogMgr.isInternalCatalog(catalogName)) {
             return Optional.of(localMetastore);
         }
@@ -156,7 +162,6 @@ public class MetadataMgr {
             return Optional.empty();
         }
 
-        Optional<String> queryId = getOptionalQueryID();
         if (queryId.isPresent()) { // use query-level cache if from query
             QueryMetadatas queryMetadatas = metadataCacheByQueryId.getUnchecked(queryId.get());
             return Optional.ofNullable(queryMetadatas.getConnectorMetadata(catalogName, queryId.get()));
@@ -478,6 +483,19 @@ public class MetadataMgr {
             }
         }
         return partitions.build();
+    }
+
+    public boolean prepareMetadata(String queryId, String catalogName, MetaPreparationItem item, Tracers tracers) {
+        Optional<ConnectorMetadata> connectorMetadata = getOptionalMetadata(Optional.of(queryId), catalogName);
+        if (connectorMetadata.isPresent()) {
+            try {
+                return connectorMetadata.get().prepareMetadata(item, tracers);
+            } catch (Exception e) {
+                LOG.error("prepare metadata failed on [{}]", item, e);
+                return true;
+            }
+        }
+        return true;
     }
 
     public void refreshTable(String catalogName, String srDbName, Table table,

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/Optimizer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/Optimizer.java
@@ -89,6 +89,7 @@ import com.starrocks.sql.optimizer.rule.tree.lowcardinality.LowCardinalityRewrit
 import com.starrocks.sql.optimizer.rule.tree.prunesubfield.PruneSubfieldRule;
 import com.starrocks.sql.optimizer.rule.tree.prunesubfield.PushDownSubfieldRule;
 import com.starrocks.sql.optimizer.task.OptimizeGroupTask;
+import com.starrocks.sql.optimizer.task.PrepareCollectMetaTask;
 import com.starrocks.sql.optimizer.task.RewriteTreeTask;
 import com.starrocks.sql.optimizer.task.TaskContext;
 import com.starrocks.sql.optimizer.validate.MVRewriteValidator;
@@ -428,6 +429,9 @@ public class Optimizer {
 
         ruleRewriteIterative(tree, rootTaskContext, RuleSetType.MULTI_DISTINCT_REWRITE);
         ruleRewriteIterative(tree, rootTaskContext, RuleSetType.PUSH_DOWN_PREDICATE);
+
+        // No heavy metadata operation before external table partition prune
+        prepareMetaOnlyOnce(tree, rootTaskContext);
 
         ruleRewriteOnlyOnce(tree, rootTaskContext, RuleSetType.PARTITION_PRUNE);
         ruleRewriteIterative(tree, rootTaskContext, RuleSetType.PRUNE_EMPTY_OPERATOR);
@@ -849,5 +853,12 @@ public class Optimizer {
         List<Rule> rules = Collections.singletonList(rule);
         context.getTaskScheduler().pushTask(new RewriteTreeTask(rootTaskContext, tree, rules, true));
         context.getTaskScheduler().executeTasks(rootTaskContext);
+    }
+
+    private void prepareMetaOnlyOnce(OptExpression tree, TaskContext rootTaskContext) {
+        if (rootTaskContext.getOptimizerContext().getSessionVariable().enableParallelPrepareMetadata()) {
+            context.getTaskScheduler().pushTask(new PrepareCollectMetaTask(rootTaskContext, tree));
+            context.getTaskScheduler().executeTasks(rootTaskContext);
+        }
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/task/PrepareCollectMetaTask.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/task/PrepareCollectMetaTask.java
@@ -1,0 +1,85 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.sql.optimizer.task;
+
+import com.google.common.util.concurrent.ThreadFactoryBuilder;
+import com.starrocks.common.profile.Timer;
+import com.starrocks.common.profile.Tracers;
+import com.starrocks.connector.MetaPreparationItem;
+import com.starrocks.server.GlobalStateMgr;
+import com.starrocks.server.MetadataMgr;
+import com.starrocks.sql.optimizer.OptExpression;
+import com.starrocks.sql.optimizer.Utils;
+import com.starrocks.sql.optimizer.operator.logical.LogicalScanOperator;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.stream.Collectors;
+
+import static com.starrocks.common.profile.Tracers.Module.EXTERNAL;
+
+public class PrepareCollectMetaTask extends OptimizerTask {
+
+    private final OptExpression planTree;
+
+    public PrepareCollectMetaTask(TaskContext context, OptExpression root) {
+        super(context);
+        this.planTree = root;
+    }
+
+    @Override
+    public void execute() {
+        List<LogicalScanOperator> scanOperators = collectScanOperators(planTree)
+                .stream()
+                .filter(scanOperator -> scanOperator.getTable().supportPreCollectMetadata())
+                .collect(Collectors.groupingBy(LogicalScanOperator::getOpType))
+                .values()
+                .stream()
+                .filter(list -> list.size() > 1)
+                .flatMap(List::stream)
+                .collect(Collectors.toList());
+
+        if (scanOperators.isEmpty()) {
+            return;
+        }
+
+        int threadPoolSize = context.getOptimizerContext().getSessionVariable().getPrepareMetadataPoolSize();
+        String queryId = context.getOptimizerContext().getQueryId().toString();
+        ExecutorService executorService = Executors.newFixedThreadPool(threadPoolSize,
+                new ThreadFactoryBuilder().setNameFormat(String.format("prepare-metadata-%s", queryId)).build());
+
+        MetadataMgr metadataMgr = GlobalStateMgr.getCurrentState().getMetadataMgr();
+        Tracers tracers = Tracers.get();
+        try (Timer ignored = Tracers.watchScope(EXTERNAL, "EXTERNAL.parallel_prepare_metadata")) {
+            CompletableFuture<Void> allFutures = CompletableFuture.allOf(scanOperators.stream()
+                    .map(op -> CompletableFuture.supplyAsync(() ->
+                                    metadataMgr.prepareMetadata(queryId, op.getTable().getCatalogName(),
+                                            new MetaPreparationItem(op.getTable(), op.getPredicate(), op.getLimit()),
+                                            tracers),
+                            executorService)).toArray(CompletableFuture[]::new));
+            allFutures.join();
+        }
+        executorService.shutdown();
+    }
+
+    private List<LogicalScanOperator> collectScanOperators(OptExpression tree) {
+        List<LogicalScanOperator> scanOperators = new ArrayList<>();
+        Utils.extractOperator(tree, scanOperators, op -> op instanceof LogicalScanOperator);
+        return scanOperators;
+    }
+}

--- a/test/sql/test_iceberg/R/test_iceberg_parallel_prepare_metadata
+++ b/test/sql/test_iceberg/R/test_iceberg_parallel_prepare_metadata
@@ -1,0 +1,46 @@
+-- name: test_iceberg_parallel_prepare_metadata
+create external catalog ice_cat_${uuid0}
+properties
+(
+    "type" = "iceberg",
+    "iceberg.catalog.type" = "hive",
+    "hive.metastore.uris" = "${iceberg_catalog_hive_metastore_uris}"
+);
+-- result:
+[]
+-- !result
+create database ice_cat_${uuid0}.ice_db_${uuid0};
+-- result:
+[]
+-- !result
+create table ice_cat_${uuid0}.ice_db_${uuid0}.ice_tbl_${uuid0} (
+  col_str string,
+  col_int int
+) partition by (col_int);
+-- result:
+[]
+-- !result
+insert into ice_cat_${uuid0}.ice_db_${uuid0}.ice_tbl_${uuid0} values ("a", 1),("a", 2);
+-- result:
+[]
+-- !result
+set enable_parallel_prepare_metadata=true;
+-- result:
+[]
+-- !result
+select a.col_str from ice_cat_${uuid0}.ice_db_${uuid0}.ice_tbl_${uuid0} a join ice_cat_${uuid0}.ice_db_${uuid0}.ice_tbl_${uuid0} b on a.col_str = b.col_str where a.col_int = 1 and b.col_int = 2;
+-- result:
+a
+-- !result
+drop table ice_cat_${uuid0}.ice_db_${uuid0}.ice_tbl_${uuid0} force;
+-- result:
+[]
+-- !result
+drop database ice_cat_${uuid0}.ice_db_${uuid0};
+-- result:
+[]
+-- !result
+drop catalog ice_cat_${uuid0};
+-- result:
+[]
+-- !result

--- a/test/sql/test_iceberg/T/test_iceberg_parallel_prepare_metadata
+++ b/test/sql/test_iceberg/T/test_iceberg_parallel_prepare_metadata
@@ -1,0 +1,22 @@
+-- name: test_iceberg_parallel_prepare_metadata
+create external catalog ice_cat_${uuid0}
+properties
+(
+    "type" = "iceberg",
+    "iceberg.catalog.type" = "hive",
+    "hive.metastore.uris" = "${iceberg_catalog_hive_metastore_uris}"
+);
+
+create database ice_cat_${uuid0}.ice_db_${uuid0};
+
+create table ice_cat_${uuid0}.ice_db_${uuid0}.ice_tbl_${uuid0} (
+  col_str string,
+  col_int int
+) partition by (col_int);
+
+insert into ice_cat_${uuid0}.ice_db_${uuid0}.ice_tbl_${uuid0} values ("a", 1),("a", 2);
+set enable_parallel_prepare_metadata=true;
+select a.col_str from ice_cat_${uuid0}.ice_db_${uuid0}.ice_tbl_${uuid0} a join ice_cat_${uuid0}.ice_db_${uuid0}.ice_tbl_${uuid0} b on a.col_str = b.col_str where a.col_int = 1 and b.col_int = 2;
+drop table ice_cat_${uuid0}.ice_db_${uuid0}.ice_tbl_${uuid0} force;
+drop database ice_cat_${uuid0}.ice_db_${uuid0};
+drop catalog ice_cat_${uuid0};


### PR DESCRIPTION
Why I'm doing:
our optimizer processes each table serially. If the job planning time for each iceberg  is 0.5s. So ten tables are 5s in a query. Due to external catalog support query level metadata cache, so we can collect the metadata of all tables in parallel.

What I'm doing:
collect all table's metadata in parallel before partition prune rule. we only support iceberg table warmup metadata now

![image](https://github.com/StarRocks/starrocks/assets/91597003/183f8144-7839-4275-82f4-72083f80ab27)

5 tables join on with different partition id
base: 18s
optimized: 4s

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
