### PR TITLE
[Enhancement][Cherry-Pick][Branch-3.1] Using ORC column id in SearchArgument (backport #42516)

### DIFF
--- a/be/src/exec/hdfs_scanner_orc.cpp
+++ b/be/src/exec/hdfs_scanner_orc.cpp
@@ -412,7 +412,7 @@ Status HdfsOrcScanner::do_open(RuntimeState* runtime_state) {
     }
     const OrcPredicates orc_predicates{&conjuncts, _scanner_ctx.runtime_filter_collector};
     RETURN_IF_ERROR(_orc_reader->init(std::move(reader), &orc_predicates));
-        
+
     return Status::OK();
 }
 

--- a/be/src/exec/hdfs_scanner_orc.cpp
+++ b/be/src/exec/hdfs_scanner_orc.cpp
@@ -379,16 +379,6 @@ Status HdfsOrcScanner::do_open(RuntimeState* runtime_state) {
     _orc_reader->set_runtime_state(runtime_state);
     _orc_reader->set_current_file_name(_file->filename());
     RETURN_IF_ERROR(_orc_reader->set_timezone(_scanner_ctx.timezone));
-    if (_use_orc_sargs) {
-        std::vector<Expr*> conjuncts;
-        for (const auto& it : _scanner_ctx.conjunct_ctxs_by_slot) {
-            for (const auto& it2 : it.second) {
-                conjuncts.push_back(it2->root());
-            }
-        }
-        RETURN_IF_ERROR(
-                _orc_reader->set_conjuncts_and_runtime_filters(conjuncts, _scanner_ctx.runtime_filter_collector));
-    }
     _orc_reader->set_hive_column_names(_scanner_ctx.hive_column_names);
     _orc_reader->set_case_sensitive(_scanner_ctx.case_sensitive);
     if (config::enable_orc_late_materialization && _lazy_load_ctx.lazy_load_slots.size() != 0 &&
@@ -412,7 +402,17 @@ Status HdfsOrcScanner::do_open(RuntimeState* runtime_state) {
         orc_hdfs_file_stream->setStripes(std::move(stripes));
     }
 
-    RETURN_IF_ERROR(_orc_reader->init(std::move(reader)));
+    std::vector<Expr*> conjuncts{};
+    if (_use_orc_sargs) {
+        for (const auto& it : _scanner_ctx.conjunct_ctxs_by_slot) {
+            for (const auto& it2 : it.second) {
+                conjuncts.push_back(it2->root());
+            }
+        }
+    }
+    const OrcPredicates orc_predicates{&conjuncts, _scanner_ctx.runtime_filter_collector};
+    RETURN_IF_ERROR(_orc_reader->init(std::move(reader), &orc_predicates));
+        
     return Status::OK();
 }
 
@@ -559,25 +559,28 @@ Status HdfsOrcScanner::do_init(RuntimeState* runtime_state, const HdfsScannerPar
 void HdfsOrcScanner::do_update_counter(HdfsScanProfile* profile) {
     const std::string orcProfileSectionPrefix = "ORC";
 
-    RuntimeProfile* root = profile->runtime_profile;
-    ADD_COUNTER(root, orcProfileSectionPrefix, TUnit::NONE);
+    RuntimeProfile* root_profile = profile->runtime_profile;
+    ADD_COUNTER(root_profile, orcProfileSectionPrefix, TUnit::NONE);
 
-    do_update_iceberg_v2_counter(root, orcProfileSectionPrefix);
+    do_update_iceberg_v2_counter(root_profile, orcProfileSectionPrefix);
 
     size_t total_stripe_size = 0;
     for (const auto& v : _app_stats.orc_stripe_sizes) {
         total_stripe_size += v;
     }
 
-    RuntimeProfile::Counter* total_stripe_size_counter = root->add_child_counter(
+    RuntimeProfile::Counter* total_stripe_size_counter = root_profile->add_child_counter(
             "TotalStripeSize", TUnit::BYTES, RuntimeProfile::Counter::create_strategy(TCounterAggregateType::SUM),
             orcProfileSectionPrefix);
-    RuntimeProfile::Counter* total_stripe_number_counter = root->add_child_counter(
+    RuntimeProfile::Counter* total_stripe_number_counter = root_profile->add_child_counter(
             "TotalStripeNumber", TUnit::UNIT, RuntimeProfile::Counter::create_strategy(TCounterAggregateType::SUM),
             orcProfileSectionPrefix);
-
     COUNTER_UPDATE(total_stripe_size_counter, total_stripe_size);
     COUNTER_UPDATE(total_stripe_number_counter, _app_stats.orc_stripe_sizes.size());
+    if (_orc_reader != nullptr) {
+        // _orc_reader is nullptr for split task
+        root_profile->add_info_string("ORCSearchArgument: ", _orc_reader->get_search_argument_string());
+    }
 }
 
 } // namespace starrocks

--- a/be/src/exec/hdfs_scanner_text.cpp
+++ b/be/src/exec/hdfs_scanner_text.cpp
@@ -207,6 +207,10 @@ Status HdfsTextScanner::do_open(RuntimeState* runtime_state) {
     return Status::OK();
 }
 
+void HdfsTextScanner::do_update_counter(HdfsScanProfile* profile) {
+    profile->runtime_profile->add_info_string("TextCompression", CompressionTypePB_Name(_compression_type));
+}
+
 void HdfsTextScanner::do_close(RuntimeState* runtime_state) noexcept {
     _reader.reset();
 }

--- a/be/src/exec/hdfs_scanner_text.h
+++ b/be/src/exec/hdfs_scanner_text.h
@@ -28,6 +28,7 @@ public:
     ~HdfsTextScanner() override = default;
 
     Status do_open(RuntimeState* runtime_state) override;
+    void do_update_counter(HdfsScanProfile* profile) override;
     void do_close(RuntimeState* runtime_state) noexcept override;
     Status do_get_next(RuntimeState* runtime_state, ChunkPtr* chunk) override;
     Status do_init(RuntimeState* runtime_state, const HdfsScannerParams& scanner_params) override;

--- a/be/src/formats/orc/apache-orc/c++/include/orc/Type.hh
+++ b/be/src/formats/orc/apache-orc/c++/include/orc/Type.hh
@@ -54,7 +54,6 @@ public:
     virtual TypeKind getKind() const = 0;
     virtual uint64_t getSubtypeCount() const = 0;
     virtual const Type* getSubtype(uint64_t childId) const = 0;
-    virtual const Type* getSubtypeByColumnId(uint64_t columnId) const = 0;
     virtual const std::string& getFieldName(uint64_t childId) const = 0;
     virtual uint64_t getFieldNamesCount() const = 0;
     virtual uint64_t getMaximumLength() const = 0;

--- a/be/src/formats/orc/apache-orc/c++/include/orc/sargs/SearchArgument.hh
+++ b/be/src/formats/orc/apache-orc/c++/include/orc/sargs/SearchArgument.hh
@@ -214,6 +214,15 @@ public:
                                       const std::initializer_list<Literal>& literals) = 0;
     virtual SearchArgumentBuilder& in(const std::string& column, PredicateDataType type,
                                       const std::vector<Literal>& literals) = 0;
+    /**
+     * Add an in leaf to the current item on the stack.
+     * @param columnId the column id of the column
+     * @param type the type of the expression
+     * @param literals the literals
+     * @return this
+    */
+    virtual SearchArgumentBuilder& in(uint64_t columnId, PredicateDataType type,
+                                      const std::vector<Literal>& literals) = 0;
 
     /**
      * Add an in leaf to the current item on the stack.

--- a/be/src/formats/orc/apache-orc/c++/src/TypeImpl.cc
+++ b/be/src/formats/orc/apache-orc/c++/src/TypeImpl.cc
@@ -18,7 +18,6 @@
 
 #include "TypeImpl.hh"
 
-#include <iostream>
 #include <sstream>
 
 #include "Adaptor.hh"
@@ -112,21 +111,6 @@ uint64_t TypeImpl::getSubtypeCount() const {
 
 const Type* TypeImpl::getSubtype(uint64_t i) const {
     return subTypes[i].get();
-}
-
-const Type* TypeImpl::getSubtypeByColumnId(uint64_t id) const {
-    ensureIdAssigned();
-    if (id == columnId) {
-        return this;
-    }
-
-    buildColumnIdToPosMap();
-
-    auto it = columnIdToPos.find(id);
-    if (it == columnIdToPos.end()) {
-        throw std::range_error("Error column id range: " + std::to_string(id));
-    }
-    return subTypes[it->second].get();
 }
 
 const std::string& TypeImpl::getFieldName(uint64_t i) const {

--- a/be/src/formats/orc/apache-orc/c++/src/TypeImpl.hh
+++ b/be/src/formats/orc/apache-orc/c++/src/TypeImpl.hh
@@ -67,8 +67,6 @@ public:
 
     const Type* getSubtype(uint64_t i) const override;
 
-    const Type* getSubtypeByColumnId(uint64_t columnId) const override;
-
     const std::string& getFieldName(uint64_t i) const override;
 
     uint64_t getFieldNamesCount() const override;

--- a/be/src/formats/orc/apache-orc/c++/src/sargs/PredicateLeaf.cc
+++ b/be/src/formats/orc/apache-orc/c++/src/sargs/PredicateLeaf.cc
@@ -93,6 +93,17 @@ PredicateLeaf::PredicateLeaf(Operator op, PredicateDataType type, std::string co
     validate();
 }
 
+PredicateLeaf::PredicateLeaf(Operator op, PredicateDataType type, uint64_t columnId,
+                             const std::vector<Literal>& literals)
+        : mOperator(op),
+          mType(type),
+          mHasColumnName(false),
+          mColumnId(columnId),
+          mLiterals(literals.begin(), literals.end()) {
+    mHashCode = hashCode();
+    validate();
+}
+
 void PredicateLeaf::validateColumn() const {
     if (mHasColumnName && mColumnName.empty()) {
         throw std::invalid_argument("column name should not be empty");

--- a/be/src/formats/orc/apache-orc/c++/src/sargs/PredicateLeaf.hh
+++ b/be/src/formats/orc/apache-orc/c++/src/sargs/PredicateLeaf.hh
@@ -85,6 +85,8 @@ public:
 
     PredicateLeaf(Operator op, PredicateDataType type, std::string colName, const std::vector<Literal>& literalList);
 
+    PredicateLeaf(Operator op, PredicateDataType type, uint64_t columnId, const std::vector<Literal>& literalList);
+
     /**
      * Get the operator for the leaf.
      */

--- a/be/src/formats/orc/apache-orc/c++/src/sargs/SearchArgument.cc
+++ b/be/src/formats/orc/apache-orc/c++/src/sargs/SearchArgument.cc
@@ -181,9 +181,9 @@ SearchArgumentBuilder& SearchArgumentBuilderImpl::nullSafeEquals(uint64_t column
     return compareOperator(PredicateLeaf::Operator::NULL_SAFE_EQUALS, columnId, type, literal);
 }
 
-template <typename T>
+template <typename T, typename CONTAINER>
 SearchArgumentBuilder& SearchArgumentBuilderImpl::addChildForIn(T column, PredicateDataType type,
-                                                                const std::initializer_list<Literal>& literals) {
+                                                                const CONTAINER& literals) {
     TreeNode& parent = mCurrTree.front();
     if (isInvalidColumn(column)) {
         parent->addChild(std::make_shared<ExpressionTree>((TruthValue::YES_NO_NULL)));
@@ -199,17 +199,12 @@ SearchArgumentBuilder& SearchArgumentBuilderImpl::addChildForIn(T column, Predic
 
 SearchArgumentBuilder& SearchArgumentBuilderImpl::in(const std::string& column, PredicateDataType type,
                                                      const std::vector<Literal>& literals) {
-    TreeNode& parent = mCurrTree.front();
-    if (isInvalidColumn(column)) {
-        parent->addChild(std::make_shared<ExpressionTree>((TruthValue::YES_NO_NULL)));
-    } else {
-        if (literals.size() == 0) {
-            throw std::invalid_argument("Can't create in expression with no arguments");
-        }
-        PredicateLeaf leaf(PredicateLeaf::Operator::IN, type, column, literals);
-        parent->addChild(std::make_shared<ExpressionTree>(addLeaf(leaf)));
-    }
-    return *this;
+    return addChildForIn(column, type, literals);
+}
+
+SearchArgumentBuilder& SearchArgumentBuilderImpl::in(uint64_t columnId, PredicateDataType type,
+                                                     const std::vector<Literal>& literals) {
+    return addChildForIn(columnId, type, literals);
 }
 
 SearchArgumentBuilder& SearchArgumentBuilderImpl::in(const std::string& column, PredicateDataType type,

--- a/be/src/formats/orc/apache-orc/c++/src/sargs/SearchArgument.hh
+++ b/be/src/formats/orc/apache-orc/c++/src/sargs/SearchArgument.hh
@@ -212,6 +212,7 @@ public:
      */
     SearchArgumentBuilder& in(uint64_t columnId, PredicateDataType type,
                               const std::initializer_list<Literal>& literals) override;
+    SearchArgumentBuilder& in(uint64_t columnId, PredicateDataType type, const std::vector<Literal>& literals) override;
 
     /**
      * Add an is null leaf to the current item on the stack.
@@ -273,9 +274,8 @@ private:
     template <typename T>
     SearchArgumentBuilder& compareOperator(PredicateLeaf::Operator op, const T& column, PredicateDataType type,
                                            const Literal& literal);
-    template <typename T>
-    SearchArgumentBuilder& addChildForIn(T column, PredicateDataType type,
-                                         const std::initializer_list<Literal>& literals);
+    template <typename T, typename CONTAINER>
+    SearchArgumentBuilder& addChildForIn(T column, PredicateDataType type, const CONTAINER& literals);
 
     template <typename T>
     SearchArgumentBuilder& addChildForIsNull(T column, PredicateDataType type);

--- a/be/src/formats/orc/orc_chunk_reader.cpp
+++ b/be/src/formats/orc/orc_chunk_reader.cpp
@@ -756,7 +756,7 @@ bool OrcChunkReader::_ok_to_add_binary_in_conjunct(
     const TExprOpcode::type& op_type = conjunct->op();
     DCHECK(node_type == TExprNodeType::BINARY_PRED || node_type == TExprNodeType::IN_PRED);
 
-    if (!_supported_binary_ops.contains(op_type)) {
+    if (_supported_binary_ops.find(op_type) == _supported_binary_ops.end()) {
         return false;
     }
 
@@ -786,12 +786,12 @@ bool OrcChunkReader::_ok_to_add_binary_in_conjunct(
 
     for (int i = 1; i < conjunct->get_num_children(); i++) {
         c = conjunct->get_child(i);
-        if (!_supported_literal_types.contains(c->node_type())) {
+        if (_supported_literal_types.find(c->node_type()) == _supported_literal_types.end()) {
             return false;
         }
     }
     for (int i = 0; i < conjunct->get_num_children(); i++) {
-        if (!_supported_logical_types.contains(conjunct->get_child(i)->type().type)) {
+        if (_supported_logical_types.find(conjunct->get_child(i)->type().type) == _supported_logical_types.end()) {
             return false;
         }
     }
@@ -833,7 +833,7 @@ bool OrcChunkReader::_ok_to_add_is_null_conjunct(
 bool OrcChunkReader::_ok_to_add_conjunct(
         const Expr* conjunct, const std::unordered_map<SlotId, size_t>& slot_id_to_pos_in_src_slot_descriptors) {
     const TExprNodeType::type& node_type = conjunct->node_type();
-    if (!_supported_expr_node_types.contains(node_type)) {
+    if (_supported_expr_node_types.find(node_type) == _supported_expr_node_types.end()) {
         return false;
     }
 

--- a/be/src/formats/orc/orc_mapping.h
+++ b/be/src/formats/orc/orc_mapping.h
@@ -113,7 +113,6 @@ public:
 
 private:
     std::unordered_map<size_t, const OrcMappingOrcType> _mapping;
-    std::unordered_map<std::string, orc::Type*> _new_mapping;
 
     Status set_include_column_id_by_type(const OrcMappingPtr& mapping, const TypeDescriptor& desc,
                                          std::list<uint64_t>* column_id_list);

--- a/be/src/formats/orc/utils.h
+++ b/be/src/formats/orc/utils.h
@@ -23,6 +23,7 @@
 #include "cctz/civil_time.h"
 #include "cctz/time_zone.h"
 #include "column/vectorized_fwd.h"
+#include "exec/pipeline/operator.h"
 #include "formats/orc/orc_mapping.h"
 #include "formats/orc/utils.h"
 #include "gen_cpp/orc_proto.pb.h"
@@ -32,6 +33,14 @@
 #include "types/timestamp_value.h"
 
 namespace starrocks {
+
+class OrcPredicates {
+public:
+    OrcPredicates(const std::vector<Expr*>* conjuncts, const RuntimeFilterProbeCollector* rf_collector)
+            : conjuncts(conjuncts), rf_collector(rf_collector) {}
+    const std::vector<Expr*>* conjuncts;
+    const RuntimeFilterProbeCollector* rf_collector;
+};
 
 // Hive ORC char type will pad trailing spaces.
 // https://docs.cloudera.com/documentation/enterprise/6/6.3/topics/impala_char.html


### PR DESCRIPTION
cp from #42516

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [x] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5

