### PR TITLE
[Enhancement] Ngram bloom filter support like  predicate and case_insensitive mode

### DIFF
--- a/be/src/exprs/expr.cpp
+++ b/be/src/exprs/expr.cpp
@@ -846,7 +846,7 @@ bool Expr::support_ngram_bloom_filter(ExprContext* context) const {
 }
 
 bool Expr::ngram_bloom_filter(ExprContext* context, const BloomFilter* bf,
-                              const BloomFilterReaderOptions& reader_options) const {
+                              const NgramBloomFilterReaderOptions& reader_options) const {
     bool no_need_to_filt = true;
     for (auto& child : _children) {
         if (!child->ngram_bloom_filter(context, bf, reader_options)) {

--- a/be/src/exprs/expr.cpp
+++ b/be/src/exprs/expr.cpp
@@ -845,10 +845,11 @@ bool Expr::support_ngram_bloom_filter(ExprContext* context) const {
     return support;
 }
 
-bool Expr::ngram_bloom_filter(ExprContext* context, const BloomFilter* bf, size_t gram_num) const {
+bool Expr::ngram_bloom_filter(ExprContext* context, const BloomFilter* bf,
+                              const BloomFilterReaderOptions& reader_options) const {
     bool no_need_to_filt = true;
     for (auto& child : _children) {
-        if (!child->ngram_bloom_filter(context, bf, gram_num)) {
+        if (!child->ngram_bloom_filter(context, bf, reader_options)) {
             return false;
         }
     }

--- a/be/src/exprs/expr.h
+++ b/be/src/exprs/expr.h
@@ -254,7 +254,8 @@ public:
     virtual bool support_ngram_bloom_filter(ExprContext* context) const;
 
     // Return false to filter out a data page.
-    virtual bool ngram_bloom_filter(ExprContext* context, const BloomFilter* bf, size_t gram_num) const;
+    virtual bool ngram_bloom_filter(ExprContext* context, const BloomFilter* bf,
+                                    const BloomFilterReaderOptions& reader_options) const;
 
     // Return true if this expr or any of its children is index only filter, otherwise return false
     bool is_index_only_filter() const;

--- a/be/src/exprs/expr.h
+++ b/be/src/exprs/expr.h
@@ -255,7 +255,7 @@ public:
 
     // Return false to filter out a data page.
     virtual bool ngram_bloom_filter(ExprContext* context, const BloomFilter* bf,
-                                    const BloomFilterReaderOptions& reader_options) const;
+                                    const NgramBloomFilterReaderOptions& reader_options) const;
 
     // Return true if this expr or any of its children is index only filter, otherwise return false
     bool is_index_only_filter() const;

--- a/be/src/exprs/expr_context.cpp
+++ b/be/src/exprs/expr_context.cpp
@@ -186,8 +186,8 @@ StatusOr<ColumnPtr> ExprContext::evaluate(Expr* e, Chunk* chunk, uint8_t* filter
     }
 }
 
-bool ExprContext::ngram_bloom_filter(const BloomFilter* bf, size_t gram_num) {
-    return _root->ngram_bloom_filter(this, bf, gram_num);
+bool ExprContext::ngram_bloom_filter(const BloomFilter* bf, const BloomFilterReaderOptions& reader_options) {
+    return _root->ngram_bloom_filter(this, bf, reader_options);
 }
 
 bool ExprContext::support_ngram_bloom_filter() {

--- a/be/src/exprs/expr_context.cpp
+++ b/be/src/exprs/expr_context.cpp
@@ -186,7 +186,7 @@ StatusOr<ColumnPtr> ExprContext::evaluate(Expr* e, Chunk* chunk, uint8_t* filter
     }
 }
 
-bool ExprContext::ngram_bloom_filter(const BloomFilter* bf, const BloomFilterReaderOptions& reader_options) {
+bool ExprContext::ngram_bloom_filter(const BloomFilter* bf, const NgramBloomFilterReaderOptions& reader_options) {
     return _root->ngram_bloom_filter(this, bf, reader_options);
 }
 

--- a/be/src/exprs/expr_context.h
+++ b/be/src/exprs/expr_context.h
@@ -55,6 +55,7 @@ class RuntimeState;
 class ObjectPool;
 class TColumnValue;
 class BloomFilter;
+struct BloomFilterReaderOptions;
 
 /// An ExprContext contains the state for the execution of a tree of Exprs, in particular
 /// the FunctionContexts necessary for the expr tree. This allows for multi-threaded
@@ -115,7 +116,7 @@ public:
 
     [[nodiscard]] StatusOr<ColumnPtr> evaluate(Chunk* chunk, uint8_t* filter = nullptr);
     [[nodiscard]] StatusOr<ColumnPtr> evaluate(Expr* expr, Chunk* chunk, uint8_t* filter = nullptr);
-    bool ngram_bloom_filter(const BloomFilter* bf, size_t gram_num);
+    bool ngram_bloom_filter(const BloomFilter* bf, const BloomFilterReaderOptions& reader_options);
     bool support_ngram_bloom_filter();
     bool is_index_only_filter() const;
 

--- a/be/src/exprs/expr_context.h
+++ b/be/src/exprs/expr_context.h
@@ -55,7 +55,7 @@ class RuntimeState;
 class ObjectPool;
 class TColumnValue;
 class BloomFilter;
-struct BloomFilterReaderOptions;
+struct NgramBloomFilterReaderOptions;
 
 /// An ExprContext contains the state for the execution of a tree of Exprs, in particular
 /// the FunctionContexts necessary for the expr tree. This allows for multi-threaded
@@ -116,7 +116,7 @@ public:
 
     [[nodiscard]] StatusOr<ColumnPtr> evaluate(Chunk* chunk, uint8_t* filter = nullptr);
     [[nodiscard]] StatusOr<ColumnPtr> evaluate(Expr* expr, Chunk* chunk, uint8_t* filter = nullptr);
-    bool ngram_bloom_filter(const BloomFilter* bf, const BloomFilterReaderOptions& reader_options);
+    bool ngram_bloom_filter(const BloomFilter* bf, const NgramBloomFilterReaderOptions& reader_options);
     bool support_ngram_bloom_filter();
     bool is_index_only_filter() const;
 

--- a/be/src/exprs/function_call_expr.cpp
+++ b/be/src/exprs/function_call_expr.cpp
@@ -21,7 +21,6 @@
 #include "exprs/anyval_util.h"
 #include "exprs/builtin_functions.h"
 #include "exprs/expr_context.h"
-#include "exprs/like_predicate.h"
 #include "gutil/strings/substitute.h"
 #include "runtime/current_thread.h"
 #include "runtime/user_function_cache.h"
@@ -178,54 +177,35 @@ StatusOr<ColumnPtr> VectorizedFunctionCallExpr::evaluate_checked(starrocks::Expr
 }
 
 bool VectorizedFunctionCallExpr::ngram_bloom_filter(ExprContext* context, const BloomFilter* bf,
-                                                    const BloomFilterReaderOptions& reader_options) const {
+                                                    const NgramBloomFilterReaderOptions& reader_options) const {
     FunctionContext* fn_ctx = context->fn_context(_fn_context_index);
-    std::vector<Slice>& ngram_set = fn_ctx->get_ngram_set();
-    size_t index_gram_num = reader_options.index_gram_num;
-    bool index_case_sensitive = reader_options.index_case_sensitive;
+    std::unique_ptr<NgramBloomFilterState>& ngram_state = fn_ctx->get_ngram_state();
 
-    const auto& gram_num_column = fn_ctx->get_constant_column(2);
-    // case like ngram_search(col,"needle", 5) when col has a 4gram bloom filter, don't use this index
-    if (gram_num_column != nullptr) {
-        size_t predicate_gram_num = ColumnHelper::get_const_value<TYPE_INT>(gram_num_column);
-        if (index_gram_num != predicate_gram_num) {
-            return true;
-        }
-    }
-
-    if (UNLIKELY(ngram_set.size() == 0)) {
-        Slice needle;
-        if (_fn_desc->name == "like" || _fn_desc->name == "regex") {
-            // not implemented right now
-            return true;
+    // initialize ngram_state: determine whether this index useful or not, split needle into ngram_set if useful
+    if (ngram_state = nullptr) {
+        ngram_state = std::make_unique<NgramBloomFilterState>();
+        std::vector<Slice>& ngram_set = ngram_state->ngram_set;
+        bool index_useful;
+        if (_fn_desc->name == "like") {
+            index_useful = split_like_string_to_ngram(fn_ctx, reader_options, ngram_set);
         } else {
-            // checked in support_ngram_bloom_filter(size_t gram_num), so it 's safe to get const column's value
-            const auto& needle_column = fn_ctx->get_constant_column(1);
-            if (index_case_sensitive) {
-                needle = ColumnHelper::get_const_value<TYPE_VARCHAR>(needle_column);
-            } else {
-                std::string buf;
-                tolower(ColumnHelper::get_const_value<TYPE_VARCHAR>(needle_column), buf);
-                needle = Slice(buf);
-            }
+            index_useful = split_normal_string_to_ngram(fn_ctx, reader_options, ngram_state.get(), _fn_desc->name);
         }
-
-        std::vector<size_t> index;
-        size_t slice_gram_num = get_utf8_index(needle, &index);
-        ngram_set.reserve(slice_gram_num - index_gram_num + 1);
-
-        size_t j;
-        for (j = 0; j + index_gram_num <= slice_gram_num; j++) {
-            // find next ngram
-            size_t cur_ngram_length = j + index_gram_num < slice_gram_num ? index[j + index_gram_num] - index[j]
-                                                                          : needle.get_size() - index[j];
-            Slice cur_ngram = Slice(needle.data + index[j], cur_ngram_length);
-
-            ngram_set.push_back(cur_ngram);
-        }
+        ngram_state->initialized = true;
+        ngram_state->index_useful = index_useful;
     }
 
-    for (auto& ngram : ngram_set) {
+    DCHECK(ngram_state != nullptr);
+    DCHECK(ngram_state->initialized);
+
+    // this index can not be used to this function
+    if (!ngram_state->index_useful) {
+        return true;
+    }
+
+    // if empty, which means needle is too short, so index_valid should be false
+    DCHECK(!ngram_state->ngram_set.empty());
+    for (auto& ngram : ngram_state->ngram_set) {
         if (bf->test_bytes(ngram.get_data(), ngram.get_size())) {
             return true;
         }
@@ -241,8 +221,113 @@ bool VectorizedFunctionCallExpr::support_ngram_bloom_filter(ExprContext* context
         return false;
     }
 
-    return _fn_desc->name == "regex" || _fn_desc->name == "like" || _fn_desc->name == "ngram_search" ||
+    return _fn_desc->name == "like" || _fn_desc->name == "ngram_search" ||
            _fn_desc->name == "ngram_search_case_insensitive";
 }
 
+// return false if this index can not be used, otherwise set ngram_set and return true
+bool VectorizedFunctionCallExpr::split_normal_string_to_ngram(FunctionContext* fn_ctx,
+                                                              const NgramBloomFilterReaderOptions& reader_options,
+                                                              NgramBloomFilterState* ngram_state,
+                                                              string func_name) const {
+    size_t index_gram_num = reader_options.index_gram_num;
+    bool index_case_sensitive = reader_options.index_case_sensitive;
+    std::vector<Slice>& ngram_set = ngram_state->ngram_set;
+
+    auto gram_num_column = fn_ctx->get_constant_column(2);
+    if (gram_num_column != nullptr) {
+        size_t predicate_gram_num = ColumnHelper::get_const_value<TYPE_INT>(gram_num_column);
+        // case like ngram_search(col,"needle", 5) when col has a 4gram bloom filter, don't use this index
+        if (index_gram_num != predicate_gram_num) {
+            return false;
+        }
+    }
+
+    // if ngram bloom filter is case_sensitive,but function is case insensitive
+    if (index_case_sensitive && func_name == "ngram_search_case_insensitive") {
+        return false;
+    }
+
+    // checked in support_ngram_bloom_filter(size_t gram_num), so it 's safe to get const column's value
+    Slice needle;
+    const auto& needle_column = fn_ctx->get_constant_column(1);
+
+    if (index_case_sensitive) {
+        needle = ColumnHelper::get_const_value<TYPE_VARCHAR>(needle_column);
+    } else {
+        // for case_insensitive, we need to convert needle to lower case
+        std::string& buf = ngram_state->buffer;
+        needle = ColumnHelper::get_const_value<TYPE_VARCHAR>(needle_column).tolower(buf);
+    }
+
+    std::vector<size_t> index;
+    size_t slice_gram_num = get_utf8_index(needle, &index);
+    // case like "ngram_search
+    if (slice_gram_num < index_gram_num) {
+        return false;
+    }
+    ngram_set.reserve(slice_gram_num - index_gram_num + 1);
+
+    size_t j;
+    for (j = 0; j + index_gram_num <= slice_gram_num; j++) {
+        // find next ngram
+        size_t cur_ngram_length = j + index_gram_num < slice_gram_num ? index[j + index_gram_num] - index[j]
+                                                                      : needle.get_size() - index[j];
+        Slice cur_ngram = Slice(needle.data + index[j], cur_ngram_length);
+
+        ngram_set.push_back(cur_ngram);
+    }
+    // case like "ngram_search(col, "nee", 3) when col has a 4gram bloom filter, don't use this index
+    if (ngram_set.empty()) return false;
+    return true;
+}
+
+bool VectorizedFunctionCallExpr::split_like_string_to_ngram(FunctionContext* fn_ctx,
+                                                            const NgramBloomFilterReaderOptions& reader_options,
+                                                            std::vector<Slice>& ngram_set) const {
+    size_t index_gram_num = reader_options.index_gram_num;
+    auto needle_column = fn_ctx->get_constant_column(1);
+    if (needle_column == nullptr) {
+        return false;
+    }
+
+    Slice needle = ColumnHelper::get_const_value<TYPE_VARCHAR>(needle_column);
+
+    size_t cur_valid_grams_num = 0;
+    size_t cur_grams_begin_index = 0;
+    bool escaped = false;
+
+    // when iteration begin,[cur_grams_begin_index, i) is the current ngram
+    // cur_valid_grams_num is the number of utf-8 gram in slice[cur_grams_begin_index, i)
+    // escaped means needle[i - 1] is '\\'
+    for (size_t i = 0; i < needle.size;) {
+        if (escaped && (needle[i] == '%' || needle[i] == '_' || needle[i] == '\\')) {
+            ++cur_valid_grams_num;
+            escaped = false;
+            ++i;
+        } else if (!escaped && (needle[i] == '%' || needle[i] == '_')) {
+            cur_valid_grams_num = 0;
+            escaped = false;
+            ++i;
+            cur_grams_begin_index = i;
+        } else if (!escaped && needle[i] == '\\') {
+            escaped = true;
+            ++i;
+        } else {
+            size_t cur_gram_length = UTF8_BYTE_LENGTH_TABLE[static_cast<unsigned char>(needle.data[i])];
+            i += cur_gram_length;
+            ++cur_valid_grams_num;
+            escaped = false;
+        }
+
+        if (cur_valid_grams_num == index_gram_num) {
+            ngram_set.push_back(Slice(needle.data + cur_grams_begin_index, i - cur_grams_begin_index));
+            cur_valid_grams_num = 0;
+            cur_grams_begin_index = i;
+        }
+    }
+    // case like "like(col, "nee") when col has a 4gram bloom filter, don't use this index
+    if (ngram_set.empty()) return false;
+    return true;
+}
 } // namespace starrocks

--- a/be/src/exprs/function_call_expr.h
+++ b/be/src/exprs/function_call_expr.h
@@ -50,7 +50,7 @@ protected:
 
 private:
     bool split_normal_string_to_ngram(FunctionContext* fn_ctx, const NgramBloomFilterReaderOptions& reader_options,
-                                      NgramBloomFilterState* ngram_state, std::string func_name) const;
+                                      NgramBloomFilterState* ngram_state, const std::string& func_name) const;
 
     bool split_like_string_to_ngram(FunctionContext* fn_ctx, const NgramBloomFilterReaderOptions& reader_options,
                                     std::vector<Slice>& ngram_set) const;

--- a/be/src/exprs/function_call_expr.h
+++ b/be/src/exprs/function_call_expr.h
@@ -33,7 +33,8 @@ public:
     const FunctionDescriptor* get_function_desc() { return _fn_desc; }
 
     bool support_ngram_bloom_filter(ExprContext* context) const override;
-    bool ngram_bloom_filter(ExprContext* context, const BloomFilter* bf, size_t gram_num) const override;
+    bool ngram_bloom_filter(ExprContext* context, const BloomFilter* bf,
+                            const BloomFilterReaderOptions& reader_options) const override;
 
 protected:
     [[nodiscard]] Status prepare(RuntimeState* state, ExprContext* context) override;

--- a/be/src/exprs/function_call_expr.h
+++ b/be/src/exprs/function_call_expr.h
@@ -34,7 +34,7 @@ public:
 
     bool support_ngram_bloom_filter(ExprContext* context) const override;
     bool ngram_bloom_filter(ExprContext* context, const BloomFilter* bf,
-                            const BloomFilterReaderOptions& reader_options) const override;
+                            const NgramBloomFilterReaderOptions& reader_options) const override;
 
 protected:
     [[nodiscard]] Status prepare(RuntimeState* state, ExprContext* context) override;
@@ -49,6 +49,12 @@ protected:
     [[nodiscard]] StatusOr<ColumnPtr> evaluate_checked(ExprContext* context, Chunk* ptr) override;
 
 private:
+    bool split_normal_string_to_ngram(FunctionContext* fn_ctx, const NgramBloomFilterReaderOptions& reader_options,
+                                      NgramBloomFilterState* ngram_state, std::string func_name) const;
+
+    bool split_like_string_to_ngram(FunctionContext* fn_ctx, const NgramBloomFilterReaderOptions& reader_options,
+                                    std::vector<Slice>& ngram_set) const;
+
     const FunctionDescriptor* _fn_desc{nullptr};
 
     bool _is_returning_random_value = false;

--- a/be/src/exprs/function_context.cpp
+++ b/be/src/exprs/function_context.cpp
@@ -22,6 +22,7 @@
 #include "column/type_traits.h"
 #include "exprs/agg/java_udaf_function.h"
 #include "runtime/runtime_state.h"
+#include "storage/rowset/bloom_filter.h"
 #include "types/logical_type_infra.h"
 
 namespace starrocks {

--- a/be/src/exprs/function_context.h
+++ b/be/src/exprs/function_context.h
@@ -32,6 +32,7 @@ class RuntimeState;
 class Column;
 class Slice;
 struct JavaUDAFContext;
+struct NgramBloomFilterState;
 using ColumnPtr = std::shared_ptr<Column>;
 
 class FunctionContext {
@@ -174,7 +175,7 @@ public:
 
     bool error_if_overflow() const;
 
-    std::vector<Slice>& get_ngram_set() { return ngram_set; }
+    std::unique_ptr<NgramBloomFilterState>& get_ngram_state() { return _ngramState; }
 
 private:
     friend class ExprContext;
@@ -220,7 +221,7 @@ private:
     ssize_t group_concat_max_len = 1024;
 
     // used for ngram bloom filter to speed up some function
-    std::vector<Slice> ngram_set;
+    std::unique_ptr<NgramBloomFilterState> _ngramState;
 };
 
 } // namespace starrocks

--- a/be/src/exprs/ngram.cpp
+++ b/be/src/exprs/ngram.cpp
@@ -153,23 +153,24 @@ private:
         std::vector<NgramHash> map_restore_helper(MAX_STRING_SIZE, 0);
 
         NullColumnPtr res_null = nullptr;
-        BinaryColumn* haystack = nullptr;
+        ColumnPtr haystackPtr = nullptr;
         // used in case_insensitive
         StatusOr<ColumnPtr> lower;
         if (haystack_column->is_nullable()) {
             auto haystack_nullable = ColumnHelper::as_column<NullableColumn>(haystack_column);
             res_null = haystack_nullable->null_column();
-            haystack = ColumnHelper::as_raw_column<BinaryColumn>(haystack_nullable->data_column());
+            haystackPtr = haystack_nullable->data_column();
         } else {
-            haystack = ColumnHelper::as_raw_column<BinaryColumn>(haystack_column);
+            haystackPtr = haystack_column;
         }
         if constexpr (case_insensitive) {
             Columns temp;
-            temp.emplace_back(haystack_column);
+            temp.emplace_back(haystackPtr);
             lower = StringFunctions::lower(nullptr, temp);
-            haystack = ColumnHelper::as_raw_column<BinaryColumn>(lower.value());
+            haystackPtr = lower.value();
         }
 
+        BinaryColumn* haystack = ColumnHelper::as_raw_column<BinaryColumn>(haystackPtr);
         size_t chunk_size = haystack->size();
         auto res = RunTimeColumnType<TYPE_DOUBLE>::create(chunk_size);
 

--- a/be/src/exprs/ngram.cpp
+++ b/be/src/exprs/ngram.cpp
@@ -268,7 +268,7 @@ private:
     }
 
     void inline static tolower(const Slice& str, std::string& buf) {
-        buf = str.to_string();
+        buf.assign(str.get_data(), str.get_size());
         std::transform(buf.begin(), buf.end(), buf.begin(), [](unsigned char c) { return std::tolower(c); });
     }
 

--- a/be/src/storage/column_expr_predicate.cpp
+++ b/be/src/storage/column_expr_predicate.cpp
@@ -185,7 +185,7 @@ bool ColumnExprPredicate::zone_map_filter(const ZoneMapDetail& detail) const {
 }
 
 bool ColumnExprPredicate::ngram_bloom_filter(const BloomFilter* bf,
-                                             const BloomFilterReaderOptions& reader_options) const {
+                                             const NgramBloomFilterReaderOptions& reader_options) const {
     return _expr_ctxs[0]->ngram_bloom_filter(bf, reader_options);
 }
 

--- a/be/src/storage/column_expr_predicate.cpp
+++ b/be/src/storage/column_expr_predicate.cpp
@@ -184,8 +184,9 @@ bool ColumnExprPredicate::zone_map_filter(const ZoneMapDetail& detail) const {
     return false;
 }
 
-bool ColumnExprPredicate::ngram_bloom_filter(const BloomFilter* bf, size_t gram_num) const {
-    return _expr_ctxs[0]->ngram_bloom_filter(bf, gram_num);
+bool ColumnExprPredicate::ngram_bloom_filter(const BloomFilter* bf,
+                                             const BloomFilterReaderOptions& reader_options) const {
+    return _expr_ctxs[0]->ngram_bloom_filter(bf, reader_options);
 }
 
 Status ColumnExprPredicate::convert_to(const ColumnPredicate** output, const TypeInfoPtr& target_type_info,

--- a/be/src/storage/column_expr_predicate.h
+++ b/be/src/storage/column_expr_predicate.h
@@ -45,7 +45,7 @@ public:
     bool zone_map_filter(const ZoneMapDetail& detail) const override;
     bool support_bloom_filter() const override { return false; }
     bool support_ngram_bloom_filter() const override { return _expr_ctxs[0]->support_ngram_bloom_filter(); }
-    bool ngram_bloom_filter(const BloomFilter* bf, size_t gram_num) const override;
+    bool ngram_bloom_filter(const BloomFilter* bf, const BloomFilterReaderOptions& reader_options) const override;
     PredicateType type() const override { return PredicateType::kExpr; }
     bool can_vectorized() const override { return true; }
 

--- a/be/src/storage/column_expr_predicate.h
+++ b/be/src/storage/column_expr_predicate.h
@@ -45,7 +45,7 @@ public:
     bool zone_map_filter(const ZoneMapDetail& detail) const override;
     bool support_bloom_filter() const override { return false; }
     bool support_ngram_bloom_filter() const override { return _expr_ctxs[0]->support_ngram_bloom_filter(); }
-    bool ngram_bloom_filter(const BloomFilter* bf, const BloomFilterReaderOptions& reader_options) const override;
+    bool ngram_bloom_filter(const BloomFilter* bf, const NgramBloomFilterReaderOptions& reader_options) const override;
     PredicateType type() const override { return PredicateType::kExpr; }
     bool can_vectorized() const override { return true; }
 

--- a/be/src/storage/column_predicate.h
+++ b/be/src/storage/column_predicate.h
@@ -47,7 +47,7 @@ class ExprContext;
 class RuntimeState;
 class SlotDescriptor;
 class BitmapIndexIterator;
-class BloomFilter;
+struct BloomFilterReaderOptions;
 } // namespace starrocks
 
 namespace starrocks {
@@ -167,7 +167,9 @@ public:
     virtual bool bloom_filter(const BloomFilter* bf) const { return true; }
 
     // Return false to filter out a data page.
-    virtual bool ngram_bloom_filter(const BloomFilter* bf, size_t gram_num) const { return true; }
+    virtual bool ngram_bloom_filter(const BloomFilter* bf, const BloomFilterReaderOptions& reader_options) const {
+        return true;
+    }
 
     [[nodiscard]] virtual Status seek_bitmap_dictionary(BitmapIndexIterator* iter, SparseRange<>* range) const {
         return Status::Cancelled("not implemented");

--- a/be/src/storage/column_predicate.h
+++ b/be/src/storage/column_predicate.h
@@ -47,7 +47,7 @@ class ExprContext;
 class RuntimeState;
 class SlotDescriptor;
 class BitmapIndexIterator;
-struct BloomFilterReaderOptions;
+struct NgramBloomFilterReaderOptions;
 } // namespace starrocks
 
 namespace starrocks {
@@ -167,7 +167,7 @@ public:
     virtual bool bloom_filter(const BloomFilter* bf) const { return true; }
 
     // Return false to filter out a data page.
-    virtual bool ngram_bloom_filter(const BloomFilter* bf, const BloomFilterReaderOptions& reader_options) const {
+    virtual bool ngram_bloom_filter(const BloomFilter* bf, const NgramBloomFilterReaderOptions& reader_options) const {
         return true;
     }
 

--- a/be/src/storage/metadata_util.cpp
+++ b/be/src/storage/metadata_util.cpp
@@ -311,7 +311,7 @@ Status convert_t_schema_to_pb_schema(const TTabletSchema& tablet_schema, uint32_
 
                 index_pb->set_index_type(IndexType::NGRAMBF);
                 const auto& index_col_name = index.columns[0];
-                const auto& mit = column_map.find(index_col_name);
+                const auto& mit = column_map.find(boost::to_lower_copy(index_col_name));
 
                 if (mit != column_map.end()) {
                     mit->second->set_is_bf_column(true);

--- a/be/src/storage/rowset/bloom_filter.h
+++ b/be/src/storage/rowset/bloom_filter.h
@@ -45,9 +45,12 @@
 #include "util/murmur_hash3.h"
 
 namespace starrocks {
+class Slice;
+
 static const std::string FPP_KEY = "bloom_filter_fpp";
 static const std::string GRAM_NUM_KEY = "gram_num";
 static const std::string CASE_SENSITIVE_KEY = "case_sensitive";
+// used in write
 struct BloomFilterOptions {
     // false positive probablity
     double fpp = 0.05;
@@ -58,9 +61,19 @@ struct BloomFilterOptions {
     bool case_sensitive = true;
 };
 
-struct BloomFilterReaderOptions {
+// used in read from ngram bloom filter
+struct NgramBloomFilterReaderOptions {
     size_t index_gram_num = 0;
     bool index_case_sensitive = true;
+};
+
+struct NgramBloomFilterState {
+    bool initialized = false;
+    // whether this index can be used for predicate or not
+    bool index_useful = false;
+    std::vector<Slice> ngram_set;
+    // when index is case_insensitive, buffer is used to store the lower case of ngram_set
+    std::string buffer;
 };
 
 // Base class for bloom filter

--- a/be/src/storage/rowset/bloom_filter.h
+++ b/be/src/storage/rowset/bloom_filter.h
@@ -47,6 +47,7 @@
 namespace starrocks {
 static const std::string FPP_KEY = "bloom_filter_fpp";
 static const std::string GRAM_NUM_KEY = "gram_num";
+static const std::string CASE_SENSITIVE_KEY = "case_sensitive";
 struct BloomFilterOptions {
     // false positive probablity
     double fpp = 0.05;
@@ -54,6 +55,12 @@ struct BloomFilterOptions {
     bool use_ngram = false;
     // only use when use_ngram is true
     size_t gram_num = 0;
+    bool case_sensitive = true;
+};
+
+struct BloomFilterReaderOptions {
+    size_t index_gram_num = 0;
+    bool index_case_sensitive = true;
 };
 
 // Base class for bloom filter

--- a/be/src/storage/rowset/bloom_filter_index_writer.cpp
+++ b/be/src/storage/rowset/bloom_filter_index_writer.cpp
@@ -186,7 +186,8 @@ private:
     std::vector<std::unique_ptr<BloomFilter>> _bfs;
 };
 
-template <LogicalType field_type>
+// handle most cases
+template <LogicalType field_type, typename Enable = void>
 class NgramBloomFilterIndexWriterImpl : public BloomFilterIndexWriterImpl<field_type> {
 public:
     using CppType = typename CppTypeTraits<field_type>::CppType;
@@ -198,11 +199,14 @@ public:
     void add_values(const void* values, size_t count) override { return; }
 };
 
-template <>
-class NgramBloomFilterIndexWriterImpl<TYPE_VARCHAR> : public BloomFilterIndexWriterImpl<TYPE_VARCHAR> {
+template <LogicalType field_type>
+class NgramBloomFilterIndexWriterImpl<field_type, std::enable_if_t<is_slice_type<field_type>()>>
+        : public BloomFilterIndexWriterImpl<field_type> {
 public:
+    using CppType = typename CppTypeTraits<field_type>::CppType;
+    using BloomFilterIndexWriterImpl<field_type>::_values;
     explicit NgramBloomFilterIndexWriterImpl(const BloomFilterOptions& bf_options, TypeInfoPtr typeinfo)
-            : BloomFilterIndexWriterImpl<TYPE_VARCHAR>(bf_options, std::move(typeinfo)) {}
+            : BloomFilterIndexWriterImpl<field_type>(bf_options, std::move(typeinfo)) {}
 
     void add_values(const void* values, size_t count) override {
         size_t gram_num = this->_bf_options.gram_num;
@@ -221,12 +225,12 @@ public:
                 // add this ngram into set
                 if (_values.find(unaligned_load<CppType>(&cur_ngram)) == _values.end()) {
                     if (this->_bf_options.case_sensitive) {
-                        _values.insert(get_value<TYPE_VARCHAR>(&cur_ngram, this->_typeinfo, &this->_pool));
+                        _values.insert(get_value<field_type>(&cur_ngram, this->_typeinfo, &this->_pool));
                     } else {
                         // todo::exist two copy of ngram, need to optimize
                         std::string lower_ngram;
                         Slice lower_ngram_slice = cur_ngram.tolower(lower_ngram);
-                        _values.insert(get_value<TYPE_VARCHAR>(&lower_ngram_slice, this->_typeinfo, &this->_pool));
+                        _values.insert(get_value<field_type>(&lower_ngram_slice, this->_typeinfo, &this->_pool));
                     }
                 }
             }

--- a/be/src/storage/rowset/bloom_filter_index_writer.cpp
+++ b/be/src/storage/rowset/bloom_filter_index_writer.cpp
@@ -191,7 +191,6 @@ template <LogicalType field_type>
 class NgramBloomFilterIndexWriterImpl : public BloomFilterIndexWriterImpl<field_type> {
 public:
     using CppType = typename CppTypeTraits<field_type>::CppType;
-    using ValueDict = typename BloomFilterTraits<CppType>::ValueDict;
     using BloomFilterIndexWriterImpl<field_type>::_values;
 
     explicit NgramBloomFilterIndexWriterImpl(const BloomFilterOptions& bf_options, TypeInfoPtr typeinfo)
@@ -236,13 +235,14 @@ public:
                         Slice lower_ngram_slice(lower_ngram);
                         _values.insert(get_value<TYPE_VARCHAR>(&cur_ngram, this->_typeinfo, &this->_pool));
                     }
+                }
             }
 
             // move to next row
             ++cur_slice;
         }
     }
-    };
+};
 
 struct BloomFilterBuilderFunctor {
     template <LogicalType ftype>
@@ -256,11 +256,12 @@ struct BloomFilterBuilderFunctor {
         return Status::OK();
     }
 };
+} // namespace
 
 // TODO currently we don't support bloom filter index for tinyint/hll/float/double
 Status BloomFilterIndexWriter::create(const BloomFilterOptions& bf_options, const TypeInfoPtr& typeinfo,
                                       std::unique_ptr<BloomFilterIndexWriter>* res) {
     return field_type_dispatch_bloomfilter(typeinfo->type(), BloomFilterBuilderFunctor(), res, bf_options, typeinfo);
-}
+} // namespace
 
 } // namespace starrocks

--- a/be/src/storage/rowset/column_reader.cpp
+++ b/be/src/storage/rowset/column_reader.cpp
@@ -367,7 +367,8 @@ Status ColumnReader::bloom_filter(const std::vector<const ColumnPredicate*>& pre
         RETURN_IF_ERROR(bf_iter->read_bloom_filter(pid, &bf));
         for (const auto* pred : predicates) {
             if ((pred->support_bloom_filter() && pred->bloom_filter(bf.get())) ||
-                (pred->support_ngram_bloom_filter() && pred->ngram_bloom_filter(bf.get(), _get_gram_num_for_ngram()))) {
+                (pred->support_ngram_bloom_filter() &&
+                 pred->ngram_bloom_filter(bf.get(), _get_reader_options_for_ngram()))) {
                 bf_row_ranges.add(
                         Range<>(_ordinal_index->get_first_ordinal(pid), _ordinal_index->get_last_ordinal(pid) + 1));
             }
@@ -686,9 +687,9 @@ size_t ColumnReader::mem_usage() const {
     return size;
 }
 
-BloomFilterReaderOptions ColumnReader::_get_reader_options_for_ngram() const {
+NgramBloomFilterReaderOptions ColumnReader::_get_reader_options_for_ngram() const {
     // initialize with invalid number
-    BloomFilterReaderOptions reader_options;
+    NgramBloomFilterReaderOptions reader_options;
     std::shared_ptr<TabletIndex> ngram_bf_index;
 
     Status status = _segment->tablet_schema().get_indexes_for_column(_column_unique_id, NGRAMBF, ngram_bf_index);

--- a/be/src/storage/rowset/column_reader.h
+++ b/be/src/storage/rowset/column_reader.h
@@ -78,7 +78,7 @@ class ParsedPage;
 class ZoneMapIndexPB;
 class ZoneMapPB;
 class Segment;
-struct BloomFilterReaderOptions;
+struct NgramBloomFilterReaderOptions;
 
 // There will be concurrent users to read the same column. So
 // we should do our best to reduce resource usage through share
@@ -189,7 +189,7 @@ private:
 
     Status _load_inverted_index(const std::shared_ptr<TabletIndex>& index_meta, const SegmentReadOptions& opts);
 
-    BloomFilterReaderOptions _get_reader_options_for_ngram() const;
+    NgramBloomFilterReaderOptions _get_reader_options_for_ngram() const;
 
     // ColumnReader will be resident in memory. When there are many columns in the table,
     // the meta in ColumnReader takes up a lot of memory,

--- a/be/src/storage/rowset/column_reader.h
+++ b/be/src/storage/rowset/column_reader.h
@@ -78,6 +78,7 @@ class ParsedPage;
 class ZoneMapIndexPB;
 class ZoneMapPB;
 class Segment;
+struct BloomFilterReaderOptions;
 
 // There will be concurrent users to read the same column. So
 // we should do our best to reduce resource usage through share
@@ -187,8 +188,8 @@ private:
                             std::unordered_set<uint32_t>* del_partial_filtered_pages, std::vector<uint32_t>* pages);
 
     Status _load_inverted_index(const std::shared_ptr<TabletIndex>& index_meta, const SegmentReadOptions& opts);
-    // return zero means an invalid gram num
-    size_t _get_gram_num_for_ngram() const;
+
+    BloomFilterReaderOptions _get_reader_options_for_ngram() const;
 
     // ColumnReader will be resident in memory. When there are many columns in the table,
     // the meta in ColumnReader takes up a lot of memory,

--- a/be/src/storage/rowset/column_writer.cpp
+++ b/be/src/storage/rowset/column_writer.cpp
@@ -416,6 +416,12 @@ Status ScalarColumnWriter::init() {
                 const std::string& fpp = it->second; // The value corresponding to the key "bloom_filter_fpp"
                 bf_options.fpp = std::stod(fpp);
             }
+            it = index_properties.find(CASE_SENSITIVE_KEY);
+            if (it != index_properties.end()) {
+                // Found the key "case_sensitive"
+                const std::string& case_sensitive = it->second; // The value corresponding to the key "case_sensitive"
+                bf_options.case_sensitive = (case_sensitive == "true");
+            }
         }
         RETURN_IF_ERROR(BloomFilterIndexWriter::create(bf_options, _type_info, &_bloom_filter_index_builder));
     }

--- a/be/src/storage/schema_change_utils.cpp
+++ b/be/src/storage/schema_change_utils.cpp
@@ -706,6 +706,10 @@ Status SchemaChangeUtils::parse_request_normal(const TabletSchemaCSPtr& base_sch
                        base_schema->has_index(ref_column.unique_id(), GIN)) {
                 *sc_directly = true;
                 return Status::OK();
+            } else if (new_schema->has_index(new_column.unique_id(), NGRAMBF) !=
+                       base_schema->has_index(ref_column.unique_id(), NGRAMBF)) {
+                *sc_directly = true;
+                return Status::OK();
             }
         }
     }

--- a/be/src/util/slice.h
+++ b/be/src/util/slice.h
@@ -34,6 +34,7 @@
 
 #pragma once
 
+#include <algorithm>
 #include <cassert>
 #include <cstddef>
 #include <cstdint>
@@ -339,6 +340,11 @@ private:
 
 inline void swap(OwnedSlice& s1, OwnedSlice& s2) {
     s1.swap(s2);
+}
+
+void inline static tolower(const Slice& str, std::string& buf) {
+    buf.assign(str.get_data(), str.get_size());
+    std::transform(buf.begin(), buf.end(), buf.begin(), [](unsigned char c) { return std::tolower(c); });
 }
 
 } // namespace starrocks

--- a/be/src/util/slice.h
+++ b/be/src/util/slice.h
@@ -183,6 +183,13 @@ public:
         return ((size >= x.size) && memequal(data + (size - x.size), x.size, x.data, x.size));
     }
 
+    Slice tolower(std::string& buf) {
+        // copy this slice into buf
+        buf.assign(get_data(), get_size());
+        std::transform(buf.begin(), buf.end(), buf.begin(), [](unsigned char c) { return std::tolower(c); });
+        return Slice(buf.data(), buf.size());
+    }
+
     /// @brief Comparator struct, useful for ordered collections (like STL maps).
     struct Comparator {
         /// Compare two slices using Slice::compare()
@@ -340,11 +347,6 @@ private:
 
 inline void swap(OwnedSlice& s1, OwnedSlice& s2) {
     s1.swap(s2);
-}
-
-void inline static tolower(const Slice& str, std::string& buf) {
-    buf.assign(str.get_data(), str.get_size());
-    std::transform(buf.begin(), buf.end(), buf.begin(), [](unsigned char c) { return std::tolower(c); });
 }
 
 } // namespace starrocks

--- a/fe/fe-core/src/main/java/com/starrocks/analysis/BloomFilterIndexUtil.java
+++ b/fe/fe-core/src/main/java/com/starrocks/analysis/BloomFilterIndexUtil.java
@@ -70,7 +70,6 @@ public class BloomFilterIndexUtil {
             if (!caseSensitive.equalsIgnoreCase("true") && !caseSensitive.equalsIgnoreCase("false")) {
                 throw new SemanticException("Ngram Bloom filter's case_sensitive should be true or false");
             }
-            properties.remove(CASE_SENSITIVE_KEY);
         }
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/analysis/BloomFilterIndexUtil.java
+++ b/fe/fe-core/src/main/java/com/starrocks/analysis/BloomFilterIndexUtil.java
@@ -28,10 +28,11 @@ import java.util.Map;
 import java.util.Set;
 
 public class BloomFilterIndexUtil {
-    public static String FPP_KEY = NgramBfIndexParamsKey.BLOOM_FILTER_FPP.toString().toLowerCase(Locale.ROOT);
-    public static String GRAM_NUM_KEY = NgramBfIndexParamsKey.GRAM_NUM.toString().toLowerCase(Locale.ROOT);
+    public static final String FPP_KEY = NgramBfIndexParamsKey.BLOOM_FILTER_FPP.toString().toLowerCase(Locale.ROOT);
+    public static final String GRAM_NUM_KEY = NgramBfIndexParamsKey.GRAM_NUM.toString().toLowerCase(Locale.ROOT);
 
-    public static String CASE_SENSITIVE_KEY = NgramBfIndexParamsKey.CASE_SENSITIVE.toString().toLowerCase(Locale.ROOT);
+    public static final String CASE_SENSITIVE_KEY =
+            NgramBfIndexParamsKey.CASE_SENSITIVE.toString().toLowerCase(Locale.ROOT);
     private static final double MAX_FPP = 0.05;
     private static final double MIN_FPP = 0.0001;
 
@@ -49,7 +50,6 @@ public class BloomFilterIndexUtil {
             if (bfFpp < MIN_FPP || bfFpp > MAX_FPP) {
                 throw new SemanticException("Bloom filter fpp should in [" + MIN_FPP + ", " + MAX_FPP + "]");
             }
-            properties.remove(FPP_KEY);
         }
 
         return bfFpp;
@@ -61,7 +61,6 @@ public class BloomFilterIndexUtil {
             if (gram_num <= 0) {
                 throw new SemanticException("Ngram Bloom filter's gram_num should be positive number");
             }
-            properties.remove(GRAM_NUM_KEY);
         }
     }
 
@@ -92,14 +91,9 @@ public class BloomFilterIndexUtil {
             throw new SemanticException("Ngram Bloom filter index only used in columns of DUP_KEYS/PRIMARY table or "
                     + "key columns of UNIQUE_KEYS/AGG_KEYS table. invalid column: " + column.getName());
         }
-
         analyzeBloomFilterFpp(properties);
         analyzeBloomFilterGramNum(properties);
-        analyzeBloomFilterGramNum(properties);
         analyzeBloomFilterCaseSensitive(properties);
-        if (!properties.isEmpty()) {
-            throw new SemanticException("Invalid properties for Ngram Bloom filter index: " + properties.keySet());
-        }
     }
 
     public static void analyseBfWithNgramBf(Set<Index> newIndexs, Set<String> bfColumns) throws AnalysisException {

--- a/fe/fe-core/src/main/java/com/starrocks/common/FeConstants.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/FeConstants.java
@@ -45,6 +45,9 @@ public class FeConstants {
 
     // NGRAM Bloom filter's default gram number
     public static final int DEFAULT_GRAM_NUM = 2;
+
+    public static final String NGRAM_CASE_SENSITIVE = "true";
+
     // general model
     @Deprecated
     // for rollback compatible

--- a/fe/fe-core/src/main/java/com/starrocks/common/FeConstants.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/FeConstants.java
@@ -46,7 +46,7 @@ public class FeConstants {
     // NGRAM Bloom filter's default gram number
     public static final int DEFAULT_GRAM_NUM = 2;
 
-    public static final String NGRAM_CASE_SENSITIVE = "true";
+    public static final Boolean NGRAM_CASE_SENSITIVE = true;
 
     // general model
     @Deprecated

--- a/fe/fe-core/src/main/java/com/starrocks/common/NgramBfIndexParamsKey.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/NgramBfIndexParamsKey.java
@@ -25,7 +25,8 @@ public enum NgramBfIndexParamsKey implements ParamsKey {
     /**
      * bloom filter's false positive possibility
      */
-    BLOOM_FILTER_FPP(String.valueOf(FeConstants.DEFAULT_BLOOM_FILTER_FPP), true);
+    BLOOM_FILTER_FPP(String.valueOf(FeConstants.DEFAULT_BLOOM_FILTER_FPP), true),
+    CASE_SENSITIVE(FeConstants.NGRAM_CASE_SENSITIVE, true);
 
     private final String defaultValue;
     private boolean needDefault = false;

--- a/fe/fe-core/src/main/java/com/starrocks/common/NgramBfIndexParamsKey.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/NgramBfIndexParamsKey.java
@@ -26,7 +26,7 @@ public enum NgramBfIndexParamsKey implements ParamsKey {
      * bloom filter's false positive possibility
      */
     BLOOM_FILTER_FPP(String.valueOf(FeConstants.DEFAULT_BLOOM_FILTER_FPP), true),
-    CASE_SENSITIVE(FeConstants.NGRAM_CASE_SENSITIVE, true);
+    CASE_SENSITIVE(String.valueOf(FeConstants.NGRAM_CASE_SENSITIVE), true);
 
     private final String defaultValue;
     private boolean needDefault = false;

--- a/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AnalyzeCreateTableTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AnalyzeCreateTableTest.java
@@ -441,9 +441,9 @@ public class AnalyzeCreateTableTest {
 
         // create index with invalid properties
         sql = "CREATE TABLE TABLE1 (COL1 INT, COL2 VARCHAR(10)," +
-                "INDEX INDEX1(COL2) USING NGRAMBF ('BLOOM_FILTER_FPP' = '0.01', 'GRAM_NUM' = '2', 'INVALID' = '2'))" +
+                "INDEX INDEX1(COL2) USING NGRAMBF ('BLOOM_FILTER_FPP' = '0.01', 'GRAM_NUM' = '2', 'CASE_SENSITIVE' = '2'))" +
                 "AGGREGATE KEY(COL1, COL2) DISTRIBUTED BY HASH(COL1) BUCKETS 10;";
-        analyzeFail(sql, "Invalid properties for Ngram Bloom filter index");
+        analyzeFail(sql, "Ngram Bloom filter's case_sensitive should be true or false");
 
         // create index with correct fpp and gram num and case-insensitive
         sql = "CREATE TABLE TABLE1 (COL1 INT, COL2 VARCHAR(10)," +

--- a/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AnalyzeCreateTableTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AnalyzeCreateTableTest.java
@@ -439,9 +439,15 @@ public class AnalyzeCreateTableTest {
         analyzeFail(sql, "Ngram Bloom filter index only used in columns of " +
                 "DUP_KEYS/PRIMARY table or key columns of UNIQUE_KEYS/AGG_KEYS table");
 
-        // create index with correct fpp and gram num
+        // create index with invalid properties
         sql = "CREATE TABLE TABLE1 (COL1 INT, COL2 VARCHAR(10)," +
-                "INDEX INDEX1(COL2) USING NGRAMBF ('BLOOM_FILTER_FPP' = '0.01', 'GRAM_NUM' = '2'))" +
+                "INDEX INDEX1(COL2) USING NGRAMBF ('BLOOM_FILTER_FPP' = '0.01', 'GRAM_NUM' = '2', 'INVALID' = '2'))" +
+                "AGGREGATE KEY(COL1, COL2) DISTRIBUTED BY HASH(COL1) BUCKETS 10;";
+        analyzeFail(sql, "Invalid properties for Ngram Bloom filter index");
+
+        // create index with correct fpp and gram num and case-insensitive
+        sql = "CREATE TABLE TABLE1 (COL1 INT, COL2 VARCHAR(10)," +
+                "INDEX INDEX1(COL2) USING NGRAMBF ('BLOOM_FILTER_FPP' = '0.01', 'GRAM_NUM' = '2', 'CASE_SENSITIVE' = 'false'))" +
                 "AGGREGATE KEY(COL1, COL2) DISTRIBUTED BY HASH(COL1) BUCKETS 10;";
         analyzeSuccess(sql);
     }

--- a/test/sql/test_index/R/test_ngram_bloom_filter
+++ b/test/sql/test_index/R/test_ngram_bloom_filter
@@ -101,3 +101,100 @@ show index from ngram_index_default_3;
 -- result:
 ngram_bloom_filter_db_2.ngram_index_default_3		idx_name1		username						NGRAMBF	
 -- !result
+-- name: test_ngram_bloom_filter_like
+CREATE TABLE ngram_index_like(
+    timestamp DATETIME NOT NULL,
+    username STRING,
+    price INT NULL,
+    INDEX idx_name1(username) USING NGRAMBF ("gram_num" = "4", "bloom_filter_fpp" = "0.05")
+)PROPERTIES ("replication_num" = "1");
+-- result:
+-- !result
+insert into ngram_index_like values ('2023-01-01',"hina",3);
+-- result:
+-- !result
+insert into ngram_index_like values ('2023-01-01',"chinese",3);
+-- result:
+-- !result
+select * from ngram_index_like where username like 'chia%';
+-- result:
+-- !result
+select * from ngram_index_like where username like '_hine%';
+-- result:
+2023-01-01 00:00:00	chinese	3
+-- !result
+select * from ngram_index_like where username like '_hin%';
+-- result:
+2023-01-01 00:00:00	chinese	3
+-- !result
+-- name: test_ngram_bloom_filter_case_insensitive
+CREATE TABLE ngram_index_case_in_sensitive(
+    timestamp DATETIME NOT NULL,
+    Username STRING,
+    price INT NULL
+)PROPERTIES ("replication_num" = "1");
+-- result:
+-- !result
+insert into ngram_index_case_in_sensitive values ('2023-01-01',"aAbac",3);
+-- result:
+-- !result
+insert into ngram_index_case_in_sensitive values ('2023-01-01',"AaBAa",3);
+-- result:
+-- !result
+select ngram_search(Username,"aabaa",4) as order_col from ngram_index_case_in_sensitive order by order_col desc;
+-- result:
+0.0
+0.0
+-- !result
+select ngram_search_case_insensitive(Username,"aabaa",4) as order_col from ngram_index_case_in_sensitive order by order_col desc;
+-- result:
+1.0
+0.5
+-- !result
+ALTER TABLE ngram_index_case_in_sensitive ADD INDEX idx_name1(Username) USING NGRAMBF ('gram_num' = "4", "bloom_filter_fpp" = "0.01");
+-- result:
+-- !result
+function: wait_alter_table_finish()
+-- result:
+None
+-- !result
+select * from ngram_index_case_in_sensitive order by ngram_search(Username,"aabaa",4) desc;
+-- result:
+-- !result
+select * from ngram_index_case_in_sensitive order by ngram_search_case_insensitive(Username,"aabaa",4) desc;
+-- result:
+2023-01-01 00:00:00	AaBAa	3
+2023-01-01 00:00:00	aAbac	3
+-- !result
+drop index idx_name1 on ngram_index_case_in_sensitive;
+-- result:
+-- !result
+function: wait_alter_table_finish()
+-- result:
+None
+-- !result
+ALTER TABLE ngram_index_case_in_sensitive ADD INDEX idx_name1(Username) USING NGRAMBF ('gram_num' = "4", "bloom_filter_fpp" = "0.05", "case_sensitive" = "false");
+-- result:
+-- !result
+function: wait_alter_table_finish()
+-- result:
+None
+-- !result
+select * from ngram_index_case_in_sensitive order by ngram_search(Username,"aabaa",4) desc;
+-- result:
+2023-01-01 00:00:00	aAbac	3
+2023-01-01 00:00:00	AaBAa	3
+-- !result
+select * from ngram_index_case_in_sensitive order by ngram_search_case_insensitive(Username,"aabaa",4) desc;
+-- result:
+2023-01-01 00:00:00	AaBAa	3
+2023-01-01 00:00:00	aAbac	3
+-- !result
+insert into ngram_index_case_in_sensitive values ('2023-01-01',"DDDDDDd",3);
+-- result:
+-- !result
+select * from ngram_index_case_in_sensitive order by ngram_search_case_insensitive(Username,"aabaa",4) desc;
+-- result:
+2023-01-01 00:00:00	AaBAa	3
+2023-01-01 00:00:00	aAbac	3
+-- !result

--- a/test/sql/test_index/R/test_ngram_bloom_filter
+++ b/test/sql/test_index/R/test_ngram_bloom_filter
@@ -17,15 +17,15 @@ show index from ngram_index;
 -- result:
 ngram_bloom_filter_db_1.ngram_index		idx_name1		username						NGRAMBF("bloom_filter_fpp" = "0.05", "gram_num" = "4")	
 -- !result
-insert into ngram_index values ('2023-01-01',"chinese",3),('2023-01-02',"chineeeinese",4),('2023-01-03',"我爱吃烤全羊yangyangchinchin",4),('2023-01-04',"tonightisgreadchin",4);
+insert into ngram_index values ('2023-01-01',"chinese",3),('2023-01-02',"chineaaaaaaaaaaaab",4),('2023-01-03',"我爱吃烤全羊yangyangchin",4),('2023-01-04',"tonightisgreadnight",4);
 -- result:
 -- !result
 select * from ngram_index order by ngram_search(username, 'chinese',4) desc;
 -- result:
 2023-01-01 00:00:00	chinese	3
-2023-01-02 00:00:00	chineeeinese	4
-2023-01-03 00:00:00	我爱吃烤全羊yangyangchinchin	4
-2023-01-04 00:00:00	tonightisgreadchin	4
+2023-01-02 00:00:00	chineaaaaaaaaaaaab	4
+2023-01-03 00:00:00	我爱吃烤全羊yangyangchin	4
+2023-01-04 00:00:00	tonightisgreadnight	4
 -- !result
 drop index idx_name1 on ngram_index;
 -- result:
@@ -51,9 +51,9 @@ ngram_bloom_filter_db_1.ngram_index		idx_name1		username						NGRAMBF("bloom_fil
 select * from ngram_index order by  ngram_search(username, 'chinese',4) desc;
 -- result:
 2023-01-01 00:00:00	chinese	3
-2023-01-02 00:00:00	chineeeinese	4
-2023-01-03 00:00:00	我爱吃烤全羊yangyangchinchin	4
-2023-01-04 00:00:00	tonightisgreadchin	4
+2023-01-02 00:00:00	chineaaaaaaaaaaaab	4
+2023-01-03 00:00:00	我爱吃烤全羊yangyangchin	4
+2023-01-04 00:00:00	tonightisgreadnight	4
 -- !result
 drop database ngram_bloom_filter_db_1;
 -- result:

--- a/test/sql/test_index/R/test_ngram_bloom_filter
+++ b/test/sql/test_index/R/test_ngram_bloom_filter
@@ -58,6 +58,7 @@ select * from ngram_index order by  ngram_search(username, 'chinese',4) desc;
 drop database ngram_bloom_filter_db_1;
 -- result:
 -- !result
+
 -- name: test_ngram_bloom_filter_default
 create database ngram_bloom_filter_db_2;
 -- result:
@@ -101,6 +102,7 @@ show index from ngram_index_default_3;
 -- result:
 ngram_bloom_filter_db_2.ngram_index_default_3		idx_name1		username						NGRAMBF	
 -- !result
+
 -- name: test_ngram_bloom_filter_like
 CREATE TABLE ngram_index_like(
     timestamp DATETIME NOT NULL,
@@ -127,6 +129,7 @@ select * from ngram_index_like where username like '_hin%';
 -- result:
 2023-01-01 00:00:00	chinese	3
 -- !result
+
 -- name: test_ngram_bloom_filter_case_insensitive
 CREATE TABLE ngram_index_case_in_sensitive(
     timestamp DATETIME NOT NULL,
@@ -197,4 +200,30 @@ select * from ngram_index_case_in_sensitive order by ngram_search_case_insensiti
 -- result:
 2023-01-01 00:00:00	AaBAa	3
 2023-01-01 00:00:00	aAbac	3
+-- !result
+
+-- name: test_ngram_bloom_filter_char
+create database ngram_bloom_filter_db_3;
+-- result:
+-- !result
+use ngram_bloom_filter_db_3;
+-- result:
+-- !result
+CREATE TABLE ngram_index_char(
+    timestamp DATETIME NOT NULL,
+    username char(20) NOT NULL,
+    price INT NULL,
+    INDEX idx_name1(username) USING NGRAMBF ("gram_num" = "4", "bloom_filter_fpp" = "0.05")
+)PROPERTIES ("replication_num" = "1");
+-- result:
+-- !result
+show index from ngram_index_char;
+-- result:
+ngram_bloom_filter_db_3.ngram_index_char		idx_name1		username						NGRAMBF("bloom_filter_fpp" = "0.05", "gram_num" = "4")	
+-- !result
+insert into ngram_index_char values ('2023-01-01',"chinese",3),('2023-01-02',"chineaaa",4),('2023-01-03',"我爱chin",4),('2023-01-04',"toniggrht",4);
+-- result:
+-- !result
+select * from ngram_index_char where username like '_hiaa%';
+-- result:
 -- !result

--- a/test/sql/test_index/T/test_ngram_bloom_filter
+++ b/test/sql/test_index/T/test_ngram_bloom_filter
@@ -10,7 +10,7 @@ CREATE TABLE ngram_index(
 
 show index from ngram_index;
 
-insert into ngram_index values ('2023-01-01',"chinese",3),('2023-01-02',"chineeeinese",4),('2023-01-03',"我爱吃烤全羊yangyangchinchin",4),('2023-01-04',"tonightisgreadchin",4);
+insert into ngram_index values ('2023-01-01',"chinese",3),('2023-01-02',"chineaaaaaaaaaaaab",4),('2023-01-03',"我爱吃烤全羊yangyangchin",4),('2023-01-04',"tonightisgreadnight",4);
 
 select * from ngram_index order by ngram_search(username, 'chinese',4) desc;
 drop index idx_name1 on ngram_index;

--- a/test/sql/test_index/T/test_ngram_bloom_filter
+++ b/test/sql/test_index/T/test_ngram_bloom_filter
@@ -104,3 +104,19 @@ select * from ngram_index_case_in_sensitive order by ngram_search_case_insensiti
 insert into ngram_index_case_in_sensitive values ('2023-01-01',"DDDDDDd",3);
 --  one row is filterd
 select * from ngram_index_case_in_sensitive order by ngram_search_case_insensitive(Username,"aabaa",4) desc;
+
+
+-- name: test_ngram_bloom_filter_char
+create database ngram_bloom_filter_db_3;
+use ngram_bloom_filter_db_3;
+CREATE TABLE ngram_index_char(
+    timestamp DATETIME NOT NULL,
+    username char(20) NOT NULL,
+    price INT NULL,
+    INDEX idx_name1(username) USING NGRAMBF ("gram_num" = "4", "bloom_filter_fpp" = "0.05")
+)PROPERTIES ("replication_num" = "1");
+
+show index from ngram_index_char;
+
+insert into ngram_index_char values ('2023-01-01',"chinese",3),('2023-01-02',"chineaaa",4),('2023-01-03',"我爱chin",4),('2023-01-04',"toniggrht",4);
+select * from ngram_index_char where username like '_hiaa%';

--- a/test/sql/test_index/T/test_ngram_bloom_filter
+++ b/test/sql/test_index/T/test_ngram_bloom_filter
@@ -49,3 +49,58 @@ CREATE TABLE ngram_index_default_3(
     INDEX idx_name1(username) USING NGRAMBF
 )PROPERTIES ("replication_num" = "1");
 show index from ngram_index_default_3;
+
+-- name: test_ngram_bloom_filter_like
+CREATE TABLE ngram_index_like(
+    timestamp DATETIME NOT NULL,
+    username STRING,
+    price INT NULL,
+    INDEX idx_name1(username) USING NGRAMBF ("gram_num" = "4", "bloom_filter_fpp" = "0.05")
+)PROPERTIES ("replication_num" = "1");
+
+insert into ngram_index_like values ('2023-01-01',"hina",3);
+insert into ngram_index_like values ('2023-01-01',"chinese",3);
+-- 2 rows are filterd
+select * from ngram_index_like where username like 'chia%';
+-- one row output, one row is filterd
+select * from ngram_index_like where username like '_hine%';
+-- this can not use index
+select * from ngram_index_like where username like '_hin%';
+
+
+-- name: test_ngram_bloom_filter_case_insensitive
+CREATE TABLE ngram_index_case_in_sensitive(
+    timestamp DATETIME NOT NULL,
+    Username STRING,
+    price INT NULL
+)PROPERTIES ("replication_num" = "1");
+insert into ngram_index_case_in_sensitive values ('2023-01-01',"aAbac",3);
+insert into ngram_index_case_in_sensitive values ('2023-01-01',"AaBAa",3);
+
+select ngram_search(Username,"aabaa",4) as order_col from ngram_index_case_in_sensitive order by order_col desc;
+
+select ngram_search_case_insensitive(Username,"aabaa",4) as order_col from ngram_index_case_in_sensitive order by order_col desc;
+
+
+ALTER TABLE ngram_index_case_in_sensitive ADD INDEX idx_name1(Username) USING NGRAMBF ('gram_num' = "4", "bloom_filter_fpp" = "0.01");
+function: wait_alter_table_finish()
+
+-- index and function is case sensitive, so tow rows is filterd
+select * from ngram_index_case_in_sensitive order by ngram_search(Username,"aabaa",4) desc;
+-- function is case insensitive, index is sensitive, so index doesn't filter any data
+select * from ngram_index_case_in_sensitive order by ngram_search_case_insensitive(Username,"aabaa",4) desc;
+
+drop index idx_name1 on ngram_index_case_in_sensitive;
+function: wait_alter_table_finish()
+
+ALTER TABLE ngram_index_case_in_sensitive ADD INDEX idx_name1(Username) USING NGRAMBF ('gram_num' = "4", "bloom_filter_fpp" = "0.05", "case_sensitive" = "false");
+function: wait_alter_table_finish()
+-- function is case sensitive, index is case insensitive, index doesn't filter any data 
+-- because tow rows all hit bloom filter if case insensitive, which is a bad case
+select * from ngram_index_case_in_sensitive order by ngram_search(Username,"aabaa",4) desc;
+
+-- both are case insensitive, can't filter data 
+select * from ngram_index_case_in_sensitive order by ngram_search_case_insensitive(Username,"aabaa",4) desc;
+insert into ngram_index_case_in_sensitive values ('2023-01-01',"DDDDDDd",3);
+--  one row is filterd
+select * from ngram_index_case_in_sensitive order by ngram_search_case_insensitive(Username,"aabaa",4) desc;


### PR DESCRIPTION
## Why I'm doing:
ngram  bloom filter index support like predicate and "case_insensitive" property. "case_insensitive" property is for some  string function which is case insensitive like "ngram_search_case_insensitive"

for sql  in clickbench:
`"SELECT SearchPhrase, MIN(URL), MIN(Title), COUNT(*) AS c, COUNT(DISTINCT UserID) FROM hits WHERE Title LIKE '%Google%' AND URL NOT LIKE '%.google.%' AND SearchPhrase <> '' GROUP BY SearchPhrase ORDER BY c DESC LIMIT 10;"` using 1fe 3be(6core+32GB)

before this pr: 0.81s
after this pr with index on column "Title": 0.28s
`ALTER TABLE hits ADD INDEX idx_name1(Title) USING NGRAMBF ('gram_num' = "5", "bloom_filter_fpp" = "0.05");`

profile:

```
- BloomFilterFilter: 45.875ms
 - __MAX_OF_BloomFilterFilter: 57.738ms
 - __MIN_OF_BloomFilterFilter: 40.006ms
- BloomFilterFilterRows: 85.727M (85726654)
 - __MAX_OF_BloomFilterFilterRows: 3.648M (3648042)
 - __MIN_OF_BloomFilterFilterRows: 3.527M (3526633)
```


## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
- [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
