### PR TITLE
[BugFix] tolerant trailing slash after bucket name in storage volume location

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/storagevolume/StorageVolume.java
+++ b/fe/fe-core/src/main/java/com/starrocks/storagevolume/StorageVolume.java
@@ -120,7 +120,7 @@ public class StorageVolume implements Writable, GsonPostProcessable {
             if (enablePartitionedPrefix) {
                 for (String location : locations) {
                     URI uri = URI.create(location);
-                    if (!uri.getPath().isEmpty()) {
+                    if (!uri.getPath().isEmpty() && !"/".equals(uri.getPath())) {
                         throw new DdlException(String.format(
                                 "Storage volume '%s' has '%s'='true', the location '%s'" +
                                         " should not contain sub path after bucket name!",


### PR DESCRIPTION
* don't report error if there is just a trailing slash after bucket name

## Why I'm doing:

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
