### PR TITLE
[BugFix] Fix NPE from trim() method when no enable parameter given in GlobalDictMetaService request

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/http/meta/GlobalDictMetaService.java
+++ b/fe/fe-core/src/main/java/com/starrocks/http/meta/GlobalDictMetaService.java
@@ -86,21 +86,26 @@ public class GlobalDictMetaService {
             if (method.equals(HttpMethod.POST)) {
                 String tableName = request.getSingleParameter(TABLE_NAME);
                 String dbName = request.getSingleParameter(DB_NAME);
-                if (Strings.isNullOrEmpty(dbName) || Strings.isNullOrEmpty(tableName)) {
-                    response.appendContent("Miss db_name parameter or table_name");
+                String enableParam = request.getSingleParameter(ENABLE);
+                if (Strings.isNullOrEmpty(dbName) || Strings.isNullOrEmpty(tableName) || Strings.isNullOrEmpty(enableParam)) {
+                    response.appendContent("Missing db_name, table_name, or enable parameter");
                     writeResponse(request, response, HttpResponseStatus.BAD_REQUEST);
                     return;
                 }
-
-                boolean isEnable = "true".equalsIgnoreCase(request.getSingleParameter(ENABLE).trim());
-
+                if (!enableParam.trim().equalsIgnoreCase("true") && !enableParam.trim().equalsIgnoreCase("false")) {
+                    response.appendContent("Invalid enable parameter. It should be either 'true' or 'false'");
+                    writeResponse(request, response, HttpResponseStatus.BAD_REQUEST);
+                    return;
+                }
+                boolean isEnable = Boolean.parseBoolean(enableParam.trim());
                 GlobalStateMgr.getCurrentState().getLocalMetastore()
                         .setHasForbiddenGlobalDict(dbName, tableName, isEnable);
                 response.appendContent(new RestBaseResult("apply success").toJson());
             } else {
                 response.appendContent(new RestBaseResult("HTTP method is not allowed.").toJson());
+                writeResponse(request, response, HttpResponseStatus.METHOD_NOT_ALLOWED);
+                return;
             }
-            writeResponse(request, response, HttpResponseStatus.METHOD_NOT_ALLOWED);
             sendResult(request, response);
         }
     }


### PR DESCRIPTION
## Why I'm doing:
When no enable parameter given in request trim() method throws NPE.

## What I'm doing:
Setted that parameter default as true and add controls.

Fixes #issue

## What type of PR is this:

- [X] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [X] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [x] 3.1
  - [x] 3.0
  - [ ] 2.5
