### PR TITLE
[BugFix] skip checking chunk size for load job (backport #40756)

### DIFF
--- a/be/src/service/internal_service.cpp
+++ b/be/src/service/internal_service.cpp
@@ -299,6 +299,10 @@ Status PInternalServiceImplBase<T>::_exec_plan_fragment(brpc::Controller* cntl) 
     if (UNLIKELY(!t_request.query_options.__isset.batch_size)) {
         return Status::InvalidArgument("batch_size is not set");
     }
+    // Before version 2.5, broker load was not executed in the pipeline engine.
+    // The batch_size params may not be set in the request sent by FE.
+    // During the grayscale upgrade process, the request sent by the old version of FE will report an error.
+    // For compatibility, choose to skip checking batch_size for load job here.
     bool need_check_chunk_size = true;
     if (t_request.query_options.__isset.query_type && t_request.query_options.query_type == TQueryType::LOAD) {
         need_check_chunk_size = false;

--- a/be/src/service/internal_service.cpp
+++ b/be/src/service/internal_service.cpp
@@ -295,14 +295,21 @@ Status PInternalServiceImplBase<T>::_exec_plan_fragment(brpc::Controller* cntl) 
         uint32_t len = ser_request.size();
         RETURN_IF_ERROR(deserialize_thrift_msg(buf, &len, TProtocolType::BINARY, &t_request));
     }
+
     if (UNLIKELY(!t_request.query_options.__isset.batch_size)) {
         return Status::InvalidArgument("batch_size is not set");
     }
-    auto batch_size = t_request.query_options.batch_size;
-    if (UNLIKELY(batch_size <= 0 || batch_size > MAX_CHUNK_SIZE)) {
-        return Status::InvalidArgument(
-                fmt::format("batch_size is out of range, it must be in the range (0, {}], current value is [{}]",
-                            MAX_CHUNK_SIZE, batch_size));
+    bool need_check_chunk_size = true;
+    if (t_request.query_options.__isset.query_type && t_request.query_options.query_type == TQueryType::LOAD) {
+        need_check_chunk_size = false;
+    }
+    if (need_check_chunk_size) {
+        auto batch_size = t_request.query_options.batch_size;
+        if (UNLIKELY(batch_size <= 0 || batch_size > MAX_CHUNK_SIZE)) {
+            return Status::InvalidArgument(
+                    fmt::format("batch_size is out of range, it must be in the range (0, {}], current value is [{}]",
+                                MAX_CHUNK_SIZE, batch_size));
+        }
     }
 
     bool is_pipeline = t_request.__isset.is_pipeline && t_request.is_pipeline;


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:

fix compitable issue introduced by #40756

this is because broker load in version-2.3 not use pipeline engine and not set batch_size, so BE will report error.
we choose to skip checking chunk size for load job to avoid this issue.

fix https://github.com/StarRocks/StarRocksTest/issues/6534


## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [x] This is a backport pr

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5

