### PR TITLE
[BugFix] Create table failed when deploying shared-data cluster in k8s with CN nodes only (backport #41418)

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/system/SystemInfoService.java
+++ b/fe/fe-core/src/main/java/com/starrocks/system/SystemInfoService.java
@@ -440,6 +440,12 @@ public class SystemInfoService implements GsonPostProcessable {
         idToReportVersionRef = ImmutableMap.<Long, AtomicLong>of();
     }
 
+    // only for test
+    public void dropAllComputeNode() {
+        // update idToComputeNodeRef
+        idToComputeNodeRef.clear();
+    }
+
     public Backend getBackend(long backendId) {
         return idToBackendRef.get(backendId);
     }
@@ -552,37 +558,7 @@ public class SystemInfoService implements GsonPostProcessable {
     }
 
     public Backend getBackendWithBePort(String host, int bePort) {
-
-        Pair<String, String> targetPair;
-        try {
-            targetPair = NetUtils.getIpAndFqdnByHost(host);
-        } catch (UnknownHostException e) {
-            LOG.warn("failed to get right ip by fqdn {}", e.getMessage());
-            return null;
-        }
-
-        for (Backend backend : idToBackendRef.values()) {
-            Pair<String, String> curPair;
-            try {
-                curPair = NetUtils.getIpAndFqdnByHost(backend.getHost());
-            } catch (UnknownHostException e) {
-                LOG.warn("failed to get right ip by fqdn {}", e.getMessage());
-                continue;
-            }
-            boolean hostMatch = false;
-            // target, cur has same ip
-            if (targetPair.first.equals(curPair.first)) {
-                hostMatch = true;
-            }
-            // target, cur has same fqdn and both of them are not equal ""
-            if (!hostMatch && targetPair.second.equals(curPair.second) && !curPair.second.equals("")) {
-                hostMatch = true;
-            }
-            if (hostMatch && (backend.getBePort() == bePort)) {
-                return backend;
-            }
-        }
-        return null;
+        return getComputeNodeWithBePortCommon(host, bePort, idToBackendRef);
     }
 
     public ComputeNode getBackendOrComputeNodeWithBePort(String host, int bePort) {
@@ -626,8 +602,37 @@ public class SystemInfoService implements GsonPostProcessable {
     }
 
     public ComputeNode getComputeNodeWithBePort(String host, int bePort) {
-        for (ComputeNode computeNode : idToComputeNodeRef.values()) {
-            if (computeNode.getHost().equals(host) && computeNode.getBePort() == bePort) {
+        return getComputeNodeWithBePortCommon(host, bePort, idToComputeNodeRef);
+    }
+
+    private <T extends ComputeNode> T getComputeNodeWithBePortCommon(String host, int bePort,
+                                                                     Map<Long, T> nodeRef) {
+        Pair<String, String> targetPair;
+        try {
+            targetPair = NetUtils.getIpAndFqdnByHost(host);
+        } catch (UnknownHostException e) {
+            LOG.warn("failed to get right ip by fqdn {}", e.getMessage());
+            return null;
+        }
+
+        for (T computeNode : nodeRef.values()) {
+            Pair<String, String> curPair;
+            try {
+                curPair = NetUtils.getIpAndFqdnByHost(computeNode.getHost());
+            } catch (UnknownHostException e) {
+                LOG.warn("failed to get right ip by fqdn {}", e.getMessage());
+                continue;
+            }
+            boolean hostMatch = false;
+            // target, cur has same ip
+            if (targetPair.first.equals(curPair.first)) {
+                hostMatch = true;
+            }
+            // target, cur has same fqdn and both of them are not equal ""
+            if (!hostMatch && targetPair.second.equals(curPair.second) && !curPair.second.equals("")) {
+                hostMatch = true;
+            }
+            if (hostMatch && (computeNode.getBePort() == bePort)) {
                 return computeNode;
             }
         }

--- a/fe/fe-core/src/test/java/com/starrocks/system/SystemInfoServiceTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/system/SystemInfoServiceTest.java
@@ -123,6 +123,8 @@ public class SystemInfoServiceTest {
 
     @Test
     public void testGetBackendOrComputeNode() {
+        mockNet();
+
         Backend be = new Backend(10001, "host1", 1000);
         service.addBackend(be);
         ComputeNode cn = new ComputeNode(10002, "host2", 1000);
@@ -289,5 +291,32 @@ public class SystemInfoServiceTest {
         latch.await();
 
         Assert.assertEquals(10L, version.get());
+    }
+
+    @Test
+    public void testGetComputeNodeWithBePort() throws Exception {
+        mockNet();
+
+        ComputeNode be1 = new ComputeNode(10001, "127.0.0.1", 1000);
+        be1.setBePort(1001);
+        service.addComputeNode(be1);
+        ComputeNode beIP1 = service.getComputeNodeWithBePort("127.0.0.1", 1001);
+
+        service.dropAllComputeNode();
+
+        ComputeNode be2 = new ComputeNode(10001, "newHost-1", 1000);
+        be2.setBePort(1001);
+        service.addComputeNode(be2);
+        ComputeNode beFqdn = service.getComputeNodeWithBePort("127.0.0.1", 1001);
+
+        Assert.assertTrue(beFqdn != null && beIP1 != null);
+
+        service.dropAllComputeNode();
+
+        ComputeNode be3 = new ComputeNode(10001, "127.0.0.1", 1000);
+        be3.setBePort(1001);
+        service.addComputeNode(be3);
+        ComputeNode beIP3 = service.getComputeNodeWithBePort("127.0.0.2", 1001);
+        Assert.assertTrue(beIP3 == null);
     }
 }


### PR DESCRIPTION

## Why I'm doing:

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [x] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5

