### PR TITLE
[BugFix] PosixFileSystem::delete_dir_recursive() should return OK on non-exist file

### DIFF
--- a/be/src/fs/fs.h
+++ b/be/src/fs/fs.h
@@ -248,6 +248,7 @@ public:
     // NOTE: The dir must be empty.
     virtual Status delete_dir(const std::string& dirname) = 0;
 
+    // TODO: Rename this method, because this method can also delete a normal file.
     // Deletes the contents of 'dirname' (if it is a directory) and the contents of all its subdirectories,
     // recursively, then deletes 'dirname' itself. Symlinks are not followed (symlink is removed, not its target).
     virtual Status delete_dir_recursive(const std::string& dirname) = 0;

--- a/be/src/fs/fs_posix.cpp
+++ b/be/src/fs/fs_posix.cpp
@@ -542,7 +542,7 @@ public:
             RETURN_IF_ERROR(st);
             return delete_dir(dirname);
         } else {
-            return delete_file(dirname);
+            return ignore_not_found(delete_file(dirname));
         }
     }
 

--- a/be/test/fs/fs_posix_test.cpp
+++ b/be/test/fs/fs_posix_test.cpp
@@ -252,6 +252,8 @@ TEST_F(PosixFileSystemTest, test_delete_files) {
     EXPECT_OK(fs->delete_files(paths));
     EXPECT_TRUE(fs->path_exists(path1).is_not_found());
     EXPECT_TRUE(fs->path_exists(path2).is_not_found());
+    EXPECT_OK(fs->delete_dir_recursive(path1));
+    EXPECT_OK(fs->delete_dir_recursive(path2));
 }
 
 } // namespace starrocks


### PR DESCRIPTION
The current implementation of `PosixFileSystem::delete_dir_recursive()` in a multi-threaded environment, it may happen that a file is deleted by another thread after `stat(2)` but before `PosixFileSystem::delete_file()`, in which case `PosixFileSystem::delete_dir_recursive` should return OK, not NotFound

Fixes #41771

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [x] 3.1
  - [x] 3.0
  - [x] 2.5
