### PR TITLE
[Enhancement] Get update partitions for iceberg table analyze with partition update time

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/IcebergTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/IcebergTable.java
@@ -181,7 +181,6 @@ public class IcebergTable extends Table {
         return null;
     }
 
-
     public long nextPartitionId() {
         return partitionIdGen.getAndIncrement();
     }

--- a/fe/fe-core/src/main/java/com/starrocks/connector/ConnectorPartitionTraits.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/ConnectorPartitionTraits.java
@@ -145,7 +145,7 @@ public abstract class ConnectorPartitionTraits {
      */
     abstract Map<String, List<List<String>>> getPartitionList(Column partitionColumn) throws AnalysisException;
 
-    abstract Map<String, PartitionInfo> getPartitionNameWithPartitionInfo();
+    public abstract Map<String, PartitionInfo> getPartitionNameWithPartitionInfo();
 
     /**
      * The max of refresh ts for all partitions
@@ -160,7 +160,7 @@ public abstract class ConnectorPartitionTraits {
 
     // ========================================= Implementations ==============================================
 
-    abstract static class DefaultTraits extends ConnectorPartitionTraits {
+    public abstract static class DefaultTraits extends ConnectorPartitionTraits {
 
         @Override
         public boolean supportPartitionRefresh() {

--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergPartitionUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergPartitionUtils.java
@@ -14,9 +14,7 @@
 
 package com.starrocks.connector.iceberg;
 
-import com.google.common.base.Objects;
 import com.google.common.base.Preconditions;
-import com.google.common.collect.ImmutableSet;
 import com.starrocks.catalog.Column;
 import com.starrocks.catalog.IcebergTable;
 import com.starrocks.catalog.Type;
@@ -24,19 +22,8 @@ import com.starrocks.common.util.TimeUtils;
 import com.starrocks.connector.PartitionUtil;
 import com.starrocks.connector.exception.StarRocksConnectorException;
 import com.starrocks.statistic.StatisticUtils;
-import org.apache.iceberg.AddedRowsScanTask;
-import org.apache.iceberg.ChangelogOperation;
-import org.apache.iceberg.ChangelogScanTask;
-import org.apache.iceberg.DeletedDataFileScanTask;
-import org.apache.iceberg.FileScanTask;
-import org.apache.iceberg.IncrementalChangelogScan;
 import org.apache.iceberg.PartitionField;
-import org.apache.iceberg.PartitionSpec;
 import org.apache.iceberg.Schema;
-import org.apache.iceberg.Snapshot;
-import org.apache.iceberg.StructLike;
-import org.apache.iceberg.Table;
-import org.apache.iceberg.io.CloseableIterable;
 import org.apache.iceberg.types.Types;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -46,106 +33,9 @@ import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
-import java.util.Set;
-import java.util.stream.Collectors;
 
 public class IcebergPartitionUtils {
     private static final Logger LOG = LogManager.getLogger(IcebergPartitionUtils.class);
-    public static class IcebergPartition {
-        private PartitionSpec spec;
-        private StructLike data;
-        private ChangelogOperation operation;
-
-        IcebergPartition(PartitionSpec spec, StructLike data, ChangelogOperation operation) {
-            this.spec = spec;
-            this.data = data;
-            this.operation = operation;
-        }
-
-        @Override
-        public boolean equals(Object o) {
-            if (this == o) {
-                return true;
-            }
-            if (!(o instanceof IcebergPartition)) {
-                return false;
-            }
-            IcebergPartition that = (IcebergPartition) o;
-            return Objects.equal(spec, that.spec) &&
-                    Objects.equal(data, that.data) && operation == that.operation;
-        }
-
-        @Override
-        public int hashCode() {
-            return Objects.hashCode(spec, data, operation);
-        }
-    }
-
-    public static Set<String> getChangedPartitionNames(Table table, long fromTimestampMillis,
-                                                       Snapshot toSnapshot) {
-        Set<IcebergPartition> changedPartition = getChangedPartition(table, fromTimestampMillis,
-                toSnapshot);
-        return changedPartition.stream().map(partition -> PartitionUtil.
-                convertIcebergPartitionToPartitionName(table.spec(), partition.data)).collect(Collectors.toSet());
-    }
-
-    public static Set<IcebergPartition> getChangedPartition(Table table, long fromExclusiveTimestampMillis,
-                                                            Snapshot toSnapshot) {
-        ImmutableSet.Builder<IcebergPartition> builder = ImmutableSet.builder();
-        Snapshot snapShot = toSnapshot;
-        if (toSnapshot.timestampMillis() >= fromExclusiveTimestampMillis) {
-            // find the first snapshot which it's timestampMillis is less than or equals fromExclusiveTimestampMillis
-            while (snapShot.parentId() != null) {
-                snapShot = table.snapshot(snapShot.parentId());
-                // snapshot is null when it's expired
-                if (snapShot == null || snapShot.timestampMillis() <= fromExclusiveTimestampMillis) {
-                    break;
-                }
-            }
-            // get incremental changelog scan when find the first snapshot
-            // which it's timestampMillis is less than fromExclusiveTimestampMillis
-            if (snapShot != null && snapShot.timestampMillis() <= fromExclusiveTimestampMillis) {
-                IncrementalChangelogScan incrementalChangelogScan = table.newIncrementalChangelogScan().
-                        fromSnapshotExclusive(snapShot.snapshotId()).toSnapshot(toSnapshot.snapshotId());
-                try (CloseableIterable<ChangelogScanTask> tasks = incrementalChangelogScan.planFiles()) {
-                    for (ChangelogScanTask task : tasks) {
-                        ChangelogOperation operation = task.operation();
-                        if (operation == ChangelogOperation.INSERT) {
-                            AddedRowsScanTask addedRowsScanTask = (AddedRowsScanTask) task;
-                            StructLike data = addedRowsScanTask.file().partition();
-                            builder.add(new IcebergPartition(addedRowsScanTask.spec(), data, operation));
-                        } else if (operation == ChangelogOperation.DELETE) {
-                            DeletedDataFileScanTask deletedDataFileScanTask = (DeletedDataFileScanTask) task;
-                            StructLike data = deletedDataFileScanTask.file().partition();
-                            builder.add(new IcebergPartition(deletedDataFileScanTask.spec(), data, operation));
-                        } else {
-                            LOG.warn("Do not support this iceberg change log type, operation is {}", operation);
-                        }
-                    }
-                } catch (Exception e) {
-                    LOG.warn("get incrementalChangelogScan failed", e);
-                    return getAllPartition(table);
-                }
-                return builder.build();
-            }
-        }
-
-        return getAllPartition(table);
-    }
-
-    public static Set<IcebergPartition> getAllPartition(Table table) {
-        ImmutableSet.Builder<IcebergPartition> builder = ImmutableSet.builder();
-        try (CloseableIterable<FileScanTask> tasks = table.newScan().planFiles()) {
-            for (FileScanTask task : tasks) {
-                PartitionSpec spec = task.spec();
-                StructLike data = task.partition();
-                builder.add(new IcebergPartition(spec, data, ChangelogOperation.INSERT));
-            }
-        } catch (Exception e) {
-            LOG.warn("get all iceberg partition failed", e);
-        }
-        return builder.build();
-    }
 
     // Normalize partition name to yyyy-MM-dd (Type is Date) or yyyy-MM-dd HH:mm:ss (Type is Datetime)
     // Iceberg partition field transform support year, month, day, hour now,

--- a/fe/fe-core/src/main/java/com/starrocks/statistic/ExternalFullStatisticsCollectJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/statistic/ExternalFullStatisticsCollectJob.java
@@ -206,6 +206,12 @@ public class ExternalFullStatisticsCollectJob extends StatisticsCollectJob {
             return false;
         }
         IcebergTable icebergTable = (IcebergTable) table;
+        if (icebergTable.getNativeTable().specs().size() > 1) {
+            LOG.warn("Do not supported analyze iceberg table {} with partition evolution", table.getName());
+            throw new StarRocksConnectorException("Do not supported analyze iceberg table " + table.getName() +
+                    " with partition evolution");
+        }
+
         PartitionField partitionField = icebergTable.getPartitionField(partitionColumn);
         if (partitionField == null) {
             LOG.warn("Partition column {} not found in table {}", partitionColumn, table.getName());

--- a/fe/fe-core/src/main/java/com/starrocks/statistic/StatisticsCollectJobFactory.java
+++ b/fe/fe-core/src/main/java/com/starrocks/statistic/StatisticsCollectJobFactory.java
@@ -20,14 +20,13 @@ import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.starrocks.catalog.Database;
 import com.starrocks.catalog.HiveTable;
-import com.starrocks.catalog.IcebergTable;
 import com.starrocks.catalog.OlapTable;
 import com.starrocks.catalog.Partition;
 import com.starrocks.catalog.Table;
 import com.starrocks.common.Config;
+import com.starrocks.connector.ConnectorPartitionTraits;
 import com.starrocks.connector.ConnectorTableColumnStats;
 import com.starrocks.connector.PartitionInfo;
-import com.starrocks.connector.iceberg.IcebergPartitionUtils;
 import com.starrocks.monitor.unit.ByteSizeUnit;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.sql.common.ErrorType;
@@ -39,7 +38,6 @@ import org.apache.logging.log4j.Logger;
 import java.time.Clock;
 import java.time.Instant;
 import java.time.LocalDateTime;
-import java.time.ZoneId;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -86,7 +84,8 @@ public class StatisticsCollectJobFactory {
             if (db == null) {
                 return Collections.emptyList();
             }
-            createJob(statsJobs, nativeAnalyzeJob, db, db.getTable(nativeAnalyzeJob.getTableId()), nativeAnalyzeJob.getColumns());
+            createJob(statsJobs, nativeAnalyzeJob, db, db.getTable(nativeAnalyzeJob.getTableId()),
+                    nativeAnalyzeJob.getColumns());
         }
 
         return statsJobs;
@@ -304,12 +303,19 @@ public class StatisticsCollectJobFactory {
                 }
             }
         } else if (table.isIcebergTable()) {
-            IcebergTable icebergTable = (IcebergTable) table;
-            if (statisticsUpdateTime != LocalDateTime.MIN && !icebergTable.isUnPartitioned()) {
-                updatedPartitions.addAll(IcebergPartitionUtils.getChangedPartitionNames(icebergTable.getNativeTable(),
-                        statisticsUpdateTime.atZone(ZoneId.systemDefault()).toInstant().toEpochMilli()
-                                - 60 * 1000L,
-                        icebergTable.getNativeTable().currentSnapshot()));
+            if (statisticsUpdateTime != LocalDateTime.MIN) {
+                ConnectorPartitionTraits.build(table).getPartitionNameWithPartitionInfo().
+                        forEach((partitionName, partitionInfo) -> {
+                            // for external table, we get last modified time from other system, there may be a time
+                            // inconsistency between the two systems, so we add 60 seconds to make sure table update
+                            // time is later than statistics update time
+                            LocalDateTime partitionUpdateTime = LocalDateTime.ofInstant(
+                                    Instant.ofEpochMilli(partitionInfo.getModifiedTime() / 1000).plusSeconds(60),
+                                    Clock.systemDefaultZone().getZone());
+                            if (partitionUpdateTime.isAfter(statisticsUpdateTime)) {
+                                updatedPartitions.add(partitionName);
+                            }
+                        });
             }
         }
         LOG.info("create external full statistics job for table: {}, partitions: {}",
@@ -422,7 +428,8 @@ public class StatisticsCollectJobFactory {
         }
     }
 
-    private static void createSampleStatsJob(List<StatisticsCollectJob> allTableJobMap, NativeAnalyzeJob job, Database db,
+    private static void createSampleStatsJob(List<StatisticsCollectJob> allTableJobMap, NativeAnalyzeJob job,
+                                             Database db,
                                              Table table, List<String> columns) {
         StatisticsCollectJob sample = buildStatisticsCollectJob(db, table, null, columns,
                 StatsConstants.AnalyzeType.SAMPLE, job.getScheduleType(), job.getProperties());

--- a/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/IcebergPartitionUtilsTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/IcebergPartitionUtilsTest.java
@@ -14,7 +14,6 @@
 
 package com.starrocks.connector.iceberg;
 
-import com.google.common.collect.ImmutableSet;
 import com.starrocks.catalog.Type;
 import com.starrocks.common.util.TimeUtils;
 import com.starrocks.qe.ConnectContext;
@@ -22,18 +21,13 @@ import com.starrocks.sql.plan.ConnectorPlanTestBase;
 import com.starrocks.utframe.UtFrameUtils;
 import mockit.Mock;
 import mockit.MockUp;
-import org.apache.iceberg.ChangelogOperation;
-import org.apache.iceberg.PartitionData;
 import org.apache.iceberg.PartitionField;
-import org.apache.iceberg.PartitionSpec;
-import org.apache.iceberg.types.Types;
 import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 
-import java.util.Set;
 import java.util.TimeZone;
 
 public class IcebergPartitionUtilsTest extends TableTestBase {
@@ -46,34 +40,6 @@ public class IcebergPartitionUtilsTest extends TableTestBase {
         UtFrameUtils.createMinStarRocksCluster();
         connectContext = UtFrameUtils.createDefaultCtx();
         ConnectorPlanTestBase.mockAllCatalogs(connectContext, temp.newFolder().toURI().toString());
-    }
-
-    @Test
-    public void testIcebergPartition() {
-        PartitionSpec spec = PartitionSpec.unpartitioned();
-        Types.StructType structType1 = Types.StructType.of(
-                Types.NestedField.required(1, "id", Types.IntegerType.get()),
-                Types.NestedField.required(2, "name", Types.StringType.get())
-        );
-        PartitionData data1 = new PartitionData(structType1);
-        IcebergPartitionUtils.IcebergPartition partition1 =
-                new IcebergPartitionUtils.IcebergPartition(spec, data1, ChangelogOperation.INSERT);
-
-        Types.StructType structType2 = Types.StructType.of(
-                Types.NestedField.required(1, "id", Types.IntegerType.get()),
-                Types.NestedField.required(2, "name", Types.StringType.get()),
-                Types.NestedField.required(3, "age", Types.IntegerType.get())
-        );
-        PartitionData data2 = new PartitionData(structType2);
-        IcebergPartitionUtils.IcebergPartition partition2 =
-                new IcebergPartitionUtils.IcebergPartition(spec, data2, ChangelogOperation.INSERT);
-
-        IcebergPartitionUtils.IcebergPartition partition3 = partition1;
-        Assert.assertEquals(partition3, partition1);
-        Assert.assertNotEquals(partition1, partition2);
-
-        Set<IcebergPartitionUtils.IcebergPartition> set = ImmutableSet.of(partition1, partition2, partition3);
-        Assert.assertEquals(2, set.size());
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/statistic/StatisticsCollectJobTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/statistic/StatisticsCollectJobTest.java
@@ -18,7 +18,6 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
-import com.google.common.collect.Sets;
 import com.starrocks.catalog.Database;
 import com.starrocks.catalog.IcebergTable;
 import com.starrocks.catalog.InternalCatalog;
@@ -27,9 +26,10 @@ import com.starrocks.catalog.Partition;
 import com.starrocks.catalog.Table;
 import com.starrocks.common.Config;
 import com.starrocks.common.jmockit.Deencapsulation;
+import com.starrocks.connector.ConnectorPartitionTraits;
 import com.starrocks.connector.ConnectorTableColumnStats;
+import com.starrocks.connector.PartitionInfo;
 import com.starrocks.connector.exception.StarRocksConnectorException;
-import com.starrocks.connector.iceberg.IcebergPartitionUtils;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.sql.optimizer.statistics.CachedStatisticStorage;
@@ -42,7 +42,6 @@ import mockit.Mock;
 import mockit.MockUp;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.iceberg.PartitionField;
-import org.apache.iceberg.Snapshot;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.BeforeClass;
@@ -57,10 +56,8 @@ import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 import java.util.stream.Collectors;
 
 public class StatisticsCollectJobTest extends PlanTestNoneDBBase {
@@ -736,6 +733,7 @@ public class StatisticsCollectJobTest extends PlanTestNoneDBBase {
         Assert.assertEquals(0, statsJobs.size());
 
         // test collect statistics time before table update time
+        LocalDateTime statsUpdateTime = LocalDateTime.now().minusHours(2);
         new MockUp<AnalyzeMgr>() {
             @Mock
             public Map<AnalyzeMgr.StatsMetaKey, ExternalBasicStatsMeta> getExternalBasicStatsMetaMap() {
@@ -743,21 +741,23 @@ public class StatisticsCollectJobTest extends PlanTestNoneDBBase {
                 metaMap.put(new AnalyzeMgr.StatsMetaKey("iceberg0", "partitioned_db", "t1"),
                         new ExternalBasicStatsMeta("iceberg0", "partitioned_db", "t1", null,
                                 StatsConstants.AnalyzeType.FULL,
-                                LocalDateTime.now().minusHours(2), Maps.newHashMap()));
+                                statsUpdateTime, Maps.newHashMap()));
                 return metaMap;
             }
         };
-
-        new MockUp<IcebergPartitionUtils>() {
+        new MockUp<ConnectorPartitionTraits.DefaultTraits>() {
             @Mock
-            public Set<String> getChangedPartitionNames(org.apache.iceberg.Table table, long fromTimestampMillis,
-                                                               Snapshot toSnapshot) {
-                return new HashSet<>();
+            public Map<String, PartitionInfo> getPartitionNameWithPartitionInfo() {
+                return ImmutableMap.of("date=2020-01-01", new com.starrocks.connector.iceberg.Partition(
+                        statsUpdateTime.plusSeconds(2).atZone(Clock.systemDefaultZone().getZone()).
+                                toInstant().toEpochMilli() * 1000));
             }
         };
+
         // the default row count is Config.statistic_auto_collect_small_table_rows - 1, need to collect statistics now
         statsJobs = StatisticsCollectJobFactory.buildExternalStatisticsCollectJob(analyzeJob);
         Assert.assertEquals(1, statsJobs.size());
+        Assert.assertEquals(1, ((ExternalFullStatisticsCollectJob) statsJobs.get(0)).getPartitionNames().size());
 
         // test collect statistics time before table update time, and row count is 100, need to collect statistics
         new MockUp<AnalyzeMgr>() {
@@ -767,7 +767,7 @@ public class StatisticsCollectJobTest extends PlanTestNoneDBBase {
                 metaMap.put(new AnalyzeMgr.StatsMetaKey("iceberg0", "partitioned_db", "t1"),
                         new ExternalBasicStatsMeta("iceberg0", "partitioned_db", "t1", null,
                                 StatsConstants.AnalyzeType.FULL,
-                                LocalDateTime.now().minusHours(2), Maps.newHashMap()));
+                                statsUpdateTime, Maps.newHashMap()));
                 return metaMap;
             }
         };
@@ -778,11 +778,18 @@ public class StatisticsCollectJobTest extends PlanTestNoneDBBase {
                         100));
             }
         };
-        new MockUp<IcebergPartitionUtils>() {
+        new MockUp<ConnectorPartitionTraits.DefaultTraits>() {
             @Mock
-            public Set<String> getChangedPartitionNames(org.apache.iceberg.Table table, long fromTimestampMillis,
-                                                        Snapshot toSnapshot) {
-                return Sets.newHashSet("date=2020-01-01", "date=2020-01-02", "date=2020-01-03");
+            public Map<String, PartitionInfo> getPartitionNameWithPartitionInfo() {
+                long needUpdateTime = statsUpdateTime.plusSeconds(120).
+                        atZone(Clock.systemDefaultZone().getZone()).toInstant().toEpochMilli() * 1000;
+                long noNeedUpdateTime = statsUpdateTime.minusSeconds(120).
+                        atZone(Clock.systemDefaultZone().getZone()).toInstant().toEpochMilli() * 1000;
+                return ImmutableMap.of("date=2020-01-01", new com.starrocks.connector.iceberg.Partition(needUpdateTime),
+                        "date=2020-01-02", new com.starrocks.connector.iceberg.Partition(needUpdateTime),
+                        "date=2020-01-03", new com.starrocks.connector.iceberg.Partition(needUpdateTime),
+                        "date=2020-01-04", new com.starrocks.connector.iceberg.Partition(noNeedUpdateTime),
+                        "date=2020-01-05", new com.starrocks.connector.iceberg.Partition(noNeedUpdateTime));
             }
         };
         statsJobs = StatisticsCollectJobFactory.buildExternalStatisticsCollectJob(analyzeJob);
@@ -1145,6 +1152,29 @@ public class StatisticsCollectJobTest extends PlanTestNoneDBBase {
 
         expectedException.expect(StarRocksConnectorException.class);
         expectedException.expectMessage("Partition column date not found in table iceberg0.partitioned_db.t1");
+        collectJob.buildCollectSQLList(1);
+    }
+
+    @Test
+    public void testExternalFullStatisticsBuildCollectSQLWithException3() {
+        // test partition transform is bucket
+        Database database =
+                connectContext.getGlobalStateMgr().getMetadataMgr().getDb("iceberg0", "partitioned_transforms_db");
+        Table table =
+                connectContext.getGlobalStateMgr().getMetadataMgr().getTable("iceberg0", "partitioned_transforms_db",
+                        "t0_date_month_identity_evolution");
+        ExternalFullStatisticsCollectJob collectJob = (ExternalFullStatisticsCollectJob)
+                StatisticsCollectJobFactory.buildExternalStatisticsCollectJob("iceberg0",
+                        database,
+                        table, null,
+                        Lists.newArrayList("id", "data", "ts"),
+                        StatsConstants.AnalyzeType.FULL,
+                        StatsConstants.ScheduleType.ONCE,
+                        Maps.newHashMap());
+
+        expectedException.expect(StarRocksConnectorException.class);
+        expectedException.expectMessage("Do not supported analyze iceberg table" +
+                " t0_date_month_identity_evolution with partition evolution");
         collectJob.buildCollectSQLList(1);
     }
 


### PR DESCRIPTION
Why I'm doing:
analyze iceberg table use old way to check if partition updated 
What I'm doing:
1. remove unused code in IcebergPartitionUtils
2. disable analyze table for iceberg with partition evolution
Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
