### PR TITLE
[BugFix] Fix type of exprs is not match slot

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/analysis/IntLiteral.java
+++ b/fe/fe-core/src/main/java/com/starrocks/analysis/IntLiteral.java
@@ -393,7 +393,7 @@ public class IntLiteral extends LiteralExpr {
     @Override
     public int hashCode() {
         // IntLiteral(0) equals to LargeIntLiteral(0), so their hash codes must equal.
-        return Objects.hash(getLongValue());
+        return Objects.hash(getLongValue(), type);
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/analysis/LargeIntLiteral.java
+++ b/fe/fe-core/src/main/java/com/starrocks/analysis/LargeIntLiteral.java
@@ -259,7 +259,7 @@ public class LargeIntLiteral extends LiteralExpr {
     @Override
     public int hashCode() {
         // IntLiteral(0) equals to LargeIntLiteral(0), so their hash codes must equal.
-        return Objects.hash(getLongValue());
+        return Objects.hash(getLongValue(), type);
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/analysis/LiteralExpr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/analysis/LiteralExpr.java
@@ -51,6 +51,7 @@ import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
 import java.util.Map;
+import java.util.Objects;
 
 public abstract class LiteralExpr extends Expr implements Comparable<LiteralExpr> {
     public LiteralExpr() {
@@ -222,7 +223,7 @@ public abstract class LiteralExpr extends Expr implements Comparable<LiteralExpr
                 || (this instanceof FloatLiteral && !(obj instanceof FloatLiteral))) {
             return false;
         }
-        return this.compareLiteral(((LiteralExpr) obj)) == 0;
+        return this.compareLiteral(((LiteralExpr) obj)) == 0 && Objects.equals(type, ((LiteralExpr) obj).type);
     }
 
     @Override

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/ExprHashCodeTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/ExprHashCodeTest.java
@@ -112,8 +112,8 @@ public class ExprHashCodeTest {
 
         // IntLiteral/LargeIntLiteral doesn't equal to FloatLiteral/BoolLiteral.
         // IntLiteral can equal to LargeIntLiteral.
-        Streams.forEachPair(intLiterals.stream(), largeIntLiterals.stream(), Assertions::assertEquals);
-        Streams.forEachPair(largeIntLiterals.stream(), intLiterals.stream(), Assertions::assertEquals);
+        Streams.forEachPair(intLiterals.stream(), largeIntLiterals.stream(), Assertions::assertNotEquals);
+        Streams.forEachPair(largeIntLiterals.stream(), intLiterals.stream(), Assertions::assertNotEquals);
         Streams.forEachPair(intLiterals.stream(), Streams.concat(floatLiterals.stream(), boolLiterals.stream()),
                 Assertions::assertNotEquals);
         Streams.forEachPair(largeIntLiterals.stream(), Streams.concat(floatLiterals.stream(), boolLiterals.stream()),

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/ExprHashCodeTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/ExprHashCodeTest.java
@@ -111,7 +111,7 @@ public class ExprHashCodeTest {
         });
 
         // IntLiteral/LargeIntLiteral doesn't equal to FloatLiteral/BoolLiteral.
-        // IntLiteral can equal to LargeIntLiteral.
+        // IntLiteral doesn't equal to LargeIntLiteral.
         Streams.forEachPair(intLiterals.stream(), largeIntLiterals.stream(), Assertions::assertNotEquals);
         Streams.forEachPair(largeIntLiterals.stream(), intLiterals.stream(), Assertions::assertNotEquals);
         Streams.forEachPair(intLiterals.stream(), Streams.concat(floatLiterals.stream(), boolLiterals.stream()),

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/operator/ColumnFilterConverterTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/operator/ColumnFilterConverterTest.java
@@ -127,8 +127,8 @@ public class ColumnFilterConverterTest {
         assertTrue(result.containsKey("name"));
         assertTrue(result.containsKey("sex"));
 
-        assertEquals(new IntLiteral(1), result.get("age").getLowerBound());
-        assertEquals(new IntLiteral(1), result.get("age").getUpperBound());
+        assertEquals(new IntLiteral(1).getLongValue(), result.get("age").getLowerBound().getLongValue());
+        assertEquals(new IntLiteral(1).getLongValue(), result.get("age").getUpperBound().getLongValue());
 
         assertEquals(4, result.get("name").getInPredicateLiterals().size());
         assertEquals(new StringLiteral("1"), result.get("name").getInPredicateLiterals().get(0));


### PR DESCRIPTION
## Why I'm doing:
Previously, expressions with different types were treated as the same expression resulting in query errors. Here's a fix for that

## What I'm doing:

Fixes #40871

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
