### PR TITLE
[BugFix] cast array to array crash with const inputs

### DIFF
--- a/be/src/exprs/vectorized/cast_expr_array.cpp
+++ b/be/src/exprs/vectorized/cast_expr_array.cpp
@@ -30,6 +30,7 @@ StatusOr<ColumnPtr> VectorizedCastArrayExpr::evaluate_checked(ExprContext* conte
     ColumnPtr cast_column = column->clone_shared();
     ArrayColumn::Ptr array_col = nullptr;
     NullableColumn::Ptr nullable_col = nullptr;
+    cast_column = ColumnHelper::unpack_and_duplicate_const_column(column->size(), cast_column);
     ColumnPtr src_col = cast_column;
 
     if (src_col->is_nullable()) {

--- a/be/test/exprs/vectorized/cast_expr_test.cpp
+++ b/be/test/exprs/vectorized/cast_expr_test.cpp
@@ -2210,7 +2210,7 @@ TEST_F(VectorizedCastExprTest, array_int_to_array_string) {
         expr->clear_children();
         expr->add_child(const_array);
         auto result = expr->evaluate(nullptr, nullptr);
-        ASSERT_EQ("[['1','4'], ['1','4'], ['1','4']]", result->debug_string());
+        ASSERT_EQ("['1','4'], ['1','4'], ['1','4']", result->debug_string());
     }
 }
 


### PR DESCRIPTION
## Why I'm doing:

after
https://github.com/StarRocks/starrocks/pull/19793, cast may encounter const inputs, it has to handle such case.

## What I'm doing:

Fixes https://github.com/StarRocks/starrocks/issues/42445

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5

