### PR TITLE
[Enhancement] Optimize the display format of the Parquet profile to help showing the relationship of different parts.

### DIFF
--- a/be/src/exec/hdfs_scanner.cpp
+++ b/be/src/exec/hdfs_scanner.cpp
@@ -259,7 +259,7 @@ Status HdfsScanner::open_random_access_file() {
 }
 
 void HdfsScanner::do_update_iceberg_v2_counter(RuntimeProfile* parent_profile, const std::string& parent_name) {
-    const std::string ICEBERG_TIMER = "IcebergV2FormatTimer";
+    const std::string ICEBERG_TIMER = "IcebergV2FormatTime";
     ADD_CHILD_COUNTER(parent_profile, ICEBERG_TIMER, TUnit::NONE, parent_name);
 
     RuntimeProfile::Counter* delete_build_timer =

--- a/be/src/formats/parquet/group_reader.cpp
+++ b/be/src/formats/parquet/group_reader.cpp
@@ -121,9 +121,9 @@ Status GroupReader::get_next(ChunkPtr* chunk, size_t* row_count) {
     size_t active_rows = active_chunk->num_rows();
     if (active_rows > 0 && !_lazy_column_indices.empty()) {
         ChunkPtr lazy_chunk = _create_read_chunk(_lazy_column_indices);
-        RETURN_IF_ERROR(_lazy_skip_rows(_lazy_column_indices, lazy_chunk, *row_count));
 
         SCOPED_RAW_TIMER(&_param.stats->group_chunk_read_ns);
+        RETURN_IF_ERROR(_lazy_skip_rows(_lazy_column_indices, lazy_chunk, *row_count));
         // read data into lazy chunk
         _column_reader_opts.context->filter = has_filter ? &chunk_filter : nullptr;
         Status st = _read(_lazy_column_indices, &count, &lazy_chunk);


### PR DESCRIPTION
## Why I'm doing:
The origin parquet section in profile contains much time information. However, they are not well indented, which make it confusing when analyze the time cost.

## What I'm doing:
1. Optimize the display format of the parquet section in the profile.
2. The origin `GroupChunkReadTime` does not contain the lazy skip time, which make the `GroupChunkReadTime` less than `PageReadTime` when skipping much pages, it is not reasonable and we fix it.

Now, the parquet section in profile looks like: 
```
- Parquet:
    - ParquetReaderInit:
        - InitFooterGetTime: 1m27s
            - ReaderInitFooterRead: 1m19s
            - FooterCacheReadTime: 1.900ms
            - FooterCacheReadCount: 126.101K (126101)
            - FooterCacheWriteTime: 49.523ms
            - FooterCacheWriteBytes: 299.667 GB
            - FooterCacheWriteCount: 24.953K (24953)
            - FooterCacheWriteFailCount: 1.151M (1150803)
        - InitColumnNamesSetTime: 7.396ms
        - InitReadColumnsPrepareTime: 3.531ms
        - InitGroupReaderInitTime: 3m31s
            - ReaderInitColumnReaderInit: 390.094ms
    - ParquetGroupRead:
        - GroupChunkReadTime: 7s107ms
            - PageReadTime: 6s995ms
                - PageDecompressTime: 550.046ms
            - PageReadBytes: 217.216 GB
            - PageReadBytesUncompressed: 294.290 GB
            - PageReadCount: 26.333M (26332985)
            - PageSkipCounter: 43.519K (43519)
            - HasPageStatistics: 503.932K (503932)
            - LevelDecodeTime: 14.077ms
            - ValueDecodeTime: 66.953ms
        - GroupDictFilter: 4.150ms
        - GroupDictDecode: 301.470us
    - IcebergV2FormatTime: 
        - DeleteFileBuildFilterTime: 0ns
        - DeleteFileBuildTime: 0ns
        - DeleteFilesPerScan: 0
    - RequestBytesRead: 2.318 TB
    - RequestBytesReadUncompressed: 2.393 TB
- ReaderInit: 4m58s
- RawRowsRead: 32.948B (32947687172)
- RowsRead: 88.198K (88198)
- ScanRanges: 1.302M (1301857)
```

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5

