### PR TITLE
[Refactor] call generate_ir according to is_compiable

### DIFF
--- a/be/src/exprs/arithmetic_expr.cpp
+++ b/be/src/exprs/arithmetic_expr.cpp
@@ -127,8 +127,8 @@ public:
 
     StatusOr<LLVMDatum> generate_ir_impl(ExprContext* context, JITContext* jit_ctx) override {
         std::vector<LLVMDatum> datums(2);
-        ASSIGN_OR_RETURN(datums[0], _children[0]->generate_ir_impl(context, jit_ctx))
-        ASSIGN_OR_RETURN(datums[1], _children[1]->generate_ir_impl(context, jit_ctx))
+        ASSIGN_OR_RETURN(datums[0], _children[0]->generate_ir(context, jit_ctx))
+        ASSIGN_OR_RETURN(datums[1], _children[1]->generate_ir(context, jit_ctx))
 
         if constexpr (lt_is_decimal<Type>) {
             // TODO(yueyang): Implement decimal arithmetic in LLVM IR.
@@ -191,8 +191,8 @@ public:
 
     StatusOr<LLVMDatum> generate_ir_impl(ExprContext* context, JITContext* jit_ctx) override {
         std::vector<LLVMDatum> datums(2);
-        ASSIGN_OR_RETURN(datums[0], _children[0]->generate_ir_impl(context, jit_ctx))
-        ASSIGN_OR_RETURN(datums[1], _children[1]->generate_ir_impl(context, jit_ctx))
+        ASSIGN_OR_RETURN(datums[0], _children[0]->generate_ir(context, jit_ctx))
+        ASSIGN_OR_RETURN(datums[1], _children[1]->generate_ir(context, jit_ctx))
 
         if constexpr (lt_is_decimal<Type>) {
             // TODO(yueyang): Implement decimal arithmetic in LLVM IR.
@@ -264,8 +264,8 @@ public:
 
     StatusOr<LLVMDatum> generate_ir_impl(ExprContext* context, JITContext* jit_ctx) override {
         std::vector<LLVMDatum> datums(2);
-        ASSIGN_OR_RETURN(datums[0], _children[0]->generate_ir_impl(context, jit_ctx))
-        ASSIGN_OR_RETURN(datums[1], _children[1]->generate_ir_impl(context, jit_ctx))
+        ASSIGN_OR_RETURN(datums[0], _children[0]->generate_ir(context, jit_ctx))
+        ASSIGN_OR_RETURN(datums[1], _children[1]->generate_ir(context, jit_ctx))
 
         if constexpr (lt_is_decimal<Type>) {
             // TODO(yueyang): Implement decimal arithmetic in LLVM IR.
@@ -301,7 +301,7 @@ public:
     bool is_compilable() const override { return IRHelper::support_jit(Type); }
 
     StatusOr<LLVMDatum> generate_ir_impl(ExprContext* context, JITContext* jit_ctx) override {
-        ASSIGN_OR_RETURN(auto datum, _children[0]->generate_ir_impl(context, jit_ctx))
+        ASSIGN_OR_RETURN(auto datum, _children[0]->generate_ir(context, jit_ctx))
         using ArithmeticBitNot = ArithmeticUnaryOperator<BitNotOp, Type>;
         datum.value = ArithmeticBitNot::generate_ir(jit_ctx->builder, datum.value);
         return datum;
@@ -333,8 +333,8 @@ public:
 
     StatusOr<LLVMDatum> generate_ir_impl(ExprContext* context, JITContext* jit_ctx) override {
         std::vector<LLVMDatum> datums(2);
-        ASSIGN_OR_RETURN(datums[0], _children[0]->generate_ir_impl(context, jit_ctx))
-        ASSIGN_OR_RETURN(datums[1], _children[1]->generate_ir_impl(context, jit_ctx))
+        ASSIGN_OR_RETURN(datums[0], _children[0]->generate_ir(context, jit_ctx))
+        ASSIGN_OR_RETURN(datums[1], _children[1]->generate_ir(context, jit_ctx))
 
         using ArithmeticOp = ArithmeticBinaryOperator<OP, Type>;
         using CppType = RunTimeCppType<Type>;

--- a/be/src/exprs/binary_predicate.cpp
+++ b/be/src/exprs/binary_predicate.cpp
@@ -120,8 +120,8 @@ public:
             return Status::NotSupported("JIT of decimal cmp not support");
         } else {
             std::vector<LLVMDatum> datums(2);
-            ASSIGN_OR_RETURN(datums[0], _children[0]->generate_ir_impl(context, jit_ctx))
-            ASSIGN_OR_RETURN(datums[1], _children[1]->generate_ir_impl(context, jit_ctx))
+            ASSIGN_OR_RETURN(datums[0], _children[0]->generate_ir(context, jit_ctx))
+            ASSIGN_OR_RETURN(datums[1], _children[1]->generate_ir(context, jit_ctx))
 
             auto* l = datums[0].value;
             auto* r = datums[1].value;
@@ -388,8 +388,8 @@ public:
 
     StatusOr<LLVMDatum> generate_ir_impl(ExprContext* context, JITContext* jit_ctx) override {
         std::vector<LLVMDatum> datums(2);
-        ASSIGN_OR_RETURN(datums[0], _children[0]->generate_ir_impl(context, jit_ctx))
-        ASSIGN_OR_RETURN(datums[1], _children[1]->generate_ir_impl(context, jit_ctx))
+        ASSIGN_OR_RETURN(datums[0], _children[0]->generate_ir(context, jit_ctx))
+        ASSIGN_OR_RETURN(datums[1], _children[1]->generate_ir(context, jit_ctx))
         auto& b = jit_ctx->builder;
         if constexpr (lt_is_decimal<Type>) {
             // TODO(yueyang): Implement decimal cmp in LLVM IR.

--- a/be/src/exprs/case_expr.cpp
+++ b/be/src/exprs/case_expr.cpp
@@ -98,7 +98,7 @@ public:
                                                           head->getParent());
                     auto* next = llvm::BasicBlock::Create(head->getContext(), "next_" + std::to_string(i),
                                                           head->getParent());
-                    ASSIGN_OR_RETURN(auto datum_i, _children[i]->generate_ir_impl(context, jit_ctx))
+                    ASSIGN_OR_RETURN(auto datum_i, _children[i]->generate_ir(context, jit_ctx))
                     if (i == 0) { // if caseExpr is null, go to else
                         datum_0 = datum_i;
                         llvm::Value* is_null = nullptr;
@@ -125,7 +125,7 @@ public:
                             b.CreateCondBr(cmp_eq, then, next);
                         }
                         b.SetInsertPoint(then);
-                        ASSIGN_OR_RETURN(auto datum_i_1, _children[i + 1]->generate_ir_impl(context, jit_ctx))
+                        ASSIGN_OR_RETURN(auto datum_i_1, _children[i + 1]->generate_ir(context, jit_ctx))
                         b.CreateStore(datum_i_1.value, res);
                         b.CreateStore(datum_i_1.null_flag, res_null);
                         b.CreateBr(join);
@@ -138,7 +138,7 @@ public:
                                                           head->getParent());
                     auto* next = llvm::BasicBlock::Create(head->getContext(), "next_" + std::to_string(i),
                                                           head->getParent());
-                    ASSIGN_OR_RETURN(auto datum_i, _children[i]->generate_ir_impl(context, jit_ctx))
+                    ASSIGN_OR_RETURN(auto datum_i, _children[i]->generate_ir(context, jit_ctx))
                     auto* is_true = IRHelper::bool_to_cond(b, datum_i.value);
                     if (_children[i]->is_nullable()) {
                         auto* not_null = b.CreateICmpEQ(datum_i.null_flag, llvm::ConstantInt::get(b.getInt8Ty(), 0));
@@ -148,7 +148,7 @@ public:
                     }
                     b.SetInsertPoint(then);
 
-                    ASSIGN_OR_RETURN(auto datum_i_1, _children[i + 1]->generate_ir_impl(context, jit_ctx))
+                    ASSIGN_OR_RETURN(auto datum_i_1, _children[i + 1]->generate_ir(context, jit_ctx))
                     b.CreateStore(datum_i_1.value, res);
                     b.CreateStore(datum_i_1.null_flag, res_null);
                     b.CreateBr(join);
@@ -159,7 +159,7 @@ public:
             b.SetInsertPoint(else_block);
             LLVMDatum else_val;
             if (_has_else_expr) {
-                ASSIGN_OR_RETURN(else_val, _children.back()->generate_ir_impl(context, jit_ctx))
+                ASSIGN_OR_RETURN(else_val, _children.back()->generate_ir(context, jit_ctx))
             } else {
                 ASSIGN_OR_RETURN(else_val.value, IRHelper::create_ir_number(b, ResultType, 0))
                 else_val.null_flag = llvm::ConstantInt::get(b.getInt8Ty(), 1);

--- a/be/src/exprs/cast_expr.cpp
+++ b/be/src/exprs/cast_expr.cpp
@@ -1142,7 +1142,7 @@ public:
     }
 
     StatusOr<LLVMDatum> generate_ir_impl(ExprContext* context, JITContext* jit_ctx) override {
-        ASSIGN_OR_RETURN(auto datum, _children[0]->generate_ir_impl(context, jit_ctx))
+        ASSIGN_OR_RETURN(auto datum, _children[0]->generate_ir(context, jit_ctx))
         auto* l = datum.value;
         auto& b = jit_ctx->builder;
         if constexpr (FromType == TYPE_JSON || ToType == TYPE_JSON) {

--- a/be/src/exprs/expr.cpp
+++ b/be/src/exprs/expr.cpp
@@ -699,7 +699,7 @@ ColumnRef* Expr::get_column_ref() {
 }
 
 StatusOr<LLVMDatum> Expr::generate_ir(ExprContext* context, JITContext* jit_ctx) {
-    if (this->is_compilable(context->_runtime_state)) {
+    if (this->is_compilable()) {
         return this->generate_ir_impl(context, jit_ctx);
     } else {
         return Expr::generate_ir_impl(context, jit_ctx);

--- a/be/src/exprs/expr.cpp
+++ b/be/src/exprs/expr.cpp
@@ -698,6 +698,14 @@ ColumnRef* Expr::get_column_ref() {
     return nullptr;
 }
 
+StatusOr<LLVMDatum> Expr::generate_ir(ExprContext* context, JITContext* jit_ctx) {
+    if (this->is_compilable(context->_runtime_state)) {
+        return this->generate_ir_impl(context, jit_ctx);
+    } else {
+        return Expr::generate_ir_impl(context, jit_ctx);
+    }
+}
+
 StatusOr<LLVMDatum> Expr::generate_ir_impl(ExprContext* context, JITContext* jit_ctx) {
     if (is_compilable()) {
 #if BE_TEST

--- a/be/src/exprs/expr.h
+++ b/be/src/exprs/expr.h
@@ -226,10 +226,7 @@ public:
     // Get the first column ref in expr.
     ColumnRef* get_column_ref();
 
-    /**
-     * @brief For JIT compile, generate specific evaluation IR code for this expr.
-     * Its internal logic is similar to the 'evaluate_checked' function.
-     */
+    StatusOr<LLVMDatum> generate_ir(ExprContext* context, JITContext* jit_ctx);
 
     virtual StatusOr<LLVMDatum> generate_ir_impl(ExprContext* context, JITContext* jit_ctx);
 

--- a/be/src/exprs/jit/jit_engine.cpp
+++ b/be/src/exprs/jit/jit_engine.cpp
@@ -175,7 +175,7 @@ Status JITEngine::generate_scalar_function_ir(ExprContext* context, llvm::Module
     counter_phi->addIncoming(llvm::ConstantInt::get(size_type, 0), entry);
 
     JITContext jc = {counter_phi, columns, module, b, 0};
-    ASSIGN_OR_RETURN(auto result, expr->generate_ir_impl(context, &jc))
+    ASSIGN_OR_RETURN(auto result, expr->generate_ir(context, &jc))
 
     // Pseudo code:
     // values_last[counter] = result_value;


### PR DESCRIPTION
## Why I'm doing:

call generate_ir_imp directly even it isn't compilable, would generate wrong ir.

## What I'm doing:

call generate_ir_imp according to whether the expr is compiable.


## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
