### PR TITLE
[BugFix] Fix wrong read/write stat and metrics

### DIFF
--- a/be/src/io/io_profiler.cpp
+++ b/be/src/io/io_profiler.cpp
@@ -138,6 +138,15 @@ IOStatEntry* IOProfiler::get_context() {
     return current_io_stat;
 }
 
+IOProfiler::IOStat IOProfiler::get_context_io() {
+    if (current_io_stat != nullptr) {
+        return IOStat{current_io_stat->read_ops,  current_io_stat->read_bytes,  0,
+                      current_io_stat->write_ops, current_io_stat->write_bytes, 0};
+    } else {
+        return IOStat{0, 0, 0, 0, 0, 0};
+    }
+}
+
 void IOProfiler::set_context(IOStatEntry* entry) {
     current_io_stat = entry;
 }

--- a/be/src/io/io_profiler.h
+++ b/be/src/io/io_profiler.h
@@ -58,10 +58,12 @@ public:
     static Status start(IOMode op);
     static void stop();
     static void reset();
+    static IOMode get_context_io_mode() { return static_cast<IOMode>(_context_io_mode.load()); }
 
     static void set_context(uint32_t tag, uint64_t tablet_id);
     static void set_context(IOStatEntry* entry);
     static IOStatEntry* get_context();
+    static IOStat get_context_io();
     static void clear_context();
 
     static void take_tls_io_snapshot(IOStat* snapshot);
@@ -89,6 +91,8 @@ public:
         ~Scope() { set_context(_old); }
 
         IOStat current_scoped_tls_io() { return calculate_scoped_tls_io(_tls_io_snapshot); }
+
+        IOStat current_context_io() { return get_context_io(); }
 
     private:
         IOStatEntry* _old{nullptr};

--- a/be/src/io/io_profiler.h
+++ b/be/src/io/io_profiler.h
@@ -101,15 +101,15 @@ public:
 
     static inline void add_read(int64_t bytes, int64_t latency_ns) {
         _add_tls_read(bytes, latency_ns);
-        if (_context_io_mode & IOMode::IOMODE_WRITE) {
-            _add_context_write(bytes);
+        if (_context_io_mode & IOMode::IOMODE_READ) {
+            _add_context_read(bytes);
         }
     }
 
     static inline void add_write(int64_t bytes, int64_t latency_ns) {
         _add_tls_write(bytes, latency_ns);
-        if (_context_io_mode & IOMode::IOMODE_READ) {
-            _add_context_read(bytes);
+        if (_context_io_mode & IOMode::IOMODE_WRITE) {
+            _add_context_write(bytes);
         }
     }
 

--- a/be/src/storage/memtable.cpp
+++ b/be/src/storage/memtable.cpp
@@ -344,7 +344,7 @@ Status MemTable::flush(SegmentPB* seg_info) {
     StarRocksMetrics::instance()->memtable_flush_duration_us.increment(duration_ns / 1000);
     StarRocksMetrics::instance()->memtable_flush_io_time_us.increment(io_stat.write_time_ns / 1000);
     auto flush_bytes = memory_usage();
-    StarRocksMetrics::instance()->memtable_flush_bytes_total.increment(flush_bytes);
+    StarRocksMetrics::instance()->memtable_flush_memory_bytes_total.increment(flush_bytes);
     StarRocksMetrics::instance()->memtable_flush_disk_bytes_total.increment(io_stat.write_bytes);
     VLOG(1) << "memtable of tablet " << _tablet_id << " flush duration: " << duration_ns / 1000 << "us, "
             << "io time: " << io_stat.write_time_ns / 1000 << "us, memory bytes: " << flush_bytes

--- a/be/src/storage/memtable.cpp
+++ b/be/src/storage/memtable.cpp
@@ -345,8 +345,10 @@ Status MemTable::flush(SegmentPB* seg_info) {
     StarRocksMetrics::instance()->memtable_flush_io_time_us.increment(io_stat.write_time_ns / 1000);
     auto flush_bytes = memory_usage();
     StarRocksMetrics::instance()->memtable_flush_bytes_total.increment(flush_bytes);
+    StarRocksMetrics::instance()->memtable_flush_disk_bytes_total.increment(io_stat.write_bytes);
     VLOG(1) << "memtable of tablet " << _tablet_id << " flush duration: " << duration_ns / 1000 << "us, "
-            << "io time: " << io_stat.write_time_ns / 1000 << "us, bytes: " << flush_bytes;
+            << "io time: " << io_stat.write_time_ns / 1000 << "us, memory bytes: " << flush_bytes
+            << ", disk bytes: " << io_stat.write_bytes;
     return Status::OK();
 }
 

--- a/be/src/util/starrocks_metrics.cpp
+++ b/be/src/util/starrocks_metrics.cpp
@@ -56,6 +56,13 @@ StarRocksMetrics::StarRocksMetrics() : _metrics(_s_registry_name) {
 
     REGISTER_STARROCKS_METRIC(memtable_flush_total);
     REGISTER_STARROCKS_METRIC(memtable_flush_duration_us);
+    REGISTER_STARROCKS_METRIC(memtable_flush_io_time_us);
+    REGISTER_STARROCKS_METRIC(memtable_flush_bytes_total);
+    REGISTER_STARROCKS_METRIC(memtable_flush_disk_bytes_total);
+    REGISTER_STARROCKS_METRIC(segment_flush_total);
+    REGISTER_STARROCKS_METRIC(segment_flush_duration_us);
+    REGISTER_STARROCKS_METRIC(segment_flush_io_time_us);
+    REGISTER_STARROCKS_METRIC(segment_flush_bytes_total);
 
     REGISTER_STARROCKS_METRIC(update_rowset_commit_request_total);
     REGISTER_STARROCKS_METRIC(update_rowset_commit_request_failed);

--- a/be/src/util/starrocks_metrics.cpp
+++ b/be/src/util/starrocks_metrics.cpp
@@ -57,7 +57,7 @@ StarRocksMetrics::StarRocksMetrics() : _metrics(_s_registry_name) {
     REGISTER_STARROCKS_METRIC(memtable_flush_total);
     REGISTER_STARROCKS_METRIC(memtable_flush_duration_us);
     REGISTER_STARROCKS_METRIC(memtable_flush_io_time_us);
-    REGISTER_STARROCKS_METRIC(memtable_flush_bytes_total);
+    REGISTER_STARROCKS_METRIC(memtable_flush_memory_bytes_total);
     REGISTER_STARROCKS_METRIC(memtable_flush_disk_bytes_total);
     REGISTER_STARROCKS_METRIC(segment_flush_total);
     REGISTER_STARROCKS_METRIC(segment_flush_duration_us);

--- a/be/src/util/starrocks_metrics.h
+++ b/be/src/util/starrocks_metrics.h
@@ -179,7 +179,10 @@ public:
     METRIC_DEFINE_INT_COUNTER(memtable_flush_total, MetricUnit::OPERATIONS);
     METRIC_DEFINE_INT_COUNTER(memtable_flush_duration_us, MetricUnit::MICROSECONDS);
     METRIC_DEFINE_INT_COUNTER(memtable_flush_io_time_us, MetricUnit::MICROSECONDS);
+    // total memory size of memtables
     METRIC_DEFINE_INT_COUNTER(memtable_flush_bytes_total, MetricUnit::BYTES);
+    // total disk size of memtables which is smaller than memtable_flush_bytes_total because of compression
+    METRIC_DEFINE_INT_COUNTER(memtable_flush_disk_bytes_total, MetricUnit::BYTES);
     METRIC_DEFINE_INT_COUNTER(segment_flush_total, MetricUnit::OPERATIONS);
     METRIC_DEFINE_INT_COUNTER(segment_flush_duration_us, MetricUnit::MICROSECONDS);
     METRIC_DEFINE_INT_COUNTER(segment_flush_io_time_us, MetricUnit::MICROSECONDS);

--- a/be/src/util/starrocks_metrics.h
+++ b/be/src/util/starrocks_metrics.h
@@ -180,8 +180,8 @@ public:
     METRIC_DEFINE_INT_COUNTER(memtable_flush_duration_us, MetricUnit::MICROSECONDS);
     METRIC_DEFINE_INT_COUNTER(memtable_flush_io_time_us, MetricUnit::MICROSECONDS);
     // total memory size of memtables
-    METRIC_DEFINE_INT_COUNTER(memtable_flush_bytes_total, MetricUnit::BYTES);
-    // total disk size of memtables which is smaller than memtable_flush_bytes_total because of compression
+    METRIC_DEFINE_INT_COUNTER(memtable_flush_memory_bytes_total, MetricUnit::BYTES);
+    // total disk size of memtables which is smaller than memtable_flush_memory_bytes_total because of compression
     METRIC_DEFINE_INT_COUNTER(memtable_flush_disk_bytes_total, MetricUnit::BYTES);
     METRIC_DEFINE_INT_COUNTER(segment_flush_total, MetricUnit::OPERATIONS);
     METRIC_DEFINE_INT_COUNTER(segment_flush_duration_us, MetricUnit::MICROSECONDS);

--- a/be/test/CMakeLists.txt
+++ b/be/test/CMakeLists.txt
@@ -182,6 +182,7 @@ set(EXEC_FILES
         ./http/transaction_stream_load_test.cpp
         ./io/array_input_stream_test.cpp
         ./io/compressed_input_stream_test.cpp
+        ./io/io_profiler_test.cpp
         ./io/fd_output_stream_test.cpp
         ./io/s3_output_stream_test.cpp
         ./io/s3_input_stream_test.cpp

--- a/be/test/io/io_profiler_test.cpp
+++ b/be/test/io/io_profiler_test.cpp
@@ -1,0 +1,109 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "io/io_profiler.h"
+
+#include <gtest/gtest.h>
+
+#include "testutil/assert.h"
+
+namespace starrocks {
+
+#define ADD_READ_IO_STAT(stat, bytes, time_ns) \
+    stat.read_ops += 1;                        \
+    stat.read_bytes += bytes;                  \
+    stat.read_time_ns += time_ns
+
+#define ADD_WRITE_IO_STAT(stat, bytes, time_ns) \
+    stat.write_ops += 1;                        \
+    stat.write_bytes += bytes;                  \
+    stat.write_time_ns += time_ns
+
+#define ASSERT_IO_STAT_EQ(expect, actual)                \
+    ASSERT_EQ(expect.read_ops, actual.read_ops);         \
+    ASSERT_EQ(expect.read_bytes, actual.read_bytes);     \
+    ASSERT_EQ(expect.read_time_ns, actual.read_time_ns); \
+    ASSERT_EQ(expect.write_ops, actual.write_ops);       \
+    ASSERT_EQ(expect.write_bytes, actual.write_bytes);   \
+    ASSERT_EQ(expect.write_time_ns, actual.write_time_ns)
+
+TEST(IOProfilerTest, test_tls_io) {
+    auto scope = IOProfiler::scope(IOProfiler::TAG_LOAD, 1);
+    // the init io stat may be not 0, because other test cases maybe have updated the stat
+    auto expect = scope.current_scoped_tls_io();
+
+    IOProfiler::add_read(1, 1000);
+    ADD_READ_IO_STAT(expect, 1, 1000);
+    auto actual1 = scope.current_scoped_tls_io();
+    ASSERT_IO_STAT_EQ(expect, actual1);
+
+    IOProfiler::add_write(2, 200000);
+    ADD_WRITE_IO_STAT(expect, 2, 200000);
+    auto actual2 = scope.current_scoped_tls_io();
+    ASSERT_IO_STAT_EQ(expect, actual2);
+
+    IOProfiler::add_write(1024, 500000);
+    ADD_WRITE_IO_STAT(expect, 1024, 500000);
+    auto actual3 = scope.current_scoped_tls_io();
+    ASSERT_IO_STAT_EQ(expect, actual3);
+
+    IOProfiler::add_read(1048576, 1000000);
+    ADD_READ_IO_STAT(expect, 1048576, 1000000);
+    auto actual4 = scope.current_scoped_tls_io();
+    ASSERT_IO_STAT_EQ(expect, actual4);
+}
+
+TEST(IOProfilerTest, test_context_io) {
+    auto scope = IOProfiler::scope(IOProfiler::TAG_LOAD, 2);
+    auto expect = IOProfiler::IOStat{0, 0, 0, 0, 0, 0};
+
+    // io mode is IOMODE_NONE
+    ASSERT_EQ(IOProfiler::IOMode::IOMODE_NONE, IOProfiler::get_context_io_mode());
+    IOProfiler::add_read(1, 1000);
+    IOProfiler::add_write(1, 1000);
+    ASSERT_IO_STAT_EQ(expect, scope.current_context_io());
+
+    // io mode is IOMODE_READ
+    ASSERT_OK(IOProfiler::start(IOProfiler::IOMode::IOMODE_READ));
+    ASSERT_EQ(IOProfiler::IOMode::IOMODE_READ, IOProfiler::get_context_io_mode());
+    IOProfiler::add_read(2, 2000);
+    ADD_READ_IO_STAT(expect, 2, 0);
+    IOProfiler::add_write(2, 2000);
+    ASSERT_IO_STAT_EQ(expect, scope.current_context_io());
+    IOProfiler::stop();
+    ASSERT_EQ(IOProfiler::IOMode::IOMODE_NONE, IOProfiler::get_context_io_mode());
+
+    // io mode is IOMODE_WRITE
+    ASSERT_OK(IOProfiler::start(IOProfiler::IOMode::IOMODE_WRITE));
+    ASSERT_EQ(IOProfiler::IOMode::IOMODE_WRITE, IOProfiler::get_context_io_mode());
+    IOProfiler::add_read(3, 3000);
+    IOProfiler::add_write(3, 3000);
+    ADD_WRITE_IO_STAT(expect, 3, 0);
+    ASSERT_IO_STAT_EQ(expect, scope.current_context_io());
+    IOProfiler::stop();
+    ASSERT_EQ(IOProfiler::IOMode::IOMODE_NONE, IOProfiler::get_context_io_mode());
+
+    // io mode is IOMODE_ALL
+    ASSERT_OK(IOProfiler::start(IOProfiler::IOMode::IOMODE_ALL));
+    ASSERT_EQ(IOProfiler::IOMode::IOMODE_ALL, IOProfiler::get_context_io_mode());
+    IOProfiler::add_read(4, 4000);
+    ADD_READ_IO_STAT(expect, 4, 0);
+    IOProfiler::add_write(4, 4000);
+    ADD_WRITE_IO_STAT(expect, 4, 0);
+    ASSERT_IO_STAT_EQ(expect, scope.current_context_io());
+    IOProfiler::stop();
+    ASSERT_EQ(IOProfiler::IOMode::IOMODE_NONE, IOProfiler::get_context_io_mode());
+}
+
+} // namespace starrocks

--- a/be/test/storage/memtable_test.cpp
+++ b/be/test/storage/memtable_test.cpp
@@ -524,7 +524,7 @@ TEST_F(MemTableTest, test_metrics) {
     // because other test cases may also update the metrics concurrently if
     // run tests in parallel, and it's hard to get the accurate value
     ASSERT_TRUE(StarRocksMetrics::instance()->memtable_flush_total.value() > 0);
-    ASSERT_TRUE(StarRocksMetrics::instance()->memtable_flush_bytes_total.value() > 0);
+    ASSERT_TRUE(StarRocksMetrics::instance()->memtable_flush_memory_bytes_total.value() > 0);
     ASSERT_TRUE(StarRocksMetrics::instance()->memtable_flush_disk_bytes_total.value() > 0);
 }
 

--- a/be/test/storage/memtable_test.cpp
+++ b/be/test/storage/memtable_test.cpp
@@ -35,6 +35,7 @@
 #include "storage/rowset/rowset_writer.h"
 #include "storage/rowset/rowset_writer_context.h"
 #include "testutil/assert.h"
+#include "util/starrocks_metrics.h"
 
 namespace starrocks {
 
@@ -501,6 +502,30 @@ TEST_F(MemTableTest, testPrimaryKeysSizeLimitCompositePK) {
     auto res = _mem_table->insert(*chunk, indexes.data(), 0, indexes.size());
     ASSERT_TRUE(res.ok());
     ASSERT_FALSE(_mem_table->finalize().ok());
+}
+
+TEST_F(MemTableTest, test_metrics) {
+    const string path = "./MemTableTest_test_metrics";
+    MySetUp(create_tablet_schema("pk int,name varchar,pv int", 1, KeysType::DUP_KEYS), "pk int,name varchar,pv int",
+            path);
+    const size_t n = 1000;
+    auto pchunk = gen_chunk(*_slots, n);
+    vector<uint32_t> indexes;
+    indexes.reserve(n);
+    for (int i = 0; i < n; i++) {
+        indexes.emplace_back(i);
+    }
+    std::shuffle(indexes.begin(), indexes.end(), std::mt19937(std::random_device()()));
+    auto res = _mem_table->insert(*pchunk, indexes.data(), 0, indexes.size());
+    ASSERT_TRUE(res.ok());
+    ASSERT_TRUE(_mem_table->finalize().ok());
+    ASSERT_OK(_mem_table->flush());
+    // just verify the metrics have value, rather than verify it accurately
+    // because other test cases may also update the metrics concurrently if
+    // run tests in parallel, and it's hard to get the accurate value
+    ASSERT_TRUE(StarRocksMetrics::instance()->memtable_flush_total.value() > 0);
+    ASSERT_TRUE(StarRocksMetrics::instance()->memtable_flush_bytes_total.value() > 0);
+    ASSERT_TRUE(StarRocksMetrics::instance()->memtable_flush_disk_bytes_total.value() > 0);
 }
 
 } // namespace starrocks

--- a/be/test/storage/segment_flush_executor_test.cpp
+++ b/be/test/storage/segment_flush_executor_test.cpp
@@ -35,6 +35,7 @@
 #include "storage/tablet_manager.h"
 #include "storage/txn_manager.h"
 #include "testutil/assert.h"
+#include "util/starrocks_metrics.h"
 
 namespace starrocks {
 
@@ -281,6 +282,12 @@ TEST_F(SegmentFlushExecutorTest, test_write_and_commit_segment) {
     ASSERT_OK(get_prepared_rowset(_tablet->tablet_id(), delta_writer->txn_id(), _partition_id, &prepared_rowset));
     check_single_segment_rowset_result(prepared_rowset, 10);
     ASSERT_OK(StorageEngine::instance()->txn_manager()->delete_txn(_partition_id, _tablet, delta_writer->txn_id()));
+
+    // just verify the metrics have value, rather than verify it accurately
+    // because other test cases may also update the metrics concurrently if
+    // run tests in parallel, and it's hard to get the accurate value
+    ASSERT_TRUE(StarRocksMetrics::instance()->segment_flush_total.value() > 0);
+    ASSERT_TRUE(StarRocksMetrics::instance()->segment_flush_bytes_total.value() > 0);
 }
 
 TEST_F(SegmentFlushExecutorTest, test_submit_after_cancel) {

--- a/be/test/util/starrocks_metrics_test.cpp
+++ b/be/test/util/starrocks_metrics_test.cpp
@@ -307,7 +307,7 @@ TEST_F(StarRocksMetricsTest, test_metrics_register) {
     ASSERT_NE(nullptr, instance->get_metric("memtable_flush_total"));
     ASSERT_NE(nullptr, instance->get_metric("memtable_flush_duration_us"));
     ASSERT_NE(nullptr, instance->get_metric("memtable_flush_io_time_us"));
-    ASSERT_NE(nullptr, instance->get_metric("memtable_flush_bytes_total"));
+    ASSERT_NE(nullptr, instance->get_metric("memtable_flush_memory_bytes_total"));
     ASSERT_NE(nullptr, instance->get_metric("memtable_flush_disk_bytes_total"));
     ASSERT_NE(nullptr, instance->get_metric("segment_flush_total"));
     ASSERT_NE(nullptr, instance->get_metric("segment_flush_duration_us"));

--- a/be/test/util/starrocks_metrics_test.cpp
+++ b/be/test/util/starrocks_metrics_test.cpp
@@ -302,4 +302,17 @@ TEST_F(StarRocksMetricsTest, PageCacheMetrics) {
     ASSERT_STREQ(std::to_string(cache->get_capacity()).c_str(), capacity_metric->to_string().c_str());
 }
 
+TEST_F(StarRocksMetricsTest, test_metrics_register) {
+    auto instance = StarRocksMetrics::instance()->metrics();
+    ASSERT_NE(nullptr, instance->get_metric("memtable_flush_total"));
+    ASSERT_NE(nullptr, instance->get_metric("memtable_flush_duration_us"));
+    ASSERT_NE(nullptr, instance->get_metric("memtable_flush_io_time_us"));
+    ASSERT_NE(nullptr, instance->get_metric("memtable_flush_bytes_total"));
+    ASSERT_NE(nullptr, instance->get_metric("memtable_flush_disk_bytes_total"));
+    ASSERT_NE(nullptr, instance->get_metric("segment_flush_total"));
+    ASSERT_NE(nullptr, instance->get_metric("segment_flush_duration_us"));
+    ASSERT_NE(nullptr, instance->get_metric("segment_flush_io_time_us"));
+    ASSERT_NE(nullptr, instance->get_metric("segment_flush_bytes_total"));
+}
+
 } // namespace starrocks


### PR DESCRIPTION
Why I'm doing:
introduced by #40173, read/write stat is mixed in IOProfiler, and some metrics are defined but not registered

What I'm doing:
fix the problem, and add ut

Fixes #issue

## What type of PR is this:

- [X] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [X] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
