### PR TITLE
[BugFix] Report total number of tablets to FE in shared-data mode

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/common/proc/BackendsProcDir.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/proc/BackendsProcDir.java
@@ -66,6 +66,7 @@ public class BackendsProcDir implements ProcDirInterface {
     private static final Logger LOG = LogManager.getLogger(BackendsProcDir.class);
 
     public static final ImmutableList<String> TITLE_NAMES;
+    public static final ImmutableList<String> TITLE_NAMES_SHARED_DATA;
     static {
         ImmutableList.Builder<String> builder = new ImmutableList.Builder<String>()
                 .add("BackendId").add("IP").add("HeartbeatPort")
@@ -76,10 +77,12 @@ public class BackendsProcDir implements ProcDirInterface {
                 .add("DataUsedPct").add("CpuCores").add("NumRunningQueries").add("MemUsedPct").add("CpuUsedPct")
                 .add("DataCacheMetrics")
                 .add("location");
-        if (RunMode.isSharedDataMode()) {
-            builder.add("StarletPort").add("WorkerId");
-        }
         TITLE_NAMES = builder.build();
+        builder = new ImmutableList.Builder<String>()
+                .addAll(TITLE_NAMES)
+                .add("StarletPort")
+                .add("WorkerId");
+        TITLE_NAMES_SHARED_DATA = builder.build();
     }
 
     private SystemInfoService clusterInfoService;
@@ -88,12 +91,20 @@ public class BackendsProcDir implements ProcDirInterface {
         this.clusterInfoService = clusterInfoService;
     }
 
+    public static List<String> getMetadata() {
+        if (RunMode.isSharedDataMode()) {
+            return TITLE_NAMES_SHARED_DATA;
+        } else {
+            return TITLE_NAMES;
+        }
+    }
+
     @Override
     public ProcResult fetchResult() throws AnalysisException {
         Preconditions.checkNotNull(clusterInfoService);
 
         BaseProcResult result = new BaseProcResult();
-        result.setNames(TITLE_NAMES);
+        result.setNames(getMetadata());
 
         final List<List<String>> backendInfos = getClusterBackendInfos();
         for (List<String> backendInfo : backendInfos) {
@@ -116,6 +127,7 @@ public class BackendsProcDir implements ProcDirInterface {
         long start = System.currentTimeMillis();
         Stopwatch watch = Stopwatch.createUnstarted();
         List<List<Comparable>> comparableBackendInfos = new LinkedList<>();
+        long tabletNum = 0;
         for (long backendId : backendIds) {
             Backend backend = clusterInfoService.getBackend(backendId);
             if (backend == null) {
@@ -123,7 +135,12 @@ public class BackendsProcDir implements ProcDirInterface {
             }
 
             watch.start();
-            long tabletNum = GlobalStateMgr.getCurrentState().getTabletInvertedIndex().getTabletNumByBackendId(backendId);
+            if (RunMode.isSharedDataMode()) {
+                String workerAddr = backend.getHost() + ":" + backend.getStarletPort();
+                tabletNum = GlobalStateMgr.getCurrentState().getStarOSAgent().getWorkerTabletNum(workerAddr);
+            } else {
+                tabletNum = GlobalStateMgr.getCurrentState().getTabletInvertedIndex().getTabletNumByBackendId(backendId);
+            }
             watch.stop();
             List<Comparable> backendInfo = Lists.newArrayList();
             backendInfo.add(String.valueOf(backendId));

--- a/fe/fe-core/src/main/java/com/starrocks/common/proc/ComputeNodeProcDir.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/proc/ComputeNodeProcDir.java
@@ -40,6 +40,8 @@ public class ComputeNodeProcDir implements ProcDirInterface {
     private static final Logger LOG = LogManager.getLogger(ComputeNodeProcDir.class);
 
     public static final ImmutableList<String> TITLE_NAMES;
+    public static final ImmutableList<String> TITLE_NAMES_SHARED_DATA;
+
     static {
         ImmutableList.Builder<String> builder = new ImmutableList.Builder<String>()
                 .add("ComputeNodeId").add("IP").add("HeartbeatPort")
@@ -47,10 +49,13 @@ public class ComputeNodeProcDir implements ProcDirInterface {
                 .add("SystemDecommissioned").add("ClusterDecommissioned").add("ErrMsg")
                 .add("Version")
                 .add("CpuCores").add("NumRunningQueries").add("MemUsedPct").add("CpuUsedPct").add("HasStoragePath");
-        if (RunMode.isSharedDataMode()) {
-            builder.add("StarletPort").add("WorkerId");
-        }
         TITLE_NAMES = builder.build();
+        builder = new ImmutableList.Builder<String>()
+                .addAll(TITLE_NAMES)
+                .add("StarletPort")
+                .add("WorkerId")
+                .add("TabletNum");
+        TITLE_NAMES_SHARED_DATA = builder.build();
     }
 
     private SystemInfoService clusterInfoService;
@@ -59,11 +64,19 @@ public class ComputeNodeProcDir implements ProcDirInterface {
         this.clusterInfoService = clusterInfoService;
     }
 
+    public static List<String> getMetadata() {
+        if (RunMode.isSharedDataMode()) {
+            return TITLE_NAMES_SHARED_DATA;
+        } else {
+            return TITLE_NAMES;
+        }
+    }
+
     @Override
     public ProcResult fetchResult()
             throws AnalysisException {
         BaseProcResult result = new BaseProcResult();
-        result.setNames(TITLE_NAMES);
+        result.setNames(getMetadata());
 
         final List<List<String>> computeNodesInfos = getClusterComputeNodesInfos();
         for (List<String> computeNodesInfo : computeNodesInfos) {
@@ -138,6 +151,10 @@ public class ComputeNodeProcDir implements ProcDirInterface {
                 computeNodeInfo.add(String.valueOf(computeNode.getStarletPort()));
                 long workerId = GlobalStateMgr.getCurrentState().getStarOSAgent().getWorkerIdByBackendId(computeNodeId);
                 computeNodeInfo.add(String.valueOf(workerId));
+
+                String workerAddr = computeNode.getHost() + ":" + computeNode.getStarletPort();
+                long tabletNum = GlobalStateMgr.getCurrentState().getStarOSAgent().getWorkerTabletNum(workerAddr);
+                computeNodeInfo.add(tabletNum);
             }
 
             comparableComputeNodeInfos.add(computeNodeInfo);

--- a/fe/fe-core/src/main/java/com/starrocks/lake/StarOSAgent.java
+++ b/fe/fe-core/src/main/java/com/starrocks/lake/StarOSAgent.java
@@ -280,6 +280,16 @@ public class StarOSAgent {
         return workerId;
     }
 
+    public long getWorkerTabletNum(String workerIpPort) {
+        try {
+            WorkerInfo workerInfo = client.getWorkerInfo(serviceId, workerIpPort);
+            return workerInfo.getTabletNum();
+        } catch (StarClientException e) {
+            LOG.info("Failed to get worker tablet num from starMgr, Error: {}.", e.getMessage());
+        }
+        return 0;
+    }
+
     public void addWorker(long nodeId, String workerIpPort, long workerGroupId) {
         prepare();
         try (LockCloseable lock = new LockCloseable(rwLock.writeLock())) {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/ShowBackendsStmt.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/ShowBackendsStmt.java
@@ -35,7 +35,7 @@ public class ShowBackendsStmt extends ShowStmt {
     @Override
     public ShowResultSetMetaData getMetaData() {
         ShowResultSetMetaData.Builder builder = ShowResultSetMetaData.builder();
-        for (String title : BackendsProcDir.TITLE_NAMES) {
+        for (String title : BackendsProcDir.getMetadata()) {
             builder.addColumn(new Column(title, ScalarType.createVarchar(30)));
         }
         return builder.build();

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/ShowComputeNodesStmt.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/ShowComputeNodesStmt.java
@@ -33,7 +33,7 @@ public class ShowComputeNodesStmt extends ShowStmt {
 
     public ShowResultSetMetaData getMetaData() {
         ShowResultSetMetaData.Builder builder = ShowResultSetMetaData.builder();
-        for (String title : ComputeNodeProcDir.TITLE_NAMES) {
+        for (String title : ComputeNodeProcDir.getMetadata()) {
             builder.addColumn(new Column(title, ScalarType.createVarchar(30)));
         }
         return builder.build();

--- a/fe/fe-core/src/test/java/com/starrocks/common/proc/BackendsProcDirTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/common/proc/BackendsProcDirTest.java
@@ -36,9 +36,12 @@ package com.starrocks.common.proc;
 
 import com.starrocks.catalog.TabletInvertedIndex;
 import com.starrocks.common.AnalysisException;
+import com.starrocks.common.ExceptionChecker;
+import com.starrocks.lake.StarOSAgent;
 import com.starrocks.persist.EditLog;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.server.NodeMgr;
+import com.starrocks.server.RunMode;
 import com.starrocks.system.Backend;
 import com.starrocks.system.SystemInfoService;
 import mockit.Expectations;
@@ -48,9 +51,13 @@ import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
+import java.util.List;
+
 public class BackendsProcDirTest {
     private Backend b1;
     private Backend b2;
+    private final long tabletNumSharedData = 200;
+    private final long tabletNumSharedNothing = 2;
 
     @Mocked
     private SystemInfoService systemInfoService;
@@ -60,6 +67,10 @@ public class BackendsProcDirTest {
     private GlobalStateMgr globalStateMgr;
     @Mocked
     private EditLog editLog;
+    @Mocked
+    private StarOSAgent starOsAgent;
+    @Mocked
+    private RunMode runMode;
 
     @Mocked
     private NodeMgr nodeMgr;
@@ -111,7 +122,11 @@ public class BackendsProcDirTest {
 
                 tabletInvertedIndex.getTabletNumByBackendId(anyLong);
                 minTimes = 0;
-                result = 2;
+                result = tabletNumSharedNothing;
+
+                starOsAgent.getWorkerTabletNum(anyString);
+                minTimes = 0;
+                result = tabletNumSharedData;
             }
         };
 
@@ -124,6 +139,10 @@ public class BackendsProcDirTest {
                 globalStateMgr.getNodeMgr();
                 minTimes = 0;
                 result = nodeMgr;
+
+                globalStateMgr.getStarOSAgent();
+                minTimes = 0;
+                result = starOsAgent;
             }
         };
 
@@ -142,67 +161,88 @@ public class BackendsProcDirTest {
         // systemInfoService = null;
     }
 
-    @Test(expected = AnalysisException.class)
-    public void testLookupNormal() throws AnalysisException {
-        BackendsProcDir dir;
-        ProcNodeInterface node;
-
-        dir = new BackendsProcDir(systemInfoService);
-        try {
-            node = dir.lookup("1000");
+    @Test
+    public void testLookupNormal() {
+        ExceptionChecker.expectThrowsNoException(() -> {
+            BackendsProcDir dir = new BackendsProcDir(systemInfoService);
+            ProcNodeInterface node = dir.lookup("1000");
             Assert.assertNotNull(node);
             Assert.assertTrue(node instanceof BackendProcNode);
-        } catch (AnalysisException e) {
-            e.printStackTrace();
-            Assert.fail();
-        }
+        });
 
-        dir = new BackendsProcDir(systemInfoService);
-        try {
-            node = dir.lookup("1001");
+        ExceptionChecker.expectThrowsNoException(() -> {
+            BackendsProcDir dir = new BackendsProcDir(systemInfoService);
+            ProcNodeInterface node = dir.lookup("1001");
             Assert.assertNotNull(node);
             Assert.assertTrue(node instanceof BackendProcNode);
-        } catch (AnalysisException e) {
-            Assert.fail();
-        }
+        });
 
-        dir = new BackendsProcDir(systemInfoService);
-        node = dir.lookup("1002");
-        Assert.fail();
+        ExceptionChecker.expectThrows(AnalysisException.class, () -> {
+            BackendsProcDir dir = new BackendsProcDir(systemInfoService);
+            dir.lookup("1002");
+        });
     }
 
     @Test
     public void testLookupInvalid() {
-        BackendsProcDir dir;
-        ProcNodeInterface node;
+        BackendsProcDir dir = new BackendsProcDir(systemInfoService);
+        ExceptionChecker.expectThrows(AnalysisException.class, () -> dir.lookup(null));
+        ExceptionChecker.expectThrows(AnalysisException.class, () -> dir.lookup(""));
+    }
 
-        dir = new BackendsProcDir(systemInfoService);
-        try {
-            node = dir.lookup(null);
-        } catch (AnalysisException e) {
-            e.printStackTrace();
+    private int getTabletNumColumnIndex(List<String> names) {
+        for (int i = 0; i < names.size(); ++i) {
+            if ("TabletNum".equals(names.get(i))) {
+                return i;
+            }
         }
+        return -1;
+    }
 
-        try {
-            node = dir.lookup("");
-        } catch (AnalysisException e) {
-            e.printStackTrace();
+    @Test
+    public void testFetchResultSharedNothing() throws AnalysisException {
+        new Expectations() {
+            {
+                runMode.isSharedDataMode();
+                minTimes = 0;
+                result = false;
+            }
+        };
+
+        BackendsProcDir dir = new BackendsProcDir(systemInfoService);
+        ProcResult result = dir.fetchResult();
+        Assert.assertNotNull(result);
+        Assert.assertTrue(result instanceof BaseProcResult);
+        int columnIndex = getTabletNumColumnIndex(result.getColumnNames());
+        Assert.assertTrue(columnIndex >= 0);
+        for (List<String> row : result.getRows()) {
+            Assert.assertEquals(String.valueOf(tabletNumSharedNothing), row.get(columnIndex));
         }
     }
 
     @Test
-    public void testFetchResultNormal() throws AnalysisException {
-        BackendsProcDir dir;
-        ProcResult result;
+    public void testFetchResultSharedData() throws AnalysisException {
+        new Expectations() {
+            {
+                runMode.isSharedDataMode();
+                minTimes = 0;
+                result = true;
+            }
+        };
 
-        dir = new BackendsProcDir(systemInfoService);
-        result = dir.fetchResult();
+        BackendsProcDir dir = new BackendsProcDir(systemInfoService);
+        ProcResult result = dir.fetchResult();
         Assert.assertNotNull(result);
         Assert.assertTrue(result instanceof BaseProcResult);
+        int columnIndex = getTabletNumColumnIndex(result.getColumnNames());
+        Assert.assertTrue(columnIndex >= 0);
+        for (List<String> row : result.getRows()) {
+            Assert.assertEquals(String.valueOf(tabletNumSharedData), row.get(columnIndex));
+        }
     }
 
     @Test
     public void testIPTitle() {
-        Assert.assertTrue(BackendsProcDir.TITLE_NAMES.get(1).equals("IP"));
+        Assert.assertEquals("IP", BackendsProcDir.TITLE_NAMES.get(1));
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/common/proc/ComputeNodeProcDirTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/common/proc/ComputeNodeProcDirTest.java
@@ -1,0 +1,146 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.common.proc;
+
+import com.starrocks.common.AnalysisException;
+import com.starrocks.lake.StarOSAgent;
+import com.starrocks.server.GlobalStateMgr;
+import com.starrocks.server.NodeMgr;
+import com.starrocks.server.RunMode;
+import com.starrocks.system.Backend;
+import com.starrocks.system.ComputeNode;
+import com.starrocks.system.SystemInfoService;
+import mockit.Expectations;
+import mockit.Mocked;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.List;
+
+public class ComputeNodeProcDirTest {
+    private ComputeNode b1;
+    private ComputeNode b2;
+    private final long tabletNumSharedData = 200;
+
+    private final SystemInfoService systemInfoService = new SystemInfoService();
+
+    @Mocked
+    private GlobalStateMgr globalStateMgr;
+    @Mocked
+    private StarOSAgent starOsAgent;
+    @Mocked
+    private NodeMgr nodeMgr;
+    @Mocked
+    private RunMode runMode;
+
+    @Before
+    public void setUp() {
+        b1 = new ComputeNode(1000, "host1", 10000);
+        b1.updateOnce(10001, 10003, 10005);
+        b2 = new Backend(1001, "host2", 20000);
+        b2.updateOnce(20001, 20003, 20005);
+        systemInfoService.addComputeNode(b1);
+        systemInfoService.addComputeNode(b2);
+
+        new Expectations() {
+            {
+                GlobalStateMgr.getCurrentState();
+                minTimes = 0;
+                result = globalStateMgr;
+
+                starOsAgent.getWorkerTabletNum(anyString);
+                minTimes = 0;
+                result = tabletNumSharedData;
+            }
+        };
+
+        new Expectations(globalStateMgr) {
+            {
+                globalStateMgr.getNodeMgr();
+                minTimes = 0;
+                result = nodeMgr;
+
+                globalStateMgr.getStarOSAgent();
+                minTimes = 0;
+                result = starOsAgent;
+            }
+        };
+
+        new Expectations(nodeMgr) {
+            {
+                nodeMgr.getClusterInfo();
+                minTimes = 0;
+                result = systemInfoService;
+            }
+        };
+
+    }
+
+    @After
+    public void tearDown() {
+        // systemInfoService = null;
+    }
+
+    private int getTabletNumColumnIndex(List<String> names) {
+        for (int i = 0; i < names.size(); ++i) {
+            if ("TabletNum".equals(names.get(i))) {
+                return i;
+            }
+        }
+        return -1;
+    }
+
+    @Test
+    public void testFetchResultSharedNothing() throws AnalysisException {
+        new Expectations() {
+            {
+                RunMode.isSharedDataMode();
+                minTimes = 0;
+                result = false;
+            }
+        };
+
+        ComputeNodeProcDir dir = new ComputeNodeProcDir(systemInfoService);
+        ProcResult result = dir.fetchResult();
+        Assert.assertNotNull(result);
+        Assert.assertTrue(result instanceof BaseProcResult);
+        int columnIndex = getTabletNumColumnIndex(result.getColumnNames());
+        // no "TabletNum" column in shared-nothing mode
+        Assert.assertEquals(-1, columnIndex);
+    }
+
+    @Test
+    public void testFetchResultSharedData() throws AnalysisException {
+        new Expectations() {
+            {
+                RunMode.isSharedDataMode();
+                minTimes = 1;
+                result = true;
+            }
+        };
+
+        ComputeNodeProcDir dir = new ComputeNodeProcDir(systemInfoService);
+        ProcResult result = dir.fetchResult();
+        Assert.assertNotNull(result);
+        Assert.assertTrue(result instanceof BaseProcResult);
+        int columnIndex = getTabletNumColumnIndex(result.getColumnNames());
+        Assert.assertTrue(columnIndex >= 0);
+        for (List<String> row : result.getRows()) {
+            Assert.assertEquals(String.valueOf(tabletNumSharedData), row.get(columnIndex));
+        }
+    }
+}

--- a/fe/fe-core/src/test/java/com/starrocks/lake/StarOSAgentTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/lake/StarOSAgentTest.java
@@ -31,6 +31,7 @@ import com.staros.proto.ReplicaRole;
 import com.staros.proto.S3FileStoreInfo;
 import com.staros.proto.ShardGroupInfo;
 import com.staros.proto.ShardInfo;
+import com.staros.proto.StarStatus;
 import com.staros.proto.StatusCode;
 import com.staros.proto.WorkerGroupDetailInfo;
 import com.staros.proto.WorkerInfo;
@@ -472,12 +473,13 @@ public class StarOSAgentTest {
     }
 
     private WorkerInfo newWorkerInfo(long workerId, String ipPort, int beHeartbeatPort, int bePort, int beHttpPort,
-                                     int beBrpcPort) {
+                                     int beBrpcPort, int tabletNum) {
         return WorkerInfo.newBuilder().setWorkerId(workerId).setIpPort(ipPort)
                 .putWorkerProperties("be_heartbeat_port", String.valueOf(beHeartbeatPort))
                 .putWorkerProperties("be_port", String.valueOf(bePort))
                 .putWorkerProperties("be_http_port", String.valueOf(beHttpPort))
                 .putWorkerProperties("be_brpc_port", String.valueOf(beBrpcPort))
+                .setTabletNum(tabletNum)
                 .build();
     }
 
@@ -487,15 +489,15 @@ public class StarOSAgentTest {
         Deencapsulation.setField(starosAgent, "serviceId", serviceId);
 
         long workerId0 = 10000L;
-        WorkerInfo worker0 = newWorkerInfo(workerId0, "127.0.0.1:8090", 9050, 9060, 8040, 8060);
+        WorkerInfo worker0 = newWorkerInfo(workerId0, "127.0.0.1:8090", 9050, 9060, 8040, 8060, 10);
         long workerId1 = 10001L;
-        WorkerInfo worker1 = newWorkerInfo(workerId1, "127.0.0.2:8091", 9051, 9061, 8041, 8061);
+        WorkerInfo worker1 = newWorkerInfo(workerId1, "127.0.0.2:8091", 9051, 9061, 8041, 8061, 10);
         long groupId0 = 10L;
         WorkerGroupDetailInfo group0 = WorkerGroupDetailInfo.newBuilder().setGroupId(groupId0).addWorkersInfo(worker0)
                 .addWorkersInfo(worker1).build();
 
         long workerId2 = 10002L;
-        WorkerInfo worker2 = newWorkerInfo(workerId2, "127.0.0.3:8092", 9052, 9062, 8042, 8062);
+        WorkerInfo worker2 = newWorkerInfo(workerId2, "127.0.0.3:8092", 9052, 9062, 8042, 8062, 10);
         long groupId1 = 11L;
         WorkerGroupDetailInfo group1 = WorkerGroupDetailInfo.newBuilder().setGroupId(groupId1).addWorkersInfo(worker2)
                 .build();
@@ -518,6 +520,50 @@ public class StarOSAgentTest {
 
         List<Long> nodes = starosAgent.getWorkersByWorkerGroup(groupId0);
         Assert.assertEquals(2, nodes.size());
+    }
+
+    @Test
+    public void testGetWorkerTabletNum() throws StarClientException {
+        String serviceId = "1";
+        String workerIpPort = "127.0.0.1:8093";
+        long workerId = 20000L;
+        int expectedTabletNum = 10086;
+        Deencapsulation.setField(starosAgent, "serviceId", serviceId);
+        WorkerInfo worker = newWorkerInfo(workerId, workerIpPort, 9050, 9060, 8040, 8060, expectedTabletNum);
+
+        new Expectations() {
+            {
+                client.getWorkerInfo(serviceId, workerIpPort);
+                minTimes = 1;
+                result = worker;
+            }
+        };
+        long tabletNum = starosAgent.getWorkerTabletNum(workerIpPort);
+        Assert.assertEquals(expectedTabletNum, worker.getTabletNum());
+        Assert.assertEquals(expectedTabletNum, tabletNum);
+    }
+
+    @Test
+    public void testGetWorkerTabletNumExcepted() throws StarClientException {
+        String serviceId = "1";
+        String workerIpPort = "127.0.0.1:8093";
+        Deencapsulation.setField(starosAgent, "serviceId", serviceId);
+
+        new Expectations() {
+            {
+                client.getWorkerInfo(serviceId, anyString);
+                result = new StarClientException(
+                        StarStatus.newBuilder().setStatusCode(StatusCode.INTERNAL).setErrorMsg("injected error")
+                                .build());
+                minTimes = 1;
+            }
+        };
+
+        ExceptionChecker.expectThrowsNoException(() -> {
+            // no exception at all, return 0 instead
+            long tabletNum = starosAgent.getWorkerTabletNum(workerIpPort);
+            Assert.assertEquals(0, tabletNum);
+        });
     }
 
     @Test
@@ -665,9 +711,9 @@ public class StarOSAgentTest {
             @Mock
             public List<WorkerGroupDetailInfo> listWorkerGroup(String serviceId, List<Long> groupIds, boolean include) {
                 long workerId0 = 10000L;
-                WorkerInfo worker0 = newWorkerInfo(workerId0, "127.0.0.1:8090", 9050, 9060, 8040, 8060);
+                WorkerInfo worker0 = newWorkerInfo(workerId0, "127.0.0.1:8090", 9050, 9060, 8040, 8060, 10);
                 long workerId1 = 10001L;
-                WorkerInfo worker1 = newWorkerInfo(workerId1, "127.0.0.2:8091", 9051, 9061, 8041, 8061);
+                WorkerInfo worker1 = newWorkerInfo(workerId1, "127.0.0.2:8091", 9051, 9061, 8041, 8061, 10);
                 WorkerGroupDetailInfo group = WorkerGroupDetailInfo.newBuilder().addWorkersInfo(worker0)
                         .addWorkersInfo(worker1).build();
                 return Lists.newArrayList(group);

--- a/fe/fe-core/src/test/java/com/starrocks/qe/ShowExecutorTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/qe/ShowExecutorTest.java
@@ -342,10 +342,6 @@ public class ShowExecutorTest {
                 minTimes = 0;
                 result = globalStateMgr;
 
-                GlobalStateMgr.getCurrentState();
-                minTimes = 0;
-                result = globalStateMgr;
-
                 GlobalStateMgr.getCurrentState().getMetadataMgr().listDbNames("default_catalog");
                 minTimes = 0;
                 result = Lists.newArrayList("testDb");
@@ -705,33 +701,15 @@ public class ShowExecutorTest {
     }
 
     @Test
-    public void testShowBackends() throws AnalysisException, DdlException {
+    public void testShowBackendsSharedDataMode(@Mocked StarOSAgent starosAgent) throws AnalysisException, DdlException {
         SystemInfoService clusterInfo = AccessTestUtil.fetchSystemInfoService();
-        StarOSAgent starosAgent = new StarOSAgent();
 
         // mock backends
-        Backend backend = new Backend();
-        new Expectations(clusterInfo) {
-            {
-                clusterInfo.getBackend(1L);
-                minTimes = 0;
-                result = backend;
-            }
-        };
+        Backend backend = new Backend(1L, "127.0.0.1", 12345);
+        backend.updateResourceUsage(0, 100L, 1L, 30);
+        clusterInfo.addBackend(backend);
 
         NodeMgr nodeMgr = new NodeMgr();
-        new MockUp<GlobalStateMgr>() {
-            @Mock
-            NodeMgr getNodeMgr() {
-                return nodeMgr;
-            }
-
-            @Mock
-            StarOSAgent getStarOSAgent() {
-                return starosAgent;
-            }
-        };
-
         new Expectations(nodeMgr) {
             {
                 nodeMgr.getClusterInfo();
@@ -740,26 +718,37 @@ public class ShowExecutorTest {
             }
         };
 
-        new MockUp<SystemInfoService>() {
-            @Mock
-            List<Long> getBackendIds(boolean needAlive) {
-                List<Long> backends = Lists.newArrayList();
-                backends.add(1L);
-                return backends;
-            }
-        };
+        new Expectations(globalStateMgr) {
+            {
+                globalStateMgr.getNodeMgr();
+                minTimes = 0;
+                result = nodeMgr;
 
-        new MockUp<StarOSAgent>() {
-            @Mock
-            long getWorkerIdByBackendId(long backendId) {
-                return 5;
+                globalStateMgr.getStarOSAgent();
+                minTimes = 0;
+                result = starosAgent;
             }
         };
 
         new MockUp<RunMode>() {
             @Mock
-            public RunMode getCurrentRunMode() {
+            RunMode getCurrentRunMode() {
                 return RunMode.SHARED_DATA;
+            }
+        };
+
+        long tabletNum = 1024;
+        long workerId = 1122;
+        new Expectations() {
+            {
+                starosAgent.getWorkerTabletNum(anyString);
+                minTimes = 1;
+                result = tabletNum;
+
+                starosAgent.getWorkerIdByBackendId(anyLong);
+                minTimes = 1;
+                result = workerId;
+
             }
         };
 
@@ -777,34 +766,22 @@ public class ShowExecutorTest {
         Assert.assertEquals("WorkerId", resultSet.getMetaData().getColumn(29).getName());
 
         Assert.assertTrue(resultSet.next());
-        System.out.println(resultSet);
         Assert.assertEquals("1", resultSet.getString(0));
         Assert.assertEquals("0", resultSet.getString(23));
         Assert.assertEquals("N/A", resultSet.getString(26));
-        Assert.assertEquals("5", resultSet.getString(29));
+        Assert.assertEquals(String.valueOf(workerId), resultSet.getString(29));
+        Assert.assertEquals(String.valueOf(tabletNum), resultSet.getString(11));
     }
 
     @Test
-    public void testShowComputeNodes() throws AnalysisException, DdlException {
+    public void testShowComputeNodesSharedData(@Mocked StarOSAgent starosAgent) throws AnalysisException, DdlException {
         SystemInfoService clusterInfo = AccessTestUtil.fetchSystemInfoService();
-        StarOSAgent starosAgent = new StarOSAgent();
 
         ComputeNode node = new ComputeNode(1L, "127.0.0.1", 80);
         node.updateResourceUsage(10, 100L, 1L, 30);
+        clusterInfo.addComputeNode(node);
 
         NodeMgr nodeMgr = new NodeMgr();
-        new MockUp<GlobalStateMgr>() {
-            @Mock
-            NodeMgr getNodeMgr() {
-                return nodeMgr;
-            }
-
-            @Mock
-            StarOSAgent getStarOSAgent() {
-                return starosAgent;
-            }
-        };
-
         new Expectations(nodeMgr) {
             {
                 nodeMgr.getClusterInfo();
@@ -813,18 +790,15 @@ public class ShowExecutorTest {
             }
         };
 
-        new MockUp<SystemInfoService>() {
-            @Mock
-            List<Long> getComputeNodeIds(boolean needAlive) {
-                return ImmutableList.of(node.getId());
-            }
+        new Expectations(globalStateMgr) {
+            {
+                globalStateMgr.getNodeMgr();
+                minTimes = 0;
+                result = nodeMgr;
 
-            @Mock
-            ComputeNode getComputeNode(long computeNodeId) {
-                if (computeNodeId == node.getId()) {
-                    return node;
-                }
-                return null;
+                globalStateMgr.getStarOSAgent();
+                minTimes = 0;
+                result = starosAgent;
             }
         };
 
@@ -837,15 +811,17 @@ public class ShowExecutorTest {
 
         new MockUp<RunMode>() {
             @Mock
-            public RunMode getCurrentRunMode() {
+            RunMode getCurrentRunMode() {
                 return RunMode.SHARED_DATA;
             }
         };
 
-        new MockUp<StarOSAgent>() {
-            @Mock
-            long getWorkerIdByBackendId(long backendId) {
-                return 5;
+        long tabletNum = 1024;
+        new Expectations() {
+            {
+                starosAgent.getWorkerTabletNum(anyString);
+                minTimes = 0;
+                result = tabletNum;
             }
         };
 
@@ -853,17 +829,19 @@ public class ShowExecutorTest {
         ShowExecutor executor = new ShowExecutor(ctx, stmt);
         ShowResultSet resultSet = executor.execute();
 
-        Assert.assertEquals(ComputeNodeProcDir.TITLE_NAMES.size(), resultSet.getMetaData().getColumnCount());
-        for (int i = 0; i < ComputeNodeProcDir.TITLE_NAMES.size(); ++i) {
-            Assert.assertEquals(ComputeNodeProcDir.TITLE_NAMES.get(i), resultSet.getMetaData().getColumn(i).getName());
+        Assert.assertEquals(ComputeNodeProcDir.TITLE_NAMES_SHARED_DATA.size(),
+                resultSet.getMetaData().getColumnCount());
+        for (int i = 0; i < ComputeNodeProcDir.TITLE_NAMES_SHARED_DATA.size(); ++i) {
+            Assert.assertEquals(ComputeNodeProcDir.TITLE_NAMES_SHARED_DATA.get(i),
+                    resultSet.getMetaData().getColumn(i).getName());
         }
-        System.out.println(resultSet.getMetaData().getColumn(13));
 
         Assert.assertTrue(resultSet.next());
         Assert.assertEquals("16", resultSet.getString(13));
         Assert.assertEquals("10", resultSet.getString(14));
         Assert.assertEquals("1.00 %", resultSet.getString(15));
         Assert.assertEquals("3.0 %", resultSet.getString(16));
+        Assert.assertEquals(String.valueOf(tabletNum), resultSet.getString(20));
     }
 
     @Test


### PR DESCRIPTION
* Current show backends command doesn’t show correct tabletNum in shared-data mode, it is always 0.
* Fix it by reporting the number of tablets from starmgr worker info

## Why I'm doing:

## What I'm doing:

Fixes #40582

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [x] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [x] 3.1
  - [ ] 3.0
  - [ ] 2.5
