### PR TITLE
[BugFix] use mv partition range to refresh when active mv

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/alter/AlterMVJobExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/AlterMVJobExecutor.java
@@ -16,13 +16,11 @@ package com.starrocks.alter;
 
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
-import com.google.common.collect.Range;
 import com.starrocks.analysis.IntLiteral;
 import com.starrocks.analysis.StringLiteral;
 import com.starrocks.analysis.TableName;
 import com.starrocks.catalog.ForeignKeyConstraint;
 import com.starrocks.catalog.MaterializedView;
-import com.starrocks.catalog.PartitionKey;
 import com.starrocks.catalog.Table;
 import com.starrocks.catalog.TableProperty;
 import com.starrocks.catalog.UniqueConstraint;
@@ -49,7 +47,6 @@ import com.starrocks.sql.ast.AlterMaterializedViewStatusClause;
 import com.starrocks.sql.ast.AsyncRefreshSchemeDesc;
 import com.starrocks.sql.ast.IntervalLiteral;
 import com.starrocks.sql.ast.ModifyTablePropertiesClause;
-import com.starrocks.sql.ast.PartitionRangeDesc;
 import com.starrocks.sql.ast.RefreshSchemeClause;
 import com.starrocks.sql.ast.SetListItem;
 import com.starrocks.sql.ast.SetStmt;
@@ -60,7 +57,6 @@ import com.starrocks.sql.optimizer.Utils;
 import org.apache.commons.lang3.StringUtils;
 import org.threeten.extra.PeriodDuration;
 
-import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 
@@ -341,27 +337,15 @@ public class AlterMVJobExecutor extends AlterJobExecutor {
                 if (materializedView.isActive()) {
                     return null;
                 }
-                // Get mv partition range, use it to refresh mv
-                PartitionRangeDesc partitionRangeDesc = null;
-                if (materializedView.getPartitionInfo().isRangePartition()) {
-                    Collection<Range<PartitionKey>> mvPartitionKeyRanges =
-                            materializedView.getRangePartitionMap().values();
-                    PartitionKey startPartitionKey = mvPartitionKeyRanges.stream().map(Range::lowerEndpoint).
-                            min(PartitionKey::compareTo).orElse(null);
-                    PartitionKey endPartitionKey = mvPartitionKeyRanges.stream().map(Range::upperEndpoint).
-                            max(PartitionKey::compareTo).orElse(null);
-
-                    if (startPartitionKey != null && endPartitionKey != null) {
-                        partitionRangeDesc = new PartitionRangeDesc(startPartitionKey.getKeys().get(0).getStringValue(),
-                                endPartitionKey.getKeys().get(0).getStringValue());
-                    }
-                }
 
                 GlobalStateMgr.getCurrentState().getAlterJobMgr().
                         alterMaterializedViewStatus(materializedView, status, false);
-                GlobalStateMgr.getCurrentState().getLocalMetastore()
-                        .refreshMaterializedView(dbName, materializedView.getName(), true, partitionRangeDesc,
-                                Constants.TaskRunPriority.NORMAL.value(), true, false);
+                // for manual refresh type, do not refresh
+                if (materializedView.getRefreshScheme().getType() != MaterializedView.RefreshType.MANUAL) {
+                    GlobalStateMgr.getCurrentState().getLocalMetastore()
+                            .refreshMaterializedView(dbName, materializedView.getName(), true, null,
+                                    Constants.TaskRunPriority.NORMAL.value(), true, false);
+                }
             } else if (AlterMaterializedViewStatusClause.INACTIVE.equalsIgnoreCase(status)) {
                 if (!materializedView.isActive()) {
                     return null;

--- a/fe/fe-core/src/main/java/com/starrocks/server/LocalMetastore.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/LocalMetastore.java
@@ -3747,7 +3747,7 @@ public class LocalMetastore implements ConnectorMetadata {
         TaskManager taskManager = GlobalStateMgr.getCurrentState().getTaskManager();
         Task refreshTask = taskManager.getTask(TaskBuilder.getMvTaskName(materializedView.getId()));
         if (refreshTask != null) {
-            taskManager.killTask(refreshTask.getName(), false);
+            taskManager.killTask(refreshTask.getName(), true);
         }
     }
 

--- a/test/sql/test_materialized_view/R/test_materialized_view_status
+++ b/test/sql/test_materialized_view/R/test_materialized_view_status
@@ -108,3 +108,52 @@ refresh materialized view mv2  with sync mode;
 select * from mv2 order by k1;
 -- result:
 -- !result
+drop table t1;
+-- result:
+-- !result
+CREATE TABLE `t1` (
+  `k1` date NULL COMMENT "",
+  `v1` int(11) NULL COMMENT "",
+  `v2` int(11) NULL COMMENT ""
+) ENGINE=OLAP
+DUPLICATE KEY(`k1`)
+COMMENT "OLAP"
+PARTITION BY RANGE(`k1`)
+(PARTITION pbefore VALUES [("0000-01-01"), ("2023-01-01")),
+PARTITION p20230101 VALUES [("2023-01-01"), ("2023-02-01")),
+PARTITION p20230201 VALUES [("2023-02-01"), ("2023-03-01")),
+PARTITION p20230301 VALUES [("2023-03-01"), ("2023-04-01")),
+PARTITION p20230401 VALUES [("2023-04-01"), ("2023-05-01")),
+PARTITION p20230501 VALUES [("2023-05-01"), ("2023-06-01")))
+DISTRIBUTED BY HASH(`k1`) BUCKETS 2
+PROPERTIES (
+"replication_num" = "1"
+);
+-- result:
+-- !result
+insert into t1 values ("2019-01-01",1,1),("2019-01-01",1,2),("2019-01-01",2,1),("2019-01-01",2,2),
+                                         ("2023-01-11",1,1),("2023-01-11",1,2),("2023-02-11",2,1),("2023-01-11",2,2),
+                                         ("2023-03-11",1,1),("2023-05-11",1,2),("2023-04-11",2,1),("2023-05-01",2,2);
+-- result:
+-- !result
+CREATE MATERIALIZED VIEW mv3
+PARTITION BY (k1)
+REFRESH DEFERRED MANUAL
+AS SELECT k1,v1 FROM t1;
+-- result:
+-- !result
+refresh MATERIALIZED VIEW mv3 PARTITION start ('2023-02-01') end ('2023-05-01') with sync mode;
+-- result:
+-- !result
+ALTER MATERIALIZED VIEW mv3 INACTIVE;
+-- result:
+-- !result
+ALTER MATERIALIZED VIEW mv3 ACTIVE;
+-- result:
+-- !result
+show partitions from mv3;
+-- result:
+[REGEX].*p20230201.*
+.*p20230301.*
+.*p20230401.*
+-- !result

--- a/test/sql/test_materialized_view/T/test_materialized_view_status
+++ b/test/sql/test_materialized_view/T/test_materialized_view_status
@@ -76,3 +76,38 @@ PROPERTIES(
 alter materialized view mv2 active;
 refresh materialized view mv2  with sync mode;
 select * from mv2 order by k1;
+
+
+drop table t1;
+CREATE TABLE `t1` (
+  `k1` date NULL COMMENT "",
+  `v1` int(11) NULL COMMENT "",
+  `v2` int(11) NULL COMMENT ""
+) ENGINE=OLAP
+DUPLICATE KEY(`k1`)
+COMMENT "OLAP"
+PARTITION BY RANGE(`k1`)
+(PARTITION pbefore VALUES [("0000-01-01"), ("2023-01-01")),
+PARTITION p20230101 VALUES [("2023-01-01"), ("2023-02-01")),
+PARTITION p20230201 VALUES [("2023-02-01"), ("2023-03-01")),
+PARTITION p20230301 VALUES [("2023-03-01"), ("2023-04-01")),
+PARTITION p20230401 VALUES [("2023-04-01"), ("2023-05-01")),
+PARTITION p20230501 VALUES [("2023-05-01"), ("2023-06-01")))
+DISTRIBUTED BY HASH(`k1`) BUCKETS 2
+PROPERTIES (
+"replication_num" = "1"
+);
+
+insert into t1 values ("2019-01-01",1,1),("2019-01-01",1,2),("2019-01-01",2,1),("2019-01-01",2,2),
+                                         ("2023-01-11",1,1),("2023-01-11",1,2),("2023-02-11",2,1),("2023-01-11",2,2),
+                                         ("2023-03-11",1,1),("2023-05-11",1,2),("2023-04-11",2,1),("2023-05-01",2,2);
+
+CREATE MATERIALIZED VIEW mv3
+PARTITION BY (k1)
+REFRESH DEFERRED MANUAL
+AS SELECT k1,v1 FROM t1;
+
+refresh MATERIALIZED VIEW mv3 PARTITION start ('2023-02-01') end ('2023-05-01') with sync mode;
+ALTER MATERIALIZED VIEW mv3 INACTIVE;
+ALTER MATERIALIZED VIEW mv3 ACTIVE;
+show partitions from mv3


### PR DESCRIPTION
Why I'm doing:
active mv will refresh all partitons of ref base table, it should only refresh partitions exist in mv
What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [x] 3.1
  - [x] 3.0
  - [x] 2.5
