### PR TITLE
[BugFix] Reset historical io stats after catch io profile

### DIFF
--- a/be/src/io/io_profiler.cpp
+++ b/be/src/io/io_profiler.cpp
@@ -308,6 +308,7 @@ std::string IOProfiler::profile_and_get_topn_stats_str(const std::string& mode, 
             ss << it << "\n";
         }
     }
+    IOProfiler::reset();
     return ss.str();
 }
 

--- a/be/src/io/io_profiler.cpp
+++ b/be/src/io/io_profiler.cpp
@@ -106,6 +106,10 @@ public:
 static std::mutex _io_stats_mutex;
 static std::unordered_set<IOStatEntry, IOStatEntryHash> _io_stats;
 
+bool IOProfiler::is_empty() {
+    return _io_stats.empty();
+}
+
 void IOProfiler::reset() {
     uint32_t old_mode = _context_io_mode.load();
     if (old_mode != IOMode::IOMODE_NONE) {

--- a/be/src/io/io_profiler.h
+++ b/be/src/io/io_profiler.h
@@ -71,6 +71,8 @@ public:
     static void take_tls_io_snapshot(IOStat* snapshot);
     static IOStat calculate_scoped_tls_io(const IOStat& snapshot);
 
+    static bool is_empty();
+
     class Scope {
     public:
         Scope() = delete;

--- a/be/test/io/io_profiler_test.cpp
+++ b/be/test/io/io_profiler_test.cpp
@@ -128,7 +128,6 @@ TEST(IOProfilerTest, test_profile_and_get_topn_stats) {
     IOProfiler::stop();
     ASSERT_FALSE(IOProfiler::is_empty());
     auto ret = IOProfiler::profile_and_get_topn_stats_str("all", 1, 1);
-    LOG(INFO) << ret;
     ASSERT_TRUE(IOProfiler::is_empty());
 }
 

--- a/be/test/io/io_profiler_test.cpp
+++ b/be/test/io/io_profiler_test.cpp
@@ -117,4 +117,19 @@ TEST(IOProfilerTest, test_context_io) {
     ASSERT_EQ(IOProfiler::IOMode::IOMODE_NONE, IOProfiler::get_context_io_mode());
 }
 
+TEST(IOProfilerTest, test_profile_and_get_topn_stats) {
+    auto scope = IOProfiler::scope(IOProfiler::TAG_LOAD, 2);
+    auto expect = IOProfiler::IOStat{0, 0, 0, 0, 0, 0};
+    ASSERT_OK(IOProfiler::start(IOProfiler::IOMode::IOMODE_ALL));
+    IOProfiler::add_read(4, 4000);
+    ADD_READ_IO_STAT(expect, 4, 0);
+    IOProfiler::add_write(4, 4000);
+    ADD_WRITE_IO_STAT(expect, 4, 0);
+    IOProfiler::stop();
+    ASSERT_FALSE(IOProfiler::is_empty());
+    auto ret = IOProfiler::profile_and_get_topn_stats_str("all", 1, 1);
+    LOG(INFO) << ret;
+    ASSERT_TRUE(IOProfiler::is_empty());
+}
+
 } // namespace starrocks


### PR DESCRIPTION
## Why I'm doing:
We can determine which tablets consume high IO by obtaining the IO profile, but the historical data included in the IO profile may affect the judgment.

## What I'm doing:

Clear the historical io stat data.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [x] 3.1
  - [x] 3.0
  - [x] 2.5
