### PR TITLE
[BugFix] Fix _index_length not show up in debug_string

### DIFF
--- a/be/src/storage/tablet_schema.cpp
+++ b/be/src/storage/tablet_schema.cpp
@@ -712,7 +712,7 @@ std::string TabletColumn::debug_string() const {
        << ",default_value=" << (has_default_value() ? default_value() : "N/A")
        << ",precision=" << (has_precision() ? std::to_string(_precision) : "N/A")
        << ",frac=" << (has_scale() ? std::to_string(_scale) : "N/A") << ",length=" << _length
-       << ",index_length=" << _index_length << ",is_bf_column=" << is_bf_column()
+       << ",index_length=" << static_cast<int>(_index_length) << ",is_bf_column=" << is_bf_column()
        << ",has_bitmap_index=" << has_bitmap_index() << ")";
     return ss.str();
 }

--- a/be/test/storage/tablet_schema_map_test.cpp
+++ b/be/test/storage/tablet_schema_map_test.cpp
@@ -33,6 +33,7 @@ TEST(TabletSchemaMapTest, test_all) {
     c0->set_type("INT");
     c0->set_is_key(true);
     c0->set_is_nullable(true);
+    c0->set_index_length(4);
 
     TabletSchemaMap schema_map;
 
@@ -43,6 +44,7 @@ TEST(TabletSchemaMapTest, test_all) {
 
     ASSERT_FALSE(schema_map.contains(schema_pb.id()));
     auto [schema0, inserted0] = schema_map.emplace(schema_pb);
+    ASSERT_TRUE(schema0->debug_string().find(",index_length=4") != std::string::npos);
     ASSERT_TRUE(inserted0);
     ASSERT_TRUE(schema0 != nullptr);
     ASSERT_EQ(schema_pb.id(), schema0->id());


### PR DESCRIPTION
## Why I'm doing:

_index_length is stored as uint8_t(char), so it will be treated as char in debug_string, causing output issue

## What I'm doing:

Fix this


## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [x] 3.1
  - [x] 3.0
  - [x] 2.5
