### PR TITLE
[Enhancement] adaptive choose execute nodes base on the volume of processed data

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/common/Config.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/Config.java
@@ -2870,4 +2870,7 @@ public class Config extends ConfigBase {
     // The longest supported VARCHAR length.
     @ConfField(mutable = true)
     public static int max_varchar_length = 1048576;
+
+    @ConfField(mutable = true)
+    public static int adaptive_choose_instances_threshold = 32;
 }

--- a/fe/fe-core/src/main/java/com/starrocks/common/FeConstants.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/FeConstants.java
@@ -79,6 +79,10 @@ public class FeConstants {
     public static boolean runningUnitTest = false;
     // Set this flag false to suppress showing local shuffle columns in verbose explain, when running FE unit tests.
     public static boolean showScanNodeLocalShuffleColumnsInExplain = true;
+
+    // Set this flag false to suppress showing fragment cost, when running FE unit tests.
+    public static boolean showFragmentCost = true;
+
     // set to true when replay from query dump
     public static boolean isReplayFromQueryDump = false;
     // set false to resolve ut

--- a/fe/fe-core/src/main/java/com/starrocks/planner/PlanFragment.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/PlanFragment.java
@@ -39,6 +39,7 @@ import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
 import com.starrocks.analysis.Expr;
+import com.starrocks.common.FeConstants;
 import com.starrocks.common.Pair;
 import com.starrocks.common.TreeNode;
 import com.starrocks.qe.ConnectContext;
@@ -150,6 +151,8 @@ public class PlanFragment extends TreeNode<PlanFragment> {
     protected boolean assignScanRangesPerDriverSeq = false;
     protected boolean withLocalShuffle = false;
 
+    protected double fragmentCost;
+
     protected final Map<Integer, RuntimeFilterDescription> buildRuntimeFilters = Maps.newTreeMap();
     protected final Map<Integer, RuntimeFilterDescription> probeRuntimeFilters = Maps.newTreeMap();
 
@@ -203,6 +206,14 @@ public class PlanFragment extends TreeNode<PlanFragment> {
         for (PlanNode child : node.getChildren()) {
             setFragmentInPlanTree(child);
         }
+    }
+
+    public double getFragmentCost() {
+        return fragmentCost;
+    }
+
+    public void setFragmentCost(double fragmentCost) {
+        this.fragmentCost = fragmentCost;
     }
 
     public boolean canUsePipeline() {
@@ -522,6 +533,9 @@ public class PlanFragment extends TreeNode<PlanFragment> {
     public String getVerboseExplain() {
         StringBuilder str = new StringBuilder();
         Preconditions.checkState(dataPartition != null);
+        if (FeConstants.showFragmentCost) {
+            str.append("  Fragment Cost: ").append(fragmentCost).append("\n");
+        }
         if (CollectionUtils.isNotEmpty(outputExprs)) {
             str.append("  Output Exprs:");
             str.append(outputExprs.stream().map(Expr::toSql)

--- a/fe/fe-core/src/main/java/com/starrocks/qe/CoordinatorPreprocessor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/CoordinatorPreprocessor.java
@@ -40,7 +40,6 @@ import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.service.FrontendOptions;
 import com.starrocks.sql.common.ErrorType;
 import com.starrocks.sql.common.StarRocksPlannerException;
-import com.starrocks.statistic.StatisticUtils;
 import com.starrocks.system.ComputeNode;
 import com.starrocks.thrift.TDescriptorTable;
 import com.starrocks.thrift.TNetworkAddress;
@@ -96,10 +95,10 @@ public class CoordinatorPreprocessor {
     }
 
     @VisibleForTesting
-    CoordinatorPreprocessor(List<PlanFragment> fragments, List<ScanNode> scanNodes) {
+    CoordinatorPreprocessor(List<PlanFragment> fragments, List<ScanNode> scanNodes, ConnectContext context) {
         this.coordAddress = new TNetworkAddress(LOCAL_IP, Config.rpc_port);
 
-        this.connectContext = StatisticUtils.buildConnectContext();
+        this.connectContext = context;
         this.jobSpec = JobSpec.Factory.mockJobSpec(connectContext, fragments, scanNodes);
         this.executionDAG = ExecutionDAG.build(jobSpec);
 

--- a/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
@@ -34,6 +34,8 @@
 
 package com.starrocks.qe;
 
+import com.google.common.base.Enums;
+import com.google.common.base.Joiner;
 import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Maps;
@@ -64,6 +66,7 @@ import com.starrocks.thrift.TSpillToRemoteStorageOptions;
 import com.starrocks.thrift.TTabletInternalParallelMode;
 import com.starrocks.thrift.TTimeUnit;
 import org.apache.commons.lang3.EnumUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.jetbrains.annotations.TestOnly;
@@ -78,6 +81,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
+
+import static com.starrocks.qe.SessionVariableConstants.ChooseInstancesMode.LOCALITY;
 
 // System variable
 @SuppressWarnings("FieldMayBeFinal")
@@ -339,6 +344,8 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
     public static final String CBO_ENABLE_PARALLEL_PREPARE_METADATA = "enable_parallel_prepare_metadata";
 
     public static final String SKEW_JOIN_RAND_RANGE = "skew_join_rand_range";
+
+    public static final String CHOOSE_EXECUTE_INSTANCES_MODE = "choose_execute_instances_mode";
 
     // --------  New planner session variables end --------
 
@@ -1770,6 +1777,26 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
 
     @VariableMgr.VarAttr(name = ENABLE_RESULT_SINK_ACCUMULATE)
     private boolean enableResultSinkAccumulate = true;
+
+    @VarAttr(name = CHOOSE_EXECUTE_INSTANCES_MODE)
+    private String chooseExecuteInstancesMode = LOCALITY.name();
+
+    public SessionVariableConstants.ChooseInstancesMode getChooseExecuteInstancesMode() {
+        return Enums.getIfPresent(SessionVariableConstants.ChooseInstancesMode.class,
+                        StringUtils.upperCase(chooseExecuteInstancesMode))
+                .or(SessionVariableConstants.ChooseInstancesMode.LOCALITY);
+    }
+
+    public void setChooseExecuteInstancesMode(String mode) {
+        SessionVariableConstants.ChooseInstancesMode result =
+                Enums.getIfPresent(SessionVariableConstants.ChooseInstancesMode.class, StringUtils.upperCase(mode))
+                        .orNull();
+        if (result == null) {
+            String legalValues = Joiner.on(" | ").join(SessionVariableConstants.ChooseInstancesMode.values());
+            throw new IllegalArgumentException("Legal values of choose_execute_instances_mode are " + legalValues);
+        }
+        this.chooseExecuteInstancesMode = StringUtils.upperCase(mode);
+    }
 
     public boolean isCboDecimalCastStringStrict() {
         return cboDecimalCastStringStrict;

--- a/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariableConstants.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariableConstants.java
@@ -35,9 +35,19 @@ public class SessionVariableConstants {
     public static final String VARCHAR = "varchar";
 
     public enum ChooseInstancesMode {
+
+        // the number of chosen instances is the same as the max number of instances from its children fragments
         LOCALITY,
+
+        // auto increase or decrease the instances based on the processed data size
         AUTO,
+
+        // choose more instances than the max number of instances from its children fragments
+        // if the remote fragment needs process too much data
         ADAPTIVE_INCREASE,
+
+        // choose fewer instances than the max number of instances from its children fragments
+        // if the remote fragment doesn't need process too much data
         ADAPTIVE_DECREASE;
 
         public boolean enableIncreaseInstance() {

--- a/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariableConstants.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariableConstants.java
@@ -34,6 +34,21 @@ public class SessionVariableConstants {
 
     public static final String VARCHAR = "varchar";
 
+    public enum ChooseInstancesMode {
+        LOCALITY,
+        AUTO,
+        ADAPTIVE_INCREASE,
+        ADAPTIVE_DECREASE;
+
+        public boolean enableIncreaseInstance() {
+            return this == AUTO || this == ADAPTIVE_INCREASE;
+        }
+
+        public boolean enableDecreaseInstance() {
+            return this == AUTO || this == ADAPTIVE_DECREASE;
+        }
+    }
+
     public enum AggregationStage {
         AUTO,
         ONE_STAGE,

--- a/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/DefaultWorkerProvider.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/DefaultWorkerProvider.java
@@ -216,10 +216,19 @@ public class DefaultWorkerProvider implements WorkerProvider {
         return new ArrayList<>(selectedWorkerIds);
     }
 
+    /**
+     * if usedComputeNode turns on or no backend, we add all compute nodes to the result.
+     * if perferComputeNode turns on, we just return computeNode set
+     * else add backend set and return
+     * @return
+     */
     @Override
     public List<Long> getAllAvailableNodes() {
         List<Long> nodeIds = Lists.newArrayList();
-        nodeIds.addAll(availableID2ComputeNode.keySet());
+        if (usedComputeNode || availableID2Backend.isEmpty()) {
+            nodeIds.addAll(availableID2ComputeNode.keySet());
+        }
+
         if (preferComputeNode) {
             return nodeIds;
         }

--- a/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/DefaultWorkerProvider.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/DefaultWorkerProvider.java
@@ -233,6 +233,11 @@ public class DefaultWorkerProvider implements WorkerProvider {
     }
 
     @Override
+    public void selectWorkerUnchecked(Long workerId) {
+        selectedWorkerIds.add(workerId);
+    }
+
+    @Override
     public String toString() {
         return toString(usedComputeNode);
     }
@@ -246,9 +251,7 @@ public class DefaultWorkerProvider implements WorkerProvider {
         return chooseComputeNode ? computeNodesToString() : backendsToString();
     }
 
-    private void selectWorkerUnchecked(Long workerId) {
-        selectedWorkerIds.add(workerId);
-    }
+
 
     private void reportWorkerNotFoundException(boolean chooseComputeNode) throws NonRecoverableException {
         throw new NonRecoverableException(

--- a/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/DefaultWorkerProvider.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/DefaultWorkerProvider.java
@@ -18,6 +18,7 @@ import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
 import com.starrocks.common.FeConstants;
 import com.starrocks.qe.SimpleScheduler;
@@ -213,6 +214,17 @@ public class DefaultWorkerProvider implements WorkerProvider {
     @Override
     public List<Long> getSelectedWorkerIds() {
         return new ArrayList<>(selectedWorkerIds);
+    }
+
+    @Override
+    public List<Long> getAllAvailableNodes() {
+        List<Long> nodeIds = Lists.newArrayList();
+        nodeIds.addAll(availableID2ComputeNode.keySet());
+        if (preferComputeNode) {
+            return nodeIds;
+        }
+        nodeIds.addAll(availableID2Backend.keySet());
+        return nodeIds;
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/WorkerProvider.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/WorkerProvider.java
@@ -78,6 +78,8 @@ public interface WorkerProvider {
 
     List<Long> getSelectedWorkerIds();
 
+    List<Long> getAllAvailableNodes();
+
     default boolean isPreferComputeNode() {
         return false;
     }

--- a/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/WorkerProvider.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/WorkerProvider.java
@@ -80,6 +80,8 @@ public interface WorkerProvider {
 
     List<Long> getAllAvailableNodes();
 
+    void selectWorkerUnchecked(Long workerId);
+
     default boolean isPreferComputeNode() {
         return false;
     }

--- a/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/assignment/RemoteFragmentAssignmentStrategy.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/assignment/RemoteFragmentAssignmentStrategy.java
@@ -16,19 +16,25 @@ package com.starrocks.qe.scheduler.assignment;
 
 import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
+import com.starrocks.common.Config;
 import com.starrocks.common.UserException;
 import com.starrocks.planner.DataPartition;
 import com.starrocks.planner.MultiCastPlanFragment;
 import com.starrocks.planner.PlanFragment;
 import com.starrocks.qe.ConnectContext;
+import com.starrocks.qe.SessionVariableConstants;
 import com.starrocks.qe.scheduler.WorkerProvider;
 import com.starrocks.qe.scheduler.dag.ExecutionFragment;
 import com.starrocks.qe.scheduler.dag.FragmentInstance;
 
 import java.util.Collections;
+import java.util.Comparator;
 import java.util.List;
 import java.util.Random;
 import java.util.Set;
+import java.util.stream.Collectors;
+
+import static com.starrocks.sql.optimizer.statistics.StatisticsEstimateCoefficient.TINY_SCALE_ROWS_LIMIT;
 
 /**
  * The assignment strategy for fragments whose left most node is not a scan node.
@@ -38,6 +44,7 @@ public class RemoteFragmentAssignmentStrategy implements FragmentAssignmentStrat
     private final ConnectContext connectContext;
     private final WorkerProvider workerProvider;
     private final boolean isGatherOutput;
+    private final boolean usePipeline;
     private final boolean enableDopAdaption;
 
     private final Random random;
@@ -46,6 +53,7 @@ public class RemoteFragmentAssignmentStrategy implements FragmentAssignmentStrat
                                             boolean usePipeline, boolean isGatherOutput, Random random) {
         this.connectContext = connectContext;
         this.workerProvider = workerProvider;
+        this.usePipeline = usePipeline;
         this.enableDopAdaption = usePipeline && connectContext.getSessionVariable().isEnablePipelineAdaptiveDop();
         this.isGatherOutput = isGatherOutput;
         this.random = random;
@@ -96,7 +104,7 @@ public class RemoteFragmentAssignmentStrategy implements FragmentAssignmentStrat
 
         List<Long> selectedComputedNodes = workerProvider.selectAllComputeNodes();
         if (workerProvider.isPreferComputeNode() && !selectedComputedNodes.isEmpty()) {
-            workerIdSet.addAll(selectedComputedNodes);
+            workerIdSet = adaptiveChooseNodes(fragment, selectedComputedNodes, Sets.newHashSet());
             // make olapScan maxParallelism equals prefer compute node number
             maxParallelism = workerIdSet.size() * fragment.getParallelExecNum();
         } else if (fragment.isUnionFragment() && isGatherOutput) {
@@ -128,9 +136,17 @@ public class RemoteFragmentAssignmentStrategy implements FragmentAssignmentStrat
             }
 
             ExecutionFragment maxFragment = execFragment.getChild(maxIndex);
-            maxFragment.getInstances().stream()
+            Set<Long> childUsedHost = maxFragment.getInstances().stream()
                     .map(FragmentInstance::getWorkerId)
-                    .forEach(workerIdSet::add);
+                    .collect(Collectors.toSet());
+            workerIdSet = adaptiveChooseNodes(fragment, workerProvider.getAllAvailableNodes(), childUsedHost);
+
+            // The adaptive choose nodes process may change the selected nodes number.
+            // When enable pipeline engine but dop is not 0, We have to change the maxParallelism value
+            // to ensure it keeps equal with the size of workerIdSet.
+            if (usePipeline) {
+                maxParallelism = workerIdSet.size();
+            }
         }
 
         if (enableDopAdaption) {
@@ -166,4 +182,50 @@ public class RemoteFragmentAssignmentStrategy implements FragmentAssignmentStrat
         // TODO: switch to unpartitioned/coord execution if our input fragment
         // is executed that way (could have been downgraded from distributed)
     }
+
+
+    private Set<Long> adaptiveChooseNodes(PlanFragment fragment, List<Long> candidates,
+                                           Set<Long> childUsedHosts) {
+        List<Long> childHosts = Lists.newArrayList(childUsedHosts);
+
+        // sometimes we may reverse the fragment order like SHUFFLE_HASH_BUCKET plan, so we need sort
+        // the list to ensure the most left child is at the 0 index position.
+        List<PlanFragment> sortedFragments = fragment.getChildren().stream()
+                .sorted(Comparator.comparing(e -> e.getPlanRoot().getId().asInt()))
+                .collect(Collectors.toList());
+
+        long maxOutputOfRightChild = sortedFragments.stream().skip(1)
+                .map(e -> e.getPlanRoot().getCardinality()).reduce(Long::max)
+                .orElse(fragment.getChild(0).getPlanRoot().getCardinality());
+        long outputOfMostLeftChild = sortedFragments.get(0).getPlanRoot().getCardinality();
+
+        long baseNodeNums = Math.max(1, maxOutputOfRightChild / TINY_SCALE_ROWS_LIMIT / fragment.getPipelineDop());
+        double base = Math.max(Math.E, baseNodeNums);
+
+        long amplifyFactor = Math.round(Math.max(1,
+                Math.log(outputOfMostLeftChild / TINY_SCALE_ROWS_LIMIT / fragment.getPipelineDop()) / Math.log(base)));
+
+        long nodeNums = Math.min(amplifyFactor * baseNodeNums, candidates.size());
+
+        SessionVariableConstants.ChooseInstancesMode mode = connectContext.getSessionVariable()
+                .getChooseExecuteInstancesMode();
+        if (mode.enableIncreaseInstance() && nodeNums > childUsedHosts.size()) {
+            for (Long id : candidates) {
+                if (!childUsedHosts.contains(id)) {
+                    childHosts.add(id);
+                    if (childHosts.size() == nodeNums) {
+                        break;
+                    }
+                }
+            }
+            return Sets.newHashSet(childHosts);
+        } else if (mode.enableDecreaseInstance() && nodeNums < childUsedHosts.size()
+                && candidates.size() >= Config.adaptive_choose_instances_threshold) {
+            Collections.shuffle(childHosts, random);
+            return childHosts.stream().limit(nodeNums).collect(Collectors.toSet());
+        } else {
+            return Sets.newHashSet(childHosts);
+        }
+    }
+
 }

--- a/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/assignment/RemoteFragmentAssignmentStrategy.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/assignment/RemoteFragmentAssignmentStrategy.java
@@ -213,6 +213,7 @@ public class RemoteFragmentAssignmentStrategy implements FragmentAssignmentStrat
             for (Long id : candidates) {
                 if (!childUsedHosts.contains(id)) {
                     childHosts.add(id);
+                    workerProvider.selectWorkerUnchecked(id);
                     if (childHosts.size() == nodeNums) {
                         break;
                     }

--- a/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/assignment/RemoteFragmentAssignmentStrategy.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/assignment/RemoteFragmentAssignmentStrategy.java
@@ -104,7 +104,7 @@ public class RemoteFragmentAssignmentStrategy implements FragmentAssignmentStrat
 
         List<Long> selectedComputedNodes = workerProvider.selectAllComputeNodes();
         if (workerProvider.isPreferComputeNode() && !selectedComputedNodes.isEmpty()) {
-            workerIdSet = adaptiveChooseNodes(fragment, selectedComputedNodes, Sets.newHashSet());
+            workerIdSet = adaptiveChooseNodes(fragment, selectedComputedNodes, Sets.newHashSet(selectedComputedNodes));
             // make olapScan maxParallelism equals prefer compute node number
             maxParallelism = workerIdSet.size() * fragment.getParallelExecNum();
         } else if (fragment.isUnionFragment() && isGatherOutput) {

--- a/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/dag/JobSpec.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/dag/JobSpec.java
@@ -309,7 +309,7 @@ public class JobSpec {
                     .needReport(false)
                     .queryGlobals(queryGlobals)
                     .queryOptions(queryOptions)
-                    .enablePipeline(true)
+                    .enablePipeline(context.getSessionVariable().isEnablePipelineEngine())
                     .resourceGroup(null)
                     .build();
         }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/SetStmtAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/SetStmtAnalyzer.java
@@ -14,6 +14,8 @@
 
 package com.starrocks.sql.analyzer;
 
+import com.google.common.base.Enums;
+import com.google.common.base.Joiner;
 import com.google.common.base.Strings;
 import com.google.common.collect.Lists;
 import com.starrocks.analysis.CastExpr;
@@ -196,6 +198,16 @@ public class SetStmtAnalyzer {
         if (variable.equalsIgnoreCase(SessionVariable.ADAPTIVE_DOP_MAX_BLOCK_ROWS_PER_DRIVER_SEQ)) {
             checkRangeLongVariable(resolvedExpression, SessionVariable.ADAPTIVE_DOP_MAX_BLOCK_ROWS_PER_DRIVER_SEQ, 1L,
                     null);
+        }
+
+        if (variable.equalsIgnoreCase(SessionVariable.CHOOSE_EXECUTE_INSTANCES_MODE)) {
+            SessionVariableConstants.ChooseInstancesMode mode =
+                    Enums.getIfPresent(SessionVariableConstants.ChooseInstancesMode.class,
+                            StringUtils.upperCase(resolvedExpression.getStringValue())).orNull();
+            if (mode == null) {
+                String legalValues = Joiner.on(" | ").join(SessionVariableConstants.ChooseInstancesMode.values());
+                throw new IllegalArgumentException("Legal values of choose_execute_instances_mode are " + legalValues);
+            }
         }
 
         // materialized_view_rewrite_mode

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/OptExpression.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/OptExpression.java
@@ -290,6 +290,16 @@ public class OptExpression {
             return this;
         }
 
+        public Builder setStatistics(Statistics statistics) {
+            optExpression.statistics = statistics;
+            return this;
+        }
+
+        public Builder setCost(double cost) {
+            optExpression.cost = cost;
+            return this;
+        }
+
         public OptExpression build() {
             OptExpression tmp = optExpression;
             optExpression = null;

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/AddDecodeNodeForDictStringRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/AddDecodeNodeForDictStringRule.java
@@ -482,6 +482,7 @@ public class AddDecodeNodeForDictStringRule implements TreeRewriteRule {
 
                     OptExpression.Builder builder = OptExpression.builder()
                             .setOp(newOlapScan)
+                            .setInputs(Lists.newArrayList())
                             .setLogicalProperty(rewriteLogicProperty(optExpression.getLogicalProperty(),
                             context.stringColumnIdToDictColumnIds))
                             .setStatistics(optExpression.getStatistics())

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/AddDecodeNodeForDictStringRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/AddDecodeNodeForDictStringRule.java
@@ -354,11 +354,14 @@ public class AddDecodeNodeForDictStringRule implements TreeRewriteRule {
             if (context.hasEncoded || needRewrite) {
                 if (needRewrite) {
                     PhysicalTopNOperator newTopN = rewriteTopNOperator(topN, context);
-                    OptExpression result = OptExpression.create(newTopN, newChildExpr);
-                    result.setStatistics(optExpression.getStatistics());
-                    result.setLogicalProperty(rewriteLogicProperty(optExpression.getLogicalProperty(),
-                            context.stringColumnIdToDictColumnIds));
-                    return visitProjectionAfter(result, context);
+                    OptExpression.Builder builder = OptExpression.builder()
+                            .setOp(newTopN)
+                            .setInputs(Lists.newArrayList(newChildExpr))
+                            .setStatistics(optExpression.getStatistics())
+                            .setLogicalProperty(rewriteLogicProperty(optExpression.getLogicalProperty(),
+                                    context.stringColumnIdToDictColumnIds))
+                            .setCost(optExpression.getCost());
+                    return visitProjectionAfter(builder.build(), context);
                 } else {
                     insertDecodeExpr(optExpression, Collections.singletonList(newChildExpr), 0, context);
                     return visitProjectionAfter(optExpression, context);
@@ -476,11 +479,14 @@ public class AddDecodeNodeForDictStringRule implements TreeRewriteRule {
                     newOlapScan.setNeedSortedByKeyPerTablet(scanOperator.needSortedByKeyPerTablet());
                     newOlapScan.setNeedOutputChunkByBucket(scanOperator.needOutputChunkByBucket());
                     newOlapScan.setWithoutColocateRequirement(scanOperator.isWithoutColocateRequirement());
-                    OptExpression result = new OptExpression(newOlapScan);
-                    result.setLogicalProperty(rewriteLogicProperty(optExpression.getLogicalProperty(),
-                            context.stringColumnIdToDictColumnIds));
-                    result.setStatistics(optExpression.getStatistics());
-                    return visitProjectionAfter(result, context);
+
+                    OptExpression.Builder builder = OptExpression.builder()
+                            .setOp(newOlapScan)
+                            .setLogicalProperty(rewriteLogicProperty(optExpression.getLogicalProperty(),
+                            context.stringColumnIdToDictColumnIds))
+                            .setStatistics(optExpression.getStatistics())
+                            .setCost(optExpression.getCost());
+                    return visitProjectionAfter(builder.build(), context);
                 }
             }
             return visitProjectionAfter(optExpression, context);
@@ -843,11 +849,14 @@ public class AddDecodeNodeForDictStringRule implements TreeRewriteRule {
             if (context.hasEncoded || needRewrite) {
                 if (needRewrite && unsupportedAggs.isEmpty()) {
                     PhysicalHashAggregateOperator newAggOper = rewriteAggOperator(aggOperator, context);
-                    OptExpression result = OptExpression.create(newAggOper, newChildExpr);
-                    result.setStatistics(aggExpr.getStatistics());
-                    result.setLogicalProperty(
-                            rewriteLogicProperty(aggExpr.getLogicalProperty(), context.stringColumnIdToDictColumnIds));
-                    return visitProjectionAfter(result, context);
+                    OptExpression.Builder builder = OptExpression.builder()
+                            .setOp(newAggOper)
+                            .setInputs(Lists.newArrayList(newChildExpr))
+                            .setStatistics(aggExpr.getStatistics())
+                            .setCost(aggExpr.getCost())
+                            .setLogicalProperty(rewriteLogicProperty(aggExpr.getLogicalProperty(),
+                                    context.stringColumnIdToDictColumnIds));
+                    return visitProjectionAfter(builder.build(), context);
                 } else {
                     insertDecodeExpr(aggExpr, Collections.singletonList(newChildExpr), 0, context);
                     return visitProjectionAfter(aggExpr, context);
@@ -875,11 +884,14 @@ public class AddDecodeNodeForDictStringRule implements TreeRewriteRule {
                 if (exchangeOperator.couldApplyStringDict(context.getEncodedStringCols())) {
                     PhysicalDistributionOperator newExchangeOper = rewriteDistribution(exchangeOperator, context);
 
-                    OptExpression result = OptExpression.create(newExchangeOper, newChildExpr);
-                    result.setStatistics(exchangeExpr.getStatistics());
-                    result.setLogicalProperty(rewriteLogicProperty(exchangeExpr.getLogicalProperty(),
-                            context.stringColumnIdToDictColumnIds));
-                    return visitProjectionAfter(result, context);
+                    OptExpression.Builder builder = OptExpression.builder()
+                            .setOp(newExchangeOper)
+                            .setInputs(Lists.newArrayList(newChildExpr))
+                            .setStatistics(exchangeExpr.getStatistics())
+                            .setCost(exchangeExpr.getCost())
+                            .setLogicalProperty(rewriteLogicProperty(exchangeExpr.getLogicalProperty(),
+                                    context.stringColumnIdToDictColumnIds));
+                    return visitProjectionAfter(builder.build(), context);
                 } else {
                     insertDecodeExpr(exchangeExpr, Collections.singletonList(newChildExpr), 0, context);
                     return visitProjectionAfter(exchangeExpr, context);
@@ -976,14 +988,16 @@ public class AddDecodeNodeForDictStringRule implements TreeRewriteRule {
         }
         PhysicalDecodeOperator decodeOperator = new PhysicalDecodeOperator(ImmutableMap.copyOf(dictToStrings),
                 Maps.newHashMap(context.stringFunctions));
-        OptExpression result = OptExpression.create(decodeOperator, childExpr);
-        result.setStatistics(childExpr.get(0).getStatistics());
 
         LogicalProperty decodeProperty = new LogicalProperty(childExpr.get(0).getLogicalProperty());
-        result.setLogicalProperty(
-                DecodeVisitor.rewriteLogicProperty(decodeProperty, decodeOperator.getDictIdToStringsId()));
+        OptExpression.Builder builder = OptExpression.builder()
+                .setOp(decodeOperator)
+                .setInputs(Lists.newArrayList(childExpr))
+                .setStatistics(childExpr.get(0).getStatistics())
+                .setCost(childExpr.get(0).getCost())
+                .setLogicalProperty(DecodeVisitor.rewriteLogicProperty(decodeProperty, decodeOperator.getDictIdToStringsId()));
         context.clear();
-        return result;
+        return builder.build();
     }
 
     // Check if an expression can be optimized using a dictionary

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/lowcardinality/DecodeRewriter.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/lowcardinality/DecodeRewriter.java
@@ -164,7 +164,6 @@ public class DecodeRewriter extends OptExpressionVisitor<OptExpression, ColumnRe
                 .map(c -> inputStringRefs.contains(c) ? context.stringRefToDictRefMap.getOrDefault(c, c) : c)
                 .collect(Collectors.toList());
 
-        // @todo: refactor it, SingleDistinctFunctionPos depend on the map's order
         Map<ColumnRefOperator, CallOperator> aggregations = Maps.newLinkedHashMap();
         for (ColumnRefOperator aggRef : aggregate.getAggregations().keySet()) {
             CallOperator aggFn = aggregate.getAggregations().get(aggRef);

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/StatisticsEstimateCoefficient.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/StatisticsEstimateCoefficient.java
@@ -53,7 +53,7 @@ public class StatisticsEstimateCoefficient {
     // default shuffle column row count limit
     public static final double DEFAULT_PRUNE_SHUFFLE_COLUMN_ROWS_LIMIT = 200000;
 
-    public static final long TINY_SCALE_ROWS_LIMIT = 100000;
+    public static final long TINY_SCALE_ROWS_LIMIT = 50000;
 
     // a small scale rows, such as default push down aggregate row count limit, 100w
     public static final long SMALL_SCALE_ROWS_LIMIT = 1000000;

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/StatisticsEstimateCoefficient.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/StatisticsEstimateCoefficient.java
@@ -52,6 +52,9 @@ public class StatisticsEstimateCoefficient {
     public static final double DEFAULT_ANTI_JOIN_SELECTIVITY_COEFFICIENT = 0.4;
     // default shuffle column row count limit
     public static final double DEFAULT_PRUNE_SHUFFLE_COLUMN_ROWS_LIMIT = 200000;
+
+    public static final long TINY_SCALE_ROWS_LIMIT = 100000;
+
     // a small scale rows, such as default push down aggregate row count limit, 100w
     public static final long SMALL_SCALE_ROWS_LIMIT = 1000000;
     // default or predicate limit

--- a/fe/fe-core/src/main/java/com/starrocks/sql/plan/PlanFragmentBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/plan/PlanFragmentBuilder.java
@@ -400,7 +400,7 @@ public class PlanFragmentBuilder {
             for (PlanFragment child : fragment.getChildren()) {
                 computeFragmentCost(context, child);
             }
-            OptExpression output = getOptExpression(context, fragment.getPlanRoot());
+            OptExpression output = getOptExpressionFromPlanNode(context, fragment.getPlanRoot());
 
             // scan fragment
             if (fragment.getLeftMostNode() instanceof ScanNode) {
@@ -409,13 +409,13 @@ public class PlanFragmentBuilder {
             }
 
             List<OptExpression> inputs = fragment.getChildren().stream().map(PlanFragment::getPlanRoot)
-                    .map(p -> getOptExpression(context, p)).collect(Collectors.toList());
+                    .map(p -> getOptExpressionFromPlanNode(context, p)).collect(Collectors.toList());
 
             double childCost = inputs.stream().map(OptExpression::getCost).reduce(Double::sum).orElse(0D);
             fragment.setFragmentCost(output.getCost() - childCost);
         }
 
-        private OptExpression getOptExpression(ExecPlan context, PlanNode node) {
+        private OptExpression getOptExpressionFromPlanNode(ExecPlan context, PlanNode node) {
             if (context.getOptExpression(node.getId().asInt()) == null && node instanceof ProjectNode) {
                 node = node.getChild(0);
             }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/plan/PlanFragmentBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/plan/PlanFragmentBuilder.java
@@ -391,7 +391,35 @@ public class PlanFragmentBuilder {
         }
 
         public PlanFragment translate(OptExpression optExpression, ExecPlan context) {
-            return visit(optExpression, context);
+            PlanFragment fragment = visit(optExpression, context);
+            computeFragmentCost(context, fragment);
+            return fragment;
+        }
+
+        private void computeFragmentCost(ExecPlan context, PlanFragment fragment) {
+            for (PlanFragment child : fragment.getChildren()) {
+                computeFragmentCost(context, child);
+            }
+            OptExpression output = getOptExpression(context, fragment.getPlanRoot());
+
+            // scan fragment
+            if (fragment.getLeftMostNode() instanceof ScanNode) {
+                fragment.setFragmentCost(output.getCost());
+                return;
+            }
+
+            List<OptExpression> inputs = fragment.getChildren().stream().map(PlanFragment::getPlanRoot)
+                    .map(p -> getOptExpression(context, p)).collect(Collectors.toList());
+
+            double childCost = inputs.stream().map(OptExpression::getCost).reduce(Double::sum).orElse(0D);
+            fragment.setFragmentCost(output.getCost() - childCost);
+        }
+
+        private OptExpression getOptExpression(ExecPlan context, PlanNode node) {
+            if (context.getOptExpression(node.getId().asInt()) == null && node instanceof ProjectNode) {
+                node = node.getChild(0);
+            }
+            return context.getOptExpression(node.getId().asInt());
         }
 
         @Override

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/SelectStmtTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/SelectStmtTest.java
@@ -61,6 +61,7 @@ public class SelectStmtTest {
     @BeforeAll
     public static void setUp() throws Exception {
         UtFrameUtils.createMinStarRocksCluster();
+        FeConstants.showFragmentCost = false;
         String createTblStmtStr = "create table db1.tbl1(k1 varchar(32), k2 varchar(32), k3 varchar(32), k4 int) "
                 + "AGGREGATE KEY(k1, k2,k3,k4) distributed by hash(k1) buckets 3 properties('replication_num' = '1');";
         String createBaseAllStmtStr = "create table db1.baseall(k1 int) distributed by hash(k1) "

--- a/fe/fe-core/src/test/java/com/starrocks/qe/AdaptiveChooseNodesTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/qe/AdaptiveChooseNodesTest.java
@@ -1,0 +1,96 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.qe;
+
+import com.starrocks.common.ConfigBase;
+import com.starrocks.common.FeConstants;
+import com.starrocks.qe.scheduler.dag.ExecutionDAG;
+import com.starrocks.sql.plan.DistributedEnvPlanTestBase;
+import com.starrocks.sql.plan.ExecPlan;
+import com.starrocks.thrift.TUniqueId;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import java.util.stream.Collectors;
+
+public class AdaptiveChooseNodesTest extends DistributedEnvPlanTestBase {
+
+    @BeforeClass
+    public static void beforeClass() throws Exception {
+        DistributedEnvPlanTestBase.beforeClass();
+        FeConstants.runningUnitTest = true;
+    }
+
+    @Test
+    public void testDecreaseNodesInPipeline() throws Exception {
+        ConfigBase.setMutableConfig("adaptive_choose_instances_threshold", "3");
+        connectContext.getSessionVariable().setChooseExecuteInstancesMode("auto");
+        connectContext.getSessionVariable().setPipelineDop(2);
+        connectContext.setExecutionId(new TUniqueId(0x33, 0x0));
+        String sql = "select count(*) from lineorder_new_l group by P_SIZE";
+        ExecPlan execPlan = getExecPlan(sql);
+        CoordinatorPreprocessor prepare = new CoordinatorPreprocessor(execPlan.getFragments(), execPlan.getScanNodes(),
+                connectContext);
+        prepare.computeFragmentInstances();
+
+        ExecutionDAG dag = prepare.getExecutionDAG();
+
+        // bottom fragment use 3 nodes
+        Assert.assertEquals(3, dag.getFragmentsInCreatedOrder().get(2).getInstances().size());
+
+        // remote fragment use 1 nodes
+        Assert.assertEquals(1, dag.getFragmentsInCreatedOrder().get(1).getInstances().size());
+        Assert.assertEquals(1, dag.getFragmentsInCreatedOrder().get(1).getNumSendersPerExchange().size());
+
+        connectContext.getSessionVariable().setEnablePipelineEngine(false);
+        execPlan = getExecPlan(sql);
+        prepare = new CoordinatorPreprocessor(execPlan.getFragments(), execPlan.getScanNodes(), connectContext);
+        prepare.computeFragmentInstances();
+
+        dag = prepare.getExecutionDAG();
+
+        // bottom fragment use 3 nodes
+        Assert.assertEquals(3, dag.getFragmentsInCreatedOrder().get(2).getInstances().size());
+
+        // not in pipeline engine, decrease nodes to 1. The instance exec param size also be 3.
+        Assert.assertEquals(3, dag.getFragmentsInCreatedOrder().get(1).getInstances().size());
+        Assert.assertEquals(1, dag.getFragmentsInCreatedOrder().get(1).getInstances()
+                .stream().map(e -> e.getWorkerId()).collect(Collectors.toSet()).size());
+        Assert.assertEquals(1, dag.getFragmentsInCreatedOrder().get(1).getNumSendersPerExchange().size());
+    }
+
+    @Test
+    public void testIncreaseNodes() throws Exception {
+        ConfigBase.setMutableConfig("adaptive_choose_instances_threshold", "3");
+        connectContext.getSessionVariable().setChooseExecuteInstancesMode("auto");
+        connectContext.getSessionVariable().setPipelineDop(2);
+        connectContext.setExecutionId(new TUniqueId(0x33, 0x0));
+        String sql = "select * from (select * from skew_table where id = 1) t " +
+                "join (select abs(id) abs from skew_table where id = 1) tt on t.id = tt.abs";
+        ExecPlan execPlan = getExecPlan(sql);
+        CoordinatorPreprocessor prepare = new CoordinatorPreprocessor(execPlan.getFragments(), execPlan.getScanNodes(),
+                connectContext);
+        prepare.computeFragmentInstances();
+
+        ExecutionDAG dag = prepare.getExecutionDAG();
+        // scan fragment only hit one tablet use 1 nodes
+        Assert.assertEquals(1, dag.getFragmentsInCreatedOrder().get(2).getInstances().size());
+        Assert.assertEquals(1, dag.getFragmentsInCreatedOrder().get(3).getInstances().size());
+
+        // join fragment use 3 nodes
+        Assert.assertEquals(3, dag.getFragmentsInCreatedOrder().get(1).getInstances().size());
+    }
+}

--- a/fe/fe-core/src/test/java/com/starrocks/qe/AdaptiveChooseNodesTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/qe/AdaptiveChooseNodesTest.java
@@ -60,6 +60,8 @@ public class AdaptiveChooseNodesTest extends DistributedEnvPlanTestBase {
 
         // join fragment use 3 nodes
         Assert.assertEquals(3, dag.getFragmentsInCreatedOrder().get(1).getInstances().size());
+
+        Assert.assertEquals(3, prepare.getWorkerProvider().getSelectedWorkerIds().size());
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/qe/CoordinatorTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/qe/CoordinatorTest.java
@@ -38,6 +38,7 @@ import com.starrocks.qe.scheduler.dag.ExecutionFragment;
 import com.starrocks.qe.scheduler.dag.FragmentInstance;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.sql.plan.PlanTestBase;
+import com.starrocks.statistic.StatisticUtils;
 import com.starrocks.system.Backend;
 import com.starrocks.thrift.TBinlogOffset;
 import com.starrocks.thrift.TDescriptorTable;
@@ -159,7 +160,8 @@ public class CoordinatorTest extends PlanTestBase {
         binlogScan.finalizeStats(null);
 
         List<ScanNode> scanNodes = Arrays.asList(binlogScan);
-        CoordinatorPreprocessor prepare = new CoordinatorPreprocessor(Lists.newArrayList(), scanNodes);
+        CoordinatorPreprocessor prepare = new CoordinatorPreprocessor(Lists.newArrayList(), scanNodes,
+                StatisticUtils.buildConnectContext());
         prepare.computeFragmentInstances();
 
         FragmentScanRangeAssignment scanRangeMap =
@@ -217,7 +219,8 @@ public class CoordinatorTest extends PlanTestBase {
         fragments.add(fragment);
 
         // Build topology
-        CoordinatorPreprocessor prepare = new CoordinatorPreprocessor(fragments, scanNodes);
+        CoordinatorPreprocessor prepare = new CoordinatorPreprocessor(fragments, scanNodes,
+                StatisticUtils.buildConnectContext());
         prepare.computeFragmentInstances();
 
         // Assert

--- a/fe/fe-core/src/test/java/com/starrocks/qe/SessionVariableTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/qe/SessionVariableTest.java
@@ -42,4 +42,26 @@ public class SessionVariableTest {
         Assert.assertEquals(SessionVariable.DEFAULT_SESSION_VARIABLE.getPipelineProfileLevel(), kv.defaultValue);
         Assert.assertEquals(100, kv.actualValue);
     }
+
+    @Test
+    public void testSetChooseMode() {
+        SessionVariable sessionVariable = new SessionVariable();
+        sessionVariable.setChooseExecuteInstancesMode("adaptive_increase");
+        Assert.assertTrue(sessionVariable.getChooseExecuteInstancesMode().enableIncreaseInstance());
+
+        sessionVariable.setChooseExecuteInstancesMode("adaptive_decrease");
+        Assert.assertTrue(sessionVariable.getChooseExecuteInstancesMode().enableDecreaseInstance());
+
+        sessionVariable.setChooseExecuteInstancesMode("auto");
+        Assert.assertTrue(sessionVariable.getChooseExecuteInstancesMode().enableIncreaseInstance());
+        Assert.assertTrue(sessionVariable.getChooseExecuteInstancesMode().enableDecreaseInstance());
+
+        try {
+            sessionVariable.setChooseExecuteInstancesMode("xxx");
+            Assert.fail("cannot set a invalid value");
+        } catch (Exception e) {
+            Assert.assertTrue(e.getMessage(),
+                    e.getMessage().contains("Legal values of choose_execute_instances_mode are"));
+        }
+    }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/DistributedEnvPlanTestBase.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/DistributedEnvPlanTestBase.java
@@ -28,6 +28,7 @@ public class DistributedEnvPlanTestBase extends PlanTestBase {
         PlanTestBase.beforeClass();
         UtFrameUtils.addMockBackend(10002);
         UtFrameUtils.addMockBackend(10003);
+        UtFrameUtils.addMockComputeNode(10004);
 
         starRocksAssert.withTable("CREATE TABLE `lineorder_new_l` (\n" +
                 "  `LO_ORDERKEY` int(11) NOT NULL COMMENT \"\",\n" +

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/DistributedEnvPlanTestBase.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/DistributedEnvPlanTestBase.java
@@ -26,6 +26,9 @@ public class DistributedEnvPlanTestBase extends PlanTestBase {
     @BeforeClass
     public static void beforeClass() throws Exception {
         PlanTestBase.beforeClass();
+        UtFrameUtils.addMockBackend(10002);
+        UtFrameUtils.addMockBackend(10003);
+
         starRocksAssert.withTable("CREATE TABLE `lineorder_new_l` (\n" +
                 "  `LO_ORDERKEY` int(11) NOT NULL COMMENT \"\",\n" +
                 "  `LO_ORDERDATE` date NOT NULL COMMENT \"\",\n" +
@@ -100,6 +103,9 @@ public class DistributedEnvPlanTestBase extends PlanTestBase {
                 "\"replication_num\" = \"1\",\n" +
                 "\"in_memory\" = \"false\"\n" +
                 ");");
+        starRocksAssert.withTable("create table `skew_table` (id int, name varchar(20)) ENGINE=OLAP  " +
+                "DUPLICATE KEY(id)" +
+                "distributed by hash(id) buckets 10 properties('replication_num' = '1')");
 
         GlobalStateMgr globalStateMgr = connectContext.getGlobalStateMgr();
         int scale = 100;
@@ -140,6 +146,10 @@ public class DistributedEnvPlanTestBase extends PlanTestBase {
 
         OlapTable datesN = (OlapTable) globalStateMgr.getDb("test").getTable("dates_n");
         setTableStatistics(datesN, 2556);
+
+        OlapTable skewTable =
+                (OlapTable) globalStateMgr.getDb("test").getTable("skew_table");
+        setTableStatistics(skewTable, 10000000);
 
         UtFrameUtils.addMockBackend(10002);
         UtFrameUtils.addMockBackend(10003);

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/MockTpchStatisticStorage.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/MockTpchStatisticStorage.java
@@ -15,6 +15,7 @@
 
 package com.starrocks.sql.plan;
 
+import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Maps;
 import com.starrocks.catalog.Database;
 import com.starrocks.catalog.OlapTable;
@@ -316,6 +317,10 @@ public class MockTpchStatisticStorage implements StatisticStorage {
         // S_COMMENT   VARCHAR(101)
         tableSupplier.put("s_comment", new ColumnStatistic(NEGATIVE_INFINITY, POSITIVE_INFINITY, 0, 101, 10000));
         tableStatistics.put("supplier", tableSupplier);
+
+        tableStatistics.put("lineorder_new_l", ImmutableMap.of("P_SIZE", new ColumnStatistic(1, 5, 0, 1, 5)));
+        tableStatistics.put("skew_table", ImmutableMap.of("id", new ColumnStatistic(1, 1, 0, 1, 1)));
+
     }
 
     @Override

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/PlanTestNoneDBBase.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/PlanTestNoneDBBase.java
@@ -89,6 +89,7 @@ public class PlanTestNoneDBBase {
         connectContext.getSessionVariable().setUseLowCardinalityOptimizeV2(false);
         FeConstants.enablePruneEmptyOutputScan = false;
         FeConstants.showJoinLocalShuffleInExplain = false;
+        FeConstants.showFragmentCost = false;
     }
 
     @Before


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:
- adaptive choose execute nodes base on the volume of processed data
- add fragment cost in verbose fragment plan
Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
