### PR TITLE
[BugFix] fix convert left outer join to inner join bug

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/Optimizer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/Optimizer.java
@@ -836,9 +836,6 @@ public class Optimizer {
         }
         context.getTaskScheduler().pushTask(new RewriteTreeTask(rootTaskContext, tree, rules, false));
         context.getTaskScheduler().executeTasks(rootTaskContext);
-        if (ruleSetType.equals(RuleSetType.PUSH_DOWN_PREDICATE)) {
-            context.reset();
-        }
     }
 
     private void ruleRewriteIterative(OptExpression tree, TaskContext rootTaskContext, Rule rule) {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/OptimizerContext.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/OptimizerContext.java
@@ -282,7 +282,7 @@ public class OptimizerContext {
     }
 
     // Should clear pushdownNotNullPredicates after each call of PUSH_DOWN_PREDICATE rule set
-    public void reset() {
+    public void clearNotNullPredicates() {
         pushdownNotNullPredicates.clear();
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MaterializedViewRewriter.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MaterializedViewRewriter.java
@@ -1914,7 +1914,7 @@ public class MaterializedViewRewriter {
         // To ensure join's property is deduced which is needed in `predicate-push-down`, derive its logical property.
         deriveLogicalProperty(joinOptExpression);
         Preconditions.checkState(joinOptExpression.getOp() instanceof LogicalJoinOperator);
-        optimizerContext.reset();
+        optimizerContext.clearNotNullPredicates();
         JoinPredicatePushdown joinPredicatePushdown = new JoinPredicatePushdown(joinOptExpression,
                 false, true, materializationContext.getQueryRefFactory(),
                 true, optimizerContext);

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/task/RewriteTreeTask.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/task/RewriteTreeTask.java
@@ -57,7 +57,9 @@ public class RewriteTreeTask extends OptimizerTask {
     public void execute() {
         // first node must be RewriteAnchorNode
         rewrite(planTree, 0, planTree.getInputs().get(0));
-
+        // pushdownNotNullPredicates should task-bind, reset it before another RewriteTreeTask
+        // TODO: refactor TaskContext to make it local to support this requirement better?
+        context.getOptimizerContext().clearNotNullPredicates();
         if (change > 0 && !onlyOnce) {
             pushTask(new RewriteTreeTask(context, planTree, rules, onlyOnce));
         }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/JoinTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/JoinTest.java
@@ -30,6 +30,31 @@ import org.junit.Ignore;
 import org.junit.Test;
 
 public class JoinTest extends PlanTestBase {
+    @Test
+    public void testIsNullPredicatePushdownClear() throws Exception {
+        {
+            String sql = "with cte_tbl as (\n" +
+                    "  select v1, count(distinct v2) as clickcnt from " +
+                    "(select * from t0) t0 join t1 on t0.v1= t1.v4 where 1 = 1 and t0.v2 in (select v7 from t2) group by v1\n" +
+                    ") select t3.* from (select * from t3 left join cte_tbl on v10 = v1 where v11 = 11) t3 where 1 = 1 ";
+            String plan = getFragmentPlan(sql);
+            // should be LEFT OUTER JOIN, not INNER JOIN
+            assertContains(plan, "13:HASH JOIN\n" +
+                    "  |  join op: LEFT OUTER JOIN");
+        }
+
+        {
+            // remove where 1 = 1
+            String sql = "with cte_tbl as (\n" +
+                    "  select v1, count(distinct v2) as clickcnt from " +
+                    "(select * from t0) t0 join t1 on t0.v1= t1.v4 where 1 = 1 and t0.v2 in (select v7 from t2) group by v1\n" +
+                    ") select t3.* from (select * from t3 left join cte_tbl on v10 = v1 where v11 = 11) t3";
+            String plan = getFragmentPlan(sql);
+            // should be LEFT OUTER JOIN, not INNER JOIN
+            assertContains(plan, "13:HASH JOIN\n" +
+                    "  |  join op: LEFT OUTER JOIN");
+        }
+    }
 
     @Test
     public void testColocateDistributeSatisfyShuffleColumns() throws Exception {


### PR DESCRIPTION
## Why I'm doing:
left outer join is incorrecly converted into inner join, The reason is that pushdownNotNullPredicates of OptimizerContext is not clear after RewriteTreeTask rewrite retry. 

## What I'm doing:
reset OptimizerContext after every RewriteTreeTask run.

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [x] 3.1
  - [x] 3.0
  - [x] 2.5
