### PR TITLE
[Enhancement] Add SingleFlight for eliminating redundant work

### DIFF
--- a/be/src/util/bthreads/future.h
+++ b/be/src/util/bthreads/future.h
@@ -54,8 +54,6 @@ public:
         return _state->wait_until(abs);
     }
 
-    SharedFuture<R> share() { return SharedFuture<R>(std::move(_state)); }
-
 protected:
     constexpr FutureBase() noexcept : _state() {}
 
@@ -76,6 +74,8 @@ protected:
         ~Reset() { _future._state.reset(); }
         FutureBase& _future;
     };
+
+    SharedFuture<R> share() { return SharedFuture<R>(std::move(_state)); }
 
     std::shared_ptr<SharedState<R>> _state;
 };
@@ -110,6 +110,8 @@ public:
         this->wait_and_check_exception();
         return std::move(this->_state->value());
     }
+
+    using BaseType::share;
 
 private:
     friend class Promise<R>;
@@ -231,7 +233,7 @@ private:
     friend class Future<R>;
 
     using BaseType = FutureBase<R>;
-    using BaseType::share;
+
     explicit SharedFuture(std::shared_ptr<SharedState<R>> state) : BaseType(std::move(state)) {}
 };
 

--- a/be/src/util/bthreads/future.h
+++ b/be/src/util/bthreads/future.h
@@ -224,6 +224,8 @@ public:
         return this->_state->value();
     }
 
+    bool operator==(const SharedFuture rhs) const { return this->_state == rhs._state; }
+
 private:
     friend class Promise<R>;
     friend class Future<R>;

--- a/be/src/util/bthreads/future.h
+++ b/be/src/util/bthreads/future.h
@@ -146,6 +146,8 @@ public:
         return this->_state->value();
     }
 
+    using BaseType::share;
+
 private:
     friend class Promise<R&>;
 
@@ -176,6 +178,8 @@ public:
         typename BaseType::Reset reset(*this);
         this->wait_and_check_exception();
     }
+
+    using BaseType::share;
 
 private:
     friend class Promise<void>;
@@ -228,6 +232,8 @@ public:
 
     bool operator==(const SharedFuture rhs) const { return this->_state == rhs._state; }
 
+    bool operator<(const SharedFuture rhs) const { return this->_state < rhs._state; }
+
 private:
     friend class Promise<R>;
     friend class Future<R>;
@@ -273,6 +279,10 @@ public:
         return this->_state->value();
     }
 
+    bool operator==(const SharedFuture rhs) const { return this->_state == rhs._state; }
+
+    bool operator<(const SharedFuture rhs) const { return this->_state < rhs._state; }
+
 private:
     friend class Promise<R&>;
 
@@ -314,6 +324,10 @@ public:
         SharedStateBase::check_state(this->_state);
         this->wait_and_check_exception();
     }
+
+    bool operator==(const SharedFuture rhs) const { return this->_state == rhs._state; }
+
+    bool operator<(const SharedFuture rhs) const { return this->_state < rhs._state; }
 
 private:
     friend class Promise<void>;

--- a/be/src/util/bthreads/future.h
+++ b/be/src/util/bthreads/future.h
@@ -231,7 +231,7 @@ private:
     friend class Future<R>;
 
     using BaseType = FutureBase<R>;
-
+    using BaseType::share;
     explicit SharedFuture(std::shared_ptr<SharedState<R>> state) : BaseType(std::move(state)) {}
 };
 

--- a/be/src/util/bthreads/single_flight.h
+++ b/be/src/util/bthreads/single_flight.h
@@ -1,0 +1,93 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <bthread/mutex.h>
+
+#include <mutex>
+#include <unordered_map>
+
+#include "testutil/sync_point.h"
+#include "util/bthreads/future.h"
+
+namespace starrocks::bthreads::singleflight {
+
+// Inspired by Golang's SingleFlight: https://github.com/golang/sync/blob/master/singleflight/singleflight.go
+template <typename K, typename R>
+class Group {
+public:
+    // Do executes and returns the results of the given function, making
+    // sure that only one execution is in-flight for a given key at a
+    // time. If a duplicate comes in, the duplicate caller waits for the
+    // original to complete and receives the same results.
+    template <typename Func, typename... Args>
+    R Do(K key, Func&& func, Args&&... args) {
+        auto f = DoFuture(key, std::forward<Func>(func), std::forward<Args>(args)...);
+        return f.get();
+    }
+
+    template <typename Func, typename... Args>
+    SharedFuture<R> DoFuture(K key, Func&& func, Args&&... args) {
+        std::unique_lock lock(_doing_mtx);
+
+        auto it = _doing.find(key);
+        if (it != _doing.end()) {
+            auto f = it->second;
+            lock.unlock();
+            TEST_SYNC_POINT("singleflight::Group::Do:1");
+            return f;
+        }
+
+        auto promise = bthreads::Promise<R>();
+        auto future = promise.get_future().share();
+        _doing.emplace(key, future);
+        lock.unlock();
+
+        TEST_SYNC_POINT("singleflight::Group::Do:2");
+        try {
+            promise.set_value(func(std::forward<Args>(args)...));
+        } catch (...) {
+            promise.set_exception(std::current_exception());
+        }
+        TEST_SYNC_POINT("singleflight::Group::Do:3");
+
+        lock.lock();
+        it = _doing.find(key);
+        if (it != _doing.end() && it->second == future) {
+            _doing.erase(it);
+        }
+        lock.unlock();
+
+        return future;
+    }
+
+    // Forget tells the singleflight to forget about a key.  Future calls
+    // to Do for this key will call the function rather than waiting for
+    // an earlier call to complete.
+    void Forget(K key) {
+        TEST_SYNC_POINT("singleflight::Group::Forget:1");
+        {
+            std::lock_guard l(_doing_mtx);
+            _doing.erase(key);
+        }
+        TEST_SYNC_POINT("singleflight::Group::Forget:2");
+    }
+
+private:
+    bthread::Mutex _doing_mtx;
+    std::unordered_map<K, SharedFuture<R>> _doing;
+};
+
+} // namespace starrocks::bthreads::singleflight

--- a/be/test/CMakeLists.txt
+++ b/be/test/CMakeLists.txt
@@ -373,6 +373,7 @@ set(EXEC_FILES
         ./util/bthreads/semaphore_test.cpp
         ./util/bthreads/shared_mutex_test.cpp
         ./util/bthreads/shared_future_test.cpp
+        ./util/bthreads/single_flight_test.cpp
         ./util/c_string_test.cpp
         ./util/cidr_test.cpp
         ./util/coding_test.cpp

--- a/be/test/util/bthreads/single_flight_test.cpp
+++ b/be/test/util/bthreads/single_flight_test.cpp
@@ -1,0 +1,112 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "util/bthreads/single_flight.h"
+
+#include <bthread/bthread.h>
+#include <gtest/gtest.h>
+
+#include "testutil/assert.h"
+#include "testutil/parallel_test.h"
+#include "util/bthreads/util.h"
+#include "util/defer_op.h"
+
+namespace starrocks::bthreads {
+
+PARALLEL_TEST(SingleFlightTest, test_single_threaded) {
+    int n = 0;
+    singleflight::Group<int, int> test_group;
+    for (int i = 0; i < 5; i++) {
+        auto r = test_group.Do(0, [&]() { return n++; });
+        EXPECT_EQ(i, r);
+    }
+    EXPECT_EQ(5, n);
+}
+
+PARALLEL_TEST(SingleFlightTest, test_wait01) {
+    auto do_func = [&](std::atomic<int>* count) { return count->fetch_add(1, std::memory_order_relaxed); };
+
+    const std::string KEY = "test_key";
+    std::atomic<int> cnt{0};
+    singleflight::Group<std::string, int> test_group;
+
+    SyncPoint::GetInstance()->LoadDependency({{"singleflight::Group::Do:1", "singleflight::Group::Do:2"}});
+    SyncPoint::GetInstance()->EnableProcessing();
+    DeferOp defer([]() { SyncPoint::GetInstance()->DisableProcessing(); });
+
+    ASSIGN_OR_ABORT(auto tid, bthreads::start_bthread([&]() { EXPECT_EQ(0, test_group.Do(KEY, do_func, &cnt)); }));
+    EXPECT_EQ(0, test_group.Do(KEY, do_func, &cnt));
+    EXPECT_EQ(0, bthread_join(tid, nullptr));
+    EXPECT_EQ(1, cnt.load(std::memory_order_relaxed));
+}
+
+// Like above but use std::thread
+PARALLEL_TEST(SingleFlightTest, test_wait02) {
+    auto do_func = [&](std::atomic<int>* count) { return count->fetch_add(1, std::memory_order_relaxed); };
+
+    const std::string KEY = "test_key";
+    std::atomic<int> cnt{0};
+    singleflight::Group<std::string, int> test_group;
+
+    SyncPoint::GetInstance()->LoadDependency({{"singleflight::Group::Do:1", "singleflight::Group::Do:2"}});
+    SyncPoint::GetInstance()->EnableProcessing();
+    DeferOp defer([]() { SyncPoint::GetInstance()->DisableProcessing(); });
+
+    auto t = std::thread([&]() { EXPECT_EQ(0, test_group.Do(KEY, do_func, &cnt)); });
+    EXPECT_EQ(0, test_group.Do(KEY, do_func, &cnt));
+    t.join();
+    EXPECT_EQ(1, cnt.load(std::memory_order_relaxed));
+}
+
+PARALLEL_TEST(SingleFlightTest, test_exception) {
+    std::atomic<int> counter{0};
+    auto do_func = [&]() {
+        counter.fetch_add(1, std::memory_order_relaxed);
+        throw std::logic_error("injected error");
+        return 0;
+    };
+    singleflight::Group<int, int> test_group;
+    EXPECT_THROW({ test_group.Do(1, do_func); }, std::logic_error);
+
+    SyncPoint::GetInstance()->LoadDependency({{"singleflight::Group::Do:1", "singleflight::Group::Do:2"}});
+    SyncPoint::GetInstance()->EnableProcessing();
+    DeferOp defer([]() { SyncPoint::GetInstance()->DisableProcessing(); });
+
+    ASSIGN_OR_ABORT(auto tid,
+                    bthreads::start_bthread([&]() { EXPECT_THROW({ test_group.Do(1, do_func); }, std::logic_error); }));
+    EXPECT_THROW({ test_group.Do(1, do_func); }, std::logic_error);
+    EXPECT_EQ(0, bthread_join(tid, nullptr));
+    EXPECT_EQ(2, counter.load(std::memory_order_relaxed));
+}
+
+PARALLEL_TEST(SingleFlightTest, test_forget) {
+    std::atomic<int> counter{0};
+    auto func = [](std::atomic<int>* cnt) { return cnt->fetch_add(1, std::memory_order_relaxed); };
+    constexpr int KEY = 1;
+    singleflight::Group<int, int> test_group;
+    SyncPoint::GetInstance()->LoadDependency({
+            {"singleflight::Group::Do:2", "singleflight::Group::Forget:1"},
+            {"singleflight::Group::Forget:2", "singleflight::Group::Do:3"},
+    });
+    SyncPoint::GetInstance()->EnableProcessing();
+    DeferOp defer([]() { SyncPoint::GetInstance()->DisableProcessing(); });
+
+    ASSIGN_OR_ABORT(auto tid, bthreads::start_bthread([&]() { (void)test_group.Do(KEY, func, &counter); }));
+    test_group.Forget(KEY);
+    (void)test_group.Do(KEY, func, &counter);
+    EXPECT_EQ(0, bthread_join(tid, nullptr));
+    EXPECT_EQ(2, counter.load(std::memory_order_relaxed));
+}
+
+} // namespace starrocks::bthreads


### PR DESCRIPTION
## Why I'm doing
There are some cases in StarRocks where multiple requests are made for the same resource at the same time. This can lead to redundant work, increased service load, and overall inefficiency. Here are some examples of such situations:
1. publish version RPC times out and the FE initiates a retry, there may be multiple publish version tasks reading tablet metadata and txn logs at the same time.
2. publish version, multiple tablets are reading the same combined txn log at the same time(#42542).
3. Multiple requests reading the same segment file at the same time.
4. Multiple tablets concurrently requesting the same schema file during data loading.

## What I'm doing
In the Go programming language, the singleflight package provides a powerful solution to this problem. This patch add a C++ implementation of singleflight. Other patches that utilize singleflight to reduce redundant requests will be submitted later.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [x] 3.1
  - [ ] 3.0
  - [ ] 2.5
