### PR TITLE
[BugFix] Fix lake primary index compilation error

### DIFF
--- a/be/src/storage/lake/local_pk_index_manager.h
+++ b/be/src/storage/lake/local_pk_index_manager.h
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifdef USE_STAROS
 #pragma once
 
 #include <set>
@@ -29,6 +28,7 @@ namespace lake {
 
 class UpdateManager;
 
+#ifdef USE_STAROS
 class LocalPkIndexManager {
 public:
     static void gc(UpdateManager* update_manager, DataDir* data_dir, std::set<std::string>& tablet_ids);
@@ -41,8 +41,20 @@ public:
 private:
     static bool need_evict_tablet(const std::string& tablet_pk_path);
 };
+#else
+class LocalPkIndexManager {
+public:
+    static void gc(UpdateManager* update_manager, DataDir* data_dir, std::set<std::string>& tablet_ids) {}
+
+    static void evict(UpdateManager* update_manager, DataDir* data_dir, std::set<std::string>& tablet_ids) {}
+
+    // remove pk index meta first, and if success then remove dir.
+    static Status clear_persistent_index(int64_t tablet_id) {}
+
+private:
+    static bool need_evict_tablet(const std::string& tablet_pk_path) {}
+};
+#endif // USE_STAROS
 
 } // namespace lake
 } // namespace starrocks
-
-#endif // USE_STAROS


### PR DESCRIPTION
## Why I'm doing:
Fix lake primary index compilation error without using staros
## What I'm doing:
Add default implementation for LocalPkIndexManager without using staros
Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [x] 3.1
  - [ ] 3.0
  - [ ] 2.5
