### PR TITLE
[BugFix] fix incorrect argument type check

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/validate/TypeChecker.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/validate/TypeChecker.java
@@ -165,7 +165,11 @@ public class TypeChecker implements PlanValidator.Checker {
                         isMergeAggFn = isSplit && hasRemoveDistinctFunc && !aggCall.isRemovedDistinct();
                         break;
                     case GLOBAL:
-                        isMergeAggFn = isSplit && (!hasRemoveDistinctFunc || !aggCall.isRemovedDistinct());
+                        if (hasRemoveDistinctFunc) {
+                            isMergeAggFn = !aggCall.isRemovedDistinct();
+                        } else if (isSplit) {
+                            isMergeAggFn = true;
+                        }
                         break;
                     case DISTINCT_GLOBAL:
                         isMergeAggFn = true;

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/DistributedEnvPlanWithCostTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/DistributedEnvPlanWithCostTest.java
@@ -1583,4 +1583,11 @@ public class DistributedEnvPlanWithCostTest extends DistributedEnvPlanTestBase {
         assertCContains(plan, "C_NAME-->[-Infinity, Infinity, 0.0, 25.0, 600000.0] ESTIMATE",
                 "C_NATIONKEY-->[0.0, 24.0, 0.0, 4.0, 25.0] ESTIMATE");
     }
+
+    @Test
+    public void testOneTabletDistinctAgg() throws Exception {
+        String sql = "select sum(id), group_concat(distinct name) from skew_table where id = 1 group by id";
+        String plan = getFragmentPlan(sql);
+        System.out.println(plan);
+    }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/DistributedEnvPlanWithCostTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/DistributedEnvPlanWithCostTest.java
@@ -1588,6 +1588,15 @@ public class DistributedEnvPlanWithCostTest extends DistributedEnvPlanTestBase {
     public void testOneTabletDistinctAgg() throws Exception {
         String sql = "select sum(id), group_concat(distinct name) from skew_table where id = 1 group by id";
         String plan = getFragmentPlan(sql);
-        System.out.println(plan);
+        assertContains(plan, "2:AGGREGATE (update finalize)\n" +
+                "  |  output: sum(3: sum), group_concat(2: name, ',')\n" +
+                "  |  group by: 1: id\n" +
+                "  |  \n" +
+                "  1:AGGREGATE (update serialize)\n" +
+                "  |  output: sum(1: id)\n" +
+                "  |  group by: 1: id, 2: name\n" +
+                "  |  \n" +
+                "  0:OlapScanNode\n" +
+                "     TABLE: skew_table");
     }
 }

--- a/test/sql/test_agg/R/test_distinct_agg
+++ b/test/sql/test_agg/R/test_distinct_agg
@@ -1,6 +1,6 @@
 -- name: test_distinct_agg
 CREATE TABLE `skew_agg` (
-  `c0` bigint DEFAULT NULL,
+  `c0` int DEFAULT NULL,
   `c1` bigint DEFAULT NULL,
   `c2` bigint DEFAULT NULL,
   `c3` bigint DEFAULT NULL,
@@ -985,4 +985,8 @@ select array_agg(distinct c2), count(distinct c2), sum(c3) from skew_agg group b
 [3]	1	5000
 [3]	1	5000
 [3]	1	5000
+-- !result
+select sum(c0), count(distinct c2, c3) from skew_agg where c0 = 480816 and c1 = 2 group by c4;
+-- result:
+480816	1
 -- !result

--- a/test/sql/test_agg/T/test_distinct_agg
+++ b/test/sql/test_agg/T/test_distinct_agg
@@ -1,7 +1,7 @@
 -- name: test_distinct_agg
 
 CREATE TABLE `skew_agg` (
-  `c0` bigint DEFAULT NULL,
+  `c0` int DEFAULT NULL,
   `c1` bigint DEFAULT NULL,
   `c2` bigint DEFAULT NULL,
   `c3` bigint DEFAULT NULL,
@@ -319,3 +319,5 @@ select group_concat(distinct c2), array_agg(distinct c2), count(distinct c2), su
 select group_concat(distinct c2), array_agg(distinct c2), count(distinct c2), sum(c3) from skew_agg group by c1;
 select group_concat(distinct c2), array_agg(distinct c2), count(distinct c2), sum(c3) from skew_agg group by rollup(c1, c2);
 select array_agg(distinct c2), count(distinct c2), sum(c3) from skew_agg group by rollup(c1, c2);
+
+select sum(c0), count(distinct c2, c3) from skew_agg where c0 = 480816 and c1 = 2 group by c4;


### PR DESCRIPTION
## Why I'm doing:
For sql like `select sum(id), group_concat(distinct name) from skew_table where id = 1 group by id`, we may generate a plan after `SplitMultiPhaseAggRule`:
`
GLOBAL AGG (unsplit)
    DISTINCT GLOABL AGG(split)
        LOCAL AGG(split)
`
It want to be further splited in `SplitTwoPhaseAggRule` but won't be split if the tablet is only one. The type checker regards the unsplit agg is not a merge function which will check its args type in function signature and its input col type. This may lead a unexpected error.

## What I'm doing:
change the check logic. Use the logic similar with setMergeFn in plan builder to check.

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [x] 3.1
  - [ ] 3.0
  - [ ] 2.5
