### PR TITLE
[BugFix]Fix the bug of setting the default value for the float type when creating table

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/analysis/FloatLiteral.java
+++ b/fe/fe-core/src/main/java/com/starrocks/analysis/FloatLiteral.java
@@ -127,11 +127,7 @@ public class FloatLiteral extends LiteralExpr {
         // Figure out if this will fit in a FLOAT without loosing precision.
         float fvalue;
         fvalue = value.floatValue();
-        if (fvalue == this.value) {
-            type = Type.FLOAT;
-        } else {
-            type = Type.DOUBLE;
-        }
+        type = Float.toString(fvalue).equals(Double.toString(value)) ? Type.FLOAT : Type.DOUBLE;
     }
 
     private void checkValue(Double value) throws AnalysisException {

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/ColumnDefTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/ColumnDefTest.java
@@ -214,6 +214,53 @@ public class ColumnDefTest {
         }
     }
 
+    @Test
+    public void testFloatDefaultValue() throws AnalysisException {
+        ColumnDef column1 =
+                new ColumnDef("col", floatCol, false, null, true, new DefaultValueDef(true, new StringLiteral("1")),
+                        "");
+        column1.analyze(true);
+        Assert.assertEquals("1", column1.getDefaultValue());
+
+        ColumnDef column2 =
+                new ColumnDef("col", floatCol, false, null, true, new DefaultValueDef(true, new StringLiteral("1.1")),
+                        "");
+        column2.analyze(true);
+        Assert.assertEquals("1.1", column2.getDefaultValue());
+
+        ColumnDef column3 =
+                new ColumnDef("col", floatCol, false, null, true, new DefaultValueDef(true, new StringLiteral("1.100000000")),
+                        "");
+        Assert.assertEquals("1.100000000", column3.getDefaultValue());
+
+        ColumnDef column4 =
+                new ColumnDef("col", floatCol, false, null, true, new DefaultValueDef(true, new StringLiteral("1.1234567")),
+                        "");
+        Assert.assertEquals("1.1234567", column4.getDefaultValue());
+
+        ColumnDef column5 =
+                new ColumnDef("col", floatCol, false, null, true, new DefaultValueDef(true, new StringLiteral("1.12345678")),
+                        "");
+        try {
+            column5.analyze(true);
+        } catch (AnalysisException e) {
+            Assert.assertTrue(e.getMessage().contains("Default value will loose precision: 1.12345678"));
+        }
+
+        ColumnDef column6 =
+                new ColumnDef("col", floatCol, false, null, true, new DefaultValueDef(true, new StringLiteral("123456789")),
+                        "");
+        try {
+            column6.analyze(true);
+        } catch (AnalysisException e) {
+            Assert.assertTrue(e.getMessage().contains("Default value will loose precision: 123456789"));
+        }
+        ColumnDef column7 =
+                new ColumnDef("col", floatCol, false, null, true, new DefaultValueDef(true, new StringLiteral("1.99E38")),
+                        "");
+        Assert.assertEquals("1.99E38", column7.getDefaultValue());
+    }
+
     @Test(expected = AnalysisException.class)
     public void testArrayHLL() throws AnalysisException {
         ColumnDef column =

--- a/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AnalyzeDecimalV3Test.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AnalyzeDecimalV3Test.java
@@ -893,7 +893,7 @@ public class AnalyzeDecimalV3Test {
             Assert.assertEquals(items.get(0).getType(), ScalarType.DOUBLE);
             Assert.assertEquals(items.get(1).getType(),
                     ScalarType.createDecimalV3Type(PrimitiveType.DECIMAL128, 38, 0));
-            Assert.assertEquals(items.get(2).getType(), ScalarType.DOUBLE);
+            Assert.assertEquals(items.get(2).getType(), ScalarType.FLOAT);
             Assert.assertEquals(items.get(3).getType(), ScalarType.createDecimalV3NarrowestType(3, 2));
             Assert.assertEquals(items.get(4).getType(), ScalarType.createDecimalV3TypeForZero(1));
         }


### PR DESCRIPTION
## Why I'm doing:
The judgment of the data type after `FLOAT DEFAULT` is incorrect.
An exception will be thrown when executing `create table t_test(a int, b float default "0.1");` :

![image](https://github.com/StarRocks/starrocks/assets/79825592/5f976b00-3658-46c5-a535-6f80ccdafd57)


## What I'm doing:
The reason is that the default value is incorrectly determined as the double type by checking whether two floating-point values are equal.
I modified the comparison method of two floating-point data to prevent two numbers from being judged as unequal even if they are the same. The toString methods of Double and Float can be used to accurately compare two floating-point numbers, without being affected by trailing zeros.

![image](https://github.com/StarRocks/starrocks/assets/79825592/93619bfd-7771-4c54-9442-833f58ee0411)

Fixes #42370

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
