### PR TITLE
[BugFix] Fix three dict_mapping crash problems (#40897)

### DIFF
--- a/be/src/exprs/dict_query_expr.cpp
+++ b/be/src/exprs/dict_query_expr.cpp
@@ -43,17 +43,21 @@ StatusOr<ColumnPtr> DictQueryExpr::evaluate_checked(ExprContext* context, Chunk*
             column = ColumnHelper::unpack_and_duplicate_const_column(size, column);
         }
     }
-    ChunkPtr key_chunk = ChunkHelper::new_chunk(_key_schema, size);
-    key_chunk->reset();
-    for (int i = 0; i < _dict_query_expr.key_fields.size(); ++i) {
-        ColumnPtr key_column = columns[1 + i];
-        key_chunk->update_column_by_index(key_column, i);
-    }
+
+    Columns key_columns(columns.begin() + 1, columns.end());
+    DCHECK(_key_schema.num_fields() == key_columns.size());
+    auto key_chunk = std::make_unique<Chunk>(std::move(key_columns), std::make_shared<Schema>(_key_schema));
+    key_chunk->check_or_die();
+
     for (size_t i = 0; i < key_chunk->num_columns(); ++i) {
         key_chunk->set_slot_id_to_index(_key_slot_ids[i], i);
     }
 
     for (auto& column : key_chunk->columns()) {
+        // key does not support null value, return error in this case
+        if (column->has_null()) {
+            return Status::InternalError("invalid parameter : get NULL paramenter");
+        }
         if (column->is_nullable()) {
             column = ColumnHelper::update_column_nullable(false, column, column->size());
         }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/scalar/DictQueryOperator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/scalar/DictQueryOperator.java
@@ -27,8 +27,9 @@ public class DictQueryOperator extends CallOperator {
     private final TDictQueryExpr dictQueryExpr;
     private final Function fn;
 
-    public DictQueryOperator(List<ScalarOperator> arguments, TDictQueryExpr dictQueryExpr, Function fn) {
-        super(FunctionSet.DICT_MAPPING, Type.BIGINT, arguments);
+    public DictQueryOperator(List<ScalarOperator> arguments, TDictQueryExpr dictQueryExpr, Function fn,
+                             Type type) {
+        super(FunctionSet.DICT_MAPPING, type, arguments);
         this.dictQueryExpr = dictQueryExpr;
         this.fn = fn;
     }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/transformer/SqlToScalarOperatorTranslator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/transformer/SqlToScalarOperatorTranslator.java
@@ -841,7 +841,7 @@ public final class SqlToScalarOperatorTranslator {
                     .stream()
                     .map(child -> visit(child, context.clone(node)))
                     .collect(Collectors.toList());
-            return new DictQueryOperator(arguments, node.getDictQueryExpr(), node.getFn());
+            return new DictQueryOperator(arguments, node.getDictQueryExpr(), node.getFn(), node.getType());
         }
 
         @Override

--- a/test/sql/test_dict_mapping_function/R/test_dict_mapping_function
+++ b/test/sql/test_dict_mapping_function/R/test_dict_mapping_function
@@ -61,3 +61,136 @@ DROP TABLE t_expression_cast;
 DROP DATABASE test_expression_cast_db;
 -- result:
 -- !result
+-- name: test_dictmapping_multiple_column
+CREATE DATABASE test_dictmapping_multiple_column;
+-- result:
+-- !result
+use test_dictmapping_multiple_column;
+-- result:
+-- !result
+create table dict(col_1 int, col_2 string, col_3 bigint not null auto_increment, col_4 int)
+primary key(col_1, col_2)
+distributed by hash(col_1, col_2)
+PROPERTIES (
+"replication_num" = "1"
+);
+-- result:
+-- !result
+INSERT INTO dict VALUES (1, "abc", default, 0);
+-- result:
+-- !result
+create table t(col_1 int, col_2 string)
+primary key(col_1)
+distributed by hash(col_1)
+PROPERTIES (
+"replication_num" = "1"
+);
+-- result:
+-- !result
+INSERT INTO t VALUES (1, "abc");
+-- result:
+-- !result
+SELECT dict_mapping("dict", col_1, col_2) FROM t;
+-- result:
+1
+-- !result
+DROP DATABASE test_dictmapping_multiple_column;
+-- result:
+-- !result
+-- name: test_dictmapping_null_column
+CREATE DATABASE test_dictmapping_null_column;
+-- result:
+-- !result
+use test_dictmapping_null_column;
+-- result:
+-- !result
+create table dict(col_1 int, col_2 string, col_3 bigint not null auto_increment, col_4 int)
+primary key(col_1, col_2)
+distributed by hash(col_1, col_2)
+PROPERTIES (
+"replication_num" = "1"
+);
+-- result:
+-- !result
+INSERT INTO dict VALUES (1, "abc", default, 0);
+-- result:
+-- !result
+create table t(col_1 int, col_2 string)
+primary key(col_1)
+distributed by hash(col_1)
+PROPERTIES (
+"replication_num" = "1"
+);
+-- result:
+-- !result
+INSERT INTO t VALUES (1, NULL), (2, "abc");
+-- result:
+-- !result
+SELECT dict_mapping("dict", col_1, col_2) FROM t;
+-- result:
+E: (1064, 'invalid parameter : get NULL paramenter')
+-- !result
+DROP DATABASE test_dictmapping_null_column;
+-- result:
+-- !result
+-- name: test_dictmapping_DictQueryOperator_bug
+CREATE DATABASE test_dictmapping_DictQueryOperator_bug;
+-- result:
+-- !result
+USE test_dictmapping_DictQueryOperator_bug;
+-- result:
+-- !result
+create table dict(col_1 int, col_2 string, col_3 bigint not null auto_increment, col_4 int)
+                primary key(col_1)
+                distributed by hash(col_1)
+PROPERTIES (
+"replication_num" = "1"
+);
+-- result:
+-- !result
+insert into dict values(1, 'hello world 1', default, 1 * 10);
+-- result:
+-- !result
+insert into dict values(2, 'hello world 2', default, 2 * 10);
+-- result:
+-- !result
+insert into dict values(3, 'hello world 3', default, 3 * 10);
+-- result:
+-- !result
+insert into dict values(4, 'hello world 4', default, 4 * 10);
+-- result:
+-- !result
+insert into dict values(5, 'hello world 5', default, 5 * 10);
+-- result:
+-- !result
+insert into dict values(6, 'hello world 6', default, 6 * 10);
+-- result:
+-- !result
+insert into dict values(7, 'hello world 7', default, 7 * 10);
+-- result:
+-- !result
+insert into dict values(8, 'hello world 8', default, 8 * 10);
+-- result:
+-- !result
+insert into dict values(9, 'hello world 9', default, 9 * 10);
+-- result:
+-- !result
+insert into dict values(10, 'hello world 10', default, 10 * 10);
+-- result:
+-- !result
+create table fact_tbl_2(col_i int, col_2 varchar(20), col_mapvalue bigint)
+PROPERTIES (
+"replication_num" = "1"
+);
+-- result:
+-- !result
+insert into fact_tbl_2
+                values
+                (1, 'Beijing', DICT_mapping("dict", cast(1 as int))),
+                (2, 'Shenzhen', DICT_MAPping("dict", cast(2 as int), "col_3")),
+                (3, 'Shanghai', Dict_Mapping("dict", cast(3 as int), "col_4"));
+-- result:
+-- !result
+DROP DATABASE test_dictmapping_DictQueryOperator_bug;
+-- result:
+-- !result

--- a/test/sql/test_dict_mapping_function/T/test_dict_mapping_function
+++ b/test/sql/test_dict_mapping_function/T/test_dict_mapping_function
@@ -37,3 +37,84 @@ sync;
 SELECT * FROM test_table;
 DROP TABLE t_expression_cast;
 DROP DATABASE test_expression_cast_db;
+
+-- name: test_dictmapping_multiple_column
+CREATE DATABASE test_dictmapping_multiple_column;
+use test_dictmapping_multiple_column;
+create table dict(col_1 int, col_2 string, col_3 bigint not null auto_increment, col_4 int)
+primary key(col_1, col_2)
+distributed by hash(col_1, col_2)
+PROPERTIES (
+"replication_num" = "1"
+);
+
+INSERT INTO dict VALUES (1, "abc", default, 0);
+
+create table t(col_1 int, col_2 string)
+primary key(col_1)
+distributed by hash(col_1)
+PROPERTIES (
+"replication_num" = "1"
+);
+
+INSERT INTO t VALUES (1, "abc");
+
+SELECT dict_mapping("dict", col_1, col_2) FROM t;
+
+DROP DATABASE test_dictmapping_multiple_column;
+
+-- name: test_dictmapping_null_column
+CREATE DATABASE test_dictmapping_null_column;
+use test_dictmapping_null_column;
+create table dict(col_1 int, col_2 string, col_3 bigint not null auto_increment, col_4 int)
+primary key(col_1, col_2)
+distributed by hash(col_1, col_2)
+PROPERTIES (
+"replication_num" = "1"
+);
+
+INSERT INTO dict VALUES (1, "abc", default, 0);
+
+create table t(col_1 int, col_2 string)
+primary key(col_1)
+distributed by hash(col_1)
+PROPERTIES (
+"replication_num" = "1"
+);
+
+INSERT INTO t VALUES (1, NULL), (2, "abc");
+
+SELECT dict_mapping("dict", col_1, col_2) FROM t;
+
+DROP DATABASE test_dictmapping_null_column;
+
+-- name: test_dictmapping_DictQueryOperator_bug
+CREATE DATABASE test_dictmapping_DictQueryOperator_bug;
+USE test_dictmapping_DictQueryOperator_bug;
+create table dict(col_1 int, col_2 string, col_3 bigint not null auto_increment, col_4 int)
+                primary key(col_1)
+                distributed by hash(col_1)
+PROPERTIES (
+"replication_num" = "1"
+);
+insert into dict values(1, 'hello world 1', default, 1 * 10);
+insert into dict values(2, 'hello world 2', default, 2 * 10);
+insert into dict values(3, 'hello world 3', default, 3 * 10);
+insert into dict values(4, 'hello world 4', default, 4 * 10);
+insert into dict values(5, 'hello world 5', default, 5 * 10);
+insert into dict values(6, 'hello world 6', default, 6 * 10);
+insert into dict values(7, 'hello world 7', default, 7 * 10);
+insert into dict values(8, 'hello world 8', default, 8 * 10);
+insert into dict values(9, 'hello world 9', default, 9 * 10);
+insert into dict values(10, 'hello world 10', default, 10 * 10);
+create table fact_tbl_2(col_i int, col_2 varchar(20), col_mapvalue bigint)
+PROPERTIES (
+"replication_num" = "1"
+);
+insert into fact_tbl_2
+                values
+                (1, 'Beijing', DICT_mapping("dict", cast(1 as int))),
+                (2, 'Shenzhen', DICT_MAPping("dict", cast(2 as int), "col_3")),
+                (3, 'Shanghai', Dict_Mapping("dict", cast(3 as int), "col_4"));
+
+DROP DATABASE test_dictmapping_DictQueryOperator_bug;


### PR DESCRIPTION
Problem 1:
In debug/asan mode, dict_mapping function will crash if the given key has multiple column. It is because we forget to resize all key column size before call chunk->update_column_by_index() which make the chunk->check_or_die assert fail in debug/asan.

Problem 2:
If the given key value has null value, BE will crash. dict_mapping does not support null value in key.

Problem 3:
Suppose we have a table with column A as type INT. And we want execute: insert into table (A) values (dict_mapping(...)), BE will crash. This because DictQueryOperator always has return type BIGINT(which is a bug). It will cause optimizer generated a wrong execution plan(miss a necessary cast expression) and make be crash finally.

Solution:
1. construct chunk directly using columns and schema
2. return error if key chunk has null value
3. make sure DictQueryOperator return type is correct.

Fixes #40897

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
