### PR TITLE
[BugFix] Replace the `rapidjson::StringRef` with `SetString` to avoid refrencing a temporary string pointer which cause `stack-use-after-return` memory issue in datacache http action (backport #41663) 

### DIFF
--- a/be/src/block_cache/block_cache.cpp
+++ b/be/src/block_cache/block_cache.cpp
@@ -179,4 +179,8 @@ Status BlockCache::shutdown() {
     return st;
 }
 
+DataCacheEngineType BlockCache::engine_type() {
+    return _kv_cache->engine_type();
+}
+
 } // namespace starrocks

--- a/be/src/block_cache/block_cache.h
+++ b/be/src/block_cache/block_cache.h
@@ -70,6 +70,8 @@ public:
 
     bool is_initialized() { return _initialized.load(std::memory_order_relaxed); }
 
+    DataCacheEngineType engine_type();
+
     static const size_t MAX_BLOCK_SIZE;
 
 private:

--- a/be/src/block_cache/cachelib_wrapper.h
+++ b/be/src/block_cache/cachelib_wrapper.h
@@ -66,6 +66,8 @@ public:
 
     Status shutdown() override;
 
+    DataCacheEngineType engine_type() override { return DataCacheEngineType::CACHELIB; }
+
 private:
     void _dump_cache_stats();
 

--- a/be/src/block_cache/kv_cache.h
+++ b/be/src/block_cache/kv_cache.h
@@ -20,10 +20,11 @@
 #include "common/status.h"
 #include "starcache/star_cache.h"
 
+namespace starrocks {
 using DataCacheMetrics = starcache::CacheMetrics;
 using DataCacheStatus = starcache::CacheStatus;
 
-namespace starrocks {
+enum class DataCacheEngineType { STARCACHE, CACHELIB };
 
 class KvCache {
 public:
@@ -55,6 +56,8 @@ public:
     virtual void record_read_cache(size_t size, int64_t lateny_us) = 0;
 
     virtual Status shutdown() = 0;
+
+    virtual DataCacheEngineType engine_type() = 0;
 };
 
 } // namespace starrocks

--- a/be/src/block_cache/starcache_wrapper.h
+++ b/be/src/block_cache/starcache_wrapper.h
@@ -48,6 +48,8 @@ public:
 
     Status shutdown() override;
 
+    DataCacheEngineType engine_type() override { return DataCacheEngineType::STARCACHE; }
+
 private:
     std::unique_ptr<starcache::StarCache> _cache;
     std::unique_ptr<starcache::TimeBasedCacheAdaptor> _cache_adaptor;

--- a/be/test/CMakeLists.txt
+++ b/be/test/CMakeLists.txt
@@ -175,6 +175,7 @@ set(EXEC_FILES
         ./http/http_utils_test.cpp
         ./http/message_body_sink_test.cpp
         ./http/metrics_action_test.cpp
+        ./http/datacache_action_test.cpp
         ./http/stream_load_test.cpp
         ./http/transaction_stream_load_test.cpp
         ./io/array_input_stream_test.cpp

--- a/be/test/http/datacache_action_test.cpp
+++ b/be/test/http/datacache_action_test.cpp
@@ -1,0 +1,116 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "http/action/datacache_action.h"
+
+#include <event2/http.h>
+#include <event2/http_struct.h>
+#include <gtest/gtest.h>
+#include <rapidjson/document.h>
+
+#include "block_cache/block_cache.h"
+#include "gen_cpp/FrontendService_types.h"
+#include "gen_cpp/HeartbeatService_types.h"
+#include "http/http_channel.h"
+#include "http/http_request.h"
+#include "runtime/exec_env.h"
+#include "util/brpc_stub_cache.h"
+
+namespace starrocks {
+
+extern void (*s_injected_send_reply)(HttpRequest*, HttpStatus, const std::string&);
+
+namespace {
+static std::string k_response_str;
+static void inject_send_reply(HttpRequest* request, HttpStatus status, const std::string& content) {
+    k_response_str = content;
+}
+} // namespace
+
+Status init_datacache_instance(const std::string& engine, BlockCache* cache) {
+    if (cache->is_initialized()) {
+        return Status::OK();
+    }
+    CacheOptions options;
+    options.mem_space_size = 20 * 1024 * 1024;
+    options.block_size = 256 * 1024;
+    options.max_concurrent_inserts = 100000;
+    options.enable_checksum = false;
+    options.engine = engine;
+    return cache->init(options);
+}
+
+class DataCacheActionTest : public testing::Test {
+public:
+    DataCacheActionTest() = default;
+    ~DataCacheActionTest() override = default;
+    static void SetUpTestSuite() { s_injected_send_reply = inject_send_reply; }
+    static void TearDownTestSuite() { s_injected_send_reply = nullptr; }
+
+    void SetUp() override {
+        k_response_str = "";
+        _env._brpc_stub_cache = new BrpcStubCache();
+        _evhttp_req = evhttp_request_new(nullptr, nullptr);
+    }
+    void TearDown() override {
+        delete _env._brpc_stub_cache;
+        _env._brpc_stub_cache = nullptr;
+
+        if (_evhttp_req != nullptr) {
+            evhttp_request_free(_evhttp_req);
+        }
+    }
+
+private:
+    ExecEnv _env;
+    evhttp_request* _evhttp_req = nullptr;
+};
+
+TEST_F(DataCacheActionTest, stat_success) {
+    auto cache = BlockCache::instance();
+    ASSERT_TRUE(init_datacache_instance("starcache", cache).ok());
+    _env._block_cache = cache;
+
+    DataCacheAction action(&_env);
+
+    HttpRequest request(_evhttp_req);
+    request._method = HttpMethod::GET;
+    request._params.emplace("action", "stat");
+    request.set_handler(&action);
+    action.on_header(&request);
+    action.handle(&request);
+
+    rapidjson::Document doc;
+    doc.Parse(k_response_str.c_str());
+    ASSERT_STREQ("NORMAL", doc["status"].GetString());
+
+    _env._block_cache = nullptr;
+}
+
+TEST_F(DataCacheActionTest, stat_with_uninitialized_cache) {
+    DataCacheAction action(&_env);
+
+    HttpRequest request(_evhttp_req);
+    request._method = HttpMethod::GET;
+    request._params.emplace("action", "stat");
+    request.set_handler(&action);
+    action.on_header(&request);
+    action.handle(&request);
+
+    rapidjson::Document doc;
+    doc.Parse(k_response_str.c_str());
+    ASSERT_STREQ("Cache system is not ready", doc["error"].GetString());
+}
+
+} // namespace starrocks


### PR DESCRIPTION
Why I'm doing:
We use rapidjson::StringRef in the handler of datacache action to construct the response content. However, it only reference an exist string pointer without copying its content. In our case, it reference a local string pointer, and may cause stack-use-after-return memory issue when the local string is freed.

What I'm doing:
Use the SetString to copy the string content and avoid this problem.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [x] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5

