### PR TITLE
[BugFix] Fix partition predicates compensate bug with multi partition tables

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/MaterializationContext.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/MaterializationContext.java
@@ -28,7 +28,6 @@ import com.starrocks.sql.optimizer.operator.logical.LogicalOlapScanOperator;
 import com.starrocks.sql.optimizer.operator.logical.LogicalScanOperator;
 import com.starrocks.sql.optimizer.operator.pattern.Pattern;
 import com.starrocks.sql.optimizer.operator.scalar.ColumnRefOperator;
-import com.starrocks.sql.optimizer.operator.scalar.ConstantOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ScalarOperator;
 import com.starrocks.sql.optimizer.rule.transformation.materialization.MaterializedViewRewriter;
 import com.starrocks.sql.optimizer.rule.transformation.materialization.MvUtils;
@@ -45,7 +44,6 @@ import java.util.Set;
 import java.util.stream.Collectors;
 
 import static com.starrocks.sql.optimizer.OptimizerTraceUtil.logMVRewrite;
-import static com.starrocks.sql.optimizer.rule.transformation.materialization.MvPartitionCompensator.getMVPrunedPartitionPredicates;
 import static com.starrocks.sql.optimizer.rule.transformation.materialization.MvPartitionCompensator.isNeedCompensatePartitionPredicate;
 
 public class MaterializationContext {
@@ -94,8 +92,6 @@ public class MaterializationContext {
     // But it is different for each materialized view, compensate partition predicate from the plan's
     // `selectedPartitionIds`, and check `isNeedCompensatePartitionPredicate` to get more information.
     private Optional<Boolean> isCompensatePartitionPredicateOpt = Optional.empty();
-    // Cache a mv's pruned partition predicates in the rewrite because it's not changed through the context.
-    private Optional<ScalarOperator> mvPrunedPartitionPredicateOpt = Optional.empty();
     // Cache partition compensates predicates for each ScanNode and isCompensate pair.
     private Map<Pair<LogicalScanOperator, Boolean>, List<ScalarOperator>> scanOpToPartitionCompensatePredicates;
 
@@ -438,18 +434,6 @@ public class MaterializationContext {
 
     public boolean isCompensatePartitionPredicate() {
         return isCompensatePartitionPredicateOpt.orElse(true);
-    }
-
-    public ScalarOperator getMVPrunedPartitionPredicate() {
-        if (!mvPrunedPartitionPredicateOpt.isPresent()) {
-            List<ScalarOperator> mvPrunedPartitionPredicates = getMVPrunedPartitionPredicates(mv, mvExpression);
-            if (mvPrunedPartitionPredicates == null || mvPrunedPartitionPredicates.isEmpty()) {
-                mvPrunedPartitionPredicateOpt = Optional.of(ConstantOperator.TRUE);
-            } else {
-                mvPrunedPartitionPredicateOpt = Optional.of(Utils.compoundAnd(mvPrunedPartitionPredicates));
-            }
-        }
-        return mvPrunedPartitionPredicateOpt.get();
     }
 
     public Map<Pair<LogicalScanOperator, Boolean>, List<ScalarOperator>> getScanOpToPartitionCompensatePredicates() {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/MaterializedViewOptimizer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/MaterializedViewOptimizer.java
@@ -35,6 +35,8 @@ public class MaterializedViewOptimizer {
                                   boolean inlineView) {
         // optimize the sql by rule and disable rule based materialized view rewrite
         OptimizerConfig optimizerConfig = new OptimizerConfig(OptimizerConfig.OptimizerAlgorithm.RULE_BASED);
+        // Disable partition prune for mv's plan so no needs  to compensate pruned predicates anymore.
+        // Only needs to compensate mv's ref-base-table's partition predicates when mv's freshness cannot be satisfied.
         optimizerConfig.disableRuleSet(RuleSetType.PARTITION_PRUNE);
         optimizerConfig.disableRuleSet(RuleSetType.ALL_MV_REWRITE);
         // INTERSECT_REWRITE is used for INTERSECT related plan optimize, which can not be SPJG;

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/ScanOperatorPredicates.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/ScanOperatorPredicates.java
@@ -73,9 +73,13 @@ public class ScanOperatorPredicates {
         return noEvalPartitionConjuncts;
     }
 
+    /**
+     * TODO: it's better to record pruned partition predicates directly.
+     * @return: Return pruned partition conjuncts after OptPartitionPruner.
+     */
     public List<ScalarOperator> getPrunedPartitionConjuncts() {
         return partitionConjuncts.stream()
-                .filter(x -> !nonPartitionConjuncts.contains(x)).collect(Collectors.toList());
+                .filter(x -> !noEvalPartitionConjuncts.contains(x)).collect(Collectors.toList());
     }
 
     public List<ScalarOperator> getNonPartitionConjuncts() {
@@ -136,5 +140,26 @@ public class ScanOperatorPredicates {
     public int hashCode() {
         return Objects.hash(idToPartitionKey, selectedPartitionIds, partitionConjuncts, noEvalPartitionConjuncts,
                 nonPartitionConjuncts, minMaxConjuncts, minMaxColumnRefMap);
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        if (!selectedPartitionIds.isEmpty()) {
+            sb.append(String.format("selectedPartitionIds=%s, ", selectedPartitionIds));
+        }
+        if (!partitionConjuncts.isEmpty()) {
+            sb.append(String.format("partitionConjuncts=%s, ", partitionConjuncts));
+        }
+        if (!noEvalPartitionConjuncts.isEmpty()) {
+            sb.append(String.format("noEvalPartitionConjuncts=%s, ", noEvalPartitionConjuncts));
+        }
+        if (!nonPartitionConjuncts.isEmpty()) {
+            sb.append(String.format("nonPartitionConjuncts=%s, ", nonPartitionConjuncts));
+        }
+        if (!minMaxConjuncts.isEmpty()) {
+            sb.append(String.format("minMaxConjuncts=%s, ", minMaxConjuncts));
+        }
+        return sb.toString();
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/ScanOperatorPredicates.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/ScanOperatorPredicates.java
@@ -15,6 +15,7 @@
 
 package com.starrocks.sql.optimizer.operator;
 
+import com.google.common.base.Joiner;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.starrocks.catalog.Column;
@@ -144,22 +145,22 @@ public class ScanOperatorPredicates {
 
     @Override
     public String toString() {
-        StringBuilder sb = new StringBuilder();
+        List<String> strings = Lists.newArrayList();
         if (!selectedPartitionIds.isEmpty()) {
-            sb.append(String.format("selectedPartitionIds=%s, ", selectedPartitionIds));
+            strings.add(String.format("selectedPartitionIds=%s", selectedPartitionIds));
         }
         if (!partitionConjuncts.isEmpty()) {
-            sb.append(String.format("partitionConjuncts=%s, ", partitionConjuncts));
+            strings.add(String.format("partitionConjuncts=%s", partitionConjuncts));
         }
         if (!noEvalPartitionConjuncts.isEmpty()) {
-            sb.append(String.format("noEvalPartitionConjuncts=%s, ", noEvalPartitionConjuncts));
+            strings.add(String.format("noEvalPartitionConjuncts=%s", noEvalPartitionConjuncts));
         }
         if (!nonPartitionConjuncts.isEmpty()) {
-            sb.append(String.format("nonPartitionConjuncts=%s, ", nonPartitionConjuncts));
+            strings.add(String.format("nonPartitionConjuncts=%s", nonPartitionConjuncts));
         }
         if (!minMaxConjuncts.isEmpty()) {
-            sb.append(String.format("minMaxConjuncts=%s, ", minMaxConjuncts));
+            strings.add(String.format("minMaxConjuncts=%s", minMaxConjuncts));
         }
-        return sb.toString();
+        return Joiner.on(", ").join(strings);
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MaterializedViewRewriter.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MaterializedViewRewriter.java
@@ -610,10 +610,16 @@ public class MaterializedViewRewriter {
         return ConstantOperator.TRUE;
     }
 
+    /**
+     * Only compensate mv's partition predicate when mv's freshness cannot satisfy query's need.
+     * When mv's freshness is ok, return constant true because
+     * {@link com.starrocks.sql.optimizer.MaterializedViewOptimizer#optimize} disabled partition pruning and no need
+     * compensate pruned predicates.
+     * @return
+     */
     private ScalarOperator getMVCompensatePartitionPredicate() {
         return  materializationContext.isCompensatePartitionPredicate() ?
-                materializationContext.getMvPartialPartitionPredicate() :
-                materializationContext.getMVPrunedPartitionPredicate();
+                materializationContext.getMvPartialPartitionPredicate() : ConstantOperator.TRUE;
     }
 
     private OptExpression rewriteViewDelta(List<Table> queryTables,

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvPartitionCompensator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvPartitionCompensator.java
@@ -39,6 +39,7 @@ import com.starrocks.common.AnalysisException;
 import com.starrocks.common.Pair;
 import com.starrocks.common.UserException;
 import com.starrocks.common.util.DateUtils;
+import com.starrocks.common.util.DebugUtil;
 import com.starrocks.connector.PartitionUtil;
 import com.starrocks.sql.analyzer.RelationFields;
 import com.starrocks.sql.analyzer.RelationId;
@@ -103,7 +104,7 @@ public class MvPartitionCompensator {
      * @param queryPlan : query opt expression
      * @param mvContext : materialized view context
      * @return Optional<Boolean>: if `queryPlan` contains ref table, Optional is set and return whether mv can satisfy
-     * query plan's refreshness, other Optional.empty() is returned.
+     * query plan's freshness, other Optional.empty() is returned.
      */
     public static Optional<Boolean> isNeedCompensatePartitionPredicate(OptExpression queryPlan,
                                                                        MaterializationContext mvContext) {
@@ -228,9 +229,9 @@ public class MvPartitionCompensator {
      *      `partitionPredicate` : k1>='2020-02-11'
      *      however for mv  we need: k1>='2020-02-11' and k1 < "2020-03-01"
      */
-    public static ScalarOperator compensatePartitionPredicate(MaterializationContext mvContext,
-                                                              ColumnRefFactory columnRefFactory,
-                                                              OptExpression queryExpression) {
+    public static ScalarOperator compensateQueryPartitionPredicate(MaterializationContext mvContext,
+                                                                   ColumnRefFactory columnRefFactory,
+                                                                   OptExpression queryExpression) {
         List<LogicalScanOperator> scanOperators = MvUtils.getScanOperator(queryExpression);
         if (scanOperators.isEmpty()) {
             return ConstantOperator.createBoolean(true);
@@ -241,6 +242,7 @@ public class MvPartitionCompensator {
         // Compensate partition predicates and add them into query predicate.
         Map<Pair<LogicalScanOperator, Boolean>, List<ScalarOperator>> scanOperatorScalarOperatorMap =
                 mvContext.getScanOpToPartitionCompensatePredicates();
+        MaterializedView mv = mvContext.getMv();
         for (LogicalScanOperator scanOperator : scanOperators) {
             if (!SUPPORTED_PARTITION_COMPENSATE_SCAN_TYPES.contains(scanOperator.getOpType())) {
                 continue;
@@ -248,7 +250,7 @@ public class MvPartitionCompensator {
             List<ScalarOperator> partitionPredicate = scanOperatorScalarOperatorMap
                     .computeIfAbsent(Pair.create(scanOperator, isCompensatePartition), x -> {
                         return isCompensatePartition ? getCompensatePartitionPredicates(mvContext, columnRefFactory,
-                                scanOperator) : getScanOpPrunedPartitionPredicates(scanOperator);
+                                scanOperator) : getScanOpPrunedPartitionPredicates(mv, scanOperator);
                     });
             if (partitionPredicate == null) {
                 logMVRewrite(mvContext.getMv().getName(), "Compensate partition failed for scan {}",
@@ -259,7 +261,7 @@ public class MvPartitionCompensator {
         }
         ScalarOperator compensatePredicate = partitionPredicates.isEmpty() ? ConstantOperator.createBoolean(true) :
                 Utils.compoundAnd(partitionPredicates);
-        logMVRewrite(mvContext.getMv().getName(), "Compensate partition predicate:{}", compensatePredicate);
+        logMVRewrite(mvContext.getMv().getName(), "Query Compensate partition predicate:{}", compensatePredicate);
         return compensatePredicate;
     }
 
@@ -625,35 +627,8 @@ public class MvPartitionCompensator {
         }
     }
 
-    public static List<ScalarOperator> getMVPrunedPartitionPredicates(MaterializedView mv,
-                                                                      OptExpression mvPlan) {
-        Pair<Table, Column> partitionTableAndColumns = mv.getDirectTableAndPartitionColumn();
-        if (partitionTableAndColumns == null) {
-            return null;
-        }
-
-        Table refBaseTable = partitionTableAndColumns.first;
-        List<LogicalScanOperator> scanOperators = MvUtils.getScanOperator(mvPlan);
-        for (LogicalScanOperator scanOperator : scanOperators) {
-            if (!isRefBaseTable(scanOperator, refBaseTable)) {
-                continue;
-            }
-
-            List<ScalarOperator> prunedPredicates = getScanOpPrunedPartitionPredicates(scanOperator);
-            if (prunedPredicates == null || prunedPredicates.isEmpty()) {
-                return List.of(ConstantOperator.TRUE);
-            } else {
-                return prunedPredicates;
-            }
-        }
-        return null;
-    }
-
-    private static List<ScalarOperator> getScanOpPrunedPartitionPredicates(LogicalScanOperator scanOperator) {
-        if (scanOperator == null) {
-            return null;
-        }
-
+    private static List<ScalarOperator> getScanOpPrunedPartitionPredicates(MaterializedView mv,
+                                                                           LogicalScanOperator scanOperator) {
         if (scanOperator instanceof LogicalOlapScanOperator) {
             return ((LogicalOlapScanOperator) scanOperator).getPrunedPartitionPredicates();
         } else if (SUPPORTED_PARTITION_COMPENSATE_EXTERNAL_SCAN_TYPES.contains(scanOperator.getOpType())) {
@@ -661,10 +636,15 @@ public class MvPartitionCompensator {
                 ScanOperatorPredicates scanOperatorPredicates = scanOperator.getScanOperatorPredicates();
                 return scanOperatorPredicates.getPrunedPartitionConjuncts();
             } catch (AnalysisException e) {
+                logMVRewrite(mv.getName(), "Compensate partition predicate for mv {} failed: {}",
+                        mv.getName(), DebugUtil.getStackTrace(e));
                 return null;
             }
         } else {
             // Cannot decide whether it has been pruned or not, return null for now.
+            logMVRewrite(mv.getName(), "Compensate partition predicate for mv {} failed: unsupported scan " +
+                            "operator type {} for {}", mv.getName(),
+                    scanOperator.getOpType(), scanOperator.getTable().getName());
             return null;
         }
     }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvUtils.java
@@ -604,13 +604,9 @@ public class MvUtils {
                     if (context != null) {
                         joinKeyColumns.union(context);
                     }
-                    optExpression.inputAt(0).getOp().accept(this, optExpression.inputAt(0), joinKeyColumns);
-                    optExpression.inputAt(1).getOp().accept(this, optExpression.inputAt(1), joinKeyColumns);
-                } else if (joinType.isLeftOuterJoin() || joinType.isLeftAntiJoin()) {
-                    optExpression.inputAt(0).getOp().accept(this, optExpression.inputAt(0), joinKeyColumns);
-                } else if (joinType.isRightOuterJoin() || joinType.isRightAntiJoin()) {
-                    optExpression.inputAt(1).getOp().accept(this, optExpression.inputAt(1), joinKeyColumns);
                 }
+                optExpression.inputAt(0).getOp().accept(this, optExpression.inputAt(0), joinKeyColumns);
+                optExpression.inputAt(1).getOp().accept(this, optExpression.inputAt(1), joinKeyColumns);
                 List<ScalarOperator> conjuncts = Utils.extractConjuncts(
                         Utils.compoundAnd(joinOperator.getPredicate(), joinOperator.getOnPredicate()));
                 for (ScalarOperator conjunct : conjuncts) {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/rule/BaseMaterializedViewRewriteRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/rule/BaseMaterializedViewRewriteRule.java
@@ -219,18 +219,17 @@ public abstract class BaseMaterializedViewRewriteRule extends TransformationRule
                                                   ReplaceColumnRefRewriter queryColumnRefRewriter) {
         // Cache partition predicate predicates because it's expensive time costing if there are too many materialized views or
         // query expressions are too complex.
-        final ScalarOperator queryPartitionPredicate = MvPartitionCompensator.compensatePartitionPredicate(mvContext,
-                queryColumnRefFactory, queryExpression);
+        final ScalarOperator queryPartitionPredicate = MvPartitionCompensator.compensateQueryPartitionPredicate(
+                mvContext, queryColumnRefFactory, queryExpression);
         if (queryPartitionPredicate == null) {
             logMVRewrite(mvContext.getOptimizerContext(), this, "Compensate query expression's partition " +
                     "predicates from pruned partitions failed.");
             return null;
         }
-        // only add valid predicates into query split predicate
+
         Set<ScalarOperator> queryConjuncts = MvUtils.getPredicateForRewrite(queryExpression);
+        // only add valid predicates into query split predicate
         if (!ConstantOperator.TRUE.equals(queryPartitionPredicate)) {
-            logMVRewrite(mvContext.getOptimizerContext(), this, "Query compensate partition predicate:{}",
-                    queryPartitionPredicate);
             queryConjuncts.addAll(MvUtils.getAllValidPredicates(queryPartitionPredicate));
         }
 

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvRewriteHiveTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvRewriteHiveTest.java
@@ -14,13 +14,26 @@
 
 package com.starrocks.sql.optimizer.rule.transformation.materialization;
 
+import com.google.common.collect.ImmutableList;
 import com.starrocks.catalog.MaterializedView;
+import com.starrocks.common.util.DebugUtil;
+import com.starrocks.sql.ast.QueryStatement;
+import com.starrocks.sql.optimizer.OptExpression;
+import com.starrocks.sql.optimizer.OptimizerConfig;
+import com.starrocks.sql.optimizer.Utils;
+import com.starrocks.sql.optimizer.base.ColumnRefFactory;
+import com.starrocks.sql.optimizer.operator.ScanOperatorPredicates;
+import com.starrocks.sql.optimizer.operator.logical.LogicalScanOperator;
+import com.starrocks.sql.optimizer.operator.scalar.ScalarOperator;
+import com.starrocks.sql.optimizer.transformer.LogicalPlan;
 import com.starrocks.sql.plan.ConnectorPlanTestBase;
 import com.starrocks.sql.plan.PlanTestBase;
+import com.starrocks.utframe.UtFrameUtils;
 import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
+import java.util.List;
 import java.util.Set;
 
 public class MvRewriteHiveTest extends MvRewriteTestBase {
@@ -341,5 +354,208 @@ public class MvRewriteHiveTest extends MvRewriteTestBase {
         String plan = getFragmentPlan(query1);
         PlanTestBase.assertContains(plan, "hive_partitioned_mv");
         dropMv("test", "hive_partitioned_mv");
+    }
+
+    private List<LogicalScanOperator> getQueryOptExpression(String query) {
+        ColumnRefFactory columnRefFactory = new ColumnRefFactory();
+        QueryStatement statement = null;
+        try {
+            statement = (QueryStatement) UtFrameUtils.parseStmtWithNewParser(query, connectContext);
+        } catch (Exception e) {
+            Assert.fail("Parse query failed:" + DebugUtil.getStackTrace(e));
+        }
+        LogicalPlan logicalPlan = UtFrameUtils.getQueryLogicalPlan(connectContext, columnRefFactory, statement);
+        OptimizerConfig optimizerConfig = new OptimizerConfig(OptimizerConfig.OptimizerAlgorithm.RULE_BASED);
+        OptExpression optExpression = UtFrameUtils.getQueryOptExpression(connectContext, columnRefFactory,
+                logicalPlan, optimizerConfig);
+        List<LogicalScanOperator> scanOperators = MvUtils.getScanOperator(optExpression);
+        return scanOperators;
+    }
+
+    private ScanOperatorPredicates getScanOperatorPredicates(LogicalScanOperator logicalScanOperator) {
+        try {
+            return logicalScanOperator.getScanOperatorPredicates();
+        } catch (Exception e) {
+            Assert.fail();
+        }
+        return null;
+    }
+
+    @Test
+    public void testHivePartitionPruner0() {
+        String query = "SELECT `l_suppkey`, `l_orderkey`, sum(l_orderkey)  FROM `hive0`.`partitioned_db`.`lineitem_par` " +
+                "GROUP BY `l_orderkey`, `l_suppkey`;";
+        List<LogicalScanOperator> scanOperators = getQueryOptExpression(query);
+        Assert.assertTrue(scanOperators.size() == 1);
+        ScanOperatorPredicates scanOperatorPredicates = getScanOperatorPredicates(scanOperators.get(0));
+        Assert.assertTrue(scanOperatorPredicates != null);
+        Assert.assertTrue(scanOperatorPredicates.getIdToPartitionKey().size() == 6);
+        Assert.assertTrue(scanOperatorPredicates.getPartitionConjuncts().size() == 0);
+        Assert.assertTrue(scanOperatorPredicates.getSelectedPartitionIds().size() == 6);
+        Assert.assertTrue(scanOperatorPredicates.getPrunedPartitionConjuncts().size() == 0);
+        Assert.assertTrue(scanOperatorPredicates.getNonPartitionConjuncts().size() == 0);
+        Assert.assertTrue(scanOperators.get(0).getPredicate() == null);
+    }
+
+    @Test
+    public void testHivePartitionPruner1() {
+        // queries that can be pruned by optimizer
+        List<String> queries = ImmutableList.of(
+                "SELECT `l_suppkey`, `l_orderkey`, sum(l_orderkey)  FROM `hive0`.`partitioned_db`.`lineitem_par` " +
+                        "WHERE l_shipdate = '1998-01-01' GROUP BY `l_orderkey`, `l_suppkey`;",
+                "SELECT `l_suppkey`, `l_orderkey`, sum(l_orderkey)  FROM `hive0`.`partitioned_db`.`lineitem_par` " +
+                        "WHERE date_sub(l_shipdate, interval 1 day) = '1998-01-02' GROUP BY `l_orderkey`, `l_suppkey`;"
+        );
+        for (String query : queries) {
+            List<LogicalScanOperator> scanOperators = getQueryOptExpression(query);
+            Assert.assertTrue(scanOperators.size() == 1);
+            ScanOperatorPredicates scanOperatorPredicates = getScanOperatorPredicates(scanOperators.get(0));
+            Assert.assertTrue(scanOperatorPredicates != null);
+            Assert.assertTrue(scanOperatorPredicates.getIdToPartitionKey().size() == 6);
+            Assert.assertTrue(scanOperatorPredicates.getPartitionConjuncts().size() == 1);
+            Assert.assertTrue(scanOperatorPredicates.getSelectedPartitionIds().size() == 1);
+            Assert.assertTrue(scanOperatorPredicates.getNonPartitionConjuncts().size() == 0);
+            Assert.assertTrue(scanOperatorPredicates.getNoEvalPartitionConjuncts().size() == 0);
+            Assert.assertTrue(scanOperatorPredicates.getPrunedPartitionConjuncts().size() == 1);
+            // TODO: fixme
+            Assert.assertTrue(scanOperators.get(0).getPredicate() != null);
+        }
+    }
+
+    @Test
+    public void testHivePartitionPruner2() {
+        String query = "SELECT `l_suppkey`, `l_orderkey`, sum(l_orderkey)  FROM `hive0`.`partitioned_db`.`lineitem_par` " +
+                "WHERE date_trunc('month', l_shipdate) = date_sub('1998-01-02', interval 1 day) " +
+                "GROUP BY `l_orderkey`, `l_suppkey`;";
+        List<LogicalScanOperator> scanOperators = getQueryOptExpression(query);
+        Assert.assertTrue(scanOperators.size() == 1);
+        ScanOperatorPredicates scanOperatorPredicates = getScanOperatorPredicates(scanOperators.get(0));
+        Assert.assertTrue(scanOperatorPredicates != null);
+        Assert.assertTrue(scanOperatorPredicates.getIdToPartitionKey().size() == 6);
+        Assert.assertTrue(scanOperatorPredicates.getPartitionConjuncts().size() == 1);
+        Assert.assertTrue(scanOperatorPredicates.getNonPartitionConjuncts().size() == 0);
+        Assert.assertTrue(scanOperatorPredicates.getSelectedPartitionIds().size() == 6);
+        Assert.assertTrue(scanOperatorPredicates.getNoEvalPartitionConjuncts().size() == 1);
+        Assert.assertTrue(scanOperatorPredicates.getPrunedPartitionConjuncts().size() == 0);
+        Assert.assertTrue(scanOperators.get(0).getPredicate() != null);
+    }
+
+    @Test
+    public void testHivePartitionPruner3() {
+        String query = "SELECT `l_suppkey`, `l_orderkey`, sum(l_orderkey)  FROM `hive0`.`partitioned_db`.`lineitem_par` " +
+                " WHERE date_trunc('month', l_shipdate) = date_sub('1998-01-02', interval 1 day) " +
+                " and l_shipdate >= '1998-01-01' and l_orderkey > 1000 " +
+                " GROUP BY `l_orderkey`, `l_suppkey`;";
+        List<LogicalScanOperator> scanOperators = getQueryOptExpression(query);
+        Assert.assertTrue(scanOperators.size() == 1);
+        ScanOperatorPredicates scanOperatorPredicates = getScanOperatorPredicates(scanOperators.get(0));
+        Assert.assertTrue(scanOperatorPredicates != null);
+        Assert.assertTrue(scanOperatorPredicates.getIdToPartitionKey().size() == 6);
+        Assert.assertTrue(scanOperatorPredicates.getNonPartitionConjuncts().size() == 1);
+        Assert.assertTrue(scanOperatorPredicates.getSelectedPartitionIds().size() == 5);
+
+        Assert.assertTrue(scanOperatorPredicates.getPartitionConjuncts().size() == 2);
+        Assert.assertTrue(scanOperatorPredicates.getNoEvalPartitionConjuncts().size() == 1);
+        Assert.assertTrue(scanOperatorPredicates.getPrunedPartitionConjuncts().size() == 1);
+
+        Assert.assertTrue(scanOperators.get(0).getPredicate() != null);
+        List<ScalarOperator> predicates = Utils.extractConjuncts(scanOperators.get(0).getPredicate());
+        Assert.assertTrue(predicates.size() == 3);
+    }
+
+    @Test
+    public void testHivePartitionPruneWithTwoTables1() {
+        String mv1 = "CREATE MATERIALIZED VIEW mv1\n" +
+                "DISTRIBUTED BY RANDOM\n" +
+                "PARTITION BY (l_shipdate)\n" +
+                "PROPERTIES (\"force_external_table_query_rewrite\" = \"true\") AS \n" +
+                " SELECT o_orderkey, l_suppkey, l_shipdate, sum(l_orderkey)  " +
+                " FROM hive0.partitioned_db.lineitem_par as a " +
+                " LEFT JOIN hive0.partitioned_db.orders as b ON b.o_orderkey=a.l_orderkey \n " +
+                " WHERE b.o_orderdate >= '1991-01-01' and a.l_shipdate >= '1991-01-01' \n " +
+                " GROUP BY o_orderkey, l_suppkey, l_shipdate;";
+
+        starRocksAssert.withMaterializedView(mv1, (obj) -> {
+            String mvName = (String) obj;
+            refreshMaterializedView(DB_NAME, mvName);
+            {
+                String query = "SELECT o_orderkey, l_suppkey, l_shipdate, sum(l_orderkey)  " +
+                        " FROM hive0.partitioned_db.lineitem_par as a " +
+                        " LEFT JOIN hive0.partitioned_db.orders as b ON b.o_orderkey=a.l_orderkey \n " +
+                        " WHERE b.o_orderdate >= '1991-01-01' and a.l_shipdate >= '1991-01-01' \n " +
+                        " GROUP BY o_orderkey, l_suppkey, l_shipdate;";
+
+                String plan = getFragmentPlan(query);
+                PlanTestBase.assertContains(plan, "0:OlapScanNode\n" +
+                        "     TABLE: mv1\n" +
+                        "     PREAGGREGATION: ON\n" +
+                        "     partitions=6/6\n" +
+                        "     rollup: mv1");
+            }
+
+            {
+                String query = "SELECT o_orderkey, l_suppkey, l_shipdate, sum(l_orderkey)  " +
+                        " FROM hive0.partitioned_db.lineitem_par as a " +
+                        " LEFT JOIN hive0.partitioned_db.orders as b ON b.o_orderkey=a.l_orderkey \n " +
+                        " WHERE b.o_orderdate >= '1991-01-01' and a.l_suppkey > 1 and a.l_shipdate >= '1991-01-01' \n " +
+                        " GROUP BY o_orderkey, l_suppkey, l_shipdate;";
+
+                String plan = getFragmentPlan(query);
+                PlanTestBase.assertContains(plan, "0:OlapScanNode\n" +
+                        "     TABLE: mv1\n" +
+                        "     PREAGGREGATION: ON\n" +
+                        "     PREDICATES: 28: l_suppkey > 1\n" +
+                        "     partitions=6/6\n" +
+                        "     rollup: mv1");
+            }
+        });
+    }
+
+    @Test
+    public void testHivePartitionPruneWithTwoTables2() {
+        String mv1 = "CREATE MATERIALIZED VIEW mv1\n" +
+                "DISTRIBUTED BY RANDOM\n" +
+                "PARTITION BY (l_shipdate)\n" +
+                "PROPERTIES (\"force_external_table_query_rewrite\" = \"true\") AS \n" +
+                " SELECT o_orderkey, l_suppkey, l_shipdate, sum(l_orderkey)  " +
+                " FROM hive0.partitioned_db.lineitem_par as a " +
+                " LEFT JOIN hive0.partitioned_db.orders as b ON b.o_orderkey=a.l_orderkey \n " +
+                " WHERE b.o_orderdate is not null and a.l_shipdate is not null \n " +
+                " GROUP BY o_orderkey, l_suppkey, l_shipdate;";
+
+        starRocksAssert.withMaterializedView(mv1, (obj) -> {
+            String mvName = (String) obj;
+            refreshMaterializedView(DB_NAME, mvName);
+            {
+                String query = "SELECT o_orderkey, l_suppkey, l_shipdate, sum(l_orderkey)  " +
+                        " FROM hive0.partitioned_db.lineitem_par as a " +
+                        " LEFT JOIN hive0.partitioned_db.orders as b ON b.o_orderkey=a.l_orderkey \n " +
+                        " WHERE b.o_orderdate is not null and a.l_shipdate is not null \n " +
+                        " GROUP BY o_orderkey, l_suppkey, l_shipdate;";
+
+                String plan = getFragmentPlan(query);
+                PlanTestBase.assertContains(plan, "0:OlapScanNode\n" +
+                        "     TABLE: mv1\n" +
+                        "     PREAGGREGATION: ON\n" +
+                        "     partitions=6/6\n" +
+                        "     rollup: mv1");
+            }
+
+            {
+                String query = "SELECT o_orderkey, l_suppkey, l_shipdate, sum(l_orderkey)  " +
+                        " FROM hive0.partitioned_db.lineitem_par as a " +
+                        " LEFT JOIN hive0.partitioned_db.orders as b ON b.o_orderkey=a.l_orderkey \n " +
+                        " WHERE b.o_orderdate is not null and a.l_suppkey > 1 and a.l_shipdate is not null \n " +
+                        " GROUP BY o_orderkey, l_suppkey, l_shipdate;";
+
+                String plan = getFragmentPlan(query);
+                PlanTestBase.assertContains(plan, "0:OlapScanNode\n" +
+                        "     TABLE: mv1\n" +
+                        "     PREAGGREGATION: ON\n" +
+                        "     PREDICATES: 28: l_suppkey > 1\n" +
+                        "     partitions=6/6\n" +
+                        "     rollup: mv1");
+            }
+        });
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/utframe/UtFrameUtils.java
+++ b/fe/fe-core/src/test/java/com/starrocks/utframe/UtFrameUtils.java
@@ -109,6 +109,7 @@ import com.starrocks.sql.common.SqlDigestBuilder;
 import com.starrocks.sql.optimizer.LogicalPlanPrinter;
 import com.starrocks.sql.optimizer.OptExpression;
 import com.starrocks.sql.optimizer.Optimizer;
+import com.starrocks.sql.optimizer.OptimizerConfig;
 import com.starrocks.sql.optimizer.base.ColumnRefFactory;
 import com.starrocks.sql.optimizer.base.ColumnRefSet;
 import com.starrocks.sql.optimizer.base.PhysicalPropertySet;
@@ -750,6 +751,45 @@ public class UtFrameUtils {
         }
     }
 
+    public static LogicalPlan getQueryLogicalPlan(ConnectContext connectContext,
+                                                  ColumnRefFactory columnRefFactory,
+                                                  QueryStatement statement) {
+        LogicalPlan logicalPlan;
+        try (Timer t = Tracers.watchScope("Transformer")) {
+            logicalPlan = new RelationTransformer(columnRefFactory, connectContext)
+                    .transform((statement).getQueryRelation());
+
+        }
+        return logicalPlan;
+    }
+
+    public static OptExpression getQueryOptExpression(ConnectContext connectContext,
+                                                      ColumnRefFactory columnRefFactory,
+                                                      LogicalPlan logicalPlan,
+                                                      OptimizerConfig optimizerConfig) {
+        OptExpression optimizedPlan;
+        try (Timer t = Tracers.watchScope("Optimizer")) {
+            Optimizer optimizer = null;
+            if (optimizerConfig != null) {
+                optimizer = new Optimizer(optimizerConfig);
+            } else {
+                optimizer = new Optimizer();
+            }
+            optimizedPlan = optimizer.optimize(
+                    connectContext,
+                    logicalPlan.getRoot(),
+                    new PhysicalPropertySet(),
+                    new ColumnRefSet(logicalPlan.getOutputColumn()),
+                    columnRefFactory);
+        }
+        return optimizedPlan;
+    }
+    public static OptExpression getQueryOptExpression(ConnectContext connectContext,
+                                                      ColumnRefFactory columnRefFactory,
+                                                      LogicalPlan logicalPlan) {
+        return getQueryOptExpression(connectContext, columnRefFactory, logicalPlan, null);
+    }
+
     private static Pair<String, ExecPlan> getQueryExecPlan(QueryStatement statement, ConnectContext connectContext)
             throws Exception {
         SessionVariable oldSessionVariable = connectContext.getSessionVariable();
@@ -759,24 +799,8 @@ public class UtFrameUtils {
             }
 
             ColumnRefFactory columnRefFactory = new ColumnRefFactory();
-
-            LogicalPlan logicalPlan;
-            try (Timer t = Tracers.watchScope("Transformer")) {
-                logicalPlan = new RelationTransformer(columnRefFactory, connectContext)
-                        .transform((statement).getQueryRelation());
-
-            }
-
-            OptExpression optimizedPlan;
-            try (Timer t = Tracers.watchScope("Optimizer")) {
-                Optimizer optimizer = new Optimizer();
-                optimizedPlan = optimizer.optimize(
-                        connectContext,
-                        logicalPlan.getRoot(),
-                        new PhysicalPropertySet(),
-                        new ColumnRefSet(logicalPlan.getOutputColumn()),
-                        columnRefFactory);
-            }
+            LogicalPlan logicalPlan = getQueryLogicalPlan(connectContext, columnRefFactory, statement);
+            OptExpression optimizedPlan = getQueryOptExpression(connectContext, columnRefFactory, logicalPlan);
 
             ExecPlan execPlan;
             try (Timer t = Tracers.watchScope("Builder")) {


### PR DESCRIPTION
## Why I'm doing:

When mv define query contain multi table's partition predicates(eg, join with two tables which each table has its partition predicate in the define query), mv rewrite will be failed for now.

## What I'm doing:

1. Collect all predicates for join's childs no matter which kinds of join types in `MvUtils#getPredicateForRewrite `, otherwise MV's defined plan may lose the child's predicates.
2. Remove `getMVPrunedPartitionPredicates ` when mv can satisfy query's freshness because MV's plan is not partition pruned, so its partition predicates should be complete when its freshness can be satisfied.

Add more tests.


Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
