### PR TITLE
[BugFix] Fix show backup/restore empty result without FROM clause

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/qe/ShowExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/ShowExecutor.java
@@ -1761,12 +1761,9 @@ public class ShowExecutor {
 
             for (Database db : dbs) {
                 AbstractJob jobI = GlobalStateMgr.getCurrentState().getBackupHandler().getJob(db.getId());
-                if (jobI == null) {
+                if (jobI == null || !(jobI instanceof BackupJob)) {
                     // show next db
                     continue;
-                }
-                if (!(jobI instanceof BackupJob)) {
-                    return new ShowResultSet(statement.getMetaData(), EMPTY_SET);
                 }
 
                 BackupJob backupJob = (BackupJob) jobI;
@@ -1810,12 +1807,9 @@ public class ShowExecutor {
 
             for (Database db : dbs) {
                 AbstractJob jobI = GlobalStateMgr.getCurrentState().getBackupHandler().getJob(db.getId());
-                if (jobI == null) {
+                if (jobI == null || !(jobI instanceof RestoreJob)) {
                     // show next db
                     continue;
-                }
-                if (!(jobI instanceof RestoreJob)) {
-                    return new ShowResultSet(statement.getMetaData(), EMPTY_SET);
                 }
 
                 RestoreJob restoreJob = (RestoreJob) jobI;

--- a/fe/fe-core/src/main/java/com/starrocks/qe/ShowExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/ShowExecutor.java
@@ -1761,6 +1761,10 @@ public class ShowExecutor {
 
             for (Database db : dbs) {
                 AbstractJob jobI = GlobalStateMgr.getCurrentState().getBackupHandler().getJob(db.getId());
+                if (jobI == null) {
+                    // show next db
+                    continue;
+                }
                 if (!(jobI instanceof BackupJob)) {
                     return new ShowResultSet(statement.getMetaData(), EMPTY_SET);
                 }
@@ -1806,6 +1810,10 @@ public class ShowExecutor {
 
             for (Database db : dbs) {
                 AbstractJob jobI = GlobalStateMgr.getCurrentState().getBackupHandler().getJob(db.getId());
+                if (jobI == null) {
+                    // show next db
+                    continue;
+                }
                 if (!(jobI instanceof RestoreJob)) {
                     return new ShowResultSet(statement.getMetaData(), EMPTY_SET);
                 }

--- a/test/sql/test_show_backup_restore/R/test_show_backup_restore
+++ b/test/sql/test_show_backup_restore/R/test_show_backup_restore
@@ -1,0 +1,16 @@
+-- name: test_show_empty_backup_restore;
+CREATE DATABASE test1;
+-- result:
+-- !result
+CREATE DATABASE test2;
+-- result:
+-- !result
+CREATE DATABASE test3;
+-- result:
+-- !result
+SHOW BACKUP;
+-- result:
+-- !result
+SHOW RESTORE;
+-- result:
+-- !result

--- a/test/sql/test_show_backup_restore/T/test_show_backup_restore
+++ b/test/sql/test_show_backup_restore/T/test_show_backup_restore
@@ -1,0 +1,7 @@
+-- name: test_show_empty_backup_restore;
+CREATE DATABASE test1;
+CREATE DATABASE test2;
+CREATE DATABASE test3;
+
+SHOW BACKUP;
+SHOW RESTORE;


### PR DESCRIPTION
## Why I'm doing:
This problem is introduced by pr #42436. If we execute SHOW BACKUP/RESTORE without FROM clause, we will show all database by default. If one of them does not contain any backup/restore information, it will return empty result even the other database does has backup/restore information.

## What I'm doing:
Continue to check if one of dbs does not contain any backup/restore information.

Fix https://github.com/StarRocks/StarRocksTest/issues/6544

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
