### PR TITLE
[BugFix] Fix lowcardinality v2 runtime filter crash

### DIFF
--- a/be/src/exec/pipeline/fragment_executor.cpp
+++ b/be/src/exec/pipeline/fragment_executor.cpp
@@ -714,8 +714,8 @@ Status FragmentExecutor::prepare(ExecEnv* exec_env, const TExecPlanFragmentParam
         auto mem_tracker = _fragment_ctx->runtime_state()->instance_mem_tracker();
         SCOPED_THREAD_LOCAL_MEM_TRACKER_SETTER(mem_tracker);
 
-        RETURN_IF_ERROR(_prepare_exec_plan(exec_env, request));
         RETURN_IF_ERROR(_prepare_global_dict(request));
+        RETURN_IF_ERROR(_prepare_exec_plan(exec_env, request));
     }
     {
         SCOPED_RAW_TIMER(&profiler.prepare_pipeline_driver_time);

--- a/test/sql/test_low_cardinality/R/test_low_cardinality2
+++ b/test/sql/test_low_cardinality/R/test_low_cardinality2
@@ -309,11 +309,11 @@ insert into s2 select * from s2;
 -- !result
 [UC] analyze full table s1;
 -- result:
-test_db_d0be16369d5011eeb01500163e04d4c2.s1	analyze	status	OK
+test_db_72538010da2a11eebf99c1cb78b81852.s1	analyze	status	OK
 -- !result
 [UC] analyze full table s2;
 -- result:
-test_db_d0be16369d5011eeb01500163e04d4c2.s2	analyze	status	OK
+test_db_72538010da2a11eebf99c1cb78b81852.s2	analyze	status	OK
 -- !result
 function: wait_global_dict_ready('v3', 's1')
 -- result:
@@ -331,12 +331,12 @@ function: wait_global_dict_ready('v4', 's2')
 -- result:
 
 -- !result
-select concat(upper(v2), "1"), max(v3) from s2 where v4 = "BJ" group by upper(v2);
+select concat(upper(v2), "1"), max(v3) from s2 where v4 = "BJ" group by upper(v2) order by 1, 2;
 -- result:
-8351	Chongqing
 3681	Jiangxi
+8351	Chongqing
 -- !result
-select concat(upper(v4), "1"), max(v3) from s2 where v4 = "BJ" group by upper(v4);
+select concat(upper(v4), "1"), max(v3) from s2 where v4 = "BJ" group by upper(v4) order by 1, 2;
 -- result:
 BJ1	Jiangxi
 -- !result
@@ -458,6 +458,55 @@ where x2 = "anhui"
 GROUP BY x1
 HAVING MAX(y2) = "JX";
 -- result:
-ixgnauG	anhui	QH1	JX
 nauhciS	anhui	SH1	JX
+ixgnauG	anhui	QH1	JX
+-- !result
+CREATE TABLE `supplier` (
+  `s_suppkey` int(11) NOT NULL COMMENT "",
+  `s_name` varchar(26) NOT NULL COMMENT "",
+  `s_region` varchar(13) NOT NULL COMMENT ""
+) ENGINE=OLAP 
+DUPLICATE KEY(`s_suppkey`)
+COMMENT "OLAP"
+DISTRIBUTED BY HASH(`s_suppkey`) BUCKETS 12 
+PROPERTIES (
+"replication_num" = "1"
+);
+-- result:
+-- !result
+insert into
+    supplier
+SELECT
+    generate_series,
+    generate_series,
+    generate_series % 16
+FROM
+    TABLE(generate_series(1, 4096));
+-- result:
+-- !result
+[UC] analyze full table supplier;
+-- result:
+test_db_72538010da2a11eebf99c1cb78b81852.supplier	analyze	status	OK
+-- !result
+function: wait_global_dict_ready('s_region', 'supplier')
+-- result:
+
+-- !result
+with agged_supplier as ( select S_NAME, max(s_region) as mx_addr from supplier group by S_NAME ), 
+agged_supplier_1 as ( select l.S_NAME, l.mx_addr mx_addr from agged_supplier l join [shuffle] supplier r on l.S_NAME=r.S_NAME ), 
+agged_supplier_2 as ( select S_NAME, if(mx_addr = 'key', 'key2', S_NAME) mx_addr from agged_supplier_1 l ), agged_supplier_4 
+as ( select S_NAME, mx_addr from agged_supplier_2 l group by S_NAME,mx_addr ), 
+agged_supplier_5 as ( select l.S_NAME, l.mx_addr from agged_supplier_4 l join supplier r where r.s_suppkey=10 ) 
+select l.S_NAME,l.mx_addr from agged_supplier_5 l right join [shuffle] supplier z on l.S_NAME = z.S_NAME and l.mx_addr = z.s_region order by 2 nulls last,1 limit 10
+-- result:
+1	1
+10	10
+11	11
+12	12
+13	13
+14	14
+15	15
+2	2
+3	3
+4	4
 -- !result

--- a/test/sql/test_low_cardinality/R/test_low_cardinality2
+++ b/test/sql/test_low_cardinality/R/test_low_cardinality2
@@ -497,7 +497,7 @@ agged_supplier_1 as ( select l.S_NAME, l.mx_addr mx_addr from agged_supplier l j
 agged_supplier_2 as ( select S_NAME, if(mx_addr = 'key', 'key2', S_NAME) mx_addr from agged_supplier_1 l ), agged_supplier_4 
 as ( select S_NAME, mx_addr from agged_supplier_2 l group by S_NAME,mx_addr ), 
 agged_supplier_5 as ( select l.S_NAME, l.mx_addr from agged_supplier_4 l join supplier r where r.s_suppkey=10 ) 
-select l.S_NAME,l.mx_addr from agged_supplier_5 l right join [shuffle] supplier z on l.S_NAME = z.S_NAME and l.mx_addr = z.s_region order by 2 nulls last,1 limit 10
+select l.S_NAME,l.mx_addr from agged_supplier_5 l right join [shuffle] supplier z on l.S_NAME = z.S_NAME and l.mx_addr = z.s_region order by 2 nulls last,1 limit 10;
 -- result:
 1	1
 10	10

--- a/test/sql/test_low_cardinality/T/test_low_cardinality2
+++ b/test/sql/test_low_cardinality/T/test_low_cardinality2
@@ -304,8 +304,8 @@ function: wait_global_dict_ready('v4', 's1')
 function: wait_global_dict_ready('v3', 's2')
 function: wait_global_dict_ready('v4', 's2')
 
-select concat(upper(v2), "1"), max(v3) from s2 where v4 = "BJ" group by upper(v2);
-select concat(upper(v4), "1"), max(v3) from s2 where v4 = "BJ" group by upper(v4);
+select concat(upper(v2), "1"), max(v3) from s2 where v4 = "BJ" group by upper(v2) order by 1, 2;
+select concat(upper(v4), "1"), max(v3) from s2 where v4 = "BJ" group by upper(v4) order by 1, 2;
 
 select count(distinct v3), max(v3), count(distinct v4) as a from s2;
 
@@ -389,3 +389,36 @@ where x2 = "anhui"
 GROUP BY x1
 HAVING MAX(y2) = "JX";
 
+
+CREATE TABLE `supplier` (
+  `s_suppkey` int(11) NOT NULL COMMENT "",
+  `s_name` varchar(26) NOT NULL COMMENT "",
+  `s_region` varchar(13) NOT NULL COMMENT ""
+) ENGINE=OLAP 
+DUPLICATE KEY(`s_suppkey`)
+COMMENT "OLAP"
+DISTRIBUTED BY HASH(`s_suppkey`) BUCKETS 12 
+PROPERTIES (
+"replication_num" = "1"
+);
+
+insert into
+    supplier
+SELECT
+    generate_series,
+    generate_series,
+    generate_series % 16
+FROM
+    TABLE(generate_series(1, 4096));
+
+[UC] analyze full table supplier;
+
+function: wait_global_dict_ready('s_region', 'supplier')
+
+
+with agged_supplier as ( select S_NAME, max(s_region) as mx_addr from supplier group by S_NAME ), 
+agged_supplier_1 as ( select l.S_NAME, l.mx_addr mx_addr from agged_supplier l join [shuffle] supplier r on l.S_NAME=r.S_NAME ), 
+agged_supplier_2 as ( select S_NAME, if(mx_addr = 'key', 'key2', S_NAME) mx_addr from agged_supplier_1 l ), agged_supplier_4 
+as ( select S_NAME, mx_addr from agged_supplier_2 l group by S_NAME,mx_addr ), 
+agged_supplier_5 as ( select l.S_NAME, l.mx_addr from agged_supplier_4 l join supplier r where r.s_suppkey=10 ) 
+select l.S_NAME,l.mx_addr from agged_supplier_5 l right join [shuffle] supplier z on l.S_NAME = z.S_NAME and l.mx_addr = z.s_region order by 2 nulls last,1 limit 10

--- a/test/sql/test_low_cardinality/T/test_low_cardinality2
+++ b/test/sql/test_low_cardinality/T/test_low_cardinality2
@@ -421,4 +421,4 @@ agged_supplier_1 as ( select l.S_NAME, l.mx_addr mx_addr from agged_supplier l j
 agged_supplier_2 as ( select S_NAME, if(mx_addr = 'key', 'key2', S_NAME) mx_addr from agged_supplier_1 l ), agged_supplier_4 
 as ( select S_NAME, mx_addr from agged_supplier_2 l group by S_NAME,mx_addr ), 
 agged_supplier_5 as ( select l.S_NAME, l.mx_addr from agged_supplier_4 l join supplier r where r.s_suppkey=10 ) 
-select l.S_NAME,l.mx_addr from agged_supplier_5 l right join [shuffle] supplier z on l.S_NAME = z.S_NAME and l.mx_addr = z.s_region order by 2 nulls last,1 limit 10
+select l.S_NAME,l.mx_addr from agged_supplier_5 l right join [shuffle] supplier z on l.S_NAME = z.S_NAME and l.mx_addr = z.s_region order by 2 nulls last,1 limit 10;


### PR DESCRIPTION
we have supported runtime filter in lowcardinality v2.

```
*** SIGSEGV (@0x3c0) received by PID 1799443 (TID 0x7f94992ca640) from PID 960; stack trace: ***
    @         0x1db4c8ba google::(anonymous namespace)::FailureSignalHandler()
    @     0x7f957f1ba520 (unknown)
    @         0x10ab30b9 std::__shared_ptr<>::get()
    @         0x10ab1f8c starrocks::RuntimeState::obj_pool()
    @         0x1b949049 _ZZN9starrocks18DictOptimizeParser12rewrite_exprEPNS_11ExprContextEPNS_4ExprEiENKUlvE_clEv
    @         0x1b94c327 _ZZN9starrocks15DictMappingExpr7rewriteIZNS_18DictOptimizeParser12rewrite_exprEPNS_11ExprContextEPNS_4ExprEiEUlvE_EENS_6StatusEOT_ENKUlvE_clEv
    @         0x1b94d579 _ZSt13__invoke_implIvZN9starrocks15DictMappingExpr7rewriteIZNS0_18DictOptimizeParser12rewrite_exprEPNS0_11ExprContextEPNS0_4ExprEiEUlvE_EENS0_6StatusEOT_EUlvE_JEESA_St14__invoke_otherOT0_DpOT1_
    @         0x1b94d3f7 _ZSt8__invokeIZN9starrocks15DictMappingExpr7rewriteIZNS0_18DictOptimizeParser12rewrite_exprEPNS0_11ExprContextEPNS0_4ExprEiEUlvE_EENS0_6StatusEOT_EUlvE_JEENSt15__invoke_resultISA_JDpT0_EE4typeESB_DpOSE_
    @         0x1b94cffc _ZZSt9call_onceIZN9starrocks15DictMappingExpr7rewriteIZNS0_18DictOptimizeParser12rewrite_exprEPNS0_11ExprContextEPNS0_4ExprEiEUlvE_EENS0_6StatusEOT_EUlvE_JEEvRSt9once_flagSB_DpOT0_ENKUlvE_clEv
    @         0x1b94d419 _ZZNSt9once_flag18_Prepare_executionC4IZSt9call_onceIZN9starrocks15DictMappingExpr7rewriteIZNS3_18DictOptimizeParser12rewrite_exprEPNS3_11ExprContextEPNS3_4ExprEiEUlvE_EENS3_6StatusEOT_EUlvE_JEEvRS_SE_DpOT0_EUlvE_EERSD_ENKUlvE_clEv
    @         0x1b94d42e _ZZNSt9once_flag18_Prepare_executionC4IZSt9call_onceIZN9starrocks15DictMappingExpr7rewriteIZNS3_18DictOptimizeParser12rewrite_exprEPNS3_11ExprContextEPNS3_4ExprEiEUlvE_EENS3_6StatusEOT_EUlvE_JEEvRS_SE_DpOT0_EUlvE_EERSD_ENUlvE_4_FUNEv
    @     0x7f957f211ee8 (unknown)
    @         0x1b9457c0 __gthread_once()
    @         0x1b94d101 _ZSt9call_onceIZN9starrocks15DictMappingExpr7rewriteIZNS0_18DictOptimizeParser12rewrite_exprEPNS0_11ExprContextEPNS0_4ExprEiEUlvE_EENS0_6StatusEOT_EUlvE_JEEvRSt9once_flagSB_DpOT0_
    @         0x1b94c816 _ZN9starrocks15DictMappingExpr7rewriteIZNS_18DictOptimizeParser12rewrite_exprEPNS_11ExprContextEPNS_4ExprEiEUlvE_EENS_6StatusEOT_
    @         0x1b949848 starrocks::DictOptimizeParser::rewrite_expr()
    @         0x17c41190 starrocks::DictMappingExpr::open()
    @         0x15f11fd9 starrocks::Expr::open()
    @         0x15efc881 starrocks::ExprContext::open()
    @         0x17fa8f90 starrocks::RuntimeFilterProbeDescriptor::replace_probe_expr_ctx()
    @         0x12377a94 starrocks::ProjectNode::push_down_join_runtime_filter()
    @         0x12c1fd29 starrocks::ExecNode::push_down_join_runtime_filter_recursively()
    @         0x12c1fdf6 starrocks::ExecNode::push_down_join_runtime_filter_recursively()
    @         0x12c1fdf6 starrocks::ExecNode::push_down_join_runtime_filter_recursively()
    @         0x12c1fdf6 starrocks::ExecNode::push_down_join_runtime_filter_recursively()
    @         0x12c1fdf6 starrocks::ExecNode::push_down_join_runtime_filter_recursively()
    @         0x12c1fdf6 starrocks::ExecNode::push_down_join_runtime_filter_recursively()
    @         0x12c0aca4 starrocks::pipeline::FragmentExecutor::_prepare_exec_plan()
    @         0x12c14056 starrocks::pipeline::FragmentExecutor::prepare()
    @         0x1ba5352b starrocks::PInternalServiceImplBase<>::_exec_plan_fragment_by_pipeline()
    @         0x1ba52f46 starrocks::PInternalServiceImplBase<>::_exec_plan_fragment()
    @         0x1ba4cbb5 starrocks::PInternalServiceImplBase<>::_exec_plan_fragment()
```

## Why I'm doing:

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
