### PR TITLE
[BugFix] avoid scan mem limit zero (`available_chunk_source_count` SIGFPE)

### DIFF
--- a/be/src/exec/pipeline/scan/connector_scan_operator.h
+++ b/be/src/exec/pipeline/scan/connector_scan_operator.h
@@ -39,8 +39,8 @@ struct ConnectorScanOperatorMemShareArbitrator {
             : query_mem_limit(query_mem_limit), scan_mem_limit(query_mem_limit) {}
 
     int64_t set_scan_mem_ratio(double mem_ratio) {
-        scan_mem_limit = query_mem_limit * mem_ratio;
-        return std::max<int64_t>(1, scan_mem_limit);
+        scan_mem_limit = std::max<int64_t>(1, query_mem_limit * mem_ratio);
+        return scan_mem_limit;
     }
 
     int64_t update_chunk_source_mem_bytes(int64_t old_value, int64_t new_value);

--- a/be/src/exec/pipeline/scan/connector_scan_operator.h
+++ b/be/src/exec/pipeline/scan/connector_scan_operator.h
@@ -40,7 +40,7 @@ struct ConnectorScanOperatorMemShareArbitrator {
 
     int64_t set_scan_mem_ratio(double mem_ratio) {
         scan_mem_limit = query_mem_limit * mem_ratio;
-        return scan_mem_limit;
+        return std::max<int64_t>(1, scan_mem_limit);
     }
 
     int64_t update_chunk_source_mem_bytes(int64_t old_value, int64_t new_value);


### PR DESCRIPTION
> Why I'm doing:

To the sql like

>  sql = """CREATE MATERIALIZED VIEW mv1 REFRESH MANUAL properties ("session.query_mem_limit" = "1") AS SELECT k1,sum(k6),avg(k7) FROM t1 group by k1;"""


If `query_scan_mem_limit` is very small, `scan_mem_limit` value could be zero, which will lead to zero division in following function

```C++
    int available_chunk_source_count(int32_t plan_node_id, int driver_sequence) const {
        int64_t scan_mem_limit_value = scan_mem_limit.load(std::memory_order_relaxed);
        int64_t running_chunk_source_count_value = running_chunk_source_count.load(std::memory_order_relaxed);
        int64_t chunk_source_mem_bytes_value = get_chunk_source_mem_bytes();

     // ---- both values will be zero
        int64_t max_count = std::max(1L, scan_mem_limit_value / chunk_source_mem_bytes_value);
        int64_t avail_count = max_count;
        int64_t per_count = avail_count / dop + 1;
...
}

```

> What I'm doing:

To avoid scan mem limit is zero.

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
