### PR TITLE
[BugFix] Fix nested mv rewrite bugs

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/pattern/Pattern.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/pattern/Pattern.java
@@ -15,7 +15,7 @@
 package com.starrocks.sql.optimizer.operator.pattern;
 
 import com.google.common.base.Preconditions;
-import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Lists;
 import com.starrocks.sql.optimizer.GroupExpression;
 import com.starrocks.sql.optimizer.OptExpression;
@@ -28,7 +28,7 @@ import java.util.List;
  * Pattern is used in rules as a placeholder for group
  */
 public class Pattern {
-    public static final ImmutableList<OperatorType> ALL_SCAN_TYPES = ImmutableList.<OperatorType>builder()
+    public static final ImmutableSet<OperatorType> ALL_SCAN_TYPES = ImmutableSet.<OperatorType>builder()
             .add(OperatorType.LOGICAL_OLAP_SCAN)
             .add(OperatorType.LOGICAL_HIVE_SCAN)
             .add(OperatorType.LOGICAL_ICEBERG_SCAN)

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/Binder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/Binder.java
@@ -35,6 +35,14 @@ public class Binder {
     // Used to track the groupExpressions ask history of each group node
     private final List<Integer> groupExpressionIndex;
 
+    // `multiJoinBinder` is used for MULTI_JOIN pattern and is stateless so can be used in recursive.
+    private final MultiJoinBinder multiJoinBinder = new MultiJoinBinder();
+    // `isPatternWithoutChildren` is to mark whether the input pattern can be used for zero child optimization.
+    private final boolean isPatternWithoutChildren;
+    // `nextIdx` marks the current idx which iterates calling `next()` method and it's used for MULTI_JOIN pattern
+    // to optimize iteration expansions.
+    private int nextIdx = 0;
+
     /**
      * Extract a expression from GroupExpression which match the given pattern
      *
@@ -45,7 +53,13 @@ public class Binder {
     public Binder(Pattern pattern, GroupExpression groupExpression) {
         this.pattern = pattern;
         this.groupExpression = groupExpression;
-        groupExpressionIndex = Lists.newArrayList(0);
+        this.groupExpressionIndex = Lists.newArrayList(0);
+
+        // MULTI_JOIN is a special pattern which can contain children groups if the input group expression
+        // is not a scan node.
+        this.isPatternWithoutChildren = pattern.isPatternMultiJoin()
+                ? Pattern.ALL_SCAN_TYPES.contains(groupExpression.getOp().getOpType())
+                : pattern.children().size() == 0;
     }
 
     /*
@@ -66,7 +80,7 @@ public class Binder {
      */
     public OptExpression next() {
         // For logic scan to physical scan, we only need to match once
-        if (pattern.children().size() == 0 && groupExpressionIndex.get(0) > 0) {
+        if (isPatternWithoutChildren && groupExpressionIndex.get(0) > 0) {
             return null;
         }
 
@@ -82,16 +96,19 @@ public class Binder {
             expression = match(pattern, groupExpression);
         } while (expression == null && this.groupExpressionIndex.size() != 1);
 
+        nextIdx++;
         return expression;
     }
+
 
     /**
      * Pattern tree match groupExpression tree
      */
     private OptExpression match(Pattern pattern, GroupExpression groupExpression) {
         if (pattern.isPatternMultiJoin()) {
-            return new MultiJoinBinder().match(groupExpression);
+            return multiJoinBinder.match(groupExpression);
         }
+
         if (!pattern.matchWithoutChild(groupExpression)) {
             return null;
         }
@@ -137,14 +154,14 @@ public class Binder {
      * extract GroupExpression by groupExpressionIndex
      */
     private GroupExpression extractGroupExpression(Pattern pattern, Group group) {
+        int valueIndex = groupExpressionIndex.get(groupTraceKey);
         if (pattern.isPatternLeaf() || pattern.isPatternMultiLeaf()) {
-            if (groupExpressionIndex.get(groupTraceKey) > 0) {
+            if (valueIndex > 0) {
                 groupExpressionIndex.remove(groupTraceKey);
                 return null;
             }
             return group.getFirstLogicalExpression();
         } else {
-            int valueIndex = groupExpressionIndex.get(groupTraceKey);
             if (valueIndex >= group.getLogicalExpressions().size()) {
                 groupExpressionIndex.remove(groupTraceKey);
                 return null;
@@ -162,8 +179,7 @@ public class Binder {
      * 2. Regular matching is extremely slow in this case since it needs to recursive descent the tree, build the
      * binding state and check the expression at the same time. But MULTI_JOIN could enumerate the GE without any check
      */
-    class MultiJoinBinder {
-
+    private class MultiJoinBinder {
         public OptExpression match(GroupExpression ge) {
             // 1. Check if the entire tree is MULTI_JOIN
             // 2. Enumerate GE
@@ -175,17 +191,19 @@ public class Binder {
         }
 
         private OptExpression enumerate(GroupExpression ge) {
-            if (ge == null || !isMultiJoinGE(ge)) {
-                return null;
-            }
             List<OptExpression> resultInputs = Lists.newArrayList();
-
             int groupExpressionIndex = 0;
             while (groupExpressionIndex < ge.getInputs().size()) {
                 trace();
-                Group group = ge.getInputs().get(groupExpressionIndex);
-                OptExpression opt = enumerate(extractGroupExpression(group));
 
+                Group group = ge.getInputs().get(groupExpressionIndex);
+                GroupExpression nextGroupExpression = extractGroupExpression(group);
+                // avoid recursive
+                if (nextGroupExpression == null || !isMultiJoinOp(nextGroupExpression)) {
+                    return null;
+                }
+
+                OptExpression opt = enumerate(nextGroupExpression);
                 if (opt == null) {
                     return null;
                 } else {
@@ -204,7 +222,41 @@ public class Binder {
                 groupExpressionIndex.remove(groupTraceKey);
                 return null;
             }
-            return group.getLogicalExpressions().get(valueIndex);
+            List<GroupExpression> groupExpressions = group.getLogicalExpressions();
+            GroupExpression next = groupExpressions.get(valueIndex);
+            if (nextIdx == 0) {
+                return next;
+            }
+
+            // shortcut for no child group expression
+            if (Pattern.ALL_SCAN_TYPES.contains(next.getOp().getOpType()) && valueIndex > 0) {
+                groupExpressionIndex.remove(groupTraceKey);
+                return null;
+            }
+            // directly return if next has rewritten by mv
+            if (next.hasAppliedMVRules()) {
+                return next;
+            }
+
+            // NOTE: To avoid iterating all children group expressions which may take a lot of time, only iterate
+            // group expressions which are already rewritten by mv except the first iteration, so can be used for
+            // nested mv rewritten.
+            // TODO: Introduce rule based join-reorder for mv rewrite, so can reduce this iteration time.
+            int geSize = groupExpressions.size();
+            while (++valueIndex < geSize) {
+                next = group.getLogicalExpressions().get(valueIndex);
+                if (next.hasAppliedMVRules()) {
+                    groupExpressionIndex.set(groupTraceKey, valueIndex);
+                    return next;
+                }
+            }
+            groupExpressionIndex.remove(groupTraceKey);
+            return null;
+        }
+
+        private boolean isMultiJoinOp(GroupExpression ge) {
+            OperatorType operatorType = ge.getOp().getOpType();
+            return operatorType.equals(OperatorType.LOGICAL_JOIN) || Pattern.ALL_SCAN_TYPES.contains(operatorType);
         }
 
         private boolean isMultiJoin(GroupExpression ge) {
@@ -217,7 +269,7 @@ public class Binder {
          * we also need to consider this kind of GE as MULTI_JOIN
          */
         private boolean isMultiJoinRecursive(GroupExpression ge) {
-            if (!isMultiJoinOp(ge.getOp().getOpType())) {
+            if (!isMultiJoinOp(ge)) {
                 return false;
             }
 
@@ -233,21 +285,15 @@ public class Binder {
             return true;
         }
 
+        /**
+         * Check Group's logical expressions except the first has already been rewritten by mv rules.
+         * @param g : Group to check whether it has been rewritten by mv rules.
+         * @return : true if the Group has GroupExpression which is rewritten by mv rules.
+         */
         private boolean hasRewrittenMvScan(Group g) {
-            for (GroupExpression ge : g.getLogicalExpressions()) {
-                if ((ge.getOp().getOpType() == OperatorType.LOGICAL_OLAP_SCAN)) {
-                    return true;
-                }
-            }
-            return false;
-        }
-
-        private boolean isMultiJoinGE(GroupExpression ge) {
-            return isMultiJoinOp(ge.getOp().getOpType());
-        }
-
-        private boolean isMultiJoinOp(OperatorType operatorType) {
-            return Pattern.ALL_SCAN_TYPES.contains(operatorType) || operatorType.equals(OperatorType.LOGICAL_JOIN);
+            return g.getLogicalExpressions().stream()
+                    .skip(1) // since first logical expression has already been checked.
+                    .anyMatch(ge -> ge.getOp().getOpType() == OperatorType.LOGICAL_OLAP_SCAN && ge.hasAppliedMVRules());
         }
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/rule/BaseMaterializedViewRewriteRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/rule/BaseMaterializedViewRewriteRule.java
@@ -96,7 +96,7 @@ public abstract class BaseMaterializedViewRewriteRule extends TransformationRule
         try {
             return doTransform(queryExpression, context);
         } catch (Exception e) {
-            String errMsg = ExceptionUtils.getMessage(e);
+            String errMsg = ExceptionUtils.getStackTrace(e);
             // for mv rewrite rules, do not disturb query when exception.
             logMVRewrite(context, this, "mv rewrite exception, exception message:{}", errMsg);
             return Lists.newArrayList();
@@ -116,6 +116,8 @@ public abstract class BaseMaterializedViewRewriteRule extends TransformationRule
             mvCandidateContexts.addAll(context.getCandidateMvs());
         }
         mvCandidateContexts.removeIf(x -> !x.prune(context, queryExpression));
+
+        // Order all candidate mvs by priority so can be rewritten fast.
         MaterializationContext.RewriteOrdering ordering =
                 new MaterializationContext.RewriteOrdering(queryExpression, context.getColumnRefFactory());
         mvCandidateContexts.sort(ordering);

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/task/ApplyRuleTask.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/task/ApplyRuleTask.java
@@ -115,12 +115,15 @@ public class ApplyRuleTask extends OptimizerTask {
             }
 
             GroupExpression newGroupExpression = result.second;
-            if (sessionVariable.isEnableMaterializedViewForceRewrite()) {
+
+            // Add this rule into `appliedRules` to mark rules which have already been applied.
+            {
                 // new bitset should derive old bitset's info to track the lineage of applied rules.
                 newGroupExpression.mergeAppliedRules(groupExpression.getAppliedRuleMasks());
                 // new bitset add new rule which it's derived from.
                 newGroupExpression.addNewAppliedRule(rule);
             }
+
             if (newGroupExpression.getOp().isLogical()) {
                 // For logic newGroupExpression, optimize it
                 pushTask(new OptimizeExpressionTask(context, newGroupExpression, isExplore));

--- a/fe/fe-core/src/test/java/com/starrocks/planner/ViewBaseMvRewriteTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/planner/ViewBaseMvRewriteTest.java
@@ -503,4 +503,29 @@ public class ViewBaseMvRewriteTest extends MaterializedViewTestBase {
             sql(query).contains("mv_q15");
         }
     }
+
+    @Test
+    public void testViewRewriteWithNestedMVs() throws Exception {
+        String tbl1 = "CREATE TABLE test_t1 (\n" +
+                " k1 INT,\n" +
+                " v1 INT,\n" +
+                " v2 INT)\n" +
+                " DUPLICATE KEY(k1)\n" +
+                " DISTRIBUTED BY HASH(k1);";
+        starRocksAssert.withTable(tbl1);
+        String view1 = "create view v1 as select k1,sum(v1) as sum_v1 from test_t1 group by k1;";
+        String view2 = "create view v2 as select k1,sum(v2) as sum_v2 from test_t1 group by k1;";
+        starRocksAssert.withView(view1);
+        starRocksAssert.withView(view2);
+
+        String mv = "create materialized view mv1 refresh manual as select v1.k1,v1.sum_v1,v2.sum_v2 from " +
+                "v1 join v2 on v1.k1=v2.k1;";
+        starRocksAssert.withMaterializedView(mv, () -> {
+            sql(" select v1.k1,v1.sum_v1,v2.sum_v2 from v1 join v2 on v1.k1=v2.k1 order by 1;")
+                    .contains("mv1");
+        });
+        starRocksAssert.dropView("v1");
+        starRocksAssert.dropView("v2");
+        starRocksAssert.dropTable("test_t1");
+    }
 }


### PR DESCRIPTION
Why I'm doing:

MV nested with MV does not worked as expected:
```
    @Test
    public void testNestedMVRewriteWithSSB() {
        String mv1 = "CREATE MATERIALIZED VIEW mv1 REFRESH ASYNC every (interval 10 minute) AS\n" +
                "select lo_orderkey, lo_custkey, p_partkey, p_name\n" +
                "from lineorder join part on lo_partkey = p_partkey;";
        String mv2 = "CREATE MATERIALIZED VIEW mv2 REFRESH ASYNC every (interval 10 minute) AS\n" +
                "select c_custkey from customer group by c_custkey;";
        String mv3 = "CREATE MATERIALIZED VIEW mv3 REFRESH ASYNC every (interval 10 minute) AS\n" +
                "select * from mv1 lo join mv2 cust on lo.lo_custkey = cust.c_custkey;";

        setTracLogModule("MV");
        connectContext.getSessionVariable().setQueryIncludingMVNames("mv1,mv2,mv3");
        starRocksAssert.withMaterializedViews(ImmutableList.of(mv1, mv2, mv3), (obj) -> {
            List<String> mvNames = (List<String>) obj;
            String query = "select *\n" +
                    "from (\n" +
                    "    select lo_orderkey, lo_custkey, p_partkey, p_name\n" +
                    "    from lineorder\n" +
                    "    join part on lo_partkey = p_partkey\n" +
                    ") lo\n" +
                    "join (\n" +
                    "    select c_custkey\n" +
                    "    from customer\n" +
                    "    group by c_custkey\n" +
                    ") cust\n" +
                    "on lo.lo_custkey = cust.c_custkey;";
            sql(query).contains("mv3");
        });
        connectContext.getSessionVariable().setQueryIncludingMVNames("");
    }
```

The root cause is this:

```
        // For logic scan to physical scan, we only need to match once
        if (pattern.children().size() == 0 && groupExpressionIndex.get(0) > 0) {
        ...
       }
```
`PATTERN_MULTIJOIN`'s children is 0.

What I'm doing:
- Fix the bug above.
- Optimize some codes.

Fixes [#issue](https://github.com/StarRocks/starrocks/issues/40261)

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
