### PR TITLE
[BugFix] remain unsupported operator when dict mapping rewrite

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/DictMappingRewriter.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/DictMappingRewriter.java
@@ -14,9 +14,10 @@
 
 package com.starrocks.sql.optimizer.rule.tree;
 
-import com.google.common.base.Preconditions;
 import com.google.common.collect.Lists;
 import com.starrocks.catalog.Type;
+import com.starrocks.sql.common.ErrorType;
+import com.starrocks.sql.common.StarRocksPlannerException;
 import com.starrocks.sql.optimizer.base.ColumnRefSet;
 import com.starrocks.sql.optimizer.operator.scalar.BinaryPredicateOperator;
 import com.starrocks.sql.optimizer.operator.scalar.CallOperator;
@@ -76,7 +77,11 @@ public class DictMappingRewriter {
     // rewrite scalar operator as dict mapping operator
     ScalarOperator rewriteAsDictMapping(ScalarOperator scalarOperator, Type type) {
         final ColumnRefSet usedColumns = scalarOperator.getUsedColumns();
-        Preconditions.checkState(usedColumns.cardinality() == 1);
+        ColumnRefSet usedCols = scalarOperator.getUsedColumns();
+        if (usedCols.cardinality() != 1) {
+            throw new StarRocksPlannerException(ErrorType.INTERNAL_ERROR,
+                    "%s used more than one column when DictExpr rewriting", scalarOperator);
+        }
         final Integer dictColumnId = decodeContext.stringColumnIdToDictColumnIds.get(usedColumns.getFirstId());
         ColumnRefOperator dictColumn = decodeContext.columnRefFactory.getColumnRef(dictColumnId);
         scalarOperator = new DictMappingOperator(dictColumn, scalarOperator.clone(), type);
@@ -107,6 +112,7 @@ public class DictMappingRewriter {
                 }
                 if (!disableApplied || !hasApplied) {
                     context.hasAppliedOperator = hasApplied;
+                    context.hasUnsupportedOperator = disableApplied;
                     return operator;
                 } else {
                     context.hasAppliedOperator = false;

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/LowCardinalityTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/LowCardinalityTest.java
@@ -1940,4 +1940,12 @@ public class LowCardinalityTest extends PlanTestBase {
                 "  |  ");
     }
 
+
+    @Test
+    public void testNestedStringFunc() throws Exception {
+        String sql = "SELECT CASE WHEN S_ADDRESS = '' THEN '' ELSE SUBSTR(MD5(S_ADDRESS), 1, 3) END AS value FROM supplier;";
+        String plan = getFragmentPlan(sql);
+        assertContains(plan, "if(DictDecode(10: S_ADDRESS, [<place-holder> = '']), ''," +
+                " substr(md5(DictDecode(10: S_ADDRESS, [<place-holder>])), 1, 3))");
+    }
 }

--- a/test/sql/test_low_cardinality/R/test_low_cardinality
+++ b/test/sql/test_low_cardinality/R/test_low_cardinality
@@ -1,4 +1,4 @@
--- name: test_split_or
+-- name: test_low_cardinality
 CREATE TABLE `common_duplicate` (
   `c0` int(11) NOT NULL COMMENT "",
   `c1` int(11) NOT NULL COMMENT "",
@@ -612,11 +612,11 @@ INSERT INTO low_card_duplicate (c0,c1,c2,c3,c4,c5,c6) VALUES
 -- !result
 [UC] analyze full table common_duplicate;
 -- result:
-test_db_d992a13ebf6811eeb62000163e04d4c2.common_duplicate	analyze	status	OK
+test_db_90045066dbac11eebf782207f0c28980.common_duplicate	analyze	status	OK
 -- !result
 [UC] analyze full table low_card_duplicate;
 -- result:
-test_db_d992a13ebf6811eeb62000163e04d4c2.low_card_duplicate	analyze	status	OK
+test_db_90045066dbac11eebf782207f0c28980.low_card_duplicate	analyze	status	OK
 -- !result
 function: wait_global_dict_ready('c3', 'low_card_duplicate')
 -- result:
@@ -676,16 +676,16 @@ order by
 limit
     10;
 -- result:
-None	beijing - a	beijing-a	68616E677A686F75	hangz	1	hangzhou	000beijing	beijing		zhengzhou	hangzhouhangzhouhangzhou	hangsu	gnijieb	hou	hangzhou  	beijing	None	angz	ijing	beijing - a	BEIJING	a
+None	beijing - a	beijing-a	7368616E67686169	shang	0	shanghai	000beijing	beijing		szhenghai	shanghaishanghaishanghai	shanghai	gnijieb	hai	shanghai  	beijing	None	hang	ijing	beijing - a	BEIJING	a
 None	beijing - a	beijing-a	6265696A696E67	beiji	0	beijing	000beijing	beijing		beijing	beijingbeijingbeijing	beijing	gnijieb	ing	beijing   	beijing	None	eiji	ijing	beijing - a	BEIJING	a
 None	beijing - a	beijing-a	7368656E7A68656E	shenz	0	shenzhen	000beijing	beijing		shenzhen	shenzhenshenzhenshenzhen	shenzhen	gnijieb	hen	shenzhen  	beijing	None	henz	ijing	beijing - a	BEIJING	a
-None	beijing - a	beijing-a	7368616E67686169	shang	0	shanghai	000beijing	beijing		szhenghai	shanghaishanghaishanghai	shanghai	gnijieb	hai	shanghai  	beijing	None	hang	ijing	beijing - a	BEIJING	a
+None	beijing - a	beijing-a	68616E677A686F75	hangz	1	hangzhou	000beijing	beijing		zhengzhou	hangzhouhangzhouhangzhou	hangsu	gnijieb	hou	hangzhou  	beijing	None	angz	ijing	beijing - a	BEIJING	a
 None	beijing - a	beijing-a	6775616E677A686F75	guang	0	guangzhou	000beijing	beijing		guangzhou	guangzhouguangzhouguangzhou	guangsu	gnijieb	hou	guangzhou 	beijing	None	uang	ijing	beijing - a	BEIJING	a
-None	guangzhou - a	guangzhou-a	6265696A696E67	beiji	0	beijing	0guangzhou	guangzhou		beijing	beijingbeijingbeijing	beijing	uohzgnaug	ing	beijing   	guangzhou	None	eiji	angzhou	guangzhou - a	GUANGZHOU	a
-None	guangzhou - a	guangzhou-a	6775616E677A686F75	guang	0	guangzhou	0guangzhou	guangzhou		guangzhou	guangzhouguangzhouguangzhou	guangsu	uohzgnaug	hou	guangzhou 	guangzhou	None	uang	angzhou	guangzhou - a	GUANGZHOU	a
-None	guangzhou - a	guangzhou-a	7368616E67686169	shang	0	shanghai	0guangzhou	guangzhou		szhenghai	shanghaishanghaishanghai	shanghai	uohzgnaug	hai	shanghai  	guangzhou	None	hang	angzhou	guangzhou - a	GUANGZHOU	a
 None	guangzhou - a	guangzhou-a	68616E677A686F75	hangz	1	hangzhou	0guangzhou	guangzhou		zhengzhou	hangzhouhangzhouhangzhou	hangsu	uohzgnaug	hou	hangzhou  	guangzhou	None	angz	angzhou	guangzhou - a	GUANGZHOU	a
+None	guangzhou - a	guangzhou-a	7368616E67686169	shang	0	shanghai	0guangzhou	guangzhou		szhenghai	shanghaishanghaishanghai	shanghai	uohzgnaug	hai	shanghai  	guangzhou	None	hang	angzhou	guangzhou - a	GUANGZHOU	a
+None	guangzhou - a	guangzhou-a	6265696A696E67	beiji	0	beijing	0guangzhou	guangzhou		beijing	beijingbeijingbeijing	beijing	uohzgnaug	ing	beijing   	guangzhou	None	eiji	angzhou	guangzhou - a	GUANGZHOU	a
 None	guangzhou - a	guangzhou-a	7368656E7A68656E	shenz	0	shenzhen	0guangzhou	guangzhou		shenzhen	shenzhenshenzhenshenzhen	shenzhen	uohzgnaug	hen	shenzhen  	guangzhou	None	henz	angzhou	guangzhou - a	GUANGZHOU	a
+None	guangzhou - a	guangzhou-a	6775616E677A686F75	guang	0	guangzhou	0guangzhou	guangzhou		guangzhou	guangzhouguangzhouguangzhou	guangsu	uohzgnaug	hou	guangzhou 	guangzhou	None	uang	angzhou	guangzhou - a	GUANGZHOU	a
 -- !result
 select
     CONCAT(concatenated_values, '-', lower_c3),
@@ -710,11 +710,11 @@ group by
     lower_c3
 order by max(lower_c3) limit 5;
 -- result:
-shenzhen - a-beijing	beijing	1	["nehznehs"]
-beijing - a-beijing	beijing	1	["gnijieb"]
-guangzhou - a-beijing	beijing	1	["uohzgnaug"]
-hangzhou - a-beijing	beijing	1	["uohzgnah"]
 shanghai - a-beijing	beijing	1	["iahgnahs"]
+beijing - a-beijing	beijing	1	["gnijieb"]
+shenzhen - a-beijing	beijing	1	["nehznehs"]
+hangzhou - a-beijing	beijing	1	["uohzgnah"]
+guangzhou - a-beijing	beijing	1	["uohzgnaug"]
 -- !result
 SELECT
     CONCAT(lcd.c4, ' - ', 'a') AS concatenated_values,
@@ -785,11 +785,11 @@ select
 from
     low_card_duplicate lcd;
 -- result:
-shanghai
+hangzhou
 beijing
+shanghai
 guangzhou
 shenzhen
-hangzhou
 -- !result
 SELECT
     c4,
@@ -999,11 +999,11 @@ FROM
 GROUP BY
     grouped_results.upper_c1;
 -- result:
+SHANGHAI	990	c
 SHENZHEN	770	c
 BEIJING	1034	c
 GUANGZHOU	968	c
 HANGZHOU	1056	c
-SHANGHAI	990	c
 -- !result
 SELECT
     lcd.c0,
@@ -1257,8 +1257,8 @@ FROM
 ORDER BY c1, c2, rank limit 10;
 -- result:
 		1	0.00175303445490039722
-		6	0.00738631979156705382
 		6	0.00142515312812037520
+		6	0.00738631979156705382
 		7	0.00952553311745999506
 		11	2.0835238245287E-7
 		17	0.00573706498198447023
@@ -1290,16 +1290,16 @@ FROM
     low_card_duplicate
 ORDER BY c1, c2, rank limit 10;
 -- result:
-		1	0.00175303445490039722
 		1	9896154.00000000000000000000
-		6	0.00738631979156705382
+		1	0.00175303445490039722
+		6	8983395.00000000000000000000
 		6	7954463.00000000000000000000
 		6	0.00142515312812037520
-		6	8983395.00000000000000000000
+		6	0.00738631979156705382
 		7	7953378.00000000000000000000
 		7	0.00952553311745999506
-		11	2.0835238245287E-7
 		11	7077253.00000000000000000000
+		11	2.0835238245287E-7
 -- !result
 select
     unnest
@@ -1332,4 +1332,33 @@ a
 a
 a
 a
+-- !result
+SELECT CASE WHEN c3 = 'hangzhouxx' THEN 'hang' ELSE SUBSTR(MD5(c3), 1, 8) END AS value FROM low_card_duplicate order by value limit 10;
+-- result:
+0420a206
+0420a206
+0420a206
+0420a206
+0420a206
+0420a206
+0420a206
+0420a206
+0420a206
+0420a206
+-- !result
+set low_cardinality_optimize_v2 = false;
+-- result:
+-- !result
+SELECT CASE WHEN c3 = 'hangzhouxx' THEN 'hang' ELSE SUBSTR(MD5(c3), 1, 8) END AS value FROM low_card_duplicate order by value limit 10;
+-- result:
+0420a206
+0420a206
+0420a206
+0420a206
+0420a206
+0420a206
+0420a206
+0420a206
+0420a206
+0420a206
 -- !result

--- a/test/sql/test_low_cardinality/R/test_low_cardinality
+++ b/test/sql/test_low_cardinality/R/test_low_cardinality
@@ -1,4 +1,5 @@
 -- name: test_low_cardinality
+-- name: test_split_or
 CREATE TABLE `common_duplicate` (
   `c0` int(11) NOT NULL COMMENT "",
   `c1` int(11) NOT NULL COMMENT "",
@@ -612,11 +613,11 @@ INSERT INTO low_card_duplicate (c0,c1,c2,c3,c4,c5,c6) VALUES
 -- !result
 [UC] analyze full table common_duplicate;
 -- result:
-test_db_90045066dbac11eebf782207f0c28980.common_duplicate	analyze	status	OK
+test_db_d992a13ebf6811eeb62000163e04d4c2.common_duplicate	analyze	status	OK
 -- !result
 [UC] analyze full table low_card_duplicate;
 -- result:
-test_db_90045066dbac11eebf782207f0c28980.low_card_duplicate	analyze	status	OK
+test_db_d992a13ebf6811eeb62000163e04d4c2.low_card_duplicate	analyze	status	OK
 -- !result
 function: wait_global_dict_ready('c3', 'low_card_duplicate')
 -- result:
@@ -676,16 +677,16 @@ order by
 limit
     10;
 -- result:
-None	beijing - a	beijing-a	7368616E67686169	shang	0	shanghai	000beijing	beijing		szhenghai	shanghaishanghaishanghai	shanghai	gnijieb	hai	shanghai  	beijing	None	hang	ijing	beijing - a	BEIJING	a
+None	beijing - a	beijing-a	68616E677A686F75	hangz	1	hangzhou	000beijing	beijing		zhengzhou	hangzhouhangzhouhangzhou	hangsu	gnijieb	hou	hangzhou  	beijing	None	angz	ijing	beijing - a	BEIJING	a
 None	beijing - a	beijing-a	6265696A696E67	beiji	0	beijing	000beijing	beijing		beijing	beijingbeijingbeijing	beijing	gnijieb	ing	beijing   	beijing	None	eiji	ijing	beijing - a	BEIJING	a
 None	beijing - a	beijing-a	7368656E7A68656E	shenz	0	shenzhen	000beijing	beijing		shenzhen	shenzhenshenzhenshenzhen	shenzhen	gnijieb	hen	shenzhen  	beijing	None	henz	ijing	beijing - a	BEIJING	a
-None	beijing - a	beijing-a	68616E677A686F75	hangz	1	hangzhou	000beijing	beijing		zhengzhou	hangzhouhangzhouhangzhou	hangsu	gnijieb	hou	hangzhou  	beijing	None	angz	ijing	beijing - a	BEIJING	a
+None	beijing - a	beijing-a	7368616E67686169	shang	0	shanghai	000beijing	beijing		szhenghai	shanghaishanghaishanghai	shanghai	gnijieb	hai	shanghai  	beijing	None	hang	ijing	beijing - a	BEIJING	a
 None	beijing - a	beijing-a	6775616E677A686F75	guang	0	guangzhou	000beijing	beijing		guangzhou	guangzhouguangzhouguangzhou	guangsu	gnijieb	hou	guangzhou 	beijing	None	uang	ijing	beijing - a	BEIJING	a
-None	guangzhou - a	guangzhou-a	68616E677A686F75	hangz	1	hangzhou	0guangzhou	guangzhou		zhengzhou	hangzhouhangzhouhangzhou	hangsu	uohzgnaug	hou	hangzhou  	guangzhou	None	angz	angzhou	guangzhou - a	GUANGZHOU	a
-None	guangzhou - a	guangzhou-a	7368616E67686169	shang	0	shanghai	0guangzhou	guangzhou		szhenghai	shanghaishanghaishanghai	shanghai	uohzgnaug	hai	shanghai  	guangzhou	None	hang	angzhou	guangzhou - a	GUANGZHOU	a
 None	guangzhou - a	guangzhou-a	6265696A696E67	beiji	0	beijing	0guangzhou	guangzhou		beijing	beijingbeijingbeijing	beijing	uohzgnaug	ing	beijing   	guangzhou	None	eiji	angzhou	guangzhou - a	GUANGZHOU	a
-None	guangzhou - a	guangzhou-a	7368656E7A68656E	shenz	0	shenzhen	0guangzhou	guangzhou		shenzhen	shenzhenshenzhenshenzhen	shenzhen	uohzgnaug	hen	shenzhen  	guangzhou	None	henz	angzhou	guangzhou - a	GUANGZHOU	a
 None	guangzhou - a	guangzhou-a	6775616E677A686F75	guang	0	guangzhou	0guangzhou	guangzhou		guangzhou	guangzhouguangzhouguangzhou	guangsu	uohzgnaug	hou	guangzhou 	guangzhou	None	uang	angzhou	guangzhou - a	GUANGZHOU	a
+None	guangzhou - a	guangzhou-a	7368616E67686169	shang	0	shanghai	0guangzhou	guangzhou		szhenghai	shanghaishanghaishanghai	shanghai	uohzgnaug	hai	shanghai  	guangzhou	None	hang	angzhou	guangzhou - a	GUANGZHOU	a
+None	guangzhou - a	guangzhou-a	68616E677A686F75	hangz	1	hangzhou	0guangzhou	guangzhou		zhengzhou	hangzhouhangzhouhangzhou	hangsu	uohzgnaug	hou	hangzhou  	guangzhou	None	angz	angzhou	guangzhou - a	GUANGZHOU	a
+None	guangzhou - a	guangzhou-a	7368656E7A68656E	shenz	0	shenzhen	0guangzhou	guangzhou		shenzhen	shenzhenshenzhenshenzhen	shenzhen	uohzgnaug	hen	shenzhen  	guangzhou	None	henz	angzhou	guangzhou - a	GUANGZHOU	a
 -- !result
 select
     CONCAT(concatenated_values, '-', lower_c3),
@@ -710,11 +711,11 @@ group by
     lower_c3
 order by max(lower_c3) limit 5;
 -- result:
-shanghai - a-beijing	beijing	1	["iahgnahs"]
-beijing - a-beijing	beijing	1	["gnijieb"]
 shenzhen - a-beijing	beijing	1	["nehznehs"]
-hangzhou - a-beijing	beijing	1	["uohzgnah"]
+beijing - a-beijing	beijing	1	["gnijieb"]
 guangzhou - a-beijing	beijing	1	["uohzgnaug"]
+hangzhou - a-beijing	beijing	1	["uohzgnah"]
+shanghai - a-beijing	beijing	1	["iahgnahs"]
 -- !result
 SELECT
     CONCAT(lcd.c4, ' - ', 'a') AS concatenated_values,
@@ -785,11 +786,11 @@ select
 from
     low_card_duplicate lcd;
 -- result:
-hangzhou
-beijing
 shanghai
+beijing
 guangzhou
 shenzhen
+hangzhou
 -- !result
 SELECT
     c4,
@@ -999,11 +1000,11 @@ FROM
 GROUP BY
     grouped_results.upper_c1;
 -- result:
-SHANGHAI	990	c
 SHENZHEN	770	c
 BEIJING	1034	c
 GUANGZHOU	968	c
 HANGZHOU	1056	c
+SHANGHAI	990	c
 -- !result
 SELECT
     lcd.c0,
@@ -1257,8 +1258,8 @@ FROM
 ORDER BY c1, c2, rank limit 10;
 -- result:
 		1	0.00175303445490039722
-		6	0.00142515312812037520
 		6	0.00738631979156705382
+		6	0.00142515312812037520
 		7	0.00952553311745999506
 		11	2.0835238245287E-7
 		17	0.00573706498198447023
@@ -1290,16 +1291,16 @@ FROM
     low_card_duplicate
 ORDER BY c1, c2, rank limit 10;
 -- result:
-		1	9896154.00000000000000000000
 		1	0.00175303445490039722
-		6	8983395.00000000000000000000
+		1	9896154.00000000000000000000
+		6	0.00738631979156705382
 		6	7954463.00000000000000000000
 		6	0.00142515312812037520
-		6	0.00738631979156705382
+		6	8983395.00000000000000000000
 		7	7953378.00000000000000000000
 		7	0.00952553311745999506
-		11	7077253.00000000000000000000
 		11	2.0835238245287E-7
+		11	7077253.00000000000000000000
 -- !result
 select
     unnest

--- a/test/sql/test_low_cardinality/T/test_low_cardinality
+++ b/test/sql/test_low_cardinality/T/test_low_cardinality
@@ -1,4 +1,4 @@
--- name: test_split_or
+-- name: test_low_cardinality
 CREATE TABLE `common_duplicate` (
   `c0` int(11) NOT NULL COMMENT "",
   `c1` int(11) NOT NULL COMMENT "",
@@ -1149,5 +1149,8 @@ order by
 limit
     10;
 
+SELECT CASE WHEN c3 = 'hangzhouxx' THEN 'hang' ELSE SUBSTR(MD5(c3), 1, 8) END AS value FROM low_card_duplicate order by value limit 10;
 
+set low_cardinality_optimize_v2 = false;
 
+SELECT CASE WHEN c3 = 'hangzhouxx' THEN 'hang' ELSE SUBSTR(MD5(c3), 1, 8) END AS value FROM low_card_duplicate order by value limit 10;


### PR DESCRIPTION
## Why I'm doing:
fails in `Preconditions.checkState(usedColumns.cardinality() == 1);`
```
java.lang.IllegalStateException: null
        at com.google.common.base.Preconditions.checkState(Preconditions.java:496) ~[spark-dpp-1.0.0.jar:?]
        at com.starrocks.sql.optimizer.rule.tree.DictMappingRewriter.rewriteAsDictMapping(DictMappingRewriter.java:67) ~[starrocks-fe.jar:?]
        at com.starrocks.sql.optimizer.rule.tree.DictMappingRewriter.rewrite(DictMappingRewriter.java:46) ~[starrocks-fe.jar:?]
        at com.starrocks.sql.optimizer.rule.tree.AddDecodeNodeForDictStringRule$DecodeVisitor.rewriteOneScalarOperatorForProjection(AddDecodeNodeForDictStringRule.java:560) ~[starrocks-fe.jar:?]
        at
```

## What I'm doing:
For sql:
```
SELECT if( S_ADDRESS = 'a' , 'a' , SUBSTR(MD5(S_ADDRESS), 1, 8) END AS value FROM supplier;
```
When rewriting the nested function, `S_ADDRESS = 'a'` can apply dict with `hasApplied = true`,  `SUBSTR(MD5(S_ADDRESS), 1, 8)` has unsupported func and its rewrite result is `SUBSTR(MD5(dict_mapping(S_ADDRESS)), 1, 8)` with `hasApplied = false` and `disableApplied = false` . 
For the if function, the rewrite context is `hasApplied = true` and  `disableApplied = false` , it choose the wrong rewrite branch.
```
for (int i = 0; i < children.size(); i++) {
                    context.reset();
                    children.set(i, children.get(i).accept(this, context));
                    hasApplied = hasApplied || context.hasAppliedOperator;
                    disableApplied = disableApplied || context.hasUnsupportedOperator;
                }
                if (!disableApplied || !hasApplied) {
                    context.hasAppliedOperator = hasApplied;
                    return operator;
                } else {
                    context.hasAppliedOperator = false;
                    return visit(operator, context);
                }
```
We need to propagate the `hasUnsupportedOperator` to the outer to ensure the  scalarOperator with hasApplied child and has unsuppored child to do dict mapping process again.

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [x] 3.1
  - [x] 3.0
  - [x] 2.5
