### PR TITLE
[BugFix] fix cancel refresh mv command cannot stop task

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/TaskRun.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/TaskRun.java
@@ -51,6 +51,7 @@ public class TaskRun implements Comparable<TaskRun> {
     public static final String FORCE = "FORCE";
     public static final String START_TASK_RUN_ID = "START_TASK_RUN_ID";
     public static final String IS_TEST = "__IS_TEST__";
+    private boolean isKilled = false;
 
     private long taskId;
 
@@ -137,6 +138,14 @@ public class TaskRun implements Comparable<TaskRun> {
 
     public String getUUID() {
         return taskRunId;
+    }
+
+    public void kill() {
+        isKilled = true;
+    }
+
+    public boolean isKilled() {
+        return isKilled;
     }
 
     public Map<String, String> refreshTaskProperties(ConnectContext ctx) {
@@ -229,6 +238,7 @@ public class TaskRun implements Comparable<TaskRun> {
         taskRunContext.setTaskType(type);
         taskRunContext.setStatus(status);
         taskRunContext.setExecuteOption(executeOption);
+        taskRunContext.setTaskRun(this);
 
         processor.processTaskRun(taskRunContext);
 

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/TaskRunContext.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/TaskRunContext.java
@@ -30,6 +30,7 @@ public class TaskRunContext {
     TaskRunStatus status;
     ExecuteOption executeOption;
     String taskRunId;
+    TaskRun taskRun;
 
     public TaskRunContext() {
     }
@@ -45,6 +46,7 @@ public class TaskRunContext {
         this.status = context.status;
         this.executeOption = context.executeOption;
         this.taskRunId = context.taskRunId;
+        this.taskRun = context.taskRun;
     }
 
     public ConnectContext getCtx() {
@@ -125,5 +127,13 @@ public class TaskRunContext {
 
     public void setTaskRunId(String uuid) {
         this.taskRunId = uuid;
+    }
+
+    public TaskRun getTaskRun() {
+        return taskRun;
+    }
+
+    public void setTaskRun(TaskRun taskRun) {
+        this.taskRun = taskRun;
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/TaskRunManager.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/TaskRunManager.java
@@ -98,6 +98,7 @@ public class TaskRunManager implements MemoryTrackable {
         if (taskRun == null) {
             return false;
         }
+        taskRun.kill();
         ConnectContext runCtx = taskRun.getRunCtx();
         if (runCtx != null) {
             runCtx.kill(false, "kill TaskRun");

--- a/fe/fe-core/src/test/java/com/starrocks/scheduler/PartitionBasedMvRefreshProcessorTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/scheduler/PartitionBasedMvRefreshProcessorTest.java
@@ -2949,6 +2949,36 @@ public class PartitionBasedMvRefreshProcessorTest extends MVRefreshTestBase {
     }
 
     @Test
+    public void testCancelRefreshMV() throws Exception {
+        starRocksAssert.useDatabase("test")
+                .withMaterializedView("CREATE MATERIALIZED VIEW `test`.`hive_parttbl_mv1`\n" +
+                        "COMMENT \"MATERIALIZED_VIEW\"\n" +
+                        "PARTITION BY (`l_shipdate`)\n" +
+                        "DISTRIBUTED BY HASH(`l_orderkey`) BUCKETS 10\n" +
+                        "REFRESH DEFERRED MANUAL\n" +
+                        "PROPERTIES (\n" +
+                        "\"replication_num\" = \"1\",\n" +
+                        "\"storage_medium\" = \"HDD\"\n" +
+                        ")\n" +
+                        "AS SELECT `l_orderkey`, `l_suppkey`, `l_shipdate`  FROM `hive0`.`partitioned_db`.`lineitem_par` as a;");
+        Database testDb = GlobalStateMgr.getCurrentState().getDb("test");
+        MaterializedView materializedView = ((MaterializedView) testDb.getTable("hive_parttbl_mv1"));
+
+        Task task = TaskBuilder.buildMvTask(materializedView, testDb.getFullName());
+        TaskRun taskRun = TaskRunBuilder.newBuilder(task).build();
+
+        taskRun.kill();
+        try {
+            initAndExecuteTaskRun(taskRun);
+        } catch (Exception e) {
+            Assert.assertTrue(e.getMessage().contains("error-msg : User Cancelled"));
+            starRocksAssert.dropMaterializedView("hive_parttbl_mv1");
+            return;
+        }
+        Assert.fail("should throw exception");
+    }
+
+    @Test
     public void testDropBaseVersionMetaOfExternalTable() throws Exception {
         starRocksAssert.withMaterializedView("create materialized view test_drop_partition_mv1\n" +
                 "PARTITION BY date_trunc('day', l_shipdate) \n" +


### PR DESCRIPTION
Why I'm doing:
cacnel refresh materialized view may not work sometime, because of the kill task need **executor**(StmtExecutor)  from connect context, but **executor** only be set after get insert into statement plan
What I'm doing:
check task run is killed before executor run insert stmt , do not generate next task when task run is killed
Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [x] 3.1
  - [x] 3.0
  - [x] 2.5
