### PR TITLE
[Enhancement] Imporve JoinReroder performance

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/join/JoinOrder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/join/JoinOrder.java
@@ -318,6 +318,10 @@ public abstract class JoinOrder {
         Map<ColumnRefOperator, ScalarOperator> leftExpression = new HashMap<>();
         Map<ColumnRefOperator, ScalarOperator> rightExpression = new HashMap<>();
         if (!onPredicates.isEmpty()) {
+            ColumnRefSet allChildColumns = new ColumnRefSet();
+            allChildColumns.union(leftExprInfo.expr.getOutputColumns());
+            allChildColumns.union(rightExprInfo.expr.getOutputColumns());
+
             for (int i = 0; i < onPredicates.size(); i++) {
                 ScalarOperator predicate = onPredicates.get(i);
                 ColumnRefSet useColumns = predicate.getUsedColumns();
@@ -341,9 +345,6 @@ public abstract class JoinOrder {
                         continue;
                     }
 
-                    ColumnRefSet allChildColumns = new ColumnRefSet();
-                    allChildColumns.union(leftExprInfo.expr.getOutputColumns());
-                    allChildColumns.union(rightExprInfo.expr.getOutputColumns());
                     if (allChildColumns.containsAll(valueUseColumns)) {
                         // depend on two children, must rewrite to origin expression
                         ReplaceColumnRefRewriter rewriter =


### PR DESCRIPTION
## Why I'm doing:

Fixes #27472, the predicate need all children to compute expression, can't push down to any child's projection, we should remove the predicate in this join node

optimize tpcds-64 800ms to 400ms, because remove check valid-plan phase

## What I'm doing:

Fixes #27472

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [x] 3.1
  - [ ] 3.0
  - [ ] 2.5
