### PR TITLE
[BugFix] Fix minor mv backup/restore bugs

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/backup/BackupHandler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/backup/BackupHandler.java
@@ -446,7 +446,7 @@ public class BackupHandler extends FrontendDaemon implements Writable, MemoryTra
                 if (remoteTbl.isCloudNativeTable()) {
                     ErrorReport.reportDdlException(ErrorCode.ERR_NOT_OLAP_TABLE, remoteTbl.getName());
                 }
-                mvRestoreContext.addIntoMvBaseTableBackupInfoIfNeeded(remoteTbl, jobInfo, tblInfo);
+                mvRestoreContext.addIntoMvBaseTableBackupInfoIfNeeded(db.getOriginName(), remoteTbl, jobInfo, tblInfo);
             }
         }
         restoreJob = new RestoreJob(stmt.getLabel(), stmt.getBackupTimestamp(),

--- a/fe/fe-core/src/main/java/com/starrocks/backup/mv/MVRestoreUpdater.java
+++ b/fe/fe-core/src/main/java/com/starrocks/backup/mv/MVRestoreUpdater.java
@@ -252,7 +252,7 @@ public class MVRestoreUpdater {
         Database db = GlobalStateMgr.getCurrentState().getDb(localDbName);
         String localTableName = mvBaseTableBackupInfo.getLocalTableName();
         if (db == null) {
-            LOG.warn("BaseTable(local) %s's db %s is not found, remote db/table: %s/%s",
+            LOG.warn("BaseTable(local) {}'s db {} is not found, remote db/table: {}/{}",
                     localTableName, localDbName, remoteDbName, remoteTableName);
             return Pair.create(false, Optional.empty());
         }

--- a/fe/fe-core/src/main/java/com/starrocks/backup/mv/MvRestoreContext.java
+++ b/fe/fe-core/src/main/java/com/starrocks/backup/mv/MvRestoreContext.java
@@ -60,7 +60,8 @@ public class MvRestoreContext {
         return mvIdToTableNameMap;
     }
 
-    public void addIntoMvBaseTableBackupInfoIfNeeded(Table remoteTbl,
+    public void addIntoMvBaseTableBackupInfoIfNeeded(String localDbName,
+                                                     Table remoteTbl,
                                                      BackupJobInfo jobInfo,
                                                      BackupJobInfo.BackupTableInfo backupTableInfo) {
         if (remoteTbl == null) {
@@ -77,7 +78,6 @@ public class MvRestoreContext {
         if (remoteTbl.getRelatedMaterializedViews() == null || remoteTbl.getRelatedMaterializedViews().isEmpty()) {
             return;
         }
-        String localDbName = jobInfo.dbName;
         String localTableName = jobInfo.getAliasByOriginNameIfSet(remoteTbl.getName());
         MvBaseTableBackupInfo mvBaseTableBackupInfo =
                 new MvBaseTableBackupInfo(backupTableInfo, localDbName, localTableName, remoteTbl.getId(), jobInfo.backupTime);
@@ -96,7 +96,7 @@ public class MvRestoreContext {
         }
         for (BackupJobInfo.BackupTableInfo tblInfo : jobInfo.tables.values()) {
             Table remoteTbl = backupMeta.getTable(tblInfo.name);
-            addIntoMvBaseTableBackupInfoIfNeeded(remoteTbl, jobInfo, tblInfo);
+            addIntoMvBaseTableBackupInfoIfNeeded(job.getDbName(), remoteTbl, jobInfo, tblInfo);
         }
     }
 


### PR DESCRIPTION
Why I'm doing:
`localDbName` should not come from `BackupJobInfo jobInfo;` rather from `RestoreJob restoreJob `.

```
        String localDbName = jobInfo.dbName;

```
What I'm doing:
- use the correnct db to set the restore table's local db.

Fixes [#issue
](https://github.com/StarRocks/StarRocksTest/issues/6021)


## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
