### PR TITLE
[BugFix] Support Iceberg partition compensation for mv rewrite

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/OlapTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/OlapTable.java
@@ -1740,6 +1740,11 @@ public class OlapTable extends Table {
         return partitionInfo != null && partitionInfo.isPartitioned();
     }
 
+    @Override
+    public boolean isUnPartitioned() {
+        return !isPartitionedTable();
+    }
+
     // NOTE: It's different from `isPartitionedTable` which `isPartitioned` means table has many buckets rather than
     // partitions.
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/MaterializationContext.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/MaterializationContext.java
@@ -45,6 +45,8 @@ import java.util.Set;
 import java.util.stream.Collectors;
 
 import static com.starrocks.sql.optimizer.OptimizerTraceUtil.logMVRewrite;
+import static com.starrocks.sql.optimizer.rule.transformation.materialization.MvPartitionCompensator.getMVPrunedPartitionPredicates;
+import static com.starrocks.sql.optimizer.rule.transformation.materialization.MvPartitionCompensator.isNeedCompensatePartitionPredicate;
 
 public class MaterializationContext {
     private final MaterializedView mv;
@@ -429,7 +431,7 @@ public class MaterializationContext {
             SessionVariable sessionVariable = optimizerContext.getSessionVariable();
             // only set this when `queryExpression` contains ref table, otherwise the cached value maybe dirty.
             isCompensatePartitionPredicateOpt = sessionVariable.isEnableMaterializedViewRewritePartitionCompensate() ?
-                    MvUtils.isNeedCompensatePartitionPredicate(queryExpression, this) : Optional.of(false);
+                    isNeedCompensatePartitionPredicate(queryExpression, this) : Optional.of(false);
         }
         return isCompensatePartitionPredicateOpt.orElse(true);
     }
@@ -440,7 +442,7 @@ public class MaterializationContext {
 
     public ScalarOperator getMVPrunedPartitionPredicate() {
         if (!mvPrunedPartitionPredicateOpt.isPresent()) {
-            List<ScalarOperator> mvPrunedPartitionPredicates = MvUtils.getMVPrunedPartitionPredicates(mv, mvExpression);
+            List<ScalarOperator> mvPrunedPartitionPredicates = getMVPrunedPartitionPredicates(mv, mvExpression);
             if (mvPrunedPartitionPredicates == null || mvPrunedPartitionPredicates.isEmpty()) {
                 mvPrunedPartitionPredicateOpt = Optional.of(ConstantOperator.TRUE);
             } else {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/MvRewritePreprocessor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/MvRewritePreprocessor.java
@@ -83,7 +83,7 @@ import java.util.Set;
 import java.util.stream.Collectors;
 
 import static com.starrocks.sql.optimizer.OptimizerTraceUtil.logMVPrepare;
-import static com.starrocks.sql.optimizer.rule.transformation.materialization.MvUtils.getMvPartialPartitionPredicates;
+import static com.starrocks.sql.optimizer.rule.transformation.materialization.MvPartitionCompensator.getMvPartialPartitionPredicates;
 
 public class MvRewritePreprocessor {
     private static final Logger LOG = LogManager.getLogger(MvRewritePreprocessor.class);

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/OptExternalPartitionPruner.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/OptExternalPartitionPruner.java
@@ -308,6 +308,8 @@ public class OptExternalPartitionPruner {
         } else if (table instanceof IcebergTable) {
             IcebergTable icebergTable = (IcebergTable) table;
             if (!icebergTable.getSnapshot().isPresent()) {
+                // TODO: for iceberg table, it cannot decide whether it's pruned or not when `selectedPartitionIds`
+                //  is empty. It's expensive to set all partitions here.
                 return;
             }
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvPartitionCompensator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvPartitionCompensator.java
@@ -1,0 +1,703 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.sql.optimizer.rule.transformation.materialization;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Preconditions;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
+import com.google.common.collect.Range;
+import com.google.common.collect.Sets;
+import com.starrocks.analysis.Expr;
+import com.starrocks.analysis.LiteralExpr;
+import com.starrocks.analysis.SlotRef;
+import com.starrocks.analysis.StringLiteral;
+import com.starrocks.catalog.Column;
+import com.starrocks.catalog.ExpressionRangePartitionInfo;
+import com.starrocks.catalog.MaterializedView;
+import com.starrocks.catalog.OlapTable;
+import com.starrocks.catalog.Partition;
+import com.starrocks.catalog.PartitionKey;
+import com.starrocks.catalog.RangePartitionInfo;
+import com.starrocks.catalog.SinglePartitionInfo;
+import com.starrocks.catalog.Table;
+import com.starrocks.common.AnalysisException;
+import com.starrocks.common.Pair;
+import com.starrocks.common.UserException;
+import com.starrocks.common.util.DateUtils;
+import com.starrocks.connector.PartitionUtil;
+import com.starrocks.sql.analyzer.RelationFields;
+import com.starrocks.sql.analyzer.RelationId;
+import com.starrocks.sql.analyzer.Scope;
+import com.starrocks.sql.optimizer.MaterializationContext;
+import com.starrocks.sql.optimizer.OptExpression;
+import com.starrocks.sql.optimizer.Utils;
+import com.starrocks.sql.optimizer.base.ColumnRefFactory;
+import com.starrocks.sql.optimizer.operator.OperatorType;
+import com.starrocks.sql.optimizer.operator.ScanOperatorPredicates;
+import com.starrocks.sql.optimizer.operator.logical.LogicalOlapScanOperator;
+import com.starrocks.sql.optimizer.operator.logical.LogicalScanOperator;
+import com.starrocks.sql.optimizer.operator.logical.LogicalViewScanOperator;
+import com.starrocks.sql.optimizer.operator.scalar.ColumnRefOperator;
+import com.starrocks.sql.optimizer.operator.scalar.ConstantOperator;
+import com.starrocks.sql.optimizer.operator.scalar.InPredicateOperator;
+import com.starrocks.sql.optimizer.operator.scalar.ScalarOperator;
+import com.starrocks.sql.optimizer.transformer.ExpressionMapping;
+import com.starrocks.sql.optimizer.transformer.SqlToScalarOperatorTranslator;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import java.time.LocalDateTime;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import static com.starrocks.sql.optimizer.OptimizerTraceUtil.logMVRewrite;
+
+/**
+ * This class represents all partition compensations for partition predicates in a materialized view.
+ */
+public class MvPartitionCompensator {
+    private static final Logger LOG = LogManager.getLogger(MvPartitionCompensator.class);
+
+    /**
+     * External scan operators should be supported if it has been supported in
+     * {@link com.starrocks.sql.optimizer.rewrite.OptExternalPartitionPruner}
+     */
+    public static final ImmutableSet<OperatorType> SUPPORTED_PARTITION_COMPENSATE_EXTERNAL_SCAN_TYPES =
+            ImmutableSet.<OperatorType>builder()
+                    .add(OperatorType.LOGICAL_HIVE_SCAN)
+                    .add(OperatorType.LOGICAL_ICEBERG_SCAN)
+                    .build();
+
+    public static final ImmutableSet<OperatorType> SUPPORTED_PARTITION_COMPENSATE_SCAN_TYPES =
+            ImmutableSet.<OperatorType>builder()
+                    .add(OperatorType.LOGICAL_OLAP_SCAN)
+                    .addAll(SUPPORTED_PARTITION_COMPENSATE_EXTERNAL_SCAN_TYPES)
+                    .build();
+
+    /**
+     * Determine whether to compensate extra partition predicates to query plan for the mv,
+     * - if it needs compensate, use `selectedPartitionIds` to compensate complete partition ranges
+     *  with lower and upper bound.
+     * - if not compensate, use original pruned partition predicates as the compensated partition
+     *  predicates.
+     * @param queryPlan : query opt expression
+     * @param mvContext : materialized view context
+     * @return Optional<Boolean>: if `queryPlan` contains ref table, Optional is set and return whether mv can satisfy
+     * query plan's refreshness, other Optional.empty() is returned.
+     */
+    public static Optional<Boolean> isNeedCompensatePartitionPredicate(OptExpression queryPlan,
+                                                                       MaterializationContext mvContext) {
+        Set<String> mvPartitionNameToRefresh = mvContext.getMvPartitionNamesToRefresh();
+        // If mv contains no partitions to refresh, no need compensate
+        if (Objects.isNull(mvPartitionNameToRefresh) || mvPartitionNameToRefresh.isEmpty()) {
+            return Optional.of(false);
+        }
+
+        // If ref table contains no partitions to refresh, no need compensate.
+        // If the mv is partitioned and non-ref table need refresh, then all partitions need to be refreshed,
+        // it can not be a candidate.
+        Set<String> refTablePartitionNameToRefresh = mvContext.getRefTableUpdatePartitionNames();
+        if (Objects.isNull(refTablePartitionNameToRefresh) || refTablePartitionNameToRefresh.isEmpty()) {
+            // NOTE: This should not happen: `mvPartitionNameToRefresh` is not empty, so `refTablePartitionNameToRefresh`
+            // should not empty. Return true in the situation to avoid bad cases.
+            return Optional.of(true);
+        }
+
+        List<LogicalScanOperator> scanOperators = MvUtils.getScanOperator(queryPlan);
+        // If no scan operator, no need compensate
+        if (scanOperators.isEmpty()) {
+            return Optional.of(false);
+        }
+        if (scanOperators.stream().anyMatch(scan -> scan instanceof LogicalViewScanOperator)) {
+            return Optional.of(true);
+        }
+
+        // If no partition table and columns, no need compensate
+        MaterializedView mv = mvContext.getMv();
+        Pair<Table, Column> partitionTableAndColumns = mv.getDirectTableAndPartitionColumn();
+        if (partitionTableAndColumns == null) {
+            return Optional.of(false);
+        }
+
+        // only set this when `queryExpression` contains ref table, otherwise the cached value maybe dirty.
+        Table refBaseTable = partitionTableAndColumns.first;
+        LogicalScanOperator refScanOperator = getRefBaseTableScanOperator(scanOperators, refBaseTable);
+        if (refScanOperator == null) {
+            return Optional.empty();
+        }
+
+        Table table = refScanOperator.getTable();
+        // If table's not partitioned, no need compensate
+        if (table.isUnPartitioned()) {
+            return Optional.of(false);
+        }
+
+        if (refScanOperator instanceof LogicalOlapScanOperator) {
+            LogicalOlapScanOperator olapScanOperator = (LogicalOlapScanOperator) refScanOperator;
+            OlapTable olapTable = (OlapTable) olapScanOperator.getTable();
+
+            List<Long> selectPartitionIds = olapScanOperator.getSelectedPartitionId();
+            if (Objects.isNull(selectPartitionIds) || selectPartitionIds.size() == 0) {
+                return Optional.of(false);
+            }
+
+            // determine whether query's partitions can be satisfied by materialized view.
+            for (Long selectPartitionId : selectPartitionIds) {
+                Partition partition = olapTable.getPartition(selectPartitionId);
+                if (partition != null && refTablePartitionNameToRefresh.contains(partition.getName())) {
+                    return Optional.of(true);
+                }
+            }
+            return Optional.of(false);
+        } else if (SUPPORTED_PARTITION_COMPENSATE_EXTERNAL_SCAN_TYPES.contains(refScanOperator.getOpType())) {
+            try {
+                ScanOperatorPredicates scanOperatorPredicates = refScanOperator.getScanOperatorPredicates();
+                if (scanOperatorPredicates == null) {
+                    return Optional.of(true);
+                }
+
+                Collection<Long> selectPartitionIds = scanOperatorPredicates.getSelectedPartitionIds();
+                if (Objects.isNull(selectPartitionIds) || selectPartitionIds.size() == 0) {
+                    // see OptExternalPartitionPruner#computePartitionInfo:
+                    // it's not the same meaning when selectPartitionIds is null and empty for hive and other tables
+                    if (refScanOperator.getOpType() == OperatorType.LOGICAL_HIVE_SCAN) {
+                        return Optional.of(false);
+                    } else {
+                        return Optional.of(true);
+                    }
+                }
+                // determine whether query's partitions can be satisfied by materialized view.
+                List<PartitionKey> selectPartitionKeys = scanOperatorPredicates.getSelectedPartitionKeys();
+                for (PartitionKey partitionKey : selectPartitionKeys) {
+                    String mvPartitionName = PartitionUtil.generateMVPartitionName(partitionKey);
+                    if (refTablePartitionNameToRefresh.contains(mvPartitionName)) {
+                        return Optional.of(true);
+                    }
+                }
+                return Optional.of(false);
+            } catch (AnalysisException e) {
+                return Optional.of(true);
+            }
+        } else {
+            return Optional.of(true);
+        }
+    }
+
+    /**
+     * - if `isCompensate` is true, use `selectedPartitionIds` to compensate complete partition ranges
+     *  with lower and upper bound.
+     * - otherwise use original pruned partition predicates as the compensated partition
+     *  predicates.
+     * NOTE: When MV has enough partitions for the query, no need to compensate anymore for both mv and the query's plan.
+     *       A query can be rewritten just by the original SQL.
+     * NOTE: It's not safe if `isCompensate` is always false:
+     *      - partitionPredicate is null if olap scan operator cannot prune partitions.
+     *      - partitionPredicate is not exact even if olap scan operator has pruned partitions.
+     * eg:
+     *      t1:
+     *       PARTITION p1 VALUES [("0000-01-01"), ("2020-01-01")), has data
+     *       PARTITION p2 VALUES [("2020-01-01"), ("2020-02-01")), has data
+     *       PARTITION p3 VALUES [("2020-02-01"), ("2020-03-01")), has data
+     *       PARTITION p4 VALUES [("2020-03-01"), ("2020-04-01")), no data
+     *       PARTITION p5 VALUES [("2020-04-01"), ("2020-05-01")), no data
+     *
+     *      query1 : SELECT k1, sum(v1) as sum_v1 FROM t1 group by k1;
+     *      `partitionPredicate` : null
+     *
+     *      query2 : SELECT k1, sum(v1) as sum_v1 FROM t1 where k1>='2020-02-01' group by k1;
+     *      `partitionPredicate` : k1>='2020-02-11'
+     *      however for mv  we need: k1>='2020-02-11' and k1 < "2020-03-01"
+     */
+    public static ScalarOperator compensatePartitionPredicate(MaterializationContext mvContext,
+                                                              ColumnRefFactory columnRefFactory,
+                                                              OptExpression queryExpression) {
+        List<LogicalScanOperator> scanOperators = MvUtils.getScanOperator(queryExpression);
+        if (scanOperators.isEmpty()) {
+            return ConstantOperator.createBoolean(true);
+        }
+
+        List<ScalarOperator> partitionPredicates = Lists.newArrayList();
+        boolean isCompensatePartition = mvContext.getOrInitCompensatePartitionPredicate(queryExpression);
+        // Compensate partition predicates and add them into query predicate.
+        Map<Pair<LogicalScanOperator, Boolean>, List<ScalarOperator>> scanOperatorScalarOperatorMap =
+                mvContext.getScanOpToPartitionCompensatePredicates();
+        for (LogicalScanOperator scanOperator : scanOperators) {
+            if (!SUPPORTED_PARTITION_COMPENSATE_SCAN_TYPES.contains(scanOperator.getOpType())) {
+                continue;
+            }
+            List<ScalarOperator> partitionPredicate = scanOperatorScalarOperatorMap
+                    .computeIfAbsent(Pair.create(scanOperator, isCompensatePartition), x -> {
+                        return isCompensatePartition ? getCompensatePartitionPredicates(mvContext, columnRefFactory,
+                                scanOperator) : getScanOpPrunedPartitionPredicates(scanOperator);
+                    });
+            if (partitionPredicate == null) {
+                logMVRewrite(mvContext.getMv().getName(), "Compensate partition failed for scan {}",
+                        scanOperator.getTable().getName());
+                return null;
+            }
+            partitionPredicates.addAll(partitionPredicate);
+        }
+        ScalarOperator compensatePredicate = partitionPredicates.isEmpty() ? ConstantOperator.createBoolean(true) :
+                Utils.compoundAnd(partitionPredicates);
+        logMVRewrite(mvContext.getMv().getName(), "Compensate partition predicate:{}", compensatePredicate);
+        return compensatePredicate;
+    }
+
+    private static List<ScalarOperator> getCompensatePartitionPredicates(MaterializationContext mvContext,
+                                                                         ColumnRefFactory columnRefFactory,
+                                                                         LogicalScanOperator scanOperator) {
+        List<ScalarOperator> partitionPredicate = null;
+        if (scanOperator instanceof LogicalOlapScanOperator) {
+            partitionPredicate = compensatePartitionPredicateForOlapScan((LogicalOlapScanOperator) scanOperator,
+                    columnRefFactory);
+        } else if (SUPPORTED_PARTITION_COMPENSATE_EXTERNAL_SCAN_TYPES.contains(scanOperator.getOpType())) {
+            partitionPredicate = compensatePartitionPredicateForExternalTables(scanOperator);
+        } else {
+            logMVRewrite(mvContext.getMv().getName(), "Compensate partition failed: unsupported scan " +
+                            "operator type {} for {}", scanOperator.getOpType(), scanOperator.getTable().getName());
+            return null;
+        }
+        return partitionPredicate;
+    }
+
+    private static List<ScalarOperator> compensatePartitionPredicateForExternalTables(LogicalScanOperator scanOperator) {
+        ScanOperatorPredicates scanOperatorPredicates = null;
+        try {
+            scanOperatorPredicates = scanOperator.getScanOperatorPredicates();
+        } catch (AnalysisException e) {
+            return null;
+        }
+        if (scanOperatorPredicates == null) {
+            return null;
+        }
+
+        List<ScalarOperator> partitionPredicates = Lists.newArrayList();
+        Table baseTable = scanOperator.getTable();
+        if (baseTable.isUnPartitioned()) {
+            return partitionPredicates;
+        }
+
+        OperatorType operatorType = scanOperator.getOpType();
+        // only used for hive
+        if (operatorType == OperatorType.LOGICAL_HIVE_SCAN && scanOperatorPredicates.getSelectedPartitionIds().size()
+                == scanOperatorPredicates.getIdToPartitionKey().size()) {
+            return partitionPredicates;
+        }
+
+        List<Range<PartitionKey>> ranges = Lists.newArrayList();
+        for (PartitionKey selectedPartitionKey : scanOperatorPredicates.getSelectedPartitionKeys()) {
+            try {
+                LiteralExpr expr = PartitionUtil.addOffsetForLiteral(selectedPartitionKey.getKeys().get(0), 1,
+                        PartitionUtil.getDateTimeInterval(baseTable, baseTable.getPartitionColumns().get(0)));
+                PartitionKey partitionKey = new PartitionKey(ImmutableList.of(expr), selectedPartitionKey.getTypes());
+                ranges.add(Range.closedOpen(selectedPartitionKey, partitionKey));
+            } catch (AnalysisException e) {
+                LOG.warn("Compute partition key range failed. ", e);
+                return partitionPredicates;
+            }
+        }
+
+        List<Range<PartitionKey>> mergedRanges = MvUtils.mergeRanges(ranges);
+        ColumnRefOperator partitionColumnRef = scanOperator.getColumnReference(baseTable.getPartitionColumns().get(0));
+        ScalarOperator partitionPredicate = convertPartitionKeysToPredicate(partitionColumnRef, mergedRanges);
+        if (partitionPredicate != null) {
+            partitionPredicates.add(partitionPredicate);
+        }
+
+        return partitionPredicates;
+    }
+
+    /**
+     * Compensate olap table's partition predicates from olap scan operator which may be pruned by optimizer before or not.
+     *
+     * @param olapScanOperator   : olap scan operator that needs to compensate partition predicates.
+     * @param columnRefFactory   : column ref factory that used to generate new partition predicate epxr.
+     * @return
+     */
+    private static List<ScalarOperator> compensatePartitionPredicateForOlapScan(LogicalOlapScanOperator olapScanOperator,
+                                                                                ColumnRefFactory columnRefFactory) {
+        List<ScalarOperator> partitionPredicates = Lists.newArrayList();
+        Preconditions.checkState(olapScanOperator.getTable().isNativeTableOrMaterializedView());
+        OlapTable olapTable = (OlapTable) olapScanOperator.getTable();
+
+        // compensate nothing for single partition table
+        if (olapTable.getPartitionInfo() instanceof SinglePartitionInfo) {
+            return partitionPredicates;
+        }
+
+        // compensate nothing if selected partitions are the same with the total partitions.
+        if (olapScanOperator.getSelectedPartitionId() != null
+                && olapScanOperator.getSelectedPartitionId().size() == olapTable.getPartitions().size()) {
+            return partitionPredicates;
+        }
+
+        // if no partitions are selected, return pruned partition predicates directly.
+        if (olapScanOperator.getSelectedPartitionId().isEmpty()) {
+            return olapScanOperator.getPrunedPartitionPredicates();
+        }
+
+        if (olapTable.getPartitionInfo() instanceof ExpressionRangePartitionInfo) {
+            ExpressionRangePartitionInfo partitionInfo =
+                    (ExpressionRangePartitionInfo) olapTable.getPartitionInfo();
+            Expr partitionExpr = partitionInfo.getPartitionExprs().get(0);
+            List<SlotRef> slotRefs = Lists.newArrayList();
+            partitionExpr.collect(SlotRef.class, slotRefs);
+            Preconditions.checkState(slotRefs.size() == 1);
+            Optional<ColumnRefOperator> partitionColumn =
+                    olapScanOperator.getColRefToColumnMetaMap().keySet().stream()
+                            .filter(columnRefOperator -> columnRefOperator.getName()
+                                    .equals(slotRefs.get(0).getColumnName()))
+                            .findFirst();
+            // compensate nothing if there is no partition column predicate in the scan node.
+            if (!partitionColumn.isPresent()) {
+                return null;
+            }
+
+            ExpressionMapping mapping =
+                    new ExpressionMapping(new Scope(RelationId.anonymous(), new RelationFields()));
+            mapping.put(slotRefs.get(0), partitionColumn.get());
+            ScalarOperator partitionScalarOperator =
+                    SqlToScalarOperatorTranslator.translate(partitionExpr, mapping, columnRefFactory);
+            List<Range<PartitionKey>> selectedRanges = Lists.newArrayList();
+            // compensate selected partition ranges from selected partition id
+            for (long pid : olapScanOperator.getSelectedPartitionId()) {
+                selectedRanges.add(partitionInfo.getRange(pid));
+            }
+
+            // normalize selected partition ranges
+            List<Range<PartitionKey>> mergedRanges = MvUtils.mergeRanges(selectedRanges);
+            ScalarOperator partitionPredicate =
+                    convertPartitionKeysToPredicate(partitionScalarOperator, mergedRanges);
+            partitionPredicates.add(partitionPredicate);
+        } else if (olapTable.getPartitionInfo() instanceof RangePartitionInfo) {
+            RangePartitionInfo rangePartitionInfo = (RangePartitionInfo) olapTable.getPartitionInfo();
+            List<Column> partitionColumns = rangePartitionInfo.getPartitionColumns();
+            if (partitionColumns.size() != 1) {
+                // now do not support more than one partition columns
+                return null;
+            }
+            List<Range<PartitionKey>> selectedRanges = Lists.newArrayList();
+            for (long pid : olapScanOperator.getSelectedPartitionId()) {
+                selectedRanges.add(rangePartitionInfo.getRange(pid));
+            }
+            ColumnRefOperator partitionColumnRef = olapScanOperator.getColumnReference(partitionColumns.get(0));
+            List<Range<PartitionKey>> mergedRanges = MvUtils.mergeRanges(selectedRanges);
+            ScalarOperator partitionPredicate =
+                    convertPartitionKeysToPredicate(partitionColumnRef, mergedRanges);
+            if (partitionPredicate != null) {
+                partitionPredicates.add(partitionPredicate);
+            }
+        } else {
+            return null;
+        }
+
+        return partitionPredicates;
+    }
+
+    public static ScalarOperator convertListPartitionKeys(ScalarOperator partitionColRef,
+                                                          List<Range<PartitionKey>> partitionRanges) {
+        List<ScalarOperator> inArgs = Lists.newArrayList();
+        inArgs.add(partitionColRef);
+        for (Range<PartitionKey> range : partitionRanges) {
+            if (range.isEmpty()) {
+                continue;
+            }
+
+            // see `convertToDateRange`
+            if (range.hasLowerBound() && range.hasUpperBound()) {
+                // partition range must have lower bound and upper bound
+                ConstantOperator lowerBound =
+                        (ConstantOperator) SqlToScalarOperatorTranslator.translate(range.lowerEndpoint().getKeys().get(0));
+                ConstantOperator upperBound =
+                        (ConstantOperator) SqlToScalarOperatorTranslator.translate(range.upperEndpoint().getKeys().get(0));
+                Preconditions.checkState(lowerBound.getType().isStringType());
+                Preconditions.checkState(upperBound.getType().isStringType());
+                inArgs.add(lowerBound);
+            } else if (range.hasUpperBound()) {
+                ConstantOperator upperBound =
+                        (ConstantOperator) SqlToScalarOperatorTranslator.translate(range.upperEndpoint().getKeys().get(0));
+                Preconditions.checkState(upperBound.getType().isStringType());
+                inArgs.add(upperBound);
+            } else if (range.hasLowerBound()) {
+                ConstantOperator lowerBound =
+                        (ConstantOperator) SqlToScalarOperatorTranslator.translate(range.lowerEndpoint().getKeys().get(0));
+                Preconditions.checkState(lowerBound.getType().isStringType());
+                inArgs.add(lowerBound);
+            } else {
+                // continue
+            }
+        }
+        if (inArgs.size() == 1) {
+            return ConstantOperator.TRUE;
+        } else {
+            return new InPredicateOperator(false, inArgs);
+        }
+    }
+
+    private static ScalarOperator convertPartitionKeysToPredicate(ScalarOperator partitionColumn,
+                                                                  List<Range<PartitionKey>> partitionKeys) {
+        boolean isListPartition = partitionColumn.getType().isStringType();
+        // NOTE: For string type partition column, it should be list partition rather than range partition.
+        if (isListPartition) {
+            return convertListPartitionKeys(partitionColumn, partitionKeys);
+        } else {
+            List<ScalarOperator> rangePredicates = MvUtils.convertRanges(partitionColumn, partitionKeys);
+            return Utils.compoundOr(rangePredicates);
+        }
+    }
+
+    // try to get partial partition predicates of partitioned mv.
+    // eg, mv1's base partition table is t1, partition column is k1 and has two partition:
+    // p1:[2022-01-01, 2022-01-02), p1 is updated(refreshed),
+    // p2:[2022-01-02, 2022-01-03), p2 is outdated,
+    // then this function will return predicate:
+    // k1 >= "2022-01-01" and k1 < "2022-01-02"
+    // NOTE: This method can be only used in query rewrite and cannot be used in insert routine.
+    public static ScalarOperator getMvPartialPartitionPredicates(
+            MaterializedView mv,
+            OptExpression mvPlan,
+            Set<String> mvPartitionNamesToRefresh) throws AnalysisException {
+        Pair<Table, Column> partitionTableAndColumns = mv.getDirectTableAndPartitionColumn();
+        if (partitionTableAndColumns == null) {
+            return null;
+        }
+
+        Table refBaseTable = partitionTableAndColumns.first;
+        List<Range<PartitionKey>> latestBaseTableRanges =
+                getLatestPartitionRangeForTable(refBaseTable, partitionTableAndColumns.second,
+                        mv, mvPartitionNamesToRefresh);
+        if (latestBaseTableRanges.isEmpty()) {
+            // if there isn't an updated partition, do not rewrite
+            return null;
+        }
+
+        Column partitionColumn = partitionTableAndColumns.second;
+        Expr partitionExpr = mv.getFirstPartitionRefTableExpr();
+        List<LogicalScanOperator> scanOperators = MvUtils.getScanOperator(mvPlan);
+        for (LogicalScanOperator scanOperator : scanOperators) {
+            if (!isRefBaseTable(scanOperator, refBaseTable)) {
+                continue;
+            }
+            final Optional<ColumnRefOperator> columnRefOption;
+            if (scanOperator instanceof LogicalViewScanOperator) {
+                LogicalViewScanOperator viewScanOperator = scanOperator.cast();
+                columnRefOption = Optional.ofNullable(viewScanOperator.getExpressionMapping(partitionExpr));
+            } else {
+                columnRefOption = Optional.ofNullable(scanOperator.getColumnReference(partitionColumn));
+            }
+            if (!columnRefOption.isPresent()) {
+                continue;
+            }
+            return convertPartitionKeysToPredicate(columnRefOption.get(), latestBaseTableRanges);
+        }
+        return null;
+    }
+
+    // convert varchar date to date type
+    @VisibleForTesting
+    public static Range<PartitionKey> convertToDateRange(Range<PartitionKey> from) throws AnalysisException {
+        if (from.hasLowerBound() && from.hasUpperBound()) {
+            StringLiteral lowerString = (StringLiteral) from.lowerEndpoint().getKeys().get(0);
+            LocalDateTime lowerDateTime = DateUtils.parseDatTimeString(lowerString.getStringValue());
+            PartitionKey lowerPartitionKey = PartitionKey.ofDate(lowerDateTime.toLocalDate());
+
+            StringLiteral upperString = (StringLiteral) from.upperEndpoint().getKeys().get(0);
+            LocalDateTime upperDateTime = DateUtils.parseDatTimeString(upperString.getStringValue());
+            PartitionKey upperPartitionKey = PartitionKey.ofDate(upperDateTime.toLocalDate());
+            return Range.range(lowerPartitionKey, from.lowerBoundType(), upperPartitionKey, from.upperBoundType());
+        } else if (from.hasUpperBound()) {
+            StringLiteral upperString = (StringLiteral) from.upperEndpoint().getKeys().get(0);
+            LocalDateTime upperDateTime = DateUtils.parseDatTimeString(upperString.getStringValue());
+            PartitionKey upperPartitionKey = PartitionKey.ofDate(upperDateTime.toLocalDate());
+            return Range.upTo(upperPartitionKey, from.upperBoundType());
+        } else if (from.hasLowerBound()) {
+            StringLiteral lowerString = (StringLiteral) from.lowerEndpoint().getKeys().get(0);
+            LocalDateTime lowerDateTime = DateUtils.parseDatTimeString(lowerString.getStringValue());
+            PartitionKey lowerPartitionKey = PartitionKey.ofDate(lowerDateTime.toLocalDate());
+            return Range.downTo(lowerPartitionKey, from.lowerBoundType());
+        }
+        return Range.all();
+    }
+
+    /**
+     * Return the updated partition key ranges of the specific table.
+     *
+     * NOTE: This method can be only used in query rewrite and cannot be used to insert routine.
+     * @param partitionByTable          : the base table of the mv
+     * @param partitionColumn           : the partition column of the base table
+     * @param mv                        : the materialized view
+     * @param mvPartitionNamesToRefresh : the updated partition names  of the materialized view
+     * @return
+     */
+    private static List<Range<PartitionKey>> getLatestPartitionRangeForTable(
+            Table partitionByTable,
+            Column partitionColumn,
+            MaterializedView mv,
+            Set<String> mvPartitionNamesToRefresh) throws AnalysisException {
+        Set<String> refBaseTableUpdatedPartitionNames = mv.getUpdatedPartitionNamesOfTable(partitionByTable, true);
+        List<Range<PartitionKey>> refBaseTableRanges = getLatestPartitionRange(partitionByTable, partitionColumn,
+                refBaseTableUpdatedPartitionNames, MaterializedView.getPartitionExpr(mv));
+        // date to varchar range
+        Map<Range<PartitionKey>, Range<PartitionKey>> baseRangeMapping = null;
+        boolean isConvertToDate = PartitionUtil.isConvertToDate(mv.getFirstPartitionRefTableExpr(), partitionColumn);
+        if (isConvertToDate) {
+            baseRangeMapping = Maps.newHashMap();
+            // convert varchar range to date range
+            List<Range<PartitionKey>> baseTableDateRanges = Lists.newArrayList();
+            for (Range<PartitionKey> range : refBaseTableRanges) {
+                Range<PartitionKey> datePartitionRange = convertToDateRange(range);
+                baseTableDateRanges.add(datePartitionRange);
+                baseRangeMapping.put(datePartitionRange, range);
+            }
+            refBaseTableRanges = baseTableDateRanges;
+        }
+        // materialized view latest partition ranges except to-refresh partitions
+        List<Range<PartitionKey>> mvRanges = getLatestPartitionRangeForNativeTable(mv, mvPartitionNamesToRefresh);
+
+        List<Range<PartitionKey>> latestBaseTableRanges = Lists.newArrayList();
+        for (Range<PartitionKey> range : refBaseTableRanges) {
+            // if materialized view's partition range can enclose the ref base table range, we think that
+            // the materialized view's partition has been refreshed and should be compensated into the materialized
+            // view's partition predicate.
+            if (mvRanges.stream().anyMatch(mvRange -> mvRange.encloses(range))) {
+                latestBaseTableRanges.add(range);
+            }
+        }
+        if (isConvertToDate) {
+            // treat string type partition as list, so no need merge
+            List<Range<PartitionKey>> tmpRangeList = Lists.newArrayList();
+            for (Range<PartitionKey> range : latestBaseTableRanges) {
+                tmpRangeList.add(baseRangeMapping.get(range));
+            }
+            return tmpRangeList;
+        } else {
+            return MvUtils.mergeRanges(latestBaseTableRanges);
+        }
+    }
+
+    private static List<Range<PartitionKey>> getLatestPartitionRangeForNativeTable(OlapTable partitionTable,
+                                                                                   Set<String> modifiedPartitionNames) {
+        // partitions that will be excluded
+        Set<Long> filteredIds = Sets.newHashSet();
+        for (Partition p : partitionTable.getPartitions()) {
+            if (modifiedPartitionNames.contains(p.getName()) || !p.hasData()) {
+                filteredIds.add(p.getId());
+            }
+        }
+        RangePartitionInfo rangePartitionInfo = (RangePartitionInfo) partitionTable.getPartitionInfo();
+        return rangePartitionInfo.getRangeList(filteredIds, false);
+    }
+
+    private static List<Range<PartitionKey>> getLatestPartitionRange(
+            Table table, Column partitionColumn, Set<String> modifiedPartitionNames, Expr partitionExpr) {
+        if (table.isNativeTableOrMaterializedView()) {
+            return getLatestPartitionRangeForNativeTable((OlapTable) table, modifiedPartitionNames);
+        } else {
+            Map<String, Range<PartitionKey>> partitionMap;
+            try {
+                partitionMap = PartitionUtil.getPartitionKeyRange(table, partitionColumn, partitionExpr);
+            } catch (UserException e) {
+                LOG.warn("Materialized view Optimizer compute partition range failed.", e);
+                return Lists.newArrayList();
+            }
+            return partitionMap.entrySet().stream().filter(entry -> !modifiedPartitionNames.contains(entry.getKey())).
+                    map(Map.Entry::getValue).collect(Collectors.toList());
+        }
+    }
+
+    public static List<ScalarOperator> getMVPrunedPartitionPredicates(MaterializedView mv,
+                                                                      OptExpression mvPlan) {
+        Pair<Table, Column> partitionTableAndColumns = mv.getDirectTableAndPartitionColumn();
+        if (partitionTableAndColumns == null) {
+            return null;
+        }
+
+        Table refBaseTable = partitionTableAndColumns.first;
+        List<LogicalScanOperator> scanOperators = MvUtils.getScanOperator(mvPlan);
+        for (LogicalScanOperator scanOperator : scanOperators) {
+            if (!isRefBaseTable(scanOperator, refBaseTable)) {
+                continue;
+            }
+
+            List<ScalarOperator> prunedPredicates = getScanOpPrunedPartitionPredicates(scanOperator);
+            if (prunedPredicates == null || prunedPredicates.isEmpty()) {
+                return List.of(ConstantOperator.TRUE);
+            } else {
+                return prunedPredicates;
+            }
+        }
+        return null;
+    }
+
+    private static List<ScalarOperator> getScanOpPrunedPartitionPredicates(LogicalScanOperator scanOperator) {
+        if (scanOperator == null) {
+            return null;
+        }
+
+        if (scanOperator instanceof LogicalOlapScanOperator) {
+            return ((LogicalOlapScanOperator) scanOperator).getPrunedPartitionPredicates();
+        } else if (SUPPORTED_PARTITION_COMPENSATE_EXTERNAL_SCAN_TYPES.contains(scanOperator.getOpType())) {
+            try {
+                ScanOperatorPredicates scanOperatorPredicates = scanOperator.getScanOperatorPredicates();
+                return scanOperatorPredicates.getPrunedPartitionConjuncts();
+            } catch (AnalysisException e) {
+                return null;
+            }
+        } else {
+            // Cannot decide whether it has been pruned or not, return null for now.
+            return null;
+        }
+    }
+
+    /**
+     * Find scan operator which contains the ref-base-table of the materialized view.
+     * @param scanOperators: scan operators extracted from query plan.
+     * @param refBaseTable: ref-base-table of the materialized view.
+     * @return: the first scan operator which contains the ref-base-table of the materialized view if existed,
+     * otherwise null is returned.
+     */
+    private static LogicalScanOperator getRefBaseTableScanOperator(List<LogicalScanOperator> scanOperators,
+                                                                   Table refBaseTable) {
+        Optional<LogicalScanOperator> optRefScanOperator =
+                scanOperators.stream().filter(x -> isRefBaseTable(x, refBaseTable)).findFirst();
+        if (!optRefScanOperator.isPresent()) {
+            return null;
+        }
+        return optRefScanOperator.get();
+    }
+
+    private static boolean isRefBaseTable(LogicalScanOperator scanOperator, Table refBaseTable) {
+        Table scanTable = scanOperator.getTable();
+        if (scanTable.isNativeTableOrMaterializedView() && !scanTable.equals(refBaseTable)) {
+            return false;
+        }
+        if (scanOperator instanceof LogicalViewScanOperator) {
+            return true;
+        }
+        if (!scanTable.isNativeTableOrMaterializedView() && !scanTable.getTableIdentifier().equals(
+                refBaseTable.getTableIdentifier())) {
+            return false;
+        }
+        return true;
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvUtils.java
@@ -18,7 +18,6 @@ package com.starrocks.sql.optimizer.rule.transformation.materialization;
 import com.google.common.base.Joiner;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Predicates;
-import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Range;
@@ -28,43 +27,30 @@ import com.starrocks.analysis.BinaryType;
 import com.starrocks.analysis.CompoundPredicate;
 import com.starrocks.analysis.DateLiteral;
 import com.starrocks.analysis.Expr;
-import com.starrocks.analysis.IntLiteral;
 import com.starrocks.analysis.JoinOperator;
 import com.starrocks.analysis.LiteralExpr;
 import com.starrocks.analysis.SlotRef;
-import com.starrocks.analysis.StringLiteral;
 import com.starrocks.catalog.Column;
 import com.starrocks.catalog.Database;
-import com.starrocks.catalog.ExpressionRangePartitionInfo;
-import com.starrocks.catalog.HiveTable;
 import com.starrocks.catalog.MaterializedView;
 import com.starrocks.catalog.MvId;
 import com.starrocks.catalog.MvPlanContext;
 import com.starrocks.catalog.OlapTable;
-import com.starrocks.catalog.Partition;
 import com.starrocks.catalog.PartitionKey;
-import com.starrocks.catalog.RangePartitionInfo;
-import com.starrocks.catalog.SinglePartitionInfo;
 import com.starrocks.catalog.Table;
 import com.starrocks.common.AnalysisException;
 import com.starrocks.common.Pair;
-import com.starrocks.common.UserException;
 import com.starrocks.common.util.DateUtils;
 import com.starrocks.common.util.RangeUtils;
-import com.starrocks.connector.PartitionUtil;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.sql.analyzer.Analyzer;
-import com.starrocks.sql.analyzer.RelationFields;
-import com.starrocks.sql.analyzer.RelationId;
-import com.starrocks.sql.analyzer.Scope;
 import com.starrocks.sql.analyzer.SemanticException;
 import com.starrocks.sql.ast.QueryRelation;
 import com.starrocks.sql.ast.QueryStatement;
 import com.starrocks.sql.ast.StatementBase;
 import com.starrocks.sql.optimizer.ExpressionContext;
 import com.starrocks.sql.optimizer.JoinHelper;
-import com.starrocks.sql.optimizer.MaterializationContext;
 import com.starrocks.sql.optimizer.MvPlanContextBuilder;
 import com.starrocks.sql.optimizer.OptExpression;
 import com.starrocks.sql.optimizer.OptExpressionVisitor;
@@ -78,11 +64,8 @@ import com.starrocks.sql.optimizer.base.PhysicalPropertySet;
 import com.starrocks.sql.optimizer.operator.AggType;
 import com.starrocks.sql.optimizer.operator.Operator;
 import com.starrocks.sql.optimizer.operator.OperatorBuilderFactory;
-import com.starrocks.sql.optimizer.operator.OperatorType;
-import com.starrocks.sql.optimizer.operator.ScanOperatorPredicates;
 import com.starrocks.sql.optimizer.operator.logical.LogicalAggregationOperator;
 import com.starrocks.sql.optimizer.operator.logical.LogicalFilterOperator;
-import com.starrocks.sql.optimizer.operator.logical.LogicalHiveScanOperator;
 import com.starrocks.sql.optimizer.operator.logical.LogicalJoinOperator;
 import com.starrocks.sql.optimizer.operator.logical.LogicalOlapScanOperator;
 import com.starrocks.sql.optimizer.operator.logical.LogicalOperator;
@@ -95,13 +78,11 @@ import com.starrocks.sql.optimizer.operator.scalar.BinaryPredicateOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ColumnRefOperator;
 import com.starrocks.sql.optimizer.operator.scalar.CompoundPredicateOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ConstantOperator;
-import com.starrocks.sql.optimizer.operator.scalar.InPredicateOperator;
 import com.starrocks.sql.optimizer.operator.scalar.IsNullPredicateOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ScalarOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ScalarOperatorVisitor;
 import com.starrocks.sql.optimizer.rewrite.ReplaceColumnRefRewriter;
 import com.starrocks.sql.optimizer.rewrite.ScalarOperatorRewriter;
-import com.starrocks.sql.optimizer.transformer.ExpressionMapping;
 import com.starrocks.sql.optimizer.transformer.LogicalPlan;
 import com.starrocks.sql.optimizer.transformer.RelationTransformer;
 import com.starrocks.sql.optimizer.transformer.SqlToScalarOperatorTranslator;
@@ -111,14 +92,12 @@ import org.apache.commons.collections4.SetUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
-import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
-import java.util.Optional;
 import java.util.Set;
 import java.util.TreeSet;
 import java.util.function.Function;
@@ -462,27 +441,6 @@ public class MvUtils {
                 new ColumnRefSet(logicalPlan.getOutputColumn()),
                 columnRefFactory);
         return Pair.create(optimizedPlan, logicalPlan);
-    }
-
-    public static List<OptExpression> collectScanExprs(OptExpression expression) {
-        List<OptExpression> scanExprs = Lists.newArrayList();
-        OptExpressionVisitor scanCollector = new OptExpressionVisitor<Void, Void>() {
-            @Override
-            public Void visit(OptExpression optExpression, Void context) {
-                for (OptExpression input : optExpression.getInputs()) {
-                    super.visit(input, context);
-                }
-                return null;
-            }
-
-            @Override
-            public Void visitLogicalTableScan(OptExpression optExpression, Void context) {
-                scanExprs.add(optExpression);
-                return null;
-            }
-        };
-        expression.getOp().accept(scanCollector, expression, null);
-        return scanExprs;
     }
 
     public static List<OptExpression> collectJoinExpr(OptExpression expression) {
@@ -878,58 +836,6 @@ public class MvUtils {
         return columnRefOperators;
     }
 
-    public static ScalarOperator convertListPartitionKeys(ScalarOperator partitionColRef,
-                                                          List<Range<PartitionKey>> partitionRanges) {
-        List<ScalarOperator> inArgs = Lists.newArrayList();
-        inArgs.add(partitionColRef);
-        for (Range<PartitionKey> range : partitionRanges) {
-            if (range.isEmpty()) {
-                continue;
-            }
-
-            // see `convertToDateRange`
-            if (range.hasLowerBound() && range.hasUpperBound()) {
-                // partition range must have lower bound and upper bound
-                ConstantOperator lowerBound =
-                        (ConstantOperator) SqlToScalarOperatorTranslator.translate(range.lowerEndpoint().getKeys().get(0));
-                ConstantOperator upperBound =
-                        (ConstantOperator) SqlToScalarOperatorTranslator.translate(range.upperEndpoint().getKeys().get(0));
-                Preconditions.checkState(lowerBound.getType().isStringType());
-                Preconditions.checkState(upperBound.getType().isStringType());
-                inArgs.add(lowerBound);
-            } else if (range.hasUpperBound()) {
-                ConstantOperator upperBound =
-                        (ConstantOperator) SqlToScalarOperatorTranslator.translate(range.upperEndpoint().getKeys().get(0));
-                Preconditions.checkState(upperBound.getType().isStringType());
-                inArgs.add(upperBound);
-            } else if (range.hasLowerBound()) {
-                ConstantOperator lowerBound =
-                        (ConstantOperator) SqlToScalarOperatorTranslator.translate(range.lowerEndpoint().getKeys().get(0));
-                Preconditions.checkState(lowerBound.getType().isStringType());
-                inArgs.add(lowerBound);
-            } else {
-                // continue
-            }
-        }
-        if (inArgs.size() == 1) {
-            return ConstantOperator.TRUE;
-        } else {
-            return new InPredicateOperator(false, inArgs);
-        }
-    }
-
-    public static ScalarOperator convertPartitionKeysToPredicate(ScalarOperator partitionColumn,
-                                                                 List<Range<PartitionKey>> partitionKeys) {
-        boolean isListPartition = partitionColumn.getType().isStringType();
-        // NOTE: For string type partition column, it should be list partition rather than range partition.
-        if (isListPartition) {
-            return convertListPartitionKeys(partitionColumn, partitionKeys);
-        } else {
-            List<ScalarOperator> rangePredicates = MvUtils.convertRanges(partitionColumn, partitionKeys);
-            return Utils.compoundOr(rangePredicates);
-        }
-    }
-
     public static List<ScalarOperator> convertRanges(ScalarOperator partitionScalar,
                                                      List<Range<PartitionKey>> partitionRanges) {
         List<ScalarOperator> rangeParts = Lists.newArrayList();
@@ -1039,450 +945,6 @@ public class MvUtils {
         return mergedRanges;
     }
 
-    private static boolean supportCompensatePartitionPredicateForHiveScan(List<PartitionKey> partitionKeys) {
-        for (PartitionKey partitionKey : partitionKeys) {
-            // only support one partition column now.
-            if (partitionKey.getKeys().size() != 1) {
-                return false;
-            }
-            LiteralExpr e = partitionKey.getKeys().get(0);
-            // Only support date/int type
-            if (!(e instanceof DateLiteral || e instanceof IntLiteral)) {
-                return false;
-            }
-        }
-        return true;
-    }
-
-    public static List<ScalarOperator> compensatePartitionPredicateForHiveScan(LogicalHiveScanOperator scanOperator) {
-        ScanOperatorPredicates scanOperatorPredicates = scanOperator.getScanOperatorPredicates();
-        List<ScalarOperator> partitionPredicates = Lists.newArrayList();
-
-        Preconditions.checkState(scanOperator.getTable().isHiveTable());
-        HiveTable hiveTable = (HiveTable) scanOperator.getTable();
-        if (hiveTable.isUnPartitioned()) {
-            return partitionPredicates;
-        }
-        if (scanOperatorPredicates.getSelectedPartitionIds().size() ==
-                scanOperatorPredicates.getIdToPartitionKey().size()) {
-            return partitionPredicates;
-        }
-        if (!supportCompensatePartitionPredicateForHiveScan(scanOperatorPredicates.getSelectedPartitionKeys())) {
-            return partitionPredicates;
-        }
-        List<Range<PartitionKey>> ranges = Lists.newArrayList();
-        for (PartitionKey selectedPartitionKey : scanOperatorPredicates.getSelectedPartitionKeys()) {
-            try {
-                LiteralExpr expr = PartitionUtil.addOffsetForLiteral(selectedPartitionKey.getKeys().get(0), 1,
-                        PartitionUtil.getDateTimeInterval(hiveTable, hiveTable.getPartitionColumns().get(0)));
-                PartitionKey partitionKey = new PartitionKey(ImmutableList.of(expr), selectedPartitionKey.getTypes());
-                ranges.add(Range.closedOpen(selectedPartitionKey, partitionKey));
-            } catch (AnalysisException e) {
-                LOG.warn("Compute partition key range failed. ", e);
-                return partitionPredicates;
-            }
-        }
-
-        List<Range<PartitionKey>> mergedRanges = mergeRanges(ranges);
-        ColumnRefOperator partitionColumnRef = scanOperator.getColumnReference(hiveTable.getPartitionColumns().get(0));
-        ScalarOperator partitionPredicate = convertPartitionKeysToPredicate(partitionColumnRef, mergedRanges);
-        if (partitionPredicate != null) {
-            partitionPredicates.add(partitionPredicate);
-        }
-
-        return partitionPredicates;
-    }
-
-    public static final ImmutableList<OperatorType> SUPPORTED_PARTITION_COMPENSATE_SCAN_TYPES =
-            ImmutableList.<OperatorType>builder()
-            .add(OperatorType.LOGICAL_OLAP_SCAN)
-            .add(OperatorType.LOGICAL_HIVE_SCAN)
-            .build();
-    /**
-     * - if `isCompensate` is true, use `selectedPartitionIds` to compensate complete partition ranges
-     *  with lower and upper bound.
-     * - otherwise use original pruned partition predicates as the compensated partition
-     *  predicates.
-     * NOTE: When MV has enough partitions for the query, no need to compensate anymore for both mv and the query's plan.
-     *       A query can be rewritten just by the original SQL.
-     * NOTE: It's not safe if `isCompensate` is always false:
-     *      - partitionPredicate is null if olap scan operator cannot prune partitions.
-     *      - partitionPredicate is not exact even if olap scan operator has pruned partitions.
-     * eg:
-     *      t1:
-     *       PARTITION p1 VALUES [("0000-01-01"), ("2020-01-01")), has data
-     *       PARTITION p2 VALUES [("2020-01-01"), ("2020-02-01")), has data
-     *       PARTITION p3 VALUES [("2020-02-01"), ("2020-03-01")), has data
-     *       PARTITION p4 VALUES [("2020-03-01"), ("2020-04-01")), no data
-     *       PARTITION p5 VALUES [("2020-04-01"), ("2020-05-01")), no data
-     *
-     *      query1 : SELECT k1, sum(v1) as sum_v1 FROM t1 group by k1;
-     *      `partitionPredicate` : null
-     *
-     *      query2 : SELECT k1, sum(v1) as sum_v1 FROM t1 where k1>='2020-02-01' group by k1;
-     *      `partitionPredicate` : k1>='2020-02-11'
-     *      however for mv  we need: k1>='2020-02-11' and k1 < "2020-03-01"
-     */
-    public static ScalarOperator compensatePartitionPredicate(MaterializationContext mvContext,
-                                                              ColumnRefFactory columnRefFactory,
-                                                              OptExpression queryExpression) {
-        List<LogicalScanOperator> scanOperators = MvUtils.getScanOperator(queryExpression);
-        if (scanOperators.isEmpty()) {
-            return ConstantOperator.createBoolean(true);
-        }
-
-        List<ScalarOperator> partitionPredicates = Lists.newArrayList();
-        boolean isCompensatePartition = mvContext.getOrInitCompensatePartitionPredicate(queryExpression);
-        // Compensate partition predicates and add them into query predicate.
-        Map<Pair<LogicalScanOperator, Boolean>, List<ScalarOperator>> scanOperatorScalarOperatorMap =
-                mvContext.getScanOpToPartitionCompensatePredicates();
-        for (LogicalScanOperator scanOperator : scanOperators) {
-            if (!SUPPORTED_PARTITION_COMPENSATE_SCAN_TYPES.contains(scanOperator.getOpType())) {
-                continue;
-            }
-            List<ScalarOperator> partitionPredicate = scanOperatorScalarOperatorMap
-                    .computeIfAbsent(Pair.create(scanOperator, isCompensatePartition), x -> {
-                        return isCompensatePartition ? getCompensatePartitionPredicates(columnRefFactory, scanOperator) :
-                                getScanOpPrunedPartitionPredicates(scanOperator);
-                    });
-            if (partitionPredicate == null) {
-                return null;
-            }
-            partitionPredicates.addAll(partitionPredicate);
-        }
-        return partitionPredicates.isEmpty() ? ConstantOperator.createBoolean(true) :
-                Utils.compoundAnd(partitionPredicates);
-    }
-
-    private static List<ScalarOperator> getCompensatePartitionPredicates(ColumnRefFactory columnRefFactory,
-                                                                         LogicalScanOperator scanOperator) {
-        List<ScalarOperator> partitionPredicate = null;
-        if (scanOperator instanceof LogicalOlapScanOperator) {
-            partitionPredicate = compensatePartitionPredicateForOlapScan((LogicalOlapScanOperator) scanOperator,
-                    columnRefFactory);
-        } else if (scanOperator instanceof LogicalHiveScanOperator) {
-            partitionPredicate = compensatePartitionPredicateForHiveScan((LogicalHiveScanOperator) scanOperator);
-        } else {
-            return null;
-        }
-        return partitionPredicate;
-    }
-
-    /**
-     * Determine whether to compensate extra partition predicates,
-     * - if it needs compensate, use `selectedPartitionIds` to compensate complete partition ranges
-     *  with lower and upper bound.
-     * - if not compensate, use original pruned partition predicates as the compensated partition
-     *  predicates.
-     * @param plan : query opt expression
-     * @param mvContext : materialized view context
-     * @return
-     */
-    public static Optional<Boolean> isNeedCompensatePartitionPredicate(OptExpression plan,
-                                                                       MaterializationContext mvContext) {
-        Set<String> mvPartitionNameToRefresh = mvContext.getMvPartitionNamesToRefresh();
-        // If mv contains no partitions to refresh, no need compensate
-        if (Objects.isNull(mvPartitionNameToRefresh) || mvPartitionNameToRefresh.isEmpty()) {
-            return Optional.of(false);
-        }
-
-        // If ref table contains no partitions to refresh, no need compensate.
-        // If the mv is partitioned and non-ref table need refresh, then all partitions need to be refreshed,
-        // it can not be a candidate.
-        Set<String> refTablePartitionNameToRefresh = mvContext.getRefTableUpdatePartitionNames();
-        if (Objects.isNull(refTablePartitionNameToRefresh) || refTablePartitionNameToRefresh.isEmpty()) {
-            // NOTE: This should not happen: `mvPartitionNameToRefresh` is not empty, so `refTablePartitionNameToRefresh`
-            // should not empty. Return true in the situation to avoid bad cases.
-            return Optional.of(true);
-        }
-
-        List<LogicalScanOperator> scanOperators = MvUtils.getScanOperator(plan);
-        // If no scan operator, no need compensate
-        if (scanOperators.isEmpty()) {
-            return Optional.of(false);
-        }
-        if (scanOperators.stream().anyMatch(scan -> scan instanceof LogicalViewScanOperator)) {
-            return Optional.of(true);
-        }
-
-        // If no partition table and columns, no need compensate
-        MaterializedView mv = mvContext.getMv();
-        Pair<Table, Column> partitionTableAndColumns = mv.getDirectTableAndPartitionColumn();
-        if (partitionTableAndColumns == null) {
-            return Optional.of(false);
-        }
-        Table refBaseTable = partitionTableAndColumns.first;
-        Optional<LogicalScanOperator> optRefScanOperator =
-                scanOperators.stream().filter(x -> isRefBaseTable(x, refBaseTable)).findFirst();
-        if (!optRefScanOperator.isPresent()) {
-            return Optional.empty();
-        }
-
-        LogicalScanOperator scanOperator = optRefScanOperator.get();
-        if (scanOperator instanceof LogicalOlapScanOperator) {
-            LogicalOlapScanOperator olapScanOperator = (LogicalOlapScanOperator) scanOperator;
-            OlapTable olapTable = (OlapTable) olapScanOperator.getTable();
-            // If table's not partitioned, no need compensate
-            if (olapTable.getPartitionInfo() instanceof SinglePartitionInfo) {
-                return Optional.of(false);
-            }
-
-            List<Long> selectPartitionIds = olapScanOperator.getSelectedPartitionId();
-            if (Objects.isNull(selectPartitionIds) || selectPartitionIds.size() == 0) {
-                return Optional.of(false);
-            }
-
-            // determine whether query's partitions can be satisfied by materialized view.
-            for (Long selectPartitionId : selectPartitionIds) {
-                Partition partition = olapTable.getPartition(selectPartitionId);
-                if (partition != null && refTablePartitionNameToRefresh.contains(partition.getName())) {
-                    return Optional.of(true);
-                }
-            }
-            return Optional.of(false);
-        } else if (scanOperator instanceof LogicalHiveScanOperator) {
-            HiveTable hiveTable = (HiveTable) scanOperator.getTable();
-            // If table's not partitioned, no need compensate
-            if (hiveTable.isUnPartitioned()) {
-                return Optional.of(false);
-            }
-            LogicalHiveScanOperator hiveScanOperator = (LogicalHiveScanOperator)  scanOperator;
-            ScanOperatorPredicates scanOperatorPredicates = hiveScanOperator.getScanOperatorPredicates();
-            Collection<Long> selectPartitionIds = scanOperatorPredicates.getSelectedPartitionIds();
-            if (Objects.isNull(selectPartitionIds) || selectPartitionIds.size() == 0) {
-                return Optional.of(false);
-            }
-            // determine whether query's partitions can be satisfied by materialized view.
-            List<PartitionKey> selectPartitionKeys = scanOperatorPredicates.getSelectedPartitionKeys();
-            for (PartitionKey partitionKey : selectPartitionKeys) {
-                String mvPartitionName = PartitionUtil.generateMVPartitionName(partitionKey);
-                if (refTablePartitionNameToRefresh.contains(mvPartitionName)) {
-                    return Optional.of(true);
-                }
-            }
-            return Optional.of(false);
-        } else {
-            return Optional.of(true);
-        }
-    }
-
-    /**
-     * Compensate olap table's partition predicates from olap scan operator which may be pruned by optimizer before or not.
-     *
-     * @param olapScanOperator   : olap scan operator that needs to compensate partition predicates.
-     * @param columnRefFactory   : column ref factory that used to generate new partition predicate epxr.
-     * @return
-     */
-    private static List<ScalarOperator> compensatePartitionPredicateForOlapScan(LogicalOlapScanOperator olapScanOperator,
-                                                                                ColumnRefFactory columnRefFactory) {
-        List<ScalarOperator> partitionPredicates = Lists.newArrayList();
-        Preconditions.checkState(olapScanOperator.getTable().isNativeTableOrMaterializedView());
-        OlapTable olapTable = (OlapTable) olapScanOperator.getTable();
-
-        // compensate nothing for single partition table
-        if (olapTable.getPartitionInfo() instanceof SinglePartitionInfo) {
-            return partitionPredicates;
-        }
-
-        // compensate nothing if selected partitions are the same with the total partitions.
-        if (olapScanOperator.getSelectedPartitionId() != null
-                && olapScanOperator.getSelectedPartitionId().size() == olapTable.getPartitions().size()) {
-            return partitionPredicates;
-        }
-
-        // if no partitions are selected, return pruned partition predicates directly.
-        if (olapScanOperator.getSelectedPartitionId().isEmpty()) {
-            return olapScanOperator.getPrunedPartitionPredicates();
-        }
-
-        if (olapTable.getPartitionInfo() instanceof ExpressionRangePartitionInfo) {
-            ExpressionRangePartitionInfo partitionInfo =
-                    (ExpressionRangePartitionInfo) olapTable.getPartitionInfo();
-            Expr partitionExpr = partitionInfo.getPartitionExprs().get(0);
-            List<SlotRef> slotRefs = Lists.newArrayList();
-            partitionExpr.collect(SlotRef.class, slotRefs);
-            Preconditions.checkState(slotRefs.size() == 1);
-            Optional<ColumnRefOperator> partitionColumn =
-                    olapScanOperator.getColRefToColumnMetaMap().keySet().stream()
-                            .filter(columnRefOperator -> columnRefOperator.getName()
-                                    .equals(slotRefs.get(0).getColumnName()))
-                            .findFirst();
-            // compensate nothing if there is no partition column predicate in the scan node.
-            if (!partitionColumn.isPresent()) {
-                return null;
-            }
-
-            ExpressionMapping mapping =
-                    new ExpressionMapping(new Scope(RelationId.anonymous(), new RelationFields()));
-            mapping.put(slotRefs.get(0), partitionColumn.get());
-            ScalarOperator partitionScalarOperator =
-                    SqlToScalarOperatorTranslator.translate(partitionExpr, mapping, columnRefFactory);
-            List<Range<PartitionKey>> selectedRanges = Lists.newArrayList();
-            // compensate selected partition ranges from selected partition id
-            for (long pid : olapScanOperator.getSelectedPartitionId()) {
-                selectedRanges.add(partitionInfo.getRange(pid));
-            }
-
-            // normalize selected partition ranges
-            List<Range<PartitionKey>> mergedRanges = MvUtils.mergeRanges(selectedRanges);
-            ScalarOperator partitionPredicate =
-                    convertPartitionKeysToPredicate(partitionScalarOperator, mergedRanges);
-            partitionPredicates.add(partitionPredicate);
-        } else if (olapTable.getPartitionInfo() instanceof RangePartitionInfo) {
-            RangePartitionInfo rangePartitionInfo = (RangePartitionInfo) olapTable.getPartitionInfo();
-            List<Column> partitionColumns = rangePartitionInfo.getPartitionColumns();
-            if (partitionColumns.size() != 1) {
-                // now do not support more than one partition columns
-                return null;
-            }
-            List<Range<PartitionKey>> selectedRanges = Lists.newArrayList();
-            for (long pid : olapScanOperator.getSelectedPartitionId()) {
-                selectedRanges.add(rangePartitionInfo.getRange(pid));
-            }
-            ColumnRefOperator partitionColumnRef = olapScanOperator.getColumnReference(partitionColumns.get(0));
-            List<Range<PartitionKey>> mergedRanges = MvUtils.mergeRanges(selectedRanges);
-            ScalarOperator partitionPredicate =
-                    convertPartitionKeysToPredicate(partitionColumnRef, mergedRanges);
-            if (partitionPredicate != null) {
-                partitionPredicates.add(partitionPredicate);
-            }
-        } else {
-            return null;
-        }
-
-        return partitionPredicates;
-    }
-
-    // try to get partial partition predicates of partitioned mv.
-    // eg, mv1's base partition table is t1, partition column is k1 and has two partition:
-    // p1:[2022-01-01, 2022-01-02), p1 is updated(refreshed),
-    // p2:[2022-01-02, 2022-01-03), p2 is outdated,
-    // then this function will return predicate:
-    // k1 >= "2022-01-01" and k1 < "2022-01-02"
-    // NOTE: This method can be only used in query rewrite and cannot be used in insert routine.
-    public static ScalarOperator getMvPartialPartitionPredicates(
-            MaterializedView mv,
-            OptExpression mvPlan,
-            Set<String> mvPartitionNamesToRefresh) throws AnalysisException {
-        Pair<Table, Column> partitionTableAndColumns = mv.getDirectTableAndPartitionColumn();
-        if (partitionTableAndColumns == null) {
-            return null;
-        }
-
-        Table refBaseTable = partitionTableAndColumns.first;
-        List<Range<PartitionKey>> latestBaseTableRanges =
-                getLatestPartitionRangeForTable(refBaseTable, partitionTableAndColumns.second,
-                        mv, mvPartitionNamesToRefresh);
-        if (latestBaseTableRanges.isEmpty()) {
-            // if there isn't an updated partition, do not rewrite
-            return null;
-        }
-
-        Column partitionColumn = partitionTableAndColumns.second;
-        List<OptExpression> scanExprs = MvUtils.collectScanExprs(mvPlan);
-        Expr partitionExpr = mv.getFirstPartitionRefTableExpr();
-        for (OptExpression scanExpr : scanExprs) {
-            LogicalScanOperator scanOperator = (LogicalScanOperator) scanExpr.getOp();
-            if (!isRefBaseTable(scanOperator, refBaseTable)) {
-                continue;
-            }
-            final Optional<ColumnRefOperator> columnRefOption;
-            if (scanOperator instanceof LogicalViewScanOperator) {
-                LogicalViewScanOperator viewScanOperator = scanOperator.cast();
-                columnRefOption = Optional.ofNullable(viewScanOperator.getExpressionMapping(partitionExpr));
-            } else {
-                columnRefOption = Optional.ofNullable(scanOperator.getColumnReference(partitionColumn));
-            }
-            if (!columnRefOption.isPresent()) {
-                continue;
-            }
-            return convertPartitionKeysToPredicate(columnRefOption.get(), latestBaseTableRanges);
-        }
-        return null;
-    }
-
-    public static List<ScalarOperator> getMVPrunedPartitionPredicates(MaterializedView mv,
-                                                                      OptExpression mvPlan) {
-        Pair<Table, Column> partitionTableAndColumns = mv.getDirectTableAndPartitionColumn();
-        if (partitionTableAndColumns == null) {
-            return null;
-        }
-
-        Table refBaseTable = partitionTableAndColumns.first;
-        List<OptExpression> scanExprs = MvUtils.collectScanExprs(mvPlan);
-        for (OptExpression scanExpr : scanExprs) {
-            LogicalScanOperator scanOperator = (LogicalScanOperator) scanExpr.getOp();
-            if (!isRefBaseTable(scanOperator, refBaseTable)) {
-                continue;
-            }
-
-            List<ScalarOperator> prunedPredicates = getScanOpPrunedPartitionPredicates(scanOperator);
-            if (prunedPredicates == null || prunedPredicates.isEmpty()) {
-                return List.of(ConstantOperator.TRUE);
-            } else {
-                return prunedPredicates;
-            }
-        }
-        return null;
-    }
-
-    private static List<ScalarOperator> getScanOpPrunedPartitionPredicates(LogicalScanOperator scanOperator) {
-        if (scanOperator == null) {
-            return null;
-        }
-
-        if (scanOperator instanceof LogicalOlapScanOperator) {
-            return ((LogicalOlapScanOperator) scanOperator).getPrunedPartitionPredicates();
-        } else if (scanOperator instanceof LogicalHiveScanOperator) {
-            ScanOperatorPredicates scanOperatorPredicates =
-                    ((LogicalHiveScanOperator) scanOperator).getScanOperatorPredicates();
-            return scanOperatorPredicates.getPrunedPartitionConjuncts();
-        } else {
-            // Cannot decide whether it has been pruned or not, return null for now.
-            return null;
-        }
-    }
-
-    private static boolean isRefBaseTable(LogicalScanOperator scanOperator, Table refBaseTable) {
-        Table scanTable = scanOperator.getTable();
-        if (scanTable.isNativeTableOrMaterializedView() && !scanTable.equals(refBaseTable)) {
-            return false;
-        }
-        if (scanOperator instanceof LogicalViewScanOperator) {
-            return true;
-        }
-        if (!scanTable.isNativeTableOrMaterializedView() && !scanTable.getTableIdentifier().equals(
-                refBaseTable.getTableIdentifier())) {
-            return false;
-        }
-        return true;
-    }
-
-    // convert varchar date to date type
-    public static Range<PartitionKey> convertToDateRange(Range<PartitionKey> from) throws AnalysisException {
-        if (from.hasLowerBound() && from.hasUpperBound()) {
-            StringLiteral lowerString = (StringLiteral) from.lowerEndpoint().getKeys().get(0);
-            LocalDateTime lowerDateTime = DateUtils.parseDatTimeString(lowerString.getStringValue());
-            PartitionKey lowerPartitionKey = PartitionKey.ofDate(lowerDateTime.toLocalDate());
-
-            StringLiteral upperString = (StringLiteral) from.upperEndpoint().getKeys().get(0);
-            LocalDateTime upperDateTime = DateUtils.parseDatTimeString(upperString.getStringValue());
-            PartitionKey upperPartitionKey = PartitionKey.ofDate(upperDateTime.toLocalDate());
-            return Range.range(lowerPartitionKey, from.lowerBoundType(), upperPartitionKey, from.upperBoundType());
-        } else if (from.hasUpperBound()) {
-            StringLiteral upperString = (StringLiteral) from.upperEndpoint().getKeys().get(0);
-            LocalDateTime upperDateTime = DateUtils.parseDatTimeString(upperString.getStringValue());
-            PartitionKey upperPartitionKey = PartitionKey.ofDate(upperDateTime.toLocalDate());
-            return Range.upTo(upperPartitionKey, from.upperBoundType());
-        } else if (from.hasLowerBound()) {
-            StringLiteral lowerString = (StringLiteral) from.lowerEndpoint().getKeys().get(0);
-            LocalDateTime lowerDateTime = DateUtils.parseDatTimeString(lowerString.getStringValue());
-            PartitionKey lowerPartitionKey = PartitionKey.ofDate(lowerDateTime.toLocalDate());
-            return Range.downTo(lowerPartitionKey, from.lowerBoundType());
-        }
-        return Range.all();
-    }
-
     public static boolean isDateRange(Range<PartitionKey> range) {
         if (range.hasUpperBound()) {
             PartitionKey partitionKey = range.upperEndpoint();
@@ -1523,91 +985,7 @@ public class MvUtils {
         return partitionKey;
     }
 
-    /**
-     * Return the updated partition key ranges of the specific table.
-     *
-     * NOTE: This method can be only used in query rewrite and cannot be used to insert routine.
-     * @param partitionByTable          : the base table of the mv
-     * @param partitionColumn           : the partition column of the base table
-     * @param mv                        : the materialized view
-     * @param mvPartitionNamesToRefresh : the updated partition names  of the materialized view
-     * @return
-     */
-    private static List<Range<PartitionKey>> getLatestPartitionRangeForTable(
-            Table partitionByTable,
-            Column partitionColumn,
-            MaterializedView mv,
-            Set<String> mvPartitionNamesToRefresh) throws AnalysisException {
-        Set<String> refBaseTableUpdatedPartitionNames = mv.getUpdatedPartitionNamesOfTable(partitionByTable, true);
-        List<Range<PartitionKey>> refBaseTableRanges = getLatestPartitionRange(partitionByTable, partitionColumn,
-                refBaseTableUpdatedPartitionNames, MaterializedView.getPartitionExpr(mv));
-        // date to varchar range
-        Map<Range<PartitionKey>, Range<PartitionKey>> baseRangeMapping = null;
-        boolean isConvertToDate = PartitionUtil.isConvertToDate(mv.getFirstPartitionRefTableExpr(), partitionColumn);
-        if (isConvertToDate) {
-            baseRangeMapping = Maps.newHashMap();
-            // convert varchar range to date range
-            List<Range<PartitionKey>> baseTableDateRanges = Lists.newArrayList();
-            for (Range<PartitionKey> range : refBaseTableRanges) {
-                Range<PartitionKey> datePartitionRange = convertToDateRange(range);
-                baseTableDateRanges.add(datePartitionRange);
-                baseRangeMapping.put(datePartitionRange, range);
-            }
-            refBaseTableRanges = baseTableDateRanges;
-        }
-        // materialized view latest partition ranges except to-refresh partitions
-        List<Range<PartitionKey>> mvRanges = getLatestPartitionRangeForNativeTable(mv, mvPartitionNamesToRefresh);
 
-        List<Range<PartitionKey>> latestBaseTableRanges = Lists.newArrayList();
-        for (Range<PartitionKey> range : refBaseTableRanges) {
-            // if materialized view's partition range can enclose the ref base table range, we think that
-            // the materialized view's partition has been refreshed and should be compensated into the materialized
-            // view's partition predicate.
-            if (mvRanges.stream().anyMatch(mvRange -> mvRange.encloses(range))) {
-                latestBaseTableRanges.add(range);
-            }
-        }
-        if (isConvertToDate) {
-            // treat string type partition as list, so no need merge
-            List<Range<PartitionKey>> tmpRangeList = Lists.newArrayList();
-            for (Range<PartitionKey> range : latestBaseTableRanges) {
-                tmpRangeList.add(baseRangeMapping.get(range));
-            }
-            return tmpRangeList;
-        } else {
-            return MvUtils.mergeRanges(latestBaseTableRanges);
-        }
-    }
-
-    private static List<Range<PartitionKey>> getLatestPartitionRangeForNativeTable(OlapTable partitionTable,
-                                                                                   Set<String> modifiedPartitionNames) {
-        // partitions that will be excluded
-        Set<Long> filteredIds = Sets.newHashSet();
-        for (Partition p : partitionTable.getPartitions()) {
-            if (modifiedPartitionNames.contains(p.getName()) || !p.hasData()) {
-                filteredIds.add(p.getId());
-            }
-        }
-        RangePartitionInfo rangePartitionInfo = (RangePartitionInfo) partitionTable.getPartitionInfo();
-        return rangePartitionInfo.getRangeList(filteredIds, false);
-    }
-
-    private static List<Range<PartitionKey>> getLatestPartitionRange(
-            Table table, Column partitionColumn, Set<String> modifiedPartitionNames, Expr partitionExpr) {
-        if (table.isNativeTableOrMaterializedView()) {
-            return getLatestPartitionRangeForNativeTable((OlapTable) table, modifiedPartitionNames);
-        } else {
-            Map<String, Range<PartitionKey>> partitionMap;
-            try {
-                partitionMap = PartitionUtil.getPartitionKeyRange(table, partitionColumn, partitionExpr);
-            } catch (UserException e) {
-                LOG.warn("Materialized view Optimizer compute partition range failed.", e);
-                return Lists.newArrayList();
-            }
-            return partitionMap.entrySet().stream().filter(entry -> !modifiedPartitionNames.contains(entry.getKey())).
-                    map(Map.Entry::getValue).collect(Collectors.toList());
-        }
-    }
 
     public static String toString(Object o) {
         if (o == null) {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/rule/BaseMaterializedViewRewriteRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/rule/BaseMaterializedViewRewriteRule.java
@@ -42,6 +42,7 @@ import com.starrocks.sql.optimizer.rule.transformation.materialization.BestMvSel
 import com.starrocks.sql.optimizer.rule.transformation.materialization.MVColumnPruner;
 import com.starrocks.sql.optimizer.rule.transformation.materialization.MVPartitionPruner;
 import com.starrocks.sql.optimizer.rule.transformation.materialization.MaterializedViewRewriter;
+import com.starrocks.sql.optimizer.rule.transformation.materialization.MvPartitionCompensator;
 import com.starrocks.sql.optimizer.rule.transformation.materialization.MvUtils;
 import com.starrocks.sql.optimizer.rule.transformation.materialization.PredicateSplit;
 import org.apache.commons.collections4.CollectionUtils;
@@ -218,7 +219,7 @@ public abstract class BaseMaterializedViewRewriteRule extends TransformationRule
                                                   ReplaceColumnRefRewriter queryColumnRefRewriter) {
         // Cache partition predicate predicates because it's expensive time costing if there are too many materialized views or
         // query expressions are too complex.
-        final ScalarOperator queryPartitionPredicate = MvUtils.compensatePartitionPredicate(mvContext,
+        final ScalarOperator queryPartitionPredicate = MvPartitionCompensator.compensatePartitionPredicate(mvContext,
                 queryColumnRefFactory, queryExpression);
         if (queryPartitionPredicate == null) {
             logMVRewrite(mvContext.getOptimizerContext(), this, "Compensate query expression's partition " +

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvRewritePreprocessorTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvRewritePreprocessorTest.java
@@ -38,6 +38,7 @@ import com.starrocks.sql.optimizer.base.PhysicalPropertySet;
 import com.starrocks.sql.optimizer.operator.OperatorType;
 import com.starrocks.sql.optimizer.operator.logical.LogicalFilterOperator;
 import com.starrocks.sql.optimizer.operator.logical.LogicalOlapScanOperator;
+import com.starrocks.sql.optimizer.operator.logical.LogicalScanOperator;
 import com.starrocks.sql.optimizer.operator.logical.LogicalTreeAnchorOperator;
 import com.starrocks.sql.optimizer.operator.pattern.Pattern;
 import com.starrocks.sql.optimizer.operator.physical.PhysicalOlapScanOperator;
@@ -266,7 +267,7 @@ public class MvRewritePreprocessorTest extends MvRewriteTestBase {
             MaterializationContext materializationContext3 =
                     optimizer3.getContext().getCandidateMvs().iterator().next();
             Assert.assertEquals("mv_5", materializationContext3.getMv().getName());
-            List<OptExpression> scanExpr3 = MvUtils.collectScanExprs(materializationContext3.getMvExpression());
+            List<LogicalScanOperator> scanExpr3 = MvUtils.getScanOperator(materializationContext3.getMvExpression());
             Assert.assertEquals(1, scanExpr3.size());
             ScalarOperator scalarOperator3 = materializationContext3.getMvPartialPartitionPredicate();
             if (scalarOperator3 != null) {

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvUtilsTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvUtilsTest.java
@@ -45,6 +45,8 @@ import org.junit.Test;
 
 import java.util.Set;
 
+import static com.starrocks.sql.optimizer.rule.transformation.materialization.MvPartitionCompensator.convertToDateRange;
+
 public class MvUtilsTest {
     private static ConnectContext connectContext;
     private static StarRocksAssert starRocksAssert;
@@ -156,7 +158,7 @@ public class MvUtilsTest {
         {
             PartitionKey upper = PartitionKey.ofString("20231010");
             Range<PartitionKey> upRange = Range.atMost(upper);
-            Range<PartitionKey> upResult = MvUtils.convertToDateRange(upRange);
+            Range<PartitionKey> upResult = convertToDateRange(upRange);
             Assert.assertTrue(upResult.hasUpperBound());
             Assert.assertTrue(upResult.upperEndpoint().getTypes().get(0).isDateType());
             Assert.assertTrue(upResult.upperEndpoint().getKeys().get(0) instanceof DateLiteral);
@@ -169,7 +171,7 @@ public class MvUtilsTest {
         {
             PartitionKey lower = PartitionKey.ofString("20231010");
             Range<PartitionKey> lowRange = Range.atLeast(lower);
-            Range<PartitionKey> lowResult = MvUtils.convertToDateRange(lowRange);
+            Range<PartitionKey> lowResult = convertToDateRange(lowRange);
             Assert.assertTrue(lowResult.hasLowerBound());
             Assert.assertTrue(lowResult.lowerEndpoint().getTypes().get(0).isDateType());
             Assert.assertTrue(lowResult.lowerEndpoint().getKeys().get(0) instanceof DateLiteral);
@@ -183,7 +185,7 @@ public class MvUtilsTest {
             PartitionKey lower = PartitionKey.ofString("20231010");
             Range<PartitionKey> range = Range.atLeast(lower);
             range = range.intersection(Range.atMost(PartitionKey.ofString("20231020")));
-            Range<PartitionKey> result = MvUtils.convertToDateRange(range);
+            Range<PartitionKey> result = convertToDateRange(range);
             Assert.assertTrue(result.hasLowerBound());
             Assert.assertTrue(result.lowerEndpoint().getTypes().get(0).isDateType());
             Assert.assertTrue(result.lowerEndpoint().getKeys().get(0) instanceof DateLiteral);


### PR DESCRIPTION
## Why I'm doing:
Since #32659 supports partition prune for iceberg table in optimizer rule.

MV Rewrite can use it to compensate partitions for mv rewrite just like OlapTable and Hive.

So we can supports query better like this(mv with ttl)
```
create materialized view __itest_mv0
distributed by random
properties('partition_ttl_number'='1')
partition by str2date(dt,'%Y%m%d')
as select * from hive.hive_mv_test.tbl1;

explain select * from hive.hive_mv_test.tbl1 where dt >= "20230927" and dt <  "20230928"
```
## What I'm doing:
- Split `MvUtils` methods into `MvPartitionCompensator` which represents all partition compensations' method.
- Support iceberg partition compensation for mv rewrite.

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
