### PR TITLE
[BugFix] Ignore data property in shared_data mode

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/common/util/PropertyAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/util/PropertyAnalyzer.java
@@ -239,6 +239,14 @@ public class PropertyAnalyzer {
             return inferredDataProperty;
         }
 
+        // Data property is not supported in shared mode. Return the inferredDataProperty directly.
+        if (RunMode.isSharedDataMode()) {
+            properties.remove(mediumKey);
+            properties.remove(coolDownTimeKey);
+            properties.remove(coolDownTTLKey);
+            return inferredDataProperty;
+        }
+
         TStorageMedium storageMedium = null;
         long coolDownTimeStamp = DataProperty.MAX_COOLDOWN_TIME_MS;
 


### PR DESCRIPTION
## Why I'm doing:
Data property is not supported in shared_data mode. For example, if a user run the sql `ALTER TABLE ods_ro_log_itemflow set ("storage_cooldown_ttl"="1 DAY");`, new partition can not be created.
## What I'm doing:
Ignore data property in shared_data mode
Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [x] 3.1
  - [ ] 3.0
  - [ ] 2.5
