### PR TITLE
[Feature] Use new data format of memtable for multi-version

### DIFF
--- a/be/src/storage/lake/lake_persistent_index.cpp
+++ b/be/src/storage/lake/lake_persistent_index.cpp
@@ -29,24 +29,25 @@ LakePersistentIndex::~LakePersistentIndex() {
 Status LakePersistentIndex::get(size_t n, const Slice* keys, IndexValue* values) {
     KeyIndexesInfo not_founds;
     size_t num_found;
-    return _memtable->get(n, keys, values, &not_founds, &num_found);
+    // Assuming we always want the latest value now
+    return _memtable->get(n, keys, values, &not_founds, &num_found, -1);
 }
 
 Status LakePersistentIndex::upsert(size_t n, const Slice* keys, const IndexValue* values, IndexValue* old_values,
                                    IOStat* stat) {
     KeyIndexesInfo not_founds;
     size_t num_found;
-    return _memtable->upsert(n, keys, values, old_values, &not_founds, &num_found);
+    return _memtable->upsert(n, keys, values, old_values, &not_founds, &num_found, _version.major_number());
 }
 
 Status LakePersistentIndex::insert(size_t n, const Slice* keys, const IndexValue* values, int64_t version) {
-    return _memtable->insert(n, keys, values);
+    return _memtable->insert(n, keys, values, version);
 }
 
 Status LakePersistentIndex::erase(size_t n, const Slice* keys, IndexValue* old_values) {
     KeyIndexesInfo not_founds;
     size_t num_found;
-    return _memtable->erase(n, keys, old_values, &not_founds, &num_found);
+    return _memtable->erase(n, keys, old_values, &not_founds, &num_found, _version.major_number());
 }
 
 Status LakePersistentIndex::try_replace(size_t n, const Slice* keys, const IndexValue* values,
@@ -63,7 +64,7 @@ Status LakePersistentIndex::try_replace(size_t n, const Slice* keys, const Index
             failed->emplace_back(values[i].get_value() & 0xFFFFFFFF);
         }
     }
-    RETURN_IF_ERROR(_memtable->replace(keys, values, replace_idxes));
+    RETURN_IF_ERROR(_memtable->replace(keys, values, replace_idxes, _version.major_number()));
     return Status::OK();
 }
 

--- a/be/src/storage/lake/persistent_index_memtable.cpp
+++ b/be/src/storage/lake/persistent_index_memtable.cpp
@@ -16,14 +16,8 @@
 
 namespace starrocks::lake {
 
-void PersistentIndexMemtable::insert(const std::string& key, int64_t version, const IndexValue& value) {
-    std::list<IndexValueInfo> index_value_infos;
-    index_value_infos.emplace_front(version, value);
-    _map.emplace(key, index_value_infos);
-}
-
-void PersistentIndexMemtable::update(std::list<IndexValueInfo>* index_value_infos, int64_t version,
-                                     const IndexValue& value) {
+void PersistentIndexMemtable::update_index_value(std::list<IndexValueInfo>* index_value_infos, int64_t version,
+                                                 const IndexValue& value) {
     std::list<IndexValueInfo> t;
     t.emplace_front(version, value);
     index_value_infos->swap(t);
@@ -35,16 +29,16 @@ Status PersistentIndexMemtable::upsert(size_t n, const Slice* keys, const IndexV
     for (size_t i = 0; i < n; ++i) {
         auto key = keys[i].to_string();
         const auto value = values[i];
-        auto it = _map.find(key);
-        if (it == _map.end()) {
+        std::list<IndexValueInfo> index_value_infos;
+        index_value_infos.emplace_front(version, value);
+        if (auto [it, inserted] = _map.emplace(key, index_value_infos); inserted) {
             not_found->key_index_infos.emplace_back(i);
-            insert(key, version, value);
         } else {
-            auto& index_value_infos = it->second;
-            auto old_value = index_value_infos.front().second;
+            auto& old_index_value_infos = it->second;
+            auto old_value = old_index_value_infos.front().second;
             old_values[i] = old_value;
             nfound += old_value.get_value() != NullIndexValue;
-            update(&it->second, version, value);
+            update_index_value(&old_index_value_infos, version, value);
         }
     }
     *num_found = nfound;
@@ -56,13 +50,13 @@ Status PersistentIndexMemtable::insert(size_t n, const Slice* keys, const IndexV
         auto key = keys[i].to_string();
         auto size = keys[i].get_size();
         const auto value = values[i];
-        auto it = _map.find(key);
-        if (it != _map.end()) {
+        std::list<IndexValueInfo> index_value_infos;
+        index_value_infos.emplace_front(version, value);
+        if (auto [it, inserted] = _map.emplace(key, index_value_infos); !inserted) {
             std::string msg = strings::Substitute("PersistentIndexMemtable<$0> insert found duplicate key $1", size,
                                                   hexdump((const char*)key.data(), size));
+            LOG(WARNING) << msg;
             return Status::AlreadyExist(msg);
-        } else {
-            insert(key, version, value);
         }
     }
     return Status::OK();
@@ -73,17 +67,17 @@ Status PersistentIndexMemtable::erase(size_t n, const Slice* keys, IndexValue* o
     size_t nfound = 0;
     for (size_t i = 0; i < n; ++i) {
         auto key = keys[i].to_string();
-        auto it = _map.find(key);
-        if (it == _map.end()) {
+        std::list<IndexValueInfo> index_value_infos;
+        index_value_infos.emplace_front(version, IndexValue(NullIndexValue));
+        if (auto [it, inserted] = _map.emplace(key, index_value_infos); inserted) {
             old_values[i] = NullIndexValue;
             not_found->key_index_infos.emplace_back(i);
-            insert(key, version, IndexValue(NullIndexValue));
         } else {
-            auto& index_value_infos = it->second;
-            auto old_index_value = index_value_infos.front().second;
+            auto& old_index_value_infos = it->second;
+            auto old_index_value = old_index_value_infos.front().second;
             old_values[i] = old_index_value;
             nfound += old_index_value.get_value() != NullIndexValue;
-            update(&index_value_infos, version, IndexValue(NullIndexValue));
+            update_index_value(&old_index_value_infos, version, IndexValue(NullIndexValue));
         }
     }
     *num_found = nfound;
@@ -95,11 +89,10 @@ Status PersistentIndexMemtable::replace(const Slice* keys, const IndexValue* val
     for (unsigned long idx : replace_idxes) {
         auto key = keys[idx].to_string();
         const auto value = values[idx];
-        auto it = _map.find(key);
-        if (it == _map.end()) {
-            insert(key, version, value);
-        } else {
-            update(&it->second, version, value);
+        std::list<IndexValueInfo> index_value_infos;
+        index_value_infos.emplace_front(version, value);
+        if (auto [it, inserted] = _map.emplace(key, index_value_infos); !inserted) {
+            update_index_value(&it->second, version, value);
         }
     }
     return Status::OK();

--- a/be/src/storage/lake/persistent_index_memtable.h
+++ b/be/src/storage/lake/persistent_index_memtable.h
@@ -46,9 +46,8 @@ public:
     void clear();
 
 private:
-    void insert(const std::string& key, int64_t version, const IndexValue& value);
-
-    static void update(std::list<IndexValueInfo>* index_value_info, int64_t version, const IndexValue& value);
+    static void update_index_value(std::list<IndexValueInfo>* index_value_info, int64_t version,
+                                   const IndexValue& value);
 
 private:
     phmap::btree_map<std::string, std::list<IndexValueInfo>, std::less<>> _map;

--- a/be/src/storage/lake/persistent_index_memtable.h
+++ b/be/src/storage/lake/persistent_index_memtable.h
@@ -21,28 +21,27 @@
 namespace starrocks::lake {
 
 using IndexValueInfo = std::pair<int64_t, IndexValue>;
-static constexpr uint64_t LatestVersion = -1;
 
 class PersistentIndexMemtable {
 public:
     // |version|: version of index values
     Status upsert(size_t n, const Slice* keys, const IndexValue* values, IndexValue* old_values,
-                  KeyIndexesInfo* not_found, size_t* num_found, int64_t version = LatestVersion);
+                  KeyIndexesInfo* not_found, size_t* num_found, int64_t version);
 
     // |version|: version of index values
-    Status insert(size_t n, const Slice* keys, const IndexValue* values, int64_t version = LatestVersion);
+    Status insert(size_t n, const Slice* keys, const IndexValue* values, int64_t version);
 
     // |version|: version of index values
     Status erase(size_t n, const Slice* keys, IndexValue* old_values, KeyIndexesInfo* not_found, size_t* num_found,
-                 int64_t version = LatestVersion);
+                 int64_t version);
 
     // |version|: version of index values
     Status replace(const Slice* keys, const IndexValue* values, const std::vector<size_t>& replace_idxes,
-                   int64_t version = LatestVersion);
+                   int64_t version);
 
     // |version|: version of index values
     Status get(size_t n, const Slice* keys, IndexValue* values, KeyIndexesInfo* not_found, size_t* num_found,
-               int64_t version = LatestVersion);
+               int64_t version);
 
     void clear();
 

--- a/be/src/storage/lake/persistent_index_memtable.h
+++ b/be/src/storage/lake/persistent_index_memtable.h
@@ -21,34 +21,35 @@
 namespace starrocks::lake {
 
 using IndexValueInfo = std::pair<int64_t, IndexValue>;
+static constexpr uint64_t LatestVersion = -1;
 
 class PersistentIndexMemtable {
 public:
-    // |version|: version of index values, -1 means latest version
+    // |version|: version of index values
     Status upsert(size_t n, const Slice* keys, const IndexValue* values, IndexValue* old_values,
-                  KeyIndexesInfo* not_found, size_t* num_found, int64_t version = -1);
+                  KeyIndexesInfo* not_found, size_t* num_found, int64_t version = LatestVersion);
 
-    // |version|: version of index values, -1 means latest version
-    Status insert(size_t n, const Slice* keys, const IndexValue* values, int64_t version = -1);
+    // |version|: version of index values
+    Status insert(size_t n, const Slice* keys, const IndexValue* values, int64_t version = LatestVersion);
 
-    // |version|: version of index values, -1 means latest version
+    // |version|: version of index values
     Status erase(size_t n, const Slice* keys, IndexValue* old_values, KeyIndexesInfo* not_found, size_t* num_found,
-                 int64_t version = -1);
+                 int64_t version = LatestVersion);
 
-    // |version|: version of index values, -1 means latest version
+    // |version|: version of index values
     Status replace(const Slice* keys, const IndexValue* values, const std::vector<size_t>& replace_idxes,
-                   int64_t version = -1);
+                   int64_t version = LatestVersion);
 
-    // |version|: version of index values, -1 means latest version
+    // |version|: version of index values
     Status get(size_t n, const Slice* keys, IndexValue* values, KeyIndexesInfo* not_found, size_t* num_found,
-               int64_t version = -1);
+               int64_t version = LatestVersion);
 
     void clear();
 
 private:
     void insert(const std::string& key, int64_t version, const IndexValue& value);
 
-    static void update(std::list<IndexValueInfo>& index_value_info, int64_t version, const IndexValue& value);
+    static void update(std::list<IndexValueInfo>* index_value_info, int64_t version, const IndexValue& value);
 
 private:
     phmap::btree_map<std::string, std::list<IndexValueInfo>, std::less<>> _map;

--- a/be/test/storage/lake/persistent_index_memtable_test.cpp
+++ b/be/test/storage/lake/persistent_index_memtable_test.cpp
@@ -35,15 +35,15 @@ TEST(PersistentIndexMemtableTest, test_basic_api) {
         key_slices.emplace_back((uint8_t*)(&keys[i]), sizeof(Key));
     }
     auto memtable = std::make_unique<PersistentIndexMemtable>();
-    ASSERT_OK(memtable->insert(N, key_slices.data(), values.data()));
+    ASSERT_OK(memtable->insert(N, key_slices.data(), values.data(), -1));
     // insert duplicate should return error
-    ASSERT_FALSE(memtable->insert(N, key_slices.data(), values.data()).ok());
+    ASSERT_FALSE(memtable->insert(N, key_slices.data(), values.data(), -1).ok());
 
     // test get
     vector<IndexValue> get_values(keys.size());
     KeyIndexesInfo get_not_found;
     size_t get_num_found = 0;
-    ASSERT_TRUE(memtable->get(N, key_slices.data(), get_values.data(), &get_not_found, &get_num_found).ok());
+    ASSERT_TRUE(memtable->get(N, key_slices.data(), get_values.data(), &get_not_found, &get_num_found, -1).ok());
     ASSERT_EQ(keys.size(), get_num_found);
     ASSERT_EQ(get_not_found.size(), 0);
     for (int i = 0; i < values.size(); i++) {
@@ -61,7 +61,8 @@ TEST(PersistentIndexMemtableTest, test_basic_api) {
     KeyIndexesInfo get2_not_found;
     size_t get2_num_found = 0;
     // should only find 0,2,..N-2, not found: N,N+2, .. N*2-2
-    ASSERT_TRUE(memtable->get(N, get2_key_slices.data(), get2_values.data(), &get2_not_found, &get2_num_found).ok());
+    ASSERT_TRUE(
+            memtable->get(N, get2_key_slices.data(), get2_values.data(), &get2_not_found, &get2_num_found, -1).ok());
     ASSERT_EQ(N / 2, get2_num_found);
 
     // test erase
@@ -78,9 +79,9 @@ TEST(PersistentIndexMemtableTest, test_basic_api) {
     vector<IndexValue> erase_old_values(erase_keys.size());
     KeyIndexesInfo erase_not_found;
     size_t erase_num_found = 0;
-    ASSERT_TRUE(
-            memtable->erase(num, erase_key_slices.data(), erase_old_values.data(), &erase_not_found, &erase_num_found)
-                    .ok());
+    ASSERT_TRUE(memtable->erase(num, erase_key_slices.data(), erase_old_values.data(), &erase_not_found,
+                                &erase_num_found, -1)
+                        .ok());
     ASSERT_EQ(erase_num_found, (N + 2) / 3);
     // N+2 not found
     ASSERT_EQ(erase_not_found.size(), 1);
@@ -109,7 +110,7 @@ TEST(PersistentIndexMemtableTest, test_basic_api) {
     KeyIndexesInfo upsert_not_found;
     size_t upsert_num_found = 0;
     ASSERT_TRUE(memtable->upsert(N, upsert_key_slices.data(), upsert_values.data(), upsert_old_values.data(),
-                                 &upsert_not_found, &upsert_num_found)
+                                 &upsert_not_found, &upsert_num_found, -1)
                         .ok());
     ASSERT_EQ(upsert_num_found, expect_exists);
     ASSERT_EQ(upsert_not_found.size(), expect_not_found);
@@ -134,16 +135,16 @@ TEST(PersistentIndexMemtableTest, test_replace) {
     }
 
     auto memtable = std::make_unique<PersistentIndexMemtable>();
-    ASSERT_OK(memtable->insert(N, key_slices.data(), values.data()));
+    ASSERT_OK(memtable->insert(N, key_slices.data(), values.data(), -1));
 
     //replace
-    Status st = memtable->replace(key_slices.data(), replace_values.data(), replace_idxes);
+    Status st = memtable->replace(key_slices.data(), replace_values.data(), replace_idxes, -1);
     ASSERT_TRUE(st.ok());
     std::vector<IndexValue> new_get_values(keys.size());
     KeyIndexesInfo get_not_found;
     size_t get_num_found = 0;
-    ASSERT_TRUE(
-            memtable->get(keys.size(), key_slices.data(), new_get_values.data(), &get_not_found, &get_num_found).ok());
+    ASSERT_TRUE(memtable->get(keys.size(), key_slices.data(), new_get_values.data(), &get_not_found, &get_num_found, -1)
+                        .ok());
     ASSERT_EQ(keys.size(), new_get_values.size());
     for (int i = 0; i < N; i++) {
         ASSERT_EQ(replace_values[i], new_get_values[i]);


### PR DESCRIPTION
## Why I'm doing:
In #33441, memtable has been implemented. But in this implementation, we need to encode the version in the key. When we want to read the latest version, we may need to scan all the map and decode every key which may cause poor performance. The most common scenarios in pk index is to get the latest version now.
## What I'm doing:
We design a new data format for memtable. We use `std::list<pair<int64_t, IndexValue>>` for multi-versions. The latest version will always the front of the list so we do not need to decode the key. To support multi-version in future, the previous versions will also be stored in the list. We only support storing the latest version now. Version is passed by `LakePersistentIndex`.

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [x] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
