### PR TITLE
[BugFix] Fix the problem of SinkIOBuffer getting stuck

### DIFF
--- a/be/src/exec/CMakeLists.txt
+++ b/be/src/exec/CMakeLists.txt
@@ -199,6 +199,7 @@ set(EXEC_FILES
     pipeline/scan/schema_scan_operator.cpp
     pipeline/scan/schema_scan_context.cpp
     pipeline/sink/iceberg_table_sink_operator.cpp
+    pipeline/sink/sink_io_buffer.cpp
     pipeline/sink/hive_table_sink_operator.cpp
     pipeline/sink/table_function_table_sink_operator.cpp
     pipeline/sink/blackhole_table_sink_operator.cpp

--- a/be/src/exec/pipeline/sink/export_sink_operator.cpp
+++ b/be/src/exec/pipeline/sink/export_sink_operator.cpp
@@ -43,7 +43,7 @@ public:
     void close(RuntimeState* state) override;
 
 private:
-    void _process_chunk(bthread::TaskIterator<ChunkPtr>& iter) override;
+    void _add_chunk(const ChunkPtr& chunk) override;
 
     Status _open_file_writer();
 
@@ -83,23 +83,7 @@ void ExportSinkIOBuffer::close(RuntimeState* state) {
     SinkIOBuffer::close(state);
 }
 
-void ExportSinkIOBuffer::_process_chunk(bthread::TaskIterator<ChunkPtr>& iter) {
-    DeferOp op([&]() {
-        auto nc = _num_pending_chunks.fetch_sub(1);
-        DCHECK_GE(nc, 1L);
-    });
-
-    if (_is_finished) {
-        return;
-    }
-
-    if (_is_cancelled && !_is_finished) {
-        if (_num_pending_chunks == 1) {
-            close(_state);
-        }
-        return;
-    }
-
+void ExportSinkIOBuffer::_add_chunk(const ChunkPtr& chunk) {
     if (_file_builder == nullptr) {
         if (Status status = _open_file_writer(); !status.ok()) {
             LOG(WARNING) << "open file write failed, error: " << status.to_string();
@@ -107,14 +91,7 @@ void ExportSinkIOBuffer::_process_chunk(bthread::TaskIterator<ChunkPtr>& iter) {
             return;
         }
     }
-    const auto& chunk = *iter;
-    if (chunk == nullptr) {
-        // this is the last chunk, finish task is first put into queue and then ++_num_pending_chunks,
-        // So _num_pending_chunks maybe 0 or 1 here.
-        DCHECK_LE(_num_pending_chunks, 1);
-        close(_state);
-        return;
-    }
+
     if (Status status = _file_builder->add_chunk(chunk.get()); !status.ok()) {
         LOG(WARNING) << "add chunk to file builder failed, error: " << status.to_string();
         _fragment_ctx->cancel(status);

--- a/be/src/exec/pipeline/sink/file_sink_operator.cpp
+++ b/be/src/exec/pipeline/sink/file_sink_operator.cpp
@@ -127,7 +127,6 @@ void FileSinkIOBuffer::_add_chunk(const ChunkPtr& chunk) {
         _is_writer_opened = true;
     }
 
-
     if (Status status = _writer->append_chunk(chunk.get()); !status.ok()) {
         status = status.clone_and_prepend("add chunk to file writer failed, error");
         LOG(WARNING) << status;

--- a/be/src/exec/pipeline/sink/mysql_table_sink_operator.cpp
+++ b/be/src/exec/pipeline/sink/mysql_table_sink_operator.cpp
@@ -43,7 +43,7 @@ public:
     void close(RuntimeState* state) override;
 
 private:
-    void _process_chunk(bthread::TaskIterator<ChunkPtr>& iter) override;
+    void _add_chunk(const ChunkPtr& chunk) override;
 
     Status _open_mysql_table_writer();
 
@@ -78,23 +78,7 @@ void MysqlTableSinkIOBuffer::close(RuntimeState* state) {
     SinkIOBuffer::close(state);
 }
 
-void MysqlTableSinkIOBuffer::_process_chunk(bthread::TaskIterator<ChunkPtr>& iter) {
-    DeferOp op([&]() {
-        auto nc = _num_pending_chunks.fetch_sub(1);
-        DCHECK_GE(nc, 1L);
-    });
-
-    if (_is_finished) {
-        return;
-    }
-
-    if (_is_cancelled && !_is_finished) {
-        if (_num_pending_chunks == 1) {
-            close(_state);
-        }
-        return;
-    }
-
+void MysqlTableSinkIOBuffer::_add_chunk(const ChunkPtr& chunk) {
     if (_writer == nullptr) {
         if (Status status = _open_mysql_table_writer(); !status.ok()) {
             LOG(WARNING) << "open mysql table writer failed, error: " << status.to_string();
@@ -103,14 +87,6 @@ void MysqlTableSinkIOBuffer::_process_chunk(bthread::TaskIterator<ChunkPtr>& ite
         }
     }
 
-    const auto& chunk = *iter;
-    if (chunk == nullptr) {
-        // this is the last chunk
-        auto nc = _num_pending_chunks.load();
-        DCHECK_LE(nc, 1L);
-        close(_state);
-        return;
-    }
     if (Status status = _writer->append(chunk.get()); !status.ok()) {
         LOG(WARNING) << "add chunk to mysql table writer failed, error: " << status.to_string();
         _fragment_ctx->cancel(status);

--- a/be/src/exec/pipeline/sink/sink_io_buffer.cpp
+++ b/be/src/exec/pipeline/sink/sink_io_buffer.cpp
@@ -1,0 +1,44 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "exec/pipeline/sink/sink_io_buffer.h"
+
+namespace starrocks::pipeline {
+
+void SinkIOBuffer::_process_chunk(bthread::TaskIterator<ChunkPtr>& iter) {
+    DeferOp op([&]() {
+        --_num_pending_chunks;
+    });
+
+    if (_is_finished) {
+        return;
+    }
+
+    const auto& chunk = *iter;
+    if (chunk == nullptr) {
+        close(_state);
+        return;
+    }
+
+    if (_is_cancelled && !_is_finished) {
+        if (_num_pending_chunks <= 1) {
+            close(_state);
+        }
+        return;
+    }
+
+    _add_chunk(chunk);
+}
+
+} // namespace starrocks::pipeline

--- a/be/src/exec/pipeline/sink/sink_io_buffer.cpp
+++ b/be/src/exec/pipeline/sink/sink_io_buffer.cpp
@@ -30,9 +30,7 @@ void SinkIOBuffer::_process_chunk(bthread::TaskIterator<ChunkPtr>& iter) {
     }
 
     if (_is_cancelled) {
-        if (_num_pending_chunks <= 1) {
-            close(_state);
-        }
+        close(_state);
         return;
     }
 

--- a/be/src/exec/pipeline/sink/sink_io_buffer.cpp
+++ b/be/src/exec/pipeline/sink/sink_io_buffer.cpp
@@ -17,9 +17,7 @@
 namespace starrocks::pipeline {
 
 void SinkIOBuffer::_process_chunk(bthread::TaskIterator<ChunkPtr>& iter) {
-    DeferOp op([&]() {
-        --_num_pending_chunks;
-    });
+    DeferOp op([&]() { --_num_pending_chunks; });
 
     if (_is_finished) {
         return;

--- a/be/src/exec/pipeline/sink/sink_io_buffer.cpp
+++ b/be/src/exec/pipeline/sink/sink_io_buffer.cpp
@@ -29,7 +29,7 @@ void SinkIOBuffer::_process_chunk(bthread::TaskIterator<ChunkPtr>& iter) {
         return;
     }
 
-    if (_is_cancelled && !_is_finished) {
+    if (_is_cancelled) {
         if (_num_pending_chunks <= 1) {
             close(_state);
         }

--- a/be/src/exec/pipeline/sink/sink_io_buffer.h
+++ b/be/src/exec/pipeline/sink/sink_io_buffer.h
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#pragma once
+
 #include <memory>
 #include <shared_mutex>
 
@@ -124,8 +126,11 @@ public:
         return 0;
     }
 
+    int num_pending_chunks() const { return _num_pending_chunks; }
+
 protected:
-    virtual void _process_chunk(bthread::TaskIterator<ChunkPtr>& iter) = 0;
+    virtual void _process_chunk(bthread::TaskIterator<ChunkPtr>& iter);
+    virtual void _add_chunk(const ChunkPtr& chunk) = 0;
 
     std::unique_ptr<bthread::ExecutionQueueId<ChunkPtr>> _exec_queue_id;
 

--- a/be/src/runtime/runtime_state.h
+++ b/be/src/runtime/runtime_state.h
@@ -141,6 +141,9 @@ public:
     MemTracker* instance_mem_tracker() { return _instance_mem_tracker.get(); }
     MemPool* instance_mem_pool() { return _instance_mem_pool.get(); }
     std::shared_ptr<MemTracker> query_mem_tracker_ptr() { return _query_mem_tracker; }
+    void set_query_mem_tracker(const std::shared_ptr<MemTracker>& query_mem_tracker) {
+        _query_mem_tracker = query_mem_tracker;
+    }
     const std::shared_ptr<MemTracker>& query_mem_tracker_ptr() const { return _query_mem_tracker; }
     std::shared_ptr<MemTracker> instance_mem_tracker_ptr() { return _instance_mem_tracker; }
     RuntimeFilterPort* runtime_filter_port() { return _runtime_filter_port; }

--- a/be/test/exec/sink/sink_io_buffer_test.cpp
+++ b/be/test/exec/sink/sink_io_buffer_test.cpp
@@ -259,7 +259,7 @@ protected:
 
     static void poll_thread(void* arg1) {
         auto* buf = reinterpret_cast<MockSinkIOBuffer*>(arg1);
-        (void) buf->set_finishing();
+        (void)buf->set_finishing();
     }
 
     static void run_check(MockSinkIOBuffer& buf, const std::vector<Task>& task) {

--- a/be/test/exec/sink/sink_io_buffer_test.cpp
+++ b/be/test/exec/sink/sink_io_buffer_test.cpp
@@ -177,7 +177,7 @@ protected:
             return;
         }
 
-        if (_is_cancelled && !_is_finished) {
+        if (_is_cancelled) {
             set_and_wait_promise(chunk, BEFORE_CANCEL_CHECK_COUNTER);
             if (_num_pending_chunks <= 1) {
                 set_and_wait_promise(chunk, AFTER_CANCEL_CHECK_COUNTER);

--- a/be/test/exec/sink/sink_io_buffer_test.cpp
+++ b/be/test/exec/sink/sink_io_buffer_test.cpp
@@ -14,114 +14,609 @@
 
 #include "exec/pipeline/sink/sink_io_buffer.h"
 
-#include <gtest/gtest-param-test.h>
 #include <gtest/gtest.h>
 
 #include <future>
 #include <thread>
 
+#include "column/fixed_length_column.h"
 #include "testutil/assert.h"
 
 namespace starrocks::pipeline {
 
-// This is a mock test for synchronization between SinkIOBuffer and its underlying execution queue.
-// Query-related context (including SinkIOBuffer) would only be destroyed after SinkIOBuffer becomes finished.
-// Although we do not guarantee SinkIOBuffer outlives execution queue, we can still avoid use-after-free problem by
-// skipping stop task in consumer thread.
-
-namespace {
 class MockSinkIOBuffer : public SinkIOBuffer {
 public:
-    MockSinkIOBuffer(int num_sinkers) : SinkIOBuffer(num_sinkers) {}
+    enum PromiseType {
+        BEFORE_ADD_TO_QUEUE = 0,
+        BEFORE_ADD_COUNTER = 1,
+        AFTER_ADD_COUNTER = 2,
+        BEFORE_EXECUTE = 3,
+        BEFORE_CANCEL_CHECK_COUNTER = 4,
+        AFTER_CANCEL_CHECK_COUNTER = 5,
+        BEFORE_DEC_COUNTER = 6,
+        AFTER_DEC_COUNTER = 7,
+        END
+    };
+
+    enum ChunkType { FIRST_CHUNK = 0, SECOND_CHUNK = 1, CLOSE_CHUNK = 2 };
+
+    enum ControlType { ALL = 0, SET = 1, WAIT = 2 };
+
+    MockSinkIOBuffer(int num_sinkers) : SinkIOBuffer(num_sinkers) {
+        _first_chunk_wait_promises.resize(PromiseType::END);
+        _first_chunk_control_promises.resize(PromiseType::END);
+        _second_chunk_wait_promises.resize(PromiseType::END);
+        _second_chunk_control_promises.resize(PromiseType::END);
+        _close_chunk_wait_promises.resize(PromiseType::END);
+        _close_chunk_control_promises.resize(PromiseType::END);
+
+        for (int i = 0; i < PromiseType::END; i++) {
+            _first_chunk_wait_promises[i].second = _first_chunk_wait_promises[i].first.get_future();
+            _first_chunk_control_promises[i].second = _first_chunk_control_promises[i].first.get_future();
+            _second_chunk_wait_promises[i].second = _second_chunk_wait_promises[i].first.get_future();
+            _second_chunk_control_promises[i].second = _second_chunk_control_promises[i].first.get_future();
+            _close_chunk_wait_promises[i].second = _close_chunk_wait_promises[i].first.get_future();
+            _close_chunk_control_promises[i].second = _close_chunk_control_promises[i].first.get_future();
+        }
+
+        _value = std::make_unique<int>();
+    }
+
+    ~MockSinkIOBuffer() { _value.reset(); }
 
     static int execute_io_task(void* meta, bthread::TaskIterator<ChunkPtr>& iter) {
-        if (iter.is_queue_stopped()) {
-            _promise.get_future().wait();
-        }
-
-        if (iter.is_queue_stopped()) { // skip stop task
-            return 0;
-        }
-
-        auto* sink_io_buffer = static_cast<MockSinkIOBuffer*>(meta);
-        // calling dummy() causes use-after-free if we do not skip stop task
-        sink_io_buffer->dummy();
-        for (; iter; ++iter) {
-            sink_io_buffer->_process_chunk(iter);
-        }
-        return 0;
+        return SinkIOBuffer::execute_io_task(meta, iter);
     }
 
     Status prepare(RuntimeState* state, RuntimeProfile* parent_profile) override {
-        int ret =
-                bthread::execution_queue_start<ChunkPtr>(&_execq_id, nullptr, &MockSinkIOBuffer::execute_io_task, this);
-        _exec_queue_id = std::make_unique<bthread::ExecutionQueueId<ChunkPtr>>(_execq_id);
-        EXPECT_TRUE(ret == 0);
+        _state = state;
+        _exec_queue_id = std::make_unique<bthread::ExecutionQueueId<ChunkPtr>>();
+        int ret = bthread::execution_queue_start<ChunkPtr>(_exec_queue_id.get(), nullptr,
+                                                           &MockSinkIOBuffer::execute_io_task, this);
         if (ret != 0) {
-            return Status::InternalError("start execution queue error");
+            _exec_queue_id.reset();
+            return Status::InternalError("start execution queue failed");
         }
         return Status::OK();
     }
 
-    void _process_chunk(bthread::TaskIterator<ChunkPtr>& iter) override {
+    void _add_chunk(const ChunkPtr& chunk) override { dummy(); }
+
+    void set_and_wait_promise(const ChunkPtr& chunk, PromiseType type) {
+        if (chunk == nullptr) {
+            LOG(INFO) << "SET_AND_WAIT: " << (int)CLOSE_CHUNK << ":" << (int)type << std::endl;
+            _close_chunk_control_promises[type].first.set_value();
+            _close_chunk_wait_promises[type].second.get();
+        } else if (chunk->num_rows() == 1) {
+            LOG(INFO) << "SET_AND_WAIT: " << (int)FIRST_CHUNK << ":" << (int)type << std::endl;
+            _first_chunk_control_promises[type].first.set_value();
+            _first_chunk_wait_promises[type].second.get();
+        } else if (chunk->num_rows() == 2) {
+            LOG(INFO) << "SET_AND_WAIT: " << (int)SECOND_CHUNK << ":" << (int)type << std::endl;
+            _second_chunk_control_promises[type].first.set_value();
+            _second_chunk_wait_promises[type].second.get();
+        }
+    }
+
+    void set_wait_promise(ChunkType chunk_type, PromiseType type) {
+        LOG(INFO) << "SET: " << (int)chunk_type << ":" << (int)type << std::endl;
+        if (chunk_type == FIRST_CHUNK) {
+            _first_chunk_wait_promises[type].first.set_value();
+        } else if (chunk_type == SECOND_CHUNK) {
+            _second_chunk_wait_promises[type].first.set_value();
+        } else if (chunk_type == CLOSE_CHUNK) {
+            _close_chunk_wait_promises[type].first.set_value();
+        }
+    }
+
+    void wait_control_promise(ChunkType chunk_type, PromiseType type) {
+        LOG(INFO) << "WAIT: " << (int)chunk_type << ":" << (int)type << std::endl;
+        if (chunk_type == FIRST_CHUNK) {
+            _first_chunk_control_promises[type].second.wait();
+        } else if (chunk_type == SECOND_CHUNK) {
+            _second_chunk_control_promises[type].second.wait();
+        } else if (chunk_type == CLOSE_CHUNK) {
+            _close_chunk_control_promises[type].second.wait();
+        }
+    }
+
+    Status append_chunk(RuntimeState* state, const ChunkPtr& chunk) override {
+        if (Status status = get_io_status(); !status.ok()) {
+            return status;
+        }
+        set_and_wait_promise(chunk, BEFORE_ADD_TO_QUEUE);
+        if (bthread::execution_queue_execute(*_exec_queue_id, chunk) != 0) {
+            return Status::InternalError("submit io task failed");
+        }
+        set_and_wait_promise(chunk, BEFORE_ADD_COUNTER);
+        ++_num_pending_chunks;
+        set_and_wait_promise(chunk, AFTER_ADD_COUNTER);
+        return Status::OK();
+    }
+
+    ALWAYS_NOINLINE void dummy() { *_value = 10; }
+
+    Status set_finishing() override {
+        if (--_num_result_sinkers == 0) {
+            // when all writes are over, we add a nullptr as a special mark to trigger close
+            if (_is_finishing_failed) {
+                return Status::InternalError("set finishing failed");
+            } else {
+                set_and_wait_promise(nullptr, BEFORE_ADD_TO_QUEUE);
+                int v = bthread::execution_queue_execute(*_exec_queue_id, nullptr);
+                if (v != 0) {
+                    return Status::InternalError("submit task failed");
+                }
+                set_and_wait_promise(nullptr, BEFORE_ADD_COUNTER);
+                ++_num_pending_chunks;
+                set_and_wait_promise(nullptr, AFTER_ADD_COUNTER);
+            }
+        }
+        return Status::OK();
+    }
+
+    void set_is_finishing_failed(bool is_finishing_failed) { _is_finishing_failed = is_finishing_failed; }
+
+protected:
+    virtual void _process_chunk(bthread::TaskIterator<ChunkPtr>& iter) override {
         DeferOp op([&]() {
-            --_num_pending_chunks;
-            DCHECK(_num_pending_chunks >= 0);
+            set_and_wait_promise(*iter, BEFORE_DEC_COUNTER);
+            _num_pending_chunks--;
+            set_and_wait_promise(*iter, AFTER_DEC_COUNTER);
         });
 
-        // close is already done, just skip
-        if (_is_finished) {
-            return;
-        }
+        set_and_wait_promise(*iter, BEFORE_EXECUTE);
 
-        // cancelling has happened but close is not invoked
-        if (_is_cancelled && !_is_finished) {
-            if (_num_pending_chunks == 1) {
-                close(_state);
-            }
+        if (_is_finished) {
             return;
         }
 
         const auto& chunk = *iter;
         if (chunk == nullptr) {
-            // this is the last chunk
-            EXPECT_EQ(_num_pending_chunks, 1);
             close(_state);
             return;
         }
 
-        // handle this chunk
-        std::this_thread::sleep_for(std::chrono::milliseconds(10));
+        if (_is_cancelled && !_is_finished) {
+            set_and_wait_promise(chunk, BEFORE_CANCEL_CHECK_COUNTER);
+            if (_num_pending_chunks <= 1) {
+                set_and_wait_promise(chunk, AFTER_CANCEL_CHECK_COUNTER);
+                close(_state);
+            }
+            return;
+        }
+
+        _add_chunk(chunk);
     }
-
-    ALWAYS_NOINLINE void dummy() { std::cout << _num_pending_chunks << std::endl; }
-
-    static void set_promise_value() { _promise.set_value(); }
 
 private:
-    bthread::ExecutionQueueId<ChunkPtr> _execq_id;
-    static std::promise<void> _promise;
+    std::vector<std::pair<std::promise<void>, std::future<void>>> _first_chunk_wait_promises;
+    std::vector<std::pair<std::promise<void>, std::future<void>>> _first_chunk_control_promises;
+
+    std::vector<std::pair<std::promise<void>, std::future<void>>> _second_chunk_wait_promises;
+    std::vector<std::pair<std::promise<void>, std::future<void>>> _second_chunk_control_promises;
+
+    std::vector<std::pair<std::promise<void>, std::future<void>>> _close_chunk_wait_promises;
+    std::vector<std::pair<std::promise<void>, std::future<void>>> _close_chunk_control_promises;
+
+    std::promise<void> _finishing_promise;
+    std::promise<void> _before_cancel_promise;
+
+    std::unique_ptr<int> _value;
+    bool _is_finishing_failed = false;
 };
 
-std::promise<void> MockSinkIOBuffer::_promise;
+class MockSinkIOBuffer2 : public SinkIOBuffer {
+public:
+    MockSinkIOBuffer2(int num_sinkers) : SinkIOBuffer(num_sinkers) { _value = std::make_unique<int>(); }
 
-TEST(SinkIOBufferTest, test_basic) {
-    auto sink_buffer = std::make_unique<MockSinkIOBuffer>(10);
-    {
-        ASSERT_OK(sink_buffer->prepare(nullptr, nullptr));
+    Status prepare(RuntimeState* state, RuntimeProfile* parent_profile) override {
+        _state = state;
+        _exec_queue_id = std::make_unique<bthread::ExecutionQueueId<ChunkPtr>>();
+        int ret = bthread::execution_queue_start<ChunkPtr>(_exec_queue_id.get(), nullptr,
+                                                           &MockSinkIOBuffer::execute_io_task, this);
+        if (ret != 0) {
+            _exec_queue_id.reset();
+            return Status::InternalError("start execution queue failed");
+        }
+        return Status::OK();
+    }
 
-        auto chunk = std::make_shared<Chunk>();
-        ASSERT_OK(sink_buffer->append_chunk(nullptr, chunk));
-        ASSERT_OK(sink_buffer->append_chunk(nullptr, chunk));
-        ASSERT_OK(sink_buffer->append_chunk(nullptr, nullptr)); // append close marker
+    void _add_chunk(const ChunkPtr& chunk) override { dummy(); }
 
-        // wait until consumer thread finished all non-stop tasks
-        while (!sink_buffer->is_finished()) {
-            std::this_thread::sleep_for(std::chrono::milliseconds(10));
+    ALWAYS_NOINLINE void dummy() { *_value = 10; }
+
+private:
+    std::unique_ptr<int> _value;
+};
+
+using ControlType = MockSinkIOBuffer::ControlType;
+using PromiseType = MockSinkIOBuffer::PromiseType;
+using ChunkType = MockSinkIOBuffer::ChunkType;
+
+class SinkIOBufferTest : public testing::Test {
+protected:
+    struct Task {
+        ControlType control_type;
+        ChunkType chunk_type;
+        PromiseType promise_type;
+    };
+
+    SinkIOBufferTest() = default;
+
+    void SetUp() override {}
+
+    static void operator_thread(void* arg1, void* arg2) {
+        auto* buf = reinterpret_cast<MockSinkIOBuffer*>(arg1);
+        auto* runtime_state = reinterpret_cast<RuntimeState*>(arg2);
+
+        auto first_chunk = gen_test_chunk(1);
+        ASSERT_OK(buf->append_chunk(runtime_state, first_chunk));
+
+        auto second_chunk = gen_test_chunk(2);
+        ASSERT_OK(buf->append_chunk(runtime_state, second_chunk));
+    }
+
+    static void poll_thread(void* arg1) {
+        auto* buf = reinterpret_cast<MockSinkIOBuffer*>(arg1);
+        (void) buf->set_finishing();
+    }
+
+    static void run_check(MockSinkIOBuffer& buf, const std::vector<Task>& task) {
+        for (size_t i = 0; i < task.size(); i++) {
+            if (task[i].control_type == ControlType::WAIT) {
+                buf.wait_control_promise(task[i].chunk_type, task[i].promise_type);
+            } else if (task[i].control_type == ControlType::SET) {
+                buf.set_wait_promise(task[i].chunk_type, task[i].promise_type);
+            } else {
+                buf.wait_control_promise(task[i].chunk_type, task[i].promise_type);
+                buf.set_wait_promise(task[i].chunk_type, task[i].promise_type);
+            }
         }
     }
-    MockSinkIOBuffer::set_promise_value();
+
+protected:
+    static ChunkPtr gen_test_chunk(int value);
+    static std::shared_ptr<RuntimeState> gen_test_runtime_state();
+};
+
+ChunkPtr SinkIOBufferTest::gen_test_chunk(int value) {
+    auto col = Int32Column::create();
+    col->resize(value);
+    auto chunk = std::make_shared<Chunk>();
+    chunk->append_column(col, 1);
+    return chunk;
 }
-} // namespace
+
+std::shared_ptr<RuntimeState> SinkIOBufferTest::gen_test_runtime_state() {
+    auto runtime_state = std::make_shared<RuntimeState>();
+    auto mem_tracker = std::make_shared<MemTracker>();
+    runtime_state->set_query_mem_tracker(mem_tracker);
+    return runtime_state;
+}
+
+// Execute sequentially one by one
+TEST_F(SinkIOBufferTest, test_basic_1) {
+    auto runtime_state = gen_test_runtime_state();
+    auto sink_buffer = std::make_unique<MockSinkIOBuffer>(1);
+    ASSERT_OK(sink_buffer->prepare(runtime_state.get(), nullptr));
+
+    std::thread thread1(operator_thread, sink_buffer.get(), runtime_state.get());
+    std::vector<Task> tasks1 = {
+            // Append first chunk and wait
+            {ControlType::ALL, ChunkType::FIRST_CHUNK, PromiseType::BEFORE_ADD_TO_QUEUE},
+            {ControlType::ALL, ChunkType::FIRST_CHUNK, PromiseType::BEFORE_ADD_COUNTER},
+            {ControlType::ALL, ChunkType::FIRST_CHUNK, PromiseType::AFTER_ADD_COUNTER},
+            {ControlType::ALL, ChunkType::FIRST_CHUNK, PromiseType::BEFORE_EXECUTE},
+            {ControlType::ALL, ChunkType::FIRST_CHUNK, PromiseType::BEFORE_DEC_COUNTER},
+            {ControlType::ALL, ChunkType::FIRST_CHUNK, PromiseType::AFTER_DEC_COUNTER},
+
+            // Append second chunk and wait
+            {ControlType::ALL, ChunkType::SECOND_CHUNK, PromiseType::BEFORE_ADD_TO_QUEUE},
+            {ControlType::ALL, ChunkType::SECOND_CHUNK, PromiseType::BEFORE_ADD_COUNTER},
+            {ControlType::ALL, ChunkType::SECOND_CHUNK, PromiseType::AFTER_ADD_COUNTER},
+            {ControlType::ALL, ChunkType::SECOND_CHUNK, PromiseType::BEFORE_EXECUTE},
+            {ControlType::ALL, ChunkType::SECOND_CHUNK, PromiseType::BEFORE_DEC_COUNTER},
+            {ControlType::ALL, ChunkType::SECOND_CHUNK, PromiseType::AFTER_DEC_COUNTER},
+    };
+    run_check(*sink_buffer, tasks1);
+
+    std::thread thread2(poll_thread, sink_buffer.get());
+    std::vector<Task> tasks2 = {
+            // Append close chunk
+            {ControlType::ALL, ChunkType::CLOSE_CHUNK, PromiseType::BEFORE_ADD_TO_QUEUE},
+            {ControlType::ALL, ChunkType::CLOSE_CHUNK, PromiseType::BEFORE_ADD_COUNTER},
+            {ControlType::ALL, ChunkType::CLOSE_CHUNK, PromiseType::AFTER_ADD_COUNTER},
+            {ControlType::ALL, ChunkType::CLOSE_CHUNK, PromiseType::BEFORE_EXECUTE},
+            {ControlType::ALL, ChunkType::CLOSE_CHUNK, PromiseType::BEFORE_DEC_COUNTER},
+            {ControlType::ALL, ChunkType::CLOSE_CHUNK, PromiseType::AFTER_DEC_COUNTER},
+    };
+    run_check(*sink_buffer, tasks2);
+
+    thread1.join();
+    thread2.join();
+    ASSERT_TRUE(sink_buffer->is_finished());
+
+    sink_buffer.reset();
+}
+
+// Add all and run
+TEST_F(SinkIOBufferTest, test_basic_2) {
+    auto runtime_state = gen_test_runtime_state();
+    auto sink_buffer = std::make_unique<MockSinkIOBuffer>(1);
+    ASSERT_OK(sink_buffer->prepare(runtime_state.get(), nullptr));
+
+    std::thread thread1(operator_thread, sink_buffer.get(), runtime_state.get());
+    std::vector<Task> tasks1 = {
+            // Append first chunk
+            {ControlType::ALL, ChunkType::FIRST_CHUNK, PromiseType::BEFORE_ADD_TO_QUEUE},
+            {ControlType::ALL, ChunkType::FIRST_CHUNK, PromiseType::BEFORE_ADD_COUNTER},
+            {ControlType::ALL, ChunkType::FIRST_CHUNK, PromiseType::AFTER_ADD_COUNTER},
+
+            // Append second chunk
+            {ControlType::ALL, ChunkType::SECOND_CHUNK, PromiseType::BEFORE_ADD_TO_QUEUE},
+            {ControlType::ALL, ChunkType::SECOND_CHUNK, PromiseType::BEFORE_ADD_COUNTER},
+            {ControlType::ALL, ChunkType::SECOND_CHUNK, PromiseType::AFTER_ADD_COUNTER},
+    };
+    run_check(*sink_buffer, tasks1);
+
+    std::thread thread2(poll_thread, sink_buffer.get());
+    std::vector<Task> tasks2 = {
+            {ControlType::ALL, ChunkType::CLOSE_CHUNK, PromiseType::BEFORE_ADD_TO_QUEUE},
+            {ControlType::ALL, ChunkType::CLOSE_CHUNK, PromiseType::BEFORE_ADD_COUNTER},
+            {ControlType::ALL, ChunkType::CLOSE_CHUNK, PromiseType::AFTER_ADD_COUNTER},
+    };
+    run_check(*sink_buffer, tasks2);
+
+    std::vector<Task> tasks3 = {
+            // Append close chunk
+            {ControlType::ALL, ChunkType::FIRST_CHUNK, PromiseType::BEFORE_EXECUTE},
+            {ControlType::ALL, ChunkType::FIRST_CHUNK, PromiseType::BEFORE_DEC_COUNTER},
+            {ControlType::ALL, ChunkType::FIRST_CHUNK, PromiseType::AFTER_DEC_COUNTER},
+
+            {ControlType::ALL, ChunkType::SECOND_CHUNK, PromiseType::BEFORE_EXECUTE},
+            {ControlType::ALL, ChunkType::SECOND_CHUNK, PromiseType::BEFORE_DEC_COUNTER},
+            {ControlType::ALL, ChunkType::SECOND_CHUNK, PromiseType::AFTER_DEC_COUNTER},
+
+            {ControlType::ALL, ChunkType::CLOSE_CHUNK, PromiseType::BEFORE_EXECUTE},
+            {ControlType::ALL, ChunkType::CLOSE_CHUNK, PromiseType::BEFORE_DEC_COUNTER},
+            {ControlType::ALL, ChunkType::CLOSE_CHUNK, PromiseType::AFTER_DEC_COUNTER},
+    };
+    run_check(*sink_buffer, tasks3);
+
+    thread1.join();
+    thread2.join();
+    ASSERT_TRUE(sink_buffer->is_finished());
+
+    sink_buffer.reset();
+}
+
+// Cancel when there is no task
+TEST_F(SinkIOBufferTest, test_cancel_1) {
+    auto runtime_state = gen_test_runtime_state();
+    auto sink_buffer = std::make_unique<MockSinkIOBuffer>(1);
+    ASSERT_OK(sink_buffer->prepare(runtime_state.get(), nullptr));
+
+    std::thread thread1(operator_thread, sink_buffer.get(), runtime_state.get());
+    std::vector<Task> tasks1 = {
+            // Append first chunk and wait
+            {ControlType::ALL, ChunkType::FIRST_CHUNK, PromiseType::BEFORE_ADD_TO_QUEUE},
+            {ControlType::ALL, ChunkType::FIRST_CHUNK, PromiseType::BEFORE_ADD_COUNTER},
+            {ControlType::ALL, ChunkType::FIRST_CHUNK, PromiseType::AFTER_ADD_COUNTER},
+            {ControlType::ALL, ChunkType::FIRST_CHUNK, PromiseType::BEFORE_EXECUTE},
+            {ControlType::ALL, ChunkType::FIRST_CHUNK, PromiseType::BEFORE_DEC_COUNTER},
+            {ControlType::ALL, ChunkType::FIRST_CHUNK, PromiseType::AFTER_DEC_COUNTER},
+
+            // Append second chunk and wait
+            {ControlType::ALL, ChunkType::SECOND_CHUNK, PromiseType::BEFORE_ADD_TO_QUEUE},
+            {ControlType::ALL, ChunkType::SECOND_CHUNK, PromiseType::BEFORE_ADD_COUNTER},
+            {ControlType::ALL, ChunkType::SECOND_CHUNK, PromiseType::AFTER_ADD_COUNTER},
+            {ControlType::ALL, ChunkType::SECOND_CHUNK, PromiseType::BEFORE_EXECUTE},
+            {ControlType::ALL, ChunkType::SECOND_CHUNK, PromiseType::BEFORE_DEC_COUNTER},
+            {ControlType::ALL, ChunkType::SECOND_CHUNK, PromiseType::AFTER_DEC_COUNTER},
+    };
+    run_check(*sink_buffer, tasks1);
+
+    sink_buffer->cancel_one_sinker();
+    std::thread thread2(poll_thread, sink_buffer.get());
+    std::vector<Task> tasks2 = {
+            // Append close chunk
+            {ControlType::ALL, ChunkType::CLOSE_CHUNK, PromiseType::BEFORE_ADD_TO_QUEUE},
+            {ControlType::ALL, ChunkType::CLOSE_CHUNK, PromiseType::BEFORE_ADD_COUNTER},
+            {ControlType::ALL, ChunkType::CLOSE_CHUNK, PromiseType::AFTER_ADD_COUNTER},
+            {ControlType::ALL, ChunkType::CLOSE_CHUNK, PromiseType::BEFORE_EXECUTE},
+            {ControlType::ALL, ChunkType::CLOSE_CHUNK, PromiseType::BEFORE_DEC_COUNTER},
+            {ControlType::ALL, ChunkType::CLOSE_CHUNK, PromiseType::AFTER_DEC_COUNTER},
+    };
+    run_check(*sink_buffer, tasks2);
+
+    thread1.join();
+    thread2.join();
+    ASSERT_TRUE(sink_buffer->is_finished());
+
+    sink_buffer.reset();
+}
+
+// Cancel (_num_pending_chunks = 0)
+TEST_F(SinkIOBufferTest, test_cancel_2) {
+    auto runtime_state = gen_test_runtime_state();
+    auto sink_buffer = std::make_unique<MockSinkIOBuffer>(1);
+    ASSERT_OK(sink_buffer->prepare(runtime_state.get(), nullptr));
+
+    std::thread thread1(operator_thread, sink_buffer.get(), runtime_state.get());
+    std::vector<Task> tasks1 = {
+            // Append first chunk and wait
+            {ControlType::ALL, ChunkType::FIRST_CHUNK, PromiseType::BEFORE_ADD_TO_QUEUE},
+            {ControlType::ALL, ChunkType::FIRST_CHUNK, PromiseType::BEFORE_ADD_COUNTER},
+            {ControlType::ALL, ChunkType::FIRST_CHUNK, PromiseType::AFTER_ADD_COUNTER},
+            {ControlType::ALL, ChunkType::FIRST_CHUNK, PromiseType::BEFORE_EXECUTE},
+            {ControlType::ALL, ChunkType::FIRST_CHUNK, PromiseType::BEFORE_DEC_COUNTER},
+            {ControlType::ALL, ChunkType::FIRST_CHUNK, PromiseType::AFTER_DEC_COUNTER},
+
+            // Append second chunk and wait
+            {ControlType::ALL, ChunkType::SECOND_CHUNK, PromiseType::BEFORE_ADD_TO_QUEUE},
+            {ControlType::WAIT, ChunkType::SECOND_CHUNK, PromiseType::BEFORE_ADD_COUNTER},
+    };
+    run_check(*sink_buffer, tasks1);
+
+    sink_buffer->cancel_one_sinker();
+
+    std::vector<Task> tasks2 = {
+            {ControlType::ALL, ChunkType::SECOND_CHUNK, PromiseType::BEFORE_EXECUTE},
+            {ControlType::WAIT, ChunkType::SECOND_CHUNK, PromiseType::BEFORE_CANCEL_CHECK_COUNTER},
+    };
+    run_check(*sink_buffer, tasks2);
+    ASSERT_EQ(sink_buffer->num_pending_chunks(), 0);
+
+    std::thread thread2(poll_thread, sink_buffer.get());
+
+    std::vector<Task> tasks3 = {
+            {ControlType::SET, ChunkType::SECOND_CHUNK, PromiseType::BEFORE_CANCEL_CHECK_COUNTER},
+            {ControlType::ALL, ChunkType::SECOND_CHUNK, PromiseType::AFTER_CANCEL_CHECK_COUNTER},
+            {ControlType::ALL, ChunkType::SECOND_CHUNK, PromiseType::BEFORE_DEC_COUNTER},
+            {ControlType::ALL, ChunkType::SECOND_CHUNK, PromiseType::AFTER_DEC_COUNTER},
+            {ControlType::SET, ChunkType::SECOND_CHUNK, PromiseType::BEFORE_ADD_COUNTER},
+            {ControlType::ALL, ChunkType::SECOND_CHUNK, PromiseType::AFTER_ADD_COUNTER},
+
+            {ControlType::ALL, ChunkType::CLOSE_CHUNK, PromiseType::BEFORE_ADD_TO_QUEUE},
+    };
+    run_check(*sink_buffer, tasks3);
+
+    thread1.join();
+    thread2.join();
+    ASSERT_TRUE(sink_buffer->is_finished());
+
+    sink_buffer.reset();
+}
+
+// Cancel (_num_pending_chunks = 2)
+TEST_F(SinkIOBufferTest, test_cancel_3) {
+    auto runtime_state = gen_test_runtime_state();
+    auto sink_buffer = std::make_unique<MockSinkIOBuffer>(1);
+    ASSERT_OK(sink_buffer->prepare(runtime_state.get(), nullptr));
+
+    std::thread thread1(operator_thread, sink_buffer.get(), runtime_state.get());
+    std::vector<Task> tasks1 = {
+            // Append first chunk and wait
+            {ControlType::ALL, ChunkType::FIRST_CHUNK, PromiseType::BEFORE_ADD_TO_QUEUE},
+            {ControlType::ALL, ChunkType::FIRST_CHUNK, PromiseType::BEFORE_ADD_COUNTER},
+            {ControlType::ALL, ChunkType::FIRST_CHUNK, PromiseType::AFTER_ADD_COUNTER},
+            {ControlType::ALL, ChunkType::FIRST_CHUNK, PromiseType::BEFORE_EXECUTE},
+            {ControlType::ALL, ChunkType::FIRST_CHUNK, PromiseType::BEFORE_DEC_COUNTER},
+            {ControlType::ALL, ChunkType::FIRST_CHUNK, PromiseType::AFTER_DEC_COUNTER},
+
+            // Append second chunk and wait
+            {ControlType::ALL, ChunkType::SECOND_CHUNK, PromiseType::BEFORE_ADD_TO_QUEUE},
+            {ControlType::ALL, ChunkType::SECOND_CHUNK, PromiseType::BEFORE_ADD_COUNTER},
+            {ControlType::ALL, ChunkType::SECOND_CHUNK, PromiseType::AFTER_ADD_COUNTER},
+            {ControlType::WAIT, ChunkType::SECOND_CHUNK, PromiseType::BEFORE_EXECUTE},
+    };
+    run_check(*sink_buffer, tasks1);
+
+    sink_buffer->cancel_one_sinker();
+
+    std::vector<Task> tasks2 = {
+            {ControlType::SET, ChunkType::SECOND_CHUNK, PromiseType::BEFORE_EXECUTE},
+            {ControlType::WAIT, ChunkType::SECOND_CHUNK, PromiseType::BEFORE_CANCEL_CHECK_COUNTER},
+    };
+    run_check(*sink_buffer, tasks2);
+
+    std::thread thread2(poll_thread, sink_buffer.get());
+    std::vector<Task> tasks3 = {
+            {ControlType::ALL, ChunkType::CLOSE_CHUNK, PromiseType::BEFORE_ADD_TO_QUEUE},
+            {ControlType::ALL, ChunkType::CLOSE_CHUNK, PromiseType::BEFORE_ADD_COUNTER},
+            {ControlType::ALL, ChunkType::CLOSE_CHUNK, PromiseType::AFTER_ADD_COUNTER},
+    };
+    run_check(*sink_buffer, tasks3);
+
+    ASSERT_EQ(sink_buffer->num_pending_chunks(), 2);
+
+    std::vector<Task> tasks4 = {
+            {ControlType::SET, ChunkType::SECOND_CHUNK, PromiseType::BEFORE_CANCEL_CHECK_COUNTER},
+            {ControlType::ALL, ChunkType::SECOND_CHUNK, PromiseType::BEFORE_DEC_COUNTER},
+            {ControlType::ALL, ChunkType::SECOND_CHUNK, PromiseType::AFTER_DEC_COUNTER},
+
+            {ControlType::ALL, ChunkType::CLOSE_CHUNK, PromiseType::BEFORE_EXECUTE},
+            {ControlType::ALL, ChunkType::CLOSE_CHUNK, PromiseType::BEFORE_DEC_COUNTER},
+            {ControlType::ALL, ChunkType::CLOSE_CHUNK, PromiseType::AFTER_DEC_COUNTER},
+    };
+    run_check(*sink_buffer, tasks4);
+
+    thread1.join();
+    thread2.join();
+    ASSERT_TRUE(sink_buffer->is_finished());
+
+    sink_buffer.reset();
+}
+
+TEST_F(SinkIOBufferTest, test_push_close_to_execute_queue_failed) {
+    auto runtime_state = gen_test_runtime_state();
+    auto sink_buffer = std::make_unique<MockSinkIOBuffer>(1);
+    sink_buffer->set_is_finishing_failed(true);
+    ASSERT_OK(sink_buffer->prepare(runtime_state.get(), nullptr));
+
+    std::thread thread1(operator_thread, sink_buffer.get(), runtime_state.get());
+    std::vector<Task> tasks1 = {
+            // Append first chunk
+            {ControlType::ALL, ChunkType::FIRST_CHUNK, PromiseType::BEFORE_ADD_TO_QUEUE},
+            {ControlType::ALL, ChunkType::FIRST_CHUNK, PromiseType::BEFORE_ADD_COUNTER},
+            {ControlType::ALL, ChunkType::FIRST_CHUNK, PromiseType::AFTER_ADD_COUNTER},
+
+            // Append second chunk
+            {ControlType::ALL, ChunkType::SECOND_CHUNK, PromiseType::BEFORE_ADD_TO_QUEUE},
+            {ControlType::ALL, ChunkType::SECOND_CHUNK, PromiseType::BEFORE_ADD_COUNTER},
+            {ControlType::ALL, ChunkType::SECOND_CHUNK, PromiseType::AFTER_ADD_COUNTER},
+    };
+    run_check(*sink_buffer, tasks1);
+
+    sink_buffer->cancel_one_sinker();
+
+    std::thread thread2(poll_thread, sink_buffer.get());
+
+    std::vector<Task> tasks3 = {
+            {ControlType::ALL, ChunkType::FIRST_CHUNK, PromiseType::BEFORE_EXECUTE},
+            {ControlType::ALL, ChunkType::FIRST_CHUNK, PromiseType::BEFORE_CANCEL_CHECK_COUNTER},
+            {ControlType::ALL, ChunkType::FIRST_CHUNK, PromiseType::BEFORE_DEC_COUNTER},
+            {ControlType::ALL, ChunkType::FIRST_CHUNK, PromiseType::AFTER_DEC_COUNTER},
+
+            {ControlType::ALL, ChunkType::SECOND_CHUNK, PromiseType::BEFORE_EXECUTE},
+            {ControlType::ALL, ChunkType::SECOND_CHUNK, PromiseType::BEFORE_CANCEL_CHECK_COUNTER},
+            {ControlType::ALL, ChunkType::SECOND_CHUNK, PromiseType::AFTER_CANCEL_CHECK_COUNTER},
+            {ControlType::ALL, ChunkType::SECOND_CHUNK, PromiseType::BEFORE_DEC_COUNTER},
+            {ControlType::ALL, ChunkType::SECOND_CHUNK, PromiseType::AFTER_DEC_COUNTER},
+    };
+    run_check(*sink_buffer, tasks3);
+
+    thread1.join();
+    thread2.join();
+    ASSERT_TRUE(sink_buffer->is_finished());
+
+    sink_buffer.reset();
+}
+
+TEST_F(SinkIOBufferTest, test_base_class) {
+    auto runtime_state = gen_test_runtime_state();
+    auto sink_buffer = std::make_unique<MockSinkIOBuffer2>(1);
+    ASSERT_OK(sink_buffer->prepare(runtime_state.get(), nullptr));
+
+    auto first_chunk = gen_test_chunk(1);
+    ASSERT_OK(sink_buffer->append_chunk(runtime_state.get(), first_chunk));
+
+    auto second_chunk = gen_test_chunk(2);
+    ASSERT_OK(sink_buffer->append_chunk(runtime_state.get(), second_chunk));
+
+    ASSERT_OK(sink_buffer->set_finishing());
+
+    int i = 0;
+    while (!sink_buffer->is_finished()) {
+        usleep(10000);
+        i++;
+        if (i > 1000) {
+            ASSERT_FALSE(true);
+        }
+    }
+
+    sink_buffer.reset();
+}
 
 } // namespace starrocks::pipeline


### PR DESCRIPTION
## Why I'm doing:

If `_cancelled` is true and io queue is executing the last data chunk, the `_pending_num_tasks` maybe 0/1/2. So the subsequent sentinel requests cannot be executed either.

0: The io task is already pushed to queue and run, but _pending_num_tasks is not +1 now.
2: The sentinel request is pushed back to queue, and ++_pending_num_tasks.

## What I'm doing:

* Extract public code and put it into SinkIOBuffer
* Add a SinkIOBuffer test framework
* Move sentinel request before cancel check.
* Rmove the dcheck of _pending_num_tasks.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [x] 3.1
  - [x] 3.0
  - [x] 2.5
