### PR TITLE
[Enhancement] Remove duplicated http request log

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/http/HttpServerHandler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/http/HttpServerHandler.java
@@ -105,8 +105,8 @@ public class HttpServerHandler extends ChannelInboundHandlerAdapter {
                     long latency = System.currentTimeMillis() - startTime;
                     metrics.handlingRequestsNum.increase(-1L);
                     metrics.requestHandleLatencyMs.update(latency);
-                    if (latency > Config.http_slow_request_threshold_ms) {
-                        LOG.info("receive http request. uri: {}, thread id: {}, startTime: {}, latency: {} ms",
+                    if (latency >= Config.http_slow_request_threshold_ms) {
+                        LOG.warn("receive slow http request. uri: {}, thread id: {}, startTime: {}, latency: {} ms",
                                 WebUtils.sanitizeHttpReqUri(req.getRequest().uri()), Thread.currentThread().getId(),
                                 startTime, latency);
                     }

--- a/fe/fe-core/src/main/java/com/starrocks/http/HttpServerHandler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/http/HttpServerHandler.java
@@ -34,6 +34,7 @@
 
 package com.starrocks.http;
 
+import com.starrocks.common.Config;
 import com.starrocks.http.action.IndexAction;
 import com.starrocks.http.action.NotFoundAction;
 import io.netty.buffer.Unpooled;
@@ -104,11 +105,11 @@ public class HttpServerHandler extends ChannelInboundHandlerAdapter {
                     long latency = System.currentTimeMillis() - startTime;
                     metrics.handlingRequestsNum.increase(-1L);
                     metrics.requestHandleLatencyMs.update(latency);
-                    LOG.info("receive http request. url: {}, thread id: {}, startTime: {}, latency: {} ms",
-                            req.getRequest().uri(), Thread.currentThread().getId(), startTime, latency);
-                    LOG.info("receive http request. uri: {}, thread id: {}, startTime: {}, latency: {} ms",
-                            WebUtils.sanitizeHttpReqUri(req.getRequest().uri()), Thread.currentThread().getId(),
-                            startTime, latency);
+                    if (latency > Config.http_slow_request_threshold_ms) {
+                        LOG.info("receive http request. uri: {}, thread id: {}, startTime: {}, latency: {} ms",
+                                WebUtils.sanitizeHttpReqUri(req.getRequest().uri()), Thread.currentThread().getId(),
+                                startTime, latency);
+                    }
                 }
             }
         } else {


### PR DESCRIPTION
## Why I'm doing:
HttpServerHandler.channelRead() logs duplicated messages

## What I'm doing:
remove the duplicate log, and only log if the latency of http request is larger than Config.http_slow_request_threshold_ms

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [X] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [x] 3.1
  - [ ] 3.0
  - [ ] 2.5
