### PR TITLE
[BugFix] fix query iceberg equality delete parquet file without primary key column

### DIFF
--- a/be/src/connector/connector.h
+++ b/be/src/connector/connector.h
@@ -93,7 +93,8 @@ protected:
     RuntimeProfile* _runtime_profile = nullptr;
     TupleDescriptor* _tuple_desc = nullptr;
     pipeline::ScanSplitContext* _split_context = nullptr;
-    void _init_chunk(ChunkPtr* chunk, size_t n) { *chunk = ChunkHelper::new_chunk(*_tuple_desc, n); }
+
+    virtual void _init_chunk(ChunkPtr* chunk, size_t n) { *chunk = ChunkHelper::new_chunk(*_tuple_desc, n); }
 };
 
 class StreamDataSource : public DataSource {

--- a/be/src/connector/hive_connector.h
+++ b/be/src/connector/hive_connector.h
@@ -78,6 +78,7 @@ public:
     bool can_estimate_mem_usage() const override { return true; }
 
     void get_split_tasks(std::vector<pipeline::ScanSplitContextPtr>* split_tasks) override;
+    void _init_chunk(ChunkPtr* chunk, size_t n) override;
 
 private:
     const HiveDataSourceProvider* _provider;

--- a/test/sql/test_iceberg/R/test_iceberg_v2
+++ b/test/sql/test_iceberg/R/test_iceberg_v2
@@ -66,6 +66,7 @@ select count(*) from iceberg_sql_test_${uuid0}.iceberg_ci_db.iceberg_v2_orc_part
 select k1,k3 from iceberg_sql_test_${uuid0}.iceberg_ci_db.iceberg_v2_orc_partitioned_table group by k1,k3 having count(1) > 1;
 -- result:
 -- !result
+
 /*
  CREATE TABLE `hive_catalog`.`iceberg_ci_db`.`iceberg_v2_parquet_unpartitioned_table` (
   `k1` INT NOT NULL,
@@ -82,9 +83,17 @@ select * from iceberg_sql_test_${uuid0}.iceberg_ci_db.iceberg_v2_parquet_unparti
 1	tianjing
 2	guangzhou
 -- !result
+select k2 from iceberg_sql_test_${uuid0}.iceberg_ci_db.iceberg_v2_parquet_unpartitioned_table order by k2;
+-- result:
+guangzhou
+tianjing
+-- !result
 select count(*) from iceberg_sql_test_${uuid0}.iceberg_ci_db.iceberg_v2_parquet_unpartitioned_table;
 -- result:
 2
+-- !result
+select k1 from iceberg_sql_test_${uuid0}.iceberg_ci_db.iceberg_v2_parquet_unpartitioned_table group by k1 having count(1) > 1;
+-- result:
 -- !result
 /*
 CREATE TABLE `hive_catalog`.`iceberg_ci_db`.`iceberg_v2_parquet_partitioned_table` (
@@ -104,6 +113,24 @@ select * from iceberg_sql_test_${uuid0}.iceberg_ci_db.iceberg_v2_parquet_partiti
 1	beijing	zhangsan
 2	shanghai	lisi
 -- !result
+select k2 from iceberg_sql_test_${uuid0}.iceberg_ci_db.iceberg_v2_parquet_partitioned_table order by k2;
+-- result:
+beijing
+shanghai
+-- !result
+select k3 from iceberg_sql_test_${uuid0}.iceberg_ci_db.iceberg_v2_parquet_partitioned_table order by k1;
+-- result:
+zhangsan
+lisi
+-- !result
+select count(*) from iceberg_sql_test_${uuid0}.iceberg_ci_db.iceberg_v2_parquet_partitioned_table;
+-- result:
+2
+-- !result
+select k1,k3 from iceberg_sql_test_${uuid0}.iceberg_ci_db.iceberg_v2_parquet_partitioned_table group by k1,k3 having count(1) > 1;
+-- result:
+-- !result
+
 drop catalog iceberg_sql_test_${uuid0};
 -- result:
 []

--- a/test/sql/test_iceberg/T/test_iceberg_v2
+++ b/test/sql/test_iceberg/T/test_iceberg_v2
@@ -49,7 +49,7 @@ select count(*) from iceberg_sql_test_${uuid0}.iceberg_ci_db.iceberg_v2_orc_part
 
 select k1,k3 from iceberg_sql_test_${uuid0}.iceberg_ci_db.iceberg_v2_orc_partitioned_table group by k1,k3 having count(1) > 1;
 
--- unpartitioned table with parquet (eq-delete && pos-delete)
+-- unpartitioned table with parquet (eq-delete && pos-delete) 
 /*
  CREATE TABLE `hive_catalog`.`iceberg_ci_db`.`iceberg_v2_parquet_unpartitioned_table` (
   `k1` INT NOT NULL,
@@ -63,7 +63,11 @@ select k1,k3 from iceberg_sql_test_${uuid0}.iceberg_ci_db.iceberg_v2_orc_partiti
 
 select * from iceberg_sql_test_${uuid0}.iceberg_ci_db.iceberg_v2_parquet_unpartitioned_table order by k1;
 
+select k2 from iceberg_sql_test_${uuid0}.iceberg_ci_db.iceberg_v2_parquet_unpartitioned_table order by k2;
+
 select count(*) from iceberg_sql_test_${uuid0}.iceberg_ci_db.iceberg_v2_parquet_unpartitioned_table;
+
+select k1 from iceberg_sql_test_${uuid0}.iceberg_ci_db.iceberg_v2_parquet_unpartitioned_table group by k1 having count(1) > 1;
 
 -- partitioned table with parquet (eq-delete && pos-delete)
 /*
@@ -80,5 +84,13 @@ WITH (
 */
 
 select * from iceberg_sql_test_${uuid0}.iceberg_ci_db.iceberg_v2_parquet_partitioned_table order by k1;
+
+select k2 from iceberg_sql_test_${uuid0}.iceberg_ci_db.iceberg_v2_parquet_partitioned_table order by k2;
+
+select k3 from iceberg_sql_test_${uuid0}.iceberg_ci_db.iceberg_v2_parquet_partitioned_table order by k1;
+
+select count(*) from iceberg_sql_test_${uuid0}.iceberg_ci_db.iceberg_v2_parquet_partitioned_table;
+
+select k1,k3 from iceberg_sql_test_${uuid0}.iceberg_ci_db.iceberg_v2_parquet_partitioned_table group by k1,k3 having count(1) > 1;
 
 drop catalog iceberg_sql_test_${uuid0};


### PR DESCRIPTION
## Why I'm doing:
The data reading from parquet group reader need to be swapped using slot id when filling the check created by hive_connector.  When select_items doesn't have primary key column on iceberg v2 table, the chunk created by hive_connector doesn't have the primary column slot id. 

## What I'm doing:
Adding primary column slot id if there is no select item in the query.

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
