### PR TITLE
[BugFix] The column unique ID may be incorrectly updated when upgrading to version 3.2.3

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/MaterializedIndexMeta.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/MaterializedIndexMeta.java
@@ -68,7 +68,7 @@ public class MaterializedIndexMeta implements Writable, GsonPostProcessable {
     @SerializedName(value = "sortKeyUniqueIds")
     public List<Integer> sortKeyUniqueIds;
     @SerializedName(value = "schemaVersion")
-    private int schemaVersion = -1;
+    private int schemaVersion = 0;
     @SerializedName(value = "schemaHash")
     private int schemaHash;
     @SerializedName(value = "schemaId")

--- a/fe/fe-core/src/main/java/com/starrocks/leader/ReportHandler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/leader/ReportHandler.java
@@ -1521,6 +1521,9 @@ public class ReportHandler extends Daemon implements MemoryTrackable {
                     if (olapTable == null) {
                         continue;
                     }
+                    if (olapTable.getMaxColUniqueId() <= Column.COLUMN_UNIQUE_ID_INIT_VALUE) {
+                        continue;
+                    }
                     MaterializedIndexMeta indexMeta = olapTable.getIndexMetaByIndexId(indexId);
                     if (indexMeta == null) {
                         continue;

--- a/fe/fe-core/src/main/java/com/starrocks/task/UpdateSchemaTask.java
+++ b/fe/fe-core/src/main/java/com/starrocks/task/UpdateSchemaTask.java
@@ -51,7 +51,7 @@ public class UpdateSchemaTask extends AgentTask {
                             long tableId, long indexId, List<Long> tablets,
                             long schemaId, long schemaVersion,
                             TOlapTableColumnParam columnParam) {
-        super(null, backendId, TTaskType.UPDATE_SCHEMA, dbId, tableId, -1, indexId, -1);
+        super(null, backendId, TTaskType.UPDATE_SCHEMA, dbId, tableId, -1, indexId, -1, schemaId);
 
         this.schemaId = schemaId;
         this.schemaVersion = schemaVersion;


### PR DESCRIPTION
## Why I'm doing:
The table which support fast schema evolution will send an update schema task to BE when FE find the tablet schema in BE is not latest. However, the tablets created on BE before version 3.2 do not have schema version. When upgraded to version 3.2, they will be initialized with default values(-1) and the FE will consider these tablets in need of updating the tablet schema which will cause column unique id updated incorrectly because thess tablets have no column unique id in FE.

## What I'm doing:
Fix the bug.

Fixes https://github.com/StarRocks/StarRocksTest/issues/6123

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
