### PR TITLE
[Enhancement] Optimize broker load small orc files

### DIFF
--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -821,6 +821,9 @@ CONF_mBool(orc_coalesce_read_enable, "true");
 // Default is 8MB for tiny stripe threshold size
 CONF_Int32(orc_tiny_stripe_threshold_size, "8388608");
 
+// orc load parameters
+CONF_Int32(orc_loading_buffer_size, "8388608");
+
 // parquet reader
 CONF_mBool(parquet_coalesce_read_enable, "true");
 CONF_Bool(parquet_late_materialization_enable, "true");

--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -821,7 +821,8 @@ CONF_mBool(orc_coalesce_read_enable, "true");
 // Default is 8MB for tiny stripe threshold size
 CONF_Int32(orc_tiny_stripe_threshold_size, "8388608");
 
-// orc load parameters
+// When the ORC file file size is smaller than orc_loading_buffer_size,
+// we'll read the whole file at once instead of reading a footer first.
 CONF_Int32(orc_loading_buffer_size, "8388608");
 
 // parquet reader

--- a/be/src/exec/orc_scanner.cpp
+++ b/be/src/exec/orc_scanner.cpp
@@ -206,8 +206,8 @@ Status ORCScanner::_open_next_orc_reader() {
                 .max_buffer_size = config::io_coalesce_read_max_buffer_size};
         shared_buffered_input_stream->set_coalesce_options(options);
 
-        // If file size smaller than 8mb, we will load the whole file in one IO request
-        if (file_size < 8 * 1024 * 1024) {
+        // If file size smaller than orc_loading_buffer_size, we will load the whole file in one IO request
+        if (file_size < config::orc_loading_buffer_size) {
             std::vector<io::SharedBufferedInputStream::IORange> io_ranges{};
             io_ranges.emplace_back(0, file_size);
             RETURN_IF_ERROR(shared_buffered_input_stream->set_io_ranges(io_ranges));

--- a/be/src/exec/orc_scanner.cpp
+++ b/be/src/exec/orc_scanner.cpp
@@ -199,10 +199,11 @@ Status ORCScanner::_open_next_orc_reader() {
         std::shared_ptr<io::SeekableInputStream> input_stream = file->stream();
         ASSIGN_OR_RETURN(uint64_t file_size, file->get_size());
 
-        auto shared_buffered_input_stream = std::make_shared<io::SharedBufferedInputStream>(input_stream, file_name, file_size);
+        auto shared_buffered_input_stream =
+                std::make_shared<io::SharedBufferedInputStream>(input_stream, file_name, file_size);
         const io::SharedBufferedInputStream::CoalesceOptions options = {
-            .max_dist_size = config::io_coalesce_read_max_distance_size,
-            .max_buffer_size = config::io_coalesce_read_max_buffer_size};
+                .max_dist_size = config::io_coalesce_read_max_distance_size,
+                .max_buffer_size = config::io_coalesce_read_max_buffer_size};
         shared_buffered_input_stream->set_coalesce_options(options);
 
         // If file size smaller than 8mb, we will load the whole file in one IO request

--- a/be/test/CMakeLists.txt
+++ b/be/test/CMakeLists.txt
@@ -61,6 +61,7 @@ set(EXEC_FILES
         ./exec/chunks_sorter_test.cpp
         ./exec/connector_scan_node_test.cpp
         ./exec/csv_scanner_test.cpp
+        ./exec/orc_scanner_test.cpp
         ./exec/file_scanner_test.cpp
         ./exec/file_scan_node_test.cpp
         ./exec/hdfs_scanner_test.cpp

--- a/be/test/exec/orc_scanner_test.cpp
+++ b/be/test/exec/orc_scanner_test.cpp
@@ -1,0 +1,69 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <exec/orc_scanner.h>
+#include <gtest/gtest.h>
+
+#include "runtime/runtime_state.h"
+
+namespace starrocks {
+
+class ORCScannerTest : public ::testing::Test {
+public:
+    TBrokerScanRange create_scan_range(const std::vector<std::string>& file_names) {
+        TBrokerScanRange scan_range;
+
+        std::vector<TBrokerRangeDesc> ranges;
+        ranges.resize(file_names.size());
+        for (auto i = 0; i < file_names.size(); ++i) {
+            TBrokerRangeDesc& range = ranges[i];
+            range.__set_path(file_names[i]);
+            range.start_offset = 0;
+            range.size = std::numeric_limits<int64_t>::max();
+            range.file_type = TFileType::FILE_LOCAL;
+            range.__set_format_type(TFileFormatType::FORMAT_ORC);
+        }
+        scan_range.ranges = ranges;
+        return scan_range;
+    }
+
+    void SetUp() override {
+        std::string starrocks_home = getenv("STARROCKS_HOME");
+        test_exec_dir = starrocks_home + "/be/test/exec";
+    }
+
+    std::string test_exec_dir;
+};
+
+TEST_F(ORCScannerTest, get_schema) {
+    RuntimeState state(TUniqueId(), TQueryOptions(), TQueryGlobals(), nullptr);
+    auto scan_range = create_scan_range({test_exec_dir + "/test_data/orc_scanner/type_mismatch.orc"});
+
+    scan_range.params.__set_schema_sample_file_count(1);
+
+    ScannerCounter counter{};
+    RuntimeProfile profile{"test"};
+    std::unique_ptr<ORCScanner> scanner = std::make_unique<ORCScanner>(&state, &profile, scan_range, &counter, true);
+
+    auto st = scanner->open();
+    EXPECT_TRUE(st.ok());
+
+    std::vector<SlotDescriptor> schemas;
+    st = scanner->get_schema(&schemas);
+    EXPECT_TRUE(st.ok());
+
+    EXPECT_EQ("VARCHAR(1048576)", schemas[0].type().debug_string());
+}
+
+} // namespace starrocks


### PR DESCRIPTION
## Why I'm doing:
If orc file's size is small, we can use one io request to load it

## What I'm doing:
Support it

Fix https://github.com/StarRocks/StarRocksTest/issues/6250

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
