### PR TITLE
[BugFix] Fixed incorrect schema id in CreateReplicaTask

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/alter/LakeTableSchemaChangeJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/LakeTableSchemaChangeJob.java
@@ -336,7 +336,7 @@ public class LakeTableSchemaChangeJob extends AlterJobV2 {
                         sortKeyIdxes = copiedSortKeyIdxes;
                     }
 
-                    TTabletSchema tabletSchema = SchemaInfo.builder()
+                    TTabletSchema tabletSchema = SchemaInfo.newBuilder()
                             .setId(shadowIdxId) // For newly create materialized index, schema id equals to index id
                             .setKeysType(originKeysType)
                             .setShortKeyColumnCount(shadowShortKeyColumnCount)
@@ -360,7 +360,7 @@ public class LakeTableSchemaChangeJob extends AlterJobV2 {
                         }
                         countDownLatch.addMark(backendId, shadowTabletId);
 
-                        CreateReplicaTask task = CreateReplicaTask.builder()
+                        CreateReplicaTask task = CreateReplicaTask.newBuilder()
                                 .setNodeId(backendId)
                                 .setDbId(dbId)
                                 .setTableId(tableId)

--- a/fe/fe-core/src/main/java/com/starrocks/alter/LakeTableSchemaChangeJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/LakeTableSchemaChangeJob.java
@@ -337,7 +337,7 @@ public class LakeTableSchemaChangeJob extends AlterJobV2 {
                     }
 
                     TTabletSchema tabletSchema = SchemaInfo.builder()
-                            .setId(shadowIdxId)
+                            .setId(shadowIdxId) // For newly create materialized index, schema id equals to index id
                             .setKeysType(originKeysType)
                             .setShortKeyColumnCount(shadowShortKeyColumnCount)
                             .setSortKeyUniqueIds(copiedSortKeyIdxes)
@@ -374,6 +374,7 @@ public class LakeTableSchemaChangeJob extends AlterJobV2 {
                                 .setTabletType(TTabletType.TABLET_TYPE_LAKE)
                                 .setCompressionType(table.getCompressionType())
                                 .setCreateSchemaFile(createSchemaFile)
+                                .setTabletSchema(tabletSchema)
                                 .build();
                         // For each partition, the schema file is created only when the first Tablet is created
                         createSchemaFile = false;

--- a/fe/fe-core/src/main/java/com/starrocks/alter/LakeTableSchemaChangeJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/LakeTableSchemaChangeJob.java
@@ -347,6 +347,7 @@ public class LakeTableSchemaChangeJob extends AlterJobV2 {
                             .setBloomFilterFpp(bfFpp)
                             .setStorageType(TStorageType.COLUMN)
                             .addColumns(shadowSchema)
+                            .setSchemaHash(0)
                             .build().toTabletSchema();
 
                     boolean createSchemaFile = true;

--- a/fe/fe-core/src/main/java/com/starrocks/alter/LakeTableSchemaChangeJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/LakeTableSchemaChangeJob.java
@@ -34,6 +34,7 @@ import com.starrocks.catalog.MvId;
 import com.starrocks.catalog.OlapTable;
 import com.starrocks.catalog.Partition;
 import com.starrocks.catalog.PhysicalPartition;
+import com.starrocks.catalog.SchemaInfo;
 import com.starrocks.catalog.Tablet;
 import com.starrocks.catalog.TabletInvertedIndex;
 import com.starrocks.catalog.TabletMeta;
@@ -64,6 +65,7 @@ import com.starrocks.task.AlterReplicaTask;
 import com.starrocks.task.CreateReplicaTask;
 import com.starrocks.thrift.TStorageMedium;
 import com.starrocks.thrift.TStorageType;
+import com.starrocks.thrift.TTabletSchema;
 import com.starrocks.thrift.TTabletType;
 import com.starrocks.thrift.TTaskType;
 import com.starrocks.transaction.GlobalTransactionMgr;
@@ -334,6 +336,19 @@ public class LakeTableSchemaChangeJob extends AlterJobV2 {
                         sortKeyIdxes = copiedSortKeyIdxes;
                     }
 
+                    TTabletSchema tabletSchema = SchemaInfo.builder()
+                            .setId(shadowIdxId)
+                            .setKeysType(originKeysType)
+                            .setShortKeyColumnCount(shadowShortKeyColumnCount)
+                            .setSortKeyUniqueIds(copiedSortKeyIdxes)
+                            .setSortKeyUniqueIds(null)
+                            .setIndexes(indexes)
+                            .setBloomFilterColumnNames(bfColumns)
+                            .setBloomFilterFpp(bfFpp)
+                            .setStorageType(TStorageType.COLUMN)
+                            .addColumns(shadowSchema)
+                            .build().toTabletSchema();
+
                     boolean createSchemaFile = true;
                     for (Tablet shadowTablet : shadowIdx.getTablets()) {
                         long shadowTabletId = shadowTablet.getId();
@@ -343,20 +358,26 @@ public class LakeTableSchemaChangeJob extends AlterJobV2 {
                             throw new AlterCancelException("No alive backend");
                         }
                         countDownLatch.addMark(backendId, shadowTabletId);
-                        // No need to set base tablet id for CreateReplicaTask
-                        CreateReplicaTask createReplicaTask =
-                                new CreateReplicaTask(backendId, dbId, tableId, partitionId,
-                                        shadowIdxId, shadowTabletId, shadowShortKeyColumnCount, 0,
-                                        Partition.PARTITION_INIT_VERSION,
-                                        originKeysType, TStorageType.COLUMN, storageMedium, shadowSchema,
-                                        bfColumns, bfFpp,
-                                        countDownLatch, indexes, table.isInMemory(), table.enablePersistentIndex(),
-                                        table.primaryIndexCacheExpireSec(), TTabletType.TABLET_TYPE_LAKE,
-                                        table.getCompressionType(),
-                                        copiedSortKeyIdxes, null, createSchemaFile);
+
+                        CreateReplicaTask task = CreateReplicaTask.builder()
+                                .setNodeId(backendId)
+                                .setDbId(dbId)
+                                .setTableId(tableId)
+                                .setPartitionId(partitionId)
+                                .setIndexId(shadowIdxId)
+                                .setTabletId(shadowTabletId)
+                                .setVersion(Partition.PARTITION_INIT_VERSION)
+                                .setStorageMedium(storageMedium)
+                                .setLatch(countDownLatch)
+                                .setEnablePersistentIndex(table.enablePersistentIndex())
+                                .setPrimaryIndexCacheExpireSec(table.primaryIndexCacheExpireSec())
+                                .setTabletType(TTabletType.TABLET_TYPE_LAKE)
+                                .setCompressionType(table.getCompressionType())
+                                .setCreateSchemaFile(createSchemaFile)
+                                .build();
                         // For each partition, the schema file is created only when the first Tablet is created
                         createSchemaFile = false;
-                        batchTask.addTask(createReplicaTask);
+                        batchTask.addTask(task);
                     }
                 }
             }

--- a/fe/fe-core/src/main/java/com/starrocks/alter/RollupJobV2.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/RollupJobV2.java
@@ -260,7 +260,7 @@ public class RollupJobV2 extends AlterJobV2 implements GsonPostProcessable {
                 TTabletType tabletType = tbl.getPartitionInfo().getTabletType(partition.getParentId());
                 MaterializedIndex rollupIndex = entry.getValue();
 
-                TTabletSchema tabletSchema = SchemaInfo.builder()
+                TTabletSchema tabletSchema = SchemaInfo.newBuilder()
                         .setId(rollupIndexId) // For newly created materialized, schema id equals to index id
                         .setVersion(rollupSchemaVersion)
                         .setKeysType(rollupKeysType)
@@ -283,7 +283,7 @@ public class RollupJobV2 extends AlterJobV2 implements GsonPostProcessable {
                         long backendId = rollupReplica.getBackendId();
                         Preconditions.checkNotNull(tabletIdMap.get(rollupTabletId)); // baseTabletId
                         countDownLatch.addMark(backendId, rollupTabletId);
-                        CreateReplicaTask task = CreateReplicaTask.builder()
+                        CreateReplicaTask task = CreateReplicaTask.newBuilder()
                                 .setNodeId(backendId)
                                 .setDbId(dbId)
                                 .setTableId(tableId)

--- a/fe/fe-core/src/main/java/com/starrocks/alter/RollupJobV2.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/RollupJobV2.java
@@ -63,6 +63,7 @@ import com.starrocks.catalog.PrimitiveType;
 import com.starrocks.catalog.Replica;
 import com.starrocks.catalog.Replica.ReplicaState;
 import com.starrocks.catalog.ScalarType;
+import com.starrocks.catalog.SchemaInfo;
 import com.starrocks.catalog.Tablet;
 import com.starrocks.catalog.TabletInvertedIndex;
 import com.starrocks.catalog.TabletMeta;
@@ -95,6 +96,7 @@ import com.starrocks.task.AlterReplicaTask;
 import com.starrocks.task.CreateReplicaTask;
 import com.starrocks.thrift.TStorageMedium;
 import com.starrocks.thrift.TStorageType;
+import com.starrocks.thrift.TTabletSchema;
 import com.starrocks.thrift.TTabletType;
 import com.starrocks.thrift.TTaskType;
 import io.opentelemetry.api.trace.StatusCode;
@@ -258,6 +260,20 @@ public class RollupJobV2 extends AlterJobV2 implements GsonPostProcessable {
                 TTabletType tabletType = tbl.getPartitionInfo().getTabletType(partition.getParentId());
                 MaterializedIndex rollupIndex = entry.getValue();
 
+                TTabletSchema tabletSchema = SchemaInfo.builder()
+                        .setId(rollupIndexId)
+                        .setVersion(rollupSchemaVersion)
+                        .setKeysType(rollupKeysType)
+                        .setShortKeyColumnCount(rollupShortKeyColumnCount)
+                        .setStorageType(TStorageType.COLUMN)
+                        .setBloomFilterColumnNames(tbl.getCopiedBfColumns())
+                        .setBloomFilterFpp(tbl.getBfFpp())
+                        .setIndexes(tbl.getCopiedIndexes())
+                        .setSortKeyIndexes(null) // Rollup tablets does not have sort key
+                        .setSortKeyUniqueIds(null)
+                        .addColumns(rollupSchema)
+                        .build().toTabletSchema();
+
                 Map<Long, Long> tabletIdMap = this.physicalPartitionIdToBaseRollupTabletIdMap.get(partitionId);
                 for (Tablet rollupTablet : rollupIndex.getTablets()) {
                     long rollupTabletId = rollupTablet.getId();
@@ -266,23 +282,25 @@ public class RollupJobV2 extends AlterJobV2 implements GsonPostProcessable {
                         long backendId = rollupReplica.getBackendId();
                         Preconditions.checkNotNull(tabletIdMap.get(rollupTabletId)); // baseTabletId
                         countDownLatch.addMark(backendId, rollupTabletId);
-                        // create replica with version 1.
-                        // version will be updated by following load process, or when rollup task finished.
-                        CreateReplicaTask createReplicaTask = new CreateReplicaTask(
-                                backendId, dbId, tableId, partitionId, rollupIndexId, rollupTabletId,
-                                rollupShortKeyColumnCount, rollupSchemaHash,
-                                Partition.PARTITION_INIT_VERSION,
-                                rollupKeysType, TStorageType.COLUMN, storageMedium,
-                                rollupSchema, tbl.getCopiedBfColumns(), tbl.getBfFpp(), countDownLatch,
-                                tbl.getCopiedIndexes(),
-                                tbl.isInMemory(),
-                                tbl.enablePersistentIndex(),
-                                tbl.primaryIndexCacheExpireSec(),
-                                tabletType, tbl.getCompressionType(), null,
-                                null, true);
-                        createReplicaTask.setBaseTablet(tabletIdMap.get(rollupTabletId), baseSchemaHash);
-                        createReplicaTask.setSchemaVersion(rollupSchemaVersion);
-                        batchTask.addTask(createReplicaTask);
+                        CreateReplicaTask task = CreateReplicaTask.builder()
+                                .setNodeId(backendId)
+                                .setDbId(dbId)
+                                .setTableId(tableId)
+                                .setPartitionId(partitionId)
+                                .setIndexId(rollupIndexId)
+                                .setTabletId(rollupTabletId)
+                                .setVersion(Partition.PARTITION_INIT_VERSION)
+                                .setStorageMedium(storageMedium)
+                                .setLatch(countDownLatch)
+                                .setEnablePersistentIndex(tbl.enablePersistentIndex())
+                                .setPrimaryIndexCacheExpireSec(tbl.primaryIndexCacheExpireSec())
+                                .setTabletType(tabletType)
+                                .setCompressionType(tbl.getCompressionType())
+                                .setCreateSchemaFile(true)
+                                .setBaseTabletId(tabletIdMap.get(rollupTabletId))
+                                .setTabletSchema(tabletSchema)
+                                .build();
+                        batchTask.addTask(task);
                     } // end for rollupReplicas
                 } // end for rollupTablets
             }

--- a/fe/fe-core/src/main/java/com/starrocks/alter/RollupJobV2.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/RollupJobV2.java
@@ -265,6 +265,7 @@ public class RollupJobV2 extends AlterJobV2 implements GsonPostProcessable {
                         .setVersion(rollupSchemaVersion)
                         .setKeysType(rollupKeysType)
                         .setShortKeyColumnCount(rollupShortKeyColumnCount)
+                        .setSchemaHash(rollupSchemaHash)
                         .setStorageType(TStorageType.COLUMN)
                         .setBloomFilterColumnNames(tbl.getCopiedBfColumns())
                         .setBloomFilterFpp(tbl.getBfFpp())

--- a/fe/fe-core/src/main/java/com/starrocks/alter/RollupJobV2.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/RollupJobV2.java
@@ -261,7 +261,7 @@ public class RollupJobV2 extends AlterJobV2 implements GsonPostProcessable {
                 MaterializedIndex rollupIndex = entry.getValue();
 
                 TTabletSchema tabletSchema = SchemaInfo.builder()
-                        .setId(rollupIndexId)
+                        .setId(rollupIndexId) // For newly created materialized, schema id equals to index id
                         .setVersion(rollupSchemaVersion)
                         .setKeysType(rollupKeysType)
                         .setShortKeyColumnCount(rollupShortKeyColumnCount)

--- a/fe/fe-core/src/main/java/com/starrocks/alter/SchemaChangeJobV2.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/SchemaChangeJobV2.java
@@ -314,7 +314,7 @@ public class SchemaChangeJobV2 extends AlterJobV2 {
                     long originIndexId = indexIdMap.get(shadowIdxId);
                     KeysType originKeysType = tbl.getKeysTypeByIndexId(originIndexId);
                     List<Column> originSchema = tbl.getSchemaByIndexId(originIndexId);
-                    TTabletSchema tabletSchema = SchemaInfo.builder()
+                    TTabletSchema tabletSchema = SchemaInfo.newBuilder()
                             .setId(shadowIdxId) // For newly created materialized, schema id equals to index id
                             .setKeysType(originKeysType)
                             .setShortKeyColumnCount(shadowShortKeyColumnCount)
@@ -336,7 +336,7 @@ public class SchemaChangeJobV2 extends AlterJobV2 {
                         for (Replica shadowReplica : shadowReplicas) {
                             long backendId = shadowReplica.getBackendId();
                             countDownLatch.addMark(backendId, shadowTabletId);
-                            CreateReplicaTask task = CreateReplicaTask.builder()
+                            CreateReplicaTask task = CreateReplicaTask.newBuilder()
                                     .setNodeId(backendId)
                                     .setDbId(dbId)
                                     .setTableId(tableId)

--- a/fe/fe-core/src/main/java/com/starrocks/alter/SchemaChangeJobV2.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/SchemaChangeJobV2.java
@@ -314,7 +314,7 @@ public class SchemaChangeJobV2 extends AlterJobV2 {
                     KeysType originKeysType = tbl.getKeysTypeByIndexId(originIndexId);
                     List<Column> originSchema = tbl.getSchemaByIndexId(originIndexId);
                     TTabletSchema tabletSchema = SchemaInfo.builder()
-                            .setId(shadowIdxId)
+                            .setId(shadowIdxId) // For newly created materialized, schema id equals to index id
                             .setKeysType(originKeysType)
                             .setShortKeyColumnCount(shadowShortKeyColumnCount)
                             .setVersion(shadowSchemaVersion)

--- a/fe/fe-core/src/main/java/com/starrocks/alter/SchemaChangeJobV2.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/SchemaChangeJobV2.java
@@ -63,6 +63,7 @@ import com.starrocks.catalog.Partition;
 import com.starrocks.catalog.PhysicalPartition;
 import com.starrocks.catalog.Replica;
 import com.starrocks.catalog.Replica.ReplicaState;
+import com.starrocks.catalog.SchemaInfo;
 import com.starrocks.catalog.Tablet;
 import com.starrocks.catalog.TabletInvertedIndex;
 import com.starrocks.catalog.TabletMeta;
@@ -100,6 +101,7 @@ import com.starrocks.thrift.TQueryGlobals;
 import com.starrocks.thrift.TQueryOptions;
 import com.starrocks.thrift.TStorageMedium;
 import com.starrocks.thrift.TStorageType;
+import com.starrocks.thrift.TTabletSchema;
 import com.starrocks.thrift.TTaskType;
 import io.opentelemetry.api.trace.StatusCode;
 import org.apache.logging.log4j.LogManager;
@@ -307,35 +309,49 @@ public class SchemaChangeJobV2 extends AlterJobV2 {
 
                     short shadowShortKeyColumnCount = indexShortKeyMap.get(shadowIdxId);
                     List<Column> shadowSchema = indexSchemaMap.get(shadowIdxId);
-                    int shadowSchemaHash = indexSchemaVersionAndHashMap.get(shadowIdxId).schemaHash;
                     int shadowSchemaVersion = indexSchemaVersionAndHashMap.get(shadowIdxId).schemaVersion;
                     long originIndexId = indexIdMap.get(shadowIdxId);
-                    int originSchemaHash = tbl.getSchemaHashByIndexId(originIndexId);
                     KeysType originKeysType = tbl.getKeysTypeByIndexId(originIndexId);
                     List<Column> originSchema = tbl.getSchemaByIndexId(originIndexId);
-
+                    TTabletSchema tabletSchema = SchemaInfo.builder()
+                            .setId(shadowIdxId)
+                            .setKeysType(originKeysType)
+                            .setShortKeyColumnCount(shadowShortKeyColumnCount)
+                            .setVersion(shadowSchemaVersion)
+                            .setStorageType(tbl.getStorageType())
+                            .setBloomFilterColumnNames(bfColumns)
+                            .setBloomFilterFpp(bfFpp)
+                            .setIndexes(indexes)
+                            .setSortKeyIndexes(originIndexId == baseIndexId ? sortKeyIdxes : null)
+                            .setSortKeyUniqueIds(originIndexId == baseIndexId ? sortKeyUniqueIds : null)
+                            .addColumns(shadowSchema)
+                            .build().toTabletSchema();
                     for (Tablet shadowTablet : shadowIdx.getTablets()) {
                         long shadowTabletId = shadowTablet.getId();
                         List<Replica> shadowReplicas = ((LocalTablet) shadowTablet).getImmutableReplicas();
+                        long baseTabletId = physicalPartitionIndexTabletMap.get(partitionId, shadowIdxId)
+                                .get(shadowTabletId);
                         for (Replica shadowReplica : shadowReplicas) {
                             long backendId = shadowReplica.getBackendId();
                             countDownLatch.addMark(backendId, shadowTabletId);
-                            CreateReplicaTask createReplicaTask = new CreateReplicaTask(
-                                    backendId, dbId, tableId, partitionId, shadowIdxId, shadowTabletId,
-                                    shadowShortKeyColumnCount, shadowSchemaHash, shadowSchemaVersion,
-                                    Partition.PARTITION_INIT_VERSION,
-                                    originKeysType, tbl.getStorageType(), storageMedium,
-                                    shadowSchema, bfColumns, bfFpp, countDownLatch, indexes,
-                                    tbl.isInMemory(),
-                                    tbl.enablePersistentIndex(),
-                                    tbl.primaryIndexCacheExpireSec(),
-                                    tbl.getPartitionInfo().getTabletType(partition.getParentId()),
-                                    tbl.getCompressionType(), originIndexId == baseIndexId ? sortKeyIdxes : null,
-                                    originIndexId == baseIndexId ? sortKeyUniqueIds : null);
-                            createReplicaTask.setBaseTablet(
-                                    physicalPartitionIndexTabletMap.get(partitionId, shadowIdxId).get(shadowTabletId),
-                                    originSchemaHash);
-                            batchTask.addTask(createReplicaTask);
+                            CreateReplicaTask task = CreateReplicaTask.builder()
+                                    .setNodeId(backendId)
+                                    .setDbId(dbId)
+                                    .setTableId(tableId)
+                                    .setPartitionId(partitionId)
+                                    .setIndexId(shadowIdxId)
+                                    .setTabletId(shadowTabletId)
+                                    .setVersion(Partition.PARTITION_INIT_VERSION)
+                                    .setStorageMedium(storageMedium)
+                                    .setLatch(countDownLatch)
+                                    .setEnablePersistentIndex(tbl.enablePersistentIndex())
+                                    .setPrimaryIndexCacheExpireSec(tbl.primaryIndexCacheExpireSec())
+                                    .setTabletType(tbl.getPartitionInfo().getTabletType(partition.getParentId()))
+                                    .setCompressionType(tbl.getCompressionType())
+                                    .setBaseTabletId(baseTabletId)
+                                    .setTabletSchema(tabletSchema)
+                                    .build();
+                            batchTask.addTask(task);
                         } // end for rollupReplicas
                     } // end for rollupTablets
                 }
@@ -511,7 +527,7 @@ public class SchemaChangeJobV2 extends AlterJobV2 {
                         Map<String, SlotDescriptor> slotDescByName = new HashMap<>();
 
                         /*
-                          * The expression substitution is needed here, because all slotRefs in 
+                          * The expression substitution is needed here, because all slotRefs in
                           * GeneratedColumnExpr are still is unAnalyzed. slotRefs get isAnalyzed == true
                           * if it is init by SlotDescriptor. The slot information will be used by be to indentify
                           * the column location in a chunk.

--- a/fe/fe-core/src/main/java/com/starrocks/alter/SchemaChangeJobV2.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/SchemaChangeJobV2.java
@@ -309,6 +309,7 @@ public class SchemaChangeJobV2 extends AlterJobV2 {
 
                     short shadowShortKeyColumnCount = indexShortKeyMap.get(shadowIdxId);
                     List<Column> shadowSchema = indexSchemaMap.get(shadowIdxId);
+                    int shadowSchemaHash = indexSchemaVersionAndHashMap.get(shadowIdxId).schemaHash;
                     int shadowSchemaVersion = indexSchemaVersionAndHashMap.get(shadowIdxId).schemaVersion;
                     long originIndexId = indexIdMap.get(shadowIdxId);
                     KeysType originKeysType = tbl.getKeysTypeByIndexId(originIndexId);
@@ -317,6 +318,7 @@ public class SchemaChangeJobV2 extends AlterJobV2 {
                             .setId(shadowIdxId) // For newly created materialized, schema id equals to index id
                             .setKeysType(originKeysType)
                             .setShortKeyColumnCount(shadowShortKeyColumnCount)
+                            .setSchemaHash(shadowSchemaHash)
                             .setVersion(shadowSchemaVersion)
                             .setStorageType(tbl.getStorageType())
                             .setBloomFilterColumnNames(bfColumns)

--- a/fe/fe-core/src/main/java/com/starrocks/backup/RestoreJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/backup/RestoreJob.java
@@ -896,7 +896,7 @@ public class RestoreJob extends AbstractJob {
                 MaterializedIndexMeta indexMeta = localTbl.getIndexMetaByIndexId(restoredIdx.getId());
                 TabletMeta tabletMeta = new TabletMeta(dbId, localTbl.getId(), physicalPartition.getId(),
                         restoredIdx.getId(), indexMeta.getSchemaHash(), TStorageMedium.HDD);
-                TTabletSchema tabletSchema = SchemaInfo.builder()
+                TTabletSchema tabletSchema = SchemaInfo.newBuilder()
                         .setId(indexMeta.getSchemaId())
                         .setKeysType(indexMeta.getKeysType())
                         .setShortKeyColumnCount(indexMeta.getShortKeyColumnCount())
@@ -917,7 +917,7 @@ public class RestoreJob extends AbstractJob {
                         LOG.info("tablet {} physical partition {} index {} replica {}",
                                 restoreTablet.getId(), physicalPartition.getId(), restoredIdx.getId(),
                                 restoreReplica.getId());
-                        CreateReplicaTask task = CreateReplicaTask.builder()
+                        CreateReplicaTask task = CreateReplicaTask.newBuilder()
                                 .setNodeId(restoreReplica.getBackendId())
                                 .setDbId(dbId)
                                 .setTableId(localTbl.getId())

--- a/fe/fe-core/src/main/java/com/starrocks/backup/RestoreJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/backup/RestoreJob.java
@@ -900,6 +900,7 @@ public class RestoreJob extends AbstractJob {
                         .setId(indexMeta.getSchemaId())
                         .setKeysType(indexMeta.getKeysType())
                         .setShortKeyColumnCount(indexMeta.getShortKeyColumnCount())
+                        .setSchemaHash(indexMeta.getSchemaHash())
                         .setSortKeyIndexes(indexMeta.getSortKeyIdxes())
                         .setSortKeyUniqueIds(indexMeta.getSortKeyUniqueIds())
                         .setStorageType(indexMeta.getStorageType())

--- a/fe/fe-core/src/main/java/com/starrocks/backup/RestoreJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/backup/RestoreJob.java
@@ -71,6 +71,7 @@ import com.starrocks.catalog.PartitionKey;
 import com.starrocks.catalog.PhysicalPartition;
 import com.starrocks.catalog.RangePartitionInfo;
 import com.starrocks.catalog.Replica;
+import com.starrocks.catalog.SchemaInfo;
 import com.starrocks.catalog.Table;
 import com.starrocks.catalog.Tablet;
 import com.starrocks.catalog.TabletMeta;
@@ -100,6 +101,7 @@ import com.starrocks.thrift.TFinishTaskRequest;
 import com.starrocks.thrift.THdfsProperties;
 import com.starrocks.thrift.TStatusCode;
 import com.starrocks.thrift.TStorageMedium;
+import com.starrocks.thrift.TTabletSchema;
 import com.starrocks.thrift.TTaskType;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -894,6 +896,18 @@ public class RestoreJob extends AbstractJob {
                 MaterializedIndexMeta indexMeta = localTbl.getIndexMetaByIndexId(restoredIdx.getId());
                 TabletMeta tabletMeta = new TabletMeta(dbId, localTbl.getId(), physicalPartition.getId(),
                         restoredIdx.getId(), indexMeta.getSchemaHash(), TStorageMedium.HDD);
+                TTabletSchema tabletSchema = SchemaInfo.builder()
+                        .setId(indexMeta.getSchemaId())
+                        .setKeysType(indexMeta.getKeysType())
+                        .setShortKeyColumnCount(indexMeta.getShortKeyColumnCount())
+                        .setSortKeyIndexes(indexMeta.getSortKeyIdxes())
+                        .setSortKeyUniqueIds(indexMeta.getSortKeyUniqueIds())
+                        .setStorageType(indexMeta.getStorageType())
+                        .addColumns(indexMeta.getSchema())
+                        .setBloomFilterColumnNames(bfColumns)
+                        .setBloomFilterFpp(bfFpp)
+                        .setIndexes(localTbl.getCopiedIndexes())
+                        .build().toTabletSchema();
                 for (Tablet restoreTablet : restoredIdx.getTablets()) {
                     GlobalStateMgr.getCurrentState().getTabletInvertedIndex().addTablet(restoreTablet.getId(), tabletMeta);
                     for (Replica restoreReplica : ((LocalTablet) restoreTablet).getImmutableReplicas()) {
@@ -902,21 +916,22 @@ public class RestoreJob extends AbstractJob {
                         LOG.info("tablet {} physical partition {} index {} replica {}",
                                 restoreTablet.getId(), physicalPartition.getId(), restoredIdx.getId(),
                                 restoreReplica.getId());
-                        CreateReplicaTask task = new CreateReplicaTask(restoreReplica.getBackendId(), dbId,
-                                localTbl.getId(), physicalPartition.getId(), restoredIdx.getId(),
-                                restoreTablet.getId(), indexMeta.getShortKeyColumnCount(),
-                                indexMeta.getSchemaHash(), indexMeta.getSchemaVersion(), restoreReplica.getVersion(),
-                                indexMeta.getKeysType(), indexMeta.getStorageType(),
-                                TStorageMedium.HDD /* all restored replicas will be saved to HDD */,
-                                indexMeta.getSchema(), bfColumns, bfFpp, null,
-                                localTbl.getCopiedIndexes(),
-                                localTbl.isInMemory(),
-                                localTbl.enablePersistentIndex(),
-                                localTbl.primaryIndexCacheExpireSec(),
-                                localTbl.getPartitionInfo().getTabletType(restorePart.getId()),
-                                localTbl.getCompressionType(), indexMeta.getSortKeyIdxes(),
-                                indexMeta.getSortKeyUniqueIds());
-                        task.setInRestoreMode(true);
+                        CreateReplicaTask task = CreateReplicaTask.builder()
+                                .setNodeId(restoreReplica.getBackendId())
+                                .setDbId(dbId)
+                                .setTableId(localTbl.getId())
+                                .setPartitionId(physicalPartition.getId())
+                                .setIndexId(restoredIdx.getId())
+                                .setTabletId(restoreTablet.getId())
+                                .setVersion(restoreReplica.getVersion())
+                                .setStorageMedium(TStorageMedium.HDD) /* all restored replicas will be saved to HDD */
+                                .setEnablePersistentIndex(localTbl.enablePersistentIndex())
+                                .setPrimaryIndexCacheExpireSec(localTbl.primaryIndexCacheExpireSec())
+                                .setTabletType(localTbl.getPartitionInfo().getTabletType(restorePart.getId()))
+                                .setCompressionType(localTbl.getCompressionType())
+                                .setInRestoreMode(true)
+                                .setTabletSchema(tabletSchema)
+                                .build();
                         batchTask.addTask(task);
                     }
                 }

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/SchemaInfo.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/SchemaInfo.java
@@ -160,7 +160,7 @@ public class SchemaInfo {
         return tSchema;
     }
 
-    public static Builder builder() {
+    public static Builder newBuilder() {
         return new Builder();
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/SchemaInfo.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/SchemaInfo.java
@@ -1,0 +1,271 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.catalog;
+
+import com.google.common.base.Preconditions;
+import com.google.gson.annotations.SerializedName;
+import com.starrocks.alter.SchemaChangeHandler;
+import com.starrocks.thrift.TColumn;
+import com.starrocks.thrift.TOlapTableIndex;
+import com.starrocks.thrift.TStorageType;
+import com.starrocks.thrift.TTabletSchema;
+import org.apache.commons.collections.CollectionUtils;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Objects;
+import java.util.Set;
+
+public class SchemaInfo {
+    @SerializedName("id")
+    private final long id;
+    @SerializedName("shortKeyColumnCount")
+    private final short shortKeyColumnCount;
+    @SerializedName("keysType")
+    private final KeysType keysType;
+    @SerializedName("storageType")
+    private final TStorageType storageType;
+    @SerializedName("version")
+    private final int version;
+    @SerializedName("columns")
+    private final List<Column> columns;
+    @SerializedName("sortKeyIndexes")
+    private final List<Integer> sortKeyIndexes;
+    @SerializedName("sortKeyUniqueIds")
+    private final List<Integer> sortKeyUniqueIds;
+    @SerializedName("indexes")
+    private final List<Index> indexes;
+    @SerializedName("bfColumns")
+    private final Set<String> bloomFilterColumnNames;
+    @SerializedName("bfColumnFpp")
+    private final double bloomFilterFpp; // false positive probability
+
+    private SchemaInfo(Builder builder) {
+        this.id = builder.id;
+        this.shortKeyColumnCount = builder.shortKeyColumnCount;
+        this.keysType = builder.keysType;
+        this.storageType = builder.storageType;
+        this.version = builder.version;
+        this.columns = new ArrayList<>(builder.columns);
+        this.sortKeyIndexes = builder.sortKeyIndexes;
+        this.sortKeyUniqueIds = builder.sortKeyUniqueIds;
+        this.indexes = builder.indexes;
+        this.bloomFilterColumnNames = builder.bloomFilterColumnNames;
+        this.bloomFilterFpp = builder.bloomFilterFpp;
+    }
+
+    public long getId() {
+        return id;
+    }
+
+    public short getShortKeyColumnCount() {
+        return shortKeyColumnCount;
+    }
+
+    public KeysType getKeysType() {
+        return keysType;
+    }
+
+    public TStorageType getStorageType() {
+        return storageType;
+    }
+
+    public int getVersion() {
+        return version;
+    }
+
+    public List<Column> getColumns() {
+        return columns;
+    }
+
+    public List<Integer> getSortKeyIndexes() {
+        return sortKeyIndexes;
+    }
+
+    public List<Integer> getSortKeyUniqueIds() {
+        return sortKeyUniqueIds;
+    }
+
+    public List<Index> getIndexes() {
+        return indexes;
+    }
+
+    public Set<String> getBloomFilterColumnNames() {
+        return bloomFilterColumnNames;
+    }
+
+    public double getBloomFilterFpp() {
+        return bloomFilterFpp;
+    }
+
+    public TTabletSchema toTabletSchema() {
+        TTabletSchema tSchema = new TTabletSchema();
+        tSchema.setShort_key_column_count(shortKeyColumnCount);
+        tSchema.setKeys_type(keysType.toThrift());
+        tSchema.setStorage_type(storageType);
+        tSchema.setId(id);
+        tSchema.setSchema_version(version);
+        tSchema.setSchema_hash(0/*unused now*/);
+        tSchema.setIs_in_memory(false/*unused now*/);
+
+        List<TColumn> tColumns = new ArrayList<TColumn>();
+        for (Column column : columns) {
+            TColumn tColumn = column.toThrift();
+            // is bloom filter column
+            if (bloomFilterColumnNames != null && bloomFilterColumnNames.contains(column.getName())) {
+                tColumn.setIs_bloom_filter_column(true);
+            }
+            // when doing schema change, some modified column has a prefix in name.
+            // this prefix is only used in FE, not visible to BE, so we should remove this prefix.
+            if (column.getName().startsWith(SchemaChangeHandler.SHADOW_NAME_PRFIX)) {
+                tColumn.setColumn_name(column.getName().substring(SchemaChangeHandler.SHADOW_NAME_PRFIX.length()));
+            }
+            if (column.getName().startsWith(SchemaChangeHandler.SHADOW_NAME_PRFIX_V1)) {
+                tColumn.setColumn_name(column.getName().substring(SchemaChangeHandler.SHADOW_NAME_PRFIX_V1.length()));
+            }
+            tColumns.add(tColumn);
+        }
+        tSchema.setColumns(tColumns);
+        tSchema.setSort_key_idxes(sortKeyIndexes);
+        tSchema.setSort_key_unique_ids(sortKeyUniqueIds);
+
+        if (CollectionUtils.isNotEmpty(indexes)) {
+            List<TOlapTableIndex> tIndexes = new ArrayList<>();
+            for (Index index : indexes) {
+                tIndexes.add(index.toThrift());
+            }
+            tSchema.setIndexes(tIndexes);
+        }
+
+        if (bloomFilterColumnNames != null) {
+            tSchema.setBloom_filter_fpp(bloomFilterFpp);
+        }
+        return tSchema;
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public static class Builder {
+        private long id;
+        private int version;
+        private KeysType keysType;
+        private short shortKeyColumnCount;
+        private TStorageType storageType;
+        private List<Column> columns;
+        private List<Integer> sortKeyIndexes;
+        private List<Integer> sortKeyUniqueIds;
+        private List<Index> indexes;
+        private Set<String> bloomFilterColumnNames;
+        private double bloomFilterFpp; // false positive probability
+
+        private Builder() {
+        }
+
+        public Builder setId(long id) {
+            this.id = id;
+            return this;
+        }
+
+        public Builder setVersion(int version) {
+            this.version = version;
+            return this;
+        }
+
+        public Builder setKeysType(KeysType keysType) {
+            this.keysType = keysType;
+            return this;
+        }
+
+        public Builder setShortKeyColumnCount(short count) {
+            this.shortKeyColumnCount = count;
+            return this;
+        }
+
+        public Builder setStorageType(TStorageType storageType) {
+            this.storageType = storageType;
+            return this;
+        }
+
+        public Builder addColumn(Column column) {
+            Objects.requireNonNull(column, "column is null");
+            if (columns == null) {
+                this.columns = new ArrayList<>();
+            }
+            columns.add(column);
+            return this;
+        }
+
+        public Builder addColumns(List<Column> columns) {
+            for (Column col : columns) {
+                addColumn(col);
+            }
+            return this;
+        }
+
+        public Builder setSortKeyIndexes(List<Integer> sortKeyIndexes) {
+            Preconditions.checkState(this.sortKeyIndexes == null);
+            this.sortKeyIndexes = sortKeyIndexes;
+            return this;
+        }
+
+        public Builder setSortKeyUniqueIds(List<Integer> sortKeyUniqueIds) {
+            Preconditions.checkState(this.sortKeyUniqueIds == null);
+            this.sortKeyUniqueIds = sortKeyUniqueIds;
+            return this;
+        }
+
+        public Builder setIndexes(List<Index> indexes) {
+            Preconditions.checkState(this.indexes == null);
+            this.indexes = indexes;
+            return this;
+        }
+
+        public Builder setBloomFilterColumnNames(Collection<String> bloomFilterColumnNames) {
+            Preconditions.checkState(this.bloomFilterColumnNames == null);
+            if (bloomFilterColumnNames != null) {
+                this.bloomFilterColumnNames = new HashSet<>(bloomFilterColumnNames);
+            }
+            return this;
+        }
+
+        public Builder setBloomFilterFpp(double fpp) {
+            this.bloomFilterFpp = fpp;
+            return this;
+        }
+
+        public SchemaInfo build() {
+            if (id == 0) {
+                throw new RuntimeException("id not set");
+            }
+            if (keysType == null) {
+                throw new RuntimeException("keys type not set");
+            }
+            if (shortKeyColumnCount == 0) {
+                throw new RuntimeException("short key column count not set");
+            }
+            if (columns == null) {
+                throw new RuntimeException("no column");
+            }
+            if (storageType == null) {
+                throw new RuntimeException("storage type not set");
+            }
+            return new SchemaInfo(this);
+        }
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/SchemaInfo.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/SchemaInfo.java
@@ -60,7 +60,7 @@ public class SchemaInfo {
         this.keysType = builder.keysType;
         this.storageType = builder.storageType;
         this.version = builder.version;
-        this.columns = new ArrayList<>(builder.columns);
+        this.columns = builder.columns;
         this.sortKeyIndexes = builder.sortKeyIndexes;
         this.sortKeyUniqueIds = builder.sortKeyUniqueIds;
         this.indexes = builder.indexes;
@@ -250,21 +250,11 @@ public class SchemaInfo {
         }
 
         public SchemaInfo build() {
-            if (id == 0) {
-                throw new RuntimeException("id not set");
-            }
-            if (keysType == null) {
-                throw new RuntimeException("keys type not set");
-            }
-            if (shortKeyColumnCount == 0) {
-                throw new RuntimeException("short key column count not set");
-            }
-            if (columns == null) {
-                throw new RuntimeException("no column");
-            }
-            if (storageType == null) {
-                throw new RuntimeException("storage type not set");
-            }
+            Preconditions.checkState(id > 0);
+            Preconditions.checkState(keysType != null);
+            Preconditions.checkState(shortKeyColumnCount > 0);
+            Preconditions.checkState(columns != null);
+            Preconditions.checkState(storageType != null);
             return new SchemaInfo(this);
         }
     }

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/SchemaInfo.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/SchemaInfo.java
@@ -41,6 +41,8 @@ public class SchemaInfo {
     private final TStorageType storageType;
     @SerializedName("version")
     private final int version;
+    @SerializedName("schemaHahs")
+    private final int schemaHash;
     @SerializedName("columns")
     private final List<Column> columns;
     @SerializedName("sortKeyIndexes")
@@ -66,6 +68,7 @@ public class SchemaInfo {
         this.indexes = builder.indexes;
         this.bloomFilterColumnNames = builder.bloomFilterColumnNames;
         this.bloomFilterFpp = builder.bloomFilterFpp;
+        this.schemaHash = builder.schemaHash;
     }
 
     public long getId() {
@@ -119,7 +122,7 @@ public class SchemaInfo {
         tSchema.setStorage_type(storageType);
         tSchema.setId(id);
         tSchema.setSchema_version(version);
-        tSchema.setSchema_hash(0/*unused now*/);
+        tSchema.setSchema_hash(schemaHash);
         tSchema.setIs_in_memory(false/*unused now*/);
 
         List<TColumn> tColumns = new ArrayList<TColumn>();
@@ -164,6 +167,7 @@ public class SchemaInfo {
     public static class Builder {
         private long id;
         private int version;
+        private int schemaHash;
         private KeysType keysType;
         private short shortKeyColumnCount;
         private TStorageType storageType;
@@ -246,6 +250,11 @@ public class SchemaInfo {
 
         public Builder setBloomFilterFpp(double fpp) {
             this.bloomFilterFpp = fpp;
+            return this;
+        }
+
+        public Builder setSchemaHash(int schemaHash) {
+            this.schemaHash = schemaHash;
             return this;
         }
 

--- a/fe/fe-core/src/main/java/com/starrocks/clone/TabletSchedCtx.java
+++ b/fe/fe-core/src/main/java/com/starrocks/clone/TabletSchedCtx.java
@@ -936,7 +936,7 @@ public class TabletSchedCtx implements Comparable<TabletSchedCtx> {
             if (indexMeta == null) {
                 throw new SchedException(Status.UNRECOVERABLE, "materialized view " + indexId + " does not exist");
             }
-            TTabletSchema tabletSchema = SchemaInfo.builder()
+            TTabletSchema tabletSchema = SchemaInfo.newBuilder()
                     .setId(indexMeta.getSchemaId())
                     .setShortKeyColumnCount(indexMeta.getShortKeyColumnCount())
                     .setSchemaHash(indexMeta.getSchemaHash())
@@ -951,7 +951,7 @@ public class TabletSchedCtx implements Comparable<TabletSchedCtx> {
                     .setSortKeyUniqueIds(indexMeta.getSortKeyUniqueIds())
                     .build().toTabletSchema();
 
-            CreateReplicaTask task = CreateReplicaTask.builder()
+            CreateReplicaTask task = CreateReplicaTask.newBuilder()
                     .setNodeId(destBackendId)
                     .setDbId(dbId)
                     .setTableId(tblId)

--- a/fe/fe-core/src/main/java/com/starrocks/clone/TabletSchedCtx.java
+++ b/fe/fe-core/src/main/java/com/starrocks/clone/TabletSchedCtx.java
@@ -49,6 +49,7 @@ import com.starrocks.catalog.OlapTable;
 import com.starrocks.catalog.Partition;
 import com.starrocks.catalog.Replica;
 import com.starrocks.catalog.Replica.ReplicaState;
+import com.starrocks.catalog.SchemaInfo;
 import com.starrocks.catalog.Table;
 import com.starrocks.clone.DiskAndTabletLoadReBalancer.BalanceType;
 import com.starrocks.clone.SchedException.Status;
@@ -77,6 +78,7 @@ import com.starrocks.thrift.TStatusCode;
 import com.starrocks.thrift.TStorageMedium;
 import com.starrocks.thrift.TTabletInfo;
 import com.starrocks.thrift.TTabletSchedule;
+import com.starrocks.thrift.TTabletSchema;
 import com.starrocks.thrift.TTaskType;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -934,20 +936,37 @@ public class TabletSchedCtx implements Comparable<TabletSchedCtx> {
             if (indexMeta == null) {
                 throw new SchedException(Status.UNRECOVERABLE, "materialized view " + indexId + " does not exist");
             }
-            CreateReplicaTask createReplicaTask = new CreateReplicaTask(destBackendId, dbId,
-                    tblId, partitionId, indexId, tabletId, indexMeta.getShortKeyColumnCount(),
-                    indexMeta.getSchemaHash(), indexMeta.getSchemaVersion(), visibleVersion,
-                    indexMeta.getKeysType(),
-                    indexMeta.getStorageType(),
-                    TStorageMedium.HDD, indexMeta.getSchema(), olapTable.getCopiedBfColumns(), olapTable.getBfFpp(), null,
-                    olapTable.getCopiedIndexes(),
-                    olapTable.isInMemory(),
-                    olapTable.enablePersistentIndex(),
-                    olapTable.primaryIndexCacheExpireSec(),
-                    olapTable.getPartitionInfo().getTabletType(partitionId),
-                    olapTable.getCompressionType(), indexMeta.getSortKeyIdxes(),
-                    indexMeta.getSortKeyUniqueIds());
-            createReplicaTask.setRecoverySource(RecoverySource.SCHEDULER);
+            TTabletSchema tabletSchema = SchemaInfo.builder()
+                    .setId(indexMeta.getSchemaId())
+                    .setShortKeyColumnCount(indexMeta.getShortKeyColumnCount())
+                    .setKeysType(indexMeta.getKeysType())
+                    .setStorageType(indexMeta.getStorageType())
+                    .setVersion(indexMeta.getSchemaVersion())
+                    .addColumns(indexMeta.getSchema())
+                    .setBloomFilterColumnNames(olapTable.getCopiedBfColumns())
+                    .setBloomFilterFpp(olapTable.getBfFpp())
+                    .setIndexes(olapTable.getCopiedIndexes())
+                    .setSortKeyIndexes(indexMeta.getSortKeyIdxes())
+                    .setSortKeyUniqueIds(indexMeta.getSortKeyUniqueIds())
+                    .build().toTabletSchema();
+
+            CreateReplicaTask task = CreateReplicaTask.builder()
+                    .setNodeId(destBackendId)
+                    .setDbId(dbId)
+                    .setTableId(tblId)
+                    .setPartitionId(partitionId)
+                    .setIndexId(indexId)
+                    .setTabletId(tabletId)
+                    .setVersion(visibleVersion)
+                    .setStorageMedium(TStorageMedium.HDD)
+                    .setEnablePersistentIndex(olapTable.enablePersistentIndex())
+                    .setPrimaryIndexCacheExpireSec(olapTable.primaryIndexCacheExpireSec())
+                    .setTabletType(olapTable.getPartitionInfo().getTabletType(partitionId))
+                    .setCompressionType(olapTable.getCompressionType())
+                    .setRecoverySource(RecoverySource.SCHEDULER)
+                    .setTabletSchema(tabletSchema)
+                    .build();
+
             taskTimeoutMs = Config.tablet_sched_min_clone_task_timeout_sec * 1000;
 
             Replica emptyReplica =
@@ -956,7 +975,7 @@ public class TabletSchedCtx implements Comparable<TabletSchedCtx> {
             // addReplica() method will add this replica to tablet inverted index too.
             tablet.addReplica(emptyReplica);
             state = State.RUNNING;
-            return createReplicaTask;
+            return task;
         } finally {
             locker.unLockDatabase(db, LockType.WRITE);
         }

--- a/fe/fe-core/src/main/java/com/starrocks/clone/TabletSchedCtx.java
+++ b/fe/fe-core/src/main/java/com/starrocks/clone/TabletSchedCtx.java
@@ -939,6 +939,7 @@ public class TabletSchedCtx implements Comparable<TabletSchedCtx> {
             TTabletSchema tabletSchema = SchemaInfo.builder()
                     .setId(indexMeta.getSchemaId())
                     .setShortKeyColumnCount(indexMeta.getShortKeyColumnCount())
+                    .setSchemaHash(indexMeta.getSchemaHash())
                     .setKeysType(indexMeta.getKeysType())
                     .setStorageType(indexMeta.getStorageType())
                     .setVersion(indexMeta.getSchemaVersion())

--- a/fe/fe-core/src/main/java/com/starrocks/leader/ReportHandler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/leader/ReportHandler.java
@@ -902,7 +902,7 @@ public class ReportHandler extends Daemon implements MemoryTrackable {
                                     MaterializedIndexMeta indexMeta = olapTable.getIndexMetaByIndexId(indexId);
                                     Set<String> bfColumns = olapTable.getCopiedBfColumns();
                                     double bfFpp = olapTable.getBfFpp();
-                                    TTabletSchema tabletSchema = SchemaInfo.builder()
+                                    TTabletSchema tabletSchema = SchemaInfo.newBuilder()
                                             .setId(indexMeta.getSchemaId())
                                             .setKeysType(indexMeta.getKeysType())
                                             .setShortKeyColumnCount(indexMeta.getShortKeyColumnCount())
@@ -916,7 +916,7 @@ public class ReportHandler extends Daemon implements MemoryTrackable {
                                             .setSortKeyIndexes(indexMeta.getSortKeyIdxes())
                                             .setSortKeyUniqueIds(indexMeta.getSortKeyUniqueIds())
                                             .build().toTabletSchema();
-                                    CreateReplicaTask task = CreateReplicaTask.builder()
+                                    CreateReplicaTask task = CreateReplicaTask.newBuilder()
                                             .setNodeId(backendId)
                                             .setDbId(dbId)
                                             .setTableId(tableId)

--- a/fe/fe-core/src/main/java/com/starrocks/leader/ReportHandler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/leader/ReportHandler.java
@@ -62,6 +62,7 @@ import com.starrocks.catalog.Partition;
 import com.starrocks.catalog.PhysicalPartition;
 import com.starrocks.catalog.Replica;
 import com.starrocks.catalog.Replica.ReplicaState;
+import com.starrocks.catalog.SchemaInfo;
 import com.starrocks.catalog.TabletInvertedIndex;
 import com.starrocks.catalog.TabletMeta;
 import com.starrocks.clone.TabletChecker;
@@ -117,6 +118,7 @@ import com.starrocks.thrift.TStatusCode;
 import com.starrocks.thrift.TStorageMedium;
 import com.starrocks.thrift.TTablet;
 import com.starrocks.thrift.TTabletInfo;
+import com.starrocks.thrift.TTabletSchema;
 import com.starrocks.thrift.TTaskType;
 import com.starrocks.thrift.TTxnType;
 import com.starrocks.thrift.TWorkGroup;
@@ -900,22 +902,35 @@ public class ReportHandler extends Daemon implements MemoryTrackable {
                                     MaterializedIndexMeta indexMeta = olapTable.getIndexMetaByIndexId(indexId);
                                     Set<String> bfColumns = olapTable.getCopiedBfColumns();
                                     double bfFpp = olapTable.getBfFpp();
-                                    CreateReplicaTask createReplicaTask = new CreateReplicaTask(backendId, dbId,
-                                            tableId, partitionId, indexId, tabletId, indexMeta.getShortKeyColumnCount(),
-                                            indexMeta.getSchemaHash(), indexMeta.getSchemaVersion(),
-                                            partition.getVisibleVersion(),
-                                            indexMeta.getKeysType(),
-                                            olapTable.getStorageType(),
-                                            TStorageMedium.HDD, indexMeta.getSchema(), bfColumns, bfFpp, null,
-                                            olapTable.getCopiedIndexes(),
-                                            olapTable.isInMemory(),
-                                            olapTable.enablePersistentIndex(),
-                                            olapTable.primaryIndexCacheExpireSec(),
-                                            olapTable.getPartitionInfo().getTabletType(partitionId),
-                                            olapTable.getCompressionType(), indexMeta.getSortKeyIdxes(),
-                                            indexMeta.getSortKeyUniqueIds());
-                                    createReplicaTask.setRecoverySource(RecoverySource.REPORT);
-                                    createReplicaBatchTask.addTask(createReplicaTask);
+                                    TTabletSchema tabletSchema = SchemaInfo.builder()
+                                            .setId(indexMeta.getSchemaId())
+                                            .setKeysType(indexMeta.getKeysType())
+                                            .setShortKeyColumnCount(indexMeta.getShortKeyColumnCount())
+                                            .setVersion(indexMeta.getSchemaVersion())
+                                            .setStorageType(olapTable.getStorageType())
+                                            .addColumns(indexMeta.getSchema())
+                                            .setBloomFilterColumnNames(bfColumns)
+                                            .setBloomFilterFpp(bfFpp)
+                                            .setIndexes(olapTable.getCopiedIndexes())
+                                            .setSortKeyIndexes(indexMeta.getSortKeyIdxes())
+                                            .setSortKeyUniqueIds(indexMeta.getSortKeyUniqueIds())
+                                            .build().toTabletSchema();
+                                    CreateReplicaTask task = CreateReplicaTask.builder()
+                                            .setNodeId(backendId)
+                                            .setDbId(dbId)
+                                            .setTableId(tableId)
+                                            .setPartitionId(partitionId)
+                                            .setIndexId(indexId)
+                                            .setVersion(partition.getVisibleVersion())
+                                            .setStorageMedium(TStorageMedium.HDD)
+                                            .setEnablePersistentIndex(olapTable.enablePersistentIndex())
+                                            .setPrimaryIndexCacheExpireSec(olapTable.primaryIndexCacheExpireSec())
+                                            .setTabletType(olapTable.getPartitionInfo().getTabletType(partitionId))
+                                            .setCompressionType(olapTable.getCompressionType())
+                                            .setRecoverySource(RecoverySource.REPORT)
+                                            .setTabletSchema(tabletSchema)
+                                            .build();
+                                    createReplicaBatchTask.addTask(task);
                                 } else {
                                     // just set this replica as bad
                                     if (replica.setBad(true)) {

--- a/fe/fe-core/src/main/java/com/starrocks/leader/ReportHandler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/leader/ReportHandler.java
@@ -906,6 +906,7 @@ public class ReportHandler extends Daemon implements MemoryTrackable {
                                             .setId(indexMeta.getSchemaId())
                                             .setKeysType(indexMeta.getKeysType())
                                             .setShortKeyColumnCount(indexMeta.getShortKeyColumnCount())
+                                            .setSchemaHash(indexMeta.getSchemaHash())
                                             .setVersion(indexMeta.getSchemaVersion())
                                             .setStorageType(olapTable.getStorageType())
                                             .addColumns(indexMeta.getSchema())

--- a/fe/fe-core/src/main/java/com/starrocks/server/LocalMetastore.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/LocalMetastore.java
@@ -2033,7 +2033,7 @@ public class LocalMetastore implements ConnectorMetadata {
         MaterializedIndexMeta indexMeta = table.getIndexMetaByIndexId(index.getId());
         TTabletType tabletType = isCloudNativeTable ? TTabletType.TABLET_TYPE_LAKE : TTabletType.TABLET_TYPE_DISK;
         TStorageMedium storageMedium = table.getPartitionInfo().getDataProperty(partition.getParentId()).getStorageMedium();
-        TTabletSchema tabletSchema = SchemaInfo.builder()
+        TTabletSchema tabletSchema = SchemaInfo.newBuilder()
                 .setId(indexMeta.getSchemaId())
                 .setVersion(indexMeta.getSchemaVersion())
                 .setKeysType(indexMeta.getKeysType())
@@ -2066,7 +2066,7 @@ public class LocalMetastore implements ConnectorMetadata {
             }
 
             for (Long nodeId : nodeIdsOfReplicas) {
-                CreateReplicaTask task = CreateReplicaTask.builder()
+                CreateReplicaTask task = CreateReplicaTask.newBuilder()
                         .setNodeId(nodeId)
                         .setDbId(dbId)
                         .setTableId(table.getId())

--- a/fe/fe-core/src/main/java/com/starrocks/server/LocalMetastore.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/LocalMetastore.java
@@ -2038,6 +2038,7 @@ public class LocalMetastore implements ConnectorMetadata {
                 .setVersion(indexMeta.getSchemaVersion())
                 .setKeysType(indexMeta.getKeysType())
                 .setShortKeyColumnCount(indexMeta.getShortKeyColumnCount())
+                .setSchemaHash(indexMeta.getSchemaHash())
                 .setStorageType(indexMeta.getStorageType())
                 .setIndexes(table.getIndexes())
                 .setSortKeyIndexes(indexMeta.getSortKeyIdxes())

--- a/fe/fe-core/src/main/java/com/starrocks/server/LocalMetastore.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/LocalMetastore.java
@@ -2048,7 +2048,7 @@ public class LocalMetastore implements ConnectorMetadata {
 
         for (Tablet tablet : index.getTablets()) {
             List<Long> nodeIdsOfReplicas = new ArrayList<>();
-            if (RunMode.isSharedNothingMode()) {
+            if (table.isCloudNativeTableOrMaterializedView()) {
                 try {
                     Warehouse warehouse = GlobalStateMgr.getCurrentState().getWarehouseMgr().getDefaultWarehouse();
                     long nodeId = ((LakeTablet) tablet).

--- a/fe/fe-core/src/main/java/com/starrocks/task/CreateReplicaTask.java
+++ b/fe/fe-core/src/main/java/com/starrocks/task/CreateReplicaTask.java
@@ -102,7 +102,7 @@ public class CreateReplicaTask extends AgentTask {
         this.inRestoreMode = builder.isInRestoreMode();
     }
 
-    public static Builder builder() {
+    public static Builder newBuilder() {
         return new Builder();
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/task/CreateReplicaTask.java
+++ b/fe/fe-core/src/main/java/com/starrocks/task/CreateReplicaTask.java
@@ -34,32 +34,21 @@
 
 package com.starrocks.task;
 
-import com.starrocks.alter.SchemaChangeHandler;
+import com.google.common.base.Preconditions;
 import com.starrocks.binlog.BinlogConfig;
-import com.starrocks.catalog.Column;
-import com.starrocks.catalog.Index;
-import com.starrocks.catalog.KeysType;
 import com.starrocks.common.Status;
 import com.starrocks.common.util.concurrent.MarkedCountDownLatch;
 import com.starrocks.thrift.TBinlogConfig;
-import com.starrocks.thrift.TColumn;
 import com.starrocks.thrift.TCompressionType;
 import com.starrocks.thrift.TCreateTabletReq;
-import com.starrocks.thrift.TOlapTableIndex;
 import com.starrocks.thrift.TPersistentIndexType;
 import com.starrocks.thrift.TStatusCode;
 import com.starrocks.thrift.TStorageMedium;
-import com.starrocks.thrift.TStorageType;
 import com.starrocks.thrift.TTabletSchema;
 import com.starrocks.thrift.TTabletType;
 import com.starrocks.thrift.TTaskType;
-import org.apache.commons.collections.CollectionUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Set;
 
 public class CreateReplicaTask extends AgentTask {
     private static final Logger LOG = LogManager.getLogger(CreateReplicaTask.class);
@@ -69,37 +58,15 @@ public class CreateReplicaTask extends AgentTask {
         REPORT
     }
 
-    private short shortKeyColumnCount;
-    private int schemaHash;
-    private int schemaVersion;
-
-    private long version;
-
-    private KeysType keysType;
-    private TStorageType storageType;
-    private TCompressionType compressionType;
-    private TStorageMedium storageMedium;
-
-    private List<Column> columns;
-    private List<Integer> sortKeyIdxes;
-    private List<Integer> sortKeyUniqueIds;
-
-    // bloom filter columns
-    private Set<String> bfColumns;
-    private double bfFpp;
-
-    // indexes
-    private List<Index> indexes;
-
-    private boolean isInMemory;
-
-    private boolean enablePersistentIndex;
-
+    private final long version;
+    private final TCompressionType compressionType;
+    private final TStorageMedium storageMedium;
+    private final boolean enablePersistentIndex;
     private TPersistentIndexType persistentIndexType;
 
     private BinlogConfig binlogConfig;
 
-    private TTabletType tabletType;
+    private final TTabletType tabletType;
 
     // used for synchronous process
     private MarkedCountDownLatch<Long, Long> latch;
@@ -112,126 +79,31 @@ public class CreateReplicaTask extends AgentTask {
 
     private RecoverySource recoverySource;
 
-    // true if this task is created by recover request(See comment of Config.recover_with_empty_tablet)
-    private boolean isRecoverTask = false;
-
-    private boolean isFromScheduler = false;
-
     private int primaryIndexCacheExpireSec = 0;
     private boolean createSchemaFile = true;
+    private final TTabletSchema tabletSchema;
 
-    public CreateReplicaTask(long backendId, long dbId, long tableId, long partitionId, long indexId, long tabletId,
-                             short shortKeyColumnCount, int schemaHash, long version,
-                             KeysType keysType, TStorageType storageType,
-                             TStorageMedium storageMedium, List<Column> columns,
-                             Set<String> bfColumns, double bfFpp, MarkedCountDownLatch<Long, Long> latch,
-                             List<Index> indexes,
-                             boolean isInMemory,
-                             boolean enablePersistentIndex,
-                             int primaryIndexCacheExpireSec,
-                             TTabletType tabletType, TCompressionType compressionType) {
-        this(backendId, dbId, tableId, partitionId, indexId, tabletId, shortKeyColumnCount,
-                schemaHash, 0, version, keysType, storageType, storageMedium, columns, bfColumns,
-                bfFpp, latch, indexes, isInMemory, enablePersistentIndex, primaryIndexCacheExpireSec,
-                tabletType, compressionType, null, null);
+    private CreateReplicaTask(Builder builder) {
+        super(null, builder.getNodeId(), TTaskType.CREATE, builder.getDbId(), builder.getTableId(),
+                builder.getTableId(), builder.getIndexId(), builder.getTabletId());
+        this.version = builder.getVersion();
+        this.storageMedium = builder.getStorageMedium();
+        this.latch = builder.getLatch();
+        this.enablePersistentIndex = builder.isEnablePersistentIndex();
+        this.primaryIndexCacheExpireSec = builder.getPrimaryIndexCacheExpireSec();
+        this.persistentIndexType = builder.getPersistentIndexType();
+        this.tabletType = builder.getTabletType();
+        this.compressionType = builder.getCompressionType();
+        this.tabletSchema = builder.getTabletSchema();
+        this.binlogConfig = builder.getBinlogConfig();
+        this.createSchemaFile = builder.isCreateSchemaFile();
+        this.baseTabletId = builder.getBaseTabletId();
+        this.recoverySource = builder.getRecoverySource();
+        this.inRestoreMode = builder.isInRestoreMode();
     }
 
-    public CreateReplicaTask(long backendId, long dbId, long tableId, long partitionId, long indexId, long tabletId,
-                             short shortKeyColumnCount, int schemaHash, long version,
-                             KeysType keysType, TStorageType storageType,
-                             TStorageMedium storageMedium, List<Column> columns,
-                             Set<String> bfColumns, double bfFpp, MarkedCountDownLatch<Long, Long> latch,
-                             List<Index> indexes,
-                             boolean isInMemory,
-                             boolean enablePersistentIndex,
-                             int primaryIndexCacheExpireSec,
-                             BinlogConfig binlogConfig,
-                             TTabletType tabletType, TCompressionType compressionType, List<Integer> sortKeyIdxes,
-                             List<Integer> sortKeyUniqueIds) {
-
-        this(backendId, dbId, tableId, partitionId, indexId, tabletId, shortKeyColumnCount, schemaHash, 0, version,
-                keysType, storageType, storageMedium, columns, bfColumns, bfFpp, latch, indexes, isInMemory,
-                enablePersistentIndex, primaryIndexCacheExpireSec, tabletType, compressionType, sortKeyIdxes, sortKeyUniqueIds);
-        this.binlogConfig = binlogConfig;
-    }
-
-    public CreateReplicaTask(long backendId, long dbId, long tableId, long partitionId, long indexId, long tabletId,
-                             short shortKeyColumnCount, int schemaHash, long version,
-                             KeysType keysType, TStorageType storageType,
-                             TStorageMedium storageMedium, List<Column> columns,
-                             Set<String> bfColumns, double bfFpp, MarkedCountDownLatch<Long, Long> latch,
-                             List<Index> indexes,
-                             boolean isInMemory,
-                             boolean enablePersistentIndex,
-                             int primaryIndexCacheExpireSec,
-                             TTabletType tabletType, TCompressionType compressionType, List<Integer> sortKeyIdxes,
-                             List<Integer> sortKeyUniqueIds,
-                             boolean createSchemaFile) {
-        this(backendId, dbId, tableId, partitionId, indexId, tabletId, shortKeyColumnCount, schemaHash, 0, version,
-                keysType, storageType, storageMedium, columns, bfColumns, bfFpp, latch, indexes, isInMemory,
-                enablePersistentIndex, primaryIndexCacheExpireSec, tabletType, compressionType, sortKeyIdxes, sortKeyUniqueIds);
-        this.createSchemaFile = createSchemaFile;
-    }
-
-    public CreateReplicaTask(long backendId, long dbId, long tableId, long partitionId, long indexId, long tabletId,
-                             short shortKeyColumnCount, int schemaHash, int schemaVersion, long version,
-                             KeysType keysType, TStorageType storageType,
-                             TStorageMedium storageMedium, List<Column> columns,
-                             Set<String> bfColumns, double bfFpp, MarkedCountDownLatch<Long, Long> latch,
-                             List<Index> indexes,
-                             boolean isInMemory,
-                             boolean enablePersistentIndex,
-                             int primaryIndexCacheExpireSec,
-                             TTabletType tabletType, TCompressionType compressionType, List<Integer> sortKeyIdxes,
-                             List<Integer> sortKeyUniqueIds) {
-        super(null, backendId, TTaskType.CREATE, dbId, tableId, partitionId, indexId, tabletId);
-
-        this.shortKeyColumnCount = shortKeyColumnCount;
-        this.schemaHash = schemaHash;
-        this.schemaVersion = schemaVersion;
-
-        this.version = version;
-
-        this.keysType = keysType;
-        this.storageType = storageType;
-        this.storageMedium = storageMedium;
-
-        this.columns = columns;
-        this.sortKeyIdxes = sortKeyIdxes;
-        this.sortKeyUniqueIds = sortKeyUniqueIds;
-
-        this.bfColumns = bfColumns;
-        this.indexes = indexes;
-        this.bfFpp = bfFpp;
-
-        this.latch = latch;
-
-        this.isInMemory = isInMemory;
-        this.enablePersistentIndex = enablePersistentIndex;
-        this.primaryIndexCacheExpireSec = primaryIndexCacheExpireSec;
-        this.tabletType = tabletType;
-
-        this.compressionType = compressionType;
-    }
-
-    public CreateReplicaTask(long backendId, long dbId, long tableId, long partitionId, long indexId, long tabletId,
-                             short shortKeyColumnCount, int schemaHash, long version,
-                             KeysType keysType, TStorageType storageType,
-                             TStorageMedium storageMedium, List<Column> columns,
-                             Set<String> bfColumns, double bfFpp, MarkedCountDownLatch<Long, Long> latch,
-                             List<Index> indexes,
-                             boolean isInMemory,
-                             boolean enablePersistentIndex,
-                             int primaryIndexCacheExpireSec,
-                             TPersistentIndexType persistentIndexType,
-                             TTabletType tabletType, TCompressionType compressionType, List<Integer> sortKeyIdxes,
-                             List<Integer> sortKeyUniqueIds,
-                             boolean createSchemaFile) {
-        this(backendId, dbId, tableId, partitionId, indexId, tabletId, shortKeyColumnCount, schemaHash, version,
-                keysType, storageType, storageMedium, columns, bfColumns, bfFpp, latch, indexes, isInMemory,
-                enablePersistentIndex, primaryIndexCacheExpireSec, tabletType, compressionType, sortKeyIdxes, sortKeyUniqueIds,
-                createSchemaFile);
-        this.persistentIndexType = persistentIndexType;
+    public static Builder builder() {
+        return new Builder();
     }
 
     public void setRecoverySource(RecoverySource source) {
@@ -240,10 +112,6 @@ public class CreateReplicaTask extends AgentTask {
 
     public RecoverySource getRecoverySource() {
         return this.recoverySource;
-    }
-
-    public void setSchemaVersion(int schemaVersion) {
-        this.schemaVersion = schemaVersion;
     }
 
     public void countDownLatch(long backendId, long tabletId) {
@@ -267,10 +135,6 @@ public class CreateReplicaTask extends AgentTask {
         this.latch = latch;
     }
 
-    public void setInRestoreMode(boolean inRestoreMode) {
-        this.inRestoreMode = inRestoreMode;
-    }
-
     public void setBaseTablet(long baseTabletId, int baseSchemaHash) {
         this.baseTabletId = baseTabletId;
         this.baseSchemaHash = baseSchemaHash;
@@ -283,80 +147,249 @@ public class CreateReplicaTask extends AgentTask {
     public TCreateTabletReq toThrift() {
         TCreateTabletReq createTabletReq = new TCreateTabletReq();
         createTabletReq.setTablet_id(tabletId);
-
-        TTabletSchema tSchema = new TTabletSchema();
-        tSchema.setShort_key_column_count(shortKeyColumnCount);
-        tSchema.setSchema_hash(schemaHash);
-        tSchema.setKeys_type(keysType.toThrift());
-        tSchema.setStorage_type(storageType);
-        tSchema.setId(indexId); // use index id as the schema id. assume schema change will assign a new index id.
-        tSchema.setSchema_version(schemaVersion);
-
-        List<TColumn> tColumns = new ArrayList<TColumn>();
-        for (Column column : columns) {
-            TColumn tColumn = column.toThrift();
-            // is bloom filter column
-            if (bfColumns != null && bfColumns.contains(column.getName())) {
-                tColumn.setIs_bloom_filter_column(true);
-            }
-            // when doing schema change, some modified column has a prefix in name.
-            // this prefix is only used in FE, not visible to BE, so we should remove this prefix.
-            if (column.getName().startsWith(SchemaChangeHandler.SHADOW_NAME_PRFIX)) {
-                tColumn.setColumn_name(column.getName().substring(SchemaChangeHandler.SHADOW_NAME_PRFIX.length()));
-            }
-            if (column.getName().startsWith(SchemaChangeHandler.SHADOW_NAME_PRFIX_V1)) {
-                tColumn.setColumn_name(column.getName().substring(SchemaChangeHandler.SHADOW_NAME_PRFIX_V1.length()));
-            }
-            tColumns.add(tColumn);
-        }
-        tSchema.setColumns(tColumns);
-        tSchema.setSort_key_idxes(sortKeyIdxes);
-        tSchema.setSort_key_unique_ids(sortKeyUniqueIds);
-
-        if (CollectionUtils.isNotEmpty(indexes)) {
-            List<TOlapTableIndex> tIndexes = new ArrayList<>();
-            for (Index index : indexes) {
-                tIndexes.add(index.toThrift());
-            }
-            tSchema.setIndexes(tIndexes);
-        }
-
-        if (bfColumns != null) {
-            tSchema.setBloom_filter_fpp(bfFpp);
-        }
-        tSchema.setIs_in_memory(isInMemory);
-        createTabletReq.setTablet_schema(tSchema);
-
+        createTabletReq.setTablet_schema(tabletSchema);
         createTabletReq.setVersion(version);
-
         createTabletReq.setStorage_medium(storageMedium);
         createTabletReq.setEnable_persistent_index(enablePersistentIndex);
-
         if (persistentIndexType != null) {
             createTabletReq.setPersistent_index_type(persistentIndexType);
         }
-
         createTabletReq.setPrimary_index_cache_expire_sec(primaryIndexCacheExpireSec);
-
         if (binlogConfig != null) {
             TBinlogConfig tBinlogConfig = binlogConfig.toTBinlogConfig();
             createTabletReq.setBinlog_config(tBinlogConfig);
         }
-
         if (inRestoreMode) {
             createTabletReq.setIn_restore_mode(true);
         }
         createTabletReq.setTable_id(tableId);
         createTabletReq.setPartition_id(partitionId);
-
         if (baseTabletId != -1) {
             createTabletReq.setBase_tablet_id(baseTabletId);
             createTabletReq.setBase_schema_hash(baseSchemaHash);
         }
-
         createTabletReq.setCompression_type(compressionType);
         createTabletReq.setTablet_type(tabletType);
         createTabletReq.setCreate_schema_file(createSchemaFile);
         return createTabletReq;
+    }
+
+    public static class Builder {
+        public static final long INVALID_ID = -1;
+        private long nodeId = INVALID_ID;
+        private long dbId = INVALID_ID;
+        private long tableId = INVALID_ID;
+        private long partitionId = INVALID_ID;
+        private long indexId = INVALID_ID;
+        private long tabletId = INVALID_ID;
+        private long version;
+        private TCompressionType compressionType;
+        private TStorageMedium storageMedium;
+        private boolean enablePersistentIndex;
+        private TPersistentIndexType persistentIndexType;
+        private BinlogConfig binlogConfig;
+        private TTabletType tabletType = TTabletType.TABLET_TYPE_DISK;
+        private MarkedCountDownLatch<Long, Long> latch;
+        private boolean inRestoreMode = false;
+        private long baseTabletId = INVALID_ID;
+        private RecoverySource recoverySource;
+        private int primaryIndexCacheExpireSec = 0;
+        private boolean createSchemaFile = true;
+        private TTabletSchema tabletSchema;
+
+        private Builder() {
+        }
+
+        public long getNodeId() {
+            return nodeId;
+        }
+
+        public Builder setNodeId(long nodeId) {
+            this.nodeId = nodeId;
+            return this;
+        }
+
+        public long getDbId() {
+            return dbId;
+        }
+
+        public Builder setDbId(long dbId) {
+            this.dbId = dbId;
+            return this;
+        }
+
+        public long getTableId() {
+            return tableId;
+        }
+
+        public Builder setTableId(long tableId) {
+            this.tableId = tableId;
+            return this;
+        }
+
+        public long getPartitionId() {
+            return partitionId;
+        }
+
+        public Builder setPartitionId(long partitionId) {
+            this.partitionId = partitionId;
+            return this;
+        }
+
+        public long getIndexId() {
+            return indexId;
+        }
+
+        public Builder setIndexId(long indexId) {
+            this.indexId = indexId;
+            return this;
+        }
+
+        public long getTabletId() {
+            return tabletId;
+        }
+
+        public Builder setTabletId(long tabletId) {
+            this.tabletId = tabletId;
+            return this;
+        }
+
+        public long getVersion() {
+            return version;
+        }
+
+        public Builder setVersion(long version) {
+            this.version = version;
+            return this;
+        }
+
+        public TCompressionType getCompressionType() {
+            return compressionType;
+        }
+
+        public Builder setCompressionType(TCompressionType compressionType) {
+            this.compressionType = compressionType;
+            return this;
+        }
+
+        public TStorageMedium getStorageMedium() {
+            return storageMedium;
+        }
+
+        public Builder setStorageMedium(TStorageMedium storageMedium) {
+            this.storageMedium = storageMedium;
+            return this;
+        }
+
+        public boolean isEnablePersistentIndex() {
+            return enablePersistentIndex;
+        }
+
+        public Builder setEnablePersistentIndex(boolean enablePersistentIndex) {
+            this.enablePersistentIndex = enablePersistentIndex;
+            return this;
+        }
+
+        public TPersistentIndexType getPersistentIndexType() {
+            return persistentIndexType;
+        }
+
+        public Builder setPersistentIndexType(TPersistentIndexType persistentIndexType) {
+            this.persistentIndexType = persistentIndexType;
+            return this;
+        }
+
+        public BinlogConfig getBinlogConfig() {
+            return binlogConfig;
+        }
+
+        public Builder setBinlogConfig(BinlogConfig binlogConfig) {
+            this.binlogConfig = binlogConfig;
+            return this;
+        }
+
+        public TTabletType getTabletType() {
+            return tabletType;
+        }
+
+        public Builder setTabletType(TTabletType tabletType) {
+            this.tabletType = tabletType;
+            return this;
+        }
+
+        public MarkedCountDownLatch<Long, Long> getLatch() {
+            return latch;
+        }
+
+        public Builder setLatch(MarkedCountDownLatch<Long, Long> latch) {
+            this.latch = latch;
+            return this;
+        }
+
+        public boolean isInRestoreMode() {
+            return inRestoreMode;
+        }
+
+        public Builder setInRestoreMode(boolean inRestoreMode) {
+            this.inRestoreMode = inRestoreMode;
+            return this;
+        }
+
+        public long getBaseTabletId() {
+            return baseTabletId;
+        }
+
+        public Builder setBaseTabletId(long baseTabletId) {
+            this.baseTabletId = baseTabletId;
+            return this;
+        }
+
+        public RecoverySource getRecoverySource() {
+            return recoverySource;
+        }
+
+        public Builder setRecoverySource(RecoverySource recoverySource) {
+            this.recoverySource = recoverySource;
+            return this;
+        }
+
+        public int getPrimaryIndexCacheExpireSec() {
+            return primaryIndexCacheExpireSec;
+        }
+
+        public Builder setPrimaryIndexCacheExpireSec(int primaryIndexCacheExpireSec) {
+            this.primaryIndexCacheExpireSec = primaryIndexCacheExpireSec;
+            return this;
+        }
+
+        public boolean isCreateSchemaFile() {
+            return createSchemaFile;
+        }
+
+        public Builder setCreateSchemaFile(boolean createSchemaFile) {
+            this.createSchemaFile = createSchemaFile;
+            return this;
+        }
+
+        public TTabletSchema getTabletSchema() {
+            return tabletSchema;
+        }
+
+        public Builder setTabletSchema(TTabletSchema tabletSchema) {
+            this.tabletSchema = tabletSchema;
+            return this;
+        }
+
+        public CreateReplicaTask build() {
+            Preconditions.checkState(nodeId != INVALID_ID);
+            Preconditions.checkState(dbId != INVALID_ID);
+            Preconditions.checkState(tableId != INVALID_ID);
+            Preconditions.checkState(partitionId != INVALID_ID);
+            Preconditions.checkState(indexId != INVALID_ID);
+            Preconditions.checkState(tabletId != INVALID_ID);
+            Preconditions.checkState(tabletSchema != null);
+
+            return new CreateReplicaTask(this);
+        }
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/task/CreateReplicaTask.java
+++ b/fe/fe-core/src/main/java/com/starrocks/task/CreateReplicaTask.java
@@ -85,7 +85,7 @@ public class CreateReplicaTask extends AgentTask {
 
     private CreateReplicaTask(Builder builder) {
         super(null, builder.getNodeId(), TTaskType.CREATE, builder.getDbId(), builder.getTableId(),
-                builder.getTableId(), builder.getIndexId(), builder.getTabletId());
+                builder.getPartitionId(), builder.getIndexId(), builder.getTabletId());
         this.version = builder.getVersion();
         this.storageMedium = builder.getStorageMedium();
         this.latch = builder.getLatch();

--- a/fe/fe-core/src/main/java/com/starrocks/task/CreateReplicaTask.java
+++ b/fe/fe-core/src/main/java/com/starrocks/task/CreateReplicaTask.java
@@ -182,7 +182,7 @@ public class CreateReplicaTask extends AgentTask {
         private long partitionId = INVALID_ID;
         private long indexId = INVALID_ID;
         private long tabletId = INVALID_ID;
-        private long version;
+        private long version = INVALID_ID;
         private TCompressionType compressionType;
         private TStorageMedium storageMedium;
         private boolean enablePersistentIndex;
@@ -387,6 +387,7 @@ public class CreateReplicaTask extends AgentTask {
             Preconditions.checkState(partitionId != INVALID_ID);
             Preconditions.checkState(indexId != INVALID_ID);
             Preconditions.checkState(tabletId != INVALID_ID);
+            Preconditions.checkState(version != INVALID_ID);
             Preconditions.checkState(tabletSchema != null);
 
             return new CreateReplicaTask(this);

--- a/fe/fe-core/src/main/java/com/starrocks/task/CreateReplicaTask.java
+++ b/fe/fe-core/src/main/java/com/starrocks/task/CreateReplicaTask.java
@@ -175,7 +175,8 @@ public class CreateReplicaTask extends AgentTask {
     }
 
     public static class Builder {
-        public static final long INVALID_ID = -1;
+        // TabletSchedCtx will use -1 to initialize many fields, so here we choose -2 as an invalid id.
+        public static final long INVALID_ID = -2;
         private long nodeId = INVALID_ID;
         private long dbId = INVALID_ID;
         private long tableId = INVALID_ID;

--- a/fe/fe-core/src/test/java/com/starrocks/clone/TabletSchedulerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/clone/TabletSchedulerTest.java
@@ -391,7 +391,7 @@ public class TabletSchedulerTest {
         long replicaId = 10007L;
         long schemaId = indexId;
 
-        TTabletSchema tabletSchema = SchemaInfo.builder().setId(schemaId)
+        TTabletSchema tabletSchema = SchemaInfo.newBuilder().setId(schemaId)
                 .setKeysType(DUP_KEYS)
                 .setShortKeyColumnCount((short) 1)
                 .setSchemaHash(-1)
@@ -399,7 +399,7 @@ public class TabletSchedulerTest {
                 .addColumn(new Column())
                 .build().toTabletSchema();
 
-        CreateReplicaTask createReplicaTask = CreateReplicaTask.builder()
+        CreateReplicaTask createReplicaTask = CreateReplicaTask.newBuilder()
                 .setNodeId(beId)
                 .setDbId(dbId)
                 .setTableId(tblId)

--- a/fe/fe-core/src/test/java/com/starrocks/clone/TabletSchedulerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/clone/TabletSchedulerTest.java
@@ -17,6 +17,7 @@ package com.starrocks.clone;
 import com.google.common.collect.Maps;
 import com.starrocks.catalog.CatalogRecycleBin;
 import com.starrocks.catalog.ColocateTableIndex;
+import com.starrocks.catalog.Column;
 import com.starrocks.catalog.DataProperty;
 import com.starrocks.catalog.Database;
 import com.starrocks.catalog.FakeEditLog;
@@ -394,7 +395,7 @@ public class TabletSchedulerTest {
                 .setKeysType(DUP_KEYS)
                 .setShortKeyColumnCount((short) 1)
                 .setStorageType(TStorageType.COLUMN)
-                .addColumns(new ArrayList<>())
+                .addColumn(new Column())
                 .build().toTabletSchema();
 
         CreateReplicaTask createReplicaTask = CreateReplicaTask.builder()

--- a/fe/fe-core/src/test/java/com/starrocks/clone/TabletSchedulerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/clone/TabletSchedulerTest.java
@@ -394,6 +394,7 @@ public class TabletSchedulerTest {
         TTabletSchema tabletSchema = SchemaInfo.builder().setId(schemaId)
                 .setKeysType(DUP_KEYS)
                 .setShortKeyColumnCount((short) 1)
+                .setSchemaHash(-1)
                 .setStorageType(TStorageType.COLUMN)
                 .addColumn(new Column())
                 .build().toTabletSchema();
@@ -404,6 +405,7 @@ public class TabletSchedulerTest {
                 .setTableId(tblId)
                 .setPartitionId(partitionId)
                 .setIndexId(indexId)
+                .setVersion(1)
                 .setTabletId(tabletId)
                 .setStorageMedium(TStorageMedium.HDD)
                 .setPrimaryIndexCacheExpireSec(1)

--- a/fe/fe-core/src/test/java/com/starrocks/clone/TabletSchedulerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/clone/TabletSchedulerTest.java
@@ -25,6 +25,7 @@ import com.starrocks.catalog.Partition;
 import com.starrocks.catalog.RecyclePartitionInfo;
 import com.starrocks.catalog.RecycleRangePartitionInfo;
 import com.starrocks.catalog.Replica;
+import com.starrocks.catalog.SchemaInfo;
 import com.starrocks.catalog.Table;
 import com.starrocks.catalog.TabletInvertedIndex;
 import com.starrocks.catalog.TabletMeta;
@@ -46,6 +47,7 @@ import com.starrocks.thrift.TStatus;
 import com.starrocks.thrift.TStatusCode;
 import com.starrocks.thrift.TStorageMedium;
 import com.starrocks.thrift.TStorageType;
+import com.starrocks.thrift.TTabletSchema;
 import com.starrocks.thrift.TTabletType;
 import mockit.Expectations;
 import mockit.Mocked;
@@ -386,19 +388,30 @@ public class TabletSchedulerTest {
         long indexId = 10005L;
         long tabletId = 10006L;
         long replicaId = 10007L;
-        short count = 1;
+        long schemaId = indexId;
+
+        TTabletSchema tabletSchema = SchemaInfo.builder().setId(schemaId)
+                .setKeysType(DUP_KEYS)
+                .setShortKeyColumnCount((short) 1)
+                .setStorageType(TStorageType.COLUMN)
+                .addColumns(new ArrayList<>())
+                .build().toTabletSchema();
+
+        CreateReplicaTask createReplicaTask = CreateReplicaTask.builder()
+                .setNodeId(beId)
+                .setDbId(dbId)
+                .setTableId(tblId)
+                .setPartitionId(partitionId)
+                .setIndexId(indexId)
+                .setTabletId(tabletId)
+                .setStorageMedium(TStorageMedium.HDD)
+                .setPrimaryIndexCacheExpireSec(1)
+                .setTabletType(TTabletType.TABLET_TYPE_DISK)
+                .setCompressionType(TCompressionType.LZ4_FRAME)
+                .setTabletSchema(tabletSchema)
+                .build();
+
         TabletMeta tabletMeta = new TabletMeta(dbId, tblId, partitionId, indexId, -1, TStorageMedium.HDD);
-        CreateReplicaTask createReplicaTask = new CreateReplicaTask(beId, dbId, tblId, partitionId, indexId, tabletId, count,
-                -1, -1L,
-                DUP_KEYS,
-                TStorageType.COLUMN,
-                TStorageMedium.HDD, null, null, 0.0, null,
-                null,
-                false,
-                false,
-                1,
-                TTabletType.TABLET_TYPE_DISK,
-                TCompressionType.LZ4_FRAME);
 
         Replica replica = new Replica(replicaId, beId, -1, Replica.ReplicaState.RECOVER);
 

--- a/fe/fe-core/src/test/java/com/starrocks/task/AgentTaskTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/task/AgentTaskTest.java
@@ -116,7 +116,7 @@ public class AgentTaskTest {
 
         PartitionKey pk3 = PartitionKey.createInfinityPartitionKey(Arrays.asList(columns.get(0)), true);
 
-        TTabletSchema tabletSchema = SchemaInfo.builder()
+        TTabletSchema tabletSchema = SchemaInfo.newBuilder()
                 .setId(indexId1)
                 .setKeysType(KeysType.AGG_KEYS)
                 .setShortKeyColumnCount(shortKeyNum)
@@ -125,7 +125,7 @@ public class AgentTaskTest {
                 .addColumns(columns)
                 .build().toTabletSchema();
 
-        createReplicaTask = CreateReplicaTask.builder()
+        createReplicaTask = CreateReplicaTask.newBuilder()
                 .setNodeId(backendId1)
                 .setDbId(dbId)
                 .setTableId(tableId)

--- a/fe/fe-core/src/test/java/com/starrocks/task/AgentTaskTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/task/AgentTaskTest.java
@@ -135,6 +135,7 @@ public class AgentTaskTest {
                 .setStorageMedium(TStorageMedium.SSD)
                 .setTabletType(TTabletType.TABLET_TYPE_DISK)
                 .setCompressionType(TCompressionType.LZ4_FRAME)
+                .setTabletSchema(tabletSchema)
                 .build();
 
         // drop

--- a/fe/fe-core/src/test/java/com/starrocks/task/AgentTaskTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/task/AgentTaskTest.java
@@ -41,6 +41,7 @@ import com.starrocks.catalog.KeysType;
 import com.starrocks.catalog.PartitionKey;
 import com.starrocks.catalog.PrimitiveType;
 import com.starrocks.catalog.ScalarType;
+import com.starrocks.catalog.SchemaInfo;
 import com.starrocks.common.AnalysisException;
 import com.starrocks.common.Pair;
 import com.starrocks.common.util.concurrent.MarkedCountDownLatch;
@@ -50,6 +51,7 @@ import com.starrocks.thrift.TBackend;
 import com.starrocks.thrift.TCompressionType;
 import com.starrocks.thrift.TStorageMedium;
 import com.starrocks.thrift.TStorageType;
+import com.starrocks.thrift.TTabletSchema;
 import com.starrocks.thrift.TTabletType;
 import com.starrocks.thrift.TTaskType;
 import org.junit.Assert;
@@ -114,15 +116,26 @@ public class AgentTaskTest {
 
         PartitionKey pk3 = PartitionKey.createInfinityPartitionKey(Arrays.asList(columns.get(0)), true);
 
-        // create tasks
+        TTabletSchema tabletSchema = SchemaInfo.builder()
+                .setId(indexId1)
+                .setKeysType(KeysType.AGG_KEYS)
+                .setShortKeyColumnCount(shortKeyNum)
+                .setStorageType(storageType)
+                .addColumns(columns)
+                .build().toTabletSchema();
 
-        // create
-        createReplicaTask = new CreateReplicaTask(backendId1, dbId, tableId, partitionId,
-                indexId1, tabletId1, shortKeyNum, 0,
-                version, KeysType.AGG_KEYS,
-                storageType, TStorageMedium.SSD,
-                columns, null, 0, latch, null,
-                false, false, 0, TTabletType.TABLET_TYPE_DISK, TCompressionType.LZ4_FRAME);
+        createReplicaTask = CreateReplicaTask.builder()
+                .setNodeId(backendId1)
+                .setDbId(dbId)
+                .setTableId(tableId)
+                .setPartitionId(partitionId)
+                .setIndexId(indexId1)
+                .setTabletId(tabletId1)
+                .setVersion(version)
+                .setStorageMedium(TStorageMedium.SSD)
+                .setTabletType(TTabletType.TABLET_TYPE_DISK)
+                .setCompressionType(TCompressionType.LZ4_FRAME)
+                .build();
 
         // drop
         dropTask = new DropReplicaTask(backendId1, tabletId1, 0, false);

--- a/fe/fe-core/src/test/java/com/starrocks/task/AgentTaskTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/task/AgentTaskTest.java
@@ -120,6 +120,7 @@ public class AgentTaskTest {
                 .setId(indexId1)
                 .setKeysType(KeysType.AGG_KEYS)
                 .setShortKeyColumnCount(shortKeyNum)
+                .setSchemaHash(0)
                 .setStorageType(storageType)
                 .addColumns(columns)
                 .build().toTabletSchema();


### PR DESCRIPTION
CreateReplicaTask always uses the index id as the schema id, but for tables that have performed fast schema evolution, the schema id is not equal to the index id.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
