### PR TITLE
[BugFix] Fix race condition when access delete predicate list in tablet meta (#42099)

### DIFF
--- a/be/src/storage/tablet.cpp
+++ b/be/src/storage/tablet.cpp
@@ -195,9 +195,9 @@ Status Tablet::revise_tablet_meta(const std::vector<RowsetMetaSharedPtr>& rowset
         // delete versions from new local tablet_meta
         for (const Version& version : versions_to_delete) {
             new_tablet_meta->delete_rs_meta_by_version(version, nullptr);
-            // lock free version for version_for_delete_predicate
-            // caller of revise_tablet_meta has acquired the _meta_lock
-            if (new_tablet_meta->version_for_delete_predicate_unlocked(version)) {
+            // version_for_delete_predicate in tablet_meta is already
+            // lock free
+            if (new_tablet_meta->version_for_delete_predicate(version)) {
                 new_tablet_meta->remove_delete_predicate_by_version(version);
             }
             LOG(INFO) << "delete version from new local tablet_meta when clone. [table=" << full_name()

--- a/be/src/storage/tablet.cpp
+++ b/be/src/storage/tablet.cpp
@@ -1188,7 +1188,7 @@ void Tablet::get_compaction_status(std::string* json_result) {
 
         delete_flags.reserve(rowsets.size());
         for (auto& rs : rowsets) {
-            delete_flags.push_back(version_for_delete_predicate(rs->version()));
+            delete_flags.push_back(version_for_delete_predicate_unlocked(rs->version()));
         }
         // get snapshot version path json_doc
         _timestamped_version_tracker.get_stale_version_path_json_doc(stale_path_arr);

--- a/be/src/storage/tablet.h
+++ b/be/src/storage/tablet.h
@@ -159,6 +159,7 @@ public:
 
     const DelPredicateArray& delete_predicates() const { return _tablet_meta->delete_predicates(); }
     [[nodiscard]] bool version_for_delete_predicate(const Version& version);
+    [[nodiscard]] bool version_for_delete_predicate_unlocked(const Version& version);
     [[nodiscard]] bool has_delete_predicates(const Version& version);
 
     // meta lock

--- a/be/src/storage/tablet_meta.h
+++ b/be/src/storage/tablet_meta.h
@@ -188,7 +188,6 @@ public:
     void remove_delete_predicate_by_version(const Version& version);
     const DelPredicateArray& delete_predicates() const;
     bool version_for_delete_predicate(const Version& version);
-    bool version_for_delete_predicate_unlocked(const Version& version);
     std::string full_name() const;
 
     void set_partition_id(int64_t partition_id);

--- a/be/src/storage/tablet_meta.h
+++ b/be/src/storage/tablet_meta.h
@@ -188,6 +188,7 @@ public:
     void remove_delete_predicate_by_version(const Version& version);
     const DelPredicateArray& delete_predicates() const;
     bool version_for_delete_predicate(const Version& version);
+    bool version_for_delete_predicate_unlocked(const Version& version);
     std::string full_name() const;
 
     void set_partition_id(int64_t partition_id);


### PR DESCRIPTION
## Why I'm doing:
tablet::version_for_delete_predicate do not hold lock to access delete predicate list which may cause crash.

## What I'm doing:
Try to acquire lock in share mode when access delete predicate list

Fixes #42099

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [x] 3.1
  - [x] 3.0
  - [x] 2.5
