### PR TITLE
[BugFix] fix column not found after mv rewrite for 3.1 (backport #39639)

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/AggregatedMaterializedViewRewriter.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/AggregatedMaterializedViewRewriter.java
@@ -208,7 +208,9 @@ public class AggregatedMaterializedViewRewriter extends MaterializedViewRewriter
             Map<ColumnRefOperator, ScalarOperator> queryColumnRefToScalarMap = Maps.newHashMap();
             for (Map.Entry<ColumnRefOperator, CallOperator> entry : oldAggregations.entrySet()) {
                 ScalarOperator scalarOp = entry.getValue();
-                ScalarOperator rewritten = rewriteScalarOperator(entry.getValue(),
+                ScalarOperator mapped = rewriteContext.getQueryColumnRefRewriter().rewrite(scalarOp.clone());
+                ScalarOperator swapped = columnRewriter.rewriteByQueryEc(mapped);
+                ScalarOperator rewritten = rewriteScalarOperator(swapped,
                         queryExprToMvExprRewriter, rewriteContext.getOutputMapping(),
                         originalColumnSet, aggregateFunctionRewriter);
                 if (rewritten == null) {
@@ -216,6 +218,18 @@ public class AggregatedMaterializedViewRewriter extends MaterializedViewRewriter
                     return null;
                 }
                 queryColumnRefToScalarMap.put(entry.getKey(), rewritten);
+            }
+            for (ColumnRefOperator groupKey : queryAggregationOperator.getGroupingKeys()) {
+                ScalarOperator mapped = rewriteContext.getQueryColumnRefRewriter().rewrite(groupKey.clone());
+                ScalarOperator swapped = columnRewriter.rewriteByQueryEc(mapped);
+                ScalarOperator rewritten = rewriteScalarOperator(swapped,
+                        queryExprToMvExprRewriter, rewriteContext.getOutputMapping(),
+                        originalColumnSet, aggregateFunctionRewriter);
+                if (rewritten == null) {
+                    logMVRewrite(mvRewriteContext, "mapping grouping key failed: {}", groupKey.toString());
+                    return null;
+                }
+                queryColumnRefToScalarMap.put(groupKey, rewritten);
             }
             ReplaceColumnRefRewriter rewriter = new ReplaceColumnRefRewriter(queryColumnRefToScalarMap);
             ScalarOperator aggPredicate = queryAggregationOperator.getPredicate();

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MaterializedViewRewriter.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MaterializedViewRewriter.java
@@ -574,7 +574,7 @@ public class MaterializedViewRewriter {
         final ReplaceColumnRefRewriter mvColumnRefRewriter =
                 MvUtils.getReplaceColumnRefWriter(mvExpression, mvColumnRefFactory);
 
-        final Set<ScalarOperator> mvConjuncts = MvUtils.getAllValidPredicates(mvExpression);
+        final Set<ScalarOperator> mvConjuncts = MvUtils.getPredicateForRewrite(mvExpression);
         ScalarOperator mvPartitionCompensate = compensateMVPartitionPredicate(mvConjuncts, mvColumnRefRewriter);
         if (mvPartitionCompensate != ConstantOperator.TRUE) {
             mvConjuncts.addAll(MvUtils.getAllValidPredicates(mvPartitionCompensate));
@@ -1771,10 +1771,7 @@ public class MaterializedViewRewriter {
     protected OptExpression queryBasedRewrite(RewriteContext rewriteContext, ScalarOperator compensationPredicates,
                                               OptExpression queryExpression) {
         // query predicate and (not viewToQueryCompensationPredicate) is the final query compensation predicate
-        ScalarOperator queryCompensationPredicate = MvUtils.canonizePredicate(
-                Utils.compoundAnd(
-                        rewriteContext.getQueryPredicateSplit().toScalarOperator(),
-                        CompoundPredicateOperator.not(compensationPredicates)));
+        ScalarOperator queryCompensationPredicate = CompoundPredicateOperator.not(compensationPredicates);
         List<ScalarOperator> predicates = Utils.extractConjuncts(queryCompensationPredicate);
         predicates.removeAll(mvRewriteContext.getOnPredicates());
         queryCompensationPredicate = Utils.compoundAnd(predicates);
@@ -1848,7 +1845,6 @@ public class MaterializedViewRewriter {
                 // predicate can not be pushdown, we should add it it optExpression
                 Operator.Builder builder = OperatorBuilderFactory.build(optExpression.getOp());
                 builder.withOperator(optExpression.getOp());
-                // builder.setPredicate(Utils.compoundAnd(predicate, optExpression.getOp().getPredicate()));
                 ScalarOperator canonizePredicates = MvUtils.canonizePredicateForRewrite(
                         queryMaterializationContext, Utils.compoundAnd(predicate, optExpression.getOp().getPredicate()));
                 builder.setPredicate(canonizePredicates);

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvUtils.java
@@ -62,6 +62,7 @@ import com.starrocks.sql.analyzer.SemanticException;
 import com.starrocks.sql.ast.QueryRelation;
 import com.starrocks.sql.ast.QueryStatement;
 import com.starrocks.sql.ast.StatementBase;
+import com.starrocks.sql.optimizer.JoinHelper;
 import com.starrocks.sql.optimizer.MaterializationContext;
 import com.starrocks.sql.optimizer.MvPlanContextBuilder;
 import com.starrocks.sql.optimizer.OptExpression;
@@ -90,6 +91,7 @@ import com.starrocks.sql.optimizer.operator.scalar.BinaryPredicateOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ColumnRefOperator;
 import com.starrocks.sql.optimizer.operator.scalar.CompoundPredicateOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ConstantOperator;
+import com.starrocks.sql.optimizer.operator.scalar.IsNullPredicateOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ScalarOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ScalarOperatorVisitor;
 import com.starrocks.sql.optimizer.rewrite.ReplaceColumnRefRewriter;
@@ -588,6 +590,78 @@ public class MvUtils {
 
     public static boolean isRedundantPredicate(ScalarOperator predicate) {
         return predicate.isPushdown() || predicate.isRedundant();
+    }
+
+    // for A inner join B A.a = B.b;
+    // A.a is not null and B.b is not null can be deduced from join.
+    // This function only extracts predicates from inner/semi join and scan node,
+    // which scan node will exclude IsNullPredicateOperator predicates if it's not null
+    // and its column ref is in the join's keys
+    public static Set<ScalarOperator> getPredicateForRewrite(OptExpression root) {
+        Set<ScalarOperator> result = Sets.newHashSet();
+        OptExpressionVisitor predicateVisitor = new OptExpressionVisitor<Object, ColumnRefSet>() {
+            @Override
+            public Object visit(OptExpression optExpression, ColumnRefSet context) {
+                for (OptExpression child : optExpression.getInputs()) {
+                    child.getOp().accept(this, child, null);
+                }
+                return null;
+            }
+
+            public Object visitLogicalTableScan(OptExpression optExpression, ColumnRefSet context) {
+                List<ScalarOperator> conjuncts = Utils.extractConjuncts(optExpression.getOp().getPredicate());
+                for (ScalarOperator conjunct : conjuncts) {
+                    if (!isValidPredicate(conjunct)) {
+                        continue;
+                    }
+                    if (conjunct instanceof IsNullPredicateOperator) {
+                        IsNullPredicateOperator isNullPredicateOperator = conjunct.cast();
+                        if (isNullPredicateOperator.isNotNull() && context != null
+                                && context.containsAll(isNullPredicateOperator.getUsedColumns())) {
+                            // if column ref is join key and column ref is not null can be ignored for inner and semi join
+                            continue;
+                        }
+                    }
+                    result.add(conjunct);
+                }
+                return null;
+            }
+
+            public Object visitLogicalJoin(OptExpression optExpression, ColumnRefSet context) {
+                LogicalJoinOperator joinOperator = optExpression.getOp().cast();
+
+                ColumnRefSet joinKeyColumns = new ColumnRefSet();
+                JoinOperator joinType = joinOperator.getJoinType();
+                if (joinType.isInnerJoin() || joinType.isCrossJoin() || joinType.isSemiJoin()) {
+                    List<ScalarOperator> onConjuncts = Utils.extractConjuncts(joinOperator.getOnPredicate());
+                    ColumnRefSet leftChildColumns = optExpression.inputAt(0).getOutputColumns();
+                    ColumnRefSet rightChildColumns = optExpression.inputAt(1).getOutputColumns();
+                    List<BinaryPredicateOperator> eqOnPredicates = JoinHelper.getEqualsPredicate(
+                            leftChildColumns, rightChildColumns, onConjuncts);
+                    eqOnPredicates.forEach(predicate -> joinKeyColumns.union(predicate.getUsedColumns()));
+                    if (context != null) {
+                        joinKeyColumns.union(context);
+                    }
+                    optExpression.inputAt(0).getOp().accept(this, optExpression.inputAt(0), joinKeyColumns);
+                    optExpression.inputAt(1).getOp().accept(this, optExpression.inputAt(1), joinKeyColumns);
+                } else if (joinType.isLeftOuterJoin() || joinType.isLeftAntiJoin()) {
+                    optExpression.inputAt(0).getOp().accept(this, optExpression.inputAt(0), joinKeyColumns);
+                } else if (joinType.isRightOuterJoin() || joinType.isRightAntiJoin()) {
+                    optExpression.inputAt(1).getOp().accept(this, optExpression.inputAt(1), joinKeyColumns);
+                }
+                List<ScalarOperator> conjuncts = Utils.extractConjuncts(
+                        Utils.compoundAnd(joinOperator.getPredicate(), joinOperator.getOnPredicate()));
+                for (ScalarOperator conjunct : conjuncts) {
+                    if (!isValidPredicate(conjunct)) {
+                        continue;
+                    }
+                    result.add(conjunct);
+                }
+                return null;
+            }
+        };
+        root.getOp().accept(predicateVisitor, root, null);
+        return result;
     }
 
     /**

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/rule/BaseMaterializedViewRewriteRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/rule/BaseMaterializedViewRewriteRule.java
@@ -197,7 +197,7 @@ public abstract class BaseMaterializedViewRewriteRule extends TransformationRule
             return null;
         }
         // only add valid predicates into query split predicate
-        Set<ScalarOperator> queryConjuncts = MvUtils.getAllValidPredicates(queryExpression);
+        Set<ScalarOperator> queryConjuncts = MvUtils.getPredicateForRewrite(queryExpression);
         if (!ConstantOperator.TRUE.equals(queryPartitionPredicate)) {
             logMVRewrite(optimizerContext, this, "Query compensate partition predicate:{}",
                     queryPartitionPredicate);

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/RefreshMaterializedViewTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/RefreshMaterializedViewTest.java
@@ -26,6 +26,7 @@ import com.starrocks.catalog.Replica;
 import com.starrocks.catalog.Table;
 import com.starrocks.catalog.Tablet;
 import com.starrocks.clone.DynamicPartitionScheduler;
+import com.starrocks.connector.ConnectorPartitionTraits;
 import com.starrocks.qe.StmtExecutor;
 import com.starrocks.schema.MTable;
 import com.starrocks.server.GlobalStateMgr;
@@ -36,6 +37,7 @@ import com.starrocks.sql.ast.RefreshMaterializedViewStatement;
 import com.starrocks.sql.optimizer.rule.transformation.materialization.MvRewriteTestBase;
 import com.starrocks.sql.plan.ExecPlan;
 import com.starrocks.utframe.UtFrameUtils;
+import mockit.Expectations;
 import mockit.Mock;
 import mockit.MockUp;
 import org.junit.Assert;
@@ -53,6 +55,9 @@ import java.util.function.Function;
 import java.util.stream.Collectors;
 
 public class RefreshMaterializedViewTest  extends MvRewriteTestBase {
+    // 1hour: set it to 1 hour to avoid FE's async update too late.
+    private static final long MV_STALENESS = 60 * 60;
+
     @BeforeClass
     public static void beforeClass() throws Exception {
         MvRewriteTestBase.beforeClass();
@@ -123,7 +128,6 @@ public class RefreshMaterializedViewTest  extends MvRewriteTestBase {
         }
     }
 
-
     @Test
     public void testRefreshExecution() throws Exception {
         executeInsertSql(connectContext, "insert into tbl_with_mv values(\"2022-02-20\", 1, 10)");
@@ -156,7 +160,8 @@ public class RefreshMaterializedViewTest  extends MvRewriteTestBase {
     }
 
     @Test
-    public void testMaxMVRewriteStaleness1() throws Exception {
+    public void testMaxMVRewriteStaleness1() {
+
         starRocksAssert.withTable(new MTable("tbl_staleness1", "k2",
                         ImmutableList.of(
                                 "k1 date",
@@ -188,8 +193,8 @@ public class RefreshMaterializedViewTest  extends MvRewriteTestBase {
 
                     // alter mv_rewrite_staleness
                     {
-                        String alterMvSql = "alter materialized view mv_with_mv_rewrite_staleness " +
-                                "set (\"mv_rewrite_staleness_second\" = \"60\")";
+                        String alterMvSql = String.format("alter materialized view mv_with_mv_rewrite_staleness " +
+                                "set (\"mv_rewrite_staleness_second\" = \"%s\")", MV_STALENESS);
                         AlterMaterializedViewStmt stmt =
                                 (AlterMaterializedViewStmt) UtFrameUtils.parseStmtWithNewParser(alterMvSql, connectContext);
                         GlobalStateMgr.getCurrentState().alterMaterializedView(stmt);
@@ -244,7 +249,7 @@ public class RefreshMaterializedViewTest  extends MvRewriteTestBase {
                             "distributed by hash(k2) buckets 3\n" +
                             "PROPERTIES (\n" +
                             "\"replication_num\" = \"1\"," +
-                            "\"mv_rewrite_staleness_second\" = \"60\"" +
+                            "\"mv_rewrite_staleness_second\" = \"" + MV_STALENESS + "\"" +
                             ")" +
                             "refresh manual\n" +
                             "as select k1, k2, v1  from tbl_staleness2;");
@@ -286,7 +291,7 @@ public class RefreshMaterializedViewTest  extends MvRewriteTestBase {
 
                         long mvRefreshTimeStamp = mv1.getLastRefreshTime();
                         Assert.assertTrue(mvRefreshTimeStamp < tblMaxPartitionRefreshTimestamp);
-                        Assert.assertTrue((tblMaxPartitionRefreshTimestamp - mvRefreshTimeStamp) / 1000 < 60);
+                        Assert.assertTrue((tblMaxPartitionRefreshTimestamp - mvRefreshTimeStamp) / 1000 < MV_STALENESS);
                         Assert.assertTrue(mv1.isStalenessSatisfied());
 
                         Set<String> partitionsToRefresh = getPartitionNamesToRefreshForMv(mv1);
@@ -317,7 +322,7 @@ public class RefreshMaterializedViewTest  extends MvRewriteTestBase {
                             "distributed by hash(k2) buckets 3\n" +
                             "PROPERTIES (\n" +
                             "\"replication_num\" = \"1\"," +
-                            "\"mv_rewrite_staleness_second\" = \"60\"" +
+                            "\"mv_rewrite_staleness_second\" = \"" + MV_STALENESS + "\"" +
                             ")" +
                             "refresh manual\n" +
                             "as select k1, k2, v1  from tbl_staleness3;");
@@ -326,7 +331,7 @@ public class RefreshMaterializedViewTest  extends MvRewriteTestBase {
                             "distributed by hash(k2) buckets 3\n" +
                             "PROPERTIES (\n" +
                             "\"replication_num\" = \"1\"," +
-                            "\"mv_rewrite_staleness_second\" = \"60\"" +
+                            "\"mv_rewrite_staleness_second\" = \"" + MV_STALENESS + "\"" +
                             ")" +
                             "refresh manual\n" +
                             "as select k1, k2, count(1)  from mv_with_mv_rewrite_staleness21 group by k1, k2;");
@@ -383,7 +388,7 @@ public class RefreshMaterializedViewTest  extends MvRewriteTestBase {
 
                             long mvRefreshTimeStamp = mv1.getLastRefreshTime();
                             Assert.assertTrue(mvRefreshTimeStamp < tblMaxPartitionRefreshTimestamp);
-                            Assert.assertTrue((tblMaxPartitionRefreshTimestamp - mvRefreshTimeStamp) / 1000 < 60);
+                            Assert.assertTrue((tblMaxPartitionRefreshTimestamp - mvRefreshTimeStamp) / 1000 < MV_STALENESS);
                             Assert.assertTrue(mv1.isStalenessSatisfied());
 
                             Set<String> partitionsToRefresh = getPartitionNamesToRefreshForMv(mv1);
@@ -404,7 +409,7 @@ public class RefreshMaterializedViewTest  extends MvRewriteTestBase {
 
                             long mvRefreshTimeStamp = mv2.getLastRefreshTime();
                             Assert.assertTrue(mvRefreshTimeStamp <= tblMaxPartitionRefreshTimestamp);
-                            Assert.assertTrue((tblMaxPartitionRefreshTimestamp - mvRefreshTimeStamp) / 1000 < 60);
+                            Assert.assertTrue((tblMaxPartitionRefreshTimestamp - mvRefreshTimeStamp) / 1000 < MV_STALENESS);
                             Assert.assertTrue(mv2.isStalenessSatisfied());
 
                             Set<String> partitionsToRefresh = getPartitionNamesToRefreshForMv(mv2);

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MVRewriteWithSchemaChangeTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MVRewriteWithSchemaChangeTest.java
@@ -168,6 +168,8 @@ public class MVRewriteWithSchemaChangeTest extends MvRewriteTestBase {
                 "FROM t1_agg AS t1_17 " +
                 "GROUP BY t1_17.c_1_0, t1_17.c_1_1 ORDER BY t1_17.c_1_0 DESC, t1_17.c_1_1 ASC");
 
+        // NOTE: change `selectBestRowCountIndex` to prefer non-baseIndexId so can choose the mv for
+        // mv's rowCount and columnSize is the same with the base table.
         {
             String query = "select * from t1_agg";
             String plan = UtFrameUtils.getVerboseFragmentPlan(connectContext, query);

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvRewriteOnTpcdsTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvRewriteOnTpcdsTest.java
@@ -1,0 +1,207 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.sql.optimizer.rule.transformation.materialization;
+
+import com.starrocks.planner.MaterializedViewTestBase;
+import com.starrocks.sql.plan.TPCDSPlanTestBase;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+public class MvRewriteOnTpcdsTest extends MaterializedViewTestBase {
+    @BeforeClass
+    public static void beforeClass() throws Exception {
+        TPCDSPlanTestBase.beforeClass();
+        connectContext.getSessionVariable().setMaterializedViewRewriteMode("force");
+    }
+
+    @Test
+    public void testQuery16() throws Exception {
+        connectContext.executeSql("drop materialized view if exists __mv__ta0008");
+        createAndRefreshMV("test", "CREATE MATERIALIZED VIEW __mv__ta0008 (_ca0005, _ca0006, _ca0007)\n" +
+                "REFRESH ASYNC START(\"2023-12-01 10:00:00\") EVERY(INTERVAL 1 DAY)\n" +
+                "PROPERTIES (\n" +
+                "  \"replication_num\" = \"1\"\n" +
+                ")\n" +
+                "AS\n" +
+                "SELECT\n" +
+                "  (count(DISTINCT _ta0002.cs_order_number)) AS _ca0005\n" +
+                "  ,(sum(_ta0002.cs_ext_ship_cost)) AS _ca0006\n" +
+                "  ,(sum(_ta0002.cs_net_profit)) AS _ca0007\n" +
+                "FROM\n" +
+                "  (\n" +
+                "    SELECT\n" +
+                "      catalog_sales.cs_order_number\n" +
+                "      ,catalog_sales.cs_net_profit\n" +
+                "      ,catalog_sales.cs_ext_ship_cost\n" +
+                "    FROM\n" +
+                "      catalog_sales\n" +
+                "      INNER JOIN\n" +
+                "      date_dim\n" +
+                "      ON (catalog_sales.cs_ship_date_sk = date_dim.d_date_sk)\n" +
+                "      INNER JOIN\n" +
+                "      customer_address\n" +
+                "      ON (catalog_sales.cs_ship_addr_sk = customer_address.ca_address_sk)\n" +
+                "      INNER JOIN\n" +
+                "      call_center\n" +
+                "      ON (catalog_sales.cs_call_center_sk = call_center.cc_call_center_sk)\n" +
+                "      LEFT SEMI JOIN\n" +
+                "      (\n" +
+                "        SELECT\n" +
+                "          catalog_sales.cs_order_number\n" +
+                "          ,catalog_sales.cs_warehouse_sk\n" +
+                "        FROM\n" +
+                "          catalog_sales\n" +
+                "      ) _ta0000\n" +
+                "      ON (catalog_sales.cs_order_number = _ta0000.cs_order_number)\n" +
+                "         AND (catalog_sales.cs_warehouse_sk != _ta0000.cs_warehouse_sk)\n" +
+                "      LEFT ANTI JOIN\n" +
+                "      catalog_returns\n" +
+                "      ON (catalog_sales.cs_order_number = catalog_returns.cr_order_number)\n" +
+                "    WHERE\n" +
+                "      (date_dim.d_date <= \"2002-04-02\")\n" +
+                "      AND call_center.cc_county in (\"Williamson County\", \"Williamson County\"," +
+                " \"Williamson County\", \"Williamson County\", \"Williamson County\")\n" +
+                "      AND (customer_address.ca_state = \"GA\")\n" +
+                "      AND (catalog_sales.cs_ship_date_sk IS NOT NULL)\n" +
+                "      AND (\"2002-02-01\" <= date_dim.d_date)\n" +
+                "  ) _ta0002;");
+
+        {
+            MVRewriteChecker checker = sql(TPCDSPlanTestBase.Q16);
+            checker.contains("__mv__ta0008");
+        }
+    }
+
+    @Test
+    public void testQuery39() throws Exception {
+        connectContext.executeSql("drop materialized view if exists __mv__ta0006");
+        createAndRefreshMV("test", "CREATE MATERIALIZED VIEW __mv__ta0006 (" +
+                "_ca0003, _ca0004, _ca0005, d_moy, d_year, w_warehouse_name, w_warehouse_sk, i_item_sk)\n" +
+                "DISTRIBUTED BY HASH (d_moy, d_year, w_warehouse_name, w_warehouse_sk, i_item_sk)\n" +
+                "REFRESH ASYNC START(\"2023-12-01 10:00:00\") EVERY(INTERVAL 1 DAY)\n" +
+                "PROPERTIES (\n" +
+                "  \"replication_num\" = \"1\"\n" +
+                ")\n" +
+                "AS\n" +
+                "SELECT\n" +
+                "  (stddev_samp(_ta0000.inv_quantity_on_hand)) AS _ca0003\n" +
+                "  ,(sum(_ta0000.inv_quantity_on_hand)) AS _ca0004\n" +
+                "  ,(count(_ta0000.inv_quantity_on_hand)) AS _ca0005\n" +
+                "  ,_ta0000.d_moy\n" +
+                "  ,_ta0000.d_year\n" +
+                "  ,_ta0000.w_warehouse_name\n" +
+                "  ,_ta0000.w_warehouse_sk\n" +
+                "  ,_ta0000.i_item_sk\n" +
+                "FROM\n" +
+                "  (\n" +
+                "    SELECT\n" +
+                "      warehouse.w_warehouse_sk\n" +
+                "      ,warehouse.w_warehouse_name\n" +
+                "      ,date_dim.d_moy\n" +
+                "      ,inventory.inv_quantity_on_hand\n" +
+                "      ,item.i_item_sk\n" +
+                "      ,date_dim.d_year\n" +
+                "    FROM\n" +
+                "      inventory\n" +
+                "      INNER JOIN\n" +
+                "      item\n" +
+                "      ON (inventory.inv_item_sk = item.i_item_sk)\n" +
+                "      INNER JOIN\n" +
+                "      warehouse\n" +
+                "      ON (inventory.inv_warehouse_sk = warehouse.w_warehouse_sk)\n" +
+                "      INNER JOIN\n" +
+                "      date_dim\n" +
+                "      ON (inventory.inv_date_sk = date_dim.d_date_sk)\n" +
+                "  ) _ta0000\n" +
+                "GROUP BY\n" +
+                "  _ta0000.d_moy\n" +
+                "  , _ta0000.d_year\n" +
+                "  , _ta0000.w_warehouse_name\n" +
+                "  , _ta0000.w_warehouse_sk\n" +
+                "  , _ta0000.i_item_sk;");
+        {
+            // q39-1
+            MVRewriteChecker checker = sql(TPCDSPlanTestBase.Q39_1);
+            checker.contains("__mv__ta0006");
+        }
+
+        {
+            // q39-2
+            MVRewriteChecker checker = sql(TPCDSPlanTestBase.Q39_2);
+            checker.contains("__mv__ta0006");
+        }
+    }
+
+    @Test
+    public void testQuery83() throws Exception {
+        connectContext.executeSql("drop materialized view if exists __mv__ta0007");
+        createAndRefreshMV("test", "CREATE MATERIALIZED VIEW __mv__ta0007 (_ca0006, i_item_id)\n" +
+                "DISTRIBUTED BY HASH (i_item_id)\n" +
+                "REFRESH ASYNC START(\"2023-12-01 10:00:00\") EVERY(INTERVAL 1 DAY)\n" +
+                "PROPERTIES (\n" +
+                "  \"replication_num\" = \"1\"\n" +
+                ")\n" +
+                "AS\n" +
+                "SELECT\n" +
+                "  (sum(_ta0003.sr_return_quantity)) AS _ca0006\n" +
+                "  ,_ta0003.i_item_id\n" +
+                "FROM\n" +
+                "  (\n" +
+                "    SELECT\n" +
+                "      item.i_item_id\n" +
+                "      ,store_returns.sr_return_quantity\n" +
+                "    FROM\n" +
+                "      store_returns\n" +
+                "      INNER JOIN\n" +
+                "      item\n" +
+                "      ON (store_returns.sr_item_sk = item.i_item_sk)\n" +
+                "      INNER JOIN\n" +
+                "      date_dim\n" +
+                "      ON (store_returns.sr_returned_date_sk = date_dim.d_date_sk)\n" +
+                "      LEFT SEMI JOIN\n" +
+                "      (\n" +
+                "        SELECT\n" +
+                "          _ta0000.d_date\n" +
+                "        FROM\n" +
+                "          (\n" +
+                "            SELECT\n" +
+                "              date_dim.d_date\n" +
+                "              ,date_dim.d_week_seq\n" +
+                "            FROM\n" +
+                "              date_dim\n" +
+                "          ) _ta0000\n" +
+                "          LEFT SEMI JOIN\n" +
+                "          (\n" +
+                "            SELECT\n" +
+                "              date_dim.d_week_seq\n" +
+                "              ,date_dim.d_date\n" +
+                "            FROM\n" +
+                "              date_dim\n" +
+                "          ) _ta0001\n" +
+                "          ON (_ta0000.d_week_seq = _ta0001.d_week_seq)\n" +
+                "             AND (_ta0001.d_week_seq IS NOT NULL)\n" +
+                "             AND _ta0001.d_date in (\"2000-06-30\", \"2000-09-27\", \"2000-11-17\")\n" +
+                "      ) _ta0002\n" +
+                "      ON (date_dim.d_date = _ta0002.d_date)\n" +
+                "         AND (_ta0002.d_date IS NOT NULL)\n" +
+                "  ) _ta0003\n" +
+                "GROUP BY\n" +
+                "  _ta0003.i_item_id;");
+        {
+            MVRewriteChecker checker = sql(TPCDSPlanTestBase.Q83);
+            checker.contains("__mv__ta0007");
+        }
+    }
+}

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvRewriteOnTpcdsTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvRewriteOnTpcdsTest.java
@@ -88,7 +88,7 @@ public class MvRewriteOnTpcdsTest extends MaterializedViewTestBase {
     public void testQuery39() throws Exception {
         connectContext.executeSql("drop materialized view if exists __mv__ta0006");
         createAndRefreshMV("test", "CREATE MATERIALIZED VIEW __mv__ta0006 (" +
-                "_ca0003, _ca0004, _ca0005, d_moy, d_year, w_warehouse_name, w_warehouse_sk, i_item_sk)\n" +
+                "d_moy, d_year, w_warehouse_name, w_warehouse_sk, i_item_sk, _ca0003, _ca0004, _ca0005)\n" +
                 "DISTRIBUTED BY HASH (d_moy, d_year, w_warehouse_name, w_warehouse_sk, i_item_sk)\n" +
                 "REFRESH ASYNC START(\"2023-12-01 10:00:00\") EVERY(INTERVAL 1 DAY)\n" +
                 "PROPERTIES (\n" +
@@ -96,14 +96,14 @@ public class MvRewriteOnTpcdsTest extends MaterializedViewTestBase {
                 ")\n" +
                 "AS\n" +
                 "SELECT\n" +
-                "  (stddev_samp(_ta0000.inv_quantity_on_hand)) AS _ca0003\n" +
-                "  ,(sum(_ta0000.inv_quantity_on_hand)) AS _ca0004\n" +
-                "  ,(count(_ta0000.inv_quantity_on_hand)) AS _ca0005\n" +
-                "  ,_ta0000.d_moy\n" +
+                "  _ta0000.d_moy\n" +
                 "  ,_ta0000.d_year\n" +
                 "  ,_ta0000.w_warehouse_name\n" +
                 "  ,_ta0000.w_warehouse_sk\n" +
                 "  ,_ta0000.i_item_sk\n" +
+                "  ,(stddev_samp(_ta0000.inv_quantity_on_hand)) AS _ca0003\n" +
+                "  ,(sum(_ta0000.inv_quantity_on_hand)) AS _ca0004\n" +
+                "  ,(count(_ta0000.inv_quantity_on_hand)) AS _ca0005\n" +
                 "FROM\n" +
                 "  (\n" +
                 "    SELECT\n" +

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvRewriteTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvRewriteTest.java
@@ -2258,4 +2258,64 @@ public class MvRewriteTest extends MvRewriteTestBase {
         }
     }
 
+    @Test
+    public void test() throws Exception {
+        connectContext.executeSql("drop table if exists t11");
+        starRocksAssert.withTable("create table t11(\n" +
+                "shop_id int,\n" +
+                "region int,\n" +
+                "shop_type string,\n" +
+                "shop_flag string,\n" +
+                "store_id String,\n" +
+                "store_qty Double\n" +
+                ") DUPLICATE key(shop_id) distributed by hash(shop_id) buckets 1 " +
+                "PROPERTIES (\n" +
+                "\"replication_num\" = \"1\"\n" +
+                ");");
+        cluster.runSql("test", "insert into\n" +
+                "t11\n" +
+                "values\n" +
+                "(1, 1, 's', 'o', '1', null),\n" +
+                "(1, 1, 'm', 'o', '2', 2),\n" +
+                "(1, 1, 'b', 'c', '3', 1);");
+        connectContext.executeSql("drop materialized view if exists mv11");
+        starRocksAssert.withMaterializedView("create MATERIALIZED VIEW mv11 (region, ct) " +
+                "DISTRIBUTED BY RANDOM buckets 1 REFRESH MANUAL as\n" +
+                "select region,\n" +
+                "count(\n" +
+                "distinct (\n" +
+                "case\n" +
+                "when store_qty > 0 then store_id\n" +
+                "else null\n" +
+                "end\n" +
+                ")\n" +
+                ")\n" +
+                "from t11\n" +
+                "group by region;");
+        cluster.runSql("test", "refresh materialized view mv11 with sync mode");
+        {
+            String query = "select region,\n" +
+                    "count(\n" +
+                    "distinct (\n" +
+                    "case\n" +
+                    "when store_qty > 0.0 then store_id\n" +
+                    "else null\n" +
+                    "end\n" +
+                    ")\n" +
+                    ") as ct\n" +
+                    "from t11\n" +
+                    "group by region\n" +
+                    "having\n" +
+                    "count(\n" +
+                    "distinct (\n" +
+                    "case\n" +
+                    "when store_qty > 0.0 then store_id\n" +
+                    "else null\n" +
+                    "end\n" +
+                    ")\n" +
+                    ") > 0\n";
+            String plan = getFragmentPlan(query);
+            PlanTestBase.assertContains(plan, "mv11", "PREDICATES: 10: ct > 0");
+        }
+    }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvRewriteUnionTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvRewriteUnionTest.java
@@ -408,7 +408,7 @@ public class MvRewriteUnionTest extends MvRewriteTestBase {
                                 Pair.create("SELECT k1,k2, v1,v2 from mt1 where k1 != 3 and k2 like 'a%'",
                                         "TABLE: mt1\n" +
                                                 "     PREAGGREGATION: ON\n" +
-                                                "     PREDICATES: 9: k1 != 3, (9: k1 < 3) OR (9: k1 > 3), 10: k2 LIKE 'a%'\n" +
+                                                "     PREDICATES: 9: k1 != 3, 10: k2 LIKE 'a%'\n" +
                                                 "     partitions=2/3")
                         );
                         for (Pair<String, String> p : sqls) {

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvRewriteUnionTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvRewriteUnionTest.java
@@ -193,12 +193,12 @@ public class MvRewriteUnionTest extends MvRewriteTestBase {
         PlanTestBase.assertContains(plan2, "2:OlapScanNode\n" +
                 "     TABLE: emps2\n" +
                 "     PREAGGREGATION: ON\n" +
-                "     PREDICATES: 15: deptno < 120, 15: deptno >= 100\n" +
+                "     PREDICATES: 15: deptno >= 100, 15: deptno < 120\n" +
                 "     partitions=1/1");
         PlanTestBase.assertContains(plan2, "1:OlapScanNode\n" +
                 "     TABLE: depts2\n" +
                 "     PREAGGREGATION: ON\n" +
-                "     PREDICATES: 18: deptno < 120, 18: deptno >= 100");
+                "     PREDICATES: 18: deptno >= 100, 18: deptno < 120");
     }
 
     @Test


### PR DESCRIPTION
Why I'm doing:
query failed after mv rewrite because that column is not found.

What I'm doing:
There are several reasons for this type bug.

1. IsNullPredicate can not be rewritten if mv has this predicate but query do not
2. aggregate has having predicates on grouping key. The keys are not mapped to base tables and not rewritten by query ec, so rewrite failed.
3. aggregate has having predicates on aggregations, The aggregations are not mapped to base tables and not rewritten by query ec, so rewrite failed.

Fix it by:

1. refactor get predicates logics to get only necessary predicates to avoid IsNullPredicate bug
2. mapping keys to based tables and rewrite them by query ec before writing
3. mapping aggregations to based tables and rewrite them by query ec before writing
5. add uts on some tpcds queries
Fixes #38844

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [x] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5

