### PR TITLE
[Enhancement] run detect_java_runtime in jni scanner and libhdfs

### DIFF
--- a/be/src/connector/hive_connector.cpp
+++ b/be/src/connector/hive_connector.cpp
@@ -69,13 +69,6 @@ std::string HiveDataSource::name() const {
 }
 
 Status HiveDataSource::open(RuntimeState* state) {
-    // right now we don't force user to set JAVA_HOME.
-    // but when we access hdfs via JNI, we have to make sure JAVA_HOME is set,
-    // otherwise be will crash because of failure to create JVM.
-    const char* p = std::getenv("JAVA_HOME");
-    if (p == nullptr) {
-        return Status::RuntimeError("env 'JAVA_HOME' is not set");
-    }
     const auto& hdfs_scan_node = _provider->_hdfs_scan_node;
     if (_scan_range.file_length == 0) {
         _no_data = true;

--- a/be/src/exec/jni_scanner.cpp
+++ b/be/src/exec/jni_scanner.cpp
@@ -36,6 +36,7 @@ Status JniScanner::_check_jni_exception(JNIEnv* env, const std::string& message)
 }
 
 Status JniScanner::do_init(RuntimeState* runtime_state, const HdfsScannerParams& scanner_params) {
+    RETURN_IF_ERROR(detect_java_runtime());
     _init_profile(scanner_params);
     SCOPED_RAW_TIMER(&_app_stats.reader_init_ns);
     JNIEnv* env = JVMFunctionHelper::getInstance().getEnv();

--- a/be/src/fs/hdfs/hdfs_fs_cache.cpp
+++ b/be/src/fs/hdfs/hdfs_fs_cache.cpp
@@ -18,6 +18,7 @@
 
 #include "common/config.h"
 #include "gutil/strings/substitute.h"
+#include "udf/java/java_udf.h"
 #include "util/hdfs_util.h"
 
 namespace starrocks {
@@ -49,6 +50,7 @@ static const std::map<std::string, std::string> get_cloud_properties(const FSOpt
 
 static Status create_hdfs_fs_handle(const std::string& namenode, const std::shared_ptr<HdfsFsClient>& hdfs_client,
                                     const FSOptions& options) {
+    RETURN_IF_ERROR(detect_java_runtime());
     auto hdfs_builder = hdfsNewBuilder();
     hdfsBuilderSetNameNode(hdfs_builder, namenode.c_str());
     const THdfsProperties* properties = options.hdfs_properties();


### PR DESCRIPTION
## Why I'm doing:

To help diagnose jni problem faster.

## What I'm doing:

Check 'JAVA_HOME' env is set when jni is used.

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
