### PR TITLE
[Enhancement] Refine string metric merge algorithm

### DIFF
--- a/be/src/exec/chunks_sorter_full_sort.cpp
+++ b/be/src/exec/chunks_sorter_full_sort.cpp
@@ -136,10 +136,10 @@ Status ChunksSorterFullSort::_merge_sorted(RuntimeState* state) {
     // columns's permutation in multiple passes.
     if (_early_materialized_slots.empty() || _sorted_chunks.size() < 3) {
         _early_materialized_slots.clear();
-        _runtime_profile->add_info_string("LateMaterialization", "false");
+        _runtime_profile->add_info_string("LateMaterialization", "False");
         RETURN_IF_ERROR(merge_sorted_chunks(_sort_desc, _sort_exprs, _sorted_chunks, &_merged_runs));
     } else {
-        _runtime_profile->add_info_string("LateMaterialization", "true");
+        _runtime_profile->add_info_string("LateMaterialization", "True");
         _split_late_and_early_chunks();
         _assign_ordinals();
         RETURN_IF_ERROR(merge_sorted_chunks(_sort_desc, _sort_exprs, _early_materialized_chunks, &_merged_runs));

--- a/be/src/exec/query_cache/cache_operator.cpp
+++ b/be/src/exec/query_cache/cache_operator.cpp
@@ -201,9 +201,6 @@ void CacheOperator::close(RuntimeState* state) {
     _cache_populate_tablets_counter->update(_populate_tablets.size());
     _cache_probe_tablets_counter->update(_probe_tablets.size());
     _cache_passthrough_tablets_counter->update(passthrough_tablets.size());
-    _unique_metrics->add_info_string("CacheProbeTablets", flatten_tablet_set(_probe_tablets));
-    _unique_metrics->add_info_string("CachePopulateTablets", flatten_tablet_set(_populate_tablets));
-    _unique_metrics->add_info_string("CachePassthroughTablets", flatten_tablet_set(passthrough_tablets));
 
     Operator::close(state);
 }

--- a/be/src/exec/query_cache/cache_operator.cpp
+++ b/be/src/exec/query_cache/cache_operator.cpp
@@ -186,10 +186,6 @@ Status CacheOperator::prepare(RuntimeState* state) {
     return Status::OK();
 }
 
-static inline std::string flatten_tablet_set(const std::unordered_set<int64_t>& tablets) {
-    return fmt::format("{}", fmt::join(tablets.begin(), tablets.end(), ","));
-}
-
 void CacheOperator::close(RuntimeState* state) {
     std::unordered_set<int64_t> passthrough_tablets;
     for (auto tablet_id : _all_tablets) {

--- a/be/src/exec/sorting/merge_path.cpp
+++ b/be/src/exec/sorting/merge_path.cpp
@@ -1128,7 +1128,7 @@ void MergePathCascadeMerger::_finishing() {
 void MergePathCascadeMerger::_init_late_materialization() {
     DeferOp defer([this]() {
         std::for_each(_metrics.begin(), _metrics.end(), [this](auto& metrics) {
-            metrics.profile->add_info_string("LateMaterialization", _late_materialization ? "true" : "false");
+            metrics.profile->add_info_string("LateMaterialization", _late_materialization ? "True" : "False");
         });
     });
 

--- a/be/test/util/runtime_profile_test.cpp
+++ b/be/test/util/runtime_profile_test.cpp
@@ -301,6 +301,31 @@ TEST(TestRuntimeProfile, testConflictInfoString) {
     ASSERT_EQ(expected_values, actual_values);
 }
 
+static void test_mass_conflict_info_string(int num) {
+    std::shared_ptr<ObjectPool> obj_pool = std::make_shared<ObjectPool>();
+    std::vector<std::shared_ptr<RuntimeProfile>> profile_ptrs;
+    std::vector<RuntimeProfile*> profiles;
+    for (int i = 1; i <= num; ++i) {
+        auto profile = std::make_shared<RuntimeProfile>("profile");
+        profile->add_info_string("key", std::to_string(i));
+        profile_ptrs.push_back(profile);
+        profiles.push_back(profile.get());
+    }
+
+    auto* merged_profile = RuntimeProfile::merge_isomorphic_profiles(obj_pool.get(), profiles);
+    for (int i = 0; i < num - 1; ++i) {
+        ASSERT_TRUE(merged_profile->get_info_string("key__DUP(" + std::to_string(i) + ")") != nullptr);
+    }
+}
+
+TEST(TestRuntimeProfile, testMassConflictInfoString) {
+    for (int i = 1; i <= 32; ++i) {
+        test_mass_conflict_info_string(i);
+    }
+    test_mass_conflict_info_string(1024);
+    test_mass_conflict_info_string(3267);
+}
+
 TEST(TestRuntimeProfile, testCopyCounterWithParent) {
     auto strategy_unit = create_strategy(TUnit::UNIT);
     auto strategy_time = create_strategy(TUnit::TIME_NS);

--- a/fe/fe-core/src/main/java/com/starrocks/common/util/RuntimeProfile.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/util/RuntimeProfile.java
@@ -498,13 +498,24 @@ public class RuntimeProfile {
                 if ((pos = key.indexOf("__DUP(")) != -1) {
                     originalKey = key.substring(0, pos);
                 }
-                int i = 0;
+                int offset = -1;
+                int previousOffset;
+                int step = 1;
                 while (true) {
-                    String indexedKey = String.format("%s__DUP(%d)", originalKey, i++);
+                    previousOffset = offset;
+                    offset += step;
+                    String indexedKey = String.format("%s__DUP(%d)", originalKey, offset);
                     if (!this.infoStrings.containsKey(indexedKey)) {
-                        this.infoStrings.put(indexedKey, value);
-                        break;
+                        if (step == 1) {
+                            this.infoStrings.put(indexedKey, value);
+                            break;
+                        }
+                        // Forward too much, try to forward half of the former size
+                        offset = previousOffset;
+                        step >>= 1;
+                        continue;
                     }
+                    step <<= 1;
                 }
             }
         });

--- a/fe/fe-core/src/test/java/com/starrocks/common/util/RuntimeProfileTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/common/util/RuntimeProfileTest.java
@@ -612,6 +612,30 @@ public class RuntimeProfileTest {
     }
 
     @Test
+    public void testMassConflictInfoString() {
+        for (int i = 1; i <= 32; i++) {
+            testMassConflictInfoString(i);
+        }
+        testMassConflictInfoString(1024);
+        testMassConflictInfoString(3267);
+    }
+
+    private void testMassConflictInfoString(int num) {
+        List<RuntimeProfile> profiles = Lists.newArrayList();
+        for (int i = 1; i <= num; i++) {
+            RuntimeProfile profile = new RuntimeProfile();
+            profile.addInfoString("key", Integer.toString(i));
+            profiles.add(profile);
+        }
+
+        RuntimeProfile mergedProfile = RuntimeProfile.mergeIsomorphicProfiles(profiles, null);
+        Assert.assertNotNull(mergedProfile);
+        for (int i = 0; i < num - 1; i++) {
+            Assert.assertNotNull(mergedProfile.getInfoString(String.format("key__DUP(%s)", i)));
+        }
+    }
+
+    @Test
     public void testJsonProfileFormater() {
         //profile
         RuntimeProfile profile = new RuntimeProfile("profile");


### PR DESCRIPTION
## Why I'm doing:

Info string merge algorithm is too slow when there are thousands of conflicts. For each conflict, the algorithm will probe the next unused suffix like `key__DUP(0)`、`key__DUP(1)`、`key__DUP(1000)`, starting from `0`.

## What I'm doing:

1. Change linear probing to exponential probing.
2. Remove these metrics: `CacheProbeTablets`/`CachePassthroughTablets`/`CachePopulateTablets`. It may decrease the readibility of the profile.

For 2500 key of the same name merge:

* Before: 2s
* After: 200ms

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [x] 3.1
  - [ ] 3.0
  - [ ] 2.5
