### PR TITLE
[BugFix] add predicate used columns in check

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/validate/InputDependenciesChecker.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/validate/InputDependenciesChecker.java
@@ -125,7 +125,9 @@ public class InputDependenciesChecker implements PlanValidator.Checker {
             ColumnRefSet usedCols = optExpression.getRowOutputInfo().getUsedColumnRefSet();
             if (optExpression.getOp().getPredicate() != null) {
                 ColumnRefSet predicateCols = optExpression.getOp().getPredicate().getUsedColumns();
-                predicateCols.except(optExpression.getRowOutputInfo().getOutputColumnRefSet());
+                //
+                predicateCols.except(ColumnRefSet.createByIds(optExpression.getRowOutputInfo()
+                        .getOriginalColOutputInfo().keySet()));
                 usedCols.union(predicateCols);
             }
             checkInputCols(inputCols, usedCols, optExpression);

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/validate/InputDependenciesChecker.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/validate/InputDependenciesChecker.java
@@ -124,7 +124,9 @@ public class InputDependenciesChecker implements PlanValidator.Checker {
             ColumnRefSet inputCols = optExpression.inputAt(0).getRowOutputInfo().getOutputColumnRefSet();
             ColumnRefSet usedCols = optExpression.getRowOutputInfo().getUsedColumnRefSet();
             if (optExpression.getOp().getPredicate() != null) {
-                usedCols.union(optExpression.getOp().getPredicate().getUsedColumns());
+                ColumnRefSet predicateCols = optExpression.getOp().getPredicate().getUsedColumns();
+                predicateCols.except(optExpression.getRowOutputInfo().getOutputColumnRefSet());
+                usedCols.union(predicateCols);
             }
             checkInputCols(inputCols, usedCols, optExpression);
         }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/validate/InputDependenciesChecker.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/validate/InputDependenciesChecker.java
@@ -125,7 +125,8 @@ public class InputDependenciesChecker implements PlanValidator.Checker {
             ColumnRefSet usedCols = optExpression.getRowOutputInfo().getUsedColumnRefSet();
             if (optExpression.getOp().getPredicate() != null) {
                 ColumnRefSet predicateCols = optExpression.getOp().getPredicate().getUsedColumns();
-                //
+                // The predicate cols should be from the input cols or the output cols of this operator
+                // So we need except the used columns from the output of this operator
                 predicateCols.except(ColumnRefSet.createByIds(optExpression.getRowOutputInfo()
                         .getOriginalColOutputInfo().keySet()));
                 usedCols.union(predicateCols);

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/validate/InputDependenciesChecker.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/validate/InputDependenciesChecker.java
@@ -123,6 +123,9 @@ public class InputDependenciesChecker implements PlanValidator.Checker {
             }
             ColumnRefSet inputCols = optExpression.inputAt(0).getRowOutputInfo().getOutputColumnRefSet();
             ColumnRefSet usedCols = optExpression.getRowOutputInfo().getUsedColumnRefSet();
+            if (optExpression.getOp().getPredicate() != null) {
+                usedCols.union(optExpression.getOp().getPredicate().getUsedColumns());
+            }
             checkInputCols(inputCols, usedCols, optExpression);
         }
 


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:
Predicate used cols from child output, so the required columns need contains these columns.

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [x] 3.1
  - [x] 3.0
  - [ ] 2.5
