### PR TITLE
[Enhancement] optimize cast string to datetime

### DIFF
--- a/be/src/exprs/cast_expr.cpp
+++ b/be/src/exprs/cast_expr.cpp
@@ -904,43 +904,76 @@ UNARY_FN_CAST(TYPE_DATE, TYPE_DATETIME, DateToTimestmap);
 
 template <LogicalType FromType, LogicalType ToType, bool AllowThrowException>
 static ColumnPtr cast_from_string_to_datetime_fn(ColumnPtr& column) {
-    ColumnViewer<TYPE_VARCHAR> viewer(column);
-    ColumnBuilder<TYPE_DATETIME> builder(viewer.size());
+    const int num_rows = column->size();
 
-    if (!column->has_null()) {
-        for (int row = 0; row < viewer.size(); ++row) {
-            auto value = viewer.value(row);
-            TimestampValue v;
-
-            bool right = v.from_string(value.data, value.size);
-            if constexpr (AllowThrowException) {
-                if (!right) {
-                    THROW_RUNTIME_ERROR_WITH_TYPES_AND_VALUE(TYPE_VARCHAR, TYPE_DATETIME, value.to_string());
-                }
-            }
-            builder.append(v, !right);
-        }
-    } else {
-        for (int row = 0; row < viewer.size(); ++row) {
-            if (viewer.is_null(row)) {
-                builder.append_null();
-                continue;
-            }
-
-            auto value = viewer.value(row);
-            TimestampValue v;
-
-            bool right = v.from_string(value.data, value.size);
-            if constexpr (AllowThrowException) {
-                if (!right) {
-                    THROW_RUNTIME_ERROR_WITH_TYPES_AND_VALUE(TYPE_VARCHAR, TYPE_DATETIME, value.to_string());
-                }
-            }
-            builder.append(v, !right);
-        }
+    if (column->only_null()) {
+        return ColumnHelper::create_const_null_column(num_rows);
     }
 
-    return builder.build(column->is_constant());
+    if (column->is_constant()) {
+        const auto* input_column = ColumnHelper::get_binary_column(column.get());
+        const auto slice_value = input_column->get_slice(0);
+
+        TimestampValue datetime_value;
+        const bool success = datetime_value.from_string(slice_value.data, slice_value.size);
+
+        if (!success) {
+            if constexpr (AllowThrowException) {
+                THROW_RUNTIME_ERROR_WITH_TYPES_AND_VALUE(FromType, ToType, slice_value.to_string());
+            }
+            return ColumnHelper::create_const_null_column(num_rows);
+        }
+        return ColumnHelper::create_const_column<ToType>(datetime_value, num_rows);
+    }
+
+    auto res_data_column = RunTimeColumnType<ToType>::create();
+    res_data_column->resize(num_rows);
+    auto& res_data = res_data_column->get_data();
+
+    if (column->is_nullable()) {
+        const auto* input_column = down_cast<NullableColumn*>(column.get());
+        const auto* data_column = down_cast<BinaryColumn*>(input_column->data_column().get());
+
+        NullColumnPtr null_column = ColumnHelper::as_column<NullColumn>(input_column->null_column()->clone());
+        auto& null_data = down_cast<NullColumn*>(null_column.get())->get_data();
+
+        for (int i = 0; i < num_rows; ++i) {
+            if (!null_data[i]) {
+                auto slice_value = data_column->get_slice(i);
+                const bool success = res_data[i].from_string(slice_value.data, slice_value.size);
+
+                if constexpr (AllowThrowException) {
+                    if (!success) {
+                        THROW_RUNTIME_ERROR_WITH_TYPES_AND_VALUE(FromType, ToType, slice_value.to_string());
+                    }
+                }
+                null_data[i] = !success;
+            }
+        }
+        return NullableColumn::create(std::move(res_data_column), std::move(null_column));
+    } else {
+        auto* data_column = down_cast<BinaryColumn*>(column.get());
+        NullColumnPtr null_column = NullColumn::create(num_rows);
+        auto& null_data = null_column->get_data();
+
+        bool has_null = false;
+        for (int i = 0; i < num_rows; ++i) {
+            auto slice_value = data_column->get_slice(i);
+            const bool success = res_data[i].from_string(slice_value.data, slice_value.size);
+
+            if constexpr (AllowThrowException) {
+                if (!success) {
+                    THROW_RUNTIME_ERROR_WITH_TYPES_AND_VALUE(FromType, ToType, slice_value.to_string());
+                }
+            }
+            null_data[i] = !success;
+            has_null |= !success;
+        }
+        if (!has_null) {
+            return res_data_column;
+        }
+        return NullableColumn::create(std::move(res_data_column), std::move(null_column));
+    }
 }
 CUSTOMIZE_FN_CAST(TYPE_VARCHAR, TYPE_DATETIME, cast_from_string_to_datetime_fn);
 

--- a/be/src/runtime/time_types.cpp
+++ b/be/src/runtime/time_types.cpp
@@ -175,6 +175,10 @@ int64_t date::standardize_date(int64_t value) {
     return value;
 }
 
+static bool is_space(char ch) {
+    return UNLIKELY(ch == ' ' || ch == '\t' || ch == '\n' || ch == '\v' || ch == '\f' || ch == '\r');
+}
+
 bool date::from_string(const char* date_str, size_t len, int* year, int* month, int* day, int* hour, int* minute,
                        int* second, int* microsecond) {
     const char* ptr = date_str;
@@ -186,7 +190,7 @@ bool date::from_string(const char* date_str, size_t len, int* year, int* month, 
     int32_t date_len[MAX_DATE_PARTS];
 
     // Skip space character
-    while (ptr < end && isspace(*ptr)) {
+    while (ptr < end && is_space(*ptr)) {
         ptr++;
     }
     if (ptr == end || !isdigit(*ptr)) {
@@ -253,8 +257,8 @@ bool date::from_string(const char* date_str, size_t len, int* year, int* month, 
             continue;
         }
         // escape separator
-        while (ptr < end && (ispunct(*ptr) || isspace(*ptr))) {
-            if (isspace(*ptr)) {
+        while (ptr < end && (ispunct(*ptr) || is_space(*ptr))) {
+            if (is_space(*ptr)) {
                 if (((1 << field_idx) & allow_space_mask) == 0) {
                     return false;
                 }
@@ -298,31 +302,25 @@ bool date::from_string(const char* date_str, size_t len, int* year, int* month, 
     return true;
 }
 
-// Get date base on format "%Y-%m-%d", '-' means any char.
+// Get date base on format "%YYYY-%mm-%dd", where '-' means any char.
 // compare every char.
-bool date::from_string_to_date_internal(const char* ptr, int* year, int* month, int* day) {
-    uint8_t year1;
-    uint8_t year2;
-    uint8_t year3;
-    uint8_t year4;
-    uint8_t month1;
-    uint8_t month2;
-    uint8_t day1;
-    uint8_t day2;
-    if (char_to_digit(ptr, 0, &year1) || char_to_digit(ptr, 1, &year2) || char_to_digit(ptr, 2, &year3) ||
-        char_to_digit(ptr, 3, &year4) || isdigit(ptr[4]) || char_to_digit(ptr, 5, &month1) ||
-        char_to_digit(ptr, 6, &month2) || isdigit(ptr[7]) || char_to_digit(ptr, 8, &day1) ||
-        char_to_digit(ptr, 9, &day2)) {
+// Note that this method does not check whether the parsed year, month, and day are in valid range.
+bool date::from_string_to_date_internal(const char* ptr, int* pyear, int* pmonth, int* pday) {
+    const bool is_valid = isdigit(ptr[0]) && isdigit(ptr[1]) && isdigit(ptr[2]) && isdigit(ptr[3]) &&
+                          !isdigit(ptr[4]) && isdigit(ptr[5]) && isdigit(ptr[6]) && !isdigit(ptr[7]) &&
+                          isdigit(ptr[8]) && isdigit(ptr[9]);
+    if (!is_valid) {
         return false;
     }
 
-    *year = year1 * 1000 + year2 * 100 + year3 * 10 + year4;
-    *month = month1 * 10 + month2;
-    *day = day1 * 10 + day2;
+    const int year = ptr[0] * 1000 + ptr[1] * 100 + ptr[2] * 10 + ptr[3] - static_cast<int>('0') * 1111;
+    const int month = ptr[5] * 10 + ptr[6] - static_cast<int>('0') * 11;
+    const int day = ptr[8] * 10 + ptr[9] - static_cast<int>('0') * 11;
 
-    if (*month > 12 || (*day > DAYS_IN_MONTH[is_leap(*year)][*month])) {
-        return false;
-    }
+    *pyear = year;
+    *pmonth = month;
+    *pday = day;
+
     return true;
 }
 
@@ -331,11 +329,11 @@ bool date::from_string_to_date(const char* date_str, size_t len, int* year, int*
     const char* ptr = date_str;
     const char* end = date_str + len;
     // Skip space character
-    while (ptr < end && isspace(*ptr)) {
+    while (ptr < end && is_space(*ptr)) {
         ++ptr;
     }
     // Skip space character
-    while (ptr < end && isspace(*(end - 1))) {
+    while (ptr < end && is_space(*(end - 1))) {
         --end;
     }
 
@@ -370,7 +368,7 @@ bool date::is_standard_datetime_format(const char* ptr, int length, const char**
             const char* local_ptr = ptr + 10;
             length -= 18;
             for (int i = 0; i < length; ++i) {
-                if (!isspace(local_ptr[i])) {
+                if (!is_space(local_ptr[i])) {
                     return false;
                 }
             }
@@ -424,7 +422,6 @@ bool date::from_string_to_datetime_internal(const char* ptr_date, const char* pt
 
     return true;
 }
-
 // if string content is 10 chars try to process based on "%Y-%m-%d",
 //    if successful return result;
 //    else failed use uncommon approach.
@@ -432,39 +429,44 @@ bool date::from_string_to_datetime_internal(const char* ptr_date, const char* pt
 //    if successful return result;
 //    else failed use uncommon approach.
 // else use uncommon approach.
-bool date::from_string_to_datetime(const char* date_str, size_t len, int* year, int* month, int* day, int* hour,
-                                   int* minute, int* second, int* microsecond) {
+//
+// @return <is_valid, is_only_date>
+//     is_valid is true if the date_str is valid datetime string.
+//     is_only_date is true if the date_str only contains date part.
+//         hour, minute, second, and microsecond of res will be undefined if is_only_date is true.
+std::pair<bool, bool> date::from_string_to_datetime(const char* date_str, size_t len, ToDatetimeResult* res) {
+    auto& [year, month, day, hour, minute, second, microsecond] = *res;
+
     const char* ptr = date_str;
     const char* end = date_str + len;
     // Skip space character
-    while (ptr < end && isspace(*ptr)) {
+    while (ptr < end && is_space(*ptr)) {
         ++ptr;
     }
-    while (ptr < end && isspace(*(end - 1))) {
+    while (ptr < end && is_space(*(end - 1))) {
         --end;
     }
 
     int length = end - ptr;
     if (length == 10) {
-        *hour = *minute = *second = *microsecond = 0;
-        bool result = from_string_to_date_internal(ptr, year, month, day);
-        if (!result) {
-            return from_string(date_str, len, year, month, day, hour, minute, second, microsecond);
+        const bool is_valid = from_string_to_date_internal(ptr, &year, &month, &day);
+        if (is_valid) {
+            return {true, true};
         }
-        return result;
+        return {from_string(date_str, len, &year, &month, &day, &hour, &minute, &second, &microsecond), false};
     }
 
     const char* ptr_date = ptr;
     const char* ptr_time = nullptr;
     if (is_standard_datetime_format(ptr, length, &ptr_time)) {
-        bool result = from_string_to_datetime_internal(ptr_date, ptr_time, year, month, day, hour, minute, second,
-                                                       microsecond);
-        if (!result) {
-            return from_string(date_str, len, year, month, day, hour, minute, second, microsecond);
+        const bool is_valid = from_string_to_datetime_internal(ptr_date, ptr_time, &year, &month, &day, &hour, &minute,
+                                                               &second, &microsecond);
+        if (is_valid) {
+            return {true, false};
         }
-        return result;
+        return {from_string(date_str, len, &year, &month, &day, &hour, &minute, &second, &microsecond), false};
     } else {
-        return from_string(date_str, len, year, month, day, hour, minute, second, microsecond);
+        return {from_string(date_str, len, &year, &month, &day, &hour, &minute, &second, &microsecond), false};
     }
 }
 
@@ -515,14 +517,6 @@ bool date::is_leap(int year) {
     return ((year % 4) == 0) && ((year % 100 != 0) || ((year % 400) == 0 && year));
 }
 
-bool date::check(int year, int month, int day) {
-    if (year > 9999 || month > 12 || month < 1 || day > 31 || day < 1) {
-        return false;
-    }
-
-    return day <= DAYS_IN_MONTH[is_leap(year)][month];
-}
-
 void date::to_string(int year, int month, int day, char* to) {
     uint32_t temp;
     temp = year / 100;
@@ -542,10 +536,6 @@ void date::to_string(int year, int month, int day, char* to) {
 
     to[8] = day / 10 + '0';
     to[9] = day % 10 + '0';
-}
-
-bool timestamp::check_time(int hour, int minute, int second, int microsecond) {
-    return hour < HOURS_PER_DAY && minute < MINS_PER_HOUR && second < SECS_PER_MINUTE && microsecond < USECS_PER_SEC;
 }
 
 } // namespace starrocks

--- a/be/src/runtime/time_types.cpp
+++ b/be/src/runtime/time_types.cpp
@@ -176,6 +176,7 @@ int64_t date::standardize_date(int64_t value) {
 }
 
 static bool is_space(char ch) {
+    // \t, \n, \v, \f, \r are 9~13, respectively.
     return UNLIKELY(ch == ' ' || (ch >= 9 && ch <= 13));
 }
 

--- a/be/src/runtime/time_types.cpp
+++ b/be/src/runtime/time_types.cpp
@@ -176,7 +176,7 @@ int64_t date::standardize_date(int64_t value) {
 }
 
 static bool is_space(char ch) {
-    return UNLIKELY(ch == ' ' || ch == '\t' || ch == '\n' || ch == '\v' || ch == '\f' || ch == '\r');
+    return UNLIKELY(ch == ' ' || (ch >= 9 && ch <= 13));
 }
 
 bool date::from_string(const char* date_str, size_t len, int* year, int* month, int* day, int* hour, int* minute,

--- a/be/src/runtime/time_types.cpp
+++ b/be/src/runtime/time_types.cpp
@@ -302,7 +302,7 @@ bool date::from_string(const char* date_str, size_t len, int* year, int* month, 
     return true;
 }
 
-// Get date base on format "%YYYY-%mm-%dd", where '-' means any char.
+// Get date base on format "%Y-%m-%d", where '-' means any char.
 // compare every char.
 // Note that this method does not check whether the parsed year, month, and day are in valid range.
 bool date::from_string_to_date_internal(const char* ptr, int* pyear, int* pmonth, int* pday) {

--- a/test/sql/test_function/R/test_cast_string_to_datetime
+++ b/test/sql/test_function/R/test_cast_string_to_datetime
@@ -1,0 +1,303 @@
+-- name: test_cast_string_to_datetime
+create table t1 (
+    k1 int NULL,
+    date_str string,
+    datetime_str string,
+    date_str_with_whitespace string,
+    datetime_str_with_whitespace string
+)
+duplicate key(k1)
+distributed by hash(k1) buckets 32;
+-- result:
+-- !result
+CREATE TABLE __row_util (
+  k1 bigint null
+) ENGINE=OLAP
+DUPLICATE KEY(`k1`)
+DISTRIBUTED BY HASH(`k1`) BUCKETS 32;
+-- result:
+-- !result
+insert into __row_util select generate_series from TABLE(generate_series(0, 10000 - 1));
+-- result:
+-- !result
+insert into __row_util select k1 + 20000 from __row_util; 
+insert into __row_util select k1 + 40000 from __row_util; 
+insert into __row_util select k1 + 80000 from __row_util; 
+
+insert into t1
+select 
+    cast(random() *2e9 as int), 
+    cast(cast(date_add('2020-01-01', INTERVAL row_number() over() DAY) as date) as varchar),
+    concat(cast(cast(date_add('2020-01-01', INTERVAL row_number() over() DAY) as date) as varchar), ' 01:02:03'), 
+    concat('  ', cast(cast(date_add('2020-01-01', INTERVAL row_number() over() DAY) as date) as varchar), '  '), 
+    concat('   ', cast(cast(date_add('2020-01-01', INTERVAL row_number() over() DAY) as date) as varchar), ' 01:02:03  ')
+from __row_util;
+-- result:
+-- !result
+insert into t1 (date_str)
+values 
+    ("20200101"),
+    ("20200101010203"),
+    ("20200101T010203"),
+    ("20200101T0102033"),
+    ("20200101T010203.123"),
+
+    ("200101"),
+    ("200101010203"),
+    ("200101T010203"),
+    ("200101T0102033"),
+    ("200101T010203.123"),
+
+    ("2020.01.01"),
+    ("2020.01.01T01.02.03"),
+    ("2020.01.01T01.02.033"),
+    ("2020.01.01T01.0203.123"),
+
+    ("  20200101 "),
+    ("  20200101010203   "),
+    ("  20200101T010203"),
+    ("20200101T0102033  "),
+    ("  20200101T010203.123    \n"),
+    ("  20200101T010203.123    \n \t \v \f \r "),
+    
+    ("2020.13.29"),
+    ("2020.13.61"),
+
+    ("2020.02.29"),
+    ("2020.02.28"),
+    ("2000.02.29"),
+    ("2000.02.28"),
+
+    ("2021.02.28"),
+    ("2100.02.28"),
+
+    ("invalid"),
+
+    ("2021.02.29"),
+    ("2100.02.29"),
+
+    ("?100.02.28"),
+    ("2?00.02.28"),
+    ("21?0.02.28"),
+    ("210?.02.28"),
+    ("2100902.28"),
+    ("2100.?2.28"),
+    ("2100.0?.28"),
+    ("2100.02928"),
+    ("2100.02.?8"),
+    ("2100.02.2?");
+-- result:
+-- !result
+    
+
+select 
+    ifnull(sum(murmur_hash3_32(
+        cast(date_str as datetime)
+    )), 0) +
+    ifnull(sum(murmur_hash3_32(
+        cast(date_str_with_whitespace as datetime)
+    )), 0) +
+    ifnull(sum(murmur_hash3_32(
+        cast(datetime_str as datetime)
+    )), 0) +
+    ifnull(sum(murmur_hash3_32(
+        cast(datetime_str_with_whitespace as datetime)
+    )), 0)
+from t1;
+-- result:
+-1390046567746
+-- !result
+insert into t1
+select 
+    cast(random() *2e9 as int), 
+    null, null, null ,null
+from __row_util;
+-- result:
+-- !result
+    
+select 
+    ifnull(sum(murmur_hash3_32(
+        cast(date_str as datetime)
+    )), 0) +
+    ifnull(sum(murmur_hash3_32(
+        cast(date_str_with_whitespace as datetime)
+    )), 0) +
+    ifnull(sum(murmur_hash3_32(
+        cast(datetime_str as datetime)
+    )), 0) +
+    ifnull(sum(murmur_hash3_32(
+        cast(datetime_str_with_whitespace as datetime)
+    )), 0)
+from t1;
+-- result:
+-1390046567746
+-- !result
+select cast(NULL as datetime);
+-- result:
+None
+-- !result
+select cast("20200101" as datetime);
+-- result:
+2020-01-01 00:00:00
+-- !result
+select cast("20200101010203" as datetime);
+-- result:
+2020-01-01 01:02:03
+-- !result
+select cast("20200101T010203" as datetime);
+-- result:
+2020-01-01 01:02:03
+-- !result
+select cast("20200101T0102033" as datetime);
+-- result:
+2020-01-01 01:02:03
+-- !result
+select cast("20200101T010203.123" as datetime);
+-- result:
+2020-01-01 01:02:03.123000
+-- !result
+select cast("200101" as datetime);
+-- result:
+2020-01-01 00:00:00
+-- !result
+select cast("200101010203" as datetime);
+-- result:
+2020-01-01 01:02:03
+-- !result
+select cast("200101T010203" as datetime);
+-- result:
+2020-01-01 01:02:03
+-- !result
+select cast("200101T0102033" as datetime);
+-- result:
+None
+-- !result
+select cast("200101T010203.123" as datetime);
+-- result:
+2020-01-01 01:02:03.123000
+-- !result
+select cast("2020.01.01" as datetime);
+-- result:
+2020-01-01 00:00:00
+-- !result
+select cast("2020.01.01T01.02.03" as datetime);
+-- result:
+2020-01-01 01:02:03
+-- !result
+select cast("2020.01.01T01.02.033" as datetime);
+-- result:
+2020-01-01 01:02:03
+-- !result
+select cast("2020.01.01T01.0203.123" as datetime);
+-- result:
+2020-01-01 01:02:03.123000
+-- !result
+select cast("  20200101 " as datetime);
+-- result:
+2020-01-01 00:00:00
+-- !result
+select cast("  20200101010203   " as datetime);
+-- result:
+None
+-- !result
+select cast("  20200101T010203" as datetime);
+-- result:
+2020-01-01 01:02:03
+-- !result
+select cast("20200101T0102033  " as datetime);
+-- result:
+None
+-- !result
+select cast("  20200101T010203.123    \n" as datetime);
+-- result:
+2020-01-01 01:02:03.123000
+-- !result
+select cast("  20200101T010203.123    \n \t \v \f \r " as datetime);
+-- result:
+2020-01-01 01:02:03.123000
+-- !result
+    
+select cast("2020.13.29" as datetime);
+-- result:
+None
+-- !result
+select cast("2020.13.61" as datetime);
+-- result:
+None
+-- !result
+select cast("2020.02.29" as datetime);
+-- result:
+2020-02-29 00:00:00
+-- !result
+select cast("2020.02.28" as datetime);
+-- result:
+2020-02-28 00:00:00
+-- !result
+select cast("2000.02.29" as datetime);
+-- result:
+2000-02-29 00:00:00
+-- !result
+select cast("2000.02.28" as datetime);
+-- result:
+2000-02-28 00:00:00
+-- !result
+select cast("2021.02.28" as datetime);
+-- result:
+2021-02-28 00:00:00
+-- !result
+select cast("2100.02.28" as datetime);
+-- result:
+2100-02-28 00:00:00
+-- !result
+select cast("invalid" as datetime);
+-- result:
+None
+-- !result
+select cast("2021.02.29" as datetime);
+-- result:
+None
+-- !result
+select cast("2100.02.29" as datetime);
+-- result:
+None
+-- !result
+select cast("?100.02.28" as datetime);
+-- result:
+None
+-- !result
+select cast("2?00.02.28" as datetime);
+-- result:
+None
+-- !result
+select cast("21?0.02.28" as datetime);
+-- result:
+None
+-- !result
+select cast("210?.02.28" as datetime);
+-- result:
+0210-02-28 00:00:00
+-- !result
+select cast("2100902.28" as datetime);
+-- result:
+None
+-- !result
+select cast("2100.?2.28" as datetime);
+-- result:
+2100-02-28 00:00:00
+-- !result
+select cast("2100.0?.28" as datetime);
+-- result:
+None
+-- !result
+select cast("2100.02928" as datetime);
+-- result:
+None
+-- !result
+select cast("2100.02.?8" as datetime);
+-- result:
+2100-02-08 00:00:00
+-- !result
+select cast("2100.02.2?" as datetime);
+-- result:
+2100-02-02 00:00:00
+-- !result

--- a/test/sql/test_function/T/test_cast_string_to_datetime
+++ b/test/sql/test_function/T/test_cast_string_to_datetime
@@ -1,0 +1,182 @@
+-- name: test_cast_string_to_datetime
+
+-- # 1.1 Prepare Table and Data.
+create table t1 (
+    k1 int NULL,
+    date_str string,
+    datetime_str string,
+    date_str_with_whitespace string,
+    datetime_str_with_whitespace string
+)
+duplicate key(k1)
+distributed by hash(k1) buckets 32;
+
+
+CREATE TABLE __row_util (
+  k1 bigint null
+) ENGINE=OLAP
+DUPLICATE KEY(`k1`)
+DISTRIBUTED BY HASH(`k1`) BUCKETS 32;
+insert into __row_util select generate_series from TABLE(generate_series(0, 10000 - 1));
+insert into __row_util select k1 + 20000 from __row_util; 
+insert into __row_util select k1 + 40000 from __row_util; 
+insert into __row_util select k1 + 80000 from __row_util; 
+
+-- ## 1.2 Insert valid date and datetime with/without whitespace.
+insert into t1
+select 
+    cast(random() *2e9 as int), 
+    cast(cast(date_add('2020-01-01', INTERVAL row_number() over() DAY) as date) as varchar),
+    concat(cast(cast(date_add('2020-01-01', INTERVAL row_number() over() DAY) as date) as varchar), ' 01:02:03'), 
+    concat('  ', cast(cast(date_add('2020-01-01', INTERVAL row_number() over() DAY) as date) as varchar), '  '), 
+    concat('   ', cast(cast(date_add('2020-01-01', INTERVAL row_number() over() DAY) as date) as varchar), ' 01:02:03  ')
+from __row_util;
+
+insert into t1 (date_str)
+values 
+    ("20200101"),
+    ("20200101010203"),
+    ("20200101T010203"),
+    ("20200101T0102033"),
+    ("20200101T010203.123"),
+
+    ("200101"),
+    ("200101010203"),
+    ("200101T010203"),
+    ("200101T0102033"),
+    ("200101T010203.123"),
+
+    ("2020.01.01"),
+    ("2020.01.01T01.02.03"),
+    ("2020.01.01T01.02.033"),
+    ("2020.01.01T01.0203.123"),
+
+    ("  20200101 "),
+    ("  20200101010203   "),
+    ("  20200101T010203"),
+    ("20200101T0102033  "),
+    ("  20200101T010203.123    \n"),
+    ("  20200101T010203.123    \n \t \v \f \r "),
+    
+    ("2020.13.29"),
+    ("2020.13.61"),
+
+    ("2020.02.29"),
+    ("2020.02.28"),
+    ("2000.02.29"),
+    ("2000.02.28"),
+
+    ("2021.02.28"),
+    ("2100.02.28"),
+
+-- ## 1.3 Insert invalid datetime.
+    ("invalid"),
+
+    ("2021.02.29"),
+    ("2100.02.29"),
+
+    ("?100.02.28"),
+    ("2?00.02.28"),
+    ("21?0.02.28"),
+    ("210?.02.28"),
+    ("2100902.28"),
+    ("2100.?2.28"),
+    ("2100.0?.28"),
+    ("2100.02928"),
+    ("2100.02.?8"),
+    ("2100.02.2?");
+    
+-- # 2. Query.
+
+-- ## 2.1 Query without null row.
+select 
+    ifnull(sum(murmur_hash3_32(
+        cast(date_str as datetime)
+    )), 0) +
+    ifnull(sum(murmur_hash3_32(
+        cast(date_str_with_whitespace as datetime)
+    )), 0) +
+    ifnull(sum(murmur_hash3_32(
+        cast(datetime_str as datetime)
+    )), 0) +
+    ifnull(sum(murmur_hash3_32(
+        cast(datetime_str_with_whitespace as datetime)
+    )), 0)
+from t1;
+
+-- ## 2.2 Query with null row.
+insert into t1
+select 
+    cast(random() *2e9 as int), 
+    null, null, null ,null
+from __row_util;
+    
+select 
+    ifnull(sum(murmur_hash3_32(
+        cast(date_str as datetime)
+    )), 0) +
+    ifnull(sum(murmur_hash3_32(
+        cast(date_str_with_whitespace as datetime)
+    )), 0) +
+    ifnull(sum(murmur_hash3_32(
+        cast(datetime_str as datetime)
+    )), 0) +
+    ifnull(sum(murmur_hash3_32(
+        cast(datetime_str_with_whitespace as datetime)
+    )), 0)
+from t1;
+
+-- ## 2.3 Query constants.
+select cast(NULL as datetime);
+select cast("20200101" as datetime);
+select cast("20200101010203" as datetime);
+select cast("20200101T010203" as datetime);
+select cast("20200101T0102033" as datetime);
+select cast("20200101T010203.123" as datetime);
+
+select cast("200101" as datetime);
+select cast("200101010203" as datetime);
+select cast("200101T010203" as datetime);
+select cast("200101T0102033" as datetime);
+select cast("200101T010203.123" as datetime);
+
+select cast("2020.01.01" as datetime);
+select cast("2020.01.01T01.02.03" as datetime);
+select cast("2020.01.01T01.02.033" as datetime);
+select cast("2020.01.01T01.0203.123" as datetime);
+
+select cast("  20200101 " as datetime);
+select cast("  20200101010203   " as datetime);
+select cast("  20200101T010203" as datetime);
+select cast("20200101T0102033  " as datetime);
+select cast("  20200101T010203.123    \n" as datetime);
+select cast("  20200101T010203.123    \n \t \v \f \r " as datetime);
+    
+select cast("2020.13.29" as datetime);
+select cast("2020.13.61" as datetime);
+
+select cast("2020.02.29" as datetime);
+select cast("2020.02.28" as datetime);
+select cast("2000.02.29" as datetime);
+select cast("2000.02.28" as datetime);
+
+select cast("2021.02.28" as datetime);
+select cast("2100.02.28" as datetime);
+
+select cast("invalid" as datetime);
+
+select cast("2021.02.29" as datetime);
+select cast("2100.02.29" as datetime);
+
+select cast("?100.02.28" as datetime);
+select cast("2?00.02.28" as datetime);
+select cast("21?0.02.28" as datetime);
+select cast("210?.02.28" as datetime);
+select cast("2100902.28" as datetime);
+select cast("2100.?2.28" as datetime);
+select cast("2100.0?.28" as datetime);
+select cast("2100.02928" as datetime);
+select cast("2100.02.?8" as datetime);
+select cast("2100.02.2?" as datetime);
+
+

--- a/test/sql/test_function/T/test_cast_string_to_datetime
+++ b/test/sql/test_function/T/test_cast_string_to_datetime
@@ -127,56 +127,56 @@ select
 from t1;
 
 -- ## 2.3 Query constants.
-select cast(NULL as datetime);
-select cast("20200101" as datetime);
-select cast("20200101010203" as datetime);
-select cast("20200101T010203" as datetime);
-select cast("20200101T0102033" as datetime);
-select cast("20200101T010203.123" as datetime);
+select cast(column_0 as datetime) from (values (NULL)) as tmp;
+select cast(column_0 as datetime) from (values ("20200101")) as tmp;
+select cast(column_0 as datetime) from (values ("20200101010203")) as tmp;
+select cast(column_0 as datetime) from (values ("20200101T010203")) as tmp;
+select cast(column_0 as datetime) from (values ("20200101T0102033")) as tmp;
+select cast(column_0 as datetime) from (values ("20200101T010203.123")) as tmp;
 
-select cast("200101" as datetime);
-select cast("200101010203" as datetime);
-select cast("200101T010203" as datetime);
-select cast("200101T0102033" as datetime);
-select cast("200101T010203.123" as datetime);
+select cast(column_0 as datetime) from (values ("200101")) as tmp;
+select cast(column_0 as datetime) from (values ("200101010203")) as tmp;
+select cast(column_0 as datetime) from (values ("200101T010203")) as tmp;
+select cast(column_0 as datetime) from (values ("200101T0102033")) as tmp;
+select cast(column_0 as datetime) from (values ("200101T010203.123")) as tmp;
 
-select cast("2020.01.01" as datetime);
-select cast("2020.01.01T01.02.03" as datetime);
-select cast("2020.01.01T01.02.033" as datetime);
-select cast("2020.01.01T01.0203.123" as datetime);
+select cast(column_0 as datetime) from (values ("2020.01.01")) as tmp;
+select cast(column_0 as datetime) from (values ("2020.01.01T01.02.03")) as tmp;
+select cast(column_0 as datetime) from (values ("2020.01.01T01.02.033")) as tmp;
+select cast(column_0 as datetime) from (values ("2020.01.01T01.0203.123")) as tmp;
 
-select cast("  20200101 " as datetime);
-select cast("  20200101010203   " as datetime);
-select cast("  20200101T010203" as datetime);
-select cast("20200101T0102033  " as datetime);
-select cast("  20200101T010203.123    \n" as datetime);
-select cast("  20200101T010203.123    \n \t \v \f \r " as datetime);
+select cast(column_0 as datetime) from (values ("  20200101 ")) as tmp;
+select cast(column_0 as datetime) from (values ("  20200101010203   ")) as tmp;
+select cast(column_0 as datetime) from (values ("  20200101T010203")) as tmp;
+select cast(column_0 as datetime) from (values ("20200101T0102033  ")) as tmp;
+select cast(column_0 as datetime) from (values ("  20200101T010203.123    \n")) as tmp;
+select cast(column_0 as datetime) from (values ("  20200101T010203.123    \n \t \v \f \r ")) as tmp;
     
-select cast("2020.13.29" as datetime);
-select cast("2020.13.61" as datetime);
+select cast(column_0 as datetime) from (values ("2020.13.29")) as tmp;
+select cast(column_0 as datetime) from (values ("2020.13.61")) as tmp;
 
-select cast("2020.02.29" as datetime);
-select cast("2020.02.28" as datetime);
-select cast("2000.02.29" as datetime);
-select cast("2000.02.28" as datetime);
+select cast(column_0 as datetime) from (values ("2020.02.29")) as tmp;
+select cast(column_0 as datetime) from (values ("2020.02.28")) as tmp;
+select cast(column_0 as datetime) from (values ("2000.02.29")) as tmp;
+select cast(column_0 as datetime) from (values ("2000.02.28")) as tmp;
 
-select cast("2021.02.28" as datetime);
-select cast("2100.02.28" as datetime);
+select cast(column_0 as datetime) from (values ("2021.02.28")) as tmp;
+select cast(column_0 as datetime) from (values ("2100.02.28")) as tmp;
 
-select cast("invalid" as datetime);
+select cast(column_0 as datetime) from (values ("invalid")) as tmp;
 
-select cast("2021.02.29" as datetime);
-select cast("2100.02.29" as datetime);
+select cast(column_0 as datetime) from (values ("2021.02.29")) as tmp;
+select cast(column_0 as datetime) from (values ("2100.02.29")) as tmp;
 
-select cast("?100.02.28" as datetime);
-select cast("2?00.02.28" as datetime);
-select cast("21?0.02.28" as datetime);
-select cast("210?.02.28" as datetime);
-select cast("2100902.28" as datetime);
-select cast("2100.?2.28" as datetime);
-select cast("2100.0?.28" as datetime);
-select cast("2100.02928" as datetime);
-select cast("2100.02.?8" as datetime);
-select cast("2100.02.2?" as datetime);
+select cast(column_0 as datetime) from (values ("?100.02.28")) as tmp;
+select cast(column_0 as datetime) from (values ("2?00.02.28")) as tmp;
+select cast(column_0 as datetime) from (values ("21?0.02.28")) as tmp;
+select cast(column_0 as datetime) from (values ("210?.02.28")) as tmp;
+select cast(column_0 as datetime) from (values ("2100902.28")) as tmp;
+select cast(column_0 as datetime) from (values ("2100.?2.28")) as tmp;
+select cast(column_0 as datetime) from (values ("2100.0?.28")) as tmp;
+select cast(column_0 as datetime) from (values ("2100.02928")) as tmp;
+select cast(column_0 as datetime) from (values ("2100.02.?8")) as tmp;
+select cast(column_0 as datetime) from (values ("2100.02.2?")) as tmp;
 
 


### PR DESCRIPTION
## Why I'm doing:
To optimize cast string to datetime.

## What I'm doing:

This PR applies the following optimizations to expressions like `CAST('2022-01-02' as DATETIME)`, resulting in a performance improvement of 35% to 40%:
1. Optimized `std::isspace` with a handwritten version.
2. Simplified the logic in `from_string_to_date_internal`.
3. Removed the range checks for year, month, and day in `from_string_to_date_internal`, as these checks were a bottleneck and are already performed by the caller.
4. Pre-allocated the data_column and null_column for the result.
5. If the input string is found to contain only the date part, then the calculations and validity checks for hour, minute, second, and microsecond are skipped.

perf CPU before PR:
![image](https://github.com/StarRocks/starrocks/assets/13313784/93afb3fa-ecfd-42d5-af5c-071843b686b8)

perf CPU after CPU:
![image](https://github.com/StarRocks/starrocks/assets/13313784/e694031d-3c5c-425a-a4e6-6c9b268e30e4)


## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
