### PR TITLE
[BugFix] array low-cardinality conficit with subfield-prune

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/ColumnAccessPath.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/ColumnAccessPath.java
@@ -51,7 +51,7 @@ public class ColumnAccessPath {
     // The top one must be ROOT
     private TAccessPathType type;
 
-    private String path;
+    private final String path;
 
     private final List<ColumnAccessPath> children;
 
@@ -113,6 +113,10 @@ public class ColumnAccessPath {
 
     public ColumnAccessPath getChildPath(String path) {
         return children.stream().filter(p -> p.path.equals(path)).findFirst().orElse(null);
+    }
+
+    public List<ColumnAccessPath> getChildren() {
+        return children;
     }
 
     public void clearChildPath() {

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/LowCardinalityArrayTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/LowCardinalityArrayTest.java
@@ -499,4 +499,12 @@ public class LowCardinalityArrayTest extends PlanTestBase {
         assertNotContains(plan, "DictDecode");
         assertContains(plan, "<slot 9> : array_slice(5: S_PHONE, -1, 2)");
     }
+
+    @Test
+    public void testArrayPruneSubfield() throws Exception {
+        String sql = "select S_NAME from supplier_nullable where array_length(S_ADDRESS) = 2";
+        String plan = getVerboseExplain(sql);
+        assertNotContains(plan, "dict_col=");
+        assertContains(plan, "PredicateAccessPath: [/S_ADDRESS/OFFSET]");
+    }
 }


### PR DESCRIPTION
## Why I'm doing:

`array_length(array<string>)` don't need read element data, but low-cardinality need

```
MySQL g0> explain verbose SELECT t1_3.c_1_1,
         t1_3.c_1_0
FROM t1 AS t1_3
WHERE ((t1_3.c_1_2) IS NULL)
GROUP BY  t1_3.c_1_1, t1_3.c_1_0
 
+----------------------------------------------------------------------+
| Explain String                                                       |
+----------------------------------------------------------------------+
| RESOURCE GROUP: default_wg                                           |
|                                                                      |
| PLAN FRAGMENT 0(F01)                                                 |
|   Fragment Cost: 0.0                                                 |
|   Output Exprs:2: c_1_1 | 1: c_1_0                                   |
|   Input Partition: UNPARTITIONED                                     |
|   RESULT SINK                                                        |
|                                                                      |
|   3:EXCHANGE                                                         |
|      cardinality: 1                                                  |
|                                                                      |
| PLAN FRAGMENT 1(F00)                                                 |
|   Fragment Cost: 43.0                                                |
|                                                                      |
|   Input Partition: RANDOM                                            |
|   OutPut Partition: UNPARTITIONED                                    |
|   OutPut Exchange Id: 03                                             |
|                                                                      |
|   2:AGGREGATE (update finalize)                                      |
|   |  group by: [2: c_1_1, DATETIME, true], [1: c_1_0, BOOLEAN, true] |
|   |  cardinality: 1                                                  |
|   |                                                                  |
|   1:Project                                                          |
|   |  output columns:                                                 |
|   |  1 <-> [1: c_1_0, BOOLEAN, true]                                 |
|   |  2 <-> [2: c_1_1, DATETIME, true]                                |
|   |  cardinality: 1                                                  |
|   |                                                                  |
|   0:OlapScanNode                                                     |
|      table: t1, rollup: t1                                           |
|      preAggregation: on                                              |
|      Predicates: array_length(4: c_1_2) IS NULL                      |
|      dict_col=c_1_2                                                  |
|      partitionsRatio=1/47, tabletsRatio=3/3                          |
|      tabletList=34370,34372,34374                                    |
|      actualRows=9, avgRowSize=25.0                                   |
|      Pruned type: 4 <-> [ARRAY<INT>]                                 |
|      ColumnAccessPath: [/c_1_2/OFFSET]                               |
|      PredicateAccessPath: [/c_1_2/OFFSET]                            |
|      cardinality: 1                                                  |
+----------------------------------------------------------------------+
```
## What I'm doing:

Fixes https://github.com/StarRocks/StarRocksTest/issues/6435

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
