### PR TITLE
[Enhancement] Add io time stat for memtable/segment flush (backport #40173) (backport #40407) (backport #41898)

### DIFF
--- a/be/src/fs/fs_posix.cpp
+++ b/be/src/fs/fs_posix.cpp
@@ -33,6 +33,7 @@
 #include "testutil/sync_point.h"
 #include "util/errno.h"
 #include "util/slice.h"
+#include "util/stopwatch.hpp"
 
 #ifdef USE_STAROS
 #include "fslib/metric_key.h"
@@ -205,6 +206,8 @@ public:
 #ifdef USE_STAROS
         staros::starlet::metrics::TimeObserver<prometheus::Histogram> write_latency(s_sr_posix_write_iolatency);
 #endif
+        MonotonicStopWatch watch;
+        watch.start();
         size_t bytes_written = 0;
         RETURN_IF_ERROR(do_writev_at(_fd, _filename, _filesize, data, cnt, &bytes_written));
         _filesize += bytes_written;
@@ -212,7 +215,7 @@ public:
 #ifdef USE_STAROS
         s_sr_posix_write_iosize.Observe(bytes_written);
 #endif
-        IOProfiler::add_write(bytes_written);
+        IOProfiler::add_write(bytes_written, watch.elapsed_time());
         return Status::OK();
     }
 

--- a/be/src/fs/fs_posix.cpp
+++ b/be/src/fs/fs_posix.cpp
@@ -294,10 +294,13 @@ public:
     }
 
     Status sync() override {
+        MonotonicStopWatch watch;
+        watch.start();
         if (_pending_sync) {
             _pending_sync = false;
             RETURN_IF_ERROR(do_sync(_fd, _filename));
         }
+        IOProfiler::add_sync(watch.elapsed_time());
         return Status::OK();
     }
 

--- a/be/src/io/fd_input_stream.cpp
+++ b/be/src/io/fd_input_stream.cpp
@@ -22,6 +22,7 @@
 #include "gutil/macros.h"
 #include "io/io_error.h"
 #include "io_profiler.h"
+#include "util/stopwatch.hpp"
 
 #ifdef USE_STAROS
 #include "fslib/metric_key.h"
@@ -69,6 +70,8 @@ Status FdInputStream::close() {
 
 StatusOr<int64_t> FdInputStream::read(void* data, int64_t count) {
     CHECK_IS_CLOSED(_is_closed);
+    MonotonicStopWatch watch;
+    watch.start();
     ssize_t res;
 #ifdef USE_STAROS
     staros::starlet::metrics::TimeObserver<prometheus::Histogram> observer(s_posixread_iolatency);
@@ -82,7 +85,7 @@ StatusOr<int64_t> FdInputStream::read(void* data, int64_t count) {
     s_posixread_iosize.Observe(res);
 #endif
     _offset += res;
-    IOProfiler::add_read(res);
+    IOProfiler::add_read(res, watch.elapsed_time());
     return res;
 }
 

--- a/be/src/io/fd_output_stream.cpp
+++ b/be/src/io/fd_output_stream.cpp
@@ -22,6 +22,7 @@
 #include "gutil/macros.h"
 #include "io/io_error.h"
 #include "io/io_profiler.h"
+#include "util/stopwatch.hpp"
 
 namespace starrocks::io {
 
@@ -56,6 +57,8 @@ Status FdOutputStream::write(const void* data, int64_t count) {
     if (UNLIKELY(count < 0)) {
         return Status::InvalidArgument(fmt::format("negative count: {}", count));
     }
+    MonotonicStopWatch watch;
+    watch.start();
     int64_t bytes_written = 0;
     while (bytes_written < count) {
         ssize_t r = ::write(_fd, static_cast<const char*>(data) + bytes_written, count - bytes_written);
@@ -69,7 +72,7 @@ Status FdOutputStream::write(const void* data, int64_t count) {
             }
         }
     }
-    IOProfiler::add_write(bytes_written);
+    IOProfiler::add_write(bytes_written, watch.elapsed_time());
     return Status::OK();
 }
 

--- a/be/src/io/io_profiler.cpp
+++ b/be/src/io/io_profiler.cpp
@@ -22,17 +22,17 @@
 
 namespace starrocks {
 
-std::atomic<uint32_t> IOProfiler::_mode(0);
+std::atomic<uint32_t> IOProfiler::_context_io_mode(0);
 
 Status IOProfiler::start(IOProfiler::IOMode op) {
     if (op == IOMode::IOMODE_NONE) {
         return Status::InternalError("invalid io profiler mode");
     }
-    uint32_t old_mode = _mode.load();
+    uint32_t old_mode = _context_io_mode.load();
     if (old_mode != IOMode::IOMODE_NONE) {
         return Status::InternalError("io profiler is already started");
     }
-    if (_mode.compare_exchange_strong(old_mode, (uint32_t)op)) {
+    if (_context_io_mode.compare_exchange_strong(old_mode, (uint32_t)op)) {
         LOG(INFO) << "io profiler started, mode=" << op;
         return Status::OK();
     } else {
@@ -42,12 +42,12 @@ Status IOProfiler::start(IOProfiler::IOMode op) {
 }
 
 void IOProfiler::stop() {
-    uint32_t old_mode = _mode.load();
+    uint32_t old_mode = _context_io_mode.load();
     if (old_mode == IOMode::IOMODE_NONE) {
         LOG(INFO) << "io profiler is not started";
         return;
     }
-    if (_mode.compare_exchange_strong(old_mode, IOMode::IOMODE_NONE)) {
+    if (_context_io_mode.compare_exchange_strong(old_mode, IOMode::IOMODE_NONE)) {
         LOG(INFO) << "io profiler stopped";
     } else {
         LOG(WARNING) << "io profiler already stopped";
@@ -111,7 +111,7 @@ bool IOProfiler::is_empty() {
 }
 
 void IOProfiler::reset() {
-    uint32_t old_mode = _mode.load();
+    uint32_t old_mode = _context_io_mode.load();
     if (old_mode != IOMode::IOMODE_NONE) {
         LOG(WARNING) << "stop io profiler before reset";
         return;
@@ -150,16 +150,48 @@ void IOProfiler::clear_context() {
     current_io_stat = nullptr;
 }
 
-void IOProfiler::_add_read(int64_t bytes) {
+void IOProfiler::_add_context_read(int64_t bytes) {
     if (current_io_stat != nullptr) {
         current_io_stat->add_read(bytes);
     }
 }
 
-void IOProfiler::_add_write(int64_t bytes) {
+void IOProfiler::_add_context_write(int64_t bytes) {
     if (current_io_stat != nullptr) {
         current_io_stat->add_write(bytes);
     }
+}
+
+// Thread local IO statistics which accumulates all IO since the thread is started
+thread_local IOProfiler::IOStat tls_io_stat{0, 0, 0, 0, 0, 0};
+
+void IOProfiler::take_tls_io_snapshot(IOStat* snapshot) {
+    snapshot->read_ops = tls_io_stat.read_ops;
+    snapshot->read_bytes = tls_io_stat.read_bytes;
+    snapshot->read_time_ns = tls_io_stat.read_time_ns;
+    snapshot->write_ops = tls_io_stat.write_ops;
+    snapshot->write_bytes = tls_io_stat.write_bytes;
+    snapshot->write_time_ns = tls_io_stat.write_time_ns;
+}
+
+IOProfiler::IOStat IOProfiler::calculate_scoped_tls_io(const IOStat& snapshot) {
+    IOStat io_stat{
+            tls_io_stat.read_ops - snapshot.read_ops,         tls_io_stat.read_bytes - snapshot.read_bytes,
+            tls_io_stat.read_time_ns - snapshot.read_time_ns, tls_io_stat.write_ops - snapshot.write_ops,
+            tls_io_stat.write_bytes - snapshot.write_bytes,   tls_io_stat.write_time_ns - snapshot.write_time_ns};
+    return io_stat;
+}
+
+void IOProfiler::_add_tls_read(int64_t bytes, int64_t latency_ns) {
+    tls_io_stat.read_ops += 1;
+    tls_io_stat.read_bytes += bytes;
+    tls_io_stat.read_time_ns += latency_ns;
+}
+
+void IOProfiler::_add_tls_write(int64_t bytes, int64_t latency_ns) {
+    tls_io_stat.write_ops += 1;
+    tls_io_stat.write_bytes += bytes;
+    tls_io_stat.write_time_ns += latency_ns;
 }
 
 const char* IOProfiler::tag_to_string(uint32_t tag) {
@@ -191,7 +223,7 @@ StatusOr<std::vector<std::string>> IOProfiler::get_topn_stats(size_t n,
                                                               const std::function<int64_t(const IOStatEntry&)>& func) {
     std::vector<std::pair<uint64_t, const IOStatEntry*>> stats;
     std::lock_guard<std::mutex> l(_io_stats_mutex);
-    if (_mode.load() != IOMode::IOMODE_NONE) {
+    if (_context_io_mode.load() != IOMode::IOMODE_NONE) {
         return Status::InternalError("io profiler still running");
     }
     stats.reserve(_io_stats.size());

--- a/be/src/io/io_profiler.cpp
+++ b/be/src/io/io_profiler.cpp
@@ -142,6 +142,15 @@ IOStatEntry* IOProfiler::get_context() {
     return current_io_stat;
 }
 
+IOProfiler::IOStat IOProfiler::get_context_io() {
+    if (current_io_stat != nullptr) {
+        return IOStat{current_io_stat->read_ops,  current_io_stat->read_bytes,  0,
+                      current_io_stat->write_ops, current_io_stat->write_bytes, 0};
+    } else {
+        return IOStat{0, 0, 0, 0, 0, 0};
+    }
+}
+
 void IOProfiler::set_context(IOStatEntry* entry) {
     current_io_stat = entry;
 }

--- a/be/src/io/io_profiler.h
+++ b/be/src/io/io_profiler.h
@@ -43,6 +43,16 @@ public:
         TAG_MIGRATE,
         TAG_SIZE,
     };
+
+    struct IOStat {
+        uint64_t read_ops;
+        uint64_t read_bytes;
+        uint64_t read_time_ns;
+        uint64_t write_ops;
+        uint64_t write_bytes;
+        uint64_t write_time_ns;
+    };
+
     static const char* tag_to_string(uint32_t tag);
 
     static Status start(IOMode op);
@@ -56,40 +66,52 @@ public:
 
     static bool is_empty();
 
+    static void take_tls_io_snapshot(IOStat* snapshot);
+    static IOStat calculate_scoped_tls_io(const IOStat& snapshot);
+
     class Scope {
     public:
         Scope() = delete;
         Scope(const Scope&) = delete;
         Scope(Scope&& other) {
             _old = other._old;
+            _tls_io_snapshot = other._tls_io_snapshot;
             other._old = nullptr;
         }
         Scope(uint32_t tag, uint64_t tablet_id) {
             _old = get_context();
             set_context(tag, tablet_id);
+            take_tls_io_snapshot(&_tls_io_snapshot);
         }
         Scope(IOStatEntry* entry) {
             _old = get_context();
             set_context(entry);
+            take_tls_io_snapshot(&_tls_io_snapshot);
         }
         ~Scope() { set_context(_old); }
 
+        IOStat current_scoped_tls_io() { return calculate_scoped_tls_io(_tls_io_snapshot); }
+
     private:
         IOStatEntry* _old{nullptr};
+        // A snapshot of the thread local io stat when this scope is created
+        IOStat _tls_io_snapshot;
     };
 
     static Scope scope(uint32_t tag, uint64_t tablet_id) { return Scope(tag, tablet_id); }
     static Scope scope(IOStatEntry* entry) { return Scope(entry); }
 
-    static inline void add_read(int64_t bytes) {
-        if (_mode & IOMode::IOMODE_READ) {
-            _add_read(bytes);
+    static inline void add_read(int64_t bytes, int64_t latency_ns) {
+        _add_tls_read(bytes, latency_ns);
+        if (_context_io_mode & IOMode::IOMODE_WRITE) {
+            _add_context_write(bytes);
         }
     }
 
-    static inline void add_write(int64_t bytes) {
-        if (_mode & IOMode::IOMODE_WRITE) {
-            _add_write(bytes);
+    static inline void add_write(int64_t bytes, int64_t latency_ns) {
+        _add_tls_write(bytes, latency_ns);
+        if (_context_io_mode & IOMode::IOMODE_READ) {
+            _add_context_read(bytes);
         }
     }
 
@@ -110,10 +132,15 @@ protected:
     static StatusOr<std::vector<std::string>> get_topn_stats(size_t n,
                                                              const std::function<int64_t(const IOStatEntry&)>& func);
 
-    static void _add_read(int64_t bytes);
-    static void _add_write(int64_t bytes);
+    // Update thread local io statistics
+    static void _add_tls_read(int64_t bytes, int64_t latency_ns);
+    static void _add_tls_write(int64_t bytes, int64_t latency_ns);
 
-    static std::atomic<uint32_t> _mode;
+    // Update io statistics associated with a context, such as tag + tablet_id
+    static void _add_context_read(int64_t bytes);
+    static void _add_context_write(int64_t bytes);
+
+    static std::atomic<uint32_t> _context_io_mode;
 };
 
 } // namespace starrocks

--- a/be/src/io/io_profiler.h
+++ b/be/src/io/io_profiler.h
@@ -51,6 +51,8 @@ public:
         uint64_t write_ops;
         uint64_t write_bytes;
         uint64_t write_time_ns;
+        uint64_t sync_ops;
+        uint64_t sync_time_ns;
     };
 
     static const char* tag_to_string(uint32_t tag);
@@ -119,6 +121,8 @@ public:
         }
     }
 
+    static inline void add_sync(int64_t latency_ns) { _add_tls_sync(latency_ns); }
+
     static StatusOr<std::vector<std::string>> get_topn_read_stats(size_t n);
     static StatusOr<std::vector<std::string>> get_topn_write_stats(size_t n);
     static StatusOr<std::vector<std::string>> get_topn_total_stats(size_t n);
@@ -139,6 +143,7 @@ protected:
     // Update thread local io statistics
     static void _add_tls_read(int64_t bytes, int64_t latency_ns);
     static void _add_tls_write(int64_t bytes, int64_t latency_ns);
+    static void _add_tls_sync(int64_t latency_ns);
 
     // Update io statistics associated with a context, such as tag + tablet_id
     static void _add_context_read(int64_t bytes);

--- a/be/src/io/io_profiler.h
+++ b/be/src/io/io_profiler.h
@@ -58,10 +58,12 @@ public:
     static Status start(IOMode op);
     static void stop();
     static void reset();
+    static IOMode get_context_io_mode() { return static_cast<IOMode>(_context_io_mode.load()); }
 
     static void set_context(uint32_t tag, uint64_t tablet_id);
     static void set_context(IOStatEntry* entry);
     static IOStatEntry* get_context();
+    static IOStat get_context_io();
     static void clear_context();
 
     static bool is_empty();
@@ -92,6 +94,8 @@ public:
 
         IOStat current_scoped_tls_io() { return calculate_scoped_tls_io(_tls_io_snapshot); }
 
+        IOStat current_context_io() { return get_context_io(); }
+
     private:
         IOStatEntry* _old{nullptr};
         // A snapshot of the thread local io stat when this scope is created
@@ -103,15 +107,15 @@ public:
 
     static inline void add_read(int64_t bytes, int64_t latency_ns) {
         _add_tls_read(bytes, latency_ns);
-        if (_context_io_mode & IOMode::IOMODE_WRITE) {
-            _add_context_write(bytes);
+        if (_context_io_mode & IOMode::IOMODE_READ) {
+            _add_context_read(bytes);
         }
     }
 
     static inline void add_write(int64_t bytes, int64_t latency_ns) {
         _add_tls_write(bytes, latency_ns);
-        if (_context_io_mode & IOMode::IOMODE_READ) {
-            _add_context_read(bytes);
+        if (_context_io_mode & IOMode::IOMODE_WRITE) {
+            _add_context_write(bytes);
         }
     }
 

--- a/be/src/storage/delta_writer.cpp
+++ b/be/src/storage/delta_writer.cpp
@@ -411,10 +411,11 @@ Status DeltaWriter::write_segment(const SegmentPB& segment_pb, butil::IOBuf& dat
     auto io_stat = scope.current_scoped_tls_io();
     StarRocksMetrics::instance()->segment_flush_total.increment(1);
     StarRocksMetrics::instance()->segment_flush_duration_us.increment(duration_ns / 1000);
-    StarRocksMetrics::instance()->segment_flush_io_time_us.increment(io_stat.write_time_ns / 1000);
+    auto io_time_us = (io_stat.write_time_ns + io_stat.sync_time_ns) / 1000;
+    StarRocksMetrics::instance()->segment_flush_io_time_us.increment(io_time_us);
     StarRocksMetrics::instance()->segment_flush_bytes_total.increment(segment_pb.data_size());
     VLOG(1) << "Flush segment tablet " << _opt.tablet_id << " segment: " << segment_pb.DebugString()
-            << ", duration: " << duration_ns / 1000 << "us, io time: " << io_stat.write_time_ns / 1000 << "us";
+            << ", duration: " << duration_ns / 1000 << "us, io_time: " << io_time_us << "us";
     return Status::OK();
 }
 

--- a/be/src/storage/delta_writer.cpp
+++ b/be/src/storage/delta_writer.cpp
@@ -16,6 +16,7 @@
 
 #include <utility>
 
+#include "io/io_profiler.h"
 #include "runtime/current_thread.h"
 #include "runtime/descriptors.h"
 #include "storage/compaction_manager.h"
@@ -30,6 +31,7 @@
 #include "storage/tablet_updates.h"
 #include "storage/txn_manager.h"
 #include "storage/update_manager.h"
+#include "util/starrocks_metrics.h"
 
 namespace starrocks {
 
@@ -399,9 +401,21 @@ Status DeltaWriter::write_segment(const SegmentPB& segment_pb, butil::IOBuf& dat
                                                  segment_pb.segment_id(), _opt.tablet_id,
                                                  _replica_state_name(_replica_state)));
     }
-    VLOG(1) << "Flush segment tablet " << _opt.tablet_id << " segment " << segment_pb.DebugString();
 
-    return _rowset_writer->flush_segment(segment_pb, data);
+    auto scope = IOProfiler::scope(IOProfiler::TAG_LOAD, _tablet->tablet_id());
+    int64_t duration_ns = 0;
+    {
+        SCOPED_RAW_TIMER(&duration_ns);
+        RETURN_IF_ERROR(_rowset_writer->flush_segment(segment_pb, data));
+    }
+    auto io_stat = scope.current_scoped_tls_io();
+    StarRocksMetrics::instance()->segment_flush_total.increment(1);
+    StarRocksMetrics::instance()->segment_flush_duration_us.increment(duration_ns / 1000);
+    StarRocksMetrics::instance()->segment_flush_io_time_us.increment(io_stat.write_time_ns / 1000);
+    StarRocksMetrics::instance()->segment_flush_bytes_total.increment(segment_pb.data_size());
+    VLOG(1) << "Flush segment tablet " << _opt.tablet_id << " segment: " << segment_pb.DebugString()
+            << ", duration: " << duration_ns / 1000 << "us, io time: " << io_stat.write_time_ns / 1000 << "us";
+    return Status::OK();
 }
 
 Status DeltaWriter::close() {

--- a/be/src/storage/memtable.cpp
+++ b/be/src/storage/memtable.cpp
@@ -285,7 +285,6 @@ Status MemTable::flush(SegmentPB* seg_info) {
                 fmt::format("memtable of tablet {} reache the capacity limit, detail msg: {}", _tablet_id, msg));
     }
     auto scope = IOProfiler::scope(IOProfiler::TAG_LOAD, _tablet_id);
-
     int64_t duration_ns = 0;
     {
         SCOPED_RAW_TIMER(&duration_ns);
@@ -295,9 +294,14 @@ Status MemTable::flush(SegmentPB* seg_info) {
             RETURN_IF_ERROR(_sink->flush_chunk(*_result_chunk, seg_info));
         }
     }
+    auto io_stat = scope.current_scoped_tls_io();
     StarRocksMetrics::instance()->memtable_flush_total.increment(1);
     StarRocksMetrics::instance()->memtable_flush_duration_us.increment(duration_ns / 1000);
-    VLOG(1) << "memtable of tablet " << _tablet_id << " flush: " << duration_ns / 1000 << "us";
+    StarRocksMetrics::instance()->memtable_flush_io_time_us.increment(io_stat.write_time_ns / 1000);
+    auto flush_bytes = memory_usage();
+    StarRocksMetrics::instance()->memtable_flush_bytes_total.increment(flush_bytes);
+    VLOG(1) << "memtable of tablet " << _tablet_id << " flush duration: " << duration_ns / 1000 << "us, "
+            << "io time: " << io_stat.write_time_ns / 1000 << "us, bytes: " << flush_bytes;
     return Status::OK();
 }
 

--- a/be/src/storage/memtable.cpp
+++ b/be/src/storage/memtable.cpp
@@ -299,9 +299,11 @@ Status MemTable::flush(SegmentPB* seg_info) {
     StarRocksMetrics::instance()->memtable_flush_duration_us.increment(duration_ns / 1000);
     StarRocksMetrics::instance()->memtable_flush_io_time_us.increment(io_stat.write_time_ns / 1000);
     auto flush_bytes = memory_usage();
-    StarRocksMetrics::instance()->memtable_flush_bytes_total.increment(flush_bytes);
+    StarRocksMetrics::instance()->memtable_flush_memory_bytes_total.increment(flush_bytes);
+    StarRocksMetrics::instance()->memtable_flush_disk_bytes_total.increment(io_stat.write_bytes);
     VLOG(1) << "memtable of tablet " << _tablet_id << " flush duration: " << duration_ns / 1000 << "us, "
-            << "io time: " << io_stat.write_time_ns / 1000 << "us, bytes: " << flush_bytes;
+            << "io time: " << io_stat.write_time_ns / 1000 << "us, memory bytes: " << flush_bytes
+            << ", disk bytes: " << io_stat.write_bytes;
     return Status::OK();
 }
 

--- a/be/src/storage/memtable.cpp
+++ b/be/src/storage/memtable.cpp
@@ -297,12 +297,13 @@ Status MemTable::flush(SegmentPB* seg_info) {
     auto io_stat = scope.current_scoped_tls_io();
     StarRocksMetrics::instance()->memtable_flush_total.increment(1);
     StarRocksMetrics::instance()->memtable_flush_duration_us.increment(duration_ns / 1000);
-    StarRocksMetrics::instance()->memtable_flush_io_time_us.increment(io_stat.write_time_ns / 1000);
+    auto io_time_us = (io_stat.write_time_ns + io_stat.sync_time_ns) / 1000;
+    StarRocksMetrics::instance()->memtable_flush_io_time_us.increment(io_time_us);
     auto flush_bytes = memory_usage();
     StarRocksMetrics::instance()->memtable_flush_memory_bytes_total.increment(flush_bytes);
     StarRocksMetrics::instance()->memtable_flush_disk_bytes_total.increment(io_stat.write_bytes);
     VLOG(1) << "memtable of tablet " << _tablet_id << " flush duration: " << duration_ns / 1000 << "us, "
-            << "io time: " << io_stat.write_time_ns / 1000 << "us, memory bytes: " << flush_bytes
+            << "io time: " << io_time_us << "us, memory bytes: " << flush_bytes
             << ", disk bytes: " << io_stat.write_bytes;
     return Status::OK();
 }

--- a/be/src/storage/persistent_index.cpp
+++ b/be/src/storage/persistent_index.cpp
@@ -40,6 +40,7 @@
 #include "util/faststring.h"
 #include "util/filesystem_util.h"
 #include "util/raw_container.h"
+#include "util/stopwatch.hpp"
 #include "util/xxh3.h"
 
 namespace starrocks {
@@ -1947,10 +1948,12 @@ Status ShardByLengthMutableIndex::commit(MutableIndexMetaPB* meta, const EditVer
         // open l0 to calc checksum
         std::unique_ptr<RandomAccessFile> l0_rfile;
         ASSIGN_OR_RETURN(l0_rfile, fs->new_random_access_file(file_name));
+        MonotonicStopWatch watch;
+        watch.start();
         size_t snapshot_size = _index_file->size();
         // special case, snapshot file was written by phmap::BinaryOutputArchive which does not use system profiled API
         // so add write stats manually
-        IOProfiler::add_write(snapshot_size);
+        IOProfiler::add_write(snapshot_size, watch.elapsed_time());
         meta->clear_wals();
         IndexSnapshotMetaPB* snapshot = meta->mutable_snapshot();
         version.to_pb(snapshot->mutable_version());
@@ -2030,6 +2033,8 @@ Status ShardByLengthMutableIndex::load(const MutableIndexMetaPB& meta) {
                 return Status::Corruption(error_msg);
             }
         }
+        MonotonicStopWatch watch;
+        watch.start();
         // do load snapshot
         if (!load_snapshot(ar, dumped_shard_idxes)) {
             std::string err_msg = strings::Substitute("failed load snapshot from file $0", index_file_name);
@@ -2038,7 +2043,7 @@ Status ShardByLengthMutableIndex::load(const MutableIndexMetaPB& meta) {
         }
         // special case, snapshot file was written by phmap::BinaryOutputArchive which does not use system profiled API
         // so add read stats manually
-        IOProfiler::add_read(snapshot_size);
+        IOProfiler::add_read(snapshot_size, watch.elapsed_time());
     }
     // if mutable index is empty, set _offset as 0, otherwise set _offset as snapshot size
     _offset = snapshot_off + snapshot_size;

--- a/be/src/storage/segment_flush_executor.cpp
+++ b/be/src/storage/segment_flush_executor.cpp
@@ -24,7 +24,6 @@
 #include "gen_cpp/InternalService_types.h"
 #include "gen_cpp/Types_types.h"
 #include "gen_cpp/internal_service.pb.h"
-#include "io/io_profiler.h"
 #include "runtime/current_thread.h"
 #include "service/brpc.h"
 #include "storage/delta_writer.h"
@@ -78,7 +77,6 @@ public:
 
         auto st = Status::OK();
         if (_request->has_segment() && _cntl->request_attachment().size() > 0) {
-            auto scope = IOProfiler::scope(IOProfiler::TAG_LOAD, _writer->tablet()->tablet_id());
             auto& segment_pb = _request->segment();
             st = _writer->write_segment(segment_pb, _cntl->request_attachment());
         } else if (!_request->eos()) {

--- a/be/src/util/starrocks_metrics.cpp
+++ b/be/src/util/starrocks_metrics.cpp
@@ -57,6 +57,13 @@ StarRocksMetrics::StarRocksMetrics() : _metrics(_s_registry_name) {
 
     REGISTER_STARROCKS_METRIC(memtable_flush_total);
     REGISTER_STARROCKS_METRIC(memtable_flush_duration_us);
+    REGISTER_STARROCKS_METRIC(memtable_flush_io_time_us);
+    REGISTER_STARROCKS_METRIC(memtable_flush_memory_bytes_total);
+    REGISTER_STARROCKS_METRIC(memtable_flush_disk_bytes_total);
+    REGISTER_STARROCKS_METRIC(segment_flush_total);
+    REGISTER_STARROCKS_METRIC(segment_flush_duration_us);
+    REGISTER_STARROCKS_METRIC(segment_flush_io_time_us);
+    REGISTER_STARROCKS_METRIC(segment_flush_bytes_total);
 
     REGISTER_STARROCKS_METRIC(update_rowset_commit_request_total);
     REGISTER_STARROCKS_METRIC(update_rowset_commit_request_failed);

--- a/be/src/util/starrocks_metrics.h
+++ b/be/src/util/starrocks_metrics.h
@@ -172,6 +172,12 @@ public:
 
     METRIC_DEFINE_INT_COUNTER(memtable_flush_total, MetricUnit::OPERATIONS);
     METRIC_DEFINE_INT_COUNTER(memtable_flush_duration_us, MetricUnit::MICROSECONDS);
+    METRIC_DEFINE_INT_COUNTER(memtable_flush_io_time_us, MetricUnit::MICROSECONDS);
+    METRIC_DEFINE_INT_COUNTER(memtable_flush_bytes_total, MetricUnit::BYTES);
+    METRIC_DEFINE_INT_COUNTER(segment_flush_total, MetricUnit::OPERATIONS);
+    METRIC_DEFINE_INT_COUNTER(segment_flush_duration_us, MetricUnit::MICROSECONDS);
+    METRIC_DEFINE_INT_COUNTER(segment_flush_io_time_us, MetricUnit::MICROSECONDS);
+    METRIC_DEFINE_INT_COUNTER(segment_flush_bytes_total, MetricUnit::BYTES);
 
     METRIC_DEFINE_INT_COUNTER(update_rowset_commit_request_total, MetricUnit::REQUESTS);
     METRIC_DEFINE_INT_COUNTER(update_rowset_commit_request_failed, MetricUnit::REQUESTS);

--- a/be/src/util/starrocks_metrics.h
+++ b/be/src/util/starrocks_metrics.h
@@ -173,7 +173,10 @@ public:
     METRIC_DEFINE_INT_COUNTER(memtable_flush_total, MetricUnit::OPERATIONS);
     METRIC_DEFINE_INT_COUNTER(memtable_flush_duration_us, MetricUnit::MICROSECONDS);
     METRIC_DEFINE_INT_COUNTER(memtable_flush_io_time_us, MetricUnit::MICROSECONDS);
-    METRIC_DEFINE_INT_COUNTER(memtable_flush_bytes_total, MetricUnit::BYTES);
+    // total memory size of memtables
+    METRIC_DEFINE_INT_COUNTER(memtable_flush_memory_bytes_total, MetricUnit::BYTES);
+    // total disk size of memtables which is smaller than memtable_flush_memory_bytes_total because of compression
+    METRIC_DEFINE_INT_COUNTER(memtable_flush_disk_bytes_total, MetricUnit::BYTES);
     METRIC_DEFINE_INT_COUNTER(segment_flush_total, MetricUnit::OPERATIONS);
     METRIC_DEFINE_INT_COUNTER(segment_flush_duration_us, MetricUnit::MICROSECONDS);
     METRIC_DEFINE_INT_COUNTER(segment_flush_io_time_us, MetricUnit::MICROSECONDS);

--- a/be/test/CMakeLists.txt
+++ b/be/test/CMakeLists.txt
@@ -174,6 +174,7 @@ set(EXEC_FILES
         ./http/transaction_stream_load_test.cpp
         ./io/array_input_stream_test.cpp
         ./io/compressed_input_stream_test.cpp
+        ./io/io_profiler_test.cpp
         ./io/fd_output_stream_test.cpp
         ./io/s3_output_stream_test.cpp
         ./io/s3_input_stream_test.cpp

--- a/be/test/io/io_profiler_test.cpp
+++ b/be/test/io/io_profiler_test.cpp
@@ -1,0 +1,109 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "io/io_profiler.h"
+
+#include <gtest/gtest.h>
+
+#include "testutil/assert.h"
+
+namespace starrocks {
+
+#define ADD_READ_IO_STAT(stat, bytes, time_ns) \
+    stat.read_ops += 1;                        \
+    stat.read_bytes += bytes;                  \
+    stat.read_time_ns += time_ns
+
+#define ADD_WRITE_IO_STAT(stat, bytes, time_ns) \
+    stat.write_ops += 1;                        \
+    stat.write_bytes += bytes;                  \
+    stat.write_time_ns += time_ns
+
+#define ASSERT_IO_STAT_EQ(expect, actual)                \
+    ASSERT_EQ(expect.read_ops, actual.read_ops);         \
+    ASSERT_EQ(expect.read_bytes, actual.read_bytes);     \
+    ASSERT_EQ(expect.read_time_ns, actual.read_time_ns); \
+    ASSERT_EQ(expect.write_ops, actual.write_ops);       \
+    ASSERT_EQ(expect.write_bytes, actual.write_bytes);   \
+    ASSERT_EQ(expect.write_time_ns, actual.write_time_ns)
+
+TEST(IOProfilerTest, test_tls_io) {
+    auto scope = IOProfiler::scope(IOProfiler::TAG_LOAD, 1);
+    // the init io stat may be not 0, because other test cases maybe have updated the stat
+    auto expect = scope.current_scoped_tls_io();
+
+    IOProfiler::add_read(1, 1000);
+    ADD_READ_IO_STAT(expect, 1, 1000);
+    auto actual1 = scope.current_scoped_tls_io();
+    ASSERT_IO_STAT_EQ(expect, actual1);
+
+    IOProfiler::add_write(2, 200000);
+    ADD_WRITE_IO_STAT(expect, 2, 200000);
+    auto actual2 = scope.current_scoped_tls_io();
+    ASSERT_IO_STAT_EQ(expect, actual2);
+
+    IOProfiler::add_write(1024, 500000);
+    ADD_WRITE_IO_STAT(expect, 1024, 500000);
+    auto actual3 = scope.current_scoped_tls_io();
+    ASSERT_IO_STAT_EQ(expect, actual3);
+
+    IOProfiler::add_read(1048576, 1000000);
+    ADD_READ_IO_STAT(expect, 1048576, 1000000);
+    auto actual4 = scope.current_scoped_tls_io();
+    ASSERT_IO_STAT_EQ(expect, actual4);
+}
+
+TEST(IOProfilerTest, test_context_io) {
+    auto scope = IOProfiler::scope(IOProfiler::TAG_LOAD, 2);
+    auto expect = IOProfiler::IOStat{0, 0, 0, 0, 0, 0};
+
+    // io mode is IOMODE_NONE
+    ASSERT_EQ(IOProfiler::IOMode::IOMODE_NONE, IOProfiler::get_context_io_mode());
+    IOProfiler::add_read(1, 1000);
+    IOProfiler::add_write(1, 1000);
+    ASSERT_IO_STAT_EQ(expect, scope.current_context_io());
+
+    // io mode is IOMODE_READ
+    ASSERT_OK(IOProfiler::start(IOProfiler::IOMode::IOMODE_READ));
+    ASSERT_EQ(IOProfiler::IOMode::IOMODE_READ, IOProfiler::get_context_io_mode());
+    IOProfiler::add_read(2, 2000);
+    ADD_READ_IO_STAT(expect, 2, 0);
+    IOProfiler::add_write(2, 2000);
+    ASSERT_IO_STAT_EQ(expect, scope.current_context_io());
+    IOProfiler::stop();
+    ASSERT_EQ(IOProfiler::IOMode::IOMODE_NONE, IOProfiler::get_context_io_mode());
+
+    // io mode is IOMODE_WRITE
+    ASSERT_OK(IOProfiler::start(IOProfiler::IOMode::IOMODE_WRITE));
+    ASSERT_EQ(IOProfiler::IOMode::IOMODE_WRITE, IOProfiler::get_context_io_mode());
+    IOProfiler::add_read(3, 3000);
+    IOProfiler::add_write(3, 3000);
+    ADD_WRITE_IO_STAT(expect, 3, 0);
+    ASSERT_IO_STAT_EQ(expect, scope.current_context_io());
+    IOProfiler::stop();
+    ASSERT_EQ(IOProfiler::IOMode::IOMODE_NONE, IOProfiler::get_context_io_mode());
+
+    // io mode is IOMODE_ALL
+    ASSERT_OK(IOProfiler::start(IOProfiler::IOMode::IOMODE_ALL));
+    ASSERT_EQ(IOProfiler::IOMode::IOMODE_ALL, IOProfiler::get_context_io_mode());
+    IOProfiler::add_read(4, 4000);
+    ADD_READ_IO_STAT(expect, 4, 0);
+    IOProfiler::add_write(4, 4000);
+    ADD_WRITE_IO_STAT(expect, 4, 0);
+    ASSERT_IO_STAT_EQ(expect, scope.current_context_io());
+    IOProfiler::stop();
+    ASSERT_EQ(IOProfiler::IOMode::IOMODE_NONE, IOProfiler::get_context_io_mode());
+}
+
+} // namespace starrocks

--- a/be/test/io/io_profiler_test.cpp
+++ b/be/test/io/io_profiler_test.cpp
@@ -30,13 +30,19 @@ namespace starrocks {
     stat.write_bytes += bytes;                  \
     stat.write_time_ns += time_ns
 
-#define ASSERT_IO_STAT_EQ(expect, actual)                \
-    ASSERT_EQ(expect.read_ops, actual.read_ops);         \
-    ASSERT_EQ(expect.read_bytes, actual.read_bytes);     \
-    ASSERT_EQ(expect.read_time_ns, actual.read_time_ns); \
-    ASSERT_EQ(expect.write_ops, actual.write_ops);       \
-    ASSERT_EQ(expect.write_bytes, actual.write_bytes);   \
-    ASSERT_EQ(expect.write_time_ns, actual.write_time_ns)
+#define ADD_SYNC_IO_STAT(stat, time_ns) \
+    stat.sync_ops += 1;                 \
+    stat.sync_time_ns += time_ns
+
+#define ASSERT_IO_STAT_EQ(expect, actual)                  \
+    ASSERT_EQ(expect.read_ops, actual.read_ops);           \
+    ASSERT_EQ(expect.read_bytes, actual.read_bytes);       \
+    ASSERT_EQ(expect.read_time_ns, actual.read_time_ns);   \
+    ASSERT_EQ(expect.write_ops, actual.write_ops);         \
+    ASSERT_EQ(expect.write_bytes, actual.write_bytes);     \
+    ASSERT_EQ(expect.write_time_ns, actual.write_time_ns); \
+    ASSERT_EQ(expect.sync_ops, actual.sync_ops);           \
+    ASSERT_EQ(expect.sync_time_ns, actual.sync_time_ns)
 
 TEST(IOProfilerTest, test_tls_io) {
     auto scope = IOProfiler::scope(IOProfiler::TAG_LOAD, 1);
@@ -62,6 +68,11 @@ TEST(IOProfilerTest, test_tls_io) {
     ADD_READ_IO_STAT(expect, 1048576, 1000000);
     auto actual4 = scope.current_scoped_tls_io();
     ASSERT_IO_STAT_EQ(expect, actual4);
+
+    IOProfiler::add_sync(9883);
+    ADD_SYNC_IO_STAT(expect, 9883);
+    auto actual5 = scope.current_scoped_tls_io();
+    ASSERT_IO_STAT_EQ(expect, actual5);
 }
 
 TEST(IOProfilerTest, test_context_io) {

--- a/be/test/storage/memtable_test.cpp
+++ b/be/test/storage/memtable_test.cpp
@@ -510,8 +510,7 @@ TEST_F(MemTableTest, test_metrics) {
         indexes.emplace_back(i);
     }
     std::shuffle(indexes.begin(), indexes.end(), std::mt19937(std::random_device()()));
-    auto res = _mem_table->insert(*pchunk, indexes.data(), 0, indexes.size());
-    ASSERT_TRUE(res.ok());
+    _mem_table->insert(*pchunk, indexes.data(), 0, indexes.size());
     ASSERT_TRUE(_mem_table->finalize().ok());
     ASSERT_OK(_mem_table->flush());
     // just verify the metrics have value, rather than verify it accurately

--- a/be/test/storage/segment_flush_executor_test.cpp
+++ b/be/test/storage/segment_flush_executor_test.cpp
@@ -35,6 +35,7 @@
 #include "storage/tablet_manager.h"
 #include "storage/txn_manager.h"
 #include "testutil/assert.h"
+#include "util/starrocks_metrics.h"
 
 namespace starrocks {
 
@@ -281,6 +282,12 @@ TEST_F(SegmentFlushExecutorTest, test_write_and_commit_segment) {
     ASSERT_OK(get_prepared_rowset(_tablet->tablet_id(), delta_writer->txn_id(), _partition_id, &prepared_rowset));
     check_single_segment_rowset_result(prepared_rowset, 10);
     ASSERT_OK(StorageEngine::instance()->txn_manager()->delete_txn(_partition_id, _tablet, delta_writer->txn_id()));
+
+    // just verify the metrics have value, rather than verify it accurately
+    // because other test cases may also update the metrics concurrently if
+    // run tests in parallel, and it's hard to get the accurate value
+    ASSERT_TRUE(StarRocksMetrics::instance()->segment_flush_total.value() > 0);
+    ASSERT_TRUE(StarRocksMetrics::instance()->segment_flush_bytes_total.value() > 0);
 }
 
 TEST_F(SegmentFlushExecutorTest, test_submit_after_cancel) {

--- a/be/test/util/starrocks_metrics_test.cpp
+++ b/be/test/util/starrocks_metrics_test.cpp
@@ -301,4 +301,17 @@ TEST_F(StarRocksMetricsTest, PageCacheMetrics) {
     ASSERT_STREQ(std::to_string(cache->get_capacity()).c_str(), capacity_metric->to_string().c_str());
 }
 
+TEST_F(StarRocksMetricsTest, test_metrics_register) {
+    auto instance = StarRocksMetrics::instance()->metrics();
+    ASSERT_NE(nullptr, instance->get_metric("memtable_flush_total"));
+    ASSERT_NE(nullptr, instance->get_metric("memtable_flush_duration_us"));
+    ASSERT_NE(nullptr, instance->get_metric("memtable_flush_io_time_us"));
+    ASSERT_NE(nullptr, instance->get_metric("memtable_flush_memory_bytes_total"));
+    ASSERT_NE(nullptr, instance->get_metric("memtable_flush_disk_bytes_total"));
+    ASSERT_NE(nullptr, instance->get_metric("segment_flush_total"));
+    ASSERT_NE(nullptr, instance->get_metric("segment_flush_duration_us"));
+    ASSERT_NE(nullptr, instance->get_metric("segment_flush_io_time_us"));
+    ASSERT_NE(nullptr, instance->get_metric("segment_flush_bytes_total"));
+}
+
 } // namespace starrocks


### PR DESCRIPTION
## Why I'm doing:
backport #40173 #40407 #41898

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [X] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [X] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [X] This is a backport pr

## Bugfix cherry-pick branch check:
- [X] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5

