### PR TITLE
[Enhancement] add timezone in log event timestamp

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/common/Log4jConfig.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/Log4jConfig.java
@@ -61,11 +61,11 @@ public class Log4jConfig extends XmlConfiguration {
             "<Configuration status=\"info\" packages=\"com.starrocks.common\">\n" +
             "  <Appenders>\n" +
             "    <Console name=\"ConsoleErr\" target=\"SYSTEM_ERR\" follow=\"true\">\n" +
-            "      <PatternLayout pattern=\"%d{yyyy-MM-dd HH:mm:ss,SSS Z} %p (%t|%tid) [%C{1}.%M():%L] %m%n\"/>\n" +
+            "      <PatternLayout pattern=\"%d{yyyy-MM-dd HH:mm:ss.SSSZ} %p (%t|%tid) [%C{1}.%M():%L] %m%n\"/>\n" +
             "    </Console>\n" +
             "    <RollingFile name=\"Sys\" fileName=\"${sys_log_dir}/fe.log\" filePattern=\"${sys_log_dir}/fe.log.${sys_file_pattern}-%i\">\n" +
             "      <PatternLayout charset=\"UTF-8\">\n" +
-            "        <Pattern>%d{yyyy-MM-dd HH:mm:ss,SSS Z} %p (%t|%tid) [%C{1}.%M():%L] %m%n</Pattern>\n" +
+            "        <Pattern>%d{yyyy-MM-dd HH:mm:ss.SSSZ} %p (%t|%tid) [%C{1}.%M():%L] %m%n</Pattern>\n" +
             "      </PatternLayout>\n" +
             "      <Policies>\n" +
             "        <TimeBasedTriggeringPolicy/>\n" +
@@ -80,7 +80,7 @@ public class Log4jConfig extends XmlConfiguration {
             "    </RollingFile>\n" +
             "    <RollingFile name=\"SysWF\" fileName=\"${sys_log_dir}/fe.warn.log\" filePattern=\"${sys_log_dir}/fe.warn.log.${sys_file_pattern}-%i\">\n" +
             "      <PatternLayout charset=\"UTF-8\">\n" +
-            "        <Pattern>%d{yyyy-MM-dd HH:mm:ss,SSS Z} %p (%t|%tid) [%C{1}.%M():%L] %m%n</Pattern>\n" +
+            "        <Pattern>%d{yyyy-MM-dd HH:mm:ss.SSSZ} %p (%t|%tid) [%C{1}.%M():%L] %m%n</Pattern>\n" +
             "      </PatternLayout>\n" +
             "      <Policies>\n" +
             "        <TimeBasedTriggeringPolicy/>\n" +
@@ -95,7 +95,7 @@ public class Log4jConfig extends XmlConfiguration {
             "    </RollingFile>\n" +
             "    <RollingFile name=\"Auditfile\" fileName=\"${audit_log_dir}/fe.audit.log\" filePattern=\"${audit_log_dir}/fe.audit.log.${audit_file_pattern}-%i\">\n" +
             "      <PatternLayout charset=\"UTF-8\">\n" +
-            "        <Pattern>%d{yyyy-MM-dd HH:mm:ss,SSS Z} [%c{1}] %m%n</Pattern>\n" +
+            "        <Pattern>%d{yyyy-MM-dd HH:mm:ss.SSSZ} [%c{1}] %m%n</Pattern>\n" +
             "      </PatternLayout>\n" +
             "      <Policies>\n" +
             "        <TimeBasedTriggeringPolicy/>\n" +
@@ -110,7 +110,7 @@ public class Log4jConfig extends XmlConfiguration {
             "    </RollingFile>\n" +
             "    <RollingFile name=\"dumpFile\" fileName=\"${dump_log_dir}/fe.dump.log\" filePattern=\"${dump_log_dir}/fe.dump.log.${dump_file_pattern}-%i\">\n" +
             "      <PatternLayout charset=\"UTF-8\">\n" +
-            "        <Pattern>%d{yyyy-MM-dd HH:mm:ss,SSS Z} [%c{1}] %m%n</Pattern>\n" +
+            "        <Pattern>%d{yyyy-MM-dd HH:mm:ss.SSSZ} [%c{1}] %m%n</Pattern>\n" +
             "      </PatternLayout>\n" +
             "      <Policies>\n" +
             "        <TimeBasedTriggeringPolicy/>\n" +
@@ -125,7 +125,7 @@ public class Log4jConfig extends XmlConfiguration {
             "    </RollingFile>\n" +
             "    <RollingFile name=\"BigQueryFile\" fileName=\"${big_query_log_dir}/fe.big_query.log\" filePattern=\"${big_query_log_dir}/fe.big_query.log.${big_query_file_pattern}-%i\">\n" +
             "      <PatternLayout charset=\"UTF-8\">\n" +
-            "        <Pattern>%d{yyyy-MM-dd HH:mm:ss,SSS Z} [%c{1}] %m%n</Pattern>\n" +
+            "        <Pattern>%d{yyyy-MM-dd HH:mm:ss.SSSZ} [%c{1}] %m%n</Pattern>\n" +
             "      </PatternLayout>\n" +
             "      <Policies>\n" +
             "        <TimeBasedTriggeringPolicy/>\n" +
@@ -140,7 +140,7 @@ public class Log4jConfig extends XmlConfiguration {
             "    </RollingFile>\n" +
             "    <RollingFile name=\"InternalFile\" fileName=\"${internal_log_dir}/fe.internal.log\" filePattern=\"${internal_log_dir}/fe.internal.log.${internal_file_pattern}-%i\">\n" +
             "      <PatternLayout charset=\"UTF-8\">\n" +
-            "        <Pattern>%d{yyyy-MM-dd HH:mm:ss,SSS Z} %p (%t|%tid) [%C{1}.%M():%L] %m%n</Pattern>\n" +
+            "        <Pattern>%d{yyyy-MM-dd HH:mm:ss.SSSZ} %p (%t|%tid) [%C{1}.%M():%L] %m%n</Pattern>\n" +
             "      </PatternLayout>\n" +
             "      <Policies>\n" +
             "        <TimeBasedTriggeringPolicy/>\n" +

--- a/fe/fe-core/src/main/java/com/starrocks/common/Log4jConfig.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/Log4jConfig.java
@@ -61,11 +61,11 @@ public class Log4jConfig extends XmlConfiguration {
             "<Configuration status=\"info\" packages=\"com.starrocks.common\">\n" +
             "  <Appenders>\n" +
             "    <Console name=\"ConsoleErr\" target=\"SYSTEM_ERR\" follow=\"true\">\n" +
-            "      <PatternLayout pattern=\"%d{yyyy-MM-dd HH:mm:ss,SSS} %p (%t|%tid) [%C{1}.%M():%L] %m%n\"/>\n" +
+            "      <PatternLayout pattern=\"%d{yyyy-MM-dd HH:mm:ss,SSS Z} %p (%t|%tid) [%C{1}.%M():%L] %m%n\"/>\n" +
             "    </Console>\n" +
             "    <RollingFile name=\"Sys\" fileName=\"${sys_log_dir}/fe.log\" filePattern=\"${sys_log_dir}/fe.log.${sys_file_pattern}-%i\">\n" +
             "      <PatternLayout charset=\"UTF-8\">\n" +
-            "        <Pattern>%d{yyyy-MM-dd HH:mm:ss,SSS} %p (%t|%tid) [%C{1}.%M():%L] %m%n</Pattern>\n" +
+            "        <Pattern>%d{yyyy-MM-dd HH:mm:ss,SSS Z} %p (%t|%tid) [%C{1}.%M():%L] %m%n</Pattern>\n" +
             "      </PatternLayout>\n" +
             "      <Policies>\n" +
             "        <TimeBasedTriggeringPolicy/>\n" +
@@ -80,7 +80,7 @@ public class Log4jConfig extends XmlConfiguration {
             "    </RollingFile>\n" +
             "    <RollingFile name=\"SysWF\" fileName=\"${sys_log_dir}/fe.warn.log\" filePattern=\"${sys_log_dir}/fe.warn.log.${sys_file_pattern}-%i\">\n" +
             "      <PatternLayout charset=\"UTF-8\">\n" +
-            "        <Pattern>%d{yyyy-MM-dd HH:mm:ss,SSS} %p (%t|%tid) [%C{1}.%M():%L] %m%n</Pattern>\n" +
+            "        <Pattern>%d{yyyy-MM-dd HH:mm:ss,SSS Z} %p (%t|%tid) [%C{1}.%M():%L] %m%n</Pattern>\n" +
             "      </PatternLayout>\n" +
             "      <Policies>\n" +
             "        <TimeBasedTriggeringPolicy/>\n" +
@@ -95,7 +95,7 @@ public class Log4jConfig extends XmlConfiguration {
             "    </RollingFile>\n" +
             "    <RollingFile name=\"Auditfile\" fileName=\"${audit_log_dir}/fe.audit.log\" filePattern=\"${audit_log_dir}/fe.audit.log.${audit_file_pattern}-%i\">\n" +
             "      <PatternLayout charset=\"UTF-8\">\n" +
-            "        <Pattern>%d{yyyy-MM-dd HH:mm:ss,SSS} [%c{1}] %m%n</Pattern>\n" +
+            "        <Pattern>%d{yyyy-MM-dd HH:mm:ss,SSS Z} [%c{1}] %m%n</Pattern>\n" +
             "      </PatternLayout>\n" +
             "      <Policies>\n" +
             "        <TimeBasedTriggeringPolicy/>\n" +
@@ -110,7 +110,7 @@ public class Log4jConfig extends XmlConfiguration {
             "    </RollingFile>\n" +
             "    <RollingFile name=\"dumpFile\" fileName=\"${dump_log_dir}/fe.dump.log\" filePattern=\"${dump_log_dir}/fe.dump.log.${dump_file_pattern}-%i\">\n" +
             "      <PatternLayout charset=\"UTF-8\">\n" +
-            "        <Pattern>%d{yyyy-MM-dd HH:mm:ss,SSS} [%c{1}] %m%n</Pattern>\n" +
+            "        <Pattern>%d{yyyy-MM-dd HH:mm:ss,SSS Z} [%c{1}] %m%n</Pattern>\n" +
             "      </PatternLayout>\n" +
             "      <Policies>\n" +
             "        <TimeBasedTriggeringPolicy/>\n" +
@@ -125,7 +125,7 @@ public class Log4jConfig extends XmlConfiguration {
             "    </RollingFile>\n" +
             "    <RollingFile name=\"BigQueryFile\" fileName=\"${big_query_log_dir}/fe.big_query.log\" filePattern=\"${big_query_log_dir}/fe.big_query.log.${big_query_file_pattern}-%i\">\n" +
             "      <PatternLayout charset=\"UTF-8\">\n" +
-            "        <Pattern>%d{yyyy-MM-dd HH:mm:ss,SSS} [%c{1}] %m%n</Pattern>\n" +
+            "        <Pattern>%d{yyyy-MM-dd HH:mm:ss,SSS Z} [%c{1}] %m%n</Pattern>\n" +
             "      </PatternLayout>\n" +
             "      <Policies>\n" +
             "        <TimeBasedTriggeringPolicy/>\n" +
@@ -140,7 +140,7 @@ public class Log4jConfig extends XmlConfiguration {
             "    </RollingFile>\n" +
             "    <RollingFile name=\"InternalFile\" fileName=\"${internal_log_dir}/fe.internal.log\" filePattern=\"${internal_log_dir}/fe.internal.log.${internal_file_pattern}-%i\">\n" +
             "      <PatternLayout charset=\"UTF-8\">\n" +
-            "        <Pattern>%d{yyyy-MM-dd HH:mm:ss,SSS} %p (%t|%tid) [%C{1}.%M():%L] %m%n</Pattern>\n" +
+            "        <Pattern>%d{yyyy-MM-dd HH:mm:ss,SSS Z} %p (%t|%tid) [%C{1}.%M():%L] %m%n</Pattern>\n" +
             "      </PatternLayout>\n" +
             "      <Policies>\n" +
             "        <TimeBasedTriggeringPolicy/>\n" +


### PR DESCRIPTION
^ 

## Before 

The log event timestamp in FE doesn't have timezone, as a result it fails to show the expected timestamp in Datadog, see example:
```
2024-03-06 13:01:49,056 INFO (nioEventLoopGroup-7-14|205) [RestBaseAction.handleRequest():70] receive http request. url=/api/health
2024-03-06 13:01:49,056 INFO (nioEventLoopGroup-7-15|206) [RestBaseAction.handleRequest():70] receive http request. url=/api/health
``` 

## After 

```
2024-03-06 19:50:46.049-0800 INFO (nioEventLoopGroup-7-24|181) [RestBaseAction.handleRequest():70] receive http request. url=/api/health
2024-03-06 19:50:46.049-0800 INFO (nioEventLoopGroup-7-23|180) [RestBaseAction.handleRequest():70] receive http request. url=/api/health
```

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [x] 3.1
  - [x] 3.1-cs
  - [ ] 3.0
  - [ ] 2.5
