### PR TITLE
[BugFix] fix profile scan metrics skewed

### DIFF
--- a/be/src/exec/pipeline/scan/scan_operator.cpp
+++ b/be/src/exec/pipeline/scan/scan_operator.cpp
@@ -300,7 +300,7 @@ Status ScanOperator::_try_to_trigger_next_scan(RuntimeState* state) {
     int size = 0;
 
     // pick up already started chunk source.
-    while (--cnt >= 0) {
+    while (--cnt >= 0 && size < total_cnt) {
         _chunk_source_idx = (_chunk_source_idx + 1) % _io_tasks_per_scan_operator;
         int i = _chunk_source_idx;
         if (_is_io_task_running[i]) {
@@ -318,7 +318,6 @@ Status ScanOperator::_try_to_trigger_next_scan(RuntimeState* state) {
         }
     }
 
-    size = std::min(size, total_cnt);
     // pick up new chunk source.
     begin_pickup_morsels();
     ASSIGN_OR_RETURN(auto morsel_ready, _morsel_queue->ready_for_next());


### PR DESCRIPTION
## Why I'm doing:

Chunk source level metrics in profile are skewed 

Using this case `select count(*) from lineorder;`, the profile shows like

```
               - RowsRead: 18.001B (18001137060)
                 - __MAX_OF_RowsRead: 3.030B (3029667213)
                 - __MIN_OF_RowsRead: 5.990M (5989695)
               - ScanRanges: 5.220K (5220)
                 - __MAX_OF_ScanRanges: 887
                 - __MIN_OF_ScanRanges: 2
               - ScanRangesSize: 348.544 GB
                 - __MAX_OF_ScanRangesSize: 59.488 GB
                 - __MIN_OF_ScanRangesSize: 128.000 MB
 ```

## What I'm doing:

The reason is that each scan operator tries to use chunk source with index 0 as much as possible. As a result, many metrics are accumulated on chunk source 0, causing the profile to appear skewed. Although it has no impact on execution time, it significantly affects the analysis of the profile.

and after fix, the profile shows like , much better now(although still skewed). 

```
               - RowsRead: 18.001B (18001137060)
                 - __MAX_OF_RowsRead: 399.667M (399667233)
                 - __MIN_OF_RowsRead: 195.304M (195304090)
               - ScanRanges: 5.220K (5220)
                 - __MAX_OF_ScanRanges: 115
                 - __MIN_OF_ScanRanges: 54
               - ScanRangesSize: 348.544 GB
                 - __MAX_OF_ScanRangesSize: 7.653 GB
                 - __MIN_OF_ScanRangesSize: 3.686 GB
```


Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [x] 3.1
  - [x] 3.0
  - [x] 2.5
