### PR TITLE
[BugFix] fix erros in start_backend.sh

### DIFF
--- a/bin/start_backend.sh
+++ b/bin/start_backend.sh
@@ -192,7 +192,7 @@ if [ ${RUN_CN} -eq 1 ]; then
 fi
 
 # enable DD profile
-if [ ${ENABLE_DATADOG_PROFILE} == "true" ] && [ -f "${STARROCKS_HOME}/datadog/ddprof" ]; then
+if [ "${ENABLE_DATADOG_PROFILE}" == "true" ] && [ -f "${STARROCKS_HOME}/datadog/ddprof" ]; then
     START_BE_CMD="${STARROCKS_HOME}/datadog/ddprof -l debug ${START_BE_CMD}"
 fi
 


### PR DESCRIPTION
Why I'm doing:

When `ENABLE_DATADOG_PROFILE` is not set, the default behavior, it throws an warning message as below:
>  bin/start_backend.sh: line 195: [: ==: unary operator expected

What I'm doing:

fix it.

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [x] 3.1
  - [x] 3.1-cs
  - [ ] 3.0
  - [ ] 2.5
