### PR TITLE
[BugFix] be will occur endless loop if  return empty when filter pred…

### DIFF
--- a/be/src/exec/short_circuit_hybrid.cpp
+++ b/be/src/exec/short_circuit_hybrid.cpp
@@ -106,6 +106,9 @@ Status ShortCircuitHybridScanNode::get_next(RuntimeState* state, ChunkPtr* chunk
             }
         }
         RETURN_IF_ERROR(ExecNode::eval_conjuncts(_conjunct_ctxs, result_chunk.get()));
+        if (result_chunk->num_rows() == 0) {
+            *eos = true;
+        }
     } else {
         *eos = true;
     }

--- a/test/sql/test_column_with_row/R/test_column_with_row_variable
+++ b/test/sql/test_column_with_row/R/test_column_with_row_variable
@@ -47,6 +47,9 @@ select * from t1_var where k1 = 3 and k2 = 3;
 -- result:
 3	3	e2222222	e2222222	2222-12-22	100
 -- !result
+select k1, k2, v3, v4 from t1_var where k1 = 3 and k2 = 3 and v1 = 'a2222222';
+-- result:
+-- !result
 set enable_short_circuit = false;
 -- result:
 []

--- a/test/sql/test_column_with_row/T/test_column_with_row_variable
+++ b/test/sql/test_column_with_row/T/test_column_with_row_variable
@@ -30,6 +30,7 @@ INSERT INTO t1_var(k1, k2, v1, v2, v3, v4) VALUES
 set enable_short_circuit = true;
 select length(v1), v1, v2, v3, v4 from t1_var where k1 = 3 and k2 = 3;
 select * from t1_var where k1 = 3 and k2 = 3;
+select k1, k2, v3, v4 from t1_var where k1 = 3 and k2 = 3 and v1 = 'a2222222';
 set enable_short_circuit = false;
 --清空
 TRUNCATE TABLE t1_var;


### PR DESCRIPTION
be will occur endless loop if  return empty when filter predicate pushed in shortcircuit scan node

## Why I'm doing:

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
