### PR TITLE
[Enhancement] Ensure mutable string configs are thread-safe

### DIFF
--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -1020,9 +1020,9 @@ CONF_Int64(max_length_for_bitmap_function, "1000000");
 
 // Configuration items for datacache
 CONF_Bool(datacache_enable, "false");
-CONF_mString(datacache_mem_size, "10%");
-CONF_mString(datacache_disk_size, "0");
-CONF_mString(datacache_disk_path, "${STARROCKS_HOME}/datacache/");
+CONF_String(datacache_mem_size, "10%");
+CONF_String(datacache_disk_size, "0");
+CONF_String(datacache_disk_path, "${STARROCKS_HOME}/datacache/");
 CONF_String(datacache_meta_path, "${STARROCKS_HOME}/datacache/");
 CONF_Int64(datacache_block_size, "262144"); // 256K
 CONF_Bool(datacache_checksum_enable, "false");

--- a/be/src/common/configbase.h
+++ b/be/src/common/configbase.h
@@ -16,6 +16,8 @@
 // under the License.
 
 #pragma once
+#include <butil/containers/doubly_buffered_data.h>
+
 #include <cstdint>
 #include <map>
 #include <mutex>
@@ -34,6 +36,48 @@ struct ConfigInfo {
     std::string defval;
     bool valmutable;
 };
+
+// A wrapper on std::string, it's safe to read/write MutableString concurrently.
+class MutableString {
+public:
+    MutableString() = default;
+    ~MutableString() = default;
+
+    // Disallow copy and move, because no usage now.
+    MutableString(const MutableString&) = delete;
+    void operator=(const MutableString&) = delete;
+    MutableString(MutableString&&) = delete;
+    void operator=(MutableString&&) = delete;
+
+    std::string value() const;
+
+    operator std::string() const { return value(); }
+
+    MutableString& operator=(std::string s);
+
+private:
+    static bool update_value(std::string& bg, std::string new_value) {
+        bg = std::move(new_value);
+        return true;
+    }
+
+    mutable butil::DoublyBufferedData<std::string> _str;
+};
+
+inline std::string MutableString::value() const {
+    butil::DoublyBufferedData<std::string>::ScopedPtr ptr;
+    _str.Read(&ptr);
+    return *ptr;
+}
+
+inline MutableString& MutableString::operator=(std::string s) {
+    _str.Modify(update_value, std::move(s));
+    return *this;
+}
+
+inline std::ostream& operator<<(std::ostream& os, const MutableString& s) {
+    return os << s.value();
+}
 
 class Register {
 public:
@@ -87,7 +131,7 @@ public:
 #define CONF_mInt32(name, defaultstr) DEFINE_FIELD(int32_t, name, defaultstr, true)
 #define CONF_mInt64(name, defaultstr) DEFINE_FIELD(int64_t, name, defaultstr, true)
 #define CONF_mDouble(name, defaultstr) DEFINE_FIELD(double, name, defaultstr, true)
-#define CONF_mString(name, defaultstr) DEFINE_FIELD(std::string, name, defaultstr, true)
+#define CONF_mString(name, defaultstr) DEFINE_FIELD(MutableString, name, defaultstr, true)
 #else
 #define CONF_Bool(name, defaultstr) DECLARE_FIELD(bool, name)
 #define CONF_Int16(name, defaultstr) DECLARE_FIELD(int16_t, name)
@@ -106,7 +150,7 @@ public:
 #define CONF_mInt32(name, defaultstr) DECLARE_FIELD(int32_t, name)
 #define CONF_mInt64(name, defaultstr) DECLARE_FIELD(int64_t, name)
 #define CONF_mDouble(name, defaultstr) DECLARE_FIELD(double, name)
-#define CONF_mString(name, defaultstr) DECLARE_FIELD(std::string, name)
+#define CONF_mString(name, defaultstr) DECLARE_FIELD(MutableString, name)
 #endif
 
 // Configuration properties load from config file.
@@ -128,8 +172,6 @@ extern std::map<std::string, std::string>* full_conf_map;
 bool init(const char* filename, bool fillconfmap = false);
 
 Status set_config(const std::string& field, const std::string& value);
-
-std::mutex* get_mstring_conf_lock();
 
 std::vector<ConfigInfo> list_configs();
 

--- a/be/src/http/default_path_handlers.cpp
+++ b/be/src/http/default_path_handlers.cpp
@@ -84,7 +84,6 @@ void logs_handler(const WebPageHandler::ArgumentMap& args, std::stringstream* ou
 void config_handler(const WebPageHandler::ArgumentMap& args, std::stringstream* output) {
     (*output) << "<h2>Configurations</h2>";
     (*output) << "<pre>";
-    std::lock_guard<std::mutex> l(*config::get_mstring_conf_lock());
     for (const auto& it : *(config::full_conf_map)) {
         (*output) << it.first << "=" << it.second << std::endl;
     }

--- a/be/src/runtime/exec_env.cpp
+++ b/be/src/runtime/exec_env.cpp
@@ -257,18 +257,17 @@ void GlobalEnv::_init_storage_page_cache() {
 }
 
 int64_t GlobalEnv::get_storage_page_cache_size() {
-    std::lock_guard<std::mutex> l(*config::get_mstring_conf_lock());
     int64_t mem_limit = MemInfo::physical_mem();
     if (process_mem_tracker()->has_limit()) {
         mem_limit = process_mem_tracker()->limit();
     }
-    return ParseUtil::parse_mem_spec(config::storage_page_cache_limit, mem_limit);
+    return ParseUtil::parse_mem_spec(config::storage_page_cache_limit.value(), mem_limit);
 }
 
 int64_t GlobalEnv::check_storage_page_cache_size(int64_t storage_cache_limit) {
     if (storage_cache_limit > MemInfo::physical_mem()) {
         LOG(WARNING) << "Config storage_page_cache_limit is greater than memory size, config="
-                     << config::storage_page_cache_limit << ", memory=" << MemInfo::physical_mem();
+                     << config::storage_page_cache_limit.value() << ", memory=" << MemInfo::physical_mem();
     }
     if (!config::disable_storage_page_cache) {
         if (storage_cache_limit < kcacheMinSize) {

--- a/be/src/storage/lake/vacuum.cpp
+++ b/be/src/storage/lake/vacuum.cpp
@@ -88,7 +88,7 @@ bool should_retry(const Status& st, int64_t attempted_retries) {
         return true;
     }
     auto message = st.message();
-    return MatchPattern(message, config::lake_vacuum_retry_pattern);
+    return MatchPattern(message, config::lake_vacuum_retry_pattern.value());
 }
 
 int64_t calculate_retry_delay(int64_t attempted_retries) {

--- a/be/test/storage/lake/vacuum_test.cpp
+++ b/be/test/storage/lake/vacuum_test.cpp
@@ -1311,7 +1311,7 @@ TEST(LakeVacuumTest2, test_delete_files_retry2) {
     ASSERT_OK(f1->append("111"));
     ASSERT_OK(f1->close());
 
-    auto backup = config::lake_vacuum_retry_pattern;
+    auto backup = config::lake_vacuum_retry_pattern.value();
     config::lake_vacuum_retry_pattern = ""; // Disable retry
     DeferOp defer0([&]() { config::lake_vacuum_retry_pattern = backup; });
 


### PR DESCRIPTION
## Why I'm doing:
BE's allows the definition of string configurations that can be dynamically modified at runtime. In order to avoid multi-threaded contention issues, these mutable string configurations are protected by a global mutex lock `mstring_conf_lock`, which needs to be acquired before reading or writing mutable string configurations to ensure thread safety.
There are two problems with this:
1. it's easy to forget to acquire `mstring_conf_lock` before reading or writing mutable string config, which did happened right now.
2. The global lock `mstring_conf_lock` has a potential multi-threaded scability issue.

## What I'm doing:
Define mutable string config as a `MutableString` type and provide thread-safe read and write interfaces. Instead of explicitly acquiring a global lock, users can access mutable string config as if it were a normal variable.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [x] 3.1
  - [x] 3.0
  - [x] 2.5
