### PR TITLE
[Enhancement] Supports estimating FE memory by module (backport #39053) 

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/backup/BackupHandler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/backup/BackupHandler.java
@@ -35,6 +35,7 @@
 package com.starrocks.backup;
 
 import com.google.common.base.Preconditions;
+import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
@@ -56,6 +57,7 @@ import com.starrocks.common.FeMetaVersion;
 import com.starrocks.common.Pair;
 import com.starrocks.common.io.Writable;
 import com.starrocks.common.util.LeaderDaemon;
+import com.starrocks.memory.MemoryTrackable;
 import com.starrocks.persist.metablock.SRMetaBlockEOFException;
 import com.starrocks.persist.metablock.SRMetaBlockException;
 import com.starrocks.persist.metablock.SRMetaBlockReader;
@@ -92,7 +94,7 @@ import java.util.Set;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.locks.ReentrantLock;
 
-public class BackupHandler extends LeaderDaemon implements Writable {
+public class BackupHandler extends LeaderDaemon implements Writable, MemoryTrackable {
     private static final Logger LOG = LogManager.getLogger(BackupHandler.class);
 
     public static final int SIGNATURE_VERSION = 1;
@@ -718,6 +720,12 @@ public class BackupHandler extends LeaderDaemon implements Writable {
             seqlock.unlock();
         }
     }
+
+    @Override
+    public Map<String, Long> estimateCount() {
+        return ImmutableMap.of("BackupOrRestoreJob", (long) dbIdToBackupOrRestoreJob.size());
+    }
+
 }
 
 

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/TabletInvertedIndex.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/TabletInvertedIndex.java
@@ -38,6 +38,7 @@ import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ArrayListMultimap;
 import com.google.common.collect.HashBasedTable;
+import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ListMultimap;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
@@ -48,6 +49,7 @@ import com.starrocks.catalog.Replica.ReplicaState;
 import com.starrocks.common.Config;
 import com.starrocks.common.Pair;
 import com.starrocks.lake.LakeTablet;
+import com.starrocks.memory.MemoryTrackable;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.server.LocalMetastore;
 import com.starrocks.system.Backend;
@@ -78,7 +80,7 @@ import java.util.stream.Collectors;
  * Checkpoint thread is no need to modify this inverted index, because this inverted index will not be wrote
  * into images, all meta data are in globalStateMgr, and the inverted index will be rebuild when FE restart.
  */
-public class TabletInvertedIndex {
+public class TabletInvertedIndex implements MemoryTrackable {
     private static final Logger LOG = LogManager.getLogger(TabletInvertedIndex.class);
 
     public static final int NOT_EXIST_VALUE = -1;
@@ -867,6 +869,11 @@ public class TabletInvertedIndex {
         } finally {
             writeUnlock();
         }
+    }
+
+    @Override
+    public Map<String, Long> estimateCount() {
+        return ImmutableMap.of("TabletMeta", (long) tabletMetaMap.size());
     }
 }
 

--- a/fe/fe-core/src/main/java/com/starrocks/common/Config.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/Config.java
@@ -1098,6 +1098,18 @@ public class Config extends ConfigBase {
     public static long dynamic_partition_check_interval_seconds = 600;
 
     /**
+     * If set to true, memory tracker feature will open
+     */
+    @ConfField(mutable = true)
+    public static boolean memory_tracker_enable = true;
+
+    /**
+     * Decide how often to track the memory usage of the FE process
+     */
+    @ConfField(mutable = true)
+    public static long memory_tracker_interval_seconds = 60;
+
+    /**
      * If batch creation of partitions is allowed to create half of the partitions, it is easy to generate holes.
      * By default, this is not enabled. If it is turned on, the partitions built by batch creation syntax will
      * not allow partial creation.

--- a/fe/fe-core/src/main/java/com/starrocks/common/util/ProfileManager.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/util/ProfileManager.java
@@ -35,11 +35,14 @@
 package com.starrocks.common.util;
 
 import com.google.common.base.Strings;
+import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.starrocks.common.Config;
+import com.starrocks.memory.MemoryTrackable;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.apache.spark.util.SizeEstimator;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -63,7 +66,7 @@ import java.util.concurrent.locks.ReentrantReadWriteLock.WriteLock;
  * the purpose is let coordinator can destruct earlier(the fragment profile is in Coordinator)
  *
  */
-public class ProfileManager {
+public class ProfileManager implements MemoryTrackable {
     private static final Logger LOG = LogManager.getLogger(ProfileManager.class);
     private static ProfileManager INSTANCE = null;
     public static final String QUERY_ID = "Query ID";
@@ -214,5 +217,16 @@ public class ProfileManager {
         } finally {
             readLock.unlock();
         }
+    }
+
+    @Override
+    public long estimateSize() {
+        return SizeEstimator.estimate(profileMap) + SizeEstimator.estimate(profileDeque);
+    }
+
+    @Override
+    public Map<String, Long> estimateCount() {
+        return ImmutableMap.of("Profile", (long) profileMap.size(),
+                "ProfileDeque", (long) profileDeque.size());
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/leader/LeaderImpl.java
+++ b/fe/fe-core/src/main/java/com/starrocks/leader/LeaderImpl.java
@@ -77,6 +77,7 @@ import com.starrocks.lake.LakeTablet;
 import com.starrocks.load.DeleteJob;
 import com.starrocks.load.OlapDeleteJob;
 import com.starrocks.load.loadv2.SparkLoadJob;
+import com.starrocks.memory.MemoryUsageTracker;
 import com.starrocks.persist.ReplicaPersistInfo;
 import com.starrocks.rpc.FrontendServiceProxy;
 import com.starrocks.server.GlobalStateMgr;
@@ -162,6 +163,7 @@ public class LeaderImpl {
 
     public LeaderImpl() {
         reportHandler.start();
+        MemoryUsageTracker.registerMemoryTracker("Report", reportHandler);
     }
 
     public TMasterResult finishTask(TFinishTaskRequest request) {

--- a/fe/fe-core/src/main/java/com/starrocks/leader/ReportHandler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/leader/ReportHandler.java
@@ -38,6 +38,7 @@ import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ArrayListMultimap;
 import com.google.common.collect.HashBasedTable;
+import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ListMultimap;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
@@ -67,6 +68,7 @@ import com.starrocks.common.MetaNotFoundException;
 import com.starrocks.common.Pair;
 import com.starrocks.common.util.Daemon;
 import com.starrocks.common.util.TimeUtils;
+import com.starrocks.memory.MemoryTrackable;
 import com.starrocks.metric.GaugeMetric;
 import com.starrocks.metric.Metric.MetricUnit;
 import com.starrocks.metric.MetricRepo;
@@ -111,6 +113,7 @@ import org.apache.commons.lang3.tuple.ImmutableTriple;
 import org.apache.commons.lang3.tuple.Triple;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.apache.spark.util.SizeEstimator;
 import org.apache.thrift.TException;
 
 import java.util.HashMap;
@@ -120,7 +123,22 @@ import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.BlockingQueue;
 
-public class ReportHandler extends Daemon {
+public class ReportHandler extends Daemon implements MemoryTrackable {
+    @Override
+    public long estimateSize() {
+        return SizeEstimator.estimate(reportQueue) + SizeEstimator.estimate(pendingTaskMap);
+    }
+
+    @Override
+    public Map<String, Long> estimateCount() {
+        long count = 0;
+        for (Map<Long, ReportTask> taskMap : pendingTaskMap.values()) {
+            count += taskMap.size();
+        }
+        return ImmutableMap.of("PendingTask", count,
+                                "ReportQueue", (long) reportQueue.size());
+    }
+
     public enum ReportType {
         UNKNOWN_REPORT,
         TABLET_REPORT,

--- a/fe/fe-core/src/main/java/com/starrocks/load/DeleteMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/DeleteMgr.java
@@ -37,6 +37,7 @@ package com.starrocks.load;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Joiner;
 import com.google.common.base.Preconditions;
+import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Range;
@@ -78,6 +79,7 @@ import com.starrocks.common.io.Writable;
 import com.starrocks.common.util.ListComparator;
 import com.starrocks.common.util.TimeUtils;
 import com.starrocks.lake.delete.LakeDeleteJob;
+import com.starrocks.memory.MemoryTrackable;
 import com.starrocks.mysql.privilege.PrivPredicate;
 import com.starrocks.persist.gson.GsonUtils;
 import com.starrocks.persist.metablock.SRMetaBlockEOFException;
@@ -114,7 +116,7 @@ import java.util.UUID;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
 import java.util.stream.Collectors;
 
-public class DeleteMgr implements Writable {
+public class DeleteMgr implements Writable, MemoryTrackable {
     private static final Logger LOG = LogManager.getLogger(DeleteMgr.class);
 
     // TransactionId -> DeleteJob
@@ -849,4 +851,14 @@ public class DeleteMgr implements Writable {
             dbToDeleteInfos.put(dbId, multiDeleteInfos);
         }
     }
+
+    @Override
+    public Map<String, Long> estimateCount() {
+        long count = 0;
+        for (List<MultiDeleteInfo> value : dbToDeleteInfos.values()) {
+            count += value.size();
+        }
+        return ImmutableMap.of("DeleteInfo", count);
+    }
+
 }

--- a/fe/fe-core/src/main/java/com/starrocks/load/ExportMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/ExportMgr.java
@@ -34,6 +34,7 @@
 
 package com.starrocks.load;
 
+import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.gson.Gson;
@@ -50,6 +51,7 @@ import com.starrocks.common.UserException;
 import com.starrocks.common.util.ListComparator;
 import com.starrocks.common.util.OrderByPair;
 import com.starrocks.common.util.TimeUtils;
+import com.starrocks.memory.MemoryTrackable;
 import com.starrocks.mysql.privilege.PrivPredicate;
 import com.starrocks.mysql.privilege.Privilege;
 import com.starrocks.persist.metablock.SRMetaBlockEOFException;
@@ -78,7 +80,7 @@ import java.util.UUID;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
 import java.util.stream.Collectors;
 
-public class ExportMgr {
+public class ExportMgr implements MemoryTrackable {
     private static final Logger LOG = LogManager.getLogger(ExportJob.class);
 
     // lock for export job
@@ -464,5 +466,10 @@ public class ExportMgr {
             }
             unprotectAddJob(job);
         }
+    }
+
+    @Override
+    public Map<String, Long> estimateCount() {
+        return ImmutableMap.of("ExportJob", (long) idToJob.size());
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/load/loadv2/LoadMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/loadv2/LoadMgr.java
@@ -35,6 +35,7 @@
 package com.starrocks.load.loadv2;
 
 import com.google.common.base.Strings;
+import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
@@ -55,6 +56,7 @@ import com.starrocks.load.EtlJobType;
 import com.starrocks.load.FailMsg;
 import com.starrocks.load.FailMsg.CancelType;
 import com.starrocks.load.Load;
+import com.starrocks.memory.MemoryTrackable;
 import com.starrocks.persist.AlterLoadJobOperationLog;
 import com.starrocks.persist.metablock.SRMetaBlockEOFException;
 import com.starrocks.persist.metablock.SRMetaBlockException;
@@ -100,7 +102,7 @@ import java.util.stream.Collectors;
  * LoadManager.lock
  * LoadJob.lock
  */
-public class LoadMgr implements Writable {
+public class LoadMgr implements Writable, MemoryTrackable {
     private static final Logger LOG = LogManager.getLogger(LoadMgr.class);
 
     private Map<Long, LoadJob> idToLoadJob = Maps.newConcurrentMap();
@@ -796,4 +798,10 @@ public class LoadMgr implements Writable {
             GlobalStateMgr.getCurrentGlobalTransactionMgr().getCallbackFactory().addCallback(loadJob);
         }
     }
+
+    @Override
+    public Map<String, Long> estimateCount() {
+        return ImmutableMap.of("LoadJob", (long) idToLoadJob.size());
+    }
+
 }

--- a/fe/fe-core/src/main/java/com/starrocks/load/routineload/RoutineLoadMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/routineload/RoutineLoadMgr.java
@@ -35,6 +35,7 @@
 package com.starrocks.load.routineload;
 
 import com.google.common.base.Preconditions;
+import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
@@ -52,6 +53,7 @@ import com.starrocks.common.io.Writable;
 import com.starrocks.common.util.LogBuilder;
 import com.starrocks.common.util.LogKey;
 import com.starrocks.load.RoutineLoadDesc;
+import com.starrocks.memory.MemoryTrackable;
 import com.starrocks.mysql.privilege.PrivPredicate;
 import com.starrocks.persist.AlterRoutineLoadJobOperationLog;
 import com.starrocks.persist.RoutineLoadOperation;
@@ -85,7 +87,7 @@ import java.util.concurrent.locks.ReentrantLock;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
 import java.util.stream.Collectors;
 
-public class RoutineLoadMgr implements Writable {
+public class RoutineLoadMgr implements Writable, MemoryTrackable {
     private static final Logger LOG = LogManager.getLogger(RoutineLoadMgr.class);
 
     // be => running tasks num
@@ -704,5 +706,10 @@ public class RoutineLoadMgr implements Writable {
 
             putJob(routineLoadJob);
         }
+    }
+
+    @Override
+    public Map<String, Long> estimateCount() {
+        return ImmutableMap.of("RoutineLoad", (long) idToRoutineLoadJob.size());
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/load/streamload/StreamLoadMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/streamload/StreamLoadMgr.java
@@ -14,6 +14,7 @@
 
 package com.starrocks.load.streamload;
 
+import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.starrocks.catalog.Database;
@@ -28,6 +29,7 @@ import com.starrocks.common.UserException;
 import com.starrocks.common.util.LogBuilder;
 import com.starrocks.common.util.LogKey;
 import com.starrocks.http.rest.TransactionResult;
+import com.starrocks.memory.MemoryTrackable;
 import com.starrocks.persist.metablock.SRMetaBlockEOFException;
 import com.starrocks.persist.metablock.SRMetaBlockException;
 import com.starrocks.persist.metablock.SRMetaBlockReader;
@@ -49,7 +51,7 @@ import java.util.Map;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
 import java.util.stream.Collectors;
 
-public class StreamLoadMgr {
+public class StreamLoadMgr implements MemoryTrackable {
     private static final Logger LOG = LogManager.getLogger(StreamLoadMgr.class);
 
     private Map<String, StreamLoadTask> idToStreamLoadTask;
@@ -478,5 +480,10 @@ public class StreamLoadMgr {
 
             addLoadTask(loadTask);
         }
+    }
+
+    @Override
+    public Map<String, Long> estimateCount() {
+        return ImmutableMap.of("StreamLoad", (long) idToStreamLoadTask.size());
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/memory/InternalCatalogMemoryTracker.java
+++ b/fe/fe-core/src/main/java/com/starrocks/memory/InternalCatalogMemoryTracker.java
@@ -1,0 +1,63 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.memory;
+
+import com.google.common.collect.ImmutableMap;
+import com.starrocks.catalog.Database;
+import com.starrocks.catalog.Partition;
+import com.starrocks.catalog.Table;
+import com.starrocks.server.GlobalStateMgr;
+import org.apache.spark.util.SizeEstimator;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+
+public class InternalCatalogMemoryTracker implements MemoryTrackable {
+
+    @Override
+    public long estimateSize() {
+        long estimateSize = 0L;
+        List<Database> databases = new ArrayList<>(GlobalStateMgr.getCurrentState().getIdToDb().values());
+        for (Database database : databases) {
+            List<Table> tables = database.getTables();
+            for (Table table : tables) {
+                Collection<Partition> partitions = table.getPartitions();
+                Iterator<Partition> iterator = partitions.iterator();
+                if (iterator.hasNext()) {
+                    estimateSize += SizeEstimator.estimate(iterator.next()) * partitions.size();
+                }
+            }
+        }
+        return estimateSize;
+    }
+
+    @Override
+    public Map<String, Long> estimateCount() {
+        long estimateCount = 0;
+        List<Database> databases = new ArrayList<>(GlobalStateMgr.getCurrentState().getIdToDb().values());
+        for (Database database : databases) {
+            List<Table> tables = database.getTables();
+            for (Table table : tables) {
+                Collection<Partition> partitions = table.getPartitions();
+                estimateCount += partitions.size();
+            }
+        }
+        return ImmutableMap.of("Partition", estimateCount);
+    }
+
+}

--- a/fe/fe-core/src/main/java/com/starrocks/memory/MemoryStat.java
+++ b/fe/fe-core/src/main/java/com/starrocks/memory/MemoryStat.java
@@ -1,0 +1,48 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.memory;
+
+public class MemoryStat {
+
+    private long currentConsumption;
+
+    private long objectCount;
+
+    private long peakConsumption;
+
+    public long getCurrentConsumption() {
+        return currentConsumption;
+    }
+
+    public void setCurrentConsumption(long currentConsumption) {
+        this.currentConsumption = currentConsumption;
+    }
+
+    public long getObjectCount() {
+        return objectCount;
+    }
+
+    public void setObjectCount(long objectCount) {
+        this.objectCount = objectCount;
+    }
+
+    public long getPeakConsumption() {
+        return peakConsumption;
+    }
+
+    public void setPeakConsumption(long peakConsumption) {
+        this.peakConsumption = peakConsumption;
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/memory/MemoryTrackable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/memory/MemoryTrackable.java
@@ -1,0 +1,29 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.memory;
+
+import org.apache.spark.util.SizeEstimator;
+
+import java.util.Map;
+
+public interface MemoryTrackable {
+
+    default long estimateSize() {
+        return SizeEstimator.estimate(this);
+    }
+
+    Map<String, Long> estimateCount();
+
+}

--- a/fe/fe-core/src/main/java/com/starrocks/memory/MemoryUsageTracker.java
+++ b/fe/fe-core/src/main/java/com/starrocks/memory/MemoryUsageTracker.java
@@ -1,0 +1,135 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.memory;
+
+import com.google.common.collect.Maps;
+import com.starrocks.common.Config;
+import com.starrocks.common.util.LeaderDaemon;
+import com.starrocks.common.util.ProfileManager;
+import com.starrocks.monitor.unit.ByteSizeValue;
+import com.starrocks.qe.QeProcessor;
+import com.starrocks.qe.QeProcessorImpl;
+import com.starrocks.server.GlobalStateMgr;
+import com.starrocks.sql.optimizer.statistics.CacheDictManager;
+import com.starrocks.sql.optimizer.statistics.IDictManager;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class MemoryUsageTracker extends LeaderDaemon {
+
+    private static final Logger LOG = LogManager.getLogger(MemoryUsageTracker.class);
+
+    // Used to save references to metadata submodules which need to be tracked memory on.
+    // If the object needs to be counted, it first needs to be added to this collection.
+    private static final Map<String, Map<String, MemoryTrackable>> REFERENCE = Maps.newConcurrentMap();
+
+    private static final Map<String, MemoryStat> MEMORY_USAGE = Maps.newConcurrentMap();
+
+    private boolean initialize;
+    public MemoryUsageTracker() {
+        super("MemoryUsageTracker", Config.memory_tracker_interval_seconds * 1000L);
+    }
+
+    private void initMemoryTracker() {
+        GlobalStateMgr currentState = GlobalStateMgr.getCurrentState();
+
+        registerMemoryTracker("Load", currentState.getLoadMgr());
+        registerMemoryTracker("Load", currentState.getRoutineLoadMgr());
+        registerMemoryTracker("Load", currentState.getStreamLoadMgr());
+
+        registerMemoryTracker("Export", currentState.getExportMgr());
+        registerMemoryTracker("Delete", currentState.getDeleteMgr());
+        registerMemoryTracker("Transaction", currentState.getGlobalTransactionMgr());
+        registerMemoryTracker("Backup", currentState.getBackupHandler());
+        registerMemoryTracker("Task", currentState.getTaskManager());
+        registerMemoryTracker("Task", currentState.getTaskManager().getTaskRunManager());
+        registerMemoryTracker("Tablet", currentState.getTabletInvertedIndex());
+        registerMemoryTracker("Profile", ProfileManager.getInstance());
+        registerMemoryTracker("LocalCatalog", new InternalCatalogMemoryTracker());
+
+        QeProcessor qeProcessor = QeProcessorImpl.INSTANCE;
+        if (qeProcessor instanceof QeProcessorImpl) {
+            registerMemoryTracker("Coordinator", (QeProcessorImpl) qeProcessor);
+        }
+
+        IDictManager dictManager = IDictManager.getInstance();
+        if (dictManager instanceof CacheDictManager) {
+            registerMemoryTracker("Dict", (CacheDictManager) dictManager);
+        }
+
+        LOG.info("Memory usage tracker init success");
+
+        initialize = true;
+    }
+
+    public static void registerMemoryTracker(String moduleName, MemoryTrackable object) {
+        REFERENCE.computeIfAbsent(moduleName, k -> new HashMap<>());
+        REFERENCE.get(moduleName).put(object.getClass().getSimpleName(), object);
+    }
+
+    public static void trackMemory() {
+        long startTime;
+        long endTime;
+        for (Map.Entry<String, Map<String, MemoryTrackable>> entry : REFERENCE.entrySet()) {
+            String moduleName = entry.getKey();
+            Map<String, MemoryTrackable> statMap = entry.getValue();
+            MemoryStat memoryStat = new MemoryStat();
+            long estimateSize = 0L;
+            long estimateCount = 0L;
+            for (Map.Entry<String, MemoryTrackable> statEntry : statMap.entrySet()) {
+                String className = statEntry.getKey();
+                MemoryTrackable tracker = statEntry.getValue();
+                startTime = System.currentTimeMillis();
+                long currentEstimateSize = tracker.estimateSize();
+                Map<String, Long> counterMap = tracker.estimateCount();
+                endTime = System.currentTimeMillis();
+                estimateSize += currentEstimateSize;
+
+                StringBuilder sb  = new StringBuilder();
+                for (Map.Entry<String, Long> subEntry : counterMap.entrySet()) {
+                    sb.append(subEntry.getKey()).append(" with ").append(subEntry.getValue())
+                            .append(" object(s). ");
+                }
+
+                LOG.info("({}ms) Module {} - {} estimated {} of memory. Contains {}",
+                        endTime - startTime, moduleName, className,
+                        new ByteSizeValue(currentEstimateSize), sb.toString());
+            }
+            memoryStat.setCurrentConsumption(estimateSize);
+            memoryStat.setObjectCount(estimateCount);
+            MemoryStat oldMemoryStat = MEMORY_USAGE.get(moduleName);
+            if (oldMemoryStat != null) {
+                memoryStat.setPeakConsumption(Math.max(oldMemoryStat.getPeakConsumption(), estimateSize));
+            } else {
+                memoryStat.setPeakConsumption(estimateSize);
+            }
+            MEMORY_USAGE.put(moduleName, memoryStat);
+        }
+    }
+
+    @Override
+    protected void runAfterCatalogReady() {
+        if (!initialize) {
+            initMemoryTracker();
+        }
+        setInterval(Config.memory_tracker_interval_seconds * 1000L);
+        if (Config.memory_tracker_enable) {
+            trackMemory();
+        }
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/qe/QeProcessorImpl.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/QeProcessorImpl.java
@@ -34,10 +34,12 @@
 
 package com.starrocks.qe;
 
+import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Maps;
 import com.starrocks.catalog.MvId;
 import com.starrocks.common.UserException;
 import com.starrocks.common.util.DebugUtil;
+import com.starrocks.memory.MemoryTrackable;
 import com.starrocks.thrift.TBatchReportExecStatusParams;
 import com.starrocks.thrift.TBatchReportExecStatusResult;
 import com.starrocks.thrift.TNetworkAddress;
@@ -50,13 +52,14 @@ import com.starrocks.thrift.TStatusCode;
 import com.starrocks.thrift.TUniqueId;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.apache.spark.util.SizeEstimator;
 
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
-public final class QeProcessorImpl implements QeProcessor {
+public final class QeProcessorImpl implements QeProcessor, MemoryTrackable {
 
     private static final Logger LOG = LogManager.getLogger(QeProcessorImpl.class);
     private Map<TUniqueId, QueryInfo> coordinatorMap;
@@ -243,6 +246,16 @@ public final class QeProcessorImpl implements QeProcessor {
     @Override
     public long getCoordinatorCount() {
         return coordinatorMap.size();
+    }
+
+    @Override
+    public long estimateSize() {
+        return SizeEstimator.estimate(coordinatorMap);
+    }
+
+    @Override
+    public Map<String, Long> estimateCount() {
+        return ImmutableMap.of("QueryInfo", (long) coordinatorMap.size());
     }
 
     public static final class QueryInfo {

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/TaskManager.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/TaskManager.java
@@ -19,6 +19,7 @@ import com.clearspring.analytics.util.Lists;
 import com.clearspring.analytics.util.Preconditions;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Maps;
 import com.google.gson.annotations.SerializedName;
 import com.starrocks.catalog.Column;
@@ -29,6 +30,7 @@ import com.starrocks.common.io.Text;
 import com.starrocks.common.util.QueryableReentrantLock;
 import com.starrocks.common.util.TimeUtils;
 import com.starrocks.common.util.Util;
+import com.starrocks.memory.MemoryTrackable;
 import com.starrocks.persist.gson.GsonUtils;
 import com.starrocks.persist.metablock.SRMetaBlockEOFException;
 import com.starrocks.persist.metablock.SRMetaBlockException;
@@ -45,6 +47,7 @@ import com.starrocks.sql.common.DmlException;
 import com.starrocks.sql.optimizer.Utils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.apache.spark.util.SizeEstimator;
 
 import java.io.DataInputStream;
 import java.io.DataOutputStream;
@@ -68,7 +71,7 @@ import java.util.stream.Collectors;
 
 import static com.starrocks.scheduler.SubmitResult.SubmitStatus.SUBMITTED;
 
-public class TaskManager {
+public class TaskManager implements MemoryTrackable {
 
     private static final Logger LOG = LogManager.getLogger(TaskManager.class);
 
@@ -887,4 +890,15 @@ public class TaskManager {
     public long getTaskCount() {
         return this.idToTaskMap.size();
     }
+
+    @Override
+    public Map<String, Long> estimateCount() {
+        return ImmutableMap.of("Task", (long) idToTaskMap.size());
+    }
+
+    @Override
+    public long estimateSize() {
+        return SizeEstimator.estimate(idToTaskMap.values());
+    }
+
 }

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/TaskRunManager.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/TaskRunManager.java
@@ -15,6 +15,7 @@
 
 package com.starrocks.scheduler;
 
+import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Queues;
 import com.google.gson.JsonObject;
@@ -22,6 +23,7 @@ import com.starrocks.common.Config;
 import com.starrocks.common.util.QueryableReentrantLock;
 import com.starrocks.common.util.UUIDUtil;
 import com.starrocks.common.util.Util;
+import com.starrocks.memory.MemoryTrackable;
 import com.starrocks.persist.gson.GsonUtils;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.scheduler.persist.TaskRunStatus;
@@ -38,7 +40,7 @@ import java.util.concurrent.Future;
 import java.util.concurrent.PriorityBlockingQueue;
 import java.util.concurrent.TimeUnit;
 
-public class TaskRunManager {
+public class TaskRunManager implements MemoryTrackable {
 
     private static final Logger LOG = LogManager.getLogger(TaskRunManager.class);
 
@@ -285,5 +287,20 @@ public class TaskRunManager {
         res.addProperty("running", GsonUtils.GSON.toJson(runningTaskRunMap));
         res.addProperty("pending", GsonUtils.GSON.toJson(pendingTaskRunMap));
         return res.toString();
+    }
+
+    @Override
+    public Map<String, Long> estimateCount() {
+        long validPendingCount = 0;
+        for (Long taskId : pendingTaskRunMap.keySet()) {
+            PriorityBlockingQueue<TaskRun> taskRuns = pendingTaskRunMap.get(taskId);
+            if (taskRuns != null && !taskRuns.isEmpty()) {
+                validPendingCount += taskRuns.size();
+            }
+        }
+
+        return ImmutableMap.of("PendingTaskRun", validPendingCount,
+                "RunningTaskRun", (long) runningTaskRunMap.size(),
+                "HistoryTaskRun", taskRunHistory.getTaskRunCount());
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/server/GlobalStateMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/GlobalStateMgr.java
@@ -171,6 +171,7 @@ import com.starrocks.load.routineload.RoutineLoadMgr;
 import com.starrocks.load.routineload.RoutineLoadScheduler;
 import com.starrocks.load.routineload.RoutineLoadTaskScheduler;
 import com.starrocks.load.streamload.StreamLoadMgr;
+import com.starrocks.memory.MemoryUsageTracker;
 import com.starrocks.meta.MetaContext;
 import com.starrocks.metric.MetricRepo;
 import com.starrocks.mysql.privilege.Auth;
@@ -522,6 +523,8 @@ public class GlobalStateMgr {
 
     private MVActiveChecker mvActiveChecker;
 
+    private MemoryUsageTracker memoryUsageTracker;
+
     public NodeMgr getNodeMgr() {
         return nodeMgr;
     }
@@ -762,6 +765,8 @@ public class GlobalStateMgr {
                 LOG.warn("check config failed", e);
             }
         });
+
+        this.memoryUsageTracker = new MemoryUsageTracker();
     }
 
     public static void destroyCheckpoint() {
@@ -1402,6 +1407,9 @@ public class GlobalStateMgr {
         configRefreshDaemon.start();
 
         lockChecker.start();
+
+        // The memory tracker should be placed at the end
+        memoryUsageTracker.start();
     }
 
     private void transferToNonLeader(FrontendNodeType newType) {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/CacheDictManager.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/CacheDictManager.java
@@ -23,6 +23,7 @@ import com.starrocks.catalog.Database;
 import com.starrocks.common.Config;
 import com.starrocks.common.Pair;
 import com.starrocks.common.Status;
+import com.starrocks.memory.MemoryTrackable;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.sql.optimizer.base.ColumnIdentifier;
@@ -34,6 +35,7 @@ import org.checkerframework.checker.nullness.qual.NonNull;
 
 import java.nio.ByteBuffer;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
@@ -42,7 +44,7 @@ import java.util.concurrent.Executor;
 
 import static com.starrocks.statistic.StatisticExecutor.queryDictSync;
 
-public class CacheDictManager implements IDictManager {
+public class CacheDictManager implements IDictManager, MemoryTrackable {
     private static final Logger LOG = LogManager.getLogger(CacheDictManager.class);
     private static final Set<ColumnIdentifier> NO_DICT_STRING_COLUMNS = Sets.newConcurrentHashSet();
     private static final Set<Long> FORBIDDEN_DICT_TABLE_IDS = Sets.newConcurrentHashSet();
@@ -288,5 +290,10 @@ public class CacheDictManager implements IDictManager {
             }
         }
         return Optional.empty();
+    }
+
+    @Override
+    public Map<String, Long> estimateCount() {
+        return ImmutableMap.of("ColumnDict", (long) dictStatistics.asMap().size());
     }
 }


### PR DESCRIPTION
Why I'm doing:

When we encounter a FE memory problem, we don't know where the memory is occupying the most, which makes it more difficult for us to troubleshoot the problem and the troubleshooting cycle is relatively long.
And for some problems, we may not be able to get the factory where the problem is caused. Users may restart directly when solving the problem, resulting in us not discovering the root cause of the problem.

What I'm doing:

Add a memory estimation and statistics module so that we can refer to it when analyzing memory problems. First, we narrow the problem to a certain range, and then we count it every 60 seconds, so that we leave a historical information. When the user restarts, We can also see which module takes up more memory based on the log history.

Fixes https://github.com/StarRocks/starrocks/pull/39053

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [x] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5

