### PR TITLE
[BugFix] fix reading iceberg equality delete correctness issue

### DIFF
--- a/be/src/exec/hdfs_scanner.cpp
+++ b/be/src/exec/hdfs_scanner.cpp
@@ -83,7 +83,6 @@ Status HdfsScanner::init(RuntimeState* runtime_state, const HdfsScannerParams& s
 
     RETURN_IF_ERROR(_init_mor_processor(runtime_state, scanner_params.mor_params));
     Status status = do_init(runtime_state, scanner_params);
-    RETURN_IF_ERROR(_mor_processor->build_hash_table(runtime_state));
 
     return status;
 }
@@ -187,6 +186,7 @@ Status HdfsScanner::open(RuntimeState* runtime_state) {
     }
     RETURN_IF_ERROR(_build_scanner_context());
     RETURN_IF_ERROR(do_open(runtime_state));
+    RETURN_IF_ERROR(_mor_processor->build_hash_table(runtime_state));
     _opened = true;
     VLOG_FILE << "open file success: " << _scanner_params.path;
     return Status::OK();

--- a/test/sql/test_iceberg/R/test_iceberg_v2
+++ b/test/sql/test_iceberg/R/test_iceberg_v2
@@ -14,15 +14,15 @@ create external catalog iceberg_sql_test_${uuid0} PROPERTIES ("type"="iceberg", 
 )
 */
 
-select * from iceberg_sql_test_${uuid0}.iceberg_ci_db.iceberg_v2_orc_unpartitioned_table;
+select * from iceberg_sql_test_${uuid0}.iceberg_ci_db.iceberg_v2_orc_unpartitioned_table order by k1;
 -- result:
 1	tianjing
 2	guangzhou
 -- !result
-select k2 from iceberg_sql_test_${uuid0}.iceberg_ci_db.iceberg_v2_orc_unpartitioned_table;
+select k2 from iceberg_sql_test_${uuid0}.iceberg_ci_db.iceberg_v2_orc_unpartitioned_table order by k2;
 -- result:
-tianjing
 guangzhou
+tianjing
 -- !result
 select count(*) from iceberg_sql_test_${uuid0}.iceberg_ci_db.iceberg_v2_orc_unpartitioned_table;
 -- result:
@@ -44,17 +44,17 @@ WITH (
 )
 */
 
-select * from iceberg_sql_test_${uuid0}.iceberg_ci_db.iceberg_v2_orc_partitioned_table;
+select * from iceberg_sql_test_${uuid0}.iceberg_ci_db.iceberg_v2_orc_partitioned_table order by k1;
 -- result:
 1	beijing	zhangsan
 2	shanghai	lisi
 -- !result
-select k2 from iceberg_sql_test_${uuid0}.iceberg_ci_db.iceberg_v2_orc_partitioned_table;
+select k2 from iceberg_sql_test_${uuid0}.iceberg_ci_db.iceberg_v2_orc_partitioned_table order by k2;
 -- result:
-shanghai
 beijing
+shanghai
 -- !result
-select k3 from iceberg_sql_test_${uuid0}.iceberg_ci_db.iceberg_v2_orc_partitioned_table;
+select k3 from iceberg_sql_test_${uuid0}.iceberg_ci_db.iceberg_v2_orc_partitioned_table order by k1;
 -- result:
 zhangsan
 lisi
@@ -66,7 +66,7 @@ select count(*) from iceberg_sql_test_${uuid0}.iceberg_ci_db.iceberg_v2_orc_part
 select k1,k3 from iceberg_sql_test_${uuid0}.iceberg_ci_db.iceberg_v2_orc_partitioned_table group by k1,k3 having count(1) > 1;
 -- result:
 -- !result
-drop catalog iceberg_sql_test_${uuid0}
+drop catalog iceberg_sql_test_${uuid0};
 -- result:
 []
 -- !result

--- a/test/sql/test_iceberg/R/test_iceberg_v2
+++ b/test/sql/test_iceberg/R/test_iceberg_v2
@@ -1,0 +1,72 @@
+-- name: test_iceberg_v2
+create external catalog iceberg_sql_test_${uuid0} PROPERTIES ("type"="iceberg", "iceberg.catalog.type"="hive", "iceberg.catalog.hive.metastore.uris"="${iceberg_catalog_hive_metastore_uris}","enable_iceberg_metadata_cache"="true");
+-- result:
+[]
+-- !result
+/*
+ CREATE TABLE `hive_catalog`.`iceberg_ci_db`.`iceberg_v2_orc_unpartitioned_table` (
+  `k1` INT NOT NULL,
+  `k2` VARCHAR(2147483647),
+  CONSTRAINT `7193cf04-1e4f-4aec-be16-2aa54bb92b4c` PRIMARY KEY (`k1`) NOT ENFORCED
+) WITH (
+  'write-format' = 'orc',
+  'write.upsert.enabled' = 'true'
+)
+*/
+
+select * from iceberg_sql_test_${uuid0}.iceberg_ci_db.iceberg_v2_orc_unpartitioned_table;
+-- result:
+1	tianjing
+2	guangzhou
+-- !result
+select k2 from iceberg_sql_test_${uuid0}.iceberg_ci_db.iceberg_v2_orc_unpartitioned_table;
+-- result:
+tianjing
+guangzhou
+-- !result
+select count(*) from iceberg_sql_test_${uuid0}.iceberg_ci_db.iceberg_v2_orc_unpartitioned_table;
+-- result:
+2
+-- !result
+select k1 from iceberg_sql_test_${uuid0}.iceberg_ci_db.iceberg_v2_orc_unpartitioned_table group by k1 having count(1) > 1;
+-- result:
+-- !result
+/*
+CREATE TABLE `hive_catalog`.`iceberg_ci_db`.`iceberg_v2_orc_partitioned_table` (
+  `k1` INT NOT NULL,
+  `k2` VARCHAR(2147483647),
+  `k3` VARCHAR(2147483647) NOT NULL,
+  CONSTRAINT `cfcc11a4-b515-44e8-a6c2-5fe99a2e92ee` PRIMARY KEY (`k1`, `k3`) NOT ENFORCED
+) PARTITIONED BY (`k3`)
+WITH (
+  'write-format' = 'orc',
+  'write.upsert.enabled' = 'true'
+)
+*/
+
+select * from iceberg_sql_test_${uuid0}.iceberg_ci_db.iceberg_v2_orc_partitioned_table;
+-- result:
+1	beijing	zhangsan
+2	shanghai	lisi
+-- !result
+select k2 from iceberg_sql_test_${uuid0}.iceberg_ci_db.iceberg_v2_orc_partitioned_table;
+-- result:
+shanghai
+beijing
+-- !result
+select k3 from iceberg_sql_test_${uuid0}.iceberg_ci_db.iceberg_v2_orc_partitioned_table;
+-- result:
+zhangsan
+lisi
+-- !result
+select count(*) from iceberg_sql_test_${uuid0}.iceberg_ci_db.iceberg_v2_orc_partitioned_table;
+-- result:
+2
+-- !result
+select k1,k3 from iceberg_sql_test_${uuid0}.iceberg_ci_db.iceberg_v2_orc_partitioned_table group by k1,k3 having count(1) > 1;
+-- result:
+-- !result
+drop catalog iceberg_sql_test_${uuid0}
+-- result:
+[]
+-- !result

--- a/test/sql/test_iceberg/T/test_iceberg_v2
+++ b/test/sql/test_iceberg/T/test_iceberg_v2
@@ -17,9 +17,9 @@ create external catalog iceberg_sql_test_${uuid0} PROPERTIES ("type"="iceberg", 
 )
 */
 
-select * from iceberg_sql_test_${uuid0}.iceberg_ci_db.iceberg_v2_orc_unpartitioned_table;
+select * from iceberg_sql_test_${uuid0}.iceberg_ci_db.iceberg_v2_orc_unpartitioned_table order by k1;
 
-select k2 from iceberg_sql_test_${uuid0}.iceberg_ci_db.iceberg_v2_orc_unpartitioned_table;
+select k2 from iceberg_sql_test_${uuid0}.iceberg_ci_db.iceberg_v2_orc_unpartitioned_table order by k2;
 
 select count(*) from iceberg_sql_test_${uuid0}.iceberg_ci_db.iceberg_v2_orc_unpartitioned_table;
 
@@ -39,15 +39,15 @@ WITH (
 )
 */
 
-select * from iceberg_sql_test_${uuid0}.iceberg_ci_db.iceberg_v2_orc_partitioned_table;
+select * from iceberg_sql_test_${uuid0}.iceberg_ci_db.iceberg_v2_orc_partitioned_table order by k1;
 
-select k2 from iceberg_sql_test_${uuid0}.iceberg_ci_db.iceberg_v2_orc_partitioned_table;
+select k2 from iceberg_sql_test_${uuid0}.iceberg_ci_db.iceberg_v2_orc_partitioned_table order by k2;
 
-select k3 from iceberg_sql_test_${uuid0}.iceberg_ci_db.iceberg_v2_orc_partitioned_table;
+select k3 from iceberg_sql_test_${uuid0}.iceberg_ci_db.iceberg_v2_orc_partitioned_table order by k1;
 
 select count(*) from iceberg_sql_test_${uuid0}.iceberg_ci_db.iceberg_v2_orc_partitioned_table;
 
 select k1,k3 from iceberg_sql_test_${uuid0}.iceberg_ci_db.iceberg_v2_orc_partitioned_table group by k1,k3 having count(1) > 1;
 
 
-drop catalog iceberg_sql_test_${uuid0}
+drop catalog iceberg_sql_test_${uuid0};

--- a/test/sql/test_iceberg/T/test_iceberg_v2
+++ b/test/sql/test_iceberg/T/test_iceberg_v2
@@ -1,0 +1,53 @@
+-- name: test_iceberg_v2
+
+create external catalog iceberg_sql_test_${uuid0} PROPERTIES ("type"="iceberg", "iceberg.catalog.type"="hive", "iceberg.catalog.hive.metastore.uris"="${iceberg_catalog_hive_metastore_uris}","enable_iceberg_metadata_cache"="true");
+
+-- Currently only flink can write iceberg equality delete file. The table in the case was created in advance and some test data was inserted using flink. If you want test more cases, you could contact stephen5217@163.com
+
+
+-- unpartitioned table with orc (eq-delete && pos-delete) 
+/*
+ CREATE TABLE `hive_catalog`.`iceberg_ci_db`.`iceberg_v2_orc_unpartitioned_table` (
+  `k1` INT NOT NULL,
+  `k2` VARCHAR(2147483647),
+  CONSTRAINT `7193cf04-1e4f-4aec-be16-2aa54bb92b4c` PRIMARY KEY (`k1`) NOT ENFORCED
+) WITH (
+  'write-format' = 'orc',
+  'write.upsert.enabled' = 'true'
+)
+*/
+
+select * from iceberg_sql_test_${uuid0}.iceberg_ci_db.iceberg_v2_orc_unpartitioned_table;
+
+select k2 from iceberg_sql_test_${uuid0}.iceberg_ci_db.iceberg_v2_orc_unpartitioned_table;
+
+select count(*) from iceberg_sql_test_${uuid0}.iceberg_ci_db.iceberg_v2_orc_unpartitioned_table;
+
+select k1 from iceberg_sql_test_${uuid0}.iceberg_ci_db.iceberg_v2_orc_unpartitioned_table group by k1 having count(1) > 1;
+
+-- partitioned table with orc (eq-delete && pos-delete)
+/*
+CREATE TABLE `hive_catalog`.`iceberg_ci_db`.`iceberg_v2_orc_partitioned_table` (
+  `k1` INT NOT NULL,
+  `k2` VARCHAR(2147483647),
+  `k3` VARCHAR(2147483647) NOT NULL,
+  CONSTRAINT `cfcc11a4-b515-44e8-a6c2-5fe99a2e92ee` PRIMARY KEY (`k1`, `k3`) NOT ENFORCED
+) PARTITIONED BY (`k3`)
+WITH (
+  'write-format' = 'orc',
+  'write.upsert.enabled' = 'true'
+)
+*/
+
+select * from iceberg_sql_test_${uuid0}.iceberg_ci_db.iceberg_v2_orc_partitioned_table;
+
+select k2 from iceberg_sql_test_${uuid0}.iceberg_ci_db.iceberg_v2_orc_partitioned_table;
+
+select k3 from iceberg_sql_test_${uuid0}.iceberg_ci_db.iceberg_v2_orc_partitioned_table;
+
+select count(*) from iceberg_sql_test_${uuid0}.iceberg_ci_db.iceberg_v2_orc_partitioned_table;
+
+select k1,k3 from iceberg_sql_test_${uuid0}.iceberg_ci_db.iceberg_v2_orc_partitioned_table group by k1,k3 having count(1) > 1;
+
+
+drop catalog iceberg_sql_test_${uuid0}


### PR DESCRIPTION
## Why I'm doing:
StarRocks failed to deduplicate by this refacotr https://github.com/StarRocks/starrocks/pull/41004 when reading iceberg equality delete files

## What I'm doing:
- fix correctness issue
- add sql tests

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
