### PR TITLE
[BugFix] Fix disk metrics bug when partition name does not end with number.

### DIFF
--- a/be/src/util/disk_info.cpp
+++ b/be/src/util/disk_info.cpp
@@ -43,8 +43,6 @@ int DiskInfo::_s_num_datanode_dirs;
 void DiskInfo::get_device_names() {
     // Format of this file is:
     //    major, minor, #blocks, name
-    // We are only interesting in name which is formatted as device_name<partition #>
-    // The same device will show up multiple times for each partition (e.g. sda1, sda2).
     std::ifstream partitions("/proc/partitions", std::ios::in);
 
     while (partitions.good() && !partitions.eof()) {
@@ -63,9 +61,6 @@ void DiskInfo::get_device_names() {
         if (name == "name") {
             continue;
         }
-
-        // Remove the partition# from the name.  e.g. sda2 --> sda
-        boost::trim_right_if(name, boost::is_any_of("0123456789"));
 
         // Create a mapping of all device ids (one per partition) to the disk id.
         int major_dev_id = atoi(fields[0].c_str());
@@ -192,7 +187,6 @@ Status DiskInfo::get_disk_devices(const std::vector<std::string>& paths, std::se
                 continue;
             }
             std::string dev(basename(dev_path));
-            boost::trim_right_if(dev, boost::is_any_of("0123456789"));
             if (_s_disk_name_to_disk_id.find(dev) != std::end(_s_disk_name_to_disk_id)) {
                 max_mount_size = mount_size;
                 match_dev = dev;


### PR DESCRIPTION
## Why I'm doing:
When the partition name does not end with a number, it is incorrect to trim the suffix number to get the device name. For example, the device name is `nvme0n1` and the partition name is `nvme0n1p1`, in this case the device name generated from the partition is `nvme0n1p` and using this name to find statistics from `/proc/diskstats` will fail.

## What I'm doing:
Do not trim the partition name, and show the device partition statistic.

Fixes #29093

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [x] 3.1
  - [x] 3.0
  - [x] 2.5
