### PR TITLE
[BugFix][branch-3.1] fix compilation errors when WITH_CACHELIB=ON

### DIFF
--- a/be/src/block_cache/cachelib_wrapper.h
+++ b/be/src/block_cache/cachelib_wrapper.h
@@ -50,7 +50,7 @@ public:
 
     Status remove_cache(const std::string& key) override;
 
-    std::unordered_map<std::string, double> cache_stats() override;
+    std::unordered_map<std::string, double> cache_stats();
 
     const DataCacheMetrics cache_metrics() override;
 


### PR DESCRIPTION
## Why I'm doing:
fix compilation errors in 3.1 when WITH_CACHELIB=ON:
```
In file included from /data/starrocks/be/src/block_cache/block_cache.cpp:22:
/data/starrocks/be/src/block_cache/cachelib_wrapper.h:53:45: error: 'std::unordered_map<std::__cxx11::basic_string<char>, double> starrocks::CacheLibWrapper::cache_stats()' marked 'override', but does not override
   53 |     std::unordered_map<std::string, double> cache_stats() override;
      |                                             ^~~~~~~~~~~

In file included from /data/starrocks/be/src/block_cache/cachelib_wrapper.cpp:15:
/data/starrocks/be/src/block_cache/cachelib_wrapper.h:53:45: error: 'std::unordered_map<std::__cxx11::basic_string<char>, double> starrocks::CacheLibWrapper::cache_stats()' marked 'override', but does not override
   53 |     std::unordered_map<std::string, double> cache_stats() override;
```
## What I'm doing:

remove override keyword. 
Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
- [ ] I have added documentation for my new feature or new function
- [x] This is a backport pr

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5

