### PR TITLE
[BugFix] fix resultset metadata of prepare protocol

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/analysis/Expr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/analysis/Expr.java
@@ -1063,6 +1063,10 @@ public abstract class Expr extends TreeNode<Expr> implements ParseNode, Cloneabl
         return isConstantImpl();
     }
 
+    public final boolean isParameter() {
+        return this instanceof Parameter;
+    }
+
     /**
      * Implements isConstant() - computes the value without using 'isConstant_'.
      */

--- a/fe/fe-core/src/main/java/com/starrocks/analysis/Parameter.java
+++ b/fe/fe-core/src/main/java/com/starrocks/analysis/Parameter.java
@@ -17,6 +17,9 @@ package com.starrocks.analysis;
 import com.starrocks.catalog.Type;
 import com.starrocks.sql.ast.AstVisitor;
 
+/**
+ * Parameter used in prepare-statement, placeholder ? is translated into a Parameter
+ */
 public class Parameter extends Expr {
     private final int slotId;
 
@@ -55,10 +58,17 @@ public class Parameter extends Expr {
 
     @Override
     public Type getType() {
+        Type res;
         if (expr != null) {
-            return expr.getType();
+            res = expr.getType();
+        } else {
+            res = super.getType();
         }
-        return super.getType();
+        // use STRING as default type, since string is compatible with almost all types in the type inference
+        if (res.isInvalid()) {
+            res = Type.STRING;
+        }
+        return res;
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/mysql/MysqlCapability.java
+++ b/fe/fe-core/src/main/java/com/starrocks/mysql/MysqlCapability.java
@@ -127,6 +127,10 @@ public class MysqlCapability {
         return sb.toString();
     }
 
+    public boolean isDeprecateEof() {
+        return (flags & Flag.CLIENT_DEPRECATE_EOF.getFlagBit()) != 0;
+    }
+
     public boolean isProtocol41() {
         return (flags & Flag.CLIENT_PROTOCOL_41.getFlagBit()) != 0;
     }

--- a/fe/fe-core/src/main/java/com/starrocks/qe/StmtExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/StmtExecutor.java
@@ -1752,11 +1752,9 @@ public class StmtExecutor {
                 serializer.writeField(colNames.get(i), parameters.get(i).getType());
                 context.getMysqlChannel().sendOnePacket(serializer.toByteBuffer());
             }
-            if (!serializer.getCapability().isDeprecateEof()) {
-                MysqlEofPacket eofPacket = new MysqlEofPacket(context.getState());
-                eofPacket.writeTo(serializer);
-                context.getMysqlChannel().sendOnePacket(serializer.toByteBuffer());
-            }
+            MysqlEofPacket eofPacket = new MysqlEofPacket(context.getState());
+            eofPacket.writeTo(serializer);
+            context.getMysqlChannel().sendOnePacket(serializer.toByteBuffer());
         }
 
         if (numColumns > 0) {
@@ -1765,11 +1763,9 @@ public class StmtExecutor {
                 serializer.writeField(field.getName(), field.getType());
                 context.getMysqlChannel().sendOnePacket(serializer.toByteBuffer());
             }
-            if (!serializer.getCapability().isDeprecateEof()) {
-                MysqlEofPacket eofPacket = new MysqlEofPacket(context.getState());
-                eofPacket.writeTo(serializer);
-                context.getMysqlChannel().sendOnePacket(serializer.toByteBuffer());
-            }
+            MysqlEofPacket eofPacket = new MysqlEofPacket(context.getState());
+            eofPacket.writeTo(serializer);
+            context.getMysqlChannel().sendOnePacket(serializer.toByteBuffer());
         }
 
         context.getMysqlChannel().flush();

--- a/fe/fe-core/src/main/java/com/starrocks/qe/StmtExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/StmtExecutor.java
@@ -114,6 +114,7 @@ import com.starrocks.sql.StatementPlanner;
 import com.starrocks.sql.analyzer.AnalyzerUtils;
 import com.starrocks.sql.analyzer.AstToStringBuilder;
 import com.starrocks.sql.analyzer.Authorizer;
+import com.starrocks.sql.analyzer.Field;
 import com.starrocks.sql.analyzer.SemanticException;
 import com.starrocks.sql.ast.AddBackendBlackListStmt;
 import com.starrocks.sql.ast.AddSqlBlackListStmt;
@@ -1723,13 +1724,14 @@ public class StmtExecutor {
 
     private void sendStmtPrepareOK(PrepareStmt prepareStmt) throws IOException {
         // https://dev.mysql.com/doc/dev/mysql-server/latest/page_protocol_com_stmt_prepare.html#sect_protocol_com_stmt_prepare_response
+        QueryStatement query = (QueryStatement) prepareStmt.getInnerStmt();
         serializer.reset();
         // 0x00 OK
         serializer.writeInt1(0);
         // statement_id
         serializer.writeInt4(Integer.valueOf(prepareStmt.getName()));
         // num_columns
-        int numColumns = 0;
+        int numColumns = query.getQueryRelation().getRelationFields().size();
         serializer.writeInt2(numColumns);
         // num_params
         int numParams = prepareStmt.getParameters().size();
@@ -1741,6 +1743,7 @@ public class StmtExecutor {
         // metadata follows
         serializer.writeInt1(1);
         context.getMysqlChannel().sendOnePacket(serializer.toByteBuffer());
+
         if (numParams > 0) {
             List<String> colNames = prepareStmt.getParameterLabels();
             List<Parameter> parameters = prepareStmt.getParameters();
@@ -1750,7 +1753,19 @@ public class StmtExecutor {
                 context.getMysqlChannel().sendOnePacket(serializer.toByteBuffer());
             }
             context.getState().setEof();
-        } else {
+        }
+
+        if (numColumns > 0) {
+            for (Field field : query.getQueryRelation().getRelationFields().getAllFields()) {
+                serializer.reset();
+                serializer.writeField(field.getName(), field.getType());
+                context.getMysqlChannel().sendOnePacket(serializer.toByteBuffer());
+            }
+
+            context.getState().setEof();
+        }
+
+        if (numParams == 0 && numColumns == 0) {
             context.getMysqlChannel().flush();
             context.getState().setStateType(MysqlStateType.NOOP);
         }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/PrepareAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/PrepareAnalyzer.java
@@ -23,8 +23,12 @@ import com.starrocks.sql.ast.StatementBase;
 import com.starrocks.sql.common.ErrorType;
 import com.starrocks.sql.common.StarRocksPlannerException;
 import com.starrocks.sql.optimizer.validate.ValidateException;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 public class PrepareAnalyzer {
+
+    private static final Logger LOG = LogManager.getLogger(PrepareAnalyzer.class);
     private final ConnectContext session;
 
     public PrepareAnalyzer(ConnectContext session) {
@@ -41,6 +45,12 @@ public class PrepareAnalyzer {
             StatementBase innerStmt = prepareStmt.getInnerStmt();
             if (!(innerStmt instanceof QueryStatement)) {
                 throw new ValidateException("Invalid statement type for prepared statement", ErrorType.USER_ERROR);
+            }
+            try {
+                Analyzer.analyze(innerStmt, ConnectContext.get());
+            } catch (SemanticException ignored) {
+                // ignore analyze failure, since not all expressions are supported
+                LOG.warn("analyze failed when prepare", ignored);
             }
         }
     }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/PrepareAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/PrepareAnalyzer.java
@@ -46,12 +46,9 @@ public class PrepareAnalyzer {
             if (!(innerStmt instanceof QueryStatement)) {
                 throw new ValidateException("Invalid statement type for prepared statement", ErrorType.USER_ERROR);
             }
-            try {
-                Analyzer.analyze(innerStmt, ConnectContext.get());
-            } catch (SemanticException ignored) {
-                // ignore analyze failure, since not all expressions are supported
-                LOG.warn("analyze failed when prepare", ignored);
-            }
+            // Analyzing when preparing is only used to return the correct resultset meta, but not to generate an
+            // execution plan
+            Analyzer.analyze(innerStmt, ConnectContext.get());
         }
     }
 

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/PreparedStmtTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/PreparedStmtTest.java
@@ -64,7 +64,7 @@ public class PreparedStmtTest{
 
     @Test
     public void testParser() throws Exception {
-        String sql1= "PREPARE stmt2 FROM select * from demo.prepare_stmt where k1 = ? and k2 = ?;";
+        String sql1 = "PREPARE stmt2 FROM select * from demo.prepare_stmt where c1 = ? and c2 = ?;";
         String sql2 = "PREPARE stmt3 FROM 'select * from demo.prepare_stmt';";
         String sql3 = "execute stmt3;";
         String sql4 = "execute stmt2 using @i;";


### PR DESCRIPTION
## Why I'm doing:
- According to [MySQL Spec](https://dev.mysql.com/doc/dev/mysql-server/latest/page_protocol_com_stmt_prepare.html#sect_protocol_com_stmt_prepare_response), the prepare statement needs to return the metadata of query output, which means the server needs to **analyze** the statement

## What I'm doing:
- Analyze the statement when prepare, to return the correct resultset metadata
- Treat the `Parameter` as string Type when inferencing type, since string is compatible with almost all types

## Out of scope
- Optimize the query performance of prepare-statement

Fixes #38672

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
