### PR TITLE
[BugFix] Reset replica minReadableVerion in restore

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/Replica.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/Replica.java
@@ -406,6 +406,7 @@ public class Replica implements Writable {
         this.lastSuccessVersion = newVersion;
         this.dataSize = newDataSize;
         this.rowCount = newRowCount;
+        this.minReadableVersion = newVersion;
     }
 
     /* last failed version:  LFV

--- a/fe/fe-core/src/test/java/com/starrocks/catalog/ReplicaTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/ReplicaTest.java
@@ -218,5 +218,11 @@ public class ReplicaTest {
         assertEquals(18, originalReplica.getVersion());
         assertEquals(-1, originalReplica.getLastFailedVersion());
     }
+
+    @Test
+    public void testUpdateVersion4() {
+        Replica originalReplica = new Replica(10000, 20000, 3, 0, 100, 78, ReplicaState.NORMAL, 0, 6);
+        originalReplica.updateForRestore(2, 10, 20);
+    }
 }
 

--- a/fe/fe-core/src/test/java/com/starrocks/catalog/ReplicaTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/ReplicaTest.java
@@ -223,6 +223,7 @@ public class ReplicaTest {
     public void testUpdateVersion4() {
         Replica originalReplica = new Replica(10000, 20000, 3, 0, 100, 78, ReplicaState.NORMAL, 0, 6);
         originalReplica.updateForRestore(2, 10, 20);
+        assertEquals(2, originalReplica.getMinReadableVersion());
     }
 }
 


### PR DESCRIPTION
## Why I'm doing:
Suppose we have a table with version 10 and minReadableVersion 5. And we have a snapshot for this table with version 2. When we restore this snapshot directly without dropping the original table, the replica's minReadableVersion for it have not been reset. So we have the partition with visibleVersion = 2 and minReadableVersion = 5 which is wrong.

## What I'm doing:
reset the minReadableVersion in restore if necessary.

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [x] 3.1
  - [x] 3.0
  - [x] 2.5
