### PR TITLE
[Enhancement] Enable chunk_size session variable for pipeline engine

### DIFF
--- a/be/src/exec/pipeline/chunk_accumulate_operator.cpp
+++ b/be/src/exec/pipeline/chunk_accumulate_operator.cpp
@@ -14,10 +14,15 @@
 
 #include "exec/pipeline/chunk_accumulate_operator.h"
 
-#include "column/chunk.h"
 #include "runtime/runtime_state.h"
 
 namespace starrocks::pipeline {
+
+Status ChunkAccumulateOperator::prepare(RuntimeState* state) {
+    RETURN_IF_ERROR(Operator::prepare(state));
+    _acc.set_max_size(state->chunk_size());
+    return Status::OK();
+}
 
 Status ChunkAccumulateOperator::push_chunk(RuntimeState* state, const ChunkPtr& chunk) {
     _acc.push(chunk);

--- a/be/src/exec/pipeline/chunk_accumulate_operator.h
+++ b/be/src/exec/pipeline/chunk_accumulate_operator.h
@@ -30,6 +30,7 @@ public:
             : Operator(factory, id, "chunk_accumulate", plan_node_id, true, driver_sequence) {}
 
     ~ChunkAccumulateOperator() override = default;
+    Status prepare(RuntimeState* state) override;
 
     Status push_chunk(RuntimeState* state, const ChunkPtr& chunk) override;
     StatusOr<ChunkPtr> pull_chunk(RuntimeState* state) override;

--- a/be/src/runtime/runtime_state.cpp
+++ b/be/src/runtime/runtime_state.cpp
@@ -179,10 +179,7 @@ void RuntimeState::_init(const TUniqueId& fragment_instance_id, const TQueryOpti
         _query_options.max_errors = 100;
     }
 
-    // if BE was in grayscale upgrade. old BE chunk size was 4096.
-    // if FE set a zero batch_size, batch_size will be set to DEFAULT_CHUNK_SIZE
-    // (DEFAULT_CHUNK_SIZE was 2048 before version 2.0/2.1.0). which will cause overflow
-    if (_query_options.batch_size <= DEFAULT_CHUNK_SIZE) {
+    if (_query_options.batch_size <= 0) {
         _query_options.batch_size = DEFAULT_CHUNK_SIZE;
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
@@ -865,8 +865,6 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
     @VariableMgr.VarAttr(name = CHUNK_SIZE, flag = VariableMgr.INVISIBLE)
     private int chunkSize = 4096;
 
-    public static final int PIPELINE_BATCH_SIZE = 4096;
-
     // auto, force_streaming, force_preaggregation
     @VariableMgr.VarAttr(name = STREAMING_PREAGGREGATION_MODE)
     private String streamingPreaggregationMode = SessionVariableConstants.AUTO;
@@ -2115,6 +2113,10 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
 
     public int getExchangeInstanceParallel() {
         return exchangeInstanceParallel;
+    }
+
+    public int getChunkSize() {
+        return chunkSize;
     }
 
     public boolean getEnableInsertStrict() {

--- a/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/TFragmentInstanceFactory.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/TFragmentInstanceFactory.java
@@ -135,7 +135,7 @@ public class TFragmentInstanceFactory {
 
             if (isEnablePipeline) {
                 result.setIs_pipeline(true);
-                result.getQuery_options().setBatch_size(SessionVariable.PIPELINE_BATCH_SIZE);
+                result.getQuery_options().setBatch_size(sessionVariable.getChunkSize());
                 result.setEnable_shared_scan(sessionVariable.isEnableSharedScan());
                 result.params.setEnable_exchange_pass_through(sessionVariable.isEnableExchangePassThrough());
                 result.params.setEnable_exchange_perf(sessionVariable.isEnableExchangePerf());

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/SetStmtAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/SetStmtAnalyzer.java
@@ -115,6 +115,11 @@ public class SetStmtAnalyzer {
             }
         }
 
+        // Check variable chunk_size value if valid
+        if (variable.equalsIgnoreCase(SessionVariable.CHUNK_SIZE)) {
+            checkRangeLongVariable(resolvedExpression, SessionVariable.CHUNK_SIZE, 1L, 65535L);
+        }
+
         // Check variable load_mem_limit value is valid
         if (variable.equalsIgnoreCase(SessionVariable.LOAD_MEM_LIMIT)) {
             checkRangeLongVariable(resolvedExpression, SessionVariable.LOAD_MEM_LIMIT, 0L, null);


### PR DESCRIPTION
## What I'm doing:

* Enable `chunk_size` session variable for pipeline engine.
* Echo with #40756. Check validality when setting chunk_size.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [x] 3.1
  - [ ] 3.0
  - [ ] 2.5
