### PR TITLE
[Feature] Update flush_thread_num_per_store default value in shared data mode

### DIFF
--- a/be/src/http/action/update_config_action.cpp
+++ b/be/src/http/action/update_config_action.cpp
@@ -102,7 +102,10 @@ Status UpdateConfigAction::update_config(const std::string& name, const std::str
                     config::max_compaction_concurrency);
         });
         _config_callback.emplace("flush_thread_num_per_store", [&]() {
-            const size_t dir_cnt = StorageEngine::instance()->get_stores().size();
+            size_t dir_cnt = StorageEngine::instance()->get_stores().size();
+#ifdef USE_STAROS
+            dir_cnt = 1;
+#endif
             (void)StorageEngine::instance()->memtable_flush_executor()->update_max_threads(
                     config::flush_thread_num_per_store * dir_cnt);
             (void)StorageEngine::instance()->segment_replicate_executor()->update_max_threads(

--- a/be/test/CMakeLists.txt
+++ b/be/test/CMakeLists.txt
@@ -1,6 +1,7 @@
 set(EXEC_FILES
         ./agent/agent_task_test.cpp
         ./agent/master_info_test.cpp
+        ./agent/heartbeat_server_test.cpp
         ./column/array_column_test.cpp
         ./column/binary_column_test.cpp
         ./column/chunk_test.cpp

--- a/be/test/agent/heartbeat_server_test.cpp
+++ b/be/test/agent/heartbeat_server_test.cpp
@@ -1,0 +1,78 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+#include "agent/heartbeat_server.h"
+
+#include <random>
+
+#include "common/config.h"
+#include "gtest/gtest.h"
+#include "http/action/update_config_action.h"
+#include "service/service_be/http_service.h"
+
+namespace starrocks {
+
+class HeartbeatServerTest : public testing::Test {
+public:
+    HeartbeatServerTest() = default;
+    ~HeartbeatServerTest() override = default;
+
+    void SetUp() override {
+        std::vector<StorePath> paths;
+        StorePath path("/tmp/");
+        paths.push_back(path);
+
+        _exec_env = ExecEnv::GetInstance();
+
+        std::random_device rd;
+        std::mt19937 gen(rd());
+        std::uniform_int_distribution<> distr(config::be_http_port, std::min(config::be_http_port + 100, 65536));
+        auto http_server_port = distr(gen);
+
+        _http_server = std::make_unique<HttpServiceBE>(_exec_env, http_server_port, config::be_http_num_workers);
+        EXPECT_TRUE(_http_server->start().ok());
+    }
+
+    void TearDown() override {
+        _exec_env->wait_for_finish();
+        _exec_env->stop();
+        _http_server->stop();
+        _http_server->join();
+        _http_server.reset();
+        _exec_env->destroy();
+    }
+
+private:
+    ExecEnv* _exec_env;
+    std::unique_ptr<HttpServiceBE> _http_server;
+};
+
+#ifdef USE_STAROS
+TEST_F(HeartbeatServerTest, update_flush_thread_number_test) {
+    TMasterInfo info;
+    TNetworkAddress addr;
+    addr.__set_hostname("127.0.0.1");
+    info.__set_network_address(addr);
+    info.__set_http_port(8030);
+    info.__set_run_mode(TRunMode::SHARED_DATA);
+
+    THeartbeatResult result;
+    HeartbeatServer server;
+    server.heartbeat(result, info);
+
+    static auto num_hardware_cores = static_cast<int32_t>(CpuInfo::num_cores());
+    EXPECT_EQ(config::flush_thread_num_per_store, 2 * num_hardware_cores);
+}
+#endif
+
+} // namespace starrocks


### PR DESCRIPTION
## Why I'm doing:

Default value of 'flush_thread_num_per_store' is 2, which is too small for shared data cluster. This pr increases the default value to 2 * cpu cores

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [x] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [x] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [x] 3.1
  - [ ] 3.0
  - [ ] 2.5
