### PR TITLE
[Enhancement] Add fe config enable_legacy_compatibility_for_replication for cross cluster replication (backport #42333)

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/AggregateType.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/AggregateType.java
@@ -164,7 +164,11 @@ public enum AggregateType {
                 (this.isReplaceFamily() && type.isComplexType());
     }
 
-    public static Type extendedPrecision(Type type) {
+    public static Type extendedPrecision(Type type, boolean legacyCompatible) {
+        if (legacyCompatible) {
+            return type;
+        }
+
         if (type.isDecimalV3()) {
             return ScalarType.createDecimalV3Type(PrimitiveType.DECIMAL128, 38, ((ScalarType) type).getScalarScale());
         }

--- a/fe/fe-core/src/main/java/com/starrocks/common/Config.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/Config.java
@@ -2665,6 +2665,8 @@ public class Config extends ConfigBase {
     public static int replication_max_parallel_data_size_mb = 10240; // 10g
     @ConfField(mutable = true)
     public static int replication_transaction_timeout_sec = 1 * 60 * 60; // 1hour
+    @ConfField(mutable = true)
+    public static boolean enable_legacy_compatibility_for_replication = false;
 
     @ConfField(mutable = true)
     public static boolean jdbc_meta_default_cache_enable = false;

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/ColumnDef.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/ColumnDef.java
@@ -55,6 +55,7 @@ import com.starrocks.catalog.PrimitiveType;
 import com.starrocks.catalog.ScalarType;
 import com.starrocks.catalog.Type;
 import com.starrocks.common.AnalysisException;
+import com.starrocks.common.Config;
 import com.starrocks.sql.analyzer.FeNameFormat;
 import com.starrocks.sql.common.EngineType;
 import com.starrocks.sql.parser.NodePosition;
@@ -314,7 +315,8 @@ public class ColumnDef implements ParseNode {
 
         if (getAggregateType() == AggregateType.SUM) {
             // For the decimal type we extend to decimal128 to avoid overflow
-            typeDef.setType(AggregateType.extendedPrecision(typeDef.getType()));
+            typeDef.setType(AggregateType.extendedPrecision(typeDef.getType(),
+                    Config.enable_legacy_compatibility_for_replication));
         }
 
         typeDef.analyze();

--- a/fe/fe-core/src/test/java/com/starrocks/catalog/TypeTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/TypeTest.java
@@ -269,4 +269,11 @@ public class TypeTest {
         // test initialed fieldMap by ctor in deserializer.
         Assert.assertEquals(1, ((StructType) deType).getFieldPos("c1"));
     }
+
+    @Test
+    public void testExtendedPrecision() {
+        ScalarType type = ScalarType.createDecimalV3Type(PrimitiveType.DECIMAL128, 10, 4);
+        Assert.assertTrue(type == AggregateType.extendedPrecision(type, true));
+        Assert.assertTrue(type != AggregateType.extendedPrecision(type, false));
+    }
 }


### PR DESCRIPTION
## Why I'm doing:
https://github.com/StarRocks/starrocks/pull/7236 
Decimal type used in aggregation column will be changed from decimal(x, scale) to decimal(38, scale) in new starrocks version, which causes compatible problems in cross cluster replication.

## What I'm doing:
Add fe config enable_legacy_compatibility_for_replication to keep compatible with old cluster for cross cluster replication.

Backport of pr: https://github.com/StarRocks/starrocks/pull/42333

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [x] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
