### PR TITLE
[Feature] S3 storage volume support partitioned prefix feature

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/OlapTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/OlapTable.java
@@ -84,6 +84,7 @@ import com.starrocks.common.util.TimeUtils;
 import com.starrocks.common.util.Util;
 import com.starrocks.common.util.concurrent.MarkedCountDownLatch;
 import com.starrocks.lake.DataCacheInfo;
+import com.starrocks.lake.StarOSAgent;
 import com.starrocks.lake.StorageInfo;
 import com.starrocks.persist.ColocatePersistInfo;
 import com.starrocks.qe.OriginStatement;
@@ -3045,10 +3046,7 @@ public class OlapTable extends Table {
     public FilePathInfo getPartitionFilePathInfo(long partitionId) {
         FilePathInfo pathInfo = getDefaultFilePathInfo();
         if (pathInfo != null) {
-            FilePathInfo.Builder builder = FilePathInfo.newBuilder();
-            builder.mergeFrom(pathInfo);
-            builder.setFullPath(builder.getFullPath() + "/" + partitionId);
-            return builder.build();
+            return StarOSAgent.allocatePartitionFilePathInfo(pathInfo, partitionId);
         }
         return null;
     }

--- a/fe/fe-core/src/main/java/com/starrocks/credential/CloudConfigurationConstants.java
+++ b/fe/fe-core/src/main/java/com/starrocks/credential/CloudConfigurationConstants.java
@@ -32,6 +32,13 @@ public class CloudConfigurationConstants {
     public static final String AWS_S3_ENDPOINT = "aws.s3.endpoint";
 
     // Configuration for AWS s3
+    /**
+     * Storage Volume specific parameters
+     */
+    // whether enable partitioned prefix layout on s3 storage
+    public static final String AWS_S3_ENABLE_PARTITIONED_PREFIX = "aws.s3.enable_partitioned_prefix";
+    // how many partitions to be created as the prefix.
+    public static final String AWS_S3_NUM_PARTITIONED_PREFIX = "aws.s3.num_partitioned_prefix";
 
     /**
      * Enable S3 path style access ie disabling the default virtual hosting behaviour.

--- a/fe/fe-core/src/main/java/com/starrocks/lake/StarOSAgent.java
+++ b/fe/fe-core/src/main/java/com/starrocks/lake/StarOSAgent.java
@@ -724,4 +724,9 @@ public class StarOSAgent {
         Preconditions.checkState(shardInfos.size() == 1);
         return shardInfos.get(0);
     }
+
+    public static FilePathInfo allocatePartitionFilePathInfo(FilePathInfo tableFilePathInfo, long partitionId) {
+        String allocPath = StarClient.allocateFilePath(tableFilePathInfo, Long.hashCode(partitionId));
+        return tableFilePathInfo.toBuilder().setFullPath(String.format("%s/%d", allocPath, partitionId)).build();
+    }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/server/SharedNothingStorageVolumeMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/SharedNothingStorageVolumeMgr.java
@@ -16,6 +16,7 @@ package com.starrocks.server;
 
 import com.google.gson.annotations.SerializedName;
 import com.staros.util.LockCloseable;
+import com.starrocks.common.DdlException;
 import com.starrocks.common.InvalidConfException;
 import com.starrocks.persist.DropStorageVolumeLog;
 import com.starrocks.persist.metablock.SRMetaBlockEOFException;
@@ -66,7 +67,7 @@ public class SharedNothingStorageVolumeMgr extends StorageVolumeMgr {
     @Override
     protected String createInternalNoLock(String name, String svType, List<String> locations,
                                           Map<String, String> params, Optional<Boolean> enabled,
-                                          String comment) {
+                                          String comment) throws DdlException {
         String id = UUID.randomUUID().toString();
         StorageVolume sv = new StorageVolume(id, name, svType, locations, params, enabled.orElse(true), comment);
         GlobalStateMgr.getCurrentState().getEditLog().logCreateStorageVolume(sv);

--- a/fe/fe-core/src/main/java/com/starrocks/server/StorageVolumeMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/StorageVolumeMgr.java
@@ -15,6 +15,7 @@
 package com.starrocks.server;
 
 import com.google.common.base.Preconditions;
+import com.google.common.collect.Lists;
 import com.google.gson.annotations.SerializedName;
 import com.staros.util.LockCloseable;
 import com.starrocks.common.AlreadyExistsException;
@@ -164,6 +165,14 @@ public abstract class StorageVolumeMgr implements Writable, GsonPostProcessable 
             StorageVolume copied = new StorageVolume(sv);
             validateParams(copied.getType(), params);
 
+            List<String> immutableProperties =
+                    Lists.newArrayList(CloudConfigurationConstants.AWS_S3_NUM_PARTITIONED_PREFIX,
+                            CloudConfigurationConstants.AWS_S3_ENABLE_PARTITIONED_PREFIX);
+            for (String param : immutableProperties) {
+                if (params.containsKey(param)) {
+                    throw new DdlException(String.format("Storage volume property '%s' is immutable!", param));
+                }
+            }
             if (enabled.isPresent()) {
                 boolean enabledValue = enabled.get();
                 if (!enabledValue) {
@@ -289,6 +298,36 @@ public abstract class StorageVolumeMgr implements Writable, GsonPostProcessable 
         for (String key : params.keySet()) {
             if (!PARAM_NAMES.contains(key)) {
                 throw new DdlException("Invalid properties " + key);
+            }
+        }
+
+        // storage volume type specific checks
+        if (!svType.equalsIgnoreCase(S3)) {
+            // The following two properties can be only set when storage volume type is 'S3'
+            List<String> s3Params = Lists.newArrayList(
+                    CloudConfigurationConstants.AWS_S3_NUM_PARTITIONED_PREFIX,
+                    CloudConfigurationConstants.AWS_S3_ENABLE_PARTITIONED_PREFIX);
+            for (String param : s3Params) {
+                if (params.containsKey(param)) {
+                    throw new DdlException(
+                            String.format("Invalid property '%s' for storage volume type '%s'", param, svType));
+                }
+            }
+        }
+        if (params.containsKey(CloudConfigurationConstants.AWS_S3_NUM_PARTITIONED_PREFIX)) {
+            try {
+                int value = Integer.parseInt(params.get(CloudConfigurationConstants.AWS_S3_NUM_PARTITIONED_PREFIX));
+                if (value < 0) {
+                    throw new DdlException(String.format(
+                            "Invalid property value '%s' for property '%s', expecting a positive integer string.",
+                            params.get(CloudConfigurationConstants.AWS_S3_NUM_PARTITIONED_PREFIX),
+                            CloudConfigurationConstants.AWS_S3_NUM_PARTITIONED_PREFIX));
+                }
+            } catch (NumberFormatException e) {
+                throw new DdlException(String.format(
+                        "Invalid property value '%s' for property '%s', expecting a valid integer string.",
+                        params.get(CloudConfigurationConstants.AWS_S3_NUM_PARTITIONED_PREFIX),
+                        CloudConfigurationConstants.AWS_S3_NUM_PARTITIONED_PREFIX));
             }
         }
     }

--- a/fe/fe-core/src/test/java/com/starrocks/credential/AWSCloudConfigurationTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/credential/AWSCloudConfigurationTest.java
@@ -14,6 +14,8 @@
 
 package com.starrocks.credential;
 
+import com.staros.proto.FileStoreInfo;
+import com.starrocks.credential.aws.AWSCloudConfiguration;
 import com.starrocks.credential.aws.AWSCloudCredential;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hive.conf.HiveConf;
@@ -131,6 +133,59 @@ public class AWSCloudConfigurationTest {
         {
             AWSCloudCredential credential = CloudConfigurationFactory.buildGlueCloudCredential(hiveConf);
             Assert.assertNotNull(credential);
+        }
+    }
+
+    @Test
+    public void testEnablePartitionedPrefixConfiguration() {
+        Map<String, String> properties = new HashMap<>();
+        properties.put("aws.s3.access_key", "ak");
+        properties.put("aws.s3.secret_key", "sk");
+        properties.put("aws.s3.iam_role_arn", "arn");
+        properties.put("aws.s3.sts.endpoint", "endpoint");
+
+        {
+            CloudConfiguration cloudConfiguration =
+                    CloudConfigurationFactory.buildCloudConfigurationForStorage(properties, true);
+            Assert.assertNotNull(cloudConfiguration);
+            Assert.assertTrue(cloudConfiguration instanceof AWSCloudConfiguration);
+            FileStoreInfo fsInfo = cloudConfiguration.toFileStoreInfo();
+            Assert.assertFalse(fsInfo.getS3FsInfo().getPartitionedPrefixEnabled());
+            Assert.assertEquals(0, fsInfo.getS3FsInfo().getNumPartitionedPrefix());
+        }
+
+        properties.put("aws.s3.enable_partitioned_prefix", "true");
+        {
+            CloudConfiguration cloudConfiguration =
+                    CloudConfigurationFactory.buildCloudConfigurationForStorage(properties);
+            Assert.assertTrue(cloudConfiguration instanceof AWSCloudConfiguration);
+            FileStoreInfo fsInfo = cloudConfiguration.toFileStoreInfo();
+            Assert.assertTrue(fsInfo.getS3FsInfo().getPartitionedPrefixEnabled());
+            // set default to 256
+            Assert.assertEquals(256, fsInfo.getS3FsInfo().getNumPartitionedPrefix());
+        }
+
+        properties.put("aws.s3.num_partitioned_prefix", "not_a_number");
+        {
+            // invalid number for partitioned_prefix property
+            Assert.assertThrows(IllegalArgumentException.class, () ->
+                    CloudConfigurationFactory.buildCloudConfigurationForStorage(properties));
+        }
+
+        properties.put("aws.s3.num_partitioned_prefix", "-12");
+        {
+            // must be positive integer
+            Assert.assertThrows(IllegalArgumentException.class, () ->
+                    CloudConfigurationFactory.buildCloudConfigurationForStorage(properties));
+        }
+        properties.put("aws.s3.num_partitioned_prefix", "1024");
+        {
+            CloudConfiguration cloudConfiguration =
+                    CloudConfigurationFactory.buildCloudConfigurationForStorage(properties);
+            Assert.assertTrue(cloudConfiguration instanceof AWSCloudConfiguration);
+            FileStoreInfo fsInfo = cloudConfiguration.toFileStoreInfo();
+            Assert.assertTrue(fsInfo.getS3FsInfo().getPartitionedPrefixEnabled());
+            Assert.assertEquals(1024, fsInfo.getS3FsInfo().getNumPartitionedPrefix());
         }
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/pseudocluster/PseudoClusterTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/pseudocluster/PseudoClusterTest.java
@@ -22,6 +22,7 @@ import com.staros.proto.FileStoreType;
 import com.staros.proto.S3FileStoreInfo;
 import com.starrocks.common.AnalysisException;
 import com.starrocks.common.Config;
+import com.starrocks.common.DdlException;
 import com.starrocks.lake.StarOSAgent;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.server.RunMode;
@@ -239,7 +240,7 @@ public class PseudoClusterTest {
 
         new MockUp<SharedNothingStorageVolumeMgr>() {
             @Mock
-            public StorageVolume getStorageVolume(String svKey) throws AnalysisException {
+            public StorageVolume getStorageVolume(String svKey) throws AnalysisException, DdlException {
                 return StorageVolume.fromFileStoreInfo(fsInfo);
             }
 

--- a/fe/fe-core/src/test/java/com/starrocks/storagevolume/StorageVolumeTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/storagevolume/StorageVolumeTest.java
@@ -30,6 +30,7 @@ import com.starrocks.common.io.FastByteArrayOutputStream;
 import com.starrocks.common.jmockit.Deencapsulation;
 import com.starrocks.connector.hadoop.HadoopExt;
 import com.starrocks.credential.CloudConfiguration;
+import com.starrocks.credential.CloudConfigurationConstants;
 import com.starrocks.credential.CloudType;
 import com.starrocks.credential.aws.AWSCloudConfiguration;
 import com.starrocks.credential.hdfs.HDFSCloudConfiguration;
@@ -82,7 +83,7 @@ public class StorageVolumeTest {
     }
 
     @Test
-    public void testAWSDefaultCredential() throws AnalysisException {
+    public void testAWSDefaultCredential() throws AnalysisException, DdlException {
         Map<String, String> storageParams = new HashMap<>();
         storageParams.put(AWS_S3_REGION, "region");
         storageParams.put(AWS_S3_ENDPOINT, "endpoint");
@@ -104,7 +105,7 @@ public class StorageVolumeTest {
     }
 
     @Test
-    public void testAWSSimpleCredential() throws AnalysisException {
+    public void testAWSSimpleCredential() throws AnalysisException, DdlException {
         Map<String, String> storageParams = new HashMap<>();
         storageParams.put(AWS_S3_REGION, "region");
         storageParams.put(AWS_S3_ENDPOINT, "endpoint");
@@ -131,7 +132,7 @@ public class StorageVolumeTest {
     }
 
     @Test
-    public void testAWSInstanceProfile() throws AnalysisException {
+    public void testAWSInstanceProfile() throws AnalysisException, DdlException {
         Map<String, String> storageParams = new HashMap<>();
         storageParams.put(AWS_S3_REGION, "region");
         storageParams.put(AWS_S3_ENDPOINT, "endpoint");
@@ -154,7 +155,7 @@ public class StorageVolumeTest {
     }
 
     @Test
-    public void testAWSAssumeIamRole() throws AnalysisException {
+    public void testAWSAssumeIamRole() throws AnalysisException, DdlException {
         Map<String, String> storageParams = new HashMap<>();
         storageParams.put(AWS_S3_REGION, "region");
         storageParams.put(AWS_S3_ENDPOINT, "endpoint");
@@ -196,7 +197,7 @@ public class StorageVolumeTest {
     }
 
     @Test
-    public void testHDFSSimpleCredential() {
+    public void testHDFSSimpleCredential() throws DdlException {
         Map<String, String> storageParams = new HashMap<>();
         storageParams.put(HDFS_AUTHENTICATION, HDFSCloudCredential.SIMPLE_AUTH);
         storageParams.put(HDFS_USERNAME, "username");
@@ -249,7 +250,7 @@ public class StorageVolumeTest {
     }
 
     @Test
-    public void testHDFSKerberosCredential() throws AnalysisException {
+    public void testHDFSKerberosCredential() throws AnalysisException, DdlException {
         Map<String, String> storageParams = new HashMap<>();
         storageParams.put(HDFS_AUTHENTICATION, HDFSCloudCredential.KERBEROS_AUTH);
         storageParams.put(HDFS_KERBEROS_PRINCIPAL_DEPRECATED, "nn/abc@ABC.COM");
@@ -305,7 +306,7 @@ public class StorageVolumeTest {
     }
 
     @Test
-    public void testHDFSEmptyCredential() {
+    public void testHDFSEmptyCredential() throws DdlException {
         Map<String, String> storageParams = new HashMap<>();
         StorageVolume sv = new StorageVolume("1", "test", "hdfs", Arrays.asList("hdfs://abc"),
                 storageParams, true, "");
@@ -318,7 +319,7 @@ public class StorageVolumeTest {
     }
 
     @Test
-    public void testHDFSViewFS() {
+    public void testHDFSViewFS() throws DdlException {
         Map<String, String> storageParams = new HashMap<>();
         storageParams.put("fs.viewfs.mounttable.ClusterX.link./data", "hdfs://nn1-clusterx.example.com:8020/data");
         storageParams.put("fs.viewfs.mounttable.ClusterX.link./project", "hdfs://nn2-clusterx.example.com:8020/project");
@@ -337,7 +338,7 @@ public class StorageVolumeTest {
     }
 
     @Test
-    public void testHDFSAddConfigResources() {
+    public void testHDFSAddConfigResources() throws DdlException {
         String runningDir = MockedFrontend.getInstance().getRunningDir();
         String confFile = runningDir + "/conf/hdfs-site.xml";
         String content = "<configuration>\n" +
@@ -370,7 +371,7 @@ public class StorageVolumeTest {
     }
 
     @Test
-    public void testAzureSharedKeyCredential() {
+    public void testAzureSharedKeyCredential() throws DdlException {
         Map<String, String> storageParams = new HashMap<>();
         storageParams.put(AZURE_BLOB_ENDPOINT, "endpoint");
         storageParams.put(AZURE_BLOB_SHARED_KEY, "shared_key");
@@ -396,7 +397,7 @@ public class StorageVolumeTest {
     }
 
     @Test
-    public void testAzureSasTokenCredential() {
+    public void testAzureSasTokenCredential() throws DdlException {
         Map<String, String> storageParams = new HashMap<>();
         storageParams.put(AZURE_BLOB_ENDPOINT, "endpoint");
         storageParams.put(AZURE_BLOB_SAS_TOKEN, "sas_token");
@@ -429,7 +430,7 @@ public class StorageVolumeTest {
     }
 
     @Test
-    public void testFromFileStoreInfo() {
+    public void testFromFileStoreInfo() throws DdlException {
         AwsSimpleCredentialInfo simpleCredentialInfo = AwsSimpleCredentialInfo.newBuilder()
                 .setAccessKey("ak").setAccessKeySecret("sk").build();
         AwsCredentialInfo credentialInfo = AwsCredentialInfo.newBuilder().setSimpleCredential(simpleCredentialInfo).build();
@@ -482,6 +483,42 @@ public class StorageVolumeTest {
         fs = FileStoreInfo.newBuilder().setHdfsFsInfo(hdfs).setFsKey("0").setFsType(FileStoreType.HDFS).build();
         sv = StorageVolume.fromFileStoreInfo(fs);
         Assert.assertEquals(CloudType.HDFS, sv.getCloudConfiguration().getCloudType());
+    }
+
+    @Test
+    public void testGetParamsFromFileStoreInfo() {
+        AwsCredentialInfo.Builder awsCredBuilder = AwsCredentialInfo.newBuilder();
+        awsCredBuilder.getSimpleCredentialBuilder()
+                .setAccessKey("ak")
+                .setAccessKeySecret("sk")
+                .build();
+
+        FileStoreInfo.Builder fsInfoBuilder = FileStoreInfo.newBuilder();
+        fsInfoBuilder.getS3FsInfoBuilder()
+                .setBucket("bucket")
+                .setEndpoint("endpoint")
+                .setRegion("region")
+                .setCredential(awsCredBuilder);
+        fsInfoBuilder.setFsKey("0").setFsType(FileStoreType.S3);
+
+        {
+            FileStoreInfo fs = fsInfoBuilder.build();
+            Map<String, String> params = StorageVolume.getParamsFromFileStoreInfo(fs);
+            Assert.assertFalse(params.containsKey(CloudConfigurationConstants.AWS_S3_ENABLE_PARTITIONED_PREFIX));
+            Assert.assertFalse(params.containsKey(CloudConfigurationConstants.AWS_S3_NUM_PARTITIONED_PREFIX));
+        }
+
+        fsInfoBuilder.getS3FsInfoBuilder()
+                .setPartitionedPrefixEnabled(true)
+                .setNumPartitionedPrefix(32);
+
+        {
+            FileStoreInfo fs = fsInfoBuilder.build();
+            Map<String, String> params = StorageVolume.getParamsFromFileStoreInfo(fs);
+            Assert.assertTrue(params.containsKey(CloudConfigurationConstants.AWS_S3_ENABLE_PARTITIONED_PREFIX));
+            Assert.assertTrue(params.containsKey(CloudConfigurationConstants.AWS_S3_NUM_PARTITIONED_PREFIX));
+            Assert.assertEquals("32", params.get(CloudConfigurationConstants.AWS_S3_NUM_PARTITIONED_PREFIX));
+        }
     }
 
     @Test

--- a/test/sql/test_storage_volume/R/alter_storage_volume
+++ b/test/sql/test_storage_volume/R/alter_storage_volume
@@ -23,3 +23,18 @@ E: (1064, 'Getting analyzing error. Detail message: Unknown storage volume: stor
 SHOW STORAGE VOLUMES LIKE 'storage_volume_alter';
 -- result:
 -- !result
+-- name: test_alter_storage_volume_immutable_properties @cloud
+CREATE STORAGE VOLUME IF NOT EXISTS storage_volume_immutable type = s3 LOCATIONS = ('s3://xxx') COMMENT 'comment' PROPERTIES ("aws.s3.endpoint"="endpoint", "aws.s3.region"="us-west-2", "aws.s3.use_aws_sdk_default_behavior" = "true", "enabled"="false");
+-- result:
+-- !result
+ALTER STORAGE VOLUME storage_volume_immutable SET ("aws.s3.enable_partitioned_prefix" = "true");
+-- result:
+E: (1064, "Storage volume property 'aws.s3.enable_partitioned_prefix' is immutable!")
+-- !result
+ALTER STORAGE VOLUME storage_volume_immutable SET ("aws.s3.num_partitioned_prefix" = "32");
+-- result:
+E: (1064, "Storage volume property 'aws.s3.num_partitioned_prefix' is immutable!")
+-- !result
+DROP STORAGE VOLUME IF EXISTS storage_volume_immutable;
+-- result:
+-- !result

--- a/test/sql/test_storage_volume/R/create_storage_volume
+++ b/test/sql/test_storage_volume/R/create_storage_volume
@@ -1,4 +1,4 @@
--- name: testCreateStorageVolume
+-- name: testCreateStorageVolume @cloud
 CREATE STORAGE VOLUME storage_volume_create type = s3 LOCATIONS = ('s3://xxx') COMMENT 'comment' PROPERTIES ("aws.s3.endpoint"="endpoint", "aws.s3.region"="us-west-2", "aws.s3.use_aws_sdk_default_behavior" = "false", "enabled"="false", "aws.s3.secret_key"="secret_key", "aws.s3.access_key"="access_key");
 -- result:
 -- !result
@@ -19,11 +19,30 @@ storage_volume_create
 -- !result
 DESC STORAGE VOLUME 'storage_volume_create';
 -- result:
-storage_volume_create	S3	false	s3://xxx	{"aws.s3.access_key":"******","aws.s3.region":"us-west-2","aws.s3.secret_key":"******","aws.s3.use_aws_sdk_default_behavior":"false","aws.s3.endpoint":"endpoint"}	false	comment
+storage_volume_create	S3	false	s3://xxx	{"aws.s3.access_key":"******","aws.s3.secret_key":"******","aws.s3.endpoint":"endpoint","aws.s3.region":"us-west-2","aws.s3.use_instance_profile":"false","aws.s3.use_aws_sdk_default_behavior":"false"}	false	comment
 -- !result
 DROP STORAGE VOLUME IF EXISTS storage_volume_create;
 -- result:
 -- !result
 SHOW STORAGE VOLUMES like 'storage_volume_create';
+-- result:
+-- !result
+-- name: test_create_s3_storage_volume_with_partitioned_prefix @cloud
+CREATE STORAGE VOLUME IF NOT EXISTS storage_volume_partioned_prefix_success TYPE = S3 LOCATIONS = ('s3://bucketname') PROPERTIES ("aws.s3.use_aws_sdk_default_behavior" = "true", "aws.s3.enable_partitioned_prefix" = "true", "aws.s3.num_partitioned_prefix" = "1024");
+-- result:
+-- !result
+CREATE STORAGE VOLUME IF NOT EXISTS storage_volume_partioned_prefix_fail1 TYPE = S3 LOCATIONS = ('s3://bucketname/subpath') PROPERTIES ("aws.s3.use_aws_sdk_default_behavior" = "true", "aws.s3.enable_partitioned_prefix" = "true", "aws.s3.num_partitioned_prefix" = "1024");
+-- result:
+E: (1064, "Storage volume 'storage_volume_partioned_prefix_fail1' has 'aws.s3.enable_partitioned_prefix'='true', the location 's3://bucketname/subpath' should not contain sub path after bucket name!")
+-- !result
+CREATE STORAGE VOLUME IF NOT EXISTS storage_volume_partioned_prefix_fail2 TYPE = S3 LOCATIONS = ('s3://bucketname') PROPERTIES ("aws.s3.use_aws_sdk_default_behavior" = "true", "aws.s3.enable_partitioned_prefix" = "true", "aws.s3.num_partitioned_prefix" = "-1");
+-- result:
+E: (1064, "Invalid property value '-1' for property 'aws.s3.num_partitioned_prefix', expecting a positive integer string.")
+-- !result
+CREATE STORAGE VOLUME IF NOT EXISTS storage_volume_partioned_prefix_fail3 TYPE = S3 LOCATIONS = ('s3://bucketname') PROPERTIES ("aws.s3.use_aws_sdk_default_behavior" = "true", "aws.s3.enable_partitioned_prefix" = "true", "aws.s3.num_partitioned_prefix" = "aa");
+-- result:
+E: (1064, "Invalid property value 'aa' for property 'aws.s3.num_partitioned_prefix', expecting a valid integer string.")
+-- !result
+DROP STORAGE VOLUME IF EXISTS storage_volume_partioned_prefix_success;
 -- result:
 -- !result

--- a/test/sql/test_storage_volume/R/set_as_default
+++ b/test/sql/test_storage_volume/R/set_as_default
@@ -1,4 +1,4 @@
--- name: testSetAsDefault
+-- name: testSetAsDefault @cloud
 CREATE STORAGE VOLUME IF NOT EXISTS storage_volume_default_1 type = s3 LOCATIONS = ('s3://xxx') COMMENT 'comment' PROPERTIES ("aws.s3.endpoint"="endpoint", "aws.s3.region"="us-west-2", "aws.s3.use_aws_sdk_default_behavior" = "true", "enabled"="false");
 -- result:
 -- !result
@@ -29,8 +29,8 @@ E: (1064, 'Unexpected exception: default storage volume can not be removed')
 -- !result
 SHOW STORAGE VOLUMES like 'storage_volume_default%';
 -- result:
-storage_volume_default_2
 storage_volume_default_1
+storage_volume_default_2
 -- !result
 SHOW STORAGE VOLUMES like 'storage_volume_default_1';
 -- result:
@@ -55,4 +55,7 @@ SHOW STORAGE VOLUMES like 'storage_volume_default_1';
 DESC STORAGE VOLUME 'storage_volume_default_1';
 -- result:
 E: (1064, 'Getting analyzing error. Detail message: Unknown storage volume: storage_volume_default_1.')
+-- !result
+SET builtin_storage_volume AS DEFAULT STORAGE VOLUME;
+-- result:
 -- !result

--- a/test/sql/test_storage_volume/T/alter_storage_volume
+++ b/test/sql/test_storage_volume/T/alter_storage_volume
@@ -6,3 +6,8 @@ DESC STORAGE VOLUME storage_volume_alter;
 DROP STORAGE VOLUME IF EXISTS storage_volume_alter;
 DESC STORAGE VOLUME storage_volume_alter;
 SHOW STORAGE VOLUMES LIKE 'storage_volume_alter';
+-- name: test_alter_storage_volume_immutable_properties @cloud
+CREATE STORAGE VOLUME IF NOT EXISTS storage_volume_immutable type = s3 LOCATIONS = ('s3://xxx') COMMENT 'comment' PROPERTIES ("aws.s3.endpoint"="endpoint", "aws.s3.region"="us-west-2", "aws.s3.use_aws_sdk_default_behavior" = "true", "enabled"="false");
+ALTER STORAGE VOLUME storage_volume_immutable SET ("aws.s3.enable_partitioned_prefix" = "true");
+ALTER STORAGE VOLUME storage_volume_immutable SET ("aws.s3.num_partitioned_prefix" = "32");
+DROP STORAGE VOLUME IF EXISTS storage_volume_immutable;

--- a/test/sql/test_storage_volume/T/create_storage_volume
+++ b/test/sql/test_storage_volume/T/create_storage_volume
@@ -1,4 +1,4 @@
--- name: testCreateStorageVolume
+-- name: testCreateStorageVolume @cloud
 CREATE STORAGE VOLUME storage_volume_create type = s3 LOCATIONS = ('s3://xxx') COMMENT 'comment' PROPERTIES ("aws.s3.endpoint"="endpoint", "aws.s3.region"="us-west-2", "aws.s3.use_aws_sdk_default_behavior" = "false", "enabled"="false", "aws.s3.secret_key"="secret_key", "aws.s3.access_key"="access_key");
 SHOW STORAGE VOLUMES like 'storage_volume_create';
 CREATE STORAGE VOLUME storage_volume_create type = s3 LOCATIONS = ('s3://xxx') COMMENT 'comment' PROPERTIES ("aws.s3.endpoint"="endpoint", "aws.s3.region"="us-west-2", "aws.s3.use_aws_sdk_default_behavior" = "true", "enabled"="false");
@@ -7,3 +7,9 @@ SHOW STORAGE VOLUMES like 'storage_volume_create';
 DESC STORAGE VOLUME 'storage_volume_create';
 DROP STORAGE VOLUME IF EXISTS storage_volume_create;
 SHOW STORAGE VOLUMES like 'storage_volume_create';
+-- name: test_create_s3_storage_volume_with_partitioned_prefix @cloud
+CREATE STORAGE VOLUME IF NOT EXISTS storage_volume_partioned_prefix_success TYPE = S3 LOCATIONS = ('s3://bucketname') PROPERTIES ("aws.s3.use_aws_sdk_default_behavior" = "true", "aws.s3.enable_partitioned_prefix" = "true", "aws.s3.num_partitioned_prefix" = "1024");
+CREATE STORAGE VOLUME IF NOT EXISTS storage_volume_partioned_prefix_fail1 TYPE = S3 LOCATIONS = ('s3://bucketname/subpath') PROPERTIES ("aws.s3.use_aws_sdk_default_behavior" = "true", "aws.s3.enable_partitioned_prefix" = "true", "aws.s3.num_partitioned_prefix" = "1024");
+CREATE STORAGE VOLUME IF NOT EXISTS storage_volume_partioned_prefix_fail2 TYPE = S3 LOCATIONS = ('s3://bucketname') PROPERTIES ("aws.s3.use_aws_sdk_default_behavior" = "true", "aws.s3.enable_partitioned_prefix" = "true", "aws.s3.num_partitioned_prefix" = "-1");
+CREATE STORAGE VOLUME IF NOT EXISTS storage_volume_partioned_prefix_fail3 TYPE = S3 LOCATIONS = ('s3://bucketname') PROPERTIES ("aws.s3.use_aws_sdk_default_behavior" = "true", "aws.s3.enable_partitioned_prefix" = "true", "aws.s3.num_partitioned_prefix" = "aa");
+DROP STORAGE VOLUME IF EXISTS storage_volume_partioned_prefix_success;

--- a/test/sql/test_storage_volume/T/set_as_default
+++ b/test/sql/test_storage_volume/T/set_as_default
@@ -1,4 +1,4 @@
--- name: testSetAsDefault
+-- name: testSetAsDefault @cloud
 CREATE STORAGE VOLUME IF NOT EXISTS storage_volume_default_1 type = s3 LOCATIONS = ('s3://xxx') COMMENT 'comment' PROPERTIES ("aws.s3.endpoint"="endpoint", "aws.s3.region"="us-west-2", "aws.s3.use_aws_sdk_default_behavior" = "true", "enabled"="false");
 DESC STORAGE VOLUME 'storage_volume_default_1';
 CREATE STORAGE VOLUME IF NOT EXISTS storage_volume_default_2 type = s3 LOCATIONS = ('s3://xxx') COMMENT 'comment' PROPERTIES ("aws.s3.endpoint"="endpoint", "aws.s3.region"="us-west-2", "aws.s3.use_aws_sdk_default_behavior" = "true", "enabled"="false");
@@ -15,3 +15,4 @@ DESC STORAGE VOLUME 'storage_volume_default_2';
 DROP STORAGE VOLUME IF EXISTS storage_volume_default_1;
 SHOW STORAGE VOLUMES like 'storage_volume_default_1';
 DESC STORAGE VOLUME 'storage_volume_default_1';
+SET builtin_storage_volume AS DEFAULT STORAGE VOLUME;


### PR DESCRIPTION
* s3 storage volume added the following two properties to support partitioned prefix feature
  - aws.s3.enable_partitioned_prefix
  - aws.s3.num_partitioned_prefix

## Why I'm doing:

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [x] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [x] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
