### PR TITLE
[BugFix] Add more logs for external tables' materialized view creating

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
@@ -1568,10 +1568,10 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
     @VarAttr(name = CBO_MATERIALIZED_VIEW_REWRITE_RELATED_MVS_LIMIT, flag = VariableMgr.INVISIBLE)
     private int cboMaterializedViewRewriteRelatedMVsLimit = 64;
 
-    @VarAttr(name = QUERY_EXCLUDING_MV_NAMES, flag = VariableMgr.INVISIBLE)
+    @VarAttr(name = QUERY_EXCLUDING_MV_NAMES)
     private String queryExcludingMVNames = "";
 
-    @VarAttr(name = QUERY_INCLUDING_MV_NAMES, flag = VariableMgr.INVISIBLE)
+    @VarAttr(name = QUERY_INCLUDING_MV_NAMES)
     private String queryIncludingMVNames = "";
 
     @VarAttr(name = ANALYZE_FOR_MV)

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/OptimizerTraceUtil.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/OptimizerTraceUtil.java
@@ -19,6 +19,7 @@ import com.starrocks.common.profile.Tracers;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.sql.ast.QueryStatement;
 import com.starrocks.sql.common.DebugRelationTracer;
+import com.starrocks.sql.common.QueryDebugOptions;
 import com.starrocks.sql.optimizer.rule.Rule;
 import org.slf4j.helpers.MessageFormatter;
 
@@ -117,5 +118,14 @@ public class OptimizerTraceUtil {
             sb.append("\n");
             return sb.toString();
         });
+    }
+
+    public static boolean isTraceEnabled() {
+        ConnectContext context = ConnectContext.get();
+        if (context == null) {
+            return false;
+        }
+        QueryDebugOptions debugOptions = context.getSessionVariable().getQueryDebugOptions();
+        return debugOptions.isEnableQueryTraceLog();
     }
 }


### PR DESCRIPTION
## Why I'm doing:
In some cases, external tables cannot relate them with materialized views. it's hard to debug where is the problem.

## What I'm doing:

- set query_excluding_mv_names/query_including_mv_names visible to users
- `query_including_mv_names` will always include those mvs even they are not associated with base tables.

```
set query_including_mv_names='mv1,mv2';

set query_debug_options='{"enableQueryTraceLog":"true"}';
```
Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
