### PR TITLE
[Enhancement] Thread check joinable before some process join in storage_engine

### DIFF
--- a/be/src/exec/file_scan_node.cpp
+++ b/be/src/exec/file_scan_node.cpp
@@ -180,7 +180,9 @@ void FileScanNode::close(RuntimeState* state) {
     _queue_writer_cond.notify_all();
     _queue_reader_cond.notify_all();
     for (auto& _scanner_thread : _scanner_threads) {
-        _scanner_thread.join();
+        if (_scanner_thread.joinable()) {
+            _scanner_thread.join();
+        }
     }
 
     while (!_chunk_queue.empty()) {

--- a/be/src/exec/file_scan_node.cpp
+++ b/be/src/exec/file_scan_node.cpp
@@ -180,9 +180,7 @@ void FileScanNode::close(RuntimeState* state) {
     _queue_writer_cond.notify_all();
     _queue_reader_cond.notify_all();
     for (auto& _scanner_thread : _scanner_threads) {
-        if (_scanner_thread.joinable()) {
-            _scanner_thread.join();
-        }
+        _scanner_thread.join();
     }
 
     while (!_chunk_queue.empty()) {

--- a/be/src/storage/storage_engine.cpp
+++ b/be/src/storage/storage_engine.cpp
@@ -185,9 +185,8 @@ void StorageEngine::load_data_dirs(const std::vector<DataDir*>& data_dirs) {
         Thread::set_thread_name(threads.back(), "compact_data_dir");
     }
     for (auto& thread : threads) {
-        if (thread.joinable()) {
-            thread.join();
-        }
+        DCHECK(thread.joinable());
+        thread.join();
     }
 }
 
@@ -280,9 +279,8 @@ Status StorageEngine::_init_store_map() {
         Thread::set_thread_name(threads.back(), "init_store_path");
     }
     for (auto& thread : threads) {
-        if (thread.joinable()) {
-            thread.join();
-        }
+        DCHECK(thread.joinable());
+        thread.join();
     }
 
     if (!error_msg.empty()) {

--- a/be/src/storage/storage_engine.cpp
+++ b/be/src/storage/storage_engine.cpp
@@ -185,7 +185,9 @@ void StorageEngine::load_data_dirs(const std::vector<DataDir*>& data_dirs) {
         Thread::set_thread_name(threads.back(), "compact_data_dir");
     }
     for (auto& thread : threads) {
-        thread.join();
+        if (thread.joinable()) {
+            thread.join();
+        }
     }
 }
 
@@ -278,7 +280,9 @@ Status StorageEngine::_init_store_map() {
         Thread::set_thread_name(threads.back(), "init_store_path");
     }
     for (auto& thread : threads) {
-        thread.join();
+        if (thread.joinable()) {
+            thread.join();
+        }
     }
 
     if (!error_msg.empty()) {


### PR DESCRIPTION
## Why I'm doing:
Some thread join not check joinable before join which may cause collapse
## What I'm doing:
Add joinable check before join
Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
