### PR TITLE
[Enhancement] Support size-tiered compaction for pk (backport #41130)

### DIFF
--- a/be/src/storage/tablet_updates.cpp
+++ b/be/src/storage/tablet_updates.cpp
@@ -2397,8 +2397,9 @@ struct CompactionEntry {
     bool operator<(const CompactionEntry& rhs) const { return score_per_row > rhs.score_per_row; }
 };
 
-static string int_list_to_string(const vector<uint32_t>& l) {
-    string ret;
+template <typename T>
+static std::string int_list_to_string(const std::vector<T>& l) {
+    std::string ret;
     for (size_t i = 0; i < l.size(); i++) {
         if (i > 0) {
             ret.append(",");
@@ -2409,6 +2410,9 @@ static string int_list_to_string(const vector<uint32_t>& l) {
 }
 
 Status TabletUpdates::compaction(MemTracker* mem_tracker) {
+    if (config::enable_pk_size_tiered_compaction_strategy) {
+        return compaction_for_size_tiered(mem_tracker);
+    }
     if (_error) {
         return Status::InternalError(strings::Substitute(
                 "compaction failed, tablet updates is in error state: tablet:$0 $1", _tablet.tablet_id(), _error_msg));
@@ -2516,6 +2520,174 @@ Status TabletUpdates::compaction(MemTracker* mem_tracker) {
               << " #valid_segments:" << total_valid_segments << " #rows:" << total_rows << "->"
               << total_rows_after_compaction << " bytes:" << PrettyPrinter::print(total_bytes, TUnit::BYTES) << "->"
               << PrettyPrinter::print(total_bytes_after_compaction, TUnit::BYTES) << "(estimate)";
+
+    MemTracker* prev_tracker = tls_thread_status.set_mem_tracker(mem_tracker);
+    DeferOp op([&] { tls_thread_status.set_mem_tracker(prev_tracker); });
+
+    Status st = _do_compaction(&info);
+    if (!st.ok()) {
+        _compaction_running = false;
+        _last_compaction_failure_millis = UnixMillis();
+    } else {
+        _last_compaction_success_millis = UnixMillis();
+    }
+    return st;
+}
+
+Status TabletUpdates::compaction_for_size_tiered(MemTracker* mem_tracker) {
+    if (_error) {
+        return Status::InternalError(strings::Substitute(
+                "compaction failed, tablet updates is in error state: tablet:$0 $1", _tablet.tablet_id(), _error_msg));
+    }
+    bool was_runing = false;
+    if (!_compaction_running.compare_exchange_strong(was_runing, true)) {
+        return Status::InternalError("illegal state: another compaction is running");
+    }
+    vector<uint32_t> rowsets;
+    std::unique_ptr<CompactionInfo> info = std::make_unique<CompactionInfo>();
+    {
+        std::lock_guard rl(_lock);
+        if (_edit_version_infos.empty()) {
+            string msg = strings::Substitute("tablet deleted when compaction tablet:$0", _tablet.tablet_id());
+            LOG(WARNING) << msg;
+            return Status::InternalError(msg);
+        }
+        // 1. start compaction at current apply version
+        info->start_version = _edit_version_infos[_apply_version_idx]->version;
+        rowsets = _edit_version_infos[_apply_version_idx]->rowsets;
+    }
+
+    size_t total_valid_rowsets = 0;
+    size_t total_valid_segments = 0;
+    // level -1 keep empty rowsets and have no IO overhead, so we can merge them with any level
+    std::map<int, vector<CompactionEntry>> candidates_by_level;
+    {
+        std::lock_guard lg(_rowset_stats_lock);
+        for (auto rowsetid : rowsets) {
+            auto itr = _rowset_stats.find(rowsetid);
+            if (itr == _rowset_stats.end()) {
+                // should not happen
+                string msg = strings::Substitute("rowset not found in rowset stats tablet=$0 rowset=$1",
+                                                 _tablet.tablet_id(), rowsetid);
+                DCHECK(false) << msg;
+                LOG(WARNING) << msg;
+            } else if (itr->second->compaction_score > 0) {
+                auto& stat = *itr->second;
+                total_valid_rowsets++;
+                total_valid_segments += stat.num_segments;
+                int32_t level = _calc_compaction_level(&stat);
+                candidates_by_level[level].emplace_back();
+                auto& e = candidates_by_level[level].back();
+                e.rowsetid = itr->first;
+                e.score_per_row =
+                        (level == -1) ? 0 : (float)((double)stat.compaction_score / (stat.num_rows - stat.num_dels));
+                e.num_rows = stat.num_rows;
+                e.num_dels = stat.num_dels;
+                e.bytes = stat.byte_size;
+                e.num_segments = stat.num_segments;
+            }
+        }
+    }
+
+    int64_t total_rows = 0;
+    int64_t total_bytes = 0;
+    int32_t compaction_level = -1;
+    int64_t max_score = 0;
+    for (auto& [level, candidates] : candidates_by_level) {
+        if (level == -1) {
+            continue;
+        }
+        int64_t total_segments = 0;
+        int64_t del_rows = 0;
+        int64_t level_score = 0;
+        for (auto& e : candidates) {
+            level_score += e.score_per_row * (e.num_rows - e.num_dels);
+            total_segments += e.num_segments;
+            del_rows += e.num_dels;
+        }
+        if (level_score > max_score && (total_segments > 1 || del_rows > 0)) {
+            compaction_level = level;
+            max_score = level_score;
+        }
+    }
+
+    int64_t total_merged_segments = 0;
+    RowsetStats stat;
+    std::set<int32_t> compaction_level_candidate;
+    max_score = 0;
+    do {
+        auto iter = candidates_by_level.find(compaction_level);
+        if (iter == candidates_by_level.end()) {
+            break;
+        }
+        for (auto& e : iter->second) {
+            size_t new_rows = stat.num_rows + e.num_rows - e.num_dels;
+            size_t new_bytes = stat.byte_size;
+            if (e.num_rows != 0) {
+                new_bytes += e.bytes * (e.num_rows - e.num_dels) / e.num_rows;
+            }
+            if ((stat.byte_size > 0 && new_bytes > config::update_compaction_result_bytes * 2) ||
+                info->inputs.size() >= config::max_update_compaction_num_singleton_deltas) {
+                break;
+            }
+            max_score += e.score_per_row * (e.num_rows - e.num_dels);
+            info->inputs.emplace_back(e.rowsetid);
+            stat.num_rows = new_rows;
+            stat.byte_size = new_bytes;
+            total_rows += e.num_rows;
+            total_bytes += e.bytes;
+            total_merged_segments += e.num_segments;
+        }
+        compaction_level_candidate.insert(compaction_level);
+        compaction_level = _calc_compaction_level(&stat);
+        stat.num_segments = stat.byte_size > 0 ? (stat.byte_size - 1) / config::max_segment_file_size + 1 : 0;
+        _calc_compaction_score(&stat);
+    } while (stat.byte_size <= config::update_compaction_result_bytes * 2 &&
+             info->inputs.size() < config::max_update_compaction_num_singleton_deltas &&
+             compaction_level_candidate.find(compaction_level) == compaction_level_candidate.end() &&
+             candidates_by_level.find(compaction_level) != candidates_by_level.end() && stat.compaction_score > 0);
+
+    if (compaction_level_candidate.find(-1) == compaction_level_candidate.end()) {
+        if (candidates_by_level[-1].size() > 0) {
+            for (auto& e : candidates_by_level[-1]) {
+                info->inputs.emplace_back(e.rowsetid);
+                total_merged_segments += e.num_segments;
+            }
+            compaction_level_candidate.insert(-1);
+        }
+    }
+
+    size_t version_count = rowsets.size() - info->inputs.size() + _pending_commits.size();
+    // too many rowsets, try to trigger compaction again
+    if (version_count >= config::tablet_max_versions * 80 / 100) {
+        LOG(INFO) << strings::Substitute(
+                "tablet:$0 will try to trigger compaction again because of too many compaction version_count:$1, "
+                "pending:$2",
+                _tablet.tablet_id(), version_count, _pending_commits.size());
+    } else {
+        // give 10s time gitter, so same table's compaction don't start at same time
+        _last_compaction_time_ms = UnixMillis() + rand() % 10000;
+    }
+
+    int64_t del_rows = total_rows - stat.num_rows;
+    // 1. no candidate rowsets, skip compaction
+    // 2. only an empty rowset, skip compaction
+    if (info->inputs.empty() || (info->inputs.size() <= 1 && compaction_level == -1 && del_rows == 0)) {
+        LOG(INFO) << "no candidate rowset to do update compaction, tablet:" << _tablet.tablet_id();
+        _compaction_running = false;
+        return Status::OK();
+    }
+
+    std::sort(info->inputs.begin(), info->inputs.end());
+    std::vector<int32_t> levels(compaction_level_candidate.begin(), compaction_level_candidate.end());
+    LOG(INFO) << "update compaction start tablet:" << _tablet.tablet_id()
+              << " version:" << info->start_version.to_string() << " score:" << max_score
+              << " merge levels:" << int_list_to_string(levels) << " pick:" << info->inputs.size()
+              << "/valid:" << total_valid_rowsets << "/all:" << rowsets.size() << " "
+              << int_list_to_string(info->inputs) << " #pick_segments:" << total_merged_segments
+              << " #valid_segments:" << total_valid_segments << " #rows:" << total_rows << "->" << stat.num_rows
+              << " bytes:" << PrettyPrinter::print(total_bytes, TUnit::BYTES) << "->"
+              << PrettyPrinter::print(stat.byte_size, TUnit::BYTES) << "(estimate)";
 
     MemTracker* prev_tracker = tls_thread_status.set_mem_tracker(mem_tracker);
     DeferOp op([&] { tls_thread_status.set_mem_tracker(prev_tracker); });
@@ -2815,6 +2987,30 @@ void TabletUpdates::get_compaction_status(std::string* json_result) {
     *json_result = std::string(strbuf.GetString());
 }
 
+int32_t TabletUpdates::_calc_compaction_level(RowsetStats* stats) {
+    if (stats->num_rows == 0) {
+        return -1;
+    }
+    size_t new_rows = stats->num_rows - stats->num_dels;
+    size_t new_bytes = stats->byte_size * new_rows / stats->num_rows;
+
+    int64_t level_multiple = config::size_tiered_level_multiple;
+    int64_t min_level_size = config::size_tiered_min_level_size;
+    int64_t level_num = config::size_tiered_level_num;
+    int64_t max_level_size = min_level_size * pow(level_multiple, level_num);
+
+    if (new_bytes == 0) {
+        return -1;
+    } else if (new_bytes <= min_level_size) {
+        return 0;
+    } else if (new_bytes >= max_level_size) {
+        return level_num;
+    } else {
+        auto x = (double)new_bytes / min_level_size;
+        return log(x) / log((double)level_multiple);
+    }
+}
+
 void TabletUpdates::_calc_compaction_score(RowsetStats* stats) {
     if (stats->num_rows == 0) {
         stats->compaction_score = config::update_compaction_size_threshold;
@@ -2980,9 +3176,11 @@ int64_t TabletUpdates::get_average_row_size() {
 }
 
 std::string TabletUpdates::RowsetStats::to_string() const {
-    return strings::Substitute("[seg:$0 row:$1 del:$2 bytes:$3 row_size:$4 compaction:$5 partial_update_by_column:$6]",
-                               num_segments, num_rows, num_dels, byte_size, row_size, compaction_score,
-                               partial_update_by_column);
+    return strings::Substitute(
+            "[seg:$0 row:$1 del:$2 bytes:$3 row_size:$4 compaction_score:$5 compaction_level:$6 "
+            "partial_update_by_column:$7]",
+            num_segments, num_rows, num_dels, byte_size, row_size, compaction_score, compaction_level,
+            partial_update_by_column);
 }
 
 std::string TabletUpdates::debug_string() const {

--- a/be/src/storage/tablet_updates.h
+++ b/be/src/storage/tablet_updates.h
@@ -185,6 +185,7 @@ public:
 
     // perform compaction, should only be called by compaction thread
     Status compaction(MemTracker* mem_tracker);
+    Status compaction_for_size_tiered(MemTracker* mem_tracker);
 
     // perform compaction with specified rowsets, this may be a manual compaction invoked by tools or data fixing jobs
     Status compaction(MemTracker* mem_tracker, const vector<uint32_t>& input_rowset_ids);
@@ -359,6 +360,7 @@ private:
         size_t byte_size = 0;
         size_t row_size = 0;
         int64_t compaction_score = 0;
+        int32_t compaction_level = -1;
         bool partial_update_by_column = false;
         std::string to_string() const;
     };
@@ -399,6 +401,7 @@ private:
 
     Status _do_compaction(std::unique_ptr<CompactionInfo>* pinfo);
 
+    int32_t _calc_compaction_level(RowsetStats* stats);
     void _calc_compaction_score(RowsetStats* stats);
 
     Status _do_update(uint32_t rowset_id, int32_t upsert_idx, int32_t condition_column, int64_t read_version,
@@ -452,6 +455,12 @@ private:
 
     // these functions is only used in ut
     void stop_apply(bool apply_stopped) { _apply_stopped = apply_stopped; }
+    void stop_compaction(bool running) {
+        _compaction_running = running;
+        if (running) {
+            _last_compaction_time_ms = UnixMillis();
+        }
+    }
 
     void check_for_apply() { _check_for_apply(); }
 

--- a/be/test/storage/rowset_column_partial_update_test.cpp
+++ b/be/test/storage/rowset_column_partial_update_test.cpp
@@ -47,6 +47,7 @@ public:
         _compaction_mem_tracker = std::make_unique<MemTracker>(-1);
         _update_mem_tracker = std::make_unique<MemTracker>();
         config::primary_key_batch_get_index_memory_limit = GetParam();
+        config::enable_pk_size_tiered_compaction_strategy = false;
     }
 
     void TearDown() override {
@@ -56,6 +57,7 @@ public:
                 tablet.reset();
             }
         }
+        config::enable_pk_size_tiered_compaction_strategy = true;
     }
 
     RowsetSharedPtr create_rowset(const TabletSharedPtr& tablet, const vector<int64_t>& keys, bool add_v3 = false) {

--- a/be/test/storage/tablet_updates_test.cpp
+++ b/be/test/storage/tablet_updates_test.cpp
@@ -566,7 +566,10 @@ public:
         return StorageEngine::instance()->tablet_manager()->get_tablet(tablet_id, false);
     }
 
-    void SetUp() override { _compaction_mem_tracker = std::make_unique<MemTracker>(-1); }
+    void SetUp() override { 
+        _compaction_mem_tracker = std::make_unique<MemTracker>(-1); 
+        config::enable_pk_size_tiered_compaction_strategy = false;
+    }
 
     void TearDown() override {
         if (_tablet2) {
@@ -577,6 +580,7 @@ public:
             StorageEngine::instance()->tablet_manager()->drop_tablet(_tablet->tablet_id());
             _tablet.reset();
         }
+        config::enable_pk_size_tiered_compaction_strategy = true;
     }
 
     static Status full_clone(const TabletSharedPtr& source_tablet, int clone_version,
@@ -3977,6 +3981,82 @@ TEST_F(TabletUpdatesTest, test_recover_rowset_sorter) {
     ASSERT_TRUE(latest_rowsets[0]->rowset_meta()->max_compact_input_rowset_id() <
                 latest_rowsets[1]->rowset_meta()->get_rowset_seg_id());
     config::max_update_compaction_num_singleton_deltas = old_config;
+}
+
+TEST_F(TabletUpdatesTest, test_size_tiered_compaction) {
+    config::enable_pk_size_tiered_compaction_strategy = true;
+    config::size_tiered_level_multiple = 2;
+    config::size_tiered_level_num = 7;
+    config::size_tiered_min_level_size = 64;
+    config::update_compaction_size_threshold = 64 * 1024 * 1024;
+    config::update_compaction_per_tablet_min_interval_seconds = 86400;
+    _tablet = create_tablet(rand(), rand());
+    _tablet->updates()->stop_compaction(true);
+
+    std::vector<RowsetSharedPtr> rowsets;
+    std::vector<int64_t> keys;
+
+    // level 0 rowsets
+    for (int i = 0; i < 10; i++) {
+        keys.clear();
+        keys.emplace_back(i);
+        rowsets.emplace_back(create_rowset(_tablet, keys, nullptr, false, false));
+    }
+    int64_t version = 2;
+    for (int i = 0; i < rowsets.size(); i++) {
+        auto st = _tablet->rowset_commit(version, rowsets[i]);
+        ASSERT_TRUE(st.ok()) << st.to_string();
+        ASSERT_EQ(version, _tablet->updates()->max_version());
+        ASSERT_EQ(version, _tablet->updates()->version_history_count());
+        version++;
+    }
+    ASSERT_EQ(10, read_tablet(_tablet, version - 1));
+
+    // empty rowsets level -1
+    rowsets.clear();
+    for (int i = 0; i < 2; i++) {
+        rowsets.emplace_back(create_rowset(_tablet, keys, nullptr, true, false));
+    }
+    // delete history rowsets data
+    rowsets.emplace_back(create_rowset(_tablet, keys, nullptr, false, false));
+    for (int i = 0; i < rowsets.size(); i++) {
+        auto st = _tablet->rowset_commit(version, rowsets[i]);
+        ASSERT_TRUE(st.ok()) << st.to_string();
+        ASSERT_EQ(version, _tablet->updates()->max_version());
+        ASSERT_EQ(version, _tablet->updates()->version_history_count());
+        version++;
+    }
+    ASSERT_EQ(10, read_tablet(_tablet, version - 1));
+
+    // high level rowsets
+    rowsets.clear();
+    int N = 2000;
+    for (int i = 1; i < 3; i++) {
+        keys.clear();
+        for (int j = 0; j < N; j++) {
+            keys.emplace_back(i * 10000 + j);
+        }
+        rowsets.emplace_back(create_rowset(_tablet, keys, nullptr, false, false));
+    }
+    for (int i = 0; i < rowsets.size(); i++) {
+        auto st = _tablet->rowset_commit(version, rowsets[i]);
+        ASSERT_TRUE(st.ok()) << st.to_string();
+        ASSERT_EQ(version, _tablet->updates()->max_version());
+        ASSERT_EQ(version, _tablet->updates()->version_history_count());
+        version++;
+    }
+    ASSERT_EQ(10 + N * 2, read_tablet(_tablet, version - 1));
+
+    rowsets.clear();
+    ASSERT_TRUE(_tablet->updates()->get_applied_rowsets(version - 1, &rowsets).ok());
+    ASSERT_EQ(15, rowsets.size());
+
+    _tablet->updates()->stop_compaction(false);
+    ASSERT_TRUE(_tablet->updates()->compaction_for_size_tiered(_compaction_mem_tracker.get()).ok());
+
+    rowsets.clear();
+    ASSERT_TRUE(_tablet->updates()->get_applied_rowsets(version - 1, &rowsets).ok());
+    ASSERT_EQ(3, rowsets.size());
 }
 
 } // namespace starrocks

--- a/be/test/storage/tablet_updates_test.cpp
+++ b/be/test/storage/tablet_updates_test.cpp
@@ -566,8 +566,8 @@ public:
         return StorageEngine::instance()->tablet_manager()->get_tablet(tablet_id, false);
     }
 
-    void SetUp() override { 
-        _compaction_mem_tracker = std::make_unique<MemTracker>(-1); 
+    void SetUp() override {
+        _compaction_mem_tracker = std::make_unique<MemTracker>(-1);
         config::enable_pk_size_tiered_compaction_strategy = false;
     }
 

--- a/be/test/storage/tablet_updates_test.h
+++ b/be/test/storage/tablet_updates_test.h
@@ -1,0 +1,860 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <gtest/gtest.h>
+
+#include <chrono>
+#include <memory>
+#include <string>
+#include <thread>
+
+#include "column/datum_tuple.h"
+#include "column/vectorized_fwd.h"
+#include "fs/fs.h"
+#include "gutil/strings/substitute.h"
+#include "runtime/runtime_state.h"
+#include "storage/chunk_helper.h"
+#include "storage/empty_iterator.h"
+#include "storage/kv_store.h"
+#include "storage/primary_key_encoder.h"
+#include "storage/rowset/rowset_factory.h"
+#include "storage/rowset/rowset_options.h"
+#include "storage/rowset/rowset_writer.h"
+#include "storage/rowset/rowset_writer_context.h"
+#include "storage/rowset/segment.h"
+#include "storage/schema_change.h"
+#include "storage/snapshot_manager.h"
+#include "storage/storage_engine.h"
+#include "storage/tablet.h"
+#include "storage/tablet_manager.h"
+#include "storage/tablet_meta_manager.h"
+#include "storage/tablet_reader.h"
+#include "storage/tablet_updates.h"
+#include "storage/union_iterator.h"
+#include "storage/update_manager.h"
+#include "testutil/assert.h"
+#include "util/defer_op.h"
+#include "util/path_util.h"
+
+namespace starrocks {
+
+enum PartialUpdateCloneCase {
+    CASE1, // rowset status is committed in meta, rowset file is partial rowset
+    CASE2, // rowset status is committed in meta, rowset file is partial rowset, but rowset is apply success after link file
+    CASE3, // rowset status is committed in meta, rowset file is full rowset
+    CASE4  // rowset status is applied in meta, rowset file is full rowset
+};
+
+template <class T>
+static void append_datum_func(std::shared_ptr<Column> col, T val) {
+    if (val == -1) {
+        col->append_nulls(1);
+    } else {
+        col->append_datum(Datum(val));
+    }
+}
+
+class TabletUpdatesTest : public testing::Test {
+public:
+    RowsetSharedPtr create_rowset(const TabletSharedPtr& tablet, const vector<int64_t>& keys,
+                                  Column* one_delete = nullptr, bool empty = false, bool has_merge_condition = false) {
+        RowsetWriterContext writer_context;
+        RowsetId rowset_id = StorageEngine::instance()->next_rowset_id();
+        writer_context.rowset_id = rowset_id;
+        writer_context.tablet_id = tablet->tablet_id();
+        writer_context.tablet_schema_hash = tablet->schema_hash();
+        writer_context.partition_id = 0;
+        writer_context.rowset_path_prefix = tablet->schema_hash_path();
+        writer_context.rowset_state = COMMITTED;
+        writer_context.tablet_schema = tablet->thread_safe_get_tablet_schema();
+        writer_context.version.first = 0;
+        writer_context.version.second = 0;
+        writer_context.segments_overlap = NONOVERLAPPING;
+        if (has_merge_condition) {
+            writer_context.merge_condition = "v2";
+        }
+        std::unique_ptr<RowsetWriter> writer;
+        EXPECT_TRUE(RowsetFactory::create_rowset_writer(writer_context, &writer).ok());
+        if (empty) {
+            return *writer->build();
+        }
+        auto schema = ChunkHelper::convert_schema(tablet->thread_safe_get_tablet_schema());
+        auto chunk = ChunkHelper::new_chunk(schema, keys.size());
+        auto& cols = chunk->columns();
+        for (int64_t key : keys) {
+            if (schema.num_key_fields() == 1) {
+                cols[0]->append_datum(Datum(key));
+            } else {
+                cols[0]->append_datum(Datum(key));
+                string v = fmt::to_string(key * 234234342345);
+                cols[1]->append_datum(Datum(Slice(v)));
+                cols[2]->append_datum(Datum((int32_t)key));
+            }
+            int vcol_start = schema.num_key_fields();
+            cols[vcol_start]->append_datum(Datum((int16_t)(key % 100 + 1)));
+            if (cols[vcol_start + 1]->is_binary()) {
+                string v = fmt::to_string(key % 1000 + 2);
+                cols[vcol_start + 1]->append_datum(Datum(Slice(v)));
+            } else {
+                cols[vcol_start + 1]->append_datum(Datum((int32_t)(key % 1000 + 2)));
+            }
+        }
+        if (one_delete == nullptr && !keys.empty()) {
+            CHECK_OK(writer->flush_chunk(*chunk));
+        } else if (one_delete == nullptr) {
+            CHECK_OK(writer->flush());
+        } else if (one_delete != nullptr) {
+            CHECK_OK(writer->flush_chunk_with_deletes(*chunk, *one_delete));
+        }
+        return *writer->build();
+    }
+
+    RowsetSharedPtr create_rowset_with_mutiple_segments(const TabletSharedPtr& tablet,
+                                                        const vector<vector<int64_t>>& keys_by_segment,
+                                                        Column* one_delete = nullptr, bool empty = false,
+                                                        bool has_merge_condition = false) {
+        RowsetWriterContext writer_context;
+        RowsetId rowset_id = StorageEngine::instance()->next_rowset_id();
+        writer_context.rowset_id = rowset_id;
+        writer_context.tablet_id = tablet->tablet_id();
+        writer_context.tablet_schema_hash = tablet->schema_hash();
+        writer_context.partition_id = 0;
+        writer_context.rowset_path_prefix = tablet->schema_hash_path();
+        writer_context.rowset_state = COMMITTED;
+        writer_context.tablet_schema = tablet->thread_safe_get_tablet_schema();
+        writer_context.version.first = 0;
+        writer_context.version.second = 0;
+        writer_context.segments_overlap = OVERLAP_UNKNOWN;
+        if (has_merge_condition) {
+            writer_context.merge_condition = "v2";
+        }
+        std::unique_ptr<RowsetWriter> writer;
+        EXPECT_TRUE(RowsetFactory::create_rowset_writer(writer_context, &writer).ok());
+        if (empty) {
+            return *writer->build();
+        }
+        auto schema = ChunkHelper::convert_schema(tablet->thread_safe_get_tablet_schema());
+        for (int i = 0; i < keys_by_segment.size(); i++) {
+            auto chunk = ChunkHelper::new_chunk(schema, keys_by_segment[i].size());
+            auto& cols = chunk->columns();
+            for (int64_t key : keys_by_segment[i]) {
+                if (schema.num_key_fields() == 1) {
+                    cols[0]->append_datum(Datum(key));
+                } else {
+                    cols[0]->append_datum(Datum(key));
+                    string v = fmt::to_string(key * 234234342345);
+                    cols[1]->append_datum(Datum(Slice(v)));
+                    cols[2]->append_datum(Datum((int32_t)key));
+                }
+                int vcol_start = schema.num_key_fields();
+                cols[vcol_start]->append_datum(Datum((int16_t)(key % 100 + 1)));
+                if (cols[vcol_start + 1]->is_binary()) {
+                    string v = fmt::to_string(key % 1000 + 2);
+                    cols[vcol_start + 1]->append_datum(Datum(Slice(v)));
+                } else {
+                    cols[vcol_start + 1]->append_datum(Datum((int32_t)(key % 1000 + 2)));
+                }
+            }
+            if (one_delete == nullptr && !keys_by_segment[i].empty()) {
+                CHECK_OK(writer->flush_chunk(*chunk));
+            } else if (one_delete == nullptr) {
+                CHECK_OK(writer->flush());
+            } else if (one_delete != nullptr) {
+                CHECK_OK(writer->flush_chunk_with_deletes(*chunk, *one_delete));
+            }
+        }
+        return *writer->build();
+    }
+
+    RowsetSharedPtr create_partial_rowset(const TabletSharedPtr& tablet, const vector<int64_t>& keys,
+                                          std::vector<int32_t>& column_indexes,
+                                          const std::shared_ptr<TabletSchema>& partial_schema) {
+        // create partial rowset
+        RowsetWriterContext writer_context;
+        RowsetId rowset_id = StorageEngine::instance()->next_rowset_id();
+        writer_context.rowset_id = rowset_id;
+        writer_context.tablet_id = tablet->tablet_id();
+        writer_context.tablet_schema_hash = tablet->schema_hash();
+        writer_context.partition_id = 0;
+        writer_context.rowset_path_prefix = tablet->schema_hash_path();
+        writer_context.rowset_state = COMMITTED;
+        writer_context.tablet_schema = partial_schema;
+        writer_context.referenced_column_ids = column_indexes;
+        writer_context.full_tablet_schema = tablet->tablet_schema();
+        writer_context.is_partial_update = true;
+        writer_context.version.first = 0;
+        writer_context.version.second = 0;
+        writer_context.segments_overlap = NONOVERLAPPING;
+        std::unique_ptr<RowsetWriter> writer;
+        EXPECT_TRUE(RowsetFactory::create_rowset_writer(writer_context, &writer).ok());
+        auto schema = ChunkHelper::convert_schema(partial_schema);
+
+        if (keys.size() > 0) {
+            auto chunk = ChunkHelper::new_chunk(schema, keys.size());
+            EXPECT_TRUE(2 == chunk->num_columns());
+            auto& cols = chunk->columns();
+            for (long key : keys) {
+                cols[0]->append_datum(Datum(key));
+                cols[1]->append_datum(Datum((int16_t)(key % 100 + 3)));
+            }
+            CHECK_OK(writer->flush_chunk(*chunk));
+        }
+        RowsetSharedPtr partial_rowset = *writer->build();
+
+        return partial_rowset;
+    }
+
+    RowsetSharedPtr create_rowsets(const TabletSharedPtr& tablet, const vector<int64_t>& keys,
+                                   std::size_t max_rows_per_segment) {
+        RowsetWriterContext writer_context;
+        RowsetId rowset_id = StorageEngine::instance()->next_rowset_id();
+        writer_context.rowset_id = rowset_id;
+        writer_context.tablet_id = tablet->tablet_id();
+        writer_context.tablet_schema_hash = tablet->schema_hash();
+        writer_context.partition_id = 0;
+        writer_context.rowset_path_prefix = tablet->schema_hash_path();
+        writer_context.rowset_state = COMMITTED;
+        writer_context.tablet_schema = tablet->thread_safe_get_tablet_schema();
+        writer_context.version.first = 0;
+        writer_context.version.second = 0;
+        writer_context.segments_overlap = NONOVERLAPPING;
+        std::unique_ptr<RowsetWriter> writer;
+        EXPECT_TRUE(RowsetFactory::create_rowset_writer(writer_context, &writer).ok());
+        auto schema = ChunkHelper::convert_schema(tablet->thread_safe_get_tablet_schema());
+        for (std::size_t written_rows = 0; written_rows < keys.size(); written_rows += max_rows_per_segment) {
+            auto chunk = ChunkHelper::new_chunk(schema, max_rows_per_segment);
+            auto& cols = chunk->columns();
+            for (size_t i = 0; i < max_rows_per_segment; i++) {
+                cols[0]->append_datum(Datum(keys[written_rows + i]));
+                cols[1]->append_datum(Datum((int16_t)(keys[written_rows + i] % 100 + 1)));
+                cols[2]->append_datum(Datum((int32_t)(keys[written_rows + i] % 1000 + 2)));
+            }
+            CHECK_OK(writer->flush_chunk(*chunk));
+        }
+        return *writer->build();
+    }
+
+    RowsetSharedPtr create_rowset_schema_change_sort_key(const TabletSharedPtr& tablet, const vector<int64_t>& keys) {
+        RowsetWriterContext writer_context;
+        RowsetId rowset_id = StorageEngine::instance()->next_rowset_id();
+        writer_context.rowset_id = rowset_id;
+        writer_context.tablet_id = tablet->tablet_id();
+        writer_context.tablet_schema_hash = tablet->schema_hash();
+        writer_context.partition_id = 0;
+        writer_context.rowset_path_prefix = tablet->schema_hash_path();
+        writer_context.rowset_state = COMMITTED;
+        writer_context.tablet_schema = tablet->thread_safe_get_tablet_schema();
+        writer_context.version.first = 0;
+        writer_context.version.second = 0;
+        writer_context.segments_overlap = NONOVERLAPPING;
+        std::unique_ptr<RowsetWriter> writer;
+        EXPECT_TRUE(RowsetFactory::create_rowset_writer(writer_context, &writer).ok());
+        auto schema = ChunkHelper::convert_schema(tablet->thread_safe_get_tablet_schema());
+        const auto nkeys = keys.size();
+        auto chunk = ChunkHelper::new_chunk(schema, nkeys);
+        auto& cols = chunk->columns();
+        for (int64_t key : keys) {
+            cols[0]->append_datum(Datum(key));
+            cols[1]->append_datum(Datum((int16_t)(nkeys - 1 - key)));
+            cols[2]->append_datum(Datum((int32_t)(key)));
+        }
+        CHECK_OK(writer->flush_chunk(*chunk));
+        return *writer->build();
+    }
+
+    StatusOr<RowsetSharedPtr> create_rowset_column_with_row(const TabletSharedPtr& tablet, const vector<int64_t>& keys,
+                                                            bool large_var_column = false) {
+        RowsetWriterContext writer_context;
+        RowsetId rowset_id = StorageEngine::instance()->next_rowset_id();
+        writer_context.rowset_id = rowset_id;
+        writer_context.tablet_id = tablet->tablet_id();
+        writer_context.tablet_schema_hash = tablet->schema_hash();
+        writer_context.partition_id = 0;
+        writer_context.rowset_path_prefix = tablet->schema_hash_path();
+        writer_context.rowset_state = COMMITTED;
+        writer_context.tablet_schema = tablet->thread_safe_get_tablet_schema();
+        writer_context.version.first = 0;
+        writer_context.version.second = 0;
+        writer_context.segments_overlap = NONOVERLAPPING;
+        std::unique_ptr<RowsetWriter> writer;
+        EXPECT_TRUE(RowsetFactory::create_rowset_writer(writer_context, &writer).ok());
+        auto schema = ChunkHelper::convert_schema(tablet->thread_safe_get_tablet_schema());
+        const auto nkeys = keys.size();
+        const auto& column = tablet->thread_safe_get_tablet_schema()->columns().back();
+        std::vector<ColumnId> cids(tablet->thread_safe_get_tablet_schema()->num_columns() - 1);
+        if (column.name() == Schema::FULL_ROW_COLUMN) {
+            for (int i = 0; i < tablet->thread_safe_get_tablet_schema()->num_columns() - 1; i++) {
+                cids[i] = i;
+            }
+        }
+        auto schema_without_full_row_column = std::make_unique<Schema>(&schema, cids);
+        auto chunk = ChunkHelper::new_chunk(*schema_without_full_row_column, nkeys);
+        string varchar_value;
+        if (large_var_column) {
+            varchar_value = std::string(1024 * 1024, 'a');
+        } else {
+            varchar_value = std::string(1024, 'a');
+        }
+        auto& cols = chunk->columns();
+        for (int64_t key : keys) {
+            cols[0]->append_datum(Datum(key));
+            cols[1]->append_datum(Datum((int16_t)(nkeys - 1 - key)));
+            cols[2]->append_datum(Datum(Slice(varchar_value)));
+        }
+        RETURN_IF_ERROR(writer->flush_chunk(*chunk));
+        return *writer->build();
+    }
+
+    RowsetSharedPtr create_rowset_sort_key_error_encode_case(const TabletSharedPtr& tablet,
+                                                             const vector<int64_t>& keys) {
+        RowsetWriterContext writer_context;
+        RowsetId rowset_id = StorageEngine::instance()->next_rowset_id();
+        writer_context.rowset_id = rowset_id;
+        writer_context.tablet_id = tablet->tablet_id();
+        writer_context.tablet_schema_hash = tablet->schema_hash();
+        writer_context.partition_id = 0;
+        writer_context.rowset_path_prefix = tablet->schema_hash_path();
+        writer_context.rowset_state = COMMITTED;
+        writer_context.tablet_schema = tablet->thread_safe_get_tablet_schema();
+        writer_context.version.first = 0;
+        writer_context.version.second = 0;
+        writer_context.segments_overlap = NONOVERLAPPING;
+        std::unique_ptr<RowsetWriter> writer;
+        EXPECT_TRUE(RowsetFactory::create_rowset_writer(writer_context, &writer).ok());
+        auto schema = ChunkHelper::convert_schema(tablet->thread_safe_get_tablet_schema());
+        const auto nkeys = keys.size();
+        auto chunk = ChunkHelper::new_chunk(schema, nkeys);
+        auto& cols = chunk->columns();
+        for (auto i = 0; i < nkeys; ++i) {
+            cols[0]->append_datum(Datum(keys[i]));
+            cols[1]->append_datum(Datum((int16_t)1));
+            cols[2]->append_datum(Datum((int32_t)(keys[nkeys - 1 - i])));
+        }
+        CHECK_OK(writer->flush_chunk(*chunk));
+        return *writer->build();
+    }
+
+    RowsetSharedPtr create_nullable_sort_key_rowset(const TabletSharedPtr& tablet,
+                                                    const vector<vector<int64_t>>& all_cols) {
+        RowsetWriterContext writer_context;
+        RowsetId rowset_id = StorageEngine::instance()->next_rowset_id();
+        writer_context.rowset_id = rowset_id;
+        writer_context.tablet_id = tablet->tablet_id();
+        writer_context.tablet_schema_hash = tablet->schema_hash();
+        writer_context.partition_id = 0;
+        writer_context.rowset_path_prefix = tablet->schema_hash_path();
+        writer_context.rowset_state = COMMITTED;
+        writer_context.tablet_schema = tablet->thread_safe_get_tablet_schema();
+        writer_context.version.first = 0;
+        writer_context.version.second = 0;
+        writer_context.segments_overlap = NONOVERLAPPING;
+        std::unique_ptr<RowsetWriter> writer;
+        EXPECT_TRUE(RowsetFactory::create_rowset_writer(writer_context, &writer).ok());
+        auto schema = ChunkHelper::convert_schema(tablet->thread_safe_get_tablet_schema());
+        const auto keys_size = all_cols[0].size();
+        auto chunk = ChunkHelper::new_chunk(schema, keys_size);
+        auto& cols = chunk->columns();
+        for (auto i = 0; i < keys_size; ++i) {
+            append_datum_func(cols[0], static_cast<int64_t>(all_cols[0][i]));
+            append_datum_func(cols[1], static_cast<int16_t>(all_cols[1][i]));
+            append_datum_func(cols[2], static_cast<int32_t>(all_cols[2][i]));
+        }
+
+        CHECK_OK(writer->flush_chunk(*chunk));
+        return *writer->build();
+    }
+
+    TabletSharedPtr create_tablet(int64_t tablet_id, int32_t schema_hash, bool multi_column_pk = false) {
+        TCreateTabletReq request;
+        request.tablet_id = tablet_id;
+        request.__set_version(1);
+        request.__set_version_hash(0);
+        request.tablet_schema.schema_hash = schema_hash;
+        request.tablet_schema.short_key_column_count = 1;
+        request.tablet_schema.keys_type = TKeysType::PRIMARY_KEYS;
+        request.tablet_schema.storage_type = TStorageType::COLUMN;
+
+        if (multi_column_pk) {
+            TColumn pk1;
+            pk1.column_name = "pk1_bigint";
+            pk1.__set_is_key(true);
+            pk1.column_type.type = TPrimitiveType::BIGINT;
+            request.tablet_schema.columns.push_back(pk1);
+            TColumn pk2;
+            pk2.column_name = "pk2_varchar";
+            pk2.__set_is_key(true);
+            pk2.column_type.type = TPrimitiveType::VARCHAR;
+            pk2.column_type.len = 128;
+            request.tablet_schema.columns.push_back(pk2);
+            TColumn pk3;
+            pk3.column_name = "pk3_int";
+            pk3.__set_is_key(true);
+            pk3.column_type.type = TPrimitiveType::INT;
+            request.tablet_schema.columns.push_back(pk3);
+        } else {
+            TColumn k1;
+            k1.column_name = "pk";
+            k1.__set_is_key(true);
+            k1.column_type.type = TPrimitiveType::BIGINT;
+            request.tablet_schema.columns.push_back(k1);
+        }
+
+        TColumn k2;
+        k2.column_name = "v1";
+        k2.__set_is_key(false);
+        k2.column_type.type = TPrimitiveType::SMALLINT;
+        request.tablet_schema.columns.push_back(k2);
+
+        TColumn k3;
+        k3.column_name = "v2";
+        k3.__set_is_key(false);
+        k3.column_type.type = TPrimitiveType::INT;
+        request.tablet_schema.columns.push_back(k3);
+        auto st = StorageEngine::instance()->create_tablet(request);
+        CHECK(st.ok()) << st.to_string();
+        return StorageEngine::instance()->tablet_manager()->get_tablet(tablet_id, false);
+    }
+
+    TabletSharedPtr create_tablet_with_sort_key(int64_t tablet_id, int32_t schema_hash,
+                                                std::vector<int32_t> sort_key_idxes) {
+        TCreateTabletReq request;
+        request.tablet_id = tablet_id;
+        request.__set_version(1);
+        request.tablet_schema.schema_hash = schema_hash;
+        request.tablet_schema.short_key_column_count = 1;
+        request.tablet_schema.keys_type = TKeysType::PRIMARY_KEYS;
+        request.tablet_schema.storage_type = TStorageType::COLUMN;
+        request.tablet_schema.sort_key_idxes = sort_key_idxes;
+
+        TColumn k1;
+        k1.column_name = "pk";
+        k1.__set_is_key(true);
+        k1.column_type.type = TPrimitiveType::BIGINT;
+        request.tablet_schema.columns.push_back(k1);
+
+        TColumn k2;
+        k2.column_name = "v1";
+        k2.__set_is_key(false);
+        k2.column_type.type = TPrimitiveType::SMALLINT;
+        request.tablet_schema.columns.push_back(k2);
+
+        TColumn k3;
+        k3.column_name = "v2";
+        k3.__set_is_key(false);
+        k3.column_type.type = TPrimitiveType::INT;
+        request.tablet_schema.columns.push_back(k3);
+        auto st = StorageEngine::instance()->create_tablet(request);
+        CHECK(st.ok()) << st.to_string();
+        return StorageEngine::instance()->tablet_manager()->get_tablet(tablet_id, false);
+    }
+
+    TabletSharedPtr create_tablet_with_nullable_sort_key(int64_t tablet_id, int32_t schema_hash,
+                                                         std::vector<int32_t> sort_key_idxes) {
+        TCreateTabletReq request;
+        request.tablet_id = tablet_id;
+        request.__set_version(1);
+        request.tablet_schema.schema_hash = schema_hash;
+        request.tablet_schema.short_key_column_count = 1;
+        request.tablet_schema.keys_type = TKeysType::PRIMARY_KEYS;
+        request.tablet_schema.storage_type = TStorageType::COLUMN;
+        request.tablet_schema.sort_key_idxes = sort_key_idxes;
+
+        TColumn k1;
+        k1.column_name = "pk";
+        k1.__set_is_key(true);
+        k1.column_type.type = TPrimitiveType::BIGINT;
+        request.tablet_schema.columns.push_back(k1);
+
+        TColumn k2;
+        k2.column_name = "v1";
+        k2.__set_is_key(false);
+        k2.__set_is_allow_null(true);
+        k2.column_type.type = TPrimitiveType::SMALLINT;
+        request.tablet_schema.columns.push_back(k2);
+
+        TColumn k3;
+        k3.column_name = "v2";
+        k3.__set_is_key(false);
+        k3.__set_is_allow_null(true);
+        k3.column_type.type = TPrimitiveType::INT;
+        request.tablet_schema.columns.push_back(k3);
+        auto st = StorageEngine::instance()->create_tablet(request);
+        CHECK(st.ok()) << st.to_string();
+        return StorageEngine::instance()->tablet_manager()->get_tablet(tablet_id, false);
+    }
+
+    TabletSharedPtr create_tablet_column_with_row(int64_t tablet_id, int32_t schema_hash,
+                                                  bool multi_column_pk = false) {
+        TCreateTabletReq request;
+        request.tablet_id = tablet_id;
+        request.__set_version(1);
+        request.__set_version_hash(0);
+        request.tablet_schema.schema_hash = schema_hash;
+        request.tablet_schema.short_key_column_count = 1;
+        request.tablet_schema.keys_type = TKeysType::PRIMARY_KEYS;
+        request.tablet_schema.storage_type = TStorageType::COLUMN;
+
+        if (multi_column_pk) {
+            TColumn pk1;
+            pk1.column_name = "pk1_bigint";
+            pk1.__set_is_key(true);
+            pk1.column_type.type = TPrimitiveType::BIGINT;
+            request.tablet_schema.columns.push_back(pk1);
+            TColumn pk2;
+            pk2.column_name = "pk2_varchar";
+            pk2.__set_is_key(true);
+            pk2.column_type.type = TPrimitiveType::VARCHAR;
+            pk2.column_type.len = 128;
+            request.tablet_schema.columns.push_back(pk2);
+            TColumn pk3;
+            pk3.column_name = "pk3_int";
+            pk3.__set_is_key(true);
+            pk3.column_type.type = TPrimitiveType::INT;
+            request.tablet_schema.columns.push_back(pk3);
+        } else {
+            TColumn k1;
+            k1.column_name = "pk";
+            k1.__set_is_key(true);
+            k1.column_type.type = TPrimitiveType::BIGINT;
+            request.tablet_schema.columns.push_back(k1);
+        }
+
+        TColumn k2;
+        k2.column_name = "v1";
+        k2.__set_is_key(false);
+        k2.column_type.type = TPrimitiveType::SMALLINT;
+        request.tablet_schema.columns.push_back(k2);
+
+        TColumn k3;
+        k3.column_name = "v2";
+        k3.__set_is_key(false);
+        k3.column_type.type = TPrimitiveType::VARCHAR;
+        k3.column_type.len = TypeDescriptor::MAX_VARCHAR_LENGTH;
+        request.tablet_schema.columns.push_back(k3);
+
+        TColumn row;
+        row.column_name = Schema::FULL_ROW_COLUMN;
+        TColumnType ctype;
+        ctype.__set_type(TPrimitiveType::VARCHAR);
+        ctype.__set_len(TypeDescriptor::MAX_VARCHAR_LENGTH);
+        row.__set_column_type(ctype);
+        row.__set_aggregation_type(TAggregationType::REPLACE);
+        row.__set_is_allow_null(false);
+        row.__set_default_value("");
+        request.tablet_schema.columns.push_back(row);
+
+        auto st = StorageEngine::instance()->create_tablet(request);
+        CHECK(st.ok()) << st.to_string();
+        return StorageEngine::instance()->tablet_manager()->get_tablet(tablet_id, false);
+    }
+
+    TabletSharedPtr create_tablet2(int64_t tablet_id, int32_t schema_hash) {
+        TCreateTabletReq request;
+        request.tablet_id = tablet_id;
+        request.__set_version(1);
+        request.__set_version_hash(0);
+        request.tablet_schema.schema_hash = schema_hash;
+        request.tablet_schema.short_key_column_count = 1;
+        request.tablet_schema.keys_type = TKeysType::PRIMARY_KEYS;
+        request.tablet_schema.storage_type = TStorageType::COLUMN;
+
+        TColumn k1;
+        k1.column_name = "pk";
+        k1.__set_is_key(true);
+        k1.column_type.type = TPrimitiveType::BIGINT;
+        request.tablet_schema.columns.push_back(k1);
+
+        TColumn k2;
+        k2.column_name = "v1";
+        k2.__set_is_key(false);
+        k2.column_type.type = TPrimitiveType::SMALLINT;
+        request.tablet_schema.columns.push_back(k2);
+
+        TColumn k3;
+        k3.column_name = "v2";
+        k3.__set_is_key(false);
+        k3.column_type.type = TPrimitiveType::INT;
+        request.tablet_schema.columns.push_back(k3);
+
+        TColumn k4;
+        k4.column_name = "v3";
+        k4.__set_is_key(false);
+        k4.column_type.type = TPrimitiveType::INT;
+        k4.__set_default_value("1");
+        request.tablet_schema.columns.push_back(k4);
+        auto st = StorageEngine::instance()->create_tablet(request);
+        CHECK(st.ok()) << st.to_string();
+        return StorageEngine::instance()->tablet_manager()->get_tablet(tablet_id, false);
+    }
+
+    TabletSharedPtr create_tablet_to_schema_change(int64_t tablet_id, int32_t schema_hash) {
+        TCreateTabletReq request;
+        request.tablet_id = tablet_id;
+        request.__set_version(1);
+        request.__set_version_hash(0);
+        request.tablet_schema.schema_hash = schema_hash;
+        request.tablet_schema.short_key_column_count = 1;
+        request.tablet_schema.keys_type = TKeysType::PRIMARY_KEYS;
+        request.tablet_schema.storage_type = TStorageType::COLUMN;
+
+        TColumn k1;
+        k1.column_name = "pk";
+        k1.__set_is_key(true);
+        k1.column_type.type = TPrimitiveType::BIGINT;
+        request.tablet_schema.columns.push_back(k1);
+
+        TColumn k2;
+        k2.column_name = "v1";
+        k2.__set_is_key(false);
+        k2.column_type.type = TPrimitiveType::SMALLINT;
+        request.tablet_schema.columns.push_back(k2);
+
+        TColumn k3;
+        k3.column_name = "v2";
+        k3.__set_is_key(false);
+        k3.column_type.type = TPrimitiveType::VARCHAR;
+        k3.column_type.len = 128;
+        request.tablet_schema.columns.push_back(k3);
+
+        auto st = StorageEngine::instance()->create_tablet(request);
+        CHECK(st.ok()) << st.to_string();
+        return StorageEngine::instance()->tablet_manager()->get_tablet(tablet_id, false);
+    }
+
+    TabletSharedPtr create_tablet_to_add_generated_column(int64_t tablet_id, int32_t schema_hash) {
+        TCreateTabletReq request;
+        request.tablet_id = tablet_id;
+        request.__set_version(1);
+        request.__set_version_hash(0);
+        request.tablet_schema.schema_hash = schema_hash;
+        request.tablet_schema.short_key_column_count = 1;
+        request.tablet_schema.keys_type = TKeysType::PRIMARY_KEYS;
+        request.tablet_schema.storage_type = TStorageType::COLUMN;
+
+        TColumn k1;
+        k1.column_name = "pk";
+        k1.__set_is_key(true);
+        k1.column_type.type = TPrimitiveType::BIGINT;
+        request.tablet_schema.columns.push_back(k1);
+
+        TColumn k2;
+        k2.column_name = "v1";
+        k2.__set_is_key(false);
+        k2.column_type.type = TPrimitiveType::SMALLINT;
+        request.tablet_schema.columns.push_back(k2);
+
+        TColumn k3;
+        k3.column_name = "v2";
+        k3.__set_is_key(false);
+        k3.column_type.type = TPrimitiveType::INT;
+        request.tablet_schema.columns.push_back(k3);
+
+        TColumn k4;
+        k4.column_name = "newcol";
+        k4.__set_is_key(false);
+        k4.__set_is_allow_null(true);
+        k4.column_type.type = TPrimitiveType::BIGINT;
+        request.tablet_schema.columns.push_back(k4);
+        auto st = StorageEngine::instance()->create_tablet(request);
+        CHECK(st.ok()) << st.to_string();
+        return StorageEngine::instance()->tablet_manager()->get_tablet(tablet_id, false);
+    }
+
+    void SetUp() override {
+        _compaction_mem_tracker = std::make_unique<MemTracker>(-1);
+        config::enable_pk_size_tiered_compaction_strategy = false;
+    }
+
+    void TearDown() override {
+        if (_tablet2) {
+            (void)StorageEngine::instance()->tablet_manager()->drop_tablet(_tablet2->tablet_id());
+            _tablet2.reset();
+        }
+        if (_tablet) {
+            (void)StorageEngine::instance()->tablet_manager()->drop_tablet(_tablet->tablet_id());
+            _tablet.reset();
+        }
+        config::enable_pk_size_tiered_compaction_strategy = true;
+    }
+
+    static Status full_clone(const TabletSharedPtr& source_tablet, int clone_version,
+                             const TabletSharedPtr& dest_tablet) {
+        auto snapshot_dir = SnapshotManager::instance()->snapshot_full(source_tablet, clone_version, 3600);
+        CHECK(snapshot_dir.ok()) << snapshot_dir.status();
+
+        DeferOp defer1([&]() { (void)fs::remove_all(*snapshot_dir); });
+
+        auto meta_dir = SnapshotManager::instance()->get_schema_hash_full_path(source_tablet, *snapshot_dir);
+        auto snapshot_meta = SnapshotManager::instance()->parse_snapshot_meta(meta_dir + "/meta");
+        CHECK(snapshot_meta.ok()) << snapshot_meta.status();
+
+        RETURN_IF_ERROR(SnapshotManager::instance()->assign_new_rowset_id(&(*snapshot_meta), meta_dir));
+
+        std::set<std::string> files;
+        auto st = fs::list_dirs_files(meta_dir, nullptr, &files);
+        CHECK(st.ok()) << st;
+        files.erase("meta");
+
+        for (const auto& f : files) {
+            std::string src = meta_dir + "/" + f;
+            std::string dst = dest_tablet->schema_hash_path() + "/" + f;
+            st = FileSystem::Default()->link_file(src, dst);
+            if (st.ok()) {
+                LOG(INFO) << "Linked " << src << " to " << dst;
+            } else if (st.is_already_exist()) {
+                LOG(INFO) << dst << " already exist";
+            } else {
+                return st;
+            }
+        }
+        // Pretend that source_tablet is a peer replica of dest_tablet
+        snapshot_meta->tablet_meta().set_tablet_id(dest_tablet->tablet_id());
+        snapshot_meta->tablet_meta().set_schema_hash(dest_tablet->schema_hash());
+        for (auto& rm : snapshot_meta->rowset_metas()) {
+            rm.set_tablet_id(dest_tablet->tablet_id());
+        }
+
+        st = dest_tablet->updates()->load_snapshot(*snapshot_meta);
+        dest_tablet->updates()->remove_expired_versions(time(nullptr));
+        return st;
+    }
+
+    static StatusOr<TabletSharedPtr> clone_a_new_replica(const TabletSharedPtr& source_tablet, int64_t new_tablet_id) {
+        auto clone_version = source_tablet->max_version().second;
+        auto snapshot_dir = SnapshotManager::instance()->snapshot_full(source_tablet, clone_version, 3600);
+        CHECK(snapshot_dir.ok()) << snapshot_dir.status();
+
+        DeferOp defer1([&]() { (void)fs::remove_all(*snapshot_dir); });
+
+        auto meta_dir = SnapshotManager::instance()->get_schema_hash_full_path(source_tablet, *snapshot_dir);
+        auto meta_file = meta_dir + "/meta";
+        auto snapshot_meta = SnapshotManager::instance()->parse_snapshot_meta(meta_file);
+        CHECK(snapshot_meta.ok()) << snapshot_meta.status();
+
+        // Assign a new tablet_id and overwrite the meta file.
+        snapshot_meta->tablet_meta().set_tablet_id(new_tablet_id);
+        CHECK(snapshot_meta->serialize_to_file(meta_file).ok());
+
+        RETURN_IF_ERROR(SnapshotManager::instance()->assign_new_rowset_id(&(*snapshot_meta), meta_dir));
+
+        auto store = source_tablet->data_dir();
+        auto new_schema_hash = source_tablet->schema_hash();
+        std::string new_tablet_path = store->path() + DATA_PREFIX;
+        new_tablet_path = path_util::join_path_segments(new_tablet_path, std::to_string(source_tablet->shard_id()));
+        new_tablet_path = path_util::join_path_segments(new_tablet_path, std::to_string(new_tablet_id));
+        new_tablet_path = path_util::join_path_segments(new_tablet_path, std::to_string(new_schema_hash));
+        CHECK(std::filesystem::create_directories(new_tablet_path));
+
+        std::set<std::string> files;
+        CHECK(fs::list_dirs_files(meta_dir, nullptr, &files).ok());
+        for (const auto& f : files) {
+            std::string src = meta_dir + "/" + f;
+            std::string dst = new_tablet_path + "/" + f;
+            Status st = FileSystem::Default()->link_file(src, dst);
+            if (st.ok()) {
+                LOG(INFO) << "Linked " << src << " to " << dst;
+            } else if (st.is_already_exist()) {
+                LOG(INFO) << dst << " already exist";
+            } else {
+                return st;
+            }
+        }
+
+        auto tablet_manager = StorageEngine::instance()->tablet_manager();
+        auto st = tablet_manager->create_tablet_from_meta_snapshot(store, new_tablet_id, new_schema_hash,
+                                                                   new_tablet_path);
+        CHECK(st.ok()) << st;
+        return tablet_manager->get_tablet(new_tablet_id, false);
+    }
+
+    void test_writeread(bool enable_persistent_index);
+    void test_writeread_with_delete(bool enable_persistent_index);
+    void test_noncontinous_commit(bool enable_persistent_index);
+    void test_noncontinous_meta_save_load(bool enable_persistent_index);
+    void test_save_meta(bool enable_persistent_index);
+    void test_load_from_pb(bool enable_persistent_index);
+    void test_remove_expired_versions(bool enable_persistent_index);
+    void test_apply(bool enable_persistent_index, bool has_merge_condition);
+    void test_condition_update_apply(bool enable_persistent_index);
+    void test_concurrent_write_read_and_gc(bool enable_persistent_index);
+    void test_compaction_score_not_enough(bool enable_persistent_index);
+    void test_compaction_score_enough_duplicate(bool enable_persistent_index);
+    void test_compaction_score_enough_normal(bool enable_persistent_index);
+    void test_horizontal_compaction(bool enable_persistent_index);
+    void test_vertical_compaction(bool enable_persistent_index);
+    void test_compaction_with_empty_rowset(bool enable_persistent_index, bool vertical, bool multi_column_pk);
+    void test_link_from(bool enable_persistent_index);
+    void test_convert_from(bool enable_persistent_index);
+    void test_convert_from_with_pending(bool enable_persistent_index);
+    void test_convert_from_with_mutiple_segment(bool enable_persistent_index);
+    void test_reorder_from(bool enable_persistent_index);
+    void test_load_snapshot_incremental(bool enable_persistent_index);
+    void test_load_snapshot_incremental_ignore_already_committed_version(bool enable_persistent_index);
+    void test_load_snapshot_incremental_mismatched_tablet_id(bool enable_persistent_index);
+    void test_load_snapshot_incremental_data_file_not_exist(bool enable_persistent_index);
+    void test_load_snapshot_incremental_incorrect_version(bool enable_persistent_index);
+    void test_load_snapshot_incremental_with_partial_rowset_old(bool enable_persistent_index);
+    void test_load_snapshot_incremental_with_partial_rowset_new(bool enable_persistent_index,
+                                                                PartialUpdateCloneCase update_case);
+    void test_load_snapshot_primary(int64_t num_version, const std::vector<uint64_t>& holes);
+    void test_load_snapshot_primary(int64_t max_version, const std::vector<uint64_t>& holes,
+                                    bool enable_persistent_index);
+    void test_load_snapshot_full(bool enable_persistent_index);
+    void test_load_snapshot_full_file_not_exist(bool enable_persistent_index);
+    void test_load_snapshot_full_mismatched_tablet_id(bool enable_persistent_index);
+    void test_issue_4193(bool enable_persistent_index);
+    void test_issue_4181(bool enable_persistent_index);
+    void test_snapshot_with_empty_rowset(bool enable_persistent_index);
+    void test_get_column_values(bool enable_persistent_index);
+    void test_get_missing_version_ranges(const std::vector<int64_t>& versions,
+                                         const std::vector<int64_t>& expected_missing_ranges);
+    void test_get_rowsets_for_incremental_snapshot(const std::vector<int64_t>& versions,
+                                                   const std::vector<int64_t>& missing_ranges,
+                                                   const std::vector<int64_t>& expect_rowset_versions, bool gc,
+                                                   bool expect_error);
+
+    void tablets_prepare(const TabletSharedPtr& tablet0, const TabletSharedPtr& tablet1,
+                         std::vector<int32_t>& column_indexes, const std::shared_ptr<TabletSchema>& partial_schema);
+    void snapshot_prepare(const TabletSharedPtr& tablet, const std::vector<int64_t>& delta_versions,
+                          std::string* snapshot_id_path, std::string* snapshot_dir,
+                          std::vector<RowsetSharedPtr>* snapshot_rowsets,
+                          std::vector<RowsetMetaSharedPtr>* snapshot_rowset_metas,
+                          const TabletMetaSharedPtr& snapshot_tablet_meta);
+    void load_snapshot(const std::string& meta_dir, const TabletSharedPtr& tablet, SegmentFooterPB* footer);
+    void test_schema_change_optimiazation_adding_generated_column(bool enable_persistent_index);
+    void test_pk_dump(size_t rowset_cnt);
+    void update_and_recover(bool enable_persistent_index);
+
+protected:
+    TabletSharedPtr _tablet;
+    TabletSharedPtr _tablet2;
+    std::unique_ptr<MemTracker> _compaction_mem_tracker;
+};
+
+ssize_t read_tablet_and_compare_schema_changed(const TabletSharedPtr& tablet, int64_t version,
+                                               const vector<int64_t>& keys);
+
+ssize_t read_tablet(const TabletSharedPtr& tablet, int64_t version);
+
+ssize_t read_tablet_and_compare(const TabletSharedPtr& tablet, int64_t version, const vector<int64_t>& keys);
+
+ssize_t read_tablet_and_compare_schema_changed_sort_key1(const TabletSharedPtr& tablet, int64_t version,
+                                                         const vector<int64_t>& keys);
+
+ssize_t read_tablet_and_compare_schema_changed_sort_key2(const TabletSharedPtr& tablet, int64_t version,
+                                                         const vector<int64_t>& keys);
+
+} // namespace starrocks


### PR DESCRIPTION
This PR supports size-tiered compaction for primary key table to reduce the IO amplification of compaction

1. Add config enable_pk_size_tiered_compaction_strategy to control new policy.
2. When pick rowsets to do compaction, we separate rowsets into different rowset levels by data size. And merge the rowsets in the same level to reduce IO amplification.

Test Steps:

1. The total data size is 2GB.
2. set update_compaction_internal_second as 30.
3. Import a rowset of 1/2000 size every 1 second, continuously importing 2000 versions until all data are ingested.
4. update a rowset of 1/2000 size every 1 second, continuously importing 2000 versions until all data are updated.
5. Calculate the total write volume of compaction.

* Without Size Tiered Compaction Policy

  | Ingestion size | total data write size |  Write amplification | total pindex read size | peak rowset num 
-- | -- | -- | -- | -- | --
2G + insert + 1/1000 | 747278172 | 8919009198.08 |11.9 | 2701060739 | 38 
2G + upsert + 1/1000 | 747278172 | 13466337280.0 |18.0 | 6428381124 | 37

* With Size Tiered Compaction Policy

  | Ingestion size | total data write size |  Write amplification | total pindex read size | peak rowset num 
-- | -- | -- | -- | -- | --
2G + insert + 1/1000 | 747278172 | 2898861752.32 |3.8 | 1617695405 | 41 
2G + upsert + 1/1000 | 747278172 | 4657376133.12 |6.2 | 3456960053 | 41

## Why I'm doing:

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [x] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [x] This is a backport pr

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5

