### PR TITLE
[BugFix] Fix mv rewrite unknown error for query with IsNullPredicate (backport #39075)

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/ScalarOperatorRewriter.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/ScalarOperatorRewriter.java
@@ -32,6 +32,7 @@ import com.starrocks.sql.optimizer.rewrite.scalar.SimplifiedPredicateRule;
 import com.starrocks.sql.optimizer.rewrite.scalar.SimplifiedScanColumnRule;
 
 import java.util.List;
+import java.util.stream.Collectors;
 
 public class ScalarOperatorRewriter {
     public static final List<ScalarOperatorRewriteRule> DEFAULT_TYPE_CAST_RULE = Lists.newArrayList(
@@ -63,17 +64,9 @@ public class ScalarOperatorRewriter {
             new ArithmeticCommutativeRule()
     );
 
-    public static final List<ScalarOperatorRewriteRule> MV_SCALAR_REWRITE_RULES = Lists.newArrayList(
-            // required
-            new ImplicitCastRule(),
-            // optional
-            new ReduceCastRule(),
-            new MvNormalizePredicateRule(),
-            new FoldConstantsRule(),
-            new SimplifiedPredicateRule(),
-            new ExtractCommonPredicateRule(),
-            new ArithmeticCommutativeRule()
-    );
+    public static final List<ScalarOperatorRewriteRule> MV_SCALAR_REWRITE_RULES = DEFAULT_REWRITE_SCAN_PREDICATE_RULES.stream()
+            .map(rule -> rule instanceof NormalizePredicateRule ? new MvNormalizePredicateRule() : rule)
+            .collect(Collectors.toList());
 
     private final ScalarOperatorRewriteContext context;
 

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rewrite/ScalarOperatorRewriterTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rewrite/ScalarOperatorRewriterTest.java
@@ -24,6 +24,7 @@ import com.starrocks.sql.optimizer.operator.scalar.CastOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ColumnRefOperator;
 import com.starrocks.sql.optimizer.operator.scalar.CompoundPredicateOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ConstantOperator;
+import com.starrocks.sql.optimizer.operator.scalar.IsNullPredicateOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ScalarOperator;
 import com.starrocks.sql.optimizer.rewrite.scalar.ImplicitCastRule;
 import com.starrocks.sql.optimizer.rewrite.scalar.MvNormalizePredicateRule;
@@ -148,5 +149,18 @@ public class ScalarOperatorRewriterTest {
 
             Assert.assertEquals("2: b < 101: b", result.toString());
         }
+    }
+
+    @Test
+    public void testNormalizeIsNull() {
+        ColumnRefOperator column1 = new ColumnRefOperator(0, Type.INT, "test0", false);
+        IsNullPredicateOperator isnotNull = new IsNullPredicateOperator(true, column1);
+        ScalarOperator rewritten = new ScalarOperatorRewriter()
+                .rewrite(isnotNull, ScalarOperatorRewriter.MV_SCALAR_REWRITE_RULES);
+        Assert.assertEquals(ConstantOperator.TRUE, rewritten);
+
+        ScalarOperator rewritten2 = new ScalarOperatorRewriter()
+                .rewrite(isnotNull, ScalarOperatorRewriter.DEFAULT_REWRITE_SCAN_PREDICATE_RULES);
+        Assert.assertEquals(ConstantOperator.TRUE, rewritten2);
     }
 }

--- a/test/sql/test_materialized_view/R/test_mv_rewrite_on_tpcds
+++ b/test/sql/test_materialized_view/R/test_mv_rewrite_on_tpcds
@@ -1,0 +1,88 @@
+-- name: test_TPCDS_query94
+function: prepare_data("tpcds", "${db[0]}")
+set materialized_view_rewrite_mode='force';
+
+DROP MATERIALIZED VIEW IF EXISTS __mv__ta0008;
+
+CREATE MATERIALIZED VIEW __mv__ta0008 (_ca0005, _ca0006, _ca0007)
+REFRESH ASYNC START("2023-12-01 10:00:00") EVERY(INTERVAL 1 DAY)
+PROPERTIES (
+  "replicated_storage" = "true",
+  "replication_num" = "1",
+  "storage_medium" = "HDD"
+)
+AS
+SELECT
+  (count(DISTINCT _ta0002.ws_order_number)) AS _ca0005
+  ,(sum(_ta0002.ws_ext_ship_cost)) AS _ca0006
+  ,(sum(_ta0002.ws_net_profit)) AS _ca0007
+FROM
+  (
+    SELECT
+      web_sales.ws_order_number
+      ,web_sales.ws_net_profit
+      ,web_sales.ws_ext_ship_cost
+    FROM
+      web_sales
+      INNER JOIN
+      date_dim
+      ON (web_sales.ws_ship_date_sk = date_dim.d_date_sk)
+      INNER JOIN
+      customer_address
+      ON (web_sales.ws_ship_addr_sk = customer_address.ca_address_sk)
+      INNER JOIN
+      web_site
+      ON (web_sales.ws_web_site_sk = web_site.web_site_sk)
+      LEFT SEMI JOIN
+      (
+        SELECT
+          web_sales.ws_order_number
+          ,web_sales.ws_warehouse_sk
+        FROM
+          web_sales
+      ) _ta0000
+      ON (web_sales.ws_order_number = _ta0000.ws_order_number)
+         AND (web_sales.ws_warehouse_sk != _ta0000.ws_warehouse_sk)
+      LEFT ANTI JOIN
+      web_returns
+      ON (web_sales.ws_order_number = web_returns.wr_order_number)
+    WHERE
+      (date_dim.d_date <= "1999-04-02")
+      AND (web_site.web_company_name = "pri")
+      AND (customer_address.ca_state = "IL")
+      AND ("1999-02-01" <= date_dim.d_date)
+      AND (web_sales.ws_ship_date_sk IS NOT NULL)
+  ) _ta0002;
+
+REFRESH MATERIALIZED VIEW __mv__ta0008 WITH SYNC MODE;
+
+EXPLAIN logical
+select  
+   count(distinct ws_order_number) as "order count"
+  ,sum(ws_ext_ship_cost) as "total shipping cost"
+  ,sum(ws_net_profit) as "total net profit"
+from
+   web_sales ws1
+  ,date_dim
+  ,customer_address
+  ,web_site
+where
+    d_date between '1999-2-01' and 
+           date_add(cast('1999-2-01' as date), 60)
+and ws1.ws_ship_date_sk = d_date_sk
+and ws1.ws_ship_addr_sk = ca_address_sk
+and ca_state = 'IL'
+and ws1.ws_web_site_sk = web_site_sk
+and web_company_name = 'pri'
+and exists (select *
+            from web_sales ws2
+            where ws1.ws_order_number = ws2.ws_order_number
+              and ws1.ws_warehouse_sk <> ws2.ws_warehouse_sk)
+and not exists(select *
+               from web_returns wr1
+               where ws1.ws_order_number = wr1.wr_order_number)
+order by count(distinct ws_order_number)
+limit 100;
+-- result:
+[REGEX].*__mv__ta0008.*
+-- !result

--- a/test/sql/test_materialized_view/T/test_mv_rewrite_on_tpcds
+++ b/test/sql/test_materialized_view/T/test_mv_rewrite_on_tpcds
@@ -1,0 +1,86 @@
+-- name: test_TPCDS_query94
+function: prepare_data("tpcds", "${db[0]}")
+
+set materialized_view_rewrite_mode='force';
+
+DROP MATERIALIZED VIEW IF EXISTS __mv__ta0008;
+
+CREATE MATERIALIZED VIEW __mv__ta0008 (_ca0005, _ca0006, _ca0007)
+REFRESH ASYNC START("2023-12-01 10:00:00") EVERY(INTERVAL 1 DAY)
+PROPERTIES (
+  "replicated_storage" = "true",
+  "replication_num" = "1",
+  "storage_medium" = "HDD"
+)
+AS
+SELECT
+  (count(DISTINCT _ta0002.ws_order_number)) AS _ca0005
+  ,(sum(_ta0002.ws_ext_ship_cost)) AS _ca0006
+  ,(sum(_ta0002.ws_net_profit)) AS _ca0007
+FROM
+  (
+    SELECT
+      web_sales.ws_order_number
+      ,web_sales.ws_net_profit
+      ,web_sales.ws_ext_ship_cost
+    FROM
+      web_sales
+      INNER JOIN
+      date_dim
+      ON (web_sales.ws_ship_date_sk = date_dim.d_date_sk)
+      INNER JOIN
+      customer_address
+      ON (web_sales.ws_ship_addr_sk = customer_address.ca_address_sk)
+      INNER JOIN
+      web_site
+      ON (web_sales.ws_web_site_sk = web_site.web_site_sk)
+      LEFT SEMI JOIN
+      (
+        SELECT
+          web_sales.ws_order_number
+          ,web_sales.ws_warehouse_sk
+        FROM
+          web_sales
+      ) _ta0000
+      ON (web_sales.ws_order_number = _ta0000.ws_order_number)
+         AND (web_sales.ws_warehouse_sk != _ta0000.ws_warehouse_sk)
+      LEFT ANTI JOIN
+      web_returns
+      ON (web_sales.ws_order_number = web_returns.wr_order_number)
+    WHERE
+      (date_dim.d_date <= "1999-04-02")
+      AND (web_site.web_company_name = "pri")
+      AND (customer_address.ca_state = "IL")
+      AND ("1999-02-01" <= date_dim.d_date)
+      AND (web_sales.ws_ship_date_sk IS NOT NULL)
+  ) _ta0002;
+
+REFRESH MATERIALIZED VIEW __mv__ta0008 WITH SYNC MODE;
+
+EXPLAIN logical
+select  
+   count(distinct ws_order_number) as "order count"
+  ,sum(ws_ext_ship_cost) as "total shipping cost"
+  ,sum(ws_net_profit) as "total net profit"
+from
+   web_sales ws1
+  ,date_dim
+  ,customer_address
+  ,web_site
+where
+    d_date between '1999-2-01' and 
+           date_add(cast('1999-2-01' as date), 60)
+and ws1.ws_ship_date_sk = d_date_sk
+and ws1.ws_ship_addr_sk = ca_address_sk
+and ca_state = 'IL'
+and ws1.ws_web_site_sk = web_site_sk
+and web_company_name = 'pri'
+and exists (select *
+            from web_sales ws2
+            where ws1.ws_order_number = ws2.ws_order_number
+              and ws1.ws_warehouse_sk <> ws2.ws_warehouse_sk)
+and not exists(select *
+               from web_returns wr1
+               where ws1.ws_order_number = wr1.wr_order_number)
+order by count(distinct ws_order_number)
+limit 100;


### PR DESCRIPTION
## Why I'm doing:
Mv rewrite failed when query/mv has column is not null predicate for none-nullable column.

## What I'm doing:
Fix it by normalizing the column is not null predicate to true and then the compensation predicates can be constructed to rewrite by mv.

Fixes #39045

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [x] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5

