### PR TITLE
[BugFix]fixed SQLBLACKLIST row contains multiple spaces and line separators

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/meta/SqlBlackList.java
+++ b/fe/fe-core/src/main/java/com/starrocks/meta/SqlBlackList.java
@@ -35,8 +35,9 @@ public class SqlBlackList {
     }
 
     public static void verifying(String sql) throws AnalysisException {
+        String formatSql = sql.replace("\r", " ").replace("\n", " ").replaceAll("\\s+", " ");
         for (BlackListSql patternAndId : getInstance().sqlBlackListMap.values()) {
-            Matcher m = patternAndId.pattern.matcher(sql);
+            Matcher m = patternAndId.pattern.matcher(formatSql);
             if (m.find()) {
                 ErrorReport.reportAnalysisException(ErrorCode.ERR_SQL_IN_BLACKLIST_ERROR);
             }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/AddSqlBlackListStmt.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/AddSqlBlackListStmt.java
@@ -45,7 +45,10 @@ public class AddSqlBlackListStmt extends StatementBase {
     }
 
     public void analyze() throws SemanticException {
-        sql = sql.trim().toLowerCase().replaceAll(" +", " ");
+        sql = sql.trim().toLowerCase().replaceAll(" +", " ")
+                .replace("\r", " ")
+                .replace("\n", " ")
+                .replaceAll("\\s+", " ");
         if (sql.length() > 0) {
             try {
                 sqlPattern = Pattern.compile(sql);

--- a/fe/fe-core/src/test/java/com/starrocks/planner/QueryPlannerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/planner/QueryPlannerTest.java
@@ -167,6 +167,58 @@ public class QueryPlannerTest {
         stmtExecutor2.execute();
         Assert.assertEquals("Access denied; This sql is in blacklist, please contact your admin",
                 connectContext.getState().getErrorMessage());
+        connectContext.getState().setError("");
+
+        String sqlWithLineSeparators = "select k1 \n" +
+                " from \n" +
+                " test.baseall";
+        StatementBase statement1 = SqlParser.parse(sqlWithLineSeparators, connectContext.getSessionVariable().getSqlMode()).get(0);
+        StmtExecutor stmtExecutor4 = new StmtExecutor(connectContext, statement1);
+        stmtExecutor4.execute();
+        Assert.assertEquals("Access denied; This sql is in blacklist, please contact your admin",
+                connectContext.getState().getErrorMessage());
+        connectContext.getState().setError("");
+
+        String deleteBlackListSql = "delete sqlblacklist " + String.valueOf(id);
+        StmtExecutor stmtExecutor3 = new StmtExecutor(connectContext, deleteBlackListSql);
+        stmtExecutor3.execute();
+        Assert.assertEquals(0, SqlBlackList.getInstance().sqlBlackListMap.entrySet().size());
+    }
+
+    @Test
+    public void testSqlBlackListWithLineSeparators() throws Exception {
+        String setEnableSqlBlacklist = "admin set frontend config (\"enable_sql_blacklist\" = \"true\")";
+        StmtExecutor stmtExecutor0 = new StmtExecutor(connectContext, setEnableSqlBlacklist);
+        stmtExecutor0.execute();
+
+        String addBlackListSql = "add sqlblacklist \"select \n k1 from .+\"";
+        StmtExecutor stmtExecutor1 = new StmtExecutor(connectContext, addBlackListSql);
+        stmtExecutor1.execute();
+
+        Assert.assertEquals(SqlBlackList.getInstance().sqlBlackListMap.entrySet().size(), 1);
+        long id = -1;
+        for (Map.Entry<String, BlackListSql> entry : SqlBlackList.getInstance().sqlBlackListMap.entrySet()) {
+            id = entry.getValue().id;
+            Assert.assertEquals("select k1 from .+", entry.getKey());
+        }
+
+        String sql = "select k1 from test.baseall";
+        StatementBase statement = SqlParser.parse(sql, connectContext.getSessionVariable().getSqlMode()).get(0);
+        StmtExecutor stmtExecutor2 = new StmtExecutor(connectContext, statement);
+        stmtExecutor2.execute();
+        Assert.assertEquals("Access denied; This sql is in blacklist, please contact your admin",
+                connectContext.getState().getErrorMessage());
+        connectContext.getState().setError("");
+
+        String sqlWithLineSeparators = "select k1 \n" +
+                " from \n" +
+                " test.baseall";
+        StatementBase statement1 = SqlParser.parse(sqlWithLineSeparators, connectContext.getSessionVariable().getSqlMode()).get(0);
+        StmtExecutor stmtExecutor4 = new StmtExecutor(connectContext, statement1);
+        stmtExecutor4.execute();
+        Assert.assertEquals("Access denied; This sql is in blacklist, please contact your admin",
+                connectContext.getState().getErrorMessage());
+        connectContext.getState().setError("");
 
         String deleteBlackListSql = "delete sqlblacklist " + String.valueOf(id);
         StmtExecutor stmtExecutor3 = new StmtExecutor(connectContext, deleteBlackListSql);

--- a/fe/fe-core/src/test/java/com/starrocks/planner/QueryPlannerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/planner/QueryPlannerTest.java
@@ -195,7 +195,7 @@ public class QueryPlannerTest {
         StmtExecutor stmtExecutor1 = new StmtExecutor(connectContext, addBlackListSql);
         stmtExecutor1.execute();
 
-        Assert.assertEquals(SqlBlackList.getInstance().sqlBlackListMap.entrySet().size(), 1);
+        Assert.assertEquals(1, SqlBlackList.getInstance().sqlBlackListMap.entrySet().size());
         long id = -1;
         for (Map.Entry<String, BlackListSql> entry : SqlBlackList.getInstance().sqlBlackListMap.entrySet()) {
             id = entry.getValue().id;


### PR DESCRIPTION
when SQLBLACKLIST sql contains multiple spaces and line separators, the forbidden SQL can pass 。Adding multiple conditions to  verifying sql 。

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
- [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [x] 3.1
  - [ ] 3.0
  - [ ] 2.5
