### PR TITLE
[Feature] Add a second version implementation of get table schema and partition API.

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/DistributionInfo.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/DistributionInfo.java
@@ -67,6 +67,10 @@ public abstract class DistributionInfo implements Writable {
         this.typeStr = this.type.name();
     }
 
+    public String getTypeStr() {
+        return typeStr;
+    }
+
     public DistributionInfoType getType() {
         return type;
     }

--- a/fe/fe-core/src/main/java/com/starrocks/http/HttpServer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/http/HttpServer.java
@@ -91,6 +91,7 @@ import com.starrocks.http.rest.TableRowCountAction;
 import com.starrocks.http.rest.TableSchemaAction;
 import com.starrocks.http.rest.TransactionLoadAction;
 import com.starrocks.http.rest.TriggerAction;
+import com.starrocks.http.rest.v2.TablePartitionAction;
 import com.starrocks.leader.MetaHelper;
 import com.starrocks.metric.GaugeMetric;
 import com.starrocks.metric.GaugeMetricImpl;
@@ -213,6 +214,8 @@ public class HttpServer {
         // external usage
         TableRowCountAction.registerAction(controller);
         TableSchemaAction.registerAction(controller);
+        com.starrocks.http.rest.v2.TableSchemaAction.registerAction(controller);
+        TablePartitionAction.registerAction(controller);
         TableQueryPlanAction.registerAction(controller);
 
         BootstrapFinishAction.registerAction(controller);

--- a/fe/fe-core/src/main/java/com/starrocks/http/rest/RestBaseAction.java
+++ b/fe/fe-core/src/main/java/com/starrocks/http/rest/RestBaseAction.java
@@ -40,6 +40,7 @@ import com.google.common.base.Strings;
 import com.starrocks.common.DdlException;
 import com.starrocks.common.ErrorCode;
 import com.starrocks.common.Pair;
+import com.starrocks.common.StarRocksHttpException;
 import com.starrocks.common.util.UUIDUtil;
 import com.starrocks.http.ActionController;
 import com.starrocks.http.BaseAction;
@@ -54,22 +55,33 @@ import com.starrocks.sql.ast.UserIdentity;
 import com.starrocks.thrift.TNetworkAddress;
 import io.netty.handler.codec.http.HttpHeaderNames;
 import io.netty.handler.codec.http.HttpResponseStatus;
+import org.apache.commons.lang3.math.NumberUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.List;
+import java.util.Optional;
+import java.util.function.Function;
 
 public class RestBaseAction extends BaseAction {
-    protected static final String CATALOG_KEY = "catalog";
 
+    private static final Logger LOG = LogManager.getLogger(RestBaseAction.class);
+
+    protected static final String CATALOG_KEY = "catalog";
     protected static final String DB_KEY = "db";
     protected static final String TABLE_KEY = "table";
     protected static final String LABEL_KEY = "label";
     protected static final String WAREHOUSE_KEY = "warehouse";
-    private static final Logger LOG = LogManager.getLogger(RestBaseAction.class);
 
+    protected static final String PAGE_NUM_KEY = "page_num";
+    protected static final String PAGE_SIZE_KEY = "page_size";
+
+    protected static final int DEFAULT_PAGE_NUM = 0;
+    protected static final int DEFAULT_PAGE_SIZE = 100;
+
+    protected static final String JSON_CONTENT_TYPE = "application/json; charset=UTF-8";
     protected static ObjectMapper mapper = new ObjectMapper();
 
     public RestBaseAction(ActionController controller) {
@@ -145,16 +157,26 @@ public class RestBaseAction extends BaseAction {
     }
 
     public void sendResult(BaseRequest request, BaseResponse response, RestBaseResult result) {
-        response.appendContent(result.toJson());
-        writeResponse(request, response, HttpResponseStatus.OK);
+        sendResult(request, response, HttpResponseStatus.OK, result);
     }
 
     public void sendResult(BaseRequest request, BaseResponse response, HttpResponseStatus status) {
-        writeResponse(request, response, status);
+        sendResult(request, response, status, null);
     }
 
     public void sendResult(BaseRequest request, BaseResponse response) {
-        writeResponse(request, response, HttpResponseStatus.OK);
+        sendResult(request, response, HttpResponseStatus.OK);
+    }
+
+    public void sendResult(BaseRequest request,
+                           BaseResponse response,
+                           HttpResponseStatus status,
+                           RestBaseResult result) {
+        if (null != result) {
+            response.setContentType(JSON_CONTENT_TYPE);
+            response.appendContent(result.toJson());
+        }
+        writeResponse(request, response, status);
     }
 
     public void sendResultByJson(BaseRequest request, BaseResponse response, Object obj) {
@@ -166,7 +188,7 @@ public class RestBaseAction extends BaseAction {
         }
 
         // send result
-        response.setContentType("application/json");
+        response.setContentType(JSON_CONTENT_TYPE);
         response.getContent().append(result);
         sendResult(request, response);
     }
@@ -198,4 +220,72 @@ public class RestBaseAction extends BaseAction {
                 new TNetworkAddress(leaderIpAndPort.first, leaderIpAndPort.second));
         return true;
     }
+
+    /**
+     * Get single parameter value.
+     *
+     * @param request       http request
+     * @param paramName     parameter name
+     * @param typeConverter convert the String parameter value to target type
+     * @return parameter value, or {@code null} if missing
+     */
+    protected static <T> T getSingleParameter(BaseRequest request,
+                                              String paramName,
+                                              Function<String, T> typeConverter) {
+        return getSingleParameterOrDefault(request, paramName, null, typeConverter);
+    }
+
+    /**
+     * Get single parameter value.
+     *
+     * @param request       http request
+     * @param paramName     parameter name
+     * @param typeConverter convert the String parameter value to target type
+     * @return parameter value
+     * @throws StarRocksHttpException if parameter is missing
+     */
+    protected static <T> T getSingleParameterRequired(BaseRequest request,
+                                                      String paramName,
+                                                      Function<String, T> typeConverter) {
+        String value = request.getSingleParameter(paramName);
+        if (null == value) {
+            throw new StarRocksHttpException(
+                    HttpResponseStatus.BAD_REQUEST,
+                    String.format("Missing parameter %s", paramName)
+            );
+        }
+        return typeConverter.apply(value);
+    }
+
+    /**
+     * Get single parameter value.
+     *
+     * @param request       http request
+     * @param paramName     parameter name
+     * @param defaultValue  default parameter value if missing
+     * @param typeConverter convert the String parameter value to target type
+     * @return parameter value, or {@code defaultValue} if missing
+     */
+    protected static <T> T getSingleParameterOrDefault(BaseRequest request,
+                                                       String paramName,
+                                                       T defaultValue,
+                                                       Function<String, T> typeConverter) {
+        String value = request.getSingleParameter(paramName);
+        return Optional.ofNullable(value).map(typeConverter).orElse(defaultValue);
+    }
+
+    protected static int getPageNum(BaseRequest request) {
+        return getSingleParameterOrDefault(request, PAGE_NUM_KEY, DEFAULT_PAGE_NUM, value -> {
+            int pn = NumberUtils.toInt(value, DEFAULT_PAGE_NUM);
+            return pn <= 0 ? DEFAULT_PAGE_NUM : pn;
+        });
+    }
+
+    protected static int getPageSize(BaseRequest request) {
+        return getSingleParameterOrDefault(request, PAGE_SIZE_KEY, DEFAULT_PAGE_SIZE, value -> {
+            int ps = NumberUtils.toInt(value, DEFAULT_PAGE_SIZE);
+            return ps <= 0 ? DEFAULT_PAGE_SIZE : ps;
+        });
+    }
+
 }

--- a/fe/fe-core/src/main/java/com/starrocks/http/rest/RestBaseResult.java
+++ b/fe/fe-core/src/main/java/com/starrocks/http/rest/RestBaseResult.java
@@ -34,10 +34,8 @@
 
 package com.starrocks.http.rest;
 
-import com.google.gson.ExclusionStrategy;
-import com.google.gson.FieldAttributes;
 import com.google.gson.Gson;
-import com.google.gson.GsonBuilder;
+import com.google.gson.annotations.SerializedName;
 
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
@@ -55,10 +53,12 @@ public class RestBaseResult {
     // For compatibility, status still exists in /api/v1, removed in /api/v2 and later version.
     @Legacy
     public ActionStatus status;
+    @SerializedName("code")
     public String code;
     // For compatibility, msg still exists in /api/v1, removed in /api/v2 and later version.
     @Legacy
     public String msg;
+    @SerializedName("message")
     public String message;
 
     public RestBaseResult() {
@@ -85,18 +85,11 @@ public class RestBaseResult {
         return gson.toJson(this);
     }
 
-    public String toJsonString() {
-        Gson gson = new GsonBuilder().setExclusionStrategies(new ExclusionStrategy() {
-            @Override
-            public boolean shouldSkipField(FieldAttributes f) {
-                return f.getAnnotation(Legacy.class) != null;
-            }
+    public String getCode() {
+        return code;
+    }
 
-            @Override
-            public boolean shouldSkipClass(Class<?> clazz) {
-                return false;
-            }
-        }).create();
-        return gson.toJson(this);
+    public String getMessage() {
+        return message;
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/http/rest/v2/RestBaseResultV2.java
+++ b/fe/fe-core/src/main/java/com/starrocks/http/rest/v2/RestBaseResultV2.java
@@ -1,0 +1,149 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.http.rest.v2;
+
+import com.google.gson.ExclusionStrategy;
+import com.google.gson.FieldAttributes;
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.google.gson.annotations.SerializedName;
+import com.starrocks.http.rest.RestBaseResult;
+
+import java.util.List;
+import java.util.Objects;
+
+public class RestBaseResultV2<T> extends RestBaseResult {
+
+    @SerializedName("result")
+    private T result;
+
+    public RestBaseResultV2() {
+    }
+
+    public RestBaseResultV2(String msg) {
+        super(msg);
+    }
+
+    public static <R> RestBaseResultV2<R> ok(R result) {
+        RestBaseResultV2<R> obj = new RestBaseResultV2<>();
+        obj.result = result;
+        return obj;
+    }
+
+    public RestBaseResultV2(T result) {
+        super();
+        this.result = result;
+    }
+
+    public RestBaseResultV2(int code, String message) {
+        this(Objects.toString(code), message);
+    }
+
+    public RestBaseResultV2(String code, String message) {
+        this.code = code;
+        this.message = message;
+    }
+
+    @Override
+    public String toJson() {
+        Gson gson = new GsonBuilder()
+                .setExclusionStrategies(new ExclusionStrategy() {
+                    @Override
+                    public boolean shouldSkipField(FieldAttributes f) {
+                        return f.getAnnotation(Legacy.class) != null;
+                    }
+
+                    @Override
+                    public boolean shouldSkipClass(Class<?> clazz) {
+                        return false;
+                    }
+                }).create();
+        return gson.toJson(this);
+    }
+
+    public T getResult() {
+        return result;
+    }
+
+    /**
+     * Paged result.
+     */
+    public static class PagedResult<T> {
+
+        @SerializedName("pageNum")
+        private Integer pageNum;
+
+        @SerializedName("pageSize")
+        private Integer pageSize;
+
+        /**
+         * Total pages.
+         */
+        @SerializedName("pages")
+        private Integer pages;
+
+        /**
+         * Total elements.
+         */
+        @SerializedName("total")
+        private Integer total;
+
+        @SerializedName("items")
+        private List<T> items;
+
+        public PagedResult() {
+        }
+
+        public Integer getPageNum() {
+            return pageNum;
+        }
+
+        public void setPageNum(Integer pageNum) {
+            this.pageNum = pageNum;
+        }
+
+        public Integer getPageSize() {
+            return pageSize;
+        }
+
+        public void setPageSize(Integer pageSize) {
+            this.pageSize = pageSize;
+        }
+
+        public Integer getPages() {
+            return pages;
+        }
+
+        public void setPages(Integer pages) {
+            this.pages = pages;
+        }
+
+        public Integer getTotal() {
+            return total;
+        }
+
+        public void setTotal(Integer total) {
+            this.total = total;
+        }
+
+        public List<T> getItems() {
+            return items;
+        }
+
+        public void setItems(List<T> items) {
+            this.items = items;
+        }
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/http/rest/v2/TableBaseAction.java
+++ b/fe/fe-core/src/main/java/com/starrocks/http/rest/v2/TableBaseAction.java
@@ -1,0 +1,122 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package com.starrocks.http.rest.v2;
+
+import com.starrocks.catalog.Database;
+import com.starrocks.catalog.OlapTable;
+import com.starrocks.catalog.Table;
+import com.starrocks.common.DdlException;
+import com.starrocks.common.ErrorCode;
+import com.starrocks.common.StarRocksHttpException;
+import com.starrocks.common.util.concurrent.lock.LockType;
+import com.starrocks.common.util.concurrent.lock.Locker;
+import com.starrocks.http.ActionController;
+import com.starrocks.http.BaseRequest;
+import com.starrocks.http.BaseResponse;
+import com.starrocks.http.rest.RestBaseAction;
+import com.starrocks.privilege.AccessDeniedException;
+import com.starrocks.privilege.PrivilegeType;
+import com.starrocks.qe.ConnectContext;
+import com.starrocks.server.GlobalStateMgr;
+import io.netty.handler.codec.http.HttpResponseStatus;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import java.util.Optional;
+import java.util.function.Function;
+
+import static com.starrocks.catalog.InternalCatalog.DEFAULT_INTERNAL_CATALOG_NAME;
+import static com.starrocks.sql.analyzer.Authorizer.checkTableAction;
+
+public abstract class TableBaseAction extends RestBaseAction {
+
+    protected static final Logger LOG = LogManager.getLogger(TableBaseAction.class);
+
+    public TableBaseAction(ActionController controller) {
+        super(controller);
+    }
+
+    @Override
+    protected void executeWithoutPassword(BaseRequest request,
+                                          BaseResponse response) throws DdlException, AccessDeniedException {
+        try {
+            this.doExecuteWithoutPassword(request, response);
+        } catch (StarRocksHttpException e) {
+            HttpResponseStatus status = e.getCode();
+            sendResult(request, response, status, new RestBaseResultV2<>(status.code(), e.getMessage()));
+        } catch (Exception e) {
+            LOG.error("Get table[{}/{}/{}] meta info error.",
+                    request.getSingleParameter(CATALOG_KEY),
+                    request.getSingleParameter(DB_KEY),
+                    request.getSingleParameter(TABLE_KEY),
+                    e);
+            HttpResponseStatus status = HttpResponseStatus.INTERNAL_SERVER_ERROR;
+            sendResult(request, response, status, new RestBaseResultV2<>(status.code(), e.getMessage()));
+        }
+    }
+
+    protected abstract void doExecuteWithoutPassword(
+            BaseRequest request, BaseResponse response) throws AccessDeniedException;
+
+    /**
+     * Get {@link OlapTable} object by name, and apply it with {@code tableFunction}
+     *
+     * @throws AccessDeniedException If the user does not have {@code SELECT} permission on the table.
+     */
+    protected <T> T getAndApplyOlapTable(String catalogName,
+                                         String dbName,
+                                         String tableName,
+                                         Function<OlapTable, T> tableFunction) throws AccessDeniedException {
+        // check privilege for select, otherwise return 401 HTTP status
+        checkTableAction(
+                ConnectContext.get().getCurrentUserIdentity(),
+                ConnectContext.get().getCurrentRoleIds(),
+                catalogName,
+                dbName,
+                tableName,
+                PrivilegeType.SELECT
+        );
+
+        Database db = GlobalStateMgr.getCurrentState().getDb(dbName);
+        if (null == db || !Optional.ofNullable(db.getCatalogName())
+                .orElse(DEFAULT_INTERNAL_CATALOG_NAME).equalsIgnoreCase(catalogName)) {
+            throw new StarRocksHttpException(
+                    HttpResponseStatus.NOT_FOUND, ErrorCode.ERR_BAD_DB_ERROR.formatErrorMsg(dbName)
+            );
+        }
+
+        final Locker locker = new Locker();
+        locker.lockDatabase(db, LockType.READ);
+        try {
+            Table table = db.getTable(tableName);
+            if (null == table) {
+                throw new StarRocksHttpException(
+                        HttpResponseStatus.NOT_FOUND, ErrorCode.ERR_BAD_TABLE_ERROR.formatErrorMsg(tableName)
+                );
+            }
+
+            // just only support OlapTable currently
+            if (!(table instanceof OlapTable)) {
+                throw new StarRocksHttpException(
+                        HttpResponseStatus.FORBIDDEN, ErrorCode.ERR_NOT_OLAP_TABLE.formatErrorMsg(tableName)
+                );
+            }
+
+            return tableFunction.apply((OlapTable) table);
+        } finally {
+            locker.unLockDatabase(db, LockType.READ);
+        }
+    }
+
+}

--- a/fe/fe-core/src/main/java/com/starrocks/http/rest/v2/TablePartitionAction.java
+++ b/fe/fe-core/src/main/java/com/starrocks/http/rest/v2/TablePartitionAction.java
@@ -1,0 +1,95 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.http.rest.v2;
+
+
+import com.starrocks.catalog.Partition;
+import com.starrocks.http.ActionController;
+import com.starrocks.http.BaseRequest;
+import com.starrocks.http.BaseResponse;
+import com.starrocks.http.IllegalArgException;
+import com.starrocks.http.rest.v2.RestBaseResultV2.PagedResult;
+import com.starrocks.http.rest.v2.vo.PartitionInfoView.PartitionView;
+import com.starrocks.privilege.AccessDeniedException;
+import io.netty.handler.codec.http.HttpMethod;
+import org.apache.commons.collections4.CollectionUtils;
+import org.apache.commons.lang3.BooleanUtils;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Comparator;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+import static com.starrocks.catalog.InternalCatalog.DEFAULT_INTERNAL_CATALOG_NAME;
+
+public class TablePartitionAction extends TableBaseAction {
+
+    private static final String TEMPORARY_KEY = "temporary";
+
+    public TablePartitionAction(ActionController controller) {
+        super(controller);
+    }
+
+    public static void registerAction(ActionController controller) throws IllegalArgException {
+        controller.registerHandler(
+                HttpMethod.GET,
+                String.format(
+                        "/api/v2/catalogs/{%s}/databases/{%s}/tables/{%s}/partition", CATALOG_KEY, DB_KEY, TABLE_KEY),
+                new TablePartitionAction(controller));
+    }
+
+    @Override
+    protected void doExecuteWithoutPassword(
+            BaseRequest request, BaseResponse response) throws AccessDeniedException {
+        String catalogName = getSingleParameterOrDefault(
+                request, CATALOG_KEY, DEFAULT_INTERNAL_CATALOG_NAME, Function.identity());
+        String dbName = getSingleParameterRequired(request, DB_KEY, Function.identity());
+        String tableName = getSingleParameterRequired(request, TABLE_KEY, Function.identity());
+        boolean temporary = getSingleParameterOrDefault(request, TEMPORARY_KEY, false, BooleanUtils::toBoolean);
+        int pageNum = getPageNum(request);
+        int pageSize = getPageSize(request);
+
+        PagedResult<PartitionView> pagedResult = this.getAndApplyOlapTable(catalogName, dbName, tableName, olapTable -> {
+            PagedResult<PartitionView> result = new PagedResult<>();
+            result.setPageNum(pageNum);
+            result.setPageSize(pageSize);
+            result.setPages(0);
+            result.setTotal(0);
+            result.setItems(new ArrayList<>(0));
+
+            Collection<Partition> partitions =
+                    temporary ? olapTable.getTempPartitions() : olapTable.getPartitions();
+            if (CollectionUtils.isNotEmpty(partitions)) {
+                int pages = partitions.size() / pageSize;
+                result.setPages(partitions.size() % pageSize == 0 ? pages : (pages + 1));
+                result.setTotal(partitions.size());
+                result.setItems(partitions.stream()
+                        .sorted(Comparator.comparingLong(Partition::getId))
+                        .skip((long) pageNum * pageSize)
+                        .limit(pageSize)
+                        .map(partition ->
+                                PartitionView.createFrom(olapTable.getPartitionInfo(), partition))
+                        .collect(Collectors.toList())
+                );
+            }
+
+            return result;
+        });
+
+        sendResult(request, response, RestBaseResultV2.ok(pagedResult));
+    }
+
+}

--- a/fe/fe-core/src/main/java/com/starrocks/http/rest/v2/TableSchemaAction.java
+++ b/fe/fe-core/src/main/java/com/starrocks/http/rest/v2/TableSchemaAction.java
@@ -1,0 +1,56 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.http.rest.v2;
+
+import com.starrocks.http.ActionController;
+import com.starrocks.http.BaseRequest;
+import com.starrocks.http.BaseResponse;
+import com.starrocks.http.IllegalArgException;
+import com.starrocks.http.rest.v2.vo.TableSchemaView;
+import com.starrocks.privilege.AccessDeniedException;
+import io.netty.handler.codec.http.HttpMethod;
+
+import java.util.function.Function;
+
+import static com.starrocks.catalog.InternalCatalog.DEFAULT_INTERNAL_CATALOG_NAME;
+
+public class TableSchemaAction extends TableBaseAction {
+
+    public TableSchemaAction(ActionController controller) {
+        super(controller);
+    }
+
+    public static void registerAction(ActionController controller) throws IllegalArgException {
+        controller.registerHandler(
+                HttpMethod.GET,
+                String.format(
+                        "/api/v2/catalogs/{%s}/databases/{%s}/tables/{%s}/schema", CATALOG_KEY, DB_KEY, TABLE_KEY),
+                new TableSchemaAction(controller));
+    }
+
+    @Override
+    protected void doExecuteWithoutPassword(
+            BaseRequest request, BaseResponse response) throws AccessDeniedException {
+        String catalogName = getSingleParameterOrDefault(
+                request, CATALOG_KEY, DEFAULT_INTERNAL_CATALOG_NAME, Function.identity());
+        String dbName = getSingleParameterRequired(request, DB_KEY, Function.identity());
+        String tableName = getSingleParameterRequired(request, TABLE_KEY, Function.identity());
+
+        TableSchemaView result = this.getAndApplyOlapTable(
+                catalogName, dbName, tableName, TableSchemaView::createFrom);
+        sendResult(request, response, new RestBaseResultV2<>(result));
+    }
+
+}

--- a/fe/fe-core/src/main/java/com/starrocks/http/rest/v2/vo/ColumnView.java
+++ b/fe/fe-core/src/main/java/com/starrocks/http/rest/v2/vo/ColumnView.java
@@ -1,0 +1,230 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.http.rest.v2.vo;
+
+import com.google.gson.annotations.SerializedName;
+import com.starrocks.catalog.Column;
+import com.starrocks.catalog.PrimitiveType;
+import com.starrocks.catalog.ScalarType;
+
+import java.util.Optional;
+
+public class ColumnView {
+
+    @SerializedName("name")
+    private String name;
+
+    @SerializedName("primitiveType")
+    private String primitiveType;
+
+    @SerializedName("primitiveTypeSize")
+    private Integer primitiveTypeSize;
+
+    @SerializedName("columnSize")
+    private Integer columnSize;
+
+    @SerializedName("precision")
+    private Integer precision;
+
+    @SerializedName("scale")
+    private Integer scale;
+
+    @SerializedName("aggregationType")
+    private String aggregationType;
+
+    @SerializedName("isKey")
+    private Boolean key;
+
+    @SerializedName("isAllowNull")
+    private Boolean allowNull;
+
+    @SerializedName("isAutoIncrement")
+    private Boolean autoIncrement;
+
+    @SerializedName("defaultValueType")
+    private String defaultValueType;
+
+    @SerializedName("defaultValue")
+    private String defaultValue;
+
+    @SerializedName("defaultExpr")
+    private String defaultExpr;
+
+    @SerializedName("comment")
+    private String comment;
+
+    @SerializedName("uniqueId")
+    private Integer uniqueId;
+
+    public ColumnView() {
+    }
+
+    /**
+     * Create from {@link Column}
+     */
+    public static ColumnView createFrom(Column column) {
+        ColumnView cvo = new ColumnView();
+        cvo.setName(column.getName());
+
+        Optional.ofNullable(column.getType())
+                .ifPresent(type -> {
+                    PrimitiveType primitiveType = type.getPrimitiveType();
+                    cvo.setPrimitiveType(primitiveType.toString());
+                    cvo.setPrimitiveTypeSize(primitiveType.getTypeSize());
+                    cvo.setColumnSize(type.getColumnSize());
+                    if (type instanceof ScalarType) {
+                        ScalarType scalarType = (ScalarType) type;
+                        cvo.setPrecision(scalarType.getScalarPrecision());
+                        cvo.setScale(scalarType.getScalarScale());
+                    }
+                });
+
+        Optional.ofNullable(column.getAggregationType())
+                .ifPresent(aggType -> cvo.setAggregationType(aggType.toSql()));
+
+        cvo.setKey(column.isKey());
+        cvo.setAllowNull(column.isAllowNull());
+        cvo.setAutoIncrement(column.isAutoIncrement());
+        cvo.setDefaultValueType(column.getDefaultValueType().name());
+        cvo.setDefaultValue(column.getDefaultValue());
+
+        Optional.ofNullable(column.getDefaultExpr())
+                .ifPresent(defaultExpr -> cvo.setDefaultExpr(defaultExpr.getExpr()));
+
+        cvo.setComment(column.getComment());
+        cvo.setUniqueId(column.getUniqueId());
+        return cvo;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String getPrimitiveType() {
+        return primitiveType;
+    }
+
+    public void setPrimitiveType(String primitiveType) {
+        this.primitiveType = primitiveType;
+    }
+
+    public Integer getPrimitiveTypeSize() {
+        return primitiveTypeSize;
+    }
+
+    public void setPrimitiveTypeSize(Integer primitiveTypeSize) {
+        this.primitiveTypeSize = primitiveTypeSize;
+    }
+
+    public Integer getColumnSize() {
+        return columnSize;
+    }
+
+    public void setColumnSize(Integer columnSize) {
+        this.columnSize = columnSize;
+    }
+
+    public Integer getPrecision() {
+        return precision;
+    }
+
+    public void setPrecision(Integer precision) {
+        this.precision = precision;
+    }
+
+    public Integer getScale() {
+        return scale;
+    }
+
+    public void setScale(Integer scale) {
+        this.scale = scale;
+    }
+
+    public String getAggregationType() {
+        return aggregationType;
+    }
+
+    public void setAggregationType(String aggregationType) {
+        this.aggregationType = aggregationType;
+    }
+
+    public Boolean getKey() {
+        return key;
+    }
+
+    public void setKey(Boolean key) {
+        this.key = key;
+    }
+
+    public Boolean getAllowNull() {
+        return allowNull;
+    }
+
+    public void setAllowNull(Boolean allowNull) {
+        this.allowNull = allowNull;
+    }
+
+    public Boolean getAutoIncrement() {
+        return autoIncrement;
+    }
+
+    public void setAutoIncrement(Boolean autoIncrement) {
+        this.autoIncrement = autoIncrement;
+    }
+
+    public String getDefaultValueType() {
+        return defaultValueType;
+    }
+
+    public void setDefaultValueType(String defaultValueType) {
+        this.defaultValueType = defaultValueType;
+    }
+
+    public String getDefaultValue() {
+        return defaultValue;
+    }
+
+    public void setDefaultValue(String defaultValue) {
+        this.defaultValue = defaultValue;
+    }
+
+    public String getDefaultExpr() {
+        return defaultExpr;
+    }
+
+    public void setDefaultExpr(String defaultExpr) {
+        this.defaultExpr = defaultExpr;
+    }
+
+    public String getComment() {
+        return comment;
+    }
+
+    public void setComment(String comment) {
+        this.comment = comment;
+    }
+
+    public Integer getUniqueId() {
+        return uniqueId;
+    }
+
+    public void setUniqueId(Integer uniqueId) {
+        this.uniqueId = uniqueId;
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/http/rest/v2/vo/DistributionInfoView.java
+++ b/fe/fe-core/src/main/java/com/starrocks/http/rest/v2/vo/DistributionInfoView.java
@@ -1,0 +1,89 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.http.rest.v2.vo;
+
+import com.google.gson.annotations.SerializedName;
+import com.starrocks.catalog.DistributionInfo;
+import com.starrocks.catalog.HashDistributionInfo;
+import com.starrocks.catalog.RandomDistributionInfo;
+
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+public class DistributionInfoView {
+
+    @SerializedName("type")
+    private String type;
+
+    @SerializedName("bucketNum")
+    private Integer bucketNum;
+
+    @SerializedName("distributionColumns")
+    private List<ColumnView> distributionColumns;
+
+    public DistributionInfoView() {
+    }
+
+    /**
+     * Create from {@link DistributionInfo}
+     */
+    public static DistributionInfoView createFrom(DistributionInfo distributionInfo) {
+        DistributionInfoView dvo = new DistributionInfoView();
+        Optional.ofNullable(distributionInfo.getType())
+                .map(Enum::name).ifPresent(dvo::setType);
+
+        if (distributionInfo instanceof HashDistributionInfo) {
+            HashDistributionInfo hdi = (HashDistributionInfo) distributionInfo;
+            dvo.setBucketNum(hdi.getBucketNum());
+            Optional.ofNullable(hdi.getDistributionColumns())
+                    .map(columns -> columns.stream()
+                            .filter(Objects::nonNull)
+                            .map(ColumnView::createFrom)
+                            .collect(Collectors.toList()))
+                    .ifPresent(dvo::setDistributionColumns);
+        } else if (distributionInfo instanceof RandomDistributionInfo) {
+            RandomDistributionInfo rdi = (RandomDistributionInfo) distributionInfo;
+            dvo.setBucketNum(rdi.getBucketNum());
+        }
+
+        return dvo;
+    }
+
+    public String getType() {
+        return type;
+    }
+
+    public void setType(String type) {
+        this.type = type;
+    }
+
+    public int getBucketNum() {
+        return bucketNum;
+    }
+
+    public void setBucketNum(int bucketNum) {
+        this.bucketNum = bucketNum;
+    }
+
+    public List<ColumnView> getDistributionColumns() {
+        return distributionColumns;
+    }
+
+    public void setDistributionColumns(List<ColumnView> distributionColumns) {
+        this.distributionColumns = distributionColumns;
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/http/rest/v2/vo/IndexView.java
+++ b/fe/fe-core/src/main/java/com/starrocks/http/rest/v2/vo/IndexView.java
@@ -1,0 +1,111 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.http.rest.v2.vo;
+
+import com.google.gson.annotations.SerializedName;
+import com.starrocks.analysis.IndexDef;
+import com.starrocks.catalog.Index;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+public class IndexView {
+
+    @SerializedName("indexId")
+    private Long indexId;
+
+    @SerializedName("indexName")
+    private String indexName;
+
+    @SerializedName("indexType")
+    private String indexType;
+
+    @SerializedName("columns")
+    private List<String> columns;
+
+    @SerializedName("comment")
+    private String comment;
+
+    @SerializedName("properties")
+    private Map<String, String> properties;
+
+    public IndexView() {
+    }
+
+    /**
+     * Create from {@link Index}
+     */
+    public static IndexView createFrom(Index index) {
+        IndexView ivo = new IndexView();
+        ivo.setIndexId(index.getIndexId());
+        ivo.setIndexName(index.getIndexName());
+        Optional.ofNullable(index.getIndexType())
+                .map(IndexDef.IndexType::getDisplayName)
+                .ifPresent(ivo::setIndexType);
+        ivo.setColumns(index.getColumns());
+        ivo.setComment(index.getComment());
+        ivo.setProperties(index.getProperties());
+        return ivo;
+    }
+
+    public Long getIndexId() {
+        return indexId;
+    }
+
+    public void setIndexId(Long indexId) {
+        this.indexId = indexId;
+    }
+
+    public String getIndexName() {
+        return indexName;
+    }
+
+    public void setIndexName(String indexName) {
+        this.indexName = indexName;
+    }
+
+    public String getIndexType() {
+        return indexType;
+    }
+
+    public void setIndexType(String indexType) {
+        this.indexType = indexType;
+    }
+
+    public List<String> getColumns() {
+        return columns;
+    }
+
+    public void setColumns(List<String> columns) {
+        this.columns = columns;
+    }
+
+    public String getComment() {
+        return comment;
+    }
+
+    public void setComment(String comment) {
+        this.comment = comment;
+    }
+
+    public Map<String, String> getProperties() {
+        return properties;
+    }
+
+    public void setProperties(Map<String, String> properties) {
+        this.properties = properties;
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/http/rest/v2/vo/MaterializedIndexMetaView.java
+++ b/fe/fe-core/src/main/java/com/starrocks/http/rest/v2/vo/MaterializedIndexMetaView.java
@@ -1,0 +1,82 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.http.rest.v2.vo;
+
+import com.google.gson.annotations.SerializedName;
+import com.starrocks.catalog.MaterializedIndexMeta;
+
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+public class MaterializedIndexMetaView {
+
+    @SerializedName("indexId")
+    private Long indexId;
+
+    @SerializedName("keysType")
+    private String keysType;
+
+    @SerializedName("columns")
+    private List<ColumnView> columns;
+
+    public MaterializedIndexMetaView() {
+    }
+
+    /**
+     * Create from {@link MaterializedIndexMeta}
+     */
+    public static MaterializedIndexMetaView createFrom(MaterializedIndexMeta indexMeta) {
+        MaterializedIndexMetaView imvo = new MaterializedIndexMetaView();
+        imvo.setIndexId(indexMeta.getIndexId());
+
+        Optional.ofNullable(indexMeta.getKeysType())
+                .ifPresent(keysType -> imvo.setKeysType(keysType.name()));
+
+        Optional.ofNullable(indexMeta.getSchema())
+                .map(columns -> columns.stream()
+                        .filter(Objects::nonNull)
+                        .map(ColumnView::createFrom)
+                        .collect(Collectors.toList()))
+                .ifPresent(imvo::setColumns);
+
+        return imvo;
+    }
+
+    public Long getIndexId() {
+        return indexId;
+    }
+
+    public void setIndexId(Long indexId) {
+        this.indexId = indexId;
+    }
+
+    public String getKeysType() {
+        return keysType;
+    }
+
+    public void setKeysType(String keysType) {
+        this.keysType = keysType;
+    }
+
+    public List<ColumnView> getColumns() {
+        return columns;
+    }
+
+    public void setColumns(List<ColumnView> columns) {
+        this.columns = columns;
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/http/rest/v2/vo/PartitionInfoView.java
+++ b/fe/fe-core/src/main/java/com/starrocks/http/rest/v2/vo/PartitionInfoView.java
@@ -1,0 +1,298 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.http.rest.v2.vo;
+
+import com.google.gson.annotations.SerializedName;
+import com.staros.client.StarClientException;
+import com.staros.proto.ShardInfo;
+import com.starrocks.catalog.MaterializedIndex;
+import com.starrocks.catalog.Partition;
+import com.starrocks.catalog.PartitionInfo;
+import com.starrocks.catalog.PartitionType;
+import com.starrocks.catalog.RangePartitionInfo;
+import com.starrocks.catalog.Tablet;
+import com.starrocks.lake.LakeTablet;
+import com.starrocks.lake.StarOSAgent;
+import com.starrocks.load.PartitionUtils;
+import com.starrocks.server.GlobalStateMgr;
+import org.apache.commons.collections4.CollectionUtils;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+public class PartitionInfoView {
+
+    @SerializedName("type")
+    private String type;
+
+    @SerializedName("partitionColumns")
+    private List<ColumnView> partitionColumns;
+
+    public PartitionInfoView() {
+    }
+
+    /**
+     * Create from {@link PartitionInfo}
+     */
+    public static PartitionInfoView createFrom(PartitionInfo partitionInfo) {
+        PartitionInfoView pvo = new PartitionInfoView();
+        pvo.setType(partitionInfo.getType().typeString);
+        if (!partitionInfo.isPartitioned()) {
+            return pvo;
+        }
+
+        Optional.ofNullable(partitionInfo.getPartitionColumns())
+                .map(columns -> columns.stream()
+                        .filter(Objects::nonNull)
+                        .map(ColumnView::createFrom)
+                        .collect(Collectors.toList()))
+                .ifPresent(pvo::setPartitionColumns);
+
+        return pvo;
+    }
+
+    public String getType() {
+        return type;
+    }
+
+    public void setType(String type) {
+        this.type = type;
+    }
+
+    public List<ColumnView> getPartitionColumns() {
+        return partitionColumns;
+    }
+
+    public void setPartitionColumns(List<ColumnView> partitionColumns) {
+        this.partitionColumns = partitionColumns;
+    }
+
+    public static class PartitionView {
+
+        @SerializedName("id")
+        private Long id;
+
+        @SerializedName("name")
+        private String name;
+
+        @SerializedName("bucketNum")
+        private Integer bucketNum;
+
+        @SerializedName("distributionType")
+        private String distributionType;
+
+        @SerializedName("visibleVersion")
+        private Long visibleVersion;
+
+        @SerializedName("visibleVersionTime")
+        private Long visibleVersionTime;
+
+        @SerializedName("nextVersion")
+        private Long nextVersion;
+
+        @SerializedName("isMinPartition")
+        private Boolean isMinPartition;
+
+        @SerializedName("isMaxPartition")
+        private Boolean isMaxPartition;
+
+        @SerializedName("startKeys")
+        private List<Object> startKeys;
+
+        @SerializedName("endKeys")
+        private List<Object> endKeys;
+
+        @SerializedName("storagePath")
+        private String storagePath;
+
+        @SerializedName("tablets")
+        private List<TabletView> tablets;
+
+        public PartitionView() {
+        }
+
+        /**
+         * Create from {@link Partition}
+         */
+        public static PartitionView createFrom(PartitionInfo partitionInfo, Partition partition) {
+            PartitionView pvo = new PartitionView();
+            pvo.setId(partition.getId());
+            pvo.setName(partition.getName());
+
+            Optional.ofNullable(partition.getDistributionInfo()).ifPresent(distributionInfo -> {
+                pvo.setBucketNum(distributionInfo.getBucketNum());
+                pvo.setDistributionType(distributionInfo.getTypeStr());
+            });
+
+            pvo.setVisibleVersion(partition.getVisibleVersion());
+            pvo.setVisibleVersionTime(partition.getVisibleVersionTime());
+            pvo.setNextVersion(partition.getNextVersion());
+
+            PartitionType partitionType = partitionInfo.getType();
+            switch (partitionType) {
+                case UNPARTITIONED:
+                    pvo.setMinPartition(true);
+                    pvo.setMaxPartition(true);
+                    pvo.setStartKeys(new ArrayList<>(0));
+                    pvo.setEndKeys(new ArrayList<>(0));
+                    break;
+                case RANGE:
+                    RangePartitionInfo rpi = (RangePartitionInfo) partitionInfo;
+                    PartitionUtils.RangePartitionBoundary boundary =
+                            PartitionUtils.calRangePartitionBoundary(rpi.getRange(partition.getId()));
+                    pvo.setMinPartition(boundary.isMinPartition());
+                    pvo.setMaxPartition(boundary.isMaxPartition());
+                    pvo.setStartKeys(boundary.getStartKeys());
+                    pvo.setEndKeys(boundary.getEndKeys());
+                    break;
+                // LIST/EXPR_RANGE_V2
+                default:
+                    // TODO add more type support in the future
+            }
+
+            List<MaterializedIndex> allIndices = partition.getMaterializedIndices(MaterializedIndex.IndexExtState.ALL);
+            if (CollectionUtils.isNotEmpty(allIndices)) {
+                MaterializedIndex materializedIndex = allIndices.get(0);
+                List<Tablet> tablets = materializedIndex.getTablets();
+                if (CollectionUtils.isNotEmpty(tablets)) {
+                    Optional<LakeTablet> lakeTabletOptional = tablets.stream()
+                            .filter(tablet -> tablet instanceof LakeTablet)
+                            .map(tablet -> (LakeTablet) tablet)
+                            .findFirst();
+                    if (lakeTabletOptional.isPresent()) {
+                        LakeTablet lakeTablet = lakeTabletOptional.get();
+                        try {
+                            ShardInfo shardInfo = GlobalStateMgr.getCurrentState().getStarOSAgent()
+                                    .getShardInfo(lakeTablet.getShardId(), StarOSAgent.DEFAULT_WORKER_GROUP_ID);
+                            pvo.setStoragePath(shardInfo.getFilePath().getFullPath());
+                        } catch (StarClientException e) {
+                            throw new IllegalStateException(e.getMessage(), e);
+                        }
+                    }
+                    pvo.setTablets(tablets.stream().map(TabletView::createFrom).collect(Collectors.toList()));
+                }
+            }
+
+            return pvo;
+        }
+
+        public Long getId() {
+            return id;
+        }
+
+        public void setId(Long id) {
+            this.id = id;
+        }
+
+        public String getName() {
+            return name;
+        }
+
+        public void setName(String name) {
+            this.name = name;
+        }
+
+        public Integer getBucketNum() {
+            return bucketNum;
+        }
+
+        public void setBucketNum(Integer bucketNum) {
+            this.bucketNum = bucketNum;
+        }
+
+        public String getDistributionType() {
+            return distributionType;
+        }
+
+        public void setDistributionType(String distributionType) {
+            this.distributionType = distributionType;
+        }
+
+        public Long getVisibleVersion() {
+            return visibleVersion;
+        }
+
+        public void setVisibleVersion(Long visibleVersion) {
+            this.visibleVersion = visibleVersion;
+        }
+
+        public Long getVisibleVersionTime() {
+            return visibleVersionTime;
+        }
+
+        public void setVisibleVersionTime(Long visibleVersionTime) {
+            this.visibleVersionTime = visibleVersionTime;
+        }
+
+        public Long getNextVersion() {
+            return nextVersion;
+        }
+
+        public void setNextVersion(Long nextVersion) {
+            this.nextVersion = nextVersion;
+        }
+
+        public Boolean getMinPartition() {
+            return isMinPartition;
+        }
+
+        public void setMinPartition(Boolean minPartition) {
+            isMinPartition = minPartition;
+        }
+
+        public Boolean getMaxPartition() {
+            return isMaxPartition;
+        }
+
+        public void setMaxPartition(Boolean maxPartition) {
+            isMaxPartition = maxPartition;
+        }
+
+        public List<Object> getStartKeys() {
+            return startKeys;
+        }
+
+        public void setStartKeys(List<Object> startKeys) {
+            this.startKeys = startKeys;
+        }
+
+        public List<Object> getEndKeys() {
+            return endKeys;
+        }
+
+        public void setEndKeys(List<Object> endKeys) {
+            this.endKeys = endKeys;
+        }
+
+        public String getStoragePath() {
+            return storagePath;
+        }
+
+        public void setStoragePath(String storagePath) {
+            this.storagePath = storagePath;
+        }
+
+        public List<TabletView> getTablets() {
+            return tablets;
+        }
+
+        public void setTablets(List<TabletView> tablets) {
+            this.tablets = tablets;
+        }
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/http/rest/v2/vo/TableSchemaView.java
+++ b/fe/fe-core/src/main/java/com/starrocks/http/rest/v2/vo/TableSchemaView.java
@@ -1,0 +1,263 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.http.rest.v2.vo;
+
+import com.google.gson.annotations.SerializedName;
+import com.starrocks.catalog.MaterializedIndexMeta;
+import com.starrocks.catalog.OlapTable;
+import com.starrocks.catalog.Table.TableType;
+
+import java.util.Comparator;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+public class TableSchemaView {
+
+    @SerializedName("id")
+    private Long id;
+
+    @SerializedName("name")
+    private String name;
+
+    @SerializedName("tableType")
+    private String tableType;
+
+    @SerializedName("keysType")
+    private String keysType;
+
+    @SerializedName("comment")
+    private String comment;
+
+    @SerializedName("createTime")
+    private Long createTime;
+
+    @SerializedName("columns")
+    private List<ColumnView> columns;
+
+    @SerializedName("indexMetas")
+    private List<MaterializedIndexMetaView> indexMetas;
+
+    @SerializedName("partitionInfo")
+    private PartitionInfoView partitionInfo;
+
+    @SerializedName("defaultDistributionInfo")
+    private DistributionInfoView defaultDistributionInfo;
+
+    @SerializedName("colocateGroup")
+    private String colocateGroup;
+
+    @SerializedName("indexes")
+    private List<IndexView> indexes;
+
+    @SerializedName("baseIndexId")
+    private Long baseIndexId;
+
+    @SerializedName("maxIndexId")
+    private Long maxIndexId;
+
+    @SerializedName("maxColUniqueId")
+    private Integer maxColUniqueId;
+
+    @SerializedName("properties")
+    private Map<String, String> properties;
+
+    public TableSchemaView() {
+    }
+
+    /**
+     * Create from {@link OlapTable}
+     */
+    public static TableSchemaView createFrom(OlapTable table) {
+        TableSchemaView svo = new TableSchemaView();
+        svo.setId(table.getId());
+        svo.setName(table.getName());
+        Optional.ofNullable(table.getType())
+                .ifPresent(type -> svo.setTableType(TableType.serialize(type)));
+        Optional.ofNullable(table.getKeysType())
+                .ifPresent(type -> svo.setKeysType(type.name()));
+        svo.setComment(table.getComment());
+        svo.setCreateTime(table.getCreateTime());
+
+        Optional.ofNullable(table.getFullSchema())
+                .map(columns -> columns.stream()
+                        .filter(Objects::nonNull)
+                        .map(ColumnView::createFrom)
+                        .collect(Collectors.toList()))
+                .ifPresent(svo::setColumns);
+
+        Optional.ofNullable(table.getIndexIdToMeta())
+                .map(indexIdToMetas -> indexIdToMetas.values().stream()
+                        .filter(Objects::nonNull)
+                        .sorted(Comparator.comparingLong(MaterializedIndexMeta::getIndexId))
+                        .map(MaterializedIndexMetaView::createFrom)
+                        .collect(Collectors.toList()))
+                .ifPresent(svo::setIndexMetas);
+
+        Optional.ofNullable(table.getPartitionInfo())
+                .ifPresent(pi -> svo.setPartitionInfo(PartitionInfoView.createFrom(pi)));
+
+        Optional.ofNullable(table.getDefaultDistributionInfo())
+                .ifPresent(di -> svo.setDefaultDistributionInfo(DistributionInfoView.createFrom(di)));
+
+        svo.setColocateGroup(table.getColocateGroup());
+
+        Optional.ofNullable(table.getIndexes())
+                .map(indices -> indices.stream()
+                        .filter(Objects::nonNull)
+                        .map(IndexView::createFrom)
+                        .collect(Collectors.toList()))
+                .ifPresent(svo::setIndexes);
+
+        svo.setBaseIndexId(table.getBaseIndexId());
+        svo.setMaxIndexId(table.getMaxIndexId());
+        svo.setMaxColUniqueId(table.getMaxColUniqueId());
+
+        Optional.ofNullable(table.getTableProperty())
+                .ifPresent(prop -> svo.setProperties(prop.getProperties()));
+
+        return svo;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String getTableType() {
+        return tableType;
+    }
+
+    public void setTableType(String tableType) {
+        this.tableType = tableType;
+    }
+
+    public String getKeysType() {
+        return keysType;
+    }
+
+    public void setKeysType(String keysType) {
+        this.keysType = keysType;
+    }
+
+    public String getComment() {
+        return comment;
+    }
+
+    public void setComment(String comment) {
+        this.comment = comment;
+    }
+
+    public Long getCreateTime() {
+        return createTime;
+    }
+
+    public void setCreateTime(Long createTime) {
+        this.createTime = createTime;
+    }
+
+    public List<ColumnView> getColumns() {
+        return columns;
+    }
+
+    public void setColumns(List<ColumnView> columns) {
+        this.columns = columns;
+    }
+
+    public List<MaterializedIndexMetaView> getIndexMetas() {
+        return indexMetas;
+    }
+
+    public void setIndexMetas(List<MaterializedIndexMetaView> indexMetas) {
+        this.indexMetas = indexMetas;
+    }
+
+    public PartitionInfoView getPartitionInfo() {
+        return partitionInfo;
+    }
+
+    public void setPartitionInfo(PartitionInfoView partitionInfo) {
+        this.partitionInfo = partitionInfo;
+    }
+
+    public DistributionInfoView getDefaultDistributionInfo() {
+        return defaultDistributionInfo;
+    }
+
+    public void setDefaultDistributionInfo(DistributionInfoView defaultDistributionInfo) {
+        this.defaultDistributionInfo = defaultDistributionInfo;
+    }
+
+    public String getColocateGroup() {
+        return colocateGroup;
+    }
+
+    public void setColocateGroup(String colocateGroup) {
+        this.colocateGroup = colocateGroup;
+    }
+
+    public List<IndexView> getIndexes() {
+        return indexes;
+    }
+
+    public void setIndexes(List<IndexView> indexes) {
+        this.indexes = indexes;
+    }
+
+    public Long getBaseIndexId() {
+        return baseIndexId;
+    }
+
+    public void setBaseIndexId(Long baseIndexId) {
+        this.baseIndexId = baseIndexId;
+    }
+
+    public Long getMaxIndexId() {
+        return maxIndexId;
+    }
+
+    public void setMaxIndexId(Long maxIndexId) {
+        this.maxIndexId = maxIndexId;
+    }
+
+    public Integer getMaxColUniqueId() {
+        return maxColUniqueId;
+    }
+
+    public void setMaxColUniqueId(Integer maxColUniqueId) {
+        this.maxColUniqueId = maxColUniqueId;
+    }
+
+    public Map<String, String> getProperties() {
+        return properties;
+    }
+
+    public void setProperties(Map<String, String> properties) {
+        this.properties = properties;
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/http/rest/v2/vo/TabletView.java
+++ b/fe/fe-core/src/main/java/com/starrocks/http/rest/v2/vo/TabletView.java
@@ -1,0 +1,80 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.http.rest.v2.vo;
+
+import com.google.gson.annotations.SerializedName;
+import com.starrocks.catalog.Tablet;
+import com.starrocks.lake.LakeTablet;
+import com.starrocks.server.GlobalStateMgr;
+import com.starrocks.server.WarehouseManager;
+
+import java.util.Set;
+
+public class TabletView {
+
+    @SerializedName("id")
+    private Long id;
+
+    @SerializedName("primaryComputeNodeId")
+    private Long primaryComputeNodeId;
+
+    @SerializedName("backendIds")
+    private Set<Long> backendIds;
+
+    public TabletView() {
+    }
+
+    /**
+     * Create from {@link Tablet}
+     */
+    public static TabletView createFrom(Tablet tablet) {
+        TabletView tvo = new TabletView();
+        tvo.setId(tablet.getId());
+        tvo.setBackendIds(tablet.getBackendIds());
+
+        if (tablet instanceof LakeTablet) {
+            LakeTablet lakeTablet = (LakeTablet) tablet;
+            Long computeNodeId = GlobalStateMgr.getCurrentState().getWarehouseMgr()
+                    .getComputeNodeId(WarehouseManager.DEFAULT_WAREHOUSE_ID, lakeTablet);
+            tvo.setPrimaryComputeNodeId(computeNodeId);
+        }
+
+        return tvo;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public Long getPrimaryComputeNodeId() {
+        return primaryComputeNodeId;
+    }
+
+    public void setPrimaryComputeNodeId(Long primaryComputeNodeId) {
+        this.primaryComputeNodeId = primaryComputeNodeId;
+    }
+
+    public Set<Long> getBackendIds() {
+        return backendIds;
+    }
+
+    public void setBackendIds(Set<Long> backendIds) {
+        this.backendIds = backendIds;
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/http/rest/v2/vo/package-info.java
+++ b/fe/fe-core/src/main/java/com/starrocks/http/rest/v2/vo/package-info.java
@@ -1,0 +1,21 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+ * VO is the abbreviation of View Object, which is used to organize and encapsulate <br/>
+ * the persistence layer data in the desired form and return it to the client, <br/>
+ * while shielding the details of the persistence layer data (such as entity object). <br/>
+ * The <a href="https://docs.oracle.com/cd/A97688_16/generic.903/bc_guide/bc_awhatisavo.htm">Oracle Docs</a> give more introduction.
+ */
+package com.starrocks.http.rest.v2.vo;

--- a/fe/fe-core/src/main/java/com/starrocks/load/PartitionUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/PartitionUtils.java
@@ -16,6 +16,7 @@ package com.starrocks.load;
 
 import com.google.common.collect.Lists;
 import com.google.common.collect.Range;
+import com.starrocks.analysis.DateLiteral;
 import com.starrocks.analysis.LiteralExpr;
 import com.starrocks.catalog.Database;
 import com.starrocks.catalog.ListPartitionInfo;
@@ -39,9 +40,12 @@ import com.starrocks.persist.RangePartitionPersistInfo;
 import com.starrocks.persist.SinglePartitionPersistInfo;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.sql.ast.DistributionDesc;
+import com.starrocks.sql.common.ErrorType;
+import com.starrocks.sql.common.StarRocksPlannerException;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -155,6 +159,99 @@ public class PartitionUtils {
                     invertedIndex.deleteTablet(tablet.getId());
                 }
             }
+        }
+    }
+
+    public static RangePartitionBoundary calRangePartitionBoundary(Range<PartitionKey> range) {
+        boolean isMaxPartition = range.upperEndpoint().isMaxValue();
+        boolean isMinPartition = range.lowerEndpoint().isMinValue();
+
+        // start keys
+        List<LiteralExpr> rangeKeyExprs;
+        List<Object> startKeys = new ArrayList<>();
+        if (!isMinPartition) {
+            rangeKeyExprs = range.lowerEndpoint().getKeys();
+            for (LiteralExpr literalExpr : rangeKeyExprs) {
+                Object keyValue;
+                if (literalExpr instanceof DateLiteral) {
+                    keyValue = convertDateLiteralToNumber((DateLiteral) literalExpr);
+                } else {
+                    keyValue = literalExpr.getRealObjectValue();
+                }
+
+                startKeys.add(keyValue);
+            }
+        }
+
+        // end keys
+        // is empty list when max partition
+        List<Object> endKeys = new ArrayList<>();
+        if (!isMaxPartition) {
+            rangeKeyExprs = range.upperEndpoint().getKeys();
+            for (LiteralExpr literalExpr : rangeKeyExprs) {
+                Object keyValue;
+                if (literalExpr instanceof DateLiteral) {
+                    keyValue = convertDateLiteralToNumber((DateLiteral) literalExpr);
+                } else {
+                    keyValue = literalExpr.getRealObjectValue();
+                }
+                endKeys.add(keyValue);
+            }
+        }
+
+        return new RangePartitionBoundary(isMinPartition, isMaxPartition, startKeys, endKeys);
+    }
+
+    // This is to be compatible with Spark Load Job formats for Date type.
+    // Because the historical version is serialized and deserialized with a special hash number for DateLiteral,
+    // special processing is also done here for DateLiteral to keep the historical version compatible.
+    // The deserialized code is in "SparkDpp.createPartitionRangeKeys"
+    public static Object convertDateLiteralToNumber(DateLiteral dateLiteral) {
+        if (dateLiteral.getType().isDate()) {
+            return (dateLiteral.getYear() * 16 * 32L
+                    + dateLiteral.getMonth() * 32
+                    + dateLiteral.getDay());
+        } else if (dateLiteral.getType().isDatetime()) {
+            return dateLiteral.getLongValue();
+        } else {
+            throw new StarRocksPlannerException("Invalid date type: " + dateLiteral.getType(), ErrorType.INTERNAL_ERROR);
+        }
+    }
+
+    public static class RangePartitionBoundary {
+
+        private final boolean minPartition;
+
+        private final boolean maxPartition;
+
+        private final List<Object> startKeys;
+
+        private final List<Object> endKeys;
+
+        public RangePartitionBoundary(boolean minPartition,
+                                      boolean maxPartition,
+                                      List<Object> startKeys,
+                                      List<Object> endKeys) {
+            this.minPartition = minPartition;
+            this.maxPartition = maxPartition;
+            this.startKeys = startKeys;
+            this.endKeys = endKeys;
+        }
+
+        public boolean isMinPartition() {
+            return minPartition;
+        }
+
+        public boolean isMaxPartition() {
+            return maxPartition;
+        }
+
+        public List<Object> getStartKeys() {
+            return startKeys;
+        }
+
+        public List<Object> getEndKeys() {
+            return endKeys;
         }
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/http/BadHttpRequestTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/http/BadHttpRequestTest.java
@@ -21,7 +21,6 @@ import okhttp3.RequestBody;
 import okhttp3.Response;
 import org.jetbrains.annotations.NotNull;
 import org.junit.Assert;
-import org.junit.Before;
 import org.junit.Test;
 
 import java.io.IOException;
@@ -35,10 +34,8 @@ public class BadHttpRequestTest extends StarRocksHttpTestCase {
 
     private static String STREAM_LOAD_URL_FORMAT;
 
-    @Before
     @Override
-    public void setUp() {
-        super.setUp();
+    protected void doSetUp() throws Exception {
         STREAM_LOAD_URL_FORMAT = "http://localhost:" + HTTP_PORT + STREAM_LOAD_URI_FORMAT;
     }
 

--- a/fe/fe-core/src/test/java/com/starrocks/http/ExecuteSqlActionTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/http/ExecuteSqlActionTest.java
@@ -20,7 +20,6 @@ import okhttp3.RequestBody;
 import okhttp3.Response;
 import org.json.JSONObject;
 import org.junit.Assert;
-import org.junit.Before;
 import org.junit.FixMethodOrder;
 import org.junit.Test;
 import org.junit.runners.MethodSorters;
@@ -33,15 +32,13 @@ public class ExecuteSqlActionTest extends StarRocksHttpTestCase {
     private static final String QUERY_EXECUTE_API = "/api/v1/catalogs/default_catalog/sql";
 
     @Override
-    @Before
-    public void setUp() {
-        super.setUp();
+    protected void doSetUp() throws Exception {
         MetricRepo.init();
         ExecuteEnv.setup();
     }
 
     @Test
-    public void test1ExecuteSqlSuccess() throws IOException {
+    public void test1ExecuteSqlSuccess() throws Exception {
         super.setUpWithCatalog();
         RequestBody body =
                 RequestBody.create(JSON, "{ \"query\" :  \"kill 0\" }");

--- a/fe/fe-core/src/test/java/com/starrocks/http/RestBaseResultTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/http/RestBaseResultTest.java
@@ -15,20 +15,42 @@
 package com.starrocks.http;
 
 import com.starrocks.http.rest.RestBaseResult;
-import org.junit.Assert;
+import com.starrocks.http.rest.v2.RestBaseResultV2;
 import org.junit.Test;
 
+import static org.junit.Assert.assertEquals;
+
 public class RestBaseResultTest {
+
     @Test
     public void testToJson() {
-        RestBaseResult result = new RestBaseResult();
-        Assert.assertEquals(result.toJson(),
-                "{\"status\":\"OK\",\"code\":\"0\",\"msg\":\"Success\",\"message\":\"OK\"}");
-        Assert.assertEquals(result.toJsonString(), "{\"code\":\"0\",\"message\":\"OK\"}");
+        {
+            RestBaseResult resultV1 = new RestBaseResult();
+            assertEquals(
+                    "{\"status\":\"OK\",\"code\":\"0\",\"msg\":\"Success\",\"message\":\"OK\"}",
+                    resultV1.toJson()
+            );
 
-        RestBaseResult failedResult = new RestBaseResult("NPE");
-        Assert.assertEquals(failedResult.toJson(),
-                "{\"status\":\"FAILED\",\"code\":\"1\",\"msg\":\"NPE\",\"message\":\"NPE\"}");
-        Assert.assertEquals(failedResult.toJsonString(), "{\"code\":\"1\",\"message\":\"NPE\"}");
+            RestBaseResultV2<Object> resultV2 = new RestBaseResultV2<>();
+            assertEquals(
+                    "{\"code\":\"0\",\"message\":\"OK\"}",
+                    resultV2.toJson()
+            );
+        }
+
+        {
+            RestBaseResult resultV1 = new RestBaseResult("NPE");
+            assertEquals(
+                    "{\"status\":\"FAILED\",\"code\":\"1\",\"msg\":\"NPE\",\"message\":\"NPE\"}",
+                    resultV1.toJson()
+            );
+
+            RestBaseResultV2<Object> resultV2 = new RestBaseResultV2<>("NPE");
+            assertEquals(
+                    "{\"code\":\"1\",\"message\":\"NPE\"}",
+                    resultV2.toJson()
+            );
+        }
     }
+
 }

--- a/fe/fe-core/src/test/java/com/starrocks/http/StarRocksHttpTestCase.java
+++ b/fe/fe-core/src/test/java/com/starrocks/http/StarRocksHttpTestCase.java
@@ -112,17 +112,19 @@ public abstract class StarRocksHttpTestCase {
     public static final String DB_NAME = "testDb";
     public static final String TABLE_NAME = "testTbl";
 
+    protected static final String ES_TABLE_NAME = "es_table";
+
     protected static long testBackendId1 = 1000;
     protected static long testBackendId2 = 1001;
     protected static long testBackendId3 = 1002;
 
-    private static long testReplicaId1 = 2000;
-    private static long testReplicaId2 = 2001;
-    private static long testReplicaId3 = 2002;
+    protected static long testReplicaId1 = 2000;
+    protected static long testReplicaId2 = 2001;
+    protected static long testReplicaId3 = 2002;
 
     protected static long testDbId = 100L;
     protected static long testTableId = 200L;
-    private static long testPartitionId = 201L;
+    protected static long testPartitionId = 201L;
     public static long testIndexId = testTableId; // the base indexid == tableid
     protected static long tabletId = 400L;
 
@@ -133,7 +135,6 @@ public abstract class StarRocksHttpTestCase {
 
     protected static String URI;
     protected static String BASE_URL;
-
     protected static final String AUTH_KEY = "Authorization";
     protected String rootAuth = Credentials.basic("root", "");
 
@@ -269,7 +270,7 @@ public abstract class StarRocksHttpTestCase {
         db.registerTableUnlocked(table);
         OlapTable table1 = newTable(TABLE_NAME + 1);
         db.registerTableUnlocked(table1);
-        EsTable esTable = newEsTable("es_table");
+        EsTable esTable = newEsTable(ES_TABLE_NAME);
         db.registerTableUnlocked(esTable);
         OlapTable newEmptyTable = newEmptyTable("test_empty_table");
         db.registerTableUnlocked(newEmptyTable);
@@ -336,7 +337,7 @@ public abstract class StarRocksHttpTestCase {
         db.registerTableUnlocked(table);
         OlapTable table1 = newTable(TABLE_NAME + 1);
         db.registerTableUnlocked(table1);
-        EsTable esTable = newEsTable("es_table");
+        EsTable esTable = newEsTable(ES_TABLE_NAME);
         db.registerTableUnlocked(esTable);
         OlapTable newEmptyTable = newEmptyTable("test_empty_table");
         db.registerTableUnlocked(newEmptyTable);
@@ -442,7 +443,7 @@ public abstract class StarRocksHttpTestCase {
     }
 
     @Before
-    public void setUp() {
+    public void setUp() throws Exception {
         GlobalStateMgr globalStateMgr = newDelegateCatalog();
         SystemInfoService systemInfoService = new SystemInfoService();
         TabletInvertedIndex tabletInvertedIndex = new TabletInvertedIndex();
@@ -492,7 +493,7 @@ public abstract class StarRocksHttpTestCase {
         doSetUp();
     }
 
-    public void setUpWithCatalog() {
+    public void setUpWithCatalog() throws Exception {
         GlobalStateMgr globalStateMgr = newDelegateGlobalStateMgr();
         SystemInfoService systemInfoService = new SystemInfoService();
         TabletInvertedIndex tabletInvertedIndex = new TabletInvertedIndex();
@@ -567,7 +568,7 @@ public abstract class StarRocksHttpTestCase {
         httpServer.shutDown();
     }
 
-    protected void doSetUp() {
+    protected void doSetUp() throws Exception {
 
     }
 

--- a/fe/fe-core/src/test/java/com/starrocks/http/TableQueryPlanActionTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/http/TableQueryPlanActionTest.java
@@ -39,10 +39,8 @@ import okhttp3.Request;
 import okhttp3.RequestBody;
 import okhttp3.Response;
 import org.apache.thrift.TDeserializer;
-import org.apache.thrift.TException;
 import org.json.JSONObject;
 import org.junit.Assert;
-import org.junit.Before;
 import org.junit.Test;
 
 import java.io.IOException;
@@ -55,14 +53,12 @@ public class TableQueryPlanActionTest extends StarRocksHttpTestCase {
     protected static String ES_TABLE_URL;
 
     @Override
-    @Before
-    public void setUp() {
-        super.setUp();
+    protected void doSetUp() throws Exception {
         ES_TABLE_URL = "http://localhost:" + HTTP_PORT + "/api/" + DB_NAME + "/es_table";
     }
 
     @Test
-    public void testQueryPlanAction() throws IOException, TException {
+    public void testQueryPlanAction() throws Exception {
         super.setUpWithCatalog();
         RequestBody body =
                 RequestBody.create(JSON, "{ \"sql\" :  \" select k1 as alias_1,k2 from " + DB_NAME + "." + TABLE_NAME + " \" }");
@@ -164,7 +160,7 @@ public class TableQueryPlanActionTest extends StarRocksHttpTestCase {
     }
 
     @Test
-    public void testQueryPlanActionPruneEmpty() throws IOException {
+    public void testQueryPlanActionPruneEmpty() throws Exception {
         super.setUpWithCatalog();
 
 

--- a/fe/fe-core/src/test/java/com/starrocks/http/rest/v2/TablePartitionActionTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/http/rest/v2/TablePartitionActionTest.java
@@ -1,0 +1,513 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.http.rest.v2;
+
+import com.google.common.collect.Range;
+import com.google.common.collect.Sets;
+import com.google.gson.reflect.TypeToken;
+import com.staros.proto.FilePathInfo;
+import com.staros.proto.FileStoreInfo;
+import com.staros.proto.FileStoreType;
+import com.staros.proto.S3FileStoreInfo;
+import com.staros.proto.ShardInfo;
+import com.starrocks.analysis.IndexDef;
+import com.starrocks.analysis.StringLiteral;
+import com.starrocks.catalog.AggregateType;
+import com.starrocks.catalog.Column;
+import com.starrocks.catalog.Database;
+import com.starrocks.catalog.DistributionInfo;
+import com.starrocks.catalog.HashDistributionInfo;
+import com.starrocks.catalog.Index;
+import com.starrocks.catalog.KeysType;
+import com.starrocks.catalog.LocalTablet;
+import com.starrocks.catalog.MaterializedIndex;
+import com.starrocks.catalog.OlapTable;
+import com.starrocks.catalog.Partition;
+import com.starrocks.catalog.PartitionKey;
+import com.starrocks.catalog.RangePartitionInfo;
+import com.starrocks.catalog.Replica;
+import com.starrocks.catalog.Table;
+import com.starrocks.catalog.TableIndexes;
+import com.starrocks.catalog.TabletMeta;
+import com.starrocks.catalog.Type;
+import com.starrocks.http.StarRocksHttpTestCase;
+import com.starrocks.http.rest.v2.RestBaseResultV2.PagedResult;
+import com.starrocks.http.rest.v2.vo.PartitionInfoView.PartitionView;
+import com.starrocks.http.rest.v2.vo.TabletView;
+import com.starrocks.lake.DataCacheInfo;
+import com.starrocks.lake.LakeTable;
+import com.starrocks.lake.LakeTablet;
+import com.starrocks.persist.gson.GsonUtils;
+import com.starrocks.server.GlobalStateMgr;
+import com.starrocks.sql.ast.ColumnDef;
+import com.starrocks.sql.ast.PartitionValue;
+import com.starrocks.thrift.TStorageMedium;
+import mockit.Expectations;
+import okhttp3.Request;
+import okhttp3.Response;
+import org.apache.http.client.utils.URIBuilder;
+import org.assertj.core.util.Lists;
+import org.junit.FixMethodOrder;
+import org.junit.Test;
+import org.junit.runners.MethodSorters;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.function.Consumer;
+
+import static com.starrocks.catalog.InternalCatalog.DEFAULT_INTERNAL_CATALOG_NAME;
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+@FixMethodOrder(MethodSorters.JVM)
+public class TablePartitionActionTest extends StarRocksHttpTestCase {
+
+    private static final String TABLE_PARTITION_URL_PATTERN =
+            BASE_URL + "/api/v2/catalogs/%s/databases/%s/tables/%s/partition";
+
+    private static final String PAGE_NUM_KEY = "page_num";
+    private static final String PAGE_SIZE_KEY = "page_size";
+
+    private static final Long TB_OLAP_TABLE_ID = testTableId + 11000L;
+    private static final String TB_OLAP_TABLE_NAME = "tb_olap_table_test";
+
+    private static final Long TB_LAKE_TABLE_ID = testTableId + 12000L;
+    private static final String TB_LAKE_TABLE_NAME = "tb_lake_table_test";
+
+    private static final Long BASE_PARTITION_ID = testPartitionId + 11000L;
+
+    private static final int PARTITION_SIZE = 7;
+
+    @Test
+    public void testNonOlapTable() throws Exception {
+        Request request = newRequest(DEFAULT_INTERNAL_CATALOG_NAME, DB_NAME, ES_TABLE_NAME);
+        try (Response response = networkClient.newCall(request).execute()) {
+            RestBaseResultV2<PagedResult<PartitionView>> resp = parseResponseBody(response.body().string());
+            assertEquals("403", resp.getCode());
+            assertTrue(resp.getMessage().contains("is not a OLAP table"));
+        }
+    }
+
+    @Test
+    public void testOlapTable() throws Exception {
+        Database db = GlobalStateMgr.getCurrentState().getDb(testDbId);
+        db.registerTableUnlocked(newOlapTable(
+                TB_OLAP_TABLE_ID, TB_OLAP_TABLE_NAME, PARTITION_SIZE));
+
+        Request request = newRequest(DEFAULT_INTERNAL_CATALOG_NAME, DB_NAME, TB_OLAP_TABLE_NAME);
+        try (Response response = networkClient.newCall(request).execute()) {
+            RestBaseResultV2<PagedResult<PartitionView>> resp = parseResponseBody(response.body().string());
+            assertEquals("0", resp.getCode());
+            PagedResult<PartitionView> tablePartition = resp.getResult();
+
+            List<PartitionView> partitionItems = tablePartition.getItems();
+            assertEquals(PARTITION_SIZE, partitionItems.size());
+
+            {
+                PartitionView partition = partitionItems.get(0);
+                assertEquals(BASE_PARTITION_ID, partition.getId());
+                assertEquals("testPartition_0", partition.getName());
+                assertEquals(8, partition.getBucketNum().intValue());
+                assertEquals("HASH", partition.getDistributionType());
+                assertEquals(testStartVersion, partition.getVisibleVersion().longValue());
+                assertTrue(partition.getVisibleVersionTime() > 0L);
+                assertEquals(testStartVersion + 1, partition.getNextVersion().longValue());
+                // assertFalse(partition.getMinPartition());
+                // assertFalse(partition.getMaxPartition());
+                assertArrayEquals(new Object[] {0.0D}, partition.getStartKeys().toArray(new Object[0]));
+                assertArrayEquals(new Object[] {10.0D}, partition.getEndKeys().toArray(new Object[0]));
+                assertNull(partition.getStoragePath());
+
+                List<TabletView> tablets = partition.getTablets();
+                assertEquals(1, tablets.size());
+                {
+                    TabletView tablet = tablets.get(0);
+                    assertEquals(tabletId, tablet.getId().longValue());
+                    assertNull(tablet.getPrimaryComputeNodeId());
+                    assertArrayEquals(
+                            new Long[] {testBackendId1, testBackendId2, testBackendId3},
+                            tablet.getBackendIds().toArray(new Long[0]));
+                }
+            }
+
+        } finally {
+            db.dropTable(TB_OLAP_TABLE_ID);
+        }
+    }
+
+    @Test
+    public void testLakeTable() throws Exception {
+        Database db = GlobalStateMgr.getCurrentState().getDb(testDbId);
+        db.registerTableUnlocked(newLakeTable(
+                TB_LAKE_TABLE_ID, TB_LAKE_TABLE_NAME, PARTITION_SIZE));
+
+        Request request = newRequest(DEFAULT_INTERNAL_CATALOG_NAME, DB_NAME, TB_LAKE_TABLE_NAME);
+        try (Response response = networkClient.newCall(request).execute()) {
+            RestBaseResultV2<PagedResult<PartitionView>> resp = parseResponseBody(response.body().string());
+            assertEquals("0", resp.getCode());
+            PagedResult<PartitionView> tablePartition = resp.getResult();
+
+            List<PartitionView> partitionItems = tablePartition.getItems();
+            assertEquals(PARTITION_SIZE, partitionItems.size());
+
+            {
+                PartitionView partition = partitionItems.get(0);
+                assertEquals(BASE_PARTITION_ID, partition.getId());
+                assertEquals("testPartition_0", partition.getName());
+                assertEquals(8, partition.getBucketNum().intValue());
+                assertEquals("HASH", partition.getDistributionType());
+                assertEquals(testStartVersion, partition.getVisibleVersion().longValue());
+                assertTrue(partition.getVisibleVersionTime() > 0L);
+                assertEquals(testStartVersion + 1, partition.getNextVersion().longValue());
+                // assertFalse(partition.getMinPartition());
+                // assertFalse(partition.getMaxPartition());
+                assertArrayEquals(new Object[] {0.0D}, partition.getStartKeys().toArray(new Object[0]));
+                assertArrayEquals(new Object[] {10.0D}, partition.getEndKeys().toArray(new Object[0]));
+                assertEquals("s3://test-bucket/" + TB_LAKE_TABLE_NAME, partition.getStoragePath());
+
+                List<TabletView> tablets = partition.getTablets();
+                assertEquals(1, tablets.size());
+                {
+                    TabletView tablet = tablets.get(0);
+                    assertEquals(tabletId, tablet.getId().longValue());
+                    assertEquals(testBackendId1, tablet.getPrimaryComputeNodeId().longValue());
+                    assertArrayEquals(
+                            new Long[] {testBackendId1},
+                            tablet.getBackendIds().toArray(new Long[0]));
+                }
+            }
+
+        } finally {
+            db.dropTable(TB_LAKE_TABLE_ID);
+        }
+    }
+
+    @Test
+    public void testPages() throws Exception {
+        Database db = GlobalStateMgr.getCurrentState().getDb(testDbId);
+        db.registerTableUnlocked(newOlapTable(
+                TB_OLAP_TABLE_ID, TB_OLAP_TABLE_NAME, PARTITION_SIZE));
+
+        {
+            Request request = newRequest(DEFAULT_INTERNAL_CATALOG_NAME, DB_NAME, TB_OLAP_TABLE_NAME);
+            try (Response response = networkClient.newCall(request).execute()) {
+                RestBaseResultV2<PagedResult<PartitionView>> resp = parseResponseBody(response.body().string());
+                assertEquals("0", resp.getCode());
+                PagedResult<PartitionView> tablePartition = resp.getResult();
+                assertEquals(0, tablePartition.getPageNum().intValue());
+                assertEquals(100, tablePartition.getPageSize().intValue());
+                assertEquals(1, tablePartition.getPages().intValue());
+                assertEquals(7, tablePartition.getTotal().intValue());
+                assertEquals(7, tablePartition.getItems().size());
+            }
+        }
+
+        {
+            Request request = newRequest(DEFAULT_INTERNAL_CATALOG_NAME, DB_NAME, TB_OLAP_TABLE_NAME,
+                    uriBuilder -> {
+                        uriBuilder.addParameter(PAGE_NUM_KEY, "-1");
+                        uriBuilder.addParameter(PAGE_SIZE_KEY, "-1");
+                    });
+            try (Response response = networkClient.newCall(request).execute()) {
+                RestBaseResultV2<PagedResult<PartitionView>> resp = parseResponseBody(response.body().string());
+                assertEquals("0", resp.getCode());
+                PagedResult<PartitionView> tablePartition = resp.getResult();
+                assertEquals(0, tablePartition.getPageNum().intValue());
+                assertEquals(100, tablePartition.getPageSize().intValue());
+                assertEquals(1, tablePartition.getPages().intValue());
+                assertEquals(7, tablePartition.getTotal().intValue());
+                assertEquals(7, tablePartition.getItems().size());
+            }
+        }
+
+        {
+            Request request = newRequest(DEFAULT_INTERNAL_CATALOG_NAME, DB_NAME, TB_OLAP_TABLE_NAME,
+                    uriBuilder -> {
+                        uriBuilder.addParameter(PAGE_NUM_KEY, "0");
+                        uriBuilder.addParameter(PAGE_SIZE_KEY, "1");
+                    });
+            try (Response response = networkClient.newCall(request).execute()) {
+                RestBaseResultV2<PagedResult<PartitionView>> resp = parseResponseBody(response.body().string());
+                assertEquals("0", resp.getCode());
+                PagedResult<PartitionView> tablePartition = resp.getResult();
+                assertEquals(0, tablePartition.getPageNum().intValue());
+                assertEquals(1, tablePartition.getPageSize().intValue());
+                assertEquals(7, tablePartition.getPages().intValue());
+                assertEquals(7, tablePartition.getTotal().intValue());
+                assertEquals(1, tablePartition.getItems().size());
+            }
+        }
+
+        {
+            Request request = newRequest(DEFAULT_INTERNAL_CATALOG_NAME, DB_NAME, TB_OLAP_TABLE_NAME,
+                    uriBuilder -> {
+                        uriBuilder.addParameter(PAGE_NUM_KEY, "0");
+                        uriBuilder.addParameter(PAGE_SIZE_KEY, "7");
+                    });
+            try (Response response = networkClient.newCall(request).execute()) {
+                RestBaseResultV2<PagedResult<PartitionView>> resp = parseResponseBody(response.body().string());
+                assertEquals("0", resp.getCode());
+                PagedResult<PartitionView> tablePartition = resp.getResult();
+                assertEquals(0, tablePartition.getPageNum().intValue());
+                assertEquals(7, tablePartition.getPageSize().intValue());
+                assertEquals(1, tablePartition.getPages().intValue());
+                assertEquals(7, tablePartition.getTotal().intValue());
+                assertEquals(7, tablePartition.getItems().size());
+            }
+        }
+
+        {
+            Request request = newRequest(DEFAULT_INTERNAL_CATALOG_NAME, DB_NAME, TB_OLAP_TABLE_NAME,
+                    uriBuilder -> {
+                        uriBuilder.addParameter(PAGE_NUM_KEY, "1");
+                        uriBuilder.addParameter(PAGE_SIZE_KEY, "3");
+                    });
+            try (Response response = networkClient.newCall(request).execute()) {
+                RestBaseResultV2<PagedResult<PartitionView>> resp = parseResponseBody(response.body().string());
+                assertEquals("0", resp.getCode());
+                PagedResult<PartitionView> tablePartition = resp.getResult();
+                assertEquals(1, tablePartition.getPageNum().intValue());
+                assertEquals(3, tablePartition.getPageSize().intValue());
+                assertEquals(3, tablePartition.getPages().intValue());
+                assertEquals(7, tablePartition.getTotal().intValue());
+                assertEquals(3, tablePartition.getItems().size());
+            }
+        }
+
+        {
+            Request request = newRequest(DEFAULT_INTERNAL_CATALOG_NAME, DB_NAME, TB_OLAP_TABLE_NAME,
+                    uriBuilder -> {
+                        uriBuilder.addParameter(PAGE_NUM_KEY, "1");
+                        uriBuilder.addParameter(PAGE_SIZE_KEY, "7");
+                    });
+            try (Response response = networkClient.newCall(request).execute()) {
+                RestBaseResultV2<PagedResult<PartitionView>> resp = parseResponseBody(response.body().string());
+                assertEquals("0", resp.getCode());
+                PagedResult<PartitionView> tablePartition = resp.getResult();
+                assertEquals(1, tablePartition.getPageNum().intValue());
+                assertEquals(7, tablePartition.getPageSize().intValue());
+                assertEquals(1, tablePartition.getPages().intValue());
+                assertEquals(7, tablePartition.getTotal().intValue());
+                assertEquals(0, tablePartition.getItems().size());
+            }
+        }
+
+        db.dropTable(TB_OLAP_TABLE_ID);
+    }
+
+    private static OlapTable newOlapTable(Long tableId, String tableName, int partitionSize) throws Exception {
+        GlobalStateMgr.getCurrentState().getTabletInvertedIndex().clear();
+
+        Column c1 = new Column("c1", Type.DOUBLE, true, null, false, null, "cc1", 1);
+        Column c2 = new Column("c2", Type.DEFAULT_DECIMAL64, false, AggregateType.SUM, true,
+                new ColumnDef.DefaultValueDef(true, new StringLiteral("0")), "cc2", 2);
+        List<Column> columns = Lists.newArrayList(c1, c2);
+
+        RangePartitionInfo partitionInfo = new RangePartitionInfo(
+                Lists.newArrayList(c1)
+        );
+
+        DistributionInfo defaultDistributionInfo = new HashDistributionInfo(8, Lists.newArrayList(c1));
+
+        Index idx1 = new Index(
+                testIndexId, "idx1", Lists.newArrayList("c1"),
+                IndexDef.IndexType.BITMAP, "c_idx1", new HashMap<>());
+        Index idx2 = new Index(
+                testIndexId + 1, "idx2", Lists.newArrayList("c2"),
+                IndexDef.IndexType.NGRAMBF, "c_idx2", new HashMap<>());
+        TableIndexes indexes = new TableIndexes(
+                Lists.newArrayList(idx1, idx2)
+        );
+        OlapTable olapTable = new OlapTable(
+                tableId,
+                tableName,
+                columns,
+                KeysType.DUP_KEYS,
+                partitionInfo,
+                defaultDistributionInfo,
+                indexes,
+                Table.TableType.OLAP
+        );
+
+        // tablet
+        LocalTablet tablet = new LocalTablet(tabletId);
+
+        // index
+        MaterializedIndex baseIndex = new MaterializedIndex(testIndexId, MaterializedIndex.IndexState.NORMAL);
+        TabletMeta tabletMeta = new TabletMeta(
+                testDbId, TB_OLAP_TABLE_ID, BASE_PARTITION_ID, testIndexId, testSchemaHash, TStorageMedium.HDD);
+        baseIndex.addTablet(tablet, tabletMeta);
+
+        tablet.addReplica(new Replica(
+                testReplicaId1, testBackendId1, testStartVersion, testSchemaHash,
+                1024000L, 2000L, Replica.ReplicaState.NORMAL, -1, 0));
+        tablet.addReplica(new Replica(
+                testReplicaId2, testBackendId2, testStartVersion, testSchemaHash,
+                1024000L, 2000L, Replica.ReplicaState.NORMAL, -1, 0));
+        tablet.addReplica(new Replica(
+                testReplicaId3, testBackendId3, testStartVersion, testSchemaHash,
+                1024000L, 2000L, Replica.ReplicaState.NORMAL, -1, 0));
+
+        for (int i = 0; i < partitionSize; i++) {
+            DistributionInfo distributionInfo = new HashDistributionInfo(8, Lists.newArrayList(c1));
+
+            long partitionId = BASE_PARTITION_ID + i;
+            Partition partition = new Partition(partitionId, "testPartition_" + i, baseIndex, distributionInfo);
+            partition.setVisibleVersion(testStartVersion, System.currentTimeMillis());
+            partition.setNextVersion(testStartVersion + 1);
+
+            PartitionKey rangeLower = PartitionKey.createPartitionKey(
+                    Lists.newArrayList(new PartitionValue(String.valueOf(i * 10))), Lists.newArrayList(c1));
+            PartitionKey rangeUpper = PartitionKey.createPartitionKey(
+                    Lists.newArrayList(new PartitionValue(String.valueOf((i + 1) * 10))), Lists.newArrayList(c1));
+
+            partitionInfo.setRange(partitionId, false, Range.closedOpen(rangeLower, rangeUpper));
+
+            olapTable.addPartition(partition);
+        }
+
+        return olapTable;
+    }
+
+    private static LakeTable newLakeTable(Long tableId, String tableName, int partitionSize) throws Exception {
+        GlobalStateMgr.getCurrentState().getTabletInvertedIndex().clear();
+
+        Column c1 = new Column("c1", Type.DOUBLE, true, null, false, null, "cc1", 1);
+        Column c2 = new Column("c2", Type.DEFAULT_DECIMAL64, false, AggregateType.SUM, true,
+                new ColumnDef.DefaultValueDef(true, new StringLiteral("0")), "cc2", 2);
+        List<Column> columns = Lists.newArrayList(c1, c2);
+
+        RangePartitionInfo partitionInfo = new RangePartitionInfo(
+                Lists.newArrayList(c1)
+        );
+
+        DistributionInfo defaultDistributionInfo = new HashDistributionInfo(8, Lists.newArrayList(c1));
+
+        LakeTable lakeTable = new LakeTable(
+                tableId,
+                tableName,
+                columns,
+                KeysType.DUP_KEYS,
+                partitionInfo,
+                defaultDistributionInfo
+        );
+
+        // tablet
+        LakeTablet tablet = new LakeTablet(tabletId);
+
+        // index
+        MaterializedIndex baseIndex = new MaterializedIndex(testIndexId, MaterializedIndex.IndexState.NORMAL);
+        TabletMeta tabletMeta = new TabletMeta(
+                testDbId, TB_LAKE_TABLE_ID, BASE_PARTITION_ID, testIndexId, testSchemaHash, TStorageMedium.HDD, true);
+        baseIndex.addTablet(tablet, tabletMeta);
+
+        FilePathInfo.Builder builder = FilePathInfo.newBuilder();
+        FileStoreInfo.Builder fsBuilder = builder.getFsInfoBuilder();
+
+        S3FileStoreInfo.Builder s3FsBuilder = fsBuilder.getS3FsInfoBuilder();
+        s3FsBuilder.setBucket("test-bucket");
+        s3FsBuilder.setRegion("test-region");
+        S3FileStoreInfo s3FsInfo = s3FsBuilder.build();
+
+        fsBuilder.setFsType(FileStoreType.S3);
+        fsBuilder.setFsKey("test-bucket");
+        fsBuilder.setS3FsInfo(s3FsInfo);
+        FileStoreInfo fsInfo = fsBuilder.build();
+
+        builder.setFsInfo(fsInfo);
+        builder.setFullPath("s3://test-bucket/" + tableName);
+        FilePathInfo pathInfo = builder.build();
+        lakeTable.setStorageInfo(pathInfo, new DataCacheInfo(false, false));
+
+        new Expectations(tablet) {
+            {
+                GlobalStateMgr.getCurrentState().getStarOSAgent().getShardInfo(anyLong, anyLong);
+                minTimes = 0;
+                result = ShardInfo.newBuilder()
+                        .setFilePath(pathInfo)
+                        .build();
+
+                tablet.getBackendIds();
+                minTimes = 0;
+                result = Sets.newHashSet(testBackendId1);
+
+                GlobalStateMgr.getCurrentState().getWarehouseMgr()
+                        .getComputeNodeId(anyLong, (LakeTablet) any);
+                minTimes = 0;
+                result = testBackendId1;
+            }
+        };
+
+        for (int i = 0; i < partitionSize; i++) {
+            DistributionInfo distributionInfo = new HashDistributionInfo(8, Lists.newArrayList(c1));
+
+            long partitionId = BASE_PARTITION_ID + i;
+            Partition partition = new Partition(partitionId, "testPartition_" + i, baseIndex, distributionInfo);
+            partition.setVisibleVersion(testStartVersion, System.currentTimeMillis());
+            partition.setNextVersion(testStartVersion + 1);
+
+            PartitionKey rangeLower = PartitionKey.createPartitionKey(
+                    Lists.newArrayList(new PartitionValue(String.valueOf(i * 10))), Lists.newArrayList(c1));
+            PartitionKey rangeUpper = PartitionKey.createPartitionKey(
+                    Lists.newArrayList(new PartitionValue(String.valueOf((i + 1) * 10))), Lists.newArrayList(c1));
+
+            partitionInfo.setRange(partitionId, false, Range.closedOpen(rangeLower, rangeUpper));
+
+            lakeTable.addPartition(partition);
+        }
+
+        return lakeTable;
+    }
+
+    private static RestBaseResultV2<PagedResult<PartitionView>> parseResponseBody(String body) {
+        try {
+            System.out.println("resp: " + body);
+            return GsonUtils.GSON.fromJson(
+                    body,
+                    new TypeToken<RestBaseResultV2<PagedResult<PartitionView>>>() {
+                    }.getType());
+        } catch (Exception e) {
+            fail("invalid resp body: " + body);
+            throw new IllegalStateException(e);
+        }
+    }
+
+    private Request newRequest(String catalog, String database, String table) throws Exception {
+        return newRequest(catalog, database, table, null);
+    }
+
+    private Request newRequest(String catalog,
+                               String database,
+                               String table,
+                               Consumer<URIBuilder> consumer) throws Exception {
+        URIBuilder uriBuilder = new URIBuilder(toPartitionUrl(catalog, database, table));
+        if (null != consumer) {
+            consumer.accept(uriBuilder);
+        }
+        return new Request.Builder()
+                .get()
+                .addHeader(AUTH_KEY, rootAuth)
+                .url(uriBuilder.build().toURL())
+                .build();
+    }
+
+    private static String toPartitionUrl(String catalog, String database, String table) {
+        return String.format(TABLE_PARTITION_URL_PATTERN, catalog, database, table);
+    }
+
+}

--- a/fe/fe-core/src/test/java/com/starrocks/http/rest/v2/TableSchemaActionTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/http/rest/v2/TableSchemaActionTest.java
@@ -1,0 +1,287 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.http.rest.v2;
+
+import com.google.gson.reflect.TypeToken;
+import com.starrocks.analysis.IndexDef;
+import com.starrocks.analysis.StringLiteral;
+import com.starrocks.catalog.AggregateType;
+import com.starrocks.catalog.Column;
+import com.starrocks.catalog.Database;
+import com.starrocks.catalog.DistributionInfo;
+import com.starrocks.catalog.HashDistributionInfo;
+import com.starrocks.catalog.Index;
+import com.starrocks.catalog.KeysType;
+import com.starrocks.catalog.OlapTable;
+import com.starrocks.catalog.PartitionInfo;
+import com.starrocks.catalog.PartitionType;
+import com.starrocks.catalog.PrimitiveType;
+import com.starrocks.catalog.RangePartitionInfo;
+import com.starrocks.catalog.Table;
+import com.starrocks.catalog.TableIndexes;
+import com.starrocks.catalog.TableProperty;
+import com.starrocks.catalog.Type;
+import com.starrocks.http.StarRocksHttpTestCase;
+import com.starrocks.http.rest.v2.vo.ColumnView;
+import com.starrocks.http.rest.v2.vo.DistributionInfoView;
+import com.starrocks.http.rest.v2.vo.IndexView;
+import com.starrocks.http.rest.v2.vo.MaterializedIndexMetaView;
+import com.starrocks.http.rest.v2.vo.PartitionInfoView;
+import com.starrocks.http.rest.v2.vo.TableSchemaView;
+import com.starrocks.persist.gson.GsonUtils;
+import com.starrocks.server.GlobalStateMgr;
+import com.starrocks.sql.ast.ColumnDef;
+import com.starrocks.thrift.TStorageType;
+import okhttp3.Request;
+import okhttp3.Response;
+import org.assertj.core.util.Lists;
+import org.junit.FixMethodOrder;
+import org.junit.Test;
+import org.junit.runners.MethodSorters;
+
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import static com.starrocks.catalog.InternalCatalog.DEFAULT_INTERNAL_CATALOG_NAME;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+@FixMethodOrder(MethodSorters.JVM)
+public class TableSchemaActionTest extends StarRocksHttpTestCase {
+
+    private static final String TABLE_SCHEMA_URL_PATTERN =
+            BASE_URL + "/api/v2/catalogs/%s/databases/%s/tables/%s/schema";
+
+    private static final Long TB_GET_TABLE_SCHEMA_ID = testTableId + 10000L;
+    private static final String TB_GET_TABLE_SCHEMA_NAME = "tb_table_schema_test";
+
+    @Override
+    protected void doSetUp() {
+        Database db = GlobalStateMgr.getCurrentState().getDb(testDbId);
+        db.registerTableUnlocked(newOlapTable(TB_GET_TABLE_SCHEMA_ID, TB_GET_TABLE_SCHEMA_NAME));
+    }
+
+    @Test
+    public void testNonOlapTable() throws Exception {
+        Request request = newRequest(DEFAULT_INTERNAL_CATALOG_NAME, DB_NAME, ES_TABLE_NAME);
+        try (Response response = networkClient.newCall(request).execute()) {
+            RestBaseResultV2<TableSchemaView> resp = parseResponseBody(response.body().string());
+            assertEquals("403", resp.getCode());
+            assertTrue(resp.getMessage().contains("is not a OLAP table"));
+        }
+    }
+
+    @Test
+    public void testOlapTable() throws Exception {
+        Request request = newRequest(DEFAULT_INTERNAL_CATALOG_NAME, DB_NAME, TB_GET_TABLE_SCHEMA_NAME);
+        try (Response response = networkClient.newCall(request).execute()) {
+            RestBaseResultV2<TableSchemaView> resp = parseResponseBody(response.body().string());
+            assertEquals("0", resp.getCode());
+            TableSchemaView tableSchema = resp.getResult();
+            assertEquals(TB_GET_TABLE_SCHEMA_ID, tableSchema.getId());
+            assertEquals(TB_GET_TABLE_SCHEMA_NAME, tableSchema.getName());
+            assertEquals(Table.TableType.serialize(Table.TableType.OLAP), tableSchema.getTableType());
+            assertEquals(KeysType.DUP_KEYS.name(), tableSchema.getKeysType());
+            assertEquals("c_" + TB_GET_TABLE_SCHEMA_NAME, tableSchema.getComment());
+            assertTrue(tableSchema.getCreateTime() > 0L);
+
+            List<ColumnView> columns = tableSchema.getColumns();
+            assertEquals(2, columns.size());
+            {
+                ColumnView column = columns.get(0);
+                assertEquals("c1", column.getName());
+                assertEquals(PrimitiveType.DOUBLE.toString(), column.getPrimitiveType());
+                assertEquals(8, column.getPrimitiveTypeSize().intValue());
+                assertEquals(Type.DOUBLE.getColumnSize(), column.getColumnSize());
+                assertEquals(0, column.getPrecision().intValue());
+                assertEquals(0, column.getScale().intValue());
+                assertNull(column.getAggregationType());
+                assertTrue(column.getKey());
+                assertFalse(column.getAllowNull());
+                assertFalse(column.getAutoIncrement());
+                assertNull(column.getDefaultValue());
+                assertEquals("NULL", column.getDefaultValueType());
+                assertNull(column.getDefaultExpr());
+                assertEquals("cc1", column.getComment());
+                assertEquals(1, column.getUniqueId().intValue());
+            }
+
+            {
+                ColumnView column = columns.get(1);
+                assertEquals("c2", column.getName());
+                assertEquals(PrimitiveType.DECIMAL64.toString(), column.getPrimitiveType());
+                assertEquals(8, column.getPrimitiveTypeSize().intValue());
+                assertEquals(Type.DEFAULT_DECIMAL64.getColumnSize(), column.getColumnSize());
+                assertEquals(18, column.getPrecision().intValue());
+                assertEquals(6, column.getScale().intValue());
+                assertEquals(AggregateType.SUM.toSql(), column.getAggregationType());
+                assertFalse(column.getKey());
+                assertTrue(column.getAllowNull());
+                assertFalse(column.getAutoIncrement());
+                assertEquals("0", column.getDefaultValue());
+                assertEquals("CONST", column.getDefaultValueType());
+                assertNull(column.getDefaultExpr());
+                assertEquals("cc2", column.getComment());
+                assertEquals(2, column.getUniqueId().intValue());
+            }
+
+            List<MaterializedIndexMetaView> indexMetas = tableSchema.getIndexMetas();
+            assertEquals(1, indexMetas.size());
+            {
+                MaterializedIndexMetaView indexMeta = indexMetas.get(0);
+                assertEquals(TB_GET_TABLE_SCHEMA_ID, indexMeta.getIndexId());
+                assertEquals(KeysType.DUP_KEYS.name(), indexMeta.getKeysType());
+                List<ColumnView> cols = indexMeta.getColumns();
+                assertEquals(1, cols.size());
+                assertEquals("c1", cols.get(0).getName());
+            }
+
+            PartitionInfoView partitionInfo = tableSchema.getPartitionInfo();
+            assertEquals(PartitionType.RANGE.typeString, partitionInfo.getType());
+            List<ColumnView> partitionColumns = partitionInfo.getPartitionColumns();
+            assertEquals(1, partitionColumns.size());
+            assertEquals("c1", partitionColumns.get(0).getName());
+
+            DistributionInfoView distributionInfo = tableSchema.getDefaultDistributionInfo();
+            assertEquals(DistributionInfo.DistributionInfoType.HASH.name(), distributionInfo.getType());
+            assertEquals(8, distributionInfo.getBucketNum());
+            List<ColumnView> distributionColumns = distributionInfo.getDistributionColumns();
+            assertEquals(1, distributionColumns.size());
+            assertEquals("c1", distributionColumns.get(0).getName());
+
+            assertEquals("cg1", tableSchema.getColocateGroup());
+
+            List<IndexView> indexes = tableSchema.getIndexes();
+            assertEquals(2, indexes.size());
+            {
+                IndexView idx = indexes.get(0);
+                assertEquals(TB_GET_TABLE_SCHEMA_ID, idx.getIndexId());
+                assertEquals("idx1", idx.getIndexName());
+                assertEquals(IndexDef.IndexType.BITMAP.getDisplayName(), idx.getIndexType());
+                assertEquals(1, idx.getColumns().size());
+                assertEquals("c1", idx.getColumns().get(0));
+                assertEquals("c_idx1", idx.getComment());
+                assertTrue(idx.getProperties().isEmpty());
+            }
+
+            {
+                IndexView idx = indexes.get(1);
+                assertEquals(TB_GET_TABLE_SCHEMA_ID + 1, idx.getIndexId().longValue());
+                assertEquals("idx2", idx.getIndexName());
+                assertEquals(IndexDef.IndexType.NGRAMBF.getDisplayName(), idx.getIndexType());
+                assertEquals(1, idx.getColumns().size());
+                assertEquals("c2", idx.getColumns().get(0));
+                assertEquals("c_idx2", idx.getComment());
+                assertTrue(idx.getProperties().isEmpty());
+            }
+
+            assertEquals(TB_GET_TABLE_SCHEMA_ID, tableSchema.getBaseIndexId());
+            assertEquals(TB_GET_TABLE_SCHEMA_ID + 65535L, tableSchema.getMaxIndexId().longValue());
+            assertEquals(65535, tableSchema.getMaxColUniqueId().intValue());
+
+            Map<String, String> properties = tableSchema.getProperties();
+            assertEquals(2, properties.size());
+            assertEquals("3", properties.get("replication_num"));
+            assertEquals("cg1", properties.get("colocate_with"));
+        }
+    }
+
+    private static OlapTable newOlapTable(Long tableId, String tableName) {
+        GlobalStateMgr.getCurrentState().getTabletInvertedIndex().clear();
+
+        Column c1 = new Column("c1", Type.DOUBLE, true, null, false, null, "cc1", 1);
+        Column c2 = new Column("c2", Type.DEFAULT_DECIMAL64, false, AggregateType.SUM, true,
+                new ColumnDef.DefaultValueDef(true, new StringLiteral("0")), "cc2", 2);
+        List<Column> columns = Lists.newArrayList(c1, c2);
+
+        PartitionInfo partitionInfo = new RangePartitionInfo(
+                Lists.newArrayList(c1)
+        );
+
+        DistributionInfo distributionInfo = new HashDistributionInfo(8, Lists.newArrayList(c1));
+
+        Index idx1 = new Index(
+                tableId, "idx1", Lists.newArrayList("c1"),
+                IndexDef.IndexType.BITMAP, "c_idx1", new HashMap<>());
+        Index idx2 = new Index(
+                tableId + 1, "idx2", Lists.newArrayList("c2"),
+                IndexDef.IndexType.NGRAMBF, "c_idx2", new HashMap<>());
+        TableIndexes indexes = new TableIndexes(
+                Lists.newArrayList(idx1, idx2)
+        );
+        OlapTable olapTable = new OlapTable(
+                tableId,
+                tableName,
+                columns,
+                KeysType.DUP_KEYS,
+                partitionInfo,
+                distributionInfo,
+                indexes,
+                Table.TableType.OLAP
+        );
+
+        olapTable.setColocateGroup("cg1");
+        olapTable.setBaseIndexId(idx1.getIndexId());
+        olapTable.setMaxIndexId(idx1.getIndexId() + 65535L);
+        olapTable.setMaxColUniqueId(65535);
+
+        olapTable.setIndexMeta(
+                idx1.getIndexId(), idx1.getIndexName(), Lists.newArrayList(c1), 0, 0, (short) 1,
+                TStorageType.COLUMN, KeysType.DUP_KEYS
+        );
+
+        olapTable.setComment("c_" + TB_GET_TABLE_SCHEMA_NAME);
+
+        TableProperty tableProperty = new TableProperty(new LinkedHashMap<>() {
+            private static final long serialVersionUID = 486917502839696846L;
+
+            {
+                put("replication_num", "3");
+                put("colocate_with", "cg1");
+            }
+        });
+        olapTable.setTableProperty(tableProperty);
+        return olapTable;
+    }
+
+    private static RestBaseResultV2<TableSchemaView> parseResponseBody(String body) {
+        try {
+            System.out.println("resp: " + body);
+            return GsonUtils.GSON.fromJson(body, new TypeToken<RestBaseResultV2<TableSchemaView>>() {
+            }.getType());
+        } catch (Exception e) {
+            fail("invalid resp body: " + body);
+            throw new IllegalStateException(e);
+        }
+    }
+
+    private Request newRequest(String catalog, String database, String table) {
+        return new Request.Builder()
+                .get()
+                .addHeader(AUTH_KEY, rootAuth)
+                .url(toSchemaUrl(catalog, database, table))
+                .build();
+    }
+
+    private static String toSchemaUrl(String catalog, String database, String table) {
+        return String.format(TABLE_SCHEMA_URL_PATTERN, catalog, database, table);
+    }
+
+}

--- a/fe/fe-core/src/test/java/com/starrocks/load/PartitionUtilsTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/load/PartitionUtilsTest.java
@@ -1,0 +1,36 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.load;
+
+import com.starrocks.analysis.DateLiteral;
+import com.starrocks.catalog.ScalarType;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class PartitionUtilsTest {
+
+    @Test
+    public void testConvertDateLiteralToDouble() throws Exception {
+        Object result = PartitionUtils.convertDateLiteralToNumber(
+                new DateLiteral("2015-03-01", ScalarType.DATE));
+        assertEquals(1031777L, result);
+
+        result = PartitionUtils.convertDateLiteralToNumber(
+                new DateLiteral("2015-03-01 12:00:00", ScalarType.DATETIME));
+        assertEquals(20150301120000L, result);
+    }
+
+}

--- a/fe/fe-core/src/test/java/com/starrocks/load/loadv2/SparkLoadPendingTaskTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/load/loadv2/SparkLoadPendingTaskTest.java
@@ -37,7 +37,6 @@ package com.starrocks.load.loadv2;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.starrocks.analysis.BrokerDesc;
-import com.starrocks.analysis.DateLiteral;
 import com.starrocks.catalog.AggregateType;
 import com.starrocks.catalog.Column;
 import com.starrocks.catalog.Database;
@@ -397,14 +396,4 @@ public class SparkLoadPendingTaskTest {
         Assert.assertEquals(partition3Id, etlPartitions.get(0).partitionId);
     }
 
-    @Test
-    public void testConvertDateLiteralToDouble() throws AnalysisException {
-        Object result = SparkLoadPendingTask.convertDateLiteralToNumber(
-                new DateLiteral("2015-03-01", ScalarType.DATE));
-        Assert.assertEquals(1031777L, result);
-
-        result = SparkLoadPendingTask.convertDateLiteralToNumber(
-                new DateLiteral("2015-03-01 12:00:00", ScalarType.DATETIME));
-        Assert.assertEquals(20150301120000L, result);
-    }
 }


### PR DESCRIPTION
__Why I'm doing:__

You can learn about the background from PR [#38466](https://github.com/StarRocks/starrocks/pull/38466).

__What I'm doing:__

This is a relatively big feature, and we will split it into multiple PRs. Related PRs include:

- [#38466: Refactor StreamLoad transaction API, and reuse it for bypass write](https://github.com/StarRocks/starrocks/pull/38466)

This PR is one of them, which mainly add a second version implementation of get table schema and partition API. This version of the API is designed to be as neutral as possible, and not tied to specific scenarios. __Howeaver, there are still some usage restrictions to note__:

1. Currently only supports `OlapTable`.
2. This version of the API does not return all table schema and partition information. The current result response has satisfied the _Bypass Write_ scenario. On the premise of ensuring compatibility, developers can gradually improve the interface according to their own business scenarios.

The API of Get Table Schema and Partition are defined as follows:

__Get Table Schema API Definition__

- Path: `/api/v2/catalogs/{catalog}/databases/{db}/tables/{table}/schema`
- Method: `GET`
- Parameter:

Name | Type | Required | Default | Desc
--- | --- | --- | --- | ---
catalog | string | no | `default_catalog` | Path Parameter, Represents the data catalog name
db | string | yes | | Path Parameter, Represents the database name
table | string | yes | | Path Parameter, Represents the table name

- Response:

Response Example:

```json
{
  "code": "0",
  "message": "OK",
  "result": {
    "id": 10200,
    "name": "tb_table_schema_test",
    "tableType": "OLAP",
    "keysType": "DUP_KEYS",
    "comment": "c_tb_table_schema_test",
    "createTime": 1709197545,
    "columns": [
      {
        "name": "c1",
        "primitiveType": "DOUBLE",
        "primitiveTypeSize": 8,
        "columnSize": 15,
        "precision": 0,
        "scale": 0,
        "isKey": true,
        "isAllowNull": false,
        "isAutoIncrement": false,
        "defaultValueType": "NULL",
        "comment": "cc1",
        "uniqueId": 1
      },
      {
        "name": "c2",
        "primitiveType": "DECIMAL64",
        "primitiveTypeSize": 8,
        "columnSize": 18,
        "precision": 18,
        "scale": 6,
        "aggregationType": "SUM",
        "isKey": false,
        "isAllowNull": true,
        "isAutoIncrement": false,
        "defaultValueType": "CONST",
        "defaultValue": "0",
        "comment": "cc2",
        "uniqueId": 2
      }
    ],
    "indexMetas": [
      {
        "indexId": 10200,
        "keysType": "DUP_KEYS",
        "columns": [
          {
            "name": "c1",
            "primitiveType": "DOUBLE",
            "primitiveTypeSize": 8,
            "columnSize": 15,
            "precision": 0,
            "scale": 0,
            "isKey": true,
            "isAllowNull": false,
            "isAutoIncrement": false,
            "defaultValueType": "NULL",
            "comment": "cc1",
            "uniqueId": 1
          }
        ]
      }
    ],
    "partitionInfo": {
      "type": "RANGE",
      "partitionColumns": [
        {
          "name": "c1",
          "primitiveType": "DOUBLE",
          "primitiveTypeSize": 8,
          "columnSize": 15,
          "precision": 0,
          "scale": 0,
          "isKey": true,
          "isAllowNull": false,
          "isAutoIncrement": false,
          "defaultValueType": "NULL",
          "comment": "cc1",
          "uniqueId": 1
        }
      ]
    },
    "defaultDistributionInfo": {
      "type": "HASH",
      "bucketNum": 8,
      "distributionColumns": [
        {
          "name": "c1",
          "primitiveType": "DOUBLE",
          "primitiveTypeSize": 8,
          "columnSize": 15,
          "precision": 0,
          "scale": 0,
          "isKey": true,
          "isAllowNull": false,
          "isAutoIncrement": false,
          "defaultValueType": "NULL",
          "comment": "cc1",
          "uniqueId": 1
        }
      ]
    },
    "colocateGroup": "cg1",
    "indexes": [
      {
        "indexId": 10200,
        "indexName": "idx1",
        "indexType": "BITMAP",
        "columns": [
          "c1"
        ],
        "comment": "c_idx1",
        "properties": {}
      },
      {
        "indexId": 10201,
        "indexName": "idx2",
        "indexType": "NGRAMBF",
        "columns": [
          "c2"
        ],
        "comment": "c_idx2",
        "properties": {}
      }
    ],
    "baseIndexId": 10200,
    "maxIndexId": 75735,
    "maxColUniqueId": 65535,
    "properties": {
      "replication_num": "3",
      "colocate_with": "cg1"
    }
  }
}
```

__Get Table Partition API Definition__

- Path: `/api/v2/catalogs/{catalog}/databases/{db}/tables/{table}/partition`
- Method: `GET`
- Parameter:

Name | Type | Required | Default | Desc
--- | --- | --- | --- | ---
catalog | string | no | `default_catalog` | Path Parameter, Represents the data catalog name
db | string | yes | | Path Parameter, Represents the database name
table | string | yes | | Path Parameter, Represents the table name
temporary | boolean | no | false | Query Parameter, if set to `true`, If set to true, it means get temporary partition info

- Response:

The response template is as follows:

```json
{
  "code": "0",
  "message": "OK",
  "result": {
    "pageNum": 1,
    "pageSize": 7,
    "pages": 1,
    "total": 7,
    "items": []
  }
}
```

Parameter description:

- `pageNum`: the page number in request.
- `pageSize`: the page size in request.
- `pages`: total page size.
- `total`: total item size.
- `items`: data items.


Response Example:

```json
{
  "code": "0",
  "message": "OK",
  "result": {
    "pageNum": 1,
    "pageSize": 3,
    "pages": 3,
    "total": 7,
    "items": [
      {
        "id": 11204,
        "name": "testPartition_3",
        "bucketNum": 8,
        "distributionType": "HASH",
        "visibleVersion": 12,
        "visibleVersionTime": 1711351506629,
        "nextVersion": 13,
        "isMinPartition": false,
        "isMaxPartition": false,
        "startKeys": [
          30.0
        ],
        "endKeys": [
          40.0
        ],
        "tablets": [
          {
            "id": 400,
            "backendIds": [
              1000,
              1001,
              1002
            ]
          }
        ]
      },
      {
        "id": 11205,
        "name": "testPartition_4",
        "bucketNum": 8,
        "distributionType": "HASH",
        "visibleVersion": 12,
        "visibleVersionTime": 1711351506629,
        "nextVersion": 13,
        "isMinPartition": false,
        "isMaxPartition": false,
        "startKeys": [
          40.0
        ],
        "endKeys": [
          50.0
        ],
        "tablets": [
          {
            "id": 400,
            "backendIds": [
              1000,
              1001,
              1002
            ]
          }
        ]
      },
      {
        "id": 11206,
        "name": "testPartition_5",
        "bucketNum": 8,
        "distributionType": "HASH",
        "visibleVersion": 12,
        "visibleVersionTime": 1711351506629,
        "nextVersion": 13,
        "isMinPartition": false,
        "isMaxPartition": false,
        "startKeys": [
          50.0
        ],
        "endKeys": [
          60.0
        ],
        "tablets": [
          {
            "id": 400,
            "backendIds": [
              1000,
              1001,
              1002
            ]
          }
        ]
      }
    ]
  }
}
```

__Fixes #issue__

## What type of PR is this:

- [ ] BugFix
- [x] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:

- [ ] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
