### PR TITLE
[Enhancement] enhance mv rewrite by considering sort key during selecting best mv for 3.2 (backport #41956)

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/rule/BaseMaterializedViewRewriteRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/rule/BaseMaterializedViewRewriteRule.java
@@ -30,7 +30,6 @@ import com.starrocks.sql.optimizer.OptimizerContext;
 import com.starrocks.sql.optimizer.QueryMaterializationContext;
 import com.starrocks.sql.optimizer.base.ColumnRefFactory;
 import com.starrocks.sql.optimizer.operator.Operator;
-import com.starrocks.sql.optimizer.operator.logical.LogicalAggregationOperator;
 import com.starrocks.sql.optimizer.operator.logical.LogicalOlapScanOperator;
 import com.starrocks.sql.optimizer.operator.pattern.Pattern;
 import com.starrocks.sql.optimizer.operator.scalar.ConstantOperator;
@@ -110,8 +109,7 @@ public abstract class BaseMaterializedViewRewriteRule extends TransformationRule
                 return expressions;
             } else {
                 // in rule phase, only return the best one result
-                BestMvSelector bestMvSelector = new BestMvSelector(
-                        expressions, context, queryExpression.getOp() instanceof LogicalAggregationOperator);
+                BestMvSelector bestMvSelector = new BestMvSelector(expressions, context, queryExpression);
                 return Lists.newArrayList(bestMvSelector.selectBest());
             }
         } catch (Exception e) {

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvRewriteTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvRewriteTest.java
@@ -1915,6 +1915,7 @@ public class MvRewriteTest extends MvRewriteTestBase {
 
         starRocksAssert.getCtx().getSessionVariable().setEnableMaterializedViewRewriteForInsert(
                 SessionVariable.DEFAULT_SESSION_VARIABLE.isEnableMaterializedViewRewriteForInsert());
+        starRocksAssert.dropMaterializedView("mv_insert");
     }
 
     /**
@@ -2093,6 +2094,69 @@ public class MvRewriteTest extends MvRewriteTestBase {
             String plan = getFragmentPlan(query);
             PlanTestBase.assertContains(plan, "mv1");
             PlanTestBase.assertNotContains(plan, "event_time1 >= '2023-01-05 00:00:00'");
+        }
+    }
+
+    @Test
+    public void testMvRewriteWithSortKey() throws Exception {
+        connectContext.getSessionVariable().setOptimizerExecuteTimeout(3000000);
+        {
+            starRocksAssert.withMaterializedView("create MATERIALIZED VIEW if not exists mv_order_by_v1 " +
+                    "DISTRIBUTED BY RANDOM buckets 1 " +
+                    "order by (v1) " +
+                    "REFRESH MANUAL " +
+                    "as\n" +
+                    "select v1, v2, sum(v3) from t0 group by v1, v2");
+            cluster.runSql("test", "refresh materialized view mv_order_by_v1 with sync mode");
+            starRocksAssert.withMaterializedView("create MATERIALIZED VIEW if not exists mv_order_by_v2 " +
+                    "DISTRIBUTED BY RANDOM buckets 1 " +
+                    "order by (v2) " +
+                    "REFRESH MANUAL " +
+                    "as\n" +
+                    "select v1, v2, sum(v3) from t0 group by v1, v2");
+            cluster.runSql("test", "refresh materialized view mv_order_by_v2 with sync mode");
+            {
+                // in predicate
+                String query = "select v1, v2, sum(v3) from t0 where v1 in (1, 2, 3) group by v1, v2;";
+                String plan = getFragmentPlan(query);
+                PlanTestBase.assertContains(plan, "mv_order_by_v1");
+            }
+            {
+                // equal predicate
+                String query = "select v1, v2, sum(v3) from t0 where v1 = 1 group by v1, v2;";
+                String plan = getFragmentPlan(query);
+                PlanTestBase.assertContains(plan, "mv_order_by_v1");
+            }
+            starRocksAssert.dropMaterializedView("mv_order_by_v1");
+            starRocksAssert.dropMaterializedView("mv_order_by_v2");
+        }
+        {
+            starRocksAssert.withMaterializedView("create MATERIALIZED VIEW if not exists mv_order_by_v1 " +
+                    "DISTRIBUTED BY RANDOM buckets 1 " +
+                    "order by (v1) " +
+                    "REFRESH MANUAL " +
+                    "as\n" +
+                    "select v1, v2, v3 from t0");
+            cluster.runSql("test", "refresh materialized view mv_order_by_v1 with sync mode");
+            starRocksAssert.withMaterializedView("create MATERIALIZED VIEW if not exists mv_order_by_v2 " +
+                    "DISTRIBUTED BY RANDOM buckets 1 " +
+                    "order by (v2) " +
+                    "REFRESH MANUAL " +
+                    "as\n" +
+                    "select v1, v2, v3 from t0");
+            cluster.runSql("test", "refresh materialized view mv_order_by_v2 with sync mode");
+            {
+                String query = "select v1, v2, v3 from t0 where v1 in (1, 2, 3);";
+                String plan = getFragmentPlan(query);
+                PlanTestBase.assertContains(plan, "mv_order_by_v1");
+            }
+            {
+                String query = "select v1, v2, v3 from t0 where v1 = 1;";
+                String plan = getFragmentPlan(query);
+                PlanTestBase.assertContains(plan, "mv_order_by_v1");
+            }
+            starRocksAssert.dropMaterializedView("mv_order_by_v1");
+            starRocksAssert.dropMaterializedView("mv_order_by_v2");
         }
     }
 }


### PR DESCRIPTION
## Why I'm doing:
Now when query has multi mv rewritten results, we need to choose the best mv. But we do not consider sort key of mv, which will influence the query performance.

## What I'm doing:

enhance mv rewrite by considering sort key during selecting best mv

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [x] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [x] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5

