### PR TITLE
[Doc] Add Datasource variable to dashboard, and user can choose different datasources

### DIFF
--- a/extra/grafana/kubernetes/StarRocks-Overview-kubernetes-3.0.json
+++ b/extra/grafana/kubernetes/StarRocks-Overview-kubernetes-3.0.json
@@ -1,14 +1,4 @@
 {
-    "__inputs": [
-    {
-      "name": "StarRocks_Prometheus",
-      "label": "StarRocks",
-      "description": "",
-      "type": "datasource",
-      "pluginId": "prometheus",
-      "pluginName": "Prometheus"
-    }
-  ],
   "__requires": [
     {
       "type": "grafana",
@@ -8297,6 +8287,21 @@
   "tags": [],
   "templating": {
     "list": [
+      {
+        "description": "",
+        "hide": 0,
+        "includeAll": false,
+        "label": "Datasource",
+        "multi": false,
+        "name": "StarRocks_Prometheus",
+        "options": [],
+        "query": "prometheus",
+        "queryValue": "",
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "type": "datasource"
+      },
       {
         "current": {
           "selected": false,


### PR DESCRIPTION
## Why I'm doing:

When users have multiple StarRocks clusters and want to switch views on Grafana, so we need to provide the function of switching datasources for users.

## What I'm doing:

Add Datasource variable to dashboard, and make sure it take effect.

datasource which has starrocks metrics
<img width="1487" alt="image" src="https://github.com/StarRocks/starrocks/assets/7991096/b8d0d7a0-dce4-4b81-acf2-61fd2f965b81">

datasource which does not have starrocks metrics.
<img width="1434" alt="image" src="https://github.com/StarRocks/starrocks/assets/7991096/2835456f-c8c0-4149-b185-e8c12a93e809">




Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [x] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
