### PR TITLE
[Enhancement] array_expr return constant column

### DIFF
--- a/be/src/exprs/agg/window_funnel.h
+++ b/be/src/exprs/agg/window_funnel.h
@@ -453,7 +453,7 @@ public:
 
         // get event
         uint8_t event_level = 0;
-        const ArrayColumn* event_column;
+        const ArrayColumn* event_column = nullptr;
         size_t offset = 0;
         size_t array_size = 0;
 
@@ -465,14 +465,13 @@ public:
             auto offsets_ptr = offsets.get_data().data();
             offset = offsets_ptr[0];
             array_size = offsets_ptr[1] - offsets_ptr[0];
-        } else if (columns[3]->is_array()) {
+        } else {
+            DCHECK(columns[3]->is_array());
             event_column = down_cast<const ArrayColumn*>(columns[3]);
             const UInt32Column& offsets = event_column->offsets();
             auto offsets_ptr = offsets.get_data().data();
             offset = offsets_ptr[row_num];
             array_size = offsets_ptr[row_num + 1] - offsets_ptr[row_num];
-        } else {
-            DCHECK(false);
         }
 
         const Column& elements = event_column->elements();

--- a/be/src/exprs/agg/window_funnel.h
+++ b/be/src/exprs/agg/window_funnel.h
@@ -24,6 +24,7 @@
 #include "column/array_column.h"
 #include "column/binary_column.h"
 #include "column/column_helper.h"
+#include "column/const_column.h"
 #include "column/datum.h"
 #include "column/fixed_length_column.h"
 #include "column/nullable_column.h"
@@ -452,12 +453,27 @@ public:
 
         // get event
         uint8_t event_level = 0;
-        const auto* event_column = down_cast<const ArrayColumn*>(columns[3]);
+        const ArrayColumn* event_column;
+        size_t offset = 0;
+        size_t array_size = 0;
 
-        const UInt32Column& offsets = event_column->offsets();
-        auto offsets_ptr = offsets.get_data().data();
-        size_t offset = offsets_ptr[row_num];
-        size_t array_size = offsets_ptr[row_num + 1] - offsets_ptr[row_num];
+        DCHECK(!columns[3]->only_null());
+        if (columns[3]->is_constant()) {
+            event_column =
+                    down_cast<const ArrayColumn*>(down_cast<const ConstColumn*>(columns[3])->data_column().get());
+            const UInt32Column& offsets = event_column->offsets();
+            auto offsets_ptr = offsets.get_data().data();
+            offset = offsets_ptr[0];
+            array_size = offsets_ptr[1] - offsets_ptr[0];
+        } else if (columns[3]->is_array()) {
+            event_column = down_cast<const ArrayColumn*>(columns[3]);
+            const UInt32Column& offsets = event_column->offsets();
+            auto offsets_ptr = offsets.get_data().data();
+            offset = offsets_ptr[row_num];
+            array_size = offsets_ptr[row_num + 1] - offsets_ptr[row_num];
+        } else {
+            DCHECK(false);
+        }
 
         const Column& elements = event_column->elements();
         if (elements.is_nullable()) {

--- a/be/src/exprs/array_expr.cpp
+++ b/be/src/exprs/array_expr.cpp
@@ -17,6 +17,7 @@
 #include "column/array_column.h"
 #include "column/chunk.h"
 #include "column/column_helper.h"
+#include "column/const_column.h"
 #include "column/fixed_length_column.h"
 #include "common/object_pool.h"
 
@@ -33,21 +34,24 @@ public:
         const TypeDescriptor& element_type = _type.children[0];
         const size_t num_elements = _children.size();
 
-        size_t num_rows = 1;
+        size_t output_rows = 1;
         // use chunk num_rows
         if (chunk) {
-            num_rows = chunk->num_rows();
+            output_rows = chunk->num_rows();
         }
 
+        bool all_const = true;
         std::vector<ColumnPtr> element_columns(num_elements);
         for (size_t i = 0; i < num_elements; i++) {
             ASSIGN_OR_RETURN(auto col, _children[i]->evaluate_checked(context, chunk));
-            num_rows = std::max(num_rows, col->size());
+            output_rows = std::max(output_rows, col->size());
+            all_const &= col->is_constant();
             element_columns[i] = std::move(col);
         }
 
+        int cal_rows = all_const ? 1 : output_rows;
         for (size_t i = 0; i < num_elements; i++) {
-            element_columns[i] = ColumnHelper::unfold_const_column(element_type, num_rows, element_columns[i]);
+            element_columns[i] = ColumnHelper::unfold_const_column(element_type, cal_rows, element_columns[i]);
         }
 
         auto array_elements = ColumnHelper::create_column(element_type, true);
@@ -56,7 +60,7 @@ public:
         // fill array column.
         uint32_t curr_offset = 0;
         array_offsets->append(curr_offset);
-        for (size_t i = 0; i < num_rows; i++) {
+        for (size_t i = 0; i < cal_rows; i++) {
             for (const auto& element : element_columns) {
                 array_elements->append(*element, i, 1);
             }
@@ -64,7 +68,11 @@ public:
             array_offsets->append(curr_offset);
         }
 
-        return ArrayColumn::create(std::move(array_elements), std::move(array_offsets));
+        auto ptr = ArrayColumn::create(std::move(array_elements), std::move(array_offsets));
+        if (all_const) {
+            return ConstColumn::create(std::move(ptr), output_rows);
+        }
+        return ptr;
     }
 
     Expr* clone(ObjectPool* pool) const override { return pool->add(new ArrayExpr(*this)); }

--- a/be/src/exprs/cast_nested.cpp
+++ b/be/src/exprs/cast_nested.cpp
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include "column/column_helper.h"
+#include "column/const_column.h"
 #include "column/map_column.h"
 #include "column/struct_column.h"
 #include "exprs/cast_expr.h"
@@ -120,6 +121,9 @@ StatusOr<ColumnPtr> CastArrayExpr::evaluate_checked(ExprContext* context, Chunk*
             ArrayColumn::create(std::move(casted_element_column),
                                 ColumnHelper::as_column<UInt32Column>(array_column->offsets_column()->clone_shared()));
     RETURN_IF_ERROR(casted_array->unfold_const_children(_type));
+    if (orig_column->is_constant()) {
+        return ConstColumn::create(casted_array, orig_column->size());
+    }
     if (!orig_column->is_nullable()) {
         return std::move(casted_array);
     }

--- a/be/src/exprs/math_functions.cpp
+++ b/be/src/exprs/math_functions.cpp
@@ -768,6 +768,17 @@ StatusOr<ColumnPtr> MathFunctions::cosine_similarity(FunctionContext* context, c
                 fmt::format("cosine_similarity does not support null values. {} array has null value.",
                             base->has_null() ? "base" : "target"));
     }
+    if (base->is_constant()) {
+        auto* const_column = down_cast<const ConstColumn*>(base);
+        const_column->data_column()->assign(base->size(), 0);
+        base = const_column->data_column().get();
+    }
+    if (target->is_constant()) {
+        auto* const_column = down_cast<const ConstColumn*>(target);
+        const_column->data_column()->assign(target->size(), 0);
+        target = const_column->data_column().get();
+    }
+
     if (base->is_nullable()) {
         base = down_cast<const NullableColumn*>(base)->data_column().get();
     }

--- a/test/sql/test_array_fn/T/test_array_fn
+++ b/test/sql/test_array_fn/T/test_array_fn
@@ -1,4 +1,4 @@
--]- name: test_array_functions
+-- name: test_array_functions
 CREATE TABLE array_test ( 
 pk bigint not null ,
 s_1   Array<String>, 

--- a/test/sql/test_join/R/test_join_map
+++ b/test/sql/test_join/R/test_join_map
@@ -36,7 +36,7 @@ select t.map2, s.map2 from map_test t join map_test s on s.map2 = t.map2 order b
 {0:["1","2"]}	{0:["1","2"]}
 {1:[]}	{1:[]}
 {null:null}	{null:null}
-{3:["3",null],null:null}	{3:["3",null],null:null}
+{null:null,3:["3",null]}	{null:null,3:["3",null]}
 -- !result
 select t.map3, s.map3 from map_test t join map_test s on s.map3 = t.map3 order by t.pk;
 -- result:
@@ -366,12 +366,12 @@ select t.map2, s.map2 from map_test t join map_test s on map_apply((k,v)->(k+1,a
 {0:["1","2"]}	{0:["1","2"]}
 {1:[]}	{1:[]}
 {null:null}	{null:null}
-{3:["3",null],null:null}	{3:["3",null],null:null}
+{null:null,3:["3",null]}	{null:null,3:["3",null]}
 -- !result
 select t.map2, s.map2 from map_test t join map_test s on map_apply((k,v)->(k+1,v),s.map2) = map_apply((k,v)->(k+1,v),t.map2) order by t.pk;
 -- result:
 {0:["1","2"]}	{0:["1","2"]}
 {1:[]}	{1:[]}
 {null:null}	{null:null}
-{3:["3",null],null:null}	{3:["3",null],null:null}
+{null:null,3:["3",null]}	{null:null,3:["3",null]}
 -- !result


### PR DESCRIPTION
Why I'm doing:

What I'm doing:
optimize array_expr use large memory

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [x] 3.1
  - [ ] 3.0
  - [ ] 2.5
