### PR TITLE
[Feature][Issue 39849]add datadog java/cpp profiling lib

### DIFF
--- a/docker/dockerfiles/artifacts/artifact.Dockerfile
+++ b/docker/dockerfiles/artifacts/artifact.Dockerfile
@@ -48,7 +48,7 @@ RUN apt-get update -y && apt-get install -y --no-install-recommends wget tar xz-
 ADD 'https://dtdg.co/latest-java-tracer' /datadog/dd-java-agent.jar
 
 # Get ddprof for BE profiling
-RUN imagearch=$(arch | sed s/aarch64/arm64/ | sed s/x86_64/amd64/) \
+RUN imagearch=$(arch | sed 's/aarch64/arm64/; s/x86_64/amd64/') \
     && wget --no-check-certificate "https://github.com/DataDog/ddprof/releases/download/v0.15.3/ddprof-0.15.3-${imagearch}-linux.tar.xz" -O ddprof-linux.tar.xz \
     && tar xvf ddprof-linux.tar.xz && mkdir -p /datadog/  \
     && mv ddprof/bin/ddprof /datadog/ \
@@ -56,7 +56,6 @@ RUN imagearch=$(arch | sed s/aarch64/arm64/ | sed s/x86_64/amd64/) \
 
 FROM busybox:latest
 ARG RELEASE_VERSION
-ARG TARGETARCH
 
 LABEL org.opencontainers.image.source="https://github.com/starrocks/starrocks"
 LABEL org.starrocks.version=${RELEASE_VERSION:-"UNKNOWN"}

--- a/docker/dockerfiles/artifacts/artifact.Dockerfile
+++ b/docker/dockerfiles/artifacts/artifact.Dockerfile
@@ -40,6 +40,19 @@ COPY . /build/starrocks
 WORKDIR /build/starrocks
 RUN --mount=type=cache,target=/root/.m2/ STARROCKS_VERSION=${RELEASE_VERSION} BUILD_TYPE=${BUILD_TYPE} MAVEN_OPTS=${MAVEN_OPTS} ./build.sh --be --enable-shared-data --clean -j `nproc`
 
+FROM ubuntu:22.04 as datadog-downloader
+
+RUN apt-get update -y && apt-get install -y --no-install-recommends wget tar xz-utils
+
+# download the latest dd-java-agent
+ADD 'https://dtdg.co/latest-java-tracer' /datadog/dd-java-agent.jar
+
+# Get ddprof for BE profiling
+RUN imagearch=$(arch | sed s/aarch64/arm64/ | sed s/x86_64/amd64/) \
+    && wget --no-check-certificate "https://github.com/DataDog/ddprof/releases/download/v0.15.3/ddprof-0.15.3-${imagearch}-linux.tar.xz" -O ddprof-linux.tar.xz \
+    && tar xvf ddprof-linux.tar.xz && mkdir -p /datadog/  \
+    && mv ddprof/bin/ddprof /datadog/ \
+    && chmod 755 /datadog/ddprof
 
 FROM busybox:latest
 ARG RELEASE_VERSION
@@ -52,14 +65,7 @@ COPY --from=fe-builder /build/starrocks/output /release/fe_artifacts
 COPY --from=be-builder /build/starrocks/output /release/be_artifacts
 COPY --from=broker-builder /build/starrocks/fs_brokers/apache_hdfs_broker/output /release/broker_artifacts
 
-# download the latest dd-java-agent
-ADD 'https://dtdg.co/latest-java-tracer' /release/fe_artifacts/fe/datadog/dd-java-agent.jar
-
-# Get ddprof for BE profiling
-ADD https://github.com/DataDog/ddprof/releases/download/v0.15.3/ddprof-0.15.3-${TARGETARCH}-linux.tar.xz ddprof-linux.tar.xz
-RUN tar xvf ddprof-linux.tar.xz && mkdir -p /release/be_artifacts/be/datadog/  \
-    && mv ddprof/bin/ddprof /release/be_artifacts/be/datadog/ \
-    && chmod 755 /release/be_artifacts/be/datadog/ddprof \
-    && rm -f ddprof-linux.tar.xz
+COPY --from=datadog-downloader /datadog/dd-java-agent.jar /release/fe_artifacts/fe/datadog/dd-java-agent.jar
+COPY --from=datadog-downloader /datadog/ddprof /release/be_artifacts/be/datadog/ddprof
 
 WORKDIR /release


### PR DESCRIPTION
Why I'm doing:
Add datadog java/cpp profling library to SR images, they're used in https://github.com/StarRocks/starrocks/pull/39913.

What I'm doing:

^ add in artifacts image

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [x] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [x] 3.1
  - [ ] 3.1-cs
  - [ ] 3.0
  - [ ] 2.5

--- test plan----
The arm64/amd64 ddprof libraries:
```
wget "https://github.com/DataDog/ddprof/releases/download/v0.15.3/ddprof-0.15.3-arm64-linux.tar.xz" -O ddprof-linux.tar.xz \
    && tar xvf ddprof-linux.tar.xz && ls -l ddprof/bin/ddprof
> -rwxr-xr-x@ 1 m.xu  staff  20634896 Jan 22 06:58 ddprof/bin/ddprof


wget "https://github.com/DataDog/ddprof/releases/download/v0.15.3/ddprof-0.15.3-amd64-linux.tar.xz" -O ddprof-linux.tar.xz \
    && tar xvf ddprof-linux.tar.xz && ls -l ddprof/bin/ddprof
> -rwxr-xr-x@ 1 m.xu  staff  20813440 Jan 22 06:57 ddprof/bin/ddprof
```


Build multi-arc images, and check the `ddprof` file
```
# arm64
 DOCKER_BUILDKIT=1 docker buildx build --platform linux/arm64    -f docker/dockerfiles/artifacts/artifact.Dockerfile .
 

# amd64 
DOCKER_BUILDKIT=1 docker buildx build --platform linux/amd64    -f docker/dockerfiles/artifacts/artifact.Dockerfile .
 => => writing image sha256:d58cd0e655c62235c03d19a1ddefecf757393a69f3ab27bf7b339e4990e31d8c    

/release # ls -l be_artifacts/be/datadog/ddprof 
-rwxr-xr-x    1 root     root      20813440 Jan 22 14:57 be_artifacts/be/datadog/ddprof

# without `--platform` in CLI
DOCKER_BUILDKIT=1 docker buildx build    -f docker/dockerfiles/artifacts/artifact.Dockerfile .
=> => writing image sha256:d58cd0e655c62235c03d19a1ddefecf757393a69f3ab27bf7b339e4990e31d8c 
```
