### PR TITLE
[BugFix] fix wrong slot index when handling iceberg delete columns

### DIFF
--- a/be/src/exec/hdfs_scanner.h
+++ b/be/src/exec/hdfs_scanner.h
@@ -168,7 +168,7 @@ struct HdfsScannerParams {
     // The file last modification time
     int64_t modification_time = 0;
 
-    TupleDescriptor* tuple_desc = nullptr;
+    const TupleDescriptor* tuple_desc = nullptr;
 
     // columns read from file
     std::vector<SlotDescriptor*> materialize_slots;

--- a/be/src/formats/parquet/group_reader.cpp
+++ b/be/src/formats/parquet/group_reader.cpp
@@ -380,11 +380,9 @@ void GroupReader::collect_io_ranges(std::vector<io::SharedBufferedInputStream::I
 }
 
 void GroupReader::_init_read_chunk() {
-    const auto& slots = _param.tuple_desc->slots();
-    std::vector<SlotDescriptor*> read_slots;
+    std::vector<const SlotDescriptor*> read_slots;
     for (const auto& column : _param.read_cols) {
-        int chunk_index = column.idx_in_chunk;
-        read_slots.emplace_back(slots[chunk_index]);
+        read_slots.emplace_back(column.slot_desc);
     }
     size_t chunk_size = _param.chunk_size;
     _read_chunk = ChunkHelper::new_chunk(read_slots, chunk_size);

--- a/be/src/formats/parquet/group_reader.cpp
+++ b/be/src/formats/parquet/group_reader.cpp
@@ -380,7 +380,7 @@ void GroupReader::collect_io_ranges(std::vector<io::SharedBufferedInputStream::I
 }
 
 void GroupReader::_init_read_chunk() {
-    std::vector<const SlotDescriptor*> read_slots;
+    std::vector<SlotDescriptor*> read_slots;
     for (const auto& column : _param.read_cols) {
         read_slots.emplace_back(column.slot_desc);
     }

--- a/be/src/formats/parquet/group_reader.h
+++ b/be/src/formats/parquet/group_reader.h
@@ -45,10 +45,7 @@ struct GroupReaderParam {
         // column type in parquet file
         tparquet::Type::type type_in_parquet;
 
-        // column index in chunk
-        // int32_t idx_in_chunk;
-
-        const SlotDescriptor* slot_desc = nullptr;
+        SlotDescriptor* slot_desc = nullptr;
 
         const TIcebergSchemaField* t_iceberg_schema_field = nullptr;
 

--- a/be/src/formats/parquet/group_reader.h
+++ b/be/src/formats/parquet/group_reader.h
@@ -46,7 +46,7 @@ struct GroupReaderParam {
         tparquet::Type::type type_in_parquet;
 
         // column index in chunk
-        int32_t idx_in_chunk;
+        // int32_t idx_in_chunk;
 
         const SlotDescriptor* slot_desc = nullptr;
 

--- a/be/src/formats/parquet/meta_helper.cpp
+++ b/be/src/formats/parquet/meta_helper.cpp
@@ -53,9 +53,8 @@ void ParquetMetaHelper::prepare_read_columns(const std::vector<HdfsScannerContex
         if (field_idx < 0) continue;
 
         auto parquet_type = _file_metadata->schema().get_stored_column_by_field_idx(field_idx)->physical_type;
-        GroupReaderParam::Column column =
-                _build_column(field_idx, materialized_column.idx_in_chunk, parquet_type, materialized_column.slot_desc,
-                              materialized_column.decode_needed);
+        GroupReaderParam::Column column = _build_column(field_idx, parquet_type, materialized_column.slot_desc,
+                                                        materialized_column.decode_needed);
         read_cols.emplace_back(column);
     }
 }
@@ -119,9 +118,8 @@ void IcebergMetaHelper::prepare_read_columns(const std::vector<HdfsScannerContex
 
         auto parquet_type = _file_metadata->schema().get_stored_column_by_field_id(field_id)->physical_type;
 
-        GroupReaderParam::Column column =
-                _build_column(field_idx, materialized_column.idx_in_chunk, parquet_type, materialized_column.slot_desc,
-                              materialized_column.decode_needed, iceberg_it->second);
+        GroupReaderParam::Column column = _build_column(field_idx, parquet_type, materialized_column.slot_desc,
+                                                        materialized_column.decode_needed, iceberg_it->second);
         read_cols.emplace_back(column);
     }
 }

--- a/be/src/formats/parquet/meta_helper.h
+++ b/be/src/formats/parquet/meta_helper.h
@@ -61,7 +61,7 @@ public:
 
 protected:
     GroupReaderParam::Column _build_column(int32_t idx_in_parquet, const tparquet::Type::type& type_in_parquet,
-                                           const SlotDescriptor* slot_desc, bool decode_needed,
+                                           SlotDescriptor* slot_desc, bool decode_needed,
                                            const TIcebergSchemaField* t_iceberg_schema_field = nullptr) const {
         GroupReaderParam::Column column{};
         column.idx_in_parquet = idx_in_parquet;

--- a/be/src/formats/parquet/meta_helper.h
+++ b/be/src/formats/parquet/meta_helper.h
@@ -60,14 +60,12 @@ public:
     }
 
 protected:
-    GroupReaderParam::Column _build_column(int32_t idx_in_parquet, int32_t idx_in_chunk,
-                                           const tparquet::Type::type& type_in_parquet, const SlotDescriptor* slot_desc,
-                                           bool decode_needed,
+    GroupReaderParam::Column _build_column(int32_t idx_in_parquet, const tparquet::Type::type& type_in_parquet,
+                                           const SlotDescriptor* slot_desc, bool decode_needed,
                                            const TIcebergSchemaField* t_iceberg_schema_field = nullptr) const {
         GroupReaderParam::Column column{};
         column.idx_in_parquet = idx_in_parquet;
         column.type_in_parquet = type_in_parquet;
-        column.idx_in_chunk = idx_in_chunk;
         column.slot_desc = slot_desc;
         column.t_iceberg_schema_field = t_iceberg_schema_field;
         column.decode_needed = decode_needed;

--- a/be/test/formats/parquet/group_reader_test.cpp
+++ b/be/test/formats/parquet/group_reader_test.cpp
@@ -156,7 +156,7 @@ ChunkPtr GroupReaderTest::_create_chunk(GroupReaderParam* param) {
     ChunkPtr chunk = std::make_shared<Chunk>();
     for (auto& column : param->read_cols) {
         auto c = ColumnHelper::create_column(column.slot_type(), true);
-        chunk->append_column(c, column.idx_in_chunk);
+        chunk->append_column(c, column.slot_id());
     }
     return chunk;
 }

--- a/be/test/formats/parquet/group_reader_test.cpp
+++ b/be/test/formats/parquet/group_reader_test.cpp
@@ -321,7 +321,6 @@ static GroupReaderParam::Column _create_group_reader_param_of_column(int idx, tp
             new SlotDescriptor(idx, fmt::format("col{}", idx), TypeDescriptor::from_logical_type(prim_type));
     GroupReaderParam::Column c;
     c.idx_in_parquet = idx;
-    c.idx_in_chunk = idx;
     c.type_in_parquet = par_type;
     c.slot_desc = slot;
     return c;


### PR DESCRIPTION
## Why I'm doing:

We compute wrong slot index when dealing with deleted columns.

## What I'm doing:

data in `_materialize_index_in_chunk` should not exceed `slots.size()`

Fixes https://github.com/StarRocks/starrocks/issues/41866


When I'm debugging this issue, I can see we compute wrong slot index

**I0228 16:21:48.260135 490497 group_reader.cpp:398] [xxx] tuple desc = 0x6070000de9d0, slot desc = 0xbebebebebebebebe, slot index = 3**

```
I0228 16:21:46.591665 490466 descriptors.cpp:756] [xxx] create descriptor. tuple desc = 0x6070000de9d0, slot desc = 0x60d000050330, name = id
I0228 16:21:46.591701 490466 descriptors.cpp:756] [xxx] create descriptor. tuple desc = 0x6070000de9d0, slot desc = 0x60d000050400, name = yyyymmdd
I0228 16:21:46.591732 490466 descriptors.cpp:756] [xxx] create descriptor. tuple desc = 0x6070000de9d0, slot desc = 0x60d0000504d0, name = type
I0228 16:21:46.591763 490466 descriptors.cpp:756] [xxx] create descriptor. tuple desc = 0x6070000dea40, slot desc = 0x60d0000505a0, name = id
I0228 16:21:46.591782 490466 descriptors.cpp:756] [xxx] create descriptor. tuple desc = 0x6070000dea40, slot desc = 0x60d000050670, name = yyyymmdd
I0228 16:21:48.260039 490497 group_reader.cpp:53] [xxx] tuple desc = 0x6070000de9d0, slot desc = 0x60d000050330
I0228 16:21:48.260061 490497 group_reader.cpp:53] [xxx] tuple desc = 0x6070000de9d0, slot desc = 0x60d000050400
I0228 16:21:48.260088 490497 group_reader.cpp:53] [xxx] tuple desc = 0x6070000de9d0, slot desc = 0x60d0000504d0
I0228 16:21:48.260099 490497 group_reader.cpp:390] [xxx] tuple desc = 0x6070000de9d0, slot desc = 0x60d000050330
I0228 16:21:48.260105 490497 group_reader.cpp:390] [xxx] tuple desc = 0x6070000de9d0, slot desc = 0x60d000050400
I0228 16:21:48.260111 490497 group_reader.cpp:390] [xxx] tuple desc = 0x6070000de9d0, slot desc = 0x60d0000504d0
I0228 16:21:48.260121 490497 group_reader.cpp:398] [xxx] tuple desc = 0x6070000de9d0, slot desc = 0x60d000050330, slot index = 0
I0228 16:21:48.260128 490497 group_reader.cpp:398] [xxx] tuple desc = 0x6070000de9d0, slot desc = 0x60d0000504d0, slot index = 2
I0228 16:21:48.260135 490497 group_reader.cpp:398] [xxx] tuple desc = 0x6070000de9d0, slot desc = 0xbebebebebebebebe, slot index = 3
```


## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5