### PR TITLE
[BugFix] disable lowcardinality optimize in join predicate columns

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/AddDecodeNodeForDictStringRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/AddDecodeNodeForDictStringRule.java
@@ -205,7 +205,15 @@ public class AddDecodeNodeForDictStringRule implements TreeRewriteRule {
             if (optExpression.getOp().getProjection() != null) {
                 Projection projection = optExpression.getOp().getProjection();
                 context.needEncode = context.needEncode || projection.needApplyStringDict(context.allStringColumnIds);
-                if (context.needEncode) {
+                // When disableDictOptimizeColumns is not empty, we need to disable the columns
+                // that generate them for low cardinality optimization.
+                //
+                // This is because the upper-level nodes require the disabling of these
+                // columns as well as the columns that generate them.
+                // The upper-level node wants to avoid low-cardinality optimization columns
+                // to be executed in Shuffle partition by or Runtime Filter.
+
+                if (context.needEncode || !context.disableDictOptimizeColumns.isEmpty()) {
                     projection.fillDisableDictOptimizeColumns(context.disableDictOptimizeColumns,
                             context.allStringColumnIds);
                 }
@@ -332,7 +340,7 @@ public class AddDecodeNodeForDictStringRule implements TreeRewriteRule {
             // top N node
             PhysicalTopNOperator topN = (PhysicalTopNOperator) optExpression.getOp();
             context.needEncode = topN.couldApplyStringDict(context.allStringColumnIds);
-            if (context.needEncode) {
+            if (context.needEncode || !context.disableDictOptimizeColumns.isEmpty()) {
                 topN.fillDisableDictOptimizeColumns(context.disableDictOptimizeColumns, context.allStringColumnIds);
             }
 
@@ -814,7 +822,7 @@ public class AddDecodeNodeForDictStringRule implements TreeRewriteRule {
                 return aggExpr;
             }
             context.needEncode = aggOperator.couldApplyStringDict(context.allStringColumnIds);
-            if (context.needEncode) {
+            if (context.needEncode || !context.disableDictOptimizeColumns.isEmpty()) {
                 aggOperator.fillDisableDictOptimizeColumns(context.disableDictOptimizeColumns,
                         context.allStringColumnIds);
             }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/LowCardinalityTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/LowCardinalityTest.java
@@ -1904,4 +1904,40 @@ public class LowCardinalityTest extends PlanTestBase {
                 "  1:Project\n" +
                 "  |  <slot 9> : if(CURRENT_ROLE() = 'root', DictDecode(10: S_ADDRESS, [concat(<place-holder>, 'ccc')]), '***')");
     }
+
+    @Test
+    public void testJoinWithMinMaxAgg() throws Exception {
+        String sql = "\n" +
+                "\n" +
+                "with agged_supplier as (\n" +
+                "    select S_NAME, max(S_ADDRESS) as mx_addr from supplier_nullable group by S_NAME\n" +
+                "),\n" +
+                "agged_supplier_1 as (\n" +
+                "    select l.S_NAME, l.mx_addr mx_addr from agged_supplier l left join " +
+                "[shuffle] supplier_nullable r on l.S_NAME=r.S_NAME\n" +
+                "),\n" +
+                "agged_supplier_2 as (\n" +
+                "  select S_NAME, if(mx_addr = 'key', 'key2', S_NAME) mx_addr from agged_supplier_1 l\n" +
+                "),\n" +
+                "agged_supplier_4 as (\n" +
+                "  select S_NAME, mx_addr from agged_supplier_2 l group by S_NAME,mx_addr\n" +
+                "),\n" +
+                "agged_supplier_5 as (\n" +
+                "    select l.S_NAME, l.mx_addr from agged_supplier_4 l join supplier_nullable r\n" +
+                ")\n" +
+                "select l.S_NAME,l.mx_addr from agged_supplier_5 l \n" +
+                "left join [shuffle] supplier_nullable z on l.S_NAME = z.S_NAME and l.mx_addr = z.S_ADDRESS\n" +
+                ";";
+        String plan = getCostExplain(sql);
+        assertContains(plan, "  1:AGGREGATE (update finalize)\n" +
+                "  |  aggregate: max[([3: S_ADDRESS, VARCHAR, true]); args: VARCHAR; " +
+                "result: VARCHAR; args nullable: true; result nullable: true]\n" +
+                "  |  group by: [2: S_NAME, CHAR, false]\n" +
+                "  |  cardinality: 1\n" +
+                "  |  column statistics: \n" +
+                "  |  * S_NAME-->[-Infinity, Infinity, 0.0, 1.0, 1.0] UNKNOWN\n" +
+                "  |  * max-->[-Infinity, Infinity, 0.0, 1.0, 1.0] UNKNOWN\n" +
+                "  |  ");
+    }
+
 }


### PR DESCRIPTION
## Why I'm doing:
if a plan is Join->AGG->Project->Join
the Project has_encode is false. it won't disable use lowcardinality optimize.

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [x] 3.1
  - [x] 3.0
  - [x] 2.5
