### PR TITLE
[Enhancement] Support config alias names

### DIFF
--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -363,6 +363,7 @@ CONF_Int64(max_row_source_mask_memory_bytes, "209715200");
 
 // Port to start debug http server in BE
 CONF_Int32(be_http_port, "8040");
+CONF_Alias(be_http_port, webserver_port);
 // Number of http workers in BE
 CONF_Int32(be_http_num_workers, "48");
 // Period to update rate counters and sampling counters in ms.

--- a/be/src/common/configbase.h
+++ b/be/src/common/configbase.h
@@ -214,7 +214,8 @@ public:
         assert(strcmp(field->name(), alias) != 0);
         [[maybe_unused]] auto [_, ok] = Field::fields().emplace(std::string(alias), field);
         if (!ok) {
-            std::cerr << fmt::format("The alias '{}' for config '{}' already exists\n", alias, field->name());
+            std::cerr << fmt::format("The alias name '{}' for config '{}' already used, please choose another one\n",
+                                     alias, field->name());
             std::abort();
         }
     }
@@ -231,6 +232,7 @@ public:
 #define DECLARE_FIELD(FIELD_TYPE, FIELD_NAME) extern FIELD_TYPE FIELD_NAME;
 
 #ifdef __IN_CONFIGBASE_CPP__
+// NOTE: alias configs must be defined after the true config, otherwise there will be a compile error
 #define CONF_Alias(name, alias) DEFINE_ALIAS(name, alias)
 #define CONF_Bool(name, defaultstr) DEFINE_FIELD(bool, name, defaultstr, false, "bool")
 #define CONF_Int16(name, defaultstr) DEFINE_FIELD(int16_t, name, defaultstr, false, "int16")
@@ -251,6 +253,7 @@ public:
 #define CONF_mDouble(name, defaultstr) DEFINE_FIELD(double, name, defaultstr, true, "double")
 #define CONF_mString(name, defaultstr) DEFINE_FIELD(MutableString, name, defaultstr, true, "string")
 #else
+// NOTE: alias configs must be defined after the true config, otherwise there will be a compile error
 #define CONF_Alias(name, alias)
 #define CONF_Bool(name, defaultstr) DECLARE_FIELD(bool, name)
 #define CONF_Int16(name, defaultstr) DECLARE_FIELD(int16_t, name)

--- a/be/src/common/configbase.h
+++ b/be/src/common/configbase.h
@@ -164,7 +164,6 @@ protected:
 template <typename T, typename = void>
 class FieldImpl;
 
-//// FieldImpl<bool/int16_t/int32_t/int64_t/double>
 template <typename T>
 class FieldImpl<T> final : public Field {
 public:

--- a/be/src/common/configbase.h
+++ b/be/src/common/configbase.h
@@ -194,6 +194,9 @@ public:
         for (auto& part : parts) {
             T v;
             StripWhiteSpace(&part);
+            if (part.empty()) {
+                continue;
+            }
             if (!strtox(part, v)) {
                 return false;
             }

--- a/be/src/common/configbase.h
+++ b/be/src/common/configbase.h
@@ -226,7 +226,7 @@ public:
     FIELD_TYPE FIELD_NAME;                                                         \
     static FieldImpl<FIELD_TYPE> field_##FIELD_NAME(TYPE_NAME, #FIELD_NAME, &FIELD_NAME, FIELD_DEFAULT, VALMUTABLE);
 
-#define DEFINE_ALIAS(REAL_NAME, ALIAS_NAME) static Alias alias_##ALIAS_NAME(#REAL_NAME, &(field_##REAL_NAME));
+#define DEFINE_ALIAS(REAL_NAME, ALIAS_NAME) static Alias alias_##ALIAS_NAME(#ALIAS_NAME, &(field_##REAL_NAME));
 
 #define DECLARE_FIELD(FIELD_TYPE, FIELD_NAME) extern FIELD_TYPE FIELD_NAME;
 

--- a/be/src/common/configbase.h
+++ b/be/src/common/configbase.h
@@ -40,8 +40,6 @@ class Status;
 
 namespace config {
 
-class MutableString;
-
 struct ConfigInfo {
     std::string name;
     std::string value;

--- a/be/test/common/config_test.cpp
+++ b/be/test/common/config_test.cpp
@@ -61,20 +61,20 @@ TEST_F(ConfigTest, test_list_configs) {
             {"cfg_mbool", "true", "bool", "true", true},
             {"cfg_double", "123.456", "double", "123.456", false},
             {"cfg_mdouble", "-123.456", "double", "-123.456", true},
-            {"cfg_int16", "2561", "int16_t", "2561", false},
-            {"cfg_mint16", "-2561", "int16_t", "-2561", true},
-            {"cfg_int32", "65536123", "int32_t", "65536123", false},
-            {"cfg_mint32", "-65536123", "int32_t", "-65536123", true},
-            {"cfg_int64", "4294967296123", "int64_t", "4294967296123", false},
-            {"cfg_mint64", "-4294967296123", "int64_t", "-4294967296123", true},
-            {"cfg_string", "test_string", "std::string", "test_string", false},
-            {"cfg_mstring", "test_mstring", "MutableString", "test_mstring", true},
-            {"cfg_bools", "true,false,true", "std::vector<bool>", "true,false,true", false},
-            {"cfg_doubles", "0.1,0.2,0.3", "std::vector<double>", "0.1,0.2,0.3", false},
-            {"cfg_int16s", "1,2,3", "std::vector<int16_t>", "1,2,3", false},
-            {"cfg_int32s", "10,20,30", "std::vector<int32_t>", "10,20,30", false},
-            {"cfg_int64s", "100,200,300", "std::vector<int64_t>", "100,200,300", false},
-            {"cfg_strings", "s1,s2,s3", "std::vector<std::string>", "s1,s2,s3", false},
+            {"cfg_int16", "2561", "int16", "2561", false},
+            {"cfg_mint16", "-2561", "int16", "-2561", true},
+            {"cfg_int32", "65536123", "int32", "65536123", false},
+            {"cfg_mint32", "-65536123", "int32", "-65536123", true},
+            {"cfg_int64", "4294967296123", "int64", "4294967296123", false},
+            {"cfg_mint64", "-4294967296123", "int64", "-4294967296123", true},
+            {"cfg_string", "test_string", "string", "test_string", false},
+            {"cfg_mstring", "test_mstring", "string", "test_mstring", true},
+            {"cfg_bools", "true,false,true", "list<bool>", "true,false,true", false},
+            {"cfg_doubles", "0.1,0.2,0.3", "list<double>", "0.1,0.2,0.3", false},
+            {"cfg_int16s", "1,2,3", "list<int16>", "1,2,3", false},
+            {"cfg_int32s", "10,20,30", "list<int32>", "10,20,30", false},
+            {"cfg_int64s", "100,200,300", "list<int64>", "100,200,300", false},
+            {"cfg_strings", "s1,s2,s3", "list<string>", "s1,s2,s3", false},
     };
 
     std::vector<ConfigInfo> configs = config::list_configs();
@@ -148,7 +148,7 @@ TEST_F(ConfigTest, UpdateConfigs) {
     ASSERT_TRUE(cfg_bool_immutable);
     s = config::set_config("cfg_bool_immutable", "false");
     ASSERT_FALSE(s.ok());
-    ASSERT_EQ(s.to_string(), "Not supported: 'cfg_bool_immutable' is not support to modify");
+    ASSERT_EQ(s.to_string(), "Not supported: 'cfg_bool_immutable' is immutable");
     ASSERT_TRUE(cfg_bool_immutable);
 
     // convert error
@@ -171,7 +171,7 @@ TEST_F(ConfigTest, UpdateConfigs) {
     // not support
     s = config::set_config("cfg_std_string", "test");
     ASSERT_FALSE(s.ok());
-    ASSERT_EQ(s.to_string(), "Not supported: 'cfg_std_string' is not support to modify");
+    ASSERT_EQ(s.to_string(), "Not supported: 'cfg_std_string' is immutable");
     ASSERT_EQ(cfg_std_string, "starrocks_config_test_string");
 }
 

--- a/be/test/common/config_test.cpp
+++ b/be/test/common/config_test.cpp
@@ -59,9 +59,7 @@ TEST_F(ConfigTest, test_init) {
     CONF_String(cfg_string_env, "prefix/${ConfigTestEnv1}/suffix");
     CONF_Bool(cfg_bool_env, "false");
     // Invalid config file name
-    {
-        EXPECT_FALSE(config::init("/path/to/nonexist/file"));
-    }
+    { EXPECT_FALSE(config::init("/path/to/nonexist/file")); }
     // Invalid bool value
     {
         std::stringstream ss;
@@ -154,20 +152,20 @@ TEST_F(ConfigTest, test_unknown_config) {
     EXPECT_EQ(10, cfg_int32);
 }
 
-TEST_F(ConfigTest, test_empty_value) {
-    CONF_Int32(cfg_int32, "10");
+TEST_F(ConfigTest, test_empty_string_value) {
+    CONF_String(cfg_string, "10");
     std::stringstream ss;
-    ss << "cfg_int32 =\n";
+    ss << "cfg_string=\n";
     ASSERT_TRUE(config::init(ss));
-    EXPECT_EQ(10, cfg_int32);
+    EXPECT_EQ("", cfg_string);
 }
 
-TEST_F(ConfigTest, test_no_value) {
-    CONF_Int32(cfg_int32, "10");
+TEST_F(ConfigTest, test_no_string_value) {
+    CONF_String(cfg_string, "10");
     std::stringstream ss;
-    ss << "cfg_int32\n";
+    ss << "cfg_string\n";
     ASSERT_TRUE(config::init(ss));
-    EXPECT_EQ(10, cfg_int32);
+    EXPECT_EQ("", cfg_string);
 }
 
 TEST_F(ConfigTest, test_duplicate_assignment) {

--- a/be/test/common/config_test.cpp
+++ b/be/test/common/config_test.cpp
@@ -60,7 +60,7 @@ TEST_F(ConfigTest, test_init) {
     CONF_Bool(cfg_bool_env, "false");
     // Invalid config file name
     {
-        EXPECT_FALSE(config::init("/path/to/nonexist/file");
+        EXPECT_FALSE(config::init("/path/to/nonexist/file"));
     }
     // Invalid bool value
     {
@@ -363,19 +363,16 @@ TEST_F(ConfigTest, test_read_write_mutable_string_concurrently) {
 }
 
 TEST_F(ConfigTest, test_alias) {
-    CONF_Int16(cfg_int16, "2561");
-    CONF_mInt16(be_http_port, "8000");
-    CONF_Alias(be_http_port, webserver_port);
+    CONF_mInt16(cfg_int32, "8000");
+    CONF_Alias(cfg_int32, cfg_int32_alias);
 
     std::stringstream ss;
     ss << R"DEL(
-        doris_cfg_int16 = 54321
-        webserver_port = 8080
+        cfg_int32_alias = 8080
        )DEL";
 
     EXPECT_TRUE(config::init(ss));
-    EXPECT_EQ(54321, cfg_int16);
-    EXPECT_EQ(8080, be_http_port);
+    EXPECT_EQ(8080, cfg_int32);
 }
 
 } // namespace starrocks

--- a/be/test/common/config_test.cpp
+++ b/be/test/common/config_test.cpp
@@ -253,6 +253,26 @@ TEST_F(ConfigTest, test_list_configs) {
     }
 }
 
+TEST_F(ConfigTest, test_empty_list) {
+    CONF_Strings(cfg_strings, "");
+    CONF_Int32s(cfg_int32s, "");
+    ASSERT_TRUE(config::init(nullptr));
+    EXPECT_EQ(0, cfg_strings.size());
+    EXPECT_EQ(0, cfg_int32s.size());
+}
+
+TEST_F(ConfigTest, test_list_with_spaces) {
+    CONF_Strings(cfg_strings, "");
+    CONF_Int32s(cfg_int32s, "");
+    std::stringstream ss;
+    ss << R"(cfg_strings=,s1,,s2, s3,s4 
+             cfg_int32s=,10,, 12, 14 
+          )";
+    ASSERT_TRUE(config::init(ss));
+    EXPECT_THAT(cfg_strings, ElementsAre("s1", "s2", "s3", "s4"));
+    EXPECT_THAT(cfg_int32s, ElementsAre(10, 12, 14));
+}
+
 TEST_F(ConfigTest, test_set_config) {
     CONF_Bool(cfg_bool_immutable, "true");
     CONF_mBool(cfg_bool, "false");

--- a/be/test/common/config_test.cpp
+++ b/be/test/common/config_test.cpp
@@ -380,13 +380,58 @@ TEST_F(ConfigTest, test_read_write_mutable_string_concurrently) {
     }
 }
 
-TEST_F(ConfigTest, test_alias) {
+TEST_F(ConfigTest, test_alias01) {
     CONF_mInt16(cfg_int32, "8000");
     CONF_Alias(cfg_int32, cfg_int32_alias);
 
     std::stringstream ss;
     ss << R"DEL(
         cfg_int32_alias = 8080
+       )DEL";
+
+    EXPECT_TRUE(config::init(ss));
+    EXPECT_EQ(8080, cfg_int32);
+}
+
+TEST_F(ConfigTest, test_alias02) {
+    CONF_mInt16(cfg_int32, "8000");
+    CONF_Alias(cfg_int32, cfg_int32_alias);
+
+    std::stringstream ss;
+    ss << R"DEL(
+        cfg_int32_alias = 8080
+        cfg_int32 = 8001
+       )DEL";
+
+    EXPECT_TRUE(config::init(ss));
+    EXPECT_EQ(8001, cfg_int32);
+}
+
+TEST_F(ConfigTest, test_alias03) {
+    CONF_mInt16(cfg_int32, "8000");
+    CONF_Alias(cfg_int32, cfg_int32_alias1);
+    CONF_Alias(cfg_int32, cfg_int32_alias2);
+
+    std::stringstream ss;
+    ss << R"DEL(
+        cfg_int32_alias1 = 8080
+        cfg_int32_alias2 = 8090
+       )DEL";
+
+    EXPECT_TRUE(config::init(ss));
+    EXPECT_EQ(8090, cfg_int32);
+}
+
+TEST_F(ConfigTest, test_alias04) {
+    CONF_mInt16(cfg_int32, "8000");
+    CONF_Alias(cfg_int32, cfg_int32_alias1);
+    CONF_Alias(cfg_int32, cfg_int32_alias2);
+
+    // Different assgnment order from test_alias03
+    std::stringstream ss;
+    ss << R"DEL(
+        cfg_int32_alias2 = 8090
+        cfg_int32_alias1 = 8080
        )DEL";
 
     EXPECT_TRUE(config::init(ss));

--- a/conf/be_test.conf
+++ b/conf/be_test.conf
@@ -1,16 +1,15 @@
-// Copyright 2021-present StarRocks, Inc. All rights reserved.
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     https://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+# Copyright 2021-present StarRocks, Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 # INFO, WARNING, ERROR, FATAL
 sys_log_level = INFO


### PR DESCRIPTION
## Why I'm doing:
There are misnamed configurations in StarRocks, such as missing correct prefixes, misspellings, or module names that have been changed. If the configuration name is changed directly, this can lead to compatibility issues.

This can be solved by introducing an aliasing mechanism.

## What I'm doing:
1. support for setting configuration item aliases: `CONF_Alias(real_name, alias_name)`
2. output a warning message if duplicate configuration item assignments are encountered
3. output a warning message if an unknown configuration item is encountered
4. decouple the type name shown in the system table `be_configs` from the C++ type name, and use "bool, int32,int64,string,list<bool/itn32/int64/string>" to represent the type name, instead of "bool, int32_t, int64_t, std::string, MutableString, std::vector<bool/int32_t/int64_t/std::string>"
5. use type erasure technique to store configuration information of different types and realize polymorphism, replace the original way of determining type information by type name, so that the code can be more extensible and more readable
6. remove some duplicate code
7. more unit tests

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [x] 3.1
  - [x] 3.0
  - [x] 2.5
