### PR TITLE
[BugFix] fix expr ref pruned column in transformation phase

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/transformer/QueryTransformer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/transformer/QueryTransformer.java
@@ -98,7 +98,7 @@ class QueryTransformer {
         builder = window(builder, analyticExprList);
 
         if (queryBlock.hasOrderByClause()) {
-            if (!queryBlock.getGroupBy().isEmpty() && !queryBlock.getAggregate().isEmpty()) {
+            if (!queryBlock.getGroupBy().isEmpty() || !queryBlock.getAggregate().isEmpty()) {
                 // requires output fields, groups and translated aggregations to be visible for queries with aggregation
                 List<String> outputNames = new ArrayList<>(queryBlock.getColumnOutputNames());
                 for (int i = 0; i < queryBlock.getOrderSourceExpressions().size(); ++i) {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/transformer/QueryTransformer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/transformer/QueryTransformer.java
@@ -127,7 +127,7 @@ class QueryTransformer {
             }
         }
 
-        builder = distinct(builder, queryBlock.isDistinct(), queryBlock.hasOrderByClause(), queryBlock.getOutputExpression());
+        builder = distinct(builder, queryBlock.isDistinct(), queryBlock.getOutputExpression());
         // add project to express order by expression
         builder = project(builder, Iterables.concat(queryBlock.getOrderByExpressions(), queryBlock.getOutputExpression()));
         List<ColumnRefOperator> orderByColumns = Lists.newArrayList();
@@ -593,14 +593,10 @@ class QueryTransformer {
         return subOpt.withNewRoot(sortOperator);
     }
 
-    private OptExprBuilder distinct(OptExprBuilder subOpt, boolean isDistinct, boolean hasOrderBy,
-                                    List<Expr> outputExpressions) {
+    private OptExprBuilder distinct(OptExprBuilder subOpt, boolean isDistinct, List<Expr> outputExpressions) {
         if (isDistinct) {
-            // Add project before DISTINCT to express select item. If there is an orderByClause,
-            // we can skip this process because we had done it in the previous step.
-            if (!hasOrderBy) {
-                subOpt = project(subOpt, outputExpressions);
-            }
+            // Add project before DISTINCT to express select item
+            subOpt = project(subOpt, outputExpressions);
             List<ColumnRefOperator> groupByColumns = Lists.newArrayList();
             for (Expr expr : outputExpressions) {
                 ColumnRefOperator column = (ColumnRefOperator) SqlToScalarOperatorTranslator

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/DistinctAggTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/DistinctAggTest.java
@@ -16,8 +16,8 @@ package com.starrocks.sql.plan;
 
 import com.google.common.collect.Lists;
 import com.starrocks.common.FeConstants;
-import org.junit.Test;
 import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -35,13 +35,13 @@ public class DistinctAggTest extends PlanTestBase {
 
     @ParameterizedTest(name = "sql_{index}: {0}.")
     @MethodSource("sqlWithDistinctLimit")
-    public void testSqlWithDistinctLimit(String sql, String expectedPlan) throws Exception {
+    void testSqlWithDistinctLimit(String sql, String expectedPlan) throws Exception {
         String plan = getFragmentPlan(sql);
         assertContains(plan, expectedPlan);
     }
 
     @Test
-    public void testDistinctConstants() throws Exception {
+    void testDistinctConstants() throws Exception {
         String sql = "select count(distinct 1, 2, 3, 4), sum(distinct 1), avg(distinct 1), " +
                 "group_concat(distinct 1, 2 order by 1), array_agg(distinct 1 order by 1) from t0 group by v2;";
         String plan = getFragmentPlan(sql);
@@ -67,6 +67,15 @@ public class DistinctAggTest extends PlanTestBase {
         plan = getFragmentPlan(sql);
         assertContains(plan, "2:AGGREGATE (update serialize)\n" +
                 "  |  output: group_concat(DISTINCT '1.33', ',')");
+
+        sql = "select  distinct 111 as id, 111 as id from t0 order by id + 1";
+        plan = getFragmentPlan(sql);
+        assertContains(plan, "4:Project\n" +
+                "  |  <slot 5> : 5: expr\n" +
+                "  |  \n" +
+                "  3:SORT\n" +
+                "  |  order by: <slot 6> 6: expr ASC\n" +
+                "  |  offset: 0");
     }
 
     private static Stream<Arguments> sqlWithDistinctLimit() {


### PR DESCRIPTION
## Why I'm doing:
```
select distinct 111 as id order by id
```
The plan after transformation phase is
```
LOGICAL
->  LogicalProjectOperator {projection=[3: expr]}
    ->  LogicalTopNOperator {phase=FINAL, orderBy=[2: expr ASC NULLS FIRST], limit=-1, offset=0}
        ->  LogicalProjectOperator {projection=[2: expr -> 2: expr, 3: expr -> 3 : expr]}
            ->  LogicalAggregation {type=GLOBAL ,aggregations={} ,groupKeys=[3: expr]}
                ->  LogicalProjectOperator {projection=[3: expr]}
                    ->  LogicalProjectOperator {projection=[111,  111]}
                        ->  LOGICAL_VALUES
```
2: expr had been pruned but orderByExpr still ref it.

## What I'm doing:
Root cause:
We you reslove expr `111`, you got `columnRefOperator:3`, while resloving expr `id` you got `columnRefOperator:2`.
![image](https://github.com/StarRocks/starrocks/assets/110370499/4b2cd09a-de83-4a1a-a417-e0fff4c93b35)
This reason is `filedMaping` only update in the first time, but `expressionToColumns` update all the time which makes the unmatched.
```
if (outputExprInOrderByScope.contains(outputExprIdx)) {
                outputTranslations.putWithSymbol(expression,
                        new SlotRef(null, outputNames.get(outputExprIdx)), columnRefOperator);
            } else {
                outputTranslations.putWithSymbol(expression, expression, columnRefOperator);
            }
```
According to the SQL semantics, orderSourceExpressions can only reference expressions that exist in the distinct clause. Therefore, it is sufficient to only project the outputExpr of the query.


Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [x] 3.1
  - [x] 3.0
  - [x] 2.5
