### PR TITLE
[Enhancement] Swap the FileMetaData instance directly instead of `move` because the class has no a movable assignment operator.

### DIFF
--- a/be/src/formats/parquet/file_reader.cpp
+++ b/be/src/formats/parquet/file_reader.cpp
@@ -135,17 +135,21 @@ Status FileReader::_parse_footer(FileMetaDataPtr* file_metadata_ptr, int64_t* fi
         }
     }
 
-    tparquet::FileMetaData t_metadata;
-    // deserialize footer
-    RETURN_IF_ERROR(deserialize_thrift_msg(reinterpret_cast<const uint8*>(footer_buffer.data()) + footer_buffer.size() -
-                                                   PARQUET_FOOTER_SIZE - metadata_length,
-                                           &metadata_length, TProtocolType::COMPACT, &t_metadata));
+    // NOTICE: When you need to modify the logic within this scope (including the subfuctions), you should be
+    // particularly careful to ensure that it does not affect the correctness of the footer's memory statistics.
+    {
+        int64_t before_bytes = CurrentThread::current().get_consumed_bytes();
+        tparquet::FileMetaData t_metadata;
+        // deserialize footer
+        RETURN_IF_ERROR(deserialize_thrift_msg(reinterpret_cast<const uint8*>(footer_buffer.data()) +
+                                                       footer_buffer.size() - PARQUET_FOOTER_SIZE - metadata_length,
+                                               &metadata_length, TProtocolType::COMPACT, &t_metadata));
 
-    int64_t before_bytes = CurrentThread::current().get_consumed_bytes();
-    *file_metadata_ptr = std::make_shared<FileMetaData>();
-    FileMetaData* file_metadata = file_metadata_ptr->get();
-    RETURN_IF_ERROR(file_metadata->init(t_metadata, _scanner_ctx->case_sensitive));
-    *file_metadata_size = CurrentThread::current().get_consumed_bytes() - before_bytes;
+        *file_metadata_ptr = std::make_shared<FileMetaData>();
+        FileMetaData* file_metadata = file_metadata_ptr->get();
+        RETURN_IF_ERROR(file_metadata->init(t_metadata, _scanner_ctx->case_sensitive));
+        *file_metadata_size = CurrentThread::current().get_consumed_bytes() - before_bytes;
+    }
 #ifdef BE_TEST
     *file_metadata_size = sizeof(FileMetaData);
 #endif

--- a/be/src/formats/parquet/metadata.cpp
+++ b/be/src/formats/parquet/metadata.cpp
@@ -24,7 +24,7 @@ Status FileMetaData::init(tparquet::FileMetaData& t_metadata, bool case_sensitiv
     // construct schema from thrift
     RETURN_IF_ERROR(_schema.from_thrift(t_metadata.schema, case_sensitive));
     _num_rows = t_metadata.num_rows;
-    _t_metadata = std::move(t_metadata);
+    tparquet::swap(_t_metadata, t_metadata);
     if (_t_metadata.__isset.created_by) {
         _writer_version = ApplicationVersion(_t_metadata.created_by);
     } else {


### PR DESCRIPTION
## Why I'm doing:
We use `std::move` to try move the FileMetaData instance and skip copying before, while the class has no a movable assignment operator. So it does not work as expected.

## What I'm doing:
1. Use the `swap` function in this class to swap the instance directly and skip copying.
2. Adjust the `FileMetaData` memory statistics because we use zero copy mode now.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
