### PR TITLE
[BugFix] Fix heap-use-after-free of ThreadPool bvar

### DIFF
--- a/be/src/util/threadpool.cpp
+++ b/be/src/util/threadpool.cpp
@@ -571,9 +571,11 @@ void ThreadPool::dispatch_thread() {
         task.runnable.reset();
         MonoTime finish_time = MonoTime::Now();
 
-        _total_executed_tasks.fetch_add(1);
-        _total_pending_time_ns.fetch_add(start_time.GetDeltaSince(task.submit_time).ToNanoseconds());
-        _total_execute_time_ns.fetch_add(finish_time.GetDeltaSince(start_time).ToNanoseconds());
+        _total_executed_tasks.fetch_add(1, std::memory_order_relaxed);
+        _total_pending_time_ns.fetch_add(start_time.GetDeltaSince(task.submit_time).ToNanoseconds(),
+                                         std::memory_order_relaxed);
+        _total_execute_time_ns.fetch_add(finish_time.GetDeltaSince(start_time).ToNanoseconds(),
+                                         std::memory_order_relaxed);
 
         l.lock();
         _last_active_timestamp = MonoTime::Now();

--- a/be/src/util/threadpool.cpp
+++ b/be/src/util/threadpool.cpp
@@ -571,11 +571,9 @@ void ThreadPool::dispatch_thread() {
         task.runnable.reset();
         MonoTime finish_time = MonoTime::Now();
 
-        _total_executed_tasks.fetch_add(1, std::memory_order_relaxed);
-        _total_pending_time_ns.fetch_add(start_time.GetDeltaSince(task.submit_time).ToNanoseconds(),
-                                         std::memory_order_relaxed);
-        _total_execute_time_ns.fetch_add(finish_time.GetDeltaSince(start_time).ToNanoseconds(),
-                                         std::memory_order_relaxed);
+        _total_executed_tasks.increment(1);
+        _total_pending_time_ns.increment(start_time.GetDeltaSince(task.submit_time).ToNanoseconds());
+        _total_execute_time_ns.increment(finish_time.GetDeltaSince(start_time).ToNanoseconds());
 
         l.lock();
         _last_active_timestamp = MonoTime::Now();

--- a/be/src/util/threadpool.cpp
+++ b/be/src/util/threadpool.cpp
@@ -571,9 +571,9 @@ void ThreadPool::dispatch_thread() {
         task.runnable.reset();
         MonoTime finish_time = MonoTime::Now();
 
-        _total_executed_tasks << 1;
-        _total_pending_time_ns << start_time.GetDeltaSince(task.submit_time).ToNanoseconds();
-        _total_execute_time_ns << finish_time.GetDeltaSince(start_time).ToNanoseconds();
+        _total_executed_tasks.fetch_add(1);
+        _total_pending_time_ns.fetch_add(start_time.GetDeltaSince(task.submit_time).ToNanoseconds());
+        _total_execute_time_ns.fetch_add(finish_time.GetDeltaSince(start_time).ToNanoseconds());
 
         l.lock();
         _last_active_timestamp = MonoTime::Now();

--- a/be/src/util/threadpool.h
+++ b/be/src/util/threadpool.h
@@ -248,11 +248,11 @@ public:
 
     int max_threads() const { return _max_threads.load(std::memory_order_acquire); }
 
-    int64_t total_executed_tasks() const { return _total_executed_tasks; }
+    int64_t total_executed_tasks() const { return _total_executed_tasks.load(); }
 
-    int64_t total_pending_time_ns() const { return _total_pending_time_ns; }
+    int64_t total_pending_time_ns() const { return _total_pending_time_ns.load(); }
 
-    int64_t total_execute_time_ns() const { return _total_execute_time_ns; }
+    int64_t total_execute_time_ns() const { return _total_execute_time_ns.load(); }
 
 private:
     friend class ThreadPoolBuilder;

--- a/be/src/util/threadpool.h
+++ b/be/src/util/threadpool.h
@@ -34,7 +34,6 @@
 
 #pragma once
 
-#include <bvar/bvar.h>
 #include <fmt/format.h>
 
 #include <atomic>
@@ -249,14 +248,11 @@ public:
 
     int max_threads() const { return _max_threads.load(std::memory_order_acquire); }
 
-    // Use bvar as the counter, and should not be called frequently.
-    int64_t total_executed_tasks() const { return _total_executed_tasks.get_value(); }
+    int64_t total_executed_tasks() const { return _total_executed_tasks; }
 
-    // Use bvar as the counter, and should not be called frequently.
-    int64_t total_pending_time_ns() const { return _total_pending_time_ns.get_value(); }
+    int64_t total_pending_time_ns() const { return _total_pending_time_ns; }
 
-    // Use bvar as the counter, and should not be called frequently.
-    int64_t total_execute_time_ns() const { return _total_execute_time_ns.get_value(); }
+    int64_t total_execute_time_ns() const { return _total_execute_time_ns; }
 
 private:
     friend class ThreadPoolBuilder;
@@ -383,13 +379,13 @@ private:
     std::unique_ptr<ThreadPoolToken> _tokenless;
 
     // Total number of tasks that have finished
-    bvar::Adder<int64_t> _total_executed_tasks;
+    std::atomic<int64_t> _total_executed_tasks;
 
     // Total time in nanoseconds that tasks pending in the queue.
-    bvar::Adder<int64_t> _total_pending_time_ns;
+    std::atomic<int64_t> _total_pending_time_ns;
 
     // Total time in nanoseconds to execute tasks.
-    bvar::Adder<int64_t> _total_execute_time_ns;
+    std::atomic<int64_t> _total_execute_time_ns;
 
     ThreadPool(const ThreadPool&) = delete;
     const ThreadPool& operator=(const ThreadPool&) = delete;

--- a/be/src/util/threadpool.h
+++ b/be/src/util/threadpool.h
@@ -53,6 +53,7 @@
 #include "util/bthreads/semaphore.h"
 // resolve `barrier` macro conflicts with boost/thread.hpp header file
 #undef barrier
+#include "util/metrics.h"
 #include "util/monotime.h"
 #include "util/priority_queue.h"
 
@@ -248,11 +249,11 @@ public:
 
     int max_threads() const { return _max_threads.load(std::memory_order_acquire); }
 
-    int64_t total_executed_tasks() const { return _total_executed_tasks.load(); }
+    int64_t total_executed_tasks() const { return _total_executed_tasks.value(); }
 
-    int64_t total_pending_time_ns() const { return _total_pending_time_ns.load(); }
+    int64_t total_pending_time_ns() const { return _total_pending_time_ns.value(); }
 
-    int64_t total_execute_time_ns() const { return _total_execute_time_ns.load(); }
+    int64_t total_execute_time_ns() const { return _total_execute_time_ns.value(); }
 
 private:
     friend class ThreadPoolBuilder;
@@ -379,13 +380,13 @@ private:
     std::unique_ptr<ThreadPoolToken> _tokenless;
 
     // Total number of tasks that have finished
-    std::atomic<int64_t> _total_executed_tasks;
+    CoreLocalCounter<int64_t> _total_executed_tasks{MetricUnit::NOUNIT};
 
     // Total time in nanoseconds that tasks pending in the queue.
-    std::atomic<int64_t> _total_pending_time_ns;
+    CoreLocalCounter<int64_t> _total_pending_time_ns{MetricUnit::NOUNIT};
 
     // Total time in nanoseconds to execute tasks.
-    std::atomic<int64_t> _total_execute_time_ns;
+    CoreLocalCounter<int64_t> _total_execute_time_ns{MetricUnit::NOUNIT};
 
     ThreadPool(const ThreadPool&) = delete;
     const ThreadPool& operator=(const ThreadPool&) = delete;

--- a/be/test/CMakeLists.txt
+++ b/be/test/CMakeLists.txt
@@ -377,6 +377,7 @@ set(EXEC_FILES
         ./util/cidr_test.cpp
         ./util/coding_test.cpp
         ./util/core_local_test.cpp
+        ./util/core_local_counter_test.cpp
         ./util/countdown_latch_test.cpp
         ./util/crc32c_test.cpp
         ./util/dynamic_cache_test.cpp

--- a/be/test/util/core_local_counter_test.cpp
+++ b/be/test/util/core_local_counter_test.cpp
@@ -1,0 +1,132 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <bvar/bvar.h>
+#include <gtest/gtest.h>
+
+#include <atomic>
+
+#include "util/metrics.h"
+
+namespace starrocks {
+
+const size_t OPS_PER_THREAD = 500000;
+
+static void* thread_counter(void* arg) {
+    bvar::Adder<uint64_t>* reducer = (bvar::Adder<uint64_t>*)arg;
+    butil::Timer timer;
+    timer.start();
+    for (size_t i = 0; i < OPS_PER_THREAD; ++i) {
+        (*reducer) << 2;
+    }
+    timer.stop();
+    return (void*)(timer.n_elapsed());
+}
+
+void* add_atomic(void* arg) {
+    butil::atomic<uint64_t>* counter = (butil::atomic<uint64_t>*)arg;
+    butil::Timer timer;
+    timer.start();
+    for (size_t i = 0; i < OPS_PER_THREAD / 100; ++i) {
+        counter->fetch_add(2, butil::memory_order_relaxed);
+    }
+    timer.stop();
+    return (void*)(timer.n_elapsed());
+}
+
+static long start_perf_test_with_atomic(size_t num_thread) {
+    butil::atomic<uint64_t> counter(0);
+    pthread_t threads[num_thread];
+    for (size_t i = 0; i < num_thread; ++i) {
+        pthread_create(&threads[i], nullptr, &add_atomic, (void*)&counter);
+    }
+    long totol_time = 0;
+    for (size_t i = 0; i < num_thread; ++i) {
+        void* ret;
+        pthread_join(threads[i], &ret);
+        totol_time += (long)ret;
+    }
+    long avg_time = totol_time / (OPS_PER_THREAD / 100 * num_thread);
+    EXPECT_EQ(2ul * num_thread * OPS_PER_THREAD / 100, counter.load());
+    return avg_time;
+}
+
+static long start_perf_test_with_adder(size_t num_thread) {
+    bvar::Adder<uint64_t> reducer;
+    EXPECT_TRUE(reducer.valid());
+    pthread_t threads[num_thread];
+    for (size_t i = 0; i < num_thread; ++i) {
+        pthread_create(&threads[i], nullptr, &thread_counter, (void*)&reducer);
+    }
+    long totol_time = 0;
+    for (size_t i = 0; i < num_thread; ++i) {
+        void* ret = nullptr;
+        pthread_join(threads[i], &ret);
+        totol_time += (long)ret;
+    }
+    long avg_time = totol_time / (OPS_PER_THREAD * num_thread);
+    EXPECT_EQ(2ul * num_thread * OPS_PER_THREAD, reducer.get_value());
+    return avg_time;
+}
+
+static void* core_local_counter(void* arg) {
+    CoreLocalCounter<int64_t>* counter = (CoreLocalCounter<int64_t>*)arg;
+    butil::Timer timer;
+    timer.start();
+    for (size_t i = 0; i < OPS_PER_THREAD; ++i) {
+        counter->increment(2);
+    }
+    timer.stop();
+    return (void*)(timer.n_elapsed());
+}
+
+static long start_perf_test_with_core_local(size_t num_thread) {
+    CoreLocalCounter<int64_t> counter(MetricUnit::NOUNIT);
+    pthread_t threads[num_thread];
+    for (size_t i = 0; i < num_thread; ++i) {
+        pthread_create(&threads[i], nullptr, &core_local_counter, (void*)&counter);
+    }
+    long totol_time = 0;
+    for (size_t i = 0; i < num_thread; ++i) {
+        void* ret = nullptr;
+        pthread_join(threads[i], &ret);
+        totol_time += (long)ret;
+    }
+    long avg_time = totol_time / (OPS_PER_THREAD * num_thread);
+    EXPECT_EQ(2ul * num_thread * OPS_PER_THREAD, counter.value());
+    return avg_time;
+}
+
+// Compare the performance among bvar, atomic and CoreLocalCounter.
+// You should build the test with BUILD_TYPE=release. The way to test
+// is same as that of brpc https://github.com/apache/brpc/blob/1.3.0/test/bvar_reducer_unittest.cpp#L124
+TEST(CoreLocalCounterTest, DISABLED_test_perf) {
+    std::ostringstream oss;
+    for (size_t i = 1; i <= 24; ++i) {
+        oss << i << '\t' << start_perf_test_with_adder(i) << '\n';
+    }
+    LOG(INFO) << "Adder performance:\n" << oss.str();
+    oss.str("");
+    for (size_t i = 1; i <= 24; ++i) {
+        oss << i << '\t' << start_perf_test_with_core_local(i) << '\n';
+    }
+    LOG(INFO) << "CoreLocal performance:\n" << oss.str();
+    oss.str("");
+    for (size_t i = 1; i <= 24; ++i) {
+        oss << i << '\t' << start_perf_test_with_atomic(i) << '\n';
+    }
+    LOG(INFO) << "Atomic performance:\n" << oss.str();
+}
+
+} // namespace starrocks


### PR DESCRIPTION
## Why I'm doing:
Fix #42319.
The problem is introduced by #40171. The pr adds bvar members in `ThreadPool`, and each thread will update the bvars. bvar uses thread-local to improve performance, and will do some work (`delete_thread_exit_helper`) in `__nptl_deallocate_tsd` before the pthread exits. It will access bvar members here.
```
      #5 0x2075252f in bvar::detail::AgentGroup<bvar::detail::AgentCombiner<long, long, bvar::detail::AddTo<long> >::Agent>::_destroy_tls_blocks() (/root/starrocks/be/ut_build_ASAN/test/starrocks_test+0x2075252f)
      #6 0x25a5c0a2 in butil::detail::delete_thread_exit_helper(void*) (/root/starrocks/be/ut_build_ASAN/test/starrocks_test+0x25a5c0a2)
      #7 0x7fe5fdb57ca1 in __nptl_deallocate_tsd (/lib64/libpthread.so.0+0x7ca1)
      #8 0x7fe5fdb57eb2 in start_thread (/lib64/libpthread.so.0+0x7eb2)
```
But `ThreadPool` does not join the thread before destructing the pool itself, so it's possible that the bvar members are destroyed before `delete_thread_exit_helper` finishes which will lead to heap-use-after-free.

## What I'm doing:
There are two ways to fix the problem
1. the threadpool joins the thread to ensure the thread totally exits, and then destructs the pool itself
2. replace bvar with CoreLocalCounter to ensure the thread will not access threadpool members out of `ThreadPool::dispatch_thread`

The 1 is more elegant, but more complicated because the threadpool is dynamic, and need a way to join threads (only join the threads in the destructor is not enough). Currently use 2 to fix the problem. According to the test, updating bvar takes about 10ns constantly as the number of threads increase, and CoreLocalCounter takes about 20ns constantly. I think it's acceptable to use CoreLocalCounter in this scenario.


## What type of PR is this:

- [X] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [X] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [X] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [X] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
