### PR TITLE
[BugFix] fix wrong slot index when handling iceberg delete columns

### DIFF
--- a/be/src/connector/hive_connector.cpp
+++ b/be/src/connector/hive_connector.cpp
@@ -263,13 +263,13 @@ Status HiveDataSource::_init_tuples_and_slots(RuntimeState* state) {
         for (SlotDescriptor* d_slot_desc : delete_column_tuple_desc->slots()) {
             _equality_delete_slots.emplace_back(d_slot_desc);
             if (!id_to_slots.contains(d_slot_desc->id())) {
-                _materialize_slots.push_back(d_slot_desc);
                 const auto& it = id_to_index.find(d_slot_desc->id());
                 if (it == id_to_index.end()) {
                     return Status::InternalError(
-                            "Invalid slot id in delete_column_slot_ids. id =  " + std::to_string(d_slot_desc->id()) +
-                            ", name = " + d_slot_desc->col_name());
+                            fmt::format("Invalid slot id in delete_column_slot_ids. id = {}, name = {}",
+                                        d_slot_desc->id(), d_slot_desc->col_name()));
                 }
+                _materialize_slots.push_back(d_slot_desc);
                 _materialize_index_in_chunk.push_back(it->second);
             }
         }

--- a/be/src/connector/hive_connector.h
+++ b/be/src/connector/hive_connector.h
@@ -87,7 +87,7 @@ private:
     Status _init_conjunct_ctxs(RuntimeState* state);
     void _update_has_any_predicate();
     Status _decompose_conjunct_ctxs(RuntimeState* state);
-    void _init_tuples_and_slots(RuntimeState* state);
+    Status _init_tuples_and_slots(RuntimeState* state);
     void _init_counter(RuntimeState* state);
     void _init_rf_counters();
 


### PR DESCRIPTION
## Why I'm doing:

We compute wrong slot index when dealing with deleted columns.

## What I'm doing:

data in `_materialize_index_in_chunk` should not exceed `slots.size()`

Fixes https://github.com/StarRocks/starrocks/issues/41866


When I'm debugging this issue, I can see we compute wrong slot index

**I0228 16:21:48.260135 490497 group_reader.cpp:398] [xxx] tuple desc = 0x6070000de9d0, slot desc = 0xbebebebebebebebe, slot index = 3**

```
I0228 16:21:46.591665 490466 descriptors.cpp:756] [xxx] create descriptor. tuple desc = 0x6070000de9d0, slot desc = 0x60d000050330, name = id
I0228 16:21:46.591701 490466 descriptors.cpp:756] [xxx] create descriptor. tuple desc = 0x6070000de9d0, slot desc = 0x60d000050400, name = yyyymmdd
I0228 16:21:46.591732 490466 descriptors.cpp:756] [xxx] create descriptor. tuple desc = 0x6070000de9d0, slot desc = 0x60d0000504d0, name = type
I0228 16:21:46.591763 490466 descriptors.cpp:756] [xxx] create descriptor. tuple desc = 0x6070000dea40, slot desc = 0x60d0000505a0, name = id
I0228 16:21:46.591782 490466 descriptors.cpp:756] [xxx] create descriptor. tuple desc = 0x6070000dea40, slot desc = 0x60d000050670, name = yyyymmdd
I0228 16:21:48.260039 490497 group_reader.cpp:53] [xxx] tuple desc = 0x6070000de9d0, slot desc = 0x60d000050330
I0228 16:21:48.260061 490497 group_reader.cpp:53] [xxx] tuple desc = 0x6070000de9d0, slot desc = 0x60d000050400
I0228 16:21:48.260088 490497 group_reader.cpp:53] [xxx] tuple desc = 0x6070000de9d0, slot desc = 0x60d0000504d0
I0228 16:21:48.260099 490497 group_reader.cpp:390] [xxx] tuple desc = 0x6070000de9d0, slot desc = 0x60d000050330
I0228 16:21:48.260105 490497 group_reader.cpp:390] [xxx] tuple desc = 0x6070000de9d0, slot desc = 0x60d000050400
I0228 16:21:48.260111 490497 group_reader.cpp:390] [xxx] tuple desc = 0x6070000de9d0, slot desc = 0x60d0000504d0
I0228 16:21:48.260121 490497 group_reader.cpp:398] [xxx] tuple desc = 0x6070000de9d0, slot desc = 0x60d000050330, slot index = 0
I0228 16:21:48.260128 490497 group_reader.cpp:398] [xxx] tuple desc = 0x6070000de9d0, slot desc = 0x60d0000504d0, slot index = 2
I0228 16:21:48.260135 490497 group_reader.cpp:398] [xxx] tuple desc = 0x6070000de9d0, slot desc = 0xbebebebebebebebe, slot index = 3
```


## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
