### PR TITLE
[Enhancement] Make PosixFileSystem::iterate_dir2 more robust

### DIFF
--- a/be/src/fs/fs_posix.cpp
+++ b/be/src/fs/fs_posix.cpp
@@ -458,7 +458,7 @@ public:
                 break;
             }
             if (UNLIKELY(errno != saved_errno)) {
-                PLOG(ERROR) << "errno changed to " << errno << ", will restore it back to " << saved_errno;
+                LOG(INFO) << "errno changed to " << errno << ", will restore it back to " << saved_errno;
                 errno = saved_errno;
             }
         }

--- a/be/src/fs/fs_posix.cpp
+++ b/be/src/fs/fs_posix.cpp
@@ -427,10 +427,14 @@ public:
     Status iterate_dir2(const std::string& dir, const std::function<bool(DirEntry)>& cb) override {
         DIR* d = opendir(dir.c_str());
         if (d == nullptr) {
+            // If the error is caused by a nonexist directory or is not a directory, does not print log
+            PLOG_IF(WARNING, errno != ENOENT && errno != ENOTDIR) << "Fail to open " << dir;
             return io_error(dir, errno);
         }
         errno = 0;
+        Status ret;
         struct dirent* entry;
+        // FIXME: readdir is not thread-safe, replace it with readdir_r
         while ((entry = readdir(d)) != nullptr) {
             std::string_view name(entry->d_name);
             if (name == "." || name == "..") {
@@ -439,6 +443,8 @@ public:
             struct stat child_stat;
             std::string child_path = fmt::format("{}/{}", dir, name);
             if (stat(child_path.c_str(), &child_stat) != 0) {
+                PLOG(WARNING) << "Fail to stat " << child_path;
+                ret.update(io_error(child_path, errno));
                 break;
             }
             DirEntry de;
@@ -446,14 +452,25 @@ public:
             de.is_dir = S_ISDIR(child_stat.st_mode);
             de.mtime = static_cast<int64_t>(child_stat.st_mtime);
             de.size = child_stat.st_size;
+            auto saved_errno = errno;
             // callback returning false means to terminate iteration
             if (!cb(de)) {
                 break;
             }
+            if (UNLIKELY(errno != saved_errno)) {
+                PLOG(ERROR) << "errno changed to " << errno << ", will restore it back to " << saved_errno;
+                errno = saved_errno;
+            }
         }
-        closedir(d);
-        if (errno != 0) return io_error(dir, errno);
-        return Status::OK();
+        if (entry == nullptr && errno != 0) {
+            PLOG(WARNING) << "Fail to read " << dir;
+            ret.update(io_error(dir, errno));
+        }
+        if (closedir(d) != 0) {
+            PLOG(WARNING) << "Fail to close " << dir;
+            ret.update(io_error(dir, errno));
+        }
+        return ret;
     }
 
     Status delete_file(const std::string& fname) override {

--- a/be/src/fs/fs_posix.cpp
+++ b/be/src/fs/fs_posix.cpp
@@ -434,7 +434,7 @@ public:
         errno = 0;
         Status ret;
         struct dirent* entry;
-        // FIXME: readdir is not thread-safe, replace it with readdir_r
+        // FIXME: readdir is not required to be thread-safe, replace it with readdir_r
         while ((entry = readdir(d)) != nullptr) {
             std::string_view name(entry->d_name);
             if (name == "." || name == "..") {


### PR DESCRIPTION
This patch contains the following changes:
1. Restore errno after callback to avoid incorrectly identifying that readdir(3) has encountered an error
2. More error logs

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [x] 3.1
  - [ ] 3.0
  - [ ] 2.5
