### PR TITLE
[Enhancement] Improve hdfs metrics display

### DIFF
--- a/be/src/exec/hdfs_scanner.cpp
+++ b/be/src/exec/hdfs_scanner.cpp
@@ -14,10 +14,9 @@
 
 #include "exec/hdfs_scanner.h"
 
-#include "fs/hdfs/fs_hdfs.h"
-
 #include "column/column_helper.h"
 #include "exec/exec_node.h"
+#include "fs/hdfs/fs_hdfs.h"
 #include "io/compressed_input_stream.h"
 #include "io/shared_buffered_input_stream.h"
 #include "util/compression/stream_compression.h"

--- a/be/src/exec/hdfs_scanner.cpp
+++ b/be/src/exec/hdfs_scanner.cpp
@@ -295,7 +295,7 @@ void HdfsScanner::update_hdfs_counter(HdfsScanProfile* profile) {
 
     for (int64_t i = 0, sz = statistics->size(); i < sz; i++) {
         auto&& name = statistics->name(i);
-        if (name == HdfsReadMetricsKey::kOpenFSTimeNs || name == HdfsReadMetricsKey::kOpenFileTimeNs) {
+        if (name == HdfsReadMetricsKey::kTotalOpenFSTimeNs || name == HdfsReadMetricsKey::kTotalOpenFileTimeNs) {
             auto&& counter = ADD_CHILD_COUNTER(runtime_profile, name, TUnit::TIME_NS, kHdfsIOProfileSectionPrefix);
             COUNTER_UPDATE(counter, statistics->value(i));
         } else if (name == HdfsReadMetricsKey::kTotalBytesRead || name == HdfsReadMetricsKey::kTotalLocalBytesRead ||

--- a/be/src/exec/hdfs_scanner.cpp
+++ b/be/src/exec/hdfs_scanner.cpp
@@ -282,6 +282,7 @@ int64_t HdfsScanner::estimated_mem_usage() const {
 
 void HdfsScanner::update_hdfs_counter(HdfsScanProfile* profile) {
     if (_file == nullptr) return;
+    static const char* const kHdfsIOProfileSectionPrefix = "HdfsIOMetrics";
 
     auto res = _file->get_numeric_statistics();
     if (!res.ok()) return;
@@ -290,7 +291,6 @@ void HdfsScanner::update_hdfs_counter(HdfsScanProfile* profile) {
     if (statistics == nullptr || statistics->size() == 0) return;
 
     RuntimeProfile* runtime_profile = profile->runtime_profile;
-    static constexpr std::string kHdfsIOProfileSectionPrefix = "HdfsIOMetrics";
     ADD_COUNTER(profile->runtime_profile, kHdfsIOProfileSectionPrefix, TUnit::NONE);
 
     for (int64_t i = 0, sz = statistics->size(); i < sz; i++) {

--- a/be/src/exec/hdfs_scanner.cpp
+++ b/be/src/exec/hdfs_scanner.cpp
@@ -14,7 +14,7 @@
 
 #include "exec/hdfs_scanner.h"
 
-#include <fs/hdfs/fs_hdfs.h>
+#include "fs/hdfs/fs_hdfs.h"
 
 #include "column/column_helper.h"
 #include "exec/exec_node.h"

--- a/be/src/fs/hdfs/fs_hdfs.cpp
+++ b/be/src/fs/hdfs/fs_hdfs.cpp
@@ -39,7 +39,7 @@ public:
 
     StatusOr<hdfsFS> getOrCreateFS() {
         if (_hdfs_client == nullptr) {
-            SCOPED_RAW_TIMER(&_open_time_ns);
+            SCOPED_RAW_TIMER(&_open_fs_time_ns);
             std::string namenode;
             RETURN_IF_ERROR(get_namenode_from_path(_path, &namenode));
             RETURN_IF_ERROR(HdfsFsCache::instance()->get_connection(namenode, _hdfs_client, _options));
@@ -49,7 +49,7 @@ public:
 
     StatusOr<hdfsFile> getOrCreateFile() {
         if (_file == nullptr) {
-            SCOPED_RAW_TIMER(&_open_time_ns);
+            SCOPED_RAW_TIMER(&_open_file_time_ns);
             auto st = getOrCreateFS();
             if (!st.ok()) return st.status();
             _file = hdfsOpenFile(st.value(), _path.c_str(), O_RDONLY, _buffer_size, 0, 0);
@@ -67,7 +67,8 @@ public:
 
     hdfsFS getFS() { return _hdfs_client->hdfs_fs; }
     hdfsFile getFile() { return _file; }
-    int64_t getOpenTimeNs() const { return _open_time_ns; }
+    int64_t getOpenFSTimeNs() const { return _open_fs_time_ns; }
+    int64_t getOpenFileTimeNs() const { return _open_file_time_ns; }
     const std::string& getPath() const { return _path; }
     void setOffset(int64_t offset) { _offset = offset; }
 
@@ -158,7 +159,8 @@ private:
     int _buffer_size;
     std::shared_ptr<HdfsFsClient> _hdfs_client = nullptr;
     hdfsFile _file = nullptr;
-    int64_t _open_time_ns = 0;
+    int64_t _open_fs_time_ns = 0;
+    int64_t _open_file_time_ns = 0;
     int64_t _offset = 0;
 };
 
@@ -244,28 +246,29 @@ StatusOr<std::unique_ptr<io::NumericStatistics>> HdfsInputStream::get_numeric_st
         if (file == nullptr) {
             return Status::OK();
         }
-        int64_t open_time_ns = _handle->getOpenTimeNs();
-        int64_t open_time_ms = open_time_ns * 0.000001;
-        stats->append("OpenTimeMs", open_time_ms);
+        stats->append(HdfsReadMetricsKey::kOpenFSTimeNs, _handle->getOpenFSTimeNs());
+        stats->append(HdfsReadMetricsKey::kOpenFileTimeNs, _handle->getOpenFileTimeNs());
 
         struct hdfsReadStatistics* hdfs_statistics = nullptr;
         auto r = hdfsFileGetReadStatistics(file, &hdfs_statistics);
         if (r == -1) {
             return Status::IOError(fmt::format("Fail to get read statistics of {}: {}", r, get_hdfs_err_msg()));
         }
-        stats->append("TotalBytesRead", hdfs_statistics->totalBytesRead);
-        stats->append("TotalLocalBytesRead", hdfs_statistics->totalLocalBytesRead);
-        stats->append("TotalShortCircuitBytesRead", hdfs_statistics->totalShortCircuitBytesRead);
-        stats->append("TotalZeroCopyBytesRead", hdfs_statistics->totalZeroCopyBytesRead);
+        stats->append(HdfsReadMetricsKey::kTotalBytesRead, hdfs_statistics->totalBytesRead);
+        stats->append(HdfsReadMetricsKey::kTotalLocalBytesRead, hdfs_statistics->totalLocalBytesRead);
+        stats->append(HdfsReadMetricsKey::kTotalShortCircuitBytesRead, hdfs_statistics->totalShortCircuitBytesRead);
+        stats->append(HdfsReadMetricsKey::kTotalZeroCopyBytesRead, hdfs_statistics->totalZeroCopyBytesRead);
         hdfsFileFreeReadStatistics(hdfs_statistics);
 
         if (config::hdfs_client_enable_hedged_read) {
             struct hdfsHedgedReadMetrics* hdfs_hedged_read_statistics = nullptr;
             r = hdfsGetHedgedReadMetrics(_handle->getFS(), &hdfs_hedged_read_statistics);
             if (r == 0) {
-                stats->append("TotalHedgedReadOps", hdfs_hedged_read_statistics->hedgedReadOps);
-                stats->append("TotalHedgedReadOpsInCurThread", hdfs_hedged_read_statistics->hedgedReadOpsInCurThread);
-                stats->append("TotalHedgedReadOpsWin", hdfs_hedged_read_statistics->hedgedReadOpsWin);
+                stats->append(HdfsReadMetricsKey::kTotalHedgedReadOps, hdfs_hedged_read_statistics->hedgedReadOps);
+                stats->append(HdfsReadMetricsKey::kTotalHedgedReadOpsInCurThread,
+                              hdfs_hedged_read_statistics->hedgedReadOpsInCurThread);
+                stats->append(HdfsReadMetricsKey::kTotalHedgedReadOpsWin,
+                              hdfs_hedged_read_statistics->hedgedReadOpsWin);
                 hdfsFreeHedgedReadMetrics(hdfs_hedged_read_statistics);
             }
         }

--- a/be/src/fs/hdfs/fs_hdfs.cpp
+++ b/be/src/fs/hdfs/fs_hdfs.cpp
@@ -49,8 +49,8 @@ public:
 
     StatusOr<hdfsFile> getOrCreateFile() {
         if (_file == nullptr) {
-            SCOPED_RAW_TIMER(&_total_open_file_time_ns);
             auto st = getOrCreateFS();
+            SCOPED_RAW_TIMER(&_total_open_file_time_ns);
             if (!st.ok()) return st.status();
             _file = hdfsOpenFile(st.value(), _path.c_str(), O_RDONLY, _buffer_size, 0, 0);
             if (_file == nullptr) {

--- a/be/src/fs/hdfs/fs_hdfs.h
+++ b/be/src/fs/hdfs/fs_hdfs.h
@@ -18,6 +18,21 @@
 
 namespace starrocks {
 
+struct HdfsReadMetricsKey {
+    static constexpr std::string_view kOpenFSTimeNs = "OpenFSTimeNs";
+    static constexpr std::string_view kOpenFileTimeNs = "OpenFileTimeNs";
+
+    static constexpr std::string_view kTotalBytesRead = "TotalBytesRead";
+    static constexpr std::string_view kTotalLocalBytesRead = "TotalLocalBytesRead";
+    static constexpr std::string_view kTotalShortCircuitBytesRead = "TotalShortCircuitBytesRead";
+    static constexpr std::string_view kTotalZeroCopyBytesRead = "TotalZeroCopyBytesRead";
+
+    // metrics for hedged read
+    static constexpr std::string_view kTotalHedgedReadOps = "TotalHedgedReadOps";
+    static constexpr std::string_view kTotalHedgedReadOpsInCurThread = "TotalHedgedReadOpsInCurThread";
+    static constexpr std::string_view kTotalHedgedReadOpsWin = "TotalHedgedReadOpsWin";
+};
+
 std::unique_ptr<FileSystem> new_fs_hdfs(const FSOptions& options);
 
 } // namespace starrocks

--- a/be/src/fs/hdfs/fs_hdfs.h
+++ b/be/src/fs/hdfs/fs_hdfs.h
@@ -19,18 +19,18 @@
 namespace starrocks {
 
 struct HdfsReadMetricsKey {
-    static constexpr std::string_view kTotalOpenFSTimeNs = "TotalOpenFSTimeNs";
-    static constexpr std::string_view kTotalOpenFileTimeNs = "TotalOpenFileTimeNs";
+    static constexpr const char* kTotalOpenFSTimeNs = "TotalOpenFSTimeNs";
+    static constexpr const char* kTotalOpenFileTimeNs = "TotalOpenFileTimeNs";
 
-    static constexpr std::string_view kTotalBytesRead = "TotalBytesRead";
-    static constexpr std::string_view kTotalLocalBytesRead = "TotalLocalBytesRead";
-    static constexpr std::string_view kTotalShortCircuitBytesRead = "TotalShortCircuitBytesRead";
-    static constexpr std::string_view kTotalZeroCopyBytesRead = "TotalZeroCopyBytesRead";
+    static constexpr const char* kTotalBytesRead = "TotalBytesRead";
+    static constexpr const char* kTotalLocalBytesRead = "TotalLocalBytesRead";
+    static constexpr const char* kTotalShortCircuitBytesRead = "TotalShortCircuitBytesRead";
+    static constexpr const char* kTotalZeroCopyBytesRead = "TotalZeroCopyBytesRead";
 
     // metrics for hedged read
-    static constexpr std::string_view kTotalHedgedReadOps = "TotalHedgedReadOps";
-    static constexpr std::string_view kTotalHedgedReadOpsInCurThread = "TotalHedgedReadOpsInCurThread";
-    static constexpr std::string_view kTotalHedgedReadOpsWin = "TotalHedgedReadOpsWin";
+    static constexpr const char* kTotalHedgedReadOps = "TotalHedgedReadOps";
+    static constexpr const char* kTotalHedgedReadOpsInCurThread = "TotalHedgedReadOpsInCurThread";
+    static constexpr const char* kTotalHedgedReadOpsWin = "TotalHedgedReadOpsWin";
 };
 
 std::unique_ptr<FileSystem> new_fs_hdfs(const FSOptions& options);

--- a/be/src/fs/hdfs/fs_hdfs.h
+++ b/be/src/fs/hdfs/fs_hdfs.h
@@ -19,8 +19,8 @@
 namespace starrocks {
 
 struct HdfsReadMetricsKey {
-    static constexpr std::string_view kOpenFSTimeNs = "OpenFSTimeNs";
-    static constexpr std::string_view kOpenFileTimeNs = "OpenFileTimeNs";
+    static constexpr std::string_view kTotalOpenFSTimeNs = "TotalOpenFSTimeNs";
+    static constexpr std::string_view kTotalOpenFileTimeNs = "TotalOpenFileTimeNs";
 
     static constexpr std::string_view kTotalBytesRead = "TotalBytesRead";
     static constexpr std::string_view kTotalLocalBytesRead = "TotalLocalBytesRead";


### PR DESCRIPTION
## Why I'm doing:
previous metrics show is 
```bash
 - HdfsIO: 0ns
   - OpenTimeMs: 9.944K (9944)
     - __MAX_OF_OpenTimeMs: 1.243K (1243)
     - __MIN_OF_OpenTimeMs: 1.243K (1243)
   - TotalBytesRead: 7.987B (7986747100)
     - __MAX_OF_TotalBytesRead: 1.181B (1180814896)
     - __MIN_OF_TotalBytesRead: 870.259M (870258928)
   - TotalLocalBytesRead: 0
   - TotalShortCircuitBytesRead: 0
   - TotalZeroCopyBytesRead: 0
```

## What I'm doing:
Improve it to

```bash
 - HdfsIOMetrics: 
   - TotalBytesRead: 7.438 GB
     - __MAX_OF_TotalBytesRead: 1.157 GB
     - __MIN_OF_TotalBytesRead: 829.985 MB
   - TotalLocalBytesRead: 0.000 B
   - TotalOpenFSTimeNs: 1s211ms
     - __MAX_OF_TotalOpenFSTimeNs: 1s211ms
     - __MIN_OF_TotalOpenFSTimeNs: 1s210ms
   - TotalOpenFileTimeNs: 123.973ms
     - __MAX_OF_TotalOpenFileTimeNs: 132.744ms
     - __MIN_OF_TotalOpenFileTimeNs: 117.279ms
   - TotalShortCircuitBytesRead: 0.000 B
   - TotalZeroCopyBytesRead: 0.000 B
```

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [x] 3.1
  - [x] 3.0
  - [ ] 2.5
