### PR TITLE
[BugFix] fix for semantics of const column

### DIFF
--- a/be/src/column/const_column.cpp
+++ b/be/src/column/const_column.cpp
@@ -27,10 +27,6 @@ ConstColumn::ConstColumn(ColumnPtr data) : ConstColumn(std::move(data), 0) {}
 
 ConstColumn::ConstColumn(ColumnPtr data, size_t size) : _data(std::move(data)), _size(size) {
     DCHECK(!_data->is_constant());
-    if (_data->is_nullable() && size > 0 && !_data->is_null(0)) {
-        _data = down_cast<NullableColumn*>(_data.get())->data_column();
-    }
-    DCHECK(_data->is_nullable() ? _size == 0 || _data->is_null(0) : true);
     if (_data->size() > 1) {
         _data->resize(1);
     }

--- a/be/src/column/const_column.h
+++ b/be/src/column/const_column.h
@@ -50,10 +50,7 @@ public:
 
     bool is_null(size_t index) const override { return _data->is_null(0); }
 
-    bool only_null() const override {
-        DCHECK(_data->is_nullable() ? _size == 0 || _data->is_null(0) : true);
-        return _data->is_nullable();
-    }
+    bool only_null() const override { return _data->has_null(); }
 
     bool has_null() const override { return _data->has_null(); }
 


### PR DESCRIPTION
## Why I'm doing:

Right now the const column method semantics are wrong

```
ConstColumn::ConstColumn(ColumnPtr data, size_t size) : _data(std::move(data)), _size(size) {
    DCHECK(!_data->is_constant());
    if (_data->is_nullable() && size > 0 && !_data->is_null(0)) {
        _data = down_cast<NullableColumn*>(_data.get())->data_column();
    }
    DCHECK(_data->is_nullable() ? _size == 0 || _data->is_null(0) : true);
    if (_data->size() > 1) {
        _data->resize(1);
    }
}

bool is_nullable() const override { return _data->is_nullable(); }
```

Think about in ctor, data is a nullable column, and underlying is a int8column with value 10 in it.

And after construction, const column `data` field is not nullable column any more, but int8 column.

And when you ask this cont column `is_nullable`, it will return false. But this is not what we expect, because when we construct this const column, we pass a nullable column.

-----------------

And `only_null` is also not correct,
```
    bool only_null() const override {
        DCHECK(_data->is_nullable() ? _size == 0 || _data->is_null(0) : true);
        return _data->is_nullable();
    }
```

## What I'm doing:

don't unpack nullable column when construct const column

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
