### PR TITLE
[BugFix] Fixe bug where tablet was not deleted from meta when removing disk path from be.conf

### DIFF
--- a/be/src/agent/agent_task.cpp
+++ b/be/src/agent/agent_task.cpp
@@ -253,8 +253,18 @@ void run_create_tablet_task(const std::shared_ptr<CreateTabletAgentTaskRequest>&
         tablet_info.data_size = 0;
         tablet_info.__set_path_hash(tablet->data_dir()->path_hash());
     }
+    TStatus task_status;
+    task_status.__set_status_code(status_code);
+    task_status.__set_error_msgs(error_msgs);
 
-    unify_finish_agent_task(status_code, error_msgs, agent_task_req->task_type, agent_task_req->signature, true);
+    finish_task_request.__set_backend(BackendOptions::get_localBackend());
+    finish_task_request.__set_task_type(agent_task_req->task_type);
+    finish_task_request.__set_signature(agent_task_req->signature);
+    finish_task_request.__set_report_version(g_report_version.load(std::memory_order_relaxed));
+    finish_task_request.__set_task_status(task_status);
+
+    finish_task(finish_task_request);
+    remove_task_info(agent_task_req->task_type, agent_task_req->signature);
 }
 
 void run_alter_tablet_task(const std::shared_ptr<AlterTabletAgentTaskRequest>& agent_task_req, ExecEnv* exec_env) {

--- a/be/src/agent/task_worker_pool.cpp
+++ b/be/src/agent/task_worker_pool.cpp
@@ -692,7 +692,8 @@ void* ReportOlapTableTaskWorkerPool::_worker_thread_callback(void* arg_this) {
         }
         request.tablets.clear();
 
-        request.__set_report_version(g_report_version.load(std::memory_order_relaxed));
+        int64_t report_version = g_report_version.load(std::memory_order_relaxed);
+        request.__set_report_version(report_version);
         Status st_report = StorageEngine::instance()->tablet_manager()->report_all_tablets_info(&request.tablets);
         if (!st_report.ok()) {
             LOG(WARNING) << "Fail to report all tablets info, err=" << st_report.to_string();
@@ -714,6 +715,8 @@ void* ReportOlapTableTaskWorkerPool::_worker_thread_callback(void* arg_this) {
             StarRocksMetrics::instance()->report_all_tablets_requests_failed.increment(1);
             LOG(WARNING) << "Fail to report olap table state to " << master_address.hostname << ":"
                          << master_address.port << ", err=" << status;
+        } else {
+            LOG(INFO) << "Report tablets successfully, report version: " << report_version;
         }
 
         // wait for notifying until timeout

--- a/fe/fe-core/src/main/java/com/starrocks/leader/LeaderImpl.java
+++ b/fe/fe-core/src/main/java/com/starrocks/leader/LeaderImpl.java
@@ -404,7 +404,7 @@ public class LeaderImpl {
                         .updateBackendReportVersion(task.getBackendId(), request.getReport_version(), task.getDbId());
 
                 createReplicaTask.countDownLatch(task.getBackendId(), task.getSignature());
-                LOG.debug("finish create replica. tablet id: {}, be: {}, report version: {}",
+                LOG.info("finish create replica. tablet id: {}, be: {}, report version: {}",
                         tabletId, task.getBackendId(), request.getReport_version());
             }
 

--- a/fe/fe-core/src/main/java/com/starrocks/leader/LeaderImpl.java
+++ b/fe/fe-core/src/main/java/com/starrocks/leader/LeaderImpl.java
@@ -396,11 +396,9 @@ public class LeaderImpl {
                                     "finish recover create replica task. set replica to good. tablet {}, replica {}, backend {}",
                                     tabletId, task.getBackendId(), replica.getId());
                         }
-                    } else {
-                        LOG.warn("replica not found in inverted index");
                     }
                 } else {
-                    LOG.warn("request not set tablet infos");
+                    LOG.warn("tablet_info not set in finishTaskRequest");
                 }
 
                 // this should be called before 'countDownLatch()'

--- a/fe/fe-core/src/main/java/com/starrocks/leader/LeaderImpl.java
+++ b/fe/fe-core/src/main/java/com/starrocks/leader/LeaderImpl.java
@@ -408,8 +408,8 @@ public class LeaderImpl {
                         .updateBackendReportVersion(task.getBackendId(), request.getReport_version(), task.getDbId());
 
                 createReplicaTask.countDownLatch(task.getBackendId(), task.getSignature());
-                LOG.info("finish create replica. tablet id: {}, be: {}, report version: {}",
-                        tabletId, task.getBackendId(), request.getReport_version());
+                LOG.info("finish create replica. tablet id: {}, be: {}, report version: {}, tablet type: {}",
+                        tabletId, task.getBackendId(), request.getReport_version(), createReplicaTask.getTabletType());
             }
 
             if (createReplicaTask.getRecoverySource() == RecoverySource.SCHEDULER) {

--- a/fe/fe-core/src/main/java/com/starrocks/leader/LeaderImpl.java
+++ b/fe/fe-core/src/main/java/com/starrocks/leader/LeaderImpl.java
@@ -398,7 +398,7 @@ public class LeaderImpl {
                         }
                     }
                 } else {
-                    LOG.warn("tablet_info not set in finishTaskRequest");
+                    LOG.warn("tablet_info is not set in finishTaskRequest");
                 }
 
                 // this should be called before 'countDownLatch()'

--- a/fe/fe-core/src/main/java/com/starrocks/leader/LeaderImpl.java
+++ b/fe/fe-core/src/main/java/com/starrocks/leader/LeaderImpl.java
@@ -396,7 +396,11 @@ public class LeaderImpl {
                                     "finish recover create replica task. set replica to good. tablet {}, replica {}, backend {}",
                                     tabletId, task.getBackendId(), replica.getId());
                         }
+                    } else {
+                        LOG.warn("replica not found in inverted index");
                     }
+                } else {
+                    LOG.warn("request not set tablet infos");
                 }
 
                 // this should be called before 'countDownLatch()'

--- a/fe/fe-core/src/main/java/com/starrocks/leader/ReportHandler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/leader/ReportHandler.java
@@ -860,11 +860,10 @@ public class ReportHandler extends Daemon implements MemoryTrackable {
 
                     long currentBackendReportVersion =
                             GlobalStateMgr.getCurrentState().getNodeMgr().getClusterInfo().getBackendReportVersion(backendId);
-                    long pathHash = replica.getPathHash();
-                    if (pathHash == -1L) {
-                        continue;
-                    }
-                    DiskInfo diskInfo = hashToDiskInfo.get(pathHash);
+                    DiskInfo diskInfo = hashToDiskInfo.get(replica.getPathHash());
+
+                    // Only check reportVersion when the disk is online,
+                    // as there will be no tablet changes on an unavailable disk
                     if (diskInfo != null
                             && diskInfo.getState() == DiskInfo.DiskState.ONLINE
                             && backendReportVersion < currentBackendReportVersion) {

--- a/fe/fe-core/src/main/java/com/starrocks/leader/ReportHandler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/leader/ReportHandler.java
@@ -869,9 +869,11 @@ public class ReportHandler extends Daemon implements MemoryTrackable {
                             && backendReportVersion < currentBackendReportVersion) {
                         continue;
                     } else if (diskInfo == null) {
-                        LOG.info("disk of path hash {} dose not exist, delete its tablets from meta", replica.getPathHash());
+                        LOG.info("disk of path hash {} dose not exist, delete tablet {} on backend {} from meta",
+                                tableId, backendId, replica.getPathHash());
                     } else if (diskInfo.getState() != DiskInfo.DiskState.ONLINE) {
-                        LOG.info("disk of path hash {} not available, delete its tablets from meta", replica.getPathHash());
+                        LOG.info("disk of path hash {} not available, delete tablet {} on backend {} from meta",
+                                tableId, backendId, replica.getPathHash());
                     }
 
                     ReplicaState state = replica.getState();

--- a/fe/fe-core/src/main/java/com/starrocks/leader/ReportHandler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/leader/ReportHandler.java
@@ -868,6 +868,10 @@ public class ReportHandler extends Daemon implements MemoryTrackable {
                             && diskInfo.getState() == DiskInfo.DiskState.ONLINE
                             && backendReportVersion < currentBackendReportVersion) {
                         continue;
+                    } else if (diskInfo == null) {
+                        LOG.info("disk of path hash {} dose not exist, delete its tablets from meta", replica.getPathHash());
+                    } else if (diskInfo.getState() != DiskInfo.DiskState.ONLINE) {
+                        LOG.info("disk of path hash {} not available, delete its tablets from meta", replica.getPathHash());
                     }
 
                     ReplicaState state = replica.getState();

--- a/fe/fe-core/src/main/java/com/starrocks/leader/ReportHandler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/leader/ReportHandler.java
@@ -867,12 +867,14 @@ public class ReportHandler extends Daemon implements MemoryTrackable {
                     if (diskInfo != null
                             && diskInfo.getState() == DiskInfo.DiskState.ONLINE
                             && backendReportVersion < currentBackendReportVersion) {
-                        continue;
+                        LOG.warn("report Version from be: {} is outdated, report version in request: {}, " +
+                                "latest report version: {}", backendId, backendReportVersion, currentBackendReportVersion);
+                        break DB_TRAVERSE;
                     } else if (diskInfo == null) {
-                        LOG.info("disk of path hash {} dose not exist, delete tablet {} on backend {} from meta",
+                        LOG.warn("disk of path hash {} dose not exist, delete tablet {} on backend {} from meta",
                                 tableId, backendId, replica.getPathHash());
                     } else if (diskInfo.getState() != DiskInfo.DiskState.ONLINE) {
-                        LOG.info("disk of path hash {} not available, delete tablet {} on backend {} from meta",
+                        LOG.warn("disk of path hash {} not available, delete tablet {} on backend {} from meta",
                                 tableId, backendId, replica.getPathHash());
                     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/system/SystemInfoService.java
+++ b/fe/fe-core/src/main/java/com/starrocks/system/SystemInfoService.java
@@ -942,7 +942,7 @@ public class SystemInfoService implements GsonPostProcessable {
                 Database db = GlobalStateMgr.getCurrentState().getDb(dbId);
                 if (db != null) {
                     updateReportVersionIncrementally(atomicLong, newReportVersion);
-                    LOG.debug("update backend {} report version: {}, db: {}", backendId, newReportVersion, dbId);
+                    LOG.info("update backend {} report version: {}, db: {}", backendId, newReportVersion, dbId);
                 } else {
                     LOG.warn("failed to update backend report version, db {} does not exist", dbId);
                 }

--- a/fe/fe-core/src/main/java/com/starrocks/task/CreateReplicaTask.java
+++ b/fe/fe-core/src/main/java/com/starrocks/task/CreateReplicaTask.java
@@ -276,6 +276,10 @@ public class CreateReplicaTask extends AgentTask {
         this.baseSchemaHash = baseSchemaHash;
     }
 
+    public TTabletType getTabletType() {
+        return tabletType;
+    }
+
     public TCreateTabletReq toThrift() {
         TCreateTabletReq createTabletReq = new TCreateTabletReq();
         createTabletReq.setTablet_id(tabletId);

--- a/fe/fe-core/src/test/java/com/starrocks/pseudocluster/PseudoBackend.java
+++ b/fe/fe-core/src/test/java/com/starrocks/pseudocluster/PseudoBackend.java
@@ -108,6 +108,7 @@ import com.starrocks.thrift.TBackendInfo;
 import com.starrocks.thrift.TCancelPlanFragmentParams;
 import com.starrocks.thrift.TCancelPlanFragmentResult;
 import com.starrocks.thrift.TCloneReq;
+import com.starrocks.thrift.TCreateTabletReq;
 import com.starrocks.thrift.TDataSink;
 import com.starrocks.thrift.TDataSinkType;
 import com.starrocks.thrift.TDeleteEtlFilesRequest;
@@ -578,7 +579,15 @@ public class PseudoBackend {
         if (request.create_tablet_req.tablet_type == TTabletType.TABLET_TYPE_LAKE) {
             lakeTabletManager.createTablet(request.create_tablet_req);
         } else {
-            tabletManager.createTablet(request.create_tablet_req);
+            TCreateTabletReq createTabletReq = request.create_tablet_req;
+            tabletManager.createTablet(createTabletReq);
+            TTabletInfo tabletInfo = new TTabletInfo();
+            tabletInfo.setPath_hash(PATH_HASH);
+            tabletInfo.setData_size(0);
+            tabletInfo.setTablet_id(createTabletReq.tablet_id);
+            tabletInfo.setSchema_hash(createTabletReq.tablet_schema.schema_hash);
+            tabletInfo.setVersion(createTabletReq.version);
+            finish.setFinish_tablet_infos(Lists.newArrayList(new TTabletInfo()));
         }
     }
 


### PR DESCRIPTION
## Why I'm doing:
A disk is removed from be's conf. The normal repair logic is as follows:
1. BE reports the full amount of tablets to FE. At this time, it will not bring along the tablets that have been removed from the disk.
2. FE compares the tablets reported by BE with the tablets recorded in its own metadata, and deletes replicas of tablets that do not exist in BE from the metadata.
3. Make up for the lost replicas based on the tablets on other BEs.

However, if there are too many tablets on a BE, the processing time of the second step is too long. As long as tablets are created or imported on the BE, which is controlled by reportVersion, the deletion will not be performed, resulting in incorrect metadata information being recorded on the FE side.

## What I'm doing:
Only check reportVersion when the disk is online, as there will be no tablet changes on an unavailable disk.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [x] 3.1
  - [x] 3.0
  - [x] 2.5
