### PR TITLE
[BugFix] fix audit log error code incorrect

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/qe/ConnectProcessor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/ConnectProcessor.java
@@ -188,7 +188,15 @@ public class ConnectProcessor {
         }
 
         // TODO how to unify TStatusCode, ErrorCode, ErrType, ConnectContext.errorCode
-        String errorCode = StringUtils.isNotEmpty(ctx.getErrorCode()) ? ctx.getErrorCode() : ctx.getState().getErrType().name();
+        String errorCode = "";
+        if (ctx.getState().getErrType() != QueryState.ErrType.EMPTY) {
+            // error happens in FE execution.
+            errorCode = ctx.getState().getErrType().name();
+        } else if (StringUtils.isNotEmpty(ctx.getErrorCode())) {
+            // error happens in BE execution.
+            errorCode = ctx.getErrorCode();
+        }
+
         ctx.getAuditEventBuilder().setEventType(EventType.AFTER_QUERY)
                 .setState(ctx.getState().toString())
                 .setErrorCode(errorCode)

--- a/fe/fe-core/src/main/java/com/starrocks/qe/ConnectProcessor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/ConnectProcessor.java
@@ -189,7 +189,7 @@ public class ConnectProcessor {
 
         // TODO how to unify TStatusCode, ErrorCode, ErrType, ConnectContext.errorCode
         String errorCode = "";
-        if (ctx.getState().getErrType() != QueryState.ErrType.EMPTY) {
+        if (ctx.getState().getErrType() != QueryState.ErrType.UNKNOWN) {
             // error happens in FE execution.
             errorCode = ctx.getState().getErrType().name();
         } else if (StringUtils.isNotEmpty(ctx.getErrorCode())) {

--- a/fe/fe-core/src/main/java/com/starrocks/qe/QueryState.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/QueryState.java
@@ -70,14 +70,14 @@ public class QueryState {
 
         IO_ERR,
 
-        OTHER_ERR
+        EMPTY
     }
 
     private MysqlStateType stateType = MysqlStateType.OK;
     private String errorMessage = "";
     private ErrorCode errorCode;
     private String infoMessage;
-    private ErrType errType = ErrType.OTHER_ERR;
+    private ErrType errType = ErrType.EMPTY;
     private boolean isQuery = false;
     private long affectedRows = 0;
     private int warningRows = 0;
@@ -93,7 +93,7 @@ public class QueryState {
         errorMessage = "";
         errorCode = null;
         infoMessage = null;
-        errType = ErrType.OTHER_ERR;
+        errType = ErrType.EMPTY;
         isQuery = false;
         affectedRows = 0;
         warningRows = 0;

--- a/fe/fe-core/src/main/java/com/starrocks/qe/QueryState.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/QueryState.java
@@ -70,14 +70,14 @@ public class QueryState {
 
         IO_ERR,
 
-        EMPTY
+        UNKNOWN
     }
 
     private MysqlStateType stateType = MysqlStateType.OK;
     private String errorMessage = "";
     private ErrorCode errorCode;
     private String infoMessage;
-    private ErrType errType = ErrType.EMPTY;
+    private ErrType errType = ErrType.UNKNOWN;
     private boolean isQuery = false;
     private long affectedRows = 0;
     private int warningRows = 0;
@@ -93,7 +93,7 @@ public class QueryState {
         errorMessage = "";
         errorCode = null;
         infoMessage = null;
-        errType = ErrType.EMPTY;
+        errType = ErrType.UNKNOWN;
         isQuery = false;
         affectedRows = 0;
         warningRows = 0;

--- a/fe/fe-core/src/test/java/com/starrocks/planner/QueryPlannerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/planner/QueryPlannerTest.java
@@ -40,12 +40,14 @@ import com.starrocks.ha.FrontendNodeType;
 import com.starrocks.meta.BlackListSql;
 import com.starrocks.meta.SqlBlackList;
 import com.starrocks.qe.ConnectContext;
+import com.starrocks.qe.QueryState;
 import com.starrocks.qe.StmtExecutor;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.sql.ast.CreateDbStmt;
 import com.starrocks.sql.ast.DropDbStmt;
 import com.starrocks.sql.ast.ShowCreateDbStmt;
 import com.starrocks.sql.ast.StatementBase;
+import com.starrocks.sql.ast.UserIdentity;
 import com.starrocks.sql.parser.SqlParser;
 import com.starrocks.utframe.StarRocksAssert;
 import com.starrocks.utframe.UtFrameUtils;
@@ -335,5 +337,18 @@ public class QueryPlannerTest {
             connectContext.getSessionVariable().setFollowerQueryForwardMode("follower");
             Assert.assertTrue(executor.isForwardToLeader() == true);
         }
+    }
+
+    @Test
+    public void testErrTypeInQueryState() throws Exception {
+        ConnectContext ctx = UtFrameUtils.initCtxForNewPrivilege(UserIdentity.ROOT);
+        ctx.setQueryId(UUIDUtil.genUUID());
+        StmtExecutor executor = new StmtExecutor(ctx, "select * from test.baseall");
+        executor.execute();
+        Assert.assertEquals(QueryState.ErrType.UNKNOWN, ctx.getState().getErrType());
+
+        executor = new StmtExecutor(ctx, "select * from test.baseallxxx");
+        executor.execute();
+        Assert.assertEquals(QueryState.ErrType.ANALYSIS_ERR, ctx.getState().getErrType());
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/qe/ConnectProcessorTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/qe/ConnectProcessorTest.java
@@ -589,4 +589,17 @@ public class ConnectProcessorTest extends DDLTestBase {
 
         Assert.assertFalse(Strings.isNullOrEmpty(QueryDetailQueue.getQueryDetailsAfterTime(0).get(0).getSql()));
     }
+
+    @Test
+    public void testErrTypeInQueryState() throws Exception {
+        ConnectContext ctx = UtFrameUtils.initCtxForNewPrivilege(UserIdentity.ROOT);
+        ctx.setQueryId(UUIDUtil.genUUID());
+        StmtExecutor executor = new StmtExecutor(ctx, "select * from testDb1.testTable1");
+        executor.execute();
+        Assert.assertEquals(QueryState.ErrType.UNKNOWN, ctx.getState().getErrType());
+
+        executor = new StmtExecutor(ctx, "select * from testDb1.testTable1xxx");
+        executor.execute();
+        Assert.assertEquals(QueryState.ErrType.ANALYSIS_ERR, ctx.getState().getErrType());
+    }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/qe/ConnectProcessorTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/qe/ConnectProcessorTest.java
@@ -590,16 +590,5 @@ public class ConnectProcessorTest extends DDLTestBase {
         Assert.assertFalse(Strings.isNullOrEmpty(QueryDetailQueue.getQueryDetailsAfterTime(0).get(0).getSql()));
     }
 
-    @Test
-    public void testErrTypeInQueryState() throws Exception {
-        ConnectContext ctx = UtFrameUtils.initCtxForNewPrivilege(UserIdentity.ROOT);
-        ctx.setQueryId(UUIDUtil.genUUID());
-        StmtExecutor executor = new StmtExecutor(ctx, "select * from testDb1.testTable1");
-        executor.execute();
-        Assert.assertEquals(QueryState.ErrType.UNKNOWN, ctx.getState().getErrType());
 
-        executor = new StmtExecutor(ctx, "select * from testDb1.testTable1xxx");
-        executor.execute();
-        Assert.assertEquals(QueryState.ErrType.ANALYSIS_ERR, ctx.getState().getErrType());
-    }
 }


### PR DESCRIPTION
## Why I'm doing:
The default errorType in QueryState is `OTHER_ERROR`. We mistakenly audit it in audit log.
## What I'm doing:
Filter this info in audit log.

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [x] 3.1
  - [x] 3.0
  - [x] 2.5
