### PR TITLE
[BugFix]lazy_column_coalesce_counter should be shared on the whole node

### DIFF
--- a/be/src/connector/hive_connector.h
+++ b/be/src/connector/hive_connector.h
@@ -51,7 +51,6 @@ protected:
     ConnectorScanNode* _scan_node;
     const THdfsScanNode _hdfs_scan_node;
     int64_t _max_file_length = 0;
-    std::atomic<int32_t> _lazy_column_coalesce_counter = 0;
 };
 
 class HiveDataSource final : public DataSource {
@@ -65,7 +64,7 @@ public:
     Status get_next(RuntimeState* state, ChunkPtr* chunk) override;
     const std::string get_custom_coredump_msg() const override;
     std::atomic<int32_t>* get_lazy_column_coalesce_counter() {
-        return &(const_cast<HiveDataSourceProvider*>(_provider)->_lazy_column_coalesce_counter);
+        return _provider->_scan_node->get_lazy_column_coalesce_counter();;
     }
     int32_t scan_range_indicate_const_column_index(SlotId id) const;
 

--- a/be/src/exec/connector_scan_node.h
+++ b/be/src/exec/connector_scan_node.h
@@ -52,6 +52,7 @@ public:
     connector::DataSourceProvider* data_source_provider() { return _data_source_provider.get(); }
     connector::ConnectorType connector_type() { return _connector_type; }
     bool always_shared_scan() const override;
+    std::atomic<int32_t>* get_lazy_column_coalesce_counter() { return &_lazy_column_coalesce_counter; }
 
 #ifdef BE_TEST
     bool use_stream_load_thread_pool() { return _use_stream_load_thread_pool; };
@@ -93,6 +94,7 @@ private:
     std::atomic<int32_t> _scanner_submit_count = 0;
     std::atomic<int32_t> _running_threads = 0;
     std::atomic<int32_t> _closed_scanners = 0;
+    std::atomic<int32_t> _lazy_column_coalesce_counter = 0;
     template <typename T>
     class Stack {
     public:


### PR DESCRIPTION
## Why I'm doing:
introduced by #36526, counter only shared in scan range, but we need it is shared on the whole node. 

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
