### PR TITLE
[BugFix] Fix data ingestion stuck when the new automatic partition and the old partition are distributed on different backends

### DIFF
--- a/be/src/exec/tablet_sink_index_channel.cpp
+++ b/be/src/exec/tablet_sink_index_channel.cpp
@@ -403,7 +403,7 @@ bool NodeChannel::is_full() {
 
 Status NodeChannel::add_chunk(Chunk* input, const std::vector<int64_t>& tablet_ids,
                               const std::vector<uint32_t>& indexes, uint32_t from, uint32_t size) {
-    if (_cancelled || _send_finished) {
+    if (_cancelled || _closed) {
         return _err_st;
     }
 
@@ -463,7 +463,7 @@ Status NodeChannel::add_chunk(Chunk* input, const std::vector<int64_t>& tablet_i
 
 Status NodeChannel::add_chunks(Chunk* input, const std::vector<std::vector<int64_t>>& index_tablet_ids,
                                const std::vector<uint32_t>& indexes, uint32_t from, uint32_t size) {
-    if (_cancelled || _send_finished) {
+    if (_cancelled || _closed) {
         return _err_st;
     }
 
@@ -534,8 +534,8 @@ Status NodeChannel::_filter_indexes_with_where_expr(Chunk* input, const std::vec
     return Status::OK();
 }
 
-Status NodeChannel::_send_request(bool eos, bool wait_all_sender_close) {
-    if (eos) {
+Status NodeChannel::_send_request(bool eos, bool finished) {
+    if (eos || finished) {
         if (_request_queue.empty()) {
             if (_cur_chunk.get() == nullptr) {
                 _cur_chunk = std::make_unique<Chunk>();
@@ -548,6 +548,7 @@ Status NodeChannel::_send_request(bool eos, bool wait_all_sender_close) {
         // try to send chunk in queue first
         if (_request_queue.size() > 1) {
             eos = false;
+            finished = false;
         }
     }
 
@@ -568,9 +569,6 @@ Status NodeChannel::_send_request(bool eos, bool wait_all_sender_close) {
         if (UNLIKELY(eos)) {
             req->set_eos(true);
 
-            if (wait_all_sender_close) {
-                req->set_wait_all_sender_close(true);
-            }
             auto& partition_ids = _parent->_index_id_partition_ids[req->index_id()];
             if (!partition_ids.empty()) {
                 VLOG(2) << "partition_ids:" << std::string(partition_ids.begin(), partition_ids.end());
@@ -580,7 +578,15 @@ Status NodeChannel::_send_request(bool eos, bool wait_all_sender_close) {
             }
 
             // eos request must be the last request
-            _send_finished = true;
+            _closed = true;
+        }
+
+        // This is added for automatic partition. We need to ensure that
+        // all data has been sent before the incremental channel is closed.
+        if (UNLIKELY(finished)) {
+            req->set_wait_all_sender_close(true);
+
+            _finished = true;
         }
 
         req->set_packet_seq(_next_packet_seq);
@@ -818,13 +824,30 @@ Status NodeChannel::_wait_one_prev_request() {
     return Status::OK();
 }
 
-Status NodeChannel::try_close(bool wait_all_sender_close) {
-    if (_cancelled || _send_finished) {
+Status NodeChannel::try_close() {
+    if (_cancelled || _closed) {
         return _err_st;
     }
 
     if (_check_prev_request_done()) {
-        auto st = _send_request(true /* eos */, wait_all_sender_close);
+        auto st = _send_request(true /* eos */, false /* finished */);
+        if (!st.ok()) {
+            _cancelled = true;
+            _err_st = st;
+            return _err_st;
+        }
+    }
+
+    return Status::OK();
+}
+
+Status NodeChannel::try_finish() {
+    if (_cancelled || _finished || _closed) {
+        return _err_st;
+    }
+
+    if (_check_prev_request_done()) {
+        auto st = _send_request(false /* eos */, true /* finished */);
         if (!st.ok()) {
             _cancelled = true;
             _err_st = st;
@@ -836,7 +859,11 @@ Status NodeChannel::try_close(bool wait_all_sender_close) {
 }
 
 bool NodeChannel::is_close_done() {
-    return (_send_finished && _check_all_prev_request_done()) || _cancelled;
+    return (_closed && _check_all_prev_request_done()) || _cancelled;
+}
+
+bool NodeChannel::is_finished() {
+    return (_finished && _check_all_prev_request_done()) || _cancelled;
 }
 
 Status NodeChannel::close_wait(RuntimeState* state) {
@@ -845,7 +872,7 @@ Status NodeChannel::close_wait(RuntimeState* state) {
     }
 
     // 1. send eos request to commit write util finish
-    while (!_send_finished) {
+    while (!_closed) {
         RETURN_IF_ERROR(_send_request(true /* eos */));
     }
 

--- a/be/src/exec/tablet_sink_index_channel.h
+++ b/be/src/exec/tablet_sink_index_channel.h
@@ -136,10 +136,12 @@ public:
     // async close interface: try_close() -> [is_close_done()] -> close_wait()
     // if is_close_done() return true, close_wait() will not block
     // otherwise close_wait() will block
-    Status try_close(bool wait_all_sender_close = false);
+    Status try_close();
     bool is_close_done();
     Status close_wait(RuntimeState* state);
 
+    Status try_finish();
+    bool is_finished();
     void cancel(const Status& err_st);
 
     void time_report(std::unordered_map<int64_t, AddBatchCounter>* add_batch_counter_map, int64_t* serialize_batch_ns,
@@ -200,8 +202,11 @@ private:
     // user cancel or get some errors
     bool _cancelled{false};
 
-    // send finished means the consumer thread which send the rpc can exit
-    bool _send_finished{false};
+    // channel is closed
+    bool _closed{false};
+
+    // data sending is finished
+    bool _finished{false};
 
     std::unique_ptr<RowDescriptor> _row_desc;
 

--- a/be/src/exec/tablet_sink_sender.cpp
+++ b/be/src/exec/tablet_sink_sender.cpp
@@ -187,11 +187,13 @@ Status TabletSinkSender::try_close(RuntimeState* state) {
     bool intolerable_failure = false;
     for (auto& index_channel : _channels) {
         if (index_channel->has_incremental_node_channel()) {
-            // close initial node channel and wait it done
+            // try to finish initial node channel and wait it done
+            // This is added for automatic partition. We need to ensure that
+            // all data has been sent before the incremental channel is closed.
             index_channel->for_each_initial_node_channel([&index_channel, &err_st,
                                                           &intolerable_failure](NodeChannel* ch) {
                 if (!index_channel->is_failed_channel(ch)) {
-                    auto st = ch->try_close(true);
+                    auto st = ch->try_finish();
                     if (!st.ok()) {
                         LOG(WARNING) << "close initial channel failed. channel_name=" << ch->name()
                                      << ", load_info=" << ch->print_load_info() << ", error_msg=" << st.message();
@@ -210,19 +212,18 @@ Status TabletSinkSender::try_close(RuntimeState* state) {
                 break;
             }
 
-            bool is_initial_node_channel_close_done = true;
-            index_channel->for_each_initial_node_channel([&is_initial_node_channel_close_done](NodeChannel* ch) {
-                is_initial_node_channel_close_done &= ch->is_close_done();
+            bool is_initial_node_channel_finished = true;
+            index_channel->for_each_initial_node_channel([&is_initial_node_channel_finished](NodeChannel* ch) {
+                is_initial_node_channel_finished &= ch->is_finished();
             });
 
-            // close initial node channel not finish, can not close incremental node channel
-            if (!is_initial_node_channel_close_done) {
+            // initial node channel not finish, can not close incremental node channel
+            if (!is_initial_node_channel_finished) {
                 break;
             }
 
-            // close incremental node channel
-            index_channel->for_each_incremental_node_channel([&index_channel, &err_st,
-                                                              &intolerable_failure](NodeChannel* ch) {
+            // close both initial & incremental node channel
+            index_channel->for_each_node_channel([&index_channel, &err_st, &intolerable_failure](NodeChannel* ch) {
                 if (!index_channel->is_failed_channel(ch)) {
                     auto st = ch->try_close();
                     if (!st.ok()) {

--- a/be/src/runtime/tablets_channel.cpp
+++ b/be/src/runtime/tablets_channel.cpp
@@ -30,17 +30,17 @@ bool TabletsChannel::drain_senders(int64_t timeout, const std::string& log_msg) 
         if (current > next_logging) {
             LOG(INFO) << log_msg << ", wait all sender close already "
                       << std::chrono::duration_cast<std::chrono::milliseconds>(current - start).count()
-                      << "ms still has " << _num_remaining_senders << " sender";
+                      << "ms still has " << _num_initial_senders << " sender";
             next_logging += duration;
         }
     };
 
     Awaitility wait;
-    auto cond = [&]() { return _num_remaining_senders.load(std::memory_order_acquire) == 0; };
+    auto cond = [&]() { return _num_initial_senders.load(std::memory_order_acquire) <= 0; };
     auto ret = wait.timeout(timeout).interval(check_interval).interval_callback(cb).until(cond);
     if (!ret) {
         LOG(INFO) << log_msg << " wait all sender close timeout " << timeout / 1000 << "ms still has "
-                  << _num_remaining_senders << " sender";
+                  << _num_initial_senders << " sender";
     }
     return ret;
 }

--- a/be/src/runtime/tablets_channel.h
+++ b/be/src/runtime/tablets_channel.h
@@ -72,6 +72,9 @@ protected:
     // counter of remaining senders
     std::atomic<int> _num_remaining_senders = 0;
 
+    // counter of initial senders
+    std::atomic<int> _num_initial_senders = 0;
+
     std::unordered_map<int64_t, std::atomic<int>> _tablet_id_to_num_remaining_senders;
 };
 

--- a/test/sql/test_automatic_partition/R/test_automatic_partition
+++ b/test/sql/test_automatic_partition/R/test_automatic_partition
@@ -524,3 +524,47 @@ select * from ss;
 -- result:
 2021-01-01	1
 -- !result
+
+-- name: test_two_replica
+CREATE TABLE ss( event_day DATE, pv BIGINT) DUPLICATE KEY(event_day) PARTITION BY date_trunc('month', event_day) DISTRIBUTED BY HASH(event_day) BUCKETS 1 PROPERTIES("replication_num" = "2");
+-- result:
+-- !result
+insert into ss values('2002-01-01', 2);
+-- result:
+-- !result
+insert into ss values('2002-01-02', 2);
+-- result:
+-- !result
+insert into ss values('2002-01-03', 2);
+-- result:
+-- !result
+insert into ss values('2002-01-04', 2);
+-- result:
+-- !result
+insert into ss values('2002-01-05', 2);
+-- result:
+-- !result
+insert into ss values('2002-01-06', 2);
+-- result:
+-- !result
+insert into ss values('2002-01-07', 2);
+-- result:
+-- !result
+insert into ss values('2002-01-08', 2);
+-- result:
+-- !result
+insert into ss values('2002-01-09', 2);
+-- result:
+-- !result
+select * from ss;
+-- result:
+2002-01-01	2
+2002-01-02	2
+2002-01-03	2
+2002-01-04	2
+2002-01-05	2
+2002-01-06	2
+2002-01-07	2
+2002-01-08	2
+2002-01-09	2
+-- !result

--- a/test/sql/test_automatic_partition/T/test_automatic_partition
+++ b/test/sql/test_automatic_partition/T/test_automatic_partition
@@ -166,3 +166,16 @@ insert into ss values('0001-02-01', 2);
 select * from ss;
 alter table ss drop partition p200201;
 select * from ss;
+
+-- name: test_two_replica
+CREATE TABLE ss( event_day DATE, pv BIGINT) DUPLICATE KEY(event_day) PARTITION BY date_trunc('month', event_day) DISTRIBUTED BY HASH(event_day) BUCKETS 1 PROPERTIES("replication_num" = "2");
+insert into ss values('2002-01-01', 2);
+insert into ss values('2002-01-02', 2);
+insert into ss values('2002-01-03', 2);
+insert into ss values('2002-01-04', 2);
+insert into ss values('2002-01-05', 2);
+insert into ss values('2002-01-06', 2);
+insert into ss values('2002-01-07', 2);
+insert into ss values('2002-01-08', 2);
+insert into ss values('2002-01-09', 2);
+select * from ss;


### PR DESCRIPTION
## Why I'm doing:
Currently, StarRocks first close the original partition and then close the newly created partition for automatic partition data ingestion when the new partition and the old partition are distributed on different backends. This bug occurred during the processing of the original partition's close, because it will wait for the secondary replica of the newly created partition to close on the original partition' backend, leading to a cyclic wait and causing a stuck situation.

## What I'm doing:
Split the close request into two requests: 'finished' and 'closed', where 'finished' indicate data sending is finished, it does not require waiting for the secondary replica to close. This approach avoids circular dependencies.

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [x] 3.1
  - [x] 3.0
  - [ ] 2.5
