### PR TITLE
[Enhancement] use rbo view based mv rewrite for 3.2 (backport #42173)

### DIFF
--- a/test/sql/test_materialized_view/R/test_view_based_mv_rewrite
+++ b/test/sql/test_materialized_view/R/test_view_based_mv_rewrite
@@ -1,0 +1,70 @@
+-- name: test_agg_join_on_multi_tables_rewrite
+set enable_view_based_mv_rewrite = true;
+
+CREATE TABLE `t1` (
+`v4` bigint NULL COMMENT "",
+`v5` bigint NULL COMMENT "",
+`v6` bigint NULL
+) ENGINE=OLAP
+DUPLICATE KEY(`v4`, `v5`, v6)
+DISTRIBUTED BY HASH(`v4`) BUCKETS 3
+PROPERTIES (
+    "replication_num" = "1",
+    "in_memory" = "false"
+);
+INSERT INTO `t1` (`v4`, `v5`, `v6`) VALUES (1, 10, 100);
+INSERT INTO `t1` (`v4`, `v5`, `v6`) VALUES (2, 20, 200);
+INSERT INTO `t1` (`v4`, `v5`, `v6`) VALUES (3, 30, 300);
+INSERT INTO `t1` (`v4`, `v5`, `v6`) VALUES (4, 40, 400);
+INSERT INTO `t1` (`v4`, `v5`, `v6`) VALUES (5, 50, 500);
+
+CREATE TABLE `t2` (
+`c4` bigint NULL COMMENT "",
+`c5` bigint NULL COMMENT "",
+`c6` bigint NULL
+) ENGINE=OLAP
+DUPLICATE KEY(`c4`, `c5`, c6)
+DISTRIBUTED BY HASH(`c4`) BUCKETS 3
+PROPERTIES (
+    "replication_num" = "1",
+    "in_memory" = "false"
+);
+
+INSERT INTO `t2` (`c4`, `c5`, `c6`) VALUES (1, 1009, 10009);
+INSERT INTO `t2` (`c4`, `c5`, `c6`) VALUES (2, NULL, 10010);
+INSERT INTO `t2` (`c4`, `c5`, `c6`) VALUES (3, 1011, NULL);
+INSERT INTO `t2` (`c4`, `c5`, `c6`) VALUES (4, 1009, 10009);
+INSERT INTO `t2` (`c4`, `c5`, `c6`) VALUES (5, NULL, 10010);
+
+create view agg_view_1
+as
+select v4, sum(v5) as total from t1 group by v4;
+
+create materialized view mv_1
+DISTRIBUTED by hash(`v4`)
+refresh manual
+as
+select v4, total, c5, c6 from t2 join agg_view_1 on c4 = v4;
+
+refresh materialized view mv_1 with sync mode;
+
+function: check_hit_materialized_view("select v4, total, c5, c6 from t2 join agg_view_1 on c4 = v4", "mv_1")
+
+-- name: test_agg_join_on_single_tables_rewrite
+set enable_view_based_mv_rewrite = true;
+CREATE TABLE t1 (
+                    k1 INT,
+                    v1 INT,
+                    v2 INT)
+                DUPLICATE KEY(k1)
+                DISTRIBUTED BY HASH(k1);
+
+insert into t1 values (1,1,1),(2,1,1),(3,1,1),(1,2,3),(2,2,3),(3,2,3);
+
+create view v1 as select k1,sum(v1) as sum_v1 from t1 group by k1;
+
+create materialized view mv_2 refresh manual as select v1.k1,v1.sum_v1,t1.v1 from v1 join t1 on v1.k1=t1.k1;
+
+refresh materialized view mv_2 with sync mode;
+
+function: check_hit_materialized_view("select v1.k1,v1.sum_v1,t1.v1 from v1 join t1 on v1.k1=t1.k1 order by 1,3;", "mv_2")

--- a/test/sql/test_materialized_view/T/test_view_based_mv_rewrite
+++ b/test/sql/test_materialized_view/T/test_view_based_mv_rewrite
@@ -1,0 +1,65 @@
+-- name: test_agg_join_on_multi_tables_rewrite
+set enable_view_based_mv_rewrite = true;
+
+CREATE TABLE `t1` (
+`v4` bigint NULL COMMENT "",
+`v5` bigint NULL COMMENT "",
+`v6` bigint NULL
+) ENGINE=OLAP
+DUPLICATE KEY(`v4`, `v5`, v6)
+DISTRIBUTED BY HASH(`v4`) BUCKETS 3
+PROPERTIES (
+    "replication_num" = "1",
+    "in_memory" = "false"
+);
+INSERT INTO `t1` (`v4`, `v5`, `v6`) VALUES (1, 10, 100);
+INSERT INTO `t1` (`v4`, `v5`, `v6`) VALUES (2, 20, 200);
+INSERT INTO `t1` (`v4`, `v5`, `v6`) VALUES (3, 30, 300);
+INSERT INTO `t1` (`v4`, `v5`, `v6`) VALUES (4, 40, 400);
+INSERT INTO `t1` (`v4`, `v5`, `v6`) VALUES (5, 50, 500);
+
+CREATE TABLE `t2` (
+`c4` bigint NULL COMMENT "",
+`c5` bigint NULL COMMENT "",
+`c6` bigint NULL
+) ENGINE=OLAP
+DUPLICATE KEY(`c4`, `c5`, c6)
+DISTRIBUTED BY HASH(`c4`) BUCKETS 3
+PROPERTIES (
+    "replication_num" = "1",
+    "in_memory" = "false"
+);
+
+INSERT INTO `t2` (`c4`, `c5`, `c6`) VALUES (1, 1009, 10009);
+INSERT INTO `t2` (`c4`, `c5`, `c6`) VALUES (2, NULL, 10010);
+INSERT INTO `t2` (`c4`, `c5`, `c6`) VALUES (3, 1011, NULL);
+INSERT INTO `t2` (`c4`, `c5`, `c6`) VALUES (4, 1009, 10009);
+INSERT INTO `t2` (`c4`, `c5`, `c6`) VALUES (5, NULL, 10010);
+
+create view agg_view_1
+as
+select v4, sum(v5) as total from t1 group by v4;
+
+create materialized view mv_1
+DISTRIBUTED by hash(`v4`)
+refresh manual
+as
+select v4, total, c5, c6 from t2 join agg_view_1 on c4 = v4;
+
+refresh materialized view mv_1 with sync mode;
+
+function: check_hit_materialized_view("select v4, total, c5, c6 from t2 join agg_view_1 on c4 = v4", "mv_1")
+
+-- name: test_agg_join_on_single_tables_rewrite
+CREATE TABLE t1 (
+                    k1 INT,
+                    v1 INT,
+                    v2 INT)
+                DUPLICATE KEY(k1)
+                DISTRIBUTED BY HASH(k1);
+insert into t1 values (1,1,1),(2,1,1),(3,1,1),(1,2,3),(2,2,3),(3,2,3);
+create view v1 as select k1,sum(v1) as sum_v1 from t1 group by k1;
+create materialized view mv_2 refresh manual as select v1.k1,v1.sum_v1,t1.v1 from v1 join t1 on v1.k1=t1.k1;
+refresh materialized view mv_2 with sync mode;
+set enable_view_based_mv_rewrite = true;
+function: check_hit_materialized_view("select v1.k1,v1.sum_v1,t1.v1 from v1 join t1 on v1.k1=t1.k1 order by 1,3;", "mv_2")


### PR DESCRIPTION
## Why I'm doing:
now view based mv rewrite is cbo, which is not stable.

## What I'm doing:
use rbo to do view based mv rewrite to make it more stable.


## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [x] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5

