### PR TITLE
[BugFix] Add the missing closure ref count in multi_get (#42005)

### DIFF
--- a/be/src/storage/table_reader.cpp
+++ b/be/src/storage/table_reader.cpp
@@ -259,6 +259,8 @@ Status TableReader::_tablet_multi_get_rpc(PInternalService_Stub* stub, int64_t t
             closure = nullptr;
         }
     });
+    // ref count for next rpc call
+    closure->ref();
     if (_params->timeout_ms > 0) {
         closure->cntl.set_timeout_ms(_params->timeout_ms);
     }


### PR DESCRIPTION
## Why I'm doing:
multi_get function is used to get the corresponding value for the given key value in some primary key tablets. If the tablet is not local, be will call a rpc to get the value from the remote node.
The problem is closure->ref() is miss before call the rpc. When the rpc has finished, --closure->_ref.
It will be deleted in this case, because the ref count = 0. So we will get many unpredictable BE crash because use after free problem.

## What I'm doing:
Add an additional closure->ref() before call rpc.

Fixes #42005

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
