### PR TITLE
[Enhancement] Check meta before executing load task (backport #39878)

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/load/loadv2/LoadLoadingTask.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/loadv2/LoadLoadingTask.java
@@ -55,6 +55,7 @@ import com.starrocks.qe.Coordinator;
 import com.starrocks.qe.OriginStatement;
 import com.starrocks.qe.QeProcessorImpl;
 import com.starrocks.qe.SessionVariable;
+import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.sql.LoadPlanner;
 import com.starrocks.thrift.TBrokerFileStatus;
 import com.starrocks.thrift.TLoadJobType;
@@ -162,6 +163,8 @@ public class LoadLoadingTask extends LoadTask {
     }
 
     private void executeOnce() throws Exception {
+        checkMeta();
+
         // New one query id,
         Coordinator curCoordinator;
         if (!Config.enable_pipeline_load) {
@@ -284,5 +287,17 @@ public class LoadLoadingTask extends LoadTask {
 
     private long getLeftTimeMs() {
         return jobDeadlineMs - System.currentTimeMillis();
+    }
+
+    private void checkMeta() throws LoadException {
+        Database database = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(db.getId());
+        if (database == null) {
+            throw new LoadException(String.format("db: %s-%d has been dropped", db.getFullName(), db.getId()));
+        }
+
+        if (database.getTable(table.getId()) == null) {
+            throw new LoadException(String.format("table: %s-%d has been dropped from db: %s-%d",
+                    table.getName(), table.getId(), db.getFullName(), db.getId()));
+        }
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/load/loadv2/LoadLoadingTaskTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/load/loadv2/LoadLoadingTaskTest.java
@@ -45,7 +45,7 @@ public class LoadLoadingTaskTest {
         LoadLoadingTask loadLoadingTask = new LoadLoadingTask(database, olapTable, null, null, 0,
                 0, true, 1, new BrokerLoadJob(), "UTC", 10,
                 System.currentTimeMillis(), false, null, null, null,
-                TLoadJobType.BROKER, 0, null);
+                TLoadJobType.BROKER, 0, null, null);
 
         // database not exist
         boolean exceptionThrown = false;

--- a/fe/fe-core/src/test/java/com/starrocks/load/loadv2/LoadLoadingTaskTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/load/loadv2/LoadLoadingTaskTest.java
@@ -1,0 +1,74 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.load.loadv2;
+
+import com.starrocks.catalog.CatalogIdGenerator;
+import com.starrocks.catalog.Database;
+import com.starrocks.catalog.KeysType;
+import com.starrocks.catalog.OlapTable;
+import com.starrocks.cluster.Cluster;
+import com.starrocks.common.LoadException;
+import com.starrocks.server.GlobalStateMgr;
+import com.starrocks.system.SystemInfoService;
+import com.starrocks.thrift.TLoadJobType;
+import mockit.Expectations;
+import mockit.Mocked;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.ArrayList;
+
+public class LoadLoadingTaskTest {
+    @Test
+    public void testExecuteTaskWhenMetaDropped(@Mocked CatalogIdGenerator idGenerator) {
+        new Expectations() {
+            {
+                idGenerator.getNextId();
+                result = 1;
+                times = 1;
+            }};
+
+        Database database = new Database(10000L, "test");
+        OlapTable olapTable = new OlapTable(10001L, "tbl", new ArrayList<>(), KeysType.AGG_KEYS, null, null);
+        LoadLoadingTask loadLoadingTask = new LoadLoadingTask(database, olapTable, null, null, 0,
+                0, true, 1, new BrokerLoadJob(), "UTC", 10,
+                System.currentTimeMillis(), false, null, null, null,
+                TLoadJobType.BROKER, 0, null);
+
+        // database not exist
+        boolean exceptionThrown = false;
+        try {
+            loadLoadingTask.executeTask();
+        } catch (Exception e) {
+            Assert.assertTrue(e instanceof LoadException);
+            exceptionThrown = true;
+        }
+
+        Assert.assertTrue(exceptionThrown);
+
+        // table not exist
+        exceptionThrown = false;
+        GlobalStateMgr.getCurrentState().getLocalMetastore()
+                .replayCreateCluster(new Cluster(SystemInfoService.DEFAULT_CLUSTER, 1));
+        GlobalStateMgr.getCurrentState().getLocalMetastore().unprotectCreateDb(database);
+        try {
+            loadLoadingTask.executeTask();
+        } catch (Exception e) {
+            Assert.assertTrue(e instanceof LoadException);
+            exceptionThrown = true;
+        }
+        Assert.assertTrue(exceptionThrown);
+    }
+}


### PR DESCRIPTION
backport #39878

Why I'm doing:
LoadTask may wait for a long time before being executed. If the table is dropped during this period, the execution will report an error: Fail to get tablet. The error message needs to be optimized.

What I'm doing:
Check meta before executing LoadTask.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [x] This is a backport pr
