### PR TITLE
[BugFix] Fix bug which cause storage volume is shown unexpectedly

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/qe/ShowExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/ShowExecutor.java
@@ -1071,7 +1071,7 @@ public class ShowExecutor {
         createSqlBuilder.append("CREATE DATABASE `").append(showStmt.getDb()).append("`");
         if (!Strings.isNullOrEmpty(db.getLocation())) {
             createSqlBuilder.append("\nPROPERTIES (\"location\" = \"").append(db.getLocation()).append("\")");
-        } else if (RunMode.isSharedDataMode()) {
+        } else if (RunMode.isSharedDataMode() && !db.isSystemDatabase()) {
             String volume = GlobalStateMgr.getCurrentState().getStorageVolumeMgr().getStorageVolumeNameOfDb(db.getId());
             createSqlBuilder.append("\nPROPERTIES (\"storage_volume\" = \"").append(volume).append("\")");
         }


### PR DESCRIPTION
## Why I'm doing:
The system database information_schema and sys  is not bind to storage volume. But in show create db statement, it will show it has been bind to storage volume.
```
mysql> show create database information_schema;
+--------------------+-----------------------------------------------------------------------------------------------+
| Database           | Create Database                                                                               |
+--------------------+-----------------------------------------------------------------------------------------------+
| information_schema | CREATE DATABASE `information_schema`
PROPERTIES ("storage_volume" = "builtin_storage_volume") |
+--------------------+-----------------------------------------------------------------------------------------------+
1 row in set (0.00 sec)
```
## What I'm doing:
Fix bug which cause storage volume is shown unexpectedly.
```
mysql> show create database information_schema;
+--------------------+--------------------------------------+
| Database           | Create Database                      |
+--------------------+--------------------------------------+
| information_schema | CREATE DATABASE `information_schema` |
+--------------------+--------------------------------------+
1 row in set (0.01 sec)
```
Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [x] 3.1
  - [ ] 3.0
  - [ ] 2.5
