### PR TITLE
[Enhancement] Evaluate time functions with constant arguments

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/ScalarOperatorFunctions.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/ScalarOperatorFunctions.java
@@ -174,6 +174,12 @@ public class ScalarOperatorFunctions {
         }
     }
 
+    @ConstantFunction(name = "quarters_add", argTypes = {DATETIME, INT}, returnType = DATETIME, isMonotonic = true)
+    public static ConstantOperator quartersAdd(ConstantOperator date, ConstantOperator quarter) {
+        return ConstantOperator.createDatetimeOrNull(
+                date.getDatetime().plus(quarter.getInt(), IsoFields.QUARTER_YEARS));
+    }
+
     @ConstantFunction.List(list = {
             @ConstantFunction(name = "months_add", argTypes = {DATETIME,
                     INT}, returnType = DATETIME, isMonotonic = true),
@@ -188,6 +194,11 @@ public class ScalarOperatorFunctions {
         } else {
             return ConstantOperator.createDatetimeOrNull(date.getDatetime().plusMonths(month.getInt()));
         }
+    }
+
+    @ConstantFunction(name = "weeks_add", argTypes = {DATETIME, INT}, returnType = DATETIME, isMonotonic = true)
+    public static ConstantOperator weeksAdd(ConstantOperator date, ConstantOperator week) {
+        return ConstantOperator.createDatetimeOrNull(date.getDatetime().plusWeeks(week.getInt()));
     }
 
     @ConstantFunction.List(list = {
@@ -212,6 +223,11 @@ public class ScalarOperatorFunctions {
     @ConstantFunction(name = "seconds_add", argTypes = {DATETIME, INT}, returnType = DATETIME, isMonotonic = true)
     public static ConstantOperator secondsAdd(ConstantOperator date, ConstantOperator second) {
         return ConstantOperator.createDatetimeOrNull(date.getDatetime().plusSeconds(second.getInt()));
+    }
+
+    @ConstantFunction(name = "milliseconds_add", argTypes = {DATETIME, INT}, returnType = DATETIME, isMonotonic = true)
+    public static ConstantOperator millisecondsAdd(ConstantOperator date, ConstantOperator millisecond) {
+        return ConstantOperator.createDatetimeOrNull(date.getDatetime().plus(millisecond.getInt(), ChronoUnit.MILLIS));
     }
 
     @ConstantFunction.List(list = {
@@ -349,6 +365,12 @@ public class ScalarOperatorFunctions {
         return ConstantOperator.createDatetimeOrNull(date.getDatetime().minusYears(year.getInt()));
     }
 
+    @ConstantFunction(name = "quarters_sub", argTypes = {DATETIME, INT}, returnType = DATETIME, isMonotonic = true)
+    public static ConstantOperator quartersSub(ConstantOperator date, ConstantOperator quarter) {
+        return ConstantOperator.createDatetimeOrNull(
+                date.getDatetime().minus(quarter.getInt(), IsoFields.QUARTER_YEARS));
+    }
+
     @ConstantFunction(name = "months_sub", argTypes = {DATETIME, INT}, returnType = DATETIME, isMonotonic = true)
     public static ConstantOperator monthsSub(ConstantOperator date, ConstantOperator month) {
         return ConstantOperator.createDatetimeOrNull(date.getDatetime().minusMonths(month.getInt()));
@@ -361,6 +383,11 @@ public class ScalarOperatorFunctions {
     })
     public static ConstantOperator daysSub(ConstantOperator date, ConstantOperator day) {
         return ConstantOperator.createDatetimeOrNull(date.getDatetime().minusDays(day.getInt()));
+    }
+
+    @ConstantFunction(name = "weeks_sub", argTypes = {DATETIME, INT}, returnType = DATETIME, isMonotonic = true)
+    public static ConstantOperator weeksSub(ConstantOperator date, ConstantOperator week) {
+        return ConstantOperator.createDatetimeOrNull(date.getDatetime().minusWeeks(week.getInt()));
     }
 
     @ConstantFunction(name = "hours_sub", argTypes = {DATETIME, INT}, returnType = DATETIME, isMonotonic = true)
@@ -376,6 +403,11 @@ public class ScalarOperatorFunctions {
     @ConstantFunction(name = "seconds_sub", argTypes = {DATETIME, INT}, returnType = DATETIME, isMonotonic = true)
     public static ConstantOperator secondsSub(ConstantOperator date, ConstantOperator second) {
         return ConstantOperator.createDatetimeOrNull(date.getDatetime().minusSeconds(second.getInt()));
+    }
+
+    @ConstantFunction(name = "milliseconds_sub", argTypes = {DATETIME, INT}, returnType = DATETIME, isMonotonic = true)
+    public static ConstantOperator millisecondsSub(ConstantOperator date, ConstantOperator millisecond) {
+        return ConstantOperator.createDatetimeOrNull(date.getDatetime().minus(millisecond.getInt(), ChronoUnit.MILLIS));
     }
 
     @ConstantFunction.List(list = {

--- a/fe/fe-core/src/test/java/com/starrocks/connector/parser/trino/TrinoFunctionTransformTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/parser/trino/TrinoFunctionTransformTest.java
@@ -197,7 +197,7 @@ public class TrinoFunctionTransformTest extends TrinoTestBase {
         assertPlanContains(sql, "2014-03-08 10:00:00");
 
         sql = "select date_add('week', 1, TIMESTAMP '2014-03-08 09:00:00');";
-        assertPlanContains(sql, "weeks_add('2014-03-08 09:00:00', 1)");
+        assertPlanContains(sql, "2014-03-15 09:00:00");
 
         sql = "select date_add('month', 1, TIMESTAMP '2014-03-08 09:00:00');";
         assertPlanContains(sql, "'2014-04-08 09:00:00'");
@@ -227,16 +227,16 @@ public class TrinoFunctionTransformTest extends TrinoTestBase {
         assertPlanContains(sql, "years_add(8: th, 2)");
 
         sql = "select date_add('quarter', 2, TIMESTAMP '2014-03-08 09:00:00');";
-        assertPlanContains(sql, "quarters_add('2014-03-08 09:00:00', 2)");
+        assertPlanContains(sql, "2014-09-08 09:00:00");
 
         sql = "select date_add('quarter', -1, TIMESTAMP '2014-03-08 09:00:00');";
-        assertPlanContains(sql, "quarters_add('2014-03-08 09:00:00', -1)");
+        assertPlanContains(sql, "2013-12-08 09:00:00");
 
         sql = "select date_add('millisecond', 20, TIMESTAMP '2014-03-08 09:00:00');";
-        assertPlanContains(sql, "milliseconds_add('2014-03-08 09:00:00', 20)");
+        assertPlanContains(sql, "2014-03-08 09:00:00.020000");
 
         sql = "select date_add('millisecond', -100, TIMESTAMP '2014-03-08 09:00:00');";
-        assertPlanContains(sql, "milliseconds_add('2014-03-08 09:00:00', -100)");
+        assertPlanContains(sql, "2014-03-08 08:59:59.900000");
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rewrite/ScalarOperatorFunctionsTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rewrite/ScalarOperatorFunctionsTest.java
@@ -54,6 +54,7 @@ public class ScalarOperatorFunctionsTest {
 
     private static ConstantOperator O_TI_10;
     private static ConstantOperator O_SI_10;
+    private static ConstantOperator O_INT_1;
     private static ConstantOperator O_INT_10;
     private static ConstantOperator O_FLOAT_100;
     private static ConstantOperator O_DOUBLE_100;
@@ -79,6 +80,7 @@ public class ScalarOperatorFunctionsTest {
         O_DT_20150323_092355 = ConstantOperator.createDatetime(LocalDateTime.of(2015, 3, 23, 9, 23, 55));
         O_TI_10 = ConstantOperator.createTinyInt((byte) 10);
         O_SI_10 = ConstantOperator.createSmallInt((short) 10);
+        O_INT_1 = ConstantOperator.createInt(1);
         O_INT_10 = ConstantOperator.createInt(10);
         O_FLOAT_100 = ConstantOperator.createFloat(100);
         O_DOUBLE_100 = ConstantOperator.createFloat(100);
@@ -125,9 +127,21 @@ public class ScalarOperatorFunctionsTest {
     }
 
     @Test
+    public void quartersAdd() {
+        assertEquals("2015-06-23T09:23:55",
+                ScalarOperatorFunctions.quartersAdd(O_DT_20150323_092355, O_INT_1).getDatetime().toString());
+    }
+
+    @Test
     public void monthsAdd() {
         assertEquals("2016-01-23T09:23:55",
                 ScalarOperatorFunctions.monthsAdd(O_DT_20150323_092355, O_INT_10).getDatetime().toString());
+    }
+
+    @Test
+    public void weeksAdd() {
+        assertEquals("2015-06-01T09:23:55",
+                ScalarOperatorFunctions.weeksAdd(O_DT_20150323_092355, O_INT_10).getDatetime().toString());
     }
 
     @Test
@@ -152,6 +166,12 @@ public class ScalarOperatorFunctionsTest {
     public void secondsAdd() {
         assertEquals("2015-03-23T09:24:05",
                 ScalarOperatorFunctions.secondsAdd(O_DT_20150323_092355, O_INT_10).getDatetime().toString());
+    }
+
+    @Test
+    public void millisecondsAdd() {
+        assertEquals("2015-03-23T09:23:55.010",
+                ScalarOperatorFunctions.millisecondsAdd(O_DT_20150323_092355, O_INT_10).getDatetime().toString());
     }
 
     @Test
@@ -497,9 +517,21 @@ public class ScalarOperatorFunctionsTest {
     }
 
     @Test
+    public void quartersSub() {
+        assertEquals("2014-12-23T09:23:55",
+                ScalarOperatorFunctions.quartersSub(O_DT_20150323_092355, O_INT_1).getDatetime().toString());
+    }
+
+    @Test
     public void monthsSub() {
         assertEquals("2014-05-23T09:23:55",
                 ScalarOperatorFunctions.monthsSub(O_DT_20150323_092355, O_INT_10).getDatetime().toString());
+    }
+
+    @Test
+    public void weeksSub() {
+        assertEquals("2015-01-12T09:23:55",
+                ScalarOperatorFunctions.weeksSub(O_DT_20150323_092355, O_INT_10).getDatetime().toString());
     }
 
     @Test
@@ -524,6 +556,12 @@ public class ScalarOperatorFunctionsTest {
     public void secondsSub() {
         assertEquals("2015-03-23T09:23:45",
                 ScalarOperatorFunctions.secondsSub(O_DT_20150323_092355, O_INT_10).getDatetime().toString());
+    }
+
+    @Test
+    public void millisecondsSub() {
+        assertEquals("2015-03-23T09:23:54.990",
+                ScalarOperatorFunctions.millisecondsSub(O_DT_20150323_092355, O_INT_10).getDatetime().toString());
     }
 
     @Test


### PR DESCRIPTION
## Why I'm doing:

sql like this cannot calculate cardinality correctly. Because the constant function `milliseconds_add("1994-06-04", 1)` is not evaluated.

```sql
select count(*) from lineitem where l_receiptdate < milliseconds_add("1994-06-04", 1);
```

## What I'm doing:

Add rules to evaluate time related functions with constant arguments, including `quarters_add`、`quarters_sub`、`weeks_add`、`weeks_sub`、`milliseconds_add`、`milliseconds_sub`.

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
