### PR TITLE
[Enhancement] Add some LoadChannel/AsyncDeltaWriter/DeltaWriter metrics

### DIFF
--- a/be/src/runtime/load_channel.cpp
+++ b/be/src/runtime/load_channel.cpp
@@ -45,6 +45,7 @@
 #include "util/compression/block_compression.h"
 #include "util/faststring.h"
 #include "util/lru_cache.h"
+#include "util/starrocks_metrics.h"
 
 #define RETURN_RESPONSE_IF_ERROR(stmt, response)                                      \
     do {                                                                              \
@@ -158,6 +159,8 @@ void LoadChannel::add_chunks(const PTabletWriterAddChunksRequest& req, PTabletWr
         response->mutable_status()->add_error_msgs("server not support repeated chunk");
         return;
     }
+    MonotonicStopWatch watch;
+    watch.start();
     faststring uncompressed_buffer;
     std::unique_ptr<Chunk> chunk;
     for (int i = 0; i < req.requests_size(); i++) {
@@ -181,6 +184,8 @@ void LoadChannel::add_chunks(const PTabletWriterAddChunksRequest& req, PTabletWr
             return;
         }
     }
+    StarRocksMetrics::instance()->load_channel_add_chunks_total.increment(1);
+    StarRocksMetrics::instance()->load_channel_add_chunks_duration_us.increment(watch.elapsed_time() / 1000);
 }
 
 void LoadChannel::add_segment(brpc::Controller* cntl, const PTabletWriterAddSegmentRequest* request,

--- a/be/src/storage/async_delta_writer.h
+++ b/be/src/storage/async_delta_writer.h
@@ -112,6 +112,8 @@ private:
     };
 
     struct Task {
+        Task() : create_time_ns(MonotonicNanos()) {}
+
         // If chunk == nullptr, this is a commit task
         Chunk* chunk = nullptr;
         const uint32_t* indexes = nullptr;
@@ -121,6 +123,7 @@ private:
         bool abort = false;
         bool abort_with_log = false;
         bool flush_after_write = false;
+        int64_t create_time_ns;
     };
 
     static int _execute(void* meta, bthread::TaskIterator<AsyncDeltaWriter::Task>& iter);

--- a/be/src/storage/memtable.cpp
+++ b/be/src/storage/memtable.cpp
@@ -316,7 +316,7 @@ Status MemTable::finalize() {
         }
     }
 
-    StarRocksMetrics::instance()->memtable_flush_duration_us.increment(duration_ns / 1000);
+    StarRocksMetrics::instance()->memtable_finalize_duration_us.increment(duration_ns / 1000);
     return Status::OK();
 }
 

--- a/be/src/util/starrocks_metrics.cpp
+++ b/be/src/util/starrocks_metrics.cpp
@@ -54,7 +54,22 @@ StarRocksMetrics::StarRocksMetrics() : _metrics(_s_registry_name) {
     REGISTER_STARROCKS_METRIC(query_scan_bytes);
     REGISTER_STARROCKS_METRIC(query_scan_rows);
 
+    REGISTER_STARROCKS_METRIC(load_channel_add_chunks_total);
+    REGISTER_STARROCKS_METRIC(load_channel_add_chunks_duration_us);
+    REGISTER_STARROCKS_METRIC(load_channel_add_chunks_wait_memtable_duration_us);
+    REGISTER_STARROCKS_METRIC(load_channel_add_chunks_wait_writer_duration_us);
+    REGISTER_STARROCKS_METRIC(load_channel_add_chunks_wait_replica_duration_us);
+
+    REGISTER_STARROCKS_METRIC(async_delta_writer_execute_total);
+    REGISTER_STARROCKS_METRIC(async_delta_writer_task_total);
+    REGISTER_STARROCKS_METRIC(async_delta_writer_task_execute_duration_us);
+    REGISTER_STARROCKS_METRIC(async_delta_writer_task_pending_duration_us);
+
+    REGISTER_STARROCKS_METRIC(delta_writer_wait_flush_duration_us);
+    REGISTER_STARROCKS_METRIC(delta_writer_wait_replica_duration_us);
+
     REGISTER_STARROCKS_METRIC(memtable_flush_total);
+    REGISTER_STARROCKS_METRIC(memtable_finalize_duration_us);
     REGISTER_STARROCKS_METRIC(memtable_flush_duration_us);
     REGISTER_STARROCKS_METRIC(memtable_flush_io_time_us);
     REGISTER_STARROCKS_METRIC(memtable_flush_memory_bytes_total);

--- a/be/src/util/starrocks_metrics.h
+++ b/be/src/util/starrocks_metrics.h
@@ -195,7 +195,39 @@ public:
     METRIC_DEFINE_INT_COUNTER(load_rows_total, MetricUnit::ROWS);
     METRIC_DEFINE_INT_COUNTER(load_bytes_total, MetricUnit::BYTES);
 
+    // Metrics for LoadChannel
+    // The number that LoadChannel#add_chunks is accessed
+    METRIC_DEFINE_INT_COUNTER(load_channel_add_chunks_total, MetricUnit::OPERATIONS);
+    // Accumulated time that LoadChannel#add_chunks costs. The time can be divided into
+    // waiting memtable, waiting async delta writer, waiting replicas, and others.
+    METRIC_DEFINE_INT_COUNTER(load_channel_add_chunks_duration_us, MetricUnit::MICROSECONDS);
+    // Accumulated time that waiting memtable costs in LoadChannel#add_chunks
+    METRIC_DEFINE_INT_COUNTER(load_channel_add_chunks_wait_memtable_duration_us, MetricUnit::MICROSECONDS);
+    // Accumulated time that waiting async delta writer costs in LoadChannel#add_chunks
+    METRIC_DEFINE_INT_COUNTER(load_channel_add_chunks_wait_writer_duration_us, MetricUnit::MICROSECONDS);
+    // Accumulated time that waiting replicas costs in LoadChannel#add_chunks
+    METRIC_DEFINE_INT_COUNTER(load_channel_add_chunks_wait_replica_duration_us, MetricUnit::MICROSECONDS);
+
+    // Metrics for async delta writer
+    // The number of AsyncDeltaWriter::_execute is accessed. Each execution may run multiple tasks
+    METRIC_DEFINE_INT_COUNTER(async_delta_writer_execute_total, MetricUnit::OPERATIONS);
+    // The number of task that executed
+    METRIC_DEFINE_INT_COUNTER(async_delta_writer_task_total, MetricUnit::OPERATIONS);
+    // Accumulated time that task execution costs
+    METRIC_DEFINE_INT_COUNTER(async_delta_writer_task_execute_duration_us, MetricUnit::MICROSECONDS);
+    // Accumulated time that task pends in the queue
+    METRIC_DEFINE_INT_COUNTER(async_delta_writer_task_pending_duration_us, MetricUnit::MICROSECONDS);
+
+    // Metrics for delta writer
+    // Accumulated time that delta writer waits for memtable flush. It's part of
+    // async_delta_writer_task_execute_duration_us
+    METRIC_DEFINE_INT_COUNTER(delta_writer_wait_flush_duration_us, MetricUnit::MICROSECONDS);
+    // Accumulated time that delta writer waits for secondary replicas sync. It's part of
+    // async_delta_writer_task_execute_duration_us
+    METRIC_DEFINE_INT_COUNTER(delta_writer_wait_replica_duration_us, MetricUnit::MICROSECONDS);
+
     METRIC_DEFINE_INT_COUNTER(memtable_flush_total, MetricUnit::OPERATIONS);
+    METRIC_DEFINE_INT_COUNTER(memtable_finalize_duration_us, MetricUnit::MICROSECONDS);
     METRIC_DEFINE_INT_COUNTER(memtable_flush_duration_us, MetricUnit::MICROSECONDS);
     METRIC_DEFINE_INT_COUNTER(memtable_flush_io_time_us, MetricUnit::MICROSECONDS);
     // total memory size of memtables

--- a/be/test/util/starrocks_metrics_test.cpp
+++ b/be/test/util/starrocks_metrics_test.cpp
@@ -327,6 +327,18 @@ TEST_F(StarRocksMetricsTest, test_metrics_register) {
     assert_threadpool_metrics_register("segment_flush", instance);
     assert_threadpool_metrics_register("update_apply", instance);
     assert_threadpool_metrics_register("pk_index_compaction", instance);
+    ASSERT_NE(nullptr, instance->get_metric("load_channel_add_chunks_total"));
+    ASSERT_NE(nullptr, instance->get_metric("load_channel_add_chunks_duration_us"));
+    ASSERT_NE(nullptr, instance->get_metric("load_channel_add_chunks_wait_memtable_duration_us"));
+    ASSERT_NE(nullptr, instance->get_metric("load_channel_add_chunks_wait_writer_duration_us"));
+    ASSERT_NE(nullptr, instance->get_metric("load_channel_add_chunks_wait_replica_duration_us"));
+    ASSERT_NE(nullptr, instance->get_metric("async_delta_writer_execute_total"));
+    ASSERT_NE(nullptr, instance->get_metric("async_delta_writer_task_total"));
+    ASSERT_NE(nullptr, instance->get_metric("async_delta_writer_task_execute_duration_us"));
+    ASSERT_NE(nullptr, instance->get_metric("async_delta_writer_task_pending_duration_us"));
+    ASSERT_NE(nullptr, instance->get_metric("delta_writer_wait_flush_duration_us"));
+    ASSERT_NE(nullptr, instance->get_metric("delta_writer_wait_replica_duration_us"));
+    ASSERT_NE(nullptr, instance->get_metric("memtable_finalize_duration_us"));
 }
 
 } // namespace starrocks


### PR DESCRIPTION
## Why I'm doing:
Add some metrics to enhance the observability of load

## What I'm doing:
* To analyze why the brpc `tablet_writer_add_chunks` is slow, add following metrics 

|  name  | description  |
|  ----  | ----  |
| load_channel_add_chunks_total  | The number that LoadChannel#add_chunks is accessed |
| load_channel_add_chunks_duration_us  | Accumulated time that LoadChannel#add_chunks costs. The time can be divided into waiting memtable, waiting async delta writer, waiting replicas, and others|
| load_channel_add_chunks_wait_memtable_duration_us | Accumulated time that waiting memtable costs in LoadChannel#add_chunks |
| load_channel_add_chunks_wait_writer_duration_us | Accumulated time that waiting async delta writer tasks costs in LoadChannel#add_chunks |
| load_channel_add_chunks_wait_replica_duration_us | Accumulated time that waiting secondary replicas costs in LoadChannel#add_chunks | 

* To analyze why LoadChannel#add_chunks costs much time to wait for writer, add following metrics

|  name  | description  |
|  ----  | ----  |
| async_delta_writer_execute_total  | The number of AsyncDeltaWriter::_execute is accessed. Each execution will run a batch of tasks |
| async_delta_writer_task_total  | The number of task that executed |
| async_delta_writer_task_execute_duration_us | Accumulated time that task execution costs |
| async_delta_writer_task_pending_duration_us | Accumulated time that task pends in the queue |
| delta_writer_wait_flush_duration_us | Accumulated time that delta writer waits for memtable flush. It's part of async_delta_writer_task_execute_duration_us |
| delta_writer_wait_replica_duration_us | Accumulated time that delta writer waits for secondary replicas sync. It's part of async_delta_writer_task_execute_duration_us  |

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
