### PR TITLE
[Enhancement] Fixed an error message for a failed decimal validation

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/analysis/DecimalLiteral.java
+++ b/fe/fe-core/src/main/java/com/starrocks/analysis/DecimalLiteral.java
@@ -204,7 +204,7 @@ public class DecimalLiteral extends LiteralExpr {
         return value;
     }
 
-    public void checkPrecisionAndScale(int precision, int scale) throws AnalysisException {
+    public void checkPrecisionAndScale(Type columnType, int precision, int scale) throws AnalysisException {
         Preconditions.checkNotNull(this.value);
         boolean valid = true;
         int realPrecision = getRealPrecision(this.value);
@@ -220,7 +220,7 @@ public class DecimalLiteral extends LiteralExpr {
         if (!valid) {
             String errMsg = String.format(
                     "Type %s is too narrow to hold the DecimalLiteral '%s' (precision=%d, scale=%d)",
-                    type.toString(), value.toPlainString(), realPrecision, realScale);
+                    columnType.toString(), value.toPlainString(), realPrecision, realScale);
             throw new AnalysisException(errMsg);
         }
     }
@@ -254,7 +254,7 @@ public class DecimalLiteral extends LiteralExpr {
         int precision = scalarType.getScalarPrecision();
         int scale = scalarType.getScalarScale();
         try {
-            checkPrecisionAndScale(precision, scale);
+            checkPrecisionAndScale(type, precision, scale);
         } catch (AnalysisException e) {
             throw new InternalError(e.getMessage());
         }

--- a/fe/fe-core/src/main/java/com/starrocks/load/DeleteMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/DeleteMgr.java
@@ -655,7 +655,7 @@ public class DeleteMgr implements Writable, MemoryTrackable {
 
         LiteralExpr result = LiteralExpr.create(value, Objects.requireNonNull(column.getType()));
         if (result instanceof DecimalLiteral) {
-            ((DecimalLiteral) result).checkPrecisionAndScale(column.getPrecision(), column.getScale());
+            ((DecimalLiteral) result).checkPrecisionAndScale(column.getType(), column.getPrecision(), column.getScale());
         } else if (result instanceof DateLiteral) {
             predicate.setChild(childNo, result);
         }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/ColumnDef.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/ColumnDef.java
@@ -416,7 +416,8 @@ public class ColumnDef implements ParseNode {
                 case DECIMAL64:
                 case DECIMAL128:
                     DecimalLiteral decimalLiteral = new DecimalLiteral(defaultValue);
-                    decimalLiteral.checkPrecisionAndScale(scalarType.getScalarPrecision(), scalarType.getScalarScale());
+                    decimalLiteral.checkPrecisionAndScale(scalarType,
+                            scalarType.getScalarPrecision(), scalarType.getScalarScale());
                     break;
                 case DATE:
                 case DATETIME:


### PR DESCRIPTION
```
 create table decimal_test (
    ->     name string NOT NULL,
    ->     age decimal64(10,0) DEFAULT '0.00'
    -> ) PRIMARY KEY (name)
    -> DISTRIBUTED BY HASH(name)
    -> PROPERTIES("replication_num" = "1",
    -> "enable_persistent_index" = "true");
```

It will output a misleading error message because `DECIMAL32`  is the inferred type for 0.00, not the type defined for the field.
```
ERROR 1064 (HY000): Getting analyzing error. Detail message: Invalid default value for 'age': Type DECIMAL32(2,2) is too narrow to hold the DecimalLiteral '0.00' (precision=2, scale=2).
```

after this PR:
```
ERROR 1064 (HY000): Getting analyzing error. Detail message: Invalid default value for 'age': Type DECIMAL64(10,0) is too narrow to hold the DecimalLiteral '0.00' (precision=2, scale=2).
```

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [x] 3.1
  - [ ] 3.0
  - [ ] 2.5
