### PR TITLE
[BugFix] Unconsistent delvec after disk disable (#41893)

### DIFF
--- a/be/src/storage/storage_engine.cpp
+++ b/be/src/storage/storage_engine.cpp
@@ -965,6 +965,12 @@ Status StorageEngine::_perform_update_compaction(DataDir* data_dir) {
                 fmt::format("Fail to check migrate tablet, tablet_id: {}", best_tablet->tablet_id()));
     }
 
+    auto tablet_id = best_tablet->tablet_id();
+    auto new_tablet = _tablet_manager->get_tablet(tablet_id);
+    if (new_tablet != nullptr && new_tablet->data_dir()->path_hash() != data_dir->path_hash()) {
+        return Status::InternalError(fmt::format("tablet has been migrated, tablet_id: {}", tablet_id));
+    }
+
     Status res;
     int64_t duration_ns = 0;
     {

--- a/be/src/storage/tablet_manager.cpp
+++ b/be/src/storage/tablet_manager.cpp
@@ -444,6 +444,7 @@ Status TabletManager::drop_tablets_on_error_root_path(const std::vector<TabletIn
         return Status::OK();
     }
     auto num_shards = _tablets_shards.size();
+    std::vector<TabletSharedPtr> dropped_tablets;
     for (int i = 0; i < num_shards; i++) {
         std::unique_lock wlock(_tablets_shards[i].lock);
         for (const TabletInfo& tablet_info : tablet_info_vec) {
@@ -459,9 +460,19 @@ Status TabletManager::drop_tablets_on_error_root_path(const std::vector<TabletIn
                 TabletMap& tablet_map = _get_tablet_map(tablet_id);
                 _remove_tablet_from_partition(*dropped_tablet);
                 tablet_map.erase(tablet_id);
+
+                dropped_tablets.push_back(dropped_tablet);
             }
         }
     }
+
+    for (const auto& dropped_tablet : dropped_tablets) {
+        // make sure dropped tablet state is TABLET_SHUTDOWN
+        std::unique_lock l(dropped_tablet->get_header_lock());
+        (void)dropped_tablet->set_tablet_state(TABLET_SHUTDOWN);
+        dropped_tablet->save_meta();
+    }
+
     return Status::OK();
 }
 

--- a/be/src/storage/tablet_updates.cpp
+++ b/be/src/storage/tablet_updates.cpp
@@ -258,10 +258,10 @@ Status TabletUpdates::_load_from_pb(const TabletUpdatesPB& tablet_updates_pb) {
     std::unique_lock l1(_lock);
     std::unique_lock l2(_rowsets_lock);
 
-    std::vector<TabletSegmentId> tsids;
+    std::unordered_set<TabletSegmentId> tsids;
     for (auto& [rsid, rowset] : _rowsets) {
         for (uint32_t i = 0; i < rowset->num_segments(); i++) {
-            tsids.emplace_back(TabletSegmentId{_tablet.tablet_id(), rsid + i});
+            tsids.insert(TabletSegmentId{_tablet.tablet_id(), rsid + i});
         }
     }
 
@@ -349,10 +349,24 @@ Status TabletUpdates::_load_from_pb(const TabletUpdatesPB& tablet_updates_pb) {
     }
     del_vector_cardinality_by_rssid.clear();
 
+    for (auto& [rsid, rowset] : _rowsets) {
+        for (uint32_t i = 0; i < rowset->num_segments(); i++) {
+            tsids.insert(TabletSegmentId{_tablet.tablet_id(), rsid + i});
+        }
+    }
+
     l2.unlock(); // _rowsets_lock
 
+    std::vector<TabletSegmentId> tsids_vec;
+    tsids_vec.resize(tsids.size());
+    for (const auto& tsid : tsids) {
+        tsids_vec.emplace_back(tsid);
+    }
+
     RETURN_IF_ERROR(_load_pending_rowsets());
-    StorageEngine::instance()->update_manager()->clear_cached_del_vec(tsids);
+    StorageEngine::instance()->update_manager()->clear_cached_del_vec(tsids_vec);
+    StorageEngine::instance()->update_manager()->clear_cached_delta_column_group(tsids_vec);
+    StorageEngine::instance()->update_manager()->index_cache().try_remove_by_key(_tablet.tablet_id());
 
     _update_total_stats(_edit_version_infos[_apply_version_idx]->rowsets, nullptr, nullptr);
     VLOG(1) << "load tablet " << _debug_string(false, true);

--- a/be/test/storage/tablet_mgr_test.cpp
+++ b/be/test/storage/tablet_mgr_test.cpp
@@ -503,4 +503,16 @@ TEST_F(TabletMgrTest, RsVersionMapTest) {
     ASSERT_EQ(to_replace.size(), 3);
 }
 
+TEST_F(TabletMgrTest, RemoveTabletInDiskDisable) {
+    TTabletId tablet_id = 4251234;
+    TSchemaHash schema_hash = 3929134;
+    TCreateTabletReq create_tablet_req = get_create_tablet_request(tablet_id, schema_hash);
+    Status create_st = StorageEngine::instance()->create_tablet(create_tablet_req);
+    std::vector<TabletInfo> tablet_info_vec;
+    TabletInfo tablet_info(tablet_id, schema_hash, UniqueId::gen_uid());
+
+    tablet_info_vec.push_back(tablet_info);
+    StorageEngine::instance()->tablet_manager()->drop_tablets_on_error_root_path(tablet_info_vec);
+}
+
 } // namespace starrocks


### PR DESCRIPTION
Problem:
When we disable a disk, the tablets on it will be clone from the other replica into a new disk. Some abnormal case will happen as following:

1. Begin to disable a disk, drop the tablet from the map in tabletManager. But this step will not clear the TabletUpdates Meta at all, including the delvec cache

2. Before disk disable, suppose we have the following version information: for tablet 12345:
Segment 1 (generated from version 1): k1->1, k2->1, k3->1 (with delvec version2 which delete k1->1) rowset segment id = 0
Segment 2 (generated from version 2): k1->2, rowset segment id = 1
Segment 3 (generated from version 2.1): k1->2, k2->1, k3->1 rowset segment id = 2

3. Suppose we begin the clone process, we want to clone the version 2 from other replica into a new disk. We will clone the version2.1 for this tablet and get Segment 3 (generated from version 2.1): k1->2, k2->1, k3->1 now.

4. But the problem here is that: the snapshot for version2.1 will reset the rowset segment id. It means that the Segment in clone tablet with rowset segment id = 0. Therefore, the incoming apply process for this tablet using tsid = {12345, 0} to acquire the latest delvec. But we acquire it first in the cache which mean that we get the delvec for Segment 1 instead.

Currently, the migration task for primary key table has the similar problem.

Solution:
1. Clear the delvec/dcg cache in _load_from_pb to make sure the new tablet will not affect by the Potentially inconsistent cache
2. Double check before primary key table compaction to ensure that we compact in the right datadir
3. make sure set the tablet state as shut down when drop it from tablet_map

Fixes #41893

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
