### PR TITLE
[BugFix] Fix tablet metadata gc when tablet that has no data ingestion for a long time

### DIFF
--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -949,6 +949,7 @@ CONF_mBool(lake_enable_publish_version_trace_log, "false");
 CONF_mString(lake_vacuum_retry_pattern, "*request rate*");
 CONF_mInt64(lake_vacuum_retry_max_attempts, "5");
 CONF_mInt64(lake_vacuum_retry_min_delay_ms, "10");
+CONF_mInt64(lake_vacuum_max_retained_versions, "100");
 CONF_mBool(enable_primary_key_recover, "false");
 CONF_mBool(lake_enable_compaction_async_write, "false");
 CONF_mInt64(lake_pk_compaction_max_input_rowsets, "5");

--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -949,7 +949,7 @@ CONF_mBool(lake_enable_publish_version_trace_log, "false");
 CONF_mString(lake_vacuum_retry_pattern, "*request rate*");
 CONF_mInt64(lake_vacuum_retry_max_attempts, "5");
 CONF_mInt64(lake_vacuum_retry_min_delay_ms, "10");
-CONF_mInt64(lake_vacuum_max_retained_versions, "100");
+CONF_mInt64(lake_max_garbage_version_distance, "100");
 CONF_mBool(enable_primary_key_recover, "false");
 CONF_mBool(lake_enable_compaction_async_write, "false");
 CONF_mInt64(lake_pk_compaction_max_input_rowsets, "5");

--- a/be/src/storage/lake/transactions.cpp
+++ b/be/src/storage/lake/transactions.cpp
@@ -170,6 +170,8 @@ StatusOr<TabletMetadataPtr> publish_version(TabletManager* tablet_mgr, int64_t t
                 new_metadata->mutable_orphan_files()->Clear();
             }
 
+            // force update prev_garbage_version at most config::lake_vacuum_max_retained_versions tablet meta versions,
+            // prevent prev_garbage_version from not being updated for a long time and affecting tablet meta vacuum
             if (base_metadata->compaction_inputs_size() > 0 || base_metadata->orphan_files_size() > 0 ||
                 base_metadata->version() - base_metadata->prev_garbage_version() >=
                         config::lake_vacuum_max_retained_versions) {

--- a/be/src/storage/lake/transactions.cpp
+++ b/be/src/storage/lake/transactions.cpp
@@ -170,7 +170,9 @@ StatusOr<TabletMetadataPtr> publish_version(TabletManager* tablet_mgr, int64_t t
                 new_metadata->mutable_orphan_files()->Clear();
             }
 
-            if (base_metadata->compaction_inputs_size() > 0 || base_metadata->orphan_files_size() > 0) {
+            if (base_metadata->compaction_inputs_size() > 0 || base_metadata->orphan_files_size() > 0 ||
+                base_metadata->version() - base_metadata->prev_garbage_version() >=
+                        config::lake_vacuum_max_retained_versions) {
                 new_metadata->set_prev_garbage_version(base_metadata->version());
             }
 

--- a/be/src/storage/lake/transactions.cpp
+++ b/be/src/storage/lake/transactions.cpp
@@ -170,11 +170,11 @@ StatusOr<TabletMetadataPtr> publish_version(TabletManager* tablet_mgr, int64_t t
                 new_metadata->mutable_orphan_files()->Clear();
             }
 
-            // force update prev_garbage_version at most config::lake_vacuum_max_retained_versions tablet meta versions,
+            // force update prev_garbage_version at most config::lake_max_garbage_version_distance,
             // prevent prev_garbage_version from not being updated for a long time and affecting tablet meta vacuum
             if (base_metadata->compaction_inputs_size() > 0 || base_metadata->orphan_files_size() > 0 ||
                 base_metadata->version() - base_metadata->prev_garbage_version() >=
-                        config::lake_vacuum_max_retained_versions) {
+                        config::lake_max_garbage_version_distance) {
                 new_metadata->set_prev_garbage_version(base_metadata->version());
             }
 


### PR DESCRIPTION
## Why I'm doing:
When a tablet has no data ingestion for a long time while other tablets in the same partition have data ingestion, the tablet metadata versions may not clean.

## What I'm doing:
Fix tablet metadata gc when tablet that has no data ingestion for a long time

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [x] 3.1
  - [ ] 3.0
  - [ ] 2.5
