### PR TITLE
[BugFix] Fix thrift reopen failed bug when the socket is already closed

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/common/GenericPool.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/GenericPool.java
@@ -65,13 +65,19 @@ public class GenericPool<VALUE extends org.apache.thrift.TServiceClient> {
 
     public boolean reopen(VALUE object, int timeoutMs) {
         boolean ok = true;
-        object.getOutputProtocol().getTransport().close();
+        try {
+            object.getOutputProtocol().getTransport().close();
+        } catch (Exception ignored) {
+            // Close exceptions are ignored because the socket may have been closed.
+        }
+
         try {
             object.getOutputProtocol().getTransport().open();
             // transport.open() doesn't set timeout, Maybe the timeoutMs change.
             TSocket socket = (TSocket) object.getOutputProtocol().getTransport();
             socket.setTimeout(timeoutMs);
         } catch (TTransportException e) {
+            LOG.warn("reopen error", e);
             ok = false;
         }
         return ok;
@@ -79,7 +85,12 @@ public class GenericPool<VALUE extends org.apache.thrift.TServiceClient> {
 
     public boolean reopen(VALUE object) {
         boolean ok = true;
-        object.getOutputProtocol().getTransport().close();
+        try {
+            object.getOutputProtocol().getTransport().close();
+        } catch (Exception ignored) {
+            // Close exceptions are ignored because the socket may have been closed.
+        }
+
         try {
             object.getOutputProtocol().getTransport().open();
         } catch (TTransportException e) {


### PR DESCRIPTION
## Why I'm doing:
`object.getOutputProtocol().getTransport().close()` may throw exception because the socket is already closed.

## What I'm doing:
Ignore the close exception in reopen()

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [x] 3.1
  - [x] 3.0
  - [x] 2.5
