### PR TITLE
[Enhancement] Avoid repeated calculation of bitmap memory usage

### DIFF
--- a/be/src/column/object_column.cpp
+++ b/be/src/column/object_column.cpp
@@ -30,7 +30,7 @@ size_t ObjectColumn<T>::byte_size(size_t from, size_t size) const {
     DCHECK_LE(from + size, this->size()) << "Range error";
     size_t byte_size = 0;
     for (size_t i = 0; i < size; ++i) {
-        byte_size += _pool[from + i].serialize_size();
+        byte_size += _pool[from + i].mem_usage();
     }
     return byte_size;
 }

--- a/be/src/exprs/bitmap_functions.cpp
+++ b/be/src/exprs/bitmap_functions.cpp
@@ -569,7 +569,7 @@ StatusOr<ColumnPtr> BitmapFunctions::bitmap_to_base64(FunctionContext* context, 
 
     for (int row = 0; row < size; ++row) {
         BitmapValue* bitmap = viewer.value(row);
-        int byteSize = bitmap->getSizeInBytes();
+        int byteSize = bitmap->get_size_in_bytes();
         std::unique_ptr<char[]> buf;
         buf.reset(new char[byteSize]);
 
@@ -684,7 +684,7 @@ StatusOr<ColumnPtr> BitmapFunctions::bitmap_to_binary(FunctionContext* context, 
     raw::RawString buf;
     for (int row = 0; row < size; ++row) {
         BitmapValue* bitmap = viewer.value(row);
-        size_t serialize_size = bitmap->getSizeInBytes();
+        size_t serialize_size = bitmap->get_size_in_bytes();
         buf.resize(serialize_size);
         bitmap->write(buf.data());
         builder.append(Slice(buf.data(), serialize_size));

--- a/be/src/storage/row_store_encoder_simple.cpp
+++ b/be/src/storage/row_store_encoder_simple.cpp
@@ -164,7 +164,7 @@ Status RowStoreEncoderSimple::decode_columns_from_full_row_column(const Schema& 
 
 // encode bitmap<column_num>
 void RowStoreEncoderSimple::encode_null_bitmap(BitmapValue& null_bitmap, std::string* dest) {
-    size_t len = null_bitmap.getSizeInBytes();
+    size_t len = null_bitmap.get_size_in_bytes();
     encode_integral<size_t>(len, dest);
     std::string bitmap_value;
     bitmap_value.reserve(len);

--- a/be/src/types/bitmap_value.cpp
+++ b/be/src/types/bitmap_value.cpp
@@ -59,11 +59,14 @@ static void get_only_value_to_set_and_common_value_to_bitmap(const phmap::flat_h
     }
 }
 
-BitmapValue::BitmapValue() = default;
-
 BitmapValue::BitmapValue(BitmapValue&& other) noexcept
-        : _bitmap(std::move(other._bitmap)), _set(std::move(other._set)), _sv(other._sv), _type(other._type) {
+        : _bitmap(std::move(other._bitmap)),
+          _set(std::move(other._set)),
+          _sv(other._sv),
+          _mem_usage(other._mem_usage),
+          _type(other._type) {
     other._sv = 0;
+    other._mem_usage = 0;
     other._type = EMPTY;
 }
 
@@ -72,8 +75,10 @@ BitmapValue& BitmapValue::operator=(BitmapValue&& other) noexcept {
         this->_bitmap = std::move(other._bitmap);
         this->_set = std::move(other._set);
         this->_sv = other._sv;
+        this->_mem_usage = other._mem_usage;
         this->_type = other._type;
         other._sv = 0;
+        other._mem_usage = 0;
         other._type = EMPTY;
     }
     return *this;
@@ -97,6 +102,7 @@ BitmapValue::BitmapValue(const BitmapValue& other)
         : _bitmap(other._bitmap),
           _set(other._set == nullptr ? nullptr : std::make_unique<phmap::flat_hash_set<uint64_t>>(*other._set)),
           _sv(other._sv),
+          _mem_usage(other._mem_usage),
           _type(other._type) {
     // TODO: _set is usually relatively small, and it needs system performance testing to decide
     //  whether to change std::unique_ptr to std::shared_ptr and support shallow copy
@@ -107,6 +113,7 @@ BitmapValue& BitmapValue::operator=(const BitmapValue& other) {
         this->_bitmap = other._bitmap;
         this->_set = other._set == nullptr ? nullptr : std::make_unique<phmap::flat_hash_set<uint64_t>>(*other._set);
         this->_sv = other._sv;
+        this->_mem_usage = other._mem_usage;
         this->_type = other._type;
     }
     return *this;
@@ -146,6 +153,7 @@ void BitmapValue::_from_set_to_bitmap() {
 // EMPTY  -> BITMAP
 // SINGLE -> BITMAP
 BitmapValue& BitmapValue::operator|=(const BitmapValue& rhs) {
+    _mem_usage = 0;
     switch (rhs._type) {
     case EMPTY:
         return *this;
@@ -215,6 +223,7 @@ BitmapValue& BitmapValue::operator|=(const BitmapValue& rhs) {
 // BITMAP -> EMPTY
 // BITMAP -> SINGLE
 BitmapValue& BitmapValue::operator&=(const BitmapValue& rhs) {
+    _mem_usage = 0;
     switch (rhs._type) {
     case EMPTY:
         reset();
@@ -312,6 +321,7 @@ BitmapValue& BitmapValue::operator&=(const BitmapValue& rhs) {
 }
 
 void BitmapValue::remove(uint64_t rhs) {
+    _mem_usage = 0;
     switch (_type) {
     case EMPTY:
         break;
@@ -331,6 +341,7 @@ void BitmapValue::remove(uint64_t rhs) {
 }
 
 BitmapValue& BitmapValue::operator-=(const BitmapValue& rhs) {
+    _mem_usage = 0;
     switch (rhs._type) {
     case EMPTY:
         break;
@@ -412,6 +423,7 @@ BitmapValue& BitmapValue::operator-=(const BitmapValue& rhs) {
 }
 
 BitmapValue& BitmapValue::operator^=(const BitmapValue& rhs) {
+    _mem_usage = 0;
     switch (rhs._type) {
     case EMPTY:
         break;
@@ -621,7 +633,7 @@ std::optional<uint64_t> BitmapValue::min() const {
 
 // Return how many bytes are required to serialize this bitmap.
 // See BitmapTypeCode for the serialized format.
-size_t BitmapValue::getSizeInBytes() const {
+size_t BitmapValue::get_size_in_bytes() const {
     size_t res = 0;
     switch (_type) {
     case EMPTY:
@@ -679,6 +691,7 @@ void BitmapValue::write(char* dst) const {
 // Deserialize a bitmap value from `src`.
 // Return false if `src` begins with unknown type code, true otherwise.
 bool BitmapValue::deserialize(const char* src) {
+    _mem_usage = 0;
     if (src == nullptr) {
         _type = EMPTY;
         return true;
@@ -729,6 +742,7 @@ bool BitmapValue::deserialize(const char* src) {
 }
 
 bool BitmapValue::valid_and_deserialize(const char* src, size_t max_bytes) {
+    _mem_usage = 0;
     if (!max_bytes) {
         return false;
     }
@@ -878,13 +892,14 @@ void BitmapValue::to_array(std::vector<int64_t>* array) const {
 
 size_t BitmapValue::serialize(uint8_t* dst) const {
     write(reinterpret_cast<char*>(dst));
-    return getSizeInBytes();
+    return get_size_in_bytes();
 }
 
 // When you persist bitmap value to disk, you could call this method.
 // This method should be called before `serialize_size`.
 void BitmapValue::compress() const {
     if (_type == BITMAP) {
+        _mem_usage = 0;
         // no need to copy on write
         _bitmap->runOptimize();
         _bitmap->shrinkToFit();
@@ -903,6 +918,7 @@ void BitmapValue::clear() {
         _set->clear();
     }
     _sv = 0;
+    _mem_usage = 0;
     _type = EMPTY;
 }
 
@@ -910,6 +926,7 @@ void BitmapValue::reset() {
     _bitmap.reset();
     _set.reset();
     _sv = 0;
+    _mem_usage = 0;
     _type = EMPTY;
 }
 
@@ -927,7 +944,7 @@ void BitmapValue::_from_bitmap_to_smaller_type() {
     _bitmap.reset();
 }
 
-std::vector<BitmapValue> BitmapValue::split_bitmap(size_t batch_size) {
+std::vector<BitmapValue> BitmapValue::split_bitmap(size_t batch_size) const {
     std::vector<BitmapValue> results;
 
     if (batch_size == 0) {
@@ -1078,7 +1095,7 @@ int64_t BitmapValue::bitmap_subset_limit_internal(const int64_t& range_start, co
             auto end = _bitmap->begin();
 
             int64_t offset = 0;
-            for (; end != _bitmap->end() && offset < abs_limit && *end <= range_start;) {
+            for (; end != _bitmap->end() && offset < abs_limit && * end <= range_start;) {
                 ++end;
                 ++offset;
             }
@@ -1145,6 +1162,7 @@ int64_t BitmapValue::bitmap_subset_in_range_internal(const int64_t& range_start,
 }
 
 void BitmapValue::add_many(size_t n_args, const uint32_t* vals) {
+    _mem_usage = 0;
     if (_type != BITMAP) {
         for (size_t i = 0; i < n_args; i++) {
             add(vals[i]);

--- a/be/src/types/bitmap_value.cpp
+++ b/be/src/types/bitmap_value.cpp
@@ -1095,7 +1095,7 @@ int64_t BitmapValue::bitmap_subset_limit_internal(const int64_t& range_start, co
             auto end = _bitmap->begin();
 
             int64_t offset = 0;
-            for (; end != _bitmap->end() && offset < abs_limit && * end <= range_start;) {
+            for (; end != _bitmap->end() && offset < abs_limit && *end <= range_start;) {
                 ++end;
                 ++offset;
             }

--- a/be/src/types/bitmap_value.h
+++ b/be/src/types/bitmap_value.h
@@ -59,8 +59,8 @@ namespace starrocks {
 
 namespace detail {
 class Roaring64Map;
-class BitmapValueIter;
 } // namespace detail
+
 // Represent the in-memory and on-disk structure of StarRocks's BITMAP data type.
 // Optimize for the case where the bitmap contains 0 or 1 element which is common
 // for streaming load scenario.
@@ -70,13 +70,13 @@ public:
 
     enum BitmapDataType {
         EMPTY = 0,
-        SINGLE = 1, // single element
-        BITMAP = 2, // more than one elements
+        SINGLE = 1,
+        BITMAP = 2,
         SET = 3
     };
 
     // Construct an empty bitmap.
-    BitmapValue();
+    BitmapValue() = default;
 
     BitmapValue(const BitmapValue& other);
     BitmapValue& operator=(const BitmapValue& other);
@@ -98,6 +98,7 @@ public:
 
     // It is recommended to use batch writing to improve performance, such as add_many.
     void add(uint64_t value) {
+        _mem_usage = 0;
         switch (_type) {
         case EMPTY:
             _sv = value;
@@ -163,7 +164,7 @@ public:
 
     // Return how many bytes are required to serialize this bitmap.
     // See BitmapTypeCode for the serialized format.
-    size_t getSizeInBytes() const;
+    size_t get_size_in_bytes() const;
 
     // Serialize the bitmap value to dst, which should be large enough.
     // Client should call `getSizeInBytes` first to get the serialized size.
@@ -183,7 +184,7 @@ public:
 
     size_t serialize(uint8_t* dst) const;
 
-    uint64_t serialize_size() const { return getSizeInBytes(); }
+    uint64_t serialize_size() const { return get_size_in_bytes(); }
 
     // When you persist bitmap value to disk, you could call this method.
     // This method should be called before `serialize_size`.
@@ -200,10 +201,16 @@ public:
     int64_t bitmap_subset_in_range_internal(const int64_t& range_start, const int64_t& range_end,
                                             BitmapValue* ret_bitmap) const;
 
-    std::vector<BitmapValue> split_bitmap(size_t batch_size);
+    std::vector<BitmapValue> split_bitmap(size_t batch_size) const;
 
     BitmapDataType type() const { return _type; }
     bool is_shared() const { return _bitmap.use_count() > 1; }
+    int64_t mem_usage() const {
+        if (_mem_usage == 0) {
+            _mem_usage = get_size_in_bytes();
+        }
+        return _mem_usage;
+    }
 
 private:
     void _from_bitmap_to_smaller_type();
@@ -226,6 +233,7 @@ private:
     std::shared_ptr<detail::Roaring64Map> _bitmap = nullptr;
     std::unique_ptr<phmap::flat_hash_set<uint64_t>> _set;
     uint64_t _sv = 0; // store the single value when _type == SINGLE
+    mutable int64_t _mem_usage = 0;
     BitmapDataType _type{EMPTY};
 };
 

--- a/be/src/types/bitmap_value.h
+++ b/be/src/types/bitmap_value.h
@@ -68,12 +68,7 @@ class BitmapValue {
 public:
     friend class BitmapValueIter;
 
-    enum BitmapDataType {
-        EMPTY = 0,
-        SINGLE = 1,
-        BITMAP = 2,
-        SET = 3
-    };
+    enum BitmapDataType { EMPTY = 0, SINGLE = 1, BITMAP = 2, SET = 3 };
 
     // Construct an empty bitmap.
     BitmapValue() = default;

--- a/be/src/types/hll.h
+++ b/be/src/types/hll.h
@@ -141,6 +141,8 @@ public:
 
     uint64_t serialize_size() const { return max_serialized_size(); }
 
+    uint64_t mem_usage() const { return max_serialized_size(); }
+
     // common interface
     void clear();
 

--- a/be/src/util/bitmap_intersect.h
+++ b/be/src/util/bitmap_intersect.h
@@ -148,7 +148,7 @@ public:
         size_t size = 4;
         for (auto& kv : _bitmaps) {
             size += detail::serialize_size(kv.first);
-            size += kv.second.getSizeInBytes();
+            size += kv.second.get_size_in_bytes();
         }
         return size;
     }
@@ -161,7 +161,7 @@ public:
         for (auto& kv : _bitmaps) {
             writer = detail::write_to(kv.first, writer);
             kv.second.write(writer);
-            writer += kv.second.getSizeInBytes();
+            writer += kv.second.get_size_in_bytes();
         }
     }
 
@@ -173,7 +173,7 @@ public:
             T key;
             detail::read_from(&reader, &key);
             BitmapValue bitmap(reader);
-            reader += bitmap.getSizeInBytes();
+            reader += bitmap.get_size_in_bytes();
             _bitmaps[key] = bitmap;
         }
     }

--- a/be/src/util/json.h
+++ b/be/src/util/json.h
@@ -109,6 +109,7 @@ public:
     ////////////////// serialization  //////////////////////
     size_t serialize(uint8_t* dst) const;
     uint64_t serialize_size() const;
+    uint64_t mem_usage() const { return serialize_size(); }
 
     ////////////////// RAW accessor ////////////////////////////
     Slice get_slice() const;

--- a/be/src/util/percentile_value.h
+++ b/be/src/util/percentile_value.h
@@ -41,6 +41,8 @@ public:
         return 1 + _tdigest.serialize_size();
     }
 
+    uint64_t mem_usage() const { return 1 + _tdigest.serialize_size(); }
+
     size_t serialize(uint8_t* writer) const {
         *(writer) = _type;
         return _tdigest.serialize(writer + 1);

--- a/be/test/exprs/bitmap_functions_test.cpp
+++ b/be/test/exprs/bitmap_functions_test.cpp
@@ -48,7 +48,7 @@ TEST_F(VecBitmapFunctionsTest, bitmapEmptyTest) {
 
         auto* bitmap = ColumnHelper::get_const_value<TYPE_OBJECT>(column);
 
-        ASSERT_EQ(1, bitmap->getSizeInBytes());
+        ASSERT_EQ(1, bitmap->get_size_in_bytes());
     }
 }
 

--- a/be/test/exprs/cast_expr_test.cpp
+++ b/be/test/exprs/cast_expr_test.cpp
@@ -1092,7 +1092,7 @@ TEST_F(VectorizedCastExprTest, stringCastBitmapFailed1) {
     BitmapValue bitmap_value(bits);
 
     std::string buf;
-    buf.resize(bitmap_value.getSizeInBytes());
+    buf.resize(bitmap_value.get_size_in_bytes());
     bitmap_value.write((char*)buf.c_str());
     // non-exist type bitmap.
     *((uint8_t*)(buf.c_str())) = (uint8_t)14;
@@ -1125,7 +1125,7 @@ TEST_F(VectorizedCastExprTest, stringCastBitmapSingle) {
     bitmap_value.add(1);
 
     std::string buf;
-    buf.resize(bitmap_value.getSizeInBytes());
+    buf.resize(bitmap_value.get_size_in_bytes());
     bitmap_value.write((char*)buf.c_str());
 
     expr_node.type = gen_type_desc(expr_node.child_type);
@@ -1161,7 +1161,7 @@ TEST_F(VectorizedCastExprTest, stringCastBitmapSingleFailed) {
     bitmap_value.add(1);
 
     std::string buf;
-    buf.resize(bitmap_value.getSizeInBytes());
+    buf.resize(bitmap_value.get_size_in_bytes());
     bitmap_value.write((char*)buf.c_str());
 
     size_t half_length = buf.size() / 2;
@@ -1198,7 +1198,7 @@ TEST_F(VectorizedCastExprTest, stringCastBitmapSet) {
     bitmap_value.add(2);
 
     std::string buf;
-    buf.resize(bitmap_value.getSizeInBytes());
+    buf.resize(bitmap_value.get_size_in_bytes());
     bitmap_value.write((char*)buf.c_str());
 
     expr_node.type = gen_type_desc(expr_node.child_type);
@@ -1236,7 +1236,7 @@ TEST_F(VectorizedCastExprTest, stringCastBitmapSetFailed) {
     bitmap_value.add(2);
 
     std::string buf;
-    buf.resize(bitmap_value.getSizeInBytes());
+    buf.resize(bitmap_value.get_size_in_bytes());
     bitmap_value.write((char*)buf.c_str());
 
     size_t half_length = buf.size() / 2;
@@ -1275,7 +1275,7 @@ TEST_F(VectorizedCastExprTest, stringCastBitmapMap) {
     BitmapValue bitmap_value(bits);
 
     std::string buf;
-    buf.resize(bitmap_value.getSizeInBytes());
+    buf.resize(bitmap_value.get_size_in_bytes());
     bitmap_value.write((char*)buf.c_str());
 
     expr_node.type = gen_type_desc(expr_node.child_type);
@@ -1316,7 +1316,7 @@ TEST_F(VectorizedCastExprTest, stringCastBitmapMapFailed) {
     BitmapValue bitmap_value(bits);
 
     std::string buf;
-    buf.resize(bitmap_value.getSizeInBytes());
+    buf.resize(bitmap_value.get_size_in_bytes());
     bitmap_value.write((char*)buf.c_str());
     size_t half_length = buf.size() / 2;
 

--- a/be/test/types/bitmap_value_test.cpp
+++ b/be/test/types/bitmap_value_test.cpp
@@ -66,6 +66,7 @@ void BitmapValueTest::check_bitmap(BitmapDataType type, const BitmapValue& bitma
     for (auto i = start; i < end; i++) {
         ASSERT_TRUE(bitmap.contains(i));
     }
+    ASSERT_EQ(bitmap.mem_usage(), bitmap.serialize_size());
 }
 
 void BitmapValueTest::check_bitmap(BitmapDataType type, const BitmapValue& bitmap, uint64_t start_1, uint64_t end_1,
@@ -78,6 +79,7 @@ void BitmapValueTest::check_bitmap(BitmapDataType type, const BitmapValue& bitma
     for (auto i = start_2; i < end_2; i++) {
         ASSERT_TRUE(bitmap.contains(i));
     }
+    ASSERT_EQ(bitmap.mem_usage(), bitmap.serialize_size());
 }
 
 TEST_F(BitmapValueTest, copy_construct) {
@@ -96,6 +98,7 @@ TEST_F(BitmapValueTest, assign_operator) {
     bitmap_1.add(64);
     check_bitmap(BitmapDataType::BITMAP, bitmap_1, 0, 65);
     check_bitmap(BitmapDataType::BITMAP, _large_bitmap, 0, 64);
+    ASSERT_EQ(bitmap_1.mem_usage(), bitmap_1.serialize_size());
 
     BitmapValue bitmap_2 = _medium_bitmap;
     bitmap_2.add(14);
@@ -572,7 +575,7 @@ TEST_F(BitmapValueTest, bitmap_min) {
 
 TEST_F(BitmapValueTest, bitmap_serialize_deserialize) {
     // empty bitmap
-    size_t size = _empty_bitmap.getSizeInBytes();
+    size_t size = _empty_bitmap.get_size_in_bytes();
     char buf_1[size];
     _empty_bitmap.write(buf_1);
     BitmapValue bitmap_1;
@@ -581,7 +584,7 @@ TEST_F(BitmapValueTest, bitmap_serialize_deserialize) {
     check_bitmap(BitmapDataType::EMPTY, bitmap_1, 0, 0);
 
     // single bitmap
-    size = _single_bitmap.getSizeInBytes();
+    size = _single_bitmap.get_size_in_bytes();
     char buf_2[size];
     _single_bitmap.write(buf_2);
     BitmapValue bitmap_2;
@@ -590,7 +593,7 @@ TEST_F(BitmapValueTest, bitmap_serialize_deserialize) {
     check_bitmap(BitmapDataType::SINGLE, bitmap_2, 0, 1);
 
     // medium bitmap
-    size = _medium_bitmap.getSizeInBytes();
+    size = _medium_bitmap.get_size_in_bytes();
     char buf_3[size];
     _medium_bitmap.write(buf_3);
     BitmapValue bitmap_3;
@@ -599,7 +602,7 @@ TEST_F(BitmapValueTest, bitmap_serialize_deserialize) {
     check_bitmap(BitmapDataType::SET, bitmap_3, 0, 14);
 
     // large bitmap
-    size = _large_bitmap.getSizeInBytes();
+    size = _large_bitmap.get_size_in_bytes();
     char buf_4[size];
     _large_bitmap.write(buf_4);
     BitmapValue bitmap_4;
@@ -610,7 +613,7 @@ TEST_F(BitmapValueTest, bitmap_serialize_deserialize) {
 
 TEST_F(BitmapValueTest, test_valid_and_deserialize) {
     // empty bitmap
-    size_t size = _empty_bitmap.getSizeInBytes();
+    size_t size = _empty_bitmap.get_size_in_bytes();
     char buf_1[size];
     _empty_bitmap.write(buf_1);
     BitmapValue bitmap_1;
@@ -619,7 +622,7 @@ TEST_F(BitmapValueTest, test_valid_and_deserialize) {
     check_bitmap(BitmapDataType::EMPTY, bitmap_1, 0, 0);
 
     // single bitmap
-    size = _single_bitmap.getSizeInBytes();
+    size = _single_bitmap.get_size_in_bytes();
     char buf_2[size];
     _single_bitmap.write(buf_2);
     BitmapValue bitmap_2;
@@ -628,7 +631,7 @@ TEST_F(BitmapValueTest, test_valid_and_deserialize) {
     check_bitmap(BitmapDataType::SINGLE, bitmap_2, 0, 1);
 
     // medium bitmap
-    size = _medium_bitmap.getSizeInBytes();
+    size = _medium_bitmap.get_size_in_bytes();
     char buf_3[size];
     _medium_bitmap.write(buf_3);
     BitmapValue bitmap_3;
@@ -637,7 +640,7 @@ TEST_F(BitmapValueTest, test_valid_and_deserialize) {
     check_bitmap(BitmapDataType::SET, bitmap_3, 0, 14);
 
     // large bitmap
-    size = _large_bitmap.getSizeInBytes();
+    size = _large_bitmap.get_size_in_bytes();
     char buf_4[size];
     _large_bitmap.write(buf_4);
     BitmapValue bitmap_4(_large_bitmap);
@@ -1011,7 +1014,7 @@ TEST_F(BitmapValueTest, next_batch) {
 
 std::string convert_bitmap_to_string(BitmapValue& bitmap) {
     std::string buf;
-    buf.resize(bitmap.getSizeInBytes());
+    buf.resize(bitmap.get_size_in_bytes());
     bitmap.write((char*)buf.c_str());
     return buf;
 }


### PR DESCRIPTION
## Why I'm doing:

Currently, `BitmapValue` already supports copy on write, but `Column::mem_usage` will still repeatedly calculate mem_usage of same bitmap. The cost of bitmap calculating mem_usage is relatively high, so currently a field mem_usage is added to `BitmapValue` to prevent repeated calculation of mem_usage.

performance test:

create table and prepare data

```
mysql> select count(*) from lineorder;
+-----------+
| count(*)  |
+-----------+
| 143999468 |
+-----------+

CREATE TABLE `bitmap_1m` (
  `k1` int(11) NULL COMMENT "",
  `v1` bitmap BITMAP_UNION NULL COMMENT ""
) ENGINE=OLAP 
AGGREGATE KEY(`k1`)
DISTRIBUTED BY HASH(`k1`) BUCKETS 1 
PROPERTIES (
"replication_num" = "1",
"in_memory" = "false",
"enable_persistent_index" = "false",
"replicated_storage" = "true",
"fast_schema_evolution" = "true",
"compression" = "LZ4"
); 

insert into bitmap_1m select lo_partkey%500 as c1, bitmap_agg(lo_orderkey) from lineorder group by c1;
```

query sql:

```
select count(lo_partkey), count(v1) from lineorder join bitmap_1m on lo_linenumber=k1 and bitmap_contains(v1, lo_orderkey);
```

before opt:

```
TotalTime: 19.328s
ChunkAccumulateTime: 5.714s
```

after opt:

```
TotalTime: 13.584s
ChunkAccumulateTime: 38.451ms
```

## What I'm doing:

1. Add item _mem_usage to `BitmapValue` to prevent repeat mem usage calculation.
2. Rename `getSizeInBytes` to `get_size_in_bytes`.
3. Add interface mem_usage for `BitmapValue`, `HyperLogLog`, `JsonValue`, `PercentileValue`.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [x] 3.1
  - [x] 3.0
  - [x] 2.5
