### PR TITLE
[UT] Add option to run-be-ut.sh to filter cases of specific group

### DIFF
--- a/be/src/testutil/parallel_test.h
+++ b/be/src/testutil/parallel_test.h
@@ -22,4 +22,17 @@
 // in parallel.
 #define TOKENPASTE(x, y) x##y
 #define TOKENPASTE2(x, y) TOKENPASTE(x, y)
+
 #define PARALLEL_TEST(test_case_name, test_name) TEST(TOKENPASTE2(test_case_name, __LINE__), test_name)
+#define GROUP_PARALLEL_TEST(group_name, test_case_name, test_name) \
+    PARALLEL_TEST(test_case_name, group_name##_##test_name)
+
+#define GROUP_TEST_F(group_name, test_case_name, test_name) TEST_F(test_case_name, group_name##_##test_name)
+
+#ifdef NDEBUG
+#define GROUP_SLOW_PARALLEL_TEST(test_case_name, test_name) GROUP_PARALLEL_TEST(SLOW, test_case_name, test_name)
+#define GROUP_SLOW_TEST_F(test_case_name, test_name) GROUP_TEST_F(SLOW, test_case_name, test_name)
+#else
+#define GROUP_SLOW_PARALLEL_TEST(test_case_name, test_name) GROUP_PARALLEL_TEST(DISABLED, test_case_name, test_name)
+#define GROUP_SLOW_TEST_F(test_case_name, test_name) GROUP_TEST_F(DISABLED, test_case_name, test_name)
+#endif

--- a/be/test/column/binary_column_test.cpp
+++ b/be/test/column/binary_column_test.cpp
@@ -34,7 +34,7 @@ PARALLEL_TEST(BinaryColumnTest, test_create) {
 }
 
 // NOLINTNEXTLINE
-PARALLEL_TEST(BinaryColumnTest, test_binary_column_upgrade_if_overflow) {
+GROUP_SLOW_PARALLEL_TEST(BinaryColumnTest, test_binary_column_upgrade_if_overflow) {
     // small column
     auto column = BinaryColumn::create();
     for (size_t i = 0; i < 10; i++) {
@@ -44,7 +44,6 @@ PARALLEL_TEST(BinaryColumnTest, test_binary_column_upgrade_if_overflow) {
     ASSERT_TRUE(ret.ok());
     ASSERT_TRUE(ret.value() == nullptr);
 
-#ifdef NDEBUG
     // offset overflow
     column = BinaryColumn::create();
     size_t count = 1 << 30;
@@ -60,7 +59,6 @@ PARALLEL_TEST(BinaryColumnTest, test_binary_column_upgrade_if_overflow) {
         ASSERT_EQ(ret.value()->get(i).get_slice().to_string(), std::to_string(i));
     }
 
-    /*
     // row size overflow
     // the case will allocate a lot of memory, so temp remove it
     count = Column::MAX_CAPACITY_LIMIT + 5;
@@ -71,12 +69,10 @@ PARALLEL_TEST(BinaryColumnTest, test_binary_column_upgrade_if_overflow) {
     }
     ret = column->upgrade_if_overflow();
     ASSERT_TRUE(!ret.ok());
-    */
-#endif
 }
 
 // NOLINTNEXTLINE
-PARALLEL_TEST(BinaryColumnTest, test_binary_column_downgrade) {
+GROUP_SLOW_PARALLEL_TEST(BinaryColumnTest, test_binary_column_downgrade) {
     auto column = BinaryColumn::create();
     column->append_string("test");
     ASSERT_FALSE(column->has_large_column());
@@ -97,7 +93,6 @@ PARALLEL_TEST(BinaryColumnTest, test_binary_column_downgrade) {
         ASSERT_EQ(ret.value()->get(i).get_slice(), Slice(std::to_string(i)));
     }
 
-#ifdef NDEBUG
     large_column = LargeBinaryColumn::create();
     size_t count = 1 << 29;
     for (size_t i = 0; i < count; i++) {
@@ -105,7 +100,6 @@ PARALLEL_TEST(BinaryColumnTest, test_binary_column_downgrade) {
     }
     ret = large_column->downgrade();
     ASSERT_FALSE(ret.ok());
-#endif
 }
 
 // NOLINTNEXTLINE

--- a/be/test/column/chunk_test.cpp
+++ b/be/test/column/chunk_test.cpp
@@ -22,6 +22,7 @@
 #include "column/field.h"
 #include "column/fixed_length_column.h"
 #include "column/vectorized_fwd.h"
+#include "testutil/parallel_test.h"
 
 namespace starrocks {
 
@@ -88,8 +89,7 @@ public:
 };
 
 // NOLINTNEXTLINE
-TEST_F(ChunkTest, test_chunk_upgrade_if_overflow) {
-#ifdef NDEBUG
+GROUP_SLOW_TEST_F(ChunkTest, test_chunk_upgrade_if_overflow) {
     size_t row_count = 1 << 30;
     auto c1 = BinaryColumn::create();
     c1->resize(row_count);
@@ -105,7 +105,6 @@ TEST_F(ChunkTest, test_chunk_upgrade_if_overflow) {
     ASSERT_TRUE(st.ok());
     ASSERT_TRUE(chunk->get_column_by_slot_id(1)->is_binary());
     ASSERT_TRUE(chunk->get_column_by_slot_id(2)->is_large_binary());
-#endif
 }
 
 // NOLINTNEXTLINE

--- a/run-be-ut.sh
+++ b/run-be-ut.sh
@@ -38,7 +38,7 @@ Usage: $0 <options>
      --with-gcov                    enable to build with gcov
      --with-aws                     enable to test aws
      --with-bench                   enable to build with benchmark
-     --without-group                don't run cases of the group
+     --excluding-test-suit          don't run cases of specific suit
      --module                       module to run uts
      --enable-shared-data           enable to build with shared-data feature support
      --use-staros                   DEPRECATED. an alias of --enable-shared-data option
@@ -82,7 +82,7 @@ OPTS=$(getopt \
   -l 'module:' \
   -l 'with-aws' \
   -l 'with-bench' \
-  -l 'without-group:' \
+  -l 'excluding-test-suit:' \
   -l 'use-staros' \
   -l 'enable-shared-data' \
   -o 'j:' \
@@ -101,7 +101,7 @@ CLEAN=0
 DRY_RUN=0
 TEST_NAME=*
 TEST_MODULE=".*"
-WITHOUT_GROUP=
+EXCLUDING_TEST_SUIT=
 HELP=0
 WITH_AWS=OFF
 USE_STAROS=OFF
@@ -117,7 +117,7 @@ while true; do
         --help) HELP=1 ; shift ;;
         --with-aws) WITH_AWS=ON; shift ;;
         --with-gcov) WITH_GCOV=ON; shift ;;
-        --without-group) WITHOUT_GROUP=$2; shift 2;;
+        --excluding-test-suit) EXCLUDING_TEST_SUIT=$2; shift 2;;
         --enable-shared-data|--use-staros) USE_STAROS=ON; shift ;;
         -j) PARALLEL=$2; shift 2 ;;
         --) shift ;  break ;;
@@ -256,10 +256,10 @@ if [ $WITH_AWS = "OFF" ]; then
     append_negative_case "*S3*"
 fi
 
-if [ -n "$WITHOUT_GROUP" ]; then
-    without_groups=$WITHOUT_GROUP
-    without_group_array=("${without_groups//|/ }")
-    for element in ${without_group_array[*]}; do
+if [ -n "$EXCLUDING_TEST_SUIT" ]; then
+    excluding_test_suit=$EXCLUDING_TEST_SUIT
+    excluding_test_suit_array=("${excluding_test_suit//|/ }")
+    for element in ${excluding_test_suit_array[*]}; do
         append_negative_case "*.${element}_*"
     done
 fi

--- a/run-be-ut.sh
+++ b/run-be-ut.sh
@@ -38,6 +38,7 @@ Usage: $0 <options>
      --with-gcov                    enable to build with gcov
      --with-aws                     enable to test aws
      --with-bench                   enable to build with benchmark
+     --without-group                don't run cases of the group
      --module                       module to run uts
      --enable-shared-data           enable to build with shared-data feature support
      --use-staros                   DEPRECATED. an alias of --enable-shared-data option
@@ -81,6 +82,7 @@ OPTS=$(getopt \
   -l 'module:' \
   -l 'with-aws' \
   -l 'with-bench' \
+  -l 'without-group:' \
   -l 'use-staros' \
   -l 'enable-shared-data' \
   -o 'j:' \
@@ -99,6 +101,7 @@ CLEAN=0
 DRY_RUN=0
 TEST_NAME=*
 TEST_MODULE=".*"
+WITHOUT_GROUP=
 HELP=0
 WITH_AWS=OFF
 USE_STAROS=OFF
@@ -114,6 +117,7 @@ while true; do
         --help) HELP=1 ; shift ;;
         --with-aws) WITH_AWS=ON; shift ;;
         --with-gcov) WITH_GCOV=ON; shift ;;
+        --without-group) WITHOUT_GROUP=$2; shift 2;;
         --enable-shared-data|--use-staros) USE_STAROS=ON; shift ;;
         -j) PARALLEL=$2; shift 2 ;;
         --) shift ;  break ;;
@@ -250,6 +254,14 @@ export ASAN_OPTIONS="abort_on_error=1:disable_coredump=0:unmap_shadow_on_exit=1:
 
 if [ $WITH_AWS = "OFF" ]; then
     append_negative_case "*S3*"
+fi
+
+if [ -n "$WITHOUT_GROUP" ]; then
+    without_groups=$WITHOUT_GROUP
+    without_group_array=("${without_groups//|/ }")
+    for element in ${without_group_array[*]}; do
+        append_negative_case "*.${element}_*"
+    done
 fi
 
 # prepare util test_data


### PR DESCRIPTION
## Why I'm doing:

Currently, some cases need to allocate a large amount of memory, so they will execute very slowly. Here we add a function that can exclude cases under a specific group. Users can decide which cases to run based on different needs.

Cases of slow group will be disabled on asan or debug mode.

## What I'm doing:

Usage:

```
./run-be-ut.sh --without-group "SLOW" 
./run-be-ut.sh --without-group "SLOW|XXX" 
````

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [x] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [x] 3.1
  - [x] 3.0
  - [x] 2.5
