### PR TITLE
[BugFix] foreignKey constraints should not be changed by the caller

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/Table.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/Table.java
@@ -820,6 +820,9 @@ public class Table extends MetaObject implements Writable, GsonPostProcessable, 
         this.foreignKeyConstraints = foreignKeyConstraints;
     }
 
+    /**
+     * Get foreign key constraints of this table. Caller should not change the returned list.
+     */
     public List<ForeignKeyConstraint> getForeignKeyConstraints() {
         return this.foreignKeyConstraints;
     }


### PR DESCRIPTION
## Why I'm doing:

`foreignKeyConstraints` is not safe if it's changed.
```
for (xxx)
            List<ForeignKeyConstraint> foreignKeyConstraints = mvChildTable.getForeignKeyConstraints();
            List<ForeignKeyConstraint> mvForeignKeyConstraints = Lists.newArrayList();
            if (materializedView.getForeignKeyConstraints() != null) {
                // add ForeignKeyConstraint from mv
                materializedView.getForeignKeyConstraints().stream().filter(foreignKeyConstraint -> {
                    if (foreignKeyConstraint.getChildTableInfo() == null) {
                        return false;
                    }
                    Table table = foreignKeyConstraint.getChildTableInfo().getTableChecked();
                    return table.equals(mvChildTable);
                }).forEach(mvForeignKeyConstraints::add);
            }

            if (foreignKeyConstraints == null) {
                foreignKeyConstraints = mvForeignKeyConstraints;
            } else if (materializedView.getForeignKeyConstraints() != null) {
                foreignKeyConstraints.addAll(mvForeignKeyConstraints);
            }
            if (foreignKeyConstraints.isEmpty()) {
                continue;
            }
```
## What I'm doing:
- Get foreign key constraints of this table. Caller should not change the returned list.

Fixes [#issue](https://github.com/StarRocks/StarRocksTest/issues/6405)

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [x] 3.1
  - [ ] 3.0
  - [ ] 2.5
