### PR TITLE
[BugFix] fix alter foreign key constraint bug in fe follower

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/alter/AlterMVJobExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/AlterMVJobExecutor.java
@@ -218,6 +218,11 @@ public class AlterMVJobExecutor extends AlterJobExecutor {
         }
         if (propClone.containsKey(PropertyAnalyzer.PROPERTIES_FOREIGN_KEY_CONSTRAINT)) {
             materializedView.setForeignKeyConstraints(foreignKeyConstraints);
+            // get the updated foreign key constraint from table property.
+            // for external table, create time is added into FOREIGN_KEY_CONSTRAINT
+            Map<String, String> mvProperties = materializedView.getTableProperty().getProperties();
+            String foreignKeys = mvProperties.get(PropertyAnalyzer.PROPERTIES_FOREIGN_KEY_CONSTRAINT);
+            propClone.put(PropertyAnalyzer.PROPERTIES_FOREIGN_KEY_CONSTRAINT, foreignKeys);
             isChanged = true;
         }
         if (propClone.containsKey(PropertyAnalyzer.PROPERTIES_MV_REWRITE_STALENESS_SECOND)) {

--- a/fe/fe-core/src/test/java/com/starrocks/alter/AlterTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/alter/AlterTest.java
@@ -58,6 +58,8 @@ import com.starrocks.common.MetaNotFoundException;
 import com.starrocks.common.UserException;
 import com.starrocks.common.util.TimeUtils;
 import com.starrocks.persist.ListPartitionPersistInfo;
+import com.starrocks.persist.ModifyTablePropertyOperationLog;
+import com.starrocks.persist.OperationType;
 import com.starrocks.persist.PartitionPersistInfoV2;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.qe.DDLStmtExecutor;
@@ -93,6 +95,7 @@ import com.starrocks.sql.ast.SingleItemListPartitionDesc;
 import com.starrocks.sql.ast.TruncatePartitionClause;
 import com.starrocks.sql.ast.TruncateTableStmt;
 import com.starrocks.sql.ast.UserIdentity;
+import com.starrocks.sql.plan.ConnectorPlanTestBase;
 import com.starrocks.thrift.TStorageMedium;
 import com.starrocks.utframe.StarRocksAssert;
 import com.starrocks.utframe.UtFrameUtils;
@@ -2466,5 +2469,63 @@ public class AlterTest {
         String sql = "ALTER TABLE t2 ADD PARTITIONS START (\"2021-01-04\") END (\"2021-01-06\") EVERY (INTERVAL 1 DAY);";
         AlterTableStmt alterTableStmt = (AlterTableStmt) UtFrameUtils.parseStmtWithNewParser(sql, ctx);
         GlobalStateMgr.getCurrentState().getLocalMetastore().alterTable(alterTableStmt);
+    }
+
+    @Test
+    public void testAlterForeignKey() throws Exception {
+        UtFrameUtils.setUpForPersistTest();
+        ConnectorPlanTestBase.mockHiveCatalog(connectContext);
+        {
+            // inner table
+            starRocksAssert.useDatabase("test").withMaterializedView("create materialized view if not exists `fk_mv_1` " +
+                    "refresh manual " +
+                    "as " +
+                    "select t1.event_day, t1.site_id, t2.user_name " +
+                    "from site_access_date_trunc t1 join site_access_time_slice t2 " +
+                    "on t1.site_id = t2.site_id");
+            connectContext.executeSql("alter materialized view fk_mv_1 set " +
+                    "( 'unique_constraints'='site_access_date_trunc.site_id'); ");
+            connectContext.executeSql("alter materialized view fk_mv_1 set " +
+                    "( 'foreign_key_constraints'='site_access_time_slice(site_id)" +
+                    " REFERENCES site_access_date_trunc(site_id)'); ");
+            while (true) {
+                ModifyTablePropertyOperationLog modifyMvLog =
+                        (ModifyTablePropertyOperationLog) UtFrameUtils.PseudoJournalReplayer.
+                                replayNextJournal(OperationType.OP_ALTER_MATERIALIZED_VIEW_PROPERTIES);
+                Assert.assertNotNull(modifyMvLog);
+                if (modifyMvLog.getProperties().containsKey("foreign_key_constraints")) {
+                    Assert.assertEquals("default_catalog.10001.10133(site_id) " +
+                                    "REFERENCES default_catalog.10001.10118(site_id)",
+                            modifyMvLog.getProperties().get("foreign_key_constraints"));
+                    break;
+                }
+            }
+        }
+
+        {
+            // external table
+            starRocksAssert.withMaterializedView("create materialized view if not exists `fk_mv_2` " +
+                    "refresh manual " +
+                    "as " +
+                    "select t1.l_orderkey, t1.l_partkey, t2.o_totalprice " +
+                    "from hive0.tpch.lineitem t1 join hive0.tpch.orders t2 " +
+                    "on t1.l_orderkey = t2.o_orderkey");
+            connectContext.executeSql("alter materialized view fk_mv_2 set " +
+                    "( 'unique_constraints'='hive0.tpch.orders.o_orderkey'); ");
+            connectContext.executeSql("alter materialized view fk_mv_2 set " +
+                    "( 'foreign_key_constraints'='hive0.tpch.lineitem(l_orderkey) " +
+                    "REFERENCES hive0.tpch.orders(o_orderkey)'); ");
+            while (true) {
+                ModifyTablePropertyOperationLog modifyMvLog =
+                        (ModifyTablePropertyOperationLog) UtFrameUtils.PseudoJournalReplayer.
+                                replayNextJournal(OperationType.OP_ALTER_MATERIALIZED_VIEW_PROPERTIES);
+                Assert.assertNotNull(modifyMvLog);
+                if (modifyMvLog.getProperties().containsKey("foreign_key_constraints")) {
+                    Assert.assertEquals("hive0.tpch.lineitem:0(l_orderkey) REFERENCES hive0.tpch.orders:0(o_orderkey)",
+                            modifyMvLog.getProperties().get("foreign_key_constraints"));
+                    break;
+                }
+            }
+        }
     }
 }


### PR DESCRIPTION
## Why I'm doing:
alter foreign key constraint will fail n fe follower because the foreign key lose the table identifier.

## What I'm doing:
Add table identifier into alter log to make sure replay is ok.

Fixes SR-24423

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
