### PR TITLE
[BugFix] split limit directly in some rules (backport #35875)

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/logical/LogicalLimitOperator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/logical/LogicalLimitOperator.java
@@ -51,10 +51,14 @@ public class LogicalLimitOperator extends LogicalOperator {
         super(OperatorType.LOGICAL_LIMIT);
     }
 
+    // use init LogicalLimitOperator only when the split and merge limit rule can be applied
+    // in the further step
     public static LogicalLimitOperator init(long limit) {
         return new LogicalLimitOperator(limit, DEFAULT_OFFSET, Phase.INIT);
     }
 
+    // use init LogicalLimitOperator only when the split and merge limit rule can be applied
+    // in the further step
     public static LogicalLimitOperator init(long limit, long offset) {
         return new LogicalLimitOperator(limit, offset, Phase.INIT);
     }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/MergeLimitWithLimitRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/MergeLimitWithLimitRule.java
@@ -76,6 +76,7 @@ public class MergeLimitWithLimitRule extends TransformationRule {
         LogicalLimitOperator l1 = (LogicalLimitOperator) input.getOp();
         LogicalLimitOperator l2 = (LogicalLimitOperator) input.getInputs().get(0).getOp();
 
+<<<<<<< HEAD
         Preconditions.checkState(!l1.hasOffset());
 
         // l2 range
@@ -93,10 +94,43 @@ public class MergeLimitWithLimitRule extends TransformationRule {
         Operator result;
         if (l1.getLimit() <= l2.getLimit()) {
             result = LogicalLimitOperator.local(limit, l2.getOffset());
+=======
+        LogicalLimitOperator result;
+        if (l1.hasOffset() || l2.hasOffset()) {
+            // l2 range
+            long l2Min = l2.hasOffset() ? l2.getOffset() : Operator.DEFAULT_OFFSET;
+            long l2Max = l2Min + l2.getLimit();
+
+            // l1 range
+            long l1Min = l1.hasOffset() ? l2Min + l1.getOffset() : l2Min;
+            long l1Max = l1Min + l1.getLimit();
+
+            long offset = Math.max(l2Min, l1Min);
+            long limit = Math.min(l2Max, l1Max) - offset;
+
+            if (limit <= 0) {
+                limit = 0;
+                offset = Operator.DEFAULT_OFFSET;
+            }
+
+            if (offset <= 0) {
+                offset = Operator.DEFAULT_OFFSET;
+            }
+
+            result = LogicalLimitOperator.init(limit, offset);
+
+>>>>>>> ff5b93df13 ([BugFix] split limit directly in some rules  (#35875))
         } else {
             result = LogicalLimitOperator.init(limit, l2.getOffset());
         }
+        List<OptExpression> inputs = input.getInputs().get(0).getInputs();
 
-        return Lists.newArrayList(OptExpression.create(result, input.getInputs().get(0).getInputs()));
+        if (result.isInit()) {
+            LogicalLimitOperator global = LogicalLimitOperator.global(result.getLimit(), result.getOffset());
+            LogicalLimitOperator local = LogicalLimitOperator.local(result.getLimit() + result.getOffset());
+            return Lists.newArrayList(OptExpression.create(global, OptExpression.create(local, inputs)));
+        } else {
+            return Lists.newArrayList(OptExpression.create(result, inputs));
+        }
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/MergeLimitWithLimitRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/MergeLimitWithLimitRule.java
@@ -19,7 +19,6 @@ import com.google.common.base.Preconditions;
 import com.google.common.collect.Lists;
 import com.starrocks.sql.optimizer.OptExpression;
 import com.starrocks.sql.optimizer.OptimizerContext;
-import com.starrocks.sql.optimizer.operator.Operator;
 import com.starrocks.sql.optimizer.operator.OperatorType;
 import com.starrocks.sql.optimizer.operator.logical.LogicalLimitOperator;
 import com.starrocks.sql.optimizer.operator.pattern.Pattern;
@@ -76,7 +75,6 @@ public class MergeLimitWithLimitRule extends TransformationRule {
         LogicalLimitOperator l1 = (LogicalLimitOperator) input.getOp();
         LogicalLimitOperator l2 = (LogicalLimitOperator) input.getInputs().get(0).getOp();
 
-<<<<<<< HEAD
         Preconditions.checkState(!l1.hasOffset());
 
         // l2 range
@@ -91,40 +89,14 @@ public class MergeLimitWithLimitRule extends TransformationRule {
             limit = 0;
         }
 
-        Operator result;
+        LogicalLimitOperator result;
         if (l1.getLimit() <= l2.getLimit()) {
             result = LogicalLimitOperator.local(limit, l2.getOffset());
-=======
-        LogicalLimitOperator result;
-        if (l1.hasOffset() || l2.hasOffset()) {
-            // l2 range
-            long l2Min = l2.hasOffset() ? l2.getOffset() : Operator.DEFAULT_OFFSET;
-            long l2Max = l2Min + l2.getLimit();
-
-            // l1 range
-            long l1Min = l1.hasOffset() ? l2Min + l1.getOffset() : l2Min;
-            long l1Max = l1Min + l1.getLimit();
-
-            long offset = Math.max(l2Min, l1Min);
-            long limit = Math.min(l2Max, l1Max) - offset;
-
-            if (limit <= 0) {
-                limit = 0;
-                offset = Operator.DEFAULT_OFFSET;
-            }
-
-            if (offset <= 0) {
-                offset = Operator.DEFAULT_OFFSET;
-            }
-
-            result = LogicalLimitOperator.init(limit, offset);
-
->>>>>>> ff5b93df13 ([BugFix] split limit directly in some rules  (#35875))
         } else {
             result = LogicalLimitOperator.init(limit, l2.getOffset());
         }
-        List<OptExpression> inputs = input.getInputs().get(0).getInputs();
 
+        List<OptExpression> inputs = input.getInputs().get(0).getInputs();
         if (result.isInit()) {
             LogicalLimitOperator global = LogicalLimitOperator.global(result.getLimit(), result.getOffset());
             LogicalLimitOperator local = LogicalLimitOperator.local(result.getLimit() + result.getOffset());

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/MergeLimitWithSortRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/MergeLimitWithSortRule.java
@@ -38,7 +38,7 @@ public class MergeLimitWithSortRule extends TransformationRule {
 
         // Merge Init-Limit/Local-limit and Sort
         // Local-limit may be generate at MergeLimitWithLimitRule
-        return (limit.isInit() || limit.isLocal()) && !topN.hasLimit();
+        return limit.isInit() || limit.isLocal();
     }
 
     @Override
@@ -47,6 +47,10 @@ public class MergeLimitWithSortRule extends TransformationRule {
         LogicalLimitOperator limit = (LogicalLimitOperator) input.getOp();
         LogicalTopNOperator sort = (LogicalTopNOperator) input.getInputs().get(0).getOp();
 
+        long minLimit = limit.getLimit();
+        if (sort.hasLimit()) {
+            minLimit = Math.min(minLimit, sort.getLimit());
+        }
         OptExpression result = new OptExpression(
                 new LogicalTopNOperator(sort.getOrderByElements(), limit.getLimit(), limit.getOffset()));
         result.getInputs().addAll(input.getInputs().get(0).getInputs());

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/PushDownProjectLimitRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/PushDownProjectLimitRule.java
@@ -15,7 +15,6 @@
 
 package com.starrocks.sql.optimizer.rule.transformation;
 
-import com.google.common.base.Preconditions;
 import com.google.common.collect.Lists;
 import com.starrocks.sql.optimizer.OptExpression;
 import com.starrocks.sql.optimizer.OptimizerContext;
@@ -49,13 +48,12 @@ public class PushDownProjectLimitRule extends TransformationRule {
     @Override
     public boolean check(OptExpression input, OptimizerContext context) {
         LogicalLimitOperator limit = (LogicalLimitOperator) input.getInputs().get(0).getOp();
-        return limit.isGlobal();
+        return limit.isGlobal() && !limit.hasOffset();
     }
 
     @Override
     public List<OptExpression> transform(OptExpression project, OptimizerContext context) {
         LogicalLimitOperator limit = (LogicalLimitOperator) project.getInputs().get(0).getOp();
-        Preconditions.checkState(!limit.hasOffset());
         LogicalLimitOperator newLimit = LogicalLimitOperator.global(limit.getLimit());
         return Lists.newArrayList(OptExpression.create(newLimit,
                 OptExpression.create(project.getOp(), project.getInputs().get(0).getInputs())));

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/LimitTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/LimitTest.java
@@ -738,7 +738,7 @@ public class LimitTest extends PlanTestBase {
                 "LIMIT \n" +
                 "  61202;";
         String plan = getFragmentPlan(sql);
-        assertContains(plan, "5:MERGING-EXCHANGE\n" +
+        assertContains(plan, "7:MERGING-EXCHANGE\n" +
                 "     offset: 6\n" +
                 "     limit: 15");
         assertContains(plan, "4:TOP-N\n" +
@@ -771,7 +771,7 @@ public class LimitTest extends PlanTestBase {
                 "  |  order by: <slot 9> 9: expr ASC, <slot 4> 4: S_NATIONKEY ASC\n" +
                 "  |  offset: 0\n" +
                 "  |  limit: 21");
-        assertContains(plan, "3:MERGING-EXCHANGE\n" +
+        assertContains(plan, "5:MERGING-EXCHANGE\n" +
                 "     offset: 6\n" +
                 "     limit: 15");
     }
@@ -809,5 +809,22 @@ public class LimitTest extends PlanTestBase {
         String sql = "select * from t0 order by 'abc' limit 100, 100 ";
         String plan = getFragmentPlan(sql);
         assertContains(plan, "limit: 100");
+    }
+
+    @Test
+    public void testMergeLimitInCte() throws Exception {
+        String sql = "with with_t_0 as (select v1 from t0 where EXISTS (select v4 from t1)) \n" +
+                "select distinct 1 from with_t_0, (select v7, v8 from t2) subt right SEMI join t0 on subt.v8 = v2 \n" +
+                "union all \n" +
+                "select distinct 2 from with_t_0, (select v10, v11 from t3) subt right SEMI join t0 on subt.v11 = v3;";
+        String plan = getFragmentPlan(sql);
+        System.out.println(plan);
+        assertContains(plan, "7:UNION\n" +
+                "  |  \n" +
+                "  |----33:EXCHANGE\n" +
+                "  |       limit: 1\n" +
+                "  |    \n" +
+                "  20:EXCHANGE\n" +
+                "     limit: 1");
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/LimitTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/LimitTest.java
@@ -738,7 +738,7 @@ public class LimitTest extends PlanTestBase {
                 "LIMIT \n" +
                 "  61202;";
         String plan = getFragmentPlan(sql);
-        assertContains(plan, "7:MERGING-EXCHANGE\n" +
+        assertContains(plan, "5:MERGING-EXCHANGE\n" +
                 "     offset: 6\n" +
                 "     limit: 15");
         assertContains(plan, "4:TOP-N\n" +
@@ -771,7 +771,7 @@ public class LimitTest extends PlanTestBase {
                 "  |  order by: <slot 9> 9: expr ASC, <slot 4> 4: S_NATIONKEY ASC\n" +
                 "  |  offset: 0\n" +
                 "  |  limit: 21");
-        assertContains(plan, "5:MERGING-EXCHANGE\n" +
+        assertContains(plan, "3:MERGING-EXCHANGE\n" +
                 "     offset: 6\n" +
                 "     limit: 15");
     }
@@ -819,12 +819,12 @@ public class LimitTest extends PlanTestBase {
                 "select distinct 2 from with_t_0, (select v10, v11 from t3) subt right SEMI join t0 on subt.v11 = v3;";
         String plan = getFragmentPlan(sql);
         System.out.println(plan);
-        assertContains(plan, "7:UNION\n" +
+        assertContains(plan, "6:UNION\n" +
                 "  |  \n" +
-                "  |----33:EXCHANGE\n" +
+                "  |----32:EXCHANGE\n" +
                 "  |       limit: 1\n" +
                 "  |    \n" +
-                "  20:EXCHANGE\n" +
+                "  19:EXCHANGE\n" +
                 "     limit: 1");
     }
 }


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [x] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5

Why I'm doing:
If a rule yeilds a new OptExpression like `limit(init) -> child`, it may skip the splitLimit rule which makes the final plan is illegal.
```
 private void rewrite(OptExpression parent, int childIndex, OptExpression root) {
        SessionVariable sessionVariable = context.getOptimizerContext().getSessionVariable();

        for (Rule rule : rules) {
            .....
        }

        // prune cte column depend on prune right child first
        for (int i = root.getInputs().size() - 1; i >= 0; i--) {
            rewrite(root, i, root.getInputs().get(i));
        }
    }
```

What I'm doing:
Directly split the new generated init limit like `limit(global) -> limit(local) -> child`. When process this op's child `limit(local) -> child` the further rule in MERGE_LIMIT ruleset would merge the limit(local) to its child.

Fixes #issue
https://github.com/StarRocks/StarRocksTest/issues/4815

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

