### PR TITLE
[Enhancement] user variable support array type

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/analysis/UserVariableExpr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/analysis/UserVariableExpr.java
@@ -1,0 +1,81 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.analysis;
+
+import com.starrocks.sql.ast.AstVisitor;
+import com.starrocks.sql.parser.NodePosition;
+
+import java.util.Objects;
+
+public class UserVariableExpr extends Expr {
+
+    private final String name;
+
+    private Expr value;
+
+    public UserVariableExpr(String name, NodePosition pos) {
+        super(pos);
+        this.name = name;
+    }
+
+
+    protected UserVariableExpr(UserVariableExpr other) {
+        super(other);
+        name = other.name;
+        value = other.value;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public Expr getValue() {
+        return value;
+    }
+
+    public void setValue(Expr value) {
+        this.value = value;
+    }
+
+    @Override
+    public <R, C> R accept(AstVisitor<R, C> visitor, C context) {
+        return visitor.visitUserVariableExpr(this, context);
+    }
+
+    @Override
+    public Expr clone() {
+        return new UserVariableExpr(this);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        if (!super.equals(o)) {
+            return false;
+        }
+        UserVariableExpr that = (UserVariableExpr) o;
+        return Objects.equals(name, that.name) && Objects.equals(value, that.value);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(super.hashCode(), name, value);
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/analysis/VariableExpr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/analysis/VariableExpr.java
@@ -47,8 +47,6 @@ public class VariableExpr extends Expr {
     private final SetType setType;
     private final String name;
     private Object value;
-    private boolean isNull;
-
     @VisibleForTesting
     public VariableExpr(String name) {
         this(name, SetType.SESSION);
@@ -69,7 +67,6 @@ public class VariableExpr extends Expr {
         setType = other.setType;
         name = other.name;
         value = other.value;
-        isNull = other.isNull;
     }
 
     public SetType getSetType() {
@@ -86,14 +83,6 @@ public class VariableExpr extends Expr {
 
     public void setValue(Object value) {
         this.value = value;
-    }
-
-    public boolean isNull() {
-        return isNull;
-    }
-
-    public void setIsNull() {
-        isNull = true;
     }
 
     @Override
@@ -117,7 +106,7 @@ public class VariableExpr extends Expr {
 
     @Override
     public int hashCode() {
-        return Objects.hash(super.hashCode(), name, setType, value, isNull);
+        return Objects.hash(super.hashCode(), name, setType, value);
     }
 
     @Override
@@ -126,6 +115,6 @@ public class VariableExpr extends Expr {
         if (o == null || getClass() != o.getClass()) return false;
         if (!super.equals(o)) return false;
         VariableExpr that = (VariableExpr) o;
-        return isNull == that.isNull && setType == that.setType && Objects.equals(name, that.name) && Objects.equals(value, that.value);
+        return setType == that.setType && Objects.equals(name, that.name) && Objects.equals(value, that.value);
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AstToStringBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AstToStringBuilder.java
@@ -1185,6 +1185,7 @@ public class AstToStringBuilder {
             return sb.toString();
         }
 
+        @Override
         public String visitUserVariableExpr(UserVariableExpr node, Void context) {
             StringBuilder sb = new StringBuilder();
             sb.append("@");

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AstToStringBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AstToStringBuilder.java
@@ -51,6 +51,7 @@ import com.starrocks.analysis.StringLiteral;
 import com.starrocks.analysis.SubfieldExpr;
 import com.starrocks.analysis.Subquery;
 import com.starrocks.analysis.TimestampArithmeticExpr;
+import com.starrocks.analysis.UserVariableExpr;
 import com.starrocks.analysis.VariableExpr;
 import com.starrocks.binlog.BinlogConfig;
 import com.starrocks.catalog.BrokerTable;
@@ -1180,6 +1181,13 @@ public class AstToStringBuilder {
                     sb.append("SESSION.");
                 }
             }
+            sb.append(node.getName());
+            return sb.toString();
+        }
+
+        public String visitUserVariableExpr(UserVariableExpr node, Void context) {
+            StringBuilder sb = new StringBuilder();
+            sb.append("@");
             sb.append(node.getName());
             return sb.toString();
         }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/ExpressionAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/ExpressionAnalyzer.java
@@ -59,6 +59,7 @@ import com.starrocks.analysis.SubfieldExpr;
 import com.starrocks.analysis.Subquery;
 import com.starrocks.analysis.TableName;
 import com.starrocks.analysis.TimestampArithmeticExpr;
+import com.starrocks.analysis.UserVariableExpr;
 import com.starrocks.analysis.VariableExpr;
 import com.starrocks.catalog.AggregateFunction;
 import com.starrocks.catalog.ArrayType;
@@ -99,7 +100,6 @@ import com.starrocks.sql.ast.FieldReference;
 import com.starrocks.sql.ast.LambdaArgument;
 import com.starrocks.sql.ast.LambdaFunctionExpr;
 import com.starrocks.sql.ast.MapExpr;
-import com.starrocks.sql.ast.SetType;
 import com.starrocks.sql.ast.UserIdentity;
 import com.starrocks.sql.ast.UserVariable;
 import com.starrocks.sql.common.TypeManager;
@@ -1679,33 +1679,27 @@ public class ExpressionAnalyzer {
         @Override
         public Void visitVariableExpr(VariableExpr node, Scope context) {
             try {
-                if (node.getSetType() != null && node.getSetType().equals(SetType.USER)) {
-                    UserVariable userVariable = session.getUserVariable(node.getName());
-                    // If referring to an uninitialized variable, its value is NULL and a string type.
-                    if (userVariable == null) {
-                        node.setType(Type.STRING);
-                        node.setIsNull();
-                        return null;
-                    }
-
-                    Type variableType = userVariable.getEvaluatedExpression().getType();
-                    node.setType(variableType);
-
-                    if (userVariable.getEvaluatedExpression() instanceof NullLiteral) {
-                        node.setIsNull();
-                    } else {
-                        node.setValue(userVariable.getEvaluatedExpression().getRealObjectValue());
-                    }
-                } else {
-                    VariableMgr.fillValue(session.getSessionVariable(), node);
-                    if (!Strings.isNullOrEmpty(node.getName()) &&
-                            node.getName().equalsIgnoreCase(SessionVariable.SQL_MODE)) {
-                        node.setType(Type.VARCHAR);
-                        node.setValue(SqlModeHelper.decode((long) node.getValue()));
-                    }
+                VariableMgr.fillValue(session.getSessionVariable(), node);
+                if (!Strings.isNullOrEmpty(node.getName()) &&
+                        node.getName().equalsIgnoreCase(SessionVariable.SQL_MODE)) {
+                    node.setType(Type.VARCHAR);
+                    node.setValue(SqlModeHelper.decode((long) node.getValue()));
                 }
             } catch (DdlException e) {
                 throw new SemanticException(e.getMessage());
+            }
+            return null;
+        }
+
+        @Override
+        public Void visitUserVariableExpr(UserVariableExpr node, Scope context) {
+            UserVariable userVariable = session.getUserVariable(node.getName());
+            if (userVariable == null) {
+                node.setValue(NullLiteral.create(Type.STRING));
+                node.setType(Type.STRING);
+            } else {
+                node.setType(userVariable.getEvaluatedExpression().getType());
+                node.setValue(userVariable.getEvaluatedExpression());
             }
             return null;
         }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/SetStmtAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/SetStmtAnalyzer.java
@@ -423,7 +423,7 @@ public class SetStmtAnalyzer {
             ArrayType arrayType = (ArrayType) type;
             PrimitiveType itemPrimitiveType = arrayType.getItemType().getPrimitiveType();
             if (itemPrimitiveType.isDateType() || itemPrimitiveType.isNumericType() ||
-                    itemPrimitiveType.isCharFamily() || itemPrimitiveType.isJsonType()) {
+                    itemPrimitiveType.isCharFamily()) {
                 return true;
             }
         } else if (type.isScalarType()) {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/SetStmtAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/SetStmtAnalyzer.java
@@ -356,8 +356,6 @@ public class SetStmtAnalyzer {
                 Expr variableResult = queryStatement.getQueryRelation().getOutputExpression().get(0);
 
                 Type type = variableResult.getType();
-                PrimitiveType primitiveType = variableResult.getType().getPrimitiveType();
-
                 //can not apply to metric types or complex type except array type
                 if (!checkUserVariableType(type)) {
                     throw new SemanticException("Can't set variable with type " + variableResult.getType());

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/AstVisitor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/AstVisitor.java
@@ -48,6 +48,7 @@ import com.starrocks.analysis.SlotRef;
 import com.starrocks.analysis.SubfieldExpr;
 import com.starrocks.analysis.Subquery;
 import com.starrocks.analysis.TimestampArithmeticExpr;
+import com.starrocks.analysis.UserVariableExpr;
 import com.starrocks.analysis.UserVariableHint;
 import com.starrocks.analysis.VariableExpr;
 import com.starrocks.connector.parser.trino.PlaceholderExpr;
@@ -1268,6 +1269,10 @@ public interface AstVisitor<R, C> {
     }
 
     default R visitVariableExpr(VariableExpr node, C context) {
+        return visitExpression(node, context);
+    }
+
+    default R visitUserVariableExpr(UserVariableExpr node, C context) {
         return visitExpression(node, context);
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/UserVariable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/UserVariable.java
@@ -152,12 +152,13 @@ public class UserVariable extends SetListItem {
     }
 
     /**
-     * first byte
+     * It's the same with MYSQL_PROTOCAL.
+     * the value of the first byte meaning:
      * less 251 means the length of the following bytes
      * 251 means NULL
-     * 252 means the length need 2 bytes to represent
-     * 253 means the length need 3 bytes to represent
-     * 254 means the length need 8 bytes to represent
+     * 252 means the length need the next 2 bytes to represent
+     * 253 means the length need the next 3 bytes to represent
+     * 254 means the length need the next 8 bytes to represent
      * @param bytes
      * @return
      */

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/UserVariable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/UserVariable.java
@@ -15,10 +15,10 @@
 package com.starrocks.sql.ast;
 
 import com.google.common.base.Preconditions;
-import com.google.common.collect.Lists;
 import com.starrocks.analysis.Expr;
 import com.starrocks.analysis.LiteralExpr;
 import com.starrocks.analysis.NullLiteral;
+import com.starrocks.analysis.StringLiteral;
 import com.starrocks.analysis.Subquery;
 import com.starrocks.catalog.Type;
 import com.starrocks.common.AnalysisException;
@@ -30,14 +30,11 @@ import com.starrocks.qe.StmtExecutor;
 import com.starrocks.sql.StatementPlanner;
 import com.starrocks.sql.analyzer.AstToSQLBuilder;
 import com.starrocks.sql.analyzer.SemanticException;
+import com.starrocks.sql.common.TypeManager;
 import com.starrocks.sql.parser.NodePosition;
 import com.starrocks.sql.plan.ExecPlan;
 import com.starrocks.thrift.TResultBatch;
 import com.starrocks.thrift.TResultSinkType;
-import com.starrocks.thrift.TVariableData;
-import org.apache.thrift.TDeserializer;
-import org.apache.thrift.TException;
-import org.apache.thrift.protocol.TCompactProtocol;
 
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
@@ -46,7 +43,7 @@ import java.util.List;
 public class UserVariable extends SetListItem {
     private final String variable;
     private Expr unevaluatedExpression;
-    private LiteralExpr evaluatedExpression;
+    private Expr evaluatedExpression;
 
     private final boolean isFromHint;
     public UserVariable(String variable, Expr unevaluatedExpression, NodePosition pos) {
@@ -58,7 +55,7 @@ public class UserVariable extends SetListItem {
         this.variable = variable;
         this.unevaluatedExpression = unevaluatedExpression;
         if (unevaluatedExpression instanceof LiteralExpr) {
-            this.evaluatedExpression = (LiteralExpr) unevaluatedExpression;
+            this.evaluatedExpression = unevaluatedExpression;
         }
         this.isFromHint = isFromHint;
     }
@@ -77,11 +74,11 @@ public class UserVariable extends SetListItem {
         this.unevaluatedExpression = unevaluatedExpression;
     }
 
-    public LiteralExpr getEvaluatedExpression() {
+    public Expr getEvaluatedExpression() {
         return evaluatedExpression;
     }
 
-    public void setEvaluatedExpression(LiteralExpr evaluatedExpression) {
+    public void setEvaluatedExpression(Expr evaluatedExpression) {
         this.evaluatedExpression = evaluatedExpression;
     }
 
@@ -97,55 +94,86 @@ public class UserVariable extends SetListItem {
     public void deriveUserVariableExpressionResult(ConnectContext ctx) {
         QueryStatement queryStatement = ((Subquery) unevaluatedExpression).getQueryStatement();
         ExecPlan execPlan = StatementPlanner.plan(queryStatement,
-                ConnectContext.get(), TResultSinkType.VARIABLE);
+                ConnectContext.get(), TResultSinkType.MYSQL_PROTOCAL);
         StmtExecutor executor = new StmtExecutor(ctx, queryStatement);
         Pair<List<TResultBatch>, Status> sqlResult = executor.executeStmtWithExecPlan(ctx, execPlan);
         if (!sqlResult.second.ok()) {
             throw new SemanticException(sqlResult.second.getErrorMsg());
         } else {
-            try {
-                List<TVariableData> result = deserializerVariableData(sqlResult.first);
-                LiteralExpr resultExpr;
-                if (result.isEmpty()) {
-                    resultExpr = new NullLiteral();
-                } else {
-                    Preconditions.checkState(result.size() == 1);
-                    if (result.get(0).isIsNull()) {
-                        resultExpr = new NullLiteral();
-                    } else {
-                        Type userVariableType = unevaluatedExpression.getType();
-                        //JSON type will be stored as string type
-                        if (userVariableType.isJsonType()) {
-                            userVariableType = Type.VARCHAR;
-                        }
-                        resultExpr = LiteralExpr.create(
-                                StandardCharsets.UTF_8.decode(result.get(0).result).toString(), userVariableType);
-                    }
-                }
-                evaluatedExpression = resultExpr;
-            } catch (TException | AnalysisException e) {
-                throw new SemanticException(e.getMessage());
-            }
+            evaluatedExpression = decodeVariableData(sqlResult.first, unevaluatedExpression.getType());
         }
 
         if (ctx.getState().getStateType() == QueryState.MysqlStateType.ERR) {
             throw new SemanticException(ctx.getState().getErrorMessage());
         }
     }
-    private static List<TVariableData> deserializerVariableData(List<TResultBatch> sqlResult) throws TException {
-        List<TVariableData> statistics = Lists.newArrayList();
 
-        TDeserializer deserializer = new TDeserializer(new TCompactProtocol.Factory());
-        for (TResultBatch resultBatch : sqlResult) {
-            for (ByteBuffer bb : resultBatch.rows) {
-                TVariableData sd = new TVariableData();
-                byte[] bytes = new byte[bb.limit() - bb.position()];
-                bb.get(bytes);
-                deserializer.deserialize(sd, bytes);
-                statistics.add(sd);
-            }
+    private static Expr decodeVariableData(List<TResultBatch> sqlResult, Type targetType) {
+        Preconditions.checkState(sqlResult.size() == 1,
+                "subquery in user variable must return at most 1 value");
+        Preconditions.checkState(sqlResult.get(0).getRows().size() == 1,
+                "subquery in user variable must return at most 1 value");
+        ByteBuffer byteBuffer = sqlResult.get(0).getRows().get(0);
+        byte[] bytes = new byte[byteBuffer.limit() - byteBuffer.position()];
+        byteBuffer.get(bytes);
+
+        int lengthOffset = getOffset(bytes);
+
+        // process null value
+        if (lengthOffset == -1) {
+            return NullLiteral.create(Type.VARCHAR);
         }
 
-        return statistics;
+        String value;
+        try {
+            value = new String(bytes, lengthOffset, bytes.length - lengthOffset, StandardCharsets.UTF_8);
+        } catch (Exception e) {
+            throw new SemanticException("unable decode bytes to string. bytes offset: %s, bytes length: %s",
+                    lengthOffset, bytes.length);
+        }
+
+        //JSON type will be stored as string type
+        if (targetType.isJsonType()) {
+            targetType = Type.VARCHAR;
+        }
+
+        if (targetType.isScalarType()) {
+            try {
+                return LiteralExpr.create(value, targetType);
+            } catch (AnalysisException e) {
+                throw new SemanticException("Unsupported string value: %s to type: %s", value, targetType);
+            }
+        } else if (targetType.isArrayType()) {
+            //build a cast(string to array) expr
+            return TypeManager.addCastExpr(new StringLiteral(value), targetType);
+        } else {
+            throw new SemanticException("Unsupported type: %s in user variable", targetType);
+        }
+    }
+
+    /**
+     * first byte
+     * less 251 means the length of the following bytes
+     * 251 means NULL
+     * 252 means the length need 2 bytes to represent
+     * 253 means the length need 3 bytes to represent
+     * 254 means the length need 8 bytes to represent
+     * @param bytes
+     * @return
+     */
+    private static int getOffset(byte[] bytes) {
+        int sw = bytes[0] & 0xff;
+        switch (sw) {
+            case 251:
+                return -1;
+            case 252:
+                return 3;
+            case 253:
+                return 4;
+            case 254:
+                return 9;
+            default:
+                return 1;
+        }
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/transformer/SqlToScalarOperatorTranslator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/transformer/SqlToScalarOperatorTranslator.java
@@ -46,6 +46,7 @@ import com.starrocks.analysis.SlotRef;
 import com.starrocks.analysis.SubfieldExpr;
 import com.starrocks.analysis.Subquery;
 import com.starrocks.analysis.TimestampArithmeticExpr;
+import com.starrocks.analysis.UserVariableExpr;
 import com.starrocks.analysis.VariableExpr;
 import com.starrocks.catalog.Function;
 import com.starrocks.catalog.FunctionSet;
@@ -745,11 +746,12 @@ public final class SqlToScalarOperatorTranslator {
 
         @Override
         public ScalarOperator visitVariableExpr(VariableExpr node, Context context) {
-            if (node.isNull()) {
-                return ConstantOperator.createNull(node.getType());
-            } else {
-                return new ConstantOperator(node.getValue(), node.getType());
-            }
+            return new ConstantOperator(node.getValue(), node.getType());
+        }
+
+        @Override
+        public ScalarOperator visitUserVariableExpr(UserVariableExpr node, Context context) {
+            return visit(node.getValue(), context);
         }
 
         @Override

--- a/fe/fe-core/src/main/java/com/starrocks/sql/parser/AstBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/parser/AstBuilder.java
@@ -80,6 +80,7 @@ import com.starrocks.analysis.TaskName;
 import com.starrocks.analysis.TimestampArithmeticExpr;
 import com.starrocks.analysis.TypeDef;
 import com.starrocks.analysis.UserDesc;
+import com.starrocks.analysis.UserVariableExpr;
 import com.starrocks.analysis.VarBinaryLiteral;
 import com.starrocks.analysis.VariableExpr;
 import com.starrocks.catalog.AggregateType;
@@ -3340,7 +3341,7 @@ public class AstBuilder extends StarRocksBaseVisitor<ParseNode> {
 
     @Override
     public ParseNode visitSetUserVar(StarRocksParser.SetUserVarContext context) {
-        VariableExpr variableDesc = (VariableExpr) visit(context.userVariable());
+        UserVariableExpr variableDesc = (UserVariableExpr) visit(context.userVariable());
         Expr expr = (Expr) visit(context.expression());
         return new UserVariable(variableDesc.getName(), expr, createPos(context));
     }
@@ -6535,7 +6536,7 @@ public class AstBuilder extends StarRocksBaseVisitor<ParseNode> {
     @Override
     public ParseNode visitUserVariable(StarRocksParser.UserVariableContext context) {
         String variable = ((Identifier) visit(context.identifierOrString())).getValue();
-        return new VariableExpr(variable, SetType.USER, createPos(context));
+        return new UserVariableExpr(variable, createPos(context));
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/sql/parser/AstBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/parser/AstBuilder.java
@@ -7018,7 +7018,7 @@ public class AstBuilder extends StarRocksBaseVisitor<ParseNode> {
         if (context.identifierOrString() != null) {
             queryStatementContext.forEach(varNameContext -> {
                 Identifier identifier = (Identifier) visit(varNameContext);
-                variableExprs.add(new VariableExpr(identifier.getValue(), SetType.USER));
+                variableExprs.add(new UserVariableExpr(identifier.getValue(), identifier.getPos()));
             });
         }
         return new ExecuteStmt(stmtName, variableExprs);

--- a/fe/fe-core/src/main/java/com/starrocks/sql/parser/HintFactory.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/parser/HintFactory.java
@@ -21,8 +21,8 @@ import com.starrocks.analysis.BinaryType;
 import com.starrocks.analysis.Expr;
 import com.starrocks.analysis.HintNode;
 import com.starrocks.analysis.SetVarHint;
+import com.starrocks.analysis.UserVariableExpr;
 import com.starrocks.analysis.UserVariableHint;
-import com.starrocks.analysis.VariableExpr;
 import com.starrocks.qe.SessionVariable;
 import com.starrocks.sql.ast.UserVariable;
 import org.antlr.v4.runtime.Token;
@@ -167,8 +167,8 @@ public class HintFactory {
                     return null;
                 }
 
-                if (binaryPredicate.getChild(0) instanceof VariableExpr) {
-                    VariableExpr variableExpr = (VariableExpr) binaryPredicate.getChild(0);
+                if (binaryPredicate.getChild(0) instanceof UserVariableExpr) {
+                    UserVariableExpr variableExpr = (UserVariableExpr) binaryPredicate.getChild(0);
                     userVariables.put(variableExpr.getName(),
                             new UserVariable(variableExpr.getName(), binaryPredicate.getChild(1),
                                     true, binaryPredicate.getPos()));

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/SetStmtTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/SetStmtTest.java
@@ -82,7 +82,7 @@ public class SetStmtTest {
         com.starrocks.sql.analyzer.Analyzer.analyze(stmt, ctx);
 
         Assert.assertEquals("times", ((UserVariable) stmt.getSetListItems().get(0)).getVariable());
-        Assert.assertEquals("100", ((UserVariable) stmt.getSetListItems().get(0)).getEvaluatedExpression().getStringValue());
+        Assert.assertEquals("100", ((UserVariable) stmt.getSetListItems().get(0)).getEvaluatedExpression().toSqlImpl());
         Assert.assertTrue(stmt.getSetListItems().get(1) instanceof SetNamesVar);
         Assert.assertEquals("utf8", ((SetNamesVar) stmt.getSetListItems().get(1)).getCharset());
     }

--- a/fe/fe-core/src/test/java/com/starrocks/qe/SetExecutorTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/qe/SetExecutorTest.java
@@ -135,7 +135,8 @@ public class SetExecutorTest {
         executor.execute();
         UserVariable userVariable = ctx.getUserVariable("var");
         Assert.assertTrue(userVariable.getEvaluatedExpression().getType().matchesType(type));
-        Assert.assertEquals(value.getStringValue(), userVariable.getEvaluatedExpression().getStringValue());
+        LiteralExpr literalExpr = (LiteralExpr) userVariable.getEvaluatedExpression();
+        Assert.assertEquals(value.getStringValue(), literalExpr.getStringValue());
         String planFragment = UtFrameUtils.getPlanAndFragment(ctx, "select @var").second.
                 getExplainString(TExplainLevel.NORMAL);
         Assert.assertTrue(planFragment.contains(value.getStringValue()));
@@ -167,7 +168,8 @@ public class SetExecutorTest {
         executor.execute();
         UserVariable userVariable = ctx.getUserVariable("var");
         Assert.assertTrue(userVariable.getEvaluatedExpression().getType().isDecimalV3());
-        Assert.assertEquals("10", userVariable.getEvaluatedExpression().getStringValue());
+        LiteralExpr literalExpr = (LiteralExpr) userVariable.getEvaluatedExpression();
+        Assert.assertEquals("10", literalExpr.getStringValue());
 
         sql = "set @var = cast(1 as boolean)";
         stmt = (SetStmt) UtFrameUtils.parseStmtWithNewParser(sql, ctx);

--- a/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AnalyzeSetVariableTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AnalyzeSetVariableTest.java
@@ -80,7 +80,7 @@ public class AnalyzeSetVariableTest {
         SetStmt setStmt = (SetStmt) analyzeSuccess(sql);
         UserVariable userVariable = (UserVariable) setStmt.getSetListItems().get(0);
         Assert.assertNotNull(userVariable.getEvaluatedExpression());
-        Assert.assertEquals("3", userVariable.getEvaluatedExpression().getStringValue());
+        Assert.assertEquals("3", userVariable.getEvaluatedExpression().toString());
 
         sql = "set @var = abs(1.2)";
         setStmt = (SetStmt) analyzeSuccess(sql);

--- a/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AnalyzeSetVariableTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AnalyzeSetVariableTest.java
@@ -14,6 +14,7 @@
 
 package com.starrocks.sql.analyzer;
 
+import com.starrocks.analysis.LiteralExpr;
 import com.starrocks.analysis.Subquery;
 import com.starrocks.catalog.ResourceGroupMgr;
 import com.starrocks.server.GlobalStateMgr;
@@ -80,9 +81,14 @@ public class AnalyzeSetVariableTest {
         SetStmt setStmt = (SetStmt) analyzeSuccess(sql);
         UserVariable userVariable = (UserVariable) setStmt.getSetListItems().get(0);
         Assert.assertNotNull(userVariable.getEvaluatedExpression());
-        Assert.assertEquals("3", userVariable.getEvaluatedExpression().toString());
+        Assert.assertEquals("3", ((LiteralExpr) userVariable.getEvaluatedExpression()).getStringValue());
 
         sql = "set @var = abs(1.2)";
+        setStmt = (SetStmt) analyzeSuccess(sql);
+        userVariable = (UserVariable) setStmt.getSetListItems().get(0);
+        Assert.assertTrue(userVariable.getUnevaluatedExpression() instanceof Subquery);
+
+        sql = "set @var =JSON_ARRAY(1, 2, 3)";
         setStmt = (SetStmt) analyzeSuccess(sql);
         userVariable = (UserVariable) setStmt.getSetListItems().get(0);
         Assert.assertTrue(userVariable.getUnevaluatedExpression() instanceof Subquery);
@@ -105,7 +111,14 @@ public class AnalyzeSetVariableTest {
         Assert.assertEquals(2, setStmt.getSetListItems().size());
 
         sql = "set @var = [1,2,3]";
-        analyzeFail(sql, "Can't set variable with type ARRAY");
+        setStmt = (SetStmt) analyzeSuccess(sql);
+        Assert.assertEquals(1, setStmt.getSetListItems().size());
+
+        sql = "set @var = to_binary('abab', 'hex')";
+        analyzeFail(sql, "Can't set variable with type VARBINARY");
+
+        sql = "set @var = [bitmap_empty(), bitmap_empty(), bitmap_empty()]";
+        analyzeFail(sql, "Can't set variable with type ARRAY<BITMAP>");
 
         sql = "set @var = bitmap_empty()";
         analyzeFail(sql, "Can't set variable with type BITMAP");

--- a/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/ExpressionAnalyzerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/ExpressionAnalyzerTest.java
@@ -19,6 +19,7 @@ import com.starrocks.analysis.Expr;
 import com.starrocks.analysis.IntLiteral;
 import com.starrocks.analysis.SlotRef;
 import com.starrocks.analysis.StringLiteral;
+import com.starrocks.analysis.UserVariableExpr;
 import com.starrocks.catalog.ArrayType;
 import com.starrocks.catalog.Function;
 import com.starrocks.catalog.MapType;
@@ -26,6 +27,8 @@ import com.starrocks.catalog.PrimitiveType;
 import com.starrocks.catalog.ScalarType;
 import com.starrocks.catalog.Type;
 import com.starrocks.qe.ConnectContext;
+import com.starrocks.sql.parser.NodePosition;
+import com.starrocks.sql.parser.SqlParser;
 import com.starrocks.sql.plan.ExecPlan;
 import com.starrocks.sql.plan.PlanTestBase;
 import com.starrocks.thrift.TExprNodeType;
@@ -213,5 +216,14 @@ public class ExpressionAnalyzerTest extends PlanTestBase {
             Assert.assertEquals(fnCoalesce.functionName(), "coalesce");
             Assert.assertEquals(fnCoalesce.getReturnType(), dateTimeType);
         }
+    }
+
+    @Test
+    public void testUserVariableExprAnalyzer() {
+        Expr expr = SqlParser.parseSqlToExpr("[1, 2, 3]", 32);
+        UserVariableExpr userVariableExpr = new UserVariableExpr("test", NodePosition.ZERO);
+        userVariableExpr.setValue(expr);
+        UserVariableExpr copy = (UserVariableExpr) userVariableExpr.clone();
+        Assert.assertEquals(userVariableExpr, copy);
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/SelectHintTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/SelectHintTest.java
@@ -40,5 +40,16 @@ public class SelectHintTest extends PlanTestBase {
                 "  |  \n" +
                 "  0:OlapScanNode\n" +
                 "     TABLE: t0");
+
+        sql = "select /*+ set_user_variable(@a = 1, @b = (select array_agg(v4) from t1))*/ @a, @b, v1 from t0";
+        plan = getFragmentPlan(sql);
+        assertContains(plan, "1:Project\n" +
+                "  |  <slot 1> : 1: v1\n" +
+                "  |  <slot 4> : 1\n" +
+                "  |  <slot 5> : 'MOCK_HINT_VALUE'\n" +
+                "  |  \n" +
+                "  0:OlapScanNode\n" +
+                "     TABLE: t0\n" +
+                "     PREAGGREGATION: ON");
     }
 }

--- a/test/sql/test_hint/R/test_hint
+++ b/test/sql/test_hint/R/test_hint
@@ -226,6 +226,20 @@ select @test;
 -- result:
 ["测试","测试","abc"]
 -- !result
+set @test = (select array_col from all_type where date_col > '2021-01-01');
+-- result:
+-- !result
+select @test;
+-- result:
+None
+-- !result
+set @test= (select JSON_OBJECT(' Daniel Smith', 26, 'Lily Smith', 25));
+-- result:
+-- !result
+select @test;
+-- result:
+{" Daniel Smith": 26, "Lily Smith": 25}
+-- !result
 set @test = (select array_agg(c2) from (select t2.c2 from t2 join t2 tt join t2 ttt join t2 tttt) t);
 -- result:
 -- !result

--- a/test/sql/test_hint/R/test_hint
+++ b/test/sql/test_hint/R/test_hint
@@ -38,6 +38,23 @@ PROPERTIES (
 "compression" = "LZ4");
 -- result:
 -- !result
+CREATE TABLE all_type (
+    date_col DATE,
+    datetime_col DATETIME,
+    int_col int,
+    float_col FLOAT,
+    double_col DOUBLE,
+    decimal_col DECIMAL(10, 2),
+    varchar_col VARCHAR(255),
+    char_col CHAR(10),
+    array_col ARRAY<STRING>
+) ENGINE=OLAP
+  DUPLICATE KEY(date_col)
+  COMMENT "OLAP"
+  DISTRIBUTED BY HASH(date_col) BUCKETS 5
+  PROPERTIES ("replication_num" = "1");
+-- result:
+-- !result
 INSERT INTO t1 (c0, c1, c2, c3) VALUES
   (1, 'a', 'Value1', 10),
   (2, 'b', 'Value2', 20),
@@ -45,6 +62,9 @@ INSERT INTO t1 (c0, c1, c2, c3) VALUES
   (4, 'd', 'Value4', 40),
   (5, null, 'Value5', 50),
   (5, 'f', 'Value6', 60);
+-- result:
+-- !result
+insert into all_type values('2021-01-01', '2021-01-01 12:00:01.123', 111111, -1.23, 1.54654, 120.26, '测试 test"', '测试\'', ['测试', '测试', 'abc'] );
 -- result:
 -- !result
 insert /*+ set_user_variable(@a = (select max(c3) from t1)) */ into t2 select /*+ set_user_variable(@b = (select min(c1) from t1)) */
@@ -142,4 +162,74 @@ properties (
 ) as select /*+ set_user_variable(@c = (select min(c3) from t1)) */ * from t1;
 -- result:
 E: (1064, 'unsupported user variable hint in Materialized view for now.')
+-- !result
+set @test = (select date_col from all_type);
+-- result:
+-- !result
+select @test;
+-- result:
+2021-01-01
+-- !result
+set @test = (select datetime_col from all_type);
+-- result:
+-- !result
+select @test;
+-- result:
+2021-01-01 12:00:01.123000
+-- !result
+set @test = (select int_col from all_type);
+-- result:
+-- !result
+select @test;
+-- result:
+111111
+-- !result
+set @test = (select float_col from all_type);
+-- result:
+-- !result
+select @test;
+-- result:
+-1.23
+-- !result
+set @test = (select double_col from all_type);
+-- result:
+-- !result
+select @test;
+-- result:
+1.54654
+-- !result
+set @test = (select decimal_col from all_type);
+-- result:
+-- !result
+select @test;
+-- result:
+120.26
+-- !result
+set @test = (select varchar_col from all_type);
+-- result:
+-- !result
+select @test;
+-- result:
+测试 test"
+-- !result
+set @test = (select char_col from all_type);
+-- result:
+-- !result
+select @test;
+-- result:
+测试'
+-- !result
+set @test = (select array_col from all_type);
+-- result:
+-- !result
+select @test;
+-- result:
+["测试","测试","abc"]
+-- !result
+set @test = (select array_agg(c2) from (select t2.c2 from t2 join t2 tt join t2 ttt join t2 tttt) t);
+-- result:
+-- !result
+select array_length(@test);
+-- result:
+1296
 -- !result

--- a/test/sql/test_hint/T/test_hint
+++ b/test/sql/test_hint/T/test_hint
@@ -131,6 +131,12 @@ select @test;
 set @test = (select array_col from all_type);
 select @test;
 
+set @test = (select array_col from all_type where date_col > '2021-01-01');
+select @test;
+
+set @test= (select JSON_OBJECT(' Daniel Smith', 26, 'Lily Smith', 25));
+select @test;
+
 set @test = (select array_agg(c2) from (select t2.c2 from t2 join t2 tt join t2 ttt join t2 tttt) t);
 select array_length(@test);
 

--- a/test/sql/test_hint/T/test_hint
+++ b/test/sql/test_hint/T/test_hint
@@ -36,6 +36,22 @@ PROPERTIES (
 "replicated_storage" = "true",
 "compression" = "LZ4");
 
+CREATE TABLE all_type (
+    date_col DATE,
+    datetime_col DATETIME,
+    int_col int,
+    float_col FLOAT,
+    double_col DOUBLE,
+    decimal_col DECIMAL(10, 2),
+    varchar_col VARCHAR(255),
+    char_col CHAR(10),
+    array_col ARRAY<STRING>
+) ENGINE=OLAP
+  DUPLICATE KEY(date_col)
+  COMMENT "OLAP"
+  DISTRIBUTED BY HASH(date_col) BUCKETS 5
+  PROPERTIES ("replication_num" = "1");
+
 INSERT INTO t1 (c0, c1, c2, c3) VALUES
   (1, 'a', 'Value1', 10),
   (2, 'b', 'Value2', 20),
@@ -43,6 +59,8 @@ INSERT INTO t1 (c0, c1, c2, c3) VALUES
   (4, 'd', 'Value4', 40),
   (5, null, 'Value5', 50),
   (5, 'f', 'Value6', 60);
+
+insert into all_type values('2021-01-01', '2021-01-01 12:00:01.123', 111111, -1.23, 1.54654, 120.26, '测试 test"', '测试\'', ['测试', '测试', 'abc'] );
 
 
 insert /*+ set_user_variable(@a = (select max(c3) from t1)) */ into t2 select /*+ set_user_variable(@b = (select min(c1) from t1)) */
@@ -86,4 +104,33 @@ properties (
 ) as select /*+ set_user_variable(@c = (select min(c3) from t1)) */ * from t1;
 
 
+set @test = (select date_col from all_type);
+select @test;
+
+set @test = (select datetime_col from all_type);
+select @test;
+
+set @test = (select int_col from all_type);
+select @test;
+
+set @test = (select float_col from all_type);
+select @test;
+
+set @test = (select double_col from all_type);
+select @test;
+
+set @test = (select decimal_col from all_type);
+select @test;
+
+set @test = (select varchar_col from all_type);
+select @test;
+
+set @test = (select char_col from all_type);
+select @test;
+
+set @test = (select array_col from all_type);
+select @test;
+
+set @test = (select array_agg(c2) from (select t2.c2 from t2 join t2 tt join t2 ttt join t2 tttt) t);
+select array_length(@test);
 


### PR DESCRIPTION
## Why I'm doing:
The client needs to concatenate a constant array with a large table. During the chunking process, the array object is being duplicated multiple times, leading to low execution efficiency.

## What I'm doing:
Enable user-defined variables to support array types. The native MySQL_PROTOCOL protocol sends results encoded in UTF-8, making it easy to decode scalar result sets into strings. Ultimately, convert the user's array type variable using the `cast(string to array)` expression.

Perf test:
`set cbo_prune_subfield = flase` to prevent pushdown array_length below the join. 
Because our array_length function is not optimized for constant columns, it fails to demonstrate the value of the modification. As a temporary solution, we've modified the array_length code so that it only calculates once when the parameter is a constant column.

case 1:
takes 5.2s  return 36864 rows
```
set @a = (select array_agg(v2) as col from (select t0.v2 from jdbc_test t0 join jdbc_test t1 join jdbc_test t2 limit 1000000) t); -- cost 2.7s the array has one million elements
select if(array_length(@a)>100, t1.v1, t2.v2) from jdbc_test t1 join jdbc_test t2;
```

case 2:
limit the join output to 10 rows, it still cost 10.5s.
```
select if(array_length(col)>100, v1, v2) from (select col, t1.v1, t2.v2 from (select array_agg(v2) as col from (select t0.v2 from jdbc_test t0 join jdbc_test t1 join jdbc_test t2 limit 1000000) t) t join jdbc_test t1 join jdbc_test t2 limit 10) t;
```


Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
