### PR TITLE
[BugFix] Fix analyze problem for dict_mapping function (#40897)

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/alter/SchemaChangeJobV2.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/SchemaChangeJobV2.java
@@ -597,7 +597,11 @@ public class SchemaChangeJobV2 extends AlterJobV2 {
                                                     new Field(col.getName(), col.getType(), tableName, null))
                                             .collect(Collectors.toList())));
 
-                            ConnectContext.get().setDatabase(db.getFullName());
+                            if (ConnectContext.get() == null) {
+                                LOG.warn("Connect Context is null when add/modify generated column");
+                            } else {
+                                ConnectContext.get().setDatabase(db.getFullName());
+                            }
 
                             RewriteAliasVisitor visitor =
                                     new RewriteAliasVisitor(sourceScope, outputScope,

--- a/fe/fe-core/src/main/java/com/starrocks/alter/SchemaChangeJobV2.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/SchemaChangeJobV2.java
@@ -78,7 +78,6 @@ import com.starrocks.common.util.concurrent.lock.Locker;
 import com.starrocks.journal.JournalTask;
 import com.starrocks.persist.EditLog;
 import com.starrocks.persist.gson.GsonUtils;
-import com.starrocks.privilege.PrivilegeBuiltinConstants;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.sql.analyzer.AnalyzeState;
@@ -88,7 +87,6 @@ import com.starrocks.sql.analyzer.RelationFields;
 import com.starrocks.sql.analyzer.RelationId;
 import com.starrocks.sql.analyzer.Scope;
 import com.starrocks.sql.analyzer.SelectAnalyzer.RewriteAliasVisitor;
-import com.starrocks.sql.ast.UserIdentity;
 import com.starrocks.sql.optimizer.statistics.IDictManager;
 import com.starrocks.task.AgentBatchTask;
 import com.starrocks.task.AgentTask;
@@ -599,14 +597,6 @@ public class SchemaChangeJobV2 extends AlterJobV2 {
                                                     new Field(col.getName(), col.getType(), tableName, null))
                                             .collect(Collectors.toList())));
 
-                            if (ConnectContext.get() == null) {
-                                ConnectContext context = new ConnectContext();
-                                context.setGlobalStateMgr(GlobalStateMgr.getCurrentState());
-                                context.setCurrentUserIdentity(UserIdentity.ROOT);
-                                context.setCurrentRoleIds(Sets.newHashSet(PrivilegeBuiltinConstants.ROOT_ROLE_ID));
-                                context.setQualifiedUser(UserIdentity.ROOT.getUser());
-                                context.setThreadLocalInfo();
-                            }
                             ConnectContext.get().setDatabase(db.getFullName());
 
                             RewriteAliasVisitor visitor =

--- a/fe/fe-core/src/main/java/com/starrocks/alter/SchemaChangeJobV2.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/SchemaChangeJobV2.java
@@ -78,6 +78,7 @@ import com.starrocks.common.util.concurrent.lock.Locker;
 import com.starrocks.journal.JournalTask;
 import com.starrocks.persist.EditLog;
 import com.starrocks.persist.gson.GsonUtils;
+import com.starrocks.privilege.PrivilegeBuiltinConstants;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.sql.analyzer.AnalyzeState;
@@ -87,6 +88,7 @@ import com.starrocks.sql.analyzer.RelationFields;
 import com.starrocks.sql.analyzer.RelationId;
 import com.starrocks.sql.analyzer.Scope;
 import com.starrocks.sql.analyzer.SelectAnalyzer.RewriteAliasVisitor;
+import com.starrocks.sql.ast.UserIdentity;
 import com.starrocks.sql.optimizer.statistics.IDictManager;
 import com.starrocks.task.AgentBatchTask;
 import com.starrocks.task.AgentTask;
@@ -596,6 +598,16 @@ public class SchemaChangeJobV2 extends AlterJobV2 {
                                     new RelationFields(tbl.getBaseSchema().stream().map(col ->
                                                     new Field(col.getName(), col.getType(), tableName, null))
                                             .collect(Collectors.toList())));
+
+                            if (ConnectContext.get() == null) {
+                                ConnectContext context = new ConnectContext();
+                                context.setGlobalStateMgr(GlobalStateMgr.getCurrentState());
+                                context.setCurrentUserIdentity(UserIdentity.ROOT);
+                                context.setCurrentRoleIds(Sets.newHashSet(PrivilegeBuiltinConstants.ROOT_ROLE_ID));
+                                context.setQualifiedUser(UserIdentity.ROOT.getUser());
+                                context.setThreadLocalInfo();
+                            }
+                            ConnectContext.get().setDatabase(db.getFullName());
 
                             RewriteAliasVisitor visitor =
                                     new RewriteAliasVisitor(sourceScope, outputScope,

--- a/fe/fe-core/src/main/java/com/starrocks/load/Load.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/Load.java
@@ -615,6 +615,7 @@ public class Load {
                         context.setThreadLocalInfo();
                     }
                     ConnectContext.get().setDatabase(dbName);
+                    break;
                 }
             }
         }

--- a/fe/fe-core/src/main/java/com/starrocks/load/Load.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/Load.java
@@ -44,6 +44,7 @@ import com.starrocks.analysis.Analyzer;
 import com.starrocks.analysis.BinaryPredicate;
 import com.starrocks.analysis.BinaryType;
 import com.starrocks.analysis.CastExpr;
+import com.starrocks.analysis.DictQueryExpr;
 import com.starrocks.analysis.Expr;
 import com.starrocks.analysis.ExprSubstitutionMap;
 import com.starrocks.analysis.FunctionCallExpr;
@@ -74,6 +75,7 @@ import com.starrocks.common.Pair;
 import com.starrocks.common.StarRocksFEMetaVersion;
 import com.starrocks.common.UserException;
 import com.starrocks.load.loadv2.JobState;
+import com.starrocks.privilege.PrivilegeBuiltinConstants;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.sql.analyzer.AnalyzeState;
@@ -257,6 +259,12 @@ public class Load {
             shadowColumnDescs.add(importColumnDesc);
         }
         return shadowColumnDescs;
+    }
+
+    public static boolean checDictQueryExpr(Expr checkExpr) {
+        List<DictQueryExpr> result = Lists.newArrayList();
+        checkExpr.collect(DictQueryExpr.class, result);
+        return result.size() != 0;
     }
 
     public static boolean tableSupportOpColumn(Table tbl) {
@@ -591,6 +599,23 @@ public class Load {
         for (Column column : tbl.getFullSchema()) {
             if (column.getDefineExpr() != null) {
                 mvDefineExpr.put(column.getName(), column.getDefineExpr());
+            }
+        }
+
+
+        if (dbName != "") {
+            for (Entry<String, Expr> entry : exprsByName.entrySet()) {
+                if (entry.getValue() != null && checDictQueryExpr(entry.getValue())) {
+                    if (ConnectContext.get() == null) {
+                        ConnectContext context = new ConnectContext();
+                        context.setGlobalStateMgr(GlobalStateMgr.getCurrentState());
+                        context.setCurrentUserIdentity(UserIdentity.ROOT);
+                        context.setCurrentRoleIds(Sets.newHashSet(PrivilegeBuiltinConstants.ROOT_ROLE_ID));
+                        context.setQualifiedUser(UserIdentity.ROOT.getUser());
+                        context.setThreadLocalInfo();
+                    }
+                    ConnectContext.get().setDatabase(dbName);
+                }
             }
         }
 

--- a/fe/fe-core/src/main/java/com/starrocks/load/Load.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/Load.java
@@ -603,7 +603,7 @@ public class Load {
         }
 
 
-        if (dbName != "") {
+        if (dbName != null && !dbName.isEmpty()) {
             for (Entry<String, Expr> entry : exprsByName.entrySet()) {
                 if (entry.getValue() != null && checDictQueryExpr(entry.getValue())) {
                     if (ConnectContext.get() == null) {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/CreateTableAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/CreateTableAnalyzer.java
@@ -485,7 +485,7 @@ public class CreateTableAnalyzer {
                         for (SlotRef slot : slots) {
                             Column refColumn = columnsMap.get(slot.getColumnName());
                             if (refColumn == null) {
-                                throw new SemanticException("column:" + slot.getColumnName() + " does not existed");
+                                throw new SemanticException("column:" + slot.getColumnName() + " does not exist");
                             }
                             if (refColumn.isGeneratedColumn()) {
                                 throw new SemanticException("Expression can not refers to other generated columns");

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/CreateTableAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/CreateTableAnalyzer.java
@@ -484,6 +484,9 @@ public class CreateTableAnalyzer {
                     if (slots.size() != 0) {
                         for (SlotRef slot : slots) {
                             Column refColumn = columnsMap.get(slot.getColumnName());
+                            if (refColumn == null) {
+                                throw new SemanticException("column:" + slot.getColumnName() + " does not existed");
+                            }
                             if (refColumn.isGeneratedColumn()) {
                                 throw new SemanticException("Expression can not refers to other generated columns");
                             }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/DictQueryFunctionTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/DictQueryFunctionTest.java
@@ -199,9 +199,6 @@ public class DictQueryFunctionTest {
                 }
                 throw new RuntimeException("expect no exception, actual: " + e.getMessage(), e);
             }
-            if (expectException != null) {
-                throw new RuntimeException(String.format("expect exception: %s, actual no exception", expectException.getName()));
-            }
         }
 
     }

--- a/test/sql/test_dict_mapping_function/R/test_dict_mapping_function
+++ b/test/sql/test_dict_mapping_function/R/test_dict_mapping_function
@@ -1,11 +1,11 @@
--- name: test_expression_cast
-CREATE DATABASE test_expression_cast_db;
+-- name: test_dict_mapping_streamload
+CREATE DATABASE test_dict_mapping_streamload;
 -- result:
 -- !result
-USE test_expression_cast_db;
+USE test_dict_mapping_streamload;
 -- result:
 -- !result
-CREATE TABLE `t_expression_cast` (
+CREATE TABLE `t_dict_mapping_streamload` (
   `id1` bigint(20) NOT NULL COMMENT "",
   `id2` bigint(20) NOT NULL AUTO_INCREMENT COMMENT ""
 ) ENGINE=OLAP 
@@ -20,7 +20,7 @@ PROPERTIES (
 );
 -- result:
 -- !result
-INSERT INTO t_expression_cast VALUES (1, DEFAULT),(2, DEFAULT),(3, DEFAULT);
+INSERT INTO t_dict_mapping_streamload VALUES (1, DEFAULT),(2, DEFAULT),(3, DEFAULT);
 -- result:
 -- !result
 CREATE TABLE `test_table` (
@@ -38,7 +38,7 @@ PROPERTIES (
 );
 -- result:
 -- !result
-shell: curl --location-trusted -u root: -T ${root_path}/lib/../common/data/stream_load/sr_dict_mapping_case_1.csv -XPUT -H partial_update:false -H label:stream_load_dict_mapping_case_1 -H column_separator:, -H columns:"xx, id1=xx, id2=dict_mapping('test_expression_cast_db.t_expression_cast', cast(xx as BIGINT))" ${url}/api/test_expression_cast_db/test_table/_stream_load
+shell: curl --location-trusted -u root: -T ${root_path}/lib/../common/data/stream_load/sr_dict_mapping_case_1.csv -XPUT -H partial_update:false -H label:stream_load_dict_mapping_case_1 -H column_separator:, -H columns:"id1, id2=dict_mapping('t_dict_mapping_streamload', id1)" ${url}/api/test_dict_mapping_streamload/test_table/_stream_load
 -- result:
 0
 {
@@ -55,10 +55,10 @@ SELECT * FROM test_table;
 2	2
 3	3
 -- !result
-DROP TABLE t_expression_cast;
+DROP TABLE t_dict_mapping_streamload;
 -- result:
 -- !result
-DROP DATABASE test_expression_cast_db;
+DROP DATABASE test_dict_mapping_streamload;
 -- result:
 -- !result
 -- name: test_dictmapping_multiple_column
@@ -186,17 +186,83 @@ PROPERTIES (
 -- !result
 insert into fact_tbl_2
                 values
-                (1, 'Beijing', DICT_mapping("dict", cast(1 as int))),
-                (2, 'Shenzhen', DICT_MAPping("dict", cast(2 as int), "col_3")),
-                (3, 'Shanghai', Dict_Mapping("dict", cast(3 as int), "col_4"));
+                (1, 'Beijing', DICT_mapping("dict", 1)),
+                (2, 'Shenzhen', DICT_MAPping("dict", 2, "col_3")),
+                (3, 'Shanghai', Dict_Mapping("dict", 3, "col_4"));
 -- result:
--- !result
-SELECT * FROM fact_tbl_2 ORDER BY col_i;
--- result:
-1	Beijing	1
-2	Shenzhen	2
-3	Shanghai	30
 -- !result
 DROP DATABASE test_dictmapping_DictQueryOperator_bug;
+-- result:
+-- !result
+-- name: test_dictmapping_add_generated_column_with_dict_mapping
+CREATE DATABASE test_dictmapping_add_generated_column_with_dict_mapping;
+-- result:
+-- !result
+USE test_dictmapping_add_generated_column_with_dict_mapping;
+-- result:
+-- !result
+create table dict(col_1 int, col_2 string, col_3 bigint not null auto_increment, col_4 int)
+primary key(col_1, col_2)
+distributed by hash(col_1, col_2)
+PROPERTIES (
+"replication_num" = "1"
+);
+-- result:
+-- !result
+INSERT INTO dict VALUES (1, "abc", default, 0);
+-- result:
+-- !result
+create table t_dictmapping_add_generated_column_with_dict_mapping(col_1 int, col_2 string)
+primary key(col_1)
+distributed by hash(col_1)
+PROPERTIES (
+"replication_num" = "1"
+);
+-- result:
+-- !result
+INSERT INTO t_dictmapping_add_generated_column_with_dict_mapping VALUES (1, "abc");
+-- result:
+-- !result
+ALTER TABLE t_dictmapping_add_generated_column_with_dict_mapping ADD COLUMN newcol BIGINT AS
+dict_mapping("dict", col_1, col_2);
+-- result:
+-- !result
+function: wait_alter_table_finish()
+-- result:
+None
+-- !result
+SELECT * FROM t_dictmapping_add_generated_column_with_dict_mapping;
+-- result:
+1	abc	1
+-- !result
+DROP TABLE t_dictmapping_add_generated_column_with_dict_mapping;
+-- result:
+-- !result
+DROP DATABASE test_dictmapping_add_generated_column_with_dict_mapping;
+-- result:
+-- !result
+-- name: test_dictmapping_generated_column_in_create_table
+CREATE DATABASE test_dictmapping_generated_column_in_create_table;
+-- result:
+-- !result
+USE test_dictmapping_generated_column_in_create_table;
+-- result:
+-- !result
+create table dict(col_1 int, col_2 string, col_3 bigint not null auto_increment, col_4 int)
+primary key(col_1)
+distributed by hash(col_1)
+PROPERTIES (
+"replication_num" = "1"
+);
+-- result:
+-- !result
+create table fact_tbl_1(col_1 int, col_2 varchar(20), col_mapvalue bigint as Dict_Mapping("dict", COL_1, false))
+PROPERTIES (
+"replication_num" = "1"
+);
+-- result:
+E: (1064, 'Getting analyzing error. Detail message: column:COL_1 does not existed.')
+-- !result
+DROP DATABASE test_dictmapping_generated_column_in_create_table;
 -- result:
 -- !result

--- a/test/sql/test_dict_mapping_function/R/test_dict_mapping_function
+++ b/test/sql/test_dict_mapping_function/R/test_dict_mapping_function
@@ -261,7 +261,7 @@ PROPERTIES (
 "replication_num" = "1"
 );
 -- result:
-E: (1064, 'Getting analyzing error. Detail message: column:COL_1 does not existed.')
+E: (1064, 'Getting analyzing error. Detail message: column:COL_1 does not exist.')
 -- !result
 DROP DATABASE test_dictmapping_generated_column_in_create_table;
 -- result:

--- a/test/sql/test_dict_mapping_function/T/test_dict_mapping_function
+++ b/test/sql/test_dict_mapping_function/T/test_dict_mapping_function
@@ -1,7 +1,7 @@
--- name: test_expression_cast
-CREATE DATABASE test_expression_cast_db;
-USE test_expression_cast_db;
-CREATE TABLE `t_expression_cast` (
+-- name: test_dict_mapping_streamload
+CREATE DATABASE test_dict_mapping_streamload;
+USE test_dict_mapping_streamload;
+CREATE TABLE `t_dict_mapping_streamload` (
   `id1` bigint(20) NOT NULL COMMENT "",
   `id2` bigint(20) NOT NULL AUTO_INCREMENT COMMENT ""
 ) ENGINE=OLAP 
@@ -15,7 +15,7 @@ PROPERTIES (
 "compression" = "LZ4"
 );
 
-INSERT INTO t_expression_cast VALUES (1, DEFAULT),(2, DEFAULT),(3, DEFAULT);
+INSERT INTO t_dict_mapping_streamload VALUES (1, DEFAULT),(2, DEFAULT),(3, DEFAULT);
 
 CREATE TABLE `test_table` (
   `id1` bigint(20) NOT NULL COMMENT "",
@@ -31,12 +31,12 @@ PROPERTIES (
 "compression" = "LZ4"
 );
 
-shell: curl --location-trusted -u root: -T ${root_path}/lib/../common/data/stream_load/sr_dict_mapping_case_1.csv -XPUT -H partial_update:false -H label:stream_load_dict_mapping_case_1 -H column_separator:, -H columns:"xx, id1=xx, id2=dict_mapping('test_expression_cast_db.t_expression_cast', cast(xx as BIGINT))" ${url}/api/test_expression_cast_db/test_table/_stream_load
+shell: curl --location-trusted -u root: -T ${root_path}/lib/../common/data/stream_load/sr_dict_mapping_case_1.csv -XPUT -H partial_update:false -H label:stream_load_dict_mapping_case_1 -H column_separator:, -H columns:"id1, id2=dict_mapping('t_dict_mapping_streamload', id1)" ${url}/api/test_dict_mapping_streamload/test_table/_stream_load
 sync;
 
 SELECT * FROM test_table;
-DROP TABLE t_expression_cast;
-DROP DATABASE test_expression_cast_db;
+DROP TABLE t_dict_mapping_streamload;
+DROP DATABASE test_dict_mapping_streamload;
 
 -- name: test_dictmapping_multiple_column
 CREATE DATABASE test_dictmapping_multiple_column;
@@ -113,8 +113,54 @@ PROPERTIES (
 );
 insert into fact_tbl_2
                 values
-                (1, 'Beijing', DICT_mapping("dict", cast(1 as int))),
-                (2, 'Shenzhen', DICT_MAPping("dict", cast(2 as int), "col_3")),
-                (3, 'Shanghai', Dict_Mapping("dict", cast(3 as int), "col_4"));
-SELECT * FROM fact_tbl_2 ORDER BY col_i;
+                (1, 'Beijing', DICT_mapping("dict", 1)),
+                (2, 'Shenzhen', DICT_MAPping("dict", 2, "col_3")),
+                (3, 'Shanghai', Dict_Mapping("dict", 3, "col_4"));
 DROP DATABASE test_dictmapping_DictQueryOperator_bug;
+
+-- name: test_dictmapping_add_generated_column_with_dict_mapping
+CREATE DATABASE test_dictmapping_add_generated_column_with_dict_mapping;
+USE test_dictmapping_add_generated_column_with_dict_mapping;
+
+create table dict(col_1 int, col_2 string, col_3 bigint not null auto_increment, col_4 int)
+primary key(col_1, col_2)
+distributed by hash(col_1, col_2)
+PROPERTIES (
+"replication_num" = "1"
+);
+
+INSERT INTO dict VALUES (1, "abc", default, 0);
+
+create table t_dictmapping_add_generated_column_with_dict_mapping(col_1 int, col_2 string)
+primary key(col_1)
+distributed by hash(col_1)
+PROPERTIES (
+"replication_num" = "1"
+);
+
+INSERT INTO t_dictmapping_add_generated_column_with_dict_mapping VALUES (1, "abc");
+ALTER TABLE t_dictmapping_add_generated_column_with_dict_mapping ADD COLUMN newcol BIGINT AS
+dict_mapping("dict", col_1, col_2);
+function: wait_alter_table_finish()
+SELECT * FROM t_dictmapping_add_generated_column_with_dict_mapping;
+
+DROP TABLE t_dictmapping_add_generated_column_with_dict_mapping;
+DROP DATABASE test_dictmapping_add_generated_column_with_dict_mapping;
+
+-- name: test_dictmapping_generated_column_in_create_table
+CREATE DATABASE test_dictmapping_generated_column_in_create_table;
+USE test_dictmapping_generated_column_in_create_table;
+
+create table dict(col_1 int, col_2 string, col_3 bigint not null auto_increment, col_4 int)
+primary key(col_1)
+distributed by hash(col_1)
+PROPERTIES (
+"replication_num" = "1"
+);
+
+create table fact_tbl_1(col_1 int, col_2 varchar(20), col_mapvalue bigint as Dict_Mapping("dict", COL_1, false))
+PROPERTIES (
+"replication_num" = "1"
+);
+
+DROP DATABASE test_dictmapping_generated_column_in_create_table;


### PR DESCRIPTION
No DB selected:
1. If we execute a streamload with dict_mapping like dict_mapping(dict_table) name
we sill get no db selected exception unless we use dict_mapping(db.dict_table).
It is because ConnectContext.get() is NULL when analyze dict_mapping expression.
2. Add a generated column with dict_mapping like dict_mapping(dict_table) with
get no db selected exception. It is because ConnectContext.get() is NULL
when analyze dict_mapping expression for generated column.

NPE problem:
If we specify a generated column with dict_mapping expression in create table stmt
with wrong column name, will get NPE problem
(See SQL-TEST test_dictmapping_generated_column_in_create_table)

Cast Type problem:
Support dict_table has INT key column, and we call dict_mapping(dict_table, 1) will
fail. Because 1 is tinyint by default.

Solution:

For No DB selected:
Construct a new ConnectContext to analyze

For NPE problem:
Check column is null or not

For Cast Type problem:
Cast the type to target key column type in anaylze phase

Fixes #40897

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
