### PR TITLE
[BugFix] Fix generated column become NULL after compaction in pk table

### DIFF
--- a/be/src/storage/rowset/rowset_meta.h
+++ b/be/src/storage/rowset/rowset_meta.h
@@ -234,12 +234,14 @@ public:
     // new rowset.
     // Before calling it, please confirm if you need a complete `rowset_meta` that includes `tablet_schema_pb`.
     // If not, perhaps `get_meta_pb_without_schema()` is enough.
-    void get_full_meta_pb(RowsetMetaPB* rs_meta_pb) const {
+    void get_full_meta_pb(RowsetMetaPB* rs_meta_pb, const TabletSchemaCSPtr& tablet_schema = nullptr) const {
         *rs_meta_pb = *_rowset_meta_pb;
-        if (_schema != nullptr) {
+        const TabletSchemaCSPtr& target_schema = (tablet_schema != nullptr) ? tablet_schema : _schema;
+
+        if (target_schema != nullptr) {
             rs_meta_pb->clear_tablet_schema();
             TabletSchemaPB* ts_pb = rs_meta_pb->mutable_tablet_schema();
-            _schema->to_schema_pb(ts_pb);
+            target_schema->to_schema_pb(ts_pb);
         }
     }
 

--- a/be/src/storage/tablet_updates.cpp
+++ b/be/src/storage/tablet_updates.cpp
@@ -3369,7 +3369,8 @@ Status TabletUpdates::link_from(Tablet* base_tablet, int64_t request_version, Ch
         new_rowset_info.num_segments = src_rowset.num_segments();
         // use src_rowset's meta as base, change some fields to new tablet
         auto& rowset_meta_pb = new_rowset_info.rowset_meta_pb;
-        src_rowset.rowset_meta()->get_full_meta_pb(&rowset_meta_pb);
+        // reset rowset schema to the latest one
+        src_rowset.rowset_meta()->get_full_meta_pb(&rowset_meta_pb, _tablet.tablet_schema());
         rowset_meta_pb.set_deprecated_rowset_id(0);
         rowset_meta_pb.set_rowset_id(rid.to_string());
         rowset_meta_pb.set_rowset_seg_id(new_rowset_info.rowset_id);

--- a/test/sql/test_materialized_column/R/test_materialized_column
+++ b/test/sql/test_materialized_column/R/test_materialized_column
@@ -1018,3 +1018,63 @@ PROPERTIES (
 DROP DATABASE test_schema_change_for_after;
 -- result:
 -- !result
+-- name: test_compaction_after_adding_generated_column
+CREATE DATABASE test_compaction_after_adding_generated_column;
+-- result:
+-- !result
+USE test_compaction_after_adding_generated_column;
+-- result:
+-- !result
+CREATE TABLE `t` (
+  `c1` BIGINT NOT NULL COMMENT "",
+  `c2` BIGINT NOT NULL COMMENT "",
+  `c3` BIGINT as `c1` + `c2`
+) ENGINE=OLAP 
+PRIMARY KEY(`c1`)
+DISTRIBUTED BY HASH(`c1`) BUCKETS 1
+PROPERTIES (
+"replication_num" = "1",
+"in_memory" = "false",
+"enable_persistent_index" = "false",
+"replicated_storage" = "true",
+"compression" = "LZ4"
+);
+-- result:
+-- !result
+INSERT INTO t values (1,1),(2,2),(3,3),(4,4);
+-- result:
+-- !result
+ALTER TABLE t drop column c3;
+-- result:
+-- !result
+INSERT INTO t values (1,1),(2,2),(3,3),(4,4);
+-- result:
+-- !result
+ALTER TABLE t add column c4 BIGINT as c1 + c2 + 10;
+-- result:
+-- !result
+function: wait_alter_table_finish()
+-- result:
+None
+-- !result
+SELECT sleep(10);
+-- result:
+1
+-- !result
+[UC]ALTER TABLE t COMPACT;
+-- result:
+-- !result
+SELECT sleep(30);
+-- result:
+1
+-- !result
+SELECT * FROM t;
+-- result:
+1	1	12
+2	2	14
+3	3	16
+4	4	18
+-- !result
+DROP DATABASE test_compaction_after_adding_generated_column;
+-- result:
+-- !result

--- a/test/sql/test_materialized_column/T/test_materialized_column
+++ b/test/sql/test_materialized_column/T/test_materialized_column
@@ -378,3 +378,37 @@ function: wait_alter_table_finish()
 SHOW CREATE TABLE t0;
 
 DROP DATABASE test_schema_change_for_after;
+
+-- name: test_compaction_after_adding_generated_column
+CREATE DATABASE test_compaction_after_adding_generated_column;
+USE test_compaction_after_adding_generated_column;
+
+CREATE TABLE `t` (
+  `c1` BIGINT NOT NULL COMMENT "",
+  `c2` BIGINT NOT NULL COMMENT "",
+  `c3` BIGINT as `c1` + `c2`
+) ENGINE=OLAP 
+PRIMARY KEY(`c1`)
+DISTRIBUTED BY HASH(`c1`) BUCKETS 1
+PROPERTIES (
+"replication_num" = "1",
+"in_memory" = "false",
+"enable_persistent_index" = "false",
+"replicated_storage" = "true",
+"compression" = "LZ4"
+);
+INSERT INTO t values (1,1),(2,2),(3,3),(4,4);
+ALTER TABLE t drop column c3;
+
+INSERT INTO t values (1,1),(2,2),(3,3),(4,4);
+ALTER TABLE t add column c4 BIGINT as c1 + c2 + 10;
+function: wait_alter_table_finish()
+
+SELECT sleep(10);
+
+[UC]ALTER TABLE t COMPACT;
+SELECT sleep(30);
+
+SELECT * FROM t;
+
+DROP DATABASE test_compaction_after_adding_generated_column;


### PR DESCRIPTION
## Why I'm doing:
Suppose we have a PK table t with c1, c2, c3 and execute SQL as following:
1. INSERT INTO t VALUES (1,1),(2,2),(3,3); rowset 1 with tablet_schema version 0
2. drop column c3;
3. INSERT INTO t VALUES (1,1),(2,2),(3,3); rowset 2 with tablet_schema version 1
4. add column c4 as c1 + c2;

After finishing adding c4, if compaction begin with rowset 1 and rowset 2, it will use schema in rowset 2 to do compaction, because rowset 2 has greater schema version than rowset 1. But the problem is, use schema(c1, c2) will miss the column c4, SegmentIterator will not read the value of the generated column c4 and lead to be NULL after compaction.

This is a corner case about generated columns with light schema change and will only affect generated columns and pk tables.

## What I'm doing:
Reset the schema to the latest for all rowset in link_from

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
