### PR TITLE
[BugFix] Fix pk index gc which will clear pk index dir improperly

### DIFF
--- a/be/src/storage/lake/local_pk_index_manager.cpp
+++ b/be/src/storage/lake/local_pk_index_manager.cpp
@@ -63,7 +63,7 @@ void LocalPkIndexManager::gc(UpdateManager* update_manager, DataDir* data_dir, s
         auto tablet_pk_path = pk_path + "/" + tablet_id;
         int64_t id = 0;
         try {
-            std::stoll(tablet_id);
+            id = std::stoll(tablet_id);
         } catch (std::invalid_argument const& ex) {
             LOG(ERROR) << "Invalid tablet: " << tablet_id;
             continue;


### PR DESCRIPTION
Why I'm doing:
PK index dir will be cleared every 5 hours because the id is not set which is 0. If pk index dir is cleared, the concurrent load will fail and there may also be correctness problem.
What I'm doing:
Set id to the value parsed from tablet_id
Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [x] 3.1
  - [ ] 3.0
  - [ ] 2.5
