### PR TITLE
[Enhancement] add Werror option for clang

### DIFF
--- a/be/CMakeLists.txt
+++ b/be/CMakeLists.txt
@@ -610,6 +610,7 @@ set(CXX_COMMON_FLAGS "${CXX_COMMON_FLAGS} -Wno-deprecated -Wno-vla -Wno-comment"
 set(CXX_COMMON_FLAGS "${CXX_COMMON_FLAGS} -fno-sized-deallocation")
 
 if (CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
+    set(CXX_COMMON_FLAGS "${CXX_COMMON_FLAGS} -Werror")
     set(CXX_COMMON_FLAGS "${CXX_COMMON_FLAGS} -Wno-unused-parameter -Wno-documentation -Wno-weak-vtables")
     # Turn on following warning as error explicitly
     set(CXX_COMMON_FLAGS "${CXX_COMMON_FLAGS} -Werror=string-plus-int")

--- a/be/src/exec/pipeline/spill_process_channel.cpp
+++ b/be/src/exec/pipeline/spill_process_channel.cpp
@@ -25,7 +25,7 @@ void SpillProcessTask::reset() {
 SpillProcessChannelPtr SpillProcessChannelFactory::get_or_create(int32_t sequence) {
     DCHECK_LT(sequence, _channels.size());
     if (_channels[sequence] == nullptr) {
-        _channels[sequence] = std::make_shared<SpillProcessChannel>(this);
+        _channels[sequence] = std::make_shared<SpillProcessChannel>();
     }
     return _channels[sequence];
 }

--- a/be/src/exec/pipeline/spill_process_channel.h
+++ b/be/src/exec/pipeline/spill_process_channel.h
@@ -73,7 +73,7 @@ using SpillProcessChannelFactoryPtr = std::shared_ptr<SpillProcessChannelFactory
 // SpillProcessOperator
 class SpillProcessChannel {
 public:
-    SpillProcessChannel(SpillProcessChannelFactory* factory) : _parent(factory) {}
+    SpillProcessChannel() {}
 
     bool add_spill_task(SpillProcessTask&& task) {
         DCHECK(!_is_finishing);
@@ -124,7 +124,6 @@ private:
     std::shared_ptr<spill::Spiller> _spiller;
     UnboundedBlockingQueue<SpillProcessTask> _spill_tasks;
     SpillProcessTask _current_task;
-    SpillProcessChannelFactory* _parent;
 };
 
 class SpillProcessTasksBuilder {

--- a/be/src/exprs/cast_expr.cpp
+++ b/be/src/exprs/cast_expr.cpp
@@ -17,7 +17,9 @@
 #include <llvm/ADT/APInt.h>
 #include <ryu/ryu.h>
 
+#include <limits>
 #include <stdexcept>
+#include <type_traits>
 #include <utility>
 
 #include "column/column_builder.h"
@@ -1155,7 +1157,12 @@ public:
                                                                                lt_is_float<ToType>)) {
                 typedef RunTimeCppType<FromType> FromCppType;
                 typedef RunTimeCppType<ToType> ToCppType;
-                if constexpr (std::numeric_limits<ToCppType>::max() < std::numeric_limits<FromCppType>::max()) {
+
+                if constexpr ((std::is_floating_point_v<ToCppType> || std::is_floating_point_v<FromCppType>)
+                                      ? (static_cast<long double>(std::numeric_limits<ToCppType>::max()) <
+                                         static_cast<long double>(std::numeric_limits<FromCppType>::max()))
+                                      : (std::numeric_limits<ToCppType>::max() <
+                                         std::numeric_limits<FromCppType>::max())) {
                     // Check overflow.
 
                     llvm::Value* max_overflow = nullptr;

--- a/be/src/exprs/jit/jit_expr.cpp
+++ b/be/src/exprs/jit/jit_expr.cpp
@@ -37,10 +37,10 @@ JITExpr* JITExpr::create(ObjectPool* pool, Expr* expr) {
     node.type = expr->type().to_thrift();
     node.output_scale = expr->output_scale();
     node.is_monotonic = expr->is_monotonic();
-    return pool->add(new JITExpr(pool, node, expr));
+    return pool->add(new JITExpr(node, expr));
 }
 
-JITExpr::JITExpr(ObjectPool* pool, const TExprNode& node, Expr* expr) : Expr(node), _pool(pool), _expr(expr) {
+JITExpr::JITExpr(const TExprNode& node, Expr* expr) : Expr(node), _expr(expr) {
     _expr->get_uncompilable_exprs(_children);
 }
 

--- a/be/src/exprs/jit/jit_expr.h
+++ b/be/src/exprs/jit/jit_expr.h
@@ -32,7 +32,7 @@ class JITExpr final : public Expr {
 public:
     static JITExpr* create(ObjectPool* pool, Expr* expr);
 
-    JITExpr(ObjectPool* pool, const TExprNode& node, Expr* expr);
+    JITExpr(const TExprNode& node, Expr* expr);
 
     ~JITExpr() override;
 
@@ -54,7 +54,6 @@ protected:
     StatusOr<ColumnPtr> evaluate_checked(ExprContext* context, Chunk* ptr) override;
 
 private:
-    ObjectPool* _pool;
     // The original expression.
     Expr* _expr;
     bool _is_prepared = false;

--- a/be/src/exprs/string_functions.cpp
+++ b/be/src/exprs/string_functions.cpp
@@ -2458,8 +2458,7 @@ static inline std::string unhex_4chars(Slice s) {
     }
     return ret;
 }
-#endif
-
+#else
 static inline char hexdigit_1char(char ch) {
     if (int value = ch - '0'; value >= 0 && value <= ('9' - '0')) {
         return value;
@@ -2497,6 +2496,7 @@ static inline std::string unhex_1char(Slice str) {
     }
     return ret;
 }
+#endif
 
 DEFINE_STRING_UNARY_FN_WITH_IMPL(unhexImpl, str) {
 #ifdef __AVX2__

--- a/be/src/storage/rowset/dict_page.cpp
+++ b/be/src/storage/rowset/dict_page.cpp
@@ -235,7 +235,8 @@ Status DictPageDecoder<Type>::next_batch(const SparseRange<>& range, Column* dst
         _dict_decoder->at_index(codewords[i], &value);
         numbers[i] = value;
     }
-    if (dst->append_numbers(numbers.data(), numbers.size() * SIZE_OF_TYPE) == -1) {
+    size_t nappend = dst->append_numbers(numbers.data(), numbers.size() * SIZE_OF_TYPE);
+    if (UNLIKELY(nappend != numbers.size())) {
         return Status::InternalError("append numbers failed");
     }
     return Status::OK();

--- a/be/src/storage/rowset/dict_page.cpp
+++ b/be/src/storage/rowset/dict_page.cpp
@@ -237,7 +237,8 @@ Status DictPageDecoder<Type>::next_batch(const SparseRange<>& range, Column* dst
     }
     size_t nappend = dst->append_numbers(numbers.data(), numbers.size() * SIZE_OF_TYPE);
     if (UNLIKELY(nappend != numbers.size())) {
-        return Status::InternalError("append numbers failed");
+        return Status::InternalError(
+                fmt::format("append_numbers failed, expected rows[{}], actual rows[{}]", numbers.size(), nappend));
     }
     return Status::OK();
 }

--- a/be/src/storage/rowset/dict_page.cpp
+++ b/be/src/storage/rowset/dict_page.cpp
@@ -235,7 +235,9 @@ Status DictPageDecoder<Type>::next_batch(const SparseRange<>& range, Column* dst
         _dict_decoder->at_index(codewords[i], &value);
         numbers[i] = value;
     }
-    dst->append_numbers(numbers.data(), numbers.size() * SIZE_OF_TYPE);
+    if (dst->append_numbers(numbers.data(), numbers.size() * SIZE_OF_TYPE) == -1) {
+        return Status::InternalError("append numbers failed");
+    }
     return Status::OK();
 }
 


### PR DESCRIPTION
Why I'm doing:

What I'm doing:

1. enable Werror under clang compilation to find more potential problems.
2. fix compile warnings under clang compilation.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
