### PR TITLE
[Enhancement] Improve cast fail error message

### DIFF
--- a/be/src/exprs/cast_expr.cpp
+++ b/be/src/exprs/cast_expr.cpp
@@ -1665,8 +1665,7 @@ Expr* VectorizedCastExprFactory::create_primitive_cast(ObjectPool* pool, const T
             CASE_TO_STRING_FROM(TYPE_JSON, allow_throw_exception);
             CASE_TO_STRING_FROM(TYPE_VARBINARY, allow_throw_exception);
         default:
-            LOG(WARNING) << "Not support cast from type: " << type_to_string(from_type)
-                         << ", to type: " << type_to_string(to_type);
+            LOG(WARNING) << "Not support cast " << type_to_string(from_type) << " to " << type_to_string(to_type);
             return nullptr;
         }
     } else if (from_type == TYPE_JSON || to_type == TYPE_JSON) {
@@ -1683,8 +1682,7 @@ Expr* VectorizedCastExprFactory::create_primitive_cast(ObjectPool* pool, const T
                 CASE_FROM_JSON_TO(TYPE_DOUBLE, allow_throw_exception);
                 CASE_FROM_JSON_TO(TYPE_JSON, allow_throw_exception);
             default:
-                LOG(WARNING) << "Not support cast from type: " << type_to_string(from_type)
-                             << ", to type: " << type_to_string(to_type);
+                LOG(WARNING) << "Not support cast " << type_to_string(from_type) << " to " << type_to_string(to_type);
                 return nullptr;
             }
         } else {
@@ -1707,8 +1705,7 @@ Expr* VectorizedCastExprFactory::create_primitive_cast(ObjectPool* pool, const T
                 CASE_TO_JSON(TYPE_TIME, allow_throw_exception);
                 CASE_TO_JSON(TYPE_DATETIME, allow_throw_exception);
             default:
-                LOG(WARNING) << "Not support cast from type: " << type_to_string(from_type)
-                             << ", to type: " << type_to_string(to_type);
+                LOG(WARNING) << "Not support cast " << type_to_string(from_type) << " to " << type_to_string(to_type);
                 return nullptr;
             }
         }
@@ -1720,8 +1717,7 @@ Expr* VectorizedCastExprFactory::create_primitive_cast(ObjectPool* pool, const T
                 return new VectorizedCastExpr<TYPE_VARCHAR, TYPE_VARBINARY, false>(node);
             }
         } else {
-            LOG(WARNING) << "Not support cast from type: " << type_to_string(from_type)
-                         << ", to type: " << type_to_string(to_type);
+            LOG(WARNING) << "Not support cast " << type_to_string(from_type) << " to " << type_to_string(to_type);
             return nullptr;
         }
     } else {
@@ -1742,8 +1738,7 @@ Expr* VectorizedCastExprFactory::create_primitive_cast(ObjectPool* pool, const T
             CASE_TO_TYPE(TYPE_DECIMAL64, allow_throw_exception);
             CASE_TO_TYPE(TYPE_DECIMAL128, allow_throw_exception);
         default:
-            LOG(WARNING) << "Not support cast from type: " << type_to_string(from_type)
-                         << ", to type: " << type_to_string(to_type);
+            LOG(WARNING) << "Not support cast " << type_to_string(from_type) << " to " << type_to_string(to_type);
             return nullptr;
         }
     }
@@ -1816,7 +1811,7 @@ Expr* VectorizedCastExprFactory::from_thrift(ObjectPool* pool, const TExprNode& 
     }
     auto ret = create_cast_expr(pool, node, from_type, to_type, allow_throw_exception);
     if (!ret.ok()) {
-        LOG(WARNING) << "Don't support to cast type: " << from_type << " to type: " << to_type;
+        LOG(WARNING) << "Not support cast " << from_type << " to " << to_type;
         return nullptr;
     }
     return std::move(ret).value().release();
@@ -1838,7 +1833,7 @@ Expr* VectorizedCastExprFactory::from_type(const TypeDescriptor& from, const Typ
                                            ObjectPool* pool, bool allow_throw_exception) {
     auto ret = create_cast_expr(pool, from, to, allow_throw_exception);
     if (!ret.ok()) {
-        LOG(WARNING) << "Don't support to cast type: " << from << " to type: " << to;
+        LOG(WARNING) << "Not support cast " << from << " to " << to;
         return nullptr;
     }
     auto cast_expr = std::move(ret).value().release();

--- a/be/src/exprs/expr.cpp
+++ b/be/src/exprs/expr.cpp
@@ -353,11 +353,13 @@ Status Expr::create_vectorized_expr(starrocks::ObjectPool* pool, const starrocks
             if (*expr == nullptr) {
                 TypeDescriptor to_type = TypeDescriptor::from_thrift(texpr_node.type);
                 TypeDescriptor from_type(thrift_to_type(texpr_node.child_type));
+                // In cast TExprNode, child_type is used to represent scalar type,
+                // and child_type_desc is used to represent complex types, such as struct, map, array
                 if (texpr_node.__isset.child_type_desc) {
                     from_type = TypeDescriptor::from_thrift(texpr_node.child_type_desc);
                 }
                 auto err_msg =
-                        fmt::format("Not support cast {} to {}", from_type.debug_string(), to_type.debug_string());
+                        fmt::format("Not support cast {} to {}.", from_type.debug_string(), to_type.debug_string());
                 LOG(WARNING) << err_msg;
                 return Status::InternalError(err_msg);
             } else {

--- a/be/src/exprs/expr.cpp
+++ b/be/src/exprs/expr.cpp
@@ -351,12 +351,13 @@ Status Expr::create_vectorized_expr(starrocks::ObjectPool* pool, const starrocks
             *expr = pool->add(VectorizedCastExprFactory::from_thrift(
                     pool, texpr_node, (state == nullptr) ? false : state->query_options().allow_throw_exception));
             if (*expr == nullptr) {
-                LogicalType to_type = TypeDescriptor::from_thrift(texpr_node.type).type;
-                LogicalType from_type = thrift_to_type(texpr_node.child_type);
-                std::string err_msg = fmt::format(
-                        "Vectorized engine does not support the operator, cast from {} to {} failed, maybe use switch "
-                        "function",
-                        type_to_string_v2(from_type), type_to_string_v2(to_type));
+                TypeDescriptor to_type = TypeDescriptor::from_thrift(texpr_node.type);
+                TypeDescriptor from_type(thrift_to_type(texpr_node.child_type));
+                if (texpr_node.__isset.child_type_desc) {
+                    from_type = TypeDescriptor::from_thrift(texpr_node.child_type_desc);
+                }
+                auto err_msg =
+                        fmt::format("Not support cast {} to {}", from_type.debug_string(), to_type.debug_string());
                 LOG(WARNING) << err_msg;
                 return Status::InternalError(err_msg);
             } else {

--- a/be/test/exprs/cast_expr_test.cpp
+++ b/be/test/exprs/cast_expr_test.cpp
@@ -2334,14 +2334,28 @@ TEST_F(VectorizedCastExprTest, json_to_array_with_const_input) {
 }
 
 TEST_F(VectorizedCastExprTest, unsupported_test) {
+    TExprNode cast_expr;
+    cast_expr.node_type = TExprNodeType::CAST_EXPR;
+    cast_expr.__set_opcode(TExprOpcode::CAST);
+    cast_expr.num_children = 1;
+
     // can't cast arry<array<int>> to array<bool> rather than crash
-    expr_node.child_type = to_thrift(LogicalType::TYPE_ARRAY);
-    expr_node.child_type_desc = gen_multi_array_type_desc(to_thrift(TYPE_INT), 2);
-    expr_node.type = gen_multi_array_type_desc(to_thrift(TYPE_BOOLEAN), 1);
-
-    std::unique_ptr<Expr> expr(VectorizedCastExprFactory::from_thrift(expr_node));
-
+    cast_expr.type = gen_multi_array_type_desc(to_thrift(TYPE_BOOLEAN), 1);
+    cast_expr.__isset.child_type = false;
+    cast_expr.__set_child_type_desc(gen_multi_array_type_desc(to_thrift(TYPE_INT), 2));
+    std::unique_ptr<Expr> expr(VectorizedCastExprFactory::from_thrift(cast_expr));
     ASSERT_TRUE(expr == nullptr);
+
+    // can't cast array<int> to varchar
+    cast_expr.type = gen_type_desc(to_thrift(LogicalType::TYPE_VARCHAR));
+    cast_expr.__isset.child_type = false;
+    cast_expr.__set_child_type_desc(gen_multi_array_type_desc(to_thrift(TYPE_INT), 1));
+    std::unique_ptr<Expr> expr2(VectorizedCastExprFactory::from_thrift(cast_expr));
+    ASSERT_TRUE(expr2 == nullptr);
+
+    Expr* expr3 = nullptr;
+    ObjectPool pool;
+    ASSERT_FALSE(Expr::create_vectorized_expr(&pool, cast_expr, &expr3, &runtime_state).ok());
 }
 
 } // namespace starrocks


### PR DESCRIPTION

## Why I'm doing:
```
mysql> insert into t2 select k1, k2 from t3;
ERROR 1064 (HY000): Vectorized engine does not support the operator, cast from INVALID to VARCHAR failed, maybe use switch function backend [id=10004] [host=xxx]
```
k2 is varchar in t2 and map<int, array<int>> in t3.

## What I'm doing:
```
mysql> insert into t2 select k1, k2 from t3;
ERROR 1064 (HY000): Not support cast MAP<INT, ARRAY<INT>> to VARCHAR(100). backend [id=10004] [host=xxx]
```
1. fix from_type is INVALID type when cast map/array to string
2. improve fail message

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [x] 3.1
  - [ ] 3.0
  - [ ] 2.5
