### PR TITLE
[Enhancement]support object storage that not compatible with s3

### DIFF
--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -804,6 +804,8 @@ CONF_Int64(object_storage_connect_timeout_ms, "-1");
 // When it's 0, low speed limit check will be disabled.
 CONF_Int64(object_storage_request_timeout_ms, "-1");
 
+CONF_Strings(fallback_to_hadoop_fs_list, "");
+
 // text reader
 // Spilt text file's scan range into io ranges of 16mb size
 CONF_Int64(text_io_range_size, "16777216");

--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -805,6 +805,7 @@ CONF_Int64(object_storage_connect_timeout_ms, "-1");
 CONF_Int64(object_storage_request_timeout_ms, "-1");
 
 CONF_Strings(fallback_to_hadoop_fs_list, "");
+CONF_Strings(s3_compatible_fs_list, "s3n://, s3a://, s3://, oss://, cos://, cosn://, obs://, ks3://, tos://");
 
 // text reader
 // Spilt text file's scan range into io ranges of 16mb size

--- a/be/src/fs/fs.cpp
+++ b/be/src/fs/fs.cpp
@@ -65,6 +65,9 @@ inline std::shared_ptr<FileSystem> get_tls_fs_starlet() {
 #endif
 
 StatusOr<std::unique_ptr<FileSystem>> FileSystem::CreateUniqueFromString(std::string_view uri, FSOptions options) {
+    if (fs::is_fallback_to_hadoop_fs(uri)) {
+        return new_fs_hdfs(options);
+    }
     if (fs::is_posix_uri(uri)) {
         return new_fs_posix();
     }
@@ -87,6 +90,9 @@ StatusOr<std::unique_ptr<FileSystem>> FileSystem::CreateUniqueFromString(std::st
 }
 
 StatusOr<std::shared_ptr<FileSystem>> FileSystem::CreateSharedFromString(std::string_view uri) {
+    if (fs::is_fallback_to_hadoop_fs(uri)) {
+        return get_tls_fs_hdfs();
+    }
     if (fs::is_posix_uri(uri)) {
         return get_tls_fs_posix();
     }

--- a/be/src/fs/fs_util.h
+++ b/be/src/fs/fs_util.h
@@ -18,6 +18,7 @@
 #include <string>
 #include <vector>
 
+#include "common/config.h"
 #include "fs/fs.h"
 #include "testutil/sync_point.h"
 
@@ -196,9 +197,20 @@ inline bool starts_with(std::string_view s, std::string_view prefix) {
     return (s.size() >= prefix.size()) && (memcmp(s.data(), prefix.data(), prefix.size()) == 0);
 }
 
+inline bool is_fallback_to_hadoop_fs(std::string_view uri) {
+    if (!config::fallback_to_hadoop_fs_list.empty()) {
+        for (const auto& item : config::fallback_to_hadoop_fs_list) {
+            if (starts_with(uri, item)) {
+                return true;
+            }
+        }
+    }
+    return false;
+}
+
 inline bool is_s3_uri(std::string_view uri) {
-    return starts_with(uri, "oss://") || starts_with(uri, "s3n://") || starts_with(uri, "s3a://") ||
-           starts_with(uri, "s3://") || starts_with(uri, "cos://") || starts_with(uri, "cosn://") ||
+    return starts_with(uri, "s3n://") || starts_with(uri, "s3a://") || starts_with(uri, "s3://") ||
+           starts_with(uri, "oss://") || starts_with(uri, "cos://") || starts_with(uri, "cosn://") ||
            starts_with(uri, "obs://") || starts_with(uri, "ks3://") || starts_with(uri, "tos://");
 }
 

--- a/be/src/fs/fs_util.h
+++ b/be/src/fs/fs_util.h
@@ -197,21 +197,21 @@ inline bool starts_with(std::string_view s, std::string_view prefix) {
     return (s.size() >= prefix.size()) && (memcmp(s.data(), prefix.data(), prefix.size()) == 0);
 }
 
-inline bool is_fallback_to_hadoop_fs(std::string_view uri) {
-    if (!config::fallback_to_hadoop_fs_list.empty()) {
-        for (const auto& item : config::fallback_to_hadoop_fs_list) {
-            if (starts_with(uri, item)) {
-                return true;
-            }
+inline bool is_in_list(std::string_view uri, const std::vector<std::string>& list) {
+    for (const auto& item : list) {
+        if (starts_with(uri, item)) {
+            return true;
         }
     }
     return false;
 }
 
+inline bool is_fallback_to_hadoop_fs(std::string_view uri) {
+    return is_in_list(uri, config::fallback_to_hadoop_fs_list);
+}
+
 inline bool is_s3_uri(std::string_view uri) {
-    return starts_with(uri, "s3n://") || starts_with(uri, "s3a://") || starts_with(uri, "s3://") ||
-           starts_with(uri, "oss://") || starts_with(uri, "cos://") || starts_with(uri, "cosn://") ||
-           starts_with(uri, "obs://") || starts_with(uri, "ks3://") || starts_with(uri, "tos://");
+    return is_in_list(uri, config::s3_compatible_fs_list);
 }
 
 inline bool is_azure_uri(std::string_view uri) {

--- a/be/test/fs/fs_test.cpp
+++ b/be/test/fs/fs_test.cpp
@@ -41,6 +41,26 @@ TEST(FileSystemTest, test_good_construction) {
         ASSIGN_OR_ABORT(auto fs, FileSystem::CreateSharedFromString(c.uri));
         ASSERT_EQ(fs->type(), c.type);
     }
+
+    {
+        ASSIGN_OR_ABORT(auto fs, FileSystem::CreateUniqueFromString("unknown1://"));
+        ASSERT_EQ(fs->type(), FileSystem::HDFS);
+    }
+
+    {
+        ASSIGN_OR_ABORT(auto fs, FileSystem::CreateSharedFromString("unknown1://"));
+        ASSERT_EQ(fs->type(), FileSystem::HDFS);
+    }
+
+    {
+        ASSIGN_OR_ABORT(auto fs, FileSystem::CreateUniqueFromString("unknown2://"));
+        ASSERT_EQ(fs->type(), FileSystem::S3);
+    }
+
+    {
+        ASSIGN_OR_ABORT(auto fs, FileSystem::CreateSharedFromString("unknown2://"));
+        ASSERT_EQ(fs->type(), FileSystem::S3);
+    }
 }
 
 } // namespace starrocks

--- a/conf/be_test.conf
+++ b/conf/be_test.conf
@@ -41,6 +41,8 @@ scanner_thread_pool_thread_num=1
 flush_thread_num_per_store=1
 pipeline_connector_scan_thread_num_per_cpu=1
 starlet_cache_thread_num=1
+fallback_to_hadoop_fs_list=unknown1://
+s3_compatible_fs_list=s3n://, s3a://, s3://, oss://, cos://, cosn://, obs://, ks3://, tos://, unknown1://, unknown2://
 
 # Enable jaeger tracing by setting jaeger_endpoint
 # jaeger_endpoint = localhost:6831


### PR DESCRIPTION
## Why I'm doing:
some object storage is not compatible with s3 sdk

## What I'm doing:
support access object storage without s3 sdk

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [x] 3.1
  - [x] 3.0
  - [ ] 2.5
