### PR TITLE
[BugFix] fix refresh iceberg mv with expired snapshot

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/connector/ConnectorPartitionTraits.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/ConnectorPartitionTraits.java
@@ -283,7 +283,9 @@ public abstract class ConnectorPartitionTraits {
                     long basePartitionVersion = latestPartitionInfo.get(basePartitionName).getModifiedTime();
 
                     MaterializedView.BasePartitionInfo basePartitionInfo = versionEntry.getValue();
-                    if (basePartitionInfo == null || basePartitionVersion != basePartitionInfo.getVersion()) {
+                    // basePartitionVersion less than 0 is illegal
+                    if ((basePartitionInfo == null || basePartitionVersion != basePartitionInfo.getVersion())
+                            && basePartitionVersion >= 0) {
                         result.add(basePartitionName);
                     }
                 }

--- a/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/IcebergMetadataTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/IcebergMetadataTest.java
@@ -1096,6 +1096,33 @@ public class IcebergMetadataTest extends TableTestBase {
     }
 
     @Test
+    public void testGetPartitionsWithExpireSnapshot() {
+        mockedNativeTableB.newAppend().appendFile(FILE_B_1).commit();
+        mockedNativeTableB.refresh();
+        mockedNativeTableB.newAppend().appendFile(FILE_B_2).commit();
+        mockedNativeTableB.refresh();
+        mockedNativeTableB.expireSnapshots().expireOlderThan(System.currentTimeMillis()).commit();
+        mockedNativeTableB.refresh();
+
+        Map<String, String> config = new HashMap<>();
+        config.put(HIVE_METASTORE_URIS, "thrift://188.122.12.1:8732");
+        config.put(ICEBERG_CATALOG_TYPE, "hive");
+        IcebergHiveCatalog icebergHiveCatalog = new IcebergHiveCatalog("iceberg_catalog", new Configuration(), config);
+        CachingIcebergCatalog cachingIcebergCatalog = new CachingIcebergCatalog(icebergHiveCatalog, 3,
+                Executors.newSingleThreadExecutor());
+        IcebergMetadata metadata = new IcebergMetadata(CATALOG_NAME, HDFS_ENVIRONMENT, cachingIcebergCatalog,
+                Executors.newSingleThreadExecutor(), Executors.newSingleThreadExecutor());
+
+        IcebergTable icebergTable = new IcebergTable(1, "srTableName", "iceberg_catalog",
+                "resource_name", "db",
+                "table", Lists.newArrayList(), mockedNativeTableB, Maps.newHashMap());
+
+        List<PartitionInfo> partitions = metadata.getPartitions(icebergTable, ImmutableList.of("k2=2", "k2=3"));
+        Assert.assertEquals(2, partitions.size());
+        Assert.assertTrue(partitions.stream().anyMatch(x -> x.getModifiedTime() == -1));
+    }
+
+    @Test
     public void testRefreshTableException(@Mocked CachingIcebergCatalog icebergCatalog) {
         new Expectations() {
             {


### PR DESCRIPTION
## Why I'm doing:

Each Iceberg data file records its snapshot id. we can get last-modified-time according to the snapshot id with iceberg sdk. If user performs the expire_snapshot procedure, the expired snapshot will be null in the iceberg partitioned table job planning. and we can't get the last modified time. 
## What I'm doing:

Fixes #issue
https://github.com/StarRocks/starrocks/issues/41335

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [x] 3.1
  - [ ] 3.0
  - [ ] 2.5
