### PR TITLE
[Refactor]remove the code of parquet late materialize v1

### DIFF
--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -820,7 +820,6 @@ CONF_Int32(orc_tiny_stripe_threshold_size, "8388608");
 // parquet reader
 CONF_mBool(parquet_coalesce_read_enable, "true");
 CONF_Bool(parquet_late_materialization_enable, "true");
-CONF_Bool(parquet_late_materialization_v2_enable, "true");
 CONF_Bool(parquet_page_index_enable, "true");
 
 CONF_Int32(io_coalesce_read_max_buffer_size, "8388608");

--- a/be/src/formats/parquet/column_reader.h
+++ b/be/src/formats/parquet/column_reader.h
@@ -28,13 +28,6 @@ struct HdfsScanStats;
 } // namespace starrocks
 
 namespace starrocks::parquet {
-struct ColumnReaderContext {
-    Buffer<uint8_t>* filter = nullptr;
-    size_t next_row = 0;
-    size_t rows_to_skip = 0;
-
-    void advance(size_t num_rows) { next_row += num_rows; }
-};
 
 struct ColumnReaderOptions {
     std::string timezone;
@@ -44,7 +37,6 @@ struct ColumnReaderOptions {
     RandomAccessFile* file = nullptr;
     const tparquet::RowGroup* row_group_meta = nullptr;
     uint64_t first_row_index = 0;
-    ColumnReaderContext* context = nullptr;
 };
 
 class StoredColumnReader;
@@ -88,14 +80,6 @@ public:
                                                   std::vector<const TIcebergSchemaField*>& iceberg_schema_subfield);
 
     virtual ~ColumnReader() = default;
-
-    virtual Status prepare_batch(size_t* num_records, Column* column) = 0;
-    virtual Status finish_batch() = 0;
-
-    Status next_batch(size_t* num_records, Column* column) {
-        RETURN_IF_ERROR(prepare_batch(num_records, column));
-        return finish_batch();
-    }
 
     virtual Status read_range(const Range<uint64_t>& range, const Filter* filter, Column* dst) = 0;
 

--- a/be/src/formats/parquet/group_reader.h
+++ b/be/src/formats/parquet/group_reader.h
@@ -99,14 +99,7 @@ public:
     Status init();
     // we need load dict for dict_filter, so prepare should be after collec_io_range
     Status prepare();
-    Status get_next(ChunkPtr* chunk, size_t* row_count) {
-        // TODO: new late materialization with read_range only deal with case enable late materialization
-        if (config::parquet_late_materialization_enable && config::parquet_late_materialization_v2_enable) {
-            return _do_get_next_new(chunk, row_count);
-        } else {
-            return _do_get_next(chunk, row_count);
-        }
-    }
+    Status get_next(ChunkPtr* chunk, size_t* row_count);
     void close();
     void collect_io_ranges(std::vector<io::SharedBufferedInputStream::IORange>* ranges, int64_t* end_offset,
                            ColumnIOType type = ColumnIOType::PAGES);
@@ -130,15 +123,10 @@ public:
 
     void _init_read_chunk();
 
-    Status _do_get_next(ChunkPtr* chunk, size_t* row_count);
-    Status _do_get_next_new(ChunkPtr* chunk, size_t* row_count);
     Status _read_range(const std::vector<int>& read_columns, const Range<uint64_t>& range, const Filter* filter,
                        ChunkPtr* chunk);
 
     StatusOr<size_t> _read_range_round_by_round(const Range<uint64_t>& range, Filter* filter, ChunkPtr* chunk);
-
-    Status _read(const std::vector<int>& read_columns, size_t* row_count, ChunkPtr* chunk);
-    Status _lazy_skip_rows(const std::vector<int>& read_columns, const ChunkPtr& chunk, size_t chunk_size);
 
     // row group meta
     const tparquet::RowGroup* _row_group_metadata = nullptr;

--- a/be/src/formats/parquet/stored_column_reader.cpp
+++ b/be/src/formats/parquet/stored_column_reader.cpp
@@ -40,8 +40,6 @@ public:
 
     void reset() override;
 
-    Status do_read_records(size_t* num_rows, ColumnContentType content_type, Column* dst) override;
-
     void get_levels(level_t** def_levels, level_t** rep_levels, size_t* num_levels) override {
         *def_levels = &_def_levels[0];
         *rep_levels = &_rep_levels[0];
@@ -51,9 +49,6 @@ public:
     Status load_specific_page(size_t cur_page_idx, uint64_t offset, uint64_t first_row) override;
 
     void set_page_change_on_record_boundry() override { _page_change_on_record_boundry = true; }
-
-protected:
-    bool page_selected(size_t num_values) override;
 
 private:
     // Try to decode enough levels in levels buffer, if there are no enough levels, will throw InternalError msg.
@@ -112,14 +107,6 @@ public:
     // Reset internal state and ready for next read_values
     void reset() override;
 
-    Status do_read_records(size_t* num_records, ColumnContentType content_type, Column* dst) override {
-        if (_need_parse_levels) {
-            return _read_records_and_levels(num_records, content_type, dst);
-        } else {
-            return _read_records_only(num_records, content_type, dst);
-        }
-    }
-
     // If need_levels is set, client will get all levels through get_levels function.
     // If need_levels is not set, read_records may not records levels information, this will
     // improve performance. So set this flag when you only needs it.
@@ -149,8 +136,6 @@ public:
 
 private:
     Status _decode_levels(size_t num_levels);
-    Status _read_records_only(size_t* num_records, ColumnContentType content_type, Column* dst);
-    Status _read_records_and_levels(size_t* num_records, ColumnContentType content_type, Column* dst);
     Status _lazy_skip_values(uint64_t begin) override;
     Status _read_values_on_levels(size_t num_values, starrocks::parquet::ColumnContentType content_type,
                                   starrocks::Column* dst, bool append_default) override;
@@ -188,8 +173,6 @@ public:
 
     void reset() override {}
 
-    Status do_read_records(size_t* num_rows, ColumnContentType content_type, Column* dst) override;
-
     void get_levels(level_t** def_levels, level_t** rep_levels, size_t* num_levels) override {
         *def_levels = nullptr;
         *rep_levels = nullptr;
@@ -218,74 +201,6 @@ void RepeatedStoredColumnReader::reset() {
     memmove(&_rep_levels[0], &_rep_levels[_levels_parsed], num_levels * sizeof(level_t));
     _levels_decoded -= _levels_parsed;
     _levels_parsed = 0;
-}
-
-Status RepeatedStoredColumnReader::do_read_records(size_t* num_records, ColumnContentType content_type, Column* dst) {
-    if (_eof) {
-        *num_records = 0;
-        return Status::EndOfFile("");
-    }
-
-    size_t records_read = 0;
-    do {
-        if (_num_values_left_in_cur_page == 0) {
-            size_t read_count = 0;
-            auto st = next_page(*num_records - records_read, content_type, &read_count, dst);
-            DCHECK(read_count <= (*num_records - records_read));
-            records_read += read_count;
-            if (!st.ok()) {
-                if (st.is_end_of_file()) {
-                    if (_meet_first_record) {
-                        records_read++;
-                    }
-                    _eof = true;
-                    break;
-                } else {
-                    return st;
-                }
-            }
-        }
-
-        // NOTE: must have values in current page.
-        DCHECK_GT(_num_values_left_in_cur_page, 0);
-
-        size_t records_to_read = *num_records - records_read;
-        RETURN_IF_ERROR(_decode_levels(records_to_read));
-
-        size_t num_parsed_levels = 0;
-        _delimit_rows(&records_to_read, &num_parsed_levels);
-
-        // decode value read from reader
-        {
-            // ensure enough capacity
-            _is_nulls.resize(num_parsed_levels);
-            int null_pos = 0;
-            for (int i = 0; i < num_parsed_levels; ++i) {
-                level_t def_level = _def_levels[i + _levels_parsed];
-                _is_nulls[null_pos] = (def_level < _field->max_def_level());
-                // if current def level < ancestor def level, the ancestor will be not defined too, so that we don't
-                // need to add null value to this column. Otherwise, we need to add null value to this column.
-                null_pos += (def_level >= _field->level_info.immediate_repeated_ancestor_def_level);
-            }
-            RETURN_IF_ERROR(_reader->decode_values(null_pos, &_is_nulls[0], content_type, dst));
-        }
-
-        records_read += records_to_read;
-        _levels_parsed += num_parsed_levels;
-        _num_values_left_in_cur_page -= num_parsed_levels;
-        update_read_context(records_to_read);
-    } while (records_read < *num_records);
-
-    DCHECK(records_read <= *num_records);
-
-    *num_records = records_read;
-    return Status::OK();
-}
-
-// For repeated columns, it is difficult to skip rows according the num_values in header because
-// there may be multiple values in one row. So we don't realize it util the page index is ready later.
-bool RepeatedStoredColumnReader::page_selected(size_t num_values) {
-    return true;
 }
 
 void RepeatedStoredColumnReader::_delimit_rows(size_t* num_rows, size_t* num_levels_parsed) {
@@ -381,127 +296,6 @@ void OptionalStoredColumnReader::reset() {
     _levels_parsed = 0;
 }
 
-Status OptionalStoredColumnReader::_read_records_and_levels(size_t* num_records, ColumnContentType content_type,
-                                                            Column* dst) {
-    SCOPED_RAW_TIMER(&_opts.stats->column_read_ns);
-    if (_eof) {
-        *num_records = 0;
-        return Status::EndOfFile("");
-    }
-    size_t records_read = 0;
-    do {
-        if (_num_values_left_in_cur_page == 0) {
-            size_t read_count = 0;
-            auto st = next_page(*num_records - records_read, content_type, &read_count, dst);
-            records_read += read_count;
-            if (!st.ok()) {
-                if (st.is_end_of_file()) {
-                    _eof = true;
-                    break;
-                } else {
-                    return st;
-                }
-            }
-        }
-
-        size_t records_to_read = std::min(*num_records - records_read, _num_values_left_in_cur_page);
-        if (records_to_read == 0) {
-            break;
-        }
-
-        RETURN_IF_ERROR(_decode_levels(records_to_read));
-
-        {
-            _is_nulls.resize(records_to_read);
-            // decode def levels
-            for (size_t i = 0; i < records_to_read; ++i) {
-                _is_nulls[i] = _def_levels[_levels_parsed + i] < _field->max_def_level();
-            }
-            RETURN_IF_ERROR(_reader->decode_values(records_to_read, &_is_nulls[0], content_type, dst));
-        }
-        _num_values_left_in_cur_page -= records_to_read;
-        _levels_parsed += records_to_read;
-        records_read += records_to_read;
-        update_read_context(records_to_read);
-    } while (records_read < *num_records);
-    *num_records = records_read;
-    return Status::OK();
-}
-
-Status OptionalStoredColumnReader::_read_records_only(size_t* num_records, ColumnContentType content_type,
-                                                      Column* dst) {
-    SCOPED_RAW_TIMER(&_opts.stats->column_read_ns);
-    if (_eof) {
-        return Status::EndOfFile("");
-    }
-    size_t records_read = 0;
-    do {
-        if (_num_values_left_in_cur_page == 0) {
-            size_t read_count = 0;
-            auto st = next_page(*num_records - records_read, content_type, &read_count, dst);
-            records_read += read_count;
-            if (!st.ok()) {
-                if (st.is_end_of_file()) {
-                    _eof = true;
-                    break;
-                } else {
-                    return st;
-                }
-            }
-        }
-
-        size_t records_to_read = std::min(*num_records - records_read, _num_values_left_in_cur_page);
-        if (records_to_read == 0) {
-            break;
-        }
-
-        size_t repeated_count = _reader->def_level_decoder().next_repeated_count();
-        if (repeated_count > 0) {
-            records_to_read = std::min(records_to_read, repeated_count);
-            level_t def_level = 0;
-            { def_level = _reader->def_level_decoder().get_repeated_value(records_to_read); }
-            if (def_level >= _field->max_def_level()) {
-                RETURN_IF_ERROR(_reader->decode_values(records_to_read, content_type, dst));
-            } else {
-                dst->append_nulls(records_to_read);
-            }
-        } else {
-            size_t new_capacity = records_to_read;
-            if (new_capacity > _levels_capacity) {
-                new_capacity = BitUtil::next_power_of_two(new_capacity);
-                _def_levels.resize(new_capacity);
-                _levels_capacity = new_capacity;
-            }
-            size_t res_def = _reader->decode_def_levels(records_to_read, &_def_levels[0]);
-            if (UNLIKELY(res_def != records_to_read)) {
-                return Status::InternalError(
-                        fmt::format("def levels need to parsed: {}, def levels parsed: {}", records_to_read, res_def));
-            }
-            size_t i = 0;
-            while (i < records_to_read) {
-                size_t j = i;
-                bool is_null = _def_levels[j] < _field->max_def_level();
-                j++;
-                while (j < records_to_read && is_null == (_def_levels[j] < _field->max_def_level())) {
-                    j++;
-                }
-                if (is_null) {
-                    dst->append_nulls(j - i);
-                } else {
-                    RETURN_IF_ERROR(_reader->decode_values(j - i, content_type, dst));
-                }
-                i = j;
-            }
-        }
-
-        _num_values_left_in_cur_page -= records_to_read;
-        records_read += records_to_read;
-        update_read_context(records_to_read);
-    } while (records_read < *num_records);
-    *num_records = records_read;
-    return Status::OK();
-}
-
 Status OptionalStoredColumnReader::_decode_levels(size_t num_levels) {
     constexpr size_t min_level_batch_size = 4096;
     size_t levels_remaining = _levels_decoded - _levels_parsed;
@@ -529,35 +323,6 @@ Status OptionalStoredColumnReader::_decode_levels(size_t num_levels) {
     return Status::OK();
 }
 
-Status RequiredStoredColumnReader::do_read_records(size_t* num_records, ColumnContentType content_type, Column* dst) {
-    size_t records_read = 0;
-    while (records_read < *num_records) {
-        if (_num_values_left_in_cur_page == 0) {
-            size_t read_count = 0;
-            auto st = next_page(*num_records - records_read, content_type, &read_count, dst);
-            records_read += read_count;
-            if (!st.ok()) {
-                if (st.is_end_of_file()) {
-                    break;
-                } else {
-                    return st;
-                }
-            }
-        }
-
-        size_t records_to_read = std::min(*num_records - records_read, _num_values_left_in_cur_page);
-        if (records_to_read == 0) {
-            break;
-        }
-        RETURN_IF_ERROR(_reader->decode_values(records_to_read, content_type, dst));
-        records_read += records_to_read;
-        _num_values_left_in_cur_page -= records_to_read;
-        update_read_context(records_to_read);
-    }
-    *num_records = records_read;
-    return Status::OK();
-}
-
 Status StoredColumnReader::create(const ColumnReaderOptions& opts, const ParquetField* field,
                                   const tparquet::ColumnChunk* chunk_metadata,
                                   std::unique_ptr<StoredColumnReader>* out) {
@@ -575,118 +340,6 @@ Status StoredColumnReader::create(const ColumnReaderOptions& opts, const Parquet
         *out = std::move(reader);
     }
     return Status::OK();
-}
-
-Status StoredColumnReaderImpl::next_page(size_t records_to_read, ColumnContentType content_type, size_t* records_read,
-                                         Column* dst) {
-    *records_read = 0;
-    size_t records_to_skip = 0;
-    RETURN_IF_ERROR(_next_selected_page(records_to_read, content_type, &records_to_skip, dst));
-    if (records_to_skip == 0) {
-        return Status::OK();
-    }
-
-    if (_opts.context->rows_to_skip > 0) {
-        _opts.context->rows_to_skip -= records_to_skip;
-    }
-    if (_opts.context->filter) {
-        dst->append_default(records_to_skip);
-        append_default_levels(records_to_skip);
-        *records_read = records_to_skip;
-    }
-    return Status::OK();
-}
-
-Status StoredColumnReaderImpl::_next_selected_page(size_t records_to_read, ColumnContentType content_type,
-                                                   size_t* records_to_skip, Column* dst) {
-    *records_to_skip = 0;
-    do {
-        size_t remain_values =
-                _num_values_skip_in_cur_page > 0 ? _reader->num_values() - _num_values_skip_in_cur_page : 0;
-        if (remain_values == 0) {
-            RETURN_IF_ERROR(_reader->load_header());
-            size_t num_values = _reader->num_values();
-            if (num_values == 0) {
-                if (_reader->current_page_is_dict()) {
-                    RETURN_IF_ERROR(_reader->load_page());
-                } else {
-                    RETURN_IF_ERROR(_reader->skip_page());
-                }
-                continue;
-            }
-            _num_values_skip_in_cur_page = 0;
-            remain_values = num_values;
-        }
-
-        size_t to_read = records_to_read - *records_to_skip;
-        if (page_selected(remain_values)) {
-            RETURN_IF_ERROR(_reader->load_page());
-            _num_values_left_in_cur_page = _reader->num_values();
-            size_t batch_size = records_to_read;
-            RETURN_IF_ERROR(_lazy_load_page_rows(batch_size, content_type, dst));
-            _num_values_skip_in_cur_page = 0;
-            break;
-        }
-
-        if (_opts.context->filter) {
-            _opts.context->advance(std::min(to_read, remain_values));
-        }
-        if (to_read < remain_values) {
-            _num_values_skip_in_cur_page += to_read;
-            *records_to_skip += to_read;
-            break;
-        }
-        RETURN_IF_ERROR(_reader->skip_page());
-        *records_to_skip += remain_values;
-        _num_values_skip_in_cur_page = 0;
-    } while (*records_to_skip < records_to_read);
-
-    return Status::OK();
-}
-
-Status StoredColumnReaderImpl::_lazy_load_page_rows(size_t batch_size, ColumnContentType content_type, Column* dst) {
-    size_t load_rows = _num_values_skip_in_cur_page;
-    if (load_rows == 0) {
-        return Status::OK();
-    }
-
-    // TODO: We simply use reading records to decode and seek rows position now, it may cause some extra
-    // memory copy. A more efficient way requires major changes to the current code, but it is necessary.
-    auto filter = _opts.context->filter;
-    auto rows_to_skip = _opts.context->rows_to_skip;
-    _opts.context->filter = nullptr;
-    _opts.context->rows_to_skip = 0;
-    while (load_rows > 0) {
-        size_t to_read = std::min(load_rows, batch_size);
-        auto temp_column = dst->clone_empty();
-        RETURN_IF_ERROR(do_read_records(&to_read, content_type, temp_column.get()));
-        // TODO(SmithCruise) Refactor it
-        // We need reset def/rep cursor after lazy load
-        reset();
-        load_rows -= to_read;
-    }
-    _opts.context->filter = filter;
-    _opts.context->rows_to_skip = rows_to_skip;
-    return Status::OK();
-}
-
-bool StoredColumnReaderImpl::page_selected(size_t num_values) {
-    auto filter = _opts.context->filter;
-    if (!filter) {
-        return true;
-    }
-    size_t start_row = _opts.context->next_row;
-    int end_row = std::min(start_row + num_values, filter->size()) - 1;
-    return SIMD::find_nonzero(*filter, start_row) <= end_row;
-}
-
-void StoredColumnReaderImpl::update_read_context(size_t records_read) {
-    if (_opts.context->rows_to_skip > 0) {
-        _opts.context->rows_to_skip -= records_read;
-    }
-    if (_opts.context->filter) {
-        _opts.context->advance(records_read);
-    }
 }
 
 size_t StoredColumnReaderImpl::get_level_to_decode_batch_size(size_t row, size_t num_values_left_in_cur_page,

--- a/be/src/formats/parquet/stored_column_reader.cpp
+++ b/be/src/formats/parquet/stored_column_reader.cpp
@@ -70,7 +70,6 @@ private:
 private:
     const ParquetField* _field = nullptr;
 
-    bool _eof = false;
     bool _meet_first_record = false;
 
     size_t _not_null_to_skip = 0;
@@ -146,8 +145,6 @@ private:
     // so that the advantages of RLE encoding can be fully utilized and a lot of overhead
     // can be saved in decoding.
     bool _need_parse_levels = false;
-
-    bool _eof = false;
 
     size_t _levels_parsed = 0;
     size_t _levels_decoded = 0;

--- a/be/src/formats/parquet/stored_column_reader.h
+++ b/be/src/formats/parquet/stored_column_reader.h
@@ -49,8 +49,6 @@ public:
     // so currently we can't put need_parse_levels into StoredColumnReaderOptions.
     virtual void set_need_parse_levels(bool need_parse_levels) {}
 
-    virtual Status read_records(size_t* num_rows, ColumnContentType content_type, Column* dst) = 0;
-
     virtual Status read_range(const Range<uint64_t>& range, const Filter* filter, ColumnContentType content_type,
                               Column* dst) = 0;
 
@@ -83,14 +81,6 @@ public:
     // Reset internal state and ready for next read_values
     virtual void reset() = 0;
 
-    // Try to read values that can assemble up to num_rows rows. For example if we want to read
-    // an array type, and stored value is [1, 2, 3], [4], [5, 6], when the input num_rows is 3,
-    // this function will fill (1, 2, 3, 4, 5, 6) into 'dst'.
-    Status read_records(size_t* num_rows, ColumnContentType content_type, Column* dst) override {
-        reset();
-        return do_read_records(num_rows, content_type, dst);
-    }
-
     Status read_range(const Range<uint64_t>& range, const Filter* filter, ColumnContentType content_type,
                       Column* dst) override;
 
@@ -113,12 +103,6 @@ public:
     static size_t count_not_null(level_t* def_levels, size_t num_parsed_levels, level_t max_def_level);
 
 protected:
-    virtual bool page_selected(size_t num_values);
-
-    virtual Status do_read_records(size_t* num_rows, ColumnContentType content_type, Column* dst) = 0;
-
-    Status next_page(size_t records_to_read, ColumnContentType content_type, size_t* records_read, Column* dst);
-
     virtual Status _next_page();
     virtual bool _cur_page_selected(size_t row_readed, const Filter* filter, size_t to_read);
 

--- a/be/src/formats/parquet/stored_column_reader_with_index.h
+++ b/be/src/formats/parquet/stored_column_reader_with_index.h
@@ -35,10 +35,6 @@ public:
         _inner_reader->set_need_parse_levels(need_parse_levels);
     }
 
-    Status read_records(size_t* num_rows, ColumnContentType content_type, Column* dst) override {
-        return _inner_reader->read_records(num_rows, content_type, dst);
-    }
-
     Status read_range(const Range<uint64_t>& range, const Filter* filter, ColumnContentType content_type,
                       Column* dst) override;
 

--- a/be/test/formats/parquet/group_reader_test.cpp
+++ b/be/test/formats/parquet/group_reader_test.cpp
@@ -39,13 +39,12 @@ public:
     explicit MockColumnReader(tparquet::Type::type type) : _type(type) {}
     ~MockColumnReader() override = default;
 
-    Status prepare_batch(size_t* num_records, Column* column) override {
+    Status read_range(const Range<uint64_t>& range, const Filter* filter, Column* dst) override {
+        size_t num_rows = static_cast<size_t>(range.span_size());
         if (_step > 1) {
-            *num_records = 0;
             return Status::EndOfFile("");
         }
         size_t start = 0;
-        size_t num_rows = 0;
         if (_step == 0) {
             start = 0;
             num_rows = 8;
@@ -55,29 +54,21 @@ public:
         }
 
         if (_type == tparquet::Type::type::INT32) {
-            _append_int32_column(column, start, num_rows);
+            _append_int32_column(dst, start, num_rows);
         } else if (_type == tparquet::Type::type::INT64) {
-            _append_int64_column(column, start, num_rows);
+            _append_int64_column(dst, start, num_rows);
         } else if (_type == tparquet::Type::type::INT96) {
-            _append_int96_column(column, start, num_rows);
+            _append_int96_column(dst, start, num_rows);
         } else if (_type == tparquet::Type::type::BYTE_ARRAY) {
-            _append_binary_column(column, start, num_rows);
+            _append_binary_column(dst, start, num_rows);
         } else if (_type == tparquet::Type::type::FLOAT) {
-            _append_float_column(column, start, num_rows);
+            _append_float_column(dst, start, num_rows);
         } else if (_type == tparquet::Type::type::DOUBLE) {
-            _append_double_column(column, start, num_rows);
+            _append_double_column(dst, start, num_rows);
         }
 
         _step++;
-        *num_records = num_rows;
         return Status::OK();
-    }
-
-    Status finish_batch() override { return Status::OK(); }
-
-    Status read_range(const Range<uint64_t>& range, const Filter* filter, Column* dst) override {
-        size_t rows = static_cast<size_t>(range.span_size());
-        return prepare_batch(&rows, dst);
     }
 
     void set_need_parse_levels(bool need_parse_levels) override{};


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:
remove the parquet late materialize v1, 
as the parquet_late_materialization_v2_enable was not public for users,
i think we can delete if safely, 
and we'd better give some upgrade note just in case.

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [x] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [x] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
