### PR TITLE
[Enhancement] support clang 16 compile(#42550)

### DIFF
--- a/be/CMakeLists.txt
+++ b/be/CMakeLists.txt
@@ -648,6 +648,8 @@ if (CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
     if (CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL "16.0.0")
         # ignore warning from apache-orc
         set(CXX_COMMON_FLAGS "${CXX_COMMON_FLAGS} -Wno-unsafe-buffer-usage")
+        # ignore warning from geo
+        set(CXX_COMMON_FLAGS "${CXX_COMMON_FLAGS} -Wno-unused-but-set-variable")
     endif ()
 else ()
     set(CXX_GCC_FLAGS "${CXX_GCC_FLAGS} -fcoroutines")


### PR DESCRIPTION
## Why I'm doing:
Compile be with clang-16. This is a reopen for #42550 which is closed by mistake.

## What I'm doing:
Install clang-16 based on the [LDB Toolchain](https://github.com/amosbird/ldb_toolchain_gen), and compile with the following commands in the docker develop environment.

```
export PATH=/opt/ldb/bin:$PATH
export CC="/opt/ldb/bin/clang"
export CXX="/opt/ldb/bin/clang++"
bash build.sh --be  -j 8 --clean
```

Got the following errors.

```
/root/starrocks/be/../gensrc/build//geo/wkt_yacc.y.cpp:1153:9: error: variable 'wkt_nerrs' set but not used [-Werror,-Wunused-but-set-variable]                                                                            int yynerrs;        ^                                                                                                                                                                                                              /root/starrocks/gensrc/build/geo/wkt_yacc.y.cpp:72:25: note: expanded from macro 'yynerrs'                                                                                                                             #define yynerrs         wkt_nerrs
                        ^                                                                                                                                                                                              
1 error generated. 
```

Just add a compile flag for Geo lib.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [x] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
