### PR TITLE
[BugFix] fix JSON IS NULL

### DIFF
--- a/be/src/column/column.h
+++ b/be/src/column/column.h
@@ -93,6 +93,8 @@ public:
 
     virtual bool is_object() const { return false; }
 
+    virtual bool is_json() const { return false; }
+
     virtual bool is_array() const { return false; }
 
     virtual bool is_map() const { return false; }

--- a/be/src/column/const_column.h
+++ b/be/src/column/const_column.h
@@ -47,6 +47,7 @@ public:
     ~ConstColumn() override = default;
 
     bool is_nullable() const override { return _data->is_nullable(); }
+    bool is_json() const override { return _data->is_json(); }
 
     bool is_null(size_t index) const override { return _data->is_null(0); }
 

--- a/be/src/column/json_column.h
+++ b/be/src/column/json_column.h
@@ -49,6 +49,7 @@ public:
     void append_datum(const Datum& datum) override;
     void put_mysql_row_buffer(starrocks::MysqlRowBuffer* buf, size_t idx) const override;
     std::string get_name() const override;
+    bool is_json() const override { return true; }
 
     const uint8_t* deserialize_and_append(const uint8_t* pos) override;
     uint32_t serialize_size(size_t idx) const override;

--- a/be/src/column/nullable_column.h
+++ b/be/src/column/nullable_column.h
@@ -81,6 +81,7 @@ public:
     void update_has_null();
 
     bool is_nullable() const override { return true; }
+    bool is_json() const override { return _data_column->is_json(); }
 
     bool is_null(size_t index) const override {
         DCHECK_EQ(_null_column->size(), _data_column->size());

--- a/be/src/util/json.cpp
+++ b/be/src/util/json.cpp
@@ -307,6 +307,10 @@ bool JsonValue::is_none() const {
     return to_vslice().isNone();
 }
 
+bool JsonValue::is_null_or_none() const {
+    return is_null() || is_none();
+}
+
 std::ostream& operator<<(std::ostream& os, const JsonValue& json) {
     return os << json.to_string_uncheck();
 }

--- a/be/src/util/json.h
+++ b/be/src/util/json.h
@@ -126,6 +126,7 @@ public:
     StatusOr<JsonValue> get_obj(const std::string& key) const;
     bool is_null() const;
     bool is_none() const;
+    bool is_null_or_none() const;
 
     ////////////////// util  //////////////////////
     StatusOr<std::string> to_string() const;

--- a/test/sql/test_json/R/null
+++ b/test/sql/test_json/R/null
@@ -1,0 +1,53 @@
+-- name: test_json_null
+drop database if exists db_json_null;
+-- result:
+-- !result
+create database db_json_null;
+-- result:
+-- !result
+use db_json_null;
+-- result:
+-- !result
+CREATE TABLE `t0` (
+  `c0` int(11) NULL,
+  `c1` json NULL
+);
+-- result:
+-- !result
+INSERT INTO t0 VALUES(0, '{"a": 0, "b": null}');
+-- result:
+-- !result
+SELECT c1 IS NULL FROM t0;
+-- result:
+0
+-- !result
+SELECT c1->'a' IS NULL, c1->'a' IS NOT NULL FROM t0;
+-- result:
+0	0
+-- !result
+SELECT c1->'b' IS NULL, c1->'b' IS NOT NULL FROM t0;
+-- result:
+1	1
+-- !result
+SELECT c1->'c' IS NULL, c1->'c' IS NOT NULL FROM t0;
+-- result:
+1	1
+-- !result
+SELECT 
+    parse_json('{"a": 0, "b": null}')->'a' IS NULL,
+    parse_json('{"a": 0, "b": null}')->'a' IS NOT NULL;
+-- result:
+0	0
+-- !result
+SELECT 
+    parse_json('{"a": 0, "b": null}')->'b' IS NULL,
+    parse_json('{"a": 0, "b": null}')->'b' IS NOT NULL;
+-- result:
+1	1
+-- !result
+SELECT 
+    parse_json('{"a": 0, "b": null}')->'c' IS NULL,
+    parse_json('{"a": 0, "b": null}')->'c' IS NOT NULL;
+-- result:
+1	0
+-- !result

--- a/test/sql/test_json/T/null
+++ b/test/sql/test_json/T/null
@@ -1,0 +1,28 @@
+-- name: test_json_null
+
+drop database if exists db_json_null;
+create database db_json_null;
+use db_json_null;
+
+CREATE TABLE `t0` (
+  `c0` int(11) NULL,
+  `c1` json NULL
+);
+
+INSERT INTO t0 VALUES(0, '{"a": 0, "b": null}');
+
+
+SELECT c1 IS NULL FROM t0;
+SELECT c1->'a' IS NULL, c1->'a' IS NOT NULL FROM t0;
+SELECT c1->'b' IS NULL, c1->'b' IS NOT NULL FROM t0;
+SELECT c1->'c' IS NULL, c1->'c' IS NOT NULL FROM t0;
+
+SELECT 
+    parse_json('{"a": 0, "b": null}')->'a' IS NULL,
+    parse_json('{"a": 0, "b": null}')->'a' IS NOT NULL;
+SELECT 
+    parse_json('{"a": 0, "b": null}')->'b' IS NULL,
+    parse_json('{"a": 0, "b": null}')->'b' IS NOT NULL;
+SELECT 
+    parse_json('{"a": 0, "b": null}')->'c' IS NULL,
+    parse_json('{"a": 0, "b": null}')->'c' IS NOT NULL;

--- a/test/sql/test_semi/R/test_invalid_flat_json
+++ b/test/sql/test_semi/R/test_invalid_flat_json
@@ -51,7 +51,7 @@ select JSON_LENGTH(j1, "$.key2"), JSON_LENGTH(j1, "$.key3"), JSON_LENGTH(j1, "$.
 -- !result
 select json_object('"1"')->"1", json_object('"1"')->"1" is null;
 -- result:
-null	0
+null	1
 -- !result
 select j1, j1->"1", j1->"1" is null from js1 order by v1, v2;
 -- result:
@@ -64,7 +64,7 @@ select j1, j1->"1", j1->"1" is null from js1 order by v1, v2;
 None	None	1
 "1"	None	1
 {"k1": null, "k2": 2}	None	1
-{"1": null}	null	0
+{"1": null}	null	1
 {"a": null}	None	1
 None	None	1
 {}	None	1


### PR DESCRIPTION
## Why I'm doing:
- `SELECT parse_json('{"a": null}') -> 'a' IS NULL` returns false, which is not intuitive and not easy to use

## What I'm doing:
- Treat `JSON NULL` as `NULL` 

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [x] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [x] 3.1
  - [ ] 3.0
  - [ ] 2.5
