### PR TITLE
[Refactor] refactor hdfs scanner orc code

### DIFF
--- a/be/src/exec/hdfs_scanner_orc.cpp
+++ b/be/src/exec/hdfs_scanner_orc.cpp
@@ -335,10 +335,9 @@ Status HdfsOrcScanner::build_stripes(orc::Reader* reader, std::vector<DiskRange>
         int64_t offset = stripeInfo.offset();
 
         if (offset >= scan_start && offset < scan_end) {
-            s.offset = offset;
-            s.length = stripeInfo.datalength() + stripeInfo.indexlength() + stripeInfo.footerlength();
-            stripes->emplace_back(s);
-            _app_stats.orc_stripe_sizes.push_back(s.length);
+            int64_t length = stripeInfo.datalength() + stripeInfo.indexlength() + stripeInfo.footerlength();
+            stripes->emplace_back(offset, length);
+            _app_stats.orc_stripe_sizes.push_back(length);
         }
     }
     return Status::OK();

--- a/be/src/exec/hdfs_scanner_orc.cpp
+++ b/be/src/exec/hdfs_scanner_orc.cpp
@@ -87,9 +87,9 @@ bool OrcRowReaderFilter::filterOnOpeningStripe(uint64_t stripeIndex,
     uint64_t offset = stripeInformation->offset();
 
     const auto* scan_range = _scanner_ctx.scan_range;
-    size_t scan_start = scan_range->offset;
-    size_t scan_end = scan_range->length + scan_start;
-    if (offset >= scan_start && offset < scan_end) {
+    size_t scan_begin = scan_range->offset;
+    size_t scan_end = scan_range->length + scan_begin;
+    if (offset >= scan_begin && offset < scan_end) {
         return false;
     }
     return true;
@@ -306,30 +306,65 @@ bool OrcRowReaderFilter::filterOnPickStringDictionary(
     return false;
 }
 
-Status HdfsOrcScanner::do_open(RuntimeState* runtime_state) {
-    RETURN_IF_ERROR(open_random_access_file());
-    auto input_stream = std::make_unique<ORCHdfsFileStream>(_file.get(), _file->get_size().value(),
-                                                            _shared_buffered_input_stream.get());
-    input_stream->set_lazy_column_coalesce_counter(_scanner_ctx.lazy_column_coalesce_counter);
-    input_stream->set_app_stats(&_app_stats);
-    ORCHdfsFileStream* orc_hdfs_file_stream = input_stream.get();
+Status HdfsOrcScanner::build_iceberg_delete_builder() {
+    if (_scanner_params.deletes.empty()) return Status::OK();
+    SCOPED_RAW_TIMER(&_app_stats.iceberg_delete_file_build_ns);
+    const IcebergDeleteBuilder iceberg_delete_builder(_scanner_params.fs, _scanner_params.path,
+                                                      _scanner_params.conjunct_ctxs, _scanner_params.materialize_slots,
+                                                      &_need_skip_rowids);
 
-    SCOPED_RAW_TIMER(&_app_stats.reader_init_ns);
-    std::unique_ptr<orc::Reader> reader;
-    try {
-        orc::ReaderOptions options;
-        options.setMemoryPool(*getOrcMemoryPool());
-        reader = orc::createReader(std::move(input_stream), options);
-    } catch (std::exception& e) {
-        auto s = strings::Substitute("HdfsOrcScanner::do_open failed. reason = $0", e.what());
-        LOG(WARNING) << s;
-        if (errno == ENOENT || s.find("404") != std::string::npos) {
-            return Status::RemoteFileNotFound(s);
-        }
-
-        return Status::InternalError(s);
+    for (const auto& tdelete_file : _scanner_params.deletes) {
+        RETURN_IF_ERROR(iceberg_delete_builder.build_orc(_runtime_state->timezone(), *tdelete_file,
+                                                         _scanner_params.mor_params.equality_slots, _runtime_state,
+                                                         _mor_processor));
     }
+    _app_stats.iceberg_delete_files_per_scan += _scanner_params.deletes.size();
+    return Status::OK();
+}
 
+Status HdfsOrcScanner::build_stripes(orc::Reader* reader, std::vector<DiskRange>* stripes) {
+    uint64_t stripe_number = reader->getNumberOfStripes();
+    std::vector<DiskRange> stripe_disk_ranges{};
+
+    const auto* scan_range = _scanner_ctx.scan_range;
+    size_t scan_begin = scan_range->offset;
+    size_t scan_end = scan_range->length + scan_begin;
+
+    for (uint64_t idx = 0; idx < stripe_number; idx++) {
+        auto stripeInfo = reader->getStripeInOrcFormat(idx);
+        int64_t offset = stripeInfo.offset();
+
+        if (offset >= scan_begin && offset < scan_end) {
+            int64_t length = stripeInfo.datalength() + stripeInfo.indexlength() + stripeInfo.footerlength();
+            stripe_disk_ranges.emplace_back(offset, length);
+            _app_stats.orc_stripe_sizes.push_back(length);
+        }
+    }
+    return Status::OK();
+}
+
+Status HdfsOrcScanner::build_io_ranges(ORCHdfsFileStream* file_stream, const std::vector<DiskRange>& stripes) {
+    bool tiny_stripe_read = true;
+    for (const DiskRange& disk_range : stripes) {
+        if (disk_range.length > config::orc_tiny_stripe_threshold_size) {
+            tiny_stripe_read = false;
+            break;
+        }
+    }
+    // we need to start tiny stripe optimization if all stripe's size smaller than config::orc_tiny_stripe_threshold_size
+    if (tiny_stripe_read) {
+        std::vector<io::SharedBufferedInputStream::IORange> io_ranges{};
+        DiskRangeHelper::mergeAdjacentDiskRanges(io_ranges, stripes, config::io_coalesce_read_max_distance_size,
+                                                 config::orc_tiny_stripe_threshold_size);
+        for (const auto& it : io_ranges) {
+            _app_stats.orc_total_tiny_stripe_size += it.size;
+        }
+        RETURN_IF_ERROR(file_stream->setIORanges(io_ranges));
+    }
+    return Status::OK();
+}
+
+Status HdfsOrcScanner::resolve_columns(orc::Reader* reader) {
     std::unordered_set<std::string> known_column_names;
     OrcChunkReader::build_column_name_set(&known_column_names, _scanner_ctx.hive_column_names, reader->getType(),
                                           _scanner_ctx.case_sensitive);
@@ -338,11 +373,9 @@ Status HdfsOrcScanner::do_open(RuntimeState* runtime_state) {
     if (skip) {
         LOG(INFO) << "HdfsOrcScanner: do_open. skip file for non existed slot conjuncts.";
         _should_skip_file = true;
-        // no need to intialize following context.
         return Status::OK();
     }
 
-    // create orc reader for further reading.
     int src_slot_index = 0;
     for (const auto& column : _scanner_ctx.materialized_columns) {
         auto col_name = OrcChunkReader::format_column_name(column.col_name, _scanner_ctx.case_sensitive);
@@ -372,7 +405,44 @@ Status HdfsOrcScanner::do_open(RuntimeState* runtime_state) {
         _src_slot_descriptors.emplace_back(column.slot_desc);
         src_slot_index++;
     }
+    return Status::OK();
+}
 
+Status HdfsOrcScanner::do_open(RuntimeState* runtime_state) {
+    // create wrapped input stream.
+    RETURN_IF_ERROR(open_random_access_file());
+    auto input_stream = std::make_unique<ORCHdfsFileStream>(_file.get(), _file->get_size().value(),
+                                                            _shared_buffered_input_stream.get());
+    input_stream->set_lazy_column_coalesce_counter(_scanner_ctx.lazy_column_coalesce_counter);
+    input_stream->set_app_stats(&_app_stats);
+    ORCHdfsFileStream* orc_hdfs_file_stream = input_stream.get();
+
+    // create orc reader on this input stream.
+    SCOPED_RAW_TIMER(&_app_stats.reader_init_ns);
+    std::unique_ptr<orc::Reader> reader;
+    try {
+        orc::ReaderOptions options;
+        options.setMemoryPool(*getOrcMemoryPool());
+        reader = orc::createReader(std::move(input_stream), options);
+    } catch (std::exception& e) {
+        auto s = strings::Substitute("HdfsOrcScanner::do_open failed. reason = $0", e.what());
+        LOG(WARNING) << s;
+        if (errno == ENOENT || s.find("404") != std::string::npos) {
+            return Status::RemoteFileNotFound(s);
+        }
+        return Status::InternalError(s);
+    }
+
+    // select stripes to read and resolve columns aganist this orc file.
+    std::vector<DiskRange> stripes;
+    RETURN_IF_ERROR(build_stripes(reader.get(), &stripes));
+    RETURN_IF_ERROR(build_io_ranges(orc_hdfs_file_stream, stripes));
+    RETURN_IF_ERROR(resolve_columns(reader.get()));
+    if (_should_skip_file) {
+        return Status::OK();
+    }
+
+    // create orc chunk reader .
     _orc_reader = std::make_unique<OrcChunkReader>(runtime_state->chunk_size(), _src_slot_descriptors);
     _orc_row_reader_filter = std::make_shared<OrcRowReaderFilter>(_scanner_ctx, _orc_reader.get());
     _orc_reader->disable_broker_load_mode();
@@ -398,42 +468,11 @@ Status HdfsOrcScanner::do_open(RuntimeState* runtime_state) {
         _orc_reader->set_lazy_load_context(&_lazy_load_ctx);
     }
 
-    // select out strips we are going to read.
-    {
-        uint64_t stripe_number = reader->getNumberOfStripes();
-        std::vector<DiskRange> stripe_disk_ranges{};
-        for (uint64_t idx = 0; idx < stripe_number; idx++) {
-            auto stripeInfo = reader->getStripeInOrcFormat(idx);
-            if (_orc_row_reader_filter->filterOnOpeningStripe(idx, &stripeInfo)) continue;
-            int64_t offset = stripeInfo.offset();
-            int64_t length = stripeInfo.datalength() + stripeInfo.indexlength() + stripeInfo.footerlength();
-            stripe_disk_ranges.emplace_back(offset, length);
-            _app_stats.orc_stripe_sizes.push_back(length);
-        }
-
-        {
-            bool tiny_stripe_read = true;
-            for (const DiskRange& disk_range : stripe_disk_ranges) {
-                if (disk_range.length > config::orc_tiny_stripe_threshold_size) {
-                    tiny_stripe_read = false;
-                    break;
-                }
-            }
-            // we need to start tiny stripe optimization if all stripe's size smaller than config::orc_tiny_stripe_threshold_size
-            if (tiny_stripe_read) {
-                std::vector<io::SharedBufferedInputStream::IORange> io_ranges{};
-                DiskRangeHelper::mergeAdjacentDiskRanges(io_ranges, stripe_disk_ranges,
-                                                         config::io_coalesce_read_max_distance_size,
-                                                         config::orc_tiny_stripe_threshold_size);
-                for (const auto& it : io_ranges) {
-                    _app_stats.orc_total_tiny_stripe_size += it.size;
-                }
-                RETURN_IF_ERROR(orc_hdfs_file_stream->setIORanges(io_ranges));
-            }
-        }
-    }
-
     RETURN_IF_ERROR(_orc_reader->init(std::move(reader)));
+
+    // create iceberg delete builder at last
+    RETURN_IF_ERROR(build_iceberg_delete_builder());
+
     return Status::OK();
 }
 
@@ -571,22 +610,6 @@ StatusOr<size_t> HdfsOrcScanner::_do_get_next(ChunkPtr* chunk) {
 Status HdfsOrcScanner::do_init(RuntimeState* runtime_state, const HdfsScannerParams& scanner_params) {
     _should_skip_file = false;
     _use_orc_sargs = true;
-    // todo: build predicate hook and ranges hook.
-
-    if (!scanner_params.deletes.empty()) {
-        SCOPED_RAW_TIMER(&_app_stats.iceberg_delete_file_build_ns);
-        const IcebergDeleteBuilder iceberg_delete_builder(scanner_params.fs, scanner_params.path,
-                                                          scanner_params.conjunct_ctxs,
-                                                          scanner_params.materialize_slots, &_need_skip_rowids);
-
-        for (const auto& tdelete_file : scanner_params.deletes) {
-            RETURN_IF_ERROR(iceberg_delete_builder.build_orc(runtime_state->timezone(), *tdelete_file,
-                                                             scanner_params.mor_params.equality_slots, runtime_state,
-                                                             _mor_processor));
-        }
-        _app_stats.iceberg_delete_files_per_scan += scanner_params.deletes.size();
-    }
-
     return Status::OK();
 }
 

--- a/be/src/exec/hdfs_scanner_orc.h
+++ b/be/src/exec/hdfs_scanner_orc.h
@@ -18,6 +18,8 @@
 
 #include "exec/hdfs_scanner.h"
 #include "formats/orc/orc_chunk_reader.h"
+#include "formats/orc/orc_input_stream.h"
+#include "formats/orc/utils.h"
 
 namespace starrocks {
 
@@ -48,6 +50,11 @@ private:
     // hdfs_scanner_orc will only eval conjunctions in _eval_conjunct_ctxs_by_materialized_slot
     // _eval_conjunct_ctxs_by_materialized_slot's slot must be existed in orc file
     std::unordered_map<SlotId, std::vector<ExprContext*>> _eval_conjunct_ctxs_by_materialized_slot{};
+
+    Status build_iceberg_delete_builder();
+    Status build_stripes(orc::Reader* reader, std::vector<DiskRange>* stripes);
+    Status build_io_ranges(ORCHdfsFileStream* file_stream, const std::vector<DiskRange>& stripes);
+    Status resolve_columns(orc::Reader* reader);
 
     // disable orc search argument would be much easier for
     // writing unittest of customized filter

--- a/be/src/exec/hdfs_scanner_orc.h
+++ b/be/src/exec/hdfs_scanner_orc.h
@@ -35,7 +35,6 @@ public:
     Status do_get_next(RuntimeState* runtime_state, ChunkPtr* chunk) override;
     Status do_init(RuntimeState* runtime_state, const HdfsScannerParams& scanner_params) override;
     void do_update_counter(HdfsScanProfile* profile) override;
-
     void disable_use_orc_sargs() { _use_orc_sargs = false; }
 
 private:
@@ -66,6 +65,7 @@ private:
     Filter _dict_filter;
     Filter _chunk_filter;
     std::set<int64_t> _need_skip_rowids;
+    std::unique_ptr<ORCHdfsFileStream> _input_stream;
 };
 
 } // namespace starrocks

--- a/be/src/formats/orc/utils.h
+++ b/be/src/formats/orc/utils.h
@@ -21,7 +21,6 @@
 #include "cctz/time_zone.h"
 #include "column/vectorized_fwd.h"
 #include "formats/orc/orc_mapping.h"
-#include "formats/orc/utils.h"
 #include "gen_cpp/orc_proto.pb.h"
 #include "io/shared_buffered_input_stream.h"
 #include "types/date_value.h"

--- a/be/test/exec/hdfs_scanner_test.cpp
+++ b/be/test/exec/hdfs_scanner_test.cpp
@@ -455,12 +455,6 @@ public:
         errno = ret_errno;
         throw std::runtime_error(ret_message);
     }
-
-    void prepareCache(PrepareCacheScope scope, uint64_t offset, uint64_t length) override {
-        errno = ret_errno;
-        throw std::runtime_error(ret_message);
-    }
-
     int ret_errno = 0;
     std::string ret_message;
 };

--- a/be/test/exec/hdfs_scanner_test.cpp
+++ b/be/test/exec/hdfs_scanner_test.cpp
@@ -469,11 +469,14 @@ TEST_F(HdfsScannerTest, TestOrcReaderException) {
     struct ErrorContent {
         int ret_errno;
         std::string ret_message;
+        TStatusCode::type ret_code;
     };
 
     std::vector<ErrorContent> error_contents = {
-            ErrorContent{.ret_errno = 0, .ret_message = "read error"},
-            ErrorContent{.ret_errno = ENOENT, .ret_message = "S3 SDK Error. Code = 404"},
+            ErrorContent{.ret_errno = 0, .ret_message = "read error", .ret_code = TStatusCode::INTERNAL_ERROR},
+            ErrorContent{.ret_errno = ENOENT,
+                         .ret_message = "S3 SDK Error. Code = 404",
+                         .ret_code = TStatusCode::REMOTE_FILE_NOT_FOUND},
     };
 
     for (const auto& ec : error_contents) {
@@ -500,6 +503,7 @@ TEST_F(HdfsScannerTest, TestOrcReaderException) {
 
         status = scanner->open(_runtime_state);
         EXPECT_FALSE(status.ok()) << status.message();
+        EXPECT_EQ(status.code(), ec.ret_code);
         scanner->close();
     }
 }

--- a/be/test/exec/hdfs_scanner_test.cpp
+++ b/be/test/exec/hdfs_scanner_test.cpp
@@ -423,6 +423,87 @@ TEST_F(HdfsScannerTest, TestOrcGetNext) {
     scanner->close();
 }
 
+TEST_F(HdfsScannerTest, TestOrcSkipFile) {
+    auto scanner = std::make_shared<HdfsOrcScanner>();
+
+    auto* range = _create_scan_range(mtypes_orc_file, 0, 0);
+    auto* tuple_desc = _create_tuple_desc(mtypes_orc_descs);
+    auto* param = _create_param(mtypes_orc_file, range, tuple_desc);
+    // partition values for [PART_x, PART_y]
+    std::vector<int64_t> values = {10, 20};
+    extend_partition_values(&_pool, param, values);
+
+    ASSERT_OK(Expr::prepare(param->partition_values, _runtime_state));
+    ASSERT_OK(Expr::open(param->partition_values, _runtime_state));
+
+    Status status = scanner->init(_runtime_state, *param);
+    EXPECT_TRUE(status.ok());
+
+    scanner->_should_skip_file = true;
+    status = scanner->open(_runtime_state);
+    EXPECT_TRUE(status.ok());
+
+    READ_SCANNER_ROWS(scanner, 0);
+    EXPECT_EQ(scanner->raw_rows_read(), 0);
+    scanner->close();
+}
+
+class BadOrcFileStream : public ORCHdfsFileStream {
+public:
+    BadOrcFileStream() : ORCHdfsFileStream(nullptr, 1024 * 1024, nullptr) {}
+    void read(void* buf, uint64_t length, uint64_t offset) override {
+        errno = ret_errno;
+        throw std::runtime_error(ret_message);
+    }
+
+    void prepareCache(PrepareCacheScope scope, uint64_t offset, uint64_t length) override {
+        errno = ret_errno;
+        throw std::runtime_error(ret_message);
+    }
+
+    int ret_errno = 0;
+    std::string ret_message;
+};
+
+TEST_F(HdfsScannerTest, TestOrcReaderException) {
+    struct ErrorContent {
+        int ret_errno;
+        std::string ret_message;
+    };
+
+    std::vector<ErrorContent> error_contents = {
+            ErrorContent{.ret_errno = 0, .ret_message = "read error"},
+            ErrorContent{.ret_errno = ENOENT, .ret_message = "S3 SDK Error. Code = 404"},
+    };
+
+    for (const auto& ec : error_contents) {
+        auto scanner = std::make_shared<HdfsOrcScanner>();
+
+        auto* range = _create_scan_range(mtypes_orc_file, 0, 0);
+        auto* tuple_desc = _create_tuple_desc(mtypes_orc_descs);
+        auto* param = _create_param(mtypes_orc_file, range, tuple_desc);
+
+        // partition values for [PART_x, PART_y]
+        std::vector<int64_t> values = {10, 20};
+        extend_partition_values(&_pool, param, values);
+
+        ASSERT_OK(Expr::prepare(param->partition_values, _runtime_state));
+        ASSERT_OK(Expr::open(param->partition_values, _runtime_state));
+
+        std::unique_ptr<BadOrcFileStream> file_stream(new BadOrcFileStream());
+        file_stream->ret_errno = ec.ret_errno;
+        file_stream->ret_message = ec.ret_message;
+        scanner->_input_stream = std::move(file_stream);
+
+        Status status = scanner->init(_runtime_state, *param);
+        EXPECT_TRUE(status.ok());
+
+        status = scanner->open(_runtime_state);
+        EXPECT_FALSE(status.ok()) << status.message();
+        scanner->close();
+    }
+}
+
 static void extend_mtypes_orc_min_max_conjuncts(ObjectPool* pool, HdfsScannerParams* params,
                                                 const std::vector<int>& values) {
     const TupleDescriptor* min_max_tuple_desc = params->min_max_tuple_desc;


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:

To refactor hdfs scanner orc init/open method:
- extract `build_iceberg_delete_builder` method (build iceberg delete builder)
- extract `build_stripes` method (select stripes we are going to read)
- extract `resolve_columns` method (resolve column names and init lazy load context)

And:
- I've put `build_iceberg_delete_builder` at end of `open` code.
- because sometimes we might early quit then we don't need to build iceberg delete builder at all.

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [x] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
