### PR TITLE
[BugFix] Fix show load npe

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/load/loadv2/LoadMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/loadv2/LoadMgr.java
@@ -567,13 +567,13 @@ public class LoadMgr implements Writable, MemoryTrackable {
     }
 
     public List<LoadJob> getLoadJobsByDb(long dbId, String labelValue, boolean accurateMatch) {
-
         List<LoadJob> loadJobList = Lists.newArrayList();
-        if (dbId != -1 && !dbIdToLabelToLoadJobs.containsKey(dbId)) {
-            return loadJobList;
-        }
         readLock();
         try {
+            if (dbId != -1 && !dbIdToLabelToLoadJobs.containsKey(dbId)) {
+                return loadJobList;
+            }
+
             for (Map<String, List<LoadJob>> dbJobs : dbIdToLabelToLoadJobs.values()) {
                 Map<String, List<LoadJob>> labelToLoadJobs = dbId == -1 ? dbJobs : dbIdToLabelToLoadJobs.get(dbId);
 

--- a/fe/fe-core/src/test/java/com/starrocks/load/loadv2/LoadMgrTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/load/loadv2/LoadMgrTest.java
@@ -37,6 +37,7 @@ package com.starrocks.load.loadv2;
 import com.starrocks.catalog.Database;
 import com.starrocks.catalog.Table;
 import com.starrocks.common.Config;
+import com.starrocks.common.MetaNotFoundException;
 import com.starrocks.common.jmockit.Deencapsulation;
 import com.starrocks.meta.MetaContext;
 import com.starrocks.persist.metablock.SRMetaBlockReader;
@@ -58,7 +59,7 @@ import java.io.FileOutputStream;
 import java.util.List;
 import java.util.Map;
 
-public class LoadManagerTest {
+public class LoadMgrTest {
     private LoadMgr loadManager;
     private final String fieldName = "idToLoadJob";
 
@@ -348,5 +349,14 @@ public class LoadManagerTest {
         Map<Long, LoadJob> idToLoadJob = Deencapsulation.getField(loadManager2, "idToLoadJob");
 
         Assert.assertEquals(3, idToLoadJob.size());
+    }
+
+    @Test
+    public void testGetLoadJobsByDb(@Mocked GlobalStateMgr globalStateMgr) throws MetaNotFoundException {
+        LoadMgr loadMgr = new LoadMgr(new LoadJobScheduler());
+        LoadJob job1 = new InsertLoadJob("job1", 1L, 1L, System.currentTimeMillis(), "", "");
+        Deencapsulation.invoke(loadMgr, "addLoadJob", job1);
+        Assert.assertTrue(loadMgr.getLoadJobsByDb(2L, "job1", true).isEmpty());
+        Assert.assertEquals(1, loadMgr.getLoadJobsByDb(1L, "job1", true).size());
     }
 }


### PR DESCRIPTION
labelToLoadJobs may be removed by LoadLabelCleaner, so should check db exist in dbIdToLabelToLoadJobs in read lock when getting load jobs by db

## Why I'm doing:

## What I'm doing:

Fixes https://github.com/StarRocks/StarRocksTest/issues/6336

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [x] 3.1
  - [x] 3.0
  - [ ] 2.5
