### PR TITLE
[Enhancement] Return exception error content when cancel channel (branch-3.1) (backport #40031)

### DIFF
--- a/be/src/exec/tablet_sink.cpp
+++ b/be/src/exec/tablet_sink.cpp
@@ -871,6 +871,7 @@ Status NodeChannel::close_wait(RuntimeState* state) {
 }
 
 void NodeChannel::cancel(const Status& err_st) {
+    if (_cancel_finished) return;
     // cancel rpc request, accelerate the release of related resources
     for (auto closure : _add_batch_closures) {
         closure->cancel();
@@ -879,6 +880,11 @@ void NodeChannel::cancel(const Status& err_st) {
     for (int i = 0; i < _rpc_request.requests_size(); i++) {
         _cancel(_rpc_request.requests(i).index_id(), err_st);
     }
+    _cancel_finished = true;
+}
+
+void NodeChannel::cancel() {
+    cancel(_err_st);
 }
 
 void NodeChannel::_cancel(int64_t index_id, const Status& err_st) {
@@ -1664,7 +1670,7 @@ Status OlapTableSink::try_close(RuntimeState* state) {
                     this->mark_as_failed(ch);
                 }
             } else {
-                ch->cancel(Status::Cancelled("channel failed"));
+                ch->cancel();
             }
             if (this->has_intolerable_failure()) {
                 intolerable_failure = true;
@@ -1686,7 +1692,7 @@ Status OlapTableSink::try_close(RuntimeState* state) {
                                     index_channel->mark_as_failed(ch);
                                 }
                             } else {
-                                ch->cancel(Status::Cancelled("channel failed"));
+                                ch->cancel();
                             }
                             if (index_channel->has_intolerable_failure()) {
                                 intolerable_failure = true;
@@ -1720,7 +1726,7 @@ Status OlapTableSink::try_close(RuntimeState* state) {
                                     index_channel->mark_as_failed(ch);
                                 }
                             } else {
-                                ch->cancel(Status::Cancelled("channel failed"));
+                                ch->cancel();
                             }
                             if (index_channel->has_intolerable_failure()) {
                                 intolerable_failure = true;

--- a/be/src/exec/tablet_sink.h
+++ b/be/src/exec/tablet_sink.h
@@ -138,6 +138,7 @@ public:
     Status close_wait(RuntimeState* state);
 
     void cancel(const Status& err_st);
+    void cancel();
 
     void time_report(std::unordered_map<int64_t, AddBatchCounter>* add_batch_counter_map, int64_t* serialize_batch_ns,
                      int64_t* actual_consume_ns) {
@@ -189,6 +190,7 @@ private:
 
     // user cancel or get some errors
     bool _cancelled{false};
+    bool _cancel_finished{true};
 
     // send finished means the consumer thread which send the rpc can exit
     bool _send_finished{false};

--- a/be/src/exec/tablet_sink.h
+++ b/be/src/exec/tablet_sink.h
@@ -138,6 +138,7 @@ public:
     Status close_wait(RuntimeState* state);
 
     void cancel(const Status& err_st);
+    void cancel();
 
     void time_report(std::unordered_map<int64_t, AddBatchCounter>* add_batch_counter_map, int64_t* serialize_batch_ns,
                      int64_t* actual_consume_ns) {
@@ -189,6 +190,7 @@ private:
 
     // user cancel or get some errors
     bool _cancelled{false};
+    bool _cancel_finished{false};
 
     // send finished means the consumer thread which send the rpc can exit
     bool _send_finished{false};

--- a/be/src/exec/tablet_sink.h
+++ b/be/src/exec/tablet_sink.h
@@ -138,7 +138,6 @@ public:
     Status close_wait(RuntimeState* state);
 
     void cancel(const Status& err_st);
-    void cancel();
 
     void time_report(std::unordered_map<int64_t, AddBatchCounter>* add_batch_counter_map, int64_t* serialize_batch_ns,
                      int64_t* actual_consume_ns) {
@@ -190,7 +189,6 @@ private:
 
     // user cancel or get some errors
     bool _cancelled{false};
-    bool _cancel_finished{false};
 
     // send finished means the consumer thread which send the rpc can exit
     bool _send_finished{false};

--- a/be/src/exec/tablet_sink_index_channel.cpp
+++ b/be/src/exec/tablet_sink_index_channel.cpp
@@ -337,10 +337,16 @@ Status NodeChannel::_serialize_chunk(const Chunk* src, ChunkPB* dst) {
     {
         SCOPED_RAW_TIMER(&_serialize_batch_ns);
         StatusOr<ChunkPB> res = Status::OK();
-        TRY_CATCH_BAD_ALLOC(res = serde::ProtobufChunkSerde::serialize(*src));
-        if (!res.ok()) {
+        // This lambda is to get the result of TRY_CATCH_ALLOC_SCOPE_END()
+        auto st = [&]() {
+            TRY_CATCH_ALLOC_SCOPE_START()
+            res = serde::ProtobufChunkSerde::serialize(*src);
+            return res.status();
+            TRY_CATCH_ALLOC_SCOPE_END()
+        }();
+        if (!st.ok()) {
             _cancelled = true;
-            _err_st = res.status();
+            _err_st = st;
             return _err_st;
         }
         res->Swap(dst);
@@ -878,6 +884,8 @@ Status NodeChannel::close_wait(RuntimeState* state) {
 }
 
 void NodeChannel::cancel(const Status& err_st) {
+    if (_cancel_finished) return;
+
     // cancel rpc request, accelerate the release of related resources
     for (auto closure : _add_batch_closures) {
         closure->cancel();
@@ -886,6 +894,12 @@ void NodeChannel::cancel(const Status& err_st) {
     for (int i = 0; i < _rpc_request.requests_size(); i++) {
         _cancel(_rpc_request.requests(i).index_id(), err_st);
     }
+
+    _cancel_finished = true;
+}
+
+void NodeChannel::cancel() {
+    cancel(_err_st);
 }
 
 void NodeChannel::_cancel(int64_t index_id, const Status& err_st) {


### PR DESCRIPTION
This is a backport of #40031 to branch-3.1.
---
Why I'm doing:
The previous https://github.com/StarRocks/starrocks/pull/39908 cancels the failed channel, but the error status is overwritten by `channel failed`.
What I'm doing:
This PR includes 2 changes:
1. return the exact error when we cancel the failed channel.
2. avoid canceling failed channels repeatedly.
Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [x] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [x] 3.1
  - [x] 3.0
  - [x] 2.5

