### PR TITLE
[Enhancement] change the task execution user to current_user when creating

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/TaskBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/TaskBuilder.java
@@ -160,7 +160,9 @@ public class TaskBuilder {
         task.setDefinition(materializedView.getTaskDefinition());
         task.setPostRun(getAnalyzeMVStmt(materializedView.getName()));
         task.setExpireTime(0L);
-        task.setCreateUser(ConnectContext.get().getCurrentUserIdentity().getUser());
+        if (ConnectContext.get() != null) {
+            task.setCreateUser(ConnectContext.get().getCurrentUserIdentity().getUser());
+        }
         handleSpecialTaskProperties(task);
         return task;
     }

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/TaskBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/TaskBuilder.java
@@ -83,6 +83,7 @@ public class TaskBuilder {
         task.setDefinition(submitTaskStmt.getSqlText());
         task.setProperties(submitTaskStmt.getProperties());
         task.setExpireTime(System.currentTimeMillis() + Config.task_ttl_second * 1000L);
+        task.setCreateUser(ConnectContext.get().getCurrentUserIdentity().getUser());
 
         handleSpecialTaskProperties(task);
         return task;
@@ -159,6 +160,7 @@ public class TaskBuilder {
         task.setDefinition(materializedView.getTaskDefinition());
         task.setPostRun(getAnalyzeMVStmt(materializedView.getName()));
         task.setExpireTime(0L);
+        task.setCreateUser(ConnectContext.get().getCurrentUserIdentity().getUser());
         handleSpecialTaskProperties(task);
         return task;
     }
@@ -174,6 +176,7 @@ public class TaskBuilder {
         task.setDefinition(materializedView.getTaskDefinition());
         task.setPostRun(getAnalyzeMVStmt(materializedView.getName()));
         task.setExpireTime(0L);
+        task.setCreateUser(ConnectContext.get().getCurrentUserIdentity().getUser());
         handleSpecialTaskProperties(task);
         return task;
     }

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/SubmitTaskStmtTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/SubmitTaskStmtTest.java
@@ -207,4 +207,15 @@ public class SubmitTaskStmtTest {
         Assert.assertNull(tm.getTask(taskName));
         starRocksAssert.dropMaterializedView(name);
     }
+
+    @Test
+    public void createTaskWithUser() throws Exception {
+        TaskManager tm = GlobalStateMgr.getCurrentState().getTaskManager();
+        connectContext.executeSql("CREATE USER 'test2' IDENTIFIED BY ''");
+        connectContext.executeSql("GRANT all on DATABASE test to test2");
+        connectContext.executeSql("GRANT all on test.* to test2");
+        connectContext.executeSql("EXECUTE AS test2 WITH NO REVERT");
+        connectContext.executeSql(("submit task task_with_user as create table t_tmp as select * from test.tbl1"));
+        Assert.assertEquals("test2", tm.getTask("task_with_user").getCreateUser());
+    }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/SubmitTaskStmtTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/SubmitTaskStmtTest.java
@@ -32,6 +32,7 @@ import com.starrocks.sql.analyzer.AnalyzeTestUtil;
 import com.starrocks.sql.analyzer.TaskAnalyzer;
 import com.starrocks.sql.ast.StatementBase;
 import com.starrocks.sql.ast.SubmitTaskStmt;
+import com.starrocks.sql.ast.UserIdentity;
 import com.starrocks.utframe.StarRocksAssert;
 import com.starrocks.utframe.UtFrameUtils;
 import com.starrocks.warehouse.LocalWarehouse;
@@ -217,5 +218,9 @@ public class SubmitTaskStmtTest {
         connectContext.executeSql("EXECUTE AS test2 WITH NO REVERT");
         connectContext.executeSql(("submit task task_with_user as create table t_tmp as select * from test.tbl1"));
         Assert.assertEquals("test2", tm.getTask("task_with_user").getCreateUser());
+
+        starRocksAssert.getCtx().setCurrentUserIdentity(UserIdentity.ROOT);
+        starRocksAssert.getCtx().setCurrentRoleIds(starRocksAssert.getCtx().getGlobalStateMgr()
+                .getAuthorizationMgr().getRoleIdsByUser(UserIdentity.ROOT));
     }
 }


### PR DESCRIPTION
Why I'm doing:
- Current we use the `root` to execute all tasks, but it's not reasonable in some cases
- For example, submit a task with `user1` but finally execute as `root` will muddle the privilege and resource management

What I'm doing:
- Change the task execution user to creator

Behavior change:
- Previous use the `ROOT` to execute all tasks
- Current use the creator to executor all tasks

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [x] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [x] 3.1
  - [ ] 3.0
  - [ ] 2.5
