### PR TITLE
[Enhancement][Cherry-Pick][Branch-3.2] Reorder hive/hudi scan ranges to improve probe sql (backport #42634)

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/connector/RemoteScanRangeLocations.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/RemoteScanRangeLocations.java
@@ -39,6 +39,7 @@ import org.apache.logging.log4j.Logger;
 
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 
@@ -231,7 +232,6 @@ public class RemoteScanRangeLocations {
                         LOG.debug("Add scan range success. partition: {}, file: {}, range: {}-{}",
                                 partitions.get(i).getFullPath(), fileDesc.getFileName(), 0, fileDesc.getLength());
                     }
-
                 }
             }
         } else if (table instanceof HudiTable) {
@@ -264,6 +264,12 @@ public class RemoteScanRangeLocations {
             String message = "Only Hive/Hudi table is supported.";
             throw new StarRocksPlannerException(message, ErrorType.INTERNAL_ERROR);
         }
+
+        // Previously, the order of the scan range was from front to back, which would cause some probing sql to
+        // encounter very bad cases (scan ranges that meet the predicate conditions are in the later partitions),
+        // making BE have to scan more data to find rows that meet the conditions.
+        // So shuffle scan ranges can naturally disrupt the scan ranges' order to avoid very bad cases.
+        Collections.shuffle(result);
 
         LOG.debug("Get {} scan range locations cost: {} ms",
                 getScanRangeLocationsSize(), (System.currentTimeMillis() - start));

--- a/fe/fe-core/src/test/java/com/starrocks/connector/RemoteScanRangeLocationsTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/RemoteScanRangeLocationsTest.java
@@ -20,6 +20,7 @@ import com.starrocks.planner.PlanNodeId;
 import com.starrocks.qe.DefaultCoordinator;
 import com.starrocks.sql.plan.ConnectorPlanTestBase;
 import com.starrocks.sql.plan.PlanTestBase;
+import com.starrocks.thrift.THdfsScanRange;
 import com.starrocks.thrift.TScanRange;
 import com.starrocks.thrift.TScanRangeLocations;
 import com.starrocks.utframe.UtFrameUtils;
@@ -54,8 +55,19 @@ public class RemoteScanRangeLocationsTest extends PlanTestBase {
                 .get(new PlanNodeId(0)).getScanRangeLocations(100);
         Assert.assertEquals(4, scanRangeLocations.size());
 
+        scanRangeLocations.sort((o1, o2) -> {
+            THdfsScanRange scanRange1 = o1.scan_range.hdfs_scan_range;
+            THdfsScanRange scanRange2 = o2.scan_range.hdfs_scan_range;
+            if (scanRange1.relative_path.equalsIgnoreCase(scanRange2.relative_path)) {
+                return (int) (scanRange1.offset - scanRange2.offset);
+            } else {
+                return scanRange1.compareTo(scanRange2);
+            }
+        });
+
         TScanRange scanRange1 = scanRangeLocations.get(0).scan_range;
         TScanRange scanRange2 = scanRangeLocations.get(1).scan_range;
+
         Assert.assertEquals(scanRange1.hdfs_scan_range.length, scanRange2.hdfs_scan_range.offset);
     }
 
@@ -68,6 +80,16 @@ public class RemoteScanRangeLocationsTest extends PlanTestBase {
         List<TScanRangeLocations> scanRangeLocations = pair.second.getFragments().get(1).collectScanNodes()
                 .get(new PlanNodeId(0)).getScanRangeLocations(100);
         Assert.assertEquals(8, scanRangeLocations.size());
+
+        scanRangeLocations.sort((o1, o2) -> {
+            THdfsScanRange scanRange1 = o1.scan_range.hdfs_scan_range;
+            THdfsScanRange scanRange2 = o2.scan_range.hdfs_scan_range;
+            if (scanRange1.relative_path.equalsIgnoreCase(scanRange2.relative_path)) {
+                return (int) (scanRange1.offset - scanRange2.offset);
+            } else {
+                return scanRange1.compareTo(scanRange2);
+            }
+        });
 
         Assert.assertEquals(0, scanRangeLocations.get(0).scan_range.hdfs_scan_range.offset);
         long previousOffset = scanRangeLocations.get(0).scan_range.hdfs_scan_range.length;


### PR DESCRIPTION
cp from #42634

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [x] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5

