### PR TITLE
[Feature] optimize count and agg pattern sql.

### DIFF
--- a/be/src/exec/aggregator.h
+++ b/be/src/exec/aggregator.h
@@ -471,6 +471,9 @@ protected:
     // Exprs used to evaluate group by column
     std::vector<ExprContext*> _group_by_expr_ctxs;
     Columns _group_by_columns;
+    Columns _const_group_by_columns;
+    bool _all_const_group_by_columns = true;
+
     std::vector<ColumnType> _group_by_types;
 
     // Tuple into which Update()/Merge()/Serialize() results are stored.

--- a/be/src/exec/connector_scan_node.cpp
+++ b/be/src/exec/connector_scan_node.cpp
@@ -689,13 +689,16 @@ StatusOr<pipeline::MorselQueuePtr> ConnectorScanNode::convert_scan_range_to_mors
         size_t num_total_scan_ranges) {
     _data_source_provider->peek_scan_ranges(scan_ranges);
 
+    int rep = 10;
     pipeline::Morsels morsels;
     // If this scan node does not accept non-empty scan ranges, create a placeholder one.
     if (!accept_empty_scan_ranges() && scan_ranges.empty()) {
         morsels.emplace_back(std::make_unique<pipeline::ScanMorsel>(node_id, TScanRangeParams()));
     } else {
-        for (const auto& scan_range : scan_ranges) {
-            morsels.emplace_back(std::make_unique<pipeline::ScanMorsel>(node_id, scan_range));
+        for (int i = 0; i < rep; i++) {
+            for (const auto& scan_range : scan_ranges) {
+                morsels.emplace_back(std::make_unique<pipeline::ScanMorsel>(node_id, scan_range));
+            }
         }
     }
     return std::make_unique<pipeline::DynamicMorselQueue>(std::move(morsels));

--- a/be/src/exec/hdfs_scanner.cpp
+++ b/be/src/exec/hdfs_scanner.cpp
@@ -377,27 +377,19 @@ void HdfsScannerContext::update_materialized_columns(const std::unordered_set<st
     materialized_columns.swap(updated_columns);
 }
 
-void HdfsScannerContext::update_not_existed_columns_of_chunk(ChunkPtr* chunk, size_t row_count) {
-    if (not_existed_slots.empty() || row_count <= 0) return;
-
+void HdfsScannerContext::append_or_update_not_existed_columns_to_chunk(ChunkPtr* chunk, size_t row_count) {
+    if (not_existed_slots.empty() || row_count < 0) return;
     ChunkPtr& ck = (*chunk);
     for (auto* slot_desc : not_existed_slots) {
-        ck->get_column_by_slot_id(slot_desc->id())->append_default(row_count);
-    }
-}
-
-void HdfsScannerContext::append_not_existed_columns_to_chunk(ChunkPtr* chunk, size_t row_count) {
-    if (not_existed_slots.size() == 0) return;
-
-    ChunkPtr& ck = (*chunk);
-    ck->set_num_rows(row_count);
-    for (auto* slot_desc : not_existed_slots) {
-        auto col = ColumnHelper::create_column(slot_desc->type(), slot_desc->is_nullable());
-        if (row_count > 0) {
-            col->append_default(row_count);
+        // create const column here.
+        auto col = ColumnHelper::create_column(slot_desc->type(), slot_desc->is_nullable(), true, row_count);
+        if (ck->is_slot_exist(slot_desc->id())) {
+            ck->update_column(std::move(col), slot_desc->id());
+        } else {
+            ck->append_column(std::move(col), slot_desc->id());
         }
-        ck->append_column(std::move(col), slot_desc->id());
     }
+    ck->set_num_rows(row_count);
 }
 
 Status HdfsScannerContext::evaluate_on_conjunct_ctxs_by_slot(ChunkPtr* chunk, Filter* filter) {
@@ -423,7 +415,7 @@ StatusOr<bool> HdfsScannerContext::should_skip_by_evaluating_not_existed_slots()
 
     // build chunk for evaluation.
     ChunkPtr chunk = std::make_shared<Chunk>();
-    append_not_existed_columns_to_chunk(&chunk, 1);
+    append_or_update_not_existed_columns_to_chunk(&chunk, 1);
     // do evaluation.
     {
         SCOPED_RAW_TIMER(&stats->expr_filter_ns);
@@ -433,33 +425,21 @@ StatusOr<bool> HdfsScannerContext::should_skip_by_evaluating_not_existed_slots()
 }
 
 void HdfsScannerContext::append_or_update_partition_column_to_chunk(ChunkPtr* chunk, size_t row_count) {
-    if (partition_columns.size() == 0 || row_count <= 0) return;
-
+    if (partition_columns.size() == 0 || row_count < 0) return;
     ChunkPtr& ck = (*chunk);
-    ck->set_num_rows(row_count);
-
     for (size_t i = 0; i < partition_columns.size(); i++) {
         SlotDescriptor* slot_desc = partition_columns[i].slot_desc;
         DCHECK(partition_values[i]->is_constant());
-        auto* const_column = ColumnHelper::as_raw_column<ConstColumn>(partition_values[i]);
-        ColumnPtr data_column = const_column->data_column();
-        auto chunk_part_column = ColumnHelper::create_column(slot_desc->type(), slot_desc->is_nullable());
-
-        if (row_count > 0) {
-            if (data_column->is_nullable()) {
-                chunk_part_column->append_nulls(1);
-            } else {
-                chunk_part_column->append(*data_column, 0, 1);
-            }
-            chunk_part_column->assign(row_count, 0);
-        }
-
+        // create constant column here.
+        ColumnPtr chunk_part_column = partition_values[i]->clone_shared();
+        chunk_part_column->resize(row_count);
         if (ck->is_slot_exist(slot_desc->id())) {
             ck->update_column(std::move(chunk_part_column), slot_desc->id());
         } else {
             ck->append_column(std::move(chunk_part_column), slot_desc->id());
         }
     }
+    ck->set_num_rows(row_count);
 }
 
 bool HdfsScannerContext::can_use_dict_filter_on_slot(SlotDescriptor* slot) const {

--- a/be/src/exec/hdfs_scanner.h
+++ b/be/src/exec/hdfs_scanner.h
@@ -272,12 +272,18 @@ struct HdfsScannerContext {
     // and to update not_existed slots and conjuncts.
     // and to update `conjunct_ctxs_by_slot` field.
     void update_materialized_columns(const std::unordered_set<std::string>& names);
+
     // "not existed columns" are materialized columns not found in file
     // this usually happens when use changes schema. for example
     // user create table with 3 fields A, B, C, and there is one file F1
     // but user change schema and add one field like D.
     // when user select(A, B, C, D), then D is the non-existed column in file F1.
-    void update_not_existed_columns_of_chunk(ChunkPtr* chunk, size_t row_count);
+    void append_or_update_not_existed_columns_to_chunk(ChunkPtr* chunk, size_t row_count);
+
+    // If there is no partition column in the chunk，append partition column to chunk，
+    // otherwise update partition column in chunk
+    void append_or_update_partition_column_to_chunk(ChunkPtr* chunk, size_t row_count);
+
     // if we can skip this file by evaluating conjuncts of non-existed columns with default value.
     StatusOr<bool> should_skip_by_evaluating_not_existed_slots();
     std::vector<SlotDescriptor*> not_existed_slots;
@@ -285,11 +291,6 @@ struct HdfsScannerContext {
 
     // other helper functions.
     bool can_use_dict_filter_on_slot(SlotDescriptor* slot) const;
-
-    void append_not_existed_columns_to_chunk(ChunkPtr* chunk, size_t row_count);
-
-    // If there is no partition column in the chunk，append partition column to chunk，otherwise update partition column in chunk
-    void append_or_update_partition_column_to_chunk(ChunkPtr* chunk, size_t row_count);
     Status evaluate_on_conjunct_ctxs_by_slot(ChunkPtr* chunk, Filter* filter);
 };
 

--- a/be/src/exec/hdfs_scanner_orc.cpp
+++ b/be/src/exec/hdfs_scanner_orc.cpp
@@ -585,7 +585,7 @@ StatusOr<size_t> HdfsOrcScanner::_do_get_next(ChunkPtr* chunk) {
             }
 
             // we need to append none existed column before do eval, just for count(*) optimization
-            _scanner_ctx.append_not_existed_columns_to_chunk(chunk, rows_read);
+            _scanner_ctx.append_or_update_not_existed_columns_to_chunk(chunk, rows_read);
 
             // do stats before we filter rows which does not match.
             _app_stats.raw_rows_read += rows_read;

--- a/be/src/exec/jni_scanner.cpp
+++ b/be/src/exec/jni_scanner.cpp
@@ -383,7 +383,7 @@ Status JniScanner::do_get_next(RuntimeState* runtime_state, ChunkPtr* chunk) {
     // important to add columns before evaluation
     // because ctxs_by_slot maybe refers to some non-existed slot or partition slot.
     size_t chunk_size = (*chunk)->num_rows();
-    _scanner_ctx.append_not_existed_columns_to_chunk(chunk, chunk_size);
+    _scanner_ctx.append_or_update_not_existed_columns_to_chunk(chunk, chunk_size);
 
     RETURN_IF_ERROR(_scanner_ctx.evaluate_on_conjunct_ctxs_by_slot(chunk, &_chunk_filter));
     return status;
@@ -413,7 +413,7 @@ Status HiveJniScanner::do_get_next(RuntimeState* runtime_state, ChunkPtr* chunk)
         chunk_size = first_non_partition_column->size();
     }
 
-    _scanner_ctx.append_not_existed_columns_to_chunk(chunk, chunk_size);
+    _scanner_ctx.append_or_update_not_existed_columns_to_chunk(chunk, chunk_size);
     // right now only hive table need append partition columns explictly, paimon and hudi reader will append partition columns in Java side
     _scanner_ctx.append_or_update_partition_column_to_chunk(chunk, chunk_size);
     RETURN_IF_ERROR(_scanner_ctx.evaluate_on_conjunct_ctxs_by_slot(chunk, &_chunk_filter));

--- a/be/src/exprs/agg/aggregate.h
+++ b/be/src/exprs/agg/aggregate.h
@@ -42,6 +42,10 @@ enum AggStateTableKind { RESULT = 0, INTERMEDIATE = 1, DETAIL_RESULT = 2, DETAIL
 using AggDataPtr = uint8_t*;
 using ConstAggDataPtr = const uint8_t*;
 
+// if we use constexpr not const here,
+// we will get compilation error like `error: ‘reinterpret_cast’ from integer to pointer`
+static const AggDataPtr CONST_COLUMN_AGG_DATA_PTR = reinterpret_cast<AggDataPtr>(0x1);
+
 // Aggregate function interface
 // Aggregate function instances don't contain aggregation state, the aggregation state is stored in
 // other objects

--- a/be/src/exprs/agg/count.h
+++ b/be/src/exprs/agg/count.h
@@ -48,6 +48,19 @@ public:
         ++this->data(state).count;
     }
 
+    void update_batch(FunctionContext* ctx, size_t chunk_size, size_t state_offset, const Column** columns,
+                      AggDataPtr* states) const override {
+        bool const_states = (states[chunk_size] == CONST_COLUMN_AGG_DATA_PTR);
+        if (const_states) {
+            this->data(states[0] + state_offset).count += chunk_size;
+            return;
+        }
+
+        for (size_t i = 0; i < chunk_size; ++i) {
+            ++this->data(states[i] + state_offset).count;
+        }
+    }
+
     AggStateTableKind agg_state_table_kind(bool is_append_only) const override { return AggStateTableKind::RESULT; }
 
     void retract(FunctionContext* ctx, const Column** columns, AggDataPtr __restrict state,

--- a/be/src/formats/parquet/file_reader.cpp
+++ b/be/src/formats/parquet/file_reader.cpp
@@ -640,6 +640,12 @@ Status FileReader::get_next(ChunkPtr* chunk) {
 }
 
 Status FileReader::_exec_no_materialized_column_scan(ChunkPtr* chunk) {
+    if (_scan_row_count == _total_row_count) {
+        rep -= 1;
+        if (rep > 0) {
+            _scan_row_count = 0;
+        }
+    }
     if (_scan_row_count < _total_row_count) {
         size_t read_size = std::min(static_cast<size_t>(_chunk_size), _total_row_count - _scan_row_count);
         _scanner_ctx->update_not_existed_columns_of_chunk(chunk, read_size);

--- a/be/src/formats/parquet/file_reader.cpp
+++ b/be/src/formats/parquet/file_reader.cpp
@@ -613,7 +613,7 @@ Status FileReader::get_next(ChunkPtr* chunk) {
         Status status = _row_group_readers[_cur_row_group_idx]->get_next(chunk, &row_count);
         if (status.ok() || status.is_end_of_file()) {
             if (row_count > 0) {
-                _scanner_ctx->update_not_existed_columns_of_chunk(chunk, row_count);
+                _scanner_ctx->append_or_update_not_existed_columns_to_chunk(chunk, row_count);
                 _scanner_ctx->append_or_update_partition_column_to_chunk(chunk, row_count);
                 _scan_row_count += (*chunk)->num_rows();
             }
@@ -648,7 +648,7 @@ Status FileReader::_exec_no_materialized_column_scan(ChunkPtr* chunk) {
     }
     if (_scan_row_count < _total_row_count) {
         size_t read_size = std::min(static_cast<size_t>(_chunk_size), _total_row_count - _scan_row_count);
-        _scanner_ctx->update_not_existed_columns_of_chunk(chunk, read_size);
+        _scanner_ctx->append_or_update_not_existed_columns_to_chunk(chunk, read_size);
         _scanner_ctx->append_or_update_partition_column_to_chunk(chunk, read_size);
         _scan_row_count += read_size;
         return Status::OK();

--- a/be/src/formats/parquet/file_reader.h
+++ b/be/src/formats/parquet/file_reader.h
@@ -136,6 +136,8 @@ private:
     GroupReaderParam _group_reader_param;
     std::shared_ptr<MetaHelper> _meta_helper = nullptr;
     const std::set<int64_t>* _need_skip_rowids;
+
+    int rep = 10;
 };
 
 } // namespace starrocks::parquet


### PR DESCRIPTION
## Why I'm doing:

To optimize cout(1) and agg pattern sql, such as `select count(1), dt from t group by dt`

see also https://github.com/StarRocks/starrocks/pull/41124/files 

## What I'm doing:

Few changes:
1. output const column from scan node
2. keep const column as much as possible in project node
3. in agg hash map stage, if group by columns are all const,  we only need to evaluate agg expr once
4. in agg count stage, if agg states are all the same, we can do optimization.

Fixes #issue

-----

Old performance

```
| 30133400 |         2452635 |
| 30019900 |         2452636 |
| 29884900 |         2452637 |
| 29857900 |         2452638 |
| 30013500 |         2452639 |
| 30053000 |         2452640 |
| 29719100 |         2452641 |
| 30148700 |         2452642 |
+----------+-----------------+
1823 rows in set (55.327 sec)
```

New Performance

```
| 30133400 |         2452635 |
| 30019900 |         2452636 |
| 29884900 |         2452637 |
| 29857900 |         2452638 |
| 30013500 |         2452639 |
| 30053000 |         2452640 |
| 29719100 |         2452641 |
| 30148700 |         2452642 |
+----------+-----------------+
1823 rows in set (40.082 sec)
```

the performance improves about (55/40 - 1) ~= 37.5%

## What type of PR is this:

- [ ] BugFix
- [x] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
