### PR TITLE
[BugFix] fix longest match in regexp_extract (backport #27990)

### DIFF
--- a/be/src/exprs/string_functions.cpp
+++ b/be/src/exprs/string_functions.cpp
@@ -3116,7 +3116,7 @@ Status StringFunctions::regexp_extract_prepare(FunctionContext* context, Functio
 
     state->options = std::make_unique<re2::RE2::Options>();
     state->options->set_log_errors(false);
-    state->options->set_longest_match(true);
+    state->options->set_longest_match(false);
     state->options->set_dot_nl(true);
 
     // go row regex

--- a/be/test/exprs/string_fn_test.cpp
+++ b/be/test/exprs/string_fn_test.cpp
@@ -1677,7 +1677,7 @@ PARALLEL_TEST(VecStringFunctionsTest, regexpExtract) {
                           "(i)(.*?)(s)"};
     int indexs[] = {1, 2, 1, 2};
 
-    std::string res[] = {"b", "drrry", "i", "tdecisiondli"};
+    std::string res[] = {"b", "drrry", "i", "tdeci"};
 
     for (int i = 0; i < sizeof(strs) / sizeof(strs[0]); ++i) {
         str->append(strs[i]);


### PR DESCRIPTION
Why I'm doing:

What I'm doing:

backport #27990

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [x] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5

