### PR TITLE
[Enhancement] Add build host distributor into FE/BE version info

### DIFF
--- a/be/src/common/version.h
+++ b/be/src/common/version.h
@@ -21,4 +21,5 @@ extern const char* STARROCKS_BUILD_TYPE;
 extern const char* STARROCKS_BUILD_TIME;
 extern const char* STARROCKS_BUILD_USER;
 extern const char* STARROCKS_BUILD_HOST;
+extern const char* STARROCKS_BUILD_DISTRO_ID;
 } // namespace starrocks

--- a/be/src/util/debug_util.cpp
+++ b/be/src/util/debug_util.cpp
@@ -65,6 +65,7 @@ std::string get_build_version(bool compact) {
     ss << STARROCKS_VERSION << "-" << STARROCKS_COMMIT_HASH << std::endl << "BuildType: " << STARROCKS_BUILD_TYPE;
     if (!compact) {
         ss << std::endl
+           << "Build distributor id: " << STARROCKS_BUILD_DISTRO_ID << std::endl
            << "Built on " << STARROCKS_BUILD_TIME << " by " << STARROCKS_BUILD_USER << "@" << STARROCKS_BUILD_HOST;
     }
 

--- a/bin/show_fe_version.sh
+++ b/bin/show_fe_version.sh
@@ -47,7 +47,7 @@ if [ -f $PID_DIR/fe.pid ]; then
     mv $PID_DIR/fe.pid $PID_DIR/fe.pid.bak
 fi
 
-$JAVA com.starrocks.StarRocksFE -v 2>/dev/null | tail -5
+$JAVA com.starrocks.StarRocksFE -v
 
 if [ -f $PID_DIR/fe.pid.bak ]; then 
     mv $PID_DIR/fe.pid.bak $PID_DIR/fe.pid 

--- a/fe/fe-core/src/main/java/com/starrocks/StarRocksFE.java
+++ b/fe/fe-core/src/main/java/com/starrocks/StarRocksFE.java
@@ -107,15 +107,16 @@ public class StarRocksFE {
             // init config
             new Config().init(starRocksDir + "/conf/fe.conf");
 
+            // check command line options
+            // NOTE: do it before init log4jConfig to avoid unnecessary stdout messages
+            checkCommandLineOptions(cmdLineOpts);
+
             Log4jConfig.initLogging();
 
             // set dns cache ttl
             java.security.Security.setProperty("networkaddress.cache.ttl", "60");
             // Need to put if before `GlobalStateMgr.getCurrentState().waitForReady()`, because it may access aws service
             setAWSHttpClient();
-
-            // check command line options
-            checkCommandLineOptions(cmdLineOpts);
 
             // check meta dir
             MetaHelper.checkMetaDir();
@@ -333,6 +334,7 @@ public class StarRocksFE {
             System.out.println("Commit hash: " + Version.STARROCKS_COMMIT_HASH);
             System.out.println("Build type: " + Version.STARROCKS_BUILD_TYPE);
             System.out.println("Build time: " + Version.STARROCKS_BUILD_TIME);
+            System.out.println("Build distributor id: " + Version.STARROCKS_BUILD_DISTRO_ID);
             System.out.println("Build user: " + Version.STARROCKS_BUILD_USER + "@" + Version.STARROCKS_BUILD_HOST);
             System.out.println("Java compile version: " + Version.STARROCKS_JAVA_COMPILE_VERSION);
             System.exit(0);


### PR DESCRIPTION
* add 'Build distributor id' info into fe/be version info
* be able to known which distributor id the artifact is built on

## Why I'm doing:

## What I'm doing:

Example output with this PR:

* FE
```
root@f221cc40947e:~/starrocks/output# ./fe/bin/show_fe_version.sh
Build version: build_id
Commit hash: 1bd2705
Build type: RELEASE
Build time: 2024-02-28 08:52:43
Build distributor id: ubuntu
Build user: StarRocks@docker (Ubuntu 22.04.3 LTS)
Java compile version: openjdk full version "11.0.20.1+1-post-Ubuntu-0ubuntu122.04"
```
* BE
```
root@f221cc40947e:~/starrocks/output# ./be/bin/show_be_version.sh
build_id-1bd2705
BuildType: RELEASE
Build distributor id: ubuntu
Built on 2024-02-28 08:27:35 by StarRocks@docker (Ubuntu 22.04.3 LTS)
```

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [X] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [X] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [X] I have checked the version labels which the pr will be auto-backported to the target branch
  - [X] 3.2
  - [X] 3.1
  - [X] 3.0
  - [ ] 2.5
