### PR TITLE
[BugFix] Fix orc reader is using outdate rowsInCurrentStripe

### DIFF
--- a/be/src/formats/orc/apache-orc/c++/src/Reader.cc
+++ b/be/src/formats/orc/apache-orc/c++/src/Reader.cc
@@ -1061,6 +1061,8 @@ void RowReaderImpl::startNextStripe() {
             throw ParseError(msg.str());
         }
 
+        rowsInCurrentStripe = currentStripeInfo.numberofrows();
+
         bool skipStripe = false;
         bool skipStripeByScanRangeMisMatch = false;
         if (sargsApplier) {
@@ -1093,7 +1095,6 @@ void RowReaderImpl::startNextStripe() {
             contents->stream->releaseToOffset(currentStripeInfo.offset());
         }
         currentStripeFooter = getStripeFooter(currentStripeInfo, *contents);
-        rowsInCurrentStripe = currentStripeInfo.numberofrows();
         // We need to check this stripe is already set in shared buffer(tiny stripe optimize) to avoid shared buffer overlap
         if (isIOCoalesceEnabled &&
             !contents->stream->isAlreadyCollectedInSharedBuffer(currentStripeInfo.offset(), stripeSize)) {


### PR DESCRIPTION
## Why I'm doing:
In https://github.com/StarRocks/starrocks/pull/41751, we move eval stripe stats before `getStripeFooter()`, but forget to move variable `rowsInCurrentStripe`. It will cause metrics errors.

## What I'm doing:
Fix it

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
