### PR TITLE
[BugFix] remove queries_not_in_workgroup for /api/pipeline_blocking_drivers

### DIFF
--- a/be/src/http/action/pipeline_blocking_drivers_action.cpp
+++ b/be/src/http/action/pipeline_blocking_drivers_action.cpp
@@ -159,15 +159,10 @@ void PipelineBlockingDriversAction::_handle_stat(HttpRequest* req) {
             };
         };
 
-        QueryMap query_map_not_in_wg;
-        _exec_env->wg_driver_executor()->iterate_immutable_blocking_driver(iterate_func_generator(query_map_not_in_wg));
-        rapidjson::Document queries_not_in_wg_obj = query_map_to_doc_func(query_map_not_in_wg);
-
         QueryMap query_map_in_wg;
         _exec_env->wg_driver_executor()->iterate_immutable_blocking_driver(iterate_func_generator(query_map_in_wg));
         rapidjson::Document queries_in_wg_obj = query_map_to_doc_func(query_map_in_wg);
 
-        root.AddMember("queries_not_in_workgroup", queries_not_in_wg_obj, allocator);
         root.AddMember("queries_in_workgroup", queries_in_wg_obj, allocator);
     });
 }

--- a/be/src/http/action/pipeline_blocking_drivers_action.h
+++ b/be/src/http/action/pipeline_blocking_drivers_action.h
@@ -39,7 +39,7 @@ private:
     void _handle(HttpRequest* req, const std::function<void(rapidjson::Document& root)>& func);
     // Returns information about the blocking drivers with the following format:
     // {
-    //      "queries_not_in_workgroup": [{
+    //      "queries_in_workgroup": [{
     //          "query_id": "str",
     //          "fragments": [{
     //              "fragment_id": "str",
@@ -49,8 +49,7 @@ private:
     //                  "driver_desc": "str"
     //              }]
     //          }]
-    //      }],
-    //      "queries_in_workgroup": []
+    //      }]
     // }
     void _handle_stat(HttpRequest* req);
     void _handle_error(HttpRequest* req, const std::string& error_msg);


### PR DESCRIPTION
Why I'm doing:
#24421 removes logics of non-resource-group in BE, which just replaces all the invocations of `exec_env->driver_executor()` to `exec_env->wg_driver_executor()`. 
As a result, `/api/pipeline_blocking_drivers` will returns duplicated queries in the filed `queries_not_in_workgroup` and `queries_in_workgroup`.
```javascript
{
    "queries_not_in_workgroup": [/*query1, query2*/],
    "queries_in_workgroup":  [/*query1, query2*/]
}
```

What I'm doing:
Remove `queries_not_in_workgroup` from the result of  `/api/pipeline_blocking_drivers`.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [x] 3.1
  - [ ] 3.0
  - [ ] 2.5
