### PR TITLE
[cherrypick][branch-3.1-cs][Feature][Issue 39849]add datadog java/cpp profiling lib (#40652)

### DIFF
--- a/docker/dockerfiles/artifacts/artifact.Dockerfile
+++ b/docker/dockerfiles/artifacts/artifact.Dockerfile
@@ -40,6 +40,19 @@ COPY . /build/starrocks
 WORKDIR /build/starrocks
 RUN --mount=type=cache,target=/root/.m2/ STARROCKS_VERSION=${RELEASE_VERSION} BUILD_TYPE=${BUILD_TYPE} MAVEN_OPTS=${MAVEN_OPTS} ./build.sh --be --use-staros --clean -j `nproc`
 
+FROM ubuntu:22.04 as datadog-downloader
+
+RUN apt-get update -y && apt-get install -y --no-install-recommends wget tar xz-utils
+
+# download the latest dd-java-agent
+ADD 'https://dtdg.co/latest-java-tracer' /datadog/dd-java-agent.jar
+
+# Get ddprof for BE profiling
+RUN imagearch=$(arch | sed 's/aarch64/arm64/; s/x86_64/amd64/') \
+    && wget --no-check-certificate "https://github.com/DataDog/ddprof/releases/download/v0.15.3/ddprof-0.15.3-${imagearch}-linux.tar.xz" -O ddprof-linux.tar.xz \
+    && tar xvf ddprof-linux.tar.xz && mkdir -p /datadog/  \
+    && mv ddprof/bin/ddprof /datadog/ \
+    && chmod 755 /datadog/ddprof
 
 FROM busybox:latest
 ARG RELEASE_VERSION
@@ -50,5 +63,8 @@ LABEL org.starrocks.version=${RELEASE_VERSION:-"UNKNOWN"}
 COPY --from=fe-builder /build/starrocks/output /release/fe_artifacts
 COPY --from=be-builder /build/starrocks/output /release/be_artifacts
 COPY --from=broker-builder /build/starrocks/fs_brokers/apache_hdfs_broker/output /release/broker_artifacts
+
+COPY --from=datadog-downloader /datadog/dd-java-agent.jar /release/fe_artifacts/fe/datadog/dd-java-agent.jar
+COPY --from=datadog-downloader /datadog/ddprof /release/be_artifacts/be/datadog/ddprof
 
 WORKDIR /release


### PR DESCRIPTION
## Why I'm doing:
^ cherrypick https://github.com/StarRocks/starrocks/pull/40652 to branch `3.1-cs` manually

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [x] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
