### PR TITLE
[BugFix] fix information_schema.partitions_meta where clause bug

### DIFF
--- a/be/src/exec/schema_scanner/schema_partitions_meta_scanner.cpp
+++ b/be/src/exec/schema_scanner/schema_partitions_meta_scanner.cpp
@@ -66,9 +66,6 @@ Status SchemaPartitionsMetaScanner::start(RuntimeState* state) {
     if (nullptr != _param->db) {
         auth_info.__set_pattern(*(_param->db));
     }
-    if (nullptr != _param->table) {
-        auth_info.__set_pattern(*(_param->table));
-    }
     if (nullptr != _param->current_user_ident) {
         auth_info.__set_current_user_ident(*(_param->current_user_ident));
     } else {


### PR DESCRIPTION
## Why I'm doing:
```
create table aaa (id int);
select concat('"', table_name, '"'), hex(table_name), table_name='aaa' from information_schema.partitions_meta where db_name = 'test';
```
will be empty
## What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
