### PR TITLE
[UT] Fix unstable DictQueryOperator sql-test

### DIFF
--- a/test/sql/test_dict_mapping_function/R/test_dict_mapping_function
+++ b/test/sql/test_dict_mapping_function/R/test_dict_mapping_function
@@ -191,7 +191,7 @@ insert into fact_tbl_2
                 (3, 'Shanghai', Dict_Mapping("dict", cast(3 as int), "col_4"));
 -- result:
 -- !result
-SELECT * FROM fact_tbl_2;
+SELECT * FROM fact_tbl_2 ORDER BY col_i;
 -- result:
 1	Beijing	1
 2	Shenzhen	2

--- a/test/sql/test_dict_mapping_function/T/test_dict_mapping_function
+++ b/test/sql/test_dict_mapping_function/T/test_dict_mapping_function
@@ -116,5 +116,5 @@ insert into fact_tbl_2
                 (1, 'Beijing', DICT_mapping("dict", cast(1 as int))),
                 (2, 'Shenzhen', DICT_MAPping("dict", cast(2 as int), "col_3")),
                 (3, 'Shanghai', Dict_Mapping("dict", cast(3 as int), "col_4"));
-SELECT * FROM fact_tbl_2;
+SELECT * FROM fact_tbl_2 ORDER BY col_i;
 DROP DATABASE test_dictmapping_DictQueryOperator_bug;


### PR DESCRIPTION
## Why I'm doing:
Unstable DictQueryOperator sql-test result cause by SELECT stmt
## What I'm doing:
Add ORDER BY clause to make the output stable
Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [x] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
