### PR TITLE
[BugFix] making this version comparison more resilient as it fails issues/41016

### DIFF
--- a/contrib/dbt-connector/dbt/adapters/starrocks/impl.py
+++ b/contrib/dbt-connector/dbt/adapters/starrocks/impl.py
@@ -144,14 +144,9 @@ class StarRocksAdapter(SQLAdapter):
         conn = self.connections.get_if_exists()
         if conn:
             server_version = conn.handle.server_version
-            version_detail = version.split(".")
-            version_detail = (int(version_detail[0]), int(version_detail[1]), int(version_detail[2]))
-            if version_detail[0] > server_version[0]:
-                return True
-            elif version_detail[0] == server_version[0] and version_detail[1] > server_version[1]:
-                return True
-            elif version_detail[0] == server_version[0] and version_detail[1] == server_version[1] \
-                    and version_detail[2] > server_version[2]:
+            server_version_tuple = tuple(int(part) for part in server_version if part.isdigit())
+            version_detail_tuple = tuple(int(part) for part in version.split(".") if part.isdigit())
+            if version_detail_tuple > server_version_tuple:
                 return True
         return False
 


### PR DESCRIPTION
## Why I'm doing:
Fixed https://github.com/StarRocks/dbt-starrocks/issues/23 which causes problems with version 3.2
Used to spit out 
`'>' not supported between instances of 'int' and 'str'`

## What I'm doing:

Fixes #issue
https://github.com/StarRocks/dbt-starrocks/issues/23

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [x] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
