### PR TITLE
[Enhancement] Add fs sync time to IO profiler

### DIFF
--- a/be/src/fs/fs_posix.cpp
+++ b/be/src/fs/fs_posix.cpp
@@ -295,10 +295,13 @@ public:
     }
 
     Status sync() override {
+        MonotonicStopWatch watch;
+        watch.start();
         if (_pending_sync) {
             _pending_sync = false;
             RETURN_IF_ERROR(do_sync(_fd, _filename));
         }
+        IOProfiler::add_sync(watch.elapsed_time());
         return Status::OK();
     }
 

--- a/be/src/io/io_profiler.cpp
+++ b/be/src/io/io_profiler.cpp
@@ -168,7 +168,7 @@ void IOProfiler::_add_context_write(int64_t bytes) {
 }
 
 // Thread local IO statistics which accumulates all IO since the thread is started
-thread_local IOProfiler::IOStat tls_io_stat{0, 0, 0, 0, 0, 0};
+thread_local IOProfiler::IOStat tls_io_stat{0, 0, 0, 0, 0, 0, 0, 0};
 
 void IOProfiler::take_tls_io_snapshot(IOStat* snapshot) {
     snapshot->read_ops = tls_io_stat.read_ops;
@@ -177,13 +177,15 @@ void IOProfiler::take_tls_io_snapshot(IOStat* snapshot) {
     snapshot->write_ops = tls_io_stat.write_ops;
     snapshot->write_bytes = tls_io_stat.write_bytes;
     snapshot->write_time_ns = tls_io_stat.write_time_ns;
+    snapshot->sync_ops = tls_io_stat.sync_ops;
+    snapshot->sync_time_ns = tls_io_stat.sync_time_ns;
 }
 
 IOProfiler::IOStat IOProfiler::calculate_scoped_tls_io(const IOStat& snapshot) {
-    IOStat io_stat{
-            tls_io_stat.read_ops - snapshot.read_ops,         tls_io_stat.read_bytes - snapshot.read_bytes,
-            tls_io_stat.read_time_ns - snapshot.read_time_ns, tls_io_stat.write_ops - snapshot.write_ops,
-            tls_io_stat.write_bytes - snapshot.write_bytes,   tls_io_stat.write_time_ns - snapshot.write_time_ns};
+    IOStat io_stat{tls_io_stat.read_ops - snapshot.read_ops,         tls_io_stat.read_bytes - snapshot.read_bytes,
+                   tls_io_stat.read_time_ns - snapshot.read_time_ns, tls_io_stat.write_ops - snapshot.write_ops,
+                   tls_io_stat.write_bytes - snapshot.write_bytes,   tls_io_stat.write_time_ns - snapshot.write_time_ns,
+                   tls_io_stat.sync_ops - snapshot.sync_ops,         tls_io_stat.sync_time_ns - snapshot.sync_time_ns};
     return io_stat;
 }
 
@@ -197,6 +199,11 @@ void IOProfiler::_add_tls_write(int64_t bytes, int64_t latency_ns) {
     tls_io_stat.write_ops += 1;
     tls_io_stat.write_bytes += bytes;
     tls_io_stat.write_time_ns += latency_ns;
+}
+
+void IOProfiler::_add_tls_sync(int64_t latency_ns) {
+    tls_io_stat.sync_ops += 1;
+    tls_io_stat.sync_time_ns += latency_ns;
 }
 
 const char* IOProfiler::tag_to_string(uint32_t tag) {

--- a/be/src/io/io_profiler.h
+++ b/be/src/io/io_profiler.h
@@ -51,6 +51,8 @@ public:
         uint64_t write_ops;
         uint64_t write_bytes;
         uint64_t write_time_ns;
+        uint64_t sync_ops;
+        uint64_t sync_time_ns;
     };
 
     static const char* tag_to_string(uint32_t tag);
@@ -117,6 +119,8 @@ public:
         }
     }
 
+    static inline void add_sync(int64_t latency_ns) { _add_tls_sync(latency_ns); }
+
     static StatusOr<std::vector<std::string>> get_topn_read_stats(size_t n);
     static StatusOr<std::vector<std::string>> get_topn_write_stats(size_t n);
     static StatusOr<std::vector<std::string>> get_topn_total_stats(size_t n);
@@ -137,6 +141,7 @@ protected:
     // Update thread local io statistics
     static void _add_tls_read(int64_t bytes, int64_t latency_ns);
     static void _add_tls_write(int64_t bytes, int64_t latency_ns);
+    static void _add_tls_sync(int64_t latency_ns);
 
     // Update io statistics associated with a context, such as tag + tablet_id
     static void _add_context_read(int64_t bytes);

--- a/be/src/storage/delta_writer.cpp
+++ b/be/src/storage/delta_writer.cpp
@@ -436,10 +436,11 @@ Status DeltaWriter::write_segment(const SegmentPB& segment_pb, butil::IOBuf& dat
     auto io_stat = scope.current_scoped_tls_io();
     StarRocksMetrics::instance()->segment_flush_total.increment(1);
     StarRocksMetrics::instance()->segment_flush_duration_us.increment(duration_ns / 1000);
-    StarRocksMetrics::instance()->segment_flush_io_time_us.increment(io_stat.write_time_ns / 1000);
+    auto io_time_us = (io_stat.write_time_ns + io_stat.sync_time_ns) / 1000;
+    StarRocksMetrics::instance()->segment_flush_io_time_us.increment(io_time_us);
     StarRocksMetrics::instance()->segment_flush_bytes_total.increment(segment_pb.data_size());
     VLOG(1) << "Flush segment tablet " << _opt.tablet_id << " segment: " << segment_pb.DebugString()
-            << ", duration: " << duration_ns / 1000 << "us, io time: " << io_stat.write_time_ns / 1000 << "us";
+            << ", duration: " << duration_ns / 1000 << "us, io_time: " << io_time_us << "us";
     return Status::OK();
 }
 

--- a/be/src/storage/memtable.cpp
+++ b/be/src/storage/memtable.cpp
@@ -342,12 +342,13 @@ Status MemTable::flush(SegmentPB* seg_info) {
     auto io_stat = scope.current_scoped_tls_io();
     StarRocksMetrics::instance()->memtable_flush_total.increment(1);
     StarRocksMetrics::instance()->memtable_flush_duration_us.increment(duration_ns / 1000);
-    StarRocksMetrics::instance()->memtable_flush_io_time_us.increment(io_stat.write_time_ns / 1000);
+    auto io_time_us = (io_stat.write_time_ns + io_stat.sync_time_ns) / 1000;
+    StarRocksMetrics::instance()->memtable_flush_io_time_us.increment(io_time_us);
     auto flush_bytes = memory_usage();
     StarRocksMetrics::instance()->memtable_flush_memory_bytes_total.increment(flush_bytes);
     StarRocksMetrics::instance()->memtable_flush_disk_bytes_total.increment(io_stat.write_bytes);
     VLOG(1) << "memtable of tablet " << _tablet_id << " flush duration: " << duration_ns / 1000 << "us, "
-            << "io time: " << io_stat.write_time_ns / 1000 << "us, memory bytes: " << flush_bytes
+            << "io time: " << io_time_us << "us, memory bytes: " << flush_bytes
             << ", disk bytes: " << io_stat.write_bytes;
     return Status::OK();
 }

--- a/be/test/io/io_profiler_test.cpp
+++ b/be/test/io/io_profiler_test.cpp
@@ -30,13 +30,19 @@ namespace starrocks {
     stat.write_bytes += bytes;                  \
     stat.write_time_ns += time_ns
 
-#define ASSERT_IO_STAT_EQ(expect, actual)                \
-    ASSERT_EQ(expect.read_ops, actual.read_ops);         \
-    ASSERT_EQ(expect.read_bytes, actual.read_bytes);     \
-    ASSERT_EQ(expect.read_time_ns, actual.read_time_ns); \
-    ASSERT_EQ(expect.write_ops, actual.write_ops);       \
-    ASSERT_EQ(expect.write_bytes, actual.write_bytes);   \
-    ASSERT_EQ(expect.write_time_ns, actual.write_time_ns)
+#define ADD_SYNC_IO_STAT(stat, time_ns) \
+    stat.sync_ops += 1;                 \
+    stat.sync_time_ns += time_ns
+
+#define ASSERT_IO_STAT_EQ(expect, actual)                  \
+    ASSERT_EQ(expect.read_ops, actual.read_ops);           \
+    ASSERT_EQ(expect.read_bytes, actual.read_bytes);       \
+    ASSERT_EQ(expect.read_time_ns, actual.read_time_ns);   \
+    ASSERT_EQ(expect.write_ops, actual.write_ops);         \
+    ASSERT_EQ(expect.write_bytes, actual.write_bytes);     \
+    ASSERT_EQ(expect.write_time_ns, actual.write_time_ns); \
+    ASSERT_EQ(expect.sync_ops, actual.sync_ops);           \
+    ASSERT_EQ(expect.sync_time_ns, actual.sync_time_ns)
 
 TEST(IOProfilerTest, test_tls_io) {
     auto scope = IOProfiler::scope(IOProfiler::TAG_LOAD, 1);
@@ -62,6 +68,11 @@ TEST(IOProfilerTest, test_tls_io) {
     ADD_READ_IO_STAT(expect, 1048576, 1000000);
     auto actual4 = scope.current_scoped_tls_io();
     ASSERT_IO_STAT_EQ(expect, actual4);
+
+    IOProfiler::add_sync(9883);
+    ADD_SYNC_IO_STAT(expect, 9883);
+    auto actual5 = scope.current_scoped_tls_io();
+    ASSERT_IO_STAT_EQ(expect, actual5);
 }
 
 TEST(IOProfilerTest, test_context_io) {


### PR DESCRIPTION
## Why I'm doing:
fs sync can also take much time, and IO profiler should consider it

## What I'm doing:
add fs sync time to IO profiler

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [X] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
