### PR TITLE
[BugFix] Fix drop normal table failed when table has synchronized mv

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/alter/SchemaChangeHandler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/SchemaChangeHandler.java
@@ -1255,38 +1255,10 @@ public class SchemaChangeHandler extends AlterHandler {
             }
 
             // 3. check partition key
-            List<Column> partitionColumns = olapTable.getPartitionInfo().getPartitionColumns();
-            for (Column partitionCol : partitionColumns) {
-                String colName = partitionCol.getName();
-                Optional<Column> col = alterSchema.stream().filter(c -> c.nameEquals(colName, true)).findFirst();
-                if (col.isPresent() && !col.get().equals(partitionCol)) {
-                    throw new DdlException("Can not modify partition column[" + colName + "]. index["
-                            + olapTable.getIndexNameById(alterIndexId) + "]");
-                }
-                if (col.isEmpty() && alterIndexId == olapTable.getBaseIndexId()) {
-                    // 2.1 partition column cannot be deleted.
-                    throw new DdlException("Partition column[" + partitionCol.getName()
-                            + "] cannot be dropped. index[" + olapTable.getIndexNameById(alterIndexId) + "]");
-                    // ATTN. partition columns' order also need remaining unchanged.
-                    // for now, we only allow one partition column, so no need to check order.
-                }
-            } // end for partitionColumns
+            checkPartitionColumnChange(olapTable, alterSchema, alterIndexId);
 
             // 4. check distribution key:
-            List<Column> distributionColumns = olapTable.getDefaultDistributionInfo().getDistributionColumns();
-            for (Column distributionCol : distributionColumns) {
-                String colName = distributionCol.getName();
-                Optional<Column> col = alterSchema.stream().filter(c -> c.nameEquals(colName, true)).findFirst();
-                if (col.isPresent() && !col.get().equals(distributionCol)) {
-                    throw new DdlException("Can not modify distribution column[" + colName + "]. index["
-                            + olapTable.getIndexNameById(alterIndexId) + "]");
-                }
-                if (col.isEmpty() && alterIndexId == olapTable.getBaseIndexId()) {
-                    // 2.2 distribution column cannot be deleted.
-                    throw new DdlException("Distribution column[" + distributionCol.getName()
-                            + "] cannot be dropped. index[" + olapTable.getIndexNameById(alterIndexId) + "]");
-                }
-            } // end for distributionCols
+            checkDistributionColumnChange(olapTable, alterSchema, alterIndexId);
 
             // 5. calc short key
             List<Integer> sortKeyIdxes = new ArrayList<>();
@@ -1332,6 +1304,58 @@ public class SchemaChangeHandler extends AlterHandler {
         } // end for indices
 
         return dataBuilder.build();
+    }
+
+    private void checkPartitionColumnChange(OlapTable olapTable, List<Column> alterSchema, long alterIndexId)
+            throws DdlException {
+        // Since partition key and distribution key's schema change can only happen in base index,
+        // only check it in base index.There may be some trivial changes between base index and other
+        // indices(eg: AggregateType), so check it in base index.
+        if (alterIndexId != olapTable.getBaseIndexId()) {
+            return;
+        }
+
+        List<Column> partitionColumns = olapTable.getPartitionInfo().getPartitionColumns();
+        for (Column partitionCol : partitionColumns) {
+            String colName = partitionCol.getName();
+            Optional<Column> col = alterSchema.stream().filter(c -> c.nameEquals(colName, true)).findFirst();
+            if (col.isPresent() && !col.get().equals(partitionCol)) {
+                throw new DdlException("Can not modify partition column[" + colName + "]. index["
+                        + olapTable.getIndexNameById(alterIndexId) + "]");
+            }
+            if (col.isEmpty() && alterIndexId == olapTable.getBaseIndexId()) {
+                // 2.1 partition column cannot be deleted.
+                throw new DdlException("Partition column[" + partitionCol.getName()
+                        + "] cannot be dropped. index[" + olapTable.getIndexNameById(alterIndexId) + "]");
+                // ATTN. partition columns' order also need remaining unchanged.
+                // for now, we only allow one partition column, so no need to check order.
+            }
+        } // end for partitionColumns
+    }
+
+    private void checkDistributionColumnChange(OlapTable olapTable, List<Column> alterSchema, long alterIndexId)
+            throws DdlException {
+        // Since partition key and distribution key's schema change can only happen in base index,
+        // only check it in base index.There may be some trivial changes between base index and other
+        // indices(eg: AggregateType), so check it in base index.
+        if (alterIndexId != olapTable.getBaseIndexId()) {
+            return;
+        }
+
+        List<Column> distributionColumns = olapTable.getDefaultDistributionInfo().getDistributionColumns();
+        for (Column distributionCol : distributionColumns) {
+            String colName = distributionCol.getName();
+            Optional<Column> col = alterSchema.stream().filter(c -> c.nameEquals(colName, true)).findFirst();
+            if (col.isPresent() && !col.get().equals(distributionCol)) {
+                throw new DdlException("Can not modify distribution column[" + colName + "]. index["
+                        + olapTable.getIndexNameById(alterIndexId) + "]");
+            }
+            if (col.isEmpty() && alterIndexId == olapTable.getBaseIndexId()) {
+                // 2.2 distribution column cannot be deleted.
+                throw new DdlException("Distribution column[" + distributionCol.getName()
+                        + "] cannot be dropped. index[" + olapTable.getIndexNameById(alterIndexId) + "]");
+            }
+        } // end for distributionCols
     }
 
     private AlterJobV2 createJobForProcessModifySortKeyColumn(long dbId, OlapTable olapTable,

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/CreateMaterializedViewStmt.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/CreateMaterializedViewStmt.java
@@ -640,6 +640,7 @@ public class CreateMaterializedViewStmt extends DdlStmt {
             if (mvColumnItem.getAggregationType() != null) {
                 break;
             }
+            // NOTE: Change aggregate type of the column to none rather than null
             mvColumnItem.setAggregationType(AggregateType.NONE, true);
         }
     }
@@ -709,6 +710,7 @@ public class CreateMaterializedViewStmt extends DdlStmt {
             // supply value
             for (; theBeginIndexOfValue < mvColumnItemList.size(); theBeginIndexOfValue++) {
                 MVColumnItem mvColumnItem = mvColumnItemList.get(theBeginIndexOfValue);
+                // NOTE: Change aggregate type of the column to none rather than null
                 mvColumnItem.setAggregationType(AggregateType.NONE, true);
             }
         }

--- a/test/sql/test_schema_change/R/test_schema_change_with_sync_mv
+++ b/test/sql/test_schema_change/R/test_schema_change_with_sync_mv
@@ -1,0 +1,123 @@
+-- name: test_schema_change_with_sync_mv
+CREATE TABLE IF NOT EXISTS t1
+(
+    `id` bigint(20) NULL,
+    `k2` datetime NULL,
+    `k3` varchar(32),
+    `k4` int(11) NULL,
+    `k5` bigint(20),
+    `k6` double NULL,
+    `k7` varchar(255) NULL
+    ) ENGINE = OLAP
+    DUPLICATE KEY(id, k2, k3)
+    PARTITION BY RANGE(k2)(
+    START ("2022-04-17") END ("2022-05-01") EVERY (INTERVAL 1 day))
+    DISTRIBUTED BY HASH(id)
+    PROPERTIES
+(
+    "replication_num" = "1",
+    "dynamic_partition.enable" = "true",
+    "dynamic_partition.time_unit" = "DAY",
+    "dynamic_partition.end" = "2",
+    "dynamic_partition.prefix" = "p"
+);
+-- result:
+-- !result
+INSERT INTO t1 values(1, '2022-04-17 00:00:00', 'k3', 1, 1, 1.0, 'k7'), (2, '2022-04-20 00:00:00', 'k4', 1, 1, 1.0, 'k7');
+-- result:
+-- !result
+CREATE MATERIALIZED VIEW mv_t1 AS
+SELECT k2,k3,id,k4,k5,k6,k7 FROM t1 ORDER BY k2,k3,id;
+-- result:
+-- !result
+function: wait_materialized_view_finish()
+-- result:
+None
+-- !result
+                 
+alter table t1 drop column id;
+-- result:
+E: (1064, 'Distribution column[id] cannot be dropped. index[t1]')
+-- !result
+function: wait_alter_table_finish()
+-- result:
+
+-- !result
+select * from t1 order by id;
+-- result:
+1	2022-04-17 00:00:00	k3	1	1	1.0	k7
+2	2022-04-20 00:00:00	k4	1	1	1.0	k7
+-- !result
+alter table t1 drop column k2;
+-- result:
+E: (1064, 'Partition column[k2] cannot be dropped. index[t1]')
+-- !result
+function: wait_alter_table_finish()
+-- result:
+
+-- !result
+select * from t1 order by id;
+-- result:
+1	2022-04-17 00:00:00	k3	1	1	1.0	k7
+2	2022-04-20 00:00:00	k4	1	1	1.0	k7
+-- !result
+alter table t1 drop column k3;
+-- result:
+-- !result
+function: wait_alter_table_finish()
+-- result:
+None
+-- !result
+select * from t1 order by id;
+-- result:
+1	2022-04-17 00:00:00	1	1	1.0	k7
+2	2022-04-20 00:00:00	1	1	1.0	k7
+-- !result
+alter table t1 drop column k4;
+-- result:
+-- !result
+function: wait_alter_table_finish()
+-- result:
+None
+-- !result
+select * from t1 order by id;
+-- result:
+1	2022-04-17 00:00:00	1	1.0	k7
+2	2022-04-20 00:00:00	1	1.0	k7
+-- !result
+alter table t1 drop column k5;
+-- result:
+-- !result
+function: wait_alter_table_finish()
+-- result:
+None
+-- !result
+select * from t1 order by id;
+-- result:
+1	2022-04-17 00:00:00	1.0	k7
+2	2022-04-20 00:00:00	1.0	k7
+-- !result
+alter table t1 drop column k6;
+-- result:
+-- !result
+function: wait_alter_table_finish()
+-- result:
+None
+-- !result
+select * from t1 order by id;
+-- result:
+1	2022-04-17 00:00:00	k7
+2	2022-04-20 00:00:00	k7
+-- !result
+alter table t1 drop column k7;
+-- result:
+-- !result
+function: wait_alter_table_finish()
+-- result:
+None
+-- !result
+select * from t1 order by id;
+-- result:
+1	2022-04-17 00:00:00
+2	2022-04-20 00:00:00
+-- !result

--- a/test/sql/test_schema_change/T/test_schema_change_with_sync_mv
+++ b/test/sql/test_schema_change/T/test_schema_change_with_sync_mv
@@ -1,0 +1,56 @@
+-- name: test_schema_change_with_sync_mv
+CREATE TABLE IF NOT EXISTS t1
+(
+    `id` bigint(20) NULL,
+    `k2` datetime NULL,
+    `k3` varchar(32),
+    `k4` int(11) NULL,
+    `k5` bigint(20),
+    `k6` double NULL,
+    `k7` varchar(255) NULL
+    ) ENGINE = OLAP
+    DUPLICATE KEY(id, k2, k3)
+    PARTITION BY RANGE(k2)(
+    START ("2022-04-17") END ("2022-05-01") EVERY (INTERVAL 1 day))
+    DISTRIBUTED BY HASH(id)
+    PROPERTIES
+(
+    "replication_num" = "1",
+    "dynamic_partition.enable" = "true",
+    "dynamic_partition.time_unit" = "DAY",
+    "dynamic_partition.end" = "2",
+    "dynamic_partition.prefix" = "p"
+);
+INSERT INTO t1 values(1, '2022-04-17 00:00:00', 'k3', 1, 1, 1.0, 'k7'), (2, '2022-04-20 00:00:00', 'k4', 1, 1, 1.0, 'k7');
+
+CREATE MATERIALIZED VIEW mv_t1 AS
+SELECT k2,k3,id,k4,k5,k6,k7 FROM t1 ORDER BY k2,k3,id;
+function: wait_materialized_view_finish()
+                 
+alter table t1 drop column id;
+function: wait_alter_table_finish()
+select * from t1 order by id;
+
+alter table t1 drop column k2;
+function: wait_alter_table_finish()
+select * from t1 order by id;
+
+alter table t1 drop column k3;
+function: wait_alter_table_finish()
+select * from t1 order by id;
+
+alter table t1 drop column k4;
+function: wait_alter_table_finish()
+select * from t1 order by id;
+
+alter table t1 drop column k5;
+function: wait_alter_table_finish()
+select * from t1 order by id;
+
+alter table t1 drop column k6;
+function: wait_alter_table_finish()
+select * from t1 order by id;
+
+alter table t1 drop column k7;
+function: wait_alter_table_finish()
+select * from t1 order by id;


### PR DESCRIPTION
## Why I'm doing:
- drop column will be failed if the table contains synchronized mv even if the column is not distribution key or partition key.

## What I'm doing:
- Since partition key and distribution key's schema change can only happen in base index, only check it in base index.There may be some trivial changes between base index and other indices(eg: AggregateType), so check it in base index.

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
