### PR TITLE
[Enhancement] Enhance mv rewrite by rule(Part 2)

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/Optimizer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/Optimizer.java
@@ -472,8 +472,8 @@ public class Optimizer {
         CTEUtils.collectCteOperators(tree, context);
 
         // see JoinPredicatePushdown
-        JoinPredicatePushdown.JoinPushDownParams joinPushDownParams = context.getJoinPushDownParams();
-        joinPushDownParams.prepare(context, sessionVariable, mvRewriteStrategy);
+        JoinPredicatePushdown.JoinPredicatePushDownContext joinPredicatePushDownContext = context.getJoinPushDownParams();
+        joinPredicatePushDownContext.prepare(context, sessionVariable, mvRewriteStrategy);
 
         // inline CTE if consume use once
         while (cteContext.hasInlineCTE()) {
@@ -530,7 +530,7 @@ public class Optimizer {
 
         // rule-based materialized view rewrite: early stage
         doMVRewriteWithMultiStages(tree, rootTaskContext);
-        joinPushDownParams.reset();
+        joinPredicatePushDownContext.reset();
 
         // Limit push must be after the column prune,
         // otherwise the Node containing limit may be prune

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/OptimizerContext.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/OptimizerContext.java
@@ -61,12 +61,13 @@ public class OptimizerContext {
 
     private long updateTableId = -1;
 
-    private JoinPredicatePushdown.JoinPushDownParams joinPushDownParams = new JoinPredicatePushdown.JoinPushDownParams();
-
     private boolean isObtainedFromInternalStatistics = false;
     private final Stopwatch optimizerTimer = Stopwatch.createStarted();
     private final Map<RuleType, Stopwatch> ruleWatchMap = Maps.newHashMap();
 
+    // The context for join predicate pushdown rule
+    private JoinPredicatePushdown.JoinPredicatePushDownContext joinPredicatePushDownContext =
+            new JoinPredicatePushdown.JoinPredicatePushDownContext();
     // QueryMaterializationContext is different from MaterializationContext that it keeps the context during the query
     // lifecycle instead of per materialized view.
     private QueryMaterializationContext queryMaterializationContext = new QueryMaterializationContext();
@@ -186,8 +187,8 @@ public class OptimizerContext {
         return queryMaterializationContext.getValidCandidateMVs();
     }
 
-    public JoinPredicatePushdown.JoinPushDownParams getJoinPushDownParams() {
-        return joinPushDownParams;
+    public JoinPredicatePushdown.JoinPredicatePushDownContext getJoinPushDownParams() {
+        return joinPredicatePushDownContext;
     }
 
     public void setUpdateTableId(long updateTableId) {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/OptimizerContext.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/OptimizerContext.java
@@ -29,6 +29,7 @@ import com.starrocks.sql.optimizer.base.ColumnRefFactory;
 import com.starrocks.sql.optimizer.dump.DumpInfo;
 import com.starrocks.sql.optimizer.operator.logical.LogicalOlapScanOperator;
 import com.starrocks.sql.optimizer.operator.scalar.IsNullPredicateOperator;
+import com.starrocks.sql.optimizer.rewrite.JoinPredicatePushdown;
 import com.starrocks.sql.optimizer.rule.RuleSet;
 import com.starrocks.sql.optimizer.rule.RuleType;
 import com.starrocks.sql.optimizer.task.SeriallyTaskScheduler;
@@ -59,7 +60,9 @@ public class OptimizerContext {
     private Set<OlapTable>  queryTables;
 
     private long updateTableId = -1;
-    private boolean enableLeftRightJoinEquivalenceDerive = true;
+
+    private JoinPredicatePushdown.JoinPushDownParams joinPushDownParams = new JoinPredicatePushdown.JoinPushDownParams();
+
     private boolean isObtainedFromInternalStatistics = false;
     private final Stopwatch optimizerTimer = Stopwatch.createStarted();
     private final Map<RuleType, Stopwatch> ruleWatchMap = Maps.newHashMap();
@@ -183,12 +186,8 @@ public class OptimizerContext {
         return queryMaterializationContext.getValidCandidateMVs();
     }
 
-    public void setEnableLeftRightJoinEquivalenceDerive(boolean enableLeftRightJoinEquivalenceDerive) {
-        this.enableLeftRightJoinEquivalenceDerive = enableLeftRightJoinEquivalenceDerive;
-    }
-
-    public boolean isEnableLeftRightJoinEquivalenceDerive() {
-        return enableLeftRightJoinEquivalenceDerive;
+    public JoinPredicatePushdown.JoinPushDownParams getJoinPushDownParams() {
+        return joinPushDownParams;
     }
 
     public void setUpdateTableId(long updateTableId) {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/QueryMaterializationContext.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/QueryMaterializationContext.java
@@ -94,6 +94,8 @@ public class QueryMaterializationContext {
         }
     }
 
+    private boolean hasRewrittenSuccess = false;
+
     public QueryMaterializationContext() {
     }
 
@@ -231,5 +233,13 @@ public class QueryMaterializationContext {
         Tracers.record(Tracers.Module.BASE, "MVQueryContextCacheStats", mvQueryContextCache.stats().toString());
         Tracers.record(Tracers.Module.BASE, "MVQueryCacheStats", queryCacheStats.toString());
         this.mvQueryContextCache.invalidateAll();
+    }
+
+    public void markRewriteSuccess(boolean val) {
+        this.hasRewrittenSuccess = val;
+    }
+
+    public boolean hasRewrittenSuccess() {
+        return this.hasRewrittenSuccess;
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/JoinPredicatePushdown.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/JoinPredicatePushdown.java
@@ -122,10 +122,6 @@ public class JoinPredicatePushdown {
     }
 
     public OptExpression pushdown(ScalarOperator predicateToPush) {
-        JoinPushDownParams params = optimizerContext.getJoinPushDownParams();
-        if (!params.enableJoinPredicatePushDown) {
-            return joinOptExpression;
-        }
         Preconditions.checkState(joinOptExpression.getOp() instanceof LogicalJoinOperator);
         ScalarOperator derivedPredicate = predicateDerive(predicateToPush);
         return pushDownPredicate(derivedPredicate);

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/JoinPredicatePushdown.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/JoinPredicatePushdown.java
@@ -86,9 +86,7 @@ public class JoinPredicatePushdown {
                 return;
             }
             JoinPushDownParams joinPushDownParams = context.getJoinPushDownParams();
-            // disable equivalence derive for outer join
             joinPushDownParams.enableLeftRightJoinEquivalenceDerive = false;
-            // disable outer join to inner join
             if (mvRewriteStrategy.mvStrategy.isMultiStages()) {
                 joinPushDownParams.enableJoinPredicatePushDown = false;
             }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/JoinPredicatePushdown.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/JoinPredicatePushdown.java
@@ -20,6 +20,7 @@ import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
 import com.starrocks.analysis.JoinOperator;
 import com.starrocks.qe.ConnectContext;
+import com.starrocks.qe.SessionVariable;
 import com.starrocks.sql.optimizer.JoinHelper;
 import com.starrocks.sql.optimizer.OptExpression;
 import com.starrocks.sql.optimizer.OptimizerContext;
@@ -36,6 +37,7 @@ import com.starrocks.sql.optimizer.operator.scalar.BinaryPredicateOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ColumnRefOperator;
 import com.starrocks.sql.optimizer.operator.scalar.IsNullPredicateOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ScalarOperator;
+import com.starrocks.sql.optimizer.rule.transformation.materialization.MvRewriteStrategy;
 import com.starrocks.sql.optimizer.rule.transformation.materialization.MvUtils;
 import org.apache.commons.collections4.CollectionUtils;
 
@@ -59,19 +61,61 @@ public class JoinPredicatePushdown {
 
     private List<ScalarOperator> leftPushDown;
     private List<ScalarOperator> rightPushDown;
-    private boolean enableLeftRightOuterJoinEquivalenceDerive = true;
+
+    /**
+     * Whether to do complete equivalence derive in
+     * {@link com.starrocks.sql.optimizer.rewrite.JoinPredicatePushdown}, eg: outer join to inner join,
+     * or derive equivalence derive for outer joins.
+     * NOTE: It's useful for normal queries but it will disturb some rewrite rule(eg: mv rewrite, table prune), so add
+     * a config to control it.
+     */
+    public static class JoinPushDownParams {
+        public boolean enableLeftRightJoinEquivalenceDerive = true;
+        public boolean enableLeftRightJoinToInnerJoin = true;
+
+        /**
+         * Prepare the join push down parameters.
+         * @param context: change the join push down parameters based on the context
+         * @param sessionVariable: the input session variable
+         * @param mvRewriteStrategy: the input mv rewrite strategy
+         */
+        public void prepare(OptimizerContext context,
+                            SessionVariable sessionVariable,
+                            MvRewriteStrategy mvRewriteStrategy) {
+            if (!sessionVariable.isEnableRboTablePrune() && !mvRewriteStrategy.mvStrategy.isMultiStages()) {
+                return;
+            }
+            JoinPushDownParams joinPushDownParams = context.getJoinPushDownParams();
+            // disable equivalence derive for outer join
+            joinPushDownParams.enableLeftRightJoinEquivalenceDerive = false;
+            // disable outer join to inner join
+            if (mvRewriteStrategy.mvStrategy.isMultiStages()) {
+                joinPushDownParams.enableLeftRightJoinToInnerJoin = false;
+            }
+        }
+
+        /**
+         * Reset the join push down parameters.
+         */
+        public void reset() {
+            this.enableLeftRightJoinEquivalenceDerive = true;
+            this.enableLeftRightJoinToInnerJoin = true;
+        }
+    }
+
+    // Join push down parameters to control the push down strategies.
+    private final JoinPushDownParams joinPushDownParams;
 
     private final OptimizerContext optimizerContext;
 
     public JoinPredicatePushdown(
             OptExpression joinOptExpression, boolean isOnPredicate, boolean directToChild,
-            ColumnRefFactory columnRefFactory, boolean enableLeftRightOuterJoinEquivalenceDerive,
-            OptimizerContext optimizerContext) {
+            ColumnRefFactory columnRefFactory, OptimizerContext optimizerContext) {
         this.joinOptExpression = joinOptExpression;
         this.isOnPredicate = isOnPredicate;
         this.directToChild = directToChild;
         this.columnRefFactory = columnRefFactory;
-        this.enableLeftRightOuterJoinEquivalenceDerive = enableLeftRightOuterJoinEquivalenceDerive;
+        this.joinPushDownParams = optimizerContext.getJoinPushDownParams();
         this.leftPushDown = Lists.newArrayList();
         this.rightPushDown = Lists.newArrayList();
         this.optimizerContext = optimizerContext;
@@ -378,7 +422,7 @@ public class JoinPredicatePushdown {
             newOnPredicate = equivalenceDeriveOnPredicate(newOnPredicate, joinOptExpression, join);
             return newOnPredicate;
         } else {
-            if (join.getJoinType().isOuterJoin()) {
+            if (joinPushDownParams.enableLeftRightJoinToInnerJoin && join.getJoinType().isOuterJoin()) {
                 joinOptExpression = convertOuterToInner(joinOptExpression, predicateToPush);
                 join = (LogicalJoinOperator) joinOptExpression.getOp();
             }
@@ -389,8 +433,8 @@ public class JoinPredicatePushdown {
             } else {
                 ScalarOperator predicate = rangePredicateDerive(predicateToPush);
                 JoinOperator joinType = join.getJoinType();
-                if (!joinType.isLeftOuterJoin() && !joinType.isRightOuterJoin() ||
-                        enableLeftRightOuterJoinEquivalenceDerive) {
+                if (joinPushDownParams.enableLeftRightJoinEquivalenceDerive ||
+                        (!joinType.isLeftOuterJoin() && !joinType.isRightOuterJoin())) {
                     getPushdownPredicatesFromEquivalenceDerive(
                             Utils.compoundAnd(join.getOnPredicate(), predicate), joinOptExpression, join);
                 }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/JoinPredicatePushdown.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/JoinPredicatePushdown.java
@@ -69,7 +69,7 @@ public class JoinPredicatePushdown {
      * NOTE: It's useful for normal queries but it will disturb some rewrite rule(eg: mv rewrite, table prune), so add
      * a config to control it.
      */
-    public static class JoinPushDownParams {
+    public static class JoinPredicatePushDownContext {
         public boolean enableLeftRightJoinEquivalenceDerive = true;
         public boolean enableJoinPredicatePushDown = true;
 
@@ -85,10 +85,10 @@ public class JoinPredicatePushdown {
             if (!sessionVariable.isEnableRboTablePrune() && !mvRewriteStrategy.mvStrategy.isMultiStages()) {
                 return;
             }
-            JoinPushDownParams joinPushDownParams = context.getJoinPushDownParams();
-            joinPushDownParams.enableLeftRightJoinEquivalenceDerive = false;
+            JoinPredicatePushDownContext joinPredicatePushDownContext = context.getJoinPushDownParams();
+            joinPredicatePushDownContext.enableLeftRightJoinEquivalenceDerive = false;
             if (mvRewriteStrategy.mvStrategy.isMultiStages()) {
-                joinPushDownParams.enableJoinPredicatePushDown = false;
+                joinPredicatePushDownContext.enableJoinPredicatePushDown = false;
             }
         }
 
@@ -102,7 +102,7 @@ public class JoinPredicatePushdown {
     }
 
     // Join push down parameters to control the push down strategies.
-    private final JoinPushDownParams joinPushDownParams;
+    private final JoinPredicatePushDownContext joinPredicatePushDownContext;
 
     private final OptimizerContext optimizerContext;
 
@@ -113,7 +113,7 @@ public class JoinPredicatePushdown {
         this.isOnPredicate = isOnPredicate;
         this.directToChild = directToChild;
         this.columnRefFactory = columnRefFactory;
-        this.joinPushDownParams = optimizerContext.getJoinPushDownParams();
+        this.joinPredicatePushDownContext = optimizerContext.getJoinPushDownParams();
         this.leftPushDown = Lists.newArrayList();
         this.rightPushDown = Lists.newArrayList();
         this.optimizerContext = optimizerContext;
@@ -431,7 +431,7 @@ public class JoinPredicatePushdown {
             } else {
                 ScalarOperator predicate = rangePredicateDerive(predicateToPush);
                 JoinOperator joinType = join.getJoinType();
-                if (joinPushDownParams.enableLeftRightJoinEquivalenceDerive ||
+                if (joinPredicatePushDownContext.enableLeftRightJoinEquivalenceDerive ||
                         (!joinType.isLeftOuterJoin() && !joinType.isRightOuterJoin())) {
                     getPushdownPredicatesFromEquivalenceDerive(
                             Utils.compoundAnd(join.getOnPredicate(), predicate), joinOptExpression, join);

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/PushDownJoinOnClauseRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/PushDownJoinOnClauseRule.java
@@ -49,8 +49,7 @@ public class PushDownJoinOnClauseRule extends TransformationRule {
         LogicalJoinOperator join = (LogicalJoinOperator) input.getOp();
         ScalarOperator on = join.getOnPredicate();
         JoinPredicatePushdown joinPredicatePushdown = new JoinPredicatePushdown(
-                input, true, false, context.getColumnRefFactory(),
-                context.isEnableLeftRightJoinEquivalenceDerive(), context);
+                input, true, false, context.getColumnRefFactory(), context);
         OptExpression root = joinPredicatePushdown.pushdown(join.getOnPredicate());
         ((LogicalJoinOperator) root.getOp()).setHasPushDownJoinOnClause(true);
         if (root.getOp().equals(input.getOp()) && on.equals(join.getOnPredicate()) &&

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/PushDownJoinOnClauseRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/PushDownJoinOnClauseRule.java
@@ -36,8 +36,11 @@ public class PushDownJoinOnClauseRule extends TransformationRule {
     @Override
     public boolean check(final OptExpression input, OptimizerContext context) {
         LogicalJoinOperator joinOperator = (LogicalJoinOperator) input.getOp();
-
         if (joinOperator.hasPushDownJoinOnClause()) {
+            return false;
+        }
+        JoinPredicatePushdown.JoinPushDownParams params = context.getJoinPushDownParams();
+        if (!params.enableJoinPredicatePushDown) {
             return false;
         }
         return joinOperator.getOnPredicate() != null;

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/PushDownJoinOnClauseRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/PushDownJoinOnClauseRule.java
@@ -39,7 +39,7 @@ public class PushDownJoinOnClauseRule extends TransformationRule {
         if (joinOperator.hasPushDownJoinOnClause()) {
             return false;
         }
-        JoinPredicatePushdown.JoinPushDownParams params = context.getJoinPushDownParams();
+        JoinPredicatePushdown.JoinPredicatePushDownContext params = context.getJoinPushDownParams();
         if (!params.enableJoinPredicatePushDown) {
             return false;
         }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/PushDownPredicateJoinRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/PushDownPredicateJoinRule.java
@@ -20,6 +20,7 @@ import com.starrocks.sql.optimizer.OptExpression;
 import com.starrocks.sql.optimizer.OptimizerContext;
 import com.starrocks.sql.optimizer.operator.OperatorType;
 import com.starrocks.sql.optimizer.operator.logical.LogicalFilterOperator;
+import com.starrocks.sql.optimizer.operator.logical.LogicalJoinOperator;
 import com.starrocks.sql.optimizer.operator.pattern.Pattern;
 import com.starrocks.sql.optimizer.rewrite.JoinPredicatePushdown;
 import com.starrocks.sql.optimizer.rule.RuleType;
@@ -34,6 +35,16 @@ public class PushDownPredicateJoinRule extends TransformationRule {
                         .addChildren(Pattern.create(OperatorType.PATTERN_LEAF))));
     }
 
+    @Override
+    public boolean check(OptExpression input, OptimizerContext context) {
+        JoinPredicatePushdown.JoinPushDownParams params = context.getJoinPushDownParams();
+        OptExpression joinOpt = input.getInputs().get(0);
+        LogicalJoinOperator joinOperator = (LogicalJoinOperator) joinOpt.getOp();
+        if (joinOperator.getJoinType().isOuterJoin() && !params.enableJoinPredicatePushDown) {
+            return false;
+        }
+        return true;
+    }
 
     @Override
     public List<OptExpression> transform(OptExpression input, OptimizerContext context) {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/PushDownPredicateJoinRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/PushDownPredicateJoinRule.java
@@ -40,8 +40,7 @@ public class PushDownPredicateJoinRule extends TransformationRule {
         LogicalFilterOperator filter = (LogicalFilterOperator) input.getOp();
         OptExpression joinOpt = input.getInputs().get(0);
         JoinPredicatePushdown joinPredicatePushdown = new JoinPredicatePushdown(
-                joinOpt, false, false, context.getColumnRefFactory(),
-                context.isEnableLeftRightJoinEquivalenceDerive(), context);
+                joinOpt, false, false, context.getColumnRefFactory(), context);
         return Lists.newArrayList(joinPredicatePushdown.pushdown(filter.getPredicate()));
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/PushDownPredicateJoinRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/PushDownPredicateJoinRule.java
@@ -37,7 +37,7 @@ public class PushDownPredicateJoinRule extends TransformationRule {
 
     @Override
     public boolean check(OptExpression input, OptimizerContext context) {
-        JoinPredicatePushdown.JoinPushDownParams params = context.getJoinPushDownParams();
+        JoinPredicatePushdown.JoinPredicatePushDownContext params = context.getJoinPushDownParams();
         OptExpression joinOpt = input.getInputs().get(0);
         LogicalJoinOperator joinOperator = (LogicalJoinOperator) joinOpt.getOp();
         if (joinOperator.getJoinType().isOuterJoin() && !params.enableJoinPredicatePushDown) {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MaterializedViewRewriter.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MaterializedViewRewriter.java
@@ -1765,6 +1765,10 @@ public class MaterializedViewRewriter implements IMaterializedViewRewriter {
         if (materializationContext.getMv().getRefreshScheme().isSync()) {
             return null;
         }
+        JoinPredicatePushdown.JoinPushDownParams params = optimizerContext.getJoinPushDownParams();
+        if (!params.enableJoinPredicatePushDown) {
+            return null;
+        }
         List<LogicalScanOperator> scanOperators = MvUtils.getScanOperator(rewriteContext.getMvExpression());
         if (scanOperators.stream().anyMatch(scan -> scan instanceof LogicalViewScanOperator)) {
             // TODO: support union rewrite for view based mv rewrite
@@ -1978,6 +1982,8 @@ public class MaterializedViewRewriter implements IMaterializedViewRewriter {
                 return null;
             }
 
+            // TODO(fixme): Push-down predicates will pollute the original input operators, if rewrite fail we should retrieve
+            // push-down predicates.
             OptExpression newQueryExpr = pushdownPredicatesForJoin(queryExpression, queryCompensationPredicate);
             deriveLogicalProperty(newQueryExpr);
             if (mvRewriteContext.getEnforcedNonExistedColumns() != null &&

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MaterializedViewRewriter.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MaterializedViewRewriter.java
@@ -2060,8 +2060,7 @@ public class MaterializedViewRewriter implements IMaterializedViewRewriter {
         Preconditions.checkState(joinOptExpression.getOp() instanceof LogicalJoinOperator);
         optimizerContext.clearNotNullPredicates();
         JoinPredicatePushdown joinPredicatePushdown = new JoinPredicatePushdown(joinOptExpression,
-                false, true, materializationContext.getQueryRefFactory(),
-                true, optimizerContext);
+                false, true, materializationContext.getQueryRefFactory(), optimizerContext);
         return joinPredicatePushdown.pushdown(predicate);
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MaterializedViewRewriter.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MaterializedViewRewriter.java
@@ -1765,7 +1765,7 @@ public class MaterializedViewRewriter implements IMaterializedViewRewriter {
         if (materializationContext.getMv().getRefreshScheme().isSync()) {
             return null;
         }
-        JoinPredicatePushdown.JoinPushDownParams params = optimizerContext.getJoinPushDownParams();
+        JoinPredicatePushdown.JoinPredicatePushDownContext params = optimizerContext.getJoinPushDownParams();
         if (!params.enableJoinPredicatePushDown) {
             return null;
         }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvRewriteStrategy.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvRewriteStrategy.java
@@ -23,39 +23,26 @@ import com.starrocks.sql.optimizer.OptimizerConfig;
 import com.starrocks.sql.optimizer.OptimizerContext;
 import com.starrocks.sql.optimizer.rule.RuleSetType;
 
-import java.util.HashMap;
-import java.util.Map;
-
 public class MvRewriteStrategy {
     public static final MvRewriteStrategy DEFAULT = new MvRewriteStrategy();
 
+    /**
+     * Materialized view rewrite strategy, when multi stages is enabled, we will rewrite query plan in multi stages.
+     * - Default: rewrite the query after required rules are executed in rule based rewrite stage.
+     * - MultiStage: rewrite the query in early stage(before some rules which may break plans' structure) and later stage
+     * (required rules are executed) in rule based rewrite stage.
+     * Attention: MultiStage may increase rewrite optimizer time, so it's disabled by default.
+     */
     public enum MVStrategy {
         DEFAULT(0),
         MULTI_STAGES(1);
         private int ordinal;
-
         MVStrategy(int ordinal) {
             this.ordinal = ordinal;
         }
         public int getOrdinal() {
             return this.ordinal;
         }
-        public static Map<Integer, MVStrategy> ORDINAL_MAP = getOrdinalMap();
-        public static Map<Integer, MVStrategy> getOrdinalMap() {
-            Map<Integer, MVStrategy> ordinalMap = new HashMap<>();
-            for (MVStrategy mode : MVStrategy.values()) {
-                ordinalMap.put(mode.ordinal, mode);
-            }
-            return ordinalMap;
-        }
-
-        public static MVStrategy create(int ordinal) {
-            if (ORDINAL_MAP.containsKey(ordinal)) {
-                return ORDINAL_MAP.get(ordinal);
-            }
-            return DEFAULT;
-        }
-
         public boolean isMultiStages() {
             return this == MULTI_STAGES;
         }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/rule/BaseMaterializedViewRewriteRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/rule/BaseMaterializedViewRewriteRule.java
@@ -227,6 +227,8 @@ public abstract class BaseMaterializedViewRewriteRule extends TransformationRule
             IMaterializedViewMetricsEntity mvEntity =
                     MaterializedViewMetricsRegistry.getInstance().getMetricsEntity(mvContext.getMv().getMvId());
             mvEntity.increaseQueryMatchedCount(1L);
+            // mark: query has been rewritten by mv success.
+            context.getQueryMaterializationContext().markRewriteSuccess(true);
 
             // Do not try to enumerate all plans, it would take a lot of time
             int limit = context.getSessionVariable().getCboMaterializedViewRewriteRuleOutputLimit();

--- a/fe/fe-core/src/test/java/com/starrocks/planner/MaterializedViewRewriteWithSSBTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/planner/MaterializedViewRewriteWithSSBTest.java
@@ -1,0 +1,191 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.planner;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Lists;
+import com.starrocks.common.FeConstants;
+import org.junit.BeforeClass;
+import org.junit.FixMethodOrder;
+import org.junit.Test;
+import org.junit.runners.MethodSorters;
+
+@FixMethodOrder(MethodSorters.NAME_ASCENDING)
+public class MaterializedViewRewriteWithSSBTest extends MaterializedViewTestBase {
+    @BeforeClass
+    public static void beforeClass() throws Exception {
+        FeConstants.USE_MOCK_DICT_MANAGER = true;
+        MaterializedViewTestBase.beforeClass();
+
+        starRocksAssert.useDatabase(MATERIALIZED_DB_NAME);
+        // create SSB tables
+        // put lineorder last because it depends on other tables for foreign key constraints
+        createTables("sql/ssb/", Lists.newArrayList("customer", "dates", "supplier", "part", "lineorder"));
+        connectContext.getSessionVariable().setMaterializedViewRewriteMode("force");
+//        connectContext.getSessionVariable().setCboPruneSubfield(false);
+        connectContext.getSessionVariable().setEnableMaterializedViewPushDownRewrite(true);
+    }
+
+    @Test
+    public void testNestedMVRewriteWithSSB() {
+        String mv1 = "CREATE MATERIALIZED VIEW mv1 REFRESH ASYNC every (interval 10 minute) AS\n" +
+                "select lo_orderkey, lo_custkey, p_partkey, p_name\n" +
+                "from lineorder join part on lo_partkey = p_partkey;";
+        String mv2 = "CREATE MATERIALIZED VIEW mv2 REFRESH ASYNC every (interval 10 minute) AS\n" +
+                "select c_custkey from customer group by c_custkey;";
+        String mv3 = "CREATE MATERIALIZED VIEW mv3 REFRESH ASYNC every (interval 10 minute) AS\n" +
+                "select * from mv1 lo join mv2 cust on lo.lo_custkey = cust.c_custkey;";
+
+        starRocksAssert.withMaterializedViews(ImmutableList.of(mv1, mv2, mv3), (obj) -> {
+            String query = "select *\n" +
+                    "from (\n" +
+                    "    select lo_orderkey, lo_custkey, p_partkey, p_name\n" +
+                    "    from lineorder\n" +
+                    "    join part on lo_partkey = p_partkey\n" +
+                    ") lo\n" +
+                    "join (\n" +
+                    "    select c_custkey\n" +
+                    "    from customer\n" +
+                    "    group by c_custkey\n" +
+                    ") cust\n" +
+                    "on lo.lo_custkey = cust.c_custkey;";
+            sql(query).contains("mv3");
+        });
+    }
+
+    @Test
+    public void testJoinWithPredicatePushDown() {
+        String mv = "CREATE MATERIALIZED VIEW mv0 REFRESH MANUAL as " +
+                "select p_brand, LO_ORDERDATE, sum(LO_REVENUE) as revenue_sum\n" +
+                "from lineorder l left join part p on l.LO_PARTKEY = p.P_PARTKEY\n" +
+                "group by p_brand, LO_ORDERDATE";
+
+        // This case must disable outer join to inner join in `JoinPredicatePushdown`
+        setTracLogModule("Optimizer");
+        starRocksAssert.withMaterializedView(mv, () -> {
+            String query = "select t1.p_brand as p_brand, t1.LO_ORDERDATE as LO_ORDERDATE,\n" +
+                    "SUM(revenue_sum) + SUM(supplycost_sum) as revenue_and_supplycost_sum\n" +
+                    "from\n" +
+                    "(\n" +
+                    "   select p_brand, LO_ORDERDATE, sum(LO_REVENUE) as revenue_sum\n" +
+                    "   from lineorder l left join part p on l.LO_PARTKEY = p.P_PARTKEY\n" +
+                    "   group by p_brand, LO_ORDERDATE" +
+                    ") t1\n" +
+                    "inner join (\n" +
+                    "   select p_brand, LO_ORDERDATE, sum(LO_REVENUE) as supplycost_sum\n" +
+                    "   from lineorder l left join part p on l.LO_PARTKEY = p.P_PARTKEY\n" +
+                    "   group by p_brand, LO_ORDERDATE" +
+                    ") t2 on t1.p_brand = t2.p_brand and t1.LO_ORDERDATE = t2.LO_ORDERDATE\n" +
+                    "group by t1.p_brand, t1.LO_ORDERDATE;";
+            sql(query).contains("mv0");
+        });
+    }
+
+    @Test
+    public void testJoinWithAggPushDown0() {
+        String mv = "CREATE MATERIALIZED VIEW mv0 REFRESH MANUAL as " +
+                "select LO_ORDERDATE, sum(LO_REVENUE) as revenue_sum\n" +
+                "from lineorder l group by LO_ORDERDATE";
+        starRocksAssert.withMaterializedView(mv, () -> {
+            String query = "select LO_ORDERDATE, sum(LO_REVENUE) as revenue_sum\n" +
+                    "   from lineorder l join dates d on l.LO_ORDERDATE = d.d_datekey\n" +
+                    "   group by LO_ORDERDATE";
+            sql(query).contains("mv0");
+        });
+    }
+
+    @Test
+    public void testJoinWithMultiCountDistinct() {
+        String mv = "CREATE MATERIALIZED VIEW mv0 REFRESH MANUAL as " +
+                "select LO_ORDERDATE, " +
+                "   bitmap_union(to_bitmap(LO_REVENUE)), \n" +
+                "   bitmap_union(to_bitmap(lo_linenumber)), \n" +
+                "   bitmap_union(to_bitmap(lo_custkey)), \n" +
+                "   bitmap_union(to_bitmap(lo_partkey)), \n" +
+                "   bitmap_union(to_bitmap(lo_suppkey)), \n" +
+                "   bitmap_union(to_bitmap(lo_orderpriority)), \n" +
+                "   bitmap_union(to_bitmap(lo_shippriority)), \n" +
+                "   bitmap_union(to_bitmap(lo_ordtotalprice)), \n" +
+                "   bitmap_union(to_bitmap(lo_tax)), \n" +
+                "   bitmap_union(to_bitmap(lo_shipmode)) \n" +
+                "from lineorder l group by LO_ORDERDATE";
+        setTracLogModule("MV");
+        starRocksAssert.withMaterializedView(mv, () -> {
+            {
+                String query = "select LO_ORDERDATE, count(distinct LO_REVENUE) as revenue_sum\n" +
+                        "   from lineorder l \n" +
+                        "   group by LO_ORDERDATE";
+                sql(query).contains("mv0");
+            }
+            {
+                String query = "select LO_ORDERDATE, " +
+                    "   count(distinct LO_REVENUE), \n" +
+                    "   count(distinct lo_linenumber), \n" +
+                    "   count(distinct lo_custkey), \n" +
+                    "   count(distinct lo_suppkey), \n" +
+                    "   count(distinct lo_partkey), \n" +
+                    "   count(distinct lo_orderpriority), \n" +
+                    "   count(distinct lo_shippriority), \n" +
+                    "   count(distinct lo_ordtotalprice), \n" +
+                    "   count(distinct lo_tax), \n" +
+                    "   count(distinct lo_shipmode) \n" +
+                    "from lineorder l group by LO_ORDERDATE";
+                sql(query).contains("mv0");
+            }
+        });
+    }
+
+    @Test
+    public void testJoinWithAggPushDown1() {
+        String mv = "CREATE MATERIALIZED VIEW mv0 REFRESH MANUAL as " +
+                "select LO_ORDERDATE, bitmap_union(to_bitmap(LO_REVENUE)) as revenue_sum\n" +
+                "from lineorder l group by LO_ORDERDATE";
+        starRocksAssert.withMaterializedView(mv, () -> {
+            {
+                String query = "select LO_ORDERDATE, count(distinct LO_REVENUE) as revenue_sum\n" +
+                        "   from lineorder l \n" +
+                        "   group by LO_ORDERDATE";
+                sql(query).contains("mv0");
+            }
+            {
+                String query = "select LO_ORDERDATE, bitmap_union(to_bitmap(LO_REVENUE)) as revenue_sum\n" +
+                        "   from lineorder l join dates d on l.LO_ORDERDATE = d.d_datekey\n" +
+                        "   group by LO_ORDERDATE";
+                sql(query).contains("mv0");
+            }
+            {
+                String query = "select LO_ORDERDATE, count(distinct LO_REVENUE) as revenue_sum\n" +
+                        "   from lineorder l join dates d on l.LO_ORDERDATE = d.d_datekey\n" +
+                        "   group by LO_ORDERDATE";
+                sql(query).contains("mv0");
+            }
+        });
+    }
+
+    @Test
+    public void testJoinWithAggPushDown2() {
+        String mv = "CREATE MATERIALIZED VIEW mv0 REFRESH MANUAL as " +
+                "select LO_ORDERDATE, count(distinct LO_REVENUE) as revenue_sum\n" +
+                "from lineorder l group by LO_ORDERDATE";
+        starRocksAssert.withMaterializedView(mv, () -> {
+            {
+                String query = "select LO_ORDERDATE, count(distinct LO_REVENUE) as revenue_sum\n" +
+                        "   from lineorder l join dates d on l.LO_ORDERDATE = d.d_datekey\n" +
+                        "   group by LO_ORDERDATE";
+                sql(query).notContain("mv0");
+            }
+        });
+    }
+}

--- a/fe/fe-core/src/test/java/com/starrocks/planner/MaterializedViewRewriteWithSSBTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/planner/MaterializedViewRewriteWithSSBTest.java
@@ -34,7 +34,6 @@ public class MaterializedViewRewriteWithSSBTest extends MaterializedViewTestBase
         // put lineorder last because it depends on other tables for foreign key constraints
         createTables("sql/ssb/", Lists.newArrayList("customer", "dates", "supplier", "part", "lineorder"));
         connectContext.getSessionVariable().setMaterializedViewRewriteMode("force");
-//        connectContext.getSessionVariable().setCboPruneSubfield(false);
         connectContext.getSessionVariable().setEnableMaterializedViewPushDownRewrite(true);
     }
 

--- a/fe/fe-core/src/test/java/com/starrocks/planner/MaterializedViewSSBTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/planner/MaterializedViewSSBTest.java
@@ -14,7 +14,6 @@
 
 package com.starrocks.planner;
 
-import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
 import com.starrocks.common.FeConstants;
 import com.starrocks.sql.plan.PlanTestBase;
@@ -128,34 +127,5 @@ public class MaterializedViewSSBTest extends MaterializedViewTestBase {
         String plan = getFragmentPlan(query);
         PlanTestBase.assertContains(plan, "lineorder_flat_mv");
         connectContext.getSessionVariable().setCboMaterializedViewRewriteRelatedMVsLimit(oldVal);
-    }
-
-    @Test
-    public void testNestedMVRewriteWithSSB() {
-        String mv1 = "CREATE MATERIALIZED VIEW mv1 REFRESH ASYNC every (interval 10 minute) AS\n" +
-                "select lo_orderkey, lo_custkey, p_partkey, p_name\n" +
-                "from lineorder join part on lo_partkey = p_partkey;";
-        String mv2 = "CREATE MATERIALIZED VIEW mv2 REFRESH ASYNC every (interval 10 minute) AS\n" +
-                "select c_custkey from customer group by c_custkey;";
-        String mv3 = "CREATE MATERIALIZED VIEW mv3 REFRESH ASYNC every (interval 10 minute) AS\n" +
-                "select * from mv1 lo join mv2 cust on lo.lo_custkey = cust.c_custkey;";
-
-        connectContext.getSessionVariable().setQueryIncludingMVNames("mv1,mv2,mv3");
-        starRocksAssert.withMaterializedViews(ImmutableList.of(mv1, mv2, mv3), (obj) -> {
-            String query = "select *\n" +
-                    "from (\n" +
-                    "    select lo_orderkey, lo_custkey, p_partkey, p_name\n" +
-                    "    from lineorder\n" +
-                    "    join part on lo_partkey = p_partkey\n" +
-                    ") lo\n" +
-                    "join (\n" +
-                    "    select c_custkey\n" +
-                    "    from customer\n" +
-                    "    group by c_custkey\n" +
-                    ") cust\n" +
-                    "on lo.lo_custkey = cust.c_custkey;";
-            sql(query).contains("mv3");
-        });
-        connectContext.getSessionVariable().setQueryIncludingMVNames("");
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/planner/MaterializedViewWithMultiStageTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/planner/MaterializedViewWithMultiStageTest.java
@@ -15,6 +15,7 @@
 package com.starrocks.planner;
 
 import org.junit.BeforeClass;
+import org.junit.Test;
 
 /**
  * Run all tests in MaterializedViewTest in multi stage mode.
@@ -29,5 +30,33 @@ public class MaterializedViewWithMultiStageTest extends MaterializedViewTest {
     @Override
     public void testJoinDeriveRewrite() {
         // ignore test case
+    }
+
+    @Test
+    public void testViewDeltaJoinUKFK17() {
+        // set join derive rewrite in view delta
+        setTracLogModule("Optimizer");
+        String mv = "select emps.empid, emps.deptno, dependents.name from emps\n"
+                + "left outer join depts b on (emps.deptno=b.deptno)\n"
+                + "left outer join dependents using (empid)";
+
+        String query = "select emps.empid, dependents.name from emps\n"
+                + " join dependents using (empid)\n"
+                + "where dependents.name = 'name1'";
+        testRewriteOK(mv, query);
+    }
+
+    @Test
+    public void testOuterJoinWithRangePredicates() {
+        {
+            String mv = "select deptno as col1, empid as col2, emps.locationid as col3 from emps " +
+                    " left join locations on emps.locationid = locations.locationid where emps.deptno > 10";
+            testRewriteOK(mv, "select count(*) from " +
+                    "emps  left join locations on emps.locationid = locations.locationid where emps.deptno > 10");
+            testRewriteOK(mv, "select count(*) from " +
+                    "emps  left join locations on emps.locationid = locations.locationid where emps.deptno > 20");
+            testRewriteFail(mv, "select count(*) from " +
+                    "emps  left join locations on emps.locationid = locations.locationid where emps.deptno < 10");
+        }
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/planner/MaterializedViewWithMultiStageTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/planner/MaterializedViewWithMultiStageTest.java
@@ -1,0 +1,33 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.planner;
+
+import org.junit.BeforeClass;
+
+/**
+ * Run all tests in MaterializedViewTest in multi stage mode.
+ */
+public class MaterializedViewWithMultiStageTest extends MaterializedViewTest {
+    @BeforeClass
+    public static void beforeClass() throws Exception {
+        MaterializedViewTest.beforeClass();
+        connectContext.getSessionVariable().setMaterializedViewRewriteMode("force");
+    }
+
+    @Override
+    public void testJoinDeriveRewrite() {
+        // ignore test case
+    }
+}


### PR DESCRIPTION
## Why I'm doing:

1. Query which has join operators cannot be rewritten by mv as expect.
2. MV Rewrite Rule may be affected than other rules., eg (count distinct to cte or join prredicate push down)

Case1:
```
-- MV
CREATE MATERIALIZED VIEW mv0 REFRESH MANUAL as 
select p_brand, LO_ORDERDATE, sum(LO_REVENUE) as revenue_sum
from lineorder l left join part p on l.LO_PARTKEY = p.P_PARTKEY
group by p_brand, LO_ORDERDATE

-- Query rewrite fail!
select t1.p_brand as p_brand, t1.LO_ORDERDATE as LO_ORDERDATE,
SUM(revenue_sum) + SUM(supplycost_sum) as revenue_and_supplycost_sum
from
(
   select p_brand, LO_ORDERDATE, sum(LO_REVENUE) as revenue_sum
   from lineorder l left join part p on l.LO_PARTKEY = p.P_PARTKEY
   group by p_brand, LO_ORDERDATE
) t1
inner join (
   select p_brand, LO_ORDERDATE, sum(LO_REVENUE) as supplycost_sum
   from lineorder l left join part p on l.LO_PARTKEY = p.P_PARTKEY
   group by p_brand, LO_ORDERDATE
) t2 on t1.p_brand = t2.p_brand and t1.LO_ORDERDATE = t2.LO_ORDERDATE
group by t1.p_brand, t1.LO_ORDERDATE;
```
Case2:
```
-- MV
CREATE MATERIALIZED VIEW mv0 REFRESH MANUAL as 
select LO_ORDERDATE, 
   bitmap_union(to_bitmap(LO_REVENUE)), 
   bitmap_union(to_bitmap(lo_linenumber)), 
   bitmap_union(to_bitmap(lo_custkey)), 
   bitmap_union(to_bitmap(lo_partkey)), 
   bitmap_union(to_bitmap(lo_suppkey)), 
   bitmap_union(to_bitmap(lo_orderpriority)), 
   bitmap_union(to_bitmap(lo_shippriority)), 
   bitmap_union(to_bitmap(lo_ordtotalprice)), 
   bitmap_union(to_bitmap(lo_tax)), 
   bitmap_union(to_bitmap(lo_shipmode)) 
from lineorder l group by LO_ORDERDATE

select LO_ORDERDATE, 
   count(distinct LO_REVENUE), 
   count(distinct lo_linenumber), 
   count(distinct lo_custkey), 
   count(distinct lo_suppkey), 
   count(distinct lo_partkey), 
   count(distinct lo_orderpriority), 
   count(distinct lo_shippriority), 
   count(distinct lo_ordtotalprice), 
   count(distinct lo_tax), 
   count(distinct lo_shipmode) 
from lineorder l group by LO_ORDERDATE
```

This is because mv rewrite rules have conflicts with other rules, eg:
- `RuleSetType.PUSH_DOWN_PREDICATE` will disturb join's type (eg, full outer join to left join or outer join to inner join) or push extra predicates below childrens;
- `RewriteMultiDistinctRule` will rewrite count distinct to ctes which are not supported rewrite for mv.

## What I'm doing:
- Introduce multi stages rewrite strategy for mv rewrite, try to rewrite in early and later stages to avoid above rules affect.

- Since `MultiStage` strategy will increase optimizer cost if query cannot be rewritten in multi stages, so `MultiStage` rewrite only be used when force rewrite is enabled.

You can use this by:
```
set materialized_view_rewrite_mode = 'force';
```


## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
