### PR TITLE
[BugFix] Enhance rule base mv rewrite

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
@@ -1504,7 +1504,7 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
     private boolean enableMaterializedViewRewritePartitionCompensate = true;
 
     @VarAttr(name = ENABLE_FORCE_RULE_BASED_MV_REWRITE)
-    private boolean enableForceRuleBasedMvRewrite = false;
+    private boolean enableForceRuleBasedMvRewrite = true;
 
     @VarAttr(name = ENABLE_RULE_BASED_MATERIALIZED_VIEW_REWRITE)
     private boolean enableRuleBasedMaterializedViewRewrite = true;
@@ -2974,6 +2974,7 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
         return materializedViewJoinSameTablePermutationLimit;
     }
 
+    @Deprecated
     public boolean isEnableMaterializedViewSingleTableViewDeltaRewrite() {
         return enableMaterializedViewSingleTableViewDeltaRewrite;
     }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/common/DebugOperatorTracer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/common/DebugOperatorTracer.java
@@ -191,7 +191,10 @@ public class DebugOperatorTracer extends OperatorVisitor<String, Void> {
     public String visitLogicalAggregation(LogicalAggregationOperator node, Void context) {
         return "LogicalAggregation" + " {type=" + node.getType() +
                 " ,aggregations=" + node.getAggregations() +
-                " ,groupKeys=" + node.getGroupingKeys() + "}";
+                " ,groupKeys=" + node.getGroupingKeys() +
+                " ,projection=" + node.getProjection() +
+                " ,predicate=" + node.getPredicate() +
+                "}";
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/MvRewritePreprocessor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/MvRewritePreprocessor.java
@@ -65,6 +65,7 @@ import com.starrocks.sql.optimizer.operator.scalar.ColumnRefOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ScalarOperator;
 import com.starrocks.sql.optimizer.rule.RuleSetType;
 import com.starrocks.sql.optimizer.rule.mv.MVUtils;
+import com.starrocks.sql.optimizer.rule.transformation.materialization.MvRewriteStrategy;
 import com.starrocks.sql.optimizer.rule.transformation.materialization.MvUtils;
 import org.apache.commons.collections.CollectionUtils;
 import org.apache.logging.log4j.LogManager;
@@ -91,23 +92,16 @@ public class MvRewritePreprocessor {
     private final ConnectContext connectContext;
     private final ColumnRefFactory queryColumnRefFactory;
     private final OptimizerContext context;
-    private final OptExpression logicalTree;
     private final ColumnRefSet requiredColumns;
 
     public MvRewritePreprocessor(ConnectContext connectContext,
                                  ColumnRefFactory queryColumnRefFactory,
                                  OptimizerContext context,
-                                 OptExpression logicalTree,
                                  ColumnRefSet requiredColumns) {
         this.connectContext = connectContext;
         this.queryColumnRefFactory = queryColumnRefFactory;
         this.context = context;
-        this.logicalTree = logicalTree;
         this.requiredColumns = requiredColumns;
-    }
-
-    public OptExpression getLogicalTree() {
-        return logicalTree;
     }
 
     @VisibleForTesting
@@ -225,7 +219,7 @@ public class MvRewritePreprocessor {
         }
     }
 
-    public void prepare(OptExpression queryOptExpression) {
+    public void prepare(OptExpression queryOptExpression, MvRewriteStrategy strategy) {
         // MV Rewrite will be used when cbo is enabled.
         if (context.getOptimizerConfig().isRuleBased()) {
             return;
@@ -249,17 +243,20 @@ public class MvRewritePreprocessor {
                 prepareRelatedMVs(queryTables, mvWithPlanContexts);
 
                 // 5. process relate mvs with views
-                processPlanWithView(queryMaterializationContext, connectContext, logicalTree,
+                processPlanWithView(queryMaterializationContext, connectContext, queryOptExpression,
                         queryColumnRefFactory, requiredColumns);
+
+                // add queryMaterializationContext into context
+                if (context.getCandidateMvs() != null && !context.getCandidateMvs().isEmpty()) {
+                    context.setQueryMaterializationContext(queryMaterializationContext);
+                }
+
+                // initialize mv rewrite strategy finally
+                MvRewriteStrategy.prepareRewriteStrategy(context, connectContext, queryOptExpression, strategy);
             } catch (Exception e) {
                 List<String> tableNames = queryTables.stream().map(Table::getName).collect(Collectors.toList());
                 logMVPrepare(connectContext, "Prepare query tables {} for mv failed:{}", tableNames, e.getMessage());
                 LOG.warn("Prepare query tables {} for mv failed", tableNames, e);
-            }
-
-            // add queryMaterializationContext into context
-            if (context.getCandidateMvs() != null && !context.getCandidateMvs().isEmpty()) {
-                context.setQueryMaterializationContext(queryMaterializationContext);
             }
         }
     }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/Optimizer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/Optimizer.java
@@ -65,6 +65,7 @@ import com.starrocks.sql.optimizer.rule.transformation.RewriteSimpleAggToMetaSca
 import com.starrocks.sql.optimizer.rule.transformation.SeparateProjectRule;
 import com.starrocks.sql.optimizer.rule.transformation.SkewJoinOptimizeRule;
 import com.starrocks.sql.optimizer.rule.transformation.SplitScanORToUnionRule;
+import com.starrocks.sql.optimizer.rule.transformation.materialization.MvRewriteStrategy;
 import com.starrocks.sql.optimizer.rule.transformation.materialization.MvUtils;
 import com.starrocks.sql.optimizer.rule.transformation.pruner.CboTablePruneRule;
 import com.starrocks.sql.optimizer.rule.transformation.pruner.PrimaryKeyUpdateTableRule;
@@ -115,6 +116,7 @@ public class Optimizer {
     private static final Logger LOG = LogManager.getLogger(Optimizer.class);
     private OptimizerContext context;
     private final OptimizerConfig optimizerConfig;
+    private MvRewriteStrategy mvRewriteStrategy = new MvRewriteStrategy();
 
     private long updateTableId = -1;
 
@@ -281,9 +283,9 @@ public class Optimizer {
         context.setQueryTables(queryTables);
         context.setUpdateTableId(updateTableId);
 
-        // prepare related mvs if needed
-        new MvRewritePreprocessor(connectContext, columnRefFactory,
-                context, logicOperatorTree, requiredColumns).prepare(logicOperatorTree);
+        // prepare related mvs if needed and initialize mv rewrite strategy
+        new MvRewritePreprocessor(connectContext, columnRefFactory, context, requiredColumns)
+                .prepare(logicOperatorTree, mvRewriteStrategy);
     }
 
     private void pruneTables(OptExpression tree, TaskContext rootTaskContext, ColumnRefSet requiredColumns) {
@@ -318,6 +320,25 @@ public class Optimizer {
             ruleRewriteOnlyOnce(tree, rootTaskContext, RuleSetType.PRUNE_COLUMNS);
             context.setEnableLeftRightJoinEquivalenceDerive(true);
             ruleRewriteIterative(tree, rootTaskContext, RuleSetType.PUSH_DOWN_PREDICATE);
+        }
+    }
+
+    private void ruleBasedMaterializedViewRewrite(OptExpression tree,
+                                                  TaskContext rootTaskContext) {
+        if (!mvRewriteStrategy.enableMaterializedViewRewrite || context.getQueryMaterializationContext() == null) {
+            return;
+        }
+        if (mvRewriteStrategy.enableRBOSingleViewRewrite) {
+            // try view based mv rewrite first, then try normal mv rewrite rules
+            viewBasedMvRuleRewrite(tree, rootTaskContext);
+        }
+        if (mvRewriteStrategy.enableForceRBORewrite) {
+            // use rule based mv rewrite strategy to do mv rewrite for multi tables query
+            ruleRewriteIterative(tree, rootTaskContext, RuleSetType.MULTI_TABLE_MV_REWRITE);
+        }
+        if (mvRewriteStrategy.enableRBOSingleTableRewrite) {
+            // now add single table materialized view rewrite rules in rule based rewrite phase to boost optimization
+            ruleRewriteIterative(tree, rootTaskContext, RuleSetType.SINGLE_TABLE_MV_REWRITE);
         }
     }
 
@@ -477,23 +498,11 @@ public class Optimizer {
         ruleRewriteOnlyOnce(tree, rootTaskContext, RuleSetType.INTERSECT_REWRITE);
         ruleRewriteIterative(tree, rootTaskContext, new RemoveAggregationFromAggTable());
 
-
         ruleRewriteOnlyOnce(tree, rootTaskContext, SplitScanORToUnionRule.getInstance());
         ruleRewriteOnlyOnce(tree, rootTaskContext, new PushDownTopNBelowUnionRule());
 
-        // try view based mv rewrite first, then try normal mv rewrite rules
-        if (isEnableSingleViewMvRewrite()) {
-            // view based mv rewrite for single view
-            viewBasedMvRuleRewrite(tree, rootTaskContext);
-        }
-
-        if (sessionVariable.isEnableMaterializedViewRewrite() && sessionVariable.isEnableForceRuleBasedMvRewrite()) {
-            // use rule based mv rewrite strategy to do mv rewrite for single table and multi tables query
-            ruleRewriteIterative(tree, rootTaskContext, RuleSetType.ALL_MV_REWRITE);
-        } else if (isEnableSingleTableMVRewrite(rootTaskContext, sessionVariable, tree)) {
-            // now add single table materialized view rewrite rules in rule based rewrite phase to boost optimization
-            ruleRewriteIterative(tree, rootTaskContext, RuleSetType.SINGLE_TABLE_MV_REWRITE);
-        }
+        // rule based materialized view rewrite
+        ruleBasedMaterializedViewRewrite(tree, rootTaskContext);
 
         // NOTE: This rule should be after MV Rewrite because MV Rewrite cannot handle
         // select count(distinct c) from t group by a, b
@@ -550,49 +559,6 @@ public class Optimizer {
             OptimizerTraceUtil.logMVRewriteRule("VIEW_BASED_MV_REWRITE",
                     "single table view based mv rule rewrite failed.", e);
         }
-    }
-
-    private boolean isEnableSingleViewMvRewrite() {
-        return context.getQueryMaterializationContext() != null
-                && context.getQueryMaterializationContext().getLogicalTreeWithView() != null
-                && !optimizerConfig.isRuleSetTypeDisable(RuleSetType.SINGLE_TABLE_MV_REWRITE)
-                && !context.getCandidateMvs().isEmpty()
-                && context.getCandidateMvs().stream().anyMatch(MaterializationContext::isSingleTable)
-                && context.getSessionVariable().isEnableRuleBasedMaterializedViewRewrite();
-    }
-
-    private boolean isEnableSingleTableMVRewrite(TaskContext rootTaskContext,
-                                                 SessionVariable sessionVariable,
-                                                 OptExpression queryPlan) {
-        if (sessionVariable.isDisableMaterializedViewRewrite()) {
-            return false;
-        }
-        // if disable single mv rewrite, return false.
-        if (optimizerConfig.isRuleSetTypeDisable(RuleSetType.SINGLE_TABLE_MV_REWRITE)) {
-            return false;
-        }
-        // if disable isEnableMaterializedViewRewrite/isEnableRuleBasedMaterializedViewRewrite, return false.
-        if (!sessionVariable.isEnableMaterializedViewRewrite()
-                || !sessionVariable.isEnableRuleBasedMaterializedViewRewrite()) {
-            return false;
-        }
-        // if mv candidates are empty, return false.
-        if (rootTaskContext.getOptimizerContext().getCandidateMvs().isEmpty()) {
-            return false;
-        }
-        // If query only has one table use single table rewrite, view delta only rewrites multi-tables query.
-        if (!sessionVariable.isEnableMaterializedViewSingleTableViewDeltaRewrite() &&
-                MvUtils.getAllTables(queryPlan).size() <= 1) {
-            return true;
-        }
-        // If view delta is enabled and there are multi-table mvs, return false.
-        // if mv has multi table sources, we will process it in memo to support view delta join rewrite
-        if (sessionVariable.isEnableMaterializedViewViewDeltaRewrite() &&
-                rootTaskContext.getOptimizerContext().getCandidateMvs()
-                        .stream().anyMatch(MaterializationContext::hasMultiTables)) {
-            return false;
-        }
-        return true;
     }
 
     private OptExpression rewriteAndValidatePlan(
@@ -716,10 +682,8 @@ public class Optimizer {
             context.getRuleSet().addRealtimeMVRules();
         }
 
-        if (isEnableMultiTableRewrite(connectContext, tree)) {
-            if (sessionVariable.isEnableMaterializedViewViewDeltaRewrite() &&
-                    rootTaskContext.getOptimizerContext().getCandidateMvs()
-                            .stream().anyMatch(MaterializationContext::hasMultiTables)) {
+        if (mvRewriteStrategy.enableCBORewrite) {
+            if (mvRewriteStrategy.enableCBOSingleTableRewrite) {
                 context.getRuleSet().addSingleTableMvRewriteRule();
             }
             context.getRuleSet().addMultiTableMvRewriteRule();
@@ -727,26 +691,6 @@ public class Optimizer {
 
         context.getTaskScheduler().pushTask(new OptimizeGroupTask(rootTaskContext, memo.getRootGroup()));
         context.getTaskScheduler().executeTasks(rootTaskContext);
-    }
-
-    private boolean isEnableMultiTableRewrite(ConnectContext connectContext, OptExpression queryPlan) {
-        if (connectContext.getSessionVariable().isDisableMaterializedViewRewrite()) {
-            return false;
-        }
-
-        if (context.getCandidateMvs().isEmpty()) {
-            return false;
-        }
-
-        if (!connectContext.getSessionVariable().isEnableMaterializedViewRewrite()) {
-            return false;
-        }
-
-        if (!connectContext.getSessionVariable().isEnableMaterializedViewSingleTableViewDeltaRewrite() &&
-                MvUtils.getAllTables(queryPlan).size() <= 1) {
-            return false;
-        }
-        return true;
     }
 
     private OptExpression physicalRuleRewrite(TaskContext rootTaskContext, OptExpression result) {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/OptimizerTraceUtil.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/OptimizerTraceUtil.java
@@ -64,9 +64,11 @@ public class OptimizerTraceUtil {
             Object[] args = new Object[] {
                     mvRewriteContext.getRule().type().name(),
                     mvContext.getMv().getName(),
+                    mvRewriteContext.getMaterializationContext().getOptimizerContext().isInMemoPhase(),
                     MessageFormatter.arrayFormat(format, object).getMessage()
             };
-            return MessageFormatter.arrayFormat("[MV TRACE] [REWRITE {} {}] {}", args).getMessage();
+            return MessageFormatter.arrayFormat("[MV TRACE] [REWRITE {} {}] [InMemo:{}] {}",
+                    args).getMessage();
         });
     }
 
@@ -75,9 +77,10 @@ public class OptimizerTraceUtil {
         Tracers.log(Tracers.Module.MV, input -> {
             Object[] args = new Object[] {
                     rule.type().name(),
+                    optimizerContext.isInMemoPhase(),
                     MessageFormatter.arrayFormat(format, object).getMessage()
             };
-            return MessageFormatter.arrayFormat("[MV TRACE] [REWRITE {}] {}", args).getMessage();
+            return MessageFormatter.arrayFormat("[MV TRACE] [REWRITE {}] [InMemo:{}] {}", args).getMessage();
         });
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/AggregatedMaterializedViewRewriter.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/AggregatedMaterializedViewRewriter.java
@@ -198,7 +198,8 @@ public class AggregatedMaterializedViewRewriter extends MaterializedViewRewriter
                         queryExprToMvExprRewriter, rewriteContext.getOutputMapping(),
                         originalColumnSet, aggregateFunctionRewriter);
             if (rewritten == null) {
-                logMVRewrite(mvRewriteContext, "Rewrite aggregate group-by/agg expr failed: {}", scalarOp.toString());
+                logMVRewrite(mvRewriteContext, "Rewrite projection with aggregate group-by/agg expr " +
+                        "failed: {}", scalarOp.toString());
                 return null;
             }
             newQueryProjection.put(entry.getKey(), rewritten);

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvRewriteStrategy.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvRewriteStrategy.java
@@ -1,0 +1,147 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.sql.optimizer.rule.transformation.materialization;
+
+import com.google.common.base.Preconditions;
+import com.starrocks.qe.ConnectContext;
+import com.starrocks.qe.SessionVariable;
+import com.starrocks.sql.optimizer.MaterializationContext;
+import com.starrocks.sql.optimizer.OptExpression;
+import com.starrocks.sql.optimizer.OptimizerConfig;
+import com.starrocks.sql.optimizer.OptimizerContext;
+import com.starrocks.sql.optimizer.rule.RuleSetType;
+
+public class MvRewriteStrategy {
+    public static final MvRewriteStrategy DEFAULT = new MvRewriteStrategy();
+
+    // general config
+    public boolean enableMaterializedViewRewrite = false;
+    // Whether enable force rewrite for query plans with join operator by rule based mv rewrite
+    public boolean enableForceRBORewrite = false;
+
+    // rbo config
+    public boolean enableRBOSingleViewRewrite = false;
+    public boolean enableRBOSingleTableRewrite = false;
+
+    // cbo config
+    public boolean enableCBORewrite = false;
+    public boolean enableCBOSingleTableRewrite = false;
+
+    static class MvStrategyArbitrator {
+        private final OptimizerConfig optimizerConfig;
+        private final OptimizerContext optimizerContext;
+        private final SessionVariable sessionVariable;
+
+        public MvStrategyArbitrator(OptimizerContext optimizerContext,
+                                    ConnectContext connectContext) {
+            this.optimizerContext = optimizerContext;
+            this.optimizerConfig = optimizerContext.getOptimizerConfig();
+            // from connectContext rather than optimizerContext
+            this.sessionVariable = connectContext.getSessionVariable();
+        }
+
+        private boolean isEnableMaterializedViewRewrite() {
+            if (sessionVariable.isDisableMaterializedViewRewrite()) {
+                return false;
+            }
+            // if disable isEnableMaterializedViewRewrite, return false.
+            if (!sessionVariable.isEnableMaterializedViewRewrite()) {
+                return false;
+            }
+            // if mv candidates are empty, return false.
+            if (optimizerContext.getCandidateMvs() == null ||
+                    optimizerContext.getCandidateMvs().isEmpty()) {
+                return false;
+            }
+            if (optimizerConfig.isRuleSetTypeDisable(RuleSetType.SINGLE_TABLE_MV_REWRITE) &&
+                    optimizerConfig.isRuleSetTypeDisable(RuleSetType.MULTI_TABLE_MV_REWRITE)) {
+                return false;
+            }
+            return true;
+        }
+
+        private boolean isEnableRBOSingleViewRewrite() {
+            return optimizerContext.getQueryMaterializationContext() != null
+                    && optimizerContext.getQueryMaterializationContext().getLogicalTreeWithView() != null
+                    && !optimizerConfig.isRuleSetTypeDisable(RuleSetType.SINGLE_TABLE_MV_REWRITE)
+                    && optimizerContext.getCandidateMvs().stream().anyMatch(MaterializationContext::isSingleTable);
+        }
+
+        private boolean isEnableRBOSingleTableRewrite(OptExpression queryPlan) {
+            // if disable single mv rewrite, return false.
+            if (optimizerConfig.isRuleSetTypeDisable(RuleSetType.SINGLE_TABLE_MV_REWRITE)) {
+                return false;
+            }
+            // If query only has one table use single table rewrite, view delta only rewrites multi-tables query.
+            if (!sessionVariable.isEnableMaterializedViewSingleTableViewDeltaRewrite() &&
+                    MvUtils.getAllTables(queryPlan).size() <= 1) {
+                return true;
+            }
+            // If view delta is enabled and there are multi-table mvs, return false.
+            // if mv has multi table sources, we will process it in memo to support view delta join rewrite
+            if (sessionVariable.isEnableMaterializedViewViewDeltaRewrite() &&
+                    optimizerContext.getCandidateMvs().stream().anyMatch(MaterializationContext::hasMultiTables)) {
+                return false;
+            }
+            return true;
+        }
+
+        private boolean isEnableCBOSingleTableRewrite() {
+            if (sessionVariable.isEnableMaterializedViewViewDeltaRewrite() &&
+                    optimizerContext.getCandidateMvs().stream().anyMatch(MaterializationContext::hasMultiTables)) {
+                return true;
+            }
+            return false;
+        }
+
+        private boolean isEnableCBOMultiTableRewrite(OptExpression queryPlan) {
+            if (!sessionVariable.isEnableMaterializedViewSingleTableViewDeltaRewrite() &&
+                    MvUtils.getAllTables(queryPlan).size() <= 1) {
+                return false;
+            }
+            return true;
+        }
+    }
+
+    /**
+     * Prepare mv rewrite strategy used in optimizor's rbo/cbo phase.
+     * @param optimizerContext: optimizer context
+     * @param connectContext: connect context
+     * @param queryPlan: query plan to rewrite or not
+     * @param strategy: mv rewrite strategy to be updated
+     */
+    public static void prepareRewriteStrategy(OptimizerContext optimizerContext,
+                                              ConnectContext connectContext,
+                                              OptExpression queryPlan,
+                                              MvRewriteStrategy strategy) {
+        Preconditions.checkState(strategy != null, "MvRewriteStrategy is null");
+        MvStrategyArbitrator arbitrator = new MvStrategyArbitrator(optimizerContext, connectContext);
+        strategy.enableMaterializedViewRewrite = arbitrator.isEnableMaterializedViewRewrite();
+        // only rewrite when enableMaterializedViewRewrite is enabled
+        if (!strategy.enableMaterializedViewRewrite) {
+            return;
+        }
+        SessionVariable sessionVariable = connectContext.getSessionVariable();
+        strategy.enableForceRBORewrite = sessionVariable.isEnableForceRuleBasedMvRewrite();
+
+        // rbo strategies
+        strategy.enableRBOSingleViewRewrite = arbitrator.isEnableRBOSingleViewRewrite();
+        strategy.enableRBOSingleTableRewrite = arbitrator.isEnableRBOSingleTableRewrite(queryPlan);
+
+        // cbo strategies
+        strategy.enableCBORewrite = arbitrator.isEnableCBOMultiTableRewrite(queryPlan);
+        strategy.enableCBOSingleTableRewrite = arbitrator.isEnableCBOSingleTableRewrite();
+    }
+}

--- a/fe/fe-core/src/test/java/com/starrocks/planner/MaterializedViewTPCHTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/planner/MaterializedViewTPCHTest.java
@@ -51,6 +51,11 @@ public class MaterializedViewTPCHTest extends MaterializedViewTestBase {
         setTableStatistics(t4, 150000 * scale);
         OlapTable t7 = (OlapTable) globalStateMgr.getDb(MATERIALIZED_DB_NAME).getTable("lineitem");
         setTableStatistics(t7, 6000000 * scale);
+
+        // When force rule based rewrite is enabled, query will be transformed into scan in Rule Rewrite Phase.
+        // And OneTabletExecutorVisitor#visitLogicalTableScan will deduce `supportOneTabletOpt` because this test
+        // case has no tablets left after mv rewrite.
+        connectContext.getSessionVariable().setEnableForceRuleBasedMvRewrite(false);
     }
 
     @ParameterizedTest(name = "Tpch.{0}")

--- a/fe/fe-core/src/test/java/com/starrocks/planner/MaterializedViewTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/planner/MaterializedViewTest.java
@@ -1801,7 +1801,6 @@ public class MaterializedViewTest extends MaterializedViewTestBase {
 
     @Test
     public void testAggJoinViewDelta() {
-        connectContext.getSessionVariable().setOptimizerExecuteTimeout(300000000);
         String mv = "SELECT" +
                 " `LO_ORDERKEY` as col1, C_CUSTKEY, S_SUPPKEY, P_PARTKEY," +
                 " sum(LO_QUANTITY) as total_quantity, sum(LO_ORDTOTALPRICE) as total_price, count(*) as num" +
@@ -2848,11 +2847,10 @@ public class MaterializedViewTest extends MaterializedViewTestBase {
                 "bitmap_union(bitmap_hash(concat(user_name, \"b\"))), " +
                 "bitmap_union(bitmap_hash(concat(user_name, \"c\"))) from user_tags group by user_id, time;";
         connectContext.getSessionVariable().setMaterializedViewRewriteMode("force");
+        connectContext.getSessionVariable().setCboCteReuse(false);
         testRewriteOK(mv, "select user_id, bitmap_union(bitmap_hash(user_name)) x from user_tags group by user_id;");
         testRewriteOK(mv, "select user_id, bitmap_count(bitmap_union(bitmap_hash(user_name))) x " +
                 "from user_tags group by user_id;");
-        // FIXME: MV Rewrite should take care cte reuse node later.
-        connectContext.getSessionVariable().setCboCteReuse(false);
         testRewriteOK(mv, "select user_id, count(distinct user_name), " +
                 " count(distinct concat(user_name, \"a\")), count(distinct concat(user_name, \"b\"))," +
                 " count(distinct concat(user_name, \"c\"))  from user_tags group by user_id;");
@@ -5255,13 +5253,11 @@ public class MaterializedViewTest extends MaterializedViewTestBase {
         PlanTestBase.setTableStatistics((OlapTable) table1, 1000000);
         PlanTestBase.setTableStatistics((OlapTable) table2, 1000000);
 
-        {
-            testRewriteFail(mv, query);
-        }
-
         // For enforce-columns changed which also changed mv's cost model, use force rewrite to force the result.
         connectContext.getSessionVariable()
                 .setMaterializedViewRewriteMode(SessionVariable.MaterializedViewRewriteMode.FORCE.toString());
+        testRewriteOK(mv, query);
+
         {
             MVRewriteChecker checker = testRewriteOK(mv, query);
             checker.contains("UNION");

--- a/fe/fe-core/src/test/java/com/starrocks/planner/TablePruningTestBase.java
+++ b/fe/fe-core/src/test/java/com/starrocks/planner/TablePruningTestBase.java
@@ -23,17 +23,14 @@ import com.starrocks.utframe.UtFrameUtils;
 import joptsimple.internal.Strings;
 import kotlin.text.Charsets;
 import org.apache.commons.io.IOUtils;
-import org.apache.hadoop.io.Text;
 import org.junit.Assert;
 
 import java.io.File;
-import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.nio.file.Files;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.Comparator;
 import java.util.Iterator;
 import java.util.List;

--- a/fe/fe-core/src/test/java/com/starrocks/planner/ViewBaseMvRewriteTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/planner/ViewBaseMvRewriteTest.java
@@ -442,7 +442,6 @@ public class ViewBaseMvRewriteTest extends MaterializedViewTestBase {
                     "FROM view_1 v1\n" +
                     "JOIN view_2 v2 ON v1.l_partkey = v2.l_partkey\n" +
                     "AND v1.l_suppkey = v2.l_suppkey;";
-            setTracLogModule("MV");
             testRewriteOK(mv, query);
             starRocksAssert.dropMaterializedView("mv_2");
         }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvRefreshAndRewriteIcebergTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvRefreshAndRewriteIcebergTest.java
@@ -1523,7 +1523,7 @@ public class MvRefreshAndRewriteIcebergTest extends MvRewriteTestBase {
                     " where t1.d in ('2023-08-01')\n" +
                     " group by t1.a, t2.b, t1.d;";
             String plan = getFragmentPlan(query);
-            PlanTestBase.assertNotContains(plan, "test_mv1");
+            PlanTestBase.assertContains(plan, "test_mv1");
         }
 
         connectContext.getSessionVariable().setMaterializedViewRewriteMode("force");

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvRewritePartitionTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvRewritePartitionTest.java
@@ -17,7 +17,6 @@ package com.starrocks.sql.optimizer.rule.transformation.materialization;
 import com.google.common.base.Joiner;
 import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableList;
-import com.starrocks.common.Pair;
 import com.starrocks.common.profile.Tracers;
 import com.starrocks.sql.plan.PlanTestBase;
 import org.junit.AfterClass;
@@ -566,14 +565,40 @@ public class MvRewritePartitionTest extends MvRewriteTestBase {
         }
     }
 
+    static class PCompensateExpect {
+        public String partitionPredicate;
+        public boolean isCompensateUnionAll;
+        public boolean isExpectRewrite;
+        public PCompensateExpect(String partitionPredicate, boolean isCompensateUnionAll, boolean isExpectRewrite) {
+            this.partitionPredicate = partitionPredicate;
+            this.isCompensateUnionAll = isCompensateUnionAll;
+            this.isExpectRewrite = isExpectRewrite;
+        }
+
+        public static PCompensateExpect create(String partitionPredicate, boolean isCompensateUnionAll,
+                                               boolean isExpectRewrite) {
+            return new PCompensateExpect(partitionPredicate, isCompensateUnionAll, isExpectRewrite);
+        }
+
+        public static PCompensateExpect create(String partitionPredicate, boolean isExpectRewrite) {
+            return new PCompensateExpect(partitionPredicate, false, isExpectRewrite);
+        }
+
+        @Override
+        public String toString() {
+            return String.format("partitionPredicate=%s, isCompensateUnionAll=%s, isExpectRewrite=%s",
+                    partitionPredicate, isCompensateUnionAll, isExpectRewrite);
+        }
+    }
+
     class PartitionCompensateParam {
         public String mvPartitionExpr;
         public String refreshStart;
         public String refreshEnd;
-        public List<Pair<String, Boolean>> expectPartitionPredicates;
+        public List<PCompensateExpect> expectPartitionPredicates;
         public PartitionCompensateParam(String mvPartitionExpr,
                                         String refreshStart, String refreshEnd,
-                                        List<Pair<String, Boolean>> expectPartitionPredicates) {
+                                        List<PCompensateExpect> expectPartitionPredicates) {
             this.mvPartitionExpr = mvPartitionExpr;
             this.refreshStart = refreshStart;
             this.refreshEnd = refreshEnd;
@@ -583,7 +608,7 @@ public class MvRewritePartitionTest extends MvRewriteTestBase {
         @Override
         public String toString() {
             return String.format("mvPartitionExpr=%s, refreshStart=%s, refreshEnd=%s, " +
-                    "expectPartitionPredicates=%s", mvPartitionExpr, refreshStart, refreshEnd,
+                            "expectPartitionPredicates=%s", mvPartitionExpr, refreshStart, refreshEnd,
                     Joiner.on(",").join(expectPartitionPredicates));
         }
     }
@@ -602,20 +627,24 @@ public class MvRewritePartitionTest extends MvRewriteTestBase {
                     String mvName = (String) obj;
                     cluster.runSql("test", String.format("refresh materialized view %s partition " +
                             "start('%s') end('%s') with sync mode;", mvName, param.refreshStart, param.refreshEnd));
-                    for (Pair<String, Boolean> expect : param.expectPartitionPredicates) {
-                        if (!Strings.isNullOrEmpty(expect.first)) {
-                            System.out.println(String.format("predicate:%s, expect:%s", expect.first, expect.second));
+                    for (PCompensateExpect expect : param.expectPartitionPredicates) {
+                        if (!Strings.isNullOrEmpty(expect.partitionPredicate)) {
+                            System.out.println(String.format("expect=%s", expect));
                             String query = String.format("select a.t1a, a.id_date, sum(a.t1b), sum(b.t1b) \n" +
                                     "from table_with_day_partition a\n" +
                                     " left join table_with_day_partition1 b on a.id_date=b.id_date \n" +
                                     " left join table_with_day_partition2 c on a.id_date=c.id_date \n" +
                                     " where %s " +
-                                    " group by a.t1a,a.id_date;", expect.first);
+                                    " group by a.t1a,a.id_date;", expect.partitionPredicate);
                             String plan = getFragmentPlan(query);
-                            if (expect.second) {
+                            if (expect.isExpectRewrite) {
+                                if (expect.isCompensateUnionAll) {
+                                    PlanTestBase.assertContains(plan, "UNION");
+                                }
                                 PlanTestBase.assertContains(plan, mvName);
                             } else {
                                 PlanTestBase.assertNotContains(plan, mvName);
+                                PlanTestBase.assertNotContains(plan, "UNION");
                             }
                         }
                     }
@@ -630,19 +659,19 @@ public class MvRewritePartitionTest extends MvRewriteTestBase {
                         "1991-03-30", "1991-03-31",
                         ImmutableList.of(
                                 // no partition expressions
-                                Pair.create("a.id_date='1991-03-30'", true),
-                                Pair.create("a.id_date>='1991-03-30'", false),
-                                Pair.create("a.id_date!='1991-03-30'", false),
+                                PCompensateExpect.create("a.id_date='1991-03-30'", false, true),
+                                PCompensateExpect.create("a.id_date>='1991-03-30'", true, true),
+                                PCompensateExpect.create("a.id_date!='1991-03-30'", false),
                                 // with partition expressions && partition expressions can be pruned
-                                Pair.create("date_format(a.id_date, '%Y%m%d')='19910330'", true),
-                                Pair.create("date_format(a.id_date, '%Y-%m-%d')='1991-03-30'", true),
-                                Pair.create("date_trunc('day', a.id_date)='1991-03-30'", true),
-                                Pair.create("date_trunc('day', a.id_date)>='1991-03-30'", false),
-                                Pair.create("subdate(a.id_date, interval 1 day)='1991-03-29'", true),
-                                Pair.create("adddate(a.id_date, interval 1 day)='1991-03-31'", true),
+                                PCompensateExpect.create("date_format(a.id_date, '%Y%m%d')='19910330'", false, true),
+                                PCompensateExpect.create("date_format(a.id_date, '%Y-%m-%d')='1991-03-30'", false, true),
+                                PCompensateExpect.create("date_trunc('day', a.id_date)='1991-03-30'", false, true),
+                                PCompensateExpect.create("date_trunc('day', a.id_date)>='1991-03-30'", true, true),
+                                PCompensateExpect.create("subdate(a.id_date, interval 1 day)='1991-03-29'", false, true),
+                                PCompensateExpect.create("adddate(a.id_date, interval 1 day)='1991-03-31'", false, true),
                                 // with partition expressions && partition expressions can be pruned
-                                Pair.create("cast(a.id_date as string)='1991-03-30'", false),
-                                Pair.create("cast(a.id_date as string) >='1991-03-30'", false)
+                                PCompensateExpect.create("cast(a.id_date as string)='1991-03-30'", false),
+                                PCompensateExpect.create("cast(a.id_date as string) >='1991-03-30'", false)
                         )
                 ),
                 // partition: slot
@@ -650,19 +679,19 @@ public class MvRewritePartitionTest extends MvRewriteTestBase {
                         "1991-03-30", "1991-03-31",
                         ImmutableList.of(
                                 // no partition expressions
-                                Pair.create("a.id_date='1991-03-30'", true),
-                                Pair.create("a.id_date>='1991-03-30'", false),
-                                Pair.create("a.id_date!='1991-03-30'", false),
+                                PCompensateExpect.create("a.id_date='1991-03-30'", false, true),
+                                PCompensateExpect.create("a.id_date>='1991-03-30'", true, true),
+                                PCompensateExpect.create("a.id_date!='1991-03-30'", false),
                                 // with partition expressions && partition expressions can be pruned
-                                Pair.create("date_format(a.id_date, '%Y%m%d')='19910330'", true),
-                                Pair.create("date_format(a.id_date, '%Y-%m-%d')='1991-03-30'", true),
-                                Pair.create("date_trunc('day', a.id_date)='1991-03-30'", true),
-                                Pair.create("date_trunc('day', a.id_date)>='1991-03-30'", false),
-                                Pair.create("subdate(a.id_date, interval 1 day)='1991-03-29'", true),
-                                Pair.create("adddate(a.id_date, interval 1 day)='1991-03-31'", true),
+                                PCompensateExpect.create("date_format(a.id_date, '%Y%m%d')='19910330'", false, true),
+                                PCompensateExpect.create("date_format(a.id_date, '%Y-%m-%d')='1991-03-30'", false, true),
+                                PCompensateExpect.create("date_trunc('day', a.id_date)='1991-03-30'", false, true),
+                                PCompensateExpect.create("date_trunc('day', a.id_date)>='1991-03-30'", true, true),
+                                PCompensateExpect.create("subdate(a.id_date, interval 1 day)='1991-03-29'", false, true),
+                                PCompensateExpect.create("adddate(a.id_date, interval 1 day)='1991-03-31'", false, true),
                                 // with partition expressions && partition expressions can be pruned
-                                Pair.create("cast(a.id_date as string)='1991-03-30'", false),
-                                Pair.create("cast(a.id_date as string) >='1991-03-30'", false)
+                                PCompensateExpect.create("cast(a.id_date as string)='1991-03-30'", false),
+                                PCompensateExpect.create("cast(a.id_date as string) >='1991-03-30'", false)
                         )
                 )
         );
@@ -681,19 +710,19 @@ public class MvRewritePartitionTest extends MvRewriteTestBase {
                         "1991-03-30", "1991-03-31",
                         ImmutableList.of(
                                 // no partition expressions
-                                Pair.create("a.id_date='1991-03-30'", true),
-                                Pair.create("a.id_date>='1991-03-30'", true),
-                                Pair.create("a.id_date!='1991-03-30'", true),
+                                PCompensateExpect.create("a.id_date='1991-03-30'", true),
+                                PCompensateExpect.create("a.id_date>='1991-03-30'", true),
+                                PCompensateExpect.create("a.id_date!='1991-03-30'", true),
                                 // with partition expressions && partition expressions can be pruned
-                                Pair.create("date_format(a.id_date, '%Y%m%d')='19910330'", true),
-                                Pair.create("date_format(a.id_date, '%Y-%m-%d')='1991-03-30'", true),
-                                Pair.create("date_trunc('day', a.id_date)='1991-03-30'", true),
-                                Pair.create("date_trunc('day', a.id_date)>='1991-03-30'", true),
-                                Pair.create("subdate(a.id_date, interval 1 day)='1991-03-29'", true),
-                                Pair.create("adddate(a.id_date, interval 1 day)='1991-03-31'", true),
+                                PCompensateExpect.create("date_format(a.id_date, '%Y%m%d')='19910330'", true),
+                                PCompensateExpect.create("date_format(a.id_date, '%Y-%m-%d')='1991-03-30'", true),
+                                PCompensateExpect.create("date_trunc('day', a.id_date)='1991-03-30'", true),
+                                PCompensateExpect.create("date_trunc('day', a.id_date)>='1991-03-30'", true),
+                                PCompensateExpect.create("subdate(a.id_date, interval 1 day)='1991-03-29'", true),
+                                PCompensateExpect.create("adddate(a.id_date, interval 1 day)='1991-03-31'", true),
                                 // with partition expressions && partition expressions can be pruned
-                                Pair.create("cast(a.id_date as string)='1991-03-30'", true),
-                                Pair.create("cast(a.id_date as string) >='1991-03-30'", true)
+                                PCompensateExpect.create("cast(a.id_date as string)='1991-03-30'", true),
+                                PCompensateExpect.create("cast(a.id_date as string) >='1991-03-30'", true)
                         )
                 ),
                 // partition: slot
@@ -701,19 +730,19 @@ public class MvRewritePartitionTest extends MvRewriteTestBase {
                         "1991-03-30", "1991-03-31",
                         ImmutableList.of(
                                 // no partition expressions
-                                Pair.create("a.id_date='1991-03-30'", true),
-                                Pair.create("a.id_date>='1991-03-30'", true),
-                                Pair.create("a.id_date!='1991-03-30'", true),
+                                PCompensateExpect.create("a.id_date='1991-03-30'", true),
+                                PCompensateExpect.create("a.id_date>='1991-03-30'", true),
+                                PCompensateExpect.create("a.id_date!='1991-03-30'", true),
                                 // with partition expressions && partition expressions can be pruned
-                                Pair.create("date_format(a.id_date, '%Y%m%d')='19910330'", true),
-                                Pair.create("date_format(a.id_date, '%Y-%m-%d')='1991-03-30'", true),
-                                Pair.create("date_trunc('day', a.id_date)='1991-03-30'", true),
-                                Pair.create("date_trunc('day', a.id_date)>='1991-03-30'", true),
-                                Pair.create("subdate(a.id_date, interval 1 day)='1991-03-29'", true),
-                                Pair.create("adddate(a.id_date, interval 1 day)='1991-03-31'", true),
+                                PCompensateExpect.create("date_format(a.id_date, '%Y%m%d')='19910330'", true),
+                                PCompensateExpect.create("date_format(a.id_date, '%Y-%m-%d')='1991-03-30'", true),
+                                PCompensateExpect.create("date_trunc('day', a.id_date)='1991-03-30'", true),
+                                PCompensateExpect.create("date_trunc('day', a.id_date)>='1991-03-30'", true),
+                                PCompensateExpect.create("subdate(a.id_date, interval 1 day)='1991-03-29'", true),
+                                PCompensateExpect.create("adddate(a.id_date, interval 1 day)='1991-03-31'", true),
                                 // with partition expressions && partition expressions can be pruned
-                                Pair.create("cast(a.id_date as string)='1991-03-30'", true),
-                                Pair.create("cast(a.id_date as string) >='1991-03-30'", true)
+                                PCompensateExpect.create("cast(a.id_date as string)='1991-03-30'", true),
+                                PCompensateExpect.create("cast(a.id_date as string) >='1991-03-30'", true)
                         )
                 )
         );

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvRewritePreprocessorTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvRewritePreprocessorTest.java
@@ -284,7 +284,7 @@ public class MvRewritePreprocessorTest extends MvRewriteTestBase {
         }
     }
 
-    private MvRewritePreprocessor buildMvProcessor(String query) {
+    private Pair<MvRewritePreprocessor, OptExpression> buildMvProcessor(String query) {
         ColumnRefFactory columnRefFactory = new ColumnRefFactory();
         OptimizerConfig optimizerConfig = new OptimizerConfig();
         OptimizerContext context = new OptimizerContext(new Memo(), columnRefFactory, connectContext, optimizerConfig);
@@ -297,8 +297,8 @@ public class MvRewritePreprocessorTest extends MvRewriteTestBase {
             ColumnRefSet requiredColumns = new ColumnRefSet(logicalPlan.getOutputColumn());
             OptExpression logicalTree = logicalPlan.getRoot();
             MvRewritePreprocessor preprocessor = new MvRewritePreprocessor(connectContext, columnRefFactory,
-                    context, logicalTree, requiredColumns);
-            return preprocessor;
+                    context, requiredColumns);
+            return Pair.create(preprocessor, logicalTree);
         } catch (Exception e) {
             return null;
         }
@@ -332,8 +332,9 @@ public class MvRewritePreprocessorTest extends MvRewriteTestBase {
             // query 1
             {
                 String query = "select k1, v1, v2 from t1";
-                MvRewritePreprocessor preprocessor = buildMvProcessor(query);
-                OptExpression logicalTree = preprocessor.getLogicalTree();
+                Pair<MvRewritePreprocessor, OptExpression> result = buildMvProcessor(query);
+                MvRewritePreprocessor preprocessor = result.first;
+                OptExpression logicalTree = result.second;
 
                 Set<Table> queryTables = MvUtils.getAllTables(logicalTree).stream().collect(Collectors.toSet());
                 Set<MaterializedView> relatedMVs = preprocessor.getRelatedMVs(queryTables, false);
@@ -356,8 +357,9 @@ public class MvRewritePreprocessorTest extends MvRewriteTestBase {
             // query 2
             {
                 String query = "select t1.k1, t1.v1, t1.v2, t0.v1 as v21 from t1 join t0 on t1.k1=t0.v1";
-                MvRewritePreprocessor preprocessor = buildMvProcessor(query);
-                OptExpression logicalTree = preprocessor.getLogicalTree();
+                Pair<MvRewritePreprocessor, OptExpression> result = buildMvProcessor(query);
+                MvRewritePreprocessor preprocessor = result.first;
+                OptExpression logicalTree = result.second;
 
                 Set<Table> queryTables = MvUtils.getAllTables(logicalTree).stream().collect(Collectors.toSet());
                 Set<MaterializedView> relatedMVs = preprocessor.getRelatedMVs(queryTables, false);
@@ -402,8 +404,9 @@ public class MvRewritePreprocessorTest extends MvRewriteTestBase {
             // query 1
             {
                 String query = "select k1, v1, v2 from t1";
-                MvRewritePreprocessor preprocessor = buildMvProcessor(query);
-                OptExpression logicalTree = preprocessor.getLogicalTree();
+                Pair<MvRewritePreprocessor, OptExpression> result = buildMvProcessor(query);
+                MvRewritePreprocessor preprocessor = result.first;
+                OptExpression logicalTree = result.second;
 
                 Set<Table> queryTables = MvUtils.getAllTables(logicalTree).stream().collect(Collectors.toSet());
                 Set<MaterializedView> relatedMVs = preprocessor.getRelatedMVs(queryTables, false);
@@ -432,8 +435,9 @@ public class MvRewritePreprocessorTest extends MvRewriteTestBase {
             // query 2
             {
                 String query = "select t1.k1, t1.v1, t1.v2, t0.v1 as v21 from t1 join t0 on t1.k1=t0.v1";
-                MvRewritePreprocessor preprocessor = buildMvProcessor(query);
-                OptExpression logicalTree = preprocessor.getLogicalTree();
+                Pair<MvRewritePreprocessor, OptExpression> result = buildMvProcessor(query);
+                MvRewritePreprocessor preprocessor = result.first;
+                OptExpression logicalTree = result.second;
 
                 Set<Table> queryTables = MvUtils.getAllTables(logicalTree).stream().collect(Collectors.toSet());
                 Set<MaterializedView> relatedMVs = preprocessor.getRelatedMVs(queryTables, false);
@@ -546,8 +550,9 @@ public class MvRewritePreprocessorTest extends MvRewriteTestBase {
             // query 1
             {
                 String query = "select k1, v1, v2 from t1 where k1 > 3";
-                MvRewritePreprocessor preprocessor = buildMvProcessor(query);
-                OptExpression logicalTree = preprocessor.getLogicalTree();
+                Pair<MvRewritePreprocessor, OptExpression> result = buildMvProcessor(query);
+                MvRewritePreprocessor preprocessor = result.first;
+                OptExpression logicalTree = result.second;
 
                 Set<Table> queryTables = MvUtils.getAllTables(logicalTree).stream().collect(Collectors.toSet());
                 Set<MaterializedView> relatedMVs = preprocessor.getRelatedMVs(queryTables, false);
@@ -597,8 +602,9 @@ public class MvRewritePreprocessorTest extends MvRewriteTestBase {
             // query 1
             {
                 String query = "select k1, v1, v2 from t1 where k1 > 3";
-                MvRewritePreprocessor preprocessor = buildMvProcessor(query);
-                OptExpression logicalTree = preprocessor.getLogicalTree();
+                Pair<MvRewritePreprocessor, OptExpression> result = buildMvProcessor(query);
+                MvRewritePreprocessor preprocessor = result.first;
+                OptExpression logicalTree = result.second;
 
                 Set<Table> queryTables = MvUtils.getAllTables(logicalTree).stream().collect(Collectors.toSet());
                 Set<MaterializedView> relatedMVs = preprocessor.getRelatedMVs(queryTables, false);
@@ -681,8 +687,9 @@ public class MvRewritePreprocessorTest extends MvRewriteTestBase {
 
 
             String query = "select * from view0";
-            MvRewritePreprocessor preprocessor = buildMvProcessor(query);
-            OptExpression logicalTree = preprocessor.getLogicalTree();
+            Pair<MvRewritePreprocessor, OptExpression> result = buildMvProcessor(query);
+            MvRewritePreprocessor preprocessor = result.first;
+            OptExpression logicalTree = result.second;
 
             Set<Table> queryTables = MvUtils.getAllTables(logicalTree).stream().collect(Collectors.toSet());
             Set<MaterializedView> relatedMVs = preprocessor.getRelatedMVs(queryTables, false);

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/PlanTestNoneDBBase.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/PlanTestNoneDBBase.java
@@ -142,7 +142,7 @@ public class PlanTestNoneDBBase {
     private static String normalizeLogicalPlan(String plan) {
         return Stream.of(plan.split("\n"))
                 .filter(s -> !s.contains("tabletList"))
-                .map(str -> str.replaceAll("\\d+: ", "col\\$: ").trim())
+                .map(str -> str.replaceAll("\\d+:", "col\\$:").trim())
                 .map(str -> str.replaceAll("\\[\\d+]", "[col\\$]").trim())
                 .map(str -> str.replaceAll("\\[\\d+, \\d+]", "[col\\$, col\\$]").trim())
                 .map(str -> str.replaceAll("\\[\\d+, \\d+, \\d+]", "[col\\$, col\\$, col\\$]").trim())

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/ReplayWithMVFromDumpTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/ReplayWithMVFromDumpTest.java
@@ -87,7 +87,8 @@ public class ReplayWithMVFromDumpTest extends ReplayFromDumpTestBase {
         String jsonStr = getDumpInfoFromFile("query_dump/materialized-view/mock_join_agg1");
         // Table and mv have no stats, mv rewrite is ok.
         Pair<QueryDumpInfo, String> replayPair = getCostPlanFragment(jsonStr, null);
-        assertContains(replayPair.second, "table: tbl_mock_001, rollup: tbl_mock_001");
+        // Rewrite OK when enhance rule based mv rewrite.
+        assertContains(replayPair.second, "table: test_mv0, rollup: test_mv0");
         FeConstants.isReplayFromQueryDump = false;
     }
 
@@ -152,7 +153,7 @@ public class ReplayWithMVFromDumpTest extends ReplayFromDumpTestBase {
                 getPlanFragment(getDumpInfoFromFile("query_dump/materialized-view/mv_on_mv2"),
                         connectContext.getSessionVariable(), TExplainLevel.NORMAL);
         connectContext.getSessionVariable().setMaterializedViewRewriteMode("default");
-        assertContains("test_mv2");
+        assertContains(replayPair.second, "test_mv2");
     }
 
     @Test
@@ -160,7 +161,7 @@ public class ReplayWithMVFromDumpTest extends ReplayFromDumpTestBase {
         Pair<QueryDumpInfo, String> replayPair =
                 getPlanFragment(getDumpInfoFromFile("query_dump/materialized-view/agg_with_having1"),
                         connectContext.getSessionVariable(), TExplainLevel.NORMAL);
-        assertContains("TEST_MV_2");
+        assertContains(replayPair.second, "TEST_MV_2");
     }
 
     @Test
@@ -168,7 +169,7 @@ public class ReplayWithMVFromDumpTest extends ReplayFromDumpTestBase {
         Pair<QueryDumpInfo, String> replayPair =
                 getPlanFragment(getDumpInfoFromFile("query_dump/materialized-view/agg_with_having2"),
                         connectContext.getSessionVariable(), TExplainLevel.NORMAL);
-        assertContains("TEST_MV_2");
+        assertContains(replayPair.second, "TEST_MV_2");
     }
 
     @Test
@@ -184,7 +185,8 @@ public class ReplayWithMVFromDumpTest extends ReplayFromDumpTestBase {
         Pair<QueryDumpInfo, String> replayPair =
                 getPlanFragment(getDumpInfoFromFile("query_dump/materialized-view/mock_agg_with_having3"),
                         connectContext.getSessionVariable(), TExplainLevel.NORMAL);
-        assertContains(replayPair.second, "tbl_mock_021");
+        // Rewrite OK since rule based mv is enhanced
+        assertContains(replayPair.second, "test_mv2");
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/TracerMVTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/TracerMVTest.java
@@ -165,6 +165,6 @@ public class TracerMVTest extends MaterializedViewTestBase {
         Tracers.close();
         assertContains(pr, "[MV TRACE]");
         assertContains(pr, "has related materialized views");
-        assertContains(pr, "Rewrite aggregate group-by/agg expr failed");
+        assertContains(pr, "Rewrite projection with aggregate group-by/agg expr failed");
     }
 }

--- a/fe/fe-core/src/test/resources/sql/query_dump/materialized-view/mock_agg_with_having3.json
+++ b/fe/fe-core/src/test/resources/sql/query_dump/materialized-view/mock_agg_with_having3.json
@@ -5,9 +5,9 @@
     "db_mock_000.tbl_mock_007": "CREATE TABLE db_mock_000.tbl_mock_007 (\nmock_013 date ,\nmock_010 date ,\nmock_011 varchar(90) ,\nmock_008 varchar(60) ,\nmock_009 varchar(90) ,\nmock_012 varchar(90) \n) ENGINE\u003d OLAP \nDUPLICATE KEY(mock_013, mock_010, mock_011)\nDISTRIBUTED BY HASH(mock_013, mock_010, mock_008) BUCKETS 50 \nPROPERTIES (\n\"replication_num\" \u003d \"1\"\n);",
     "db_mock_000.tbl_mock_014": "CREATE TABLE db_mock_000.tbl_mock_014 (\nmock_004 date ,\nmock_006 varchar(240) ,\nmock_015 varchar(900) \n) ENGINE\u003d OLAP \nDUPLICATE KEY(mock_004, mock_006)\nDISTRIBUTED BY HASH(mock_004, mock_006) BUCKETS 25 \nPROPERTIES (\n\"replication_num\" \u003d \"1\"\n);",
     "db_mock_000.tbl_mock_016": "CREATE TABLE db_mock_000.tbl_mock_016 (\nmock_004 date ,\nmock_018 varchar(240) ,\nmock_017 varchar(240) \n) ENGINE\u003d OLAP \nDUPLICATE KEY(mock_004, mock_018)\nDISTRIBUTED BY HASH(mock_004, mock_018) BUCKETS 1 \nPROPERTIES (\n\"replication_num\" \u003d \"1\"\n);",
-    "db_mock_000.tbl_mock_019": "CREATE MATERIALIZED VIEW `tbl_mock_019` (`mock_003`, `mock_006`, `mock_004`, `mock_020`)\n\nDISTRIBUTED BY HASH(mock_004, mock_006) BUCKETS 50 \nREFRESH MANUAL\nPROPERTIES (\n\"replication_num\" \u003d \"1\"\n)\nAS SELECT tbl_mock_025.mock_003, tbl_mock_025.mock_006, tbl_mock_025.mock_004, sum(tbl_mock_025.mock_002) AS mock_020\nFROM db_mock_000.tbl_mock_001 AS tbl_mock_025\nGROUP BY 1, 2, 3;",
-    "db_mock_000.tbl_mock_021": "CREATE MATERIALIZED VIEW `tbl_mock_021` (`mock_006`, `mock_015`, `mock_009`, `mock_005`, `mock_012`, `mock_018`, `mock_022`, `mock_002`, `mock_003`, `mock_004`, `mock_020`)\n\nDISTRIBUTED BY HASH(mock_006) BUCKETS 50 \nREFRESH MANUAL\nPROPERTIES (\n\"replication_num\" \u003d \"1\"\n)\nAS SELECT tbl_mock_025.mock_006, tbl_mock_028.mock_015, tbl_mock_027.mock_009, tbl_mock_025.mock_005, tbl_mock_027.mock_012, tbl_mock_029.mock_018, tbl_mock_025.mock_004 AS mock_022, tbl_mock_025.mock_002, tbl_mock_026.mock_003, tbl_mock_026.mock_004, tbl_mock_026.mock_020\nFROM db_mock_000.tbl_mock_001 AS tbl_mock_025 INNER JOIN db_mock_000.tbl_mock_019 AS tbl_mock_026 ON tbl_mock_025.mock_006 \u003d tbl_mock_026.mock_006 LEFT OUTER JOIN db_mock_000.tbl_mock_007 AS tbl_mock_027 ON (((tbl_mock_027.mock_008 \u003d \u00271\u0027) AND (tbl_mock_025.mock_006 \u003d tbl_mock_027.mock_011)) AND (tbl_mock_027.mock_013 \u003c\u003d \u00272023-03-31\u0027)) AND (tbl_mock_027.mock_010 \u003e \u00272023-03-31\u0027) LEFT OUTER JOIN db_mock_000.tbl_mock_014 AS tbl_mock_028 ON (tbl_mock_025.mock_006 \u003d tbl_mock_028.mock_006) AND (tbl_mock_028.mock_004 \u003d \u00272023-03-31\u0027) LEFT OUTER JOIN db_mock_000.tbl_mock_016 AS tbl_mock_029 ON (tbl_mock_025.mock_005 \u003d tbl_mock_029.mock_017) AND (tbl_mock_029.mock_004 \u003d \u00272023-03-31\u0027);",
-    "db_mock_000.tbl_mock_023": "CREATE MATERIALIZED VIEW `tbl_mock_023` (`mock_006`, `mock_015`, `mock_009`, `mock_005`, `mock_012`, `mock_018`, `mock_022`, `mock_003`, `mock_004`, `mock_020`, `mock_002`)\n\nDISTRIBUTED BY HASH(mock_006) BUCKETS 50 \nREFRESH MANUAL\nPROPERTIES (\n\"replication_num\" \u003d \"1\"\n)\nAS SELECT tbl_mock_021.mock_006, tbl_mock_021.mock_015, tbl_mock_021.mock_009, tbl_mock_021.mock_005, tbl_mock_021.mock_012, tbl_mock_021.mock_018, tbl_mock_021.mock_022, tbl_mock_021.mock_003, tbl_mock_021.mock_004, tbl_mock_021.mock_020, sum(tbl_mock_021.mock_002) AS mock_002\nFROM db_mock_000.tbl_mock_021\nGROUP BY 1, 2, 3, 4, 5, 6, 7, 8, 9, 10;"
+    "db_mock_000.test_mv0": "CREATE MATERIALIZED VIEW `test_mv0` (`mock_003`, `mock_006`, `mock_004`, `mock_020`)\n\nDISTRIBUTED BY HASH(mock_004, mock_006) BUCKETS 50 \nREFRESH MANUAL\nPROPERTIES (\n\"replication_num\" \u003d \"1\"\n)\nAS SELECT tbl_mock_025.mock_003, tbl_mock_025.mock_006, tbl_mock_025.mock_004, sum(tbl_mock_025.mock_002) AS mock_020\nFROM db_mock_000.tbl_mock_001 AS tbl_mock_025\nGROUP BY 1, 2, 3;",
+    "db_mock_000.test_mv1": "CREATE MATERIALIZED VIEW `test_mv1` (`mock_006`, `mock_015`, `mock_009`, `mock_005`, `mock_012`, `mock_018`, `mock_022`, `mock_002`, `mock_003`, `mock_004`, `mock_020`)\n\nDISTRIBUTED BY HASH(mock_006) BUCKETS 50 \nREFRESH MANUAL\nPROPERTIES (\n\"replication_num\" \u003d \"1\"\n)\nAS SELECT tbl_mock_025.mock_006, tbl_mock_028.mock_015, tbl_mock_027.mock_009, tbl_mock_025.mock_005, tbl_mock_027.mock_012, tbl_mock_029.mock_018, tbl_mock_025.mock_004 AS mock_022, tbl_mock_025.mock_002, tbl_mock_026.mock_003, tbl_mock_026.mock_004, tbl_mock_026.mock_020\nFROM db_mock_000.tbl_mock_001 AS tbl_mock_025 INNER JOIN db_mock_000.test_mv0 AS tbl_mock_026 ON tbl_mock_025.mock_006 \u003d tbl_mock_026.mock_006 LEFT OUTER JOIN db_mock_000.tbl_mock_007 AS tbl_mock_027 ON (((tbl_mock_027.mock_008 \u003d \u00271\u0027) AND (tbl_mock_025.mock_006 \u003d tbl_mock_027.mock_011)) AND (tbl_mock_027.mock_013 \u003c\u003d \u00272023-03-31\u0027)) AND (tbl_mock_027.mock_010 \u003e \u00272023-03-31\u0027) LEFT OUTER JOIN db_mock_000.tbl_mock_014 AS tbl_mock_028 ON (tbl_mock_025.mock_006 \u003d tbl_mock_028.mock_006) AND (tbl_mock_028.mock_004 \u003d \u00272023-03-31\u0027) LEFT OUTER JOIN db_mock_000.tbl_mock_016 AS tbl_mock_029 ON (tbl_mock_025.mock_005 \u003d tbl_mock_029.mock_017) AND (tbl_mock_029.mock_004 \u003d \u00272023-03-31\u0027);",
+    "db_mock_000.test_mv2": "CREATE MATERIALIZED VIEW `test_mv2` (`mock_006`, `mock_015`, `mock_009`, `mock_005`, `mock_012`, `mock_018`, `mock_022`, `mock_003`, `mock_004`, `mock_020`, `mock_002`)\n\nDISTRIBUTED BY HASH(mock_006) BUCKETS 50 \nREFRESH MANUAL\nPROPERTIES (\n\"replication_num\" \u003d \"1\"\n)\nAS SELECT test_mv1.mock_006, test_mv1.mock_015, test_mv1.mock_009, test_mv1.mock_005, test_mv1.mock_012, test_mv1.mock_018, test_mv1.mock_022, test_mv1.mock_003, test_mv1.mock_004, test_mv1.mock_020, sum(test_mv1.mock_002) AS mock_002\nFROM db_mock_000.test_mv1\nGROUP BY 1, 2, 3, 4, 5, 6, 7, 8, 9, 10;"
   },
   "table_row_count": {
     "db_mock_000.tbl_mock_016": {
@@ -22,14 +22,14 @@
     "db_mock_000.tbl_mock_007": {
       "tbl_mock_007": 0
     },
-    "db_mock_000.tbl_mock_019": {
-      "tbl_mock_019": 1
+    "db_mock_000.test_mv0": {
+      "test_mv0": 1
     },
-    "db_mock_000.tbl_mock_021": {
-      "tbl_mock_021": 3
+    "db_mock_000.test_mv1": {
+      "test_mv1": 3
     },
-    "db_mock_000.tbl_mock_023": {
-      "tbl_mock_023": 0
+    "db_mock_000.test_mv2": {
+      "test_mv2": 0
     }
   },
   "column_statistics": {
@@ -58,13 +58,13 @@
       "mock_008": "[-Infinity, Infinity, 0.0, 1.0, 1.0] UNKNOWN",
       "mock_012": "[-Infinity, Infinity, 0.0, 1.0, 1.0] UNKNOWN"
     },
-    "db_mock_000.tbl_mock_019": {
+    "db_mock_000.test_mv0": {
       "mock_004": "[-Infinity, Infinity, 1.0, 4.0, 1.0] ESTIMATE",
       "mock_020": "[3.3, 3.3, 0.0, 16.0, 1.0] ESTIMATE",
       "mock_006": "[-Infinity, Infinity, 0.0, 1.0, 1.0] ESTIMATE",
       "mock_003": "[-Infinity, Infinity, 0.0, 1.0, 1.0] ESTIMATE"
     },
-    "db_mock_000.tbl_mock_021": {
+    "db_mock_000.test_mv1": {
       "mock_022": "[-Infinity, Infinity, 1.0, 4.0, 1.0] ESTIMATE",
       "mock_004": "[-Infinity, Infinity, 1.0, 4.0, 1.0] ESTIMATE",
       "mock_009": "[-Infinity, Infinity, 1.0, 0.0, 1.0] ESTIMATE",
@@ -77,7 +77,7 @@
       "mock_002": "[1.1, 1.1, 0.0, 16.0, 1.0] ESTIMATE",
       "mock_003": "[-Infinity, Infinity, 0.0, 0.3333333333333333, 1.0] ESTIMATE"
     },
-    "db_mock_000.tbl_mock_023": {
+    "db_mock_000.test_mv2": {
       "mock_009": "[-Infinity, Infinity, 0.0, 1.0, 1.0] UNKNOWN",
       "mock_020": "[-Infinity, Infinity, 0.0, 1.0, 1.0] UNKNOWN",
       "mock_005": "[-Infinity, Infinity, 0.0, 1.0, 1.0] UNKNOWN",

--- a/fe/fe-core/src/test/resources/sql/query_dump/materialized-view/mock_join_agg1.json
+++ b/fe/fe-core/src/test/resources/sql/query_dump/materialized-view/mock_join_agg1.json
@@ -4,13 +4,13 @@
     "db_mock_000.tbl_mock_001": "CREATE TABLE db_mock_000.tbl_mock_001 (\nmock_003 int(11) NOT NULL ,\nmock_005 int(11) NOT NULL ,\nmock_006 int(11) NOT NULL ,\nmock_004 varchar(20) NOT NULL ,\nmock_002 int(11) NOT NULL \n) ENGINE\u003d OLAP \nDUPLICATE KEY(mock_003)\nDISTRIBUTED BY HASH(mock_003)\nPROPERTIES (\n\"replication_num\" \u003d \"1\"\n);",
     "db_mock_000.tbl_mock_007": "CREATE TABLE db_mock_000.tbl_mock_007 (\nmock_008 int(11) ,\nmock_009 varchar(20) NOT NULL \n) ENGINE\u003d OLAP \nDUPLICATE KEY(mock_008)\nDISTRIBUTED BY HASH(mock_008)\nPROPERTIES (\n\"replication_num\" \u003d \"1\"\n);",
     "db_mock_000.tbl_mock_010": "CREATE TABLE db_mock_000.tbl_mock_010 (\nmock_011 int(11) NOT NULL ,\nmock_012 varchar(20) NOT NULL \n) ENGINE\u003d OLAP \nDUPLICATE KEY(mock_011)\nDISTRIBUTED BY HASH(mock_011)\nPROPERTIES (\n\"replication_num\" \u003d \"1\"\n);",
-    "db_mock_000.tbl_mock_013": "CREATE MATERIALIZED VIEW `tbl_mock_013` (`mock_003`, `mock_014`, `mock_015`, `mock_016`)\n\nDISTRIBUTED BY HASH(mock_003) BUCKETS 48 \nREFRESH MANUAL\nPROPERTIES (\n\"replication_num\" \u003d \"1\"\n)\nAS SELECT mock_003, bitmap_union(to_bitmap(mock_002)) AS mock_014, hll_union(hll_hash(mock_002)) AS mock_015, percentile_union(percentile_hash(mock_002)) AS mock_016\nFROM db_mock_000.tbl_mock_001 INNER JOIN db_mock_000.tbl_mock_007 ON mock_005 \u003d mock_008 INNER JOIN db_mock_000.tbl_mock_010 ON mock_006 \u003d mock_011\nGROUP BY mock_003;"
+    "db_mock_000.test_mv0": "CREATE MATERIALIZED VIEW `test_mv0` (`mock_003`, `mock_014`, `mock_015`, `mock_016`)\n\nDISTRIBUTED BY HASH(mock_003) BUCKETS 48 \nREFRESH MANUAL\nPROPERTIES (\n\"replication_num\" \u003d \"1\"\n)\nAS SELECT mock_003, bitmap_union(to_bitmap(mock_002)) AS mock_014, hll_union(hll_hash(mock_002)) AS mock_015, percentile_union(percentile_hash(mock_002)) AS mock_016\nFROM db_mock_000.tbl_mock_001 INNER JOIN db_mock_000.tbl_mock_007 ON mock_005 \u003d mock_008 INNER JOIN db_mock_000.tbl_mock_010 ON mock_006 \u003d mock_011\nGROUP BY mock_003;"
   },
   "table_row_count": {
     "db_mock_000.tbl_mock_007": {
       "t2": 200000
     },
-    "db_mock_000.tbl_mock_013": {
+    "db_mock_000.test_mv0": {
       "mv1": 20000
     },
     "db_mock_000.tbl_mock_010": {
@@ -24,7 +24,7 @@
     "db_mock_000.tbl_mock_007": {
       "mock_008": "[-Infinity, Infinity, 0.0, 1.0, 1.0] UNKNOWN"
     },
-    "db_mock_000.tbl_mock_013": {
+    "db_mock_000.test_mv0": {
       "mock_003": "[-Infinity, Infinity, 0.0, 1.0, 1.0] UNKNOWN",
       "mock_014": "[-Infinity, Infinity, 0.0, 1.0, 1.0] UNKNOWN"
     },

--- a/test/sql/test_materialized_view/R/test_materialized_view_force_rewrite
+++ b/test/sql/test_materialized_view/R/test_materialized_view_force_rewrite
@@ -53,6 +53,9 @@ analyze full table mv1;
 -- result:
 [REGEX].*analyze	status	OK
 -- !result
+set enable_force_rule_based_mv_rewrite=false;
+-- result:
+-- !result
 set materialized_view_rewrite_mode="disable";
 -- result:
 -- !result

--- a/test/sql/test_materialized_view/T/test_materialized_view_force_rewrite
+++ b/test/sql/test_materialized_view/T/test_materialized_view_force_rewrite
@@ -44,6 +44,7 @@ refresh materialized view mv1 with sync mode;
 
 analyze full table mv1;
 
+set enable_force_rule_based_mv_rewrite=false;
 set materialized_view_rewrite_mode="disable";
 -- hit
 function: check_no_hit_materialized_view("SELECT t1.t1_id, bitmap_union(to_bitmap(t1.t1_age)) FROM t1 INNER JOIN t2 ON t1.t1_t2_id=t2.t2_id INNER JOIN t3 ON t1.t1_t3_id=t3.t3_id group by t1.t1_id", "mv1")


### PR DESCRIPTION
## Why I'm doing:

- Query which has join operators cannot be rewritten by mv as expect.

## What I'm doing:
- Enable rule based mv rewrite for multi table plans which contains join operators to make it more robust for join's rewrite.
- Refactor mv's rewrite config/strategy into `MvRewriteStrategy` for better code reading.


Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [x] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
