### PR TITLE
[Enhancement] Control implicit cast optimization by cbo_eq_base_type

### DIFF
--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rewrite/ScalarOperatorRewriterTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rewrite/ScalarOperatorRewriterTest.java
@@ -97,10 +97,10 @@ public class ScalarOperatorRewriterTest {
         assertEquals(root, result);
         assertEquals(OperatorType.BINARY, result.getChild(0).getOpType());
         assertEquals(OperatorType.VARIABLE, result.getChild(0).getChild(0).getOpType());
-        assertEquals(OperatorType.CONSTANT, result.getChild(0).getChild(1).getOpType());
+        assertEquals(OperatorType.CALL, result.getChild(0).getChild(1).getOpType());
 
-        assertEquals(Type.VARCHAR, result.getChild(0).getChild(0).getType());
-        assertEquals(Type.VARCHAR, result.getChild(0).getChild(1).getType());
+        assertEquals(Type.VARCHAR.getPrimitiveType(), result.getChild(0).getChild(0).getType().getPrimitiveType());
+        assertEquals(Type.VARCHAR.getPrimitiveType(), result.getChild(0).getChild(1).getType().getPrimitiveType());
 
         assertEquals(OperatorType.COMPOUND, result.getChild(1).getOpType());
         assertEquals(OperatorType.BINARY, result.getChild(1).getChild(0).getOpType());

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/ExpressionTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/ExpressionTest.java
@@ -1719,4 +1719,25 @@ public class ExpressionTest extends PlanTestBase {
         assertContains(plan, "PREDICATES: (bitmap_contains(5: b1, CAST(1: v1 AS BIGINT))) " +
                 "OR (bitmap_contains(5: b1, CAST(2: v2 AS BIGINT)))");
     }
+
+    @Test
+    public void testCastStringDouble() throws Exception {
+        try {
+            connectContext.getSessionVariable().setCboEqBaseType("VARCHAR");
+            String sql = "select t1a = 1 from test_all_type";
+            String plan = getVerboseExplain(sql);
+            assertContains(plan, "11 <-> [1: t1a, VARCHAR, true] = '1'");
+        } finally {
+            connectContext.getSessionVariable().setCboEqBaseType("VARCHAR");
+        }
+
+        try {
+            connectContext.getSessionVariable().setCboEqBaseType("DECIMAL");
+            String sql = "select t1a = 1 from test_all_type";
+            String plan = getVerboseExplain(sql);
+            assertContains(plan, "cast([1: t1a, VARCHAR, true] as DECIMAL128(38,9)) = 1");
+        } finally {
+            connectContext.getSessionVariable().setCboEqBaseType("VARCHAR");
+        }
+    }
 }


### PR DESCRIPTION
Why I'm doing:

What I'm doing:

ImplicitCastRule will optimize operator: `str = 1`/`st > 1`, variable operator = constant operator,  will cast constant opterator to variable operator type at first


Follow: https://github.com/StarRocks/starrocks/pull/34208

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [x] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [x] 3.1
  - [x] 3.0
  - [x] 2.5
