### PR TITLE
[Enhancement] support to get iceberg scan metrics in different threads

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/cost/IcebergMetricsReporter.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/cost/IcebergMetricsReporter.java
@@ -14,69 +14,85 @@
 
 package com.starrocks.connector.iceberg.cost;
 
-import com.google.common.collect.Lists;
+import org.apache.iceberg.expressions.Expression;
+import org.apache.iceberg.expressions.ExpressionUtil;
 import org.apache.iceberg.metrics.MetricsReport;
 import org.apache.iceberg.metrics.MetricsReporter;
 import org.apache.iceberg.metrics.ScanReport;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 
-import java.util.List;
+import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
 
 public class IcebergMetricsReporter implements MetricsReporter {
-    private static final Logger LOG = LogManager.getLogger(IcebergMetricsReporter.class);
-
-    protected static ThreadLocal<IcebergMetricsReporter> threadLocalReporter = new ThreadLocal<>();
-    private final List<MetricsReport> reports = Lists.newArrayList();
-
-    public static IcebergMetricsReporter get() {
-        return threadLocalReporter.get();
-    }
-
-    public static void remove() {
-        threadLocalReporter.remove();
-    }
-
-    public void setThreadLocalReporter() {
-        threadLocalReporter.set(this);
-    }
+    private final Map<ScanMetricsFilter, ScanReport> reports = new ConcurrentHashMap<>();
 
     @Override
     public void report(MetricsReport report) {
-        IcebergMetricsReporter reporter = get();
-        if (reporter == null) {
-            return;
+        if (report instanceof ScanReport) {
+            ScanReport scanReport = (ScanReport) report;
+            String tableName = scanReport.tableName();
+            long snapshotId = scanReport.snapshotId();
+            Expression predicate = scanReport.filter();
+            ScanMetricsFilter filter = new ScanMetricsFilter(tableName, predicate, snapshotId);
+            reports.put(filter, scanReport);
         }
-
-        reporter.reports.add(report);
-        LOG.debug(String.format("Received metrics report: %s", report));
     }
 
-    public static Optional<IcebergScanReportWithCounter> lastReport() {
-        IcebergMetricsReporter reporter = get();
-        if (reporter == null || reporter.reports.isEmpty()) {
+    public Optional<ScanReport> getReporter(String catalogName, String dbName, String tableName,
+                                                              long snapshotId, Expression icebergPredicate) {
+        if (reports.isEmpty()) {
             return Optional.empty();
         }
 
-        int reportCount = reporter.reports.size();
-        return Optional.of(new IcebergScanReportWithCounter(reportCount, (ScanReport) reporter.reports.get(reportCount - 1)));
+        ScanMetricsFilter filter = ScanMetricsFilter.from(catalogName, dbName, tableName, snapshotId, icebergPredicate);
+
+        ScanReport report = reports.get(filter);
+        return Optional.ofNullable(report);
     }
 
-    public static class IcebergScanReportWithCounter {
-        private final int count;
-        private final ScanReport scanReport;
-        IcebergScanReportWithCounter(int count, ScanReport scanReport) {
-            this.count = count;
-            this.scanReport = scanReport;
+    public void clear() {
+        reports.clear();
+    }
+
+    private static class ScanMetricsFilter {
+        String icebergTableName;
+        Expression predicate;
+        long snapshotId;
+
+        static ScanMetricsFilter from(String catalogName, String dbName, String tableName,
+                                      long snapshotId, Expression icebergPredicate) {
+            String icebergTableName = catalogName + '.' + dbName + "." + tableName;
+            Expression sanitizeExpr = ExpressionUtil.sanitize(icebergPredicate);
+            return new ScanMetricsFilter(icebergTableName, sanitizeExpr, snapshotId);
         }
 
-        public int getCount() {
-            return count;
+        public ScanMetricsFilter(String tableName, Expression predicate, long snapshotId) {
+            this.icebergTableName = tableName;
+            this.predicate = predicate;
+            this.snapshotId = snapshotId;
         }
 
-        public ScanReport getScanReport() {
-            return scanReport;
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) {
+                return true;
+            }
+
+            if (o == null || getClass() != o.getClass()) {
+                return false;
+            }
+            ScanMetricsFilter filter = (ScanMetricsFilter) o;
+            return snapshotId == filter.snapshotId &&
+                    Objects.equals(icebergTableName, filter.icebergTableName) &&
+                    ExpressionUtil.toSanitizedString(predicate).equalsIgnoreCase(
+                            ExpressionUtil.toSanitizedString(filter.predicate));
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(icebergTableName, snapshotId);
         }
     }
 }


### PR DESCRIPTION
Why I'm doing:
we use thread local iceberg metrics reporter in our query optimizer. If we parallel scan multiple tables in thread pool. we can't get thread local reporter. 

What I'm doing:
refactor iceberg metrics reporter to collect metrics in different thread.

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
