### PR TITLE
[BugFix] Fix uncorrect key columns in DictQueryExpr

### DIFF
--- a/be/src/exprs/dict_query_expr.cpp
+++ b/be/src/exprs/dict_query_expr.cpp
@@ -44,7 +44,8 @@ StatusOr<ColumnPtr> DictQueryExpr::evaluate_checked(ExprContext* context, Chunk*
         }
     }
 
-    Columns key_columns(columns.begin() + 1, columns.end());
+    // key_columns should be columns[1] ~ columns[1 + _dict_query_expr.key_fields.size()]
+    Columns key_columns(columns.begin() + 1, columns.begin() + 1 + _dict_query_expr.key_fields.size());
     DCHECK(_key_schema.num_fields() == key_columns.size());
     auto key_chunk = std::make_unique<Chunk>(std::move(key_columns), std::make_shared<Schema>(_key_schema));
     key_chunk->check_or_die();

--- a/test/sql/test_dict_mapping_function/R/test_dict_mapping_function
+++ b/test/sql/test_dict_mapping_function/R/test_dict_mapping_function
@@ -191,6 +191,12 @@ insert into fact_tbl_2
                 (3, 'Shanghai', Dict_Mapping("dict", cast(3 as int), "col_4"));
 -- result:
 -- !result
+SELECT * FROM fact_tbl_2;
+-- result:
+1	Beijing	1
+2	Shenzhen	2
+3	Shanghai	30
+-- !result
 DROP DATABASE test_dictmapping_DictQueryOperator_bug;
 -- result:
 -- !result

--- a/test/sql/test_dict_mapping_function/T/test_dict_mapping_function
+++ b/test/sql/test_dict_mapping_function/T/test_dict_mapping_function
@@ -116,5 +116,5 @@ insert into fact_tbl_2
                 (1, 'Beijing', DICT_mapping("dict", cast(1 as int))),
                 (2, 'Shenzhen', DICT_MAPping("dict", cast(2 as int), "col_3")),
                 (3, 'Shanghai', Dict_Mapping("dict", cast(3 as int), "col_4"));
-
+SELECT * FROM fact_tbl_2;
 DROP DATABASE test_dictmapping_DictQueryOperator_bug;


### PR DESCRIPTION
Problem:
In DictQueryExpr, we will construct key columns using children exprs. But we construct the wrong keys because sometimes, children exprs will contain some other extra optional function parameter and make the key columns is uncorrect.

Solution:
Construct key columns from columns[1] ~ columns[1 + key_size]

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
