### PR TITLE
[Enhancement] when ddl input is invalid, set error type as ANALYSIS_ERR

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/alter/SchemaChangeHandler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/SchemaChangeHandler.java
@@ -2340,7 +2340,12 @@ public class SchemaChangeHandler extends AlterHandler {
         for (String col : indexDef.getColumns()) {
             Column column = olapTable.getColumn(col);
             if (column != null) {
-                indexDef.checkColumn(column, olapTable.getKeysType());
+                // only throw DdlException
+                try {
+                    indexDef.checkColumn(column, olapTable.getKeysType());
+                } catch (Exception e) {
+                    throw new DdlException(e.getMessage());
+                }
             } else {
                 throw new DdlException("BITMAP column does not exist in table. invalid column: " + col);
             }

--- a/fe/fe-core/src/main/java/com/starrocks/qe/StmtExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/StmtExecutor.java
@@ -1611,7 +1611,7 @@ public class StmtExecutor {
         return explainString;
     }
 
-    private void handleDdlStmt() {
+    private void handleDdlStmt() throws DdlException {
         try {
             ShowResultSet resultSet = DDLStmtExecutor.execute(parsedStmt, context);
             if (resultSet == null) {
@@ -1633,6 +1633,10 @@ public class StmtExecutor {
                 LOG.warn("DDL statement (" + sql + ") process failed.", e);
             }
             context.setState(e.getQueryState());
+        } catch (DdlException e) {
+            // let StmtExecutor.execute catch this exception
+            // which will set error as ANALYSIS_ERR
+            throw e;
         } catch (Throwable e) {
             // Maybe our bug or wrong input parameters
             String sql = AstToStringBuilder.toString(parsedStmt);

--- a/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AnalyzeAlterTableStatementTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AnalyzeAlterTableStatementTest.java
@@ -90,12 +90,29 @@ public class AnalyzeAlterTableStatementTest {
     }
 
     @Test
-    public void testCreateIndex() {
+    public void testCreateIndex() throws Exception {
         String sql = "CREATE INDEX index1 ON `test`.`t0` (`col1`) USING BITMAP COMMENT 'balabala'";
         analyzeSuccess(sql);
 
         sql = "alter table t0 add index index1 (v2)";
         analyzeSuccess(sql);
+
+        AnalyzeTestUtil.getStarRocksAssert().withTable("CREATE TABLE test.bitmapTable\n" +
+                "(\n" +
+                "    k1 date,\n" +
+                "    k2 int,\n" +
+                "    v1 int sum\n" +
+                ") AGGREGATE KEY (k1, k2)\n" +
+                "DISTRIBUTED BY HASH(k2) BUCKETS 3\n" +
+                "PROPERTIES('replication_num' = '1');");
+        // create bitmap index on v1
+        sql = "CREATE INDEX index1 ON `test`.`bitmapTable` (`v1`) USING BITMAP COMMENT 'balabala'";
+        StmtExecutor stmtExecutor = new StmtExecutor(connectContext, sql);
+        stmtExecutor.execute();
+        Assert.assertEquals(connectContext.getState().getErrType(), QueryState.ErrType.ANALYSIS_ERR);
+        connectContext.getState().getErrorMessage()
+                .contains(
+                        "BITMAP index only used in columns of DUP_KEYS/PRIMARY_KEYS table or key columns of UNIQUE_KEYS/AGG_KEYS table");
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AnalyzeAlterTableStatementTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AnalyzeAlterTableStatementTest.java
@@ -112,7 +112,8 @@ public class AnalyzeAlterTableStatementTest {
         Assert.assertEquals(connectContext.getState().getErrType(), QueryState.ErrType.ANALYSIS_ERR);
         connectContext.getState().getErrorMessage()
                 .contains(
-                        "BITMAP index only used in columns of DUP_KEYS/PRIMARY_KEYS table or key columns of UNIQUE_KEYS/AGG_KEYS table");
+                        "BITMAP index only used in columns of " +
+                                "DUP_KEYS/PRIMARY_KEYS table or key columns of UNIQUE_KEYS/AGG_KEYS table");
     }
 
     @Test

--- a/test/sql/test_alter_table/R/test_alter_table_abnormal
+++ b/test/sql/test_alter_table/R/test_alter_table_abnormal
@@ -12,35 +12,35 @@ INSERT INTO t0 VALUES(0, '2024-01-01 00:00:00', 10, '100');
 -- !result
 ALTER TABLE t0 ADD COLUMN k0 FLOAT;
 -- result:
-E: (1064, 'Unexpected exception: Repeatedly add same column with different definition: k0')
+E: (1064, 'Repeatedly add same column with different definition: k0')
 -- !result
 ALTER TABLE t0 ADD COLUMN v0 BIGINT;
 -- result:
-E: (1064, 'Unexpected exception: Repeatedly add same column with different definition: v0')
+E: (1064, 'Repeatedly add same column with different definition: v0')
 -- !result
 ALTER TABLE t0 DROP COLUMN k1;
 -- result:
-E: (1064, 'Unexpected exception: Can not drop key column in primary data model table')
+E: (1064, 'Can not drop key column in primary data model table')
 -- !result
 ALTER TABLE t0 DROP COLUMN k0;
 -- result:
-E: (1064, 'Unexpected exception: Can not drop key column in primary data model table')
+E: (1064, 'Can not drop key column in primary data model table')
 -- !result
 ALTER TABLE t0 MODIFY COLUMN k0 INT;
 -- result:
-E: (1064, 'Unexpected exception: Can not modify key column: k0 for primary key table')
+E: (1064, 'Can not modify key column: k0 for primary key table')
 -- !result
 ALTER TABLE t0 MODIFY COLUMN k0 LARGEINT;
 -- result:
-E: (1064, 'Unexpected exception: Can not modify key column: k0 for primary key table')
+E: (1064, 'Can not modify key column: k0 for primary key table')
 -- !result
 ALTER TABLE t0 MODIFY COLUMN v0 BIGINT;
 -- result:
-E: (1064, 'Unexpected exception: Can not modify sort column in primary data model table')
+E: (1064, 'Can not modify sort column in primary data model table')
 -- !result
 ALTER TABLE t0 MODIFY COLUMN v1 VARCHAR(200), MODIFY COLUMN v0 BIGINT;
 -- result:
-E: (1064, 'Unexpected exception: Can not modify sort column in primary data model table')
+E: (1064, 'Can not modify sort column in primary data model table')
 -- !result
 ALTER TABLE t0 MODIFY COLUMN v1 VARCHAR(100) MAX;
 -- result:
@@ -51,7 +51,7 @@ E: (1064, "Getting analyzing error from line 1, column 26 to line 1, column 38. 
 -- !result
 ALTER TABLE t0 ADD COLUMN v2 BIGINT, ADD COLUMN v2 FLOAT;
 -- result:
-E: (1064, 'Unexpected exception: Repeatedly add same column with different definition: v2')
+E: (1064, 'Repeatedly add same column with different definition: v2')
 -- !result
 ALTER TABLE t0 ADD COLUMN v2 BIGINT, ADD COLUMN v2 BIGINT KEY;
 -- result:
@@ -73,27 +73,27 @@ v1	varchar(100)	YES	false	None
 -- !result
 ALTER TABLE t0 ADD COLUMN v2 BIGINT, ADD COLUMN v0 BIGINT;
 -- result:
-E: (1064, 'Unexpected exception: Repeatedly add same column with different definition: v0')
+E: (1064, 'Repeatedly add same column with different definition: v0')
 -- !result
 ALTER TABLE t0 DROP COLUMN k0;
 -- result:
-E: (1064, 'Unexpected exception: Can not drop key column in primary data model table')
+E: (1064, 'Can not drop key column in primary data model table')
 -- !result
 ALTER TABLE t0 DROP COLUMN v1, DROP COLUMN k0;
 -- result:
-E: (1064, 'Unexpected exception: Can not drop key column in primary data model table')
+E: (1064, 'Can not drop key column in primary data model table')
 -- !result
 ALTER TABLE t0 DROP COLUMN v0;
 -- result:
-E: (1064, 'Unexpected exception: Can not drop sort column in primary data model table')
+E: (1064, 'Can not drop sort column in primary data model table')
 -- !result
 ALTER TABLE t0 DROP COLUMN v1, DROP COLUMN v0;
 -- result:
-E: (1064, 'Unexpected exception: Can not drop sort column in primary data model table')
+E: (1064, 'Can not drop sort column in primary data model table')
 -- !result
 ALTER TABLE t0 DROP COLUMN v1, DROP COLUMN v100;
 -- result:
-E: (1064, 'Unexpected exception: Column does not exists: v100')
+E: (1064, 'Column does not exists: v100')
 -- !result
 DESC t0;
 -- result:
@@ -122,15 +122,15 @@ E: (1064, "Getting analyzing error from line 1, column 26 to line 1, column 42. 
 -- !result
 ALTER TABLE t1 ADD column v2 BIGINT MIN;
 -- result:
-E: (1064, 'Unexpected exception: Can not assign aggregation method on column in Unique data model table: v2')
+E: (1064, 'Can not assign aggregation method on column in Unique data model table: v2')
 -- !result
 ALTER TABLE t1 ADD COLUMN v2 BIGINT, ADD COLUMN v2 FLOAT;
 -- result:
-E: (1064, 'Unexpected exception: Repeatedly add same column with different definition: v2')
+E: (1064, 'Repeatedly add same column with different definition: v2')
 -- !result
 ALTER TABLE t1 ADD COLUMN v2 BIGINT, ADD COLUMN v2 BIGINT KEY;
 -- result:
-E: (1064, 'Unexpected exception: Repeatedly add same column with different definition: v2')
+E: (1064, 'Repeatedly add same column with different definition: v2')
 -- !result
 ALTER TABLE t1 ADD COLUMN v2 BIGINT, DROP COLUMN v2;
 -- result:
@@ -144,23 +144,23 @@ v1	varchar(100)	YES	false	None
 -- !result
 ALTER TABLE t1 ADD COLUMN v2 BIGINT, ADD COLUMN v0 BIGINT;
 -- result:
-E: (1064, 'Unexpected exception: Can not add column which already exists in base table: v0')
+E: (1064, 'Can not add column which already exists in base table: v0')
 -- !result
 ALTER TABLE t1 DROP COLUMN k1;
 -- result:
-E: (1064, 'Unexpected exception: Can not drop key column in Unique data model table')
+E: (1064, 'Can not drop key column in Unique data model table')
 -- !result
 ALTER TABLE t1 DROP COLUMN v0, DROP COLUMN k1;
 -- result:
-E: (1064, 'Unexpected exception: Can not drop key column in Unique data model table')
+E: (1064, 'Can not drop key column in Unique data model table')
 -- !result
 ALTER TABLE t1 DROP COLUMN v0, DROP COLUMN v100;
 -- result:
-E: (1064, 'Unexpected exception: Column does not exists: v100')
+E: (1064, 'Column does not exists: v100')
 -- !result
 ALTER TABLE t1 MODIFY COLUMN v1 VARCHAR(100) MAX;
 -- result:
-E: (1064, 'Unexpected exception: Can not assign aggregation method on column in Unique data model table: v1')
+E: (1064, 'Can not assign aggregation method on column in Unique data model table: v1')
 -- !result
 DESC t1;
 -- result:
@@ -189,30 +189,30 @@ E: (1064, "Getting analyzing error from line 1, column 26 to line 1, column 42. 
 -- !result
 ALTER TABLE t2 ADD column v2 BIGINT MIN;
 -- result:
-E: (1064, 'Unexpected exception: Can not assign aggregation method on column in Duplicate data model table: v2')
+E: (1064, 'Can not assign aggregation method on column in Duplicate data model table: v2')
 -- !result
 ALTER TABLE t2 ADD COLUMN v2 BIGINT, ADD COLUMN v2 FLOAT;
 -- result:
-E: (1064, 'Unexpected exception: Repeatedly add same column with different definition: v2')
+E: (1064, 'Repeatedly add same column with different definition: v2')
 -- !result
 ALTER TABLE t2 ADD COLUMN v2 BIGINT, ADD COLUMN v2 BIGINT KEY;
 -- result:
-E: (1064, 'Unexpected exception: Repeatedly add same column with different definition: v2')
+E: (1064, 'Repeatedly add same column with different definition: v2')
 -- !result
 ALTER TABLE t2 ADD COLUMN v2 BIGINT, DROP COLUMN v2;
 -- result:
 -- !result
 ALTER TABLE t2 ADD COLUMN v2 BIGINT, ADD COLUMN v0 BIGINT;
 -- result:
-E: (1064, 'Unexpected exception: Can not add column which already exists in base table: v0')
+E: (1064, 'Can not add column which already exists in base table: v0')
 -- !result
 ALTER TABLE t2 DROP COLUMN v0, DROP COLUMN v100;
 -- result:
-E: (1064, 'Unexpected exception: Column does not exists: v100')
+E: (1064, 'Column does not exists: v100')
 -- !result
 ALTER TABLE t2 MODIFY COLUMN v1 VARCHAR(100) MAX;
 -- result:
-E: (1064, 'Unexpected exception: Can not assign aggregation method on column in Duplicate data model table: v1')
+E: (1064, 'Can not assign aggregation method on column in Duplicate data model table: v1')
 -- !result
 DESC t2;
 -- result:
@@ -241,7 +241,7 @@ PROPERTIES ("fast_schema_evolution" = "true", "replication_num"="1");
 -- !result
 ALTER TABLE t9 DROP COLUMN c1;
 -- result:
-E: (1064, 'Unexpected exception: Partition column[c1] cannot be dropped. index[t9]')
+E: (1064, 'Partition column[c1] cannot be dropped. index[t9]')
 -- !result
 CREATE TABLE t10 (
 c0 int(11) NULL COMMENT "",
@@ -258,7 +258,7 @@ PROPERTIES ("fast_schema_evolution" = "false", "replication_num"="1");
 -- !result
 ALTER TABLE t10 DROP COLUMN c1;
 -- result:
-E: (1064, 'Unexpected exception: Partition column[c1] cannot be dropped. index[t10]')
+E: (1064, 'Partition column[c1] cannot be dropped. index[t10]')
 -- !result
 CREATE TABLE site_access1 (
     event_day DATETIME NOT NULL,
@@ -275,10 +275,10 @@ PROPERTIES('replication_num'='1');
 -- !result
 ALTER TABLE site_access1 DROP COLUMN event_day;
 -- result:
-E: (1064, 'Unexpected exception: Partition column[event_day] cannot be dropped. index[site_access1]')
+E: (1064, 'Partition column[event_day] cannot be dropped. index[site_access1]')
 -- !result
 ALTER TABLE site_access1 DROP COLUMN site_id;
 -- result:
-E: (1064, 'Unexpected exception: Distribution column[site_id] cannot be dropped. index[site_access1]')
+E: (1064, 'Distribution column[site_id] cannot be dropped. index[site_access1]')
 -- !result
 

--- a/test/sql/test_auto_increment/R/test_auto_increment
+++ b/test/sql/test_auto_increment/R/test_auto_increment
@@ -27,7 +27,7 @@ E: (1064, 'Getting analyzing error from line 1, column 53 to line 1, column 74. 
 -- !result
 DROP DATABASE test_create_table_abnormal;
 -- result:
-E: (1064, "Unexpected exception: Can't drop database 'test_create_table_abnormal'; database doesn't exist")
+E: (1064, "Can't drop database 'test_create_table_abnormal'; database doesn't exist")
 -- !result
 -- name: test_create_table_normal
 CREATE DATABASE test_create_table_normal_auto_increment;
@@ -495,7 +495,7 @@ E: (1064, "Getting syntax error from line 1, column 25 to line 1, column 39. Det
 -- !result
 ALTER TABLE t MODIFY COLUMN job2 BIGINT;
 -- result:
-E: (1064, "Unexpected exception: Can't not modify a AUTO_INCREMENT column")
+E: (1064, "Can't not modify a AUTO_INCREMENT column")
 -- !result
 ALTER TABLE t MODIFY COLUMN job2 BIGINT AUTO_INCREMENT;
 -- result:

--- a/test/sql/test_automatic_bucket/R/test_automatic_partition
+++ b/test/sql/test_automatic_bucket/R/test_automatic_partition
@@ -45,7 +45,7 @@ create table t0(k int) properties('bucket_size'='0');
 -- !result
 create table t(k int) properties('bucket_size'='-1');
 -- result:
-E: (1064, 'Unexpected exception: Illegal bucket size: -1')
+E: (1064, 'Illegal bucket size: -1')
 -- !result
 create table t(k int) properties('bucket_size'='1024');
 -- result:

--- a/test/sql/test_automatic_partition/R/test_automatic_partition_list
+++ b/test/sql/test_automatic_partition/R/test_automatic_partition_list
@@ -124,7 +124,7 @@ ALTER TABLE list_auto_single ADD PARTITION psingle VALUES IN ("2023-04-01");
 -- !result
 ALTER TABLE list_auto_single ADD PARTITION pmul VALUES IN ("2022-04-01", "2022-04-02");
 -- result:
-E: (1064, 'Unexpected exception: Automatically partitioned tables does not support multiple values in the same partition')
+E: (1064, 'Automatically partitioned tables does not support multiple values in the same partition')
 -- !result
 CREATE TABLE list_normal_single (
     id bigint  ,

--- a/test/sql/test_column_rename/R/test_column_rename
+++ b/test/sql/test_column_rename/R/test_column_rename
@@ -40,7 +40,7 @@ ALTER TABLE t1 RENAME COLUMN k1 TO k2;
 -- !result
 ALTER TABLE t1 RENAME COLUMN v1 TO v2;
 -- result:
-E: (1064, "Unexpected exception: Getting analyzing error. Detail message: Duplicate column name 'v2'.")
+E: (1064, "Getting analyzing error. Detail message: Duplicate column name 'v2'.")
 -- !result
 select * from t1;
 -- result:

--- a/test/sql/test_column_rename/R/test_column_rename2
+++ b/test/sql/test_column_rename/R/test_column_rename2
@@ -105,5 +105,5 @@ alter table site_access rename column site_id to id;
 -- !result
 alter table site_access add column site_id int;
 -- result:
-E: (1064, 'Unexpected exception: Can not add column which already exists in physical column: site_id, you can remove `id` int(11) NULL DEFAULT "10" COMMENT "" and try again.')
+E: (1064, 'Can not add column which already exists in physical column: site_id, you can remove `id` int(11) NULL DEFAULT "10" COMMENT "" and try again.')
 -- !result

--- a/test/sql/test_ddl/R/test_alter_pk_reorder
+++ b/test/sql/test_ddl/R/test_alter_pk_reorder
@@ -83,11 +83,11 @@ PROPERTIES (
 -- !result
 ALTER TABLE test_alter_pk_reorder_column_type ORDER BY(v3, v4);
 -- result:
-E: (1064, 'Unexpected exception: Sort key column[v4] type not supported: DOUBLE in PrimaryKey table')
+E: (1064, 'Sort key column[v4] type not supported: DOUBLE in PrimaryKey table')
 -- !result
 ALTER TABLE test_alter_pk_reorder_column_type ORDER BY(v3, v5);
 -- result:
-E: (1064, 'Unexpected exception: Sort key column[v5] type not supported: FLOAT in PrimaryKey table')
+E: (1064, 'Sort key column[v5] type not supported: FLOAT in PrimaryKey table')
 -- !result
 ALTER TABLE test_alter_pk_reorder_column_type ORDER BY(v3);
 -- result:

--- a/test/sql/test_dictionary/R/test_dictionary
+++ b/test/sql/test_dictionary/R/test_dictionary
@@ -678,32 +678,32 @@ E: (1064, 'Getting analyzing error. Detail message: empty key list for dictionar
 CREATE DICTIONARY test_dictionary_error_2 USING t_dictionary_error (id1 KEY, id2 VALUE)
 PROPERTIES("dictionary_warm_up" = "abc", "dictionary_memory_limit" = "1024", "dictionary_refresh_interval" = "3600");
 -- result:
-E: (1064, 'Unexpected exception: parse dictionary_warm_up failed, given parameter: abc')
+E: (1064, 'parse dictionary_warm_up failed, given parameter: abc')
 -- !result
 CREATE DICTIONARY test_dictionary_error_2 USING t_dictionary_error (id1 KEY, id2 VALUE)
 PROPERTIES("dictionary_warm_up" = "TRUE", "dictionary_memory_limit" = "abc", "dictionary_refresh_interval" = "3600");
 -- result:
-E: (1064, 'Unexpected exception: parse dictionary_memory_limit failed, given parameter: abc')
+E: (1064, 'parse dictionary_memory_limit failed, given parameter: abc')
 -- !result
 CREATE DICTIONARY test_dictionary_error_2 USING t_dictionary_error (id1 KEY, id2 VALUE)
 PROPERTIES("dictionary_warm_up" = "TRUE", "dictionary_memory_limit" = "1024", "dictionary_refresh_interval" = "abc");
 -- result:
-E: (1064, 'Unexpected exception: parse dictionary_refresh_interval failed, given parameter: abc')
+E: (1064, 'parse dictionary_refresh_interval failed, given parameter: abc')
 -- !result
 CREATE DICTIONARY test_dictionary_error_2 USING t_dictionary_error (id1 KEY, id2 VALUE)
 PROPERTIES("abc" = "bcd", "dictionary_memory_limit" = "1024", "dictionary_refresh_interval" = "abc");
 -- result:
-E: (1064, 'Unexpected exception: unknown property for dictionary: abc')
+E: (1064, 'unknown property for dictionary: abc')
 -- !result
 CREATE DICTIONARY test_dictionary_error_2 USING t_dictionary_error (id1 KEY, id2 VALUE)
 PROPERTIES("dictionary_warm_up" = "abc", "abc" = "bcd", "dictionary_refresh_interval" = "3600");
 -- result:
-E: (1064, 'Unexpected exception: unknown property for dictionary: abc')
+E: (1064, 'unknown property for dictionary: abc')
 -- !result
 CREATE DICTIONARY test_dictionary_error_2 USING t_dictionary_error (id1 KEY, id2 VALUE)
 PROPERTIES("dictionary_warm_up" = "abc", "dictionary_memory_limit" = "1024", "abc" = "bcd");
 -- result:
-E: (1064, 'Unexpected exception: unknown property for dictionary: abc')
+E: (1064, 'unknown property for dictionary: abc')
 -- !result
 CREATE DICTIONARY test_dictionary_error_2 USING t_dictionary_error (id1 KEY, id2 VALUE)
 PROPERTIES("dicTionary_warM_up" = "tRue", "dictionaRy_memory_liMit" = "1024", "dictiOnary_reFResh_inTerval" = "3600");
@@ -855,57 +855,57 @@ DROP DICTIONARY test_dictionary_error_3;
 CREATE DICTIONARY test_dictionary_error_3 USING t_dictionary_error (id1 KEY, id2 VALUE)
 PROPERTIES("dictionaRy_memory_liMit" = "KB");
 -- result:
-E: (1064, 'Unexpected exception: parse dictionary_memory_limit failed, given parameter: KB')
+E: (1064, 'parse dictionary_memory_limit failed, given parameter: KB')
 -- !result
 CREATE DICTIONARY test_dictionary_error_3 USING t_dictionary_error (id1 KEY, id2 VALUE)
 PROPERTIES("dictionaRy_memory_liMit" = "MB");
 -- result:
-E: (1064, 'Unexpected exception: parse dictionary_memory_limit failed, given parameter: MB')
+E: (1064, 'parse dictionary_memory_limit failed, given parameter: MB')
 -- !result
 CREATE DICTIONARY test_dictionary_error_3 USING t_dictionary_error (id1 KEY, id2 VALUE)
 PROPERTIES("dictionaRy_memory_liMit" = "GB");
 -- result:
-E: (1064, 'Unexpected exception: parse dictionary_memory_limit failed, given parameter: GB')
+E: (1064, 'parse dictionary_memory_limit failed, given parameter: GB')
 -- !result
 CREATE DICTIONARY test_dictionary_error_3 USING t_dictionary_error (id1 KEY, id2 VALUE)
 PROPERTIES("dictionaRy_memory_liMit" = "B");
 -- result:
-E: (1064, 'Unexpected exception: parse dictionary_memory_limit failed, given parameter: B')
+E: (1064, 'parse dictionary_memory_limit failed, given parameter: B')
 -- !result
 CREATE DICTIONARY test_dictionary_error_3 USING t_dictionary_error (id1 KEY, id2 VALUE)
 PROPERTIES("dictionaRy_memory_liMit" = "G");
 -- result:
-E: (1064, 'Unexpected exception: parse dictionary_memory_limit failed, given parameter: G')
+E: (1064, 'parse dictionary_memory_limit failed, given parameter: G')
 -- !result
 CREATE DICTIONARY test_dictionary_error_3 USING t_dictionary_error (id1 KEY, id2 VALUE)
 PROPERTIES("dictionaRy_memory_liMit" = "m");
 -- result:
-E: (1064, 'Unexpected exception: parse dictionary_memory_limit failed, given parameter: m')
+E: (1064, 'parse dictionary_memory_limit failed, given parameter: m')
 -- !result
 CREATE DICTIONARY test_dictionary_error_3 USING t_dictionary_error (id1 KEY, id2 VALUE)
 PROPERTIES("dictionaRy_memory_liMit" = "K");
 -- result:
-E: (1064, 'Unexpected exception: parse dictionary_memory_limit failed, given parameter: K')
+E: (1064, 'parse dictionary_memory_limit failed, given parameter: K')
 -- !result
 CREATE DICTIONARY test_dictionary_error_3 USING t_dictionary_error (id1 KEY, id2 VALUE)
 PROPERTIES("dictionaRy_memory_liMit" = "asdK");
 -- result:
-E: (1064, 'Unexpected exception: parse dictionary_memory_limit failed, given parameter: asdK')
+E: (1064, 'parse dictionary_memory_limit failed, given parameter: asdK')
 -- !result
 CREATE DICTIONARY test_dictionary_error_3 USING t_dictionary_error (id1 KEY, id2 VALUE)
 PROPERTIES("dictionaRy_memory_liMit" = "GBKB");
 -- result:
-E: (1064, 'Unexpected exception: parse dictionary_memory_limit failed, given parameter: GBKB')
+E: (1064, 'parse dictionary_memory_limit failed, given parameter: GBKB')
 -- !result
 CREATE DICTIONARY test_dictionary_error_3 USING t_dictionary_error (id1 KEY, id2 VALUE)
 PROPERTIES("dictionaRy_memory_liMit" = "123GBKB");
 -- result:
-E: (1064, 'Unexpected exception: parse dictionary_memory_limit failed, given parameter: 123GBKB')
+E: (1064, 'parse dictionary_memory_limit failed, given parameter: 123GBKB')
 -- !result
 CREATE DICTIONARY test_dictionary_error_3 USING t_dictionary_error (id1 KEY, id2 VALUE)
 PROPERTIES("dictionaRy_memory_liMit" = "");
 -- result:
-E: (1064, 'Unexpected exception: parse dictionary_memory_limit failed, given parameter: ')
+E: (1064, 'parse dictionary_memory_limit failed, given parameter: ')
 -- !result
 DROP TABLE t_dictionary_error;
 -- result:

--- a/test/sql/test_fast_schema_evolution/R/test_fast_schema_evolution
+++ b/test/sql/test_fast_schema_evolution/R/test_fast_schema_evolution
@@ -588,7 +588,7 @@ None
 -- !result
 ALTER TABLE tab1 DROP COLUMN v5;
 -- result:
-E: (1064, 'Unexpected exception: No key column left. index[mv1]')
+E: (1064, 'No key column left. index[mv1]')
 -- !result
 function: wait_alter_table_finish()
 -- result:
@@ -596,7 +596,7 @@ function: wait_alter_table_finish()
 -- !result
 ALTER TABLE tab1 ADD COLUMN v5 tinyint;
 -- result:
-E: (1064, 'Unexpected exception: Repeatedly add same column with different definition: v5')
+E: (1064, 'Repeatedly add same column with different definition: v5')
 -- !result
 function: wait_alter_table_finish()
 -- result:

--- a/test/sql/test_function/R/test_substr
+++ b/test/sql/test_function/R/test_substr
@@ -4,35 +4,35 @@ create table t1 (id int, v bigint) distributed by hash(id) properties ("replicat
 -- !result
 select SUBSTR('', 9223372036854775807) ;
 -- result:
-E: (1064, 'Unexpected exception: Cast argument 9223372036854775807 to int type failed.')
+E: (1064, 'Cast argument 9223372036854775807 to int type failed.')
 -- !result
 select SUBSTR('', 9223372036854775807, 465254298) ;
 -- result:
-E: (1064, 'Unexpected exception: Cast argument 9223372036854775807 to int type failed.')
+E: (1064, 'Cast argument 9223372036854775807 to int type failed.')
 -- !result
 select SUBSTR('', -9223372036854775807, 465254298) ;
 -- result:
-E: (1064, 'Unexpected exception: Cast argument -9223372036854775807 to int type failed.')
+E: (1064, 'Cast argument -9223372036854775807 to int type failed.')
 -- !result
 select SUBSTR('', 9223372036854775806, 465254298) ;
 -- result:
-E: (1064, 'Unexpected exception: Cast argument 9223372036854775806 to int type failed.')
+E: (1064, 'Cast argument 9223372036854775806 to int type failed.')
 -- !result
 select SUBSTRING('', 9223372036854775807) ;
 -- result:
-E: (1064, 'Unexpected exception: Cast argument 9223372036854775807 to int type failed.')
+E: (1064, 'Cast argument 9223372036854775807 to int type failed.')
 -- !result
 select SUBSTRING('', 9223372036854775807, 465254298) ;
 -- result:
-E: (1064, 'Unexpected exception: Cast argument 9223372036854775807 to int type failed.')
+E: (1064, 'Cast argument 9223372036854775807 to int type failed.')
 -- !result
 select SUBSTRING('', -9223372036854775807, 465254298) ;
 -- result:
-E: (1064, 'Unexpected exception: Cast argument -9223372036854775807 to int type failed.')
+E: (1064, 'Cast argument -9223372036854775807 to int type failed.')
 -- !result
 select SUBSTRING('', 9223372036854775806, 465254298) ;
 -- result:
-E: (1064, 'Unexpected exception: Cast argument 9223372036854775806 to int type failed.')
+E: (1064, 'Cast argument 9223372036854775806 to int type failed.')
 -- !result
 insert into t1 values(1, 9223372036854775807), (2, -9223372036854775807), (3, 9223372036854775806);
 -- result:

--- a/test/sql/test_iceberg/R/test_iceberg_alter_table
+++ b/test/sql/test_iceberg/R/test_iceberg_alter_table
@@ -35,7 +35,7 @@ rename column col1 to col11;
 alter table iceberg_sql_test_${uuid0}.iceberg_db_${uuid0}.ice_tbl_${uuid0}
 add column col5 string not null default "--";
 -- result:
-E: (1064, 'Unexpected exception: column in iceberg table must be nullable.')
+E: (1064, 'column in iceberg table must be nullable.')
 -- !result
 alter table iceberg_sql_test_${uuid0}.iceberg_db_${uuid0}.ice_tbl_${uuid0}
 modify column col4 BIGINT;

--- a/test/sql/test_materialized_column/R/test_materialized_column
+++ b/test/sql/test_materialized_column/R/test_materialized_column
@@ -380,11 +380,11 @@ E: (1064, 'Getting syntax error. Detail message: Generated Column can not be KEY
 -- !result
 ALTER TABLE t MODIFY COLUMN mc_2 INT;
 -- result:
-E: (1064, 'Unexpected exception: Can not modify a generated column to a non-generated column')
+E: (1064, 'Can not modify a generated column to a non-generated column')
 -- !result
 ALTER TABLE t MODIFY COLUMN job BIGINT AS (id);
 -- result:
-E: (1064, 'Unexpected exception: Can not modify a non-generated column to a generated column')
+E: (1064, 'Can not modify a non-generated column to a generated column')
 -- !result
 ALTER TABLE t DROP COLUMN mc_2;
 -- result:
@@ -411,11 +411,11 @@ CREATE TABLE t ( id BIGINT NOT NULL, name BIGINT NOT NULL, job INT NOT NULL, mc 
 -- !result
 ALTER TABLE t ADD COLUMN newcol INT DEFAULT "0" AFTER mc;
 -- result:
-E: (1064, 'Unexpected exception: Can not add column after Generated Column')
+E: (1064, 'Can not add column after Generated Column')
 -- !result
 ALTER TABLE t MODIFY COLUMN job BIGINT;
 -- result:
-E: (1064, 'Unexpected exception: Do not support modify column: job, because it associates with the generated column')
+E: (1064, 'Do not support modify column: job, because it associates with the generated column')
 -- !result
 ALTER TABLE t DROP COLUMN job;
 -- result:
@@ -906,15 +906,15 @@ CREATE TABLE t0 ( v1 BIGINT NOT NULL, v2 BIGINT NOT NULL, v3 BIGINT NOT NULL) DU
 -- !result
 alter table t0 add column testcol1 BIGINT after xxx, add column testcol2 BIGINT after testcol1;
 -- result:
-E: (1064, 'Unexpected exception: Column[xxx] does not found')
+E: (1064, 'Column[xxx] does not found')
 -- !result
 alter table t0 add column testcol1 BIGINT after v1, add column testcol2 BIGINT after xxx;
 -- result:
-E: (1064, 'Unexpected exception: Column[xxx] does not found')
+E: (1064, 'Column[xxx] does not found')
 -- !result
 alter table t0 add column testcol1 BIGINT after xxx, add column testcol2 BIGINT after xxx;
 -- result:
-E: (1064, 'Unexpected exception: Column[xxx] does not found')
+E: (1064, 'Column[xxx] does not found')
 -- !result
 alter table t0 add column testcol1 BIGINT as v1 + 10 after xxx, add column testcol2 BIGINT after xxx;
 -- result:
@@ -926,7 +926,7 @@ E: (1064, 'Getting syntax error from line 1, column 26 to line 1, column 50. Det
 -- !result
 alter table t0 add column testcol1 BIGINT as v1 + 10, add column testcol2 BIGINT after testcol1;
 -- result:
-E: (1064, 'Unexpected exception: Can not add column after Generated Column')
+E: (1064, 'Can not add column after Generated Column')
 -- !result
 alter table t0 add column testcol1 BIGINT after v1, add column testcol2 BIGINT after testcol1;
 -- result:

--- a/test/sql/test_materialized_view/R/test_mv_on_view
+++ b/test/sql/test_materialized_view/R/test_mv_on_view
@@ -89,7 +89,7 @@ None
 -- !result
 [UC] ALTER MATERIALIZED VIEW mv_on_view_1 ACTIVE;
 -- result:
-E: (1064, 'Unexpected exception: Getting analyzing error. Detail message: Can not active materialized view [mv_on_view_1] because analyze materialized view define sql: \n\nCREATE MATERIALIZED VIEW `mv_on_view_1` (`event_day`, `sum_pv`)\nDISTRIBUTED BY RANDOM\nREFRESH ASYNC\nPROPERTIES (\n"replicated_storage" = "true",\n"replication_num" = "1",\n"storage_medium" = "HDD"\n)\nAS SELECT `db_mv_on_view`.`view1`.`event_day`, `db_mv_on_view`.`view1`.`sum_pv`\nFROM `db_mv_on_view`.`view1`;\n\nCause an error: View db_mv_on_view.view1 references invalid table(s) or column(s) or function(s) or definer/invoker of view lack rights to use them: Getting analyzing error. Detail message: Column \'`db_mv_on_view`.`jj`.`pv`\' cannot be resolved..')
+E: (1064, 'Getting analyzing error. Detail message: Can not active materialized view [mv_on_view_1] because analyze materialized view define sql: \n\nCREATE MATERIALIZED VIEW `mv_on_view_1` (`event_day`, `sum_pv`)\nDISTRIBUTED BY RANDOM\nREFRESH ASYNC\nPROPERTIES (\n"replicated_storage" = "true",\n"replication_num" = "1",\n"storage_medium" = "HDD"\n)\nAS SELECT `db_mv_on_view`.`view1`.`event_day`, `db_mv_on_view`.`view1`.`sum_pv`\nFROM `db_mv_on_view`.`view1`;\n\nCause an error: View db_mv_on_view.view1 references invalid table(s) or column(s) or function(s) or definer/invoker of view lack rights to use them: Getting analyzing error. Detail message: Column \'`db_mv_on_view`.`jj`.`pv`\' cannot be resolved..')
 -- !result
 SELECT IS_ACTIVE, INACTIVE_REASON FROM information_schema.materialized_views WHERE table_name = 'mv_on_view_1';
 -- result:

--- a/test/sql/test_materialized_view/R/test_mv_swap
+++ b/test/sql/test_materialized_view/R/test_mv_swap
@@ -87,15 +87,15 @@ SELECT * FROM mv2 ORDER BY event_day;
 -- !result
 ALTER MATERIALIZED VIEW mv1 SWAP WITH ss;
 -- result:
-E: (1064, 'Unexpected exception: Materialized view can only SWAP WITH materialized view')
+E: (1064, 'Materialized view can only SWAP WITH materialized view')
 -- !result
 ALTER TABLE ss SWAP WITH mv1;
 -- result:
-E: (1064, 'Unexpected exception: Materialized view can only SWAP WITH materialized view')
+E: (1064, 'Materialized view can only SWAP WITH materialized view')
 -- !result
 ALTER MATERIALIZED VIEW mv1 SWAP WITH mv1;
 -- result:
-E: (1064, 'Unexpected exception: New name conflicts with rollup index name: mv1')
+E: (1064, 'New name conflicts with rollup index name: mv1')
 -- !result
 ALTER MATERIALIZED VIEW mv1 SWAP WITH mv2;
 -- result:
@@ -123,11 +123,11 @@ false	base-mv inactive: mv_on_mv_1
 -- !result
 ALTER MATERIALIZED VIEW mv_on_mv_1 ACTIVE;
 -- result:
-E: (1064, 'Unexpected exception: Getting analyzing error. Detail message: Can not active materialized view [mv_on_mv_1] because analyze materialized view define sql: \n\nCREATE MATERIALIZED VIEW `mv_on_mv_1` (`sum_sum_pv`)\nDISTRIBUTED BY RANDOM\nREFRESH ASYNC\nPROPERTIES (\n"replicated_storage" = "true",\n"replication_num" = "1",\n"storage_medium" = "HDD"\n)\nAS SELECT sum(`db_test_mv_swap`.`mv1`.`sum_pv`) AS `sum_sum_pv`\nFROM `db_test_mv_swap`.`mv1`;\n\nCause an error: Column \'`db_test_mv_swap`.`mv1`.`sum_pv`\' cannot be resolved.')
+E: (1064, 'Getting analyzing error. Detail message: Can not active materialized view [mv_on_mv_1] because analyze materialized view define sql: \n\nCREATE MATERIALIZED VIEW `mv_on_mv_1` (`sum_sum_pv`)\nDISTRIBUTED BY RANDOM\nREFRESH ASYNC\nPROPERTIES (\n"replicated_storage" = "true",\n"replication_num" = "1",\n"storage_medium" = "HDD"\n)\nAS SELECT sum(`db_test_mv_swap`.`mv1`.`sum_pv`) AS `sum_sum_pv`\nFROM `db_test_mv_swap`.`mv1`;\n\nCause an error: Column \'`db_test_mv_swap`.`mv1`.`sum_pv`\' cannot be resolved.')
 -- !result
 ALTER MATERIALIZED VIEW mv_on_mv_2 ACTIVE;
 -- result:
-E: (1064, 'Unexpected exception: Getting analyzing error. Detail message: Can not active materialized view [mv_on_mv_2] because analyze materialized view define sql: \n\nCREATE MATERIALIZED VIEW `mv_on_mv_2` (`sum_sum_pv + 1`)\nDISTRIBUTED BY RANDOM\nREFRESH ASYNC\nPROPERTIES (\n"replicated_storage" = "true",\n"replication_num" = "1",\n"storage_medium" = "HDD"\n)\nAS SELECT `db_test_mv_swap`.`mv_on_mv_1`.`sum_sum_pv` + 1 AS `sum_sum_pv + 1`\nFROM `db_test_mv_swap`.`mv_on_mv_1`;\n\nCause an error: Create/Rebuild materialized view from inactive materialized view: mv_on_mv_1.')
+E: (1064, 'Getting analyzing error. Detail message: Can not active materialized view [mv_on_mv_2] because analyze materialized view define sql: \n\nCREATE MATERIALIZED VIEW `mv_on_mv_2` (`sum_sum_pv + 1`)\nDISTRIBUTED BY RANDOM\nREFRESH ASYNC\nPROPERTIES (\n"replicated_storage" = "true",\n"replication_num" = "1",\n"storage_medium" = "HDD"\n)\nAS SELECT `db_test_mv_swap`.`mv_on_mv_1`.`sum_sum_pv` + 1 AS `sum_sum_pv + 1`\nFROM `db_test_mv_swap`.`mv_on_mv_1`;\n\nCause an error: Create/Rebuild materialized view from inactive materialized view: mv_on_mv_1.')
 -- !result
 SELECT IS_ACTIVE, INACTIVE_REASON FROM information_schema.materialized_views WHERE table_name = 'mv_on_mv_1';
 -- result:

--- a/test/sql/test_primary_index_cache_expire/R/test_primary_index_cache_expire
+++ b/test/sql/test_primary_index_cache_expire/R/test_primary_index_cache_expire
@@ -122,7 +122,7 @@ PROPERTIES (
     "primary_index_cache_expire_sec" = "-100"
 );
 -- result:
-E: (1064, 'Unexpected exception: Property primary_index_cache_expire_sec must not be less than 0')
+E: (1064, 'Property primary_index_cache_expire_sec must not be less than 0')
 -- !result
 CREATE table tab3 (
       k1 INTEGER,
@@ -139,5 +139,5 @@ PROPERTIES (
     "primary_index_cache_expire_sec" = "asd"
 );
 -- result:
-E: (1064, 'Unexpected exception: Property primary_index_cache_expire_sec must be integer: asd')
+E: (1064, 'Property primary_index_cache_expire_sec must be integer: asd')
 -- !result

--- a/test/sql/test_random_distribution/R/test_random_distribution
+++ b/test/sql/test_random_distribution/R/test_random_distribution
@@ -188,7 +188,7 @@ PROPERTIES (
 -- !result
 alter table t add partition p5 values less than ("50") distributed by hash(k) buckets 10;
 -- result:
-E: (1064, 'Unexpected exception: Cannot assign different distribution type. default is: RANDOM')
+E: (1064, 'Cannot assign different distribution type. default is: RANDOM')
 -- !result
 insert into t values(-1,-1),(5,5),(15,15),(35,35);
 -- result:

--- a/test/sql/test_sort_key/R/test_sort_key_agg_tbl
+++ b/test/sql/test_sort_key/R/test_sort_key_agg_tbl
@@ -101,11 +101,11 @@ select * from agg_test;
 -- !result
 alter table agg_test order by (k2,v1);
 -- result:
-E: (1064, 'Unexpected exception: The sort columns of AGGREGATE KEY table must be same with key columns')
+E: (1064, 'The sort columns of AGGREGATE KEY table must be same with key columns')
 -- !result
 alter table agg_test order by (k2);
 -- result:
-E: (1064, 'Unexpected exception: The sort columns of AGGREGATE KEY table must be same with key columns')
+E: (1064, 'The sort columns of AGGREGATE KEY table must be same with key columns')
 -- !result
 alter table agg_test order by (k1,k2);
 -- result:

--- a/test/sql/test_sort_key/R/test_sort_key_uni_tbl
+++ b/test/sql/test_sort_key/R/test_sort_key_uni_tbl
@@ -98,11 +98,11 @@ select * from uni_test;
 -- !result
 alter table uni_test order by (k2,v1);
 -- result:
-E: (1064, 'Unexpected exception: The sort columns of UNIQUE KEY table must be same with key columns')
+E: (1064, 'The sort columns of UNIQUE KEY table must be same with key columns')
 -- !result
 alter table uni_test order by (k2);
 -- result:
-E: (1064, 'Unexpected exception: The sort columns of UNIQUE KEY table must be same with key columns')
+E: (1064, 'The sort columns of UNIQUE KEY table must be same with key columns')
 -- !result
 alter table uni_test order by (k1,k2);
 -- result:

--- a/test/sql/test_storage_volume/R/create_storage_volume
+++ b/test/sql/test_storage_volume/R/create_storage_volume
@@ -8,7 +8,7 @@ storage_volume_create
 -- !result
 CREATE STORAGE VOLUME storage_volume_create type = s3 LOCATIONS = ('s3://xxx') COMMENT 'comment' PROPERTIES ("aws.s3.endpoint"="endpoint", "aws.s3.region"="us-west-2", "aws.s3.use_aws_sdk_default_behavior" = "true", "enabled"="false");
 -- result:
-E: (1064, "Unexpected exception: Storage volume 'storage_volume_create' already exists")
+E: (1064, "Storage volume 'storage_volume_create' already exists")
 -- !result
 CREATE STORAGE VOLUME IF NOT EXISTS storage_volume_create type = s3 LOCATIONS = ('s3://xxx') COMMENT 'comment' PROPERTIES ("aws.s3.endpoint"="endpoint", "aws.s3.region"="us-west-2", "aws.s3.use_aws_sdk_default_behavior" = "true", "enabled"="false");
 -- result:

--- a/test/sql/test_storage_volume/R/drop_storage_volume
+++ b/test/sql/test_storage_volume/R/drop_storage_volume
@@ -8,7 +8,7 @@ storage_volume_drop
 -- !result
 DROP STORAGE VOLUME storage_volume_drop_1;
 -- result:
-E: (1064, "Unexpected exception: Storage volume 'storage_volume_drop_1' does not exist")
+E: (1064, "Storage volume 'storage_volume_drop_1' does not exist")
 -- !result
 DROP STORAGE VOLUME IF EXISTS storage_volume_drop_1;
 -- result:

--- a/test/sql/test_storage_volume/R/set_as_default
+++ b/test/sql/test_storage_volume/R/set_as_default
@@ -11,7 +11,7 @@ CREATE STORAGE VOLUME IF NOT EXISTS storage_volume_default_2 type = s3 LOCATIONS
 -- !result
 SET storage_volume_default_1 AS DEFAULT STORAGE VOLUME;
 -- result:
-E: (1064, "Unexpected exception: Storage volume 'storage_volume_default_1' is disabled")
+E: (1064, "Storage volume 'storage_volume_default_1' is disabled")
 -- !result
 ALTER STORAGE VOLUME storage_volume_default_1 SET ("aws.s3.region"="us-west-1", "aws.s3.endpoint"="endpoint1", "enabled"="true");
 -- result:
@@ -25,7 +25,7 @@ storage_volume_default_1	S3	true	s3://xxx	{"aws.s3.region":"us-west-1","aws.s3.u
 -- !result
 DROP STORAGE VOLUME IF EXISTS storage_volume_default_1;
 -- result:
-E: (1064, 'Unexpected exception: default storage volume can not be removed')
+E: (1064, 'default storage volume can not be removed')
 -- !result
 SHOW STORAGE VOLUMES like 'storage_volume_default%';
 -- result:

--- a/test/sql/test_task/R/test_drop
+++ b/test/sql/test_task/R/test_drop
@@ -37,7 +37,7 @@ test_kill	FAILED	kill TaskRun
 -- !result
 drop task not_exist_task;
 -- result:
-E: (1064, 'Unexpected exception: Getting analyzing error. Detail message: Task not_exist_task is not exist.')
+E: (1064, 'Getting analyzing error. Detail message: Task not_exist_task is not exist.')
 -- !result
 drop database test_drop_task_${uuid0};
 -- result:


### PR DESCRIPTION
## Why I'm doing:
 some ddl operations will  validate input  parameters after analyze phase, but when validation failed after analyze phase, mysql error type will set as "Unexpected exception", which implies this is a bug.

## What I'm doing:
change error type as ANALYSIS_ERR

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [x] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
