### PR TITLE
[BugFix] Fix crash when using sort key in column with row store

### DIFF
--- a/be/src/exec/short_circuit_hybrid.cpp
+++ b/be/src/exec/short_circuit_hybrid.cpp
@@ -116,8 +116,11 @@ Status ShortCircuitHybridScanNode::get_next(RuntimeState* state, ChunkPtr* chunk
 Status ShortCircuitHybridScanNode::_process_key_chunk() {
     DCHECK(_tablets.size() > 0);
     _tablet_schema = _tablets[0]->tablet_schema();
-    auto& key_column_cids = _tablet_schema->sort_key_idxes();
-    auto key_schema = ChunkHelper::convert_schema(_tablet_schema, key_column_cids);
+    vector<uint32_t> pk_columns;
+    for (size_t i = 0; i < _tablet_schema->num_key_columns(); i++) {
+        pk_columns.push_back((uint32_t)i);
+    }
+    auto key_schema = ChunkHelper::convert_schema(_tablet_schema, pk_columns);
 
     _key_chunk = ChunkHelper::new_chunk(key_schema, _num_rows);
     _key_chunk->reset();


### PR DESCRIPTION
## Why I'm doing:

Using sort key in column with row store will crash in tests, because sort key instead of pk is used in ShortCircuitHybridScanNode.

## What I'm doing:

Fix this.

Fixes #40956

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
