### PR TITLE
[Feature] Support typeof function

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/analysis/FunctionCallExpr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/analysis/FunctionCallExpr.java
@@ -505,5 +505,4 @@ public class FunctionCallExpr extends Expr {
             return this;
         }
     }
-
 }

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/ArrayType.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/ArrayType.java
@@ -170,6 +170,14 @@ public class ArrayType extends Type {
     public String toMysqlColumnTypeString() {
         return toSql();
     }
+
+    @Override
+    protected String toTypeString(int depth) {
+        if (depth >= MAX_NESTING_DEPTH) {
+            return "array<...>";
+        }
+        return String.format("array<%s>", itemType.toTypeString(depth + 1));
+    }
 }
 
 

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/MapType.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/MapType.java
@@ -217,5 +217,14 @@ public class MapType extends Type {
     public String toMysqlColumnTypeString() {
         return toSql();
     }
+
+    @Override
+    protected String toTypeString(int depth) {
+        if (depth >= MAX_NESTING_DEPTH) {
+            return "map<...>";
+        }
+        return String.format("map<%s,%s>",
+                keyType.toTypeString(depth + 1), valueType.toTypeString(depth + 1));
+    }
 }
 

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/PseudoType.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/PseudoType.java
@@ -50,4 +50,9 @@ public class PseudoType extends Type {
     protected String toSql(int depth) {
         return toString();
     }
+
+    @Override
+    protected String toTypeString(int depth) {
+        return toString();
+    }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/ScalarType.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/ScalarType.java
@@ -876,4 +876,24 @@ public class ScalarType extends Type implements Cloneable {
                 return toSql();
         }
     }
+
+    @Override
+    protected String toTypeString(int depth) {
+        StringBuilder stringBuilder = new StringBuilder();
+        switch (type) {
+            case DECIMALV2:
+                stringBuilder.append("decimal").append("(").append(precision).append(", ").append(scale).append(")");
+                break;
+            case DECIMAL32:
+            case DECIMAL64:
+            case DECIMAL128:
+                stringBuilder.append(type.toString().toLowerCase()).append("(").append(precision).append(", ")
+                        .append(scale).append(")");
+                break;
+            default:
+                stringBuilder.append(type.toString().toLowerCase());
+                break;
+        }
+        return stringBuilder.toString();
+    }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/StructField.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/StructField.java
@@ -80,6 +80,14 @@ public class StructField {
         return sb.toString();
     }
 
+    public String toTypeString(int depth) {
+        String typeSql = (depth < Type.MAX_NESTING_DEPTH) ? type.toTypeString(depth) : "...";
+        StringBuilder sb = new StringBuilder();
+        sb.append(name).append(' ');
+        sb.append(typeSql);
+        return sb.toString();
+    }
+
     /**
      * Pretty prints this field with lpad number of leading spaces.
      * Calls prettyPrint(lpad) on this field's type.

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/StructType.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/StructType.java
@@ -326,5 +326,17 @@ public class StructType extends Type {
     public String toMysqlColumnTypeString() {
         return toSql();
     }
+
+    @Override
+    protected String toTypeString(int depth) {
+        if (depth >= MAX_NESTING_DEPTH) {
+            return "struct<...>";
+        }
+        ArrayList<String> fieldsSql = Lists.newArrayList();
+        for (StructField f : fields) {
+            fieldsSql.add(f.toTypeString(depth + 1));
+        }
+        return String.format("struct<%s>", Joiner.on(", ").join(fieldsSql));
+    }
 }
 

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/Type.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/Type.java
@@ -571,6 +571,12 @@ public abstract class Type implements Cloneable {
      */
     protected abstract String toSql(int depth);
 
+    public final String toTypeString() {
+        return toTypeString(0);
+    }
+
+    protected abstract String toTypeString(int depth);
+    
     /**
      * Same as toSql() but adds newlines and spaces for better readability of nested types.
      */

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/ScalarOperatorFunctions.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/ScalarOperatorFunctions.java
@@ -1245,5 +1245,11 @@ public class ScalarOperatorFunctions {
 
         return ConstantOperator.createBoolean(roleNames.contains(role.getVarchar()));
     }
+
+    @ConstantFunction(name = "typeof_internal", returnType = VARCHAR, argTypes = { VARCHAR })
+    public static ConstantOperator typeofInternal(ConstantOperator value) {
+        return ConstantOperator.createVarchar(value.getVarchar());
+    }
+
 }
 

--- a/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AnalyzeFunctionTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AnalyzeFunctionTest.java
@@ -295,4 +295,10 @@ public class AnalyzeFunctionTest {
         analyzeFail("select covar_pop(v1,3) from t0");
         analyzeFail("select corr(v1) from t0");
     }
+
+    @Test
+    public void testTypeofFunction() throws Exception {
+        analyzeFail("select typeof(cast(1 as tinyint),  cast(1 as int))");
+        analyzeFail("select typeof()");
+    }
 }

--- a/test/sql/test_function/R/test_typeof
+++ b/test/sql/test_function/R/test_typeof
@@ -1,0 +1,177 @@
+-- name: test_typeof_literal
+select typeof(cast(1 as tinyint));
+-- result:
+tinyint
+-- !result
+select typeof(cast(1 as smallint));
+-- result:
+smallint
+-- !result
+select typeof(cast(1 as int));
+-- result:
+int
+-- !result
+select typeof(cast(1 as bigint));
+-- result:
+bigint
+-- !result
+select typeof(cast(1 as largeint));
+-- result:
+largeint
+-- !result
+select typeof(cast(1 as decimal(19, 2)));
+-- result:
+decimal128(19, 2)
+-- !result
+select typeof(cast(1 as double));
+-- result:
+double
+-- !result
+select typeof(cast(1 as float));
+-- result:
+float
+-- !result
+select typeof(cast(1 as boolean));
+-- result:
+boolean
+-- !result
+select typeof(cast(1 as char));
+-- result:
+char
+-- !result
+select typeof(cast(1 as string));
+-- result:
+varchar
+-- !result
+select typeof(cast(1 as varchar));
+-- result:
+varchar
+-- !result
+select typeof(cast('s' as BINARY));
+-- result:
+varbinary
+-- !result
+select typeof(cast('2023-03-07' as date));
+-- result:
+date
+-- !result
+select typeof(cast('2023-03-07 11:22:33' as datetime));
+-- result:
+datetime
+-- !result
+select typeof([1, 2, 3]);
+-- result:
+array<tinyint>
+-- !result
+select typeof(get_json_object('{"k1":1, "k2":"v2"}', '$.k1'));
+-- result:
+varchar
+-- !result
+select typeof(map{1:"apple", 2:"orange", 3:"pear"});
+-- result:
+map<tinyint,varchar>
+-- !result
+select typeof(struct(1, 2, 3, 4));
+-- result:
+struct<col1 tinyint, col2 tinyint, col3 tinyint, col4 tinyint>
+-- !result
+select typeof(bitmap_empty());
+-- result:
+bitmap
+-- !result
+select typeof(hll_empty());
+-- result:
+hll
+-- !result
+select typeof(parse_json('{"a": 1, "b": true}'));
+-- result:
+json
+-- !result
+select typeof(null);
+-- result:
+null_type
+-- !result
+-- name: test_typeof_table
+create table t1 properties("replication_num" = "1") as
+select cast(1 as tinyint) as c1
+,cast(1 as smallint) as c2
+,cast(1 as int) as c3
+,cast(1 as bigint) as c4
+,cast(1 as largeint) as c5
+,cast(1 as decimal(19, 2)) as c6
+,cast(1 as double) as c7
+,cast(1 as float) as c8
+,cast(1 as boolean) as c9
+,cast(1 as char) as c10
+,cast(1 as string) as c11
+,cast(1 as varchar) as c12
+,cast('s' as BINARY) as c13
+,cast('2023-03-07' as date) as c14
+,cast('2023-03-07 11:22:33' as datetime) as c15
+,[1, 2, 3] as c16
+,get_json_object('{"k1":1, "k2":"v2"}', '$.k1') as c17
+,map{1:"apple", 2:"orange", 3:"pear"} as c18
+,struct(1, 2, 3, 4) as c19
+,parse_json('{"a": 1, "b": true}') as c20;
+-- result:
+-- !result
+select typeof(c1)
+  ,typeof(c2)
+  ,typeof(c3)
+  ,typeof(c4)
+  ,typeof(c5)
+  ,typeof(c6)
+  ,typeof(c7)
+  ,typeof(c8)
+  ,typeof(c9)
+  ,typeof(c10)
+  ,typeof(c11)
+  ,typeof(c12)
+  ,typeof(c13)
+  ,typeof(c14)
+  ,typeof(c15)
+  ,typeof(c16)
+  ,typeof(c17)
+  ,typeof(c18)
+  ,typeof(c19)
+  ,typeof(c20)
+  from t1;
+-- result:
+tinyint	smallint	int	bigint	largeint	decimal128(19, 2)	decimal128(38, 9)	decimal128(38, 9)	boolean	varchar	varchar	varchar	varbinary	date	datetime	array<tinyint>	varchar	map<tinyint,varchar>	struct<col1 tinyint, col2 tinyint, col3 tinyint, col4 tinyint>	json
+-- !result
+-- name: test_typeof_table_bitmap
+CREATE TABLE pv_bitmap (
+    dt INT(11) NULL COMMENT "",
+    page VARCHAR(10) NULL COMMENT "",
+    user_id bitmap BITMAP_UNION NULL COMMENT ""
+) ENGINE=OLAP
+AGGREGATE KEY(dt, page)
+COMMENT "OLAP"
+DISTRIBUTED BY HASH(dt)
+properties("replication_num" = "1");
+-- result:
+-- !result
+insert into pv_bitmap values(1, 'test', to_bitmap(10));
+-- result:
+-- !result
+select typeof(user_id) from pv_bitmap;
+-- result:
+bitmap
+-- !result
+-- name: test_typeof_table_hll
+create table test_uv(
+    dt date,
+    id int,
+    uv_set hll hll_union
+)
+distributed by hash(id)
+properties("replication_num" = "1");
+-- result:
+-- !result
+insert into test_uv values('2024-01-01', 1, hll_hash(10));
+-- result:
+-- !result
+select typeof(uv_set) from test_uv;
+-- result:
+hll
+-- !result

--- a/test/sql/test_function/T/test_typeof
+++ b/test/sql/test_function/T/test_typeof
@@ -1,0 +1,94 @@
+-- name: test_typeof_literal
+select typeof(cast(1 as tinyint));
+select typeof(cast(1 as smallint));
+select typeof(cast(1 as int));
+select typeof(cast(1 as bigint));
+select typeof(cast(1 as largeint));
+select typeof(cast(1 as decimal(19, 2)));
+select typeof(cast(1 as double));
+select typeof(cast(1 as float));
+select typeof(cast(1 as boolean));
+select typeof(cast(1 as char));
+select typeof(cast(1 as string));
+select typeof(cast(1 as varchar));
+select typeof(cast('s' as BINARY));
+select typeof(cast('2023-03-07' as date));
+select typeof(cast('2023-03-07 11:22:33' as datetime));
+select typeof([1, 2, 3]);
+select typeof(get_json_object('{"k1":1, "k2":"v2"}', '$.k1'));
+select typeof(map{1:"apple", 2:"orange", 3:"pear"});
+select typeof(struct(1, 2, 3, 4));
+select typeof(bitmap_empty());
+select typeof(hll_empty());
+select typeof(parse_json('{"a": 1, "b": true}'));
+select typeof(null);
+
+-- name: test_typeof_table
+create table t1 properties("replication_num" = "1") as
+select cast(1 as tinyint) as c1
+,cast(1 as smallint) as c2
+,cast(1 as int) as c3
+,cast(1 as bigint) as c4
+,cast(1 as largeint) as c5
+,cast(1 as decimal(19, 2)) as c6
+,cast(1 as double) as c7
+,cast(1 as float) as c8
+,cast(1 as boolean) as c9
+,cast(1 as char) as c10
+,cast(1 as string) as c11
+,cast(1 as varchar) as c12
+,cast('s' as BINARY) as c13
+,cast('2023-03-07' as date) as c14
+,cast('2023-03-07 11:22:33' as datetime) as c15
+,[1, 2, 3] as c16
+,get_json_object('{"k1":1, "k2":"v2"}', '$.k1') as c17
+,map{1:"apple", 2:"orange", 3:"pear"} as c18
+,struct(1, 2, 3, 4) as c19
+,parse_json('{"a": 1, "b": true}') as c20;
+select typeof(c1)
+  ,typeof(c2)
+  ,typeof(c3)
+  ,typeof(c4)
+  ,typeof(c5)
+  ,typeof(c6)
+  ,typeof(c7)
+  ,typeof(c8)
+  ,typeof(c9)
+  ,typeof(c10)
+  ,typeof(c11)
+  ,typeof(c12)
+  ,typeof(c13)
+  ,typeof(c14)
+  ,typeof(c15)
+  ,typeof(c16)
+  ,typeof(c17)
+  ,typeof(c18)
+  ,typeof(c19)
+  ,typeof(c20)
+  from t1;
+-- name: test_typeof_table_bitmap
+CREATE TABLE pv_bitmap (
+    dt INT(11) NULL COMMENT "",
+    page VARCHAR(10) NULL COMMENT "",
+    user_id bitmap BITMAP_UNION NULL COMMENT ""
+) ENGINE=OLAP
+AGGREGATE KEY(dt, page)
+COMMENT "OLAP"
+DISTRIBUTED BY HASH(dt)
+properties("replication_num" = "1");
+
+insert into pv_bitmap values(1, 'test', to_bitmap(10));
+
+select typeof(user_id) from pv_bitmap;
+
+-- name: test_typeof_table_hll
+create table test_uv(
+    dt date,
+    id int,
+    uv_set hll hll_union
+)
+distributed by hash(id)
+properties("replication_num" = "1");
+
+insert into test_uv values('2024-01-01', 1, hll_hash(10));
+select typeof(uv_set) from test_uv;


### PR DESCRIPTION
## Why I'm doing:

https://github.com/StarRocks/starrocks/issues/36245

## What I'm doing:

The typeof function is completely implemented in fe. 
In ExpressionAnalyzer.visitFunctionCall, we can get the parameter type of typeof. At this time, we have already got the result of the typeof function. We only need to directly replace the current FunctionCallExpr with StringLiteral, but I can't get the parent node of typeof, so I can't make this replacement. To solve this problem, I put StringLiteral in the position of the typeof parameter, and then rewrite it in the FoldConstantsRule.

## What type of PR is this:

- [ ] BugFix
- [x] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [x] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
