### PR TITLE
[Enhancement] No UNSTABLE state is set when offset is not initialized

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/load/routineload/KafkaRoutineLoadJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/routineload/KafkaRoutineLoadJob.java
@@ -816,14 +816,16 @@ public class KafkaRoutineLoadJob extends RoutineLoadJob {
         long now = System.currentTimeMillis();
 
         for (Map.Entry<Integer, Long> entry : partitionTimestamps.entrySet()) {
-            int partition = entry.getKey();
-            long lag = (now - entry.getValue().longValue()) / 1000;
-            if (lag > Config.routine_load_unstable_threshold_second) {
-                updateSubstate(JobSubstate.UNSTABLE, new ErrorReason(InternalErrorCode.SLOW_RUNNING_ERR,
-                        String.format("The lag [%d] of partition [%d] exceeds " +
-                                        "Config.routine_load_unstable_threshold_second [%d]",
-                                lag, partition, Config.routine_load_unstable_threshold_second)));
-                return;
+            if (entry.getValue().longValue() > 0 && Config.routine_load_unstable_threshold_second > 0) {
+                int partition = entry.getKey();
+                long lag = (now - entry.getValue().longValue()) / 1000;
+                if (lag > Config.routine_load_unstable_threshold_second) {
+                    updateSubstate(JobSubstate.UNSTABLE, new ErrorReason(InternalErrorCode.SLOW_RUNNING_ERR,
+                            String.format("The lag [%d] of partition [%d] exceeds " +
+                                            "Config.routine_load_unstable_threshold_second [%d]",
+                                    lag, partition, Config.routine_load_unstable_threshold_second)));
+                    return;
+                }
             }
         }
         updateSubstate(JobSubstate.STABLE, null);

--- a/fe/fe-core/src/main/java/com/starrocks/load/routineload/RoutineLoadJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/routineload/RoutineLoadJob.java
@@ -1963,6 +1963,9 @@ public abstract class RoutineLoadJob extends AbstractTxnStateChangeCallback impl
 
     protected void updateSubstate(JobSubstate substate, ErrorReason reason) throws UserException {
         writeLock();
+        if (this.substate == substate && reason == null) {
+            return;
+        }
         LOG.info(new LogBuilder(LogKey.ROUTINE_LOAD_JOB, id)
                 .add("current_job_substate", this.substate)
                 .add("desire_job_substate", substate)

--- a/fe/fe-core/src/main/java/com/starrocks/load/routineload/RoutineLoadJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/routineload/RoutineLoadJob.java
@@ -960,6 +960,9 @@ public abstract class RoutineLoadJob extends AbstractTxnStateChangeCallback impl
     public void afterCommitted(TransactionState txnState, boolean txnOperated) throws UserException {
         long taskBeId = -1L;
         try {
+            // Update the job state is the job is too slow.
+            updateSubstate();
+
             if (txnOperated) {
                 // find task in job
                 Optional<RoutineLoadTaskInfo> routineLoadTaskInfoOptional = routineLoadTaskInfoList.stream().filter(
@@ -1087,6 +1090,9 @@ public abstract class RoutineLoadJob extends AbstractTxnStateChangeCallback impl
             throws UserException {
         long taskBeId = -1L;
         try {
+            // Update the job state is the job is too slow.
+            updateSubstate();
+
             if (txnOperated) {
                 // step0: find task in job
                 Optional<RoutineLoadTaskInfo> routineLoadTaskInfoOptional = routineLoadTaskInfoList.stream().filter(

--- a/fe/fe-core/src/main/java/com/starrocks/load/routineload/RoutineLoadTaskScheduler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/routineload/RoutineLoadTaskScheduler.java
@@ -193,9 +193,6 @@ public class RoutineLoadTaskScheduler extends FrontendDaemon {
                 delayPutToQueue(routineLoadTaskInfo, msg);
                 return;
             }
-            // Update the job state is the job is too slow.
-            routineLoadManager.getJob(routineLoadTaskInfo.getJobId()).updateSubstate();
-
         } catch (RoutineLoadPauseException e) {
             String msg = "fe abort task with reason: check task ready to execute failed, " + e.getMessage();
             routineLoadManager.getJob(routineLoadTaskInfo.getJobId()).updateState(
@@ -207,6 +204,8 @@ public class RoutineLoadTaskScheduler extends FrontendDaemon {
         } catch (Exception e) {
             LOG.warn("check task ready to execute failed", e);
             delayPutToQueue(routineLoadTaskInfo, "check task ready to execute failed, err: " + e.getMessage());
+            // Update the job state is the job is too slow.
+            routineLoadManager.getJob(routineLoadTaskInfo.getJobId()).updateSubstate();
             return;
         }
 
@@ -220,6 +219,8 @@ public class RoutineLoadTaskScheduler extends FrontendDaemon {
                                     "current value is %d",
                             routineLoadTaskInfo.getTaskScheduleIntervalMs() / 1000,
                             Config.max_routine_load_task_num_per_be));
+            // Update the job state is the job is too slow.
+            routineLoadManager.getJob(routineLoadTaskInfo.getJobId()).updateSubstate();
             return;
         }
 


### PR DESCRIPTION
## Why I'm doing:
1. Some kafka producer clients always write messages with timestamp 0. 
2. When all tasks of a routine load job has not been scheduled for a long time, it will be set as UNSTABLE when new messages are comming.
## What I'm doing:
1. no setting routine load job as unstable when the offset is 0 (OFFSET_ZERO)
3. Set routine load job UNSTABLE if necessary when the task is commited/aborted.
Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
