### PR TITLE
[Enhancement] Support wild cards in the file paths for external tables.

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/FileTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/FileTable.java
@@ -54,6 +54,7 @@ public class FileTable extends Table {
     public static final String JSON_KEY_FILE_PATH = "path";
     public static final String JSON_KEY_FORMAT = "format";
     private static final String JSON_RECURSIVE_DIRECTORIES = "enable_recursive_listing";
+    private static final String JSON_ENABLE_WILDCARDS = "enable_wildcards";
     private static final String JSON_KEY_FILE_PROPERTIES = "fileProperties";
 
     public static final String JSON_KEY_COLUMN_SEPARATOR = "column_separator";
@@ -129,9 +130,10 @@ public class FileTable extends Table {
         HiveRemoteFileIO remoteFileIO = new HiveRemoteFileIO(configuration);
         boolean recursive = Boolean.parseBoolean(fileProperties.getOrDefault(JSON_RECURSIVE_DIRECTORIES, "false"));
         RemotePathKey pathKey = new RemotePathKey(getTableLocation(), recursive, Optional.empty());
+        boolean enableWildCards = Boolean.parseBoolean(fileProperties.getOrDefault(JSON_ENABLE_WILDCARDS, "false"));
 
         try {
-            Map<RemotePathKey, List<RemoteFileDesc>> result = remoteFileIO.getRemoteFiles(pathKey);
+            Map<RemotePathKey, List<RemoteFileDesc>> result = remoteFileIO.getRemoteFiles(pathKey, enableWildCards);
             if (result.isEmpty()) {
                 throw new DdlException("No file exists for FileTable: " + this.getName());
             }

--- a/fe/fe-core/src/main/java/com/starrocks/connector/RemoteFileDesc.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/RemoteFileDesc.java
@@ -25,6 +25,9 @@ import java.util.List;
 
 public class RemoteFileDesc {
     private String fileName;
+    // Optional.
+    // The full path of the remote file.
+    private String fullPath;
     private String compression;
     private long length;
     private long modificationTime;
@@ -114,6 +117,15 @@ public class RemoteFileDesc {
         return this;
     }
 
+    public RemoteFileDesc setFullPath(String fullPath) {
+        this.fullPath = fullPath;
+        return this;
+    }
+
+    public String getFullPath() {
+        return this.fullPath;
+    }
+
     public ImmutableList<String> getHudiDeltaLogs() {
         return hudiDeltaLogs;
     }
@@ -133,6 +145,7 @@ public class RemoteFileDesc {
     public String toString() {
         final StringBuilder sb = new StringBuilder("RemoteFileDesc{");
         sb.append("fileName='").append(fileName).append('\'');
+	sb.append("fullPath='").append(fullPath).append('\'');
         sb.append(", compression='").append(compression).append('\'');
         sb.append(", length=").append(length);
         sb.append(", modificationTime=").append(modificationTime);

--- a/fe/fe-core/src/main/java/com/starrocks/connector/RemoteFileDesc.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/RemoteFileDesc.java
@@ -145,7 +145,7 @@ public class RemoteFileDesc {
     public String toString() {
         final StringBuilder sb = new StringBuilder("RemoteFileDesc{");
         sb.append("fileName='").append(fileName).append('\'');
-	sb.append("fullPath='").append(fullPath).append('\'');
+        sb.append("fullPath='").append(fullPath).append('\'');
         sb.append(", compression='").append(compression).append('\'');
         sb.append(", length=").append(length);
         sb.append(", modificationTime=").append(modificationTime);

--- a/fe/fe-core/src/main/java/com/starrocks/planner/FileTableScanNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/FileTableScanNode.java
@@ -85,10 +85,16 @@ public class FileTableScanNode extends ScanNode {
 
             THdfsScanRange hdfsScanRange = new THdfsScanRange();
             hdfsScanRange.setRelative_path(file.getFileName());
-            if (fileTable.getTableLocation().endsWith("/")) {
-                hdfsScanRange.setFull_path(fileTable.getTableLocation() + file.getFileName());
+	    // If `fullPath` is set, we just pass it down directly. Otherwise we try to concatenate the `fileName`
+            // and `tableLocation` to get the full path.
+            if (file.getFullPath() != null) {
+                hdfsScanRange.setFull_path(file.getFullPath());
             } else {
-                hdfsScanRange.setFull_path(fileTable.getTableLocation());
+                if (fileTable.getTableLocation().endsWith("/")) {
+                    hdfsScanRange.setFull_path(fileTable.getTableLocation() + file.getFileName());
+                } else {
+                    hdfsScanRange.setFull_path(fileTable.getTableLocation());
+                }
             }
             hdfsScanRange.setOffset(blockDesc.getOffset());
             hdfsScanRange.setLength(blockDesc.getLength());

--- a/fe/fe-core/src/test/java/com/starrocks/connector/hive/MockedRemoteFileSystem.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/hive/MockedRemoteFileSystem.java
@@ -156,7 +156,7 @@ public class MockedRemoteFileSystem extends FileSystem {
                     0, false, 0, 0, 0, new Path(HDFS_RECURSIVE_TABLE));
         }
 
-        return new FileStatus[]{fileStatus};
+        return new FileStatus[] {fileStatus};
     }
 
     @Override

--- a/fe/fe-core/src/test/java/com/starrocks/connector/hive/MockedRemoteFileSystem.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/hive/MockedRemoteFileSystem.java
@@ -146,6 +146,20 @@ public class MockedRemoteFileSystem extends FileSystem {
     }
 
     @Override
+    public FileStatus[] globStatus(Path path) {
+        FileStatus fileStatus = null;
+        if (this.hdfsTable.equals(HDFS_HIVE_TABLE)) {
+            fileStatus = new FileStatus(
+                    0, false, 0, 0, 0, new Path(HDFS_HIVE_TABLE));
+        } else if (this.hdfsTable.equals(HDFS_RECURSIVE_TABLE)) {
+            fileStatus = new FileStatus(
+                    0, false, 0, 0, 0, new Path(HDFS_RECURSIVE_TABLE));
+        }
+
+        return new FileStatus[]{fileStatus};
+    }
+
+    @Override
     public URI getUri() {
         throw new UnsupportedOperationException();
     }


### PR DESCRIPTION
Why I'm doing:
Wild cards in the file paths are not supported for external file tables.

What I'm doing:
Add an option called `enable_wildcards` for external file tables. If the option is enabled, then wild cards are supported in the file paths for external file tables.

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
- [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [x] 3.1
  - [ ] 3.0
  - [ ] 2.5
