### PR TITLE
[Enhancement] Change hive file split logic

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/connector/RemoteScanRangeLocations.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/RemoteScanRangeLocations.java
@@ -90,14 +90,16 @@ public class RemoteScanRangeLocations {
         // because it may be changed before calling 'splitScanRangeLocations'
         // and after needSplit has been calculated.
         final long splitSize = Config.hive_max_split_size;
-        long totalSize = 0;
+        long totalSize = fileDesc.getLength();
         long offset = 0;
+
         if (blockDesc.isPresent()) {
-            totalSize = blockDesc.get().getLength();
-            offset = blockDesc.get().getOffset();
-        } else {
-            totalSize = fileDesc.getLength();
+            // If blockDesc existed, we will split according block desc
+            RemoteFileBlockDesc block = blockDesc.get();
+            totalSize = block.getLength();
+            offset = block.getOffset();
         }
+
         boolean needSplit = fileDesc.isSplittable() && totalSize > splitSize;
         if (needSplit) {
             splitScanRangeLocations(partitionId, partition, fileDesc, blockDesc, offset, totalSize, splitSize,

--- a/fe/fe-core/src/main/java/com/starrocks/connector/RemoteScanRangeLocations.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/RemoteScanRangeLocations.java
@@ -61,6 +61,7 @@ public class RemoteScanRangeLocations {
 
     private final List<TScanRangeLocations> result = new ArrayList<>();
     private final List<DescriptorTable.ReferencedPartitionInfo> partitionInfos = new ArrayList<>();
+    private boolean forceScheduleLocal = false;
 
     public void setup(DescriptorTable descTbl, Table table, HDFSScanNodePredicates scanNodePredicates) {
         Collection<Long> selectedPartitionIds = scanNodePredicates.getSelectedPartitionIds();
@@ -75,30 +76,39 @@ public class RemoteScanRangeLocations {
             partitionInfos.add(partitionInfo);
             descTbl.addReferencedPartitions(table, partitionInfo);
         }
+
+        forceScheduleLocal = ConnectContext.get().getSessionVariable().getForceScheduleLocal();
     }
 
     private void addScanRangeLocations(long partitionId, RemoteFileInfo partition, RemoteFileDesc fileDesc,
-                                       RemoteFileBlockDesc blockDesc, DataCacheOptions dataCacheOptions) {
+                                       Optional<RemoteFileBlockDesc> blockDesc, DataCacheOptions dataCacheOptions) {
         // NOTE: Config.hive_max_split_size should be extracted to a local variable,
         // because it may be changed before calling 'splitScanRangeLocations'
         // and after needSplit has been calculated.
-        long splitSize = Config.hive_max_split_size;
-        boolean needSplit = fileDesc.isSplittable() && blockDesc.getLength() > splitSize;
-        if (needSplit) {
-            splitScanRangeLocations(partitionId, partition, fileDesc, blockDesc, splitSize, dataCacheOptions);
+        final long splitSize = Config.hive_max_split_size;
+        long totalSize = 0;
+        long offset = 0;
+        if (blockDesc.isPresent()) {
+            totalSize = blockDesc.get().getLength();
+            offset = blockDesc.get().getOffset();
         } else {
-            createScanRangeLocationsForSplit(partitionId, partition, fileDesc, blockDesc, blockDesc.getOffset(),
-                    blockDesc.getLength(), dataCacheOptions);
+            totalSize = fileDesc.getLength();
+        }
+        boolean needSplit = fileDesc.isSplittable() && totalSize > splitSize;
+        if (needSplit) {
+            splitScanRangeLocations(partitionId, partition, fileDesc, blockDesc, offset, totalSize, splitSize,
+                    dataCacheOptions);
+        } else {
+            createScanRangeLocationsForSplit(partitionId, partition, fileDesc, blockDesc, offset, totalSize,
+                    dataCacheOptions);
         }
     }
 
     private void splitScanRangeLocations(long partitionId, RemoteFileInfo partition,
                                          RemoteFileDesc fileDesc,
-                                         RemoteFileBlockDesc blockDesc,
-                                         long splitSize, DataCacheOptions dataCacheOptions) {
-        long remainingBytes = blockDesc.getLength();
-        long length = blockDesc.getLength();
-        long offset = blockDesc.getOffset();
+                                         Optional<RemoteFileBlockDesc> blockDesc,
+                                         long offset, long length, long splitSize, DataCacheOptions dataCacheOptions) {
+        long remainingBytes = length;
         do {
             if (remainingBytes < 2 * splitSize) {
                 createScanRangeLocationsForSplit(partitionId, partition, fileDesc,
@@ -116,7 +126,7 @@ public class RemoteScanRangeLocations {
 
     private void createScanRangeLocationsForSplit(long partitionId, RemoteFileInfo partition,
                                                   RemoteFileDesc fileDesc,
-                                                  RemoteFileBlockDesc blockDesc,
+                                                  Optional<RemoteFileBlockDesc> blockDesc,
                                                   long offset, long length, DataCacheOptions dataCacheOptions) {
         TScanRangeLocations scanRangeLocations = new TScanRangeLocations();
 
@@ -142,15 +152,20 @@ public class RemoteScanRangeLocations {
         scanRange.setHdfs_scan_range(hdfsScanRange);
         scanRangeLocations.setScan_range(scanRange);
 
-        if (blockDesc.getReplicaHostIds().length == 0) {
-            String message = String.format("hdfs file block has no host. file = %s/%s",
-                    partition.getFullPath(), fileDesc.getFileName());
-            throw new StarRocksPlannerException(message, ErrorType.INTERNAL_ERROR);
-        }
+        if (blockDesc.isPresent()) {
+            if (blockDesc.get().getReplicaHostIds().length == 0) {
+                String message = String.format("hdfs file block has no host. file = %s/%s",
+                        partition.getFullPath(), fileDesc.getFileName());
+                throw new StarRocksPlannerException(message, ErrorType.INTERNAL_ERROR);
+            }
 
-        for (long hostId : blockDesc.getReplicaHostIds()) {
-            String host = blockDesc.getDataNodeIp(hostId);
-            TScanRangeLocation scanRangeLocation = new TScanRangeLocation(new TNetworkAddress(host, -1));
+            for (long hostId : blockDesc.get().getReplicaHostIds()) {
+                String host = blockDesc.get().getDataNodeIp(hostId);
+                TScanRangeLocation scanRangeLocation = new TScanRangeLocation(new TNetworkAddress(host, -1));
+                scanRangeLocations.addToLocations(scanRangeLocation);
+            }
+        } else {
+            TScanRangeLocation scanRangeLocation = new TScanRangeLocation(new TNetworkAddress("-1", -1));
             scanRangeLocations.addToLocations(scanRangeLocation);
         }
 
@@ -284,13 +299,23 @@ public class RemoteScanRangeLocations {
                     if (fileDesc.getLength() == 0) {
                         continue;
                     }
-                    for (RemoteFileBlockDesc blockDesc : fileDesc.getBlockDescs()) {
-                        addScanRangeLocations(partitionInfos.get(i).getId(), partitions.get(i), fileDesc, blockDesc,
+                    if (forceScheduleLocal) {
+                        for (RemoteFileBlockDesc blockDesc : fileDesc.getBlockDescs()) {
+                            addScanRangeLocations(partitionInfos.get(i).getId(), partitions.get(i), fileDesc,
+                                    Optional.of(blockDesc),
+                                    dataCacheOptions);
+                            LOG.debug("Add scan range success. partition: {}, file: {}, block: {}-{}",
+                                    partitions.get(i).getFullPath(), fileDesc.getFileName(), blockDesc.getOffset(),
+                                    blockDesc.getLength());
+                        }
+                    } else {
+                        addScanRangeLocations(partitionInfos.get(i).getId(), partitions.get(i), fileDesc,
+                                Optional.empty(),
                                 dataCacheOptions);
-                        LOG.debug("Add scan range success. partition: {}, file: {}, block: {}-{}",
-                                partitions.get(i).getFullPath(), fileDesc.getFileName(), blockDesc.getOffset(),
-                                blockDesc.getLength());
+                        LOG.debug("Add scan range success. partition: {}, file: {}, range: {}-{}",
+                                partitions.get(i).getFullPath(), fileDesc.getFileName(), 0, fileDesc.getLength());
                     }
+
                 }
             }
         } else if (table instanceof HudiTable) {

--- a/fe/fe-core/src/main/java/com/starrocks/connector/RemoteScanRangeLocations.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/RemoteScanRangeLocations.java
@@ -77,7 +77,11 @@ public class RemoteScanRangeLocations {
             descTbl.addReferencedPartitions(table, partitionInfo);
         }
 
-        forceScheduleLocal = ConnectContext.get().getSessionVariable().getForceScheduleLocal();
+        forceScheduleLocal = false;
+        if (ConnectContext.get() != null) {
+            // ConnectContext sometimes will be nullptr, we need to cover it up
+            forceScheduleLocal = ConnectContext.get().getSessionVariable().getForceScheduleLocal();
+        }
     }
 
     private void addScanRangeLocations(long partitionId, RemoteFileInfo partition, RemoteFileDesc fileDesc,

--- a/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
@@ -1931,6 +1931,10 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
         return hivePartitionStatsSampleSize;
     }
 
+    public void setForceScheduleLocal(boolean forceScheduleLocal) {
+        this.forceScheduleLocal = forceScheduleLocal;
+    }
+
     public boolean getEnableAdaptiveSinkDop() {
         return enableAdaptiveSinkDop;
     }

--- a/fe/fe-core/src/test/java/com/starrocks/connector/RemoteScanRangeLocationsTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/RemoteScanRangeLocationsTest.java
@@ -1,0 +1,88 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.connector;
+
+import com.starrocks.common.Config;
+import com.starrocks.common.Pair;
+import com.starrocks.planner.PlanNodeId;
+import com.starrocks.qe.DefaultCoordinator;
+import com.starrocks.sql.analyzer.AnalyzeTestUtil;
+import com.starrocks.sql.plan.ConnectorPlanTestBase;
+import com.starrocks.sql.plan.PlanTestBase;
+import com.starrocks.thrift.TScanRange;
+import com.starrocks.thrift.TScanRangeLocations;
+import com.starrocks.utframe.UtFrameUtils;
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import java.util.List;
+
+public class RemoteScanRangeLocationsTest extends PlanTestBase {
+
+    @BeforeClass
+    public static void beforeClass() throws Exception {
+        PlanTestBase.beforeClass();
+        AnalyzeTestUtil.setConnectContext(connectContext);
+        ConnectorPlanTestBase.mockHiveCatalog(connectContext);
+        Config.hive_max_split_size = 512 * 1024 * 1024;
+    }
+
+    @AfterClass
+    public static void afterClass() {
+        // reset all configures
+        Config.hive_max_split_size = 64 * 1024 * 1024;
+        connectContext.getSessionVariable().setForceScheduleLocal(false);
+    }
+
+    @Test
+    public void testHiveSplit() throws Exception {
+        String executeSql = "select * from hive0.file_split_db.file_split_tbl;";
+        Pair<String, DefaultCoordinator> pair = UtFrameUtils.getPlanAndStartScheduling(connectContext, executeSql);
+        List<TScanRangeLocations> scanRangeLocations = pair.second.getFragments().get(1).collectScanNodes()
+                .get(new PlanNodeId(0)).getScanRangeLocations(100);
+        Assert.assertEquals(4, scanRangeLocations.size());
+
+        TScanRange scanRange1 = scanRangeLocations.get(0).scan_range;
+        TScanRange scanRange2 = scanRangeLocations.get(1).scan_range;
+        Assert.assertEquals(scanRange1.hdfs_scan_range.length, scanRange2.hdfs_scan_range.offset);
+    }
+
+    @Test
+    public void testHiveSplitWithForceLocalSchedule() throws Exception {
+        connectContext.getSessionVariable().setForceScheduleLocal(true);
+
+        String executeSql = "select * from hive0.file_split_db.file_split_tbl;";
+        Pair<String, DefaultCoordinator> pair = UtFrameUtils.getPlanAndStartScheduling(connectContext, executeSql);
+        List<TScanRangeLocations> scanRangeLocations = pair.second.getFragments().get(1).collectScanNodes()
+                .get(new PlanNodeId(0)).getScanRangeLocations(100);
+        Assert.assertEquals(8, scanRangeLocations.size());
+
+        Assert.assertEquals(0, scanRangeLocations.get(0).scan_range.hdfs_scan_range.offset);
+        long previousOffset = scanRangeLocations.get(0).scan_range.hdfs_scan_range.length;
+        for (int i = 1; i < 4; i++) {
+            Assert.assertEquals(previousOffset, scanRangeLocations.get(i).scan_range.hdfs_scan_range.offset);
+            previousOffset += scanRangeLocations.get(i).scan_range.hdfs_scan_range.length;
+        }
+
+        Assert.assertEquals(0, scanRangeLocations.get(4).scan_range.hdfs_scan_range.offset);
+        previousOffset = scanRangeLocations.get(4).scan_range.hdfs_scan_range.length;
+        for (int i = 5; i < 8; i++) {
+            Assert.assertEquals(previousOffset, scanRangeLocations.get(i).scan_range.hdfs_scan_range.offset);
+            previousOffset += scanRangeLocations.get(i).scan_range.hdfs_scan_range.length;
+        }
+    }
+}

--- a/fe/fe-core/src/test/java/com/starrocks/connector/hive/MockedHiveMetadata.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/hive/MockedHiveMetadata.java
@@ -97,6 +97,7 @@ public class MockedHiveMetadata implements ConnectorMetadata {
         mockPartitionTable();
         mockView();
         mockSubfieldTable();
+        mockFileSplitTable();
     }
 
     @Override
@@ -385,6 +386,50 @@ public class MockedHiveMetadata implements ConnectorMetadata {
                 new HiveTableInfo(HiveMetastoreApiConverter.toHiveTable(tbl, MOCKED_HIVE_CATALOG_NAME),
                         ImmutableList.of(), 5, regionStats, MOCKED_FILES));
 
+    }
+
+    private static void mockFileSplitTable() {
+        final String dbName = "file_split_db";
+        MOCK_TABLE_MAP.putIfAbsent(dbName, new CaseInsensitiveMap<>());
+        Map<String, HiveTableInfo> mockTables = MOCK_TABLE_MAP.get(dbName);
+
+        List<FieldSchema> cols = Lists.newArrayList();
+        cols.add(new FieldSchema("col_int", "int", null));
+        StorageDescriptor sd =
+                new StorageDescriptor(cols, "", MAPRED_PARQUET_INPUT_FORMAT_CLASS, "", false,
+                        -1, null, Lists.newArrayList(), Lists.newArrayList(), Maps.newHashMap());
+
+        CaseInsensitiveMap<String, ColumnStatistic> regionStats = new CaseInsensitiveMap<>();
+        regionStats.put("col_int", ColumnStatistic.unknown());
+
+        Table tbl =
+                new Table("file_split_tbl", dbName, null, 0, 0, 0, sd, Lists.newArrayList(), Maps.newHashMap(), null,
+                        null,
+                        "EXTERNAL_TABLE");
+
+        final long oneGigabytes = 1024 * 1024 * 1024;
+        final long oneMegabytes = 1024 * 1024;
+        HiveRemoteFileIO fileIO = new HiveRemoteFileIO(new Configuration());
+        ImmutableList<RemoteFileBlockDesc> blockDescs = ImmutableList.of(
+                new RemoteFileBlockDesc(0, 256 * oneMegabytes, new long[] {123}, new long[] {123}, fileIO),
+                new RemoteFileBlockDesc(256 * oneMegabytes, 256 * oneMegabytes, new long[] {123}, new long[] {123},
+                        fileIO),
+                new RemoteFileBlockDesc(512 * oneMegabytes, 256 * oneMegabytes, new long[] {123}, new long[] {123},
+                        fileIO),
+                new RemoteFileBlockDesc(768 * oneMegabytes, 256 * oneMegabytes, new long[] {123}, new long[] {123},
+                        fileIO)
+        );
+        RemoteFileDesc fileDesc1 = new RemoteFileDesc("file1", "zlib", oneGigabytes, 0, blockDescs, ImmutableList.of());
+        fileDesc1.setSplittable(true);
+        RemoteFileDesc fileDesc2 = new RemoteFileDesc("file2", "zlib", oneGigabytes, 0, blockDescs, ImmutableList.of());
+        fileDesc2.setSplittable(true);
+        List<RemoteFileInfo> files =
+                ImmutableList.of(new RemoteFileInfo(RemoteFileInputFormat.ORC, ImmutableList.of(
+                        fileDesc1, fileDesc2), null));
+
+        mockTables.put(tbl.getTableName(),
+                new HiveTableInfo(HiveMetastoreApiConverter.toHiveTable(tbl, MOCKED_HIVE_CATALOG_NAME),
+                        ImmutableList.of(), 5, regionStats, files));
     }
 
     public static void mockTPCHTable() {

--- a/fe/fe-core/src/test/java/com/starrocks/statistic/StatisticsCollectJobTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/statistic/StatisticsCollectJobTest.java
@@ -568,7 +568,7 @@ public class StatisticsCollectJobTest extends PlanTestNoneDBBase {
                         Maps.newHashMap(),
                         StatsConstants.ScheduleStatus.PENDING,
                         LocalDateTime.MIN));
-        Assert.assertEquals(28, jobs.size());
+        Assert.assertEquals(29, jobs.size());
     }
 
     @Test


### PR DESCRIPTION
## Why I'm doing:
The previous implementation, we split the hive's file based on block desc. This means, even if we set `hive_max_split_size` larger than the HDFS block size, it didn't work anymore.

`actual_hive_max_split_size` = min(`hive_max_split_size`, 'hdfs_block_size');

## What I'm doing:
Change the hive's split logic.
If the user enables `force_schedule_local=true`, we will follow the original logic to use HDFS short circuit read.
If the user set `force_schedule_local=false`, we will split based on fileDesc.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
