### PR TITLE
[UT] Fix sql-test inverted index with replicated_storage mode off

### DIFF
--- a/test/sql/test_inverted_index/R/test_inverted_index
+++ b/test/sql/test_inverted_index/R/test_inverted_index
@@ -10,7 +10,7 @@ PROPERTIES (
 "replication_num" = "1",
 "in_memory" = "false",
 "enable_persistent_index" = "false",
-"replicated_storage" = "true",
+"replicated_storage" = "false",
 "compression" = "LZ4"
 );
 -- result:
@@ -44,7 +44,7 @@ PROPERTIES (
 "replication_num" = "1",
 "in_memory" = "false",
 "enable_persistent_index" = "false",
-"replicated_storage" = "true",
+"replicated_storage" = "false",
 "compression" = "LZ4"
 );
 -- result:

--- a/test/sql/test_inverted_index/T/test_inverted_index
+++ b/test/sql/test_inverted_index/T/test_inverted_index
@@ -10,7 +10,7 @@ PROPERTIES (
 "replication_num" = "1",
 "in_memory" = "false",
 "enable_persistent_index" = "false",
-"replicated_storage" = "true",
+"replicated_storage" = "false",
 "compression" = "LZ4"
 );
 
@@ -36,7 +36,7 @@ PROPERTIES (
 "replication_num" = "1",
 "in_memory" = "false",
 "enable_persistent_index" = "false",
-"replicated_storage" = "true",
+"replicated_storage" = "false",
 "compression" = "LZ4"
 );
 


### PR DESCRIPTION
Change replicated_storage = false for inverted index sql-test
Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [x] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
