### PR TITLE
[BugFix] use db lock in follower or cbo_use_db_lock is true

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/StatementPlanner.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/StatementPlanner.java
@@ -118,14 +118,19 @@ public class StatementPlanner {
 
             // Note: we only could get the olap table after Analyzing phase
             boolean isOnlyOlapTableQueries = AnalyzerUtils.isOnlyHasOlapTables(stmt);
-            if (isOnlyOlapTableQueries && stmt instanceof QueryStatement) {
-                unLock(dbs);
-                needWholePhaseLock = false;
-                return planQuery(stmt, resultSinkType, session, true);
-            }
-
             if (stmt instanceof QueryStatement) {
-                return planQuery(stmt, resultSinkType, session, false);
+                QueryStatement queryStmt = (QueryStatement) stmt;
+                resultSinkType = queryStmt.hasOutFileClause() ? TResultSinkType.FILE : resultSinkType;
+                ExecPlan plan;
+                if (isLockFree(isOnlyOlapTableQueries, session)) {
+                    unLock(dbs);
+                    needWholePhaseLock = false;
+                    plan = createQueryPlanWithReTry(queryStmt, session, resultSinkType);
+                } else {
+                    plan = createQueryPlan(queryStmt.getQueryRelation(), session, resultSinkType);
+                }
+                setOutfileSink(queryStmt, plan);
+                return plan;
             } else if (stmt instanceof InsertStmt) {
                 InsertStmt insertStmt = (InsertStmt) stmt;
                 boolean isSelect = !(insertStmt.getQueryStatement().getQueryRelation() instanceof ValuesRelation);
@@ -148,20 +153,14 @@ public class StatementPlanner {
         return null;
     }
 
-    private static ExecPlan planQuery(StatementBase stmt,
-                                      TResultSinkType resultSinkType,
-                                      ConnectContext session,
-                                      boolean isOnlyOlapTable) {
-        QueryStatement queryStmt = (QueryStatement) stmt;
-        resultSinkType = queryStmt.hasOutFileClause() ? TResultSinkType.FILE : resultSinkType;
-        ExecPlan plan;
-        if (!isOnlyOlapTable || !GlobalStateMgr.getCurrentState().isLeader() || session.getSessionVariable().isCboUseDBLock()) {
-            plan = createQueryPlan(queryStmt.getQueryRelation(), session, resultSinkType);
-        } else {
-            plan = createQueryPlanWithReTry(queryStmt, session, resultSinkType);
-        }
-        setOutfileSink(queryStmt, plan);
-        return plan;
+    private static boolean isLockFree(boolean isOnlyOlapTable, ConnectContext session) {
+        // condition can use conflict detection to replace db lock
+        // 1. all tables are olap table
+        // 2. node is master node
+        // 3. cbo_use_lock_db = false
+        return isOnlyOlapTable
+                && GlobalStateMgr.getCurrentState().isLeader()
+                && !session.getSessionVariable().isCboUseDBLock();
     }
 
     private static ExecPlan createQueryPlan(Relation relation,

--- a/fe/fe-core/src/main/java/com/starrocks/sql/StatementPlanner.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/StatementPlanner.java
@@ -155,8 +155,8 @@ public class StatementPlanner {
 
     private static boolean isLockFree(boolean isOnlyOlapTable, ConnectContext session) {
         // condition can use conflict detection to replace db lock
-        // 1. all tables are olap table
-        // 2. node is master node
+        // 1. all tables are olap tables
+        // 2. node is leader node
         // 3. cbo_use_lock_db = false
         return isOnlyOlapTable
                 && GlobalStateMgr.getCurrentState().isLeader()

--- a/fe/fe-core/src/test/java/com/starrocks/planner/QueryPlanLockFreeTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/planner/QueryPlanLockFreeTest.java
@@ -1,0 +1,86 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.planner;
+
+import com.starrocks.catalog.OlapTable;
+import com.starrocks.common.FeConstants;
+import com.starrocks.common.Pair;
+import com.starrocks.common.util.UUIDUtil;
+import com.starrocks.ha.FrontendNodeType;
+import com.starrocks.qe.ConnectContext;
+import com.starrocks.server.GlobalStateMgr;
+import com.starrocks.sql.plan.ExecPlan;
+import com.starrocks.utframe.StarRocksAssert;
+import com.starrocks.utframe.UtFrameUtils;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+public class QueryPlanLockFreeTest {
+    private static ConnectContext connectContext;
+    private static StarRocksAssert starRocksAssert;
+    private static String DB_NAME = "test";
+
+    @BeforeClass
+    public static void beforeClass() throws Exception {
+        UtFrameUtils.createMinStarRocksCluster();
+
+        FeConstants.enablePruneEmptyOutputScan = false;
+
+        // create connect context
+        connectContext = UtFrameUtils.createDefaultCtx();
+        connectContext.setQueryId(UUIDUtil.genUUID());
+        starRocksAssert = new StarRocksAssert(connectContext);
+        starRocksAssert.withDatabase(DB_NAME).useDatabase(DB_NAME);
+
+        starRocksAssert.withTable("CREATE TABLE IF NOT EXISTS `t0` (\n" +
+                "  `k1` int(11) NULL,\n" +
+                "  `k2` int(11) NULL,\n" +
+                "  `k3` int(11) NULL,\n" +
+                "  `v1` int SUM NULL,\n" +
+                "  `v2` bigint SUM NULL,\n" +
+                "  `v3` largeint SUM NULL,\n" +
+                "  `v4` double SUM NULL,\n" +
+                "  `v5` decimal(10, 3) SUM NULL\n" +
+                ") ENGINE=OLAP\n" +
+                "AGGREGATE KEY(`k1`, `k2`, `k3`)\n" +
+                "DISTRIBUTED BY HASH(`k2`) BUCKETS 10\n" +
+                "PROPERTIES (\n" +
+                " \"replication_num\" = \"1\"\n" +
+                ");");
+    }
+
+    @Test
+    public void testPlanStrategy() throws Exception {
+        String sql = "select * from t0";
+        OlapTable table = (OlapTable) GlobalStateMgr.getCurrentState().getMetadataMgr()
+                .getTable("default_catalog", DB_NAME, "t0");
+        table.lastVersionUpdateStartTime.set(2);
+        table.lastVersionUpdateEndTime.set(1);
+        try {
+            UtFrameUtils.getPlanAndFragment(connectContext, sql);
+        } catch (Exception e) {
+            Assert.assertTrue(e.getMessage(),
+                    e.getMessage().contains("The tablet write operation update metadata take a long time"));
+        }
+        connectContext.getSessionVariable().setCboUseDBLock(true);
+        Pair<String, ExecPlan> plan = UtFrameUtils.getPlanAndFragment(connectContext, sql);
+        Assert.assertTrue(plan.first, plan.first.contains("SCAN"));
+        GlobalStateMgr.getCurrentState().setFrontendNodeType(FrontendNodeType.FOLLOWER);
+        plan = UtFrameUtils.getPlanAndFragment(connectContext, sql);
+        Assert.assertTrue(plan.first, plan.first.contains("SCAN"));
+    }
+
+}

--- a/fe/fe-core/src/test/java/com/starrocks/planner/QueryPlanLockFreeTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/planner/QueryPlanLockFreeTest.java
@@ -24,6 +24,7 @@ import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.sql.plan.ExecPlan;
 import com.starrocks.utframe.StarRocksAssert;
 import com.starrocks.utframe.UtFrameUtils;
+import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -81,6 +82,12 @@ public class QueryPlanLockFreeTest {
         GlobalStateMgr.getCurrentState().setFrontendNodeType(FrontendNodeType.FOLLOWER);
         plan = UtFrameUtils.getPlanAndFragment(connectContext, sql);
         Assert.assertTrue(plan.first, plan.first.contains("SCAN"));
+    }
+
+    @AfterClass
+    public static void afterClass() {
+        connectContext.getSessionVariable().setCboUseDBLock(false);
+        GlobalStateMgr.getCurrentState().setFrontendNodeType(FrontendNodeType.LEADER);
     }
 
 }

--- a/fe/fe-core/src/test/java/com/starrocks/planner/QueryPlanLockFreeTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/planner/QueryPlanLockFreeTest.java
@@ -29,6 +29,8 @@ import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
+import static org.junit.Assert.fail;
+
 public class QueryPlanLockFreeTest {
     private static ConnectContext connectContext;
     private static StarRocksAssert starRocksAssert;
@@ -72,6 +74,7 @@ public class QueryPlanLockFreeTest {
         table.lastVersionUpdateEndTime.set(1);
         try {
             UtFrameUtils.getPlanAndFragment(connectContext, sql);
+            fail("should fail here");
         } catch (Exception e) {
             Assert.assertTrue(e.getMessage(),
                     e.getMessage().contains("The tablet write operation update metadata take a long time"));


### PR DESCRIPTION
Why I'm doing:
The plan is build without lock protection when in follower node or `cbo_use_db_locl` is true.

What I'm doing:
Only use db lock free mode when:
`all tables are olap table` && `node is leader node` && `cbo_use_lock_db = false`

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5

