### PR TITLE
[Enhancement] Using ORC column id in SearchArgument

### DIFF
--- a/be/src/exec/hdfs_scanner_orc.cpp
+++ b/be/src/exec/hdfs_scanner_orc.cpp
@@ -697,7 +697,10 @@ void HdfsOrcScanner::do_update_counter(HdfsScanProfile* profile) {
     COUNTER_UPDATE(stripe_active_lazy_coalesce_seperately_counter,
                    _app_stats.orc_stripe_active_lazy_coalesce_seperately);
 
-    root->add_info_string("ORCSearchArgument: ", _orc_reader->get_search_argument_string());
+    if (_orc_reader != nullptr) {
+        // _orc_reader is nullptr for split task
+        root->add_info_string("ORCSearchArgument: ", _orc_reader->get_search_argument_string());
+    }
 }
 
 } // namespace starrocks

--- a/be/src/exec/hdfs_scanner_orc.cpp
+++ b/be/src/exec/hdfs_scanner_orc.cpp
@@ -506,20 +506,19 @@ Status HdfsOrcScanner::do_open(RuntimeState* runtime_state) {
     }
 
     std::unique_ptr<OrcPredicates> orc_predicates = nullptr;
+    std::vector<Expr*> conjuncts{};
     if (_use_orc_sargs) {
-        std::vector<Expr*> conjuncts;
         for (const auto& it : _scanner_ctx.conjunct_ctxs_by_slot) {
             for (const auto& it2 : it.second) {
                 conjuncts.push_back(it2->root());
             }
         }
-        orc_predicates = std::make_unique<OrcPredicates>(&conjuncts, _scanner_ctx.runtime_filter_collector);
     }
+    orc_predicates = std::make_unique<OrcPredicates>(&conjuncts, _scanner_ctx.runtime_filter_collector);
     RETURN_IF_ERROR(_orc_reader->init(std::move(reader), orc_predicates.get()));
 
     // create iceberg delete builder at last
     RETURN_IF_ERROR(build_iceberg_delete_builder());
-
     return Status::OK();
 }
 

--- a/be/src/exec/hdfs_scanner_text.cpp
+++ b/be/src/exec/hdfs_scanner_text.cpp
@@ -279,6 +279,10 @@ Status HdfsTextScanner::do_open(RuntimeState* runtime_state) {
     return Status::OK();
 }
 
+void HdfsTextScanner::do_update_counter(HdfsScanProfile* profile) {
+    profile->runtime_profile->add_info_string("TextCompression", CompressionTypePB_Name(_compression_type));
+}
+
 void HdfsTextScanner::do_close(RuntimeState* runtime_state) noexcept {
     _reader.reset();
 }

--- a/be/src/exec/hdfs_scanner_text.h
+++ b/be/src/exec/hdfs_scanner_text.h
@@ -28,6 +28,7 @@ public:
     ~HdfsTextScanner() override = default;
 
     Status do_open(RuntimeState* runtime_state) override;
+    void do_update_counter(HdfsScanProfile* profile) override;
     void do_close(RuntimeState* runtime_state) noexcept override;
     Status do_get_next(RuntimeState* runtime_state, ChunkPtr* chunk) override;
     Status do_init(RuntimeState* runtime_state, const HdfsScannerParams& scanner_params) override;

--- a/be/src/formats/orc/apache-orc/c++/include/orc/Type.hh
+++ b/be/src/formats/orc/apache-orc/c++/include/orc/Type.hh
@@ -54,7 +54,6 @@ public:
     virtual TypeKind getKind() const = 0;
     virtual uint64_t getSubtypeCount() const = 0;
     virtual const Type* getSubtype(uint64_t childId) const = 0;
-    virtual const Type* getSubtypeByColumnId(uint64_t columnId) const = 0;
     virtual const std::string& getFieldName(uint64_t childId) const = 0;
     virtual uint64_t getFieldNamesCount() const = 0;
     virtual uint64_t getMaximumLength() const = 0;

--- a/be/src/formats/orc/apache-orc/c++/include/orc/sargs/SearchArgument.hh
+++ b/be/src/formats/orc/apache-orc/c++/include/orc/sargs/SearchArgument.hh
@@ -214,6 +214,15 @@ public:
                                       const std::initializer_list<Literal>& literals) = 0;
     virtual SearchArgumentBuilder& in(const std::string& column, PredicateDataType type,
                                       const std::vector<Literal>& literals) = 0;
+    /**
+     * Add an in leaf to the current item on the stack.
+     * @param columnId the column id of the column
+     * @param type the type of the expression
+     * @param literals the literals
+     * @return this
+    */
+    virtual SearchArgumentBuilder& in(uint64_t columnId, PredicateDataType type,
+                                      const std::vector<Literal>& literals) = 0;
 
     /**
      * Add an in leaf to the current item on the stack.

--- a/be/src/formats/orc/apache-orc/c++/src/TypeImpl.cc
+++ b/be/src/formats/orc/apache-orc/c++/src/TypeImpl.cc
@@ -18,7 +18,6 @@
 
 #include "TypeImpl.hh"
 
-#include <iostream>
 #include <sstream>
 
 #include "Adaptor.hh"
@@ -112,21 +111,6 @@ uint64_t TypeImpl::getSubtypeCount() const {
 
 const Type* TypeImpl::getSubtype(uint64_t i) const {
     return subTypes[i].get();
-}
-
-const Type* TypeImpl::getSubtypeByColumnId(uint64_t id) const {
-    ensureIdAssigned();
-    if (id == columnId) {
-        return this;
-    }
-
-    buildColumnIdToPosMap();
-
-    auto it = columnIdToPos.find(id);
-    if (it == columnIdToPos.end()) {
-        throw std::range_error("Error column id range: " + std::to_string(id));
-    }
-    return subTypes[it->second].get();
 }
 
 const std::string& TypeImpl::getFieldName(uint64_t i) const {

--- a/be/src/formats/orc/apache-orc/c++/src/TypeImpl.hh
+++ b/be/src/formats/orc/apache-orc/c++/src/TypeImpl.hh
@@ -67,8 +67,6 @@ public:
 
     const Type* getSubtype(uint64_t i) const override;
 
-    const Type* getSubtypeByColumnId(uint64_t columnId) const override;
-
     const std::string& getFieldName(uint64_t i) const override;
 
     uint64_t getFieldNamesCount() const override;

--- a/be/src/formats/orc/apache-orc/c++/src/sargs/PredicateLeaf.cc
+++ b/be/src/formats/orc/apache-orc/c++/src/sargs/PredicateLeaf.cc
@@ -93,6 +93,17 @@ PredicateLeaf::PredicateLeaf(Operator op, PredicateDataType type, std::string co
     validate();
 }
 
+PredicateLeaf::PredicateLeaf(Operator op, PredicateDataType type, uint64_t columnId,
+                             const std::vector<Literal>& literals)
+        : mOperator(op),
+          mType(type),
+          mHasColumnName(false),
+          mColumnId(columnId),
+          mLiterals(literals.begin(), literals.end()) {
+    mHashCode = hashCode();
+    validate();
+}
+
 void PredicateLeaf::validateColumn() const {
     if (mHasColumnName && mColumnName.empty()) {
         throw std::invalid_argument("column name should not be empty");

--- a/be/src/formats/orc/apache-orc/c++/src/sargs/PredicateLeaf.hh
+++ b/be/src/formats/orc/apache-orc/c++/src/sargs/PredicateLeaf.hh
@@ -85,6 +85,8 @@ public:
 
     PredicateLeaf(Operator op, PredicateDataType type, std::string colName, const std::vector<Literal>& literalList);
 
+    PredicateLeaf(Operator op, PredicateDataType type, uint64_t columnId, const std::vector<Literal>& literalList);
+
     /**
      * Get the operator for the leaf.
      */

--- a/be/src/formats/orc/apache-orc/c++/src/sargs/SearchArgument.cc
+++ b/be/src/formats/orc/apache-orc/c++/src/sargs/SearchArgument.cc
@@ -181,9 +181,9 @@ SearchArgumentBuilder& SearchArgumentBuilderImpl::nullSafeEquals(uint64_t column
     return compareOperator(PredicateLeaf::Operator::NULL_SAFE_EQUALS, columnId, type, literal);
 }
 
-template <typename T>
+template <typename T, typename CONTAINER>
 SearchArgumentBuilder& SearchArgumentBuilderImpl::addChildForIn(T column, PredicateDataType type,
-                                                                const std::initializer_list<Literal>& literals) {
+                                                                const CONTAINER& literals) {
     TreeNode& parent = mCurrTree.front();
     if (isInvalidColumn(column)) {
         parent->addChild(std::make_shared<ExpressionTree>((TruthValue::YES_NO_NULL)));
@@ -199,17 +199,12 @@ SearchArgumentBuilder& SearchArgumentBuilderImpl::addChildForIn(T column, Predic
 
 SearchArgumentBuilder& SearchArgumentBuilderImpl::in(const std::string& column, PredicateDataType type,
                                                      const std::vector<Literal>& literals) {
-    TreeNode& parent = mCurrTree.front();
-    if (isInvalidColumn(column)) {
-        parent->addChild(std::make_shared<ExpressionTree>((TruthValue::YES_NO_NULL)));
-    } else {
-        if (literals.size() == 0) {
-            throw std::invalid_argument("Can't create in expression with no arguments");
-        }
-        PredicateLeaf leaf(PredicateLeaf::Operator::IN, type, column, literals);
-        parent->addChild(std::make_shared<ExpressionTree>(addLeaf(leaf)));
-    }
-    return *this;
+    return addChildForIn(column, type, literals);
+}
+
+SearchArgumentBuilder& SearchArgumentBuilderImpl::in(uint64_t columnId, PredicateDataType type,
+                                                     const std::vector<Literal>& literals) {
+    return addChildForIn(columnId, type, literals);
 }
 
 SearchArgumentBuilder& SearchArgumentBuilderImpl::in(const std::string& column, PredicateDataType type,

--- a/be/src/formats/orc/apache-orc/c++/src/sargs/SearchArgument.hh
+++ b/be/src/formats/orc/apache-orc/c++/src/sargs/SearchArgument.hh
@@ -212,6 +212,7 @@ public:
      */
     SearchArgumentBuilder& in(uint64_t columnId, PredicateDataType type,
                               const std::initializer_list<Literal>& literals) override;
+    SearchArgumentBuilder& in(uint64_t columnId, PredicateDataType type, const std::vector<Literal>& literals) override;
 
     /**
      * Add an is null leaf to the current item on the stack.
@@ -273,9 +274,8 @@ private:
     template <typename T>
     SearchArgumentBuilder& compareOperator(PredicateLeaf::Operator op, const T& column, PredicateDataType type,
                                            const Literal& literal);
-    template <typename T>
-    SearchArgumentBuilder& addChildForIn(T column, PredicateDataType type,
-                                         const std::initializer_list<Literal>& literals);
+    template <typename T, typename CONTAINER>
+    SearchArgumentBuilder& addChildForIn(T column, PredicateDataType type, const CONTAINER& literals);
 
     template <typename T>
     SearchArgumentBuilder& addChildForIsNull(T column, PredicateDataType type);

--- a/be/src/formats/orc/orc_chunk_reader.cpp
+++ b/be/src/formats/orc/orc_chunk_reader.cpp
@@ -63,7 +63,6 @@ OrcChunkReader::OrcChunkReader(int chunk_size, std::vector<SlotDescriptor*> src_
         if (*iter_slot == nullptr) {
             iter_slot = _src_slot_descriptors.erase(iter_slot);
         } else {
-            _slot_id_to_desc[(*iter_slot)->id()] = *iter_slot;
             ++iter_slot;
         }
     }
@@ -83,11 +82,11 @@ OrcChunkReader::OrcChunkReader()
     _row_reader_options.useWriterTimezone();
 }
 
-Status OrcChunkReader::init(std::unique_ptr<orc::InputStream> input_stream) {
+Status OrcChunkReader::init(std::unique_ptr<orc::InputStream> input_stream, const OrcPredicates* orc_predicates) {
     try {
         _reader_options.setMemoryPool(*getOrcMemoryPool());
         auto reader = orc::createReader(std::move(input_stream), _reader_options);
-        RETURN_IF_ERROR(init(std::move(reader)));
+        RETURN_IF_ERROR(init(std::move(reader), orc_predicates));
     } catch (std::exception& e) {
         auto s = strings::Substitute("OrcChunkReader::init failed. reason = $0, file = $1", e.what(),
                                      _current_file_name);
@@ -183,7 +182,7 @@ const std::vector<bool>& OrcChunkReader::TEST_get_lazyload_column_id_list() {
     return _row_reader->getLazyLoadColumns();
 }
 
-Status OrcChunkReader::init(std::unique_ptr<orc::Reader> reader) {
+Status OrcChunkReader::init(std::unique_ptr<orc::Reader> reader, const OrcPredicates* orc_predicates) {
     _reader = std::move(reader);
     // ORC writes empty schema (struct<>) to ORC files containing zero rows.
     // Hive 0.12
@@ -196,6 +195,20 @@ Status OrcChunkReader::init(std::unique_ptr<orc::Reader> reader) {
         set_use_orc_column_names(true);
     }
 
+    // Build root_mapping, including all columns in orc.
+    _orc_mapping_options.filename = _current_file_name;
+    _orc_mapping_options.case_sensitive = _case_sensitive;
+    ASSIGN_OR_RETURN(_root_mapping,
+                     OrcMappingFactory::build_mapping(_src_slot_descriptors, _reader->getType(), _use_orc_column_names,
+                                                      _hive_column_names, _orc_mapping_options));
+    DCHECK(_root_mapping != nullptr);
+    RETURN_IF_ERROR(_init_include_columns(_root_mapping));
+    RETURN_IF_ERROR(_init_src_types(_root_mapping));
+
+    if (orc_predicates != nullptr) {
+        RETURN_IF_ERROR(build_search_argument_by_predicates(orc_predicates));
+    }
+
     // ensure search argument is not null.
     // we are going to put row reader filter into search argument applier
     // and search argument applier only be constructed when search argument is not null.
@@ -204,16 +217,7 @@ Status OrcChunkReader::init(std::unique_ptr<orc::Reader> reader) {
         builder->literal(orc::TruthValue::YES_NO_NULL);
         _row_reader_options.searchArgument(builder->build());
     }
-    // Build root_mapping, including all columns in orc.
-    _orc_mapping_options.filename = _current_file_name;
-    _orc_mapping_options.case_sensitive = _case_sensitive;
-    std::unique_ptr<OrcMapping> root_mapping = nullptr;
-    ASSIGN_OR_RETURN(root_mapping,
-                     OrcMappingFactory::build_mapping(_src_slot_descriptors, _reader->getType(), _use_orc_column_names,
-                                                      _hive_column_names, _orc_mapping_options));
-    DCHECK(root_mapping != nullptr);
-    RETURN_IF_ERROR(_init_include_columns(root_mapping));
-    RETURN_IF_ERROR(_init_src_types(root_mapping));
+
     try {
         _row_reader = _reader->createRowReader(_row_reader_options);
     } catch (std::exception& e) {
@@ -222,12 +226,7 @@ Status OrcChunkReader::init(std::unique_ptr<orc::Reader> reader) {
         LOG(WARNING) << s;
         return Status::InternalError(s);
     }
-    // Build selected column mapping, because after `include column operation`, all included column's column id
-    // will re-assign.
-    ASSIGN_OR_RETURN(_root_selected_mapping,
-                     OrcMappingFactory::build_mapping(_src_slot_descriptors, _reader->getType(), _use_orc_column_names,
-                                                      _hive_column_names, _orc_mapping_options));
-    DCHECK(_root_selected_mapping != nullptr);
+
     // TODO(SmithCruise) delete _init_position_in_orc() when develop subfield lazy load.
     RETURN_IF_ERROR(_init_position_in_orc());
     RETURN_IF_ERROR(_init_cast_exprs());
@@ -428,8 +427,7 @@ Status OrcChunkReader::_init_src_types(const std::unique_ptr<OrcMapping>& mappin
         if (slot_desc == nullptr) {
             continue;
         }
-        const orc::Type* orc_type =
-                _reader->getType().getSubtypeByColumnId(mapping->get_orc_type_child_mapping(i).orc_type->getColumnId());
+        const orc::Type* orc_type = mapping->get_orc_type_child_mapping(i).orc_type;
         RETURN_IF_ERROR(_create_type_descriptor_by_orc(
                 slot_desc->type(), orc_type, mapping->get_orc_type_child_mapping(i).orc_mapping, &_src_types[i]));
         _try_implicit_cast(&_src_types[i], slot_desc->type());
@@ -475,28 +473,18 @@ Status OrcChunkReader::_init_column_readers() {
         if (slot_desc == nullptr) {
             continue;
         }
-        ASSIGN_OR_RETURN(
-                std::unique_ptr<ORCColumnReader> column_reader,
-                ORCColumnReader::create(
-                        _src_types[column_pos], _root_selected_mapping->get_orc_type_child_mapping(column_pos).orc_type,
-                        slot_desc->is_nullable(),
-                        _root_selected_mapping->get_orc_type_child_mapping(column_pos).orc_mapping, this));
+        ASSIGN_OR_RETURN(std::unique_ptr<ORCColumnReader> column_reader,
+                         ORCColumnReader::create(
+                                 _src_types[column_pos], _root_mapping->get_orc_type_child_mapping(column_pos).orc_type,
+                                 slot_desc->is_nullable(),
+                                 _root_mapping->get_orc_type_child_mapping(column_pos).orc_mapping, this));
         _column_readers.emplace_back(std::move(column_reader));
     }
     DCHECK_EQ(_column_readers.size(), column_size);
     return Status::OK();
 }
 
-OrcChunkReader::~OrcChunkReader() {
-    _batch.reset(nullptr);
-    _reader.reset(nullptr);
-    _row_reader.reset(nullptr);
-    _src_types.clear();
-    _slot_id_to_desc.clear();
-    _slot_id_to_position.clear();
-    _cast_exprs.clear();
-    _column_readers.clear();
-}
+OrcChunkReader::~OrcChunkReader() = default;
 
 Status OrcChunkReader::read_next(orc::RowReader::ReadPosition* pos) {
     if (_batch == nullptr) {
@@ -540,9 +528,8 @@ Status OrcChunkReader::_fill_chunk(ChunkPtr* chunk, const std::vector<SlotDescri
             src_index = (*indices)[src_index];
         }
         set_current_slot(slot_desc);
-        orc::ColumnVectorBatch* cvb =
-                batch_vec->fieldsColumnIdMap[_root_selected_mapping->get_orc_type_child_mapping(src_index)
-                                                     .orc_type->getColumnId()];
+        orc::ColumnVectorBatch* cvb = batch_vec->fieldsColumnIdMap[_root_mapping->get_orc_type_child_mapping(src_index)
+                                                                           .orc_type->getColumnId()];
         if (!slot_desc->is_nullable() && cvb->hasNulls) {
             if (_broker_load_mode) {
                 std::string error_msg =
@@ -699,24 +686,26 @@ void OrcChunkReader::set_row_reader_filter(std::shared_ptr<orc::RowReaderFilter>
     _row_reader_options.rowReaderFilter(std::move(filter));
 }
 
-static std::unordered_set<TExprOpcode::type> _supported_binary_ops = {
+static const std::unordered_set<TExprOpcode::type> _supported_binary_ops = {
         TExprOpcode::EQ,          TExprOpcode::NE,        TExprOpcode::LT,
         TExprOpcode::LE,          TExprOpcode::GT,        TExprOpcode::GE,
         TExprOpcode::EQ_FOR_NULL, TExprOpcode::FILTER_IN, TExprOpcode::FILTER_NOT_IN,
 };
 
-static std::unordered_set<TExprNodeType::type> _supported_literal_types = {
+static const std::unordered_set<TExprNodeType::type> _supported_literal_types = {
         TExprNodeType::type::BOOL_LITERAL,   TExprNodeType::type::DATE_LITERAL,      TExprNodeType::type::FLOAT_LITERAL,
         TExprNodeType::type::INT_LITERAL,    TExprNodeType::type::DECIMAL_LITERAL,   TExprNodeType::type::NULL_LITERAL,
         TExprNodeType::type::STRING_LITERAL, TExprNodeType::type::LARGE_INT_LITERAL,
 };
 
-static std::unordered_set<TExprNodeType::type> _supported_expr_node_types = {
+static const std::unordered_set<TExprNodeType::type> _supported_expr_node_types = {
         // predicates
         TExprNodeType::type::COMPOUND_PRED,
         TExprNodeType::type::BINARY_PRED,
         TExprNodeType::type::IN_PRED,
         TExprNodeType::type::IS_NULL_PRED,
+        // is null & is not null
+        TExprNodeType::type::FUNCTION_CALL,
         // literal & slot ref
         TExprNodeType::type::BOOL_LITERAL,
         TExprNodeType::type::DATE_LITERAL,
@@ -727,11 +716,9 @@ static std::unordered_set<TExprNodeType::type> _supported_expr_node_types = {
         TExprNodeType::type::SLOT_REF,
         TExprNodeType::type::STRING_LITERAL,
         TExprNodeType::type::LARGE_INT_LITERAL,
-        // is null & is not null
-        TExprNodeType::type::FUNCTION_CALL,
 };
 
-static std::unordered_map<LogicalType, orc::PredicateDataType> _supported_logical_types = {
+static const std::unordered_map<LogicalType, orc::PredicateDataType> _supported_logical_types = {
         {LogicalType::TYPE_BOOLEAN, orc::PredicateDataType::BOOLEAN},
         {LogicalType::TYPE_TINYINT, orc::PredicateDataType::LONG},
         {LogicalType::TYPE_SMALLINT, orc::PredicateDataType::LONG},
@@ -753,98 +740,126 @@ static std::unordered_map<LogicalType, orc::PredicateDataType> _supported_logica
         {LogicalType::TYPE_DECIMAL128, orc::PredicateDataType::DECIMAL},
 };
 
-bool OrcChunkReader::_ok_to_add_conjunct(const Expr* conjunct) {
+bool OrcChunkReader::_ok_to_add_compound_conjunct(
+        const Expr* conjunct, const std::unordered_map<SlotId, size_t>& slot_id_to_pos_in_src_slot_descriptors) {
+    DCHECK_EQ(TExprNodeType::COMPOUND_PRED, conjunct->node_type());
+    const TExprOpcode::type& op_type = conjunct->op();
+
+    if (!(op_type == TExprOpcode::COMPOUND_AND || op_type == TExprOpcode::COMPOUND_NOT ||
+          op_type == TExprOpcode::COMPOUND_OR)) {
+        return false;
+    }
+
+    for (const Expr* c : conjunct->children()) {
+        if (!_ok_to_add_conjunct(c, slot_id_to_pos_in_src_slot_descriptors)) {
+            return false;
+        }
+    }
+    return true;
+}
+
+bool OrcChunkReader::_ok_to_add_binary_in_conjunct(
+        const Expr* conjunct, const std::unordered_map<SlotId, size_t>& slot_id_to_pos_in_src_slot_descriptors) {
     const TExprNodeType::type& node_type = conjunct->node_type();
     const TExprOpcode::type& op_type = conjunct->op();
-    if (_supported_expr_node_types.find(node_type) == _supported_expr_node_types.end()) {
+    DCHECK(node_type == TExprNodeType::BINARY_PRED || node_type == TExprNodeType::IN_PRED);
+
+    if (!_supported_binary_ops.contains(op_type)) {
+        return false;
+    }
+
+    // first child should be slot
+    // and others should be literal.
+    Expr* c = conjunct->get_child(0);
+    if (c->node_type() != TExprNodeType::type::SLOT_REF) {
+        return false;
+    }
+    const SlotId slot_id = down_cast<ColumnRef*>(c)->slot_id();
+
+    // slot can't be not found.
+    const auto& iter = slot_id_to_pos_in_src_slot_descriptors.find(slot_id);
+    if (iter == slot_id_to_pos_in_src_slot_descriptors.end()) {
+        return false;
+    }
+
+    const SlotDescriptor* slot_desc = _src_slot_descriptors[iter->second];
+    // It's unsafe to do eval on char type because of padding problems.
+    if (slot_desc->type().type == TYPE_CHAR) {
+        return false;
+    }
+
+    if (conjunct->get_num_children() == 1) {
+        return false;
+    }
+
+    for (int i = 1; i < conjunct->get_num_children(); i++) {
+        c = conjunct->get_child(i);
+        if (!_supported_literal_types.contains(c->node_type())) {
+            return false;
+        }
+    }
+    for (int i = 0; i < conjunct->get_num_children(); i++) {
+        if (!_supported_logical_types.contains(conjunct->get_child(i)->type().type)) {
+            return false;
+        }
+    }
+
+    return true;
+}
+
+bool OrcChunkReader::_ok_to_add_is_null_conjunct(
+        const Expr* conjunct, const std::unordered_map<SlotId, size_t>& slot_id_to_pos_in_src_slot_descriptors) {
+    const TExprNodeType::type& node_type = conjunct->node_type();
+
+    DCHECK(node_type == TExprNodeType::IS_NULL_PRED || node_type == TExprNodeType::FUNCTION_CALL);
+
+    // first child should be slot
+    // and others should be literal.
+    Expr* c = conjunct->get_child(0);
+    if (c->node_type() != TExprNodeType::type::SLOT_REF) {
+        return false;
+    }
+    const SlotId slot_id = down_cast<ColumnRef*>(c)->slot_id();
+
+    // slot can't be not found.
+    const auto& iter = slot_id_to_pos_in_src_slot_descriptors.find(slot_id);
+    if (iter == slot_id_to_pos_in_src_slot_descriptors.end()) {
+        return false;
+    }
+
+    if (node_type == TExprNodeType::FUNCTION_CALL) {
+        // check is null & is not null
+        std::string null_str;
+        if (!conjunct->is_null_scalar_function(null_str)) {
+            return false;
+        }
+    }
+
+    return true;
+}
+
+bool OrcChunkReader::_ok_to_add_conjunct(
+        const Expr* conjunct, const std::unordered_map<SlotId, size_t>& slot_id_to_pos_in_src_slot_descriptors) {
+    const TExprNodeType::type& node_type = conjunct->node_type();
+    if (!_supported_expr_node_types.contains(node_type)) {
         return false;
     }
 
     // compound pred: and, or not.
     if (node_type == TExprNodeType::COMPOUND_PRED) {
-        if (!(op_type == TExprOpcode::COMPOUND_AND || op_type == TExprOpcode::COMPOUND_NOT ||
-              op_type == TExprOpcode::COMPOUND_OR)) {
-            return false;
-        }
-        for (Expr* c : conjunct->children()) {
-            if (!_ok_to_add_conjunct(c)) {
-                return false;
-            }
-        }
-        return true;
+        return _ok_to_add_compound_conjunct(conjunct, slot_id_to_pos_in_src_slot_descriptors);
     }
 
     // binary pred: EQ, NE, LT etc.
     if (node_type == TExprNodeType::BINARY_PRED || node_type == TExprNodeType::IN_PRED) {
-        if (_supported_binary_ops.find(op_type) == _supported_binary_ops.end()) {
-            return false;
-        }
+        return _ok_to_add_binary_in_conjunct(conjunct, slot_id_to_pos_in_src_slot_descriptors);
     }
 
-    // supported one level. first child is slot, and others are literal values.
-    // and only support some of logical types.
-    if (node_type == TExprNodeType::BINARY_PRED || node_type == TExprNodeType::IN_PRED ||
-        node_type == TExprNodeType::IS_NULL_PRED || node_type == TExprNodeType::FUNCTION_CALL) {
-        // first child should be slot
-        // and others should be literal.
-        Expr* c = conjunct->get_child(0);
-        if (c->node_type() != TExprNodeType::type::SLOT_REF) {
-            return false;
-        }
-        auto* ref = down_cast<ColumnRef*>(c);
-        SlotId slot_id = ref->slot_id();
-        // slot can not be found.
-        auto iter = _slot_id_to_desc.find(slot_id);
-        if (iter == _slot_id_to_desc.end()) {
-            return false;
-        }
-        SlotDescriptor* slot_desc = iter->second;
-        // It's unsafe to do eval on char type because of padding problems.
-        if (slot_desc->type().type == TYPE_CHAR) {
-            return false;
-        }
-
-        if (conjunct->get_num_children() == 1) {
-            if (node_type == TExprNodeType::IS_NULL_PRED) {
-                // null predicate only has one child
-                // we don't need to return false
-            } else if (node_type == TExprNodeType::FUNCTION_CALL) {
-                // null predicate only has one child
-                // check is null & is not null
-                std::string null_str;
-                if (!conjunct->is_null_scalar_function(null_str)) {
-                    return false;
-                }
-            } else {
-                return false;
-            }
-        }
-
-        // We only support is null / is not null in function call
-        if (node_type == TExprNodeType::FUNCTION_CALL) {
-            std::string null_str;
-            if (!conjunct->is_null_scalar_function(null_str)) {
-                return false;
-            }
-        }
-
-        for (int i = 1; i < conjunct->get_num_children(); i++) {
-            c = conjunct->get_child(i);
-            if (_supported_literal_types.find(c->node_type()) == _supported_literal_types.end()) {
-                return false;
-            }
-        }
-        for (int i = 0; i < conjunct->get_num_children(); i++) {
-            Expr* expr = conjunct->get_child(i);
-            LogicalType lt = expr->type().type;
-            if (_supported_logical_types.find(lt) == _supported_logical_types.end()) {
-                return false;
-            }
-        }
-        return true;
+    if (node_type == TExprNodeType::IS_NULL_PRED || node_type == TExprNodeType::FUNCTION_CALL) {
+        return _ok_to_add_is_null_conjunct(conjunct, slot_id_to_pos_in_src_slot_descriptors);
     }
 
-    return true;
+    return false;
 }
 
 static inline orc::Int128 to_orc128(int128_t value) {
@@ -907,7 +922,9 @@ static StatusOr<orc::Literal> translate_to_orc_literal(Expr* lit, orc::Predicate
     return Status::InternalError("failed to handle logical type = " + std::to_string(ltype));
 }
 
-Status OrcChunkReader::_add_conjunct(const Expr* conjunct, std::unique_ptr<orc::SearchArgumentBuilder>& builder) {
+Status OrcChunkReader::_add_conjunct(const Expr* conjunct,
+                                     const std::unordered_map<SlotId, size_t>& slot_id_to_pos_in_src_slot_descriptors,
+                                     std::unique_ptr<orc::SearchArgumentBuilder>& builder) {
     const TExprNodeType::type& node_type = conjunct->node_type();
     const TExprOpcode::type& op_type = conjunct->op();
 
@@ -916,9 +933,11 @@ Status OrcChunkReader::_add_conjunct(const Expr* conjunct, std::unique_ptr<orc::
     if (node_type == TExprNodeType::type::SLOT_REF) {
         auto* ref = down_cast<const ColumnRef*>(conjunct);
         DCHECK(conjunct->type().type == LogicalType::TYPE_BOOLEAN);
-        SlotId slot_id = ref->slot_id();
-        std::string name = _slot_id_to_desc[slot_id]->col_name();
-        builder->equals(name, orc::PredicateDataType::BOOLEAN, true);
+        const SlotId& slot_id = ref->slot_id();
+        const uint64_t column_id =
+                _root_mapping->get_orc_type_child_mapping(slot_id_to_pos_in_src_slot_descriptors.at(slot_id))
+                        .orc_type->getColumnId();
+        builder->equals(column_id, orc::PredicateDataType::BOOLEAN, true);
         return Status::OK();
     }
 
@@ -934,7 +953,7 @@ Status OrcChunkReader::_add_conjunct(const Expr* conjunct, std::unique_ptr<orc::
                                          std::to_string(op_type));
         }
         for (Expr* c : conjunct->children()) {
-            RETURN_IF_ERROR(_add_conjunct(c, builder));
+            RETURN_IF_ERROR(_add_conjunct(c, slot_id_to_pos_in_src_slot_descriptors, builder));
         }
         builder->end();
         return Status::OK();
@@ -960,18 +979,25 @@ Status OrcChunkReader::_add_conjunct(const Expr* conjunct, std::unique_ptr<orc::
 
     Expr* slot = conjunct->get_child(0);
     DCHECK(slot->is_slotref());
-    auto* ref = down_cast<ColumnRef*>(slot);
-    const SlotId& slot_id = ref->slot_id();
-    const std::string& name = _slot_id_to_desc[slot_id]->col_name();
+    const SlotId& slot_id = down_cast<ColumnRef*>(slot)->slot_id();
+    const size_t pos = slot_id_to_pos_in_src_slot_descriptors.at(slot_id);
+    const uint64_t column_id = _root_mapping->get_orc_type_child_mapping(pos).orc_type->getColumnId();
 
-    orc::PredicateDataType pred_type = orc::PredicateDataType::LONG;
-    auto type_it = _supported_logical_types.find(slot->type().type);
-    if (type_it != _supported_logical_types.end()) {
-        pred_type = type_it->second;
-    } else {
-        return Status::NotSupported(
-                fmt::format("orc chunk reader don't support {}.", std::to_string(slot->type().type)));
+    if (node_type == TExprNodeType::IS_NULL_PRED || node_type == TExprNodeType::FUNCTION_CALL) {
+        std::string null_function_name;
+        if (conjunct->is_null_scalar_function(null_function_name)) {
+            if (null_function_name == "null") {
+                builder->isNull(column_id, orc::PredicateDataType::BOOLEAN);
+            } else if (null_function_name == "not null") {
+                builder->startNot();
+                builder->isNull(column_id, orc::PredicateDataType::BOOLEAN);
+                builder->end();
+            }
+        }
+        return Status::OK();
     }
+
+    orc::PredicateDataType pred_type = _supported_logical_types.at(slot->type().type);
 
     if (node_type == TExprNodeType::type::BINARY_PRED) {
         Expr* lit = conjunct->get_child(1);
@@ -979,37 +1005,37 @@ Status OrcChunkReader::_add_conjunct(const Expr* conjunct, std::unique_ptr<orc::
 
         switch (op_type) {
         case TExprOpcode::EQ:
-            builder->equals(name, pred_type, literal);
+            builder->equals(column_id, pred_type, literal);
             break;
 
         case TExprOpcode::NE:
             builder->startNot();
-            builder->equals(name, pred_type, literal);
+            builder->equals(column_id, pred_type, literal);
             builder->end();
             break;
 
         case TExprOpcode::LT:
-            builder->lessThan(name, pred_type, literal);
+            builder->lessThan(column_id, pred_type, literal);
             break;
 
         case TExprOpcode::LE:
-            builder->lessThanEquals(name, pred_type, literal);
+            builder->lessThanEquals(column_id, pred_type, literal);
             break;
 
         case TExprOpcode::GT:
             builder->startNot();
-            builder->lessThanEquals(name, pred_type, literal);
+            builder->lessThanEquals(column_id, pred_type, literal);
             builder->end();
             break;
 
         case TExprOpcode::GE:
             builder->startNot();
-            builder->lessThan(name, pred_type, literal);
+            builder->lessThan(column_id, pred_type, literal);
             builder->end();
             break;
 
         case TExprOpcode::EQ_FOR_NULL:
-            builder->nullSafeEquals(name, pred_type, literal);
+            builder->nullSafeEquals(column_id, pred_type, literal);
             break;
 
         default:
@@ -1030,23 +1056,9 @@ Status OrcChunkReader::_add_conjunct(const Expr* conjunct, std::unique_ptr<orc::
             ASSIGN_OR_RETURN(orc::Literal literal, translate_to_orc_literal(lit, pred_type));
             literals.emplace_back(literal);
         }
-        builder->in(name, pred_type, literals);
+        builder->in(column_id, pred_type, literals);
         if (neg) {
             builder->end();
-        }
-        return Status::OK();
-    }
-
-    if (node_type == TExprNodeType::IS_NULL_PRED || node_type == TExprNodeType::FUNCTION_CALL) {
-        std::string null_function_name;
-        if (conjunct->is_null_scalar_function(null_function_name)) {
-            if (null_function_name == "null") {
-                builder->isNull(name, pred_type);
-            } else if (null_function_name == "not null") {
-                builder->startNot();
-                builder->isNull(name, pred_type);
-                builder->end();
-            }
         }
         return Status::OK();
     }
@@ -1054,13 +1066,13 @@ Status OrcChunkReader::_add_conjunct(const Expr* conjunct, std::unique_ptr<orc::
     return Status::InternalError("unexpected node_type = " + std::to_string(node_type));
 }
 
-#define ADD_RF_TO_BUILDER                                            \
-    {                                                                \
-        builder->lessThanEquals(slot->col_name(), pred_type, upper); \
-        builder->startNot();                                         \
-        builder->lessThan(slot->col_name(), pred_type, lower);       \
-        builder->end();                                              \
-        return true;                                                 \
+#define ADD_RF_TO_BUILDER                                     \
+    {                                                         \
+        builder->lessThanEquals(column_id, pred_type, upper); \
+        builder->startNot();                                  \
+        builder->lessThan(column_id, pred_type, lower);       \
+        builder->end();                                       \
+        return true;                                          \
     }
 
 #define ADD_RF_BOOLEAN_TYPE(type)                                      \
@@ -1141,7 +1153,8 @@ Status OrcChunkReader::_add_conjunct(const Expr* conjunct, std::unique_ptr<orc::
         ADD_RF_TO_BUILDER                                                                                        \
     }
 
-bool OrcChunkReader::_add_runtime_filter(const SlotDescriptor* slot, const JoinRuntimeFilter* rf,
+bool OrcChunkReader::_add_runtime_filter(const uint64_t column_id, const SlotDescriptor* slot,
+                                         const JoinRuntimeFilter* rf,
                                          std::unique_ptr<orc::SearchArgumentBuilder>& builder) {
     LogicalType ltype = slot->type().type;
     auto type_it = _supported_logical_types.find(ltype);
@@ -1169,35 +1182,46 @@ bool OrcChunkReader::_add_runtime_filter(const SlotDescriptor* slot, const JoinR
     return false;
 }
 
-Status OrcChunkReader::set_conjuncts(const std::vector<Expr*>& conjuncts) {
-    return set_conjuncts_and_runtime_filters(conjuncts, nullptr);
-}
+Status OrcChunkReader::build_search_argument_by_predicates(const OrcPredicates* orc_predicates) {
+    if (_root_mapping == nullptr) {
+        DCHECK(false);
+        return Status::InternalError("You should call build OrcMapping before build_search_argument_by_predicates()");
+    }
 
-Status OrcChunkReader::set_conjuncts_and_runtime_filters(const std::vector<Expr*>& conjuncts,
-                                                         const RuntimeFilterProbeCollector* rf_collector) {
+    if (orc_predicates->conjuncts == nullptr) {
+        DCHECK(false);
+        return Status::InternalError("conjuncts must not be null");
+    }
+
+    std::unordered_map<SlotId, size_t> slot_id_to_pos_in_src_slot_descriptors{};
+    for (size_t i = 0; i < _src_slot_descriptors.size(); i++) {
+        slot_id_to_pos_in_src_slot_descriptors.emplace(_src_slot_descriptors[i]->id(), i);
+    }
+
     std::unique_ptr<orc::SearchArgumentBuilder> builder = orc::SearchArgumentFactory::newBuilder();
     int ok = 0;
     builder->startAnd();
-    for (Expr* expr : conjuncts) {
-        bool applied = _ok_to_add_conjunct(expr);
+    for (Expr* expr : *orc_predicates->conjuncts) {
+        bool applied = _ok_to_add_conjunct(expr, slot_id_to_pos_in_src_slot_descriptors);
         VLOG_FILE << "OrcChunkReader: add_conjunct: " << expr->debug_string() << ", applied: " << applied;
         if (!applied) {
             continue;
         }
         ok += 1;
-        RETURN_IF_ERROR(_add_conjunct(expr, builder));
+        RETURN_IF_ERROR(_add_conjunct(expr, slot_id_to_pos_in_src_slot_descriptors, builder));
     }
 
-    if (rf_collector != nullptr) {
-        for (auto& it : rf_collector->descriptors()) {
+    if (orc_predicates->rf_collector != nullptr) {
+        for (auto& it : orc_predicates->rf_collector->descriptors()) {
             RuntimeFilterProbeDescriptor* rf_desc = it.second;
             const JoinRuntimeFilter* filter = rf_desc->runtime_filter();
             SlotId probe_slot_id;
             if (filter == nullptr || filter->has_null() || !rf_desc->is_probe_slot_ref(&probe_slot_id)) continue;
-            auto it2 = _slot_id_to_desc.find(probe_slot_id);
-            if (it2 == _slot_id_to_desc.end()) continue;
-            SlotDescriptor* slot_desc = it2->second;
-            if (_add_runtime_filter(slot_desc, filter, builder)) {
+            auto it2 = slot_id_to_pos_in_src_slot_descriptors.find(probe_slot_id);
+            if (it2 == slot_id_to_pos_in_src_slot_descriptors.end()) continue;
+            const SlotDescriptor* slot_desc = _src_slot_descriptors[it2->second];
+            const uint64_t column_id = _root_mapping->get_orc_type_child_mapping(it2->second).orc_type->getColumnId();
+            if (_add_runtime_filter(column_id, slot_desc, filter, builder)) {
                 ok += 1;
             }
         }
@@ -1323,6 +1347,14 @@ Status OrcChunkReader::get_schema(std::vector<SlotDescriptor>* schema) {
         schema->emplace_back(i, name, tp);
     }
     return Status::OK();
+}
+
+std::string OrcChunkReader::get_search_argument_string() const {
+    if (_row_reader_options.getSearchArgument() == nullptr) {
+        return "None";
+    } else {
+        return _row_reader_options.getSearchArgument()->toString();
+    }
 }
 
 } // namespace starrocks

--- a/be/src/formats/orc/orc_mapping.h
+++ b/be/src/formats/orc/orc_mapping.h
@@ -113,7 +113,6 @@ public:
 
 private:
     std::unordered_map<size_t, const OrcMappingOrcType> _mapping;
-    std::unordered_map<std::string, orc::Type*> _new_mapping;
 
     Status set_include_column_id_by_type(const OrcMappingPtr& mapping, const TypeDescriptor& desc,
                                          std::list<uint64_t>* column_id_list);

--- a/be/src/formats/orc/utils.h
+++ b/be/src/formats/orc/utils.h
@@ -20,6 +20,7 @@
 #include "cctz/civil_time.h"
 #include "cctz/time_zone.h"
 #include "column/vectorized_fwd.h"
+#include "exec/pipeline/operator.h"
 #include "formats/orc/orc_mapping.h"
 #include "gen_cpp/orc_proto.pb.h"
 #include "io/shared_buffered_input_stream.h"
@@ -27,6 +28,14 @@
 #include "types/timestamp_value.h"
 
 namespace starrocks {
+
+class OrcPredicates {
+public:
+    OrcPredicates(const std::vector<Expr*>* conjuncts, const RuntimeFilterProbeCollector* rf_collector)
+            : conjuncts(conjuncts), rf_collector(rf_collector) {}
+    const std::vector<Expr*>* conjuncts;
+    const RuntimeFilterProbeCollector* rf_collector;
+};
 
 class DiskRange {
 public:

--- a/be/test/formats/orc/orc_chunk_reader_test.cpp
+++ b/be/test/formats/orc/orc_chunk_reader_test.cpp
@@ -24,11 +24,13 @@
 
 #include "column/struct_column.h"
 #include "common/object_pool.h"
+#include "exprs/is_null_predicate.h"
+#include "formats/orc/memory_stream/MemoryInputStream.hh"
+#include "formats/orc/memory_stream/MemoryOutputStream.hh"
 #include "gen_cpp/Exprs_types.h"
 #include "gutil/strings/substitute.h"
 #include "runtime/descriptor_helper.h"
 #include "runtime/descriptors.h"
-#include "runtime/mem_tracker.h"
 #include "runtime/runtime_state.h"
 
 namespace starrocks {
@@ -390,10 +392,10 @@ TEST_F(OrcChunkReaderTest, SkipFileByConjunctsEQ) {
                                 lit_node);
     ExprContext* ctx = create_expr_context(&_pool, nodes);
     std::vector<Expr*> conjuncts = {ctx->root()};
-    reader.set_conjuncts(conjuncts);
+    OrcPredicates predicates{&conjuncts, nullptr};
 
     auto input_stream = orc::readLocalFile(default_orc_file);
-    reader.init(std::move(input_stream));
+    reader.init(std::move(input_stream), &predicates);
     uint64_t records = get_hit_rows(&reader);
     EXPECT_EQ(records, 0);
 }
@@ -413,10 +415,11 @@ TEST_F(OrcChunkReaderTest, SkipStripeByConjunctsEQ) {
                                 lit_node);
     ExprContext* ctx = create_expr_context(&_pool, nodes);
     std::vector<Expr*> conjuncts = {ctx->root()};
-    reader.set_conjuncts(conjuncts);
+    OrcPredicates predicates{&conjuncts, nullptr};
 
     auto input_stream = orc::readLocalFile(default_orc_file);
-    reader.init(std::move(input_stream));
+    auto st = reader.init(std::move(input_stream), &predicates);
+    ASSERT_TRUE(st.ok());
     uint64_t records = get_hit_rows(&reader);
     // at most read one stripe.
     EXPECT_LE(records, 4880);
@@ -444,10 +447,11 @@ TEST_F(OrcChunkReaderTest, SkipStripeByConjunctsInPred) {
                            lit_nodes);
     ExprContext* ctx = create_expr_context(&_pool, nodes);
     std::vector<Expr*> conjuncts = {ctx->root()};
-    reader.set_conjuncts(conjuncts);
+    OrcPredicates predicates{&conjuncts, nullptr};
 
     auto input_stream = orc::readLocalFile(default_orc_file);
-    reader.init(std::move(input_stream));
+    auto st = reader.init(std::move(input_stream), &predicates);
+    ASSERT_TRUE(st.ok());
     uint64_t records = get_hit_rows(&reader);
     EXPECT_LE(records, 0);
 }
@@ -2388,6 +2392,353 @@ TEST_F(OrcChunkReaderTest, DatetimeMicrosecond) {
         EXPECT_EQ("[2, 2006-01-02 07:04:05.900000]", result->debug_row(1));
         EXPECT_EQ("[3, 2006-01-02 07:04:05.999999]", result->debug_row(2));
         EXPECT_EQ("[4, 2006-01-02 07:04:05.999999]", result->debug_row(3));
+    }
+}
+
+/**
+ * struct<_col1:int,_col2:int>
+ * {"_col1":1,"_col2":10001}
+ * {"_col1":2,"_col2":10002}
+ * {"_col1":3,"_col2":10003}
+ * {"_col1":4,"_col2":10004}
+ * .....
+ */
+TEST_F(OrcChunkReaderTest, TestSearchArgumentWithUnmatchedColumnName) {
+    MemoryOutputStream buffer(1024000);
+
+    {
+        // prepare data
+        orc::WriterOptions writerOptions;
+        // force to make stripe every time.
+        writerOptions.setStripeSize(128);
+        writerOptions.setRowIndexStride(128);
+        ORC_UNIQUE_PTR<orc::Type> schema(orc::Type::buildTypeFromString("struct<_col1:int,_col2:int>"));
+        ORC_UNIQUE_PTR<orc::Writer> writer = createWriter(*schema, &buffer, writerOptions);
+
+        size_t batch_size = 128;
+        size_t batch_num = 3;
+        ORC_UNIQUE_PTR<orc::ColumnVectorBatch> batch = writer->createRowBatch(batch_size);
+        auto* root = dynamic_cast<orc::StructVectorBatch*>(batch.get());
+        auto* col1 = dynamic_cast<orc::LongVectorBatch*>(root->fields[0]);
+        auto* col2 = dynamic_cast<orc::LongVectorBatch*>(root->fields[1]);
+
+        size_t index = 1;
+        for (size_t k = 0; k < batch_num; k++) {
+            for (size_t i = 0; i < batch_size; i++) {
+                col1->data[i] = index;
+                col2->data[i] = 10000 + index;
+                index += 1;
+            }
+            col1->numElements = batch_size;
+            col2->numElements = batch_size;
+            root->numElements = batch_size;
+            writer->add(*batch);
+        }
+        writer->close();
+    }
+    SlotDesc col1{"col1", TypeDescriptor::from_logical_type(LogicalType::TYPE_INT)};
+    SlotDesc col2{"col2", TypeDescriptor::from_logical_type(LogicalType::TYPE_INT)};
+
+    SlotDesc slot_descs[] = {col1, col2, {""}};
+    std::vector<SlotDescriptor*> src_slot_descriptors;
+    ObjectPool pool;
+    create_slot_descriptors(_runtime_state.get(), &pool, &src_slot_descriptors, slot_descs);
+    std::vector<std::string> hive_column_names = {"col1", "col2"};
+
+    // filter all by col1
+    {
+        std::vector<TExprNode> nodes;
+        TExprNode lit_node = create_int_literal_node(TPrimitiveType::TINYINT, 0);
+        push_binary_pred_texpr_node(nodes, TExprOpcode::type::EQ, src_slot_descriptors[0], TPrimitiveType::TINYINT,
+                                    lit_node);
+        ExprContext* ctx = create_expr_context(&_pool, nodes);
+        std::vector<Expr*> conjuncts = {ctx->root()};
+        OrcPredicates predicates{&conjuncts, nullptr};
+
+        OrcChunkReader reader(_runtime_state->chunk_size(), src_slot_descriptors);
+        auto input_stream =
+                ORC_UNIQUE_PTR<orc::InputStream>(new MemoryInputStream(buffer.getData(), buffer.getLength()));
+        reader.set_hive_column_names(&hive_column_names);
+        Status st = reader.init(std::move(input_stream), &predicates);
+        ASSERT_TRUE(st.ok()) << st.message();
+        uint64_t records = get_hit_rows(&reader);
+        EXPECT_EQ(records, 0);
+    }
+
+    // filter all by col2
+    {
+        std::vector<TExprNode> nodes;
+        TExprNode lit_node = create_int_literal_node(TPrimitiveType::TINYINT, 100);
+        push_binary_pred_texpr_node(nodes, TExprOpcode::type::EQ, src_slot_descriptors[1], TPrimitiveType::TINYINT,
+                                    lit_node);
+        ExprContext* ctx = create_expr_context(&_pool, nodes);
+        std::vector<Expr*> conjuncts = {ctx->root()};
+        OrcPredicates predicates{&conjuncts, nullptr};
+
+        OrcChunkReader reader(_runtime_state->chunk_size(), src_slot_descriptors);
+        auto input_stream =
+                ORC_UNIQUE_PTR<orc::InputStream>(new MemoryInputStream(buffer.getData(), buffer.getLength()));
+        reader.set_hive_column_names(&hive_column_names);
+        Status st = reader.init(std::move(input_stream), &predicates);
+        ASSERT_TRUE(st.ok());
+        uint64_t records = get_hit_rows(&reader);
+        EXPECT_EQ(records, 0);
+    }
+
+    // filter partial by col1
+    {
+        std::vector<TExprNode> nodes;
+        TExprNode lit_node = create_int_literal_node(TPrimitiveType::INT, 130);
+        push_binary_pred_texpr_node(nodes, TExprOpcode::type::GT, src_slot_descriptors[0], TPrimitiveType::INT,
+                                    lit_node);
+        ExprContext* ctx = create_expr_context(&_pool, nodes);
+        std::vector<Expr*> conjuncts = {ctx->root()};
+        OrcPredicates predicates{&conjuncts, nullptr};
+
+        OrcChunkReader reader(_runtime_state->chunk_size(), src_slot_descriptors);
+        auto input_stream =
+                ORC_UNIQUE_PTR<orc::InputStream>(new MemoryInputStream(buffer.getData(), buffer.getLength()));
+        reader.set_hive_column_names(&hive_column_names);
+        Status st = reader.init(std::move(input_stream), &predicates);
+        ASSERT_TRUE(st.ok());
+        uint64_t records = get_hit_rows(&reader);
+        EXPECT_EQ(records, 256);
+    }
+
+    // filter partial by col2
+    {
+        std::vector<TExprNode> nodes;
+        TExprNode lit_node = create_int_literal_node(TPrimitiveType::INT, 130);
+        push_binary_pred_texpr_node(nodes, TExprOpcode::type::GT, src_slot_descriptors[1], TPrimitiveType::INT,
+                                    lit_node);
+        ExprContext* ctx = create_expr_context(&_pool, nodes);
+        std::vector<Expr*> conjuncts = {ctx->root()};
+        OrcPredicates predicates{&conjuncts, nullptr};
+
+        OrcChunkReader reader(_runtime_state->chunk_size(), src_slot_descriptors);
+        auto input_stream =
+                ORC_UNIQUE_PTR<orc::InputStream>(new MemoryInputStream(buffer.getData(), buffer.getLength()));
+        reader.set_hive_column_names(&hive_column_names);
+        Status st = reader.init(std::move(input_stream), &predicates);
+        ASSERT_TRUE(st.ok());
+        uint64_t records = get_hit_rows(&reader);
+        EXPECT_EQ(records, 384);
+    }
+
+    // filter nothing by col2
+    {
+        std::vector<TExprNode> nodes;
+        TExprNode lit_node = create_int_literal_node(TPrimitiveType::TINYINT, 100);
+        push_binary_pred_texpr_node(nodes, TExprOpcode::type::GT, src_slot_descriptors[1], TPrimitiveType::TINYINT,
+                                    lit_node);
+        ExprContext* ctx = create_expr_context(&_pool, nodes);
+        std::vector<Expr*> conjuncts = {ctx->root()};
+        OrcPredicates predicates{&conjuncts, nullptr};
+
+        OrcChunkReader reader(_runtime_state->chunk_size(), src_slot_descriptors);
+        auto input_stream =
+                ORC_UNIQUE_PTR<orc::InputStream>(new MemoryInputStream(buffer.getData(), buffer.getLength()));
+        reader.set_hive_column_names(&hive_column_names);
+        Status st = reader.init(std::move(input_stream), &predicates);
+        ASSERT_TRUE(st.ok());
+        uint64_t records = get_hit_rows(&reader);
+        EXPECT_EQ(records, 384);
+    }
+}
+
+/**
+ * struct<col1:int,col2:int, col3: struct<col4: int>>
+ * {"col1":1,"col2":10001, "col3": struct<"col4": 10001>}
+ * {"col1":2,"col2":10002, "col3": struct<"col4": 10002>}
+ * {"col1":3,"col2":10003, "col3": struct<"col4": 10003>}
+ * {"col1":4,"col2":10004, "col3": struct<"col4": 10004>}
+ * .....
+ */
+TEST_F(OrcChunkReaderTest, TestSearchArgumentWithMatchedColumnName) {
+    MemoryOutputStream buffer(1024000);
+
+    {
+        // prepare data
+        orc::WriterOptions writerOptions;
+        // force to make stripe every time.
+        writerOptions.setStripeSize(128);
+        writerOptions.setRowIndexStride(128);
+        ORC_UNIQUE_PTR<orc::Type> schema(
+                orc::Type::buildTypeFromString("struct<col1:int,col2:int,col3:struct<col4:int>>"));
+        ORC_UNIQUE_PTR<orc::Writer> writer = createWriter(*schema, &buffer, writerOptions);
+
+        size_t batch_size = 128;
+        size_t batch_num = 3;
+        ORC_UNIQUE_PTR<orc::ColumnVectorBatch> batch = writer->createRowBatch(batch_size);
+        auto* root = dynamic_cast<orc::StructVectorBatch*>(batch.get());
+        auto* col1 = dynamic_cast<orc::LongVectorBatch*>(root->fields[0]);
+        auto* col2 = dynamic_cast<orc::LongVectorBatch*>(root->fields[1]);
+        auto* col3 = dynamic_cast<orc::StructVectorBatch*>(root->fields[2]);
+        auto* col4 = dynamic_cast<orc::LongVectorBatch*>(col3->fields[0]);
+
+        size_t index = 1;
+        for (size_t k = 0; k < batch_num; k++) {
+            for (size_t i = 0; i < batch_size; i++) {
+                col1->data[i] = index;
+                col2->data[i] = 10000 + index;
+                col4->data[i] = 10000 + index;
+                index += 1;
+            }
+            col1->numElements = batch_size;
+            col2->numElements = batch_size;
+            root->numElements = batch_size;
+            writer->add(*batch);
+        }
+        writer->close();
+    }
+    SlotDesc col1{"col1", TypeDescriptor::from_logical_type(LogicalType::TYPE_INT)};
+    SlotDesc col2{"col2", TypeDescriptor::from_logical_type(LogicalType::TYPE_INT)};
+    TypeDescriptor col3_type = TypeDescriptor::from_logical_type(LogicalType::TYPE_STRUCT);
+    col3_type.field_names.emplace_back("col4");
+    col3_type.children.emplace_back(TypeDescriptor::from_logical_type(LogicalType::TYPE_INT));
+    SlotDesc col3{"col3", col3_type};
+
+    SlotDesc slot_descs[] = {col1, col2, col3, {""}};
+    std::vector<SlotDescriptor*> src_slot_descriptors;
+    ObjectPool pool;
+    create_slot_descriptors(_runtime_state.get(), &pool, &src_slot_descriptors, slot_descs);
+
+    // filter all by col1
+    {
+        std::vector<TExprNode> nodes;
+        TExprNode lit_node = create_int_literal_node(TPrimitiveType::INT, 0);
+        push_binary_pred_texpr_node(nodes, TExprOpcode::type::LT, src_slot_descriptors[0], TPrimitiveType::INT,
+                                    lit_node);
+        ExprContext* ctx = create_expr_context(&_pool, nodes);
+        std::vector<Expr*> conjuncts = {ctx->root()};
+        OrcPredicates predicates{&conjuncts, nullptr};
+
+        OrcChunkReader reader(_runtime_state->chunk_size(), src_slot_descriptors);
+        auto input_stream =
+                ORC_UNIQUE_PTR<orc::InputStream>(new MemoryInputStream(buffer.getData(), buffer.getLength()));
+        Status st = reader.init(std::move(input_stream), &predicates);
+        ASSERT_TRUE(st.ok()) << st.message();
+        uint64_t records = get_hit_rows(&reader);
+        EXPECT_EQ(records, 0);
+    }
+
+    // filter partial all by col1
+    {
+        std::vector<TExprNode> nodes;
+        TExprNode lit_node = create_int_literal_node(TPrimitiveType::INT, 50);
+        push_binary_pred_texpr_node(nodes, TExprOpcode::type::NE, src_slot_descriptors[0], TPrimitiveType::INT,
+                                    lit_node);
+        ExprContext* ctx = create_expr_context(&_pool, nodes);
+        std::vector<Expr*> conjuncts = {ctx->root()};
+        OrcPredicates predicates{&conjuncts, nullptr};
+
+        OrcChunkReader reader(_runtime_state->chunk_size(), src_slot_descriptors);
+        auto input_stream =
+                ORC_UNIQUE_PTR<orc::InputStream>(new MemoryInputStream(buffer.getData(), buffer.getLength()));
+        Status st = reader.init(std::move(input_stream), &predicates);
+        ASSERT_TRUE(st.ok()) << st.message();
+        uint64_t records = get_hit_rows(&reader);
+        EXPECT_EQ(records, 384);
+    }
+
+    // filter partial all by col1
+    {
+        std::vector<TExprNode> nodes;
+        TExprNode lit_node = create_int_literal_node(TPrimitiveType::INT, 129);
+        push_binary_pred_texpr_node(nodes, TExprOpcode::type::LT, src_slot_descriptors[0], TPrimitiveType::INT,
+                                    lit_node);
+        ExprContext* ctx = create_expr_context(&_pool, nodes);
+        std::vector<Expr*> conjuncts = {ctx->root()};
+        OrcPredicates predicates{&conjuncts, nullptr};
+
+        OrcChunkReader reader(_runtime_state->chunk_size(), src_slot_descriptors);
+        auto input_stream =
+                ORC_UNIQUE_PTR<orc::InputStream>(new MemoryInputStream(buffer.getData(), buffer.getLength()));
+        Status st = reader.init(std::move(input_stream), &predicates);
+        ASSERT_TRUE(st.ok()) << st.message();
+        uint64_t records = get_hit_rows(&reader);
+        EXPECT_EQ(records, 128);
+    }
+
+    // filter partial by col1
+    {
+        std::vector<TExprNode> nodes;
+        TExprNode lit_node = create_int_literal_node(TPrimitiveType::INT, 129);
+        push_binary_pred_texpr_node(nodes, TExprOpcode::type::LE, src_slot_descriptors[0], TPrimitiveType::INT,
+                                    lit_node);
+        ExprContext* ctx = create_expr_context(&_pool, nodes);
+        std::vector<Expr*> conjuncts = {ctx->root()};
+        OrcPredicates predicates{&conjuncts, nullptr};
+
+        OrcChunkReader reader(_runtime_state->chunk_size(), src_slot_descriptors);
+        auto input_stream =
+                ORC_UNIQUE_PTR<orc::InputStream>(new MemoryInputStream(buffer.getData(), buffer.getLength()));
+        Status st = reader.init(std::move(input_stream), &predicates);
+        ASSERT_TRUE(st.ok()) << st.message();
+        uint64_t records = get_hit_rows(&reader);
+        EXPECT_EQ(records, 256);
+    }
+
+    // filter col3 by is null
+    {
+        TExprNode expr_node;
+        expr_node.type = gen_type_desc(TPrimitiveType::BOOLEAN);
+        expr_node.node_type = TExprNodeType::FUNCTION_CALL;
+        expr_node.fn.name.function_name = "is_null_pred";
+        expr_node.__isset.fn = true;
+        std::unique_ptr<Expr> expr(VectorizedIsNullPredicateFactory::from_thrift(expr_node));
+
+        TExprNode slot_ref;
+        slot_ref.node_type = TExprNodeType::SLOT_REF;
+        slot_ref.__set_type(create_primitive_type_desc(TPrimitiveType::TINYINT));
+        slot_ref.num_children = 0;
+        slot_ref.__isset.slot_ref = true;
+        slot_ref.slot_ref.slot_id = 2;
+        slot_ref.slot_ref.tuple_id = 0;
+        slot_ref.__set_is_nullable(true);
+        std::unique_ptr<ColumnRef> column_ref = std::make_unique<ColumnRef>(slot_ref);
+        expr->add_child(column_ref.get());
+        std::vector<Expr*> conjuncts = {expr.get()};
+        OrcPredicates predicates{&conjuncts, nullptr};
+
+        OrcChunkReader reader(_runtime_state->chunk_size(), src_slot_descriptors);
+        auto input_stream =
+                ORC_UNIQUE_PTR<orc::InputStream>(new MemoryInputStream(buffer.getData(), buffer.getLength()));
+        Status st = reader.init(std::move(input_stream), &predicates);
+        ASSERT_TRUE(st.ok()) << st.message();
+        uint64_t records = get_hit_rows(&reader);
+        EXPECT_EQ(records, 0);
+    }
+
+    // filter col3 by is not null
+    {
+        TExprNode expr_node;
+        expr_node.type = gen_type_desc(TPrimitiveType::BOOLEAN);
+        expr_node.node_type = TExprNodeType::FUNCTION_CALL;
+        expr_node.fn.name.function_name = "is_not_null_pred";
+        expr_node.__isset.fn = true;
+        std::unique_ptr<Expr> expr(VectorizedIsNullPredicateFactory::from_thrift(expr_node));
+
+        TExprNode slot_ref;
+        slot_ref.node_type = TExprNodeType::SLOT_REF;
+        slot_ref.__set_type(create_primitive_type_desc(TPrimitiveType::TINYINT));
+        slot_ref.num_children = 0;
+        slot_ref.__isset.slot_ref = true;
+        slot_ref.slot_ref.slot_id = 2;
+        slot_ref.slot_ref.tuple_id = 0;
+        slot_ref.__set_is_nullable(true);
+        std::unique_ptr<ColumnRef> column_ref = std::make_unique<ColumnRef>(slot_ref);
+        expr->add_child(column_ref.get());
+        std::vector<Expr*> conjuncts = {expr.get()};
+        OrcPredicates predicates{&conjuncts, nullptr};
+
+        OrcChunkReader reader(_runtime_state->chunk_size(), src_slot_descriptors);
+        auto input_stream =
+                ORC_UNIQUE_PTR<orc::InputStream>(new MemoryInputStream(buffer.getData(), buffer.getLength()));
+        Status st = reader.init(std::move(input_stream), &predicates);
+        ASSERT_TRUE(st.ok()) << st.message();
+        uint64_t records = get_hit_rows(&reader);
+        EXPECT_EQ(records, 384);
     }
 }
 


### PR DESCRIPTION
## Why I'm doing:
Using orc's column id to push down predicates.

Previous unmerged pr: https://github.com/StarRocks/starrocks/pull/15798

## What I'm doing:
* Using column id to setup search argument
* Port some code from apache-orc
* Remove some unused codes.
* Add text compression and orc sargs in profile

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [x] 3.1
  - [ ] 3.0
  - [ ] 2.5
