### PR TITLE
[Enhancement] Requires the pipe database to be the same as the target table database

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/PipeAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/PipeAnalyzer.java
@@ -193,9 +193,9 @@ public class PipeAnalyzer {
             ErrorReport.reportSemanticException(ErrorCode.ERR_BAD_PIPE_STATEMENT, "only support FileTableFunction");
         }
 
-        if (!stmt.getPipeName().getDbName().equals(insertStmt.getTableName().getDb())) {
+        if (!stmt.getPipeName().getDbName().equalsIgnoreCase(insertStmt.getTableName().getDb())) {
             ErrorReport.reportSemanticException(ErrorCode.ERR_BAD_PIPE_STATEMENT,
-                    String.format("pipe's database [%s] and target table's database [%s] should be the same",
+                    String.format("pipe's database [%s] and target table's database [%s] should be the same ignoring case",
                             stmt.getPipeName().getDbName(), insertStmt.getTableName().getDb()));
         }
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/PipeAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/PipeAnalyzer.java
@@ -171,7 +171,7 @@ public class PipeAnalyzer {
 
         if (!stmt.getPipeName().getDbName().equalsIgnoreCase(insertStmt.getTableName().getDb())) {
             ErrorReport.reportSemanticException(ErrorCode.ERR_BAD_PIPE_STATEMENT,
-                    String.format("pipe's database [%s] and target table's database [%s] should be the same ignoring case",
+                    String.format("pipe's database [%s] and target table's database [%s] should be the same",
                             stmt.getPipeName().getDbName(), insertStmt.getTableName().getDb()));
         }
 
@@ -188,7 +188,8 @@ public class PipeAnalyzer {
         }
         SelectRelation selectRelation = (SelectRelation) queryStatement.getQueryRelation();
         if (selectRelation.hasAggregation() || selectRelation.hasOrderByClause() || selectRelation.hasLimit()) {
-            ErrorReport.reportSemanticException(ErrorCode.ERR_BAD_PIPE_STATEMENT, "must be a vanilla select statement");
+            ErrorReport.reportSemanticException(ErrorCode.ERR_BAD_PIPE_STATEMENT, "must be a vanilla select statement." +
+                    " Aggregation, order by clause, limit clause are not supported yet.");
         }
         if (!(selectRelation.getRelation() instanceof FileTableFunctionRelation)) {
             ErrorReport.reportSemanticException(ErrorCode.ERR_BAD_PIPE_STATEMENT, "only support FileTableFunction");

--- a/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AnalyzeCreatePipeTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AnalyzeCreatePipeTest.java
@@ -1,0 +1,62 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//   http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package com.starrocks.sql.analyzer;
+
+import com.starrocks.sql.ast.pipe.CreatePipeStmt;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+public class AnalyzeCreatePipeTest {
+    @BeforeClass
+    public static void beforeClass() throws Exception {
+        AnalyzeTestUtil.init();
+    }
+
+    @Test
+    public void testNormal() {
+        {
+            // pipe's database: not set
+            // target table's database: not set
+            // result: current database
+            CreatePipeStmt stmt = (CreatePipeStmt) AnalyzeTestUtil.analyzeSuccess(
+                    "create pipe pipe5 properties(\"auto_ingest\"=\"true\") as " +
+                            "insert into t0 select col_int, col_string, 1 from files(\"path\"=\"fake://somewhere/1.parquet\"," +
+                            " \"format\"=\"parquet\")");
+            Assert.assertEquals("test", stmt.getInsertStmt().getTableName().getDb());
+            Assert.assertEquals(stmt.getPipeName().getDbName(), stmt.getInsertStmt().getTableName().getDb());
+        }
+        {
+            // pipe's database: not set
+            // target table's database: 'test'
+            // result: target table's database
+            CreatePipeStmt stmt = (CreatePipeStmt) AnalyzeTestUtil.analyzeSuccess(
+                    "create pipe pipe5 properties(\"auto_ingest\"=\"true\") as " +
+                            "insert into test.t0 select col_int, col_string, 1 from files(\"path\"=\"fake://somewhere/1.parquet\"," +
+                            " \"format\"=\"parquet\")");
+            Assert.assertEquals(stmt.getPipeName().getDbName(), stmt.getInsertStmt().getTableName().getDb());
+        }
+        {
+            // pipe's database: 'test1'
+            // target table's database: 'test'
+            // result: error
+            AnalyzeTestUtil.analyzeFail(
+                    "create pipe test1.pipe5 properties(\"auto_ingest\"=\"true\") as " +
+                            "insert into test.t0 select col_int, col_string, 1 from files(\"path\"=\"fake://somewhere/1.parquet\"," +
+                            " \"format\"=\"parquet\")");
+        }
+    }
+}


### PR DESCRIPTION
## Why I'm doing:
```
create pipe db0.pipe5 properties("auto_ingest"="true") as insert into db1.tbl_pipe select * from files("path"="file://somewhere/1.parquet", "format"="parquet");

```
When we use the statement above to create a pipe, the pipe belongs to the database `db0`, which is different from the target table's database.
It's confusing that the pipe belongs to `db0` writes data to table belongs to `db1`.
## What I'm doing:
This PR adds the constraint requiring the pipe database to be the same as the target table database. When they are not different, an error `Bad pipe statement: 'pipe's db and target table's db should be the same'` is reported.
```
[db1]> create pipe db0.pipe4 properties("auto_ingest"="true") as insert into db0.tbl_pipe select * from files("path"="file:///home/ricky/code/work/python-test/1.parquet", "format"="parquet");

ERROR 1064 (HY000): Getting analyzing error. Detail message: Bad pipe statement: 'pipe's db and target table's db should be the same.
```
The database of pipe would be set  as following rules:
| Pipe's database | Target table's database | Result |
| --- | ---| ---|
| Not set | Not set | Current Database  |
| Not set | Set | Target table's database |
| Set | Not set | The pipe's given database must be the same as the current database |
| Set | Set | The pipe's given database must be the same as the target table's database|

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [x] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
