### PR TITLE
[Enhancement] Support memory probing metadata functions (backport #39888) 

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/memory/MemoryUsageTracker.java
+++ b/fe/fe-core/src/main/java/com/starrocks/memory/MemoryUsageTracker.java
@@ -27,8 +27,8 @@ import com.starrocks.sql.optimizer.statistics.IDictManager;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
-import java.util.HashMap;
 import java.util.Map;
+import java.util.concurrent.ConcurrentSkipListMap;
 
 public class MemoryUsageTracker extends FrontendDaemon {
 
@@ -36,7 +36,8 @@ public class MemoryUsageTracker extends FrontendDaemon {
 
     // Used to save references to metadata submodules which need to be tracked memory on.
     // If the object needs to be counted, it first needs to be added to this collection.
-    private static final Map<String, Map<String, MemoryTrackable>> REFERENCE = Maps.newConcurrentMap();
+    public static final Map<String, Map<String, MemoryTrackable>> REFERENCE =
+            new ConcurrentSkipListMap<>(String.CASE_INSENSITIVE_ORDER);
 
     private static final Map<String, MemoryStat> MEMORY_USAGE = Maps.newConcurrentMap();
 
@@ -78,7 +79,7 @@ public class MemoryUsageTracker extends FrontendDaemon {
     }
 
     public static void registerMemoryTracker(String moduleName, MemoryTrackable object) {
-        REFERENCE.computeIfAbsent(moduleName, k -> new HashMap<>());
+        REFERENCE.computeIfAbsent(moduleName, k -> new ConcurrentSkipListMap<>(String.CASE_INSENSITIVE_ORDER));
         REFERENCE.get(moduleName).put(object.getClass().getSimpleName(), object);
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/ScalarOperatorFunctions.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/ScalarOperatorFunctions.java
@@ -60,6 +60,9 @@ import com.starrocks.common.util.TimeUtils;
 import com.starrocks.connector.PartitionInfo;
 import com.starrocks.connector.PartitionUtil;
 import com.starrocks.connector.hive.Partition;
+import com.starrocks.memory.MemoryTrackable;
+import com.starrocks.memory.MemoryUsageTracker;
+import com.starrocks.monitor.unit.ByteSizeValue;
 import com.starrocks.privilege.AccessDeniedException;
 import com.starrocks.privilege.AuthorizationMgr;
 import com.starrocks.privilege.ObjectType;
@@ -73,7 +76,9 @@ import org.apache.commons.collections4.MapUtils;
 import org.apache.commons.collections4.SetUtils;
 import org.apache.commons.lang.StringUtils;
 import org.apache.commons.lang3.tuple.Pair;
+import org.apache.spark.util.SizeEstimator;
 
+import java.lang.reflect.Field;
 import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.time.DayOfWeek;
@@ -1143,7 +1148,7 @@ public class ScalarOperatorFunctions {
 
     // =================================== meta functions ==================================== //
 
-    private static Table inspectExternalTable(TableName tableName) {
+    public static Table inspectExternalTable(TableName tableName) {
         Table table = GlobalStateMgr.getCurrentState().getMetadataMgr().getTable(tableName)
                 .orElseThrow(() -> ErrorReport.buildSemanticException(ErrorCode.ERR_BAD_TABLE_ERROR, tableName));
         ConnectContext connectContext = ConnectContext.get();
@@ -1159,7 +1164,7 @@ public class ScalarOperatorFunctions {
         return table;
     }
 
-    private static Pair<Database, Table> inspectTable(TableName tableName) {
+    public static Pair<Database, Table> inspectTable(TableName tableName) {
         Database db = GlobalStateMgr.getCurrentState().mayGetDb(tableName.getDb())
                 .orElseThrow(() -> ErrorReport.buildSemanticException(ErrorCode.ERR_BAD_DB_ERROR, tableName.getDb()));
         Table table = db.tryGetTable(tableName.getTbl())
@@ -1256,6 +1261,65 @@ public class ScalarOperatorFunctions {
 
         String json = GlobalStateMgr.getCurrentState().getConnectorTblMetaInfoMgr().inspect();
         return ConstantOperator.createVarchar(json);
+    }
+
+    @ConstantFunction(name = "inspect_memory", argTypes = {VARCHAR}, returnType = VARCHAR, isMetaFunction = true)
+    public static ConstantOperator inspectMemory(ConstantOperator moduleName) {
+        Map<String, MemoryTrackable> statMap = MemoryUsageTracker.REFERENCE.get(moduleName.getVarchar());
+        if (statMap == null) {
+            ErrorReport.reportSemanticException(ErrorCode.ERR_INVALID_PARAMETER,
+                    "Module " + moduleName + " not found.");
+        }
+        long estimateSize = 0;
+        for (Map.Entry<String, MemoryTrackable> statEntry : statMap.entrySet()) {
+            MemoryTrackable tracker = statEntry.getValue();
+            estimateSize += tracker.estimateSize();
+        }
+
+        return ConstantOperator.createVarchar(new ByteSizeValue(estimateSize).toString());
+    }
+
+    @ConstantFunction(name = "inspect_memory_detail", argTypes = {VARCHAR, VARCHAR},
+            returnType = VARCHAR, isMetaFunction = true)
+    public static ConstantOperator inspectMemoryDetail(ConstantOperator moduleName, ConstantOperator clazzInfo) {
+        Map<String, MemoryTrackable> statMap = MemoryUsageTracker.REFERENCE.get(moduleName.getVarchar());
+        if (statMap == null) {
+            ErrorReport.reportSemanticException(ErrorCode.ERR_INVALID_PARAMETER,
+                    "Module " + moduleName + " not found.");
+        }
+        String classInfo = clazzInfo.getVarchar();
+        String clazzName;
+        String fieldName = null;
+        if (classInfo.contains(".")) {
+            clazzName = classInfo.split("\\.")[0];
+            fieldName = classInfo.split("\\.")[1];
+        } else {
+            clazzName = classInfo;
+        }
+        MemoryTrackable memoryTrackable = statMap.get(clazzName);
+        if (memoryTrackable == null) {
+            ErrorReport.reportSemanticException(ErrorCode.ERR_INVALID_PARAMETER,
+                    "In module " + moduleName + " - " + clazzName + " not found.");
+        }
+        long estimateSize = 0;
+        if (fieldName == null) {
+            estimateSize = memoryTrackable.estimateSize();
+        } else {
+            try {
+                Field field = memoryTrackable.getClass().getDeclaredField(fieldName);
+                field.setAccessible(true);
+                Object object = field.get(memoryTrackable);
+                estimateSize = SizeEstimator.estimate(object);
+            } catch (NoSuchFieldException e) {
+                ErrorReport.reportSemanticException(ErrorCode.ERR_INVALID_PARAMETER,
+                        "In module " + moduleName + " - " + clazzName + " field " + fieldName + " not found.");
+            } catch (IllegalAccessException e) {
+                ErrorReport.reportSemanticException(ErrorCode.ERR_INVALID_PARAMETER,
+                        "Get module " + moduleName + " - " + clazzName + " field " + fieldName + " error.");
+            }
+        }
+
+        return ConstantOperator.createVarchar(new ByteSizeValue(estimateSize).toString());
     }
 
     /**

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rewrite/MetaFunctionsTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rewrite/MetaFunctionsTest.java
@@ -1,0 +1,149 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.sql.optimizer.rewrite;
+
+import com.starrocks.analysis.TableName;
+import com.starrocks.catalog.Type;
+import com.starrocks.common.Config;
+import com.starrocks.common.ErrorReportException;
+import com.starrocks.common.FeConstants;
+import com.starrocks.leader.ReportHandler;
+import com.starrocks.memory.MemoryUsageTracker;
+import com.starrocks.qe.ConnectContext;
+import com.starrocks.sql.analyzer.SemanticException;
+import com.starrocks.sql.ast.UserIdentity;
+import com.starrocks.sql.optimizer.operator.scalar.ConstantOperator;
+import com.starrocks.utframe.StarRocksAssert;
+import com.starrocks.utframe.UtFrameUtils;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+public class MetaFunctionsTest {
+
+    static {
+        MemoryUsageTracker.registerMemoryTracker("Report", new ReportHandler());
+    }
+
+    private static ConnectContext connectContext;
+    private static StarRocksAssert starRocksAssert;
+
+    @BeforeClass
+    public static void beforeClass() throws Exception {
+        FeConstants.runningUnitTest = true;
+        Config.alter_scheduler_interval_millisecond = 100;
+        Config.dynamic_partition_enable = true;
+        Config.dynamic_partition_check_interval_seconds = 1;
+        Config.enable_strict_storage_medium_check = false;
+        UtFrameUtils.createMinStarRocksCluster();
+        UtFrameUtils.addMockBackend(10002);
+        UtFrameUtils.addMockBackend(10003);
+        // create connect context
+        connectContext = UtFrameUtils.createDefaultCtx();
+        starRocksAssert = new StarRocksAssert(connectContext);
+
+        starRocksAssert.withDatabase("test").useDatabase("test")
+                .withTable("CREATE TABLE test.tbl1\n" +
+                        "(\n" +
+                        "    k1 date,\n" +
+                        "    k2 int,\n" +
+                        "    v1 int sum\n" +
+                        ")\n" +
+                        "PARTITION BY RANGE(k1)\n" +
+                        "(\n" +
+                        "    PARTITION p1 values less than('2020-02-01'),\n" +
+                        "    PARTITION p2 values less than('2020-03-01')\n" +
+                        ")\n" +
+                        "DISTRIBUTED BY HASH(k2) BUCKETS 3\n" +
+                        "PROPERTIES('replication_num' = '1');")
+                .withTable("CREATE EXTERNAL TABLE mysql_external_table\n" +
+                        "(\n" +
+                        "    k1 DATE,\n" +
+                        "    k2 INT,\n" +
+                        "    k3 SMALLINT,\n" +
+                        "    k4 VARCHAR(2048),\n" +
+                        "    k5 DATETIME\n" +
+                        ")\n" +
+                        "ENGINE=mysql\n" +
+                        "PROPERTIES\n" +
+                        "(\n" +
+                        "    \"host\" = \"127.0.0.1\",\n" +
+                        "    \"port\" = \"3306\",\n" +
+                        "    \"user\" = \"mysql_user\",\n" +
+                        "    \"password\" = \"mysql_passwd\",\n" +
+                        "    \"database\" = \"mysql_db_test\",\n" +
+                        "    \"table\" = \"mysql_table_test\"\n" +
+                        ");");
+    }
+
+    @Test
+    public void testInspectMemory() {
+        ScalarOperatorFunctions.inspectMemory(new ConstantOperator("report", Type.VARCHAR));
+    }
+
+    @Test(expected = SemanticException.class)
+    public void testInspectMemoryFailed() {
+        ScalarOperatorFunctions.inspectMemory(new ConstantOperator("abc", Type.VARCHAR));
+    }
+
+    @Test
+    public void testInspectMemoryDetail() {
+        MemoryUsageTracker.registerMemoryTracker("Report", new ReportHandler());
+        try {
+            ScalarOperatorFunctions.inspectMemoryDetail(
+                    new ConstantOperator("abc", Type.VARCHAR),
+                    new ConstantOperator("def", Type.VARCHAR));
+            Assert.fail();
+        } catch (Exception ex) {
+        }
+        try {
+            ScalarOperatorFunctions.inspectMemoryDetail(
+                    new ConstantOperator("report", Type.VARCHAR),
+                    new ConstantOperator("def", Type.VARCHAR));
+            Assert.fail();
+        } catch (Exception ex) {
+        }
+        try {
+            ScalarOperatorFunctions.inspectMemoryDetail(
+                    new ConstantOperator("report", Type.VARCHAR),
+                    new ConstantOperator("reportHandler.abc", Type.VARCHAR));
+            Assert.fail();
+        } catch (Exception ex) {
+        }
+        ScalarOperatorFunctions.inspectMemoryDetail(
+                new ConstantOperator("report", Type.VARCHAR),
+                new ConstantOperator("reportHandler", Type.VARCHAR));
+        ScalarOperatorFunctions.inspectMemoryDetail(
+                new ConstantOperator("report", Type.VARCHAR),
+                new ConstantOperator("reportHandler.reportQueue", Type.VARCHAR));
+    }
+
+    private UserIdentity testUser = UserIdentity.createAnalyzedUserIdentWithIp("test_user", "%");
+
+    @Test(expected = ErrorReportException.class)
+    public void testInspectTableAccessDeniedException() {
+        connectContext.setCurrentUserIdentity(testUser);
+        connectContext.setCurrentRoleIds(testUser);
+        ScalarOperatorFunctions.inspectTable(new TableName("test", "tbl1"));
+    }
+
+    @Test(expected = ErrorReportException.class)
+    public void testInspectExternalTableAccessDeniedException() {
+        connectContext.setCurrentUserIdentity(testUser);
+        connectContext.setCurrentRoleIds(testUser);
+        ScalarOperatorFunctions.inspectTable(new TableName("test", "mysql_external_table"));
+    }
+
+}


### PR DESCRIPTION
Why I'm doing:
Only periodic logs cannot cover some other scenarios. For objects with references, we may perform on-site calculations through metadata functions, and we can even use reflection to calculate some objects that are not written in code.

What I'm doing:
Add 2 functions
inspect_memory inspect_memory passes in a module object and calculates the object size of this module on-site.
inspect_memory_detail inspect_memory_detail can calculate the size of a class or even a field in a module, which is a relatively fine-grained on-site calculation coverage.

Fixes https://github.com/StarRocks/starrocks/pull/39888

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [x] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5

