### PR TITLE
[BugFix] cpu usage is unbalance when backup some database, expecially a new instance

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/backup/BackupJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/backup/BackupJob.java
@@ -792,7 +792,7 @@ public class BackupJob extends AbstractJob {
             replicaIds.add(replica.getId());
         }
 
-        Collections.sort(replicaIds);
+        Collections.shuffle(replicaIds);
         for (Long replicaId : replicaIds) {
             Replica replica = tablet.getReplicaById(replicaId);
             if (replica.getLastFailedVersion() < 0 && (replica.getVersion() >= visibleVersion)) {

--- a/fe/fe-core/src/main/java/com/starrocks/task/AgentTaskQueue.java
+++ b/fe/fe-core/src/main/java/com/starrocks/task/AgentTaskQueue.java
@@ -195,6 +195,11 @@ public class AgentTaskQueue {
         return res;
     }
 
+    // this is just for unit test
+    public static synchronized Map<Long, AgentTask> getTasks(long backendId, TTaskType type) {
+        return tasks.get(backendId, type);
+    }
+
     public static synchronized List<AgentTask> getDiffTasks(long backendId, Map<TTaskType, Set<Long>> runningTasks) {
         List<AgentTask> diffTasks = new ArrayList<AgentTask>();
         if (!tasks.containsRow(backendId)) {

--- a/fe/fe-core/src/test/java/com/starrocks/backup/BackupJobPrimaryKeyTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/backup/BackupJobPrimaryKeyTest.java
@@ -244,9 +244,10 @@ public class BackupJobPrimaryKeyTest {
         Assert.assertEquals(backupTbl.getSignature(BackupHandler.SIGNATURE_VERSION, partNames, true),
                 ((OlapTable) db.getTable(tblId)).getSignature(BackupHandler.SIGNATURE_VERSION, partNames, true));
         Assert.assertEquals(1, AgentTaskQueue.getTaskNum());
-        AgentTask task = AgentTaskQueue.getTask(backendId, TTaskType.MAKE_SNAPSHOT, tabletId);
-        Assert.assertTrue(task instanceof SnapshotTask);
-        SnapshotTask snapshotTask = (SnapshotTask) task;
+        List<AgentTask> tasks = UnitTestUtil.getTasksWithRandomBE(backendId, TTaskType.MAKE_SNAPSHOT, tabletId);
+        Assert.assertEquals(1, tasks.size());
+        Assert.assertTrue(tasks.get(0) instanceof SnapshotTask);
+        SnapshotTask snapshotTask = (SnapshotTask) tasks.get(0);
 
         // 2. snapshoting
         job.run();
@@ -275,9 +276,10 @@ public class BackupJobPrimaryKeyTest {
         Assert.assertEquals(Status.OK, job.getStatus());
         Assert.assertEquals(BackupJobState.UPLOADING, job.getState());
         Assert.assertEquals(1, AgentTaskQueue.getTaskNum());
-        task = AgentTaskQueue.getTask(backendId, TTaskType.UPLOAD, id.get() - 1);
-        Assert.assertTrue(task instanceof UploadTask);
-        UploadTask upTask = (UploadTask) task;
+        tasks = UnitTestUtil.getTasksWithRandomBE(backendId, TTaskType.UPLOAD, id.get() - 1);
+        Assert.assertEquals(1, tasks.size());
+        Assert.assertTrue(tasks.get(0) instanceof UploadTask);
+        UploadTask upTask = (UploadTask) tasks.get(0);
 
         Assert.assertEquals(job.getJobId(), upTask.getJobId());
         Map<String, String> srcToDest = upTask.getSrcToDestPath();

--- a/fe/fe-core/src/test/java/com/starrocks/backup/BackupJobTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/backup/BackupJobTest.java
@@ -235,9 +235,10 @@ public class BackupJobTest {
         Assert.assertEquals(backupTbl.getSignature(BackupHandler.SIGNATURE_VERSION, partNames, true),
                 ((OlapTable) db.getTable(tblId)).getSignature(BackupHandler.SIGNATURE_VERSION, partNames, true));
         Assert.assertEquals(1, AgentTaskQueue.getTaskNum());
-        AgentTask task = AgentTaskQueue.getTask(backendId, TTaskType.MAKE_SNAPSHOT, tabletId);
-        Assert.assertTrue(task instanceof SnapshotTask);
-        SnapshotTask snapshotTask = (SnapshotTask) task;
+        List<AgentTask> tasks = UnitTestUtil.getTasksWithRandomBE(backendId, TTaskType.MAKE_SNAPSHOT, tabletId);
+        Assert.assertEquals(1, tasks.size());
+        Assert.assertTrue(tasks.get(0) instanceof SnapshotTask);
+        SnapshotTask snapshotTask = (SnapshotTask) tasks.get(0);
 
         // 2. snapshoting
         job.run();
@@ -267,9 +268,10 @@ public class BackupJobTest {
         Assert.assertEquals(Status.OK, job.getStatus());
         Assert.assertEquals(BackupJobState.UPLOADING, job.getState());
         Assert.assertEquals(1, AgentTaskQueue.getTaskNum());
-        task = AgentTaskQueue.getTask(backendId, TTaskType.UPLOAD, id.get() - 1);
-        Assert.assertTrue(task instanceof UploadTask);
-        UploadTask upTask = (UploadTask) task;
+        tasks = UnitTestUtil.getTasksWithRandomBE(backendId, TTaskType.UPLOAD, id.get() - 1);
+        Assert.assertEquals(1, tasks.size());
+        Assert.assertTrue(tasks.get(0) instanceof UploadTask);
+        UploadTask upTask = (UploadTask) tasks.get(0);
 
         Assert.assertEquals(job.getJobId(), upTask.getJobId());
         Map<String, String> srcToDest = upTask.getSrcToDestPath();

--- a/fe/fe-core/src/test/java/com/starrocks/common/util/UnitTestUtil.java
+++ b/fe/fe-core/src/test/java/com/starrocks/common/util/UnitTestUtil.java
@@ -57,10 +57,13 @@ import com.starrocks.catalog.TabletMeta;
 import com.starrocks.catalog.Type;
 import com.starrocks.common.jmockit.Deencapsulation;
 import com.starrocks.system.Backend;
+import com.starrocks.task.AgentTask;
+import com.starrocks.task.AgentTaskQueue;
 import com.starrocks.thrift.TDisk;
 import com.starrocks.thrift.TStorageMedium;
 import com.starrocks.thrift.TStorageType;
 import com.starrocks.thrift.TTabletType;
+import com.starrocks.thrift.TTaskType;
 import org.junit.Assert;
 
 import java.lang.reflect.Method;
@@ -331,6 +334,26 @@ public class UnitTestUtil {
             }
         }
         return innerClass;
+    }
+
+    /*
+     * NOTE: Three replicates will create in createOlapTableByName().
+     */
+    public static List<AgentTask> getTasksWithRandomBE(long startBeId, TTaskType taskType, long signature) {
+        Map<Long, AgentTask> signatureMap;
+        List<AgentTask> tasks = new ArrayList<>();
+        for (long id = startBeId; id < startBeId + 3; id++) {
+            signatureMap = AgentTaskQueue.getTasks(id, taskType);
+            if (signatureMap == null) {
+                continue;
+            }
+            if (signature < 0) {
+                tasks.addAll(signatureMap.values());
+            } else if (signatureMap.containsKey(signature)) {
+                tasks.add(signatureMap.get(signature));
+            }
+        }
+        return tasks;
     }
 
 }


### PR DESCRIPTION
All the backup tasks will run under one be node, and others have no tasks to execute, expecially when we create table with replicate_num=3 and have 3 be.

Under such environment, all the lowest tablet replicas always distributed on one machine.

So when we try to backup a large database, all the backup jobs will run with that be nodes, and got unbalanced cpu/network usage.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [x] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5