### PR TITLE
[Enhancement] Rename debug function name in shared buffer

### DIFF
--- a/be/src/io/shared_buffered_input_stream.cpp
+++ b/be/src/io/shared_buffered_input_stream.cpp
@@ -38,7 +38,7 @@ void SharedBufferedInputStream::SharedBuffer::align(int64_t align_size, int64_t 
     }
 }
 
-std::string SharedBufferedInputStream::SharedBuffer::debug() const {
+std::string SharedBufferedInputStream::SharedBuffer::debug_string() const {
     return strings::Substitute(
             "SharedBuffer raw_offset=$0, raw_size=$1, offset=$2, size=$3, ref_count=$4, buffer_capacity=$5", raw_offset,
             raw_size, offset, size, ref_count, buffer.capacity());

--- a/be/src/io/shared_buffered_input_stream.h
+++ b/be/src/io/shared_buffered_input_stream.h
@@ -48,7 +48,7 @@ public:
         int64_t ref_count;
         std::vector<uint8_t> buffer;
         void align(int64_t align_size, int64_t file_size);
-        std::string debug() const;
+        std::string debug_string() const;
     };
 
     SharedBufferedInputStream(std::shared_ptr<SeekableInputStream> stream, std::string filename, size_t file_size);

--- a/be/test/io/shared_buffered_input_stream_test.cpp
+++ b/be/test/io/shared_buffered_input_stream_test.cpp
@@ -176,7 +176,7 @@ TEST_F(SharedBufferedInputStreamTest, test_orc) {
     ASSERT_EQ(
             "SharedBuffer raw_offset=22420223, raw_size=197, offset=22282240, size=262144, ref_count=2, "
             "buffer_capacity=0",
-            sb.value()->debug());
+            sb.value()->debug_string());
 }
 
 } // namespace starrocks::io


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:

rename function name from `debug()` to `debug_string()` which introduced by #41330

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
