### PR TITLE
[UT] improve tpcds test case performance

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/common/FeConstants.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/FeConstants.java
@@ -77,6 +77,8 @@ public class FeConstants {
     public static int checkpoint_interval_second = 60; // 1 minutes
     // set this flag true to skip some step when running FE unit test
     public static boolean runningUnitTest = false;
+    // set this flag false to skip test view in plan test
+    public static boolean unitTestView = true;
     // Set this flag false to suppress showing local shuffle columns in verbose explain, when running FE unit tests.
     public static boolean showScanNodeLocalShuffleColumnsInExplain = true;
     // set to true when replay from query dump

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/TPCDSPushAggTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/TPCDSPushAggTest.java
@@ -15,8 +15,11 @@
 
 package com.starrocks.sql.plan;
 
+import com.starrocks.common.FeConstants;
 import org.apache.commons.lang3.StringUtils;
+import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -25,6 +28,16 @@ import java.util.Arrays;
 import java.util.stream.Stream;
 
 public class TPCDSPushAggTest extends TPCDS1TTestBase {
+    @BeforeAll
+    public static void beforeAll() {
+        FeConstants.unitTestView = false;
+    }
+
+    @AfterAll
+    public static void afterAll() {
+        FeConstants.unitTestView = true;
+    }
+
     private void check(int mode, String sql, int aggNum) throws Exception {
         connectContext.getSessionVariable().setCboPushDownAggregateMode(mode);
         sql = getTPCDS(sql);
@@ -35,7 +48,7 @@ public class TPCDSPushAggTest extends TPCDS1TTestBase {
     }
 
     @ParameterizedTest(name = "{0}")
-    @MethodSource("testCastProvider")
+    @MethodSource("testPushDownProvider")
     public void testTPCDSPushDownAgg(String sql, int orig, int auto, int force, int mid, int high) throws Exception {
         check(-1, sql, orig);
         check(0, sql, auto);
@@ -45,8 +58,29 @@ public class TPCDSPushAggTest extends TPCDS1TTestBase {
     }
 
     @ParameterizedTest(name = "{0}")
-    @MethodSource("testCastProvider")
+    @MethodSource("testUnPushDownProvider")
+    public void testTPCDSUnPushDownAgg(String sql, int orig, int auto, int force, int mid, int high) throws Exception {
+        check(-1, sql, orig);
+        check(0, sql, auto);
+        check(1, sql, force);
+        check(2, sql, mid);
+        check(3, sql, high);
+    }
+
+    //    @ParameterizedTest(name = "{0}")
+    //    @MethodSource("testPushDownProvider")
     public void debugTPCDSPushDownAgg(String sql, int orig, int auto, int force, int mid, int high) throws Exception {
+        orig = getAggNum(-1, sql);
+        auto = getAggNum(0, sql);
+        force = getAggNum(1, sql);
+        mid = getAggNum(2, sql);
+        high = getAggNum(3, sql);
+        System.out.printf("Arguments.of(\"%s\", %d, %d, %d, %d, %d),\n", sql, orig, auto, force, mid, high);
+    }
+
+    //    @ParameterizedTest(name = "{0}")
+    //    @MethodSource("testUnPushDownProvider")
+    public void debugTPCDSUnPushDownAgg(String sql, int orig, int auto, int force, int mid, int high) throws Exception {
         orig = getAggNum(-1, sql);
         auto = getAggNum(0, sql);
         force = getAggNum(1, sql);
@@ -62,7 +96,7 @@ public class TPCDSPushAggTest extends TPCDS1TTestBase {
         return StringUtils.countMatches(plan, ":AGGREGATE ");
     }
 
-    private static Stream<Arguments> testCastProvider() {
+    private static Stream<Arguments> testPushDownProvider() {
         // orig(-1), auto(0), force(1), mid(2), high(3)
         Arguments[] cases = new Arguments[] {
                 Arguments.of("Q01", 4, 4, 6, 4, 6),
@@ -70,55 +104,26 @@ public class TPCDSPushAggTest extends TPCDS1TTestBase {
                 Arguments.of("Q03", 2, 4, 4, 4, 4),
                 Arguments.of("Q04", 12, 10, 12, 10, 12),
                 Arguments.of("Q05", 8, 16, 16, 16, 16),
-                Arguments.of("Q06", 6, 6, 6, 6, 6),
-                Arguments.of("Q07", 2, 2, 2, 2, 2),
                 Arguments.of("Q08", 4, 6, 6, 6, 6),
-                Arguments.of("Q09", 30, 30, 30, 30, 30),
-                Arguments.of("Q10", 2, 2, 2, 2, 2),
                 Arguments.of("Q11", 8, 6, 8, 6, 8),
                 Arguments.of("Q12", 2, 4, 4, 4, 4),
-                Arguments.of("Q13", 2, 2, 2, 2, 2),
-                Arguments.of("Q14_1", 16, 16, 16, 16, 16),
-                Arguments.of("Q14_2", 12, 12, 12, 12, 12),
                 Arguments.of("Q15", 2, 4, 4, 4, 4),
-                Arguments.of("Q16", 4, 4, 4, 4, 4),
-                Arguments.of("Q17", 2, 2, 2, 2, 2),
-                Arguments.of("Q18", 2, 2, 2, 2, 2),
                 Arguments.of("Q19", 2, 2, 4, 2, 2),
                 Arguments.of("Q20", 2, 4, 4, 4, 4),
-                Arguments.of("Q21", 2, 2, 2, 2, 2),
-                Arguments.of("Q22", 2, 2, 2, 2, 2),
                 Arguments.of("Q23_1", 10, 13, 13, 13, 13),
-                // Arguments.of("Q23_2", 11, 16, 18, 16, 18),
                 Arguments.of("Q24_1", 6, 6, 7, 6, 6),
                 Arguments.of("Q24_2", 6, 6, 7, 6, 6),
-                Arguments.of("Q25", 2, 2, 2, 2, 2),
-                Arguments.of("Q26", 2, 2, 2, 2, 2),
-                Arguments.of("Q27", 2, 2, 2, 2, 2),
-                Arguments.of("Q28", 24, 24, 24, 24, 24),
-                Arguments.of("Q29", 2, 2, 2, 2, 2),
                 Arguments.of("Q30", 4, 4, 6, 4, 4),
                 Arguments.of("Q31", 4, 8, 8, 8, 8),
-                Arguments.of("Q32", 4, 4, 4, 4, 4),
                 Arguments.of("Q33", 8, 14, 14, 14, 14),
-                Arguments.of("Q34", 2, 2, 2, 2, 2),
-                Arguments.of("Q35", 2, 2, 2, 2, 2),
-                Arguments.of("Q36", 2, 2, 2, 2, 2),
                 Arguments.of("Q37", 2, 6, 8, 6, 7),
                 Arguments.of("Q38", 8, 12, 20, 12, 17),
-                Arguments.of("Q39_1", 2, 2, 2, 2, 2),
-                Arguments.of("Q39_2", 2, 2, 2, 2, 2),
-                Arguments.of("Q40", 2, 2, 2, 2, 2),
                 Arguments.of("Q41", 4, 4, 6, 4, 4),
                 Arguments.of("Q42", 2, 4, 4, 4, 4),
                 Arguments.of("Q43", 2, 4, 4, 4, 4),
-                Arguments.of("Q44", 8, 8, 8, 8, 8),
                 Arguments.of("Q45", 6, 6, 8, 6, 8),
                 Arguments.of("Q46", 2, 2, 4, 2, 2),
                 Arguments.of("Q47", 2, 2, 4, 4, 4),
-                Arguments.of("Q48", 2, 2, 2, 2, 2),
-                Arguments.of("Q49", 8, 8, 8, 8, 8),
-                Arguments.of("Q50", 2, 2, 2, 2, 2),
                 Arguments.of("Q51", 4, 8, 8, 8, 8),
                 Arguments.of("Q52", 2, 4, 4, 4, 4),
                 Arguments.of("Q53", 2, 2, 4, 4, 4),
@@ -129,44 +134,80 @@ public class TPCDSPushAggTest extends TPCDS1TTestBase {
                 Arguments.of("Q58", 6, 12, 12, 12, 12),
                 Arguments.of("Q59", 2, 4, 4, 4, 4),
                 Arguments.of("Q60", 8, 14, 14, 14, 14),
-                Arguments.of("Q61", 4, 4, 4, 4, 4),
-                Arguments.of("Q62", 2, 2, 2, 2, 2),
                 Arguments.of("Q63", 2, 2, 4, 4, 4),
-                Arguments.of("Q64", 4, 4, 4, 4, 4),
                 Arguments.of("Q65", 6, 6, 10, 10, 10),
-                Arguments.of("Q66", 6, 6, 6, 6, 6),
-                Arguments.of("Q67", 2, 2, 2, 2, 2),
                 Arguments.of("Q68", 1, 1, 3, 1, 1),
-                Arguments.of("Q69", 2, 2, 2, 2, 2),
                 Arguments.of("Q70", 4, 6, 6, 6, 6),
                 Arguments.of("Q71", 2, 2, 8, 8, 8),
-                Arguments.of("Q72", 2, 2, 2, 2, 2),
-                Arguments.of("Q73", 2, 2, 2, 2, 2),
                 Arguments.of("Q74", 8, 12, 8, 12, 8),
                 Arguments.of("Q75", 4, 4, 16, 4, 4),
-                Arguments.of("Q76", 2, 2, 2, 2, 2),
                 Arguments.of("Q77", 14, 26, 26, 26, 26),
                 Arguments.of("Q78", 6, 6, 9, 6, 6),
                 Arguments.of("Q79", 2, 2, 4, 2, 2),
-                Arguments.of("Q80", 8, 8, 8, 8, 8),
                 Arguments.of("Q81", 4, 4, 6, 4, 4),
                 Arguments.of("Q82", 2, 6, 8, 6, 7),
                 Arguments.of("Q83", 6, 12, 12, 12, 12),
-                Arguments.of("Q84", 0, 0, 0, 0, 0),
-                Arguments.of("Q85", 2, 2, 2, 2, 2),
-                Arguments.of("Q86", 2, 2, 2, 2, 2),
                 Arguments.of("Q87", 8, 12, 20, 12, 17),
                 Arguments.of("Q88", 16, 16, 16, 16, 16),
                 Arguments.of("Q89", 2, 2, 4, 4, 4),
-                Arguments.of("Q90", 4, 4, 4, 4, 4),
                 Arguments.of("Q91", 2, 2, 4, 2, 4),
+                Arguments.of("Q97", 6, 10, 12, 10, 12),
+                Arguments.of("Q98", 2, 4, 4, 4, 4),
+        };
+
+        return Arrays.stream(cases);
+    }
+
+    private static Stream<Arguments> testUnPushDownProvider() {
+        // orig(-1), auto(0), force(1), mid(2), high(3)
+        Arguments[] cases = new Arguments[] {
+                Arguments.of("Q06", 6, 6, 6, 6, 6),
+                Arguments.of("Q07", 2, 2, 2, 2, 2),
+                Arguments.of("Q09", 30, 30, 30, 30, 30),
+                Arguments.of("Q10", 2, 2, 2, 2, 2),
+                Arguments.of("Q13", 2, 2, 2, 2, 2),
+                Arguments.of("Q14_1", 16, 16, 16, 16, 16),
+                Arguments.of("Q14_2", 12, 12, 12, 12, 12),
+                Arguments.of("Q16", 4, 4, 4, 4, 4),
+                Arguments.of("Q17", 2, 2, 2, 2, 2),
+                Arguments.of("Q18", 2, 2, 2, 2, 2),
+                Arguments.of("Q21", 2, 2, 2, 2, 2),
+                Arguments.of("Q22", 2, 2, 2, 2, 2),
+                Arguments.of("Q25", 2, 2, 2, 2, 2),
+                Arguments.of("Q26", 2, 2, 2, 2, 2),
+                Arguments.of("Q27", 2, 2, 2, 2, 2),
+                Arguments.of("Q28", 24, 24, 24, 24, 24),
+                Arguments.of("Q29", 2, 2, 2, 2, 2),
+                Arguments.of("Q32", 4, 4, 4, 4, 4),
+                Arguments.of("Q34", 2, 2, 2, 2, 2),
+                Arguments.of("Q35", 2, 2, 2, 2, 2),
+                Arguments.of("Q36", 2, 2, 2, 2, 2),
+                Arguments.of("Q39_1", 2, 2, 2, 2, 2),
+                Arguments.of("Q39_2", 2, 2, 2, 2, 2),
+                Arguments.of("Q40", 2, 2, 2, 2, 2),
+                Arguments.of("Q44", 8, 8, 8, 8, 8),
+                Arguments.of("Q48", 2, 2, 2, 2, 2),
+                Arguments.of("Q49", 8, 8, 8, 8, 8),
+                Arguments.of("Q50", 2, 2, 2, 2, 2),
+                Arguments.of("Q61", 4, 4, 4, 4, 4),
+                Arguments.of("Q62", 2, 2, 2, 2, 2),
+                Arguments.of("Q64", 4, 4, 4, 4, 4),
+                Arguments.of("Q66", 6, 6, 6, 6, 6),
+                Arguments.of("Q67", 2, 2, 2, 2, 2),
+                Arguments.of("Q69", 2, 2, 2, 2, 2),
+                Arguments.of("Q72", 2, 2, 2, 2, 2),
+                Arguments.of("Q73", 2, 2, 2, 2, 2),
+                Arguments.of("Q76", 2, 2, 2, 2, 2),
+                Arguments.of("Q80", 8, 8, 8, 8, 8),
+                Arguments.of("Q84", 0, 0, 0, 0, 0),
+                Arguments.of("Q85", 2, 2, 2, 2, 2),
+                Arguments.of("Q86", 2, 2, 2, 2, 2),
+                Arguments.of("Q90", 4, 4, 4, 4, 4),
                 Arguments.of("Q92", 4, 4, 4, 4, 4),
                 Arguments.of("Q93", 2, 2, 2, 2, 2),
                 Arguments.of("Q94", 4, 4, 4, 4, 4),
                 Arguments.of("Q95", 4, 4, 4, 4, 4),
                 Arguments.of("Q96", 2, 2, 2, 2, 2),
-                Arguments.of("Q97", 6, 10, 12, 10, 12),
-                Arguments.of("Q98", 2, 4, 4, 4, 4),
                 Arguments.of("Q99", 2, 2, 2, 2, 2),
         };
 

--- a/fe/fe-core/src/test/java/com/starrocks/utframe/UtFrameUtils.java
+++ b/fe/fe-core/src/test/java/com/starrocks/utframe/UtFrameUtils.java
@@ -614,6 +614,9 @@ public class UtFrameUtils {
 
     private static void testView(ConnectContext connectContext, String originStmt, StatementBase statementBase)
             throws Exception {
+        if (!FeConstants.unitTestView) {
+            return;
+        }
         if (statementBase instanceof QueryStatement && !connectContext.getDatabase().isEmpty() &&
                 !statementBase.isExplain()) {
             String viewName = "view" + INDEX.getAndIncrement();


### PR DESCRIPTION
## Why I'm doing:
improve the performance of TPCDSPushAggTest

1. don't test unused view (save 2s)
2. split test cast to two group

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [x] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
