### PR TITLE
[BugFix] Fix null-json is string

### DIFF
--- a/be/src/exprs/json_functions.cpp
+++ b/be/src/exprs/json_functions.cpp
@@ -493,13 +493,11 @@ StatusOr<ColumnPtr> JsonFunctions::json_query(FunctionContext* context, const Co
 template <LogicalType ResultType>
 static Status _convert_json_slice(const vpack::Slice& slice, ColumnBuilder<ResultType>& result) {
     try {
-        if (slice.isNone()) {
+        if (slice.isNone() || slice.isNull()) {
             result.append_null();
         } else if constexpr (ResultType == TYPE_JSON) {
             JsonValue value(slice);
             result.append(std::move(value));
-        } else if (slice.isNull()) {
-            result.append_null();
         } else if constexpr (ResultType == TYPE_VARCHAR || ResultType == TYPE_CHAR) {
             if (LIKELY(slice.isType(vpack::ValueType::String))) {
                 vpack::ValueLength len;

--- a/test/sql/test_semi/R/test_invalid_flat_json
+++ b/test/sql/test_semi/R/test_invalid_flat_json
@@ -1,0 +1,62 @@
+-- name: test_flat_not_object_json_load @system
+CREATE TABLE `js1` (
+  `v1` bigint(20) NULL COMMENT "",
+  `v2` int(11) NULL COMMENT "",
+  `j1` json NULL COMMENT ""
+) ENGINE=OLAP 
+DUPLICATE KEY(`v1`)
+COMMENT "OLAP"
+DISTRIBUTED BY HASH(`v1`) BUCKETS 10 
+PROPERTIES (
+"replication_num" = "1",
+"in_memory" = "false",
+"enable_persistent_index" = "false",
+"replicated_storage" = "false",
+"fast_schema_evolution" = "true",
+"compression" = "LZ4"
+);
+-- result:
+-- !result
+insert into js1 values(1,1, parse_json('[{"s1": 4}, {"s2": 5}]'));
+-- result:
+-- !result
+insert into js1 values(2,1, parse_json('"a"'));
+-- result:
+-- !result
+insert into js1 values(3,1, parse_json('1'));
+-- result:
+-- !result
+insert into js1 values(4,1, parse_json('2020-12-12'));
+-- result:
+-- !result
+insert into js1 values(5,1, parse_json('1.000000'));
+-- result:
+-- !result
+insert into js1 values(6,1, parse_json(''));
+-- result:
+-- !result
+insert into js1 values(6,1, parse_json(null));
+-- result:
+-- !result
+insert into js1 values(6,1, parse_json(TRUE));
+-- result:
+-- !result
+select get_json_string(j1, "$.key2"), get_json_double(j1, "$.key3"), get_json_string(j1, "$.key4") from js1 order by v1 limit 2;
+-- result:
+None	None	None
+None	None	None
+-- !result
+select JSON_EXISTS(j1, "$.key2"), JSON_EXISTS(j1, "$.key2.key3") from js1 order by v1 limit 2;
+-- result:
+None	None
+None	None
+-- !result
+select JSON_LENGTH(j1, "$.key2"), JSON_LENGTH(j1, "$.key3"), JSON_LENGTH(j1, "$.key4") from js1 order by v1 limit 2;
+-- result:
+None	None	None
+None	None	None
+-- !result
+select json_object('"1"')->"1";
+-- result:
+None
+-- !result

--- a/test/sql/test_semi/T/test_invalid_flat_json
+++ b/test/sql/test_semi/T/test_invalid_flat_json
@@ -1,0 +1,36 @@
+-- name: test_flat_not_object_json_load @system
+
+CREATE TABLE `js1` (
+  `v1` bigint(20) NULL COMMENT "",
+  `v2` int(11) NULL COMMENT "",
+  `j1` json NULL COMMENT ""
+) ENGINE=OLAP 
+DUPLICATE KEY(`v1`)
+COMMENT "OLAP"
+DISTRIBUTED BY HASH(`v1`) BUCKETS 10 
+PROPERTIES (
+"replication_num" = "1",
+"in_memory" = "false",
+"enable_persistent_index" = "false",
+"replicated_storage" = "false",
+"fast_schema_evolution" = "true",
+"compression" = "LZ4"
+);
+
+
+insert into js1 values(1,1, parse_json('[{"s1": 4}, {"s2": 5}]'));
+insert into js1 values(2,1, parse_json('"a"'));
+insert into js1 values(3,1, parse_json('1'));
+insert into js1 values(4,1, parse_json('2020-12-12'));
+insert into js1 values(5,1, parse_json('1.000000'));
+insert into js1 values(6,1, parse_json(''));
+insert into js1 values(6,1, parse_json(null));
+insert into js1 values(6,1, parse_json(TRUE));
+
+select get_json_string(j1, "$.key2"), get_json_double(j1, "$.key3"), get_json_string(j1, "$.key4") from js1 order by v1 limit 2;
+
+select JSON_EXISTS(j1, "$.key2"), JSON_EXISTS(j1, "$.key2.key3") from js1 order by v1 limit 2;
+
+select JSON_LENGTH(j1, "$.key2"), JSON_LENGTH(j1, "$.key3"), JSON_LENGTH(j1, "$.key4") from js1 order by v1 limit 2;
+
+select json_object('"1"')->"1";


### PR DESCRIPTION
Why I'm doing:

What I'm doing:
```
MySQL test_db_feceed3ebf3d11ee9de900163e04d4c2> select json_object('"1"')->"1"
+-------------------------+
| json_object('"1"')->'1' |
+-------------------------+
| null                    |
+-------------------------+
1 row in set
Time: 0.024s
MySQL test_db_feceed3ebf3d11ee9de900163e04d4c2> select json_object('"1"')->"1" is null
+-----------------------------------+
| (json_object('"1"')->'1') IS NULL |
+-----------------------------------+
| 0                                 |
+-----------------------------------+
1 row in set
Time: 0.014s
MySQL test_db_feceed3ebf3d11ee9de900163e04d4c2> select json_object('"1"')
+--------------------+
| json_object('"1"') |
+--------------------+
| {"1": null}        |
+--------------------+
1 row in set
Time: 0.008s
```

the `null` is json-null, as a string, not real null, change to

```
MySQL test_db_feceed3ebf3d11ee9de900163e04d4c2> select json_object('"1"')->"1"
+-------------------------+
| json_object('"1"')->'1' |
+-------------------------+
| <null>                  |
+-------------------------+
1 row in set
Time: 0.024s
MySQL test_db_feceed3ebf3d11ee9de900163e04d4c2> select json_object('"1"')->"1" is null
+-----------------------------------+
| (json_object('"1"')->'1') IS NULL |
+-----------------------------------+
| 1                                 |
+-----------------------------------+
1 row in set
Time: 0.014s
MySQL test_db_feceed3ebf3d11ee9de900163e04d4c2> select json_object('"1"')
+--------------------+
| json_object('"1"') |
+--------------------+
| {"1": null}        |
+--------------------+
1 row in set
Time: 0.008s
```

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [x] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [x] 3.1
  - [x] 3.0
  - [x] 2.5
