### PR TITLE
[Enhancement] Add config data_page_size

### DIFF
--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -263,6 +263,9 @@ CONF_Int32(min_file_descriptor_number, "60000");
 CONF_Int64(index_stream_cache_capacity, "10737418240");
 // CONF_Int64(max_packed_row_block_size, "20971520");
 
+// data and index page size, default is 64k
+CONF_Int32(data_page_size, "65536");
+
 // Cache for storage page size
 CONF_mString(storage_page_cache_limit, "20%");
 // whether to disable page cache feature in storage

--- a/be/src/storage/olap_define.h
+++ b/be/src/storage/olap_define.h
@@ -43,9 +43,6 @@
 
 namespace starrocks {
 
-// data and index page size, default is 64k
-static const size_t OLAP_PAGE_SIZE = 65536;
-
 static const uint64_t OLAP_FIX_HEADER_MAGIC_NUMBER = 0;
 
 uint32_t get_olap_string_max_length();

--- a/be/src/storage/rowset/binary_plain_page.h
+++ b/be/src/storage/rowset/binary_plain_page.h
@@ -123,7 +123,7 @@ public:
 
     void reset() override {
         _offsets.clear();
-        _buffer.reserve(_options.data_page_size == 0 ? 65536 : _options.data_page_size);
+        _buffer.reserve(_options.data_page_size == 0 ? config::data_page_size : _options.data_page_size);
         _buffer.resize(_reserved_head_size);
         _next_offset = 0;
         _size_estimate = sizeof(uint32_t);

--- a/be/src/storage/rowset/column_writer.h
+++ b/be/src/storage/rowset/column_writer.h
@@ -64,7 +64,7 @@ struct ColumnWriterOptions {
     // - input: column_id/unique_id/type/length/encoding/compression/is_nullable members
     // - output: encoding/indexes/dict_page members
     ColumnMetaPB* meta;
-    uint32_t data_page_size = OLAP_PAGE_SIZE;
+    uint32_t data_page_size = config::data_page_size;
     uint32_t page_format = 2;
     // store compressed page only when space saving is above the threshold.
     // space saving = 1 - compressed_size / uncompressed_size

--- a/be/src/storage/rowset/indexed_column_writer.h
+++ b/be/src/storage/rowset/indexed_column_writer.h
@@ -59,7 +59,7 @@ class PageBuilder;
 class WritableFile;
 
 struct IndexedColumnWriterOptions {
-    size_t index_page_size = OLAP_PAGE_SIZE;
+    size_t index_page_size = config::data_page_size;
     bool write_ordinal_index = false;
     bool write_value_index = false;
     EncodingTypePB encoding = DEFAULT_ENCODING;


### PR DESCRIPTION
## Why I'm doing:

In some time-series data scenarios, the data of one be will reach the 10T ~ 30T level. The data volume is relatively large and there are few queries. The current be metadata will not be eliminated once loaded. In this scenario, the ordinal index and column zone map will It takes up a lot of memory (10G~100G), so add a configuration here to change the page size, thereby reducing the use of this memory of metadata.

## What I'm doing:

Add one config to set data page size

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [x] 3.1
  - [x] 3.0
  - [x] 2.5
