### PR TITLE
[BugFix] remove invalid `quantile="avg"` prometheus metric output

### DIFF
--- a/be/src/http/action/metrics_action.cpp
+++ b/be/src/http/action/metrics_action.cpp
@@ -238,7 +238,6 @@ bool PrometheusMetricsVisitor::_dump_latency_recorder_suffix(const butil::String
         << si->metric_name << "{quantile=\"0.999\"} " << si->latency_percentiles[3] << '\n'
         << si->metric_name << "{quantile=\"0.9999\"} " << si->latency_percentiles[4] << '\n'
         << si->metric_name << "{quantile=\"1\"} " << si->latency_percentiles[5] << '\n'
-        << si->metric_name << "{quantile=\"avg\"} " << si->latency_avg << '\n'
         << si->metric_name
         << "_sum "
         // There is no sum of latency in bvar output, just use


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:

Fixes #40611

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [x] 3.1
  - [x] 3.0
  - [ ] 2.5
