### PR TITLE
[BugFix] Fix mv refresh possible deadlock between checkBaseTablePartitionChange and prepareRefreshPlan

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/common/util/concurrent/lock/Locker.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/util/concurrent/lock/Locker.java
@@ -29,6 +29,7 @@ import org.apache.logging.log4j.Logger;
 
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.Comparator;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -200,6 +201,34 @@ public class Locker {
                 QueryableReentrantReadWriteLock rwLock = database.getRwLock();
                 rwLock.sharedUnlock();
             }
+        }
+    }
+
+    /**
+     * lock databases in ascending order of id.
+     * @param dbs: databases to be locked
+     * @param lockType: lock type
+     */
+    public void lockDatabases(List<Database> dbs, LockType lockType) {
+        if (dbs == null) {
+            return;
+        }
+        dbs.sort(Comparator.comparingLong(Database::getId));
+        for (Database db : dbs) {
+            lockDatabase(db, lockType);
+        }
+    }
+
+    /**
+     * @param dbs: databases to be locked
+     * @param lockType: lock type
+     */
+    public void unlockDatabases(List<Database> dbs, LockType lockType) {
+        if (dbs == null) {
+            return;
+        }
+        for (Database db : dbs) {
+            unLockDatabase(db, lockType);
         }
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/StatementPlanner.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/StatementPlanner.java
@@ -74,7 +74,6 @@ import com.starrocks.transaction.RunningTxnExceedException;
 import com.starrocks.transaction.TransactionState;
 
 import java.util.ArrayList;
-import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -334,10 +333,7 @@ public class StatementPlanner {
             return;
         }
         List<Database> dbList = new ArrayList<>(dbs.values());
-        dbList.sort(Comparator.comparingLong(Database::getId));
-        for (Database db : dbList) {
-            locker.lockDatabase(db, LockType.READ);
-        }
+        locker.lockDatabases(dbList, LockType.READ);
     }
 
     // unLock all database after analyze
@@ -345,9 +341,8 @@ public class StatementPlanner {
         if (dbs == null) {
             return;
         }
-        for (Database db : dbs.values()) {
-            locker.unLockDatabase(db, LockType.READ);
-        }
+        List<Database> dbList = new ArrayList<>(dbs.values());
+        locker.unlockDatabases(dbList, LockType.READ);
     }
 
     // if query stmt has OUTFILE clause, set info into ResultSink.

--- a/fe/fe-core/src/test/java/com/starrocks/alter/SchemaChangeHandlerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/alter/SchemaChangeHandlerTest.java
@@ -40,6 +40,7 @@ import com.starrocks.catalog.Index;
 import com.starrocks.catalog.MaterializedIndexMeta;
 import com.starrocks.catalog.OlapTable;
 import com.starrocks.catalog.OlapTable.OlapTableState;
+import com.starrocks.common.Config;
 import com.starrocks.common.DdlException;
 import com.starrocks.common.util.concurrent.lock.LockType;
 import com.starrocks.common.util.concurrent.lock.Locker;
@@ -49,14 +50,18 @@ import com.starrocks.utframe.TestWithFeService;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.junit.Assert;
+import org.junit.FixMethodOrder;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+import org.junit.runners.MethodSorters;
 
 import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 
+
+@FixMethodOrder(MethodSorters.NAME_ASCENDING)
 public class SchemaChangeHandlerTest extends TestWithFeService {
 
     private static final Logger LOG = LogManager.getLogger(SchemaChangeHandlerTest.class);
@@ -64,6 +69,12 @@ public class SchemaChangeHandlerTest extends TestWithFeService {
 
     @Override
     protected void runBeforeAll() throws Exception {
+        // set some parameters to speedup test
+        Config.tablet_sched_checker_interval_seconds = 1;
+        Config.tablet_sched_repair_delay_factor_second = 1;
+        Config.enable_new_publish_mechanism = true;
+        Config.alter_scheduler_interval_millisecond = 100;
+
         //create database db1
         createDatabase("test");
 


### PR DESCRIPTION
## Why I'm doing:
As LockChecker:
```
[LockChecker.checkSlowLocks() : 109] slow db locks: [{
	"lockState": "readLocked",
	"slowReadLockCount": 1,
	"dumpThreads": "lockHoldTime: 10776 ms;dump thread: starrocks-taskrun-pool-18, id: 270776\n    java.base@11.0.21/jdk.internal.misc.Unsafe.park(Native Method)\n    java.base@11.0.21/java.util.concurrent.locks.LockSupport.park(LockSupport.java:194)\n    java.base@11.0.21/java.util.concurrent.locks.AbstractQueuedSynchronizer.parkAndCheckInterrupt(AbstractQueuedSynchronizer.java:885)\n    java.base@11.0.21/java.util.concurrent.locks.AbstractQueuedSynchronizer.doAcquireShared(AbstractQueuedSynchronizer.java:1009)\n    java.base@11.0.21/java.util.concurrent.locks.AbstractQueuedSynchronizer.acquireShared(AbstractQueuedSynchronizer.java:1324)\n    java.base@11.0.21/java.util.concurrent.locks.ReentrantReadWriteLock$ReadLock.lock(ReentrantReadWriteLock.java:738)\n    app//com.starrocks.common.util.QueryableReentrantReadWriteLock.sharedLock(QueryableReentrantReadWriteLock.java:30)\n    app//com.starrocks.catalog.Database.readLock(Database.java:156)\n    app//com.starrocks.sql.StatementPlanner.lock(StatementPlanner.java:241)\n    app//com.starrocks.scheduler.PartitionBasedMvRefreshProcessor.prepareRefreshPlan(PartitionBasedMvRefreshProcessor.java:227)\n    app//com.starrocks.scheduler.PartitionBasedMvRefreshProcessor.doMvRefresh(PartitionBasedMvRefreshProcessor.java:193)\n    app//com.starrocks.scheduler.PartitionBasedMvRefreshProcessor.processTaskRun(PartitionBasedMvRefreshProcessor.java:133)\n    app//com.starrocks.scheduler.TaskRun.executeTaskRun(TaskRun.java:176)\n    app//com.starrocks.scheduler.TaskRunExecutor.lambda$executeTaskRun$0(TaskRunExecutor.java:37)\n    app//com.starrocks.scheduler.TaskRunExecutor$$Lambda$1179/0x00000008409cec40.get(Unknown Source)\n    java.base@11.0.21/java.util.concurrent.CompletableFuture$AsyncSupply.run(CompletableFuture.java:1700)\n    java.base@11.0.21/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)\n    java.base@11.0.21/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)\n    java.base@11.0.21/java.lang.Thread.run(Thread.java:829)\n;",
	"lockDbName": "dws",
	"lockWaiters": [{
		"threadId": 34,
		"threadName": "tablet checker"
	},
	{
		"threadId": 275567,
		"threadName": "thrift-server-pool-122846"
	},
	{
		"threadId": 275550,
		"threadName": "thrift-server-pool-122835"
	},
	{
		"threadId": 21,
		"threadName": "PUBLISH_VERSION"
	},
	{
		"threadId": 269983,
		"threadName": "starrocks-taskrun-pool-17"
	},
	{
		"threadId": 271119,
		"threadName": "starrocks-taskrun-pool-19"
	}]
},
{
	"lockState": "readLocked",
	"slowReadLockCount": 1,
	"dumpThreads": "lockHoldTime: 10783 ms;dump thread: starrocks-taskrun-pool-17, id: 269983\n    java.base@11.0.21/jdk.internal.misc.Unsafe.park(Native Method)\n    java.base@11.0.21/java.util.concurrent.locks.LockSupport.park(LockSupport.java:194)\n    java.base@11.0.21/java.util.concurrent.locks.AbstractQueuedSynchronizer.parkAndCheckInterrupt(AbstractQueuedSynchronizer.java:885)\n    java.base@11.0.21/java.util.concurrent.locks.AbstractQueuedSynchronizer.doAcquireShared(AbstractQueuedSynchronizer.java:1009)\n    java.base@11.0.21/java.util.concurrent.locks.AbstractQueuedSynchronizer.acquireShared(AbstractQueuedSynchronizer.java:1324)\n    java.base@11.0.21/java.util.concurrent.locks.ReentrantReadWriteLock$ReadLock.lock(ReentrantReadWriteLock.java:738)\n    app//com.starrocks.common.util.QueryableReentrantReadWriteLock.sharedLock(QueryableReentrantReadWriteLock.java:30)\n    app//com.starrocks.catalog.Database.readLock(Database.java:156)\n    app//com.starrocks.scheduler.PartitionBasedMvRefreshProcessor.checkBaseTablePartitionChange(PartitionBasedMvRefreshProcessor.java:831)\n    app//com.starrocks.scheduler.PartitionBasedMvRefreshProcessor.doMvRefresh(PartitionBasedMvRefreshProcessor.java:165)\n    app//com.starrocks.scheduler.PartitionBasedMvRefreshProcessor.processTaskRun(PartitionBasedMvRefreshProcessor.java:133)\n    app//com.starrocks.scheduler.TaskRun.executeTaskRun(TaskRun.java:176)\n    app//com.starrocks.scheduler.TaskRunExecutor.lambda$executeTaskRun$0(TaskRunExecutor.java:37)\n    app//com.starrocks.scheduler.TaskRunExecutor$$Lambda$1179/0x00000008409cec40.get(Unknown Source)\n    java.base@11.0.21/java.util.concurrent.CompletableFuture$AsyncSupply.run(CompletableFuture.java:1700)\n    java.base@11.0.21/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)\n    java.base@11.0.21/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)\n    java.base@11.0.21/java.lang.Thread.run(Thread.java:829)\n;",
	"lockDbName": "ads",
	"lockWaiters": [{
		"threadId": 275519,
		"threadName": "starrocks-mysql-nio-pool-47"
	},
	{
		"threadId": 270776,
		"threadName": "starrocks-taskrun-pool-18"
	},
	{
		"threadId": 6308,
		"threadName": "starrocks-taskrun-pool-0"
	}]
}]
```


## What I'm doing:
The root cause is because `checkBaseTablePartitionChange` locks base table one by one in random(hash) order, 
but `prepareRefreshPlan` locks multi dbs in a specific order.

- Fix mv refresh possible deadlock between checkBaseTablePartitionChange and prepareRefreshPlan

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [x] 3.1
  - [x] 3.0
  - [x] 2.5
