### PR TITLE
[BugFix] MapExpr check invalid key type

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/ExpressionAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/ExpressionAnalyzer.java
@@ -496,6 +496,9 @@ public class ExpressionAnalyzer {
                 Type originalType = node.getType();
                 if (originalType == Type.ANY_MAP) {
                     Type keyType = node.getKeyCommonType();
+                    if (!keyType.isValidMapKeyType()) {
+                        throw new SemanticException("Map key don't supported type: " + keyType, node.getPos());
+                    }
                     Type valueType = node.getValueCommonType();
                     node.setType(new MapType(keyType, valueType));
                 }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AnalyzeExprTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AnalyzeExprTest.java
@@ -511,4 +511,19 @@ public class AnalyzeExprTest {
         analyzeSuccess("select map_from_arrays([1, 2], NULL)");
     }
 
+    @Test
+    public void testMapInvalidKeyType() {
+        analyzeSuccess("select map(1, 2)");
+        analyzeSuccess("select map(1, [])");
+        analyzeSuccess("select map('a', row(1, 2))");
+        analyzeSuccess("select map('abc', row(1, 2))");
+        analyzeSuccess("select map(cast('2020-02-20' as date), row(1, 2))");
+        analyzeSuccess("select map(cast('2020-02-20' as datetime), row(1, 2))");
+
+        analyzeFail("select map([], 123)");
+        analyzeFail("select map(row(1,2,3), 123)");
+        analyzeFail("select map(map(1,2), 123)");
+        analyzeFail("select map(parse_json('{\"a\": 1}'), map(1,2))");
+    }
+
 }

--- a/test/sql/test_array_fn/R/test_array_fn
+++ b/test/sql/test_array_fn/R/test_array_fn
@@ -4548,11 +4548,11 @@ select array_contains_seq([json_keys('{"a":1,"b":2}')], [json_keys('{"a":1,"b":2
 -- result:
 1
 -- !result
-select array_contains_seq([map([1,2,5],[2,4,5])], [map([1,2,5],[2,4,5])]);
+select array_contains_seq([map(1,[2,4,5])], [map(1,[2,4,5])]);
 -- result:
 1
 -- !result
-select array_contains_seq([map([1,2,5],[2,4,5])], [map([1,2],[2,4])]);
+select array_contains_seq([map(1,[2,4,5])], [map(2,[2,4])]);
 -- result:
 0
 -- !result

--- a/test/sql/test_array_fn/T/test_array_fn
+++ b/test/sql/test_array_fn/T/test_array_fn
@@ -1,4 +1,4 @@
--- name: test_array_functions
+-]- name: test_array_functions
 CREATE TABLE array_test ( 
 pk bigint not null ,
 s_1   Array<String>, 
@@ -877,8 +877,8 @@ select array_contains_seq(['a','b','c'], ['a','c']);
 select array_contains_seq([[1, 2], [3, 4], [5, 6]], [[1, 2], [3, 4]]);
 select array_contains_seq([json_keys('{"a":1,"b":2}')], [json_keys('{"a":1}')]);
 select array_contains_seq([json_keys('{"a":1,"b":2}')], [json_keys('{"a":1,"b":2}')]);
-select array_contains_seq([map([1,2,5],[2,4,5])], [map([1,2,5],[2,4,5])]);
-select array_contains_seq([map([1,2,5],[2,4,5])], [map([1,2],[2,4])]);
+select array_contains_seq([map(1,[2,4,5])], [map(1,[2,4,5])]);
+select array_contains_seq([map(1,[2,4,5])], [map(2,[2,4])]);
 select array_contains_seq([1, 2, NULL, 3, 4], ['a']);
 select array_contains_seq([1, 2, NULL, 3, 4], [2,3]);
 select array_contains_seq([1, 2, NULL, 3, 4], null);

--- a/test/sql/test_map/R/test_map
+++ b/test/sql/test_map/R/test_map
@@ -115,45 +115,45 @@ from (select c1 from (values(map())) as t(c1)) t;
 select map_concat(c1, map(map(),map()))
 from (select c1 from (values(map())) as t(c1)) t;
 -- result:
-{{}:{}}
+E: (1064, "Getting analyzing error from line 1, column 22 to line 1, column 37. Detail message: Map key don't supported type: MAP<NULL_TYPE,NULL_TYPE>.")
 -- !result
 select map_concat(c1, map(map(),[]))
 from (select c1 from (values(map())) as t(c1)) t;
 -- result:
-{{}:[]}
+E: (1064, "Getting analyzing error from line 1, column 22 to line 1, column 34. Detail message: Map key don't supported type: MAP<NULL_TYPE,NULL_TYPE>.")
 -- !result
 select map_concat(c1, map([],map()))
 from (select c1 from (values(map())) as t(c1)) t;
 -- result:
-{[]:{}}
+E: (1064, "Getting analyzing error from line 1, column 22 to line 1, column 34. Detail message: Map key don't supported type: ARRAY<NULL_TYPE>.")
 -- !result
 select map_concat(c1, map())
 from (select c1 from (values(map([], []))) as t(c1)) t;
 -- result:
-{[]:[]}
+E: (1064, "Getting analyzing error from line 2, column 29 to line 2, column 39. Detail message: Map key don't supported type: ARRAY<NULL_TYPE>.")
 -- !result
 select map_concat(c1, map())
 from (select c1 from (values(map([], [[]]))) as t(c1)) t;
 -- result:
-{[]:[[]]}
+E: (1064, "Getting analyzing error from line 2, column 29 to line 2, column 41. Detail message: Map key don't supported type: ARRAY<NULL_TYPE>.")
 -- !result
 select map_concat(c1, map([1], [2]))
 from (select c1 from (values(map([], []))) as t(c1)) t;
 -- result:
-{[1]:[2],[]:[]}
+E: (1064, "Getting analyzing error from line 2, column 29 to line 2, column 39. Detail message: Map key don't supported type: ARRAY<NULL_TYPE>.")
 -- !result
 select map_concat(c1, map([1], [[2]]))
 from (select c1 from (values(map([], [[]]))) as t(c1)) t;
 -- result:
-{[1]:[[2]],[]:[[]]}
+E: (1064, "Getting analyzing error from line 2, column 29 to line 2, column 41. Detail message: Map key don't supported type: ARRAY<NULL_TYPE>.")
 -- !result
 select map_concat(c1, map(named_struct('1',2), named_struct('A', [map()])))
 from (select c1 from (values(map())) as t(c1)) t;
 -- result:
-{{"1":2}:{"A":[{}]}}
+E: (1064, "Getting analyzing error from line 1, column 22 to line 1, column 73. Detail message: Map key don't supported type: struct<1 tinyint(4)>.")
 -- !result
 select map_concat(c1, map(named_struct('1',2), named_struct('A', [map([],[[named_struct('C', [[map()]])]])])))
 from (select c1 from (values(map())) as t(c1)) t;
 -- result:
-{{"1":2}:{"A":[{[]:[[{"C":[[{}]]}]]}]}}
+E: (1064, "Getting analyzing error from line 1, column 66 to line 1, column 105. Detail message: Map key don't supported type: ARRAY<NULL_TYPE>.")
 -- !result

--- a/test/sql/test_map/T/test_map
+++ b/test/sql/test_map/T/test_map
@@ -48,6 +48,7 @@ from (select c1 from (values(map())) as t(c1)) t;
 select map_concat(c1, map(1,2))
 from (select c1 from (values(map())) as t(c1)) t;
 
+-- invaild map key type
 select map_concat(c1, map(map(),map()))
 from (select c1 from (values(map())) as t(c1)) t;
 


### PR DESCRIPTION
## Why I'm doing:
MapExpr check key type, doesn't support CollectionType/Json/HLL/BITMAP/...

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [x] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [x] 3.1
  - [x] 3.0
  - [ ] 2.5
