### PR TITLE
[Feature] Support LoadChannel profile

### DIFF
--- a/be/src/exec/pipeline/exec_state_reporter.cpp
+++ b/be/src/exec/pipeline/exec_state_reporter.cpp
@@ -80,8 +80,10 @@ TReportExecStatusParams ExecStateReporter::create_report_exec_status_params(Quer
             profile->to_thrift(&params.profile);
             params.__isset.profile = true;
 
-            load_channel_profile->to_thrift(&params.load_channel_profile);
-            params.__isset.load_channel_profile = true;
+            if (runtime_state->query_options().query_type == TQueryType::LOAD) {
+                load_channel_profile->to_thrift(&params.load_channel_profile);
+                params.__isset.load_channel_profile = true;
+            }
         }
 
         if (!runtime_state->output_files().empty()) {

--- a/be/src/exec/pipeline/exec_state_reporter.cpp
+++ b/be/src/exec/pipeline/exec_state_reporter.cpp
@@ -44,6 +44,7 @@ std::string to_http_path(const std::string& token, const std::string& file_name)
 TReportExecStatusParams ExecStateReporter::create_report_exec_status_params(QueryContext* query_ctx,
                                                                             FragmentContext* fragment_ctx,
                                                                             RuntimeProfile* profile,
+                                                                            RuntimeProfile* load_channel_profile,
                                                                             const Status& status, bool done) {
     TReportExecStatusParams params;
     auto* runtime_state = fragment_ctx->runtime_state();
@@ -66,6 +67,9 @@ TReportExecStatusParams ExecStateReporter::create_report_exec_status_params(Quer
         if (query_ctx->enable_profile()) {
             profile->to_thrift(&params.profile);
             params.__isset.profile = true;
+
+            load_channel_profile->to_thrift(&params.load_channel_profile);
+            params.__isset.load_channel_profile = true;
         }
     } else {
         if (runtime_state->query_options().query_type == TQueryType::LOAD) {
@@ -75,6 +79,9 @@ TReportExecStatusParams ExecStateReporter::create_report_exec_status_params(Quer
         if (query_ctx->enable_profile()) {
             profile->to_thrift(&params.profile);
             params.__isset.profile = true;
+
+            load_channel_profile->to_thrift(&params.load_channel_profile);
+            params.__isset.load_channel_profile = true;
         }
 
         if (!runtime_state->output_files().empty()) {

--- a/be/src/exec/pipeline/exec_state_reporter.h
+++ b/be/src/exec/pipeline/exec_state_reporter.h
@@ -33,8 +33,9 @@ public:
 
     static TReportExecStatusParams create_report_exec_status_params(QueryContext* query_ctx,
                                                                     FragmentContext* fragment_ctx,
-                                                                    RuntimeProfile* profile, const Status& status,
-                                                                    bool done);
+                                                                    RuntimeProfile* profile,
+                                                                    RuntimeProfile* load_channel_profile,
+                                                                    const Status& status, bool done);
     static Status report_exec_status(const TReportExecStatusParams& params, ExecEnv* exec_env,
                                      const TNetworkAddress& fe_addr);
 

--- a/be/src/exec/pipeline/pipeline_driver_executor.cpp
+++ b/be/src/exec/pipeline/pipeline_driver_executor.cpp
@@ -308,7 +308,6 @@ void GlobalDriverExecutor::report_exec_state(QueryContext* query_ctx, FragmentCo
         query_exec_wall_time->set(query_ctx->lifetime());
     }
 
-
     // Load channel profile will be merged on FE
     auto* load_channel_profile = fragment_ctx->runtime_state()->load_channel_profile();
     auto params = ExecStateReporter::create_report_exec_status_params(query_ctx, fragment_ctx, profile,

--- a/be/src/exec/pipeline/pipeline_driver_executor.cpp
+++ b/be/src/exec/pipeline/pipeline_driver_executor.cpp
@@ -308,7 +308,11 @@ void GlobalDriverExecutor::report_exec_state(QueryContext* query_ctx, FragmentCo
         query_exec_wall_time->set(query_ctx->lifetime());
     }
 
-    auto params = ExecStateReporter::create_report_exec_status_params(query_ctx, fragment_ctx, profile, status, done);
+
+    // Load channel profile will be merged on FE
+    auto* load_channel_profile = fragment_ctx->runtime_state()->load_channel_profile();
+    auto params = ExecStateReporter::create_report_exec_status_params(query_ctx, fragment_ctx, profile,
+                                                                      load_channel_profile, status, done);
     auto fe_addr = fragment_ctx->fe_addr();
     if (fe_addr.hostname.empty()) {
         // query executed by external connectors, like spark and flink connector,

--- a/be/src/exec/pipeline/query_context.h
+++ b/be/src/exec/pipeline/query_context.h
@@ -93,6 +93,7 @@ public:
     void set_enable_pipeline_level_shuffle(bool flag) { _enable_pipeline_level_shuffle = flag; }
     bool enable_pipeline_level_shuffle() { return _enable_pipeline_level_shuffle; }
     void set_enable_profile() { _enable_profile = true; }
+    bool get_enable_profile_flag() { return _enable_profile; }
     bool enable_profile() {
         if (_enable_profile) {
             return true;
@@ -126,6 +127,7 @@ public:
         }
         _big_query_profile_threshold_ns = factor * big_query_profile_threshold;
     }
+    int64_t get_big_query_profile_threshold_ns() { return _big_query_profile_threshold_ns; }
     void set_runtime_profile_report_interval(int64_t runtime_profile_report_interval_s) {
         _runtime_profile_report_interval_ns = 1'000'000'000L * runtime_profile_report_interval_s;
     }

--- a/be/src/exec/pipeline/query_context.h
+++ b/be/src/exec/pipeline/query_context.h
@@ -127,7 +127,7 @@ public:
         }
         _big_query_profile_threshold_ns = factor * big_query_profile_threshold;
     }
-    int64_t get_big_query_profile_threshold_ns() { return _big_query_profile_threshold_ns; }
+    int64_t get_big_query_profile_threshold_ns() const { return _big_query_profile_threshold_ns; }
     void set_runtime_profile_report_interval(int64_t runtime_profile_report_interval_s) {
         _runtime_profile_report_interval_ns = 1'000'000'000L * runtime_profile_report_interval_s;
     }

--- a/be/src/exec/tablet_sink.cpp
+++ b/be/src/exec/tablet_sink.cpp
@@ -168,11 +168,15 @@ Status OlapTableSink::init(const TDataSink& t_sink, RuntimeState* state) {
         _colocate_mv_index = table_sink.enable_colocate_mv_index && config::enable_load_colocate_mv;
     }
 
+    // Query context is only available for pipeline engine
     auto query_ctx = state->query_ctx();
-    _load_channel_profile_config.set_enable_profile(query_ctx->get_enable_profile_flag());
-    _load_channel_profile_config.set_big_query_profile_threshold_ns(query_ctx->get_big_query_profile_threshold_ns());
-    _load_channel_profile_config.set_runtime_profile_report_interval_ns(
-            query_ctx->get_runtime_profile_report_interval_ns());
+    if (query_ctx) {
+        _load_channel_profile_config.set_enable_profile(query_ctx->get_enable_profile_flag());
+        _load_channel_profile_config.set_big_query_profile_threshold_ns(
+                query_ctx->get_big_query_profile_threshold_ns());
+        _load_channel_profile_config.set_runtime_profile_report_interval_ns(
+                query_ctx->get_runtime_profile_report_interval_ns());
+    }
 
     return Status::OK();
 }

--- a/be/src/exec/tablet_sink.cpp
+++ b/be/src/exec/tablet_sink.cpp
@@ -168,6 +168,12 @@ Status OlapTableSink::init(const TDataSink& t_sink, RuntimeState* state) {
         _colocate_mv_index = table_sink.enable_colocate_mv_index && config::enable_load_colocate_mv;
     }
 
+    auto query_ctx = state->query_ctx();
+    _load_channel_profile_config.set_enable_profile(query_ctx->get_enable_profile_flag());
+    _load_channel_profile_config.set_big_query_profile_threshold_ns(query_ctx->get_big_query_profile_threshold_ns());
+    _load_channel_profile_config.set_runtime_profile_report_interval_ns(
+            query_ctx->get_runtime_profile_report_interval_ns());
+
     return Status::OK();
 }
 

--- a/be/src/exec/tablet_sink.h
+++ b/be/src/exec/tablet_sink.h
@@ -245,6 +245,8 @@ private:
     int64_t _automatic_bucket_size = 0;
     std::set<int64_t> _immutable_partition_ids;
     RuntimeState* _state = nullptr;
+
+    PLoadChannelProfileConfig _load_channel_profile_config;
 };
 
 } // namespace starrocks::stream_load

--- a/be/src/runtime/lake_tablets_channel.cpp
+++ b/be/src/runtime/lake_tablets_channel.cpp
@@ -350,7 +350,6 @@ void LakeTabletsChannel::add_chunk(Chunk* chunk, const PTabletWriterAddChunkRequ
 
         // back pressure OlapTableSink since there are too many memtables need to flush
         while (dw->queueing_memtable_num() >= config::max_queueing_memtable_per_tablet) {
-            auto t1 = watch.elapsed_time();
             if (watch.elapsed_time() / 1000000 > request.timeout_ms()) {
                 LOG(INFO) << "LakeTabletsChannel txn_id: " << _txn_id << " load_id: " << print_id(request.id())
                           << " wait tablet " << tablet_id << " flush memtable " << request.timeout_ms()
@@ -358,7 +357,7 @@ void LakeTabletsChannel::add_chunk(Chunk* chunk, const PTabletWriterAddChunkRequ
                 break;
             }
             bthread_usleep(10000); // 10ms
-            wait_memtable_flush_time_ns += watch.elapsed_time() - t1;
+            wait_memtable_flush_time_ns += 10000000;
         }
 
         if (auto st = dw->open(); !st.ok()) { // Fail to `open()` AsyncDeltaWriter

--- a/be/src/runtime/lake_tablets_channel.h
+++ b/be/src/runtime/lake_tablets_channel.h
@@ -20,6 +20,7 @@ namespace starrocks {
 
 class LoadChannel;
 class MemTracker;
+class RuntimeProfile;
 struct TabletsChannelKey;
 
 namespace lake {
@@ -27,6 +28,7 @@ class TabletManager;
 }
 
 std::shared_ptr<TabletsChannel> new_lake_tablets_channel(LoadChannel* load_channel, lake::TabletManager* tablet_manager,
-                                                         const TabletsChannelKey& key, MemTracker* mem_tracker);
+                                                         const TabletsChannelKey& key, MemTracker* mem_tracker,
+                                                         RuntimeProfile* parent_profile);
 
 } // namespace starrocks

--- a/be/src/runtime/load_channel.cpp
+++ b/be/src/runtime/load_channel.cpp
@@ -237,6 +237,7 @@ void LoadChannel::remove_tablets_channel(int64_t index_id) {
     _tablets_channels.erase(index_id);
     if (_tablets_channels.empty()) {
         l.unlock();
+        _closed.store(true);
         _load_mgr->remove_load_channel(_load_id);
         // Do NOT touch |this| since here, it could have been deleted.
     }

--- a/be/src/runtime/load_channel.cpp
+++ b/be/src/runtime/load_channel.cpp
@@ -80,7 +80,6 @@ LoadChannel::LoadChannel(LoadChannelMgr* mgr, LakeTabletManager* lake_tablet_mgr
     _root_profile->add_info_string("LoadId", print_id(load_id));
     _root_profile->add_info_string("TxnId", std::to_string(txn_id));
     _profile = _root_profile->create_child(fmt::format("Channel (host={})", BackendOptions::get_localhost()), true);
-    _profile->add_info_string("Address", BackendOptions::get_localhost());
     _index_num = ADD_COUNTER(_profile, "IndexNum", TUnit::UNIT);
     ADD_COUNTER(_profile, "LoadMemoryLimit", TUnit::BYTES)->set(_mem_tracker->limit());
     _peak_memory_usage = ADD_PEAK_COUNTER(_profile, "PeakMemoryUsage", TUnit::BYTES);

--- a/be/src/runtime/load_channel.cpp
+++ b/be/src/runtime/load_channel.cpp
@@ -360,6 +360,7 @@ void LoadChannel::report_profile(PTabletWriterAddBatchResult* result, bool print
     }
 
     COUNTER_SET(_peak_memory_usage, _mem_tracker->peak_consumption());
+    _profile->inc_version();
 
     if (print_profile) {
         std::stringstream ss;

--- a/be/src/runtime/load_channel.h
+++ b/be/src/runtime/load_channel.h
@@ -139,6 +139,7 @@ private:
     bthread::Mutex _lock;
     // index id -> tablets channel
     std::unordered_map<int64_t, std::shared_ptr<TabletsChannel>> _tablets_channels;
+    std::atomic<bool> _closed{false};
 
     Span _span;
     size_t _num_chunk{0};

--- a/be/src/runtime/load_channel.h
+++ b/be/src/runtime/load_channel.h
@@ -119,12 +119,12 @@ public:
 
     Span get_span() { return _span; }
 
+    void report_profile(PTabletWriterAddBatchResult* result, bool print_profile);
+
 private:
     void _add_chunk(Chunk* chunk, const PTabletWriterAddChunkRequest& request, PTabletWriterAddBatchResult* response);
     Status _build_chunk_meta(const ChunkPB& pb_chunk);
     Status _deserialize_chunk(const ChunkPB& pchunk, Chunk& chunk, faststring* uncompressed_buffer);
-
-    void _report_profile(PTabletWriterAddBatchResult* result);
 
     LoadChannelMgr* _load_mgr;
     LakeTabletManager* _lake_tablet_mgr;
@@ -160,7 +160,7 @@ private:
     bool _enable_profile{false};
     int64_t _big_query_profile_threshold_ns{-1};
     int64_t _runtime_profile_report_interval_ns = std::numeric_limits<int64_t>::max();
-    std::atomic<int64_t> _last_report_time_ns{-1};
+    std::atomic<int64_t> _last_report_time_ns{0};
     std::atomic<bool> _final_report{false};
 
     RuntimeProfile::Counter* _index_num = nullptr;

--- a/be/src/runtime/load_channel_mgr.cpp
+++ b/be/src/runtime/load_channel_mgr.cpp
@@ -116,6 +116,9 @@ void LoadChannelMgr::open(brpc::Controller* cntl, const PTabletWriterOpenRequest
 
             channel.reset(new LoadChannel(this, ExecEnv::GetInstance()->lake_tablet_manager(), load_id, txn_id,
                                           request.txn_trace_parent(), job_timeout_s, std::move(job_mem_tracker)));
+            if (request.has_load_channel_profile_config()) {
+                channel->set_profile_config(request.load_channel_profile_config());
+            }
             _load_channels.insert({load_id, channel});
         } else {
             response->mutable_status()->set_status_code(TStatusCode::MEM_LIMIT_EXCEEDED);

--- a/be/src/runtime/local_tablets_channel.cpp
+++ b/be/src/runtime/local_tablets_channel.cpp
@@ -361,8 +361,6 @@ void LocalTabletsChannel::add_chunk(Chunk* chunk, const PTabletWriterAddChunkReq
     _flush_stale_memtables();
 
     if (close_channel) {
-        _load_channel->remove_tablets_channel(_index_id);
-
         // persist txn.
         std::vector<TabletSharedPtr> tablets;
         tablets.reserve(request.tablet_ids().size());
@@ -410,6 +408,11 @@ void LocalTabletsChannel::add_chunk(Chunk* chunk, const PTabletWriterAddChunkReq
             wait_memtable_flush_time_us);
     StarRocksMetrics::instance()->load_channel_add_chunks_wait_writer_duration_us.increment(wait_writer_us);
     StarRocksMetrics::instance()->load_channel_add_chunks_wait_replica_duration_us.increment(wait_replica_us);
+
+    // remove tablets channel and load channel after all things done
+    if (close_channel) {
+        _load_channel->remove_tablets_channel(_index_id);
+    }
 }
 
 void LocalTabletsChannel::_flush_stale_memtables() {

--- a/be/src/runtime/local_tablets_channel.cpp
+++ b/be/src/runtime/local_tablets_channel.cpp
@@ -55,7 +55,7 @@ namespace starrocks {
 std::atomic<uint64_t> LocalTabletsChannel::_s_tablet_writer_count;
 
 LocalTabletsChannel::LocalTabletsChannel(LoadChannel* load_channel, const TabletsChannelKey& key,
-                                         MemTracker* mem_tracker)
+                                         MemTracker* mem_tracker, RuntimeProfile* parent_profile)
         : TabletsChannel(),
           _load_channel(load_channel),
           _key(key),
@@ -65,6 +65,18 @@ LocalTabletsChannel::LocalTabletsChannel(LoadChannel* load_channel, const Tablet
     std::call_once(once_flag, [] {
         REGISTER_GAUGE_STARROCKS_METRIC(tablet_writer_count, [&]() { return _s_tablet_writer_count.load(); });
     });
+
+    _profile = parent_profile->create_child(fmt::format("Index (id={})", key.index_id));
+    _primary_tablets_num = ADD_COUNTER(_profile, "PrimaryTabletsNum", TUnit::UNIT);
+    _secondary_tablets_num = ADD_COUNTER(_profile, "SecondaryTabletsNum", TUnit::UNIT);
+    _open_counter = ADD_COUNTER(_profile, "OpenCount", TUnit::UNIT);
+    _open_timer = ADD_TIMER(_profile, "OpenTime");
+    _add_chunk_counter = ADD_COUNTER(_profile, "AddChunkCount", TUnit::UNIT);
+    _add_chunk_timer = ADD_TIMER(_profile, "AddChunkTime");
+    _add_row_num = ADD_COUNTER(_profile, "AddRowNum", TUnit::UNIT);
+    _wait_flush_timer = ADD_CHILD_TIMER(_profile, "WaitFlushTime", "AddChunkTime");
+    _wait_writer_timer = ADD_CHILD_TIMER(_profile, "WaitWriterTime", "AddChunkTime");
+    _wait_replica_timer = ADD_CHILD_TIMER(_profile, "WaitReplicaTime", "AddChunkTime");
 }
 
 LocalTabletsChannel::~LocalTabletsChannel() {
@@ -74,6 +86,8 @@ LocalTabletsChannel::~LocalTabletsChannel() {
 
 Status LocalTabletsChannel::open(const PTabletWriterOpenRequest& params, PTabletWriterOpenResult* result,
                                  std::shared_ptr<OlapTableSchemaParam> schema, bool is_incremental) {
+    SCOPED_TIMER(_open_timer);
+    COUNTER_UPDATE(_open_counter, 1);
     std::unique_lock<bthreads::BThreadSharedMutex> lk(_rw_mtx);
     _txn_id = params.txn_id();
     _index_id = params.index_id();
@@ -131,8 +145,6 @@ void LocalTabletsChannel::add_chunk(Chunk* chunk, const PTabletWriterAddChunkReq
     MonotonicStopWatch watch;
     watch.start();
     std::shared_lock<bthreads::BThreadSharedMutex> lk(_rw_mtx);
-    auto t0 = std::chrono::steady_clock::now();
-    int64_t wait_memtable_flush_time_us = 0;
 
     if (UNLIKELY(!request.has_sender_id())) {
         response->mutable_status()->set_status_code(TStatusCode::INVALID_ARGUMENT);
@@ -223,12 +235,15 @@ void LocalTabletsChannel::add_chunk(Chunk* chunk, const PTabletWriterAddChunkReq
     std::unordered_map<int64_t, std::vector<int64_t>> node_id_to_abort_tablets;
     context->set_node_id_to_abort_tablets(&node_id_to_abort_tablets);
 
+    int64_t wait_memtable_flush_time_ns = 0;
+    int32_t total_row_num = 0;
     for (int i = 0; i < channel_size; ++i) {
         size_t from = channel_row_idx_start_points[i];
         size_t size = channel_row_idx_start_points[i + 1] - from;
         if (size == 0) {
             continue;
         }
+        total_row_num += size;
         auto tablet_id = tablet_ids[row_indexes[from]];
         auto it = _delta_writers.find(tablet_id);
         DCHECK(it != _delta_writers.end());
@@ -236,15 +251,14 @@ void LocalTabletsChannel::add_chunk(Chunk* chunk, const PTabletWriterAddChunkReq
 
         // back pressure OlapTableSink since there are too many memtables need to flush
         while (delta_writer->get_flush_stats().queueing_memtable_num >= config::max_queueing_memtable_per_tablet) {
-            auto t1 = std::chrono::steady_clock::now();
-            if (std::chrono::duration_cast<std::chrono::microseconds>(t1 - t0).count() / 1000 > request.timeout_ms()) {
+            if (watch.elapsed_time() / 1000000 > request.timeout_ms()) {
                 LOG(INFO) << "LocalTabletsChannel txn_id: " << _txn_id << " load_id: " << print_id(request.id())
                           << " wait tablet " << tablet_id << " flush memtable " << request.timeout_ms()
                           << "ms still has queueing num " << delta_writer->get_flush_stats().queueing_memtable_num;
                 break;
             }
             bthread_usleep(10000); // 10ms
-            wait_memtable_flush_time_us += 10000;
+            wait_memtable_flush_time_ns += 10000000;
         }
 
         AsyncDeltaWriterRequest req;
@@ -278,9 +292,10 @@ void LocalTabletsChannel::add_chunk(Chunk* chunk, const PTabletWriterAddChunkReq
     // here.
     context.reset();
 
+    auto start_wait_writer_ts = watch.elapsed_time();
     // This will only block the bthread, will not block the pthread
     count_down_latch.wait();
-    auto wait_writer_ts = watch.elapsed_time();
+    auto finish_wait_writer_ts = watch.elapsed_time();
 
     // Abort tablets which primary replica already failed
     if (response->status().status_code() != TStatusCode::OK) {
@@ -302,9 +317,7 @@ void LocalTabletsChannel::add_chunk(Chunk* chunk, const PTabletWriterAddChunkReq
                     i++;
                     // only sleep in bthread
                     bthread_usleep(10000); // 10ms
-                    auto t1 = std::chrono::steady_clock::now();
-                    if (std::chrono::duration_cast<std::chrono::microseconds>(t1 - t0).count() / 1000 >
-                        request.timeout_ms()) {
+                    if (watch.elapsed_time() / 1000000 > request.timeout_ms()) {
                         LOG(INFO) << "LocalTabletsChannel txn_id: " << _txn_id << " load_id: " << print_id(request.id())
                                   << " wait tablet " << tablet_id << " secondary replica finish timeout "
                                   << request.timeout_ms() << "ms still in state " << state;
@@ -315,8 +328,7 @@ void LocalTabletsChannel::add_chunk(Chunk* chunk, const PTabletWriterAddChunkReq
                     if (i % 6000 == 0) {
                         LOG(INFO) << "LocalTabletsChannel txn_id: " << _txn_id << " load_id: " << print_id(request.id())
                                   << " wait tablet " << tablet_id << " secondary replica finish already "
-                                  << std::chrono::duration_cast<std::chrono::microseconds>(t1 - t0).count() / 1000
-                                  << "ms still in state " << state;
+                                  << watch.elapsed_time() / 1000000 << "ms still in state " << state;
                     }
                 } while (true);
             }
@@ -325,7 +337,7 @@ void LocalTabletsChannel::add_chunk(Chunk* chunk, const PTabletWriterAddChunkReq
             }
         }
     }
-    auto wait_replica_ts = watch.elapsed_time();
+    auto finish_wait_replica_ts = watch.elapsed_time();
 
     {
         std::lock_guard lock(_senders[request.sender_id()].lock);
@@ -376,7 +388,7 @@ void LocalTabletsChannel::add_chunk(Chunk* chunk, const PTabletWriterAddChunkReq
         _num_initial_senders.fetch_sub(1);
         std::string msg = fmt::format("LocalTabletsChannel txn_id: {} load_id: {}", _txn_id, print_id(request.id()));
         auto remain = request.timeout_ms();
-        remain -= std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - t0).count();
+        remain -= watch.elapsed_time() / 1000000;
 
         // unlock write lock so that incremental open can aquire read lock
         lk.unlock();
@@ -389,10 +401,9 @@ void LocalTabletsChannel::add_chunk(Chunk* chunk, const PTabletWriterAddChunkReq
         last_execution_time_us = response->execution_time_us();
     }
     auto t1 = std::chrono::steady_clock::now();
-    response->set_execution_time_us(last_execution_time_us +
-                                    std::chrono::duration_cast<std::chrono::microseconds>(t1 - t0).count());
+    response->set_execution_time_us(last_execution_time_us + watch.elapsed_time() / 1000);
     response->set_wait_lock_time_us(0); // We didn't measure the lock wait time, just give the caller a fake time
-    response->set_wait_memtable_flush_time_us(wait_memtable_flush_time_us);
+    response->set_wait_memtable_flush_time_us(wait_memtable_flush_time_ns / 1000);
 
     // reset error message if it already set by other replica
     {
@@ -402,12 +413,19 @@ void LocalTabletsChannel::add_chunk(Chunk* chunk, const PTabletWriterAddChunkReq
             response->mutable_status()->add_error_msgs(std::string(_status.message()));
         }
     }
-    auto wait_writer_us = wait_writer_ts / 1000 - wait_memtable_flush_time_us;
-    auto wait_replica_us = (wait_replica_ts - wait_writer_ts) / 1000;
+    auto wait_writer_ns = finish_wait_writer_ts - start_wait_writer_ts;
+    auto wait_replica_ns = finish_wait_replica_ts - finish_wait_writer_ts;
     StarRocksMetrics::instance()->load_channel_add_chunks_wait_memtable_duration_us.increment(
-            wait_memtable_flush_time_us);
-    StarRocksMetrics::instance()->load_channel_add_chunks_wait_writer_duration_us.increment(wait_writer_us);
-    StarRocksMetrics::instance()->load_channel_add_chunks_wait_replica_duration_us.increment(wait_replica_us);
+            wait_memtable_flush_time_ns / 1000);
+    StarRocksMetrics::instance()->load_channel_add_chunks_wait_writer_duration_us.increment(wait_writer_ns / 1000);
+    StarRocksMetrics::instance()->load_channel_add_chunks_wait_replica_duration_us.increment(wait_replica_ns / 1000);
+
+    COUNTER_UPDATE(_add_chunk_counter, 1);
+    COUNTER_UPDATE(_add_chunk_timer, watch.elapsed_time());
+    COUNTER_UPDATE(_add_row_num, total_row_num);
+    COUNTER_UPDATE(_wait_flush_timer, wait_memtable_flush_time_ns);
+    COUNTER_UPDATE(_wait_writer_timer, wait_writer_ns);
+    COUNTER_UPDATE(_wait_replica_timer, wait_replica_ns);
 
     // remove tablets channel and load channel after all things done
     if (close_channel) {
@@ -609,6 +627,8 @@ Status LocalTabletsChannel::_open_all_writers(const PTabletWriterOpenRequest& pa
     std::vector<int64_t> tablet_ids;
     tablet_ids.reserve(params.tablets_size());
     std::vector<int64_t> failed_tablet_ids;
+    int32_t primary_num = 0;
+    int32_t secondary_num = 0;
     for (const PTabletWithPartition& tablet : params.tablets()) {
         DeltaWriterOptions options;
         options.tablet_id = tablet.tablet_id();
@@ -634,11 +654,14 @@ Status LocalTabletsChannel::_open_all_writers(const PTabletWriterOpenRequest& pa
             }
             if (options.replicas.size() > 0 && options.replicas[0].node_id() == options.node_id) {
                 options.replica_state = Primary;
+                primary_num += 1;
             } else {
                 options.replica_state = Secondary;
+                secondary_num += 1;
             }
         } else {
             options.replica_state = Peer;
+            primary_num += 1;
         }
         options.merge_condition = params.merge_condition();
         options.partial_update_mode = params.partial_update_mode();
@@ -680,6 +703,8 @@ Status LocalTabletsChannel::_open_all_writers(const PTabletWriterOpenRequest& pa
         ss << " _num_remaining_senders: " << _num_remaining_senders;
         LOG(INFO) << ss.str();
     }
+    COUNTER_UPDATE(_primary_tablets_num, primary_num);
+    COUNTER_UPDATE(_secondary_tablets_num, secondary_num);
     return Status::OK();
 }
 
@@ -929,8 +954,8 @@ void LocalTabletsChannel::WriteCallback::run(const Status& st, const CommittedRo
 }
 
 std::shared_ptr<TabletsChannel> new_local_tablets_channel(LoadChannel* load_channel, const TabletsChannelKey& key,
-                                                          MemTracker* mem_tracker) {
-    return std::make_shared<LocalTabletsChannel>(load_channel, key, mem_tracker);
+                                                          MemTracker* mem_tracker, RuntimeProfile* profile) {
+    return std::make_shared<LocalTabletsChannel>(load_channel, key, mem_tracker, profile);
 }
 
 } // namespace starrocks

--- a/be/src/runtime/local_tablets_channel.cpp
+++ b/be/src/runtime/local_tablets_channel.cpp
@@ -75,7 +75,7 @@ LocalTabletsChannel::LocalTabletsChannel(LoadChannel* load_channel, const Tablet
     _add_chunk_timer = ADD_TIMER(_profile, "AddChunkTime");
     _add_row_num = ADD_COUNTER(_profile, "AddRowNum", TUnit::UNIT);
     _wait_flush_timer = ADD_CHILD_TIMER(_profile, "WaitFlushTime", "AddChunkTime");
-    _wait_writer_timer = ADD_CHILD_TIMER(_profile, "WaitWriterTime", "AddChunkTime");
+    _wait_write_timer = ADD_CHILD_TIMER(_profile, "WaitWriteTime", "AddChunkTime");
     _wait_replica_timer = ADD_CHILD_TIMER(_profile, "WaitReplicaTime", "AddChunkTime");
     _wait_txn_persist_timer = ADD_CHILD_TIMER(_profile, "WaitTxnPersistTime", "AddChunkTime");
 }
@@ -433,7 +433,7 @@ void LocalTabletsChannel::add_chunk(Chunk* chunk, const PTabletWriterAddChunkReq
     COUNTER_UPDATE(_add_chunk_timer, watch.elapsed_time());
     COUNTER_UPDATE(_add_row_num, total_row_num);
     COUNTER_UPDATE(_wait_flush_timer, wait_memtable_flush_time_us * 1000);
-    COUNTER_UPDATE(_wait_writer_timer, wait_writer_ns);
+    COUNTER_UPDATE(_wait_write_timer, wait_writer_ns);
     COUNTER_UPDATE(_wait_replica_timer, wait_replica_ns);
 
     // remove tablets channel and load channel after all things done

--- a/be/src/runtime/local_tablets_channel.h
+++ b/be/src/runtime/local_tablets_channel.h
@@ -246,6 +246,8 @@ private:
     RuntimeProfile::Counter* _wait_writer_timer = nullptr;
     // Accumulated time to wait for secondary replicas in add_chunk()
     RuntimeProfile::Counter* _wait_replica_timer = nullptr;
+    // Accumulated time to wait for txn persist in add_chunk()
+    RuntimeProfile::Counter* _wait_txn_persist_timer = nullptr;
 };
 
 std::shared_ptr<TabletsChannel> new_local_tablets_channel(LoadChannel* load_channel, const TabletsChannelKey& key,

--- a/be/src/runtime/local_tablets_channel.h
+++ b/be/src/runtime/local_tablets_channel.h
@@ -243,7 +243,7 @@ private:
     // Accumulated time to wait for memtable flush in add_chunk()
     RuntimeProfile::Counter* _wait_flush_timer = nullptr;
     // Accumulated time to wait for async delta writers in add_chunk()
-    RuntimeProfile::Counter* _wait_writer_timer = nullptr;
+    RuntimeProfile::Counter* _wait_write_timer = nullptr;
     // Accumulated time to wait for secondary replicas in add_chunk()
     RuntimeProfile::Counter* _wait_replica_timer = nullptr;
     // Accumulated time to wait for txn persist in add_chunk()

--- a/be/src/runtime/runtime_state.cpp
+++ b/be/src/runtime/runtime_state.cpp
@@ -76,6 +76,7 @@ RuntimeState::RuntimeState(const TUniqueId& fragment_instance_id, const TQueryOp
           _num_rows_load_unselected(0),
           _num_print_error_rows(0) {
     _profile = std::make_shared<RuntimeProfile>("Fragment " + print_id(fragment_instance_id));
+    _load_channel_profile = std::make_shared<RuntimeProfile>("LoadChannel");
     _init(fragment_instance_id, query_options, query_globals, exec_env);
 }
 
@@ -93,12 +94,14 @@ RuntimeState::RuntimeState(const TUniqueId& query_id, const TUniqueId& fragment_
           _num_rows_load_unselected(0),
           _num_print_error_rows(0) {
     _profile = std::make_shared<RuntimeProfile>("Fragment " + print_id(fragment_instance_id));
+    _load_channel_profile = std::make_shared<RuntimeProfile>("LoadChannel");
     _init(fragment_instance_id, query_options, query_globals, exec_env);
 }
 
 RuntimeState::RuntimeState(const TQueryGlobals& query_globals)
         : _unreported_error_idx(0), _obj_pool(new ObjectPool()), _is_cancelled(false), _per_fragment_instance_idx(0) {
     _profile = std::make_shared<RuntimeProfile>("<unnamed>");
+    _load_channel_profile = std::make_shared<RuntimeProfile>("<unnamed>");
     _query_options.batch_size = DEFAULT_CHUNK_SIZE;
     if (query_globals.__isset.time_zone) {
         _timezone = query_globals.time_zone;
@@ -124,6 +127,7 @@ RuntimeState::RuntimeState(const TQueryGlobals& query_globals)
 
 RuntimeState::RuntimeState(ExecEnv* exec_env) : _exec_env(exec_env) {
     _profile = std::make_shared<RuntimeProfile>("<unnamed>");
+    _load_channel_profile = std::make_shared<RuntimeProfile>("<unnamed>");
     _query_options.batch_size = DEFAULT_CHUNK_SIZE;
     _timezone = TimezoneUtils::default_time_zone;
     _timestamp_us = 0;

--- a/be/src/runtime/runtime_state.h
+++ b/be/src/runtime/runtime_state.h
@@ -158,6 +158,9 @@ public:
     RuntimeProfile* runtime_profile() { return _profile.get(); }
     std::shared_ptr<RuntimeProfile> runtime_profile_ptr() { return _profile; }
 
+    RuntimeProfile* load_channel_profile() { return _load_channel_profile.get(); }
+    std::shared_ptr<RuntimeProfile> load_channel_profile_ptr() { return _load_channel_profile; }
+
     [[nodiscard]] Status query_status() {
         std::lock_guard<std::mutex> l(_process_status_lock);
         return _process_status;
@@ -471,6 +474,7 @@ private:
     // put runtime state before _obj_pool, so that it will be deconstructed after
     // _obj_pool. Because some object in _obj_pool will use profile when deconstructing.
     std::shared_ptr<RuntimeProfile> _profile;
+    std::shared_ptr<RuntimeProfile> _load_channel_profile;
 
     // An aggregation function may have multiple versions of implementation, func_version determines the chosen version.
     int _func_version = 0;

--- a/be/src/service/service_be/backend_service.cpp
+++ b/be/src/service/service_be/backend_service.cpp
@@ -23,6 +23,7 @@
 // "License"); you may not use this file except in compliance
 // with the License.  You may obtain a copy of the License at
 //
+
 //   http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing,

--- a/be/src/util/uid_util.cpp
+++ b/be/src/util/uid_util.cpp
@@ -44,6 +44,15 @@ std::ostream& operator<<(std::ostream& os, const UniqueId& uid) {
     return os;
 }
 
+std::string print_id(const UniqueId& id) {
+    boost::uuids::uuid uuid{};
+    int64_t hi = gbswap_64(id.hi);
+    int64_t lo = gbswap_64(id.lo);
+    memcpy(uuid.data + 0, &hi, 8);
+    memcpy(uuid.data + 8, &lo, 8);
+    return boost::uuids::to_string(uuid);
+}
+
 std::string print_id(const TUniqueId& id) {
     boost::uuids::uuid uuid{};
     int64_t hi = gbswap_64(id.hi);

--- a/be/src/util/uid_util.h
+++ b/be/src/util/uid_util.h
@@ -144,6 +144,7 @@ TUniqueId generate_uuid();
 
 std::ostream& operator<<(std::ostream& os, const UniqueId& uid);
 
+std::string print_id(const UniqueId& id);
 std::string print_id(const TUniqueId& id);
 std::string print_id(const PUniqueId& id);
 

--- a/be/test/CMakeLists.txt
+++ b/be/test/CMakeLists.txt
@@ -333,6 +333,7 @@ set(EXEC_FILES
         ./runtime/fragment_mgr_test.cpp
         ./runtime/int128_arithmetic_ops_test.cpp
         ./runtime/kafka_consumer_pipe_test.cpp
+        ./runtime/local_tablets_channel_test.cpp
         ./runtime/lake_tablets_channel_test.cpp
         ./runtime/large_int_value_test.cpp
         ./runtime/load_channel_test.cpp

--- a/be/test/runtime/lake_tablets_channel_test.cpp
+++ b/be/test/runtime/lake_tablets_channel_test.cpp
@@ -43,6 +43,7 @@
 #include "storage/tablet_schema.h"
 #include "testutil/assert.h"
 #include "testutil/id_generator.h"
+#include "util/runtime_profile.h"
 #include "util/uid_util.h"
 
 namespace starrocks {
@@ -55,6 +56,7 @@ public:
     LakeTabletsChannelTest() {
         _schema_id = next_id();
         _mem_tracker = std::make_unique<MemTracker>(1024 * 1024);
+        _root_profile = std::make_unique<RuntimeProfile>("LoadChannel");
         _location_provider = std::make_unique<lake::FixedLocationProvider>(kTestGroupPath);
         _update_manager = std::make_unique<lake::UpdateManager>(_location_provider.get(), _mem_tracker.get());
         _tablet_manager =
@@ -195,9 +197,9 @@ protected:
         _load_channel =
                 std::make_shared<LoadChannel>(_load_channel_mgr.get(), _tablet_manager.get(), UniqueId::gen_uid(),
                                               next_id(), string(), 1000, std::move(load_mem_tracker));
-        TabletsChannelKey key{UniqueId::gen_uid().to_proto(), 99999};
-        _tablets_channel =
-                new_lake_tablets_channel(_load_channel.get(), _tablet_manager.get(), key, _load_channel->mem_tracker());
+        TabletsChannelKey key{UniqueId::gen_uid().to_proto(), kIndexId};
+        _tablets_channel = new_lake_tablets_channel(_load_channel.get(), _tablet_manager.get(), key,
+                                                    _load_channel->mem_tracker(), _root_profile.get());
     }
 
     void TearDown() override {
@@ -243,6 +245,7 @@ protected:
 
     int64_t _schema_id;
     std::unique_ptr<MemTracker> _mem_tracker;
+    std::unique_ptr<RuntimeProfile> _root_profile;
     std::unique_ptr<lake::FixedLocationProvider> _location_provider;
     std::unique_ptr<lake::UpdateManager> _update_manager;
     std::unique_ptr<lake::TabletManager> _tablet_manager;
@@ -752,6 +755,45 @@ TEST_F(LakeTabletsChannelTest, test_finish_after_abort) {
         _tablets_channel->add_chunk(nullptr, finish_request, &finish_response2);
         ASSERT_EQ(TStatusCode::DUPLICATE_RPC_INVOCATION, finish_response2.status().status_code());
     }
+}
+
+TEST_F(LakeTabletsChannelTest, test_profile) {
+    auto open_request = _open_request;
+    open_request.set_num_senders(1);
+
+    ASSERT_OK(_tablets_channel->open(open_request, &_open_response, _schema_param, false));
+
+    constexpr int kChunkSize = 128;
+    constexpr int kChunkSizePerTablet = kChunkSize / 4;
+    auto chunk = generate_data(kChunkSize);
+
+    PTabletWriterAddChunkRequest add_chunk_request;
+    PTabletWriterAddBatchResult add_chunk_response;
+    add_chunk_request.set_index_id(kIndexId);
+    add_chunk_request.set_sender_id(0);
+    add_chunk_request.set_eos(true);
+    add_chunk_request.set_packet_seq(0);
+
+    for (int i = 0; i < kChunkSize; i++) {
+        int64_t tablet_id = 10086 + (i / kChunkSizePerTablet);
+        add_chunk_request.add_tablet_ids(tablet_id);
+        add_chunk_request.add_partition_ids(tablet_id < 10088 ? 10 : 11);
+    }
+
+    ASSIGN_OR_ABORT(auto chunk_pb, serde::ProtobufChunkSerde::serialize(chunk));
+    add_chunk_request.mutable_chunk()->Swap(&chunk_pb);
+
+    _tablets_channel->add_chunk(&chunk, add_chunk_request, &add_chunk_response);
+    ASSERT_TRUE(add_chunk_response.status().status_code() == TStatusCode::OK);
+
+    auto* profile = _root_profile->get_child(fmt::format("Index (id={})", kIndexId));
+    ASSERT_NE(nullptr, profile);
+    ASSERT_EQ(4, profile->get_counter("TabletsNum")->value());
+    ASSERT_EQ(1, profile->get_counter("OpenCount")->value());
+    ASSERT_TRUE(profile->get_counter("OpenTime")->value() > 0);
+    ASSERT_EQ(1, profile->get_counter("AddChunkCount")->value());
+    ASSERT_TRUE(profile->get_counter("AddChunkTime")->value() > 0);
+    ASSERT_EQ(chunk.num_rows(), profile->get_counter("AddRowNum")->value());
 }
 
 } // namespace starrocks

--- a/be/test/runtime/load_channel_test.cpp
+++ b/be/test/runtime/load_channel_test.cpp
@@ -40,6 +40,7 @@
 #include "storage/tablet_schema.h"
 #include "testutil/assert.h"
 #include "testutil/id_generator.h"
+#include "util/thrift_util.h"
 #include "util/uid_util.h"
 
 namespace starrocks {
@@ -505,6 +506,152 @@ TEST_F(LoadChannelTestForLakeTablet, test_add_segment) {
         EXPECT_EQ(TStatusCode::INTERNAL_ERROR, response.status().status_code());
         EXPECT_EQ("channel is not local tablets channel.", response.status().error_msgs()[0]);
     }
+}
+
+TEST_F(LoadChannelTestForLakeTablet, test_report_profile) {
+    {
+        // enable_profile = false and big_query_profile_threshold_ns = 0
+        // should not report
+        PLoadChannelProfileConfig profile_config;
+        profile_config.set_enable_profile(false);
+        profile_config.set_big_query_profile_threshold_ns(0);
+        profile_config.set_runtime_profile_report_interval_ns(0);
+        _load_channel->set_profile_config(profile_config);
+
+        PTabletWriterAddBatchResult add_chunk_response;
+        _load_channel->report_profile(&add_chunk_response, false);
+        ASSERT_FALSE(add_chunk_response.has_load_channel_profile());
+    }
+
+    {
+        // enable_profile = false and big_query_profile_threshold_ns > 0,
+        // but not reach threshold, should not report
+        PLoadChannelProfileConfig profile_config;
+        profile_config.set_enable_profile(false);
+        profile_config.set_big_query_profile_threshold_ns(std::numeric_limits<int64_t>::max());
+        profile_config.set_runtime_profile_report_interval_ns(0);
+        _load_channel->set_profile_config(profile_config);
+
+        PTabletWriterAddBatchResult add_chunk_response;
+        _load_channel->report_profile(&add_chunk_response, false);
+        ASSERT_FALSE(add_chunk_response.has_load_channel_profile());
+    }
+
+    {
+        // enable_profile = true, but not reach report interval, should not report
+        PLoadChannelProfileConfig profile_config;
+        profile_config.set_enable_profile(true);
+        profile_config.set_big_query_profile_threshold_ns(0);
+        profile_config.set_runtime_profile_report_interval_ns(std::numeric_limits<int64_t>::max());
+        _load_channel->set_profile_config(profile_config);
+
+        PTabletWriterAddBatchResult add_chunk_response;
+        _load_channel->report_profile(&add_chunk_response, false);
+        ASSERT_FALSE(add_chunk_response.has_load_channel_profile());
+    }
+
+    {
+        // enable_profile = true, should report
+        PLoadChannelProfileConfig profile_config;
+        profile_config.set_enable_profile(true);
+        profile_config.set_big_query_profile_threshold_ns(0);
+        profile_config.set_runtime_profile_report_interval_ns(100);
+        _load_channel->set_profile_config(profile_config);
+        std::this_thread::sleep_for(std::chrono::microseconds(10));
+
+        PTabletWriterAddBatchResult add_chunk_response;
+        _load_channel->report_profile(&add_chunk_response, false);
+        ASSERT_TRUE(add_chunk_response.has_load_channel_profile());
+    }
+
+    {
+        // big_query_profile_threshold_ns = 10, and reach the threshold, should report
+        PLoadChannelProfileConfig profile_config;
+        profile_config.set_enable_profile(false);
+        profile_config.set_big_query_profile_threshold_ns(10);
+        profile_config.set_runtime_profile_report_interval_ns(100);
+        _load_channel->set_profile_config(profile_config);
+        std::this_thread::sleep_for(std::chrono::microseconds(10));
+
+        PTabletWriterAddBatchResult add_chunk_response;
+        _load_channel->report_profile(&add_chunk_response, true);
+        ASSERT_TRUE(add_chunk_response.has_load_channel_profile());
+    }
+}
+
+TEST_F(LoadChannelTestForLakeTablet, test_final_profile) {
+    PTabletWriterOpenRequest open_request = _open_request;
+    open_request.set_num_senders(1);
+    PLoadChannelProfileConfig profile_config;
+    profile_config.set_enable_profile(true);
+    _load_channel->set_profile_config(profile_config);
+    open_request.mutable_load_channel_profile_config()->CopyFrom(profile_config);
+
+    PTabletWriterOpenResult open_response;
+    _load_channel->open(nullptr, open_request, &open_response, nullptr);
+    ASSERT_EQ(TStatusCode::OK, open_response.status().status_code());
+
+    constexpr int kChunkSize = 128;
+    constexpr int kChunkSizePerTablet = kChunkSize / 4;
+    auto chunk = generate_data(kChunkSize);
+
+    PTabletWriterAddChunkRequest add_chunk_request;
+    PTabletWriterAddBatchResult add_chunk_response;
+    {
+        add_chunk_request.set_index_id(kIndexId);
+        add_chunk_request.set_sender_id(0);
+        add_chunk_request.set_eos(true);
+        add_chunk_request.set_packet_seq(0);
+
+        ASSIGN_OR_ABORT(auto chunk_pb, serde::ProtobufChunkSerde::serialize(chunk));
+        add_chunk_request.mutable_chunk()->Swap(&chunk_pb);
+
+        for (int i = 0; i < kChunkSize; i++) {
+            int64_t tablet_id = 10086 + (i / kChunkSizePerTablet);
+            add_chunk_request.add_tablet_ids(tablet_id);
+            add_chunk_request.add_partition_ids(tablet_id < 10088 ? 10 : 11);
+        }
+    }
+
+    auto clear_response = [](PTabletWriterAddBatchResult* response) {
+        PTabletWriterAddBatchResult tmp;
+        response->Swap(&tmp);
+    };
+
+    _load_channel->add_chunk(add_chunk_request, &add_chunk_response);
+    ASSERT_TRUE(add_chunk_response.status().status_code() == TStatusCode::OK);
+    ASSERT_TRUE(add_chunk_response.has_load_channel_profile());
+
+    const auto* buf = (const uint8_t*)(add_chunk_response.load_channel_profile().data());
+    uint32_t len = add_chunk_response.load_channel_profile().size();
+    TRuntimeProfileTree thrift_profile;
+    auto st = deserialize_thrift_msg(buf, &len, TProtocolType::BINARY, &thrift_profile);
+    ASSERT_OK(st);
+    std::shared_ptr<RuntimeProfile> profile = std::make_shared<RuntimeProfile>("LoadChannel");
+    profile->update(thrift_profile);
+    ASSERT_EQ(print_id(_load_channel->load_id()), *profile->get_info_string("LoadId"));
+    ASSERT_EQ(std::to_string(_load_channel->txn_id()), *profile->get_info_string("TxnId"));
+
+    ASSERT_EQ(1, profile->num_children());
+    RuntimeProfile* channel_profile = profile->get_child(0);
+    ASSERT_NE(nullptr, profile);
+    ASSERT_EQ(fmt::format("Channel (host={})", BackendOptions::get_localhost()), channel_profile->name());
+    ASSERT_EQ(BackendOptions::get_localhost(), *channel_profile->get_info_string("Address"));
+    ASSERT_EQ(1, channel_profile->get_counter("IndexNum")->value());
+    ASSERT_EQ(-1, channel_profile->get_counter("LoadMemoryLimit")->value());
+
+    ASSERT_EQ(1, channel_profile->num_children());
+    RuntimeProfile* index_profile = channel_profile->get_child(0);
+    ASSERT_NE(nullptr, profile);
+    ASSERT_EQ(fmt::format("Index (id={})", kIndexId), index_profile->name());
+    ASSERT_EQ(4, index_profile->get_counter("TabletsNum")->value());
+    ASSERT_EQ(1, index_profile->get_counter("OpenCount")->value());
+    ASSERT_TRUE(index_profile->get_counter("OpenTime")->value() > 0);
+    ASSERT_EQ(1, index_profile->get_counter("AddChunkCount")->value());
+    ASSERT_TRUE(index_profile->get_counter("AddChunkTime")->value() > 0);
+    ASSERT_EQ(chunk.num_rows(), index_profile->get_counter("AddRowNum")->value());
+
+    clear_response(&add_chunk_response);
 }
 
 } // namespace starrocks

--- a/be/test/runtime/load_channel_test.cpp
+++ b/be/test/runtime/load_channel_test.cpp
@@ -636,7 +636,6 @@ TEST_F(LoadChannelTestForLakeTablet, test_final_profile) {
     RuntimeProfile* channel_profile = profile->get_child(0);
     ASSERT_NE(nullptr, profile);
     ASSERT_EQ(fmt::format("Channel (host={})", BackendOptions::get_localhost()), channel_profile->name());
-    ASSERT_EQ(BackendOptions::get_localhost(), *channel_profile->get_info_string("Address"));
     ASSERT_EQ(1, channel_profile->get_counter("IndexNum")->value());
     ASSERT_EQ(-1, channel_profile->get_counter("LoadMemoryLimit")->value());
 

--- a/be/test/runtime/local_tablets_channel_test.cpp
+++ b/be/test/runtime/local_tablets_channel_test.cpp
@@ -1,0 +1,239 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "runtime/local_tablets_channel.h"
+
+#include <fmt/format.h>
+#include <gtest/gtest.h>
+
+#include "column/chunk.h"
+#include "column/fixed_length_column.h"
+#include "column/schema.h"
+#include "column/vectorized_fwd.h"
+#include "common/logging.h"
+#include "gen_cpp/internal_service.pb.h"
+#include "runtime/load_channel.h"
+#include "runtime/load_channel_mgr.h"
+#include "runtime/mem_tracker.h"
+#include "serde/protobuf_serde.h"
+#include "storage/chunk_helper.h"
+#include "storage/rowset/segment_options.h"
+#include "storage/storage_engine.h"
+#include "storage/tablet_manager.h"
+#include "storage/tablet_schema.h"
+#include "testutil/assert.h"
+#include "testutil/id_generator.h"
+#include "util/runtime_profile.h"
+
+namespace starrocks {
+
+class LocalTabletsChannelTest : public testing::Test {
+protected:
+    void SetUp() override {
+        srand(GetCurrentTimeMicros());
+
+        _node_id = 100;
+        _load_id.set_hi(456789);
+        _load_id.set_lo(987654);
+        _txn_id = 10000;
+        _db_id = 100;
+        _table_id = 101;
+        _partition_id = 10;
+        _index_id = 1;
+        _tablet_id = rand();
+        _tablet = create_tablet(_tablet_id, rand());
+        _schema = std::make_shared<Schema>(ChunkHelper::convert_schema(_tablet->tablet_schema()));
+
+        _mem_tracker = std::make_unique<MemTracker>(1024 * 1024);
+        _root_profile = std::make_unique<RuntimeProfile>("LoadChannel");
+        _load_channel_mgr = std::make_unique<LoadChannelMgr>();
+        auto load_mem_tracker = std::make_unique<MemTracker>(-1, "", _mem_tracker.get());
+        _load_channel = std::make_shared<LoadChannel>(_load_channel_mgr.get(), nullptr, _load_id, _txn_id, string(),
+                                                      1000, std::move(load_mem_tracker));
+        _open_request = create_open_request();
+        TabletsChannelKey key{_load_id, _index_id};
+        _schema_param.reset(new OlapTableSchemaParam());
+        ASSERT_OK(_schema_param->init(_open_request.schema()));
+        _tablets_channel =
+                new_local_tablets_channel(_load_channel.get(), key, _load_channel->mem_tracker(), _root_profile.get());
+    }
+
+    void TearDown() override {
+        _tablets_channel.reset();
+        _load_channel.reset();
+        if (_tablet) {
+            _tablet.reset();
+            auto st = StorageEngine::instance()->tablet_manager()->drop_tablet(_tablet_id);
+            ASSERT_OK(st);
+        }
+    }
+
+    TabletSharedPtr create_tablet(int64_t tablet_id, int32_t schema_hash) {
+        TCreateTabletReq request;
+        request.tablet_id = tablet_id;
+        request.__set_version(1);
+        request.tablet_schema.schema_hash = schema_hash;
+        request.tablet_schema.short_key_column_count = 1;
+        request.tablet_schema.keys_type = TKeysType::DUP_KEYS;
+        request.tablet_schema.storage_type = TStorageType::COLUMN;
+
+        TColumn c0;
+        c0.column_name = "c0";
+        c0.__set_is_key(true);
+        c0.column_type.type = TPrimitiveType::INT;
+        request.tablet_schema.columns.push_back(c0);
+
+        TColumn c1;
+        c1.column_name = "c1";
+        c1.__set_is_key(false);
+        c1.column_type.type = TPrimitiveType::INT;
+        request.tablet_schema.columns.push_back(c1);
+
+        auto st = StorageEngine::instance()->create_tablet(request);
+        CHECK(st.ok()) << st.to_string();
+        return StorageEngine::instance()->tablet_manager()->get_tablet(tablet_id, false);
+    }
+
+    PTabletWriterOpenRequest create_open_request() {
+        PTabletWriterOpenRequest request;
+        request.mutable_id()->CopyFrom(_load_id);
+        request.set_index_id(_index_id);
+        request.set_txn_id(_txn_id);
+        request.set_is_lake_tablet(false);
+        request.set_is_replicated_storage(true);
+        request.set_node_id(_node_id);
+        request.set_write_quorum(WriteQuorumTypePB::MAJORITY);
+        request.set_miss_auto_increment_column(false);
+        request.set_table_id(_table_id);
+        request.set_is_incremental(false);
+        request.set_num_senders(1);
+        request.set_sender_id(0);
+        request.set_need_gen_rollup(false);
+        request.set_load_channel_timeout_s(10);
+        request.set_is_vectorized(true);
+        request.set_timeout_ms(10000);
+
+        request.set_immutable_tablet_size(0);
+        auto tablet = request.add_tablets();
+        tablet->set_partition_id(_partition_id);
+        tablet->set_tablet_id(_tablet_id);
+        auto replica = tablet->add_replicas();
+        replica->set_host("127.0.0.1");
+        replica->set_port(8060);
+        replica->set_node_id(_node_id);
+
+        auto schema = request.mutable_schema();
+        schema->set_db_id(_db_id);
+        schema->set_table_id(_table_id);
+        schema->set_version(1);
+        auto index = schema->add_indexes();
+        index->set_id(_index_id);
+        index->set_schema_hash(0);
+        for (int i = 0, sz = _tablet->tablet_schema()->num_columns(); i < sz; i++) {
+            auto slot = request.mutable_schema()->add_slot_descs();
+            auto& column = _tablet->tablet_schema()->column(i);
+            slot->set_id(i);
+            slot->set_byte_offset(i * sizeof(int) /*unused*/);
+            slot->set_col_name(std::string(column.name()));
+            slot->set_slot_idx(i);
+            slot->set_is_materialized(true);
+            slot->mutable_slot_type()->add_types()->mutable_scalar_type()->set_type(column.type());
+            index->add_columns(std::string(column.name()));
+        }
+        auto tuple_desc = schema->mutable_tuple_desc();
+        tuple_desc->set_id(1);
+        tuple_desc->set_byte_size(8 /*unused*/);
+        tuple_desc->set_num_null_bytes(0 /*unused*/);
+        tuple_desc->set_table_id(_table_id);
+
+        return request;
+    }
+
+    Chunk generate_data(int64_t chunk_size) {
+        std::vector<int> v0(chunk_size);
+        std::vector<int> v1(chunk_size);
+        for (int i = 0; i < chunk_size; i++) {
+            v0[i] = i;
+        }
+        auto c0 = Int32Column::create();
+        auto c1 = Int32Column::create();
+        c0->append_numbers(v0.data(), v0.size() * sizeof(int));
+        c1->append_numbers(v1.data(), v1.size() * sizeof(int));
+        Chunk chunk({c0, c1}, _schema);
+        chunk.set_slot_id_to_index(0, 0);
+        chunk.set_slot_id_to_index(1, 1);
+        return chunk;
+    }
+
+    int64_t _node_id;
+    PUniqueId _load_id;
+    int64_t _txn_id;
+    int64_t _db_id;
+    int64_t _table_id;
+    int64_t _partition_id;
+    int32_t _index_id;
+    int64_t _tablet_id;
+    std::unique_ptr<MemTracker> _mem_tracker;
+    std::unique_ptr<RuntimeProfile> _root_profile;
+    std::unique_ptr<LoadChannelMgr> _load_channel_mgr;
+    std::shared_ptr<LoadChannel> _load_channel;
+    std::shared_ptr<TabletsChannel> _tablets_channel;
+
+    TabletSharedPtr _tablet;
+    std::shared_ptr<Schema> _schema;
+    std::shared_ptr<OlapTableSchemaParam> _schema_param;
+
+    PTabletWriterOpenRequest _open_request;
+    PTabletWriterOpenResult _open_response;
+};
+
+TEST_F(LocalTabletsChannelTest, test_profile) {
+    auto open_request = _open_request;
+
+    ASSERT_OK(_tablets_channel->open(open_request, &_open_response, _schema_param, false));
+
+    PTabletWriterAddChunkRequest add_chunk_request;
+    add_chunk_request.mutable_id()->CopyFrom(_load_id);
+    add_chunk_request.set_index_id(_index_id);
+    add_chunk_request.set_sender_id(0);
+    add_chunk_request.set_eos(true);
+    add_chunk_request.set_packet_seq(0);
+
+    int chunk_size = 16;
+    auto chunk = generate_data(chunk_size);
+    ASSIGN_OR_ABORT(auto chunk_pb, serde::ProtobufChunkSerde::serialize(chunk));
+    add_chunk_request.mutable_chunk()->Swap(&chunk_pb);
+
+    for (int i = 0; i < chunk_size; i++) {
+        add_chunk_request.add_tablet_ids(_tablet_id);
+        add_chunk_request.add_partition_ids(_partition_id);
+    }
+
+    PTabletWriterAddBatchResult add_chunk_response;
+    _tablets_channel->add_chunk(&chunk, add_chunk_request, &add_chunk_response);
+    ASSERT_TRUE(add_chunk_response.status().status_code() == TStatusCode::OK)
+            << add_chunk_response.status().error_msgs(0);
+
+    auto* profile = _root_profile->get_child(fmt::format("Index (id={})", _index_id));
+    ASSERT_NE(nullptr, profile);
+    ASSERT_EQ(1, profile->get_counter("PrimaryTabletsNum")->value());
+    ASSERT_EQ(0, profile->get_counter("SecondaryTabletsNum")->value());
+    ASSERT_EQ(1, profile->get_counter("OpenCount")->value());
+    ASSERT_TRUE(profile->get_counter("OpenTime")->value() > 0);
+    ASSERT_EQ(1, profile->get_counter("AddChunkCount")->value());
+    ASSERT_TRUE(profile->get_counter("AddChunkTime")->value() > 0);
+    ASSERT_EQ(chunk.num_rows(), profile->get_counter("AddRowNum")->value());
+}
+
+} // namespace starrocks

--- a/be/test/util/uid_util_test.cpp
+++ b/be/test/util/uid_util_test.cpp
@@ -110,4 +110,23 @@ TEST_F(UidUtilTest, Hash) {
     }
 }
 
+TEST_F(UidUtilTest, PrintId) {
+    {
+        UniqueId id(12345678987654321, 98765432123456789);
+        ASSERT_STREQ("002bdc54-6291-f4b1-015e-e2a321ce7d15", print_id(id).c_str());
+    }
+    {
+        PUniqueId puid;
+        puid.set_hi(12345678987654321);
+        puid.set_lo(98765432123456789);
+        ASSERT_STREQ("002bdc54-6291-f4b1-015e-e2a321ce7d15", print_id(puid).c_str());
+    }
+    {
+        TUniqueId tuid;
+        tuid.__set_hi(12345678987654321);
+        tuid.__set_lo(98765432123456789);
+        ASSERT_STREQ("002bdc54-6291-f4b1-015e-e2a321ce7d15", print_id(tuid).c_str());
+    }
+}
+
 } // namespace starrocks

--- a/fe/fe-core/src/main/java/com/starrocks/common/util/Counter.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/util/Counter.java
@@ -115,8 +115,12 @@ public class Counter {
     }
 
     public static TCounterStrategy createStrategy(TUnit type) {
-        TCounterStrategy strategy = new TCounterStrategy();
         TCounterAggregateType aggregateType = isTimeType(type) ? TCounterAggregateType.AVG : TCounterAggregateType.SUM;
+        return createStrategy(aggregateType);
+    }
+
+    public static TCounterStrategy createStrategy(TCounterAggregateType aggregateType) {
+        TCounterStrategy strategy = new TCounterStrategy();
         TCounterMergeType mergeType = TCounterMergeType.MERGE_ALL;
         strategy.aggregate_type = aggregateType;
         strategy.merge_type = mergeType;

--- a/fe/fe-core/src/main/java/com/starrocks/qe/DefaultCoordinator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/DefaultCoordinator.java
@@ -890,6 +890,8 @@ public class DefaultCoordinator extends Coordinator {
             if (!execState.updateExecStatus(params)) {
                 return;
             }
+
+            queryProfile.updateLoadChannelProfile(params);
         } finally {
             unlock();
         }

--- a/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/QueryRuntimeProfile.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/QueryRuntimeProfile.java
@@ -76,6 +76,8 @@ public class QueryRuntimeProfile {
      */
     private static final Long MARKED_COUNT_DOWN_VALUE = -1L;
 
+    public static final String LOAD_CHANNEL_PROFILE_NAME = "LoadChannel";
+
     private final JobSpec jobSpec;
 
     private final ConnectContext connectContext;
@@ -140,7 +142,7 @@ public class QueryRuntimeProfile {
         }
 
         if (jobSpec.hasOlapTableSink()) {
-            loadChannelProfile = Optional.of(new RuntimeProfile("LoadChannel"));
+            loadChannelProfile = Optional.of(new RuntimeProfile(LOAD_CHANNEL_PROFILE_NAME));
             queryProfile.addChild(loadChannelProfile.get());
         } else {
             loadChannelProfile = Optional.empty();

--- a/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/QueryRuntimeProfile.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/QueryRuntimeProfile.java
@@ -578,7 +578,7 @@ public class QueryRuntimeProfile {
 
         RuntimeProfile mergedChannelProfile =
                 RuntimeProfile.mergeIsomorphicProfiles(channelProfiles, Sets.newHashSet("Address"));
-        if (mergedChannelProfile == null ) {
+        if (mergedChannelProfile == null) {
             if (LOG.isDebugEnabled()) {
                 StringBuilder builder = new StringBuilder();
                 originProfile.prettyPrint(builder, "");

--- a/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/dag/JobSpec.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/dag/JobSpec.java
@@ -481,7 +481,14 @@ public class JobSpec {
             return GlobalStateMgr.getCurrentState().getGlobalSlotProvider();
         }
     }
-
+    public boolean hasOlapTableSink() {
+        for (PlanFragment fragment : fragments) {
+            if (fragment.hasOlapTableSink()) {
+                return true;
+            }
+        }
+        return false;
+    }
     public static class Builder {
         private final JobSpec instance = new JobSpec();
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ExplainAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ExplainAnalyzer.java
@@ -61,6 +61,8 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
+import static com.starrocks.qe.scheduler.QueryRuntimeProfile.LOAD_CHANNEL_PROFILE_NAME;
+
 public class ExplainAnalyzer {
     private static final Logger LOG = LogManager.getLogger(ExplainAnalyzer.class);
 
@@ -194,6 +196,10 @@ public class ExplainAnalyzer {
 
         for (int i = 0; i < executionProfile.getChildList().size(); i++) {
             RuntimeProfile fragmentProfile = executionProfile.getChildList().get(i).first;
+            // TODO support analyze load channel profile
+            if (LOAD_CHANNEL_PROFILE_NAME.equals(fragmentProfile.getName())) {
+                continue;
+            }
 
             ProfileNodeParser parser = new ProfileNodeParser(isRuntimeProfile, fragmentProfile);
             Map<Integer, NodeInfo> nodeInfos = parser.parse();

--- a/fe/fe-core/src/test/java/com/starrocks/qe/scheduler/QueryRuntimeProfileTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/qe/scheduler/QueryRuntimeProfileTest.java
@@ -1,0 +1,167 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.qe.scheduler;
+
+import com.starrocks.common.util.Counter;
+import com.starrocks.common.util.RuntimeProfile;
+import com.starrocks.common.util.UUIDUtil;
+import com.starrocks.qe.ConnectContext;
+import com.starrocks.qe.scheduler.dag.JobSpec;
+import com.starrocks.thrift.FrontendServiceVersion;
+import com.starrocks.thrift.TCounterAggregateType;
+import com.starrocks.thrift.TReportExecStatusParams;
+import com.starrocks.thrift.TRuntimeProfileTree;
+import com.starrocks.thrift.TUnit;
+import com.starrocks.utframe.UtFrameUtils;
+import mockit.Expectations;
+import mockit.Mocked;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.Optional;
+
+public class QueryRuntimeProfileTest {
+
+    private ConnectContext connectContext;
+
+    @Mocked
+    private JobSpec jobSpec;
+
+    @Before
+    public void setup() {
+        connectContext = UtFrameUtils.createDefaultCtx();
+        connectContext.setQueryId(UUIDUtil.genUUID());
+        connectContext.setExecutionId(UUIDUtil.toTUniqueId(connectContext.getQueryId()));
+
+        new Expectations() {
+            {
+                jobSpec.getQueryId();
+                result = connectContext.getExecutionId();
+                minTimes = 0;
+
+                jobSpec.isEnablePipeline();
+                result = true;
+                minTimes = 0;
+            }
+        };
+    }
+
+    @Test
+    public void testLoadChannelProfile1() {
+        new Expectations() {
+            {
+                jobSpec.hasOlapTableSink();
+                result = true;
+                minTimes = 0;
+            }
+        };
+
+        QueryRuntimeProfile profile = new QueryRuntimeProfile(connectContext, jobSpec, 1);
+        TReportExecStatusParams reportExecStatusParams = buildReportStatus();
+        profile.updateLoadChannelProfile(reportExecStatusParams);
+        Optional<RuntimeProfile> optional = profile.mergeLoadChannelProfile();
+        Assert.assertTrue(optional.isPresent());
+        RuntimeProfile mergedProfile = optional.get();
+
+        Assert.assertEquals("LoadChannel", mergedProfile.getName());
+        Assert.assertEquals("288fb1df-f955-472f-a377-cb1e10e4d993", mergedProfile.getInfoString("LoadId"));
+        Assert.assertEquals("40", mergedProfile.getInfoString("TxnId"));
+        Assert.assertEquals("127.0.0.1,127.0.0.2", mergedProfile.getInfoString("BackendAddresses"));
+        Assert.assertEquals(2, mergedProfile.getCounter("ChannelNum").getValue());
+        Assert.assertEquals(537395200, mergedProfile.getCounter("PeakMemoryUsage").getValue());
+        Assert.assertEquals(1073741824, mergedProfile.getCounter("__MAX_OF_PeakMemoryUsage").getValue());
+        Assert.assertEquals(1048576, mergedProfile.getCounter("__MIN_OF_PeakMemoryUsage").getValue());
+        Assert.assertEquals(2, mergedProfile.getChildMap().size());
+
+        RuntimeProfile indexProfile1 = mergedProfile.getChild("Index (id=10176)");
+        Assert.assertEquals(162, indexProfile1.getCounter("AddChunkCount").getValue());
+        Assert.assertEquals(82, indexProfile1.getCounter("__MAX_OF_AddChunkCount").getValue());
+        Assert.assertEquals(80, indexProfile1.getCounter("__MIN_OF_AddChunkCount").getValue());
+        Assert.assertEquals(15000000000L, indexProfile1.getCounter("AddChunkTime").getValue());
+        Assert.assertEquals(20000000000L, indexProfile1.getCounter("__MAX_OF_AddChunkTime").getValue());
+        Assert.assertEquals(10000000000L, indexProfile1.getCounter("__MIN_OF_AddChunkTime").getValue());
+
+        RuntimeProfile indexProfile2 = mergedProfile.getChild("Index (id=10298)");
+        Assert.assertEquals(162, indexProfile2.getCounter("AddChunkCount").getValue());
+        Assert.assertEquals(82, indexProfile2.getCounter("__MAX_OF_AddChunkCount").getValue());
+        Assert.assertEquals(80, indexProfile2.getCounter("__MIN_OF_AddChunkCount").getValue());
+        Assert.assertEquals(1500000000L, indexProfile2.getCounter("AddChunkTime").getValue());
+        Assert.assertEquals(2000000000L, indexProfile2.getCounter("__MAX_OF_AddChunkTime").getValue());
+        Assert.assertEquals(1000000000L, indexProfile2.getCounter("__MIN_OF_AddChunkTime").getValue());
+    }
+
+    private TReportExecStatusParams buildReportStatus() {
+        RuntimeProfile profile = new RuntimeProfile("LoadChannel");
+        profile.addInfoString("LoadId", "288fb1df-f955-472f-a377-cb1e10e4d993");
+        profile.addInfoString("TxnId", "40");
+
+        RuntimeProfile channelProfile1 = new RuntimeProfile("Channel (host=127.0.0.1)");
+        profile.addChild(channelProfile1);
+        channelProfile1.addInfoString("Address", "127.0.0.1");
+        Counter peakMemoryCounter1 = channelProfile1.addCounter("PeakMemoryUsage", TUnit.BYTES,
+                Counter.createStrategy(TCounterAggregateType.AVG));
+        peakMemoryCounter1.setValue(1024 * 1024 * 1024);
+
+        RuntimeProfile indexProfile1 = new RuntimeProfile("Index (id=10176)");
+        channelProfile1.addChild(indexProfile1);
+        Counter addChunkCounter1 = indexProfile1.addCounter("AddChunkCount", TUnit.UNIT,
+                Counter.createStrategy(TUnit.UNIT));
+        addChunkCounter1.setValue(82);
+        Counter addChunkTime1 = indexProfile1.addCounter("AddChunkTime", TUnit.TIME_NS,
+                Counter.createStrategy(TCounterAggregateType.AVG));
+        addChunkTime1.setValue(20000000000L);
+
+        RuntimeProfile indexProfile2 = new RuntimeProfile("Index (id=10298)");
+        channelProfile1.addChild(indexProfile2);
+        Counter addChunkCounter2 = indexProfile2.addCounter("AddChunkCount", TUnit.UNIT,
+                Counter.createStrategy(TUnit.UNIT));
+        addChunkCounter2.setValue(82);
+        Counter addChunkTime2 = indexProfile2.addCounter("AddChunkTime", TUnit.TIME_NS,
+                Counter.createStrategy(TCounterAggregateType.AVG));
+        addChunkTime2.setValue(1000000000L);
+
+        RuntimeProfile channelProfile2 = new RuntimeProfile("Channel (host=127.0.0.2)");
+        profile.addChild(channelProfile2);
+        channelProfile2.addInfoString("Address", "127.0.0.2");
+        Counter peakMemoryCounter2 = channelProfile2.addCounter("PeakMemoryUsage", TUnit.BYTES,
+                Counter.createStrategy(TCounterAggregateType.AVG));
+        peakMemoryCounter2.setValue(1024 * 1024);
+
+        RuntimeProfile indexProfile3 = new RuntimeProfile("Index (id=10176)");
+        channelProfile2.addChild(indexProfile3);
+        Counter addChunkCounter3 = indexProfile3.addCounter("AddChunkCount", TUnit.UNIT,
+                Counter.createStrategy(TUnit.UNIT));
+        addChunkCounter3.setValue(80);
+        Counter addChunkTime3 = indexProfile3.addCounter("AddChunkTime", TUnit.TIME_NS,
+                Counter.createStrategy(TCounterAggregateType.AVG));
+        addChunkTime3.setValue(10000000000L);
+
+        RuntimeProfile indexProfile4 = new RuntimeProfile("Index (id=10298)");
+        channelProfile2.addChild(indexProfile4);
+        Counter addChunkCounter4 = indexProfile4.addCounter("AddChunkCount", TUnit.UNIT,
+                Counter.createStrategy(TUnit.UNIT));
+        addChunkCounter4.setValue(80);
+        Counter addChunkTime4 = indexProfile4.addCounter("AddChunkTime", TUnit.TIME_NS,
+                Counter.createStrategy(TCounterAggregateType.AVG));
+        addChunkTime4.setValue(2000000000L);
+
+        TReportExecStatusParams params = new TReportExecStatusParams(FrontendServiceVersion.V1);
+        TRuntimeProfileTree profileTree = profile.toThrift();
+        params.setLoad_channel_profile(profileTree);
+
+        return params;
+    }
+}

--- a/fe/fe-core/src/test/java/com/starrocks/qe/scheduler/QueryRuntimeProfileTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/qe/scheduler/QueryRuntimeProfileTest.java
@@ -60,7 +60,7 @@ public class QueryRuntimeProfileTest {
     }
 
     @Test
-    public void testLoadChannelProfile1() {
+    public void testLoadChannelProfile() {
         new Expectations() {
             {
                 jobSpec.hasOlapTableSink();
@@ -110,7 +110,6 @@ public class QueryRuntimeProfileTest {
 
         RuntimeProfile channelProfile1 = new RuntimeProfile("Channel (host=127.0.0.1)");
         profile.addChild(channelProfile1);
-        channelProfile1.addInfoString("Address", "127.0.0.1");
         Counter peakMemoryCounter1 = channelProfile1.addCounter("PeakMemoryUsage", TUnit.BYTES,
                 Counter.createStrategy(TCounterAggregateType.AVG));
         peakMemoryCounter1.setValue(1024 * 1024 * 1024);
@@ -135,7 +134,6 @@ public class QueryRuntimeProfileTest {
 
         RuntimeProfile channelProfile2 = new RuntimeProfile("Channel (host=127.0.0.2)");
         profile.addChild(channelProfile2);
-        channelProfile2.addInfoString("Address", "127.0.0.2");
         Counter peakMemoryCounter2 = channelProfile2.addCounter("PeakMemoryUsage", TUnit.BYTES,
                 Counter.createStrategy(TCounterAggregateType.AVG));
         peakMemoryCounter2.setValue(1024 * 1024);

--- a/gensrc/proto/internal_service.proto
+++ b/gensrc/proto/internal_service.proto
@@ -151,6 +151,12 @@ message PTabletInfo {
     repeated int64 valid_dict_collected_version = 6;
 }
 
+message PLoadChannelProfileConfig {
+    optional bool enable_profile = 1;
+    optional int64 big_query_profile_threshold_ns = 2;
+    optional int64 runtime_profile_report_interval_ns = 3;
+}
+
 // Open a tablet writer.
 message PTabletWriterOpenRequest {
     required PUniqueId id = 1;
@@ -181,6 +187,7 @@ message PTabletWriterOpenRequest {
 
     // tablet's data size larger than this will mark as inmutable
     optional int64 immutable_tablet_size = 33 [default = 0];
+    optional PLoadChannelProfileConfig load_channel_profile_config = 34;
 };
 
 message PTabletWriterOpenResult {
@@ -248,6 +255,7 @@ message PTabletWriterAddBatchResult {
 
     repeated int64 immutable_tablet_ids = 7;
     repeated int64 immutable_partition_ids = 8;
+    optional bytes load_channel_profile = 9;
 };
 
 message PTabletWriterAddSegmentRequest {
@@ -643,7 +651,7 @@ service PInternalService {
     rpc local_tablet_reader_scan_get_next(PTabletReaderScanGetNextRequest) returns (PTabletReaderScanGetNextResult);
 
     rpc execute_command(ExecuteCommandRequestPB) returns (ExecuteCommandResultPB);
-    
+
     rpc update_fail_point_status(PUpdateFailPointStatusRequest) returns (PUpdateFailPointStatusResponse);
     rpc list_fail_point(PListFailPointRequest) returns (PListFailPointResponse);
 

--- a/gensrc/proto/internal_service.proto
+++ b/gensrc/proto/internal_service.proto
@@ -651,7 +651,6 @@ service PInternalService {
     rpc local_tablet_reader_scan_get_next(PTabletReaderScanGetNextRequest) returns (PTabletReaderScanGetNextResult);
 
     rpc execute_command(ExecuteCommandRequestPB) returns (ExecuteCommandResultPB);
-
     rpc update_fail_point_status(PUpdateFailPointStatusRequest) returns (PUpdateFailPointStatusResponse);
     rpc list_fail_point(PListFailPointRequest) returns (PListFailPointResponse);
 

--- a/gensrc/thrift/FrontendService.thrift
+++ b/gensrc/thrift/FrontendService.thrift
@@ -717,6 +717,8 @@ struct TReportExecStatusParams {
   25: optional list<Types.TSinkCommitInfo> sink_commit_infos
 
   27: optional string rejected_record_path
+
+  28: optional RuntimeProfile.TRuntimeProfileTree load_channel_profile;
 }
 
 struct TAuditStatistics {

--- a/gensrc/thrift/RuntimeProfile.thrift
+++ b/gensrc/thrift/RuntimeProfile.thrift
@@ -80,6 +80,9 @@ struct TRuntimeProfileNode {
   
   // map from parent counter name to child counter name
   8: required map<string, set<string>> child_counters_map
+
+  // The version of this profile
+  9: optional i64 version
 }
 
 // A flattened tree of runtime profiles, obtained by an

--- a/test/sql/test_profile/R/test_load_channel_profile
+++ b/test/sql/test_profile/R/test_load_channel_profile
@@ -1,0 +1,42 @@
+-- name: test_load_channel_profile
+CREATE TABLE `t0` (
+  `v1` int(11) NOT NULL,
+  `v2` int(11) NOT NULL,
+  `v3` int(11) NOT NULL
+) ENGINE=OLAP
+DUPLICATE KEY(`v1`)
+DISTRIBUTED BY HASH(`v1`) BUCKETS 10
+PROPERTIES (
+ "replication_num" = "1"
+);
+-- result:
+-- !result
+CREATE MATERIALIZED VIEW `mv1` AS
+SELECT `v1`, SUM(`v2`) FROM `t0`
+GROUP BY `v1`;
+-- result:
+-- !result
+CREATE MATERIALIZED VIEW `mv2` AS
+SELECT `v1`, MAX(`v3`) FROM `t0`
+GROUP BY `v1`;
+-- result:
+E: (1064, 'A materialized view or rollup index is being created on the table "t0". Please wait until the current operation completes.\nTo check the status of the operation, see https://docs.starrocks.io/en-us/latest/sql-reference/sql-statements/data-manipulation/SHOW%20ALTER%20MATERIALIZED%20VIEW or https://docs.starrocks.io/en-us/latest/sql-reference/sql-statements/data-manipulation/SHOW%20ALTER')
+-- !result
+SET enable_profile = 1;
+-- result:
+-- !result
+INSERT INTO `t0` (v1, v2, v3) values
+    (1, 1, 1),
+    (1, 1, 2),
+    (1, 1, 3),
+    (1, 2, 4),
+    (1, 2, 5),
+    (1, 2, 6),
+    (2, 3, 7),
+    (2, 3, 8),
+    (2, 3, 9),
+    (2, 4, 10),
+    (2, 4, 11),
+    (2, 4, 12);
+-- result:
+-- !result

--- a/test/sql/test_profile/R/test_load_channel_profile
+++ b/test/sql/test_profile/R/test_load_channel_profile
@@ -16,14 +16,18 @@ SELECT `v1`, SUM(`v2`) FROM `t0`
 GROUP BY `v1`;
 -- result:
 -- !result
+function: wait_materialized_view_finish()
+-- result:
+None
+-- !result
 CREATE MATERIALIZED VIEW `mv2` AS
 SELECT `v1`, MAX(`v3`) FROM `t0`
 GROUP BY `v1`;
 -- result:
-E: (1064, 'A materialized view or rollup index is being created on the table "t0". Please wait until the current operation completes.\nTo check the status of the operation, see https://docs.starrocks.io/en-us/latest/sql-reference/sql-statements/data-manipulation/SHOW%20ALTER%20MATERIALIZED%20VIEW or https://docs.starrocks.io/en-us/latest/sql-reference/sql-statements/data-manipulation/SHOW%20ALTER')
 -- !result
-SET enable_profile = 1;
+function: wait_materialized_view_finish()
 -- result:
+None
 -- !result
 INSERT INTO `t0` (v1, v2, v3) values
     (1, 1, 1),
@@ -39,4 +43,23 @@ INSERT INTO `t0` (v1, v2, v3) values
     (2, 4, 11),
     (2, 4, 12);
 -- result:
+-- !result
+SET enable_profile="true";
+-- result:
+-- !result
+INSERT INTO `t0` SELECT * FROM `t0`;
+-- result:
+-- !result
+with
+    profile as (
+        select unnest as line from (values(1))t(v) join unnest(split(get_query_profile(last_query_id()), "\n") )
+    ), result as (
+        select count(*) as value from profile where line like "%LoadChannel%"
+        UNION ALL
+        select count(*) as value from profile where line like "%Index (id=%"
+    )
+select * from result order by value;
+-- result:
+1
+3
 -- !result

--- a/test/sql/test_profile/T/test_load_channel_profile
+++ b/test/sql/test_profile/T/test_load_channel_profile
@@ -1,0 +1,35 @@
+-- name: test_load_channel_profile
+CREATE TABLE `t0` (
+  `v1` int(11) NOT NULL,
+  `v2` int(11) NOT NULL,
+  `v3` int(11) NOT NULL
+) ENGINE=OLAP
+DUPLICATE KEY(`v1`)
+DISTRIBUTED BY HASH(`v1`) BUCKETS 10
+PROPERTIES (
+ "replication_num" = "1"
+);
+
+CREATE MATERIALIZED VIEW `mv1` AS
+SELECT `v1`, SUM(`v2`) FROM `t0`
+GROUP BY `v1`;
+
+CREATE MATERIALIZED VIEW `mv2` AS
+SELECT `v1`, MAX(`v3`) FROM `t0`
+GROUP BY `v1`;
+
+SET enable_profile = 1;
+
+INSERT INTO `t0` (v1, v2, v3) values
+    (1, 1, 1),
+    (1, 1, 2),
+    (1, 1, 3),
+    (1, 2, 4),
+    (1, 2, 5),
+    (1, 2, 6),
+    (2, 3, 7),
+    (2, 3, 8),
+    (2, 3, 9),
+    (2, 4, 10),
+    (2, 4, 11),
+    (2, 4, 12);

--- a/test/sql/test_profile/T/test_load_channel_profile
+++ b/test/sql/test_profile/T/test_load_channel_profile
@@ -14,11 +14,13 @@ CREATE MATERIALIZED VIEW `mv1` AS
 SELECT `v1`, SUM(`v2`) FROM `t0`
 GROUP BY `v1`;
 
+function: wait_materialized_view_finish()
+
 CREATE MATERIALIZED VIEW `mv2` AS
 SELECT `v1`, MAX(`v3`) FROM `t0`
 GROUP BY `v1`;
 
-SET enable_profile = 1;
+function: wait_materialized_view_finish()
 
 INSERT INTO `t0` (v1, v2, v3) values
     (1, 1, 1),
@@ -33,3 +35,17 @@ INSERT INTO `t0` (v1, v2, v3) values
     (2, 4, 10),
     (2, 4, 11),
     (2, 4, 12);
+
+SET enable_profile="true";
+
+INSERT INTO `t0` SELECT * FROM `t0`;
+
+with
+    profile as (
+        select unnest as line from (values(1))t(v) join unnest(split(get_query_profile(last_query_id()), "\n") )
+    ), result as (
+        select count(*) as value from profile where line like "%LoadChannel%"
+        UNION ALL
+        select count(*) as value from profile where line like "%Index (id=%"
+    )
+select * from result order by value;


### PR DESCRIPTION
## Why I'm doing:
Currently the profile of operator `OlapTableSink` has a metric `RpcServerSideTime` to get the total time cost of `LoadChannel`, but  `LoadChannel` does too many things, and we need to get detailed information to know where the time costs if the load is slow. So need to add profile for `LoadChannel`.

## What I'm doing:
Add profile for `LoadChannel`
* use `RuntimeProfile` to record the information of `LoadChannel`
* the profile will be reported to the FE in the path: `LoadChannel` -> `OlapTableSink` -> Fragment Instance -> FE
* integrate the profile with the query profile, and show it at the same level as Fragment
* the configurations for profile is same as that of query profile
   * enable it by session variable `enable_profile` and `big_query_profile_threshold`
   * control report interval by `runtime_profile_report_interval`
* this pr only adds some basic metrics in the profile, and more metrics can be added later

For example, there are 3 BEs, and use broker load to load data to a table with 1 rollup. The profile for load channel will be
* pipeline_profile_level = 2
```
LoadChannel:
       - LoadId: 288fb1df-f955-472f-a377-cb1e10e4d993
       - TxnId: 40
      Channel (host=127.0.0.1):
         - Address: 127.0.0.1
         - IndexNum: 3
         - LoadMemoryLimit: 1.792 GB
         - PeakMemoryUsage: 1.028 GB
        Index (id=10176):
           - AddChunkCount: 82
           - AddChunkTime: 20s7ms
             - WaitFlushTime: 0ns
             - WaitReplicaTime: 1s389ms
             - WaitWriterTime: 18s420ms
           - AddRowNum: 380.714K (380714)
           - OpenCount: 1
           - OpenTime: 140.273ms
           - PrimaryTabletsNum: 10
           - SecondaryTabletsNum: 20
        Index (id=10298):
           - AddChunkCount: 82
           - AddChunkTime: 1s678ms
             - WaitFlushTime: 0ns
             - WaitReplicaTime: 271.704ms
             - WaitWriterTime: 1s361ms
           - AddRowNum: 380.714K (380714)
           - OpenCount: 1
           - OpenTime: 114.102ms
           - PrimaryTabletsNum: 10
           - SecondaryTabletsNum: 20
      Channel (host=127.0.0.2):
         - Address: 127.0.0.2
         - IndexNum: 3
         - LoadMemoryLimit: 1.792 GB
         - PeakMemoryUsage: 1.019 GB
        Index (id=10176):
           - AddChunkCount: 80
           - AddChunkTime: 18s0ms
             - WaitFlushTime: 0ns
             - WaitReplicaTime: 40.334us
             - WaitWriterTime: 17s842ms
           - AddRowNum: 379.695K (379695)
           - OpenCount: 1
           - OpenTime: 141.632ms
           - PrimaryTabletsNum: 10
           - SecondaryTabletsNum: 20
        Index (id=10298):
           - AddChunkCount: 81
           - AddChunkTime: 2s33ms
             - WaitFlushTime: 0ns
             - WaitReplicaTime: 40.281us
             - WaitWriterTime: 1s976ms
           - AddRowNum: 381.078K (381078)
           - OpenCount: 1
           - OpenTime: 99.104ms
           - PrimaryTabletsNum: 10
           - SecondaryTabletsNum: 20
      Channel (host=127.0.0.3):
         - Address: 127.0.0.3
         - IndexNum: 3
         - LoadMemoryLimit: 1.792 GB
         - PeakMemoryUsage: 1.024 GB
        Index (id=10176):
           - AddChunkCount: 81
           - AddChunkTime: 20s234ms
             - WaitFlushTime: 0ns
             - WaitReplicaTime: 60.856us
             - WaitWriterTime: 20s153ms
           - AddRowNum: 381.015K (381015)
           - OpenCount: 1
           - OpenTime: 98.831ms
           - PrimaryTabletsNum: 10
           - SecondaryTabletsNum: 20
        Index (id=10298):
           - AddChunkCount: 81
           - AddChunkTime: 2s9ms
             - WaitFlushTime: 0ns
             - WaitReplicaTime: 523.244ms
             - WaitWriterTime: 1s407ms
           - AddRowNum: 381.015K (381015)
           - OpenCount: 1
           - OpenTime: 85.780ms
           - PrimaryTabletsNum: 10
           - SecondaryTabletsNum: 20
```
* pipeline_profile_level = 1
```
LoadChannel:
       - LoadId: c42f8ed4-6662-4021-9a31-733ceaeaae53
       - TxnId: 41
       - BackendAddresses: 127.0.0.1,127.0.0.2
       - ChannelNum: 3
       - IndexNum: 9
         - __MAX_OF_IndexNum: 3
         - __MIN_OF_IndexNum: 3
       - LoadMemoryLimit: 5.376 GB
         - __MAX_OF_LoadMemoryLimit: 1.792 GB
         - __MIN_OF_LoadMemoryLimit: 1.792 GB
       - PeakMemoryUsage: 1.055 GB
         - __MAX_OF_PeakMemoryUsage: 1.111 GB
         - __MIN_OF_PeakMemoryUsage: 1.024 GB
      Index (id=10180):
         - AddChunkCount: 244
           - __MAX_OF_AddChunkCount: 82
           - __MIN_OF_AddChunkCount: 81
         - AddChunkTime: 19s127ms
           - __MAX_OF_AddChunkTime: 19s669ms
           - __MIN_OF_AddChunkTime: 18s570ms
           - WaitFlushTime: 0ns
           - WaitReplicaTime: 302.289ms
             - __MAX_OF_WaitReplicaTime: 634.582ms
             - __MIN_OF_WaitReplicaTime: 50.101us
           - WaitWriterTime: 18s750ms
             - __MAX_OF_WaitWriterTime: 19s640ms
             - __MIN_OF_WaitWriterTime: 18s198ms
         - AddRowNum: 1.143M (1142807)
           - __MAX_OF_AddRowNum: 381.078K (381078)
           - __MIN_OF_AddRowNum: 380.714K (380714)
         - OpenCount: 3
           - __MAX_OF_OpenCount: 1
           - __MIN_OF_OpenCount: 1
         - OpenTime: 88.190ms
           - __MAX_OF_OpenTime: 92.434ms
           - __MIN_OF_OpenTime: 82.826ms
         - PrimaryTabletsNum: 30
           - __MAX_OF_PrimaryTabletsNum: 10
           - __MIN_OF_PrimaryTabletsNum: 10
         - SecondaryTabletsNum: 60
           - __MAX_OF_SecondaryTabletsNum: 20
           - __MIN_OF_SecondaryTabletsNum: 20
      Index (id=10302):
         - AddChunkCount: 244
           - __MAX_OF_AddChunkCount: 82
           - __MIN_OF_AddChunkCount: 81
         - AddChunkTime: 1s978ms
           - __MAX_OF_AddChunkTime: 2s262ms
           - __MIN_OF_AddChunkTime: 1s651ms
           - WaitFlushTime: 0ns
           - WaitReplicaTime: 144.405ms
             - __MAX_OF_WaitReplicaTime: 423.074ms
             - __MIN_OF_WaitReplicaTime: 37.525us
           - WaitWriterTime: 1s676ms
             - __MAX_OF_WaitWriterTime: 1s977ms
             - __MIN_OF_WaitWriterTime: 1s130ms
         - AddRowNum: 1.143M (1142807)
           - __MAX_OF_AddRowNum: 381.078K (381078)
           - __MIN_OF_AddRowNum: 380.714K (380714)
         - OpenCount: 3
           - __MAX_OF_OpenCount: 1
           - __MIN_OF_OpenCount: 1
         - OpenTime: 84.895ms
           - __MAX_OF_OpenTime: 86.325ms
           - __MIN_OF_OpenTime: 84.179ms
         - PrimaryTabletsNum: 30
           - __MAX_OF_PrimaryTabletsNum: 10
           - __MIN_OF_PrimaryTabletsNum: 10
         - SecondaryTabletsNum: 60
           - __MAX_OF_SecondaryTabletsNum: 20
           - __MIN_OF_SecondaryTabletsNum: 20     
```


## What type of PR is this:

- [ ] BugFix
- [x] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [X] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
