### PR TITLE
[Enhancement] Support complex type in column with row

### DIFF
--- a/be/src/column/object_column.h
+++ b/be/src/column/object_column.h
@@ -22,6 +22,7 @@
 #include "common/object_pool.h"
 #include "types/bitmap_value.h"
 #include "types/hll.h"
+#include "util/json.h"
 #include "util/percentile_value.h"
 
 namespace starrocks {
@@ -121,6 +122,8 @@ public:
                          uint32_t max_one_row_size) override;
 
     const uint8_t* deserialize_and_append(const uint8_t* pos) override;
+
+    bool deserialize_and_append(const Slice& src);
 
     void deserialize_and_append_batch(Buffer<Slice>& srcs, size_t chunk_size) override;
 

--- a/be/src/storage/row_store_encoder.cpp
+++ b/be/src/storage/row_store_encoder.cpp
@@ -47,6 +47,13 @@ bool RowStoreEncoder::is_field_supported(const Field& f) {
     case TYPE_DECIMALV2:
     case TYPE_FLOAT:
     case TYPE_DOUBLE:
+    case TYPE_JSON:
+    case TYPE_HLL:
+    case TYPE_OBJECT:
+    case TYPE_PERCENTILE:
+    case TYPE_ARRAY:
+    case TYPE_STRUCT:
+    case TYPE_MAP:
         return true;
     default:
         return false;

--- a/be/src/storage/row_store_encoder_simple.cpp
+++ b/be/src/storage/row_store_encoder_simple.cpp
@@ -17,6 +17,7 @@
 #include "column/binary_column.h"
 #include "column/chunk.h"
 #include "column/fixed_length_column.h"
+#include "column/object_column.h"
 #include "column/schema.h"
 #include "common/status.h"
 #include "gutil/endian.h"
@@ -146,14 +147,34 @@ Status RowStoreEncoderSimple::decode_columns_from_full_row_column(const Schema& 
             auto s_offset = reinterpret_cast<const uint8_t*>(s.data);
             int32_t col_length = offsets[idx];
             // char(n) need strip trailing '\x00'
-            if (schema.field(j)->type()->type() == TYPE_CHAR) {
+            auto t = schema.field(j)->type()->type();
+            if (t == TYPE_CHAR) {
                 // slice : 0x0 (column separator) + col length (4) + char(n) value
                 auto char_start = s.data + 1 + 4;
                 Slice slice(char_start, strnlen(char_start, col_length));
                 dest_column->append_datum(slice);
+            } else if (t == TYPE_HLL) {
+                ObjectColumn<HyperLogLog>* object_column = down_cast<ObjectColumn<HyperLogLog>*>(dest_column);
+                Slice slice(s.data, col_length);
+                if (!object_column->deserialize_and_append(slice)) {
+                    return Status::InternalError("deserialize_and_append failed");
+                }
+            } else if (t == TYPE_PERCENTILE) {
+                ObjectColumn<PercentileValue>* object_column = down_cast<ObjectColumn<PercentileValue>*>(dest_column);
+                Slice slice(s.data, col_length);
+                if (!object_column->deserialize_and_append(slice)) {
+                    return Status::InternalError("deserialize_and_append failed");
+                }
+            } else if (t == TYPE_OBJECT) {
+                ObjectColumn<BitmapValue>* object_column = down_cast<ObjectColumn<BitmapValue>*>(dest_column);
+                Slice slice(s.data, col_length);
+                if (!object_column->deserialize_and_append(slice)) {
+                    return Status::InternalError("deserialize_and_append failed");
+                }
             } else {
                 Slice slice(s.data, col_length);
-                dest_column->deserialize_and_append(s_offset);
+                auto pos = dest_column->deserialize_and_append(s_offset);
+                DCHECK_EQ(pos, s_offset + col_length);
             }
             s.remove_prefix(col_length);
             cur_read_idx++;

--- a/fe/fe-core/src/main/java/com/starrocks/common/util/PropertyAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/util/PropertyAnalyzer.java
@@ -562,12 +562,6 @@ public class PropertyAnalyzer {
                 if (olapTable.getColumns().stream().filter(column -> !column.isKey()).count() == 0) {
                     throw new AnalysisException("column_with_row storage type must have some non-key columns");
                 }
-                for (Column column : olapTable.getColumns()) {
-                    if (!column.isKey() && column.getType().isComplexType()) {
-                        throw new AnalysisException(
-                                "column_with_row storage type does not support complex type. column: " + column.getName());
-                    }
-                }
             } else {
                 throw new AnalysisException(storageType + " for " + olapTable.getKeysType() + " table not supported");
             }

--- a/fe/fe-core/src/test/java/com/starrocks/pseudocluster/PseudoClusterTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/pseudocluster/PseudoClusterTest.java
@@ -85,15 +85,10 @@ public class PseudoClusterTest {
             } catch (Exception e) {
                 Assert.assertTrue(e.getMessage().contains("column_with_row storage type must have some non-key columns"));
             }
-            try {
-                stmt.execute("create table test2 ( pk bigint NOT NULL, v array<int> NOT NULL) " +
-                        "primary KEY (pk) DISTRIBUTED BY HASH(pk) BUCKETS 7 " +
-                        "PROPERTIES(\"replication_num\" = \"3\", \"storage_medium\" = \"SSD\", " +
-                        "\"storage_type\" = \"column_with_row\")");
-                Assert.fail("should throw exception");
-            } catch (Exception e) {
-                Assert.assertTrue(e.getMessage().contains("column_with_row storage type does not support complex type"));
-            }
+            stmt.execute("create table test2 ( pk bigint NOT NULL, v1 array<int> NOT NULL, v2 bitmap NOT NULL) " +
+                    "primary KEY (pk) DISTRIBUTED BY HASH(pk) BUCKETS 7 " +
+                    "PROPERTIES(\"replication_num\" = \"3\", \"storage_medium\" = \"SSD\", " +
+                    "\"storage_type\" = \"column_with_row\")");
             stmt.execute("create table test3 ( pk bigint NOT NULL, v int NOT NULL) " +
                     "primary KEY (pk) DISTRIBUTED BY HASH(pk) BUCKETS 7 " +
                     "PROPERTIES(\"replication_num\" = \"3\", \"storage_medium\" = \"SSD\", " +


### PR DESCRIPTION
## Why I'm doing:

Currently, column with row storage type does not support complex types like bitmap, array, struct, bitmap

## What I'm doing:

Support those types

Fixes #38174 #38090

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
