### PR TITLE
[BugFix] Synchronous materialized view rewrite should respect original base index

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AnalyzerUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AnalyzerUtils.java
@@ -123,6 +123,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -595,11 +596,40 @@ public class AnalyzerUtils {
 
     private static class OlapTableCollector extends TableCollector {
         private Set<OlapTable> olapTables;
-        private Map<Long, OlapTable> idMap;
+        private Map<TableIndexId, OlapTable> idMap;
 
         public OlapTableCollector(Set<OlapTable> tables) {
             this.olapTables = tables;
             this.idMap = new HashMap<>();
+        }
+
+        /**
+         * One table may contain multi MaterializeIndexMetas. and it's different if one has tableA and baseIndex a
+         * and one has tableA and baseIndex b. So use TableId and its base table index as the key to distinguish a TableRelation.
+         */
+        class TableIndexId {
+            long tableId;
+            long baseIndexId;
+            public TableIndexId(long tableId, long indexId) {
+                this.tableId = tableId;
+                this.baseIndexId = indexId;
+            }
+            @Override
+            public boolean equals(Object o) {
+                if (this == o) {
+                    return true;
+                }
+                if (o == null || getClass() != o.getClass()) {
+                    return false;
+                }
+                TableIndexId that = (TableIndexId) o;
+                return tableId == that.tableId && baseIndexId == that.baseIndexId;
+            }
+
+            @Override
+            public int hashCode() {
+                return Objects.hash(tableId, baseIndexId);
+            }
         }
 
         @Override
@@ -624,7 +654,8 @@ public class AnalyzerUtils {
         // TODO: support cloud native table and mv
         private Table copyTable(Table originalTable) {
             OlapTable table = (OlapTable) originalTable;
-            OlapTable existed = idMap.get(table.getId());
+            TableIndexId tableIndexId = new TableIndexId(table.getId(), table.getBaseIndexId());
+            OlapTable existed = idMap.get(tableIndexId);
             if (existed != null) {
                 return existed;
             }
@@ -639,7 +670,7 @@ public class AnalyzerUtils {
             }
 
             olapTables.add(table);
-            idMap.put(table.getId(), table);
+            idMap.put(tableIndexId, table);
             table.copyOnlyForQuery(copied);
             return copied;
         }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/mv/MaterializedViewRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/mv/MaterializedViewRule.java
@@ -194,15 +194,15 @@ public class MaterializedViewRule extends Rule {
         Map<String, Integer> queryScanNodeColumnNameToIds = queryRelIdToColumnNameIds.get(relationId);
 
         Iterator<MaterializedIndexMeta> iterator = candidateIndexIdToMeta.iterator();
+        // Consider all IndexMetas of the base table so can be decided by cost strategy for better performance.
+        // eg:
+        // tbl1     : <a int, b  string, c string> and column `a` is short key
+        // tbl1_mv  : select b, a, c from tbl1 and column `b` is short key
+        // Q1: select * from tbl1 where a = 1, should choose tbl1
+        // Q2: select * from tbl1 where b = 'a', should choose tbl1_mv
         while (iterator.hasNext()) {
             MaterializedIndexMeta mvMeta = iterator.next();
             long mvIdx = mvMeta.getIndexId();
-
-            // Ignore original query index.
-            if (mvIdx == scanOperator.getSelectedIndexId()) {
-                iterator.remove();
-                continue;
-            }
 
             // Ignore indexes which cannot be remapping with query by column names.
             List<Column> mvNonAggregatedColumns = mvMeta.getNonAggregatedColumns();

--- a/test/lib/sr_sql_lib.py
+++ b/test/lib/sr_sql_lib.py
@@ -1007,15 +1007,15 @@ class StarrocksSQLApiLib(object):
         """
         tools.assert_true(str(res).find(mv_name) > 0, "assert mv %s is not found" % (mv_name))
 
-    def check_hit_materialized_view(self, query, mv_name):
+    def check_hit_materialized_view(self, query, *expects):
         """
         assert mv_name is hit in query
         """
         time.sleep(1)
         sql = "explain %s" % (query)
         res = self.execute_sql(sql, True)
-        #print(res)
-        tools.assert_true(str(res["result"]).find(mv_name) > 0, "assert mv %s is not found" % (mv_name))
+        for expect in expects:
+            tools.assert_true(str(res["result"]).find(expect) > 0, "assert expect %s is not found in plan" % (expect))
 
     def check_no_hit_materialized_view(self, query, mv_name):
         """

--- a/test/sql/test_materialized_view/R/test_sync_materialized_view_rewrite
+++ b/test/sql/test_materialized_view/R/test_sync_materialized_view_rewrite
@@ -300,7 +300,7 @@ SELECT col2,col3,col0,id,col1 FROM test_base_table1 ORDER BY col2,col3,col0;
 -- !result
 analyze full table test_base_table1 with sync mode;
 -- result:
-test_db_afc3e318c02611eea0bedbbedfe51b53.test_base_table1	analyze	status	OK
+test_db_44197a8ac1a011eea0bfdbbedfe51b53.test_base_table1	analyze	status	OK
 -- !result
 function: wait_materialized_view_finish()
 -- result:
@@ -318,6 +318,47 @@ select col3, min(col1) startTime, max(col1) endTime from test_base_table1 where 
 -- result:
 Guangdong	10001	10001
 Fujian	None	None
+-- !result
+function: check_hit_materialized_view("select * from test_base_table1 where col0=123456789", "rollup: test_base_table1")
+-- result:
+None
+-- !result
+select * from test_base_table1 where col0=123456789;
+-- result:
+123456789	2022-04-30 12:00:00	Guangdong	1	10001
+-- !result
+function: check_hit_materialized_view("select * from test_base_table1 where col2 >='2022-04-30 12:00:00'", "rollup: mv_test_base_table1")
+-- result:
+None
+-- !result
+select * from test_base_table1 where col2 >='2022-04-30 12:00:00';
+-- result:
+123456789	2022-04-30 12:00:00	Guangdong	1	10001
+987654321	2022-04-30 13:00:00	Fujian	None	None
+-- !result
+function: check_hit_materialized_view("select * from (select col0, col2, col3, id, col1 from test_base_table1 where col0=123456789 union select col0, col2, col3, id, col1 from test_base_table1 where col2 >='2022-04-30 12:00:00') t;", "rollup: mv_test_base_table1",  "rollup: test_base_table1")
+-- result:
+None
+-- !result
+select * from (select col0, col2, col3, id, col1 from test_base_table1 where col0=123456789 union select col0, col2, col3, id, col1 from test_base_table1 where col2 >='2022-04-30 12:00:00') t;
+-- result:
+123456789	2022-04-30 12:00:00	Guangdong	1	10001
+987654321	2022-04-30 13:00:00	Fujian	None	None
+-- !result
+set enable_sync_materialized_view_rewrite=false;
+-- result:
+-- !result
+function: check_hit_materialized_view("select * from (select col0, col2, col3, id, col1 from test_base_table1 where col0=123456789 union select col0, col2, col3, id, col1 from mv_test_base_table1 [_SYNC_MV_] where col2 >='2022-04-30 12:00:00') t;", "rollup: mv_test_base_table1",  "rollup: test_base_table1")
+-- result:
+None
+-- !result
+select * from (select col0, col2, col3, id, col1 from test_base_table1 where col0=123456789 union select col0, col2, col3, id, col1 from mv_test_base_table1 [_SYNC_MV_] where col2 >='2022-04-30 12:00:00') t;
+-- result:
+987654321	2022-04-30 13:00:00	Fujian	None	None
+123456789	2022-04-30 12:00:00	Guangdong	1	10001
+-- !result
+set enable_sync_materialized_view_rewrite=true;
+-- result:
 -- !result
 drop table test_base_table1;
 -- result:

--- a/test/sql/test_materialized_view/T/test_sync_materialized_view_rewrite
+++ b/test/sql/test_materialized_view/T/test_sync_materialized_view_rewrite
@@ -154,4 +154,21 @@ function: wait_global_dict_ready("col3", "test_base_table1")
 function: check_hit_materialized_view("select col3, min(col1) startTime, max(col1) endTime from test_base_table1 where col2 BETWEEN '2022-04-29 15:12:23' and '2022-04-30 15:12:23' group by col3;", "mv_test_base_table1")
 -- check result it's ok
 select col3, min(col1) startTime, max(col1) endTime from test_base_table1 where col2 BETWEEN '2022-04-29 00:00:00' and '2022-04-30 23:00:00' group by col3;
+
+-- check hit base table's order key
+function: check_hit_materialized_view("select * from test_base_table1 where col0=123456789", "rollup: test_base_table1")
+select * from test_base_table1 where col0=123456789;
+-- check hit sync mv's order key
+function: check_hit_materialized_view("select * from test_base_table1 where col2 >='2022-04-30 12:00:00'", "rollup: mv_test_base_table1")
+select * from test_base_table1 where col2 >='2022-04-30 12:00:00';
+
+-- check both hit base table and sync mv's order key
+function: check_hit_materialized_view("select * from (select col0, col2, col3, id, col1 from test_base_table1 where col0=123456789 union select col0, col2, col3, id, col1 from test_base_table1 where col2 >='2022-04-30 12:00:00') t;", "rollup: mv_test_base_table1",  "rollup: test_base_table1")
+select * from (select col0, col2, col3, id, col1 from test_base_table1 where col0=123456789 union select col0, col2, col3, id, col1 from test_base_table1 where col2 >='2022-04-30 12:00:00') t;
+
+set enable_sync_materialized_view_rewrite=false;
+function: check_hit_materialized_view("select * from (select col0, col2, col3, id, col1 from test_base_table1 where col0=123456789 union select col0, col2, col3, id, col1 from mv_test_base_table1 [_SYNC_MV_] where col2 >='2022-04-30 12:00:00') t;", "rollup: mv_test_base_table1",  "rollup: test_base_table1")
+select * from (select col0, col2, col3, id, col1 from test_base_table1 where col0=123456789 union select col0, col2, col3, id, col1 from mv_test_base_table1 [_SYNC_MV_] where col2 >='2022-04-30 12:00:00') t;
+set enable_sync_materialized_view_rewrite=true;
+
 drop table test_base_table1;


### PR DESCRIPTION

Why I'm doing:

If base table and its synchronous mv have different short keys,  plan rewriter should choose different index meta for different scenses.

eg: 
```
CREATE TABLE IF NOT EXISTS test_base_table1
(
    `col0`             int(11) NULL,
    `col2`           datetime NULL,
    `col3`         varchar(32) NULL,
    `id`               bigint(20) NULL,
    `col1`           bigint(20) NULL
) DUPLICATE KEY(col0, col2, col3)
  PARTITION BY RANGE(col2)(
  START ("2022-04-17") END ("2022-05-01") EVERY (INTERVAL 1 day))
  DISTRIBUTED BY HASH(col0)
  PROPERTIES
(
    "replication_num" = "1"
);

INSERT INTO test_base_table1 (col0, col2, col3, id, col1) VALUES (123456789, '2022-04-30 12:00:00', 'Guangdong', 1, 10001);
INSERT INTO test_base_table1 (col0, col2, col3) VALUES (987654321, '2022-04-30 13:00:00', 'Fujian');

CREATE MATERIALIZED VIEW mv_test_base_table1 AS
SELECT col2,col3,col0,id,col1 FROM test_base_table1 ORDER BY col2,col3,col0;

select * from (select col0, col2, col3, id, col1 from test_base_table1 where col0=123456789 union select col0, col2, col3, id, col1 from test_base_table1 where col2 >='2022-04-30 12:00:00') t;
```

What I'm doing:
- Synchronous materialized view rewrite keeps original base index id so can be compared later.
- Fix `_SYNC_MV_` hint conflicts with copy-only lock optimizations.

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [x] 3.1
  - [ ] 3.0
  - [ ] 2.5
