### PR TITLE
[BugFix] Avoid PruneEmptyScanRule on Iceberg tables with hasNullParti…

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/IcebergTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/IcebergTable.java
@@ -93,6 +93,8 @@ public class IcebergTable extends Table {
     private org.apache.iceberg.Table nativeTable; // actual iceberg table
     private List<Column> partitionColumns;
 
+    private boolean hasNullPartitionField = false;
+
     private final AtomicLong partitionIdGen = new AtomicLong(0L);
 
     public IcebergTable() {
@@ -135,6 +137,14 @@ public class IcebergTable extends Table {
             snapshot = Optional.ofNullable(getNativeTable().currentSnapshot());
             return snapshot;
         }
+    }
+
+    public boolean hasNullPartitionField() {
+        return hasNullPartitionField;
+    }
+
+    public void setHasNullPartitionField(boolean hasNullPartitionField) {
+        this.hasNullPartitionField = hasNullPartitionField;
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/IcebergTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/IcebergTable.java
@@ -143,8 +143,8 @@ public class IcebergTable extends Table {
         return hasNullPartitionField;
     }
 
-    public void setHasNullPartitionField(boolean hasNullPartitionField) {
-        this.hasNullPartitionField = hasNullPartitionField;
+    public void setNullPartitionTrue() {
+        this.hasNullPartitionField = true;
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/connector/PartitionUtil.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/PartitionUtil.java
@@ -725,6 +725,15 @@ public class PartitionUtil {
         return ICEBERG_DEFAULT_PARTITION;
     }
 
+    public static boolean hasNullPartitionField(PartitionSpec spec, PartitionData data) {
+        for (int i = 0; i < spec.fields().size(); i++) {
+            if (data.get(i) == null) {
+                return true;
+            }
+        }
+        return false;
+    }
+
     public static List<String> getIcebergPartitionValues(PartitionSpec spec, StructLike partition) {
         PartitionData partitionData = (PartitionData) partition;
         List<String> partitionValues = new ArrayList<>();

--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergMetadata.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergMetadata.java
@@ -117,6 +117,7 @@ import static com.google.common.collect.ImmutableList.toImmutableList;
 import static com.starrocks.common.profile.Tracers.Module.EXTERNAL;
 import static com.starrocks.connector.ColumnTypeConverter.fromIcebergType;
 import static com.starrocks.connector.PartitionUtil.createPartitionKeyWithType;
+import static com.starrocks.connector.PartitionUtil.hasNullPartitionField;
 import static com.starrocks.connector.iceberg.IcebergApiConverter.parsePartitionFields;
 import static com.starrocks.connector.iceberg.IcebergApiConverter.toIcebergApiSchema;
 import static com.starrocks.connector.iceberg.IcebergCatalogType.GLUE_CATALOG;
@@ -458,6 +459,12 @@ public class IcebergMetadata implements ConnectorMetadata {
         List<Column> partitionColumns = icebergTable.getPartitionColumnsIncludeTransformed();
         for (FileScanTask fileScanTask : icebergSplitTasks) {
             org.apache.iceberg.PartitionData partitionData = (org.apache.iceberg.PartitionData) fileScanTask.file().partition();
+
+            if (hasNullPartitionField(spec, partitionData)) {
+                icebergTable.setHasNullPartitionField(true);
+                return Lists.newArrayList();
+            }
+
             List<String> values = PartitionUtil.getIcebergPartitionValues(spec, partitionData);
 
             if (values.size() != partitionColumns.size()) {

--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergMetadata.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergMetadata.java
@@ -461,7 +461,7 @@ public class IcebergMetadata implements ConnectorMetadata {
             org.apache.iceberg.PartitionData partitionData = (org.apache.iceberg.PartitionData) fileScanTask.file().partition();
 
             if (hasNullPartitionField(spec, partitionData)) {
-                icebergTable.setHasNullPartitionField(true);
+                icebergTable.setNullPartitionTrue();
                 return Lists.newArrayList();
             }
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/logical/LogicalIcebergScanOperator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/logical/LogicalIcebergScanOperator.java
@@ -65,9 +65,11 @@ public class LogicalIcebergScanOperator extends LogicalScanOperator {
 
     @Override
     public boolean isEmptyOutputRows() {
-        return !table.isUnPartitioned() &&
-                !(((IcebergTable) table).hasPartitionTransformedEvolution()) &&
-                predicates.getSelectedPartitionIds().isEmpty();
+        IcebergTable icebergTable = (IcebergTable) table;
+        return !icebergTable.isUnPartitioned() &&
+               !icebergTable.hasNullPartitionField() &&
+               !icebergTable.hasPartitionTransformedEvolution() &&
+               predicates.getSelectedPartitionIds().isEmpty();
     }
 
     public boolean hasUnknownColumn() {


### PR DESCRIPTION
Normally, the Iceberg table does not `hasNullPartitionField`, but we encountered a similar situation, which resulted in presto or spark SQL being able to return the correct results, while StarRocks returned an empty set for all queries on this table.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [x] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5