### PR TITLE
[BugFix] Fix partition prune error after truncate list partition

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/ListPartitionInfo.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/ListPartitionInfo.java
@@ -439,6 +439,7 @@ public class ListPartitionInfo extends PartitionInfo {
             this.setLiteralExprValues(partitionId, values);
         }
         this.idToStorageCacheInfo.put(partitionId, dataCacheInfo);
+        idToIsTempPartition.put(partitionId, false);
     }
 
     @Override

--- a/test/sql/test_list_partition/R/test_select_after_truncate_list_partition
+++ b/test/sql/test_list_partition/R/test_select_after_truncate_list_partition
@@ -1,0 +1,59 @@
+-- name: test_select_after_truncate_list_partition
+create database test_select_after_truncate_list_partition_zz1;
+-- result:
+-- !result
+use test_select_after_truncate_list_partition_zz1;
+-- result:
+-- !result
+CREATE TABLE IF NOT EXISTS t_ptr_label_ice(
+    obj_id string not null COMMENT'客户编号',
+    lab_numr string not null COMMENT'标签编号',
+    busi_date string not null COMMENT'业务日期',
+    lab_val VARCHAR(1048576) COMMENT'值'
+)UNIQUE KEY(obj_id, lab_numr, busi_date)
+PARTITION BY LIST (lab_numr, busi_date)(
+    PARTITION p1 VALUES IN (("lab1", "2022-01-01")),
+   PARTITION p2 VALUES IN (("lab3", "2022-01-03")),
+   PARTITION p3 VALUES IN (("lab5", "2022-01-07")),
+   PARTITION p4 VALUES IN (("lab9", "2022-01-09"))
+)
+DISTRIBUTED BY HASH(obj_id);
+-- result:
+-- !result
+INSERT INTO t_ptr_label_ice (obj_id, lab_numr, busi_date, lab_val) VALUES
+('obj1', 'lab1', '2022-01-01', 'val1'),
+('obj2', 'lab1', '2022-01-01', 'val2'),
+('obj3', 'lab3', '2022-01-03', 'val3'),
+('obj4', 'lab3', '2022-01-03', 'val4'),
+('obj5', 'lab3', '2022-01-03', 'val5'),
+('obj6', 'lab3', '2022-01-03', 'val6'),
+('obj7', 'lab5', '2022-01-07', 'val7'),
+('obj8', 'lab5', '2022-01-07', 'val8'),
+('obj9', 'lab9', '2022-01-09', 'val9'),
+('obj10', 'lab9', '2022-01-09', 'val10');
+-- result:
+-- !result
+select count(*) from t_ptr_label_ice where busi_date="2022-01-01" ;
+-- result:
+2
+-- !result
+ALTER TABLE t_ptr_label_ice truncate PARTITION p1;
+-- result:
+-- !result
+INSERT INTO t_ptr_label_ice (obj_id, lab_numr, busi_date, lab_val) VALUES
+('obj1', 'lab1', '2022-01-01', 'val1'),
+('obj2', 'lab1', '2022-01-01', 'val2'),
+('obj3', 'lab3', '2022-01-03', 'val3'),
+('obj4', 'lab3', '2022-01-03', 'val4'),
+('obj5', 'lab3', '2022-01-03', 'val5'),
+('obj6', 'lab3', '2022-01-03', 'val6'),
+('obj7', 'lab5', '2022-01-07', 'val7'),
+('obj8', 'lab5', '2022-01-07', 'val8'),
+('obj9', 'lab9', '2022-01-09', 'val9'),
+('obj10', 'lab9', '2022-01-09', 'val10');
+-- result:
+-- !result
+select count(*) from t_ptr_label_ice where busi_date="2022-01-01" ;
+-- result:
+2
+-- !result

--- a/test/sql/test_list_partition/T/test_select_after_truncate_list_partition
+++ b/test/sql/test_list_partition/T/test_select_after_truncate_list_partition
@@ -1,0 +1,50 @@
+-- name: test_select_after_truncate_list_partition
+create database test_select_after_truncate_list_partition_zz1;
+use test_select_after_truncate_list_partition_zz1;
+
+CREATE TABLE IF NOT EXISTS t_ptr_label_ice(
+    obj_id string not null COMMENT'客户编号',
+    lab_numr string not null COMMENT'标签编号',
+    busi_date string not null COMMENT'业务日期',
+    lab_val VARCHAR(1048576) COMMENT'值'
+)UNIQUE KEY(obj_id, lab_numr, busi_date)
+PARTITION BY LIST (lab_numr, busi_date)(
+    PARTITION p1 VALUES IN (("lab1", "2022-01-01")),
+   PARTITION p2 VALUES IN (("lab3", "2022-01-03")),
+   PARTITION p3 VALUES IN (("lab5", "2022-01-07")),
+   PARTITION p4 VALUES IN (("lab9", "2022-01-09"))
+)
+DISTRIBUTED BY HASH(obj_id);
+
+
+INSERT INTO t_ptr_label_ice (obj_id, lab_numr, busi_date, lab_val) VALUES
+('obj1', 'lab1', '2022-01-01', 'val1'),
+('obj2', 'lab1', '2022-01-01', 'val2'),
+('obj3', 'lab3', '2022-01-03', 'val3'),
+('obj4', 'lab3', '2022-01-03', 'val4'),
+('obj5', 'lab3', '2022-01-03', 'val5'),
+('obj6', 'lab3', '2022-01-03', 'val6'),
+('obj7', 'lab5', '2022-01-07', 'val7'),
+('obj8', 'lab5', '2022-01-07', 'val8'),
+('obj9', 'lab9', '2022-01-09', 'val9'),
+('obj10', 'lab9', '2022-01-09', 'val10');
+
+select count(*) from t_ptr_label_ice where busi_date="2022-01-01" ;
+
+ALTER TABLE t_ptr_label_ice truncate PARTITION p1;
+
+INSERT INTO t_ptr_label_ice (obj_id, lab_numr, busi_date, lab_val) VALUES
+('obj1', 'lab1', '2022-01-01', 'val1'),
+('obj2', 'lab1', '2022-01-01', 'val2'),
+('obj3', 'lab3', '2022-01-03', 'val3'),
+('obj4', 'lab3', '2022-01-03', 'val4'),
+('obj5', 'lab3', '2022-01-03', 'val5'),
+('obj6', 'lab3', '2022-01-03', 'val6'),
+('obj7', 'lab5', '2022-01-07', 'val7'),
+('obj8', 'lab5', '2022-01-07', 'val8'),
+('obj9', 'lab9', '2022-01-09', 'val9'),
+('obj10', 'lab9', '2022-01-09', 'val10');
+
+select count(*) from t_ptr_label_ice where busi_date="2022-01-01" ;
+
+


### PR DESCRIPTION
The newly created partition after truncation is not added to `idToIsTempPartition`
which leads to partition prune error result and make the result of query empty.

Fixes SR-24658

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [x] 3.1
  - [x] 3.0
  - [ ] 2.5
