### PR TITLE
[Feature] add sys.fe_memory_usage table (backport #40464) 

### DIFF
--- a/be/src/exec/CMakeLists.txt
+++ b/be/src/exec/CMakeLists.txt
@@ -150,6 +150,7 @@ set(EXEC_FILES
     schema_scanner/schema_stream_loads_scanner.cpp
     schema_scanner/sys_object_dependencies.cpp
     schema_scanner/sys_fe_locks.cpp
+    schema_scanner/sys_fe_memory_usage.cpp
     jdbc_scanner.cpp
     sorting/compare_column.cpp
     sorting/merge_column.cpp

--- a/be/src/exec/schema_scanner.cpp
+++ b/be/src/exec/schema_scanner.cpp
@@ -50,6 +50,7 @@
 #include "exec/schema_scanner/starrocks_grants_to_scanner.h"
 #include "exec/schema_scanner/starrocks_role_edges_scanner.h"
 #include "exec/schema_scanner/sys_fe_locks.h"
+#include "exec/schema_scanner/sys_fe_memory_usage.h"
 #include "exec/schema_scanner/sys_object_dependencies.h"
 #include "gen_cpp/Descriptors_types.h"
 #include "gen_cpp/FrontendService_types.h"
@@ -181,6 +182,8 @@ std::unique_ptr<SchemaScanner> SchemaScanner::create(TSchemaTableType::type type
         return std::make_unique<SchemaTablePipes>();
     case TSchemaTableType::SYS_FE_LOCKS:
         return std::make_unique<SysFeLocks>();
+    case TSchemaTableType::SYS_FE_MEMORY_USAGE:
+        return std::make_unique<SysFeMemoryUsage>();
     default:
         return std::make_unique<SchemaDummyScanner>();
     }

--- a/be/src/exec/schema_scanner/schema_helper.cpp
+++ b/be/src/exec/schema_scanner/schema_helper.cpp
@@ -82,6 +82,12 @@ Status SchemaHelper::list_fe_locks(const std::string& ip, int32_t port, const TF
             ip, port, [&req, &res](FrontendServiceConnection& client) { client->listFeLocks(*res, req); });
 }
 
+Status SchemaHelper::list_fe_memory_usage(const std::string& ip, int32_t port, const TFeMemoryReq& req,
+                                          TFeMemoryRes* res) {
+    return ThriftRpcHelper::rpc<FrontendServiceClient>(
+            ip, port, [&req, &res](FrontendServiceConnection& client) { client->listFeMemoryUsage(*res, req); });
+}
+
 Status SchemaHelper::get_tables_info(const std::string& ip, const int32_t port, const TGetTablesInfoRequest& request,
                                      TGetTablesInfoResponse* response, const int timeout_ms) {
     return ThriftRpcHelper::rpc<FrontendServiceClient>(

--- a/be/src/exec/schema_scanner/schema_helper.h
+++ b/be/src/exec/schema_scanner/schema_helper.h
@@ -47,6 +47,8 @@ public:
                                            TObjectDependencyRes* res);
     static Status list_fe_locks(const std::string& ip, int32_t port, const TFeLocksReq& req, TFeLocksRes* res);
 
+    static Status list_fe_memory_usage(const std::string& ip, int32_t port, const TFeMemoryReq& req, TFeMemoryRes* res);
+
     static Status get_tables_info(const std::string& ip, const int32_t port, const TGetTablesInfoRequest& request,
                                   TGetTablesInfoResponse* response, const int timeout_ms);
 

--- a/be/src/exec/schema_scanner/sys_fe_memory_usage.cpp
+++ b/be/src/exec/schema_scanner/sys_fe_memory_usage.cpp
@@ -1,0 +1,73 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "exec/schema_scanner/sys_fe_memory_usage.h"
+
+#include "exec/schema_scanner/schema_helper.h"
+#include "gen_cpp/FrontendService_types.h"
+#include "runtime/runtime_state.h"
+#include "runtime/string_value.h"
+
+namespace starrocks {
+
+SchemaScanner::ColumnDesc SysFeMemoryUsage::_s_columns[] = {{"module_name", TYPE_VARCHAR, sizeof(StringValue), true},
+                                                            {"class_name", TYPE_VARCHAR, sizeof(StringValue), true},
+                                                            {"current_consumption", TYPE_BIGINT, sizeof(long), true},
+                                                            {"peak_consumption", TYPE_BIGINT, sizeof(long), true},
+                                                            {"counter_info", TYPE_VARCHAR, sizeof(StringValue), true}};
+
+SysFeMemoryUsage::SysFeMemoryUsage()
+        : SchemaScanner(_s_columns, sizeof(_s_columns) / sizeof(SchemaScanner::ColumnDesc)) {}
+
+SysFeMemoryUsage::~SysFeMemoryUsage() = default;
+
+Status SysFeMemoryUsage::start(RuntimeState* state) {
+    RETURN_IF(!_is_init, Status::InternalError("used before initialized."));
+    RETURN_IF(!_param->ip || !_param->port, Status::InternalError("IP or port not exists"));
+
+    RETURN_IF_ERROR(SchemaScanner::start(state));
+
+    TAuthInfo auth = build_auth_info();
+    TFeMemoryReq request;
+    request.__set_auth_info(auth);
+
+    return (SchemaHelper::list_fe_memory_usage(*(_param->ip), _param->port, request, &_result));
+}
+
+Status SysFeMemoryUsage::_fill_chunk(ChunkPtr* chunk) {
+    auto& slot_id_map = (*chunk)->get_slot_id_to_index_map();
+    const TFeMemoryItem& info = _result.items[_index];
+    DatumArray datum_array{Slice(info.module_name), Slice(info.class_name), info.current_consumption,
+                           info.peak_consumption, Slice(info.counter_info)};
+    for (const auto& [slot_id, index] : slot_id_map) {
+        Column* column = (*chunk)->get_column_by_slot_id(slot_id).get();
+        column->append_datum(datum_array[slot_id - 1]);
+    }
+    _index++;
+    return {};
+}
+
+Status SysFeMemoryUsage::get_next(ChunkPtr* chunk, bool* eos) {
+    RETURN_IF(!_is_init, Status::InternalError("Used before initialized."));
+    RETURN_IF((nullptr == chunk || nullptr == eos), Status::InternalError("input pointer is nullptr."));
+
+    if (_index >= _result.items.size()) {
+        *eos = true;
+        return Status::OK();
+    }
+    *eos = false;
+    return _fill_chunk(chunk);
+}
+
+} // namespace starrocks

--- a/be/src/exec/schema_scanner/sys_fe_memory_usage.h
+++ b/be/src/exec/schema_scanner/sys_fe_memory_usage.h
@@ -1,0 +1,37 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include "exec/schema_scanner.h"
+#include "gen_cpp/FrontendService_types.h"
+
+namespace starrocks {
+
+class SysFeMemoryUsage : public SchemaScanner {
+public:
+    SysFeMemoryUsage();
+    ~SysFeMemoryUsage() override;
+    Status start(RuntimeState* state) override;
+    Status get_next(ChunkPtr* chunk, bool* eos) override;
+
+private:
+    Status _fill_chunk(ChunkPtr* chunk);
+
+    size_t _index = 0;
+    TFeMemoryRes _result;
+    static SchemaScanner::ColumnDesc _s_columns[];
+};
+
+} // namespace starrocks

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/system/SystemId.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/system/SystemId.java
@@ -109,7 +109,7 @@ public class SystemId {
     public static final long GRANTS_TO_USERS_ID = 103L;
     public static final long OBJECT_DEPENDENCIES = 104L;
     public static final long FE_LOCKS_ID = 105L;
-
+    public static final long MEMORY_USAGE_ID = 106L;
     public static final long PIPE_FILES_ID = 120L;
     public static final long PIPES_ID = 121L;
 }

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/system/sys/SysDb.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/system/sys/SysDb.java
@@ -33,6 +33,7 @@ public class SysDb extends Database {
         super.registerTableUnlocked(GrantsTo.createGrantsToUsers());
         super.registerTableUnlocked(SysObjectDependencies.create());
         super.registerTableUnlocked(SysFeLocks.create());
+        super.registerTableUnlocked(SysFeMemoryUsage.create());
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/system/sys/SysFeMemoryUsage.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/system/sys/SysFeMemoryUsage.java
@@ -1,0 +1,87 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.catalog.system.sys;
+
+import com.starrocks.catalog.PrimitiveType;
+import com.starrocks.catalog.ScalarType;
+import com.starrocks.catalog.Table;
+import com.starrocks.catalog.system.SystemId;
+import com.starrocks.catalog.system.SystemTable;
+import com.starrocks.memory.MemoryUsageTracker;
+import com.starrocks.privilege.AccessDeniedException;
+import com.starrocks.privilege.PrivilegeType;
+import com.starrocks.sql.analyzer.Authorizer;
+import com.starrocks.sql.ast.UserIdentity;
+import com.starrocks.thrift.TAuthInfo;
+import com.starrocks.thrift.TFeMemoryItem;
+import com.starrocks.thrift.TFeMemoryReq;
+import com.starrocks.thrift.TFeMemoryRes;
+import com.starrocks.thrift.TSchemaTableType;
+import org.apache.thrift.TException;
+
+
+public class SysFeMemoryUsage {
+
+
+    public static final String NAME = "fe_memory_usage";
+
+    public static SystemTable create() {
+        return new SystemTable(SystemId.MEMORY_USAGE_ID, NAME,
+                Table.TableType.SCHEMA,
+                SystemTable.builder()
+                        .column("module_name", ScalarType.createVarcharType(256))
+                        .column("class_name", ScalarType.createVarcharType(256))
+                        .column("current_consumption", ScalarType.createType(PrimitiveType.BIGINT))
+                        .column("peak_consumption", ScalarType.createType(PrimitiveType.BIGINT))
+                        .column("counter_info", ScalarType.createVarcharType(65532))
+                        .build(),
+                TSchemaTableType.SYS_FE_MEMORY_USAGE);
+    }
+
+    public static TFeMemoryRes listFeMemoryUsage(TFeMemoryReq request) throws TException {
+        TAuthInfo auth = request.getAuth_info();
+        UserIdentity currentUser;
+        if (auth.isSetCurrent_user_ident()) {
+            currentUser = UserIdentity.fromThrift(auth.getCurrent_user_ident());
+        } else {
+            currentUser = UserIdentity.createAnalyzedUserIdentWithIp(auth.getUser(), auth.getUser_ip());
+        }
+
+        try {
+            Authorizer.checkSystemAction(currentUser, null, PrivilegeType.OPERATE);
+        } catch (AccessDeniedException e) {
+            throw new TException(e.getMessage(), e);
+        }
+
+        TFeMemoryRes response = new TFeMemoryRes();
+
+        MemoryUsageTracker.MEMORY_USAGE.forEach((moduleName, module) -> {
+            if (module != null) {
+                module.forEach((className, memoryStat) -> {
+                    TFeMemoryItem item = new TFeMemoryItem();
+                    item.setModule_name(moduleName);
+                    item.setClass_name(className);
+                    item.setCurrent_consumption(memoryStat.getCurrentConsumption());
+                    item.setPeak_consumption(memoryStat.getPeakConsumption());
+                    item.setCounter_info(memoryStat.getCounterInfo());
+                    response.addToItems(item);
+                });
+            }
+        });
+
+        return response;
+    }
+
+}

--- a/fe/fe-core/src/main/java/com/starrocks/memory/MemoryStat.java
+++ b/fe/fe-core/src/main/java/com/starrocks/memory/MemoryStat.java
@@ -18,9 +18,9 @@ public class MemoryStat {
 
     private long currentConsumption;
 
-    private long objectCount;
-
     private long peakConsumption;
+
+    private String counterInfo;
 
     public long getCurrentConsumption() {
         return currentConsumption;
@@ -30,19 +30,19 @@ public class MemoryStat {
         this.currentConsumption = currentConsumption;
     }
 
-    public long getObjectCount() {
-        return objectCount;
-    }
-
-    public void setObjectCount(long objectCount) {
-        this.objectCount = objectCount;
-    }
-
     public long getPeakConsumption() {
         return peakConsumption;
     }
 
     public void setPeakConsumption(long peakConsumption) {
         this.peakConsumption = peakConsumption;
+    }
+
+    public String getCounterInfo() {
+        return counterInfo;
+    }
+
+    public void setCounterInfo(String counterInfo) {
+        this.counterInfo = counterInfo;
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/memory/MemoryUsageTracker.java
+++ b/fe/fe-core/src/main/java/com/starrocks/memory/MemoryUsageTracker.java
@@ -19,6 +19,7 @@ import com.starrocks.common.Config;
 import com.starrocks.common.util.FrontendDaemon;
 import com.starrocks.common.util.ProfileManager;
 import com.starrocks.monitor.unit.ByteSizeValue;
+import com.starrocks.persist.gson.GsonUtils;
 import com.starrocks.qe.QeProcessor;
 import com.starrocks.qe.QeProcessorImpl;
 import com.starrocks.server.GlobalStateMgr;
@@ -39,7 +40,7 @@ public class MemoryUsageTracker extends FrontendDaemon {
     public static final Map<String, Map<String, MemoryTrackable>> REFERENCE =
             new ConcurrentSkipListMap<>(String.CASE_INSENSITIVE_ORDER);
 
-    private static final Map<String, MemoryStat> MEMORY_USAGE = Maps.newConcurrentMap();
+    public static final Map<String, Map<String, MemoryStat>> MEMORY_USAGE = Maps.newConcurrentMap();
 
     private boolean initialize;
     public MemoryUsageTracker() {
@@ -89,9 +90,6 @@ public class MemoryUsageTracker extends FrontendDaemon {
         for (Map.Entry<String, Map<String, MemoryTrackable>> entry : REFERENCE.entrySet()) {
             String moduleName = entry.getKey();
             Map<String, MemoryTrackable> statMap = entry.getValue();
-            MemoryStat memoryStat = new MemoryStat();
-            long estimateSize = 0L;
-            long estimateCount = 0L;
             for (Map.Entry<String, MemoryTrackable> statEntry : statMap.entrySet()) {
                 String className = statEntry.getKey();
                 MemoryTrackable tracker = statEntry.getValue();
@@ -99,27 +97,29 @@ public class MemoryUsageTracker extends FrontendDaemon {
                 long currentEstimateSize = tracker.estimateSize();
                 Map<String, Long> counterMap = tracker.estimateCount();
                 endTime = System.currentTimeMillis();
-                estimateSize += currentEstimateSize;
 
                 StringBuilder sb  = new StringBuilder();
                 for (Map.Entry<String, Long> subEntry : counterMap.entrySet()) {
                     sb.append(subEntry.getKey()).append(" with ").append(subEntry.getValue())
                             .append(" object(s). ");
                 }
+                MemoryStat memoryStat = new MemoryStat();
+                MEMORY_USAGE.computeIfAbsent(moduleName, k -> new ConcurrentSkipListMap<>(String.CASE_INSENSITIVE_ORDER));
+                memoryStat.setCurrentConsumption(currentEstimateSize);
+                Map<String, MemoryStat> usageMap = MEMORY_USAGE.get(moduleName);
+                MemoryStat oldMemoryStat = usageMap.get(className);
+                if (oldMemoryStat != null) {
+                    memoryStat.setPeakConsumption(Math.max(oldMemoryStat.getPeakConsumption(), currentEstimateSize));
+                } else {
+                    memoryStat.setPeakConsumption(currentEstimateSize);
+                }
+                memoryStat.setCounterInfo(GsonUtils.GSON.toJson(counterMap));
+                usageMap.put(className, memoryStat);
 
                 LOG.info("({}ms) Module {} - {} estimated {} of memory. Contains {}",
                         endTime - startTime, moduleName, className,
                         new ByteSizeValue(currentEstimateSize), sb.toString());
             }
-            memoryStat.setCurrentConsumption(estimateSize);
-            memoryStat.setObjectCount(estimateCount);
-            MemoryStat oldMemoryStat = MEMORY_USAGE.get(moduleName);
-            if (oldMemoryStat != null) {
-                memoryStat.setPeakConsumption(Math.max(oldMemoryStat.getPeakConsumption(), estimateSize));
-            } else {
-                memoryStat.setPeakConsumption(estimateSize);
-            }
-            MEMORY_USAGE.put(moduleName, memoryStat);
         }
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/service/FrontendServiceImpl.java
+++ b/fe/fe-core/src/main/java/com/starrocks/service/FrontendServiceImpl.java
@@ -69,6 +69,7 @@ import com.starrocks.catalog.View;
 import com.starrocks.catalog.system.sys.GrantsTo;
 import com.starrocks.catalog.system.sys.RoleEdges;
 import com.starrocks.catalog.system.sys.SysFeLocks;
+import com.starrocks.catalog.system.sys.SysFeMemoryUsage;
 import com.starrocks.catalog.system.sys.SysObjectDependencies;
 import com.starrocks.cluster.ClusterNamespace;
 import com.starrocks.common.AnalysisException;
@@ -177,6 +178,8 @@ import com.starrocks.thrift.TExecPlanFragmentParams;
 import com.starrocks.thrift.TExprNode;
 import com.starrocks.thrift.TFeLocksReq;
 import com.starrocks.thrift.TFeLocksRes;
+import com.starrocks.thrift.TFeMemoryReq;
+import com.starrocks.thrift.TFeMemoryRes;
 import com.starrocks.thrift.TFeResult;
 import com.starrocks.thrift.TFetchResourceResult;
 import com.starrocks.thrift.TFinishSlotRequirementRequest;
@@ -654,6 +657,11 @@ public class FrontendServiceImpl implements FrontendService.Iface {
     @Override
     public TFeLocksRes listFeLocks(TFeLocksReq params) throws TException {
         return SysFeLocks.listLocks(params, true);
+    }
+
+    @Override
+    public TFeMemoryRes listFeMemoryUsage(TFeMemoryReq request) throws TException {
+        return SysFeMemoryUsage.listFeMemoryUsage(request);
     }
 
     // list MaterializedView table match pattern

--- a/fe/fe-core/src/test/java/com/starrocks/catalog/system/sys/SysFeMemoryUsageTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/system/sys/SysFeMemoryUsageTest.java
@@ -1,0 +1,64 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.catalog.system.sys;
+
+import com.google.common.collect.ImmutableMap;
+import com.starrocks.memory.MemoryStat;
+import com.starrocks.memory.MemoryUsageTracker;
+import com.starrocks.privilege.AccessControlProvider;
+import com.starrocks.privilege.AccessDeniedException;
+import com.starrocks.privilege.PrivilegeType;
+import com.starrocks.sql.analyzer.Authorizer;
+import com.starrocks.sql.ast.UserIdentity;
+import com.starrocks.thrift.TAuthInfo;
+import com.starrocks.thrift.TFeMemoryReq;
+import com.starrocks.thrift.TFeMemoryRes;
+import mockit.Expectations;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.thrift.TException;
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class SysFeMemoryUsageTest {
+
+    @Test
+    public void testListFeMemoryUsage() throws TException, AccessDeniedException {
+        TFeMemoryReq req = new TFeMemoryReq();
+        TAuthInfo auth = new TAuthInfo();
+        auth.setUser("root");
+        auth.setUser_ip("127.0.0.1");
+        req.setAuth_info(auth);
+
+        AccessControlProvider accessControlProvider = Authorizer.getInstance();
+        new Expectations(accessControlProvider) {
+            {
+                Authorizer.checkSystemAction((UserIdentity) any, (Set<Long>) any, (PrivilegeType) any);
+                result = null;
+                minTimes = 0;
+            }
+        };
+        Map<String, Map<String, MemoryStat>> memoryUsage = MemoryUsageTracker.MEMORY_USAGE;
+        MemoryStat memoryStat = new MemoryStat();
+        memoryUsage.put("test", ImmutableMap.of("test", memoryStat));
+
+        TFeMemoryRes res = SysFeMemoryUsage.listFeMemoryUsage(req);
+        assertTrue(StringUtils.isNotEmpty(res.toString()));
+    }
+
+}

--- a/gensrc/thrift/Descriptors.thrift
+++ b/gensrc/thrift/Descriptors.thrift
@@ -165,6 +165,7 @@ enum TSchemaTableType {
     SCH_FE_METRICS,
     STARROCKS_OBJECT_DEPENDENCIES,
     SYS_FE_LOCKS,
+    SYS_FE_MEMORY_USAGE
 }
 
 enum THdfsCompression {

--- a/gensrc/thrift/FrontendService.thrift
+++ b/gensrc/thrift/FrontendService.thrift
@@ -1578,6 +1578,22 @@ struct TFeLocksRes {
     1: optional list<TFeLocksItem> items
 }
 
+struct TFeMemoryItem {
+    1: optional string module_name
+    2: optional string class_name
+    3: optional i64 current_consumption
+    4: optional i64 peak_consumption
+    5: optional string counter_info
+}
+
+struct TFeMemoryReq {
+    1: optional TAuthInfo auth_info
+}
+
+struct TFeMemoryRes {
+    1: optional list<TFeMemoryItem> items
+}
+
 enum TGrantsToType {
     ROLE,
     USER,
@@ -1747,6 +1763,9 @@ service FrontendService {
 
     // sys.fe_locks
     TFeLocksRes listFeLocks(1: TFeLocksReq request)
+
+    // sys.fe_memory_usage
+    TFeMemoryRes listFeMemoryUsage(1: TFeMemoryReq request)
 
     TRequireSlotResponse requireSlotAsync(1: TRequireSlotRequest request)
     TFinishSlotRequirementResponse finishSlotRequirement(1: TFinishSlotRequirementRequest request)

--- a/test/sql/test_sys/R/test_fe_memory_usage
+++ b/test/sql/test_sys/R/test_fe_memory_usage
@@ -1,0 +1,5 @@
+-- name: test_fe_memory_usage
+select count(*) > 10 from sys.fe_memory_usage;
+-- result:
+1
+-- !result

--- a/test/sql/test_sys/T/test_fe_memory_usage
+++ b/test/sql/test_sys/T/test_fe_memory_usage
@@ -1,0 +1,2 @@
+-- name: test_fe_memory_usage
+select count(*) > 10 from sys.fe_memory_usage;


### PR DESCRIPTION
Why I'm doing:
Although we have log monitoring, for some environments, users may not have a way to directly obtain log information and view it, so we expose a metadata table to check the current memory statistics.

What I'm doing:

Fixes #40464

```
+--------------+------------------------------+---------------------+------------------+------------------------------------------------------------+
| module_name  | class_name                   | current_consumption | peak_consumption | counter_info                                               |
+--------------+------------------------------+---------------------+------------------+------------------------------------------------------------+
| Delete       | DeleteMgr                    |                 416 |              416 | {"DeleteInfo":0}                                           |
| Load         | LoadMgr                      |            12187384 |         12187384 | {"LoadJob":0}                                              |
| Load         | RoutineLoadMgr               |                 592 |              592 | {"RoutineLoad":0}                                          |
| Load         | StreamLoadMgr                |                 376 |              376 | {"StreamLoad":0}                                           |
| Task         | TaskManager                  |                  80 |               80 | {"Task":0}                                                 |
| Task         | TaskRunManager               |            12187384 |         12187384 | {"PendingTaskRun":0,"RunningTaskRun":0,"HistoryTaskRun":0} |
| Report       | ReportHandler                |            12188992 |         12188992 | {"PendingTask":0,"ReportQueue":0}                          |
| Backup       | BackupHandler                |            12183864 |         14562256 | {"BackupOrRestoreJob":0}                                   |
| Coordinator  | QeProcessorImpl              |                 240 |              240 | {"QueryInfo":0}                                            |
| Profile      | ProfileManager               |                 112 |              112 | {"Profile":0,"LoadProfile":0}                              |
| Transaction  | GlobalTransactionMgr         |            12183864 |         12183864 | {"Transaction":0}                                          |
| Dict         | CacheDictManager             |            12188768 |         12188768 | {"ColumnDict":0}                                           |
| Export       | ExportMgr                    |                 248 |              248 | {"ExportJob":0}                                            |
| Tablet       | TabletInvertedIndex          |               30168 |            30168 | {"TabletMeta":48}                                          |
| LocalCatalog | InternalCatalogMemoryTracker |               33424 |            33424 | {"Partition":5}                                            |
+--------------+------------------------------+---------------------+------------------+------------------------------------------------------------+
```

## What type of PR is this:

- [ ] BugFix
- [x] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [x] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [x] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5

