### PR TITLE
[Enhancement] create mv partition in small batch

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/common/Config.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/Config.java
@@ -1235,6 +1235,9 @@ public class Config extends ConfigBase {
     @ConfField(mutable = true)
     public static boolean enable_create_partial_partition_in_batch = false;
 
+    @ConfField(mutable = true, comment = "The interval of create partition batch, to avoid too frequent")
+    public static long mv_create_partition_batch_interval_ms = 1000;
+
     /**
      * The number of query retries.
      * A query may retry if we encounter RPC exception and no result has been sent to user.

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/PartitionBasedMvRefreshProcessor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/PartitionBasedMvRefreshProcessor.java
@@ -111,6 +111,7 @@ import com.starrocks.sql.optimizer.rule.transformation.materialization.MvUtils;
 import com.starrocks.sql.parser.SqlParser;
 import com.starrocks.sql.plan.ExecPlan;
 import org.apache.commons.collections.CollectionUtils;
+import org.apache.commons.collections4.ListUtils;
 import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -153,6 +154,7 @@ public class PartitionBasedMvRefreshProcessor extends BaseTaskRunProcessor {
     private static final int MV_DEFAULT_QUERY_TIMEOUT = 3600;
 
     private static final int MAX_RETRY_NUM = 10;
+    private static final int CREATE_PARTITION_BATCH_SIZE = 64;
 
     private Database db;
     private MaterializedView materializedView;
@@ -1864,17 +1866,24 @@ public class PartitionBasedMvRefreshProcessor extends BaseTaskRunProcessor {
                     new SingleRangePartitionDesc(false, mvPartitionName, partitionKeyDesc, partitionProperties);
             partitionDescs.add(singleRangePartitionDesc);
         }
-        RangePartitionDesc rangePartitionDesc =
-                new RangePartitionDesc(materializedView.getPartitionColumnNames(), partitionDescs);
 
-        try {
-            GlobalStateMgr.getCurrentState().getLocalMetastore().addPartitions(
-                    database, materializedView.getName(),
-                    new AddPartitionClause(rangePartitionDesc, distributionDesc,
-                            partitionProperties, false));
-        } catch (Exception e) {
-            throw new DmlException("Expression add partition failed: %s, db: %s, table: %s", e, e.getMessage(),
-                    database.getFullName(), materializedView.getName());
+        // create partitions in small batch, to avoid create too many partitions at once
+        for (List<PartitionDesc> batch : ListUtils.partition(partitionDescs, CREATE_PARTITION_BATCH_SIZE)) {
+            RangePartitionDesc rangePartitionDesc =
+                    new RangePartitionDesc(materializedView.getPartitionColumnNames(), batch);
+            AddPartitionClause alterPartition = new AddPartitionClause(rangePartitionDesc, distributionDesc,
+                    partitionProperties, false);
+            try {
+                GlobalStateMgr.getCurrentState().getLocalMetastore().addPartitions(
+                        database, materializedView.getName(), alterPartition);
+            } catch (Exception e) {
+                throw new DmlException("Expression add partition failed: %s, db: %s, table: %s", e, e.getMessage(),
+                        database.getFullName(), materializedView.getName());
+            }
+            try {
+                Thread.sleep(Config.mv_create_partition_batch_interval_ms);
+            } catch (InterruptedException ignore) {
+            }
         }
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/PartitionBasedMvRefreshProcessor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/PartitionBasedMvRefreshProcessor.java
@@ -22,6 +22,7 @@ import com.google.common.collect.Maps;
 import com.google.common.collect.Multimap;
 import com.google.common.collect.Range;
 import com.google.common.collect.Sets;
+import com.google.common.util.concurrent.Uninterruptibles;
 import com.starrocks.analysis.Expr;
 import com.starrocks.analysis.FunctionCallExpr;
 import com.starrocks.analysis.IsNullPredicate;
@@ -128,6 +129,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.Consumer;
 import java.util.stream.Collectors;
@@ -1880,10 +1882,7 @@ public class PartitionBasedMvRefreshProcessor extends BaseTaskRunProcessor {
                 throw new DmlException("Expression add partition failed: %s, db: %s, table: %s", e, e.getMessage(),
                         database.getFullName(), materializedView.getName());
             }
-            try {
-                Thread.sleep(Config.mv_create_partition_batch_interval_ms);
-            } catch (InterruptedException ignore) {
-            }
+            Uninterruptibles.sleepUninterruptibly(Config.mv_create_partition_batch_interval_ms, TimeUnit.MILLISECONDS);
         }
     }
 


### PR DESCRIPTION

## Why I'm doing:
- After creating the MV, even if partition refresh, the first task would create all partitions at once, which is not robust when there're a lot candidate partitions


## What I'm doing:
- Create partitions in small batch, and wait some time between each batch

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [x] 3.1
  - [ ] 3.0
  - [ ] 2.5
