### PR TITLE
[Doc] Fix some labels to support both BE/CN

### DIFF
--- a/extra/grafana/kubernetes/StarRocks-Overview-kubernetes-3.0.json
+++ b/extra/grafana/kubernetes/StarRocks-Overview-kubernetes-3.0.json
@@ -4146,28 +4146,28 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(starrocks_be_txn_request{app_kubernetes_io_component=\"be\", namespace=\"$namespace\", service=~\"${service:pipe}\", type=\"begin\"})",
+          "expr": "sum(starrocks_be_txn_request{job=~\"${service:pipe}\", namespace=\"$namespace\", service=~\"${service:pipe}\", type=\"begin\"})",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "begin",
           "refId": "A"
         },
         {
-          "expr": "sum(starrocks_be_txn_request{app_kubernetes_io_component=\"be\", namespace=\"$namespace\", service=~\"${service:pipe}\", type=\"exec\"})",
+          "expr": "sum(starrocks_be_txn_request{job=~\"${service:pipe}\", namespace=\"$namespace\", service=~\"${service:pipe}\", type=\"exec\"})",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "exec",
           "refId": "B"
         },
         {
-          "expr": "sum(starrocks_be_txn_request{app_kubernetes_io_component=\"be\", namespace=\"$namespace\", service=~\"${service:pipe}\", type=\"commit\"})",
+          "expr": "sum(starrocks_be_txn_request{job=~\"${service:pipe}\", namespace=\"$namespace\", service=~\"${service:pipe}\", type=\"commit\"})",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "commit",
           "refId": "C"
         },
         {
-          "expr": "sum(starrocks_be_txn_request{app_kubernetes_io_component=\"be\", namespace=\"$namespace\", service=~\"${service:pipe}\", type=\"rollback\"})",
+          "expr": "sum(starrocks_be_txn_request{job=~\"${service:pipe}\", namespace=\"$namespace\", service=~\"${service:pipe}\", type=\"rollback\"})",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "rollback",
@@ -4266,14 +4266,14 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(rate(starrocks_be_stream_load{app_kubernetes_io_component=\"be\", namespace=\"$namespace\", service=~\"${service:pipe}\", type=\"receive_bytes\"}[$interval]))",
+          "expr": "sum(rate(starrocks_be_stream_load{job=~\"${service:pipe}\", namespace=\"$namespace\", service=~\"${service:pipe}\", type=\"receive_bytes\"}[$interval]))",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "bytes",
           "refId": "A"
         },
         {
-          "expr": "sum(rate(starrocks_be_stream_load{app_kubernetes_io_component=\"be\", namespace=\"$namespace\", service=~\"${service:pipe}\", type=\"load_rows\"}[$interval]))",
+          "expr": "sum(rate(starrocks_be_stream_load{job=~\"${service:pipe}\", namespace=\"$namespace\", service=~\"${service:pipe}\", type=\"load_rows\"}[$interval]))",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "rows",


### PR DESCRIPTION
Why I'm doing:

Some labels in metrics is fixed to 'be'. In order to support both BE/CN, we need to change it

What I'm doing:

use other labels to support both BE/CN.
![image](https://github.com/StarRocks/starrocks/assets/7991096/acd340c3-5dd8-4a5a-9c7b-146b52ec3df2)
![image](https://github.com/StarRocks/starrocks/assets/7991096/6e960168-852d-42ab-8102-e61cf9ef7571)

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [x] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
