### PR TITLE
[Enhancement] enable modification DOP in FE by default

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/qe/GlobalVariable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/GlobalVariable.java
@@ -151,11 +151,11 @@ public final class GlobalVariable {
 
     // Effective iff it is non-negative.
     @VariableMgr.VarAttr(name = QUERY_QUEUE_DRIVER_HIGH_WATER, flag = VariableMgr.GLOBAL)
-    private static int queryQueueDriverHighWater = -1;
+    private static int queryQueueDriverHighWater = 0;
 
     // Effective iff it is non-negative.
     @VariableMgr.VarAttr(name = QUERY_QUEUE_DRIVER_LOW_WATER, flag = VariableMgr.GLOBAL)
-    private static int queryQueueDriverLowWater = -1;
+    private static int queryQueueDriverLowWater = 0;
 
     // Effective iff it is positive.
     @VariableMgr.VarAttr(name = QUERY_QUEUE_MEM_USED_PCT_LIMIT, flag = VariableMgr.GLOBAL)


### PR DESCRIPTION
## Why I'm doing:
#40368 provider a new strategy to modify pipeline DOP by running fragments for non-query-queue, but this strategy isn't enabled by default.

## What I'm doing:

- Enable modification DOP in FE by default, if the cluster is a new one.
- Inherit the previous config, if the cluster is upgrade from the old verson.

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [x] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [x] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
