### PR TITLE
[BugFix] Fix LDAP authentication bug where empty password can successfully login on AD server

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/mysql/security/LdapSecurity.java
+++ b/fe/fe-core/src/main/java/com/starrocks/mysql/security/LdapSecurity.java
@@ -15,6 +15,7 @@
 
 package com.starrocks.mysql.security;
 
+import com.google.common.base.Strings;
 import com.starrocks.common.Config;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -32,6 +33,11 @@ public class LdapSecurity {
 
     //bind to ldap server to check password
     public static boolean checkPassword(String dn, String password) {
+        if (Strings.isNullOrEmpty(password)) {
+            LOG.warn("empty password is not allowed for simple authentication");
+            return false;
+        }
+
         String url = "ldap://" + Config.authentication_ldap_simple_server_host + ":" +
                 Config.authentication_ldap_simple_server_port;
         Hashtable<String, String> env = new Hashtable<>();
@@ -64,6 +70,11 @@ public class LdapSecurity {
     //2. search user
     //3. if match exactly one, check password
     public static boolean checkPasswordByRoot(String user, String password) {
+        if (Strings.isNullOrEmpty(Config.authentication_ldap_simple_bind_root_pwd)) {
+            LOG.warn("empty password is not allowed for simple authentication");
+            return false;
+        }
+
         String url = "ldap://" + Config.authentication_ldap_simple_server_host + ":" +
                 Config.authentication_ldap_simple_server_port;
         Hashtable<String, String> env = new Hashtable<>();


### PR DESCRIPTION
## Why I'm doing:
If you supply an empty string, an empty byte/char array, or null to the Context.SECURITY_CREDENTIALS environment property, then the authentication mechanism will be "none". This is because the LDAP requires the password to be nonempty for simple authentication. The protocol automatically converts the authentication to "none" if a password is not supplied.
https://docs.oracle.com/javase/jndi/tutorial/ldap/security/simple.html

## What I'm doing:
Reject empty password.

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [x] 3.1
  - [x] 3.0
  - [x] 2.5
