### PR TITLE
[BugFix] fix orc translate_to_orc_literal() has no return value

### DIFF
--- a/be/src/formats/orc/orc_chunk_reader.cpp
+++ b/be/src/formats/orc/orc_chunk_reader.cpp
@@ -892,9 +892,9 @@ static StatusOr<orc::Literal> translate_to_orc_literal(Expr* lit, orc::Predicate
         return orc::Literal{orc::Int128(datum.get_int64()), lit->type().precision, lit->type().scale};
     case LogicalType::TYPE_DECIMAL128:
         return orc::Literal{to_orc128(datum.get_int128()), lit->type().precision, lit->type().scale};
-    default:
-        CHECK(false) << "failed to handle logical type = " << std::to_string(ltype);
     }
+    LOG(WARNING) << "failed to handle logical type = " << std::to_string(ltype) << " in translate_to_orc_literal()";
+    return Status::InternalError("failed to handle logical type = " + std::to_string(ltype));
 }
 
 Status OrcChunkReader::_add_conjunct(const Expr* conjunct, std::unique_ptr<orc::SearchArgumentBuilder>& builder) {

--- a/be/src/formats/orc/orc_chunk_reader.cpp
+++ b/be/src/formats/orc/orc_chunk_reader.cpp
@@ -892,6 +892,8 @@ static StatusOr<orc::Literal> translate_to_orc_literal(Expr* lit, orc::Predicate
         return orc::Literal{orc::Int128(datum.get_int64()), lit->type().precision, lit->type().scale};
     case LogicalType::TYPE_DECIMAL128:
         return orc::Literal{to_orc128(datum.get_int128()), lit->type().precision, lit->type().scale};
+    default:
+        DCHECK(false);
     }
     LOG(WARNING) << "failed to handle logical type = " << std::to_string(ltype) << " in translate_to_orc_literal()";
     return Status::InternalError("failed to handle logical type = " + std::to_string(ltype));


### PR DESCRIPTION
## Why I'm doing:
`translate_to_orc_literal()` has no return value, it will crash directly

## What I'm doing:
return `Status::InternalError()` to avoid crash

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [x] 3.1
  - [x] 3.0
  - [ ] 2.5
