### PR TITLE
[BugFix] Only merge partition range when mv's ref base table is range partition

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/connector/PartitionUtil.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/PartitionUtil.java
@@ -282,7 +282,7 @@ public class PartitionUtil {
     }
 
     // check the partitionColumn exist in the partitionColumns
-    private static int checkAndGetPartitionColumnIndex(List<Column> partitionColumns, Column partitionColumn)
+    public static int checkAndGetPartitionColumnIndex(List<Column> partitionColumns, Column partitionColumn)
             throws AnalysisException {
         int partitionColumnIndex = -1;
         for (int index = 0; index < partitionColumns.size(); ++index) {

--- a/fe/fe-core/src/main/java/com/starrocks/connector/PartitionUtil.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/PartitionUtil.java
@@ -442,48 +442,50 @@ public class PartitionUtil {
         LinkedHashMap<String, PartitionKey> sortedPartitionLinkMap = mvPartitionKeyMap.entrySet().stream()
                 .sorted(Map.Entry.comparingByValue(PartitionKey::compareTo))
                 .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue, (e1, e2) -> e1, LinkedHashMap::new));
-        int index = 0;
-        PartitionKey lastPartitionKey = null;
-        String lastPartitionName = null;
 
         boolean isConvertToDate = isConvertToDate(partitionExpr, partitionColumn);
         Map<String, Range<PartitionKey>> mvPartitionRangeMap = new LinkedHashMap<>();
-        for (Map.Entry<String, PartitionKey> entry : sortedPartitionLinkMap.entrySet()) {
-            if (index == 0) {
-                lastPartitionName = entry.getKey();
-                lastPartitionKey = entry.getValue();
-                if (lastPartitionKey.getKeys().get(0).isNullable()) {
-                    // If partition key is NULL literal, rewrite it to min value.
-                    lastPartitionKey = PartitionKey.createInfinityPartitionKeyWithType(
-                            ImmutableList.of(partitionColumn.getPrimitiveType()), false);
-                }
-                ++index;
-                continue;
-            }
-            Preconditions.checkState(!mvPartitionRangeMap.containsKey(lastPartitionName));
-            PartitionKey upperBound = entry.getValue();
-            mvPartitionRangeMap.put(lastPartitionName, Range.closedOpen(lastPartitionKey, upperBound));
-            lastPartitionName = entry.getKey();
-            lastPartitionKey = upperBound;
-        }
-        if (lastPartitionName != null) {
-            PartitionKey endKey = new PartitionKey();
-            if (!isConvertToDate) {
-                endKey.pushColumn(addOffsetForLiteral(lastPartitionKey.getKeys().get(0), 1,
-                                getDateTimeInterval(table, partitionColumn)), partitionColumn.getPrimitiveType());
-            } else {
-                PartitionKey lastDate = convertToDate(lastPartitionKey);
-                String lastDateFormat = lastPartitionKey.getKeys().get(0).getStringValue();
-                DateTimeFormatter formatter = DateUtils.probeFormat(lastDateFormat);
-                DateLiteral nextDate = (DateLiteral) addOffsetForLiteral(lastDate.getKeys().get(0), 1,
-                        getDateTimeInterval(table, partitionColumn));
-                LiteralExpr nextStringDate = new StringLiteral(nextDate.toLocalDateTime().format(formatter));
-                endKey.pushColumn(nextStringDate, partitionColumn.getPrimitiveType());
-            }
 
-            putRangeToMvPartitionRangeMap(mvPartitionRangeMap, lastPartitionName, lastPartitionKey, endKey);
+        PrimitiveType partitionColPrimType = partitionColumn.getPrimitiveType();
+        DateTimeInterval partitionDateTimeInterval = getDateTimeInterval(table, partitionColumn);
+
+        // NOTE: For external table, convert partition values to partition ranges just like list partition.
+        // Each partition's lower bound is the partition value itself, and the upper bound is the next partition value.
+        // This is more robust, and it's better to handle the case where the partition value is not continuous.
+        for (Map.Entry<String, PartitionKey> entry : sortedPartitionLinkMap.entrySet()) {
+            String partitionKeyName = entry.getKey();
+            PartitionKey lowerBound = entry.getValue();
+            if (lowerBound.getKeys().get(0).isNullable()) {
+                // If partition key is NULL literal, rewrite it to min value.
+                lowerBound = PartitionKey.createInfinityPartitionKeyWithType(
+                        ImmutableList.of(partitionColumn.getPrimitiveType()), false);
+            }
+            Preconditions.checkState(!mvPartitionRangeMap.containsKey(partitionKeyName));
+            PartitionKey upperBound = nextPartitionKey(lowerBound, partitionDateTimeInterval, partitionColPrimType,
+                    isConvertToDate);
+            mvPartitionRangeMap.put(partitionKeyName, Range.closedOpen(lowerBound, upperBound));
         }
         return mvPartitionRangeMap;
+    }
+
+    public static PartitionKey nextPartitionKey(PartitionKey lastPartitionKey,
+                                                DateTimeInterval dateTimeInterval,
+                                                PrimitiveType partitionColPrimType,
+                                                boolean isStringConvertToDate) throws AnalysisException {
+        LiteralExpr literalExpr;
+        if (isStringConvertToDate) {
+            PartitionKey lastDate = convertToDate(lastPartitionKey);
+            String lastDateFormat = lastPartitionKey.getKeys().get(0).getStringValue();
+            DateTimeFormatter formatter = DateUtils.probeFormat(lastDateFormat);
+            DateLiteral nextDate = (DateLiteral) addOffsetForLiteral(lastDate.getKeys().get(0), 1,
+                    dateTimeInterval);
+            literalExpr = new StringLiteral(nextDate.toLocalDateTime().format(formatter));
+        } else {
+            literalExpr = addOffsetForLiteral(lastPartitionKey.getKeys().get(0), 1, dateTimeInterval);
+        }
+        PartitionKey partitionKey = new PartitionKey();
+        partitionKey.pushColumn(literalExpr, partitionColPrimType);
+        return partitionKey;
     }
 
     /**

--- a/fe/fe-core/src/main/java/com/starrocks/sql/common/QueryDebugOptions.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/common/QueryDebugOptions.java
@@ -29,7 +29,7 @@ public class QueryDebugOptions {
     private int maxRefreshMaterializedViewRetryNum = 1;
 
     @SerializedName(value = "enableMVEagerUnionAllRewrite")
-    private boolean enableMVEagerUnionAllRewrite = false;
+    private boolean enableMVEagerUnionAllRewrite = true;
 
     @SerializedName(value = "enableQueryTraceLog")
     private boolean enableQueryTraceLog = false;

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/MaterializationContext.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/MaterializationContext.java
@@ -431,7 +431,7 @@ public class MaterializationContext {
             MvPartitionCompensator.PCType pcType = isNeedCompensate ?
                     deducePartitionCompensateType(queryExpression, this) :
                     MvPartitionCompensator.PCType.NO_COMPENSATE;
-            logMVRewrite(mv.getName(), "deduce partition compensate type: {}", pcType);
+            logMVRewrite(mv.getName(), "Deduce partition compensate type: {}", pcType);
             mvPCompensateTypeOpt = Optional.of(pcType);
         }
         return mvPCompensateTypeOpt.get();

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MaterializedViewRewriter.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MaterializedViewRewriter.java
@@ -1739,6 +1739,7 @@ public class MaterializedViewRewriter {
         //                                       /      \
         //                                  EXTRA-OP    MV-SCAN
         setAppliedUnionAllRewrite(queryInput.getOp());
+        setAppliedUnionAllRewrite(viewInput.getOp());
 
         // createUnion will return the union all result of queryInput and viewInput
         //           Union

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MaterializedViewRewriter.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MaterializedViewRewriter.java
@@ -1587,11 +1587,9 @@ public class MaterializedViewRewriter {
         // use union-all rewrite eagerly if union-all rewrite can be used.
         QueryDebugOptions debugOptions  = optimizerContext.getSessionVariable().getQueryDebugOptions();
         // To support more union all rewrite cases, we can pull up query's predicates to make possible for union rewrite.
-        // But if partitions are not pruned, rewritten plan may scan all mv partitions, which is not efficient, so only enable
-        // this when query's partitions have been pruned.
-        // eg:
-        // mv: SELECT dt,sum(num) FROM t2 GROUP BY dt;
-        // mv: SELECT dt,sum(num) FROM t2 GROUP BY dt;
+        // But rewritten plan may scan all mv partitions when:
+        //  - mv has no partitions which query's plan to scan: PCType.NO_REWRITE
+        //  - query's partitions have been pruned(we cannot decide whether to pull up or not): PCType.NO_PRUNED_COMPENSATE
         boolean isUnionAllRewriteWithPullUp = materializationContext.canUnionAllRewriteWithPullUpPredicates();
         ColumnRefSet queryOutputColumnRefs = debugOptions.isEnableMVEagerUnionAllRewrite() && isUnionAllRewriteWithPullUp ?
                 rewriteContext.getQueryExpression().getOutputColumns() : null;

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MaterializedViewRewriter.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MaterializedViewRewriter.java
@@ -96,6 +96,7 @@ import java.util.Set;
 import java.util.stream.Collectors;
 
 import static com.starrocks.sql.optimizer.OptimizerTraceUtil.logMVRewrite;
+import static com.starrocks.sql.optimizer.rule.transformation.materialization.MvUtils.setAppliedUnionAllRewrite;
 
 /*
  * SPJG materialized view rewriter, based on
@@ -111,7 +112,6 @@ public class MaterializedViewRewriter {
     protected final OptimizerContext optimizerContext;
     // Mark whether query's plan is rewritten by materialized view.
     public static final String REWRITE_SUCCESS = "Rewrite Succeed";
-    public static final int OP_UNION_ALL_BIT = 1 << 0;
 
     private static final Map<JoinOperator, List<JoinOperator>> JOIN_COMPATIBLE_MAP =
             ImmutableMap.<JoinOperator, List<JoinOperator>>builder()
@@ -1551,10 +1551,6 @@ public class MaterializedViewRewriter {
                 });
     }
 
-    private static void setAppliedUnionAllRewrite(Operator op) {
-        int opRuleMask = op.getOpRuleMask() | OP_UNION_ALL_BIT;
-        op.setOpRuleMask(opRuleMask);
-    }
 
     private PredicateSplit getUnionRewriteQueryCompensation(RewriteContext rewriteContext,
                                                             ColumnRewriter columnRewriter) {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvUtils.java
@@ -918,6 +918,24 @@ public class MvUtils {
         return listPart;
     }
 
+    /**
+     * Determine whether to the base table is range partitioned.
+     * @param refBaseTable: ref base table of the materialized view
+     * @return: true if the ref base table is range partitioned, otherwise false.
+     */
+    public static boolean isListPartition(Table refBaseTable) {
+        Preconditions.checkState(refBaseTable != null);
+        if (refBaseTable.isUnPartitioned()) {
+            return false;
+        }
+        if (refBaseTable.isNativeTableOrMaterializedView()) {
+            OlapTable olapTable = (OlapTable) refBaseTable;
+            return olapTable.getPartitionInfo().isListPartition();
+        } else {
+            return true;
+        }
+    }
+
     public static List<Range<PartitionKey>> mergeRanges(List<Range<PartitionKey>> ranges) {
         ranges.sort(RangeUtils.RANGE_COMPARATOR);
         List<Range<PartitionKey>> mergedRanges = Lists.newArrayList();

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvUtils.java
@@ -109,6 +109,8 @@ import static com.starrocks.sql.optimizer.OptimizerTraceUtil.logMVPrepare;
 public class MvUtils {
     private static final Logger LOG = LogManager.getLogger(MvUtils.class);
 
+    public static final int OP_UNION_ALL_BIT = 1 << 0;
+
     public static Set<MaterializedView> getRelatedMvs(ConnectContext connectContext,
                                                       int maxLevel,
                                                       Set<Table> tablesToCheck) {
@@ -1200,5 +1202,15 @@ public class MvUtils {
         builder.withOperator(logicalTree.getOp());
         Operator newOp = builder.build();
         return OptExpression.create(newOp, inputs);
+    }
+
+    public static void setAppliedUnionAllRewrite(Operator op) {
+        int opRuleMask = op.getOpRuleMask() | OP_UNION_ALL_BIT;
+        op.setOpRuleMask(opRuleMask);
+    }
+
+    public static boolean isAppliedUnionAllRewrite(Operator op) {
+        int opRuleMask = op.getOpRuleMask();
+        return (opRuleMask & OP_UNION_ALL_BIT) != 0;
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/rule/AggregateJoinRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/rule/AggregateJoinRule.java
@@ -25,6 +25,8 @@ import com.starrocks.sql.optimizer.rule.transformation.materialization.Aggregate
 import com.starrocks.sql.optimizer.rule.transformation.materialization.MaterializedViewRewriter;
 import com.starrocks.sql.optimizer.rule.transformation.materialization.MvUtils;
 
+import static com.starrocks.sql.optimizer.rule.transformation.materialization.MvUtils.isAppliedUnionAllRewrite;
+
 /*
  *
  * Here is the rule for pattern Aggregate-Join

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/rule/AggregateJoinRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/rule/AggregateJoinRule.java
@@ -44,6 +44,10 @@ public class AggregateJoinRule extends BaseMaterializedViewRewriteRule {
 
     @Override
     public boolean check(OptExpression input, OptimizerContext context) {
+        // To avoid dead-loop rewrite, no rewrite when query extra predicate is not changed
+        if (isAppliedUnionAllRewrite(input.getOp())) {
+            return false;
+        }
         if (!MvUtils.isLogicalSPJG(input)) {
             return false;
         }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/rule/AggregateScanRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/rule/AggregateScanRule.java
@@ -44,6 +44,10 @@ public class AggregateScanRule extends BaseMaterializedViewRewriteRule {
 
     @Override
     public boolean check(OptExpression input, OptimizerContext context) {
+        // To avoid dead-loop rewrite, no rewrite when query extra predicate is not changed
+        if (isAppliedUnionAllRewrite(input.getOp())) {
+            return false;
+        }
         if (!MvUtils.isLogicalSPJG(input)) {
             return false;
         }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/rule/AggregateScanRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/rule/AggregateScanRule.java
@@ -25,6 +25,8 @@ import com.starrocks.sql.optimizer.rule.transformation.materialization.Aggregate
 import com.starrocks.sql.optimizer.rule.transformation.materialization.MaterializedViewRewriter;
 import com.starrocks.sql.optimizer.rule.transformation.materialization.MvUtils;
 
+import static com.starrocks.sql.optimizer.rule.transformation.materialization.MvUtils.isAppliedUnionAllRewrite;
+
 /**
  * Materialized View Rewrite Rule for pattern:
  * - Aggregate

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/rule/BaseMaterializedViewRewriteRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/rule/BaseMaterializedViewRewriteRule.java
@@ -54,7 +54,7 @@ import java.util.stream.Collectors;
 
 import static com.starrocks.metric.MaterializedViewMetricsEntity.isUpdateMaterializedViewMetrics;
 import static com.starrocks.sql.optimizer.OptimizerTraceUtil.logMVRewrite;
-import static com.starrocks.sql.optimizer.rule.transformation.materialization.MaterializedViewRewriter.OP_UNION_ALL_BIT;
+import static com.starrocks.sql.optimizer.rule.transformation.materialization.MvUtils.isAppliedUnionAllRewrite;
 
 public abstract class BaseMaterializedViewRewriteRule extends TransformationRule {
 
@@ -79,11 +79,6 @@ public abstract class BaseMaterializedViewRewriteRule extends TransformationRule
             return true;
         }
         return input.getInputs().stream().allMatch(this::checkOlapScanWithoutTabletOrPartitionHints);
-    }
-
-    protected boolean isAppliedUnionAllRewrite(Operator op) {
-        int opRuleMask = op.getOpRuleMask();
-        return (opRuleMask & OP_UNION_ALL_BIT) != 0;
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/rule/BaseMaterializedViewRewriteRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/rule/BaseMaterializedViewRewriteRule.java
@@ -81,7 +81,7 @@ public abstract class BaseMaterializedViewRewriteRule extends TransformationRule
         return input.getInputs().stream().allMatch(this::checkOlapScanWithoutTabletOrPartitionHints);
     }
 
-    private boolean isAppliedUnionAllRewrite(Operator op) {
+    protected boolean isAppliedUnionAllRewrite(Operator op) {
         int opRuleMask = op.getOpRuleMask();
         return (opRuleMask & OP_UNION_ALL_BIT) != 0;
     }

--- a/test/sql/test_materialized_view/R/test_mv_partition_compensate_hive
+++ b/test/sql/test_materialized_view/R/test_mv_partition_compensate_hive
@@ -6,348 +6,1624 @@ properties
     "hive.catalog.type" = "hive",
     "hive.metastore.uris" = "${hive_metastore_uris}"
 );
-
-
--- create hive table
+-- result:
+-- !result
 set catalog mv_hive_${uuid0};
+-- result:
+-- !result
 create database mv_hive_db_${uuid0};
+-- result:
+-- !result
 use mv_hive_db_${uuid0};
-
+-- result:
+-- !result
 CREATE TABLE t1 (
   num int,
   dt date
 )
 PARTITION BY (dt);
+-- result:
+-- !result
 INSERT INTO t1 VALUES 
   (1,"2020-06-15"),(2,"2020-06-18"),(3,"2020-06-21"),(4,"2020-06-24"),
   (1,"2020-07-02"),(2,"2020-07-05"),(3,"2020-07-08"),(4,"2020-07-11"),
   (1,"2020-07-16"),(2,"2020-07-19"),(3,"2020-07-22"),(4,"2020-07-25"),
   (2,"2020-06-15"),(3,"2020-06-18"),(4,"2020-06-21"),(5,"2020-06-24"),
   (2,"2020-07-02"),(3,"2020-07-05"),(4,"2020-07-08"),(5,"2020-07-11");
-
+-- result:
+-- !result
 CREATE TABLE t2 (
   num int,
   dt string
 )
 PARTITION BY (dt);
+-- result:
+-- !result
 INSERT INTO t2 VALUES 
   (1,"2020-06-15"),(2,"2020-06-18"),(3,"2020-06-21"),(4,"2020-06-24"),
   (1,"2020-07-02"),(2,"2020-07-05"),(3,"2020-07-08"),(4,"2020-07-11"),
   (1,"2020-07-16"),(2,"2020-07-19"),(3,"2020-07-22"),(4,"2020-07-25"),
   (2,"2020-06-15"),(3,"2020-06-18"),(4,"2020-06-21"),(5,"2020-06-24"),
   (2,"2020-07-02"),(3,"2020-07-05"),(4,"2020-07-08"),(5,"2020-07-11");
-
--- create mv
+-- result:
+-- !result
 set catalog default_catalog;
+-- result:
+-- !result
 create database db_${uuid0};
+-- result:
+-- !result
 use db_${uuid0};
-
-
--- Test partition compensate without partition expression
+-- result:
+-- !result
 CREATE MATERIALIZED VIEW test_mv1 
 PARTITION BY dt 
 REFRESH DEFERRED MANUAL AS 
   SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 GROUP BY dt;
-
+-- result:
+-- !result
 REFRESH MATERIALIZED VIEW test_mv1 WITH SYNC MODE;
-
 function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 where dt='2020-06-15' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
 function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 where dt !='2020-06-15' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
 function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 where dt>='2020-06-15' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
 function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 where dt>'2020-06-15' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
 function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 where dt>'2020-06-15' and dt < '2020-07-22' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
 function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 where dt>'2020-06-15' and dt <= '2020-07-22' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
 function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 where (dt>'2020-06-15' and dt <= '2020-06-22') or dt>'2020-07-01' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
 function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 where dt in ('2020-06-15', '2020-06-22', '2020-07-01') GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
 function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 where date_trunc('day', dt) ='2020-06-15' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
 function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 where date_trunc('month', dt) ='2020-06-01' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
 function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 where date_trunc('month', dt) ='2020-07-01' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
 function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 GROUP BY dt;", "test_mv1")
-
+-- result:
+None
+-- !result
 SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 where dt='2020-06-15' GROUP BY dt order by dt;
+-- result:
+2020-06-15	3
+-- !result
 SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 where dt !='2020-06-15' GROUP BY dt order by dt;
+-- result:
+2020-06-18	5
+2020-06-21	7
+2020-06-24	9
+2020-07-02	3
+2020-07-05	5
+2020-07-08	7
+2020-07-11	9
+2020-07-16	1
+2020-07-19	2
+2020-07-22	3
+2020-07-25	4
+-- !result
 SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 where dt>='2020-06-15' GROUP BY dt order by dt;
+-- result:
+2020-06-15	3
+2020-06-18	5
+2020-06-21	7
+2020-06-24	9
+2020-07-02	3
+2020-07-05	5
+2020-07-08	7
+2020-07-11	9
+2020-07-16	1
+2020-07-19	2
+2020-07-22	3
+2020-07-25	4
+-- !result
 SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 where dt>'2020-06-15' GROUP BY dt order by dt;
+-- result:
+2020-06-18	5
+2020-06-21	7
+2020-06-24	9
+2020-07-02	3
+2020-07-05	5
+2020-07-08	7
+2020-07-11	9
+2020-07-16	1
+2020-07-19	2
+2020-07-22	3
+2020-07-25	4
+-- !result
 SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 where dt>'2020-06-15' and dt < '2020-07-22' GROUP BY dt order by dt;
+-- result:
+2020-06-18	5
+2020-06-21	7
+2020-06-24	9
+2020-07-02	3
+2020-07-05	5
+2020-07-08	7
+2020-07-11	9
+2020-07-16	1
+2020-07-19	2
+-- !result
 SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 where dt>'2020-06-15' and dt <= '2020-07-22' GROUP BY dt order by dt;
+-- result:
+2020-06-18	5
+2020-06-21	7
+2020-06-24	9
+2020-07-02	3
+2020-07-05	5
+2020-07-08	7
+2020-07-11	9
+2020-07-16	1
+2020-07-19	2
+2020-07-22	3
+-- !result
 SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 where (dt>'2020-06-15' and dt <= '2020-06-22') or dt>'2020-07-01' GROUP BY dt order by dt;
+-- result:
+2020-06-18	5
+2020-06-21	7
+2020-07-02	3
+2020-07-05	5
+2020-07-08	7
+2020-07-11	9
+2020-07-16	1
+2020-07-19	2
+2020-07-22	3
+2020-07-25	4
+-- !result
 SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 where dt in ('2020-06-15', '2020-06-22', '2020-07-01') GROUP BY dt order by dt;
+-- result:
+2020-06-15	3
+-- !result
 SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 where date_trunc('day', dt) ='2020-06-15' GROUP BY dt order by dt;
+-- result:
+2020-06-15	3
+-- !result
 SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 where date_trunc('month', dt) ='2020-06-01' GROUP BY dt order by dt;
+-- result:
+2020-06-15	3
+2020-06-18	5
+2020-06-21	7
+2020-06-24	9
+-- !result
 SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 where date_trunc('month', dt) ='2020-07-01' GROUP BY dt order by dt;
+-- result:
+2020-07-02	3
+2020-07-05	5
+2020-07-08	7
+2020-07-11	9
+2020-07-16	1
+2020-07-19	2
+2020-07-22	3
+2020-07-25	4
+-- !result
 SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 GROUP BY dt order by dt;
-
--- union rewrite
+-- result:
+2020-06-15	3
+2020-06-18	5
+2020-06-21	7
+2020-06-24	9
+2020-07-02	3
+2020-07-05	5
+2020-07-08	7
+2020-07-11	9
+2020-07-16	1
+2020-07-19	2
+2020-07-22	3
+2020-07-25	4
+-- !result
 INSERT INTO mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 VALUES (3, "2020-06-15");
+-- result:
+-- !result
 function: check_no_hit_materialized_view("SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 where dt='2020-06-15' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
 function: check_no_hit_materialized_view("SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 where date_trunc('day', dt) ='2020-06-15' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
 function: check_no_hit_materialized_view("SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 where dt in ('2020-06-15', '2020-06-22', '2020-07-01') GROUP BY dt;", "test_mv1")
-
+-- result:
+None
+-- !result
 function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 where date_trunc('day', dt) ='2020-06-21' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
 function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 where dt !='2020-06-15' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
 function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 where dt>'2020-06-15' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
 function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 where dt>'2020-06-15' and dt < '2020-07-22' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
 function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 where dt>'2020-06-15' and dt <= '2020-07-22' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
 function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 where (dt>'2020-06-15' and dt <= '2020-06-22') or dt>'2020-07-01' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
 function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 where dt in ('2020-06-21', '2020-07-25') GROUP BY dt;", "test_mv1")
--- cannot partition prune
+-- result:
+None
+-- !result
 function: check_no_hit_materialized_view("SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 where date_trunc('month', dt) ='2020-07-01' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
 function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 where dt between '2020-06-16' and '2020-07-01' GROUP BY dt;", "test_mv1")
-
+-- result:
+None
+-- !result
 function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 where dt between '2020-06-15' and '2020-07-01' GROUP BY dt;", "test_mv1", "UNION")
+-- result:
+None
+-- !result
 function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 where dt>='2020-06-15' GROUP BY dt;", "test_mv1", "UNION")
+-- result:
+None
+-- !result
 function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 where dt in ('2020-06-15', '2020-06-21', '2020-07-25') GROUP BY dt;", "test_mv1", "UNION")
--- cannot partition prune
+-- result:
+None
+-- !result
 function: check_no_hit_materialized_view("SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 where date_trunc('month', dt) ='2020-06-01' GROUP BY dt;", "test_mv1", "UNION")
+-- result:
+None
+-- !result
 function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 GROUP BY dt;", "test_mv1", "UNION")
-
+-- result:
+None
+-- !result
 SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 where dt='2020-06-15' GROUP BY dt order by dt;
+-- result:
+2020-06-15	6
+-- !result
 SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 where dt !='2020-06-15' GROUP BY dt order by dt;
+-- result:
+2020-06-18	5
+2020-06-21	7
+2020-06-24	9
+2020-07-02	3
+2020-07-05	5
+2020-07-08	7
+2020-07-11	9
+2020-07-16	1
+2020-07-19	2
+2020-07-22	3
+2020-07-25	4
+-- !result
 SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 where dt>='2020-06-15' GROUP BY dt order by dt;
+-- result:
+2020-06-15	6
+2020-06-18	5
+2020-06-21	7
+2020-06-24	9
+2020-07-02	3
+2020-07-05	5
+2020-07-08	7
+2020-07-11	9
+2020-07-16	1
+2020-07-19	2
+2020-07-22	3
+2020-07-25	4
+-- !result
 SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 where dt>'2020-06-15' GROUP BY dt order by dt;
+-- result:
+2020-06-18	5
+2020-06-21	7
+2020-06-24	9
+2020-07-02	3
+2020-07-05	5
+2020-07-08	7
+2020-07-11	9
+2020-07-16	1
+2020-07-19	2
+2020-07-22	3
+2020-07-25	4
+-- !result
 SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 where dt>'2020-06-15' and dt < '2020-07-22' GROUP BY dt order by dt;
+-- result:
+2020-06-18	5
+2020-06-21	7
+2020-06-24	9
+2020-07-02	3
+2020-07-05	5
+2020-07-08	7
+2020-07-11	9
+2020-07-16	1
+2020-07-19	2
+-- !result
 SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 where dt>'2020-06-15' and dt <= '2020-07-22' GROUP BY dt order by dt;
+-- result:
+2020-06-18	5
+2020-06-21	7
+2020-06-24	9
+2020-07-02	3
+2020-07-05	5
+2020-07-08	7
+2020-07-11	9
+2020-07-16	1
+2020-07-19	2
+2020-07-22	3
+-- !result
 SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 where (dt>'2020-06-15' and dt <= '2020-06-22') or dt>'2020-07-01' GROUP BY dt order by dt;
+-- result:
+2020-06-18	5
+2020-06-21	7
+2020-07-02	3
+2020-07-05	5
+2020-07-08	7
+2020-07-11	9
+2020-07-16	1
+2020-07-19	2
+2020-07-22	3
+2020-07-25	4
+-- !result
 SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 where dt in ('2020-06-22', '2020-07-01') GROUP BY dt order by dt;
+-- result:
+-- !result
 SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 where dt in ('2020-06-15', '2020-06-22', '2020-07-01') GROUP BY dt order by dt;
+-- result:
+2020-06-15	6
+-- !result
 SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 where dt between '2020-06-15' and '2020-07-01' GROUP BY dt order by dt;
+-- result:
+2020-06-15	6
+2020-06-18	5
+2020-06-21	7
+2020-06-24	9
+-- !result
 SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 where date_trunc('day', dt) ='2020-06-15' GROUP BY dt order by dt;
+-- result:
+2020-06-15	6
+-- !result
 SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 where date_trunc('month', dt) ='2020-06-01' GROUP BY dt order by dt;
+-- result:
+2020-06-15	6
+2020-06-18	5
+2020-06-21	7
+2020-06-24	9
+-- !result
 SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 where date_trunc('month', dt) ='2020-07-01' GROUP BY dt order by dt;
+-- result:
+2020-07-02	3
+2020-07-05	5
+2020-07-08	7
+2020-07-11	9
+2020-07-16	1
+2020-07-19	2
+2020-07-22	3
+2020-07-25	4
+-- !result
 SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 GROUP BY dt order by dt;
-
-
+-- result:
+2020-06-15	6
+2020-06-18	5
+2020-06-21	7
+2020-06-24	9
+2020-07-02	3
+2020-07-05	5
+2020-07-08	7
+2020-07-11	9
+2020-07-16	1
+2020-07-19	2
+2020-07-22	3
+2020-07-25	4
+-- !result
 drop materialized view default_catalog.db_${uuid0}.test_mv1;
-
--- Test partition compensate with partition expression
+-- result:
+-- !result
 CREATE MATERIALIZED VIEW test_mv1 
 PARTITION BY date_trunc('day', dt)
 REFRESH DEFERRED MANUAL AS 
   SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 GROUP BY dt;
+-- result:
+-- !result
 REFRESH MATERIALIZED VIEW test_mv1 WITH SYNC MODE;
-
 function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 where dt='2020-06-15' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
 function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 where dt !='2020-06-15' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
 function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 where dt>='2020-06-15' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
 function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 where dt>'2020-06-15' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
 function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 where dt>'2020-06-15' and dt < '2020-07-22' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
 function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 where dt>'2020-06-15' and dt <= '2020-07-22' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
 function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 where (dt>'2020-06-15' and dt <= '2020-06-22') or dt>'2020-07-01' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
 function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 where dt in ('2020-06-15', '2020-06-22', '2020-07-01') GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
 function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 where date_trunc('day', dt) ='2020-06-15' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
 function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 where date_trunc('month', dt) ='2020-06-01' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
 function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 where date_trunc('month', dt) ='2020-07-01' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
 function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 GROUP BY dt;", "test_mv1")
-
+-- result:
+None
+-- !result
 SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 where dt='2020-06-15' GROUP BY dt order by dt;
+-- result:
+2020-06-15	6
+-- !result
 SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 where dt !='2020-06-15' GROUP BY dt order by dt;
+-- result:
+2020-06-18	5
+2020-06-21	7
+2020-06-24	9
+2020-07-02	3
+2020-07-05	5
+2020-07-08	7
+2020-07-11	9
+2020-07-16	1
+2020-07-19	2
+2020-07-22	3
+2020-07-25	4
+-- !result
 SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 where dt>='2020-06-15' GROUP BY dt order by dt;
+-- result:
+2020-06-15	6
+2020-06-18	5
+2020-06-21	7
+2020-06-24	9
+2020-07-02	3
+2020-07-05	5
+2020-07-08	7
+2020-07-11	9
+2020-07-16	1
+2020-07-19	2
+2020-07-22	3
+2020-07-25	4
+-- !result
 SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 where dt>'2020-06-15' GROUP BY dt order by dt;
+-- result:
+2020-06-18	5
+2020-06-21	7
+2020-06-24	9
+2020-07-02	3
+2020-07-05	5
+2020-07-08	7
+2020-07-11	9
+2020-07-16	1
+2020-07-19	2
+2020-07-22	3
+2020-07-25	4
+-- !result
 SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 where dt>'2020-06-15' and dt < '2020-07-22' GROUP BY dt order by dt;
+-- result:
+2020-06-18	5
+2020-06-21	7
+2020-06-24	9
+2020-07-02	3
+2020-07-05	5
+2020-07-08	7
+2020-07-11	9
+2020-07-16	1
+2020-07-19	2
+-- !result
 SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 where dt>'2020-06-15' and dt <= '2020-07-22' GROUP BY dt order by dt;
+-- result:
+2020-06-18	5
+2020-06-21	7
+2020-06-24	9
+2020-07-02	3
+2020-07-05	5
+2020-07-08	7
+2020-07-11	9
+2020-07-16	1
+2020-07-19	2
+2020-07-22	3
+-- !result
 SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 where (dt>'2020-06-15' and dt <= '2020-06-22') or dt>'2020-07-01' GROUP BY dt order by dt;
+-- result:
+2020-06-18	5
+2020-06-21	7
+2020-07-02	3
+2020-07-05	5
+2020-07-08	7
+2020-07-11	9
+2020-07-16	1
+2020-07-19	2
+2020-07-22	3
+2020-07-25	4
+-- !result
 SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 where dt in ('2020-06-15', '2020-06-22', '2020-07-01') GROUP BY dt order by dt;
+-- result:
+2020-06-15	6
+-- !result
 SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 where date_trunc('day', dt) ='2020-06-15' GROUP BY dt order by dt;
+-- result:
+2020-06-15	6
+-- !result
 SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 where date_trunc('month', dt) ='2020-06-01' GROUP BY dt order by dt;
+-- result:
+2020-06-15	6
+2020-06-18	5
+2020-06-21	7
+2020-06-24	9
+-- !result
 SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 where date_trunc('month', dt) ='2020-07-01' GROUP BY dt order by dt;
+-- result:
+2020-07-02	3
+2020-07-05	5
+2020-07-08	7
+2020-07-11	9
+2020-07-16	1
+2020-07-19	2
+2020-07-22	3
+2020-07-25	4
+-- !result
 SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 GROUP BY dt order by dt;
-
--- union rewrite
+-- result:
+2020-06-15	6
+2020-06-18	5
+2020-06-21	7
+2020-06-24	9
+2020-07-02	3
+2020-07-05	5
+2020-07-08	7
+2020-07-11	9
+2020-07-16	1
+2020-07-19	2
+2020-07-22	3
+2020-07-25	4
+-- !result
 INSERT INTO mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 VALUES (3, "2020-06-15");
+-- result:
+-- !result
 function: check_no_hit_materialized_view("SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 where dt='2020-06-15' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
 function: check_no_hit_materialized_view("SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 where date_trunc('day', dt) ='2020-06-15' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
 function: check_no_hit_materialized_view("SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 where dt in ('2020-06-15', '2020-06-22', '2020-07-01') GROUP BY dt;", "test_mv1")
-
+-- result:
+None
+-- !result
 function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 where date_trunc('day', dt) ='2020-06-21' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
 function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 where dt !='2020-06-15' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
 function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 where dt>'2020-06-15' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
 function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 where dt>'2020-06-15' and dt < '2020-07-22' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
 function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 where dt>'2020-06-15' and dt <= '2020-07-22' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
 function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 where (dt>'2020-06-15' and dt <= '2020-06-22') or dt>'2020-07-01' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
 function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 where dt in ('2020-06-21', '2020-07-25') GROUP BY dt;", "test_mv1")
--- cannot partition prune
+-- result:
+None
+-- !result
 function: check_no_hit_materialized_view("SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 where date_trunc('month', dt) ='2020-07-01' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
 function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 where dt between '2020-06-16' and '2020-07-01' GROUP BY dt;", "test_mv1")
-
+-- result:
+None
+-- !result
 function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 where dt between '2020-06-15' and '2020-07-01' GROUP BY dt;", "test_mv1", "UNION")
+-- result:
+None
+-- !result
 function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 where dt>='2020-06-15' GROUP BY dt;", "test_mv1", "UNION")
+-- result:
+None
+-- !result
 function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 where dt in ('2020-06-15', '2020-06-21', '2020-07-25') GROUP BY dt;", "test_mv1", "UNION")
--- cannot partition prune
+-- result:
+None
+-- !result
 function: check_no_hit_materialized_view("SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 where date_trunc('month', dt) ='2020-06-01' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
 function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 GROUP BY dt;", "test_mv1", "UNION")
-
+-- result:
+None
+-- !result
 SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 where dt='2020-06-15' GROUP BY dt order by dt;
+-- result:
+2020-06-15	9
+-- !result
 SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 where dt !='2020-06-15' GROUP BY dt order by dt;
+-- result:
+2020-06-18	5
+2020-06-21	7
+2020-06-24	9
+2020-07-02	3
+2020-07-05	5
+2020-07-08	7
+2020-07-11	9
+2020-07-16	1
+2020-07-19	2
+2020-07-22	3
+2020-07-25	4
+-- !result
 SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 where dt>='2020-06-15' GROUP BY dt order by dt;
+-- result:
+2020-06-15	9
+2020-06-18	5
+2020-06-21	7
+2020-06-24	9
+2020-07-02	3
+2020-07-05	5
+2020-07-08	7
+2020-07-11	9
+2020-07-16	1
+2020-07-19	2
+2020-07-22	3
+2020-07-25	4
+-- !result
 SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 where dt>'2020-06-15' GROUP BY dt order by dt;
+-- result:
+2020-06-18	5
+2020-06-21	7
+2020-06-24	9
+2020-07-02	3
+2020-07-05	5
+2020-07-08	7
+2020-07-11	9
+2020-07-16	1
+2020-07-19	2
+2020-07-22	3
+2020-07-25	4
+-- !result
 SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 where dt>'2020-06-15' and dt < '2020-07-22' GROUP BY dt order by dt;
+-- result:
+2020-06-18	5
+2020-06-21	7
+2020-06-24	9
+2020-07-02	3
+2020-07-05	5
+2020-07-08	7
+2020-07-11	9
+2020-07-16	1
+2020-07-19	2
+-- !result
 SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 where dt>'2020-06-15' and dt <= '2020-07-22' GROUP BY dt order by dt;
+-- result:
+2020-06-18	5
+2020-06-21	7
+2020-06-24	9
+2020-07-02	3
+2020-07-05	5
+2020-07-08	7
+2020-07-11	9
+2020-07-16	1
+2020-07-19	2
+2020-07-22	3
+-- !result
 SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 where (dt>'2020-06-15' and dt <= '2020-06-22') or dt>'2020-07-01' GROUP BY dt order by dt;
+-- result:
+2020-06-18	5
+2020-06-21	7
+2020-07-02	3
+2020-07-05	5
+2020-07-08	7
+2020-07-11	9
+2020-07-16	1
+2020-07-19	2
+2020-07-22	3
+2020-07-25	4
+-- !result
 SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 where dt in ('2020-06-22', '2020-07-01') GROUP BY dt order by dt;
+-- result:
+-- !result
 SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 where dt in ('2020-06-15', '2020-06-22', '2020-07-01') GROUP BY dt order by dt;
+-- result:
+2020-06-15	9
+-- !result
 SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 where dt between '2020-06-15' and '2020-07-01' GROUP BY dt order by dt;
+-- result:
+2020-06-15	9
+2020-06-18	5
+2020-06-21	7
+2020-06-24	9
+-- !result
 SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 where date_trunc('day', dt) ='2020-06-15' GROUP BY dt order by dt;
+-- result:
+2020-06-15	9
+-- !result
 SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 where date_trunc('month', dt) ='2020-06-01' GROUP BY dt order by dt;
+-- result:
+2020-06-15	9
+2020-06-18	5
+2020-06-21	7
+2020-06-24	9
+-- !result
 SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 where date_trunc('month', dt) ='2020-07-01' GROUP BY dt order by dt;
+-- result:
+2020-07-02	3
+2020-07-05	5
+2020-07-08	7
+2020-07-11	9
+2020-07-16	1
+2020-07-19	2
+2020-07-22	3
+2020-07-25	4
+-- !result
 SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 GROUP BY dt order by dt;
-
+-- result:
+2020-06-15	9
+2020-06-18	5
+2020-06-21	7
+2020-06-24	9
+2020-07-02	3
+2020-07-05	5
+2020-07-08	7
+2020-07-11	9
+2020-07-16	1
+2020-07-19	2
+2020-07-22	3
+2020-07-25	4
+-- !result
 drop materialized view default_catalog.db_${uuid0}.test_mv1;
-
-
-
--- Test partition compensate without partition expression
+-- result:
+-- !result
 CREATE MATERIALIZED VIEW test_mv1 
 PARTITION BY str2date(dt, '%Y-%m-%d')
 REFRESH DEFERRED MANUAL AS 
   SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t2 GROUP BY dt;
-
+-- result:
+-- !result
 REFRESH MATERIALIZED VIEW test_mv1 WITH SYNC MODE;
-
 function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t2 where dt='2020-06-15' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
 function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t2 where dt !='2020-06-15' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
 function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t2 where dt>='2020-06-15' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
 function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t2 where dt>'2020-06-15' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
 function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t2 where dt>'2020-06-15' and dt < '2020-07-22' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
 function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t2 where dt>'2020-06-15' and dt <= '2020-07-22' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
 function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t2 where (dt>'2020-06-15' and dt <= '2020-06-22') or dt>'2020-07-01' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
 function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t2 where dt in ('2020-06-15', '2020-06-22', '2020-07-01') GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
 function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t2 where date_trunc('day', dt) ='2020-06-15' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
 function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t2 where date_trunc('month', dt) ='2020-06-01' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
 function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t2 where date_trunc('month', dt) ='2020-07-01' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
 function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t2 GROUP BY dt;", "test_mv1")
-
+-- result:
+None
+-- !result
 SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t2 where dt='2020-06-15' GROUP BY dt order by dt;
+-- result:
+2020-06-15	3
+-- !result
 SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t2 where dt !='2020-06-15' GROUP BY dt order by dt;
+-- result:
+2020-06-18	5
+2020-06-21	7
+2020-06-24	9
+2020-07-02	3
+2020-07-05	5
+2020-07-08	7
+2020-07-11	9
+2020-07-16	1
+2020-07-19	2
+2020-07-22	3
+2020-07-25	4
+-- !result
 SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t2 where dt>='2020-06-15' GROUP BY dt order by dt;
+-- result:
+2020-06-15	3
+2020-06-18	5
+2020-06-21	7
+2020-06-24	9
+2020-07-02	3
+2020-07-05	5
+2020-07-08	7
+2020-07-11	9
+2020-07-16	1
+2020-07-19	2
+2020-07-22	3
+2020-07-25	4
+-- !result
 SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t2 where dt>'2020-06-15' GROUP BY dt order by dt;
+-- result:
+2020-06-18	5
+2020-06-21	7
+2020-06-24	9
+2020-07-02	3
+2020-07-05	5
+2020-07-08	7
+2020-07-11	9
+2020-07-16	1
+2020-07-19	2
+2020-07-22	3
+2020-07-25	4
+-- !result
 SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t2 where dt>'2020-06-15' and dt < '2020-07-22' GROUP BY dt order by dt;
+-- result:
+2020-06-18	5
+2020-06-21	7
+2020-06-24	9
+2020-07-02	3
+2020-07-05	5
+2020-07-08	7
+2020-07-11	9
+2020-07-16	1
+2020-07-19	2
+-- !result
 SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t2 where dt>'2020-06-15' and dt <= '2020-07-22' GROUP BY dt order by dt;
+-- result:
+2020-06-18	5
+2020-06-21	7
+2020-06-24	9
+2020-07-02	3
+2020-07-05	5
+2020-07-08	7
+2020-07-11	9
+2020-07-16	1
+2020-07-19	2
+2020-07-22	3
+-- !result
 SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t2 where (dt>'2020-06-15' and dt <= '2020-06-22') or dt>'2020-07-01' GROUP BY dt order by dt;
+-- result:
+2020-06-18	5
+2020-06-21	7
+2020-07-02	3
+2020-07-05	5
+2020-07-08	7
+2020-07-11	9
+2020-07-16	1
+2020-07-19	2
+2020-07-22	3
+2020-07-25	4
+-- !result
 SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t2 where dt in ('2020-06-15', '2020-06-22', '2020-07-01') GROUP BY dt order by dt;
+-- result:
+2020-06-15	3
+-- !result
 SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t2 where date_trunc('day', dt) ='2020-06-15' GROUP BY dt order by dt;
+-- result:
+2020-06-15	3
+-- !result
 SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t2 where date_trunc('month', dt) ='2020-06-01' GROUP BY dt order by dt;
+-- result:
+2020-06-15	3
+2020-06-18	5
+2020-06-21	7
+2020-06-24	9
+-- !result
 SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t2 where date_trunc('month', dt) ='2020-07-01' GROUP BY dt order by dt;
+-- result:
+2020-07-02	3
+2020-07-05	5
+2020-07-08	7
+2020-07-11	9
+2020-07-16	1
+2020-07-19	2
+2020-07-22	3
+2020-07-25	4
+-- !result
 SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t2 GROUP BY dt order by dt;
-
--- union rewrite
+-- result:
+2020-06-15	3
+2020-06-18	5
+2020-06-21	7
+2020-06-24	9
+2020-07-02	3
+2020-07-05	5
+2020-07-08	7
+2020-07-11	9
+2020-07-16	1
+2020-07-19	2
+2020-07-22	3
+2020-07-25	4
+-- !result
 INSERT INTO mv_hive_${uuid0}.mv_hive_db_${uuid0}.t2 VALUES (3, "2020-06-15");
+-- result:
+-- !result
 function: check_no_hit_materialized_view("SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t2 where dt='2020-06-15' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
 function: check_no_hit_materialized_view("SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t2 where date_trunc('day', dt) ='2020-06-15' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
 function: check_no_hit_materialized_view("SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t2 where dt in ('2020-06-15', '2020-06-22', '2020-07-01') GROUP BY dt;", "test_mv1")
-
--- cannot partition prune
+-- result:
+None
+-- !result
 function: check_no_hit_materialized_view("SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t2 where date_trunc('day', dt) ='2020-06-21' GROUP BY dt;", "test_mv1")
-
+-- result:
+None
+-- !result
 function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t2 where dt !='2020-06-15' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
 function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t2 where dt>'2020-06-15' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
 function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t2 where dt>'2020-06-15' and dt < '2020-07-22' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
 function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t2 where dt>'2020-06-15' and dt <= '2020-07-22' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
 function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t2 where (dt>'2020-06-15' and dt <= '2020-06-22') or dt>'2020-07-01' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
 function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t2 where dt in ('2020-06-21', '2020-07-25') GROUP BY dt;", "test_mv1")
--- cannot partition prune
+-- result:
+None
+-- !result
 function: check_no_hit_materialized_view("SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t2 where date_trunc('month', dt) ='2020-07-01' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
 function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t2 where dt between '2020-06-16' and '2020-07-01' GROUP BY dt;", "test_mv1")
-
+-- result:
+None
+-- !result
 function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t2 where dt between '2020-06-15' and '2020-07-01' GROUP BY dt;", "test_mv1", "UNION")
+-- result:
+None
+-- !result
 function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t2 where dt>='2020-06-15' GROUP BY dt;", "test_mv1", "UNION")
+-- result:
+None
+-- !result
 function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t2 where dt in ('2020-06-15', '2020-06-21', '2020-07-25') GROUP BY dt;", "test_mv1", "UNION")
--- cannot partition prune
+-- result:
+None
+-- !result
 function: check_no_hit_materialized_view("SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t2 where date_trunc('month', dt) ='2020-06-01' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
 function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t2 GROUP BY dt;", "test_mv1", "UNION")
-
+-- result:
+None
+-- !result
 SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t2 where dt='2020-06-15' GROUP BY dt order by dt;
+-- result:
+2020-06-15	6
+-- !result
 SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t2 where dt !='2020-06-15' GROUP BY dt order by dt;
+-- result:
+2020-06-18	5
+2020-06-21	7
+2020-06-24	9
+2020-07-02	3
+2020-07-05	5
+2020-07-08	7
+2020-07-11	9
+2020-07-16	1
+2020-07-19	2
+2020-07-22	3
+2020-07-25	4
+-- !result
 SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t2 where dt>='2020-06-15' GROUP BY dt order by dt;
+-- result:
+2020-06-15	6
+2020-06-18	5
+2020-06-21	7
+2020-06-24	9
+2020-07-02	3
+2020-07-05	5
+2020-07-08	7
+2020-07-11	9
+2020-07-16	1
+2020-07-19	2
+2020-07-22	3
+2020-07-25	4
+-- !result
 SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t2 where dt>'2020-06-15' GROUP BY dt order by dt;
+-- result:
+2020-06-18	5
+2020-06-21	7
+2020-06-24	9
+2020-07-02	3
+2020-07-05	5
+2020-07-08	7
+2020-07-11	9
+2020-07-16	1
+2020-07-19	2
+2020-07-22	3
+2020-07-25	4
+-- !result
 SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t2 where dt>'2020-06-15' and dt < '2020-07-22' GROUP BY dt order by dt;
+-- result:
+2020-06-18	5
+2020-06-21	7
+2020-06-24	9
+2020-07-02	3
+2020-07-05	5
+2020-07-08	7
+2020-07-11	9
+2020-07-16	1
+2020-07-19	2
+-- !result
 SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t2 where dt>'2020-06-15' and dt <= '2020-07-22' GROUP BY dt order by dt;
+-- result:
+2020-06-18	5
+2020-06-21	7
+2020-06-24	9
+2020-07-02	3
+2020-07-05	5
+2020-07-08	7
+2020-07-11	9
+2020-07-16	1
+2020-07-19	2
+2020-07-22	3
+-- !result
 SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t2 where (dt>'2020-06-15' and dt <= '2020-06-22') or dt>'2020-07-01' GROUP BY dt order by dt;
+-- result:
+2020-06-18	5
+2020-06-21	7
+2020-07-02	3
+2020-07-05	5
+2020-07-08	7
+2020-07-11	9
+2020-07-16	1
+2020-07-19	2
+2020-07-22	3
+2020-07-25	4
+-- !result
 SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t2 where dt in ('2020-06-22', '2020-07-01') GROUP BY dt order by dt;
+-- result:
+-- !result
 SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t2 where dt in ('2020-06-15', '2020-06-22', '2020-07-01') GROUP BY dt order by dt;
+-- result:
+2020-06-15	6
+-- !result
 SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t2 where dt between '2020-06-15' and '2020-07-01' GROUP BY dt order by dt;
+-- result:
+2020-06-15	6
+2020-06-18	5
+2020-06-21	7
+2020-06-24	9
+-- !result
 SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t2 where date_trunc('day', dt) ='2020-06-15' GROUP BY dt order by dt;
+-- result:
+2020-06-15	6
+-- !result
 SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t2 where date_trunc('month', dt) ='2020-06-01' GROUP BY dt order by dt;
+-- result:
+2020-06-15	6
+2020-06-18	5
+2020-06-21	7
+2020-06-24	9
+-- !result
 SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t2 where date_trunc('month', dt) ='2020-07-01' GROUP BY dt order by dt;
+-- result:
+2020-07-02	3
+2020-07-05	5
+2020-07-08	7
+2020-07-11	9
+2020-07-16	1
+2020-07-19	2
+2020-07-22	3
+2020-07-25	4
+-- !result
 SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t2 GROUP BY dt order by dt;
-
-
+-- result:
+2020-06-15	6
+2020-06-18	5
+2020-06-21	7
+2020-06-24	9
+2020-07-02	3
+2020-07-05	5
+2020-07-08	7
+2020-07-11	9
+2020-07-16	1
+2020-07-19	2
+2020-07-22	3
+2020-07-25	4
+-- !result
 drop materialized view default_catalog.db_${uuid0}.test_mv1;
-
--- Test partition compensate with partition expression
--- TODO: shold not add an extra column(dt) which cannot partition prune.
+-- result:
+-- !result
 CREATE MATERIALIZED VIEW test_mv1 
 PARTITION BY date_trunc('day', format_dt)
 REFRESH DEFERRED MANUAL AS 
   SELECT dt, str2date(dt, '%Y-%m-%d') as format_dt, sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t2 GROUP BY dt;
+-- result:
+-- !result
 REFRESH MATERIALIZED VIEW test_mv1 WITH SYNC MODE;
-
 function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t2 where dt='2020-06-15' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
 function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t2 where dt !='2020-06-15' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
 function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t2 where dt>='2020-06-15' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
 function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t2 where dt>'2020-06-15' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
 function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t2 where dt>'2020-06-15' and dt < '2020-07-22' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
 function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t2 where dt>'2020-06-15' and dt <= '2020-07-22' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
 function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t2 where (dt>'2020-06-15' and dt <= '2020-06-22') or dt>'2020-07-01' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
 function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t2 where dt in ('2020-06-15', '2020-06-22', '2020-07-01') GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
 function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t2 where date_trunc('day', dt) ='2020-06-15' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
 function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t2 where date_trunc('month', dt) ='2020-06-01' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
 function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t2 where date_trunc('month', dt) ='2020-07-01' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
 function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t2 GROUP BY dt;", "test_mv1")
-
+-- result:
+None
+-- !result
 SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t2 where dt='2020-06-15' GROUP BY dt order by dt;
+-- result:
+2020-06-15	6
+-- !result
 SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t2 where dt !='2020-06-15' GROUP BY dt order by dt;
+-- result:
+2020-06-18	5
+2020-06-21	7
+2020-06-24	9
+2020-07-02	3
+2020-07-05	5
+2020-07-08	7
+2020-07-11	9
+2020-07-16	1
+2020-07-19	2
+2020-07-22	3
+2020-07-25	4
+-- !result
 SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t2 where dt>='2020-06-15' GROUP BY dt order by dt;
+-- result:
+2020-06-15	6
+2020-06-18	5
+2020-06-21	7
+2020-06-24	9
+2020-07-02	3
+2020-07-05	5
+2020-07-08	7
+2020-07-11	9
+2020-07-16	1
+2020-07-19	2
+2020-07-22	3
+2020-07-25	4
+-- !result
 SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t2 where dt>'2020-06-15' GROUP BY dt order by dt;
+-- result:
+2020-06-18	5
+2020-06-21	7
+2020-06-24	9
+2020-07-02	3
+2020-07-05	5
+2020-07-08	7
+2020-07-11	9
+2020-07-16	1
+2020-07-19	2
+2020-07-22	3
+2020-07-25	4
+-- !result
 SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t2 where dt>'2020-06-15' and dt < '2020-07-22' GROUP BY dt order by dt;
+-- result:
+2020-06-18	5
+2020-06-21	7
+2020-06-24	9
+2020-07-02	3
+2020-07-05	5
+2020-07-08	7
+2020-07-11	9
+2020-07-16	1
+2020-07-19	2
+-- !result
 SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t2 where dt>'2020-06-15' and dt <= '2020-07-22' GROUP BY dt order by dt;
+-- result:
+2020-06-18	5
+2020-06-21	7
+2020-06-24	9
+2020-07-02	3
+2020-07-05	5
+2020-07-08	7
+2020-07-11	9
+2020-07-16	1
+2020-07-19	2
+2020-07-22	3
+-- !result
 SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t2 where (dt>'2020-06-15' and dt <= '2020-06-22') or dt>'2020-07-01' GROUP BY dt order by dt;
+-- result:
+2020-06-18	5
+2020-06-21	7
+2020-07-02	3
+2020-07-05	5
+2020-07-08	7
+2020-07-11	9
+2020-07-16	1
+2020-07-19	2
+2020-07-22	3
+2020-07-25	4
+-- !result
 SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t2 where dt in ('2020-06-15', '2020-06-22', '2020-07-01') GROUP BY dt order by dt;
+-- result:
+2020-06-15	6
+-- !result
 SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t2 where date_trunc('day', dt) ='2020-06-15' GROUP BY dt order by dt;
+-- result:
+2020-06-15	6
+-- !result
 SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t2 where date_trunc('month', dt) ='2020-06-01' GROUP BY dt order by dt;
+-- result:
+2020-06-15	6
+2020-06-18	5
+2020-06-21	7
+2020-06-24	9
+-- !result
 SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t2 where date_trunc('month', dt) ='2020-07-01' GROUP BY dt order by dt;
+-- result:
+2020-07-02	3
+2020-07-05	5
+2020-07-08	7
+2020-07-11	9
+2020-07-16	1
+2020-07-19	2
+2020-07-22	3
+2020-07-25	4
+-- !result
 SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t2 GROUP BY dt order by dt;
-
--- union rewrite
+-- result:
+2020-06-15	6
+2020-06-18	5
+2020-06-21	7
+2020-06-24	9
+2020-07-02	3
+2020-07-05	5
+2020-07-08	7
+2020-07-11	9
+2020-07-16	1
+2020-07-19	2
+2020-07-22	3
+2020-07-25	4
+-- !result
 INSERT INTO mv_hive_${uuid0}.mv_hive_db_${uuid0}.t2 VALUES (3, "2020-06-15");
+-- result:
+-- !result
 function: check_no_hit_materialized_view("SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t2 where dt='2020-06-15' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
 function: check_no_hit_materialized_view("SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t2 where date_trunc('day', dt) ='2020-06-15' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
 function: check_no_hit_materialized_view("SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t2 where dt in ('2020-06-15', '2020-06-22', '2020-07-01') GROUP BY dt;", "test_mv1")
-
--- cannot partition prune
+-- result:
+None
+-- !result
 function: check_no_hit_materialized_view("SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t2 where date_trunc('day', dt) ='2020-06-21' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
 function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t2 where dt !='2020-06-15' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
 function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t2 where dt>'2020-06-15' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
 function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t2 where dt>'2020-06-15' and dt < '2020-07-22' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
 function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t2 where dt>'2020-06-15' and dt <= '2020-07-22' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
 function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t2 where (dt>'2020-06-15' and dt <= '2020-06-22') or dt>'2020-07-01' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
 function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t2 where dt in ('2020-06-21', '2020-07-25') GROUP BY dt;", "test_mv1")
--- cannot partition prune
+-- result:
+None
+-- !result
 function: check_no_hit_materialized_view("SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t2 where date_trunc('month', dt) ='2020-07-01' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
 function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t2 where dt between '2020-06-16' and '2020-07-01' GROUP BY dt;", "test_mv1")
-
+-- result:
+None
+-- !result
 function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t2 where dt between '2020-06-15' and '2020-07-01' GROUP BY dt;", "test_mv1", "UNION")
+-- result:
+None
+-- !result
 function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t2 where dt>='2020-06-15' GROUP BY dt;", "test_mv1", "UNION")
+-- result:
+None
+-- !result
 function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t2 where dt in ('2020-06-15', '2020-06-21', '2020-07-25') GROUP BY dt;", "test_mv1", "UNION")
--- cannot partition prune
+-- result:
+None
+-- !result
 function: check_no_hit_materialized_view("SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t2 where date_trunc('month', dt) ='2020-06-01' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
 function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t2 GROUP BY dt;", "test_mv1", "UNION")
-
+-- result:
+None
+-- !result
 SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t2 where dt='2020-06-15' GROUP BY dt order by dt;
+-- result:
+2020-06-15	9
+-- !result
 SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t2 where dt !='2020-06-15' GROUP BY dt order by dt;
+-- result:
+2020-06-18	5
+2020-06-21	7
+2020-06-24	9
+2020-07-02	3
+2020-07-05	5
+2020-07-08	7
+2020-07-11	9
+2020-07-16	1
+2020-07-19	2
+2020-07-22	3
+2020-07-25	4
+-- !result
 SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t2 where dt>='2020-06-15' GROUP BY dt order by dt;
+-- result:
+2020-06-15	9
+2020-06-18	5
+2020-06-21	7
+2020-06-24	9
+2020-07-02	3
+2020-07-05	5
+2020-07-08	7
+2020-07-11	9
+2020-07-16	1
+2020-07-19	2
+2020-07-22	3
+2020-07-25	4
+-- !result
 SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t2 where dt>'2020-06-15' GROUP BY dt order by dt;
+-- result:
+2020-06-18	5
+2020-06-21	7
+2020-06-24	9
+2020-07-02	3
+2020-07-05	5
+2020-07-08	7
+2020-07-11	9
+2020-07-16	1
+2020-07-19	2
+2020-07-22	3
+2020-07-25	4
+-- !result
 SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t2 where dt>'2020-06-15' and dt < '2020-07-22' GROUP BY dt order by dt;
+-- result:
+2020-06-18	5
+2020-06-21	7
+2020-06-24	9
+2020-07-02	3
+2020-07-05	5
+2020-07-08	7
+2020-07-11	9
+2020-07-16	1
+2020-07-19	2
+-- !result
 SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t2 where dt>'2020-06-15' and dt <= '2020-07-22' GROUP BY dt order by dt;
+-- result:
+2020-06-18	5
+2020-06-21	7
+2020-06-24	9
+2020-07-02	3
+2020-07-05	5
+2020-07-08	7
+2020-07-11	9
+2020-07-16	1
+2020-07-19	2
+2020-07-22	3
+-- !result
 SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t2 where (dt>'2020-06-15' and dt <= '2020-06-22') or dt>'2020-07-01' GROUP BY dt order by dt;
+-- result:
+2020-06-18	5
+2020-06-21	7
+2020-07-02	3
+2020-07-05	5
+2020-07-08	7
+2020-07-11	9
+2020-07-16	1
+2020-07-19	2
+2020-07-22	3
+2020-07-25	4
+-- !result
 SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t2 where dt in ('2020-06-22', '2020-07-01') GROUP BY dt order by dt;
+-- result:
+-- !result
 SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t2 where dt in ('2020-06-15', '2020-06-22', '2020-07-01') GROUP BY dt order by dt;
+-- result:
+2020-06-15	9
+-- !result
 SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t2 where dt between '2020-06-15' and '2020-07-01' GROUP BY dt order by dt;
+-- result:
+2020-06-15	9
+2020-06-18	5
+2020-06-21	7
+2020-06-24	9
+-- !result
 SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t2 where date_trunc('day', dt) ='2020-06-15' GROUP BY dt order by dt;
+-- result:
+2020-06-15	9
+-- !result
 SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t2 where date_trunc('month', dt) ='2020-06-01' GROUP BY dt order by dt;
+-- result:
+2020-06-15	9
+2020-06-18	5
+2020-06-21	7
+2020-06-24	9
+-- !result
 SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t2 where date_trunc('month', dt) ='2020-07-01' GROUP BY dt order by dt;
+-- result:
+2020-07-02	3
+2020-07-05	5
+2020-07-08	7
+2020-07-11	9
+2020-07-16	1
+2020-07-19	2
+2020-07-22	3
+2020-07-25	4
+-- !result
 SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t2 GROUP BY dt order by dt;
-
+-- result:
+2020-06-15	9
+2020-06-18	5
+2020-06-21	7
+2020-06-24	9
+2020-07-02	3
+2020-07-05	5
+2020-07-08	7
+2020-07-11	9
+2020-07-16	1
+2020-07-19	2
+2020-07-22	3
+2020-07-25	4
+-- !result
 drop materialized view default_catalog.db_${uuid0}.test_mv1;
-
+-- result:
+-- !result
 drop table mv_hive_${uuid0}.mv_hive_db_${uuid0}.t2 force;
+-- result:
+-- !result
 drop table mv_hive_${uuid0}.mv_hive_db_${uuid0}.t2 force;
+-- result:
+E: (1064, "Getting analyzing error. Detail message: Unknown table 't2'.")
+-- !result

--- a/test/sql/test_materialized_view/R/test_mv_partition_compensate_iceberg
+++ b/test/sql/test_materialized_view/R/test_mv_partition_compensate_iceberg
@@ -1,0 +1,1629 @@
+-- name: test_mv_partition_compensate_iceberg
+create external catalog mv_iceberg_${uuid0}
+properties
+(
+    "type" = "iceberg",
+    "iceberg.catalog.type" = "hive",
+    "hive.metastore.uris" = "${iceberg_catalog_hive_metastore_uris}"
+);
+-- result:
+-- !result
+set catalog mv_iceberg_${uuid0};
+-- result:
+-- !result
+create database mv_ice_db_${uuid0};
+-- result:
+-- !result
+use mv_ice_db_${uuid0};
+-- result:
+-- !result
+CREATE TABLE t1 (
+  num int,
+  dt date
+)
+PARTITION BY (dt);
+-- result:
+-- !result
+INSERT INTO t1 VALUES 
+  (1,"2020-06-15"),(2,"2020-06-18"),(3,"2020-06-21"),(4,"2020-06-24"),
+  (1,"2020-07-02"),(2,"2020-07-05"),(3,"2020-07-08"),(4,"2020-07-11"),
+  (1,"2020-07-16"),(2,"2020-07-19"),(3,"2020-07-22"),(4,"2020-07-25"),
+  (2,"2020-06-15"),(3,"2020-06-18"),(4,"2020-06-21"),(5,"2020-06-24"),
+  (2,"2020-07-02"),(3,"2020-07-05"),(4,"2020-07-08"),(5,"2020-07-11");
+-- result:
+-- !result
+CREATE TABLE t2 (
+  num int,
+  dt string
+)
+PARTITION BY (dt);
+-- result:
+-- !result
+INSERT INTO t2 VALUES 
+  (1,"2020-06-15"),(2,"2020-06-18"),(3,"2020-06-21"),(4,"2020-06-24"),
+  (1,"2020-07-02"),(2,"2020-07-05"),(3,"2020-07-08"),(4,"2020-07-11"),
+  (1,"2020-07-16"),(2,"2020-07-19"),(3,"2020-07-22"),(4,"2020-07-25"),
+  (2,"2020-06-15"),(3,"2020-06-18"),(4,"2020-06-21"),(5,"2020-06-24"),
+  (2,"2020-07-02"),(3,"2020-07-05"),(4,"2020-07-08"),(5,"2020-07-11");
+-- result:
+-- !result
+set catalog default_catalog;
+-- result:
+-- !result
+create database db_${uuid0};
+-- result:
+-- !result
+use db_${uuid0};
+-- result:
+-- !result
+CREATE MATERIALIZED VIEW test_mv1 
+PARTITION BY dt 
+REFRESH DEFERRED MANUAL AS 
+  SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 GROUP BY dt;
+-- result:
+-- !result
+REFRESH MATERIALIZED VIEW test_mv1 WITH SYNC MODE;
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 where dt='2020-06-15' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 where dt !='2020-06-15' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 where dt>='2020-06-15' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 where dt>'2020-06-15' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 where dt>'2020-06-15' and dt < '2020-07-22' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 where dt>'2020-06-15' and dt <= '2020-07-22' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 where (dt>'2020-06-15' and dt <= '2020-06-22') or dt>'2020-07-01' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 where dt in ('2020-06-15', '2020-06-22', '2020-07-01') GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 where date_trunc('day', dt) ='2020-06-15' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 where date_trunc('month', dt) ='2020-06-01' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 where date_trunc('month', dt) ='2020-07-01' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 where dt='2020-06-15' GROUP BY dt order by dt;
+-- result:
+2020-06-15	3
+-- !result
+SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 where dt !='2020-06-15' GROUP BY dt order by dt;
+-- result:
+2020-06-18	5
+2020-06-21	7
+2020-06-24	9
+2020-07-02	3
+2020-07-05	5
+2020-07-08	7
+2020-07-11	9
+2020-07-16	1
+2020-07-19	2
+2020-07-22	3
+2020-07-25	4
+-- !result
+SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 where dt>='2020-06-15' GROUP BY dt order by dt;
+-- result:
+2020-06-15	3
+2020-06-18	5
+2020-06-21	7
+2020-06-24	9
+2020-07-02	3
+2020-07-05	5
+2020-07-08	7
+2020-07-11	9
+2020-07-16	1
+2020-07-19	2
+2020-07-22	3
+2020-07-25	4
+-- !result
+SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 where dt>'2020-06-15' GROUP BY dt order by dt;
+-- result:
+2020-06-18	5
+2020-06-21	7
+2020-06-24	9
+2020-07-02	3
+2020-07-05	5
+2020-07-08	7
+2020-07-11	9
+2020-07-16	1
+2020-07-19	2
+2020-07-22	3
+2020-07-25	4
+-- !result
+SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 where dt>'2020-06-15' and dt < '2020-07-22' GROUP BY dt order by dt;
+-- result:
+2020-06-18	5
+2020-06-21	7
+2020-06-24	9
+2020-07-02	3
+2020-07-05	5
+2020-07-08	7
+2020-07-11	9
+2020-07-16	1
+2020-07-19	2
+-- !result
+SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 where dt>'2020-06-15' and dt <= '2020-07-22' GROUP BY dt order by dt;
+-- result:
+2020-06-18	5
+2020-06-21	7
+2020-06-24	9
+2020-07-02	3
+2020-07-05	5
+2020-07-08	7
+2020-07-11	9
+2020-07-16	1
+2020-07-19	2
+2020-07-22	3
+-- !result
+SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 where (dt>'2020-06-15' and dt <= '2020-06-22') or dt>'2020-07-01' GROUP BY dt order by dt;
+-- result:
+2020-06-18	5
+2020-06-21	7
+2020-07-02	3
+2020-07-05	5
+2020-07-08	7
+2020-07-11	9
+2020-07-16	1
+2020-07-19	2
+2020-07-22	3
+2020-07-25	4
+-- !result
+SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 where dt in ('2020-06-15', '2020-06-22', '2020-07-01') GROUP BY dt order by dt;
+-- result:
+2020-06-15	3
+-- !result
+SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 where date_trunc('day', dt) ='2020-06-15' GROUP BY dt order by dt;
+-- result:
+2020-06-15	3
+-- !result
+SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 where date_trunc('month', dt) ='2020-06-01' GROUP BY dt order by dt;
+-- result:
+2020-06-15	3
+2020-06-18	5
+2020-06-21	7
+2020-06-24	9
+-- !result
+SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 where date_trunc('month', dt) ='2020-07-01' GROUP BY dt order by dt;
+-- result:
+2020-07-02	3
+2020-07-05	5
+2020-07-08	7
+2020-07-11	9
+2020-07-16	1
+2020-07-19	2
+2020-07-22	3
+2020-07-25	4
+-- !result
+SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 GROUP BY dt order by dt;
+-- result:
+2020-06-15	3
+2020-06-18	5
+2020-06-21	7
+2020-06-24	9
+2020-07-02	3
+2020-07-05	5
+2020-07-08	7
+2020-07-11	9
+2020-07-16	1
+2020-07-19	2
+2020-07-22	3
+2020-07-25	4
+-- !result
+INSERT INTO mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 VALUES (3, "2020-06-15");
+-- result:
+-- !result
+function: check_no_hit_materialized_view("SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 where dt='2020-06-15' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_no_hit_materialized_view("SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 where date_trunc('day', dt) ='2020-06-15' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_no_hit_materialized_view("SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 where dt in ('2020-06-15', '2020-06-22', '2020-07-01') GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 where date_trunc('day', dt) ='2020-06-21' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 where dt !='2020-06-15' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 where dt>'2020-06-15' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 where dt>'2020-06-15' and dt < '2020-07-22' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 where dt>'2020-06-15' and dt <= '2020-07-22' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 where (dt>'2020-06-15' and dt <= '2020-06-22') or dt>'2020-07-01' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 where dt in ('2020-06-21', '2020-07-25') GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_no_hit_materialized_view("SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 where date_trunc('month', dt) ='2020-07-01' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 where dt between '2020-06-16' and '2020-07-01' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 where dt between '2020-06-15' and '2020-07-01' GROUP BY dt;", "test_mv1", "UNION")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 where dt>='2020-06-15' GROUP BY dt;", "test_mv1", "UNION")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 where dt in ('2020-06-15', '2020-06-21', '2020-07-25') GROUP BY dt;", "test_mv1", "UNION")
+-- result:
+None
+-- !result
+function: check_no_hit_materialized_view("SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 where date_trunc('month', dt) ='2020-06-01' GROUP BY dt;", "test_mv1", "UNION")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 GROUP BY dt;", "test_mv1", "UNION")
+-- result:
+None
+-- !result
+SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 where dt='2020-06-15' GROUP BY dt order by dt;
+-- result:
+2020-06-15	6
+-- !result
+SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 where dt !='2020-06-15' GROUP BY dt order by dt;
+-- result:
+2020-06-18	5
+2020-06-21	7
+2020-06-24	9
+2020-07-02	3
+2020-07-05	5
+2020-07-08	7
+2020-07-11	9
+2020-07-16	1
+2020-07-19	2
+2020-07-22	3
+2020-07-25	4
+-- !result
+SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 where dt>='2020-06-15' GROUP BY dt order by dt;
+-- result:
+2020-06-15	6
+2020-06-18	5
+2020-06-21	7
+2020-06-24	9
+2020-07-02	3
+2020-07-05	5
+2020-07-08	7
+2020-07-11	9
+2020-07-16	1
+2020-07-19	2
+2020-07-22	3
+2020-07-25	4
+-- !result
+SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 where dt>'2020-06-15' GROUP BY dt order by dt;
+-- result:
+2020-06-18	5
+2020-06-21	7
+2020-06-24	9
+2020-07-02	3
+2020-07-05	5
+2020-07-08	7
+2020-07-11	9
+2020-07-16	1
+2020-07-19	2
+2020-07-22	3
+2020-07-25	4
+-- !result
+SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 where dt>'2020-06-15' and dt < '2020-07-22' GROUP BY dt order by dt;
+-- result:
+2020-06-18	5
+2020-06-21	7
+2020-06-24	9
+2020-07-02	3
+2020-07-05	5
+2020-07-08	7
+2020-07-11	9
+2020-07-16	1
+2020-07-19	2
+-- !result
+SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 where dt>'2020-06-15' and dt <= '2020-07-22' GROUP BY dt order by dt;
+-- result:
+2020-06-18	5
+2020-06-21	7
+2020-06-24	9
+2020-07-02	3
+2020-07-05	5
+2020-07-08	7
+2020-07-11	9
+2020-07-16	1
+2020-07-19	2
+2020-07-22	3
+-- !result
+SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 where (dt>'2020-06-15' and dt <= '2020-06-22') or dt>'2020-07-01' GROUP BY dt order by dt;
+-- result:
+2020-06-18	5
+2020-06-21	7
+2020-07-02	3
+2020-07-05	5
+2020-07-08	7
+2020-07-11	9
+2020-07-16	1
+2020-07-19	2
+2020-07-22	3
+2020-07-25	4
+-- !result
+SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 where dt in ('2020-06-22', '2020-07-01') GROUP BY dt order by dt;
+-- result:
+-- !result
+SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 where dt in ('2020-06-15', '2020-06-22', '2020-07-01') GROUP BY dt order by dt;
+-- result:
+2020-06-15	6
+-- !result
+SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 where dt between '2020-06-15' and '2020-07-01' GROUP BY dt order by dt;
+-- result:
+2020-06-15	6
+2020-06-18	5
+2020-06-21	7
+2020-06-24	9
+-- !result
+SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 where date_trunc('day', dt) ='2020-06-15' GROUP BY dt order by dt;
+-- result:
+2020-06-15	6
+-- !result
+SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 where date_trunc('month', dt) ='2020-06-01' GROUP BY dt order by dt;
+-- result:
+2020-06-15	6
+2020-06-18	5
+2020-06-21	7
+2020-06-24	9
+-- !result
+SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 where date_trunc('month', dt) ='2020-07-01' GROUP BY dt order by dt;
+-- result:
+2020-07-02	3
+2020-07-05	5
+2020-07-08	7
+2020-07-11	9
+2020-07-16	1
+2020-07-19	2
+2020-07-22	3
+2020-07-25	4
+-- !result
+SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 GROUP BY dt order by dt;
+-- result:
+2020-06-15	6
+2020-06-18	5
+2020-06-21	7
+2020-06-24	9
+2020-07-02	3
+2020-07-05	5
+2020-07-08	7
+2020-07-11	9
+2020-07-16	1
+2020-07-19	2
+2020-07-22	3
+2020-07-25	4
+-- !result
+drop materialized view default_catalog.db_${uuid0}.test_mv1;
+-- result:
+-- !result
+CREATE MATERIALIZED VIEW test_mv1 
+PARTITION BY date_trunc('day', dt)
+REFRESH DEFERRED MANUAL AS 
+  SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 GROUP BY dt;
+-- result:
+-- !result
+REFRESH MATERIALIZED VIEW test_mv1 WITH SYNC MODE;
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 where dt='2020-06-15' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 where dt !='2020-06-15' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 where dt>='2020-06-15' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 where dt>'2020-06-15' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 where dt>'2020-06-15' and dt < '2020-07-22' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 where dt>'2020-06-15' and dt <= '2020-07-22' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 where (dt>'2020-06-15' and dt <= '2020-06-22') or dt>'2020-07-01' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 where dt in ('2020-06-15', '2020-06-22', '2020-07-01') GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 where date_trunc('day', dt) ='2020-06-15' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 where date_trunc('month', dt) ='2020-06-01' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 where date_trunc('month', dt) ='2020-07-01' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 where dt='2020-06-15' GROUP BY dt order by dt;
+-- result:
+2020-06-15	6
+-- !result
+SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 where dt !='2020-06-15' GROUP BY dt order by dt;
+-- result:
+2020-06-18	5
+2020-06-21	7
+2020-06-24	9
+2020-07-02	3
+2020-07-05	5
+2020-07-08	7
+2020-07-11	9
+2020-07-16	1
+2020-07-19	2
+2020-07-22	3
+2020-07-25	4
+-- !result
+SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 where dt>='2020-06-15' GROUP BY dt order by dt;
+-- result:
+2020-06-15	6
+2020-06-18	5
+2020-06-21	7
+2020-06-24	9
+2020-07-02	3
+2020-07-05	5
+2020-07-08	7
+2020-07-11	9
+2020-07-16	1
+2020-07-19	2
+2020-07-22	3
+2020-07-25	4
+-- !result
+SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 where dt>'2020-06-15' GROUP BY dt order by dt;
+-- result:
+2020-06-18	5
+2020-06-21	7
+2020-06-24	9
+2020-07-02	3
+2020-07-05	5
+2020-07-08	7
+2020-07-11	9
+2020-07-16	1
+2020-07-19	2
+2020-07-22	3
+2020-07-25	4
+-- !result
+SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 where dt>'2020-06-15' and dt < '2020-07-22' GROUP BY dt order by dt;
+-- result:
+2020-06-18	5
+2020-06-21	7
+2020-06-24	9
+2020-07-02	3
+2020-07-05	5
+2020-07-08	7
+2020-07-11	9
+2020-07-16	1
+2020-07-19	2
+-- !result
+SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 where dt>'2020-06-15' and dt <= '2020-07-22' GROUP BY dt order by dt;
+-- result:
+2020-06-18	5
+2020-06-21	7
+2020-06-24	9
+2020-07-02	3
+2020-07-05	5
+2020-07-08	7
+2020-07-11	9
+2020-07-16	1
+2020-07-19	2
+2020-07-22	3
+-- !result
+SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 where (dt>'2020-06-15' and dt <= '2020-06-22') or dt>'2020-07-01' GROUP BY dt order by dt;
+-- result:
+2020-06-18	5
+2020-06-21	7
+2020-07-02	3
+2020-07-05	5
+2020-07-08	7
+2020-07-11	9
+2020-07-16	1
+2020-07-19	2
+2020-07-22	3
+2020-07-25	4
+-- !result
+SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 where dt in ('2020-06-15', '2020-06-22', '2020-07-01') GROUP BY dt order by dt;
+-- result:
+2020-06-15	6
+-- !result
+SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 where date_trunc('day', dt) ='2020-06-15' GROUP BY dt order by dt;
+-- result:
+2020-06-15	6
+-- !result
+SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 where date_trunc('month', dt) ='2020-06-01' GROUP BY dt order by dt;
+-- result:
+2020-06-15	6
+2020-06-18	5
+2020-06-21	7
+2020-06-24	9
+-- !result
+SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 where date_trunc('month', dt) ='2020-07-01' GROUP BY dt order by dt;
+-- result:
+2020-07-02	3
+2020-07-05	5
+2020-07-08	7
+2020-07-11	9
+2020-07-16	1
+2020-07-19	2
+2020-07-22	3
+2020-07-25	4
+-- !result
+SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 GROUP BY dt order by dt;
+-- result:
+2020-06-15	6
+2020-06-18	5
+2020-06-21	7
+2020-06-24	9
+2020-07-02	3
+2020-07-05	5
+2020-07-08	7
+2020-07-11	9
+2020-07-16	1
+2020-07-19	2
+2020-07-22	3
+2020-07-25	4
+-- !result
+INSERT INTO mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 VALUES (3, "2020-06-15");
+-- result:
+-- !result
+function: check_no_hit_materialized_view("SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 where dt='2020-06-15' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_no_hit_materialized_view("SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 where date_trunc('day', dt) ='2020-06-15' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_no_hit_materialized_view("SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 where dt in ('2020-06-15', '2020-06-22', '2020-07-01') GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 where date_trunc('day', dt) ='2020-06-21' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 where dt !='2020-06-15' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 where dt>'2020-06-15' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 where dt>'2020-06-15' and dt < '2020-07-22' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 where dt>'2020-06-15' and dt <= '2020-07-22' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 where (dt>'2020-06-15' and dt <= '2020-06-22') or dt>'2020-07-01' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 where dt in ('2020-06-21', '2020-07-25') GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_no_hit_materialized_view("SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 where date_trunc('month', dt) ='2020-07-01' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 where dt between '2020-06-16' and '2020-07-01' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 where dt between '2020-06-15' and '2020-07-01' GROUP BY dt;", "test_mv1", "UNION")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 where dt>='2020-06-15' GROUP BY dt;", "test_mv1", "UNION")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 where dt in ('2020-06-15', '2020-06-21', '2020-07-25') GROUP BY dt;", "test_mv1", "UNION")
+-- result:
+None
+-- !result
+function: check_no_hit_materialized_view("SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 where date_trunc('month', dt) ='2020-06-01' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 GROUP BY dt;", "test_mv1", "UNION")
+-- result:
+None
+-- !result
+SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 where dt='2020-06-15' GROUP BY dt order by dt;
+-- result:
+2020-06-15	9
+-- !result
+SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 where dt !='2020-06-15' GROUP BY dt order by dt;
+-- result:
+2020-06-18	5
+2020-06-21	7
+2020-06-24	9
+2020-07-02	3
+2020-07-05	5
+2020-07-08	7
+2020-07-11	9
+2020-07-16	1
+2020-07-19	2
+2020-07-22	3
+2020-07-25	4
+-- !result
+SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 where dt>='2020-06-15' GROUP BY dt order by dt;
+-- result:
+2020-06-15	9
+2020-06-18	5
+2020-06-21	7
+2020-06-24	9
+2020-07-02	3
+2020-07-05	5
+2020-07-08	7
+2020-07-11	9
+2020-07-16	1
+2020-07-19	2
+2020-07-22	3
+2020-07-25	4
+-- !result
+SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 where dt>'2020-06-15' GROUP BY dt order by dt;
+-- result:
+2020-06-18	5
+2020-06-21	7
+2020-06-24	9
+2020-07-02	3
+2020-07-05	5
+2020-07-08	7
+2020-07-11	9
+2020-07-16	1
+2020-07-19	2
+2020-07-22	3
+2020-07-25	4
+-- !result
+SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 where dt>'2020-06-15' and dt < '2020-07-22' GROUP BY dt order by dt;
+-- result:
+2020-06-18	5
+2020-06-21	7
+2020-06-24	9
+2020-07-02	3
+2020-07-05	5
+2020-07-08	7
+2020-07-11	9
+2020-07-16	1
+2020-07-19	2
+-- !result
+SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 where dt>'2020-06-15' and dt <= '2020-07-22' GROUP BY dt order by dt;
+-- result:
+2020-06-18	5
+2020-06-21	7
+2020-06-24	9
+2020-07-02	3
+2020-07-05	5
+2020-07-08	7
+2020-07-11	9
+2020-07-16	1
+2020-07-19	2
+2020-07-22	3
+-- !result
+SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 where (dt>'2020-06-15' and dt <= '2020-06-22') or dt>'2020-07-01' GROUP BY dt order by dt;
+-- result:
+2020-06-18	5
+2020-06-21	7
+2020-07-02	3
+2020-07-05	5
+2020-07-08	7
+2020-07-11	9
+2020-07-16	1
+2020-07-19	2
+2020-07-22	3
+2020-07-25	4
+-- !result
+SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 where dt in ('2020-06-22', '2020-07-01') GROUP BY dt order by dt;
+-- result:
+-- !result
+SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 where dt in ('2020-06-15', '2020-06-22', '2020-07-01') GROUP BY dt order by dt;
+-- result:
+2020-06-15	9
+-- !result
+SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 where dt between '2020-06-15' and '2020-07-01' GROUP BY dt order by dt;
+-- result:
+2020-06-15	9
+2020-06-18	5
+2020-06-21	7
+2020-06-24	9
+-- !result
+SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 where date_trunc('day', dt) ='2020-06-15' GROUP BY dt order by dt;
+-- result:
+2020-06-15	9
+-- !result
+SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 where date_trunc('month', dt) ='2020-06-01' GROUP BY dt order by dt;
+-- result:
+2020-06-15	9
+2020-06-18	5
+2020-06-21	7
+2020-06-24	9
+-- !result
+SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 where date_trunc('month', dt) ='2020-07-01' GROUP BY dt order by dt;
+-- result:
+2020-07-02	3
+2020-07-05	5
+2020-07-08	7
+2020-07-11	9
+2020-07-16	1
+2020-07-19	2
+2020-07-22	3
+2020-07-25	4
+-- !result
+SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 GROUP BY dt order by dt;
+-- result:
+2020-06-15	9
+2020-06-18	5
+2020-06-21	7
+2020-06-24	9
+2020-07-02	3
+2020-07-05	5
+2020-07-08	7
+2020-07-11	9
+2020-07-16	1
+2020-07-19	2
+2020-07-22	3
+2020-07-25	4
+-- !result
+drop materialized view default_catalog.db_${uuid0}.test_mv1;
+-- result:
+-- !result
+CREATE MATERIALIZED VIEW test_mv1 
+PARTITION BY str2date(dt, '%Y-%m-%d')
+REFRESH DEFERRED MANUAL AS 
+  SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t2 GROUP BY dt;
+-- result:
+-- !result
+REFRESH MATERIALIZED VIEW test_mv1 WITH SYNC MODE;
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t2 where dt='2020-06-15' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t2 where dt !='2020-06-15' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t2 where dt>='2020-06-15' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t2 where dt>'2020-06-15' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t2 where dt>'2020-06-15' and dt < '2020-07-22' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t2 where dt>'2020-06-15' and dt <= '2020-07-22' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t2 where (dt>'2020-06-15' and dt <= '2020-06-22') or dt>'2020-07-01' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t2 where dt in ('2020-06-15', '2020-06-22', '2020-07-01') GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t2 where date_trunc('day', dt) ='2020-06-15' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t2 where date_trunc('month', dt) ='2020-06-01' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t2 where date_trunc('month', dt) ='2020-07-01' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t2 GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t2 where dt='2020-06-15' GROUP BY dt order by dt;
+-- result:
+2020-06-15	3
+-- !result
+SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t2 where dt !='2020-06-15' GROUP BY dt order by dt;
+-- result:
+2020-06-18	5
+2020-06-21	7
+2020-06-24	9
+2020-07-02	3
+2020-07-05	5
+2020-07-08	7
+2020-07-11	9
+2020-07-16	1
+2020-07-19	2
+2020-07-22	3
+2020-07-25	4
+-- !result
+SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t2 where dt>='2020-06-15' GROUP BY dt order by dt;
+-- result:
+2020-06-15	3
+2020-06-18	5
+2020-06-21	7
+2020-06-24	9
+2020-07-02	3
+2020-07-05	5
+2020-07-08	7
+2020-07-11	9
+2020-07-16	1
+2020-07-19	2
+2020-07-22	3
+2020-07-25	4
+-- !result
+SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t2 where dt>'2020-06-15' GROUP BY dt order by dt;
+-- result:
+2020-06-18	5
+2020-06-21	7
+2020-06-24	9
+2020-07-02	3
+2020-07-05	5
+2020-07-08	7
+2020-07-11	9
+2020-07-16	1
+2020-07-19	2
+2020-07-22	3
+2020-07-25	4
+-- !result
+SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t2 where dt>'2020-06-15' and dt < '2020-07-22' GROUP BY dt order by dt;
+-- result:
+2020-06-18	5
+2020-06-21	7
+2020-06-24	9
+2020-07-02	3
+2020-07-05	5
+2020-07-08	7
+2020-07-11	9
+2020-07-16	1
+2020-07-19	2
+-- !result
+SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t2 where dt>'2020-06-15' and dt <= '2020-07-22' GROUP BY dt order by dt;
+-- result:
+2020-06-18	5
+2020-06-21	7
+2020-06-24	9
+2020-07-02	3
+2020-07-05	5
+2020-07-08	7
+2020-07-11	9
+2020-07-16	1
+2020-07-19	2
+2020-07-22	3
+-- !result
+SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t2 where (dt>'2020-06-15' and dt <= '2020-06-22') or dt>'2020-07-01' GROUP BY dt order by dt;
+-- result:
+2020-06-18	5
+2020-06-21	7
+2020-07-02	3
+2020-07-05	5
+2020-07-08	7
+2020-07-11	9
+2020-07-16	1
+2020-07-19	2
+2020-07-22	3
+2020-07-25	4
+-- !result
+SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t2 where dt in ('2020-06-15', '2020-06-22', '2020-07-01') GROUP BY dt order by dt;
+-- result:
+2020-06-15	3
+-- !result
+SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t2 where date_trunc('day', dt) ='2020-06-15' GROUP BY dt order by dt;
+-- result:
+2020-06-15	3
+-- !result
+SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t2 where date_trunc('month', dt) ='2020-06-01' GROUP BY dt order by dt;
+-- result:
+2020-06-15	3
+2020-06-18	5
+2020-06-21	7
+2020-06-24	9
+-- !result
+SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t2 where date_trunc('month', dt) ='2020-07-01' GROUP BY dt order by dt;
+-- result:
+2020-07-02	3
+2020-07-05	5
+2020-07-08	7
+2020-07-11	9
+2020-07-16	1
+2020-07-19	2
+2020-07-22	3
+2020-07-25	4
+-- !result
+SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t2 GROUP BY dt order by dt;
+-- result:
+2020-06-15	3
+2020-06-18	5
+2020-06-21	7
+2020-06-24	9
+2020-07-02	3
+2020-07-05	5
+2020-07-08	7
+2020-07-11	9
+2020-07-16	1
+2020-07-19	2
+2020-07-22	3
+2020-07-25	4
+-- !result
+INSERT INTO mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t2 VALUES (3, "2020-06-15");
+-- result:
+-- !result
+function: check_no_hit_materialized_view("SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t2 where dt='2020-06-15' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_no_hit_materialized_view("SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t2 where date_trunc('day', dt) ='2020-06-15' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_no_hit_materialized_view("SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t2 where dt in ('2020-06-15', '2020-06-22', '2020-07-01') GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_no_hit_materialized_view("SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t2 where date_trunc('day', dt) ='2020-06-21' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t2 where dt !='2020-06-15' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t2 where dt>'2020-06-15' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t2 where dt>'2020-06-15' and dt < '2020-07-22' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t2 where dt>'2020-06-15' and dt <= '2020-07-22' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t2 where (dt>'2020-06-15' and dt <= '2020-06-22') or dt>'2020-07-01' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t2 where dt in ('2020-06-21', '2020-07-25') GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_no_hit_materialized_view("SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t2 where date_trunc('month', dt) ='2020-07-01' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t2 where dt between '2020-06-16' and '2020-07-01' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t2 where dt between '2020-06-15' and '2020-07-01' GROUP BY dt;", "test_mv1", "UNION")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t2 where dt>='2020-06-15' GROUP BY dt;", "test_mv1", "UNION")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t2 where dt in ('2020-06-15', '2020-06-21', '2020-07-25') GROUP BY dt;", "test_mv1", "UNION")
+-- result:
+None
+-- !result
+function: check_no_hit_materialized_view("SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t2 where date_trunc('month', dt) ='2020-06-01' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t2 GROUP BY dt;", "test_mv1", "UNION")
+-- result:
+None
+-- !result
+SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t2 where dt='2020-06-15' GROUP BY dt order by dt;
+-- result:
+2020-06-15	6
+-- !result
+SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t2 where dt !='2020-06-15' GROUP BY dt order by dt;
+-- result:
+2020-06-18	5
+2020-06-21	7
+2020-06-24	9
+2020-07-02	3
+2020-07-05	5
+2020-07-08	7
+2020-07-11	9
+2020-07-16	1
+2020-07-19	2
+2020-07-22	3
+2020-07-25	4
+-- !result
+SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t2 where dt>='2020-06-15' GROUP BY dt order by dt;
+-- result:
+2020-06-15	6
+2020-06-18	5
+2020-06-21	7
+2020-06-24	9
+2020-07-02	3
+2020-07-05	5
+2020-07-08	7
+2020-07-11	9
+2020-07-16	1
+2020-07-19	2
+2020-07-22	3
+2020-07-25	4
+-- !result
+SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t2 where dt>'2020-06-15' GROUP BY dt order by dt;
+-- result:
+2020-06-18	5
+2020-06-21	7
+2020-06-24	9
+2020-07-02	3
+2020-07-05	5
+2020-07-08	7
+2020-07-11	9
+2020-07-16	1
+2020-07-19	2
+2020-07-22	3
+2020-07-25	4
+-- !result
+SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t2 where dt>'2020-06-15' and dt < '2020-07-22' GROUP BY dt order by dt;
+-- result:
+2020-06-18	5
+2020-06-21	7
+2020-06-24	9
+2020-07-02	3
+2020-07-05	5
+2020-07-08	7
+2020-07-11	9
+2020-07-16	1
+2020-07-19	2
+-- !result
+SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t2 where dt>'2020-06-15' and dt <= '2020-07-22' GROUP BY dt order by dt;
+-- result:
+2020-06-18	5
+2020-06-21	7
+2020-06-24	9
+2020-07-02	3
+2020-07-05	5
+2020-07-08	7
+2020-07-11	9
+2020-07-16	1
+2020-07-19	2
+2020-07-22	3
+-- !result
+SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t2 where (dt>'2020-06-15' and dt <= '2020-06-22') or dt>'2020-07-01' GROUP BY dt order by dt;
+-- result:
+2020-06-18	5
+2020-06-21	7
+2020-07-02	3
+2020-07-05	5
+2020-07-08	7
+2020-07-11	9
+2020-07-16	1
+2020-07-19	2
+2020-07-22	3
+2020-07-25	4
+-- !result
+SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t2 where dt in ('2020-06-22', '2020-07-01') GROUP BY dt order by dt;
+-- result:
+-- !result
+SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t2 where dt in ('2020-06-15', '2020-06-22', '2020-07-01') GROUP BY dt order by dt;
+-- result:
+2020-06-15	6
+-- !result
+SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t2 where dt between '2020-06-15' and '2020-07-01' GROUP BY dt order by dt;
+-- result:
+2020-06-15	6
+2020-06-18	5
+2020-06-21	7
+2020-06-24	9
+-- !result
+SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t2 where date_trunc('day', dt) ='2020-06-15' GROUP BY dt order by dt;
+-- result:
+2020-06-15	6
+-- !result
+SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t2 where date_trunc('month', dt) ='2020-06-01' GROUP BY dt order by dt;
+-- result:
+2020-06-15	6
+2020-06-18	5
+2020-06-21	7
+2020-06-24	9
+-- !result
+SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t2 where date_trunc('month', dt) ='2020-07-01' GROUP BY dt order by dt;
+-- result:
+2020-07-02	3
+2020-07-05	5
+2020-07-08	7
+2020-07-11	9
+2020-07-16	1
+2020-07-19	2
+2020-07-22	3
+2020-07-25	4
+-- !result
+SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t2 GROUP BY dt order by dt;
+-- result:
+2020-06-15	6
+2020-06-18	5
+2020-06-21	7
+2020-06-24	9
+2020-07-02	3
+2020-07-05	5
+2020-07-08	7
+2020-07-11	9
+2020-07-16	1
+2020-07-19	2
+2020-07-22	3
+2020-07-25	4
+-- !result
+drop materialized view default_catalog.db_${uuid0}.test_mv1;
+-- result:
+-- !result
+CREATE MATERIALIZED VIEW test_mv1 
+PARTITION BY date_trunc('day', format_dt)
+REFRESH DEFERRED MANUAL AS 
+  SELECT dt, str2date(dt, '%Y-%m-%d') as format_dt, sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t2 GROUP BY dt;
+-- result:
+-- !result
+REFRESH MATERIALIZED VIEW test_mv1 WITH SYNC MODE;
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t2 where dt='2020-06-15' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t2 where dt !='2020-06-15' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t2 where dt>='2020-06-15' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t2 where dt>'2020-06-15' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t2 where dt>'2020-06-15' and dt < '2020-07-22' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t2 where dt>'2020-06-15' and dt <= '2020-07-22' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t2 where (dt>'2020-06-15' and dt <= '2020-06-22') or dt>'2020-07-01' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t2 where dt in ('2020-06-15', '2020-06-22', '2020-07-01') GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t2 where date_trunc('day', dt) ='2020-06-15' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t2 where date_trunc('month', dt) ='2020-06-01' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t2 where date_trunc('month', dt) ='2020-07-01' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t2 GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t2 where dt='2020-06-15' GROUP BY dt order by dt;
+-- result:
+2020-06-15	6
+-- !result
+SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t2 where dt !='2020-06-15' GROUP BY dt order by dt;
+-- result:
+2020-06-18	5
+2020-06-21	7
+2020-06-24	9
+2020-07-02	3
+2020-07-05	5
+2020-07-08	7
+2020-07-11	9
+2020-07-16	1
+2020-07-19	2
+2020-07-22	3
+2020-07-25	4
+-- !result
+SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t2 where dt>='2020-06-15' GROUP BY dt order by dt;
+-- result:
+2020-06-15	6
+2020-06-18	5
+2020-06-21	7
+2020-06-24	9
+2020-07-02	3
+2020-07-05	5
+2020-07-08	7
+2020-07-11	9
+2020-07-16	1
+2020-07-19	2
+2020-07-22	3
+2020-07-25	4
+-- !result
+SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t2 where dt>'2020-06-15' GROUP BY dt order by dt;
+-- result:
+2020-06-18	5
+2020-06-21	7
+2020-06-24	9
+2020-07-02	3
+2020-07-05	5
+2020-07-08	7
+2020-07-11	9
+2020-07-16	1
+2020-07-19	2
+2020-07-22	3
+2020-07-25	4
+-- !result
+SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t2 where dt>'2020-06-15' and dt < '2020-07-22' GROUP BY dt order by dt;
+-- result:
+2020-06-18	5
+2020-06-21	7
+2020-06-24	9
+2020-07-02	3
+2020-07-05	5
+2020-07-08	7
+2020-07-11	9
+2020-07-16	1
+2020-07-19	2
+-- !result
+SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t2 where dt>'2020-06-15' and dt <= '2020-07-22' GROUP BY dt order by dt;
+-- result:
+2020-06-18	5
+2020-06-21	7
+2020-06-24	9
+2020-07-02	3
+2020-07-05	5
+2020-07-08	7
+2020-07-11	9
+2020-07-16	1
+2020-07-19	2
+2020-07-22	3
+-- !result
+SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t2 where (dt>'2020-06-15' and dt <= '2020-06-22') or dt>'2020-07-01' GROUP BY dt order by dt;
+-- result:
+2020-06-18	5
+2020-06-21	7
+2020-07-02	3
+2020-07-05	5
+2020-07-08	7
+2020-07-11	9
+2020-07-16	1
+2020-07-19	2
+2020-07-22	3
+2020-07-25	4
+-- !result
+SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t2 where dt in ('2020-06-15', '2020-06-22', '2020-07-01') GROUP BY dt order by dt;
+-- result:
+2020-06-15	6
+-- !result
+SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t2 where date_trunc('day', dt) ='2020-06-15' GROUP BY dt order by dt;
+-- result:
+2020-06-15	6
+-- !result
+SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t2 where date_trunc('month', dt) ='2020-06-01' GROUP BY dt order by dt;
+-- result:
+2020-06-15	6
+2020-06-18	5
+2020-06-21	7
+2020-06-24	9
+-- !result
+SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t2 where date_trunc('month', dt) ='2020-07-01' GROUP BY dt order by dt;
+-- result:
+2020-07-02	3
+2020-07-05	5
+2020-07-08	7
+2020-07-11	9
+2020-07-16	1
+2020-07-19	2
+2020-07-22	3
+2020-07-25	4
+-- !result
+SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t2 GROUP BY dt order by dt;
+-- result:
+2020-06-15	6
+2020-06-18	5
+2020-06-21	7
+2020-06-24	9
+2020-07-02	3
+2020-07-05	5
+2020-07-08	7
+2020-07-11	9
+2020-07-16	1
+2020-07-19	2
+2020-07-22	3
+2020-07-25	4
+-- !result
+INSERT INTO mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t2 VALUES (3, "2020-06-15");
+-- result:
+-- !result
+function: check_no_hit_materialized_view("SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t2 where dt='2020-06-15' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_no_hit_materialized_view("SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t2 where date_trunc('day', dt) ='2020-06-15' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_no_hit_materialized_view("SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t2 where dt in ('2020-06-15', '2020-06-22', '2020-07-01') GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_no_hit_materialized_view("SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t2 where date_trunc('day', dt) ='2020-06-21' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t2 where dt !='2020-06-15' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t2 where dt>'2020-06-15' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t2 where dt>'2020-06-15' and dt < '2020-07-22' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t2 where dt>'2020-06-15' and dt <= '2020-07-22' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t2 where (dt>'2020-06-15' and dt <= '2020-06-22') or dt>'2020-07-01' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t2 where dt in ('2020-06-21', '2020-07-25') GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_no_hit_materialized_view("SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t2 where date_trunc('month', dt) ='2020-07-01' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t2 where dt between '2020-06-16' and '2020-07-01' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t2 where dt between '2020-06-15' and '2020-07-01' GROUP BY dt;", "test_mv1", "UNION")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t2 where dt>='2020-06-15' GROUP BY dt;", "test_mv1", "UNION")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t2 where dt in ('2020-06-15', '2020-06-21', '2020-07-25') GROUP BY dt;", "test_mv1", "UNION")
+-- result:
+None
+-- !result
+function: check_no_hit_materialized_view("SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t2 where date_trunc('month', dt) ='2020-06-01' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t2 GROUP BY dt;", "test_mv1", "UNION")
+-- result:
+None
+-- !result
+SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t2 where dt='2020-06-15' GROUP BY dt order by dt;
+-- result:
+2020-06-15	9
+-- !result
+SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t2 where dt !='2020-06-15' GROUP BY dt order by dt;
+-- result:
+2020-06-18	5
+2020-06-21	7
+2020-06-24	9
+2020-07-02	3
+2020-07-05	5
+2020-07-08	7
+2020-07-11	9
+2020-07-16	1
+2020-07-19	2
+2020-07-22	3
+2020-07-25	4
+-- !result
+SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t2 where dt>='2020-06-15' GROUP BY dt order by dt;
+-- result:
+2020-06-15	9
+2020-06-18	5
+2020-06-21	7
+2020-06-24	9
+2020-07-02	3
+2020-07-05	5
+2020-07-08	7
+2020-07-11	9
+2020-07-16	1
+2020-07-19	2
+2020-07-22	3
+2020-07-25	4
+-- !result
+SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t2 where dt>'2020-06-15' GROUP BY dt order by dt;
+-- result:
+2020-06-18	5
+2020-06-21	7
+2020-06-24	9
+2020-07-02	3
+2020-07-05	5
+2020-07-08	7
+2020-07-11	9
+2020-07-16	1
+2020-07-19	2
+2020-07-22	3
+2020-07-25	4
+-- !result
+SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t2 where dt>'2020-06-15' and dt < '2020-07-22' GROUP BY dt order by dt;
+-- result:
+2020-06-18	5
+2020-06-21	7
+2020-06-24	9
+2020-07-02	3
+2020-07-05	5
+2020-07-08	7
+2020-07-11	9
+2020-07-16	1
+2020-07-19	2
+-- !result
+SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t2 where dt>'2020-06-15' and dt <= '2020-07-22' GROUP BY dt order by dt;
+-- result:
+2020-06-18	5
+2020-06-21	7
+2020-06-24	9
+2020-07-02	3
+2020-07-05	5
+2020-07-08	7
+2020-07-11	9
+2020-07-16	1
+2020-07-19	2
+2020-07-22	3
+-- !result
+SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t2 where (dt>'2020-06-15' and dt <= '2020-06-22') or dt>'2020-07-01' GROUP BY dt order by dt;
+-- result:
+2020-06-18	5
+2020-06-21	7
+2020-07-02	3
+2020-07-05	5
+2020-07-08	7
+2020-07-11	9
+2020-07-16	1
+2020-07-19	2
+2020-07-22	3
+2020-07-25	4
+-- !result
+SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t2 where dt in ('2020-06-22', '2020-07-01') GROUP BY dt order by dt;
+-- result:
+-- !result
+SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t2 where dt in ('2020-06-15', '2020-06-22', '2020-07-01') GROUP BY dt order by dt;
+-- result:
+2020-06-15	9
+-- !result
+SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t2 where dt between '2020-06-15' and '2020-07-01' GROUP BY dt order by dt;
+-- result:
+2020-06-15	9
+2020-06-18	5
+2020-06-21	7
+2020-06-24	9
+-- !result
+SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t2 where date_trunc('day', dt) ='2020-06-15' GROUP BY dt order by dt;
+-- result:
+2020-06-15	9
+-- !result
+SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t2 where date_trunc('month', dt) ='2020-06-01' GROUP BY dt order by dt;
+-- result:
+2020-06-15	9
+2020-06-18	5
+2020-06-21	7
+2020-06-24	9
+-- !result
+SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t2 where date_trunc('month', dt) ='2020-07-01' GROUP BY dt order by dt;
+-- result:
+2020-07-02	3
+2020-07-05	5
+2020-07-08	7
+2020-07-11	9
+2020-07-16	1
+2020-07-19	2
+2020-07-22	3
+2020-07-25	4
+-- !result
+SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t2 GROUP BY dt order by dt;
+-- result:
+2020-06-15	9
+2020-06-18	5
+2020-06-21	7
+2020-06-24	9
+2020-07-02	3
+2020-07-05	5
+2020-07-08	7
+2020-07-11	9
+2020-07-16	1
+2020-07-19	2
+2020-07-22	3
+2020-07-25	4
+-- !result
+drop materialized view default_catalog.db_${uuid0}.test_mv1;
+-- result:
+-- !result
+drop table mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t2 force;
+-- result:
+-- !result
+drop table mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t2 force;
+-- result:
+E: (1064, "Getting analyzing error. Detail message: Unknown table 't2'.")
+-- !result

--- a/test/sql/test_materialized_view/R/test_mv_partition_compensate_mysql
+++ b/test/sql/test_materialized_view/R/test_mv_partition_compensate_mysql
@@ -1,0 +1,484 @@
+-- name: test_mv_partition_compensate_mysql
+shell: mysql -h${external_mysql_ip} -u${external_mysql_user} -p${external_mysql_password} -P${external_mysql_port} -e 'create database mv_mysql_db_${uuid0};'
+-- result:
+0
+
+-- !result
+shell: mysql -h${external_mysql_ip} -u${external_mysql_user} -p${external_mysql_password} -P${external_mysql_port} -e 'use mv_mysql_db_${uuid0}; CREATE TABLE t1 (num int, dt date) PARTITION BY range columns(dt) (PARTITION p20200614 VALUES LESS THAN ("2020-06-15"),PARTITION p20200617 VALUES LESS THAN ("2020-06-18"),PARTITION p20200620 VALUES LESS THAN ("2020-06-21"),PARTITION p20200623 VALUES LESS THAN ("2020-06-24"),PARTITION p20200701 VALUES LESS THAN ("2020-07-02"),PARTITION p20200704 VALUES LESS THAN ("2020-07-05"),PARTITION p20200707 VALUES LESS THAN ("2020-07-08"),PARTITION p20200710 VALUES LESS THAN ("2020-07-11"),PARTITION p20200715 VALUES LESS THAN ("2020-07-16"),PARTITION p20200718 VALUES LESS THAN ("2020-07-19"),PARTITION p20200721 VALUES LESS THAN ("2020-07-22"),PARTITION p20200724 VALUES LESS THAN ("2020-07-25"));'
+-- result:
+0
+
+-- !result
+shell: mysql -h${external_mysql_ip} -u${external_mysql_user} -p${external_mysql_password} -P${external_mysql_port} -e 'use mv_mysql_db_${uuid0}; INSERT INTO t1 VALUES (1,"2020-06-15"),(2,"2020-06-18"),(3,"2020-06-21"),(4,"2020-06-24"),(1,"2020-07-02"),(2,"2020-07-05"),(3,"2020-07-08"),(4,"2020-07-11"),(1,"2020-07-16"),(2,"2020-07-19"),(3,"2020-07-22"),(4,"2020-07-25"),(2,"2020-06-15"),(3,"2020-06-18"),(4,"2020-06-21"),(5,"2020-06-24"),(2,"2020-07-02"),(3,"2020-07-05"),(4,"2020-07-08"),(5,"2020-07-11");'
+-- result:
+1
+mysql: [Warning] Using a password on the command line interface can be insecure.
+ERROR 1526 (HY000) at line 1: Table has no partition for value from column_list
+-- !result
+set catalog default_catalog;
+-- result:
+-- !result
+create database db_${uuid0};
+-- result:
+-- !result
+use db_${uuid0};
+-- result:
+-- !result
+create external catalog mv_mysql_${uuid0}
+properties
+(
+    "type" = "jdbc",
+    "user"="${external_mysql_user}",
+    "password"="${external_mysql_password}",
+    "jdbc_uri"="jdbc:mysql://${external_mysql_ip}:${external_mysql_port}",
+    "driver_url"="https://repo1.maven.org/maven2/mysql/mysql-connector-java/8.0.28/mysql-connector-java-8.0.28.jar",
+    "driver_class"="com.mysql.cj.jdbc.Driver"
+);
+-- result:
+-- !result
+CREATE MATERIALIZED VIEW test_mv1 
+PARTITION BY dt 
+REFRESH DEFERRED MANUAL AS 
+  SELECT dt,sum(num) FROM mv_mysql_${uuid0}.mv_mysql_db_${uuid0}.t1 GROUP BY dt;
+-- result:
+-- !result
+REFRESH MATERIALIZED VIEW test_mv1 WITH SYNC MODE;
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_mysql_${uuid0}.mv_mysql_db_${uuid0}.t1 where dt='2020-06-15' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_mysql_${uuid0}.mv_mysql_db_${uuid0}.t1 where dt !='2020-06-15' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_mysql_${uuid0}.mv_mysql_db_${uuid0}.t1 where dt>='2020-06-15' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_mysql_${uuid0}.mv_mysql_db_${uuid0}.t1 where dt>'2020-06-15' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_mysql_${uuid0}.mv_mysql_db_${uuid0}.t1 where dt>'2020-06-15' and dt < '2020-07-22' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_mysql_${uuid0}.mv_mysql_db_${uuid0}.t1 where dt>'2020-06-15' and dt <= '2020-07-22' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_mysql_${uuid0}.mv_mysql_db_${uuid0}.t1 where (dt>'2020-06-15' and dt <= '2020-06-22') or dt>'2020-07-01' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_mysql_${uuid0}.mv_mysql_db_${uuid0}.t1 where dt in ('2020-06-15', '2020-06-22', '2020-07-01') GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_mysql_${uuid0}.mv_mysql_db_${uuid0}.t1 where date_trunc('day', dt) ='2020-06-15' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_no_hit_materialized_view("SELECT dt,sum(num) FROM mv_mysql_${uuid0}.mv_mysql_db_${uuid0}.t1 where date_trunc('month', dt) ='2020-06-01' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_no_hit_materialized_view("SELECT dt,sum(num) FROM mv_mysql_${uuid0}.mv_mysql_db_${uuid0}.t1 where date_trunc('month', dt) ='2020-07-01' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_mysql_${uuid0}.mv_mysql_db_${uuid0}.t1 GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+SELECT dt,sum(num) FROM mv_mysql_${uuid0}.mv_mysql_db_${uuid0}.t1 where dt='2020-06-15' GROUP BY dt order by dt;
+-- result:
+-- !result
+SELECT dt,sum(num) FROM mv_mysql_${uuid0}.mv_mysql_db_${uuid0}.t1 where dt !='2020-06-15' GROUP BY dt order by dt;
+-- result:
+-- !result
+SELECT dt,sum(num) FROM mv_mysql_${uuid0}.mv_mysql_db_${uuid0}.t1 where dt>='2020-06-15' GROUP BY dt order by dt;
+-- result:
+-- !result
+SELECT dt,sum(num) FROM mv_mysql_${uuid0}.mv_mysql_db_${uuid0}.t1 where dt>'2020-06-15' GROUP BY dt order by dt;
+-- result:
+-- !result
+SELECT dt,sum(num) FROM mv_mysql_${uuid0}.mv_mysql_db_${uuid0}.t1 where dt>'2020-06-15' and dt < '2020-07-22' GROUP BY dt order by dt;
+-- result:
+-- !result
+SELECT dt,sum(num) FROM mv_mysql_${uuid0}.mv_mysql_db_${uuid0}.t1 where dt>'2020-06-15' and dt <= '2020-07-22' GROUP BY dt order by dt;
+-- result:
+-- !result
+SELECT dt,sum(num) FROM mv_mysql_${uuid0}.mv_mysql_db_${uuid0}.t1 where (dt>'2020-06-15' and dt <= '2020-06-22') or dt>'2020-07-01' GROUP BY dt order by dt;
+-- result:
+-- !result
+SELECT dt,sum(num) FROM mv_mysql_${uuid0}.mv_mysql_db_${uuid0}.t1 where dt in ('2020-06-15', '2020-06-22', '2020-07-01') GROUP BY dt order by dt;
+-- result:
+-- !result
+SELECT dt,sum(num) FROM mv_mysql_${uuid0}.mv_mysql_db_${uuid0}.t1 where date_trunc('day', dt) ='2020-06-15' GROUP BY dt order by dt;
+-- result:
+-- !result
+SELECT dt,sum(num) FROM mv_mysql_${uuid0}.mv_mysql_db_${uuid0}.t1 where date_trunc('month', dt) ='2020-06-01' GROUP BY dt order by dt;
+-- result:
+-- !result
+SELECT dt,sum(num) FROM mv_mysql_${uuid0}.mv_mysql_db_${uuid0}.t1 where date_trunc('month', dt) ='2020-07-01' GROUP BY dt order by dt;
+-- result:
+-- !result
+SELECT dt,sum(num) FROM mv_mysql_${uuid0}.mv_mysql_db_${uuid0}.t1 GROUP BY dt order by dt;
+-- result:
+-- !result
+shell: mysql -h${external_mysql_ip} -u${external_mysql_user} -p${external_mysql_password} -P${external_mysql_port} -e 'use mv_mysql_db_${uuid0}; INSERT INTO t1 VALUES (3,"2020-06-15");'
+-- result:
+0
+
+-- !result
+function: check_no_hit_materialized_view("SELECT dt,sum(num) FROM mv_mysql_${uuid0}.mv_mysql_db_${uuid0}.t1 where dt='2020-06-15' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_no_hit_materialized_view("SELECT dt,sum(num) FROM mv_mysql_${uuid0}.mv_mysql_db_${uuid0}.t1 where date_trunc('day', dt) ='2020-06-15' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_no_hit_materialized_view("SELECT dt,sum(num) FROM mv_mysql_${uuid0}.mv_mysql_db_${uuid0}.t1 where dt in ('2020-06-15', '2020-06-22', '2020-07-01') GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_no_hit_materialized_view("SELECT dt,sum(num) FROM mv_mysql_${uuid0}.mv_mysql_db_${uuid0}.t1 where date_trunc('day', dt) ='2020-06-21' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_no_hit_materialized_view("SELECT dt,sum(num) FROM mv_mysql_${uuid0}.mv_mysql_db_${uuid0}.t1 where dt !='2020-06-15' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_no_hit_materialized_view("SELECT dt,sum(num) FROM mv_mysql_${uuid0}.mv_mysql_db_${uuid0}.t1 where dt>'2020-06-15' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_no_hit_materialized_view("SELECT dt,sum(num) FROM mv_mysql_${uuid0}.mv_mysql_db_${uuid0}.t1 where dt>'2020-06-15' and dt < '2020-07-22' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_no_hit_materialized_view("SELECT dt,sum(num) FROM mv_mysql_${uuid0}.mv_mysql_db_${uuid0}.t1 where dt>'2020-06-15' and dt <= '2020-07-22' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_no_hit_materialized_view("SELECT dt,sum(num) FROM mv_mysql_${uuid0}.mv_mysql_db_${uuid0}.t1 where (dt>'2020-06-15' and dt <= '2020-06-22') or dt>'2020-07-01' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_no_hit_materialized_view("SELECT dt,sum(num) FROM mv_mysql_${uuid0}.mv_mysql_db_${uuid0}.t1 where dt in ('2020-06-21', '2020-07-25') GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_no_hit_materialized_view("SELECT dt,sum(num) FROM mv_mysql_${uuid0}.mv_mysql_db_${uuid0}.t1 where date_trunc('month', dt) ='2020-07-01' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_no_hit_materialized_view("SELECT dt,sum(num) FROM mv_mysql_${uuid0}.mv_mysql_db_${uuid0}.t1 where dt between '2020-06-16' and '2020-07-01' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_no_hit_materialized_view("SELECT dt,sum(num) FROM mv_mysql_${uuid0}.mv_mysql_db_${uuid0}.t1 where dt between '2020-06-15' and '2020-07-01' GROUP BY dt;", "test_mv1", "UNION")
+-- result:
+None
+-- !result
+function: check_no_hit_materialized_view("SELECT dt,sum(num) FROM mv_mysql_${uuid0}.mv_mysql_db_${uuid0}.t1 where dt>='2020-06-15' GROUP BY dt;", "test_mv1", "UNION")
+-- result:
+None
+-- !result
+function: check_no_hit_materialized_view("SELECT dt,sum(num) FROM mv_mysql_${uuid0}.mv_mysql_db_${uuid0}.t1 where dt in ('2020-06-15', '2020-06-21', '2020-07-25') GROUP BY dt;", "test_mv1", "UNION")
+-- result:
+None
+-- !result
+function: check_no_hit_materialized_view("SELECT dt,sum(num) FROM mv_mysql_${uuid0}.mv_mysql_db_${uuid0}.t1 where date_trunc('month', dt) ='2020-06-01' GROUP BY dt;", "test_mv1", "UNION")
+-- result:
+None
+-- !result
+function: check_no_hit_materialized_view("SELECT dt,sum(num) FROM mv_mysql_${uuid0}.mv_mysql_db_${uuid0}.t1 GROUP BY dt;", "test_mv1", "UNION")
+-- result:
+None
+-- !result
+SELECT dt,sum(num) FROM mv_mysql_${uuid0}.mv_mysql_db_${uuid0}.t1 where dt='2020-06-15' GROUP BY dt order by dt;
+-- result:
+2020-06-15	3
+-- !result
+SELECT dt,sum(num) FROM mv_mysql_${uuid0}.mv_mysql_db_${uuid0}.t1 where dt !='2020-06-15' GROUP BY dt order by dt;
+-- result:
+-- !result
+SELECT dt,sum(num) FROM mv_mysql_${uuid0}.mv_mysql_db_${uuid0}.t1 where dt>='2020-06-15' GROUP BY dt order by dt;
+-- result:
+2020-06-15	3
+-- !result
+SELECT dt,sum(num) FROM mv_mysql_${uuid0}.mv_mysql_db_${uuid0}.t1 where dt>'2020-06-15' GROUP BY dt order by dt;
+-- result:
+-- !result
+SELECT dt,sum(num) FROM mv_mysql_${uuid0}.mv_mysql_db_${uuid0}.t1 where dt>'2020-06-15' and dt < '2020-07-22' GROUP BY dt order by dt;
+-- result:
+-- !result
+SELECT dt,sum(num) FROM mv_mysql_${uuid0}.mv_mysql_db_${uuid0}.t1 where dt>'2020-06-15' and dt <= '2020-07-22' GROUP BY dt order by dt;
+-- result:
+-- !result
+SELECT dt,sum(num) FROM mv_mysql_${uuid0}.mv_mysql_db_${uuid0}.t1 where (dt>'2020-06-15' and dt <= '2020-06-22') or dt>'2020-07-01' GROUP BY dt order by dt;
+-- result:
+-- !result
+SELECT dt,sum(num) FROM mv_mysql_${uuid0}.mv_mysql_db_${uuid0}.t1 where dt in ('2020-06-22', '2020-07-01') GROUP BY dt order by dt;
+-- result:
+-- !result
+SELECT dt,sum(num) FROM mv_mysql_${uuid0}.mv_mysql_db_${uuid0}.t1 where dt in ('2020-06-15', '2020-06-22', '2020-07-01') GROUP BY dt order by dt;
+-- result:
+2020-06-15	3
+-- !result
+SELECT dt,sum(num) FROM mv_mysql_${uuid0}.mv_mysql_db_${uuid0}.t1 where dt between '2020-06-15' and '2020-07-01' GROUP BY dt order by dt;
+-- result:
+2020-06-15	3
+-- !result
+SELECT dt,sum(num) FROM mv_mysql_${uuid0}.mv_mysql_db_${uuid0}.t1 where date_trunc('day', dt) ='2020-06-15' GROUP BY dt order by dt;
+-- result:
+2020-06-15	3
+-- !result
+SELECT dt,sum(num) FROM mv_mysql_${uuid0}.mv_mysql_db_${uuid0}.t1 where date_trunc('month', dt) ='2020-06-01' GROUP BY dt order by dt;
+-- result:
+2020-06-15	3
+-- !result
+SELECT dt,sum(num) FROM mv_mysql_${uuid0}.mv_mysql_db_${uuid0}.t1 where date_trunc('month', dt) ='2020-07-01' GROUP BY dt order by dt;
+-- result:
+-- !result
+SELECT dt,sum(num) FROM mv_mysql_${uuid0}.mv_mysql_db_${uuid0}.t1 GROUP BY dt order by dt;
+-- result:
+2020-06-15	3
+-- !result
+drop materialized view default_catalog.db_${uuid0}.test_mv1;
+-- result:
+-- !result
+CREATE MATERIALIZED VIEW test_mv1 
+PARTITION BY date_trunc('day', dt)
+REFRESH DEFERRED MANUAL AS 
+  SELECT dt,sum(num) FROM mv_mysql_${uuid0}.mv_mysql_db_${uuid0}.t1 GROUP BY dt;
+-- result:
+-- !result
+REFRESH MATERIALIZED VIEW test_mv1 WITH SYNC MODE;
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_mysql_${uuid0}.mv_mysql_db_${uuid0}.t1 where dt='2020-06-15' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_mysql_${uuid0}.mv_mysql_db_${uuid0}.t1 where dt !='2020-06-15' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_mysql_${uuid0}.mv_mysql_db_${uuid0}.t1 where dt>='2020-06-15' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_mysql_${uuid0}.mv_mysql_db_${uuid0}.t1 where dt>'2020-06-15' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_mysql_${uuid0}.mv_mysql_db_${uuid0}.t1 where dt>'2020-06-15' and dt < '2020-07-22' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_mysql_${uuid0}.mv_mysql_db_${uuid0}.t1 where dt>'2020-06-15' and dt <= '2020-07-22' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_mysql_${uuid0}.mv_mysql_db_${uuid0}.t1 where (dt>'2020-06-15' and dt <= '2020-06-22') or dt>'2020-07-01' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_mysql_${uuid0}.mv_mysql_db_${uuid0}.t1 where dt in ('2020-06-15', '2020-06-22', '2020-07-01') GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_mysql_${uuid0}.mv_mysql_db_${uuid0}.t1 where date_trunc('day', dt) ='2020-06-15' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_no_hit_materialized_view("SELECT dt,sum(num) FROM mv_mysql_${uuid0}.mv_mysql_db_${uuid0}.t1 where date_trunc('month', dt) ='2020-06-01' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_no_hit_materialized_view("SELECT dt,sum(num) FROM mv_mysql_${uuid0}.mv_mysql_db_${uuid0}.t1 where date_trunc('month', dt) ='2020-07-01' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_mysql_${uuid0}.mv_mysql_db_${uuid0}.t1 GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+SELECT dt,sum(num) FROM mv_mysql_${uuid0}.mv_mysql_db_${uuid0}.t1 where dt='2020-06-15' GROUP BY dt order by dt;
+-- result:
+2020-06-15	3
+-- !result
+SELECT dt,sum(num) FROM mv_mysql_${uuid0}.mv_mysql_db_${uuid0}.t1 where dt !='2020-06-15' GROUP BY dt order by dt;
+-- result:
+-- !result
+SELECT dt,sum(num) FROM mv_mysql_${uuid0}.mv_mysql_db_${uuid0}.t1 where dt>='2020-06-15' GROUP BY dt order by dt;
+-- result:
+2020-06-15	3
+-- !result
+SELECT dt,sum(num) FROM mv_mysql_${uuid0}.mv_mysql_db_${uuid0}.t1 where dt>'2020-06-15' GROUP BY dt order by dt;
+-- result:
+-- !result
+SELECT dt,sum(num) FROM mv_mysql_${uuid0}.mv_mysql_db_${uuid0}.t1 where dt>'2020-06-15' and dt < '2020-07-22' GROUP BY dt order by dt;
+-- result:
+-- !result
+SELECT dt,sum(num) FROM mv_mysql_${uuid0}.mv_mysql_db_${uuid0}.t1 where dt>'2020-06-15' and dt <= '2020-07-22' GROUP BY dt order by dt;
+-- result:
+-- !result
+SELECT dt,sum(num) FROM mv_mysql_${uuid0}.mv_mysql_db_${uuid0}.t1 where (dt>'2020-06-15' and dt <= '2020-06-22') or dt>'2020-07-01' GROUP BY dt order by dt;
+-- result:
+-- !result
+SELECT dt,sum(num) FROM mv_mysql_${uuid0}.mv_mysql_db_${uuid0}.t1 where dt in ('2020-06-15', '2020-06-22', '2020-07-01') GROUP BY dt order by dt;
+-- result:
+2020-06-15	3
+-- !result
+SELECT dt,sum(num) FROM mv_mysql_${uuid0}.mv_mysql_db_${uuid0}.t1 where date_trunc('day', dt) ='2020-06-15' GROUP BY dt order by dt;
+-- result:
+2020-06-15	3
+-- !result
+SELECT dt,sum(num) FROM mv_mysql_${uuid0}.mv_mysql_db_${uuid0}.t1 where date_trunc('month', dt) ='2020-06-01' GROUP BY dt order by dt;
+-- result:
+2020-06-15	3
+-- !result
+SELECT dt,sum(num) FROM mv_mysql_${uuid0}.mv_mysql_db_${uuid0}.t1 where date_trunc('month', dt) ='2020-07-01' GROUP BY dt order by dt;
+-- result:
+-- !result
+SELECT dt,sum(num) FROM mv_mysql_${uuid0}.mv_mysql_db_${uuid0}.t1 GROUP BY dt order by dt;
+-- result:
+2020-06-15	3
+-- !result
+shell: mysql -h${external_mysql_ip} -u${external_mysql_user} -p${external_mysql_password} -P${external_mysql_port} -e 'use mv_mysql_db_${uuid0}; INSERT INTO t1 VALUES (3,"2020-06-15");'
+-- result:
+0
+
+-- !result
+alter materialized view test_mv1 set('query_rewrite_consistency' = 'loose');
+-- result:
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_mysql_${uuid0}.mv_mysql_db_${uuid0}.t1 where dt='2020-06-15' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_mysql_${uuid0}.mv_mysql_db_${uuid0}.t1 where date_trunc('day', dt) ='2020-06-15' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_mysql_${uuid0}.mv_mysql_db_${uuid0}.t1 where dt in ('2020-06-15', '2020-06-22', '2020-07-01') GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_mysql_${uuid0}.mv_mysql_db_${uuid0}.t1 where date_trunc('day', dt) ='2020-06-21' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_mysql_${uuid0}.mv_mysql_db_${uuid0}.t1 where dt !='2020-06-15' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_mysql_${uuid0}.mv_mysql_db_${uuid0}.t1 where dt>'2020-06-15' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_mysql_${uuid0}.mv_mysql_db_${uuid0}.t1 where dt>'2020-06-15' and dt < '2020-07-22' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_mysql_${uuid0}.mv_mysql_db_${uuid0}.t1 where dt>'2020-06-15' and dt <= '2020-07-22' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_mysql_${uuid0}.mv_mysql_db_${uuid0}.t1 where (dt>'2020-06-15' and dt <= '2020-06-22') or dt>'2020-07-01' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_mysql_${uuid0}.mv_mysql_db_${uuid0}.t1 where dt in ('2020-06-21', '2020-07-25') GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_no_hit_materialized_view("SELECT dt,sum(num) FROM mv_mysql_${uuid0}.mv_mysql_db_${uuid0}.t1 where date_trunc('month', dt) ='2020-07-01' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_mysql_${uuid0}.mv_mysql_db_${uuid0}.t1 where dt between '2020-06-16' and '2020-07-01' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_mysql_${uuid0}.mv_mysql_db_${uuid0}.t1 where dt between '2020-06-15' and '2020-07-01' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_mysql_${uuid0}.mv_mysql_db_${uuid0}.t1 where dt>='2020-06-15' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_mysql_${uuid0}.mv_mysql_db_${uuid0}.t1 where dt in ('2020-06-15', '2020-06-21', '2020-07-25') GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_no_hit_materialized_view("SELECT dt,sum(num) FROM mv_mysql_${uuid0}.mv_mysql_db_${uuid0}.t1 where date_trunc('month', dt) ='2020-06-01' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_mysql_${uuid0}.mv_mysql_db_${uuid0}.t1 GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+SELECT dt,sum(num) FROM mv_mysql_${uuid0}.mv_mysql_db_${uuid0}.t1 where dt='2020-06-15' GROUP BY dt order by dt;
+-- result:
+2020-06-15	3
+-- !result
+SELECT dt,sum(num) FROM mv_mysql_${uuid0}.mv_mysql_db_${uuid0}.t1 where dt !='2020-06-15' GROUP BY dt order by dt;
+-- result:
+-- !result
+SELECT dt,sum(num) FROM mv_mysql_${uuid0}.mv_mysql_db_${uuid0}.t1 where dt>='2020-06-15' GROUP BY dt order by dt;
+-- result:
+2020-06-15	3
+-- !result
+SELECT dt,sum(num) FROM mv_mysql_${uuid0}.mv_mysql_db_${uuid0}.t1 where dt>'2020-06-15' GROUP BY dt order by dt;
+-- result:
+-- !result
+SELECT dt,sum(num) FROM mv_mysql_${uuid0}.mv_mysql_db_${uuid0}.t1 where dt>'2020-06-15' and dt < '2020-07-22' GROUP BY dt order by dt;
+-- result:
+-- !result
+SELECT dt,sum(num) FROM mv_mysql_${uuid0}.mv_mysql_db_${uuid0}.t1 where dt>'2020-06-15' and dt <= '2020-07-22' GROUP BY dt order by dt;
+-- result:
+-- !result
+SELECT dt,sum(num) FROM mv_mysql_${uuid0}.mv_mysql_db_${uuid0}.t1 where (dt>'2020-06-15' and dt <= '2020-06-22') or dt>'2020-07-01' GROUP BY dt order by dt;
+-- result:
+-- !result
+SELECT dt,sum(num) FROM mv_mysql_${uuid0}.mv_mysql_db_${uuid0}.t1 where dt in ('2020-06-22', '2020-07-01') GROUP BY dt order by dt;
+-- result:
+-- !result
+SELECT dt,sum(num) FROM mv_mysql_${uuid0}.mv_mysql_db_${uuid0}.t1 where dt in ('2020-06-15', '2020-06-22', '2020-07-01') GROUP BY dt order by dt;
+-- result:
+2020-06-15	3
+-- !result
+SELECT dt,sum(num) FROM mv_mysql_${uuid0}.mv_mysql_db_${uuid0}.t1 where dt between '2020-06-15' and '2020-07-01' GROUP BY dt order by dt;
+-- result:
+2020-06-15	3
+-- !result
+SELECT dt,sum(num) FROM mv_mysql_${uuid0}.mv_mysql_db_${uuid0}.t1 where date_trunc('day', dt) ='2020-06-15' GROUP BY dt order by dt;
+-- result:
+2020-06-15	3
+-- !result
+SELECT dt,sum(num) FROM mv_mysql_${uuid0}.mv_mysql_db_${uuid0}.t1 where date_trunc('month', dt) ='2020-06-01' GROUP BY dt order by dt;
+-- result:
+2020-06-15	6
+-- !result
+SELECT dt,sum(num) FROM mv_mysql_${uuid0}.mv_mysql_db_${uuid0}.t1 where date_trunc('month', dt) ='2020-07-01' GROUP BY dt order by dt;
+-- result:
+-- !result
+SELECT dt,sum(num) FROM mv_mysql_${uuid0}.mv_mysql_db_${uuid0}.t1 GROUP BY dt order by dt;
+-- result:
+2020-06-15	3
+-- !result
+drop materialized view default_catalog.db_${uuid0}.test_mv1;
+-- result:
+-- !result
+shell: mysql -h${external_mysql_ip} -u${external_mysql_user} -p${external_mysql_password} -P${external_mysql_port} -e 'drop database mv_mysql_db_${uuid0};'
+-- result:
+0
+
+-- !result

--- a/test/sql/test_materialized_view/R/test_mv_partition_compensate_olap
+++ b/test/sql/test_materialized_view/R/test_mv_partition_compensate_olap
@@ -1,0 +1,801 @@
+-- name: test_mv_partition_compensate_olap
+create database db_${uuid0};
+-- result:
+-- !result
+use db_${uuid0};
+-- result:
+-- !result
+CREATE TABLE t1 (
+  num int,
+  dt date
+)
+DUPLICATE KEY(`num`)
+PARTITION BY RANGE(`dt`)
+(
+  PARTITION p20200615 VALUES [("2020-06-15 00:00:00"), ("2020-06-16 00:00:00")),
+  PARTITION p20200618 VALUES [("2020-06-18 00:00:00"), ("2020-06-19 00:00:00")),
+  PARTITION p20200621 VALUES [("2020-06-21 00:00:00"), ("2020-06-22 00:00:00")),
+  PARTITION p20200624 VALUES [("2020-06-24 00:00:00"), ("2020-06-25 00:00:00")),
+  PARTITION p20200702 VALUES [("2020-07-02 00:00:00"), ("2020-07-03 00:00:00")),
+  PARTITION p20200705 VALUES [("2020-07-05 00:00:00"), ("2020-07-06 00:00:00")),
+  PARTITION p20200708 VALUES [("2020-07-08 00:00:00"), ("2020-07-09 00:00:00")),
+  PARTITION p20200716 VALUES [("2020-07-16 00:00:00"), ("2020-07-17 00:00:00")),
+  PARTITION p20200719 VALUES [("2020-07-19 00:00:00"), ("2020-07-20 00:00:00")),
+  PARTITION p20200722 VALUES [("2020-07-22 00:00:00"), ("2020-07-23 00:00:00")),
+  PARTITION p20200725 VALUES [("2020-07-25 00:00:00"), ("2020-07-26 00:00:00")),
+  PARTITION p20200711 VALUES [("2020-07-11 00:00:00"), ("2020-07-12 00:00:00"))
+)
+DISTRIBUTED BY HASH(`num`);
+-- result:
+-- !result
+INSERT INTO t1 VALUES 
+  (1,"2020-06-15"),(2,"2020-06-18"),(3,"2020-06-21"),(4,"2020-06-24"),
+  (1,"2020-07-02"),(2,"2020-07-05"),(3,"2020-07-08"),(4,"2020-07-11"),
+  (1,"2020-07-16"),(2,"2020-07-19"),(3,"2020-07-22"),(4,"2020-07-25"),
+  (2,"2020-06-15"),(3,"2020-06-18"),(4,"2020-06-21"),(5,"2020-06-24"),
+  (2,"2020-07-02"),(3,"2020-07-05"),(4,"2020-07-08"),(5,"2020-07-11");
+-- result:
+-- !result
+CREATE MATERIALIZED VIEW test_mv1 
+PARTITION BY dt 
+REFRESH DEFERRED MANUAL AS 
+  SELECT dt,sum(num) FROM t1 GROUP BY dt;
+-- result:
+-- !result
+REFRESH MATERIALIZED VIEW test_mv1 WITH SYNC MODE;
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t1 where dt='2020-06-15' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t1 where dt !='2020-06-15' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t1 where dt>='2020-06-15' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t1 where dt>'2020-06-15' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t1 where dt>'2020-06-15' and dt < '2020-07-22' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t1 where dt>'2020-06-15' and dt <= '2020-07-22' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t1 where (dt>'2020-06-15' and dt <= '2020-06-22') or dt>'2020-07-01' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t1 where dt in ('2020-06-15', '2020-06-22', '2020-07-01') GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t1 where date_trunc('day', dt) ='2020-06-15' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t1 where date_trunc('month', dt) ='2020-06-01' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t1 where date_trunc('month', dt) ='2020-07-01' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t1 GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+SELECT dt,sum(num) FROM t1 where dt='2020-06-15' GROUP BY dt order by dt;
+-- result:
+2020-06-15	3
+-- !result
+SELECT dt,sum(num) FROM t1 where dt !='2020-06-15' GROUP BY dt order by dt;
+-- result:
+2020-06-18	5
+2020-06-21	7
+2020-06-24	9
+2020-07-02	3
+2020-07-05	5
+2020-07-08	7
+2020-07-11	9
+2020-07-16	1
+2020-07-19	2
+2020-07-22	3
+2020-07-25	4
+-- !result
+SELECT dt,sum(num) FROM t1 where dt>='2020-06-15' GROUP BY dt order by dt;
+-- result:
+2020-06-15	3
+2020-06-18	5
+2020-06-21	7
+2020-06-24	9
+2020-07-02	3
+2020-07-05	5
+2020-07-08	7
+2020-07-11	9
+2020-07-16	1
+2020-07-19	2
+2020-07-22	3
+2020-07-25	4
+-- !result
+SELECT dt,sum(num) FROM t1 where dt>'2020-06-15' GROUP BY dt order by dt;
+-- result:
+2020-06-18	5
+2020-06-21	7
+2020-06-24	9
+2020-07-02	3
+2020-07-05	5
+2020-07-08	7
+2020-07-11	9
+2020-07-16	1
+2020-07-19	2
+2020-07-22	3
+2020-07-25	4
+-- !result
+SELECT dt,sum(num) FROM t1 where dt>'2020-06-15' and dt < '2020-07-22' GROUP BY dt order by dt;
+-- result:
+2020-06-18	5
+2020-06-21	7
+2020-06-24	9
+2020-07-02	3
+2020-07-05	5
+2020-07-08	7
+2020-07-11	9
+2020-07-16	1
+2020-07-19	2
+-- !result
+SELECT dt,sum(num) FROM t1 where dt>'2020-06-15' and dt <= '2020-07-22' GROUP BY dt order by dt;
+-- result:
+2020-06-18	5
+2020-06-21	7
+2020-06-24	9
+2020-07-02	3
+2020-07-05	5
+2020-07-08	7
+2020-07-11	9
+2020-07-16	1
+2020-07-19	2
+2020-07-22	3
+-- !result
+SELECT dt,sum(num) FROM t1 where (dt>'2020-06-15' and dt <= '2020-06-22') or dt>'2020-07-01' GROUP BY dt order by dt;
+-- result:
+2020-06-18	5
+2020-06-21	7
+2020-07-02	3
+2020-07-05	5
+2020-07-08	7
+2020-07-11	9
+2020-07-16	1
+2020-07-19	2
+2020-07-22	3
+2020-07-25	4
+-- !result
+SELECT dt,sum(num) FROM t1 where dt in ('2020-06-15', '2020-06-22', '2020-07-01') GROUP BY dt order by dt;
+-- result:
+2020-06-15	3
+-- !result
+SELECT dt,sum(num) FROM t1 where date_trunc('day', dt) ='2020-06-15' GROUP BY dt order by dt;
+-- result:
+2020-06-15	3
+-- !result
+SELECT dt,sum(num) FROM t1 where date_trunc('month', dt) ='2020-06-01' GROUP BY dt order by dt;
+-- result:
+2020-06-15	3
+2020-06-18	5
+2020-06-21	7
+2020-06-24	9
+-- !result
+SELECT dt,sum(num) FROM t1 where date_trunc('month', dt) ='2020-07-01' GROUP BY dt order by dt;
+-- result:
+2020-07-02	3
+2020-07-05	5
+2020-07-08	7
+2020-07-11	9
+2020-07-16	1
+2020-07-19	2
+2020-07-22	3
+2020-07-25	4
+-- !result
+SELECT dt,sum(num) FROM t1 GROUP BY dt order by dt;
+-- result:
+2020-06-15	3
+2020-06-18	5
+2020-06-21	7
+2020-06-24	9
+2020-07-02	3
+2020-07-05	5
+2020-07-08	7
+2020-07-11	9
+2020-07-16	1
+2020-07-19	2
+2020-07-22	3
+2020-07-25	4
+-- !result
+INSERT INTO t1 VALUES (3, "2020-06-15");
+-- result:
+-- !result
+function: check_no_hit_materialized_view("SELECT dt,sum(num) FROM t1 where dt='2020-06-15' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_no_hit_materialized_view("SELECT dt,sum(num) FROM t1 where date_trunc('day', dt) ='2020-06-15' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_no_hit_materialized_view("SELECT dt,sum(num) FROM t1 where dt in ('2020-06-15', '2020-06-22', '2020-07-01') GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t1 where date_trunc('day', dt) ='2020-06-21' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t1 where dt !='2020-06-15' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t1 where dt>'2020-06-15' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t1 where dt>'2020-06-15' and dt < '2020-07-22' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t1 where dt>'2020-06-15' and dt <= '2020-07-22' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t1 where (dt>'2020-06-15' and dt <= '2020-06-22') or dt>'2020-07-01' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t1 where date_trunc('month', dt) ='2020-07-01' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t1 where dt between '2020-06-15' and '2020-07-01' GROUP BY dt;", "test_mv1", "UNION")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t1 where dt>='2020-06-15' GROUP BY dt;", "test_mv1", "UNION")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t1 where dt in ('2020-06-15', '2020-06-21', '2020-07-25') GROUP BY dt;", "test_mv1", "UNION")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t1 where date_trunc('month', dt) ='2020-06-01' GROUP BY dt;", "test_mv1", "UNION")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t1 GROUP BY dt;", "test_mv1", "UNION")
+-- result:
+None
+-- !result
+SELECT dt,sum(num) FROM t1 where dt='2020-06-15' GROUP BY dt order by dt;
+-- result:
+2020-06-15	6
+-- !result
+SELECT dt,sum(num) FROM t1 where dt !='2020-06-15' GROUP BY dt order by dt;
+-- result:
+2020-06-18	5
+2020-06-21	7
+2020-06-24	9
+2020-07-02	3
+2020-07-05	5
+2020-07-08	7
+2020-07-11	9
+2020-07-16	1
+2020-07-19	2
+2020-07-22	3
+2020-07-25	4
+-- !result
+SELECT dt,sum(num) FROM t1 where dt>='2020-06-15' GROUP BY dt order by dt;
+-- result:
+2020-06-15	6
+2020-06-18	5
+2020-06-21	7
+2020-06-24	9
+2020-07-02	3
+2020-07-05	5
+2020-07-08	7
+2020-07-11	9
+2020-07-16	1
+2020-07-19	2
+2020-07-22	3
+2020-07-25	4
+-- !result
+SELECT dt,sum(num) FROM t1 where dt>'2020-06-15' GROUP BY dt order by dt;
+-- result:
+2020-06-18	5
+2020-06-21	7
+2020-06-24	9
+2020-07-02	3
+2020-07-05	5
+2020-07-08	7
+2020-07-11	9
+2020-07-16	1
+2020-07-19	2
+2020-07-22	3
+2020-07-25	4
+-- !result
+SELECT dt,sum(num) FROM t1 where dt>'2020-06-15' and dt < '2020-07-22' GROUP BY dt order by dt;
+-- result:
+2020-06-18	5
+2020-06-21	7
+2020-06-24	9
+2020-07-02	3
+2020-07-05	5
+2020-07-08	7
+2020-07-11	9
+2020-07-16	1
+2020-07-19	2
+-- !result
+SELECT dt,sum(num) FROM t1 where dt>'2020-06-15' and dt <= '2020-07-22' GROUP BY dt order by dt;
+-- result:
+2020-06-18	5
+2020-06-21	7
+2020-06-24	9
+2020-07-02	3
+2020-07-05	5
+2020-07-08	7
+2020-07-11	9
+2020-07-16	1
+2020-07-19	2
+2020-07-22	3
+-- !result
+SELECT dt,sum(num) FROM t1 where (dt>'2020-06-15' and dt <= '2020-06-22') or dt>'2020-07-01' GROUP BY dt order by dt;
+-- result:
+2020-06-18	5
+2020-06-21	7
+2020-07-02	3
+2020-07-05	5
+2020-07-08	7
+2020-07-11	9
+2020-07-16	1
+2020-07-19	2
+2020-07-22	3
+2020-07-25	4
+-- !result
+SELECT dt,sum(num) FROM t1 where dt in ('2020-06-15', '2020-06-22', '2020-07-01') GROUP BY dt order by dt;
+-- result:
+2020-06-15	6
+-- !result
+SELECT dt,sum(num) FROM t1 where date_trunc('day', dt) ='2020-06-15' GROUP BY dt order by dt;
+-- result:
+2020-06-15	6
+-- !result
+SELECT dt,sum(num) FROM t1 where date_trunc('month', dt) ='2020-06-01' GROUP BY dt order by dt;
+-- result:
+2020-06-15	6
+2020-06-18	5
+2020-06-21	7
+2020-06-24	9
+-- !result
+SELECT dt,sum(num) FROM t1 where date_trunc('month', dt) ='2020-07-01' GROUP BY dt order by dt;
+-- result:
+2020-07-02	3
+2020-07-05	5
+2020-07-08	7
+2020-07-11	9
+2020-07-16	1
+2020-07-19	2
+2020-07-22	3
+2020-07-25	4
+-- !result
+SELECT dt,sum(num) FROM t1 where dt between '2020-06-15' and '2020-07-01' GROUP BY dt order by dt;
+-- result:
+2020-06-15	6
+2020-06-18	5
+2020-06-21	7
+2020-06-24	9
+-- !result
+SELECT dt,sum(num) FROM t1 GROUP BY dt order by dt;
+-- result:
+2020-06-15	6
+2020-06-18	5
+2020-06-21	7
+2020-06-24	9
+2020-07-02	3
+2020-07-05	5
+2020-07-08	7
+2020-07-11	9
+2020-07-16	1
+2020-07-19	2
+2020-07-22	3
+2020-07-25	4
+-- !result
+drop materialized view default_catalog.db_${uuid0}.test_mv1;
+-- result:
+-- !result
+CREATE MATERIALIZED VIEW test_mv1 
+PARTITION BY date_trunc('day', dt)
+REFRESH DEFERRED MANUAL AS 
+  SELECT dt,sum(num) FROM t1 GROUP BY dt;
+-- result:
+-- !result
+REFRESH MATERIALIZED VIEW test_mv1 WITH SYNC MODE;
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t1 where dt='2020-06-15' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t1 where dt !='2020-06-15' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t1 where dt>='2020-06-15' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t1 where dt>'2020-06-15' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t1 where dt>'2020-06-15' and dt < '2020-07-22' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t1 where dt>'2020-06-15' and dt <= '2020-07-22' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t1 where (dt>'2020-06-15' and dt <= '2020-06-22') or dt>'2020-07-01' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t1 where dt in ('2020-06-15', '2020-06-22', '2020-07-01') GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t1 where date_trunc('day', dt) ='2020-06-15' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t1 where date_trunc('month', dt) ='2020-06-01' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t1 where date_trunc('month', dt) ='2020-07-01' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t1 GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+SELECT dt,sum(num) FROM t1 where dt='2020-06-15' GROUP BY dt order by dt;
+-- result:
+2020-06-15	6
+-- !result
+SELECT dt,sum(num) FROM t1 where dt !='2020-06-15' GROUP BY dt order by dt;
+-- result:
+2020-06-18	5
+2020-06-21	7
+2020-06-24	9
+2020-07-02	3
+2020-07-05	5
+2020-07-08	7
+2020-07-11	9
+2020-07-16	1
+2020-07-19	2
+2020-07-22	3
+2020-07-25	4
+-- !result
+SELECT dt,sum(num) FROM t1 where dt>='2020-06-15' GROUP BY dt order by dt;
+-- result:
+2020-06-15	6
+2020-06-18	5
+2020-06-21	7
+2020-06-24	9
+2020-07-02	3
+2020-07-05	5
+2020-07-08	7
+2020-07-11	9
+2020-07-16	1
+2020-07-19	2
+2020-07-22	3
+2020-07-25	4
+-- !result
+SELECT dt,sum(num) FROM t1 where dt>'2020-06-15' GROUP BY dt order by dt;
+-- result:
+2020-06-18	5
+2020-06-21	7
+2020-06-24	9
+2020-07-02	3
+2020-07-05	5
+2020-07-08	7
+2020-07-11	9
+2020-07-16	1
+2020-07-19	2
+2020-07-22	3
+2020-07-25	4
+-- !result
+SELECT dt,sum(num) FROM t1 where dt>'2020-06-15' and dt < '2020-07-22' GROUP BY dt order by dt;
+-- result:
+2020-06-18	5
+2020-06-21	7
+2020-06-24	9
+2020-07-02	3
+2020-07-05	5
+2020-07-08	7
+2020-07-11	9
+2020-07-16	1
+2020-07-19	2
+-- !result
+SELECT dt,sum(num) FROM t1 where dt>'2020-06-15' and dt <= '2020-07-22' GROUP BY dt order by dt;
+-- result:
+2020-06-18	5
+2020-06-21	7
+2020-06-24	9
+2020-07-02	3
+2020-07-05	5
+2020-07-08	7
+2020-07-11	9
+2020-07-16	1
+2020-07-19	2
+2020-07-22	3
+-- !result
+SELECT dt,sum(num) FROM t1 where (dt>'2020-06-15' and dt <= '2020-06-22') or dt>'2020-07-01' GROUP BY dt order by dt;
+-- result:
+2020-06-18	5
+2020-06-21	7
+2020-07-02	3
+2020-07-05	5
+2020-07-08	7
+2020-07-11	9
+2020-07-16	1
+2020-07-19	2
+2020-07-22	3
+2020-07-25	4
+-- !result
+SELECT dt,sum(num) FROM t1 where dt in ('2020-06-15', '2020-06-22', '2020-07-01') GROUP BY dt order by dt;
+-- result:
+2020-06-15	6
+-- !result
+SELECT dt,sum(num) FROM t1 where date_trunc('day', dt) ='2020-06-15' GROUP BY dt order by dt;
+-- result:
+2020-06-15	6
+-- !result
+SELECT dt,sum(num) FROM t1 where date_trunc('month', dt) ='2020-06-01' GROUP BY dt order by dt;
+-- result:
+2020-06-15	6
+2020-06-18	5
+2020-06-21	7
+2020-06-24	9
+-- !result
+SELECT dt,sum(num) FROM t1 where date_trunc('month', dt) ='2020-07-01' GROUP BY dt order by dt;
+-- result:
+2020-07-02	3
+2020-07-05	5
+2020-07-08	7
+2020-07-11	9
+2020-07-16	1
+2020-07-19	2
+2020-07-22	3
+2020-07-25	4
+-- !result
+SELECT dt,sum(num) FROM t1 GROUP BY dt order by dt;
+-- result:
+2020-06-15	6
+2020-06-18	5
+2020-06-21	7
+2020-06-24	9
+2020-07-02	3
+2020-07-05	5
+2020-07-08	7
+2020-07-11	9
+2020-07-16	1
+2020-07-19	2
+2020-07-22	3
+2020-07-25	4
+-- !result
+INSERT INTO t1 VALUES (3, "2020-06-15");
+-- result:
+-- !result
+function: check_no_hit_materialized_view("SELECT dt,sum(num) FROM t1 where dt='2020-06-15' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_no_hit_materialized_view("SELECT dt,sum(num) FROM t1 where date_trunc('day', dt) ='2020-06-15' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_no_hit_materialized_view("SELECT dt,sum(num) FROM t1 where dt in ('2020-06-15', '2020-06-22', '2020-07-01') GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t1 where date_trunc('day', dt) ='2020-06-21' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t1 where dt !='2020-06-15' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t1 where dt>'2020-06-15' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t1 where dt>'2020-06-15' and dt < '2020-07-22' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t1 where dt>'2020-06-15' and dt <= '2020-07-22' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t1 where (dt>'2020-06-15' and dt <= '2020-06-22') or dt>'2020-07-01' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t1 where date_trunc('month', dt) ='2020-07-01' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t1 where dt between '2020-06-15' and '2020-07-01' GROUP BY dt;", "test_mv1", "UNION")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t1 where dt>='2020-06-15' GROUP BY dt;", "test_mv1", "UNION")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t1 where dt in ('2020-06-15', '2020-06-21', '2020-07-25') GROUP BY dt;", "test_mv1", "UNION")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t1 where date_trunc('month', dt) ='2020-06-01' GROUP BY dt;", "test_mv1", "UNION")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t1 GROUP BY dt;", "test_mv1", "UNION")
+-- result:
+None
+-- !result
+SELECT dt,sum(num) FROM t1 where dt='2020-06-15' GROUP BY dt order by dt;
+-- result:
+2020-06-15	9
+-- !result
+SELECT dt,sum(num) FROM t1 where dt !='2020-06-15' GROUP BY dt order by dt;
+-- result:
+2020-06-18	5
+2020-06-21	7
+2020-06-24	9
+2020-07-02	3
+2020-07-05	5
+2020-07-08	7
+2020-07-11	9
+2020-07-16	1
+2020-07-19	2
+2020-07-22	3
+2020-07-25	4
+-- !result
+SELECT dt,sum(num) FROM t1 where dt>='2020-06-15' GROUP BY dt order by dt;
+-- result:
+2020-06-15	9
+2020-06-18	5
+2020-06-21	7
+2020-06-24	9
+2020-07-02	3
+2020-07-05	5
+2020-07-08	7
+2020-07-11	9
+2020-07-16	1
+2020-07-19	2
+2020-07-22	3
+2020-07-25	4
+-- !result
+SELECT dt,sum(num) FROM t1 where dt>'2020-06-15' GROUP BY dt order by dt;
+-- result:
+2020-06-18	5
+2020-06-21	7
+2020-06-24	9
+2020-07-02	3
+2020-07-05	5
+2020-07-08	7
+2020-07-11	9
+2020-07-16	1
+2020-07-19	2
+2020-07-22	3
+2020-07-25	4
+-- !result
+SELECT dt,sum(num) FROM t1 where dt>'2020-06-15' and dt < '2020-07-22' GROUP BY dt order by dt;
+-- result:
+2020-06-18	5
+2020-06-21	7
+2020-06-24	9
+2020-07-02	3
+2020-07-05	5
+2020-07-08	7
+2020-07-11	9
+2020-07-16	1
+2020-07-19	2
+-- !result
+SELECT dt,sum(num) FROM t1 where dt>'2020-06-15' and dt <= '2020-07-22' GROUP BY dt order by dt;
+-- result:
+2020-06-18	5
+2020-06-21	7
+2020-06-24	9
+2020-07-02	3
+2020-07-05	5
+2020-07-08	7
+2020-07-11	9
+2020-07-16	1
+2020-07-19	2
+2020-07-22	3
+-- !result
+SELECT dt,sum(num) FROM t1 where (dt>'2020-06-15' and dt <= '2020-06-22') or dt>'2020-07-01' GROUP BY dt order by dt;
+-- result:
+2020-06-18	5
+2020-06-21	7
+2020-07-02	3
+2020-07-05	5
+2020-07-08	7
+2020-07-11	9
+2020-07-16	1
+2020-07-19	2
+2020-07-22	3
+2020-07-25	4
+-- !result
+SELECT dt,sum(num) FROM t1 where dt in ('2020-06-15', '2020-06-22', '2020-07-01') GROUP BY dt order by dt;
+-- result:
+2020-06-15	9
+-- !result
+SELECT dt,sum(num) FROM t1 where date_trunc('day', dt) ='2020-06-15' GROUP BY dt order by dt;
+-- result:
+2020-06-15	9
+-- !result
+SELECT dt,sum(num) FROM t1 where date_trunc('month', dt) ='2020-06-01' GROUP BY dt order by dt;
+-- result:
+2020-06-15	9
+2020-06-18	5
+2020-06-21	7
+2020-06-24	9
+-- !result
+SELECT dt,sum(num) FROM t1 where date_trunc('month', dt) ='2020-07-01' GROUP BY dt order by dt;
+-- result:
+2020-07-02	3
+2020-07-05	5
+2020-07-08	7
+2020-07-11	9
+2020-07-16	1
+2020-07-19	2
+2020-07-22	3
+2020-07-25	4
+-- !result
+SELECT dt,sum(num) FROM t1 where dt between '2020-06-15' and '2020-07-01' GROUP BY dt order by dt;
+-- result:
+2020-06-15	9
+2020-06-18	5
+2020-06-21	7
+2020-06-24	9
+-- !result
+SELECT dt,sum(num) FROM t1 GROUP BY dt order by dt;
+-- result:
+2020-06-15	9
+2020-06-18	5
+2020-06-21	7
+2020-06-24	9
+2020-07-02	3
+2020-07-05	5
+2020-07-08	7
+2020-07-11	9
+2020-07-16	1
+2020-07-19	2
+2020-07-22	3
+2020-07-25	4
+-- !result
+drop materialized view default_catalog.db_${uuid0}.test_mv1;
+-- result:
+-- !result
+drop table t1 force;
+-- result:
+-- !result

--- a/test/sql/test_materialized_view/R/test_mv_partition_compensate_olap
+++ b/test/sql/test_materialized_view/R/test_mv_partition_compensate_olap
@@ -36,6 +36,54 @@ INSERT INTO t1 VALUES
   (2,"2020-07-02"),(3,"2020-07-05"),(4,"2020-07-08"),(5,"2020-07-11");
 -- result:
 -- !result
+CREATE TABLE t2 (
+  num int,
+  dt datetime
+)
+DUPLICATE KEY(`num`)
+PARTITION BY RANGE(`dt`)
+(
+  PARTITION p20200615 VALUES [("2020-06-15 00:00:00"), ("2020-06-16 00:00:00")),
+  PARTITION p20200618 VALUES [("2020-06-18 00:00:00"), ("2020-06-19 00:00:00")),
+  PARTITION p20200621 VALUES [("2020-06-21 00:00:00"), ("2020-06-22 00:00:00")),
+  PARTITION p20200624 VALUES [("2020-06-24 00:00:00"), ("2020-06-25 00:00:00")),
+  PARTITION p20200702 VALUES [("2020-07-02 00:00:00"), ("2020-07-03 00:00:00")),
+  PARTITION p20200705 VALUES [("2020-07-05 00:00:00"), ("2020-07-06 00:00:00")),
+  PARTITION p20200708 VALUES [("2020-07-08 00:00:00"), ("2020-07-09 00:00:00")),
+  PARTITION p20200716 VALUES [("2020-07-16 00:00:00"), ("2020-07-17 00:00:00")),
+  PARTITION p20200719 VALUES [("2020-07-19 00:00:00"), ("2020-07-20 00:00:00")),
+  PARTITION p20200722 VALUES [("2020-07-22 00:00:00"), ("2020-07-23 00:00:00")),
+  PARTITION p20200725 VALUES [("2020-07-25 00:00:00"), ("2020-07-26 00:00:00")),
+  PARTITION p20200711 VALUES [("2020-07-11 00:00:00"), ("2020-07-12 00:00:00"))
+)
+DISTRIBUTED BY HASH(`num`);
+-- result:
+-- !result
+INSERT INTO t2 VALUES 
+  (1,"2020-06-15"),(2,"2020-06-18"),(3,"2020-06-21"),(4,"2020-06-24"),
+  (1,"2020-07-02"),(2,"2020-07-05"),(3,"2020-07-08"),(4,"2020-07-11"),
+  (1,"2020-07-16"),(2,"2020-07-19"),(3,"2020-07-22"),(4,"2020-07-25"),
+  (2,"2020-06-15"),(3,"2020-06-18"),(4,"2020-06-21"),(5,"2020-06-24"),
+  (2,"2020-07-02"),(3,"2020-07-05"),(4,"2020-07-08"),(5,"2020-07-11");
+-- result:
+-- !result
+CREATE TABLE t3 (
+  num int,
+  dt datetime
+)
+DUPLICATE KEY(`num`)
+PARTITION BY  date_trunc('day', dt) 
+DISTRIBUTED BY HASH(`num`);
+-- result:
+-- !result
+INSERT INTO t3 VALUES 
+  (1,"2020-06-15"),(2,"2020-06-18"),(3,"2020-06-21"),(4,"2020-06-24"),
+  (1,"2020-07-02"),(2,"2020-07-05"),(3,"2020-07-08"),(4,"2020-07-11"),
+  (1,"2020-07-16"),(2,"2020-07-19"),(3,"2020-07-22"),(4,"2020-07-25"),
+  (2,"2020-06-15"),(3,"2020-06-18"),(4,"2020-06-21"),(5,"2020-06-24"),
+  (2,"2020-07-02"),(3,"2020-07-05"),(4,"2020-07-08"),(5,"2020-07-11");
+-- result:
+-- !result
 CREATE MATERIALIZED VIEW test_mv1 
 PARTITION BY dt 
 REFRESH DEFERRED MANUAL AS 
@@ -732,70 +780,1544 @@ SELECT dt,sum(num) FROM t1 where dt>'2020-06-15' and dt <= '2020-07-22' GROUP BY
 2020-07-19	2
 2020-07-22	3
 -- !result
-SELECT dt,sum(num) FROM t1 where (dt>'2020-06-15' and dt <= '2020-06-22') or dt>'2020-07-01' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM t2 where (dt>'2020-06-15' and dt <= '2020-06-22') or dt>'2020-07-01' GROUP BY dt order by dt;
 -- result:
-2020-06-18	5
-2020-06-21	7
-2020-07-02	3
-2020-07-05	5
-2020-07-08	7
-2020-07-11	9
-2020-07-16	1
-2020-07-19	2
-2020-07-22	3
-2020-07-25	4
+2020-06-18 00:00:00	5
+2020-06-21 00:00:00	7
+2020-07-02 00:00:00	3
+2020-07-05 00:00:00	5
+2020-07-08 00:00:00	7
+2020-07-11 00:00:00	9
+2020-07-16 00:00:00	1
+2020-07-19 00:00:00	2
+2020-07-22 00:00:00	3
+2020-07-25 00:00:00	4
 -- !result
-SELECT dt,sum(num) FROM t1 where dt in ('2020-06-15', '2020-06-22', '2020-07-01') GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM t2 where dt in ('2020-06-15', '2020-06-22', '2020-07-01') GROUP BY dt order by dt;
 -- result:
-2020-06-15	9
+2020-06-15 00:00:00	3
 -- !result
-SELECT dt,sum(num) FROM t1 where date_trunc('day', dt) ='2020-06-15' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM t2 where date_trunc('day', dt) ='2020-06-15' GROUP BY dt order by dt;
 -- result:
-2020-06-15	9
+2020-06-15 00:00:00	3
 -- !result
-SELECT dt,sum(num) FROM t1 where date_trunc('month', dt) ='2020-06-01' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM t2 where date_trunc('month', dt) ='2020-06-01' GROUP BY dt order by dt;
 -- result:
-2020-06-15	9
-2020-06-18	5
-2020-06-21	7
-2020-06-24	9
+2020-06-15 00:00:00	3
+2020-06-18 00:00:00	5
+2020-06-21 00:00:00	7
+2020-06-24 00:00:00	9
 -- !result
-SELECT dt,sum(num) FROM t1 where date_trunc('month', dt) ='2020-07-01' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM t2 where date_trunc('month', dt) ='2020-07-01' GROUP BY dt order by dt;
 -- result:
-2020-07-02	3
-2020-07-05	5
-2020-07-08	7
-2020-07-11	9
-2020-07-16	1
-2020-07-19	2
-2020-07-22	3
-2020-07-25	4
+2020-07-02 00:00:00	3
+2020-07-05 00:00:00	5
+2020-07-08 00:00:00	7
+2020-07-11 00:00:00	9
+2020-07-16 00:00:00	1
+2020-07-19 00:00:00	2
+2020-07-22 00:00:00	3
+2020-07-25 00:00:00	4
 -- !result
-SELECT dt,sum(num) FROM t1 where dt between '2020-06-15' and '2020-07-01' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM t2 where dt between '2020-06-15' and '2020-07-01' GROUP BY dt order by dt;
 -- result:
-2020-06-15	9
-2020-06-18	5
-2020-06-21	7
-2020-06-24	9
+2020-06-15 00:00:00	3
+2020-06-18 00:00:00	5
+2020-06-21 00:00:00	7
+2020-06-24 00:00:00	9
 -- !result
-SELECT dt,sum(num) FROM t1 GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM t2 GROUP BY dt order by dt;
 -- result:
-2020-06-15	9
-2020-06-18	5
-2020-06-21	7
-2020-06-24	9
-2020-07-02	3
-2020-07-05	5
-2020-07-08	7
-2020-07-11	9
-2020-07-16	1
-2020-07-19	2
-2020-07-22	3
-2020-07-25	4
+2020-06-15 00:00:00	3
+2020-06-18 00:00:00	5
+2020-06-21 00:00:00	7
+2020-06-24 00:00:00	9
+2020-07-02 00:00:00	3
+2020-07-05 00:00:00	5
+2020-07-08 00:00:00	7
+2020-07-11 00:00:00	9
+2020-07-16 00:00:00	1
+2020-07-19 00:00:00	2
+2020-07-22 00:00:00	3
+2020-07-25 00:00:00	4
+-- !result
+drop materialized view default_catalog.db_${uuid0}.test_mv1;
+-- result:
+-- !result
+CREATE MATERIALIZED VIEW test_mv1 
+PARTITION BY date_trunc('day', dt)
+REFRESH DEFERRED MANUAL AS 
+  SELECT dt,sum(num) FROM t2 GROUP BY dt;
+-- result:
+-- !result
+REFRESH MATERIALIZED VIEW test_mv1 WITH SYNC MODE;
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t2 where dt='2020-06-15' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t2 where dt !='2020-06-15' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t2 where dt>='2020-06-15' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t2 where dt>'2020-06-15' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t2 where dt>'2020-06-15' and dt < '2020-07-22' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t2 where dt>'2020-06-15' and dt <= '2020-07-22' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t2 where (dt>'2020-06-15' and dt <= '2020-06-22') or dt>'2020-07-01' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t2 where dt in ('2020-06-15', '2020-06-22', '2020-07-01') GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t2 where date_trunc('day', dt) ='2020-06-15' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t2 where date_trunc('month', dt) ='2020-06-01' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t2 where date_trunc('month', dt) ='2020-07-01' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t2 GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+SELECT dt,sum(num) FROM t2 where dt='2020-06-15' GROUP BY dt order by dt;
+-- result:
+2020-06-15 00:00:00	3
+-- !result
+SELECT dt,sum(num) FROM t2 where dt !='2020-06-15' GROUP BY dt order by dt;
+-- result:
+2020-06-18 00:00:00	5
+2020-06-21 00:00:00	7
+2020-06-24 00:00:00	9
+2020-07-02 00:00:00	3
+2020-07-05 00:00:00	5
+2020-07-08 00:00:00	7
+2020-07-11 00:00:00	9
+2020-07-16 00:00:00	1
+2020-07-19 00:00:00	2
+2020-07-22 00:00:00	3
+2020-07-25 00:00:00	4
+-- !result
+SELECT dt,sum(num) FROM t2 where dt>='2020-06-15' GROUP BY dt order by dt;
+-- result:
+2020-06-15 00:00:00	3
+2020-06-18 00:00:00	5
+2020-06-21 00:00:00	7
+2020-06-24 00:00:00	9
+2020-07-02 00:00:00	3
+2020-07-05 00:00:00	5
+2020-07-08 00:00:00	7
+2020-07-11 00:00:00	9
+2020-07-16 00:00:00	1
+2020-07-19 00:00:00	2
+2020-07-22 00:00:00	3
+2020-07-25 00:00:00	4
+-- !result
+SELECT dt,sum(num) FROM t2 where dt>'2020-06-15' GROUP BY dt order by dt;
+-- result:
+2020-06-18 00:00:00	5
+2020-06-21 00:00:00	7
+2020-06-24 00:00:00	9
+2020-07-02 00:00:00	3
+2020-07-05 00:00:00	5
+2020-07-08 00:00:00	7
+2020-07-11 00:00:00	9
+2020-07-16 00:00:00	1
+2020-07-19 00:00:00	2
+2020-07-22 00:00:00	3
+2020-07-25 00:00:00	4
+-- !result
+SELECT dt,sum(num) FROM t2 where dt>'2020-06-15' and dt < '2020-07-22' GROUP BY dt order by dt;
+-- result:
+2020-06-18 00:00:00	5
+2020-06-21 00:00:00	7
+2020-06-24 00:00:00	9
+2020-07-02 00:00:00	3
+2020-07-05 00:00:00	5
+2020-07-08 00:00:00	7
+2020-07-11 00:00:00	9
+2020-07-16 00:00:00	1
+2020-07-19 00:00:00	2
+-- !result
+SELECT dt,sum(num) FROM t2 where dt>'2020-06-15' and dt <= '2020-07-22' GROUP BY dt order by dt;
+-- result:
+2020-06-18 00:00:00	5
+2020-06-21 00:00:00	7
+2020-06-24 00:00:00	9
+2020-07-02 00:00:00	3
+2020-07-05 00:00:00	5
+2020-07-08 00:00:00	7
+2020-07-11 00:00:00	9
+2020-07-16 00:00:00	1
+2020-07-19 00:00:00	2
+2020-07-22 00:00:00	3
+-- !result
+SELECT dt,sum(num) FROM t2 where (dt>'2020-06-15' and dt <= '2020-06-22') or dt>'2020-07-01' GROUP BY dt order by dt;
+-- result:
+2020-06-18 00:00:00	5
+2020-06-21 00:00:00	7
+2020-07-02 00:00:00	3
+2020-07-05 00:00:00	5
+2020-07-08 00:00:00	7
+2020-07-11 00:00:00	9
+2020-07-16 00:00:00	1
+2020-07-19 00:00:00	2
+2020-07-22 00:00:00	3
+2020-07-25 00:00:00	4
+-- !result
+SELECT dt,sum(num) FROM t2 where dt in ('2020-06-15', '2020-06-22', '2020-07-01') GROUP BY dt order by dt;
+-- result:
+2020-06-15 00:00:00	3
+-- !result
+SELECT dt,sum(num) FROM t2 where date_trunc('day', dt) ='2020-06-15' GROUP BY dt order by dt;
+-- result:
+2020-06-15 00:00:00	3
+-- !result
+SELECT dt,sum(num) FROM t2 where date_trunc('month', dt) ='2020-06-01' GROUP BY dt order by dt;
+-- result:
+-- !result
+SELECT dt,sum(num) FROM t2 where date_trunc('month', dt) ='2020-07-01' GROUP BY dt order by dt;
+-- result:
+-- !result
+SELECT dt,sum(num) FROM t2 GROUP BY dt order by dt;
+-- result:
+2020-06-15 00:00:00	3
+2020-06-18 00:00:00	5
+2020-06-21 00:00:00	7
+2020-06-24 00:00:00	9
+2020-07-02 00:00:00	3
+2020-07-05 00:00:00	5
+2020-07-08 00:00:00	7
+2020-07-11 00:00:00	9
+2020-07-16 00:00:00	1
+2020-07-19 00:00:00	2
+2020-07-22 00:00:00	3
+2020-07-25 00:00:00	4
+-- !result
+INSERT INTO t2 VALUES (3, "2020-06-15");
+-- result:
+-- !result
+function: check_no_hit_materialized_view("SELECT dt,sum(num) FROM t2 where dt='2020-06-15' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_no_hit_materialized_view("SELECT dt,sum(num) FROM t2 where date_trunc('day', dt) ='2020-06-15' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_no_hit_materialized_view("SELECT dt,sum(num) FROM t2 where dt in ('2020-06-15', '2020-06-22', '2020-07-01') GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t2 where date_trunc('day', dt) ='2020-06-21' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t2 where dt !='2020-06-15' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t2 where dt>'2020-06-15' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t2 where dt>'2020-06-15' and dt < '2020-07-22' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t2 where dt>'2020-06-15' and dt <= '2020-07-22' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t2 where (dt>'2020-06-15' and dt <= '2020-06-22') or dt>'2020-07-01' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t2 where date_trunc('month', dt) ='2020-07-01' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t2 where dt between '2020-06-15' and '2020-07-01' GROUP BY dt;", "test_mv1", "UNION")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t2 where dt>='2020-06-15' GROUP BY dt;", "test_mv1", "UNION")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t2 where dt in ('2020-06-15', '2020-06-21', '2020-07-25') GROUP BY dt;", "test_mv1", "UNION")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t2 where date_trunc('month', dt) ='2020-06-01' GROUP BY dt;", "test_mv1", "UNION")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t2 GROUP BY dt;", "test_mv1", "UNION")
+-- result:
+None
+-- !result
+SELECT dt,sum(num) FROM t2 where dt='2020-06-15' GROUP BY dt order by dt;
+-- result:
+2020-06-15 00:00:00	6
+-- !result
+SELECT dt,sum(num) FROM t2 where dt !='2020-06-15' GROUP BY dt order by dt;
+-- result:
+2020-06-18 00:00:00	5
+2020-06-21 00:00:00	7
+2020-06-24 00:00:00	9
+2020-07-02 00:00:00	3
+2020-07-05 00:00:00	5
+2020-07-08 00:00:00	7
+2020-07-11 00:00:00	9
+2020-07-16 00:00:00	1
+2020-07-19 00:00:00	2
+2020-07-22 00:00:00	3
+2020-07-25 00:00:00	4
+-- !result
+SELECT dt,sum(num) FROM t2 where dt>='2020-06-15' GROUP BY dt order by dt;
+-- result:
+2020-06-15 00:00:00	6
+2020-06-18 00:00:00	5
+2020-06-21 00:00:00	7
+2020-06-24 00:00:00	9
+2020-07-02 00:00:00	3
+2020-07-05 00:00:00	5
+2020-07-08 00:00:00	7
+2020-07-11 00:00:00	9
+2020-07-16 00:00:00	1
+2020-07-19 00:00:00	2
+2020-07-22 00:00:00	3
+2020-07-25 00:00:00	4
+-- !result
+SELECT dt,sum(num) FROM t2 where dt>'2020-06-15' GROUP BY dt order by dt;
+-- result:
+2020-06-18 00:00:00	5
+2020-06-21 00:00:00	7
+2020-06-24 00:00:00	9
+2020-07-02 00:00:00	3
+2020-07-05 00:00:00	5
+2020-07-08 00:00:00	7
+2020-07-11 00:00:00	9
+2020-07-16 00:00:00	1
+2020-07-19 00:00:00	2
+2020-07-22 00:00:00	3
+2020-07-25 00:00:00	4
+-- !result
+SELECT dt,sum(num) FROM t2 where dt>'2020-06-15' and dt < '2020-07-22' GROUP BY dt order by dt;
+-- result:
+2020-06-18 00:00:00	5
+2020-06-21 00:00:00	7
+2020-06-24 00:00:00	9
+2020-07-02 00:00:00	3
+2020-07-05 00:00:00	5
+2020-07-08 00:00:00	7
+2020-07-11 00:00:00	9
+2020-07-16 00:00:00	1
+2020-07-19 00:00:00	2
+-- !result
+SELECT dt,sum(num) FROM t2 where dt>'2020-06-15' and dt <= '2020-07-22' GROUP BY dt order by dt;
+-- result:
+2020-06-18 00:00:00	5
+2020-06-21 00:00:00	7
+2020-06-24 00:00:00	9
+2020-07-02 00:00:00	3
+2020-07-05 00:00:00	5
+2020-07-08 00:00:00	7
+2020-07-11 00:00:00	9
+2020-07-16 00:00:00	1
+2020-07-19 00:00:00	2
+2020-07-22 00:00:00	3
+-- !result
+SELECT dt,sum(num) FROM t2 where (dt>'2020-06-15' and dt <= '2020-06-22') or dt>'2020-07-01' GROUP BY dt order by dt;
+-- result:
+2020-06-18 00:00:00	5
+2020-06-21 00:00:00	7
+2020-07-02 00:00:00	3
+2020-07-05 00:00:00	5
+2020-07-08 00:00:00	7
+2020-07-11 00:00:00	9
+2020-07-16 00:00:00	1
+2020-07-19 00:00:00	2
+2020-07-22 00:00:00	3
+2020-07-25 00:00:00	4
+-- !result
+SELECT dt,sum(num) FROM t2 where dt in ('2020-06-15', '2020-06-22', '2020-07-01') GROUP BY dt order by dt;
+-- result:
+2020-06-15 00:00:00	6
+-- !result
+SELECT dt,sum(num) FROM t2 where date_trunc('day', dt) ='2020-06-15' GROUP BY dt order by dt;
+-- result:
+2020-06-15 00:00:00	6
+-- !result
+SELECT dt,sum(num) FROM t2 where date_trunc('month', dt) ='2020-06-01' GROUP BY dt order by dt;
+-- result:
+2020-06-18 00:00:00	5
+2020-06-21 00:00:00	7
+2020-06-24 00:00:00	9
+2020-07-02 00:00:00	3
+2020-07-05 00:00:00	5
+2020-07-08 00:00:00	7
+2020-07-11 00:00:00	9
+2020-07-16 00:00:00	1
+2020-07-19 00:00:00	2
+2020-07-22 00:00:00	3
+2020-07-25 00:00:00	4
+-- !result
+SELECT dt,sum(num) FROM t2 where date_trunc('month', dt) ='2020-07-01' GROUP BY dt order by dt;
+-- result:
+-- !result
+SELECT dt,sum(num) FROM t2 where dt between '2020-06-15' and '2020-07-01' GROUP BY dt order by dt;
+-- result:
+2020-06-15 00:00:00	6
+2020-06-18 00:00:00	5
+2020-06-21 00:00:00	7
+2020-06-24 00:00:00	9
+-- !result
+SELECT dt,sum(num) FROM t2 GROUP BY dt order by dt;
+-- result:
+2020-06-15 00:00:00	6
+2020-06-18 00:00:00	5
+2020-06-21 00:00:00	7
+2020-06-24 00:00:00	9
+2020-07-02 00:00:00	3
+2020-07-05 00:00:00	5
+2020-07-08 00:00:00	7
+2020-07-11 00:00:00	9
+2020-07-16 00:00:00	1
+2020-07-19 00:00:00	2
+2020-07-22 00:00:00	3
+2020-07-25 00:00:00	4
+-- !result
+drop materialized view default_catalog.db_${uuid0}.test_mv1;
+-- result:
+-- !result
+CREATE MATERIALIZED VIEW test_mv1 
+PARTITION BY dt
+REFRESH DEFERRED MANUAL AS 
+  SELECT dt, date_trunc('day', dt) as format_dt,sum(num) FROM t2 GROUP BY dt;
+-- result:
+-- !result
+REFRESH MATERIALIZED VIEW test_mv1 WITH SYNC MODE;
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t2 where dt='2020-06-15' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t2 where dt !='2020-06-15' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t2 where dt>='2020-06-15' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t2 where dt>'2020-06-15' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t2 where dt>'2020-06-15' and dt < '2020-07-22' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t2 where dt>'2020-06-15' and dt <= '2020-07-22' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t2 where (dt>'2020-06-15' and dt <= '2020-06-22') or dt>'2020-07-01' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t2 where dt in ('2020-06-15', '2020-06-22', '2020-07-01') GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t2 where date_trunc('day', dt) ='2020-06-15' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t2 where date_trunc('month', dt) ='2020-06-01' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t2 where date_trunc('month', dt) ='2020-07-01' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t2 GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+SELECT dt,sum(num) FROM t2 where dt='2020-06-15' GROUP BY dt order by dt;
+-- result:
+2020-06-15 00:00:00	6
+-- !result
+SELECT dt,sum(num) FROM t2 where dt !='2020-06-15' GROUP BY dt order by dt;
+-- result:
+2020-06-18 00:00:00	5
+2020-06-21 00:00:00	7
+2020-06-24 00:00:00	9
+2020-07-02 00:00:00	3
+2020-07-05 00:00:00	5
+2020-07-08 00:00:00	7
+2020-07-11 00:00:00	9
+2020-07-16 00:00:00	1
+2020-07-19 00:00:00	2
+2020-07-22 00:00:00	3
+2020-07-25 00:00:00	4
+-- !result
+SELECT dt,sum(num) FROM t2 where dt>='2020-06-15' GROUP BY dt order by dt;
+-- result:
+2020-06-15 00:00:00	6
+2020-06-18 00:00:00	5
+2020-06-21 00:00:00	7
+2020-06-24 00:00:00	9
+2020-07-02 00:00:00	3
+2020-07-05 00:00:00	5
+2020-07-08 00:00:00	7
+2020-07-11 00:00:00	9
+2020-07-16 00:00:00	1
+2020-07-19 00:00:00	2
+2020-07-22 00:00:00	3
+2020-07-25 00:00:00	4
+-- !result
+SELECT dt,sum(num) FROM t2 where dt>'2020-06-15' GROUP BY dt order by dt;
+-- result:
+2020-06-18 00:00:00	5
+2020-06-21 00:00:00	7
+2020-06-24 00:00:00	9
+2020-07-02 00:00:00	3
+2020-07-05 00:00:00	5
+2020-07-08 00:00:00	7
+2020-07-11 00:00:00	9
+2020-07-16 00:00:00	1
+2020-07-19 00:00:00	2
+2020-07-22 00:00:00	3
+2020-07-25 00:00:00	4
+-- !result
+SELECT dt,sum(num) FROM t2 where dt>'2020-06-15' and dt < '2020-07-22' GROUP BY dt order by dt;
+-- result:
+2020-06-18 00:00:00	5
+2020-06-21 00:00:00	7
+2020-06-24 00:00:00	9
+2020-07-02 00:00:00	3
+2020-07-05 00:00:00	5
+2020-07-08 00:00:00	7
+2020-07-11 00:00:00	9
+2020-07-16 00:00:00	1
+2020-07-19 00:00:00	2
+-- !result
+SELECT dt,sum(num) FROM t2 where dt>'2020-06-15' and dt <= '2020-07-22' GROUP BY dt order by dt;
+-- result:
+2020-06-18 00:00:00	5
+2020-06-21 00:00:00	7
+2020-06-24 00:00:00	9
+2020-07-02 00:00:00	3
+2020-07-05 00:00:00	5
+2020-07-08 00:00:00	7
+2020-07-11 00:00:00	9
+2020-07-16 00:00:00	1
+2020-07-19 00:00:00	2
+2020-07-22 00:00:00	3
+-- !result
+SELECT dt,sum(num) FROM t2 where (dt>'2020-06-15' and dt <= '2020-06-22') or dt>'2020-07-01' GROUP BY dt order by dt;
+-- result:
+2020-06-18 00:00:00	5
+2020-06-21 00:00:00	7
+2020-07-02 00:00:00	3
+2020-07-05 00:00:00	5
+2020-07-08 00:00:00	7
+2020-07-11 00:00:00	9
+2020-07-16 00:00:00	1
+2020-07-19 00:00:00	2
+2020-07-22 00:00:00	3
+2020-07-25 00:00:00	4
+-- !result
+SELECT dt,sum(num) FROM t2 where dt in ('2020-06-15', '2020-06-22', '2020-07-01') GROUP BY dt order by dt;
+-- result:
+2020-06-15 00:00:00	6
+-- !result
+SELECT dt,sum(num) FROM t2 where date_trunc('day', dt) ='2020-06-15' GROUP BY dt order by dt;
+-- result:
+2020-06-15 00:00:00	6
+-- !result
+SELECT dt,sum(num) FROM t2 where date_trunc('month', dt) ='2020-06-01' GROUP BY dt order by dt;
+-- result:
+-- !result
+SELECT dt,sum(num) FROM t2 where date_trunc('month', dt) ='2020-07-01' GROUP BY dt order by dt;
+-- result:
+-- !result
+SELECT dt,sum(num) FROM t2 GROUP BY dt order by dt;
+-- result:
+2020-06-15 00:00:00	6
+2020-06-18 00:00:00	5
+2020-06-21 00:00:00	7
+2020-06-24 00:00:00	9
+2020-07-02 00:00:00	3
+2020-07-05 00:00:00	5
+2020-07-08 00:00:00	7
+2020-07-11 00:00:00	9
+2020-07-16 00:00:00	1
+2020-07-19 00:00:00	2
+2020-07-22 00:00:00	3
+2020-07-25 00:00:00	4
+-- !result
+INSERT INTO t2 VALUES (3, "2020-06-15");
+-- result:
+-- !result
+function: check_no_hit_materialized_view("SELECT dt,sum(num) FROM t2 where dt='2020-06-15' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_no_hit_materialized_view("SELECT dt,sum(num) FROM t2 where date_trunc('day', dt) ='2020-06-15' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_no_hit_materialized_view("SELECT dt,sum(num) FROM t2 where dt in ('2020-06-15', '2020-06-22', '2020-07-01') GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t2 where date_trunc('day', dt) ='2020-06-21' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t2 where dt !='2020-06-15' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t2 where dt>'2020-06-15' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t2 where dt>'2020-06-15' and dt < '2020-07-22' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t2 where dt>'2020-06-15' and dt <= '2020-07-22' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t2 where (dt>'2020-06-15' and dt <= '2020-06-22') or dt>'2020-07-01' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t2 where date_trunc('month', dt) ='2020-07-01' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t2 where dt between '2020-06-15' and '2020-07-01' GROUP BY dt;", "test_mv1", "UNION")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t2 where dt>='2020-06-15' GROUP BY dt;", "test_mv1", "UNION")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t2 where dt in ('2020-06-15', '2020-06-21', '2020-07-25') GROUP BY dt;", "test_mv1", "UNION")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t2 where date_trunc('month', dt) ='2020-06-01' GROUP BY dt;", "test_mv1", "UNION")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t2 GROUP BY dt;", "test_mv1", "UNION")
+-- result:
+None
+-- !result
+SELECT dt,sum(num) FROM t2 where dt='2020-06-15' GROUP BY dt order by dt;
+-- result:
+2020-06-15 00:00:00	9
+-- !result
+SELECT dt,sum(num) FROM t2 where dt !='2020-06-15' GROUP BY dt order by dt;
+-- result:
+2020-06-18 00:00:00	5
+2020-06-21 00:00:00	7
+2020-06-24 00:00:00	9
+2020-07-02 00:00:00	3
+2020-07-05 00:00:00	5
+2020-07-08 00:00:00	7
+2020-07-11 00:00:00	9
+2020-07-16 00:00:00	1
+2020-07-19 00:00:00	2
+2020-07-22 00:00:00	3
+2020-07-25 00:00:00	4
+-- !result
+SELECT dt,sum(num) FROM t2 where dt>='2020-06-15' GROUP BY dt order by dt;
+-- result:
+2020-06-15 00:00:00	9
+2020-06-18 00:00:00	5
+2020-06-21 00:00:00	7
+2020-06-24 00:00:00	9
+2020-07-02 00:00:00	3
+2020-07-05 00:00:00	5
+2020-07-08 00:00:00	7
+2020-07-11 00:00:00	9
+2020-07-16 00:00:00	1
+2020-07-19 00:00:00	2
+2020-07-22 00:00:00	3
+2020-07-25 00:00:00	4
+-- !result
+SELECT dt,sum(num) FROM t2 where dt>'2020-06-15' GROUP BY dt order by dt;
+-- result:
+2020-06-18 00:00:00	5
+2020-06-21 00:00:00	7
+2020-06-24 00:00:00	9
+2020-07-02 00:00:00	3
+2020-07-05 00:00:00	5
+2020-07-08 00:00:00	7
+2020-07-11 00:00:00	9
+2020-07-16 00:00:00	1
+2020-07-19 00:00:00	2
+2020-07-22 00:00:00	3
+2020-07-25 00:00:00	4
+-- !result
+SELECT dt,sum(num) FROM t2 where dt>'2020-06-15' and dt < '2020-07-22' GROUP BY dt order by dt;
+-- result:
+2020-06-18 00:00:00	5
+2020-06-21 00:00:00	7
+2020-06-24 00:00:00	9
+2020-07-02 00:00:00	3
+2020-07-05 00:00:00	5
+2020-07-08 00:00:00	7
+2020-07-11 00:00:00	9
+2020-07-16 00:00:00	1
+2020-07-19 00:00:00	2
+-- !result
+SELECT dt,sum(num) FROM t2 where dt>'2020-06-15' and dt <= '2020-07-22' GROUP BY dt order by dt;
+-- result:
+2020-06-18 00:00:00	5
+2020-06-21 00:00:00	7
+2020-06-24 00:00:00	9
+2020-07-02 00:00:00	3
+2020-07-05 00:00:00	5
+2020-07-08 00:00:00	7
+2020-07-11 00:00:00	9
+2020-07-16 00:00:00	1
+2020-07-19 00:00:00	2
+2020-07-22 00:00:00	3
+-- !result
+SELECT dt,sum(num) FROM t2 where (dt>'2020-06-15' and dt <= '2020-06-22') or dt>'2020-07-01' GROUP BY dt order by dt;
+-- result:
+2020-06-18 00:00:00	5
+2020-06-21 00:00:00	7
+2020-07-02 00:00:00	3
+2020-07-05 00:00:00	5
+2020-07-08 00:00:00	7
+2020-07-11 00:00:00	9
+2020-07-16 00:00:00	1
+2020-07-19 00:00:00	2
+2020-07-22 00:00:00	3
+2020-07-25 00:00:00	4
+-- !result
+SELECT dt,sum(num) FROM t2 where dt in ('2020-06-15', '2020-06-22', '2020-07-01') GROUP BY dt order by dt;
+-- result:
+2020-06-15 00:00:00	9
+-- !result
+SELECT dt,sum(num) FROM t2 where date_trunc('day', dt) ='2020-06-15' GROUP BY dt order by dt;
+-- result:
+2020-06-15 00:00:00	9
+-- !result
+SELECT dt,sum(num) FROM t2 where date_trunc('month', dt) ='2020-06-01' GROUP BY dt order by dt;
+-- result:
+2020-06-18 00:00:00	5
+2020-06-21 00:00:00	7
+2020-06-24 00:00:00	9
+2020-07-02 00:00:00	3
+2020-07-05 00:00:00	5
+2020-07-08 00:00:00	7
+2020-07-11 00:00:00	9
+2020-07-16 00:00:00	1
+2020-07-19 00:00:00	2
+2020-07-22 00:00:00	3
+2020-07-25 00:00:00	4
+-- !result
+SELECT dt,sum(num) FROM t2 where date_trunc('month', dt) ='2020-07-01' GROUP BY dt order by dt;
+-- result:
+-- !result
+SELECT dt,sum(num) FROM t2 where dt between '2020-06-15' and '2020-07-01' GROUP BY dt order by dt;
+-- result:
+2020-06-15 00:00:00	9
+2020-06-18 00:00:00	5
+2020-06-21 00:00:00	7
+2020-06-24 00:00:00	9
+-- !result
+SELECT dt,sum(num) FROM t2 GROUP BY dt order by dt;
+-- result:
+2020-06-15 00:00:00	9
+2020-06-18 00:00:00	5
+2020-06-21 00:00:00	7
+2020-06-24 00:00:00	9
+2020-07-02 00:00:00	3
+2020-07-05 00:00:00	5
+2020-07-08 00:00:00	7
+2020-07-11 00:00:00	9
+2020-07-16 00:00:00	1
+2020-07-19 00:00:00	2
+2020-07-22 00:00:00	3
+2020-07-25 00:00:00	4
+-- !result
+drop materialized view default_catalog.db_${uuid0}.test_mv1;
+-- result:
+-- !result
+CREATE MATERIALIZED VIEW test_mv1 
+PARTITION BY dt
+REFRESH DEFERRED MANUAL AS 
+  SELECT dt,sum(num) FROM t3 GROUP BY dt;
+-- result:
+-- !result
+REFRESH MATERIALIZED VIEW test_mv1 WITH SYNC MODE;
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t3 where dt='2020-06-15' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t3 where dt !='2020-06-15' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t3 where dt>='2020-06-15' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t3 where dt>'2020-06-15' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t3 where dt>'2020-06-15' and dt < '2020-07-22' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t3 where dt>'2020-06-15' and dt <= '2020-07-22' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t3 where (dt>'2020-06-15' and dt <= '2020-06-22') or dt>'2020-07-01' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t3 where dt in ('2020-06-15', '2020-06-22', '2020-07-01') GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t3 where date_trunc('day', dt) ='2020-06-15' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t3 where date_trunc('month', dt) ='2020-06-01' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t3 where date_trunc('month', dt) ='2020-07-01' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t3 GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+SELECT dt,sum(num) FROM t3 where dt='2020-06-15' GROUP BY dt order by dt;
+-- result:
+2020-06-15 00:00:00	3
+-- !result
+SELECT dt,sum(num) FROM t3 where dt !='2020-06-15' GROUP BY dt order by dt;
+-- result:
+2020-06-18 00:00:00	5
+2020-06-21 00:00:00	7
+2020-06-24 00:00:00	9
+2020-07-02 00:00:00	3
+2020-07-05 00:00:00	5
+2020-07-08 00:00:00	7
+2020-07-11 00:00:00	9
+2020-07-16 00:00:00	1
+2020-07-19 00:00:00	2
+2020-07-22 00:00:00	3
+2020-07-25 00:00:00	4
+-- !result
+SELECT dt,sum(num) FROM t3 where dt>='2020-06-15' GROUP BY dt order by dt;
+-- result:
+2020-06-15 00:00:00	3
+2020-06-18 00:00:00	5
+2020-06-21 00:00:00	7
+2020-06-24 00:00:00	9
+2020-07-02 00:00:00	3
+2020-07-05 00:00:00	5
+2020-07-08 00:00:00	7
+2020-07-11 00:00:00	9
+2020-07-16 00:00:00	1
+2020-07-19 00:00:00	2
+2020-07-22 00:00:00	3
+2020-07-25 00:00:00	4
+-- !result
+SELECT dt,sum(num) FROM t3 where dt>'2020-06-15' GROUP BY dt order by dt;
+-- result:
+2020-06-18 00:00:00	5
+2020-06-21 00:00:00	7
+2020-06-24 00:00:00	9
+2020-07-02 00:00:00	3
+2020-07-05 00:00:00	5
+2020-07-08 00:00:00	7
+2020-07-11 00:00:00	9
+2020-07-16 00:00:00	1
+2020-07-19 00:00:00	2
+2020-07-22 00:00:00	3
+2020-07-25 00:00:00	4
+-- !result
+SELECT dt,sum(num) FROM t3 where dt>'2020-06-15' and dt < '2020-07-22' GROUP BY dt order by dt;
+-- result:
+2020-06-18 00:00:00	5
+2020-06-21 00:00:00	7
+2020-06-24 00:00:00	9
+2020-07-02 00:00:00	3
+2020-07-05 00:00:00	5
+2020-07-08 00:00:00	7
+2020-07-11 00:00:00	9
+2020-07-16 00:00:00	1
+2020-07-19 00:00:00	2
+-- !result
+SELECT dt,sum(num) FROM t3 where dt>'2020-06-15' and dt <= '2020-07-22' GROUP BY dt order by dt;
+-- result:
+2020-06-18 00:00:00	5
+2020-06-21 00:00:00	7
+2020-06-24 00:00:00	9
+2020-07-02 00:00:00	3
+2020-07-05 00:00:00	5
+2020-07-08 00:00:00	7
+2020-07-11 00:00:00	9
+2020-07-16 00:00:00	1
+2020-07-19 00:00:00	2
+2020-07-22 00:00:00	3
+-- !result
+SELECT dt,sum(num) FROM t3 where (dt>'2020-06-15' and dt <= '2020-06-22') or dt>'2020-07-01' GROUP BY dt order by dt;
+-- result:
+2020-06-18 00:00:00	5
+2020-06-21 00:00:00	7
+2020-07-02 00:00:00	3
+2020-07-05 00:00:00	5
+2020-07-08 00:00:00	7
+2020-07-11 00:00:00	9
+2020-07-16 00:00:00	1
+2020-07-19 00:00:00	2
+2020-07-22 00:00:00	3
+2020-07-25 00:00:00	4
+-- !result
+SELECT dt,sum(num) FROM t3 where dt in ('2020-06-15', '2020-06-22', '2020-07-01') GROUP BY dt order by dt;
+-- result:
+2020-06-15 00:00:00	3
+-- !result
+SELECT dt,sum(num) FROM t3 where date_trunc('day', dt) ='2020-06-15' GROUP BY dt order by dt;
+-- result:
+2020-06-15 00:00:00	3
+-- !result
+SELECT dt,sum(num) FROM t3 where date_trunc('month', dt) ='2020-06-01' GROUP BY dt order by dt;
+-- result:
+-- !result
+SELECT dt,sum(num) FROM t3 where date_trunc('month', dt) ='2020-07-01' GROUP BY dt order by dt;
+-- result:
+-- !result
+SELECT dt,sum(num) FROM t3 GROUP BY dt order by dt;
+-- result:
+2020-06-15 00:00:00	3
+2020-06-18 00:00:00	5
+2020-06-21 00:00:00	7
+2020-06-24 00:00:00	9
+2020-07-02 00:00:00	3
+2020-07-05 00:00:00	5
+2020-07-08 00:00:00	7
+2020-07-11 00:00:00	9
+2020-07-16 00:00:00	1
+2020-07-19 00:00:00	2
+2020-07-22 00:00:00	3
+2020-07-25 00:00:00	4
+-- !result
+INSERT INTO t3 VALUES (3, "2020-06-15");
+-- result:
+-- !result
+function: check_no_hit_materialized_view("SELECT dt,sum(num) FROM t3 where dt='2020-06-15' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_no_hit_materialized_view("SELECT dt,sum(num) FROM t3 where date_trunc('day', dt) ='2020-06-15' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_no_hit_materialized_view("SELECT dt,sum(num) FROM t3 where dt in ('2020-06-15', '2020-06-22', '2020-07-01') GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t3 where date_trunc('day', dt) ='2020-06-21' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t3 where dt !='2020-06-15' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t3 where dt>'2020-06-15' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t3 where dt>'2020-06-15' and dt < '2020-07-22' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t3 where dt>'2020-06-15' and dt <= '2020-07-22' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t3 where (dt>'2020-06-15' and dt <= '2020-06-22') or dt>'2020-07-01' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t3 where date_trunc('month', dt) ='2020-07-01' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t3 where dt between '2020-06-15' and '2020-07-01' GROUP BY dt;", "test_mv1", "UNION")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t3 where dt>='2020-06-15' GROUP BY dt;", "test_mv1", "UNION")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t3 where dt in ('2020-06-15', '2020-06-21', '2020-07-25') GROUP BY dt;", "test_mv1", "UNION")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t3 where date_trunc('month', dt) ='2020-06-01' GROUP BY dt;", "test_mv1", "UNION")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t3 GROUP BY dt;", "test_mv1", "UNION")
+-- result:
+None
+-- !result
+SELECT dt,sum(num) FROM t3 where dt='2020-06-15' GROUP BY dt order by dt;
+-- result:
+2020-06-15 00:00:00	6
+-- !result
+SELECT dt,sum(num) FROM t3 where dt !='2020-06-15' GROUP BY dt order by dt;
+-- result:
+2020-06-18 00:00:00	5
+2020-06-21 00:00:00	7
+2020-06-24 00:00:00	9
+2020-07-02 00:00:00	3
+2020-07-05 00:00:00	5
+2020-07-08 00:00:00	7
+2020-07-11 00:00:00	9
+2020-07-16 00:00:00	1
+2020-07-19 00:00:00	2
+2020-07-22 00:00:00	3
+2020-07-25 00:00:00	4
+-- !result
+SELECT dt,sum(num) FROM t3 where dt>='2020-06-15' GROUP BY dt order by dt;
+-- result:
+2020-06-15 00:00:00	6
+2020-06-18 00:00:00	5
+2020-06-21 00:00:00	7
+2020-06-24 00:00:00	9
+2020-07-02 00:00:00	3
+2020-07-05 00:00:00	5
+2020-07-08 00:00:00	7
+2020-07-11 00:00:00	9
+2020-07-16 00:00:00	1
+2020-07-19 00:00:00	2
+2020-07-22 00:00:00	3
+2020-07-25 00:00:00	4
+-- !result
+SELECT dt,sum(num) FROM t3 where dt>'2020-06-15' GROUP BY dt order by dt;
+-- result:
+2020-06-18 00:00:00	5
+2020-06-21 00:00:00	7
+2020-06-24 00:00:00	9
+2020-07-02 00:00:00	3
+2020-07-05 00:00:00	5
+2020-07-08 00:00:00	7
+2020-07-11 00:00:00	9
+2020-07-16 00:00:00	1
+2020-07-19 00:00:00	2
+2020-07-22 00:00:00	3
+2020-07-25 00:00:00	4
+-- !result
+SELECT dt,sum(num) FROM t3 where dt>'2020-06-15' and dt < '2020-07-22' GROUP BY dt order by dt;
+-- result:
+2020-06-18 00:00:00	5
+2020-06-21 00:00:00	7
+2020-06-24 00:00:00	9
+2020-07-02 00:00:00	3
+2020-07-05 00:00:00	5
+2020-07-08 00:00:00	7
+2020-07-11 00:00:00	9
+2020-07-16 00:00:00	1
+2020-07-19 00:00:00	2
+-- !result
+SELECT dt,sum(num) FROM t3 where dt>'2020-06-15' and dt <= '2020-07-22' GROUP BY dt order by dt;
+-- result:
+2020-06-18 00:00:00	5
+2020-06-21 00:00:00	7
+2020-06-24 00:00:00	9
+2020-07-02 00:00:00	3
+2020-07-05 00:00:00	5
+2020-07-08 00:00:00	7
+2020-07-11 00:00:00	9
+2020-07-16 00:00:00	1
+2020-07-19 00:00:00	2
+2020-07-22 00:00:00	3
+-- !result
+SELECT dt,sum(num) FROM t3 where (dt>'2020-06-15' and dt <= '2020-06-22') or dt>'2020-07-01' GROUP BY dt order by dt;
+-- result:
+2020-06-18 00:00:00	5
+2020-06-21 00:00:00	7
+2020-07-02 00:00:00	3
+2020-07-05 00:00:00	5
+2020-07-08 00:00:00	7
+2020-07-11 00:00:00	9
+2020-07-16 00:00:00	1
+2020-07-19 00:00:00	2
+2020-07-22 00:00:00	3
+2020-07-25 00:00:00	4
+-- !result
+SELECT dt,sum(num) FROM t3 where dt in ('2020-06-15', '2020-06-22', '2020-07-01') GROUP BY dt order by dt;
+-- result:
+2020-06-15 00:00:00	6
+-- !result
+SELECT dt,sum(num) FROM t3 where date_trunc('day', dt) ='2020-06-15' GROUP BY dt order by dt;
+-- result:
+2020-06-15 00:00:00	6
+-- !result
+SELECT dt,sum(num) FROM t3 where date_trunc('month', dt) ='2020-06-01' GROUP BY dt order by dt;
+-- result:
+2020-06-18 00:00:00	5
+2020-06-21 00:00:00	7
+2020-06-24 00:00:00	9
+2020-07-02 00:00:00	3
+2020-07-05 00:00:00	5
+2020-07-08 00:00:00	7
+2020-07-11 00:00:00	9
+2020-07-16 00:00:00	1
+2020-07-19 00:00:00	2
+2020-07-22 00:00:00	3
+2020-07-25 00:00:00	4
+-- !result
+SELECT dt,sum(num) FROM t3 where date_trunc('month', dt) ='2020-07-01' GROUP BY dt order by dt;
+-- result:
+-- !result
+SELECT dt,sum(num) FROM t3 where dt between '2020-06-15' and '2020-07-01' GROUP BY dt order by dt;
+-- result:
+2020-06-15 00:00:00	6
+2020-06-18 00:00:00	5
+2020-06-21 00:00:00	7
+2020-06-24 00:00:00	9
+-- !result
+SELECT dt,sum(num) FROM t3 GROUP BY dt order by dt;
+-- result:
+2020-06-15 00:00:00	6
+2020-06-18 00:00:00	5
+2020-06-21 00:00:00	7
+2020-06-24 00:00:00	9
+2020-07-02 00:00:00	3
+2020-07-05 00:00:00	5
+2020-07-08 00:00:00	7
+2020-07-11 00:00:00	9
+2020-07-16 00:00:00	1
+2020-07-19 00:00:00	2
+2020-07-22 00:00:00	3
+2020-07-25 00:00:00	4
+-- !result
+drop materialized view default_catalog.db_${uuid0}.test_mv1;
+-- result:
+-- !result
+CREATE MATERIALIZED VIEW test_mv1 
+PARTITION BY date_trunc('day', dt)
+REFRESH DEFERRED MANUAL AS 
+  SELECT dt, sum(num) FROM t3 GROUP BY dt;
+-- result:
+-- !result
+REFRESH MATERIALIZED VIEW test_mv1 WITH SYNC MODE;
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t3 where dt='2020-06-15' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t3 where dt !='2020-06-15' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t3 where dt>='2020-06-15' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t3 where dt>'2020-06-15' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t3 where dt>'2020-06-15' and dt < '2020-07-22' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t3 where dt>'2020-06-15' and dt <= '2020-07-22' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t3 where (dt>'2020-06-15' and dt <= '2020-06-22') or dt>'2020-07-01' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t3 where dt in ('2020-06-15', '2020-06-22', '2020-07-01') GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t3 where date_trunc('day', dt) ='2020-06-15' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t3 where date_trunc('month', dt) ='2020-06-01' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t3 where date_trunc('month', dt) ='2020-07-01' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t3 GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+SELECT dt,sum(num) FROM t3 where dt='2020-06-15' GROUP BY dt order by dt;
+-- result:
+2020-06-15 00:00:00	6
+-- !result
+SELECT dt,sum(num) FROM t3 where dt !='2020-06-15' GROUP BY dt order by dt;
+-- result:
+2020-06-18 00:00:00	5
+2020-06-21 00:00:00	7
+2020-06-24 00:00:00	9
+2020-07-02 00:00:00	3
+2020-07-05 00:00:00	5
+2020-07-08 00:00:00	7
+2020-07-11 00:00:00	9
+2020-07-16 00:00:00	1
+2020-07-19 00:00:00	2
+2020-07-22 00:00:00	3
+2020-07-25 00:00:00	4
+-- !result
+SELECT dt,sum(num) FROM t3 where dt>='2020-06-15' GROUP BY dt order by dt;
+-- result:
+2020-06-15 00:00:00	6
+2020-06-18 00:00:00	5
+2020-06-21 00:00:00	7
+2020-06-24 00:00:00	9
+2020-07-02 00:00:00	3
+2020-07-05 00:00:00	5
+2020-07-08 00:00:00	7
+2020-07-11 00:00:00	9
+2020-07-16 00:00:00	1
+2020-07-19 00:00:00	2
+2020-07-22 00:00:00	3
+2020-07-25 00:00:00	4
+-- !result
+SELECT dt,sum(num) FROM t3 where dt>'2020-06-15' GROUP BY dt order by dt;
+-- result:
+2020-06-18 00:00:00	5
+2020-06-21 00:00:00	7
+2020-06-24 00:00:00	9
+2020-07-02 00:00:00	3
+2020-07-05 00:00:00	5
+2020-07-08 00:00:00	7
+2020-07-11 00:00:00	9
+2020-07-16 00:00:00	1
+2020-07-19 00:00:00	2
+2020-07-22 00:00:00	3
+2020-07-25 00:00:00	4
+-- !result
+SELECT dt,sum(num) FROM t3 where dt>'2020-06-15' and dt < '2020-07-22' GROUP BY dt order by dt;
+-- result:
+2020-06-18 00:00:00	5
+2020-06-21 00:00:00	7
+2020-06-24 00:00:00	9
+2020-07-02 00:00:00	3
+2020-07-05 00:00:00	5
+2020-07-08 00:00:00	7
+2020-07-11 00:00:00	9
+2020-07-16 00:00:00	1
+2020-07-19 00:00:00	2
+-- !result
+SELECT dt,sum(num) FROM t3 where dt>'2020-06-15' and dt <= '2020-07-22' GROUP BY dt order by dt;
+-- result:
+2020-06-18 00:00:00	5
+2020-06-21 00:00:00	7
+2020-06-24 00:00:00	9
+2020-07-02 00:00:00	3
+2020-07-05 00:00:00	5
+2020-07-08 00:00:00	7
+2020-07-11 00:00:00	9
+2020-07-16 00:00:00	1
+2020-07-19 00:00:00	2
+2020-07-22 00:00:00	3
+-- !result
+SELECT dt,sum(num) FROM t3 where (dt>'2020-06-15' and dt <= '2020-06-22') or dt>'2020-07-01' GROUP BY dt order by dt;
+-- result:
+2020-06-18 00:00:00	5
+2020-06-21 00:00:00	7
+2020-07-02 00:00:00	3
+2020-07-05 00:00:00	5
+2020-07-08 00:00:00	7
+2020-07-11 00:00:00	9
+2020-07-16 00:00:00	1
+2020-07-19 00:00:00	2
+2020-07-22 00:00:00	3
+2020-07-25 00:00:00	4
+-- !result
+SELECT dt,sum(num) FROM t3 where dt in ('2020-06-15', '2020-06-22', '2020-07-01') GROUP BY dt order by dt;
+-- result:
+2020-06-15 00:00:00	6
+-- !result
+SELECT dt,sum(num) FROM t3 where date_trunc('day', dt) ='2020-06-15' GROUP BY dt order by dt;
+-- result:
+2020-06-15 00:00:00	6
+-- !result
+SELECT dt,sum(num) FROM t3 where date_trunc('month', dt) ='2020-06-01' GROUP BY dt order by dt;
+-- result:
+-- !result
+SELECT dt,sum(num) FROM t3 where date_trunc('month', dt) ='2020-07-01' GROUP BY dt order by dt;
+-- result:
+-- !result
+SELECT dt,sum(num) FROM t3 GROUP BY dt order by dt;
+-- result:
+2020-06-15 00:00:00	6
+2020-06-18 00:00:00	5
+2020-06-21 00:00:00	7
+2020-06-24 00:00:00	9
+2020-07-02 00:00:00	3
+2020-07-05 00:00:00	5
+2020-07-08 00:00:00	7
+2020-07-11 00:00:00	9
+2020-07-16 00:00:00	1
+2020-07-19 00:00:00	2
+2020-07-22 00:00:00	3
+2020-07-25 00:00:00	4
+-- !result
+INSERT INTO t3 VALUES (3, "2020-06-15");
+-- result:
+-- !result
+function: check_no_hit_materialized_view("SELECT dt,sum(num) FROM t3 where dt='2020-06-15' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_no_hit_materialized_view("SELECT dt,sum(num) FROM t3 where date_trunc('day', dt) ='2020-06-15' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_no_hit_materialized_view("SELECT dt,sum(num) FROM t3 where dt in ('2020-06-15', '2020-06-22', '2020-07-01') GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t3 where date_trunc('day', dt) ='2020-06-21' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t3 where dt !='2020-06-15' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t3 where dt>'2020-06-15' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t3 where dt>'2020-06-15' and dt < '2020-07-22' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t3 where dt>'2020-06-15' and dt <= '2020-07-22' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t3 where (dt>'2020-06-15' and dt <= '2020-06-22') or dt>'2020-07-01' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t3 where date_trunc('month', dt) ='2020-07-01' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t3 where dt between '2020-06-15' and '2020-07-01' GROUP BY dt;", "test_mv1", "UNION")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t3 where dt>='2020-06-15' GROUP BY dt;", "test_mv1", "UNION")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t3 where dt in ('2020-06-15', '2020-06-21', '2020-07-25') GROUP BY dt;", "test_mv1", "UNION")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t3 where date_trunc('month', dt) ='2020-06-01' GROUP BY dt;", "test_mv1", "UNION")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t3 GROUP BY dt;", "test_mv1", "UNION")
+-- result:
+None
+-- !result
+SELECT dt,sum(num) FROM t3 where dt='2020-06-15' GROUP BY dt order by dt;
+-- result:
+2020-06-15 00:00:00	9
+-- !result
+SELECT dt,sum(num) FROM t3 where dt !='2020-06-15' GROUP BY dt order by dt;
+-- result:
+2020-06-18 00:00:00	5
+2020-06-21 00:00:00	7
+2020-06-24 00:00:00	9
+2020-07-02 00:00:00	3
+2020-07-05 00:00:00	5
+2020-07-08 00:00:00	7
+2020-07-11 00:00:00	9
+2020-07-16 00:00:00	1
+2020-07-19 00:00:00	2
+2020-07-22 00:00:00	3
+2020-07-25 00:00:00	4
+-- !result
+SELECT dt,sum(num) FROM t3 where dt>='2020-06-15' GROUP BY dt order by dt;
+-- result:
+2020-06-15 00:00:00	9
+2020-06-18 00:00:00	5
+2020-06-21 00:00:00	7
+2020-06-24 00:00:00	9
+2020-07-02 00:00:00	3
+2020-07-05 00:00:00	5
+2020-07-08 00:00:00	7
+2020-07-11 00:00:00	9
+2020-07-16 00:00:00	1
+2020-07-19 00:00:00	2
+2020-07-22 00:00:00	3
+2020-07-25 00:00:00	4
+-- !result
+SELECT dt,sum(num) FROM t3 where dt>'2020-06-15' GROUP BY dt order by dt;
+-- result:
+2020-06-18 00:00:00	5
+2020-06-21 00:00:00	7
+2020-06-24 00:00:00	9
+2020-07-02 00:00:00	3
+2020-07-05 00:00:00	5
+2020-07-08 00:00:00	7
+2020-07-11 00:00:00	9
+2020-07-16 00:00:00	1
+2020-07-19 00:00:00	2
+2020-07-22 00:00:00	3
+2020-07-25 00:00:00	4
+-- !result
+SELECT dt,sum(num) FROM t3 where dt>'2020-06-15' and dt < '2020-07-22' GROUP BY dt order by dt;
+-- result:
+2020-06-18 00:00:00	5
+2020-06-21 00:00:00	7
+2020-06-24 00:00:00	9
+2020-07-02 00:00:00	3
+2020-07-05 00:00:00	5
+2020-07-08 00:00:00	7
+2020-07-11 00:00:00	9
+2020-07-16 00:00:00	1
+2020-07-19 00:00:00	2
+-- !result
+SELECT dt,sum(num) FROM t3 where dt>'2020-06-15' and dt <= '2020-07-22' GROUP BY dt order by dt;
+-- result:
+2020-06-18 00:00:00	5
+2020-06-21 00:00:00	7
+2020-06-24 00:00:00	9
+2020-07-02 00:00:00	3
+2020-07-05 00:00:00	5
+2020-07-08 00:00:00	7
+2020-07-11 00:00:00	9
+2020-07-16 00:00:00	1
+2020-07-19 00:00:00	2
+2020-07-22 00:00:00	3
+-- !result
+SELECT dt,sum(num) FROM t3 where (dt>'2020-06-15' and dt <= '2020-06-22') or dt>'2020-07-01' GROUP BY dt order by dt;
+-- result:
+2020-06-18 00:00:00	5
+2020-06-21 00:00:00	7
+2020-07-02 00:00:00	3
+2020-07-05 00:00:00	5
+2020-07-08 00:00:00	7
+2020-07-11 00:00:00	9
+2020-07-16 00:00:00	1
+2020-07-19 00:00:00	2
+2020-07-22 00:00:00	3
+2020-07-25 00:00:00	4
+-- !result
+SELECT dt,sum(num) FROM t3 where dt in ('2020-06-15', '2020-06-22', '2020-07-01') GROUP BY dt order by dt;
+-- result:
+2020-06-15 00:00:00	9
+-- !result
+SELECT dt,sum(num) FROM t3 where date_trunc('day', dt) ='2020-06-15' GROUP BY dt order by dt;
+-- result:
+2020-06-15 00:00:00	9
+-- !result
+SELECT dt,sum(num) FROM t3 where date_trunc('month', dt) ='2020-06-01' GROUP BY dt order by dt;
+-- result:
+2020-06-18 00:00:00	5
+2020-06-21 00:00:00	7
+2020-06-24 00:00:00	9
+2020-07-02 00:00:00	3
+2020-07-05 00:00:00	5
+2020-07-08 00:00:00	7
+2020-07-11 00:00:00	9
+2020-07-16 00:00:00	1
+2020-07-19 00:00:00	2
+2020-07-22 00:00:00	3
+2020-07-25 00:00:00	4
+-- !result
+SELECT dt,sum(num) FROM t3 where date_trunc('month', dt) ='2020-07-01' GROUP BY dt order by dt;
+-- result:
+-- !result
+SELECT dt,sum(num) FROM t3 where dt between '2020-06-15' and '2020-07-01' GROUP BY dt order by dt;
+-- result:
+2020-06-15 00:00:00	9
+2020-06-18 00:00:00	5
+2020-06-21 00:00:00	7
+2020-06-24 00:00:00	9
+-- !result
+SELECT dt,sum(num) FROM t3 GROUP BY dt order by dt;
+-- result:
+2020-06-15 00:00:00	9
+2020-06-18 00:00:00	5
+2020-06-21 00:00:00	7
+2020-06-24 00:00:00	9
+2020-07-02 00:00:00	3
+2020-07-05 00:00:00	5
+2020-07-08 00:00:00	7
+2020-07-11 00:00:00	9
+2020-07-16 00:00:00	1
+2020-07-19 00:00:00	2
+2020-07-22 00:00:00	3
+2020-07-25 00:00:00	4
 -- !result
 drop materialized view default_catalog.db_${uuid0}.test_mv1;
 -- result:
 -- !result
 drop table t1 force;
+-- result:
+-- !result
+drop table t2 force;
+-- result:
+-- !result
+drop table t3 force;
 -- result:
 -- !result

--- a/test/sql/test_materialized_view/T/test_mv_partition_compensate_hive
+++ b/test/sql/test_materialized_view/T/test_mv_partition_compensate_hive
@@ -1,0 +1,174 @@
+-- name: test_mv_partition_compensate_hive
+create external catalog mv_hive_${uuid0} PROPERTIES ("type"="hive", "hive.metastore.uris"="${hive_metastore_uris}");
+
+-- create hive table
+set catalog mv_hive_${uuid0};
+create database mv_hive_db_${uuid0};
+use mv_hive_db_${uuid0};
+
+CREATE TABLE t1 (
+  num int,
+  dt date
+)
+PARTITION BY (dt);
+
+INSERT INTO t1 VALUES 
+  (1,"2020-06-15"),(2,"2020-06-18"),(3,"2020-06-21"),(4,"2020-06-24"),
+  (1,"2020-07-02"),(2,"2020-07-05"),(3,"2020-07-08"),(4,"2020-07-11"),
+  (1,"2020-07-16"),(2,"2020-07-19"),(3,"2020-07-22"),(4,"2020-07-25"),
+  (2,"2020-06-15"),(3,"2020-06-18"),(4,"2020-06-21"),(5,"2020-06-24"),
+  (2,"2020-07-02"),(3,"2020-07-05"),(4,"2020-07-08"),(5,"2020-07-11");
+
+-- create mv
+set catalog default_catalog;
+create database db_${uuid0};
+use db_${uuid0};
+
+
+-- Test partition compensate without partition expression
+CREATE MATERIALIZED VIEW test_mv1 
+PARTITION BY dt 
+REFRESH DEFERRED MANUAL AS 
+  SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 GROUP BY dt;
+
+REFRESH MATERIALIZED VIEW test_mv1 WITH SYNC MODE;
+
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 where dt='2020-06-15' GROUP BY dt;", "test_mv1")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 where dt !='2020-06-15' GROUP BY dt;", "test_mv1")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 where dt>='2020-06-15' GROUP BY dt;", "test_mv1")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 where dt>'2020-06-15' GROUP BY dt;", "test_mv1")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 where dt>'2020-06-15' and dt < '2020-07-22' GROUP BY dt;", "test_mv1")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 where dt>'2020-06-15' and dt <= '2020-07-22' GROUP BY dt;", "test_mv1")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 where (dt>'2020-06-15' and dt <= '2020-06-22') or dt>'2020-07-01' GROUP BY dt;", "test_mv1")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 where dt in ('2020-06-15', '2020-06-22', '2020-07-01') GROUP BY dt;", "test_mv1")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 where date_trunc('day', dt) ='2020-06-15' GROUP BY dt;", "test_mv1")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 where date_trunc('month', dt) ='2020-06-01' GROUP BY dt;", "test_mv1")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 where date_trunc('month', dt) ='2020-07-01' GROUP BY dt;", "test_mv1")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 GROUP BY dt;", "test_mv1")
+
+SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 where dt='2020-06-15' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 where dt !='2020-06-15' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 where dt>='2020-06-15' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 where dt>'2020-06-15' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 where dt>'2020-06-15' and dt < '2020-07-22' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 where dt>'2020-06-15' and dt <= '2020-07-22' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 where (dt>'2020-06-15' and dt <= '2020-06-22') or dt>'2020-07-01' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 where dt in ('2020-06-15', '2020-06-22', '2020-07-01') GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 where date_trunc('day', dt) ='2020-06-15' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 where date_trunc('month', dt) ='2020-06-01' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 where date_trunc('month', dt) ='2020-07-01' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 GROUP BY dt order by dt;
+
+-- union rewrite
+INSERT INTO mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 VALUES (3, "2020-06-15");
+function: check_no_hit_materialized_view("SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 where dt='2020-06-15' GROUP BY dt;", "test_mv1")
+function: check_no_hit_materialized_view("SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 where date_trunc('day', dt) ='2020-06-15' GROUP BY dt;", "test_mv1")
+function: check_no_hit_materialized_view("SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 where dt in ('2020-06-15', '2020-06-22', '2020-07-01') GROUP BY dt;", "test_mv1")
+
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 where date_trunc('day', dt) ='2020-06-21' GROUP BY dt;", "test_mv1")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 where dt !='2020-06-15' GROUP BY dt;", "test_mv1")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 where dt>'2020-06-15' GROUP BY dt;", "test_mv1")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 where dt>'2020-06-15' and dt < '2020-07-22' GROUP BY dt;", "test_mv1")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 where dt>'2020-06-15' and dt <= '2020-07-22' GROUP BY dt;", "test_mv1")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 where (dt>'2020-06-15' and dt <= '2020-06-22') or dt>'2020-07-01' GROUP BY dt;", "test_mv1")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 where dt in ('2020-06-21', '2020-07-25') GROUP BY dt;", "test_mv1")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 where date_trunc('month', dt) ='2020-07-01' GROUP BY dt;", "test_mv1")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 where dt between '2020-06-16' and '2020-07-01' GROUP BY dt;", "test_mv1")
+
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 where dt between '2020-06-15' and '2020-07-01' GROUP BY dt;", "test_mv1", "UNION")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 where dt>='2020-06-15' GROUP BY dt;", "test_mv1", "UNION")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 where dt in ('2020-06-15', '2020-06-21', '2020-07-25') GROUP BY dt;", "test_mv1", "UNION")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 where date_trunc('month', dt) ='2020-06-01' GROUP BY dt;", "test_mv1", "UNION")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 GROUP BY dt;", "test_mv1", "UNION")
+
+SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 where dt='2020-06-15' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 where dt !='2020-06-15' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 where dt>='2020-06-15' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 where dt>'2020-06-15' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 where dt>'2020-06-15' and dt < '2020-07-22' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 where dt>'2020-06-15' and dt <= '2020-07-22' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 where (dt>'2020-06-15' and dt <= '2020-06-22') or dt>'2020-07-01' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 where dt in ('2020-06-22', '2020-07-01') GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 where dt in ('2020-06-15', '2020-06-22', '2020-07-01') GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 where dt between '2020-06-15' and '2020-07-01' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 where date_trunc('day', dt) ='2020-06-15' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 where date_trunc('month', dt) ='2020-06-01' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 where date_trunc('month', dt) ='2020-07-01' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 GROUP BY dt order by dt;
+
+
+drop materialized view default_catalog.db_${uuid0}.test_mv1;
+
+-- Test partition compensate with partition expression
+CREATE MATERIALIZED VIEW test_mv1 
+PARTITION BY date_trunc('day', dt)
+REFRESH DEFERRED MANUAL AS 
+  SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 GROUP BY dt;
+REFRESH MATERIALIZED VIEW test_mv1 WITH SYNC MODE;
+
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 where dt='2020-06-15' GROUP BY dt;", "test_mv1")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 where dt !='2020-06-15' GROUP BY dt;", "test_mv1")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 where dt>='2020-06-15' GROUP BY dt;", "test_mv1")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 where dt>'2020-06-15' GROUP BY dt;", "test_mv1")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 where dt>'2020-06-15' and dt < '2020-07-22' GROUP BY dt;", "test_mv1")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 where dt>'2020-06-15' and dt <= '2020-07-22' GROUP BY dt;", "test_mv1")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 where (dt>'2020-06-15' and dt <= '2020-06-22') or dt>'2020-07-01' GROUP BY dt;", "test_mv1")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 where dt in ('2020-06-15', '2020-06-22', '2020-07-01') GROUP BY dt;", "test_mv1")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 where date_trunc('day', dt) ='2020-06-15' GROUP BY dt;", "test_mv1")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 where date_trunc('month', dt) ='2020-06-01' GROUP BY dt;", "test_mv1")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 where date_trunc('month', dt) ='2020-07-01' GROUP BY dt;", "test_mv1")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 GROUP BY dt;", "test_mv1")
+
+SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 where dt='2020-06-15' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 where dt !='2020-06-15' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 where dt>='2020-06-15' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 where dt>'2020-06-15' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 where dt>'2020-06-15' and dt < '2020-07-22' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 where dt>'2020-06-15' and dt <= '2020-07-22' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 where (dt>'2020-06-15' and dt <= '2020-06-22') or dt>'2020-07-01' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 where dt in ('2020-06-15', '2020-06-22', '2020-07-01') GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 where date_trunc('day', dt) ='2020-06-15' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 where date_trunc('month', dt) ='2020-06-01' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 where date_trunc('month', dt) ='2020-07-01' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 GROUP BY dt order by dt;
+
+-- union rewrite
+INSERT INTO mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 VALUES (3, "2020-06-15");
+function: check_no_hit_materialized_view("SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 where dt='2020-06-15' GROUP BY dt;", "test_mv1")
+function: check_no_hit_materialized_view("SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 where date_trunc('day', dt) ='2020-06-15' GROUP BY dt;", "test_mv1")
+function: check_no_hit_materialized_view("SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 where dt in ('2020-06-15', '2020-06-22', '2020-07-01') GROUP BY dt;", "test_mv1")
+
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 where date_trunc('day', dt) ='2020-06-21' GROUP BY dt;", "test_mv1")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 where dt !='2020-06-15' GROUP BY dt;", "test_mv1")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 where dt>'2020-06-15' GROUP BY dt;", "test_mv1")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 where dt>'2020-06-15' and dt < '2020-07-22' GROUP BY dt;", "test_mv1")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 where dt>'2020-06-15' and dt <= '2020-07-22' GROUP BY dt;", "test_mv1")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 where (dt>'2020-06-15' and dt <= '2020-06-22') or dt>'2020-07-01' GROUP BY dt;", "test_mv1")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 where dt in ('2020-06-21', '2020-07-25') GROUP BY dt;", "test_mv1")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 where date_trunc('month', dt) ='2020-07-01' GROUP BY dt;", "test_mv1")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 where dt between '2020-06-16' and '2020-07-01' GROUP BY dt;", "test_mv1")
+
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 where dt between '2020-06-15' and '2020-07-01' GROUP BY dt;", "test_mv1", "UNION")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 where dt>='2020-06-15' GROUP BY dt;", "test_mv1", "UNION")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 where dt in ('2020-06-15', '2020-06-21', '2020-07-25') GROUP BY dt;", "test_mv1", "UNION")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 where date_trunc('month', dt) ='2020-06-01' GROUP BY dt;", "test_mv1", "UNION")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 GROUP BY dt;", "test_mv1", "UNION")
+
+SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 where dt='2020-06-15' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 where dt !='2020-06-15' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 where dt>='2020-06-15' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 where dt>'2020-06-15' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 where dt>'2020-06-15' and dt < '2020-07-22' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 where dt>'2020-06-15' and dt <= '2020-07-22' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 where (dt>'2020-06-15' and dt <= '2020-06-22') or dt>'2020-07-01' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 where dt in ('2020-06-22', '2020-07-01') GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 where dt in ('2020-06-15', '2020-06-22', '2020-07-01') GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 where dt between '2020-06-15' and '2020-07-01' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 where date_trunc('day', dt) ='2020-06-15' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 where date_trunc('month', dt) ='2020-06-01' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 where date_trunc('month', dt) ='2020-07-01' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 GROUP BY dt order by dt;
+
+drop materialized view default_catalog.db_${uuid0}.test_mv1;
+
+drop table mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 force;

--- a/test/sql/test_materialized_view/T/test_mv_partition_compensate_iceberg
+++ b/test/sql/test_materialized_view/T/test_mv_partition_compensate_iceberg
@@ -1,0 +1,353 @@
+-- name: test_mv_partition_compensate_iceberg
+create external catalog mv_iceberg_${uuid0}
+properties
+(
+    "type" = "iceberg",
+    "iceberg.catalog.type" = "hive",
+    "hive.metastore.uris" = "${iceberg_catalog_hive_metastore_uris}"
+);
+
+
+-- create iceberg table
+set catalog mv_iceberg_${uuid0};
+create database mv_ice_db_${uuid0};
+use mv_ice_db_${uuid0};
+
+CREATE TABLE t1 (
+  num int,
+  dt date
+)
+PARTITION BY (dt);
+INSERT INTO t1 VALUES 
+  (1,"2020-06-15"),(2,"2020-06-18"),(3,"2020-06-21"),(4,"2020-06-24"),
+  (1,"2020-07-02"),(2,"2020-07-05"),(3,"2020-07-08"),(4,"2020-07-11"),
+  (1,"2020-07-16"),(2,"2020-07-19"),(3,"2020-07-22"),(4,"2020-07-25"),
+  (2,"2020-06-15"),(3,"2020-06-18"),(4,"2020-06-21"),(5,"2020-06-24"),
+  (2,"2020-07-02"),(3,"2020-07-05"),(4,"2020-07-08"),(5,"2020-07-11");
+
+CREATE TABLE t2 (
+  num int,
+  dt string
+)
+PARTITION BY (dt);
+INSERT INTO t2 VALUES 
+  (1,"2020-06-15"),(2,"2020-06-18"),(3,"2020-06-21"),(4,"2020-06-24"),
+  (1,"2020-07-02"),(2,"2020-07-05"),(3,"2020-07-08"),(4,"2020-07-11"),
+  (1,"2020-07-16"),(2,"2020-07-19"),(3,"2020-07-22"),(4,"2020-07-25"),
+  (2,"2020-06-15"),(3,"2020-06-18"),(4,"2020-06-21"),(5,"2020-06-24"),
+  (2,"2020-07-02"),(3,"2020-07-05"),(4,"2020-07-08"),(5,"2020-07-11");
+
+-- create mv
+set catalog default_catalog;
+create database db_${uuid0};
+use db_${uuid0};
+
+
+-- Test partition compensate without partition expression
+CREATE MATERIALIZED VIEW test_mv1 
+PARTITION BY dt 
+REFRESH DEFERRED MANUAL AS 
+  SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 GROUP BY dt;
+
+REFRESH MATERIALIZED VIEW test_mv1 WITH SYNC MODE;
+
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 where dt='2020-06-15' GROUP BY dt;", "test_mv1")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 where dt !='2020-06-15' GROUP BY dt;", "test_mv1")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 where dt>='2020-06-15' GROUP BY dt;", "test_mv1")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 where dt>'2020-06-15' GROUP BY dt;", "test_mv1")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 where dt>'2020-06-15' and dt < '2020-07-22' GROUP BY dt;", "test_mv1")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 where dt>'2020-06-15' and dt <= '2020-07-22' GROUP BY dt;", "test_mv1")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 where (dt>'2020-06-15' and dt <= '2020-06-22') or dt>'2020-07-01' GROUP BY dt;", "test_mv1")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 where dt in ('2020-06-15', '2020-06-22', '2020-07-01') GROUP BY dt;", "test_mv1")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 where date_trunc('day', dt) ='2020-06-15' GROUP BY dt;", "test_mv1")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 where date_trunc('month', dt) ='2020-06-01' GROUP BY dt;", "test_mv1")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 where date_trunc('month', dt) ='2020-07-01' GROUP BY dt;", "test_mv1")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 GROUP BY dt;", "test_mv1")
+
+SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 where dt='2020-06-15' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 where dt !='2020-06-15' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 where dt>='2020-06-15' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 where dt>'2020-06-15' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 where dt>'2020-06-15' and dt < '2020-07-22' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 where dt>'2020-06-15' and dt <= '2020-07-22' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 where (dt>'2020-06-15' and dt <= '2020-06-22') or dt>'2020-07-01' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 where dt in ('2020-06-15', '2020-06-22', '2020-07-01') GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 where date_trunc('day', dt) ='2020-06-15' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 where date_trunc('month', dt) ='2020-06-01' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 where date_trunc('month', dt) ='2020-07-01' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 GROUP BY dt order by dt;
+
+-- union rewrite
+INSERT INTO mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 VALUES (3, "2020-06-15");
+function: check_no_hit_materialized_view("SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 where dt='2020-06-15' GROUP BY dt;", "test_mv1")
+function: check_no_hit_materialized_view("SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 where date_trunc('day', dt) ='2020-06-15' GROUP BY dt;", "test_mv1")
+function: check_no_hit_materialized_view("SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 where dt in ('2020-06-15', '2020-06-22', '2020-07-01') GROUP BY dt;", "test_mv1")
+
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 where date_trunc('day', dt) ='2020-06-21' GROUP BY dt;", "test_mv1")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 where dt !='2020-06-15' GROUP BY dt;", "test_mv1")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 where dt>'2020-06-15' GROUP BY dt;", "test_mv1")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 where dt>'2020-06-15' and dt < '2020-07-22' GROUP BY dt;", "test_mv1")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 where dt>'2020-06-15' and dt <= '2020-07-22' GROUP BY dt;", "test_mv1")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 where (dt>'2020-06-15' and dt <= '2020-06-22') or dt>'2020-07-01' GROUP BY dt;", "test_mv1")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 where dt in ('2020-06-21', '2020-07-25') GROUP BY dt;", "test_mv1")
+-- cannot partition prune
+function: check_no_hit_materialized_view("SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 where date_trunc('month', dt) ='2020-07-01' GROUP BY dt;", "test_mv1")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 where dt between '2020-06-16' and '2020-07-01' GROUP BY dt;", "test_mv1")
+
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 where dt between '2020-06-15' and '2020-07-01' GROUP BY dt;", "test_mv1", "UNION")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 where dt>='2020-06-15' GROUP BY dt;", "test_mv1", "UNION")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 where dt in ('2020-06-15', '2020-06-21', '2020-07-25') GROUP BY dt;", "test_mv1", "UNION")
+-- cannot partition prune
+function: check_no_hit_materialized_view("SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 where date_trunc('month', dt) ='2020-06-01' GROUP BY dt;", "test_mv1", "UNION")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 GROUP BY dt;", "test_mv1", "UNION")
+
+SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 where dt='2020-06-15' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 where dt !='2020-06-15' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 where dt>='2020-06-15' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 where dt>'2020-06-15' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 where dt>'2020-06-15' and dt < '2020-07-22' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 where dt>'2020-06-15' and dt <= '2020-07-22' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 where (dt>'2020-06-15' and dt <= '2020-06-22') or dt>'2020-07-01' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 where dt in ('2020-06-22', '2020-07-01') GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 where dt in ('2020-06-15', '2020-06-22', '2020-07-01') GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 where dt between '2020-06-15' and '2020-07-01' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 where date_trunc('day', dt) ='2020-06-15' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 where date_trunc('month', dt) ='2020-06-01' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 where date_trunc('month', dt) ='2020-07-01' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 GROUP BY dt order by dt;
+
+
+drop materialized view default_catalog.db_${uuid0}.test_mv1;
+
+-- Test partition compensate with partition expression
+CREATE MATERIALIZED VIEW test_mv1 
+PARTITION BY date_trunc('day', dt)
+REFRESH DEFERRED MANUAL AS 
+  SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 GROUP BY dt;
+REFRESH MATERIALIZED VIEW test_mv1 WITH SYNC MODE;
+
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 where dt='2020-06-15' GROUP BY dt;", "test_mv1")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 where dt !='2020-06-15' GROUP BY dt;", "test_mv1")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 where dt>='2020-06-15' GROUP BY dt;", "test_mv1")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 where dt>'2020-06-15' GROUP BY dt;", "test_mv1")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 where dt>'2020-06-15' and dt < '2020-07-22' GROUP BY dt;", "test_mv1")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 where dt>'2020-06-15' and dt <= '2020-07-22' GROUP BY dt;", "test_mv1")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 where (dt>'2020-06-15' and dt <= '2020-06-22') or dt>'2020-07-01' GROUP BY dt;", "test_mv1")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 where dt in ('2020-06-15', '2020-06-22', '2020-07-01') GROUP BY dt;", "test_mv1")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 where date_trunc('day', dt) ='2020-06-15' GROUP BY dt;", "test_mv1")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 where date_trunc('month', dt) ='2020-06-01' GROUP BY dt;", "test_mv1")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 where date_trunc('month', dt) ='2020-07-01' GROUP BY dt;", "test_mv1")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 GROUP BY dt;", "test_mv1")
+
+SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 where dt='2020-06-15' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 where dt !='2020-06-15' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 where dt>='2020-06-15' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 where dt>'2020-06-15' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 where dt>'2020-06-15' and dt < '2020-07-22' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 where dt>'2020-06-15' and dt <= '2020-07-22' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 where (dt>'2020-06-15' and dt <= '2020-06-22') or dt>'2020-07-01' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 where dt in ('2020-06-15', '2020-06-22', '2020-07-01') GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 where date_trunc('day', dt) ='2020-06-15' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 where date_trunc('month', dt) ='2020-06-01' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 where date_trunc('month', dt) ='2020-07-01' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 GROUP BY dt order by dt;
+
+-- union rewrite
+INSERT INTO mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 VALUES (3, "2020-06-15");
+function: check_no_hit_materialized_view("SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 where dt='2020-06-15' GROUP BY dt;", "test_mv1")
+function: check_no_hit_materialized_view("SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 where date_trunc('day', dt) ='2020-06-15' GROUP BY dt;", "test_mv1")
+function: check_no_hit_materialized_view("SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 where dt in ('2020-06-15', '2020-06-22', '2020-07-01') GROUP BY dt;", "test_mv1")
+
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 where date_trunc('day', dt) ='2020-06-21' GROUP BY dt;", "test_mv1")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 where dt !='2020-06-15' GROUP BY dt;", "test_mv1")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 where dt>'2020-06-15' GROUP BY dt;", "test_mv1")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 where dt>'2020-06-15' and dt < '2020-07-22' GROUP BY dt;", "test_mv1")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 where dt>'2020-06-15' and dt <= '2020-07-22' GROUP BY dt;", "test_mv1")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 where (dt>'2020-06-15' and dt <= '2020-06-22') or dt>'2020-07-01' GROUP BY dt;", "test_mv1")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 where dt in ('2020-06-21', '2020-07-25') GROUP BY dt;", "test_mv1")
+-- cannot partition prune
+function: check_no_hit_materialized_view("SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 where date_trunc('month', dt) ='2020-07-01' GROUP BY dt;", "test_mv1")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 where dt between '2020-06-16' and '2020-07-01' GROUP BY dt;", "test_mv1")
+
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 where dt between '2020-06-15' and '2020-07-01' GROUP BY dt;", "test_mv1", "UNION")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 where dt>='2020-06-15' GROUP BY dt;", "test_mv1", "UNION")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 where dt in ('2020-06-15', '2020-06-21', '2020-07-25') GROUP BY dt;", "test_mv1", "UNION")
+-- cannot partition prune
+function: check_no_hit_materialized_view("SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 where date_trunc('month', dt) ='2020-06-01' GROUP BY dt;", "test_mv1")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 GROUP BY dt;", "test_mv1", "UNION")
+
+SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 where dt='2020-06-15' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 where dt !='2020-06-15' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 where dt>='2020-06-15' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 where dt>'2020-06-15' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 where dt>'2020-06-15' and dt < '2020-07-22' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 where dt>'2020-06-15' and dt <= '2020-07-22' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 where (dt>'2020-06-15' and dt <= '2020-06-22') or dt>'2020-07-01' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 where dt in ('2020-06-22', '2020-07-01') GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 where dt in ('2020-06-15', '2020-06-22', '2020-07-01') GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 where dt between '2020-06-15' and '2020-07-01' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 where date_trunc('day', dt) ='2020-06-15' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 where date_trunc('month', dt) ='2020-06-01' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 where date_trunc('month', dt) ='2020-07-01' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 GROUP BY dt order by dt;
+
+drop materialized view default_catalog.db_${uuid0}.test_mv1;
+
+
+
+-- Test partition compensate without partition expression
+CREATE MATERIALIZED VIEW test_mv1 
+PARTITION BY str2date(dt, '%Y-%m-%d')
+REFRESH DEFERRED MANUAL AS 
+  SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t2 GROUP BY dt;
+
+REFRESH MATERIALIZED VIEW test_mv1 WITH SYNC MODE;
+
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t2 where dt='2020-06-15' GROUP BY dt;", "test_mv1")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t2 where dt !='2020-06-15' GROUP BY dt;", "test_mv1")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t2 where dt>='2020-06-15' GROUP BY dt;", "test_mv1")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t2 where dt>'2020-06-15' GROUP BY dt;", "test_mv1")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t2 where dt>'2020-06-15' and dt < '2020-07-22' GROUP BY dt;", "test_mv1")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t2 where dt>'2020-06-15' and dt <= '2020-07-22' GROUP BY dt;", "test_mv1")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t2 where (dt>'2020-06-15' and dt <= '2020-06-22') or dt>'2020-07-01' GROUP BY dt;", "test_mv1")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t2 where dt in ('2020-06-15', '2020-06-22', '2020-07-01') GROUP BY dt;", "test_mv1")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t2 where date_trunc('day', dt) ='2020-06-15' GROUP BY dt;", "test_mv1")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t2 where date_trunc('month', dt) ='2020-06-01' GROUP BY dt;", "test_mv1")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t2 where date_trunc('month', dt) ='2020-07-01' GROUP BY dt;", "test_mv1")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t2 GROUP BY dt;", "test_mv1")
+
+SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t2 where dt='2020-06-15' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t2 where dt !='2020-06-15' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t2 where dt>='2020-06-15' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t2 where dt>'2020-06-15' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t2 where dt>'2020-06-15' and dt < '2020-07-22' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t2 where dt>'2020-06-15' and dt <= '2020-07-22' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t2 where (dt>'2020-06-15' and dt <= '2020-06-22') or dt>'2020-07-01' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t2 where dt in ('2020-06-15', '2020-06-22', '2020-07-01') GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t2 where date_trunc('day', dt) ='2020-06-15' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t2 where date_trunc('month', dt) ='2020-06-01' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t2 where date_trunc('month', dt) ='2020-07-01' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t2 GROUP BY dt order by dt;
+
+-- union rewrite
+INSERT INTO mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t2 VALUES (3, "2020-06-15");
+function: check_no_hit_materialized_view("SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t2 where dt='2020-06-15' GROUP BY dt;", "test_mv1")
+function: check_no_hit_materialized_view("SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t2 where date_trunc('day', dt) ='2020-06-15' GROUP BY dt;", "test_mv1")
+function: check_no_hit_materialized_view("SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t2 where dt in ('2020-06-15', '2020-06-22', '2020-07-01') GROUP BY dt;", "test_mv1")
+
+-- cannot partition prune
+function: check_no_hit_materialized_view("SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t2 where date_trunc('day', dt) ='2020-06-21' GROUP BY dt;", "test_mv1")
+
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t2 where dt !='2020-06-15' GROUP BY dt;", "test_mv1")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t2 where dt>'2020-06-15' GROUP BY dt;", "test_mv1")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t2 where dt>'2020-06-15' and dt < '2020-07-22' GROUP BY dt;", "test_mv1")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t2 where dt>'2020-06-15' and dt <= '2020-07-22' GROUP BY dt;", "test_mv1")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t2 where (dt>'2020-06-15' and dt <= '2020-06-22') or dt>'2020-07-01' GROUP BY dt;", "test_mv1")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t2 where dt in ('2020-06-21', '2020-07-25') GROUP BY dt;", "test_mv1")
+-- cannot partition prune
+function: check_no_hit_materialized_view("SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t2 where date_trunc('month', dt) ='2020-07-01' GROUP BY dt;", "test_mv1")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t2 where dt between '2020-06-16' and '2020-07-01' GROUP BY dt;", "test_mv1")
+
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t2 where dt between '2020-06-15' and '2020-07-01' GROUP BY dt;", "test_mv1", "UNION")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t2 where dt>='2020-06-15' GROUP BY dt;", "test_mv1", "UNION")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t2 where dt in ('2020-06-15', '2020-06-21', '2020-07-25') GROUP BY dt;", "test_mv1", "UNION")
+-- cannot partition prune
+function: check_no_hit_materialized_view("SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t2 where date_trunc('month', dt) ='2020-06-01' GROUP BY dt;", "test_mv1")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t2 GROUP BY dt;", "test_mv1", "UNION")
+
+SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t2 where dt='2020-06-15' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t2 where dt !='2020-06-15' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t2 where dt>='2020-06-15' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t2 where dt>'2020-06-15' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t2 where dt>'2020-06-15' and dt < '2020-07-22' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t2 where dt>'2020-06-15' and dt <= '2020-07-22' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t2 where (dt>'2020-06-15' and dt <= '2020-06-22') or dt>'2020-07-01' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t2 where dt in ('2020-06-22', '2020-07-01') GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t2 where dt in ('2020-06-15', '2020-06-22', '2020-07-01') GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t2 where dt between '2020-06-15' and '2020-07-01' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t2 where date_trunc('day', dt) ='2020-06-15' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t2 where date_trunc('month', dt) ='2020-06-01' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t2 where date_trunc('month', dt) ='2020-07-01' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t2 GROUP BY dt order by dt;
+
+
+drop materialized view default_catalog.db_${uuid0}.test_mv1;
+
+-- Test partition compensate with partition expression
+-- TODO: shold not add an extra column(dt) which cannot partition prune.
+CREATE MATERIALIZED VIEW test_mv1 
+PARTITION BY date_trunc('day', format_dt)
+REFRESH DEFERRED MANUAL AS 
+  SELECT dt, str2date(dt, '%Y-%m-%d') as format_dt, sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t2 GROUP BY dt;
+REFRESH MATERIALIZED VIEW test_mv1 WITH SYNC MODE;
+
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t2 where dt='2020-06-15' GROUP BY dt;", "test_mv1")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t2 where dt !='2020-06-15' GROUP BY dt;", "test_mv1")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t2 where dt>='2020-06-15' GROUP BY dt;", "test_mv1")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t2 where dt>'2020-06-15' GROUP BY dt;", "test_mv1")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t2 where dt>'2020-06-15' and dt < '2020-07-22' GROUP BY dt;", "test_mv1")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t2 where dt>'2020-06-15' and dt <= '2020-07-22' GROUP BY dt;", "test_mv1")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t2 where (dt>'2020-06-15' and dt <= '2020-06-22') or dt>'2020-07-01' GROUP BY dt;", "test_mv1")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t2 where dt in ('2020-06-15', '2020-06-22', '2020-07-01') GROUP BY dt;", "test_mv1")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t2 where date_trunc('day', dt) ='2020-06-15' GROUP BY dt;", "test_mv1")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t2 where date_trunc('month', dt) ='2020-06-01' GROUP BY dt;", "test_mv1")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t2 where date_trunc('month', dt) ='2020-07-01' GROUP BY dt;", "test_mv1")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t2 GROUP BY dt;", "test_mv1")
+
+SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t2 where dt='2020-06-15' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t2 where dt !='2020-06-15' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t2 where dt>='2020-06-15' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t2 where dt>'2020-06-15' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t2 where dt>'2020-06-15' and dt < '2020-07-22' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t2 where dt>'2020-06-15' and dt <= '2020-07-22' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t2 where (dt>'2020-06-15' and dt <= '2020-06-22') or dt>'2020-07-01' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t2 where dt in ('2020-06-15', '2020-06-22', '2020-07-01') GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t2 where date_trunc('day', dt) ='2020-06-15' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t2 where date_trunc('month', dt) ='2020-06-01' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t2 where date_trunc('month', dt) ='2020-07-01' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t2 GROUP BY dt order by dt;
+
+-- union rewrite
+INSERT INTO mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t2 VALUES (3, "2020-06-15");
+function: check_no_hit_materialized_view("SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t2 where dt='2020-06-15' GROUP BY dt;", "test_mv1")
+function: check_no_hit_materialized_view("SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t2 where date_trunc('day', dt) ='2020-06-15' GROUP BY dt;", "test_mv1")
+function: check_no_hit_materialized_view("SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t2 where dt in ('2020-06-15', '2020-06-22', '2020-07-01') GROUP BY dt;", "test_mv1")
+
+-- cannot partition prune
+function: check_no_hit_materialized_view("SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t2 where date_trunc('day', dt) ='2020-06-21' GROUP BY dt;", "test_mv1")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t2 where dt !='2020-06-15' GROUP BY dt;", "test_mv1")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t2 where dt>'2020-06-15' GROUP BY dt;", "test_mv1")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t2 where dt>'2020-06-15' and dt < '2020-07-22' GROUP BY dt;", "test_mv1")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t2 where dt>'2020-06-15' and dt <= '2020-07-22' GROUP BY dt;", "test_mv1")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t2 where (dt>'2020-06-15' and dt <= '2020-06-22') or dt>'2020-07-01' GROUP BY dt;", "test_mv1")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t2 where dt in ('2020-06-21', '2020-07-25') GROUP BY dt;", "test_mv1")
+-- cannot partition prune
+function: check_no_hit_materialized_view("SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t2 where date_trunc('month', dt) ='2020-07-01' GROUP BY dt;", "test_mv1")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t2 where dt between '2020-06-16' and '2020-07-01' GROUP BY dt;", "test_mv1")
+
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t2 where dt between '2020-06-15' and '2020-07-01' GROUP BY dt;", "test_mv1", "UNION")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t2 where dt>='2020-06-15' GROUP BY dt;", "test_mv1", "UNION")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t2 where dt in ('2020-06-15', '2020-06-21', '2020-07-25') GROUP BY dt;", "test_mv1", "UNION")
+-- cannot partition prune
+function: check_no_hit_materialized_view("SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t2 where date_trunc('month', dt) ='2020-06-01' GROUP BY dt;", "test_mv1")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t2 GROUP BY dt;", "test_mv1", "UNION")
+
+SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t2 where dt='2020-06-15' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t2 where dt !='2020-06-15' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t2 where dt>='2020-06-15' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t2 where dt>'2020-06-15' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t2 where dt>'2020-06-15' and dt < '2020-07-22' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t2 where dt>'2020-06-15' and dt <= '2020-07-22' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t2 where (dt>'2020-06-15' and dt <= '2020-06-22') or dt>'2020-07-01' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t2 where dt in ('2020-06-22', '2020-07-01') GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t2 where dt in ('2020-06-15', '2020-06-22', '2020-07-01') GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t2 where dt between '2020-06-15' and '2020-07-01' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t2 where date_trunc('day', dt) ='2020-06-15' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t2 where date_trunc('month', dt) ='2020-06-01' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t2 where date_trunc('month', dt) ='2020-07-01' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t2 GROUP BY dt order by dt;
+
+drop materialized view default_catalog.db_${uuid0}.test_mv1;
+
+drop table mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t2 force;
+drop table mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t2 force;

--- a/test/sql/test_materialized_view/T/test_mv_partition_compensate_mysql
+++ b/test/sql/test_materialized_view/T/test_mv_partition_compensate_mysql
@@ -1,0 +1,176 @@
+-- name: test_mv_partition_compensate_mysql
+-- create mysql table
+shell: mysql -h${external_mysql_ip} -u${external_mysql_user} -p${external_mysql_password} -P${external_mysql_port} -e 'create database mv_mysql_db_${uuid0};'
+shell: mysql -h${external_mysql_ip} -u${external_mysql_user} -p${external_mysql_password} -P${external_mysql_port} -e 'use mv_mysql_db_${uuid0}; CREATE TABLE t1 (num int, dt date) PARTITION BY range columns(dt) (PARTITION p20200614 VALUES LESS THAN ("2020-06-15"),PARTITION p20200617 VALUES LESS THAN ("2020-06-18"),PARTITION p20200620 VALUES LESS THAN ("2020-06-21"),PARTITION p20200623 VALUES LESS THAN ("2020-06-24"),PARTITION p20200701 VALUES LESS THAN ("2020-07-02"),PARTITION p20200704 VALUES LESS THAN ("2020-07-05"),PARTITION p20200707 VALUES LESS THAN ("2020-07-08"),PARTITION p20200710 VALUES LESS THAN ("2020-07-11"),PARTITION p20200715 VALUES LESS THAN ("2020-07-16"),PARTITION p20200718 VALUES LESS THAN ("2020-07-19"),PARTITION p20200721 VALUES LESS THAN ("2020-07-22"),PARTITION p20200724 VALUES LESS THAN ("2020-07-25"));'
+shell: mysql -h${external_mysql_ip} -u${external_mysql_user} -p${external_mysql_password} -P${external_mysql_port} -e 'use mv_mysql_db_${uuid0}; INSERT INTO t1 VALUES (1,"2020-06-15"),(2,"2020-06-18"),(3,"2020-06-21"),(4,"2020-06-24"),(1,"2020-07-02"),(2,"2020-07-05"),(3,"2020-07-08"),(4,"2020-07-11"),(1,"2020-07-16"),(2,"2020-07-19"),(3,"2020-07-22"),(4,"2020-07-25"),(2,"2020-06-15"),(3,"2020-06-18"),(4,"2020-06-21"),(5,"2020-06-24"),(2,"2020-07-02"),(3,"2020-07-05"),(4,"2020-07-08"),(5,"2020-07-11");'
+
+set catalog default_catalog;
+create database db_${uuid0};
+use db_${uuid0};
+create external catalog mv_mysql_${uuid0}
+properties
+(
+    "type" = "jdbc",
+    "user"="${external_mysql_user}",
+    "password"="${external_mysql_password}",
+    "jdbc_uri"="jdbc:mysql://${external_mysql_ip}:${external_mysql_port}",
+    "driver_url"="https://repo1.maven.org/maven2/mysql/mysql-connector-java/8.0.28/mysql-connector-java-8.0.28.jar",
+    "driver_class"="com.mysql.cj.jdbc.Driver"
+);
+
+-- create mv
+-- Test partition compensate without partition expression
+CREATE MATERIALIZED VIEW test_mv1 
+PARTITION BY dt 
+REFRESH DEFERRED MANUAL AS 
+  SELECT dt,sum(num) FROM mv_mysql_${uuid0}.mv_mysql_db_${uuid0}.t1 GROUP BY dt;
+
+REFRESH MATERIALIZED VIEW test_mv1 WITH SYNC MODE;
+
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_mysql_${uuid0}.mv_mysql_db_${uuid0}.t1 where dt='2020-06-15' GROUP BY dt;", "test_mv1")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_mysql_${uuid0}.mv_mysql_db_${uuid0}.t1 where dt !='2020-06-15' GROUP BY dt;", "test_mv1")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_mysql_${uuid0}.mv_mysql_db_${uuid0}.t1 where dt>='2020-06-15' GROUP BY dt;", "test_mv1")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_mysql_${uuid0}.mv_mysql_db_${uuid0}.t1 where dt>'2020-06-15' GROUP BY dt;", "test_mv1")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_mysql_${uuid0}.mv_mysql_db_${uuid0}.t1 where dt>'2020-06-15' and dt < '2020-07-22' GROUP BY dt;", "test_mv1")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_mysql_${uuid0}.mv_mysql_db_${uuid0}.t1 where dt>'2020-06-15' and dt <= '2020-07-22' GROUP BY dt;", "test_mv1")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_mysql_${uuid0}.mv_mysql_db_${uuid0}.t1 where (dt>'2020-06-15' and dt <= '2020-06-22') or dt>'2020-07-01' GROUP BY dt;", "test_mv1")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_mysql_${uuid0}.mv_mysql_db_${uuid0}.t1 where dt in ('2020-06-15', '2020-06-22', '2020-07-01') GROUP BY dt;", "test_mv1")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_mysql_${uuid0}.mv_mysql_db_${uuid0}.t1 where date_trunc('day', dt) ='2020-06-15' GROUP BY dt;", "test_mv1")
+-- TODO
+function: check_no_hit_materialized_view("SELECT dt,sum(num) FROM mv_mysql_${uuid0}.mv_mysql_db_${uuid0}.t1 where date_trunc('month', dt) ='2020-06-01' GROUP BY dt;", "test_mv1")
+-- TODO
+function: check_no_hit_materialized_view("SELECT dt,sum(num) FROM mv_mysql_${uuid0}.mv_mysql_db_${uuid0}.t1 where date_trunc('month', dt) ='2020-07-01' GROUP BY dt;", "test_mv1")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_mysql_${uuid0}.mv_mysql_db_${uuid0}.t1 GROUP BY dt;", "test_mv1")
+
+SELECT dt,sum(num) FROM mv_mysql_${uuid0}.mv_mysql_db_${uuid0}.t1 where dt='2020-06-15' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM mv_mysql_${uuid0}.mv_mysql_db_${uuid0}.t1 where dt !='2020-06-15' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM mv_mysql_${uuid0}.mv_mysql_db_${uuid0}.t1 where dt>='2020-06-15' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM mv_mysql_${uuid0}.mv_mysql_db_${uuid0}.t1 where dt>'2020-06-15' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM mv_mysql_${uuid0}.mv_mysql_db_${uuid0}.t1 where dt>'2020-06-15' and dt < '2020-07-22' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM mv_mysql_${uuid0}.mv_mysql_db_${uuid0}.t1 where dt>'2020-06-15' and dt <= '2020-07-22' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM mv_mysql_${uuid0}.mv_mysql_db_${uuid0}.t1 where (dt>'2020-06-15' and dt <= '2020-06-22') or dt>'2020-07-01' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM mv_mysql_${uuid0}.mv_mysql_db_${uuid0}.t1 where dt in ('2020-06-15', '2020-06-22', '2020-07-01') GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM mv_mysql_${uuid0}.mv_mysql_db_${uuid0}.t1 where date_trunc('day', dt) ='2020-06-15' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM mv_mysql_${uuid0}.mv_mysql_db_${uuid0}.t1 where date_trunc('month', dt) ='2020-06-01' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM mv_mysql_${uuid0}.mv_mysql_db_${uuid0}.t1 where date_trunc('month', dt) ='2020-07-01' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM mv_mysql_${uuid0}.mv_mysql_db_${uuid0}.t1 GROUP BY dt order by dt;
+
+-- union rewrite
+shell: mysql -h${external_mysql_ip} -u${external_mysql_user} -p${external_mysql_password} -P${external_mysql_port} -e 'use mv_mysql_db_${uuid0}; INSERT INTO t1 VALUES (3,"2020-06-15");'
+function: check_no_hit_materialized_view("SELECT dt,sum(num) FROM mv_mysql_${uuid0}.mv_mysql_db_${uuid0}.t1 where dt='2020-06-15' GROUP BY dt;", "test_mv1")
+function: check_no_hit_materialized_view("SELECT dt,sum(num) FROM mv_mysql_${uuid0}.mv_mysql_db_${uuid0}.t1 where date_trunc('day', dt) ='2020-06-15' GROUP BY dt;", "test_mv1")
+function: check_no_hit_materialized_view("SELECT dt,sum(num) FROM mv_mysql_${uuid0}.mv_mysql_db_${uuid0}.t1 where dt in ('2020-06-15', '2020-06-22', '2020-07-01') GROUP BY dt;", "test_mv1")
+
+function: check_no_hit_materialized_view("SELECT dt,sum(num) FROM mv_mysql_${uuid0}.mv_mysql_db_${uuid0}.t1 where date_trunc('day', dt) ='2020-06-21' GROUP BY dt;", "test_mv1")
+function: check_no_hit_materialized_view("SELECT dt,sum(num) FROM mv_mysql_${uuid0}.mv_mysql_db_${uuid0}.t1 where dt !='2020-06-15' GROUP BY dt;", "test_mv1")
+function: check_no_hit_materialized_view("SELECT dt,sum(num) FROM mv_mysql_${uuid0}.mv_mysql_db_${uuid0}.t1 where dt>'2020-06-15' GROUP BY dt;", "test_mv1")
+function: check_no_hit_materialized_view("SELECT dt,sum(num) FROM mv_mysql_${uuid0}.mv_mysql_db_${uuid0}.t1 where dt>'2020-06-15' and dt < '2020-07-22' GROUP BY dt;", "test_mv1")
+function: check_no_hit_materialized_view("SELECT dt,sum(num) FROM mv_mysql_${uuid0}.mv_mysql_db_${uuid0}.t1 where dt>'2020-06-15' and dt <= '2020-07-22' GROUP BY dt;", "test_mv1")
+function: check_no_hit_materialized_view("SELECT dt,sum(num) FROM mv_mysql_${uuid0}.mv_mysql_db_${uuid0}.t1 where (dt>'2020-06-15' and dt <= '2020-06-22') or dt>'2020-07-01' GROUP BY dt;", "test_mv1")
+function: check_no_hit_materialized_view("SELECT dt,sum(num) FROM mv_mysql_${uuid0}.mv_mysql_db_${uuid0}.t1 where dt in ('2020-06-21', '2020-07-25') GROUP BY dt;", "test_mv1")
+-- cannot partition prune
+function: check_no_hit_materialized_view("SELECT dt,sum(num) FROM mv_mysql_${uuid0}.mv_mysql_db_${uuid0}.t1 where date_trunc('month', dt) ='2020-07-01' GROUP BY dt;", "test_mv1")
+function: check_no_hit_materialized_view("SELECT dt,sum(num) FROM mv_mysql_${uuid0}.mv_mysql_db_${uuid0}.t1 where dt between '2020-06-16' and '2020-07-01' GROUP BY dt;", "test_mv1")
+
+function: check_no_hit_materialized_view("SELECT dt,sum(num) FROM mv_mysql_${uuid0}.mv_mysql_db_${uuid0}.t1 where dt between '2020-06-15' and '2020-07-01' GROUP BY dt;", "test_mv1", "UNION")
+function: check_no_hit_materialized_view("SELECT dt,sum(num) FROM mv_mysql_${uuid0}.mv_mysql_db_${uuid0}.t1 where dt>='2020-06-15' GROUP BY dt;", "test_mv1", "UNION")
+function: check_no_hit_materialized_view("SELECT dt,sum(num) FROM mv_mysql_${uuid0}.mv_mysql_db_${uuid0}.t1 where dt in ('2020-06-15', '2020-06-21', '2020-07-25') GROUP BY dt;", "test_mv1", "UNION")
+-- cannot partition prune
+function: check_no_hit_materialized_view("SELECT dt,sum(num) FROM mv_mysql_${uuid0}.mv_mysql_db_${uuid0}.t1 where date_trunc('month', dt) ='2020-06-01' GROUP BY dt;", "test_mv1", "UNION")
+function: check_no_hit_materialized_view("SELECT dt,sum(num) FROM mv_mysql_${uuid0}.mv_mysql_db_${uuid0}.t1 GROUP BY dt;", "test_mv1", "UNION")
+
+SELECT dt,sum(num) FROM mv_mysql_${uuid0}.mv_mysql_db_${uuid0}.t1 where dt='2020-06-15' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM mv_mysql_${uuid0}.mv_mysql_db_${uuid0}.t1 where dt !='2020-06-15' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM mv_mysql_${uuid0}.mv_mysql_db_${uuid0}.t1 where dt>='2020-06-15' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM mv_mysql_${uuid0}.mv_mysql_db_${uuid0}.t1 where dt>'2020-06-15' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM mv_mysql_${uuid0}.mv_mysql_db_${uuid0}.t1 where dt>'2020-06-15' and dt < '2020-07-22' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM mv_mysql_${uuid0}.mv_mysql_db_${uuid0}.t1 where dt>'2020-06-15' and dt <= '2020-07-22' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM mv_mysql_${uuid0}.mv_mysql_db_${uuid0}.t1 where (dt>'2020-06-15' and dt <= '2020-06-22') or dt>'2020-07-01' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM mv_mysql_${uuid0}.mv_mysql_db_${uuid0}.t1 where dt in ('2020-06-22', '2020-07-01') GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM mv_mysql_${uuid0}.mv_mysql_db_${uuid0}.t1 where dt in ('2020-06-15', '2020-06-22', '2020-07-01') GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM mv_mysql_${uuid0}.mv_mysql_db_${uuid0}.t1 where dt between '2020-06-15' and '2020-07-01' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM mv_mysql_${uuid0}.mv_mysql_db_${uuid0}.t1 where date_trunc('day', dt) ='2020-06-15' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM mv_mysql_${uuid0}.mv_mysql_db_${uuid0}.t1 where date_trunc('month', dt) ='2020-06-01' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM mv_mysql_${uuid0}.mv_mysql_db_${uuid0}.t1 where date_trunc('month', dt) ='2020-07-01' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM mv_mysql_${uuid0}.mv_mysql_db_${uuid0}.t1 GROUP BY dt order by dt;
+
+
+drop materialized view default_catalog.db_${uuid0}.test_mv1;
+
+-- Test partition compensate with partition expression
+CREATE MATERIALIZED VIEW test_mv1 
+PARTITION BY date_trunc('day', dt)
+REFRESH DEFERRED MANUAL AS 
+  SELECT dt,sum(num) FROM mv_mysql_${uuid0}.mv_mysql_db_${uuid0}.t1 GROUP BY dt;
+REFRESH MATERIALIZED VIEW test_mv1 WITH SYNC MODE;
+
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_mysql_${uuid0}.mv_mysql_db_${uuid0}.t1 where dt='2020-06-15' GROUP BY dt;", "test_mv1")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_mysql_${uuid0}.mv_mysql_db_${uuid0}.t1 where dt !='2020-06-15' GROUP BY dt;", "test_mv1")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_mysql_${uuid0}.mv_mysql_db_${uuid0}.t1 where dt>='2020-06-15' GROUP BY dt;", "test_mv1")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_mysql_${uuid0}.mv_mysql_db_${uuid0}.t1 where dt>'2020-06-15' GROUP BY dt;", "test_mv1")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_mysql_${uuid0}.mv_mysql_db_${uuid0}.t1 where dt>'2020-06-15' and dt < '2020-07-22' GROUP BY dt;", "test_mv1")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_mysql_${uuid0}.mv_mysql_db_${uuid0}.t1 where dt>'2020-06-15' and dt <= '2020-07-22' GROUP BY dt;", "test_mv1")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_mysql_${uuid0}.mv_mysql_db_${uuid0}.t1 where (dt>'2020-06-15' and dt <= '2020-06-22') or dt>'2020-07-01' GROUP BY dt;", "test_mv1")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_mysql_${uuid0}.mv_mysql_db_${uuid0}.t1 where dt in ('2020-06-15', '2020-06-22', '2020-07-01') GROUP BY dt;", "test_mv1")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_mysql_${uuid0}.mv_mysql_db_${uuid0}.t1 where date_trunc('day', dt) ='2020-06-15' GROUP BY dt;", "test_mv1")
+-- TODO
+function: check_no_hit_materialized_view("SELECT dt,sum(num) FROM mv_mysql_${uuid0}.mv_mysql_db_${uuid0}.t1 where date_trunc('month', dt) ='2020-06-01' GROUP BY dt;", "test_mv1")
+-- TODO
+function: check_no_hit_materialized_view("SELECT dt,sum(num) FROM mv_mysql_${uuid0}.mv_mysql_db_${uuid0}.t1 where date_trunc('month', dt) ='2020-07-01' GROUP BY dt;", "test_mv1")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_mysql_${uuid0}.mv_mysql_db_${uuid0}.t1 GROUP BY dt;", "test_mv1")
+
+SELECT dt,sum(num) FROM mv_mysql_${uuid0}.mv_mysql_db_${uuid0}.t1 where dt='2020-06-15' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM mv_mysql_${uuid0}.mv_mysql_db_${uuid0}.t1 where dt !='2020-06-15' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM mv_mysql_${uuid0}.mv_mysql_db_${uuid0}.t1 where dt>='2020-06-15' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM mv_mysql_${uuid0}.mv_mysql_db_${uuid0}.t1 where dt>'2020-06-15' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM mv_mysql_${uuid0}.mv_mysql_db_${uuid0}.t1 where dt>'2020-06-15' and dt < '2020-07-22' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM mv_mysql_${uuid0}.mv_mysql_db_${uuid0}.t1 where dt>'2020-06-15' and dt <= '2020-07-22' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM mv_mysql_${uuid0}.mv_mysql_db_${uuid0}.t1 where (dt>'2020-06-15' and dt <= '2020-06-22') or dt>'2020-07-01' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM mv_mysql_${uuid0}.mv_mysql_db_${uuid0}.t1 where dt in ('2020-06-15', '2020-06-22', '2020-07-01') GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM mv_mysql_${uuid0}.mv_mysql_db_${uuid0}.t1 where date_trunc('day', dt) ='2020-06-15' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM mv_mysql_${uuid0}.mv_mysql_db_${uuid0}.t1 where date_trunc('month', dt) ='2020-06-01' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM mv_mysql_${uuid0}.mv_mysql_db_${uuid0}.t1 where date_trunc('month', dt) ='2020-07-01' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM mv_mysql_${uuid0}.mv_mysql_db_${uuid0}.t1 GROUP BY dt order by dt;
+
+-- union rewrite
+shell: mysql -h${external_mysql_ip} -u${external_mysql_user} -p${external_mysql_password} -P${external_mysql_port} -e 'use mv_mysql_db_${uuid0}; INSERT INTO t1 VALUES (3,"2020-06-15");'
+alter materialized view test_mv1 set('query_rewrite_consistency' = 'loose');
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_mysql_${uuid0}.mv_mysql_db_${uuid0}.t1 where dt='2020-06-15' GROUP BY dt;", "test_mv1")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_mysql_${uuid0}.mv_mysql_db_${uuid0}.t1 where date_trunc('day', dt) ='2020-06-15' GROUP BY dt;", "test_mv1")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_mysql_${uuid0}.mv_mysql_db_${uuid0}.t1 where dt in ('2020-06-15', '2020-06-22', '2020-07-01') GROUP BY dt;", "test_mv1")
+
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_mysql_${uuid0}.mv_mysql_db_${uuid0}.t1 where date_trunc('day', dt) ='2020-06-21' GROUP BY dt;", "test_mv1")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_mysql_${uuid0}.mv_mysql_db_${uuid0}.t1 where dt !='2020-06-15' GROUP BY dt;", "test_mv1")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_mysql_${uuid0}.mv_mysql_db_${uuid0}.t1 where dt>'2020-06-15' GROUP BY dt;", "test_mv1")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_mysql_${uuid0}.mv_mysql_db_${uuid0}.t1 where dt>'2020-06-15' and dt < '2020-07-22' GROUP BY dt;", "test_mv1")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_mysql_${uuid0}.mv_mysql_db_${uuid0}.t1 where dt>'2020-06-15' and dt <= '2020-07-22' GROUP BY dt;", "test_mv1")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_mysql_${uuid0}.mv_mysql_db_${uuid0}.t1 where (dt>'2020-06-15' and dt <= '2020-06-22') or dt>'2020-07-01' GROUP BY dt;", "test_mv1")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_mysql_${uuid0}.mv_mysql_db_${uuid0}.t1 where dt in ('2020-06-21', '2020-07-25') GROUP BY dt;", "test_mv1")
+-- cannot partition prune
+function: check_no_hit_materialized_view("SELECT dt,sum(num) FROM mv_mysql_${uuid0}.mv_mysql_db_${uuid0}.t1 where date_trunc('month', dt) ='2020-07-01' GROUP BY dt;", "test_mv1")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_mysql_${uuid0}.mv_mysql_db_${uuid0}.t1 where dt between '2020-06-16' and '2020-07-01' GROUP BY dt;", "test_mv1")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_mysql_${uuid0}.mv_mysql_db_${uuid0}.t1 where dt between '2020-06-15' and '2020-07-01' GROUP BY dt;", "test_mv1")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_mysql_${uuid0}.mv_mysql_db_${uuid0}.t1 where dt>='2020-06-15' GROUP BY dt;", "test_mv1")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_mysql_${uuid0}.mv_mysql_db_${uuid0}.t1 where dt in ('2020-06-15', '2020-06-21', '2020-07-25') GROUP BY dt;", "test_mv1")
+-- cannot partition prune
+function: check_no_hit_materialized_view("SELECT dt,sum(num) FROM mv_mysql_${uuid0}.mv_mysql_db_${uuid0}.t1 where date_trunc('month', dt) ='2020-06-01' GROUP BY dt;", "test_mv1")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_mysql_${uuid0}.mv_mysql_db_${uuid0}.t1 GROUP BY dt;", "test_mv1")
+
+SELECT dt,sum(num) FROM mv_mysql_${uuid0}.mv_mysql_db_${uuid0}.t1 where dt='2020-06-15' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM mv_mysql_${uuid0}.mv_mysql_db_${uuid0}.t1 where dt !='2020-06-15' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM mv_mysql_${uuid0}.mv_mysql_db_${uuid0}.t1 where dt>='2020-06-15' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM mv_mysql_${uuid0}.mv_mysql_db_${uuid0}.t1 where dt>'2020-06-15' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM mv_mysql_${uuid0}.mv_mysql_db_${uuid0}.t1 where dt>'2020-06-15' and dt < '2020-07-22' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM mv_mysql_${uuid0}.mv_mysql_db_${uuid0}.t1 where dt>'2020-06-15' and dt <= '2020-07-22' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM mv_mysql_${uuid0}.mv_mysql_db_${uuid0}.t1 where (dt>'2020-06-15' and dt <= '2020-06-22') or dt>'2020-07-01' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM mv_mysql_${uuid0}.mv_mysql_db_${uuid0}.t1 where dt in ('2020-06-22', '2020-07-01') GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM mv_mysql_${uuid0}.mv_mysql_db_${uuid0}.t1 where dt in ('2020-06-15', '2020-06-22', '2020-07-01') GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM mv_mysql_${uuid0}.mv_mysql_db_${uuid0}.t1 where dt between '2020-06-15' and '2020-07-01' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM mv_mysql_${uuid0}.mv_mysql_db_${uuid0}.t1 where date_trunc('day', dt) ='2020-06-15' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM mv_mysql_${uuid0}.mv_mysql_db_${uuid0}.t1 where date_trunc('month', dt) ='2020-06-01' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM mv_mysql_${uuid0}.mv_mysql_db_${uuid0}.t1 where date_trunc('month', dt) ='2020-07-01' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM mv_mysql_${uuid0}.mv_mysql_db_${uuid0}.t1 GROUP BY dt order by dt;
+
+drop materialized view default_catalog.db_${uuid0}.test_mv1;
+
+shell: mysql -h${external_mysql_ip} -u${external_mysql_user} -p${external_mysql_password} -P${external_mysql_port} -e 'drop database mv_mysql_db_${uuid0};'

--- a/test/sql/test_materialized_view/T/test_mv_partition_compensate_olap
+++ b/test/sql/test_materialized_view/T/test_mv_partition_compensate_olap
@@ -65,6 +65,21 @@ INSERT INTO t2 VALUES
   (2,"2020-06-15"),(3,"2020-06-18"),(4,"2020-06-21"),(5,"2020-06-24"),
   (2,"2020-07-02"),(3,"2020-07-05"),(4,"2020-07-08"),(5,"2020-07-11");
 
+-- base table with datetime partition column
+CREATE TABLE t3 (
+  num int,
+  dt datetime
+)
+DUPLICATE KEY(`num`)
+PARTITION BY  date_trunc('day', dt) 
+DISTRIBUTED BY HASH(`num`);
+
+INSERT INTO t3 VALUES 
+  (1,"2020-06-15"),(2,"2020-06-18"),(3,"2020-06-21"),(4,"2020-06-24"),
+  (1,"2020-07-02"),(2,"2020-07-05"),(3,"2020-07-08"),(4,"2020-07-11"),
+  (1,"2020-07-16"),(2,"2020-07-19"),(3,"2020-07-22"),(4,"2020-07-25"),
+  (2,"2020-06-15"),(3,"2020-06-18"),(4,"2020-06-21"),(5,"2020-06-24"),
+  (2,"2020-07-02"),(3,"2020-07-05"),(4,"2020-07-08"),(5,"2020-07-11");
 
 -- Test partition compensate without partition expression
 CREATE MATERIALIZED VIEW test_mv1 
@@ -279,10 +294,11 @@ SELECT dt,sum(num) FROM t2 GROUP BY dt order by dt;
 drop materialized view default_catalog.db_${uuid0}.test_mv1;
 
 -- Test partition compensate with partition expression
+-- TODO: Remove dt(extra column) later.
 CREATE MATERIALIZED VIEW test_mv1 
 PARTITION BY dt
 REFRESH DEFERRED MANUAL AS 
-  SELECT date_trunc('day', dt) as dt,sum(num) FROM t2 GROUP BY dt;
+  SELECT dt, date_trunc('day', dt) as format_dt,sum(num) FROM t2 GROUP BY dt;
 REFRESH MATERIALIZED VIEW test_mv1 WITH SYNC MODE;
 
 function: check_hit_materialized_view("SELECT dt,sum(num) FROM t2 where dt='2020-06-15' GROUP BY dt;", "test_mv1")
@@ -348,5 +364,147 @@ SELECT dt,sum(num) FROM t2 GROUP BY dt order by dt;
 
 drop materialized view default_catalog.db_${uuid0}.test_mv1;
 
+-- Test partition compensate with partition expression
+CREATE MATERIALIZED VIEW test_mv1 
+PARTITION BY dt
+REFRESH DEFERRED MANUAL AS 
+  SELECT dt,sum(num) FROM t3 GROUP BY dt;
+REFRESH MATERIALIZED VIEW test_mv1 WITH SYNC MODE;
+
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t3 where dt='2020-06-15' GROUP BY dt;", "test_mv1")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t3 where dt !='2020-06-15' GROUP BY dt;", "test_mv1")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t3 where dt>='2020-06-15' GROUP BY dt;", "test_mv1")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t3 where dt>'2020-06-15' GROUP BY dt;", "test_mv1")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t3 where dt>'2020-06-15' and dt < '2020-07-22' GROUP BY dt;", "test_mv1")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t3 where dt>'2020-06-15' and dt <= '2020-07-22' GROUP BY dt;", "test_mv1")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t3 where (dt>'2020-06-15' and dt <= '2020-06-22') or dt>'2020-07-01' GROUP BY dt;", "test_mv1")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t3 where dt in ('2020-06-15', '2020-06-22', '2020-07-01') GROUP BY dt;", "test_mv1")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t3 where date_trunc('day', dt) ='2020-06-15' GROUP BY dt;", "test_mv1")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t3 where date_trunc('month', dt) ='2020-06-01' GROUP BY dt;", "test_mv1")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t3 where date_trunc('month', dt) ='2020-07-01' GROUP BY dt;", "test_mv1")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t3 GROUP BY dt;", "test_mv1")
+
+SELECT dt,sum(num) FROM t3 where dt='2020-06-15' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM t3 where dt !='2020-06-15' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM t3 where dt>='2020-06-15' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM t3 where dt>'2020-06-15' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM t3 where dt>'2020-06-15' and dt < '2020-07-22' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM t3 where dt>'2020-06-15' and dt <= '2020-07-22' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM t3 where (dt>'2020-06-15' and dt <= '2020-06-22') or dt>'2020-07-01' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM t3 where dt in ('2020-06-15', '2020-06-22', '2020-07-01') GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM t3 where date_trunc('day', dt) ='2020-06-15' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM t3 where date_trunc('month', dt) ='2020-06-01' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM t3 where date_trunc('month', dt) ='2020-07-01' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM t3 GROUP BY dt order by dt;
+
+-- union rewrite
+INSERT INTO t3 VALUES (3, "2020-06-15");
+function: check_no_hit_materialized_view("SELECT dt,sum(num) FROM t3 where dt='2020-06-15' GROUP BY dt;", "test_mv1")
+function: check_no_hit_materialized_view("SELECT dt,sum(num) FROM t3 where date_trunc('day', dt) ='2020-06-15' GROUP BY dt;", "test_mv1")
+function: check_no_hit_materialized_view("SELECT dt,sum(num) FROM t3 where dt in ('2020-06-15', '2020-06-22', '2020-07-01') GROUP BY dt;", "test_mv1")
+
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t3 where date_trunc('day', dt) ='2020-06-21' GROUP BY dt;", "test_mv1")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t3 where dt !='2020-06-15' GROUP BY dt;", "test_mv1")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t3 where dt>'2020-06-15' GROUP BY dt;", "test_mv1")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t3 where dt>'2020-06-15' and dt < '2020-07-22' GROUP BY dt;", "test_mv1")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t3 where dt>'2020-06-15' and dt <= '2020-07-22' GROUP BY dt;", "test_mv1")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t3 where (dt>'2020-06-15' and dt <= '2020-06-22') or dt>'2020-07-01' GROUP BY dt;", "test_mv1")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t3 where date_trunc('month', dt) ='2020-07-01' GROUP BY dt;", "test_mv1")
+
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t3 where dt between '2020-06-15' and '2020-07-01' GROUP BY dt;", "test_mv1", "UNION")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t3 where dt>='2020-06-15' GROUP BY dt;", "test_mv1", "UNION")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t3 where dt in ('2020-06-15', '2020-06-21', '2020-07-25') GROUP BY dt;", "test_mv1", "UNION")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t3 where date_trunc('month', dt) ='2020-06-01' GROUP BY dt;", "test_mv1", "UNION")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t3 GROUP BY dt;", "test_mv1", "UNION")
+
+
+SELECT dt,sum(num) FROM t3 where dt='2020-06-15' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM t3 where dt !='2020-06-15' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM t3 where dt>='2020-06-15' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM t3 where dt>'2020-06-15' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM t3 where dt>'2020-06-15' and dt < '2020-07-22' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM t3 where dt>'2020-06-15' and dt <= '2020-07-22' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM t3 where (dt>'2020-06-15' and dt <= '2020-06-22') or dt>'2020-07-01' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM t3 where dt in ('2020-06-15', '2020-06-22', '2020-07-01') GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM t3 where date_trunc('day', dt) ='2020-06-15' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM t3 where date_trunc('month', dt) ='2020-06-01' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM t3 where date_trunc('month', dt) ='2020-07-01' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM t3 where dt between '2020-06-15' and '2020-07-01' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM t3 GROUP BY dt order by dt;
+
+drop materialized view default_catalog.db_${uuid0}.test_mv1;
+
+-- Test partition compensate with partition expression
+-- TODO: Remove dt(extra column) later.
+CREATE MATERIALIZED VIEW test_mv1 
+PARTITION BY date_trunc('day', dt)
+REFRESH DEFERRED MANUAL AS 
+  SELECT dt, sum(num) FROM t3 GROUP BY dt;
+REFRESH MATERIALIZED VIEW test_mv1 WITH SYNC MODE;
+
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t3 where dt='2020-06-15' GROUP BY dt;", "test_mv1")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t3 where dt !='2020-06-15' GROUP BY dt;", "test_mv1")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t3 where dt>='2020-06-15' GROUP BY dt;", "test_mv1")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t3 where dt>'2020-06-15' GROUP BY dt;", "test_mv1")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t3 where dt>'2020-06-15' and dt < '2020-07-22' GROUP BY dt;", "test_mv1")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t3 where dt>'2020-06-15' and dt <= '2020-07-22' GROUP BY dt;", "test_mv1")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t3 where (dt>'2020-06-15' and dt <= '2020-06-22') or dt>'2020-07-01' GROUP BY dt;", "test_mv1")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t3 where dt in ('2020-06-15', '2020-06-22', '2020-07-01') GROUP BY dt;", "test_mv1")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t3 where date_trunc('day', dt) ='2020-06-15' GROUP BY dt;", "test_mv1")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t3 where date_trunc('month', dt) ='2020-06-01' GROUP BY dt;", "test_mv1")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t3 where date_trunc('month', dt) ='2020-07-01' GROUP BY dt;", "test_mv1")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t3 GROUP BY dt;", "test_mv1")
+
+SELECT dt,sum(num) FROM t3 where dt='2020-06-15' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM t3 where dt !='2020-06-15' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM t3 where dt>='2020-06-15' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM t3 where dt>'2020-06-15' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM t3 where dt>'2020-06-15' and dt < '2020-07-22' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM t3 where dt>'2020-06-15' and dt <= '2020-07-22' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM t3 where (dt>'2020-06-15' and dt <= '2020-06-22') or dt>'2020-07-01' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM t3 where dt in ('2020-06-15', '2020-06-22', '2020-07-01') GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM t3 where date_trunc('day', dt) ='2020-06-15' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM t3 where date_trunc('month', dt) ='2020-06-01' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM t3 where date_trunc('month', dt) ='2020-07-01' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM t3 GROUP BY dt order by dt;
+
+-- union rewrite
+INSERT INTO t3 VALUES (3, "2020-06-15");
+function: check_no_hit_materialized_view("SELECT dt,sum(num) FROM t3 where dt='2020-06-15' GROUP BY dt;", "test_mv1")
+function: check_no_hit_materialized_view("SELECT dt,sum(num) FROM t3 where date_trunc('day', dt) ='2020-06-15' GROUP BY dt;", "test_mv1")
+function: check_no_hit_materialized_view("SELECT dt,sum(num) FROM t3 where dt in ('2020-06-15', '2020-06-22', '2020-07-01') GROUP BY dt;", "test_mv1")
+
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t3 where date_trunc('day', dt) ='2020-06-21' GROUP BY dt;", "test_mv1")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t3 where dt !='2020-06-15' GROUP BY dt;", "test_mv1")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t3 where dt>'2020-06-15' GROUP BY dt;", "test_mv1")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t3 where dt>'2020-06-15' and dt < '2020-07-22' GROUP BY dt;", "test_mv1")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t3 where dt>'2020-06-15' and dt <= '2020-07-22' GROUP BY dt;", "test_mv1")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t3 where (dt>'2020-06-15' and dt <= '2020-06-22') or dt>'2020-07-01' GROUP BY dt;", "test_mv1")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t3 where date_trunc('month', dt) ='2020-07-01' GROUP BY dt;", "test_mv1")
+
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t3 where dt between '2020-06-15' and '2020-07-01' GROUP BY dt;", "test_mv1", "UNION")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t3 where dt>='2020-06-15' GROUP BY dt;", "test_mv1", "UNION")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t3 where dt in ('2020-06-15', '2020-06-21', '2020-07-25') GROUP BY dt;", "test_mv1", "UNION")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t3 where date_trunc('month', dt) ='2020-06-01' GROUP BY dt;", "test_mv1", "UNION")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t3 GROUP BY dt;", "test_mv1", "UNION")
+
+
+SELECT dt,sum(num) FROM t3 where dt='2020-06-15' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM t3 where dt !='2020-06-15' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM t3 where dt>='2020-06-15' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM t3 where dt>'2020-06-15' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM t3 where dt>'2020-06-15' and dt < '2020-07-22' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM t3 where dt>'2020-06-15' and dt <= '2020-07-22' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM t3 where (dt>'2020-06-15' and dt <= '2020-06-22') or dt>'2020-07-01' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM t3 where dt in ('2020-06-15', '2020-06-22', '2020-07-01') GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM t3 where date_trunc('day', dt) ='2020-06-15' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM t3 where date_trunc('month', dt) ='2020-06-01' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM t3 where date_trunc('month', dt) ='2020-07-01' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM t3 where dt between '2020-06-15' and '2020-07-01' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM t3 GROUP BY dt order by dt;
+
+drop materialized view default_catalog.db_${uuid0}.test_mv1;
 
 drop table t1 force;
+drop table t2 force;
+drop table t3 force;

--- a/test/sql/test_materialized_view/T/test_mv_partition_compensate_olap
+++ b/test/sql/test_materialized_view/T/test_mv_partition_compensate_olap
@@ -1,0 +1,352 @@
+-- name: test_mv_partition_compensate_olap
+
+-- create mv
+create database db_${uuid0};
+use db_${uuid0};
+
+-- test mv with range partition 
+-- base table with date partition column
+CREATE TABLE t1 (
+  num int,
+  dt date
+)
+DUPLICATE KEY(`num`)
+PARTITION BY RANGE(`dt`)
+(
+  PARTITION p20200615 VALUES [("2020-06-15 00:00:00"), ("2020-06-16 00:00:00")),
+  PARTITION p20200618 VALUES [("2020-06-18 00:00:00"), ("2020-06-19 00:00:00")),
+  PARTITION p20200621 VALUES [("2020-06-21 00:00:00"), ("2020-06-22 00:00:00")),
+  PARTITION p20200624 VALUES [("2020-06-24 00:00:00"), ("2020-06-25 00:00:00")),
+  PARTITION p20200702 VALUES [("2020-07-02 00:00:00"), ("2020-07-03 00:00:00")),
+  PARTITION p20200705 VALUES [("2020-07-05 00:00:00"), ("2020-07-06 00:00:00")),
+  PARTITION p20200708 VALUES [("2020-07-08 00:00:00"), ("2020-07-09 00:00:00")),
+  PARTITION p20200716 VALUES [("2020-07-16 00:00:00"), ("2020-07-17 00:00:00")),
+  PARTITION p20200719 VALUES [("2020-07-19 00:00:00"), ("2020-07-20 00:00:00")),
+  PARTITION p20200722 VALUES [("2020-07-22 00:00:00"), ("2020-07-23 00:00:00")),
+  PARTITION p20200725 VALUES [("2020-07-25 00:00:00"), ("2020-07-26 00:00:00")),
+  PARTITION p20200711 VALUES [("2020-07-11 00:00:00"), ("2020-07-12 00:00:00"))
+)
+DISTRIBUTED BY HASH(`num`);
+
+INSERT INTO t1 VALUES 
+  (1,"2020-06-15"),(2,"2020-06-18"),(3,"2020-06-21"),(4,"2020-06-24"),
+  (1,"2020-07-02"),(2,"2020-07-05"),(3,"2020-07-08"),(4,"2020-07-11"),
+  (1,"2020-07-16"),(2,"2020-07-19"),(3,"2020-07-22"),(4,"2020-07-25"),
+  (2,"2020-06-15"),(3,"2020-06-18"),(4,"2020-06-21"),(5,"2020-06-24"),
+  (2,"2020-07-02"),(3,"2020-07-05"),(4,"2020-07-08"),(5,"2020-07-11");
+
+-- base table with datetime partition column
+CREATE TABLE t2 (
+  num int,
+  dt datetime
+)
+DUPLICATE KEY(`num`)
+PARTITION BY RANGE(`dt`)
+(
+  PARTITION p20200615 VALUES [("2020-06-15 00:00:00"), ("2020-06-16 00:00:00")),
+  PARTITION p20200618 VALUES [("2020-06-18 00:00:00"), ("2020-06-19 00:00:00")),
+  PARTITION p20200621 VALUES [("2020-06-21 00:00:00"), ("2020-06-22 00:00:00")),
+  PARTITION p20200624 VALUES [("2020-06-24 00:00:00"), ("2020-06-25 00:00:00")),
+  PARTITION p20200702 VALUES [("2020-07-02 00:00:00"), ("2020-07-03 00:00:00")),
+  PARTITION p20200705 VALUES [("2020-07-05 00:00:00"), ("2020-07-06 00:00:00")),
+  PARTITION p20200708 VALUES [("2020-07-08 00:00:00"), ("2020-07-09 00:00:00")),
+  PARTITION p20200716 VALUES [("2020-07-16 00:00:00"), ("2020-07-17 00:00:00")),
+  PARTITION p20200719 VALUES [("2020-07-19 00:00:00"), ("2020-07-20 00:00:00")),
+  PARTITION p20200722 VALUES [("2020-07-22 00:00:00"), ("2020-07-23 00:00:00")),
+  PARTITION p20200725 VALUES [("2020-07-25 00:00:00"), ("2020-07-26 00:00:00")),
+  PARTITION p20200711 VALUES [("2020-07-11 00:00:00"), ("2020-07-12 00:00:00"))
+)
+DISTRIBUTED BY HASH(`num`);
+
+INSERT INTO t2 VALUES 
+  (1,"2020-06-15"),(2,"2020-06-18"),(3,"2020-06-21"),(4,"2020-06-24"),
+  (1,"2020-07-02"),(2,"2020-07-05"),(3,"2020-07-08"),(4,"2020-07-11"),
+  (1,"2020-07-16"),(2,"2020-07-19"),(3,"2020-07-22"),(4,"2020-07-25"),
+  (2,"2020-06-15"),(3,"2020-06-18"),(4,"2020-06-21"),(5,"2020-06-24"),
+  (2,"2020-07-02"),(3,"2020-07-05"),(4,"2020-07-08"),(5,"2020-07-11");
+
+
+-- Test partition compensate without partition expression
+CREATE MATERIALIZED VIEW test_mv1 
+PARTITION BY dt 
+REFRESH DEFERRED MANUAL AS 
+  SELECT dt,sum(num) FROM t1 GROUP BY dt;
+
+REFRESH MATERIALIZED VIEW test_mv1 WITH SYNC MODE;
+
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t1 where dt='2020-06-15' GROUP BY dt;", "test_mv1")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t1 where dt !='2020-06-15' GROUP BY dt;", "test_mv1")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t1 where dt>='2020-06-15' GROUP BY dt;", "test_mv1")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t1 where dt>'2020-06-15' GROUP BY dt;", "test_mv1")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t1 where dt>'2020-06-15' and dt < '2020-07-22' GROUP BY dt;", "test_mv1")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t1 where dt>'2020-06-15' and dt <= '2020-07-22' GROUP BY dt;", "test_mv1")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t1 where (dt>'2020-06-15' and dt <= '2020-06-22') or dt>'2020-07-01' GROUP BY dt;", "test_mv1")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t1 where dt in ('2020-06-15', '2020-06-22', '2020-07-01') GROUP BY dt;", "test_mv1")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t1 where date_trunc('day', dt) ='2020-06-15' GROUP BY dt;", "test_mv1")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t1 where date_trunc('month', dt) ='2020-06-01' GROUP BY dt;", "test_mv1")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t1 where date_trunc('month', dt) ='2020-07-01' GROUP BY dt;", "test_mv1")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t1 GROUP BY dt;", "test_mv1")
+
+SELECT dt,sum(num) FROM t1 where dt='2020-06-15' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM t1 where dt !='2020-06-15' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM t1 where dt>='2020-06-15' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM t1 where dt>'2020-06-15' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM t1 where dt>'2020-06-15' and dt < '2020-07-22' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM t1 where dt>'2020-06-15' and dt <= '2020-07-22' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM t1 where (dt>'2020-06-15' and dt <= '2020-06-22') or dt>'2020-07-01' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM t1 where dt in ('2020-06-15', '2020-06-22', '2020-07-01') GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM t1 where date_trunc('day', dt) ='2020-06-15' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM t1 where date_trunc('month', dt) ='2020-06-01' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM t1 where date_trunc('month', dt) ='2020-07-01' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM t1 GROUP BY dt order by dt;
+
+-- union rewrite
+INSERT INTO t1 VALUES (3, "2020-06-15");
+function: check_no_hit_materialized_view("SELECT dt,sum(num) FROM t1 where dt='2020-06-15' GROUP BY dt;", "test_mv1")
+function: check_no_hit_materialized_view("SELECT dt,sum(num) FROM t1 where date_trunc('day', dt) ='2020-06-15' GROUP BY dt;", "test_mv1")
+function: check_no_hit_materialized_view("SELECT dt,sum(num) FROM t1 where dt in ('2020-06-15', '2020-06-22', '2020-07-01') GROUP BY dt;", "test_mv1")
+
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t1 where date_trunc('day', dt) ='2020-06-21' GROUP BY dt;", "test_mv1")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t1 where dt !='2020-06-15' GROUP BY dt;", "test_mv1")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t1 where dt>'2020-06-15' GROUP BY dt;", "test_mv1")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t1 where dt>'2020-06-15' and dt < '2020-07-22' GROUP BY dt;", "test_mv1")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t1 where dt>'2020-06-15' and dt <= '2020-07-22' GROUP BY dt;", "test_mv1")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t1 where (dt>'2020-06-15' and dt <= '2020-06-22') or dt>'2020-07-01' GROUP BY dt;", "test_mv1")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t1 where date_trunc('month', dt) ='2020-07-01' GROUP BY dt;", "test_mv1")
+
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t1 where dt between '2020-06-15' and '2020-07-01' GROUP BY dt;", "test_mv1", "UNION")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t1 where dt>='2020-06-15' GROUP BY dt;", "test_mv1", "UNION")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t1 where dt in ('2020-06-15', '2020-06-21', '2020-07-25') GROUP BY dt;", "test_mv1", "UNION")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t1 where date_trunc('month', dt) ='2020-06-01' GROUP BY dt;", "test_mv1", "UNION")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t1 GROUP BY dt;", "test_mv1", "UNION")
+
+
+SELECT dt,sum(num) FROM t1 where dt='2020-06-15' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM t1 where dt !='2020-06-15' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM t1 where dt>='2020-06-15' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM t1 where dt>'2020-06-15' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM t1 where dt>'2020-06-15' and dt < '2020-07-22' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM t1 where dt>'2020-06-15' and dt <= '2020-07-22' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM t1 where (dt>'2020-06-15' and dt <= '2020-06-22') or dt>'2020-07-01' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM t1 where dt in ('2020-06-15', '2020-06-22', '2020-07-01') GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM t1 where date_trunc('day', dt) ='2020-06-15' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM t1 where date_trunc('month', dt) ='2020-06-01' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM t1 where date_trunc('month', dt) ='2020-07-01' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM t1 where dt between '2020-06-15' and '2020-07-01' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM t1 GROUP BY dt order by dt;
+
+drop materialized view default_catalog.db_${uuid0}.test_mv1;
+
+-- Test partition compensate with partition expression
+CREATE MATERIALIZED VIEW test_mv1 
+PARTITION BY date_trunc('day', dt)
+REFRESH DEFERRED MANUAL AS 
+  SELECT dt,sum(num) FROM t1 GROUP BY dt;
+REFRESH MATERIALIZED VIEW test_mv1 WITH SYNC MODE;
+
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t1 where dt='2020-06-15' GROUP BY dt;", "test_mv1")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t1 where dt !='2020-06-15' GROUP BY dt;", "test_mv1")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t1 where dt>='2020-06-15' GROUP BY dt;", "test_mv1")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t1 where dt>'2020-06-15' GROUP BY dt;", "test_mv1")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t1 where dt>'2020-06-15' and dt < '2020-07-22' GROUP BY dt;", "test_mv1")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t1 where dt>'2020-06-15' and dt <= '2020-07-22' GROUP BY dt;", "test_mv1")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t1 where (dt>'2020-06-15' and dt <= '2020-06-22') or dt>'2020-07-01' GROUP BY dt;", "test_mv1")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t1 where dt in ('2020-06-15', '2020-06-22', '2020-07-01') GROUP BY dt;", "test_mv1")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t1 where date_trunc('day', dt) ='2020-06-15' GROUP BY dt;", "test_mv1")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t1 where date_trunc('month', dt) ='2020-06-01' GROUP BY dt;", "test_mv1")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t1 where date_trunc('month', dt) ='2020-07-01' GROUP BY dt;", "test_mv1")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t1 GROUP BY dt;", "test_mv1")
+
+SELECT dt,sum(num) FROM t1 where dt='2020-06-15' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM t1 where dt !='2020-06-15' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM t1 where dt>='2020-06-15' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM t1 where dt>'2020-06-15' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM t1 where dt>'2020-06-15' and dt < '2020-07-22' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM t1 where dt>'2020-06-15' and dt <= '2020-07-22' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM t1 where (dt>'2020-06-15' and dt <= '2020-06-22') or dt>'2020-07-01' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM t1 where dt in ('2020-06-15', '2020-06-22', '2020-07-01') GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM t1 where date_trunc('day', dt) ='2020-06-15' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM t1 where date_trunc('month', dt) ='2020-06-01' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM t1 where date_trunc('month', dt) ='2020-07-01' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM t1 GROUP BY dt order by dt;
+
+-- union rewrite
+INSERT INTO t1 VALUES (3, "2020-06-15");
+function: check_no_hit_materialized_view("SELECT dt,sum(num) FROM t1 where dt='2020-06-15' GROUP BY dt;", "test_mv1")
+function: check_no_hit_materialized_view("SELECT dt,sum(num) FROM t1 where date_trunc('day', dt) ='2020-06-15' GROUP BY dt;", "test_mv1")
+function: check_no_hit_materialized_view("SELECT dt,sum(num) FROM t1 where dt in ('2020-06-15', '2020-06-22', '2020-07-01') GROUP BY dt;", "test_mv1")
+
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t1 where date_trunc('day', dt) ='2020-06-21' GROUP BY dt;", "test_mv1")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t1 where dt !='2020-06-15' GROUP BY dt;", "test_mv1")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t1 where dt>'2020-06-15' GROUP BY dt;", "test_mv1")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t1 where dt>'2020-06-15' and dt < '2020-07-22' GROUP BY dt;", "test_mv1")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t1 where dt>'2020-06-15' and dt <= '2020-07-22' GROUP BY dt;", "test_mv1")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t1 where (dt>'2020-06-15' and dt <= '2020-06-22') or dt>'2020-07-01' GROUP BY dt;", "test_mv1")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t1 where date_trunc('month', dt) ='2020-07-01' GROUP BY dt;", "test_mv1")
+
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t1 where dt between '2020-06-15' and '2020-07-01' GROUP BY dt;", "test_mv1", "UNION")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t1 where dt>='2020-06-15' GROUP BY dt;", "test_mv1", "UNION")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t1 where dt in ('2020-06-15', '2020-06-21', '2020-07-25') GROUP BY dt;", "test_mv1", "UNION")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t1 where date_trunc('month', dt) ='2020-06-01' GROUP BY dt;", "test_mv1", "UNION")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t1 GROUP BY dt;", "test_mv1", "UNION")
+
+
+SELECT dt,sum(num) FROM t1 where dt='2020-06-15' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM t1 where dt !='2020-06-15' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM t1 where dt>='2020-06-15' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM t1 where dt>'2020-06-15' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM t1 where dt>'2020-06-15' and dt < '2020-07-22' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM t1 where dt>'2020-06-15' and dt <= '2020-07-22' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM t2 where (dt>'2020-06-15' and dt <= '2020-06-22') or dt>'2020-07-01' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM t2 where dt in ('2020-06-15', '2020-06-22', '2020-07-01') GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM t2 where date_trunc('day', dt) ='2020-06-15' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM t2 where date_trunc('month', dt) ='2020-06-01' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM t2 where date_trunc('month', dt) ='2020-07-01' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM t2 where dt between '2020-06-15' and '2020-07-01' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM t2 GROUP BY dt order by dt;
+
+drop materialized view default_catalog.db_${uuid0}.test_mv1;
+
+
+-- Test partition compensate with partition expression
+CREATE MATERIALIZED VIEW test_mv1 
+PARTITION BY date_trunc('day', dt)
+REFRESH DEFERRED MANUAL AS 
+  SELECT dt,sum(num) FROM t2 GROUP BY dt;
+REFRESH MATERIALIZED VIEW test_mv1 WITH SYNC MODE;
+
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t2 where dt='2020-06-15' GROUP BY dt;", "test_mv1")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t2 where dt !='2020-06-15' GROUP BY dt;", "test_mv1")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t2 where dt>='2020-06-15' GROUP BY dt;", "test_mv1")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t2 where dt>'2020-06-15' GROUP BY dt;", "test_mv1")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t2 where dt>'2020-06-15' and dt < '2020-07-22' GROUP BY dt;", "test_mv1")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t2 where dt>'2020-06-15' and dt <= '2020-07-22' GROUP BY dt;", "test_mv1")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t2 where (dt>'2020-06-15' and dt <= '2020-06-22') or dt>'2020-07-01' GROUP BY dt;", "test_mv1")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t2 where dt in ('2020-06-15', '2020-06-22', '2020-07-01') GROUP BY dt;", "test_mv1")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t2 where date_trunc('day', dt) ='2020-06-15' GROUP BY dt;", "test_mv1")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t2 where date_trunc('month', dt) ='2020-06-01' GROUP BY dt;", "test_mv1")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t2 where date_trunc('month', dt) ='2020-07-01' GROUP BY dt;", "test_mv1")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t2 GROUP BY dt;", "test_mv1")
+
+SELECT dt,sum(num) FROM t2 where dt='2020-06-15' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM t2 where dt !='2020-06-15' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM t2 where dt>='2020-06-15' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM t2 where dt>'2020-06-15' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM t2 where dt>'2020-06-15' and dt < '2020-07-22' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM t2 where dt>'2020-06-15' and dt <= '2020-07-22' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM t2 where (dt>'2020-06-15' and dt <= '2020-06-22') or dt>'2020-07-01' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM t2 where dt in ('2020-06-15', '2020-06-22', '2020-07-01') GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM t2 where date_trunc('day', dt) ='2020-06-15' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM t2 where date_trunc('month', dt) ='2020-06-01' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM t2 where date_trunc('month', dt) ='2020-07-01' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM t2 GROUP BY dt order by dt;
+
+-- union rewrite
+INSERT INTO t2 VALUES (3, "2020-06-15");
+function: check_no_hit_materialized_view("SELECT dt,sum(num) FROM t2 where dt='2020-06-15' GROUP BY dt;", "test_mv1")
+function: check_no_hit_materialized_view("SELECT dt,sum(num) FROM t2 where date_trunc('day', dt) ='2020-06-15' GROUP BY dt;", "test_mv1")
+function: check_no_hit_materialized_view("SELECT dt,sum(num) FROM t2 where dt in ('2020-06-15', '2020-06-22', '2020-07-01') GROUP BY dt;", "test_mv1")
+
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t2 where date_trunc('day', dt) ='2020-06-21' GROUP BY dt;", "test_mv1")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t2 where dt !='2020-06-15' GROUP BY dt;", "test_mv1")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t2 where dt>'2020-06-15' GROUP BY dt;", "test_mv1")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t2 where dt>'2020-06-15' and dt < '2020-07-22' GROUP BY dt;", "test_mv1")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t2 where dt>'2020-06-15' and dt <= '2020-07-22' GROUP BY dt;", "test_mv1")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t2 where (dt>'2020-06-15' and dt <= '2020-06-22') or dt>'2020-07-01' GROUP BY dt;", "test_mv1")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t2 where date_trunc('month', dt) ='2020-07-01' GROUP BY dt;", "test_mv1")
+
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t2 where dt between '2020-06-15' and '2020-07-01' GROUP BY dt;", "test_mv1", "UNION")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t2 where dt>='2020-06-15' GROUP BY dt;", "test_mv1", "UNION")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t2 where dt in ('2020-06-15', '2020-06-21', '2020-07-25') GROUP BY dt;", "test_mv1", "UNION")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t2 where date_trunc('month', dt) ='2020-06-01' GROUP BY dt;", "test_mv1", "UNION")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t2 GROUP BY dt;", "test_mv1", "UNION")
+
+
+SELECT dt,sum(num) FROM t2 where dt='2020-06-15' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM t2 where dt !='2020-06-15' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM t2 where dt>='2020-06-15' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM t2 where dt>'2020-06-15' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM t2 where dt>'2020-06-15' and dt < '2020-07-22' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM t2 where dt>'2020-06-15' and dt <= '2020-07-22' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM t2 where (dt>'2020-06-15' and dt <= '2020-06-22') or dt>'2020-07-01' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM t2 where dt in ('2020-06-15', '2020-06-22', '2020-07-01') GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM t2 where date_trunc('day', dt) ='2020-06-15' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM t2 where date_trunc('month', dt) ='2020-06-01' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM t2 where date_trunc('month', dt) ='2020-07-01' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM t2 where dt between '2020-06-15' and '2020-07-01' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM t2 GROUP BY dt order by dt;
+
+drop materialized view default_catalog.db_${uuid0}.test_mv1;
+
+-- Test partition compensate with partition expression
+CREATE MATERIALIZED VIEW test_mv1 
+PARTITION BY dt
+REFRESH DEFERRED MANUAL AS 
+  SELECT date_trunc('day', dt) as dt,sum(num) FROM t2 GROUP BY dt;
+REFRESH MATERIALIZED VIEW test_mv1 WITH SYNC MODE;
+
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t2 where dt='2020-06-15' GROUP BY dt;", "test_mv1")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t2 where dt !='2020-06-15' GROUP BY dt;", "test_mv1")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t2 where dt>='2020-06-15' GROUP BY dt;", "test_mv1")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t2 where dt>'2020-06-15' GROUP BY dt;", "test_mv1")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t2 where dt>'2020-06-15' and dt < '2020-07-22' GROUP BY dt;", "test_mv1")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t2 where dt>'2020-06-15' and dt <= '2020-07-22' GROUP BY dt;", "test_mv1")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t2 where (dt>'2020-06-15' and dt <= '2020-06-22') or dt>'2020-07-01' GROUP BY dt;", "test_mv1")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t2 where dt in ('2020-06-15', '2020-06-22', '2020-07-01') GROUP BY dt;", "test_mv1")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t2 where date_trunc('day', dt) ='2020-06-15' GROUP BY dt;", "test_mv1")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t2 where date_trunc('month', dt) ='2020-06-01' GROUP BY dt;", "test_mv1")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t2 where date_trunc('month', dt) ='2020-07-01' GROUP BY dt;", "test_mv1")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t2 GROUP BY dt;", "test_mv1")
+
+SELECT dt,sum(num) FROM t2 where dt='2020-06-15' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM t2 where dt !='2020-06-15' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM t2 where dt>='2020-06-15' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM t2 where dt>'2020-06-15' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM t2 where dt>'2020-06-15' and dt < '2020-07-22' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM t2 where dt>'2020-06-15' and dt <= '2020-07-22' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM t2 where (dt>'2020-06-15' and dt <= '2020-06-22') or dt>'2020-07-01' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM t2 where dt in ('2020-06-15', '2020-06-22', '2020-07-01') GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM t2 where date_trunc('day', dt) ='2020-06-15' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM t2 where date_trunc('month', dt) ='2020-06-01' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM t2 where date_trunc('month', dt) ='2020-07-01' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM t2 GROUP BY dt order by dt;
+
+-- union rewrite
+INSERT INTO t2 VALUES (3, "2020-06-15");
+function: check_no_hit_materialized_view("SELECT dt,sum(num) FROM t2 where dt='2020-06-15' GROUP BY dt;", "test_mv1")
+function: check_no_hit_materialized_view("SELECT dt,sum(num) FROM t2 where date_trunc('day', dt) ='2020-06-15' GROUP BY dt;", "test_mv1")
+function: check_no_hit_materialized_view("SELECT dt,sum(num) FROM t2 where dt in ('2020-06-15', '2020-06-22', '2020-07-01') GROUP BY dt;", "test_mv1")
+
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t2 where date_trunc('day', dt) ='2020-06-21' GROUP BY dt;", "test_mv1")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t2 where dt !='2020-06-15' GROUP BY dt;", "test_mv1")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t2 where dt>'2020-06-15' GROUP BY dt;", "test_mv1")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t2 where dt>'2020-06-15' and dt < '2020-07-22' GROUP BY dt;", "test_mv1")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t2 where dt>'2020-06-15' and dt <= '2020-07-22' GROUP BY dt;", "test_mv1")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t2 where (dt>'2020-06-15' and dt <= '2020-06-22') or dt>'2020-07-01' GROUP BY dt;", "test_mv1")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t2 where date_trunc('month', dt) ='2020-07-01' GROUP BY dt;", "test_mv1")
+
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t2 where dt between '2020-06-15' and '2020-07-01' GROUP BY dt;", "test_mv1", "UNION")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t2 where dt>='2020-06-15' GROUP BY dt;", "test_mv1", "UNION")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t2 where dt in ('2020-06-15', '2020-06-21', '2020-07-25') GROUP BY dt;", "test_mv1", "UNION")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t2 where date_trunc('month', dt) ='2020-06-01' GROUP BY dt;", "test_mv1", "UNION")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t2 GROUP BY dt;", "test_mv1", "UNION")
+
+
+SELECT dt,sum(num) FROM t2 where dt='2020-06-15' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM t2 where dt !='2020-06-15' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM t2 where dt>='2020-06-15' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM t2 where dt>'2020-06-15' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM t2 where dt>'2020-06-15' and dt < '2020-07-22' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM t2 where dt>'2020-06-15' and dt <= '2020-07-22' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM t2 where (dt>'2020-06-15' and dt <= '2020-06-22') or dt>'2020-07-01' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM t2 where dt in ('2020-06-15', '2020-06-22', '2020-07-01') GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM t2 where date_trunc('day', dt) ='2020-06-15' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM t2 where date_trunc('month', dt) ='2020-06-01' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM t2 where date_trunc('month', dt) ='2020-07-01' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM t2 where dt between '2020-06-15' and '2020-07-01' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM t2 GROUP BY dt order by dt;
+
+drop materialized view default_catalog.db_${uuid0}.test_mv1;
+
+
+drop table t1 force;


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:

- Introduce Partition Compensate type deduced from query's partition and mv's partition diff which can decide to different actions(no rewrite/no compensate/...);
```
/**
     * PCType means different compensate type for the specific mv and query plan:
     * - NO_REWRITE: When mv's refreshed partitions are not intersected with query's selected partitions, no need to rewrite.
     * - PRUNED_COMPENSATE: When mv's refreshed partitions are intersected with query's selected partitions, but mv's
     *      refreshed partitions are not satisfied with query's selected partitions.
     * - NO_COMPENSATE: When mv's refreshed partitions are intersected with query's selected partitions, but mv's
     *      refreshed partitions are satisfied with query's selected partitions.
     * - UNKNOWN: others we set it unknown.
     */
    public enum PCType {
        NO_REWRITE,
        PRUNED_COMPENSATE,
        NO_PRUNED_COMPENSATE,
        NO_COMPENSATE,
        UNKNOWN;

        public static boolean isNoCompensate(PCType pcType) {
            return pcType == NO_COMPENSATE;
        }

        public static boolean isCompensate(PCType pcType) {
            return !isNoCompensate(pcType);
        }

        public static boolean isUnionAllWithPullUpPredicates(PCType pcType) {
            return pcType == NO_COMPENSATE || pcType == PRUNED_COMPENSATE;
        }
    }

```
- Enable pull up predicates to support more union all rewrite cases by default:
```
   // To support more union all rewrite cases, we can pull up query's predicates to make possible for union rewrite.
   // But rewritten plan may scan all mv partitions when:
   //  - mv has no partitions which query's plan to scan: PCType.NO_REWRITE
   //  - query's partitions have been pruned(we cannot decide whether to pull up or not): PCType.NO_PRUNED_COMPENSATE
```
- To keep consistent bewteen mv rewrite and original query, disable rewrite when mv  has to-refresh partitions for unsupported partition compensate external tables.
```
    // If the scan operator is not supported, then return null when compensate type is not NO_COMPENSATE
    // which means the query cannot be rewritten only when all partitions are refreshed.
    // Change query_rewrite_consistency=loose to no check query rewrite consistency.
```
- Add olap/iceberg/hive/mysql for mv tests;

Fixes https://github.com/StarRocks/StarRocksTest/issues/6303

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
