### PR TITLE
[BugFix] Fix race condition when access delete predicate list in tablet meta (#42099)(backport #42100)

### DIFF
--- a/be/src/storage/tablet.h
+++ b/be/src/storage/tablet.h
@@ -139,6 +139,7 @@ public:
 
     const DelPredicateArray& delete_predicates() const { return _tablet_meta->delete_predicates(); }
     bool version_for_delete_predicate(const Version& version);
+    bool version_for_delete_predicate_unlocked(const Version& version);
     bool has_delete_predicates(const Version& version);
 
     // meta lock


### PR DESCRIPTION
Why I'm doing:
tablet::version_for_delete_predicate do not hold lock to access delete predicate list which may cause crash.

What I'm doing:
separate tablet::version_for_delete_predicate into to function: tablet::version_for_delete_predicate
tablet::version_for_delete_predicate_unlocked
Use this two functions base on the caller has acquire the _meta_lock or not

Fixes #42099

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [x] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5

