### PR TITLE
[Enhancement] Reduce duplicate data in RpcDataPackage during RPC transmission.

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/rpc/AttachmentRequest.java
+++ b/fe/fe-core/src/main/java/com/starrocks/rpc/AttachmentRequest.java
@@ -17,6 +17,7 @@
 
 package com.starrocks.rpc;
 
+import com.baidu.bjf.remoting.protobuf.annotation.Ignore;
 import com.starrocks.common.profile.Timer;
 import com.starrocks.common.profile.Tracers;
 import org.apache.commons.lang3.StringUtils;
@@ -31,7 +32,9 @@ import org.apache.thrift.protocol.TJSONProtocol;
 
 // used to compatible with our older thrift protocol
 public class AttachmentRequest {
+    @Ignore
     protected byte[] serializedRequest;
+    @Ignore
     protected byte[] serializedResult;
 
     public static TSerializer getSerializer(String protocol) {

--- a/fe/fe-core/src/test/java/com/starrocks/rpc/PExecPlanFragmentRequestTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/rpc/PExecPlanFragmentRequestTest.java
@@ -1,0 +1,73 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.rpc;
+
+import com.baidu.bjf.remoting.protobuf.Codec;
+import com.baidu.bjf.remoting.protobuf.ProtobufProxy;
+import com.baidu.jprotobuf.pbrpc.ProtobufRPC;
+import com.baidu.jprotobuf.pbrpc.client.PojoRpcMethodInfo;
+import com.baidu.jprotobuf.pbrpc.client.RpcMethodInfo;
+import com.baidu.jprotobuf.pbrpc.data.RpcDataPackage;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.lang.reflect.Method;
+
+/**
+ * Tests for serialization and deserialization of {@link PExecPlanFragmentRequest}.
+ */
+public class PExecPlanFragmentRequestTest {
+    private static final String ATTACHMENT_PROTOCOL = "binary";
+
+    @Test
+    public void testSerDePExecPlanFragmentRequestTest() throws Exception {
+        PExecPlanFragmentRequest request = buildPExecPlanFragmentRequest();
+        Codec<PExecPlanFragmentRequest> pExecPlanFragmentRequestCodec = ProtobufProxy.create(PExecPlanFragmentRequest.class);
+
+        byte[] encode = pExecPlanFragmentRequestCodec.encode(request);
+        PExecPlanFragmentRequest decodeRequest = pExecPlanFragmentRequestCodec.decode(encode);
+
+        Assert.assertEquals(ATTACHMENT_PROTOCOL, decodeRequest.attachmentProtocol);
+        Assert.assertNull(decodeRequest.getSerializedRequest());
+        Assert.assertNull(decodeRequest.getSerializedResult());
+    }
+
+    @Test
+    public void testBuildRpcDataPackage() throws Exception {
+        RpcMethodInfo rpcMethodInfo = buildRpcMethodInfo("execPlanFragmentAsync", PExecPlanFragmentRequest.class);
+        PExecPlanFragmentRequest request = buildPExecPlanFragmentRequest();
+        RpcDataPackage rpcData = RpcDataPackage.buildRpcDataPackage(rpcMethodInfo, new Object[] {request});
+
+        Codec<PExecPlanFragmentRequest> pExecPlanFragmentRequestCodec = ProtobufProxy.create(PExecPlanFragmentRequest.class);
+        byte[] encode = pExecPlanFragmentRequestCodec.encode(request);
+
+        Assert.assertArrayEquals(encode, rpcData.getData());
+        Assert.assertArrayEquals(request.getSerializedRequest(), rpcData.getAttachment());
+    }
+
+    private PExecPlanFragmentRequest buildPExecPlanFragmentRequest() {
+        PExecPlanFragmentRequest request = new PExecPlanFragmentRequest();
+        request.setAttachmentProtocol(ATTACHMENT_PROTOCOL);
+        request.setRequest("test-request".getBytes());
+        request.setSerializedResult(null);
+        return request;
+    }
+
+    private RpcMethodInfo buildRpcMethodInfo(String methodName, Class<?>... types) throws NoSuchMethodException {
+        Method method = PBackendService.class.getMethod(methodName, types);
+        ProtobufRPC protobufRPC = method.getAnnotation(ProtobufRPC.class);
+        return new PojoRpcMethodInfo(method, protobufRPC);
+    }
+}


### PR DESCRIPTION
## Why I'm doing:

[Enhancement] Reduce duplicate data in RpcDataPackage during RPC transmission.

Currently, the `RpcDataPackage` sent by `FE` will contain duplicate rpc data in `data` and `attachment`, which results in the available rpc body size being reduced by half.

## What I'm doing:

Add the `Ignore` annotation to the fields in `AttachmentRequest` so that these fields will not be serialized in `RpcDataPackage`.

Fixes #41277 

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
- [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [x] 3.1
  - [x] 3.0
  - [x] 2.5
