### PR TITLE
[Enhancement] support if/ifnull/nullif compare struct type with null

### DIFF
--- a/gensrc/script/functions.py
+++ b/gensrc/script/functions.py
@@ -526,6 +526,8 @@ vectorized_functions = [
     [70116, 'if', 'ANY_ARRAY', ['BOOLEAN', 'ANY_ARRAY', 'ANY_ARRAY'], 'nullptr'],
     [70117, 'if', 'ANY_MAP', ['BOOLEAN', 'ANY_MAP', 'ANY_MAP'], 'nullptr'],
     [70118, 'if', 'ANY_STRUCT', ['BOOLEAN', 'ANY_STRUCT', 'ANY_STRUCT'], 'nullptr'],
+    [701180, 'if', 'ANY_STRUCT', ['BOOLEAN', 'ANY_STRUCT', 'NULL'], 'nullptr'],
+    [701181, 'if', 'ANY_STRUCT', ['BOOLEAN', 'NULL', 'ANY_STRUCT'], 'nullptr'],
     [70119, 'if', 'JSON', ['BOOLEAN', 'JSON', 'JSON'], 'nullptr'],
 
 
@@ -551,6 +553,8 @@ vectorized_functions = [
     [70216, 'ifnull', 'ANY_ARRAY', ['ANY_ARRAY', 'ANY_ARRAY'], 'nullptr'],
     [70217, 'ifnull', 'ANY_MAP', ['ANY_MAP', 'ANY_MAP'], 'nullptr'],
     [70218, 'ifnull', 'ANY_STRUCT', ['ANY_STRUCT', 'ANY_STRUCT'], 'nullptr'],
+    [702180, 'ifnull', 'ANY_STRUCT', ['ANY_STRUCT', 'NULL'], 'nullptr'],
+    [702181, 'ifnull', 'ANY_STRUCT', ['NULL', 'ANY_STRUCT'], 'nullptr'],
     [70219, 'ifnull', 'JSON', ['JSON', 'JSON'], 'nullptr'],
 
     [70300, 'nullif', 'BOOLEAN', ['BOOLEAN', 'BOOLEAN'], 'nullptr'],
@@ -575,6 +579,8 @@ vectorized_functions = [
     [70316, 'nullif', 'ANY_ARRAY', ['ANY_ARRAY', 'ANY_ARRAY'], 'nullptr'],
     [70317, 'nullif', 'ANY_MAP', ['ANY_MAP', 'ANY_MAP'], 'nullptr'],
     [70318, 'nullif', 'ANY_STRUCT', ['ANY_STRUCT', 'ANY_STRUCT'], 'nullptr'],
+    [703180, 'nullif', 'ANY_STRUCT', ['ANY_STRUCT', 'NULL'], 'nullptr'],
+    [703181, 'nullif', 'ANY_STRUCT', ['NULL', 'ANY_STRUCT'], 'nullptr'],
     [70319, 'nullif', 'JSON', ['JSON', 'JSON'], 'nullptr'],
 
     [70400, 'coalesce', 'BOOLEAN', ['BOOLEAN', '...'], 'nullptr'],

--- a/test/sql/test_function/R/test_conditional_fn
+++ b/test/sql/test_function/R/test_conditional_fn
@@ -1,17 +1,17 @@
 -- name: test conditional functions: coalesce, case...when.., if, ifnull, nullif on nested types
-CREATE TABLE `tc` (   `i` int(11) NULL COMMENT "",   `ai` array<int(11)> NULL COMMENT "",   `ass` array<varchar(100)> NULL COMMENT "",   `mi` map<int(11),int> NULL COMMENT "",   `ms` map<int(11),varchar(100)> NULL COMMENT "" ) ENGINE=OLAP DUPLICATE KEY(`i`) COMMENT "OLAP" DISTRIBUTED BY HASH(`i`) BUCKETS 2 PROPERTIES ( "replication_num" = "1" );
+CREATE TABLE `tc` (   `i` int(11) NULL COMMENT "",   `ai` array<int(11)> NULL COMMENT "",   `ass` array<varchar(100)> NULL COMMENT "",   `mi` map<int(11),int> NULL COMMENT "",   `ms` map<int(11),varchar(100)> NULL COMMENT "",   `sis` struct<col1 int(11),col2 varchar(100)> NULL COMMENT "",   `ssi` struct<col1 varchar(100),col2 int(11)> NULL COMMENT "" ) ENGINE=OLAP DUPLICATE KEY(`i`) COMMENT "OLAP" DISTRIBUTED BY HASH(`i`) BUCKETS 2 PROPERTIES ( "replication_num" = "1" );
 -- result:
 -- !result
-insert into tc values (4, null,null, null,null);
+insert into tc values (4, null,null, null,null, null,null);
 -- result:
 -- !result
-insert into tc values (3, null,['a','b'], null,map{1:null,null:null});
+insert into tc values (3, null,['a','b'], null,map{1:null,null:null}, null,struct('a',1));
 -- result:
 -- !result
-insert into tc values (1, [1,2],null, map{1:1,null:2},null);
+insert into tc values (1, [1,2],null, map{1:1,null:2},null, struct(1,'a'),null);
 -- result:
 -- !result
-insert into tc values (2, [1,2],['a','b'], map{1:1,null:2},map{1:'b',null:null});
+insert into tc values (2, [1,2],['a','b'], map{1:1,null:2},map{1:'b',null:null}, struct(1,'a'),struct('a',1));
 -- result:
 -- !result
 select case i when 1 then ai when 3 then ass else ai end from tc order by i;
@@ -112,6 +112,27 @@ select ifnull(ai, null) from tc order by i;
 None
 None
 -- !result
+select ifnull(sss, sii), sss,sii from tc order by i;
+-- result:
+{"col1":"1","col2":"2"}	None    {"col1":"1","col2":"2"}
+{"col1":"a","col2":"b"} {"col1":"a","col2":"b"} None
+{"col1":"a","col2":"b"} None    None
+None    None    None
+-- !result
+select ifnull(null, sii), null,sii from tc order by i;
+-- result:
+{"col1":1,"col2":2} None    {"col1":1,"col2":2}
+{"col1":1,"col2":2} None    {"col1":1,"col2":2}
+None    None    None
+None    None    None
+-- !result
+select ifnull(sii, null), sii,null from tc order by i;
+-- result:
+{"col1":1,"col2":2} {"col1":1,"col2":2} None
+{"col1":1,"col2":2} {"col1":1,"col2":2} None
+None    None    None
+None    None    None
+-- !result
 select if(i>2, ms, mi) from tc order by i;
 -- result:
 {null:"2",1:"1"}
@@ -126,10 +147,31 @@ select if(i>2, ass, ai) from tc order by i;
 ["a","b"]
 None
 -- !result
+select if(i>2, sss, sii) from tc order by i;
+-- result:
+{"col1":"1","col2":"2"}
+{"col1":"a","col2":"b"}
+{"col1":"a","col2":"b"}
+None
+-- !result
 select if(ai is not null, map_from_arrays(['a', 'b'], [1, 2]), null) from tc order by i;
 -- result:
 {"a":1,"b":2}
 {"a":1,"b":2}
+None
+None
+-- !result
+select if(ai is not null, sii, null) from tc order by i;
+-- result:
+{"col1":1,"col2":2}
+{"col1":1,"col2":2}
+None
+None
+-- !result
+select if(ai is not null, null, sii) from tc order by i;
+-- result:
+None
+None
 None
 None
 -- !result
@@ -145,5 +187,26 @@ select nullif(ai, ass), ai, ass from tc order by i;
 ["1","2"]	[1,2]	None
 ["1","2"]	[1,2]	["a","b"]
 None	None	["a","b"]
+None	None	None
+-- !result
+select nullif(sii, sss), sii, sss from tc order by i;
+-- result:
+{"col1":"1","col2":"2"}	{"col1":1,"col2":2}	None
+{"col1":"1","col2":"2"}	{"col1":1,"col2":2}	{"col1":"a","col2":"b"}
+None	None	{"col1":"a","col2":"b"}
+None	None	None
+-- !result
+select nullif(null, sii), null, sii from tc order by i;
+-- result:
+None	None	{"col1":1,"col2":2}
+None	None	{"col1":1,"col2":2}
+None	None	None
+None	None	None
+-- !result
+select nullif(sii, null), sii, null from tc order by i;
+-- result:
+{"col1":1,"col2":2}	{"col1":1,"col2":2}	None
+{"col1":1,"col2":2}	{"col1":1,"col2":2}	None
+None	None	None
 None	None	None
 -- !result

--- a/test/sql/test_function/T/test_conditional_fn
+++ b/test/sql/test_function/T/test_conditional_fn
@@ -1,11 +1,11 @@
 -- name: test conditional functions: coalesce, case...when.., if, ifnull, nullif on nested types
 
-CREATE TABLE `tc` (   `i` int(11) NULL COMMENT "",   `ai` array<int(11)> NULL COMMENT "",   `ass` array<varchar(100)> NULL COMMENT "",   `mi` map<int(11),int> NULL COMMENT "",   `ms` map<int(11),varchar(100)> NULL COMMENT "" ) ENGINE=OLAP DUPLICATE KEY(`i`) COMMENT "OLAP" DISTRIBUTED BY HASH(`i`) BUCKETS 2 PROPERTIES ( "replication_num" = "1" );
+CREATE TABLE `tc` (   `i` int(11) NULL COMMENT "",   `ai` array<int(11)> NULL COMMENT "",   `ass` array<varchar(100)> NULL COMMENT "",   `mi` map<int(11),int> NULL COMMENT "",   `ms` map<int(11),varchar(100)> NULL COMMENT "",   `sii` struct<col1 int(11),col2 int(11)> NULL COMMENT "",   `sss` struct<col1 varchar(100),col2 varchar(100)> NULL COMMENT "" ) ENGINE=OLAP DUPLICATE KEY(`i`) COMMENT "OLAP" DISTRIBUTED BY HASH(`i`) BUCKETS 2 PROPERTIES ( "replication_num" = "1" );
 
-insert into tc values (4, null,null, null,null);
-insert into tc values (3, null,['a','b'], null,map{1:null,null:null});
-insert into tc values (1, [1,2],null, map{1:1,null:2},null);
-insert into tc values (2, [1,2],['a','b'], map{1:1,null:2},map{1:'b',null:null});
+insert into tc values (4, null,null, null,null, null,null);
+insert into tc values (3, null,['a','b'], null,map{1:null,null:null}, null,struct('a','b'));
+insert into tc values (1, [1,2],null, map{1:1,null:2},null, struct(1,2),null);
+insert into tc values (2, [1,2],['a','b'], map{1:1,null:2},map{1:'b',null:null}, struct(1,2),struct('a','b'));
 
 
 select case i when 1 then ai when 3 then ass else ai end from tc order by i;
@@ -28,11 +28,19 @@ select coalesce(null,ms, mi) from tc order by i;
 
 select ifnull(ms, mi), ms,mi from tc order by i;
 select ifnull(ass, ai), ass,ai from tc order by i;
-select ifnull(ai, null) from tc order by i;
+select ifnull(sss, sii), sss,sii from tc order by i;
+select ifnull(null, sii), null,sii from tc order by i;
+select ifnull(sii, null), sii,null from tc order by i;
 
 select if(i>2, ms, mi) from tc order by i;
 select if(i>2, ass, ai) from tc order by i;
+select if(i>2, sss, sii) from tc order by i;
 select if(ai is not null, map_from_arrays(['a', 'b'], [1, 2]), null) from tc order by i;
+select if(ai is not null, sii, null) from tc order by i;
+select if(ai is not null, null, sii) from tc order by i;
 
 select nullif(ms, mi), ms,mi from tc order by i;
 select nullif(ai, ass), ai, ass from tc order by i;
+select nullif(sii, sss), sii, sss from tc order by i;
+select nullif(null, sii), null, sii from tc order by i;
+select nullif(sii, null), sii, null from tc order by i;


### PR DESCRIPTION
## Why I'm doing:
Current if/ifnull/nullif condition exprs cannot make comparison on struct type with null type, as it may causes the following error during polymorphic function analyzing.
`MySQL [(none)]> select nullif(null, (1,2));`
`ERROR 1064 (HY000): Getting analyzing error. Detail message: types struct<col1 boolean> and struct<col1 tinyint(4), col2 tinyint(4)> cannot be matched.`

Note that struct<col1 tinyint(4)> currently is not affected, only those struct types with more than 1 col will throw this error.
## What I'm doing:
Adding functions with specific null type and struct type to avoid polymorphic function analyzing.

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
- [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [x] 3.1
  - [x] 3.0
  - [ ] 2.5
