### PR TITLE
[Enhancement] UK FK Join optimization (2)

### DIFF
--- a/be/src/exec/hash_join_node.cpp
+++ b/be/src/exec/hash_join_node.cpp
@@ -61,6 +61,9 @@ HashJoinNode::HashJoinNode(ObjectPool* pool, const TPlanNode& tnode, const Descr
     if (tnode.hash_join_node.__isset.distribution_mode) {
         _distribution_mode = tnode.hash_join_node.distribution_mode;
     }
+    if (tnode.hash_join_node.__isset.use_one_match_probe) {
+        _use_one_match_probe = tnode.hash_join_node.use_one_match_probe;
+    }
 }
 
 Status HashJoinNode::init(const TPlanNode& tnode, RuntimeState* state) {
@@ -465,7 +468,8 @@ pipeline::OpFactories HashJoinNode::_decompose_to_pipeline(pipeline::PipelineBui
     HashJoinerParam param(pool, _hash_join_node, _id, _type, _is_null_safes, _build_expr_ctxs, _probe_expr_ctxs,
                           _other_join_conjunct_ctxs, _conjunct_ctxs, child(1)->row_desc(), child(0)->row_desc(),
                           _row_descriptor, child(1)->type(), child(0)->type(), child(1)->conjunct_ctxs().empty(),
-                          _build_runtime_filters, _output_slots, _output_slots, _distribution_mode, false);
+                          _build_runtime_filters, _output_slots, _output_slots, _distribution_mode, false,
+                          _use_one_match_probe);
     auto hash_joiner_factory = std::make_shared<starrocks::pipeline::HashJoinerFactory>(param);
 
     // add placeholder into RuntimeFilterHub, HashJoinBuildOperator will generate runtime filters and fill it,

--- a/be/src/exec/hash_join_node.h
+++ b/be/src/exec/hash_join_node.h
@@ -108,6 +108,7 @@ private:
 
     TJoinOp::type _join_type = TJoinOp::INNER_JOIN;
     TJoinDistributionMode::type _distribution_mode = TJoinDistributionMode::NONE;
+    bool _use_one_match_probe = false;
     std::set<SlotId> _output_slots;
 
     bool _is_push_down = false;

--- a/be/src/exec/hash_joiner.cpp
+++ b/be/src/exec/hash_joiner.cpp
@@ -48,7 +48,7 @@ void HashJoinBuildMetrics::prepare(RuntimeProfile* runtime_profile) {
     build_conjunct_evaluate_timer = ADD_TIMER(runtime_profile, "BuildConjunctEvaluateTime");
     build_buckets_counter = ADD_COUNTER(runtime_profile, "BuildBuckets", TUnit::UNIT);
     runtime_filter_num = ADD_COUNTER(runtime_profile, "RuntimeFilterNum", TUnit::UNIT);
-    build_keys_per_bucket = ADD_COUNTER(runtime_profile, "BuildKeysPerBucket%", TUnit::UNIT);
+    build_keys_per_bucket = ADD_COUNTER(runtime_profile, "BuildKeysPerBucket", TUnit::UNIT);
     hash_table_memory_usage = ADD_COUNTER(runtime_profile, "HashTableMemoryUsage", TUnit::BYTES);
 }
 

--- a/be/src/exec/hash_joiner.cpp
+++ b/be/src/exec/hash_joiner.cpp
@@ -56,6 +56,7 @@ HashJoiner::HashJoiner(const HashJoinerParam& param)
         : _hash_join_node(param._hash_join_node),
           _pool(param._pool),
           _join_type(param._hash_join_node.join_op),
+          _use_one_match_probe(param._use_one_match_probe),
           _is_null_safes(param._is_null_safes),
           _build_expr_ctxs(param._build_expr_ctxs),
           _probe_expr_ctxs(param._probe_expr_ctxs),
@@ -136,6 +137,7 @@ Status HashJoiner::prepare_prober(RuntimeState* state, RuntimeProfile* runtime_p
 
 void HashJoiner::_init_hash_table_param(HashTableParam* param) {
     param->with_other_conjunct = !_other_join_conjunct_ctxs.empty();
+    param->use_one_match_probe = _use_one_match_probe;
     param->join_type = _join_type;
     param->row_desc = &_row_descriptor;
     param->build_row_desc = &_build_row_descriptor;

--- a/be/src/exec/hash_joiner.h
+++ b/be/src/exec/hash_joiner.h
@@ -73,7 +73,7 @@ struct HashJoinerParam {
                     TPlanNodeType::type probe_node_type, bool build_conjunct_ctxs_is_empty,
                     std::list<RuntimeFilterBuildDescriptor*> build_runtime_filters, std::set<SlotId> build_output_slots,
                     std::set<SlotId> probe_output_slots, const TJoinDistributionMode::type distribution_mode,
-                    bool mor_reader_mode)
+                    bool mor_reader_mode, bool use_one_match_probe)
             : _pool(pool),
               _hash_join_node(hash_join_node),
               _node_id(node_id),
@@ -93,7 +93,8 @@ struct HashJoinerParam {
               _build_output_slots(std::move(build_output_slots)),
               _probe_output_slots(std::move(probe_output_slots)),
               _distribution_mode(distribution_mode),
-              _mor_reader_mode(mor_reader_mode) {}
+              _mor_reader_mode(mor_reader_mode),
+              _use_one_match_probe(use_one_match_probe) {}
 
     HashJoinerParam(HashJoinerParam&&) = default;
     HashJoinerParam(HashJoinerParam&) = default;
@@ -120,6 +121,7 @@ struct HashJoinerParam {
 
     const TJoinDistributionMode::type _distribution_mode;
     const bool _mor_reader_mode;
+    const bool _use_one_match_probe;
 };
 
 inline bool could_short_circuit(TJoinOp::type join_type) {
@@ -307,6 +309,7 @@ public:
     }
 
     const TJoinOp::type& join_type() const { return _join_type; }
+    const bool& use_one_match_probe() const { return _use_one_match_probe; }
 
 private:
     static bool _has_null(const ColumnPtr& column);
@@ -395,6 +398,8 @@ private:
     TJoinOp::type _join_type = TJoinOp::INNER_JOIN;
     std::atomic<HashJoinPhase> _phase = HashJoinPhase::BUILD;
     bool _is_closed = false;
+
+    const bool& _use_one_match_probe;
 
     const std::vector<bool>& _is_null_safes;
     // Equal conjuncts in Join On.

--- a/be/src/exec/join_hash_map.cpp
+++ b/be/src/exec/join_hash_map.cpp
@@ -315,6 +315,7 @@ void JoinHashTable::create(const HashTableParam& param) {
         _probe_state->output_probe_column_timer = param.output_probe_column_timer;
         _probe_state->output_build_column_timer = param.output_build_column_timer;
     }
+    _probe_state->use_one_match_probe = param.use_one_match_probe;
 
     _table_items->build_chunk = std::make_shared<Chunk>();
     _table_items->with_other_conjunct = param.with_other_conjunct;

--- a/be/src/exec/join_hash_map.h
+++ b/be/src/exec/join_hash_map.h
@@ -173,6 +173,10 @@ struct HashTableProbeState {
     // 1: all match one
     JoinMatchFlag match_flag = JoinMatchFlag::NORMAL; // all match one
 
+    // For uk fk join, we already know that for each fk in the left table, there's only one match from
+    // the right table. So we can use this flag to avoid unnecessary probing.
+    bool use_one_match_probe = false;
+
     bool has_remain = false;
     // When one-to-many, one probe may not be able to probe all the data,
     // cur_probe_index records the position of the last probe
@@ -254,6 +258,7 @@ struct HashTableProbeState {
 
 struct HashTableParam {
     bool with_other_conjunct = false;
+    bool use_one_match_probe = false;
     TJoinOp::type join_type = TJoinOp::INNER_JOIN;
     const RowDescriptor* row_desc = nullptr;
     const RowDescriptor* build_row_desc = nullptr;

--- a/be/src/exec/join_hash_map.tpp
+++ b/be/src/exec/join_hash_map.tpp
@@ -973,6 +973,9 @@ void JoinHashMap<LT, BuildFunc, ProbeFunc>::_probe_from_ht(RuntimeState* state, 
                         _probe_state->probe_match_filter[i] = 1;
                     }
                     RETURN_IF_CHUNK_FULL()
+                    if (_probe_state->use_one_match_probe) {
+                        break;
+                    }
                 }
                 build_index = _table_items->next[build_index];
             } while (build_index != 0);
@@ -1117,6 +1120,9 @@ void JoinHashMap<LT, BuildFunc, ProbeFunc>::_probe_from_ht_for_left_outer_join(R
                     _probe_state->cur_row_match_count++;
 
                     RETURN_IF_CHUNK_FULL()
+                    if (_probe_state->use_one_match_probe) {
+                        break;
+                    }
                 }
                 build_index = _table_items->next[build_index];
             }

--- a/be/src/exec/join_hash_map.tpp
+++ b/be/src/exec/join_hash_map.tpp
@@ -972,10 +972,10 @@ void JoinHashMap<LT, BuildFunc, ProbeFunc>::_probe_from_ht(RuntimeState* state, 
                         _probe_state->cur_row_match_count++;
                         _probe_state->probe_match_filter[i] = 1;
                     }
-                    RETURN_IF_CHUNK_FULL()
                     if (_probe_state->use_one_match_probe) {
                         break;
                     }
+                    RETURN_IF_CHUNK_FULL()
                 }
                 build_index = _table_items->next[build_index];
             } while (build_index != 0);
@@ -1119,10 +1119,10 @@ void JoinHashMap<LT, BuildFunc, ProbeFunc>::_probe_from_ht_for_left_outer_join(R
                     match_count++;
                     _probe_state->cur_row_match_count++;
 
-                    RETURN_IF_CHUNK_FULL()
                     if (_probe_state->use_one_match_probe) {
                         break;
                     }
+                    RETURN_IF_CHUNK_FULL()
                 }
                 build_index = _table_items->next[build_index];
             }

--- a/be/src/exec/mor_processor.cpp
+++ b/be/src/exec/mor_processor.cpp
@@ -42,13 +42,13 @@ Status IcebergMORProcessor::init(RuntimeState* runtime_state, const MORParams& p
             std::make_unique<RowDescriptor>(runtime_state->desc_tbl().get_tuple_descriptor(params.mor_tuple_id), false);
     _probe_row_desc = std::make_unique<RowDescriptor>(params.tuple_desc, false);
 
-    const auto param = _pool.add(
-            new HashJoinerParam(&_pool, hash_join_node, 1, TPlanNodeType::HASH_JOIN_NODE,
-                                std::vector<bool>(params.equality_slots.size(), false), _join_exprs, _join_exprs,
-                                std::vector<ExprContext*>(), std::vector<ExprContext*>(), *_build_row_desc,
-                                *_probe_row_desc, *_probe_row_desc, TPlanNodeType::HDFS_SCAN_NODE,
-                                TPlanNodeType::HDFS_SCAN_NODE, true, std::list<RuntimeFilterBuildDescriptor*>(),
-                                std::set<SlotId>(), probe_output_slot_ids, TJoinDistributionMode::PARTITIONED, true));
+    const auto param = _pool.add(new HashJoinerParam(
+            &_pool, hash_join_node, 1, TPlanNodeType::HASH_JOIN_NODE,
+            std::vector<bool>(params.equality_slots.size(), false), _join_exprs, _join_exprs,
+            std::vector<ExprContext*>(), std::vector<ExprContext*>(), *_build_row_desc, *_probe_row_desc,
+            *_probe_row_desc, TPlanNodeType::HDFS_SCAN_NODE, TPlanNodeType::HDFS_SCAN_NODE, true,
+            std::list<RuntimeFilterBuildDescriptor*>(), std::set<SlotId>(), probe_output_slot_ids,
+            TJoinDistributionMode::PARTITIONED, true, false));
 
     _hash_joiner = _pool.add(new HashJoiner(*param));
     RETURN_IF_ERROR(_hash_joiner->prepare_builder(runtime_state, _runtime_profile));

--- a/be/src/exec/pipeline/hashjoin/hash_join_probe_operator.cpp
+++ b/be/src/exec/pipeline/hashjoin/hash_join_probe_operator.cpp
@@ -44,6 +44,10 @@ Status HashJoinProbeOperator::prepare(RuntimeState* state) {
         _join_prober->ref();
     }
 
+    if (_join_prober->use_one_match_probe()) {
+        _unique_metrics->add_info_string("UseOneMatchProbe");
+    }
+
     RETURN_IF_ERROR(_join_prober->prepare_prober(state, _unique_metrics.get()));
 
     return Status::OK();

--- a/fe/fe-core/src/main/java/com/starrocks/planner/HashJoinNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/HashJoinNode.java
@@ -130,6 +130,9 @@ public class HashJoinNode extends JoinNode {
             msg.hash_join_node.setInterpolate_passthrough(
                     ConnectContext.get().getSessionVariable().isHashJoinInterpolatePassthrough());
         }
+        if (ukfkProperty != null && ukfkProperty.useOneMatchProbe) {
+            msg.hash_join_node.setUse_one_match_probe(true);
+        }
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/sql/plan/PlanFragmentBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/plan/PlanFragmentBuilder.java
@@ -2422,7 +2422,7 @@ public class PlanFragmentBuilder {
                 if (constraints != null) {
                     UKFKConstraints.JoinProperty joinProperty = constraints.getJoinProperty();
                     if (joinProperty != null) {
-                        joinProperty.buildExpr(context);
+                        joinProperty.setOneMatchProbe(joinNode.getJoinOp());
                         joinNode.setUkfkProperty(joinProperty);
                     }
                 }

--- a/gensrc/thrift/PlanNodes.thrift
+++ b/gensrc/thrift/PlanNodes.thrift
@@ -632,6 +632,7 @@ struct THashJoinNode {
 
   // used in pipeline engine
   55: optional bool interpolate_passthrough = false
+  56: optional bool use_one_match_probe = false
 }
 
 struct TMergeJoinNode {

--- a/test/sql/test_ukfk_constraints/R/test_ukfk_constraints
+++ b/test/sql/test_ukfk_constraints/R/test_ukfk_constraints
@@ -370,3 +370,52 @@ SELECT * FROM t_uk RIGHT SEMI JOIN t_fk ON t_uk.uk = t_fk.fk AND t_uk.uk > 2 AND
 13	1	1	1	1	1	4
 14	2	2	2	2	2	4
 -- !result
+set enable_ukfk_opt=true;
+-- result:
+-- !result
+set enable_ukfk_join_reorder=false;
+-- result:
+-- !result
+SELECT * FROM t_fk JOIN t_uk ON t_uk.uk = t_fk.fk ORDER BY t_fk.id;
+-- result:
+1	1	1	1	1	1	1	1	2	3	4	5	6
+2	2	2	2	2	2	1	1	2	3	4	5	6
+3	3	3	3	3	3	1	1	2	3	4	5	6
+4	4	4	4	4	4	1	1	2	3	4	5	6
+5	5	5	5	5	5	1	1	2	3	4	5	6
+6	1	1	1	1	1	2	2	3	4	5	6	7
+7	2	2	2	2	2	2	2	3	4	5	6	7
+8	3	3	3	3	3	2	2	3	4	5	6	7
+9	4	4	4	4	4	2	2	3	4	5	6	7
+10	1	1	1	1	1	3	3	4	5	6	7	8
+11	2	2	2	2	2	3	3	4	5	6	7	8
+12	3	3	3	3	3	3	3	4	5	6	7	8
+13	1	1	1	1	1	4	4	5	6	7	8	9
+14	2	2	2	2	2	4	4	5	6	7	8	9
+15	1	1	1	1	1	5	5	6	7	8	9	0
+16	2	2	2	2	2	5	5	6	7	8	9	0
+17	3	3	3	3	3	5	5	6	7	8	9	0
+-- !result
+SELECT * FROM t_fk LEFT OUTER JOIN t_uk ON t_uk.uk = t_fk.fk ORDER BY t_fk.id;
+-- result:
+1	1	1	1	1	1	1	1	2	3	4	5	6
+2	2	2	2	2	2	1	1	2	3	4	5	6
+3	3	3	3	3	3	1	1	2	3	4	5	6
+4	4	4	4	4	4	1	1	2	3	4	5	6
+5	5	5	5	5	5	1	1	2	3	4	5	6
+6	1	1	1	1	1	2	2	3	4	5	6	7
+7	2	2	2	2	2	2	2	3	4	5	6	7
+8	3	3	3	3	3	2	2	3	4	5	6	7
+9	4	4	4	4	4	2	2	3	4	5	6	7
+10	1	1	1	1	1	3	3	4	5	6	7	8
+11	2	2	2	2	2	3	3	4	5	6	7	8
+12	3	3	3	3	3	3	3	4	5	6	7	8
+13	1	1	1	1	1	4	4	5	6	7	8	9
+14	2	2	2	2	2	4	4	5	6	7	8	9
+15	1	1	1	1	1	5	5	6	7	8	9	0
+16	2	2	2	2	2	5	5	6	7	8	9	0
+17	3	3	3	3	3	5	5	6	7	8	9	0
+18	1	1	1	1	1	None	None	None	None	None	None	None
+19	2	2	2	2	2	None	None	None	None	None	None	None
+20	3	3	3	3	3	None	None	None	None	None	None	None
+-- !result

--- a/test/sql/test_ukfk_constraints/T/test_ukfk_constraints
+++ b/test/sql/test_ukfk_constraints/T/test_ukfk_constraints
@@ -106,3 +106,10 @@ SELECT * FROM t_uk RIGHT SEMI JOIN t_fk ON t_uk.uk = t_fk.fk ORDER BY t_fk.id;
 SELECT * FROM t_uk RIGHT SEMI JOIN t_fk ON t_uk.uk = t_fk.fk AND t_uk.uk = 1 ORDER BY t_fk.id;
 SELECT * FROM t_uk RIGHT SEMI JOIN t_fk ON t_uk.uk = t_fk.fk AND t_uk.uk * (t_uk.uk + 3) < 10 ORDER BY t_fk.id;
 SELECT * FROM t_uk RIGHT SEMI JOIN t_fk ON t_uk.uk = t_fk.fk AND t_uk.uk > 2 AND t_uk.uk < 5 ORDER BY t_fk.id;
+
+set enable_ukfk_opt=true;
+set enable_ukfk_join_reorder=false;
+
+-- test one match probe
+SELECT * FROM t_fk JOIN t_uk ON t_uk.uk = t_fk.fk ORDER BY t_fk.id;
+SELECT * FROM t_fk LEFT OUTER JOIN t_uk ON t_uk.uk = t_fk.fk ORDER BY t_fk.id;


### PR DESCRIPTION
## Enhancement

This is an continuation work of the previous pr https://github.com/StarRocks/starrocks/pull/39358. Add one probe match optimization for inner join and left outer join where the right table is the uk table.

## Experiment

This optimization has little-to-no effect to the tpcds. So I use another test to illustrate this optimization.

```sql
CREATE TABLE IF NOT EXISTS t_uk (
  uk int(11) NULL,
  v1 int(11) NULL,
  v2 int(11) NULL,
  v3 int(11) NULL
) ENGINE=OLAP
DUPLICATE KEY(uk)
DISTRIBUTED BY HASH(uk) BUCKETS 10;

CREATE TABLE IF NOT EXISTS t_fk (
  id int(11) NULL,
  fk int(11) NULL,
  v1 int(11) NULL,
  v2 int(11) NULL,
  v3 int(11) NULL
) ENGINE=OLAP
DUPLICATE KEY(id)
DISTRIBUTED BY HASH(id) BUCKETS 10;
```

t_uk table has 10M rows, uk from 1 to 10M. while t_fk has 160M rows, for each uk, there's 16 rows with the same fk in the t_fk table.

```sql
SELECT SUM(t_uk.v1), SUM(t_uk.v2), SUM(t_uk.v3),
 SUM(t_fk.v1), SUM(t_fk.v2) ,SUM(t_fk.v3)
FROM t_fk JOIN t_uk ON uk = fk;
```

When testing this, the `enable_ukfk_join_reorder` should be set to `false`, otherwise, the uk will be put on the left side and the optimization will never be used.

| uk and fk of type int |  SearchHashTableTime |
|:--|:--|
| Disable Opt | 300ms |
| Enable Opt | 260ms |

And I've changed the type of `uk` and `fk` from int to `varchar(16)`, the improvement still not noticable. 

| uk and fk of type string |  SearchHashTableTime |
|:--|:--|
| Disable Opt | 700ms |
| Enable Opt | 660ms |

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
