### PR TITLE
[Enhancement] Reduce cpu cost in pk publish

### DIFF
--- a/be/src/storage/lake/compaction_policy.cpp
+++ b/be/src/storage/lake/compaction_policy.cpp
@@ -134,6 +134,9 @@ public:
     StatusOr<std::vector<RowsetPtr>> pick_rowsets() override;
     StatusOr<std::vector<RowsetPtr>> pick_rowsets(const std::shared_ptr<const TabletMetadataPB>& tablet_metadata,
                                                   bool calc_score, std::vector<bool>* has_dels);
+    // Common function to return the picked rowset indexes.
+    // For compaction score, only picked rowset indexes are needed.
+    // For compaction, picked rowsets can be constructed by picked rowset indexes.
     StatusOr<std::vector<int64_t>> pick_rowset_indexes(const std::shared_ptr<const TabletMetadataPB>& tablet_metadata,
                                                        bool calc_score, std::vector<bool>* has_dels);
 

--- a/be/src/storage/lake/compaction_policy.cpp
+++ b/be/src/storage/lake/compaction_policy.cpp
@@ -206,14 +206,12 @@ StatusOr<std::vector<RowsetPtr>> PrimaryCompactionPolicy::pick_rowsets(
     for (auto rowset_index : rowset_indexes) {
         input_rowsets.emplace_back(std::make_shared<Rowset>(_tablet_mgr, tablet_metadata, rowset_index));
     }
-    VLOG(2) << strings::Substitute("lake PrimaryCompactionPolicy pick_rowsets tabletid:$0 version:$1 inputs:$2",
-                                   tablet_metadata->id(), tablet_metadata->version(),
-                                   JoinMapped(
-                                           rowset_indexes,
-                                           [&](int64_t rowset_index) -> std::string {
-                                               return std::to_string(tablet_metadata->rowsets(rowset_index).id());
-                                           },
-                                           "|"));
+    VLOG(2) << strings::Substitute(
+            "lake PrimaryCompactionPolicy pick_rowsets tabletid:$0 version:$1 inputs:$2", tablet_metadata->id(),
+            tablet_metadata->version(),
+            JoinMapped(
+                    input_rowsets, [&](const RowsetPtr& rowset) -> std::string { return std::to_string(rowset->id()); },
+                    "|"));
     return input_rowsets;
 }
 


### PR DESCRIPTION
## Why I'm doing:
The constructor `explicit Rowset(TabletManager* tablet_mgr, TabletMetadataPtr tablet_metadata, int rowset_index);` will emplace schema to `GlobalTabletSchemaMap`. But the emplace of `GlobalTabletSchemaMap` need lock which will waste cpu cost. And in publish version, PK table needs to pick rowsets first and calculate compaction score, but only rowset indexes is needed in fact which means there is no need to construct `Rowset`.
## What I'm doing:
Split the logic of `pick_rowset_indexes` from `pick_rowsets`. For compaction score, we only need rowset indexes. For compaction, rowset can be constructed by rowset indexes.
Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
