### PR TITLE
[BugFix] fix cloud native primary key table retry publish partial update

### DIFF
--- a/be/src/storage/lake/delta_writer.cpp
+++ b/be/src/storage/lake/delta_writer.cpp
@@ -461,10 +461,6 @@ Status DeltaWriterImpl::finish(DeltaWriter::FinishMode mode) {
                 op_write->mutable_txn_meta()->add_partial_update_column_ids(_write_column_ids[i]);
                 op_write->mutable_txn_meta()->add_partial_update_column_unique_ids(tablet_column.unique_id());
             }
-            // generate rewrite segment names to avoid gc in rewrite operation
-            for (auto i = 0; i < op_write->rowset().segments_size(); i++) {
-                op_write->add_rewrite_segments(gen_segment_filename(_txn_id));
-            }
         }
         // handle condition update
         if (_merge_condition != "") {
@@ -482,12 +478,6 @@ Status DeltaWriterImpl::finish(DeltaWriter::FinishMode mode) {
                     */
                     op_write->mutable_txn_meta()->set_auto_increment_partial_update_column_id(i);
                     break;
-                }
-            }
-
-            if (op_write->rewrite_segments_size() == 0) {
-                for (auto i = 0; i < op_write->rowset().segments_size(); i++) {
-                    op_write->add_rewrite_segments(gen_segment_filename(_txn_id));
                 }
             }
         }

--- a/be/src/storage/lake/rowset_update_state.h
+++ b/be/src/storage/lake/rowset_update_state.h
@@ -61,8 +61,9 @@ public:
     Status load(const TxnLogPB_OpWrite& op_write, const TabletMetadata& metadata, int64_t base_version, Tablet* tablet,
                 const MetaFileBuilder* builder, bool need_check_conflict, bool need_lock);
 
-    Status rewrite_segment(const TxnLogPB_OpWrite& op_write, const TabletMetadata& metadata, Tablet* tablet,
-                           std::map<int, FileInfo>* replace_segments, std::vector<std::string>* orphan_files);
+    Status rewrite_segment(const TxnLogPB_OpWrite& op_write, int64_t txn_id, const TabletMetadata& metadata,
+                           Tablet* tablet, std::map<int, FileInfo>* replace_segments,
+                           std::vector<std::string>* orphan_files);
 
     const std::vector<ColumnUniquePtr>& upserts() const { return _upserts; }
     const std::vector<ColumnUniquePtr>& deletes() const { return _deletes; }

--- a/be/src/storage/lake/txn_log_applier.cpp
+++ b/be/src/storage/lake/txn_log_applier.cpp
@@ -99,7 +99,6 @@ public:
         // because if `commit_primary_index` or `finalize` fail, we can remove index in `handle_failure`.
         // if `_index_entry` is null, do nothing.
         RETURN_IF_ERROR(_tablet.update_mgr()->commit_primary_index(_index_entry, &_tablet));
-        _guard.reset(nullptr);
         return _builder.finalize(_max_txn_id);
     }
 

--- a/be/test/storage/lake/partial_update_test.cpp
+++ b/be/test/storage/lake/partial_update_test.cpp
@@ -656,6 +656,79 @@ TEST_P(LakePartialUpdateTest, test_partial_update_publish_retry) {
     ASSERT_EQ(kChunkSize, check(version, [](int c0, int c1, int c2) { return (c0 * 3 == c1) && (c0 * 4 == c2); }));
 }
 
+TEST_P(LakePartialUpdateTest, test_partial_update_publish_error_retry) {
+    if (GetParam().enable_persistent_index) return;
+    auto chunk0 = generate_data(kChunkSize, 0, false, 3);
+    auto chunk1 = generate_data(kChunkSize, 0, true, 5);
+    auto indexes = std::vector<uint32_t>(kChunkSize);
+    for (int i = 0; i < kChunkSize; i++) {
+        indexes[i] = i;
+    }
+
+    auto version = 1;
+    auto tablet_id = _tablet_metadata->id();
+    // normal write
+    {
+        auto txn_id = next_id();
+        ASSIGN_OR_ABORT(auto delta_writer, DeltaWriterBuilder()
+                                                   .set_tablet_manager(_tablet_mgr.get())
+                                                   .set_tablet_id(tablet_id)
+                                                   .set_txn_id(txn_id)
+                                                   .set_partition_id(_partition_id)
+                                                   .set_mem_tracker(_mem_tracker.get())
+                                                   .set_index_id(_tablet_schema->id())
+                                                   .build());
+        ASSERT_OK(delta_writer->open());
+        ASSERT_OK(delta_writer->write(chunk0, indexes.data(), indexes.size()));
+        ASSERT_OK(delta_writer->finish());
+        delta_writer->close();
+        // Publish version
+        ASSERT_OK(publish_single_version(tablet_id, version + 1, txn_id).status());
+        version++;
+    }
+    ASSERT_EQ(kChunkSize, check(version, [](int c0, int c1, int c2) { return (c0 * 3 == c1) && (c0 * 4 == c2); }));
+    ASSIGN_OR_ABORT(auto new_tablet_metadata, _tablet_mgr->get_tablet_metadata(tablet_id, version));
+    EXPECT_EQ(new_tablet_metadata->rowsets_size(), 1);
+
+    // partial update
+    auto txn_id = next_id();
+    {
+        TEST_ENABLE_ERROR_POINT("TabletManager::put_tablet_metadata",
+                                Status::IOError("injected put tablet metadata error"));
+
+        SyncPoint::GetInstance()->EnableProcessing();
+
+        DeferOp defer([]() {
+            TEST_DISABLE_ERROR_POINT("TabletManager::put_tablet_metadata");
+            SyncPoint::GetInstance()->DisableProcessing();
+        });
+        ASSIGN_OR_ABORT(auto delta_writer, DeltaWriterBuilder()
+                                                   .set_tablet_manager(_tablet_mgr.get())
+                                                   .set_tablet_id(tablet_id)
+                                                   .set_txn_id(txn_id)
+                                                   .set_partition_id(_partition_id)
+                                                   .set_mem_tracker(_mem_tracker.get())
+                                                   .set_index_id(_tablet_schema->id())
+                                                   .set_slot_descriptors(&_slot_pointers)
+                                                   .build());
+        ASSERT_OK(delta_writer->open());
+        ASSERT_OK(delta_writer->write(chunk1, indexes.data(), indexes.size()));
+        ASSERT_OK(delta_writer->finish());
+        delta_writer->close();
+        ASSERT_ERROR(publish_single_version(tablet_id, version + 1, txn_id).status());
+        ASSERT_EQ(kChunkSize, check(version, [](int c0, int c1, int c2) { return (c0 * 3 == c1) && (c0 * 4 == c2); }));
+    }
+    {
+        // retry publish again
+        ASSERT_OK(publish_single_version(tablet_id, version + 1, txn_id).status());
+        _tablet_mgr->prune_metacache();
+        ASSERT_EQ(kChunkSize,
+                  check(version + 1, [](int c0, int c1, int c2) { return (c0 * 5 == c1) && (c0 * 4 == c2); }));
+        ASSIGN_OR_ABORT(auto new_tablet_metadata, _tablet_mgr->get_tablet_metadata(tablet_id, version + 1));
+        EXPECT_EQ(new_tablet_metadata->rowsets_size(), 2);
+    }
+}
+
 TEST_P(LakePartialUpdateTest, test_concurrent_write_publish) {
     auto chunk0 = generate_data(kChunkSize, 0, false, 3);
     auto chunk1 = generate_data(kChunkSize, 0, true, 5);

--- a/gensrc/proto/lake_types.proto
+++ b/gensrc/proto/lake_types.proto
@@ -114,7 +114,7 @@ message TxnLogPB {
         // some txn semantic information bind to this rowset
         optional RowsetTxnMetaPB txn_meta = 2;
         repeated string dels = 3;
-        // for partial update, record dest rewrite segment names to avoid gc
+        // Deprecated
         repeated string rewrite_segments = 4;
     }
 


### PR DESCRIPTION
Why I'm doing:
When cloud native primary key table handle partial update with publish retry, we can't guarantee that each rewrite will generate a file of the same size. It will lead to inconsistent file size between S3 and starcache file. E.g.
```
-rw-rw-r-- 1 luoyixin luoyixin 1479037 Jan 30 15:16 000000000000b0b8_cb368214-e4d7-4146-9ed0-e856845b257e.dat (s3)
-rw-r--r-- 1 luoyixin luoyixin 1479153 Jan 30 16:29 000000000000b0b8_cb368214-e4d7-4146-9ed0-e856845b257e.dat (starcache file)
```
These segment files contains some data but with different file size.

And In previous PR #36772, we record segment file size in rowset meta, and this will lead to `magic number not match` when query.

What I'm doing:
This PR contains several parts:
1. Each time rewrite in partial update publish will generate a unique segment filename.
2. Call `unload` before remove primary index to make sure we already clean the error pk index when retry.
3. Some refactor.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [x] 3.1
  - [ ] 3.0
  - [ ] 2.5
