### PR TITLE
[Feature] concat_ws supports array type parameters

### DIFF
--- a/be/src/exprs/array_functions.h
+++ b/be/src/exprs/array_functions.h
@@ -72,6 +72,14 @@ public:
         return ArrayJoin::process(context, columns);
     }
 
+    static StatusOr<ColumnPtr> array_concat_ws(FunctionContext* context, const Columns& columns) {
+        DCHECK_EQ(columns.size(), 2);
+        Columns new_columns(2);
+        new_columns[0] = columns[1];
+        new_columns[1] = columns[0];
+        return ArrayJoin::process(context, new_columns);
+    }
+
     template <LogicalType type>
     static StatusOr<ColumnPtr> array_sum(FunctionContext* context, const Columns& columns) {
         return ArrayArithmetic::template array_sum<type>(context, columns);

--- a/be/test/exprs/array_functions_test.cpp
+++ b/be/test/exprs/array_functions_test.cpp
@@ -4358,6 +4358,22 @@ TEST_F(ArrayFunctionsTest, array_join_string) {
     ASSERT_EQ(Slice("44__33__22__112"), dest_column->get(2).get_slice());
 }
 
+TEST_F(ArrayFunctionsTest, array_concat_ws) {
+    auto src_column = ColumnHelper::create_column(TYPE_ARRAY_VARCHAR, true);
+    src_column->append_datum(DatumArray{"352", "66", "4325"});
+    src_column->append_datum(DatumArray{"235", "99", "8", "43251"});
+    src_column->append_datum(DatumArray{"44", "33", "22", "112"});
+
+    Slice sep_str("__");
+    auto sep_column = ColumnHelper::create_const_column<LogicalType::TYPE_VARCHAR>(sep_str, 3);
+
+    ColumnPtr dest_column = ArrayFunctions::array_concat_ws(nullptr, {sep_column, src_column}).value();
+    ASSERT_EQ(dest_column->size(), 3);
+    ASSERT_EQ(Slice("352__66__4325"), dest_column->get(0).get_slice());
+    ASSERT_EQ(Slice("235__99__8__43251"), dest_column->get(1).get_slice());
+    ASSERT_EQ(Slice("44__33__22__112"), dest_column->get(2).get_slice());
+}
+
 // NOLINTNEXTLINE
 TEST_F(ArrayFunctionsTest, array_join_nullable_elements) {
     auto src_column = ColumnHelper::create_column(TYPE_ARRAY_VARCHAR, true);
@@ -4382,6 +4398,22 @@ TEST_F(ArrayFunctionsTest, array_join_nullable_elements) {
     ASSERT_EQ(Slice("55__NULL__333__6666"), dest_column->get(0).get_slice());
     ASSERT_EQ(Slice("22__333__NULL__NULL"), dest_column->get(1).get_slice());
     ASSERT_EQ(Slice("NULL__NULL__NULL__NULL"), dest_column->get(2).get_slice());
+}
+
+TEST_F(ArrayFunctionsTest, array_concat_ws_nullable_elements) {
+    auto src_column = ColumnHelper::create_column(TYPE_ARRAY_VARCHAR, true);
+    src_column->append_datum(DatumArray{"55", Datum(), "333", "6666"});
+    src_column->append_datum(DatumArray{"22", "333", Datum(), Datum()});
+    src_column->append_datum(DatumArray{Datum(), Datum(), Datum(), Datum()});
+
+    Slice sep_str("__");
+    auto sep_column = ColumnHelper::create_const_column<LogicalType::TYPE_VARCHAR>(sep_str, 3);
+
+    ColumnPtr dest_column = ArrayFunctions::array_concat_ws(nullptr, {sep_column, src_column}).value();
+    ASSERT_EQ(dest_column->size(), 3);
+    ASSERT_EQ(Slice("55__333__6666"), dest_column->get(0).get_slice());
+    ASSERT_EQ(Slice("22__333"), dest_column->get(1).get_slice());
+    ASSERT_EQ(Slice(""), dest_column->get(2).get_slice());
 }
 
 // NOLINTNEXTLINE
@@ -4410,6 +4442,22 @@ TEST_F(ArrayFunctionsTest, array_join_nullable_array) {
     ASSERT_EQ(Slice("NULL__NULL__NULL__NULL"), dest_column->get(2).get_slice());
 }
 
+TEST_F(ArrayFunctionsTest, array_concat_ws_nullable_array) {
+    auto src_column = ColumnHelper::create_column(TYPE_ARRAY_VARCHAR, true);
+    src_column->append_datum(DatumArray{"5", Datum(), "33", "666"});
+    src_column->append_datum(Datum());
+    src_column->append_datum(DatumArray{Datum(), Datum(), Datum(), Datum()});
+
+    Slice sep_str("__");
+    auto sep_column = ColumnHelper::create_const_column<LogicalType::TYPE_VARCHAR>(sep_str, 3);
+
+    ColumnPtr dest_column = ArrayFunctions::array_concat_ws(nullptr, {sep_column, src_column}).value();
+    ASSERT_EQ(dest_column->size(), 3);
+    ASSERT_EQ(Slice("5__33__666"), dest_column->get(0).get_slice());
+    ASSERT_TRUE(dest_column->get(1).is_null());
+    ASSERT_EQ(Slice(""), dest_column->get(2).get_slice());
+}
+
 // NOLINTNEXTLINE
 TEST_F(ArrayFunctionsTest, array_join_only_null) {
     auto src_column = ColumnHelper::create_const_null_column(3);
@@ -4427,6 +4475,19 @@ TEST_F(ArrayFunctionsTest, array_join_only_null) {
     ASSERT_TRUE(dest_column->get(2).is_null());
 
     dest_column = ArrayJoin::process(nullptr, {src_column, sep_column, null_column});
+    ASSERT_EQ(dest_column->size(), 3);
+    ASSERT_TRUE(dest_column->get(0).is_null());
+    ASSERT_TRUE(dest_column->get(1).is_null());
+    ASSERT_TRUE(dest_column->get(2).is_null());
+}
+
+TEST_F(ArrayFunctionsTest, array_concat_ws_only_null) {
+    auto src_column = ColumnHelper::create_const_null_column(3);
+
+    Slice sep_str("__");
+    auto sep_column = ColumnHelper::create_const_column<LogicalType::TYPE_VARCHAR>(sep_str, 3);
+
+    ColumnPtr dest_column = ArrayFunctions::array_concat_ws(nullptr, {sep_column, src_column}).value();
     ASSERT_EQ(dest_column->size(), 3);
     ASSERT_TRUE(dest_column->get(0).is_null());
     ASSERT_TRUE(dest_column->get(1).is_null());

--- a/fe/fe-core/src/test/java/com/starrocks/connector/parser/trino/TrinoFunctionTransformTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/parser/trino/TrinoFunctionTransformTest.java
@@ -78,6 +78,16 @@ public class TrinoFunctionTransformTest extends TrinoTestBase {
 
         sql = "select contains_sequence(array[1,2,3], array[1,2])";
         assertPlanContains(sql, "array_contains_seq([1,2,3], [1,2])");
+
+        sql = "select concat_ws('_', array['1','2','3'])";
+        assertPlanContains(sql, "concat_ws('_', ['1','2','3'])");
+
+        sql = "select concat_ws('|', array_agg(event_type)) from "
+            + "(select 1 as event_type union all select 1 as event_type union all select 2 as event_type)";
+        assertPlanContains(sql, "concat_ws('|', CAST(8: array_agg AS ARRAY<VARCHAR>))");
+
+        sql = "select concat_ws('.', 5,6,'s',8,9,10)";
+        assertPlanContains(sql, "'5.6.s.8.9.10'");
     }
 
     @Test

--- a/gensrc/script/functions.py
+++ b/gensrc/script/functions.py
@@ -292,6 +292,7 @@ vectorized_functions = [
     [30250, 'concat', 'VARCHAR', ['VARCHAR', '...'], 'StringFunctions::concat', 'StringFunctions::concat_prepare', 'StringFunctions::concat_close'],
 
     [30260, 'concat_ws', 'VARCHAR', ['VARCHAR', 'VARCHAR', '...'], 'StringFunctions::concat_ws'],
+    [30261, 'concat_ws', 'VARCHAR', ['VARCHAR', 'ARRAY_VARCHAR'], 'ArrayFunctions::array_concat_ws'],
     [30270, 'find_in_set', 'INT', ['VARCHAR', 'VARCHAR'], 'StringFunctions::find_in_set'],
     [30310, 'split_part', 'VARCHAR', ['VARCHAR', 'VARCHAR', 'INT'], 'StringFunctions::split_part'],
     [30311, 'split', 'ARRAY_VARCHAR', ['VARCHAR', 'VARCHAR'], 'StringFunctions::split', 'StringFunctions::split_prepare', 'StringFunctions::split_close'],


### PR DESCRIPTION
Why I'm doing:

When I use hive, the second parameter of concat_ws can be of array type. After migrating to starrocks, it needs to be changed to array_join, and the order of parameters also needs to be changed, which makes migration difficult.

What I'm doing:

A new concat_ws function that supports array input parameters is added in be, and the code logic of array_join is used

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [x] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [x] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [x] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
