### PR TITLE
[BugFix] Fix function not found in trino mode

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/connector/parser/trino/AstBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/parser/trino/AstBuilder.java
@@ -695,7 +695,8 @@ public class AstBuilder extends AstVisitor<ParseNode, ParseTreeContext> {
         }  else if (FunctionSet.INFORMATION_FUNCTIONS.contains(node.getName().toString())) {
             callExpr = new InformationFunction(node.getName().toString().toUpperCase());
         } else {
-            callExpr = new FunctionCallExpr(node.getName().toString(), arguments);
+            FunctionName functionName = FunctionName.createFnName(node.getName().toString());
+            callExpr = new FunctionCallExpr(functionName, arguments);
         }
         if (node.getWindow().isPresent()) {
             return visitWindow((FunctionCallExpr) callExpr, node.getWindow().get(), context);

--- a/fe/fe-core/src/test/java/com/starrocks/connector/parser/trino/TrinoQueryTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/parser/trino/TrinoQueryTest.java
@@ -387,6 +387,12 @@ public class TrinoQueryTest extends TrinoTestBase {
     }
 
     @Test
+    public void testSelectFunctionWithDb() throws Exception {
+        String sql = "select test.concat_ws(',', 'test1', 'test2')";
+        assertPlanContains(sql, "concat_ws");
+    }
+
+    @Test
     public void testSelectStruct() throws Exception {
         String sql = "select c0, c1.a from test_struct";
         assertPlanContains(sql, "1:Project\n" +


### PR DESCRIPTION
Why I'm doing:

In trino mode, if you use db.function to call a function, even if the function exists, an error will be reported that the function cannot be found.

What I'm doing:

Create FunctionName in com.starrocks.connector.parser.trino.AstBuilder.visitFunctionCall with  com.starrocks.analysis.FunctionName.createFnName so that the db name and func name are set correctly.

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [x] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [x] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5