### PR TITLE
[Refactor] Refactor orc tiny stripe optimization

### DIFF
--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -810,12 +810,12 @@ CONF_Int64(text_io_range_size, "16777216");
 
 // orc reader
 CONF_Bool(enable_orc_late_materialization, "true");
-CONF_Int32(orc_row_index_cache_max_size, "1048576");
-CONF_Int32(orc_stripe_cache_max_size, "8388608");
 CONF_Bool(enable_orc_libdeflate_decompression, "true");
-CONF_Int32(orc_file_cache_max_size, "8388608");
 CONF_Int32(orc_natural_read_size, "8388608");
 CONF_mBool(orc_coalesce_read_enable, "true");
+// For orc tiny stripe optimization
+// Default is 8MB for tiny stripe threshold size
+CONF_Int32(orc_tiny_stripe_threshold_size, "8388608");
 
 // parquet reader
 CONF_mBool(parquet_coalesce_read_enable, "true");

--- a/be/src/exec/hdfs_scanner.h
+++ b/be/src/exec/hdfs_scanner.h
@@ -78,7 +78,10 @@ struct HdfsScanStats {
     // late materialize round-by-round
     int64_t group_min_round_cost = 0;
 
-    std::vector<int64_t> orc_stripe_sizes;
+    // orc stripe information
+    std::vector<int64_t> orc_stripe_sizes{};
+    int64_t orc_total_tiny_stripe_size = 0;
+
     // io coalesce
     int64_t orc_stripe_active_lazy_coalesce_together = 0;
     int64_t orc_stripe_active_lazy_coalesce_seperately = 0;

--- a/be/src/formats/orc/apache-orc/c++/include/orc/OrcFile.hh
+++ b/be/src/formats/orc/apache-orc/c++/include/orc/OrcFile.hh
@@ -57,7 +57,6 @@ public:
         uint64_t size;
         bool is_active;
     };
-    enum class PrepareCacheScope { READ_FULL_FILE, READ_FULL_STRIPE, READ_FULL_ROW_INDEX };
 
     virtual ~InputStream();
 
@@ -92,12 +91,12 @@ public:
      */
     virtual const std::string& getName() const = 0;
 
-    virtual void prepareCache(PrepareCacheScope scope, uint64_t offset, uint64_t length);
-
+    virtual std::atomic<int32_t>* get_lazy_column_coalesce_counter();
+    virtual bool isAlreadyCollectedInSharedBuffer(const int64_t offset, const int64_t length) const;
     virtual bool isIOCoalesceEnabled() const;
     virtual bool isIOAdaptiveCoalesceEnabled() const;
-    virtual void clearIORanges();
-    virtual void setIORanges(std::vector<InputStream::IORange>& io_ranges, const bool is_from_stripe);
+    virtual void releaseToOffset(const int64_t offset);
+    virtual void setIORanges(std::vector<InputStream::IORange>& io_ranges);
 };
 
 /**

--- a/be/src/formats/orc/apache-orc/c++/src/Reader.cc
+++ b/be/src/formats/orc/apache-orc/c++/src/Reader.cc
@@ -428,14 +428,9 @@ void RowReaderImpl::loadStripeIndex() {
 
     // obtain row indexes for selected columns
     uint64_t offset = currentStripeInfo.offset();
-
-    // usually row index size is small.
-    uint64_t rowIndexSize = currentStripeInfo.indexlength();
-    contents->stream->prepareCache(InputStream::PrepareCacheScope::READ_FULL_ROW_INDEX, offset, rowIndexSize);
     for (int i = 0; i < currentStripeFooter.streams_size(); ++i) {
         const proto::Stream& pbStream = currentStripeFooter.streams(i);
         uint64_t colId = pbStream.column();
-        // We only need to load active column's RowIndex
         if (selectedColumns[colId] && pbStream.has_kind() &&
             (pbStream.kind() == proto::Stream_Kind_ROW_INDEX ||
              pbStream.kind() == proto::Stream_Kind_BLOOM_FILTER_UTF8)) {
@@ -1020,7 +1015,16 @@ void RowReaderImpl::buildIORanges(std::vector<InputStream::IORange>* io_ranges) 
         // ColumnId = 0 is root column, we always need it
         if (columnId == 0 || selectedColumns[columnId] || lazyLoadColumns[columnId]) {
             bool is_active = true;
-            if (lazyLoadColumns[columnId]) {
+
+            // We didn't support stripe index lazy load, so we will regard all index stream as active column
+            bool is_stripe_index = false;
+            if (stream.has_kind() && (stream.kind() == proto::Stream_Kind_ROW_INDEX ||
+                                      stream.kind() == proto::Stream_Kind_BLOOM_FILTER_UTF8)) {
+                is_stripe_index = true;
+            }
+
+            // we only seperate io range for column's data, don't include column's index
+            if (!is_stripe_index && lazyLoadColumns[columnId]) {
                 is_active = false;
             }
             io_ranges->emplace_back(InputStream::IORange{.offset = offset, .size = length, .is_active = is_active});
@@ -1065,17 +1069,18 @@ void RowReaderImpl::startNextStripe() {
             }
         }
 
-        contents->stream->prepareCache(InputStream::PrepareCacheScope::READ_FULL_STRIPE, currentStripeInfo.offset(),
-                                       stripeSize);
+        // release previous stripe's io ranges
         if (isIOCoalesceEnabled) {
-            contents->stream->clearIORanges();
+            contents->stream->releaseToOffset(currentStripeInfo.offset());
         }
         currentStripeFooter = getStripeFooter(currentStripeInfo, *contents);
         rowsInCurrentStripe = currentStripeInfo.numberofrows();
-        if (isIOCoalesceEnabled) {
+        // We need to check this stripe is already set in shared buffer(tiny stripe optimize) to avoid shared buffer overlap
+        if (isIOCoalesceEnabled &&
+            !contents->stream->isAlreadyCollectedInSharedBuffer(currentStripeInfo.offset(), stripeSize)) {
             std::vector<InputStream::IORange> io_ranges;
             buildIORanges(&io_ranges);
-            contents->stream->setIORanges(io_ranges, true);
+            contents->stream->setIORanges(io_ranges);
         }
 
         if (sargsApplier) {
@@ -1146,6 +1151,11 @@ void RowReaderImpl::startNextStripe() {
             // advance to next stripe when current stripe has no matching rows
             currentStripe += 1;
             currentRowInStripe = 0;
+
+            if (contents->stream->get_lazy_column_coalesce_counter() != nullptr) {
+                // Skip entrie stripe, which means we didn't need to coalesce active and lazy column together
+                contents->stream->get_lazy_column_coalesce_counter()->fetch_sub(1, std::memory_order_relaxed);
+            }
         } else {
             break;
         }
@@ -1448,7 +1458,6 @@ std::unique_ptr<Reader> createReader(std::unique_ptr<InputStream> stream, const 
             throw ParseError("File size too small");
         }
         std::unique_ptr<DataBuffer<char>> buffer(new DataBuffer<char>(*contents->pool, readSize));
-        stream->prepareCache(InputStream::PrepareCacheScope::READ_FULL_FILE, 0, fileLength);
         stream->read(buffer->data(), readSize, fileLength - readSize);
 
         postscriptLength = buffer->data()[readSize - 1] & 0xff;
@@ -1555,8 +1564,6 @@ uint64_t InputStream::getNaturalReadSizeAfterSeek() const {
     return 128 * 1024;
 }
 
-void InputStream::prepareCache(PrepareCacheScope scope, uint64_t offset, uint64_t length) {}
-
 bool InputStream::isIOCoalesceEnabled() const {
     return false;
 }
@@ -1565,8 +1572,16 @@ bool InputStream::isIOAdaptiveCoalesceEnabled() const {
     return false;
 }
 
-void InputStream::clearIORanges() {}
+bool InputStream::isAlreadyCollectedInSharedBuffer(const int64_t offset, const int64_t length) const {
+    return false;
+}
 
-void InputStream::setIORanges(std::vector<InputStream::IORange>& io_ranges, const bool is_from_stripe) {}
+void InputStream::releaseToOffset(const int64_t offset) {}
+
+void InputStream::setIORanges(std::vector<InputStream::IORange>& io_ranges) {}
+
+std::atomic<int32_t>* InputStream::get_lazy_column_coalesce_counter() {
+    return nullptr;
+}
 
 } // namespace orc

--- a/be/src/formats/orc/orc_input_stream.h
+++ b/be/src/formats/orc/orc_input_stream.h
@@ -60,38 +60,28 @@ public:
 
     uint64_t getNaturalReadSizeAfterSeek() const override { return config::orc_natural_read_size / 4; }
 
-    void prepareCache(PrepareCacheScope scope, uint64_t offset, uint64_t length) override;
     void read(void* buf, uint64_t length, uint64_t offset) override;
 
     const std::string& getName() const override;
 
-    void set_lazy_column_coalesce_counter(const std::atomic<int32_t>* lazy_column_coalesce_counter) {
+    void set_lazy_column_coalesce_counter(std::atomic<int32_t>* lazy_column_coalesce_counter) {
         _lazy_column_coalesce_counter = lazy_column_coalesce_counter;
     }
     void set_app_stats(HdfsScanStats* stats) { _app_stats = stats; }
     bool isIOCoalesceEnabled() const override { return config::orc_coalesce_read_enable; }
     bool isIOAdaptiveCoalesceEnabled() const override { return config::io_coalesce_adaptive_lazy_active; }
-
-    void clearIORanges() override;
-    void setIORanges(std::vector<IORange>& io_ranges, const bool is_from_stripe) override;
-    void setStripes(std::vector<StripeInformation>&& stripes);
+    bool isAlreadyCollectedInSharedBuffer(const int64_t offset, const int64_t length) const override;
+    void releaseToOffset(const int64_t offset) override;
+    void setIORanges(std::vector<IORange>& io_ranges) override;
+    Status setIORanges(const std::vector<io::SharedBufferedInputStream::IORange>& io_ranges,
+                       const bool coalesce_active_lazy_column = true);
+    std::atomic<int32_t>* get_lazy_column_coalesce_counter() override;
 
 private:
-    void doRead(void* buf, uint64_t length, uint64_t offset);
-    bool isAlreadyCachedInBuffer(uint64_t offset, uint64_t length);
-    uint64_t computeCacheFullStripeSize(uint64_t offset, uint64_t length);
-
     RandomAccessFile* _file;
     uint64_t _length;
-    std::vector<char> _cache_buffer;
-    uint64_t _cache_offset;
     io::SharedBufferedInputStream* _sb_stream;
-
-    bool _tiny_stripe_read = false;
-    uint64_t _last_stripe_index = 0;
-    std::vector<StripeInformation> _stripes;
-
-    const std::atomic<int32_t>* _lazy_column_coalesce_counter = nullptr;
+    std::atomic<int32_t>* _lazy_column_coalesce_counter = nullptr;
     HdfsScanStats* _app_stats = nullptr;
 };
 } // namespace starrocks

--- a/be/src/formats/orc/utils.h
+++ b/be/src/formats/orc/utils.h
@@ -14,10 +14,7 @@
 
 #pragma once
 
-#include <exception>
 #include <orc/OrcFile.hh>
-#include <set>
-#include <unordered_map>
 #include <utility>
 
 #include "cctz/civil_time.h"
@@ -26,12 +23,58 @@
 #include "formats/orc/orc_mapping.h"
 #include "formats/orc/utils.h"
 #include "gen_cpp/orc_proto.pb.h"
-#include "runtime/types.h"
+#include "io/shared_buffered_input_stream.h"
 #include "types/date_value.h"
-#include "types/logical_type.h"
 #include "types/timestamp_value.h"
 
 namespace starrocks {
+
+class DiskRange {
+public:
+    DiskRange(int64_t off, int64_t len) : offset(off), length(len) {
+        DCHECK(off >= 0);
+        DCHECK(len > 0);
+    }
+
+    /**
+    * Returns the minimal DiskRange that encloses both this DiskRange
+    * and otherDiskRange. If there was a gap between the ranges the
+    * new range will cover that gap.
+    */
+    DiskRange span(const DiskRange& otherDiskRange) const {
+        const int64_t start = std::min(offset, otherDiskRange.offset);
+        const int64_t end = std::max(get_end(), otherDiskRange.get_end());
+        return DiskRange(start, end - start);
+    }
+
+    int64_t get_end() const { return offset + length; }
+
+    int64_t offset;
+    int64_t length;
+};
+
+class DiskRangeHelper {
+public:
+    static void mergeAdjacentDiskRanges(std::vector<io::SharedBufferedInputStream::IORange>& io_ranges,
+                                        const std::vector<DiskRange>& disk_ranges, const int64_t max_merge_distance,
+                                        const int64_t max_merged_size) {
+        if (disk_ranges.empty()) {
+            return;
+        }
+        DiskRange last = disk_ranges[0];
+        for (size_t i = 1; i < disk_ranges.size(); i++) {
+            DiskRange current = disk_ranges[i];
+            DiskRange merged = last.span(current);
+            if (merged.length <= max_merged_size && last.get_end() + max_merge_distance >= current.offset) {
+                last = merged;
+            } else {
+                io_ranges.emplace_back(last.offset, last.length, true);
+                last = current;
+            }
+        }
+        io_ranges.emplace_back(last.offset, last.length, true);
+    }
+};
 
 // Hive ORC char type will pad trailing spaces.
 // https://docs.cloudera.com/documentation/enterprise/6/6.3/topics/impala_char.html

--- a/be/test/CMakeLists.txt
+++ b/be/test/CMakeLists.txt
@@ -156,6 +156,7 @@ set(EXEC_FILES
         ./formats/orc/orc_column_reader_test.cpp
         ./formats/orc/orc_chunk_writer_test.cpp
         ./formats/orc/orc_lazy_load_test.cpp
+        ./formats/orc/utils_test.cpp
         ./formats/parquet/arrow_parquet_writer_test.cpp
         ./formats/parquet/parquet_schema_test.cpp
         ./formats/parquet/encoding_test.cpp

--- a/be/test/formats/orc/utils_test.cpp
+++ b/be/test/formats/orc/utils_test.cpp
@@ -1,0 +1,57 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "formats/orc/utils.h"
+
+#include <common/config.h>
+#include <gtest/gtest.h>
+
+namespace starrocks {
+
+TEST(UtilsTest, TestMergeEmptyDiskRanges) {
+    std::vector<DiskRange> disk_ranges{};
+    std::vector<io::SharedBufferedInputStream::IORange> io_ranges{};
+    DiskRangeHelper::mergeAdjacentDiskRanges(io_ranges, disk_ranges, config::io_coalesce_read_max_distance_size,
+                                             config::io_coalesce_read_max_buffer_size);
+    EXPECT_EQ(0, io_ranges.size());
+}
+
+TEST(UtilsTest, TestMergeTinyDiskRanges) {
+    std::vector<DiskRange> disk_ranges{};
+    constexpr int64_t KB = 1024;
+    disk_ranges.emplace_back(0, 1 * KB);
+    disk_ranges.emplace_back(10 * KB, 30 * KB);
+    disk_ranges.emplace_back(800 * KB, 100 * KB);
+    std::vector<io::SharedBufferedInputStream::IORange> io_ranges{};
+    DiskRangeHelper::mergeAdjacentDiskRanges(io_ranges, disk_ranges, config::io_coalesce_read_max_distance_size,
+                                             config::io_coalesce_read_max_buffer_size);
+    EXPECT_EQ(1, io_ranges.size());
+    EXPECT_EQ(0, io_ranges.at(0).offset);
+    EXPECT_EQ(900 * KB, io_ranges.at(0).size);
+}
+
+TEST(UtilsTest, TestMergeBigDiskRanges) {
+    std::vector<DiskRange> disk_ranges{};
+    constexpr int64_t MB = 1024 * 1024;
+    disk_ranges.emplace_back(0, 100 * MB);
+    disk_ranges.emplace_back(200 * MB, 100 * MB);
+    std::vector<io::SharedBufferedInputStream::IORange> io_ranges{};
+    DiskRangeHelper::mergeAdjacentDiskRanges(io_ranges, disk_ranges, config::io_coalesce_read_max_distance_size,
+                                             config::io_coalesce_read_max_buffer_size);
+    EXPECT_EQ(2, io_ranges.size());
+    EXPECT_EQ(0, io_ranges.at(0).offset);
+    EXPECT_EQ(200 * MB, io_ranges.at(1).offset);
+}
+
+} // namespace starrocks


### PR DESCRIPTION
## Why I'm doing:
The original implementation was not well integrated with the shared buffer(io coalesce), and the optimization in some places was too radical, which would lead read more data.

## What I'm doing:
* Remove prepare cache for full file, it may occur bad case when a predicate has strong selectivity. Sometime these case only need to read ORC's footer, but we will load the whole file.
* Remove prepare cache for row index, because we already collected row index's io range, shared buffer can handle it well.
* Move tiny stripe optimization into shared buffer, so SR's io coalesce policy can handle it well.
* Move tiny stripe optimization codes out of apache orc.

**Previous profile:**
```bash
 - InputStream: 
   - AppIOBytesRead: 1.530 GB
   - AppIOCounter: 322
   - AppIOTime: 5s900ms
   - FSIOBytesRead: 3.014 GB
   - FSIOCounter: 546
   - FSIOTime: 5s225ms
- SharedBuffered: 
 - DirectIOBytes: 9.042 MB
 - DirectIOCount: 62
 - DirectIOTime: 1s865ms
 - SharedIOBytes: 3.006 GB
 - SharedIOCount: 484
 - SharedIOTime: 3s587ms
- ORC: 
 - IcebergV2FormatTimer: 
   - DeleteFileBuildFilterTime: 0ns
   - DeleteFileBuildTime: 0ns
   - DeleteFilesPerScan: 0
 - StripeActiveLazyColumnIOCoalesceSeperately: 0
 - StripeActiveLazyColumnIOCoalesceTogether: 256
 - TotalStripeNumber: 256
 - TotalStripeSize: 1.548 GB
```

**Now profile:**
```bash
 - InputStream: 
   - AppIOBytesRead: 8.533 MB
   - AppIOCounter: 52.284K (52284)
   - AppIOTime: 2s55ms
   - FSIOBytesRead: 1.621 GB
   - FSIOCounter: 348
   - FSIOTime: 1s854ms
- SharedBuffered: 
 - DirectIOBytes: 14.502 MB
 - DirectIOCount: 90
 - DirectIOTime: 149.129ms
 - SharedIOBytes: 1.607 GB
 - SharedIOCount: 258
 - SharedIOTime: 1s822ms
- ORC: 
 - IcebergV2FormatTimer: 
   - DeleteFileBuildFilterTime: 0ns
   - DeleteFileBuildTime: 0ns
   - DeleteFilesPerScan: 0
 - StripeActiveLazyColumnIOCoalesceSeperately: 0
 - StripeActiveLazyColumnIOCoalesceTogether: 30
 - TotalStripeNumber: 256
 - TotalStripeSize: 1.548 GB
 - TotalTinyStripeSize: 1.360 GB
```

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [x] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
