### PR TITLE
[BugFix] Fix or preddicates use different short key indexes bug

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/Optimizer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/Optimizer.java
@@ -420,6 +420,7 @@ public class Optimizer {
         if (!optimizerConfig.isRuleDisable(TF_MATERIALIZED_VIEW)
                 && sessionVariable.isEnableSyncMaterializedViewRewrite()) {
             // Add a config to decide whether to rewrite sync mv.
+            ruleRewriteOnlyOnce(tree, rootTaskContext, SplitScanORToUnionRule.getInstance());
 
             OptimizerTraceUtil.logOptExpression("before MaterializedViewRule:\n%s", tree);
             tree = new MaterializedViewRule().transform(tree, context).get(0);

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/SplitScanORToUnionRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/SplitScanORToUnionRule.java
@@ -220,7 +220,7 @@ public class SplitScanORToUnionRule extends TransformationRule {
         return splitMaxSelectRatio < existSelectRatio / childrenNumOfUnion;
     }
 
-    private boolean isForceRewrite() {
+    public static boolean isForceRewrite() {
         // TODO: If or predicates contain olap table's sort key, we can force it to union all so to use
         //  short key optimization.
         return ConnectContext.get().getSessionVariable().getSelectRatioThreshold() < 0;

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/SplitScanORToUnionRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/SplitScanORToUnionRule.java
@@ -77,7 +77,8 @@ public class SplitScanORToUnionRule extends TransformationRule {
     @Override
     public List<OptExpression> transform(OptExpression input, OptimizerContext context) {
         try {
-            return transformImpl(input, context);
+            boolean isForceRewrite = isForceRewrite();
+            return transformImpl(input, context, isForceRewrite);
         } catch (Exception e) {
             if (LOG.isDebugEnabled()) {
                 LOG.debug("input: {}, msg: {}", input.debugString(), e.getMessage());
@@ -86,15 +87,15 @@ public class SplitScanORToUnionRule extends TransformationRule {
         }
     }
 
-    private List<OptExpression> transformImpl(OptExpression input, OptimizerContext context) {
+    private List<OptExpression> transformImpl(OptExpression input, OptimizerContext context, boolean isForceRewrite) {
         LogicalOlapScanOperator scan = (LogicalOlapScanOperator) input.getOp();
+
         long totalRowCount = StatisticsCalcUtils.getTableRowCount(scan.getTable(), scan);
         Statistics.Builder builder = StatisticsCalcUtils.estimateScanColumns(scan.getTable(),
                 scan.getColRefToColumnMetaMap());
         Statistics statistics = builder.setOutputRowCount(totalRowCount).build();
 
-        if (!isForceRewrite() &&
-                statistics.getComputeSize() <= context.getSessionVariable().getScanOrToUnionThreshold()) {
+        if (!isForceRewrite && statistics.getComputeSize() <= context.getSessionVariable().getScanOrToUnionThreshold()) {
             return Lists.newArrayList();
         }
 
@@ -103,7 +104,7 @@ public class SplitScanORToUnionRule extends TransformationRule {
         List<ColumnFilter> columnFilters = selectivityEvaluator.evaluate();
 
         // already has a predicate can use index and late materialized to filter a large part of rows
-        if (!isForceRewrite() && columnFilters.get(0).getSelectRatio() < HIGH_SELECTIVITY) {
+        if (!isForceRewrite && columnFilters.get(0).getSelectRatio() < HIGH_SELECTIVITY) {
             return Lists.newArrayList();
         }
 
@@ -113,7 +114,7 @@ public class SplitScanORToUnionRule extends TransformationRule {
                 .collect(Collectors.toList());
 
         Pair<List<ColumnFilter>, List<ColumnFilter>> pair = chooseRewriteColumnFilter(unknownSelectivityFilters,
-                statistics, columnFilters.get(0).getSelectRatio());
+                statistics, columnFilters.get(0).getSelectRatio(), isForceRewrite);
         if (pair.first == null) {
             return Lists.newArrayList();
         }
@@ -132,7 +133,8 @@ public class SplitScanORToUnionRule extends TransformationRule {
 
     private Pair<List<ColumnFilter>, List<ColumnFilter>> chooseRewriteColumnFilter(List<ColumnFilter> columnFilters,
                                                                                    Statistics statistics,
-                                                                                   double existSelectRatio) {
+                                                                                   double existSelectRatio,
+                                                                                   boolean isForceRewrite) {
         List<List<ColumnFilter>> decomposeFilters = Lists.newArrayList();
         for (ColumnFilter columnFilter : columnFilters) {
             ScalarOperator scalarOperator = columnFilter.getFilter();
@@ -143,7 +145,7 @@ public class SplitScanORToUnionRule extends TransformationRule {
         }
 
         int idx = -1;
-        double min  = isForceRewrite() ? NON_SELECTIVITY + 1 : NON_SELECTIVITY;
+        double min = isForceRewrite ? NON_SELECTIVITY + 1 : NON_SELECTIVITY;
 
         int childrenOfUnion = ConnectContext.get().getSessionVariable().getScanOrToUnionLimit();
 
@@ -163,7 +165,7 @@ public class SplitScanORToUnionRule extends TransformationRule {
         if (idx != -1) {
             List<ColumnFilter> selectedFilters = decomposeFilters.get(idx);
             double maxSelectRatio = selectedFilters.get(selectedFilters.size() - 1).getSelectRatio();
-            if (canBenefitFromSplit(existSelectRatio, maxSelectRatio)) {
+            if (isForceRewrite || canBenefitFromSplit(existSelectRatio, maxSelectRatio)) {
                 columnFilters.remove(idx);
                 return Pair.create(selectedFilters, columnFilters);
             }
@@ -214,14 +216,13 @@ public class SplitScanORToUnionRule extends TransformationRule {
     private boolean canBenefitFromSplit(double existSelectRatio, double splitMaxSelectRatio) {
         SessionVariable sessionVariable = ConnectContext.get().getSessionVariable();
         int childrenNumOfUnion = sessionVariable.getScanOrToUnionLimit();
-        if (isForceRewrite()) {
-            return true;
-        }
         existSelectRatio = Math.min(existSelectRatio, sessionVariable.getSelectRatioThreshold());
         return splitMaxSelectRatio < existSelectRatio / childrenNumOfUnion;
     }
 
     private boolean isForceRewrite() {
+        // TODO: If or predicates contain olap table's sort key, we can force it to union all so to use
+        //  short key optimization.
         return ConnectContext.get().getSessionVariable().getSelectRatioThreshold() < 0;
     }
 }

--- a/test/lib/sr_sql_lib.py
+++ b/test/lib/sr_sql_lib.py
@@ -1017,14 +1017,15 @@ class StarrocksSQLApiLib(object):
         for expect in expects:
             tools.assert_true(str(res["result"]).find(expect) > 0, "assert expect %s is not found in plan" % (expect))
 
-    def check_no_hit_materialized_view(self, query, mv_name):
+    def check_no_hit_materialized_view(self, query, *expects):
         """
         assert mv_name is hit in query
         """
         time.sleep(1)
         sql = "explain %s" % (query)
         res = self.execute_sql(sql, True)
-        tools.assert_false(str(res["result"]).find(mv_name) > 0, "assert mv %s is found" % (mv_name))
+        for expect in expects:
+            tools.assert_false(str(res["result"]).find(expect) > 0, "assert expect %s should not be found" % (expect))
 
     def wait_alter_table_finish(self, alter_type="COLUMN", off=9):
         """

--- a/test/sql/test_materialized_view/R/test_sync_materialized_view_rewrite
+++ b/test/sql/test_materialized_view/R/test_sync_materialized_view_rewrite
@@ -300,7 +300,7 @@ SELECT col2,col3,col0,id,col1 FROM test_base_table1 ORDER BY col2,col3,col0;
 -- !result
 analyze full table test_base_table1 with sync mode;
 -- result:
-test_db_44197a8ac1a011eea0bfdbbedfe51b53.test_base_table1	analyze	status	OK
+test_db_f3ff2226c33811eea0bfdbbedfe51b53.test_base_table1	analyze	status	OK
 -- !result
 function: wait_materialized_view_finish()
 -- result:
@@ -314,16 +314,16 @@ function: check_hit_materialized_view("select col3, min(col1) startTime, max(col
 -- result:
 None
 -- !result
-select col3, min(col1) startTime, max(col1) endTime from test_base_table1 where col2 BETWEEN '2022-04-29 00:00:00' and '2022-04-30 23:00:00' group by col3;
+select col3, min(col1) startTime, max(col1) endTime from test_base_table1 where col2 BETWEEN '2022-04-29 00:00:00' and '2022-04-30 23:00:00' group by col3 order by 1;
 -- result:
-Guangdong	10001	10001
 Fujian	None	None
+Guangdong	10001	10001
 -- !result
 function: check_hit_materialized_view("select * from test_base_table1 where col0=123456789", "rollup: test_base_table1")
 -- result:
 None
 -- !result
-select * from test_base_table1 where col0=123456789;
+select * from test_base_table1 where col0=123456789 order by 1;
 -- result:
 123456789	2022-04-30 12:00:00	Guangdong	1	10001
 -- !result
@@ -331,7 +331,7 @@ function: check_hit_materialized_view("select * from test_base_table1 where col2
 -- result:
 None
 -- !result
-select * from test_base_table1 where col2 >='2022-04-30 12:00:00';
+select * from test_base_table1 where col2 >='2022-04-30 12:00:00' order by 1;
 -- result:
 123456789	2022-04-30 12:00:00	Guangdong	1	10001
 987654321	2022-04-30 13:00:00	Fujian	None	None
@@ -340,10 +340,61 @@ function: check_hit_materialized_view("select * from (select col0, col2, col3, i
 -- result:
 None
 -- !result
-select * from (select col0, col2, col3, id, col1 from test_base_table1 where col0=123456789 union select col0, col2, col3, id, col1 from test_base_table1 where col2 >='2022-04-30 12:00:00') t;
+select * from (select col0, col2, col3, id, col1 from test_base_table1 where col0=123456789 union select col0, col2, col3, id, col1 from test_base_table1 where col2 >='2022-04-30 12:00:00') t order by 1;
 -- result:
 123456789	2022-04-30 12:00:00	Guangdong	1	10001
 987654321	2022-04-30 13:00:00	Fujian	None	None
+-- !result
+set select_ratio_threshold = 0.15;
+-- result:
+-- !result
+function: check_hit_materialized_view("select * from (select col0, col2, col3, id, col1 from test_base_table1 where col0=123456789 or col2 >='2022-04-30 12:00:00') t;", "rollup: mv_test_base_table1")
+-- result:
+None
+-- !result
+function: check_no_hit_materialized_view("select * from (select col0, col2, col3, id, col1 from test_base_table1 where col0=123456789 or col2 >='2022-04-30 12:00:00') t;", "rollup: test_base_table1")
+-- result:
+None
+-- !result
+select * from (select col0, col2, col3, id, col1 from test_base_table1 where col0=123456789 or col2 >='2022-04-30 12:00:00') t;
+-- result:
+123456789	2022-04-30 12:00:00	Guangdong	1	10001
+987654321	2022-04-30 13:00:00	Fujian	None	None
+-- !result
+function: check_hit_materialized_view("select * from (select col0, col2, col3, id, col1 from test_base_table1 where col0=123456789 or col2 ='2022-04-30 12:00:00') t;", "rollup: mv_test_base_table1")
+-- result:
+None
+-- !result
+function: check_no_hit_materialized_view("select * from (select col0, col2, col3, id, col1 from test_base_table1 where col0=123456789 or col2 ='2022-04-30 12:00:00') t", "rollup: test_base_table1")
+-- result:
+None
+-- !result
+select * from (select col0, col2, col3, id, col1 from test_base_table1 where col0=123456789 or col2 ='2022-04-30 12:00:00') t;
+-- result:
+123456789	2022-04-30 12:00:00	Guangdong	1	10001
+-- !result
+set select_ratio_threshold=-1;
+-- result:
+-- !result
+function: check_hit_materialized_view("select * from (select col0, col2, col3, id, col1 from test_base_table1 where col0=123456789 or col2 >='2022-04-30 12:00:00') t;", "rollup: mv_test_base_table1",  "rollup: test_base_table1")
+-- result:
+None
+-- !result
+select * from (select col0, col2, col3, id, col1 from test_base_table1 where col0=123456789 or col2 >='2022-04-30 12:00:00') t;
+-- result:
+987654321	2022-04-30 13:00:00	Fujian	None	None
+123456789	2022-04-30 12:00:00	Guangdong	1	10001
+-- !result
+function: check_hit_materialized_view("select * from (select col0, col2, col3, id, col1 from test_base_table1 where col0=123456789 or col2 ='2022-04-30 12:00:00') t;", "rollup: mv_test_base_table1",  "rollup: test_base_table1")
+-- result:
+None
+-- !result
+select * from (select col0, col2, col3, id, col1 from test_base_table1 where col0=123456789 or col2 ='2022-04-30 12:00:00') t;
+-- result:
+123456789	2022-04-30 12:00:00	Guangdong	1	10001
+-- !result
+set select_ratio_threshold = 0.15;
+-- result:
 -- !result
 set enable_sync_materialized_view_rewrite=false;
 -- result:
@@ -352,10 +403,10 @@ function: check_hit_materialized_view("select * from (select col0, col2, col3, i
 -- result:
 None
 -- !result
-select * from (select col0, col2, col3, id, col1 from test_base_table1 where col0=123456789 union select col0, col2, col3, id, col1 from mv_test_base_table1 [_SYNC_MV_] where col2 >='2022-04-30 12:00:00') t;
+select * from (select col0, col2, col3, id, col1 from test_base_table1 where col0=123456789 union select col0, col2, col3, id, col1 from mv_test_base_table1 [_SYNC_MV_] where col2 >='2022-04-30 12:00:00') t order by 1;
 -- result:
-987654321	2022-04-30 13:00:00	Fujian	None	None
 123456789	2022-04-30 12:00:00	Guangdong	1	10001
+987654321	2022-04-30 13:00:00	Fujian	None	None
 -- !result
 set enable_sync_materialized_view_rewrite=true;
 -- result:

--- a/test/sql/test_materialized_view/T/test_sync_materialized_view_rewrite
+++ b/test/sql/test_materialized_view/T/test_sync_materialized_view_rewrite
@@ -153,22 +153,39 @@ function: wait_materialized_view_finish()
 function: wait_global_dict_ready("col3", "test_base_table1")
 function: check_hit_materialized_view("select col3, min(col1) startTime, max(col1) endTime from test_base_table1 where col2 BETWEEN '2022-04-29 15:12:23' and '2022-04-30 15:12:23' group by col3;", "mv_test_base_table1")
 -- check result it's ok
-select col3, min(col1) startTime, max(col1) endTime from test_base_table1 where col2 BETWEEN '2022-04-29 00:00:00' and '2022-04-30 23:00:00' group by col3;
+select col3, min(col1) startTime, max(col1) endTime from test_base_table1 where col2 BETWEEN '2022-04-29 00:00:00' and '2022-04-30 23:00:00' group by col3 order by 1;
 
 -- check hit base table's order key
 function: check_hit_materialized_view("select * from test_base_table1 where col0=123456789", "rollup: test_base_table1")
-select * from test_base_table1 where col0=123456789;
+select * from test_base_table1 where col0=123456789 order by 1;
 -- check hit sync mv's order key
 function: check_hit_materialized_view("select * from test_base_table1 where col2 >='2022-04-30 12:00:00'", "rollup: mv_test_base_table1")
-select * from test_base_table1 where col2 >='2022-04-30 12:00:00';
+select * from test_base_table1 where col2 >='2022-04-30 12:00:00' order by 1;
 
 -- check both hit base table and sync mv's order key
 function: check_hit_materialized_view("select * from (select col0, col2, col3, id, col1 from test_base_table1 where col0=123456789 union select col0, col2, col3, id, col1 from test_base_table1 where col2 >='2022-04-30 12:00:00') t;", "rollup: mv_test_base_table1",  "rollup: test_base_table1")
-select * from (select col0, col2, col3, id, col1 from test_base_table1 where col0=123456789 union select col0, col2, col3, id, col1 from test_base_table1 where col2 >='2022-04-30 12:00:00') t;
+select * from (select col0, col2, col3, id, col1 from test_base_table1 where col0=123456789 union select col0, col2, col3, id, col1 from test_base_table1 where col2 >='2022-04-30 12:00:00') t order by 1;
+
+-- if no force convert or to union all, only chooose mv
+set select_ratio_threshold = 0.15;
+function: check_hit_materialized_view("select * from (select col0, col2, col3, id, col1 from test_base_table1 where col0=123456789 or col2 >='2022-04-30 12:00:00') t;", "rollup: mv_test_base_table1")
+function: check_no_hit_materialized_view("select * from (select col0, col2, col3, id, col1 from test_base_table1 where col0=123456789 or col2 >='2022-04-30 12:00:00') t;", "rollup: test_base_table1")
+select * from (select col0, col2, col3, id, col1 from test_base_table1 where col0=123456789 or col2 >='2022-04-30 12:00:00') t;
+function: check_hit_materialized_view("select * from (select col0, col2, col3, id, col1 from test_base_table1 where col0=123456789 or col2 ='2022-04-30 12:00:00') t;", "rollup: mv_test_base_table1")
+function: check_no_hit_materialized_view("select * from (select col0, col2, col3, id, col1 from test_base_table1 where col0=123456789 or col2 ='2022-04-30 12:00:00') t", "rollup: test_base_table1")
+select * from (select col0, col2, col3, id, col1 from test_base_table1 where col0=123456789 or col2 ='2022-04-30 12:00:00') t;
+
+-- if force convert or to union all, chooose mv and base table's short key
+set select_ratio_threshold=-1;
+function: check_hit_materialized_view("select * from (select col0, col2, col3, id, col1 from test_base_table1 where col0=123456789 or col2 >='2022-04-30 12:00:00') t;", "rollup: mv_test_base_table1",  "rollup: test_base_table1")
+select * from (select col0, col2, col3, id, col1 from test_base_table1 where col0=123456789 or col2 >='2022-04-30 12:00:00') t;
+function: check_hit_materialized_view("select * from (select col0, col2, col3, id, col1 from test_base_table1 where col0=123456789 or col2 ='2022-04-30 12:00:00') t;", "rollup: mv_test_base_table1",  "rollup: test_base_table1")
+select * from (select col0, col2, col3, id, col1 from test_base_table1 where col0=123456789 or col2 ='2022-04-30 12:00:00') t;
+set select_ratio_threshold = 0.15;
 
 set enable_sync_materialized_view_rewrite=false;
 function: check_hit_materialized_view("select * from (select col0, col2, col3, id, col1 from test_base_table1 where col0=123456789 union select col0, col2, col3, id, col1 from mv_test_base_table1 [_SYNC_MV_] where col2 >='2022-04-30 12:00:00') t;", "rollup: mv_test_base_table1",  "rollup: test_base_table1")
-select * from (select col0, col2, col3, id, col1 from test_base_table1 where col0=123456789 union select col0, col2, col3, id, col1 from mv_test_base_table1 [_SYNC_MV_] where col2 >='2022-04-30 12:00:00') t;
+select * from (select col0, col2, col3, id, col1 from test_base_table1 where col0=123456789 union select col0, col2, col3, id, col1 from mv_test_base_table1 [_SYNC_MV_] where col2 >='2022-04-30 12:00:00') t order by 1;
 set enable_sync_materialized_view_rewrite=true;
 
 drop table test_base_table1;


### PR DESCRIPTION
Why I'm doing:

For this query, we can use different sort keys for col0 and col2 if there are associated sort key rollup indexes.
```
select * from (select col0, col2, col3, id, col1 from test_base_table1 where col0=123456789 or col2 ='2022-04-30 12:00:00') t;
```

What I'm doing:
- Split or predicates to union all so can be used by mv rewrite to choose the best sort key indexes.
- Only used when split or predicates for union all forcelly.

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
