### PR TITLE
[BugFix] Make query pool memory stats more accurate

### DIFF
--- a/be/src/exec/pipeline/fragment_executor.cpp
+++ b/be/src/exec/pipeline/fragment_executor.cpp
@@ -710,8 +710,8 @@ Status FragmentExecutor::prepare(ExecEnv* exec_env, const TExecPlanFragmentParam
         RETURN_IF_ERROR(_prepare_workgroup(request));
         RETURN_IF_ERROR(_prepare_runtime_state(exec_env, request));
 
-        auto query_mem_tracker = _query_ctx->mem_tracker();
-        SCOPED_THREAD_LOCAL_MEM_TRACKER_SETTER(query_mem_tracker.get());
+        auto mem_tracker = _fragment_ctx->runtime_state()->instance_mem_tracker();
+        SCOPED_THREAD_LOCAL_MEM_TRACKER_SETTER(mem_tracker);
 
         RETURN_IF_ERROR(_prepare_exec_plan(exec_env, request));
         RETURN_IF_ERROR(_prepare_global_dict(request));
@@ -719,8 +719,8 @@ Status FragmentExecutor::prepare(ExecEnv* exec_env, const TExecPlanFragmentParam
     {
         SCOPED_RAW_TIMER(&profiler.prepare_pipeline_driver_time);
 
-        auto query_mem_tracker = _query_ctx->mem_tracker();
-        SCOPED_THREAD_LOCAL_MEM_TRACKER_SETTER(query_mem_tracker.get());
+        auto mem_tracker = _fragment_ctx->runtime_state()->instance_mem_tracker();
+        SCOPED_THREAD_LOCAL_MEM_TRACKER_SETTER(mem_tracker);
 
         RETURN_IF_ERROR(_prepare_pipeline_driver(exec_env, request));
         RETURN_IF_ERROR(_prepare_stream_load_pipe(exec_env, request));

--- a/be/src/exec/pipeline/fragment_executor.cpp
+++ b/be/src/exec/pipeline/fragment_executor.cpp
@@ -709,11 +709,19 @@ Status FragmentExecutor::prepare(ExecEnv* exec_env, const TExecPlanFragmentParam
         SCOPED_RAW_TIMER(&profiler.prepare_runtime_state_time);
         RETURN_IF_ERROR(_prepare_workgroup(request));
         RETURN_IF_ERROR(_prepare_runtime_state(exec_env, request));
+
+        auto query_mem_tracker = _query_ctx->mem_tracker();
+        SCOPED_THREAD_LOCAL_MEM_TRACKER_SETTER(query_mem_tracker.get());
+
         RETURN_IF_ERROR(_prepare_exec_plan(exec_env, request));
         RETURN_IF_ERROR(_prepare_global_dict(request));
     }
     {
         SCOPED_RAW_TIMER(&profiler.prepare_pipeline_driver_time);
+
+        auto query_mem_tracker = _query_ctx->mem_tracker();
+        SCOPED_THREAD_LOCAL_MEM_TRACKER_SETTER(query_mem_tracker.get());
+
         RETURN_IF_ERROR(_prepare_pipeline_driver(exec_env, request));
         RETURN_IF_ERROR(_prepare_stream_load_pipe(exec_env, request));
     }


### PR DESCRIPTION
## Why I'm doing:

The root cause is:
- exec plan and scan morsels are allocated in `PInternalServiceImplBase<T>::_exec_plan_fragment`
- and these allocated objects are recorded into `process` mem tracker
- however those objects(especially scan morsels) are released in `ScanOperator::_close_chunk_source`
- and these allocated objects are recorded into `query_pool` mem tracker

So `query_pool` mem tracker will be negative. 

## What I'm doing:

switch to query context mem tracker when allocate exec plan and morsels.

**Known Problem**

However I found during a period time, query pool memory usage is larger than process memory usage. I'm not sure why. And this is a known problem. But when query ends, the query pool mem tracker goes zero. 

And that's because some objects are allocated and recorded into query pool mem tracker, are released and record into process mem tracker, so query pool mem tracker is higher than process. But I'm not sure which objects.

To resolve that problem, we have to trace every objects, and that needs huge effort. Oh dear god!

![img_v3_027r_86b3c978-b21f-4e3d-8db4-4f3aea2b986g](https://github.com/StarRocks/starrocks/assets/1081215/e703ac90-5002-4ce6-884e-0e43b12a6ebc)



Fixes https://github.com/StarRocks/starrocks/issues/40965

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
