### PR TITLE
[Feature] Support dynamic modification of datacache.enable

### DIFF
--- a/be/src/service/staros_worker.cpp
+++ b/be/src/service/staros_worker.cpp
@@ -81,8 +81,7 @@ StarOSWorker::~StarOSWorker() = default;
 absl::Status StarOSWorker::add_shard(const ShardInfo& shard) {
     std::unique_lock l(_mtx);
     auto it = _shards.find(shard.id);
-    if (it != _shards.end() && it->second.shard_info.path_info.has_fs_info() && shard.path_info.has_fs_info() &&
-        it->second.shard_info.path_info.fs_info().version() < shard.path_info.fs_info().version()) {
+    if (it != _shards.end() && has_shard_info_changed(it->second.shard_info, shard)) {
         auto st = invalidate_fs(it->second.shard_info);
         if (!st.ok()) {
             return st;

--- a/fe/fe-core/src/main/java/com/starrocks/alter/AlterJobMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/AlterJobMgr.java
@@ -77,6 +77,7 @@ import com.starrocks.common.util.PropertyAnalyzer;
 import com.starrocks.common.util.TimeUtils;
 import com.starrocks.common.util.concurrent.lock.LockType;
 import com.starrocks.common.util.concurrent.lock.Locker;
+import com.starrocks.lake.DataCacheInfo;
 import com.starrocks.persist.AlterMaterializedViewBaseTableInfosLog;
 import com.starrocks.persist.AlterMaterializedViewStatusLog;
 import com.starrocks.persist.AlterViewInfo;
@@ -138,6 +139,7 @@ import java.io.DataOutputStream;
 import java.io.IOException;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
@@ -864,6 +866,10 @@ public class AlterJobMgr {
         if (olapTable.getState() != OlapTableState.NORMAL) {
             throw InvalidOlapTableStateException.of(olapTable.getState(), olapTable.getName());
         }
+        if (properties.containsKey(PropertyAnalyzer.PROPERTIES_DATACACHE_ENABLE) &&
+                !olapTable.isCloudNativeTableOrMaterializedView()) {
+            throw new DdlException("Property 'datacache.enable' is only supported in shared-data mode");
+        }
 
         for (String partitionName : partitionNames) {
             Partition partition = olapTable.getPartition(partitionName);
@@ -902,8 +908,11 @@ public class AlterJobMgr {
         // 4. tablet type
         TTabletType tTabletType =
                 PropertyAnalyzer.analyzeTabletType(properties);
+        // 5. enable data cache
+        boolean newEnableDataCache = PropertyAnalyzer.analyzeDataCacheEnable(properties);
 
         // modify meta here
+        List<Partition> partitionsToUpdateShardGroup = new ArrayList<>();
         for (String partitionName : partitionNames) {
             Partition partition = olapTable.getPartition(partitionName);
             // 1. date property
@@ -953,12 +962,43 @@ public class AlterJobMgr {
             if (tTabletType != partitionInfo.getTabletType(partition.getId())) {
                 partitionInfo.setTabletType(partition.getId(), tTabletType);
             }
+            // 5. enable data cache
+            if (olapTable.isCloudNativeTableOrMaterializedView()) {
+                DataCacheInfo dataCacheInfo = partitionInfo.getDataCacheInfo(partition.getId());
+                if (dataCacheInfo == null || newEnableDataCache != dataCacheInfo.isEnabled()) {
+                    partitionsToUpdateShardGroup.add(olapTable.getPartition(partitionName));
+                    boolean asyncWriteBack = dataCacheInfo == null ? false : dataCacheInfo.isAsyncWriteBack();
+                    partitionInfo.setDataCacheInfo(partition.getId(), new DataCacheInfo(newEnableDataCache, asyncWriteBack));
+                }
+            }
+
             ModifyPartitionInfo info = new ModifyPartitionInfo(db.getId(), olapTable.getId(), partition.getId(),
-                    newDataProperty, newReplicationNum, hasInMemory ? newInMemory : oldInMemory);
+                    newDataProperty, newReplicationNum, hasInMemory ? newInMemory : oldInMemory, newEnableDataCache);
             modifyPartitionInfos.add(info);
         }
 
-        // log here
+        if (!partitionsToUpdateShardGroup.isEmpty()) {
+            // The updateShardGroup function is called centrally here, rather than iteratively within a for-loop, to
+            // ensure that updateShardGroup and the persistence of ModifyPartitionInfo are closely enough,
+            // thereby preventing metadata inconsistency.
+            try {
+                GlobalStateMgr.getCurrentState().getStarOSAgent().updateShardGroup(
+                        partitionsToUpdateShardGroup, newEnableDataCache);
+            } catch (DdlException e) {
+                // Revert changes above and then CONTINUE the alter job for the other properties
+                // This means that if multiple properties are set at the same time, there may be only partial success!
+                for (ModifyPartitionInfo info : modifyPartitionInfos) {
+                    // revert changes in partitionInfo
+                    DataCacheInfo dataCacheInfo = partitionInfo.getDataCacheInfo(info.getPartitionId());
+                    partitionInfo.setDataCacheInfo(info.getPartitionId(),
+                            new DataCacheInfo(dataCacheInfo.isAsyncWriteBack(), !newEnableDataCache));
+                    // revert changes in modifyPartitionInfos
+                    info.setDataCacheEnable(!newEnableDataCache);
+                }
+                LOG.error(e.getMessage());
+            }
+        }
+
         BatchModifyPartitionsInfo info = new BatchModifyPartitionsInfo(modifyPartitionInfos);
         GlobalStateMgr.getCurrentState().getEditLog().logBatchModifyPartition(info);
     }
@@ -980,6 +1020,12 @@ public class AlterJobMgr {
                 if (partitionInfo.getType() == PartitionType.UNPARTITIONED) {
                     olapTable.setReplicationNum(replicationNum);
                 }
+            }
+            if (olapTable.isCloudNativeTable()) {
+                DataCacheInfo dataCacheInfo = partitionInfo.getDataCacheInfo(info.getPartitionId());
+                boolean asyncWriteBack = dataCacheInfo == null ? false : dataCacheInfo.isAsyncWriteBack();
+                partitionInfo.setDataCacheInfo(info.getPartitionId(),
+                        new DataCacheInfo(info.getDataCacheEnable(), asyncWriteBack));
             }
             partitionInfo.setIsInMemory(info.getPartitionId(), info.isInMemory());
         } finally {

--- a/fe/fe-core/src/main/java/com/starrocks/alter/SchemaChangeHandler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/SchemaChangeHandler.java
@@ -144,6 +144,16 @@ public class SchemaChangeHandler extends AlterHandler {
     // check "__doris_shadow_" to prevent compatibility problems
     public static final String SHADOW_NAME_PRFIX_V1 = "__doris_shadow_";
 
+    // List of properties that can go with LocalMetastore.alterTableProperties()
+    private static final List<String> COMMON_ALTER_PROPERTIES = new ImmutableList.Builder<String>()
+            .add(PropertyAnalyzer.PROPERTIES_PARTITION_LIVE_NUMBER)
+            .add(PropertyAnalyzer.PROPERTIES_STORAGE_MEDIUM)
+            .add(PropertyAnalyzer.PROPERTIES_STORAGE_COOLDOWN_TTL)
+            .add(PropertyAnalyzer.PROPERTIES_DATACACHE_PARTITION_DURATION)
+            .add(PropertyAnalyzer.PROPERTIES_LABELS_LOCATION)
+            .add(PropertyAnalyzer.PROPERTIES_DATACACHE_ENABLE)
+            .build();
+
     public SchemaChangeHandler() {
         super("schema change");
     }
@@ -1527,19 +1537,7 @@ public class SchemaChangeHandler extends AlterHandler {
                     return null;
                 } else if (properties.containsKey(PropertyAnalyzer.PROPERTIES_REPLICATED_STORAGE)) {
                     return null;
-                } else if (properties.containsKey(PropertyAnalyzer.PROPERTIES_PARTITION_LIVE_NUMBER)) {
-                    GlobalStateMgr.getCurrentState().getLocalMetastore().alterTableProperties(db, olapTable, properties);
-                    return null;
-                } else if (properties.containsKey(PropertyAnalyzer.PROPERTIES_STORAGE_MEDIUM)) {
-                    GlobalStateMgr.getCurrentState().getLocalMetastore().alterTableProperties(db, olapTable, properties);
-                    return null;
-                } else if (properties.containsKey(PropertyAnalyzer.PROPERTIES_STORAGE_COOLDOWN_TTL)) {
-                    GlobalStateMgr.getCurrentState().getLocalMetastore().alterTableProperties(db, olapTable, properties);
-                    return null;
-                } else if (properties.containsKey(PropertyAnalyzer.PROPERTIES_DATACACHE_PARTITION_DURATION)) {
-                    GlobalStateMgr.getCurrentState().getLocalMetastore().alterTableProperties(db, olapTable, properties);
-                    return null;
-                } else if (properties.containsKey(PropertyAnalyzer.PROPERTIES_LABELS_LOCATION)) {
+                } else if (properties.keySet().stream().anyMatch(COMMON_ALTER_PROPERTIES::contains)) {
                     GlobalStateMgr.getCurrentState().getLocalMetastore().alterTableProperties(db, olapTable, properties);
                     return null;
                 }

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/OlapTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/OlapTable.java
@@ -2469,6 +2469,15 @@ public class OlapTable extends Table {
         tableProperty.buildDataCachePartitionDuration();
     }
 
+    public void setDataCacheEnable(boolean isEnable) {
+        if (tableProperty == null) {
+            tableProperty = new TableProperty(new HashMap<>());
+        }
+        tableProperty.modifyTableProperties(PropertyAnalyzer.PROPERTIES_DATACACHE_ENABLE,
+                Boolean.valueOf(isEnable).toString());
+        tableProperty.buildDataCacheEnable();
+    }
+
     public void setStorageCoolDownTTL(PeriodDuration duration) {
         if (tableProperty == null) {
             tableProperty = new TableProperty(new HashMap<>());

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/TableProperty.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/TableProperty.java
@@ -326,6 +326,7 @@ public class TableProperty implements Writable, GsonPostProcessable {
                 buildDataCachePartitionDuration();
                 buildLocation();
                 buildStorageCoolDownTTL();
+                buildDataCacheEnable();
                 break;
             case OperationType.OP_MODIFY_TABLE_CONSTRAINT_PROPERTY:
                 buildConstraint();
@@ -634,6 +635,19 @@ public class TableProperty implements Writable, GsonPostProcessable {
         return this;
     }
 
+    public TableProperty buildDataCacheEnable() {
+        if (properties.containsKey(PropertyAnalyzer.PROPERTIES_DATACACHE_ENABLE)) {
+            boolean dataCacheEnable = Boolean.parseBoolean(
+                    properties.getOrDefault(PropertyAnalyzer.PROPERTIES_DATACACHE_ENABLE, "false"));
+            if (this.storageInfo != null) {
+                this.storageInfo.setDataCacheEnable(dataCacheEnable);
+            } else {
+                LOG.warn("Setting datacache.enable to {} while storage info is null", dataCacheEnable);
+            }
+        }
+        return this;
+    }
+
     public TableProperty buildStorageCoolDownTTL() {
         if (properties.containsKey(PropertyAnalyzer.PROPERTIES_STORAGE_COOLDOWN_TTL)) {
             String storageCoolDownTTL = properties.get(PropertyAnalyzer.PROPERTIES_STORAGE_COOLDOWN_TTL);
@@ -928,5 +942,6 @@ public class TableProperty implements Writable, GsonPostProcessable {
         buildStorageType();
         buildMvProperties();
         buildLocation();
+        buildDataCacheEnable();
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/common/util/PropertyAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/util/PropertyAnalyzer.java
@@ -1259,6 +1259,10 @@ public class PropertyAnalyzer {
         }
     }
 
+    public static boolean analyzeDataCacheEnable(Map<String, String> properties) throws AnalysisException {
+        return analyzeBooleanProp(properties, PropertyAnalyzer.PROPERTIES_DATACACHE_ENABLE, true);
+    }
+
     public static TPersistentIndexType analyzePersistentIndexType(Map<String, String> properties) throws AnalysisException {
         if (properties != null && properties.containsKey(PROPERTIES_PERSISTENT_INDEX_TYPE)) {
             String type = properties.get(PROPERTIES_PERSISTENT_INDEX_TYPE);

--- a/fe/fe-core/src/main/java/com/starrocks/lake/StarOSAgent.java
+++ b/fe/fe-core/src/main/java/com/starrocks/lake/StarOSAgent.java
@@ -22,6 +22,7 @@ import com.google.common.collect.Sets;
 import com.staros.client.StarClient;
 import com.staros.client.StarClientException;
 import com.staros.manager.StarManagerServer;
+import com.staros.proto.CacheEnableState;
 import com.staros.proto.CreateMetaGroupInfo;
 import com.staros.proto.CreateShardGroupInfo;
 import com.staros.proto.CreateShardInfo;
@@ -41,9 +42,11 @@ import com.staros.proto.ShardGroupInfo;
 import com.staros.proto.ShardInfo;
 import com.staros.proto.StatusCode;
 import com.staros.proto.UpdateMetaGroupInfo;
+import com.staros.proto.UpdateShardGroupInfo;
 import com.staros.proto.WorkerGroupDetailInfo;
 import com.staros.proto.WorkerInfo;
 import com.staros.util.LockCloseable;
+import com.starrocks.catalog.Partition;
 import com.starrocks.common.Config;
 import com.starrocks.common.DdlException;
 import com.starrocks.common.InternalErrorCode;
@@ -479,6 +482,27 @@ public class StarOSAgent {
 
         Preconditions.checkState(shardInfos.size() == numShards);
         return shardInfos.stream().map(ShardInfo::getShardId).collect(Collectors.toList());
+    }
+
+    public void updateShardGroup(List<Partition> partitionsList, boolean enableCache) throws DdlException {
+        try {
+            List<UpdateShardGroupInfo> updateShardGroupInfoList = new ArrayList<>(partitionsList.size());
+            for (Partition partition : partitionsList) {
+                updateShardGroupInfoList.add(
+                        UpdateShardGroupInfo.newBuilder()
+                                .setGroupId(partition.getShardGroupId())
+                                .setEnableCache(enableCache ? CacheEnableState.ENABLED : CacheEnableState.DISABLED)
+                                .build());
+            }
+            client.updateShardGroup(serviceId, updateShardGroupInfoList);
+        } catch (StarClientException e) {
+            StringBuilder partitionNamesBuilder = new StringBuilder();
+            for (Partition partition : partitionsList) {
+                partitionNamesBuilder.append(partition.getName()).append(" ");
+            }
+            throw new DdlException("Failed to alter partition shardGroups, PartitionNames: " +
+                    partitionNamesBuilder.toString().trim() + e.getMessage());
+        }
     }
 
     public List<Long> listShard(long groupId) throws DdlException {

--- a/fe/fe-core/src/main/java/com/starrocks/lake/StorageInfo.java
+++ b/fe/fe-core/src/main/java/com/starrocks/lake/StorageInfo.java
@@ -59,6 +59,10 @@ public class StorageInfo implements GsonPreProcessable, GsonPostProcessable {
         return new DataCacheInfo(getCacheInfo());
     }
 
+    public void setDataCacheEnable(boolean isEnable) {
+        this.cacheInfo = this.cacheInfo.toBuilder().setEnableCache(isEnable).build();
+    }
+
     @Override
     public void gsonPreProcess() throws IOException {
         if (storeInfo != null) {

--- a/fe/fe-core/src/main/java/com/starrocks/persist/ModifyPartitionInfo.java
+++ b/fe/fe-core/src/main/java/com/starrocks/persist/ModifyPartitionInfo.java
@@ -57,6 +57,8 @@ public class ModifyPartitionInfo implements Writable {
     private short replicationNum;
     @SerializedName(value = "isInMemory")
     private boolean isInMemory;
+    @SerializedName(value = "dataCacheEnable")
+    private boolean dataCacheEnable;
 
     public ModifyPartitionInfo() {
         // for persist
@@ -64,13 +66,14 @@ public class ModifyPartitionInfo implements Writable {
 
     public ModifyPartitionInfo(long dbId, long tableId, long partitionId,
                                DataProperty dataProperty, short replicationNum,
-                               boolean isInMemory) {
+                               boolean isInMemory, boolean dataCacheEnable) {
         this.dbId = dbId;
         this.tableId = tableId;
         this.partitionId = partitionId;
         this.dataProperty = dataProperty;
         this.replicationNum = replicationNum;
         this.isInMemory = isInMemory;
+        this.dataCacheEnable = dataCacheEnable;
     }
 
     public long getDbId() {
@@ -97,6 +100,14 @@ public class ModifyPartitionInfo implements Writable {
         return isInMemory;
     }
 
+    public boolean getDataCacheEnable() {
+        return dataCacheEnable;
+    }
+
+    public void setDataCacheEnable(boolean isEnable) {
+        this.dataCacheEnable = isEnable;
+    }
+
     public static ModifyPartitionInfo read(DataInput in) throws IOException {
         ModifyPartitionInfo info = new ModifyPartitionInfo();
         info.readFields(in);
@@ -119,7 +130,7 @@ public class ModifyPartitionInfo implements Writable {
         ModifyPartitionInfo otherInfo = (ModifyPartitionInfo) other;
         return dbId == otherInfo.getDbId() && tableId == otherInfo.getTableId() &&
                 dataProperty.equals(otherInfo.getDataProperty()) && replicationNum == otherInfo.getReplicationNum()
-                && isInMemory == otherInfo.isInMemory();
+                && isInMemory == otherInfo.isInMemory() && dataCacheEnable == otherInfo.getDataCacheEnable();
     }
 
     @Override
@@ -137,6 +148,10 @@ public class ModifyPartitionInfo implements Writable {
 
         out.writeShort(replicationNum);
         out.writeBoolean(isInMemory);
+        //Writing in and out dataCacheEnable must be commented out, otherwise there will be compatibility
+        //issues when reading old logs. In fact, in the new version, persistence no longer needs to
+        //be implemented through write/readFields, but through gson.
+        //out.writeBoolean(dataCacheEnable);
     }
 
     public void readFields(DataInput in) throws IOException {
@@ -153,6 +168,7 @@ public class ModifyPartitionInfo implements Writable {
 
         replicationNum = in.readShort();
         isInMemory = in.readBoolean();
+        //dataCacheEnable = in.readBoolean();
     }
 
 }

--- a/fe/fe-core/src/main/java/com/starrocks/server/LocalMetastore.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/LocalMetastore.java
@@ -134,6 +134,7 @@ import com.starrocks.connector.ConnectorMetadata;
 import com.starrocks.connector.exception.StarRocksConnectorException;
 import com.starrocks.lake.DataCacheInfo;
 import com.starrocks.lake.LakeMaterializedView;
+import com.starrocks.lake.LakeTable;
 import com.starrocks.lake.LakeTablet;
 import com.starrocks.lake.StorageInfo;
 import com.starrocks.load.pipe.PipeManager;
@@ -143,6 +144,7 @@ import com.starrocks.persist.AutoIncrementInfo;
 import com.starrocks.persist.BackendIdsUpdateInfo;
 import com.starrocks.persist.BackendTabletsInfo;
 import com.starrocks.persist.BatchDeleteReplicaInfo;
+import com.starrocks.persist.BatchModifyPartitionsInfo;
 import com.starrocks.persist.ColocatePersistInfo;
 import com.starrocks.persist.ColumnRenameInfo;
 import com.starrocks.persist.CreateDbInfo;
@@ -3023,7 +3025,9 @@ public class LocalMetastore implements ConnectorMetadata {
                                             partition.getId(),
                                             hdd,
                                             (short) -1,
-                                            partitionInfo.getIsInMemory(partition.getId()));
+                                            partitionInfo.getIsInMemory(partition.getId()),
+                                            partitionInfo.getDataCacheInfo(partition.getId()) != null &&
+                                                    partitionInfo.getDataCacheInfo(partition.getId()).isEnabled());
                             GlobalStateMgr.getCurrentState().getEditLog().logModifyPartition(info);
                         }
                     } // end for partitions
@@ -4153,6 +4157,49 @@ public class LocalMetastore implements ConnectorMetadata {
                                 ImmutableMap.of(key, propertiesToPersist.get(key)));
                 GlobalStateMgr.getCurrentState().getEditLog().logAlterTableProperties(info);
             }
+            if (propertiesToPersist.containsKey(PropertyAnalyzer.PROPERTIES_DATACACHE_ENABLE)) {
+                String dataCacheEnable = propertiesToPersist.get(PropertyAnalyzer.PROPERTIES_DATACACHE_ENABLE);
+                boolean isEnable = Boolean.parseBoolean(dataCacheEnable);
+
+                Locker locker = new Locker();
+                locker.lockDatabase(db, LockType.WRITE);
+                try {
+                    if ((table instanceof LakeTable) || (table instanceof LakeMaterializedView)) {
+                        Collection<Partition> partitions = table.getPartitions();
+                        List<Partition> partitionsList = new ArrayList<>(partitions);
+                        GlobalStateMgr.getCurrentState().getStarOSAgent().updateShardGroup(partitionsList, isEnable);
+                    } else {
+                        throw new DdlException("Property 'datacache.enable' is only supported in shared-data mode");
+                    }
+                    tableProperty.getProperties().put(PropertyAnalyzer.PROPERTIES_DATACACHE_ENABLE, dataCacheEnable);
+                    tableProperty.buildDataCacheEnable();
+
+                    // When modifying table's datacache.enable, you also need to modify the datacache info in the partitions.
+                    Collection<Partition> partitions = table.getPartitions();
+                    PartitionInfo partitionInfo = table.getPartitionInfo();
+                    List<ModifyPartitionInfo> modifyPartitionInfos = Lists.newArrayList();
+                    for (Partition partition : partitions) {
+                        DataCacheInfo dataCacheInfo = partitionInfo.getDataCacheInfo(partition.getId());
+                        boolean asyncWriteBack = dataCacheInfo == null ? false : dataCacheInfo.isAsyncWriteBack();
+                        partitionInfo.setDataCacheInfo(partition.getId(), new DataCacheInfo(isEnable, asyncWriteBack));
+
+                        ModifyPartitionInfo info = new ModifyPartitionInfo(db.getId(), table.getId(), partition.getId(),
+                                null, // DataProperty, Setting it to null means it will have no effect during replay.
+                                (short) -1,   // ReplicationNum, Setting it to -1 means it will have no effect during replay.
+                                partitionInfo.getIsInMemory(partition.getId()), isEnable);
+                        modifyPartitionInfos.add(info);
+                    }
+                    GlobalStateMgr.getCurrentState().getEditLog().logBatchModifyPartition(
+                            new BatchModifyPartitionsInfo(modifyPartitionInfos));
+
+                    ModifyTablePropertyOperationLog info =
+                            new ModifyTablePropertyOperationLog(db.getId(), table.getId(),
+                                    ImmutableMap.of(key, propertiesToPersist.get(key)));
+                    GlobalStateMgr.getCurrentState().getEditLog().logAlterTableProperties(info);
+                } finally {
+                    locker.unLockDatabase(db, LockType.WRITE);
+                }
+            }
         }
     }
 
@@ -4197,6 +4244,14 @@ public class LocalMetastore implements ConnectorMetadata {
             }
             String locations = PropertyAnalyzer.analyzeLocation(properties, true);
             results.put(PropertyAnalyzer.PROPERTIES_LABELS_LOCATION, locations);
+        }
+        if (properties.containsKey(PropertyAnalyzer.PROPERTIES_DATACACHE_ENABLE)) {
+            try {
+                PropertyAnalyzer.analyzeDataCacheEnable(properties);
+                results.put(PropertyAnalyzer.PROPERTIES_DATACACHE_ENABLE, null);
+            } catch (AnalysisException ex) {
+                throw new RuntimeException(ex.getMessage());
+            }
         }
         if (!properties.isEmpty()) {
             throw new DdlException("Modify failed because unknown properties: " + properties);
@@ -4249,7 +4304,9 @@ public class LocalMetastore implements ConnectorMetadata {
 
         // log
         ModifyPartitionInfo info = new ModifyPartitionInfo(db.getId(), table.getId(), partition.getId(),
-                newDataProperty, replicationNum, isInMemory);
+                newDataProperty, replicationNum, isInMemory,
+                partitionInfo.getDataCacheInfo(partition.getId()) != null &&
+                        partitionInfo.getDataCacheInfo(partition.getId()).isEnabled());
         GlobalStateMgr.getCurrentState().getEditLog().logModifyPartition(info);
         LOG.info("modify partition[{}-{}-{}] replication num to {}", db.getOriginName(), table.getName(),
                 partition.getName(), replicationNum);

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AlterTableClauseVisitor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AlterTableClauseVisitor.java
@@ -305,6 +305,13 @@ public class AlterTableClauseVisitor extends AstVisitor<Void, ConnectContext> {
             } catch (DateTimeParseException e) {
                 ErrorReport.reportSemanticException(ErrorCode.ERR_COMMON_ERROR, e.getMessage());
             }
+        } else if (properties.containsKey(PropertyAnalyzer.PROPERTIES_DATACACHE_ENABLE)) {
+            if (!properties.get(PropertyAnalyzer.PROPERTIES_DATACACHE_ENABLE).equalsIgnoreCase("true") &&
+                    !properties.get(PropertyAnalyzer.PROPERTIES_DATACACHE_ENABLE).equalsIgnoreCase("false")) {
+                ErrorReport.reportSemanticException(ErrorCode.ERR_COMMON_ERROR,
+                        "Property " + PropertyAnalyzer.PROPERTIES_DATACACHE_ENABLE +
+                                " must be bool type(false/true)");
+            }
             clause.setNeedTableStable(false);
         } else {
             ErrorReport.reportSemanticException(ErrorCode.ERR_COMMON_ERROR, "Unknown properties: " + properties);

--- a/fe/fe-core/src/test/java/com/starrocks/alter/LakeTableAlterMetaJobTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/alter/LakeTableAlterMetaJobTest.java
@@ -14,12 +14,15 @@
 
 package com.starrocks.alter;
 
+import com.google.common.base.Preconditions;
+import com.google.common.collect.Lists;
 import com.google.common.collect.Table;
 import com.staros.proto.FileCacheInfo;
 import com.staros.proto.FilePathInfo;
 import com.staros.proto.FileStoreInfo;
 import com.staros.proto.FileStoreType;
 import com.staros.proto.S3FileStoreInfo;
+import com.starrocks.alter.AlterJobMgr;
 import com.starrocks.catalog.AggregateType;
 import com.starrocks.catalog.Column;
 import com.starrocks.catalog.DataProperty;
@@ -36,19 +39,23 @@ import com.starrocks.catalog.Tablet;
 import com.starrocks.catalog.TabletMeta;
 import com.starrocks.catalog.Type;
 import com.starrocks.common.DdlException;
+import com.starrocks.common.ExceptionChecker;
 import com.starrocks.common.FeConstants;
 import com.starrocks.common.util.PropertyAnalyzer;
+import com.starrocks.common.util.TimeUtils;
 import com.starrocks.common.util.concurrent.MarkedCountDownLatch;
 import com.starrocks.lake.DataCacheInfo;
 import com.starrocks.lake.LakeTable;
 import com.starrocks.lake.LakeTablet;
 import com.starrocks.lake.StarOSAgent;
 import com.starrocks.lake.Utils;
+import com.starrocks.persist.BatchModifyPartitionsInfo;
 import com.starrocks.persist.EditLog;
 import com.starrocks.persist.ModifyTablePropertyOperationLog;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.rpc.RpcException;
 import com.starrocks.server.GlobalStateMgr;
+import com.starrocks.server.LocalMetastore;
 import com.starrocks.server.RunMode;
 import com.starrocks.sql.ast.AlterClause;
 import com.starrocks.sql.ast.ModifyTablePropertiesClause;
@@ -81,9 +88,12 @@ public class LakeTableAlterMetaJobTest {
     private static final int NUM_BUCKETS = 4;
     private ConnectContext connectContext;
     private LakeTableAlterMetaJob alterMetaJob;
+    private AlterJobMgr alterJobMgr;
     private Database db;
     private LakeTable table;
     private List<Long> shadowTabletIds = new ArrayList<>();
+    private PartitionInfo partitionInfo;
+    private long partitionId;
 
     public LakeTableAlterMetaJobTest() {
         connectContext = new ConnectContext(null);
@@ -126,13 +136,23 @@ public class LakeTableAlterMetaJobTest {
             public void logModifyEnablePersistentIndex(ModifyTablePropertyOperationLog info) {
 
             }
+
+            @Mock
+            public void logBatchModifyPartition(BatchModifyPartitionsInfo info) {
+
+            }
+
+            @Mock
+            public void logAlterTableProperties(ModifyTablePropertyOperationLog info) {
+
+            }
         };
 
         GlobalStateMgr.getCurrentState().setEditLog(new EditLog(new ArrayBlockingQueue<>(100)));
         final long dbId = GlobalStateMgr.getCurrentState().getNextId();
-        final long partitionId = GlobalStateMgr.getCurrentState().getNextId();
         final long tableId = GlobalStateMgr.getCurrentState().getNextId();
         final long indexId = GlobalStateMgr.getCurrentState().getNextId();
+        partitionId = GlobalStateMgr.getCurrentState().getNextId();
 
         GlobalStateMgr.getCurrentState().setStarOSAgent(new StarOSAgent());
 
@@ -144,7 +164,7 @@ public class LakeTableAlterMetaJobTest {
 
         Column c0 = new Column("c0", Type.INT, true, AggregateType.NONE, false, null, null);
         DistributionInfo dist = new HashDistributionInfo(NUM_BUCKETS, Collections.singletonList(c0));
-        PartitionInfo partitionInfo = new RangePartitionInfo(Collections.singletonList(c0));
+        partitionInfo = new RangePartitionInfo(Collections.singletonList(c0));
         partitionInfo.setDataProperty(partitionId, DataProperty.DEFAULT_DATA_PROPERTY);
 
         table = new LakeTable(tableId, "t0", Collections.singletonList(c0), keysType, partitionInfo, dist);
@@ -407,5 +427,131 @@ public class LakeTableAlterMetaJobTest {
         SchemaChangeHandler schemaChangeHandler = new SchemaChangeHandler();
         Assertions.assertThrows(DdlException.class,
                 () -> schemaChangeHandler.createAlterMetaJob(alterList, db, table));
+    }
+
+    @Test
+    public void testModifyDataCachePartitionDurationAbourtMonths() throws Exception {
+        Map<String, String> properties = new HashMap<>();
+        properties.put(PropertyAnalyzer.PROPERTIES_DATACACHE_PARTITION_DURATION, "7 months");
+        ModifyTablePropertiesClause modify = new ModifyTablePropertiesClause(properties);
+        SchemaChangeHandler schemaChangeHandler = new SchemaChangeHandler();
+
+        List<AlterClause> alterList = Collections.singletonList(modify);
+        schemaChangeHandler.analyzeAndCreateJob(alterList, db, table);
+        table.setState(OlapTable.OlapTableState.SCHEMA_CHANGE);
+
+        Assert.assertEquals("7 months", TimeUtils.toHumanReadableString(
+                table.getTableProperty().getDataCachePartitionDuration()));
+
+    }
+
+    @Test
+    public void testModifyDataCachePartitionDurationAbourtDays() throws Exception {
+        Map<String, String> properties = new HashMap<>();
+        properties.put(PropertyAnalyzer.PROPERTIES_DATACACHE_PARTITION_DURATION, "2 days");
+        ModifyTablePropertiesClause modify = new ModifyTablePropertiesClause(properties);
+        SchemaChangeHandler schemaChangeHandler = new SchemaChangeHandler();
+
+        List<AlterClause> alterList = Collections.singletonList(modify);
+        schemaChangeHandler.analyzeAndCreateJob(alterList, db, table);
+        table.setState(OlapTable.OlapTableState.SCHEMA_CHANGE);
+
+        Assert.assertEquals("2 days", TimeUtils.toHumanReadableString(
+                table.getTableProperty().getDataCachePartitionDuration()));
+
+    }
+
+    @Test
+    public void testModifyDataCachePartitionDurationAboutHours() throws Exception {
+        Map<String, String> properties = new HashMap<>();
+        properties.put(PropertyAnalyzer.PROPERTIES_DATACACHE_PARTITION_DURATION, "4 hours");
+        ModifyTablePropertiesClause modify = new ModifyTablePropertiesClause(properties);
+        SchemaChangeHandler schemaChangeHandler = new SchemaChangeHandler();
+
+        List<AlterClause> alterList = Collections.singletonList(modify);
+        schemaChangeHandler.analyzeAndCreateJob(alterList, db, table);
+        table.setState(OlapTable.OlapTableState.SCHEMA_CHANGE);
+
+        Assert.assertEquals("4 hours", TimeUtils.toHumanReadableString(
+                table.getTableProperty().getDataCachePartitionDuration()));
+    }
+
+    @Test
+    public void testModifyPartitionsPropertyDatacacheEnable() throws Exception {
+        alterJobMgr = new AlterJobMgr();
+        Map<String, String> properties = new HashMap<>();
+        List<String> partitionNames = Lists.newArrayList();
+        partitionNames.add("t0");
+
+        new MockUp<Preconditions>() {
+            @Mock
+            public void checkArgument(boolean param) {
+
+            }
+        };
+        new MockUp<StarOSAgent>() {
+            @Mock
+            public void updateShardGroup(List<Partition> partitionsList, boolean enableCache) throws DdlException {
+                throw new DdlException("Mock exception");
+            }
+        };
+
+        // Get the opposite status of current datacache.enable
+        String str = partitionInfo.getDataCacheInfo(partitionId).isEnabled() ?
+                "false" : "true";
+        properties.put(PropertyAnalyzer.PROPERTIES_DATACACHE_ENABLE, str);
+        table.setState(OlapTable.OlapTableState.NORMAL);
+        partitionInfo.setIsInMemory(partitionId, false);
+        // Although the updateShardGroup called inside modifyPartitionsProperty below will
+        // throw an exception, it will be processed inside modifyPartitionsProperty.
+        ExceptionChecker.expectThrowsNoException(() ->
+                alterJobMgr.modifyPartitionsProperty(db, table, partitionNames, properties));
+    }
+
+    @Test
+    public void testAlterTablePropertiesDatacacheEnable() throws Exception {
+        new MockUp<StarOSAgent>() {
+            @Mock
+            public void updateShardGroup(List<Partition> partitionsList, boolean enableCache) throws DdlException {
+
+            }
+        };
+        // Get the opposite status of current datacache.enable
+        String str = partitionInfo.getDataCacheInfo(partitionId).isEnabled() ?
+                "false" : "true";
+        Map<String, String> properties = new HashMap<>();
+        properties.put(PropertyAnalyzer.PROPERTIES_DATACACHE_ENABLE, str);
+        partitionInfo.setIsInMemory(partitionId, false);
+
+        LocalMetastore localMetaStore = new LocalMetastore(GlobalStateMgr.getCurrentState(),
+                GlobalStateMgr.getCurrentState().getRecycleBin(),
+                GlobalStateMgr.getCurrentState().getColocateTableIndex());
+        localMetaStore.alterTableProperties(db, table, properties);
+    }
+
+    @Test
+    public void testAnalyzeAndCreateJobDatacacheEnable() throws Exception {
+        new MockUp<GlobalStateMgr>() {
+            @Mock
+            public void alterTableProperties(Database db, OlapTable table, Map<String, String> properties)
+                    throws DdlException {
+
+            }
+        };
+        new MockUp<StarOSAgent>() {
+            @Mock
+            public void updateShardGroup(List<Partition> partitionsList, boolean enableCache) throws DdlException {
+
+            }
+        };
+
+        Map<String, String> properties = new HashMap<>();
+        properties.put(PropertyAnalyzer.PROPERTIES_DATACACHE_ENABLE, "true");
+        ModifyTablePropertiesClause modify = new ModifyTablePropertiesClause(properties);
+
+        List<AlterClause> alterList = Collections.singletonList(modify);
+        SchemaChangeHandler schemaChangeHandler = new SchemaChangeHandler();
+
+        schemaChangeHandler.analyzeAndCreateJob(alterList, db, table);
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/common/util/PropertyAnalyzerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/common/util/PropertyAnalyzerTest.java
@@ -57,4 +57,33 @@ public class PropertyAnalyzerTest {
             Assert.assertEquals("Cannot parse text to Duration", e.getMessage());
         }
     }
+
+    @Test
+    public void testAnalyzeDataCacheEnable() {
+        Map<String, String> properties = new HashMap<>();
+        properties.put(PropertyAnalyzer.PROPERTIES_DATACACHE_ENABLE, "true");
+
+        try {
+            Assert.assertTrue(PropertyAnalyzer.analyzeDataCacheEnable(properties));
+        } catch (AnalysisException e) {
+            Assert.assertTrue(false);
+        }
+
+        Assert.assertTrue(properties.size() == 0);
+        properties.put(PropertyAnalyzer.PROPERTIES_DATACACHE_ENABLE, "false");
+        try {
+            Assert.assertFalse(PropertyAnalyzer.analyzeDataCacheEnable(properties));
+        } catch (AnalysisException e) {
+            Assert.assertTrue(false);
+        }
+
+        properties.put(PropertyAnalyzer.PROPERTIES_DATACACHE_ENABLE, "abcd");
+        // If the string passed in is not "true" (ignoring case),
+        // analyzeDataCacheEnable will return false instead of throwing an exception
+        try {
+            Assert.assertFalse(PropertyAnalyzer.analyzeDataCacheEnable(properties));
+        } catch (AnalysisException e) {
+            Assert.assertTrue(false);
+        }
+    }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/lake/LakeTableTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/lake/LakeTableTest.java
@@ -159,4 +159,16 @@ public class LakeTableTest {
         LakeTable lakeTable = new LakeTable();
         Assert.assertNotNull(lakeTable.getIndexIdToMeta());
     }
+
+    @Test
+    public void testSetDataCacheEnable() {
+        LakeTable lakeTable = new LakeTable();
+        FilePathInfo pathInfo = FilePathInfo.newBuilder().build();
+        lakeTable.setStorageInfo(pathInfo, new DataCacheInfo(false, false));
+
+        lakeTable.setDataCacheEnable(true);
+        Assert.assertTrue(lakeTable.getTableProperty().getStorageInfo().getDataCacheInfo().isEnabled());
+        lakeTable.setDataCacheEnable(false);
+        Assert.assertFalse(lakeTable.getTableProperty().getStorageInfo().getDataCacheInfo().isEnabled());
+    }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/lake/ModifyDatacaheEnableTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/lake/ModifyDatacaheEnableTest.java
@@ -1,0 +1,356 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.lake;
+
+import com.google.common.base.Preconditions;
+import com.starrocks.catalog.Database;
+import com.starrocks.catalog.MaterializedView;
+import com.starrocks.catalog.OlapTable;
+import com.starrocks.catalog.Partition;
+import com.starrocks.catalog.PartitionInfo;
+import com.starrocks.catalog.Table;
+import com.starrocks.common.ExceptionChecker;
+import com.starrocks.common.UserException;
+import com.starrocks.common.util.PropertyAnalyzer;
+import com.starrocks.lake.DataCacheInfo;
+import com.starrocks.qe.ConnectContext;
+import com.starrocks.server.GlobalStateMgr;
+import com.starrocks.server.RunMode;
+import com.starrocks.sql.ast.CreateDbStmt;
+import com.starrocks.sql.ast.CreateMaterializedViewStatement;
+import com.starrocks.sql.ast.CreateTableStmt;
+import com.starrocks.utframe.UtFrameUtils;
+import mockit.Mock;
+import mockit.MockUp;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public class ModifyDatacaheEnableTest {
+    private static final Logger LOG = LogManager.getLogger(ModifyDatacaheEnableTest.class);
+    private static ConnectContext connectContext;
+
+    @BeforeClass
+    public static void beforeClass() throws Exception {
+        UtFrameUtils.createMinStarRocksCluster(RunMode.SHARED_DATA);
+        // create connect context
+        connectContext = UtFrameUtils.createDefaultCtx();
+        // create database
+        String createDbStmtStr = "create database lake_test;";
+        CreateDbStmt createDbStmt = (CreateDbStmt) UtFrameUtils.parseStmtWithNewParser(createDbStmtStr, connectContext);
+        GlobalStateMgr.getCurrentState().getMetadata().createDb(createDbStmt.getFullDbName());
+
+        ExceptionChecker.expectThrowsNoException(() -> createTable(
+                "CREATE TABLE IF NOT EXISTS `lake_test`.`lake_table` (\n" +
+                        "    `recruit_date`  DATE           NOT NULL COMMENT 'YYYY-MM-DD',\n" +
+                        "    `region_num`    TINYINT        COMMENT 'range [-128, 127]',\n" +
+                        "    `num_plate`     SMALLINT       COMMENT 'range [-32768, 32767]',\n" +
+                        "    `tel`           INT            COMMENT 'range [-2147483648, 2147483647]',\n" +
+                        "    `id`            BIGINT         COMMENT 'range [-2^63 + 1 ~ 2^63 - 1]',\n" +
+                        "    `password`      LARGEINT       COMMENT 'range [-2^127 + 1 ~ 2^127 - 1]',\n" +
+                        "    `name`          CHAR(20)       NOT NULL COMMENT 'range char(m),m in (1-255)',\n" +
+                        "    `profile`       VARCHAR(500)   NOT NULL COMMENT 'upper limit value 1048576 bytes',\n" +
+                        "    `hobby`         STRING         NOT NULL COMMENT 'upper limit value 65533 bytes',\n" +
+                        "    `leave_time`    DATETIME       COMMENT 'YYYY-MM-DD HH:MM:SS'\n" +
+                        ") ENGINE=OLAP\n" +
+                        "DUPLICATE KEY(`recruit_date`, `region_num`)\n" +
+                        "PARTITION BY RANGE(`recruit_date`)\n" +
+                        "(\n" +
+                        "    PARTITION p1 VALUES [('2022-03-11'), ('2022-03-12')),\n" +
+                        "    PARTITION p2 VALUES [('2022-03-12'), ('2022-03-13')),\n" +
+                        "    PARTITION p3 VALUES [('2022-03-13'), ('2022-03-14')),\n" +
+                        "    PARTITION p4 VALUES [('2022-03-14'), ('2022-03-15')),\n" +
+                        "    PARTITION p5 VALUES [('2022-03-15'), ('2022-03-16'))\n" +
+                        ")\n" +
+                        "DISTRIBUTED BY HASH(`recruit_date`, `region_num`) BUCKETS 100\n" +
+                        "PROPERTIES (\n" +
+                        "    'datacache.partition_duration' = '1 days',\n" +
+                        "    'datacache.enable' = 'true',\n" +
+                        "    'storage_volume' = 'builtin_storage_volume',\n" +
+                        "    'enable_async_write_back' = 'false',\n" +
+                        "    'enable_persistent_index' = 'false'\n" +
+                        ");"
+        ));
+
+        ExceptionChecker.expectThrowsNoException(() -> createTable(
+                "CREATE TABLE IF NOT EXISTS `lake_test`.`base` (\n" +
+                        "    `k1` date NULL,\n" +
+                        "    `k2` int(11) NULL,\n" +
+                        "    `v1` int(11) SUM NULL\n" +
+                        ") ENGINE=OLAP\n" +
+                        "AGGREGATE KEY(`k1`, `k2`)\n" +
+                        "COMMENT 'OLAP'\n" +
+                        "PARTITION BY RANGE(`k1`)\n" +
+                        "(\n" +
+                        "    PARTITION p1 VALUES [('0000-01-01'), ('2020-02-01')),\n" +
+                        "    PARTITION p2 VALUES [('2020-02-01'), ('2020-03-01'))\n" +
+                        ")\n" +
+                        "DISTRIBUTED BY HASH(`k2`) BUCKETS 3\n" +
+                        "PROPERTIES (\n" +
+                        "    'replication_num' = '1',\n" +
+                        "    'datacache.enable' = 'true'\n" +
+                        ");"
+        ));
+        checkLakeTable("lake_test", "base");
+        ExceptionChecker.expectThrowsNoException(() -> createMaterializedView(
+                "CREATE MATERIALIZED VIEW `lake_test`.`lake_mv`\n" +
+                        "DISTRIBUTED BY HASH(`k1`)\n" +
+                        "PROPERTIES (\n" +
+                        "    'replication_num' = '1',\n" +
+                        "    'datacache.enable' = 'true',\n" +
+                        "    'datacache.partition_duration' = '25 hour'\n" +
+                        ")\n" +
+                        "AS SELECT `k1` FROM `lake_test`.`base`;"
+        ));
+        checkMaterializedView("lake_test", "lake_mv");
+
+        new MockUp<Preconditions>() {
+            @Mock
+            public void checkArgument(boolean param) {
+
+            }
+        };
+    }
+
+    @AfterClass
+    public static void afterClass() {
+    }
+
+    private static void createTable(String sql) throws Exception {
+        CreateTableStmt createTableStmt = (CreateTableStmt) UtFrameUtils.parseStmtWithNewParser(sql, connectContext);
+        GlobalStateMgr.getCurrentState().getLocalMetastore().createTable(createTableStmt);
+    }
+
+    private static void createMaterializedView(String sql) throws Exception {
+        CreateMaterializedViewStatement createMVStmt =
+                (CreateMaterializedViewStatement) UtFrameUtils.parseStmtWithNewParser(sql, connectContext);
+        GlobalStateMgr.getCurrentState().getLocalMetastore().createMaterializedView(createMVStmt);
+    }
+
+    private static void checkLakeTable(String dbName, String tableName) {
+        Database db = GlobalStateMgr.getCurrentState().getDb(dbName);
+        Table table = db.getTable(tableName);
+        Assert.assertTrue(table.isCloudNativeTable());
+    }
+
+    private static void checkMaterializedView(String dbName, String mvName) {
+        Database db = GlobalStateMgr.getCurrentState().getDb(dbName);
+        List<MaterializedView> mvsList = db.getMaterializedViews();
+        for (MaterializedView lakeMv : mvsList) {
+            Assert.assertTrue(lakeMv.isCloudNativeMaterializedView());
+        }
+    }
+
+    private LakeTable getLakeTable(String dbName, String tableName) {
+        Database db = GlobalStateMgr.getCurrentState().getDb(dbName);
+        Table table = db.getTable(tableName);
+        Assert.assertTrue(table.isCloudNativeTable());
+        return (LakeTable) table;
+    }
+
+    private LakeMaterializedView getMaterializedView(String dbName, String mvName) {
+        Database db = GlobalStateMgr.getCurrentState().getDb(dbName);
+        List<MaterializedView> mvsList = db.getMaterializedViews();
+        for (MaterializedView lakeMv : mvsList) {
+            if (lakeMv.getName().equals(mvName)) {
+                return (LakeMaterializedView) lakeMv;
+            }
+        }
+        return null;
+    }
+
+    private static void alterTableProperties(String dbName, String tableName, boolean isEnable) {
+        Database db = GlobalStateMgr.getCurrentState().getDb(dbName);
+        OlapTable table = (OlapTable) db.getTable(tableName);
+        Map<String, String> properties = new HashMap<>();
+        properties.put(PropertyAnalyzer.PROPERTIES_DATACACHE_ENABLE, String.valueOf(isEnable));
+        ExceptionChecker.expectThrowsNoException(() ->
+                GlobalStateMgr.getCurrentState().getLocalMetastore().alterTableProperties(db, table, properties));
+    }
+
+    private static void alterPartitionProperties(String dbName, String tableName,
+            List<String> partitionNames, boolean isEnable) {
+        Database db = GlobalStateMgr.getCurrentState().getDb(dbName);
+        OlapTable table = (OlapTable) db.getTable(tableName);
+        Map<String, String> properties = new HashMap<>();
+        properties.put(PropertyAnalyzer.PROPERTIES_DATACACHE_ENABLE, String.valueOf(isEnable));
+        ExceptionChecker.expectThrowsNoException(() ->
+                GlobalStateMgr.getCurrentState().getAlterJobMgr().modifyPartitionsProperty(
+                        db, table, partitionNames, properties));
+    }
+
+    @Test
+    public void testModifyTableDatacacheEnable() throws UserException {
+        LakeTable table = getLakeTable("lake_test", "lake_table");
+        { // check the original state of datacache.enable
+            StorageInfo storageInfo = table.getTableProperty().getStorageInfo();
+            Assert.assertNotNull(storageInfo);
+            Assert.assertTrue(storageInfo.getDataCacheInfo().isEnabled());
+            PartitionInfo partitionInfo = table.getPartitionInfo();
+            Collection<Partition> partitions = table.getPartitions();
+            for (Partition partition : partitions) {
+                DataCacheInfo dataCacheInfo = partitionInfo.getDataCacheInfo(partition.getId());
+                Assert.assertTrue(dataCacheInfo.isEnabled());
+            }
+        }
+        alterTableProperties("lake_test", "lake_table", false);
+        { // check the state of datacache.enable after alter table properties
+            StorageInfo storageInfo = table.getTableProperty().getStorageInfo();
+            Assert.assertNotNull(storageInfo);
+            Assert.assertFalse(storageInfo.getDataCacheInfo().isEnabled());
+            PartitionInfo partitionInfo = table.getPartitionInfo();
+            Collection<Partition> partitions = table.getPartitions();
+            for (Partition partition : partitions) {
+                DataCacheInfo dataCacheInfo = partitionInfo.getDataCacheInfo(partition.getId());
+                Assert.assertFalse(dataCacheInfo.isEnabled());
+            }
+        }
+        alterPartitionProperties("lake_test", "lake_table", List.of("p1", "p2"), true);
+        { // check the state of datacache.enable after alter partition properties
+            StorageInfo storageInfo = table.getTableProperty().getStorageInfo();
+            Assert.assertNotNull(storageInfo);
+            Assert.assertFalse(storageInfo.getDataCacheInfo().isEnabled());
+            PartitionInfo partitionInfo = table.getPartitionInfo();
+            Collection<Partition> partitions = table.getPartitions();
+            for (Partition partition : partitions) {
+                DataCacheInfo dataCacheInfo = partitionInfo.getDataCacheInfo(partition.getId());
+                if (partition.getName().equals("p1") || partition.getName().equals("p2")) {
+                    Assert.assertTrue(dataCacheInfo.isEnabled());
+                } else {
+                    Assert.assertFalse(dataCacheInfo.isEnabled());
+                }
+            }
+        }
+        alterTableProperties("lake_test", "lake_table", true);
+        { // check the state of datacache.enable after alter table properties
+            StorageInfo storageInfo = table.getTableProperty().getStorageInfo();
+            Assert.assertNotNull(storageInfo);
+            Assert.assertTrue(storageInfo.getDataCacheInfo().isEnabled());
+            PartitionInfo partitionInfo = table.getPartitionInfo();
+            Collection<Partition> partitions = table.getPartitions();
+            for (Partition partition : partitions) {
+                DataCacheInfo dataCacheInfo = partitionInfo.getDataCacheInfo(partition.getId());
+                Assert.assertTrue(dataCacheInfo.isEnabled());
+            }
+        }
+        alterPartitionProperties("lake_test", "lake_table", List.of("p4", "p5"), false);
+        { // check the state of datacache.enable after alter partition properties
+            StorageInfo storageInfo = table.getTableProperty().getStorageInfo();
+            Assert.assertNotNull(storageInfo);
+            Assert.assertTrue(storageInfo.getDataCacheInfo().isEnabled());
+            PartitionInfo partitionInfo = table.getPartitionInfo();
+            Collection<Partition> partitions = table.getPartitions();
+            for (Partition partition : partitions) {
+                DataCacheInfo dataCacheInfo = partitionInfo.getDataCacheInfo(partition.getId());
+                if (partition.getName().equals("p4") || partition.getName().equals("p5")) {
+                    Assert.assertFalse(dataCacheInfo.isEnabled());
+                } else {
+                    Assert.assertTrue(dataCacheInfo.isEnabled());
+                }
+            }
+        }
+        alterTableProperties("lake_test", "lake_table", false);
+        { // check the state of datacache.enable after alter table properties
+            StorageInfo storageInfo = table.getTableProperty().getStorageInfo();
+            Assert.assertNotNull(storageInfo);
+            Assert.assertFalse(storageInfo.getDataCacheInfo().isEnabled());
+            PartitionInfo partitionInfo = table.getPartitionInfo();
+            Collection<Partition> partitions = table.getPartitions();
+            for (Partition partition : partitions) {
+                DataCacheInfo dataCacheInfo = partitionInfo.getDataCacheInfo(partition.getId());
+                Assert.assertFalse(dataCacheInfo.isEnabled());
+            }
+        }
+    }
+
+    @Test
+    public void testModifyPartitionDatacacheEnable() throws UserException {
+        LakeMaterializedView lakeMv = getMaterializedView("lake_test", "lake_mv");
+        { // check the original state of datacache.enable
+            StorageInfo storageInfo = lakeMv.getTableProperty().getStorageInfo();
+            Assert.assertNotNull(storageInfo);
+            Assert.assertTrue(storageInfo.getDataCacheInfo().isEnabled());
+            PartitionInfo partitionInfo = lakeMv.getPartitionInfo();
+            Collection<Partition> partitions = lakeMv.getPartitions();
+            List<Partition> partitionsList = new ArrayList<>(partitions);
+            DataCacheInfo dataCacheInfo = partitionInfo.getDataCacheInfo(partitionsList.get(0).getId());
+            Assert.assertTrue(dataCacheInfo.isEnabled());
+        }
+        alterTableProperties("lake_test", "lake_mv", false);
+        { // check the state of datacache.enable after alter table properties
+            StorageInfo storageInfo = lakeMv.getTableProperty().getStorageInfo();
+            Assert.assertNotNull(storageInfo);
+            Assert.assertFalse(storageInfo.getDataCacheInfo().isEnabled());
+            PartitionInfo partitionInfo = lakeMv.getPartitionInfo();
+            Collection<Partition> partitions = lakeMv.getPartitions();
+            List<Partition> partitionsList = new ArrayList<>(partitions);
+            DataCacheInfo dataCacheInfo = partitionInfo.getDataCacheInfo(partitionsList.get(0).getId());
+            Assert.assertFalse(dataCacheInfo.isEnabled());
+        }
+        alterPartitionProperties("lake_test", "lake_mv", List.of("lake_mv"), true);
+        { // check the state of datacache.enable after alter partition properties
+            StorageInfo storageInfo = lakeMv.getTableProperty().getStorageInfo();
+            Assert.assertNotNull(storageInfo);
+            Assert.assertFalse(storageInfo.getDataCacheInfo().isEnabled());
+            PartitionInfo partitionInfo = lakeMv.getPartitionInfo();
+            Collection<Partition> partitions = lakeMv.getPartitions();
+            List<Partition> partitionsList = new ArrayList<>(partitions);
+            DataCacheInfo dataCacheInfo = partitionInfo.getDataCacheInfo(partitionsList.get(0).getId());
+            Assert.assertTrue(dataCacheInfo.isEnabled());
+        }
+        alterTableProperties("lake_test", "lake_mv", true);
+        { // check the state of datacache.enable after alter table properties
+            StorageInfo storageInfo = lakeMv.getTableProperty().getStorageInfo();
+            Assert.assertNotNull(storageInfo);
+            Assert.assertTrue(storageInfo.getDataCacheInfo().isEnabled());
+            PartitionInfo partitionInfo = lakeMv.getPartitionInfo();
+            Collection<Partition> partitions = lakeMv.getPartitions();
+            List<Partition> partitionsList = new ArrayList<>(partitions);
+            DataCacheInfo dataCacheInfo = partitionInfo.getDataCacheInfo(partitionsList.get(0).getId());
+            Assert.assertTrue(dataCacheInfo.isEnabled());
+        }
+        alterPartitionProperties("lake_test", "lake_mv", List.of("lake_mv"), false);
+        { // check the state of datacache.enable after alter partition properties
+            StorageInfo storageInfo = lakeMv.getTableProperty().getStorageInfo();
+            Assert.assertNotNull(storageInfo);
+            Assert.assertTrue(storageInfo.getDataCacheInfo().isEnabled());
+            PartitionInfo partitionInfo = lakeMv.getPartitionInfo();
+            Collection<Partition> partitions = lakeMv.getPartitions();
+            List<Partition> partitionsList = new ArrayList<>(partitions);
+            DataCacheInfo dataCacheInfo = partitionInfo.getDataCacheInfo(partitionsList.get(0).getId());
+            Assert.assertFalse(dataCacheInfo.isEnabled());
+        }
+        alterTableProperties("lake_test", "lake_mv", false);
+        { // check the state of datacache.enable after alter table properties
+            StorageInfo storageInfo = lakeMv.getTableProperty().getStorageInfo();
+            Assert.assertNotNull(storageInfo);
+            Assert.assertFalse(storageInfo.getDataCacheInfo().isEnabled());
+            PartitionInfo partitionInfo = lakeMv.getPartitionInfo();
+            Collection<Partition> partitions = lakeMv.getPartitions();
+            List<Partition> partitionsList = new ArrayList<>(partitions);
+            DataCacheInfo dataCacheInfo = partitionInfo.getDataCacheInfo(partitionsList.get(0).getId());
+            Assert.assertFalse(dataCacheInfo.isEnabled());
+        }
+    }
+}

--- a/fe/fe-core/src/test/java/com/starrocks/persist/BatchModifyPartitionsInfoTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/persist/BatchModifyPartitionsInfoTest.java
@@ -56,7 +56,7 @@ public class BatchModifyPartitionsInfoTest {
         List<Long> partitionIds = Lists.newArrayList(PARTITION_ID_1, PARTITION_ID_2, PARTITION_ID_3);
         for (long partitionId : partitionIds) {
             partitionInfos.add(new ModifyPartitionInfo(DB_ID, TB_ID, partitionId,
-                    DataProperty.DEFAULT_DATA_PROPERTY, (short) 3, true));
+                    DataProperty.DEFAULT_DATA_PROPERTY, (short) 3, true, false));
         }
 
         BatchModifyPartitionsInfo batchModifyPartitionsInfo = new BatchModifyPartitionsInfo(partitionInfos);

--- a/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AnalyzeAlterTableStatementTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AnalyzeAlterTableStatementTest.java
@@ -130,6 +130,9 @@ public class AnalyzeAlterTableStatementTest {
         analyzeSuccess("ALTER TABLE test.t0 SET (\"default.replication_num\" = \"2\");");
         analyzeSuccess("ALTER TABLE test.t0 SET (\"datacache.partition_duration\" = \"10 days\");");
         analyzeFail("ALTER TABLE test.t0 SET (\"datacache.partition_duration\" = \"abcd\");", "Cannot parse text to Duration");
+        analyzeSuccess("ALTER TABLE test.t0 SET (\"datacache.enable\" = \"true\");");
+        analyzeSuccess("ALTER TABLE test.t0 SET (\"datacache.enable\" = \"false\");");
+        analyzeFail("ALTER TABLE test.t0 SET (\"datacache.enable\" = \"abcd\");", "must be bool type(false/true)");
         analyzeFail("ALTER TABLE test.t0 SET (\"default.replication_num\" = \"2\", \"dynamic_partition.enable\" = \"true\");",
                 "Can only set one table property at a time");
         analyzeFail("ALTER TABLE test.t0 SET (\"abc\" = \"2\");",


### PR DESCRIPTION
Supports dynamic modification of table and partition level datacache.enable attributes:
1. Synchronously modify the datacache.enable of the shardGroup in StarManager through StarManager's updateShardGroup rpc.
2. Through the heartbeat detection of the starlet worker, asynchronously modify the cache enable status of the starlet worker.

## Why I'm doing:

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [X] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [X] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [X] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [X] 3.2
  - [X] 3.1
  - [ ] 3.0
  - [ ] 2.5