### PR TITLE
[BugFix]Fix tablet delete by mistake because of the outdate report version

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/system/SystemInfoService.java
+++ b/fe/fe-core/src/main/java/com/starrocks/system/SystemInfoService.java
@@ -941,7 +941,7 @@ public class SystemInfoService implements GsonPostProcessable {
             if ((atomicLong = idToReportVersionRef.get(backendId)) != null) {
                 Database db = GlobalStateMgr.getCurrentState().getDb(dbId);
                 if (db != null) {
-                    atomicLong.set(newReportVersion);
+                    updateReportVersionIncrementally(atomicLong, newReportVersion);
                     LOG.debug("update backend {} report version: {}, db: {}", backendId, newReportVersion, dbId);
                 } else {
                     LOG.warn("failed to update backend report version, db {} does not exist", dbId);
@@ -949,6 +949,12 @@ public class SystemInfoService implements GsonPostProcessable {
             } else {
                 LOG.warn("failed to update backend report version, backend {} does not exist", backendId);
             }
+        }
+    }
+
+    protected synchronized void updateReportVersionIncrementally(AtomicLong currentVersion, long newVersion) {
+        if (currentVersion.get() < newVersion) {
+            currentVersion.set(newVersion);
         }
     }
 

--- a/fe/fe-core/src/test/java/com/starrocks/pseudocluster/PseudoBackend.java
+++ b/fe/fe-core/src/test/java/com/starrocks/pseudocluster/PseudoBackend.java
@@ -478,7 +478,6 @@ public class PseudoBackend {
         request.setTablets(tabletManager.getAllTabletInfo());
         request.setTablet_max_compaction_score(100);
         request.setBackend(tBackend);
-        reportVersion.incrementAndGet();
         request.setReport_version(reportVersion.get());
         try {
             if (!shutdown) {
@@ -667,8 +666,6 @@ public class PseudoBackend {
         TFinishTaskRequest finishTaskRequest = new TFinishTaskRequest(tBackend,
                 request.getTask_type(), request.getSignature(),
                 new TStatus(TStatusCode.OK));
-        long v = reportVersion.incrementAndGet();
-        finishTaskRequest.setReport_version(v);
         try {
             switch (finishTaskRequest.task_type) {
                 case CREATE:
@@ -697,6 +694,8 @@ public class PseudoBackend {
             finishTaskRequest.setTask_status(toStatus(e));
         }
         try {
+            long v = reportVersion.incrementAndGet();
+            finishTaskRequest.setReport_version(v);
             frontendService.finishTask(finishTaskRequest);
         } catch (TException e) {
             LOG.warn("error call finishTask", e);

--- a/fe/fe-core/src/test/java/com/starrocks/system/SystemInfoServiceTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/system/SystemInfoServiceTest.java
@@ -37,6 +37,8 @@ import java.net.InetAddress;
 import java.net.UnknownHostException;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.atomic.AtomicLong;
 import java.util.stream.Collectors;
 
 public class SystemInfoServiceTest {
@@ -304,5 +306,26 @@ public class SystemInfoServiceTest {
         service.addBackend(be);
         long backendId = service.getBackendIdWithStarletPort("newHost", 10001);
         Assert.assertEquals(be.getId(), backendId);
+    }
+
+    @Test
+    public void testUpdateReportVersionIncreasing() throws Exception {
+        long[] versions = new long[] {10, 5, 3, 2, 4, 1, 9, 7, 8, 6};
+        AtomicLong version = new AtomicLong();
+        version.set(0);
+
+        CountDownLatch latch = new CountDownLatch(10);
+        for (int i = 0; i < 10; i++) {
+            final int index = i;
+            new Thread(() -> {
+                service.updateReportVersionIncrementally(version, versions[index]);
+                System.out.println("updated version: " + versions[index]);
+                latch.countDown();
+            }).start();
+        }
+
+        latch.await();
+
+        Assert.assertEquals(10L, version.get());
     }
 }


### PR DESCRIPTION
Why I'm doing:
The report version in SystemInfoService maybe outdate in a concurrent scenario.

What I'm doing:
1. Update the report version incrementally.
2. Fix the report version bug of PseudoBackend.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [x] 3.1
  - [x] 3.0
  - [x] 2.5
