### PR TITLE
[UT] Fix lake persistent index tests which may time-consuming

### DIFF
--- a/be/test/storage/lake/lake_persistent_index_test.cpp
+++ b/be/test/storage/lake/lake_persistent_index_test.cpp
@@ -21,7 +21,7 @@
 
 namespace starrocks::lake {
 
-TEST(CloudNativePersistentIndexTest, test_basic_api) {
+TEST(LakePersistentIndexTest, test_basic_api) {
     using Key = uint64_t;
     const int N = 1000;
     vector<Key> keys;
@@ -102,13 +102,13 @@ TEST(CloudNativePersistentIndexTest, test_basic_api) {
     ASSERT_TRUE(index->upsert(N, upsert_key_slices.data(), upsert_values.data(), upsert_old_values.data()).ok());
 }
 
-TEST(CloudNativePersistentIndexTest, test_replace) {
+TEST(LakePersistentIndexTest, test_replace) {
     using Key = uint64_t;
     vector<Key> keys;
     vector<Slice> key_slices;
     vector<IndexValue> values;
     vector<IndexValue> replace_values;
-    const int N = 1000000;
+    const int N = 10000;
     keys.reserve(N);
     key_slices.reserve(N);
     vector<size_t> replace_idxes;

--- a/be/test/storage/lake/persistent_index_memtable_test.cpp
+++ b/be/test/storage/lake/persistent_index_memtable_test.cpp
@@ -121,7 +121,7 @@ TEST(PersistentIndexMemtableTest, test_replace) {
     vector<Slice> key_slices;
     vector<IndexValue> values;
     vector<IndexValue> replace_values;
-    const int N = 1000000;
+    const int N = 10000;
     keys.reserve(N);
     key_slices.reserve(N);
     vector<size_t> replace_idxes;


### PR DESCRIPTION
Why I'm doing:
Some UTs of lake persistent index  may costs more than 60s.
What I'm doing:
Reduce data size  in these uts.
Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [x] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
