### PR TITLE
[BugFix] Fix the problem of not passing callback when flushing async delta writer in shared-data mode

### DIFF
--- a/be/src/runtime/lake_tablets_channel.cpp
+++ b/be/src/runtime/lake_tablets_channel.cpp
@@ -434,6 +434,10 @@ int LakeTabletsChannel::_close_sender(const int64_t* partitions, size_t partitio
     return n - 1;
 }
 
+static void null_callback(const Status& status) {
+    (void)status;
+}
+
 void LakeTabletsChannel::_flush_stale_memtables() {
     bool high_mem_usage = false;
     if (_mem_tracker->limit_exceeded_by_ratio(70) ||
@@ -449,15 +453,15 @@ void LakeTabletsChannel::_flush_stale_memtables() {
             if (_immutable_partition_ids.count(writer->partition_id()) > 0) {
                 if (high_mem_usage) {
                     log_flushed = true;
-                    writer->flush(nullptr);
+                    writer->flush(null_callback);
                 } else if (now - last_write_ts > 1) {
                     log_flushed = true;
-                    writer->flush(nullptr);
+                    writer->flush(null_callback);
                 }
             } else {
                 if (high_mem_usage && now - last_write_ts > config::stale_memtable_flush_time_sec) {
                     log_flushed = true;
-                    writer->flush(nullptr);
+                    writer->flush(null_callback);
                 }
             }
             if (log_flushed) {


### PR DESCRIPTION
## Why I'm doing:
Not passing callback when flushing async delta writer causes be crash in shared-data mode

## What I'm doing:
Passing an callback when flushing async delta writer causes be crash in shared-data mode

Fixes https://github.com/StarRocks/StarRocksTest/issues/5969

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
