### PR TITLE
[UT] Optimise BDBEnvironmentTest.testRollbackExceptionOnSetupCluster to run faster

### DIFF
--- a/fe/fe-core/src/test/java/com/starrocks/journal/bdbje/BDBEnvironmentTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/journal/bdbje/BDBEnvironmentTest.java
@@ -20,7 +20,6 @@ import com.sleepycat.je.EnvironmentConfig;
 import com.sleepycat.je.LockMode;
 import com.sleepycat.je.dbi.DbConfigManager;
 import com.sleepycat.je.rep.ReplicatedEnvironment;
-import com.sleepycat.je.rep.ReplicationConfig;
 import com.sleepycat.je.rep.RollbackException;
 import com.sleepycat.je.rep.impl.RepGroupImpl;
 import com.sleepycat.je.rep.impl.RepImpl;

--- a/fe/fe-core/src/test/java/com/starrocks/journal/bdbje/BDBEnvironmentTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/journal/bdbje/BDBEnvironmentTest.java
@@ -16,14 +16,24 @@
 package com.starrocks.journal.bdbje;
 
 import com.sleepycat.je.DatabaseEntry;
+import com.sleepycat.je.EnvironmentConfig;
 import com.sleepycat.je.LockMode;
+import com.sleepycat.je.dbi.DbConfigManager;
 import com.sleepycat.je.rep.ReplicatedEnvironment;
+import com.sleepycat.je.rep.ReplicationConfig;
+import com.sleepycat.je.rep.RollbackException;
 import com.sleepycat.je.rep.impl.RepGroupImpl;
+import com.sleepycat.je.rep.impl.RepImpl;
+import com.sleepycat.je.rep.stream.MatchpointSearchResults;
+import com.sleepycat.je.utilint.DatabaseUtil;
+import com.sleepycat.je.utilint.VLSN;
 import com.starrocks.common.Config;
 import com.starrocks.journal.JournalException;
 import com.starrocks.utframe.UtFrameUtils;
+import mockit.Expectations;
 import mockit.Mock;
 import mockit.MockUp;
+import mockit.Mocked;
 import org.apache.commons.io.FileUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -298,122 +308,32 @@ public class BDBEnvironmentTest {
      * we think it's reached our expectation.
      */
     @Test
-    public void testRollbackExceptionOnSetupCluster() throws Exception {
-        initClusterMasterFollower();
+    public void testRollbackExceptionOnSetupCluster(@Mocked RepImpl rep) throws Exception {
+        new Expectations() {
+            {
+                rep.getName();
+                minTimes = 0;
+                result = "starrocks";
 
-        // leader write db 0
-        Long dbIndexOld = 0L;
-        String dbNameOld = String.valueOf(dbIndexOld);
-        CloseSafeDatabase leaderDb = leaderEnvironment.openDatabase(dbNameOld);
-        DatabaseEntry key = randomEntry();
-        DatabaseEntry value = randomEntry();
-        leaderDb.put(null, key, value);
-        leaderDb.close();
-        Assert.assertEquals(1, leaderEnvironment.getDatabaseNames().size());
-        Assert.assertEquals(dbIndexOld, leaderEnvironment.getDatabaseNames().get(0));
+                rep.isValid();
+                minTimes = 0;
+                result = false;
 
-        Thread.sleep(1000);
-
-        // follower read db 0
-        for (BDBEnvironment followerEnvironment : followerEnvironments) {
-            CloseSafeDatabase followerDb = followerEnvironment.openDatabase(dbNameOld);
-            DatabaseEntry newvalue = new DatabaseEntry();
-            followerDb.get(null, key, newvalue, LockMode.READ_COMMITTED);
-            Assert.assertEquals(new String(value.getData()), new String(newvalue.getData()));
-            Assert.assertEquals(1, followerEnvironment.getDatabaseNames().size());
-            Assert.assertEquals(dbIndexOld, followerEnvironment.getDatabaseNames().get(0));
-            followerDb.close();
-        }
-
-        // manually backup follower's meta dir
-        for (File followerPath : followerPaths) {
-            File dst = new File(followerPath.getAbsolutePath() + "_bk");
-            LOG.info("backup {} to {}", followerPath, dst);
-            FileUtils.copyDirectory(followerPath, dst);
-        }
-
-        // leader write 2 * txn_rollback_limit lines in new db and quit
-        Long dbIndexNew = 1L;
-        String dbNameNew = String.valueOf(dbIndexNew);
-        leaderDb = leaderEnvironment.openDatabase(dbNameNew);
-        for (int i = 0; i < Config.txn_rollback_limit * 2; i++) {
-            leaderDb.put(null, randomEntry(), randomEntry());
-        }
-        leaderDb.close();
-        Assert.assertEquals(2, leaderEnvironment.getDatabaseNames().size());
-        Assert.assertEquals(dbIndexOld, leaderEnvironment.getDatabaseNames().get(0));
-        Assert.assertEquals(dbIndexNew, leaderEnvironment.getDatabaseNames().get(1));
-
-        // close all environment
-        leaderEnvironment.close();
-        for (BDBEnvironment followerEnvironment : followerEnvironments) {
-            followerEnvironment.close();
-        }
-
-        // restore follower's path
-        for (File followerPath : followerPaths) {
-            LOG.info("delete {} ", followerPath);
-            FileUtils.deleteDirectory(followerPath);
-            File src = new File(followerPath.getAbsolutePath() + "_bk");
-            LOG.info("mv {} to {}", src, followerPath);
-            FileUtils.moveDirectory(src, followerPath);
-        }
-
-        Thread.sleep(1000);
-
-        // start follower
-        // Since we have brutally copied the metadata directory of the follower, there's a slight chance that restart
-        // would fail with the following error
-        //
-        // follower0(2):./BDBEnvironmentTest1759179149378245783 Log file 00000000.jdb was deleted unexpectedly.
-        // LOG_UNEXPECTED_FILE_DELETION: A log file was unexpectedly deleted, log is likely invalid.
-        // Environment is invalid and must be closed.
-        //
-        // We'll ignore such scenario
-        try {
-            for (int i = 0; i < 2; ++i) {
-                followerEnvironments[i] = new BDBEnvironment(
-                        followerPaths[i],
-                        String.format("follower%d", i),
-                        followerNodeHostPorts[i],
-                        followerNodeHostPorts[i],
-                        true);
-                followerEnvironments[i].setup();
-                Assert.assertEquals(1, followerEnvironments[i].getDatabaseNames().size());
-                Assert.assertEquals(dbIndexOld, followerEnvironments[i].getDatabaseNames().get(0));
+                rep.getConfigManager();
+                minTimes = 0;
+                result = new DbConfigManager(new EnvironmentConfig());
             }
-        } catch (JournalException e) {
-            LOG.warn("restart fails in testRollbackExceptionOnSetupCluster, ignore this case, ", e);
-            return;
-        }
+        };
 
-        Thread.sleep(1000);
-
-        // wait for state change
-        BDBEnvironment newMasterEnvironment = null;
-        while (newMasterEnvironment == null) {
-            Thread.sleep(1000);
-            for (int i = 0; i < 2; ++ i) {
-                if (followerEnvironments[i].getReplicatedEnvironment().getState() == ReplicatedEnvironment.State.MASTER) {
-                    newMasterEnvironment = followerEnvironments[i];
-                    LOG.warn("=========> new leader is {}", newMasterEnvironment.getReplicatedEnvironment().getNodeName());
-                    leaderDb = newMasterEnvironment.openDatabase(dbNameOld);
-                    key = randomEntry();
-                    value = randomEntry();
-                    leaderDb.put(null, key, value);
-
-                    Thread.sleep(1000);
-
-                    int followerIndex = 1 - i;
-                    CloseSafeDatabase followerDb = followerEnvironments[followerIndex].openDatabase(dbNameOld);
-                    DatabaseEntry newvalue = new DatabaseEntry();
-                    followerDb.get(null, key, newvalue, LockMode.READ_COMMITTED);
-                    Assert.assertEquals(new String(value.getData()), new String(newvalue.getData()));
-                    break;
-                }
+        new MockUp<DatabaseUtil>() {
+            @Mock
+            public void checkForNullParam(final Object param, final String name) {
+                throw new RollbackException(rep, VLSN.FIRST_VLSN, new MatchpointSearchResults(rep));
             }
-        }
+        };
 
+        leaderNodeHostPort = findUnbindHostPort();
+        leaderPath = createTmpDir();
         // set retry times = 1 to ensure no recovery
         BDBEnvironment.RETRY_TIME = 1;
         // start leader will get rollback exception

--- a/fe/fe-core/src/test/java/com/starrocks/journal/bdbje/BDBEnvironmentTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/journal/bdbje/BDBEnvironmentTest.java
@@ -325,6 +325,7 @@ public class BDBEnvironmentTest {
             }
         };
 
+        // mock DatabaseUtil.checkForNullParam to generate RollBackException
         new MockUp<DatabaseUtil>() {
             @Mock
             public void checkForNullParam(final Object param, final String name) {


### PR DESCRIPTION
Why I'm doing:

What I'm doing:
Mock the DatabaseUtil.checkForNullParam to generate RollBackException. 

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [x] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [x] 3.1
  - [x] 3.0
  - [x] 2.5
