### PR TITLE
[BugFix] Fix the bug of SinkIOBuffer user-after-free

### DIFF
--- a/be/src/exec/pipeline/sink/export_sink_operator.cpp
+++ b/be/src/exec/pipeline/sink/export_sink_operator.cpp
@@ -109,8 +109,9 @@ void ExportSinkIOBuffer::_process_chunk(bthread::TaskIterator<ChunkPtr>& iter) {
     }
     const auto& chunk = *iter;
     if (chunk == nullptr) {
-        // this is the last chunk
-        DCHECK_EQ(_num_pending_chunks, 1);
+        // this is the last chunk, finish task is first put into queue and then ++_num_pending_chunks,
+        // So _num_pending_chunks maybe 0 or 1 here.
+        DCHECK_LE(_num_pending_chunks, 1);
         close(_state);
         return;
     }

--- a/be/src/exec/pipeline/sink/file_sink_operator.cpp
+++ b/be/src/exec/pipeline/sink/file_sink_operator.cpp
@@ -150,7 +150,7 @@ void FileSinkIOBuffer::_process_chunk(bthread::TaskIterator<ChunkPtr>& iter) {
     if (chunk == nullptr) {
         // this is the last chunk
         auto nc = _num_pending_chunks.load();
-        DCHECK_EQ(nc, 1L);
+        DCHECK_LE(nc, 1L);
         close(_state);
         return;
     }

--- a/be/src/exec/pipeline/sink/mysql_table_sink_operator.cpp
+++ b/be/src/exec/pipeline/sink/mysql_table_sink_operator.cpp
@@ -107,7 +107,7 @@ void MysqlTableSinkIOBuffer::_process_chunk(bthread::TaskIterator<ChunkPtr>& ite
     if (chunk == nullptr) {
         // this is the last chunk
         auto nc = _num_pending_chunks.load();
-        DCHECK_EQ(nc, 1L);
+        DCHECK_LE(nc, 1L);
         close(_state);
         return;
     }

--- a/be/src/exec/pipeline/sink/sink_io_buffer.h
+++ b/be/src/exec/pipeline/sink/sink_io_buffer.h
@@ -57,12 +57,8 @@ public:
         if (_exec_queue_id != nullptr) {
             // If `Operator` prepare failed, there is no chance to stop queue, so will should stop queue here.
             // It is safe to call stop multiple times.
-            if (bthread::execution_queue_stop(*_exec_queue_id) != 0) {
-                LOG(WARNING) << "SinkIOBuffer stop queue failed: " << _exec_queue_id->value;
-            }
-            if (bthread::execution_queue_join(*_exec_queue_id) != 0) {
-                LOG(WARNING) << "SinkIOBuffer join queue failed: " << _exec_queue_id->value;
-            }
+            bthread::execution_queue_stop(*_exec_queue_id);
+            bthread::execution_queue_join(*_exec_queue_id);
         }
     }
 

--- a/be/test/exec/sink/sink_io_buffer_test.cpp
+++ b/be/test/exec/sink/sink_io_buffer_test.cpp
@@ -21,7 +21,6 @@
 #include <thread>
 
 #include "testutil/assert.h"
-#include "util/defer_op.h"
 
 namespace starrocks::pipeline {
 
@@ -31,16 +30,12 @@ namespace starrocks::pipeline {
 // skipping stop task in consumer thread.
 
 namespace {
-bthread::ExecutionQueueId<ChunkPtr> _execq_id;
-std::promise<void> _promise;
-
 class MockSinkIOBuffer : public SinkIOBuffer {
 public:
     MockSinkIOBuffer(int num_sinkers) : SinkIOBuffer(num_sinkers) {}
 
     static int execute_io_task(void* meta, bthread::TaskIterator<ChunkPtr>& iter) {
         if (iter.is_queue_stopped()) {
-            // block until SinkIOBuffer is destroyed
             _promise.get_future().wait();
         }
 
@@ -100,11 +95,17 @@ public:
     }
 
     ALWAYS_NOINLINE void dummy() { std::cout << _num_pending_chunks << std::endl; }
+
+    static void set_promise_value() { _promise.set_value(); }
+
+private:
+    bthread::ExecutionQueueId<ChunkPtr> _execq_id;
+    static std::promise<void> _promise;
 };
 
 TEST(SinkIOBufferTest, test_basic) {
+    auto sink_buffer = std::make_unique<MockSinkIOBuffer>(10);
     {
-        auto sink_buffer = std::make_unique<MockSinkIOBuffer>(10);
         ASSERT_OK(sink_buffer->prepare(nullptr, nullptr));
 
         auto chunk = std::make_shared<Chunk>();
@@ -117,14 +118,7 @@ TEST(SinkIOBufferTest, test_basic) {
             std::this_thread::sleep_for(std::chrono::milliseconds(10));
         }
     }
-
-    {
-        // after sink buffer is destroyed, signal the consumer thread to execute stop task
-        _promise.set_value();
-        // wait until execution queue is destroyed
-        int r = bthread::execution_queue_join(_execq_id);
-        ASSERT_EQ(r, 0);
-    }
+    MockSinkIOBuffer::set_promise_value();
 }
 } // namespace
 

--- a/be/test/exec/sink/sink_io_buffer_test.cpp
+++ b/be/test/exec/sink/sink_io_buffer_test.cpp
@@ -103,6 +103,8 @@ private:
     static std::promise<void> _promise;
 };
 
+std::promise<void> MockSinkIOBuffer::_promise;
+
 TEST(SinkIOBufferTest, test_basic) {
     auto sink_buffer = std::make_unique<MockSinkIOBuffer>(10);
     {


### PR DESCRIPTION
Why I'm doing:

This problem has been fixed about 6 times, but it still hasn’t been completely fixed.

Previous PRs that fixed this issue:

1. fix issues in export sink operator: https://github.com/StarRocks/starrocks/pull/15915
2. Fix driver pending due to unclosed sink buffer: https://github.com/StarRocks/starrocks/pull/24057
3. Ensure SinkIOBuffer outlives execution queue: https://github.com/StarRocks/starrocks/pull/25245
4. Revert "[BugFix] Ensure SinkIOBuffer outlives execution queue": https://github.com/StarRocks/starrocks/pull/25468
5. Fix SinkIOBuffer use-after-free by skipping stop task: https://github.com/StarRocks/starrocks/pull/26028
6. Fix sink operator dcheck fail occasionall: https://github.com/StarRocks/starrocks/pull/38094

Currently branch-main can reproduce this bug by adding sleep:

https://github.com/StarRocks/starrocks/pull/40633

The bug in PR3 is that: join io queue in  bthread io task so gets stuck.
The bug in PR5 is that the io thread has not exited and _is_finished has already been set to True, causing the `Operator` to be destructed first.
The bug in PR6. The reason is that set_finishing puts the request into the queue first, and then ++_num_pending_chunks, causing problems with DCHECK.

What I'm doing:

Repair principles:
- The bthread io queue exits first and then the `Operator` is destructed.
- Operator close don't be stuck for too long, otherwise the pipeline scheduling thread will be stuck.

How to fix:
1. When `SinkIOBuffer` is destructed, you need to wait for the bthread queue to exit.
2. Currently, it is only possible to exit when there is only one finish task in the queue, so the exit will be fast and the SinkIOBuffer destructor will not be stuck.
3. If `Operator` prepare failed, there is no chance to stop queue, so will should stop queue in destructor of `SinkIOBuffer`. It is safe to call queue::stop multiple times. 

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [x] 3.1
  - [x] 3.0
  - [x] 2.5
