### PR TITLE
[UT] Fix ConcurrentModificationException in restorejob test case

### DIFF
--- a/fe/fe-core/src/test/java/com/starrocks/backup/RestoreJobTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/backup/RestoreJobTest.java
@@ -56,6 +56,8 @@ import com.starrocks.catalog.Tablet;
 import com.starrocks.common.AnalysisException;
 import com.starrocks.common.jmockit.Deencapsulation;
 import com.starrocks.common.util.concurrent.MarkedCountDownLatch;
+import com.starrocks.common.util.concurrent.lock.LockType;
+import com.starrocks.common.util.concurrent.lock.Locker;
 import com.starrocks.metric.MetricRepo;
 import com.starrocks.persist.EditLog;
 import com.starrocks.server.GlobalStateMgr;
@@ -150,7 +152,14 @@ public class RestoreJobTest {
     }
 
     public void testResetPartitionForRestore() {
-        expectedRestoreTbl = (OlapTable) db.getTable(CatalogMocker.TEST_TBL4_ID);
+        Locker locker = new Locker();
+        try {
+            locker.lockDatabase(db, LockType.READ);
+            expectedRestoreTbl = (OlapTable) db.getTable(CatalogMocker.TEST_TBL4_ID);
+        } finally {
+            locker.unLockDatabase(db, LockType.READ);
+        }
+
         OlapTable localTbl = new OlapTable(expectedRestoreTbl.getId(), expectedRestoreTbl.getName(),
                 expectedRestoreTbl.getBaseSchema(), KeysType.DUP_KEYS, expectedRestoreTbl.getPartitionInfo(),
                 expectedRestoreTbl.getDefaultDistributionInfo());
@@ -237,6 +246,8 @@ public class RestoreJobTest {
             }
         };
 
+        Locker locker = new Locker();
+
         // gen BackupJobInfo
         jobInfo = new BackupJobInfo();
         jobInfo.backupTime = System.currentTimeMillis();
@@ -245,7 +256,12 @@ public class RestoreJobTest {
         jobInfo.name = label;
         jobInfo.success = true;
 
-        expectedRestoreTbl = (OlapTable) db.getTable(CatalogMocker.TEST_TBL4_ID);
+        try {
+            locker.lockDatabase(db, LockType.READ);
+            expectedRestoreTbl = (OlapTable) db.getTable(CatalogMocker.TEST_TBL4_ID);
+        } finally {
+            locker.unLockDatabase(db, LockType.READ);
+        }
         BackupTableInfo tblInfo = new BackupTableInfo();
         tblInfo.id = CatalogMocker.TEST_TBL4_ID;
         tblInfo.name = CatalogMocker.TEST_TBL4_NAME;
@@ -282,8 +298,13 @@ public class RestoreJobTest {
 
         }
 
-        // drop this table, cause we want to try restoring this table
-        db.dropTable(expectedRestoreTbl.getName());
+        try {
+            locker.lockDatabase(db, LockType.WRITE);
+            // drop this table, cause we want to try restoring this table
+            db.dropTable(expectedRestoreTbl.getName());
+        } finally {
+            locker.unLockDatabase(db, LockType.WRITE);
+        }
 
         List<Table> tbls = Lists.newArrayList();
         tbls.add(expectedRestoreTbl);
@@ -406,6 +427,7 @@ public class RestoreJobTest {
                 return true;
             }
         };
+        Locker locker = new Locker();
 
         // gen BackupJobInfo
         jobInfo = new BackupJobInfo();
@@ -415,7 +437,12 @@ public class RestoreJobTest {
         jobInfo.name = label;
         jobInfo.success = true;
 
-        expectedRestoreTbl = (OlapTable) db.getTable(CatalogMocker.TEST_TBL2_ID);
+        try {
+            locker.lockDatabase(db, LockType.READ);
+            expectedRestoreTbl = (OlapTable) db.getTable(CatalogMocker.TEST_TBL2_ID);
+        } finally {
+            locker.unLockDatabase(db, LockType.READ);
+        }
         BackupTableInfo tblInfo = new BackupTableInfo();
         tblInfo.id = CatalogMocker.TEST_TBL2_ID;
         tblInfo.name = CatalogMocker.TEST_TBL2_NAME;
@@ -445,8 +472,13 @@ public class RestoreJobTest {
             }
         }
 
-        // drop this table, cause we want to try restoring this table
-        db.dropTable(expectedRestoreTbl.getName());
+        try {
+            locker.lockDatabase(db, LockType.WRITE);
+            // drop this table, cause we want to try restoring this table
+            db.dropTable(expectedRestoreTbl.getName());
+        } finally {
+            locker.unLockDatabase(db, LockType.WRITE);
+        }
 
         List<Table> tbls = Lists.newArrayList();
         tbls.add(expectedRestoreTbl);
@@ -507,7 +539,15 @@ public class RestoreJobTest {
         sig2.update("name1".getBytes());
         System.out.println("sig2: " + Math.abs((int) sig2.getValue()));
 
-        OlapTable tbl = (OlapTable) db.getTable(CatalogMocker.TEST_TBL_NAME);
+        Locker locker = new Locker();
+
+        OlapTable tbl = null;
+        try {
+            locker.lockDatabase(db, LockType.READ);
+            tbl = (OlapTable) db.getTable(CatalogMocker.TEST_TBL_NAME);
+        } finally {
+            locker.unLockDatabase(db, LockType.READ);
+        }
         List<String> partNames = Lists.newArrayList(tbl.getPartitionNames());
         System.out.println(partNames);
         System.out.println("tbl signature: " + tbl.getSignature(BackupHandler.SIGNATURE_VERSION, partNames, true));


### PR DESCRIPTION
Fix the ConcurrentModificationException using locking to avoid ConcurrentModificationException between db.getTable and db.dropTable

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [x] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
