### PR TITLE
[BugFix] Ensure changing heartbeat_service_port take effect

### DIFF
--- a/docker/dockerfiles/be/cn_entrypoint.sh
+++ b/docker/dockerfiles/be/cn_entrypoint.sh
@@ -170,11 +170,11 @@ if [[ "x$svc_name" == "x" ]] ; then
     exit 1
 fi
 
+update_conf_from_configmap
 collect_env_info
 add_self $svc_name || exit $?
 trap exit_clean SIGTERM
 
-update_conf_from_configmap
 log_stderr "run start_cn.sh"
 
 addition_args=


### PR DESCRIPTION
## Why I'm doing:

In k8s env, when user changed the heartbeat_service_port in cn.conf, `cn_entrypoint.sh` still use the 9050 port to execute `ALTER SYSTEM ADD COMPUTE NODE ...`.

Eventually CN failed to join the StarRocks Cluster.
```
mysql> mysql> show compute nodes;
+---------------+--------------------------------------------------------------------------+---------------+--------+----------+----------+---------------------+---------------------+-------+----------------------+-----------------------+--------------------------------------------------------------------+---------------+----------+-------------------+------------+------------+----------------+-------------+----------+
| ComputeNodeId | IP                                                                       | HeartbeatPort | BePort | HttpPort | BrpcPort | LastStartTime       | LastHeartbeat       | Alive | SystemDecommissioned | ClusterDecommissioned | ErrMsg                                                             | Version       | CpuCores | NumRunningQueries | MemUsedPct | CpuUsedPct | HasStoragePath | StarletPort | WorkerId |
+---------------+--------------------------------------------------------------------------+---------------+--------+----------+----------+---------------------+---------------------+-------+----------------------+-----------------------+--------------------------------------------------------------------+---------------+----------+-------------------+------------+------------+----------------+-------------+----------+
| 10079         | kube-starrocks-cn-0.kube-starrocks-cn-search.starrocks.svc.cluster.local | 9050          | -1     | -1       | -1       | NULL                | NULL                | false | false                | false                 | java.net.ConnectException: Connection refused (Connection refused) |               | 0        | 0                 | 0.00 %     | 0.0 %      | false          | 0           | -1       |
+---------------+--------------------------------------------------------------------------+---------------+--------+----------+----------+---------------------+---------------------+-------+----------------------+-----------------------+--------------------------------------------------------------------+---------------+----------+-------------------+------------+------------+----------------+-------------+----------+
2 rows in set (0.02 sec)
```

## What I'm doing:

Find the error logic in cn_entrypoint.sh and fix it.

Build a new container image and test the logic.
```
FROM starrocks/cn-ubuntu:3.2.2

COPY cn_entrypoint.sh /opt/starrocks/cn_entrypoint.sh
```

the result:
```
mysql> show compute nodes;
+---------------+--------------------------------------------------------------------------+---------------+--------+----------+----------+---------------------+---------------------+-------+----------------------+-----------------------+--------+---------------+----------+-------------------+------------+------------+----------------+-------------+----------+
| ComputeNodeId | IP                                                                       | HeartbeatPort | BePort | HttpPort | BrpcPort | LastStartTime       | LastHeartbeat       | Alive | SystemDecommissioned | ClusterDecommissioned | ErrMsg | Version       | CpuCores | NumRunningQueries | MemUsedPct | CpuUsedPct | HasStoragePath | StarletPort | WorkerId |
+---------------+--------------------------------------------------------------------------+---------------+--------+----------+----------+---------------------+---------------------+-------+----------------------+-----------------------+--------+---------------+----------+-------------------+------------+------------+----------------+-------------+----------+
| 10084         | kube-starrocks-cn-0.kube-starrocks-cn-search.starrocks.svc.cluster.local | 19050         | 19060  | 18040    | 18060    | 2024-02-21 11:00:24 | 2024-02-21 11:00:24 | true  | false                | false                 |        | 3.2.2-269e832 | 8        | 0                 | 1.88 %     | 0.1 %      | true           | 9070        | 16       |
+---------------+--------------------------------------------------------------------------+---------------+--------+----------+----------+---------------------+---------------------+-------+----------------------+-----------------------+--------+---------------+----------+-------------------+------------+------------+----------------+-------------+----------+
```

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [x] 3.1
  - [x] 3.0
  - [x] 2.5
