### PR TITLE
[Enhancement] Add `without-starcache` build option to control whether build with starcache library.

### DIFF
--- a/be/src/block_cache/block_cache.cpp
+++ b/be/src/block_cache/block_cache.cpp
@@ -106,7 +106,7 @@ Status BlockCache::write_buffer(const CacheKey& cache_key, off_t offset, size_t 
 }
 
 Status BlockCache::write_object(const CacheKey& cache_key, const void* ptr, size_t size, DeleterFunc deleter,
-                                CacheHandle* handle, WriteCacheOptions* options) {
+                                DataCacheHandle* handle, WriteCacheOptions* options) {
     if (!ptr) {
         return Status::InvalidArgument("invalid object pointer");
     }
@@ -132,7 +132,7 @@ StatusOr<size_t> BlockCache::read_buffer(const CacheKey& cache_key, off_t offset
     return buffer.size();
 }
 
-Status BlockCache::read_object(const CacheKey& cache_key, CacheHandle* handle, ReadCacheOptions* options) {
+Status BlockCache::read_object(const CacheKey& cache_key, DataCacheHandle* handle, ReadCacheOptions* options) {
     return _kv_cache->read_object(cache_key, handle, options);
 }
 

--- a/be/src/block_cache/block_cache.h
+++ b/be/src/block_cache/block_cache.h
@@ -14,6 +14,8 @@
 
 #pragma once
 
+#include <atomic>
+
 #include "block_cache/disk_space_monitor.h"
 #include "block_cache/kv_cache.h"
 #include "common/status.h"
@@ -42,7 +44,7 @@ public:
 
     // Write object to cache, the `ptr` is the object pointer.
     Status write_object(const CacheKey& cache_key, const void* ptr, size_t size, DeleterFunc deleter,
-                        CacheHandle* handle, WriteCacheOptions* options = nullptr);
+                        DataCacheHandle* handle, WriteCacheOptions* options = nullptr);
 
     // Read data from cache, it returns the data size if successful; otherwise the error status
     // will be returned. The offset and size must be aligned by block size.
@@ -55,7 +57,7 @@ public:
     // Read object from cache, the `handle` wraps the object pointer.
     // As long as the handle object is not destroyed and the user does not manully call the `handle->release()`
     // function, the corresponding pointer will never be freed by the cache system.
-    Status read_object(const CacheKey& cache_key, CacheHandle* handle, ReadCacheOptions* options = nullptr);
+    Status read_object(const CacheKey& cache_key, DataCacheHandle* handle, ReadCacheOptions* options = nullptr);
 
     // Remove data from cache. The offset and size must be aligned by block size
     Status remove(const CacheKey& cache_key, off_t offset, size_t size);

--- a/be/src/block_cache/cachelib_wrapper.cpp
+++ b/be/src/block_cache/cachelib_wrapper.cpp
@@ -101,11 +101,12 @@ const DataCacheMetrics CacheLibWrapper::cache_metrics(int level) {
 }
 
 Status CacheLibWrapper::write_object(const std::string& key, const void* ptr, size_t size,
-                                     std::function<void()> deleter, CacheHandle* handle, WriteCacheOptions* options) {
+                                     std::function<void()> deleter, DataCacheHandle* handle,
+                                     WriteCacheOptions* options) {
     return Status::NotSupported("not supported write object in cachelib");
 }
 
-Status CacheLibWrapper::read_object(const std::string& key, CacheHandle* handle, ReadCacheOptions* options) {
+Status CacheLibWrapper::read_object(const std::string& key, DataCacheHandle* handle, ReadCacheOptions* options) {
     return Status::NotSupported("not supported read object in cachelib");
 }
 

--- a/be/src/block_cache/cachelib_wrapper.h
+++ b/be/src/block_cache/cachelib_wrapper.h
@@ -47,12 +47,12 @@ public:
     Status write_buffer(const std::string& key, const IOBuffer& buffer, WriteCacheOptions* options) override;
 
     Status write_object(const std::string& key, const void* ptr, size_t size, std::function<void()> deleter,
-                        CacheHandle* handle, WriteCacheOptions* options) override;
+                        DataCacheHandle* handle, WriteCacheOptions* options) override;
 
     Status read_buffer(const std::string& key, size_t off, size_t size, IOBuffer* buffer,
                        ReadCacheOptions* options) override;
 
-    Status read_object(const std::string& key, CacheHandle* handle, ReadCacheOptions* options) override;
+    Status read_object(const std::string& key, DataCacheHandle* handle, ReadCacheOptions* options) override;
 
     Status remove(const std::string& key) override;
 

--- a/be/src/block_cache/datacache_utils.cpp
+++ b/be/src/block_cache/datacache_utils.cpp
@@ -17,13 +17,13 @@
 namespace starrocks {
 void DataCacheUtils::set_metrics_from_thrift(TDataCacheMetrics& t_metrics, const DataCacheMetrics& metrics) {
     switch (metrics.status) {
-    case starcache::CacheStatus::NORMAL:
+    case DataCacheStatus::NORMAL:
         t_metrics.__set_status(TDataCacheStatus::NORMAL);
         break;
-    case starcache::CacheStatus::UPDATING:
+    case DataCacheStatus::UPDATING:
         t_metrics.__set_status(TDataCacheStatus::UPDATING);
         break;
-    case starcache::CacheStatus::LOADING:
+    case DataCacheStatus::LOADING:
         t_metrics.__set_status(TDataCacheStatus::LOADING);
         break;
     default:

--- a/be/src/block_cache/dummy_types.h
+++ b/be/src/block_cache/dummy_types.h
@@ -14,9 +14,7 @@
 
 #pragma once
 
-#ifdef WITH_STARCACHE
-#include "starcache/obj_handle.h"
-#endif
+#include "common/status.h"
 
 namespace starrocks {
 
@@ -29,14 +27,20 @@ public:
     void release() {}
 };
 
-// We use the `starcache::ObjectHandle` directly because implementing a new one seems unnecessary.
-// Importing the starcache headers here is not graceful, but the `cachelib` doesn't support
-// object cache and we'll deprecate it for some performance reasons. Now there is no need to
-// pay too much attention to the compatibility and upper-level abstraction of the cachelib interface.
-#ifdef WITH_STARCACHE
-using CacheHandle = starcache::ObjectHandle;
-#else
-using CacheHandle = DummyCacheHandle;
-#endif
+enum class DummyCacheStatus { NORMAL, UPDATING, ABNORMAL, LOADING };
+
+struct DummyCacheMetrics {
+    struct DirSpace {
+        std::string path;
+        size_t quota_bytes;
+    };
+    DummyCacheStatus status;
+    int64_t mem_quota_bytes;
+    size_t mem_used_bytes;
+    size_t disk_quota_bytes;
+    size_t disk_used_bytes;
+    std::vector<DirSpace> disk_dir_spaces;
+    size_t meta_used_bytes = 0;
+};
 
 } // namespace starrocks

--- a/be/src/block_cache/starcache_wrapper.cpp
+++ b/be/src/block_cache/starcache_wrapper.cpp
@@ -74,7 +74,8 @@ Status StarCacheWrapper::write_buffer(const std::string& key, const IOBuffer& bu
 }
 
 Status StarCacheWrapper::write_object(const std::string& key, const void* ptr, size_t size,
-                                      std::function<void()> deleter, CacheHandle* handle, WriteCacheOptions* options) {
+                                      std::function<void()> deleter, DataCacheHandle* handle,
+                                      WriteCacheOptions* options) {
     if (!options) {
         return to_status(_cache->set_object(key, ptr, size, deleter, handle, nullptr));
     }
@@ -109,7 +110,7 @@ Status StarCacheWrapper::read_buffer(const std::string& key, size_t off, size_t 
     return st;
 }
 
-Status StarCacheWrapper::read_object(const std::string& key, CacheHandle* handle, ReadCacheOptions* options) {
+Status StarCacheWrapper::read_object(const std::string& key, DataCacheHandle* handle, ReadCacheOptions* options) {
     if (!options) {
         return to_status(_cache->get_object(key, handle, nullptr));
     }

--- a/be/src/block_cache/starcache_wrapper.h
+++ b/be/src/block_cache/starcache_wrapper.h
@@ -31,12 +31,12 @@ public:
     Status write_buffer(const std::string& key, const IOBuffer& buffer, WriteCacheOptions* options) override;
 
     Status write_object(const std::string& key, const void* ptr, size_t size, std::function<void()> deleter,
-                        CacheHandle* handle, WriteCacheOptions* options) override;
+                        DataCacheHandle* handle, WriteCacheOptions* options) override;
 
     Status read_buffer(const std::string& key, size_t off, size_t size, IOBuffer* buffer,
                        ReadCacheOptions* options) override;
 
-    Status read_object(const std::string& key, CacheHandle* handle, ReadCacheOptions* options) override;
+    Status read_object(const std::string& key, DataCacheHandle* handle, ReadCacheOptions* options) override;
 
     Status remove(const std::string& key) override;
 

--- a/be/src/exec/schema_scanner/schema_be_datacache_metrics_scanner.cpp
+++ b/be/src/exec/schema_scanner/schema_be_datacache_metrics_scanner.cpp
@@ -47,10 +47,10 @@ Status SchemaBeDataCacheMetricsScanner::get_next(ChunkPtr* chunk, bool* eos) {
         const DataCacheMetrics& metrics = cache->cache_metrics();
 
         switch (metrics.status) {
-        case starcache::CacheStatus::NORMAL:
+        case DataCacheStatus::NORMAL:
             status = "Normal";
             break;
-        case starcache::CacheStatus::UPDATING:
+        case DataCacheStatus::UPDATING:
             status = "Updating";
             break;
         default:

--- a/be/src/formats/parquet/file_reader.cpp
+++ b/be/src/formats/parquet/file_reader.cpp
@@ -218,7 +218,7 @@ Status FileReader::_get_footer() {
     }
 
     BlockCache* cache = _cache;
-    CacheHandle cache_handle;
+    DataCacheHandle cache_handle;
     std::string metacache_key = _build_metacache_key();
     {
         SCOPED_RAW_TIMER(&_scanner_ctx->stats->footer_cache_read_ns);

--- a/be/src/http/action/datacache_action.cpp
+++ b/be/src/http/action/datacache_action.cpp
@@ -93,6 +93,7 @@ void DataCacheAction::_handle(HttpRequest* req, const std::function<void(rapidjs
 
 void DataCacheAction::_handle_stat(HttpRequest* req, BlockCache* cache) {
     _handle(req, [=](rapidjson::Document& root) {
+#ifdef WITH_STARCACHE
         auto& allocator = root.GetAllocator();
         auto&& metrics = cache->cache_metrics(2);
         std::string status = cache_status_str(metrics.status);
@@ -168,6 +169,7 @@ void DataCacheAction::_handle_stat(HttpRequest* req, BlockCache* cache) {
         root.AddMember("current_writing_count", rapidjson::Value(metrics.detail_l2->current_writing_count), allocator);
         root.AddMember("current_removing_count", rapidjson::Value(metrics.detail_l2->current_removing_count),
                        allocator);
+#endif
     });
 }
 

--- a/be/src/service/service_be/starrocks_be.cpp
+++ b/be/src/service/service_be/starrocks_be.cpp
@@ -69,6 +69,7 @@ Status init_datacache(GlobalEnv* global_env, const std::vector<StorePath>& stora
 
 #if !defined(WITH_CACHELIB) && !defined(WITH_STARCACHE)
     if (config::datacache_enable) {
+        LOG(WARNING) << "No valid engines supported, skip initializing datacache module";
         config::datacache_enable = false;
     }
 #endif
@@ -180,7 +181,11 @@ void start_be(const std::vector<StorePath>& paths, bool as_cn) {
         LOG(ERROR) << "Fail to init datacache";
         exit(1);
     }
-    LOG(INFO) << "BE start step " << start_step++ << ": datacache init successfully";
+    if (config::datacache_enable) {
+        LOG(INFO) << process_name << " start step " << start_step++ << ": datacache init successfully";
+    } else {
+        LOG(INFO) << process_name << " starts by skipping the datacache initialization";
+    }
 
     // Start thrift server
     int thrift_port = config::be_port;

--- a/be/test/block_cache/datacache_utils_test.cpp
+++ b/be/test/block_cache/datacache_utils_test.cpp
@@ -24,19 +24,19 @@ class DataCacheUtilsTest : public ::testing::Test {};
 TEST_F(DataCacheUtilsTest, test_set_metrics_from_thrift) {
     TDataCacheMetrics t_metrics{};
     DataCacheMetrics metrics{};
-    metrics.status = starcache::CacheStatus::NORMAL;
+    metrics.status = DataCacheStatus::NORMAL;
     DataCacheUtils::set_metrics_from_thrift(t_metrics, metrics);
     ASSERT_EQ(t_metrics.status, TDataCacheStatus::NORMAL);
 
-    metrics.status = starcache::CacheStatus::UPDATING;
+    metrics.status = DataCacheStatus::UPDATING;
     DataCacheUtils::set_metrics_from_thrift(t_metrics, metrics);
     ASSERT_EQ(t_metrics.status, TDataCacheStatus::UPDATING);
 
-    metrics.status = starcache::CacheStatus::LOADING;
+    metrics.status = DataCacheStatus::LOADING;
     DataCacheUtils::set_metrics_from_thrift(t_metrics, metrics);
     ASSERT_EQ(t_metrics.status, TDataCacheStatus::LOADING);
 
-    metrics.status = starcache::CacheStatus::ABNORMAL;
+    metrics.status = DataCacheStatus::ABNORMAL;
     DataCacheUtils::set_metrics_from_thrift(t_metrics, metrics);
     ASSERT_EQ(t_metrics.status, TDataCacheStatus::ABNORMAL);
 }

--- a/build.sh
+++ b/build.sh
@@ -92,6 +92,8 @@ Usage: $0 <options>
      --with-bench       build Backend with bench(default without bench)
      --with-clang-tidy  build Backend with clang-tidy(default without clang-tidy)
      --without-java-ext build Backend without java-extensions(default with java-extensions)
+     --without-starcache
+                        build Backend without starcache library
      -j                 build Backend parallel
      --output-compile-time 
                         save a list of the compile time for every C++ file in ${ROOT}/compile_times.txt.
@@ -123,6 +125,7 @@ OPTS=$(getopt \
   -l 'with-clang-tidy' \
   -l 'without-gcov' \
   -l 'without-java-ext' \
+  -l 'without-starcache' \
   -l 'use-staros' \
   -l 'enable-shared-data' \
   -l 'output-compile-time' \
@@ -145,6 +148,7 @@ RUN_UT=
 WITH_GCOV=OFF
 WITH_BENCH=OFF
 WITH_CLANG_TIDY=OFF
+WITH_STARCACHE=ON
 USE_STAROS=OFF
 BUILD_JAVA_EXT=ON
 OUTPUT_COMPILE_TIME=OFF
@@ -229,6 +233,7 @@ else
             --with-bench) WITH_BENCH=ON; shift ;;
             --with-clang-tidy) WITH_CLANG_TIDY=ON; shift ;;
             --without-java-ext) BUILD_JAVA_EXT=OFF; shift ;;
+            --without-starcache) WITH_STARCACHE=OFF; shift ;;
             --output-compile-time) OUTPUT_COMPILE_TIME=ON; shift ;;
             -h) HELP=1; shift ;;
             --help) HELP=1; shift ;;
@@ -261,6 +266,7 @@ echo "Get params:
     WITH_GCOV           -- $WITH_GCOV
     WITH_BENCH          -- $WITH_BENCH
     WITH_CLANG_TIDY     -- $WITH_CLANG_TIDY
+    WITH_STARCACHE      -- $WITH_STARCACHE
     ENABLE_SHARED_DATA  -- $USE_STAROS
     USE_AVX2            -- $USE_AVX2
     USE_AVX512          -- $USE_AVX512
@@ -362,6 +368,7 @@ if [ ${BUILD_BE} -eq 1 ] ; then
                   -DWITH_BENCH=${WITH_BENCH}                            \
                   -DWITH_CLANG_TIDY=${WITH_CLANG_TIDY}                  \
                   -DWITH_COMPRESS=${WITH_COMPRESS}                      \
+                  -DWITH_STARCACHE=${WITH_STARCACHE}                    \
                   -DUSE_STAROS=${USE_STAROS}                            \
                   -DENABLE_FAULT_INJECTION=${ENABLE_FAULT_INJECTION}    \
                   -DCMAKE_EXPORT_COMPILE_COMMANDS=ON  ..

--- a/run-be-ut.sh
+++ b/run-be-ut.sh
@@ -41,6 +41,7 @@ Usage: $0 <options>
      --excluding-test-suit          don't run cases of specific suit
      --module                       module to run uts
      --enable-shared-data           enable to build with shared-data feature support
+     --without-starcache            build without starcache library
      --use-staros                   DEPRECATED. an alias of --enable-shared-data option
      -j                             build parallel
 
@@ -85,6 +86,7 @@ OPTS=$(getopt \
   -l 'excluding-test-suit:' \
   -l 'use-staros' \
   -l 'enable-shared-data' \
+  -l 'without-starcache' \
   -o 'j:' \
   -l 'help' \
   -l 'run' \
@@ -106,6 +108,7 @@ HELP=0
 WITH_AWS=OFF
 USE_STAROS=OFF
 WITH_GCOV=OFF
+WITH_STARCACHE=ON
 while true; do
     case "$1" in
         --clean) CLEAN=1 ; shift ;;
@@ -117,6 +120,7 @@ while true; do
         --help) HELP=1 ; shift ;;
         --with-aws) WITH_AWS=ON; shift ;;
         --with-gcov) WITH_GCOV=ON; shift ;;
+        --without-starcache) WITH_STARCACHE=OFF; shift ;;
         --excluding-test-suit) EXCLUDING_TEST_SUIT=$2; shift 2;;
         --enable-shared-data|--use-staros) USE_STAROS=ON; shift ;;
         -j) PARALLEL=$2; shift 2 ;;
@@ -174,6 +178,7 @@ ${CMAKE_CMD}  -G "${CMAKE_GENERATOR}" \
             -DUSE_STAROS=${USE_STAROS} \
             -DSTARLET_INSTALL_DIR=${STARLET_INSTALL_DIR}          \
             -DWITH_GCOV=${WITH_GCOV} \
+            -DWITH_STARCACHE=${WITH_STARCACHE} \
             -DCMAKE_EXPORT_COMPILE_COMMANDS=ON ../
 
 ${BUILD_SYSTEM} -j${PARALLEL}


### PR DESCRIPTION
## Why I'm doing:
As the starcache is imported to starrocks as a precompiled library now.  Sometimes users need to build it without starcache for some compatibility issues in their own develop environment.

## What I'm doing:
We add a `without-starcache` build option and provide some dummy classes to avoid include starcache headers when building with `--without-starcache`.


## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
