### PR TITLE
[BugFix] Fix compatibility problem of storage volume

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/server/LocalMetastore.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/LocalMetastore.java
@@ -434,7 +434,9 @@ public class LocalMetastore implements ConnectorMetadata {
         try {
             Database db = new Database(createDbInfo.getId(), createDbInfo.getDbName());
             unprotectCreateDb(db);
-            stateMgr.getStorageVolumeMgr().replayBindDbToStorageVolume(createDbInfo.getStorageVolumeId(), db.getId());
+            if (createDbInfo.getStorageVolumeId() != null) {
+                stateMgr.getStorageVolumeMgr().replayBindDbToStorageVolume(createDbInfo.getStorageVolumeId(), db.getId());
+            }
             LOG.info("finish replay create db, name: {}, id: {}", db.getOriginName(), db.getId());
         } finally {
             unlock();
@@ -2338,7 +2340,7 @@ public class LocalMetastore implements ConnectorMetadata {
             }
         }
 
-        if (table.isCloudNativeTableOrMaterializedView()) {
+        if (table.isCloudNativeTableOrMaterializedView() && info.getStorageVolumeId() != null) {
             GlobalStateMgr.getCurrentState().getStorageVolumeMgr()
                     .replayBindTableToStorageVolume(info.getStorageVolumeId(), table.getId());
         }

--- a/fe/fe-core/src/main/java/com/starrocks/server/LocalMetastore.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/LocalMetastore.java
@@ -434,6 +434,7 @@ public class LocalMetastore implements ConnectorMetadata {
         try {
             Database db = new Database(createDbInfo.getId(), createDbInfo.getDbName());
             unprotectCreateDb(db);
+            // If user upgrades from 3.0, the storage volume id will be null
             if (createDbInfo.getStorageVolumeId() != null) {
                 stateMgr.getStorageVolumeMgr().replayBindDbToStorageVolume(createDbInfo.getStorageVolumeId(), db.getId());
             }
@@ -2340,6 +2341,7 @@ public class LocalMetastore implements ConnectorMetadata {
             }
         }
 
+        // If user upgrades from 3.0, the storage volume id will be null
         if (table.isCloudNativeTableOrMaterializedView() && info.getStorageVolumeId() != null) {
             GlobalStateMgr.getCurrentState().getStorageVolumeMgr()
                     .replayBindTableToStorageVolume(info.getStorageVolumeId(), table.getId());

--- a/fe/fe-core/src/main/java/com/starrocks/server/SharedDataStorageVolumeMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/SharedDataStorageVolumeMgr.java
@@ -132,6 +132,9 @@ public class SharedDataStorageVolumeMgr extends StorageVolumeMgr {
     // Because it has been checked when creating db.
     private boolean bindDbToStorageVolume(String svId, long dbId, boolean isReplay) {
         try (LockCloseable lock = new LockCloseable(rwLock.writeLock())) {
+            if (svId == null) {
+                return false;
+            }
             if (!isReplay && !storageVolumeToDbs.containsKey(svId) && getStorageVolume(svId) == null) {
                 return false;
             }
@@ -229,6 +232,9 @@ public class SharedDataStorageVolumeMgr extends StorageVolumeMgr {
     // Because it has been checked when creating table.
     private boolean bindTableToStorageVolume(String svId, long tableId, boolean isReplay) {
         try (LockCloseable lock = new LockCloseable(rwLock.writeLock())) {
+            if (svId == null) {
+                return false;
+            }
             if (!isReplay && !storageVolumeToDbs.containsKey(svId) &&
                     !storageVolumeToTables.containsKey(svId) &&
                     getStorageVolume(svId) == null) {

--- a/fe/fe-core/src/main/java/com/starrocks/server/SharedDataStorageVolumeMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/SharedDataStorageVolumeMgr.java
@@ -131,10 +131,10 @@ public class SharedDataStorageVolumeMgr extends StorageVolumeMgr {
     // In replay phase, the check of storage volume existence can be skipped.
     // Because it has been checked when creating db.
     private boolean bindDbToStorageVolume(String svId, long dbId, boolean isReplay) {
+        if (svId == null) {
+            return false;
+        }
         try (LockCloseable lock = new LockCloseable(rwLock.writeLock())) {
-            if (svId == null) {
-                return false;
-            }
             if (!isReplay && !storageVolumeToDbs.containsKey(svId) && getStorageVolume(svId) == null) {
                 return false;
             }
@@ -231,10 +231,10 @@ public class SharedDataStorageVolumeMgr extends StorageVolumeMgr {
     // In replay phase, the check of storage volume existence can be skipped.
     // Because it has been checked when creating table.
     private boolean bindTableToStorageVolume(String svId, long tableId, boolean isReplay) {
+        if (svId == null) {
+            return false;
+        }
         try (LockCloseable lock = new LockCloseable(rwLock.writeLock())) {
-            if (svId == null) {
-                return false;
-            }
             if (!isReplay && !storageVolumeToDbs.containsKey(svId) &&
                     !storageVolumeToTables.containsKey(svId) &&
                     getStorageVolume(svId) == null) {

--- a/fe/fe-core/src/main/java/com/starrocks/server/StorageVolumeMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/StorageVolumeMgr.java
@@ -49,7 +49,6 @@ import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.HashMap;
 import java.util.HashSet;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -381,22 +380,14 @@ public abstract class StorageVolumeMgr implements Writable, GsonPostProcessable 
         // If user upgrades from 3.0 and the createTableInfo and createDbInfo is replayed,
         // the image will look like: "svToDbs":{"null":[12288,81921,49154,65541,20485]}, "svToTables":{"null":[12288]}
         // The mapping null to dbs and tables should be removed. These code can be removed when 3.0 is not supported.
-        for (Iterator<Map.Entry<String, Set<Long>>> it = storageVolumeToDbs.entrySet().iterator(); it.hasNext();) {
-            Map.Entry<String, Set<Long>> entry = it.next();
-            if (String.valueOf(entry.getKey()).equals("null")) {
-                it.remove();
-                continue;
-            }
+        storageVolumeToDbs.remove("null");
+        for (Map.Entry<String, Set<Long>> entry : storageVolumeToDbs.entrySet()) {
             for (Long dbId : entry.getValue()) {
                 dbToStorageVolume.put(dbId, entry.getKey());
             }
         }
-        for (Iterator<Map.Entry<String, Set<Long>>> it = storageVolumeToTables.entrySet().iterator(); it.hasNext();) {
-            Map.Entry<String, Set<Long>> entry = it.next();
-            if (String.valueOf(entry.getKey()).equals("null")) {
-                it.remove();
-                continue;
-            }
+        storageVolumeToTables.remove("null");
+        for (Map.Entry<String, Set<Long>> entry : storageVolumeToTables.entrySet()) {
             for (Long tableId : entry.getValue()) {
                 tableToStorageVolume.put(tableId, entry.getKey());
             }

--- a/fe/fe-core/src/main/java/com/starrocks/server/StorageVolumeMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/StorageVolumeMgr.java
@@ -49,6 +49,7 @@ import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -377,12 +378,25 @@ public abstract class StorageVolumeMgr implements Writable, GsonPostProcessable 
 
     @Override
     public void gsonPostProcess() throws IOException {
-        for (Map.Entry<String, Set<Long>> entry : storageVolumeToDbs.entrySet()) {
+        // If user upgrades from 3.0 and the createTableInfo and createDbInfo is replayed,
+        // the image will look like: "svToDbs":{"null":[12288,81921,49154,65541,20485]}, "svToTables":{"null":[12288]}
+        // The mapping null to dbs and tables should be removed. These code can be removed when 3.0 is not supported.
+        for (Iterator<Map.Entry<String, Set<Long>>> it = storageVolumeToDbs.entrySet().iterator(); it.hasNext();) {
+            Map.Entry<String, Set<Long>> entry = it.next();
+            if (String.valueOf(entry.getKey()).equals("null")) {
+                it.remove();
+                continue;
+            }
             for (Long dbId : entry.getValue()) {
                 dbToStorageVolume.put(dbId, entry.getKey());
             }
         }
-        for (Map.Entry<String, Set<Long>> entry : storageVolumeToTables.entrySet()) {
+        for (Iterator<Map.Entry<String, Set<Long>>> it = storageVolumeToTables.entrySet().iterator(); it.hasNext();) {
+            Map.Entry<String, Set<Long>> entry = it.next();
+            if (String.valueOf(entry.getKey()).equals("null")) {
+                it.remove();
+                continue;
+            }
             for (Long tableId : entry.getValue()) {
                 tableToStorageVolume.put(tableId, entry.getKey());
             }

--- a/fe/fe-core/src/test/java/com/starrocks/server/SharedDataStorageVolumeMgrTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/server/SharedDataStorageVolumeMgrTest.java
@@ -536,6 +536,10 @@ public class SharedDataStorageVolumeMgrTest {
     @Test
     public void testReplayBindDbToStorageVolume() throws DdlException, AlreadyExistsException {
         SharedDataStorageVolumeMgr sdsvm = new SharedDataStorageVolumeMgr();
+        sdsvm.replayBindDbToStorageVolume(null, 2L);
+        Assert.assertTrue(sdsvm.dbToStorageVolume.isEmpty());
+        Assert.assertTrue(sdsvm.storageVolumeToDbs.isEmpty());
+
         String svName = "test";
         List<String> locations = Arrays.asList("s3://abc");
         Map<String, String> storageParams = new HashMap<>();
@@ -551,6 +555,10 @@ public class SharedDataStorageVolumeMgrTest {
     @Test
     public void testReplayBindTableToStorageVolume() throws DdlException, AlreadyExistsException {
         SharedDataStorageVolumeMgr sdsvm = new SharedDataStorageVolumeMgr();
+        sdsvm.replayBindTableToStorageVolume(null, 2L);
+        Assert.assertTrue(sdsvm.tableToStorageVolume.isEmpty());
+        Assert.assertTrue(sdsvm.storageVolumeToTables.isEmpty());
+
         String svName = "test";
         List<String> locations = Arrays.asList("s3://abc");
         Map<String, String> storageParams = new HashMap<>();
@@ -898,5 +906,7 @@ public class SharedDataStorageVolumeMgrTest {
         Assert.assertTrue(svm1.storageVolumeToTables.isEmpty());
         Assert.assertTrue(svm1.dbToStorageVolume.isEmpty());
         Assert.assertTrue(svm1.tableToStorageVolume.isEmpty());
+        Assert.assertEquals(StorageVolumeMgr.BUILTIN_STORAGE_VOLUME, svm1.getStorageVolumeNameOfDb(1L));
+        Assert.assertEquals(StorageVolumeMgr.BUILTIN_STORAGE_VOLUME, svm1.getStorageVolumeNameOfTable(1L));
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/server/SharedDataStorageVolumeMgrTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/server/SharedDataStorageVolumeMgrTest.java
@@ -67,6 +67,7 @@ import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -876,8 +877,12 @@ public class SharedDataStorageVolumeMgrTest {
             DdlException, AlreadyExistsException {
         StorageVolumeMgr svm = new SharedDataStorageVolumeMgr();
         svm.createBuiltinStorageVolume();
-        svm.replayBindDbToStorageVolume(null, 1L);
-        svm.replayBindTableToStorageVolume(null, 2L);
+        Set<Long> dbs = new HashSet<>();
+        dbs.add(1L);
+        svm.storageVolumeToDbs.put(null, dbs);
+        Set<Long> tables = new HashSet<>();
+        tables.add(2L);
+        svm.storageVolumeToTables.put(null, tables);
 
         ByteArrayOutputStream out = new ByteArrayOutputStream();
         DataOutputStream dos = new DataOutputStream(out);


### PR DESCRIPTION
## Why I'm doing:
If user upgrades from 3.0 and the createTableInfo and createDbInfo is replayed, the image will look like: 
```
{"clazz":"SharedDataStorageVolumeMgr","defaultSVId":"starrocks-qa-test-cloud-data","svToD
bs":{},"svToTables":{"null":[12288,81921,49154,65541]}}
```
If Fe is restarted, the map `storageVolumeToDbs` and `storageVolumeToTables` will be {} and {"null":[12288,81921,49154,65541]}. And this bindings mean there is a storage volume called null maps to some tables and dbs. When user use show create table, unexpected exception will be thrown because a storage volume called null does not exist. And this bindings should not be created.
## What I'm doing:
1. Do not bind storage volume to db and table if storage volume id is null in replay phase.
2. When image is loaded, clear the incorrect mapping which maps "null" to dbs and tables.
Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [x] 3.1
  - [ ] 3.0
  - [ ] 2.5
