### PR TITLE
[Feature] Add version in insert api of LakePersistentIndex

### DIFF
--- a/be/src/storage/lake/lake_persistent_index.cpp
+++ b/be/src/storage/lake/lake_persistent_index.cpp
@@ -39,7 +39,7 @@ Status LakePersistentIndex::upsert(size_t n, const Slice* keys, const IndexValue
     return _memtable->upsert(n, keys, values, old_values, &not_founds, &num_found);
 }
 
-Status LakePersistentIndex::insert(size_t n, const Slice* keys, const IndexValue* values, bool check_l1) {
+Status LakePersistentIndex::insert(size_t n, const Slice* keys, const IndexValue* values, int64_t version) {
     return _memtable->insert(n, keys, values);
 }
 

--- a/be/src/storage/lake/lake_persistent_index.h
+++ b/be/src/storage/lake/lake_persistent_index.h
@@ -43,13 +43,6 @@ public:
     Status upsert(size_t n, const Slice* keys, const IndexValue* values, IndexValue* old_values,
                   IOStat* stat = nullptr) override;
 
-    // batch insert, return error if key already exists
-    // |n|: size of key/value array
-    // |keys|: key array as raw buffer
-    // |values|: value array
-    // |check_l1|: also check l1 for insertion consistency(key must not exist previously), may imply heavy IO costs
-    Status insert(size_t n, const Slice* keys, const IndexValue* values, bool check_l1) override;
-
     // batch erase
     // |n|: size of key/value array
     // |keys|: key array as raw buffer
@@ -64,6 +57,13 @@ public:
     // |failed|: return not match rowid
     Status try_replace(size_t n, const Slice* keys, const IndexValue* values, const uint32_t max_src_rssid,
                        std::vector<uint32_t>* failed) override;
+
+    // batch insert, return error if key already exists
+    // |n|: size of key/value array
+    // |keys|: key array as raw buffer
+    // |values|: value array
+    // |version|: version of values
+    Status insert(size_t n, const Slice* keys, const IndexValue* values, int64_t version);
 
     Status minor_compact();
 

--- a/be/src/storage/persistent_index.h
+++ b/be/src/storage/persistent_index.h
@@ -720,7 +720,7 @@ public:
     // |keys|: key array as raw buffer
     // |values|: value array
     // |check_l1|: also check l1 for insertion consistency(key must not exist previously), may imply heavy IO costs
-    virtual Status insert(size_t n, const Slice* keys, const IndexValue* values, bool check_l1);
+    Status insert(size_t n, const Slice* keys, const IndexValue* values, bool check_l1);
 
     // batch erase
     // |n|: size of key/value array

--- a/be/test/storage/lake/lake_persistent_index_test.cpp
+++ b/be/test/storage/lake/lake_persistent_index_test.cpp
@@ -36,9 +36,9 @@ TEST(LakePersistentIndexTest, test_basic_api) {
         key_slices.emplace_back((uint8_t*)(&keys[i]), sizeof(Key));
     }
     auto index = std::make_unique<LakePersistentIndex>("");
-    ASSERT_OK(index->insert(N, key_slices.data(), values.data(), false));
+    ASSERT_OK(index->insert(N, key_slices.data(), values.data(), 0));
     // insert duplicate should return error
-    ASSERT_FALSE(index->insert(N, key_slices.data(), values.data(), false).ok());
+    ASSERT_FALSE(index->insert(N, key_slices.data(), values.data(), 0).ok());
 
     // test get
     vector<IndexValue> get_values(keys.size());


### PR DESCRIPTION
## Why I'm doing:
LakePersistentIndex is designed to support multi-version. We need a parameter version in insert api.
## What I'm doing:
Add version in persistent index api
Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [x] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
