### PR TITLE
[Feature] Broker support COS posix bucket

### DIFF
--- a/fs_brokers/apache_hdfs_broker/pom.xml
+++ b/fs_brokers/apache_hdfs_broker/pom.xml
@@ -339,6 +339,42 @@ under the License.
             <version>${hadoop.version}</version>
         </dependency>
 
+        <!-- https://mvnrepository.com/artifact/com.qcloud.cos/hadoop-cos -->
+        <dependency>
+            <groupId>com.qcloud.cos</groupId>
+            <artifactId>hadoop-cos</artifactId>
+            <version>3.3.0-8.3.7</version>
+        </dependency>
+
+
+        <!-- https://mvnrepository.com/artifact/com.qcloud/cos_api-bundle -->
+        <dependency>
+            <groupId>com.qcloud</groupId>
+            <artifactId>cos_api-bundle</artifactId>
+            <version>5.6.137.2</version>
+        </dependency>
+
+        <!-- https://mvnrepository.com/artifact/com.qcloud/cosn-ranger-interface -->
+        <dependency>
+            <groupId>com.qcloud</groupId>
+            <artifactId>cosn-ranger-interface</artifactId>
+            <version>1.0.5</version>
+            <scope>provided</scope>
+        </dependency>
+
+        <!-- https://mvnrepository.com/artifact/com.qcloud/chdfs_hadoop_plugin_network -->
+        <dependency>
+            <groupId>com.qcloud</groupId>
+            <artifactId>chdfs_hadoop_plugin_network</artifactId>
+            <version>3.5</version>
+        </dependency>
+
+        <!-- https://mvnrepository.com/artifact/com.qcloud/hadoop-ranger-client-for-hadoop -->
+        <dependency>
+            <groupId>com.qcloud</groupId>
+            <artifactId>hadoop-ranger-client-for-hadoop</artifactId>
+            <version>3.3.0-4.1</version>
+        </dependency>
     </dependencies>
 
     <build>

--- a/fs_brokers/apache_hdfs_broker/src/main/java/com/starrocks/broker/hdfs/FileSystemManager.java
+++ b/fs_brokers/apache_hdfs_broker/src/main/java/com/starrocks/broker/hdfs/FileSystemManager.java
@@ -149,6 +149,10 @@ public class FileSystemManager {
     private static final String FS_COS_ENDPOINT = "fs.cosn.bucket.endpoint_suffix";
     private static final String FS_COS_IMPL_DISABLE_CACHE = "fs.cosn.impl.disable.cache";
     private static final String FS_COS_IMPL = "fs.cosn.impl";
+    private static final String FS_ABSTRACTFILESYSTEM_COSN_IMPL = "fs.AbstractFileSystem.cosn.impl";
+    private static final String FS_COSN_TRSF_FS_ABSTRACTFILESYSTEM_OFS_IMPL = "fs.cosn.trsf.fs.AbstractFileSystem.ofs.impl";
+    private static final String FS_COSN_TRSF_FS_OFS_IMPL = "fs.cosn.trsf.fs.ofs.impl";
+    private static final String FS_COSN_CREDENTIALS_PROVIDER = "fs.cosn.credentials.provider";
 
     // arguments for obs
     private static final String FS_OBS_ACCESS_KEY = "fs.obs.access.key";
@@ -828,10 +832,11 @@ public class FileSystemManager {
                 String authentication = properties.getOrDefault(CommonConfigurationKeysPublic.HADOOP_SECURITY_AUTHENTICATION,
                         AUTHENTICATION_SIMPLE);
                 if (authentication.equalsIgnoreCase(AUTHENTICATION_KERBEROS)) {
-                    conf.set("fs.AbstractFileSystem.cosn.impl", "org.apache.hadoop.fs.CosN");
-                    conf.set("fs.cosn.trsf.fs.AbstractFileSystem.ofs.impl", "com.qcloud.chdfs.fs.CHDFSDelegateFSAdapter");
-                    conf.set("fs.cosn.trsf.fs.ofs.impl", "com.qcloud.chdfs.fs.CHDFSHadoopFileSystemAdapter");
-                    conf.set("fs.cosn.credentials.provider", "org.apache.hadoop.fs.auth.RangerCredentialsProvider");
+                    conf.set(FS_ABSTRACTFILESYSTEM_COSN_IMPL, "org.apache.hadoop.fs.CosN");
+                    conf.set(FS_COSN_TRSF_FS_ABSTRACTFILESYSTEM_OFS_IMPL, "com.qcloud.chdfs.fs.CHDFSDelegateFSAdapter");
+                    conf.set(FS_COSN_TRSF_FS_OFS_IMPL, "com.qcloud.chdfs.fs.CHDFSHadoopFileSystemAdapter");
+                    conf.set(FS_COSN_CREDENTIALS_PROVIDER, "org.apache.hadoop.fs.auth.RangerCredentialsProvider");
+
                     String principal = properties.getOrDefault(KERBEROS_PRINCIPAL,"");
                     String keytab = properties.getOrDefault(KERBEROS_KEYTAB,"");
 


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:
This PR adds the support of COS posix bucket.
With broker, you can use Broker Load to load data from COS posix bucket, and use SELECT INTO OUTFILE to export data to COS posix bucket.
This is maily inspired by https://cloud.tencent.com/document/product/436/82208.
```
LOAD LABEL db0.label3 (     DATA INFILE("cosn://xxx/some.parquet")     INTO TABLE tbl_student     FORMAT AS "parquet"     (name, age)  ) WITH BROKER  srbroker ( 
"fs.cosn.bucket.endpoint_suffix" = "cos.ap-guangzhou.myqcloud.com",
"fs.cosn.userinfo.region"="ap-guangzhou",
"qcloud.object.storage.ranger.service.address"="10.0.0.26:9999",
"hadoop.security.authentication"="kerberos",
"fs.ofs.tmp.cache.dir"="/tmp","fs.cosn.trsf.fs.ofs.user.appid"="12345",
"qcloud.object.storage.kerberos.principal"="hadoop/10.0.0.26@EMR-ABC",
"kerberos_principal"="hadoop/10.0.0.26@EMR-ABC", 
"kerberos_keytab"="/var/krb5kdc/emr.keytab"
);
```
```
SELECT * FROM tbl_student INTO OUTFILE "cosn://some_bucket/parquet/" FORMAT AS PARQUET PROPERTIES (
"broker.name"="srbroker",
"fs.cosn.bucket.endpoint_suffix" = "cos.ap-guangzhou.myqcloud.com",
"fs.cosn.userinfo.region"="ap-guangzhou",
"qcloud.object.storage.ranger.service.address"="10.0.0.26:9999",
"hadoop.security.authentication"="kerberos",
"fs.ofs.tmp.cache.dir"="/tmp","fs.cosn.trsf.fs.ofs.user.appid"="12345",
"qcloud.object.storage.kerberos.principal"="hadoop/10.0.0.26@EMR-ABC",
"kerberos_principal"="hadoop/10.0.0.26@EMR-ABC", 
"kerberos_keytab"="/var/krb5kdc/emr.keytab"
);
```
Fixes https://github.com/StarRocks/starrocks/issues/46020

## What type of PR is this:

- [ ] BugFix
- [x] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [x] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [x] 3.2
  - [x] 3.1
  - [ ] 3.0
