### PR TITLE
[Enhancement] Make maximal varchar string length configurable in fe.conf and be.conf. (backport #38957)

### DIFF
--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -1178,4 +1178,7 @@ CONF_mInt64(pk_dump_interval_seconds, "3600"); // 1 hour
 
 // whether enable query profile for queries initiated by spark or flink
 CONF_mBool(enable_profile_for_external_plan, "false");
+
+// the max length supported for varchar type
+CONF_mInt32(olap_string_max_length, "1048576");
 } // namespace starrocks::config

--- a/be/src/exprs/string_functions.cpp
+++ b/be/src/exprs/string_functions.cpp
@@ -366,14 +366,14 @@ Status StringFunctions::concat_prepare(FunctionContext* context, FunctionContext
     // size of concatenation of tail columns(i.e. columns except the 1st one)
     // must not exceeds SIZE_LIMIT, otherwise the result is oversize in which
     // case NULL is returned according to mysql.
-    raw::make_room(&tail, OLAP_STRING_MAX_LENGTH);
+    raw::make_room(&tail, get_olap_string_max_length());
     auto* tail_begin = (uint8_t*)tail.data();
     size_t tail_off = 0;
 
     for (auto i = 1; i < num_args; ++i) {
         auto const_arg = context->get_constant_column(i);
         auto s = ColumnHelper::get_const_value<TYPE_VARCHAR>(const_arg);
-        if (tail_off + s.size > OLAP_STRING_MAX_LENGTH) {
+        if (tail_off + s.size > get_olap_string_max_length()) {
             //oversize
             state->is_oversize = true;
             break;
@@ -797,7 +797,7 @@ public:
         size_t dst_off = 0;
         for (auto i = 0; i < num_rows; ++i) {
             auto len = len_array[i];
-            if (UNLIKELY((uint32_t)len > OLAP_STRING_MAX_LENGTH)) {
+            if (UNLIKELY((uint32_t)len > get_olap_string_max_length())) {
                 dst_offsets[i + 1] = dst_off;
                 has_null = true;
                 nulls[i] = 1;
@@ -892,11 +892,11 @@ static inline ColumnPtr repeat_const_not_null(const Columns& columns, const Bina
         raw::make_room(&dst_offsets, num_rows + 1);
         dst_offsets[0] = 0;
         size_t reserved = static_cast<size_t>(times) * src_offsets.back();
-        if (reserved > OLAP_STRING_MAX_LENGTH * num_rows) {
+        if (reserved > get_olap_string_max_length() * num_rows) {
             reserved = 0;
             for (int i = 0; i < num_rows; ++i) {
                 size_t slice_sz = src_offsets[i + 1] - src_offsets[i];
-                if (slice_sz * times < OLAP_STRING_MAX_LENGTH) {
+                if (slice_sz * times < get_olap_string_max_length()) {
                     reserved += slice_sz * times;
                 }
             }
@@ -914,7 +914,7 @@ static inline ColumnPtr repeat_const_not_null(const Columns& columns, const Bina
         }
         // if result exceed STRING_MAX_LENGTH
         // return null
-        if (s.size * times > OLAP_STRING_MAX_LENGTH) {
+        if (s.size * times > get_olap_string_max_length()) {
             dst_nulls[i] = 1;
             has_null = true;
             dst_offsets[i + 1] = dst_off;
@@ -968,7 +968,7 @@ static inline ColumnPtr repeat_not_const(const Columns& columns) {
         auto s = str_viewer.value(i);
         int32_t n = times_viewer.value(i);
 
-        if (s.size * n > OLAP_STRING_MAX_LENGTH) {
+        if (s.size * n > get_olap_string_max_length()) {
             dst_nulls[i] = 1;
             has_null = true;
             dst_offsets[i + 1] = dst_off;
@@ -1086,7 +1086,7 @@ static inline void build_translate_map(const Slice& from_str, const Slice& to_st
  * @param utf8_map the UTF-8 map.
  * @param dst the destination to store the translated chars. The caller must guarantee there is enough room.
  * @return [is_null, num_bytes].
- * - `is_null` will be true, if the number of translated chars exceeds `OLAP_STRING_MAX_LENGTH`.
+ * - `is_null` will be true, if the number of translated chars exceeds `get_olap_string_max_length()`.
  * - `num_bytes`: the number of translated chars.
  */
 static inline std::pair<bool, size_t> translate_string_with_utf8_map(
@@ -1104,7 +1104,7 @@ static inline std::pair<bool, size_t> translate_string_with_utf8_map(
             continue;
         }
 
-        if (num_bytes + dst_utf_char.size > OLAP_STRING_MAX_LENGTH) {
+        if (num_bytes + dst_utf_char.size > get_olap_string_max_length()) {
             return {true, 0};
         }
         strings::memcpy_inlined(dst + num_bytes, dst_utf_char.data, dst_utf_char.size);
@@ -1230,7 +1230,7 @@ static inline ColumnPtr translate_with_ascii_const_nonnull_from_and_to(const Col
  * @param src the source column, which may be de-wrapped from NullableColumn.
  * @param state stores the UTF-8 map.
  * @return the translated column, which may be a nullable BinaryColumn.
- *  The row will be null, if it exceeds OLAP_STRING_MAX_LENGTH after translated.
+ *  The row will be null, if it exceeds get_olap_string_max_length() after translated.
  */
 static inline ColumnPtr translate_with_utf8_const_nonnull_from_and_to(const Columns& columns, BinaryColumn* src,
                                                                       const TranslateState* state) {
@@ -1269,7 +1269,7 @@ static inline ColumnPtr translate_with_utf8_const_nonnull_from_and_to(const Colu
         src_encoded_values.reserve(s.size);
         encode_utf8_chars(s, &src_encoded_values);
 
-        dst_bytes.resize(dst_offset + std::min<size_t>(s.size * 4, OLAP_STRING_MAX_LENGTH));
+        dst_bytes.resize(dst_offset + std::min<size_t>(s.size * 4, get_olap_string_max_length()));
         uint8_t* dst_begin = dst_bytes.data() + dst_offset;
 
         const auto [is_null, num_row_bytes] = translate_string_with_utf8_map(src_encoded_values, utf8_map, dst_begin);
@@ -1297,7 +1297,7 @@ static inline ColumnPtr translate_with_utf8_const_nonnull_from_and_to(const Colu
  * @param columns the input columns, including `SRC_STR_INDEX`, `FROM_STR_INDEX`, `TO_STR_INDEX`.
  * @param state useless, `state` is useful only for the constant `from_string`, `to_string` for now.
  * @return the translated column, which may be a nullable BinaryColumn.
- *  The row will be null, if it exceeds OLAP_STRING_MAX_LENGTH after translated.
+ *  The row will be null, if it exceeds get_olap_string_max_length() after translated.
  */
 ColumnPtr translate_with_non_const_from_or_to(const Columns& columns, const TranslateState* state) {
     DCHECK(state == nullptr || !state->is_from_and_to_const);
@@ -1352,7 +1352,7 @@ ColumnPtr translate_with_non_const_from_or_to(const Columns& columns, const Tran
             src_encoded_values.reserve(src.size);
             encode_utf8_chars(src, &src_encoded_values);
 
-            dst_bytes.resize(dst_offset + std::min<size_t>(src.size * 4, OLAP_STRING_MAX_LENGTH));
+            dst_bytes.resize(dst_offset + std::min<size_t>(src.size * 4, get_olap_string_max_length()));
             uint8_t* dst_begin = dst_bytes.data() + dst_offset;
 
             const auto [is_null, num_row_bytes] =
@@ -1438,7 +1438,7 @@ enum PadType { PAD_TYPE_LEFT, PAD_TYPE_RIGHT };
 template <PadType pad_type>
 static inline ColumnPtr ascii_pad_ascii_const(Columns const& columns, BinaryColumn* src, const uint8_t* fill,
                                               const size_t fill_size, const size_t len) {
-    DCHECK(0 < len && len <= OLAP_STRING_MAX_LENGTH);
+    DCHECK(0 < len && len <= get_olap_string_max_length());
     DCHECK(fill_size > 0);
 
     const auto num_rows = src->size();
@@ -1548,7 +1548,7 @@ static inline ColumnPtr pad_utf8_const(Columns const& columns, BinaryColumn* src
 
         size_t dst_slice_size = s.size + fill_times * fill_size + fill_rest;
         // oversize
-        if (dst_slice_size > OLAP_STRING_MAX_LENGTH) {
+        if (dst_slice_size > get_olap_string_max_length()) {
             dst_nulls[i] = 1;
             has_null = true;
             dst_offsets[i + 1] = dst_off;
@@ -1586,7 +1586,7 @@ static inline ColumnPtr pad_const_not_null(const Columns& columns, BinaryColumn*
     auto fill = ColumnHelper::get_const_value<TYPE_VARCHAR>(columns[2]);
 
     // illegal length  or too-big length, return NULL
-    if (len < 0 || len > OLAP_STRING_MAX_LENGTH) {
+    if (len < 0 || len > get_olap_string_max_length()) {
         return ColumnHelper::create_const_null_column(columns[1]->size());
     }
     // len == 0, return empty string
@@ -1658,8 +1658,8 @@ ColumnPtr pad_not_const(const Columns& columns, [[maybe_unused]] const PadState*
         }
 
         int len = len_viewer.value(i);
-        // NULL if len < 0 || len > OLAP_STRING_MAX_LENGTH
-        if ((uint32)len > OLAP_STRING_MAX_LENGTH) {
+        // NULL if len < 0 || len > get_olap_string_max_length()
+        if ((uint32)len > get_olap_string_max_length()) {
             has_null = true;
             dst_offsets[i + 1] = dst_off;
             dst_nulls[i] = 1;
@@ -1719,7 +1719,7 @@ ColumnPtr pad_not_const(const Columns& columns, [[maybe_unused]] const PadState*
         const size_t dst_slice_size = str.size + fill->size * fill_times + fill_rest;
 
         // result is oversize, return NULL
-        if (dst_slice_size > OLAP_STRING_MAX_LENGTH) {
+        if (dst_slice_size > get_olap_string_max_length()) {
             has_null = true;
             dst_offsets[i + 1] = dst_off;
             dst_nulls[i] = 1;
@@ -2676,7 +2676,7 @@ static inline ColumnPtr concat_const_not_null(Columns const& columns, BinaryColu
     for (int i = 0; i < num_rows; ++i) {
         auto s = src->get_slice(i);
         const auto dst_slice_size = s.size + tail_size;
-        if (LIKELY(dst_slice_size <= OLAP_STRING_MAX_LENGTH)) {
+        if (LIKELY(dst_slice_size <= get_olap_string_max_length())) {
             dst_off += dst_slice_size;
             dst_offsets[i + 1] = dst_off;
         } else {
@@ -2694,7 +2694,7 @@ static inline ColumnPtr concat_const_not_null(Columns const& columns, BinaryColu
     for (int i = 0; i < num_rows; ++i) {
         auto s = src->get_slice(i);
         const auto dst_slice_size = s.size + tail_size;
-        if (LIKELY(dst_slice_size <= OLAP_STRING_MAX_LENGTH)) {
+        if (LIKELY(dst_slice_size <= get_olap_string_max_length())) {
             strings::memcpy_inlined(dst_begin + dst_off, s.data, s.size);
             dst_off += s.size;
             strings::memcpy_inlined(dst_begin + dst_off, tail_begin, tail_size);
@@ -2743,7 +2743,7 @@ static inline ColumnPtr concat_not_const_small(std::vector<ColumnViewer<TYPE_VAR
         bool oversize = false;
         for (auto& view : list) {
             auto v = view.value(i);
-            if (UNLIKELY(dst_slice_len + v.size > OLAP_STRING_MAX_LENGTH)) {
+            if (UNLIKELY(dst_slice_len + v.size > get_olap_string_max_length())) {
                 oversize = true;
                 break;
             }
@@ -2797,7 +2797,7 @@ static inline ColumnPtr concat_not_const(Columns const& columns) {
         bool oversize = false;
         for (auto& view : list) {
             auto v = view.value(i);
-            if (UNLIKELY(dst_slice_len + v.size > OLAP_STRING_MAX_LENGTH)) {
+            if (UNLIKELY(dst_slice_len + v.size > get_olap_string_max_length())) {
                 oversize = true;
                 break;
             }
@@ -2867,7 +2867,7 @@ ColumnPtr concat_ws_small(ColumnViewer<TYPE_VARCHAR>& sep_viewer, std::vector<Co
                 continue;
             }
             auto v = view.value(i);
-            if (UNLIKELY(dst_slice_size + v.size > OLAP_STRING_MAX_LENGTH)) {
+            if (UNLIKELY(dst_slice_size + v.size > get_olap_string_max_length())) {
                 oversize = true;
                 break;
             }
@@ -2913,7 +2913,7 @@ StatusOr<ColumnPtr> StringFunctions::concat_ws(FunctionContext* context, const C
     const auto sep_size = ColumnHelper::compute_bytes_size(columns.begin(), columns.begin() + 1);
     const auto rest_size = ColumnHelper::compute_bytes_size(columns.begin() + 1, columns.end());
     // need extra SIZE_LIMIT bytes of space for rewinding the appended separator.
-    const auto dst_bytes_max_size = rest_size + sep_size * (column_num - 2) + OLAP_STRING_MAX_LENGTH;
+    const auto dst_bytes_max_size = rest_size + sep_size * (column_num - 2) + get_olap_string_max_length();
 
     ColumnViewer<TYPE_VARCHAR> sep_viewer(columns[0]);
     std::vector<ColumnViewer<TYPE_VARCHAR>> list;
@@ -2955,7 +2955,7 @@ StatusOr<ColumnPtr> StringFunctions::concat_ws(FunctionContext* context, const C
             dst_slice_size += sep.size;
         }
         // return NULL for oversize
-        if (UNLIKELY(dst_slice_size > OLAP_STRING_MAX_LENGTH + sep.size)) {
+        if (UNLIKELY(dst_slice_size > get_olap_string_max_length() + sep.size)) {
             builder.rewind(dst_slice_size);
             builder.set_null(i);
         } else if (LIKELY(dst_slice_size > 0)) {

--- a/be/src/storage/CMakeLists.txt
+++ b/be/src/storage/CMakeLists.txt
@@ -40,6 +40,7 @@ add_library(Storage STATIC
     local_tablet_reader.cpp
     publish_version_manager.cpp
     olap_common.cpp
+    olap_define.cpp
     olap_server.cpp
     options.cpp
     page_cache.cpp

--- a/be/src/storage/olap_define.cpp
+++ b/be/src/storage/olap_define.cpp
@@ -1,0 +1,23 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "storage/olap_define.h"
+
+#include "common/config.h"
+
+namespace starrocks {
+
+uint32_t get_olap_string_max_length() {
+    return config::olap_string_max_length;
+}
+
+} // namespace starrocks

--- a/be/src/storage/olap_define.h
+++ b/be/src/storage/olap_define.h
@@ -48,8 +48,7 @@ static const size_t OLAP_PAGE_SIZE = 65536;
 
 static const uint64_t OLAP_FIX_HEADER_MAGIC_NUMBER = 0;
 
-// the max length supported for varchar type
-static const uint32_t OLAP_STRING_MAX_LENGTH = 1048576;
+uint32_t get_olap_string_max_length();
 
 // the max bytes for stored string length
 using StringLengthType = uint16_t;

--- a/be/src/storage/tablet_schema.cpp
+++ b/be/src/storage/tablet_schema.cpp
@@ -101,7 +101,7 @@ uint32_t TabletColumn::get_field_length_by_type(LogicalType type, uint32_t strin
     case TYPE_PERCENTILE:
     case TYPE_JSON:
     case TYPE_VARBINARY:
-        return string_length + sizeof(OLAP_STRING_MAX_LENGTH);
+        return string_length + sizeof(get_olap_string_max_length());
     case TYPE_ARRAY:
         return string_length;
     }

--- a/be/src/storage/types.cpp
+++ b/be/src/storage/types.cpp
@@ -897,9 +897,9 @@ template <>
 struct ScalarTypeInfoImpl<TYPE_CHAR> : public ScalarTypeInfoImplBase<TYPE_CHAR> {
     static Status from_string(void* buf, const std::string& scan_key) {
         size_t value_len = scan_key.length();
-        if (value_len > OLAP_STRING_MAX_LENGTH) {
+        if (value_len > get_olap_string_max_length()) {
             return Status::InvalidArgument(fmt::format("String(length={}) is too long, the max length is: {}",
-                                                       value_len, OLAP_STRING_MAX_LENGTH));
+                                                       value_len, get_olap_string_max_length()));
         }
 
         auto slice = unaligned_load<Slice>(buf);
@@ -962,11 +962,11 @@ struct ScalarTypeInfoImpl<TYPE_VARCHAR> : public ScalarTypeInfoImpl<TYPE_CHAR> {
 
     static Status from_string(void* buf, const std::string& scan_key) {
         size_t value_len = scan_key.length();
-        if (value_len > OLAP_STRING_MAX_LENGTH) {
+        if (value_len > get_olap_string_max_length()) {
             LOG(WARNING) << "String(length=" << value_len << ") is too long, the max length is "
-                         << OLAP_STRING_MAX_LENGTH;
+                         << get_olap_string_max_length();
             return Status::InternalError(fmt::format("String(length={}) is too long, the max length is: {}", value_len,
-                                                     OLAP_STRING_MAX_LENGTH));
+                                                     get_olap_string_max_length()));
         }
 
         auto slice = unaligned_load<Slice>(buf);

--- a/be/test/exprs/string_fn_concat_test.cpp
+++ b/be/test/exprs/string_fn_concat_test.cpp
@@ -228,7 +228,7 @@ TEST_F(StringFunctionConcatTest, concatConstOversizeTest) {
     auto col3 = BinaryColumn::create();
     auto null_col = NullColumn::create();
     for (int i = 0; i < 10; ++i) {
-        col0->append(Slice(std::string(OLAP_STRING_MAX_LENGTH - i, 'x')));
+        col0->append(Slice(std::string(get_olap_string_max_length() - i, 'x')));
         col0->append(Slice(std::string(i + 1, 'y')));
     }
     col1->append(Slice(std::string(33, 'A')));
@@ -278,7 +278,7 @@ TEST_F(StringFunctionConcatTest, concatConstOversizeTest) {
         auto s = result_binary->get_slice(i);
         std::string tail =
                 col1->get_slice(0).to_string() + col2->get_slice(0).to_string() + col3->get_slice(0).to_string();
-        if (s0.size + 99 > OLAP_STRING_MAX_LENGTH) {
+        if (s0.size + 99 > get_olap_string_max_length()) {
             ASSERT_TRUE(result->is_null(i));
         } else {
             ASSERT_FALSE(result->is_null(i));
@@ -311,7 +311,7 @@ static inline void concat_not_const_test(const NullColumnPtr& null_col, Columns 
         }
         auto s0 = col->get_slice(i);
         auto s = result_binary->get_slice(i);
-        if (s0.size + 99 > OLAP_STRING_MAX_LENGTH) {
+        if (s0.size + 99 > get_olap_string_max_length()) {
             ASSERT_TRUE(result->is_null(i));
         } else {
             ASSERT_FALSE(result->is_null(i));
@@ -364,7 +364,7 @@ TEST_F(StringFunctionConcatTest, concatNotConstSmallOversizeTest) {
     auto col3 = BinaryColumn::create();
     auto null_col = NullColumn::create();
     for (int i = 0; i < 5; ++i) {
-        col0->append(Slice(std::string(OLAP_STRING_MAX_LENGTH - i, 'x')));
+        col0->append(Slice(std::string(get_olap_string_max_length() - i, 'x')));
         col0->append(Slice(std::string(i + 1, 'y')));
     }
     const auto row_num = col0->size();
@@ -392,7 +392,7 @@ TEST_F(StringFunctionConcatTest, concatNotConstBigOversizeTest) {
     auto null_col = NullColumn::create();
 
     for (int i = 0; i < 10; ++i) {
-        col0->append(Slice(std::string(OLAP_STRING_MAX_LENGTH - i, 'x')));
+        col0->append(Slice(std::string(get_olap_string_max_length() - i, 'x')));
         col0->append(Slice(std::string(i + 1, 'x')));
     }
 
@@ -450,7 +450,7 @@ static inline void concat_ws_test(const NullColumnPtr& sep_null_col, const NullC
             expect.resize(expect.size() - sep_str.size());
         }
 
-        if (expect.size() > OLAP_STRING_MAX_LENGTH) {
+        if (expect.size() > get_olap_string_max_length()) {
             ASSERT_TRUE(result->is_null(i));
         } else {
             ASSERT_FALSE(result->is_null(i));
@@ -516,13 +516,13 @@ void prepare_concat_ws_data(const NullColumnPtr& sep_null_col, const NullColumnP
 
     for (auto i = 0; i < 5; ++i) {
         sep->append_datum(Slice(""));
-        sep->append_datum(Slice(std::string(OLAP_STRING_MAX_LENGTH, 'x')));
+        sep->append_datum(Slice(std::string(get_olap_string_max_length(), 'x')));
         sep->append_datum(Slice(std::string(i + 1, 'x')));
         sep->append_datum(Slice(std::string(5 - i, 'x')));
     }
 
     for (auto i = 0; i < 10; ++i) {
-        col0->append_datum(Slice(std::string(OLAP_STRING_MAX_LENGTH - i, 'x')));
+        col0->append_datum(Slice(std::string(get_olap_string_max_length() - i, 'x')));
         col0->append_datum(Slice(std::string(i + 1, 'x')));
     }
 
@@ -566,8 +566,8 @@ TEST_F(StringFunctionConcatTest, concatWsBigOversizeTest) {
     auto col3 = BinaryColumn::create();
     auto sep_null_col = NullColumn::create();
     auto null_col = NullColumn::create();
-    for (int i = 3786; i < 3796; ++i) {
-        sep->append(Slice(std::string(OLAP_STRING_MAX_LENGTH - i, 'x')));
+    for (int i = 3795; i < 3796; ++i) {
+        sep->append(Slice(std::string(get_olap_string_max_length() - i, 'x')));
         col0->append(Slice(std::string(100, 'y')));
         col1->append(Slice(std::string(i + 1, 'z')));
         col2->append(Slice(std::string(4096 - i, 'w')));

--- a/be/test/exprs/string_fn_pad_test.cpp
+++ b/be/test/exprs/string_fn_pad_test.cpp
@@ -138,8 +138,8 @@ TEST_F(StringFunctionPadTest, padNotConstASCIITest) {
     std::string x65531(65531, 'x');
     TestCaseArray cases = {
             {"test", 10, "123", false, "123123test", "test123123"},
-            {"test", OLAP_STRING_MAX_LENGTH + 1, "123", true, "", ""},
-            {"test", -OLAP_STRING_MAX_LENGTH - 1, "123", true, "", ""},
+            {"test", get_olap_string_max_length() + 1, "123", true, "", ""},
+            {"test", -get_olap_string_max_length() - 1, "123", true, "", ""},
             {"test", -1, "123", true, "", ""},
             {"test", 0, "x", false, "", ""},
             {"test", 10, "", false, "test", "test"},
@@ -183,8 +183,8 @@ TEST_F(StringFunctionPadTest, padNotConstUTF8Test) {
     std::string x65531(65531, 'x');
     TestCaseArray cases = {
             {"test", 10, "123", false, "123123test", "test123123"},
-            {"test", OLAP_STRING_MAX_LENGTH + 1, "123", true, "", ""},
-            {"test", -OLAP_STRING_MAX_LENGTH - 1, "123", true, "", ""},
+            {"test", get_olap_string_max_length() + 1, "123", true, "", ""},
+            {"test", -get_olap_string_max_length() - 1, "123", true, "", ""},
             {"test", -1, "123", true, "", ""},
             {"test", 0, "x", false, "", ""},
             {"test", 10, "", false, "test", "test"},
@@ -269,8 +269,8 @@ TEST_F(StringFunctionPadTest, padConstPadTest) {
     std::string x65531(65531, 'x');
     TestCaseArray cases = {
             {"test", 10, "123", false, "123123test", "test123123"},
-            {"test", OLAP_STRING_MAX_LENGTH + 1, "123", true, "", ""},
-            {"test", -OLAP_STRING_MAX_LENGTH - 1, "123", true, "", ""},
+            {"test", get_olap_string_max_length() + 1, "123", true, "", ""},
+            {"test", -get_olap_string_max_length() - 1, "123", true, "", ""},
             {"test", -1, "123", true, "", ""},
             {"test", 0, "x", false, "", ""},
             {"test", 10, "", false, "test", "test"},
@@ -367,8 +367,8 @@ TEST_F(StringFunctionPadTest, padConstLenAndPadTest) {
     std::string x65531(65531, 'x');
     TestCaseArray cases = {
             {"test", 10, "123", false, "123123test", "test123123"},
-            {"test", OLAP_STRING_MAX_LENGTH + 1, "123", true, "", ""},
-            {"test", -OLAP_STRING_MAX_LENGTH - 1, "123", true, "", ""},
+            {"test", get_olap_string_max_length() + 1, "123", true, "", ""},
+            {"test", -get_olap_string_max_length() - 1, "123", true, "", ""},
             {"test", -1, "123", true, "", ""},
             {"test", 0, "x", false, "", ""},
             {"test", 10, "", false, "test", "test"},

--- a/be/test/exprs/string_fn_repeat_test.cpp
+++ b/be/test/exprs/string_fn_repeat_test.cpp
@@ -53,7 +53,7 @@ TEST_F(StringFunctionRepeatTest, repeatLargeTest) {
     auto times = Int32Column::create();
 
     str->append(std::to_string(1));
-    times->append(OLAP_STRING_MAX_LENGTH + 100);
+    times->append(get_olap_string_max_length() + 100);
 
     columns.emplace_back(str);
     columns.emplace_back(times);
@@ -73,7 +73,7 @@ TEST_F(StringFunctionRepeatTest, repeatConstTest) {
         str->append(std::string(1, 'x'));
     }
 
-    int32_t repeat_times = OLAP_STRING_MAX_LENGTH / 100 + 10;
+    int32_t repeat_times = get_olap_string_max_length() / 100 + 10;
     times->append(repeat_times);
 
     columns.emplace_back(str);
@@ -89,7 +89,7 @@ TEST_F(StringFunctionRepeatTest, repeatConstTest) {
         auto si = str->get_slice(i);
         auto so = v.value(i);
 
-        if (si.size * repeat_times < OLAP_STRING_MAX_LENGTH) {
+        if (si.size * repeat_times < get_olap_string_max_length()) {
             ASSERT_EQ(so.size, si.size * repeat_times);
         } else {
             ASSERT_TRUE(v.is_null(i));

--- a/be/test/exprs/string_fn_space_test.cpp
+++ b/be/test/exprs/string_fn_space_test.cpp
@@ -49,9 +49,9 @@ TEST_F(StringFunctionSpaceTest, spaceConstTest) {
             {ColumnHelper::create_const_column<TYPE_INT>(-1, 1), true, ""},
             {ColumnHelper::create_const_column<TYPE_INT>(0, 1), false, ""},
             {ColumnHelper::create_const_column<TYPE_INT>(1, 1), false, std::string(1, ' ')},
-            {ColumnHelper::create_const_column<TYPE_INT>(OLAP_STRING_MAX_LENGTH - 1, 1), false,
-             std::string(OLAP_STRING_MAX_LENGTH - 1, ' ')},
-            {ColumnHelper::create_const_column<TYPE_INT>(OLAP_STRING_MAX_LENGTH + 1, 1), true, ""},
+            {ColumnHelper::create_const_column<TYPE_INT>(get_olap_string_max_length() - 1, 1), false,
+             std::string(get_olap_string_max_length() - 1, ' ')},
+            {ColumnHelper::create_const_column<TYPE_INT>(get_olap_string_max_length() + 1, 1), true, ""},
             {ColumnHelper::create_const_column<TYPE_INT>(INT32_MAX, 1), true, ""},
             {ColumnHelper::create_const_column<TYPE_INT>(INT32_MIN, 1), true, ""},
             {ColumnHelper::create_const_null_column(1), true, ""}};
@@ -79,8 +79,8 @@ TEST_F(StringFunctionSpaceTest, spaceNullableColumnTest) {
     for (int i = 0; i < 100; ++i) {
         times_col->append(INT_MIN);
         times_col->append(INT_MAX);
-        times_col->append(OLAP_STRING_MAX_LENGTH + i);
-        times_col->append(OLAP_STRING_MAX_LENGTH - i);
+        times_col->append(get_olap_string_max_length() + i);
+        times_col->append(get_olap_string_max_length() - i);
         times_col->append(i);
         times_col->append(-i);
     }
@@ -100,9 +100,9 @@ TEST_F(StringFunctionSpaceTest, spaceNullableColumnTest) {
             {0, false, false, ""},
             {INT32_MAX, false, true, ""},
             {INT32_MIN, false, true, ""},
-            {OLAP_STRING_MAX_LENGTH, false, false, std::string(OLAP_STRING_MAX_LENGTH, ' ')},
-            {OLAP_STRING_MAX_LENGTH - 1, false, false, std::string(OLAP_STRING_MAX_LENGTH - 1, ' ')},
-            {OLAP_STRING_MAX_LENGTH + 1, true, true, ""},
+            {get_olap_string_max_length(), false, false, std::string(get_olap_string_max_length(), ' ')},
+            {get_olap_string_max_length() - 1, false, false, std::string(get_olap_string_max_length() - 1, ' ')},
+            {get_olap_string_max_length() + 1, true, true, ""},
             {-10, false, true, ""},
             {0, true, true, ""},
             {100, true, true, ""},

--- a/be/test/storage/tablet_meta_test.cpp
+++ b/be/test/storage/tablet_meta_test.cpp
@@ -218,8 +218,8 @@ TEST(TabletMetaTest, test_create) {
     ASSERT_TRUE(c2_1.subcolumn(0).is_nullable());
     ASSERT_FALSE(c2_1.subcolumn(0).has_bitmap_index());
     ASSERT_FALSE(c2_1.subcolumn(0).has_default_value());
-    ASSERT_EQ(10 + sizeof(OLAP_STRING_MAX_LENGTH), c2_1.subcolumn(0).length());
-    ASSERT_EQ(10 + sizeof(OLAP_STRING_MAX_LENGTH), c2_1.subcolumn(0).index_length());
+    ASSERT_EQ(10 + sizeof(get_olap_string_max_length()), c2_1.subcolumn(0).length());
+    ASSERT_EQ(10 + sizeof(get_olap_string_max_length()), c2_1.subcolumn(0).index_length());
     ASSERT_EQ(0, c2_1.subcolumn(0).subcolumn_count());
 
     std::shared_ptr<BinlogConfig> binlog_config_ptr = tablet_meta->get_binlog_config();

--- a/fe/fe-core/src/main/java/com/starrocks/analysis/TypeDef.java
+++ b/fe/fe-core/src/main/java/com/starrocks/analysis/TypeDef.java
@@ -128,7 +128,7 @@ public class TypeDef implements ParseNode {
                 int maxLen;
                 if (type == PrimitiveType.VARCHAR) {
                     name = "Varchar";
-                    maxLen = ScalarType.MAX_VARCHAR_LENGTH;
+                    maxLen = ScalarType.getOlapMaxVarcharLength();
                 } else {
                     name = "Char";
                     maxLen = ScalarType.MAX_CHAR_LENGTH;
@@ -147,7 +147,7 @@ public class TypeDef implements ParseNode {
             }
             case VARBINARY: {
                 String name = "VARBINARY";
-                int maxLen = ScalarType.MAX_VARCHAR_LENGTH;
+                int maxLen = ScalarType.getOlapMaxVarcharLength();
                 int len = scalarType.getLength();
                 // len is decided by child, when it is -1.
                 if (scalarType.getLength() > maxLen) {

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/ScalarType.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/ScalarType.java
@@ -70,8 +70,6 @@ public class ScalarType extends Type implements Cloneable {
     // Longest supported VARCHAR and CHAR, chosen to match Hive.
     public static final int DEFAULT_STRING_LENGTH = 65533;
     public static final int MAX_VARCHAR_LENGTH = 1048576;
-    // 1GB for each line, it's enough
-    public static final int CATALOG_MAX_VARCHAR_LENGTH = 1024 * 1024 * 1024;
     public static final int MAX_CHAR_LENGTH = 255;
     // HLL DEFAULT LENGTH  2^14(registers) + 1(type)
     public static final int MAX_HLL_LENGTH = 16385;

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/ScalarType.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/ScalarType.java
@@ -70,6 +70,8 @@ public class ScalarType extends Type implements Cloneable {
     // Longest supported VARCHAR and CHAR, chosen to match Hive.
     public static final int DEFAULT_STRING_LENGTH = 65533;
     public static final int MAX_VARCHAR_LENGTH = 1048576;
+    // 1GB for each line, it's enough
+    public static final int CATALOG_MAX_VARCHAR_LENGTH = 1024 * 1024 * 1024;
     public static final int MAX_CHAR_LENGTH = 255;
     // HLL DEFAULT LENGTH  2^14(registers) + 1(type)
     public static final int MAX_HLL_LENGTH = 16385;
@@ -303,6 +305,10 @@ public class ScalarType extends Type implements Cloneable {
         }
     }
 
+    public static int getOlapMaxVarcharLength() {
+        return Config.max_varchar_length;
+    }
+
     public static ScalarType createDefaultString() {
         ScalarType stringType = ScalarType.createVarcharType(ScalarType.DEFAULT_STRING_LENGTH);
         return stringType;
@@ -315,7 +321,7 @@ public class ScalarType extends Type implements Cloneable {
     }
 
     public static ScalarType createMaxVarcharType() {
-        ScalarType stringType = ScalarType.createVarcharType(ScalarType.MAX_VARCHAR_LENGTH);
+        ScalarType stringType = ScalarType.createVarcharType(ScalarType.getOlapMaxVarcharLength());
         return stringType;
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/Type.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/Type.java
@@ -120,7 +120,7 @@ public abstract class Type implements Cloneable {
             ScalarType.createDecimalV3Type(PrimitiveType.DECIMAL128, 38, 0);
 
     public static final ScalarType VARCHAR = ScalarType.createVarcharType(-1);
-    public static final ScalarType STRING = ScalarType.createVarcharType(ScalarType.MAX_VARCHAR_LENGTH);
+    public static final ScalarType STRING = ScalarType.createVarcharType(ScalarType.getOlapMaxVarcharLength());
     public static final ScalarType DEFAULT_STRING = ScalarType.createDefaultString();
     public static final ScalarType HLL = ScalarType.createHllType();
     public static final ScalarType CHAR = ScalarType.createCharType(-1);

--- a/fe/fe-core/src/main/java/com/starrocks/common/Config.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/Config.java
@@ -2785,4 +2785,8 @@ public class Config extends ConfigBase {
 
     @ConfField(mutable = false)
     public static int jdbc_connection_idle_timeout_ms = 600000;
+
+    // The longest supported VARCHAR length.
+    @ConfField(mutable = true)
+    public static int max_varchar_length = 1048576;
 }

--- a/fe/fe-core/src/main/java/com/starrocks/connector/jdbc/PostgresSchemaResolver.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/jdbc/PostgresSchemaResolver.java
@@ -112,7 +112,7 @@ public class PostgresSchemaResolver extends JDBCSchemaResolver {
                 if (typeName.equalsIgnoreCase("varchar")) {
                     return ScalarType.createVarcharType(columnSize);
                 } else if (typeName.equalsIgnoreCase("text")) {
-                    return ScalarType.createVarcharType(ScalarType.MAX_VARCHAR_LENGTH);
+                    return ScalarType.createVarcharType(ScalarType.getOlapMaxVarcharLength());
                 }
                 primitiveType = PrimitiveType.UNKNOWN_TYPE;
                 break;
@@ -134,7 +134,7 @@ public class PostgresSchemaResolver extends JDBCSchemaResolver {
             // if user not specify numeric precision and scale, the default value is 0,
             // we can't defer the precision and scale, can only deal it as string.
             if (precision == 0) {
-                return ScalarType.createVarcharType(ScalarType.MAX_VARCHAR_LENGTH);
+                return ScalarType.createVarcharType(ScalarType.getOlapMaxVarcharLength());
             }
             return ScalarType.createUnifiedDecimalType(precision, max(digits, 0));
         }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AnalyzerUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AnalyzerUtils.java
@@ -882,7 +882,7 @@ public class AnalyzerUtils {
                     ScalarType scalarType = (ScalarType) srcType;
                     if (scalarType.getLength() > 0) {
                         len = scalarType.getLength();
-                   }
+                    }
                 }
                 ScalarType stringType = ScalarType.createVarcharType(len);
                 newType = stringType;

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AnalyzerUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AnalyzerUtils.java
@@ -877,12 +877,12 @@ public class AnalyzerUtils {
             if (PrimitiveType.VARCHAR == srcType.getPrimitiveType() ||
                     PrimitiveType.CHAR == srcType.getPrimitiveType() ||
                     PrimitiveType.NULL_TYPE == srcType.getPrimitiveType()) {
-                int len = ScalarType.MAX_VARCHAR_LENGTH;
+                int len = ScalarType.getOlapMaxVarcharLength();
                 if (srcType instanceof ScalarType) {
                     ScalarType scalarType = (ScalarType) srcType;
                     if (scalarType.getLength() > 0) {
                         len = scalarType.getLength();
-                    }
+                   }
                 }
                 ScalarType stringType = ScalarType.createVarcharType(len);
                 newType = stringType;

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/CreateFunctionStmt.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/CreateFunctionStmt.java
@@ -323,7 +323,7 @@ public class CreateFunctionStmt extends DdlStmt {
         argsDef.analyze();
         returnType.analyze();
 
-        intermediateType = TypeDef.createVarchar(ScalarType.MAX_VARCHAR_LENGTH);
+        intermediateType = TypeDef.createVarchar(ScalarType.getOlapMaxVarcharLength());
 
         String type = properties.get(TYPE_KEY);
         if (TYPE_STARROCKS_JAR.equals(type)) {

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/ColumnDefTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/ColumnDefTest.java
@@ -240,7 +240,7 @@ public class ColumnDefTest {
 
     @Test(expected = AnalysisException.class)
     public void testInvalidVarcharInsideArray() throws AnalysisException {
-        Type tooLongVarchar = ScalarType.createVarchar(ScalarType.MAX_VARCHAR_LENGTH + 1);
+        Type tooLongVarchar = ScalarType.createVarchar(ScalarType.getOlapMaxVarcharLength() + 1);
         ColumnDef column = new ColumnDef("col", new TypeDef(new ArrayType(tooLongVarchar)), false, null, true,
                 DefaultValueDef.NOT_SET, "");
         column.analyze(true);

--- a/fe/fe-core/src/test/java/com/starrocks/connector/ColumnTypeConverterTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/ColumnTypeConverterTest.java
@@ -34,7 +34,8 @@ import java.util.ArrayList;
 import java.util.LinkedList;
 import java.util.List;
 
-import static com.starrocks.catalog.ScalarType.MAX_VARCHAR_LENGTH;
+import static com.starrocks.catalog.ScalarType.CATALOG_MAX_VARCHAR_LENGTH;
+import static com.starrocks.catalog.ScalarType.getOlapMaxVarcharLength;
 import static com.starrocks.catalog.Type.UNKNOWN_TYPE;
 import static com.starrocks.connector.ColumnTypeConverter.columnEquals;
 import static com.starrocks.connector.ColumnTypeConverter.fromHiveTypeToArrayType;
@@ -42,6 +43,7 @@ import static com.starrocks.connector.ColumnTypeConverter.fromHiveTypeToMapType;
 import static com.starrocks.connector.ColumnTypeConverter.fromHudiType;
 import static com.starrocks.connector.ColumnTypeConverter.getPrecisionAndScale;
 import static com.starrocks.connector.ColumnTypeConverter.toHiveType;
+
 
 public class ColumnTypeConverterTest {
 
@@ -426,7 +428,7 @@ public class ColumnTypeConverterTest {
                 "Unsupported Hive type: VARCHAR(200000). Supported VARCHAR types: VARCHAR(<=65535)",
                 () -> toHiveType(ScalarType.createVarcharType(200000)));
 
-        Assert.assertEquals("string", toHiveType(ScalarType.createVarchar(MAX_VARCHAR_LENGTH)));
+        Assert.assertEquals("string", toHiveType(ScalarType.createVarchar(getOlapMaxVarcharLength())));
 
         ScalarType itemType = ScalarType.createType(PrimitiveType.DATE);
         ArrayType arrayType = new ArrayType(new ArrayType(itemType));

--- a/fe/fe-core/src/test/java/com/starrocks/connector/ColumnTypeConverterTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/ColumnTypeConverterTest.java
@@ -34,7 +34,6 @@ import java.util.ArrayList;
 import java.util.LinkedList;
 import java.util.List;
 
-import static com.starrocks.catalog.ScalarType.CATALOG_MAX_VARCHAR_LENGTH;
 import static com.starrocks.catalog.ScalarType.getOlapMaxVarcharLength;
 import static com.starrocks.catalog.Type.UNKNOWN_TYPE;
 import static com.starrocks.connector.ColumnTypeConverter.columnEquals;

--- a/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AnalyzerUtilsTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AnalyzerUtilsTest.java
@@ -76,5 +76,4 @@ public class AnalyzerUtilsTest {
         Expr shouldReplaceExpr = expr.getChild(0).getChild(0);
         Assert.assertTrue(shouldReplaceExpr instanceof StringLiteral);
     }
-
 }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AnalyzerUtilsTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AnalyzerUtilsTest.java
@@ -76,4 +76,5 @@ public class AnalyzerUtilsTest {
         Expr shouldReplaceExpr = expr.getChild(0).getChild(0);
         Assert.assertTrue(shouldReplaceExpr instanceof StringLiteral);
     }
+
 }


### PR DESCRIPTION
Why I'm doing:
This is needed as some of our workloads involve very long string length.
What I'm doing:
Simply make these the string length limits configurable through fe.conf and be.conf

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [x] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [x] This is a backport pr


