### PR TITLE
[BugFix] mask secret parameters when create storage volume failed(#41975)

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/storagevolume/StorageVolume.java
+++ b/fe/fe-core/src/main/java/com/starrocks/storagevolume/StorageVolume.java
@@ -82,6 +82,13 @@ public class StorageVolume implements Writable, GsonPostProcessable {
 
     public static String CREDENTIAL_MASK = "******";
 
+    private String dumpMaskedParams(Map<String, String> params) {
+        Gson gson = new Gson();
+        Map<String, String> maskedParams = new HashMap<>(params);
+        addMaskForCredential(maskedParams);
+        return gson.toJson(maskedParams);
+    }
+
     public StorageVolume(String id, String name, String svt, List<String> locations,
                          Map<String, String> params, boolean enabled, String comment) throws DdlException {
         this.id = id;
@@ -95,8 +102,7 @@ public class StorageVolume implements Writable, GsonPostProcessable {
         preprocessAuthenticationIfNeeded(configurationParams);
         this.cloudConfiguration = CloudConfigurationFactory.buildCloudConfigurationForStorage(configurationParams, true);
         if (!isValidCloudConfiguration()) {
-            Gson gson = new Gson();
-            throw new SemanticException("Storage params is not valid " + gson.toJson(params));
+            throw new SemanticException("Storage params is not valid " + dumpMaskedParams(params));
         }
         validateStorageVolumeConstraints();
     }
@@ -136,8 +142,7 @@ public class StorageVolume implements Writable, GsonPostProcessable {
         newParams.putAll(params);
         this.cloudConfiguration = CloudConfigurationFactory.buildCloudConfigurationForStorage(newParams, true);
         if (!isValidCloudConfiguration()) {
-            Gson gson = new Gson();
-            throw new SemanticException("Storage params is not valid " + gson.toJson(newParams));
+            throw new SemanticException("Storage params is not valid " + dumpMaskedParams(newParams));
         }
         this.params = newParams;
     }
@@ -211,15 +216,12 @@ public class StorageVolume implements Writable, GsonPostProcessable {
     }
 
     public void getProcNodeData(BaseProcResult result) {
-        Gson gson = new Gson();
-        Map<String, String> p = new HashMap<>(params);
-        addMaskForCredential(p);
         result.addRow(Lists.newArrayList(name,
                 svt.name(),
                 String.valueOf(GlobalStateMgr.getCurrentState().getStorageVolumeMgr()
                         .getDefaultStorageVolumeId().equals(id)),
                 Joiner.on(", ").join(locations),
-                String.valueOf(gson.toJson(p)),
+                dumpMaskedParams(params),
                 String.valueOf(enabled),
                 String.valueOf(comment)));
     }

--- a/fe/fe-core/src/test/java/com/starrocks/storagevolume/StorageVolumeTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/storagevolume/StorageVolumeTest.java
@@ -52,6 +52,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -579,5 +580,19 @@ public class StorageVolumeTest {
         Assert.assertEquals(StorageVolume.CREDENTIAL_MASK, storageParams.get(AWS_S3_SECRET_KEY));
         Assert.assertEquals(StorageVolume.CREDENTIAL_MASK, storageParams.get(AZURE_BLOB_SAS_TOKEN));
         Assert.assertEquals(StorageVolume.CREDENTIAL_MASK, storageParams.get(AZURE_BLOB_SHARED_KEY));
+    }
+
+    @Test
+    public void testAddMaskInvalidForInvalidCredential() {
+        String awsSecretKey = "SomeAWSSecretKey";
+        Map<String, String> storageParams = new HashMap<>();
+        storageParams.put(AWS_S3_ACCESS_KEY, "accessKey");
+        storageParams.put(AWS_S3_SECRET_KEY, awsSecretKey);
+        storageParams.put(AWS_S3_ENDPOINT, "endpoint");
+        Exception exception = Assert.assertThrows(SemanticException.class, () -> new StorageVolume(
+                "1", "test", "obs", Collections.singletonList("s3://foobar"), storageParams, true, ""
+        ));
+        Assert.assertFalse(exception.getMessage().contains(awsSecretKey));
+        Assert.assertTrue(exception.getMessage().contains(StorageVolume.CREDENTIAL_MASK));
     }
 }


### PR DESCRIPTION
## Why I'm doing:
When create storage volume with invalid parameters, the sql and log will dump some error message which wasn't masked.

The error message for SQL.
![image](https://github.com/StarRocks/starrocks/assets/130516674/3c160328-6f8e-4a0d-8250-ba9f55c1d12e)

and also the log message.
![image](https://github.com/StarRocks/starrocks/assets/130516674/006779eb-675d-4def-a004-eebb049de982)

## What I'm doing:

Just replace the secrete with mask.
![image](https://github.com/StarRocks/starrocks/assets/130516674/b2a1951e-9817-44c8-b98b-edddec42b4be)

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [x] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [x] 3.1
  - [ ] 3.0
  - [ ] 2.5
