### PR TITLE
[Enhancement] Support transparent union rewrite(Part 1)

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
@@ -1576,10 +1576,7 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
     private boolean enableMaterializedViewUnionRewrite = true;
 
     /**
-     * <= 0: default mode, only try to union all rewrite by logical plan tree after partition compensate
-     * 1: eager mode v1, try to pull up query's filter after union when query's output matches mv's define query
-     * which will increase union rewrite's ability.
-     * 2: eager mode v2, try to pull up query's filter after union as much as possible.
+     * see {@code MaterializedViewUnionRewriteMode} for more details.
      */
     @VarAttr(name = MATERIALIZED_VIEW_UNION_REWRITE_MODE)
     private int materializedViewUnionRewriteMode = 0;

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/MaterializationContext.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/MaterializationContext.java
@@ -20,7 +20,6 @@ import com.google.common.collect.Sets;
 import com.starrocks.catalog.MaterializedView;
 import com.starrocks.catalog.Table;
 import com.starrocks.common.Pair;
-import com.starrocks.qe.SessionVariable;
 import com.starrocks.sql.optimizer.base.ColumnRefFactory;
 import com.starrocks.sql.optimizer.operator.OperatorType;
 import com.starrocks.sql.optimizer.operator.logical.LogicalAggregationOperator;
@@ -29,7 +28,9 @@ import com.starrocks.sql.optimizer.operator.logical.LogicalScanOperator;
 import com.starrocks.sql.optimizer.operator.pattern.Pattern;
 import com.starrocks.sql.optimizer.operator.scalar.ColumnRefOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ScalarOperator;
+import com.starrocks.sql.optimizer.rule.transformation.materialization.MVCompensation;
 import com.starrocks.sql.optimizer.rule.transformation.materialization.MaterializedViewRewriter;
+import com.starrocks.sql.optimizer.rule.transformation.materialization.MvPartitionCompensator;
 import com.starrocks.sql.optimizer.rule.transformation.materialization.MvUtils;
 import com.starrocks.sql.optimizer.rule.transformation.materialization.TableScanDesc;
 import org.apache.commons.collections4.SetUtils;
@@ -39,12 +40,10 @@ import java.util.Comparator;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 
 import static com.starrocks.sql.optimizer.OptimizerTraceUtil.logMVRewrite;
-import static com.starrocks.sql.optimizer.rule.transformation.materialization.MvPartitionCompensator.isNeedCompensatePartitionPredicate;
 
 public class MaterializationContext {
     private final MaterializedView mv;
@@ -69,8 +68,6 @@ public class MaterializationContext {
 
     private final List<Table> baseTables;
 
-    private final Set<ColumnRefOperator> originQueryColumns;
-
     // tables both in query and mv
     private final List<Table> intersectingTables;
 
@@ -79,6 +76,9 @@ public class MaterializationContext {
     private final List<Integer> matchedGroups;
 
     private final ScalarOperator mvPartialPartitionPredicate;
+
+    // The output column refs of the MV which is ordered by user's select list.
+    private final List<ColumnRefOperator> mvOutputColumnRefs;
 
     // THe used count for MV used as the rewrite result in a query.
     // NOTE: mvUsedCount is a not exact value because MV may be rewritten multi times
@@ -91,7 +91,8 @@ public class MaterializationContext {
     // during one query, so it's safe to cache it and be used for each optimizer rule.
     // But it is different for each materialized view, compensate partition predicate from the plan's
     // `selectedPartitionIds`, and check `isNeedCompensatePartitionPredicate` to get more information.
-    private Optional<Boolean> isCompensatePartitionPredicateOpt = Optional.empty();
+    private MVCompensation mvMVCompensation = null;
+
     // Cache partition compensates predicates for each ScanNode and isCompensate pair.
     private Map<Pair<LogicalScanOperator, Boolean>, List<ScalarOperator>> scanOpToPartitionCompensatePredicates;
 
@@ -102,10 +103,10 @@ public class MaterializationContext {
                                   ColumnRefFactory mvColumnRefFactory,
                                   Set<String> mvPartitionNamesToRefresh,
                                   List<Table> baseTables,
-                                  Set<ColumnRefOperator> originQueryColumns,
                                   List<Table> intersectingTables,
                                   ScalarOperator mvPartialPartitionPredicate,
-                                  Set<String> refTableUpdatePartitionNames) {
+                                  Set<String> refTableUpdatePartitionNames,
+                                  List<ColumnRefOperator> mvOutputColumnRefs) {
         this.optimizerContext = optimizerContext;
         this.mv = mv;
         this.mvExpression = mvExpression;
@@ -113,11 +114,11 @@ public class MaterializationContext {
         this.mvColumnRefFactory = mvColumnRefFactory;
         this.mvPartitionNamesToRefresh = mvPartitionNamesToRefresh;
         this.baseTables = baseTables;
-        this.originQueryColumns = originQueryColumns;
         this.intersectingTables = intersectingTables;
         this.matchedGroups = Lists.newArrayList();
         this.mvPartialPartitionPredicate = mvPartialPartitionPredicate;
         this.refTableUpdatePartitionNames = refTableUpdatePartitionNames;
+        this.mvOutputColumnRefs = mvOutputColumnRefs;
         this.scanOpToPartitionCompensatePredicates = Maps.newHashMap();
     }
 
@@ -207,6 +208,10 @@ public class MaterializationContext {
             return MvUtils.isLogicalSPJG(mvExpression);
         }
         return MvUtils.isLogicalSPJ(mvExpression);
+    }
+
+    public List<ColumnRefOperator> getMvOutputColumnRefs() {
+        return mvOutputColumnRefs;
     }
 
     /**
@@ -422,18 +427,17 @@ public class MaterializationContext {
      *  means MV's partitions can cover all needed partitions from Query.
      * </p>
      */
-    public boolean getOrInitCompensatePartitionPredicate(OptExpression queryExpression) {
-        if (!isCompensatePartitionPredicateOpt.isPresent()) {
-            SessionVariable sessionVariable = optimizerContext.getSessionVariable();
+    public MVCompensation getOrInitMVCompensation(OptExpression queryExpression) {
+        if (mvMVCompensation == null) {
             // only set this when `queryExpression` contains ref table, otherwise the cached value maybe dirty.
-            isCompensatePartitionPredicateOpt = sessionVariable.isEnableMaterializedViewRewritePartitionCompensate() ?
-                    isNeedCompensatePartitionPredicate(queryExpression, this) : Optional.of(false);
+            this.mvMVCompensation = MvPartitionCompensator.getMvCompensation(queryExpression, this);
+            logMVRewrite(mv.getName(), "Init mv compensation: {}", mvMVCompensation);
         }
-        return isCompensatePartitionPredicateOpt.orElse(true);
+        return this.mvMVCompensation;
     }
 
-    public boolean isCompensatePartitionPredicate() {
-        return isCompensatePartitionPredicateOpt.orElse(true);
+    public MVCompensation getMvCompensation() {
+        return mvMVCompensation;
     }
 
     public Map<Pair<LogicalScanOperator, Boolean>, List<ScalarOperator>> getScanOpToPartitionCompensatePredicates() {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/OptimizerTraceUtil.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/OptimizerTraceUtil.java
@@ -51,10 +51,39 @@ public class OptimizerTraceUtil {
         });
     }
 
+    public static void logMVPrepare(String format, Object... object) {
+        Tracers.log(Tracers.Module.MV, input -> {
+            String str = MessageFormatter.arrayFormat(format, object).getMessage();
+            Object[] args = new Object[] {"GLOBAL", str};
+            return MessageFormatter.arrayFormat("[MV TRACE] [PREPARE {}] {}", args).getMessage();
+        });
+    }
+
+    public static void logMVPrepare(MaterializedView mv,
+                                    String format, Object... object) {
+        Tracers.log(Tracers.Module.MV, input -> {
+            String str = MessageFormatter.arrayFormat(format, object).getMessage();
+            Object[] args = new Object[] {mv == null ? "GLOBAL" : mv.getName(), str};
+            return MessageFormatter.arrayFormat("[MV TRACE] [PREPARE {}] {}", args).getMessage();
+        });
+    }
+
     public static void logMVRewrite(String mvName, String format, Object... objects) {
         Tracers.log(Tracers.Module.MV, input -> {
             String str = MessageFormatter.arrayFormat(format, objects).getMessage();
             return MessageFormatter.format("[MV TRACE] [REWRITE {}] {}", mvName, str).getMessage();
+        });
+    }
+
+    public static void logMVRewrite(MaterializationContext mvContext, String format, Object... object) {
+        Tracers.log(Tracers.Module.MV, input -> {
+            Object[] args = new Object[] {
+                    mvContext.getMv().getName(),
+                    mvContext.getOptimizerContext().isInMemoPhase(),
+                    MessageFormatter.arrayFormat(format, object).getMessage()
+            };
+            return MessageFormatter.arrayFormat("[MV TRACE] [REWRITE {}] [InMemo:{}] {}",
+                    args).getMessage();
         });
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/Operator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/Operator.java
@@ -60,6 +60,7 @@ public abstract class Operator {
     //  OP -->   EXTRA-OP    MV-SCAN  -->     UNION    MV-SCAN     ---> ....
     //                                       /      \
     //                                  EXTRA-OP    MV-SCAN
+    public static final int OP_UNION_ALL_BIT = 1 << 0;
     protected int opRuleMask = 0;
 
     // an operator logically equivalent to 'this' operator
@@ -151,8 +152,12 @@ public abstract class Operator {
         return opRuleMask;
     }
 
-    public void setOpRuleMask(int b) {
-        this.opRuleMask = b;
+    public void setOpRuleMask(int bit) {
+        this.opRuleMask |= bit;
+    }
+
+    public boolean isOpRuleMaskSet(int bit) {
+        return (opRuleMask & bit) != 0;
     }
 
     public Operator getEquivalentOp() {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/logical/LogicalOlapScanOperator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/logical/LogicalOlapScanOperator.java
@@ -228,7 +228,11 @@ public final class LogicalOlapScanOperator extends LogicalScanOperator {
         }
 
         public Builder setSelectedPartitionId(List<Long> selectedPartitionId) {
-            builder.selectedPartitionId = ImmutableList.copyOf(selectedPartitionId);
+            if (selectedPartitionId == null) {
+                builder.selectedPartitionId = null;
+            } else {
+                builder.selectedPartitionId = ImmutableList.copyOf(selectedPartitionId);
+            }
             return this;
         }
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MVColumnPruner.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MVColumnPruner.java
@@ -53,12 +53,15 @@ public class MVColumnPruner {
         }
     }
 
-    public OptExpression doPruneColumns(OptExpression project) {
-        Projection projection = project.getOp().getProjection();
+    public OptExpression doPruneColumns(OptExpression optExpression) {
+        Projection projection = optExpression.getOp().getProjection();
         // OptExpression after mv rewrite must have projection.
+        if (projection == null) {
+            return optExpression;
+        }
         Preconditions.checkState(projection != null);
         requiredOutputColumns = new ColumnRefSet(projection.getOutputColumns());
-        return project.getOp().accept(new ColumnPruneVisitor(), project, null);
+        return optExpression.getOp().accept(new ColumnPruneVisitor(), optExpression, null);
     }
 
     // Prune columns by top-down, only support SPJG/union operators.

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MVCompensation.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MVCompensation.java
@@ -1,0 +1,106 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.sql.optimizer.rule.transformation.materialization;
+
+import com.starrocks.catalog.PartitionKey;
+import com.starrocks.qe.SessionVariable;
+
+import java.util.List;
+
+/**
+ * MVCompensation is used to store the compensation information for materialized view in mv rewrite.
+ */
+public class MVCompensation {
+    // The session variable of the current query.
+    private final SessionVariable sessionVariable;
+    // The state of compensation.
+    private final MVTransparentState state;
+    // The partition ids of olap table that need to be compensated.
+    private final List<Long> olapCompensatePartitionIds;
+    // The partition keys of external table that need to be compensated.
+    private final List<PartitionKey> externalCompensatePartitionKeys;
+    private final MVUnionRewriteMode unionRewriteMode;
+
+    public MVCompensation(SessionVariable sessionVariable,
+                          MVTransparentState state,
+                          List<Long> olapCompensatePartitionIds,
+                          List<PartitionKey> externalCompensatePartitionKeys) {
+        this.sessionVariable = sessionVariable;
+        this.state = state;
+        this.olapCompensatePartitionIds = olapCompensatePartitionIds;
+        this.externalCompensatePartitionKeys = externalCompensatePartitionKeys;
+        this.unionRewriteMode = MVUnionRewriteMode.getInstance(sessionVariable.getMaterializedViewUnionRewriteMode());
+    }
+
+    public static MVCompensation createNoCompensateState(SessionVariable sessionVariable) {
+        return new MVCompensation(sessionVariable, MVTransparentState.NO_COMPENSATE, null, null);
+    }
+
+    public static MVCompensation createNoRewriteState(SessionVariable sessionVariable) {
+        return new MVCompensation(sessionVariable, MVTransparentState.NO_REWRITE, null, null);
+    }
+
+    public static MVCompensation createUnkownState(SessionVariable sessionVariable) {
+        return new MVCompensation(sessionVariable, MVTransparentState.UNKNOWN, null, null);
+    }
+
+    public MVTransparentState getState() {
+        return state;
+    }
+
+    public List<Long> getOlapCompensatePartitionIds() {
+        return olapCompensatePartitionIds;
+    }
+
+    public List<PartitionKey> getExternalCompensatePartitionKeys() {
+        return externalCompensatePartitionKeys;
+    }
+
+    public boolean isTransparentRewrite() {
+        if (!unionRewriteMode.isTransparentRewrite()) {
+            return false;
+        }
+
+        // No compensate once if mv's freshness is satisfied.
+        if (state.isPrunedCompensate()) {
+            return true;
+        }
+
+        return false;
+    }
+
+    public boolean isCompensatePartitionPredicate() {
+        // always false if it's set to false from session variable
+        if (!sessionVariable.isEnableMaterializedViewRewritePartitionCompensate()) {
+            return false;
+        }
+        if (state.isNoCompensate()) {
+            return false;
+        } else if (state.isPrunedCompensate()) {
+            return !unionRewriteMode.isTransparentRewrite();
+        } else {
+            return true;
+        }
+    }
+
+    @Override
+    public String toString() {
+        return "MvCompensation{" +
+                "state=" + state +
+                ", olapCompensatePartitionIds=" + olapCompensatePartitionIds +
+                ", externalCompensatePartitionKeys=" + externalCompensatePartitionKeys +
+                '}';
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MVPartitionPruner.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MVPartitionPruner.java
@@ -14,7 +14,13 @@
 
 package com.starrocks.sql.optimizer.rule.transformation.materialization;
 
+import com.google.common.base.Preconditions;
 import com.google.common.collect.Lists;
+import com.starrocks.analysis.TableName;
+import com.starrocks.catalog.IcebergTable;
+import com.starrocks.catalog.Table;
+import com.starrocks.common.AnalysisException;
+import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.sql.optimizer.MvRewriteContext;
 import com.starrocks.sql.optimizer.OptExpression;
 import com.starrocks.sql.optimizer.OptExpressionVisitor;
@@ -22,6 +28,8 @@ import com.starrocks.sql.optimizer.OptimizerContext;
 import com.starrocks.sql.optimizer.Utils;
 import com.starrocks.sql.optimizer.operator.Operator;
 import com.starrocks.sql.optimizer.operator.OperatorBuilderFactory;
+import com.starrocks.sql.optimizer.operator.OperatorType;
+import com.starrocks.sql.optimizer.operator.ScanOperatorPredicates;
 import com.starrocks.sql.optimizer.operator.logical.LogicalDeltaLakeScanOperator;
 import com.starrocks.sql.optimizer.operator.logical.LogicalEsScanOperator;
 import com.starrocks.sql.optimizer.operator.logical.LogicalFileScanOperator;
@@ -37,6 +45,8 @@ import com.starrocks.sql.optimizer.rewrite.OptOlapPartitionPruner;
 
 import java.util.List;
 
+import static com.starrocks.sql.optimizer.rule.transformation.materialization.MvPartitionCompensator.SUPPORTED_PARTITION_COMPENSATE_EXTERNAL_SCAN_TYPES;
+
 public class MVPartitionPruner {
     private final OptimizerContext optimizerContext;
     private final MvRewriteContext mvRewriteContext;
@@ -50,7 +60,26 @@ public class MVPartitionPruner {
         return queryExpression.getOp().accept(new MVPartitionPrunerVisitor(), queryExpression, null);
     }
 
-    private class MVPartitionPrunerVisitor extends OptExpressionVisitor<OptExpression, Void> {
+    /**
+     * For input query expression, reset/clear pruned partitions and return new query expression to be pruned again.
+     * @param optExpression: optExpression of input query
+     * @return: a new query expression with pruned partitions cleared
+     */
+    public static OptExpression resetSelectedPartitions(OptExpression optExpression) {
+        return optExpression.getOp().accept(new SelectedPartitionCleanerVisitor(), optExpression, null);
+    }
+
+    public static LogicalOlapScanOperator resetSelectedPartitions(LogicalOlapScanOperator olapScanOperator) {
+        final LogicalOlapScanOperator.Builder mvScanBuilder = OperatorBuilderFactory.build(olapScanOperator);
+        // reset original partition predicates to prune partitions/tablets again
+        mvScanBuilder.withOperator(olapScanOperator)
+                .setSelectedPartitionId(null)
+                .setPrunedPartitionPredicates(Lists.newArrayList())
+                .setSelectedTabletId(Lists.newArrayList());
+        return mvScanBuilder.build();
+    }
+
+    private static class SelectedPartitionCleanerVisitor extends OptExpressionVisitor<OptExpression, Void> {
         @Override
         public OptExpression visitLogicalTableScan(OptExpression optExpression, Void context) {
             LogicalScanOperator scanOperator = optExpression.getOp().cast();
@@ -61,12 +90,37 @@ public class MVPartitionPruner {
                 // MV   : select c1, c3, c2 from test_base_part where c2 < 2000
                 // Query: select c1, c3, c2 from test_base_part where c2 < 3000 and c3 < 3000
                 LogicalOlapScanOperator olapScanOperator = (LogicalOlapScanOperator) (scanOperator);
-                LogicalOlapScanOperator.Builder builder = new LogicalOlapScanOperator.Builder();
-                builder.withOperator(olapScanOperator)
-                        .setPrunedPartitionPredicates(Lists.newArrayList())
-                        .setSelectedPartitionId(Lists.newArrayList())
-                        .setSelectedTabletId(Lists.newArrayList());
+                LogicalScanOperator newOlapScanOperator = resetSelectedPartitions(olapScanOperator);
+                return OptExpression.create(newOlapScanOperator);
+            } else {
+                try {
+                    ScanOperatorPredicates operatorPredicates = scanOperator.getScanOperatorPredicates();
+                    operatorPredicates.clear();
+                } catch (AnalysisException e) {
+                    // ignore
+                }
+                return optExpression;
+            }
+        }
 
+        public OptExpression visit(OptExpression optExpression, Void context) {
+            List<OptExpression> children = Lists.newArrayList();
+            for (int i = 0; i < optExpression.arity(); ++i) {
+                children.add(optExpression.inputAt(i).getOp().accept(this, optExpression.inputAt(i), null));
+            }
+            return OptExpression.create(optExpression.getOp(), children);
+        }
+    }
+
+    private class MVPartitionPrunerVisitor extends OptExpressionVisitor<OptExpression, Void> {
+        @Override
+        public OptExpression visitLogicalTableScan(OptExpression optExpression, Void context) {
+            LogicalScanOperator scanOperator = optExpression.getOp().cast();
+
+            if (scanOperator instanceof LogicalOlapScanOperator) {
+                LogicalOlapScanOperator.Builder builder = new LogicalOlapScanOperator.Builder();
+                LogicalOlapScanOperator olapScanOperator = (LogicalOlapScanOperator) (scanOperator);
+                builder.withOperator(olapScanOperator);
                 // for mv: select c1, c3, c2 from test_base_part where c3 < 2000 and c1 = 1,
                 // which c3 is partition column and c1 is distribution column.
                 // we should add predicate c3 < 2000 and c1 = 1 into scan operator to do pruning
@@ -78,29 +132,31 @@ public class MVPartitionPruner {
                     ScalarOperator newPredicate = Utils.compoundAnd(originPredicate, mvRewriteContext.getMvPruneConjunct());
                     builder.setPredicate(newPredicate);
                 }
-                LogicalOlapScanOperator copiedOlapScanOperator = builder.build();
+                LogicalOlapScanOperator newOlapScanOperator = builder.build();
 
                 // prune partition
-                final LogicalOlapScanOperator prunedOlapScanOperator =
-                        OptOlapPartitionPruner.prunePartitions(copiedOlapScanOperator);
+                List<Long> selectedPartitionIds = olapScanOperator.getSelectedPartitionId();
+                if (selectedPartitionIds == null || selectedPartitionIds.isEmpty()) {
+                    newOlapScanOperator =  OptOlapPartitionPruner.prunePartitions(newOlapScanOperator);
+                }
 
                 // prune distribution key
-                copiedOlapScanOperator.buildColumnFilters(prunedOlapScanOperator.getPredicate());
-                List<Long> selectedTabletIds = OptDistributionPruner.pruneTabletIds(copiedOlapScanOperator,
-                        prunedOlapScanOperator.getSelectedPartitionId());
+                newOlapScanOperator.buildColumnFilters(newOlapScanOperator.getPredicate());
+                List<Long> selectedTabletIds = OptDistributionPruner.pruneTabletIds(newOlapScanOperator,
+                        newOlapScanOperator.getSelectedPartitionId());
 
-                ScalarOperator scanPredicate = prunedOlapScanOperator.getPredicate();
+                ScalarOperator scanPredicate = newOlapScanOperator.getPredicate();
                 if (isAddMvPrunePredicate) {
                     List<ScalarOperator> originConjuncts = Utils.extractConjuncts(scanOperator.getPredicate());
                     List<ScalarOperator> pruneConjuncts = Utils.extractConjuncts(mvRewriteContext.getMvPruneConjunct());
                     pruneConjuncts.removeAll(originConjuncts);
-                    List<ScalarOperator> currentConjuncts = Utils.extractConjuncts(prunedOlapScanOperator.getPredicate());
+                    List<ScalarOperator> currentConjuncts = Utils.extractConjuncts(newOlapScanOperator.getPredicate());
                     currentConjuncts.removeAll(pruneConjuncts);
                     scanPredicate = Utils.compoundAnd(currentConjuncts);
                 }
 
                 LogicalOlapScanOperator.Builder rewrittenBuilder = new LogicalOlapScanOperator.Builder();
-                scanOperator = rewrittenBuilder.withOperator(prunedOlapScanOperator)
+                scanOperator = rewrittenBuilder.withOperator(newOlapScanOperator)
                         .setPredicate(MvUtils.canonizePredicate(scanPredicate))
                         .setSelectedTabletId(selectedTabletIds)
                         .build();
@@ -119,6 +175,107 @@ public class MVPartitionPruner {
             return OptExpression.create(scanOperator);
         }
 
+        public OptExpression visit(OptExpression optExpression, Void context) {
+            List<OptExpression> children = Lists.newArrayList();
+            for (int i = 0; i < optExpression.arity(); ++i) {
+                children.add(optExpression.inputAt(i).getOp().accept(this, optExpression.inputAt(i), null));
+            }
+            return OptExpression.create(optExpression.getOp(), children);
+        }
+    }
+
+    /**
+     * Rewrite specific olap scan operator with specific selected partition ids.
+     */
+    public static OptExpression getOlapTableCompensatePlan(OptExpression optExpression,
+                                                           LogicalScanOperator mvRefScanOperator,
+                                                           List<Long> refTableCompensatePartitionIds) {
+        OptScanOperatorCompensator scanOperatorCompensator = new OptScanOperatorCompensator(
+                refTableCompensatePartitionIds, mvRefScanOperator);
+        return optExpression.getOp().accept(scanOperatorCompensator, optExpression, null);
+    }
+
+    /**
+     * Rewrite specific external scan operator with specific selected partition ids.
+     */
+    public static OptExpression getExternalTableCompensatePlan(OptExpression optExpression,
+                                                               LogicalScanOperator mvRefScanOperator,
+                                                               ScalarOperator extraPredicate) {
+        OptScanOperatorCompensator scanOperatorCompensator = new OptScanOperatorCompensator(
+                mvRefScanOperator, extraPredicate);
+        return optExpression.getOp().accept(scanOperatorCompensator, optExpression, null);
+    }
+
+    /**
+     * Rewrite specific olap scan operator with specific selected partition ids.
+     */
+    static class OptScanOperatorCompensator extends OptExpressionVisitor<OptExpression, Void> {
+        private final List<Long> olapTableCompensatePartitionIds;
+        private final LogicalScanOperator refScanOperator;
+        private final ScalarOperator externalExtraPredicate;
+
+        // for olap table
+        public OptScanOperatorCompensator(List<Long> refTableCompensatePartitionIds,
+                                          LogicalScanOperator scanOperator) {
+            this.refScanOperator = scanOperator;
+            this.olapTableCompensatePartitionIds = refTableCompensatePartitionIds;
+            this.externalExtraPredicate = null;
+        }
+
+        // for external table
+        public OptScanOperatorCompensator(LogicalScanOperator mvRefScanOperator,
+                                          ScalarOperator extraPredicate) {
+            this.refScanOperator = mvRefScanOperator;
+            this.olapTableCompensatePartitionIds = null;
+            this.externalExtraPredicate = extraPredicate;
+        }
+
+        @Override
+        public OptExpression visitLogicalTableScan(OptExpression optExpression, Void context) {
+            LogicalScanOperator scanOperator = optExpression.getOp().cast();
+            if (scanOperator != refScanOperator) {
+                return optExpression;
+            }
+            if (scanOperator instanceof LogicalOlapScanOperator) {
+                LogicalOlapScanOperator olapScanOperator = (LogicalOlapScanOperator) scanOperator;
+                final LogicalOlapScanOperator.Builder builder = new LogicalOlapScanOperator.Builder();
+                Preconditions.checkState(olapTableCompensatePartitionIds != null);
+                // reset original partition predicates to prune partitions/tablets again
+                builder.withOperator(olapScanOperator)
+                        .setSelectedPartitionId(olapTableCompensatePartitionIds)
+                        .setSelectedTabletId(Lists.newArrayList());
+
+                return OptExpression.create(builder.build());
+            } else if (SUPPORTED_PARTITION_COMPENSATE_EXTERNAL_SCAN_TYPES.contains(scanOperator.getOpType())) {
+                final LogicalScanOperator.Builder builder = OperatorBuilderFactory.build(refScanOperator);
+                // reset original partition predicates to prune partitions/tablets again
+                builder.withOperator(refScanOperator);
+
+                Preconditions.checkState(externalExtraPredicate != null);
+                ScalarOperator finalPredicate = Utils.compoundAnd(refScanOperator.getPredicate(), externalExtraPredicate);
+                builder.setPredicate(finalPredicate);
+                if (scanOperator.getOpType() == OperatorType.LOGICAL_ICEBERG_SCAN) {
+                    // refresh iceberg table's metadata
+                    Table refBaseTable = refScanOperator.getTable();
+                    IcebergTable cachedIcebergTable = (IcebergTable) refBaseTable;
+                    String catalogName = cachedIcebergTable.getCatalogName();
+                    String dbName = cachedIcebergTable.getRemoteDbName();
+                    TableName tableName = new TableName(catalogName, dbName, cachedIcebergTable.getName());
+                    Table currentTable = GlobalStateMgr.getCurrentState().getMetadataMgr().getTable(tableName).orElse(null);
+                    if (currentTable == null) {
+                        return null;
+                    }
+                    // Iceberg table's snapshot is cached in the mv's plan cache, need to reset it to get the latest snapshot
+                    builder.setTable(currentTable);
+                }
+                LogicalScanOperator newScanOperator = builder.build();
+                return OptExpression.create(newScanOperator);
+            } else {
+                return optExpression;
+            }
+        }
+
+        @Override
         public OptExpression visit(OptExpression optExpression, Void context) {
             List<OptExpression> children = Lists.newArrayList();
             for (int i = 0; i < optExpression.arity(); ++i) {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MVTransparentState.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MVTransparentState.java
@@ -1,0 +1,43 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.sql.optimizer.rule.transformation.materialization;
+
+/**
+ * TransparentState means different compensate type for the specific mv and query plan:
+ * - NO_REWRITE: When mv's refreshed partitions are not intersected with query's selected partitions, no need to rewrite.
+ * - NO_COMPENSATE: When mv's refreshed partitions are intersected with query's selected partitions, but mv's
+ *      refreshed partitions are satisfied with query's selected partitions.
+ * - COMPENSATE: When mv's refreshed partitions are intersected with query's selected partitions(partial pruned), but
+ *   mv's refreshed partitions are not satisfied with query's selected partitions.
+ * - UNKNOWN: others we set it unknown.
+ */
+public enum MVTransparentState {
+    NO_REWRITE,
+    NO_COMPENSATE,
+    COMPENSATE,
+    UNKNOWN;
+
+    public boolean isNoRewrite() {
+        return this == NO_REWRITE;
+    }
+
+    public boolean isNoCompensate() {
+        return this == NO_COMPENSATE;
+    }
+
+    public boolean isPrunedCompensate() {
+        return this == COMPENSATE;
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MVUnionRewriteMode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MVUnionRewriteMode.java
@@ -1,0 +1,143 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.sql.optimizer.rule.transformation.materialization;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * MVUnionRewriteMode is used to store union rewrite mode for materialized view union.
+ * The mode is used to control the union rewrite behavior:
+ *
+ * <p>Default mode</p>
+ * Query = MV + (Query - MV)
+ * Query - MV = not(Query Based MV Rewrite Compensation)
+ * eg:
+ *  query   : select * from t where a > 10
+ *  mv      : select * from t where a > 20
+ *
+ * Because MV = (Query) where a > 20
+ * Query Based MV Rewrite Compensation: a > 20
+ * Query - MV = not (Query Based MV Rewrite Compensation) and Query's predicates
+ *            = not (a > 20) and a > 10
+ *            = (a <= 20 or a is null) and a > 10
+ *            = 10 < a <= 20
+ *
+ * Query = MV + (Query - MV)
+ *       = MVBasedRewrite + QueryBasedRewrite(not mv to query compensation)
+ *       = (select * from t where a > 10) union all (select * from t where 10 < a <= 20)
+ *       = MV + (select * from t where 10 < a <= 20)
+ *
+ * <p>Pull Predicate V1 </p>
+ * Default mode needs query can be used for rewrite for mv's define query which is not always satisfied.
+ * But we can pull up some predicates to increase the ability of union rewrite.
+ *
+ * eg:
+ * Query: select dt, k1, k2 from tblA where dt >= '2023-11-01' and k2 > 1
+ *  MV  : select dt, k2 from tblA where dt = '2023-11-01'
+ *
+ * At default mode, query cannot be rewritten by mv's define query, but if we pull up some predicates to Query' and then
+ * it will be rewritten for mv.
+ *
+ *  Query'      : select dt, k1, k2 from tblA where dt >= '2023-11-01
+ *  MV          : select dt, k2 from tblA where dt = '2023-11-01'
+ *  PullUp Query: Query' where k2 > 1
+ *
+ * So Query' can be rewritten by mv's define query, only need add extra predicates after rewrite.
+ *
+ * <p>Pull Predicate V2 </p>
+ * Pull Predicate V1 only pull predicates that are not contained in MV's define query, but v2 can pull up all predicates
+ * Query: select dt, k2 from tblA where date_trunc('day', dt) >= '2023-11-01'
+ * Mv   : select dt, k2 from tblA where dt = '2023-11-01'
+ *
+ * Query'       :  select dt, k2 from tblA
+ * Pull up Query: Query' where date_trunc('day', dt) >= '2023-11-01'
+ *
+ *<p> Transparent Union Rewrite </p>
+ * If predicates are partition predicates(eg, query refreshed partitions and to-refresh partitions), we can use treat mv as a
+ * transparent table(freshness is always satisfied) and rewrite by union all.
+ *
+ * MV   : select * from t, but only refreshed partitions(dt = '2023-11-01')
+ * Query: select col1, col2 from t where dt in ('2023-11-01', '2023-11-02')
+ *
+ * In this case we can not use other modes to rewrite, since query cannot be rewritten by mv's define query(query only selects
+ * partial columns and mv's partial refreshed).
+ *
+ * If we treat mv as complete refreshed, we can rewrite it.
+ *
+ * Transparent MV: select * from t(all partition refreshed) union all select * from mv's defined query(all to-refresh partitions)
+ *
+ * Query            : select col1, col2 from t where dt in ('2023-11-01', '2023-11-02')
+ * Query Rewritten  : select col1, col2 from <Transparent MV> where dt in ('2023-11-01', '2023-11-02')
+ * Transparent MV   : Refreshed MV Partitions union all To-Refresh MV Partitions
+ *                = select * from mv where dt = '2023-11-01' union all select * from t where dt = '2023-11-02';
+ *
+ * so the final Query Rewritten:
+ * Query Rewritten: select col1, col2 from <Transparent MV> where dt in ('2023-11-01', '2023-11-02')
+ *  = select col1, col2 from (select * from mv where dt = '2023-11-01' union all select * from t where dt = '2023-11-02')
+ *      where dt in ('2023-11-01', '2023-11-02')
+ *  = select col1, col2 from mv where dt = '2023-11-01' union all select col1, col2 from t where dt = '2023-11-02'
+ *
+ * <p>Enum</p>
+ *  default: default mode, only try to union all rewrite by logical plan tree after partition compensate
+ *  1: pull predicate v1, try to pull up query's filter after union when query's output matches mv's define query
+ *      which will increase union rewrite's ability, and then use query to rewrite mv's define query.
+ *  2: pull predicate v2, try to pull up query's filter after union as much as possible.
+ *  3: transparent union all rewrite, treat mv as a transparent table(freshness is always satisfied) and rewrite by union all.
+ */
+public enum MVUnionRewriteMode {
+    DEFAULT(0),
+    PULL_PREDICATE_V1(1),
+    PULL_PREDICATE_V2(2),
+    TRANSPARENT(3);
+
+    private final int ordinal;
+
+    MVUnionRewriteMode(int ordinal) {
+        this.ordinal = ordinal;
+    }
+
+    public int getOrdinal() {
+        return ordinal;
+    }
+
+    public boolean isPullPredicateRewrite() {
+        return this == PULL_PREDICATE_V1 || this == PULL_PREDICATE_V2;
+    }
+
+    public boolean isTransparentRewrite() {
+        return this == TRANSPARENT;
+    }
+
+    public boolean isPullPredicateRewriteV2() {
+        return this == PULL_PREDICATE_V2;
+    }
+
+    public static Map<Integer, MVUnionRewriteMode> ordinalMap = getOrdinalMap();
+    public static Map<Integer, MVUnionRewriteMode> getOrdinalMap() {
+        Map<Integer, MVUnionRewriteMode> ordinalMap = new HashMap<>();
+        for (MVUnionRewriteMode mode : MVUnionRewriteMode.values()) {
+            ordinalMap.put(mode.ordinal, mode);
+        }
+        return ordinalMap;
+    }
+
+    public static MVUnionRewriteMode getInstance(int ordinal) {
+        if (ordinalMap.containsKey(ordinal)) {
+            return ordinalMap.get(ordinal);
+        }
+        return DEFAULT;
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvPartitionCompensator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvPartitionCompensator.java
@@ -43,6 +43,7 @@ import com.starrocks.common.UserException;
 import com.starrocks.common.util.DateUtils;
 import com.starrocks.common.util.DebugUtil;
 import com.starrocks.connector.PartitionUtil;
+import com.starrocks.qe.SessionVariable;
 import com.starrocks.sql.analyzer.RelationFields;
 import com.starrocks.sql.analyzer.RelationId;
 import com.starrocks.sql.analyzer.Scope;
@@ -50,10 +51,12 @@ import com.starrocks.sql.optimizer.MaterializationContext;
 import com.starrocks.sql.optimizer.OptExpression;
 import com.starrocks.sql.optimizer.Utils;
 import com.starrocks.sql.optimizer.base.ColumnRefFactory;
+import com.starrocks.sql.optimizer.operator.OperatorBuilderFactory;
 import com.starrocks.sql.optimizer.operator.OperatorType;
 import com.starrocks.sql.optimizer.operator.ScanOperatorPredicates;
 import com.starrocks.sql.optimizer.operator.logical.LogicalOlapScanOperator;
 import com.starrocks.sql.optimizer.operator.logical.LogicalScanOperator;
+import com.starrocks.sql.optimizer.operator.logical.LogicalUnionOperator;
 import com.starrocks.sql.optimizer.operator.logical.LogicalViewScanOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ColumnRefOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ConstantOperator;
@@ -72,7 +75,11 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 
+import static com.starrocks.connector.PartitionUtil.generateMVPartitionName;
 import static com.starrocks.sql.optimizer.OptimizerTraceUtil.logMVRewrite;
+import static com.starrocks.sql.optimizer.operator.Operator.OP_UNION_ALL_BIT;
+import static com.starrocks.sql.optimizer.rule.transformation.materialization.MvUtils.deriveLogicalProperty;
+import static com.starrocks.sql.optimizer.rule.transformation.materialization.MvUtils.mergeRanges;
 
 /**
  * This class represents all partition compensations for partition predicates in a materialized view.
@@ -107,14 +114,14 @@ public class MvPartitionCompensator {
      * @return Optional<Boolean>: if `queryPlan` contains ref table, Optional is set and return whether mv can satisfy
      * query plan's freshness, other Optional.empty() is returned.
      */
-    public static Optional<Boolean> isNeedCompensatePartitionPredicate(OptExpression queryPlan,
-                                                                       MaterializationContext mvContext) {
+    public static MVCompensation getMvCompensation(OptExpression queryPlan,
+                                                   MaterializationContext mvContext) {
+        SessionVariable sessionVariable = mvContext.getOptimizerContext().getSessionVariable();
         Set<String> mvPartitionNameToRefresh = mvContext.getMvPartitionNamesToRefresh();
         // If mv contains no partitions to refresh, no need compensate
         if (Objects.isNull(mvPartitionNameToRefresh) || mvPartitionNameToRefresh.isEmpty()) {
-            return Optional.of(false);
+            return MVCompensation.createNoCompensateState(sessionVariable);
         }
-
         // If ref table contains no partitions to refresh, no need compensate.
         // If the mv is partitioned and non-ref table need refresh, then all partitions need to be refreshed,
         // it can not be a candidate.
@@ -122,87 +129,309 @@ public class MvPartitionCompensator {
         if (Objects.isNull(refTablePartitionNameToRefresh) || refTablePartitionNameToRefresh.isEmpty()) {
             // NOTE: This should not happen: `mvPartitionNameToRefresh` is not empty, so `refTablePartitionNameToRefresh`
             // should not empty. Return true in the situation to avoid bad cases.
-            return Optional.of(true);
+            return MVCompensation.createNoCompensateState(sessionVariable);
         }
 
         List<LogicalScanOperator> scanOperators = MvUtils.getScanOperator(queryPlan);
         // If no scan operator, no need compensate
         if (scanOperators.isEmpty()) {
-            return Optional.of(false);
+            return MVCompensation.createUnkownState(sessionVariable);
         }
         if (scanOperators.stream().anyMatch(scan -> scan instanceof LogicalViewScanOperator)) {
-            return Optional.of(true);
+            return MVCompensation.createUnkownState(sessionVariable);
         }
 
         // If no partition table and columns, no need compensate
         MaterializedView mv = mvContext.getMv();
         Pair<Table, Column> partitionTableAndColumns = mv.getDirectTableAndPartitionColumn();
         if (partitionTableAndColumns == null) {
-            return Optional.of(false);
+            return MVCompensation.createUnkownState(sessionVariable);
         }
 
         // only set this when `queryExpression` contains ref table, otherwise the cached value maybe dirty.
         Table refBaseTable = partitionTableAndColumns.first;
         LogicalScanOperator refScanOperator = getRefBaseTableScanOperator(scanOperators, refBaseTable);
         if (refScanOperator == null) {
-            return Optional.empty();
+            return MVCompensation.createUnkownState(sessionVariable);
         }
 
         Table table = refScanOperator.getTable();
         // If table's not partitioned, no need compensate
         if (table.isUnPartitioned()) {
-            return Optional.of(false);
+            // TODO: Support this later.
+            return MVCompensation.createUnkownState(sessionVariable);
         }
 
         if (refScanOperator instanceof LogicalOlapScanOperator) {
-            LogicalOlapScanOperator olapScanOperator = (LogicalOlapScanOperator) refScanOperator;
-            OlapTable olapTable = (OlapTable) olapScanOperator.getTable();
-
-            List<Long> selectPartitionIds = olapScanOperator.getSelectedPartitionId();
-            if (Objects.isNull(selectPartitionIds) || selectPartitionIds.size() == 0) {
-                return Optional.of(false);
-            }
-
-            // determine whether query's partitions can be satisfied by materialized view.
-            for (Long selectPartitionId : selectPartitionIds) {
-                Partition partition = olapTable.getPartition(selectPartitionId);
-                if (partition != null && refTablePartitionNameToRefresh.contains(partition.getName())) {
-                    return Optional.of(true);
-                }
-            }
-            return Optional.of(false);
+            return getMvCompensationForOlap(sessionVariable, refBaseTable, refTablePartitionNameToRefresh,
+                    (LogicalOlapScanOperator) refScanOperator);
         } else if (SUPPORTED_PARTITION_COMPENSATE_EXTERNAL_SCAN_TYPES.contains(refScanOperator.getOpType())) {
-            try {
-                ScanOperatorPredicates scanOperatorPredicates = refScanOperator.getScanOperatorPredicates();
-                if (scanOperatorPredicates == null) {
-                    return Optional.of(true);
-                }
-
-                Collection<Long> selectPartitionIds = scanOperatorPredicates.getSelectedPartitionIds();
-                if (Objects.isNull(selectPartitionIds) || selectPartitionIds.size() == 0) {
-                    // see OptExternalPartitionPruner#computePartitionInfo:
-                    // it's not the same meaning when selectPartitionIds is null and empty for hive and other tables
-                    if (refScanOperator.getOpType() == OperatorType.LOGICAL_HIVE_SCAN) {
-                        return Optional.of(false);
-                    } else {
-                        return Optional.of(true);
-                    }
-                }
-                // determine whether query's partitions can be satisfied by materialized view.
-                List<PartitionKey> selectPartitionKeys = scanOperatorPredicates.getSelectedPartitionKeys();
-                for (PartitionKey partitionKey : selectPartitionKeys) {
-                    String mvPartitionName = PartitionUtil.generateMVPartitionName(partitionKey);
-                    if (refTablePartitionNameToRefresh.contains(mvPartitionName)) {
-                        return Optional.of(true);
-                    }
-                }
-                return Optional.of(false);
-            } catch (AnalysisException e) {
-                return Optional.of(true);
-            }
+            return getMvCompensationForExternal(sessionVariable, refTablePartitionNameToRefresh, refScanOperator);
         } else {
-            return Optional.of(true);
+            return MVCompensation.createUnkownState(sessionVariable);
         }
+    }
+
+    private static MVCompensation getMvCompensationForOlap(SessionVariable sessionVariable,
+                                                           Table refBaseTable,
+                                                           Set<String> refTablePartitionNameToRefresh,
+                                                           LogicalOlapScanOperator olapScanOperator) {
+        OlapTable olapTable = (OlapTable) olapScanOperator.getTable();
+
+        List<Long> selectPartitionIds = olapScanOperator.getSelectedPartitionId();
+        if (Objects.isNull(selectPartitionIds) || selectPartitionIds.size() == 0) {
+            return MVCompensation.createNoCompensateState(sessionVariable);
+        }
+
+        // if any of query's select partition ids has not been refreshed, then no rewrite with this mv.
+        if (selectPartitionIds.stream()
+                .map(id -> olapTable.getPartition(id))
+                .noneMatch(part -> refTablePartitionNameToRefresh.contains(part.getName()))) {
+            return MVCompensation.createNoCompensateState(sessionVariable);
+        }
+
+        // if mv's to refresh partitions contains any of query's select partition ids, then rewrite with compensate.
+        List<Long> toRefreshRefTablePartitions = getMvRefTableCompensatePartitionsForOlap(refTablePartitionNameToRefresh,
+                refBaseTable, olapScanOperator);
+        if (toRefreshRefTablePartitions == null) {
+            return MVCompensation.createUnkownState(sessionVariable);
+        }
+
+        if (Sets.newHashSet(toRefreshRefTablePartitions).containsAll(selectPartitionIds)) {
+            return MVCompensation.createNoRewriteState(sessionVariable);
+        }
+
+        return new MVCompensation(sessionVariable, MVTransparentState.COMPENSATE,
+                toRefreshRefTablePartitions, null);
+    }
+
+    private static MVCompensation getMvCompensationForExternal(SessionVariable sessionVariable,
+                                                               Set<String> refTablePartitionNamesToRefresh,
+                                                               LogicalScanOperator refScanOperator) {
+        try {
+            ScanOperatorPredicates scanOperatorPredicates = refScanOperator.getScanOperatorPredicates();
+            Collection<Long> selectPartitionIds = scanOperatorPredicates.getSelectedPartitionIds();
+            if (Objects.isNull(selectPartitionIds) || selectPartitionIds.size() == 0) {
+                // see OptExternalPartitionPruner#computePartitionInfo:
+                // it's not the same meaning when selectPartitionIds is null and empty for hive and other tables
+                if (refScanOperator.getOpType() == OperatorType.LOGICAL_HIVE_SCAN) {
+                    return MVCompensation.createNoCompensateState(sessionVariable);
+                } else {
+                    return MVCompensation.createUnkownState(sessionVariable);
+                }
+            }
+            List<PartitionKey> selectPartitionKeys = scanOperatorPredicates.getSelectedPartitionKeys();
+            if (selectPartitionKeys.stream()
+                    .map(PartitionUtil::generateMVPartitionName)
+                    .noneMatch(x -> refTablePartitionNamesToRefresh.contains(x))) {
+                return MVCompensation.createNoCompensateState(sessionVariable);
+            }
+            // if mv's to refresh partitions contains any of query's select partition ids, then rewrite with compensate.
+            List<PartitionKey> toRefreshRefTablePartitions = getMvRefTableCompensatePartitionsForExternal(
+                    refTablePartitionNamesToRefresh, refScanOperator);
+            if (toRefreshRefTablePartitions == null) {
+                return MVCompensation.createUnkownState(sessionVariable);
+            }
+            if (Sets.newHashSet(toRefreshRefTablePartitions).containsAll(selectPartitionKeys)) {
+                return MVCompensation.createNoRewriteState(sessionVariable);
+            }
+            return new MVCompensation(sessionVariable, MVTransparentState.COMPENSATE, null,
+                    toRefreshRefTablePartitions);
+        } catch (AnalysisException e) {
+            return MVCompensation.createUnkownState(sessionVariable);
+        }
+    }
+
+    /**
+     * Get mv's compensate partitions for ref table(olap table).
+     * @param refBaseTable: materialized view's ref base table
+     * @param refScanOperator: ref base table's scan operator.
+     * @return: need to compensate partition ids of the materialized view.
+     */
+    private static List<Long> getMvRefTableCompensatePartitionsForOlap(Set<String> refTablePartitionNameToRefresh,
+                                                                       Table refBaseTable,
+                                                                       LogicalScanOperator refScanOperator) {
+
+        LogicalOlapScanOperator olapScanOperator = ((LogicalOlapScanOperator) refScanOperator);
+        if (olapScanOperator.getSelectedPartitionId() == null) {
+            return null;
+        }
+        List<Long> refTableCompensatePartitionIds = Lists.newArrayList();
+        List<Long> selectPartitionIds = olapScanOperator.getSelectedPartitionId();
+        for (Long selectPartitionId : selectPartitionIds) {
+            Partition partition = refBaseTable.getPartition(selectPartitionId);
+            // If this partition has updated, add it into compensate partition ids.
+            if (refTablePartitionNameToRefresh.contains(partition.getName())) {
+                refTableCompensatePartitionIds.add(selectPartitionId);
+            }
+        }
+        return refTableCompensatePartitionIds;
+    }
+
+    private static List<PartitionKey> getMvRefTableCompensatePartitionsForExternal(Set<String> refTablePartitionNamesToRefresh,
+                                                                                   LogicalScanOperator refScanOperator)
+            throws AnalysisException {
+        ScanOperatorPredicates scanOperatorPredicates = null;
+        try {
+            scanOperatorPredicates = refScanOperator.getScanOperatorPredicates();
+        } catch (Exception e) {
+            return null;
+        }
+        if (scanOperatorPredicates == null) {
+            return null;
+        }
+        List<PartitionKey> refTableCompensatePartitionKeys = Lists.newArrayList();
+        List<PartitionKey> selectPartitionKeys = scanOperatorPredicates.getSelectedPartitionKeys();
+        // different behavior for different external table types
+        if (selectPartitionKeys.isEmpty() && refScanOperator.getOpType() != OperatorType.LOGICAL_HIVE_SCAN) {
+            return null;
+        }
+        for (PartitionKey partitionKey : selectPartitionKeys) {
+            String partitionName = generateMVPartitionName(partitionKey);
+            if (refTablePartitionNamesToRefresh.contains(partitionName)) {
+                refTableCompensatePartitionKeys.add(partitionKey);
+            }
+        }
+        return refTableCompensatePartitionKeys;
+    }
+    /**
+     * Get all refreshed partitions' plan of the materialized view.
+     * @param mvContext: materialized view context
+     * @return:  a pair of compensated mv scan plan(refreshed partitions) and its output columns
+     */
+    private static Pair<OptExpression, List<ColumnRefOperator>> getMvScanPlan(MaterializationContext mvContext) {
+        // NOTE: mv's scan operator has already been partition pruned by filtering refreshed partitions,
+        // see MvRewritePreprocessor#createScanMvOperator.
+        final LogicalOlapScanOperator mvScanOperator = mvContext.getScanMvOperator();
+        final MaterializedView mv = mvContext.getMv();
+        final LogicalOlapScanOperator.Builder mvScanBuilder = OperatorBuilderFactory.build(mvScanOperator);
+        final List<ColumnRefOperator> orgMvScanOutputColumns = MvUtils.getMvScanOutputColumnRefs(mv,
+                mvScanOperator);
+        mvScanBuilder.withOperator(mvScanOperator);
+        OptExpression mvScanOptExpression = OptExpression.create(mvScanBuilder.build());
+        deriveLogicalProperty(mvScanOptExpression);
+        // duplicate mv's plan and output columns
+        OptExpressionDuplicator duplicator = new OptExpressionDuplicator(mvContext);
+        OptExpression newMvScanPlan = duplicator.duplicate(mvScanOptExpression);
+        // output columns order by mv's columns
+        List<ColumnRefOperator> mvScanOutputColumns = duplicator.getMappedColumns(orgMvScanOutputColumns);
+        newMvScanPlan.getOp().setOpRuleMask(OP_UNION_ALL_BIT);
+        return Pair.create(newMvScanPlan, mvScanOutputColumns);
+    }
+
+    /**
+     * Get all to-refreshed partitions' plan of the materialized view.
+     * @param mvContext: materialized view context
+     * @param mvCompensation: materialized view's compensation info
+     * @return:  a pair of compensated mv query scan plan(to-refreshed partitions) and its output columns
+     */
+    private static Pair<OptExpression, List<ColumnRefOperator>> getMvQueryPlan(MaterializationContext mvContext,
+                                                                               MVCompensation mvCompensation) {
+        final OptExpression mvQueryPlan = mvContext.getMvExpression();
+        OptExpression compensateMvQueryPlan = getMvCompensateQueryPlan(mvContext, mvCompensation, mvQueryPlan);
+        if (compensateMvQueryPlan == null) {
+            logMVRewrite(mvContext, "Get mv compensate query plan failed");
+            return null;
+        }
+        OptExpressionDuplicator duplicator = new OptExpressionDuplicator(mvContext);
+        OptExpression newMvQueryPlan = duplicator.duplicate(compensateMvQueryPlan);
+        deriveLogicalProperty(newMvQueryPlan);
+        List<ColumnRefOperator> orgMvQueryOutputColumnRefs = mvContext.getMvOutputColumnRefs();
+        List<ColumnRefOperator> mvQueryOutputColumnRefs = duplicator.getMappedColumns(orgMvQueryOutputColumnRefs);
+        newMvQueryPlan.getOp().setOpRuleMask(OP_UNION_ALL_BIT);
+        return Pair.create(newMvQueryPlan, mvQueryOutputColumnRefs);
+    }
+
+    public static OptExpression getMvCompensateQueryPlan(MaterializationContext mvContext,
+                                                         MVCompensation mvCompensation,
+                                                         OptExpression mvQueryPlan) {
+        MaterializedView mv = mvContext.getMv();
+        Pair<Table, Column> partitionTableAndColumns = mv.getDirectTableAndPartitionColumn();
+        if (partitionTableAndColumns == null) {
+            return null;
+        }
+        // only set this when `queryExpression` contains ref table, otherwise the cached value maybe dirty.
+        Table refBaseTable = partitionTableAndColumns.first;
+        LogicalScanOperator mvRefScanOperator = getRefBaseTableScanOperator(mvQueryPlan, refBaseTable);
+        if (mvRefScanOperator == null) {
+            return null;
+        }
+
+        if (mvRefScanOperator instanceof LogicalOlapScanOperator) {
+            List<Long> refTableCompensatePartitionIds = mvCompensation.getOlapCompensatePartitionIds();
+            if (refTableCompensatePartitionIds == null) {
+                logMVRewrite(mvContext, "Get ref olap base table's compensation partition ids is null");
+                return null;
+            }
+            return MVPartitionPruner.getOlapTableCompensatePlan(mvQueryPlan, mvRefScanOperator, refTableCompensatePartitionIds);
+        } else if (SUPPORTED_PARTITION_COMPENSATE_EXTERNAL_SCAN_TYPES.contains(mvRefScanOperator.getOpType())) {
+            List<PartitionKey> refTableCompensatePartitionKeys = mvCompensation.getExternalCompensatePartitionKeys();
+            if (refTableCompensatePartitionKeys == null) {
+                logMVRewrite(mvContext, "Get ref external base table's compensation partition ids is null");
+                return null;
+            }
+
+            // NOTE: This is necessary because iceberg's physical plan will not use selectedPartitionIds to
+            // prune partitions.
+            Column mvPartitionColumn = partitionTableAndColumns.second;
+            ColumnRefOperator partitionColumnRef = mvRefScanOperator.getColumnReference(mvPartitionColumn);
+            Preconditions.checkState(partitionColumnRef != null);
+            ScalarOperator partitionPredicates = convertPartitionKeysToListPredicate(partitionColumnRef,
+                    refTableCompensatePartitionKeys);
+            Preconditions.checkState(partitionPredicates != null);
+            partitionPredicates.setRedundant(true);
+            return MVPartitionPruner.getExternalTableCompensatePlan(mvQueryPlan, mvRefScanOperator,
+                    partitionPredicates);
+        } else {
+            logMVRewrite(mvContext, "Unsupported ref base table's scan operator type:{}",
+                    mvRefScanOperator.getOpType().name());
+            return null;
+        }
+    }
+
+    /**
+     * <p> What's the transparent plan of mv? </p>
+     *
+     * Transparent MV: select * from t(all partition refreshed) union all select * from mv's defined query
+     *  (all to-refresh partitions)
+     *
+     * eg:
+     * MV       : select col1, col2 from t;
+     * MV refreshed partition: dt = '2023-11-01'
+     *
+     * Query    : select col1, col2 from t where dt in ('2023-11-01', '2023-11-02')
+     * Rewritten: select col1, col2 from <Transparent MV> where dt in ('2023-11-01', '2023-11-02')
+     *
+     * Transparent MV : Refreshed MV Partitions union all To-Refresh MV Partitions
+     * = select * from mv where dt='2023-11-01' union all select * from t where dt = '2023-11-02'
+     */
+    public static OptExpression getMvTransparentPlan(MaterializationContext mvContext,
+                                                     MVCompensation mvCompensation,
+                                                     List<ColumnRefOperator> expectOutputColumns) {
+        Preconditions.checkState(mvCompensation.isTransparentRewrite());
+        final LogicalOlapScanOperator mvScanOperator = mvContext.getScanMvOperator();
+        final MaterializedView mv = mvContext.getMv();
+        final List<ColumnRefOperator> originalOutputColumns = expectOutputColumns == null ?
+                MvUtils.getMvScanOutputColumnRefs(mv, mvScanOperator) : expectOutputColumns;
+
+        Pair<OptExpression, List<ColumnRefOperator>> mvScanPlans = getMvScanPlan(mvContext);
+        if (mvScanPlans == null) {
+            logMVRewrite(mvContext, "Get mv scan transparent plan failed");
+            return null;
+        }
+        Pair<OptExpression, List<ColumnRefOperator>> mvQueryPlans = getMvQueryPlan(mvContext, mvCompensation);
+        if (mvQueryPlans == null) {
+            logMVRewrite(mvContext, "Get mv query transparent plan failed");
+            return null;
+        }
+        LogicalUnionOperator unionOperator = new LogicalUnionOperator.Builder()
+                .setOutputColumnRefOp(originalOutputColumns)
+                .setChildOutputColumns(Lists.newArrayList(mvScanPlans.second, mvQueryPlans.second))
+                .isUnionAll(true)
+                .build();
+        OptExpression result = OptExpression.create(unionOperator, mvScanPlans.first, mvQueryPlans.first);
+        deriveLogicalProperty(result);
+        return result;
     }
 
     /**
@@ -239,14 +468,24 @@ public class MvPartitionCompensator {
         }
 
         List<ScalarOperator> partitionPredicates = Lists.newArrayList();
-        boolean isCompensatePartition = mvContext.getOrInitCompensatePartitionPredicate(queryExpression);
+        MVCompensation mvCompensation = mvContext.getMvCompensation();
+        if (mvCompensation.getState().isNoRewrite()) {
+            return null;
+        }
+        boolean isCompensatePartition = mvCompensation.isCompensatePartitionPredicate();
         // Compensate partition predicates and add them into query predicate.
         Map<Pair<LogicalScanOperator, Boolean>, List<ScalarOperator>> scanOperatorScalarOperatorMap =
                 mvContext.getScanOpToPartitionCompensatePredicates();
         MaterializedView mv = mvContext.getMv();
         for (LogicalScanOperator scanOperator : scanOperators) {
             if (!SUPPORTED_PARTITION_COMPENSATE_SCAN_TYPES.contains(scanOperator.getOpType())) {
-                continue;
+                // If the scan operator is not supported, then return null when compensate type is not NO_COMPENSATE
+                // which means the query cannot be rewritten only when all partitions are refreshed.
+                // Change query_rewrite_consistency=loose to no check query rewrite consistency.
+                if (!mvCompensation.isCompensatePartitionPredicate()) {
+                    continue;
+                }
+                return null;
             }
             List<ScalarOperator> partitionPredicate = scanOperatorScalarOperatorMap
                     .computeIfAbsent(Pair.create(scanOperator, isCompensatePartition), x -> {
@@ -277,7 +516,7 @@ public class MvPartitionCompensator {
             partitionPredicate = compensatePartitionPredicateForExternalTables(mvContext, scanOperator);
         } else {
             logMVRewrite(mvContext.getMv().getName(), "Compensate partition failed: unsupported scan " +
-                            "operator type {} for {}", scanOperator.getOpType(), scanOperator.getTable().getName());
+                    "operator type {} for {}", scanOperator.getOpType(), scanOperator.getTable().getName());
             return null;
         }
         return partitionPredicate;
@@ -356,7 +595,7 @@ public class MvPartitionCompensator {
             }
         }
 
-        List<Range<PartitionKey>> mergedRanges = MvUtils.mergeRanges(ranges);
+        List<Range<PartitionKey>> mergedRanges = mergeRanges(ranges);
         ColumnRefOperator partitionColumnRef = scanOperator.getColumnReference(baseTable.getPartitionColumns().get(0));
         ScalarOperator partitionPredicate = convertPartitionKeysToPredicate(partitionColumnRef, mergedRanges);
         if (partitionPredicate == null) {
@@ -423,9 +662,12 @@ public class MvPartitionCompensator {
             }
 
             // normalize selected partition ranges
-            List<Range<PartitionKey>> mergedRanges = MvUtils.mergeRanges(selectedRanges);
+            List<Range<PartitionKey>> mergedRanges = mergeRanges(selectedRanges);
             ScalarOperator partitionPredicate =
                     convertPartitionKeysToPredicate(partitionScalarOperator, mergedRanges);
+            if (partitionPredicate == null) {
+                return null;
+            }
             partitionPredicates.add(partitionPredicate);
         } else if (olapTable.getPartitionInfo() instanceof RangePartitionInfo) {
             RangePartitionInfo rangePartitionInfo = (RangePartitionInfo) olapTable.getPartitionInfo();
@@ -439,12 +681,13 @@ public class MvPartitionCompensator {
                 selectedRanges.add(rangePartitionInfo.getRange(pid));
             }
             ColumnRefOperator partitionColumnRef = olapScanOperator.getColumnReference(partitionColumns.get(0));
-            List<Range<PartitionKey>> mergedRanges = MvUtils.mergeRanges(selectedRanges);
+            List<Range<PartitionKey>> mergedRanges = mergeRanges(selectedRanges);
             ScalarOperator partitionPredicate =
                     convertPartitionKeysToPredicate(partitionColumnRef, mergedRanges);
-            if (partitionPredicate != null) {
-                partitionPredicates.add(partitionPredicate);
+            if (partitionPredicate == null) {
+                return null;
             }
+            partitionPredicates.add(partitionPredicate);
         } else {
             return null;
         }
@@ -452,10 +695,9 @@ public class MvPartitionCompensator {
         return partitionPredicates;
     }
 
-    public static ScalarOperator convertListPartitionKeys(ScalarOperator partitionColRef,
-                                                          List<Range<PartitionKey>> partitionRanges) {
-        List<ScalarOperator> inArgs = Lists.newArrayList();
-        inArgs.add(partitionColRef);
+    public static ScalarOperator convertPartitionRangesToListPredicate(ScalarOperator partitionColRef,
+                                                                       List<Range<PartitionKey>> partitionRanges) {
+        List<PartitionKey> keys = Lists.newArrayList();
         for (Range<PartitionKey> range : partitionRanges) {
             if (range.isEmpty()) {
                 continue;
@@ -464,16 +706,24 @@ public class MvPartitionCompensator {
             // see `convertToDateRange`
             if (range.hasLowerBound()) {
                 // partition range must have lower bound and upper bound
-                ConstantOperator lowerBound =
-                        (ConstantOperator) SqlToScalarOperatorTranslator.translate(range.lowerEndpoint().getKeys().get(0));
-                inArgs.add(lowerBound);
+                keys.add(range.lowerEndpoint());
             } else if (range.hasUpperBound()) {
-                ConstantOperator upperBound =
-                        (ConstantOperator) SqlToScalarOperatorTranslator.translate(range.upperEndpoint().getKeys().get(0));
-                Preconditions.checkState(upperBound.getType().isStringType());
+                keys.add(range.upperEndpoint());
             } else {
                 return null;
             }
+        }
+        return convertPartitionKeysToListPredicate(partitionColRef, keys);
+    }
+
+    public static ScalarOperator convertPartitionKeysToListPredicate(ScalarOperator partitionColRef,
+                                                                     Collection<PartitionKey> partitionRanges) {
+        List<ScalarOperator> inArgs = Lists.newArrayList();
+        inArgs.add(partitionColRef);
+        for (PartitionKey partitionKey : partitionRanges) {
+            LiteralExpr literalExpr = partitionKey.getKeys().get(0);
+            ConstantOperator upperBound = (ConstantOperator) SqlToScalarOperatorTranslator.translate(literalExpr);
+            inArgs.add(upperBound);
         }
         if (inArgs.size() == 1) {
             return ConstantOperator.TRUE;
@@ -484,10 +734,10 @@ public class MvPartitionCompensator {
 
     private static ScalarOperator convertPartitionKeysToPredicate(ScalarOperator partitionColumn,
                                                                   List<Range<PartitionKey>> partitionKeys) {
-        boolean isListPartition = partitionColumn.getType().isStringType();
         // NOTE: For string type partition column, it should be list partition rather than range partition.
+        boolean isListPartition = partitionColumn.getType().isStringType();
         if (isListPartition) {
-            return convertListPartitionKeys(partitionColumn, partitionKeys);
+            return MvPartitionCompensator.convertPartitionRangesToListPredicate(partitionColumn, partitionKeys);
         } else {
             List<ScalarOperator> rangePredicates = MvUtils.convertRanges(partitionColumn, partitionKeys);
             return Utils.compoundOr(rangePredicates);
@@ -511,18 +761,22 @@ public class MvPartitionCompensator {
         }
 
         Table refBaseTable = partitionTableAndColumns.first;
-        List<Range<PartitionKey>> latestBaseTableRanges =
-                getLatestPartitionRangeForTable(refBaseTable, partitionTableAndColumns.second,
-                        mv, mvPartitionNamesToRefresh);
-        if (latestBaseTableRanges.isEmpty()) {
-            // if there isn't an updated partition, do not rewrite
+        List<Range<PartitionKey>> refreshedRefBaseTableRanges = getMvRefreshedPartitionRange(refBaseTable,
+                partitionTableAndColumns.second, mv, mvPartitionNamesToRefresh);
+        if (refreshedRefBaseTableRanges == null) {
             return null;
+        }
+
+        if (refreshedRefBaseTableRanges.isEmpty()) {
+            // if there isn't an updated partition, do not rewrite
+            return ConstantOperator.TRUE;
         }
 
         Column partitionColumn = partitionTableAndColumns.second;
         Expr partitionExpr = mv.getFirstPartitionRefTableExpr();
         List<LogicalScanOperator> scanOperators = MvUtils.getScanOperator(mvPlan);
         for (LogicalScanOperator scanOperator : scanOperators) {
+            // Since mv's plan disabled partition prune, no need to compensate partition predicate for non ref base tables.
             if (!isRefBaseTable(scanOperator, refBaseTable)) {
                 continue;
             }
@@ -536,7 +790,7 @@ public class MvPartitionCompensator {
             if (!columnRefOption.isPresent()) {
                 continue;
             }
-            return convertPartitionKeysToPredicate(columnRefOption.get(), latestBaseTableRanges);
+            return convertPartitionKeysToPredicate(columnRefOption.get(), refreshedRefBaseTableRanges);
         }
         return null;
     }
@@ -568,7 +822,7 @@ public class MvPartitionCompensator {
     }
 
     /**
-     * Return the updated partition key ranges of the specific table.
+     * Return the refreshed partition key ranges of the ref base table.
      *
      * NOTE: This method can be only used in query rewrite and cannot be used to insert routine.
      * @param partitionByTable          : the base table of the mv
@@ -577,7 +831,7 @@ public class MvPartitionCompensator {
      * @param mvPartitionNamesToRefresh : the updated partition names  of the materialized view
      * @return
      */
-    private static List<Range<PartitionKey>> getLatestPartitionRangeForTable(
+    private static List<Range<PartitionKey>> getMvRefreshedPartitionRange(
             Table partitionByTable,
             Column partitionColumn,
             MaterializedView mv,
@@ -681,6 +935,31 @@ public class MvPartitionCompensator {
             return null;
         }
         return optRefScanOperator.get();
+    }
+
+    private static LogicalScanOperator getRefBaseTableScanOperator(OptExpression queryPlan,
+                                                                   Table refBaseTable) {
+
+        List<LogicalScanOperator> scanOperators = MvUtils.getScanOperator(queryPlan);
+        // If no scan operator, no need compensate
+        if (scanOperators.isEmpty()) {
+            return null;
+        }
+        if (scanOperators.stream().anyMatch(scan -> scan instanceof LogicalViewScanOperator)) {
+            return null;
+        }
+
+        LogicalScanOperator refScanOperator = getRefBaseTableScanOperator(scanOperators, refBaseTable);
+        if (refScanOperator == null) {
+            return null;
+        }
+
+        Table table = refScanOperator.getTable();
+        // If table's not partitioned, no need compensate
+        if (table.isUnPartitioned()) {
+            return null;
+        }
+        return refScanOperator;
     }
 
     private static boolean isRefBaseTable(LogicalScanOperator scanOperator, Table refBaseTable) {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/PredicateExtractor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/PredicateExtractor.java
@@ -141,7 +141,8 @@ public class PredicateExtractor extends ScalarOperatorVisitor<RangePredicate, Pr
         }
 
         TreeRangeSet<ConstantOperator> range = range(predicate.getBinaryType(), op2);
-        if (DateTruncEquivalent.INSTANCE.isEquivalent(op1, op2)) {
+        if (DateTruncEquivalent.isSupportedBinaryType(predicate.getBinaryType()) &&
+                DateTruncEquivalent.INSTANCE.isEquivalent(op1, op2)) {
             TreeRangeSet<ConstantOperator> rangeSet = TreeRangeSet.create();
             rangeSet.addAll(range);
             return new ColumnRangePredicate(op1.getChild(1).cast(), rangeSet);

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/rule/BaseMaterializedViewRewriteRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/rule/BaseMaterializedViewRewriteRule.java
@@ -39,6 +39,7 @@ import com.starrocks.sql.optimizer.rule.RuleType;
 import com.starrocks.sql.optimizer.rule.transformation.TransformationRule;
 import com.starrocks.sql.optimizer.rule.transformation.materialization.BestMvSelector;
 import com.starrocks.sql.optimizer.rule.transformation.materialization.MVColumnPruner;
+import com.starrocks.sql.optimizer.rule.transformation.materialization.MVCompensation;
 import com.starrocks.sql.optimizer.rule.transformation.materialization.MVPartitionPruner;
 import com.starrocks.sql.optimizer.rule.transformation.materialization.MaterializedViewRewriter;
 import com.starrocks.sql.optimizer.rule.transformation.materialization.MvPartitionCompensator;
@@ -53,7 +54,7 @@ import java.util.stream.Collectors;
 
 import static com.starrocks.metric.MaterializedViewMetricsEntity.isUpdateMaterializedViewMetrics;
 import static com.starrocks.sql.optimizer.OptimizerTraceUtil.logMVRewrite;
-import static com.starrocks.sql.optimizer.rule.transformation.materialization.MvUtils.isAppliedUnionAllRewrite;
+import static com.starrocks.sql.optimizer.rule.transformation.materialization.MvUtils.isAppliedMVUnionRewrite;
 
 public abstract class BaseMaterializedViewRewriteRule extends TransformationRule {
 
@@ -83,7 +84,7 @@ public abstract class BaseMaterializedViewRewriteRule extends TransformationRule
     @Override
     public boolean check(OptExpression input, OptimizerContext context) {
         // To avoid dead-loop rewrite, no rewrite when query extra predicate is not changed
-        if (isAppliedUnionAllRewrite(input.getOp())) {
+        if (isAppliedMVUnionRewrite(input)) {
             return false;
         }
         return !context.getCandidateMvs().isEmpty() && checkOlapScanWithoutTabletOrPartitionHints(input);
@@ -163,6 +164,12 @@ public abstract class BaseMaterializedViewRewriteRule extends TransformationRule
         List<Table> queryTables = MvUtils.getAllTables(queryExpression);
         ConnectContext connectContext = ConnectContext.get();
         for (MaterializationContext mvContext : mvCandidateContexts) {
+            // initialize query's compensate type based on query and mv's partition refresh status
+            MVCompensation mvCompensation = mvContext.getOrInitMVCompensation(queryExpression);
+            if (mvCompensation.getState().isNoRewrite()) {
+                continue;
+            }
+
             PredicateSplit queryPredicateSplit = getQuerySplitPredicate(context, mvContext, queryExpression,
                     queryColumnRefFactory, queryColumnRefRewriter);
             if (queryPredicateSplit == null) {

--- a/fe/fe-core/src/test/java/com/starrocks/planner/MaterializedViewManualTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/planner/MaterializedViewManualTest.java
@@ -221,7 +221,7 @@ public class MaterializedViewManualTest extends MaterializedViewTestBase {
     }
 
     @Test
-    public void testDateTruncPartitionColumnExpr() throws Exception {
+    public void testDateTruncPartitionColumnExpr1() throws Exception {
         String tableSQL = "CREATE TABLE `test_partition_expr_tbl1` (\n" +
                 "  `order_id` bigint(20) NOT NULL DEFAULT \"-1\" COMMENT \"\",\n" +
                 "  `dt` datetime NOT NULL DEFAULT \"1996-01-01 00:00:00\" COMMENT \"\",\n" +
@@ -233,27 +233,12 @@ public class MaterializedViewManualTest extends MaterializedViewTestBase {
                 "PARTITION p2023041017 VALUES [(\"2023-04-10 17:00:00\"), (\"2023-04-10 18:00:00\")),\n" +
                 "PARTITION p2023041021 VALUES [(\"2023-04-10 21:00:00\"), (\"2023-04-10 22:00:00\"))\n" +
                 ")\n" +
-                "DISTRIBUTED BY HASH(`order_id`) BUCKETS 9\n" +
-                "PROPERTIES (\n" +
-                "\"dynamic_partition.enable\" = \"true\",\n" +
-                "\"dynamic_partition.time_unit\" = \"HOUR\",\n" +
-                "\"dynamic_partition.time_zone\" = \"Asia/Shanghai\",\n" +
-                "\"dynamic_partition.start\" = \"-240\",\n" +
-                "\"dynamic_partition.end\" = \"2\",\n" +
-                "\"dynamic_partition.prefix\" = \"p\",\n" +
-                "\"dynamic_partition.buckets\" = \"9\"," +
-                "\"replication_num\" = \"1\"" +
-                ");";
+                "DISTRIBUTED BY HASH(`order_id`)";
         starRocksAssert.withTable(tableSQL);
         String mv = "CREATE MATERIALIZED VIEW `test_partition_expr_mv1`\n" +
-                "COMMENT \"MATERIALIZED_VIEW\"\n" +
                 "PARTITION BY ds \n" +
-                "DISTRIBUTED BY HASH(`order_num`) BUCKETS 10\n" +
-                "PROPERTIES (\n" +
-                "\"replication_num\" = \"1\"" +
-                ")\n" +
-                "AS\n" +
-                "SELECT \n" +
+                "DISTRIBUTED BY RANDOM \n" +
+                "AS SELECT \n" +
                 "count(DISTINCT `order_id`) AS `order_num`, \n" +
                 "date_trunc('minute', `dt`) AS ds\n" +
                 "FROM `test_partition_expr_tbl1`\n" +
@@ -278,6 +263,65 @@ public class MaterializedViewManualTest extends MaterializedViewTestBase {
                     "WHERE `dt` BETWEEN '2023-04-11' AND '2023-04-12'\n" +
                     "group by ds")
                     .match("test_partition_expr_mv1");
+        }
+
+        starRocksAssert.dropMaterializedView("test_partition_expr_mv1");
+        starRocksAssert.dropTable("test_partition_expr_tbl1");
+    }
+
+    @Test
+    public void testDateTruncPartitionColumnExpr2() throws Exception {
+        String tableSQL = "CREATE TABLE `test_partition_expr_tbl1` (\n" +
+                "  `order_id` bigint(20) NOT NULL DEFAULT \"-1\" COMMENT \"\",\n" +
+                "  `dt` datetime NOT NULL DEFAULT \"1996-01-01 00:00:00\" COMMENT \"\",\n" +
+                "  `value` varchar(256) NULL \n" +
+                ") ENGINE=OLAP\n" +
+                "DUPLICATE KEY(`order_id`, `dt`)\n" +
+                "PARTITION BY RANGE(`dt`)\n" +
+                "(\n" +
+                "PARTITION p2023041017 VALUES [(\"2023-04-10 17:00:00\"), (\"2023-04-10 18:00:00\")),\n" +
+                "PARTITION p2023041021 VALUES [(\"2023-04-10 21:00:00\"), (\"2023-04-10 22:00:00\"))\n" +
+                ")\n" +
+                "DISTRIBUTED BY HASH(`order_id`)";
+        starRocksAssert.withTable(tableSQL);
+        String mv = "CREATE MATERIALIZED VIEW `test_partition_expr_mv1`\n" +
+                "PARTITION BY ds \n" +
+                "DISTRIBUTED BY RANDOM \n" +
+                "AS SELECT \n" +
+                "count(DISTINCT `order_id`) AS `order_num`, \n" +
+                "date_trunc('day', `dt`) AS ds\n" +
+                "FROM `test_partition_expr_tbl1`\n" +
+                "group by ds;";
+        starRocksAssert.withMaterializedView(mv);
+
+        {
+            sql("SELECT \n" +
+                    "count(DISTINCT `order_id`) AS `order_num`, \n" +
+                    "date_trunc('day', `dt`) AS ds \n" +
+                    "FROM `test_partition_expr_tbl1`\n" +
+                    "WHERE date_trunc('month', `dt`) = '2023-04-01'\n" +
+                    "group by ds")
+                    .nonMatch("test_partition_expr_mv1");
+        }
+
+        {
+            sql("SELECT \n" +
+                    "count(DISTINCT `order_id`) AS `order_num`, \n" +
+                    "date_trunc('minute', `dt`) AS ds \n" +
+                    "FROM `test_partition_expr_tbl1`\n" +
+                    "WHERE date_trunc('month', `dt`) BETWEEN '2023-04-01' AND '2023-05-01'\n" +
+                    "group by ds")
+                    .nonMatch("test_partition_expr_mv1");
+        }
+
+        {
+            sql("SELECT \n" +
+                    "count(DISTINCT `order_id`) AS `order_num`, \n" +
+                    "date_trunc('minute', `dt`) AS ds \n" +
+                    "FROM `test_partition_expr_tbl1`\n" +
+                    "WHERE `dt` BETWEEN '2023-04-11' AND '2023-04-12'\n" +
+                    "group by ds")
+                    .nonMatch("test_partition_expr_mv1");
         }
 
         starRocksAssert.dropMaterializedView("test_partition_expr_mv1");

--- a/fe/fe-core/src/test/java/com/starrocks/planner/MaterializedViewSSBTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/planner/MaterializedViewSSBTest.java
@@ -21,8 +21,6 @@ import com.starrocks.sql.plan.PlanTestBase;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
-import java.util.List;
-
 public class MaterializedViewSSBTest extends MaterializedViewTestBase {
     @BeforeClass
     public static void beforeClass() throws Exception {
@@ -91,7 +89,6 @@ public class MaterializedViewSSBTest extends MaterializedViewTestBase {
 
     @Test
     public void testQuery4_1() {
-        setTracLogModule("MV");
         runFileUnitTest("materialized-view/ssb/q4-1");
     }
 

--- a/fe/fe-core/src/test/java/com/starrocks/planner/MaterializedViewTextBasedRewriteTPCHTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/planner/MaterializedViewTextBasedRewriteTPCHTest.java
@@ -53,7 +53,6 @@ public class MaterializedViewTextBasedRewriteTPCHTest extends MaterializedViewTe
     @ParameterizedTest(name = "Tpch.{0}")
     @MethodSource("tpchSource")
     public void testTPCH(String name, String sql) {
-        setTracLogModule("MV");
         testRewriteOK(sql, sql);
     }
 

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvRefreshAndRewriteIcebergTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvRefreshAndRewriteIcebergTest.java
@@ -1212,7 +1212,7 @@ public class MvRefreshAndRewriteIcebergTest extends MvRewriteTestBase {
                     " inner join iceberg0.partitioned_db.part_tbl3 t3 on t1.d=t3.d \n" +
                     " where t1.d in ('2023-08-01')\n" +
                     " group by t1.a, t2.b, t1.d;";
-            String plan = getFragmentPlan(query);
+            String plan = getFragmentPlan(query, "MV");
             PlanTestBase.assertContains(plan, "0:OlapScanNode\n" +
                     "     TABLE: test_mv1\n" +
                     "     PREAGGREGATION: ON\n" +

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvRewritePartitionTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvRewritePartitionTest.java
@@ -545,10 +545,11 @@ public class MvRewritePartitionTest extends MvRewriteTestBase {
                     " where a.id_date>='1991-03-30' " +
                     " group by a.t1a,a.id_date;";
             String plan = getFragmentPlan(query);
-            PlanTestBase.assertContains(plan, "0:OlapScanNode\n" +
-                    "     TABLE: table_with_day_partition\n" +
+            PlanTestBase.assertContains(plan, "     TABLE: table_with_day_partition\n" +
                     "     PREAGGREGATION: ON\n" +
-                    "     partitions=4/4");
+                    "     partitions=4/4\n" +
+                    "     rollup: table_with_day_partition\n" +
+                    "     tabletRatio=12/12");
         }
 
         {
@@ -636,7 +637,7 @@ public class MvRewritePartitionTest extends MvRewriteTestBase {
                                     " left join table_with_day_partition2 c on a.id_date=c.id_date \n" +
                                     " where %s " +
                                     " group by a.t1a,a.id_date;", expect.partitionPredicate);
-                            String plan = getFragmentPlan(query);
+                            String plan = getFragmentPlan(query, "MV");
                             if (expect.isExpectRewrite) {
                                 if (expect.isCompensateUnionAll) {
                                     PlanTestBase.assertContains(plan, "UNION");

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvRewriteUnionTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvRewriteUnionTest.java
@@ -184,10 +184,11 @@ public class MvRewriteUnionTest extends MvRewriteTestBase {
                 " join depts2 d2 on emps2.deptno = d2.deptno where d1.deptno < 120";
         String plan2 = getFragmentPlan(query2);
         PlanTestBase.assertContains(plan2, "join_union_mv_1");
-        PlanTestBase.assertContainsIgnoreColRefs(plan2, "7:HASH JOIN\n" +
-                "  |  join op: INNER JOIN (COLOCATE)\n" +
-                "  |  colocate: true\n" +
-                "  |  equal join conjunct: 15: deptno = 18: deptno");
+        PlanTestBase.assertContains(plan2, "  |----5:HASH JOIN\n" +
+                "  |    |  join op: INNER JOIN (BUCKET_SHUFFLE)\n" +
+                "  |    |  colocate: false, reason: \n" +
+                "  |    |  equal join conjunct: 18: deptno = 15: deptno\n" +
+                "  |    |  other predicates: 15: deptno >= 100");
         PlanTestBase.assertContainsIgnoreColRefs(plan2, "2:OlapScanNode\n" +
                 "     TABLE: emps2\n" +
                 "     PREAGGREGATION: ON\n" +
@@ -382,14 +383,14 @@ public class MvRewriteUnionTest extends MvRewriteTestBase {
                                 "SELECT k1,k2, v1,v2 from mt1 where k1<2",
                         };
                         for (String query : sqls) {
-                            String plan = getFragmentPlan(query);
+                            String plan = getFragmentPlan(query, "MV");
                             PlanTestBase.assertNotContains(plan, ":UNION");
                             PlanTestBase.assertContains(plan, "union_mv0");
                         }
                     }
                     {
                         String query = "SELECT k1,k2, v1,v2 from mt1 where k1<6";
-                        String plan = getFragmentPlan(query);
+                        String plan = getFragmentPlan(query, "MV");
                         PlanTestBase.assertContains(plan, ":UNION");
                         PlanTestBase.assertContains(plan, "union_mv0");
                     }
@@ -397,15 +398,19 @@ public class MvRewriteUnionTest extends MvRewriteTestBase {
                     {
                         List<Pair<String, String>> sqls = List.of(
                                 Pair.create("SELECT k1,k2, v1,v2 from mt1 where k1<6 and k2 like 'a%'",
-                                        "TABLE: mt1\n" +
+                                        "     TABLE: mt1\n" +
                                                 "     PREAGGREGATION: ON\n" +
                                                 "     PREDICATES: 10: k2 LIKE 'a%'\n" +
-                                                "     partitions=2/3"),
+                                                "     partitions=2/3\n" +
+                                                "     rollup: mt1\n" +
+                                                "     tabletRatio=6/6"),
                                 Pair.create("SELECT k1,k2, v1,v2 from mt1 where k1 != 3 and k2 like 'a%'",
-                                        "TABLE: mt1\n" +
+                                        "     TABLE: mt1\n" +
                                                 "     PREAGGREGATION: ON\n" +
-                                                "     PREDICATES: 9: k1 > 3, 10: k2 LIKE 'a%'\n" +
-                                                "     partitions=2/3")
+                                                "     PREDICATES: 10: k2 LIKE 'a%', 9: k1 > 3\n" +
+                                                "     partitions=2/3\n" +
+                                                "     rollup: mt1\n" +
+                                                "     tabletRatio=6/6")
                         );
                         for (Pair<String, String> p : sqls) {
                             String query = p.first;

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvTransparentUnionRewriteHiveTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvTransparentUnionRewriteHiveTest.java
@@ -1,0 +1,341 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.sql.optimizer.rule.transformation.materialization;
+
+import com.google.common.collect.ImmutableList;
+import com.starrocks.catalog.MaterializedView;
+import com.starrocks.connector.hive.MockedHiveMetadata;
+import com.starrocks.sql.plan.ConnectorPlanTestBase;
+import com.starrocks.sql.plan.PlanTestBase;
+import com.starrocks.utframe.StarRocksAssert;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import java.time.Instant;
+
+public class MvTransparentUnionRewriteHiveTest extends MvRewriteTestBase {
+    private static MockedHiveMetadata mockedHiveMetadata;
+
+    @BeforeClass
+    public static void beforeClass() throws Exception {
+        MvRewriteTestBase.beforeClass();
+        ConnectorPlanTestBase.mockHiveCatalog(connectContext);
+        mockedHiveMetadata =
+                (MockedHiveMetadata) connectContext.getGlobalStateMgr().getMetadataMgr().
+                        getOptionalMetadata(MockedHiveMetadata.MOCKED_HIVE_CATALOG_NAME).get();
+        connectContext.getSessionVariable().setMaterializedViewUnionRewriteMode(MVUnionRewriteMode.TRANSPARENT.getOrdinal());
+    }
+
+    @Before
+    public void before() {
+        startCaseTime = Instant.now().getEpochSecond();
+    }
+
+    @After
+    public void after() throws Exception {
+        PlanTestBase.cleanupEphemeralMVs(starRocksAssert, startCaseTime);
+    }
+
+    private void withPartialScanMv(StarRocksAssert.ExceptionRunnable runner) {
+        starRocksAssert.withMaterializedView("CREATE MATERIALIZED VIEW mv0\n" +
+                        "PARTITION BY (`l_shipdate`)\n" +
+                        "DISTRIBUTED BY RANDOM\n" +
+                        "REFRESH DEFERRED MANUAL\n" +
+                        "AS SELECT l_orderkey, l_suppkey, l_shipdate FROM hive0.partitioned_db.lineitem_par as a;",
+                (obj) -> {
+                    String mvName = (String) obj;
+                    cluster.runSql(DB_NAME,
+                            String.format("refresh materialized view %s with sync mode", mvName));
+                    MaterializedView mv = getMv(DB_NAME, mvName);
+                    mockedHiveMetadata.updatePartitions("partitioned_db", "lineitem_par",
+                            ImmutableList.of("l_shipdate=1998-01-02"));
+                    runner.run();
+                });
+    }
+
+    private void withPartialAggregateMv(StarRocksAssert.ExceptionRunnable runner) {
+        starRocksAssert.withMaterializedView("CREATE MATERIALIZED VIEW mv0\n" +
+                        "PARTITION BY (`l_shipdate`)\n" +
+                        "DISTRIBUTED BY RANDOM\n" +
+                        "REFRESH DEFERRED MANUAL\n" +
+                        "AS SELECT l_shipdate, l_orderkey, sum(l_suppkey) FROM " +
+                        " hive0.partitioned_db.lineitem_par as a GROUP BY l_orderkey, l_shipdate;",
+                (obj) -> {
+                    String mvName = (String) obj;
+                    cluster.runSql(DB_NAME,
+                            String.format("refresh materialized view %s with sync mode", mvName));
+                    MaterializedView mv = getMv(DB_NAME, mvName);
+                    mockedHiveMetadata.updatePartitions("partitioned_db", "lineitem_par",
+                            ImmutableList.of("l_shipdate=1998-01-02"));
+                    runner.run();
+                });
+    }
+
+    private void withPartialJoinMv(StarRocksAssert.ExceptionRunnable runner) {
+        starRocksAssert.withMaterializedView("CREATE MATERIALIZED VIEW mv0\n" +
+                        "PARTITION BY (`l_shipdate`)\n" +
+                        "DISTRIBUTED BY RANDOM\n" +
+                        "REFRESH DEFERRED MANUAL\n" +
+                        "AS SELECT a.l_orderkey, a.l_suppkey, a.l_shipdate, b.o_orderkey, b.o_custkey FROM " +
+                        "   hive0.partitioned_db.lineitem_par as a JOIN hive0.partitioned_db.orders b " +
+                        " ON a.l_orderkey = b.o_orderkey and a.l_shipdate=b.o_orderdate;",
+                (obj) -> {
+                    String mvName = (String) obj;
+                    cluster.runSql(DB_NAME,
+                            String.format("refresh materialized view %s with sync mode", mvName));
+                    MaterializedView mv = getMv(DB_NAME, mvName);
+                    mockedHiveMetadata.updatePartitions("partitioned_db", "lineitem_par",
+                            ImmutableList.of("l_shipdate=1998-01-02"));
+                    runner.run();
+                });
+    }
+
+    @Test
+    public void testTransparentRewriteWithScanMv() {
+        withPartialScanMv(() -> {
+            // no compensate rewrite
+            {
+                String[] sqls = {
+                        "SELECT l_orderkey, l_suppkey, l_shipdate FROM hive0.partitioned_db.lineitem_par as a WHERE" +
+                                " l_shipdate='1998-01-01';",
+                };
+                String[] expects = {
+                        "     TABLE: mv0\n" +
+                                "     PREAGGREGATION: ON\n" +
+                                "     partitions=1/6\n" +
+                                "     rollup: mv0\n" +
+                                "     tabletRatio=2/2",
+                };
+                for (int i = 0; i < sqls.length; i++) {
+                    String query = sqls[i];
+                    String plan = getFragmentPlan(query);
+                    PlanTestBase.assertNotContains(plan, ":UNION");
+                    PlanTestBase.assertContains(plan, "mv0");
+                    PlanTestBase.assertContains(plan, expects[i]);
+                }
+            }
+
+            // no rewrite
+            {
+                String[] sqls = {
+                        "SELECT l_orderkey, l_suppkey, l_shipdate FROM hive0.partitioned_db.lineitem_par as a WHERE" +
+                                " l_shipdate = '1998-01-02';",
+                };
+                for (String query : sqls) {
+                    String plan = getFragmentPlan(query);
+                    PlanTestBase.assertNotContains(plan, ":UNION", ": mv0");
+                }
+            }
+
+            // transparent union rewrite
+            {
+                String[] sqls = {
+                        "SELECT l_orderkey FROM hive0.partitioned_db.lineitem_par as a WHERE" +
+                                " l_shipdate >= '1998-01-02';",
+                        "SELECT l_orderkey, date_trunc('month', l_shipdate) FROM hive0.partitioned_db.lineitem_par as" +
+                                " a WHERE l_shipdate != '1998-01-01';",
+                        "SELECT l_orderkey * 2, l_shipdate FROM hive0.partitioned_db.lineitem_par as a WHERE" +
+                                " l_shipdate >= '1998-01-02' and l_suppkey > 1;",
+                };
+                String[] expects = {
+                        "     TABLE: lineitem_par\n" +
+                                "     PARTITION PREDICATES: 25: l_shipdate = '1998-01-02'\n" +
+                                "     partitions=1/6",
+                        "     TABLE: mv0\n" +
+                                "     PREAGGREGATION: ON\n" +
+                                "     PREDICATES: 22: l_shipdate >= '1998-01-02'\n" +
+                                "     partitions=5/6\n" +
+                                "     rollup: mv0\n" +
+                                "     tabletRatio=10/10", // case 1
+                        "     TABLE: lineitem_par\n" +
+                                "     PARTITION PREDICATES: 26: l_shipdate != '1998-01-01', 26: l_shipdate = '1998-01-02'\n" +
+                                "     partitions=1/6",
+                        "     TABLE: mv0\n" +
+                                "     PREAGGREGATION: ON\n" +
+                                "     PREDICATES: 23: l_shipdate != '1998-01-01'\n" +
+                                "     partitions=5/6\n" +
+                                "     rollup: mv0\n" +
+                                "     tabletRatio=10/10", // case 2
+                        "     TABLE: lineitem_par\n" +
+                                "     PARTITION PREDICATES: 26: l_shipdate >= '1998-01-02', 26: l_shipdate = '1998-01-02'\n" +
+                                "     NON-PARTITION PREDICATES: 25: l_suppkey > 1\n" +
+                                "     MIN/MAX PREDICATES: 25: l_suppkey > 1\n" +
+                                "     partitions=1/6",
+                        "     TABLE: mv0\n" +
+                                "     PREAGGREGATION: ON\n" +
+                                "     PREDICATES: 23: l_shipdate >= '1998-01-02', 22: l_suppkey > 1\n" +
+                                "     partitions=5/6\n" +
+                                "     rollup: mv0\n" +
+                                "     tabletRatio=10/10", // case 3
+                };
+                for (int i = 0; i < sqls.length; i++) {
+                    String query = sqls[i];
+                    String plan = getFragmentPlan(query);
+                    PlanTestBase.assertContains(plan, ":UNION", ": mv0", ": lineitem_par");
+                    PlanTestBase.assertContains(plan, expects[i * 2]);
+                    PlanTestBase.assertContains(plan, expects[i * 2 + 1]);
+                }
+            }
+        });
+    }
+
+    @Test
+    public void testTransparentRewriteWithScanMvNoPrune() {
+        withPartialScanMv(() -> {
+            // no compensate rewrite
+            {
+                String[] sqls = {
+                        "SELECT l_orderkey, l_suppkey, l_shipdate FROM hive0.partitioned_db.lineitem_par as a WHERE" +
+                                " date_trunc('month', l_shipdate) ='1998-01-01';",
+                };
+                String[] expects = {
+                        "     TABLE: mv0\n" +
+                                "     PREAGGREGATION: ON\n" +
+                                "     PREDICATES: date_trunc('month', 22: l_shipdate) = '1998-01-01'\n" +
+                                "     partitions=5/6\n" +
+                                "     rollup: mv0\n" +
+                                "     tabletRatio=10/10",
+                        "     TABLE: lineitem_par\n" +
+                                "     PARTITION PREDICATES: date_trunc('month', 25: l_shipdate) = '1998-01-01', " +
+                                "25: l_shipdate = '1998-01-02'\n" +
+                                "     NO EVAL-PARTITION PREDICATES: date_trunc('month', 25: l_shipdate) = '1998-01-01'\n" +
+                                "     partitions=1/6"
+                };
+                for (int i = 0; i < sqls.length; i++) {
+                    String query = sqls[i];
+                    String plan = getFragmentPlan(query);
+                    PlanTestBase.assertContains(plan, ":UNION");
+                    PlanTestBase.assertContains(plan, "mv0");
+                    PlanTestBase.assertContains(plan, expects[2 * i]);
+                    PlanTestBase.assertContains(plan, expects[2 * i + 1]);
+                }
+            }
+        });
+    }
+
+    @Test
+    public void testTransparentRewriteWithScanMvAndAggQuery() {
+        withPartialScanMv(() -> {
+            {
+                String[] sqls = {
+                        "SELECT l_shipdate, l_orderkey, sum(l_suppkey) FROM hive0.partitioned_db" +
+                                ".lineitem_par as a WHERE l_shipdate='1998-01-01' GROUP BY l_orderkey, l_shipdate;",
+                        "SELECT l_shipdate, sum(l_suppkey) FROM hive0.partitioned_db" +
+                                ".lineitem_par as a WHERE l_shipdate='1998-01-01' and l_orderkey != 1 " +
+                                " GROUP BY l_orderkey, l_shipdate;",
+                };
+                for (String query : sqls) {
+                    String plan = getFragmentPlan(query);
+                    PlanTestBase.assertNotContains(plan, ":UNION");
+                    PlanTestBase.assertContains(plan, "mv0");
+                }
+            }
+
+            {
+                String[] sqls = {
+                        "SELECT l_shipdate, l_orderkey, sum(l_suppkey) FROM hive0.partitioned_db" +
+                                ".lineitem_par as a WHERE l_shipdate >= '1998-01-01' GROUP BY l_orderkey, l_shipdate;",
+                        "SELECT l_shipdate, sum(l_suppkey) FROM hive0.partitioned_db" +
+                                ".lineitem_par as a WHERE l_shipdate !='1998-01-01' and l_orderkey != 1 " +
+                                " GROUP BY l_orderkey, l_shipdate;",
+                };
+                for (String query : sqls) {
+                    String plan = getFragmentPlan(query);
+                    PlanTestBase.assertContains(plan, ":UNION", ": mv0", ": lineitem_par");
+                }
+            }
+        });
+    }
+
+    @Test
+    public void testTransparentRewriteWithAggMv() {
+        withPartialAggregateMv(() -> {
+            {
+                String[] sqls = {
+                        "SELECT l_shipdate, l_orderkey, sum(l_suppkey) FROM hive0.partitioned_db" +
+                                ".lineitem_par as a WHERE l_shipdate='1998-01-01' GROUP BY l_orderkey, l_shipdate;",
+                        "SELECT l_shipdate, sum(l_suppkey) FROM hive0.partitioned_db" +
+                                ".lineitem_par as a WHERE l_shipdate='1998-01-01' and l_orderkey != 1 " +
+                                " GROUP BY l_orderkey, l_shipdate;",
+                };
+                for (String query : sqls) {
+                    String plan = getFragmentPlan(query);
+                    PlanTestBase.assertNotContains(plan, ":UNION");
+                    PlanTestBase.assertContains(plan, "mv0");
+                }
+            }
+
+            {
+                String[] sqls = {
+                        "SELECT l_shipdate, l_orderkey, sum(l_suppkey) FROM hive0.partitioned_db" +
+                                ".lineitem_par as a WHERE l_shipdate >= '1998-01-01' GROUP BY l_orderkey, l_shipdate;",
+                        "SELECT l_shipdate, sum(l_suppkey) FROM hive0.partitioned_db" +
+                                ".lineitem_par as a WHERE l_shipdate !='1998-01-01' and l_orderkey != 1 " +
+                                " GROUP BY l_orderkey, l_shipdate;",
+                };
+                for (String query : sqls) {
+                    String plan = getFragmentPlan(query);
+                    PlanTestBase.assertContains(plan, ":UNION", ": mv0", ": lineitem_par");
+                }
+            }
+        });
+    }
+
+    @Test
+    public void testTransparentRewriteWithJoinMv() {
+        withPartialJoinMv(() -> {
+            {
+                String[] sqls = {
+                        "SELECT a.l_orderkey, a.l_suppkey, a.l_shipdate, b.o_orderkey, b.o_custkey FROM " +
+                                " hive0.partitioned_db.lineitem_par as a JOIN hive0.partitioned_db.orders b " +
+                                " ON a.l_orderkey = b.o_orderkey and a.l_shipdate=b.o_orderdate " +
+                                "WHERE a.l_shipdate='1998-01-01';",
+                        "SELECT a.l_orderkey, a.l_suppkey, a.l_shipdate, b.o_orderkey, b.o_custkey FROM " +
+                                " hive0.partitioned_db.lineitem_par as a JOIN hive0.partitioned_db.orders b " +
+                                " ON a.l_orderkey = b.o_orderkey and a.l_shipdate=b.o_orderdate " +
+                                "WHERE a.l_shipdate='1998-01-01' and a.l_suppkey > 100;",
+                };
+                for (String query : sqls) {
+                    String plan = getFragmentPlan(query);
+                    PlanTestBase.assertNotContains(plan, ":UNION");
+                    PlanTestBase.assertContains(plan, "mv0");
+                }
+            }
+
+            {
+                String[] sqls = {
+                        "SELECT a.l_orderkey, a.l_suppkey, a.l_shipdate, b.o_orderkey, b.o_custkey FROM " +
+                                " hive0.partitioned_db.lineitem_par as a JOIN hive0.partitioned_db.orders b " +
+                                " ON a.l_orderkey = b.o_orderkey and a.l_shipdate=b.o_orderdate " +
+                                "WHERE a.l_shipdate >= '1998-01-01';",
+                        "SELECT a.l_orderkey, a.l_suppkey, a.l_shipdate, b.o_orderkey, b.o_custkey FROM " +
+                                " hive0.partitioned_db.lineitem_par as a JOIN hive0.partitioned_db.orders b " +
+                                " ON a.l_orderkey = b.o_orderkey and a.l_shipdate=b.o_orderdate " +
+                                "WHERE a.l_shipdate != '1998-01-01' and a.l_suppkey > 100;",
+                        "SELECT a.l_orderkey, a.l_suppkey, a.l_shipdate, b.o_orderkey, b.o_custkey FROM " +
+                                " hive0.partitioned_db.lineitem_par as a JOIN hive0.partitioned_db.orders b " +
+                                " ON a.l_orderkey = b.o_orderkey and a.l_shipdate=b.o_orderdate " +
+                                "WHERE a.l_shipdate <= '1998-01-05' and a.l_suppkey > 100;",
+                };
+                for (String query : sqls) {
+                    String plan = getFragmentPlan(query);
+                    PlanTestBase.assertContains(plan, ":UNION", ": mv0", ": lineitem_par");
+                }
+            }
+        });
+    }
+}

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvTransparentUnionRewriteOlapTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvTransparentUnionRewriteOlapTest.java
@@ -1,0 +1,523 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.sql.optimizer.rule.transformation.materialization;
+
+import com.google.common.collect.ImmutableList;
+import com.starrocks.catalog.MaterializedView;
+import com.starrocks.schema.MTable;
+import com.starrocks.sql.plan.PlanTestBase;
+import com.starrocks.utframe.StarRocksAssert;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import java.time.Instant;
+import java.util.Set;
+
+public class MvTransparentUnionRewriteOlapTest extends MvRewriteTestBase {
+    private static MTable m1;
+    private static MTable m2;
+
+    @BeforeClass
+    public static void beforeClass() throws Exception {
+        MvRewriteTestBase.beforeClass();
+
+        m1 = new MTable("m1", "k1",
+                ImmutableList.of(
+                        "k1 INT",
+                        "k2 string",
+                        "v1 INT",
+                        "v2 INT"
+                ),
+                "k1",
+                ImmutableList.of(
+                        "PARTITION `p1` VALUES LESS THAN ('3')",
+                        "PARTITION `p2` VALUES LESS THAN ('6')",
+                        "PARTITION `p3` VALUES LESS THAN ('9')"
+                )
+        );
+        m2 = new MTable("m2", "k1",
+                ImmutableList.of(
+                        "k1 INT",
+                        "k2 string",
+                        "v1 INT",
+                        "v2 INT"
+                ),
+                "k1",
+                ImmutableList.of(
+                        "PARTITION `p1` VALUES LESS THAN ('3')",
+                        "PARTITION `p2` VALUES LESS THAN ('6')",
+                        "PARTITION `p3` VALUES LESS THAN ('9')"
+                )
+        );
+        connectContext.getSessionVariable().setMaterializedViewUnionRewriteMode(MVUnionRewriteMode.TRANSPARENT.getOrdinal());
+    }
+
+    @Before
+    public void before() {
+        startCaseTime = Instant.now().getEpochSecond();
+    }
+
+    @After
+    public void after() throws Exception {
+        PlanTestBase.cleanupEphemeralMVs(starRocksAssert, startCaseTime);
+    }
+
+    private void withPartialScanMv(StarRocksAssert.ExceptionRunnable runner) {
+        starRocksAssert.withTable(m1, () -> {
+            cluster.runSql("test", "insert into m1 values (1,1,1,1), (4,2,1,1);");
+            starRocksAssert.withMaterializedView("CREATE MATERIALIZED VIEW mv0 " +
+                    " PARTITION BY (k1) " +
+                    " DISTRIBUTED BY HASH(k1) " +
+                    " REFRESH DEFERRED MANUAL " +
+                    " AS SELECT k1, k2, v1, v2 from m1;",
+                    () -> {
+                        starRocksAssert.refreshMvPartition(String.format("REFRESH MATERIALIZED VIEW mv0 \n" +
+                                "PARTITION START ('%s') END ('%s')", "1", "3"));
+                        MaterializedView mv1 = getMv("test", "mv0");
+                        Set<String> mvNames = mv1.getPartitionNames();
+                        Assert.assertEquals("[p1]", mvNames.toString());
+                        runner.run();
+                    });
+        });
+    }
+
+    private void withPartialAggregateMv(StarRocksAssert.ExceptionRunnable runner) {
+        starRocksAssert.withTable(m1, () -> {
+            cluster.runSql("test", "insert into m1 values (1,1,1,1), (4,2,1,1);");
+            starRocksAssert.withMaterializedView("CREATE MATERIALIZED VIEW mv0 " +
+                    " PARTITION BY (k1) " +
+                    " DISTRIBUTED BY HASH(k1) " +
+                    " REFRESH DEFERRED MANUAL " +
+                    " AS SELECT k1, k2, sum(v1), count(v2) from m1 group by k1, k2;",
+                    () -> {
+                        starRocksAssert.refreshMvPartition(String.format("REFRESH MATERIALIZED VIEW mv0 \n" +
+                                "PARTITION START ('%s') END ('%s')", "1", "3"));
+                        MaterializedView mv1 = getMv("test", "mv0");
+                        Set<String> mvNames = mv1.getPartitionNames();
+                        Assert.assertEquals("[p1]", mvNames.toString());
+
+                        runner.run();
+                    });
+        });
+    }
+
+    private void withPartialJoinMv(StarRocksAssert.ExceptionRunnable runner) {
+        starRocksAssert.withTables(ImmutableList.of(m1, m2), () -> {
+            cluster.runSql("test", "insert into m1 values (1,1,1,1), (4,2,1,1);");
+            cluster.runSql("test", "insert into m2 values (1,1,1,1), (4,2,1,1);");
+            starRocksAssert.withMaterializedView("CREATE MATERIALIZED VIEW mv0 " +
+                            " PARTITION BY (k1) " +
+                            " DISTRIBUTED BY HASH(k1) " +
+                            " REFRESH DEFERRED MANUAL " +
+                            " AS SELECT m1.k1, m1.k2, sum(m1.v1), sum(m2.v2) " +
+                            "from m1 join m2 on m1.k1=m2.k1 group by m1.k1, m1.k2;",
+                    () -> {
+                        starRocksAssert.refreshMvPartition(String.format("REFRESH MATERIALIZED VIEW mv0 \n" +
+                                "PARTITION START ('%s') END ('%s')", "1", "3"));
+                        MaterializedView mv1 = getMv("test", "mv0");
+                        Set<String> mvNames = mv1.getPartitionNames();
+                        Assert.assertEquals("[p1]", mvNames.toString());
+
+                        runner.run();
+                    });
+        });
+    }
+
+    @Test
+    public void testTransparentRewriteWithScanMv() {
+        withPartialScanMv(() -> {
+            // compensate rewrite: no compensation
+            {
+                String[] sqls = {
+                        "SELECT k1, k2, v1, v2 from m1 where k1=1",
+                        "SELECT k1, k2, v1, v2 from m1 where k1<3",
+                        "SELECT k1, k2, v1, v2 from m1 where k1<2",
+                };
+                String[] expectPlans = {
+                        "     TABLE: mv0\n" +
+                                "     PREAGGREGATION: ON\n" +
+                                "     PREDICATES: 5: k1 = 1\n" +
+                                "     partitions=1/1\n" +
+                                "     rollup: mv0\n" +
+                                "     tabletRatio=1/3",
+                        "     TABLE: mv0\n" +
+                                "     PREAGGREGATION: ON\n" +
+                                "     PREDICATES: 5: k1 < 3\n" +
+                                "     partitions=1/1\n" +
+                                "     rollup: mv0\n" +
+                                "     tabletRatio=3/3",
+                        "     TABLE: mv0\n" +
+                                "     PREAGGREGATION: ON\n" +
+                                "     PREDICATES: 5: k1 < 2\n" +
+                                "     partitions=1/1\n" +
+                                "     rollup: mv0\n" +
+                                "     tabletRatio=3/3",
+                };
+                for (int i = 0; i < sqls.length; i++) {
+                    String query = sqls[i];
+                    String plan = getFragmentPlan(query);
+                    PlanTestBase.assertNotContains(plan, ":UNION");
+                    PlanTestBase.assertContains(plan, "mv0");
+                    PlanTestBase.assertContains(plan, expectPlans[i]);
+                }
+            }
+
+            // no rewrite
+            {
+                String[] sqls = {
+                        "SELECT k1, k2, v1, v2 from m1 where k1=6 and k2 like 'a%'",
+                        "SELECT k1, k2, v1, v2 from m1 where k1=5  and k2 like 'a%'",
+                        "SELECT k1, k2, v1, v2 from m1 where k1 > 3 and k1 < 6 and k2 like 'a%'",
+                        "SELECT k1, k2, v1, v2 from m1 where k1>6 and k2 like 'a%'",
+                };
+                String[] expectPlans = {
+                        "     TABLE: m1\n" +
+                                "     PREAGGREGATION: ON\n" +
+                                "     PREDICATES: 1: k1 = 6, 2: k2 LIKE 'a%'\n" +
+                                "     partitions=1/3\n" +
+                                "     rollup: m1\n" +
+                                "     tabletRatio=1/3",
+                        "     TABLE: m1\n" +
+                                "     PREAGGREGATION: ON\n" +
+                                "     PREDICATES: 1: k1 = 5, 2: k2 LIKE 'a%'\n" +
+                                "     partitions=1/3\n" +
+                                "     rollup: m1\n" +
+                                "     tabletRatio=1/3",
+                        "     TABLE: m1\n" +
+                                "     PREAGGREGATION: ON\n" +
+                                "     PREDICATES: 1: k1 > 3, 2: k2 LIKE 'a%'\n" +
+                                "     partitions=1/3\n" +
+                                "     rollup: m1\n" +
+                                "     tabletRatio=3/3",
+                        "     TABLE: m1\n" +
+                                "     PREAGGREGATION: ON\n" +
+                                "     PREDICATES: 1: k1 > 6, 2: k2 LIKE 'a%'\n" +
+                                "     partitions=1/3\n" +
+                                "     rollup: m1\n" +
+                                "     tabletRatio=3/3",
+                };
+                for (int i = 0; i < sqls.length; i++) {
+                    String query = sqls[i];
+                    String plan = getFragmentPlan(query);
+                    PlanTestBase.assertNotContains(plan, "mv0");
+                    PlanTestBase.assertContains(plan, expectPlans[i]);
+                }
+            }
+
+            // transparent union rewrite: pruned compensation
+            {
+                String[] sqls = {
+                        "SELECT k1, k2, v1, v2 from m1 where k1<6 and k2 like 'a%'",
+                        "SELECT k1, k2, v1, v2 from m1 where k1 > 0 and k1 < 6 and k2 like 'a%'",
+                        "SELECT k1, k2, v1, v2 from m1 where k1>1 and k1 < 6 and k2 like 'a%'",
+                };
+                String[] expectPlans = {
+                        "     TABLE: m1\n" +
+                                "     PREAGGREGATION: ON\n" +
+                                "     PREDICATES: 13: k1 < 6, 14: k2 LIKE 'a%'\n" +
+                                "     partitions=1/3\n" +
+                                "     rollup: m1\n" +
+                                "     tabletRatio=3/3",
+                        "     TABLE: mv0\n" +
+                                "     PREAGGREGATION: ON\n" +
+                                "     PREDICATES: 9: k1 < 6, 10: k2 LIKE 'a%'\n" +
+                                "     partitions=1/1\n" +
+                                "     rollup: mv0\n" +
+                                "     tabletRatio=3/3",
+                        "     TABLE: m1\n" +
+                                "     PREAGGREGATION: ON\n" +
+                                "     PREDICATES: 13: k1 > 0, 13: k1 < 6, 14: k2 LIKE 'a%'\n" +
+                                "     partitions=1/3\n" +
+                                "     rollup: m1\n" +
+                                "     tabletRatio=3/3",
+                        "     TABLE: mv0\n" +
+                                "     PREAGGREGATION: ON\n" +
+                                "     PREDICATES: 9: k1 > 0, 9: k1 < 6, 10: k2 LIKE 'a%'\n" +
+                                "     partitions=1/1\n" +
+                                "     rollup: mv0\n" +
+                                "     tabletRatio=3/3",
+                        "     TABLE: m1\n" +
+                                "     PREAGGREGATION: ON\n" +
+                                "     PREDICATES: 13: k1 > 1, 13: k1 < 6, 14: k2 LIKE 'a%'\n" +
+                                "     partitions=1/3\n" +
+                                "     rollup: m1\n" +
+                                "     tabletRatio=3/3",
+                        "     TABLE: mv0\n" +
+                                "     PREAGGREGATION: ON\n" +
+                                "     PREDICATES: 9: k1 > 1, 9: k1 < 6, 10: k2 LIKE 'a%'\n" +
+                                "     partitions=1/1\n" +
+                                "     rollup: mv0\n" +
+                                "     tabletRatio=3/3",
+                };
+                for (int i = 0; i < sqls.length; i++) {
+                    String query = sqls[i];
+                    String plan = getFragmentPlan(query);
+                    PlanTestBase.assertContains(plan, ":UNION", ": mv0", ": m1");
+                    String expect1 = expectPlans[i * 2];
+                    String expect2 = expectPlans[i * 2 + 1];
+                    PlanTestBase.assertContains(plan, expect1);
+                    PlanTestBase.assertContains(plan, expect2);
+                }
+            }
+
+
+            // transparent union rewrite: no pruned compensation
+            {
+                String[] sqls = {
+                        "SELECT k1, k2, v1, v2 from m1 where k1 != 3 and k2 like 'a%'",
+                        "SELECT k1, k2, v1, v2 from m1 where k1 > 0 and k2 like 'a%'",
+                        "SELECT k1, k2, v1, v2 from m1 where k1>1 and k2 like 'a%'",
+                        "SELECT k1, k2, v1, v2 from m1 where k1>0 and k2 like 'a%'",
+                };
+                String[] expectPlans = {
+                        "     TABLE: mv0\n" +
+                                "     PREAGGREGATION: ON\n" +
+                                "     PREDICATES: 9: k1 != 3, 10: k2 LIKE 'a%'\n" +
+                                "     partitions=1/1\n" +
+                                "     rollup: mv0\n" +
+                                "     tabletRatio=3/3",
+                        "     TABLE: m1\n" +
+                                "     PREAGGREGATION: ON\n" +
+                                "     PREDICATES: 13: k1 != 3, 14: k2 LIKE 'a%'\n" +
+                                "     partitions=2/3\n" +
+                                "     rollup: m1\n" +
+                                "     tabletRatio=6/6",
+                        "     TABLE: mv0\n" +
+                                "     PREAGGREGATION: ON\n" +
+                                "     PREDICATES: 9: k1 > 0, 10: k2 LIKE 'a%'\n" +
+                                "     partitions=1/1\n" +
+                                "     rollup: mv0\n" +
+                                "     tabletRatio=3/3",
+                        "     TABLE: m1\n" +
+                                "     PREAGGREGATION: ON\n" +
+                                "     PREDICATES: 13: k1 > 0, 14: k2 LIKE 'a%'\n" +
+                                "     partitions=2/3\n" +
+                                "     rollup: m1\n" +
+                                "     tabletRatio=6/6",
+                        "     TABLE: mv0\n" +
+                                "     PREAGGREGATION: ON\n" +
+                                "     PREDICATES: 9: k1 > 1, 10: k2 LIKE 'a%'\n" +
+                                "     partitions=1/1\n" +
+                                "     rollup: mv0\n" +
+                                "     tabletRatio=3/3",
+                        "     TABLE: m1\n" +
+                                "     PREAGGREGATION: ON\n" +
+                                "     PREDICATES: 13: k1 > 1, 14: k2 LIKE 'a%'\n" +
+                                "     partitions=2/3\n" +
+                                "     rollup: m1\n" +
+                                "     tabletRatio=6/6",
+                        "     TABLE: mv0\n" +
+                                "     PREAGGREGATION: ON\n" +
+                                "     PREDICATES: 9: k1 > 0, 10: k2 LIKE 'a%'\n" +
+                                "     partitions=1/1\n" +
+                                "     rollup: mv0\n" +
+                                "     tabletRatio=3/3",
+                        "     TABLE: m1\n" +
+                                "     PREAGGREGATION: ON\n" +
+                                "     PREDICATES: 13: k1 > 0, 14: k2 LIKE 'a%'\n" +
+                                "     partitions=2/3\n" +
+                                "     rollup: m1\n" +
+                                "     tabletRatio=6/6",
+                };
+                for (int i = 0; i < sqls.length; i++) {
+                    String query = sqls[i];
+                    String plan = getFragmentPlan(query);
+                    PlanTestBase.assertContains(plan, ":UNION", ": mv0", ": m1");
+                    String expect1 = expectPlans[i * 2];
+                    String expect2 = expectPlans[i * 2 + 1];
+                    PlanTestBase.assertContains(plan, expect1);
+                    PlanTestBase.assertContains(plan, expect2);
+                }
+            }
+        });
+    }
+
+    @Test
+    public void testTransparentRewriteWithScanMvAndAggQuery() {
+        withPartialScanMv(() -> {
+            // no compensation
+            {
+                String[] sqls = {
+                        "SELECT k1, k2, sum(v1), count(v2) from m1 where k1=1 group by k1, k2",
+                        "SELECT k1, k2, sum(v1), count(v2) from m1 where k1<3 group by k1, k2",
+                        "SELECT k1, k2, sum(v1), count(v2) from m1 where k1<=2 group by k1, k2",
+                };
+                String[] expects = {
+                        "     TABLE: mv0\n" +
+                                "     PREAGGREGATION: ON\n" +
+                                "     PREDICATES: 7: k1 = 1\n" +
+                                "     partitions=1/1\n" +
+                                "     rollup: mv0\n" +
+                                "     tabletRatio=1/3",
+                        "     TABLE: mv0\n" +
+                                "     PREAGGREGATION: ON\n" +
+                                "     PREDICATES: 7: k1 < 3\n" +
+                                "     partitions=1/1\n" +
+                                "     rollup: mv0\n" +
+                                "     tabletRatio=3/3",
+                        "     TABLE: mv0\n" +
+                                "     PREAGGREGATION: ON\n" +
+                                "     PREDICATES: 7: k1 <= 2\n" +
+                                "     partitions=1/1\n" +
+                                "     rollup: mv0\n" +
+                                "     tabletRatio=3/3"
+                };
+                for (int i = 0; i < sqls.length; i++) {
+                    String query = sqls[i];
+                    String plan = getFragmentPlan(query);
+                    PlanTestBase.assertNotContains(plan, ":UNION");
+                    PlanTestBase.assertContains(plan, "mv0");
+                }
+            }
+
+            {
+                String[] sqls = {
+                        "SELECT k1, k2, sum(v1), count(v2) from m1 where k1<6 and k2 like 'a%' group by k1, k2",
+                        "SELECT k1, k2, sum(v1), count(v2) from m1 where k1!=3 and k1 < 6 and k2 like 'a%' group by k1, k2",
+                        "SELECT k1, k2, sum(v1), count(v2) from m1 where k1>1 and k1< 6 and k2 like 'a%' group by k1, k2",
+                        "SELECT k1, k2, sum(v1), count(v2) from m1 where k1<6 and k2 like 'a%' group by k1, k2",
+                        "SELECT k1, k2, sum(v1), count(v2) from m1 where k1+1<6 and k2 like 'a%' group by k1, k2",
+                };
+                for (int i = 0; i < sqls.length; i++) {
+                    String query = sqls[i];
+                    String plan = getFragmentPlan(query);
+                    PlanTestBase.assertContains(plan, ":UNION", ": mv0", ": m1");
+                }
+            }
+
+            // no pruned compensation
+            {
+                String[] sqls = {
+                        "SELECT k1, k2, sum(v1), count(v2) from m1 where k1!=3 and k2 like 'a%' group by k1, k2",
+                        "SELECT k1, k2, sum(v1), count(v2) from m1 where k1>0 and k2 like 'a%' group by k1, k2",
+                        "SELECT k1, k2, sum(v1), count(v2) from m1 where k1>1 and k2 like 'a%' group by k1, k2",
+                };
+                for (int i = 0; i < sqls.length; i++) {
+                    String query = sqls[i];
+                    String plan = getFragmentPlan(query);
+                    PlanTestBase.assertContains(plan, ": mv0");
+                }
+            }
+        });
+    }
+
+    @Test
+    public void testTransparentRewriteWithAggMv() {
+        withPartialAggregateMv(() -> {
+            // no compensation
+            {
+                String[] sqls = {
+                        "SELECT k1, k2, sum(v1), count(v2) from m1 where k1=1 group by k1, k2",
+                        "SELECT k1, k2, sum(v1), count(v2) from m1 where k1<3 group by k1, k2",
+                        "SELECT k1, k2, sum(v1), count(v2) from m1 where k1<=2 group by k1, k2",
+                };
+                for (int i = 0; i < sqls.length; i++) {
+                    String query = sqls[i];
+                    String plan = getFragmentPlan(query);
+                    PlanTestBase.assertNotContains(plan, ":UNION");
+                    PlanTestBase.assertContains(plan, "mv0");
+                }
+            }
+
+            // pruned compensation
+            {
+                String[] sqls = {
+                        "SELECT k1, k2, sum(v1), count(v2) from m1 where k1<6 and k2 like 'a%' group by k1, k2",
+                        "SELECT k1, k2, sum(v1), count(v2) from m1 where k1!=3 and k1 < 6 and k2 like 'a%' group by k1, k2",
+                        "SELECT k1, k2, sum(v1), count(v2) from m1 where k1>0 and k1 < 6 and k2 like 'a%' group by k1, k2",
+                        "SELECT k1, k2, sum(v1), count(v2) from m1 where k1>1 and k1 < 6 and k2 like 'a%' group by k1, k2",
+                        "SELECT k1, k2, sum(v1), count(v2) from m1 where k1<6 and k2 like 'a%' group by k1, k2",
+                        "SELECT k1, k2, sum(v1), count(v2) from m1 where k1+1<6 and k2 like 'a%' group by k1, k2",
+                };
+                for (int i = 0; i < sqls.length; i++) {
+                    String query = sqls[i];
+                    String plan = getFragmentPlan(query);
+                    PlanTestBase.assertContains(plan, ":UNION", ": mv0", ": m1");
+                }
+            }
+
+            // no pruned compensation
+            {
+                String[] sqls = {
+                        "SELECT k1, k2, sum(v1), count(v2) from m1 where k1!=3 and k2 like 'a%' group by k1, k2",
+                        "SELECT k1, k2, sum(v1), count(v2) from m1 where k1>0 and k2 like 'a%' group by k1, k2",
+                        "SELECT k1, k2, sum(v1), count(v2) from m1 where k1>1 and k2 like 'a%' group by k1, k2",
+                };
+                for (int i = 0; i < sqls.length; i++) {
+                    String query = sqls[i];
+                    String plan = getFragmentPlan(query);
+                    PlanTestBase.assertContains(plan, ":UNION", ": mv0");
+                }
+            }
+        });
+    }
+
+    @Test
+    public void testTransparentRewriteWithJoinMv() {
+        withPartialJoinMv(() -> {
+            {
+                String[] sqls = {
+                        "SELECT m1.k1, m1.k2, sum(m1.v1), sum(m2.v2) from m1 join m2 on m1.k1=m2.k1 where m1.k1=1 " +
+                                "group by m1.k1, m1.k2;",
+                        "SELECT m1.k1, m1.k2, sum(m1.v1), sum(m2.v2) from m1 join m2 on m1.k1=m2.k1 where m1.k1<3 " +
+                                "group by m1.k1, m1.k2;",
+                };
+                for (int i = 0; i < sqls.length; i++) {
+                    String query = sqls[i];
+                    String plan = getFragmentPlan(query);
+                    PlanTestBase.assertNotContains(plan, ":UNION");
+                    PlanTestBase.assertContains(plan, "mv0");
+                }
+            }
+
+            // pruned compensation
+            {
+                String[] sqls = {
+                        "SELECT m1.k1, m1.k2, sum(m1.v1), sum(m2.v2) from m1 join m2 on m1.k1=m2.k1 where m1.k1 > 1 and " +
+                                "m1.k1 < 6 group by m1.k1, m1.k2;",
+                        "SELECT m1.k1, m1.k2, sum(m1.v1), sum(m2.v2) from m1 join m2 on m1.k1=m2.k1 " +
+                                "where m1.k1 != 1 and m1.k1 < 6 and m1.k2 like 'a%' group by m1.k1, m1.k2;",
+                        "SELECT m1.k1, m1.k2, sum(m1.v1), sum(m2.v2) from m1 join m2 on m1.k1=m2.k1 " +
+                                "where m1.k1 < 6 and m1.k2 like 'a%' group by m1.k1, m1.k2;",
+                        "SELECT m1.k1, m1.k2, sum(m1.v1), sum(m2.v2) from m1 join m2 on m1.k1=m2.k1 " +
+                                "where m1.k1 + 1 < 6 and m1.k2 like 'a%' group by m1.k1, m1.k2;",
+                };
+                for (int i = 0; i < sqls.length; i++) {
+                    String query = sqls[i];
+                    String plan = getFragmentPlan(query);
+                    PlanTestBase.assertContains(plan, ":UNION", ": mv0", ": m1");
+                }
+            }
+
+            // no pruned compensation
+            {
+                String[] sqls = {
+                        "SELECT m1.k1, m1.k2, sum(m1.v1), sum(m2.v2) from m1 join m2 on m1.k1=m2.k1 where m1.k1 > 1 " +
+                                "group by m1.k1, m1.k2;",
+                        "SELECT m1.k1, m1.k2, sum(m1.v1), sum(m2.v2) from m1 join m2 on m1.k1=m2.k1 " +
+                                "where m1.k1 != 1 and m1.k2 like 'a%' group by m1.k1, m1.k2;",
+                };
+                for (int i = 0; i < sqls.length; i++) {
+                    String query = sqls[i];
+                    String plan = getFragmentPlan(query);
+                    PlanTestBase.assertContains(plan, ":UNION", ": mv0", ": m1");
+                }
+            }
+        });
+    }
+}

--- a/fe/fe-core/src/test/java/com/starrocks/utframe/StarRocksAssert.java
+++ b/fe/fe-core/src/test/java/com/starrocks/utframe/StarRocksAssert.java
@@ -314,6 +314,13 @@ public class StarRocksAssert {
         return this;
     }
 
+    public StarRocksAssert withTable(MTable mTable) throws Exception {
+        String sql = mTable.getCreateTableSql();
+        CreateTableStmt createTableStmt = (CreateTableStmt) UtFrameUtils.parseStmtWithNewParser(sql, ctx);
+        utCreateTableWithRetry(createTableStmt, ctx);
+        return this;
+    }
+
     public StarRocksAssert withTable(PseudoCluster cluster,
                                      MTable mTable,
                                      ExceptionRunnable action) {

--- a/test/sql/test_materialized_view/R/test_mv_partition_compensate_hive
+++ b/test/sql/test_materialized_view/R/test_mv_partition_compensate_hive
@@ -1,0 +1,1631 @@
+-- name: test_mv_partition_compensate_hive
+create external catalog mv_hive_${uuid0}
+properties
+(
+    "type" = "hive",
+    "hive.catalog.type" = "hive",
+    "hive.metastore.uris" = "${hive_metastore_uris}"
+);
+-- result:
+-- !result
+set materialized_view_union_rewrite_mode = 3;
+-- result:
+-- !result
+set catalog mv_hive_${uuid0};
+-- result:
+-- !result
+create database mv_hive_db_${uuid0};
+-- result:
+-- !result
+use mv_hive_db_${uuid0};
+-- result:
+-- !result
+CREATE TABLE t1 (
+  num int,
+  dt date
+)
+PARTITION BY (dt);
+-- result:
+-- !result
+INSERT INTO t1 VALUES 
+  (1,"2020-06-15"),(2,"2020-06-18"),(3,"2020-06-21"),(4,"2020-06-24"),
+  (1,"2020-07-02"),(2,"2020-07-05"),(3,"2020-07-08"),(4,"2020-07-11"),
+  (1,"2020-07-16"),(2,"2020-07-19"),(3,"2020-07-22"),(4,"2020-07-25"),
+  (2,"2020-06-15"),(3,"2020-06-18"),(4,"2020-06-21"),(5,"2020-06-24"),
+  (2,"2020-07-02"),(3,"2020-07-05"),(4,"2020-07-08"),(5,"2020-07-11");
+-- result:
+-- !result
+CREATE TABLE t2 (
+  num int,
+  dt string
+)
+PARTITION BY (dt);
+-- result:
+-- !result
+INSERT INTO t2 VALUES 
+  (1,"2020-06-15"),(2,"2020-06-18"),(3,"2020-06-21"),(4,"2020-06-24"),
+  (1,"2020-07-02"),(2,"2020-07-05"),(3,"2020-07-08"),(4,"2020-07-11"),
+  (1,"2020-07-16"),(2,"2020-07-19"),(3,"2020-07-22"),(4,"2020-07-25"),
+  (2,"2020-06-15"),(3,"2020-06-18"),(4,"2020-06-21"),(5,"2020-06-24"),
+  (2,"2020-07-02"),(3,"2020-07-05"),(4,"2020-07-08"),(5,"2020-07-11");
+-- result:
+-- !result
+set catalog default_catalog;
+-- result:
+-- !result
+create database db_${uuid0};
+-- result:
+-- !result
+use db_${uuid0};
+-- result:
+-- !result
+CREATE MATERIALIZED VIEW test_mv1 
+PARTITION BY dt 
+REFRESH DEFERRED MANUAL AS 
+  SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 GROUP BY dt;
+-- result:
+-- !result
+REFRESH MATERIALIZED VIEW test_mv1 WITH SYNC MODE;
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 where dt='2020-06-15' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 where dt !='2020-06-15' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 where dt>='2020-06-15' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 where dt>'2020-06-15' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 where dt>'2020-06-15' and dt < '2020-07-22' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 where dt>'2020-06-15' and dt <= '2020-07-22' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 where (dt>'2020-06-15' and dt <= '2020-06-22') or dt>'2020-07-01' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 where dt in ('2020-06-15', '2020-06-22', '2020-07-01') GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 where date_trunc('day', dt) ='2020-06-15' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 where date_trunc('month', dt) ='2020-06-01' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 where date_trunc('month', dt) ='2020-07-01' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 where dt='2020-06-15' GROUP BY dt order by dt;
+-- result:
+2020-06-15	3
+-- !result
+SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 where dt !='2020-06-15' GROUP BY dt order by dt;
+-- result:
+2020-06-18	5
+2020-06-21	7
+2020-06-24	9
+2020-07-02	3
+2020-07-05	5
+2020-07-08	7
+2020-07-11	9
+2020-07-16	1
+2020-07-19	2
+2020-07-22	3
+2020-07-25	4
+-- !result
+SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 where dt>='2020-06-15' GROUP BY dt order by dt;
+-- result:
+2020-06-15	3
+2020-06-18	5
+2020-06-21	7
+2020-06-24	9
+2020-07-02	3
+2020-07-05	5
+2020-07-08	7
+2020-07-11	9
+2020-07-16	1
+2020-07-19	2
+2020-07-22	3
+2020-07-25	4
+-- !result
+SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 where dt>'2020-06-15' GROUP BY dt order by dt;
+-- result:
+2020-06-18	5
+2020-06-21	7
+2020-06-24	9
+2020-07-02	3
+2020-07-05	5
+2020-07-08	7
+2020-07-11	9
+2020-07-16	1
+2020-07-19	2
+2020-07-22	3
+2020-07-25	4
+-- !result
+SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 where dt>'2020-06-15' and dt < '2020-07-22' GROUP BY dt order by dt;
+-- result:
+2020-06-18	5
+2020-06-21	7
+2020-06-24	9
+2020-07-02	3
+2020-07-05	5
+2020-07-08	7
+2020-07-11	9
+2020-07-16	1
+2020-07-19	2
+-- !result
+SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 where dt>'2020-06-15' and dt <= '2020-07-22' GROUP BY dt order by dt;
+-- result:
+2020-06-18	5
+2020-06-21	7
+2020-06-24	9
+2020-07-02	3
+2020-07-05	5
+2020-07-08	7
+2020-07-11	9
+2020-07-16	1
+2020-07-19	2
+2020-07-22	3
+-- !result
+SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 where (dt>'2020-06-15' and dt <= '2020-06-22') or dt>'2020-07-01' GROUP BY dt order by dt;
+-- result:
+2020-06-18	5
+2020-06-21	7
+2020-07-02	3
+2020-07-05	5
+2020-07-08	7
+2020-07-11	9
+2020-07-16	1
+2020-07-19	2
+2020-07-22	3
+2020-07-25	4
+-- !result
+SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 where dt in ('2020-06-15', '2020-06-22', '2020-07-01') GROUP BY dt order by dt;
+-- result:
+2020-06-15	3
+-- !result
+SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 where date_trunc('day', dt) ='2020-06-15' GROUP BY dt order by dt;
+-- result:
+2020-06-15	3
+-- !result
+SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 where date_trunc('month', dt) ='2020-06-01' GROUP BY dt order by dt;
+-- result:
+2020-06-15	3
+2020-06-18	5
+2020-06-21	7
+2020-06-24	9
+-- !result
+SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 where date_trunc('month', dt) ='2020-07-01' GROUP BY dt order by dt;
+-- result:
+2020-07-02	3
+2020-07-05	5
+2020-07-08	7
+2020-07-11	9
+2020-07-16	1
+2020-07-19	2
+2020-07-22	3
+2020-07-25	4
+-- !result
+SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 GROUP BY dt order by dt;
+-- result:
+2020-06-15	3
+2020-06-18	5
+2020-06-21	7
+2020-06-24	9
+2020-07-02	3
+2020-07-05	5
+2020-07-08	7
+2020-07-11	9
+2020-07-16	1
+2020-07-19	2
+2020-07-22	3
+2020-07-25	4
+-- !result
+INSERT INTO mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 VALUES (3, "2020-06-15");
+-- result:
+-- !result
+function: check_no_hit_materialized_view("SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 where dt='2020-06-15' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_no_hit_materialized_view("SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 where date_trunc('day', dt) ='2020-06-15' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_no_hit_materialized_view("SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 where dt in ('2020-06-15', '2020-06-22', '2020-07-01') GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 where date_trunc('day', dt) ='2020-06-21' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 where dt !='2020-06-15' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 where dt>'2020-06-15' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 where dt>'2020-06-15' and dt < '2020-07-22' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 where dt>'2020-06-15' and dt <= '2020-07-22' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 where (dt>'2020-06-15' and dt <= '2020-06-22') or dt>'2020-07-01' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 where dt in ('2020-06-21', '2020-07-25') GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 where date_trunc('month', dt) ='2020-07-01' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 where dt between '2020-06-16' and '2020-07-01' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 where dt between '2020-06-15' and '2020-07-01' GROUP BY dt;", "test_mv1", "UNION")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 where dt>='2020-06-15' GROUP BY dt;", "test_mv1", "UNION")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 where dt in ('2020-06-15', '2020-06-21', '2020-07-25') GROUP BY dt;", "test_mv1", "UNION")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 where date_trunc('month', dt) ='2020-06-01' GROUP BY dt;", "test_mv1", "UNION")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 GROUP BY dt;", "test_mv1", "UNION")
+-- result:
+None
+-- !result
+SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 where dt='2020-06-15' GROUP BY dt order by dt;
+-- result:
+2020-06-15	6
+-- !result
+SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 where dt !='2020-06-15' GROUP BY dt order by dt;
+-- result:
+2020-06-18	5
+2020-06-21	7
+2020-06-24	9
+2020-07-02	3
+2020-07-05	5
+2020-07-08	7
+2020-07-11	9
+2020-07-16	1
+2020-07-19	2
+2020-07-22	3
+2020-07-25	4
+-- !result
+SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 where dt>='2020-06-15' GROUP BY dt order by dt;
+-- result:
+2020-06-15	6
+2020-06-18	5
+2020-06-21	7
+2020-06-24	9
+2020-07-02	3
+2020-07-05	5
+2020-07-08	7
+2020-07-11	9
+2020-07-16	1
+2020-07-19	2
+2020-07-22	3
+2020-07-25	4
+-- !result
+SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 where dt>'2020-06-15' GROUP BY dt order by dt;
+-- result:
+2020-06-18	5
+2020-06-21	7
+2020-06-24	9
+2020-07-02	3
+2020-07-05	5
+2020-07-08	7
+2020-07-11	9
+2020-07-16	1
+2020-07-19	2
+2020-07-22	3
+2020-07-25	4
+-- !result
+SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 where dt>'2020-06-15' and dt < '2020-07-22' GROUP BY dt order by dt;
+-- result:
+2020-06-18	5
+2020-06-21	7
+2020-06-24	9
+2020-07-02	3
+2020-07-05	5
+2020-07-08	7
+2020-07-11	9
+2020-07-16	1
+2020-07-19	2
+-- !result
+SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 where dt>'2020-06-15' and dt <= '2020-07-22' GROUP BY dt order by dt;
+-- result:
+2020-06-18	5
+2020-06-21	7
+2020-06-24	9
+2020-07-02	3
+2020-07-05	5
+2020-07-08	7
+2020-07-11	9
+2020-07-16	1
+2020-07-19	2
+2020-07-22	3
+-- !result
+SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 where (dt>'2020-06-15' and dt <= '2020-06-22') or dt>'2020-07-01' GROUP BY dt order by dt;
+-- result:
+2020-06-18	5
+2020-06-21	7
+2020-07-02	3
+2020-07-05	5
+2020-07-08	7
+2020-07-11	9
+2020-07-16	1
+2020-07-19	2
+2020-07-22	3
+2020-07-25	4
+-- !result
+SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 where dt in ('2020-06-22', '2020-07-01') GROUP BY dt order by dt;
+-- result:
+-- !result
+SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 where dt in ('2020-06-15', '2020-06-22', '2020-07-01') GROUP BY dt order by dt;
+-- result:
+2020-06-15	6
+-- !result
+SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 where dt between '2020-06-15' and '2020-07-01' GROUP BY dt order by dt;
+-- result:
+2020-06-15	6
+2020-06-18	5
+2020-06-21	7
+2020-06-24	9
+-- !result
+SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 where date_trunc('day', dt) ='2020-06-15' GROUP BY dt order by dt;
+-- result:
+2020-06-15	6
+-- !result
+SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 where date_trunc('month', dt) ='2020-06-01' GROUP BY dt order by dt;
+-- result:
+2020-06-15	6
+2020-06-18	5
+2020-06-21	7
+2020-06-24	9
+-- !result
+SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 where date_trunc('month', dt) ='2020-07-01' GROUP BY dt order by dt;
+-- result:
+2020-07-02	3
+2020-07-05	5
+2020-07-08	7
+2020-07-11	9
+2020-07-16	1
+2020-07-19	2
+2020-07-22	3
+2020-07-25	4
+-- !result
+SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 GROUP BY dt order by dt;
+-- result:
+2020-06-15	6
+2020-06-18	5
+2020-06-21	7
+2020-06-24	9
+2020-07-02	3
+2020-07-05	5
+2020-07-08	7
+2020-07-11	9
+2020-07-16	1
+2020-07-19	2
+2020-07-22	3
+2020-07-25	4
+-- !result
+drop materialized view default_catalog.db_${uuid0}.test_mv1;
+-- result:
+-- !result
+CREATE MATERIALIZED VIEW test_mv1 
+PARTITION BY date_trunc('day', dt)
+REFRESH DEFERRED MANUAL AS 
+  SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 GROUP BY dt;
+-- result:
+-- !result
+REFRESH MATERIALIZED VIEW test_mv1 WITH SYNC MODE;
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 where dt='2020-06-15' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 where dt !='2020-06-15' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 where dt>='2020-06-15' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 where dt>'2020-06-15' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 where dt>'2020-06-15' and dt < '2020-07-22' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 where dt>'2020-06-15' and dt <= '2020-07-22' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 where (dt>'2020-06-15' and dt <= '2020-06-22') or dt>'2020-07-01' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 where dt in ('2020-06-15', '2020-06-22', '2020-07-01') GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 where date_trunc('day', dt) ='2020-06-15' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 where date_trunc('month', dt) ='2020-06-01' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 where date_trunc('month', dt) ='2020-07-01' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 where dt='2020-06-15' GROUP BY dt order by dt;
+-- result:
+2020-06-15	6
+-- !result
+SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 where dt !='2020-06-15' GROUP BY dt order by dt;
+-- result:
+2020-06-18	5
+2020-06-21	7
+2020-06-24	9
+2020-07-02	3
+2020-07-05	5
+2020-07-08	7
+2020-07-11	9
+2020-07-16	1
+2020-07-19	2
+2020-07-22	3
+2020-07-25	4
+-- !result
+SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 where dt>='2020-06-15' GROUP BY dt order by dt;
+-- result:
+2020-06-15	6
+2020-06-18	5
+2020-06-21	7
+2020-06-24	9
+2020-07-02	3
+2020-07-05	5
+2020-07-08	7
+2020-07-11	9
+2020-07-16	1
+2020-07-19	2
+2020-07-22	3
+2020-07-25	4
+-- !result
+SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 where dt>'2020-06-15' GROUP BY dt order by dt;
+-- result:
+2020-06-18	5
+2020-06-21	7
+2020-06-24	9
+2020-07-02	3
+2020-07-05	5
+2020-07-08	7
+2020-07-11	9
+2020-07-16	1
+2020-07-19	2
+2020-07-22	3
+2020-07-25	4
+-- !result
+SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 where dt>'2020-06-15' and dt < '2020-07-22' GROUP BY dt order by dt;
+-- result:
+2020-06-18	5
+2020-06-21	7
+2020-06-24	9
+2020-07-02	3
+2020-07-05	5
+2020-07-08	7
+2020-07-11	9
+2020-07-16	1
+2020-07-19	2
+-- !result
+SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 where dt>'2020-06-15' and dt <= '2020-07-22' GROUP BY dt order by dt;
+-- result:
+2020-06-18	5
+2020-06-21	7
+2020-06-24	9
+2020-07-02	3
+2020-07-05	5
+2020-07-08	7
+2020-07-11	9
+2020-07-16	1
+2020-07-19	2
+2020-07-22	3
+-- !result
+SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 where (dt>'2020-06-15' and dt <= '2020-06-22') or dt>'2020-07-01' GROUP BY dt order by dt;
+-- result:
+2020-06-18	5
+2020-06-21	7
+2020-07-02	3
+2020-07-05	5
+2020-07-08	7
+2020-07-11	9
+2020-07-16	1
+2020-07-19	2
+2020-07-22	3
+2020-07-25	4
+-- !result
+SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 where dt in ('2020-06-15', '2020-06-22', '2020-07-01') GROUP BY dt order by dt;
+-- result:
+2020-06-15	6
+-- !result
+SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 where date_trunc('day', dt) ='2020-06-15' GROUP BY dt order by dt;
+-- result:
+2020-06-15	6
+-- !result
+SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 where date_trunc('month', dt) ='2020-06-01' GROUP BY dt order by dt;
+-- result:
+2020-06-15	6
+2020-06-18	5
+2020-06-21	7
+2020-06-24	9
+-- !result
+SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 where date_trunc('month', dt) ='2020-07-01' GROUP BY dt order by dt;
+-- result:
+2020-07-02	3
+2020-07-05	5
+2020-07-08	7
+2020-07-11	9
+2020-07-16	1
+2020-07-19	2
+2020-07-22	3
+2020-07-25	4
+-- !result
+SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 GROUP BY dt order by dt;
+-- result:
+2020-06-15	6
+2020-06-18	5
+2020-06-21	7
+2020-06-24	9
+2020-07-02	3
+2020-07-05	5
+2020-07-08	7
+2020-07-11	9
+2020-07-16	1
+2020-07-19	2
+2020-07-22	3
+2020-07-25	4
+-- !result
+INSERT INTO mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 VALUES (3, "2020-06-15");
+-- result:
+-- !result
+function: check_no_hit_materialized_view("SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 where dt='2020-06-15' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_no_hit_materialized_view("SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 where date_trunc('day', dt) ='2020-06-15' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_no_hit_materialized_view("SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 where dt in ('2020-06-15', '2020-06-22', '2020-07-01') GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 where date_trunc('day', dt) ='2020-06-21' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 where dt !='2020-06-15' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 where dt>'2020-06-15' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 where dt>'2020-06-15' and dt < '2020-07-22' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 where dt>'2020-06-15' and dt <= '2020-07-22' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 where (dt>'2020-06-15' and dt <= '2020-06-22') or dt>'2020-07-01' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 where dt in ('2020-06-21', '2020-07-25') GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 where date_trunc('month', dt) ='2020-07-01' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 where dt between '2020-06-16' and '2020-07-01' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 where dt between '2020-06-15' and '2020-07-01' GROUP BY dt;", "test_mv1", "UNION")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 where dt>='2020-06-15' GROUP BY dt;", "test_mv1", "UNION")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 where dt in ('2020-06-15', '2020-06-21', '2020-07-25') GROUP BY dt;", "test_mv1", "UNION")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 where date_trunc('month', dt) ='2020-06-01' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 GROUP BY dt;", "test_mv1", "UNION")
+-- result:
+None
+-- !result
+SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 where dt='2020-06-15' GROUP BY dt order by dt;
+-- result:
+2020-06-15	9
+-- !result
+SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 where dt !='2020-06-15' GROUP BY dt order by dt;
+-- result:
+2020-06-18	5
+2020-06-21	7
+2020-06-24	9
+2020-07-02	3
+2020-07-05	5
+2020-07-08	7
+2020-07-11	9
+2020-07-16	1
+2020-07-19	2
+2020-07-22	3
+2020-07-25	4
+-- !result
+SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 where dt>='2020-06-15' GROUP BY dt order by dt;
+-- result:
+2020-06-15	9
+2020-06-18	5
+2020-06-21	7
+2020-06-24	9
+2020-07-02	3
+2020-07-05	5
+2020-07-08	7
+2020-07-11	9
+2020-07-16	1
+2020-07-19	2
+2020-07-22	3
+2020-07-25	4
+-- !result
+SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 where dt>'2020-06-15' GROUP BY dt order by dt;
+-- result:
+2020-06-18	5
+2020-06-21	7
+2020-06-24	9
+2020-07-02	3
+2020-07-05	5
+2020-07-08	7
+2020-07-11	9
+2020-07-16	1
+2020-07-19	2
+2020-07-22	3
+2020-07-25	4
+-- !result
+SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 where dt>'2020-06-15' and dt < '2020-07-22' GROUP BY dt order by dt;
+-- result:
+2020-06-18	5
+2020-06-21	7
+2020-06-24	9
+2020-07-02	3
+2020-07-05	5
+2020-07-08	7
+2020-07-11	9
+2020-07-16	1
+2020-07-19	2
+-- !result
+SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 where dt>'2020-06-15' and dt <= '2020-07-22' GROUP BY dt order by dt;
+-- result:
+2020-06-18	5
+2020-06-21	7
+2020-06-24	9
+2020-07-02	3
+2020-07-05	5
+2020-07-08	7
+2020-07-11	9
+2020-07-16	1
+2020-07-19	2
+2020-07-22	3
+-- !result
+SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 where (dt>'2020-06-15' and dt <= '2020-06-22') or dt>'2020-07-01' GROUP BY dt order by dt;
+-- result:
+2020-06-18	5
+2020-06-21	7
+2020-07-02	3
+2020-07-05	5
+2020-07-08	7
+2020-07-11	9
+2020-07-16	1
+2020-07-19	2
+2020-07-22	3
+2020-07-25	4
+-- !result
+SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 where dt in ('2020-06-22', '2020-07-01') GROUP BY dt order by dt;
+-- result:
+-- !result
+SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 where dt in ('2020-06-15', '2020-06-22', '2020-07-01') GROUP BY dt order by dt;
+-- result:
+2020-06-15	9
+-- !result
+SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 where dt between '2020-06-15' and '2020-07-01' GROUP BY dt order by dt;
+-- result:
+2020-06-15	9
+2020-06-18	5
+2020-06-21	7
+2020-06-24	9
+-- !result
+SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 where date_trunc('day', dt) ='2020-06-15' GROUP BY dt order by dt;
+-- result:
+2020-06-15	9
+-- !result
+SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 where date_trunc('month', dt) ='2020-06-01' GROUP BY dt order by dt;
+-- result:
+2020-06-15	9
+2020-06-18	5
+2020-06-21	7
+2020-06-24	9
+-- !result
+SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 where date_trunc('month', dt) ='2020-07-01' GROUP BY dt order by dt;
+-- result:
+2020-07-02	3
+2020-07-05	5
+2020-07-08	7
+2020-07-11	9
+2020-07-16	1
+2020-07-19	2
+2020-07-22	3
+2020-07-25	4
+-- !result
+SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 GROUP BY dt order by dt;
+-- result:
+2020-06-15	9
+2020-06-18	5
+2020-06-21	7
+2020-06-24	9
+2020-07-02	3
+2020-07-05	5
+2020-07-08	7
+2020-07-11	9
+2020-07-16	1
+2020-07-19	2
+2020-07-22	3
+2020-07-25	4
+-- !result
+drop materialized view default_catalog.db_${uuid0}.test_mv1;
+-- result:
+-- !result
+CREATE MATERIALIZED VIEW test_mv1 
+PARTITION BY str2date(dt, '%Y-%m-%d')
+REFRESH DEFERRED MANUAL AS 
+  SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t2 GROUP BY dt;
+-- result:
+-- !result
+REFRESH MATERIALIZED VIEW test_mv1 WITH SYNC MODE;
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t2 where dt='2020-06-15' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t2 where dt !='2020-06-15' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t2 where dt>='2020-06-15' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t2 where dt>'2020-06-15' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t2 where dt>'2020-06-15' and dt < '2020-07-22' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t2 where dt>'2020-06-15' and dt <= '2020-07-22' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t2 where (dt>'2020-06-15' and dt <= '2020-06-22') or dt>'2020-07-01' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t2 where dt in ('2020-06-15', '2020-06-22', '2020-07-01') GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t2 where date_trunc('day', dt) ='2020-06-15' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t2 where date_trunc('month', dt) ='2020-06-01' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t2 where date_trunc('month', dt) ='2020-07-01' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t2 GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t2 where dt='2020-06-15' GROUP BY dt order by dt;
+-- result:
+2020-06-15	3
+-- !result
+SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t2 where dt !='2020-06-15' GROUP BY dt order by dt;
+-- result:
+2020-06-18	5
+2020-06-21	7
+2020-06-24	9
+2020-07-02	3
+2020-07-05	5
+2020-07-08	7
+2020-07-11	9
+2020-07-16	1
+2020-07-19	2
+2020-07-22	3
+2020-07-25	4
+-- !result
+SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t2 where dt>='2020-06-15' GROUP BY dt order by dt;
+-- result:
+2020-06-15	3
+2020-06-18	5
+2020-06-21	7
+2020-06-24	9
+2020-07-02	3
+2020-07-05	5
+2020-07-08	7
+2020-07-11	9
+2020-07-16	1
+2020-07-19	2
+2020-07-22	3
+2020-07-25	4
+-- !result
+SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t2 where dt>'2020-06-15' GROUP BY dt order by dt;
+-- result:
+2020-06-18	5
+2020-06-21	7
+2020-06-24	9
+2020-07-02	3
+2020-07-05	5
+2020-07-08	7
+2020-07-11	9
+2020-07-16	1
+2020-07-19	2
+2020-07-22	3
+2020-07-25	4
+-- !result
+SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t2 where dt>'2020-06-15' and dt < '2020-07-22' GROUP BY dt order by dt;
+-- result:
+2020-06-18	5
+2020-06-21	7
+2020-06-24	9
+2020-07-02	3
+2020-07-05	5
+2020-07-08	7
+2020-07-11	9
+2020-07-16	1
+2020-07-19	2
+-- !result
+SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t2 where dt>'2020-06-15' and dt <= '2020-07-22' GROUP BY dt order by dt;
+-- result:
+2020-06-18	5
+2020-06-21	7
+2020-06-24	9
+2020-07-02	3
+2020-07-05	5
+2020-07-08	7
+2020-07-11	9
+2020-07-16	1
+2020-07-19	2
+2020-07-22	3
+-- !result
+SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t2 where (dt>'2020-06-15' and dt <= '2020-06-22') or dt>'2020-07-01' GROUP BY dt order by dt;
+-- result:
+2020-06-18	5
+2020-06-21	7
+2020-07-02	3
+2020-07-05	5
+2020-07-08	7
+2020-07-11	9
+2020-07-16	1
+2020-07-19	2
+2020-07-22	3
+2020-07-25	4
+-- !result
+SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t2 where dt in ('2020-06-15', '2020-06-22', '2020-07-01') GROUP BY dt order by dt;
+-- result:
+2020-06-15	3
+-- !result
+SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t2 where date_trunc('day', dt) ='2020-06-15' GROUP BY dt order by dt;
+-- result:
+2020-06-15	3
+-- !result
+SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t2 where date_trunc('month', dt) ='2020-06-01' GROUP BY dt order by dt;
+-- result:
+2020-06-15	3
+2020-06-18	5
+2020-06-21	7
+2020-06-24	9
+-- !result
+SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t2 where date_trunc('month', dt) ='2020-07-01' GROUP BY dt order by dt;
+-- result:
+2020-07-02	3
+2020-07-05	5
+2020-07-08	7
+2020-07-11	9
+2020-07-16	1
+2020-07-19	2
+2020-07-22	3
+2020-07-25	4
+-- !result
+SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t2 GROUP BY dt order by dt;
+-- result:
+2020-06-15	3
+2020-06-18	5
+2020-06-21	7
+2020-06-24	9
+2020-07-02	3
+2020-07-05	5
+2020-07-08	7
+2020-07-11	9
+2020-07-16	1
+2020-07-19	2
+2020-07-22	3
+2020-07-25	4
+-- !result
+INSERT INTO mv_hive_${uuid0}.mv_hive_db_${uuid0}.t2 VALUES (3, "2020-06-15");
+-- result:
+-- !result
+function: check_no_hit_materialized_view("SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t2 where dt='2020-06-15' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t2 where date_trunc('day', dt) ='2020-06-15' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_no_hit_materialized_view("SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t2 where dt in ('2020-06-15', '2020-06-22', '2020-07-01') GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t2 where date_trunc('day', dt) ='2020-06-21' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t2 where dt !='2020-06-15' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t2 where dt>'2020-06-15' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t2 where dt>'2020-06-15' and dt < '2020-07-22' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t2 where dt>'2020-06-15' and dt <= '2020-07-22' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t2 where (dt>'2020-06-15' and dt <= '2020-06-22') or dt>'2020-07-01' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t2 where dt in ('2020-06-21', '2020-07-25') GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t2 where date_trunc('month', dt) ='2020-07-01' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t2 where dt between '2020-06-16' and '2020-07-01' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t2 where dt between '2020-06-15' and '2020-07-01' GROUP BY dt;", "test_mv1", "UNION")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t2 where dt>='2020-06-15' GROUP BY dt;", "test_mv1", "UNION")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t2 where dt in ('2020-06-15', '2020-06-21', '2020-07-25') GROUP BY dt;", "test_mv1", "UNION")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t2 where date_trunc('month', dt) ='2020-06-01' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t2 GROUP BY dt;", "test_mv1", "UNION")
+-- result:
+None
+-- !result
+SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t2 where dt='2020-06-15' GROUP BY dt order by dt;
+-- result:
+2020-06-15	6
+-- !result
+SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t2 where dt !='2020-06-15' GROUP BY dt order by dt;
+-- result:
+2020-06-18	5
+2020-06-21	7
+2020-06-24	9
+2020-07-02	3
+2020-07-05	5
+2020-07-08	7
+2020-07-11	9
+2020-07-16	1
+2020-07-19	2
+2020-07-22	3
+2020-07-25	4
+-- !result
+SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t2 where dt>='2020-06-15' GROUP BY dt order by dt;
+-- result:
+2020-06-15	6
+2020-06-18	5
+2020-06-21	7
+2020-06-24	9
+2020-07-02	3
+2020-07-05	5
+2020-07-08	7
+2020-07-11	9
+2020-07-16	1
+2020-07-19	2
+2020-07-22	3
+2020-07-25	4
+-- !result
+SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t2 where dt>'2020-06-15' GROUP BY dt order by dt;
+-- result:
+2020-06-18	5
+2020-06-21	7
+2020-06-24	9
+2020-07-02	3
+2020-07-05	5
+2020-07-08	7
+2020-07-11	9
+2020-07-16	1
+2020-07-19	2
+2020-07-22	3
+2020-07-25	4
+-- !result
+SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t2 where dt>'2020-06-15' and dt < '2020-07-22' GROUP BY dt order by dt;
+-- result:
+2020-06-18	5
+2020-06-21	7
+2020-06-24	9
+2020-07-02	3
+2020-07-05	5
+2020-07-08	7
+2020-07-11	9
+2020-07-16	1
+2020-07-19	2
+-- !result
+SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t2 where dt>'2020-06-15' and dt <= '2020-07-22' GROUP BY dt order by dt;
+-- result:
+2020-06-18	5
+2020-06-21	7
+2020-06-24	9
+2020-07-02	3
+2020-07-05	5
+2020-07-08	7
+2020-07-11	9
+2020-07-16	1
+2020-07-19	2
+2020-07-22	3
+-- !result
+SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t2 where (dt>'2020-06-15' and dt <= '2020-06-22') or dt>'2020-07-01' GROUP BY dt order by dt;
+-- result:
+2020-06-18	5
+2020-06-21	7
+2020-07-02	3
+2020-07-05	5
+2020-07-08	7
+2020-07-11	9
+2020-07-16	1
+2020-07-19	2
+2020-07-22	3
+2020-07-25	4
+-- !result
+SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t2 where dt in ('2020-06-22', '2020-07-01') GROUP BY dt order by dt;
+-- result:
+-- !result
+SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t2 where dt in ('2020-06-15', '2020-06-22', '2020-07-01') GROUP BY dt order by dt;
+-- result:
+2020-06-15	6
+-- !result
+SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t2 where dt between '2020-06-15' and '2020-07-01' GROUP BY dt order by dt;
+-- result:
+2020-06-15	6
+2020-06-18	5
+2020-06-21	7
+2020-06-24	9
+-- !result
+SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t2 where date_trunc('day', dt) ='2020-06-15' GROUP BY dt order by dt;
+-- result:
+2020-06-15	6
+-- !result
+SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t2 where date_trunc('month', dt) ='2020-06-01' GROUP BY dt order by dt;
+-- result:
+2020-06-15	6
+2020-06-18	5
+2020-06-21	7
+2020-06-24	9
+-- !result
+SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t2 where date_trunc('month', dt) ='2020-07-01' GROUP BY dt order by dt;
+-- result:
+2020-07-02	3
+2020-07-05	5
+2020-07-08	7
+2020-07-11	9
+2020-07-16	1
+2020-07-19	2
+2020-07-22	3
+2020-07-25	4
+-- !result
+SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t2 GROUP BY dt order by dt;
+-- result:
+2020-06-15	6
+2020-06-18	5
+2020-06-21	7
+2020-06-24	9
+2020-07-02	3
+2020-07-05	5
+2020-07-08	7
+2020-07-11	9
+2020-07-16	1
+2020-07-19	2
+2020-07-22	3
+2020-07-25	4
+-- !result
+drop materialized view default_catalog.db_${uuid0}.test_mv1;
+-- result:
+-- !result
+CREATE MATERIALIZED VIEW test_mv1 
+PARTITION BY date_trunc('day', format_dt)
+REFRESH DEFERRED MANUAL AS 
+  SELECT dt, str2date(dt, '%Y-%m-%d') as format_dt, sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t2 GROUP BY dt;
+-- result:
+-- !result
+REFRESH MATERIALIZED VIEW test_mv1 WITH SYNC MODE;
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t2 where dt='2020-06-15' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t2 where dt !='2020-06-15' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t2 where dt>='2020-06-15' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t2 where dt>'2020-06-15' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t2 where dt>'2020-06-15' and dt < '2020-07-22' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t2 where dt>'2020-06-15' and dt <= '2020-07-22' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t2 where (dt>'2020-06-15' and dt <= '2020-06-22') or dt>'2020-07-01' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t2 where dt in ('2020-06-15', '2020-06-22', '2020-07-01') GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t2 where date_trunc('day', dt) ='2020-06-15' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t2 where date_trunc('month', dt) ='2020-06-01' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t2 where date_trunc('month', dt) ='2020-07-01' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t2 GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t2 where dt='2020-06-15' GROUP BY dt order by dt;
+-- result:
+2020-06-15	6
+-- !result
+SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t2 where dt !='2020-06-15' GROUP BY dt order by dt;
+-- result:
+2020-06-18	5
+2020-06-21	7
+2020-06-24	9
+2020-07-02	3
+2020-07-05	5
+2020-07-08	7
+2020-07-11	9
+2020-07-16	1
+2020-07-19	2
+2020-07-22	3
+2020-07-25	4
+-- !result
+SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t2 where dt>='2020-06-15' GROUP BY dt order by dt;
+-- result:
+2020-06-15	6
+2020-06-18	5
+2020-06-21	7
+2020-06-24	9
+2020-07-02	3
+2020-07-05	5
+2020-07-08	7
+2020-07-11	9
+2020-07-16	1
+2020-07-19	2
+2020-07-22	3
+2020-07-25	4
+-- !result
+SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t2 where dt>'2020-06-15' GROUP BY dt order by dt;
+-- result:
+2020-06-18	5
+2020-06-21	7
+2020-06-24	9
+2020-07-02	3
+2020-07-05	5
+2020-07-08	7
+2020-07-11	9
+2020-07-16	1
+2020-07-19	2
+2020-07-22	3
+2020-07-25	4
+-- !result
+SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t2 where dt>'2020-06-15' and dt < '2020-07-22' GROUP BY dt order by dt;
+-- result:
+2020-06-18	5
+2020-06-21	7
+2020-06-24	9
+2020-07-02	3
+2020-07-05	5
+2020-07-08	7
+2020-07-11	9
+2020-07-16	1
+2020-07-19	2
+-- !result
+SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t2 where dt>'2020-06-15' and dt <= '2020-07-22' GROUP BY dt order by dt;
+-- result:
+2020-06-18	5
+2020-06-21	7
+2020-06-24	9
+2020-07-02	3
+2020-07-05	5
+2020-07-08	7
+2020-07-11	9
+2020-07-16	1
+2020-07-19	2
+2020-07-22	3
+-- !result
+SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t2 where (dt>'2020-06-15' and dt <= '2020-06-22') or dt>'2020-07-01' GROUP BY dt order by dt;
+-- result:
+2020-06-18	5
+2020-06-21	7
+2020-07-02	3
+2020-07-05	5
+2020-07-08	7
+2020-07-11	9
+2020-07-16	1
+2020-07-19	2
+2020-07-22	3
+2020-07-25	4
+-- !result
+SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t2 where dt in ('2020-06-15', '2020-06-22', '2020-07-01') GROUP BY dt order by dt;
+-- result:
+2020-06-15	6
+-- !result
+SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t2 where date_trunc('day', dt) ='2020-06-15' GROUP BY dt order by dt;
+-- result:
+2020-06-15	6
+-- !result
+SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t2 where date_trunc('month', dt) ='2020-06-01' GROUP BY dt order by dt;
+-- result:
+2020-06-15	6
+2020-06-18	5
+2020-06-21	7
+2020-06-24	9
+-- !result
+SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t2 where date_trunc('month', dt) ='2020-07-01' GROUP BY dt order by dt;
+-- result:
+2020-07-02	3
+2020-07-05	5
+2020-07-08	7
+2020-07-11	9
+2020-07-16	1
+2020-07-19	2
+2020-07-22	3
+2020-07-25	4
+-- !result
+SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t2 GROUP BY dt order by dt;
+-- result:
+2020-06-15	6
+2020-06-18	5
+2020-06-21	7
+2020-06-24	9
+2020-07-02	3
+2020-07-05	5
+2020-07-08	7
+2020-07-11	9
+2020-07-16	1
+2020-07-19	2
+2020-07-22	3
+2020-07-25	4
+-- !result
+INSERT INTO mv_hive_${uuid0}.mv_hive_db_${uuid0}.t2 VALUES (3, "2020-06-15");
+-- result:
+-- !result
+function: check_no_hit_materialized_view("SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t2 where dt='2020-06-15' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t2 where date_trunc('day', dt) ='2020-06-15' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_no_hit_materialized_view("SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t2 where dt in ('2020-06-15', '2020-06-22', '2020-07-01') GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t2 where date_trunc('day', dt) ='2020-06-21' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t2 where dt !='2020-06-15' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t2 where dt>'2020-06-15' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t2 where dt>'2020-06-15' and dt < '2020-07-22' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t2 where dt>'2020-06-15' and dt <= '2020-07-22' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t2 where (dt>'2020-06-15' and dt <= '2020-06-22') or dt>'2020-07-01' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t2 where dt in ('2020-06-21', '2020-07-25') GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t2 where date_trunc('month', dt) ='2020-07-01' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t2 where dt between '2020-06-16' and '2020-07-01' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t2 where dt between '2020-06-15' and '2020-07-01' GROUP BY dt;", "test_mv1", "UNION")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t2 where dt>='2020-06-15' GROUP BY dt;", "test_mv1", "UNION")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t2 where dt in ('2020-06-15', '2020-06-21', '2020-07-25') GROUP BY dt;", "test_mv1", "UNION")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t2 where date_trunc('month', dt) ='2020-06-01' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t2 GROUP BY dt;", "test_mv1", "UNION")
+-- result:
+None
+-- !result
+SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t2 where dt='2020-06-15' GROUP BY dt order by dt;
+-- result:
+2020-06-15	9
+-- !result
+SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t2 where dt !='2020-06-15' GROUP BY dt order by dt;
+-- result:
+2020-06-18	5
+2020-06-21	7
+2020-06-24	9
+2020-07-02	3
+2020-07-05	5
+2020-07-08	7
+2020-07-11	9
+2020-07-16	1
+2020-07-19	2
+2020-07-22	3
+2020-07-25	4
+-- !result
+SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t2 where dt>='2020-06-15' GROUP BY dt order by dt;
+-- result:
+2020-06-15	9
+2020-06-18	5
+2020-06-21	7
+2020-06-24	9
+2020-07-02	3
+2020-07-05	5
+2020-07-08	7
+2020-07-11	9
+2020-07-16	1
+2020-07-19	2
+2020-07-22	3
+2020-07-25	4
+-- !result
+SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t2 where dt>'2020-06-15' GROUP BY dt order by dt;
+-- result:
+2020-06-18	5
+2020-06-21	7
+2020-06-24	9
+2020-07-02	3
+2020-07-05	5
+2020-07-08	7
+2020-07-11	9
+2020-07-16	1
+2020-07-19	2
+2020-07-22	3
+2020-07-25	4
+-- !result
+SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t2 where dt>'2020-06-15' and dt < '2020-07-22' GROUP BY dt order by dt;
+-- result:
+2020-06-18	5
+2020-06-21	7
+2020-06-24	9
+2020-07-02	3
+2020-07-05	5
+2020-07-08	7
+2020-07-11	9
+2020-07-16	1
+2020-07-19	2
+-- !result
+SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t2 where dt>'2020-06-15' and dt <= '2020-07-22' GROUP BY dt order by dt;
+-- result:
+2020-06-18	5
+2020-06-21	7
+2020-06-24	9
+2020-07-02	3
+2020-07-05	5
+2020-07-08	7
+2020-07-11	9
+2020-07-16	1
+2020-07-19	2
+2020-07-22	3
+-- !result
+SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t2 where (dt>'2020-06-15' and dt <= '2020-06-22') or dt>'2020-07-01' GROUP BY dt order by dt;
+-- result:
+2020-06-18	5
+2020-06-21	7
+2020-07-02	3
+2020-07-05	5
+2020-07-08	7
+2020-07-11	9
+2020-07-16	1
+2020-07-19	2
+2020-07-22	3
+2020-07-25	4
+-- !result
+SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t2 where dt in ('2020-06-22', '2020-07-01') GROUP BY dt order by dt;
+-- result:
+-- !result
+SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t2 where dt in ('2020-06-15', '2020-06-22', '2020-07-01') GROUP BY dt order by dt;
+-- result:
+2020-06-15	9
+-- !result
+SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t2 where dt between '2020-06-15' and '2020-07-01' GROUP BY dt order by dt;
+-- result:
+2020-06-15	9
+2020-06-18	5
+2020-06-21	7
+2020-06-24	9
+-- !result
+SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t2 where date_trunc('day', dt) ='2020-06-15' GROUP BY dt order by dt;
+-- result:
+2020-06-15	9
+-- !result
+SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t2 where date_trunc('month', dt) ='2020-06-01' GROUP BY dt order by dt;
+-- result:
+2020-06-15	9
+2020-06-18	5
+2020-06-21	7
+2020-06-24	9
+-- !result
+SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t2 where date_trunc('month', dt) ='2020-07-01' GROUP BY dt order by dt;
+-- result:
+2020-07-02	3
+2020-07-05	5
+2020-07-08	7
+2020-07-11	9
+2020-07-16	1
+2020-07-19	2
+2020-07-22	3
+2020-07-25	4
+-- !result
+SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t2 GROUP BY dt order by dt;
+-- result:
+2020-06-15	9
+2020-06-18	5
+2020-06-21	7
+2020-06-24	9
+2020-07-02	3
+2020-07-05	5
+2020-07-08	7
+2020-07-11	9
+2020-07-16	1
+2020-07-19	2
+2020-07-22	3
+2020-07-25	4
+-- !result
+drop materialized view default_catalog.db_${uuid0}.test_mv1;
+-- result:
+-- !result
+drop table mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 force;
+-- result:
+-- !result
+drop table mv_hive_${uuid0}.mv_hive_db_${uuid0}.t2 force;
+-- result:
+-- !result

--- a/test/sql/test_materialized_view/R/test_mv_partition_compensate_iceberg
+++ b/test/sql/test_materialized_view/R/test_mv_partition_compensate_iceberg
@@ -1,4 +1,4 @@
--- name: test_mv_iceberg_rewrite2
+-- name: test_mv_partition_compensate_iceberg
 create external catalog mv_iceberg_${uuid0}
 properties
 (

--- a/test/sql/test_materialized_view/R/test_mv_partition_compensate_iceberg2
+++ b/test/sql/test_materialized_view/R/test_mv_partition_compensate_iceberg2
@@ -1,4 +1,4 @@
--- name: test_mv_partition_compensate_iceberg
+-- name: test_mv_partition_compensate_iceberg2
 create external catalog mv_iceberg_${uuid0}
 properties
 (
@@ -6,348 +6,1626 @@ properties
     "iceberg.catalog.type" = "hive",
     "hive.metastore.uris" = "${iceberg_catalog_hive_metastore_uris}"
 );
-
-
--- create iceberg table
+-- result:
+-- !result
+set materialized_view_union_rewrite_mode = 3;
+-- result:
+-- !result
 set catalog mv_iceberg_${uuid0};
+-- result:
+-- !result
 create database mv_ice_db_${uuid0};
+-- result:
+-- !result
 use mv_ice_db_${uuid0};
-
+-- result:
+-- !result
 CREATE TABLE t1 (
   num int,
   dt date
 )
 PARTITION BY (dt);
+-- result:
+-- !result
 INSERT INTO t1 VALUES 
   (1,"2020-06-15"),(2,"2020-06-18"),(3,"2020-06-21"),(4,"2020-06-24"),
   (1,"2020-07-02"),(2,"2020-07-05"),(3,"2020-07-08"),(4,"2020-07-11"),
   (1,"2020-07-16"),(2,"2020-07-19"),(3,"2020-07-22"),(4,"2020-07-25"),
   (2,"2020-06-15"),(3,"2020-06-18"),(4,"2020-06-21"),(5,"2020-06-24"),
   (2,"2020-07-02"),(3,"2020-07-05"),(4,"2020-07-08"),(5,"2020-07-11");
-
+-- result:
+-- !result
 CREATE TABLE t2 (
   num int,
   dt string
 )
 PARTITION BY (dt);
+-- result:
+-- !result
 INSERT INTO t2 VALUES 
   (1,"2020-06-15"),(2,"2020-06-18"),(3,"2020-06-21"),(4,"2020-06-24"),
   (1,"2020-07-02"),(2,"2020-07-05"),(3,"2020-07-08"),(4,"2020-07-11"),
   (1,"2020-07-16"),(2,"2020-07-19"),(3,"2020-07-22"),(4,"2020-07-25"),
   (2,"2020-06-15"),(3,"2020-06-18"),(4,"2020-06-21"),(5,"2020-06-24"),
   (2,"2020-07-02"),(3,"2020-07-05"),(4,"2020-07-08"),(5,"2020-07-11");
-
--- create mv
+-- result:
+-- !result
 set catalog default_catalog;
+-- result:
+-- !result
 create database db_${uuid0};
+-- result:
+-- !result
 use db_${uuid0};
-
-
--- Test partition compensate without partition expression
+-- result:
+-- !result
 CREATE MATERIALIZED VIEW test_mv1 
 PARTITION BY dt 
 REFRESH DEFERRED MANUAL AS 
   SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 GROUP BY dt;
-
+-- result:
+-- !result
 REFRESH MATERIALIZED VIEW test_mv1 WITH SYNC MODE;
-
 function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 where dt='2020-06-15' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
 function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 where dt !='2020-06-15' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
 function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 where dt>='2020-06-15' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
 function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 where dt>'2020-06-15' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
 function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 where dt>'2020-06-15' and dt < '2020-07-22' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
 function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 where dt>'2020-06-15' and dt <= '2020-07-22' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
 function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 where (dt>'2020-06-15' and dt <= '2020-06-22') or dt>'2020-07-01' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
 function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 where dt in ('2020-06-15', '2020-06-22', '2020-07-01') GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
 function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 where date_trunc('day', dt) ='2020-06-15' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
 function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 where date_trunc('month', dt) ='2020-06-01' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
 function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 where date_trunc('month', dt) ='2020-07-01' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
 function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 GROUP BY dt;", "test_mv1")
-
+-- result:
+None
+-- !result
 SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 where dt='2020-06-15' GROUP BY dt order by dt;
+-- result:
+2020-06-15	3
+-- !result
 SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 where dt !='2020-06-15' GROUP BY dt order by dt;
+-- result:
+2020-06-18	5
+2020-06-21	7
+2020-06-24	9
+2020-07-02	3
+2020-07-05	5
+2020-07-08	7
+2020-07-11	9
+2020-07-16	1
+2020-07-19	2
+2020-07-22	3
+2020-07-25	4
+-- !result
 SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 where dt>='2020-06-15' GROUP BY dt order by dt;
+-- result:
+2020-06-15	3
+2020-06-18	5
+2020-06-21	7
+2020-06-24	9
+2020-07-02	3
+2020-07-05	5
+2020-07-08	7
+2020-07-11	9
+2020-07-16	1
+2020-07-19	2
+2020-07-22	3
+2020-07-25	4
+-- !result
 SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 where dt>'2020-06-15' GROUP BY dt order by dt;
+-- result:
+2020-06-18	5
+2020-06-21	7
+2020-06-24	9
+2020-07-02	3
+2020-07-05	5
+2020-07-08	7
+2020-07-11	9
+2020-07-16	1
+2020-07-19	2
+2020-07-22	3
+2020-07-25	4
+-- !result
 SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 where dt>'2020-06-15' and dt < '2020-07-22' GROUP BY dt order by dt;
+-- result:
+2020-06-18	5
+2020-06-21	7
+2020-06-24	9
+2020-07-02	3
+2020-07-05	5
+2020-07-08	7
+2020-07-11	9
+2020-07-16	1
+2020-07-19	2
+-- !result
 SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 where dt>'2020-06-15' and dt <= '2020-07-22' GROUP BY dt order by dt;
+-- result:
+2020-06-18	5
+2020-06-21	7
+2020-06-24	9
+2020-07-02	3
+2020-07-05	5
+2020-07-08	7
+2020-07-11	9
+2020-07-16	1
+2020-07-19	2
+2020-07-22	3
+-- !result
 SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 where (dt>'2020-06-15' and dt <= '2020-06-22') or dt>'2020-07-01' GROUP BY dt order by dt;
+-- result:
+2020-06-18	5
+2020-06-21	7
+2020-07-02	3
+2020-07-05	5
+2020-07-08	7
+2020-07-11	9
+2020-07-16	1
+2020-07-19	2
+2020-07-22	3
+2020-07-25	4
+-- !result
 SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 where dt in ('2020-06-15', '2020-06-22', '2020-07-01') GROUP BY dt order by dt;
+-- result:
+2020-06-15	3
+-- !result
 SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 where date_trunc('day', dt) ='2020-06-15' GROUP BY dt order by dt;
+-- result:
+2020-06-15	3
+-- !result
 SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 where date_trunc('month', dt) ='2020-06-01' GROUP BY dt order by dt;
+-- result:
+2020-06-15	3
+2020-06-18	5
+2020-06-21	7
+2020-06-24	9
+-- !result
 SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 where date_trunc('month', dt) ='2020-07-01' GROUP BY dt order by dt;
+-- result:
+2020-07-02	3
+2020-07-05	5
+2020-07-08	7
+2020-07-11	9
+2020-07-16	1
+2020-07-19	2
+2020-07-22	3
+2020-07-25	4
+-- !result
 SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 GROUP BY dt order by dt;
-
--- union rewrite
+-- result:
+2020-06-15	3
+2020-06-18	5
+2020-06-21	7
+2020-06-24	9
+2020-07-02	3
+2020-07-05	5
+2020-07-08	7
+2020-07-11	9
+2020-07-16	1
+2020-07-19	2
+2020-07-22	3
+2020-07-25	4
+-- !result
 INSERT INTO mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 VALUES (3, "2020-06-15");
+-- result:
+-- !result
 function: check_no_hit_materialized_view("SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 where dt='2020-06-15' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
 function: check_no_hit_materialized_view("SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 where date_trunc('day', dt) ='2020-06-15' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
 function: check_no_hit_materialized_view("SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 where dt in ('2020-06-15', '2020-06-22', '2020-07-01') GROUP BY dt;", "test_mv1")
-
+-- result:
+None
+-- !result
 function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 where date_trunc('day', dt) ='2020-06-21' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
 function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 where dt !='2020-06-15' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
 function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 where dt>'2020-06-15' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
 function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 where dt>'2020-06-15' and dt < '2020-07-22' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
 function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 where dt>'2020-06-15' and dt <= '2020-07-22' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
 function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 where (dt>'2020-06-15' and dt <= '2020-06-22') or dt>'2020-07-01' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
 function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 where dt in ('2020-06-21', '2020-07-25') GROUP BY dt;", "test_mv1")
--- cannot partition prune
-function: check_no_hit_materialized_view("SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 where date_trunc('month', dt) ='2020-07-01' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 where date_trunc('month', dt) ='2020-07-01' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
 function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 where dt between '2020-06-16' and '2020-07-01' GROUP BY dt;", "test_mv1")
-
--- function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 where dt between '2020-06-15' and '2020-07-01' GROUP BY dt;", "test_mv1", "UNION")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 where dt between '2020-06-15' and '2020-07-01' GROUP BY dt;", "test_mv1", "UNION")
+-- result:
+None
+-- !result
 function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 where dt>='2020-06-15' GROUP BY dt;", "test_mv1", "UNION")
--- function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 where dt in ('2020-06-15', '2020-06-21', '2020-07-25') GROUP BY dt;", "test_mv1", "UNION")
--- cannot partition prune
-function: check_no_hit_materialized_view("SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 where date_trunc('month', dt) ='2020-06-01' GROUP BY dt;", "test_mv1", "UNION")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 where dt in ('2020-06-15', '2020-06-21', '2020-07-25') GROUP BY dt;", "test_mv1", "UNION")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 where date_trunc('month', dt) ='2020-06-01' GROUP BY dt;", "test_mv1", "UNION")
+-- result:
+None
+-- !result
 function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 GROUP BY dt;", "test_mv1", "UNION")
-
+-- result:
+None
+-- !result
 SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 where dt='2020-06-15' GROUP BY dt order by dt;
+-- result:
+2020-06-15	6
+-- !result
 SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 where dt !='2020-06-15' GROUP BY dt order by dt;
+-- result:
+2020-06-18	5
+2020-06-21	7
+2020-06-24	9
+2020-07-02	3
+2020-07-05	5
+2020-07-08	7
+2020-07-11	9
+2020-07-16	1
+2020-07-19	2
+2020-07-22	3
+2020-07-25	4
+-- !result
 SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 where dt>='2020-06-15' GROUP BY dt order by dt;
+-- result:
+2020-06-15	6
+2020-06-18	5
+2020-06-21	7
+2020-06-24	9
+2020-07-02	3
+2020-07-05	5
+2020-07-08	7
+2020-07-11	9
+2020-07-16	1
+2020-07-19	2
+2020-07-22	3
+2020-07-25	4
+-- !result
 SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 where dt>'2020-06-15' GROUP BY dt order by dt;
+-- result:
+2020-06-18	5
+2020-06-21	7
+2020-06-24	9
+2020-07-02	3
+2020-07-05	5
+2020-07-08	7
+2020-07-11	9
+2020-07-16	1
+2020-07-19	2
+2020-07-22	3
+2020-07-25	4
+-- !result
 SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 where dt>'2020-06-15' and dt < '2020-07-22' GROUP BY dt order by dt;
+-- result:
+2020-06-18	5
+2020-06-21	7
+2020-06-24	9
+2020-07-02	3
+2020-07-05	5
+2020-07-08	7
+2020-07-11	9
+2020-07-16	1
+2020-07-19	2
+-- !result
 SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 where dt>'2020-06-15' and dt <= '2020-07-22' GROUP BY dt order by dt;
+-- result:
+2020-06-18	5
+2020-06-21	7
+2020-06-24	9
+2020-07-02	3
+2020-07-05	5
+2020-07-08	7
+2020-07-11	9
+2020-07-16	1
+2020-07-19	2
+2020-07-22	3
+-- !result
 SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 where (dt>'2020-06-15' and dt <= '2020-06-22') or dt>'2020-07-01' GROUP BY dt order by dt;
+-- result:
+2020-06-18	5
+2020-06-21	7
+2020-07-02	3
+2020-07-05	5
+2020-07-08	7
+2020-07-11	9
+2020-07-16	1
+2020-07-19	2
+2020-07-22	3
+2020-07-25	4
+-- !result
 SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 where dt in ('2020-06-22', '2020-07-01') GROUP BY dt order by dt;
+-- result:
+-- !result
 SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 where dt in ('2020-06-15', '2020-06-22', '2020-07-01') GROUP BY dt order by dt;
+-- result:
+2020-06-15	6
+-- !result
 SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 where dt between '2020-06-15' and '2020-07-01' GROUP BY dt order by dt;
+-- result:
+2020-06-15	6
+2020-06-18	5
+2020-06-21	7
+2020-06-24	9
+-- !result
 SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 where date_trunc('day', dt) ='2020-06-15' GROUP BY dt order by dt;
+-- result:
+2020-06-15	6
+-- !result
 SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 where date_trunc('month', dt) ='2020-06-01' GROUP BY dt order by dt;
+-- result:
+2020-06-15	6
+2020-06-18	5
+2020-06-21	7
+2020-06-24	9
+-- !result
 SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 where date_trunc('month', dt) ='2020-07-01' GROUP BY dt order by dt;
+-- result:
+2020-07-02	3
+2020-07-05	5
+2020-07-08	7
+2020-07-11	9
+2020-07-16	1
+2020-07-19	2
+2020-07-22	3
+2020-07-25	4
+-- !result
 SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 GROUP BY dt order by dt;
-
-
+-- result:
+2020-06-15	6
+2020-06-18	5
+2020-06-21	7
+2020-06-24	9
+2020-07-02	3
+2020-07-05	5
+2020-07-08	7
+2020-07-11	9
+2020-07-16	1
+2020-07-19	2
+2020-07-22	3
+2020-07-25	4
+-- !result
 drop materialized view default_catalog.db_${uuid0}.test_mv1;
-
--- Test partition compensate with partition expression
+-- result:
+-- !result
 CREATE MATERIALIZED VIEW test_mv1 
 PARTITION BY date_trunc('day', dt)
 REFRESH DEFERRED MANUAL AS 
   SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 GROUP BY dt;
+-- result:
+-- !result
 REFRESH MATERIALIZED VIEW test_mv1 WITH SYNC MODE;
-
 function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 where dt='2020-06-15' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
 function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 where dt !='2020-06-15' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
 function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 where dt>='2020-06-15' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
 function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 where dt>'2020-06-15' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
 function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 where dt>'2020-06-15' and dt < '2020-07-22' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
 function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 where dt>'2020-06-15' and dt <= '2020-07-22' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
 function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 where (dt>'2020-06-15' and dt <= '2020-06-22') or dt>'2020-07-01' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
 function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 where dt in ('2020-06-15', '2020-06-22', '2020-07-01') GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
 function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 where date_trunc('day', dt) ='2020-06-15' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
 function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 where date_trunc('month', dt) ='2020-06-01' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
 function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 where date_trunc('month', dt) ='2020-07-01' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
 function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 GROUP BY dt;", "test_mv1")
-
+-- result:
+None
+-- !result
 SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 where dt='2020-06-15' GROUP BY dt order by dt;
+-- result:
+2020-06-15	6
+-- !result
 SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 where dt !='2020-06-15' GROUP BY dt order by dt;
+-- result:
+2020-06-18	5
+2020-06-21	7
+2020-06-24	9
+2020-07-02	3
+2020-07-05	5
+2020-07-08	7
+2020-07-11	9
+2020-07-16	1
+2020-07-19	2
+2020-07-22	3
+2020-07-25	4
+-- !result
 SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 where dt>='2020-06-15' GROUP BY dt order by dt;
+-- result:
+2020-06-15	6
+2020-06-18	5
+2020-06-21	7
+2020-06-24	9
+2020-07-02	3
+2020-07-05	5
+2020-07-08	7
+2020-07-11	9
+2020-07-16	1
+2020-07-19	2
+2020-07-22	3
+2020-07-25	4
+-- !result
 SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 where dt>'2020-06-15' GROUP BY dt order by dt;
+-- result:
+2020-06-18	5
+2020-06-21	7
+2020-06-24	9
+2020-07-02	3
+2020-07-05	5
+2020-07-08	7
+2020-07-11	9
+2020-07-16	1
+2020-07-19	2
+2020-07-22	3
+2020-07-25	4
+-- !result
 SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 where dt>'2020-06-15' and dt < '2020-07-22' GROUP BY dt order by dt;
+-- result:
+2020-06-18	5
+2020-06-21	7
+2020-06-24	9
+2020-07-02	3
+2020-07-05	5
+2020-07-08	7
+2020-07-11	9
+2020-07-16	1
+2020-07-19	2
+-- !result
 SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 where dt>'2020-06-15' and dt <= '2020-07-22' GROUP BY dt order by dt;
+-- result:
+2020-06-18	5
+2020-06-21	7
+2020-06-24	9
+2020-07-02	3
+2020-07-05	5
+2020-07-08	7
+2020-07-11	9
+2020-07-16	1
+2020-07-19	2
+2020-07-22	3
+-- !result
 SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 where (dt>'2020-06-15' and dt <= '2020-06-22') or dt>'2020-07-01' GROUP BY dt order by dt;
+-- result:
+2020-06-18	5
+2020-06-21	7
+2020-07-02	3
+2020-07-05	5
+2020-07-08	7
+2020-07-11	9
+2020-07-16	1
+2020-07-19	2
+2020-07-22	3
+2020-07-25	4
+-- !result
 SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 where dt in ('2020-06-15', '2020-06-22', '2020-07-01') GROUP BY dt order by dt;
+-- result:
+2020-06-15	6
+-- !result
 SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 where date_trunc('day', dt) ='2020-06-15' GROUP BY dt order by dt;
+-- result:
+2020-06-15	6
+-- !result
 SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 where date_trunc('month', dt) ='2020-06-01' GROUP BY dt order by dt;
+-- result:
+2020-06-15	6
+2020-06-18	5
+2020-06-21	7
+2020-06-24	9
+-- !result
 SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 where date_trunc('month', dt) ='2020-07-01' GROUP BY dt order by dt;
+-- result:
+2020-07-02	3
+2020-07-05	5
+2020-07-08	7
+2020-07-11	9
+2020-07-16	1
+2020-07-19	2
+2020-07-22	3
+2020-07-25	4
+-- !result
 SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 GROUP BY dt order by dt;
-
--- union rewrite
+-- result:
+2020-06-15	6
+2020-06-18	5
+2020-06-21	7
+2020-06-24	9
+2020-07-02	3
+2020-07-05	5
+2020-07-08	7
+2020-07-11	9
+2020-07-16	1
+2020-07-19	2
+2020-07-22	3
+2020-07-25	4
+-- !result
 INSERT INTO mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 VALUES (3, "2020-06-15");
+-- result:
+-- !result
 function: check_no_hit_materialized_view("SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 where dt='2020-06-15' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
 function: check_no_hit_materialized_view("SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 where date_trunc('day', dt) ='2020-06-15' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
 function: check_no_hit_materialized_view("SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 where dt in ('2020-06-15', '2020-06-22', '2020-07-01') GROUP BY dt;", "test_mv1")
-
+-- result:
+None
+-- !result
 function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 where date_trunc('day', dt) ='2020-06-21' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
 function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 where dt !='2020-06-15' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
 function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 where dt>'2020-06-15' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
 function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 where dt>'2020-06-15' and dt < '2020-07-22' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
 function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 where dt>'2020-06-15' and dt <= '2020-07-22' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
 function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 where (dt>'2020-06-15' and dt <= '2020-06-22') or dt>'2020-07-01' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
 function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 where dt in ('2020-06-21', '2020-07-25') GROUP BY dt;", "test_mv1")
--- cannot partition prune
-function: check_no_hit_materialized_view("SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 where date_trunc('month', dt) ='2020-07-01' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 where date_trunc('month', dt) ='2020-07-01' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
 function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 where dt between '2020-06-16' and '2020-07-01' GROUP BY dt;", "test_mv1")
-
--- function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 where dt between '2020-06-15' and '2020-07-01' GROUP BY dt;", "test_mv1", "UNION")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 where dt between '2020-06-15' and '2020-07-01' GROUP BY dt;", "test_mv1", "UNION")
+-- result:
+None
+-- !result
 function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 where dt>='2020-06-15' GROUP BY dt;", "test_mv1", "UNION")
--- function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 where dt in ('2020-06-15', '2020-06-21', '2020-07-25') GROUP BY dt;", "test_mv1", "UNION")
--- cannot partition prune
-function: check_no_hit_materialized_view("SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 where date_trunc('month', dt) ='2020-06-01' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 where dt in ('2020-06-15', '2020-06-21', '2020-07-25') GROUP BY dt;", "test_mv1", "UNION")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 where date_trunc('month', dt) ='2020-06-01' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
 function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 GROUP BY dt;", "test_mv1", "UNION")
-
+-- result:
+None
+-- !result
 SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 where dt='2020-06-15' GROUP BY dt order by dt;
+-- result:
+2020-06-15	9
+-- !result
 SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 where dt !='2020-06-15' GROUP BY dt order by dt;
+-- result:
+2020-06-18	5
+2020-06-21	7
+2020-06-24	9
+2020-07-02	3
+2020-07-05	5
+2020-07-08	7
+2020-07-11	9
+2020-07-16	1
+2020-07-19	2
+2020-07-22	3
+2020-07-25	4
+-- !result
 SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 where dt>='2020-06-15' GROUP BY dt order by dt;
+-- result:
+2020-06-15	9
+2020-06-18	5
+2020-06-21	7
+2020-06-24	9
+2020-07-02	3
+2020-07-05	5
+2020-07-08	7
+2020-07-11	9
+2020-07-16	1
+2020-07-19	2
+2020-07-22	3
+2020-07-25	4
+-- !result
 SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 where dt>'2020-06-15' GROUP BY dt order by dt;
+-- result:
+2020-06-18	5
+2020-06-21	7
+2020-06-24	9
+2020-07-02	3
+2020-07-05	5
+2020-07-08	7
+2020-07-11	9
+2020-07-16	1
+2020-07-19	2
+2020-07-22	3
+2020-07-25	4
+-- !result
 SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 where dt>'2020-06-15' and dt < '2020-07-22' GROUP BY dt order by dt;
+-- result:
+2020-06-18	5
+2020-06-21	7
+2020-06-24	9
+2020-07-02	3
+2020-07-05	5
+2020-07-08	7
+2020-07-11	9
+2020-07-16	1
+2020-07-19	2
+-- !result
 SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 where dt>'2020-06-15' and dt <= '2020-07-22' GROUP BY dt order by dt;
+-- result:
+2020-06-18	5
+2020-06-21	7
+2020-06-24	9
+2020-07-02	3
+2020-07-05	5
+2020-07-08	7
+2020-07-11	9
+2020-07-16	1
+2020-07-19	2
+2020-07-22	3
+-- !result
 SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 where (dt>'2020-06-15' and dt <= '2020-06-22') or dt>'2020-07-01' GROUP BY dt order by dt;
+-- result:
+2020-06-18	5
+2020-06-21	7
+2020-07-02	3
+2020-07-05	5
+2020-07-08	7
+2020-07-11	9
+2020-07-16	1
+2020-07-19	2
+2020-07-22	3
+2020-07-25	4
+-- !result
 SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 where dt in ('2020-06-22', '2020-07-01') GROUP BY dt order by dt;
+-- result:
+-- !result
 SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 where dt in ('2020-06-15', '2020-06-22', '2020-07-01') GROUP BY dt order by dt;
+-- result:
+2020-06-15	9
+-- !result
 SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 where dt between '2020-06-15' and '2020-07-01' GROUP BY dt order by dt;
+-- result:
+2020-06-15	9
+2020-06-18	5
+2020-06-21	7
+2020-06-24	9
+-- !result
 SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 where date_trunc('day', dt) ='2020-06-15' GROUP BY dt order by dt;
+-- result:
+2020-06-15	9
+-- !result
 SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 where date_trunc('month', dt) ='2020-06-01' GROUP BY dt order by dt;
+-- result:
+2020-06-15	9
+2020-06-18	5
+2020-06-21	7
+2020-06-24	9
+-- !result
 SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 where date_trunc('month', dt) ='2020-07-01' GROUP BY dt order by dt;
+-- result:
+2020-07-02	3
+2020-07-05	5
+2020-07-08	7
+2020-07-11	9
+2020-07-16	1
+2020-07-19	2
+2020-07-22	3
+2020-07-25	4
+-- !result
 SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 GROUP BY dt order by dt;
-
+-- result:
+2020-06-15	9
+2020-06-18	5
+2020-06-21	7
+2020-06-24	9
+2020-07-02	3
+2020-07-05	5
+2020-07-08	7
+2020-07-11	9
+2020-07-16	1
+2020-07-19	2
+2020-07-22	3
+2020-07-25	4
+-- !result
 drop materialized view default_catalog.db_${uuid0}.test_mv1;
-
-
-
--- Test partition compensate without partition expression
+-- result:
+-- !result
 CREATE MATERIALIZED VIEW test_mv1 
 PARTITION BY str2date(dt, '%Y-%m-%d')
 REFRESH DEFERRED MANUAL AS 
   SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t2 GROUP BY dt;
-
+-- result:
+-- !result
 REFRESH MATERIALIZED VIEW test_mv1 WITH SYNC MODE;
-
 function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t2 where dt='2020-06-15' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
 function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t2 where dt !='2020-06-15' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
 function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t2 where dt>='2020-06-15' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
 function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t2 where dt>'2020-06-15' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
 function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t2 where dt>'2020-06-15' and dt < '2020-07-22' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
 function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t2 where dt>'2020-06-15' and dt <= '2020-07-22' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
 function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t2 where (dt>'2020-06-15' and dt <= '2020-06-22') or dt>'2020-07-01' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
 function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t2 where dt in ('2020-06-15', '2020-06-22', '2020-07-01') GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
 function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t2 where date_trunc('day', dt) ='2020-06-15' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
 function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t2 where date_trunc('month', dt) ='2020-06-01' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
 function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t2 where date_trunc('month', dt) ='2020-07-01' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
 function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t2 GROUP BY dt;", "test_mv1")
-
+-- result:
+None
+-- !result
 SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t2 where dt='2020-06-15' GROUP BY dt order by dt;
+-- result:
+2020-06-15	3
+-- !result
 SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t2 where dt !='2020-06-15' GROUP BY dt order by dt;
+-- result:
+2020-06-18	5
+2020-06-21	7
+2020-06-24	9
+2020-07-02	3
+2020-07-05	5
+2020-07-08	7
+2020-07-11	9
+2020-07-16	1
+2020-07-19	2
+2020-07-22	3
+2020-07-25	4
+-- !result
 SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t2 where dt>='2020-06-15' GROUP BY dt order by dt;
+-- result:
+2020-06-15	3
+2020-06-18	5
+2020-06-21	7
+2020-06-24	9
+2020-07-02	3
+2020-07-05	5
+2020-07-08	7
+2020-07-11	9
+2020-07-16	1
+2020-07-19	2
+2020-07-22	3
+2020-07-25	4
+-- !result
 SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t2 where dt>'2020-06-15' GROUP BY dt order by dt;
+-- result:
+2020-06-18	5
+2020-06-21	7
+2020-06-24	9
+2020-07-02	3
+2020-07-05	5
+2020-07-08	7
+2020-07-11	9
+2020-07-16	1
+2020-07-19	2
+2020-07-22	3
+2020-07-25	4
+-- !result
 SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t2 where dt>'2020-06-15' and dt < '2020-07-22' GROUP BY dt order by dt;
+-- result:
+2020-06-18	5
+2020-06-21	7
+2020-06-24	9
+2020-07-02	3
+2020-07-05	5
+2020-07-08	7
+2020-07-11	9
+2020-07-16	1
+2020-07-19	2
+-- !result
 SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t2 where dt>'2020-06-15' and dt <= '2020-07-22' GROUP BY dt order by dt;
+-- result:
+2020-06-18	5
+2020-06-21	7
+2020-06-24	9
+2020-07-02	3
+2020-07-05	5
+2020-07-08	7
+2020-07-11	9
+2020-07-16	1
+2020-07-19	2
+2020-07-22	3
+-- !result
 SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t2 where (dt>'2020-06-15' and dt <= '2020-06-22') or dt>'2020-07-01' GROUP BY dt order by dt;
+-- result:
+2020-06-18	5
+2020-06-21	7
+2020-07-02	3
+2020-07-05	5
+2020-07-08	7
+2020-07-11	9
+2020-07-16	1
+2020-07-19	2
+2020-07-22	3
+2020-07-25	4
+-- !result
 SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t2 where dt in ('2020-06-15', '2020-06-22', '2020-07-01') GROUP BY dt order by dt;
+-- result:
+2020-06-15	3
+-- !result
 SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t2 where date_trunc('day', dt) ='2020-06-15' GROUP BY dt order by dt;
+-- result:
+2020-06-15	3
+-- !result
 SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t2 where date_trunc('month', dt) ='2020-06-01' GROUP BY dt order by dt;
+-- result:
+2020-06-15	3
+2020-06-18	5
+2020-06-21	7
+2020-06-24	9
+-- !result
 SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t2 where date_trunc('month', dt) ='2020-07-01' GROUP BY dt order by dt;
+-- result:
+2020-07-02	3
+2020-07-05	5
+2020-07-08	7
+2020-07-11	9
+2020-07-16	1
+2020-07-19	2
+2020-07-22	3
+2020-07-25	4
+-- !result
 SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t2 GROUP BY dt order by dt;
-
--- union rewrite
+-- result:
+2020-06-15	3
+2020-06-18	5
+2020-06-21	7
+2020-06-24	9
+2020-07-02	3
+2020-07-05	5
+2020-07-08	7
+2020-07-11	9
+2020-07-16	1
+2020-07-19	2
+2020-07-22	3
+2020-07-25	4
+-- !result
 INSERT INTO mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t2 VALUES (3, "2020-06-15");
+-- result:
+-- !result
 function: check_no_hit_materialized_view("SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t2 where dt='2020-06-15' GROUP BY dt;", "test_mv1")
-function: check_no_hit_materialized_view("SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t2 where date_trunc('day', dt) ='2020-06-15' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t2 where date_trunc('day', dt) ='2020-06-15' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
 function: check_no_hit_materialized_view("SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t2 where dt in ('2020-06-15', '2020-06-22', '2020-07-01') GROUP BY dt;", "test_mv1")
-
--- cannot partition prune
-function: check_no_hit_materialized_view("SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t2 where date_trunc('day', dt) ='2020-06-21' GROUP BY dt;", "test_mv1")
-
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t2 where date_trunc('day', dt) ='2020-06-21' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
 function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t2 where dt !='2020-06-15' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
 function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t2 where dt>'2020-06-15' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
 function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t2 where dt>'2020-06-15' and dt < '2020-07-22' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
 function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t2 where dt>'2020-06-15' and dt <= '2020-07-22' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
 function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t2 where (dt>'2020-06-15' and dt <= '2020-06-22') or dt>'2020-07-01' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
 function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t2 where dt in ('2020-06-21', '2020-07-25') GROUP BY dt;", "test_mv1")
--- cannot partition prune
-function: check_no_hit_materialized_view("SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t2 where date_trunc('month', dt) ='2020-07-01' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t2 where date_trunc('month', dt) ='2020-07-01' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
 function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t2 where dt between '2020-06-16' and '2020-07-01' GROUP BY dt;", "test_mv1")
-
--- function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t2 where dt between '2020-06-15' and '2020-07-01' GROUP BY dt;", "test_mv1", "UNION")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t2 where dt between '2020-06-15' and '2020-07-01' GROUP BY dt;", "test_mv1", "UNION")
+-- result:
+None
+-- !result
 function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t2 where dt>='2020-06-15' GROUP BY dt;", "test_mv1", "UNION")
--- function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t2 where dt in ('2020-06-15', '2020-06-21', '2020-07-25') GROUP BY dt;", "test_mv1", "UNION")
--- cannot partition prune
-function: check_no_hit_materialized_view("SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t2 where date_trunc('month', dt) ='2020-06-01' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t2 where dt in ('2020-06-15', '2020-06-21', '2020-07-25') GROUP BY dt;", "test_mv1", "UNION")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t2 where date_trunc('month', dt) ='2020-06-01' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
 function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t2 GROUP BY dt;", "test_mv1", "UNION")
-
+-- result:
+None
+-- !result
 SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t2 where dt='2020-06-15' GROUP BY dt order by dt;
+-- result:
+2020-06-15	6
+-- !result
 SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t2 where dt !='2020-06-15' GROUP BY dt order by dt;
+-- result:
+2020-06-18	5
+2020-06-21	7
+2020-06-24	9
+2020-07-02	3
+2020-07-05	5
+2020-07-08	7
+2020-07-11	9
+2020-07-16	1
+2020-07-19	2
+2020-07-22	3
+2020-07-25	4
+-- !result
 SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t2 where dt>='2020-06-15' GROUP BY dt order by dt;
+-- result:
+2020-06-15	6
+2020-06-18	5
+2020-06-21	7
+2020-06-24	9
+2020-07-02	3
+2020-07-05	5
+2020-07-08	7
+2020-07-11	9
+2020-07-16	1
+2020-07-19	2
+2020-07-22	3
+2020-07-25	4
+-- !result
 SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t2 where dt>'2020-06-15' GROUP BY dt order by dt;
+-- result:
+2020-06-18	5
+2020-06-21	7
+2020-06-24	9
+2020-07-02	3
+2020-07-05	5
+2020-07-08	7
+2020-07-11	9
+2020-07-16	1
+2020-07-19	2
+2020-07-22	3
+2020-07-25	4
+-- !result
 SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t2 where dt>'2020-06-15' and dt < '2020-07-22' GROUP BY dt order by dt;
+-- result:
+2020-06-18	5
+2020-06-21	7
+2020-06-24	9
+2020-07-02	3
+2020-07-05	5
+2020-07-08	7
+2020-07-11	9
+2020-07-16	1
+2020-07-19	2
+-- !result
 SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t2 where dt>'2020-06-15' and dt <= '2020-07-22' GROUP BY dt order by dt;
+-- result:
+2020-06-18	5
+2020-06-21	7
+2020-06-24	9
+2020-07-02	3
+2020-07-05	5
+2020-07-08	7
+2020-07-11	9
+2020-07-16	1
+2020-07-19	2
+2020-07-22	3
+-- !result
 SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t2 where (dt>'2020-06-15' and dt <= '2020-06-22') or dt>'2020-07-01' GROUP BY dt order by dt;
+-- result:
+2020-06-18	5
+2020-06-21	7
+2020-07-02	3
+2020-07-05	5
+2020-07-08	7
+2020-07-11	9
+2020-07-16	1
+2020-07-19	2
+2020-07-22	3
+2020-07-25	4
+-- !result
 SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t2 where dt in ('2020-06-22', '2020-07-01') GROUP BY dt order by dt;
+-- result:
+-- !result
 SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t2 where dt in ('2020-06-15', '2020-06-22', '2020-07-01') GROUP BY dt order by dt;
+-- result:
+2020-06-15	6
+-- !result
 SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t2 where dt between '2020-06-15' and '2020-07-01' GROUP BY dt order by dt;
+-- result:
+2020-06-15	6
+2020-06-18	5
+2020-06-21	7
+2020-06-24	9
+-- !result
 SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t2 where date_trunc('day', dt) ='2020-06-15' GROUP BY dt order by dt;
+-- result:
+2020-06-15	6
+-- !result
 SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t2 where date_trunc('month', dt) ='2020-06-01' GROUP BY dt order by dt;
+-- result:
+2020-06-15	6
+2020-06-18	5
+2020-06-21	7
+2020-06-24	9
+-- !result
 SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t2 where date_trunc('month', dt) ='2020-07-01' GROUP BY dt order by dt;
+-- result:
+2020-07-02	3
+2020-07-05	5
+2020-07-08	7
+2020-07-11	9
+2020-07-16	1
+2020-07-19	2
+2020-07-22	3
+2020-07-25	4
+-- !result
 SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t2 GROUP BY dt order by dt;
-
-
+-- result:
+2020-06-15	6
+2020-06-18	5
+2020-06-21	7
+2020-06-24	9
+2020-07-02	3
+2020-07-05	5
+2020-07-08	7
+2020-07-11	9
+2020-07-16	1
+2020-07-19	2
+2020-07-22	3
+2020-07-25	4
+-- !result
 drop materialized view default_catalog.db_${uuid0}.test_mv1;
-
--- Test partition compensate with partition expression
--- TODO: shold not add an extra column(dt) which cannot partition prune.
+-- result:
+-- !result
 CREATE MATERIALIZED VIEW test_mv1 
 PARTITION BY date_trunc('day', format_dt)
 REFRESH DEFERRED MANUAL AS 
   SELECT dt, str2date(dt, '%Y-%m-%d') as format_dt, sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t2 GROUP BY dt;
+-- result:
+-- !result
 REFRESH MATERIALIZED VIEW test_mv1 WITH SYNC MODE;
-
 function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t2 where dt='2020-06-15' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
 function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t2 where dt !='2020-06-15' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
 function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t2 where dt>='2020-06-15' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
 function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t2 where dt>'2020-06-15' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
 function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t2 where dt>'2020-06-15' and dt < '2020-07-22' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
 function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t2 where dt>'2020-06-15' and dt <= '2020-07-22' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
 function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t2 where (dt>'2020-06-15' and dt <= '2020-06-22') or dt>'2020-07-01' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
 function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t2 where dt in ('2020-06-15', '2020-06-22', '2020-07-01') GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
 function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t2 where date_trunc('day', dt) ='2020-06-15' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
 function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t2 where date_trunc('month', dt) ='2020-06-01' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
 function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t2 where date_trunc('month', dt) ='2020-07-01' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
 function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t2 GROUP BY dt;", "test_mv1")
-
+-- result:
+None
+-- !result
 SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t2 where dt='2020-06-15' GROUP BY dt order by dt;
+-- result:
+2020-06-15	6
+-- !result
 SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t2 where dt !='2020-06-15' GROUP BY dt order by dt;
+-- result:
+2020-06-18	5
+2020-06-21	7
+2020-06-24	9
+2020-07-02	3
+2020-07-05	5
+2020-07-08	7
+2020-07-11	9
+2020-07-16	1
+2020-07-19	2
+2020-07-22	3
+2020-07-25	4
+-- !result
 SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t2 where dt>='2020-06-15' GROUP BY dt order by dt;
+-- result:
+2020-06-15	6
+2020-06-18	5
+2020-06-21	7
+2020-06-24	9
+2020-07-02	3
+2020-07-05	5
+2020-07-08	7
+2020-07-11	9
+2020-07-16	1
+2020-07-19	2
+2020-07-22	3
+2020-07-25	4
+-- !result
 SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t2 where dt>'2020-06-15' GROUP BY dt order by dt;
+-- result:
+2020-06-18	5
+2020-06-21	7
+2020-06-24	9
+2020-07-02	3
+2020-07-05	5
+2020-07-08	7
+2020-07-11	9
+2020-07-16	1
+2020-07-19	2
+2020-07-22	3
+2020-07-25	4
+-- !result
 SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t2 where dt>'2020-06-15' and dt < '2020-07-22' GROUP BY dt order by dt;
+-- result:
+2020-06-18	5
+2020-06-21	7
+2020-06-24	9
+2020-07-02	3
+2020-07-05	5
+2020-07-08	7
+2020-07-11	9
+2020-07-16	1
+2020-07-19	2
+-- !result
 SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t2 where dt>'2020-06-15' and dt <= '2020-07-22' GROUP BY dt order by dt;
+-- result:
+2020-06-18	5
+2020-06-21	7
+2020-06-24	9
+2020-07-02	3
+2020-07-05	5
+2020-07-08	7
+2020-07-11	9
+2020-07-16	1
+2020-07-19	2
+2020-07-22	3
+-- !result
 SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t2 where (dt>'2020-06-15' and dt <= '2020-06-22') or dt>'2020-07-01' GROUP BY dt order by dt;
+-- result:
+2020-06-18	5
+2020-06-21	7
+2020-07-02	3
+2020-07-05	5
+2020-07-08	7
+2020-07-11	9
+2020-07-16	1
+2020-07-19	2
+2020-07-22	3
+2020-07-25	4
+-- !result
 SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t2 where dt in ('2020-06-15', '2020-06-22', '2020-07-01') GROUP BY dt order by dt;
+-- result:
+2020-06-15	6
+-- !result
 SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t2 where date_trunc('day', dt) ='2020-06-15' GROUP BY dt order by dt;
+-- result:
+2020-06-15	6
+-- !result
 SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t2 where date_trunc('month', dt) ='2020-06-01' GROUP BY dt order by dt;
+-- result:
+2020-06-15	6
+2020-06-18	5
+2020-06-21	7
+2020-06-24	9
+-- !result
 SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t2 where date_trunc('month', dt) ='2020-07-01' GROUP BY dt order by dt;
+-- result:
+2020-07-02	3
+2020-07-05	5
+2020-07-08	7
+2020-07-11	9
+2020-07-16	1
+2020-07-19	2
+2020-07-22	3
+2020-07-25	4
+-- !result
 SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t2 GROUP BY dt order by dt;
-
--- union rewrite
+-- result:
+2020-06-15	6
+2020-06-18	5
+2020-06-21	7
+2020-06-24	9
+2020-07-02	3
+2020-07-05	5
+2020-07-08	7
+2020-07-11	9
+2020-07-16	1
+2020-07-19	2
+2020-07-22	3
+2020-07-25	4
+-- !result
 INSERT INTO mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t2 VALUES (3, "2020-06-15");
+-- result:
+-- !result
 function: check_no_hit_materialized_view("SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t2 where dt='2020-06-15' GROUP BY dt;", "test_mv1")
-function: check_no_hit_materialized_view("SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t2 where date_trunc('day', dt) ='2020-06-15' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t2 where date_trunc('day', dt) ='2020-06-15' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
 function: check_no_hit_materialized_view("SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t2 where dt in ('2020-06-15', '2020-06-22', '2020-07-01') GROUP BY dt;", "test_mv1")
-
--- cannot partition prune
-function: check_no_hit_materialized_view("SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t2 where date_trunc('day', dt) ='2020-06-21' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t2 where date_trunc('day', dt) ='2020-06-21' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
 function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t2 where dt !='2020-06-15' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
 function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t2 where dt>'2020-06-15' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
 function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t2 where dt>'2020-06-15' and dt < '2020-07-22' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
 function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t2 where dt>'2020-06-15' and dt <= '2020-07-22' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
 function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t2 where (dt>'2020-06-15' and dt <= '2020-06-22') or dt>'2020-07-01' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
 function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t2 where dt in ('2020-06-21', '2020-07-25') GROUP BY dt;", "test_mv1")
--- cannot partition prune
-function: check_no_hit_materialized_view("SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t2 where date_trunc('month', dt) ='2020-07-01' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t2 where date_trunc('month', dt) ='2020-07-01' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
 function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t2 where dt between '2020-06-16' and '2020-07-01' GROUP BY dt;", "test_mv1")
-
--- function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t2 where dt between '2020-06-15' and '2020-07-01' GROUP BY dt;", "test_mv1", "UNION")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t2 where dt between '2020-06-15' and '2020-07-01' GROUP BY dt;", "test_mv1", "UNION")
+-- result:
+None
+-- !result
 function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t2 where dt>='2020-06-15' GROUP BY dt;", "test_mv1", "UNION")
--- function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t2 where dt in ('2020-06-15', '2020-06-21', '2020-07-25') GROUP BY dt;", "test_mv1", "UNION")
--- cannot partition prune
-function: check_no_hit_materialized_view("SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t2 where date_trunc('month', dt) ='2020-06-01' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t2 where dt in ('2020-06-15', '2020-06-21', '2020-07-25') GROUP BY dt;", "test_mv1", "UNION")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t2 where date_trunc('month', dt) ='2020-06-01' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
 function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t2 GROUP BY dt;", "test_mv1", "UNION")
-
+-- result:
+None
+-- !result
 SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t2 where dt='2020-06-15' GROUP BY dt order by dt;
+-- result:
+2020-06-15	9
+-- !result
 SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t2 where dt !='2020-06-15' GROUP BY dt order by dt;
+-- result:
+2020-06-18	5
+2020-06-21	7
+2020-06-24	9
+2020-07-02	3
+2020-07-05	5
+2020-07-08	7
+2020-07-11	9
+2020-07-16	1
+2020-07-19	2
+2020-07-22	3
+2020-07-25	4
+-- !result
 SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t2 where dt>='2020-06-15' GROUP BY dt order by dt;
+-- result:
+2020-06-15	9
+2020-06-18	5
+2020-06-21	7
+2020-06-24	9
+2020-07-02	3
+2020-07-05	5
+2020-07-08	7
+2020-07-11	9
+2020-07-16	1
+2020-07-19	2
+2020-07-22	3
+2020-07-25	4
+-- !result
 SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t2 where dt>'2020-06-15' GROUP BY dt order by dt;
+-- result:
+2020-06-18	5
+2020-06-21	7
+2020-06-24	9
+2020-07-02	3
+2020-07-05	5
+2020-07-08	7
+2020-07-11	9
+2020-07-16	1
+2020-07-19	2
+2020-07-22	3
+2020-07-25	4
+-- !result
 SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t2 where dt>'2020-06-15' and dt < '2020-07-22' GROUP BY dt order by dt;
+-- result:
+2020-06-18	5
+2020-06-21	7
+2020-06-24	9
+2020-07-02	3
+2020-07-05	5
+2020-07-08	7
+2020-07-11	9
+2020-07-16	1
+2020-07-19	2
+-- !result
 SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t2 where dt>'2020-06-15' and dt <= '2020-07-22' GROUP BY dt order by dt;
+-- result:
+2020-06-18	5
+2020-06-21	7
+2020-06-24	9
+2020-07-02	3
+2020-07-05	5
+2020-07-08	7
+2020-07-11	9
+2020-07-16	1
+2020-07-19	2
+2020-07-22	3
+-- !result
 SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t2 where (dt>'2020-06-15' and dt <= '2020-06-22') or dt>'2020-07-01' GROUP BY dt order by dt;
+-- result:
+2020-06-18	5
+2020-06-21	7
+2020-07-02	3
+2020-07-05	5
+2020-07-08	7
+2020-07-11	9
+2020-07-16	1
+2020-07-19	2
+2020-07-22	3
+2020-07-25	4
+-- !result
 SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t2 where dt in ('2020-06-22', '2020-07-01') GROUP BY dt order by dt;
+-- result:
+-- !result
 SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t2 where dt in ('2020-06-15', '2020-06-22', '2020-07-01') GROUP BY dt order by dt;
+-- result:
+2020-06-15	9
+-- !result
 SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t2 where dt between '2020-06-15' and '2020-07-01' GROUP BY dt order by dt;
+-- result:
+2020-06-15	9
+2020-06-18	5
+2020-06-21	7
+2020-06-24	9
+-- !result
 SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t2 where date_trunc('day', dt) ='2020-06-15' GROUP BY dt order by dt;
+-- result:
+2020-06-15	9
+-- !result
 SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t2 where date_trunc('month', dt) ='2020-06-01' GROUP BY dt order by dt;
+-- result:
+2020-06-15	9
+2020-06-18	5
+2020-06-21	7
+2020-06-24	9
+-- !result
 SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t2 where date_trunc('month', dt) ='2020-07-01' GROUP BY dt order by dt;
+-- result:
+2020-07-02	3
+2020-07-05	5
+2020-07-08	7
+2020-07-11	9
+2020-07-16	1
+2020-07-19	2
+2020-07-22	3
+2020-07-25	4
+-- !result
 SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t2 GROUP BY dt order by dt;
-
+-- result:
+2020-06-15	9
+2020-06-18	5
+2020-06-21	7
+2020-06-24	9
+2020-07-02	3
+2020-07-05	5
+2020-07-08	7
+2020-07-11	9
+2020-07-16	1
+2020-07-19	2
+2020-07-22	3
+2020-07-25	4
+-- !result
 drop materialized view default_catalog.db_${uuid0}.test_mv1;
-
+-- result:
+-- !result
+drop table mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 force;
+-- result:
+-- !result
 drop table mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t2 force;
-drop table mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t2 force;
+-- result:
+-- !result

--- a/test/sql/test_materialized_view/R/test_mv_partition_compensate_mysql
+++ b/test/sql/test_materialized_view/R/test_mv_partition_compensate_mysql
@@ -1,0 +1,834 @@
+-- name: test_mv_partition_compensate_mysql
+shell: mysql -h${external_mysql_ip} -u${external_mysql_user} -p${external_mysql_password} -P${external_mysql_port} -e 'create database mv_mysql_db_${uuid0};'
+-- result:
+0
+
+-- !result
+shell: mysql -h${external_mysql_ip} -u${external_mysql_user} -p${external_mysql_password} -P${external_mysql_port} -e 'use mv_mysql_db_${uuid0}; CREATE TABLE t1 (num int, dt date) PARTITION BY range columns(dt) (PARTITION p20200614 VALUES LESS THAN ("2020-06-15"),PARTITION p20200617 VALUES LESS THAN ("2020-06-18"),PARTITION p20200620 VALUES LESS THAN ("2020-06-21"),PARTITION p20200623 VALUES LESS THAN ("2020-06-24"),PARTITION p20200701 VALUES LESS THAN ("2020-07-02"),PARTITION p20200704 VALUES LESS THAN ("2020-07-05"),PARTITION p20200707 VALUES LESS THAN ("2020-07-08"),PARTITION p20200710 VALUES LESS THAN ("2020-07-11"),PARTITION p20200715 VALUES LESS THAN ("2020-07-16"),PARTITION p20200718 VALUES LESS THAN ("2020-07-19"),PARTITION p20200721 VALUES LESS THAN ("2020-07-22"),PARTITION p20200724 VALUES LESS THAN ("2020-07-31"));'
+-- result:
+0
+
+-- !result
+shell: mysql -h${external_mysql_ip} -u${external_mysql_user} -p${external_mysql_password} -P${external_mysql_port} -e 'use mv_mysql_db_${uuid0}; INSERT INTO t1 VALUES (1,"2020-06-15"),(2,"2020-06-18"),(3,"2020-06-21"),(4,"2020-06-24"),(1,"2020-07-02"),(2,"2020-07-05"),(3,"2020-07-08"),(4,"2020-07-11"),(1,"2020-07-16"),(2,"2020-07-19"),(3,"2020-07-22"),(4,"2020-07-25"),(2,"2020-06-15"),(3,"2020-06-18"),(4,"2020-06-21"),(5,"2020-06-24"),(2,"2020-07-02"),(3,"2020-07-05"),(4,"2020-07-08"),(5,"2020-07-11");'
+-- result:
+0
+
+-- !result
+set materialized_view_union_rewrite_mode = 3;
+-- result:
+-- !result
+set catalog default_catalog;
+-- result:
+-- !result
+create database db_${uuid0};
+-- result:
+-- !result
+use db_${uuid0};
+-- result:
+-- !result
+create external catalog mv_mysql_${uuid0}
+properties
+(
+    "type" = "jdbc",
+    "user"="${external_mysql_user}",
+    "password"="${external_mysql_password}",
+    "jdbc_uri"="jdbc:mysql://${external_mysql_ip}:${external_mysql_port}",
+    "driver_url"="https://repo1.maven.org/maven2/mysql/mysql-connector-java/8.0.28/mysql-connector-java-8.0.28.jar",
+    "driver_class"="com.mysql.cj.jdbc.Driver"
+);
+-- result:
+-- !result
+CREATE MATERIALIZED VIEW test_mv1 
+PARTITION BY dt 
+REFRESH DEFERRED MANUAL AS 
+  SELECT dt,sum(num) FROM mv_mysql_${uuid0}.mv_mysql_db_${uuid0}.t1 GROUP BY dt;
+-- result:
+-- !result
+REFRESH MATERIALIZED VIEW test_mv1 WITH SYNC MODE;
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_mysql_${uuid0}.mv_mysql_db_${uuid0}.t1 where dt='2020-06-15' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_mysql_${uuid0}.mv_mysql_db_${uuid0}.t1 where dt !='2020-06-15' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_mysql_${uuid0}.mv_mysql_db_${uuid0}.t1 where dt>='2020-06-15' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_mysql_${uuid0}.mv_mysql_db_${uuid0}.t1 where dt>'2020-06-15' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_mysql_${uuid0}.mv_mysql_db_${uuid0}.t1 where dt>'2020-06-15' and dt < '2020-07-22' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_mysql_${uuid0}.mv_mysql_db_${uuid0}.t1 where dt>'2020-06-15' and dt <= '2020-07-22' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_mysql_${uuid0}.mv_mysql_db_${uuid0}.t1 where (dt>'2020-06-15' and dt <= '2020-06-22') or dt>'2020-07-01' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_mysql_${uuid0}.mv_mysql_db_${uuid0}.t1 where dt in ('2020-06-15', '2020-06-22', '2020-07-01') GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_mysql_${uuid0}.mv_mysql_db_${uuid0}.t1 where date_trunc('day', dt) ='2020-06-15' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_no_hit_materialized_view("SELECT dt,sum(num) FROM mv_mysql_${uuid0}.mv_mysql_db_${uuid0}.t1 where date_trunc('month', dt) ='2020-06-01' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_no_hit_materialized_view("SELECT dt,sum(num) FROM mv_mysql_${uuid0}.mv_mysql_db_${uuid0}.t1 where date_trunc('month', dt) ='2020-07-01' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_mysql_${uuid0}.mv_mysql_db_${uuid0}.t1 GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+SELECT dt,sum(num) FROM mv_mysql_${uuid0}.mv_mysql_db_${uuid0}.t1 where dt='2020-06-15' GROUP BY dt order by dt;
+-- result:
+2020-06-15	3
+-- !result
+SELECT dt,sum(num) FROM mv_mysql_${uuid0}.mv_mysql_db_${uuid0}.t1 where dt !='2020-06-15' GROUP BY dt order by dt;
+-- result:
+2020-06-18	5
+2020-06-21	7
+2020-06-24	9
+2020-07-02	3
+2020-07-05	5
+2020-07-08	7
+2020-07-11	9
+2020-07-16	1
+2020-07-19	2
+2020-07-22	3
+2020-07-25	4
+-- !result
+SELECT dt,sum(num) FROM mv_mysql_${uuid0}.mv_mysql_db_${uuid0}.t1 where dt>='2020-06-15' GROUP BY dt order by dt;
+-- result:
+2020-06-15	3
+2020-06-18	5
+2020-06-21	7
+2020-06-24	9
+2020-07-02	3
+2020-07-05	5
+2020-07-08	7
+2020-07-11	9
+2020-07-16	1
+2020-07-19	2
+2020-07-22	3
+2020-07-25	4
+-- !result
+SELECT dt,sum(num) FROM mv_mysql_${uuid0}.mv_mysql_db_${uuid0}.t1 where dt>'2020-06-15' GROUP BY dt order by dt;
+-- result:
+2020-06-18	5
+2020-06-21	7
+2020-06-24	9
+2020-07-02	3
+2020-07-05	5
+2020-07-08	7
+2020-07-11	9
+2020-07-16	1
+2020-07-19	2
+2020-07-22	3
+2020-07-25	4
+-- !result
+SELECT dt,sum(num) FROM mv_mysql_${uuid0}.mv_mysql_db_${uuid0}.t1 where dt>'2020-06-15' and dt < '2020-07-22' GROUP BY dt order by dt;
+-- result:
+2020-06-18	5
+2020-06-21	7
+2020-06-24	9
+2020-07-02	3
+2020-07-05	5
+2020-07-08	7
+2020-07-11	9
+2020-07-16	1
+2020-07-19	2
+-- !result
+SELECT dt,sum(num) FROM mv_mysql_${uuid0}.mv_mysql_db_${uuid0}.t1 where dt>'2020-06-15' and dt <= '2020-07-22' GROUP BY dt order by dt;
+-- result:
+2020-06-18	5
+2020-06-21	7
+2020-06-24	9
+2020-07-02	3
+2020-07-05	5
+2020-07-08	7
+2020-07-11	9
+2020-07-16	1
+2020-07-19	2
+2020-07-22	3
+-- !result
+SELECT dt,sum(num) FROM mv_mysql_${uuid0}.mv_mysql_db_${uuid0}.t1 where (dt>'2020-06-15' and dt <= '2020-06-22') or dt>'2020-07-01' GROUP BY dt order by dt;
+-- result:
+2020-06-18	5
+2020-06-21	7
+2020-07-02	3
+2020-07-05	5
+2020-07-08	7
+2020-07-11	9
+2020-07-16	1
+2020-07-19	2
+2020-07-22	3
+2020-07-25	4
+-- !result
+SELECT dt,sum(num) FROM mv_mysql_${uuid0}.mv_mysql_db_${uuid0}.t1 where dt in ('2020-06-15', '2020-06-22', '2020-07-01') GROUP BY dt order by dt;
+-- result:
+2020-06-15	3
+-- !result
+SELECT dt,sum(num) FROM mv_mysql_${uuid0}.mv_mysql_db_${uuid0}.t1 where date_trunc('day', dt) ='2020-06-15' GROUP BY dt order by dt;
+-- result:
+2020-06-15	3
+-- !result
+SELECT dt,sum(num) FROM mv_mysql_${uuid0}.mv_mysql_db_${uuid0}.t1 where date_trunc('month', dt) ='2020-06-01' GROUP BY dt order by dt;
+-- result:
+2020-06-15	3
+2020-06-18	5
+2020-06-21	7
+2020-06-24	9
+-- !result
+SELECT dt,sum(num) FROM mv_mysql_${uuid0}.mv_mysql_db_${uuid0}.t1 where date_trunc('month', dt) ='2020-07-01' GROUP BY dt order by dt;
+-- result:
+2020-07-02	3
+2020-07-05	5
+2020-07-08	7
+2020-07-11	9
+2020-07-16	1
+2020-07-19	2
+2020-07-22	3
+2020-07-25	4
+-- !result
+SELECT dt,sum(num) FROM mv_mysql_${uuid0}.mv_mysql_db_${uuid0}.t1 GROUP BY dt order by dt;
+-- result:
+2020-06-15	3
+2020-06-18	5
+2020-06-21	7
+2020-06-24	9
+2020-07-02	3
+2020-07-05	5
+2020-07-08	7
+2020-07-11	9
+2020-07-16	1
+2020-07-19	2
+2020-07-22	3
+2020-07-25	4
+-- !result
+shell: mysql -h${external_mysql_ip} -u${external_mysql_user} -p${external_mysql_password} -P${external_mysql_port} -e 'use mv_mysql_db_${uuid0}; INSERT INTO t1 VALUES (3,"2020-06-15");'
+-- result:
+0
+
+-- !result
+function: check_no_hit_materialized_view("SELECT dt,sum(num) FROM mv_mysql_${uuid0}.mv_mysql_db_${uuid0}.t1 where dt='2020-06-15' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_no_hit_materialized_view("SELECT dt,sum(num) FROM mv_mysql_${uuid0}.mv_mysql_db_${uuid0}.t1 where date_trunc('day', dt) ='2020-06-15' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_no_hit_materialized_view("SELECT dt,sum(num) FROM mv_mysql_${uuid0}.mv_mysql_db_${uuid0}.t1 where dt in ('2020-06-15', '2020-06-22', '2020-07-01') GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_no_hit_materialized_view("SELECT dt,sum(num) FROM mv_mysql_${uuid0}.mv_mysql_db_${uuid0}.t1 where date_trunc('day', dt) ='2020-06-21' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_no_hit_materialized_view("SELECT dt,sum(num) FROM mv_mysql_${uuid0}.mv_mysql_db_${uuid0}.t1 where dt !='2020-06-15' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_no_hit_materialized_view("SELECT dt,sum(num) FROM mv_mysql_${uuid0}.mv_mysql_db_${uuid0}.t1 where dt>'2020-06-15' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_no_hit_materialized_view("SELECT dt,sum(num) FROM mv_mysql_${uuid0}.mv_mysql_db_${uuid0}.t1 where dt>'2020-06-15' and dt < '2020-07-22' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_no_hit_materialized_view("SELECT dt,sum(num) FROM mv_mysql_${uuid0}.mv_mysql_db_${uuid0}.t1 where dt>'2020-06-15' and dt <= '2020-07-22' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_no_hit_materialized_view("SELECT dt,sum(num) FROM mv_mysql_${uuid0}.mv_mysql_db_${uuid0}.t1 where (dt>'2020-06-15' and dt <= '2020-06-22') or dt>'2020-07-01' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_no_hit_materialized_view("SELECT dt,sum(num) FROM mv_mysql_${uuid0}.mv_mysql_db_${uuid0}.t1 where dt in ('2020-06-21', '2020-07-25') GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_no_hit_materialized_view("SELECT dt,sum(num) FROM mv_mysql_${uuid0}.mv_mysql_db_${uuid0}.t1 where date_trunc('month', dt) ='2020-07-01' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_no_hit_materialized_view("SELECT dt,sum(num) FROM mv_mysql_${uuid0}.mv_mysql_db_${uuid0}.t1 where dt between '2020-06-16' and '2020-07-01' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_no_hit_materialized_view("SELECT dt,sum(num) FROM mv_mysql_${uuid0}.mv_mysql_db_${uuid0}.t1 where dt between '2020-06-15' and '2020-07-01' GROUP BY dt;", "test_mv1", "UNION")
+-- result:
+None
+-- !result
+function: check_no_hit_materialized_view("SELECT dt,sum(num) FROM mv_mysql_${uuid0}.mv_mysql_db_${uuid0}.t1 where dt>='2020-06-15' GROUP BY dt;", "test_mv1", "UNION")
+-- result:
+None
+-- !result
+function: check_no_hit_materialized_view("SELECT dt,sum(num) FROM mv_mysql_${uuid0}.mv_mysql_db_${uuid0}.t1 where dt in ('2020-06-15', '2020-06-21', '2020-07-25') GROUP BY dt;", "test_mv1", "UNION")
+-- result:
+None
+-- !result
+function: check_no_hit_materialized_view("SELECT dt,sum(num) FROM mv_mysql_${uuid0}.mv_mysql_db_${uuid0}.t1 where date_trunc('month', dt) ='2020-06-01' GROUP BY dt;", "test_mv1", "UNION")
+-- result:
+None
+-- !result
+function: check_no_hit_materialized_view("SELECT dt,sum(num) FROM mv_mysql_${uuid0}.mv_mysql_db_${uuid0}.t1 GROUP BY dt;", "test_mv1", "UNION")
+-- result:
+None
+-- !result
+SELECT dt,sum(num) FROM mv_mysql_${uuid0}.mv_mysql_db_${uuid0}.t1 where dt='2020-06-15' GROUP BY dt order by dt;
+-- result:
+2020-06-15	6
+-- !result
+SELECT dt,sum(num) FROM mv_mysql_${uuid0}.mv_mysql_db_${uuid0}.t1 where dt !='2020-06-15' GROUP BY dt order by dt;
+-- result:
+2020-06-18	5
+2020-06-21	7
+2020-06-24	9
+2020-07-02	3
+2020-07-05	5
+2020-07-08	7
+2020-07-11	9
+2020-07-16	1
+2020-07-19	2
+2020-07-22	3
+2020-07-25	4
+-- !result
+SELECT dt,sum(num) FROM mv_mysql_${uuid0}.mv_mysql_db_${uuid0}.t1 where dt>='2020-06-15' GROUP BY dt order by dt;
+-- result:
+2020-06-15	6
+2020-06-18	5
+2020-06-21	7
+2020-06-24	9
+2020-07-02	3
+2020-07-05	5
+2020-07-08	7
+2020-07-11	9
+2020-07-16	1
+2020-07-19	2
+2020-07-22	3
+2020-07-25	4
+-- !result
+SELECT dt,sum(num) FROM mv_mysql_${uuid0}.mv_mysql_db_${uuid0}.t1 where dt>'2020-06-15' GROUP BY dt order by dt;
+-- result:
+2020-06-18	5
+2020-06-21	7
+2020-06-24	9
+2020-07-02	3
+2020-07-05	5
+2020-07-08	7
+2020-07-11	9
+2020-07-16	1
+2020-07-19	2
+2020-07-22	3
+2020-07-25	4
+-- !result
+SELECT dt,sum(num) FROM mv_mysql_${uuid0}.mv_mysql_db_${uuid0}.t1 where dt>'2020-06-15' and dt < '2020-07-22' GROUP BY dt order by dt;
+-- result:
+2020-06-18	5
+2020-06-21	7
+2020-06-24	9
+2020-07-02	3
+2020-07-05	5
+2020-07-08	7
+2020-07-11	9
+2020-07-16	1
+2020-07-19	2
+-- !result
+SELECT dt,sum(num) FROM mv_mysql_${uuid0}.mv_mysql_db_${uuid0}.t1 where dt>'2020-06-15' and dt <= '2020-07-22' GROUP BY dt order by dt;
+-- result:
+2020-06-18	5
+2020-06-21	7
+2020-06-24	9
+2020-07-02	3
+2020-07-05	5
+2020-07-08	7
+2020-07-11	9
+2020-07-16	1
+2020-07-19	2
+2020-07-22	3
+-- !result
+SELECT dt,sum(num) FROM mv_mysql_${uuid0}.mv_mysql_db_${uuid0}.t1 where (dt>'2020-06-15' and dt <= '2020-06-22') or dt>'2020-07-01' GROUP BY dt order by dt;
+-- result:
+2020-06-18	5
+2020-06-21	7
+2020-07-02	3
+2020-07-05	5
+2020-07-08	7
+2020-07-11	9
+2020-07-16	1
+2020-07-19	2
+2020-07-22	3
+2020-07-25	4
+-- !result
+SELECT dt,sum(num) FROM mv_mysql_${uuid0}.mv_mysql_db_${uuid0}.t1 where dt in ('2020-06-22', '2020-07-01') GROUP BY dt order by dt;
+-- result:
+-- !result
+SELECT dt,sum(num) FROM mv_mysql_${uuid0}.mv_mysql_db_${uuid0}.t1 where dt in ('2020-06-15', '2020-06-22', '2020-07-01') GROUP BY dt order by dt;
+-- result:
+2020-06-15	6
+-- !result
+SELECT dt,sum(num) FROM mv_mysql_${uuid0}.mv_mysql_db_${uuid0}.t1 where dt between '2020-06-15' and '2020-07-01' GROUP BY dt order by dt;
+-- result:
+2020-06-15	6
+2020-06-18	5
+2020-06-21	7
+2020-06-24	9
+-- !result
+SELECT dt,sum(num) FROM mv_mysql_${uuid0}.mv_mysql_db_${uuid0}.t1 where date_trunc('day', dt) ='2020-06-15' GROUP BY dt order by dt;
+-- result:
+2020-06-15	6
+-- !result
+SELECT dt,sum(num) FROM mv_mysql_${uuid0}.mv_mysql_db_${uuid0}.t1 where date_trunc('month', dt) ='2020-06-01' GROUP BY dt order by dt;
+-- result:
+2020-06-15	6
+2020-06-18	5
+2020-06-21	7
+2020-06-24	9
+-- !result
+SELECT dt,sum(num) FROM mv_mysql_${uuid0}.mv_mysql_db_${uuid0}.t1 where date_trunc('month', dt) ='2020-07-01' GROUP BY dt order by dt;
+-- result:
+2020-07-02	3
+2020-07-05	5
+2020-07-08	7
+2020-07-11	9
+2020-07-16	1
+2020-07-19	2
+2020-07-22	3
+2020-07-25	4
+-- !result
+SELECT dt,sum(num) FROM mv_mysql_${uuid0}.mv_mysql_db_${uuid0}.t1 GROUP BY dt order by dt;
+-- result:
+2020-06-15	6
+2020-06-18	5
+2020-06-21	7
+2020-06-24	9
+2020-07-02	3
+2020-07-05	5
+2020-07-08	7
+2020-07-11	9
+2020-07-16	1
+2020-07-19	2
+2020-07-22	3
+2020-07-25	4
+-- !result
+drop materialized view default_catalog.db_${uuid0}.test_mv1;
+-- result:
+-- !result
+CREATE MATERIALIZED VIEW test_mv1 
+PARTITION BY date_trunc('day', dt)
+REFRESH DEFERRED MANUAL AS 
+  SELECT dt,sum(num) FROM mv_mysql_${uuid0}.mv_mysql_db_${uuid0}.t1 GROUP BY dt;
+-- result:
+-- !result
+REFRESH MATERIALIZED VIEW test_mv1 WITH SYNC MODE;
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_mysql_${uuid0}.mv_mysql_db_${uuid0}.t1 where dt='2020-06-15' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_mysql_${uuid0}.mv_mysql_db_${uuid0}.t1 where dt !='2020-06-15' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_mysql_${uuid0}.mv_mysql_db_${uuid0}.t1 where dt>='2020-06-15' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_mysql_${uuid0}.mv_mysql_db_${uuid0}.t1 where dt>'2020-06-15' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_mysql_${uuid0}.mv_mysql_db_${uuid0}.t1 where dt>'2020-06-15' and dt < '2020-07-22' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_mysql_${uuid0}.mv_mysql_db_${uuid0}.t1 where dt>'2020-06-15' and dt <= '2020-07-22' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_mysql_${uuid0}.mv_mysql_db_${uuid0}.t1 where (dt>'2020-06-15' and dt <= '2020-06-22') or dt>'2020-07-01' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_mysql_${uuid0}.mv_mysql_db_${uuid0}.t1 where dt in ('2020-06-15', '2020-06-22', '2020-07-01') GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_mysql_${uuid0}.mv_mysql_db_${uuid0}.t1 where date_trunc('day', dt) ='2020-06-15' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_no_hit_materialized_view("SELECT dt,sum(num) FROM mv_mysql_${uuid0}.mv_mysql_db_${uuid0}.t1 where date_trunc('month', dt) ='2020-06-01' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_no_hit_materialized_view("SELECT dt,sum(num) FROM mv_mysql_${uuid0}.mv_mysql_db_${uuid0}.t1 where date_trunc('month', dt) ='2020-07-01' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_mysql_${uuid0}.mv_mysql_db_${uuid0}.t1 GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+SELECT dt,sum(num) FROM mv_mysql_${uuid0}.mv_mysql_db_${uuid0}.t1 where dt='2020-06-15' GROUP BY dt order by dt;
+-- result:
+2020-06-15	6
+-- !result
+SELECT dt,sum(num) FROM mv_mysql_${uuid0}.mv_mysql_db_${uuid0}.t1 where dt !='2020-06-15' GROUP BY dt order by dt;
+-- result:
+2020-06-18	5
+2020-06-21	7
+2020-06-24	9
+2020-07-02	3
+2020-07-05	5
+2020-07-08	7
+2020-07-11	9
+2020-07-16	1
+2020-07-19	2
+2020-07-22	3
+2020-07-25	4
+-- !result
+SELECT dt,sum(num) FROM mv_mysql_${uuid0}.mv_mysql_db_${uuid0}.t1 where dt>='2020-06-15' GROUP BY dt order by dt;
+-- result:
+2020-06-15	6
+2020-06-18	5
+2020-06-21	7
+2020-06-24	9
+2020-07-02	3
+2020-07-05	5
+2020-07-08	7
+2020-07-11	9
+2020-07-16	1
+2020-07-19	2
+2020-07-22	3
+2020-07-25	4
+-- !result
+SELECT dt,sum(num) FROM mv_mysql_${uuid0}.mv_mysql_db_${uuid0}.t1 where dt>'2020-06-15' GROUP BY dt order by dt;
+-- result:
+2020-06-18	5
+2020-06-21	7
+2020-06-24	9
+2020-07-02	3
+2020-07-05	5
+2020-07-08	7
+2020-07-11	9
+2020-07-16	1
+2020-07-19	2
+2020-07-22	3
+2020-07-25	4
+-- !result
+SELECT dt,sum(num) FROM mv_mysql_${uuid0}.mv_mysql_db_${uuid0}.t1 where dt>'2020-06-15' and dt < '2020-07-22' GROUP BY dt order by dt;
+-- result:
+2020-06-18	5
+2020-06-21	7
+2020-06-24	9
+2020-07-02	3
+2020-07-05	5
+2020-07-08	7
+2020-07-11	9
+2020-07-16	1
+2020-07-19	2
+-- !result
+SELECT dt,sum(num) FROM mv_mysql_${uuid0}.mv_mysql_db_${uuid0}.t1 where dt>'2020-06-15' and dt <= '2020-07-22' GROUP BY dt order by dt;
+-- result:
+2020-06-18	5
+2020-06-21	7
+2020-06-24	9
+2020-07-02	3
+2020-07-05	5
+2020-07-08	7
+2020-07-11	9
+2020-07-16	1
+2020-07-19	2
+2020-07-22	3
+-- !result
+SELECT dt,sum(num) FROM mv_mysql_${uuid0}.mv_mysql_db_${uuid0}.t1 where (dt>'2020-06-15' and dt <= '2020-06-22') or dt>'2020-07-01' GROUP BY dt order by dt;
+-- result:
+2020-06-18	5
+2020-06-21	7
+2020-07-02	3
+2020-07-05	5
+2020-07-08	7
+2020-07-11	9
+2020-07-16	1
+2020-07-19	2
+2020-07-22	3
+2020-07-25	4
+-- !result
+SELECT dt,sum(num) FROM mv_mysql_${uuid0}.mv_mysql_db_${uuid0}.t1 where dt in ('2020-06-15', '2020-06-22', '2020-07-01') GROUP BY dt order by dt;
+-- result:
+2020-06-15	6
+-- !result
+SELECT dt,sum(num) FROM mv_mysql_${uuid0}.mv_mysql_db_${uuid0}.t1 where date_trunc('day', dt) ='2020-06-15' GROUP BY dt order by dt;
+-- result:
+2020-06-15	6
+-- !result
+SELECT dt,sum(num) FROM mv_mysql_${uuid0}.mv_mysql_db_${uuid0}.t1 where date_trunc('month', dt) ='2020-06-01' GROUP BY dt order by dt;
+-- result:
+2020-06-15	6
+2020-06-18	5
+2020-06-21	7
+2020-06-24	9
+-- !result
+SELECT dt,sum(num) FROM mv_mysql_${uuid0}.mv_mysql_db_${uuid0}.t1 where date_trunc('month', dt) ='2020-07-01' GROUP BY dt order by dt;
+-- result:
+2020-07-02	3
+2020-07-05	5
+2020-07-08	7
+2020-07-11	9
+2020-07-16	1
+2020-07-19	2
+2020-07-22	3
+2020-07-25	4
+-- !result
+SELECT dt,sum(num) FROM mv_mysql_${uuid0}.mv_mysql_db_${uuid0}.t1 GROUP BY dt order by dt;
+-- result:
+2020-06-15	6
+2020-06-18	5
+2020-06-21	7
+2020-06-24	9
+2020-07-02	3
+2020-07-05	5
+2020-07-08	7
+2020-07-11	9
+2020-07-16	1
+2020-07-19	2
+2020-07-22	3
+2020-07-25	4
+-- !result
+shell: mysql -h${external_mysql_ip} -u${external_mysql_user} -p${external_mysql_password} -P${external_mysql_port} -e 'use mv_mysql_db_${uuid0}; INSERT INTO t1 VALUES (3,"2020-06-15");'
+-- result:
+0
+
+-- !result
+alter materialized view test_mv1 set('query_rewrite_consistency' = 'loose');
+-- result:
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_mysql_${uuid0}.mv_mysql_db_${uuid0}.t1 where dt='2020-06-15' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_mysql_${uuid0}.mv_mysql_db_${uuid0}.t1 where date_trunc('day', dt) ='2020-06-15' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_mysql_${uuid0}.mv_mysql_db_${uuid0}.t1 where dt in ('2020-06-15', '2020-06-22', '2020-07-01') GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_mysql_${uuid0}.mv_mysql_db_${uuid0}.t1 where date_trunc('day', dt) ='2020-06-21' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_mysql_${uuid0}.mv_mysql_db_${uuid0}.t1 where dt !='2020-06-15' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_mysql_${uuid0}.mv_mysql_db_${uuid0}.t1 where dt>'2020-06-15' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_mysql_${uuid0}.mv_mysql_db_${uuid0}.t1 where dt>'2020-06-15' and dt < '2020-07-22' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_mysql_${uuid0}.mv_mysql_db_${uuid0}.t1 where dt>'2020-06-15' and dt <= '2020-07-22' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_mysql_${uuid0}.mv_mysql_db_${uuid0}.t1 where (dt>'2020-06-15' and dt <= '2020-06-22') or dt>'2020-07-01' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_mysql_${uuid0}.mv_mysql_db_${uuid0}.t1 where dt in ('2020-06-21', '2020-07-25') GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_no_hit_materialized_view("SELECT dt,sum(num) FROM mv_mysql_${uuid0}.mv_mysql_db_${uuid0}.t1 where date_trunc('month', dt) ='2020-07-01' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_mysql_${uuid0}.mv_mysql_db_${uuid0}.t1 where dt between '2020-06-16' and '2020-07-01' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_mysql_${uuid0}.mv_mysql_db_${uuid0}.t1 where dt between '2020-06-15' and '2020-07-01' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_mysql_${uuid0}.mv_mysql_db_${uuid0}.t1 where dt>='2020-06-15' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_mysql_${uuid0}.mv_mysql_db_${uuid0}.t1 where dt in ('2020-06-15', '2020-06-21', '2020-07-25') GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_no_hit_materialized_view("SELECT dt,sum(num) FROM mv_mysql_${uuid0}.mv_mysql_db_${uuid0}.t1 where date_trunc('month', dt) ='2020-06-01' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_mysql_${uuid0}.mv_mysql_db_${uuid0}.t1 GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+SELECT dt,sum(num) FROM mv_mysql_${uuid0}.mv_mysql_db_${uuid0}.t1 where dt='2020-06-15' GROUP BY dt order by dt;
+-- result:
+2020-06-15	6
+-- !result
+SELECT dt,sum(num) FROM mv_mysql_${uuid0}.mv_mysql_db_${uuid0}.t1 where dt !='2020-06-15' GROUP BY dt order by dt;
+-- result:
+2020-06-18	5
+2020-06-21	7
+2020-06-24	9
+2020-07-02	3
+2020-07-05	5
+2020-07-08	7
+2020-07-11	9
+2020-07-16	1
+2020-07-19	2
+2020-07-22	3
+2020-07-25	4
+-- !result
+SELECT dt,sum(num) FROM mv_mysql_${uuid0}.mv_mysql_db_${uuid0}.t1 where dt>='2020-06-15' GROUP BY dt order by dt;
+-- result:
+2020-06-15	6
+2020-06-18	5
+2020-06-21	7
+2020-06-24	9
+2020-07-02	3
+2020-07-05	5
+2020-07-08	7
+2020-07-11	9
+2020-07-16	1
+2020-07-19	2
+2020-07-22	3
+2020-07-25	4
+-- !result
+SELECT dt,sum(num) FROM mv_mysql_${uuid0}.mv_mysql_db_${uuid0}.t1 where dt>'2020-06-15' GROUP BY dt order by dt;
+-- result:
+2020-06-18	5
+2020-06-21	7
+2020-06-24	9
+2020-07-02	3
+2020-07-05	5
+2020-07-08	7
+2020-07-11	9
+2020-07-16	1
+2020-07-19	2
+2020-07-22	3
+2020-07-25	4
+-- !result
+SELECT dt,sum(num) FROM mv_mysql_${uuid0}.mv_mysql_db_${uuid0}.t1 where dt>'2020-06-15' and dt < '2020-07-22' GROUP BY dt order by dt;
+-- result:
+2020-06-18	5
+2020-06-21	7
+2020-06-24	9
+2020-07-02	3
+2020-07-05	5
+2020-07-08	7
+2020-07-11	9
+2020-07-16	1
+2020-07-19	2
+-- !result
+SELECT dt,sum(num) FROM mv_mysql_${uuid0}.mv_mysql_db_${uuid0}.t1 where dt>'2020-06-15' and dt <= '2020-07-22' GROUP BY dt order by dt;
+-- result:
+2020-06-18	5
+2020-06-21	7
+2020-06-24	9
+2020-07-02	3
+2020-07-05	5
+2020-07-08	7
+2020-07-11	9
+2020-07-16	1
+2020-07-19	2
+2020-07-22	3
+-- !result
+SELECT dt,sum(num) FROM mv_mysql_${uuid0}.mv_mysql_db_${uuid0}.t1 where (dt>'2020-06-15' and dt <= '2020-06-22') or dt>'2020-07-01' GROUP BY dt order by dt;
+-- result:
+2020-06-18	5
+2020-06-21	7
+2020-07-02	3
+2020-07-05	5
+2020-07-08	7
+2020-07-11	9
+2020-07-16	1
+2020-07-19	2
+2020-07-22	3
+2020-07-25	4
+-- !result
+SELECT dt,sum(num) FROM mv_mysql_${uuid0}.mv_mysql_db_${uuid0}.t1 where dt in ('2020-06-22', '2020-07-01') GROUP BY dt order by dt;
+-- result:
+-- !result
+SELECT dt,sum(num) FROM mv_mysql_${uuid0}.mv_mysql_db_${uuid0}.t1 where dt in ('2020-06-15', '2020-06-22', '2020-07-01') GROUP BY dt order by dt;
+-- result:
+2020-06-15	6
+-- !result
+SELECT dt,sum(num) FROM mv_mysql_${uuid0}.mv_mysql_db_${uuid0}.t1 where dt between '2020-06-15' and '2020-07-01' GROUP BY dt order by dt;
+-- result:
+2020-06-15	6
+2020-06-18	5
+2020-06-21	7
+2020-06-24	9
+-- !result
+SELECT dt,sum(num) FROM mv_mysql_${uuid0}.mv_mysql_db_${uuid0}.t1 where date_trunc('day', dt) ='2020-06-15' GROUP BY dt order by dt;
+-- result:
+2020-06-15	6
+-- !result
+SELECT dt,sum(num) FROM mv_mysql_${uuid0}.mv_mysql_db_${uuid0}.t1 where date_trunc('month', dt) ='2020-06-01' GROUP BY dt order by dt;
+-- result:
+2020-06-15	9
+2020-06-18	5
+2020-06-21	7
+2020-06-24	9
+-- !result
+SELECT dt,sum(num) FROM mv_mysql_${uuid0}.mv_mysql_db_${uuid0}.t1 where date_trunc('month', dt) ='2020-07-01' GROUP BY dt order by dt;
+-- result:
+2020-07-02	3
+2020-07-05	5
+2020-07-08	7
+2020-07-11	9
+2020-07-16	1
+2020-07-19	2
+2020-07-22	3
+2020-07-25	4
+-- !result
+SELECT dt,sum(num) FROM mv_mysql_${uuid0}.mv_mysql_db_${uuid0}.t1 GROUP BY dt order by dt;
+-- result:
+2020-06-15	6
+2020-06-18	5
+2020-06-21	7
+2020-06-24	9
+2020-07-02	3
+2020-07-05	5
+2020-07-08	7
+2020-07-11	9
+2020-07-16	1
+2020-07-19	2
+2020-07-22	3
+2020-07-25	4
+-- !result
+drop materialized view default_catalog.db_${uuid0}.test_mv1;
+-- result:
+-- !result
+shell: mysql -h${external_mysql_ip} -u${external_mysql_user} -p${external_mysql_password} -P${external_mysql_port} -e 'drop database mv_mysql_db_${uuid0};'
+-- result:
+0
+
+-- !result

--- a/test/sql/test_materialized_view/R/test_mv_partition_compensate_olap
+++ b/test/sql/test_materialized_view/R/test_mv_partition_compensate_olap
@@ -1,0 +1,2378 @@
+-- name: test_mv_partition_compensate_olap
+create database db_${uuid0};
+-- result:
+-- !result
+use db_${uuid0};
+-- result:
+-- !result
+set materialized_view_union_rewrite_mode = 3;
+-- result:
+-- !result
+CREATE TABLE t1 (
+  num int,
+  dt date
+)
+DUPLICATE KEY(`num`)
+PARTITION BY RANGE(`dt`)
+(
+  PARTITION p20200615 VALUES [("2020-06-15 00:00:00"), ("2020-06-16 00:00:00")),
+  PARTITION p20200618 VALUES [("2020-06-18 00:00:00"), ("2020-06-19 00:00:00")),
+  PARTITION p20200621 VALUES [("2020-06-21 00:00:00"), ("2020-06-22 00:00:00")),
+  PARTITION p20200624 VALUES [("2020-06-24 00:00:00"), ("2020-06-25 00:00:00")),
+  PARTITION p20200702 VALUES [("2020-07-02 00:00:00"), ("2020-07-03 00:00:00")),
+  PARTITION p20200705 VALUES [("2020-07-05 00:00:00"), ("2020-07-06 00:00:00")),
+  PARTITION p20200708 VALUES [("2020-07-08 00:00:00"), ("2020-07-09 00:00:00")),
+  PARTITION p20200716 VALUES [("2020-07-16 00:00:00"), ("2020-07-17 00:00:00")),
+  PARTITION p20200719 VALUES [("2020-07-19 00:00:00"), ("2020-07-20 00:00:00")),
+  PARTITION p20200722 VALUES [("2020-07-22 00:00:00"), ("2020-07-23 00:00:00")),
+  PARTITION p20200725 VALUES [("2020-07-25 00:00:00"), ("2020-07-26 00:00:00")),
+  PARTITION p20200711 VALUES [("2020-07-11 00:00:00"), ("2020-07-12 00:00:00"))
+)
+DISTRIBUTED BY HASH(`num`);
+-- result:
+-- !result
+INSERT INTO t1 VALUES 
+  (1,"2020-06-15"),(2,"2020-06-18"),(3,"2020-06-21"),(4,"2020-06-24"),
+  (1,"2020-07-02"),(2,"2020-07-05"),(3,"2020-07-08"),(4,"2020-07-11"),
+  (1,"2020-07-16"),(2,"2020-07-19"),(3,"2020-07-22"),(4,"2020-07-25"),
+  (2,"2020-06-15"),(3,"2020-06-18"),(4,"2020-06-21"),(5,"2020-06-24"),
+  (2,"2020-07-02"),(3,"2020-07-05"),(4,"2020-07-08"),(5,"2020-07-11");
+-- result:
+-- !result
+CREATE TABLE t2 (
+  num int,
+  dt datetime
+)
+DUPLICATE KEY(`num`)
+PARTITION BY RANGE(`dt`)
+(
+  PARTITION p20200615 VALUES [("2020-06-15 00:00:00"), ("2020-06-16 00:00:00")),
+  PARTITION p20200618 VALUES [("2020-06-18 00:00:00"), ("2020-06-19 00:00:00")),
+  PARTITION p20200621 VALUES [("2020-06-21 00:00:00"), ("2020-06-22 00:00:00")),
+  PARTITION p20200624 VALUES [("2020-06-24 00:00:00"), ("2020-06-25 00:00:00")),
+  PARTITION p20200702 VALUES [("2020-07-02 00:00:00"), ("2020-07-03 00:00:00")),
+  PARTITION p20200705 VALUES [("2020-07-05 00:00:00"), ("2020-07-06 00:00:00")),
+  PARTITION p20200708 VALUES [("2020-07-08 00:00:00"), ("2020-07-09 00:00:00")),
+  PARTITION p20200716 VALUES [("2020-07-16 00:00:00"), ("2020-07-17 00:00:00")),
+  PARTITION p20200719 VALUES [("2020-07-19 00:00:00"), ("2020-07-20 00:00:00")),
+  PARTITION p20200722 VALUES [("2020-07-22 00:00:00"), ("2020-07-23 00:00:00")),
+  PARTITION p20200725 VALUES [("2020-07-25 00:00:00"), ("2020-07-26 00:00:00")),
+  PARTITION p20200711 VALUES [("2020-07-11 00:00:00"), ("2020-07-12 00:00:00"))
+)
+DISTRIBUTED BY HASH(`num`);
+-- result:
+-- !result
+INSERT INTO t2 VALUES 
+  (1,"2020-06-15"),(2,"2020-06-18"),(3,"2020-06-21"),(4,"2020-06-24"),
+  (1,"2020-07-02"),(2,"2020-07-05"),(3,"2020-07-08"),(4,"2020-07-11"),
+  (1,"2020-07-16"),(2,"2020-07-19"),(3,"2020-07-22"),(4,"2020-07-25"),
+  (2,"2020-06-15"),(3,"2020-06-18"),(4,"2020-06-21"),(5,"2020-06-24"),
+  (2,"2020-07-02"),(3,"2020-07-05"),(4,"2020-07-08"),(5,"2020-07-11");
+-- result:
+-- !result
+CREATE TABLE t3 (
+  num int,
+  dt datetime
+)
+DUPLICATE KEY(`num`)
+PARTITION BY  date_trunc('day', dt) 
+DISTRIBUTED BY HASH(`num`);
+-- result:
+-- !result
+INSERT INTO t3 VALUES 
+  (1,"2020-06-15"),(2,"2020-06-18"),(3,"2020-06-21"),(4,"2020-06-24"),
+  (1,"2020-07-02"),(2,"2020-07-05"),(3,"2020-07-08"),(4,"2020-07-11"),
+  (1,"2020-07-16"),(2,"2020-07-19"),(3,"2020-07-22"),(4,"2020-07-25"),
+  (2,"2020-06-15"),(3,"2020-06-18"),(4,"2020-06-21"),(5,"2020-06-24"),
+  (2,"2020-07-02"),(3,"2020-07-05"),(4,"2020-07-08"),(5,"2020-07-11");
+-- result:
+-- !result
+CREATE MATERIALIZED VIEW test_mv1 
+PARTITION BY dt 
+REFRESH DEFERRED MANUAL AS 
+  SELECT dt,sum(num) FROM t1 GROUP BY dt;
+-- result:
+-- !result
+REFRESH MATERIALIZED VIEW test_mv1 WITH SYNC MODE;
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t1 where dt='2020-06-15' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t1 where dt !='2020-06-15' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t1 where dt>='2020-06-15' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t1 where dt>'2020-06-15' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t1 where dt>'2020-06-15' and dt < '2020-07-22' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t1 where dt>'2020-06-15' and dt <= '2020-07-22' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t1 where (dt>'2020-06-15' and dt <= '2020-06-22') or dt>'2020-07-01' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t1 where dt in ('2020-06-15', '2020-06-22', '2020-07-01') GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t1 where date_trunc('day', dt) ='2020-06-15' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t1 where date_trunc('month', dt) ='2020-06-01' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t1 where date_trunc('month', dt) ='2020-07-01' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t1 GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+SELECT dt,sum(num) FROM t1 where dt='2020-06-15' GROUP BY dt order by dt;
+-- result:
+2020-06-15	3
+-- !result
+SELECT dt,sum(num) FROM t1 where dt !='2020-06-15' GROUP BY dt order by dt;
+-- result:
+2020-06-18	5
+2020-06-21	7
+2020-06-24	9
+2020-07-02	3
+2020-07-05	5
+2020-07-08	7
+2020-07-11	9
+2020-07-16	1
+2020-07-19	2
+2020-07-22	3
+2020-07-25	4
+-- !result
+SELECT dt,sum(num) FROM t1 where dt>='2020-06-15' GROUP BY dt order by dt;
+-- result:
+2020-06-15	3
+2020-06-18	5
+2020-06-21	7
+2020-06-24	9
+2020-07-02	3
+2020-07-05	5
+2020-07-08	7
+2020-07-11	9
+2020-07-16	1
+2020-07-19	2
+2020-07-22	3
+2020-07-25	4
+-- !result
+SELECT dt,sum(num) FROM t1 where dt>'2020-06-15' GROUP BY dt order by dt;
+-- result:
+2020-06-18	5
+2020-06-21	7
+2020-06-24	9
+2020-07-02	3
+2020-07-05	5
+2020-07-08	7
+2020-07-11	9
+2020-07-16	1
+2020-07-19	2
+2020-07-22	3
+2020-07-25	4
+-- !result
+SELECT dt,sum(num) FROM t1 where dt>'2020-06-15' and dt < '2020-07-22' GROUP BY dt order by dt;
+-- result:
+2020-06-18	5
+2020-06-21	7
+2020-06-24	9
+2020-07-02	3
+2020-07-05	5
+2020-07-08	7
+2020-07-11	9
+2020-07-16	1
+2020-07-19	2
+-- !result
+SELECT dt,sum(num) FROM t1 where dt>'2020-06-15' and dt <= '2020-07-22' GROUP BY dt order by dt;
+-- result:
+2020-06-18	5
+2020-06-21	7
+2020-06-24	9
+2020-07-02	3
+2020-07-05	5
+2020-07-08	7
+2020-07-11	9
+2020-07-16	1
+2020-07-19	2
+2020-07-22	3
+-- !result
+SELECT dt,sum(num) FROM t1 where (dt>'2020-06-15' and dt <= '2020-06-22') or dt>'2020-07-01' GROUP BY dt order by dt;
+-- result:
+2020-06-18	5
+2020-06-21	7
+2020-07-02	3
+2020-07-05	5
+2020-07-08	7
+2020-07-11	9
+2020-07-16	1
+2020-07-19	2
+2020-07-22	3
+2020-07-25	4
+-- !result
+SELECT dt,sum(num) FROM t1 where dt in ('2020-06-15', '2020-06-22', '2020-07-01') GROUP BY dt order by dt;
+-- result:
+2020-06-15	3
+-- !result
+SELECT dt,sum(num) FROM t1 where date_trunc('day', dt) ='2020-06-15' GROUP BY dt order by dt;
+-- result:
+2020-06-15	3
+-- !result
+SELECT dt,sum(num) FROM t1 where date_trunc('month', dt) ='2020-06-01' GROUP BY dt order by dt;
+-- result:
+2020-06-15	3
+2020-06-18	5
+2020-06-21	7
+2020-06-24	9
+-- !result
+SELECT dt,sum(num) FROM t1 where date_trunc('month', dt) ='2020-07-01' GROUP BY dt order by dt;
+-- result:
+2020-07-02	3
+2020-07-05	5
+2020-07-08	7
+2020-07-11	9
+2020-07-16	1
+2020-07-19	2
+2020-07-22	3
+2020-07-25	4
+-- !result
+SELECT dt,sum(num) FROM t1 GROUP BY dt order by dt;
+-- result:
+2020-06-15	3
+2020-06-18	5
+2020-06-21	7
+2020-06-24	9
+2020-07-02	3
+2020-07-05	5
+2020-07-08	7
+2020-07-11	9
+2020-07-16	1
+2020-07-19	2
+2020-07-22	3
+2020-07-25	4
+-- !result
+INSERT INTO t1 VALUES (3, "2020-06-15");
+-- result:
+-- !result
+function: check_no_hit_materialized_view("SELECT dt,sum(num) FROM t1 where dt='2020-06-15' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_no_hit_materialized_view("SELECT dt,sum(num) FROM t1 where date_trunc('day', dt) ='2020-06-15' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_no_hit_materialized_view("SELECT dt,sum(num) FROM t1 where dt in ('2020-06-15', '2020-06-22', '2020-07-01') GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t1 where date_trunc('day', dt) ='2020-06-21' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t1 where dt !='2020-06-15' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t1 where dt>'2020-06-15' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t1 where dt>'2020-06-15' and dt < '2020-07-22' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t1 where dt>'2020-06-15' and dt <= '2020-07-22' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t1 where (dt>'2020-06-15' and dt <= '2020-06-22') or dt>'2020-07-01' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t1 where date_trunc('month', dt) ='2020-07-01' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t1 where dt between '2020-06-15' and '2020-07-01' GROUP BY dt;", "test_mv1", "UNION")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t1 where dt>='2020-06-15' GROUP BY dt;", "test_mv1", "UNION")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t1 where dt in ('2020-06-15', '2020-06-21', '2020-07-25') GROUP BY dt;", "test_mv1", "UNION")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t1 where date_trunc('month', dt) ='2020-06-01' GROUP BY dt;", "test_mv1", "UNION")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t1 GROUP BY dt;", "test_mv1", "UNION")
+-- result:
+None
+-- !result
+SELECT dt,sum(num) FROM t1 where dt='2020-06-15' GROUP BY dt order by dt;
+-- result:
+2020-06-15	6
+-- !result
+SELECT dt,sum(num) FROM t1 where dt !='2020-06-15' GROUP BY dt order by dt;
+-- result:
+2020-06-18	5
+2020-06-21	7
+2020-06-24	9
+2020-07-02	3
+2020-07-05	5
+2020-07-08	7
+2020-07-11	9
+2020-07-16	1
+2020-07-19	2
+2020-07-22	3
+2020-07-25	4
+-- !result
+SELECT dt,sum(num) FROM t1 where dt>='2020-06-15' GROUP BY dt order by dt;
+-- result:
+2020-06-15	6
+2020-06-18	5
+2020-06-21	7
+2020-06-24	9
+2020-07-02	3
+2020-07-05	5
+2020-07-08	7
+2020-07-11	9
+2020-07-16	1
+2020-07-19	2
+2020-07-22	3
+2020-07-25	4
+-- !result
+SELECT dt,sum(num) FROM t1 where dt>'2020-06-15' GROUP BY dt order by dt;
+-- result:
+2020-06-18	5
+2020-06-21	7
+2020-06-24	9
+2020-07-02	3
+2020-07-05	5
+2020-07-08	7
+2020-07-11	9
+2020-07-16	1
+2020-07-19	2
+2020-07-22	3
+2020-07-25	4
+-- !result
+SELECT dt,sum(num) FROM t1 where dt>'2020-06-15' and dt < '2020-07-22' GROUP BY dt order by dt;
+-- result:
+2020-06-18	5
+2020-06-21	7
+2020-06-24	9
+2020-07-02	3
+2020-07-05	5
+2020-07-08	7
+2020-07-11	9
+2020-07-16	1
+2020-07-19	2
+-- !result
+SELECT dt,sum(num) FROM t1 where dt>'2020-06-15' and dt <= '2020-07-22' GROUP BY dt order by dt;
+-- result:
+2020-06-18	5
+2020-06-21	7
+2020-06-24	9
+2020-07-02	3
+2020-07-05	5
+2020-07-08	7
+2020-07-11	9
+2020-07-16	1
+2020-07-19	2
+2020-07-22	3
+-- !result
+SELECT dt,sum(num) FROM t1 where (dt>'2020-06-15' and dt <= '2020-06-22') or dt>'2020-07-01' GROUP BY dt order by dt;
+-- result:
+2020-06-18	5
+2020-06-21	7
+2020-07-02	3
+2020-07-05	5
+2020-07-08	7
+2020-07-11	9
+2020-07-16	1
+2020-07-19	2
+2020-07-22	3
+2020-07-25	4
+-- !result
+SELECT dt,sum(num) FROM t1 where dt in ('2020-06-15', '2020-06-22', '2020-07-01') GROUP BY dt order by dt;
+-- result:
+2020-06-15	6
+-- !result
+SELECT dt,sum(num) FROM t1 where date_trunc('day', dt) ='2020-06-15' GROUP BY dt order by dt;
+-- result:
+2020-06-15	6
+-- !result
+SELECT dt,sum(num) FROM t1 where date_trunc('month', dt) ='2020-06-01' GROUP BY dt order by dt;
+-- result:
+2020-06-15	6
+2020-06-18	5
+2020-06-21	7
+2020-06-24	9
+-- !result
+SELECT dt,sum(num) FROM t1 where date_trunc('month', dt) ='2020-07-01' GROUP BY dt order by dt;
+-- result:
+2020-07-02	3
+2020-07-05	5
+2020-07-08	7
+2020-07-11	9
+2020-07-16	1
+2020-07-19	2
+2020-07-22	3
+2020-07-25	4
+-- !result
+SELECT dt,sum(num) FROM t1 where dt between '2020-06-15' and '2020-07-01' GROUP BY dt order by dt;
+-- result:
+2020-06-15	6
+2020-06-18	5
+2020-06-21	7
+2020-06-24	9
+-- !result
+SELECT dt,sum(num) FROM t1 GROUP BY dt order by dt;
+-- result:
+2020-06-15	6
+2020-06-18	5
+2020-06-21	7
+2020-06-24	9
+2020-07-02	3
+2020-07-05	5
+2020-07-08	7
+2020-07-11	9
+2020-07-16	1
+2020-07-19	2
+2020-07-22	3
+2020-07-25	4
+-- !result
+drop materialized view default_catalog.db_${uuid0}.test_mv1;
+-- result:
+-- !result
+CREATE MATERIALIZED VIEW test_mv1 
+PARTITION BY date_trunc('day', dt)
+REFRESH DEFERRED MANUAL AS 
+  SELECT dt,sum(num) FROM t1 GROUP BY dt;
+-- result:
+-- !result
+REFRESH MATERIALIZED VIEW test_mv1 WITH SYNC MODE;
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t1 where dt='2020-06-15' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t1 where dt !='2020-06-15' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t1 where dt>='2020-06-15' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t1 where dt>'2020-06-15' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t1 where dt>'2020-06-15' and dt < '2020-07-22' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t1 where dt>'2020-06-15' and dt <= '2020-07-22' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t1 where (dt>'2020-06-15' and dt <= '2020-06-22') or dt>'2020-07-01' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t1 where dt in ('2020-06-15', '2020-06-22', '2020-07-01') GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t1 where date_trunc('day', dt) ='2020-06-15' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t1 where date_trunc('month', dt) ='2020-06-01' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t1 where date_trunc('month', dt) ='2020-07-01' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t1 GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+SELECT dt,sum(num) FROM t1 where dt='2020-06-15' GROUP BY dt order by dt;
+-- result:
+2020-06-15	6
+-- !result
+SELECT dt,sum(num) FROM t1 where dt !='2020-06-15' GROUP BY dt order by dt;
+-- result:
+2020-06-18	5
+2020-06-21	7
+2020-06-24	9
+2020-07-02	3
+2020-07-05	5
+2020-07-08	7
+2020-07-11	9
+2020-07-16	1
+2020-07-19	2
+2020-07-22	3
+2020-07-25	4
+-- !result
+SELECT dt,sum(num) FROM t1 where dt>='2020-06-15' GROUP BY dt order by dt;
+-- result:
+2020-06-15	6
+2020-06-18	5
+2020-06-21	7
+2020-06-24	9
+2020-07-02	3
+2020-07-05	5
+2020-07-08	7
+2020-07-11	9
+2020-07-16	1
+2020-07-19	2
+2020-07-22	3
+2020-07-25	4
+-- !result
+SELECT dt,sum(num) FROM t1 where dt>'2020-06-15' GROUP BY dt order by dt;
+-- result:
+2020-06-18	5
+2020-06-21	7
+2020-06-24	9
+2020-07-02	3
+2020-07-05	5
+2020-07-08	7
+2020-07-11	9
+2020-07-16	1
+2020-07-19	2
+2020-07-22	3
+2020-07-25	4
+-- !result
+SELECT dt,sum(num) FROM t1 where dt>'2020-06-15' and dt < '2020-07-22' GROUP BY dt order by dt;
+-- result:
+2020-06-18	5
+2020-06-21	7
+2020-06-24	9
+2020-07-02	3
+2020-07-05	5
+2020-07-08	7
+2020-07-11	9
+2020-07-16	1
+2020-07-19	2
+-- !result
+SELECT dt,sum(num) FROM t1 where dt>'2020-06-15' and dt <= '2020-07-22' GROUP BY dt order by dt;
+-- result:
+2020-06-18	5
+2020-06-21	7
+2020-06-24	9
+2020-07-02	3
+2020-07-05	5
+2020-07-08	7
+2020-07-11	9
+2020-07-16	1
+2020-07-19	2
+2020-07-22	3
+-- !result
+SELECT dt,sum(num) FROM t1 where (dt>'2020-06-15' and dt <= '2020-06-22') or dt>'2020-07-01' GROUP BY dt order by dt;
+-- result:
+2020-06-18	5
+2020-06-21	7
+2020-07-02	3
+2020-07-05	5
+2020-07-08	7
+2020-07-11	9
+2020-07-16	1
+2020-07-19	2
+2020-07-22	3
+2020-07-25	4
+-- !result
+SELECT dt,sum(num) FROM t1 where dt in ('2020-06-15', '2020-06-22', '2020-07-01') GROUP BY dt order by dt;
+-- result:
+2020-06-15	6
+-- !result
+SELECT dt,sum(num) FROM t1 where date_trunc('day', dt) ='2020-06-15' GROUP BY dt order by dt;
+-- result:
+2020-06-15	6
+-- !result
+SELECT dt,sum(num) FROM t1 where date_trunc('month', dt) ='2020-06-01' GROUP BY dt order by dt;
+-- result:
+2020-06-15	6
+2020-06-18	5
+2020-06-21	7
+2020-06-24	9
+-- !result
+SELECT dt,sum(num) FROM t1 where date_trunc('month', dt) ='2020-07-01' GROUP BY dt order by dt;
+-- result:
+2020-07-02	3
+2020-07-05	5
+2020-07-08	7
+2020-07-11	9
+2020-07-16	1
+2020-07-19	2
+2020-07-22	3
+2020-07-25	4
+-- !result
+SELECT dt,sum(num) FROM t1 GROUP BY dt order by dt;
+-- result:
+2020-06-15	6
+2020-06-18	5
+2020-06-21	7
+2020-06-24	9
+2020-07-02	3
+2020-07-05	5
+2020-07-08	7
+2020-07-11	9
+2020-07-16	1
+2020-07-19	2
+2020-07-22	3
+2020-07-25	4
+-- !result
+INSERT INTO t1 VALUES (3, "2020-06-15");
+-- result:
+-- !result
+function: check_no_hit_materialized_view("SELECT dt,sum(num) FROM t1 where dt='2020-06-15' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_no_hit_materialized_view("SELECT dt,sum(num) FROM t1 where date_trunc('day', dt) ='2020-06-15' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_no_hit_materialized_view("SELECT dt,sum(num) FROM t1 where dt in ('2020-06-15', '2020-06-22', '2020-07-01') GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t1 where date_trunc('day', dt) ='2020-06-21' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t1 where dt !='2020-06-15' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t1 where dt>'2020-06-15' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t1 where dt>'2020-06-15' and dt < '2020-07-22' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t1 where dt>'2020-06-15' and dt <= '2020-07-22' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t1 where (dt>'2020-06-15' and dt <= '2020-06-22') or dt>'2020-07-01' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t1 where date_trunc('month', dt) ='2020-07-01' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t1 where dt between '2020-06-15' and '2020-07-01' GROUP BY dt;", "test_mv1", "UNION")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t1 where dt>='2020-06-15' GROUP BY dt;", "test_mv1", "UNION")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t1 where dt in ('2020-06-15', '2020-06-21', '2020-07-25') GROUP BY dt;", "test_mv1", "UNION")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t1 where date_trunc('month', dt) ='2020-06-01' GROUP BY dt;", "test_mv1", "UNION")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t1 GROUP BY dt;", "test_mv1", "UNION")
+-- result:
+None
+-- !result
+SELECT dt,sum(num) FROM t1 where dt='2020-06-15' GROUP BY dt order by dt;
+-- result:
+2020-06-15	9
+-- !result
+SELECT dt,sum(num) FROM t1 where dt !='2020-06-15' GROUP BY dt order by dt;
+-- result:
+2020-06-18	5
+2020-06-21	7
+2020-06-24	9
+2020-07-02	3
+2020-07-05	5
+2020-07-08	7
+2020-07-11	9
+2020-07-16	1
+2020-07-19	2
+2020-07-22	3
+2020-07-25	4
+-- !result
+SELECT dt,sum(num) FROM t1 where dt>='2020-06-15' GROUP BY dt order by dt;
+-- result:
+2020-06-15	9
+2020-06-18	5
+2020-06-21	7
+2020-06-24	9
+2020-07-02	3
+2020-07-05	5
+2020-07-08	7
+2020-07-11	9
+2020-07-16	1
+2020-07-19	2
+2020-07-22	3
+2020-07-25	4
+-- !result
+SELECT dt,sum(num) FROM t1 where dt>'2020-06-15' GROUP BY dt order by dt;
+-- result:
+2020-06-18	5
+2020-06-21	7
+2020-06-24	9
+2020-07-02	3
+2020-07-05	5
+2020-07-08	7
+2020-07-11	9
+2020-07-16	1
+2020-07-19	2
+2020-07-22	3
+2020-07-25	4
+-- !result
+SELECT dt,sum(num) FROM t1 where dt>'2020-06-15' and dt < '2020-07-22' GROUP BY dt order by dt;
+-- result:
+2020-06-18	5
+2020-06-21	7
+2020-06-24	9
+2020-07-02	3
+2020-07-05	5
+2020-07-08	7
+2020-07-11	9
+2020-07-16	1
+2020-07-19	2
+-- !result
+SELECT dt,sum(num) FROM t1 where dt>'2020-06-15' and dt <= '2020-07-22' GROUP BY dt order by dt;
+-- result:
+2020-06-18	5
+2020-06-21	7
+2020-06-24	9
+2020-07-02	3
+2020-07-05	5
+2020-07-08	7
+2020-07-11	9
+2020-07-16	1
+2020-07-19	2
+2020-07-22	3
+-- !result
+SELECT dt,sum(num) FROM t2 where (dt>'2020-06-15' and dt <= '2020-06-22') or dt>'2020-07-01' GROUP BY dt order by dt;
+-- result:
+2020-06-18 00:00:00	5
+2020-06-21 00:00:00	7
+2020-07-02 00:00:00	3
+2020-07-05 00:00:00	5
+2020-07-08 00:00:00	7
+2020-07-11 00:00:00	9
+2020-07-16 00:00:00	1
+2020-07-19 00:00:00	2
+2020-07-22 00:00:00	3
+2020-07-25 00:00:00	4
+-- !result
+SELECT dt,sum(num) FROM t2 where dt in ('2020-06-15', '2020-06-22', '2020-07-01') GROUP BY dt order by dt;
+-- result:
+2020-06-15 00:00:00	3
+-- !result
+SELECT dt,sum(num) FROM t2 where date_trunc('day', dt) ='2020-06-15' GROUP BY dt order by dt;
+-- result:
+2020-06-15 00:00:00	3
+-- !result
+SELECT dt,sum(num) FROM t2 where date_trunc('month', dt) ='2020-06-01' GROUP BY dt order by dt;
+-- result:
+2020-06-15 00:00:00	3
+2020-06-18 00:00:00	5
+2020-06-21 00:00:00	7
+2020-06-24 00:00:00	9
+-- !result
+SELECT dt,sum(num) FROM t2 where date_trunc('month', dt) ='2020-07-01' GROUP BY dt order by dt;
+-- result:
+2020-07-02 00:00:00	3
+2020-07-05 00:00:00	5
+2020-07-08 00:00:00	7
+2020-07-11 00:00:00	9
+2020-07-16 00:00:00	1
+2020-07-19 00:00:00	2
+2020-07-22 00:00:00	3
+2020-07-25 00:00:00	4
+-- !result
+SELECT dt,sum(num) FROM t2 where dt between '2020-06-15' and '2020-07-01' GROUP BY dt order by dt;
+-- result:
+2020-06-15 00:00:00	3
+2020-06-18 00:00:00	5
+2020-06-21 00:00:00	7
+2020-06-24 00:00:00	9
+-- !result
+SELECT dt,sum(num) FROM t2 GROUP BY dt order by dt;
+-- result:
+2020-06-15 00:00:00	3
+2020-06-18 00:00:00	5
+2020-06-21 00:00:00	7
+2020-06-24 00:00:00	9
+2020-07-02 00:00:00	3
+2020-07-05 00:00:00	5
+2020-07-08 00:00:00	7
+2020-07-11 00:00:00	9
+2020-07-16 00:00:00	1
+2020-07-19 00:00:00	2
+2020-07-22 00:00:00	3
+2020-07-25 00:00:00	4
+-- !result
+drop materialized view default_catalog.db_${uuid0}.test_mv1;
+-- result:
+-- !result
+CREATE MATERIALIZED VIEW test_mv1 
+PARTITION BY date_trunc('day', dt)
+REFRESH DEFERRED MANUAL AS 
+  SELECT dt,sum(num) FROM t2 GROUP BY dt;
+-- result:
+-- !result
+REFRESH MATERIALIZED VIEW test_mv1 WITH SYNC MODE;
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t2 where dt='2020-06-15' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t2 where dt !='2020-06-15' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t2 where dt>='2020-06-15' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t2 where dt>'2020-06-15' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t2 where dt>'2020-06-15' and dt < '2020-07-22' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t2 where dt>'2020-06-15' and dt <= '2020-07-22' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t2 where (dt>'2020-06-15' and dt <= '2020-06-22') or dt>'2020-07-01' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t2 where dt in ('2020-06-15', '2020-06-22', '2020-07-01') GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t2 where date_trunc('day', dt) ='2020-06-15' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t2 where date_trunc('month', dt) ='2020-06-01' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t2 where date_trunc('month', dt) ='2020-07-01' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t2 GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+SELECT dt,sum(num) FROM t2 where dt='2020-06-15' GROUP BY dt order by dt;
+-- result:
+2020-06-15 00:00:00	3
+-- !result
+SELECT dt,sum(num) FROM t2 where dt !='2020-06-15' GROUP BY dt order by dt;
+-- result:
+2020-06-18 00:00:00	5
+2020-06-21 00:00:00	7
+2020-06-24 00:00:00	9
+2020-07-02 00:00:00	3
+2020-07-05 00:00:00	5
+2020-07-08 00:00:00	7
+2020-07-11 00:00:00	9
+2020-07-16 00:00:00	1
+2020-07-19 00:00:00	2
+2020-07-22 00:00:00	3
+2020-07-25 00:00:00	4
+-- !result
+SELECT dt,sum(num) FROM t2 where dt>='2020-06-15' GROUP BY dt order by dt;
+-- result:
+2020-06-15 00:00:00	3
+2020-06-18 00:00:00	5
+2020-06-21 00:00:00	7
+2020-06-24 00:00:00	9
+2020-07-02 00:00:00	3
+2020-07-05 00:00:00	5
+2020-07-08 00:00:00	7
+2020-07-11 00:00:00	9
+2020-07-16 00:00:00	1
+2020-07-19 00:00:00	2
+2020-07-22 00:00:00	3
+2020-07-25 00:00:00	4
+-- !result
+SELECT dt,sum(num) FROM t2 where dt>'2020-06-15' GROUP BY dt order by dt;
+-- result:
+2020-06-18 00:00:00	5
+2020-06-21 00:00:00	7
+2020-06-24 00:00:00	9
+2020-07-02 00:00:00	3
+2020-07-05 00:00:00	5
+2020-07-08 00:00:00	7
+2020-07-11 00:00:00	9
+2020-07-16 00:00:00	1
+2020-07-19 00:00:00	2
+2020-07-22 00:00:00	3
+2020-07-25 00:00:00	4
+-- !result
+SELECT dt,sum(num) FROM t2 where dt>'2020-06-15' and dt < '2020-07-22' GROUP BY dt order by dt;
+-- result:
+2020-06-18 00:00:00	5
+2020-06-21 00:00:00	7
+2020-06-24 00:00:00	9
+2020-07-02 00:00:00	3
+2020-07-05 00:00:00	5
+2020-07-08 00:00:00	7
+2020-07-11 00:00:00	9
+2020-07-16 00:00:00	1
+2020-07-19 00:00:00	2
+-- !result
+SELECT dt,sum(num) FROM t2 where dt>'2020-06-15' and dt <= '2020-07-22' GROUP BY dt order by dt;
+-- result:
+2020-06-18 00:00:00	5
+2020-06-21 00:00:00	7
+2020-06-24 00:00:00	9
+2020-07-02 00:00:00	3
+2020-07-05 00:00:00	5
+2020-07-08 00:00:00	7
+2020-07-11 00:00:00	9
+2020-07-16 00:00:00	1
+2020-07-19 00:00:00	2
+2020-07-22 00:00:00	3
+-- !result
+SELECT dt,sum(num) FROM t2 where (dt>'2020-06-15' and dt <= '2020-06-22') or dt>'2020-07-01' GROUP BY dt order by dt;
+-- result:
+2020-06-18 00:00:00	5
+2020-06-21 00:00:00	7
+2020-07-02 00:00:00	3
+2020-07-05 00:00:00	5
+2020-07-08 00:00:00	7
+2020-07-11 00:00:00	9
+2020-07-16 00:00:00	1
+2020-07-19 00:00:00	2
+2020-07-22 00:00:00	3
+2020-07-25 00:00:00	4
+-- !result
+SELECT dt,sum(num) FROM t2 where dt in ('2020-06-15', '2020-06-22', '2020-07-01') GROUP BY dt order by dt;
+-- result:
+2020-06-15 00:00:00	3
+-- !result
+SELECT dt,sum(num) FROM t2 where date_trunc('day', dt) ='2020-06-15' GROUP BY dt order by dt;
+-- result:
+2020-06-15 00:00:00	3
+-- !result
+SELECT dt,sum(num) FROM t2 where date_trunc('month', dt) ='2020-06-01' GROUP BY dt order by dt;
+-- result:
+2020-06-15 00:00:00	3
+2020-06-18 00:00:00	5
+2020-06-21 00:00:00	7
+2020-06-24 00:00:00	9
+-- !result
+SELECT dt,sum(num) FROM t2 where date_trunc('month', dt) ='2020-07-01' GROUP BY dt order by dt;
+-- result:
+2020-07-02 00:00:00	3
+2020-07-05 00:00:00	5
+2020-07-08 00:00:00	7
+2020-07-11 00:00:00	9
+2020-07-16 00:00:00	1
+2020-07-19 00:00:00	2
+2020-07-22 00:00:00	3
+2020-07-25 00:00:00	4
+-- !result
+SELECT dt,sum(num) FROM t2 GROUP BY dt order by dt;
+-- result:
+2020-06-15 00:00:00	3
+2020-06-18 00:00:00	5
+2020-06-21 00:00:00	7
+2020-06-24 00:00:00	9
+2020-07-02 00:00:00	3
+2020-07-05 00:00:00	5
+2020-07-08 00:00:00	7
+2020-07-11 00:00:00	9
+2020-07-16 00:00:00	1
+2020-07-19 00:00:00	2
+2020-07-22 00:00:00	3
+2020-07-25 00:00:00	4
+-- !result
+INSERT INTO t2 VALUES (3, "2020-06-15");
+-- result:
+-- !result
+function: check_no_hit_materialized_view("SELECT dt,sum(num) FROM t2 where dt='2020-06-15' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_no_hit_materialized_view("SELECT dt,sum(num) FROM t2 where date_trunc('day', dt) ='2020-06-15' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_no_hit_materialized_view("SELECT dt,sum(num) FROM t2 where dt in ('2020-06-15', '2020-06-22', '2020-07-01') GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t2 where date_trunc('day', dt) ='2020-06-21' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t2 where dt !='2020-06-15' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t2 where dt>'2020-06-15' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t2 where dt>'2020-06-15' and dt < '2020-07-22' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t2 where dt>'2020-06-15' and dt <= '2020-07-22' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t2 where (dt>'2020-06-15' and dt <= '2020-06-22') or dt>'2020-07-01' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t2 where date_trunc('month', dt) ='2020-07-01' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t2 where dt between '2020-06-15' and '2020-07-01' GROUP BY dt;", "test_mv1", "UNION")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t2 where dt>='2020-06-15' GROUP BY dt;", "test_mv1", "UNION")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t2 where dt in ('2020-06-15', '2020-06-21', '2020-07-25') GROUP BY dt;", "test_mv1", "UNION")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t2 where date_trunc('month', dt) ='2020-06-01' GROUP BY dt;", "test_mv1", "UNION")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t2 GROUP BY dt;", "test_mv1", "UNION")
+-- result:
+None
+-- !result
+SELECT dt,sum(num) FROM t2 where dt='2020-06-15' GROUP BY dt order by dt;
+-- result:
+2020-06-15 00:00:00	6
+-- !result
+SELECT dt,sum(num) FROM t2 where dt !='2020-06-15' GROUP BY dt order by dt;
+-- result:
+2020-06-18 00:00:00	5
+2020-06-21 00:00:00	7
+2020-06-24 00:00:00	9
+2020-07-02 00:00:00	3
+2020-07-05 00:00:00	5
+2020-07-08 00:00:00	7
+2020-07-11 00:00:00	9
+2020-07-16 00:00:00	1
+2020-07-19 00:00:00	2
+2020-07-22 00:00:00	3
+2020-07-25 00:00:00	4
+-- !result
+SELECT dt,sum(num) FROM t2 where dt>='2020-06-15' GROUP BY dt order by dt;
+-- result:
+2020-06-15 00:00:00	6
+2020-06-18 00:00:00	5
+2020-06-21 00:00:00	7
+2020-06-24 00:00:00	9
+2020-07-02 00:00:00	3
+2020-07-05 00:00:00	5
+2020-07-08 00:00:00	7
+2020-07-11 00:00:00	9
+2020-07-16 00:00:00	1
+2020-07-19 00:00:00	2
+2020-07-22 00:00:00	3
+2020-07-25 00:00:00	4
+-- !result
+SELECT dt,sum(num) FROM t2 where dt>'2020-06-15' GROUP BY dt order by dt;
+-- result:
+2020-06-18 00:00:00	5
+2020-06-21 00:00:00	7
+2020-06-24 00:00:00	9
+2020-07-02 00:00:00	3
+2020-07-05 00:00:00	5
+2020-07-08 00:00:00	7
+2020-07-11 00:00:00	9
+2020-07-16 00:00:00	1
+2020-07-19 00:00:00	2
+2020-07-22 00:00:00	3
+2020-07-25 00:00:00	4
+-- !result
+SELECT dt,sum(num) FROM t2 where dt>'2020-06-15' and dt < '2020-07-22' GROUP BY dt order by dt;
+-- result:
+2020-06-18 00:00:00	5
+2020-06-21 00:00:00	7
+2020-06-24 00:00:00	9
+2020-07-02 00:00:00	3
+2020-07-05 00:00:00	5
+2020-07-08 00:00:00	7
+2020-07-11 00:00:00	9
+2020-07-16 00:00:00	1
+2020-07-19 00:00:00	2
+-- !result
+SELECT dt,sum(num) FROM t2 where dt>'2020-06-15' and dt <= '2020-07-22' GROUP BY dt order by dt;
+-- result:
+2020-06-18 00:00:00	5
+2020-06-21 00:00:00	7
+2020-06-24 00:00:00	9
+2020-07-02 00:00:00	3
+2020-07-05 00:00:00	5
+2020-07-08 00:00:00	7
+2020-07-11 00:00:00	9
+2020-07-16 00:00:00	1
+2020-07-19 00:00:00	2
+2020-07-22 00:00:00	3
+-- !result
+SELECT dt,sum(num) FROM t2 where (dt>'2020-06-15' and dt <= '2020-06-22') or dt>'2020-07-01' GROUP BY dt order by dt;
+-- result:
+2020-06-18 00:00:00	5
+2020-06-21 00:00:00	7
+2020-07-02 00:00:00	3
+2020-07-05 00:00:00	5
+2020-07-08 00:00:00	7
+2020-07-11 00:00:00	9
+2020-07-16 00:00:00	1
+2020-07-19 00:00:00	2
+2020-07-22 00:00:00	3
+2020-07-25 00:00:00	4
+-- !result
+SELECT dt,sum(num) FROM t2 where dt in ('2020-06-15', '2020-06-22', '2020-07-01') GROUP BY dt order by dt;
+-- result:
+2020-06-15 00:00:00	6
+-- !result
+SELECT dt,sum(num) FROM t2 where date_trunc('day', dt) ='2020-06-15' GROUP BY dt order by dt;
+-- result:
+2020-06-15 00:00:00	6
+-- !result
+SELECT dt,sum(num) FROM t2 where date_trunc('month', dt) ='2020-06-01' GROUP BY dt order by dt;
+-- result:
+2020-06-15 00:00:00	6
+2020-06-18 00:00:00	5
+2020-06-21 00:00:00	7
+2020-06-24 00:00:00	9
+-- !result
+SELECT dt,sum(num) FROM t2 where date_trunc('month', dt) ='2020-07-01' GROUP BY dt order by dt;
+-- result:
+2020-07-02 00:00:00	3
+2020-07-05 00:00:00	5
+2020-07-08 00:00:00	7
+2020-07-11 00:00:00	9
+2020-07-16 00:00:00	1
+2020-07-19 00:00:00	2
+2020-07-22 00:00:00	3
+2020-07-25 00:00:00	4
+-- !result
+SELECT dt,sum(num) FROM t2 where dt between '2020-06-15' and '2020-07-01' GROUP BY dt order by dt;
+-- result:
+2020-06-15 00:00:00	6
+2020-06-18 00:00:00	5
+2020-06-21 00:00:00	7
+2020-06-24 00:00:00	9
+-- !result
+SELECT dt,sum(num) FROM t2 GROUP BY dt order by dt;
+-- result:
+2020-06-15 00:00:00	6
+2020-06-18 00:00:00	5
+2020-06-21 00:00:00	7
+2020-06-24 00:00:00	9
+2020-07-02 00:00:00	3
+2020-07-05 00:00:00	5
+2020-07-08 00:00:00	7
+2020-07-11 00:00:00	9
+2020-07-16 00:00:00	1
+2020-07-19 00:00:00	2
+2020-07-22 00:00:00	3
+2020-07-25 00:00:00	4
+-- !result
+drop materialized view default_catalog.db_${uuid0}.test_mv1;
+-- result:
+-- !result
+CREATE MATERIALIZED VIEW test_mv1 
+PARTITION BY dt
+REFRESH DEFERRED MANUAL AS 
+  SELECT dt, date_trunc('day', dt) as format_dt,sum(num) FROM t2 GROUP BY dt;
+-- result:
+-- !result
+REFRESH MATERIALIZED VIEW test_mv1 WITH SYNC MODE;
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t2 where dt='2020-06-15' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t2 where dt !='2020-06-15' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t2 where dt>='2020-06-15' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t2 where dt>'2020-06-15' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t2 where dt>'2020-06-15' and dt < '2020-07-22' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t2 where dt>'2020-06-15' and dt <= '2020-07-22' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t2 where (dt>'2020-06-15' and dt <= '2020-06-22') or dt>'2020-07-01' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t2 where dt in ('2020-06-15', '2020-06-22', '2020-07-01') GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t2 where date_trunc('day', dt) ='2020-06-15' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t2 where date_trunc('month', dt) ='2020-06-01' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t2 where date_trunc('month', dt) ='2020-07-01' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t2 GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+SELECT dt,sum(num) FROM t2 where dt='2020-06-15' GROUP BY dt order by dt;
+-- result:
+2020-06-15 00:00:00	6
+-- !result
+SELECT dt,sum(num) FROM t2 where dt !='2020-06-15' GROUP BY dt order by dt;
+-- result:
+2020-06-18 00:00:00	5
+2020-06-21 00:00:00	7
+2020-06-24 00:00:00	9
+2020-07-02 00:00:00	3
+2020-07-05 00:00:00	5
+2020-07-08 00:00:00	7
+2020-07-11 00:00:00	9
+2020-07-16 00:00:00	1
+2020-07-19 00:00:00	2
+2020-07-22 00:00:00	3
+2020-07-25 00:00:00	4
+-- !result
+SELECT dt,sum(num) FROM t2 where dt>='2020-06-15' GROUP BY dt order by dt;
+-- result:
+2020-06-15 00:00:00	6
+2020-06-18 00:00:00	5
+2020-06-21 00:00:00	7
+2020-06-24 00:00:00	9
+2020-07-02 00:00:00	3
+2020-07-05 00:00:00	5
+2020-07-08 00:00:00	7
+2020-07-11 00:00:00	9
+2020-07-16 00:00:00	1
+2020-07-19 00:00:00	2
+2020-07-22 00:00:00	3
+2020-07-25 00:00:00	4
+-- !result
+SELECT dt,sum(num) FROM t2 where dt>'2020-06-15' GROUP BY dt order by dt;
+-- result:
+2020-06-18 00:00:00	5
+2020-06-21 00:00:00	7
+2020-06-24 00:00:00	9
+2020-07-02 00:00:00	3
+2020-07-05 00:00:00	5
+2020-07-08 00:00:00	7
+2020-07-11 00:00:00	9
+2020-07-16 00:00:00	1
+2020-07-19 00:00:00	2
+2020-07-22 00:00:00	3
+2020-07-25 00:00:00	4
+-- !result
+SELECT dt,sum(num) FROM t2 where dt>'2020-06-15' and dt < '2020-07-22' GROUP BY dt order by dt;
+-- result:
+2020-06-18 00:00:00	5
+2020-06-21 00:00:00	7
+2020-06-24 00:00:00	9
+2020-07-02 00:00:00	3
+2020-07-05 00:00:00	5
+2020-07-08 00:00:00	7
+2020-07-11 00:00:00	9
+2020-07-16 00:00:00	1
+2020-07-19 00:00:00	2
+-- !result
+SELECT dt,sum(num) FROM t2 where dt>'2020-06-15' and dt <= '2020-07-22' GROUP BY dt order by dt;
+-- result:
+2020-06-18 00:00:00	5
+2020-06-21 00:00:00	7
+2020-06-24 00:00:00	9
+2020-07-02 00:00:00	3
+2020-07-05 00:00:00	5
+2020-07-08 00:00:00	7
+2020-07-11 00:00:00	9
+2020-07-16 00:00:00	1
+2020-07-19 00:00:00	2
+2020-07-22 00:00:00	3
+-- !result
+SELECT dt,sum(num) FROM t2 where (dt>'2020-06-15' and dt <= '2020-06-22') or dt>'2020-07-01' GROUP BY dt order by dt;
+-- result:
+2020-06-18 00:00:00	5
+2020-06-21 00:00:00	7
+2020-07-02 00:00:00	3
+2020-07-05 00:00:00	5
+2020-07-08 00:00:00	7
+2020-07-11 00:00:00	9
+2020-07-16 00:00:00	1
+2020-07-19 00:00:00	2
+2020-07-22 00:00:00	3
+2020-07-25 00:00:00	4
+-- !result
+SELECT dt,sum(num) FROM t2 where dt in ('2020-06-15', '2020-06-22', '2020-07-01') GROUP BY dt order by dt;
+-- result:
+2020-06-15 00:00:00	6
+-- !result
+SELECT dt,sum(num) FROM t2 where date_trunc('day', dt) ='2020-06-15' GROUP BY dt order by dt;
+-- result:
+2020-06-15 00:00:00	6
+-- !result
+SELECT dt,sum(num) FROM t2 where date_trunc('month', dt) ='2020-06-01' GROUP BY dt order by dt;
+-- result:
+2020-06-15 00:00:00	6
+2020-06-18 00:00:00	5
+2020-06-21 00:00:00	7
+2020-06-24 00:00:00	9
+-- !result
+SELECT dt,sum(num) FROM t2 where date_trunc('month', dt) ='2020-07-01' GROUP BY dt order by dt;
+-- result:
+2020-07-02 00:00:00	3
+2020-07-05 00:00:00	5
+2020-07-08 00:00:00	7
+2020-07-11 00:00:00	9
+2020-07-16 00:00:00	1
+2020-07-19 00:00:00	2
+2020-07-22 00:00:00	3
+2020-07-25 00:00:00	4
+-- !result
+SELECT dt,sum(num) FROM t2 GROUP BY dt order by dt;
+-- result:
+2020-06-15 00:00:00	6
+2020-06-18 00:00:00	5
+2020-06-21 00:00:00	7
+2020-06-24 00:00:00	9
+2020-07-02 00:00:00	3
+2020-07-05 00:00:00	5
+2020-07-08 00:00:00	7
+2020-07-11 00:00:00	9
+2020-07-16 00:00:00	1
+2020-07-19 00:00:00	2
+2020-07-22 00:00:00	3
+2020-07-25 00:00:00	4
+-- !result
+INSERT INTO t2 VALUES (3, "2020-06-15");
+-- result:
+-- !result
+function: check_no_hit_materialized_view("SELECT dt,sum(num) FROM t2 where dt='2020-06-15' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_no_hit_materialized_view("SELECT dt,sum(num) FROM t2 where date_trunc('day', dt) ='2020-06-15' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_no_hit_materialized_view("SELECT dt,sum(num) FROM t2 where dt in ('2020-06-15', '2020-06-22', '2020-07-01') GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t2 where date_trunc('day', dt) ='2020-06-21' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t2 where dt !='2020-06-15' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t2 where dt>'2020-06-15' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t2 where dt>'2020-06-15' and dt < '2020-07-22' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t2 where dt>'2020-06-15' and dt <= '2020-07-22' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t2 where (dt>'2020-06-15' and dt <= '2020-06-22') or dt>'2020-07-01' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t2 where date_trunc('month', dt) ='2020-07-01' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t2 where dt between '2020-06-15' and '2020-07-01' GROUP BY dt;", "test_mv1", "UNION")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t2 where dt>='2020-06-15' GROUP BY dt;", "test_mv1", "UNION")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t2 where dt in ('2020-06-15', '2020-06-21', '2020-07-25') GROUP BY dt;", "test_mv1", "UNION")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t2 where date_trunc('month', dt) ='2020-06-01' GROUP BY dt;", "test_mv1", "UNION")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t2 GROUP BY dt;", "test_mv1", "UNION")
+-- result:
+None
+-- !result
+SELECT dt,sum(num) FROM t2 where dt='2020-06-15' GROUP BY dt order by dt;
+-- result:
+2020-06-15 00:00:00	9
+-- !result
+SELECT dt,sum(num) FROM t2 where dt !='2020-06-15' GROUP BY dt order by dt;
+-- result:
+2020-06-18 00:00:00	5
+2020-06-21 00:00:00	7
+2020-06-24 00:00:00	9
+2020-07-02 00:00:00	3
+2020-07-05 00:00:00	5
+2020-07-08 00:00:00	7
+2020-07-11 00:00:00	9
+2020-07-16 00:00:00	1
+2020-07-19 00:00:00	2
+2020-07-22 00:00:00	3
+2020-07-25 00:00:00	4
+-- !result
+SELECT dt,sum(num) FROM t2 where dt>='2020-06-15' GROUP BY dt order by dt;
+-- result:
+2020-06-15 00:00:00	9
+2020-06-18 00:00:00	5
+2020-06-21 00:00:00	7
+2020-06-24 00:00:00	9
+2020-07-02 00:00:00	3
+2020-07-05 00:00:00	5
+2020-07-08 00:00:00	7
+2020-07-11 00:00:00	9
+2020-07-16 00:00:00	1
+2020-07-19 00:00:00	2
+2020-07-22 00:00:00	3
+2020-07-25 00:00:00	4
+-- !result
+SELECT dt,sum(num) FROM t2 where dt>'2020-06-15' GROUP BY dt order by dt;
+-- result:
+2020-06-18 00:00:00	5
+2020-06-21 00:00:00	7
+2020-06-24 00:00:00	9
+2020-07-02 00:00:00	3
+2020-07-05 00:00:00	5
+2020-07-08 00:00:00	7
+2020-07-11 00:00:00	9
+2020-07-16 00:00:00	1
+2020-07-19 00:00:00	2
+2020-07-22 00:00:00	3
+2020-07-25 00:00:00	4
+-- !result
+SELECT dt,sum(num) FROM t2 where dt>'2020-06-15' and dt < '2020-07-22' GROUP BY dt order by dt;
+-- result:
+2020-06-18 00:00:00	5
+2020-06-21 00:00:00	7
+2020-06-24 00:00:00	9
+2020-07-02 00:00:00	3
+2020-07-05 00:00:00	5
+2020-07-08 00:00:00	7
+2020-07-11 00:00:00	9
+2020-07-16 00:00:00	1
+2020-07-19 00:00:00	2
+-- !result
+SELECT dt,sum(num) FROM t2 where dt>'2020-06-15' and dt <= '2020-07-22' GROUP BY dt order by dt;
+-- result:
+2020-06-18 00:00:00	5
+2020-06-21 00:00:00	7
+2020-06-24 00:00:00	9
+2020-07-02 00:00:00	3
+2020-07-05 00:00:00	5
+2020-07-08 00:00:00	7
+2020-07-11 00:00:00	9
+2020-07-16 00:00:00	1
+2020-07-19 00:00:00	2
+2020-07-22 00:00:00	3
+-- !result
+SELECT dt,sum(num) FROM t2 where (dt>'2020-06-15' and dt <= '2020-06-22') or dt>'2020-07-01' GROUP BY dt order by dt;
+-- result:
+2020-06-18 00:00:00	5
+2020-06-21 00:00:00	7
+2020-07-02 00:00:00	3
+2020-07-05 00:00:00	5
+2020-07-08 00:00:00	7
+2020-07-11 00:00:00	9
+2020-07-16 00:00:00	1
+2020-07-19 00:00:00	2
+2020-07-22 00:00:00	3
+2020-07-25 00:00:00	4
+-- !result
+SELECT dt,sum(num) FROM t2 where dt in ('2020-06-15', '2020-06-22', '2020-07-01') GROUP BY dt order by dt;
+-- result:
+2020-06-15 00:00:00	9
+-- !result
+SELECT dt,sum(num) FROM t2 where date_trunc('day', dt) ='2020-06-15' GROUP BY dt order by dt;
+-- result:
+2020-06-15 00:00:00	9
+-- !result
+SELECT dt,sum(num) FROM t2 where date_trunc('month', dt) ='2020-06-01' GROUP BY dt order by dt;
+-- result:
+2020-06-15 00:00:00	9
+2020-06-18 00:00:00	5
+2020-06-21 00:00:00	7
+2020-06-24 00:00:00	9
+-- !result
+SELECT dt,sum(num) FROM t2 where date_trunc('month', dt) ='2020-07-01' GROUP BY dt order by dt;
+-- result:
+2020-07-02 00:00:00	3
+2020-07-05 00:00:00	5
+2020-07-08 00:00:00	7
+2020-07-11 00:00:00	9
+2020-07-16 00:00:00	1
+2020-07-19 00:00:00	2
+2020-07-22 00:00:00	3
+2020-07-25 00:00:00	4
+-- !result
+SELECT dt,sum(num) FROM t2 where dt between '2020-06-15' and '2020-07-01' GROUP BY dt order by dt;
+-- result:
+2020-06-15 00:00:00	9
+2020-06-18 00:00:00	5
+2020-06-21 00:00:00	7
+2020-06-24 00:00:00	9
+-- !result
+SELECT dt,sum(num) FROM t2 GROUP BY dt order by dt;
+-- result:
+2020-06-15 00:00:00	9
+2020-06-18 00:00:00	5
+2020-06-21 00:00:00	7
+2020-06-24 00:00:00	9
+2020-07-02 00:00:00	3
+2020-07-05 00:00:00	5
+2020-07-08 00:00:00	7
+2020-07-11 00:00:00	9
+2020-07-16 00:00:00	1
+2020-07-19 00:00:00	2
+2020-07-22 00:00:00	3
+2020-07-25 00:00:00	4
+-- !result
+drop materialized view default_catalog.db_${uuid0}.test_mv1;
+-- result:
+-- !result
+CREATE MATERIALIZED VIEW test_mv1 
+PARTITION BY dt
+REFRESH DEFERRED MANUAL AS 
+  SELECT dt,sum(num) FROM t3 GROUP BY dt;
+-- result:
+-- !result
+REFRESH MATERIALIZED VIEW test_mv1 WITH SYNC MODE;
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t3 where dt='2020-06-15' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t3 where dt !='2020-06-15' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t3 where dt>='2020-06-15' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t3 where dt>'2020-06-15' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t3 where dt>'2020-06-15' and dt < '2020-07-22' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t3 where dt>'2020-06-15' and dt <= '2020-07-22' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t3 where (dt>'2020-06-15' and dt <= '2020-06-22') or dt>'2020-07-01' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t3 where dt in ('2020-06-15', '2020-06-22', '2020-07-01') GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t3 where date_trunc('day', dt) ='2020-06-15' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t3 where date_trunc('month', dt) ='2020-06-01' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t3 where date_trunc('month', dt) ='2020-07-01' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t3 GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+SELECT dt,sum(num) FROM t3 where dt='2020-06-15' GROUP BY dt order by dt;
+-- result:
+2020-06-15 00:00:00	3
+-- !result
+SELECT dt,sum(num) FROM t3 where dt !='2020-06-15' GROUP BY dt order by dt;
+-- result:
+2020-06-18 00:00:00	5
+2020-06-21 00:00:00	7
+2020-06-24 00:00:00	9
+2020-07-02 00:00:00	3
+2020-07-05 00:00:00	5
+2020-07-08 00:00:00	7
+2020-07-11 00:00:00	9
+2020-07-16 00:00:00	1
+2020-07-19 00:00:00	2
+2020-07-22 00:00:00	3
+2020-07-25 00:00:00	4
+-- !result
+SELECT dt,sum(num) FROM t3 where dt>='2020-06-15' GROUP BY dt order by dt;
+-- result:
+2020-06-15 00:00:00	3
+2020-06-18 00:00:00	5
+2020-06-21 00:00:00	7
+2020-06-24 00:00:00	9
+2020-07-02 00:00:00	3
+2020-07-05 00:00:00	5
+2020-07-08 00:00:00	7
+2020-07-11 00:00:00	9
+2020-07-16 00:00:00	1
+2020-07-19 00:00:00	2
+2020-07-22 00:00:00	3
+2020-07-25 00:00:00	4
+-- !result
+SELECT dt,sum(num) FROM t3 where dt>'2020-06-15' GROUP BY dt order by dt;
+-- result:
+2020-06-18 00:00:00	5
+2020-06-21 00:00:00	7
+2020-06-24 00:00:00	9
+2020-07-02 00:00:00	3
+2020-07-05 00:00:00	5
+2020-07-08 00:00:00	7
+2020-07-11 00:00:00	9
+2020-07-16 00:00:00	1
+2020-07-19 00:00:00	2
+2020-07-22 00:00:00	3
+2020-07-25 00:00:00	4
+-- !result
+SELECT dt,sum(num) FROM t3 where dt>'2020-06-15' and dt < '2020-07-22' GROUP BY dt order by dt;
+-- result:
+2020-06-18 00:00:00	5
+2020-06-21 00:00:00	7
+2020-06-24 00:00:00	9
+2020-07-02 00:00:00	3
+2020-07-05 00:00:00	5
+2020-07-08 00:00:00	7
+2020-07-11 00:00:00	9
+2020-07-16 00:00:00	1
+2020-07-19 00:00:00	2
+-- !result
+SELECT dt,sum(num) FROM t3 where dt>'2020-06-15' and dt <= '2020-07-22' GROUP BY dt order by dt;
+-- result:
+2020-06-18 00:00:00	5
+2020-06-21 00:00:00	7
+2020-06-24 00:00:00	9
+2020-07-02 00:00:00	3
+2020-07-05 00:00:00	5
+2020-07-08 00:00:00	7
+2020-07-11 00:00:00	9
+2020-07-16 00:00:00	1
+2020-07-19 00:00:00	2
+2020-07-22 00:00:00	3
+-- !result
+SELECT dt,sum(num) FROM t3 where (dt>'2020-06-15' and dt <= '2020-06-22') or dt>'2020-07-01' GROUP BY dt order by dt;
+-- result:
+2020-06-18 00:00:00	5
+2020-06-21 00:00:00	7
+2020-07-02 00:00:00	3
+2020-07-05 00:00:00	5
+2020-07-08 00:00:00	7
+2020-07-11 00:00:00	9
+2020-07-16 00:00:00	1
+2020-07-19 00:00:00	2
+2020-07-22 00:00:00	3
+2020-07-25 00:00:00	4
+-- !result
+SELECT dt,sum(num) FROM t3 where dt in ('2020-06-15', '2020-06-22', '2020-07-01') GROUP BY dt order by dt;
+-- result:
+2020-06-15 00:00:00	3
+-- !result
+SELECT dt,sum(num) FROM t3 where date_trunc('day', dt) ='2020-06-15' GROUP BY dt order by dt;
+-- result:
+2020-06-15 00:00:00	3
+-- !result
+SELECT dt,sum(num) FROM t3 where date_trunc('month', dt) ='2020-06-01' GROUP BY dt order by dt;
+-- result:
+2020-06-15 00:00:00	3
+2020-06-18 00:00:00	5
+2020-06-21 00:00:00	7
+2020-06-24 00:00:00	9
+-- !result
+SELECT dt,sum(num) FROM t3 where date_trunc('month', dt) ='2020-07-01' GROUP BY dt order by dt;
+-- result:
+2020-07-02 00:00:00	3
+2020-07-05 00:00:00	5
+2020-07-08 00:00:00	7
+2020-07-11 00:00:00	9
+2020-07-16 00:00:00	1
+2020-07-19 00:00:00	2
+2020-07-22 00:00:00	3
+2020-07-25 00:00:00	4
+-- !result
+SELECT dt,sum(num) FROM t3 GROUP BY dt order by dt;
+-- result:
+2020-06-15 00:00:00	3
+2020-06-18 00:00:00	5
+2020-06-21 00:00:00	7
+2020-06-24 00:00:00	9
+2020-07-02 00:00:00	3
+2020-07-05 00:00:00	5
+2020-07-08 00:00:00	7
+2020-07-11 00:00:00	9
+2020-07-16 00:00:00	1
+2020-07-19 00:00:00	2
+2020-07-22 00:00:00	3
+2020-07-25 00:00:00	4
+-- !result
+INSERT INTO t3 VALUES (3, "2020-06-15");
+-- result:
+-- !result
+function: check_no_hit_materialized_view("SELECT dt,sum(num) FROM t3 where dt='2020-06-15' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_no_hit_materialized_view("SELECT dt,sum(num) FROM t3 where date_trunc('day', dt) ='2020-06-15' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_no_hit_materialized_view("SELECT dt,sum(num) FROM t3 where dt in ('2020-06-15', '2020-06-22', '2020-07-01') GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t3 where date_trunc('day', dt) ='2020-06-21' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t3 where dt !='2020-06-15' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t3 where dt>'2020-06-15' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t3 where dt>'2020-06-15' and dt < '2020-07-22' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t3 where dt>'2020-06-15' and dt <= '2020-07-22' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t3 where (dt>'2020-06-15' and dt <= '2020-06-22') or dt>'2020-07-01' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t3 where date_trunc('month', dt) ='2020-07-01' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t3 where dt between '2020-06-15' and '2020-07-01' GROUP BY dt;", "test_mv1", "UNION")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t3 where dt>='2020-06-15' GROUP BY dt;", "test_mv1", "UNION")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t3 where dt in ('2020-06-15', '2020-06-21', '2020-07-25') GROUP BY dt;", "test_mv1", "UNION")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t3 where date_trunc('month', dt) ='2020-06-01' GROUP BY dt;", "test_mv1", "UNION")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t3 GROUP BY dt;", "test_mv1", "UNION")
+-- result:
+None
+-- !result
+SELECT dt,sum(num) FROM t3 where dt='2020-06-15' GROUP BY dt order by dt;
+-- result:
+2020-06-15 00:00:00	6
+-- !result
+SELECT dt,sum(num) FROM t3 where dt !='2020-06-15' GROUP BY dt order by dt;
+-- result:
+2020-06-18 00:00:00	5
+2020-06-21 00:00:00	7
+2020-06-24 00:00:00	9
+2020-07-02 00:00:00	3
+2020-07-05 00:00:00	5
+2020-07-08 00:00:00	7
+2020-07-11 00:00:00	9
+2020-07-16 00:00:00	1
+2020-07-19 00:00:00	2
+2020-07-22 00:00:00	3
+2020-07-25 00:00:00	4
+-- !result
+SELECT dt,sum(num) FROM t3 where dt>='2020-06-15' GROUP BY dt order by dt;
+-- result:
+2020-06-15 00:00:00	6
+2020-06-18 00:00:00	5
+2020-06-21 00:00:00	7
+2020-06-24 00:00:00	9
+2020-07-02 00:00:00	3
+2020-07-05 00:00:00	5
+2020-07-08 00:00:00	7
+2020-07-11 00:00:00	9
+2020-07-16 00:00:00	1
+2020-07-19 00:00:00	2
+2020-07-22 00:00:00	3
+2020-07-25 00:00:00	4
+-- !result
+SELECT dt,sum(num) FROM t3 where dt>'2020-06-15' GROUP BY dt order by dt;
+-- result:
+2020-06-18 00:00:00	5
+2020-06-21 00:00:00	7
+2020-06-24 00:00:00	9
+2020-07-02 00:00:00	3
+2020-07-05 00:00:00	5
+2020-07-08 00:00:00	7
+2020-07-11 00:00:00	9
+2020-07-16 00:00:00	1
+2020-07-19 00:00:00	2
+2020-07-22 00:00:00	3
+2020-07-25 00:00:00	4
+-- !result
+SELECT dt,sum(num) FROM t3 where dt>'2020-06-15' and dt < '2020-07-22' GROUP BY dt order by dt;
+-- result:
+2020-06-18 00:00:00	5
+2020-06-21 00:00:00	7
+2020-06-24 00:00:00	9
+2020-07-02 00:00:00	3
+2020-07-05 00:00:00	5
+2020-07-08 00:00:00	7
+2020-07-11 00:00:00	9
+2020-07-16 00:00:00	1
+2020-07-19 00:00:00	2
+-- !result
+SELECT dt,sum(num) FROM t3 where dt>'2020-06-15' and dt <= '2020-07-22' GROUP BY dt order by dt;
+-- result:
+2020-06-18 00:00:00	5
+2020-06-21 00:00:00	7
+2020-06-24 00:00:00	9
+2020-07-02 00:00:00	3
+2020-07-05 00:00:00	5
+2020-07-08 00:00:00	7
+2020-07-11 00:00:00	9
+2020-07-16 00:00:00	1
+2020-07-19 00:00:00	2
+2020-07-22 00:00:00	3
+-- !result
+SELECT dt,sum(num) FROM t3 where (dt>'2020-06-15' and dt <= '2020-06-22') or dt>'2020-07-01' GROUP BY dt order by dt;
+-- result:
+2020-06-18 00:00:00	5
+2020-06-21 00:00:00	7
+2020-07-02 00:00:00	3
+2020-07-05 00:00:00	5
+2020-07-08 00:00:00	7
+2020-07-11 00:00:00	9
+2020-07-16 00:00:00	1
+2020-07-19 00:00:00	2
+2020-07-22 00:00:00	3
+2020-07-25 00:00:00	4
+-- !result
+SELECT dt,sum(num) FROM t3 where dt in ('2020-06-15', '2020-06-22', '2020-07-01') GROUP BY dt order by dt;
+-- result:
+2020-06-15 00:00:00	6
+-- !result
+SELECT dt,sum(num) FROM t3 where date_trunc('day', dt) ='2020-06-15' GROUP BY dt order by dt;
+-- result:
+2020-06-15 00:00:00	6
+-- !result
+SELECT dt,sum(num) FROM t3 where date_trunc('month', dt) ='2020-06-01' GROUP BY dt order by dt;
+-- result:
+2020-06-15 00:00:00	6
+2020-06-18 00:00:00	5
+2020-06-21 00:00:00	7
+2020-06-24 00:00:00	9
+-- !result
+SELECT dt,sum(num) FROM t3 where date_trunc('month', dt) ='2020-07-01' GROUP BY dt order by dt;
+-- result:
+2020-07-02 00:00:00	3
+2020-07-05 00:00:00	5
+2020-07-08 00:00:00	7
+2020-07-11 00:00:00	9
+2020-07-16 00:00:00	1
+2020-07-19 00:00:00	2
+2020-07-22 00:00:00	3
+2020-07-25 00:00:00	4
+-- !result
+SELECT dt,sum(num) FROM t3 where dt between '2020-06-15' and '2020-07-01' GROUP BY dt order by dt;
+-- result:
+2020-06-15 00:00:00	6
+2020-06-18 00:00:00	5
+2020-06-21 00:00:00	7
+2020-06-24 00:00:00	9
+-- !result
+SELECT dt,sum(num) FROM t3 GROUP BY dt order by dt;
+-- result:
+2020-06-15 00:00:00	6
+2020-06-18 00:00:00	5
+2020-06-21 00:00:00	7
+2020-06-24 00:00:00	9
+2020-07-02 00:00:00	3
+2020-07-05 00:00:00	5
+2020-07-08 00:00:00	7
+2020-07-11 00:00:00	9
+2020-07-16 00:00:00	1
+2020-07-19 00:00:00	2
+2020-07-22 00:00:00	3
+2020-07-25 00:00:00	4
+-- !result
+drop materialized view default_catalog.db_${uuid0}.test_mv1;
+-- result:
+-- !result
+CREATE MATERIALIZED VIEW test_mv1 
+PARTITION BY date_trunc('day', dt)
+REFRESH DEFERRED MANUAL AS 
+  SELECT dt, sum(num) FROM t3 GROUP BY dt;
+-- result:
+-- !result
+REFRESH MATERIALIZED VIEW test_mv1 WITH SYNC MODE;
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t3 where dt='2020-06-15' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t3 where dt !='2020-06-15' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t3 where dt>='2020-06-15' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t3 where dt>'2020-06-15' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t3 where dt>'2020-06-15' and dt < '2020-07-22' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t3 where dt>'2020-06-15' and dt <= '2020-07-22' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t3 where (dt>'2020-06-15' and dt <= '2020-06-22') or dt>'2020-07-01' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t3 where dt in ('2020-06-15', '2020-06-22', '2020-07-01') GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t3 where date_trunc('day', dt) ='2020-06-15' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t3 where date_trunc('month', dt) ='2020-06-01' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t3 where date_trunc('month', dt) ='2020-07-01' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t3 GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+SELECT dt,sum(num) FROM t3 where dt='2020-06-15' GROUP BY dt order by dt;
+-- result:
+2020-06-15 00:00:00	6
+-- !result
+SELECT dt,sum(num) FROM t3 where dt !='2020-06-15' GROUP BY dt order by dt;
+-- result:
+2020-06-18 00:00:00	5
+2020-06-21 00:00:00	7
+2020-06-24 00:00:00	9
+2020-07-02 00:00:00	3
+2020-07-05 00:00:00	5
+2020-07-08 00:00:00	7
+2020-07-11 00:00:00	9
+2020-07-16 00:00:00	1
+2020-07-19 00:00:00	2
+2020-07-22 00:00:00	3
+2020-07-25 00:00:00	4
+-- !result
+SELECT dt,sum(num) FROM t3 where dt>='2020-06-15' GROUP BY dt order by dt;
+-- result:
+2020-06-15 00:00:00	6
+2020-06-18 00:00:00	5
+2020-06-21 00:00:00	7
+2020-06-24 00:00:00	9
+2020-07-02 00:00:00	3
+2020-07-05 00:00:00	5
+2020-07-08 00:00:00	7
+2020-07-11 00:00:00	9
+2020-07-16 00:00:00	1
+2020-07-19 00:00:00	2
+2020-07-22 00:00:00	3
+2020-07-25 00:00:00	4
+-- !result
+SELECT dt,sum(num) FROM t3 where dt>'2020-06-15' GROUP BY dt order by dt;
+-- result:
+2020-06-18 00:00:00	5
+2020-06-21 00:00:00	7
+2020-06-24 00:00:00	9
+2020-07-02 00:00:00	3
+2020-07-05 00:00:00	5
+2020-07-08 00:00:00	7
+2020-07-11 00:00:00	9
+2020-07-16 00:00:00	1
+2020-07-19 00:00:00	2
+2020-07-22 00:00:00	3
+2020-07-25 00:00:00	4
+-- !result
+SELECT dt,sum(num) FROM t3 where dt>'2020-06-15' and dt < '2020-07-22' GROUP BY dt order by dt;
+-- result:
+2020-06-18 00:00:00	5
+2020-06-21 00:00:00	7
+2020-06-24 00:00:00	9
+2020-07-02 00:00:00	3
+2020-07-05 00:00:00	5
+2020-07-08 00:00:00	7
+2020-07-11 00:00:00	9
+2020-07-16 00:00:00	1
+2020-07-19 00:00:00	2
+-- !result
+SELECT dt,sum(num) FROM t3 where dt>'2020-06-15' and dt <= '2020-07-22' GROUP BY dt order by dt;
+-- result:
+2020-06-18 00:00:00	5
+2020-06-21 00:00:00	7
+2020-06-24 00:00:00	9
+2020-07-02 00:00:00	3
+2020-07-05 00:00:00	5
+2020-07-08 00:00:00	7
+2020-07-11 00:00:00	9
+2020-07-16 00:00:00	1
+2020-07-19 00:00:00	2
+2020-07-22 00:00:00	3
+-- !result
+SELECT dt,sum(num) FROM t3 where (dt>'2020-06-15' and dt <= '2020-06-22') or dt>'2020-07-01' GROUP BY dt order by dt;
+-- result:
+2020-06-18 00:00:00	5
+2020-06-21 00:00:00	7
+2020-07-02 00:00:00	3
+2020-07-05 00:00:00	5
+2020-07-08 00:00:00	7
+2020-07-11 00:00:00	9
+2020-07-16 00:00:00	1
+2020-07-19 00:00:00	2
+2020-07-22 00:00:00	3
+2020-07-25 00:00:00	4
+-- !result
+SELECT dt,sum(num) FROM t3 where dt in ('2020-06-15', '2020-06-22', '2020-07-01') GROUP BY dt order by dt;
+-- result:
+2020-06-15 00:00:00	6
+-- !result
+SELECT dt,sum(num) FROM t3 where date_trunc('day', dt) ='2020-06-15' GROUP BY dt order by dt;
+-- result:
+2020-06-15 00:00:00	6
+-- !result
+SELECT dt,sum(num) FROM t3 where date_trunc('month', dt) ='2020-06-01' GROUP BY dt order by dt;
+-- result:
+2020-06-15 00:00:00	6
+2020-06-18 00:00:00	5
+2020-06-21 00:00:00	7
+2020-06-24 00:00:00	9
+-- !result
+SELECT dt,sum(num) FROM t3 where date_trunc('month', dt) ='2020-07-01' GROUP BY dt order by dt;
+-- result:
+2020-07-02 00:00:00	3
+2020-07-05 00:00:00	5
+2020-07-08 00:00:00	7
+2020-07-11 00:00:00	9
+2020-07-16 00:00:00	1
+2020-07-19 00:00:00	2
+2020-07-22 00:00:00	3
+2020-07-25 00:00:00	4
+-- !result
+SELECT dt,sum(num) FROM t3 GROUP BY dt order by dt;
+-- result:
+2020-06-15 00:00:00	6
+2020-06-18 00:00:00	5
+2020-06-21 00:00:00	7
+2020-06-24 00:00:00	9
+2020-07-02 00:00:00	3
+2020-07-05 00:00:00	5
+2020-07-08 00:00:00	7
+2020-07-11 00:00:00	9
+2020-07-16 00:00:00	1
+2020-07-19 00:00:00	2
+2020-07-22 00:00:00	3
+2020-07-25 00:00:00	4
+-- !result
+INSERT INTO t3 VALUES (3, "2020-06-15");
+-- result:
+-- !result
+function: check_no_hit_materialized_view("SELECT dt,sum(num) FROM t3 where dt='2020-06-15' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_no_hit_materialized_view("SELECT dt,sum(num) FROM t3 where date_trunc('day', dt) ='2020-06-15' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_no_hit_materialized_view("SELECT dt,sum(num) FROM t3 where dt in ('2020-06-15', '2020-06-22', '2020-07-01') GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t3 where date_trunc('day', dt) ='2020-06-21' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t3 where dt !='2020-06-15' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t3 where dt>'2020-06-15' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t3 where dt>'2020-06-15' and dt < '2020-07-22' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t3 where dt>'2020-06-15' and dt <= '2020-07-22' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t3 where (dt>'2020-06-15' and dt <= '2020-06-22') or dt>'2020-07-01' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t3 where date_trunc('month', dt) ='2020-07-01' GROUP BY dt;", "test_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t3 where dt between '2020-06-15' and '2020-07-01' GROUP BY dt;", "test_mv1", "UNION")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t3 where dt>='2020-06-15' GROUP BY dt;", "test_mv1", "UNION")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t3 where dt in ('2020-06-15', '2020-06-21', '2020-07-25') GROUP BY dt;", "test_mv1", "UNION")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t3 where date_trunc('month', dt) ='2020-06-01' GROUP BY dt;", "test_mv1", "UNION")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t3 GROUP BY dt;", "test_mv1", "UNION")
+-- result:
+None
+-- !result
+SELECT dt,sum(num) FROM t3 where dt='2020-06-15' GROUP BY dt order by dt;
+-- result:
+2020-06-15 00:00:00	9
+-- !result
+SELECT dt,sum(num) FROM t3 where dt !='2020-06-15' GROUP BY dt order by dt;
+-- result:
+2020-06-18 00:00:00	5
+2020-06-21 00:00:00	7
+2020-06-24 00:00:00	9
+2020-07-02 00:00:00	3
+2020-07-05 00:00:00	5
+2020-07-08 00:00:00	7
+2020-07-11 00:00:00	9
+2020-07-16 00:00:00	1
+2020-07-19 00:00:00	2
+2020-07-22 00:00:00	3
+2020-07-25 00:00:00	4
+-- !result
+SELECT dt,sum(num) FROM t3 where dt>='2020-06-15' GROUP BY dt order by dt;
+-- result:
+2020-06-15 00:00:00	9
+2020-06-18 00:00:00	5
+2020-06-21 00:00:00	7
+2020-06-24 00:00:00	9
+2020-07-02 00:00:00	3
+2020-07-05 00:00:00	5
+2020-07-08 00:00:00	7
+2020-07-11 00:00:00	9
+2020-07-16 00:00:00	1
+2020-07-19 00:00:00	2
+2020-07-22 00:00:00	3
+2020-07-25 00:00:00	4
+-- !result
+SELECT dt,sum(num) FROM t3 where dt>'2020-06-15' GROUP BY dt order by dt;
+-- result:
+2020-06-18 00:00:00	5
+2020-06-21 00:00:00	7
+2020-06-24 00:00:00	9
+2020-07-02 00:00:00	3
+2020-07-05 00:00:00	5
+2020-07-08 00:00:00	7
+2020-07-11 00:00:00	9
+2020-07-16 00:00:00	1
+2020-07-19 00:00:00	2
+2020-07-22 00:00:00	3
+2020-07-25 00:00:00	4
+-- !result
+SELECT dt,sum(num) FROM t3 where dt>'2020-06-15' and dt < '2020-07-22' GROUP BY dt order by dt;
+-- result:
+2020-06-18 00:00:00	5
+2020-06-21 00:00:00	7
+2020-06-24 00:00:00	9
+2020-07-02 00:00:00	3
+2020-07-05 00:00:00	5
+2020-07-08 00:00:00	7
+2020-07-11 00:00:00	9
+2020-07-16 00:00:00	1
+2020-07-19 00:00:00	2
+-- !result
+SELECT dt,sum(num) FROM t3 where dt>'2020-06-15' and dt <= '2020-07-22' GROUP BY dt order by dt;
+-- result:
+2020-06-18 00:00:00	5
+2020-06-21 00:00:00	7
+2020-06-24 00:00:00	9
+2020-07-02 00:00:00	3
+2020-07-05 00:00:00	5
+2020-07-08 00:00:00	7
+2020-07-11 00:00:00	9
+2020-07-16 00:00:00	1
+2020-07-19 00:00:00	2
+2020-07-22 00:00:00	3
+-- !result
+SELECT dt,sum(num) FROM t3 where (dt>'2020-06-15' and dt <= '2020-06-22') or dt>'2020-07-01' GROUP BY dt order by dt;
+-- result:
+2020-06-18 00:00:00	5
+2020-06-21 00:00:00	7
+2020-07-02 00:00:00	3
+2020-07-05 00:00:00	5
+2020-07-08 00:00:00	7
+2020-07-11 00:00:00	9
+2020-07-16 00:00:00	1
+2020-07-19 00:00:00	2
+2020-07-22 00:00:00	3
+2020-07-25 00:00:00	4
+-- !result
+SELECT dt,sum(num) FROM t3 where dt in ('2020-06-15', '2020-06-22', '2020-07-01') GROUP BY dt order by dt;
+-- result:
+2020-06-15 00:00:00	9
+-- !result
+SELECT dt,sum(num) FROM t3 where date_trunc('day', dt) ='2020-06-15' GROUP BY dt order by dt;
+-- result:
+2020-06-15 00:00:00	9
+-- !result
+SELECT dt,sum(num) FROM t3 where date_trunc('month', dt) ='2020-06-01' GROUP BY dt order by dt;
+-- result:
+2020-06-15 00:00:00	9
+2020-06-18 00:00:00	5
+2020-06-21 00:00:00	7
+2020-06-24 00:00:00	9
+-- !result
+SELECT dt,sum(num) FROM t3 where date_trunc('month', dt) ='2020-07-01' GROUP BY dt order by dt;
+-- result:
+2020-07-02 00:00:00	3
+2020-07-05 00:00:00	5
+2020-07-08 00:00:00	7
+2020-07-11 00:00:00	9
+2020-07-16 00:00:00	1
+2020-07-19 00:00:00	2
+2020-07-22 00:00:00	3
+2020-07-25 00:00:00	4
+-- !result
+SELECT dt,sum(num) FROM t3 where dt between '2020-06-15' and '2020-07-01' GROUP BY dt order by dt;
+-- result:
+2020-06-15 00:00:00	9
+2020-06-18 00:00:00	5
+2020-06-21 00:00:00	7
+2020-06-24 00:00:00	9
+-- !result
+SELECT dt,sum(num) FROM t3 GROUP BY dt order by dt;
+-- result:
+2020-06-15 00:00:00	9
+2020-06-18 00:00:00	5
+2020-06-21 00:00:00	7
+2020-06-24 00:00:00	9
+2020-07-02 00:00:00	3
+2020-07-05 00:00:00	5
+2020-07-08 00:00:00	7
+2020-07-11 00:00:00	9
+2020-07-16 00:00:00	1
+2020-07-19 00:00:00	2
+2020-07-22 00:00:00	3
+2020-07-25 00:00:00	4
+-- !result
+drop materialized view default_catalog.db_${uuid0}.test_mv1;
+-- result:
+-- !result
+drop table t1 force;
+-- result:
+-- !result
+drop table t2 force;
+-- result:
+-- !result
+drop table t3 force;
+-- result:
+-- !result

--- a/test/sql/test_materialized_view/T/test_mv_partition_compensate_hive
+++ b/test/sql/test_materialized_view/T/test_mv_partition_compensate_hive
@@ -1,0 +1,354 @@
+-- name: test_mv_partition_compensate_hive
+create external catalog mv_hive_${uuid0}
+properties
+(
+    "type" = "hive",
+    "hive.catalog.type" = "hive",
+    "hive.metastore.uris" = "${hive_metastore_uris}"
+);
+
+
+set materialized_view_union_rewrite_mode = 3;
+-- create hive table
+set catalog mv_hive_${uuid0};
+create database mv_hive_db_${uuid0};
+use mv_hive_db_${uuid0};
+
+CREATE TABLE t1 (
+  num int,
+  dt date
+)
+PARTITION BY (dt);
+INSERT INTO t1 VALUES 
+  (1,"2020-06-15"),(2,"2020-06-18"),(3,"2020-06-21"),(4,"2020-06-24"),
+  (1,"2020-07-02"),(2,"2020-07-05"),(3,"2020-07-08"),(4,"2020-07-11"),
+  (1,"2020-07-16"),(2,"2020-07-19"),(3,"2020-07-22"),(4,"2020-07-25"),
+  (2,"2020-06-15"),(3,"2020-06-18"),(4,"2020-06-21"),(5,"2020-06-24"),
+  (2,"2020-07-02"),(3,"2020-07-05"),(4,"2020-07-08"),(5,"2020-07-11");
+
+CREATE TABLE t2 (
+  num int,
+  dt string
+)
+PARTITION BY (dt);
+INSERT INTO t2 VALUES 
+  (1,"2020-06-15"),(2,"2020-06-18"),(3,"2020-06-21"),(4,"2020-06-24"),
+  (1,"2020-07-02"),(2,"2020-07-05"),(3,"2020-07-08"),(4,"2020-07-11"),
+  (1,"2020-07-16"),(2,"2020-07-19"),(3,"2020-07-22"),(4,"2020-07-25"),
+  (2,"2020-06-15"),(3,"2020-06-18"),(4,"2020-06-21"),(5,"2020-06-24"),
+  (2,"2020-07-02"),(3,"2020-07-05"),(4,"2020-07-08"),(5,"2020-07-11");
+
+-- create mv
+set catalog default_catalog;
+create database db_${uuid0};
+use db_${uuid0};
+
+
+-- Test partition compensate without partition expression
+CREATE MATERIALIZED VIEW test_mv1 
+PARTITION BY dt 
+REFRESH DEFERRED MANUAL AS 
+  SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 GROUP BY dt;
+
+REFRESH MATERIALIZED VIEW test_mv1 WITH SYNC MODE;
+
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 where dt='2020-06-15' GROUP BY dt;", "test_mv1")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 where dt !='2020-06-15' GROUP BY dt;", "test_mv1")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 where dt>='2020-06-15' GROUP BY dt;", "test_mv1")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 where dt>'2020-06-15' GROUP BY dt;", "test_mv1")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 where dt>'2020-06-15' and dt < '2020-07-22' GROUP BY dt;", "test_mv1")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 where dt>'2020-06-15' and dt <= '2020-07-22' GROUP BY dt;", "test_mv1")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 where (dt>'2020-06-15' and dt <= '2020-06-22') or dt>'2020-07-01' GROUP BY dt;", "test_mv1")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 where dt in ('2020-06-15', '2020-06-22', '2020-07-01') GROUP BY dt;", "test_mv1")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 where date_trunc('day', dt) ='2020-06-15' GROUP BY dt;", "test_mv1")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 where date_trunc('month', dt) ='2020-06-01' GROUP BY dt;", "test_mv1")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 where date_trunc('month', dt) ='2020-07-01' GROUP BY dt;", "test_mv1")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 GROUP BY dt;", "test_mv1")
+
+SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 where dt='2020-06-15' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 where dt !='2020-06-15' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 where dt>='2020-06-15' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 where dt>'2020-06-15' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 where dt>'2020-06-15' and dt < '2020-07-22' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 where dt>'2020-06-15' and dt <= '2020-07-22' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 where (dt>'2020-06-15' and dt <= '2020-06-22') or dt>'2020-07-01' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 where dt in ('2020-06-15', '2020-06-22', '2020-07-01') GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 where date_trunc('day', dt) ='2020-06-15' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 where date_trunc('month', dt) ='2020-06-01' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 where date_trunc('month', dt) ='2020-07-01' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 GROUP BY dt order by dt;
+
+-- union rewrite
+INSERT INTO mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 VALUES (3, "2020-06-15");
+function: check_no_hit_materialized_view("SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 where dt='2020-06-15' GROUP BY dt;", "test_mv1")
+function: check_no_hit_materialized_view("SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 where date_trunc('day', dt) ='2020-06-15' GROUP BY dt;", "test_mv1")
+function: check_no_hit_materialized_view("SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 where dt in ('2020-06-15', '2020-06-22', '2020-07-01') GROUP BY dt;", "test_mv1")
+
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 where date_trunc('day', dt) ='2020-06-21' GROUP BY dt;", "test_mv1")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 where dt !='2020-06-15' GROUP BY dt;", "test_mv1")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 where dt>'2020-06-15' GROUP BY dt;", "test_mv1")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 where dt>'2020-06-15' and dt < '2020-07-22' GROUP BY dt;", "test_mv1")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 where dt>'2020-06-15' and dt <= '2020-07-22' GROUP BY dt;", "test_mv1")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 where (dt>'2020-06-15' and dt <= '2020-06-22') or dt>'2020-07-01' GROUP BY dt;", "test_mv1")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 where dt in ('2020-06-21', '2020-07-25') GROUP BY dt;", "test_mv1")
+-- cannot partition prune
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 where date_trunc('month', dt) ='2020-07-01' GROUP BY dt;", "test_mv1")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 where dt between '2020-06-16' and '2020-07-01' GROUP BY dt;", "test_mv1")
+
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 where dt between '2020-06-15' and '2020-07-01' GROUP BY dt;", "test_mv1", "UNION")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 where dt>='2020-06-15' GROUP BY dt;", "test_mv1", "UNION")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 where dt in ('2020-06-15', '2020-06-21', '2020-07-25') GROUP BY dt;", "test_mv1", "UNION")
+-- cannot partition prune
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 where date_trunc('month', dt) ='2020-06-01' GROUP BY dt;", "test_mv1", "UNION")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 GROUP BY dt;", "test_mv1", "UNION")
+
+SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 where dt='2020-06-15' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 where dt !='2020-06-15' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 where dt>='2020-06-15' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 where dt>'2020-06-15' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 where dt>'2020-06-15' and dt < '2020-07-22' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 where dt>'2020-06-15' and dt <= '2020-07-22' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 where (dt>'2020-06-15' and dt <= '2020-06-22') or dt>'2020-07-01' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 where dt in ('2020-06-22', '2020-07-01') GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 where dt in ('2020-06-15', '2020-06-22', '2020-07-01') GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 where dt between '2020-06-15' and '2020-07-01' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 where date_trunc('day', dt) ='2020-06-15' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 where date_trunc('month', dt) ='2020-06-01' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 where date_trunc('month', dt) ='2020-07-01' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 GROUP BY dt order by dt;
+
+
+drop materialized view default_catalog.db_${uuid0}.test_mv1;
+
+-- Test partition compensate with partition expression
+CREATE MATERIALIZED VIEW test_mv1 
+PARTITION BY date_trunc('day', dt)
+REFRESH DEFERRED MANUAL AS 
+  SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 GROUP BY dt;
+REFRESH MATERIALIZED VIEW test_mv1 WITH SYNC MODE;
+
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 where dt='2020-06-15' GROUP BY dt;", "test_mv1")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 where dt !='2020-06-15' GROUP BY dt;", "test_mv1")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 where dt>='2020-06-15' GROUP BY dt;", "test_mv1")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 where dt>'2020-06-15' GROUP BY dt;", "test_mv1")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 where dt>'2020-06-15' and dt < '2020-07-22' GROUP BY dt;", "test_mv1")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 where dt>'2020-06-15' and dt <= '2020-07-22' GROUP BY dt;", "test_mv1")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 where (dt>'2020-06-15' and dt <= '2020-06-22') or dt>'2020-07-01' GROUP BY dt;", "test_mv1")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 where dt in ('2020-06-15', '2020-06-22', '2020-07-01') GROUP BY dt;", "test_mv1")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 where date_trunc('day', dt) ='2020-06-15' GROUP BY dt;", "test_mv1")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 where date_trunc('month', dt) ='2020-06-01' GROUP BY dt;", "test_mv1")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 where date_trunc('month', dt) ='2020-07-01' GROUP BY dt;", "test_mv1")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 GROUP BY dt;", "test_mv1")
+
+SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 where dt='2020-06-15' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 where dt !='2020-06-15' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 where dt>='2020-06-15' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 where dt>'2020-06-15' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 where dt>'2020-06-15' and dt < '2020-07-22' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 where dt>'2020-06-15' and dt <= '2020-07-22' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 where (dt>'2020-06-15' and dt <= '2020-06-22') or dt>'2020-07-01' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 where dt in ('2020-06-15', '2020-06-22', '2020-07-01') GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 where date_trunc('day', dt) ='2020-06-15' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 where date_trunc('month', dt) ='2020-06-01' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 where date_trunc('month', dt) ='2020-07-01' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 GROUP BY dt order by dt;
+
+-- union rewrite
+INSERT INTO mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 VALUES (3, "2020-06-15");
+function: check_no_hit_materialized_view("SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 where dt='2020-06-15' GROUP BY dt;", "test_mv1")
+function: check_no_hit_materialized_view("SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 where date_trunc('day', dt) ='2020-06-15' GROUP BY dt;", "test_mv1")
+function: check_no_hit_materialized_view("SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 where dt in ('2020-06-15', '2020-06-22', '2020-07-01') GROUP BY dt;", "test_mv1")
+
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 where date_trunc('day', dt) ='2020-06-21' GROUP BY dt;", "test_mv1")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 where dt !='2020-06-15' GROUP BY dt;", "test_mv1")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 where dt>'2020-06-15' GROUP BY dt;", "test_mv1")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 where dt>'2020-06-15' and dt < '2020-07-22' GROUP BY dt;", "test_mv1")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 where dt>'2020-06-15' and dt <= '2020-07-22' GROUP BY dt;", "test_mv1")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 where (dt>'2020-06-15' and dt <= '2020-06-22') or dt>'2020-07-01' GROUP BY dt;", "test_mv1")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 where dt in ('2020-06-21', '2020-07-25') GROUP BY dt;", "test_mv1")
+-- cannot partition prune
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 where date_trunc('month', dt) ='2020-07-01' GROUP BY dt;", "test_mv1")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 where dt between '2020-06-16' and '2020-07-01' GROUP BY dt;", "test_mv1")
+
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 where dt between '2020-06-15' and '2020-07-01' GROUP BY dt;", "test_mv1", "UNION")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 where dt>='2020-06-15' GROUP BY dt;", "test_mv1", "UNION")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 where dt in ('2020-06-15', '2020-06-21', '2020-07-25') GROUP BY dt;", "test_mv1", "UNION")
+-- cannot partition prune
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 where date_trunc('month', dt) ='2020-06-01' GROUP BY dt;", "test_mv1")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 GROUP BY dt;", "test_mv1", "UNION")
+
+SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 where dt='2020-06-15' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 where dt !='2020-06-15' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 where dt>='2020-06-15' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 where dt>'2020-06-15' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 where dt>'2020-06-15' and dt < '2020-07-22' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 where dt>'2020-06-15' and dt <= '2020-07-22' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 where (dt>'2020-06-15' and dt <= '2020-06-22') or dt>'2020-07-01' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 where dt in ('2020-06-22', '2020-07-01') GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 where dt in ('2020-06-15', '2020-06-22', '2020-07-01') GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 where dt between '2020-06-15' and '2020-07-01' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 where date_trunc('day', dt) ='2020-06-15' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 where date_trunc('month', dt) ='2020-06-01' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 where date_trunc('month', dt) ='2020-07-01' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 GROUP BY dt order by dt;
+
+drop materialized view default_catalog.db_${uuid0}.test_mv1;
+
+
+
+-- Test partition compensate without partition expression
+CREATE MATERIALIZED VIEW test_mv1 
+PARTITION BY str2date(dt, '%Y-%m-%d')
+REFRESH DEFERRED MANUAL AS 
+  SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t2 GROUP BY dt;
+
+REFRESH MATERIALIZED VIEW test_mv1 WITH SYNC MODE;
+
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t2 where dt='2020-06-15' GROUP BY dt;", "test_mv1")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t2 where dt !='2020-06-15' GROUP BY dt;", "test_mv1")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t2 where dt>='2020-06-15' GROUP BY dt;", "test_mv1")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t2 where dt>'2020-06-15' GROUP BY dt;", "test_mv1")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t2 where dt>'2020-06-15' and dt < '2020-07-22' GROUP BY dt;", "test_mv1")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t2 where dt>'2020-06-15' and dt <= '2020-07-22' GROUP BY dt;", "test_mv1")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t2 where (dt>'2020-06-15' and dt <= '2020-06-22') or dt>'2020-07-01' GROUP BY dt;", "test_mv1")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t2 where dt in ('2020-06-15', '2020-06-22', '2020-07-01') GROUP BY dt;", "test_mv1")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t2 where date_trunc('day', dt) ='2020-06-15' GROUP BY dt;", "test_mv1")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t2 where date_trunc('month', dt) ='2020-06-01' GROUP BY dt;", "test_mv1")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t2 where date_trunc('month', dt) ='2020-07-01' GROUP BY dt;", "test_mv1")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t2 GROUP BY dt;", "test_mv1")
+
+SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t2 where dt='2020-06-15' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t2 where dt !='2020-06-15' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t2 where dt>='2020-06-15' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t2 where dt>'2020-06-15' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t2 where dt>'2020-06-15' and dt < '2020-07-22' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t2 where dt>'2020-06-15' and dt <= '2020-07-22' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t2 where (dt>'2020-06-15' and dt <= '2020-06-22') or dt>'2020-07-01' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t2 where dt in ('2020-06-15', '2020-06-22', '2020-07-01') GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t2 where date_trunc('day', dt) ='2020-06-15' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t2 where date_trunc('month', dt) ='2020-06-01' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t2 where date_trunc('month', dt) ='2020-07-01' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t2 GROUP BY dt order by dt;
+
+-- union rewrite
+INSERT INTO mv_hive_${uuid0}.mv_hive_db_${uuid0}.t2 VALUES (3, "2020-06-15");
+function: check_no_hit_materialized_view("SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t2 where dt='2020-06-15' GROUP BY dt;", "test_mv1")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t2 where date_trunc('day', dt) ='2020-06-15' GROUP BY dt;", "test_mv1")
+function: check_no_hit_materialized_view("SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t2 where dt in ('2020-06-15', '2020-06-22', '2020-07-01') GROUP BY dt;", "test_mv1")
+
+-- cannot partition prune
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t2 where date_trunc('day', dt) ='2020-06-21' GROUP BY dt;", "test_mv1")
+
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t2 where dt !='2020-06-15' GROUP BY dt;", "test_mv1")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t2 where dt>'2020-06-15' GROUP BY dt;", "test_mv1")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t2 where dt>'2020-06-15' and dt < '2020-07-22' GROUP BY dt;", "test_mv1")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t2 where dt>'2020-06-15' and dt <= '2020-07-22' GROUP BY dt;", "test_mv1")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t2 where (dt>'2020-06-15' and dt <= '2020-06-22') or dt>'2020-07-01' GROUP BY dt;", "test_mv1")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t2 where dt in ('2020-06-21', '2020-07-25') GROUP BY dt;", "test_mv1")
+-- cannot partition prune
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t2 where date_trunc('month', dt) ='2020-07-01' GROUP BY dt;", "test_mv1")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t2 where dt between '2020-06-16' and '2020-07-01' GROUP BY dt;", "test_mv1")
+
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t2 where dt between '2020-06-15' and '2020-07-01' GROUP BY dt;", "test_mv1", "UNION")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t2 where dt>='2020-06-15' GROUP BY dt;", "test_mv1", "UNION")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t2 where dt in ('2020-06-15', '2020-06-21', '2020-07-25') GROUP BY dt;", "test_mv1", "UNION")
+-- cannot partition prune
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t2 where date_trunc('month', dt) ='2020-06-01' GROUP BY dt;", "test_mv1")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t2 GROUP BY dt;", "test_mv1", "UNION")
+
+SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t2 where dt='2020-06-15' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t2 where dt !='2020-06-15' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t2 where dt>='2020-06-15' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t2 where dt>'2020-06-15' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t2 where dt>'2020-06-15' and dt < '2020-07-22' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t2 where dt>'2020-06-15' and dt <= '2020-07-22' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t2 where (dt>'2020-06-15' and dt <= '2020-06-22') or dt>'2020-07-01' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t2 where dt in ('2020-06-22', '2020-07-01') GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t2 where dt in ('2020-06-15', '2020-06-22', '2020-07-01') GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t2 where dt between '2020-06-15' and '2020-07-01' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t2 where date_trunc('day', dt) ='2020-06-15' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t2 where date_trunc('month', dt) ='2020-06-01' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t2 where date_trunc('month', dt) ='2020-07-01' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t2 GROUP BY dt order by dt;
+
+
+drop materialized view default_catalog.db_${uuid0}.test_mv1;
+
+-- Test partition compensate with partition expression
+-- TODO: shold not add an extra column(dt) which cannot partition prune.
+CREATE MATERIALIZED VIEW test_mv1 
+PARTITION BY date_trunc('day', format_dt)
+REFRESH DEFERRED MANUAL AS 
+  SELECT dt, str2date(dt, '%Y-%m-%d') as format_dt, sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t2 GROUP BY dt;
+REFRESH MATERIALIZED VIEW test_mv1 WITH SYNC MODE;
+
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t2 where dt='2020-06-15' GROUP BY dt;", "test_mv1")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t2 where dt !='2020-06-15' GROUP BY dt;", "test_mv1")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t2 where dt>='2020-06-15' GROUP BY dt;", "test_mv1")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t2 where dt>'2020-06-15' GROUP BY dt;", "test_mv1")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t2 where dt>'2020-06-15' and dt < '2020-07-22' GROUP BY dt;", "test_mv1")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t2 where dt>'2020-06-15' and dt <= '2020-07-22' GROUP BY dt;", "test_mv1")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t2 where (dt>'2020-06-15' and dt <= '2020-06-22') or dt>'2020-07-01' GROUP BY dt;", "test_mv1")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t2 where dt in ('2020-06-15', '2020-06-22', '2020-07-01') GROUP BY dt;", "test_mv1")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t2 where date_trunc('day', dt) ='2020-06-15' GROUP BY dt;", "test_mv1")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t2 where date_trunc('month', dt) ='2020-06-01' GROUP BY dt;", "test_mv1")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t2 where date_trunc('month', dt) ='2020-07-01' GROUP BY dt;", "test_mv1")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t2 GROUP BY dt;", "test_mv1")
+
+SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t2 where dt='2020-06-15' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t2 where dt !='2020-06-15' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t2 where dt>='2020-06-15' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t2 where dt>'2020-06-15' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t2 where dt>'2020-06-15' and dt < '2020-07-22' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t2 where dt>'2020-06-15' and dt <= '2020-07-22' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t2 where (dt>'2020-06-15' and dt <= '2020-06-22') or dt>'2020-07-01' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t2 where dt in ('2020-06-15', '2020-06-22', '2020-07-01') GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t2 where date_trunc('day', dt) ='2020-06-15' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t2 where date_trunc('month', dt) ='2020-06-01' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t2 where date_trunc('month', dt) ='2020-07-01' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t2 GROUP BY dt order by dt;
+
+-- union rewrite
+INSERT INTO mv_hive_${uuid0}.mv_hive_db_${uuid0}.t2 VALUES (3, "2020-06-15");
+function: check_no_hit_materialized_view("SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t2 where dt='2020-06-15' GROUP BY dt;", "test_mv1")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t2 where date_trunc('day', dt) ='2020-06-15' GROUP BY dt;", "test_mv1")
+function: check_no_hit_materialized_view("SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t2 where dt in ('2020-06-15', '2020-06-22', '2020-07-01') GROUP BY dt;", "test_mv1")
+
+-- cannot partition prune
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t2 where date_trunc('day', dt) ='2020-06-21' GROUP BY dt;", "test_mv1")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t2 where dt !='2020-06-15' GROUP BY dt;", "test_mv1")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t2 where dt>'2020-06-15' GROUP BY dt;", "test_mv1")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t2 where dt>'2020-06-15' and dt < '2020-07-22' GROUP BY dt;", "test_mv1")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t2 where dt>'2020-06-15' and dt <= '2020-07-22' GROUP BY dt;", "test_mv1")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t2 where (dt>'2020-06-15' and dt <= '2020-06-22') or dt>'2020-07-01' GROUP BY dt;", "test_mv1")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t2 where dt in ('2020-06-21', '2020-07-25') GROUP BY dt;", "test_mv1")
+-- cannot partition prune
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t2 where date_trunc('month', dt) ='2020-07-01' GROUP BY dt;", "test_mv1")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t2 where dt between '2020-06-16' and '2020-07-01' GROUP BY dt;", "test_mv1")
+
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t2 where dt between '2020-06-15' and '2020-07-01' GROUP BY dt;", "test_mv1", "UNION")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t2 where dt>='2020-06-15' GROUP BY dt;", "test_mv1", "UNION")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t2 where dt in ('2020-06-15', '2020-06-21', '2020-07-25') GROUP BY dt;", "test_mv1", "UNION")
+-- cannot partition prune
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t2 where date_trunc('month', dt) ='2020-06-01' GROUP BY dt;", "test_mv1")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t2 GROUP BY dt;", "test_mv1", "UNION")
+
+SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t2 where dt='2020-06-15' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t2 where dt !='2020-06-15' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t2 where dt>='2020-06-15' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t2 where dt>'2020-06-15' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t2 where dt>'2020-06-15' and dt < '2020-07-22' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t2 where dt>'2020-06-15' and dt <= '2020-07-22' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t2 where (dt>'2020-06-15' and dt <= '2020-06-22') or dt>'2020-07-01' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t2 where dt in ('2020-06-22', '2020-07-01') GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t2 where dt in ('2020-06-15', '2020-06-22', '2020-07-01') GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t2 where dt between '2020-06-15' and '2020-07-01' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t2 where date_trunc('day', dt) ='2020-06-15' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t2 where date_trunc('month', dt) ='2020-06-01' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t2 where date_trunc('month', dt) ='2020-07-01' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t2 GROUP BY dt order by dt;
+
+drop materialized view default_catalog.db_${uuid0}.test_mv1;
+
+drop table mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 force;
+drop table mv_hive_${uuid0}.mv_hive_db_${uuid0}.t2 force;

--- a/test/sql/test_materialized_view/T/test_mv_partition_compensate_iceberg2
+++ b/test/sql/test_materialized_view/T/test_mv_partition_compensate_iceberg2
@@ -1,4 +1,4 @@
--- name: test_mv_partition_compensate_iceberg
+-- name: test_mv_partition_compensate_iceberg2
 create external catalog mv_iceberg_${uuid0}
 properties
 (
@@ -7,6 +7,7 @@ properties
     "hive.metastore.uris" = "${iceberg_catalog_hive_metastore_uris}"
 );
 
+set materialized_view_union_rewrite_mode = 3;
 
 -- create iceberg table
 set catalog mv_iceberg_${uuid0};
@@ -91,14 +92,14 @@ function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_iceberg_${uuid
 function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 where (dt>'2020-06-15' and dt <= '2020-06-22') or dt>'2020-07-01' GROUP BY dt;", "test_mv1")
 function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 where dt in ('2020-06-21', '2020-07-25') GROUP BY dt;", "test_mv1")
 -- cannot partition prune
-function: check_no_hit_materialized_view("SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 where date_trunc('month', dt) ='2020-07-01' GROUP BY dt;", "test_mv1")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 where date_trunc('month', dt) ='2020-07-01' GROUP BY dt;", "test_mv1")
 function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 where dt between '2020-06-16' and '2020-07-01' GROUP BY dt;", "test_mv1")
 
--- function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 where dt between '2020-06-15' and '2020-07-01' GROUP BY dt;", "test_mv1", "UNION")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 where dt between '2020-06-15' and '2020-07-01' GROUP BY dt;", "test_mv1", "UNION")
 function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 where dt>='2020-06-15' GROUP BY dt;", "test_mv1", "UNION")
--- function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 where dt in ('2020-06-15', '2020-06-21', '2020-07-25') GROUP BY dt;", "test_mv1", "UNION")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 where dt in ('2020-06-15', '2020-06-21', '2020-07-25') GROUP BY dt;", "test_mv1", "UNION")
 -- cannot partition prune
-function: check_no_hit_materialized_view("SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 where date_trunc('month', dt) ='2020-06-01' GROUP BY dt;", "test_mv1", "UNION")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 where date_trunc('month', dt) ='2020-06-01' GROUP BY dt;", "test_mv1", "UNION")
 function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 GROUP BY dt;", "test_mv1", "UNION")
 
 SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 where dt='2020-06-15' GROUP BY dt order by dt;
@@ -115,7 +116,6 @@ SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 where date_tru
 SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 where date_trunc('month', dt) ='2020-06-01' GROUP BY dt order by dt;
 SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 where date_trunc('month', dt) ='2020-07-01' GROUP BY dt order by dt;
 SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 GROUP BY dt order by dt;
-
 
 drop materialized view default_catalog.db_${uuid0}.test_mv1;
 
@@ -166,14 +166,14 @@ function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_iceberg_${uuid
 function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 where (dt>'2020-06-15' and dt <= '2020-06-22') or dt>'2020-07-01' GROUP BY dt;", "test_mv1")
 function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 where dt in ('2020-06-21', '2020-07-25') GROUP BY dt;", "test_mv1")
 -- cannot partition prune
-function: check_no_hit_materialized_view("SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 where date_trunc('month', dt) ='2020-07-01' GROUP BY dt;", "test_mv1")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 where date_trunc('month', dt) ='2020-07-01' GROUP BY dt;", "test_mv1")
 function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 where dt between '2020-06-16' and '2020-07-01' GROUP BY dt;", "test_mv1")
 
--- function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 where dt between '2020-06-15' and '2020-07-01' GROUP BY dt;", "test_mv1", "UNION")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 where dt between '2020-06-15' and '2020-07-01' GROUP BY dt;", "test_mv1", "UNION")
 function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 where dt>='2020-06-15' GROUP BY dt;", "test_mv1", "UNION")
--- function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 where dt in ('2020-06-15', '2020-06-21', '2020-07-25') GROUP BY dt;", "test_mv1", "UNION")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 where dt in ('2020-06-15', '2020-06-21', '2020-07-25') GROUP BY dt;", "test_mv1", "UNION")
 -- cannot partition prune
-function: check_no_hit_materialized_view("SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 where date_trunc('month', dt) ='2020-06-01' GROUP BY dt;", "test_mv1")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 where date_trunc('month', dt) ='2020-06-01' GROUP BY dt;", "test_mv1")
 function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 GROUP BY dt;", "test_mv1", "UNION")
 
 SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 where dt='2020-06-15' GROUP BY dt order by dt;
@@ -232,12 +232,12 @@ SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t2 GROUP BY dt or
 -- union rewrite
 INSERT INTO mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t2 VALUES (3, "2020-06-15");
 function: check_no_hit_materialized_view("SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t2 where dt='2020-06-15' GROUP BY dt;", "test_mv1")
-function: check_no_hit_materialized_view("SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t2 where date_trunc('day', dt) ='2020-06-15' GROUP BY dt;", "test_mv1")
+-- TODO: FIXME
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t2 where date_trunc('day', dt) ='2020-06-15' GROUP BY dt;", "test_mv1")
 function: check_no_hit_materialized_view("SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t2 where dt in ('2020-06-15', '2020-06-22', '2020-07-01') GROUP BY dt;", "test_mv1")
 
 -- cannot partition prune
-function: check_no_hit_materialized_view("SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t2 where date_trunc('day', dt) ='2020-06-21' GROUP BY dt;", "test_mv1")
-
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t2 where date_trunc('day', dt) ='2020-06-21' GROUP BY dt;", "test_mv1")
 function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t2 where dt !='2020-06-15' GROUP BY dt;", "test_mv1")
 function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t2 where dt>'2020-06-15' GROUP BY dt;", "test_mv1")
 function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t2 where dt>'2020-06-15' and dt < '2020-07-22' GROUP BY dt;", "test_mv1")
@@ -245,14 +245,14 @@ function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_iceberg_${uuid
 function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t2 where (dt>'2020-06-15' and dt <= '2020-06-22') or dt>'2020-07-01' GROUP BY dt;", "test_mv1")
 function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t2 where dt in ('2020-06-21', '2020-07-25') GROUP BY dt;", "test_mv1")
 -- cannot partition prune
-function: check_no_hit_materialized_view("SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t2 where date_trunc('month', dt) ='2020-07-01' GROUP BY dt;", "test_mv1")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t2 where date_trunc('month', dt) ='2020-07-01' GROUP BY dt;", "test_mv1")
 function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t2 where dt between '2020-06-16' and '2020-07-01' GROUP BY dt;", "test_mv1")
 
--- function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t2 where dt between '2020-06-15' and '2020-07-01' GROUP BY dt;", "test_mv1", "UNION")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t2 where dt between '2020-06-15' and '2020-07-01' GROUP BY dt;", "test_mv1", "UNION")
 function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t2 where dt>='2020-06-15' GROUP BY dt;", "test_mv1", "UNION")
--- function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t2 where dt in ('2020-06-15', '2020-06-21', '2020-07-25') GROUP BY dt;", "test_mv1", "UNION")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t2 where dt in ('2020-06-15', '2020-06-21', '2020-07-25') GROUP BY dt;", "test_mv1", "UNION")
 -- cannot partition prune
-function: check_no_hit_materialized_view("SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t2 where date_trunc('month', dt) ='2020-06-01' GROUP BY dt;", "test_mv1")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t2 where date_trunc('month', dt) ='2020-06-01' GROUP BY dt;", "test_mv1")
 function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t2 GROUP BY dt;", "test_mv1", "UNION")
 
 SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t2 where dt='2020-06-15' GROUP BY dt order by dt;
@@ -310,11 +310,12 @@ SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t2 GROUP BY dt or
 -- union rewrite
 INSERT INTO mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t2 VALUES (3, "2020-06-15");
 function: check_no_hit_materialized_view("SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t2 where dt='2020-06-15' GROUP BY dt;", "test_mv1")
-function: check_no_hit_materialized_view("SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t2 where date_trunc('day', dt) ='2020-06-15' GROUP BY dt;", "test_mv1")
+-- TODO: FIXME
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t2 where date_trunc('day', dt) ='2020-06-15' GROUP BY dt;", "test_mv1")
 function: check_no_hit_materialized_view("SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t2 where dt in ('2020-06-15', '2020-06-22', '2020-07-01') GROUP BY dt;", "test_mv1")
 
 -- cannot partition prune
-function: check_no_hit_materialized_view("SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t2 where date_trunc('day', dt) ='2020-06-21' GROUP BY dt;", "test_mv1")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t2 where date_trunc('day', dt) ='2020-06-21' GROUP BY dt;", "test_mv1")
 function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t2 where dt !='2020-06-15' GROUP BY dt;", "test_mv1")
 function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t2 where dt>'2020-06-15' GROUP BY dt;", "test_mv1")
 function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t2 where dt>'2020-06-15' and dt < '2020-07-22' GROUP BY dt;", "test_mv1")
@@ -322,14 +323,14 @@ function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_iceberg_${uuid
 function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t2 where (dt>'2020-06-15' and dt <= '2020-06-22') or dt>'2020-07-01' GROUP BY dt;", "test_mv1")
 function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t2 where dt in ('2020-06-21', '2020-07-25') GROUP BY dt;", "test_mv1")
 -- cannot partition prune
-function: check_no_hit_materialized_view("SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t2 where date_trunc('month', dt) ='2020-07-01' GROUP BY dt;", "test_mv1")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t2 where date_trunc('month', dt) ='2020-07-01' GROUP BY dt;", "test_mv1")
 function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t2 where dt between '2020-06-16' and '2020-07-01' GROUP BY dt;", "test_mv1")
 
--- function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t2 where dt between '2020-06-15' and '2020-07-01' GROUP BY dt;", "test_mv1", "UNION")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t2 where dt between '2020-06-15' and '2020-07-01' GROUP BY dt;", "test_mv1", "UNION")
 function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t2 where dt>='2020-06-15' GROUP BY dt;", "test_mv1", "UNION")
--- function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t2 where dt in ('2020-06-15', '2020-06-21', '2020-07-25') GROUP BY dt;", "test_mv1", "UNION")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t2 where dt in ('2020-06-15', '2020-06-21', '2020-07-25') GROUP BY dt;", "test_mv1", "UNION")
 -- cannot partition prune
-function: check_no_hit_materialized_view("SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t2 where date_trunc('month', dt) ='2020-06-01' GROUP BY dt;", "test_mv1")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t2 where date_trunc('month', dt) ='2020-06-01' GROUP BY dt;", "test_mv1")
 function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t2 GROUP BY dt;", "test_mv1", "UNION")
 
 SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t2 where dt='2020-06-15' GROUP BY dt order by dt;
@@ -349,5 +350,5 @@ SELECT dt,sum(num) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t2 GROUP BY dt or
 
 drop materialized view default_catalog.db_${uuid0}.test_mv1;
 
-drop table mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t2 force;
+drop table mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 force;
 drop table mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t2 force;

--- a/test/sql/test_materialized_view/T/test_mv_partition_compensate_mysql
+++ b/test/sql/test_materialized_view/T/test_mv_partition_compensate_mysql
@@ -1,0 +1,177 @@
+-- name: test_mv_partition_compensate_mysql
+-- create mysql table
+shell: mysql -h${external_mysql_ip} -u${external_mysql_user} -p${external_mysql_password} -P${external_mysql_port} -e 'create database mv_mysql_db_${uuid0};'
+shell: mysql -h${external_mysql_ip} -u${external_mysql_user} -p${external_mysql_password} -P${external_mysql_port} -e 'use mv_mysql_db_${uuid0}; CREATE TABLE t1 (num int, dt date) PARTITION BY range columns(dt) (PARTITION p20200614 VALUES LESS THAN ("2020-06-15"),PARTITION p20200617 VALUES LESS THAN ("2020-06-18"),PARTITION p20200620 VALUES LESS THAN ("2020-06-21"),PARTITION p20200623 VALUES LESS THAN ("2020-06-24"),PARTITION p20200701 VALUES LESS THAN ("2020-07-02"),PARTITION p20200704 VALUES LESS THAN ("2020-07-05"),PARTITION p20200707 VALUES LESS THAN ("2020-07-08"),PARTITION p20200710 VALUES LESS THAN ("2020-07-11"),PARTITION p20200715 VALUES LESS THAN ("2020-07-16"),PARTITION p20200718 VALUES LESS THAN ("2020-07-19"),PARTITION p20200721 VALUES LESS THAN ("2020-07-22"),PARTITION p20200724 VALUES LESS THAN ("2020-07-31"));'
+shell: mysql -h${external_mysql_ip} -u${external_mysql_user} -p${external_mysql_password} -P${external_mysql_port} -e 'use mv_mysql_db_${uuid0}; INSERT INTO t1 VALUES (1,"2020-06-15"),(2,"2020-06-18"),(3,"2020-06-21"),(4,"2020-06-24"),(1,"2020-07-02"),(2,"2020-07-05"),(3,"2020-07-08"),(4,"2020-07-11"),(1,"2020-07-16"),(2,"2020-07-19"),(3,"2020-07-22"),(4,"2020-07-25"),(2,"2020-06-15"),(3,"2020-06-18"),(4,"2020-06-21"),(5,"2020-06-24"),(2,"2020-07-02"),(3,"2020-07-05"),(4,"2020-07-08"),(5,"2020-07-11");'
+
+set materialized_view_union_rewrite_mode = 3;
+set catalog default_catalog;
+create database db_${uuid0};
+use db_${uuid0};
+create external catalog mv_mysql_${uuid0}
+properties
+(
+    "type" = "jdbc",
+    "user"="${external_mysql_user}",
+    "password"="${external_mysql_password}",
+    "jdbc_uri"="jdbc:mysql://${external_mysql_ip}:${external_mysql_port}",
+    "driver_url"="https://repo1.maven.org/maven2/mysql/mysql-connector-java/8.0.28/mysql-connector-java-8.0.28.jar",
+    "driver_class"="com.mysql.cj.jdbc.Driver"
+);
+
+-- create mv
+-- Test partition compensate without partition expression
+CREATE MATERIALIZED VIEW test_mv1 
+PARTITION BY dt 
+REFRESH DEFERRED MANUAL AS 
+  SELECT dt,sum(num) FROM mv_mysql_${uuid0}.mv_mysql_db_${uuid0}.t1 GROUP BY dt;
+
+REFRESH MATERIALIZED VIEW test_mv1 WITH SYNC MODE;
+
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_mysql_${uuid0}.mv_mysql_db_${uuid0}.t1 where dt='2020-06-15' GROUP BY dt;", "test_mv1")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_mysql_${uuid0}.mv_mysql_db_${uuid0}.t1 where dt !='2020-06-15' GROUP BY dt;", "test_mv1")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_mysql_${uuid0}.mv_mysql_db_${uuid0}.t1 where dt>='2020-06-15' GROUP BY dt;", "test_mv1")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_mysql_${uuid0}.mv_mysql_db_${uuid0}.t1 where dt>'2020-06-15' GROUP BY dt;", "test_mv1")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_mysql_${uuid0}.mv_mysql_db_${uuid0}.t1 where dt>'2020-06-15' and dt < '2020-07-22' GROUP BY dt;", "test_mv1")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_mysql_${uuid0}.mv_mysql_db_${uuid0}.t1 where dt>'2020-06-15' and dt <= '2020-07-22' GROUP BY dt;", "test_mv1")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_mysql_${uuid0}.mv_mysql_db_${uuid0}.t1 where (dt>'2020-06-15' and dt <= '2020-06-22') or dt>'2020-07-01' GROUP BY dt;", "test_mv1")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_mysql_${uuid0}.mv_mysql_db_${uuid0}.t1 where dt in ('2020-06-15', '2020-06-22', '2020-07-01') GROUP BY dt;", "test_mv1")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_mysql_${uuid0}.mv_mysql_db_${uuid0}.t1 where date_trunc('day', dt) ='2020-06-15' GROUP BY dt;", "test_mv1")
+-- TODO
+function: check_no_hit_materialized_view("SELECT dt,sum(num) FROM mv_mysql_${uuid0}.mv_mysql_db_${uuid0}.t1 where date_trunc('month', dt) ='2020-06-01' GROUP BY dt;", "test_mv1")
+-- TODO
+function: check_no_hit_materialized_view("SELECT dt,sum(num) FROM mv_mysql_${uuid0}.mv_mysql_db_${uuid0}.t1 where date_trunc('month', dt) ='2020-07-01' GROUP BY dt;", "test_mv1")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_mysql_${uuid0}.mv_mysql_db_${uuid0}.t1 GROUP BY dt;", "test_mv1")
+
+SELECT dt,sum(num) FROM mv_mysql_${uuid0}.mv_mysql_db_${uuid0}.t1 where dt='2020-06-15' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM mv_mysql_${uuid0}.mv_mysql_db_${uuid0}.t1 where dt !='2020-06-15' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM mv_mysql_${uuid0}.mv_mysql_db_${uuid0}.t1 where dt>='2020-06-15' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM mv_mysql_${uuid0}.mv_mysql_db_${uuid0}.t1 where dt>'2020-06-15' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM mv_mysql_${uuid0}.mv_mysql_db_${uuid0}.t1 where dt>'2020-06-15' and dt < '2020-07-22' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM mv_mysql_${uuid0}.mv_mysql_db_${uuid0}.t1 where dt>'2020-06-15' and dt <= '2020-07-22' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM mv_mysql_${uuid0}.mv_mysql_db_${uuid0}.t1 where (dt>'2020-06-15' and dt <= '2020-06-22') or dt>'2020-07-01' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM mv_mysql_${uuid0}.mv_mysql_db_${uuid0}.t1 where dt in ('2020-06-15', '2020-06-22', '2020-07-01') GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM mv_mysql_${uuid0}.mv_mysql_db_${uuid0}.t1 where date_trunc('day', dt) ='2020-06-15' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM mv_mysql_${uuid0}.mv_mysql_db_${uuid0}.t1 where date_trunc('month', dt) ='2020-06-01' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM mv_mysql_${uuid0}.mv_mysql_db_${uuid0}.t1 where date_trunc('month', dt) ='2020-07-01' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM mv_mysql_${uuid0}.mv_mysql_db_${uuid0}.t1 GROUP BY dt order by dt;
+
+-- union rewrite
+shell: mysql -h${external_mysql_ip} -u${external_mysql_user} -p${external_mysql_password} -P${external_mysql_port} -e 'use mv_mysql_db_${uuid0}; INSERT INTO t1 VALUES (3,"2020-06-15");'
+function: check_no_hit_materialized_view("SELECT dt,sum(num) FROM mv_mysql_${uuid0}.mv_mysql_db_${uuid0}.t1 where dt='2020-06-15' GROUP BY dt;", "test_mv1")
+function: check_no_hit_materialized_view("SELECT dt,sum(num) FROM mv_mysql_${uuid0}.mv_mysql_db_${uuid0}.t1 where date_trunc('day', dt) ='2020-06-15' GROUP BY dt;", "test_mv1")
+function: check_no_hit_materialized_view("SELECT dt,sum(num) FROM mv_mysql_${uuid0}.mv_mysql_db_${uuid0}.t1 where dt in ('2020-06-15', '2020-06-22', '2020-07-01') GROUP BY dt;", "test_mv1")
+
+function: check_no_hit_materialized_view("SELECT dt,sum(num) FROM mv_mysql_${uuid0}.mv_mysql_db_${uuid0}.t1 where date_trunc('day', dt) ='2020-06-21' GROUP BY dt;", "test_mv1")
+function: check_no_hit_materialized_view("SELECT dt,sum(num) FROM mv_mysql_${uuid0}.mv_mysql_db_${uuid0}.t1 where dt !='2020-06-15' GROUP BY dt;", "test_mv1")
+function: check_no_hit_materialized_view("SELECT dt,sum(num) FROM mv_mysql_${uuid0}.mv_mysql_db_${uuid0}.t1 where dt>'2020-06-15' GROUP BY dt;", "test_mv1")
+function: check_no_hit_materialized_view("SELECT dt,sum(num) FROM mv_mysql_${uuid0}.mv_mysql_db_${uuid0}.t1 where dt>'2020-06-15' and dt < '2020-07-22' GROUP BY dt;", "test_mv1")
+function: check_no_hit_materialized_view("SELECT dt,sum(num) FROM mv_mysql_${uuid0}.mv_mysql_db_${uuid0}.t1 where dt>'2020-06-15' and dt <= '2020-07-22' GROUP BY dt;", "test_mv1")
+function: check_no_hit_materialized_view("SELECT dt,sum(num) FROM mv_mysql_${uuid0}.mv_mysql_db_${uuid0}.t1 where (dt>'2020-06-15' and dt <= '2020-06-22') or dt>'2020-07-01' GROUP BY dt;", "test_mv1")
+function: check_no_hit_materialized_view("SELECT dt,sum(num) FROM mv_mysql_${uuid0}.mv_mysql_db_${uuid0}.t1 where dt in ('2020-06-21', '2020-07-25') GROUP BY dt;", "test_mv1")
+-- cannot partition prune
+function: check_no_hit_materialized_view("SELECT dt,sum(num) FROM mv_mysql_${uuid0}.mv_mysql_db_${uuid0}.t1 where date_trunc('month', dt) ='2020-07-01' GROUP BY dt;", "test_mv1")
+function: check_no_hit_materialized_view("SELECT dt,sum(num) FROM mv_mysql_${uuid0}.mv_mysql_db_${uuid0}.t1 where dt between '2020-06-16' and '2020-07-01' GROUP BY dt;", "test_mv1")
+
+function: check_no_hit_materialized_view("SELECT dt,sum(num) FROM mv_mysql_${uuid0}.mv_mysql_db_${uuid0}.t1 where dt between '2020-06-15' and '2020-07-01' GROUP BY dt;", "test_mv1", "UNION")
+function: check_no_hit_materialized_view("SELECT dt,sum(num) FROM mv_mysql_${uuid0}.mv_mysql_db_${uuid0}.t1 where dt>='2020-06-15' GROUP BY dt;", "test_mv1", "UNION")
+function: check_no_hit_materialized_view("SELECT dt,sum(num) FROM mv_mysql_${uuid0}.mv_mysql_db_${uuid0}.t1 where dt in ('2020-06-15', '2020-06-21', '2020-07-25') GROUP BY dt;", "test_mv1", "UNION")
+-- cannot partition prune
+function: check_no_hit_materialized_view("SELECT dt,sum(num) FROM mv_mysql_${uuid0}.mv_mysql_db_${uuid0}.t1 where date_trunc('month', dt) ='2020-06-01' GROUP BY dt;", "test_mv1", "UNION")
+function: check_no_hit_materialized_view("SELECT dt,sum(num) FROM mv_mysql_${uuid0}.mv_mysql_db_${uuid0}.t1 GROUP BY dt;", "test_mv1", "UNION")
+
+SELECT dt,sum(num) FROM mv_mysql_${uuid0}.mv_mysql_db_${uuid0}.t1 where dt='2020-06-15' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM mv_mysql_${uuid0}.mv_mysql_db_${uuid0}.t1 where dt !='2020-06-15' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM mv_mysql_${uuid0}.mv_mysql_db_${uuid0}.t1 where dt>='2020-06-15' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM mv_mysql_${uuid0}.mv_mysql_db_${uuid0}.t1 where dt>'2020-06-15' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM mv_mysql_${uuid0}.mv_mysql_db_${uuid0}.t1 where dt>'2020-06-15' and dt < '2020-07-22' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM mv_mysql_${uuid0}.mv_mysql_db_${uuid0}.t1 where dt>'2020-06-15' and dt <= '2020-07-22' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM mv_mysql_${uuid0}.mv_mysql_db_${uuid0}.t1 where (dt>'2020-06-15' and dt <= '2020-06-22') or dt>'2020-07-01' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM mv_mysql_${uuid0}.mv_mysql_db_${uuid0}.t1 where dt in ('2020-06-22', '2020-07-01') GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM mv_mysql_${uuid0}.mv_mysql_db_${uuid0}.t1 where dt in ('2020-06-15', '2020-06-22', '2020-07-01') GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM mv_mysql_${uuid0}.mv_mysql_db_${uuid0}.t1 where dt between '2020-06-15' and '2020-07-01' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM mv_mysql_${uuid0}.mv_mysql_db_${uuid0}.t1 where date_trunc('day', dt) ='2020-06-15' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM mv_mysql_${uuid0}.mv_mysql_db_${uuid0}.t1 where date_trunc('month', dt) ='2020-06-01' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM mv_mysql_${uuid0}.mv_mysql_db_${uuid0}.t1 where date_trunc('month', dt) ='2020-07-01' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM mv_mysql_${uuid0}.mv_mysql_db_${uuid0}.t1 GROUP BY dt order by dt;
+
+
+drop materialized view default_catalog.db_${uuid0}.test_mv1;
+
+-- Test partition compensate with partition expression
+CREATE MATERIALIZED VIEW test_mv1 
+PARTITION BY date_trunc('day', dt)
+REFRESH DEFERRED MANUAL AS 
+  SELECT dt,sum(num) FROM mv_mysql_${uuid0}.mv_mysql_db_${uuid0}.t1 GROUP BY dt;
+REFRESH MATERIALIZED VIEW test_mv1 WITH SYNC MODE;
+
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_mysql_${uuid0}.mv_mysql_db_${uuid0}.t1 where dt='2020-06-15' GROUP BY dt;", "test_mv1")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_mysql_${uuid0}.mv_mysql_db_${uuid0}.t1 where dt !='2020-06-15' GROUP BY dt;", "test_mv1")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_mysql_${uuid0}.mv_mysql_db_${uuid0}.t1 where dt>='2020-06-15' GROUP BY dt;", "test_mv1")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_mysql_${uuid0}.mv_mysql_db_${uuid0}.t1 where dt>'2020-06-15' GROUP BY dt;", "test_mv1")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_mysql_${uuid0}.mv_mysql_db_${uuid0}.t1 where dt>'2020-06-15' and dt < '2020-07-22' GROUP BY dt;", "test_mv1")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_mysql_${uuid0}.mv_mysql_db_${uuid0}.t1 where dt>'2020-06-15' and dt <= '2020-07-22' GROUP BY dt;", "test_mv1")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_mysql_${uuid0}.mv_mysql_db_${uuid0}.t1 where (dt>'2020-06-15' and dt <= '2020-06-22') or dt>'2020-07-01' GROUP BY dt;", "test_mv1")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_mysql_${uuid0}.mv_mysql_db_${uuid0}.t1 where dt in ('2020-06-15', '2020-06-22', '2020-07-01') GROUP BY dt;", "test_mv1")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_mysql_${uuid0}.mv_mysql_db_${uuid0}.t1 where date_trunc('day', dt) ='2020-06-15' GROUP BY dt;", "test_mv1")
+-- TODO
+function: check_no_hit_materialized_view("SELECT dt,sum(num) FROM mv_mysql_${uuid0}.mv_mysql_db_${uuid0}.t1 where date_trunc('month', dt) ='2020-06-01' GROUP BY dt;", "test_mv1")
+-- TODO
+function: check_no_hit_materialized_view("SELECT dt,sum(num) FROM mv_mysql_${uuid0}.mv_mysql_db_${uuid0}.t1 where date_trunc('month', dt) ='2020-07-01' GROUP BY dt;", "test_mv1")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_mysql_${uuid0}.mv_mysql_db_${uuid0}.t1 GROUP BY dt;", "test_mv1")
+
+SELECT dt,sum(num) FROM mv_mysql_${uuid0}.mv_mysql_db_${uuid0}.t1 where dt='2020-06-15' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM mv_mysql_${uuid0}.mv_mysql_db_${uuid0}.t1 where dt !='2020-06-15' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM mv_mysql_${uuid0}.mv_mysql_db_${uuid0}.t1 where dt>='2020-06-15' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM mv_mysql_${uuid0}.mv_mysql_db_${uuid0}.t1 where dt>'2020-06-15' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM mv_mysql_${uuid0}.mv_mysql_db_${uuid0}.t1 where dt>'2020-06-15' and dt < '2020-07-22' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM mv_mysql_${uuid0}.mv_mysql_db_${uuid0}.t1 where dt>'2020-06-15' and dt <= '2020-07-22' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM mv_mysql_${uuid0}.mv_mysql_db_${uuid0}.t1 where (dt>'2020-06-15' and dt <= '2020-06-22') or dt>'2020-07-01' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM mv_mysql_${uuid0}.mv_mysql_db_${uuid0}.t1 where dt in ('2020-06-15', '2020-06-22', '2020-07-01') GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM mv_mysql_${uuid0}.mv_mysql_db_${uuid0}.t1 where date_trunc('day', dt) ='2020-06-15' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM mv_mysql_${uuid0}.mv_mysql_db_${uuid0}.t1 where date_trunc('month', dt) ='2020-06-01' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM mv_mysql_${uuid0}.mv_mysql_db_${uuid0}.t1 where date_trunc('month', dt) ='2020-07-01' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM mv_mysql_${uuid0}.mv_mysql_db_${uuid0}.t1 GROUP BY dt order by dt;
+
+-- union rewrite
+shell: mysql -h${external_mysql_ip} -u${external_mysql_user} -p${external_mysql_password} -P${external_mysql_port} -e 'use mv_mysql_db_${uuid0}; INSERT INTO t1 VALUES (3,"2020-06-15");'
+alter materialized view test_mv1 set('query_rewrite_consistency' = 'loose');
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_mysql_${uuid0}.mv_mysql_db_${uuid0}.t1 where dt='2020-06-15' GROUP BY dt;", "test_mv1")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_mysql_${uuid0}.mv_mysql_db_${uuid0}.t1 where date_trunc('day', dt) ='2020-06-15' GROUP BY dt;", "test_mv1")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_mysql_${uuid0}.mv_mysql_db_${uuid0}.t1 where dt in ('2020-06-15', '2020-06-22', '2020-07-01') GROUP BY dt;", "test_mv1")
+
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_mysql_${uuid0}.mv_mysql_db_${uuid0}.t1 where date_trunc('day', dt) ='2020-06-21' GROUP BY dt;", "test_mv1")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_mysql_${uuid0}.mv_mysql_db_${uuid0}.t1 where dt !='2020-06-15' GROUP BY dt;", "test_mv1")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_mysql_${uuid0}.mv_mysql_db_${uuid0}.t1 where dt>'2020-06-15' GROUP BY dt;", "test_mv1")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_mysql_${uuid0}.mv_mysql_db_${uuid0}.t1 where dt>'2020-06-15' and dt < '2020-07-22' GROUP BY dt;", "test_mv1")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_mysql_${uuid0}.mv_mysql_db_${uuid0}.t1 where dt>'2020-06-15' and dt <= '2020-07-22' GROUP BY dt;", "test_mv1")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_mysql_${uuid0}.mv_mysql_db_${uuid0}.t1 where (dt>'2020-06-15' and dt <= '2020-06-22') or dt>'2020-07-01' GROUP BY dt;", "test_mv1")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_mysql_${uuid0}.mv_mysql_db_${uuid0}.t1 where dt in ('2020-06-21', '2020-07-25') GROUP BY dt;", "test_mv1")
+-- cannot partition prune
+function: check_no_hit_materialized_view("SELECT dt,sum(num) FROM mv_mysql_${uuid0}.mv_mysql_db_${uuid0}.t1 where date_trunc('month', dt) ='2020-07-01' GROUP BY dt;", "test_mv1")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_mysql_${uuid0}.mv_mysql_db_${uuid0}.t1 where dt between '2020-06-16' and '2020-07-01' GROUP BY dt;", "test_mv1")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_mysql_${uuid0}.mv_mysql_db_${uuid0}.t1 where dt between '2020-06-15' and '2020-07-01' GROUP BY dt;", "test_mv1")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_mysql_${uuid0}.mv_mysql_db_${uuid0}.t1 where dt>='2020-06-15' GROUP BY dt;", "test_mv1")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_mysql_${uuid0}.mv_mysql_db_${uuid0}.t1 where dt in ('2020-06-15', '2020-06-21', '2020-07-25') GROUP BY dt;", "test_mv1")
+-- cannot partition prune
+function: check_no_hit_materialized_view("SELECT dt,sum(num) FROM mv_mysql_${uuid0}.mv_mysql_db_${uuid0}.t1 where date_trunc('month', dt) ='2020-06-01' GROUP BY dt;", "test_mv1")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM mv_mysql_${uuid0}.mv_mysql_db_${uuid0}.t1 GROUP BY dt;", "test_mv1")
+
+SELECT dt,sum(num) FROM mv_mysql_${uuid0}.mv_mysql_db_${uuid0}.t1 where dt='2020-06-15' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM mv_mysql_${uuid0}.mv_mysql_db_${uuid0}.t1 where dt !='2020-06-15' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM mv_mysql_${uuid0}.mv_mysql_db_${uuid0}.t1 where dt>='2020-06-15' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM mv_mysql_${uuid0}.mv_mysql_db_${uuid0}.t1 where dt>'2020-06-15' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM mv_mysql_${uuid0}.mv_mysql_db_${uuid0}.t1 where dt>'2020-06-15' and dt < '2020-07-22' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM mv_mysql_${uuid0}.mv_mysql_db_${uuid0}.t1 where dt>'2020-06-15' and dt <= '2020-07-22' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM mv_mysql_${uuid0}.mv_mysql_db_${uuid0}.t1 where (dt>'2020-06-15' and dt <= '2020-06-22') or dt>'2020-07-01' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM mv_mysql_${uuid0}.mv_mysql_db_${uuid0}.t1 where dt in ('2020-06-22', '2020-07-01') GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM mv_mysql_${uuid0}.mv_mysql_db_${uuid0}.t1 where dt in ('2020-06-15', '2020-06-22', '2020-07-01') GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM mv_mysql_${uuid0}.mv_mysql_db_${uuid0}.t1 where dt between '2020-06-15' and '2020-07-01' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM mv_mysql_${uuid0}.mv_mysql_db_${uuid0}.t1 where date_trunc('day', dt) ='2020-06-15' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM mv_mysql_${uuid0}.mv_mysql_db_${uuid0}.t1 where date_trunc('month', dt) ='2020-06-01' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM mv_mysql_${uuid0}.mv_mysql_db_${uuid0}.t1 where date_trunc('month', dt) ='2020-07-01' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM mv_mysql_${uuid0}.mv_mysql_db_${uuid0}.t1 GROUP BY dt order by dt;
+
+drop materialized view default_catalog.db_${uuid0}.test_mv1;
+
+shell: mysql -h${external_mysql_ip} -u${external_mysql_user} -p${external_mysql_password} -P${external_mysql_port} -e 'drop database mv_mysql_db_${uuid0};'

--- a/test/sql/test_materialized_view/T/test_mv_partition_compensate_olap
+++ b/test/sql/test_materialized_view/T/test_mv_partition_compensate_olap
@@ -1,0 +1,511 @@
+-- name: test_mv_partition_compensate_olap
+
+-- create mv
+create database db_${uuid0};
+use db_${uuid0};
+set materialized_view_union_rewrite_mode = 3;
+
+-- test mv with range partition 
+-- base table with date partition column
+CREATE TABLE t1 (
+  num int,
+  dt date
+)
+DUPLICATE KEY(`num`)
+PARTITION BY RANGE(`dt`)
+(
+  PARTITION p20200615 VALUES [("2020-06-15 00:00:00"), ("2020-06-16 00:00:00")),
+  PARTITION p20200618 VALUES [("2020-06-18 00:00:00"), ("2020-06-19 00:00:00")),
+  PARTITION p20200621 VALUES [("2020-06-21 00:00:00"), ("2020-06-22 00:00:00")),
+  PARTITION p20200624 VALUES [("2020-06-24 00:00:00"), ("2020-06-25 00:00:00")),
+  PARTITION p20200702 VALUES [("2020-07-02 00:00:00"), ("2020-07-03 00:00:00")),
+  PARTITION p20200705 VALUES [("2020-07-05 00:00:00"), ("2020-07-06 00:00:00")),
+  PARTITION p20200708 VALUES [("2020-07-08 00:00:00"), ("2020-07-09 00:00:00")),
+  PARTITION p20200716 VALUES [("2020-07-16 00:00:00"), ("2020-07-17 00:00:00")),
+  PARTITION p20200719 VALUES [("2020-07-19 00:00:00"), ("2020-07-20 00:00:00")),
+  PARTITION p20200722 VALUES [("2020-07-22 00:00:00"), ("2020-07-23 00:00:00")),
+  PARTITION p20200725 VALUES [("2020-07-25 00:00:00"), ("2020-07-26 00:00:00")),
+  PARTITION p20200711 VALUES [("2020-07-11 00:00:00"), ("2020-07-12 00:00:00"))
+)
+DISTRIBUTED BY HASH(`num`);
+
+INSERT INTO t1 VALUES 
+  (1,"2020-06-15"),(2,"2020-06-18"),(3,"2020-06-21"),(4,"2020-06-24"),
+  (1,"2020-07-02"),(2,"2020-07-05"),(3,"2020-07-08"),(4,"2020-07-11"),
+  (1,"2020-07-16"),(2,"2020-07-19"),(3,"2020-07-22"),(4,"2020-07-25"),
+  (2,"2020-06-15"),(3,"2020-06-18"),(4,"2020-06-21"),(5,"2020-06-24"),
+  (2,"2020-07-02"),(3,"2020-07-05"),(4,"2020-07-08"),(5,"2020-07-11");
+
+-- base table with datetime partition column
+CREATE TABLE t2 (
+  num int,
+  dt datetime
+)
+DUPLICATE KEY(`num`)
+PARTITION BY RANGE(`dt`)
+(
+  PARTITION p20200615 VALUES [("2020-06-15 00:00:00"), ("2020-06-16 00:00:00")),
+  PARTITION p20200618 VALUES [("2020-06-18 00:00:00"), ("2020-06-19 00:00:00")),
+  PARTITION p20200621 VALUES [("2020-06-21 00:00:00"), ("2020-06-22 00:00:00")),
+  PARTITION p20200624 VALUES [("2020-06-24 00:00:00"), ("2020-06-25 00:00:00")),
+  PARTITION p20200702 VALUES [("2020-07-02 00:00:00"), ("2020-07-03 00:00:00")),
+  PARTITION p20200705 VALUES [("2020-07-05 00:00:00"), ("2020-07-06 00:00:00")),
+  PARTITION p20200708 VALUES [("2020-07-08 00:00:00"), ("2020-07-09 00:00:00")),
+  PARTITION p20200716 VALUES [("2020-07-16 00:00:00"), ("2020-07-17 00:00:00")),
+  PARTITION p20200719 VALUES [("2020-07-19 00:00:00"), ("2020-07-20 00:00:00")),
+  PARTITION p20200722 VALUES [("2020-07-22 00:00:00"), ("2020-07-23 00:00:00")),
+  PARTITION p20200725 VALUES [("2020-07-25 00:00:00"), ("2020-07-26 00:00:00")),
+  PARTITION p20200711 VALUES [("2020-07-11 00:00:00"), ("2020-07-12 00:00:00"))
+)
+DISTRIBUTED BY HASH(`num`);
+
+INSERT INTO t2 VALUES 
+  (1,"2020-06-15"),(2,"2020-06-18"),(3,"2020-06-21"),(4,"2020-06-24"),
+  (1,"2020-07-02"),(2,"2020-07-05"),(3,"2020-07-08"),(4,"2020-07-11"),
+  (1,"2020-07-16"),(2,"2020-07-19"),(3,"2020-07-22"),(4,"2020-07-25"),
+  (2,"2020-06-15"),(3,"2020-06-18"),(4,"2020-06-21"),(5,"2020-06-24"),
+  (2,"2020-07-02"),(3,"2020-07-05"),(4,"2020-07-08"),(5,"2020-07-11");
+
+-- base table with datetime partition column
+CREATE TABLE t3 (
+  num int,
+  dt datetime
+)
+DUPLICATE KEY(`num`)
+PARTITION BY  date_trunc('day', dt) 
+DISTRIBUTED BY HASH(`num`);
+
+INSERT INTO t3 VALUES 
+  (1,"2020-06-15"),(2,"2020-06-18"),(3,"2020-06-21"),(4,"2020-06-24"),
+  (1,"2020-07-02"),(2,"2020-07-05"),(3,"2020-07-08"),(4,"2020-07-11"),
+  (1,"2020-07-16"),(2,"2020-07-19"),(3,"2020-07-22"),(4,"2020-07-25"),
+  (2,"2020-06-15"),(3,"2020-06-18"),(4,"2020-06-21"),(5,"2020-06-24"),
+  (2,"2020-07-02"),(3,"2020-07-05"),(4,"2020-07-08"),(5,"2020-07-11");
+
+-- Test partition compensate without partition expression
+CREATE MATERIALIZED VIEW test_mv1 
+PARTITION BY dt 
+REFRESH DEFERRED MANUAL AS 
+  SELECT dt,sum(num) FROM t1 GROUP BY dt;
+
+REFRESH MATERIALIZED VIEW test_mv1 WITH SYNC MODE;
+
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t1 where dt='2020-06-15' GROUP BY dt;", "test_mv1")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t1 where dt !='2020-06-15' GROUP BY dt;", "test_mv1")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t1 where dt>='2020-06-15' GROUP BY dt;", "test_mv1")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t1 where dt>'2020-06-15' GROUP BY dt;", "test_mv1")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t1 where dt>'2020-06-15' and dt < '2020-07-22' GROUP BY dt;", "test_mv1")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t1 where dt>'2020-06-15' and dt <= '2020-07-22' GROUP BY dt;", "test_mv1")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t1 where (dt>'2020-06-15' and dt <= '2020-06-22') or dt>'2020-07-01' GROUP BY dt;", "test_mv1")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t1 where dt in ('2020-06-15', '2020-06-22', '2020-07-01') GROUP BY dt;", "test_mv1")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t1 where date_trunc('day', dt) ='2020-06-15' GROUP BY dt;", "test_mv1")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t1 where date_trunc('month', dt) ='2020-06-01' GROUP BY dt;", "test_mv1")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t1 where date_trunc('month', dt) ='2020-07-01' GROUP BY dt;", "test_mv1")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t1 GROUP BY dt;", "test_mv1")
+
+SELECT dt,sum(num) FROM t1 where dt='2020-06-15' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM t1 where dt !='2020-06-15' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM t1 where dt>='2020-06-15' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM t1 where dt>'2020-06-15' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM t1 where dt>'2020-06-15' and dt < '2020-07-22' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM t1 where dt>'2020-06-15' and dt <= '2020-07-22' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM t1 where (dt>'2020-06-15' and dt <= '2020-06-22') or dt>'2020-07-01' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM t1 where dt in ('2020-06-15', '2020-06-22', '2020-07-01') GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM t1 where date_trunc('day', dt) ='2020-06-15' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM t1 where date_trunc('month', dt) ='2020-06-01' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM t1 where date_trunc('month', dt) ='2020-07-01' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM t1 GROUP BY dt order by dt;
+
+-- union rewrite
+INSERT INTO t1 VALUES (3, "2020-06-15");
+function: check_no_hit_materialized_view("SELECT dt,sum(num) FROM t1 where dt='2020-06-15' GROUP BY dt;", "test_mv1")
+function: check_no_hit_materialized_view("SELECT dt,sum(num) FROM t1 where date_trunc('day', dt) ='2020-06-15' GROUP BY dt;", "test_mv1")
+function: check_no_hit_materialized_view("SELECT dt,sum(num) FROM t1 where dt in ('2020-06-15', '2020-06-22', '2020-07-01') GROUP BY dt;", "test_mv1")
+
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t1 where date_trunc('day', dt) ='2020-06-21' GROUP BY dt;", "test_mv1")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t1 where dt !='2020-06-15' GROUP BY dt;", "test_mv1")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t1 where dt>'2020-06-15' GROUP BY dt;", "test_mv1")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t1 where dt>'2020-06-15' and dt < '2020-07-22' GROUP BY dt;", "test_mv1")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t1 where dt>'2020-06-15' and dt <= '2020-07-22' GROUP BY dt;", "test_mv1")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t1 where (dt>'2020-06-15' and dt <= '2020-06-22') or dt>'2020-07-01' GROUP BY dt;", "test_mv1")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t1 where date_trunc('month', dt) ='2020-07-01' GROUP BY dt;", "test_mv1")
+
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t1 where dt between '2020-06-15' and '2020-07-01' GROUP BY dt;", "test_mv1", "UNION")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t1 where dt>='2020-06-15' GROUP BY dt;", "test_mv1", "UNION")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t1 where dt in ('2020-06-15', '2020-06-21', '2020-07-25') GROUP BY dt;", "test_mv1", "UNION")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t1 where date_trunc('month', dt) ='2020-06-01' GROUP BY dt;", "test_mv1", "UNION")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t1 GROUP BY dt;", "test_mv1", "UNION")
+
+
+SELECT dt,sum(num) FROM t1 where dt='2020-06-15' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM t1 where dt !='2020-06-15' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM t1 where dt>='2020-06-15' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM t1 where dt>'2020-06-15' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM t1 where dt>'2020-06-15' and dt < '2020-07-22' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM t1 where dt>'2020-06-15' and dt <= '2020-07-22' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM t1 where (dt>'2020-06-15' and dt <= '2020-06-22') or dt>'2020-07-01' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM t1 where dt in ('2020-06-15', '2020-06-22', '2020-07-01') GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM t1 where date_trunc('day', dt) ='2020-06-15' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM t1 where date_trunc('month', dt) ='2020-06-01' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM t1 where date_trunc('month', dt) ='2020-07-01' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM t1 where dt between '2020-06-15' and '2020-07-01' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM t1 GROUP BY dt order by dt;
+
+drop materialized view default_catalog.db_${uuid0}.test_mv1;
+
+-- Test partition compensate with partition expression
+CREATE MATERIALIZED VIEW test_mv1 
+PARTITION BY date_trunc('day', dt)
+REFRESH DEFERRED MANUAL AS 
+  SELECT dt,sum(num) FROM t1 GROUP BY dt;
+REFRESH MATERIALIZED VIEW test_mv1 WITH SYNC MODE;
+
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t1 where dt='2020-06-15' GROUP BY dt;", "test_mv1")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t1 where dt !='2020-06-15' GROUP BY dt;", "test_mv1")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t1 where dt>='2020-06-15' GROUP BY dt;", "test_mv1")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t1 where dt>'2020-06-15' GROUP BY dt;", "test_mv1")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t1 where dt>'2020-06-15' and dt < '2020-07-22' GROUP BY dt;", "test_mv1")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t1 where dt>'2020-06-15' and dt <= '2020-07-22' GROUP BY dt;", "test_mv1")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t1 where (dt>'2020-06-15' and dt <= '2020-06-22') or dt>'2020-07-01' GROUP BY dt;", "test_mv1")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t1 where dt in ('2020-06-15', '2020-06-22', '2020-07-01') GROUP BY dt;", "test_mv1")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t1 where date_trunc('day', dt) ='2020-06-15' GROUP BY dt;", "test_mv1")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t1 where date_trunc('month', dt) ='2020-06-01' GROUP BY dt;", "test_mv1")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t1 where date_trunc('month', dt) ='2020-07-01' GROUP BY dt;", "test_mv1")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t1 GROUP BY dt;", "test_mv1")
+
+SELECT dt,sum(num) FROM t1 where dt='2020-06-15' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM t1 where dt !='2020-06-15' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM t1 where dt>='2020-06-15' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM t1 where dt>'2020-06-15' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM t1 where dt>'2020-06-15' and dt < '2020-07-22' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM t1 where dt>'2020-06-15' and dt <= '2020-07-22' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM t1 where (dt>'2020-06-15' and dt <= '2020-06-22') or dt>'2020-07-01' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM t1 where dt in ('2020-06-15', '2020-06-22', '2020-07-01') GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM t1 where date_trunc('day', dt) ='2020-06-15' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM t1 where date_trunc('month', dt) ='2020-06-01' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM t1 where date_trunc('month', dt) ='2020-07-01' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM t1 GROUP BY dt order by dt;
+
+-- union rewrite
+INSERT INTO t1 VALUES (3, "2020-06-15");
+function: check_no_hit_materialized_view("SELECT dt,sum(num) FROM t1 where dt='2020-06-15' GROUP BY dt;", "test_mv1")
+function: check_no_hit_materialized_view("SELECT dt,sum(num) FROM t1 where date_trunc('day', dt) ='2020-06-15' GROUP BY dt;", "test_mv1")
+function: check_no_hit_materialized_view("SELECT dt,sum(num) FROM t1 where dt in ('2020-06-15', '2020-06-22', '2020-07-01') GROUP BY dt;", "test_mv1")
+
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t1 where date_trunc('day', dt) ='2020-06-21' GROUP BY dt;", "test_mv1")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t1 where dt !='2020-06-15' GROUP BY dt;", "test_mv1")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t1 where dt>'2020-06-15' GROUP BY dt;", "test_mv1")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t1 where dt>'2020-06-15' and dt < '2020-07-22' GROUP BY dt;", "test_mv1")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t1 where dt>'2020-06-15' and dt <= '2020-07-22' GROUP BY dt;", "test_mv1")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t1 where (dt>'2020-06-15' and dt <= '2020-06-22') or dt>'2020-07-01' GROUP BY dt;", "test_mv1")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t1 where date_trunc('month', dt) ='2020-07-01' GROUP BY dt;", "test_mv1")
+
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t1 where dt between '2020-06-15' and '2020-07-01' GROUP BY dt;", "test_mv1", "UNION")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t1 where dt>='2020-06-15' GROUP BY dt;", "test_mv1", "UNION")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t1 where dt in ('2020-06-15', '2020-06-21', '2020-07-25') GROUP BY dt;", "test_mv1", "UNION")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t1 where date_trunc('month', dt) ='2020-06-01' GROUP BY dt;", "test_mv1", "UNION")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t1 GROUP BY dt;", "test_mv1", "UNION")
+
+
+SELECT dt,sum(num) FROM t1 where dt='2020-06-15' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM t1 where dt !='2020-06-15' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM t1 where dt>='2020-06-15' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM t1 where dt>'2020-06-15' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM t1 where dt>'2020-06-15' and dt < '2020-07-22' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM t1 where dt>'2020-06-15' and dt <= '2020-07-22' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM t2 where (dt>'2020-06-15' and dt <= '2020-06-22') or dt>'2020-07-01' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM t2 where dt in ('2020-06-15', '2020-06-22', '2020-07-01') GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM t2 where date_trunc('day', dt) ='2020-06-15' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM t2 where date_trunc('month', dt) ='2020-06-01' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM t2 where date_trunc('month', dt) ='2020-07-01' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM t2 where dt between '2020-06-15' and '2020-07-01' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM t2 GROUP BY dt order by dt;
+
+drop materialized view default_catalog.db_${uuid0}.test_mv1;
+
+
+-- Test partition compensate with partition expression
+CREATE MATERIALIZED VIEW test_mv1 
+PARTITION BY date_trunc('day', dt)
+REFRESH DEFERRED MANUAL AS 
+  SELECT dt,sum(num) FROM t2 GROUP BY dt;
+REFRESH MATERIALIZED VIEW test_mv1 WITH SYNC MODE;
+
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t2 where dt='2020-06-15' GROUP BY dt;", "test_mv1")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t2 where dt !='2020-06-15' GROUP BY dt;", "test_mv1")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t2 where dt>='2020-06-15' GROUP BY dt;", "test_mv1")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t2 where dt>'2020-06-15' GROUP BY dt;", "test_mv1")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t2 where dt>'2020-06-15' and dt < '2020-07-22' GROUP BY dt;", "test_mv1")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t2 where dt>'2020-06-15' and dt <= '2020-07-22' GROUP BY dt;", "test_mv1")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t2 where (dt>'2020-06-15' and dt <= '2020-06-22') or dt>'2020-07-01' GROUP BY dt;", "test_mv1")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t2 where dt in ('2020-06-15', '2020-06-22', '2020-07-01') GROUP BY dt;", "test_mv1")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t2 where date_trunc('day', dt) ='2020-06-15' GROUP BY dt;", "test_mv1")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t2 where date_trunc('month', dt) ='2020-06-01' GROUP BY dt;", "test_mv1")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t2 where date_trunc('month', dt) ='2020-07-01' GROUP BY dt;", "test_mv1")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t2 GROUP BY dt;", "test_mv1")
+
+SELECT dt,sum(num) FROM t2 where dt='2020-06-15' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM t2 where dt !='2020-06-15' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM t2 where dt>='2020-06-15' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM t2 where dt>'2020-06-15' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM t2 where dt>'2020-06-15' and dt < '2020-07-22' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM t2 where dt>'2020-06-15' and dt <= '2020-07-22' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM t2 where (dt>'2020-06-15' and dt <= '2020-06-22') or dt>'2020-07-01' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM t2 where dt in ('2020-06-15', '2020-06-22', '2020-07-01') GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM t2 where date_trunc('day', dt) ='2020-06-15' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM t2 where date_trunc('month', dt) ='2020-06-01' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM t2 where date_trunc('month', dt) ='2020-07-01' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM t2 GROUP BY dt order by dt;
+
+-- union rewrite
+INSERT INTO t2 VALUES (3, "2020-06-15");
+function: check_no_hit_materialized_view("SELECT dt,sum(num) FROM t2 where dt='2020-06-15' GROUP BY dt;", "test_mv1")
+function: check_no_hit_materialized_view("SELECT dt,sum(num) FROM t2 where date_trunc('day', dt) ='2020-06-15' GROUP BY dt;", "test_mv1")
+function: check_no_hit_materialized_view("SELECT dt,sum(num) FROM t2 where dt in ('2020-06-15', '2020-06-22', '2020-07-01') GROUP BY dt;", "test_mv1")
+
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t2 where date_trunc('day', dt) ='2020-06-21' GROUP BY dt;", "test_mv1")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t2 where dt !='2020-06-15' GROUP BY dt;", "test_mv1")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t2 where dt>'2020-06-15' GROUP BY dt;", "test_mv1")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t2 where dt>'2020-06-15' and dt < '2020-07-22' GROUP BY dt;", "test_mv1")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t2 where dt>'2020-06-15' and dt <= '2020-07-22' GROUP BY dt;", "test_mv1")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t2 where (dt>'2020-06-15' and dt <= '2020-06-22') or dt>'2020-07-01' GROUP BY dt;", "test_mv1")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t2 where date_trunc('month', dt) ='2020-07-01' GROUP BY dt;", "test_mv1")
+
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t2 where dt between '2020-06-15' and '2020-07-01' GROUP BY dt;", "test_mv1", "UNION")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t2 where dt>='2020-06-15' GROUP BY dt;", "test_mv1", "UNION")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t2 where dt in ('2020-06-15', '2020-06-21', '2020-07-25') GROUP BY dt;", "test_mv1", "UNION")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t2 where date_trunc('month', dt) ='2020-06-01' GROUP BY dt;", "test_mv1", "UNION")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t2 GROUP BY dt;", "test_mv1", "UNION")
+
+
+SELECT dt,sum(num) FROM t2 where dt='2020-06-15' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM t2 where dt !='2020-06-15' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM t2 where dt>='2020-06-15' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM t2 where dt>'2020-06-15' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM t2 where dt>'2020-06-15' and dt < '2020-07-22' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM t2 where dt>'2020-06-15' and dt <= '2020-07-22' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM t2 where (dt>'2020-06-15' and dt <= '2020-06-22') or dt>'2020-07-01' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM t2 where dt in ('2020-06-15', '2020-06-22', '2020-07-01') GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM t2 where date_trunc('day', dt) ='2020-06-15' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM t2 where date_trunc('month', dt) ='2020-06-01' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM t2 where date_trunc('month', dt) ='2020-07-01' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM t2 where dt between '2020-06-15' and '2020-07-01' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM t2 GROUP BY dt order by dt;
+
+drop materialized view default_catalog.db_${uuid0}.test_mv1;
+
+-- Test partition compensate with partition expression
+-- TODO: Remove dt(extra column) later.
+CREATE MATERIALIZED VIEW test_mv1 
+PARTITION BY dt
+REFRESH DEFERRED MANUAL AS 
+  SELECT dt, date_trunc('day', dt) as format_dt,sum(num) FROM t2 GROUP BY dt;
+REFRESH MATERIALIZED VIEW test_mv1 WITH SYNC MODE;
+
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t2 where dt='2020-06-15' GROUP BY dt;", "test_mv1")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t2 where dt !='2020-06-15' GROUP BY dt;", "test_mv1")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t2 where dt>='2020-06-15' GROUP BY dt;", "test_mv1")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t2 where dt>'2020-06-15' GROUP BY dt;", "test_mv1")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t2 where dt>'2020-06-15' and dt < '2020-07-22' GROUP BY dt;", "test_mv1")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t2 where dt>'2020-06-15' and dt <= '2020-07-22' GROUP BY dt;", "test_mv1")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t2 where (dt>'2020-06-15' and dt <= '2020-06-22') or dt>'2020-07-01' GROUP BY dt;", "test_mv1")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t2 where dt in ('2020-06-15', '2020-06-22', '2020-07-01') GROUP BY dt;", "test_mv1")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t2 where date_trunc('day', dt) ='2020-06-15' GROUP BY dt;", "test_mv1")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t2 where date_trunc('month', dt) ='2020-06-01' GROUP BY dt;", "test_mv1")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t2 where date_trunc('month', dt) ='2020-07-01' GROUP BY dt;", "test_mv1")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t2 GROUP BY dt;", "test_mv1")
+
+SELECT dt,sum(num) FROM t2 where dt='2020-06-15' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM t2 where dt !='2020-06-15' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM t2 where dt>='2020-06-15' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM t2 where dt>'2020-06-15' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM t2 where dt>'2020-06-15' and dt < '2020-07-22' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM t2 where dt>'2020-06-15' and dt <= '2020-07-22' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM t2 where (dt>'2020-06-15' and dt <= '2020-06-22') or dt>'2020-07-01' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM t2 where dt in ('2020-06-15', '2020-06-22', '2020-07-01') GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM t2 where date_trunc('day', dt) ='2020-06-15' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM t2 where date_trunc('month', dt) ='2020-06-01' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM t2 where date_trunc('month', dt) ='2020-07-01' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM t2 GROUP BY dt order by dt;
+
+-- union rewrite
+INSERT INTO t2 VALUES (3, "2020-06-15");
+function: check_no_hit_materialized_view("SELECT dt,sum(num) FROM t2 where dt='2020-06-15' GROUP BY dt;", "test_mv1")
+function: check_no_hit_materialized_view("SELECT dt,sum(num) FROM t2 where date_trunc('day', dt) ='2020-06-15' GROUP BY dt;", "test_mv1")
+function: check_no_hit_materialized_view("SELECT dt,sum(num) FROM t2 where dt in ('2020-06-15', '2020-06-22', '2020-07-01') GROUP BY dt;", "test_mv1")
+
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t2 where date_trunc('day', dt) ='2020-06-21' GROUP BY dt;", "test_mv1")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t2 where dt !='2020-06-15' GROUP BY dt;", "test_mv1")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t2 where dt>'2020-06-15' GROUP BY dt;", "test_mv1")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t2 where dt>'2020-06-15' and dt < '2020-07-22' GROUP BY dt;", "test_mv1")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t2 where dt>'2020-06-15' and dt <= '2020-07-22' GROUP BY dt;", "test_mv1")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t2 where (dt>'2020-06-15' and dt <= '2020-06-22') or dt>'2020-07-01' GROUP BY dt;", "test_mv1")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t2 where date_trunc('month', dt) ='2020-07-01' GROUP BY dt;", "test_mv1")
+
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t2 where dt between '2020-06-15' and '2020-07-01' GROUP BY dt;", "test_mv1", "UNION")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t2 where dt>='2020-06-15' GROUP BY dt;", "test_mv1", "UNION")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t2 where dt in ('2020-06-15', '2020-06-21', '2020-07-25') GROUP BY dt;", "test_mv1", "UNION")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t2 where date_trunc('month', dt) ='2020-06-01' GROUP BY dt;", "test_mv1", "UNION")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t2 GROUP BY dt;", "test_mv1", "UNION")
+
+
+SELECT dt,sum(num) FROM t2 where dt='2020-06-15' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM t2 where dt !='2020-06-15' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM t2 where dt>='2020-06-15' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM t2 where dt>'2020-06-15' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM t2 where dt>'2020-06-15' and dt < '2020-07-22' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM t2 where dt>'2020-06-15' and dt <= '2020-07-22' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM t2 where (dt>'2020-06-15' and dt <= '2020-06-22') or dt>'2020-07-01' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM t2 where dt in ('2020-06-15', '2020-06-22', '2020-07-01') GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM t2 where date_trunc('day', dt) ='2020-06-15' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM t2 where date_trunc('month', dt) ='2020-06-01' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM t2 where date_trunc('month', dt) ='2020-07-01' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM t2 where dt between '2020-06-15' and '2020-07-01' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM t2 GROUP BY dt order by dt;
+
+drop materialized view default_catalog.db_${uuid0}.test_mv1;
+
+-- Test partition compensate with partition expression
+CREATE MATERIALIZED VIEW test_mv1 
+PARTITION BY dt
+REFRESH DEFERRED MANUAL AS 
+  SELECT dt,sum(num) FROM t3 GROUP BY dt;
+REFRESH MATERIALIZED VIEW test_mv1 WITH SYNC MODE;
+
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t3 where dt='2020-06-15' GROUP BY dt;", "test_mv1")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t3 where dt !='2020-06-15' GROUP BY dt;", "test_mv1")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t3 where dt>='2020-06-15' GROUP BY dt;", "test_mv1")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t3 where dt>'2020-06-15' GROUP BY dt;", "test_mv1")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t3 where dt>'2020-06-15' and dt < '2020-07-22' GROUP BY dt;", "test_mv1")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t3 where dt>'2020-06-15' and dt <= '2020-07-22' GROUP BY dt;", "test_mv1")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t3 where (dt>'2020-06-15' and dt <= '2020-06-22') or dt>'2020-07-01' GROUP BY dt;", "test_mv1")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t3 where dt in ('2020-06-15', '2020-06-22', '2020-07-01') GROUP BY dt;", "test_mv1")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t3 where date_trunc('day', dt) ='2020-06-15' GROUP BY dt;", "test_mv1")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t3 where date_trunc('month', dt) ='2020-06-01' GROUP BY dt;", "test_mv1")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t3 where date_trunc('month', dt) ='2020-07-01' GROUP BY dt;", "test_mv1")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t3 GROUP BY dt;", "test_mv1")
+
+SELECT dt,sum(num) FROM t3 where dt='2020-06-15' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM t3 where dt !='2020-06-15' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM t3 where dt>='2020-06-15' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM t3 where dt>'2020-06-15' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM t3 where dt>'2020-06-15' and dt < '2020-07-22' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM t3 where dt>'2020-06-15' and dt <= '2020-07-22' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM t3 where (dt>'2020-06-15' and dt <= '2020-06-22') or dt>'2020-07-01' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM t3 where dt in ('2020-06-15', '2020-06-22', '2020-07-01') GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM t3 where date_trunc('day', dt) ='2020-06-15' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM t3 where date_trunc('month', dt) ='2020-06-01' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM t3 where date_trunc('month', dt) ='2020-07-01' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM t3 GROUP BY dt order by dt;
+
+-- union rewrite
+INSERT INTO t3 VALUES (3, "2020-06-15");
+function: check_no_hit_materialized_view("SELECT dt,sum(num) FROM t3 where dt='2020-06-15' GROUP BY dt;", "test_mv1")
+function: check_no_hit_materialized_view("SELECT dt,sum(num) FROM t3 where date_trunc('day', dt) ='2020-06-15' GROUP BY dt;", "test_mv1")
+function: check_no_hit_materialized_view("SELECT dt,sum(num) FROM t3 where dt in ('2020-06-15', '2020-06-22', '2020-07-01') GROUP BY dt;", "test_mv1")
+
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t3 where date_trunc('day', dt) ='2020-06-21' GROUP BY dt;", "test_mv1")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t3 where dt !='2020-06-15' GROUP BY dt;", "test_mv1")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t3 where dt>'2020-06-15' GROUP BY dt;", "test_mv1")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t3 where dt>'2020-06-15' and dt < '2020-07-22' GROUP BY dt;", "test_mv1")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t3 where dt>'2020-06-15' and dt <= '2020-07-22' GROUP BY dt;", "test_mv1")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t3 where (dt>'2020-06-15' and dt <= '2020-06-22') or dt>'2020-07-01' GROUP BY dt;", "test_mv1")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t3 where date_trunc('month', dt) ='2020-07-01' GROUP BY dt;", "test_mv1")
+
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t3 where dt between '2020-06-15' and '2020-07-01' GROUP BY dt;", "test_mv1", "UNION")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t3 where dt>='2020-06-15' GROUP BY dt;", "test_mv1", "UNION")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t3 where dt in ('2020-06-15', '2020-06-21', '2020-07-25') GROUP BY dt;", "test_mv1", "UNION")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t3 where date_trunc('month', dt) ='2020-06-01' GROUP BY dt;", "test_mv1", "UNION")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t3 GROUP BY dt;", "test_mv1", "UNION")
+
+
+SELECT dt,sum(num) FROM t3 where dt='2020-06-15' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM t3 where dt !='2020-06-15' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM t3 where dt>='2020-06-15' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM t3 where dt>'2020-06-15' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM t3 where dt>'2020-06-15' and dt < '2020-07-22' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM t3 where dt>'2020-06-15' and dt <= '2020-07-22' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM t3 where (dt>'2020-06-15' and dt <= '2020-06-22') or dt>'2020-07-01' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM t3 where dt in ('2020-06-15', '2020-06-22', '2020-07-01') GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM t3 where date_trunc('day', dt) ='2020-06-15' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM t3 where date_trunc('month', dt) ='2020-06-01' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM t3 where date_trunc('month', dt) ='2020-07-01' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM t3 where dt between '2020-06-15' and '2020-07-01' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM t3 GROUP BY dt order by dt;
+
+drop materialized view default_catalog.db_${uuid0}.test_mv1;
+
+-- Test partition compensate with partition expression
+-- TODO: Remove dt(extra column) later.
+CREATE MATERIALIZED VIEW test_mv1 
+PARTITION BY date_trunc('day', dt)
+REFRESH DEFERRED MANUAL AS 
+  SELECT dt, sum(num) FROM t3 GROUP BY dt;
+REFRESH MATERIALIZED VIEW test_mv1 WITH SYNC MODE;
+
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t3 where dt='2020-06-15' GROUP BY dt;", "test_mv1")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t3 where dt !='2020-06-15' GROUP BY dt;", "test_mv1")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t3 where dt>='2020-06-15' GROUP BY dt;", "test_mv1")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t3 where dt>'2020-06-15' GROUP BY dt;", "test_mv1")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t3 where dt>'2020-06-15' and dt < '2020-07-22' GROUP BY dt;", "test_mv1")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t3 where dt>'2020-06-15' and dt <= '2020-07-22' GROUP BY dt;", "test_mv1")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t3 where (dt>'2020-06-15' and dt <= '2020-06-22') or dt>'2020-07-01' GROUP BY dt;", "test_mv1")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t3 where dt in ('2020-06-15', '2020-06-22', '2020-07-01') GROUP BY dt;", "test_mv1")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t3 where date_trunc('day', dt) ='2020-06-15' GROUP BY dt;", "test_mv1")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t3 where date_trunc('month', dt) ='2020-06-01' GROUP BY dt;", "test_mv1")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t3 where date_trunc('month', dt) ='2020-07-01' GROUP BY dt;", "test_mv1")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t3 GROUP BY dt;", "test_mv1")
+
+SELECT dt,sum(num) FROM t3 where dt='2020-06-15' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM t3 where dt !='2020-06-15' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM t3 where dt>='2020-06-15' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM t3 where dt>'2020-06-15' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM t3 where dt>'2020-06-15' and dt < '2020-07-22' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM t3 where dt>'2020-06-15' and dt <= '2020-07-22' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM t3 where (dt>'2020-06-15' and dt <= '2020-06-22') or dt>'2020-07-01' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM t3 where dt in ('2020-06-15', '2020-06-22', '2020-07-01') GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM t3 where date_trunc('day', dt) ='2020-06-15' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM t3 where date_trunc('month', dt) ='2020-06-01' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM t3 where date_trunc('month', dt) ='2020-07-01' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM t3 GROUP BY dt order by dt;
+
+-- union rewrite
+INSERT INTO t3 VALUES (3, "2020-06-15");
+function: check_no_hit_materialized_view("SELECT dt,sum(num) FROM t3 where dt='2020-06-15' GROUP BY dt;", "test_mv1")
+function: check_no_hit_materialized_view("SELECT dt,sum(num) FROM t3 where date_trunc('day', dt) ='2020-06-15' GROUP BY dt;", "test_mv1")
+function: check_no_hit_materialized_view("SELECT dt,sum(num) FROM t3 where dt in ('2020-06-15', '2020-06-22', '2020-07-01') GROUP BY dt;", "test_mv1")
+
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t3 where date_trunc('day', dt) ='2020-06-21' GROUP BY dt;", "test_mv1")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t3 where dt !='2020-06-15' GROUP BY dt;", "test_mv1")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t3 where dt>'2020-06-15' GROUP BY dt;", "test_mv1")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t3 where dt>'2020-06-15' and dt < '2020-07-22' GROUP BY dt;", "test_mv1")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t3 where dt>'2020-06-15' and dt <= '2020-07-22' GROUP BY dt;", "test_mv1")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t3 where (dt>'2020-06-15' and dt <= '2020-06-22') or dt>'2020-07-01' GROUP BY dt;", "test_mv1")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t3 where date_trunc('month', dt) ='2020-07-01' GROUP BY dt;", "test_mv1")
+
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t3 where dt between '2020-06-15' and '2020-07-01' GROUP BY dt;", "test_mv1", "UNION")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t3 where dt>='2020-06-15' GROUP BY dt;", "test_mv1", "UNION")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t3 where dt in ('2020-06-15', '2020-06-21', '2020-07-25') GROUP BY dt;", "test_mv1", "UNION")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t3 where date_trunc('month', dt) ='2020-06-01' GROUP BY dt;", "test_mv1", "UNION")
+function: check_hit_materialized_view("SELECT dt,sum(num) FROM t3 GROUP BY dt;", "test_mv1", "UNION")
+
+
+SELECT dt,sum(num) FROM t3 where dt='2020-06-15' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM t3 where dt !='2020-06-15' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM t3 where dt>='2020-06-15' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM t3 where dt>'2020-06-15' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM t3 where dt>'2020-06-15' and dt < '2020-07-22' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM t3 where dt>'2020-06-15' and dt <= '2020-07-22' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM t3 where (dt>'2020-06-15' and dt <= '2020-06-22') or dt>'2020-07-01' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM t3 where dt in ('2020-06-15', '2020-06-22', '2020-07-01') GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM t3 where date_trunc('day', dt) ='2020-06-15' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM t3 where date_trunc('month', dt) ='2020-06-01' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM t3 where date_trunc('month', dt) ='2020-07-01' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM t3 where dt between '2020-06-15' and '2020-07-01' GROUP BY dt order by dt;
+SELECT dt,sum(num) FROM t3 GROUP BY dt order by dt;
+
+drop materialized view default_catalog.db_${uuid0}.test_mv1;
+
+drop table t1 force;
+drop table t2 force;
+drop table t3 force;


### PR DESCRIPTION
## Why I'm doing:

 If predicates are partition predicates(eg, query refreshed partitions and to-refresh partitions), we can use treat mv as a
 transparent table(freshness is always satisfied) and rewrite by union all.
 ```
 MV   : select * from t, but only refreshed partitions(dt = '2023-11-01')
 Query: select col1, col2 from t where dt in ('2023-11-01', '2023-11-02')
 ```
 In this case we can not use other modes to rewrite, since query cannot be rewritten by mv's define query(query only selects
 partial columns and mv's partial refreshed).
 
 If we treat mv as complete refreshed, we can rewrite it.

 ```
 Transparent MV: select * from t(all partition refreshed)

 Query: select col1, col2 from t where dt in ('2023-11-01', '2023-11-02')

 Query Rewritten: select col1, col2 from <Transparent MV> where dt in ('2023-11-01', '2023-11-02')

 Transparent MV = Refreshed MV Partitions union all To-Refresh MV Partitions
                             = select * from mv union all select * from mv where dt = '2023-11-02'
 ```
 so the final Query Rewritten:
```
 Query Rewritten: select col1, col2 from <Transparent MV> where dt in ('2023-11-01', '2023-11-02')
       = select col1, col2 from (select * from mv union all select * from mv where dt = '2023-11-02') where dt in ('2023-11-01', '2023-11-02')
       = select col1, col2 from mv union all select col1, col2 from t where dt = '2023-11-02'
```

## What I'm doing:
- Support Transparent union all rewrite, treat mv as a transparent table(freshness is always satisfied) and rewrite by union all.

```html

 MVUnionRewriteMode is used to store union rewrite mode for materialized view union.
 The mode is used to control the union rewrite behavior:

 <p>Default mode</p>
 Query = MV + (Query - MV)
 Query - MV = not(Query Based MV Rewrite Compensation)
 eg:
  query: select * from t where a > 10
  mv : select * from t where a > 20

 Because MV = (Query) where a > 20
 Query Based MV Rewrite Compensation: a > 20
 Query - MV = not (Query Based MV Rewrite Compensation) and Query's predicates
            = not (a > 20) and a > 10
            = (a <= 20 or a is null) and a > 10
            = 10 < a <= 20

 Query = MV + (Query - MV)
       = MVBasedRewrite + QueryBasedRewrite(not mv to query compensation)
       = (select * from t where a > 10) union all (select * from t where 10 < a <= 20)
       = MV + (select * from t where 10 < a <= 20)

 <p>Pull Predicate V1 </p>
 Default mode needs query can be used for rewrite for mv's define query which is not always satisfied.
 But we can pull up some predicates to increase the ability of union rewrite.

 eg:
 Query: select dt, k1, k2 from tblA where dt >= '2023-11-01' and k2 > 1
  MV  : select dt, k2 from tblA where dt = '2023-11-01'

 At default mode, query cannot be rewritten by mv's define query, but if we pull up some predicates to Query' and then
 it will be rewritten for mv.

  Query': select dt, k1, k2 from tblA where dt >= '2023-11-01
  MV  : select dt, k2 from tblA where dt = '2023-11-01'
  PullUp Query: Query' where k2 > 1

 So Query' can be rewritten by mv's define query, only need add extra predicates after rewrite.

 <p>Pull Predicate V2 </p>
 Pull Predicate V1 only pull predicates that are not contained in MV's define query, but v2 can pull up all predicates
 Query: select dt, k2 from tblA where date_trunc('day', dt) >= '2023-11-01'
 Mv   : select dt, k2 from tblA where dt = '2023-11-01'

 Query':  select dt, k2 from tblA
 Pull up Query: Query' where date_trunc('day', dt) >= '2023-11-01'

<p> Transparent Union Rewrite </p>
 If predicates are partition predicates(eg, query refreshed partitions and to-refresh partitions), we can use treat mv as a
 transparent table(freshness is always satisfied) and rewrite by union all.

 MV   : select * from t, but only refreshed partitions(dt = '2023-11-01')
 Query: select col1, col2 from t where dt in ('2023-11-01', '2023-11-02')

 In this case we can not use other modes to rewrite, since query cannot be rewritten by mv's define query(query only selects
 partial columns and mv's partial refreshed).

 If we treat mv as complete refreshed, we can rewrite it.

 Transparent MV: select * from t(all partition refreshed)
 Query: select col1, col2 from t where dt in ('2023-11-01', '2023-11-02')
 Query Rewritten: select col1, col2 from <Transparent MV> where dt in ('2023-11-01', '2023-11-02')
 Transparent MV = Refreshed MV Partitions union all To-Refresh MV Partitions
 = select * from mv union all select * from mv where dt = '2023-11-02'

 so the final Query Rewritten:
 Query Rewritten: select col1, col2 from <Transparent MV> where dt in ('2023-11-01', '2023-11-02')
 = select col1, col2 from (select * from mv union all select * from mv where dt = '2023-11-02')
  where dt in ('2023-11-01', '2023-11-02')
 = select col1, col2 from mv union all select col1, col2 from t where dt = '2023-11-02'

 <p>Enum</p>
  default: default mode, only try to union all rewrite by logical plan tree after partition compensate
  1: pull predicate v1, try to pull up query's filter after union when query's output matches mv's define query
      which will increase union rewrite's ability, and then use query to rewrite mv's define query.
  2: pull predicate v2, try to pull up query's filter after union as much as possible.
  3: transparent union all rewrite, treat mv as a transparent table(freshness is always satisfied) and rewrite by union all.

```
Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
