### PR TITLE
[BugFix] Fix the problem of concurrent modification of _supported_logical_types

### DIFF
--- a/be/src/formats/orc/orc_chunk_reader.cpp
+++ b/be/src/formats/orc/orc_chunk_reader.cpp
@@ -954,7 +954,12 @@ Status OrcChunkReader::_add_conjunct(const Expr* conjunct, std::unique_ptr<orc::
     auto* ref = down_cast<ColumnRef*>(slot);
     const SlotId& slot_id = ref->slot_id();
     const std::string& name = _slot_id_to_desc[slot_id]->col_name();
-    orc::PredicateDataType pred_type = _supported_logical_types[slot->type().type];
+
+    orc::PredicateDataType pred_type = orc::PredicateDataType::LONG;
+    auto type_it = _supported_logical_types.find(slot->type().type);
+    if (type_it != _supported_logical_types.end()) {
+        pred_type = type_it->second;
+    }
 
     if (node_type == TExprNodeType::type::BINARY_PRED) {
         Expr* lit = conjunct->get_child(1);

--- a/be/src/formats/orc/orc_chunk_reader.cpp
+++ b/be/src/formats/orc/orc_chunk_reader.cpp
@@ -959,6 +959,9 @@ Status OrcChunkReader::_add_conjunct(const Expr* conjunct, std::unique_ptr<orc::
     auto type_it = _supported_logical_types.find(slot->type().type);
     if (type_it != _supported_logical_types.end()) {
         pred_type = type_it->second;
+    } else {
+        return Status::NotSupported(
+                fmt::format("orc chunk reader don't support {}.", std::to_string(slot->type().type)));
     }
 
     if (node_type == TExprNodeType::type::BINARY_PRED) {


### PR DESCRIPTION
## Why I'm doing:

`_supported_logical_types` is one `std::unordered_map`.  std::unordered_map<Key,T,Hash,KeyEqual,Allocator>::operator[] will insert one new key if the key is not exist. `std::unordered_map` is no thread safe, if resize concurrency, the memory will be leak or crash.

There is another problem: datetime is currenty not supported, @Smith-Cruise will fix it.

```
Direct leak of 16 byte(s) in 1 object(s) allocated from:

    #0 0xa3ab557 in operator new(unsigned long) ../../.././libsanitizer/asan/asan_new_delete.cpp:99

    #1 0x11db0800 in __gnu_cxx::new_allocator<std::__detail::_Hash_node<std::pair<starrocks::LogicalType const, orc::PredicateDataType>, false> >::allocate(unsigned long, void const*) /opt/gcc/usr/include/c++/10.3.0/ext/new_allocator.h:115

    #2 0x11dad210 in std::allocator_traits<std::allocator<std::__detail::_Hash_node<std::pair<starrocks::LogicalType const, orc::PredicateDataType>, false> > >::allocate(std::allocator<std::__detail::_Hash_node<std::pair<starrocks::LogicalType const, orc::PredicateDataType>, false> >&, unsigned long) /opt/gcc/usr/include/c++/10.3.0/bits/alloc_traits.h:460

    #3 0x11da97df in std::__detail::_Hash_node<std::pair<starrocks::LogicalType const, orc::PredicateDataType>, false>* std::__detail::_Hashtable_alloc<std::allocator<std::__detail::_Hash_node<std::pair<starrocks::LogicalType const, orc::PredicateDataType>, false> > >::_M_allocate_node<std::piecewise_construct_t const&, std::tuple<starrocks::LogicalType const&>, std::tuple<> >(std::piecewise_construct_t const&, std::tuple<starrocks::LogicalType const&>&&, std::tuple<>&&) /opt/gcc/usr/include/c++/10.3.0/bits/hashtable_policy.h:2032

    #4 0x11da4dc3 in std::_Hashtable<starrocks::LogicalType, std::pair<starrocks::LogicalType const, orc::PredicateDataType>, std::allocator<std::pair<starrocks::LogicalType const, orc::PredicateDataType> >, std::__detail::_Select1st, std::equal_to<starrocks::LogicalType>, std::hash<starrocks::LogicalType>, std::__detail::_Mod_range_hashing, std::__detail::_Default_ranged_hash, std::__detail::_Prime_rehash_policy, std::__detail::_Hashtable_traits<false, false, true> >::_Scoped_node::_Scoped_node<std::piecewise_construct_t const&, std::tuple<starrocks::LogicalType const&>, std::tuple<> >(std::__detail::_Hashtable_alloc<std::allocator<std::__detail::_Hash_node<std::pair<starrocks::LogicalType const, orc::PredicateDataType>, false> > >*, std::piecewise_construct_t const&, std::tuple<starrocks::LogicalType const&>&&, std::tuple<>&&) (/home/disk1/sr/be/lib/starrocks_be+0x11da4dc3)

    #5 0x11d9fae5 in std::__detail::_Map_base<starrocks::LogicalType, std::pair<starrocks::LogicalType const, orc::PredicateDataType>, std::allocator<std::pair<starrocks::LogicalType const, orc::PredicateDataType> >, std::__detail::_Select1st, std::equal_to<starrocks::LogicalType>, std::hash<starrocks::LogicalType>, std::__detail::_Mod_range_hashing, std::__detail::_Default_ranged_hash, std::__detail::_Prime_rehash_policy, std::__detail::_Hashtable_traits<false, false, true>, true>::operator[](starrocks::LogicalType const&) /opt/gcc/usr/include/c++/10.3.0/bits/hashtable_policy.h:712

    #6 0x11d9a9e4 in std::unordered_map<starrocks::LogicalType, orc::PredicateDataType, std::hash<starrocks::LogicalType>, std::equal_to<starrocks::LogicalType>, std::allocator<std::pair<starrocks::LogicalType const, orc::PredicateDataType> > >::operator[](starrocks::LogicalType const&) /opt/gcc/usr/include/c++/10.3.0/bits/unordered_map.h:984

    #7 0x11d879d2 in starrocks::OrcChunkReader::_add_conjunct(starrocks::Expr const*, std::unique_ptr<orc::SearchArgumentBuilder, std::default_delete<orc::SearchArgumentBuilder> >&) /root/starrocks/be/src/formats/orc/orc_chunk_reader.cpp:947

    #8 0x11d8efdf in starrocks::OrcChunkReader::set_conjuncts_and_runtime_filters(std::vector<starrocks::Expr*, std::allocator<starrocks::Expr*> > const&, starrocks::RuntimeFilterProbeCollector const*) /root/starrocks/be/src/formats/orc/orc_chunk_reader.cpp:1161

    #9 0x14670b16 in starrocks::HdfsOrcScanner::do_open(starrocks::RuntimeState*) /root/starrocks/be/src/exec/hdfs_scanner_orc.cpp:389

    #10 0x14649f1c in starrocks::HdfsScanner::open(starrocks::RuntimeState*) /root/starrocks/be/src/exec/hdfs_scanner.cpp:187

    #11 0x1455f0d1 in starrocks::connector::HiveDataSource::_init_scanner(starrocks::RuntimeState*) /root/starrocks/be/src/connector/hive_connector.cpp:672

    #12 0x14549ea3 in starrocks::connector::HiveDataSource::open(starrocks::RuntimeState*) /root/starrocks/be/src/connector/hive_connector.cpp:103

    #13 0xd028d5d in starrocks::pipeline::ConnectorChunkSource::_open_data_source(starrocks::RuntimeState*) /root/starrocks/be/src/exec/pipeline/scan/connector_scan_operator.cpp:505

    #14 0xd0293e6 in starrocks::pipeline::ConnectorChunkSource::_read_chunk(starrocks::RuntimeState*, std::shared_ptr<starrocks::Chunk>*) /root/starrocks/be/src/exec/pipeline/scan/connector_scan_operator.cpp:534

    #15 0xe0a5b55 in starrocks::pipeline::ChunkSource::buffer_next_batch_chunks_blocking(starrocks::RuntimeState*, unsigned long, starrocks::workgroup::WorkGroup const*) /root/starrocks/be/src/exec/pipeline/scan/chunk_source.cpp:67

    #16 0xcfcb83d in operator() /root/starrocks/be/src/exec/pipeline/scan/scan_operator.cpp:410

    #17 0xcfd17a1 in __invoke_impl<void, starrocks::pipeline::ScanOperator::_trigger_next_scan(starrocks::RuntimeState*, int)::<lambda()>&> /opt/gcc/usr/include/c++/10.3.0/bits/invoke.h:60

    #18 0xcfd164f in __invoke_r<void, starrocks::pipeline::ScanOperator::_trigger_next_scan(starrocks::RuntimeState*, int)::<lambda()>&> /opt/gcc/usr/include/c++/10.3.0/bits/invoke.h:110

    #19 0xcfd14c4 in _M_invoke /opt/gcc/usr/include/c++/10.3.0/bits/std_function.h:291

    #20 0xa410baf in std::function<void ()>::operator()() const /opt/gcc/usr/include/c++/10.3.0/bits/std_function.h:622

    #21 0xd54737c in starrocks::workgroup::ScanExecutor::worker_thread() /root/starrocks/be/src/exec/workgroup/scan_executor.cpp:71

    #22 0xd546ba1 in operator() /root/starrocks/be/src/exec/workgroup/scan_executor.cpp:35

    #23 0xd548b57 in __invoke_impl<void, starrocks::workgroup::ScanExecutor::initialize(int)::<lambda()>&> /opt/gcc/usr/include/c++/10.3.0/bits/invoke.h:60

    #24 0xd548726 in __invoke_r<void, starrocks::workgroup::ScanExecutor::initialize(int)::<lambda()>&> /opt/gcc/usr/include/c++/10.3.0/bits/invoke.h:110

    #25 0xd5480c3 in _M_invoke /opt/gcc/usr/include/c++/10.3.0/bits/std_function.h:291

    #26 0xa410baf in std::function<void ()>::operator()() const /opt/gcc/usr/include/c++/10.3.0/bits/std_function.h:622

    #27 0xb006df1 in starrocks::FunctionRunnable::run() (/home/disk1/sr/be/lib/starrocks_be+0xb006df1)

    #28 0xb003931 in starrocks::ThreadPool::dispatch_thread() /root/starrocks/be/src/util/threadpool.cpp:561

    #29 0xb01fce7 in void std::__invoke_impl<void, void (starrocks::ThreadPool::*&)(), starrocks::ThreadPool*&>(std::__invoke_memfun_deref, void (starrocks::ThreadPool::*&)(), starrocks::ThreadPool*&) /opt/gcc/usr/include/c++/10.3.0/bits/invoke.h:73

```

https://en.cppreference.com/w/cpp/container/unordered_map/operator_at

## What I'm doing:

Fixes https://github.com/StarRocks/StarRocksTest/issues/6331

Use find instead of operator []

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [x] 3.1
  - [x] 3.0
  - [x] 2.5
