### PR TITLE
[BugFix] Fix NPE when querying view definition

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/service/FrontendServiceImpl.java
+++ b/fe/fe-core/src/main/java/com/starrocks/service/FrontendServiceImpl.java
@@ -515,7 +515,7 @@ public class FrontendServiceImpl implements FrontendService.Iface {
                                 if (tbl != null) {
                                     try {
                                         Authorizer.checkAnyActionOnTableLikeObject(currentUser,
-                                                null, tableName.getDb(), tbl);
+                                                null, db.getFullName(), tbl);
                                     } catch (AccessDeniedException e) {
                                         continue OUTER;
                                     }


### PR DESCRIPTION
## Why I'm doing:
If the result `TableName` of `view.getTableRefs()` doesn't
contain db name, privilege checking will throw an NPE.
```
java.lang.NullPointerException: null
	at com.google.common.base.Preconditions.checkNotNull(Preconditions.java:903) ~[spark-dpp-1.0.0.jar:?]
	at com.starrocks.privilege.NativeAccessControl.checkAnyActionOnTable(NativeAccessControl.java:105) ~[starrocks-fe.jar:?]
	at com.starrocks.sql.analyzer.Authorizer.checkAnyActionOnTable(Authorizer.java:135) ~[starrocks-fe.jar:?]
	at com.starrocks.sql.analyzer.Authorizer.doCheckTableLikeObject(Authorizer.java:190) ~[starrocks-fe.jar:?]
	at com.starrocks.sql.analyzer.Authorizer.checkAnyActionOnTableLikeObject(Authorizer.java:169) ~[starrocks-fe.jar:?]
	at com.starrocks.service.FrontendServiceImpl.listTableStatus(FrontendServiceImpl.java:454) ~[starrocks-fe.jar:?]
```

## What I'm doing:
Shouldn't rely on `tableName.getDb()`, we can use the `db.getFullName()`
directly.

Fixes SSU-1200

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [x] 3.1
  - [ ] 3.0
  - [ ] 2.5
