### PR TITLE
[BugFix] The sort key maybe overwrite after doing ALTER job on a table with rollup

### DIFF
--- a/be/src/column/schema.cpp
+++ b/be/src/column/schema.cpp
@@ -42,9 +42,14 @@ Schema::Schema(Fields fields, KeysType keys_type, std::vector<ColumnId> sort_key
 Schema::Schema(Schema* schema, const std::vector<ColumnId>& cids)
         : _name_to_index_append_buffer(nullptr), _keys_type(schema->_keys_type) {
     _fields.resize(cids.size());
+    auto ori_sort_idxes = schema->sort_key_idxes();
+    std::unordered_set<ColumnId> scids(ori_sort_idxes.begin(), ori_sort_idxes.end());
     for (int i = 0; i < cids.size(); i++) {
         DCHECK_LT(cids[i], schema->_fields.size());
         _fields[i] = schema->_fields[cids[i]];
+        if (scids.find(cids[i]) != scids.end()) {
+            _sort_key_idxes.emplace_back(i);
+        }
     }
     auto is_key = [](const FieldPtr& f) { return f->is_key(); };
     _num_keys = std::count_if(_fields.begin(), _fields.end(), is_key);

--- a/be/src/storage/memtable.cpp
+++ b/be/src/storage/memtable.cpp
@@ -518,6 +518,7 @@ Status MemTable::_sort_column_inc(bool by_sort_key) {
 
     for (auto sort_key_idx : sort_key_idxes) {
         columns.push_back(_chunk->get_column_by_index(sort_key_idx));
+
     }
 
     auto sort_descs = SortDescs::asc_null_first(sort_key_idxes.size());

--- a/be/src/storage/memtable.cpp
+++ b/be/src/storage/memtable.cpp
@@ -518,7 +518,6 @@ Status MemTable::_sort_column_inc(bool by_sort_key) {
 
     for (auto sort_key_idx : sort_key_idxes) {
         columns.push_back(_chunk->get_column_by_index(sort_key_idx));
-
     }
 
     auto sort_descs = SortDescs::asc_null_first(sort_key_idxes.size());

--- a/fe/fe-core/src/main/java/com/starrocks/alter/RollupJobV2.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/RollupJobV2.java
@@ -278,8 +278,8 @@ public class RollupJobV2 extends AlterJobV2 implements GsonPostProcessable {
                                 tbl.isInMemory(),
                                 tbl.enablePersistentIndex(),
                                 tbl.primaryIndexCacheExpireSec(),
-                                tabletType, tbl.getCompressionType(), index.getSortKeyIdxes(),
-                                index.getSortKeyUniqueIds(), true);
+                                tabletType, tbl.getCompressionType(), null,
+                                null, true);
                         createReplicaTask.setBaseTablet(tabletIdMap.get(rollupTabletId), baseSchemaHash);
                         createReplicaTask.setSchemaVersion(rollupSchemaVersion);
                         batchTask.addTask(createReplicaTask);

--- a/test/sql/test_sort_key/R/test_sort_key_agg_tbl
+++ b/test/sql/test_sort_key/R/test_sort_key_agg_tbl
@@ -80,11 +80,11 @@ insert into agg_test values (1,2,2,10,9),(2,3,2,9,7),(2,1,2,8,8);
 select * from agg_test;
 -- result:
 2	1	2	8	8
-3	1	2	8	8
 1	2	2	10	9
+2	3	2	9	7
+3	1	2	8	8
 2	2	2	9	7
 1	3	2	10	9
-2	3	2	9	7
 -- !result
 function: manual_compact("sort_key_test_agg", "agg_test")
 -- result:
@@ -335,7 +335,6 @@ select * from agg_test;
 drop table agg_test;
 -- result:
 -- !result
-drop database sort_key_test_agg;
+drop database sort_key_test_agg_with_rollup;
 -- result:
-E: (1064, "Can't drop database 'sort_key_test_agg'; database doesn't exist")
 -- !result

--- a/test/sql/test_sort_key/R/test_sort_key_agg_tbl
+++ b/test/sql/test_sort_key/R/test_sort_key_agg_tbl
@@ -80,11 +80,11 @@ insert into agg_test values (1,2,2,10,9),(2,3,2,9,7),(2,1,2,8,8);
 select * from agg_test;
 -- result:
 2	1	2	8	8
-1	2	2	10	9
-2	3	2	9	7
 3	1	2	8	8
+1	2	2	10	9
 2	2	2	9	7
 1	3	2	10	9
+2	3	2	9	7
 -- !result
 function: manual_compact("sort_key_test_agg", "agg_test")
 -- result:
@@ -176,16 +176,166 @@ PROPERTIES (
 -- !result
 select * from agg_test;
 -- result:
-2	1	10	2	9
-3	1	10	2	9
 1	2	8	2	8
-2	2	9	2	7
-3	2	9	2	7
 1	3	8	2	8
+2	1	10	2	9
+2	2	9	2	7
+3	1	10	2	9
+3	2	9	2	7
 -- !result
 drop table agg_test;
 -- result:
 -- !result
 drop database sort_key_test_agg;
 -- result:
+-- !result
+-- name: test_sort_key_agg_tbl_with_rollup;
+create database sort_key_test_agg_with_rollup;
+-- result:
+-- !result
+use sort_key_test_agg_with_rollup;
+-- result:
+-- !result
+CREATE TABLE `agg_test` (
+    `k1` int(11) NOT NULL COMMENT "",
+    `k2` int(11) NOT NULL COMMENT "",
+    `v1` bigint REPLACE NULL COMMENT "",
+    `v2` bigint REPLACE NULL COMMENT "",
+    `v3` bigint REPLACE NULL COMMENT ""
+)
+AGGREGATE KEY(k1, k2)
+COMMENT "OLAP"
+DISTRIBUTED BY HASH(`k1`, `k2`) BUCKETS 1
+ORDER BY (k2,k1)
+PROPERTIES (
+    "replication_num" = "1",
+    "in_memory" = "false",
+    "storage_format" = "DEFAULT",
+    "enable_persistent_index" = "false"
+);
+-- result:
+-- !result
+insert into agg_test values (1,3,2,10,9),(2,2,2,9,7),(3,1,2,8,8);
+-- result:
+-- !result
+select * from agg_test;
+-- result:
+3	1	2	8	8
+2	2	2	9	7
+1	3	2	10	9
+-- !result
+insert into agg_test values (1,2,2,10,9),(2,3,2,9,7),(2,1,2,8,8);
+-- result:
+-- !result
+select * from agg_test;
+-- result:
+2	1	2	8	8
+1	2	2	10	9
+2	3	2	9	7
+3	1	2	8	8
+2	2	2	9	7
+1	3	2	10	9
+-- !result
+alter table agg_test add rollup r1 (k1,k2,v3,v1);
+-- result:
+-- !result
+function: wait_alter_table_finish("rollup", 8)
+-- result:
+None
+-- !result
+function: manual_compact("sort_key_test_agg_with_rollup", "agg_test")
+-- result:
+None
+-- !result
+select * from agg_test;
+-- result:
+2	1	2	8	8
+3	1	2	8	8
+1	2	2	10	9
+2	2	2	9	7
+1	3	2	10	9
+2	3	2	9	7
+-- !result
+alter table agg_test order by (k1,k2);
+-- result:
+-- !result
+function: wait_alter_table_finish()
+-- result:
+None
+-- !result
+show create table agg_test;
+-- result:
+agg_test	CREATE TABLE `agg_test` (
+  `k1` int(11) NOT NULL COMMENT "",
+  `k2` int(11) NOT NULL COMMENT "",
+  `v1` bigint(20) REPLACE NULL COMMENT "",
+  `v2` bigint(20) REPLACE NULL COMMENT "",
+  `v3` bigint(20) REPLACE NULL COMMENT ""
+) ENGINE=OLAP 
+AGGREGATE KEY(`k1`, `k2`)
+COMMENT "OLAP"
+DISTRIBUTED BY HASH(`k1`, `k2`) BUCKETS 1 
+ORDER BY(`k1`, `k2`)
+PROPERTIES (
+"replication_num" = "1",
+"in_memory" = "false",
+"enable_persistent_index" = "false",
+"replicated_storage" = "true",
+"fast_schema_evolution" = "true",
+"compression" = "LZ4"
+);
+-- !result
+select * from agg_test;
+-- result:
+1	2	2	10	9
+1	3	2	10	9
+2	1	2	8	8
+2	2	2	9	7
+2	3	2	9	7
+3	1	2	8	8
+-- !result
+alter table agg_test order by (k2,k1,v2,v1,v3);
+-- result:
+-- !result
+function: wait_alter_table_finish()
+-- result:
+None
+-- !result
+show create table agg_test;
+-- result:
+agg_test	CREATE TABLE `agg_test` (
+  `k2` int(11) NOT NULL COMMENT "",
+  `k1` int(11) NOT NULL COMMENT "",
+  `v2` bigint(20) REPLACE NULL COMMENT "",
+  `v1` bigint(20) REPLACE NULL COMMENT "",
+  `v3` bigint(20) REPLACE NULL COMMENT ""
+) ENGINE=OLAP 
+AGGREGATE KEY(`k2`, `k1`)
+COMMENT "OLAP"
+DISTRIBUTED BY HASH(`k1`, `k2`) BUCKETS 1 
+ORDER BY(`k1`, `k2`)
+PROPERTIES (
+"replication_num" = "1",
+"in_memory" = "false",
+"enable_persistent_index" = "false",
+"replicated_storage" = "true",
+"fast_schema_evolution" = "true",
+"compression" = "LZ4"
+);
+-- !result
+select * from agg_test;
+-- result:
+1	2	8	2	8
+1	3	8	2	8
+2	1	10	2	9
+2	2	9	2	7
+3	1	10	2	9
+3	2	9	2	7
+-- !result
+drop table agg_test;
+-- result:
+-- !result
+drop database sort_key_test_agg;
+-- result:
+E: (1064, "Can't drop database 'sort_key_test_agg'; database doesn't exist")
 -- !result

--- a/test/sql/test_sort_key/R/test_sort_key_dup_tbl
+++ b/test/sql/test_sort_key/R/test_sort_key_dup_tbl
@@ -137,3 +137,111 @@ select * from dup_test;
 drop database sort_key_test_dup;
 -- result:
 -- !result
+-- name: test_sort_key_dup_tbl_with_rollup
+create database sort_key_dup_tbl_with_rollup;
+-- result:
+-- !result
+use sort_key_dup_tbl_with_rollup;
+-- result:
+-- !result
+CREATE TABLE `dup_test` (
+    `k1` int(11) NOT NULL COMMENT "",
+    `k2` int(11) NOT NULL COMMENT "",
+    `v1` bigint REPLACE NULL COMMENT "",
+    `v2` bigint REPLACE NULL COMMENT "",
+    `v3` bigint REPLACE NULL COMMENT ""
+)
+DUPLICATE KEY(k1, k2)
+COMMENT "OLAP"
+DISTRIBUTED BY HASH(`k1`, `k2`) BUCKETS 1
+ORDER BY (k2, k1)
+PROPERTIES (
+    "replication_num" = "1",
+    "in_memory" = "false",
+    "storage_format" = "DEFAULT"
+);
+-- result:
+-- !result
+insert into dup_test values (1,3,2,10,9),(2,2,2,9,7),(3,1,2,8,8);
+-- result:
+-- !result
+select * from dup_test;
+-- result:
+3	1	2	8	8
+2	2	2	9	7
+1	3	2	10	9
+-- !result
+alter table dup_test add rollup r1 (k2,v2,v1);
+-- result:
+-- !result
+function: wait_alter_table_finish("rollup", 8)
+-- result:
+None
+-- !result
+insert into dup_test values (1,2,2,10,9),(2,3,2,9,7),(2,1,2,8,8);
+-- result:
+-- !result
+select * from dup_test;
+-- result:
+3	1	2	8	8
+2	2	2	9	7
+1	3	2	10	9
+2	1	2	8	8
+1	2	2	10	9
+2	3	2	9	7
+-- !result
+function: manual_compact("sort_key_dup_tbl_with_rollup", "dup_test")
+-- result:
+None
+-- !result
+select * from dup_test;
+-- result:
+2	1	2	8	8
+3	1	2	8	8
+1	2	2	10	9
+2	2	2	9	7
+1	3	2	10	9
+2	3	2	9	7
+-- !result
+alter table dup_test order by (k2,v1);
+-- result:
+-- !result
+function: wait_alter_table_finish()
+-- result:
+None
+-- !result
+show create table dup_test;
+-- result:
+dup_test	CREATE TABLE `dup_test` (
+  `k1` int(11) NOT NULL COMMENT "",
+  `k2` int(11) NOT NULL COMMENT "",
+  `v1` bigint(20) NULL COMMENT "",
+  `v2` bigint(20) NULL COMMENT "",
+  `v3` bigint(20) NULL COMMENT ""
+) ENGINE=OLAP 
+DUPLICATE KEY(`k1`, `k2`)
+COMMENT "OLAP"
+DISTRIBUTED BY HASH(`k1`, `k2`) BUCKETS 1 
+ORDER BY(`k2`, `v1`)
+PROPERTIES (
+"replication_num" = "1",
+"in_memory" = "false",
+"enable_persistent_index" = "false",
+"replicated_storage" = "true",
+"fast_schema_evolution" = "true",
+"compression" = "LZ4"
+);
+-- !result
+select * from dup_test;
+-- result:
+2	1	2	8	8
+3	1	2	8	8
+1	2	2	10	9
+2	2	2	9	7
+1	3	2	10	9
+2	3	2	9	7
+-- !result
+drop database test_sort_key_dup_tbl_with_rollup;
+-- result:
+E: (1064, "Can't drop database 'test_sort_key_dup_tbl_with_rollup'; database doesn't exist")
+-- !result

--- a/test/sql/test_sort_key/R/test_sort_key_dup_tbl
+++ b/test/sql/test_sort_key/R/test_sort_key_dup_tbl
@@ -38,11 +38,11 @@ insert into dup_test values (1,2,2,10,9),(2,3,2,9,7),(2,1,2,8,8);
 -- !result
 select * from dup_test;
 -- result:
+2	1	2	8	8
 3	1	2	8	8
+1	2	2	10	9
 2	2	2	9	7
 1	3	2	10	9
-2	1	2	8	8
-1	2	2	10	9
 2	3	2	9	7
 -- !result
 function: manual_compact("sort_key_test_dup", "dup_test")
@@ -241,7 +241,6 @@ select * from dup_test;
 1	3	2	10	9
 2	3	2	9	7
 -- !result
-drop database test_sort_key_dup_tbl_with_rollup;
+drop database sort_key_dup_tbl_with_rollup;
 -- result:
-E: (1064, "Can't drop database 'test_sort_key_dup_tbl_with_rollup'; database doesn't exist")
 -- !result

--- a/test/sql/test_sort_key/R/test_sort_key_uni_tbl
+++ b/test/sql/test_sort_key/R/test_sort_key_uni_tbl
@@ -187,10 +187,10 @@ drop database sort_key_test_uni;
 -- result:
 -- !result
 -- name: test_sort_key_uni_tbl_with_rollup;
-create database test_sort_key_uni_tbl_with_rollup;
+create database sort_key_uni_tbl_with_rollup;
 -- result:
 -- !result
-use test_sort_key_uni_tbl_with_rollup;
+use sort_key_uni_tbl_with_rollup;
 -- result:
 -- !result
 CREATE TABLE `uni_test` (
@@ -232,7 +232,7 @@ select * from uni_test;
 2	2	2	9	7
 1	3	2	10	9
 -- !result
-function: manual_compact("test_sort_key_uni_tbl_with_rollup", "uni_test")
+function: manual_compact("sort_key_uni_tbl_with_rollup", "uni_test")
 -- result:
 None
 -- !result
@@ -333,6 +333,6 @@ select * from uni_test;
 drop table uni_test;
 -- result:
 -- !result
-drop database test_sort_key_uni_tbl_with_rollup;
+drop database sort_key_uni_tbl_with_rollup;
 -- result:
 -- !result

--- a/test/sql/test_sort_key/R/test_sort_key_uni_tbl
+++ b/test/sql/test_sort_key/R/test_sort_key_uni_tbl
@@ -173,16 +173,166 @@ PROPERTIES (
 -- !result
 select * from uni_test;
 -- result:
-2	1	10	2	9
-3	1	10	2	9
 1	2	8	2	8
-2	2	9	2	7
-3	2	9	2	7
 1	3	8	2	8
+2	1	10	2	9
+2	2	9	2	7
+3	1	10	2	9
+3	2	9	2	7
 -- !result
 drop table uni_test;
 -- result:
 -- !result
 drop database sort_key_test_uni;
+-- result:
+-- !result
+-- name: test_sort_key_uni_tbl_with_rollup;
+create database test_sort_key_uni_tbl_with_rollup;
+-- result:
+-- !result
+use test_sort_key_uni_tbl_with_rollup;
+-- result:
+-- !result
+CREATE TABLE `uni_test` (
+    `k1` int(11) NOT NULL COMMENT "",
+    `k2` int(11) NOT NULL COMMENT "",
+    `v1` bigint REPLACE NULL COMMENT "",
+    `v2` bigint REPLACE NULL COMMENT "",
+    `v3` bigint REPLACE NULL COMMENT ""
+)
+UNIQUE KEY(k1, k2)
+COMMENT "OLAP"
+DISTRIBUTED BY HASH(`k1`, `k2`) BUCKETS 1
+ORDER BY (k2,k1)
+PROPERTIES (
+    "replication_num" = "1",
+    "in_memory" = "false",
+    "storage_format" = "DEFAULT"
+);
+-- result:
+-- !result
+insert into uni_test values (1,3,2,10,9),(2,2,2,9,7),(3,1,2,8,8);
+-- result:
+-- !result
+select * from uni_test;
+-- result:
+3	1	2	8	8
+2	2	2	9	7
+1	3	2	10	9
+-- !result
+insert into uni_test values (1,2,2,10,9),(2,3,2,9,7),(2,1,2,8,8);
+-- result:
+-- !result
+select * from uni_test;
+-- result:
+2	1	2	8	8
+1	2	2	10	9
+2	3	2	9	7
+3	1	2	8	8
+2	2	2	9	7
+1	3	2	10	9
+-- !result
+function: manual_compact("test_sort_key_uni_tbl_with_rollup", "uni_test")
+-- result:
+None
+-- !result
+select * from uni_test;
+-- result:
+2	1	2	8	8
+3	1	2	8	8
+1	2	2	10	9
+2	2	2	9	7
+1	3	2	10	9
+2	3	2	9	7
+-- !result
+alter table uni_test add rollup r1 (k1,k2,v3,v1);
+-- result:
+-- !result
+wait_alter_table_finish("rollup", 8);
+-- result:
+E: (1064, "Getting syntax error at line 1, column 0. Detail message: Unexpected input 'wait_alter_table_finish', the most similar input is {'ALTER', 'KILL', 'WITH', 'ANALYZE', 'DEALLOCATE', '(', ';'}.")
+-- !result
+alter table uni_test order by (k1,k2);
+-- result:
+E: (1064, 'A materialized view or rollup index is being created on the table "uni_test". Please wait until the current operation completes.\nTo check the status of the operation, see https://docs.starrocks.io/en-us/latest/sql-reference/sql-statements/data-manipulation/SHOW%20ALTER%20MATERIALIZED%20VIEW or https://docs.starrocks.io/en-us/latest/sql-reference/sql-statements/data-manipulation/SHOW%20ALTER')
+-- !result
+function: wait_alter_table_finish()
+-- result:
+
+-- !result
+show create table uni_test;
+-- result:
+uni_test	CREATE TABLE `uni_test` (
+  `k1` int(11) NOT NULL COMMENT "",
+  `k2` int(11) NOT NULL COMMENT "",
+  `v1` bigint(20) NULL COMMENT "",
+  `v2` bigint(20) NULL COMMENT "",
+  `v3` bigint(20) NULL COMMENT ""
+) ENGINE=OLAP 
+UNIQUE KEY(`k1`, `k2`)
+COMMENT "OLAP"
+DISTRIBUTED BY HASH(`k1`, `k2`) BUCKETS 1 
+ORDER BY(`k2`, `k1`)
+PROPERTIES (
+"replication_num" = "1",
+"in_memory" = "false",
+"enable_persistent_index" = "false",
+"replicated_storage" = "true",
+"fast_schema_evolution" = "true",
+"compression" = "LZ4"
+);
+-- !result
+select * from uni_test;
+-- result:
+2	1	2	8	8
+3	1	2	8	8
+1	2	2	10	9
+2	2	2	9	7
+1	3	2	10	9
+2	3	2	9	7
+-- !result
+alter table uni_test order by (k2,k1,v2,v1,v3);
+-- result:
+E: (1064, 'A materialized view or rollup index is being created on the table "uni_test". Please wait until the current operation completes.\nTo check the status of the operation, see https://docs.starrocks.io/en-us/latest/sql-reference/sql-statements/data-manipulation/SHOW%20ALTER%20MATERIALIZED%20VIEW or https://docs.starrocks.io/en-us/latest/sql-reference/sql-statements/data-manipulation/SHOW%20ALTER')
+-- !result
+function: wait_alter_table_finish()
+-- result:
+
+-- !result
+show create table uni_test;
+-- result:
+uni_test	CREATE TABLE `uni_test` (
+  `k1` int(11) NOT NULL COMMENT "",
+  `k2` int(11) NOT NULL COMMENT "",
+  `v1` bigint(20) NULL COMMENT "",
+  `v2` bigint(20) NULL COMMENT "",
+  `v3` bigint(20) NULL COMMENT ""
+) ENGINE=OLAP 
+UNIQUE KEY(`k1`, `k2`)
+COMMENT "OLAP"
+DISTRIBUTED BY HASH(`k1`, `k2`) BUCKETS 1 
+ORDER BY(`k2`, `k1`)
+PROPERTIES (
+"replication_num" = "1",
+"in_memory" = "false",
+"enable_persistent_index" = "false",
+"replicated_storage" = "true",
+"fast_schema_evolution" = "true",
+"compression" = "LZ4"
+);
+-- !result
+select * from uni_test;
+-- result:
+2	1	2	8	8
+3	1	2	8	8
+1	2	2	10	9
+2	2	2	9	7
+1	3	2	10	9
+2	3	2	9	7
+-- !result
+drop table uni_test;
+-- result:
+-- !result
+drop database test_sort_key_uni_tbl_with_rollup;
 -- result:
 -- !result

--- a/test/sql/test_sort_key/T/test_sort_key_agg_tbl
+++ b/test/sql/test_sort_key/T/test_sort_key_agg_tbl
@@ -127,4 +127,4 @@ function: wait_alter_table_finish()
 show create table agg_test;
 select * from agg_test;
 drop table agg_test;
-drop database sort_key_test_agg;
+drop database sort_key_test_agg_with_rollup;

--- a/test/sql/test_sort_key/T/test_sort_key_agg_tbl
+++ b/test/sql/test_sort_key/T/test_sort_key_agg_tbl
@@ -81,3 +81,50 @@ show create table agg_test;
 select * from agg_test;
 drop table agg_test;
 drop database sort_key_test_agg;
+
+-- name: test_sort_key_agg_tbl_with_rollup;
+
+create database sort_key_test_agg_with_rollup;
+use sort_key_test_agg_with_rollup;
+
+CREATE TABLE `agg_test` (
+    `k1` int(11) NOT NULL COMMENT "",
+    `k2` int(11) NOT NULL COMMENT "",
+    `v1` bigint REPLACE NULL COMMENT "",
+    `v2` bigint REPLACE NULL COMMENT "",
+    `v3` bigint REPLACE NULL COMMENT ""
+)
+AGGREGATE KEY(k1, k2)
+COMMENT "OLAP"
+DISTRIBUTED BY HASH(`k1`, `k2`) BUCKETS 1
+ORDER BY (k2,k1)
+PROPERTIES (
+    "replication_num" = "1",
+    "in_memory" = "false",
+    "storage_format" = "DEFAULT",
+    "enable_persistent_index" = "false"
+);
+
+insert into agg_test values (1,3,2,10,9),(2,2,2,9,7),(3,1,2,8,8);
+select * from agg_test;
+
+insert into agg_test values (1,2,2,10,9),(2,3,2,9,7),(2,1,2,8,8);
+select * from agg_test;
+
+alter table agg_test add rollup r1 (k1,k2,v3,v1);
+function: wait_alter_table_finish("rollup", 8)
+
+function: manual_compact("sort_key_test_agg_with_rollup", "agg_test")
+select * from agg_test;
+
+alter table agg_test order by (k1,k2);
+function: wait_alter_table_finish()
+show create table agg_test;
+select * from agg_test;
+
+alter table agg_test order by (k2,k1,v2,v1,v3);
+function: wait_alter_table_finish()
+show create table agg_test;
+select * from agg_test;
+drop table agg_test;
+drop database sort_key_test_agg;

--- a/test/sql/test_sort_key/T/test_sort_key_dup_tbl
+++ b/test/sql/test_sort_key/T/test_sort_key_dup_tbl
@@ -85,4 +85,4 @@ function: wait_alter_table_finish()
 show create table dup_test;
 select * from dup_test;
 
-drop database test_sort_key_dup_tbl_with_rollup;
+drop database sort_key_dup_tbl_with_rollup;

--- a/test/sql/test_sort_key/T/test_sort_key_dup_tbl
+++ b/test/sql/test_sort_key/T/test_sort_key_dup_tbl
@@ -44,3 +44,45 @@ show create table dup_test;
 select * from dup_test;
 
 drop database sort_key_test_dup;
+
+
+-- name: test_sort_key_dup_tbl_with_rollup
+
+create database sort_key_dup_tbl_with_rollup;
+use sort_key_dup_tbl_with_rollup;
+
+CREATE TABLE `dup_test` (
+    `k1` int(11) NOT NULL COMMENT "",
+    `k2` int(11) NOT NULL COMMENT "",
+    `v1` bigint REPLACE NULL COMMENT "",
+    `v2` bigint REPLACE NULL COMMENT "",
+    `v3` bigint REPLACE NULL COMMENT ""
+)
+DUPLICATE KEY(k1, k2)
+COMMENT "OLAP"
+DISTRIBUTED BY HASH(`k1`, `k2`) BUCKETS 1
+ORDER BY (k2, k1)
+PROPERTIES (
+    "replication_num" = "1",
+    "in_memory" = "false",
+    "storage_format" = "DEFAULT"
+);
+
+insert into dup_test values (1,3,2,10,9),(2,2,2,9,7),(3,1,2,8,8);
+select * from dup_test;
+
+alter table dup_test add rollup r1 (k2,v2,v1);
+function: wait_alter_table_finish("rollup", 8)
+
+insert into dup_test values (1,2,2,10,9),(2,3,2,9,7),(2,1,2,8,8);
+select * from dup_test;
+
+function: manual_compact("sort_key_dup_tbl_with_rollup", "dup_test")
+select * from dup_test;
+
+alter table dup_test order by (k2,v1);
+function: wait_alter_table_finish()
+show create table dup_test;
+select * from dup_test;
+
+drop database test_sort_key_dup_tbl_with_rollup;

--- a/test/sql/test_sort_key/T/test_sort_key_uni_tbl
+++ b/test/sql/test_sort_key/T/test_sort_key_uni_tbl
@@ -80,3 +80,52 @@ select * from uni_test;
 drop table uni_test;
 
 drop database sort_key_test_uni;
+
+
+-- name: test_sort_key_uni_tbl_with_rollup;
+
+create database test_sort_key_uni_tbl_with_rollup;
+use test_sort_key_uni_tbl_with_rollup;
+
+
+CREATE TABLE `uni_test` (
+    `k1` int(11) NOT NULL COMMENT "",
+    `k2` int(11) NOT NULL COMMENT "",
+    `v1` bigint REPLACE NULL COMMENT "",
+    `v2` bigint REPLACE NULL COMMENT "",
+    `v3` bigint REPLACE NULL COMMENT ""
+)
+UNIQUE KEY(k1, k2)
+COMMENT "OLAP"
+DISTRIBUTED BY HASH(`k1`, `k2`) BUCKETS 1
+ORDER BY (k2,k1)
+PROPERTIES (
+    "replication_num" = "1",
+    "in_memory" = "false",
+    "storage_format" = "DEFAULT"
+);
+
+insert into uni_test values (1,3,2,10,9),(2,2,2,9,7),(3,1,2,8,8);
+select * from uni_test;
+
+insert into uni_test values (1,2,2,10,9),(2,3,2,9,7),(2,1,2,8,8);
+select * from uni_test;
+
+function: manual_compact("test_sort_key_uni_tbl_with_rollup", "uni_test")
+select * from uni_test;
+
+alter table uni_test add rollup r1 (k1,k2,v3,v1);
+wait_alter_table_finish("rollup", 8);
+
+alter table uni_test order by (k1,k2);
+function: wait_alter_table_finish()
+show create table uni_test;
+select * from uni_test;
+
+alter table uni_test order by (k2,k1,v2,v1,v3);
+function: wait_alter_table_finish()
+show create table uni_test;
+select * from uni_test;
+drop table uni_test;
+
+drop database test_sort_key_uni_tbl_with_rollup;

--- a/test/sql/test_sort_key/T/test_sort_key_uni_tbl
+++ b/test/sql/test_sort_key/T/test_sort_key_uni_tbl
@@ -84,8 +84,8 @@ drop database sort_key_test_uni;
 
 -- name: test_sort_key_uni_tbl_with_rollup;
 
-create database test_sort_key_uni_tbl_with_rollup;
-use test_sort_key_uni_tbl_with_rollup;
+create database sort_key_uni_tbl_with_rollup;
+use sort_key_uni_tbl_with_rollup;
 
 
 CREATE TABLE `uni_test` (
@@ -111,7 +111,7 @@ select * from uni_test;
 insert into uni_test values (1,2,2,10,9),(2,3,2,9,7),(2,1,2,8,8);
 select * from uni_test;
 
-function: manual_compact("test_sort_key_uni_tbl_with_rollup", "uni_test")
+function: manual_compact("sort_key_uni_tbl_with_rollup", "uni_test")
 select * from uni_test;
 
 alter table uni_test add rollup r1 (k1,k2,v3,v1);
@@ -128,4 +128,4 @@ show create table uni_test;
 select * from uni_test;
 drop table uni_test;
 
-drop database test_sort_key_uni_tbl_with_rollup;
+drop database sort_key_uni_tbl_with_rollup;


### PR DESCRIPTION
## Why I'm doing:
The sort key only takes effect on the base index and rollup does not have sort key. However, the sort key of base index maybe overwrite by the rollup in alter job.

## What I'm doing:
Fix the bug.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
