### PR TITLE
[Refactor] is_jit_enabled(), opt DIV/mod, clean some log

### DIFF
--- a/be/src/exprs/expr.cpp
+++ b/be/src/exprs/expr.cpp
@@ -255,12 +255,6 @@ Status Expr::create_tree_from_thrift_with_jit(ObjectPool* pool, const std::vecto
         return status;
     }
 
-    // Check if JIT compilation is feasible on this platform.
-    auto* jit_engine = JITEngine::get_instance();
-    if (!jit_engine->support_jit()) {
-        return status;
-    }
-
     bool replaced = false;
     status = (*root_expr)->replace_compilable_exprs(root_expr, pool, replaced);
     if (!status.ok()) {
@@ -788,6 +782,7 @@ Status Expr::replace_compilable_exprs(Expr** expr, ObjectPool* pool, bool& repla
         _node_type == TExprNodeType::DICTIONARY_GET_EXPR || _node_type == TExprNodeType::PLACEHOLDER_EXPR) {
         return Status::OK();
     }
+    DCHECK(JITEngine::get_instance()->support_jit());
     if ((*expr)->should_compile()) {
         // If the current expression is compilable, we will replace it with a JITExpr.
         // This expression and its compilable subexpressions will be compiled into a single function.

--- a/be/src/exprs/jit/ir_helper.cpp
+++ b/be/src/exprs/jit/ir_helper.cpp
@@ -167,4 +167,41 @@ StatusOr<llvm::Value*> IRHelper::cast_to_type(llvm::IRBuilder<>& b, llvm::Value*
     return Status::NotSupported("JIT cast type not supported.");
 }
 
+llvm::Value* IRHelper::build_if_else(llvm::Value* condition, llvm::Type* return_type,
+                                     std::function<llvm::Value*()> then_func, std::function<llvm::Value*()> else_func,
+                                     llvm::IRBuilder<>* builder) {
+    auto* head = builder->GetInsertBlock();
+    DCHECK_NE(head, nullptr);
+
+    // Create blocks for the then, else and merge cases.
+    llvm::BasicBlock* then_bb = llvm::BasicBlock::Create(head->getContext(), "then", head->getParent());
+    llvm::BasicBlock* else_bb = llvm::BasicBlock::Create(head->getContext(), "else", head->getParent());
+    llvm::BasicBlock* merge_bb = llvm::BasicBlock::Create(head->getContext(), "merge", head->getParent());
+
+    builder->CreateCondBr(condition, then_bb, else_bb);
+
+    // Emit the then block.
+    builder->SetInsertPoint(then_bb);
+    auto then_value = then_func();
+    builder->CreateBr(merge_bb);
+
+    // refresh then_bb for phi (could have changed due to code generation of then_value).
+    then_bb = builder->GetInsertBlock();
+
+    // Emit the else block.
+    builder->SetInsertPoint(else_bb);
+    auto else_value = else_func();
+    builder->CreateBr(merge_bb);
+
+    // refresh else_bb for phi (could have changed due to code generation of else_value).
+    else_bb = builder->GetInsertBlock();
+
+    // Emit the merge block.
+    builder->SetInsertPoint(merge_bb);
+    llvm::PHINode* result_value = builder->CreatePHI(return_type, 2, "res_value");
+    result_value->addIncoming(then_value, then_bb);
+    result_value->addIncoming(else_value, else_bb);
+    return result_value;
+}
+
 } // namespace starrocks

--- a/be/src/exprs/jit/ir_helper.cpp
+++ b/be/src/exprs/jit/ir_helper.cpp
@@ -168,8 +168,8 @@ StatusOr<llvm::Value*> IRHelper::cast_to_type(llvm::IRBuilder<>& b, llvm::Value*
 }
 
 llvm::Value* IRHelper::build_if_else(llvm::Value* condition, llvm::Type* return_type,
-                                     std::function<llvm::Value*()> then_func, std::function<llvm::Value*()> else_func,
-                                     llvm::IRBuilder<>* builder) {
+                                     const std::function<llvm::Value*()>& then_func,
+                                     const std::function<llvm::Value*()>& else_func, llvm::IRBuilder<>* builder) {
     auto* head = builder->GetInsertBlock();
     DCHECK_NE(head, nullptr);
 

--- a/be/src/exprs/jit/ir_helper.h
+++ b/be/src/exprs/jit/ir_helper.h
@@ -100,8 +100,8 @@ public:
                                                const LogicalType& to_type);
 
     static llvm::Value* build_if_else(llvm::Value* condition, llvm::Type* return_type,
-                                      std::function<llvm::Value*()> then_func, std::function<llvm::Value*()> else_func,
-                                      llvm::IRBuilder<>* builder);
+                                      const std::function<llvm::Value*()>& then_func,
+                                      const std::function<llvm::Value*()>& else_func, llvm::IRBuilder<>* builder);
 };
 
 } // namespace starrocks

--- a/be/src/exprs/jit/ir_helper.h
+++ b/be/src/exprs/jit/ir_helper.h
@@ -98,6 +98,10 @@ public:
      */
     static StatusOr<llvm::Value*> cast_to_type(llvm::IRBuilder<>& b, llvm::Value* value, const LogicalType& from_type,
                                                const LogicalType& to_type);
+
+    static llvm::Value* build_if_else(llvm::Value* condition, llvm::Type* return_type,
+                                      std::function<llvm::Value*()> then_func, std::function<llvm::Value*()> else_func,
+                                      llvm::IRBuilder<>* builder);
 };
 
 } // namespace starrocks

--- a/be/src/exprs/jit/jit_engine.cpp
+++ b/be/src/exprs/jit/jit_engine.cpp
@@ -141,14 +141,13 @@ Status JITEngine::init() {
         if (mem_limit < JIT_CACHE_LOWEST_LIMIT) {
             _initialized = true;
             _support_jit = false;
-            LOG(WARNING) << "System or Process memory limit is less than 16GB, disable JIT. If force enabling jit, "
-                            "please set jit_lru_cache_size be a proper positive value";
+            LOG(WARNING) << "System or Process memory limit is less than 16GB, disable JIT";
             return Status::OK();
         } else {
             jit_lru_cache_size = std::min<int64_t>((1UL << 30), (int64_t)(mem_limit * 0.01));
         }
     }
-    LOG(INFO) << "JIT is enabled with function LRU cache size = " << jit_lru_cache_size;
+    LOG(INFO) << "JIT LRU cache size = " << jit_lru_cache_size;
     _func_cache = new_lru_cache(jit_lru_cache_size);
 #endif
     DCHECK(_func_cache != nullptr);
@@ -165,8 +164,8 @@ Status JITEngine::init() {
 Status JITEngine::compile_scalar_function(ExprContext* context, JitObjectCache* func_cache, Expr* expr,
                                           const std::vector<Expr*>& uncompilable_exprs) {
     auto* instance = JITEngine::get_instance();
-    if (UNLIKELY(!instance->support_jit())) {
-        return Status::JitCompileError("JIT is not supported");
+    if (UNLIKELY(!instance->initialized())) {
+        return Status::JitCompileError("JIT engine is not initialized");
     }
 
     auto cached = instance->lookup_function(func_cache);
@@ -379,23 +378,41 @@ llvm::Module* JITEngine::Engine::module() const {
     return _module.get();
 }
 
-static void optimize_module(llvm::Module& module) {
-    llvm::legacy::FunctionPassManager fpm(&module);
-    llvm::PassManagerBuilder pass_manager_builder;
-    llvm::legacy::PassManager pass_manager;
-    pass_manager_builder.OptLevel = 3;
-    pass_manager_builder.SLPVectorize = true;
-    pass_manager_builder.LoopVectorize = true;
-    pass_manager_builder.VerifyInput = true;
-    pass_manager_builder.VerifyOutput = true;
-    pass_manager_builder.populateModulePassManager(pass_manager);
-    pass_manager_builder.populateFunctionPassManager(fpm);
+static void optimize_module(llvm::Module& module, llvm::TargetIRAnalysis target_analysis) {
+    // Setup an optimiser pipeline
+    llvm::PassBuilder pass_builder;
+    llvm::LoopAnalysisManager loop_am;
+    llvm::FunctionAnalysisManager function_am;
+    llvm::CGSCCAnalysisManager cgscc_am;
+    llvm::ModuleAnalysisManager module_am;
 
-    fpm.doInitialization();
-    for (auto& function : module) {
-        fpm.run(function);
-    }
-    fpm.doFinalization();
+    function_am.registerPass([&] { return target_analysis; });
+
+    // Register required analysis managers
+    pass_builder.registerModuleAnalyses(module_am);
+    pass_builder.registerCGSCCAnalyses(cgscc_am);
+    pass_builder.registerFunctionAnalyses(function_am);
+    pass_builder.registerLoopAnalyses(loop_am);
+    pass_builder.crossRegisterProxies(loop_am, function_am, cgscc_am, module_am);
+
+    pass_builder.registerPipelineStartEPCallback(
+            [&](llvm::ModulePassManager& module_pm, llvm::OptimizationLevel Level) {
+                module_pm.addPass(llvm::ModuleInlinerPass());
+
+                llvm::FunctionPassManager function_pm;
+                function_pm.addPass(llvm::InstCombinePass());
+                function_pm.addPass(llvm::PromotePass());
+                function_pm.addPass(llvm::GVNPass());
+                function_pm.addPass(llvm::NewGVNPass());
+                function_pm.addPass(llvm::SimplifyCFGPass());
+                function_pm.addPass(llvm::LoopVectorizePass());
+                function_pm.addPass(llvm::SLPVectorizerPass());
+                module_pm.addPass(llvm::createModuleToFunctionPassAdaptor(std::move(function_pm)));
+
+                module_pm.addPass(llvm::GlobalOptPass());
+            });
+
+    pass_builder.buildPerModuleDefaultPipeline(llvm::OptimizationLevel::O3).run(module, module_am);
 }
 
 // Optimise and compile the module.
@@ -405,7 +422,8 @@ Status JITEngine::Engine::optimize_and_finalize_module() {
     if (llvm::verifyModule(*_module, &errs)) {
         return Status::JitCompileError(fmt::format("Failed to generate scalar function IR, errors: {}", errs.str()));
     }
-    optimize_module(*_module);
+    auto target_analysis = _target_machine->getTargetIRAnalysis();
+    optimize_module(*_module, std::move(target_analysis));
 
     if (llvm::verifyModule(*_module, &errs)) {
         return Status::JitCompileError(fmt::format("Failed to optimize scalar function IR, errors: {}", errs.str()));

--- a/be/src/exprs/jit/jit_expr.cpp
+++ b/be/src/exprs/jit/jit_expr.cpp
@@ -69,7 +69,7 @@ Status JITExpr::prepare_impl(RuntimeState* state, ExprContext* context) {
 
         // Compile the expression into native code and retrieve the function pointer.
         auto* jit_engine = JITEngine::get_instance();
-        if (!jit_engine->initialized()) {
+        if (!jit_engine->support_jit()) {
             return Status::JitCompileError("JIT is not supported");
         }
         auto expr_name = _expr->jit_func_name();

--- a/be/src/exprs/jit/jit_expr.cpp
+++ b/be/src/exprs/jit/jit_expr.cpp
@@ -82,7 +82,7 @@ Status JITExpr::prepare_impl(RuntimeState* state, ExprContext* context) {
             LOG(INFO) << "JIT: JIT compile failed, time cost: " << elapsed / 1000000.0 << " ms"
                       << " Reason: " << st;
         } else {
-            LOG(INFO) << "JIT: JIT compile success, time cost: " << elapsed / 1000000.0 << " ms";
+            VLOG_QUERY << "JIT: JIT compile success, time cost: " << elapsed / 1000000.0 << " ms";
             _jit_function = _jit_obj_cache->get_func();
             if (_jit_function == nullptr) {
                 return Status::RuntimeError("JIT func must be not null");
@@ -132,9 +132,9 @@ StatusOr<ColumnPtr> JITExpr::evaluate_checked(starrocks::ExprContext* context, C
         auto child = _children[i];
         if (UNLIKELY((column->is_constant() ^ child->is_constant()) ||
                      (column->is_nullable() ^ child->is_nullable()))) {
-            LOG(INFO) << "[JIT INPUT] expr const = " << child->is_constant() << " null= " << child->is_nullable()
-                      << " but col const = " << column->is_constant() << " null = " << column->is_nullable()
-                      << " expr= " << child->debug_string() << " col= " << column->get_name();
+            VLOG_QUERY << "[JIT INPUT] expr const = " << child->is_constant() << " null= " << child->is_nullable()
+                       << " but col const = " << column->is_constant() << " null = " << column->is_nullable()
+                       << " expr= " << child->debug_string() << " col= " << column->get_name();
         }
 
         if (column->is_constant()) {

--- a/be/src/runtime/runtime_state.cpp
+++ b/be/src/runtime/runtime_state.cpp
@@ -46,6 +46,7 @@
 #include "common/status.h"
 #include "exec/exec_node.h"
 #include "exec/pipeline/query_context.h"
+#include "exprs/jit/jit_engine.h"
 #include "fs/fs_util.h"
 #include "runtime/datetime_value.h"
 #include "runtime/descriptors.h"
@@ -509,6 +510,10 @@ Status RuntimeState::reset_epoch() {
     _tablet_commit_infos.clear();
     _tablet_fail_infos.clear();
     return Status::OK();
+}
+
+bool RuntimeState::is_jit_enabled() const {
+    return _query_options.__isset.enable_jit && _query_options.enable_jit && JITEngine::get_instance()->support_jit();
 }
 
 } // end namespace starrocks

--- a/be/src/runtime/runtime_state.h
+++ b/be/src/runtime/runtime_state.h
@@ -434,7 +434,8 @@ public:
                _query_options.enable_collect_table_level_scan_stats;
     }
 
-    bool is_jit_enabled() const { return _query_options.__isset.enable_jit && _query_options.enable_jit; }
+    bool is_jit_enabled() const;
+
     bool enable_wait_dependent_event() const {
         return _query_options.__isset.enable_wait_dependent_event && _query_options.enable_wait_dependent_event;
     }


### PR DESCRIPTION
## Why I'm doing:

1. jit is not supported when physical mem < 16GB by default. In such case, we should check jit_is_supported when checking is_jit_enabled.
2. DIV/mod is lower than scalar code.
3. avoid printing some useless logs.

## What I'm doing:

1. let `is_jit_support` check jit is supported
2. opt DIV/mod by replace `b.CreateSelect()` with jit branch, reducing about 100ms
3. clean some code
4. use new LLVM pass to get optimal performance

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [x] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
