### PR TITLE
[Enhancement] Add storage volume in tables_config

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/MaterializedView.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/MaterializedView.java
@@ -62,6 +62,7 @@ import com.starrocks.scheduler.Task;
 import com.starrocks.scheduler.TaskBuilder;
 import com.starrocks.scheduler.TaskManager;
 import com.starrocks.server.GlobalStateMgr;
+import com.starrocks.server.RunMode;
 import com.starrocks.sql.analyzer.AnalyzeState;
 import com.starrocks.sql.analyzer.ExpressionAnalyzer;
 import com.starrocks.sql.analyzer.Field;
@@ -1281,6 +1282,11 @@ public class MaterializedView extends OlapTable implements GsonPreProcessable, G
                 }
             }
         });
+
+        if (RunMode.isSharedDataMode()) {
+            String sv = GlobalStateMgr.getCurrentState().getStorageVolumeMgr().getStorageVolumeNameOfTable(this.getId());
+            propsMap.put(PropertyAnalyzer.PROPERTIES_STORAGE_VOLUME, sv);
+        }
         return propsMap;
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/service/InformationSchemaDataSource.java
+++ b/fe/fe-core/src/main/java/com/starrocks/service/InformationSchemaDataSource.java
@@ -46,6 +46,7 @@ import com.starrocks.monitor.unit.ByteSizeValue;
 import com.starrocks.privilege.AccessDeniedException;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.server.MetadataMgr;
+import com.starrocks.server.RunMode;
 import com.starrocks.sql.analyzer.Authorizer;
 import com.starrocks.sql.analyzer.SemanticException;
 import com.starrocks.sql.ast.UserIdentity;
@@ -251,6 +252,11 @@ public class InformationSchemaDataSource {
         if (properties.containsKey(PropertyAnalyzer.PROPERTIES_STORAGE_MEDIUM)) {
             propsMap.put(PropertyAnalyzer.PROPERTIES_STORAGE_MEDIUM,
                     properties.get(PropertyAnalyzer.PROPERTIES_STORAGE_MEDIUM));
+        }
+
+        if (RunMode.isSharedDataMode()) {
+            String sv = GlobalStateMgr.getCurrentState().getStorageVolumeMgr().getStorageVolumeNameOfTable(table.getId());
+            propsMap.put(PropertyAnalyzer.PROPERTIES_STORAGE_VOLUME, sv);
         }
         return propsMap;
     }

--- a/fe/fe-core/src/test/java/com/starrocks/service/LakeInformationSchemaDataSourceTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/service/LakeInformationSchemaDataSourceTest.java
@@ -1,0 +1,106 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.service;
+
+import com.google.gson.Gson;
+import com.starrocks.server.RunMode;
+import com.starrocks.service.ExecuteEnv;
+import com.starrocks.service.FrontendServiceImpl;
+import com.starrocks.sql.ast.UserIdentity;
+import com.starrocks.thrift.TAuthInfo;
+import com.starrocks.thrift.TGetTablesConfigRequest;
+import com.starrocks.thrift.TGetTablesConfigResponse;
+import com.starrocks.thrift.TTableConfigInfo;
+import com.starrocks.utframe.StarRocksAssert;
+import com.starrocks.utframe.UtFrameUtils;
+import mockit.Mocked;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class LakeInformationSchemaDataSourceTest {
+
+    @Mocked
+    ExecuteEnv exeEnv;
+    private static StarRocksAssert starRocksAssert;
+
+    @BeforeClass
+    public static void beforeClass() throws Exception {
+        UtFrameUtils.createMinStarRocksCluster(RunMode.SHARED_DATA);
+        UtFrameUtils.addMockBackend(10002);
+        UtFrameUtils.addMockBackend(10003);
+        starRocksAssert = new StarRocksAssert(UtFrameUtils.initCtxForNewPrivilege(UserIdentity.ROOT));
+    }
+
+    @Test
+    public void testGetLakeTablesConfig() throws Exception {
+        starRocksAssert.withEnableMV().withDatabase("db1").useDatabase("db1");
+
+        String createTblStmtStr = "CREATE TABLE db1.tbl1 (`k1` int,`k2` int,`k3` int,`v1` int,`v2` int,`v3` int) " +
+                "ENGINE=OLAP " + "PRIMARY KEY(`k1`, `k2`, `k3`) " +
+                "COMMENT \"OLAP\" " +
+                "DISTRIBUTED BY HASH(`k1`, `k2`, `k3`) BUCKETS 3 " +
+                "ORDER BY(`v2`, `v3`) " +
+                "PROPERTIES ('replication_num' = '1');";
+        starRocksAssert.withTable(createTblStmtStr);
+
+        String createMvStmtStr = "CREATE MATERIALIZED VIEW db1.mv1 " +
+                "DISTRIBUTED BY HASH(k1) BUCKETS 10 " +
+                "REFRESH ASYNC " +
+                "AS SELECT k1, k2 " +
+                "FROM db1.tbl1 ";
+
+        starRocksAssert.withMaterializedView(createMvStmtStr);
+
+        FrontendServiceImpl impl = new FrontendServiceImpl(exeEnv);
+        TGetTablesConfigRequest req = new TGetTablesConfigRequest();
+        TAuthInfo authInfo = new TAuthInfo();
+        authInfo.setPattern("db1");
+        authInfo.setUser("root");
+        authInfo.setUser_ip("%");
+        req.setAuth_info(authInfo);
+        TGetTablesConfigResponse response = impl.getTablesConfig(req);
+        TTableConfigInfo tableConfig = response.getTables_config_infos().stream()
+                .filter(t -> t.getTable_name().equals("tbl1")).findFirst()
+                .orElseGet(null);
+        Assert.assertEquals("db1", tableConfig.getTable_schema());
+        Assert.assertEquals("tbl1", tableConfig.getTable_name());
+        Assert.assertEquals("CLOUD_NATIVE", tableConfig.getTable_engine());
+        Assert.assertEquals("PRIMARY_KEYS", tableConfig.getTable_model());
+        Assert.assertEquals("`k1`, `k2`, `k3`", tableConfig.getPrimary_key());
+        Assert.assertEquals("", tableConfig.getPartition_key());
+        Assert.assertEquals("`k1`, `k2`, `k3`", tableConfig.getDistribute_key());
+        Assert.assertEquals("HASH", tableConfig.getDistribute_type());
+        Assert.assertEquals(3, tableConfig.getDistribute_bucket());
+        Assert.assertEquals("`v2`, `v3`", tableConfig.getSort_key());
+        Map<String, String> propsMap = new HashMap<>();
+        propsMap = new Gson().fromJson(tableConfig.getProperties(), propsMap.getClass());
+        Assert.assertEquals("builtin_storage_volume", propsMap.get("storage_volume"));
+
+
+        TTableConfigInfo mvConfig = response.getTables_config_infos().stream()
+                .filter(t -> t.getTable_engine().equals("CLOUD_NATIVE_MATERIALIZED_VIEW")).findFirst()
+                .orElseGet(null);
+        Assert.assertEquals("CLOUD_NATIVE_MATERIALIZED_VIEW", mvConfig.getTable_engine());
+        propsMap = new HashMap<>();
+        propsMap = new Gson().fromJson(mvConfig.getProperties(), propsMap.getClass());
+        Assert.assertEquals("1", propsMap.get("replication_num"));
+        Assert.assertEquals("HDD", propsMap.get("storage_medium"));
+        Assert.assertEquals("builtin_storage_volume", propsMap.get("storage_volume"));
+    }
+}


### PR DESCRIPTION
## Why I'm doing:
If users need to know the storage volume of tables, they need to use show create table one by one. It is  inconvenient for them to check.
## What I'm doing:
Add storage volume in the filed properties in `information_schema.tables_config`. This table will list all of tables and their properties. The storage volume is added in the field properties. It will look like:
```
mysql> select * from information_schema.tables_config;
+--------------------+-----------------------------+--------------+--------------+-----------------------------------------------+----------------+-----------------------------------------------+-----------------+-------------------+-----------------------------------------------+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+----------+
| TABLE_SCHEMA       | TABLE_NAME                  | TABLE_ENGINE | TABLE_MODEL  | PRIMARY_KEY                                   | PARTITION_KEY  | DISTRIBUTE_KEY                                | DISTRIBUTE_TYPE | DISTRIBUTE_BUCKET | SORT_KEY                                      | PROPERTIES                                                                                                                                                                                                                              | TABLE_ID |
+--------------------+-----------------------------+--------------+--------------+-----------------------------------------------+----------------+-----------------------------------------------+-----------------+-------------------+-----------------------------------------------+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+----------+
| ssb                | lineorder                   | CLOUD_NATIVE | PRIMARY_KEYS | `lo_orderdate`                                | `lo_orderdate` | `lo_orderdate`                                | HASH            |                24 | `lo_orderdate`                                | {"enable_persistent_index":"true","datacache.enable":"true","storage_volume":"builtin_storage_volume","enable_async_write_back":"false","replication_num":"1","compression":"LZ4","in_memory":"false"}                                  |    21345 |
+--------------------+-----------------------------+--------------+--------------+-----------------------------------------------+----------------+-----------------------------------------------+-----------------+-------------------+-----------------------------------------------+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+----------+
```
Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [x] 3.1
  - [ ] 3.0
  - [ ] 2.5
