### PR TITLE
[BugFix] add a default table name for table function relation

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/TableFunctionRelation.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/TableFunctionRelation.java
@@ -18,6 +18,7 @@ import com.starrocks.analysis.Expr;
 import com.starrocks.analysis.FunctionCallExpr;
 import com.starrocks.analysis.FunctionName;
 import com.starrocks.analysis.FunctionParams;
+import com.starrocks.analysis.TableName;
 import com.starrocks.catalog.TableFunction;
 import com.starrocks.sql.parser.NodePosition;
 
@@ -72,6 +73,11 @@ public class TableFunctionRelation extends Relation {
 
     public void setChildExpressions(List<Expr> childExpressions) {
         this.childExpressions = childExpressions;
+    }
+
+    @Override
+    public TableName getResolveTableName() {
+        return alias != null ? alias : new TableName(null, "table_function_" + functionName.getFunction());
     }
 
     @Override

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/TableFunctionTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/TableFunctionTest.java
@@ -258,7 +258,8 @@ public class TableFunctionTest extends PlanTestBase {
         assertContains(plan, "TableValueFunction");
 
         Exception e = Assert.assertThrows(SemanticException.class, () -> {
-            String sql1 = "select table_function_unnest.*, unnest.v1, unnest.v2 from (select * from test_all_type join t0_not_null) " +
+            String sql1 = "select table_function_unnest.*, unnest.v1, unnest.v2 from " +
+                    "(select * from test_all_type join t0_not_null) " +
                     "table_function_unnest, unnest(split(t1a, ','))";
             getFragmentPlan(sql1);
         });

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/TableFunctionTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/TableFunctionTest.java
@@ -14,6 +14,8 @@
 
 package com.starrocks.sql.plan;
 
+import com.starrocks.sql.analyzer.SemanticException;
+import org.junit.Assert;
 import org.junit.Test;
 
 public class TableFunctionTest extends PlanTestBase {
@@ -254,5 +256,13 @@ public class TableFunctionTest extends PlanTestBase {
                 "unnest(split(t1a, ','), v3) as unnest (v1, v2)";
         plan = getFragmentPlan(sql);
         assertContains(plan, "TableValueFunction");
+
+        Exception e = Assert.assertThrows(SemanticException.class, () -> {
+            String sql1 = "select table_function_unnest.*, unnest.v1, unnest.v2 from (select * from test_all_type join t0_not_null) " +
+                    "table_function_unnest, unnest(split(t1a, ','))";
+            getFragmentPlan(sql1);
+        });
+
+        Assert.assertTrue(e.getMessage().contains("Not unique table/alias: 'table_function_unnest'"));
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/TableFunctionTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/TableFunctionTest.java
@@ -254,7 +254,5 @@ public class TableFunctionTest extends PlanTestBase {
                 "unnest(split(t1a, ','), v3) as unnest (v1, v2)";
         plan = getFragmentPlan(sql);
         assertContains(plan, "TableValueFunction");
-
-
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/TableFunctionTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/TableFunctionTest.java
@@ -235,4 +235,26 @@ public class TableFunctionTest extends PlanTestBase {
                 "  0:OlapScanNode\n" +
                 "     TABLE: t2");
     }
+
+    @Test
+    public void testTableFunctionAlias() throws Exception {
+        String sql = "select t.*, unnest from test_all_type t, unnest(split(t1a, ','))";
+        String plan = getFragmentPlan(sql);
+        assertContains(plan, "TableValueFunction");
+
+        sql = "select table_function_unnest.*, unnest from test_all_type table_function_unnest, unnest(split(t1a, ','))";
+        plan = getFragmentPlan(sql);
+        assertContains(plan, "TableValueFunction");
+
+        sql = "select t.*, unnest from test_all_type t, unnest(split(t1a, ',')) unnest";
+        plan = getFragmentPlan(sql);
+        assertContains(plan, "TableValueFunction");
+
+        sql = "select t.*, unnest.v1, unnest.v2 from (select * from test_all_type join t0_not_null) t, " +
+                "unnest(split(t1a, ','), v3) as unnest (v1, v2)";
+        plan = getFragmentPlan(sql);
+        assertContains(plan, "TableValueFunction");
+
+
+    }
 }


### PR DESCRIPTION
## Why I'm doing:
![image](https://github.com/StarRocks/starrocks/assets/110370499/60ec98da-a024-410c-a38a-4a31453af684)

## What I'm doing:
Root cause:
![image](https://github.com/StarRocks/starrocks/assets/110370499/c56e6876-57da-4544-8c05-b07b351a2ceb)
relationAlias in Field is null.

Add a default tableName for tableFunctionRelation node.
Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [x] 3.1
  - [x] 3.0
  - [x] 2.5
