### PR TITLE
[Feature] make bucket agg support more buckets in partition table

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
@@ -420,6 +420,7 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
 
     public static final String ENABLE_SORT_AGGREGATE = "enable_sort_aggregate";
     public static final String ENABLE_PER_BUCKET_OPTIMIZE = "enable_per_bucket_optimize";
+    public static final String ENABLE_PARTITION_BUCKET_OPTIMIZE = "enable_partition_bucket_optimize";
     public static final String ENABLE_PARALLEL_MERGE = "enable_parallel_merge";
     public static final String ENABLE_QUERY_QUEUE = "enable_query_queue";
 
@@ -1279,6 +1280,9 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
     @VarAttr(name = ENABLE_PER_BUCKET_OPTIMIZE)
     private boolean enablePerBucketComputeOptimize = true;
 
+    @VarAttr(name = ENABLE_PARTITION_BUCKET_OPTIMIZE, flag = VariableMgr.INVISIBLE)
+    private boolean enablePartitionBucketOptimize = false;
+
     @VarAttr(name = ENABLE_PARALLEL_MERGE)
     private boolean enableParallelMerge = true;
 
@@ -1379,6 +1383,13 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
 
     public boolean isEnablePerBucketComputeOptimize() {
         return enablePerBucketComputeOptimize;
+    }
+
+    public boolean isEnablePartitionBucketOptimize() {
+        return enablePartitionBucketOptimize;
+    }
+    public void setEnablePartitionBucketOptimize(boolean enablePartitionBucketOptimize) {
+        this.enablePartitionBucketOptimize = enablePartitionBucketOptimize;
     }
 
     public int getWindowPartitionMode() {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/physical/PhysicalHashAggregateOperator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/physical/PhysicalHashAggregateOperator.java
@@ -65,6 +65,8 @@ public class PhysicalHashAggregateOperator extends PhysicalOperator {
 
     private boolean usePerBucketOptmize = false;
 
+    private boolean withoutColocateRequirement = false;
+
     private DataSkewInfo distinctColumnDataSkew = null;
     public PhysicalHashAggregateOperator(AggType type,
                                          List<ColumnRefOperator> groupBys,
@@ -156,6 +158,14 @@ public class PhysicalHashAggregateOperator extends PhysicalOperator {
 
     public boolean isUsePerBucketOptmize() {
         return usePerBucketOptmize;
+    }
+
+    public boolean isWithoutColocateRequirement() {
+        return withoutColocateRequirement;
+    }
+
+    public void setWithoutColocateRequirement(boolean withoutColocateRequirement) {
+        this.withoutColocateRequirement = withoutColocateRequirement;
     }
 
     public void setUsePerBucketOptmize(boolean usePerBucketOptmize) {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/physical/PhysicalOlapScanOperator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/physical/PhysicalOlapScanOperator.java
@@ -48,6 +48,7 @@ public class PhysicalOlapScanOperator extends PhysicalScanOperator {
     private String turnOffReason;
     protected boolean needSortedByKeyPerTablet = false;
     protected boolean needOutputChunkByBucket = false;
+    private boolean withoutColocateRequirement = false;
 
     private boolean usePkIndex = false;
 
@@ -159,6 +160,14 @@ public class PhysicalOlapScanOperator extends PhysicalScanOperator {
 
     public void setNeedOutputChunkByBucket(boolean needOutputChunkByBucket) {
         this.needOutputChunkByBucket = needOutputChunkByBucket;
+    }
+
+    public boolean isWithoutColocateRequirement() {
+        return withoutColocateRequirement;
+    }
+
+    public void setWithoutColocateRequirement(boolean withoutColocateRequirement) {
+        this.withoutColocateRequirement = withoutColocateRequirement;
     }
 
     public boolean isUsePkIndex() {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/AddDecodeNodeForDictStringRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/AddDecodeNodeForDictStringRule.java
@@ -475,7 +475,7 @@ public class AddDecodeNodeForDictStringRule implements TreeRewriteRule {
                     newOlapScan.setOutputColumns(newOutputColumns);
                     newOlapScan.setNeedSortedByKeyPerTablet(scanOperator.needSortedByKeyPerTablet());
                     newOlapScan.setNeedOutputChunkByBucket(scanOperator.needOutputChunkByBucket());
-
+                    newOlapScan.setWithoutColocateRequirement(scanOperator.isWithoutColocateRequirement());
                     OptExpression result = new OptExpression(newOlapScan);
                     result.setLogicalProperty(rewriteLogicProperty(optExpression.getLogicalProperty(),
                             context.stringColumnIdToDictColumnIds));
@@ -755,6 +755,7 @@ public class AddDecodeNodeForDictStringRule implements TreeRewriteRule {
             newHashAggregator.setMergedLocalAgg(aggOperator.isMergedLocalAgg());
             newHashAggregator.setUseSortAgg(aggOperator.isUseSortAgg());
             newHashAggregator.setUsePerBucketOptmize(aggOperator.isUsePerBucketOptmize());
+            newHashAggregator.setWithoutColocateRequirement(aggOperator.isWithoutColocateRequirement());
             return newHashAggregator;
         }
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/PhysicalDistributionAggOptRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/PhysicalDistributionAggOptRule.java
@@ -14,9 +14,11 @@
 
 package com.starrocks.sql.optimizer.rule.tree;
 
+import com.google.common.collect.Sets;
 import com.starrocks.catalog.Column;
 import com.starrocks.catalog.OlapTable;
 import com.starrocks.qe.ConnectContext;
+import com.starrocks.qe.SessionVariable;
 import com.starrocks.sql.optimizer.OptExpression;
 import com.starrocks.sql.optimizer.OptExpressionVisitor;
 import com.starrocks.sql.optimizer.operator.OperatorType;
@@ -26,20 +28,22 @@ import com.starrocks.sql.optimizer.operator.scalar.ColumnRefOperator;
 import com.starrocks.sql.optimizer.task.TaskContext;
 
 import java.util.List;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 public class PhysicalDistributionAggOptRule implements TreeRewriteRule {
     @Override
     public OptExpression rewrite(OptExpression root, TaskContext taskContext) {
-        if (ConnectContext.get().getSessionVariable().isEnableQueryCache()) {
+        SessionVariable sv = ConnectContext.get().getSessionVariable();
+        if (sv.isEnableQueryCache()) {
             return root;
         }
-        if (ConnectContext.get().getSessionVariable().isEnableSortAggregate()) {
+        if (sv.isEnableSortAggregate()) {
             root.getOp().accept(new UseSortAGGRule(), root, null);
             return root;
         }
-        if (ConnectContext.get().getSessionVariable().isEnablePerBucketComputeOptimize()) {
-            root.getOp().accept(new UsePerBucketOptimizeRule(), root, null);
+        if (sv.isEnablePerBucketComputeOptimize()) {
+            root.getOp().accept(new UsePerBucketOptimizeRule(sv.isEnablePartitionBucketOptimize()), root, null);
             return root;
         }
         return root;
@@ -56,6 +60,19 @@ public class PhysicalDistributionAggOptRule implements TreeRewriteRule {
     }
 
     private static class UsePerBucketOptimizeRule extends NoopVisitor {
+        private final boolean enablePartitionBucketOptimize;
+        private boolean hasColocateRequirement = false;
+
+        UsePerBucketOptimizeRule(boolean enablePartitionBucketOptimize) {
+            this.enablePartitionBucketOptimize = enablePartitionBucketOptimize;
+        }
+
+        @Override
+        public Void visitPhysicalHashJoin(OptExpression optExpression, Void context) {
+            hasColocateRequirement = true;
+            return visit(optExpression, context);
+        }
+
         @Override
         public Void visitPhysicalHashAggregate(OptExpression optExpression, Void context) {
             if (optExpression.getInputs().get(0).getOp().getOpType() != OperatorType.PHYSICAL_OLAP_SCAN) {
@@ -69,9 +86,25 @@ public class PhysicalDistributionAggOptRule implements TreeRewriteRule {
             if (!agg.getType().isGlobal() || agg.getGroupBys().isEmpty()) {
                 return null;
             }
-
             agg.setUsePerBucketOptmize(true);
             scan.setNeedOutputChunkByBucket(true);
+
+            if (!hasColocateRequirement && enablePartitionBucketOptimize) {
+                Set<Column> partitionColumns =
+                        Sets.newHashSet(((OlapTable) scan.getTable()).getPartitionInfo().getPartitionColumns());
+                List<ColumnRefOperator> groupBys = agg.getGroupBys();
+                for (ColumnRefOperator groupBy : groupBys) {
+                    Column column = scan.getColRefToColumnMetaMap().get(groupBy);
+                    if (column != null) {
+                        partitionColumns.remove(column);
+                    }
+                }
+                if (partitionColumns.isEmpty()) {
+                    agg.setWithoutColocateRequirement(true);
+                    scan.setWithoutColocateRequirement(true);
+                }
+            }
+
             return null;
         }
     }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/plan/PlanFragmentBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/plan/PlanFragmentBuilder.java
@@ -724,6 +724,7 @@ public class PlanFragmentBuilder {
             scanNode.setScanOptimzeOption(node.getScanOptimzeOption());
             scanNode.setIsSortedByKeyPerTablet(node.needSortedByKeyPerTablet());
             scanNode.setIsOutputChunkByBucket(node.needOutputChunkByBucket());
+            scanNode.setWithoutColocateRequirement(node.isWithoutColocateRequirement());
             // set tablet
             try {
                 scanNode.updateScanInfo(node.getSelectedPartitionId(),
@@ -1854,7 +1855,7 @@ public class PlanFragmentBuilder {
                 // Check colocate for the first phase in three/four-phase agg whose second phase is pruned.
                 if (!withLocalShuffle && node.isMergedLocalAgg() &&
                         hasColocateOlapScanChildInFragment(aggregationNode)) {
-                    aggregationNode.setColocate(true);
+                    aggregationNode.setColocate(!node.isWithoutColocateRequirement());
                 }
             } else if (node.getType().isGlobal() || (node.getType().isLocal() && !node.isSplit())) {
                 // Local && un-split aggregate meanings only execute local pre-aggregation, we need promise
@@ -1904,7 +1905,7 @@ public class PlanFragmentBuilder {
 
                 // Check colocate for one-phase local agg.
                 if (!withLocalShuffle && hasColocateOlapScanChildInFragment(aggregationNode)) {
-                    aggregationNode.setColocate(true);
+                    aggregationNode.setColocate(!node.isWithoutColocateRequirement());
                 }
             } else if (node.getType().isDistinctGlobal()) {
                 aggregateExprList.forEach(FunctionCallExpr::setMergeAggFn);
@@ -1919,7 +1920,7 @@ public class PlanFragmentBuilder {
                 aggregationNode.setIntermediateTuple();
 
                 if (!withLocalShuffle && hasColocateOlapScanChildInFragment(aggregationNode)) {
-                    aggregationNode.setColocate(true);
+                    aggregationNode.setColocate(!node.isWithoutColocateRequirement());
                 }
             } else if (node.getType().isDistinctLocal()) {
                 // For SQL: select count(distinct id_bigint), sum(id_int) from test_basic;

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/AggregateTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/AggregateTest.java
@@ -16,7 +16,9 @@ package com.starrocks.sql.plan;
 
 import com.starrocks.common.FeConstants;
 import com.starrocks.common.Pair;
+import com.starrocks.planner.OlapScanNode;
 import com.starrocks.planner.PlanFragment;
+import com.starrocks.planner.ScanNode;
 import com.starrocks.sql.analyzer.SemanticException;
 import com.starrocks.system.BackendCoreStat;
 import com.starrocks.thrift.TExplainLevel;
@@ -1705,6 +1707,25 @@ public class AggregateTest extends PlanTestBase {
     }
 
     @Test
+    public void testBucketAggregate() throws Exception {
+        FeConstants.runningUnitTest = true;
+        connectContext.getSessionVariable().setEnablePartitionBucketOptimize(true);
+        String sql;
+        String plan;
+        {
+            sql = "select distinct L_ORDERKEY,L_SHIPDATE from lineitem_partition_colocate;";
+            ExecPlan execPlan = getExecPlan(sql);
+            ScanNode scanNode = execPlan.getScanNodes().get(0);
+            plan = getFragmentPlan(sql);
+            Assert.assertTrue(((OlapScanNode) scanNode).getWithoutColocateRequirement());
+            assertContains(plan, "  1:AGGREGATE (update finalize)\n" +
+                    "  |  group by: 1: L_ORDERKEY, 11: L_SHIPDATE");
+        }
+        connectContext.getSessionVariable().setEnablePartitionBucketOptimize(false);
+        FeConstants.runningUnitTest = false;
+    }
+
+    @Test
     public void testMergeAggPruneColumnPruneWindow() throws Exception {
         String sql = "select v2 " +
                 "from ( " +
@@ -2296,7 +2317,6 @@ public class AggregateTest extends PlanTestBase {
         assertNotContains(plan, "multi_distinct_count");
     }
 
-
     @Test
     public void testRemoveExchange() throws Exception {
         int oldValue = connectContext.getSessionVariable().getNewPlannerAggStage();
@@ -2348,13 +2368,11 @@ public class AggregateTest extends PlanTestBase {
         getCostExplain(sql);
         plan = getCostExplain(sql);
 
-
         sql = "select percentile_cont(1, cast(0.4 as DOUBLE));";
         expectedException.expect(SemanticException.class);
         expectedException.expectMessage("Getting analyzing error. " +
                 "Detail message: percentile_cont 's second parameter's data type is wrong .");
         getCostExplain(sql);
-
 
         sql = "select PERCENTILE_DISC(1, cast(0.4 as DOUBLE));";
         expectedException.expect(SemanticException.class);
@@ -2385,7 +2403,6 @@ public class AggregateTest extends PlanTestBase {
                         "  |  output: count(2: v2), count(8: count)\n" +
                         "  |  group by: ");
 
-
         sql = "select count(distinct v2), count(v3) from t0 join t1 group by 'a'";
         plan = getFragmentPlan(sql);
         assertCContains(plan, "STREAM DATA SINK\n" +
@@ -2411,9 +2428,9 @@ public class AggregateTest extends PlanTestBase {
                 "count(distinct v2), sum(v4) from t0 join t1 group by v3";
         plan = getFragmentPlan(sql);
         assertCContains(plan, "4:AGGREGATE (update serialize)\n" +
-                "  |  STREAMING\n" +
-                "  |  output: sum(4: v4)\n" +
-                "  |  group by: 2: v2, 3: v3",
+                        "  |  STREAMING\n" +
+                        "  |  output: sum(4: v4)\n" +
+                        "  |  group by: 2: v2, 3: v3",
                 "7:AGGREGATE (update finalize)\n" +
                         "  |  output: count(2: v2), sum(8: sum)\n" +
                         "  |  group by: 3: v3");
@@ -2444,13 +2461,13 @@ public class AggregateTest extends PlanTestBase {
                 "count(distinct v2), array_length(array_agg(v1)) from t0 join t1 group by v4";
         plan = getFragmentPlan(sql);
         assertCContains(plan, "STREAM DATA SINK\n" +
-                "    EXCHANGE ID: 08\n" +
-                "    HASH_PARTITIONED: 4: v4\n" +
-                "\n" +
-                "  7:AGGREGATE (update serialize)\n" +
-                "  |  STREAMING\n" +
-                "  |  output: count(2: v2), array_agg(8: array_agg)\n" +
-                "  |  group by: 4: v4",
+                        "    EXCHANGE ID: 08\n" +
+                        "    HASH_PARTITIONED: 4: v4\n" +
+                        "\n" +
+                        "  7:AGGREGATE (update serialize)\n" +
+                        "  |  STREAMING\n" +
+                        "  |  output: count(2: v2), array_agg(8: array_agg)\n" +
+                        "  |  group by: 4: v4",
                 "9:AGGREGATE (merge finalize)\n" +
                         "  |  output: count(7: count), array_agg(8: array_agg)\n" +
                         "  |  group by: 4: v4\n" +
@@ -2611,10 +2628,10 @@ public class AggregateTest extends PlanTestBase {
         String plan = getFragmentPlan(sql);
         assertContains(plan, "output: group_concat(CAST(1: v1 AS VARCHAR), ', ')");
 
-        sql = "select /*+ set_var('sql_mode' = 'GROUP_CONCAT_LEGACY, ONLY_full_group_by') */ group_concat(v1, '-') from t0";
+        sql =
+                "select /*+ set_var('sql_mode' = 'GROUP_CONCAT_LEGACY, ONLY_full_group_by') */ group_concat(v1, '-') from t0";
         plan = getFragmentPlan(sql);
         assertContains(plan, "output: group_concat(CAST(1: v1 AS VARCHAR), '-')");
-
 
         sql = "select /*+ set_var(sql_mode = '68719476768') */ group_concat(v1, '-') from t0";
         plan = getFragmentPlan(sql);
@@ -2625,7 +2642,8 @@ public class AggregateTest extends PlanTestBase {
         assertContains(plan, "output: group_concat(CAST(1: v1 AS VARCHAR), '-')");
 
         // overwrite the GROUP_CONCAT_LEGACY
-        sql = "select /*+ set_var(sql_mode = 68719476768) */ /*+ set_var(sql_mode = 32) */ group_concat(v1, '-') from t0";
+        sql =
+                "select /*+ set_var(sql_mode = 68719476768) */ /*+ set_var(sql_mode = 32) */ group_concat(v1, '-') from t0";
         plan = getFragmentPlan(sql);
         assertContains(plan, "output: group_concat(CAST(1: v1 AS VARCHAR), '-', ',')");
     }


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:
for colocate local-one-stage aggregate with group by partition key
```
select xxx from TableX group by HashKey, partitionKey.
```
In the past for such cases, it was difficult to reduce memory usage by increasing the number of additional buckets for tables with large partitions. (This could lead to a large increase in the number of tablet). 
But in fact such cases can be optimized in this way: if the group by columns contain partitioned columns, then each physical tablet actually has no need for a strong colocate attribute. We can treat it as a non-partitioned table.

## What type of PR is this:

- [ ] BugFix
- [x] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
