### PR TITLE
[BugFix] Fix the compile problem of plugin-common (backport #36533)

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -277,13 +277,13 @@ cd ${STARROCKS_HOME}
 FE_MODULES=
 if [ ${BUILD_FE} -eq 1 ] || [ ${BUILD_SPARK_DPP} -eq 1 ] || [ ${BUILD_HIVE_UDF} -eq 1 ]; then
     if [ ${BUILD_SPARK_DPP} -eq 1 ]; then
-        FE_MODULES="fe-common,spark-dpp"
+        FE_MODULES="fe-common,plugin-common,spark-dpp"
     fi
     if [ ${BUILD_HIVE_UDF} -eq 1 ]; then
-        FE_MODULES="fe-common,hive-udf"
+        FE_MODULES="fe-common,plugin-common,hive-udf"
     fi
     if [ ${BUILD_FE} -eq 1 ]; then
-        FE_MODULES="hive-udf,fe-common,spark-dpp,fe-core"
+        FE_MODULES="hive-udf,plugin-common,fe-common,spark-dpp,fe-core"
     fi
 fi
 


### PR DESCRIPTION
Why I'm doing:

mvn package has not set param `-am` in branch-2.5, so it will be compile failed

What I'm doing:

Fix the compile problem of plugin-common

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [x] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5

