### PR TITLE
[BugFix] Incorrect error checking in PosixFileSystem::iterate_dir

### DIFF
--- a/be/src/fs/fs_posix.cpp
+++ b/be/src/fs/fs_posix.cpp
@@ -418,7 +418,6 @@ public:
             auto saved_errno = errno;
             auto r = cb(name);
             if (UNLIKELY(errno != saved_errno)) {
-                LOG(INFO) << "errno changed to " << errno << ", will restore it back to " << saved_errno;
                 errno = saved_errno;
             }
             if (!r) {
@@ -467,7 +466,6 @@ public:
             auto saved_errno = errno;
             auto r = cb(de);
             if (UNLIKELY(errno != saved_errno)) {
-                LOG(INFO) << "errno changed to " << errno << ", will restore it back to " << saved_errno;
                 errno = saved_errno;
             }
             if (!r) {

--- a/be/src/fs/fs_posix.cpp
+++ b/be/src/fs/fs_posix.cpp
@@ -417,9 +417,7 @@ public:
             }
             auto saved_errno = errno;
             auto r = cb(name);
-            if (UNLIKELY(errno != saved_errno)) {
-                errno = saved_errno;
-            }
+            errno = saved_errno;
             if (!r) {
                 break;
             }
@@ -465,9 +463,7 @@ public:
             de.size = child_stat.st_size;
             auto saved_errno = errno;
             auto r = cb(de);
-            if (UNLIKELY(errno != saved_errno)) {
-                errno = saved_errno;
-            }
+            errno = saved_errno;
             if (!r) {
                 break;
             }

--- a/be/test/fs/fs_posix_test.cpp
+++ b/be/test/fs/fs_posix_test.cpp
@@ -159,6 +159,16 @@ TEST_F(PosixFileSystemTest, iterate_dir) {
         ASSERT_STREQ("123", children[0].c_str());
         ASSERT_STREQ("abc", children[1].c_str());
     }
+    {
+        ASSERT_OK(FileSystem::Default()->iterate_dir(dir_path, [](std::string_view) {
+            errno = EBADF;
+            return false;
+        }));
+        ASSERT_OK(FileSystem::Default()->iterate_dir(dir_path, [](std::string_view) {
+            errno = EBADF;
+            return true;
+        }));
+    }
 
     // Delete non-empty directory, should fail.
     ASSERT_ERROR(FileSystem::Default()->delete_dir(dir_path));
@@ -223,6 +233,16 @@ TEST_F(PosixFileSystemTest, iterate_dir2) {
         } else {
             CHECK(false) << "Unexpected file " << name;
         }
+        return true;
+    }));
+
+    ASSERT_OK(fs->iterate_dir2("./ut_dir/fs_posix/", [&](DirEntry entry) -> bool {
+        errno = EBADF;
+        return false;
+    }));
+
+    ASSERT_OK(fs->iterate_dir2("./ut_dir/fs_posix/", [&](DirEntry entry) -> bool {
+        errno = EBADF;
         return true;
     }));
 }


### PR DESCRIPTION
1. The `iterate_dir` callback function may cause `errno` to change, and `errno` should be restored at the end of the callback.
2. should check `errno` to determine if an error occurred in `readdir` that caused the while loop to exit

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [x] 3.1
  - [x] 3.0
  - [x] 2.5
