### PR TITLE
[Enhancement] Change the parameter strict_mode to null_if_not_found of dict_mapping function(#40897)

### DIFF
--- a/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/DictQueryFunctionTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/DictQueryFunctionTest.java
@@ -129,7 +129,7 @@ public class DictQueryFunctionTest {
 
         testDictMappingFunction(
                 "SELECT dict_mapping('dict.dict_table', 'key', '2023-05-06', 'value', 'extra');",
-                "dict_mapping function strict_mode param should be bool constant.");
+                "dict_mapping function null_if_not_found param should be bool constant.");
 
         testDictMappingFunction(
                 "SELECT dict_mapping('dict.dict_table', 'key', CAST('2023-05-06' AS datetime), 'v');",

--- a/test/sql/test_dict_mapping_function/R/test_dict_mapping_function
+++ b/test/sql/test_dict_mapping_function/R/test_dict_mapping_function
@@ -123,7 +123,7 @@ PROPERTIES (
 );
 -- result:
 -- !result
-INSERT INTO t VALUES (1, NULL), (2, "abc");
+INSERT INTO t VALUES (1, NULL);
 -- result:
 -- !result
 SELECT dict_mapping("dict", col_1, col_2) FROM t;
@@ -264,5 +264,48 @@ PROPERTIES (
 E: (1064, 'Getting analyzing error. Detail message: column:COL_1 does not exist.')
 -- !result
 DROP DATABASE test_dictmapping_generated_column_in_create_table;
+-- result:
+-- !result
+-- name: test_dictmapping_null_if_not_found
+CREATE DATABASE test_dictmapping_null_if_not_found;
+-- result:
+-- !result
+USE test_dictmapping_null_if_not_found;
+-- result:
+-- !result
+CREATE TABLE `t_dictmapping_null_if_not_found` (
+  `k` BIGINT NOT NULL COMMENT "",
+  `v` BIGINT AUTO_INCREMENT
+) ENGINE=OLAP 
+PRIMARY KEY(`k`)
+DISTRIBUTED BY HASH(`k`) BUCKETS 1
+PROPERTIES (
+"replication_num" = "1",
+"in_memory" = "false",
+"enable_persistent_index" = "false",
+"replicated_storage" = "true",
+"compression" = "LZ4"
+);
+-- result:
+-- !result
+insert into t_dictmapping_null_if_not_found values (1,default);
+-- result:
+-- !result
+select dict_mapping("t_dictmapping_null_if_not_found", 2);
+-- result:
+E: (1064, 'query failed if record not exist in dict table.')
+-- !result
+select dict_mapping("t_dictmapping_null_if_not_found", 2, false);
+-- result:
+E: (1064, 'query failed if record not exist in dict table.')
+-- !result
+select dict_mapping("t_dictmapping_null_if_not_found", 2, true);
+-- result:
+None
+-- !result
+drop table t_dictmapping_null_if_not_found;
+-- result:
+-- !result
+drop database test_dictmapping_null_if_not_found;
 -- result:
 -- !result

--- a/test/sql/test_dict_mapping_function/T/test_dict_mapping_function
+++ b/test/sql/test_dict_mapping_function/T/test_dict_mapping_function
@@ -82,7 +82,7 @@ PROPERTIES (
 "replication_num" = "1"
 );
 
-INSERT INTO t VALUES (1, NULL), (2, "abc");
+INSERT INTO t VALUES (1, NULL);
 
 SELECT dict_mapping("dict", col_1, col_2) FROM t;
 
@@ -164,3 +164,30 @@ PROPERTIES (
 );
 
 DROP DATABASE test_dictmapping_generated_column_in_create_table;
+
+-- name: test_dictmapping_null_if_not_found
+CREATE DATABASE test_dictmapping_null_if_not_found;
+USE test_dictmapping_null_if_not_found;
+
+CREATE TABLE `t_dictmapping_null_if_not_found` (
+  `k` BIGINT NOT NULL COMMENT "",
+  `v` BIGINT AUTO_INCREMENT
+) ENGINE=OLAP 
+PRIMARY KEY(`k`)
+DISTRIBUTED BY HASH(`k`) BUCKETS 1
+PROPERTIES (
+"replication_num" = "1",
+"in_memory" = "false",
+"enable_persistent_index" = "false",
+"replicated_storage" = "true",
+"compression" = "LZ4"
+);
+
+insert into t_dictmapping_null_if_not_found values (1,default);
+
+select dict_mapping("t_dictmapping_null_if_not_found", 2);
+select dict_mapping("t_dictmapping_null_if_not_found", 2, false);
+select dict_mapping("t_dictmapping_null_if_not_found", 2, true);
+
+drop table t_dictmapping_null_if_not_found;
+drop database test_dictmapping_null_if_not_found;


### PR DESCRIPTION
The last optional parameter for dict_mapping is strict_mode(boolean), and its behavior if following:

If strict_mode is True : return an exception if the key is not found in dictionary table.
If strict_mode is False(Default) : return null if the key is not found in dictionary table.

We change the strict_mode into null_if_not_found to make more clear for user to use this function, and the behavior of null_if_not_found is following:
If null_if_not_found is True : return null if the key is not found in dictionary table.
If null_if_not_found is False(Default) : return an exception if the key is not found in dictionary table.

Fixes #40897

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [x] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
