### PR TITLE
[Refactor] refactor SinkIOBuffer, handle cancel and end marker in base class

### DIFF
--- a/be/src/exec/pipeline/sink/sink_io_buffer.cpp
+++ b/be/src/exec/pipeline/sink/sink_io_buffer.cpp
@@ -16,25 +16,110 @@
 
 namespace starrocks::pipeline {
 
-void SinkIOBuffer::_process_chunk(bthread::TaskIterator<ChunkPtr>& iter) {
-    DeferOp op([&]() { --_num_pending_chunks; });
-
-    if (_is_finished) {
-        return;
+int SinkIOBuffer::_process_chunk(bthread::TaskIterator<QueueItemPtr>& iter) {
+    // Is it possible the mem_tracker in _state is invalid due to the whole object is in destructing?
+    SCOPED_THREAD_LOCAL_MEM_TRACKER_SETTER(_state->query_mem_tracker_ptr().get());
+    bool fast_skip = false;
+    for (; iter; ++iter) {
+        if (_is_finished) {
+            fast_skip = true;
+            break;
+        }
+        if (*iter == nullptr || _is_cancelled) {
+            // The CANCEL state or the StopMarker triggers auto-finish workflow, enables fast-skip processing of the queue.
+            //
+            // Note that after invoking `close()`, is_finished() will return true and the caller will take the SinkIOBuffer
+            // as completion and the related resource is ready to release. There are two barriers to prevent invalid
+            // accessing of `this` object:
+            // 1. `_num_pending_chunks`, indicating that there are still on-the-fly pending chunks. However this is not
+            //   always reliable, e.g. considering the following two threads execution sequences:
+            //   [thread-A] append_chunk(chunk), done bthread::execution_queue_execute(), but not increases the counter yet,
+            //   [thread-B] execute the io task and detect the cancel state, called close() and decreases `_num_pending_chunks`
+            //              accordingly
+            //   [thread-C] check is_finished(), returns true because of close() successful and _num_pending_chunks == 0
+            //   [thread-A] execute ++_num_pending_chunks, is_finished() returns `false` again.
+            // 2. bthread::execution_queue_join() in destructor, waiting for all items in queue are processed, either because of
+            //   queue stopped or because of fast skip.
+            // Refer to: https://github.com/StarRocks/starrocks/pull/26028
+            close(_state);
+            fast_skip = true;
+            break;
+        }
+        TEST_SYNC_POINT_CALLBACK("sink_io_buffer_before_process_chunk", (*iter)->chunk_ptr.get());
+        _add_chunk((*iter)->chunk_ptr);
+        TEST_SYNC_POINT_CALLBACK("sink_io_buffer_after_process_chunk", (*iter)->chunk_ptr.get());
+        --_num_pending_chunks;
+        // Do a favor to the query_mem_tracker:
+        // decrease the chunk_ptr reference and possibly release the memory at the earliest
+        // refer to: https://github.com/StarRocks/starrocks/pull/15915
+        (*iter)->chunk_ptr.reset();
     }
 
-    const auto& chunk = *iter;
-    if (chunk == nullptr) {
-        close(_state);
-        return;
+    if (fast_skip) {
+        // make sure the `_num_pending_chunks` still reflects the real pending chunks
+        // and the chunk is released at the earliest.
+        for (; iter; ++iter) {
+#ifdef BE_TEST
+            if (*iter == nullptr) {
+                TEST_SYNC_POINT_CALLBACK("sink_io_buffer_process_chunk_end_queue", nullptr);
+            }
+#endif
+            if (*iter != nullptr) {
+                TEST_SYNC_POINT_CALLBACK("sink_io_buffer_before_process_chunk", (*iter)->chunk_ptr.get());
+                TEST_SYNC_POINT_CALLBACK("sink_io_buffer_after_process_chunk", (*iter)->chunk_ptr.get());
+                (*iter)->chunk_ptr.reset();
+            }
+            --_num_pending_chunks;
+        }
     }
-
-    if (_is_cancelled) {
-        close(_state);
-        return;
-    }
-
-    _add_chunk(chunk);
+    return 0;
 }
 
+Status SinkIOBuffer::append_chunk(RuntimeState* state, const ChunkPtr& chunk) {
+    if (Status status = get_io_status(); !status.ok()) {
+        return status;
+    }
+    if (bthread::execution_queue_execute(*_exec_queue_id, std::make_shared<QueueItem>(chunk)) != 0) {
+        return Status::InternalError("submit io task failed");
+    }
+    ++_num_pending_chunks;
+    TEST_SYNC_POINT_CALLBACK("sink_io_buffer_append_chunk", chunk.get());
+    return Status::OK();
+}
+
+Status SinkIOBuffer::set_finishing() {
+    if (--_num_result_sinkers == 0) {
+        // when all writers are done, a nullptr is added as a special mark to trigger
+        // the close action in io thread.
+        if (bthread::execution_queue_execute(*_exec_queue_id, nullptr) != 0) {
+            // recover the count of _num_result_sinkers in case of failure.
+            ++_num_result_sinkers;
+            return Status::InternalError("submit task failed");
+        }
+        ++_num_pending_chunks;
+        TEST_SYNC_POINT_CALLBACK("sink_io_buffer_apend_chunk_end_queue", nullptr);
+    }
+    return Status::OK();
+}
+
+Status SinkIOBuffer::prepare(RuntimeState* state, RuntimeProfile*) {
+    bool expected = false;
+    if (!_is_prepared.compare_exchange_strong(expected, true)) {
+        return Status::OK();
+    }
+
+    bthread::ExecutionQueueOptions options;
+    options.executor = SinkIOExecutor::instance();
+    auto queue_id = std::make_unique<bthread::ExecutionQueueId<QueueItemPtr>>();
+    int ret = bthread::execution_queue_start<QueueItemPtr>(queue_id.get(), &options, &SinkIOBuffer::execute_io_task,
+                                                           this);
+    if (ret != 0) {
+        _is_prepared = false;
+        return Status::InternalError("start execution queue error");
+    }
+    // make state change if all go well
+    _state = state;
+    _exec_queue_id = std::move(queue_id);
+    return Status::OK();
+}
 } // namespace starrocks::pipeline

--- a/be/src/exec/pipeline/sink/sink_io_buffer.h
+++ b/be/src/exec/pipeline/sink/sink_io_buffer.h
@@ -65,33 +65,16 @@ public:
         }
     }
 
-    virtual Status prepare(RuntimeState* state, RuntimeProfile* parent_profile) = 0;
+    virtual Status prepare(RuntimeState* state, RuntimeProfile* parent_profile);
 
-    virtual Status append_chunk(RuntimeState* state, const ChunkPtr& chunk) {
-        if (Status status = get_io_status(); !status.ok()) {
-            return status;
-        }
-        if (bthread::execution_queue_execute(*_exec_queue_id, chunk) != 0) {
-            return Status::InternalError("submit io task failed");
-        }
-        ++_num_pending_chunks;
-        TEST_SYNC_POINT_CALLBACK("sink_io_buffer_append_chunk", chunk.get());
-        return Status::OK();
-    }
+    // NOTE: can't stop the queue by passing `chunk=nullptr`, use `set_finishing()` interface instead.
+    virtual Status append_chunk(RuntimeState* state, const ChunkPtr& chunk);
 
     virtual bool need_input() { return _num_pending_chunks < kExecutionQueueSizeLimit; }
 
-    virtual Status set_finishing() {
-        if (--_num_result_sinkers == 0) {
-            // when all writes are over, we add a nullptr as a special mark to trigger close
-            if (bthread::execution_queue_execute(*_exec_queue_id, nullptr) != 0) {
-                return Status::InternalError("submit task failed");
-            }
-            ++_num_pending_chunks;
-            TEST_SYNC_POINT_CALLBACK("sink_io_buffer_append_chunk", nullptr);
-        }
-        return Status::OK();
-    }
+    virtual Status set_finishing();
+
+    bool is_prepared() const { return _is_prepared; }
 
     virtual bool is_finished() { return _is_finished && _num_pending_chunks == 0; }
 
@@ -118,39 +101,42 @@ public:
         return _io_status;
     }
 
-    static int execute_io_task(void* meta, bthread::TaskIterator<ChunkPtr>& iter) {
+private:
+    // A wrapper of the payload to the item in the execution queue, so the end-of-queue marker can be distinguished from the nullptr payload.
+    // That is, calling append_chunk() with a nullptr, won't accidentially stop the entire queue.
+    struct QueueItem {
+        ChunkPtr chunk_ptr;
+        QueueItem(const ChunkPtr& chunkPtr) : chunk_ptr(chunkPtr) {}
+    };
+    typedef std::shared_ptr<QueueItem> QueueItemPtr;
+
+    static int execute_io_task(void* meta, bthread::TaskIterator<QueueItemPtr>& iter) {
         if (iter.is_queue_stopped()) {
             return 0;
         }
-        auto* sink_io_buffer = static_cast<SinkIOBuffer*>(meta);
-        SCOPED_THREAD_LOCAL_MEM_TRACKER_SETTER(sink_io_buffer->_state->query_mem_tracker_ptr().get());
-        for (; iter; ++iter) {
-            TEST_SYNC_POINT_CALLBACK("sink_io_buffer_before_process_chunk", iter->get());
-            sink_io_buffer->_process_chunk(iter);
-            TEST_SYNC_POINT_CALLBACK("sink_io_buffer_after_process_chunk", iter->get());
-            (*iter).reset();
-        }
-        return 0;
+        // turn to member function execution
+        return static_cast<SinkIOBuffer*>(meta)->_process_chunk(iter);
     }
 
 protected:
-    void _process_chunk(bthread::TaskIterator<ChunkPtr>& iter);
     virtual void _add_chunk(const ChunkPtr& chunk) = 0;
 
-    std::unique_ptr<bthread::ExecutionQueueId<ChunkPtr>> _exec_queue_id;
+    mutable std::shared_mutex _io_status_mutex;
+    Status _io_status;
+    RuntimeState* _state = nullptr;
+    static const int32_t kExecutionQueueSizeLimit = 64;
 
+private:
+    int _process_chunk(bthread::TaskIterator<QueueItemPtr>& iter);
+
+    std::unique_ptr<bthread::ExecutionQueueId<QueueItemPtr>> _exec_queue_id;
+    // Counter of the result sinkers, trigger auto-finish when the counter is down to zero
     std::atomic_int32_t _num_result_sinkers = 0;
+    // Counter of the queue length
     std::atomic_int64_t _num_pending_chunks = 0;
     std::atomic_bool _is_prepared = false;
     std::atomic_bool _is_cancelled = false;
     std::atomic_bool _is_finished = false;
-
-    mutable std::shared_mutex _io_status_mutex;
-    Status _io_status;
-
-    RuntimeState* _state = nullptr;
-
-    static const int32_t kExecutionQueueSizeLimit = 64;
 };
 
 } // namespace starrocks::pipeline

--- a/be/test/CMakeLists.txt
+++ b/be/test/CMakeLists.txt
@@ -42,6 +42,7 @@ set(EXEC_FILES
         ./exec/pipeline/pipeline_test_base.cpp
         ./exec/pipeline/query_context_manger_test.cpp
         ./exec/pipeline/table_function_operator_test.cpp
+        ./exec/pipeline/sink/export_sink_operator_test.cpp
         ./exec/pipeline/sink/table_function_table_sink_operator_test.cpp
         ./exec/query_cache/query_cache_test.cpp
         ./exec/query_cache/transform_operator.cpp

--- a/be/test/exec/pipeline/sink/export_sink_operator_test.cpp
+++ b/be/test/exec/pipeline/sink/export_sink_operator_test.cpp
@@ -1,0 +1,86 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "exec/pipeline/sink/export_sink_operator.h"
+
+#include <chrono>
+#include <thread>
+
+#include "gen_cpp/RuntimeProfile_types.h"
+#include "gtest/gtest.h"
+#include "util/await.h"
+
+namespace starrocks::pipeline {
+
+TEST(ExportSinkOperatorTest, test_set_finishing) {
+    using namespace std::chrono_literals;
+    TExecPlanFragmentParams _request;
+
+    const auto& params = _request.params;
+    const auto& query_id = params.query_id;
+    const auto& fragment_id = params.fragment_instance_id;
+
+    pipeline::QueryContext* _query_ctx;
+    pipeline::FragmentContext* _fragment_ctx;
+    ExecEnv* _exec_env = ExecEnv::GetInstance();
+    RuntimeState _runtime_state(_exec_env);
+
+    _query_ctx = _exec_env->query_context_mgr()->get_or_register(query_id);
+    _query_ctx->set_query_id(query_id);
+    _query_ctx->set_total_fragments(1);
+    _query_ctx->set_delivery_expire_seconds(60);
+    _query_ctx->set_query_expire_seconds(60);
+    _query_ctx->extend_delivery_lifetime();
+    _query_ctx->extend_query_lifetime();
+    _query_ctx->set_final_sink();
+    _query_ctx->init_mem_tracker(GlobalEnv::GetInstance()->query_pool_mem_tracker()->limit(),
+                                 GlobalEnv::GetInstance()->query_pool_mem_tracker());
+
+    _fragment_ctx = _query_ctx->fragment_mgr()->get_or_register(fragment_id);
+    _fragment_ctx->set_query_id(query_id);
+    _fragment_ctx->set_fragment_instance_id(fragment_id);
+    _fragment_ctx->set_runtime_state(
+            std::make_unique<RuntimeState>(_request.params.query_id, _request.params.fragment_instance_id,
+                                           _request.query_options, _request.query_globals, _exec_env));
+    _fragment_ctx->set_is_stream_pipeline(true);
+
+    _runtime_state.set_query_ctx(_query_ctx);
+    _runtime_state.set_fragment_ctx(_fragment_ctx);
+
+    TExportSink t_sink;
+    std::vector<TExpr> t_output_expr;
+    ExportSinkOperatorFactory factory(1, t_sink, t_output_expr, 1, _fragment_ctx);
+    EXPECT_TRUE(factory.prepare(&_runtime_state).ok());
+
+    auto export_op = factory.create(1, 1);
+    EXPECT_TRUE(export_op->prepare(&_runtime_state).ok());
+
+    // push a chunk, fail to create the file writer, so the context will be in cancel state
+    ChunkPtr chunk = std::make_shared<Chunk>();
+    EXPECT_TRUE(export_op->push_chunk(&_runtime_state, chunk).ok());
+
+    int timeout_us = 5 * 1000 * 1000; // 5s
+
+    Awaitility await;
+    EXPECT_TRUE(await.timeout(timeout_us).until([&] { return _fragment_ctx->is_canceled(); }));
+
+    // now cancel the operator
+    export_op->set_finishing(&_runtime_state);
+    export_op->set_cancelled(&_runtime_state);
+
+    Awaitility await2;
+    EXPECT_TRUE(await2.timeout(timeout_us).until([&] { return !export_op->pending_finish(); }));
+}
+
+} // namespace starrocks::pipeline


### PR DESCRIPTION
* use base class prepare as much as possible. Properly revert internal
  state if prepare() fails.
* handle cancel and queue end marker in base class
* wrap ChunkPtr with a new structure, to distinguish the payload nullptr
  and the real nullptr to terminate the queue
* change a few base class methods accessibility
* add more comments to _process_chunk() implementation

Why I'm doing:

What I'm doing:

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [X] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [X] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [X] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
