### PR TITLE
[Enhancement] Insert `files()` query progress

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/load/loadv2/InsertLoadJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/loadv2/InsertLoadJob.java
@@ -75,7 +75,7 @@ public class InsertLoadJob extends LoadJob {
 
     @SerializedName("tid")
     private long tableId;
-    private long estimateScanRow;
+    private long estimateScanRow = 0;
     private TLoadJobType loadType;
 
     // only for log replay

--- a/fe/fe-core/src/main/java/com/starrocks/load/loadv2/InsertLoadJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/loadv2/InsertLoadJob.java
@@ -84,8 +84,7 @@ public class InsertLoadJob extends LoadJob {
         this.jobType = EtlJobType.INSERT;
     }
 
-    public InsertLoadJob(String label, long dbId, long tableId, long createTimestamp,
-                         long estimateScanRow, TLoadJobType type, long timeout)
+    public InsertLoadJob(String label, long dbId, long tableId, long createTimestamp, TLoadJobType type, long timeout)
             throws MetaNotFoundException {
         super(dbId, label);
         this.tableId = tableId;
@@ -93,7 +92,6 @@ public class InsertLoadJob extends LoadJob {
         this.loadStartTimestamp = createTimestamp;
         this.state = JobState.LOADING;
         this.jobType = EtlJobType.INSERT;
-        this.estimateScanRow = estimateScanRow;
         this.loadType = type;
         this.timeoutSecond = timeout;
     }
@@ -159,13 +157,20 @@ public class InsertLoadJob extends LoadJob {
             super.updateProgress(params);
             if (!loadingStatus.getLoadStatistic().getLoadFinish()) {
                 if (this.loadType == TLoadJobType.INSERT_QUERY) {
-                    progress = (int) ((double) loadingStatus.getLoadStatistic().totalSourceLoadRows() 
-                        / (estimateScanRow + 1) * 100);
+                    if (loadingStatus.getLoadStatistic().totalFileSizeB != 0) {
+                        // file scan
+                        progress = (int) ((double) loadingStatus.getLoadStatistic().sourceScanBytes() /
+                                loadingStatus.getLoadStatistic().totalFileSize() * 100);
+                    } else {
+                        // table scan
+                        progress = (int) ((double) loadingStatus.getLoadStatistic().totalSourceLoadRows()
+                                / (estimateScanRow + 1) * 100);
+                    }
                 } else {
                     progress = (int) ((double) loadingStatus.getLoadStatistic().totalSinkLoadRows() 
                         / (estimateScanRow + 1) * 100);
                 }
-                
+
                 if (progress >= 100) {
                     progress = 99;
                 }
@@ -248,5 +253,9 @@ public class InsertLoadJob extends LoadJob {
     public void readFields(DataInput in) throws IOException {
         super.readFields(in);
         tableId = in.readLong();
+    }
+
+    public void setEstimateScanRow(long rows) {
+        this.estimateScanRow = rows;
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/load/loadv2/InsertLoadJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/loadv2/InsertLoadJob.java
@@ -158,11 +158,11 @@ public class InsertLoadJob extends LoadJob {
             if (!loadingStatus.getLoadStatistic().getLoadFinish()) {
                 if (this.loadType == TLoadJobType.INSERT_QUERY) {
                     if (loadingStatus.getLoadStatistic().totalFileSizeB != 0) {
-                        // file scan
+                        // progress of file scan
                         progress = (int) ((double) loadingStatus.getLoadStatistic().sourceScanBytes() /
                                 loadingStatus.getLoadStatistic().totalFileSize() * 100);
                     } else {
-                        // table scan
+                        // progress of table scan. Slightly smaller than actual
                         progress = (int) ((double) loadingStatus.getLoadStatistic().totalSourceLoadRows()
                                 / (estimateScanRow + 1) * 100);
                     }

--- a/fe/fe-core/src/main/java/com/starrocks/load/loadv2/LoadMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/loadv2/LoadMgr.java
@@ -230,7 +230,9 @@ public class LoadMgr implements Writable, MemoryTrackable {
     }
 
     public long registerLoadJob(String label, String dbName, long tableId, EtlJobType jobType,
-                                long createTimestamp, long estimateScanRows, TLoadJobType type, long timeout)
+                                long createTimestamp, long estimateScanRows,
+                                int estimateFileNum, long estimateFileSize,
+                                TLoadJobType type, long timeout)
             throws UserException {
 
         // get db id
@@ -239,10 +241,11 @@ public class LoadMgr implements Writable, MemoryTrackable {
             throw new MetaNotFoundException("Database[" + dbName + "] does not exist");
         }
 
-        LoadJob loadJob;
+        InsertLoadJob loadJob;
         if (Objects.requireNonNull(jobType) == EtlJobType.INSERT) {
-            loadJob =
-                    new InsertLoadJob(label, db.getId(), tableId, createTimestamp, estimateScanRows, type, timeout);
+            loadJob = new InsertLoadJob(label, db.getId(), tableId, createTimestamp, type, timeout);
+            loadJob.setLoadFileInfo(estimateFileNum, estimateFileSize);
+            loadJob.setEstimateScanRow(estimateScanRows);
         } else {
             throw new LoadException("Unknown job type [" + jobType.name() + "]");
         }

--- a/fe/fe-core/src/main/java/com/starrocks/planner/FileScanNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/FileScanNode.java
@@ -147,6 +147,7 @@ public class FileScanNode extends LoadScanNode {
     private List<List<TBrokerFileStatus>> fileStatusesList;
     // file num
     private int filesAdded;
+    private long totalBytes = 0;
     
     private List<ComputeNode> nodes;
     private int nextBe = 0;
@@ -505,7 +506,6 @@ public class FileScanNode extends LoadScanNode {
             throw new UserException("No source file in this table(" + targetTable.getName() + ").");
         }
 
-        long totalBytes = 0;
         for (List<TBrokerFileStatus> fileStatuses : fileStatusesList) {
             Collections.sort(fileStatuses, T_BROKER_FILE_STATUS_COMPARATOR);
             for (TBrokerFileStatus fileStatus : fileStatuses) {
@@ -762,5 +762,12 @@ public class FileScanNode extends LoadScanNode {
         return true;
     }
 
+    public long getFileTotalSize() {
+        return totalBytes;
+    }
+
+    public int getFileNum() {
+        return filesAdded;
+    }
 
 }

--- a/fe/fe-core/src/main/java/com/starrocks/qe/StmtExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/StmtExecutor.java
@@ -1947,21 +1947,21 @@ public class StmtExecutor {
 
             List<ScanNode> scanNodes = execPlan.getScanNodes();
 
-            boolean containOlapScanNode = false;
+            boolean needQuery = false;
             for (ScanNode scanNode : scanNodes) {
                 if (scanNode instanceof OlapScanNode) {
                     estimateScanRows += ((OlapScanNode) scanNode).getActualRows();
-                    containOlapScanNode = true;
+                    needQuery = true;
                 }
                 if (scanNode instanceof FileScanNode) {
                     estimateFileNum += ((FileScanNode) scanNode).getFileNum();
                     estimateScanFileSize += ((FileScanNode ) scanNode).getFileTotalSize();
-                    containOlapScanNode = true;
+                    needQuery = true;
                 }
             }
 
             TLoadJobType type;
-            if (containOlapScanNode) {
+            if (needQuery) {
                 coord.setLoadJobType(TLoadJobType.INSERT_QUERY);
                 type = TLoadJobType.INSERT_QUERY;
             } else {


### PR DESCRIPTION
## Why I'm doing:
Now, the progress of `insert into some_tble select * from files(xxx)` is not correct. The progress would always be 99% after the insert begins.
## What I'm doing:
This PR corrects the progress of this scenario.

Fixes https://github.com/StarRocks/starrocks/issues/41824

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
