### PR TITLE
[Enhancement] unwind exception and get detailed error message

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/connector/hive/HiveMetaClient.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/hive/HiveMetaClient.java
@@ -23,7 +23,6 @@ import com.starrocks.connector.HdfsEnvironment;
 import com.starrocks.connector.exception.StarRocksConnectorException;
 import com.starrocks.connector.hive.events.MetastoreNotificationFetchException;
 import com.starrocks.connector.hive.glue.AWSCatalogMetastoreClient;
-import org.apache.commons.lang.exception.ExceptionUtils;
 import org.apache.hadoop.hive.conf.HiveConf;
 import org.apache.hadoop.hive.metastore.HiveMetaHookLoader;
 import org.apache.hadoop.hive.metastore.HiveMetaStoreClient;
@@ -461,7 +460,7 @@ public class HiveMetaClient {
                 partitionStats.putAll(client.hiveClient.getPartitionColumnStatistics(dbName, tableName, parts, columnNames));
             }
             LOG.info("Succeed to getPartitionColumnStatistics on [{}.{}] with {} times retry, slice size is {}," +
-                            " partName size is {}", dbName, tableName, retryNum, subListSize, partNames.size());
+                    " partName size is {}", dbName, tableName, retryNum, subListSize, partNames.size());
             return partitionStats;
         } catch (TTransportException te) {
             if (subListNum > 1) {

--- a/fe/fe-core/src/main/java/com/starrocks/connector/hive/HiveMetaClient.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/hive/HiveMetaClient.java
@@ -18,6 +18,7 @@ import com.google.common.collect.Lists;
 import com.starrocks.common.Config;
 import com.starrocks.common.profile.Timer;
 import com.starrocks.common.profile.Tracers;
+import com.starrocks.common.util.LogUtil;
 import com.starrocks.connector.HdfsEnvironment;
 import com.starrocks.connector.exception.StarRocksConnectorException;
 import com.starrocks.connector.hive.events.MetastoreNotificationFetchException;

--- a/fe/fe-core/src/main/java/com/starrocks/connector/hive/HiveMetaClient.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/hive/HiveMetaClient.java
@@ -173,7 +173,7 @@ public class HiveMetaClient {
         } catch (Throwable e) {
             LOG.error(messageIfError, e);
             connectionException = new StarRocksConnectorException(messageIfError + ", msg: " +
-                    ExceptionUtils.getRootCauseMessage(e), e);
+                    LogUtil.getUnwoundExceptionMessage(e), e);
             throw connectionException;
         } finally {
             if (client == null && connectionException != null) {

--- a/fe/fe-core/src/main/java/com/starrocks/connector/hive/HiveUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/hive/HiveUtils.java
@@ -41,6 +41,7 @@ import static com.starrocks.connector.hive.HiveMetastoreOperations.EXTERNAL_LOCA
 
 public class HiveUtils {
     private static final Logger LOG = LogManager.getLogger(HiveUtils.class);
+
     public static boolean isS3Url(String prefix) {
         return prefix.startsWith("oss://") || prefix.startsWith("s3n://") || prefix.startsWith("s3a://") ||
                 prefix.startsWith("s3://") || prefix.startsWith("cos://") || prefix.startsWith("cosn://") ||
@@ -174,10 +175,10 @@ public class HiveUtils {
             DecimalLiteral decimalKey = (DecimalLiteral) key;
             ScalarType type = (ScalarType) targetType;
             int scale = type.decimalScale();
-    
+
             BigDecimal scaled = decimalKey.getValue()
                     .setScale(scale, RoundingMode.HALF_UP);
-    
+
             key = new DecimalLiteral(scaled);
         }
 

--- a/fe/fe-core/src/test/java/com/starrocks/common/util/LogUtilTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/common/util/LogUtilTest.java
@@ -43,4 +43,16 @@ public class LogUtilTest {
         LogUtil.logConnectionInfoToAuditLogAndQueryQueue(new ConnectContext(), null);
         Assertions.assertFalse(QueryDetailQueue.getQueryDetailsAfterTime(0L).isEmpty());
     }
+
+    @Test
+    public void testGetUnwoundExceptionMessage() {
+        String output = null;
+        try {
+            System.out.println("hello");
+            throw new RuntimeException("hello");
+        } catch (Throwable e) {
+            output = LogUtil.getUnwoundExceptionMessage(e);
+        }
+        System.out.println(output);
+    }
 }


### PR DESCRIPTION
## Why I'm doing:

Right now the exception message is so brief that  can not be used to fix problem, sometimes we need more deep exceptions.

## What I'm doing:


To put more exception context into error message:

Message we got when access glue failed before:


> MySQL [hive0.zya]> show databases from glue_bad_glue;
> ERROR 1064 (HY000): Failed to getAllDatabases, msg: Unable to instantiate com.starrocks.connector.hive.glue.AWSCatalogMetastoreClient


And now we get more detailed message.

> MySQL [hive0.zya]> show databases from glue_bad_glue;
> ERROR 1064 (HY000): Failed to getAllDatabases, msg: Unable to instantiate com.starrocks.connector.hive.glue.AWSCatalogMetastoreClient
> Unable to verify existence of default database: User: arn:aws:iam::081976408565:user/aws-common-user is not authorized to perform: glue:GetDatabase on resource: arn:aws:glue:us-west-2:081976408565:catalog because no identity-based policy allows the glue:GetDatabase action


Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
