### PR TITLE
[Enhancement] Reduce txn log writes and deletes

### DIFF
--- a/be/src/common/statusor.h
+++ b/be/src/common/statusor.h
@@ -703,6 +703,11 @@ void StatusOr<T>::IgnoreError() const {
     // no-op
 }
 
+template <typename T>
+inline std::ostream& operator<<(std::ostream& os, const StatusOr<T>& st) {
+    return os << st.status();
+}
+
 #define ASSIGN_OR_RETURN_IMPL(varname, lhs, rhs) \
     auto&& varname = (rhs);                      \
     RETURN_IF_ERROR(varname);                    \

--- a/be/src/exec/CMakeLists.txt
+++ b/be/src/exec/CMakeLists.txt
@@ -36,6 +36,7 @@ set(EXEC_FILES
     tablet_sink_colocate_sender.cpp
     tablet_sink_index_channel.cpp
     tablet_sink_sender.cpp
+    write_combined_txn_log.cpp
     mysql_scanner.cpp
     es/es_predicate.cpp
     es/es_scan_reader.cpp

--- a/be/src/exec/tablet_info.h
+++ b/be/src/exec/tablet_info.h
@@ -236,6 +236,8 @@ public:
 
     bool is_un_partitioned() const { return _partition_columns.empty(); }
 
+    const TOlapTablePartitionParam& param() const { return _t_param; }
+
 private:
     Status _create_partition_keys(const std::vector<TExprNode>& t_exprs, ChunkRow* part_key);
 

--- a/be/src/exec/tablet_sink.cpp
+++ b/be/src/exec/tablet_sink.cpp
@@ -98,6 +98,7 @@ Status OlapTableSink::init(const TDataSink& t_sink, RuntimeState* state) {
     _need_gen_rollup = table_sink.need_gen_rollup;
     _tuple_desc_id = table_sink.tuple_id;
     _is_lake_table = table_sink.is_lake_table;
+    _write_txn_log = table_sink.write_txn_log;
     _keys_type = table_sink.keys_type;
     if (table_sink.__isset.null_expr_in_auto_increment) {
         _null_expr_in_auto_increment = table_sink.null_expr_in_auto_increment;
@@ -199,6 +200,9 @@ Status OlapTableSink::prepare(RuntimeState* state) {
 
     _sender_id = state->per_fragment_instance_idx();
     _num_senders = state->num_per_fragment_instances();
+    if (UNLIKELY(_write_txn_log && _num_senders > 1)) {
+        return Status::NotSupported("This data loading task has multiple senders and does not support merge txn logs");
+    }
 
     // Prepare the exprs to run.
     RETURN_IF_ERROR(Expr::prepare(_output_expr_ctxs, state));
@@ -827,7 +831,7 @@ Status OlapTableSink::close_wait(RuntimeState* state, Status close_status) {
     if (_tablet_sink_sender == nullptr) {
         return close_status;
     }
-    Status status = _tablet_sink_sender->close_wait(state, close_status, _ts_profile);
+    Status status = _tablet_sink_sender->close_wait(state, close_status, _ts_profile, _write_txn_log);
     if (!status.ok()) {
         _span->SetStatus(trace::StatusCode::kError, std::string(status.message()));
     }

--- a/be/src/exec/tablet_sink.h
+++ b/be/src/exec/tablet_sink.h
@@ -176,6 +176,7 @@ private:
     int _sender_id = -1;
     int _num_senders = -1;
     bool _is_lake_table = false;
+    bool _write_txn_log = false;
 
     TKeysType::type _keys_type;
 

--- a/be/src/exec/tablet_sink_colocate_sender.cpp
+++ b/be/src/exec/tablet_sink_colocate_sender.cpp
@@ -148,7 +148,7 @@ Status TabletSinkColocateSender::try_open(RuntimeState* state) {
     }
     // Prepare the exprs to run.
     RETURN_IF_ERROR(Expr::open(_output_expr_ctxs, state));
-    RETURN_IF_ERROR(_vectorized_partition->open(state));
+    RETURN_IF_ERROR(_partition_params->open(state));
     for_each_node_channel([](NodeChannel* ch) { ch->try_open(); });
     return Status::OK();
 }
@@ -244,9 +244,10 @@ bool TabletSinkColocateSender::is_close_done() {
     return _close_done;
 }
 
-Status TabletSinkColocateSender::close_wait(RuntimeState* state, Status close_status, TabletSinkProfile* ts_profile) {
+Status TabletSinkColocateSender::close_wait(RuntimeState* state, Status close_status, TabletSinkProfile* ts_profile,
+                                            bool write_txn_log) {
     if (UNLIKELY(!_colocate_mv_index)) {
-        return TabletSinkColocateSender::close_wait(state, close_status, ts_profile);
+        return TabletSinkColocateSender::close_wait(state, close_status, ts_profile, write_txn_log);
     }
     Status status = std::move(close_status);
     if (status.ok()) {
@@ -273,7 +274,15 @@ Status TabletSinkColocateSender::close_wait(RuntimeState* state, Status close_st
                 status = err_st;
                 for_each_node_channel([&status](NodeChannel* ch) { ch->cancel(status); });
             }
-
+            if (status.ok() && write_txn_log) {
+                auto merge_txn_log = [this](NodeChannel* channel) {
+                    for (auto& log : channel->txn_logs()) {
+                        _txn_log_map[log.partition_id()].add_txn_logs()->Swap(&log);
+                    }
+                };
+                for_each_node_channel(merge_txn_log);
+                status.update(_write_combined_txn_log());
+            }
             // only if status is ok can we call this _profile->total_time_counter().
             // if status is not ok, this sink may not be prepared, so that _profile is null
             SCOPED_TIMER(ts_profile->runtime_profile->total_time_counter());
@@ -303,8 +312,8 @@ Status TabletSinkColocateSender::close_wait(RuntimeState* state, Status close_st
     }
 
     Expr::close(_output_expr_ctxs, state);
-    if (_vectorized_partition) {
-        _vectorized_partition->close(state);
+    if (_partition_params) {
+        _partition_params->close(state);
     }
     return status;
 }

--- a/be/src/exec/tablet_sink_colocate_sender.h
+++ b/be/src/exec/tablet_sink_colocate_sender.h
@@ -27,7 +27,7 @@ public:
                              std::vector<ExprContext*> output_expr_ctxs, bool enable_replicated_storage,
                              TWriteQuorumType::type write_quorum_type, int num_repicas);
 
-    ~TabletSinkColocateSender() = default;
+    ~TabletSinkColocateSender() override = default;
 
 public:
     Status send_chunk(const OlapTableSchemaParam* schema, const std::vector<OlapTablePartition*>& partitions,
@@ -40,7 +40,8 @@ public:
     // if is_close_done() return true, close_wait() will not block
     // otherwise close_wait() will block
     Status try_close(RuntimeState* state) override;
-    Status close_wait(RuntimeState* state, Status close_status, TabletSinkProfile* ts_profile) override;
+    Status close_wait(RuntimeState* state, Status close_status, TabletSinkProfile* ts_profile,
+                      bool write_txn_log) override;
 
     bool is_open_done() override;
     bool is_full() override;

--- a/be/src/exec/tablet_sink_index_channel.cpp
+++ b/be/src/exec/tablet_sink_index_channel.cpp
@@ -15,18 +15,14 @@
 #include "exec/tablet_sink_index_channel.h"
 
 #include "column/chunk.h"
-#include "column/column_helper.h"
 #include "column/column_viewer.h"
 #include "column/nullable_column.h"
 #include "common/statusor.h"
-#include "config.h"
 #include "exec/tablet_sink.h"
 #include "exprs/expr_context.h"
 #include "gutil/strings/fastmem.h"
 #include "gutil/strings/join.h"
-#include "gutil/strings/substitute.h"
 #include "runtime/current_thread.h"
-#include "runtime/exec_env.h"
 #include "runtime/runtime_state.h"
 #include "serde/protobuf_serde.h"
 #include "util/brpc_stub_cache.h"
@@ -170,6 +166,11 @@ void NodeChannel::_open(int64_t index_id, RefCountClosure<PTabletWriterOpenResul
     request.set_txn_trace_parent(_parent->_txn_trace_parent);
     request.set_allocated_schema(_parent->_schema->to_protobuf());
     request.set_is_lake_tablet(_parent->_is_lake_table);
+    if (_parent->_is_lake_table) {
+        // If the OlapTableSink node is responsible for writing the txn log, then the tablet writer
+        // does not need to write the txn log again.
+        request.mutable_lake_tablet_params()->set_write_txn_log(!_parent->_write_txn_log);
+    }
     request.set_is_replicated_storage(_parent->_enable_replicated_storage);
     request.set_node_id(_node_id);
     request.set_write_quorum(_write_quorum_type);
@@ -751,6 +752,9 @@ Status NodeChannel::_wait_request(ReusableClosure<PTabletWriterAddBatchResult>* 
         if (tablet_ids.size() < 128) {
             tablet_ids.emplace_back(commit_info.tabletId);
         }
+    }
+    for (auto& log : *(closure->result.mutable_lake_tablet_data()->mutable_txn_logs())) {
+        _txn_logs.emplace_back(std::move(log));
     }
 
     if (!tablet_ids.empty()) {

--- a/be/src/exec/tablet_sink_index_channel.h
+++ b/be/src/exec/tablet_sink_index_channel.h
@@ -41,6 +41,7 @@ namespace starrocks {
 
 class MemTracker;
 class TupleDescriptor;
+class TxnLogPB;
 
 namespace stream_load {
 
@@ -157,6 +158,7 @@ public:
     std::string print_load_info() const { return _load_info; }
     std::string name() const { return _name; }
     bool enable_colocate_mv_index() const { return _enable_colocate_mv_index; }
+    std::vector<TxnLogPB>& txn_logs() { return _txn_logs; }
 
     bool is_incremental() const { return _is_incremental; }
 
@@ -220,6 +222,7 @@ private:
 
     std::vector<TTabletCommitInfo> _tablet_commit_infos;
     std::vector<TTabletFailInfo> _tablet_fail_infos;
+    std::vector<TxnLogPB> _txn_logs;
     struct {
         std::unordered_set<std::string> invalid_dict_cache_column_set;
         std::unordered_map<std::string, int64_t> valid_dict_cache_column_set;

--- a/be/src/exec/tablet_sink_sender.cpp
+++ b/be/src/exec/tablet_sink_sender.cpp
@@ -15,22 +15,22 @@
 #include "exec/tablet_sink_sender.h"
 
 #include "column/chunk.h"
-#include "column/column_helper.h"
 #include "common/statusor.h"
+#include "exec/write_combined_txn_log.h"
 #include "exprs/expr.h"
 #include "runtime/runtime_state.h"
 
 namespace starrocks::stream_load {
 
 TabletSinkSender::TabletSinkSender(PUniqueId load_id, int64_t txn_id, IndexIdToTabletBEMap index_id_to_tablet_be_map,
-                                   OlapTablePartitionParam* vectorized_partition, std::vector<IndexChannel*> channels,
+                                   OlapTablePartitionParam* partition_params, std::vector<IndexChannel*> channels,
                                    std::unordered_map<int64_t, NodeChannel*> node_channels,
                                    std::vector<ExprContext*> output_expr_ctxs, bool enable_replicated_storage,
                                    TWriteQuorumType::type write_quorum_type, int num_repicas)
         : _load_id(load_id),
           _txn_id(txn_id),
           _index_id_to_tablet_be_map(std::move(index_id_to_tablet_be_map)),
-          _vectorized_partition(vectorized_partition),
+          _partition_params(partition_params),
           _channels(std::move(channels)),
           _node_channels(std::move(node_channels)),
           _output_expr_ctxs(std::move(output_expr_ctxs)),
@@ -137,7 +137,7 @@ Status TabletSinkSender::_send_chunk_by_node(Chunk* chunk, IndexChannel* channel
 Status TabletSinkSender::try_open(RuntimeState* state) {
     // Prepare the exprs to run.
     RETURN_IF_ERROR(Expr::open(_output_expr_ctxs, state));
-    RETURN_IF_ERROR(_vectorized_partition->open(state));
+    RETURN_IF_ERROR(_partition_params->open(state));
     for_each_index_channel([](NodeChannel* ch) { ch->try_open(); });
     return Status::OK();
 }
@@ -278,7 +278,8 @@ bool TabletSinkSender::is_close_done() {
     return _close_done;
 }
 
-Status TabletSinkSender::close_wait(RuntimeState* state, Status close_status, TabletSinkProfile* ts_profile) {
+Status TabletSinkSender::close_wait(RuntimeState* state, Status close_status, TabletSinkProfile* ts_profile,
+                                    bool write_txn_log) {
     Status status = std::move(close_status);
     if (status.ok()) {
         // BE id -> add_batch method counter
@@ -308,6 +309,19 @@ Status TabletSinkSender::close_wait(RuntimeState* state, Status close_status, Ta
                 }
             }
         }
+        if (status.ok() && write_txn_log) {
+            auto merge_txn_log = [this](NodeChannel* channel) {
+                for (auto& log : channel->txn_logs()) {
+                    _txn_log_map[log.partition_id()].add_txn_logs()->Swap(&log);
+                }
+            };
+
+            for (auto& index_channel : _channels) {
+                index_channel->for_each_node_channel(merge_txn_log);
+            }
+
+            status.update(_write_combined_txn_log());
+        }
 
         // only if status is ok can we call this _profile->total_time_counter().
         // if status is not ok, this sink may not be prepared, so that _profile is null
@@ -335,8 +349,8 @@ Status TabletSinkSender::close_wait(RuntimeState* state, Status close_status, Ta
     }
 
     Expr::close(_output_expr_ctxs, state);
-    if (_vectorized_partition) {
-        _vectorized_partition->close(state);
+    if (_partition_params) {
+        _partition_params->close(state);
     }
     return status;
 }
@@ -351,6 +365,14 @@ bool TabletSinkSender::get_immutable_partition_ids(std::set<int64_t>* partition_
         }
     });
     return has_immutable_partition;
+}
+
+Status TabletSinkSender::_write_combined_txn_log() {
+    for (const auto& [partition_id, logs] : _txn_log_map) {
+        (void)partition_id;
+        RETURN_IF_ERROR(write_combined_txn_log(logs));
+    }
+    return Status::OK();
 }
 
 } // namespace starrocks::stream_load

--- a/be/src/exec/tablet_sink_sender.h
+++ b/be/src/exec/tablet_sink_sender.h
@@ -16,6 +16,10 @@
 
 #include "exec/tablet_sink_index_channel.h"
 
+namespace starrocks {
+class CombinedTxnLogPB;
+} // namespace starrocks
+
 namespace starrocks::stream_load {
 // TabletSinkSender will control one index/table's send chunks.
 class TabletSinkSender {
@@ -40,7 +44,8 @@ public:
     // if is_close_done() return true, close_wait() will not block
     // otherwise close_wait() will block
     virtual Status try_close(RuntimeState* state);
-    virtual Status close_wait(RuntimeState* state, Status close_status, TabletSinkProfile* ts_profile);
+    virtual Status close_wait(RuntimeState* state, Status close_status, TabletSinkProfile* ts_profile,
+                              bool write_txn_log);
 
     virtual bool is_open_done();
     virtual bool is_full();
@@ -65,7 +70,7 @@ public:
 
 protected:
     Status _send_chunk_by_node(Chunk* chunk, IndexChannel* channel, const std::vector<uint16_t>& selection_idx);
-
+    Status _write_combined_txn_log();
     void _mark_as_failed(const NodeChannel* ch) { _failed_channels.insert(ch->node_id()); }
     bool _is_failed_channel(const NodeChannel* ch) { return _failed_channels.count(ch->node_id()) != 0; }
     bool _has_intolerable_failure() {
@@ -85,7 +90,7 @@ protected:
     // index_id -> (tablet_id -> bes) map
     IndexIdToTabletBEMap _index_id_to_tablet_be_map;
     // partition schema
-    OlapTablePartitionParam* _vectorized_partition = nullptr;
+    OlapTablePartitionParam* _partition_params = nullptr;
     // index_channel
     std::vector<IndexChannel*> _channels;
     std::unordered_map<int64_t, NodeChannel*> _node_channels;
@@ -100,6 +105,8 @@ protected:
     std::vector<uint32_t> _node_select_idx;
     std::vector<int64_t> _tablet_ids;
     std::set<int64_t> _failed_channels;
+    // mapping from partition id to CombinedTxnLogPB
+    std::map<int64_t, CombinedTxnLogPB> _txn_log_map;
 };
 
 } // namespace starrocks::stream_load

--- a/be/src/exec/write_combined_txn_log.cpp
+++ b/be/src/exec/write_combined_txn_log.cpp
@@ -12,18 +12,16 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#pragma once
+#include "exec/write_combined_txn_log.h"
 
-#include <memory>
+#include "runtime/exec_env.h"
+#include "storage/lake/tablet_manager.h"
 
-#include "gen_cpp/lake_types.pb.h"
+namespace starrocks::stream_load {
 
-namespace starrocks {
+Status write_combined_txn_log(const CombinedTxnLogPB& logs) {
+    auto tablet_mgr = ExecEnv::GetInstance()->lake_tablet_manager();
+    return tablet_mgr->put_combined_txn_log(logs);
+}
 
-using TxnLog = TxnLogPB;
-using TxnLogPtr = std::shared_ptr<const TxnLog>;
-using MutableTxnLogPtr = std::shared_ptr<TxnLog>;
-using CombinedTxnLog = CombinedTxnLogPB;
-using CombinedTxnLogPtr = std::shared_ptr<const CombinedTxnLog>;
-
-} // namespace starrocks
+} // namespace starrocks::stream_load

--- a/be/src/exec/write_combined_txn_log.h
+++ b/be/src/exec/write_combined_txn_log.h
@@ -14,16 +14,14 @@
 
 #pragma once
 
-#include <memory>
-
-#include "gen_cpp/lake_types.pb.h"
+#include "common/status.h"
 
 namespace starrocks {
+class CombinedTxnLogPB;
+}
 
-using TxnLog = TxnLogPB;
-using TxnLogPtr = std::shared_ptr<const TxnLog>;
-using MutableTxnLogPtr = std::shared_ptr<TxnLog>;
-using CombinedTxnLog = CombinedTxnLogPB;
-using CombinedTxnLogPtr = std::shared_ptr<const CombinedTxnLog>;
+namespace starrocks::stream_load {
 
-} // namespace starrocks
+Status write_combined_txn_log(const CombinedTxnLogPB& logs);
+
+}

--- a/be/src/gutil/strings/join.h
+++ b/be/src/gutil/strings/join.h
@@ -168,7 +168,7 @@ inline string JoinStrings(const CONTAINER& components, const StringPiece& delim)
 template <class CONTAINER, typename FUNC>
 string JoinMapped(const CONTAINER& components, const FUNC& functor, const StringPiece& delim) {
     string result;
-    for (typename CONTAINER::const_iterator iter = components.begin(); iter != components.end(); iter++) {
+    for (auto iter = components.begin(); iter != components.end(); iter++) {
         if (iter != components.begin()) {
             result.append(delim.data(), delim.size());
         }

--- a/be/src/runtime/lake_tablets_channel.cpp
+++ b/be/src/runtime/lake_tablets_channel.cpp
@@ -37,6 +37,7 @@
 #include "serde/protobuf_serde.h"
 #include "service/backend_options.h"
 #include "storage/lake/async_delta_writer.h"
+#include "storage/lake/delta_writer_finish_mode.h"
 #include "storage/memtable.h"
 #include "storage/memtable_flush_executor.h"
 #include "storage/storage_engine.h"
@@ -54,6 +55,7 @@ class TabletManager;
 
 class LakeTabletsChannel : public TabletsChannel {
     using AsyncDeltaWriter = lake::AsyncDeltaWriter;
+    using TxnLogPtr = AsyncDeltaWriter::TxnLogPtr;
 
 public:
     LakeTabletsChannel(LoadChannel* load_channel, lake::TabletManager* tablet_manager, const TabletsChannelKey& key,
@@ -119,6 +121,11 @@ private:
             info->set_schema_hash(0); // required field
         }
 
+        void add_txn_log(const TxnLogPtr& txn_log) {
+            std::lock_guard l(_mtx);
+            _response->mutable_lake_tablet_data()->add_txn_logs()->CopyFrom(*txn_log);
+        }
+
     private:
         friend class LakeTabletsChannel;
 
@@ -178,6 +185,7 @@ private:
     GlobalDictByNameMaps _global_dicts;
     std::unique_ptr<MemPool> _mem_pool;
     bool _is_incremental_channel{false};
+    lake::DeltaWriterFinishMode _finish_mode{lake::DeltaWriterFinishMode::kWriteTxnLog};
 
     std::set<int64_t> _immutable_partition_ids;
 
@@ -233,6 +241,10 @@ Status LakeTabletsChannel::open(const PTabletWriterOpenRequest& params, PTabletW
     _index_id = params.index_id();
     _schema = schema;
     _is_incremental_channel = is_incremental;
+    if (params.has_lake_tablet_params() && params.lake_tablet_params().has_write_txn_log()) {
+        _finish_mode = params.lake_tablet_params().write_txn_log() ? lake::DeltaWriterFinishMode::kWriteTxnLog
+                                                                   : lake::DeltaWriterFinishMode::kDontWriteTxnLog;
+    }
 
     _senders = std::vector<Sender>(params.num_senders());
     if (_is_incremental_channel) {
@@ -399,13 +411,19 @@ void LakeTabletsChannel::add_chunk(Chunk* chunk, const PTabletWriterAddChunkRequ
                     count_down_latch.count_down();
                     continue;
                 }
-                dw->finish([&, id = tablet_id](const Status& st) {
-                    if (st.ok()) {
+                dw->finish(_finish_mode, [&, id = tablet_id](StatusOr<TxnLogPtr> res) {
+                    if (!res.ok()) {
+                        context->update_status(res.status());
+                        LOG(ERROR) << "Fail to finish tablet " << id << ": " << res.status();
+                    } else if (_finish_mode == lake::DeltaWriterFinishMode::kWriteTxnLog) {
                         context->add_finished_tablet(id);
                         VLOG(5) << "Finished tablet " << id;
+                    } else if (_finish_mode == lake::DeltaWriterFinishMode::kDontWriteTxnLog) {
+                        context->add_finished_tablet(id);
+                        context->add_txn_log(res.value());
+                        VLOG(5) << "Finished tablet " << id;
                     } else {
-                        context->update_status(st);
-                        LOG(ERROR) << "Fail to finish tablet " << id << ": " << st;
+                        CHECK(false) << "Unhandled finish mode: " << _finish_mode;
                     }
                     count_down_latch.count_down();
                 });

--- a/be/src/service/service_be/lake_service.cpp
+++ b/be/src/service/service_be/lake_service.cpp
@@ -119,6 +119,10 @@ bvar::PassiveStatus<int> g_publish_version_active_tasks("lake_publish_version_ac
 bvar::PassiveStatus<int> g_vacuum_queued_tasks("lake_vacuum_queued_tasks", get_num_vacuum_queued_tasks, nullptr);
 bvar::PassiveStatus<int> g_vacuum_active_tasks("lake_vacuum_active_tasks", get_num_vacuum_active_tasks, nullptr);
 
+std::string txn_info_string(const TxnInfoPB& info) {
+    return info.DebugString();
+}
+
 } // namespace
 
 using BThreadCountDownLatch = GenericCountDownLatch<bthread::Mutex, bthread::ConditionVariable>;
@@ -142,8 +146,8 @@ void LakeServiceImpl::publish_version(::google::protobuf::RpcController* control
         cntl->SetFailed("missing new version");
         return;
     }
-    if (request->txn_ids_size() == 0) {
-        cntl->SetFailed("missing txn_ids");
+    if (request->txn_ids_size() == 0 && request->txn_infos_size() == 0) {
+        cntl->SetFailed("missing txn_ids and txn_infos");
         return;
     }
     if (request->tablet_ids_size() == 0) {
@@ -155,6 +159,7 @@ void LakeServiceImpl::publish_version(::google::protobuf::RpcController* control
     auto timeout_deadline = std::chrono::system_clock::now() + std::chrono::milliseconds(timeout_ms);
     auto start_ts = butil::gettimeofday_us();
     auto thread_pool = publish_version_thread_pool(_env);
+    CHECK(thread_pool != nullptr);
     auto thread_pool_token = ConcurrencyLimitedThreadPoolToken(thread_pool, thread_pool->max_threads() * 2);
     auto latch = BThreadCountDownLatch(request->tablet_ids_size());
     bthread::Mutex response_mtx;
@@ -176,19 +181,32 @@ void LakeServiceImpl::publish_version(::google::protobuf::RpcController* control
             TRACE("start publish tablet $0 at thread $1", tablet_id, Thread::current_thread()->tid());
 
             auto run_ts = butil::gettimeofday_us();
-            auto base_version = request->base_version();
-            auto new_version = request->new_version();
-            auto txns = std::span<const int64_t>(request->txn_ids().data(), request->txn_ids_size());
-            auto commit_time = request->commit_time();
             auto queuing_latency = run_ts - start_ts;
             g_publish_tablet_version_queuing_latency << queuing_latency;
+
+            auto base_version = request->base_version();
+            auto new_version = request->new_version();
+            auto txns = std::vector<TxnInfoPB>();
+            if (request->txn_infos_size() > 0) {
+                txns.insert(txns.begin(), request->txn_infos().begin(), request->txn_infos().end());
+            } else { // This is a request from older version FE
+                // Construct TxnInfoPB from other fields
+                txns.reserve(request->txn_ids_size());
+                for (auto i = 0, sz = request->txn_ids_size(); i < sz; i++) {
+                    auto& info = txns.emplace_back();
+                    info.set_txn_id(request->txn_ids(i));
+                    info.set_txn_type(TXN_NORMAL);
+                    info.set_combined_txn_log(false);
+                    info.set_commit_time(request->commit_time());
+                }
+            }
 
             TRACE_COUNTER_INCREMENT("tablet_id", tablet_id);
             TRACE_COUNTER_INCREMENT("queuing_latency_us", queuing_latency);
 
             StatusOr<TabletMetadataPtr> res;
             if (std::chrono::system_clock::now() < timeout_deadline) {
-                res = lake::publish_version(_tablet_mgr, tablet_id, base_version, new_version, txns, commit_time);
+                res = lake::publish_version(_tablet_mgr, tablet_id, base_version, new_version, txns);
             } else {
                 auto t = MilliSecondsSinceEpochFromTimePoint(timeout_deadline);
                 res = Status::TimedOut(fmt::format("reached deadline={}/timeout={}", t, timeout_ms));
@@ -202,10 +220,10 @@ void LakeServiceImpl::publish_version(::google::protobuf::RpcController* control
                 g_publish_version_failed_tasks << 1;
                 if (res.status().is_resource_busy()) {
                     VLOG(2) << "Fail to publish version: " << res.status() << ". tablet_id=" << tablet_id
-                            << " txn_ids=" << JoinInts(txns, ",") << " version=" << new_version;
+                            << " txns=" << JoinMapped(txns, txn_info_string, ",") << " version=" << new_version;
                 } else {
                     LOG(WARNING) << "Fail to publish version: " << res.status() << ". tablet_id=" << tablet_id
-                                 << " txn_ids=" << JoinInts(txns, ",") << " version=" << new_version;
+                                 << " txn_ids=" << JoinMapped(txns, txn_info_string, ",") << " version=" << new_version;
                 }
                 std::lock_guard l(response_mtx);
                 response->add_failed_tablets(tablet_id);
@@ -242,9 +260,10 @@ void LakeServiceImpl::publish_version(::google::protobuf::RpcController* control
 }
 
 void LakeServiceImpl::_submit_publish_log_version_task(const int64_t* tablet_ids, size_t tablet_size,
-                                                       const int64_t* txn_ids, const int64_t* log_versions,
-                                                       size_t txn_size,
+                                                       std::span<const TxnInfoPB> txn_infos,
+                                                       const int64_t* log_versions,
                                                        ::starrocks::PublishLogVersionResponse* response) {
+    auto txn_size = txn_infos.size();
     auto thread_pool = publish_version_thread_pool(_env);
     auto latch = BThreadCountDownLatch(tablet_size);
     bthread::Mutex response_mtx;
@@ -253,11 +272,11 @@ void LakeServiceImpl::_submit_publish_log_version_task(const int64_t* tablet_ids
         auto tablet_id = tablet_ids[i];
         auto task = [&, tablet_id]() {
             DeferOp defer([&] { latch.count_down(); });
-            auto st = lake::publish_log_version(_tablet_mgr, tablet_id, txn_ids, log_versions, txn_size);
+            auto st = lake::publish_log_version(_tablet_mgr, tablet_id, txn_infos, log_versions);
             if (!st.ok()) {
                 g_publish_version_failed_tasks << 1;
                 LOG(WARNING) << "Fail to publish log version: " << st << " tablet_id=" << tablet_id
-                             << " txn_ids=" << JoinElementsIterator(txn_ids, txn_ids + txn_size, ",")
+                             << " txns=" << JoinMapped(txn_infos, txn_info_string, ",")
                              << " versions=" << JoinElementsIterator(log_versions, log_versions + txn_size, ",");
                 std::lock_guard l(response_mtx);
                 response->add_failed_tablets(tablet_id);
@@ -267,10 +286,9 @@ void LakeServiceImpl::_submit_publish_log_version_task(const int64_t* tablet_ids
         auto st = thread_pool->submit_func(task);
         if (!st.ok()) {
             g_publish_version_failed_tasks << 1;
-            LOG(WARNING) << "Fail to submit publish log version task, tablet_id: " << tablet_id
-                         << ", txn_ids: " << JoinElementsIterator(txn_ids, txn_ids + txn_size, ",")
-                         << ", versions: " << JoinElementsIterator(log_versions, log_versions + txn_size, ",")
-                         << ", error" << st;
+            LOG(WARNING) << "Fail to submit publish log version task: " << st << " tablet_id=" << tablet_id
+                         << " txns=" << JoinMapped(txn_infos, txn_info_string, ",")
+                         << " versions=" << JoinElementsIterator(log_versions, log_versions + txn_size, ",");
             std::lock_guard l(response_mtx);
             response->add_failed_tablets(tablet_id);
             latch.count_down();
@@ -290,8 +308,8 @@ void LakeServiceImpl::publish_log_version(::google::protobuf::RpcController* con
         cntl->SetFailed("missing tablet_ids");
         return;
     }
-    if (!request->has_txn_id()) {
-        cntl->SetFailed("missing txn_id");
+    if (!request->has_txn_id() && !request->has_txn_info()) {
+        cntl->SetFailed("missing txn_id and txn_info");
         return;
     }
     if (!request->has_version()) {
@@ -300,10 +318,19 @@ void LakeServiceImpl::publish_log_version(::google::protobuf::RpcController* con
     }
 
     auto tablet_ids = request->tablet_ids().data();
-    int64_t txn_id = request->txn_id();
-    int64_t version = request->version();
-
-    _submit_publish_log_version_task(tablet_ids, request->tablet_ids_size(), &txn_id, &version, 1, response);
+    auto version = int64_t{request->version()};
+    if (!request->has_txn_info()) {
+        DCHECK(request->has_txn_id());
+        auto txn_info = TxnInfoPB();
+        txn_info.set_txn_id(request->txn_id());
+        txn_info.set_txn_type(TXN_NORMAL);
+        txn_info.set_combined_txn_log(false);
+        auto txn_infos = std::span<const TxnInfoPB>(&txn_info, 1);
+        _submit_publish_log_version_task(tablet_ids, request->tablet_ids_size(), txn_infos, &version, response);
+    } else {
+        auto txn_infos = std::span<const TxnInfoPB>(&request->txn_info(), 1);
+        _submit_publish_log_version_task(tablet_ids, request->tablet_ids_size(), txn_infos, &version, response);
+    }
 }
 
 void LakeServiceImpl::publish_log_version_batch(::google::protobuf::RpcController* controller,
@@ -317,8 +344,8 @@ void LakeServiceImpl::publish_log_version_batch(::google::protobuf::RpcControlle
         cntl->SetFailed("missing tablet_ids");
         return;
     }
-    if (request->txn_ids_size() == 0) {
-        cntl->SetFailed("missing txn_ids");
+    if (request->txn_ids_size() == 0 && request->txn_infos_size() == 0) {
+        cntl->SetFailed("missing txn_ids and txn_infos");
         return;
     }
     if (request->versions_size() == 0) {
@@ -326,13 +353,23 @@ void LakeServiceImpl::publish_log_version_batch(::google::protobuf::RpcControlle
         return;
     }
 
+    auto txn_infos = std::vector<TxnInfoPB>{};
     auto tablet_ids = request->tablet_ids().data();
-    auto txn_ids = request->txn_ids().data();
     auto versions = request->versions().data();
-    DCHECK_EQ(request->txn_ids_size(), request->versions_size());
+    if (request->txn_infos_size() == 0) {
+        DCHECK_EQ(request->txn_ids_size(), request->versions_size());
+        txn_infos.reserve(request->txn_ids_size());
+        for (auto txn_id : request->txn_ids()) {
+            auto& txn_info = txn_infos.emplace_back();
+            txn_info.set_txn_id(txn_id);
+            txn_info.set_combined_txn_log(false);
+            txn_info.set_txn_type(TXN_NORMAL);
+        }
+    } else {
+        txn_infos.insert(txn_infos.begin(), request->txn_infos().begin(), request->txn_infos().end());
+    }
 
-    _submit_publish_log_version_task(tablet_ids, request->tablet_ids_size(), txn_ids, versions, request->txn_ids_size(),
-                                     response);
+    _submit_publish_log_version_task(tablet_ids, request->tablet_ids_size(), txn_infos, versions, response);
 }
 
 void LakeServiceImpl::abort_txn(::google::protobuf::RpcController* controller,
@@ -341,13 +378,15 @@ void LakeServiceImpl::abort_txn(::google::protobuf::RpcController* controller,
     brpc::ClosureGuard guard(done);
     (void)controller;
 
-    LOG(INFO) << "Aborting transactions=[" << JoinInts(request->txn_ids(), ",") << "] tablets=["
-              << JoinInts(request->tablet_ids(), ",") << "]";
+    LOG(INFO) << "Aborting transactions. request=" << request->DebugString();
 
     // Cancel active tasks.
     if (LoadChannelMgr* load_mgr = _env->load_channel_mgr(); load_mgr != nullptr) {
-        for (auto txn_id : request->txn_ids()) {
+        for (auto& txn_id : request->txn_ids()) { // For request sent by and older version FE
             load_mgr->abort_txn(txn_id);
+        }
+        for (auto& txn_info : request->txn_infos()) { // For request sent by a new version FE
+            load_mgr->abort_txn(txn_info.txn_id());
         }
     }
 
@@ -359,10 +398,22 @@ void LakeServiceImpl::abort_txn(::google::protobuf::RpcController* controller,
     auto latch = BThreadCountDownLatch(1);
     auto task = [&]() {
         DeferOp defer([&] { latch.count_down(); });
-        auto txn_ids = std::span<const int64_t>(request->txn_ids().data(), request->txn_ids_size());
-        auto txn_types = std::span<const int32_t>(request->txn_types().data(), request->txn_types_size());
+        std::vector<TxnInfoPB> txn_infos;
+        if (request->txn_infos_size() > 0) {
+            txn_infos.insert(txn_infos.begin(), request->txn_infos().begin(), request->txn_infos().end());
+        } else {
+            // Construct TxnInfoPB from txn_id and txn_type
+            txn_infos.reserve(request->txn_ids_size());
+            auto has_txn_type = request->txn_types_size() == request->txn_ids_size();
+            for (int i = 0, sz = request->txn_ids_size(); i < sz; i++) {
+                auto& info = txn_infos.emplace_back();
+                info.set_txn_id(request->txn_ids(i));
+                info.set_txn_type(has_txn_type ? request->txn_types(i) : TXN_NORMAL);
+                info.set_combined_txn_log(false);
+            }
+        }
         for (auto tablet_id : request->tablet_ids()) {
-            lake::abort_txn(_tablet_mgr, tablet_id, txn_ids, txn_types);
+            lake::abort_txn(_tablet_mgr, tablet_id, txn_infos);
         }
     };
     auto st = thread_pool->submit_func(task);

--- a/be/src/service/service_be/lake_service.h
+++ b/be/src/service/service_be/lake_service.h
@@ -95,8 +95,8 @@ public:
                      ::starrocks::VacuumFullResponse* response, ::google::protobuf::Closure* done) override;
 
 private:
-    void _submit_publish_log_version_task(const int64_t* tablet_ids, size_t tablet_size, const int64_t* txn_ids,
-                                          const int64_t* log_versions, size_t txn_size,
+    void _submit_publish_log_version_task(const int64_t* tablet_ids, size_t tablet_size,
+                                          std::span<const TxnInfoPB> txn_infos, const int64_t* log_versions,
                                           ::starrocks::PublishLogVersionResponse* response);
 
 private:

--- a/be/src/storage/lake/async_delta_writer.h
+++ b/be/src/storage/lake/async_delta_writer.h
@@ -21,6 +21,7 @@
 
 #include "common/statusor.h"
 #include "gutil/macros.h"
+#include "storage/lake/delta_writer_finish_mode.h"
 
 namespace starrocks {
 class MemTracker;
@@ -29,7 +30,8 @@ class SlotDescriptor;
 
 namespace starrocks {
 class Chunk;
-}
+class TxnLogPB;
+} // namespace starrocks
 
 namespace starrocks::lake {
 
@@ -43,8 +45,10 @@ class AsyncDeltaWriter {
     friend class AsyncDeltaWriterBuilder;
 
 public:
+    using TxnLogPtr = std::shared_ptr<const TxnLogPB>;
     using Ptr = std::unique_ptr<AsyncDeltaWriter>;
     using Callback = std::function<void(Status st)>;
+    using FinishCallback = std::function<void(StatusOr<TxnLogPtr> res)>;
 
     explicit AsyncDeltaWriter(AsyncDeltaWriterImpl* impl) : _impl(impl) {}
 
@@ -78,7 +82,9 @@ public:
     // [thread-safe]
     //
     // TODO: Change signature to `Future<Status> finish()`
-    void finish(Callback cb);
+    void finish(FinishCallback cb) { finish(DeltaWriterFinishMode::kWriteTxnLog, cb); }
+
+    void finish(DeltaWriterFinishMode mode, FinishCallback cb);
 
     // This method will wait for all running tasks completed.
     //

--- a/be/src/storage/lake/delta_writer.cpp
+++ b/be/src/storage/lake/delta_writer.cpp
@@ -27,6 +27,7 @@
 #include "runtime/mem_tracker.h"
 #include "storage/lake/filenames.h"
 #include "storage/lake/meta_file.h"
+#include "storage/lake/metacache.h"
 #include "storage/lake/pk_tablet_writer.h"
 #include "storage/lake/tablet.h"
 #include "storage/lake/tablet_manager.h"
@@ -40,10 +41,7 @@
 
 namespace starrocks::lake {
 
-using Chunk = starrocks::Chunk;
-using Column = starrocks::Column;
-using MemTable = starrocks::MemTable;
-using MemTableSink = starrocks::MemTableSink;
+using TxnLogPtr = DeltaWriter::TxnLogPtr;
 
 class TabletWriterSink : public MemTableSink {
 public:
@@ -98,7 +96,7 @@ public:
 
     Status write(const Chunk& chunk, const uint32_t* indexes, uint32_t indexes_size);
 
-    Status finish(DeltaWriter::FinishMode mode);
+    StatusOr<TxnLogPtr> finish(DeltaWriterFinishMode mode);
 
     void close();
 
@@ -404,15 +402,11 @@ Status DeltaWriterImpl::init_write_schema() {
     return Status::OK();
 }
 
-Status DeltaWriterImpl::finish(DeltaWriter::FinishMode mode) {
+StatusOr<TxnLogPtr> DeltaWriterImpl::finish(DeltaWriterFinishMode mode) {
     SCOPED_THREAD_LOCAL_MEM_SETTER(_mem_tracker, false);
     RETURN_IF_ERROR(build_schema_and_writer());
     RETURN_IF_ERROR(flush());
     RETURN_IF_ERROR(_tablet_writer->finish());
-
-    if (mode == DeltaWriter::kDontWriteTxnLog) {
-        return Status::OK();
-    }
 
     if (UNLIKELY(_txn_id < 0)) {
         return Status::InvalidArgument(fmt::format("negative txn id: {}", _txn_id));
@@ -422,6 +416,7 @@ Status DeltaWriterImpl::finish(DeltaWriter::FinishMode mode) {
     auto txn_log = std::make_shared<TxnLog>();
     txn_log->set_tablet_id(_tablet_id);
     txn_log->set_txn_id(_txn_id);
+    txn_log->set_partition_id(_partition_id);
     auto op_write = txn_log->mutable_op_write();
 
     for (auto& f : _tablet_writer->files()) {
@@ -485,12 +480,17 @@ Status DeltaWriterImpl::finish(DeltaWriter::FinishMode mode) {
             }
         }
     }
-    RETURN_IF_ERROR(tablet.put_txn_log(txn_log));
+    if (mode == kWriteTxnLog) {
+        RETURN_IF_ERROR(tablet.put_txn_log(txn_log));
+    } else {
+        auto cache_key = _tablet_manager->txn_log_location(_tablet_id, _txn_id);
+        _tablet_manager->metacache()->cache_txn_log(cache_key, txn_log);
+    }
     if (_tablet_schema->keys_type() == KeysType::PRIMARY_KEYS) {
         // preload update state here to minimaze the cost when publishing.
         tablet.update_mgr()->preload_update_state(*txn_log, &tablet);
     }
-    return Status::OK();
+    return txn_log;
 }
 
 Status DeltaWriterImpl::fill_auto_increment_id(const Chunk& chunk) {
@@ -618,7 +618,7 @@ Status DeltaWriter::write(const Chunk& chunk, const uint32_t* indexes, uint32_t 
     return _impl->write(chunk, indexes, indexes_size);
 }
 
-Status DeltaWriter::finish(FinishMode mode) {
+StatusOr<TxnLogPtr> DeltaWriter::finish(DeltaWriterFinishMode mode) {
     DCHECK_EQ(0, bthread_self()) << "Should not invoke DeltaWriter::finish() in a bthread";
     return _impl->finish(mode);
 }

--- a/be/src/storage/lake/delta_writer.h
+++ b/be/src/storage/lake/delta_writer.h
@@ -19,6 +19,7 @@
 
 #include "common/statusor.h"
 #include "gutil/macros.h"
+#include "storage/lake/delta_writer_finish_mode.h"
 
 namespace starrocks {
 class MemTracker;
@@ -27,6 +28,7 @@ class Chunk;
 class TabletSchema;
 class ThreadPool;
 struct FileInfo;
+class TxnLogPB;
 } // namespace starrocks
 
 namespace starrocks::lake {
@@ -39,10 +41,7 @@ class DeltaWriter {
     friend class DeltaWriterBuilder;
 
 public:
-    enum FinishMode {
-        kWriteTxnLog,
-        kDontWriteTxnLog,
-    };
+    using TxnLogPtr = std::shared_ptr<const TxnLogPB>;
 
     // Return the thread pool used for performing write IO.
     static ThreadPool* io_threads();
@@ -60,7 +59,7 @@ public:
     Status write(const Chunk& chunk, const uint32_t* indexes, uint32_t indexes_size);
 
     // NOTE: Do NOT invoke this method in a bthread.
-    Status finish(FinishMode mode = kWriteTxnLog);
+    StatusOr<TxnLogPtr> finish(DeltaWriterFinishMode mode = kWriteTxnLog);
 
     // Manual flush, mainly used in UT
     // NOTE: Do NOT invoke this method in a bthread.

--- a/be/src/storage/lake/delta_writer_finish_mode.h
+++ b/be/src/storage/lake/delta_writer_finish_mode.h
@@ -14,16 +14,11 @@
 
 #pragma once
 
-#include <memory>
+namespace starrocks::lake {
 
-#include "gen_cpp/lake_types.pb.h"
+enum DeltaWriterFinishMode {
+    kWriteTxnLog,
+    kDontWriteTxnLog,
+};
 
-namespace starrocks {
-
-using TxnLog = TxnLogPB;
-using TxnLogPtr = std::shared_ptr<const TxnLog>;
-using MutableTxnLogPtr = std::shared_ptr<TxnLog>;
-using CombinedTxnLog = CombinedTxnLogPB;
-using CombinedTxnLogPtr = std::shared_ptr<const CombinedTxnLog>;
-
-} // namespace starrocks
+}

--- a/be/src/storage/lake/filenames.h
+++ b/be/src/storage/lake/filenames.h
@@ -83,6 +83,23 @@ inline std::string txn_vlog_filename(int64_t tablet_id, int64_t version) {
     return fmt::format("{:016X}_{:016X}.vlog", tablet_id, version);
 }
 
+inline std::string combined_txn_log_filename(int64_t txn_id) {
+    return fmt::format("{:016X}.logs", txn_id);
+}
+
+inline bool is_combined_txn_log(std::string_view file_name) {
+    return HasSuffixString(file_name, ".logs");
+}
+
+inline int64_t parse_combined_txn_log_filename(std::string_view file_name) {
+    constexpr static int kBase = 16;
+    CHECK_EQ(21, file_name.size());
+    StringParser::ParseResult res;
+    auto txn_id = StringParser::string_to_int<int64_t>(file_name.data(), 16, kBase, &res);
+    CHECK_EQ(StringParser::PARSE_SUCCESS, res) << file_name;
+    return txn_id;
+}
+
 inline std::string tablet_metadata_lock_filename(int64_t tablet_id, int64_t version, int64_t expire_time) {
     return fmt::format("{:016X}_{:016X}_{:016X}.lock", tablet_id, version, expire_time);
 }

--- a/be/src/storage/lake/location_provider.h
+++ b/be/src/storage/lake/location_provider.h
@@ -64,6 +64,10 @@ public:
         return join_path(txn_log_root_location(tablet_id), txn_vlog_filename(tablet_id, version));
     }
 
+    std::string combined_txn_log_location(int64_t tablet_id, int64_t txn_id) const {
+        return join_path(txn_log_root_location(tablet_id), combined_txn_log_filename(txn_id));
+    }
+
     std::string segment_location(int64_t tablet_id, std::string_view segment_name) const {
         return join_path(segment_root_location(tablet_id), segment_name);
     }

--- a/be/src/storage/lake/metacache.h
+++ b/be/src/storage/lake/metacache.h
@@ -29,13 +29,14 @@ class Segment;
 class TabletSchema;
 class TabletMetadataPB;
 class TxnLogPB;
+class CombinedTxnLogPB;
 } // namespace starrocks
 
 namespace starrocks::lake {
 
-using CacheValue =
-        std::variant<std::shared_ptr<const TabletMetadataPB>, std::shared_ptr<const TxnLogPB>,
-                     std::shared_ptr<const TabletSchema>, std::shared_ptr<const DelVector>, std::shared_ptr<Segment>>;
+using CacheValue = std::variant<std::shared_ptr<const TabletMetadataPB>, std::shared_ptr<const TxnLogPB>,
+                                std::shared_ptr<const TabletSchema>, std::shared_ptr<const DelVector>,
+                                std::shared_ptr<Segment>, std::shared_ptr<const CombinedTxnLogPB>>;
 
 class Metacache {
 public:
@@ -49,6 +50,8 @@ public:
 
     std::shared_ptr<const TxnLogPB> lookup_txn_log(std::string_view key);
 
+    std::shared_ptr<const CombinedTxnLogPB> lookup_combined_txn_log(std::string_view key);
+
     std::shared_ptr<const TabletSchema> lookup_tablet_schema(std::string_view key);
 
     std::shared_ptr<Segment> lookup_segment(std::string_view key);
@@ -60,6 +63,8 @@ public:
     void cache_tablet_schema(std::string_view key, std::shared_ptr<const TabletSchema> schema, size_t size);
 
     void cache_txn_log(std::string_view key, std::shared_ptr<const TxnLogPB> log);
+
+    void cache_combined_txn_log(std::string_view key, std::shared_ptr<const CombinedTxnLogPB> log);
 
     void cache_segment(std::string_view key, std::shared_ptr<Segment> segment);
 

--- a/be/src/storage/lake/schema_change.cpp
+++ b/be/src/storage/lake/schema_change.cpp
@@ -287,7 +287,7 @@ Status SortedSchemaChange::process(RowsetPtr rowset, RowsetMetadata* new_rowset_
         RETURN_IF_ERROR(writer->write(*_new_chunk, _selective->data(), _new_chunk->num_rows()));
     }
 
-    RETURN_IF_ERROR(writer->finish(DeltaWriter::kDontWriteTxnLog));
+    RETURN_IF_ERROR(writer->finish(DeltaWriterFinishMode::kDontWriteTxnLog));
 
     for (auto& f : writer->files()) {
         new_rowset_metadata->add_segments(std::move(f.path));

--- a/be/src/storage/lake/tablet.h
+++ b/be/src/storage/lake/tablet.h
@@ -72,6 +72,8 @@ public:
 
     [[nodiscard]] Status put_txn_slog(const TxnLogPtr& log);
 
+    [[nodiscard]] Status put_combined_txn_log(const CombinedTxnLogPB& logs);
+
     StatusOr<TxnLogPtr> get_txn_log(int64_t txn_id);
 
     StatusOr<TxnLogPtr> get_txn_slog(int64_t txn_id);

--- a/be/src/storage/lake/tablet_manager.cpp
+++ b/be/src/storage/lake/tablet_manager.cpp
@@ -86,6 +86,10 @@ std::string TabletManager::txn_log_location(int64_t tablet_id, int64_t txn_id) c
     return _location_provider->txn_log_location(tablet_id, txn_id);
 }
 
+std::string TabletManager::combined_txn_log_location(int64_t tablet_id, int64_t txn_id) const {
+    return _location_provider->combined_txn_log_location(tablet_id, txn_id);
+}
+
 std::string TabletManager::txn_slog_location(int64_t tablet_id, int64_t txn_id) const {
     return _location_provider->txn_slog_location(tablet_id, txn_id);
 }
@@ -308,6 +312,21 @@ StatusOr<TxnLogPtr> TabletManager::get_txn_log(const std::string& path, bool fil
     return ptr;
 }
 
+StatusOr<CombinedTxnLogPtr> TabletManager::get_combined_txn_log(const std::string& path, bool fill_cache) {
+    if (auto ptr = _metacache->lookup_combined_txn_log(path); ptr != nullptr) {
+        TRACE("got cached combined txn log");
+        return ptr;
+    }
+    TEST_ERROR_POINT("TabletManager::get_combined_txn_log");
+    auto log = std::make_shared<CombinedTxnLogPB>();
+    ProtobufFile file(path);
+    RETURN_IF_ERROR(file.load(log.get(), fill_cache));
+    if (fill_cache) {
+        _metacache->cache_combined_txn_log(path, log);
+    }
+    return log;
+}
+
 StatusOr<TxnLogPtr> TabletManager::get_txn_log(int64_t tablet_id, int64_t txn_id) {
     return get_txn_log(txn_log_location(tablet_id, txn_id));
 }
@@ -357,6 +376,28 @@ Status TabletManager::put_txn_slog(const TxnLogPtr& log, const std::string& path
 
 Status TabletManager::put_txn_vlog(const TxnLogPtr& log, int64_t version) {
     return put_txn_log(log, txn_vlog_location(log->tablet_id(), version));
+}
+
+Status TabletManager::put_combined_txn_log(const starrocks::CombinedTxnLogPB& logs) {
+    if (UNLIKELY(logs.txn_logs_size() == 0)) {
+        return Status::InvalidArgument("empty CombinedTxnLogPB");
+    }
+    auto tablet_id = logs.txn_logs(0).tablet_id();
+    auto txn_id = logs.txn_logs(0).txn_id();
+#ifndef NDEBUG
+    // Ensure that all tablets belongs to the same partition.
+    auto partition_id = logs.txn_logs(0).partition_id();
+    for (const auto& log : logs.txn_logs()) {
+        DCHECK(log.has_tablet_id());
+        DCHECK(log.has_partition_id());
+        DCHECK(log.has_txn_id());
+        DCHECK_EQ(partition_id, log.partition_id());
+        DCHECK_EQ(txn_id, log.txn_id());
+    }
+#endif
+    auto path = _location_provider->combined_txn_log_location(tablet_id, txn_id);
+    ProtobufFile file(path);
+    return file.save(logs);
 }
 
 StatusOr<int64_t> TabletManager::get_tablet_data_size(int64_t tablet_id, int64_t* version_hint) {

--- a/be/src/storage/lake/tablet_manager.h
+++ b/be/src/storage/lake/tablet_manager.h
@@ -96,9 +96,13 @@ public:
 
     Status put_txn_vlog(const TxnLogPtr& log, int64_t version);
 
+    Status put_combined_txn_log(const CombinedTxnLogPB& logs);
+
     StatusOr<TxnLogPtr> get_txn_log(int64_t tablet_id, int64_t txn_id);
 
     StatusOr<TxnLogPtr> get_txn_log(const std::string& path, bool fill_cache = true);
+
+    StatusOr<CombinedTxnLogPtr> get_combined_txn_log(const std::string& path, bool fill_cache = true);
 
     StatusOr<TxnLogPtr> get_txn_slog(int64_t tablet_id, int64_t txn_id);
 
@@ -132,6 +136,8 @@ public:
     std::string txn_slog_location(int64_t tablet_id, int64_t txn_id) const;
 
     std::string txn_vlog_location(int64_t tablet_id, int64_t version) const;
+
+    std::string combined_txn_log_location(int64_t tablet_id, int64_t txn_id) const;
 
     std::string segment_location(int64_t tablet_id, std::string_view segment_name) const;
 

--- a/be/src/storage/lake/transactions.h
+++ b/be/src/storage/lake/transactions.h
@@ -19,6 +19,10 @@
 #include "common/statusor.h"
 #include "storage/lake/tablet_metadata.h"
 
+namespace starrocks {
+class TxnInfoPB;
+}
+
 namespace starrocks::lake {
 
 class TabletManager;
@@ -28,7 +32,7 @@ class TabletManager;
 // This function does the following:
 //
 // 1. Load the base tablet metadata with id 'tablet_id' and version 'base_version'.
-// 2. Read the transaction logs for all 'txn_ids' sequentially and apply them to the base metadata.
+// 2. Read the transaction logs for all 'txns' sequentially and apply them to the base metadata.
 // 3. Save the result as a new tablet metadata with version 'new_version'.
 // 4. Update the metadata's commit timestamp to 'commit_time'.
 // 5. Persist the new metadata to the object storage.
@@ -38,13 +42,13 @@ class TabletManager;
 // - tablet_id Id of the tablet
 // - base_version Version of the base metadata
 // - new_version The new version to be published
-// - txn_ids Transactions to apply in sequence
+// - txns Transactions to apply in sequence
 // - commit_time New commit timestamp
 //
 // Return:
 // - StatusOr containing the new published TabletMetadataPtr on success.
 StatusOr<TabletMetadataPtr> publish_version(TabletManager* tablet_mgr, int64_t tablet_id, int64_t base_version,
-                                            int64_t new_version, std::span<const int64_t> txn_ids, int64_t commit_time);
+                                            int64_t new_version, std::span<const TxnInfoPB> txns);
 
 // Publish a batch new versions of transaction logs.
 //
@@ -55,13 +59,13 @@ StatusOr<TabletMetadataPtr> publish_version(TabletManager* tablet_mgr, int64_t t
 // Parameters:
 // - tablet_mgr A pointer to the TabletManager object managing the tablet, cannot be nullptr
 // - tablet_id Id of the tablet
-// - txn_id ID of the transactions to abort
+// - txn_infos Transactions to apply
 // - log_version Version of the new file
 //
 // Return:
 // - Returns OK if the copy was successful, asynchronous deletion does not affect the return value.
-Status publish_log_version(TabletManager* tablet_mgr, int64_t tablet_id, const int64_t* txn_ids,
-                           const int64_t* log_versions, int txns_size);
+Status publish_log_version(TabletManager* tablet_mgr, int64_t tablet_id, std::span<const TxnInfoPB> txn_infos,
+                           const int64_t* log_versions);
 
 // Aborts a transaction with the specified transaction IDs on the given tablet.
 //
@@ -74,11 +78,8 @@ Status publish_log_version(TabletManager* tablet_mgr, int64_t tablet_id, const i
 // Parameters:
 // - tablet_mgr A pointer to the TabletManager object managing the tablet, cannot be nullptr
 // - tablet_id The ID of the tablet where the transaction will be aborted.
-// - txn_ids A `std::span` of `int64_t` containing the transaction IDs to be aborted.
-// - txn_types A `std::span` of `int32_t(TxnTypePB)` containing the transaction types to be aborted.
-//             Using int32_t instead of TxnTypePB due to protobuf uses int32_t to store enum
+// - txns A `std::span` of `TxnInfoPB` containing information of the transactions to be aborted.
 //
-void abort_txn(TabletManager* tablet_mgr, int64_t tablet_id, std::span<const int64_t> txn_ids,
-               std::span<const int32_t> txn_types);
+void abort_txn(TabletManager* tablet_mgr, int64_t tablet_id, std::span<const TxnInfoPB> txns);
 
 } // namespace starrocks::lake

--- a/be/src/storage/lake/vacuum.cpp
+++ b/be/src/storage/lake/vacuum.cpp
@@ -402,6 +402,11 @@ static Status vacuum_txn_log(std::string_view root_location, int64_t min_active_
             if (txn_id >= min_active_txn_id) {
                 return true;
             }
+        } else if (is_combined_txn_log(entry.name)) {
+            auto txn_id = parse_combined_txn_log_filename(entry.name);
+            if (txn_id >= min_active_txn_id) {
+                return true;
+            }
         } else {
             return true;
         }

--- a/be/test/runtime/lake_tablets_channel_test.cpp
+++ b/be/test/runtime/lake_tablets_channel_test.cpp
@@ -796,4 +796,70 @@ TEST_F(LakeTabletsChannelTest, test_profile) {
     ASSERT_TRUE(profile->get_counter("AddChunkTime")->value() > 0);
     ASSERT_EQ(chunk.num_rows(), profile->get_counter("AddRowNum")->value());
 }
+
+TEST_F(LakeTabletsChannelTest, test_dont_write_txn_log) {
+    auto open_request = _open_request;
+    open_request.set_num_senders(1);
+    open_request.mutable_lake_tablet_params()->set_write_txn_log(false);
+
+    ASSERT_OK(_tablets_channel->open(open_request, &_open_response, _schema_param, false));
+
+    constexpr int kChunkSize = 24;
+    constexpr int kChunkSizePerTablet = kChunkSize / 4;
+    auto chunk = generate_data(kChunkSize);
+
+    PTabletWriterAddChunkRequest add_chunk_request;
+    PTabletWriterAddBatchResult add_chunk_response;
+    add_chunk_request.set_index_id(kIndexId);
+    add_chunk_request.set_sender_id(0);
+    add_chunk_request.set_eos(false);
+    add_chunk_request.set_packet_seq(0);
+
+    for (int i = 0; i < kChunkSize; i++) {
+        int64_t tablet_id = 10086 + (i / kChunkSizePerTablet);
+        add_chunk_request.add_tablet_ids(tablet_id);
+        add_chunk_request.add_partition_ids(tablet_id < 10088 ? 10 : 11);
+    }
+
+    ASSIGN_OR_ABORT(auto chunk_pb, serde::ProtobufChunkSerde::serialize(chunk));
+    add_chunk_request.mutable_chunk()->Swap(&chunk_pb);
+
+    _tablets_channel->add_chunk(&chunk, add_chunk_request, &add_chunk_response);
+    ASSERT_TRUE(add_chunk_response.status().status_code() == TStatusCode::OK);
+    ASSERT_FALSE(add_chunk_response.has_lake_tablet_data());
+
+    PTabletWriterAddChunkRequest finish_request;
+    PTabletWriterAddBatchResult finish_response;
+    finish_request.set_index_id(kIndexId);
+    finish_request.set_sender_id(0);
+    finish_request.set_eos(true);
+    finish_request.set_packet_seq(1);
+    finish_request.add_partition_ids(10);
+    finish_request.add_partition_ids(11);
+
+    _tablets_channel->add_chunk(nullptr, finish_request, &finish_response);
+    ASSERT_EQ(TStatusCode::OK, finish_response.status().status_code());
+    ASSERT_EQ(4, finish_response.tablet_vec_size());
+
+    std::vector<int64_t> finished_tablets;
+    for (auto& info : finish_response.tablet_vec()) {
+        finished_tablets.emplace_back(info.tablet_id());
+    }
+    std::sort(finished_tablets.begin(), finished_tablets.end());
+    ASSERT_EQ(10086, finished_tablets[0]);
+    ASSERT_EQ(10087, finished_tablets[1]);
+    ASSERT_EQ(10088, finished_tablets[2]);
+    ASSERT_EQ(10089, finished_tablets[3]);
+
+    ASSERT_TRUE(finish_response.has_lake_tablet_data());
+    ASSERT_EQ(4, finish_response.lake_tablet_data().txn_logs_size());
+
+    auto metacache = _tablet_manager->metacache();
+    for (auto tablet_id : finished_tablets) {
+        auto txn_log_path = _tablet_manager->txn_log_location(tablet_id, kTxnId);
+        ASSERT_TRUE(metacache->lookup_txn_log(txn_log_path));
+        ASSERT_TRUE(FileSystem::Default()->path_exists(txn_log_path).is_not_found());
+    }
+}
+
 } // namespace starrocks

--- a/be/test/service/lake_service_test.cpp
+++ b/be/test/service/lake_service_test.cpp
@@ -88,6 +88,7 @@ protected:
         auto txn_id = next_id();
         TxnLog log;
         log.set_tablet_id(_tablet_id);
+        log.set_partition_id(_partition_id);
         log.set_txn_id(txn_id);
         for (int i = 0; i < num_segments; i++) {
             log.mutable_op_write()->mutable_rowset()->add_segments(generate_segment_file(txn_id));
@@ -128,7 +129,7 @@ TEST_F(LakeServiceTest, test_publish_version_missing_txn_ids) {
     request.add_tablet_ids(_tablet_id);
     _lake_service.publish_version(&cntl, &request, &response, nullptr);
     ASSERT_TRUE(cntl.Failed());
-    ASSERT_EQ("missing txn_ids", cntl.ErrorText());
+    ASSERT_EQ("missing txn_ids and txn_infos", cntl.ErrorText());
 }
 
 TEST_F(LakeServiceTest, test_publish_version_missing_base_version) {
@@ -978,7 +979,7 @@ TEST_F(LakeServiceTest, test_publish_log_version) {
         brpc::Controller cntl;
         _lake_service.publish_log_version(&cntl, &request, &response, nullptr);
         ASSERT_TRUE(cntl.Failed());
-        ASSERT_EQ("missing txn_id", cntl.ErrorText());
+        ASSERT_EQ("missing txn_id and txn_info", cntl.ErrorText());
     }
     {
         PublishLogVersionRequest request;
@@ -1044,6 +1045,46 @@ TEST_F(LakeServiceTest, test_publish_log_version) {
         ExecEnv::GetInstance()->delete_file_thread_pool()->wait();
         EXPECT_TRUE(fs::path_exist(_tablet_mgr->txn_vlog_location(_tablet_id, 10)));
     }
+    // Publish combined txn log
+    {
+        auto partition_id = next_id();
+        txn_id = next_id();
+        std::vector<int64_t> tablet_ids{next_id(), next_id(), next_id()};
+        CombinedTxnLogPB combined_txn_log;
+        for (auto tablet_id : tablet_ids) {
+            auto* log = combined_txn_log.add_txn_logs();
+            log->set_partition_id(partition_id);
+            log->set_tablet_id(tablet_id);
+            log->set_txn_id(txn_id);
+            log->mutable_op_write()->mutable_rowset()->set_overlapped(true);
+            log->mutable_op_write()->mutable_rowset()->set_num_rows(0);
+            log->mutable_op_write()->mutable_rowset()->set_data_size(0);
+        }
+        ASSERT_OK(_tablet_mgr->put_combined_txn_log(combined_txn_log));
+
+        int64_t version = 12;
+        PublishLogVersionRequest request;
+        PublishLogVersionResponse response;
+        for (auto tablet_id : tablet_ids) {
+            request.add_tablet_ids(tablet_id);
+        }
+        request.set_version(version);
+        auto* txn_info = request.mutable_txn_info();
+        txn_info->set_txn_id(txn_id);
+        txn_info->set_combined_txn_log(true);
+        txn_info->set_txn_type(TXN_NORMAL);
+        txn_info->set_commit_time(::time(nullptr));
+        brpc::Controller cntl;
+        _lake_service.publish_log_version(&cntl, &request, &response, nullptr);
+        ASSERT_FALSE(cntl.Failed());
+        ASSERT_EQ(0, response.failed_tablets_size());
+
+        ExecEnv::GetInstance()->delete_file_thread_pool()->wait();
+        for (auto tablet_id : tablet_ids) {
+            EXPECT_TRUE(fs::path_exist(_tablet_mgr->combined_txn_log_location(tablet_id, txn_id)));
+            EXPECT_TRUE(fs::path_exist(_tablet_mgr->txn_vlog_location(tablet_id, version)));
+        }
+    }
 }
 
 TEST_F(LakeServiceTest, test_publish_log_version_batch) {
@@ -1083,7 +1124,7 @@ TEST_F(LakeServiceTest, test_publish_log_version_batch) {
         brpc::Controller cntl;
         _lake_service.publish_log_version_batch(&cntl, &request, &response, nullptr);
         ASSERT_TRUE(cntl.Failed());
-        ASSERT_EQ("missing txn_ids", cntl.ErrorText());
+        ASSERT_EQ("missing txn_ids and txn_infos", cntl.ErrorText());
     }
     {
         PublishLogVersionBatchRequest request;
@@ -1163,6 +1204,57 @@ TEST_F(LakeServiceTest, test_publish_log_version_batch) {
         brpc::Controller cntl;
         _lake_service.publish_log_version_batch(&cntl, &request, &response, nullptr);
         ASSERT_TRUE(cntl.Failed());
+    }
+    // Publish combined txn log
+    {
+        auto partition_id = next_id();
+        std::vector<int64_t> txn_ids{next_id(), next_id(), next_id()};
+        std::vector<int64_t> tablet_ids{next_id(), next_id(), next_id()};
+        // prepare combined logs
+        for (auto txn_id : txn_ids) {
+            CombinedTxnLogPB combined_txn_log;
+            for (auto tablet_id : tablet_ids) {
+                auto* log = combined_txn_log.add_txn_logs();
+                log->set_partition_id(partition_id);
+                log->set_tablet_id(tablet_id);
+                log->set_txn_id(txn_id);
+                log->mutable_op_write()->mutable_rowset()->set_overlapped(true);
+                log->mutable_op_write()->mutable_rowset()->set_num_rows(0);
+                log->mutable_op_write()->mutable_rowset()->set_data_size(0);
+            }
+            ASSERT_OK(_tablet_mgr->put_combined_txn_log(combined_txn_log));
+        }
+
+        std::vector<int64_t> versions = {12, 13, 14};
+        PublishLogVersionBatchRequest request;
+        PublishLogVersionResponse response;
+        for (auto tablet_id : tablet_ids) {
+            request.add_tablet_ids(tablet_id);
+        }
+        for (auto version : versions) {
+            request.add_versions(version);
+        }
+        for (auto txn_id : txn_ids) {
+            auto* txn_info = request.add_txn_infos();
+            txn_info->set_txn_id(txn_id);
+            txn_info->set_combined_txn_log(true);
+            txn_info->set_txn_type(TXN_NORMAL);
+            txn_info->set_commit_time(::time(nullptr));
+        }
+        brpc::Controller cntl;
+        _lake_service.publish_log_version_batch(&cntl, &request, &response, nullptr);
+        ASSERT_FALSE(cntl.Failed());
+        ASSERT_EQ(0, response.failed_tablets_size());
+
+        ExecEnv::GetInstance()->delete_file_thread_pool()->wait();
+        for (auto txn_id : txn_ids) {
+            for (auto tablet_id : tablet_ids) {
+                EXPECT_TRUE(fs::path_exist(_tablet_mgr->combined_txn_log_location(tablet_id, txn_id)));
+                for (auto version : versions) {
+                    EXPECT_TRUE(fs::path_exist(_tablet_mgr->txn_vlog_location(tablet_id, version)));
+                }
+            }
+        }
     }
 }
 
@@ -1910,6 +2002,173 @@ TEST_F(LakeServiceTest, test_publish_version_for_fast_schema_evolution) {
         EXPECT_EQ(new_schema.short_key_column_count, schema.num_short_key_columns());
         compare_column(new_schema.columns[0], schema.column(0));
         compare_column(new_schema.columns[1], schema.column(1));
+    }
+}
+
+TEST_F(LakeServiceTest, test_publish_version_with_combined_log) {
+    // Put empty CombinedTxnLog should return error
+    {
+        auto combined_log = CombinedTxnLogPB();
+        ASSERT_FALSE(_tablet_mgr->put_combined_txn_log(combined_log).ok());
+    }
+
+    auto do_test = [&](int64_t txn_id, TStatusCode::type expect_code) {
+        PublishVersionRequest publish_request;
+        publish_request.set_base_version(1);
+        publish_request.set_new_version(2);
+        publish_request.add_tablet_ids(_tablet_id);
+        auto info = publish_request.add_txn_infos();
+        info->set_txn_id(txn_id);
+        info->set_combined_txn_log(true);
+        info->set_commit_time(987654321);
+        info->set_txn_type(TXN_NORMAL);
+        PublishVersionResponse response;
+        _lake_service.publish_version(nullptr, &publish_request, &response, nullptr);
+        EXPECT_EQ(expect_code, response.status().status_code());
+    };
+
+    // combined log does not exist
+    { do_test(next_id(), TStatusCode::NOT_FOUND); }
+    // CombinedTxnLog does not contain the target txn log
+    {
+        auto txn_log = generate_write_txn_log(2, 101, 4096);
+        txn_log.set_tablet_id(_tablet_id + 1);
+        auto combined_log = CombinedTxnLogPB();
+        combined_log.add_txn_logs()->CopyFrom(txn_log);
+        ASSERT_OK(_tablet_mgr->put_combined_txn_log(combined_log));
+
+        do_test(txn_log.txn_id(), TStatusCode::INTERNAL_ERROR);
+    }
+    // Publish txn success
+    {
+        auto txn_log = std::make_shared<TxnLogPB>(generate_write_txn_log(2, 101, 4096));
+        auto txn_id = txn_log->txn_id();
+        auto combined_log = CombinedTxnLogPB();
+        combined_log.add_txn_logs()->CopyFrom(*txn_log);
+
+        _tablet_mgr->metacache()->cache_txn_log(_tablet_mgr->txn_log_location(_tablet_id, txn_id), txn_log);
+
+        ASSERT_OK(_tablet_mgr->put_combined_txn_log(combined_log));
+
+        do_test(txn_id, TStatusCode::OK);
+        ExecEnv::GetInstance()->delete_file_thread_pool()->wait();
+
+        // CombinedTxnLogPB should still exist
+        auto path = _tablet_mgr->combined_txn_log_location(_tablet_id, txn_id);
+        ASSERT_OK(FileSystem::Default()->path_exists(path));
+
+        _tablet_mgr->metacache()->erase(_tablet_mgr->txn_log_location(_tablet_id, txn_id));
+        // publish again without txn log cache
+        do_test(txn_id, TStatusCode::OK);
+
+        // publish again without txn log cache and combined txn log cache
+        _tablet_mgr->metacache()->erase(_tablet_mgr->txn_log_location(_tablet_id, txn_id));
+        _tablet_mgr->metacache()->erase(_tablet_mgr->combined_txn_log_location(_tablet_id, txn_id));
+        do_test(txn_id, TStatusCode::OK);
+    }
+}
+
+TEST_F(LakeServiceTest, test_publish_version_with_txn_info) {
+    std::vector<TxnLog> logs;
+    // TxnLog with 2 segments
+    logs.emplace_back(generate_write_txn_log(2, 101, 4096));
+    ASSERT_OK(_tablet_mgr->put_txn_log(logs.back()));
+
+    // publish version
+    {
+        PublishVersionRequest request;
+        request.set_base_version(1);
+        request.set_new_version(2);
+        request.add_tablet_ids(_tablet_id);
+        auto info = request.add_txn_infos();
+        info->set_txn_id(logs[0].txn_id());
+        info->set_txn_type(TXN_NORMAL);
+        info->set_combined_txn_log(false);
+        info->set_commit_time(987654321);
+
+        PublishVersionResponse response;
+        _lake_service.publish_version(nullptr, &request, &response, nullptr);
+        ASSERT_EQ(0, response.failed_tablets_size());
+        EXPECT_EQ(0, response.status().status_code()) << response.status().error_msgs(0);
+    }
+    ASSIGN_OR_ABORT(auto tablet, _tablet_mgr->get_tablet(_tablet_id));
+    {
+        ASSIGN_OR_ABORT(auto metadata, tablet.get_metadata(2));
+        ASSERT_EQ(2, metadata->version());
+        ASSERT_EQ(_tablet_id, metadata->id());
+        ASSERT_EQ(3, metadata->next_rowset_id());
+        ASSERT_EQ(1, metadata->rowsets_size());
+        ASSERT_EQ(1, metadata->rowsets(0).id());
+        ASSERT_EQ(2, metadata->rowsets(0).segments_size());
+        ASSERT_TRUE(metadata->rowsets(0).overlapped());
+        ASSERT_EQ(logs[0].op_write().rowset().num_rows(), metadata->rowsets(0).num_rows());
+        ASSERT_EQ(logs[0].op_write().rowset().data_size(), metadata->rowsets(0).data_size());
+        ASSERT_EQ(logs[0].op_write().rowset().segments(0), metadata->rowsets(0).segments(0));
+        ASSERT_EQ(logs[0].op_write().rowset().segments(1), metadata->rowsets(0).segments(1));
+        EXPECT_EQ(987654321, metadata->commit_time());
+    }
+    ExecEnv::GetInstance()->delete_file_thread_pool()->wait();
+    // TxnLog`s should have been deleted
+    ASSERT_TRUE(tablet.get_txn_log(logs[0].txn_id()).status().is_not_found());
+}
+
+TEST_F(LakeServiceTest, test_abort_with_combined_txn_log) {
+    auto txn_id = next_id();
+    auto combined_log = std::make_shared<CombinedTxnLogPB>();
+    for (int i = 0; i < 3; i++) {
+        TxnLog log;
+        log.set_tablet_id(_tablet_id);
+        log.set_txn_id(txn_id);
+        log.set_partition_id(_partition_id);
+        log.mutable_op_write()->mutable_rowset()->add_segments(generate_segment_file(txn_id));
+        log.mutable_op_write()->mutable_rowset()->set_data_size(4096);
+        log.mutable_op_write()->mutable_rowset()->set_num_rows(101);
+        log.mutable_op_write()->mutable_rowset()->set_overlapped(true);
+        combined_log->add_txn_logs()->CopyFrom(log);
+    }
+    _tablet_mgr->put_combined_txn_log(*combined_log);
+
+    AbortTxnRequest request;
+    request.add_tablet_ids(_tablet_id);
+    request.set_skip_cleanup(false);
+    auto info = request.add_txn_infos();
+    info->set_txn_id(txn_id);
+    info->set_combined_txn_log(true);
+    info->set_txn_type(TXN_NORMAL);
+
+    {
+        TEST_ENABLE_ERROR_POINT("TabletManager::get_combined_txn_log", Status::IOError("injected error"));
+        SyncPoint::GetInstance()->EnableProcessing();
+
+        DeferOp defer([]() {
+            TEST_DISABLE_ERROR_POINT("TabletManager::load_txn_log");
+            SyncPoint::GetInstance()->DisableProcessing();
+        });
+
+        AbortTxnResponse response;
+        _lake_service.abort_txn(nullptr, &request, &response, nullptr);
+        ExecEnv::GetInstance()->delete_file_thread_pool()->wait();
+
+        for (auto&& log : combined_log->txn_logs()) {
+            for (auto&& s : log.op_write().rowset().segments()) {
+                EXPECT_TRUE(fs::path_exist(_tablet_mgr->segment_location(_tablet_id, s)));
+            }
+        }
+        EXPECT_TRUE(fs::path_exist(_tablet_mgr->combined_txn_log_location(_tablet_id, txn_id)));
+    }
+    {
+        AbortTxnResponse response;
+        _lake_service.abort_txn(nullptr, &request, &response, nullptr);
+
+        ExecEnv::GetInstance()->delete_file_thread_pool()->wait();
+
+        // TxnLog`s and segments should have been deleted
+        for (auto&& log : combined_log->txn_logs()) {
+            for (auto&& s : log.op_write().rowset().segments()) {
+                EXPECT_FALSE(fs::path_exist(_tablet_mgr->segment_location(_tablet_id, s)));
+            }
+        }
+        EXPECT_FALSE(fs::path_exist(_tablet_mgr->combined_txn_log_location(_tablet_id, txn_id)));
     }
 }
 

--- a/be/test/storage/lake/async_delta_writer_test.cpp
+++ b/be/test/storage/lake/async_delta_writer_test.cpp
@@ -177,8 +177,8 @@ TEST_F(LakeAsyncDeltaWriterTest, test_write) {
     // Write
     delta_writer->write(&chunk0, indexes.data(), indexes.size(), [&](const Status& st) { ASSERT_OK(st); });
     // finish
-    delta_writer->finish([&](const Status& st) {
-        ASSERT_OK(st);
+    delta_writer->finish([&](StatusOr<TxnLogPtr> res) {
+        ASSERT_TRUE(res.ok()) << res.ok();
         latch.count_down();
     });
 
@@ -279,8 +279,8 @@ TEST_F(LakeAsyncDeltaWriterTest, test_write_concurrently) {
 
     // finish
     CountDownLatch latch(1);
-    delta_writer->finish([&](const Status& st) {
-        ASSERT_OK(st);
+    delta_writer->finish([&](StatusOr<TxnLogPtr> res) {
+        ASSERT_TRUE(res.ok()) << res.status();
         latch.count_down();
     });
 
@@ -396,8 +396,8 @@ TEST_F(LakeAsyncDeltaWriterTest, test_finish_after_close) {
 
     auto tid = std::this_thread::get_id();
     // finish()
-    delta_writer->finish([&](const Status& st) {
-        ASSERT_ERROR(st);
+    delta_writer->finish([&](StatusOr<TxnLogPtr> res) {
+        ASSERT_FALSE(res.ok());
         ASSERT_EQ(tid, std::this_thread::get_id());
     });
 }
@@ -514,6 +514,43 @@ TEST_F(LakeAsyncDeltaWriterTest, test_concurrent_write_and_close) {
     }));
 
     SyncPoint::GetInstance()->DisableProcessing();
+}
+
+TEST_F(LakeAsyncDeltaWriterTest, test_flush) {
+    // Prepare data for writing
+    static const int kChunkSize = 128;
+    auto chunk0 = generate_data(kChunkSize);
+    auto indexes = std::vector<uint32_t>(kChunkSize);
+    for (int i = 0; i < kChunkSize; i++) {
+        indexes[i] = i;
+    }
+
+    auto txn_id = next_id();
+    auto tablet_id = _tablet_metadata->id();
+    CountDownLatch latch(1);
+    ASSIGN_OR_ABORT(auto delta_writer, AsyncDeltaWriterBuilder()
+                                               .set_tablet_manager(_tablet_mgr.get())
+                                               .set_tablet_id(tablet_id)
+                                               .set_txn_id(txn_id)
+                                               .set_partition_id(_partition_id)
+                                               .set_mem_tracker(_mem_tracker.get())
+                                               .set_schema_id(_tablet_schema->id())
+                                               .build());
+    ASSERT_OK(delta_writer->open());
+    delta_writer->write(&chunk0, indexes.data(), indexes.size(), [&](const Status& st) { ASSERT_OK(st); });
+    delta_writer->flush([&](const Status& st) {
+        ASSERT_OK(st);
+        latch.count_down();
+    });
+    latch.wait();
+    EXPECT_EQ(0, delta_writer->queueing_memtable_num());
+
+    // test flush after close
+    SyncPoint::GetInstance()->LoadDependency({{"AsyncDeltaWriterImpl::close:2", "AsyncDeltaWriterImpl::execute:1"}});
+    SyncPoint::GetInstance()->EnableProcessing();
+    DeferOp defer([&]() { SyncPoint::GetInstance()->DisableProcessing(); });
+    delta_writer->flush([&](const Status& st) { ASSERT_ERROR(st); });
+    delta_writer->close();
 }
 
 } // namespace starrocks::lake

--- a/be/test/storage/lake/metacache_test.cpp
+++ b/be/test/storage/lake/metacache_test.cpp
@@ -342,4 +342,23 @@ TEST_F(LakeMetacacheTest, test_cache_segment_if_absent_concurrency) {
     }
 }
 
+TEST_F(LakeMetacacheTest, test_combined_txn_log_cache) {
+    auto* metacache = _tablet_mgr->metacache();
+
+    auto log = std::make_shared<CombinedTxnLogPB>();
+    metacache->cache_combined_txn_log("combined1", log);
+
+    auto log2 = metacache->lookup_combined_txn_log("combined1");
+    EXPECT_EQ(log.get(), log2.get());
+
+    auto log3 = metacache->lookup_combined_txn_log("combined2");
+    ASSERT_TRUE(log3 == nullptr);
+
+    auto meta = std::make_shared<TabletMetadataPB>();
+    metacache->cache_tablet_metadata("meta1", meta);
+
+    auto log4 = metacache->lookup_combined_txn_log("meta1");
+    ASSERT_TRUE(log4 == nullptr);
+}
+
 } // namespace starrocks::lake

--- a/be/test/storage/lake/schema_change_test.cpp
+++ b/be/test/storage/lake/schema_change_test.cpp
@@ -95,8 +95,12 @@ protected:
     }
 
     Status publish_version_for_schema_change(int64_t tablet_id, int64_t new_version, int64_t txn_id) {
-        return publish_version(_tablet_manager.get(), tablet_id, 1, new_version, std::span<const int64_t>(&txn_id, 1),
-                               time(nullptr))
+        TxnInfoPB txn_info;
+        txn_info.set_txn_id(txn_id);
+        txn_info.set_combined_txn_log(false);
+        txn_info.set_commit_time(time(NULL));
+        return publish_version(_tablet_manager.get(), tablet_id, 1, new_version,
+                               std::span<const TxnInfoPB>(&txn_info, 1))
                 .status();
     }
 

--- a/fe/fe-core/pom.xml
+++ b/fe/fe-core/pom.xml
@@ -982,6 +982,12 @@ under the License.
                                     <arg value="-jar"/>
                                     <arg value="${settings.localRepository}/com/baidu/jprotobuf/${jprotobuf.version}/jprotobuf-${jprotobuf.version}-jar-with-dependencies.jar"/>
                                     <arg value="--java_out=${basedir}/target/generated-sources/proto"/>
+                                    <arg value="${starrocks.home}/gensrc/proto/lake_types.proto"/>
+                                </exec>
+                                <exec executable="${java.home}/bin/java">
+                                    <arg value="-jar"/>
+                                    <arg value="${settings.localRepository}/com/baidu/jprotobuf/${jprotobuf.version}/jprotobuf-${jprotobuf.version}-jar-with-dependencies.jar"/>
+                                    <arg value="--java_out=${basedir}/target/generated-sources/proto"/>
                                     <arg value="${starrocks.home}/gensrc/proto/internal_service.proto"/>
                                 </exec>
                                 <exec executable="${java.home}/bin/java">
@@ -995,12 +1001,6 @@ under the License.
                                     <arg value="${settings.localRepository}/com/baidu/jprotobuf/${jprotobuf.version}/jprotobuf-${jprotobuf.version}-jar-with-dependencies.jar"/>
                                     <arg value="--java_out=${basedir}/target/generated-sources/proto"/>
                                     <arg value="${starrocks.home}/gensrc/proto/tablet_schema.proto"/>
-                                </exec>
-                                <exec executable="${java.home}/bin/java">
-                                    <arg value="-jar"/>
-                                    <arg value="${settings.localRepository}/com/baidu/jprotobuf/${jprotobuf.version}/jprotobuf-${jprotobuf.version}-jar-with-dependencies.jar"/>
-                                    <arg value="--java_out=${basedir}/target/generated-sources/proto"/>
-                                    <arg value="${starrocks.home}/gensrc/proto/lake_types.proto"/>
                                 </exec>
                                 <exec executable="${java.home}/bin/java">
                                     <arg value="-jar"/>

--- a/fe/fe-core/src/main/java/com/starrocks/common/Config.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/Config.java
@@ -853,6 +853,9 @@ public class Config extends ConfigBase {
     @ConfField(mutable = true)
     public static int lake_batch_publish_min_version_num = 1;
 
+    @ConfField(mutable = true)
+    public static boolean lake_use_combined_txn_log = false;
+
     /**
      * The thrift server max worker threads
      */

--- a/fe/fe-core/src/main/java/com/starrocks/lake/LakeTableHelper.java
+++ b/fe/fe-core/src/main/java/com/starrocks/lake/LakeTableHelper.java
@@ -27,13 +27,16 @@ import com.starrocks.catalog.OlapTable;
 import com.starrocks.catalog.Partition;
 import com.starrocks.catalog.PhysicalPartition;
 import com.starrocks.catalog.Tablet;
+import com.starrocks.common.Config;
 import com.starrocks.proto.DropTableRequest;
 import com.starrocks.proto.StatusPB;
 import com.starrocks.rpc.BrpcProxy;
 import com.starrocks.rpc.LakeService;
 import com.starrocks.server.GlobalStateMgr;
+import com.starrocks.server.RunMode;
 import com.starrocks.system.ComputeNode;
 import com.starrocks.thrift.TNetworkAddress;
+import com.starrocks.transaction.TransactionState;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -191,5 +194,14 @@ public class LakeTableHelper {
             }
         }
         return maxId;
+    }
+
+    public static boolean supportCombinedTxnLog(TransactionState.LoadJobSourceType sourceType) {
+        return RunMode.isSharedDataMode() && Config.lake_use_combined_txn_log && hasSingleOlapTableSink(sourceType);
+    }
+
+    private static boolean hasSingleOlapTableSink(TransactionState.LoadJobSourceType sourceType) {
+        return sourceType == TransactionState.LoadJobSourceType.BACKEND_STREAMING ||
+                sourceType == TransactionState.LoadJobSourceType.ROUTINE_LOAD_TASK;
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/lake/PartitionPublishVersionData.java
+++ b/fe/fe-core/src/main/java/com/starrocks/lake/PartitionPublishVersionData.java
@@ -1,0 +1,73 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.lake;
+
+import com.starrocks.proto.TxnInfoPB;
+import com.starrocks.transaction.PartitionCommitInfo;
+import com.starrocks.transaction.TableCommitInfo;
+import com.starrocks.transaction.TransactionState;
+
+import java.util.ArrayList;
+import java.util.List;
+import javax.validation.constraints.NotNull;
+
+import static java.util.Objects.requireNonNull;
+
+public class PartitionPublishVersionData {
+    private final long tableId;
+    private final long partitionId;
+    private final List<TransactionState> transactionStates = new ArrayList<>();
+    private final List<Long> commitVersions = new ArrayList<>();
+    private final List<PartitionCommitInfo> partitionCommitInfos = new ArrayList<>();
+    private final List<TxnInfoPB> txnInfos = new ArrayList<>();
+
+    public PartitionPublishVersionData(long tableId, long partitionId) {
+        this.tableId = tableId;
+        this.partitionId = partitionId;
+    }
+
+    public long getPartitionId() {
+        return partitionId;
+    }
+
+    public void addTransaction(@NotNull TransactionState txnState) {
+        TableCommitInfo tableCommitInfo = requireNonNull(txnState.getTableCommitInfo(tableId));
+        PartitionCommitInfo partitionCommitInfo = requireNonNull(tableCommitInfo.getPartitionCommitInfo(partitionId));
+        commitVersions.add(partitionCommitInfo.getVersion());
+        partitionCommitInfos.add(partitionCommitInfo);
+        transactionStates.add(txnState);
+        txnInfos.add(TxnInfoHelper.fromTransactionState(txnState));
+    }
+
+    @NotNull
+    public List<TransactionState> getTransactionStates() {
+        return transactionStates;
+    }
+
+    @NotNull
+    public List<PartitionCommitInfo> getPartitionCommitInfos() {
+        return partitionCommitInfos;
+    }
+
+    @NotNull
+    public List<Long> getCommitVersions() {
+        return commitVersions;
+    }
+
+    @NotNull
+    public List<TxnInfoPB> getTxnInfos() {
+        return txnInfos;
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/lake/TxnInfoHelper.java
+++ b/fe/fe-core/src/main/java/com/starrocks/lake/TxnInfoHelper.java
@@ -12,18 +12,18 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#pragma once
+package com.starrocks.lake;
 
-#include <memory>
+import com.starrocks.proto.TxnInfoPB;
+import com.starrocks.transaction.TransactionState;
 
-#include "gen_cpp/lake_types.pb.h"
-
-namespace starrocks {
-
-using TxnLog = TxnLogPB;
-using TxnLogPtr = std::shared_ptr<const TxnLog>;
-using MutableTxnLogPtr = std::shared_ptr<TxnLog>;
-using CombinedTxnLog = CombinedTxnLogPB;
-using CombinedTxnLogPtr = std::shared_ptr<const CombinedTxnLog>;
-
-} // namespace starrocks
+public class TxnInfoHelper {
+    public static TxnInfoPB fromTransactionState(TransactionState state) {
+        TxnInfoPB infoPB = new TxnInfoPB();
+        infoPB.txnId = state.getTransactionId();
+        infoPB.combinedTxnLog = state.isCombinedTxnLog();
+        infoPB.commitTime = state.getCommitTime() / 1000; // milliseconds to seconds
+        infoPB.txnType = state.getTxnTypePB();
+        return infoPB;
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/lake/TxnInfoHelper.java
+++ b/fe/fe-core/src/main/java/com/starrocks/lake/TxnInfoHelper.java
@@ -21,7 +21,7 @@ public class TxnInfoHelper {
     public static TxnInfoPB fromTransactionState(TransactionState state) {
         TxnInfoPB infoPB = new TxnInfoPB();
         infoPB.txnId = state.getTransactionId();
-        infoPB.combinedTxnLog = state.isCombinedTxnLog();
+        infoPB.combinedTxnLog = state.isUseCombinedTxnLog();
         infoPB.commitTime = state.getCommitTime() / 1000; // milliseconds to seconds
         infoPB.txnType = state.getTxnTypePB();
         return infoPB;

--- a/fe/fe-core/src/main/java/com/starrocks/planner/OlapTableSink.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/OlapTableSink.java
@@ -188,6 +188,7 @@ public class OlapTableSink extends DataSink {
         if (txnState != null) {
             tSink.setTxn_trace_parent(txnState.getTraceParent());
             tSink.setLabel(txnState.getLabel());
+            tSink.setWrite_txn_log(txnState.isCombinedTxnLog());
         }
         tSink.setDb_id(dbId);
         tSink.setLoad_channel_timeout_s(loadChannelTimeoutS);

--- a/fe/fe-core/src/main/java/com/starrocks/planner/OlapTableSink.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/OlapTableSink.java
@@ -188,7 +188,7 @@ public class OlapTableSink extends DataSink {
         if (txnState != null) {
             tSink.setTxn_trace_parent(txnState.getTraceParent());
             tSink.setLabel(txnState.getLabel());
-            tSink.setWrite_txn_log(txnState.isCombinedTxnLog());
+            tSink.setWrite_txn_log(txnState.isUseCombinedTxnLog());
         }
         tSink.setDb_id(dbId);
         tSink.setLoad_channel_timeout_s(loadChannelTimeoutS);

--- a/fe/fe-core/src/main/java/com/starrocks/transaction/DatabaseTransactionMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/transaction/DatabaseTransactionMgr.java
@@ -61,6 +61,7 @@ import com.starrocks.common.util.DebugUtil;
 import com.starrocks.common.util.TimeUtils;
 import com.starrocks.common.util.concurrent.lock.LockType;
 import com.starrocks.common.util.concurrent.lock.Locker;
+import com.starrocks.lake.LakeTableHelper;
 import com.starrocks.load.routineload.RLTaskTxnCommitAttachment;
 import com.starrocks.metric.MetricRepo;
 import com.starrocks.persist.EditLog;
@@ -181,13 +182,14 @@ public class DatabaseTransactionMgr {
         FeNameFormat.checkLabel(label);
 
         long tid = globalStateMgr.getGlobalTransactionMgr().getTransactionIDGenerator().getNextTransactionId();
+        boolean combinedTxnLog = LakeTableHelper.supportCombinedTxnLog(sourceType);
         LOG.info("begin transaction: txn_id: {} with label {} from coordinator {}, listner id: {}",
                 tid, label, coordinator, listenerId);
         TransactionState transactionState = new TransactionState(dbId, tableIdList, tid, label, requestId, sourceType,
                 coordinator, listenerId, timeoutSecond * 1000);
         transactionState.setPrepareTime(System.currentTimeMillis());
         transactionState.setWarehouseId(warehouseId);
-
+        transactionState.setCombinedTxnLog(combinedTxnLog);
         transactionState.writeLock();
         try {
             writeLock();

--- a/fe/fe-core/src/main/java/com/starrocks/transaction/DatabaseTransactionMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/transaction/DatabaseTransactionMgr.java
@@ -189,7 +189,7 @@ public class DatabaseTransactionMgr {
                 coordinator, listenerId, timeoutSecond * 1000);
         transactionState.setPrepareTime(System.currentTimeMillis());
         transactionState.setWarehouseId(warehouseId);
-        transactionState.setCombinedTxnLog(combinedTxnLog);
+        transactionState.setUseCombinedTxnLog(combinedTxnLog);
         transactionState.writeLock();
         try {
             writeLock();

--- a/fe/fe-core/src/main/java/com/starrocks/transaction/PublishVersionDaemon.java
+++ b/fe/fe-core/src/main/java/com/starrocks/transaction/PublishVersionDaemon.java
@@ -53,9 +53,12 @@ import com.starrocks.common.UserException;
 import com.starrocks.common.util.FrontendDaemon;
 import com.starrocks.common.util.concurrent.lock.LockType;
 import com.starrocks.common.util.concurrent.lock.Locker;
+import com.starrocks.lake.PartitionPublishVersionData;
+import com.starrocks.lake.TxnInfoHelper;
 import com.starrocks.lake.Utils;
 import com.starrocks.lake.compaction.Quantiles;
 import com.starrocks.proto.DeleteTxnLogRequest;
+import com.starrocks.proto.TxnInfoPB;
 import com.starrocks.rpc.BrpcProxy;
 import com.starrocks.rpc.LakeService;
 import com.starrocks.scheduler.Constants;
@@ -79,9 +82,11 @@ import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ThreadPoolExecutor;
+import java.util.stream.Collectors;
 import javax.validation.constraints.NotNull;
 
 public class PublishVersionDaemon extends FrontendDaemon {
@@ -498,14 +503,19 @@ public class PublishVersionDaemon extends FrontendDaemon {
         });
     }
 
-    public boolean publishPartitionBatch(Database db, long tableId, long partitionId, List<Long> txnIds,
-                                         List<Long> versions, List<TransactionState> transactionStates,
+    public boolean publishPartitionBatch(Database db, long tableId, PartitionPublishVersionData publishVersionData,
                                          TransactionStateBatch stateBatch) {
+        final Long partitionId = publishVersionData.getPartitionId();
+        final List<TransactionState> transactionStates = publishVersionData.getTransactionStates();
+        final List<Long> versions = publishVersionData.getCommitVersions();
+        final List<TxnInfoPB> txnInfos = publishVersionData.getTxnInfos();
+
+        Map<Long, Set<Tablet>> shadowTabletsMap = new HashMap<>();
+        Set<Tablet> normalTablets = null;
+
         Locker locker = new Locker();
         locker.lockTablesWithIntensiveDbLock(db, Lists.newArrayList(tableId), LockType.READ);
         // version -> shadowTablets
-        Map<Long, Set<Tablet>> shadowTabletsMap = new HashMap<>();
-        Set<Tablet> normalTablets = null;
         long warehouseId = WarehouseManager.DEFAULT_WAREHOUSE_ID;
         try {
             OlapTable table = (OlapTable) db.getTable(tableId);
@@ -514,13 +524,13 @@ public class PublishVersionDaemon extends FrontendDaemon {
                 return true;
             }
 
-            PhysicalPartition partition = table.getPhysicalPartition(partitionId);
+            PhysicalPartition partition = table.getPhysicalPartition(publishVersionData.getPartitionId());
             if (partition == null) {
                 LOG.info("partition is null in publish partition batch");
                 return true;
             }
             if (partition.getVisibleVersion() + 1 != versions.get(0)) {
-                LOG.info("publish partition batch partition.getVisibleVersion() + 1 != version.get(0)" + " "
+                LOG.error("publish partition batch partition.getVisibleVersion() + 1 != version.get(0)" + " "
                         + partition.getId() + " " + partition.getVisibleVersion() + " " + versions.get(0));
                 return false;
             }
@@ -542,15 +552,12 @@ public class PublishVersionDaemon extends FrontendDaemon {
                             Set<Tablet> tabletsNew = new HashSet<>(index.getTablets());
                             shadowTabletsMap.put(versions.get(i), tabletsNew);
                         }
-
                     } else {
                         normalTablets = (normalTablets == null) ? Sets.newHashSet() : normalTablets;
                         normalTablets.addAll(index.getTablets());
                     }
                 }
-
             }
-
         } finally {
             locker.unLockTablesWithIntensiveDbLock(db, Lists.newArrayList(tableId), LockType.READ);
         }
@@ -561,24 +568,22 @@ public class PublishVersionDaemon extends FrontendDaemon {
         try {
             for (Map.Entry<Long, Set<Tablet>> item : shadowTabletsMap.entrySet()) {
                 int index = versions.indexOf(item.getKey());
-                List<Tablet> publishShdowTablets = new ArrayList<>(item.getValue());
-                Utils.publishLogVersionBatch(publishShdowTablets, txnIds.subList(index, txnIds.size()),
-                        versions.subList(index, versions.size()), warehouseId);
+                List<Tablet> publishShadowTablets = new ArrayList<>(item.getValue());
+                Utils.publishLogVersionBatch(publishShadowTablets,
+                        txnInfos.subList(index, txnInfos.size()),
+                        versions.subList(index, versions.size()),
+                        warehouseId);
             }
             if (CollectionUtils.isNotEmpty(normalTablets)) {
                 Map<Long, Double> compactionScores = new HashMap<>();
                 List<Tablet> publishTablets = new ArrayList<>();
                 publishTablets.addAll(normalTablets);
 
-                // commit time of last transactionState as commitTime
-                long commitTime = transactionStates.get(transactionStates.size() - 1).getCommitTime();
-
                 // used to delete txnLog when publish success
                 Map<ComputeNode, List<Long>> nodeToTablets = new HashMap<>();
-                Utils.publishVersionBatch(publishTablets, txnIds,
-                        startVersion - 1, endVersion, commitTime, compactionScores,
-                        warehouseId,
-                        nodeToTablets);
+                Utils.publishVersionBatch(publishTablets, txnInfos,
+                        startVersion - 1, endVersion, compactionScores, nodeToTablets,
+                        warehouseId);
 
                 Quantiles quantiles = Quantiles.compute(compactionScores.values());
                 stateBatch.setCompactionScore(tableId, partitionId, quantiles);
@@ -586,20 +591,21 @@ public class PublishVersionDaemon extends FrontendDaemon {
             }
         } catch (Exception e) {
             LOG.error("Fail to publish partition {} of txnIds {}:", partitionId,
-                    txnIds, e);
+                    txnInfos.stream().map(i -> i.txnId).collect(Collectors.toList()), e);
             return false;
         }
 
         return true;
     }
 
-    private void submitDeleteTxnLogJob(TransactionStateBatch txnStateBatch, Map<Long, List<Long>> dirtyPartitions) {
+    private void submitDeleteTxnLogJob(TransactionStateBatch txnStateBatch) {
         try {
+            // TODO: do not send abortTxn() requests for transactions with combined txn log.
+            List<Long> txnIds = txnStateBatch.getTxnIds();
             // submit may throw RejectedExecutionException if the task cannot be scheduled for execution
             getDeleteTxnLogExecutor().submit(() -> {
                 txnStateBatch.getPartitionToTablets().entrySet().stream().forEach(entry -> {
                     long partitionId = entry.getKey();
-                    List<Long> txnIds = dirtyPartitions.get(partitionId);
                     Map<ComputeNode, Set<Long>> nodeToTablets = entry.getValue();
 
                     for (Map.Entry<ComputeNode, Set<Long>> entryItem : nodeToTablets.entrySet()) {
@@ -640,47 +646,28 @@ public class PublishVersionDaemon extends FrontendDaemon {
         long dbId = txnStateBatch.getDbId();
         long tableId = txnStateBatch.getTableId();
         List<TransactionState> states = txnStateBatch.getTransactionStates();
-        // partitionId -> txnIdList
-        Map<Long, List<Long>> dirtyPartitions = new HashMap<>();
-        // partitionId -> versionList
-        Map<Long, List<Long>> partitionVersions = new HashMap<>();
-        // partitionId -> transactionState
-        Map<Long, List<TransactionState>> partitionStates = new HashMap<>();
+        Map<Long, PartitionPublishVersionData> publishVersionDataMap = new HashMap<>();
 
         for (TransactionState state : states) {
-            Map<Long, PartitionCommitInfo> partitionCommitInfoMap = state.getTableCommitInfo(tableId)
-                    .getIdToPartitionCommitInfo();
-            for (Map.Entry<Long, PartitionCommitInfo> item : partitionCommitInfoMap.entrySet()) {
-
-                if (!dirtyPartitions.containsKey(item.getKey())) {
-                    dirtyPartitions.put(item.getKey(), new ArrayList<>());
+            TableCommitInfo tableCommitInfo = Objects.requireNonNull(state.getTableCommitInfo(tableId));
+            Map<Long, PartitionCommitInfo> partitionCommitInfoMap = tableCommitInfo.getIdToPartitionCommitInfo();
+            for (Long partitionId : partitionCommitInfoMap.keySet()) {
+                if (!publishVersionDataMap.containsKey(partitionId)) {
+                    publishVersionDataMap.put(partitionId, new PartitionPublishVersionData(tableId, partitionId));
                 }
-                List<Long> partitionCommitInfo = dirtyPartitions.get(item.getKey());
-                partitionCommitInfo.add(state.getTransactionId());
-
-                if (!partitionVersions.containsKey(item.getKey())) {
-                    partitionVersions.put(item.getKey(), new ArrayList<>());
-                }
-                List<Long> versions = partitionVersions.get(item.getKey());
-                versions.add(item.getValue().getVersion());
-
-                if (!partitionStates.containsKey(item.getKey())) {
-                    partitionStates.put(item.getKey(), new ArrayList<>());
-                }
-                List<TransactionState> partitionState = partitionStates.get(item.getKey());
-                partitionState.add(state);
+                PartitionPublishVersionData publishVersionData = publishVersionDataMap.get(partitionId);
+                publishVersionData.addTransaction(state);
             }
         }
 
-        // TODO
-        // make sure the txnIdList is correspond to versions
         Database db = GlobalStateMgr.getCurrentState().getDb(dbId);
 
         if (db == null) {
             LOG.info("the database of transaction batch {} has been deleted", txnStateBatch);
             try {
                 for (TransactionState state : txnStateBatch.getTransactionStates()) {
-                    globalTransactionMgr.finishTransaction(state.getDbId(), state.getTransactionId(), Sets.newHashSet());
+                    globalTransactionMgr.finishTransaction(state.getDbId(), state.getTransactionId(),
+                            Sets.newHashSet());
                 }
             } catch (UserException ex) {
                 LOG.warn("Fail to finish txn Batch " + txnStateBatch, ex);
@@ -690,20 +677,20 @@ public class PublishVersionDaemon extends FrontendDaemon {
 
         List<CompletableFuture<Boolean>> futureList = new ArrayList<>();
 
-        for (Map.Entry<Long, List<Long>> item : dirtyPartitions.entrySet()) {
-            Long partitionId = item.getKey();
-
+        for (PartitionPublishVersionData publishVersionData : publishVersionDataMap.values()) {
             CompletableFuture<Boolean> future = CompletableFuture.supplyAsync(() -> {
-                boolean success = publishPartitionBatch(db, tableId, partitionId, item.getValue(),
-                        partitionVersions.get(partitionId), partitionStates.get(partitionId), txnStateBatch);
-                partitionStates.get(partitionId).stream().forEach(state -> state.getTableCommitInfo(tableId).
-                        getIdToPartitionCommitInfo().get(partitionId).setVersionTime(
-                                success ? System.currentTimeMillis() : -System.currentTimeMillis()));
+                boolean success = publishPartitionBatch(db, tableId, publishVersionData, txnStateBatch);
+                long versionTime = success ? System.currentTimeMillis() : -System.currentTimeMillis();
+                for (PartitionCommitInfo commitInfo : publishVersionData.getPartitionCommitInfos()) {
+                    commitInfo.setVersionTime(versionTime);
+                }
                 return success;
             }, getLakeTaskExecutor()).exceptionally(ex -> {
-                LOG.error("Fail to publish txn batch ");
-                partitionStates.get(partitionId).stream().forEach(state -> state.getTableCommitInfo(tableId).
-                        getIdToPartitionCommitInfo().get(partitionId).setVersionTime(-System.currentTimeMillis()));
+                LOG.error("Fail to publish txn batch", ex);
+                long versionTime = -System.currentTimeMillis();
+                for (PartitionCommitInfo commitInfo : publishVersionData.getPartitionCommitInfos()) {
+                    commitInfo.setVersionTime(versionTime);
+                }
                 return false;
             });
             futureList.add(future);
@@ -717,13 +704,12 @@ public class PublishVersionDaemon extends FrontendDaemon {
             if (success) {
                 try {
                     globalTransactionMgr.finishTransactionBatch(dbId, txnStateBatch, null);
-                    //
                     for (TransactionState state : txnStateBatch.getTransactionStates()) {
                         refreshMvIfNecessary(state);
                     }
 
                     // here create the job to drop txnLog, for the visibleVersion has been updated
-                    submitDeleteTxnLogJob(txnStateBatch, dirtyPartitions);
+                    submitDeleteTxnLogJob(txnStateBatch);
                 } catch (UserException e) {
                     throw new RuntimeException(e);
                 }
@@ -826,14 +812,15 @@ public class PublishVersionDaemon extends FrontendDaemon {
             locker.unLockDatabase(db, LockType.READ);
         }
 
+        TxnInfoPB txnInfo = TxnInfoHelper.fromTransactionState(txnState);
         try {
             if (CollectionUtils.isNotEmpty(shadowTablets)) {
-                Utils.publishLogVersion(shadowTablets, txnId, txnVersion, warehouseId);
+                Utils.publishLogVersion(shadowTablets, txnInfo, txnVersion, warehouseId);
             }
             if (CollectionUtils.isNotEmpty(normalTablets)) {
                 Map<Long, Double> compactionScores = new HashMap<>();
-                Utils.publishVersion(normalTablets, txnId, baseVersion, txnVersion, commitTime / 1000,
-                        compactionScores, warehouseId);
+                Utils.publishVersion(normalTablets, txnInfo, baseVersion, txnVersion, compactionScores,
+                        warehouseId);
 
                 Quantiles quantiles = Quantiles.compute(compactionScores.values());
                 partitionCommitInfo.setCompactionScore(quantiles);

--- a/fe/fe-core/src/main/java/com/starrocks/transaction/TransactionState.java
+++ b/fe/fe-core/src/main/java/com/starrocks/transaction/TransactionState.java
@@ -261,6 +261,10 @@ public class TransactionState implements Writable {
     // error replica ids
     @SerializedName("er")
     private Set<Long> errorReplicas;
+
+    @SerializedName("ctl")
+    private boolean combinedTxnLog;
+
     private final CountDownLatch latch;
 
     // these states need not be serialized
@@ -990,6 +994,14 @@ public class TransactionState implements Writable {
 
     public void setWriteDurationMs(long writeDurationMs) {
         this.writeDurationMs = writeDurationMs;
+    }
+
+    public void setCombinedTxnLog(boolean combinedTxnLog) {
+        this.combinedTxnLog = combinedTxnLog;
+    }
+
+    public boolean isCombinedTxnLog() {
+        return combinedTxnLog;
     }
 
     public ConcurrentMap<String, TOlapTablePartition> getPartitionNameToTPartition() {

--- a/fe/fe-core/src/main/java/com/starrocks/transaction/TransactionState.java
+++ b/fe/fe-core/src/main/java/com/starrocks/transaction/TransactionState.java
@@ -263,7 +263,7 @@ public class TransactionState implements Writable {
     private Set<Long> errorReplicas;
 
     @SerializedName("ctl")
-    private boolean combinedTxnLog;
+    private boolean useCombinedTxnLog;
 
     private final CountDownLatch latch;
 
@@ -996,12 +996,12 @@ public class TransactionState implements Writable {
         this.writeDurationMs = writeDurationMs;
     }
 
-    public void setCombinedTxnLog(boolean combinedTxnLog) {
-        this.combinedTxnLog = combinedTxnLog;
+    public void setUseCombinedTxnLog(boolean useCombinedTxnLog) {
+        this.useCombinedTxnLog = useCombinedTxnLog;
     }
 
-    public boolean isCombinedTxnLog() {
-        return combinedTxnLog;
+    public boolean isUseCombinedTxnLog() {
+        return useCombinedTxnLog;
     }
 
     public ConcurrentMap<String, TOlapTablePartition> getPartitionNameToTPartition() {

--- a/fe/fe-core/src/main/java/com/starrocks/transaction/TransactionStateBatch.java
+++ b/fe/fe-core/src/main/java/com/starrocks/transaction/TransactionStateBatch.java
@@ -119,7 +119,7 @@ public class TransactionStateBatch implements Writable {
     }
 
     public List<Long> getTxnIds() {
-        return transactionStates.stream().map(state -> state.getTransactionId()).collect(Collectors.toList());
+        return transactionStates.stream().map(TransactionState::getTransactionId).collect(Collectors.toList());
     }
 
     // all transactionState in batch have the same table and return the tableId

--- a/fe/fe-core/src/test/java/com/starrocks/alter/LakeTableSchemaChangeJobTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/alter/LakeTableSchemaChangeJobTest.java
@@ -28,6 +28,7 @@ import com.starrocks.common.util.concurrent.MarkedCountDownLatch;
 import com.starrocks.lake.LakeTable;
 import com.starrocks.lake.LakeTablet;
 import com.starrocks.lake.Utils;
+import com.starrocks.proto.TxnInfoPB;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.rpc.RpcException;
 import com.starrocks.server.GlobalStateMgr;
@@ -430,8 +431,8 @@ public class LakeTableSchemaChangeJobTest {
     public void testPublishVersion() throws AlterCancelException {
         new MockUp<Utils>() {
             @Mock
-            public void publishVersion(@NotNull List<Tablet> tablets, long txnId, long baseVersion, long newVersion,
-                                       long commitTime, long warehouseId)
+            public void publishVersion(@NotNull List<Tablet> tablets, TxnInfoPB txnInfo, long baseVersion,
+                                       long newVersion, long warehouseId)
                     throws
                     RpcException {
                 throw new RpcException("publish version failed", "127.0.0.1");
@@ -495,8 +496,8 @@ public class LakeTableSchemaChangeJobTest {
         // Make publish version success
         new MockUp<Utils>() {
             @Mock
-            public void publishVersion(@NotNull List<Tablet> tablets, long txnId, long baseVersion, long newVersion,
-                                       long commitTime, long warehouseId) {
+            public void publishVersion(@NotNull List<Tablet> tablets, TxnInfoPB txnInfo, long baseVersion,
+                                       long newVersion, long warehouseId) {
                 // nothing to do
             }
         };

--- a/fe/fe-core/src/test/java/com/starrocks/lake/LakeTableHelperTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/lake/LakeTableHelperTest.java
@@ -1,0 +1,79 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.lake;
+
+import com.starrocks.catalog.Database;
+import com.starrocks.catalog.Table;
+import com.starrocks.common.Config;
+import com.starrocks.qe.ConnectContext;
+import com.starrocks.server.GlobalStateMgr;
+import com.starrocks.server.RunMode;
+import com.starrocks.sql.ast.CreateDbStmt;
+import com.starrocks.sql.ast.CreateTableStmt;
+import com.starrocks.transaction.TransactionState;
+import com.starrocks.utframe.UtFrameUtils;
+import mockit.Mock;
+import mockit.MockUp;
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+public class LakeTableHelperTest {
+    private static ConnectContext connectContext;
+    private static final String DB_NAME = "test_lake_table_helper";
+
+    @BeforeClass
+    public static void beforeClass() throws Exception {
+        UtFrameUtils.createMinStarRocksCluster(RunMode.SHARED_DATA);
+        // create connect context
+        connectContext = UtFrameUtils.createDefaultCtx();
+        // create database
+        String createDbStmtStr = "create database " + DB_NAME;
+        CreateDbStmt createDbStmt = (CreateDbStmt) UtFrameUtils.parseStmtWithNewParser(createDbStmtStr, connectContext);
+        GlobalStateMgr.getCurrentState().getMetadata().createDb(createDbStmt.getFullDbName());
+    }
+
+    @AfterClass
+    public static void afterClass() {
+    }
+
+    private static LakeTable createTable(String sql) throws Exception {
+        CreateTableStmt createTableStmt = (CreateTableStmt) UtFrameUtils.parseStmtWithNewParser(sql, connectContext);
+        GlobalStateMgr.getCurrentState().getLocalMetastore().createTable(createTableStmt);
+        Table table = testDb().getTable(createTableStmt.getTableName());
+        return (LakeTable) table;
+    }
+
+    private static Database testDb() {
+        return GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(DB_NAME);
+    }
+
+    @Test
+    public void testSupportCombinedTxnLog() throws Exception {
+        Config.lake_use_combined_txn_log = true;
+        Assert.assertTrue(LakeTableHelper.supportCombinedTxnLog(TransactionState.LoadJobSourceType.BACKEND_STREAMING));
+        Assert.assertTrue(LakeTableHelper.supportCombinedTxnLog(TransactionState.LoadJobSourceType.ROUTINE_LOAD_TASK));
+        Assert.assertFalse(LakeTableHelper.supportCombinedTxnLog(TransactionState.LoadJobSourceType.INSERT_STREAMING));
+        Assert.assertFalse(LakeTableHelper.supportCombinedTxnLog(TransactionState.LoadJobSourceType.BATCH_LOAD_JOB));
+        Assert.assertFalse(LakeTableHelper.supportCombinedTxnLog(TransactionState.LoadJobSourceType.LAKE_COMPACTION));
+        Assert.assertFalse(LakeTableHelper.supportCombinedTxnLog(TransactionState.LoadJobSourceType.FRONTEND_STREAMING));
+        Assert.assertFalse(LakeTableHelper.supportCombinedTxnLog(TransactionState.LoadJobSourceType.BYPASS_WRITE));
+        Assert.assertFalse(LakeTableHelper.supportCombinedTxnLog(TransactionState.LoadJobSourceType.DELETE));
+        Assert.assertFalse(LakeTableHelper.supportCombinedTxnLog(TransactionState.LoadJobSourceType.MV_REFRESH));
+        Config.lake_use_combined_txn_log = false;
+        Assert.assertFalse(LakeTableHelper.supportCombinedTxnLog(TransactionState.LoadJobSourceType.BACKEND_STREAMING));
+    }
+}

--- a/fe/fe-core/src/test/java/com/starrocks/lake/LakeTableHelperTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/lake/LakeTableHelperTest.java
@@ -24,8 +24,6 @@ import com.starrocks.sql.ast.CreateDbStmt;
 import com.starrocks.sql.ast.CreateTableStmt;
 import com.starrocks.transaction.TransactionState;
 import com.starrocks.utframe.UtFrameUtils;
-import mockit.Mock;
-import mockit.MockUp;
 import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.BeforeClass;

--- a/gensrc/proto/internal_service.proto
+++ b/gensrc/proto/internal_service.proto
@@ -43,6 +43,7 @@ import "status.proto";
 import "types.proto";
 import "olap_common.proto";
 import "olap_file.proto";
+import "lake_types.proto";
 
 option cc_generic_services = true;
 
@@ -159,6 +160,10 @@ message PLoadChannelProfileConfig {
 
 // Open a tablet writer.
 message PTabletWriterOpenRequest {
+    message LakeTabletParams {
+        optional bool write_txn_log = 1;
+    };
+
     required PUniqueId id = 1;
     required int64 index_id = 2;
     required int64 txn_id = 3;
@@ -188,6 +193,7 @@ message PTabletWriterOpenRequest {
     // tablet's data size larger than this will mark as inmutable
     optional int64 immutable_tablet_size = 33 [default = 0];
     optional PLoadChannelProfileConfig load_channel_profile_config = 34;
+    optional LakeTabletParams lake_tablet_params = 35;
 };
 
 message PTabletWriterOpenResult {
@@ -246,6 +252,10 @@ message PTabletWriterAddChunksRequest {
 }
 
 message PTabletWriterAddBatchResult {
+    message LakeTabletData {
+        repeated TxnLogPB txn_logs = 1;
+    };
+
     required StatusPB status = 1;
     repeated PTabletInfo tablet_vec = 2;
     optional int64 execution_time_us = 3;
@@ -256,6 +266,7 @@ message PTabletWriterAddBatchResult {
     repeated int64 immutable_tablet_ids = 7;
     repeated int64 immutable_partition_ids = 8;
     optional bytes load_channel_profile = 9;
+    optional LakeTabletData lake_tablet_data = 10;
 };
 
 message PTabletWriterAddSegmentRequest {

--- a/gensrc/proto/lake_service.proto
+++ b/gensrc/proto/lake_service.proto
@@ -18,13 +18,15 @@ package starrocks;
 option java_package = "com.starrocks.proto";
 
 import "types.proto";
+import "lake_types.proto";
 import "status.proto";
 
 option cc_generic_services = true;
 
 message PublishVersionRequest {
     repeated int64 tablet_ids = 1;
-    repeated int64 txn_ids = 2;
+    // This field is deprecated now, use |txn_infos| instead.
+    repeated int64 txn_ids = 2; // deprecated
     // |base_version| would be |new_version - txn_ids_size()| now, define
     // it explicitly for more clarity and better forward compatibility.
     optional int64 base_version = 3;
@@ -32,8 +34,9 @@ message PublishVersionRequest {
     // Commit time of the transaction to be published.
     // If the size of txn_ids is greater than 1, commit_time should be the commit time of the last transaction.
     // Meansured as the number of seconds since the Epoch, 1970-01-01 00:00:00 +0000 (UTC)
-    optional int64 commit_time = 5;
+    optional int64 commit_time = 5; // deprecated
     optional int64 timeout_ms = 6;
+    repeated TxnInfoPB txn_infos = 7;
 }
 
 message PublishVersionResponse {
@@ -45,11 +48,12 @@ message PublishVersionResponse {
 
 message AbortTxnRequest {
     repeated int64 tablet_ids = 1;
-    repeated int64 txn_ids = 2;
+    repeated int64 txn_ids = 2; // deprecated
     // Whether need to clean up the txn logs
     optional bool skip_cleanup = 3;
     // Should have the save size with txn_ids or 0
-    repeated TxnTypePB txn_types = 4;
+    repeated TxnTypePB txn_types = 4; // deprecated
+    repeated TxnInfoPB txn_infos = 5;
 }
 
 message AbortTxnResponse {
@@ -68,7 +72,8 @@ message DeleteTabletResponse {
 
 message DeleteTxnLogRequest {
     repeated int64 tablet_ids = 1;
-    repeated int64 txn_ids = 2;
+    repeated int64 txn_ids = 2; // deprecated 
+    repeated TxnInfoPB txn_infos = 3;
 }
 
 message DeleteTxnLogResponse {
@@ -137,14 +142,16 @@ message TabletStatResponse {
 // Rename file txn_{tablet_id}_{txn_id} to vtxn_{tablet_id}_{version}
 message PublishLogVersionRequest {
     repeated int64 tablet_ids = 1;
-    optional int64 txn_id = 2;
+    optional int64 txn_id = 2; // deprecated
     optional int64 version = 3;
+    optional TxnInfoPB txn_info = 4;
 }
 
 message PublishLogVersionBatchRequest {
     repeated int64 tablet_ids = 1;
-    repeated int64 txn_ids = 2;
+    repeated int64 txn_ids = 2; // deprecated
     repeated int64 versions = 3;
+    repeated TxnInfoPB txn_infos = 4;
 }
 
 message PublishLogVersionResponse {

--- a/gensrc/proto/lake_types.proto
+++ b/gensrc/proto/lake_types.proto
@@ -163,6 +163,20 @@ message TxnLogPB {
     optional OpSchemaChange op_schema_change = 5;
     optional OpAlterMetadata op_alter_metadata = 6;
     optional OpReplication op_replication = 7;
+    optional int64 partition_id = 8;
+}
+
+message CombinedTxnLogPB {
+    repeated TxnLogPB txn_logs = 1;    
 }
 
 message TabletMetadataLockPB {}
+
+message TxnInfoPB {
+    optional int64 txn_id = 1;
+    optional int64 commit_time = 2;
+    // Does the transaction generated a combined txn log
+    optional bool combined_txn_log = 3;
+    optional TxnTypePB txn_type = 4;
+};
+

--- a/gensrc/proto/types.proto
+++ b/gensrc/proto/types.proto
@@ -106,7 +106,7 @@ enum WriteQuorumTypePB {
 enum TxnTypePB {
      TXN_NORMAL = 0;
      TXN_REPLICATION = 1;
- }
+}
 
  enum ReplicationTxnStatePB {
      TXN_PREPARED = 0;

--- a/gensrc/thrift/DataSinks.thrift
+++ b/gensrc/thrift/DataSinks.thrift
@@ -227,6 +227,7 @@ struct TOlapTableSink {
     // enable colocated for sync mv 
     27: optional bool enable_colocate_mv_index 
     28: optional i64 automatic_bucket_size
+    29: optional bool write_txn_log
 }
 
 struct TSchemaTableSink {


### PR DESCRIPTION
## Why I'm doing:
In the current implementation, for each data load, each Tablet creates a txn log file on the object store and deletes it after a successful publish version. This will bring a lot of object store access, which can easily lead to request limit exceeded problem, and also some API access billing.

## What I'm doing:
Instead of creating a txn log file for each Tablet at the end of data loading, the OlapTableSink node creates a single combined txn log file containing all tablet txn logs. During the publish version phase, each tablet will get the combined txn log file and find its own txn log from it.

TODO:
- Optimize abort_txn requests to avoid duplicate deletion of combined txn logs
- For transactions using a combined txn log, do not send a delete_txn_log request after the batch publish version succeeds

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [x] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
