### PR TITLE
[Enhancement] Add a config to decide whether to rewrite aggregate in rollup mode

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
@@ -533,6 +533,8 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
             "enable_materialized_view_rewrite_greedy_mode";
 
     public static final String ENABLE_MATERIALIZED_VIEW_PLAN_CACHE = "enable_materialized_view_plan_cache";
+    public static final String MATERIALIZED_VIEW_AGGREGATE_ROLLUP_REWRITE =
+            "enable_materialized_view_aggregate_rollup_rewrite";
 
     public static final String ENABLE_VIEW_BASED_MV_REWRITE = "enable_view_based_mv_rewrite";
 
@@ -1546,6 +1548,9 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
     // whether to use materialized view plan context cache to reduce mv rewrite time cost
     @VarAttr(name = ENABLE_MATERIALIZED_VIEW_PLAN_CACHE, flag = VariableMgr.INVISIBLE)
     private boolean enableMaterializedViewPlanCache = true;
+
+    @VarAttr(name = MATERIALIZED_VIEW_AGGREGATE_ROLLUP_REWRITE)
+    private boolean enableMaterializedViewAggregateRollupRewrite = true;
 
     @VarAttr(name = ENABLE_VIEW_BASED_MV_REWRITE)
     private boolean enableViewBasedMvRewrite = false;
@@ -3009,6 +3014,14 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
 
     public boolean isEnableMaterializedViewPlanCache() {
         return this.enableMaterializedViewPlanCache;
+    }
+
+    public boolean isEnableMaterializedViewAggregateRollupRewrite() {
+        return enableMaterializedViewAggregateRollupRewrite;
+    }
+
+    public void setEnableMaterializedViewAggregateRollupRewrite(boolean enableMaterializedViewAggregateRollupRewrite) {
+        this.enableMaterializedViewAggregateRollupRewrite = enableMaterializedViewAggregateRollupRewrite;
     }
 
     public void setEnableViewBasedMvRewrite(boolean enableViewBasedMvRewrite) {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/MvRewritePreprocessor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/MvRewritePreprocessor.java
@@ -274,8 +274,6 @@ public class MvRewritePreprocessor {
         logMVPrepare(connectContext, "  enable_experimental_mv: {}", Config.enable_experimental_mv);
         logMVPrepare(connectContext, "  enable_materialized_view_rewrite: {}",
                 sessionVariable.isEnableMaterializedViewRewrite());
-        logMVPrepare(connectContext, "  enable_view_based_mv_rewrite: {}",
-                sessionVariable.isEnableViewBasedMvRewrite());
         logMVPrepare(connectContext, "  enable_materialized_view_union_rewrite: {}",
                 sessionVariable.isEnableMaterializedViewUnionRewrite());
         logMVPrepare(connectContext, "  enable_materialized_view_view_delta_rewrite: {}",
@@ -292,6 +290,8 @@ public class MvRewritePreprocessor {
                 sessionVariable.isEnableSyncMaterializedViewRewrite());
         logMVPrepare(connectContext, "  enable_view_based_mv_rewrite: {}",
                 sessionVariable.isEnableViewBasedMvRewrite());
+        logMVPrepare(connectContext, "  enable_materialized_view_aggregate_rollup_rewrite: {}",
+                sessionVariable.isEnableMaterializedViewAggregateRollupRewrite());
 
         // limit
         logMVPrepare(connectContext, "---------------------------------");

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/AggregatedMaterializedViewRewriter.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/AggregatedMaterializedViewRewriter.java
@@ -84,7 +84,6 @@ public class AggregatedMaterializedViewRewriter extends MaterializedViewRewriter
             .add(FunctionSet.COUNT)
             .add(FunctionSet.MAX)
             .add(FunctionSet.MIN)
-            .add(FunctionSet.APPROX_COUNT_DISTINCT)
             .add(FunctionSet.BITMAP_UNION)
             .add(FunctionSet.BITMAP_AGG)
             .add(FunctionSet.HLL_UNION)
@@ -142,6 +141,10 @@ public class AggregatedMaterializedViewRewriter extends MaterializedViewRewriter
 
         // Cannot ROLLUP distinct
         if (isRollup) {
+            if (!optimizerContext.getSessionVariable().isEnableMaterializedViewAggregateRollupRewrite()) {
+                logMVRewrite(mvRewriteContext, "Rollup aggregate is disabled");
+                return null;
+            }
             boolean mvHasDistinctAggFunc =
                     mvAggOp.getAggregations().values().stream().anyMatch(callOp -> callOp.isDistinct()
                             && !callOp.getFnName().equalsIgnoreCase(FunctionSet.ARRAY_AGG));

--- a/fe/fe-core/src/test/java/com/starrocks/planner/MaterializedViewTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/planner/MaterializedViewTest.java
@@ -5405,4 +5405,17 @@ public class MaterializedViewTest extends MaterializedViewTestBase {
             testRewriteOK(mv, query);
         }
     }
+
+    @Test
+    public void testAggregateRollupConfig() {
+        String mv = "select deptno as col1, locationid + 1 as b, count(*) as c, sum(empid) as s " +
+                "from emps group by locationid + 1, deptno";
+        connectContext.getSessionVariable().setEnableMaterializedViewAggregateRollupRewrite(true);
+        testRewriteOK(mv, "select count(*) as c, deptno from emps group by deptno");
+        testRewriteOK(mv, "select count(*) as c, locationid + 1 from emps group by locationid + 1");
+        connectContext.getSessionVariable().setEnableMaterializedViewAggregateRollupRewrite(false);
+        testRewriteFail(mv, "select count(*) as c, deptno from emps group by deptno");
+        testRewriteFail(mv, "select count(*) as c, locationid + 1 from emps group by locationid + 1");
+        connectContext.getSessionVariable().setEnableMaterializedViewAggregateRollupRewrite(true);
+    }
 }


### PR DESCRIPTION
## Why I'm doing:
- In some cases,  mv plan after aggregate with rollup rewrite will cost too much time than no rewrite. we can add a config to control whether to support mv rewrite for rollup.

## What I'm doing:

-  add a config to control whether to support mv rewrite for rollup.


## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
