### PR TITLE
[BugFix] Fixe bug where tablet was not deleted from meta when removing disk path from be.conf (backport 41755)

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/master/MasterImpl.java
+++ b/fe/fe-core/src/main/java/com/starrocks/master/MasterImpl.java
@@ -343,6 +343,8 @@ public class MasterImpl {
                                 "finish recover create replica task. set replica to good. tablet {}, replica {}, backend {}",
                                 tabletId, task.getBackendId(), replica.getId());
                     }
+                } else {
+                    LOG.warn("tablet_info is not set in finishTaskRequest");
                 }
 
                 // this should be called before 'countDownLatch()'
@@ -350,7 +352,7 @@ public class MasterImpl {
                         .updateBackendReportVersion(task.getBackendId(), request.getReport_version(), task.getDbId());
 
                 createReplicaTask.countDownLatch(task.getBackendId(), task.getSignature());
-                LOG.debug("finish create replica. tablet id: {}, be: {}, report version: {}",
+                LOG.info("finish create replica. tablet id: {}, be: {}, report version: {}",
                         tabletId, task.getBackendId(), request.getReport_version());
             }
         } finally {

--- a/fe/fe-core/src/main/java/com/starrocks/system/SystemInfoService.java
+++ b/fe/fe-core/src/main/java/com/starrocks/system/SystemInfoService.java
@@ -935,7 +935,7 @@ public class SystemInfoService {
             if (db != null) {
                 db.readLock();
                 try {
-                    atomicLong.set(newReportVersion);
+                    updateReportVersionIncrementally(atomicLong, newReportVersion);
                     LOG.debug("update backend {} report version: {}, db: {}", backendId, newReportVersion, dbId);
                 } finally {
                     db.readUnlock();
@@ -945,6 +945,12 @@ public class SystemInfoService {
             }
         } else {
             LOG.warn("failed to update backend report version, backend {} does not exist", backendId);
+        }
+    }
+
+    protected synchronized void updateReportVersionIncrementally(AtomicLong currentVersion, long newVersion) {
+        if (currentVersion.get() < newVersion) {
+            currentVersion.set(newVersion);
         }
     }
 


### PR DESCRIPTION
## Why I'm doing:
A disk is removed from be's conf. The normal repair logic is as follows:
1. BE reports the full amount of tablets to FE. At this time, it will not bring along the tablets that have been removed from the disk.
2. FE compares the tablets reported by BE with the tablets recorded in its own metadata, and deletes replicas of tablets that do not exist in BE from the metadata.
3. Make up for the lost replicas based on the tablets on other BEs.

However, if there are too many tablets on a BE, the processing time of the second step is too long. As long as tablets are created or imported on the BE, which is controlled by reportVersion, the deletion will not be performed, resulting in incorrect metadata information being recorded on the FE side.

## What I'm doing:
Only check reportVersion when the disk is online, as there will be no tablet changes on an unavailable disk.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [x] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
