### PR TITLE
[Enhancement] enhance mv rewrite by considering sort key during selecting best mv

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/BestMvSelector.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/BestMvSelector.java
@@ -206,8 +206,8 @@ public class BestMvSelector {
                     return null;
                 }
                 int sortScore = calcSortScore(mv, equivalenceColumns, nonEquivalenceColumns);
-                CandidateContext candidateContext =
-                        new CandidateContext(expression.getStatistics(), scanOperator.getTable().getBaseSchema().size(), sortScore);
+                CandidateContext candidateContext = new CandidateContext(
+                        expression.getStatistics(), scanOperator.getTable().getBaseSchema().size(), sortScore);
                 if (isAggregate) {
                     List<MvPlanContext> planContexts = CachingMvPlanContextBuilder.getInstance().getPlanContext(
                             mv, optimizerContext.getSessionVariable().isEnableMaterializedViewPlanCache());

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/BestMvSelector.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/BestMvSelector.java
@@ -136,15 +136,16 @@ public class BestMvSelector {
             if (ret != 0) {
                 return ret;
             }
-            // compare by row number
-            ret = Double.compare(context1.getMvStatistics().getOutputRowCount(),
-                    context2.getMvStatistics().getOutputRowCount());
+
+            // larger is better
+            ret = Integer.compare(context2.sortScore, context1.sortScore);
             if (ret != 0) {
                 return ret;
             }
 
-            // larger is better
-            ret = Integer.compare(context2.sortScore, context1.sortScore);
+            // compare by row number
+            ret = Double.compare(context1.getMvStatistics().getOutputRowCount(),
+                    context2.getMvStatistics().getOutputRowCount());
             if (ret != 0) {
                 return ret;
             }
@@ -178,9 +179,9 @@ public class BestMvSelector {
     }
 
     private int calcSortScore(MaterializedView mv, Set<String> equivalenceColumns, Set<String> nonEquivalenceColumns) {
-        List<Column> schema = mv.getBaseSchema();
+        List<Column> keyColumns = mv.getKeyColumnsByIndexId(mv.getBaseIndexId());
         int score = 0;
-        for (Column col : schema) {
+        for (Column col : keyColumns) {
             String columName = col.getName().toLowerCase();
             if (equivalenceColumns.contains(columName)) {
                 score++;

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/BestMvSelector.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/BestMvSelector.java
@@ -17,29 +17,36 @@ package com.starrocks.sql.optimizer.rule.transformation.materialization;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.Lists;
+import com.google.common.collect.Sets;
+import com.starrocks.catalog.Column;
 import com.starrocks.catalog.MaterializedView;
 import com.starrocks.catalog.MvPlanContext;
+import com.starrocks.catalog.Table;
 import com.starrocks.sql.optimizer.CachingMvPlanContextBuilder;
 import com.starrocks.sql.optimizer.ExpressionContext;
 import com.starrocks.sql.optimizer.OptExpression;
 import com.starrocks.sql.optimizer.OptimizerContext;
 import com.starrocks.sql.optimizer.operator.logical.LogicalAggregationOperator;
 import com.starrocks.sql.optimizer.operator.logical.LogicalOlapScanOperator;
+import com.starrocks.sql.optimizer.operator.scalar.ScalarOperator;
 import com.starrocks.sql.optimizer.statistics.Statistics;
 import com.starrocks.sql.optimizer.statistics.StatisticsCalculator;
 
 import java.util.Comparator;
 import java.util.List;
+import java.util.Set;
 
 public class BestMvSelector {
     private final List<OptExpression> expressions;
     private final OptimizerContext context;
+    private final OptExpression queryPlan;
     private final boolean isAggQuery;
 
-    public BestMvSelector(List<OptExpression> expressions, OptimizerContext context, boolean isAggQuery) {
+    public BestMvSelector(List<OptExpression> expressions, OptimizerContext context, OptExpression queryPlan) {
         this.expressions = expressions;
         this.context = context;
-        this.isAggQuery = isAggQuery;
+        this.queryPlan = queryPlan;
+        this.isAggQuery = queryPlan.getOp() instanceof LogicalAggregationOperator;
     }
 
     public OptExpression selectBest() {
@@ -50,10 +57,19 @@ public class BestMvSelector {
         for (OptExpression expression : expressions) {
             calculateStatistics(expression, context);
         }
+
+        // collect original table scans
+        List<Table> originalTables = MvUtils.getAllTables(queryPlan);
+        Set<ScalarOperator> predicates = MvUtils.getAllValidPredicates(queryPlan);
+        Set<String> equivalenceColumns = Sets.newHashSet();
+        Set<String> nonEquivalenceColumns = Sets.newHashSet();
+        MvUtils.splitPredicate(predicates, equivalenceColumns, nonEquivalenceColumns);
         List<CandidateContext> contexts = Lists.newArrayList();
         for (int i = 0; i < expressions.size(); i++) {
-            CandidateContext mvContext =
-                    getMVContext(expressions.get(i), isAggQuery, context);
+            List<Table> expressionTables = MvUtils.getAllTables(expressions.get(i));
+            originalTables.stream().forEach(originalTable -> expressionTables.remove(originalTable));
+            CandidateContext mvContext = getMVContext(
+                    expressions.get(i), isAggQuery, context, expressionTables, equivalenceColumns, nonEquivalenceColumns);
             Preconditions.checkState(mvContext != null);
             mvContext.setIndex(i);
             contexts.add(mvContext);
@@ -72,15 +88,17 @@ public class BestMvSelector {
         // else set it to Integer.MAX_VALUE
         private int groupbyColumnNum;
         private int index;
+        private final int sortScore;
 
-        public CandidateContext(Statistics mvStatistics, int schemaColumnNum) {
-            this(mvStatistics, schemaColumnNum, 0);
+        public CandidateContext(Statistics mvStatistics, int schemaColumnNum, int sortScore) {
+            this(mvStatistics, schemaColumnNum, sortScore, 0);
         }
 
-        public CandidateContext(Statistics mvStatistics, int schemaColumnNum, int index) {
+        public CandidateContext(Statistics mvStatistics, int schemaColumnNum, int sortScore, int index) {
             this.mvStatistics = mvStatistics;
             this.schemaColumnNum = schemaColumnNum;
             this.index = index;
+            this.sortScore = sortScore;
             this.groupbyColumnNum = Integer.MAX_VALUE;
         }
 
@@ -124,6 +142,13 @@ public class BestMvSelector {
             if (ret != 0) {
                 return ret;
             }
+
+            // larger is better
+            ret = Integer.compare(context2.sortScore, context1.sortScore);
+            if (ret != 0) {
+                return ret;
+            }
+
             // compare by schema column num
             ret = Integer.compare(context1.getSchemaColumnNum(), context2.getSchemaColumnNum());
             if (ret != 0) {
@@ -152,15 +177,38 @@ public class BestMvSelector {
         expr.setStatistics(expressionContext.getStatistics());
     }
 
+    private int calcSortScore(MaterializedView mv, Set<String> equivalenceColumns, Set<String> nonEquivalenceColumns) {
+        List<Column> schema = mv.getBaseSchema();
+        int score = 0;
+        for (Column col : schema) {
+            String columName = col.getName().toLowerCase();
+            if (equivalenceColumns.contains(columName)) {
+                score++;
+            } else if (nonEquivalenceColumns.contains(columName)) {
+                // UnEquivalence predicate's columns can only match first columns in rollup.
+                score++;
+                break;
+            } else {
+                break;
+            }
+        }
+        return score;
+    }
+
     private CandidateContext getMVContext(
-            OptExpression expression, boolean isAggregate, OptimizerContext optimizerContext) {
+            OptExpression expression, boolean isAggregate, OptimizerContext optimizerContext,
+            List<Table> diffTables, Set<String> equivalenceColumns, Set<String> nonEquivalenceColumns) {
         if (expression.getOp() instanceof LogicalOlapScanOperator) {
             LogicalOlapScanOperator scanOperator = expression.getOp().cast();
             if (scanOperator.getTable().isMaterializedView()) {
+                MaterializedView mv = (MaterializedView) scanOperator.getTable();
+                if (!diffTables.contains(mv)) {
+                    return null;
+                }
+                int sortScore = calcSortScore(mv, equivalenceColumns, nonEquivalenceColumns);
                 CandidateContext candidateContext =
-                        new CandidateContext(expression.getStatistics(), scanOperator.getTable().getBaseSchema().size());
+                        new CandidateContext(expression.getStatistics(), scanOperator.getTable().getBaseSchema().size(), sortScore);
                 if (isAggregate) {
-                    MaterializedView mv = (MaterializedView) scanOperator.getTable();
                     List<MvPlanContext> planContexts = CachingMvPlanContextBuilder.getInstance().getPlanContext(
                             mv, optimizerContext.getSessionVariable().isEnableMaterializedViewPlanCache());
                     for (MvPlanContext planContext : planContexts) {
@@ -174,7 +222,8 @@ public class BestMvSelector {
             }
         }
         for (OptExpression child : expression.getInputs()) {
-            CandidateContext context = getMVContext(child, isAggregate, optimizerContext);
+            CandidateContext context = getMVContext(
+                    child, isAggregate, optimizerContext, diffTables, equivalenceColumns, nonEquivalenceColumns);
             if (context != null) {
                 return context;
             }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/BestMvSelector.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/BestMvSelector.java
@@ -60,7 +60,7 @@ public class BestMvSelector {
 
         // collect original table scans
         List<Table> originalTables = MvUtils.getAllTables(queryPlan);
-        Set<ScalarOperator> predicates = MvUtils.getAllValidPredicates(queryPlan);
+        Set<ScalarOperator> predicates = MvUtils.getAllValidPredicatesFromScans(queryPlan);
         Set<String> equivalenceColumns = Sets.newHashSet();
         Set<String> nonEquivalenceColumns = Sets.newHashSet();
         MvUtils.splitPredicate(predicates, equivalenceColumns, nonEquivalenceColumns);

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvUtils.java
@@ -83,6 +83,7 @@ import com.starrocks.sql.optimizer.operator.scalar.ScalarOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ScalarOperatorVisitor;
 import com.starrocks.sql.optimizer.rewrite.ReplaceColumnRefRewriter;
 import com.starrocks.sql.optimizer.rewrite.ScalarOperatorRewriter;
+import com.starrocks.sql.optimizer.rule.mv.MVUtils;
 import com.starrocks.sql.optimizer.transformer.LogicalPlan;
 import com.starrocks.sql.optimizer.transformer.RelationTransformer;
 import com.starrocks.sql.optimizer.transformer.SqlToScalarOperatorTranslator;
@@ -467,6 +468,23 @@ public class MvUtils {
         };
         expression.getOp().accept(joinCollector, expression, null);
         return joinExprs;
+    }
+
+    public static void splitPredicate(
+            Set<ScalarOperator> predicates,
+            Set<String> equivalenceColumns,
+            Set<String> nonEquivalenceColumns) {
+        for (ScalarOperator operator : predicates) {
+            if (!MVUtils.isPredicateUsedForPrefixIndex(operator)) {
+                continue;
+            }
+
+            if (MVUtils.isEquivalencePredicate(operator)) {
+                equivalenceColumns.add(operator.getColumnRefs().get(0).getName().toLowerCase());
+            } else {
+                nonEquivalenceColumns.add(operator.getColumnRefs().get(0).getName().toLowerCase());
+            }
+        }
     }
 
     // get all predicates within and below root

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvUtils.java
@@ -487,6 +487,13 @@ public class MvUtils {
         }
     }
 
+    public static Set<ScalarOperator> getAllValidPredicatesFromScans(OptExpression root) {
+        List<LogicalScanOperator> scanOperators = getScanOperator(root);
+        Set<ScalarOperator> predicates = Sets.newHashSet();
+        scanOperators.stream().forEach(scanOperator -> predicates.addAll(Utils.extractConjuncts(scanOperator.getPredicate())));
+        return predicates.stream().filter(MvUtils::isValidPredicate).collect(Collectors.toSet());
+    }
+
     // get all predicates within and below root
     public static Set<ScalarOperator> getAllValidPredicates(OptExpression root) {
         Set<ScalarOperator> predicates = Sets.newHashSet();

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/rule/BaseMaterializedViewRewriteRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/rule/BaseMaterializedViewRewriteRule.java
@@ -110,8 +110,7 @@ public abstract class BaseMaterializedViewRewriteRule extends TransformationRule
                 return expressions;
             } else {
                 // in rule phase, only return the best one result
-                BestMvSelector bestMvSelector = new BestMvSelector(
-                        expressions, context, queryExpression.getOp() instanceof LogicalAggregationOperator);
+                BestMvSelector bestMvSelector = new BestMvSelector(expressions, context, queryExpression);
                 return Lists.newArrayList(bestMvSelector.selectBest());
             }
         } catch (Exception e) {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/rule/BaseMaterializedViewRewriteRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/rule/BaseMaterializedViewRewriteRule.java
@@ -30,7 +30,6 @@ import com.starrocks.sql.optimizer.OptimizerContext;
 import com.starrocks.sql.optimizer.QueryMaterializationContext;
 import com.starrocks.sql.optimizer.base.ColumnRefFactory;
 import com.starrocks.sql.optimizer.operator.Operator;
-import com.starrocks.sql.optimizer.operator.logical.LogicalAggregationOperator;
 import com.starrocks.sql.optimizer.operator.logical.LogicalOlapScanOperator;
 import com.starrocks.sql.optimizer.operator.pattern.Pattern;
 import com.starrocks.sql.optimizer.operator.scalar.ConstantOperator;

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvRewriteTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvRewriteTest.java
@@ -2021,6 +2021,7 @@ public class MvRewriteTest extends MvRewriteTestBase {
 
         starRocksAssert.getCtx().getSessionVariable().setEnableMaterializedViewRewriteForInsert(
                 SessionVariable.DEFAULT_SESSION_VARIABLE.isEnableMaterializedViewRewriteForInsert());
+        starRocksAssert.dropMaterializedView("mv_insert");
     }
 
     /**

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvRewriteTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvRewriteTest.java
@@ -2202,4 +2202,67 @@ public class MvRewriteTest extends MvRewriteTestBase {
             PlanTestBase.assertContains(plan, "mv11", "PREDICATES: 10: ct > 0");
         }
     }
+
+    @Test
+    public void testMvRewriteWithSortKey() throws Exception {
+        connectContext.getSessionVariable().setOptimizerExecuteTimeout(3000000);
+        {
+            starRocksAssert.withMaterializedView("create MATERIALIZED VIEW if not exists mv_order_by_v1 " +
+                    "DISTRIBUTED BY RANDOM buckets 1 " +
+                    "order by (v1) " +
+                    "REFRESH MANUAL " +
+                    "as\n" +
+                    "select v1, v2, sum(v3) from t0 group by v1, v2");
+            cluster.runSql("test", "refresh materialized view mv_order_by_v1 with sync mode");
+            starRocksAssert.withMaterializedView("create MATERIALIZED VIEW if not exists mv_order_by_v2 " +
+                    "DISTRIBUTED BY RANDOM buckets 1 " +
+                    "order by (v2) " +
+                    "REFRESH MANUAL " +
+                    "as\n" +
+                    "select v1, v2, sum(v3) from t0 group by v1, v2");
+            cluster.runSql("test", "refresh materialized view mv_order_by_v2 with sync mode");
+            {
+                // in predicate
+                String query = "select v1, v2, sum(v3) from t0 where v1 in (1, 2, 3) group by v1, v2;";
+                String plan = getFragmentPlan(query);
+                PlanTestBase.assertContains(plan, "mv_order_by_v1");
+            }
+            {
+                // equal predicate
+                String query = "select v1, v2, sum(v3) from t0 where v1 = 1 group by v1, v2;";
+                String plan = getFragmentPlan(query);
+                PlanTestBase.assertContains(plan, "mv_order_by_v1");
+            }
+            starRocksAssert.dropMaterializedView("mv_order_by_v1");
+            starRocksAssert.dropMaterializedView("mv_order_by_v2");
+        }
+        {
+            starRocksAssert.withMaterializedView("create MATERIALIZED VIEW if not exists mv_order_by_v1 " +
+                    "DISTRIBUTED BY RANDOM buckets 1 " +
+                    "order by (v1) " +
+                    "REFRESH MANUAL " +
+                    "as\n" +
+                    "select v1, v2, v3 from t0");
+            cluster.runSql("test", "refresh materialized view mv_order_by_v1 with sync mode");
+            starRocksAssert.withMaterializedView("create MATERIALIZED VIEW if not exists mv_order_by_v2 " +
+                    "DISTRIBUTED BY RANDOM buckets 1 " +
+                    "order by (v2) " +
+                    "REFRESH MANUAL " +
+                    "as\n" +
+                    "select v1, v2, v3 from t0");
+            cluster.runSql("test", "refresh materialized view mv_order_by_v2 with sync mode");
+            {
+                String query = "select v1, v2, v3 from t0 where v1 in (1, 2, 3);";
+                String plan = getFragmentPlan(query);
+                PlanTestBase.assertContains(plan, "mv_order_by_v1");
+            }
+            {
+                String query = "select v1, v2, v3 from t0 where v1 = 1;";
+                String plan = getFragmentPlan(query);
+                PlanTestBase.assertContains(plan, "mv_order_by_v1");
+            }
+            starRocksAssert.dropMaterializedView("mv_order_by_v1");
+            starRocksAssert.dropMaterializedView("mv_order_by_v2");
+        }
+    }
 }


### PR DESCRIPTION
## Why I'm doing:
Now when query has multi mv rewritten results, we need to choose the best mv. But we do not consider sort key of mv, which will influence the query performance.

## What I'm doing:
enhance mv rewrite by considering sort key during selecting best mv

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [x] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
