### PR TITLE
[Enhancement] Remove persistent index dir when persistent index is disabled (backport #37284)

### DIFF
--- a/be/src/storage/lake/lake_primary_index.h
+++ b/be/src/storage/lake/lake_primary_index.h
@@ -32,7 +32,7 @@ class LakePrimaryIndex : public PrimaryIndex {
 public:
     LakePrimaryIndex() : PrimaryIndex() {}
     LakePrimaryIndex(const Schema& pk_schema) : PrimaryIndex(pk_schema) {}
-    ~LakePrimaryIndex() {}
+    ~LakePrimaryIndex() override;
 
     // Fetch all primary keys from the tablet associated with this index into memory
     // to build a hash index.
@@ -57,6 +57,10 @@ public:
         return nullptr;
     }
 
+    void set_enable_persistent_index(bool enable_persistent_index) {
+        _enable_persistent_index = enable_persistent_index;
+    }
+
 private:
     Status _do_lake_load(Tablet* tablet, const TabletMetadata& metadata, int64_t base_version,
                          const MetaFileBuilder* builder);
@@ -66,6 +70,7 @@ private:
     int64_t _data_version = 0;
     // make sure at most 1 thread is read or write primary index
     std::mutex _mutex;
+    bool _enable_persistent_index = false;
 };
 
 } // namespace lake

--- a/be/src/storage/lake/local_pk_index_manager.h
+++ b/be/src/storage/lake/local_pk_index_manager.h
@@ -35,11 +35,11 @@ public:
 
     static void evict(UpdateManager* update_manager, DataDir* data_dir, std::set<std::string>& tablet_ids);
 
+    // remove pk index meta first, and if success then remove dir.
+    static Status clear_persistent_index(int64_t tablet_id);
+
 private:
     static bool need_evict_tablet(const std::string& tablet_pk_path);
-
-    // remove pk index meta first, and if success then remove dir.
-    static Status clear_persistent_index(DataDir* data_dir, int64_t tablet_id, const std::string& dir);
 };
 
 } // namespace lake

--- a/be/src/storage/lake/txn_log_applier.cpp
+++ b/be/src/storage/lake/txn_log_applier.cpp
@@ -229,6 +229,8 @@ private:
                 if (_metadata->enable_persistent_index() != alter_meta.enable_persistent_index()) {
                     _metadata->set_enable_persistent_index(alter_meta.enable_persistent_index());
 
+                    _tablet.update_mgr()->set_enable_persistent_index(_tablet.id(),
+                                                                      alter_meta.enable_persistent_index());
                     // Try remove index from index cache
                     // If tablet is doing apply rowset right now, remove primary index from index cache may be failed
                     // because the primary index is available in cache

--- a/be/src/storage/lake/update_manager.cpp
+++ b/be/src/storage/lake/update_manager.cpp
@@ -18,6 +18,8 @@
 #include "gen_cpp/lake_types.pb.h"
 #include "storage/chunk_helper.h"
 #include "storage/del_vector.h"
+#include "storage/lake/lake_local_persistent_index.h"
+#include "storage/lake/local_pk_index_manager.h"
 #include "storage/lake/location_provider.h"
 #include "storage/lake/meta_file.h"
 #include "storage/lake/tablet.h"
@@ -818,6 +820,15 @@ void UpdateManager::preload_compaction_state(const TxnLog& txnlog, Tablet* table
         _compaction_cache.release(compaction_entry);
     }
     TEST_SYNC_POINT("UpdateManager::preload_compaction_state:return");
+}
+
+void UpdateManager::set_enable_persistent_index(int64_t tablet_id, bool enable_persistent_index) {
+    auto index_entry = _index_cache.get(tablet_id);
+    if (index_entry != nullptr) {
+        auto& index = index_entry->value();
+        index.set_enable_persistent_index(enable_persistent_index);
+        _index_cache.release(index_entry);
+    }
 }
 
 } // namespace starrocks::lake

--- a/be/src/storage/lake/update_manager.h
+++ b/be/src/storage/lake/update_manager.h
@@ -153,6 +153,8 @@ public:
 
     void try_remove_cache(uint32_t tablet_id, int64_t txn_id);
 
+    void set_enable_persistent_index(int64_t tablet_id, bool enable_persistent_index);
+
 private:
     // print memory tracker state
     void _print_memory_stats();

--- a/be/src/storage/primary_index.h
+++ b/be/src/storage/primary_index.h
@@ -41,7 +41,7 @@ public:
 
     PrimaryIndex();
     PrimaryIndex(const Schema& pk_schema);
-    ~PrimaryIndex();
+    virtual ~PrimaryIndex();
 
     // Fetch all primary keys from the tablet associated with this index into memory
     // to build a hash index.

--- a/be/test/storage/lake/alter_tablet_meta_test.cpp
+++ b/be/test/storage/lake/alter_tablet_meta_test.cpp
@@ -16,8 +16,10 @@
 
 #include "agent/agent_task.h"
 #include "fs/fs_util.h"
+#include "storage/chunk_helper.h"
 #include "storage/lake/schema_change.h"
 #include "storage/lake/tablet_manager.h"
+#include "storage/lake/tablet_writer.h"
 #include "test_util.h"
 #include "testutil/id_generator.h"
 
@@ -35,6 +37,33 @@ public:
         auto base_schema = _tablet_metadata->mutable_schema();
         base_schema->set_id(next_id());
         base_schema->set_keys_type(KeysType::PRIMARY_KEYS);
+
+        //
+        //  | column | type | KEY | NULL |
+        //  +--------+------+-----+------+
+        //  |   c0   |  INT | YES |  NO  |
+        //  |   c1   |  INT | NO  |  NO  |
+        base_schema->set_id(next_id());
+        base_schema->set_num_short_key_columns(1);
+        auto c0 = base_schema->add_column();
+        {
+            c0->set_unique_id(next_id());
+            c0->set_name("c0");
+            c0->set_type("INT");
+            c0->set_is_key(true);
+            c0->set_is_nullable(false);
+        }
+        auto c1 = base_schema->add_column();
+        {
+            c1->set_unique_id(next_id());
+            c1->set_name("c1");
+            c1->set_type("INT");
+            c1->set_is_key(false);
+            c1->set_is_nullable(false);
+            c1->set_aggregation("REPLACE");
+        }
+        _tablet_schema = TabletSchema::create(*base_schema);
+        _schema = std::make_shared<Schema>(ChunkHelper::convert_schema(*_tablet_schema));
     }
 
     void SetUp() override {
@@ -49,6 +78,8 @@ protected:
     constexpr static const char* const kTestDirectory = "test_alter_tablet_meta";
 
     std::unique_ptr<TabletMetadata> _tablet_metadata;
+    std::shared_ptr<TabletSchema> _tablet_schema;
+    std::shared_ptr<Schema> _schema;
 };
 
 TEST_F(AlterTabletMetaTest, test_missing_txn_id) {
@@ -70,7 +101,7 @@ TEST_F(AlterTabletMetaTest, test_missing_txn_id) {
 TEST_F(AlterTabletMetaTest, test_alter_enable_persistent_index) {
     lake::SchemaChangeHandler handler(_tablet_mgr.get());
     TUpdateTabletMetaInfoReq update_tablet_meta_req;
-    int64_t txn_id = 1;
+    int64_t txn_id = next_id();
     update_tablet_meta_req.__set_txn_id(txn_id);
 
     TTabletMetaInfo tablet_meta_info;
@@ -86,7 +117,42 @@ TEST_F(AlterTabletMetaTest, test_alter_enable_persistent_index) {
     ASSERT_OK(new_tablet_meta.status());
     ASSERT_EQ(true, new_tablet_meta.value()->enable_persistent_index());
 
-    int64_t txn_id2 = txn_id + 1;
+    txn_id = next_id();
+    std::vector<int> k0{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22};
+    std::vector<int> v0{2, 4, 6, 8, 10, 12, 14, 16, 18, 20, 22, 24, 26, 28, 30, 32, 34, 36, 38, 40, 41, 44};
+    auto c0 = Int32Column::create();
+    auto c1 = Int32Column::create();
+    c0->append_numbers(k0.data(), k0.size() * sizeof(int));
+    c1->append_numbers(v0.data(), v0.size() * sizeof(int));
+    Chunk chunk0({c0, c1}, _schema);
+    auto rowset_txn_meta = std::make_unique<RowsetTxnMetaPB>();
+    ASSIGN_OR_ABORT(auto tablet, _tablet_mgr->get_tablet(_tablet_metadata->id()));
+    std::shared_ptr<const TabletSchema> const_schema = _tablet_schema;
+    ASSIGN_OR_ABORT(auto writer, tablet.new_writer(kHorizontal, txn_id));
+    ASSERT_OK(writer->open());
+    // write segment #1
+    ASSERT_OK(writer->write(chunk0));
+    ASSERT_OK(writer->finish());
+    // write txnlog
+    auto txn_log = std::make_shared<TxnLog>();
+    txn_log->set_tablet_id(_tablet_metadata->id());
+    txn_log->set_txn_id(txn_id);
+    auto op_write = txn_log->mutable_op_write();
+    for (auto& f : writer->files()) {
+        op_write->mutable_rowset()->add_segments(std::move(f.path));
+    }
+    op_write->mutable_rowset()->set_num_rows(writer->num_rows());
+    op_write->mutable_rowset()->set_data_size(writer->data_size());
+    op_write->mutable_rowset()->set_overlapped(false);
+    ASSERT_OK(_tablet_mgr->put_txn_log(txn_log));
+    writer->close();
+    ASSERT_OK(publish_single_version(_tablet_metadata->id(), 3, txn_id).status());
+    auto data_dir = StorageEngine::instance()->get_persistent_index_store(tablet_id);
+    ASSERT_TRUE(data_dir != nullptr);
+    ASSERT_OK(FileSystem::Default()->path_exists(data_dir->get_persistent_index_path() + "/" +
+                                                 std::to_string(tablet_id)));
+
+    int64_t txn_id2 = next_id();
     TUpdateTabletMetaInfoReq update_tablet_meta_req2;
     update_tablet_meta_req2.__set_txn_id(txn_id2);
 
@@ -98,9 +164,13 @@ TEST_F(AlterTabletMetaTest, test_alter_enable_persistent_index) {
     update_tablet_meta_req2.tabletMetaInfos.push_back(tablet_meta_info2);
     ASSERT_OK(handler.process_update_tablet_meta(update_tablet_meta_req2));
 
-    auto new_tablet_meta2 = publish_single_version(tablet_id, 3, txn_id2);
+    auto new_tablet_meta2 = publish_single_version(tablet_id, 4, txn_id2);
     ASSERT_OK(new_tablet_meta2.status());
     ASSERT_EQ(false, new_tablet_meta2.value()->enable_persistent_index());
+    data_dir = StorageEngine::instance()->get_persistent_index_store(tablet_id);
+    ASSERT_TRUE(data_dir != nullptr);
+    ASSERT_ERROR(FileSystem::Default()->path_exists(data_dir->get_persistent_index_path() + "/" +
+                                                    std::to_string(tablet_id)));
 }
 
 TEST_F(AlterTabletMetaTest, test_alter_enable_persistent_index_not_change) {


### PR DESCRIPTION
## Why I'm doing:
The persistent index dir is not removed when persistent index is disabled. https://github.com/StarRocks/starrocks/pull/32184 can not handled this scenario because the tablet is still in worker.
## What I'm doing:
Remove persistent index dir synchronously when persistent index is disabled.
Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [x] This is a backport pr

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5

