### PR TITLE
[Enhancement] Simplify predicate coalesce

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/scalar/PruneTediousPredicateRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/scalar/PruneTediousPredicateRule.java
@@ -70,6 +70,8 @@ public class PruneTediousPredicateRule extends OnlyOnceScalarOperatorRewriteRule
                     && (call.getChild(2).equals(ConstantOperator.NULL) ||
                     call.getChild(2).equals(ConstantOperator.FALSE))) {
                 return Optional.of(call.getChild(0));
+            } else if (call.getFnName().equals(FunctionSet.COALESCE)) {
+                return Optional.of(SimplifiedPredicateRule.simplifiedCoalesce(call, true));
             } else {
                 return Optional.empty();
             }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/scalar/SimplifiedPredicateRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/scalar/SimplifiedPredicateRule.java
@@ -364,6 +364,8 @@ public class SimplifiedPredicateRule extends BottomUpScalarOperatorRewriteRule {
             return simplifiedTimeFns(call);
         } else if (FunctionSet.DATE_TRUNC.equalsIgnoreCase(call.getFnName())) {
             return simplifiedDateTrunc(call);
+        } else if (FunctionSet.COALESCE.equalsIgnoreCase(call.getFnName())) {
+            return simplifiedCoalesce(call);
         }
         return call;
     }
@@ -448,6 +450,34 @@ public class SimplifiedPredicateRule extends BottomUpScalarOperatorRewriteRule {
         if ("day".equalsIgnoreCase(child.toString())) {
             return call.getChild(1);
         }
+        return call;
+    }
+
+    private ScalarOperator simplifiedCoalesce(CallOperator call) {
+        ScalarOperator first = call.getChild(0);
+
+        // Find first not null arg.
+        int i = 1;
+        while (i < call.getChildren().size()) {
+            ScalarOperator child = call.getChild(i);
+            if (!ConstantOperator.NULL.equals(child)) {
+                break;
+            }
+            i++;
+        }
+
+        // All args from 1 to end is null
+        // coalesce(x, null, null, ...) equals to x.
+        if (i >= call.getChildren().size()) {
+            return first;
+        }
+
+        // coalesce(x, false)/coalesce(x, null, ..., false) equals to x.
+        ScalarOperator notNull = call.getChild(i);
+        if (ConstantOperator.FALSE.equals(notNull)) {
+            return first;
+        }
+
         return call;
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/scalar/SimplifiedPredicateRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/scalar/SimplifiedPredicateRule.java
@@ -454,6 +454,10 @@ public class SimplifiedPredicateRule extends BottomUpScalarOperatorRewriteRule {
     }
 
     private ScalarOperator simplifiedCoalesce(CallOperator call) {
+        return simplifiedCoalesce(call, false);
+    }
+
+    public static ScalarOperator simplifiedCoalesce(CallOperator call, boolean asFilter) {
         ScalarOperator first = call.getChild(0);
 
         // Find first not null arg.
@@ -472,10 +476,12 @@ public class SimplifiedPredicateRule extends BottomUpScalarOperatorRewriteRule {
             return first;
         }
 
-        // coalesce(x, false)/coalesce(x, null, ..., false) equals to x.
-        ScalarOperator notNull = call.getChild(i);
-        if (ConstantOperator.FALSE.equals(notNull)) {
-            return first;
+        if (asFilter) {
+            // coalesce(x, false)/coalesce(x, null, ..., false) equals to x.
+            ScalarOperator notNull = call.getChild(i);
+            if (ConstantOperator.FALSE.equals(notNull)) {
+                return first;
+            }
         }
 
         return call;

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/PushDownPredicateScanRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/PushDownPredicateScanRule.java
@@ -112,6 +112,4 @@ public class PushDownPredicateScanRule extends TransformationRule {
         OptExpression project = OptExpression.create(logicalProjectOperator, OptExpression.create(newScanOperator));
         return Lists.newArrayList(project);
     }
-
-
 }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/PushDownPredicateScanRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/PushDownPredicateScanRule.java
@@ -16,7 +16,6 @@ package com.starrocks.sql.optimizer.rule.transformation;
 
 import com.google.common.base.Preconditions;
 import com.google.common.collect.Lists;
-import com.starrocks.catalog.FunctionSet;
 import com.starrocks.sql.optimizer.OptExpression;
 import com.starrocks.sql.optimizer.OptimizerContext;
 import com.starrocks.sql.optimizer.Utils;
@@ -27,14 +26,12 @@ import com.starrocks.sql.optimizer.operator.logical.LogicalFilterOperator;
 import com.starrocks.sql.optimizer.operator.logical.LogicalProjectOperator;
 import com.starrocks.sql.optimizer.operator.logical.LogicalScanOperator;
 import com.starrocks.sql.optimizer.operator.pattern.Pattern;
-import com.starrocks.sql.optimizer.operator.scalar.CallOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ColumnRefOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ScalarOperator;
 import com.starrocks.sql.optimizer.rewrite.ScalarOperatorRewriter;
 import com.starrocks.sql.optimizer.rewrite.ScalarRangePredicateExtractor;
 import com.starrocks.sql.optimizer.rewrite.scalar.PruneTediousPredicateRule;
 import com.starrocks.sql.optimizer.rewrite.scalar.SimplifiedCaseWhenRule;
-import com.starrocks.sql.optimizer.rewrite.scalar.SimplifiedPredicateRule;
 import com.starrocks.sql.optimizer.rule.RuleType;
 
 import java.util.List;
@@ -100,7 +97,6 @@ public class PushDownPredicateScanRule extends TransformationRule {
 
         predicates = scalarOperatorRewriter.rewrite(predicates,
                 ScalarOperatorRewriter.DEFAULT_REWRITE_SCAN_PREDICATE_RULES);
-        predicates = simplifyCoalesce(predicates);
         predicates = Utils.transTrue2Null(predicates);
 
         // clone a new scan operator and rewrite predicate.
@@ -117,29 +113,5 @@ public class PushDownPredicateScanRule extends TransformationRule {
         return Lists.newArrayList(project);
     }
 
-    private ScalarOperator simplifyCoalesce(ScalarOperator predicate) {
-        List<ScalarOperator> conjuncts = Utils.extractConjuncts(predicate);
 
-        boolean changed = false;
-        for (int i = 0; i < conjuncts.size(); i++) {
-            ScalarOperator conjunct = conjuncts.get(i);
-            if (!(conjunct instanceof CallOperator)) {
-                continue;
-            }
-            CallOperator call = (CallOperator) conjunct;
-            if (FunctionSet.COALESCE.equalsIgnoreCase(call.getFnName())) {
-                ScalarOperator simplified = SimplifiedPredicateRule.simplifiedCoalesce(call, true);
-                if (simplified != call) {
-                    changed = true;
-                    conjuncts.set(i, simplified);
-                }
-            }
-        }
-
-        if (changed) {
-            return Utils.compoundAnd(conjuncts);
-        }
-
-        return predicate;
-    }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/PredicatePushDownTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/PredicatePushDownTest.java
@@ -1,0 +1,76 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package com.starrocks.sql.plan;
+
+import org.junit.Test;
+
+public class PredicatePushDownTest extends PlanTestBase {
+
+    @Test
+    public void testCoalescePushDown() throws Exception {
+        {
+            String sql = "select * from t0 where coalesce(v1 < 2)";
+            String plan = getFragmentPlan(sql);
+            assertContains(plan, "PREDICATES: 1: v1 < 2");
+        }
+        {
+            String sql = "select * from t0 where coalesce(v1 < 2, null)";
+            String plan = getFragmentPlan(sql);
+            assertContains(plan, "PREDICATES: 1: v1 < 2");
+        }
+        {
+            String sql = "select * from t0 where coalesce(v1 < 2, null, null)";
+            String plan = getFragmentPlan(sql);
+            assertContains(plan, "PREDICATES: 1: v1 < 2");
+        }
+        {
+            String sql = "select * from t0 where coalesce(v1 < 2, null, false)";
+            String plan = getFragmentPlan(sql);
+            assertContains(plan, "PREDICATES: 1: v1 < 2");
+        }
+        {
+            String sql = "select * from t0 where coalesce(v1 < 2, null, true)";
+            String plan = getFragmentPlan(sql);
+            assertContains(plan, "PREDICATES: coalesce(1: v1 < 2, NULL, TRUE)");
+        }
+        {
+            String sql = "select * from t0 where coalesce(v1 < 2, null, v2 > 1)";
+            String plan = getFragmentPlan(sql);
+            assertContains(plan, "PREDICATES: coalesce(1: v1 < 2, NULL, 2: v2 > 1)");
+        }
+        {
+            String sql = "WITH cte0 AS (\n" +
+                    "    SELECT v1, v2, (\n" +
+                    "        v3 BETWEEN 1 AND 3\n" +
+                    "    ) AS v3\n" +
+                    "    FROM t0\n" +
+                    "),\n" +
+                    "cte1 AS (\n" +
+                    "    SELECT cte0.v1 AS v1, cte0.v2 AS v2, cte0.v3 AS v3\n" +
+                    "    FROM cte0\n" +
+                    "),\n" +
+                    "cte2 AS (\n" +
+                    "    SELECT cte1.v1 AS v1, cte1.v2 AS v2, COALESCE(cte1.v3, false) AS v3\n" +
+                    "    FROM cte1\n" +
+                    "),\n" +
+                    "cte3 AS (\n" +
+                    "    SELECT * FROM cte2\n" +
+                    "    WHERE cte2.v3\n" +
+                    ")\n" +
+                    "SELECT * FROM cte3;";
+            String plan = getFragmentPlan(sql);
+            assertContains(plan, "PREDICATES: 3: v3 >= 1, 3: v3 <= 3");
+        }
+    }
+}

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/PredicatePushDownTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/PredicatePushDownTest.java
@@ -50,6 +50,11 @@ public class PredicatePushDownTest extends PlanTestBase {
             assertContains(plan, "(coalesce(1: v1 < 2, NULL, FALSE)) OR (3: v3 > 2)");
         }
         {
+            String sql = "select * from t0 where coalesce(v1 < 2, null, false) is null";
+            String plan = getFragmentPlan(sql);
+            assertContains(plan, "PREDICATES: coalesce(1: v1 < 2, NULL, FALSE) IS NULL");
+        }
+        {
             String sql = "select coalesce(v1 < 2, null, false) from t0";
             String plan = getFragmentPlan(sql);
             assertContains(plan, "coalesce(1: v1 < 2, NULL, FALSE)");


### PR DESCRIPTION
## Why I'm doing:

```sql
select * from t0 where coalesce(v1 < 2)
```

For sql like this, the function coalesce can be removed.

## What I'm doing:

Remove redundant coalesce in the predicate.

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
