### PR TITLE
[BugFix] Fix delete predicate in cross cluster replication for shared-data mode (backport #42055)

### DIFF
--- a/be/src/storage/lake/replication_txn_manager.cpp
+++ b/be/src/storage/lake/replication_txn_manager.cpp
@@ -35,6 +35,7 @@
 #include "runtime/current_thread.h"
 #include "runtime/exec_env.h"
 #include "service/backend_options.h"
+#include "storage/delete_handler.h"
 #include "storage/lake/location_provider.h"
 #include "storage/lake/meta_file.h"
 #include "storage/lake/tablet.h"
@@ -385,7 +386,9 @@ Status ReplicationTxnManager::convert_rowset_meta(const RowsetMeta& rowset_meta,
     rowset_metadata->set_data_size(rowset_meta.data_disk_size());
     rowset_metadata->set_num_dels(rowset_meta.get_num_delete_files());
     if (rowset_meta.has_delete_predicate()) {
-        rowset_metadata->mutable_delete_predicate()->CopyFrom(rowset_meta.delete_predicate());
+        auto* delete_predicate_pb = rowset_metadata->mutable_delete_predicate();
+        delete_predicate_pb->CopyFrom(rowset_meta.delete_predicate());
+        RETURN_IF_ERROR(convert_delete_predicate_pb(delete_predicate_pb));
     }
 
     std::string rowset_id = rowset_meta.rowset_id().to_string();
@@ -418,6 +421,40 @@ Status ReplicationTxnManager::convert_rowset_meta(const RowsetMeta& rowset_meta,
         }
     }
 
+    return Status::OK();
+}
+
+Status ReplicationTxnManager::convert_delete_predicate_pb(DeletePredicatePB* delete_predicate) {
+    for (const auto& sub_predicate : delete_predicate->sub_predicates()) {
+        TCondition condition;
+        if (!DeleteHandler::parse_condition(sub_predicate, &condition)) {
+            LOG(WARNING) << "Invalid delete condition: " << sub_predicate;
+            return Status::InternalError("Invalid delete condition: " + sub_predicate);
+        }
+        if (condition.condition_op == "IS") {
+            auto* is_null_predicate = delete_predicate->add_is_null_predicates();
+            is_null_predicate->set_column_name(condition.column_name);
+            is_null_predicate->set_is_not_null(condition.condition_values[0].compare(0, 3, "NOT") == 0);
+        } else if (condition.condition_op == "*=" || condition.condition_op == "!*=") {
+            auto* in_predicate = delete_predicate->add_in_predicates();
+            in_predicate->set_column_name(condition.column_name);
+            in_predicate->set_is_not_in(condition.condition_op.front() == '!');
+            for (const auto& value : condition.condition_values) {
+                in_predicate->add_values()->assign(value);
+            }
+        } else {
+            auto* binary_predicate = delete_predicate->add_binary_predicates();
+            binary_predicate->set_column_name(condition.column_name);
+            if (condition.condition_op == "<<") {
+                binary_predicate->set_op("<");
+            } else if (condition.condition_op == ">>") {
+                binary_predicate->set_op(">");
+            } else {
+                binary_predicate->set_op(condition.condition_op);
+            }
+            binary_predicate->set_value(condition.condition_values[0]);
+        }
+    }
     return Status::OK();
 }
 

--- a/be/src/storage/lake/replication_txn_manager.h
+++ b/be/src/storage/lake/replication_txn_manager.h
@@ -50,9 +50,11 @@ private:
                                      const TRemoteSnapshotInfo& src_snapshot_info,
                                      const TabletMetadataPtr& tablet_metadata);
 
-    Status convert_rowset_meta(const RowsetMeta& rowset_meta, TTransactionId transaction_id,
-                               TxnLogPB::OpWrite* op_write,
-                               std::unordered_map<std::string, std::string>* segment_filename_map);
+    static Status convert_rowset_meta(const RowsetMeta& rowset_meta, TTransactionId transaction_id,
+                                      TxnLogPB::OpWrite* op_write,
+                                      std::unordered_map<std::string, std::string>* segment_filename_map);
+
+    static Status convert_delete_predicate_pb(DeletePredicatePB* delete_predicate);
 
 private:
     lake::TabletManager* _tablet_manager;

--- a/be/test/storage/lake/replication_txn_manager_test.cpp
+++ b/be/test/storage/lake/replication_txn_manager_test.cpp
@@ -405,4 +405,104 @@ TEST_P(LakeReplicationTxnManagerTest, test_run_normal) {
 INSTANTIATE_TEST_SUITE_P(LakeReplicationTxnManagerTest, LakeReplicationTxnManagerTest,
                          testing::Values(TKeysType::type::AGG_KEYS, TKeysType::type::PRIMARY_KEYS));
 
+class LakeReplicationTxnManagerStaticFunctionTest : public testing::Test {
+public:
+    LakeReplicationTxnManagerStaticFunctionTest() = default;
+    ~LakeReplicationTxnManagerStaticFunctionTest() override = default;
+    void SetUp() override {}
+    void TearDown() override {}
+};
+
+TEST_F(LakeReplicationTxnManagerStaticFunctionTest, test_convert_delete_predicate_pb) {
+    DeletePredicatePB delete_predicate;
+
+    delete_predicate.add_sub_predicates()->assign("k0");
+    Status status = lake::ReplicationTxnManager::convert_delete_predicate_pb(&delete_predicate);
+    EXPECT_TRUE(!status.ok()) << status;
+
+    delete_predicate.Clear();
+    delete_predicate.add_sub_predicates()->assign("k1=1");
+    delete_predicate.add_sub_predicates()->assign("k2!=1");
+    delete_predicate.add_sub_predicates()->assign("k3>>3");
+    delete_predicate.add_sub_predicates()->assign("k4<<3");
+    delete_predicate.add_sub_predicates()->assign("k5<=5");
+    delete_predicate.add_sub_predicates()->assign("k6>=5");
+    delete_predicate.add_sub_predicates()->assign("k7=7");
+    delete_predicate.add_sub_predicates()->assign("k8!=7");
+    delete_predicate.add_sub_predicates()->assign("k9=a");
+    delete_predicate.add_sub_predicates()->assign("k10!=a");
+    delete_predicate.add_sub_predicates()->assign("k11=a");
+    delete_predicate.add_sub_predicates()->assign("k12!=a");
+
+    delete_predicate.add_sub_predicates()->assign("k13 IS NULL");
+    delete_predicate.add_sub_predicates()->assign("k14 IS NOT NULL");
+
+    delete_predicate.add_sub_predicates()->assign("k15*=1");
+
+    status = lake::ReplicationTxnManager::convert_delete_predicate_pb(&delete_predicate);
+    EXPECT_TRUE(status.ok()) << status;
+    EXPECT_EQ(12, delete_predicate.binary_predicates_size());
+    EXPECT_EQ(2, delete_predicate.is_null_predicates_size());
+    EXPECT_EQ(1, delete_predicate.in_predicates_size());
+
+    EXPECT_EQ("k1", delete_predicate.binary_predicates(0).column_name());
+    EXPECT_EQ("=", delete_predicate.binary_predicates(0).op());
+    EXPECT_EQ("1", delete_predicate.binary_predicates(0).value());
+
+    EXPECT_EQ("k2", delete_predicate.binary_predicates(1).column_name());
+    EXPECT_EQ("!=", delete_predicate.binary_predicates(1).op());
+    EXPECT_EQ("1", delete_predicate.binary_predicates(1).value());
+
+    EXPECT_EQ("k3", delete_predicate.binary_predicates(2).column_name());
+    EXPECT_EQ(">", delete_predicate.binary_predicates(2).op());
+    EXPECT_EQ("3", delete_predicate.binary_predicates(2).value());
+
+    EXPECT_EQ("k4", delete_predicate.binary_predicates(3).column_name());
+    EXPECT_EQ("<", delete_predicate.binary_predicates(3).op());
+    EXPECT_EQ("3", delete_predicate.binary_predicates(3).value());
+
+    EXPECT_EQ("k5", delete_predicate.binary_predicates(4).column_name());
+    EXPECT_EQ("<=", delete_predicate.binary_predicates(4).op());
+    EXPECT_EQ("5", delete_predicate.binary_predicates(4).value());
+
+    EXPECT_EQ("k6", delete_predicate.binary_predicates(5).column_name());
+    EXPECT_EQ(">=", delete_predicate.binary_predicates(5).op());
+    EXPECT_EQ("5", delete_predicate.binary_predicates(5).value());
+
+    EXPECT_EQ("k7", delete_predicate.binary_predicates(6).column_name());
+    EXPECT_EQ("=", delete_predicate.binary_predicates(6).op());
+    EXPECT_EQ("7", delete_predicate.binary_predicates(6).value());
+
+    EXPECT_EQ("k8", delete_predicate.binary_predicates(7).column_name());
+    EXPECT_EQ("!=", delete_predicate.binary_predicates(7).op());
+    EXPECT_EQ("7", delete_predicate.binary_predicates(7).value());
+
+    EXPECT_EQ("k9", delete_predicate.binary_predicates(8).column_name());
+    EXPECT_EQ("=", delete_predicate.binary_predicates(8).op());
+    EXPECT_EQ("a", delete_predicate.binary_predicates(8).value());
+
+    EXPECT_EQ("k10", delete_predicate.binary_predicates(9).column_name());
+    EXPECT_EQ("!=", delete_predicate.binary_predicates(9).op());
+    EXPECT_EQ("a", delete_predicate.binary_predicates(9).value());
+
+    EXPECT_EQ("k11", delete_predicate.binary_predicates(10).column_name());
+    EXPECT_EQ("=", delete_predicate.binary_predicates(10).op());
+    EXPECT_EQ("a", delete_predicate.binary_predicates(10).value());
+
+    EXPECT_EQ("k12", delete_predicate.binary_predicates(11).column_name());
+    EXPECT_EQ("!=", delete_predicate.binary_predicates(11).op());
+    EXPECT_EQ("a", delete_predicate.binary_predicates(11).value());
+
+    EXPECT_EQ("k13", delete_predicate.is_null_predicates(0).column_name());
+    EXPECT_FALSE(delete_predicate.is_null_predicates(0).is_not_null());
+
+    EXPECT_EQ("k14", delete_predicate.is_null_predicates(1).column_name());
+    EXPECT_TRUE(delete_predicate.is_null_predicates(1).is_not_null());
+
+    EXPECT_EQ("k15", delete_predicate.in_predicates(0).column_name());
+    EXPECT_FALSE(delete_predicate.in_predicates(0).is_not_in());
+    EXPECT_EQ(1, delete_predicate.in_predicates(0).values_size());
+    EXPECT_EQ("1", delete_predicate.in_predicates(0).values(0));
+}
+
 } // namespace starrocks


### PR DESCRIPTION
## Why I'm doing:
Delete predicate in shared-data mode is not the same with in shared-nothing mode.

## What I'm doing:
Fix delete predicate in cross cluster replication for shared-data mode

Backport of pr: https://github.com/StarRocks/starrocks/pull/42055

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [x] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5


