### PR TITLE
[BugFix] Fix join on-subquery cast error

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/SubqueryRelation.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/SubqueryRelation.java
@@ -52,6 +52,10 @@ public class SubqueryRelation extends QueryRelation {
         return alias == null ? "anonymous" : alias.toString();
     }
 
+    public boolean isAnonymous() {
+        return alias == null;
+    }
+
     @Override
     public List<Expr> getOutputExpression() {
         return this.queryStatement.getQueryRelation().getOutputExpression();

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/transformer/RelationTransformer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/transformer/RelationTransformer.java
@@ -1023,9 +1023,7 @@ public class RelationTransformer extends AstVisitor<LogicalPlan, ExpressionMappi
             return true;
         }
 
-        Subquery subquery = subqueries.get(0);
-        QueryStatement subqueryStmt = subquery.getQueryStatement();
-        SelectRelation selectRelation = (SelectRelation) subqueryStmt.getQueryRelation();
+        SelectRelation selectRelation = extractSubqueryRelation(subqueries);
         RelationId subqueryRelationId = selectRelation.getRelation().getScope().getRelationId();
         List<FieldId> correlatedFieldIds = selectRelation.getColumnReferences().values().stream()
                 .filter(field -> !Objects.equals(subqueryRelationId, field.getRelationId()))
@@ -1083,5 +1081,16 @@ public class RelationTransformer extends AstVisitor<LogicalPlan, ExpressionMappi
         }
 
         return usingLeftRelation;
+    }
+
+    private static SelectRelation extractSubqueryRelation(List<Subquery> subqueries) {
+        Subquery subquery = subqueries.get(0);
+        QueryStatement subqueryStmt = subquery.getQueryStatement();
+        while ((subqueryStmt.getQueryRelation() instanceof SubqueryRelation) &&
+                ((SubqueryRelation) subqueryStmt.getQueryRelation()).isAnonymous()) {
+            // Eliminate anonymous subqueries, like a in (((( select... ))))
+            subqueryStmt = ((SubqueryRelation) subqueryStmt.getQueryRelation()).getQueryStatement();
+        }
+        return (SelectRelation) subqueryStmt.getQueryRelation();
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/JoinTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/JoinTest.java
@@ -3184,4 +3184,17 @@ public class JoinTest extends PlanTestBase {
         String plan = getFragmentPlan(query);
         assertContainsIgnoreColRefs(plan, "other join predicates: 4: v1 = 1: v1");
     }
+
+    @Test
+    public void testJoinOnAnonymousSubquery() throws Exception {
+        String query = "select 'a' " +
+                "FROM t0 join t1 on t0.v2 = t1.v5 and t1.v6 in ((((" +
+                "(select v8 from t2)" +
+                "))))";
+        String plan = getFragmentPlan(query);
+        assertContains(plan, "HASH JOIN\n" +
+                "  |  join op: LEFT SEMI JOIN (BROADCAST)\n" +
+                "  |  colocate: false, reason: \n" +
+                "  |  equal join conjunct: 6: v6 = 8: v8");
+    }
 }


### PR DESCRIPTION
## Why I'm doing:

like sql:

a join b on xxx in ((((()))))....

```
java.lang.ClassCastException: class com.starrocks.sql.ast.SubqueryRelation cannot be cast to class com.starrocks.sql.ast.SelectRelation (com.starrocks.sql.ast.SubqueryRelation and com.starrocks.sql.ast.SelectRelation are in unnamed module of loader 'app')

	at com.starrocks.sql.optimizer.transformer.RelationTransformer.extractSubqueryRelation(RelationTransformer.java:1094)
	at com.starrocks.sql.optimizer.transformer.RelationTransformer.isJoinLeftRelatedSubquery(RelationTransformer.java:1026)
	at com.starrocks.sql.optimizer.transformer.RelationTransformer.parseJoinOnPredicate(RelationTransformer.java:939)
	at com.starrocks.sql.optimizer.transformer.RelationTransformer.visitJoin(RelationTransformer.java:796)
	at com.starrocks.sql.optimizer.transformer.RelationTransformer.visitJoin(RelationTransformer.java:142)
	at com.starrocks.sql.ast.JoinRelation.accept(JoinRelation.java:134)
	at com.starrocks.sql.ast.AstVisitor.visit(AstVisitor.java:68)
	at com.starrocks.sql.ast.AstVisitor.visit(AstVisitor.java:64)
	at com.starrocks.sql.optimizer.transformer.QueryTransformer.planFrom(QueryTransformer.java:165)
	at com.starrocks.sql.optimizer.transformer.QueryTransformer.plan(QueryTransformer.java:80)
	at com.starrocks.sql.optimizer.transformer.RelationTransformer.visitSelect(RelationTransformer.java:259)
	at com.starrocks.sql.optimizer.transformer.RelationTransformer.visitSelect(RelationTransformer.java:142)
	at com.starrocks.sql.ast.SelectRelation.accept(SelectRelation.java:242)
	at com.starrocks.sql.ast.AstVisitor.visit(AstVisitor.java:68)
	at com.starrocks.sql.ast.AstVisitor.visit(AstVisitor.java:64)
	at com.starrocks.sql.optimizer.transformer.RelationTransformer.transform(RelationTransformer.java:209)
	at com.starrocks.sql.optimizer.transformer.RelationTransformer.transformWithSelectLimit(RelationTransformer.java:177)
	at com.starrocks.sql.StatementPlanner.createQueryPlanWithReTry(StatementPlanner.java:241)
	at com.starrocks.sql.StatementPlanner.plan(StatementPlanner.java:134)
	at com.starrocks.sql.StatementPlanner.plan(StatementPlanner.java:91)
	at com.starrocks.utframe.UtFrameUtils.buildPlan(UtFrameUtils.java:486)
	at com.starrocks.utframe.UtFrameUtils.getPlanAndFragment(UtFrameUtils.java:527)
	at com.starrocks.sql.plan.PlanTestNoneDBBase.getFragmentPlan(PlanTestNoneDBBase.java:249)
	at com.starrocks.sql.plan.JoinTest.testJoinOnAnonymousSubquery(JoinTest.java:3194)
```

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [x] 3.1
  - [x] 3.0
  - [x] 2.5
