### PR TITLE
[BugFix] MERGE_LIMIT rule should be applied after PruneGroupByKeysRule's application

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/Optimizer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/Optimizer.java
@@ -452,6 +452,7 @@ public class Optimizer {
         }
 
         tree = pushDownAggregation(tree, rootTaskContext, requiredColumns);
+        ruleRewriteOnlyOnce(tree, rootTaskContext, RuleSetType.MERGE_LIMIT);
 
         CTEUtils.collectCteOperators(tree, context);
         // inline CTE if consume use once

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/SelectStmtTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/SelectStmtTest.java
@@ -594,4 +594,53 @@ public class SelectStmtTest {
             Assert.fail("Should not throw an exception");
         }
     }
+
+    @Test
+    public void testMergeLimitAfterPruneGroupByKeys() throws Exception {
+        String sql = "SELECT\n" +
+                "    name\n" +
+                "FROM\n" +
+                "    (\n" +
+                "        select\n" +
+                "            case\n" +
+                "                when a.emp_name in('Alice', 'Bob') then 'RD'\n" +
+                "                when a.emp_name in('Bob', 'Charlie') then 'QA'\n" +
+                "                else 'BD'\n" +
+                "            end as role,\n" +
+                "            a.emp_name as name\n" +
+                "        from\n" +
+                "            (\n" +
+                "                select 'Alice' as emp_name\n" +
+                "                union   all\n" +
+                "                select 'Bob' as emp_name\n" +
+                "                union all\n" +
+                "                select 'Charlie' as emp_name\n" +
+                "            ) a\n" +
+                "    ) SUB_QRY\n" +
+                "WHERE name IS NOT NULL AND role IN ('QA')\n" +
+                "GROUP BY name\n" +
+                "ORDER BY name ASC";
+        String plan = UtFrameUtils.getVerboseFragmentPlan(starRocksAssert.getCtx(), sql);
+        Assert.assertTrue(plan, plan.contains("PLAN FRAGMENT 0(F00)\n" +
+                "  Output Exprs:7: expr\n" +
+                "  Input Partition: UNPARTITIONED\n" +
+                "  RESULT SINK\n" +
+                "\n" +
+                "  2:SORT\n" +
+                "  |  order by: [7, VARCHAR, false] ASC\n" +
+                "  |  offset: 0\n" +
+                "  |  cardinality: 1\n" +
+                "  |  \n" +
+                "  1:Project\n" +
+                "  |  output columns:\n" +
+                "  |  7 <-> 'Charlie'\n" +
+                "  |  limit: 1\n" +
+                "  |  cardinality: 1\n" +
+                "  |  \n" +
+                "  0:UNION\n" +
+                "     constant exprs: \n" +
+                "         NULL\n" +
+                "     limit: 1\n" +
+                "     cardinality: 1\n"));
+    }
 }


### PR DESCRIPTION
## Why I'm doing:
in logicalRuleRewrite,  pushDownAggregation applies PruneGroupByKeysRule and interpolates a LogicalLimitOperator, but forgets to fold the LimitOperator inside its children. 
## What I'm doing:
So apply MERGE_LIMIT rule after pushDownAggregation's invocation.

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
