### PR TITLE
[UT] refactor and make RowsetColumnPartialUpdateTest stable

### DIFF
--- a/be/test/storage/rowset_column_partial_update_test.cpp
+++ b/be/test/storage/rowset_column_partial_update_test.cpp
@@ -361,6 +361,23 @@ static Status increment_clone(const TabletSharedPtr& sourcetablet, const std::ve
     return dest_tablet->updates()->load_snapshot(*snapshot_meta);
 }
 
+static void final_check(const TabletSharedPtr& tablet, const std::vector<RowsetSharedPtr>& rowsets) {
+    // check refcnt
+    for (const auto& rs_ptr : rowsets) {
+        bool exist = false;
+        // retry 3 times
+        for (int i = 0; i < 3; i++) {
+            bool exist =
+                    StorageEngine::instance()->update_manager()->TEST_update_state_exist(tablet.get(), rs_ptr.get());
+            if (!exist) {
+                break;
+            }
+            sleep(1);
+        }
+        ASSERT_FALSE(exist);
+    }
+}
+
 static void prepare_tablet(RowsetColumnPartialUpdateTest* self, const TabletSharedPtr& tablet, int64_t& version,
                            int64_t& version_before_partial_update, int N) {
     std::vector<int64_t> keys(N);
@@ -381,21 +398,7 @@ static void prepare_tablet(RowsetColumnPartialUpdateTest* self, const TabletShar
         ASSERT_TRUE(check_tablet(tablet, version, N, [](int64_t k1, int64_t v1, int32_t v2) {
             return (int16_t)(k1 % 100 + 1) == v1 && (int32_t)(k1 % 1000 + 2) == v2;
         }));
-        // check refcnt
-        for (const auto& rs_ptr : rowsets) {
-            bool exist = false;
-            // retry 3 times
-            for (int i = 0; i < 3; i++) {
-                bool exist = StorageEngine::instance()->update_manager()->TEST_update_state_exist(tablet.get(),
-                                                                                                  rs_ptr.get());
-                if (!exist) {
-                    break;
-                }
-                sleep(1);
-            }
-            ASSERT_FALSE(exist);
-        }
-        ASSERT_TRUE(StorageEngine::instance()->update_manager()->TEST_primary_index_refcnt(tablet->tablet_id(), 1));
+        final_check(tablet, rowsets);
         version_before_partial_update = version;
     }
 
@@ -418,21 +421,7 @@ static void prepare_tablet(RowsetColumnPartialUpdateTest* self, const TabletShar
         ASSERT_TRUE(check_tablet(tablet, version, N, [](int64_t k1, int64_t v1, int32_t v2) {
             return (int16_t)(k1 % 100 + 3) == v1 && (int32_t)(k1 % 1000 + 4) == v2;
         }));
-        // check refcnt
-        for (const auto& rs_ptr : rowsets) {
-            bool exist = false;
-            // retry 3 times
-            for (int i = 0; i < 3; i++) {
-                bool exist = StorageEngine::instance()->update_manager()->TEST_update_state_exist(tablet.get(),
-                                                                                                  rs_ptr.get());
-                if (!exist) {
-                    break;
-                }
-                sleep(1);
-            }
-            ASSERT_FALSE(exist);
-        }
-        ASSERT_TRUE(StorageEngine::instance()->update_manager()->TEST_primary_index_refcnt(tablet->tablet_id(), 1));
+        final_check(tablet, rowsets);
     }
 }
 
@@ -547,21 +536,7 @@ TEST_P(RowsetColumnPartialUpdateTest, partial_update_diff_column_and_check) {
     ASSERT_TRUE(check_tablet(tablet, version, N, [](int64_t k1, int64_t v1, int32_t v2) {
         return (int16_t)(k1 % 100 + 3) == v1 && (int32_t)(k1 % 1000 + 4) == v2;
     }));
-    // check refcnt
-    for (const auto& rs_ptr : rowsets) {
-        bool exist = false;
-        // retry 3 times
-        for (int i = 0; i < 3; i++) {
-            bool exist =
-                    StorageEngine::instance()->update_manager()->TEST_update_state_exist(tablet.get(), rs_ptr.get());
-            if (!exist) {
-                break;
-            }
-            sleep(1);
-        }
-        ASSERT_FALSE(exist);
-    }
-    ASSERT_TRUE(StorageEngine::instance()->update_manager()->TEST_primary_index_refcnt(tablet->tablet_id(), 1));
+    final_check(tablet, rowsets);
 }
 
 TEST_P(RowsetColumnPartialUpdateTest, partial_update_multi_segment_and_check) {
@@ -596,21 +571,7 @@ TEST_P(RowsetColumnPartialUpdateTest, partial_update_multi_segment_and_check) {
     ASSERT_TRUE(check_tablet(tablet, version, N, [](int64_t k1, int64_t v1, int32_t v2) {
         return (int16_t)(k1 % 100 + 3) == v1 && (int32_t)(k1 % 1000 + 4) == v2;
     }));
-    // check refcnt
-    for (const auto& rs_ptr : rowsets) {
-        bool exist = false;
-        // retry 3 times
-        for (int i = 0; i < 3; i++) {
-            bool exist =
-                    StorageEngine::instance()->update_manager()->TEST_update_state_exist(tablet.get(), rs_ptr.get());
-            if (!exist) {
-                break;
-            }
-            sleep(1);
-        }
-        ASSERT_FALSE(exist);
-    }
-    ASSERT_TRUE(StorageEngine::instance()->update_manager()->TEST_primary_index_refcnt(tablet->tablet_id(), 1));
+    final_check(tablet, rowsets);
 }
 
 TEST_P(RowsetColumnPartialUpdateTest, partial_update_multi_segment_preload_and_check) {
@@ -871,21 +832,7 @@ TEST_P(RowsetColumnPartialUpdateTest, test_upsert) {
         ASSERT_TRUE(check_tablet(tablet, version, 2 * N, [](int64_t k1, int64_t v1, int32_t v2) {
             return (int16_t)(k1 % 100 + 3) == v1 && (int32_t)(k1 % 1000 + 4) == v2;
         }));
-        // check refcnt
-        for (const auto& rs_ptr : rowsets) {
-            bool exist = false;
-            // retry 3 times
-            for (int i = 0; i < 3; i++) {
-                bool exist = StorageEngine::instance()->update_manager()->TEST_update_state_exist(tablet.get(),
-                                                                                                  rs_ptr.get());
-                if (!exist) {
-                    break;
-                }
-                sleep(1);
-            }
-            ASSERT_FALSE(exist);
-        }
-        ASSERT_TRUE(StorageEngine::instance()->update_manager()->TEST_primary_index_refcnt(tablet->tablet_id(), 1));
+        final_check(tablet, rowsets);
     }
 
     {
@@ -1005,21 +952,7 @@ TEST_P(RowsetColumnPartialUpdateTest, partial_update_too_many_segment_and_check)
     ASSERT_TRUE(check_tablet(tablet, version, N, [](int64_t k1, int64_t v1, int32_t v2) {
         return (int16_t)(k1 % 100 + 3) == v1 && (int32_t)(k1 % 1000 + 4) == v2;
     }));
-    // check refcnt
-    for (const auto& rs_ptr : rowsets) {
-        bool exist = false;
-        // retry 3 times
-        for (int i = 0; i < 3; i++) {
-            bool exist =
-                    StorageEngine::instance()->update_manager()->TEST_update_state_exist(tablet.get(), rs_ptr.get());
-            if (!exist) {
-                break;
-            }
-            sleep(1);
-        }
-        ASSERT_FALSE(exist);
-    }
-    ASSERT_TRUE(StorageEngine::instance()->update_manager()->TEST_primary_index_refcnt(tablet->tablet_id(), 1));
+    final_check(tablet, rowsets);
 }
 
 TEST_P(RowsetColumnPartialUpdateTest, partial_update_too_many_segment_and_limit_mem_tracker) {
@@ -1061,21 +994,7 @@ TEST_P(RowsetColumnPartialUpdateTest, partial_update_too_many_segment_and_limit_
         return (int16_t)(k1 % 100 + 3) == v1 && (int32_t)(k1 % 1000 + 4) == v2;
     }));
     tracker->set_limit(old_limit);
-    // check refcnt
-    for (const auto& rs_ptr : rowsets) {
-        bool exist = false;
-        // retry 3 times
-        for (int i = 0; i < 3; i++) {
-            bool exist =
-                    StorageEngine::instance()->update_manager()->TEST_update_state_exist(tablet.get(), rs_ptr.get());
-            if (!exist) {
-                break;
-            }
-            sleep(1);
-        }
-        ASSERT_FALSE(exist);
-    }
-    ASSERT_TRUE(StorageEngine::instance()->update_manager()->TEST_primary_index_refcnt(tablet->tablet_id(), 1));
+    final_check(tablet, rowsets);
 }
 
 TEST_P(RowsetColumnPartialUpdateTest, partial_update_multi_column_batch) {
@@ -1116,21 +1035,7 @@ TEST_P(RowsetColumnPartialUpdateTest, partial_update_multi_column_batch) {
         return (int16_t)(k1 % 100 + 3) == v1 && (int32_t)(k1 % 1000 + 4) == v2;
     }));
     config::vertical_compaction_max_columns_per_group = old_val;
-    // check refcnt
-    for (const auto& rs_ptr : rowsets) {
-        bool exist = false;
-        // retry 3 times
-        for (int i = 0; i < 3; i++) {
-            bool exist =
-                    StorageEngine::instance()->update_manager()->TEST_update_state_exist(tablet.get(), rs_ptr.get());
-            if (!exist) {
-                break;
-            }
-            sleep(1);
-        }
-        ASSERT_FALSE(exist);
-    }
-    ASSERT_TRUE(StorageEngine::instance()->update_manager()->TEST_primary_index_refcnt(tablet->tablet_id(), 1));
+    final_check(tablet, rowsets);
 }
 
 TEST_P(RowsetColumnPartialUpdateTest, partial_update_multi_segment_and_column_batch) {
@@ -1181,21 +1086,7 @@ TEST_P(RowsetColumnPartialUpdateTest, partial_update_multi_segment_and_column_ba
         return (int16_t)(k1 % 100 + 3) == v1 && (int32_t)(k1 % 1000 + 4) == v2;
     }));
     config::vertical_compaction_max_columns_per_group = old_val;
-    // check refcnt
-    for (const auto& rs_ptr : rowsets) {
-        bool exist = false;
-        // retry 3 times
-        for (int i = 0; i < 3; i++) {
-            bool exist =
-                    StorageEngine::instance()->update_manager()->TEST_update_state_exist(tablet.get(), rs_ptr.get());
-            if (!exist) {
-                break;
-            }
-            sleep(1);
-        }
-        ASSERT_FALSE(exist);
-    }
-    ASSERT_TRUE(StorageEngine::instance()->update_manager()->TEST_primary_index_refcnt(tablet->tablet_id(), 1));
+    final_check(tablet, rowsets);
 }
 
 INSTANTIATE_TEST_SUITE_P(RowsetColumnPartialUpdateTest, RowsetColumnPartialUpdateTest,


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:
1. Simplify code.
2. Check primary index ref cnt may not be stable, remove it.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [x] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [x] 3.1
  - [ ] 3.0
  - [ ] 2.5
