### PR TITLE
[BugFix] Should send eof packet if param packets are sent

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/qe/StmtExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/StmtExecutor.java
@@ -1736,6 +1736,10 @@ public class StmtExecutor {
         serializer.writeInt2(numParams);
         // reserved_1
         serializer.writeInt1(0);
+        // warning_count
+        serializer.writeInt2(0);
+        // metadata follows
+        serializer.writeInt1(1);
         context.getMysqlChannel().sendOnePacket(serializer.toByteBuffer());
         if (numParams > 0) {
             List<String> colNames = prepareStmt.getParameterLabels();
@@ -1745,6 +1749,10 @@ public class StmtExecutor {
                 serializer.writeField(colNames.get(i), parameters.get(i).getType());
                 context.getMysqlChannel().sendOnePacket(serializer.toByteBuffer());
             }
+            context.getState().setEof();
+        } else {
+            context.getMysqlChannel().flush();
+            context.getState().setStateType(MysqlStateType.NOOP);
         }
     }
 


### PR DESCRIPTION
## Why I'm doing:

#40948 remove the eof packet as bugfix, but it only partially fix the problem, if we are sending params packets, eof packet is still needed.

## What I'm doing:

Send eof packet if we are sending param packets, or do not send extra eof packet.
Also note that we are not sending `columns` packets, cause this feature is not supported currently, some tools using mysql client may require this feature, causing failure, e.g. postgres's mysql_fdw.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
