### PR TITLE
[Enhancement] return 1295 when statement is not supported by prepare-statement

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/common/ErrorCode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/ErrorCode.java
@@ -91,6 +91,8 @@ public enum ErrorCode {
     ERR_NOT_SUPPORTED_AUTH_MODE(1251, new byte[] {'0', '8', '0', '0', '4'},
             "Client does not support authentication protocol requested by server; consider upgrading MySQL client"),
     ERR_UNKNOWN_STORAGE_ENGINE(1286, new byte[] {'4', '2', '0', '0', '0'}, "Unknown storage engine '%s'"),
+    ERR_UNSUPPORTED_PS(1295, "HY000".getBytes(),
+            "This command is not supported in the prepared statement protocol yet"),
     ERR_UNKNOWN_TIME_ZONE(1298, new byte[] {'H', 'Y', '0', '0', '0'}, "Unknown or incorrect time zone: '%s'"),
     ERR_WRONG_OBJECT(1347, new byte[] {'H', 'Y', '0', '0', '0'}, "'%s'.'%s' is not '%s'"),
     ERR_VIEW_WRONG_LIST(1353, new byte[] {'H', 'Y', '0', '0', '0'},

--- a/fe/fe-core/src/main/java/com/starrocks/common/ErrorReport.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/ErrorReport.java
@@ -52,6 +52,7 @@ public class ErrorReport {
         ConnectContext ctx = ConnectContext.get();
         if (ctx != null) {
             ctx.getState().setError(errMsg);
+            ctx.getState().setErrorCode(errorCode);
         }
         // TODO(zc): think about LOG to file
         return errMsg;

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/PrepareAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/PrepareAnalyzer.java
@@ -14,6 +14,8 @@
 
 package com.starrocks.sql.analyzer;
 
+import com.starrocks.common.ErrorCode;
+import com.starrocks.common.ErrorReport;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.qe.PrepareStmtContext;
 import com.starrocks.sql.ast.ExecuteStmt;
@@ -44,7 +46,7 @@ public class PrepareAnalyzer {
         if (prepareStmt != null) {
             StatementBase innerStmt = prepareStmt.getInnerStmt();
             if (!(innerStmt instanceof QueryStatement)) {
-                throw new ValidateException("Invalid statement type for prepared statement", ErrorType.USER_ERROR);
+                ErrorReport.reportSemanticException(ErrorCode.ERR_UNSUPPORTED_PS, ErrorType.UNSUPPORTED);
             }
             // Analyzing when preparing is only used to return the correct resultset meta, but not to generate an
             // execution plan

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/PrepareAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/PrepareAnalyzer.java
@@ -46,7 +46,7 @@ public class PrepareAnalyzer {
         if (prepareStmt != null) {
             StatementBase innerStmt = prepareStmt.getInnerStmt();
             if (!(innerStmt instanceof QueryStatement)) {
-                ErrorReport.reportValidateException(ErrorCode.ERR_UNSUPPORTED_PS, ErrorType.UNSUPPORTED);
+                ErrorReport.reportSemanticException(ErrorCode.ERR_UNSUPPORTED_PS, ErrorType.UNSUPPORTED);
             }
             // Analyzing when preparing is only used to return the correct resultset meta, but not to generate an
             // execution plan

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/PrepareAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/PrepareAnalyzer.java
@@ -46,7 +46,7 @@ public class PrepareAnalyzer {
         if (prepareStmt != null) {
             StatementBase innerStmt = prepareStmt.getInnerStmt();
             if (!(innerStmt instanceof QueryStatement)) {
-                ErrorReport.reportSemanticException(ErrorCode.ERR_UNSUPPORTED_PS, ErrorType.UNSUPPORTED);
+                ErrorReport.reportValidateException(ErrorCode.ERR_UNSUPPORTED_PS, ErrorType.UNSUPPORTED);
             }
             // Analyzing when preparing is only used to return the correct resultset meta, but not to generate an
             // execution plan

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/PreparedStmtTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/PreparedStmtTest.java
@@ -21,7 +21,6 @@ import com.starrocks.qe.StmtExecutor;
 import com.starrocks.sql.ast.PrepareStmt;
 import com.starrocks.sql.ast.StatementBase;
 import com.starrocks.sql.common.StarRocksPlannerException;
-import com.starrocks.sql.optimizer.validate.ValidateException;
 import com.starrocks.sql.parser.SqlParser;
 import com.starrocks.utframe.StarRocksAssert;
 import com.starrocks.utframe.UtFrameUtils;
@@ -99,7 +98,8 @@ public class PreparedStmtTest{
     @Test
     public void testPrepareStatementParser() {
         String sql = "PREPARE stmt1 FROM insert into demo.prepare_stmt values (?, ?, ?, ?);";
-        Exception e = assertThrows(ValidateException.class, () -> UtFrameUtils.parseStmtWithNewParser(sql, ctx));
-        assertEquals("This command is not supported in the prepared statement protocol yet", e.getMessage());
+        Exception e = assertThrows(AnalysisException.class, () -> UtFrameUtils.parseStmtWithNewParser(sql, ctx));
+        assertEquals("Getting analyzing error. Detail message: This command is not supported in the " +
+                "prepared statement protocol yet.", e.getMessage());
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/PreparedStmtTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/PreparedStmtTest.java
@@ -29,6 +29,7 @@ import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 
@@ -98,7 +99,7 @@ public class PreparedStmtTest{
     @Test
     public void testPrepareStatementParser() {
         String sql = "PREPARE stmt1 FROM insert into demo.prepare_stmt values (?, ?, ?, ?);";
-        assertThrows("Invalid statement type for prepared statement", ValidateException.class,
-                () -> UtFrameUtils.parseStmtWithNewParser(sql, ctx));
+        Exception e = assertThrows(ValidateException.class, () -> UtFrameUtils.parseStmtWithNewParser(sql, ctx));
+        assertEquals("This command is not supported in the prepared statement protocol yet", e.getMessage());
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/pseudocluster/PseudoClusterTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/pseudocluster/PseudoClusterTest.java
@@ -23,6 +23,7 @@ import com.staros.proto.S3FileStoreInfo;
 import com.starrocks.common.AnalysisException;
 import com.starrocks.common.Config;
 import com.starrocks.common.DdlException;
+import com.starrocks.common.ErrorCode;
 import com.starrocks.lake.StarOSAgent;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.server.RunMode;
@@ -38,6 +39,7 @@ import org.junit.Test;
 import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
+import java.sql.SQLException;
 import java.sql.Statement;
 
 public class PseudoClusterTest {
@@ -120,8 +122,9 @@ public class PseudoClusterTest {
             try {
                 stmt.execute("prepare stmt2 from insert overwrite test values (1,2)");
                 Assert.fail("expected exception was not occured.");
-            } catch (Exception e) {
-                Assert.assertTrue(e.getMessage().contains("Invalid statement type for prepared statement"));
+            } catch (SQLException e) {
+                Assert.assertEquals(ErrorCode.ERR_UNSUPPORTED_PS.getCode(), e.getErrorCode());
+                Assert.assertTrue(e.getMessage().contains(ErrorCode.ERR_UNSUPPORTED_PS.formatErrorMsg()));
             }
 
             // client prepared stmt
@@ -155,8 +158,9 @@ public class PseudoClusterTest {
             try {
                 stmt.execute("prepare stmt2 from insert overwrite test values (1,2)");
                 Assert.fail("expected exception was not occured.");
-            } catch (Exception e) {
-                Assert.assertTrue(e.getMessage().contains("Invalid statement type for prepared statement"));
+            } catch (SQLException e) {
+                Assert.assertEquals(ErrorCode.ERR_UNSUPPORTED_PS.getCode(), e.getErrorCode());
+                Assert.assertTrue(e.toString(), e.getMessage().contains(ErrorCode.ERR_UNSUPPORTED_PS.formatErrorMsg()));
             }
 
             // client prepared stmt

--- a/test/sql/test_auto_increment/R/test_auto_increment
+++ b/test/sql/test_auto_increment/R/test_auto_increment
@@ -27,7 +27,7 @@ E: (1064, 'Getting analyzing error from line 1, column 53 to line 1, column 74. 
 -- !result
 DROP DATABASE test_create_table_abnormal;
 -- result:
-E: (1064, "Can't drop database 'test_create_table_abnormal'; database doesn't exist")
+E: (1008, "Can't drop database 'test_create_table_abnormal'; database doesn't exist")
 -- !result
 -- name: test_create_table_normal
 CREATE DATABASE test_create_table_normal_auto_increment;

--- a/test/sql/test_automatic_bucket/R/test_automatic_partition
+++ b/test/sql/test_automatic_bucket/R/test_automatic_partition
@@ -55,7 +55,7 @@ alter table t set('bucket_size'='0');
 -- !result
 alter table t set('bucket_size'='-1');
 -- result:
-E: (1064, 'Getting analyzing error. Detail message: Illegal bucket size: -1.')
+E: (5064, 'Getting analyzing error. Detail message: Illegal bucket size: -1.')
 -- !result
 alter table t set('bucket_size'='2048');
 -- result:

--- a/test/sql/test_column_rename/R/test_column_rename
+++ b/test/sql/test_column_rename/R/test_column_rename
@@ -206,7 +206,7 @@ alter table t2 rename column k1 to k2;
 -- !result
 insert into t2(k1,v1,v2) values(4, 5, 6);
 -- result:
-E: (1060, "Getting analyzing error. Detail message: Unknown column 'k1' in 't2'.")
+E: (1064, "Getting analyzing error. Detail message: Unknown column 'k1' in 't2'.")
 -- !result
 insert into t2(k2,v1,v2) values(4, 5, 6);
 -- result:

--- a/test/sql/test_column_rename/R/test_column_rename
+++ b/test/sql/test_column_rename/R/test_column_rename
@@ -40,7 +40,7 @@ ALTER TABLE t1 RENAME COLUMN k1 TO k2;
 -- !result
 ALTER TABLE t1 RENAME COLUMN v1 TO v2;
 -- result:
-E: (1064, "Unexpected exception: Getting analyzing error. Detail message: Duplicate column name 'v2'.")
+E: (1060, "Unexpected exception: Getting analyzing error. Detail message: Duplicate column name 'v2'.")
 -- !result
 select * from t1;
 -- result:
@@ -206,7 +206,7 @@ alter table t2 rename column k1 to k2;
 -- !result
 insert into t2(k1,v1,v2) values(4, 5, 6);
 -- result:
-E: (1064, "Getting analyzing error. Detail message: Unknown column 'k1' in 't2'.")
+E: (1060, "Getting analyzing error. Detail message: Unknown column 'k1' in 't2'.")
 -- !result
 insert into t2(k2,v1,v2) values(4, 5, 6);
 -- result:

--- a/test/sql/test_column_rename/R/test_column_rename2
+++ b/test/sql/test_column_rename/R/test_column_rename2
@@ -98,7 +98,7 @@ PROPERTIES (
 "replication_num" = "1"
 );
 -- result:
-E: (1064, "Getting analyzing error. Detail message: Table 'site_access' already exists.")
+E: (1050, "Getting analyzing error. Detail message: Table 'site_access' already exists.")
 -- !result
 alter table site_access rename column site_id to id;
 -- result:

--- a/test/sql/test_dictionary/R/test_dictionary
+++ b/test/sql/test_dictionary/R/test_dictionary
@@ -104,7 +104,7 @@ DROP DICTIONARY test_dictionary_basic_operation;
 -- !result
 DROP TABLE test_dictionary_basic_operation;
 -- result:
-E: (1064, "Getting analyzing error. Detail message: Unknown table 'test_dictionary_basic_operation'.")
+E: (1051, "Getting analyzing error. Detail message: Unknown table 'test_dictionary_basic_operation'.")
 -- !result
 -- name: test_dictionary_type_combination
 CREATE TABLE `t_type_combination` (

--- a/test/sql/test_drop_table/R/test_drop_table
+++ b/test/sql/test_drop_table/R/test_drop_table
@@ -32,7 +32,7 @@ DROP TABLE t0 FORCE;
 -- !result
 RECOVER TABLE t0;
 -- result:
-E: (1064, "Unknown table 't0'")
+E: (1051, "Unknown table 't0'")
 -- !result
 CREATE TABLE t0(c0 INT, c1 INT) DUPLICATE KEY(c0) DISTRIBUTED BY HASH(c0) BUCKETS 1 PROPERTIES('replication_num'='1');
 -- result:
@@ -48,7 +48,7 @@ CREATE TABLE t0(c0 INT, c1 INT) DUPLICATE KEY(c0) DISTRIBUTED BY HASH(c0) BUCKET
 -- !result
 RECOVER TABLE t0;
 -- result:
-E: (1064, "Table 't0' already exists")
+E: (1050, "Table 't0' already exists")
 -- !result
 INSERT INTO t0 VALUES(1, 100),(2, 200),(3, 300);
 -- result:

--- a/test/sql/test_hive/R/test_hive_sink
+++ b/test/sql/test_hive/R/test_hive_sink
@@ -23,7 +23,7 @@ select * from t1;
 -- !result
 insert into t1 values( 999,888,'9999-12-03', 3),( 999,888,'9999-12-33', 3);
 -- result:
-E: (5064, "Partition value can't be null.")
+E: (5025, "Partition value can't be null.")
 -- !result
 select * from t1;
 -- result:

--- a/test/sql/test_hive/R/test_hive_sink
+++ b/test/sql/test_hive/R/test_hive_sink
@@ -23,7 +23,7 @@ select * from t1;
 -- !result
 insert into t1 values( 999,888,'9999-12-03', 3),( 999,888,'9999-12-33', 3);
 -- result:
-E: (1064, "Partition value can't be null.")
+E: (5064, "Partition value can't be null.")
 -- !result
 select * from t1;
 -- result:

--- a/test/sql/test_materialized_view/R/test_mv_partition_compensate_iceberg
+++ b/test/sql/test_materialized_view/R/test_mv_partition_compensate_iceberg
@@ -1593,5 +1593,5 @@ drop table mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t2 force;
 -- !result
 drop table mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t2 force;
 -- result:
-E: (1064, "Getting analyzing error. Detail message: Unknown table 't2'.")
+E: (1051, "Getting analyzing error. Detail message: Unknown table 't2'.")
 -- !result

--- a/test/sql/test_preparestatement/R/test_prepare_statment_partition_changed
+++ b/test/sql/test_preparestatement/R/test_prepare_statment_partition_changed
@@ -6,9 +6,8 @@ CREATE TABLE IF NOT EXISTS prepare_stmt (
 PRIMARY KEY (k1)
 DISTRIBUTED BY HASH(k1) BUCKETS 1 PROPERTIES("replication_num" = "1");
 -- result:
-[]
 -- !result
 PREPARE stmt1 FROM insert overwrite prepare_stmt values (?, ?);
 -- result:
-E: (1295, 'Invalid statement type for prepared statement')
+E: (1295, 'Getting analyzing error. Detail message: This command is not supported in the prepared statement protocol yet.')
 -- !result

--- a/test/sql/test_preparestatement/R/test_prepare_statment_partition_changed
+++ b/test/sql/test_preparestatement/R/test_prepare_statment_partition_changed
@@ -10,5 +10,5 @@ DISTRIBUTED BY HASH(k1) BUCKETS 1 PROPERTIES("replication_num" = "1");
 -- !result
 PREPARE stmt1 FROM insert overwrite prepare_stmt values (?, ?);
 -- result:
-E: (1064, 'Invalid statement type for prepared statement')
+E: (1295, 'Invalid statement type for prepared statement')
 -- !result

--- a/test/sql/test_primary_index_cache_expire/R/test_primary_index_cache_expire
+++ b/test/sql/test_primary_index_cache_expire/R/test_primary_index_cache_expire
@@ -97,15 +97,15 @@ select * from tab1 where v2 = 200;
 -- !result
 alter table tab1 set ("primary_index_cache_expire_sec" = "add");
 -- result:
-E: (1064, 'Getting analyzing error. Detail message: Property primary_index_cache_expire_sec must be integer: add.')
+E: (5064, 'Getting analyzing error. Detail message: Property primary_index_cache_expire_sec must be integer: add.')
 -- !result
 alter table tab1 set ("primary_index_cache_expire_sec" = "-1");
 -- result:
-E: (1064, 'Getting analyzing error. Detail message: Property primary_index_cache_expire_sec must not be less than 0.')
+E: (5064, 'Getting analyzing error. Detail message: Property primary_index_cache_expire_sec must not be less than 0.')
 -- !result
 alter table tab1 set ("primary_index_cache_expire_sec" = "-3600");
 -- result:
-E: (1064, 'Getting analyzing error. Detail message: Property primary_index_cache_expire_sec must not be less than 0.')
+E: (5064, 'Getting analyzing error. Detail message: Property primary_index_cache_expire_sec must not be less than 0.')
 -- !result
 CREATE table tab2 (
       k1 INTEGER,


### PR DESCRIPTION
## Why I'm doing:
- error code 1295 is defined by MySQL for unsupported prepare-statement


## What I'm doing:

Fixes #41757

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
