### PR TITLE
[BugFix] Skip the temporary directory created by spark when list hive directory recursively

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/connector/hive/HiveRemoteFileIO.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/hive/HiveRemoteFileIO.java
@@ -188,7 +188,7 @@ public class HiveRemoteFileIO implements RemoteFileIO {
             return false;
         }
         String dirName = fileStatus.getPath().getName();
-        return !(dirName.startsWith("."));
+        return !(dirName.startsWith(".") || dirName.startsWith("_temporary"));
     }
 
     protected List<RemoteFileBlockDesc> getRemoteFileBlockDesc(BlockLocation[] blockLocations) throws IOException {

--- a/fe/fe-core/src/main/java/com/starrocks/connector/hive/HiveRemoteFileIO.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/hive/HiveRemoteFileIO.java
@@ -188,7 +188,7 @@ public class HiveRemoteFileIO implements RemoteFileIO {
             return false;
         }
         String dirName = fileStatus.getPath().getName();
-        return !(dirName.startsWith(".") || dirName.startsWith("_temporary"));
+        return !(dirName.startsWith(".") || dirName.startsWith("_"));
     }
 
     protected List<RemoteFileBlockDesc> getRemoteFileBlockDesc(BlockLocation[] blockLocations) throws IOException {

--- a/fe/fe-core/src/test/java/com/starrocks/connector/hive/MockedRemoteFileSystem.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/hive/MockedRemoteFileSystem.java
@@ -66,7 +66,8 @@ public class MockedRemoteFileSystem extends FileSystem {
         List<LocatedFileStatus> tblDirs = ImmutableList.of(
                 locatedFileStatus(new Path(HDFS_RECURSIVE_TABLE + "/subdir1"), true),
                 locatedFileStatus(new Path(HDFS_RECURSIVE_TABLE + "/subdir2"), true),
-                locatedFileStatus(new Path(HDFS_RECURSIVE_TABLE + "/.subdir3"), true)
+                locatedFileStatus(new Path(HDFS_RECURSIVE_TABLE + "/.subdir3"), true),
+                locatedFileStatus(new Path(HDFS_RECURSIVE_TABLE + "/_temporary"), true)
                 );
         recEntries.put(HDFS_RECURSIVE_TABLE, tblDirs);
 
@@ -85,6 +86,11 @@ public class MockedRemoteFileSystem extends FileSystem {
                 locatedFileStatus(new Path(HDFS_RECURSIVE_TABLE + "/.subdir3/000000_3"), false)
                 );
         recEntries.put(HDFS_RECURSIVE_TABLE + "/.subdir3", subDir3);
+
+        List<LocatedFileStatus> subDir4 = ImmutableList.of(
+                locatedFileStatus(new Path(HDFS_RECURSIVE_TABLE + "/_temporary/000000_4"), false)
+                );
+        recEntries.put(HDFS_RECURSIVE_TABLE + "/_temporary", subDir4);
 
         return recEntries;
     }


### PR DESCRIPTION
## Why I'm doing:
Spark job/sql will created temporary named _temporary(see: https://stackoverflow.com/questions/46882683/spark-temporary-creation-reason) to storing  intermediate work for ensuring consistency of the final result.  StarRocks does not skip the _temporary directory and its files when querying a Hive table, which can cause the query to fail or yield incorrect results.

## What I'm doing:
Skip directory named _temporary when recursively listing Hive directories

Fixes #42060

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [x] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [x] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [x] 3.1
  - [ ] 3.0
  - [ ] 2.5
