### PR TITLE
[Enhancement] Adjust base version before publish version

### DIFF
--- a/be/src/storage/lake/transactions.cpp
+++ b/be/src/storage/lake/transactions.cpp
@@ -80,9 +80,11 @@ void adjust_base_version(int64_t tablet_id, TabletManager* tablet_mgr, int64_t* 
 
     auto index_version = tablet_mgr->update_mgr()->get_primary_index_data_version(tablet_id);
     if (index_version > version) {
+        // There is a possibility that the index version is newer than the version in remote storage.
+        // Check whether the index version exists in remote storage. If not, clear and rebuild the index.
         auto res = tablet_mgr->get_tablet_metadata(tablet_id, index_version);
         if (res.ok()) {
-            version = std::max(version, index_version);
+            version = index_version;
         } else {
             tablet_mgr->update_mgr()->remove_primary_index_cache(tablet_id);
         }

--- a/be/src/storage/lake/transactions.cpp
+++ b/be/src/storage/lake/transactions.cpp
@@ -80,7 +80,7 @@ int64_t cal_new_base_version(int64_t tablet_id, TabletManager* tablet_mgr, int64
 
     auto index_version = tablet_mgr->update_mgr()->get_primary_index_data_version(tablet_id);
     if (index_version > new_version) {
-        tablet_mgr->update_mgr()->try_remove_primary_index_cache(tablet_id);
+        tablet_mgr->update_mgr()->remove_primary_index(tablet_id);
         return version;
     }
     if (index_version > version) {
@@ -90,7 +90,7 @@ int64_t cal_new_base_version(int64_t tablet_id, TabletManager* tablet_mgr, int64
         if (res.ok()) {
             version = index_version;
         } else {
-            tablet_mgr->update_mgr()->try_remove_primary_index_cache(tablet_id);
+            tablet_mgr->update_mgr()->remove_primary_index(tablet_id);
         }
     }
 

--- a/be/src/storage/lake/transactions.cpp
+++ b/be/src/storage/lake/transactions.cpp
@@ -80,7 +80,7 @@ int64_t cal_new_base_version(int64_t tablet_id, TabletManager* tablet_mgr, int64
 
     auto index_version = tablet_mgr->update_mgr()->get_primary_index_data_version(tablet_id);
     if (index_version > new_version) {
-        tablet_mgr->update_mgr()->remove_primary_index(tablet_id);
+        tablet_mgr->update_mgr()->unload_and_remove_primary_index(tablet_id);
         return version;
     }
     if (index_version > version) {
@@ -90,7 +90,7 @@ int64_t cal_new_base_version(int64_t tablet_id, TabletManager* tablet_mgr, int64
         if (res.ok()) {
             version = index_version;
         } else {
-            tablet_mgr->update_mgr()->remove_primary_index(tablet_id);
+            tablet_mgr->update_mgr()->unload_and_remove_primary_index(tablet_id);
         }
     }
 

--- a/be/src/storage/lake/txn_log_applier.cpp
+++ b/be/src/storage/lake/txn_log_applier.cpp
@@ -31,11 +31,6 @@
 
 namespace starrocks::lake {
 class PrimaryKeyTxnLogApplier : public TxnLogApplier {
-    template <class T>
-    using ParallelSet =
-            phmap::parallel_flat_hash_set<T, phmap::priv::hash_default_hash<T>, phmap::priv::hash_default_eq<T>,
-                                          phmap::priv::Allocator<T>, 4, std::mutex, true>;
-
 public:
     PrimaryKeyTxnLogApplier(Tablet tablet, MutableTabletMetadataPtr metadata, int64_t new_version)
             : _tablet(tablet),
@@ -46,22 +41,9 @@ public:
         _metadata->set_version(_new_version);
     }
 
-    ~PrimaryKeyTxnLogApplier() override {
-        handle_failure();
-        if (_inited) {
-            _s_schema_change_set.erase(_tablet.id());
-        }
-    }
+    ~PrimaryKeyTxnLogApplier() override { handle_failure(); }
 
-    Status init() override {
-        auto [iter, ok] = _s_schema_change_set.insert(_tablet.id());
-        if (ok) {
-            _inited = true;
-            return check_meta_version();
-        } else {
-            return Status::ResourceBusy("primary key does not support concurrent log applying");
-        }
-    }
+    Status init() override { return check_meta_version(); }
 
     Status check_meta_version() {
         // check tablet meta
@@ -303,8 +285,6 @@ private:
         return Status::OK();
     }
 
-    static inline ParallelSet<int64_t> _s_schema_change_set;
-
     Tablet _tablet;
     MutableTabletMetadataPtr _metadata;
     int64_t _base_version{0};
@@ -312,7 +292,6 @@ private:
     int64_t _max_txn_id{0}; // Used as the file name prefix of the delvec file
     MetaFileBuilder _builder;
     DynamicCache<uint64_t, LakePrimaryIndex>::Entry* _index_entry{nullptr};
-    bool _inited{false};
     std::unique_ptr<std::lock_guard<std::mutex>> _guard{nullptr};
     // True when finalize meta file success.
     bool _has_finalized = false;

--- a/be/src/storage/lake/update_manager.cpp
+++ b/be/src/storage/lake/update_manager.cpp
@@ -129,6 +129,17 @@ void UpdateManager::remove_primary_index_cache(IndexEntry* index_entry) {
     }
 }
 
+void UpdateManager::remove_primary_index(int64_t tablet_id) {
+    auto index_entry = _index_cache.get(tablet_id);
+    if (index_entry != nullptr) {
+        auto& index = index_entry->value();
+        auto guard = index.fetch_guard();
+        index.unload();
+        guard.reset(nullptr);
+        _index_cache.remove(index_entry);
+    }
+}
+
 // |metadata| contain last tablet meta info with new version
 Status UpdateManager::publish_primary_key_tablet(const TxnLogPB_OpWrite& op_write, int64_t txn_id,
                                                  const TabletMetadata& metadata, Tablet* tablet,

--- a/be/src/storage/lake/update_manager.cpp
+++ b/be/src/storage/lake/update_manager.cpp
@@ -687,6 +687,16 @@ void UpdateManager::update_primary_index_data_version(const Tablet& tablet, int6
     }
 }
 
+int64_t UpdateManager::get_primary_index_data_version(int64_t tablet_id) {
+    auto index_entry = _index_cache.get(tablet_id);
+    if (index_entry != nullptr) {
+        int64_t version = index_entry->value().data_version();
+        _index_cache.release(index_entry);
+        return version;
+    }
+    return 0;
+}
+
 void UpdateManager::_print_memory_stats() {
     static std::atomic<int64_t> last_print_ts;
     if (time(nullptr) > last_print_ts.load() + kPrintMemoryStatsInterval && _update_mem_tracker != nullptr) {

--- a/be/src/storage/lake/update_manager.cpp
+++ b/be/src/storage/lake/update_manager.cpp
@@ -129,7 +129,7 @@ void UpdateManager::remove_primary_index_cache(IndexEntry* index_entry) {
     }
 }
 
-void UpdateManager::remove_primary_index(int64_t tablet_id) {
+void UpdateManager::unload_and_remove_primary_index(int64_t tablet_id) {
     auto index_entry = _index_cache.get(tablet_id);
     if (index_entry != nullptr) {
         auto& index = index_entry->value();

--- a/be/src/storage/lake/update_manager.h
+++ b/be/src/storage/lake/update_manager.h
@@ -104,6 +104,8 @@ public:
     // update primary index data version when meta file finalize success.
     void update_primary_index_data_version(const Tablet& tablet, int64_t version);
 
+    int64_t get_primary_index_data_version(int64_t tablet_id);
+
     void expire_cache();
 
     void evict_cache(int64_t memory_urgent_level, int64_t memory_high_level);

--- a/be/src/storage/lake/update_manager.h
+++ b/be/src/storage/lake/update_manager.h
@@ -143,6 +143,8 @@ public:
     // remove index entry if it isn't nullptr
     void remove_primary_index_cache(IndexEntry* index_entry);
 
+    void remove_primary_index(int64_t tablet_id);
+
     DynamicCache<uint64_t, LakePrimaryIndex>& index_cache() { return _index_cache; }
 
     void lock_shard_pk_index_shard(int64_t tablet_id) { _get_pk_index_shard_lock(tablet_id).lock_shared(); }

--- a/be/src/storage/lake/update_manager.h
+++ b/be/src/storage/lake/update_manager.h
@@ -143,7 +143,7 @@ public:
     // remove index entry if it isn't nullptr
     void remove_primary_index_cache(IndexEntry* index_entry);
 
-    void remove_primary_index(int64_t tablet_id);
+    void unload_and_remove_primary_index(int64_t tablet_id);
 
     DynamicCache<uint64_t, LakePrimaryIndex>& index_cache() { return _index_cache; }
 

--- a/be/test/storage/lake/primary_key_publish_test.cpp
+++ b/be/test/storage/lake/primary_key_publish_test.cpp
@@ -788,6 +788,79 @@ TEST_P(LakePrimaryKeyPublishTest, test_batch_publish) {
     EXPECT_EQ(0, read_rows(tablet_id, new_version));
 }
 
+TEST_P(LakePrimaryKeyPublishTest, test_batch_publish_1) {
+    auto [chunk0, indexes0] = gen_data_and_index(kChunkSize, 0, false, true);
+    auto [chunk1, indexes1] = gen_data_and_index(kChunkSize, 0, false, true);
+    auto [chunk2, indexes2] = gen_data_and_index(kChunkSize, 0, false, true);
+    auto base_version = 1;
+    auto tablet_id = _tablet_metadata->id();
+    std::vector<int64_t> txn_ids;
+    auto txn_id = next_id();
+    txn_ids.emplace_back(txn_id);
+    ASSIGN_OR_ABORT(auto delta_writer, DeltaWriterBuilder()
+                                               .set_tablet_manager(_tablet_mgr.get())
+                                               .set_tablet_id(tablet_id)
+                                               .set_txn_id(txn_id)
+                                               .set_partition_id(_partition_id)
+                                               .set_mem_tracker(_mem_tracker.get())
+                                               .set_index_id(_tablet_schema->id())
+                                               .set_slot_descriptors(&_slot_pointers)
+                                               .build());
+    ASSERT_OK(delta_writer->open());
+    ASSERT_OK(delta_writer->write(*chunk0, indexes0.data(), indexes0.size()));
+    ASSERT_OK(delta_writer->finish());
+    delta_writer->close();
+
+    txn_id = next_id();
+    txn_ids.emplace_back(txn_id);
+    ASSIGN_OR_ABORT(delta_writer, DeltaWriterBuilder()
+                                          .set_tablet_manager(_tablet_mgr.get())
+                                          .set_tablet_id(tablet_id)
+                                          .set_txn_id(txn_id)
+                                          .set_partition_id(_partition_id)
+                                          .set_mem_tracker(_mem_tracker.get())
+                                          .set_index_id(_tablet_schema->id())
+                                          .set_slot_descriptors(&_slot_pointers)
+                                          .build());
+    ASSERT_OK(delta_writer->open());
+    ASSERT_OK(delta_writer->write(*chunk1, indexes1.data(), indexes1.size()));
+    ASSERT_OK(delta_writer->finish());
+    delta_writer->close();
+
+    auto new_version = base_version + 2;
+    ASSERT_OK(batch_publish(tablet_id, base_version, new_version, txn_ids).status());
+    ASSIGN_OR_ABORT(auto new_tablet_metadata, _tablet_mgr->get_tablet_metadata(tablet_id, new_version));
+    EXPECT_EQ(new_tablet_metadata->rowsets_size(), 2);
+    EXPECT_EQ(kChunkSize, read_rows(tablet_id, new_version));
+    EXPECT_EQ(new_tablet_metadata->rowsets(0).num_dels(), kChunkSize);
+    EXPECT_EQ(new_tablet_metadata->rowsets(1).num_dels(), 0);
+
+    txn_id = next_id();
+    txn_ids.emplace_back(txn_id);
+    ASSIGN_OR_ABORT(delta_writer, DeltaWriterBuilder()
+                                          .set_tablet_manager(_tablet_mgr.get())
+                                          .set_tablet_id(tablet_id)
+                                          .set_txn_id(txn_id)
+                                          .set_partition_id(_partition_id)
+                                          .set_mem_tracker(_mem_tracker.get())
+                                          .set_index_id(_tablet_schema->id())
+                                          .set_slot_descriptors(&_slot_pointers)
+                                          .build());
+    ASSERT_OK(delta_writer->open());
+    ASSERT_OK(delta_writer->write(*chunk2, indexes2.data(), indexes2.size()));
+    ASSERT_OK(delta_writer->finish());
+    delta_writer->close();
+
+    new_version = base_version + 3;
+    ASSERT_OK(batch_publish(tablet_id, base_version, new_version, txn_ids).status());
+    ASSIGN_OR_ABORT(new_tablet_metadata, _tablet_mgr->get_tablet_metadata(tablet_id, new_version));
+    EXPECT_EQ(new_tablet_metadata->rowsets_size(), 3);
+    EXPECT_EQ(kChunkSize, read_rows(tablet_id, new_version));
+    EXPECT_EQ(new_tablet_metadata->rowsets(0).num_dels(), kChunkSize);
+    EXPECT_EQ(new_tablet_metadata->rowsets(1).num_dels(), kChunkSize);
+    EXPECT_EQ(new_tablet_metadata->rowsets(2).num_dels(), 0);
+}
+
 TEST_P(LakePrimaryKeyPublishTest, test_mem_tracker) {
     EXPECT_EQ(1024 * 1024, _mem_tracker->limit());
     EXPECT_EQ(1024 * 1024 * config::lake_pk_preload_memory_limit_percent / 100,


### PR DESCRIPTION
## Why I'm doing:
In batch publish, the number of txns may be increased each time. For example, the list of txns to be published is [11, 12], `base_version` is 1, `new_version` is 2. And BE published txn 1 successfully, the index version has increased to 2. But the next time when FE retries, the list of txns may be [11, 12, 13], `base_version` is 1, `new_version` is 3. The index version is larger than the `base_version` so BE will return failure which will make FE retry again.

## What I'm doing:
For the second time when FE retries the publish request, BE will adjust the base version according to index version and tablet metadata version and publish from the adjusted base version.
Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
