### PR TITLE
[Feature] support to read iceberg equality delete file with parquet format (backport #41267)

### DIFF
--- a/be/src/connector/connector.h
+++ b/be/src/connector/connector.h
@@ -81,7 +81,7 @@ protected:
     const RuntimeFilterProbeCollector* _runtime_filters = nullptr;
     RuntimeProfile* _runtime_profile = nullptr;
     TupleDescriptor* _tuple_desc = nullptr;
-    void _init_chunk(ChunkPtr* chunk, size_t n) { *chunk = ChunkHelper::new_chunk(*_tuple_desc, n); }
+    virtual void _init_chunk(ChunkPtr* chunk, size_t n) { *chunk = ChunkHelper::new_chunk(*_tuple_desc, n); }
 };
 
 class StreamDataSource : public DataSource {

--- a/be/src/connector/hive_connector.cpp
+++ b/be/src/connector/hive_connector.cpp
@@ -727,7 +727,7 @@ void HiveDataSource::_init_chunk(ChunkPtr* chunk, size_t n) {
         }
 
         for (const auto& slot : _equality_delete_slots) {
-            if (!id_to_slots.contains(slot->id())) {
+            if (id_to_slots.count(slot->id()) != 0) {
                 const auto column = ColumnHelper::create_column(slot->type(), slot->is_nullable());
                 column->reserve(n);
                 (*chunk)->append_column(column, slot->id());

--- a/be/src/connector/hive_connector.cpp
+++ b/be/src/connector/hive_connector.cpp
@@ -727,7 +727,7 @@ void HiveDataSource::_init_chunk(ChunkPtr* chunk, size_t n) {
         }
 
         for (const auto& slot : _equality_delete_slots) {
-            if (id_to_slots.count(slot->id()) != 0) {
+            if (id_to_slots.count(slot->id()) == 0) {
                 const auto column = ColumnHelper::create_column(slot->type(), slot->is_nullable());
                 column->reserve(n);
                 (*chunk)->append_column(column, slot->id());

--- a/be/src/connector/hive_connector.cpp
+++ b/be/src/connector/hive_connector.cpp
@@ -237,11 +237,9 @@ void HiveDataSource::_init_tuples_and_slots(RuntimeState* state) {
         }
 
         int32_t delete_column_index = slots.size();
-        auto* delete_column_tuple_desc =
-                state->desc_tbl().get_tuple_descriptor(_provider->_hdfs_scan_node.mor_tuple_id);
+        _delete_column_tuple_desc = state->desc_tbl().get_tuple_descriptor(_provider->_hdfs_scan_node.mor_tuple_id);
 
-        std::vector<SlotDescriptor*> equality_delete_slots;
-        for (SlotDescriptor* d_slot_desc : delete_column_tuple_desc->slots()) {
+        for (SlotDescriptor* d_slot_desc : _delete_column_tuple_desc->slots()) {
             _equality_delete_slots.emplace_back(d_slot_desc);
             if (id_to_slots.find(d_slot_desc->id()) == id_to_slots.end()) {
                 _materialize_slots.push_back(d_slot_desc);
@@ -622,6 +620,7 @@ Status HiveDataSource::_init_scanner(RuntimeState* state) {
         MORParams& mor_params = scanner_params.mor_params;
         mor_params.tuple_desc = _tuple_desc;
         mor_params.equality_slots = _equality_delete_slots;
+        mor_params.delete_column_tuple_desc = _delete_column_tuple_desc;
         mor_params.mor_tuple_id = _provider->_hdfs_scan_node.mor_tuple_id;
         mor_params.runtime_profile = _runtime_profile;
     }
@@ -632,6 +631,7 @@ Status HiveDataSource::_init_scanner(RuntimeState* state) {
     if (dynamic_cast<const IcebergTableDescriptor*>(_hive_table)) {
         auto tbl = dynamic_cast<const IcebergTableDescriptor*>(_hive_table);
         scanner_params.iceberg_schema = tbl->get_iceberg_schema();
+        scanner_params.iceberg_equal_delete_schema = tbl->get_iceberg_equal_delete_schema();
     }
     scanner_params.use_block_cache = _use_block_cache;
     scanner_params.enable_populate_block_cache = _enable_populate_block_cache;
@@ -715,6 +715,25 @@ Status HiveDataSource::get_next(RuntimeState* state, ChunkPtr* chunk) {
     ChunkHelper::reorder_chunk(*_tuple_desc, chunk->get());
 
     return Status::OK();
+}
+
+void HiveDataSource::_init_chunk(ChunkPtr* chunk, size_t n) {
+    *chunk = ChunkHelper::new_chunk(*_tuple_desc, n);
+
+    if (!_equality_delete_slots.empty()) {
+        std::map<SlotId, SlotDescriptor*> id_to_slots;
+        for (const auto& slot : _tuple_desc->slots()) {
+            id_to_slots.emplace(slot->id(), slot);
+        }
+
+        for (const auto& slot : _equality_delete_slots) {
+            if (!id_to_slots.contains(slot->id())) {
+                const auto column = ColumnHelper::create_column(slot->type(), slot->is_nullable());
+                column->reserve(n);
+                (*chunk)->append_column(column, slot->id());
+            }
+        }
+    }
 }
 
 const std::string HiveDataSource::get_custom_coredump_msg() const {

--- a/be/src/connector/hive_connector.h
+++ b/be/src/connector/hive_connector.h
@@ -65,6 +65,8 @@ public:
     int64_t io_time_spent() const override;
     int64_t estimated_mem_usage() const override;
 
+    void _init_chunk(ChunkPtr* chunk, size_t n) override;
+
 private:
     const HiveDataSourceProvider* _provider;
     const THdfsScanRange _scan_range;
@@ -124,6 +126,9 @@ private:
 
     // iceberg equality delete column slots.
     std::vector<SlotDescriptor*> _equality_delete_slots;
+
+    // iceberg equality delete column tuple desc.
+    TupleDescriptor* _delete_column_tuple_desc;
 
     // partition column index in `tuple_desc`
     std::vector<int> _partition_index_in_chunk;

--- a/be/src/exec/hdfs_scanner.h
+++ b/be/src/exec/hdfs_scanner.h
@@ -176,6 +176,8 @@ struct HdfsScannerParams {
 
     const TIcebergSchema* iceberg_schema = nullptr;
 
+    const TIcebergSchema* iceberg_equal_delete_schema = nullptr;
+
     bool is_lazy_materialization_slot(SlotId slot_id) const;
 
     bool use_block_cache = false;

--- a/be/src/exec/hdfs_scanner_parquet.cpp
+++ b/be/src/exec/hdfs_scanner_parquet.cpp
@@ -31,7 +31,10 @@ Status HdfsParquetScanner::do_init(RuntimeState* runtime_state, const HdfsScanne
                 new IcebergDeleteBuilder(scanner_params.fs, scanner_params.path, scanner_params.conjunct_ctxs,
                                          scanner_params.materialize_slots, &_need_skip_rowids));
         for (const auto& tdelete_file : scanner_params.deletes) {
-            RETURN_IF_ERROR(iceberg_delete_builder->build_parquet(runtime_state->timezone(), *tdelete_file));
+            RETURN_IF_ERROR(iceberg_delete_builder->build_parquet(
+                    runtime_state->timezone(), *tdelete_file, scanner_params.mor_params.equality_slots,
+                    scanner_params.mor_params.delete_column_tuple_desc, scanner_params.iceberg_equal_delete_schema,
+                    runtime_state, _mor_processor));
         }
         _app_stats.iceberg_delete_files_per_scan += scanner_params.deletes.size();
     }

--- a/be/src/exec/iceberg/iceberg_delete_builder.cpp
+++ b/be/src/exec/iceberg/iceberg_delete_builder.cpp
@@ -223,7 +223,7 @@ Status ParquetEqualityDeleteBuilder::build(const std::string& timezone, const st
     scanner_ctx->tuple_desc = delete_column_tuple_desc;
     scanner_ctx->iceberg_schema = iceberg_equal_delete_schema;
     scanner_ctx->materialized_columns = std::move(columns);
-    scanner_ctx->scan_range = scan_ranges;
+    scanner_ctx->scan_ranges = scan_ranges;
     scanner_ctx->lazy_column_coalesce_counter = new std::atomic<int32_t>(0);
     RETURN_IF_ERROR(reader->init(scanner_ctx.get()));
 

--- a/be/src/exec/iceberg/iceberg_delete_builder.cpp
+++ b/be/src/exec/iceberg/iceberg_delete_builder.cpp
@@ -15,11 +15,14 @@
 #include "exec/iceberg/iceberg_delete_builder.h"
 
 #include "column/vectorized_fwd.h"
+#include "exec/hdfs_scanner.h"
 #include "exec/iceberg/iceberg_delete_file_iterator.h"
 #include "formats/orc/orc_chunk_reader.h"
 #include "formats/orc/orc_input_stream.h"
+#include "formats/parquet/file_reader.h"
 #include "gen_cpp/Types_types.h"
 #include "runtime/descriptors.h"
+#include "storage/chunk_helper.h"
 
 namespace starrocks {
 
@@ -132,7 +135,9 @@ Status ORCPositionDeleteBuilder::build(const std::string& timezone, const std::s
 
 Status ORCEqualityDeleteBuilder::build(const std::string& timezone, const std::string& delete_file_path,
                                        int64_t file_length, const std::shared_ptr<DefaultMORProcessor> mor_processor,
-                                       std::vector<SlotDescriptor*> slot_descs, RuntimeState* state) {
+                                       std::vector<SlotDescriptor*> slot_descs,
+                                       TupleDescriptor* delete_column_tuple_desc,
+                                       const TIcebergSchema* iceberg_equal_delete_schema, RuntimeState* state) {
     std::unique_ptr<RandomAccessFile> file;
     ASSIGN_OR_RETURN(file, _fs->new_random_access_file(delete_file_path));
 
@@ -171,6 +176,62 @@ Status ORCEqualityDeleteBuilder::build(const std::string& timezone, const std::s
 
         ChunkPtr chunk = ret.value();
         RETURN_IF_ERROR(mor_processor->append_chunk_to_hashtable(state, chunk));
+    }
+    return Status::OK();
+}
+
+Status ParquetEqualityDeleteBuilder::build(const std::string& timezone, const std::string& delete_file_path,
+                                           int64_t file_length,
+                                           const std::shared_ptr<DefaultMORProcessor> mor_processor,
+                                           std::vector<SlotDescriptor*> slot_descs,
+                                           TupleDescriptor* delete_column_tuple_desc,
+                                           const TIcebergSchema* iceberg_equal_delete_schema, RuntimeState* state) {
+    std::unique_ptr<RandomAccessFile> file;
+    ASSIGN_OR_RETURN(file, _fs->new_random_access_file(delete_file_path));
+
+    std::unique_ptr<parquet::FileReader> reader;
+    try {
+        reader = std::make_unique<parquet::FileReader>(state->chunk_size(), file.get(), file->get_size().value(), 0);
+    } catch (std::exception& e) {
+        const auto s = strings::Substitute(
+                "ParquetEqualityDeleteBuilder::build create parquet::FileReader failed. reason = $0", e.what());
+        LOG(WARNING) << s;
+        return Status::InternalError(s);
+    }
+
+    auto scanner_ctx = std::make_unique<HdfsScannerContext>();
+    auto scan_stats = std::make_unique<HdfsScanStats>();
+    std::vector<HdfsScannerContext::ColumnInfo> columns;
+    THdfsScanRange scan_range;
+    scan_range.offset = 0;
+    scan_range.length = file_length;
+    for (size_t i = 0; i < slot_descs.size(); i++) {
+        auto* slot = slot_descs[i];
+        HdfsScannerContext::ColumnInfo column;
+        column.slot_desc = slot;
+        column.idx_in_chunk = i;
+        column.decode_needed = true;
+        columns.emplace_back(column);
+    }
+    scanner_ctx->timezone = timezone;
+    scanner_ctx->stats = scan_stats.get();
+    scanner_ctx->tuple_desc = delete_column_tuple_desc;
+    scanner_ctx->iceberg_schema = iceberg_equal_delete_schema;
+    scanner_ctx->materialized_columns = std::move(columns);
+    scanner_ctx->scan_range = &scan_range;
+    scanner_ctx->lazy_column_coalesce_counter = new std::atomic<int32_t>(0);
+    RETURN_IF_ERROR(reader->init(scanner_ctx.get()));
+
+    while (true) {
+        ChunkPtr chunk = ChunkHelper::new_chunk(*delete_column_tuple_desc, state->chunk_size());
+        Status status = reader->get_next(&chunk);
+        if (status.is_end_of_file()) {
+            break;
+        }
+
+        RETURN_IF_ERROR(status);
+        ChunkPtr& result = chunk;
+        RETURN_IF_ERROR(mor_processor->append_chunk_to_hashtable(result));
     }
     return Status::OK();
 }

--- a/be/src/exec/iceberg/iceberg_delete_builder.cpp
+++ b/be/src/exec/iceberg/iceberg_delete_builder.cpp
@@ -191,7 +191,8 @@ Status ParquetEqualityDeleteBuilder::build(const std::string& timezone, const st
 
     std::unique_ptr<parquet::FileReader> reader;
     try {
-        reader = std::make_unique<parquet::FileReader>(state->chunk_size(), file.get(), file->get_size().value(), nullptr, nullptr);
+        reader = std::make_unique<parquet::FileReader>(state->chunk_size(), file.get(), file->get_size().value(),
+                                                       nullptr, nullptr);
     } catch (std::exception& e) {
         const auto s = strings::Substitute(
                 "ParquetEqualityDeleteBuilder::build create parquet::FileReader failed. reason = $0", e.what());

--- a/be/src/exec/iceberg/iceberg_delete_builder.h
+++ b/be/src/exec/iceberg/iceberg_delete_builder.h
@@ -42,6 +42,7 @@ public:
 
     virtual Status build(const std::string& timezone, const std::string& file_path, int64_t file_length,
                          std::shared_ptr<DefaultMORProcessor> mor_processor, std::vector<SlotDescriptor*> slots,
+                         TupleDescriptor* delete_column_tuple_desc, const TIcebergSchema* iceberg_equal_delete_schema,
                          RuntimeState* state) = 0;
 };
 
@@ -53,6 +54,23 @@ public:
 
     Status build(const std::string& timezone, const std::string& file_path, int64_t file_length,
                  std::shared_ptr<DefaultMORProcessor> mor_processor, std::vector<SlotDescriptor*> slots,
+                 TupleDescriptor* delete_column_tuple_desc, const TIcebergSchema* iceberg_equal_delete_schema,
+                 RuntimeState* stage) override;
+
+private:
+    FileSystem* _fs;
+    std::string _datafile_path;
+};
+
+class ParquetEqualityDeleteBuilder : public EqualityDeleteBuilder {
+public:
+    ParquetEqualityDeleteBuilder(FileSystem* fs, std::string datafile_path)
+            : _fs(fs), _datafile_path(std::move(datafile_path)) {}
+    ~ParquetEqualityDeleteBuilder() override = default;
+
+    Status build(const std::string& timezone, const std::string& file_path, int64_t file_length,
+                 std::shared_ptr<DefaultMORProcessor> mor_processor, std::vector<SlotDescriptor*> slots,
+                 TupleDescriptor* delete_column_tuple_desc, const TIcebergSchema* iceberg_equal_delete_schema,
                  RuntimeState* stage) override;
 
 private:
@@ -108,7 +126,7 @@ public:
         } else if (delete_file.file_content == TIcebergFileContent::EQUALITY_DELETES) {
             return ORCEqualityDeleteBuilder(_fs, _datafile_path)
                     .build(timezone, delete_file.full_path, delete_file.length, std::move(mor_processor),
-                           std::move(slots), state);
+                           std::move(slots), nullptr, nullptr, state);
         } else {
             const auto s = strings::Substitute("Unsupported iceberg file content: $0", delete_file.file_content);
             LOG(WARNING) << s;
@@ -116,10 +134,17 @@ public:
         }
     }
 
-    Status build_parquet(const std::string& timezone, const TIcebergDeleteFile& delete_file) {
+    Status build_parquet(const std::string& timezone, const TIcebergDeleteFile& delete_file,
+                         const std::vector<SlotDescriptor*>& slots, TupleDescriptor* delete_column_tuple_desc,
+                         const TIcebergSchema* iceberg_equal_delete_schema, RuntimeState* state,
+                         std::shared_ptr<DefaultMORProcessor> mor_processor) const {
         if (delete_file.file_content == TIcebergFileContent::POSITION_DELETES) {
             return ParquetPositionDeleteBuilder(_fs, _datafile_path)
                     .build(timezone, delete_file.full_path, delete_file.length, _need_skip_rowids);
+        } else if (delete_file.file_content == TIcebergFileContent::EQUALITY_DELETES) {
+            return ParquetEqualityDeleteBuilder(_fs, _datafile_path)
+                    .build(timezone, delete_file.full_path, delete_file.length, std::move(mor_processor),
+                           std::move(slots), delete_column_tuple_desc, iceberg_equal_delete_schema, state);
         } else {
             auto s = strings::Substitute("Unsupported iceberg file content: $0", delete_file.file_content);
             LOG(WARNING) << s;

--- a/be/src/exec/mor_processor.h
+++ b/be/src/exec/mor_processor.h
@@ -25,6 +25,7 @@ namespace starrocks {
 
 struct MORParams {
     TupleDescriptor* tuple_desc = nullptr;
+    TupleDescriptor* delete_column_tuple_desc = nullptr;
     std::vector<SlotDescriptor*> equality_slots;
     RuntimeProfile* runtime_profile = nullptr;
     int mor_tuple_id;

--- a/be/src/runtime/descriptors.cpp
+++ b/be/src/runtime/descriptors.cpp
@@ -179,6 +179,7 @@ IcebergTableDescriptor::IcebergTableDescriptor(const TTableDescriptor& tdesc, Ob
     _columns = tdesc.icebergTable.columns;
     _t_iceberg_schema = tdesc.icebergTable.iceberg_schema;
     _partition_column_names = tdesc.icebergTable.partition_column_names;
+    _t_iceberg_equal_delete_schema = tdesc.icebergTable.iceberg_equal_delete_schema;
 }
 
 std::vector<int32_t> IcebergTableDescriptor::partition_index_in_schema() {

--- a/be/src/runtime/descriptors.h
+++ b/be/src/runtime/descriptors.h
@@ -220,6 +220,7 @@ public:
     ~IcebergTableDescriptor() override = default;
     bool has_partition() const override { return false; }
     const TIcebergSchema* get_iceberg_schema() const { return &_t_iceberg_schema; }
+    const TIcebergSchema* get_iceberg_equal_delete_schema() const { return &_t_iceberg_equal_delete_schema; }
     bool is_unpartitioned_table() { return _partition_column_names.empty(); }
     const std::vector<std::string>& partition_column_names() { return _partition_column_names; }
     const std::vector<std::string> full_column_names();
@@ -230,6 +231,7 @@ public:
 
 private:
     TIcebergSchema _t_iceberg_schema;
+    TIcebergSchema _t_iceberg_equal_delete_schema;
     std::vector<std::string> _partition_column_names;
 };
 

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/IcebergTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/IcebergTable.java
@@ -44,6 +44,7 @@ import com.starrocks.thrift.TTableDescriptor;
 import com.starrocks.thrift.TTableType;
 import org.apache.iceberg.BaseTable;
 import org.apache.iceberg.PartitionField;
+import org.apache.iceberg.Schema;
 import org.apache.iceberg.Snapshot;
 import org.apache.iceberg.SortField;
 import org.apache.iceberg.types.Types;

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/IcebergTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/IcebergTable.java
@@ -266,7 +266,7 @@ public class IcebergTable extends Table {
         Preconditions.checkNotNull(partitions);
 
         TIcebergTable tIcebergTable = new TIcebergTable();
-        tIcebergTable.setLocation(nativeTable.location());
+        tIcebergTable.setLocation(getNativeTable().location());
 
         List<TColumn> tColumns = Lists.newArrayList();
         for (Column column : getBaseSchema()) {
@@ -276,6 +276,12 @@ public class IcebergTable extends Table {
 
         tIcebergTable.setIceberg_schema(IcebergApiConverter.getTIcebergSchema(nativeTable.schema()));
         tIcebergTable.setPartition_column_names(getPartitionColumnNames());
+        if (nativeTable.schema().identifierFieldIds().size() > 0) {
+            tIcebergTable.setIceberg_equal_delete_schema(IcebergApiConverter.getTIcebergSchema(
+                    new Schema(nativeTable.schema().identifierFieldIds().stream()
+                            .map(id -> nativeTable.schema().findField(id)).collect(Collectors.toList()))));
+        }
+
 
         if (!partitions.isEmpty()) {
             TPartitionMap tPartitionMap = new TPartitionMap();

--- a/gensrc/thrift/Descriptors.thrift
+++ b/gensrc/thrift/Descriptors.thrift
@@ -428,6 +428,9 @@ struct TIcebergTable {
 
     // if serialize partition info throws exception, then use unserialized partitions
     6: optional map<i64, THdfsPartition> partitions
+
+    // Iceberg equality delete schema, used to support schema evolution
+    7: optional TIcebergSchema iceberg_equal_delete_schema
 }
 
 struct THudiTable {

--- a/test/sql/test_iceberg/R/test_iceberg_v2
+++ b/test/sql/test_iceberg/R/test_iceberg_v2
@@ -1,0 +1,136 @@
+-- name: test_iceberg_v2
+create external catalog iceberg_sql_test_${uuid0} PROPERTIES ("type"="iceberg", "iceberg.catalog.type"="hive", "iceberg.catalog.hive.metastore.uris"="${iceberg_catalog_hive_metastore_uris}","enable_iceberg_metadata_cache"="true");
+-- result:
+[]
+-- !result
+/*
+ CREATE TABLE `hive_catalog`.`iceberg_ci_db`.`iceberg_v2_orc_unpartitioned_table` (
+  `k1` INT NOT NULL,
+  `k2` VARCHAR(2147483647),
+  CONSTRAINT `7193cf04-1e4f-4aec-be16-2aa54bb92b4c` PRIMARY KEY (`k1`) NOT ENFORCED
+) WITH (
+  'write-format' = 'orc',
+  'write.upsert.enabled' = 'true'
+)
+*/
+
+select * from iceberg_sql_test_${uuid0}.iceberg_ci_db.iceberg_v2_orc_unpartitioned_table order by k1;
+-- result:
+1	tianjing
+2	guangzhou
+-- !result
+select k2 from iceberg_sql_test_${uuid0}.iceberg_ci_db.iceberg_v2_orc_unpartitioned_table order by k2;
+-- result:
+guangzhou
+tianjing
+-- !result
+select count(*) from iceberg_sql_test_${uuid0}.iceberg_ci_db.iceberg_v2_orc_unpartitioned_table;
+-- result:
+2
+-- !result
+select k1 from iceberg_sql_test_${uuid0}.iceberg_ci_db.iceberg_v2_orc_unpartitioned_table group by k1 having count(1) > 1;
+-- result:
+-- !result
+/*
+CREATE TABLE `hive_catalog`.`iceberg_ci_db`.`iceberg_v2_orc_partitioned_table` (
+  `k1` INT NOT NULL,
+  `k2` VARCHAR(2147483647),
+  `k3` VARCHAR(2147483647) NOT NULL,
+  CONSTRAINT `cfcc11a4-b515-44e8-a6c2-5fe99a2e92ee` PRIMARY KEY (`k1`, `k3`) NOT ENFORCED
+) PARTITIONED BY (`k3`)
+WITH (
+  'write-format' = 'orc',
+  'write.upsert.enabled' = 'true'
+)
+*/
+
+select * from iceberg_sql_test_${uuid0}.iceberg_ci_db.iceberg_v2_orc_partitioned_table order by k1;
+-- result:
+1	beijing	zhangsan
+2	shanghai	lisi
+-- !result
+select k2 from iceberg_sql_test_${uuid0}.iceberg_ci_db.iceberg_v2_orc_partitioned_table order by k2;
+-- result:
+beijing
+shanghai
+-- !result
+select k3 from iceberg_sql_test_${uuid0}.iceberg_ci_db.iceberg_v2_orc_partitioned_table order by k1;
+-- result:
+zhangsan
+lisi
+-- !result
+select count(*) from iceberg_sql_test_${uuid0}.iceberg_ci_db.iceberg_v2_orc_partitioned_table;
+-- result:
+2
+-- !result
+select k1,k3 from iceberg_sql_test_${uuid0}.iceberg_ci_db.iceberg_v2_orc_partitioned_table group by k1,k3 having count(1) > 1;
+-- result:
+-- !result
+/*
+ CREATE TABLE `hive_catalog`.`iceberg_ci_db`.`iceberg_v2_parquet_unpartitioned_table` (
+  `k1` INT NOT NULL,
+  `k2` VARCHAR(2147483647),
+  CONSTRAINT `7193cf04-1e4f-4aec-be16-2aa54bb92b4c` PRIMARY KEY (`k1`) NOT ENFORCED
+) WITH (
+  'write-format' = 'parquet',
+  'write.upsert.enabled' = 'true'
+)
+*/
+
+select * from iceberg_sql_test_${uuid0}.iceberg_ci_db.iceberg_v2_parquet_unpartitioned_table order by k1;
+-- result:
+1	tianjing
+2	guangzhou
+-- !result
+select k2 from iceberg_sql_test_${uuid0}.iceberg_ci_db.iceberg_v2_parquet_unpartitioned_table order by k2;
+-- result:
+guangzhou
+tianjing
+-- !result
+select count(*) from iceberg_sql_test_${uuid0}.iceberg_ci_db.iceberg_v2_parquet_unpartitioned_table;
+-- result:
+2
+-- !result
+select k1 from iceberg_sql_test_${uuid0}.iceberg_ci_db.iceberg_v2_parquet_unpartitioned_table group by k1 having count(1) > 1;
+-- result:
+-- !result
+/*
+CREATE TABLE `hive_catalog`.`iceberg_ci_db`.`iceberg_v2_parquet_partitioned_table` (
+  `k1` INT NOT NULL,
+  `k2` VARCHAR(2147483647),
+  `k3` VARCHAR(2147483647) NOT NULL,
+  CONSTRAINT `cfcc11a4-b515-44e8-a6c2-5fe99a2e92ee` PRIMARY KEY (`k1`, `k3`) NOT ENFORCED
+) PARTITIONED BY (`k3`)
+WITH (
+  'write-format' = 'parquet',
+  'write.upsert.enabled' = 'true'
+)
+*/
+
+select * from iceberg_sql_test_${uuid0}.iceberg_ci_db.iceberg_v2_parquet_partitioned_table order by k1;
+-- result:
+1	beijing	zhangsan
+2	shanghai	lisi
+-- !result
+select k2 from iceberg_sql_test_${uuid0}.iceberg_ci_db.iceberg_v2_parquet_partitioned_table order by k2;
+-- result:
+beijing
+shanghai
+-- !result
+select k3 from iceberg_sql_test_${uuid0}.iceberg_ci_db.iceberg_v2_parquet_partitioned_table order by k1;
+-- result:
+zhangsan
+lisi
+-- !result
+select count(*) from iceberg_sql_test_${uuid0}.iceberg_ci_db.iceberg_v2_parquet_partitioned_table;
+-- result:
+2
+-- !result
+select k1,k3 from iceberg_sql_test_${uuid0}.iceberg_ci_db.iceberg_v2_parquet_partitioned_table group by k1,k3 having count(1) > 1;
+-- result:
+-- !result
+
+drop catalog iceberg_sql_test_${uuid0};
+-- result:
+[]
+-- !result

--- a/test/sql/test_iceberg/T/test_iceberg_v2
+++ b/test/sql/test_iceberg/T/test_iceberg_v2
@@ -1,0 +1,96 @@
+-- name: test_iceberg_v2
+
+create external catalog iceberg_sql_test_${uuid0} PROPERTIES ("type"="iceberg", "iceberg.catalog.type"="hive", "iceberg.catalog.hive.metastore.uris"="${iceberg_catalog_hive_metastore_uris}","enable_iceberg_metadata_cache"="true");
+
+-- Currently only flink can write iceberg equality delete file. The table in the case was created in advance and some test data was inserted using flink. If you want test more cases, you could contact stephen5217@163.com
+
+
+-- unpartitioned table with orc (eq-delete && pos-delete) 
+/*
+ CREATE TABLE `hive_catalog`.`iceberg_ci_db`.`iceberg_v2_orc_unpartitioned_table` (
+  `k1` INT NOT NULL,
+  `k2` VARCHAR(2147483647),
+  CONSTRAINT `7193cf04-1e4f-4aec-be16-2aa54bb92b4c` PRIMARY KEY (`k1`) NOT ENFORCED
+) WITH (
+  'write-format' = 'orc',
+  'write.upsert.enabled' = 'true'
+)
+*/
+
+select * from iceberg_sql_test_${uuid0}.iceberg_ci_db.iceberg_v2_orc_unpartitioned_table order by k1;
+
+select k2 from iceberg_sql_test_${uuid0}.iceberg_ci_db.iceberg_v2_orc_unpartitioned_table order by k2;
+
+select count(*) from iceberg_sql_test_${uuid0}.iceberg_ci_db.iceberg_v2_orc_unpartitioned_table;
+
+select k1 from iceberg_sql_test_${uuid0}.iceberg_ci_db.iceberg_v2_orc_unpartitioned_table group by k1 having count(1) > 1;
+
+-- partitioned table with orc (eq-delete && pos-delete)
+/*
+CREATE TABLE `hive_catalog`.`iceberg_ci_db`.`iceberg_v2_orc_partitioned_table` (
+  `k1` INT NOT NULL,
+  `k2` VARCHAR(2147483647),
+  `k3` VARCHAR(2147483647) NOT NULL,
+  CONSTRAINT `cfcc11a4-b515-44e8-a6c2-5fe99a2e92ee` PRIMARY KEY (`k1`, `k3`) NOT ENFORCED
+) PARTITIONED BY (`k3`)
+WITH (
+  'write-format' = 'orc',
+  'write.upsert.enabled' = 'true'
+)
+*/
+
+select * from iceberg_sql_test_${uuid0}.iceberg_ci_db.iceberg_v2_orc_partitioned_table order by k1;
+
+select k2 from iceberg_sql_test_${uuid0}.iceberg_ci_db.iceberg_v2_orc_partitioned_table order by k2;
+
+select k3 from iceberg_sql_test_${uuid0}.iceberg_ci_db.iceberg_v2_orc_partitioned_table order by k1;
+
+select count(*) from iceberg_sql_test_${uuid0}.iceberg_ci_db.iceberg_v2_orc_partitioned_table;
+
+select k1,k3 from iceberg_sql_test_${uuid0}.iceberg_ci_db.iceberg_v2_orc_partitioned_table group by k1,k3 having count(1) > 1;
+
+-- unpartitioned table with parquet (eq-delete && pos-delete)
+/*
+ CREATE TABLE `hive_catalog`.`iceberg_ci_db`.`iceberg_v2_parquet_unpartitioned_table` (
+  `k1` INT NOT NULL,
+  `k2` VARCHAR(2147483647),
+  CONSTRAINT `7193cf04-1e4f-4aec-be16-2aa54bb92b4c` PRIMARY KEY (`k1`) NOT ENFORCED
+) WITH (
+  'write-format' = 'parquet',
+  'write.upsert.enabled' = 'true'
+)
+*/
+
+select * from iceberg_sql_test_${uuid0}.iceberg_ci_db.iceberg_v2_parquet_unpartitioned_table order by k1;
+
+select k2 from iceberg_sql_test_${uuid0}.iceberg_ci_db.iceberg_v2_parquet_unpartitioned_table order by k2;
+
+select count(*) from iceberg_sql_test_${uuid0}.iceberg_ci_db.iceberg_v2_parquet_unpartitioned_table;
+
+select k1 from iceberg_sql_test_${uuid0}.iceberg_ci_db.iceberg_v2_parquet_unpartitioned_table group by k1 having count(1) > 1;
+
+-- partitioned table with parquet (eq-delete && pos-delete)
+/*
+CREATE TABLE `hive_catalog`.`iceberg_ci_db`.`iceberg_v2_parquet_partitioned_table` (
+  `k1` INT NOT NULL,
+  `k2` VARCHAR(2147483647),
+  `k3` VARCHAR(2147483647) NOT NULL,
+  CONSTRAINT `cfcc11a4-b515-44e8-a6c2-5fe99a2e92ee` PRIMARY KEY (`k1`, `k3`) NOT ENFORCED
+) PARTITIONED BY (`k3`)
+WITH (
+  'write-format' = 'parquet',
+  'write.upsert.enabled' = 'true'
+)
+*/
+
+select * from iceberg_sql_test_${uuid0}.iceberg_ci_db.iceberg_v2_parquet_partitioned_table order by k1;
+
+select k2 from iceberg_sql_test_${uuid0}.iceberg_ci_db.iceberg_v2_parquet_partitioned_table order by k2;
+
+select k3 from iceberg_sql_test_${uuid0}.iceberg_ci_db.iceberg_v2_parquet_partitioned_table order by k1;
+
+select count(*) from iceberg_sql_test_${uuid0}.iceberg_ci_db.iceberg_v2_parquet_partitioned_table;
+
+select k1,k3 from iceberg_sql_test_${uuid0}.iceberg_ci_db.iceberg_v2_parquet_partitioned_table group by k1,k3 having count(1) > 1;
+
+drop catalog iceberg_sql_test_${uuid0};


### PR DESCRIPTION
## Why I'm doing:

Using iceberg delete file to filter data file content for file with parquet format

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [x] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [x] This is a backport pr

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5

