### PR TITLE
[Tool] Get a list of compile time for each C++ file

### DIFF
--- a/build-support/compile_time.sh
+++ b/build-support/compile_time.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+# Modified from hyrise project
+
+output=`git rev-parse --show-toplevel`/compile_times.txt
+
+start=$(date +%s)
+"$@"
+end=$(date +%s)
+runtime=$((end-start))
+echo "$runtime ${*: -1}" >> "$output"

--- a/build-support/compile_time.sh
+++ b/build-support/compile_time.sh
@@ -1,4 +1,6 @@
 #!/usr/bin/env bash
+# Copyright 2021-present StarRocks, Inc. All rights reserved.
+#
 # Licensed to the Apache Software Foundation (ASF) under one
 # or more contributor license agreements.  See the NOTICE file
 # distributed with this work for additional information
@@ -18,7 +20,8 @@
 #
 # Modified from hyrise project
 
-output=`git rev-parse --show-toplevel`/compile_times.txt
+# The root directory that contains .git, i.e, the root directory of the project
+output=$(git rev-parse --show-toplevel)/compile_times.txt
 
 start=$(date +%s)
 "$@"

--- a/build-support/compile_time.sh
+++ b/build-support/compile_time.sh
@@ -16,8 +16,8 @@
 #
 # Modified from hyrise project
 
-# The root directory that contains .git, i.e, the root directory of the project
-output=$(git rev-parse --show-toplevel)/compile_times.txt
+PARENT_DIR=$(cd $(dirname "$0")/..; pwd)
+output="$PARENT_DIR"/compile_times.txt
 
 start=$(date +%s)
 "$@"

--- a/build-support/compile_time.sh
+++ b/build-support/compile_time.sh
@@ -1,22 +1,18 @@
 #!/usr/bin/env bash
+#
 # Copyright 2021-present StarRocks, Inc. All rights reserved.
 #
-# Licensed to the Apache Software Foundation (ASF) under one
-# or more contributor license agreements.  See the NOTICE file
-# distributed with this work for additional information
-# regarding copyright ownership.  The ASF licenses this file
-# to you under the Apache License, Version 2.0 (the
-# "License"); you may not use this file except in compliance
-# with the License.  You may obtain a copy of the License at
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
 #
-#   http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
-# Unless required by applicable law or agreed to in writing,
-# software distributed under the License is distributed on an
-# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-# KIND, either express or implied.  See the License for the
-# specific language governing permissions and limitations
-# under the License.
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 #
 # Modified from hyrise project
 

--- a/build-support/compile_time.sh
+++ b/build-support/compile_time.sh
@@ -16,7 +16,8 @@
 #
 # Modified from hyrise project
 
-PARENT_DIR=$(cd $(dirname "$0")/..; pwd)
+CURR_DIR=$(dirname "$0")
+PARENT_DIR=$(cd "$CURR_DIR/.."; pwd)
 output="$PARENT_DIR"/compile_times.txt
 
 start=$(date +%s)

--- a/build.sh
+++ b/build.sh
@@ -93,7 +93,7 @@ Usage: $0 <options>
      --with-clang-tidy  build Backend with clang-tidy(default without clang-tidy)
      --without-java-ext build Backend without java-extensions(default with java-extensions)
      -j                 build Backend parallel
-     --save-compile-time 
+     --output-compile-time 
                         save a list of the compile time for every C++ file in ${ROOT}/compile_times.txt.
                         Turning this option on automatically disables ccache.
 
@@ -125,7 +125,7 @@ OPTS=$(getopt \
   -l 'without-java-ext' \
   -l 'use-staros' \
   -l 'enable-shared-data' \
-  -l 'save-compile-time' \
+  -l 'output-compile-time' \
   -o 'j:' \
   -l 'help' \
   -- "$@")
@@ -147,7 +147,7 @@ WITH_BENCH=OFF
 WITH_CLANG_TIDY=OFF
 USE_STAROS=OFF
 BUILD_JAVA_EXT=ON
-SAVE_COMPILE_TIME=OFF
+OUTPUT_COMPILE_TIME=OFF
 MSG=""
 MSG_FE="Frontend"
 MSG_DPP="Spark Dpp application"
@@ -243,7 +243,7 @@ else
             --with-bench) WITH_BENCH=ON; shift ;;
             --with-clang-tidy) WITH_CLANG_TIDY=ON; shift ;;
             --without-java-ext) BUILD_JAVA_EXT=OFF; shift ;;
-            --save-compile-time) SAVE_COMPILE_TIME=ON; shift ;;
+            --output-compile-time) OUTPUT_COMPILE_TIME=ON; shift ;;
             -h) HELP=1; shift ;;
             --help) HELP=1; shift ;;
             -j) PARALLEL=$2; shift 2 ;;
@@ -284,7 +284,7 @@ echo "Get params:
     WITH_CACHELIB       -- $WITH_CACHELIB
     ENABLE_FAULT_INJECTION -- $ENABLE_FAULT_INJECTION
     BUILD_JAVA_EXT      -- $BUILD_JAVA_EXT
-    SAVE_COMPILE_TIME   -- $SAVE_COMPILE_TIME
+    OUTPUT_COMPILE_TIME   -- $OUTPUT_COMPILE_TIME
 "
 
 check_tool()
@@ -356,7 +356,7 @@ if [ ${BUILD_BE} -eq 1 ] ; then
       export STARLET_INSTALL_DIR
     fi
     
-    if [ "${SAVE_COMPILE_TIME}" == "ON" ]; then
+    if [ "${OUTPUT_COMPILE_TIME}" == "ON" ]; then
         rm -f ${ROOT}/compile_times.txt
         CXX_COMPILER_LAUNCHER=${ROOT}/build-support/compile_time.sh
     else

--- a/build.sh
+++ b/build.sh
@@ -93,6 +93,9 @@ Usage: $0 <options>
      --with-clang-tidy  build Backend with clang-tidy(default without clang-tidy)
      --without-java-ext build Backend without java-extensions(default with java-extensions)
      -j                 build Backend parallel
+     --save-compile-time 
+                        save a list of the compile time for every C++ file in ${ROOT}/compile_times.txt.
+                        Turning this option on automatically disables ccache.
 
   Eg.
     $0                                           build all
@@ -122,6 +125,7 @@ OPTS=$(getopt \
   -l 'without-java-ext' \
   -l 'use-staros' \
   -l 'enable-shared-data' \
+  -l 'save-compile-time' \
   -o 'j:' \
   -l 'help' \
   -- "$@")
@@ -143,6 +147,7 @@ WITH_BENCH=OFF
 WITH_CLANG_TIDY=OFF
 USE_STAROS=OFF
 BUILD_JAVA_EXT=ON
+SAVE_COMPILE_TIME=OFF
 MSG=""
 MSG_FE="Frontend"
 MSG_DPP="Spark Dpp application"
@@ -160,7 +165,7 @@ fi
 if [[ -z ${JEMALLOC_DEBUG} ]]; then
     JEMALLOC_DEBUG=OFF
 fi
-if [[ -z ${CCACHE} ]]; then
+if [[ -z ${CCACHE} ]] && [[ -x "$(command -v ccache)" ]]; then
     CCACHE=ccache
 fi
 
@@ -238,6 +243,7 @@ else
             --with-bench) WITH_BENCH=ON; shift ;;
             --with-clang-tidy) WITH_CLANG_TIDY=ON; shift ;;
             --without-java-ext) BUILD_JAVA_EXT=OFF; shift ;;
+            --save-compile-time) SAVE_COMPILE_TIME=ON; shift ;;
             -h) HELP=1; shift ;;
             --help) HELP=1; shift ;;
             -j) PARALLEL=$2; shift 2 ;;
@@ -278,6 +284,7 @@ echo "Get params:
     WITH_CACHELIB       -- $WITH_CACHELIB
     ENABLE_FAULT_INJECTION -- $ENABLE_FAULT_INJECTION
     BUILD_JAVA_EXT      -- $BUILD_JAVA_EXT
+    SAVE_COMPILE_TIME   -- $SAVE_COMPILE_TIME
 "
 
 check_tool()
@@ -348,16 +355,23 @@ if [ ${BUILD_BE} -eq 1 ] ; then
       fi
       export STARLET_INSTALL_DIR
     fi
+    
+    if [ "${SAVE_COMPILE_TIME}" == "ON" ]; then
+        rm -f ${ROOT}/compile_times.txt
+        CXX_COMPILER_LAUNCHER=${ROOT}/build-support/compile_time.sh
+    else
+        CXX_COMPILER_LAUNCHER=${CCACHE}
+    fi
 
     ${CMAKE_CMD} -G "${CMAKE_GENERATOR}"                                \
                   -DSTARROCKS_THIRDPARTY=${STARROCKS_THIRDPARTY}        \
                   -DSTARROCKS_HOME=${STARROCKS_HOME}                    \
                   -DSTARLET_INSTALL_DIR=${STARLET_INSTALL_DIR}          \
-                  -DCMAKE_CXX_COMPILER_LAUNCHER=${CCACHE}                  \
+                  -DCMAKE_CXX_COMPILER_LAUNCHER=${CXX_COMPILER_LAUNCHER} \
                   -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}                \
                   -DMAKE_TEST=OFF -DWITH_GCOV=${WITH_GCOV}              \
                   -DUSE_AVX2=$USE_AVX2 -DUSE_AVX512=$USE_AVX512 -DUSE_SSE4_2=$USE_SSE4_2 \
-                  -DJEMALLOC_DEBUG=$JEMALLOC_DEBUG  \
+                  -DJEMALLOC_DEBUG=$JEMALLOC_DEBUG                      \
                   -DENABLE_QUERY_DEBUG_TRACE=$ENABLE_QUERY_DEBUG_TRACE  \
                   -DWITH_BENCH=${WITH_BENCH}                            \
                   -DWITH_CLANG_TIDY=${WITH_CLANG_TIDY}                  \


### PR DESCRIPTION
## Why I'm doing:
Now it takes a long time to compile BE, maybe we should try to reduce the compilation time, and the first step to solving the problem is to know where the compilation time is spent.

## What I'm doing:
Add a new build option `--save-compile-time` to get a list of compile time for each C++ file.
Another way to get the compile time for each file is to set the CMake property(`set_property(GLOBAL PROPERTY RULE_LAUNCH_COMPILE "${CMAKE_COMMAND} -E time")`), but the compile time from this method is mixed in with the compilation output, and additional work is required to get the summary result.

Example contents of `compile_times.txt` at the end of compilation:
```
9 /home/alex/code/starrocks/be/src/formats/parquet/group_reader.cpp
8 /home/alex/code/starrocks/be/src/formats/parquet/file_reader.cpp
13 /home/alex/code/starrocks/be/src/formats/parquet/page_reader.cpp
5 /home/alex/code/starrocks/be/src/formats/parquet/level_builder.cpp
1 /home/alex/code/starrocks/be/src/formats/orc/apache-orc/c++/src/BloomFilter.cc
4 /home/alex/code/starrocks/be/src/formats/parquet/column_chunk_writer.cpp
0 /home/alex/code/starrocks/be/src/formats/orc/apache-orc/c++/src/ByteRLE.cc
0 /home/alex/code/starrocks/be/src/formats/orc/apache-orc/c++/src/Common.cc
0 /home/alex/code/starrocks/be/src/formats/orc/apache-orc/c++/src/Exceptions.cc
2 /home/alex/code/starrocks/be/src/formats/orc/apache-orc/c++/src/sargs/SearchArgument.cc
1 /home/alex/code/starrocks/be/src/formats/orc/apache-orc/c++/src/ColumnPrinter.cc
1 /home/alex/code/starrocks/be/src/formats/orc/apache-orc/c++/src/MemoryPool.cc
1 /home/alex/code/starrocks/be/src/formats/orc/apache-orc/c++/src/Int128.cc
1 /home/alex/code/starrocks/be/src/formats/orc/apache-orc/c++/src/Compression.cc
0 /home/alex/code/starrocks/be/src/formats/orc/apache-orc/c++/src/Murmur3.cc
1 /home/alex/code/starrocks/be/src/formats/orc/apache-orc/c++/src/LzoDecompressor.cc
0 /home/alex/code/starrocks/be/src/formats/orc/apache-orc/c++/src/OrcFile.cc
1 /home/alex/code/starrocks/be/src/formats/orc/apache-orc/c++/src/ColumnReader.cc
0 /home/alex/code/starrocks/be/src/formats/orc/apache-orc/c++/src/RLEV2Util.cc
0 /home/alex/code/starrocks/be/src/formats/orc/apache-orc/c++/src/RLEv1.cc
1 /home/alex/code/starrocks/be/src/formats/orc/apache-orc/c++/src/RleDecoderV2.cc
1 /home/alex/code/starrocks/be/src/formats/orc/apache-orc/c++/src/RleEncoderV2.cc
1 /home/alex/code/starrocks/be/src/formats/orc/apache-orc/c++/src/RLE.cc
1 /home/alex/code/starrocks/be/src/formats/orc/apache-orc/c++/src/StripeStream.cc
1 /home/alex/code/starrocks/be/src/formats/orc/apache-orc/c++/src/Timezone.cc
0 /home/alex/code/starrocks/be/src/formats/orc/apache-orc/c++/src/Vector.cc
2 /home/alex/code/starrocks/be/src/formats/orc/apache-orc/c++/src/ColumnWriter.cc
1 /home/alex/code/starrocks/be/src/formats/orc/apache-orc/c++/src/Statistics.cc
1 /home/alex/code/starrocks/be/src/fs/fd_cache.cpp
4 /home/alex/code/starrocks/be/src/formats/orc/apache-orc/c++/src/wrap/orc-proto-wrapper.cc
1 /home/alex/code/starrocks/be/src/formats/orc/apache-orc/c++/src/TypeImpl.cc
2 /home/alex/code/starrocks/be/src/formats/orc/apache-orc/c++/src/Reader.cc
1 /home/alex/code/starrocks/be/src/formats/orc/apache-orc/c++/src/Writer.cc
1 /home/alex/code/starrocks/be/src/formats/orc/apache-orc/c++/src/bit_packing.cc
3 /home/alex/code/starrocks/be/src/fs/fs_posix.cpp
2 /home/alex/code/starrocks/be/src/fs/fs_util.cpp
2 /home/alex/code/starrocks/be/src/fs/fs_memory.cpp
2 /home/alex/code/starrocks/be/src/fs/hdfs/hdfs_fs_cache.cpp
3 /home/alex/code/starrocks/be/src/fs/fs_broker.cpp
3 /home/alex/code/starrocks/be/src/fs/fs_s3.cpp
4 /home/alex/code/starrocks/be/src/fs/fs_starlet.cpp
5 /home/alex/code/starrocks/be/src/fs/hdfs/fs_hdfs.cpp
2 /home/alex/code/starrocks/be/src/exec/sort_exec_exprs.cpp
8 /home/alex/code/starrocks/be/src/fs/fs.cpp
6 /home/alex/code/starrocks/be/src/exec/data_sink.cpp
7 /home/alex/code/starrocks/be/src/exec/empty_set_node.cpp
7 /home/alex/code/starrocks/be/src/exec/scan_node.cpp
8 /home/alex/code/starrocks/be/src/exec/exchange_node.cpp
8 /home/alex/code/starrocks/be/src/exec/select_node.cpp
7 /home/alex/code/starrocks/be/src/exec/short_circuit.cpp
6 /home/alex/code/starrocks/be/src/exec/tablet_info.cpp
2 /home/alex/code/starrocks/be/src/exec/mysql_scanner.cpp
6 /home/alex/code/starrocks/be/src/exec/tablet_sink_colocate_sender.cpp
13 /home/alex/code/starrocks/be/src/exec/exec_node.cpp
9 /home/alex/code/starrocks/be/src/exec/short_circuit_hybrid.cpp
5 /home/alex/code/starrocks/be/src/exec/tablet_sink_sender.cpp
7 /home/alex/code/starrocks/be/src/exec/tablet_sink_index_channel.cpp
10 /home/alex/code/starrocks/be/src/exec/olap_common.cpp
1 /home/alex/code/starrocks/be/src/exec/local_file_writer.cpp
2 /home/alex/code/starrocks/be/src/exec/es/es_scroll_query.cpp
3 /home/alex/code/starrocks/be/src/exec/es/es_query_builder.cpp
4 /home/alex/code/starrocks/be/src/exec/es/es_scan_reader.cpp
```

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [x] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
