### PR TITLE
[Enhancement] Support a fake BINARY in where clause syntax for BI

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/parser/StarRocks.g4
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/parser/StarRocks.g4
@@ -2250,7 +2250,7 @@ expressionSingleton
     ;
 
 expression
-    : booleanExpression                                                                   #expressionDefault
+    : (BINARY)? booleanExpression                                                         #expressionDefault
     | NOT expression                                                                      #logicalNot
     | left=expression operator=(AND|LOGICAL_AND) right=expression                         #logicalBinary
     | left=expression operator=(OR|LOGICAL_OR) right=expression                           #logicalBinary

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/SelectStmtTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/SelectStmtTest.java
@@ -140,6 +140,23 @@ public class SelectStmtTest {
     }
 
     @Test
+    void testNavicatBinarySupport() throws Exception {
+        String sql = "SELECT ACTION_ORDER, \n" +
+                "       EVENT_OBJECT_TABLE, \n" +
+                "       TRIGGER_NAME, \n" +
+                "       EVENT_MANIPULATION, \n" +
+                "       EVENT_OBJECT_TABLE, \n" +
+                "       DEFINER, \n" +
+                "       ACTION_STATEMENT, \n" +
+                "       ACTION_TIMING\n" +
+                "FROM information_schema.triggers\n" +
+                "WHERE BINARY event_object_schema = 'test_ods_inceptor' \n" +
+                "  AND BINARY event_object_table = 'cus_ast_total_d_p' \n" +
+                "ORDER BY event_object_table";
+        starRocksAssert.query(sql).explainQuery();
+    }
+
+    @Test
     void testEqualExprNotMonotonic() throws Exception {
         ConnectContext ctx = UtFrameUtils.createDefaultCtx();
         String sql = "select k1 from db1.baseall where (k1=10) = true";


### PR DESCRIPTION
Why I'm doing:
navicat will send a sql
```
SELECT ACTION_ORDER,
       EVENT_OBJECT_TABLE,
       TRIGGER_NAME,
       EVENT_MANIPULATION,
       EVENT_OBJECT_TABLE,
       DEFINER,
       ACTION_STATEMENT,
       ACTION_TIMING
FROM information_schema.triggers
WHERE BINARY event_object_schema = 'test_ods_inceptor'
  AND BINARY event_object_table = 'cus_ast_total_d_p'
ORDER BY event_object_table
```
will throw
ERROR 1064 (HY000): Getting syntax error at line 3, column 66. Detail message: Unexpected input 'event_object_table', the most similar input is {<EOF>, ';'}.

What I'm doing:
Support a fake binary syntax so that this SQL can be executed normally. If there are users who need to support this syntax later, we will consider submitting another PR.

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [x] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [x] 3.1
  - [ ] 3.0
  - [ ] 2.5
