### PR TITLE
[BugFix] Fix the returned get_entry_sizes() whose size is incorrect

### DIFF
--- a/be/src/util/dynamic_cache.h
+++ b/be/src/util/dynamic_cache.h
@@ -303,7 +303,8 @@ public:
 
     std::vector<std::pair<Key, size_t>> get_entry_sizes() const {
         std::lock_guard<std::mutex> lg(_lock);
-        std::vector<std::pair<Key, size_t>> ret(_map.size());
+        std::vector<std::pair<Key, size_t>> ret;
+        ret.reserve(_map.size());
         auto itr = _list.begin();
         while (itr != _list.end()) {
             Entry* entry = (*itr);

--- a/be/test/util/dynamic_cache_test.cpp
+++ b/be/test/util/dynamic_cache_test.cpp
@@ -67,6 +67,7 @@ TEST(DynamicCacheTest, cache) {
     cache.clear_expired();
     ASSERT_EQ(4, cache.size());
     ASSERT_TRUE(cache.get(19) == nullptr);
+    ASSERT_EQ(4, cache.get_entry_sizes().size());
 }
 
 TEST(DynamicCacheTest, cache2) {


### PR DESCRIPTION
## Why I'm doing:
`get_entry_sizes` in DynamicCache will return the key and size of the entries. But the size of vector returned is incorrect.
## What I'm doing:
Fix the returned get_entry_sizes() whose size is incorrect
Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [x] 3.1
  - [ ] 3.0
  - [ ] 2.5
