### PR TITLE
[Refactor] skip asan stack-use-after-scope in _get_extra_file_size

### DIFF
--- a/be/src/storage/tablet_updates.cpp
+++ b/be/src/storage/tablet_updates.cpp
@@ -2944,9 +2944,10 @@ size_t TabletUpdates::_get_rowset_num_deletes(const Rowset& rowset) {
 }
 
 StatusOr<ExtraFileSize> TabletUpdates::_get_extra_file_size() const {
+    ExtraFileSize ef_size;
+#if !defined(ADDRESS_SANITIZER)
     std::string tablet_path_str = _tablet.schema_hash_path();
     std::filesystem::path tablet_path(tablet_path_str.c_str());
-    ExtraFileSize ef_size;
     try {
         for (const auto& entry : std::filesystem::directory_iterator(tablet_path)) {
             if (entry.is_regular_file()) {
@@ -2970,6 +2971,7 @@ StatusOr<ExtraFileSize> TabletUpdates::_get_extra_file_size() const {
         std::string err_msg = "Iterate dir " + tablet_path.string() + " Unknown exception occurred.";
         return Status::InternalError(err_msg);
     }
+#endif
     return ef_size;
 }
 


### PR DESCRIPTION
## Why I'm doing:
In asan mode, it detect that `directory_iterator` will have stack-use-after-scope issue, but the code seems ok. Skip the check for now to continue the rest tests until we find out why.

```
==26577==ERROR: AddressSanitizer: stack-use-after-scope on address 0x7f8adf303538 at pc 0x00000a79369d bp 0x7f8adf303390 sp 0x7f8adf303388
READ of size 8 at 0x7f8adf303538 thread T5313
   #0 0xa79369c in std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >::_M_data() const /opt/rh/gcc-toolset-10/root/usr/include/c++/10.3.0/bits/basic_string.h:187
   #1 0xa793976 in std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >::_M_is_local() const /opt/rh/gcc-toolset-10/root/usr/include/c++/10.3.0/bits/basic_string.h:222
   #2 0xa791ea1 in std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >::capacity() const /opt/rh/gcc-toolset-10/root/usr/include/c++/10.3.0/bits/basic_string.h:966
   #3 0xa8ed5c2 in std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >::reserve(unsigned long) /opt/rh/gcc-toolset-10/root/usr/include/c++/10.3.0/bits/basic_string.tcc:287
   #4 0x18abc9ca in std::filesystem::__cxx11::path::operator=(std::filesystem::__cxx11::path const&) ../../../.././libstdc++-v3/src/c++17/fs_path.cc:457
   #5 0x18aada1c in std::filesystem::__cxx11::_Dir::_Dir(std::filesystem::__cxx11::path const&, bool, std::error_code&) ../../../.././libstdc++-v3/src/c++17/fs_dir.cc:51
   #6 0x18aada1c in std::filesystem::__cxx11::directory_iterator::directory_iterator(std::filesystem::__cxx11::path const&, std::filesystem::directory_options, std::error_code*) ../../../.././libstdc++-v3/src/c++17/fs_dir.cc:135
   #7 0xab11cd5 in std::filesystem::__cxx11::directory_iterator::directory_iterator(std::filesystem::__cxx11::path const&) /opt/rh/gcc-toolset-10/root/usr/include/c++/10.3.0/bits/fs_dir.h:387
   #8 0x12d1f597 in starrocks::TabletUpdates::_get_extra_file_size() const /root/starrocks/be/src/storage/tablet_updates.cpp:2885
```

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [x] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [x] 3.1
  - [ ] 3.0
  - [ ] 2.5
