### PR TITLE
[Enhancement] Support size-tiered compaction for pk

### DIFF
--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -353,6 +353,7 @@ CONF_mInt64(size_tiered_min_level_size, "131072");
 CONF_mInt64(size_tiered_level_multiple, "5");
 CONF_mInt64(size_tiered_level_multiple_dupkey, "10");
 CONF_mInt64(size_tiered_level_num, "7");
+CONF_Bool(enable_pk_size_tiered_compaction_strategy, "true");
 
 CONF_Bool(enable_check_string_lengths, "true");
 

--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -353,7 +353,6 @@ CONF_mInt64(size_tiered_min_level_size, "131072");
 CONF_mInt64(size_tiered_level_multiple, "5");
 CONF_mInt64(size_tiered_level_multiple_dupkey, "10");
 CONF_mInt64(size_tiered_level_num, "7");
-CONF_Bool(enable_pk_size_tiered_compaction_strategy, "true");
 
 CONF_Bool(enable_check_string_lengths, "true");
 

--- a/be/src/storage/tablet_updates.cpp
+++ b/be/src/storage/tablet_updates.cpp
@@ -2729,10 +2729,13 @@ Status TabletUpdates::compaction_for_size_tiered(MemTracker* mem_tracker) {
         }
         compaction_level_candidate.insert(compaction_level);
         compaction_level = _calc_compaction_level(&stat);
+        stat.num_segments = stat.byte_size > 0 ? (stat.byte_size - 1) / config::max_segment_file_size + 1 : 0;
+        _calc_compaction_score(&stat);
     } while (stat.byte_size <= config::update_compaction_result_bytes * 2 &&
              info->inputs.size() < config::max_update_compaction_num_singleton_deltas &&
              compaction_level_candidate.find(compaction_level) == compaction_level_candidate.end() &&
-             candidates_by_level.find(compaction_level) != candidates_by_level.end());
+             candidates_by_level.find(compaction_level) != candidates_by_level.end() &&
+             stat.compaction_score > 0);
 
     if (compaction_level_candidate.find(-1) == compaction_level_candidate.end()) {
         if (candidates_by_level[-1].size() > 0) {

--- a/be/src/storage/tablet_updates.cpp
+++ b/be/src/storage/tablet_updates.cpp
@@ -2704,6 +2704,7 @@ Status TabletUpdates::compaction_for_size_tiered(MemTracker* mem_tracker) {
     int64_t total_merged_segments = 0;
     RowsetStats stat;
     std::set<int32_t> compaction_level_candidate;
+    max_score = 0;
     do {
         auto iter = candidates_by_level.find(compaction_level);
         if (iter == candidates_by_level.end()) {

--- a/be/src/storage/tablet_updates.cpp
+++ b/be/src/storage/tablet_updates.cpp
@@ -2734,8 +2734,7 @@ Status TabletUpdates::compaction_for_size_tiered(MemTracker* mem_tracker) {
     } while (stat.byte_size <= config::update_compaction_result_bytes * 2 &&
              info->inputs.size() < config::max_update_compaction_num_singleton_deltas &&
              compaction_level_candidate.find(compaction_level) == compaction_level_candidate.end() &&
-             candidates_by_level.find(compaction_level) != candidates_by_level.end() &&
-             stat.compaction_score > 0);
+             candidates_by_level.find(compaction_level) != candidates_by_level.end() && stat.compaction_score > 0);
 
     if (compaction_level_candidate.find(-1) == compaction_level_candidate.end()) {
         if (candidates_by_level[-1].size() > 0) {

--- a/be/src/storage/tablet_updates.h
+++ b/be/src/storage/tablet_updates.h
@@ -186,6 +186,7 @@ public:
 
     // perform compaction, should only be called by compaction thread
     Status compaction(MemTracker* mem_tracker);
+    Status copmaction_for_size_tiered(MemTracker* mem_tracker);
 
     // perform compaction with specified rowsets, this may be a manual compaction invoked by tools or data fixing jobs
     Status compaction(MemTracker* mem_tracker, const vector<uint32_t>& input_rowset_ids);
@@ -466,6 +467,8 @@ private:
 
     StatusOr<ExtraFileSize> _get_extra_file_size() const;
 
+    int _calc_compaction_level(RowsetStats& stat);
+
 private:
     Tablet& _tablet;
 
@@ -521,6 +524,9 @@ private:
     // the whole BE, and more more operation on this tablet is allowed
     std::atomic<bool> _error{false};
     std::string _error_msg;
+
+    int64_t _max_level_size;
+    int64_t _level_multiple;
 };
 
 } // namespace starrocks

--- a/be/src/storage/tablet_updates.h
+++ b/be/src/storage/tablet_updates.h
@@ -186,7 +186,7 @@ public:
 
     // perform compaction, should only be called by compaction thread
     Status compaction(MemTracker* mem_tracker);
-    Status copmaction_for_size_tiered(MemTracker* mem_tracker);
+    Status compaction_for_size_tiered(MemTracker* mem_tracker);
 
     // perform compaction with specified rowsets, this may be a manual compaction invoked by tools or data fixing jobs
     Status compaction(MemTracker* mem_tracker, const vector<uint32_t>& input_rowset_ids);
@@ -460,6 +460,12 @@ private:
 
     // these functions is only used in ut
     void stop_apply(bool apply_stopped) { _apply_stopped = apply_stopped; }
+    void stop_compaction(bool running) {
+        _compaction_running = running;
+        if (running) {
+            _last_compaction_time_ms = UnixMillis();
+        }
+    }
 
     void check_for_apply() { _check_for_apply(); }
 
@@ -525,6 +531,7 @@ private:
     std::atomic<bool> _error{false};
     std::string _error_msg;
 
+    int64_t _max_level;
     int64_t _max_level_size;
     int64_t _level_multiple;
 };

--- a/be/src/storage/tablet_updates.h
+++ b/be/src/storage/tablet_updates.h
@@ -367,6 +367,7 @@ private:
         size_t byte_size = 0;
         size_t row_size = 0;
         int64_t compaction_score = 0;
+        int32_t compaction_level = -1;
         bool partial_update_by_column = false;
         std::string to_string() const;
     };
@@ -407,6 +408,7 @@ private:
 
     Status _do_compaction(std::unique_ptr<CompactionInfo>* pinfo);
 
+    int32_t _calc_compaction_level(RowsetStats* stats);
     void _calc_compaction_score(RowsetStats* stats);
 
     Status _do_update(uint32_t rowset_id, int32_t upsert_idx, int32_t condition_column, int64_t read_version,
@@ -473,7 +475,7 @@ private:
 
     StatusOr<ExtraFileSize> _get_extra_file_size() const;
 
-    int _calc_compaction_level(RowsetStats& stat);
+    void _get_allowed_compaction_level(std::set<int32_t>* allow_compaction_level);
 
 private:
     Tablet& _tablet;
@@ -530,10 +532,6 @@ private:
     // the whole BE, and more more operation on this tablet is allowed
     std::atomic<bool> _error{false};
     std::string _error_msg;
-
-    int64_t _max_level;
-    int64_t _max_level_size;
-    int64_t _level_multiple;
 };
 
 } // namespace starrocks

--- a/be/src/storage/tablet_updates.h
+++ b/be/src/storage/tablet_updates.h
@@ -475,8 +475,6 @@ private:
 
     StatusOr<ExtraFileSize> _get_extra_file_size() const;
 
-    void _get_allowed_compaction_level(std::set<int32_t>* allow_compaction_level);
-
 private:
     Tablet& _tablet;
 

--- a/be/test/storage/rowset_column_partial_update_test.cpp
+++ b/be/test/storage/rowset_column_partial_update_test.cpp
@@ -47,6 +47,7 @@ public:
         _compaction_mem_tracker = std::make_unique<MemTracker>(-1);
         _update_mem_tracker = std::make_unique<MemTracker>();
         config::primary_key_batch_get_index_memory_limit = GetParam();
+        config::enable_pk_size_tiered_compaction_strategy = false;
     }
 
     void TearDown() override {
@@ -56,6 +57,7 @@ public:
                 tablet.reset();
             }
         }
+        config::enable_pk_size_tiered_compaction_strategy = true;
     }
 
     RowsetSharedPtr create_rowset(const TabletSharedPtr& tablet, const vector<int64_t>& keys, bool add_v3 = false) {

--- a/be/test/storage/tablet_updates_test.cpp
+++ b/be/test/storage/tablet_updates_test.cpp
@@ -3037,4 +3037,80 @@ TEST_F(TabletUpdatesTest, test_recover_rowset_sorter) {
     config::max_update_compaction_num_singleton_deltas = old_config;
 }
 
+TEST_F(TabletUpdatesTest, test_size_tiered_compaction) {
+    config::enable_pk_size_tiered_compaction_strategy = true;
+    config::size_tiered_level_multiple = 2;
+    config::size_tiered_level_num = 7;
+    config::size_tiered_min_level_size = 64;
+    config::update_compaction_size_threshold = 64 * 1024 * 1024;
+    config::update_compaction_per_tablet_min_interval_seconds = 86400;
+    _tablet = create_tablet(rand(), rand());
+    _tablet->updates()->stop_compaction(true);
+
+    std::vector<RowsetSharedPtr> rowsets;
+    std::vector<int64_t> keys;
+
+    // level 0 rowsets
+    for (int i = 0; i < 10; i++) {
+        keys.clear();
+        keys.emplace_back(i);
+        rowsets.emplace_back(create_rowset(_tablet, keys, nullptr, false, false));
+    }
+    int64_t version = 2;
+    for (int i = 0; i < rowsets.size(); i++) {
+        auto st = _tablet->rowset_commit(version, rowsets[i]);
+        ASSERT_TRUE(st.ok()) << st.to_string();
+        ASSERT_EQ(version, _tablet->updates()->max_version());
+        ASSERT_EQ(version, _tablet->updates()->version_history_count());
+        version++;
+    }
+    ASSERT_EQ(10, read_tablet(_tablet, version - 1));
+
+    // empty rowsets level -1
+    rowsets.clear();
+    for (int i = 0; i < 2; i++) {
+        rowsets.emplace_back(create_rowset(_tablet, keys, nullptr, true, false));
+    }
+    // delete history rowsets data
+    rowsets.emplace_back(create_rowset(_tablet, keys, nullptr, false, false));
+    for (int i = 0; i < rowsets.size(); i++) {
+        auto st = _tablet->rowset_commit(version, rowsets[i]);
+        ASSERT_TRUE(st.ok()) << st.to_string();
+        ASSERT_EQ(version, _tablet->updates()->max_version());
+        ASSERT_EQ(version, _tablet->updates()->version_history_count());
+        version++;
+    }
+    ASSERT_EQ(10, read_tablet(_tablet, version - 1));
+
+    // high level rowsets
+    rowsets.clear();
+    int N = 2000;
+    for (int i = 1; i < 3; i++) {
+        keys.clear();
+        for (int j = 0; j < N; j++) {
+            keys.emplace_back(i * 10000 + j);
+        }
+        rowsets.emplace_back(create_rowset(_tablet, keys, nullptr, false, false));
+    }
+    for (int i = 0; i < rowsets.size(); i++) {
+        auto st = _tablet->rowset_commit(version, rowsets[i]);
+        ASSERT_TRUE(st.ok()) << st.to_string();
+        ASSERT_EQ(version, _tablet->updates()->max_version());
+        ASSERT_EQ(version, _tablet->updates()->version_history_count());
+        version++;
+    }
+    ASSERT_EQ(10 + N * 2, read_tablet(_tablet, version - 1));
+
+    rowsets.clear();
+    ASSERT_TRUE(_tablet->updates()->get_applied_rowsets(version - 1, &rowsets).ok());
+    ASSERT_EQ(15, rowsets.size());
+
+    _tablet->updates()->stop_compaction(false);
+    ASSERT_TRUE(_tablet->updates()->compaction_for_size_tiered(_compaction_mem_tracker.get()).ok());
+
+    rowsets.clear();
+    ASSERT_TRUE(_tablet->updates()->get_applied_rowsets(version - 1, &rowsets).ok());
+    ASSERT_EQ(3, rowsets.size());
+}
+
 } // namespace starrocks

--- a/be/test/storage/tablet_updates_test.h
+++ b/be/test/storage/tablet_updates_test.h
@@ -673,7 +673,10 @@ public:
         return StorageEngine::instance()->tablet_manager()->get_tablet(tablet_id, false);
     }
 
-    void SetUp() override { _compaction_mem_tracker = std::make_unique<MemTracker>(-1); }
+    void SetUp() override {
+        _compaction_mem_tracker = std::make_unique<MemTracker>(-1);
+        config::enable_pk_size_tiered_compaction_strategy = false;
+    }
 
     void TearDown() override {
         if (_tablet2) {
@@ -684,6 +687,7 @@ public:
             (void)StorageEngine::instance()->tablet_manager()->drop_tablet(_tablet->tablet_id());
             _tablet.reset();
         }
+        config::enable_pk_size_tiered_compaction_strategy = true;
     }
 
     static Status full_clone(const TabletSharedPtr& source_tablet, int clone_version,


### PR DESCRIPTION
## Why I'm doing:
This PR supports size-tiered compaction for primary key table to reduce the IO amplification of compaction

## What I'm doing:
1. Add config enable_pk_size_tiered_compaction_strategy to control new policy.
2. When pick rowsets to do compaction, we separate rowsets into different rowset levels by data size. And merge the rowsets in the same level to reduce IO amplification.


#### Test
Test Steps:

1. The total data size is 2GB.
2. set update_compaction_internal_second as 30.
3. Import a rowset of 1/2000 size every 1 second, continuously importing 2000 versions until all data are ingested.
4. update a rowset of 1/2000 size every 1 second, continuously importing 2000 versions until all data are updated.
5. Calculate the total write volume of compaction.

* Without Size Tiered Compaction Policy

  | Ingestion size | total data write size |  Write amplification | total pindex read size | peak rowset num
-- | -- | -- | -- | -- | --
2G + insert + 1/1000 | 747278172 | 8919009198.08 |11.9 | 2701060739 | 38
2G + upsert + 1/1000 | 747278172 | 13466337280.0 |18.0 | 6428381124 | 37

* With Size Tiered Compaction Policy

  | Ingestion size | total data write size |  Write amplification | total pindex read size | peak rowset num
-- | -- | -- | -- | -- | --
2G + insert + 1/1000 | 747278172 | 2898861752.32 |3.8 | 1617695405 | 41
2G + upsert + 1/1000 | 747278172 | 4657376133.12 |6.2 | 3456960053 | 41

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [x] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [x] 3.1
  - [ ] 3.0
  - [ ] 2.5
