### PR TITLE
[BugFix] create table with local persistent index by mistake when CN doesn't have local disk

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/server/OlapTableFactory.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/OlapTableFactory.java
@@ -330,7 +330,7 @@ public class OlapTableFactory implements AbstractTableFactory {
                                 "when ComputeNode without storage_path, nodeId:" + cnUnSetStoragePath);
                     } else {
                         // if user has not requested persistent index, switch it to false
-                        table.setEnablePersistentIndex(false);
+                        enablePersistentIndex = false;
                     }
                 } else {
                     try {

--- a/fe/fe-core/src/main/java/com/starrocks/server/OlapTableFactory.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/OlapTableFactory.java
@@ -62,6 +62,7 @@ import com.starrocks.sql.ast.PartitionDesc;
 import com.starrocks.sql.ast.RangePartitionDesc;
 import com.starrocks.sql.ast.SingleRangePartitionDesc;
 import com.starrocks.thrift.TCompressionType;
+import com.starrocks.thrift.TPersistentIndexType;
 import com.starrocks.thrift.TStorageType;
 import com.starrocks.thrift.TTabletType;
 import org.apache.commons.lang3.StringUtils;
@@ -317,6 +318,12 @@ public class OlapTableFactory implements AbstractTableFactory {
             boolean enablePersistentIndex = analyzeRet.first;
             boolean enablePersistentIndexByUser = analyzeRet.second;
             if (enablePersistentIndex && table.isCloudNativeTable()) {
+                TPersistentIndexType persistentIndexType;
+                try {
+                    persistentIndexType = PropertyAnalyzer.analyzePersistentIndexType(properties);
+                } catch (AnalysisException e) {
+                    throw new DdlException(e.getMessage());
+                }
                 // Judge there are whether compute nodes without storagePath or not.
                 // Cannot create cloud native table with persistent_index = true when ComputeNode without storagePath
                 Set<Long> cnUnSetStoragePath =
@@ -324,22 +331,19 @@ public class OlapTableFactory implements AbstractTableFactory {
                                 stream()
                                 .filter(id -> !GlobalStateMgr.getCurrentState().getNodeMgr().getClusterInfo().getComputeNode(id).
                                         isSetStoragePath()).collect(Collectors.toSet());
-                if (cnUnSetStoragePath.size() != 0) {
+                if (cnUnSetStoragePath.size() != 0 && persistentIndexType == TPersistentIndexType.LOCAL) {
+                    // Check CN storage path when using local persistent index
                     if (enablePersistentIndexByUser) {
-                        throw new DdlException("Cannot create cloud native table with persistent_index = true " +
+                        throw new DdlException("Cannot create cloud native table with local persistent index" +
                                 "when ComputeNode without storage_path, nodeId:" + cnUnSetStoragePath);
                     } else {
                         // if user has not requested persistent index, switch it to false
                         enablePersistentIndex = false;
                     }
-                } else {
-                    try {
-                        table.setPersistentIndexType(PropertyAnalyzer.analyzePersistentIndexType(properties));
-                    } catch (AnalysisException e) {
-                        throw new DdlException(e.getMessage());
-                    }
                 }
-
+                if (enablePersistentIndex) {
+                    table.setPersistentIndexType(persistentIndexType);
+                }
             }
             table.setEnablePersistentIndex(enablePersistentIndex);
 

--- a/fe/fe-core/src/main/java/com/starrocks/system/ComputeNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/system/ComputeNode.java
@@ -175,6 +175,11 @@ public class ComputeNode implements IComputable, Writable {
         return isSetStoragePath;
     }
 
+    // for test only
+    public void setIsStoragePath(boolean isSetStoragePath) {
+        this.isSetStoragePath = isSetStoragePath;
+    }
+
     public long getId() {
         return id;
     }


### PR DESCRIPTION
## Why I'm doing:
In cloud native SR cluster, there are some CN doesn't have local disk, we don't allow it to use local persistent index, need to set `enable_persistent_index` to false.
But current code have bug that will allow user create table with local persistent index on above scenario., because :
```
if (enablePersistentIndex && table.isCloudNativeTable()) {
         ....
    if (cnUnSetStoragePath.size() != 0) {
       if (enablePersistentIndexByUser) {
           throw new DdlException("Cannot create cloud native table with persistent_index = true " +
                      "when ComputeNode without storage_path, nodeId:" + cnUnSetStoragePath);
       } else {
            // if user has not requested persistent index, switch it to false
            // ===== >>>> set it false here.
            table.setEnablePersistentIndex(false);
        }
     } else {
                    ...
     }
}
// ===== >>>> But it will be cover here.
table.setEnablePersistentIndex(enablePersistentIndex);
```

It will lead to BE publish failed:
```
load LakePrimaryIndex error: Internal error: lake_persistent_index_type of LOCAL will not take effect when as cn without any storage path
```

## What I'm doing:
1. Disable persistent index when we only have local persistent index and CN doesn't have local disk.
2. When using cloud native persistent index, we will not make the local disk check.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [x] 3.1
  - [ ] 3.0
  - [ ] 2.5
