### PR TITLE
[BugFix] Fix metrics of meta_log_count wrong bug on share-data mode

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/http/meta/MetaService.java
+++ b/fe/fe-core/src/main/java/com/starrocks/http/meta/MetaService.java
@@ -176,6 +176,7 @@ public class MetaService {
         private static final String VERSION = "version";
         private static final String PORT = "port";
         private static final String SUBDIR = "subdir";
+        private static final String FOR_GLOBAL_STATE = "for_global_state";
 
         public PutAction(ActionController controller, File imageDir) {
             super(controller, imageDir);
@@ -260,8 +261,8 @@ public class MetaService {
                 return;
             }
 
-            // When subDirStr is empty, image belongs to LocalMetaStore and others belong to staros.
-            if (Strings.isNullOrEmpty(subDirStr)) {
+            String forGlobalState = request.getSingleParameter(FOR_GLOBAL_STATE);
+            if (Strings.isNullOrEmpty(forGlobalState) || "true".equals(forGlobalState)) {
                 GlobalStateMgr.getCurrentState().setImageJournalId(version);
             }
 

--- a/fe/fe-core/src/main/java/com/starrocks/http/meta/MetaService.java
+++ b/fe/fe-core/src/main/java/com/starrocks/http/meta/MetaService.java
@@ -260,7 +260,10 @@ public class MetaService {
                 return;
             }
 
-            GlobalStateMgr.getCurrentState().setImageJournalId(version);
+            // When subDirStr is empty, image belongs to LocalMetaStore and others belong to staros.
+            if (Strings.isNullOrEmpty(subDirStr)) {
+                GlobalStateMgr.getCurrentState().setImageJournalId(version);
+            }
 
             // Delete old image files
             MetaCleaner cleaner = new MetaCleaner(realDir);

--- a/fe/fe-core/src/main/java/com/starrocks/leader/Checkpoint.java
+++ b/fe/fe-core/src/main/java/com/starrocks/leader/Checkpoint.java
@@ -169,7 +169,8 @@ public class Checkpoint extends FrontendDaemon {
             }
 
             String url = "http://" + NetUtils.getHostPortInAccessibleFormat(frontend.getHost(), Config.http_port)
-                    + "/put?version=" + imageVersion + "&port=" + Config.http_port + "&subdir=" + subDir;
+                    + "/put?version=" + imageVersion + "&port=" + Config.http_port + "&subdir=" + subDir
+                    + "&for_global_state=" + belongToGlobalStateMgr;
             try {
                 MetaHelper.getRemoteFile(url, PUT_TIMEOUT_SECOND * 1000, new NullOutputStream());
                 successPushedCnt++;


### PR DESCRIPTION
## Why I'm doing:
The metric of `meta_log_count` is the count of logs for which checkpoint has not been completed and is the result of `max_journal_id - image_journal_id`. But in shared data mode, there is another image in staros, which causes image_journal_id to be set to the value of the staros image journal id when executing staros checkpoint.

## What I'm doing:
Only update the image_journal_id when doing local metastore checkpoint.

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [x] 3.1
  - [ ] 3.0
  - [ ] 2.5
