### PR TITLE
[BugFix] disable dict_mapping function in shared data mode

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/ExpressionAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/ExpressionAnalyzer.java
@@ -90,6 +90,7 @@ import com.starrocks.qe.SessionVariable;
 import com.starrocks.qe.SqlModeHelper;
 import com.starrocks.qe.VariableMgr;
 import com.starrocks.server.GlobalStateMgr;
+import com.starrocks.server.RunMode;
 import com.starrocks.sql.ast.ArrayExpr;
 import com.starrocks.sql.ast.AstVisitor;
 import com.starrocks.sql.ast.DefaultValueExpr;
@@ -1722,6 +1723,9 @@ public class ExpressionAnalyzer {
 
         @Override
         public Void visitDictQueryExpr(DictQueryExpr node, Scope context) {
+            if (RunMode.isSharedDataMode()) {
+                throw new SemanticException("dict_mapping function do not support shared data mode");
+            }
             List<Expr> params = node.getParams().exprs();
             if (!(params.get(0) instanceof StringLiteral)) {
                 throw new SemanticException("dict_mapping function first param table_name should be string literal");

--- a/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/DictQueryFunctionTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/DictQueryFunctionTest.java
@@ -157,6 +157,7 @@ public class DictQueryFunctionTest {
                 "SELECT dict_mapping('dict.dict_table', 'key', null, 'value', true);",
                 "dict_mapping function do not support shared data mode");
         Config.run_mode = "shared_nothing";
+        RunMode.detectRunMode();
     }
 
     private void testDictMappingFunction(String sql, String expectException) {

--- a/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/DictQueryFunctionTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/DictQueryFunctionTest.java
@@ -14,7 +14,9 @@
 
 package com.starrocks.sql.analyzer;
 
+import com.starrocks.common.Config;
 import com.starrocks.qe.ConnectContext;
+import com.starrocks.server.RunMode;
 import com.starrocks.utframe.StarRocksAssert;
 import com.starrocks.utframe.UtFrameUtils;
 import org.junit.BeforeClass;
@@ -148,6 +150,13 @@ public class DictQueryFunctionTest {
         testDictMappingFunction(
                 "SELECT dict_mapping('dict.dict_table', 'key', null, 'value', true);",
                 "dict_mapping function params not match expected");
+
+        Config.run_mode = "shared_data";
+        RunMode.detectRunMode();
+        testDictMappingFunction(
+                "SELECT dict_mapping('dict.dict_table', 'key', null, 'value', true);",
+                "dict_mapping function do not support shared data mode");
+        Config.run_mode = "shared_nothing";
     }
 
     private void testDictMappingFunction(String sql, String expectException) {


### PR DESCRIPTION
disable dict_mapping function in shared data mode

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
