### PR TITLE
[Enhancement] Scale Backends for connector sink when writing static partition tables

### DIFF
--- a/be/src/exec/pipeline/exchange/exchange_sink_operator.cpp
+++ b/be/src/exec/pipeline/exchange/exchange_sink_operator.cpp
@@ -101,6 +101,8 @@ public:
     size_t _channel_total_bytes = 0;
 
     bool is_local();
+    // For UT Only
+    void set_is_local(bool is_local) { _ignore_local_data = is_local; }
 
 private:
     Status _close_internal(RuntimeState* state, FragmentContext* fragment_ctx);
@@ -788,6 +790,15 @@ int64_t ExchangeSinkOperator::construct_brpc_attachment(const PTransmitChunkPara
     }
 
     return attachment_physical_bytes;
+}
+
+// For UT Only
+void ExchangeSinkOperator::set_is_local(bool is_local) {
+    for (Channel* channel : _channels) {
+        if (channel != nullptr) {
+            channel->set_is_local(is_local);
+        }
+    }
 }
 
 ExchangeSinkOperatorFactory::ExchangeSinkOperatorFactory(

--- a/be/src/exec/pipeline/exchange/exchange_sink_operator.h
+++ b/be/src/exec/pipeline/exchange/exchange_sink_operator.h
@@ -84,6 +84,9 @@ public:
     // Return the physical bytes of attachment.
     int64_t construct_brpc_attachment(const PTransmitChunkParamsPtr& _chunk_request, butil::IOBuf& attachment);
 
+    // For UT Only
+    TPartitionType::type get_part_type() { return _part_type; }
+
 private:
     bool _is_large_chunk(size_t sz) const {
         // ref olap_scan_node.cpp release_large_columns

--- a/be/src/exec/pipeline/exchange/exchange_sink_operator.h
+++ b/be/src/exec/pipeline/exchange/exchange_sink_operator.h
@@ -86,6 +86,7 @@ public:
 
     // For UT Only
     TPartitionType::type get_part_type() { return _part_type; }
+    void set_is_local(bool is_local);
 
 private:
     bool _is_large_chunk(size_t sz) const {

--- a/be/src/exec/pipeline/exchange/exchange_sink_operator.h
+++ b/be/src/exec/pipeline/exchange/exchange_sink_operator.h
@@ -156,7 +156,7 @@ private:
     std::vector<int> _channel_indices;
     // Index of current channel to send to if _part_type == RANDOM.
     int32_t _curr_random_channel_idx = 0;
-
+    int32_t _curr_channel_sequence = 0;
     // Only used when broadcast
     PTransmitChunkParamsPtr _chunk_request;
     size_t _current_request_bytes = 0;

--- a/be/src/exec/pipeline/exchange/sink_buffer.h
+++ b/be/src/exec/pipeline/exchange/sink_buffer.h
@@ -98,6 +98,10 @@ public:
 
     void incr_sinker(RuntimeState* state);
 
+    bool connector_sink_need_scaling(int64_t buffer_size, int i) {
+        return (_bytes_enqueued.load() - _bytes_sent.load()) >= i * buffer_size * 1024 * 1024;
+    }
+
 private:
     using Mutex = bthread::Mutex;
 

--- a/be/test/CMakeLists.txt
+++ b/be/test/CMakeLists.txt
@@ -36,6 +36,7 @@ set(EXEC_FILES
         ./exec/iceberg/iceberg_delete_builder_test.cpp
         ./exec/iceberg/iceberg_table_sink_operator_test.cpp
         ./exec/workgroup/scan_task_queue_test.cpp
+        ./exec/pipeline/exchange_sink_operator_test.cpp
         ./exec/pipeline/pipeline_control_flow_test.cpp
         ./exec/pipeline/pipeline_driver_queue_test.cpp
         ./exec/pipeline/pipeline_file_scan_node_test.cpp

--- a/be/test/exec/pipeline/exchange_sink_operator_test.cpp
+++ b/be/test/exec/pipeline/exchange_sink_operator_test.cpp
@@ -102,7 +102,8 @@ TEST_F(ExchangeSinkOperatorTest, test_push_random_scale) {
             0, 2, std::move(mock_sink_buffer), TPartitionType::RANDOM_SCALE, destinations, false, 0, 0, id,
             std::move(partition_expr_ctxs), false, false, _fragment_context, output_columns);
     exchange_sink_operator_factory->set_runtime_state(_runtime_state);
-    auto exchange_sink_operator = exchange_sink_operator_factory->create(1, 0);
+    auto exchange_sink_operator =
+            std::static_pointer_cast<ExchangeSinkOperator>(exchange_sink_operator_factory->create(1, 0));
     auto chunk = std::make_shared<Chunk>();
     EXPECT_OK(exchange_sink_operator->push_chunk(_runtime_state, chunk));
 }

--- a/be/test/exec/pipeline/exchange_sink_operator_test.cpp
+++ b/be/test/exec/pipeline/exchange_sink_operator_test.cpp
@@ -90,6 +90,8 @@ TEST_F(ExchangeSinkOperatorTest, test_push_random_scale) {
     network_address.__set_port(9050);
     destination.__set_brpc_server(network_address);
     destinations.emplace_back(destination);
+    TPlanFragmentDestination mock_destination = destination;
+    destinations.emplace_back(mock_destination);
     std::vector<ExprContext*> partition_expr_ctxs;
     std::vector<int32_t> output_columns;
     // auto mock_sink_buffer = std::make_shared<MockSinkBuffer>(_fragment_context, destinations, false);

--- a/be/test/exec/pipeline/exchange_sink_operator_test.cpp
+++ b/be/test/exec/pipeline/exchange_sink_operator_test.cpp
@@ -46,6 +46,8 @@ protected:
         _request.query_options.__set_connector_sink_shuffle_buffer_size_mb(32);
         auto rs = std::make_unique<RuntimeState>(_request.params.query_id, _request.params.fragment_instance_id,
                                                  _request.query_options, _request.query_globals, _exec_env);
+        ASSERT_EQ(rs->query_options().connector_sink_shuffle_buffer_size_mb, 32);
+
         rs->set_func_version(0);
         _fragment_context->set_runtime_state(std::move(rs));
         _runtime_state = _fragment_context->runtime_state();
@@ -92,7 +94,8 @@ TEST_F(ExchangeSinkOperatorTest, test_push_random_scale) {
     std::vector<int32_t> output_columns;
     // auto mock_sink_buffer = std::make_shared<MockSinkBuffer>(_fragment_context, destinations, false);
     auto mock_sink_buffer = std::make_shared<SinkBuffer>(_fragment_context, destinations, false);
-    ASSERT_EQ(mock_sink_buffer->connector_sink_need_scaling(0, 0), true);
+    auto is_scaling = mock_sink_buffer->connector_sink_need_scaling(0, 0);
+    ASSERT_EQ(is_scaling, true);
 
     PlanNodeId id = 2;
     auto exchange_sink_operator_factory = std::make_shared<ExchangeSinkOperatorFactory>(

--- a/be/test/exec/pipeline/exchange_sink_operator_test.cpp
+++ b/be/test/exec/pipeline/exchange_sink_operator_test.cpp
@@ -107,6 +107,10 @@ TEST_F(ExchangeSinkOperatorTest, test_push_random_scale) {
     ASSERT_EQ(exchange_sink_operator->get_part_type(), TPartitionType::RANDOM_SCALE);
 
     auto chunk = std::make_shared<Chunk>();
+    auto col0 = ColumnHelper::create_column(TypeDescriptor::from_logical_type(LogicalType::TYPE_INT), true);
+    col0->append_datum((int32_t)1);
+    chunk->append_column(col0, 0);
+    exchange_sink_operator->set_is_local(true);
     EXPECT_OK(exchange_sink_operator->push_chunk(_runtime_state, chunk));
 }
 } // namespace starrocks::pipeline

--- a/be/test/exec/pipeline/exchange_sink_operator_test.cpp
+++ b/be/test/exec/pipeline/exchange_sink_operator_test.cpp
@@ -1,0 +1,100 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "exec/pipeline/exchange/exchange_sink_operator.h"
+
+#include <gmock/gmock.h>
+#include <gtest/gtest-param-test.h>
+#include <gtest/gtest.h>
+
+#include "exec/pipeline/query_context.h"
+#include "testutil/assert.h"
+
+namespace starrocks::pipeline {
+class ExchangeSinkOperatorTest : public testing::Test {
+protected:
+    void SetUp() override {
+        TExecPlanFragmentParams _request;
+
+        const auto& params = _request.params;
+        const auto& query_id = params.query_id;
+        const auto& fragment_id = params.fragment_instance_id;
+
+        pipeline::QueryContext* _query_ctx;
+
+        ExecEnv* _exec_env = ExecEnv::GetInstance();
+
+        _query_ctx = _exec_env->query_context_mgr()->get_or_register(query_id);
+        _query_ctx->set_query_id(query_id);
+        _query_ctx->init_mem_tracker(GlobalEnv::GetInstance()->query_pool_mem_tracker()->limit(),
+                                     GlobalEnv::GetInstance()->query_pool_mem_tracker());
+
+        _fragment_context = _query_ctx->fragment_mgr()->get_or_register(fragment_id);
+        _fragment_context->set_query_id(query_id);
+        _fragment_context->set_fragment_instance_id(fragment_id);
+        _request.query_options.__set_connector_sink_shuffle_buffer_size_mb(32);
+        auto rs = std::make_unique<RuntimeState>(_request.params.query_id, _request.params.fragment_instance_id,
+                                                 _request.query_options, _request.query_globals, _exec_env);
+        rs->set_func_version(0);
+        _fragment_context->set_runtime_state(std::move(rs));
+        _runtime_state = _fragment_context->runtime_state();
+    }
+
+    void TearDown() override {}
+
+    RuntimeState* _runtime_state;
+    FragmentContext* _fragment_context;
+    ObjectPool _pool;
+};
+
+class MockSinkBuffer : public SinkBuffer {
+public:
+    MockSinkBuffer(FragmentContext* fragment_ctx, const std::vector<TPlanFragmentDestination>& destinations,
+                   bool is_dest_merge)
+            : SinkBuffer(fragment_ctx, destinations, is_dest_merge) {}
+
+    MOCK_METHOD(Status, add_request, (TransmitChunkInfo & request));
+    MOCK_METHOD(bool, is_full, ());
+    MOCK_METHOD(void, set_finishing, ());
+    MOCK_METHOD(bool, is_finished, ());
+    MOCK_METHOD(void, update_profile, (RuntimeProfile * profile));
+    MOCK_METHOD(void, cancel_one_sinker, (RuntimeState* const state));
+    MOCK_METHOD(void, incr_sinker, (RuntimeState * state));
+    MOCK_METHOD(bool, connector_sink_need_scaling, (int64_t buffer_size, int i));
+};
+
+using ::testing::Return;
+using ::testing::ByMove;
+using ::testing::_;
+
+TEST_F(ExchangeSinkOperatorTest, test_push_chunk) {
+    std::vector<TPlanFragmentDestination> destinations;
+    TPlanFragmentDestination destination;
+    destination.__set_fragment_instance_id(_fragment_context->fragment_instance_id());
+    destination.__set_pipeline_driver_sequence(0);
+    destinations.emplace_back(destination);
+    std::vector<ExprContext*> partition_expr_ctxs;
+    std::vector<int32_t> output_columns;
+    // auto mock_sink_buffer = std::make_shared<MockSinkBuffer>(_fragment_context, destinations, false);
+    auto mock_sink_buffer = std::make_shared<SinkBuffer>(_fragment_context, destinations, false);
+    PlanNodeId id = 2;
+    auto exchange_sink_operator_factory = std::make_shared<ExchangeSinkOperatorFactory>(
+            0, 2, std::move(mock_sink_buffer), TPartitionType::RANDOM_SCALE, destinations, false, 0, 0, id,
+            std::move(partition_expr_ctxs), false, false, _fragment_context, output_columns);
+    exchange_sink_operator_factory->set_runtime_state(_runtime_state);
+    auto exchange_sink_operator = exchange_sink_operator_factory->create(0, 0);
+    auto chunk = std::make_shared<Chunk>();
+    EXPECT_OK(exchange_sink_operator->push_chunk(_runtime_state, chunk));
+}
+} // namespace starrocks::pipeline

--- a/be/test/exec/pipeline/exchange_sink_operator_test.cpp
+++ b/be/test/exec/pipeline/exchange_sink_operator_test.cpp
@@ -78,7 +78,7 @@ using ::testing::Return;
 using ::testing::ByMove;
 using ::testing::_;
 
-TEST_F(ExchangeSinkOperatorTest, test_push_chunk) {
+TEST_F(ExchangeSinkOperatorTest, test_push_random_scale) {
     std::vector<TPlanFragmentDestination> destinations;
     TPlanFragmentDestination destination;
     destination.__set_fragment_instance_id(_fragment_context->fragment_instance_id());
@@ -92,13 +92,14 @@ TEST_F(ExchangeSinkOperatorTest, test_push_chunk) {
     std::vector<int32_t> output_columns;
     // auto mock_sink_buffer = std::make_shared<MockSinkBuffer>(_fragment_context, destinations, false);
     auto mock_sink_buffer = std::make_shared<SinkBuffer>(_fragment_context, destinations, false);
-    ASSERT_EQ(mock_sink_buffer->connector_sink_need_scaling(0, 0), false);
+    ASSERT_EQ(mock_sink_buffer->connector_sink_need_scaling(0, 0), true);
+
     PlanNodeId id = 2;
     auto exchange_sink_operator_factory = std::make_shared<ExchangeSinkOperatorFactory>(
             0, 2, std::move(mock_sink_buffer), TPartitionType::RANDOM_SCALE, destinations, false, 0, 0, id,
             std::move(partition_expr_ctxs), false, false, _fragment_context, output_columns);
     exchange_sink_operator_factory->set_runtime_state(_runtime_state);
-    auto exchange_sink_operator = exchange_sink_operator_factory->create(0, 0);
+    auto exchange_sink_operator = exchange_sink_operator_factory->create(1, 0);
     auto chunk = std::make_shared<Chunk>();
     EXPECT_OK(exchange_sink_operator->push_chunk(_runtime_state, chunk));
 }

--- a/be/test/exec/pipeline/exchange_sink_operator_test.cpp
+++ b/be/test/exec/pipeline/exchange_sink_operator_test.cpp
@@ -104,6 +104,8 @@ TEST_F(ExchangeSinkOperatorTest, test_push_random_scale) {
     exchange_sink_operator_factory->set_runtime_state(_runtime_state);
     auto exchange_sink_operator =
             std::static_pointer_cast<ExchangeSinkOperator>(exchange_sink_operator_factory->create(1, 0));
+    ASSERT_EQ(exchange_sink_operator->get_part_type(), TPartitionType::RANDOM_SCALE);
+
     auto chunk = std::make_shared<Chunk>();
     EXPECT_OK(exchange_sink_operator->push_chunk(_runtime_state, chunk));
 }

--- a/be/test/exec/pipeline/exchange_sink_operator_test.cpp
+++ b/be/test/exec/pipeline/exchange_sink_operator_test.cpp
@@ -83,11 +83,16 @@ TEST_F(ExchangeSinkOperatorTest, test_push_chunk) {
     TPlanFragmentDestination destination;
     destination.__set_fragment_instance_id(_fragment_context->fragment_instance_id());
     destination.__set_pipeline_driver_sequence(0);
+    TNetworkAddress network_address;
+    network_address.__set_hostname("127.0.0.1");
+    network_address.__set_port(9050);
+    destination.__set_brpc_server(network_address);
     destinations.emplace_back(destination);
     std::vector<ExprContext*> partition_expr_ctxs;
     std::vector<int32_t> output_columns;
     // auto mock_sink_buffer = std::make_shared<MockSinkBuffer>(_fragment_context, destinations, false);
     auto mock_sink_buffer = std::make_shared<SinkBuffer>(_fragment_context, destinations, false);
+    ASSERT_EQ(mock_sink_buffer->connector_sink_need_scaling(0, 0), false);
     PlanNodeId id = 2;
     auto exchange_sink_operator_factory = std::make_shared<ExchangeSinkOperatorFactory>(
             0, 2, std::move(mock_sink_buffer), TPartitionType::RANDOM_SCALE, destinations, false, 0, 0, id,

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/HiveTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/HiveTable.java
@@ -82,6 +82,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 
 import static com.starrocks.server.CatalogMgr.ResourceMappingCatalog.getResourceMappingCatalogName;
 import static com.starrocks.server.CatalogMgr.ResourceMappingCatalog.isResourceMappingCatalog;
@@ -233,6 +234,13 @@ public class HiveTable extends Table implements HiveMetaStoreTable {
     public List<Column> getPartitionColumns() {
         return partColumnNames.stream()
                 .map(name -> nameToColumn.get(name))
+                .collect(Collectors.toList());
+    }
+
+    public List<Integer> getPartitionColumnIDs() {
+        return IntStream.range(0, fullSchema.size())
+                .filter(i -> partColumnNames.contains(fullSchema.get(i).getName()))
+                .boxed()
                 .collect(Collectors.toList());
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/planner/DataPartition.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/DataPartition.java
@@ -61,13 +61,15 @@ public class DataPartition {
 
     public static final DataPartition RANDOM = new DataPartition(TPartitionType.RANDOM);
 
+    public static final DataPartition RANDOM_SCALE = new DataPartition(TPartitionType.RANDOM_SCALE);
+
     private final TPartitionType type;
 
     // for hash partition: exprs used to compute hash value
     private ImmutableList<Expr> partitionExprs;
 
     public DataPartition(TPartitionType type, List<Expr> exprs) {
-        if (type != TPartitionType.UNPARTITIONED && type != TPartitionType.RANDOM) {
+        if (type != TPartitionType.UNPARTITIONED && type != TPartitionType.RANDOM && type != TPartitionType.RANDOM_SCALE) {
             Preconditions.checkNotNull(exprs);
             Preconditions.checkState(!exprs.isEmpty());
             Preconditions.checkState(
@@ -88,7 +90,7 @@ public class DataPartition {
 
     public DataPartition(TPartitionType type) {
         Preconditions.checkState(
-                type == TPartitionType.UNPARTITIONED || type == TPartitionType.RANDOM);
+                type == TPartitionType.UNPARTITIONED || type == TPartitionType.RANDOM || type == TPartitionType.RANDOM_SCALE);
         this.type = type;
         this.partitionExprs = ImmutableList.of();
     }

--- a/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
@@ -394,6 +394,7 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
     public static final String HIVE_PARTITION_STATS_SAMPLE_SIZE = "hive_partition_stats_sample_size";
 
     public static final String ENABLE_CONNECTOR_SINK_GLOBAL_SHUFFLE = "enable_connector_sink_global_shuffle";
+    public static final String CONNECTOR_SINK_SHUFFLE_BUFFER_SIZE_MB = "connector_sink_shuffle_buffer_size_mb";
     public static final String PIPELINE_SINK_DOP = "pipeline_sink_dop";
     public static final String ENABLE_ADAPTIVE_SINK_DOP = "enable_adaptive_sink_dop";
     public static final String RUNTIME_FILTER_SCAN_WAIT_TIME = "runtime_filter_scan_wait_time";
@@ -937,6 +938,9 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
     // Add a global shuffle between the connector sink fragment and its child fragment.
     @VariableMgr.VarAttr(name = ENABLE_CONNECTOR_SINK_GLOBAL_SHUFFLE, flag = VariableMgr.INVISIBLE)
     private boolean enableConnectorSinkGlobalShuffle = true;
+
+    @VariableMgr.VarAttr(name = CONNECTOR_SINK_SHUFFLE_BUFFER_SIZE_MB)
+    private long connectorSinkShuffleBufferSizeMb = 0;
 
     /*
      * The maximum pipeline dop limit which only takes effect when pipeline_dop=0.
@@ -2614,6 +2618,10 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
         return enableConnectorSinkGlobalShuffle;
     }
 
+    public long isExternalSinkShuffleBufferSizeMb() {
+        return connectorSinkShuffleBufferSizeMb;
+    }
+
     public void setPipelineSinkDop(int pipelineSinkDop) {
         this.pipelineSinkDop = pipelineSinkDop;
     }
@@ -3470,6 +3478,9 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
         tResult.setIo_tasks_per_scan_operator(ioTasksPerScanOperator);
         tResult.setConnector_io_tasks_per_scan_operator(connectorIoTasksPerScanOperator);
         tResult.setEnable_dynamic_prune_scan_range(enableDynamicPruneScanRange);
+        if (connectorSinkShuffleBufferSizeMb != 0) {
+            tResult.setConnector_sink_shuffle_buffer_size_mb(connectorSinkShuffleBufferSizeMb);
+        }
         tResult.setUse_page_cache(usePageCache);
 
         tResult.setEnable_connector_adaptive_io_tasks(enableConnectorAdaptiveIoTasks);

--- a/fe/fe-core/src/main/java/com/starrocks/sql/plan/PlanFragmentBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/plan/PlanFragmentBuilder.java
@@ -2062,7 +2062,7 @@ public class PlanFragmentBuilder {
                 dataPartition = DataPartition.hashPartitioned(distributeExpressions);
             } else if (DistributionSpec.DistributionType.ROUND_ROBIN.equals(distribution.getDistributionSpec().getType())) {
                 exchangeNode.setNumInstances(inputFragment.getPlanRoot().getNumInstances());
-                dataPartition = DataPartition.RANDOM;
+                dataPartition = DataPartition.RANDOM_SCALE;
             } else {
                 throw new StarRocksPlannerException("Unsupport exchange type : "
                         + distribution.getDistributionSpec().getType(), INTERNAL_ERROR);

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/InsertPlanTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/InsertPlanTest.java
@@ -909,7 +909,7 @@ public class InsertPlanTest extends PlanTestBase {
                 "select 1 as k1");
         String expected = "PLAN FRAGMENT 0\n" +
                 " OUTPUT EXPRS:2: expr\n" +
-                "  PARTITION: RANDOM\n" +
+                "  PARTITION: RANDOM_SCALE\n" +
                 "\n" +
                 "  TABLE FUNCTION TABLE SINK\n" +
                 "    PATH: hdfs://127.0.0.1:9000/files/data_\n" +
@@ -926,7 +926,7 @@ public class InsertPlanTest extends PlanTestBase {
                 "\n" +
                 "  STREAM DATA SINK\n" +
                 "    EXCHANGE ID: 02\n" +
-                "    RANDOM\n" +
+                "    RANDOM_SCALE\n" +
                 "\n" +
                 "  1:Project\n" +
                 "  |  <slot 2> : 1\n" +

--- a/gensrc/thrift/InternalService.thrift
+++ b/gensrc/thrift/InternalService.thrift
@@ -244,6 +244,7 @@ struct TQueryOptions {
   96: optional i64 spillable_operator_mask;
   // used to judge whether the profile need to report to FE, only meaningful when enable_profile=true
   97: optional i64 load_profile_collect_second;
+  98: optional i64 connector_sink_shuffle_buffer_size_mb;
 
   100: optional i64 group_concat_max_len = 1024;
   101: optional i64 runtime_profile_report_interval = 30;

--- a/gensrc/thrift/Partitions.thrift
+++ b/gensrc/thrift/Partitions.thrift
@@ -44,6 +44,8 @@ enum TPartitionType {
   // round-robin partition
   RANDOM,
 
+  RANDOM_SCALE,
+
   // unordered partition on a set of exprs
   // (partition bounds overlap)
   HASH_PARTITIONED,


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:

By default, all backends will take part in connector sinking all from the start, leading to small files when there is little data. This PR scales up backends one by one for static partition tables, which can cope with this problem.

todo: add result pictures after #40540 is merged.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
