### PR TITLE
[BugFix] Fix flat-json null handle

### DIFF
--- a/be/src/storage/rowset/json_column_writer.cpp
+++ b/be/src/storage/rowset/json_column_writer.cpp
@@ -141,11 +141,11 @@ void FlatJsonColumnWriter::_flat_column(std::vector<ColumnPtr>& json_datas) {
             JsonValue* json = viewer.value(i);
             auto vslice = json->to_vslice();
 
-            if (vslice.isNone() || vslice.isNull()) {
+            if (vslice.isNull()) {
                 continue;
             }
 
-            if (!vslice.isObject()) {
+            if (vslice.isNone() || !vslice.isObject() || vslice.isEmptyObject()) {
                 VLOG(8) << "flat json, row isn't object, can't be flatten";
                 return;
             }

--- a/be/src/util/json_util.cpp
+++ b/be/src/util/json_util.cpp
@@ -151,22 +151,20 @@ void JsonFlater::flatten(const Column* json_column, std::vector<ColumnPtr>* resu
 
         auto* obj = json_data->get_object(i);
         auto vslice = obj->to_vslice();
-        if (UNLIKELY(!vslice.isObject() || vslice.isNull())) {
+        if (UNLIKELY(!vslice.isObject() || vslice.isEmptyObject())) {
             for (size_t k = 0; k < result->size(); k++) {
                 (*result)[k]->append_nulls(1);
             }
             continue;
-        } else if (vslice.isEmptyObject() || vslice.isNone()) {
+        } else if (vslice.isNone()) {
             for (size_t k = 0; k < result->size(); k++) {
-                // push none
-                flat_jsons[k]->append(JsonValue::from_none());
-                flat_nulls[k]->append(0);
+                (*result)[k]->append_nulls(1);
             }
             continue;
         }
         for (size_t k = 0; k < _flat_paths.size(); k++) {
             auto st = obj->get_obj(_flat_paths[k]);
-            if (st.ok() && !st.value().to_vslice().isNull()) {
+            if (st.ok()) {
                 flat_jsons[k]->append(st.value());
                 flat_nulls[k]->append(0);
             } else {

--- a/be/src/util/json_util.cpp
+++ b/be/src/util/json_util.cpp
@@ -151,20 +151,21 @@ void JsonFlater::flatten(const Column* json_column, std::vector<ColumnPtr>* resu
 
         auto* obj = json_data->get_object(i);
         auto vslice = obj->to_vslice();
-        if (UNLIKELY(!vslice.isObject() || vslice.isEmptyObject())) {
+        if (vslice.isNone()) {
             for (size_t k = 0; k < result->size(); k++) {
                 (*result)[k]->append_nulls(1);
             }
             continue;
-        } else if (vslice.isNone()) {
+        } else if (UNLIKELY(!vslice.isObject() || vslice.isEmptyObject())) {
             for (size_t k = 0; k < result->size(); k++) {
-                (*result)[k]->append_nulls(1);
+                flat_jsons[k]->append(JsonValue::from_none());
+                flat_nulls[k]->append(0);
             }
             continue;
         }
         for (size_t k = 0; k < _flat_paths.size(); k++) {
             auto st = obj->get_obj(_flat_paths[k]);
-            if (st.ok()) {
+            if (st.ok() && !st.value().is_null()) {
                 flat_jsons[k]->append(st.value());
                 flat_nulls[k]->append(0);
             } else {

--- a/test/sql/test_semi/R/test_invalid_flat_json
+++ b/test/sql/test_semi/R/test_invalid_flat_json
@@ -41,6 +41,9 @@ insert into js1 values(6,1, parse_json(null));
 insert into js1 values(6,1, parse_json(TRUE));
 -- result:
 -- !result
+insert into js1 values(7,1, parse_json('{"k1": null, "k2": 2}'));
+-- result:
+-- !result
 select get_json_string(j1, "$.key2"), get_json_double(j1, "$.key3"), get_json_string(j1, "$.key4") from js1 order by v1 limit 2;
 -- result:
 None	None	None
@@ -48,15 +51,19 @@ None	None	None
 -- !result
 select JSON_EXISTS(j1, "$.key2"), JSON_EXISTS(j1, "$.key2.key3") from js1 order by v1 limit 2;
 -- result:
-None	None
-None	None
+0	0
+0	0
 -- !result
 select JSON_LENGTH(j1, "$.key2"), JSON_LENGTH(j1, "$.key3"), JSON_LENGTH(j1, "$.key4") from js1 order by v1 limit 2;
 -- result:
-None	None	None
-None	None	None
+0	0	0
+0	0	0
 -- !result
-select json_object('"1"')->"1";
+select json_object('"1"')->"1", json_object('"1"')->"1" is null;
 -- result:
-null
+null	0
+-- !result
+select json_object(j1)->"k3", json_object(j1)->"k1", json_object(j1)->"k2.k3" from js1 where v1 = 7;
+-- result:
+None	None	None
 -- !result

--- a/test/sql/test_semi/T/test_invalid_flat_json
+++ b/test/sql/test_semi/T/test_invalid_flat_json
@@ -26,6 +26,7 @@ insert into js1 values(5,1, parse_json('1.000000'));
 insert into js1 values(6,1, parse_json(''));
 insert into js1 values(6,1, parse_json(null));
 insert into js1 values(6,1, parse_json(TRUE));
+insert into js1 values(7,1, parse_json('{"k1": null, "k2": 2}'));
 
 select get_json_string(j1, "$.key2"), get_json_double(j1, "$.key3"), get_json_string(j1, "$.key4") from js1 order by v1 limit 2;
 
@@ -33,4 +34,6 @@ select JSON_EXISTS(j1, "$.key2"), JSON_EXISTS(j1, "$.key2.key3") from js1 order 
 
 select JSON_LENGTH(j1, "$.key2"), JSON_LENGTH(j1, "$.key3"), JSON_LENGTH(j1, "$.key4") from js1 order by v1 limit 2;
 
-select json_object('"1"')->"1";
+select json_object('"1"')->"1", json_object('"1"')->"1" is null;
+
+select json_object(j1)->"k3", json_object(j1)->"k1", json_object(j1)->"k2.k3" from js1 where v1 = 7;


### PR DESCRIPTION
Why I'm doing:

What I'm doing:

normal:
```
MySQL td> select parse_json('a')->"$.key", json_exists(parse_json('a'), "$.key"), json_exists(null, "$.key")
+--------------------------+---------------------------------------+----------------------------+
| parse_json('a')->'$.key' | json_exists(parse_json('a'), '$.key') | json_exists(NULL, '$.key') |
+--------------------------+---------------------------------------+----------------------------+
| <null>                   | 0                                     | <null>                     |
+--------------------------+---------------------------------------+----------------------------+
1 row in set
Time: 0.011s

```

In FlatJson
```
MySQL td> select parse_json('a')->"$.key", json_exists(parse_json('a'), "$.key"), json_exists(null, "$.key")
+--------------------------+---------------------------------------+----------------------------+
| parse_json('a')->'$.key' | json_exists(parse_json('a'), '$.key') | json_exists(NULL, '$.key') |
+--------------------------+---------------------------------------+----------------------------+
| <null>                   | <null>                                | <null>                     |
+--------------------------+---------------------------------------+----------------------------+
1 row in set
Time: 0.011s
```

we can flat `empty object`/`None` to `None`, but can't flat to `null`, because we can't express the `None` value in scalar-type column

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
