### PR TITLE
[BugFix] fix left outer join to inner join bug and string not equal rewrite bug for 2.5 (backport #39331)

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/Optimizer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/Optimizer.java
@@ -543,6 +543,9 @@ public class Optimizer {
         List<Rule> rules = rootTaskContext.getOptimizerContext().getRuleSet().getRewriteRulesByType(ruleSetType);
         context.getTaskScheduler().pushTask(new RewriteTreeTask(rootTaskContext, tree, rules, false));
         context.getTaskScheduler().executeTasks(rootTaskContext);
+        if (ruleSetType.equals(RuleSetType.PUSH_DOWN_PREDICATE)) {
+            context.reset();
+        }
     }
 
     private void ruleRewriteIterative(OptExpression tree, TaskContext rootTaskContext, Rule rule) {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/ScalarOperatorRewriter.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/ScalarOperatorRewriter.java
@@ -19,7 +19,6 @@ import com.starrocks.sql.optimizer.rewrite.scalar.SimplifiedPredicateRule;
 import com.starrocks.sql.optimizer.rewrite.scalar.SimplifiedScanColumnRule;
 
 import java.util.List;
-import java.util.stream.Collectors;
 
 public class ScalarOperatorRewriter {
     public static final List<ScalarOperatorRewriteRule> DEFAULT_TYPE_CAST_RULE = Lists.newArrayList(

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/ScalarOperatorRewriter.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/ScalarOperatorRewriter.java
@@ -50,17 +50,9 @@ public class ScalarOperatorRewriter {
             new ArithmeticCommutativeRule()
     );
 
-    public static final List<ScalarOperatorRewriteRule> MV_SCALAR_REWRITE_RULES = Lists.newArrayList(
-            // required
-            new ImplicitCastRule(),
-            // optional
-            new ReduceCastRule(),
-            new MvNormalizePredicateRule(),
-            new FoldConstantsRule(),
-            new SimplifiedPredicateRule(),
-            new ExtractCommonPredicateRule(),
-            new ArithmeticCommutativeRule()
-    );
+    public static final List<ScalarOperatorRewriteRule> MV_SCALAR_REWRITE_RULES = DEFAULT_REWRITE_SCAN_PREDICATE_RULES.stream()
+            .map(rule -> rule instanceof NormalizePredicateRule ? new MvNormalizePredicateRule() : rule)
+            .collect(Collectors.toList());
 
     private final ScalarOperatorRewriteContext context;
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/ScalarOperatorRewriter.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/ScalarOperatorRewriter.java
@@ -19,6 +19,7 @@ import com.starrocks.sql.optimizer.rewrite.scalar.SimplifiedPredicateRule;
 import com.starrocks.sql.optimizer.rewrite.scalar.SimplifiedScanColumnRule;
 
 import java.util.List;
+import java.util.stream.Collectors;
 
 public class ScalarOperatorRewriter {
     public static final List<ScalarOperatorRewriteRule> DEFAULT_TYPE_CAST_RULE = Lists.newArrayList(
@@ -50,9 +51,17 @@ public class ScalarOperatorRewriter {
             new ArithmeticCommutativeRule()
     );
 
-    public static final List<ScalarOperatorRewriteRule> MV_SCALAR_REWRITE_RULES = DEFAULT_REWRITE_SCAN_PREDICATE_RULES.stream()
-            .map(rule -> rule instanceof NormalizePredicateRule ? new MvNormalizePredicateRule() : rule)
-            .collect(Collectors.toList());
+    public static final List<ScalarOperatorRewriteRule> MV_SCALAR_REWRITE_RULES = Lists.newArrayList(
+            // required
+            new ImplicitCastRule(),
+            // optional
+            new ReduceCastRule(),
+            new MvNormalizePredicateRule(),
+            new FoldConstantsRule(),
+            new SimplifiedPredicateRule(),
+            new ExtractCommonPredicateRule(),
+            new ArithmeticCommutativeRule()
+    );
 
     private final ScalarOperatorRewriteContext context;
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/PushDownJoinOnClauseRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/PushDownJoinOnClauseRule.java
@@ -36,7 +36,7 @@ public class PushDownJoinOnClauseRule extends TransformationRule {
         LogicalJoinOperator join = (LogicalJoinOperator) input.getOp();
         ScalarOperator on = join.getOnPredicate();
         JoinPredicatePushdown joinPredicatePushdown = new JoinPredicatePushdown(
-                input, true, false, context.getColumnRefFactory());
+                input, true, false, context.getColumnRefFactory(), context);
         OptExpression root = joinPredicatePushdown.pushdown(join.getOnPredicate());
         ((LogicalJoinOperator) root.getOp()).setHasPushDownJoinOnClause(true);
         if (root.getOp().equals(input.getOp()) && on.equals(join.getOnPredicate()) &&

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/PushDownPredicateJoinRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/PushDownPredicateJoinRule.java
@@ -26,7 +26,7 @@ public class PushDownPredicateJoinRule extends TransformationRule {
         LogicalFilterOperator filter = (LogicalFilterOperator) input.getOp();
         OptExpression joinOpt = input.getInputs().get(0);
         JoinPredicatePushdown joinPredicatePushdown = new JoinPredicatePushdown(
-                joinOpt, false, false, context.getColumnRefFactory());
+                joinOpt, false, false, context.getColumnRefFactory(), context);
         return Lists.newArrayList(joinPredicatePushdown.pushdown(filter.getPredicate()));
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MaterializedViewRewriter.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MaterializedViewRewriter.java
@@ -1703,8 +1703,9 @@ public class MaterializedViewRewriter {
 
     private OptExpression doPushdownPredicate(OptExpression joinOptExpression, ScalarOperator predicate) {
         Preconditions.checkState(joinOptExpression.getOp() instanceof LogicalJoinOperator);
+        optimizerContext.reset();
         JoinPredicatePushdown joinPredicatePushdown = new JoinPredicatePushdown(joinOptExpression,
-                false, true, materializationContext.getQueryRefFactory());
+                false, true, materializationContext.getQueryRefFactory(), optimizerContext);
         return joinPredicatePushdown.pushdown(predicate);
     }
 

--- a/fe/fe-core/src/test/java/com/starrocks/planner/MaterializedViewTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/planner/MaterializedViewTest.java
@@ -4558,4 +4558,28 @@ public class MaterializedViewTest extends MaterializedViewTestBase {
                 " count(distinct tag_id + 3)  from user_tags;");
         connectContext.getSessionVariable().setCboCteReuse(true);
     }
+
+    @Test
+    public void testMultiLeftOuterJoin() {
+        {
+            String mv = "select t1a, t1b, v5, v8 " +
+                    "from test.test_all_type left outer join test.t1 on t1d = v4 " +
+                    "left outer join test.t2 on v5 = v7 where v9 = 10";
+            String query = "select t1a, t1b, v5, v8 " +
+                    "from test.test_all_type left outer join test.t1 on t1d = v4 " +
+                    "left outer join test.t2 on v5 = v7 where v9 = 10 and t1a != 'xxx'";
+            MVRewriteChecker checker = testRewriteOK(mv, query);
+            checker.contains("t1a != 'xxx'");
+        }
+
+        {
+            String mv = "select v1, v2, v3, v5, v8 " +
+                    "from test.t0 left outer join test.t1 on v1 = v4 " +
+                    "left outer join test.t2 on v5 = v7 where v9 = 10";
+            String query = "select v1, v2, v3, v5, v8 " +
+                    "from test.t0 left outer join test.t1 on v1 = v4 " +
+                    "left outer join test.t2 on v5 = v7 where v9 = 10 and v3 = 1";
+            testRewriteOK(mv, query);
+        }
+    }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/OptimizerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/OptimizerTest.java
@@ -230,7 +230,7 @@ public class OptimizerTest {
                         "PROPERTIES('replication_num' = '1');")
                 .withMaterializedView("create materialized view mv_3\n" +
                         "distributed by hash(k2) buckets 3\n" +
-                        "refresh async\n" +
+                        "refresh manual\n" +
                         "as select k2, sum(v1) as total from tbl_with_mv group by k2;")
                 .withMaterializedView("create materialized view mv_4\n" +
                         "PARTITION BY k1\n" +

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rewrite/JoinPredicatePushdownTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rewrite/JoinPredicatePushdownTest.java
@@ -1,0 +1,118 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.sql.optimizer.rewrite;
+
+import com.starrocks.sql.plan.PlanTestBase;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+public class JoinPredicatePushdownTest extends PlanTestBase {
+    @BeforeClass
+    public static void beforeClass() throws Exception {
+        PlanTestBase.beforeClass();
+    }
+
+    @Test
+    public void testJoinPushdownCTE() throws Exception {
+        // enable cte reuse to trigger calling PUSH_DOWN_PREDICATE rule set twice
+        connectContext.getSessionVariable().setCboCteReuse(true);
+        String query = "with xxx1 as (\n" +
+                "with x as (select * from t1 join t2 where t1.v4 = t2.v7 )\n" +
+                "select x1.v6, x2.v7 \n" +
+                "from (select * from x where x.v5 = 1 ) x1 left outer join" +
+                " (select * from x where x.v8 = 2) x2 on x1.v4 = x2.v7)\n" +
+                "select * from xxx1 where xxx1.v6 = 2\n" +
+                "union \n" +
+                "select * from xxx1 where xxx1.v7 = 3";
+        String plan = getFragmentPlan(query);
+        // must has left outer join
+        PlanTestBase.assertContains(plan, "13:HASH JOIN\n" +
+                "  |  join op: LEFT OUTER JOIN (BROADCAST)\n" +
+                "  |  colocate: false, reason: \n" +
+                "  |  equal join conjunct: 7: v4 = 16: v7\n" +
+                "  |  other predicates: (16: v7 = 3) OR (9: v6 = 2)");
+    }
+
+    @Test
+    public void testMultiLeftOuterJoin2() throws Exception {
+        connectContext.getSessionVariable().setOptimizerExecuteTimeout(3000000);
+        connectContext.getSessionVariable().disableJoinReorder();
+        String query = "select x.v1 v11, x.v2 v21, x.v3 v31, sub2.v1 v12, sub2.v2 v22 from test.t0 x inner join" +
+                " (select v1, v2, v3, v4, v5, v8 " +
+                "from test.t0 left outer join (select * from test.t1 " +
+                "inner join test.t2 on v5 = v7) sub on v1 = v4) sub2 on x.v1 = sub2.v1";
+        String plan = getFragmentPlan(query);
+    }
+
+    @Test
+    public void testMultiLeftOuterJoin() throws Exception {
+        String query = "select v1, v2, v5, v8 " +
+                "from test.t0 left outer join test.t1 on v1 = v4 " +
+                "left outer join test.t2 on v5 = v7 where v9 = 10";
+        String plan = getFragmentPlan(query);
+        PlanTestBase.assertContains(plan, "3:HASH JOIN\n" +
+                "  |  join op: INNER JOIN (BROADCAST)\n" +
+                "  |  colocate: false, reason: \n" +
+                "  |  equal join conjunct: 1: v1 = 4: v4");
+        PlanTestBase.assertContains(plan, "8:HASH JOIN\n" +
+                "  |  join op: INNER JOIN (BROADCAST)\n" +
+                "  |  colocate: false, reason: \n" +
+                "  |  equal join conjunct: 5: v5 = 7: v7");
+
+        String query2 = "select v1, v2, v5, v8 " +
+                "from test.t0 left outer join test.t1 on v1 = v4 " +
+                "left outer join test.t2 on v5 = v7 where v9 = 10 and v3 = 1";
+        String plan2 = getFragmentPlan(query2);
+        PlanTestBase.assertContains(plan2, "9:HASH JOIN\n" +
+                "  |  join op: INNER JOIN (BROADCAST)\n" +
+                "  |  colocate: false, reason: \n" +
+                "  |  equal join conjunct: 5: v5 = 7: v7");
+        PlanTestBase.assertContains(plan2, "4:HASH JOIN\n" +
+                "  |  join op: INNER JOIN (BROADCAST)\n" +
+                "  |  colocate: false, reason: \n" +
+                "  |  equal join conjunct: 1: v1 = 4: v4");
+        PlanTestBase.assertNotContains(plan2, "LEFT OUTER JOIN");
+    }
+
+    @Test
+    public void testMultiRightOuterJoin() throws Exception {
+        String query = "select v1, v2, v5, v8 " +
+                "from test.t0 right outer join test.t1 on v1 = v4 " +
+                "right outer join test.t2 on v2 = v7 where v3 = 10";
+        String plan = getFragmentPlan(query);
+        PlanTestBase.assertContains(plan, "4:HASH JOIN\n" +
+                "  |  join op: INNER JOIN (BROADCAST)\n" +
+                "  |  colocate: false, reason: \n" +
+                "  |  equal join conjunct: 1: v1 = 4: v4");
+        PlanTestBase.assertContains(plan, "8:HASH JOIN\n" +
+                "  |  join op: INNER JOIN (BROADCAST)\n" +
+                "  |  colocate: false, reason: \n" +
+                "  |  equal join conjunct: 2: v2 = 7: v7");
+
+        String query2 = "select v1, v2, v5, v8 " +
+                "from test.t0 right outer join test.t1 on v1 = v4 " +
+                "right outer join test.t2 on v2 = v7 where v5 = 10";
+        String plan2 = getFragmentPlan(query2);
+        PlanTestBase.assertContains(plan2, "7:HASH JOIN\n" +
+                "  |  join op: INNER JOIN (BROADCAST)\n" +
+                "  |  colocate: false, reason: \n" +
+                "  |  equal join conjunct: 2: v2 = 7: v7");
+        PlanTestBase.assertContains(plan2, "3:HASH JOIN\n" +
+                "  |  join op: INNER JOIN (BROADCAST)\n" +
+                "  |  colocate: false, reason: \n" +
+                "  |  equal join conjunct: 1: v1 = 4: v4");
+        PlanTestBase.assertNotContains(plan2, "LEFT OUTER JOIN");
+    }
+}

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/ReplayFromDumpTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/ReplayFromDumpTest.java
@@ -805,7 +805,7 @@ public class ReplayFromDumpTest {
         Pair<QueryDumpInfo, String> replayPair =
                 getPlanFragment(getDumpInfoFromFile("query_dump/build_join_projection"), null,
                         TExplainLevel.NORMAL);
-        Assert.assertTrue(replayPair.second, replayPair.second.contains("22:Project\n" +
+        Assert.assertTrue(replayPair.second, replayPair.second.contains("Project\n" +
                 "  |  <slot 425> : 425: row_id\n" +
                 "  |  <slot 426> : 426: enter_time\n" +
                 "  |  <slot 433> : 433: telephone2\n" +
@@ -819,7 +819,7 @@ public class ReplayFromDumpTest {
                 "  |  <slot 608> : 608: create_time\n" +
                 "  |  <slot 620> : 620: ter_user_phone\n" +
                 "  |  \n" +
-                "  21:HASH JOIN\n" +
+                "  20:HASH JOIN\n" +
                 "  |  join op: INNER JOIN (BROADCAST)\n" +
                 "  |  colocate: false, reason: \n" +
                 "  |  equal join conjunct: 590: user_id = 622: ter_user_id\n" +


### PR DESCRIPTION
Why I'm doing:
mv with string not equal predicate rewrite failed because converting left outer join to inner join failed.

What I'm doing:
Fix it by:

fix converting left outer join to inner join bug
fix query with string not equal predicate rewrite failed bug.
Fixes https://github.com/StarRocks/starrocks/issues/39330
## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [x] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5

