### PR TITLE
[Enhancement] Replace_if_not_null support bitmap type

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/AggregateType.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/AggregateType.java
@@ -112,7 +112,6 @@ public enum AggregateType {
 
         // all types except bitmap, hll, percentile and complex types.
         EnumSet<PrimitiveType> excObject = EnumSet.allOf(PrimitiveType.class);
-        excObject.remove(PrimitiveType.BITMAP);
         excObject.remove(PrimitiveType.HLL);
         excObject.remove(PrimitiveType.PERCENTILE);
         excObject.remove(PrimitiveType.INVALID_TYPE);

--- a/test/sql/test_bitmap_functions/R/test_bitmap_replace_if_not_null
+++ b/test/sql/test_bitmap_functions/R/test_bitmap_replace_if_not_null
@@ -1,0 +1,34 @@
+-- name: test_bitmap_replace_if_not_null
+CREATE TABLE `t1` (
+  `c1` int(11) NULL COMMENT "",
+  `c2` bitmap REPLACE_IF_NOT_NULL NULL COMMENT ""
+) ENGINE=OLAP
+AGGREGATE KEY(`c1`)
+DISTRIBUTED BY HASH(`c1`) BUCKETS 1
+PROPERTIES ("replication_num" = "1");
+-- result:
+-- !result
+insert into t1 values (1, bitmap_from_string("1,2,3")), (2, bitmap_from_string("4,5,6"));
+-- result:
+-- !result
+select c1, bitmap_to_string(c2) from t1 order by c1;
+-- result:
+1	1,2,3
+2	4,5,6
+-- !result
+insert into t1 values (1, null);
+-- result:
+-- !result
+select c1, bitmap_to_string(c2) from t1 order by c1;
+-- result:
+1	1,2,3
+2	4,5,6
+-- !result
+insert into t1 values (1, bitmap_from_string("7,8,9"));
+-- result:
+-- !result
+select c1, bitmap_to_string(c2) from t1 order by c1;
+-- result:
+1	7,8,9
+2	4,5,6
+-- !result

--- a/test/sql/test_bitmap_functions/T/test_bitmap_replace_if_not_null
+++ b/test/sql/test_bitmap_functions/T/test_bitmap_replace_if_not_null
@@ -1,0 +1,15 @@
+-- name: test_bitmap_replace_if_not_null
+CREATE TABLE `t1` (
+  `c1` int(11) NULL COMMENT "",
+  `c2` bitmap REPLACE_IF_NOT_NULL NULL COMMENT ""
+) ENGINE=OLAP
+AGGREGATE KEY(`c1`)
+DISTRIBUTED BY HASH(`c1`) BUCKETS 1
+PROPERTIES ("replication_num" = "1");
+
+insert into t1 values (1, bitmap_from_string("1,2,3")), (2, bitmap_from_string("4,5,6"));
+select c1, bitmap_to_string(c2) from t1 order by c1;
+insert into t1 values (1, null);
+select c1, bitmap_to_string(c2) from t1 order by c1;
+insert into t1 values (1, bitmap_from_string("7,8,9"));
+select c1, bitmap_to_string(c2) from t1 order by c1;


### PR DESCRIPTION
## Why I'm doing:

We often use `replace_if_not_null` to implement partial column updates on aggregate tables, but the current bitmap type does not support `replace_if_not_null`.

## What I'm doing:

Aggregate table support replace_if_not_null for bitmap type.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [x] 3.1
  - [x] 3.0
  - [x] 2.5
