### PR TITLE
[BugFix] Fix dict_mapping problems (#40897)

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/alter/SchemaChangeJobV2.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/SchemaChangeJobV2.java
@@ -78,6 +78,7 @@ import com.starrocks.common.util.concurrent.lock.Locker;
 import com.starrocks.journal.JournalTask;
 import com.starrocks.persist.EditLog;
 import com.starrocks.persist.gson.GsonUtils;
+import com.starrocks.privilege.PrivilegeBuiltinConstants;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.sql.analyzer.AnalyzeState;
@@ -87,6 +88,7 @@ import com.starrocks.sql.analyzer.RelationFields;
 import com.starrocks.sql.analyzer.RelationId;
 import com.starrocks.sql.analyzer.Scope;
 import com.starrocks.sql.analyzer.SelectAnalyzer.RewriteAliasVisitor;
+import com.starrocks.sql.ast.UserIdentity;
 import com.starrocks.sql.optimizer.statistics.IDictManager;
 import com.starrocks.task.AgentBatchTask;
 import com.starrocks.task.AgentTask;
@@ -597,14 +599,23 @@ public class SchemaChangeJobV2 extends AlterJobV2 {
                                                     new Field(col.getName(), col.getType(), tableName, null))
                                             .collect(Collectors.toList())));
 
+                            if (ConnectContext.get() == null) {
+                                ConnectContext context = new ConnectContext();
+                                context.setGlobalStateMgr(GlobalStateMgr.getCurrentState());
+                                context.setCurrentUserIdentity(UserIdentity.ROOT);
+                                context.setCurrentRoleIds(Sets.newHashSet(PrivilegeBuiltinConstants.ROOT_ROLE_ID));
+                                context.setQualifiedUser(UserIdentity.ROOT.getUser());
+                                context.setThreadLocalInfo();
+                            }
+                            ConnectContext.get().setDatabase(db.getFullName());
+
                             RewriteAliasVisitor visitor =
-                                    new RewriteAliasVisitor(sourceScope, outputScope,
-                                            outputExprs, ConnectContext.get());
+                                    new RewriteAliasVisitor(sourceScope, outputScope, outputExprs, ConnectContext.get());
 
                             ExpressionAnalyzer.analyzeExpression(expr, new AnalyzeState(), new Scope(RelationId.anonymous(),
                                             new RelationFields(tbl.getBaseSchema().stream().map(col -> new Field(col.getName(),
                                                     col.getType(), tableName, null)).collect(Collectors.toList()))),
-                                    ConnectContext.get());
+                                            ConnectContext.get());
 
                             Expr generatedColumnExpr = expr.accept(visitor, null);
 

--- a/fe/fe-core/src/main/java/com/starrocks/analysis/DictQueryExpr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/analysis/DictQueryExpr.java
@@ -30,6 +30,7 @@ import java.util.List;
 public class DictQueryExpr extends FunctionCallExpr {
 
     private TDictQueryExpr dictQueryExpr;
+    private String dbName;
 
     public DictQueryExpr(List<Expr> params) throws SemanticException {
         super(FunctionSet.DICT_MAPPING, params);
@@ -45,8 +46,8 @@ public class DictQueryExpr extends FunctionCallExpr {
     protected DictQueryExpr(DictQueryExpr other) {
         super(other);
         this.dictQueryExpr = other.getDictQueryExpr();
+        this.dbName = other.getDbName();
     }
-
 
     @Override
     protected void toThrift(TExprNode msg) {
@@ -75,5 +76,13 @@ public class DictQueryExpr extends FunctionCallExpr {
 
     public void setDictQueryExpr(TDictQueryExpr dictQueryExpr) {
         this.dictQueryExpr = dictQueryExpr;
+    }
+
+    public void setDbName(String dbName) {
+        this.dbName = dbName;
+    }
+
+    public String getDbName() {
+        return this.dbName;
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/load/Load.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/Load.java
@@ -264,7 +264,6 @@ public class Load {
         List<DictQueryExpr> result = Lists.newArrayList();
         checkExpr.collect(DictQueryExpr.class, result);
         for (DictQueryExpr expr : result) {
-            LOG.info("set dictquery dbname");
             expr.setDbName(dbName);
         }
         return result.size() != 0;

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/CreateTableAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/CreateTableAnalyzer.java
@@ -484,6 +484,9 @@ public class CreateTableAnalyzer {
                     if (slots.size() != 0) {
                         for (SlotRef slot : slots) {
                             Column refColumn = columnsMap.get(slot.getColumnName());
+                            if (refColumn == null) {
+                                throw new SemanticException("column:" + slot.getColumnName() + " does not existed");
+                            }
                             if (refColumn.isGeneratedColumn()) {
                                 throw new SemanticException("Expression can not refers to other generated columns");
                             }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/scalar/DictQueryOperator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/scalar/DictQueryOperator.java
@@ -27,8 +27,9 @@ public class DictQueryOperator extends CallOperator {
     private final TDictQueryExpr dictQueryExpr;
     private final Function fn;
 
-    public DictQueryOperator(List<ScalarOperator> arguments, TDictQueryExpr dictQueryExpr, Function fn) {
-        super(FunctionSet.DICT_MAPPING, Type.BIGINT, arguments);
+    public DictQueryOperator(List<ScalarOperator> arguments, TDictQueryExpr dictQueryExpr, Function fn,
+                             Type type) {
+        super(FunctionSet.DICT_MAPPING, type, arguments);
         this.dictQueryExpr = dictQueryExpr;
         this.fn = fn;
     }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/transformer/SqlToScalarOperatorTranslator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/transformer/SqlToScalarOperatorTranslator.java
@@ -841,7 +841,7 @@ public final class SqlToScalarOperatorTranslator {
                     .stream()
                     .map(child -> visit(child, context.clone(node)))
                     .collect(Collectors.toList());
-            return new DictQueryOperator(arguments, node.getDictQueryExpr(), node.getFn());
+            return new DictQueryOperator(arguments, node.getDictQueryExpr(), node.getFn(), node.getType());
         }
 
         @Override

--- a/test/sql/test_dict_mapping_function/R/test_dict_mapping_function
+++ b/test/sql/test_dict_mapping_function/R/test_dict_mapping_function
@@ -61,3 +61,249 @@ DROP TABLE t_expression_cast;
 DROP DATABASE test_expression_cast_db;
 -- result:
 -- !result
+-- name: test_generated_column_case_name
+CREATE DATABASE test_generated_column_case_name;
+-- result:
+-- !result
+USE test_generated_column_case_name;
+-- result:
+-- !result
+create table dict(col_1 int, col_2 string, col_3 bigint not null auto_increment, col_4 int)
+primary key(col_1)
+distributed by hash(col_1)
+PROPERTIES (
+"replication_num" = "1"
+);
+-- result:
+-- !result
+create table fact_tbl_1(col_1 int, col_2 varchar(20), col_mapvalue bigint as Dict_Mapping("dict", COL_1, false))
+primary key(col_1)
+distributed by hash(col_1)
+PROPERTIES (
+"replication_num" = "1"
+);
+-- result:
+E: (1064, 'Getting analyzing error. Detail message: column:COL_1 does not existed.')
+-- !result
+DROP DATABASE test_generated_column_case_name;
+-- result:
+-- !result
+-- name: test_dictmapping_multiple_column
+CREATE DATABASE test_dictmapping_multiple_column;
+-- result:
+-- !result
+use test_dictmapping_multiple_column;
+-- result:
+-- !result
+create table dict(col_1 int, col_2 string, col_3 bigint not null auto_increment, col_4 int)
+primary key(col_1, col_2)
+distributed by hash(col_1, col_2)
+PROPERTIES (
+"replication_num" = "1"
+);
+-- result:
+-- !result
+INSERT INTO dict VALUES (1, "abc", default, 0);
+-- result:
+-- !result
+create table t(col_1 int, col_2 string)
+primary key(col_1)
+distributed by hash(col_1)
+PROPERTIES (
+"replication_num" = "1"
+);
+-- result:
+-- !result
+INSERT INTO t VALUES (1, "abc");
+-- result:
+-- !result
+SELECT dict_mapping("dict", col_1, col_2) FROM t;
+-- result:
+1
+-- !result
+DROP DATABASE test_dictmapping_multiple_column;
+-- result:
+-- !result
+-- name: test_dictmapping_null_column
+CREATE DATABASE test_dictmapping_null_column;
+-- result:
+-- !result
+use test_dictmapping_null_column;
+-- result:
+-- !result
+create table dict(col_1 int, col_2 string, col_3 bigint not null auto_increment, col_4 int)
+primary key(col_1, col_2)
+distributed by hash(col_1, col_2)
+PROPERTIES (
+"replication_num" = "1"
+);
+-- result:
+-- !result
+INSERT INTO dict VALUES (1, "abc", default, 0);
+-- result:
+-- !result
+create table t(col_1 int, col_2 string)
+primary key(col_1)
+distributed by hash(col_1)
+PROPERTIES (
+"replication_num" = "1"
+);
+-- result:
+-- !result
+INSERT INTO t VALUES (1, NULL), (2, "abc");
+-- result:
+-- !result
+SELECT dict_mapping("dict", col_1, col_2) FROM t;
+-- result:
+E: (1064, 'invalid parameter : get NULL paramenter')
+-- !result
+DROP DATABASE test_dictmapping_null_column;
+-- result:
+-- !result
+-- name: test_dictmapping_DictQueryOperator_bug
+CREATE DATABASE test_dictmapping_DictQueryOperator_bug;
+-- result:
+-- !result
+USE test_dictmapping_DictQueryOperator_bug;
+-- result:
+-- !result
+create table dict(col_1 int, col_2 string, col_3 bigint not null auto_increment, col_4 int)
+                primary key(col_1)
+                distributed by hash(col_1)
+PROPERTIES (
+"replication_num" = "1"
+);
+-- result:
+-- !result
+insert into dict values(1, 'hello world 1', default, 1 * 10);
+-- result:
+-- !result
+insert into dict values(2, 'hello world 2', default, 2 * 10);
+-- result:
+-- !result
+insert into dict values(3, 'hello world 3', default, 3 * 10);
+-- result:
+-- !result
+insert into dict values(4, 'hello world 4', default, 4 * 10);
+-- result:
+-- !result
+insert into dict values(5, 'hello world 5', default, 5 * 10);
+-- result:
+-- !result
+insert into dict values(6, 'hello world 6', default, 6 * 10);
+-- result:
+-- !result
+insert into dict values(7, 'hello world 7', default, 7 * 10);
+-- result:
+-- !result
+insert into dict values(8, 'hello world 8', default, 8 * 10);
+-- result:
+-- !result
+insert into dict values(9, 'hello world 9', default, 9 * 10);
+-- result:
+-- !result
+insert into dict values(10, 'hello world 10', default, 10 * 10);
+-- result:
+-- !result
+create table fact_tbl_2(col_i int, col_2 varchar(20), col_mapvalue bigint)
+PROPERTIES (
+"replication_num" = "1"
+);
+-- result:
+-- !result
+insert into fact_tbl_2
+                values
+                (1, 'Beijing', DICT_mapping("dict", cast(1 as int))),
+                (2, 'Shenzhen', DICT_MAPping("dict", cast(2 as int), "col_3")),
+                (3, 'Shanghai', Dict_Mapping("dict", cast(3 as int), "col_4"));
+-- result:
+-- !result
+DROP DATABASE test_dictmapping_DictQueryOperator_bug;
+-- result:
+-- !result
+-- name: test_dictmapping_type_cast
+CREATE DATABASE test_dictmapping_type_cast;
+-- result:
+-- !result
+USE test_dictmapping_type_cast;
+-- result:
+-- !result
+CREATE TABLE `t_dictmapping_type_cast` (
+  `k` BIGINT NOT NULL COMMENT "",
+  `v` BIGINT AUTO_INCREMENT
+) ENGINE=OLAP 
+PRIMARY KEY(`k`)
+DISTRIBUTED BY HASH(`k`) BUCKETS 1
+PROPERTIES (
+"replication_num" = "1",
+"in_memory" = "false",
+"enable_persistent_index" = "false",
+"replicated_storage" = "true",
+"compression" = "LZ4"
+);
+-- result:
+-- !result
+insert into t_dictmapping_type_cast values (1,default);
+-- result:
+-- !result
+select dict_mapping("t_dictmapping_type_cast", 1);
+-- result:
+1
+-- !result
+select dict_mapping("t_dictmapping_type_cast", "abc");
+-- result:
+E: (1064, 'invalid parameter : get NULL paramenter')
+-- !result
+select dict_mapping("t_dictmapping_type_cast", [1,2]);
+-- result:
+E: (1064, 'Getting analyzing error. Detail message: dict_mapping function params not match expected,\nExpect: VARCHAR dict_table, BIGINT k\nActual: VARCHAR, INVALID_TYPE.')
+-- !result
+drop table t_dictmapping_type_cast;
+-- result:
+-- !result
+drop database test_dictmapping_type_cast;
+-- result:
+-- !result
+-- name: test_dictmapping_null_if_not_found
+CREATE DATABASE test_dictmapping_null_if_not_found;
+-- result:
+-- !result
+USE test_dictmapping_null_if_not_found;
+-- result:
+-- !result
+CREATE TABLE `t_dictmapping_null_if_not_found` (
+  `k` BIGINT NOT NULL COMMENT "",
+  `v` BIGINT AUTO_INCREMENT
+) ENGINE=OLAP 
+PRIMARY KEY(`k`)
+DISTRIBUTED BY HASH(`k`) BUCKETS 1
+PROPERTIES (
+"replication_num" = "1",
+"in_memory" = "false",
+"enable_persistent_index" = "false",
+"replicated_storage" = "true",
+"compression" = "LZ4"
+);
+-- result:
+-- !result
+insert into t_dictmapping_null_if_not_found values (1,default);
+-- result:
+-- !result
+select dict_mapping("t_dictmapping_null_if_not_found", 2);
+-- result:
+None
+-- !result
+select dict_mapping("t_dictmapping_null_if_not_found", 2, false);
+-- result:
+None
+-- !result
+select dict_mapping("t_dictmapping_null_if_not_found", 2, true);
+-- result:
+E: (1064, 'query failed if record not exist in dict table if null_if_not_found is false')
+-- !result
+drop table t_dictmapping_null_if_not_found;
+-- result:
+-- !result
+drop database test_dictmapping_null_if_not_found;
+-- result:
+-- !result

--- a/test/sql/test_dict_mapping_function/T/test_dict_mapping_function
+++ b/test/sql/test_dict_mapping_function/T/test_dict_mapping_function
@@ -37,3 +37,157 @@ sync;
 SELECT * FROM test_table;
 DROP TABLE t_expression_cast;
 DROP DATABASE test_expression_cast_db;
+
+-- name: test_generated_column_case_name
+CREATE DATABASE test_generated_column_case_name;
+USE test_generated_column_case_name;
+
+create table dict(col_1 int, col_2 string, col_3 bigint not null auto_increment, col_4 int)
+primary key(col_1)
+distributed by hash(col_1)
+PROPERTIES (
+"replication_num" = "1"
+);
+
+create table fact_tbl_1(col_1 int, col_2 varchar(20), col_mapvalue bigint as Dict_Mapping("dict", COL_1, false))
+primary key(col_1)
+distributed by hash(col_1)
+PROPERTIES (
+"replication_num" = "1"
+);
+
+DROP DATABASE test_generated_column_case_name;
+
+-- name: test_dictmapping_multiple_column
+CREATE DATABASE test_dictmapping_multiple_column;
+use test_dictmapping_multiple_column;
+create table dict(col_1 int, col_2 string, col_3 bigint not null auto_increment, col_4 int)
+primary key(col_1, col_2)
+distributed by hash(col_1, col_2)
+PROPERTIES (
+"replication_num" = "1"
+);
+
+INSERT INTO dict VALUES (1, "abc", default, 0);
+
+create table t(col_1 int, col_2 string)
+primary key(col_1)
+distributed by hash(col_1)
+PROPERTIES (
+"replication_num" = "1"
+);
+
+INSERT INTO t VALUES (1, "abc");
+
+SELECT dict_mapping("dict", col_1, col_2) FROM t;
+
+DROP DATABASE test_dictmapping_multiple_column;
+
+-- name: test_dictmapping_null_column
+CREATE DATABASE test_dictmapping_null_column;
+use test_dictmapping_null_column;
+create table dict(col_1 int, col_2 string, col_3 bigint not null auto_increment, col_4 int)
+primary key(col_1, col_2)
+distributed by hash(col_1, col_2)
+PROPERTIES (
+"replication_num" = "1"
+);
+
+INSERT INTO dict VALUES (1, "abc", default, 0);
+
+create table t(col_1 int, col_2 string)
+primary key(col_1)
+distributed by hash(col_1)
+PROPERTIES (
+"replication_num" = "1"
+);
+
+INSERT INTO t VALUES (1, NULL), (2, "abc");
+
+SELECT dict_mapping("dict", col_1, col_2) FROM t;
+
+DROP DATABASE test_dictmapping_null_column;
+
+-- name: test_dictmapping_DictQueryOperator_bug
+CREATE DATABASE test_dictmapping_DictQueryOperator_bug;
+USE test_dictmapping_DictQueryOperator_bug;
+create table dict(col_1 int, col_2 string, col_3 bigint not null auto_increment, col_4 int)
+                primary key(col_1)
+                distributed by hash(col_1)
+PROPERTIES (
+"replication_num" = "1"
+);
+insert into dict values(1, 'hello world 1', default, 1 * 10);
+insert into dict values(2, 'hello world 2', default, 2 * 10);
+insert into dict values(3, 'hello world 3', default, 3 * 10);
+insert into dict values(4, 'hello world 4', default, 4 * 10);
+insert into dict values(5, 'hello world 5', default, 5 * 10);
+insert into dict values(6, 'hello world 6', default, 6 * 10);
+insert into dict values(7, 'hello world 7', default, 7 * 10);
+insert into dict values(8, 'hello world 8', default, 8 * 10);
+insert into dict values(9, 'hello world 9', default, 9 * 10);
+insert into dict values(10, 'hello world 10', default, 10 * 10);
+create table fact_tbl_2(col_i int, col_2 varchar(20), col_mapvalue bigint)
+PROPERTIES (
+"replication_num" = "1"
+);
+insert into fact_tbl_2
+                values
+                (1, 'Beijing', DICT_mapping("dict", cast(1 as int))),
+                (2, 'Shenzhen', DICT_MAPping("dict", cast(2 as int), "col_3")),
+                (3, 'Shanghai', Dict_Mapping("dict", cast(3 as int), "col_4"));
+
+DROP DATABASE test_dictmapping_DictQueryOperator_bug;
+
+-- name: test_dictmapping_type_cast
+CREATE DATABASE test_dictmapping_type_cast;
+USE test_dictmapping_type_cast;
+
+CREATE TABLE `t_dictmapping_type_cast` (
+  `k` BIGINT NOT NULL COMMENT "",
+  `v` BIGINT AUTO_INCREMENT
+) ENGINE=OLAP 
+PRIMARY KEY(`k`)
+DISTRIBUTED BY HASH(`k`) BUCKETS 1
+PROPERTIES (
+"replication_num" = "1",
+"in_memory" = "false",
+"enable_persistent_index" = "false",
+"replicated_storage" = "true",
+"compression" = "LZ4"
+);
+
+insert into t_dictmapping_type_cast values (1,default);
+select dict_mapping("t_dictmapping_type_cast", 1);
+select dict_mapping("t_dictmapping_type_cast", "abc");
+select dict_mapping("t_dictmapping_type_cast", [1,2]);
+
+drop table t_dictmapping_type_cast;
+drop database test_dictmapping_type_cast;
+
+-- name: test_dictmapping_null_if_not_found
+CREATE DATABASE test_dictmapping_null_if_not_found;
+USE test_dictmapping_null_if_not_found;
+
+CREATE TABLE `t_dictmapping_null_if_not_found` (
+  `k` BIGINT NOT NULL COMMENT "",
+  `v` BIGINT AUTO_INCREMENT
+) ENGINE=OLAP 
+PRIMARY KEY(`k`)
+DISTRIBUTED BY HASH(`k`) BUCKETS 1
+PROPERTIES (
+"replication_num" = "1",
+"in_memory" = "false",
+"enable_persistent_index" = "false",
+"replicated_storage" = "true",
+"compression" = "LZ4"
+);
+
+insert into t_dictmapping_null_if_not_found values (1,default);
+
+select dict_mapping("t_dictmapping_null_if_not_found", 2);
+select dict_mapping("t_dictmapping_null_if_not_found", 2, false);
+select dict_mapping("t_dictmapping_null_if_not_found", 2, true);
+
+drop table t_dictmapping_null_if_not_found;
+drop database test_dictmapping_null_if_not_found;


### PR DESCRIPTION
Problem:
1. Crash when using dict_mapping function with multiple key columns(In debug mode)
2. Crash if there is null value in key columns
3. Crash if there specify NOT bigint type value in value list for insert stmt
4. db not selected if dict_mapping function used in streamload with table name without dbname
5. Do not support type cast for dict_mapping function parameter automatically.
6. Boolean parameter's behavior which indicate return null or exception for dict_mapping if key is not found is unexpected.

Solution:
1. Reset key chunk row in dict_query_expr
2. return error if there is null value for key.
3. Fix the return type for DictQueryOperator
4. Add dbname when analyze load plan for streamload
5. Cast the type in expressionAnalyzer if it can be cast to target type.
6. Change boolean parameter's behavior, if it is false (default) return exception if key not found, if true, return null if key not found.

Fixes #40897

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
