### PR TITLE
[Enhancement] reduce io times in ColumnarSerde::deserialize

### DIFF
--- a/be/src/exec/spill/spiller.cpp
+++ b/be/src/exec/spill/spiller.cpp
@@ -91,6 +91,10 @@ SpillProcessMetrics::SpillProcessMetrics(RuntimeProfile* profile, std::atomic_in
     local_block_count = ADD_CHILD_COUNTER(profile, "LocalBlockCount", TUnit::UNIT, "BlockCount");
     remote_block_count = ADD_CHILD_COUNTER(profile, "RemoteBlockCount", TUnit::UNIT, "BlockCount");
 
+    read_io_count = ADD_CHILD_COUNTER(profile, "ReadIOCount", TUnit::UNIT, parent);
+    local_read_io_count = ADD_CHILD_COUNTER(profile, "LocalReadIOCount", TUnit::UNIT, "ReadIOCount");
+    remote_read_io_count = ADD_CHILD_COUNTER(profile, "RemoteReadIOCount", TUnit::UNIT, "ReadIOCount");
+
     flush_io_task_count = ADD_CHILD_COUNTER(profile, "FlushIOTaskCount", TUnit::UNIT, parent);
     peak_flush_io_task_count = profile->AddHighWaterMarkCounter(
             "PeakFlushIOTaskCount", TUnit::UNIT, RuntimeProfile::Counter::create_strategy(TUnit::UNIT), parent);

--- a/be/src/exec/spill/spiller.h
+++ b/be/src/exec/spill/spiller.h
@@ -105,6 +105,12 @@ public:
     RuntimeProfile::Counter* block_count = nullptr;
     RuntimeProfile::Counter* local_block_count = nullptr;
     RuntimeProfile::Counter* remote_block_count = nullptr;
+
+    // the number of read io count
+    RuntimeProfile::Counter* read_io_count = nullptr;
+    RuntimeProfile::Counter* local_read_io_count = nullptr;
+    RuntimeProfile::Counter* remote_read_io_count = nullptr;
+
     // flush/restore task count
     RuntimeProfile::Counter* flush_io_task_count = nullptr;
     RuntimeProfile::HighWaterMarkCounter* peak_flush_io_task_count = nullptr;


### PR DESCRIPTION
## Why I'm doing:
for spilling query, we store each chunk's meta(e.g. serialized size and encode level) in Block, and deserialize it when we read chunk during restore stage.
in previous implementation, we invoke read_fully many times. for remote storage, each read_fully will issue an rpc request which is very inefficient.

## What I'm doing:
I merge some unnecessary IOs into one, to reduce IO Times.


Here are some test result in my env.
data set: ssb_100g
test SQL is a simple agg query.
```sql
set pipeline_dop=8;
set disable_spill_to_local_disk=true;
set enable_spill_to_remote_storage=true;
set spill_mode='force';
with limit_t as (select * from lineorder)
select l.lo_orderkey, l.lo_linenumber, count(l.lo_orderkey),count(l.lo_linenumber) ,count(l.lo_custkey) ,count(l.lo_partkey) ,count(l.lo_suppkey) ,count(l.lo_orderdate) ,count(l.lo_orderpriority) ,count(l.lo_shippriority) ,count(l.lo_quantity) ,count(l.lo_extendedprice) ,count(l.lo_ordtotalprice) ,count(l.lo_discount) ,count(l.lo_revenue) ,count(l.lo_supplycost) ,count(l.lo_tax) ,count(l.lo_commitdate) ,count(l.lo_shipmode) from limit_t l group by l.lo_orderkey, l.lo_linenumber order by lo_orderkey limit 100;
```

* RemoteReadIOCount: numbers of read IO requests
* RemoteReadIOTime: the cumulative time consumption of all read IO requests
* QueryTime: total time spent of this query

|  metrics  | old | new |
|  ----  | ----  | ---- |
|  RemoteReadIOCount |3.081M (3080501) | 294.428K (294428) |
|  RemoteReadIOTime | 1h34m | 14m21s |
| QueryTime |21m47s | 6m22s |



## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
