### PR TITLE
[BugFix] Get rid of overwriting JobState after create an image

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/load/EtlStatus.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/EtlStatus.java
@@ -216,6 +216,7 @@ public class EtlStatus implements Writable {
         this.progress = 0;
         this.failMsg = "";
         this.dppResult = null;
+        loadStatistic.reset();
     }
 
     @Override
@@ -524,6 +525,18 @@ public class EtlStatus implements Writable {
             if (params.done && unfinishedBackendIds.containsKey(loadStr)) {
                 unfinishedBackendIds.get(loadStr).remove(params.backend_id);
             }
+        }
+
+        public synchronized void reset() {
+            counterTbl.clear();
+            sinkBytesCounterTbl.clear();
+            sourceRowsCounterTbl.clear();
+            sourceBytesCounterTbl.clear();
+            filteredRowsCounterTbl.clear();
+            unselectedRowsCounterTbl.clear();
+            sourceScanBytesCounterTbl.clear();
+            unfinishedBackendIds.clear();
+            allBackendIds.clear();
         }
 
         // used for `show load`

--- a/fe/fe-core/src/main/java/com/starrocks/load/loadv2/BrokerLoadJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/loadv2/BrokerLoadJob.java
@@ -357,9 +357,9 @@ public class BrokerLoadJob extends BulkLoadJob {
                 return;
             }
 
+            failMsg = new FailMsg(FailMsg.CancelType.TIMEOUT, txnStatusChangeReason + ". Retry again");
+            LOG.warn("Retry timeout load jobs. job: {}, remaining retryTime: {}", id, retryTime);
             retryTime--;
-            failMsg = new FailMsg(FailMsg.CancelType.TIMEOUT, txnStatusChangeReason);
-            LOG.warn("Retry timeout load jobs. job: {}, retryTime: {}", id, retryTime);
             unprotectedClearTasksBeforeRetry(failMsg);
             try {
                 state = JobState.PENDING;

--- a/fe/fe-core/src/main/java/com/starrocks/load/loadv2/LoadJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/loadv2/LoadJob.java
@@ -1062,11 +1062,7 @@ public abstract class LoadJob extends AbstractTxnStateChangeCallback implements 
             failMsg = new FailMsg(FailMsg.CancelType.LOAD_RUN_FAIL, txnState.getReason());
             finishTimestamp = txnState.getFinishTime();
             state = JobState.CANCELLED;
-            if (retryTime <= 0 || !failMsg.getMsg().contains("timeout") || !isTimeout()) {
-                GlobalStateMgr.getCurrentState().getGlobalTransactionMgr().getCallbackFactory().removeCallback(id);
-                return;
-            }
-            retryTime--;
+            GlobalStateMgr.getCurrentState().getGlobalTransactionMgr().getCallbackFactory().removeCallback(id);
         } finally {
             writeUnlock();
         }

--- a/fe/fe-core/src/test/java/com/starrocks/load/loadv2/BrokerLoadJobTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/load/loadv2/BrokerLoadJobTest.java
@@ -68,6 +68,7 @@ import com.starrocks.transaction.TabletCommitInfo;
 import com.starrocks.transaction.TabletFailInfo;
 import com.starrocks.transaction.TransactionState;
 import com.starrocks.transaction.TxnCommitAttachment;
+import com.starrocks.transaction.TxnStateChangeCallback;
 import mockit.Expectations;
 import mockit.Injectable;
 import mockit.Mock;
@@ -623,6 +624,47 @@ public class BrokerLoadJobTest {
         Assert.assertEquals(99, (int) Deencapsulation.getField(brokerLoadJob, "progress"));
         Assert.assertEquals(1, brokerLoadJob.getFinishTimestamp());
         Assert.assertEquals(JobState.CANCELLED, brokerLoadJob.getState());
+    }
+
+    @Test
+    public void testReplayOnAbortedAfterFailure(@Injectable TransactionState txnState,
+                                                @Injectable LoadJobFinalOperation attachment,
+                                                @Injectable FailMsg failMsg) {
+        BrokerLoadJob brokerLoadJob = new BrokerLoadJob();
+        brokerLoadJob.setId(1);
+        GlobalTransactionMgr globalTxnMgr = GlobalStateMgr.getCurrentState().getGlobalTransactionMgr();
+        globalTxnMgr.getCallbackFactory().addCallback(brokerLoadJob);
+
+        // 1. The job will be keep when the failure is timeout
+        new Expectations() {
+            {
+                txnState.getTxnCommitAttachment();
+                minTimes = 0;
+                result = attachment;
+                txnState.getReason();
+                minTimes = 0;
+                result = "load timeout";
+            }
+        };
+
+        brokerLoadJob.replayOnAborted(txnState);
+        TxnStateChangeCallback callback = globalTxnMgr.getCallbackFactory().getCallback(1);
+        Assert.assertNotNull(callback);
+
+        // 2. The job will be discard when failure isn't timeout
+        new Expectations() {
+            {
+                txnState.getTxnCommitAttachment();
+                minTimes = 0;
+                result = attachment;
+                txnState.getReason();
+                minTimes = 0;
+                result = "load_run_faill";
+            }
+        };
+        brokerLoadJob.replayOnAborted(txnState);
+        callback = globalTxnMgr.getCallbackFactory().getCallback(1);
+        Assert.assertNull(callback);
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/load/loadv2/BrokerLoadJobTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/load/loadv2/BrokerLoadJobTest.java
@@ -659,7 +659,7 @@ public class BrokerLoadJobTest {
                 result = attachment;
                 txnState.getReason();
                 minTimes = 0;
-                result = "load_run_faill";
+                result = "load_run_fail";
             }
         };
         brokerLoadJob.replayOnAborted(txnState);


### PR DESCRIPTION
Why I'm doing:
The JobState of a broker load that retried after timeout will be overwritten wrong.
For example, a broker load job retry after timeout and finished. After checkpoint, the job state will be overwritten as CANCELLED.
When creating a new image by checkpoint or restart FE, it will lead to the case.

What I'm doing:
Get rid of overwriting JobState after create an image

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [x] 3.1
  - [x] 3.0
  - [ ] 2.5
