### PR TITLE
[BugFix] Fix view based mv rewrite for 3.2 (backport #39826)

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/MaterializedViewOptimizer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/MaterializedViewOptimizer.java
@@ -37,6 +37,10 @@ public class MaterializedViewOptimizer {
         OptimizerConfig optimizerConfig = new OptimizerConfig(OptimizerConfig.OptimizerAlgorithm.RULE_BASED);
         optimizerConfig.disableRuleSet(RuleSetType.PARTITION_PRUNE);
         optimizerConfig.disableRuleSet(RuleSetType.SINGLE_TABLE_MV_REWRITE);
+        // INTERSECT_REWRITE is used for INTERSECT related plan optimize, which can not be SPJG;
+        // And INTERSECT_REWRITE should be based on PARTITION_PRUNE rule set.
+        // So exclude it
+        optimizerConfig.disableRuleSet(RuleSetType.INTERSECT_REWRITE);
         optimizerConfig.disableRule(RuleType.TF_REWRITE_GROUP_BY_COUNT_DISTINCT);
         optimizerConfig.disableRule(RuleType.TF_PRUNE_EMPTY_SCAN);
         // For sync mv, no rewrite query by original sync mv rule to avoid useless rewrite.

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/logical/LogicalCTEProduceOperator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/logical/LogicalCTEProduceOperator.java
@@ -90,7 +90,7 @@ public class LogicalCTEProduceOperator extends LogicalOperator {
     }
 
     public static class Builder
-            extends LogicalOperator.Builder<LogicalCTEProduceOperator, LogicalValuesOperator.Builder> {
+            extends LogicalOperator.Builder<LogicalCTEProduceOperator, LogicalCTEProduceOperator.Builder> {
         @Override
         protected LogicalCTEProduceOperator newInstance() {
             return new LogicalCTEProduceOperator(-1);
@@ -101,7 +101,7 @@ public class LogicalCTEProduceOperator extends LogicalOperator {
         }
 
         @Override
-        public LogicalValuesOperator.Builder withOperator(LogicalCTEProduceOperator operator) {
+        public LogicalCTEProduceOperator.Builder withOperator(LogicalCTEProduceOperator operator) {
             builder.cteId = operator.cteId;
             return super.withOperator(operator);
         }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/transformer/RelationTransformer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/transformer/RelationTransformer.java
@@ -719,7 +719,14 @@ public class RelationTransformer extends AstVisitor<LogicalPlan, ExpressionMappi
         Map<Column, ColumnRefOperator> columnMetaToColRefMap = columnMetaToColRefMapBuilder.build();
         ImmutableMap<ColumnRefOperator, Column> columnRefOperatorToColumn = colRefToColumnMetaMapBuilder.build();
 
-        Map<Expr, ColumnRefOperator> exprMapping = logicalPlan.getRootBuilder().getExpressionMapping().getExpressionToColumns();
+        OptExprBuilder rootBuilder = logicalPlan.getRootBuilder();
+        // there may be nested LogicalCTEAnchorOperator, like tpcds query31
+        while (rootBuilder.getRoot().getOp() instanceof LogicalCTEAnchorOperator) {
+            // for cte, use right child as new root builder
+            rootBuilder = rootBuilder.getInputs().get(1);
+        }
+        ExpressionMapping expressionMapping = rootBuilder.getExpressionMapping();
+        Map<Expr, ColumnRefOperator> exprMapping = expressionMapping.getExpressionToColumns();
         Map<Expr, ColumnRefOperator> newExprMapping = Maps.newHashMap();
         // construct a mapping from output expr to output columns of view
         for (Map.Entry<Expr, ColumnRefOperator> entry : exprMapping.entrySet()) {

--- a/fe/fe-core/src/test/java/com/starrocks/planner/MaterializedViewTestBase.java
+++ b/fe/fe-core/src/test/java/com/starrocks/planner/MaterializedViewTestBase.java
@@ -161,7 +161,7 @@ public class MaterializedViewTestBase extends PlanTestBase {
                     String properties = this.properties != null ? "PROPERTIES (\n" +
                             this.properties + ")" : "";
                     String mvSQL = "CREATE MATERIALIZED VIEW mv0 \n" +
-                            "   DISTRIBUTED BY HASH(`" + outputNames.get(0) + "`) BUCKETS 12\n" +
+                            " REFRESH MANUAL " +
                             properties + " AS " +
                             mv;
                     starRocksAssert.withMaterializedView(mvSQL);

--- a/fe/fe-core/src/test/java/com/starrocks/planner/TpchSQL.java
+++ b/fe/fe-core/src/test/java/com/starrocks/planner/TpchSQL.java
@@ -1,0 +1,78 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.planner;
+
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.FileReader;
+import java.io.IOException;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Objects;
+
+public class TpchSQL {
+    private static String from(String name) {
+        String path = Objects.requireNonNull(ClassLoader.getSystemClassLoader().getResource("sql")).getPath();
+        File file = new File(path + "/tpchsql/q" + name + ".sql");
+        StringBuilder sb = new StringBuilder();
+        try (BufferedReader reader = new BufferedReader(new FileReader(file))) {
+            String str;
+            while ((str = reader.readLine()) != null) {
+                sb.append(str).append("\n");
+            }
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+
+        SQL_MAP.put("q" + name, sb.toString());
+        return sb.toString();
+    }
+
+    private static final Map<String, String> SQL_MAP = new LinkedHashMap<>();
+    public static final String Q01 = from("1");
+    public static final String Q02 = from("2");
+    public static final String Q03 = from("3");
+    public static final String Q04 = from("4");
+    public static final String Q05 = from("5");
+    public static final String Q06 = from("6");
+    public static final String Q07 = from("7");
+    public static final String Q08 = from("8");
+    public static final String Q09 = from("9");
+    public static final String Q10 = from("10");
+    public static final String Q11 = from("11");
+    public static final String Q12 = from("12");
+    public static final String Q13 = from("13");
+    public static final String Q14 = from("14");
+    public static final String Q15 = from("15");
+    public static final String Q16 = from("16");
+    public static final String Q17 = from("17");
+    public static final String Q18 = from("18");
+    public static final String Q19 = from("19");
+    public static final String Q20 = from("20");
+    public static final String Q21 = from("21");
+    public static final String Q22 = from("22");
+
+    public static String getSQL(String name) {
+        return SQL_MAP.get(name);
+    }
+
+    public static boolean contains(String name) {
+        return SQL_MAP.containsKey(name);
+    }
+
+    public static Map<String, String> getAllSQL() {
+        return SQL_MAP;
+    }
+}

--- a/fe/fe-core/src/test/java/com/starrocks/planner/ViewBaseMvRewriteOnTpcdsTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/planner/ViewBaseMvRewriteOnTpcdsTest.java
@@ -1,0 +1,73 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.planner;
+
+import com.google.common.collect.Lists;
+import com.google.common.collect.Sets;
+import com.starrocks.common.FeConstants;
+import com.starrocks.sql.plan.TPCDSPlanTestBase;
+import com.starrocks.sql.plan.TPCDSTestUtil;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Stream;
+
+public class ViewBaseMvRewriteOnTpcdsTest extends MaterializedViewTestBase {
+    @BeforeAll
+    public static void beforeClass() throws Exception {
+        FeConstants.USE_MOCK_DICT_MANAGER = true;
+        MaterializedViewTestBase.beforeClass();
+        connectContext.getSessionVariable().setEnableViewBasedMvRewrite(true);
+        starRocksAssert.useDatabase("test");
+        connectContext.executeSql("drop table if exists customer");
+        TPCDSTestUtil.prepareTables(starRocksAssert);
+    }
+
+    @ParameterizedTest(name = "ViewBasedRewriteOnTpcds.{0}")
+    @MethodSource("tpcdsSource")
+    public void testTPCDS(String name, String sql) throws Exception {
+        testMvRewrite(name, sql);
+    }
+
+    private void testMvRewrite(String name, String sql) throws Exception {
+        String viewName = String.format("v_%s", name).replace("-", "_");
+        String dropViewSql = "drop view if exists " + viewName;
+        connectContext.executeSql(dropViewSql);
+        String createViewSql = String.format("create view %s as %s", viewName, sql);
+        starRocksAssert.withView(createViewSql);
+        {
+            String query = String.format("select * from %s", viewName);
+            String mv = query;
+            testRewriteOK(mv, query);
+        }
+    }
+
+    private static Stream<Arguments> tpcdsSource() {
+        List<Arguments> cases = Lists.newArrayList();
+        for (Map.Entry<String, String> entry : TPCDSPlanTestBase.getSqlMap().entrySet()) {
+            // these queries are not supported because they has duplicate output column names
+            Set<String> filteredQueries = Sets.newHashSet("query39-1", "query39-2", "query64");
+            if (!filteredQueries.contains(entry.getKey())) {
+                cases.add(Arguments.of(entry.getKey(), entry.getValue()));
+            }
+        }
+        return cases.stream();
+    }
+}

--- a/fe/fe-core/src/test/java/com/starrocks/planner/ViewBaseMvRewriteOnTpchTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/planner/ViewBaseMvRewriteOnTpchTest.java
@@ -1,0 +1,70 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.planner;
+
+import com.google.common.collect.Lists;
+import com.google.common.collect.Sets;
+import com.starrocks.common.FeConstants;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Stream;
+
+public class ViewBaseMvRewriteOnTpchTest extends MaterializedViewTestBase {
+    @BeforeAll
+    public static void beforeClass() throws Exception {
+        FeConstants.USE_MOCK_DICT_MANAGER = true;
+        MaterializedViewTestBase.beforeClass();
+        connectContext.getSessionVariable().setEnableViewBasedMvRewrite(true);
+        starRocksAssert.useDatabase("test");
+    }
+
+    @ParameterizedTest(name = "ViewBasedRewriteOnTpch.{0}")
+    @MethodSource("tpchSource")
+    public void testTPCH(String name, String sql) throws Exception {
+        testMvRewrite(name, sql);
+    }
+
+    private void testMvRewrite(String name, String sql) throws Exception {
+        String viewName = String.format("v_%s", name);
+        String dropViewSql = "drop view if exists " + viewName;
+        connectContext.executeSql(dropViewSql);
+        String createViewSql = String.format("create view %s as %s", viewName, sql);
+        starRocksAssert.withView(createViewSql);
+        {
+            String query = String.format("select * from %s", viewName);
+            String mv = query;
+            testRewriteOK(mv, query);
+        }
+    }
+
+    private static Stream<Arguments> tpchSource() {
+        List<Arguments> cases = Lists.newArrayList();
+        for (Map.Entry<String, String> entry : TpchSQL.getAllSQL().entrySet()) {
+            // these queries are not supported because the view has only one column, and the column is double type, which
+            // can not be used to create mv
+            Set<String> filteredQueries = Sets.newHashSet("q6", "q14", "q17", "q19");
+            if (!filteredQueries.contains(entry.getKey())) {
+                cases.add(Arguments.of(entry.getKey(), entry.getValue()));
+            }
+        }
+        return cases.stream();
+    }
+}

--- a/fe/fe-core/src/test/java/com/starrocks/planner/ViewBaseMvRewriteTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/planner/ViewBaseMvRewriteTest.java
@@ -1,3 +1,17 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package com.starrocks.planner;
 
 import com.starrocks.common.Config;
@@ -432,5 +446,43 @@ public class ViewBaseMvRewriteTest extends MaterializedViewTestBase {
         }
         starRocksAssert.dropView("view_1");
         starRocksAssert.dropView("view_2");
+    }
+
+    @Test
+    public void testSingleCte() throws Exception {
+        String createViewSql = "CREATE VIEW `v_q15` (`s_suppkey`, `s_name`, `s_address`, `s_phone`, `total_revenue`) AS " +
+                "WITH `revenue0` (`supplier_no`, `total_revenue`)" +
+                " AS (" +
+                "SELECT " +
+                "   `lineitem`.`l_suppkey`, " +
+                "   sum(`lineitem`.`l_extendedprice` * (1 - `lineitem`.`l_discount`)) " +
+                "       AS `sum(l_extendedprice * (1 - l_discount))`\n" +
+                "FROM `lineitem`\n" +
+                "WHERE (`lineitem`.`l_shipdate` >= '1996-01-01') " +
+                "   AND (`lineitem`.`l_shipdate` < ('1996-01-01 00:00:00' + INTERVAL '3' MONTH))\n" +
+                "GROUP BY `lineitem`.`l_suppkey`)" +
+                " SELECT " +
+                "   `supplier`.`s_suppkey`, " +
+                "   `supplier`.`s_name`, " +
+                "   `supplier`.`s_address`, " +
+                "   `supplier`.`s_phone`, " +
+                "   `revenue0`.`total_revenue`\n" +
+                "FROM `supplier` , `revenue0`\n" +
+                "WHERE (`supplier`.`s_suppkey` = `revenue0`.`supplier_no`) " +
+                "   AND (`revenue0`.`total_revenue` = ((SELECT max(`revenue0`.`total_revenue`) AS `max(total_revenue)`\n" +
+                "FROM `revenue0`))) " +
+                "ORDER BY `supplier`.`s_suppkey` ASC ;";
+
+        starRocksAssert.withView(createViewSql);
+
+        String createMvSql = "create materialized view mv_q15 " +
+                "refresh manual " +
+                "as " +
+                "select * from v_q15";
+        starRocksAssert.withMaterializedView(createMvSql);
+        {
+            String query = "select * from v_q15";
+            sql(query).contains("mv_q15");
+        }
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/TPCDSPlanTestBase.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/TPCDSPlanTestBase.java
@@ -25,6 +25,7 @@ import java.io.FileReader;
 import java.io.IOException;
 import java.lang.reflect.Field;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Objects;
 
@@ -56,6 +57,9 @@ public class TPCDSPlanTestBase extends PlanTestBase {
             .put("web_site", 30L)
             .build();
 
+    // query name -> query sql
+    private static final Map<String, String> SQL_MAP = new LinkedHashMap<>();
+
     public void setTPCDSFactor(int factor) {
         ROW_COUNT_MAP.forEach((t, v) -> {
             OlapTable table = getOlapTable(t);
@@ -82,6 +86,14 @@ public class TPCDSPlanTestBase extends PlanTestBase {
         });
     }
 
+    public static Map<String, String> getSqlMap() {
+        return SQL_MAP;
+    }
+
+    public static String getSql(String queryName) {
+        return SQL_MAP.get(queryName);
+    }
+
     @BeforeClass
     public static void beforeClass() throws Exception {
         PlanTestBase.beforeClass();
@@ -93,7 +105,8 @@ public class TPCDSPlanTestBase extends PlanTestBase {
 
     private static String from(String name) {
         String path = Objects.requireNonNull(ClassLoader.getSystemClassLoader().getResource("sql")).getPath();
-        File file = new File(path + "/tpcds/query" + name + ".sql");
+        String queryName = "query" + name;
+        File file = new File(path + "/tpcds/" + queryName + ".sql");
         StringBuilder sb = new StringBuilder();
         try (BufferedReader reader = new BufferedReader(new FileReader(file))) {
             String str;
@@ -103,7 +116,9 @@ public class TPCDSPlanTestBase extends PlanTestBase {
         } catch (IOException e) {
             throw new RuntimeException(e);
         }
-        return sb.toString();
+        String sql = sb.toString();
+        SQL_MAP.put(queryName, sql);
+        return sql;
     }
 
     public static final String Q01 = from("01");
@@ -149,6 +164,8 @@ public class TPCDSPlanTestBase extends PlanTestBase {
     public static final String Q38 = from("38");
     public static final String Q39_1 = from("39-1");
     public static final String Q39_2 = from("39-2");
+    public static final String Q39_1_2 = from("39-1-2");
+    public static final String Q39_2_2 = from("39-2-2");
     public static final String Q40 = from("40");
     public static final String Q41 = from("41");
     public static final String Q42 = from("42");
@@ -174,6 +191,7 @@ public class TPCDSPlanTestBase extends PlanTestBase {
     public static final String Q62 = from("62");
     public static final String Q63 = from("63");
     public static final String Q64 = from("64");
+    public static final String Q64_2 = from("64-2");
     public static final String Q65 = from("65");
     public static final String Q66 = from("66");
     public static final String Q67 = from("67");

--- a/fe/fe-core/src/test/resources/sql/tpcds/query39-1-2.sql
+++ b/fe/fe-core/src/test/resources/sql/tpcds/query39-1-2.sql
@@ -1,0 +1,26 @@
+-- query 39-1-1, resolve duplicate names
+with inv as
+(select w_warehouse_name,w_warehouse_sk,i_item_sk,d_moy
+       ,stdev,mean, case mean when 0 then null else stdev/mean end cov
+ from(select w_warehouse_name,w_warehouse_sk,i_item_sk,d_moy
+            ,stddev_samp(inv_quantity_on_hand) stdev,avg(inv_quantity_on_hand) mean
+      from inventory
+          ,item
+          ,warehouse
+          ,date_dim
+      where inv_item_sk = i_item_sk
+        and inv_warehouse_sk = w_warehouse_sk
+        and inv_date_sk = d_date_sk
+        and d_year =2001
+      group by w_warehouse_name,w_warehouse_sk,i_item_sk,d_moy) foo
+ where case mean when 0 then 0 else stdev/mean end > 1)
+select inv1.w_warehouse_sk w_warehouse_sk_1,inv1.i_item_sk i_item_sk_1,inv1.d_moy d_moy_1,inv1.mean mean_1, inv1.cov cov_1
+        ,inv2.w_warehouse_sk w_warehouse_sk_2,inv2.i_item_sk i_item_sk_2,inv2.d_moy d_moy_2,inv2.mean mean_2, inv2.cov cov_2
+from inv inv1,inv inv2
+where inv1.i_item_sk = inv2.i_item_sk
+  and inv1.w_warehouse_sk =  inv2.w_warehouse_sk
+  and inv1.d_moy=1
+  and inv2.d_moy=1+1
+order by inv1.w_warehouse_sk,inv1.i_item_sk,inv1.d_moy,inv1.mean,inv1.cov
+        ,inv2.d_moy,inv2.mean, inv2.cov
+;

--- a/fe/fe-core/src/test/resources/sql/tpcds/query39-2-2.sql
+++ b/fe/fe-core/src/test/resources/sql/tpcds/query39-2-2.sql
@@ -1,0 +1,29 @@
+-- query 39-2-2, resolve duplicate names
+with inv as
+(select w_warehouse_name,w_warehouse_sk,i_item_sk,d_moy
+       ,stdev,mean, case mean when 0 then null else stdev/mean end cov
+ from(select w_warehouse_name,w_warehouse_sk,i_item_sk,d_moy
+            ,stddev_samp(inv_quantity_on_hand) stdev,avg(inv_quantity_on_hand) mean
+      from inventory
+          ,item
+          ,warehouse
+          ,date_dim
+      where inv_item_sk = i_item_sk
+        and inv_warehouse_sk = w_warehouse_sk
+        and inv_date_sk = d_date_sk
+        and d_year =2001
+      group by w_warehouse_name,w_warehouse_sk,i_item_sk,d_moy) foo
+ where case mean when 0 then 0 else stdev/mean end > 1)
+select inv1.w_warehouse_sk w_warehouse_sk_1,inv1.i_item_sk i_item_sk_1,inv1.d_moy d_moy_1,inv1.mean mean_1, inv1.cov cov_1
+     ,inv2.w_warehouse_sk w_warehouse_sk_2,inv2.i_item_sk i_item_sk_2,inv2.d_moy d_moy_2,inv2.mean mean_2, inv2.cov cov_2
+from inv inv1,inv inv2
+where inv1.i_item_sk = inv2.i_item_sk
+  and inv1.w_warehouse_sk =  inv2.w_warehouse_sk
+  and inv1.d_moy=1
+  and inv2.d_moy=1+1
+  and inv1.cov > 1.5
+order by inv1.w_warehouse_sk,inv1.i_item_sk,inv1.d_moy,inv1.mean,inv1.cov
+        ,inv2.d_moy,inv2.mean, inv2.cov
+;
+
+

--- a/fe/fe-core/src/test/resources/sql/tpcds/query64-2.sql
+++ b/fe/fe-core/src/test/resources/sql/tpcds/query64-2.sql
@@ -1,0 +1,121 @@
+-- query 64-2, resolve duplicate names
+with cs_ui as
+ (select cs_item_sk
+        ,sum(cs_ext_list_price) as sale,sum(cr_refunded_cash+cr_reversed_charge+cr_store_credit) as refund
+  from catalog_sales
+      ,catalog_returns
+  where cs_item_sk = cr_item_sk
+    and cs_order_number = cr_order_number
+  group by cs_item_sk
+  having sum(cs_ext_list_price)>2*sum(cr_refunded_cash+cr_reversed_charge+cr_store_credit)),
+cross_sales as
+ (select i_product_name product_name
+     ,i_item_sk item_sk
+     ,s_store_name store_name
+     ,s_zip store_zip
+     ,ad1.ca_street_number b_street_number
+     ,ad1.ca_street_name b_street_name
+     ,ad1.ca_city b_city
+     ,ad1.ca_zip b_zip
+     ,ad2.ca_street_number c_street_number
+     ,ad2.ca_street_name c_street_name
+     ,ad2.ca_city c_city
+     ,ad2.ca_zip c_zip
+     ,d1.d_year as syear
+     ,d2.d_year as fsyear
+     ,d3.d_year s2year
+     ,count(*) cnt
+     ,sum(ss_wholesale_cost) s1
+     ,sum(ss_list_price) s2
+     ,sum(ss_coupon_amt) s3
+  FROM   store_sales
+        ,store_returns
+        ,cs_ui
+        ,date_dim d1
+        ,date_dim d2
+        ,date_dim d3
+        ,store
+        ,customer
+        ,customer_demographics cd1
+        ,customer_demographics cd2
+        ,promotion
+        ,household_demographics hd1
+        ,household_demographics hd2
+        ,customer_address ad1
+        ,customer_address ad2
+        ,income_band ib1
+        ,income_band ib2
+        ,item
+  WHERE  ss_store_sk = s_store_sk AND
+         ss_sold_date_sk = d1.d_date_sk AND
+         ss_customer_sk = c_customer_sk AND
+         ss_cdemo_sk= cd1.cd_demo_sk AND
+         ss_hdemo_sk = hd1.hd_demo_sk AND
+         ss_addr_sk = ad1.ca_address_sk and
+         ss_item_sk = i_item_sk and
+         ss_item_sk = sr_item_sk and
+         ss_ticket_number = sr_ticket_number and
+         ss_item_sk = cs_ui.cs_item_sk and
+         c_current_cdemo_sk = cd2.cd_demo_sk AND
+         c_current_hdemo_sk = hd2.hd_demo_sk AND
+         c_current_addr_sk = ad2.ca_address_sk and
+         c_first_sales_date_sk = d2.d_date_sk and
+         c_first_shipto_date_sk = d3.d_date_sk and
+         ss_promo_sk = p_promo_sk and
+         hd1.hd_income_band_sk = ib1.ib_income_band_sk and
+         hd2.hd_income_band_sk = ib2.ib_income_band_sk and
+         cd1.cd_marital_status <> cd2.cd_marital_status and
+         i_color in ('purple','burlywood','indian','spring','floral','medium') and
+         i_current_price between 64 and 64 + 10 and
+         i_current_price between 64 + 1 and 64 + 15
+group by i_product_name
+       ,i_item_sk
+       ,s_store_name
+       ,s_zip
+       ,ad1.ca_street_number
+       ,ad1.ca_street_name
+       ,ad1.ca_city
+       ,ad1.ca_zip
+       ,ad2.ca_street_number
+       ,ad2.ca_street_name
+       ,ad2.ca_city
+       ,ad2.ca_zip
+       ,d1.d_year
+       ,d2.d_year
+       ,d3.d_year
+)
+select cs1.product_name
+     ,cs1.store_name
+     ,cs1.store_zip
+     ,cs1.b_street_number
+     ,cs1.b_street_name
+     ,cs1.b_city
+     ,cs1.b_zip
+     ,cs1.c_street_number
+     ,cs1.c_street_name
+     ,cs1.c_city
+     ,cs1.c_zip
+     ,cs1.syear syear_1
+     ,cs1.cnt cnt_1
+     ,cs1.s1 as s11
+     ,cs1.s2 as s21
+     ,cs1.s3 as s31
+     ,cs2.s1 as s12
+     ,cs2.s2 as s22
+     ,cs2.s3 as s32
+     ,cs2.syear syear_2
+     ,cs2.cnt cnt_2
+from cross_sales cs1,cross_sales cs2
+where cs1.item_sk=cs2.item_sk and
+     cs1.syear = 1999 and
+     cs2.syear = 1999 + 1 and
+     cs2.cnt <= cs1.cnt and
+     cs1.store_name = cs2.store_name and
+     cs1.store_zip = cs2.store_zip
+order by cs1.product_name
+       ,cs1.store_name
+       ,cs2.cnt
+       ,cs1.s1
+       ,cs2.s1;
+
+

--- a/fe/fe-core/src/test/resources/sql/tpchsql/q1.sql
+++ b/fe/fe-core/src/test/resources/sql/tpchsql/q1.sql
@@ -1,0 +1,21 @@
+select
+    l_returnflag,
+    l_linestatus,
+    sum(l_quantity) as sum_qty,
+    sum(l_extendedprice) as sum_base_price,
+    sum(l_extendedprice * (1 - l_discount)) as sum_disc_price,
+    sum(l_extendedprice * (1 - l_discount) * (1 + l_tax)) as sum_charge,
+    avg(l_quantity) as avg_qty,
+    avg(l_extendedprice) as avg_price,
+    avg(l_discount) as avg_disc,
+    count(*) as count_order
+from
+    lineitem
+where
+    l_shipdate <= date '1998-12-01'
+group by
+    l_returnflag,
+    l_linestatus
+order by
+    l_returnflag,
+    l_linestatus ;

--- a/fe/fe-core/src/test/resources/sql/tpchsql/q10.sql
+++ b/fe/fe-core/src/test/resources/sql/tpchsql/q10.sql
@@ -1,0 +1,31 @@
+select
+    c_custkey,
+    c_name,
+    sum(l_extendedprice * (1 - l_discount)) as revenue,
+    c_acctbal,
+    n_name,
+    c_address,
+    c_phone,
+    c_comment
+from
+    customer,
+    orders,
+    lineitem,
+    nation
+where
+        c_custkey = o_custkey
+  and l_orderkey = o_orderkey
+  and o_orderdate >= date '1994-05-01'
+  and o_orderdate < date '1994-08-01'
+  and l_returnflag = 'R'
+  and c_nationkey = n_nationkey
+group by
+    c_custkey,
+    c_name,
+    c_acctbal,
+    c_phone,
+    n_name,
+    c_address,
+    c_comment
+order by
+    revenue desc limit 20;

--- a/fe/fe-core/src/test/resources/sql/tpchsql/q11.sql
+++ b/fe/fe-core/src/test/resources/sql/tpchsql/q11.sql
@@ -1,0 +1,27 @@
+select
+    ps_partkey,
+    sum(ps_supplycost * ps_availqty) as value
+from
+    partsupp,
+    supplier,
+    nation
+where
+    ps_suppkey = s_suppkey
+  and s_nationkey = n_nationkey
+  and n_name = 'PERU'
+group by
+    ps_partkey having
+    sum(ps_supplycost * ps_availqty) > (
+    select
+    sum(ps_supplycost * ps_availqty) * 0.0001000000
+    from
+    partsupp,
+    supplier,
+    nation
+    where
+    ps_suppkey = s_suppkey
+                  and s_nationkey = n_nationkey
+                  and n_name = 'PERU'
+    )
+order by
+    value desc ;

--- a/fe/fe-core/src/test/resources/sql/tpchsql/q12.sql
+++ b/fe/fe-core/src/test/resources/sql/tpchsql/q12.sql
@@ -1,0 +1,28 @@
+select
+    l_shipmode,
+    sum(case
+            when o_orderpriority = '1-URGENT'
+                or o_orderpriority = '2-HIGH'
+                then cast (1 as bigint)
+            else cast(0 as bigint)
+        end) as high_line_count,
+    sum(case
+            when o_orderpriority <> '1-URGENT'
+                and o_orderpriority <> '2-HIGH'
+                then cast (1 as bigint)
+            else cast(0 as bigint)
+        end) as low_line_count
+from
+    orders,
+    lineitem
+where
+        o_orderkey = l_orderkey
+  and l_shipmode in ('REG AIR', 'MAIL')
+  and l_commitdate < l_receiptdate
+  and l_shipdate < l_commitdate
+  and l_receiptdate >= date '1997-01-01'
+  and l_receiptdate < date '1998-01-01'
+group by
+    l_shipmode
+order by
+    l_shipmode ;

--- a/fe/fe-core/src/test/resources/sql/tpchsql/q13.sql
+++ b/fe/fe-core/src/test/resources/sql/tpchsql/q13.sql
@@ -1,0 +1,20 @@
+select
+    c_count,
+    count(*) as custdist
+from
+    (
+        select
+            c_custkey,
+            count(o_orderkey) as c_count
+        from
+            customer left outer join orders on
+                        c_custkey = o_custkey
+                    and o_comment not like '%unusual%deposits%'
+        group by
+            c_custkey
+    ) a
+group by
+    c_count
+order by
+    custdist desc,
+    c_count desc ;

--- a/fe/fe-core/src/test/resources/sql/tpchsql/q14.sql
+++ b/fe/fe-core/src/test/resources/sql/tpchsql/q14.sql
@@ -1,0 +1,13 @@
+select
+            100.00 * sum(case
+                             when p_type like 'PROMO%'
+                                 then l_extendedprice * (1 - l_discount)
+                             else 0
+            end) / sum(l_extendedprice * (1 - l_discount)) as promo_revenue
+from
+    lineitem,
+    part
+where
+        l_partkey = p_partkey
+  and l_shipdate >= date '1997-02-01'
+  and l_shipdate < date '1997-03-01';

--- a/fe/fe-core/src/test/resources/sql/tpchsql/q15.sql
+++ b/fe/fe-core/src/test/resources/sql/tpchsql/q15.sql
@@ -1,0 +1,37 @@
+select
+    s_suppkey,
+    s_name,
+    s_address,
+    s_phone,
+    total_revenue
+from
+    supplier,
+    (	select
+             l_suppkey as supplier_no,
+             sum(l_extendedprice * (1 - l_discount)) as total_revenue
+         from
+             lineitem
+         where
+                 l_shipdate >= date '1995-07-01'
+           and l_shipdate < date '1995-10-01'
+         group by
+             l_suppkey) a
+where
+        s_suppkey = supplier_no
+  and total_revenue = (
+    select
+        max(total_revenue)
+    from
+        (	select
+                 l_suppkey as supplier_no,
+                 sum(l_extendedprice * (1 - l_discount)) as total_revenue
+             from
+                 lineitem
+             where
+                     l_shipdate >= date '1995-07-01'
+               and l_shipdate < date '1995-10-01'
+             group by
+                 l_suppkey) b
+)
+order by
+    s_suppkey;

--- a/fe/fe-core/src/test/resources/sql/tpchsql/q16.sql
+++ b/fe/fe-core/src/test/resources/sql/tpchsql/q16.sql
@@ -1,0 +1,31 @@
+select
+    p_brand,
+    p_type,
+    p_size,
+    count(distinct ps_suppkey) as supplier_cnt
+from
+    partsupp,
+    part
+where
+        p_partkey = ps_partkey
+  and p_brand <> 'Brand#43'
+  and p_type not like 'PROMO BURNISHED%'
+  and p_size in (31, 43, 9, 6, 18, 11, 25, 1)
+  and ps_suppkey not in (
+    select
+        s_suppkey
+    from
+        supplier
+    where
+            s_comment like '%Customer%Complaints%'
+)
+group by
+    p_brand,
+    p_type,
+    p_size
+order by
+    supplier_cnt desc,
+    p_brand,
+    p_type,
+    p_size ;
+

--- a/fe/fe-core/src/test/resources/sql/tpchsql/q17.sql
+++ b/fe/fe-core/src/test/resources/sql/tpchsql/q17.sql
@@ -1,0 +1,17 @@
+select
+        sum(l_extendedprice) / 7.0 as avg_yearly
+from
+    lineitem,
+    part
+where
+        p_partkey = l_partkey
+  and p_brand = 'Brand#35'
+  and p_container = 'JUMBO CASE'
+  and l_quantity < (
+    select
+            0.2 * avg(l_quantity)
+    from
+        lineitem
+    where
+            l_partkey = p_partkey
+) ;

--- a/fe/fe-core/src/test/resources/sql/tpchsql/q18.sql
+++ b/fe/fe-core/src/test/resources/sql/tpchsql/q18.sql
@@ -1,0 +1,32 @@
+select
+    c_name,
+    c_custkey,
+    o_orderkey,
+    o_orderdate,
+    o_totalprice,
+    sum(l_quantity)
+from
+    customer,
+    orders,
+    lineitem
+where
+        o_orderkey in (
+        select
+            l_orderkey
+        from
+            lineitem
+        group by
+            l_orderkey having
+                sum(l_quantity) > 315
+    )
+  and c_custkey = o_custkey
+  and o_orderkey = l_orderkey
+group by
+    c_name,
+    c_custkey,
+    o_orderkey,
+    o_orderdate,
+    o_totalprice
+order by
+    o_totalprice desc,
+    o_orderdate limit 100;

--- a/fe/fe-core/src/test/resources/sql/tpchsql/q19.sql
+++ b/fe/fe-core/src/test/resources/sql/tpchsql/q19.sql
@@ -1,0 +1,35 @@
+select
+    sum(l_extendedprice* (1 - l_discount)) as revenue
+from
+    lineitem,
+    part
+where
+    (
+                p_partkey = l_partkey
+            and p_brand = 'Brand#45'
+            and p_container in ('SM CASE', 'SM BOX', 'SM PACK', 'SM PKG')
+            and l_quantity >= 5 and l_quantity <= 5 + 10
+            and p_size between 1 and 5
+            and l_shipmode in ('AIR', 'AIR REG')
+            and l_shipinstruct = 'DELIVER IN PERSON'
+        )
+   or
+    (
+                p_partkey = l_partkey
+            and p_brand = 'Brand#11'
+            and p_container in ('MED BAG', 'MED BOX', 'MED PKG', 'MED PACK')
+            and l_quantity >= 15 and l_quantity <= 15 + 10
+            and p_size between 1 and 10
+            and l_shipmode in ('AIR', 'AIR REG')
+            and l_shipinstruct = 'DELIVER IN PERSON'
+        )
+   or
+    (
+                p_partkey = l_partkey
+            and p_brand = 'Brand#21'
+            and p_container in ('LG CASE', 'LG BOX', 'LG PACK', 'LG PKG')
+            and l_quantity >= 25 and l_quantity <= 25 + 10
+            and p_size between 1 and 15
+            and l_shipmode in ('AIR', 'AIR REG')
+            and l_shipinstruct = 'DELIVER IN PERSON'
+    ) ;

--- a/fe/fe-core/src/test/resources/sql/tpchsql/q2.sql
+++ b/fe/fe-core/src/test/resources/sql/tpchsql/q2.sql
@@ -1,0 +1,44 @@
+select
+    s_acctbal,
+    s_name,
+    n_name,
+    p_partkey,
+    p_mfgr,
+    s_address,
+    s_phone,
+    s_comment
+from
+    part,
+    supplier,
+    partsupp,
+    nation,
+    region
+where
+        p_partkey = ps_partkey
+  and s_suppkey = ps_suppkey
+  and p_size = 12
+  and p_type like '%COPPER'
+  and s_nationkey = n_nationkey
+  and n_regionkey = r_regionkey
+  and r_name = 'AMERICA'
+  and ps_supplycost = (
+    select
+        min(ps_supplycost)
+    from
+        partsupp,
+        supplier,
+        nation,
+        region
+    where
+            p_partkey = ps_partkey
+      and s_suppkey = ps_suppkey
+      and s_nationkey = n_nationkey
+      and n_regionkey = r_regionkey
+      and r_name = 'AMERICA'
+)
+order by
+    s_acctbal desc,
+    n_name,
+    s_name,
+    p_partkey limit 100;
+

--- a/fe/fe-core/src/test/resources/sql/tpchsql/q20.sql
+++ b/fe/fe-core/src/test/resources/sql/tpchsql/q20.sql
@@ -1,0 +1,38 @@
+select
+    s_name,
+    s_address
+from
+    supplier,
+    nation
+where
+        s_suppkey in (
+        select
+            ps_suppkey
+        from
+            partsupp
+        where
+                ps_partkey in (
+                select
+                    p_partkey
+                from
+                    part
+                where
+                        p_name like 'sienna%'
+            )
+          and ps_availqty > (
+            select
+                    0.5 * sum(l_quantity)
+            from
+                lineitem
+            where
+                    l_partkey = ps_partkey
+              and l_suppkey = ps_suppkey
+              and l_shipdate >= date '1993-01-01'
+              and l_shipdate < date '1994-01-01'
+        )
+    )
+  and s_nationkey = n_nationkey
+  and n_name = 'ARGENTINA'
+order by
+    s_name ;
+

--- a/fe/fe-core/src/test/resources/sql/tpchsql/q21.sql
+++ b/fe/fe-core/src/test/resources/sql/tpchsql/q21.sql
@@ -1,0 +1,39 @@
+select
+    s_name,
+    count(*) as numwait
+from
+    supplier,
+    lineitem l1,
+    orders,
+    nation
+where
+        s_suppkey = l1.l_suppkey
+  and o_orderkey = l1.l_orderkey
+  and o_orderstatus = 'F'
+  and l1.l_receiptdate > l1.l_commitdate
+  and exists (
+        select
+            *
+        from
+            lineitem l2
+        where
+                l2.l_orderkey = l1.l_orderkey
+          and l2.l_suppkey <> l1.l_suppkey
+    )
+  and not exists (
+        select
+            *
+        from
+            lineitem l3
+        where
+                l3.l_orderkey = l1.l_orderkey
+          and l3.l_suppkey <> l1.l_suppkey
+          and l3.l_receiptdate > l3.l_commitdate
+    )
+  and s_nationkey = n_nationkey
+  and n_name = 'CANADA'
+group by
+    s_name
+order by
+    numwait desc,
+    s_name limit 100;

--- a/fe/fe-core/src/test/resources/sql/tpchsql/q22.sql
+++ b/fe/fe-core/src/test/resources/sql/tpchsql/q22.sql
@@ -1,0 +1,37 @@
+select
+    cntrycode,
+    count(*) as numcust,
+    sum(c_acctbal) as totacctbal
+from
+    (
+        select
+            substring(c_phone , 1  ,2) as cntrycode,
+            c_acctbal
+        from
+            customer
+        where
+                substring(c_phone , 1  ,2)  in
+                ('21', '28', '24', '32', '35', '34', '37')
+          and c_acctbal > (
+            select
+                avg(c_acctbal)
+            from
+                customer
+            where
+                    c_acctbal > 0.00
+              and substring(c_phone , 1  ,2)  in
+                  ('21', '28', '24', '32', '35', '34', '37')
+        )
+          and not exists (
+                select
+                    *
+                from
+                    orders
+                where
+                        o_custkey = c_custkey
+            )
+    ) as custsale
+group by
+    cntrycode
+order by
+    cntrycode ;

--- a/fe/fe-core/src/test/resources/sql/tpchsql/q3.sql
+++ b/fe/fe-core/src/test/resources/sql/tpchsql/q3.sql
@@ -1,0 +1,23 @@
+select
+    l_orderkey,
+    sum(l_extendedprice * (1 - l_discount)) as revenue,
+    o_orderdate,
+    o_shippriority
+from
+    customer,
+    orders,
+    lineitem
+where
+  c_mktsegment = 'HOUSEHOLD'
+  and c_custkey = o_custkey
+  and l_orderkey = o_orderkey
+  and o_orderdate < date '1995-03-11'
+  and l_shipdate > date '1995-03-11'
+group by
+    l_orderkey,
+    o_orderdate,
+    o_shippriority
+order by
+    revenue desc,
+    o_orderdate limit 10;
+

--- a/fe/fe-core/src/test/resources/sql/tpchsql/q4.sql
+++ b/fe/fe-core/src/test/resources/sql/tpchsql/q4.sql
@@ -1,0 +1,21 @@
+select
+    o_orderpriority,
+    count(*) as order_count
+from
+    orders
+where
+        o_orderdate >= date '1994-09-01'
+  and o_orderdate < date '1994-12-01'
+  and exists (
+        select
+            *
+        from
+            lineitem
+        where
+                l_orderkey = o_orderkey
+          and l_receiptdate > l_commitdate
+    )
+group by
+    o_orderpriority
+order by
+    o_orderpriority ;

--- a/fe/fe-core/src/test/resources/sql/tpchsql/q5.sql
+++ b/fe/fe-core/src/test/resources/sql/tpchsql/q5.sql
@@ -1,0 +1,24 @@
+select
+    n_name,
+    sum(l_extendedprice * (1 - l_discount)) as revenue
+from
+    customer,
+    orders,
+    lineitem,
+    supplier,
+    nation,
+    region
+where
+        c_custkey = o_custkey
+  and l_orderkey = o_orderkey
+  and l_suppkey = s_suppkey
+  and c_nationkey = s_nationkey
+  and s_nationkey = n_nationkey
+  and n_regionkey = r_regionkey
+  and r_name = 'AFRICA'
+  and o_orderdate >= date '1995-01-01'
+  and o_orderdate < date '1996-01-01'
+group by
+    n_name
+order by
+    revenue desc ;

--- a/fe/fe-core/src/test/resources/sql/tpchsql/q6.sql
+++ b/fe/fe-core/src/test/resources/sql/tpchsql/q6.sql
@@ -1,0 +1,9 @@
+select
+    sum(l_extendedprice * l_discount) as revenue
+from
+    lineitem
+where
+        l_shipdate >= date '1995-01-01'
+  and l_shipdate < date '1996-01-01'
+  and l_discount between 0.02 and 0.04
+  and l_quantity < 24 ;

--- a/fe/fe-core/src/test/resources/sql/tpchsql/q7.sql
+++ b/fe/fe-core/src/test/resources/sql/tpchsql/q7.sql
@@ -1,0 +1,39 @@
+select
+    supp_nation,
+    cust_nation,
+    l_year,
+    sum(volume) as revenue
+from
+    (
+        select
+            n1.n_name as supp_nation,
+            n2.n_name as cust_nation,
+            extract(year from l_shipdate) as l_year,
+            l_extendedprice * (1 - l_discount) as volume
+        from
+            supplier,
+            lineitem,
+            orders,
+            customer,
+            nation n1,
+            nation n2
+        where
+                s_suppkey = l_suppkey
+          and o_orderkey = l_orderkey
+          and c_custkey = o_custkey
+          and s_nationkey = n1.n_nationkey
+          and c_nationkey = n2.n_nationkey
+          and (
+                (n1.n_name = 'CANADA' and n2.n_name = 'IRAN')
+                or (n1.n_name = 'IRAN' and n2.n_name = 'CANADA')
+            )
+          and l_shipdate between date '1995-01-01' and date '1996-12-31'
+    ) as shipping
+group by
+    supp_nation,
+    cust_nation,
+    l_year
+order by
+    supp_nation,
+    cust_nation,
+    l_year ;

--- a/fe/fe-core/src/test/resources/sql/tpchsql/q8.sql
+++ b/fe/fe-core/src/test/resources/sql/tpchsql/q8.sql
@@ -1,0 +1,37 @@
+select
+    o_year,
+    sum(case
+            when nation = 'IRAN' then volume
+            else 0
+        end) / sum(volume) as mkt_share
+from
+    (
+        select
+            extract(year from o_orderdate) as o_year,
+            l_extendedprice * (1 - l_discount) as volume,
+            n2.n_name as nation
+        from
+            part,
+            supplier,
+            lineitem,
+            orders,
+            customer,
+            nation n1,
+            nation n2,
+            region
+        where
+                p_partkey = l_partkey
+          and s_suppkey = l_suppkey
+          and l_orderkey = o_orderkey
+          and o_custkey = c_custkey
+          and c_nationkey = n1.n_nationkey
+          and n1.n_regionkey = r_regionkey
+          and r_name = 'MIDDLE EAST'
+          and s_nationkey = n2.n_nationkey
+          and o_orderdate between date '1995-01-01' and date '1996-12-31'
+          and p_type = 'ECONOMY ANODIZED STEEL'
+    ) as all_nations
+group by
+    o_year
+order by
+    o_year ;

--- a/fe/fe-core/src/test/resources/sql/tpchsql/q9.sql
+++ b/fe/fe-core/src/test/resources/sql/tpchsql/q9.sql
@@ -1,0 +1,32 @@
+select
+    nation,
+    o_year,
+    sum(amount) as sum_profit
+from
+    (
+        select
+            n_name as nation,
+            extract(year from o_orderdate) as o_year,
+            l_extendedprice * (1 - l_discount) - ps_supplycost * l_quantity as amount
+        from
+            part,
+            supplier,
+            lineitem,
+            partsupp,
+            orders,
+            nation
+        where
+                s_suppkey = l_suppkey
+          and ps_suppkey = l_suppkey
+          and ps_partkey = l_partkey
+          and p_partkey = l_partkey
+          and o_orderkey = l_orderkey
+          and s_nationkey = n_nationkey
+          and p_name like '%peru%'
+    ) as profit
+group by
+    nation,
+    o_year
+order by
+    nation,
+    o_year desc ;


### PR DESCRIPTION
Why I'm doing:
when views have multi ctes, view based rewrite will failed. And There are rule conflicts for mv optimizer.

What I'm doing:
support view with ctes in view based mv rewrite, and resolve rule conflicts, and add more view based mv rewrite uts on tpch and tpcds

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [x] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5

