### PR TITLE
[Enhancement] Make routine load error msg more clear

### DIFF
--- a/be/src/runtime/routine_load/data_consumer.cpp
+++ b/be/src/runtime/routine_load/data_consumer.cpp
@@ -244,8 +244,11 @@ Status KafkaDataConsumer::group_consume(TimedBlockingQueue<RdKafka::Message*>* q
             ss << msg->errstr() << ", this is no data in partition: " << msg->partition()
                << " at offset: " << msg->offset();
             LOG(WARNING) << "kafka consume failed: " << _id << ", msg: " << ss.str();
+            auto alter_doc_url =
+                    "https://docs.starrocks.io/docs/sql-reference/sql-statements/data-manipulation/ALTER_ROUTINE_LOAD";
             st = Status::InternalError(fmt::format(
-                    "{}. you can modify kafka_offsets by alter routine load, then resume the job", ss.str()));
+                    "{}. you can modify kafka_offsets by alter routine load, then resume the job. refer to {}",
+                    ss.str(), alter_doc_url));
             break;
         }
         case RdKafka::ERR__PARTITION_EOF: {

--- a/be/src/runtime/routine_load/data_consumer.h
+++ b/be/src/runtime/routine_load/data_consumer.h
@@ -119,18 +119,26 @@ public:
         }
     }
 
-    std::string get_error_msg() const { return _error_msg; }
+    std::string get_error_msg() const {
+        std::unique_lock l(_lock);
+        return _error_msg;
+    }
 
-    void reset_error_msg() { _error_msg.clear(); }
+    void reset_error_msg() {
+        std::unique_lock l(_lock);
+        _error_msg.clear();
+    }
 
 private:
     void log_event_msg(const RdKafka::Event& event) {
+        std::unique_lock l(_lock);
         if (_error_msg.empty() && event.str().size() > 0) {
             _error_msg = "event: " + event.str();
         }
     }
 
     std::string _error_msg;
+    mutable std::mutex _lock;
 };
 
 class KafkaDataConsumer : public DataConsumer {

--- a/be/src/service/internal_service.cpp
+++ b/be/src/service/internal_service.cpp
@@ -624,6 +624,11 @@ void PInternalServiceImplBase<T>::_get_info_impl(const PProxyRequest* request, P
                                                  google::protobuf::Closure* done, int timeout_ms) {
     ClosureGuard closure_guard(done);
 
+    // If we use timeout specified by user directly, there will be an issue that librakafka connect to kafka broker
+    // time out, but the BE did not have the opportunity to send the error message back to the FE , and the timer on
+    // the FE side has already timed out. This mean that the FE cannot retrieve the event message from librdkafka.
+    // Therefore, here we are reducing the actual timeout threshold of librdkafka.
+    timeout_ms = timeout_ms * 0.8;
     if (timeout_ms <= 0) {
         Status::TimedOut("get kafka info timeout").to_protobuf(response->mutable_status());
         return;

--- a/be/test/CMakeLists.txt
+++ b/be/test/CMakeLists.txt
@@ -336,6 +336,7 @@ set(EXEC_FILES
         ./runtime/mem_pool_test.cpp
         ./runtime/result_queue_mgr_test.cpp
         #./runtime/routine_load_task_executor_test.cpp
+        ./runtime/routine_load/data_consumer_test.cpp
         ./runtime/small_file_mgr_test.cpp
         ./runtime/snapshot_loader_test.cpp
         ./runtime/stream_load_pipe_test.cpp
@@ -417,6 +418,7 @@ set(EXEC_FILES
         ./gutil/cpu_test.cc
         ./gutil/sysinfo-test.cc
         ./service/lake_service_test.cpp
+        ./service/service_be/internal_service_test.cpp
         ./storage/compaction_parallelization_test.cpp
         ./storage/lake/persistent_index_memtable_test.cpp
         ./storage/lake/lake_persistent_index_test.cpp

--- a/be/test/runtime/routine_load/data_consumer_test.cpp
+++ b/be/test/runtime/routine_load/data_consumer_test.cpp
@@ -43,7 +43,6 @@ TEST_F(KafkaDataConsumerTest, test_get_partition_offset_broker_down) {
     std::cout << "get partition offset st: " << st << std::endl;
     ASSERT_FALSE(st.ok());
     ASSERT_TRUE(st.message().find("Local: All broker connections are down") != string::npos);
-    ASSERT_TRUE(st.message().find("Connection refused") != string::npos);
     ASSERT_OK(consumer.reset());
 }
 
@@ -65,7 +64,6 @@ TEST_F(KafkaDataConsumerTest, test_get_partition_meta_broker_down) {
     std::cout << "get partition meta st: " << st << std::endl;
     ASSERT_FALSE(st.ok());
     ASSERT_TRUE(st.message().find("Local: Broker transport failure") != string::npos);
-    ASSERT_TRUE(st.message().find("Connection refused") != string::npos);
     ASSERT_OK(consumer.reset());
 }
 

--- a/be/test/runtime/routine_load/data_consumer_test.cpp
+++ b/be/test/runtime/routine_load/data_consumer_test.cpp
@@ -1,0 +1,72 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "runtime/routine_load/data_consumer.h"
+
+#include <gtest/gtest.h>
+
+#include "runtime/exec_env.h"
+#include "testutil/assert.h"
+
+namespace starrocks {
+
+class KafkaDataConsumerTest : public testing::Test {};
+
+TEST_F(KafkaDataConsumerTest, test_get_partition_offset_broker_down) {
+    TKafkaLoadInfo tKafkaLoadInfo;
+    tKafkaLoadInfo.brokers = "localhost:19092";
+    tKafkaLoadInfo.topic = "test_topic";
+    tKafkaLoadInfo.partition_begin_offset = {{0, 100}};
+    auto kafka_info = std::make_unique<KafkaLoadInfo>(tKafkaLoadInfo);
+    StreamLoadContext context(ExecEnv::GetInstance());
+    context.kafka_info = std::move(kafka_info);
+
+    KafkaDataConsumer consumer(&context);
+    ASSERT_OK(consumer.init(&context));
+
+    std::vector<int32_t> partition_ids{0};
+    std::vector<int64_t> beginning_offsets;
+    std::vector<int64_t> latest_offsets;
+    int timeout = 10;
+    auto st = consumer.get_partition_offset(&partition_ids, &beginning_offsets, &latest_offsets, timeout);
+    std::cout << "get partition offset st: " << st << std::endl;
+    ASSERT_FALSE(st.ok());
+    ASSERT_TRUE(st.message().find("Local: All broker connections are down") != string::npos);
+    ASSERT_TRUE(st.message().find("Connection refused") != string::npos);
+    ASSERT_OK(consumer.reset());
+}
+
+TEST_F(KafkaDataConsumerTest, test_get_partition_meta_broker_down) {
+    TKafkaLoadInfo tKafkaLoadInfo;
+    tKafkaLoadInfo.brokers = "localhost:19092";
+    tKafkaLoadInfo.topic = "test_topic";
+    tKafkaLoadInfo.partition_begin_offset = {{0, 100}};
+    auto kafka_info = std::make_unique<KafkaLoadInfo>(tKafkaLoadInfo);
+    StreamLoadContext context(ExecEnv::GetInstance());
+    context.kafka_info = std::move(kafka_info);
+
+    KafkaDataConsumer consumer(&context);
+    ASSERT_OK(consumer.init(&context));
+
+    std::vector<int32_t> partition_ids{0};
+    int timeout = 10;
+    auto st = consumer.get_partition_meta(&partition_ids, timeout);
+    std::cout << "get partition meta st: " << st << std::endl;
+    ASSERT_FALSE(st.ok());
+    ASSERT_TRUE(st.message().find("Local: Broker transport failure") != string::npos);
+    ASSERT_TRUE(st.message().find("Connection refused") != string::npos);
+    ASSERT_OK(consumer.reset());
+}
+
+} // namespace starrocks

--- a/be/test/service/service_be/internal_service_test.cpp
+++ b/be/test/service/service_be/internal_service_test.cpp
@@ -1,0 +1,34 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "service/service_be/internal_service.h"
+
+#include <gtest/gtest.h>
+
+#include "runtime/exec_env.h"
+
+namespace starrocks {
+
+class InternalServiceTest : public testing::Test {};
+
+TEST_F(InternalServiceTest, test_get_info_timeout_invalid) {
+    BackendInternalServiceImpl<PInternalService> service(ExecEnv::GetInstance());
+    PProxyRequest request;
+    PProxyResult response;
+    service._get_info_impl(&request, &response, nullptr, -10);
+    auto st = Status(response.status());
+    ASSERT_TRUE(st.is_time_out());
+}
+
+} // namespace starrocks

--- a/fe/fe-core/src/main/java/com/starrocks/common/FeConstants.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/FeConstants.java
@@ -98,6 +98,8 @@ public class FeConstants {
             "https://docs.starrocks.io/en-us/latest/sql-reference/sql-statements/data-manipulation/SHOW%20BACKUP";
     public static final String DOCUMENT_SHOW_RESTORE =
             "https://docs.starrocks.io/en-us/latest/sql-reference/sql-statements/data-manipulation/SHOW%20RESTORE";
+    public static final String DOCUMENT_ALTER_ROUTINE_LOAD =
+            "https://docs.starrocks.io/docs/sql-reference/sql-statements/data-manipulation/ALTER_ROUTINE_LOAD";
 
     public static String getNodeNotFoundError(boolean chooseComputeNode) {
         return chooseComputeNode ? COMPUTE_NODE_NOT_FOUND_ERROR : BACKEND_NODE_NOT_FOUND_ERROR;

--- a/fe/fe-core/src/main/java/com/starrocks/common/util/KafkaUtil.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/util/KafkaUtil.java
@@ -55,6 +55,7 @@ import com.starrocks.system.ComputeNode;
 import com.starrocks.thrift.TNetworkAddress;
 import com.starrocks.thrift.TStatusCode;
 import com.starrocks.warehouse.Warehouse;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -178,76 +179,77 @@ public class KafkaUtil {
         }
 
         private PProxyResult sendProxyRequest(PProxyRequest request) throws UserException {
-            TNetworkAddress address = new TNetworkAddress();
-            try {
-                // TODO: need to refactor after be split into cn + dn
-                List<Long> nodeIds = new ArrayList<>();
-                if ((RunMode.isSharedDataMode())) {
-                    Warehouse warehouse = GlobalStateMgr.getCurrentState().getWarehouseMgr().getDefaultWarehouse();
-                    for (long nodeId : warehouse.getAnyAvailableCluster().getComputeNodeIds()) {
-                        ComputeNode node =
-                                GlobalStateMgr.getCurrentState().getNodeMgr().getClusterInfo().getBackendOrComputeNode(nodeId);
-                        if (node != null && node.isAlive()) {
-                            nodeIds.add(nodeId);
-                        }
-                    }
-                    if (nodeIds.isEmpty()) {
-                        throw new LoadException("Failed to send proxy request. No alive backends or computeNodes");
-                    }
-                } else {
-                    nodeIds = GlobalStateMgr.getCurrentState().getNodeMgr().getClusterInfo().getBackendIds(true);
-                    if (nodeIds.isEmpty()) {
-                        throw new LoadException("Failed to send proxy request. No alive backends");
+            // TODO: need to refactor after be split into cn + dn
+            List<Long> nodeIds = new ArrayList<>();
+            if ((RunMode.isSharedDataMode())) {
+                Warehouse warehouse = GlobalStateMgr.getCurrentState().getWarehouseMgr().getDefaultWarehouse();
+                for (long nodeId : warehouse.getAnyAvailableCluster().getComputeNodeIds()) {
+                    ComputeNode node =
+                            GlobalStateMgr.getCurrentState().getNodeMgr().getClusterInfo().getBackendOrComputeNode(nodeId);
+                    if (node != null && node.isAlive()) {
+                        nodeIds.add(nodeId);
                     }
                 }
+                if (nodeIds.isEmpty()) {
+                    throw new LoadException(
+                            "Failed to send get kafka partition info request. err: No alive backends or compute nodes");
+                }
+            } else {
+                nodeIds = GlobalStateMgr.getCurrentState().getNodeMgr().getClusterInfo().getBackendIds(true);
+                if (nodeIds.isEmpty()) {
+                    throw new LoadException("Failed to send get kafka partition info request. err: No alive backends");
+                }
+            }
 
-                Collections.shuffle(nodeIds);
+            Collections.shuffle(nodeIds);
+            ComputeNode be =
+                    GlobalStateMgr.getCurrentState().getNodeMgr().getClusterInfo().getBackendOrComputeNode(nodeIds.get(0));
+            TNetworkAddress address = new TNetworkAddress(be.getHost(), be.getBrpcPort());
 
-                ComputeNode be =
-                        GlobalStateMgr.getCurrentState().getNodeMgr().getClusterInfo().getBackendOrComputeNode(nodeIds.get(0));
-                address = new TNetworkAddress(be.getHost(), be.getBrpcPort());
-
-                // get info
-                int retryTimes = 0;
-                while (true) {
+            // get info
+            int retryTimes = 0;
+            while (true) {
+                try {
                     request.timeout = Config.routine_load_kafka_timeout_second;
                     Future<PProxyResult> future = BackendServiceClient.getInstance().getInfo(address, request);
-                    PProxyResult result;
-                    try {
-                        result = future.get(Config.routine_load_kafka_timeout_second, TimeUnit.SECONDS);
-                    } catch (Exception e) {
-                        LOG.warn("failed to send proxy request to " + address + " err " + e.getMessage());
-                        // Jprotobuf-rpc-socket throws an ExecutionException when an exception occurs.
-                        // We use the error message to identify the type of exception.
-                        if (e.getMessage().contains("Ocurrs time out")) {
-                            // When getting kafka info timed out, we tried again three times.
-                            if (++retryTimes > 3 || (retryTimes + 1) * Config.routine_load_kafka_timeout_second >
-                                    Config.routine_load_task_timeout_second) {
-                                throw e;
-                            }
-                            continue;
-                        } else {
-                            throw e;
-                        }
-                    }
+                    PProxyResult result = future.get(Config.routine_load_kafka_timeout_second, TimeUnit.SECONDS);
                     TStatusCode code = TStatusCode.findByValue(result.status.statusCode);
                     if (code != TStatusCode.OK) {
-                        LOG.warn("failed to send proxy request to " + address + " err " + result.status.errorMsgs);
-                        throw new UserException(
-                                "failed to send proxy request to " + address + " err " + result.status.errorMsgs);
+                        LOG.warn("Failed to process get kafka partition info in BE {}, err: {}",
+                                address, result.status.errorMsgs);
+                        throw new LoadException(
+                                String.format("%s, BE: %s", StringUtils.join(result.status.errorMsgs, ","), address));
+                    }
+                    return result;
+                } catch (LoadException e) {
+                    throw e;
+                } catch (InterruptedException e) {
+                    String msg = String.format(
+                            "Got interrupted exception when sending get kafka partition info request to BE %s", address);
+                    LOG.warn(msg);
+                    Thread.currentThread().interrupt();
+                    throw new LoadException(msg);
+                } catch (Exception e) {
+                    String msg = String.format("Failed to send get kafka partition info request to BE %s, err: %s",
+                            address, e.getMessage());
+                    LOG.warn(msg);
+
+                    // Jprotobuf-rpc-socket throws an ExecutionException when an exception occurs.
+                    // We use the error message to identify the type of exception.
+                    if (e.getMessage().contains("Ocurrs time out")) {
+                        // When getting kafka info timed out, we tried again three times.
+                        if (++retryTimes > 3 || (retryTimes + 1) * Config.routine_load_kafka_timeout_second >
+                                Config.routine_load_task_timeout_second) {
+                            throw new LoadException(msg);
+                        }
+                    } else if (e.getMessage().contains("Unable to validate object")) {
+                        throw new LoadException(String.format(
+                                "Failed to send get kafka partition info request to BE %s. err: BE is not alive", address));
                     } else {
-                        return result;
+                        throw new LoadException(msg);
                     }
                 }
-            } catch (InterruptedException ie) {
-                LOG.warn("got interrupted exception when sending proxy request to " + address);
-                Thread.currentThread().interrupt();
-                throw new LoadException("got interrupted exception when sending proxy request to " + address);
-            } catch (Exception e) {
-                LOG.warn("failed to send proxy request to " + address + " err " + e.getMessage());
-                throw new LoadException("failed to send proxy request to " + address + " err " + e.getMessage());
             }
         }
     }
 }
-

--- a/fe/fe-core/src/main/java/com/starrocks/load/routineload/KafkaRoutineLoadJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/routineload/KafkaRoutineLoadJob.java
@@ -497,7 +497,7 @@ public class KafkaRoutineLoadJob extends RoutineLoadJob {
         List<Integer> allKafkaPartitions = getAllKafkaPartitions();
         for (Integer customPartition : customKafkaPartitions) {
             if (!allKafkaPartitions.contains(customPartition)) {
-                throw new LoadException("there is an invalid custom partition: " + customPartition + " in topic: " + topic);
+                throw new LoadException("there is an invalid custom partition: " + customPartition + " for topic: " + topic);
             }
         }
     }

--- a/fe/fe-core/src/main/java/com/starrocks/load/routineload/KafkaRoutineLoadJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/routineload/KafkaRoutineLoadJob.java
@@ -497,8 +497,7 @@ public class KafkaRoutineLoadJob extends RoutineLoadJob {
         List<Integer> allKafkaPartitions = getAllKafkaPartitions();
         for (Integer customPartition : customKafkaPartitions) {
             if (!allKafkaPartitions.contains(customPartition)) {
-                throw new LoadException("there is a custom kafka partition " + customPartition
-                        + " which is invalid for topic " + topic);
+                throw new LoadException("there is an invalid custom partition: " + customPartition + " in topic: " + topic);
             }
         }
     }

--- a/fe/fe-core/src/main/java/com/starrocks/load/routineload/KafkaTaskInfo.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/routineload/KafkaTaskInfo.java
@@ -39,6 +39,7 @@ import com.google.gson.Gson;
 import com.starrocks.catalog.Database;
 import com.starrocks.catalog.Table;
 import com.starrocks.common.Config;
+import com.starrocks.common.FeConstants;
 import com.starrocks.common.MetaNotFoundException;
 import com.starrocks.common.UserException;
 import com.starrocks.common.util.KafkaUtil;
@@ -145,7 +146,8 @@ public class KafkaTaskInfo extends RoutineLoadTaskInfo {
                 } else if (latestOffset < consumeOffset) {
                     throw new RoutineLoadPauseException(
                             "there is no data in partition: " + partitionId + " at offset: " + consumeOffset + ". " +
-                                    "you can modify kafka_offsets by alter routine load, then resume the job");
+                                    "you can modify kafka_offsets by alter routine load, then resume the job. " +
+                                    "refer to " + FeConstants.DOCUMENT_ALTER_ROUTINE_LOAD);
                 }
             }
         }

--- a/fe/fe-core/src/main/java/com/starrocks/load/routineload/KafkaTaskInfo.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/routineload/KafkaTaskInfo.java
@@ -144,7 +144,7 @@ public class KafkaTaskInfo extends RoutineLoadTaskInfo {
                     return true;
                 } else if (latestOffset < consumeOffset) {
                     throw new RoutineLoadPauseException(
-                            "partition " + partitionId + " offset " + consumeOffset + " has no data. " +
+                            "there is no data in partition: " + partitionId + " at offset: " + consumeOffset + ". " +
                                     "you can modify kafka_offsets by alter routine load, then resume the job");
                 }
             }

--- a/fe/fe-core/src/main/java/com/starrocks/load/routineload/KafkaTaskInfo.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/routineload/KafkaTaskInfo.java
@@ -144,7 +144,8 @@ public class KafkaTaskInfo extends RoutineLoadTaskInfo {
                     return true;
                 } else if (latestOffset < consumeOffset) {
                     throw new RoutineLoadPauseException(
-                            "partition " + partitionId + " offset " + consumeOffset + " has no data");
+                            "partition " + partitionId + " offset " + consumeOffset + " has no data. " +
+                                    "you can modify kafka_offsets by alter routine load, then resume the job");
                 }
             }
         }

--- a/fe/fe-core/src/main/java/com/starrocks/load/routineload/KafkaTaskInfo.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/routineload/KafkaTaskInfo.java
@@ -237,6 +237,11 @@ public class KafkaTaskInfo extends RoutineLoadTaskInfo {
         return result.toString();
     }
 
+    @Override
+    String dataSourceType() {
+        return "kafka";
+    }
+
     public Map<Integer, Long> getLatestOffset() {
         return latestPartOffset;
     }

--- a/fe/fe-core/src/main/java/com/starrocks/load/routineload/PulsarTaskInfo.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/routineload/PulsarTaskInfo.java
@@ -167,6 +167,11 @@ public class PulsarTaskInfo extends RoutineLoadTaskInfo {
     }
 
     @Override
+    String dataSourceType() {
+        return "pulsar";
+    }
+
+    @Override
     public String toString() {
         return "Task id: " + getId() + ", partitions: " + partitions + ", initial positions: " + initialPositions;
     }

--- a/fe/fe-core/src/main/java/com/starrocks/load/routineload/RoutineLoadJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/routineload/RoutineLoadJob.java
@@ -494,8 +494,8 @@ public abstract class RoutineLoadJob extends AbstractTxnStateChangeCallback impl
     }
 
     public void setOtherMsg(String otherMsg) {
-        this.otherMsg = LocalDateTime.now().format(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss"))
-                + ": " + Strings.nullToEmpty(otherMsg);
+        this.otherMsg = String.format("[%s] %s", LocalDateTime.now().format(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss")),
+                Strings.nullToEmpty(otherMsg));
     }
 
     public String getDbFullName() throws MetaNotFoundException {

--- a/fe/fe-core/src/main/java/com/starrocks/load/routineload/RoutineLoadTaskInfo.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/routineload/RoutineLoadTaskInfo.java
@@ -185,7 +185,7 @@ public abstract class RoutineLoadTaskInfo {
     public void setMsg(String msg) {
         this.msg = msg;
         RoutineLoadJob routineLoadJob = routineLoadManager.getJob(jobId);
-        routineLoadJob.setOtherMsg(msg);
+        routineLoadJob.setOtherMsg(String.format("[task id: %s] [txn id: %s] %s", DebugUtil.printId(id), txnId, msg));
     }
 
     public boolean isRunningTimeout() {

--- a/fe/fe-core/src/main/java/com/starrocks/load/routineload/RoutineLoadTaskInfo.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/routineload/RoutineLoadTaskInfo.java
@@ -184,6 +184,8 @@ public abstract class RoutineLoadTaskInfo {
 
     public void setMsg(String msg) {
         this.msg = msg;
+        RoutineLoadJob routineLoadJob = routineLoadManager.getJob(jobId);
+        routineLoadJob.setOtherMsg(msg);
     }
 
     public boolean isRunningTimeout() {

--- a/fe/fe-core/src/main/java/com/starrocks/load/routineload/RoutineLoadTaskInfo.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/routineload/RoutineLoadTaskInfo.java
@@ -279,6 +279,8 @@ public abstract class RoutineLoadTaskInfo {
 
     abstract String getTaskDataSourceProperties();
 
+    abstract String dataSourceType();
+
     @Override
     public int hashCode() {
         return Objects.hashCode(id);

--- a/fe/fe-core/src/main/java/com/starrocks/load/routineload/RoutineLoadTaskScheduler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/routineload/RoutineLoadTaskScheduler.java
@@ -183,14 +183,8 @@ public class RoutineLoadTaskScheduler extends FrontendDaemon {
         try {
             // for kafka/pulsar routine load, readyToExecute means there is new data in kafka/pulsar stream
             if (!routineLoadTaskInfo.readyToExecute()) {
-                String msg = "";
-                if (routineLoadTaskInfo instanceof KafkaTaskInfo) {
-                    msg = String.format("there is no new data in kafka, wait for %d seconds to schedule again",
-                            routineLoadTaskInfo.getTaskScheduleIntervalMs() / 1000);
-                } else if (routineLoadTaskInfo instanceof PulsarTaskInfo) {
-                    msg = String.format("there is no new data in pulsar, wait for %d seconds to schedule again",
-                            routineLoadTaskInfo.getTaskScheduleIntervalMs() / 1000);
-                }
+                String msg = String.format("there is no new data in %s, wait for %d seconds to schedule again",
+                        routineLoadTaskInfo.dataSourceType(), routineLoadTaskInfo.getTaskScheduleIntervalMs() / 1000);
                 // The job keeps up with source.
                 routineLoadManager.getJob(routineLoadTaskInfo.getJobId()).updateSubstateStable();
                 delayPutToQueue(routineLoadTaskInfo, msg);

--- a/fe/fe-core/src/main/java/com/starrocks/load/routineload/RoutineLoadTaskScheduler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/routineload/RoutineLoadTaskScheduler.java
@@ -184,8 +184,11 @@ public class RoutineLoadTaskScheduler extends FrontendDaemon {
             // for kafka/pulsar routine load, readyToExecute means there is new data in kafka/pulsar stream
             if (!routineLoadTaskInfo.readyToExecute()) {
                 String msg = "";
-                if (routineLoadTaskInfo instanceof KafkaTaskInfo || routineLoadTaskInfo instanceof PulsarTaskInfo) {
-                    msg = String.format("there is no new data in kafka/pulsar, wait for %d seconds to schedule again",
+                if (routineLoadTaskInfo instanceof KafkaTaskInfo) {
+                    msg = String.format("there is no new data in kafka, wait for %d seconds to schedule again",
+                            routineLoadTaskInfo.getTaskScheduleIntervalMs() / 1000);
+                } else if (routineLoadTaskInfo instanceof PulsarTaskInfo) {
+                    msg = String.format("there is no new data in pulsar, wait for %d seconds to schedule again",
                             routineLoadTaskInfo.getTaskScheduleIntervalMs() / 1000);
                 }
                 // The job keeps up with source.

--- a/fe/fe-core/src/test/java/com/starrocks/common/util/KafkaUtilTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/common/util/KafkaUtilTest.java
@@ -1,0 +1,220 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.common.util;
+
+import com.google.common.collect.Lists;
+import com.starrocks.common.LoadException;
+import com.starrocks.common.UserException;
+import com.starrocks.proto.PProxyRequest;
+import com.starrocks.proto.PProxyResult;
+import com.starrocks.proto.StatusPB;
+import com.starrocks.rpc.BackendServiceClient;
+import com.starrocks.rpc.RpcException;
+import com.starrocks.server.GlobalStateMgr;
+import com.starrocks.server.RunMode;
+import com.starrocks.server.WarehouseManager;
+import com.starrocks.system.Backend;
+import com.starrocks.system.SystemInfoService;
+import com.starrocks.thrift.TNetworkAddress;
+import com.starrocks.warehouse.Cluster;
+import com.starrocks.warehouse.Warehouse;
+import mockit.Expectations;
+import mockit.Mock;
+import mockit.MockUp;
+import mockit.Mocked;
+import org.jetbrains.annotations.NotNull;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+public class KafkaUtilTest {
+    @Mocked
+    GlobalStateMgr globalStateMgr;
+    @Mocked
+    SystemInfoService service;
+    @Mocked
+    WarehouseManager warehouseManager;
+    @Mocked
+    Warehouse warehouse;
+    @Mocked
+    BackendServiceClient client;
+
+    @Before
+    public void before() {
+        new MockUp<RunMode>() {
+            @Mock
+            public RunMode getCurrentRunMode() {
+                return RunMode.SHARED_DATA;
+            }
+        };
+
+        new Expectations() {
+            {
+                GlobalStateMgr.getCurrentState();
+                result = globalStateMgr;
+                globalStateMgr.getWarehouseMgr();
+                result = warehouseManager;
+                warehouseManager.getDefaultWarehouse();
+                result = warehouse;
+                BackendServiceClient.getInstance();
+                minTimes = 0;
+                result = client;
+            }
+        };
+    }
+
+    @Test
+    public void testNoAliveComputeNode(@Mocked Cluster cluster) throws UserException {
+        new Expectations() {
+            {
+                cluster.getComputeNodeIds();
+                result = Lists.newArrayList(1L);
+                service.getBackendOrComputeNode(anyLong);
+                result = null;
+            }
+        };
+
+        KafkaUtil.ProxyAPI api = new KafkaUtil.ProxyAPI();
+        LoadException e = Assert.assertThrows(LoadException.class, () -> api.getBatchOffsets(null));
+        Assert.assertEquals(
+                "Failed to send get kafka partition info request. err: No alive backends or compute nodes", e.getMessage());
+    }
+
+    @Test
+    public void testGetInfoRpcException(@Mocked Cluster cluster) throws UserException, RpcException {
+        Backend backend = new Backend(1L, "127.0.0.1", 9050);
+        backend.setBeRpcPort(8060);
+        backend.setAlive(true);
+
+        new Expectations() {
+            {
+                cluster.getComputeNodeIds();
+                result = Lists.newArrayList(1L);
+                service.getBackendOrComputeNode(anyLong);
+                result = backend;
+                client.getInfo((TNetworkAddress) any, (PProxyRequest) any);
+                result = new RpcException("rpc failed");
+            }
+        };
+
+        KafkaUtil.ProxyAPI api = new KafkaUtil.ProxyAPI();
+        LoadException e = Assert.assertThrows(LoadException.class, () -> api.getBatchOffsets(null));
+        Assert.assertTrue(e.getMessage().contains("err: rpc failed"));
+    }
+
+    @Test
+    public void testGetInfoInterruptedException(@Mocked Cluster cluster) throws UserException, RpcException {
+        Backend backend = new Backend(1L, "127.0.0.1", 9050);
+        backend.setBeRpcPort(8060);
+        backend.setAlive(true);
+
+        new Expectations() {
+            {
+                cluster.getComputeNodeIds();
+                result = Lists.newArrayList(1L);
+                service.getBackendOrComputeNode(anyLong);
+                result = backend;
+                client.getInfo((TNetworkAddress) any, (PProxyRequest) any);
+                result = new InterruptedException("interrupted");
+            }
+        };
+
+        KafkaUtil.ProxyAPI api = new KafkaUtil.ProxyAPI();
+        LoadException e = Assert.assertThrows(LoadException.class, () -> api.getBatchOffsets(null));
+        Assert.assertTrue(e.getMessage().contains("Got interrupted exception"));
+    }
+
+    @Test
+    public void testGetInfoValidateObjectException(@Mocked Cluster cluster) throws UserException, RpcException {
+        Backend backend = new Backend(1L, "127.0.0.1", 9050);
+        backend.setBeRpcPort(8060);
+        backend.setAlive(true);
+
+        new Expectations() {
+            {
+                cluster.getComputeNodeIds();
+                result = Lists.newArrayList(1L);
+                service.getBackendOrComputeNode(anyLong);
+                result = backend;
+                client.getInfo((TNetworkAddress) any, (PProxyRequest) any);
+                result = new RpcException("Unable to validate object");
+            }
+        };
+
+        KafkaUtil.ProxyAPI api = new KafkaUtil.ProxyAPI();
+        LoadException e = Assert.assertThrows(LoadException.class, () -> api.getBatchOffsets(null));
+        Assert.assertTrue(e.getMessage().contains("err: BE is not alive"));
+    }
+
+    @Test
+    public void testGetInfoFailed(@Mocked Cluster cluster) throws UserException, RpcException {
+        Backend backend = new Backend(1L, "127.0.0.1", 9050);
+        backend.setBeRpcPort(8060);
+        backend.setAlive(true);
+
+        PProxyResult proxyResult = new PProxyResult();
+        StatusPB status = new StatusPB();
+        // cancelled
+        status.statusCode = 1;
+        status.errorMsgs = Lists.newArrayList("be process failed");
+        proxyResult.status = status;
+
+        new Expectations() {
+            {
+                cluster.getComputeNodeIds();
+                result = Lists.newArrayList(1L);
+                service.getBackendOrComputeNode(anyLong);
+                result = backend;
+                client.getInfo((TNetworkAddress) any, (PProxyRequest) any);
+                result = new Future<PProxyResult>() {
+                    @Override
+                    public boolean cancel(boolean mayInterruptIfRunning) {
+                        return false;
+                    }
+
+                    @Override
+                    public boolean isCancelled() {
+                        return false;
+                    }
+
+                    @Override
+                    public boolean isDone() {
+                        return true;
+                    }
+
+                    @Override
+                    public PProxyResult get() throws InterruptedException, ExecutionException {
+                        return proxyResult;
+                    }
+
+                    @Override
+                    public PProxyResult get(long timeout, @NotNull TimeUnit unit)
+                            throws InterruptedException, ExecutionException, TimeoutException {
+                        return proxyResult;
+                    }
+                };
+            }
+        };
+
+        KafkaUtil.ProxyAPI api = new KafkaUtil.ProxyAPI();
+        LoadException e = Assert.assertThrows(LoadException.class, () -> api.getBatchOffsets(null));
+        Assert.assertTrue(e.getMessage().contains("be process failed"));
+    }
+}

--- a/fe/fe-core/src/test/java/com/starrocks/load/routineload/KafkaTaskInfoTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/load/routineload/KafkaTaskInfoTest.java
@@ -62,6 +62,7 @@ public class KafkaTaskInfoTest {
                 System.currentTimeMillis(),
                 offset1,
                 Config.routine_load_task_timeout_second * 1000);
+        Assert.assertEquals("kafka", kafkaTaskInfo1.dataSourceType());
         Assert.assertTrue(kafkaTaskInfo1.readyToExecute());
 
         Map<Integer, Long> offset2 = Maps.newHashMap();

--- a/fe/fe-core/src/test/java/com/starrocks/load/routineload/PulsarTaskInfoTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/load/routineload/PulsarTaskInfoTest.java
@@ -41,5 +41,6 @@ public class PulsarTaskInfoTest {
         Assert.assertEquals(task1.getJobId(), task2.getJobId());
         Assert.assertEquals(task1.getPartitions(), task2.getPartitions());
         Assert.assertEquals(task1.getTimeoutMs(), task2.getTimeoutMs());
+        Assert.assertEquals("pulsar", task1.dataSourceType());
     }
 }


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:

1. Improve kafka error message
2. Set the timeout of BE get kafka topic partition info to 80% of the rpc timeout
3. The task error message is shown in show routine load
4. Refactor `KafkaUtil.sendProxyRequest`
5. Fix `consumer.metadata` function `all_topics` parameter

error message:
1. Kafka broker is down
```
mysql> show routine load\G
*************************** 1. row ***************************
                  Id: 106275
                Name: label0
          CreateTime: 2024-02-21 15:52:17
           PauseTime: 2024-02-21 17:17:54
             EndTime: NULL
              DbName: kafka_test
           TableName: lineorder
               State: PAUSED
      DataSourceType: KAFKA
      CurrentTaskNum: 0
       JobProperties: {"partitions":"*","rowDelimiter":"\t","partial_update":"false","columnToColumnExpr":"*","maxBatchIntervalS":"10","partial_update_mode":"null","whereExpr":"*","timezone":"Asia/Shanghai","format":"csv","columnSeparator":"'|'","log_rejected_record_num":"0","taskTimeoutSecond":"60","json_root":"","maxFilterRatio":"1.0","strict_mode":"false","jsonpaths":"","taskConsumeSecond":"15","desireTaskConcurrentNum":"5","maxErrorNum":"0","strip_outer_array":"false","currentTaskConcurrentNum":"0","maxBatchRows":"200000"}
DataSourceProperties: {"topic":"wyb_test","currentKafkaPartitions":"0","brokerList":"1.1.1.1:9093"}
    CustomProperties: {"group.id":"label0_1f9af280-5fef-44d1-85bf-44f41c4c7fcd"}
           Statistic: {"receivedBytes":2281306,"errorRows":0,"committedTaskNum":1,"loadedRows":22683,"loadRowsRate":1000,"abortedTaskNum":0,"totalRows":22683,"unselectedRows":0,"receivedBytesRate":151000,"taskExecuteTimeMs":15040}
            Progress: {"0":"501572079"}
   TimestampProgress: {}
ReasonOfStateChanged: ErrorReason{errCode = 2, msg='failed to get kafka topic: wyb_test meta, err: Local: Broker transport failure, event: [thrd:1.1.1.1:9093/bootstrap]: 1.1.1.1:9093/bootstrap: Connect to ipv4#1.1.1.1:9093 failed: Connection refused (after 0ms in state CONNECT), BE: TNetworkAddress(hostname:1.1.1.1, port:8069)'}
        ErrorLogUrls:
         TrackingSQL:
            OtherMsg:
LatestSourcePosition: {}
1 row in set (0.01 sec)

mysql> show routine load\G
*************************** 1. row ***************************
                  Id: 106275
                Name: label0
          CreateTime: 2024-02-21 15:52:17
           PauseTime: 2024-02-21 17:17:54
             EndTime: NULL
              DbName: kafka_test
           TableName: lineorder
               State: RUNNING
      DataSourceType: KAFKA
      CurrentTaskNum: 0
       JobProperties: {"partitions":"*","rowDelimiter":"\t","partial_update":"false","columnToColumnExpr":"*","maxBatchIntervalS":"10","partial_update_mode":"null","whereExpr":"*","timezone":"Asia/Shanghai","format":"csv","columnSeparator":"'|'","log_rejected_record_num":"0","taskTimeoutSecond":"60","json_root":"","maxFilterRatio":"1.0","strict_mode":"false","jsonpaths":"","taskConsumeSecond":"15","desireTaskConcurrentNum":"5","maxErrorNum":"0","strip_outer_array":"false","currentTaskConcurrentNum":"0","maxBatchRows":"200000"}
DataSourceProperties: {"topic":"wyb_test","currentKafkaPartitions":"0","brokerList":"1.1.1.1:9093"}
    CustomProperties: {"group.id":"label0_1f9af280-5fef-44d1-85bf-44f41c4c7fcd"}
           Statistic: {"receivedBytes":2281306,"errorRows":0,"committedTaskNum":1,"loadedRows":22683,"loadRowsRate":1000,"abortedTaskNum":0,"totalRows":22683,"unselectedRows":0,"receivedBytesRate":151000,"taskExecuteTimeMs":15040}
            Progress: {"0":"501572079"}
   TimestampProgress: {}
ReasonOfStateChanged:
        ErrorLogUrls:
         TrackingSQL:
            OtherMsg: [2024-03-19 18:39:29] [task id: 12178177-28e4-49e7-93e3-af5c0a06bbcb] [txn id: -1] check task ready to execute failed, err: failed to get offset of partition: 0 in topic: wyb_test, err: Local: All broker connections are down, event: [thrd:1.1.1.1:9093/bootstrap]: 1.1.1.1:9093/bootstrap: Connect to ipv4#1.1.1.1:9093 failed: Connection refused (after 0ms in state CONNECT), BE: TNetworkAddress(hostname:1.1.1.1, port:8069)
LatestSourcePosition: {}
1 row in set (0.01 sec)
```

2. BE is down
```
mysql> show routine load\G
*************************** 1. row ***************************
                  Id: 128134
                Name: label0
          CreateTime: 2024-03-07 15:42:21
           PauseTime: NULL
             EndTime: NULL
              DbName: kafka_test
           TableName: lineorder
               State: RUNNING
      DataSourceType: KAFKA
      CurrentTaskNum: 1
       JobProperties: {"partitions":"*","rowDelimiter":"\t","partial_update":"false","columnToColumnExpr":"*","maxBatchIntervalS":"10","partial_update_mode":"null","whereExpr":"*","timezone":"Asia/Shanghai","format":"csv","columnSeparator":"'|'","log_rejected_record_num":"0","taskTimeoutSecond":"60","json_root":"","maxFilterRatio":"1.0","strict_mode":"false","jsonpaths":"","taskConsumeSecond":"15","desireTaskConcurrentNum":"5","maxErrorNum":"0","strip_outer_array":"false","currentTaskConcurrentNum":"1","maxBatchRows":"200000"}
DataSourceProperties: {"topic":"wyb_test","currentKafkaPartitions":"0","brokerList":"1.1.1.1:9093"}
    CustomProperties: {"group.id":"label0_d704e31e-a674-4a76-81c2-113b395ff1fb"}
           Statistic: {"receivedBytes":90229443,"errorRows":0,"committedTaskNum":10,"loadedRows":906093,"loadRowsRate":5000,"abortedTaskNum":4,"totalRows":906093,"unselectedRows":0,"receivedBytesRate":587000,"taskExecuteTimeMs":153508}
            Progress: {"0":"2164591389"}
   TimestampProgress: {"0":"1709797992856"}
ReasonOfStateChanged:
        ErrorLogUrls:
         TrackingSQL:
            OtherMsg: [2024-03-19 18:28:37] [task id: null] [txn id: -1] check task ready to execute failed, err: Failed to send get kafka partition info request to BE TNetworkAddress(hostname:1.1.1.1, port:8069). err: BE is not alive
LatestSourcePosition: {"0":"2164333309"}
1 row in set (0.00 sec)

mysql> show routine load\G
*************************** 1. row ***************************
                  Id: 127092
                Name: label0
          CreateTime: 2024-03-07 14:28:39
           PauseTime: NULL
             EndTime: NULL
              DbName: kafka_test
           TableName: lineorder
               State: RUNNING
      DataSourceType: KAFKA
      CurrentTaskNum: 1
       JobProperties: {"partitions":"*","rowDelimiter":"\t","partial_update":"false","columnToColumnExpr":"*","maxBatchIntervalS":"10","partial_update_mode":"null","whereExpr":"*","timezone":"Asia/Shanghai","format":"csv","columnSeparator":"'|'","log_rejected_record_num":"0","taskTimeoutSecond":"60","json_root":"","maxFilterRatio":"1.0","strict_mode":"false","jsonpaths":"","taskConsumeSecond":"15","desireTaskConcurrentNum":"5","maxErrorNum":"0","strip_outer_array":"false","currentTaskConcurrentNum":"1","maxBatchRows":"200000"}
DataSourceProperties: {"topic":"wyb_test","currentKafkaPartitions":"0","brokerList":"1.1.1.1:9093"}
    CustomProperties: {"group.id":"label0_37e82761-e45e-4686-a352-7b158cfa6c37"}
           Statistic: {"receivedBytes":196467825,"errorRows":0,"committedTaskNum":18,"loadedRows":1972935,"loadRowsRate":7000,"abortedTaskNum":4,"totalRows":1972935,"unselectedRows":0,"receivedBytesRate":746000,"taskExecuteTimeMs":263315}
            Progress: {"0":"2161445207"}
   TimestampProgress: {"0":"1709795800554"}
ReasonOfStateChanged:
        ErrorLogUrls:
         TrackingSQL:
            OtherMsg: [2024-03-19 18:28:37] [task id: null] [txn id: -1] check task ready to execute failed, err: Failed to send get kafka partition info request. err: No alive backends
LatestSourcePosition: {"0":"2161425566"}
1 row in set (0.00 sec)
```

3. Unknown kafka broker host
```
mysql> show routine load\G
*************************** 1. row ***************************
                  Id: 107096
                Name: label0
          CreateTime: 2024-02-21 17:34:24
           PauseTime: 2024-02-21 17:35:04
             EndTime: NULL
              DbName: kafka_test
           TableName: lineorder
               State: PAUSED
      DataSourceType: KAFKA
      CurrentTaskNum: 0
       JobProperties: {"partitions":"*","rowDelimiter":"\t","partial_update":"false","columnToColumnExpr":"*","maxBatchIntervalS":"10","partial_update_mode":"null","whereExpr":"*","timezone":"Asia/Shanghai","format":"csv","columnSeparator":"'|'","log_rejected_record_num":"0","taskTimeoutSecond":"60","json_root":"","maxFilterRatio":"1.0","strict_mode":"false","jsonpaths":"","taskConsumeSecond":"15","desireTaskConcurrentNum":"5","maxErrorNum":"0","strip_outer_array":"false","currentTaskConcurrentNum":"0","maxBatchRows":"200000"}
DataSourceProperties: {"topic":"wyb_test","currentKafkaPartitions":"0","brokerList":"test_host:9093"}
    CustomProperties: {"group.id":"label0_18adab03-c776-472a-80ba-41ecca292f98"}
           Statistic: {"receivedBytes":0,"errorRows":0,"committedTaskNum":0,"loadedRows":0,"loadRowsRate":0,"abortedTaskNum":0,"totalRows":0,"unselectedRows":0,"receivedBytesRate":0,"taskExecuteTimeMs":1}
            Progress: {"0":"OFFSET_END"}
   TimestampProgress: {}
ReasonOfStateChanged: ErrorReason{errCode = 2, msg='failed to get kafka topic: wyb_test meta, err: Local: Broker transport failure, event: [thrd:test_host:9093/bootstrap]: test_host:9093/bootstrap: Failed to resolve 'test_host:9093': Name or service not known (after 104ms in state CONNECT), BE: TNetworkAddress(hostname:xxx, port:8069)'}
        ErrorLogUrls:
         TrackingSQL:
            OtherMsg:
LatestSourcePosition: {}
1 row in set (0.00 sec)
```

4. kafka topic or partition wrong
```
*************************** 1. row ***************************
                  Id: 130185
                Name: label0
          CreateTime: 2024-03-11 19:24:40
           PauseTime: 2024-03-11 20:47:37
             EndTime: NULL
              DbName: kafka_test
           TableName: lineorder
               State: PAUSED
      DataSourceType: KAFKA
      CurrentTaskNum: 0
       JobProperties: {"partitions":"*","rowDelimiter":"\t","partial_update":"false","columnToColumnExpr":"*","maxBatchIntervalS":"10","partial_update_mode":"null","whereExpr":"*","timezone":"Asia/Shanghai","format":"csv","columnSeparator":"'|'","log_rejected_record_num":"0","taskTimeoutSecond":"60","json_root":"","maxFilterRatio":"1.0","strict_mode":"false","jsonpaths":"","taskConsumeSecond":"15","desireTaskConcurrentNum":"5","maxErrorNum":"0","strip_outer_array":"false","currentTaskConcurrentNum":"0","maxBatchRows":"200000"}
DataSourceProperties: {"topic":"wyb_test1","currentKafkaPartitions":"0","brokerList":"1.1.1.1:9093"}
    CustomProperties: {"group.id":"label0_6d2c08f5-1811-497d-a9ab-c210778b116f"}
           Statistic: {"receivedBytes":0,"errorRows":0,"committedTaskNum":0,"loadedRows":0,"loadRowsRate":0,"abortedTaskNum":0,"totalRows":0,"unselectedRows":0,"receivedBytesRate":0,"taskExecuteTimeMs":1}
            Progress: {"0":"OFFSET_END"}
   TimestampProgress: {}
ReasonOfStateChanged: ErrorReason{errCode = 2, msg='unknown topic: wyb_test1, BE: TNetworkAddress(hostname:1.1.1.1, port:8069)'}
        ErrorLogUrls:
         TrackingSQL:
            OtherMsg:
LatestSourcePosition: {}
1 row in set (0.00 sec)

mysql> show routine load\G
*************************** 1. row ***************************
                  Id: 129583
                Name: label0
          CreateTime: 2024-03-11 17:29:41
           PauseTime: 2024-03-11 17:47:13
             EndTime: NULL
              DbName: kafka_test
           TableName: lineorder
               State: PAUSED
      DataSourceType: KAFKA
      CurrentTaskNum: 0
       JobProperties: {"partitions":"*","rowDelimiter":"\t","partial_update":"false","columnToColumnExpr":"*","maxBatchIntervalS":"10","partial_update_mode":"null","whereExpr":"*","timezone":"Asia/Shanghai","format":"csv","columnSeparator":"'|'","log_rejected_record_num":"0","taskTimeoutSecond":"60","json_root":"","maxFilterRatio":"1.0","strict_mode":"false","jsonpaths":"","taskConsumeSecond":"15","desireTaskConcurrentNum":"5","maxErrorNum":"0","strip_outer_array":"false","currentTaskConcurrentNum":"0","maxBatchRows":"200000"}
DataSourceProperties: {"topic":"wyb_test","currentKafkaPartitions":"0","brokerList":"1.1.1.1:9093"}
    CustomProperties: {"group.id":"label0_049f54bc-e382-451f-ac8a-52acad998580"}
           Statistic: {"receivedBytes":0,"errorRows":0,"committedTaskNum":0,"loadedRows":0,"loadRowsRate":0,"abortedTaskNum":0,"totalRows":0,"unselectedRows":0,"receivedBytesRate":0,"taskExecuteTimeMs":1}
            Progress: {"0":"OFFSET_END"}
   TimestampProgress: {}
ReasonOfStateChanged: ErrorReason{errCode = 2, msg='there is no partition in topic: wyb_test, BE: TNetworkAddress(hostname:1.1.1.1, port:8069)'}
        ErrorLogUrls:
         TrackingSQL:
            OtherMsg:
LatestSourcePosition: {}
1 row in set (0.00 sec)

mysql> show routine load\G
*************************** 1. row ***************************
                  Id: 130096
                Name: label0
          CreateTime: 2024-03-11 17:52:00
           PauseTime: 2024-03-11 17:59:23
             EndTime: NULL
              DbName: kafka_test
           TableName: lineorder
               State: PAUSED
      DataSourceType: KAFKA
      CurrentTaskNum: 0
       JobProperties: {"partitions":"*","rowDelimiter":"\t","partial_update":"false","columnToColumnExpr":"*","maxBatchIntervalS":"10","partial_update_mode":"null","whereExpr":"*","timezone":"Asia/Shanghai","format":"csv","columnSeparator":"'|'","log_rejected_record_num":"0","taskTimeoutSecond":"60","json_root":"","maxFilterRatio":"1.0","strict_mode":"false","jsonpaths":"","taskConsumeSecond":"15","desireTaskConcurrentNum":"5","maxErrorNum":"0","strip_outer_array":"false","currentTaskConcurrentNum":"1","maxBatchRows":"200000"}
DataSourceProperties: {"topic":"wyb_test","currentKafkaPartitions":"1","brokerList":"1.1.1.1:9093"}
    CustomProperties: {"group.id":"label0_54457248-6b16-418b-8a55-6ff169469ab5"}
           Statistic: {"receivedBytes":0,"errorRows":0,"committedTaskNum":0,"loadedRows":0,"loadRowsRate":0,"abortedTaskNum":0,"totalRows":0,"unselectedRows":0,"receivedBytesRate":0,"taskExecuteTimeMs":1}
            Progress: {"1":"OFFSET_END"}
   TimestampProgress: {}
ReasonOfStateChanged: ErrorReason{errCode = 2, msg='there is an invalid custom partition: 1 in topic: wyb_test'}
        ErrorLogUrls:
         TrackingSQL:
            OtherMsg:
LatestSourcePosition: {}
1 row in set (0.01 sec)
```

6. kafka partition offset has no data
```
mysql> show routine load\G
*************************** 1. row ***************************
                  Id: 130163
                Name: label0
          CreateTime: 2024-03-11 19:02:10
           PauseTime: 2024-03-11 19:02:23
             EndTime: NULL
              DbName: kafka_test
           TableName: lineorder
               State: PAUSED
      DataSourceType: KAFKA
      CurrentTaskNum: 0
       JobProperties: {"partitions":"*","rowDelimiter":"\t","partial_update":"false","columnToColumnExpr":"*","maxBatchIntervalS":"10","partial_update_mode":"null","whereExpr":"*","timezone":"Asia/Shanghai","format":"csv","columnSeparator":"'|'","log_rejected_record_num":"0","taskTimeoutSecond":"60","json_root":"","maxFilterRatio":"1.0","strict_mode":"false","jsonpaths":"","taskConsumeSecond":"15","desireTaskConcurrentNum":"5","maxErrorNum":"0","strip_outer_array":"false","currentTaskConcurrentNum":"1","maxBatchRows":"200000"}
DataSourceProperties: {"topic":"wyb_test","currentKafkaPartitions":"0","brokerList":"1.1.1.1:9093"}
    CustomProperties: {"group.id":"label0_09eeebfb-c0f2-4a95-a684-a8aa43d38f06"}
           Statistic: {"receivedBytes":0,"errorRows":0,"committedTaskNum":0,"loadedRows":0,"loadRowsRate":0,"abortedTaskNum":0,"totalRows":0,"unselectedRows":0,"receivedBytesRate":0,"taskExecuteTimeMs":1}
            Progress: {"0":"2999999999"}
   TimestampProgress: {}
ReasonOfStateChanged: ErrorReason{errCode = 104, msg='fe abort task with reason: check task ready to execute failed, there is no data in partition: 0 at offset: 2999999999. you can modify kafka_offsets by alter routine load, then resume the job. refer to https://docs.starrocks.io/docs/sql-reference/sql-statements/data-manipulation/ALTER_ROUTINE_LOAD'}
        ErrorLogUrls:
         TrackingSQL:
            OtherMsg:
LatestSourcePosition: {"0":"2661337494"}
1 row in set (0.00 sec)

mysql> show routine load\G
*************************** 1. row ***************************
                  Id: 130169
                Name: label0
          CreateTime: 2024-03-11 19:06:15
           PauseTime: NULL
             EndTime: NULL
              DbName: kafka_test
           TableName: lineorder
               State: RUNNING
      DataSourceType: KAFKA
      CurrentTaskNum: 1
       JobProperties: {"partitions":"*","rowDelimiter":"\t","partial_update":"false","columnToColumnExpr":"*","maxBatchIntervalS":"10","partial_update_mode":"null","whereExpr":"*","timezone":"Asia/Shanghai","format":"csv","columnSeparator":"'|'","log_rejected_record_num":"0","taskTimeoutSecond":"60","json_root":"","maxFilterRatio":"1.0","strict_mode":"false","jsonpaths":"","taskConsumeSecond":"15","desireTaskConcurrentNum":"5","maxErrorNum":"0","strip_outer_array":"false","currentTaskConcurrentNum":"1","maxBatchRows":"200000"}
DataSourceProperties: {"topic":"wyb_test","currentKafkaPartitions":"0","brokerList":"1.1.1.1:9093"}
    CustomProperties: {"group.id":"label0_8dd51864-261a-4210-82f4-aa9829af4e04"}
           Statistic: {"receivedBytes":0,"errorRows":0,"committedTaskNum":0,"loadedRows":0,"loadRowsRate":0,"abortedTaskNum":0,"totalRows":0,"unselectedRows":0,"receivedBytesRate":0,"taskExecuteTimeMs":1}
            Progress: {"0":"2661337493"}
   TimestampProgress: {}
ReasonOfStateChanged:
        ErrorLogUrls:
         TrackingSQL:
            OtherMsg: [2024-03-19 18:42:16] [task id: c191344f-f78e-46bf-aec8-2b3d8abf0351] [txn id: -1] there is no new data in kafka, wait for 10 seconds to schedule again
LatestSourcePosition: {"0":"2661337494"}
1 row in set (0.00 sec)
```

7. wrong security protocol
```
mysql> show routine load \G
*************************** 1. row ***************************
                  Id: 10518
                Name: primary_routine_load_be4ddad6_e841_11ee_8ee4_00163e21975a
          CreateTime: 2024-03-22 20:17:11
           PauseTime: 2024-03-22 20:17:25
             EndTime: NULL
              DbName: test_db
           TableName: test_all_null1
               State: PAUSED
      DataSourceType: KAFKA
      CurrentTaskNum: 0
       JobProperties: {"partitions":"*","rowDelimiter":"\t","partial_update":"false","columnToColumnExpr":"id_int,id_boolean,id_tinyint,id_smallint,id_bigint,id_largeint,id_float,id_double,id_decimal32,id_decimal64,id_decimal128,id_date,id_datetime,id_varchar","maxBatchIntervalS":"5","partial_update_mode":"null","whereExpr":"*","timezone":"Asia/Shanghai","format":"csv","columnSeparator":"'\t'","log_rejected_record_num":"0","taskTimeoutSecond":"60","json_root":"","maxFilterRatio":"1.0","strict_mode":"false","jsonpaths":"","taskConsumeSecond":"15","desireTaskConcurrentNum":"1","maxErrorNum":"1000","strip_outer_array":"false","currentTaskConcurrentNum":"1","maxBatchRows":"200000"}
DataSourceProperties: {"topic":"condition_null_update","currentKafkaPartitions":"0,1,2,3,4","brokerList":"1.1.1.1:9092"}
    CustomProperties: {"security.protocol":"SSL","group.id":"primary_routine_load_be4ddad6_e841_11ee_8ee4_00163e21975a_8adbb113-96c4-46e8-b23d-0da9c897faaf"}
           Statistic: {"receivedBytes":0,"errorRows":0,"committedTaskNum":0,"loadedRows":0,"loadRowsRate":0,"abortedTaskNum":0,"totalRows":0,"unselectedRows":0,"receivedBytesRate":0,"taskExecuteTimeMs":1}
            Progress: {"0":"OFFSET_BEGINNING","1":"OFFSET_BEGINNING","2":"OFFSET_BEGINNING","3":"OFFSET_BEGINNING","4":"OFFSET_BEGINNING"}
   TimestampProgress: {}
ReasonOfStateChanged: ErrorReason{errCode = 2, msg='failed to get kafka topic: condition_null_update meta, err: Local: Broker transport failure, event: [thrd:ssl://1.1.1.1:9092/bootstrap]: ssl://1.1.1.1:9092/bootstrap: SSL handshake failed: Disconnected: connecting to a PLAINTEXT broker listener? (after 26ms in state SSL_HANDSHAKE), BE: TNetworkAddress(hostname:1.1.1.1, port:8060)'}
        ErrorLogUrls:
            OtherMsg:
LatestSourcePosition: {}
1 row in set (0.01 sec)
```

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [x] 3.1
  - [ ] 3.0
  - [ ] 2.5
