### PR TITLE
[BugFix] Fix min-readable-version lost in follower FE

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/persist/ReplicaPersistInfo.java
+++ b/fe/fe-core/src/main/java/com/starrocks/persist/ReplicaPersistInfo.java
@@ -119,6 +119,7 @@ public class ReplicaPersistInfo implements Writable {
 
     @SerializedName("vs")
     private long version;
+    @SerializedName("minReadableVersion")
     private long minReadableVersion = 0;
     @SerializedName("sh")
     private int schemaHash = -1;


### PR DESCRIPTION
Why I'm doing:
MinReadableVerison is not sync in `ReplicaPersistentInfo` and leader FE sync `ReplicaInfo` to follower FE, the min-readable-verison is lost.

What I'm doing:

Fixes https://github.com/StarRocks/StarRocksTest/issues/6002

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [x] 3.1
  - [x] 3.0
  - [ ] 2.5
