### PR TITLE
[BugFix] Accumulator uses bytes_size instead of mem_usage to count incremental memory

### DIFF
--- a/be/src/storage/chunk_helper.cpp
+++ b/be/src/storage/chunk_helper.cpp
@@ -543,15 +543,15 @@ void ChunkPipelineAccumulator::push(const ChunkPtr& chunk) {
     DCHECK(_out_chunk == nullptr);
     if (_in_chunk == nullptr) {
         _in_chunk = chunk;
-        _mem_usage = chunk->memory_usage();
+        _mem_usage = chunk->bytes_usage();
     } else if (_in_chunk->num_rows() + chunk->num_rows() > _max_size ||
                _in_chunk->owner_info() != chunk->owner_info()) {
         _out_chunk = std::move(_in_chunk);
         _in_chunk = chunk;
-        _mem_usage = chunk->memory_usage();
+        _mem_usage = chunk->bytes_usage();
     } else {
         _in_chunk->append(*chunk);
-        _mem_usage += chunk->memory_usage();
+        _mem_usage += chunk->bytes_usage();
     }
 
     if (_out_chunk == nullptr && (_in_chunk->num_rows() >= _max_size * LOW_WATERMARK_ROWS_RATE ||

--- a/be/test/storage/chunk_helper_test.cpp
+++ b/be/test/storage/chunk_helper_test.cpp
@@ -189,7 +189,7 @@ TEST_F(ChunkHelperTest, Accumulator) {
 
 class ChunkPipelineAccumulatorTest : public ::testing::Test {
 protected:
-    ChunkPtr _generate_chunk(size_t rows, size_t cols, size_t reserve_size=0);
+    ChunkPtr _generate_chunk(size_t rows, size_t cols, size_t reserve_size = 0);
 };
 
 ChunkPtr ChunkPipelineAccumulatorTest::_generate_chunk(size_t rows, size_t cols, size_t reserve_size) {

--- a/be/test/storage/chunk_helper_test.cpp
+++ b/be/test/storage/chunk_helper_test.cpp
@@ -189,13 +189,13 @@ TEST_F(ChunkHelperTest, Accumulator) {
 
 class ChunkPipelineAccumulatorTest : public ::testing::Test {
 protected:
-    ChunkPtr _generate_chunk(size_t rows, size_t cols);
+    ChunkPtr _generate_chunk(size_t rows, size_t cols, size_t reserve_size=0);
 };
 
-ChunkPtr ChunkPipelineAccumulatorTest::_generate_chunk(size_t rows, size_t cols) {
+ChunkPtr ChunkPipelineAccumulatorTest::_generate_chunk(size_t rows, size_t cols, size_t reserve_size) {
     auto chunk = std::make_shared<Chunk>();
     for (size_t i = 0; i < cols; i++) {
-        auto col = Int8Column::create(rows, 0);
+        auto col = Int8Column::create(rows, reserve_size);
         chunk->append_column(col, i);
     }
     return chunk;
@@ -256,6 +256,18 @@ TEST_F(ChunkPipelineAccumulatorTest, test_push) {
     result_chunk = std::move(accumulator.pull());
     ASSERT_EQ(result_chunk->num_rows(), 3000);
     accumulator.finalize();
+    ASSERT_TRUE(accumulator.has_output());
+    result_chunk = std::move(accumulator.pull());
+    ASSERT_EQ(result_chunk->num_rows(), 3000);
+    ASSERT_FALSE(accumulator.has_output());
+
+    // reserve large and use less
+    accumulator.reset_state();
+    accumulator.push(_generate_chunk(1000, 20, 4000));
+    ASSERT_FALSE(accumulator.has_output());
+    accumulator.push(_generate_chunk(1000, 20, 4000));
+    ASSERT_FALSE(accumulator.has_output());
+    accumulator.push(_generate_chunk(1000, 20, 4000));
     ASSERT_TRUE(accumulator.has_output());
     result_chunk = std::move(accumulator.pull());
     ASSERT_EQ(result_chunk->num_rows(), 3000);

--- a/be/test/storage/chunk_helper_test.cpp
+++ b/be/test/storage/chunk_helper_test.cpp
@@ -263,11 +263,11 @@ TEST_F(ChunkPipelineAccumulatorTest, test_push) {
 
     // reserve large and use less
     accumulator.reset_state();
-    accumulator.push(_generate_chunk(1000, 20, 4000));
+    accumulator.push(_generate_chunk(1000, 25, 4000));
     ASSERT_FALSE(accumulator.has_output());
-    accumulator.push(_generate_chunk(1000, 20, 4000));
+    accumulator.push(_generate_chunk(1000, 25, 4000));
     ASSERT_FALSE(accumulator.has_output());
-    accumulator.push(_generate_chunk(1000, 20, 4000));
+    accumulator.push(_generate_chunk(1000, 25, 4000));
     ASSERT_TRUE(accumulator.has_output());
     result_chunk = std::move(accumulator.pull());
     ASSERT_EQ(result_chunk->num_rows(), 3000);


### PR DESCRIPTION
Why I'm doing:

`mem_usage` is used to calculate reserve memory. After executing `ExprContext::evaluate`
, the memory of chunk occupied by the actual elements is very different from the reserve memory, so byte_size is used to  calculate incrementally memory usage.

What I'm doing:

Use bytes_size instead of mem_usage to count incremental memory

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [x] 3.1
  - [x] 3.0
  - [x] 2.5
