### PR TITLE
[BugFix] Fix LocalPkIndexManager compilation error

### DIFF
--- a/be/src/storage/lake/local_pk_index_manager.h
+++ b/be/src/storage/lake/local_pk_index_manager.h
@@ -49,10 +49,10 @@ public:
     static void evict(UpdateManager* update_manager, DataDir* data_dir, std::set<std::string>& tablet_ids) {}
 
     // remove pk index meta first, and if success then remove dir.
-    static Status clear_persistent_index(int64_t tablet_id) {}
+    static Status clear_persistent_index(int64_t tablet_id) { return Status::OK(); }
 
 private:
-    static bool need_evict_tablet(const std::string& tablet_pk_path) {}
+    static bool need_evict_tablet(const std::string& tablet_pk_path) { return false; }
 };
 #endif // USE_STAROS
 


### PR DESCRIPTION
## Why I'm doing:
After #41539, default  `LocalPkIndexManager` has been added without staros, but the return value is missing in some functions, so compilation will also fail.
## What I'm doing:
Add return value of the the functions.
Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [x] 3.1
  - [ ] 3.0
  - [ ] 2.5
