### PR TITLE
[BugFix] Fix json_object flat error

### DIFF
--- a/be/src/util/json_util.cpp
+++ b/be/src/util/json_util.cpp
@@ -165,7 +165,7 @@ void JsonFlater::flatten(const Column* json_column, std::vector<ColumnPtr>* resu
         }
         for (size_t k = 0; k < _flat_paths.size(); k++) {
             auto st = obj->get_obj(_flat_paths[k]);
-            if (st.ok() && !st.value().is_null()) {
+            if (st.ok() && !st.value().is_none()) {
                 flat_jsons[k]->append(st.value());
                 flat_nulls[k]->append(0);
             } else {

--- a/test/sql/test_semi/R/test_invalid_flat_json
+++ b/test/sql/test_semi/R/test_invalid_flat_json
@@ -17,31 +17,21 @@ PROPERTIES (
 );
 -- result:
 -- !result
-insert into js1 values(1,1, parse_json('[{"s1": 4}, {"s2": 5}]'));
--- result:
--- !result
-insert into js1 values(2,1, parse_json('"a"'));
--- result:
--- !result
-insert into js1 values(3,1, parse_json('1'));
--- result:
--- !result
-insert into js1 values(4,1, parse_json('2020-12-12'));
--- result:
--- !result
-insert into js1 values(5,1, parse_json('1.000000'));
--- result:
--- !result
-insert into js1 values(6,1, parse_json(''));
--- result:
--- !result
-insert into js1 values(6,1, parse_json(null));
--- result:
--- !result
-insert into js1 values(6,1, parse_json(TRUE));
--- result:
--- !result
-insert into js1 values(7,1, parse_json('{"k1": null, "k2": 2}'));
+insert into js1 values
+(1,1, parse_json('[{"s1": 4}, {"s2": 5}]')),
+(2,2, parse_json('"a"')),
+(3,3, parse_json('1')),
+(4,4, parse_json('2020-12-12')),
+(5,5, parse_json('1.000000')),
+(6,6, parse_json('')),
+(6,7, parse_json(null)),
+(6,8, parse_json(TRUE)),
+(7,9, parse_json('{"k1": null, "k2": 2}')),
+(8,8, json_object('1')),
+(9,9, json_object('"a"')),
+(10,10, json_object('')),
+(11,11, json_object()),
+(12,12, json_object(null));
 -- result:
 -- !result
 select get_json_string(j1, "$.key2"), get_json_double(j1, "$.key3"), get_json_string(j1, "$.key4") from js1 order by v1 limit 2;
@@ -62,6 +52,23 @@ select JSON_LENGTH(j1, "$.key2"), JSON_LENGTH(j1, "$.key3"), JSON_LENGTH(j1, "$.
 select json_object('"1"')->"1", json_object('"1"')->"1" is null;
 -- result:
 null	0
+-- !result
+select j1, j1->"1", j1->"1" is null from js1 order by v1, v2;
+-- result:
+[{"s1": 4}, {"s2": 5}]	None	1
+"a"	None	1
+"1"	None	1
+"2020-12-12"	None	1
+"1.000000"	None	1
+""	None	1
+None	None	1
+"1"	None	1
+{"k1": null, "k2": 2}	None	1
+{"1": null}	null	0
+{"a": null}	None	1
+None	None	1
+{}	None	1
+None	None	1
 -- !result
 select json_object(j1)->"k3", json_object(j1)->"k1", json_object(j1)->"k2.k3" from js1 where v1 = 7;
 -- result:

--- a/test/sql/test_semi/T/test_invalid_flat_json
+++ b/test/sql/test_semi/T/test_invalid_flat_json
@@ -18,15 +18,21 @@ PROPERTIES (
 );
 
 
-insert into js1 values(1,1, parse_json('[{"s1": 4}, {"s2": 5}]'));
-insert into js1 values(2,1, parse_json('"a"'));
-insert into js1 values(3,1, parse_json('1'));
-insert into js1 values(4,1, parse_json('2020-12-12'));
-insert into js1 values(5,1, parse_json('1.000000'));
-insert into js1 values(6,1, parse_json(''));
-insert into js1 values(6,1, parse_json(null));
-insert into js1 values(6,1, parse_json(TRUE));
-insert into js1 values(7,1, parse_json('{"k1": null, "k2": 2}'));
+insert into js1 values
+(1,1, parse_json('[{"s1": 4}, {"s2": 5}]')),
+(2,2, parse_json('"a"')),
+(3,3, parse_json('1')),
+(4,4, parse_json('2020-12-12')),
+(5,5, parse_json('1.000000')),
+(6,6, parse_json('')),
+(6,7, parse_json(null)),
+(6,8, parse_json(TRUE)),
+(7,9, parse_json('{"k1": null, "k2": 2}')),
+(8,8, json_object('1')),
+(9,9, json_object('"a"')),
+(10,10, json_object('')),
+(11,11, json_object()),
+(12,12, json_object(null));
 
 select get_json_string(j1, "$.key2"), get_json_double(j1, "$.key3"), get_json_string(j1, "$.key4") from js1 order by v1 limit 2;
 
@@ -35,5 +41,7 @@ select JSON_EXISTS(j1, "$.key2"), JSON_EXISTS(j1, "$.key2.key3") from js1 order 
 select JSON_LENGTH(j1, "$.key2"), JSON_LENGTH(j1, "$.key3"), JSON_LENGTH(j1, "$.key4") from js1 order by v1 limit 2;
 
 select json_object('"1"')->"1", json_object('"1"')->"1" is null;
+
+select j1, j1->"1", j1->"1" is null from js1 order by v1, v2;
 
 select json_object(j1)->"k3", json_object(j1)->"k1", json_object(j1)->"k2.k3" from js1 where v1 = 7;


### PR DESCRIPTION
## Why I'm doing:
now, it's SR NULL
```
MySQL x12> select JSON_OBJECT('1'), JSON_OBJECT('1')->'1';
+------------------+-----------------------+
| json_object('1') | json_object('1')->'1' |
+------------------+-----------------------+
| {"1": null}      | NULL                  |
+------------------+-----------------------+
1 row in set
Time: 0.011s
MySQL x12>
```

expect, it's JSON(null)
```
MySQL x12> select JSON_OBJECT('1'), JSON_OBJECT('1')->'1';
+------------------+-----------------------+
| json_object('1') | json_object('1')->'1' |
+------------------+-----------------------+
| {"1": null}      | null                  |
+------------------+-----------------------+
1 row in set
Time: 0.011s
MySQL x12>
```
## What I'm doing:

Fixes https://github.com/StarRocks/StarRocksTest/issues/6442

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
