### PR TITLE
[Feature] Support orc_use_column_names property in session variable

### DIFF
--- a/be/src/connector/hive_connector.cpp
+++ b/be/src/connector/hive_connector.cpp
@@ -827,6 +827,7 @@ Status HiveDataSource::_init_scanner(RuntimeState* state) {
     } else if (format == THdfsFileFormat::PARQUET) {
         scanner = _pool.add(new HdfsParquetScanner());
     } else if (format == THdfsFileFormat::ORC) {
+        scanner_params.orc_use_column_names = state->query_options().orc_use_column_names;
         scanner = _pool.add(new HdfsOrcScanner());
     } else if (format == THdfsFileFormat::TEXT) {
         scanner = _pool.add(new HdfsTextScanner());

--- a/be/src/exec/hdfs_scanner.cpp
+++ b/be/src/exec/hdfs_scanner.cpp
@@ -130,6 +130,7 @@ Status HdfsScanner::_build_scanner_context() {
     ctx.min_max_tuple_desc = _scanner_params.min_max_tuple_desc;
     ctx.hive_column_names = _scanner_params.hive_column_names;
     ctx.case_sensitive = _scanner_params.case_sensitive;
+    ctx.orc_use_column_names = _scanner_params.orc_use_column_names;
     ctx.can_use_any_column = _scanner_params.can_use_any_column;
     ctx.can_use_min_max_count_opt = _scanner_params.can_use_min_max_count_opt;
     ctx.use_file_metacache = _scanner_params.use_file_metacache;

--- a/be/src/exec/hdfs_scanner.h
+++ b/be/src/exec/hdfs_scanner.h
@@ -210,6 +210,7 @@ struct HdfsScannerParams {
     bool can_use_any_column = false;
     bool can_use_min_max_count_opt = false;
     bool use_file_metacache = false;
+    bool orc_use_column_names = false;
     MORParams mor_params;
 };
 
@@ -257,6 +258,8 @@ struct HdfsScannerContext {
     std::vector<std::string>* hive_column_names = nullptr;
 
     bool case_sensitive = false;
+
+    bool orc_use_column_names = false;
 
     bool can_use_any_column = false;
 

--- a/be/src/formats/orc/column_reader.cpp
+++ b/be/src/formats/orc/column_reader.cpp
@@ -128,6 +128,17 @@ StatusOr<std::unique_ptr<ORCColumnReader>> ORCColumnReader::create(const TypeDes
     }
 }
 
+StatusOr<std::unique_ptr<ORCColumnReader>> ORCColumnReader::create_default_column_reader(const TypeDescriptor& type,
+                                                                                         bool nullable,
+                                                                                         OrcChunkReader* reader) {
+    return std::make_unique<DefaultColumnReader>(type, nullable, reader);
+}
+
+Status DefaultColumnReader::get_next(orc::ColumnVectorBatch* cvb, ColumnPtr& col, size_t from, size_t size) {
+    col->append_default(size);
+    return Status::OK();
+}
+
 Status BooleanColumnReader::get_next(orc::ColumnVectorBatch* cvb, ColumnPtr& column, size_t from, size_t size) {
     auto* data = down_cast<orc::LongVectorBatch*>(cvb);
     size_t column_start = column->size();

--- a/be/src/formats/orc/column_reader.h
+++ b/be/src/formats/orc/column_reader.h
@@ -75,6 +75,9 @@ public:
     static StatusOr<std::unique_ptr<ORCColumnReader>> create(const TypeDescriptor& type, const orc::Type* orc_type,
                                                              bool nullable, const OrcMappingPtr& orc_mapping,
                                                              OrcChunkReader* reader);
+    static StatusOr<std::unique_ptr<ORCColumnReader>> create_default_column_reader(const TypeDescriptor& type,
+                                                                                   bool nullable,
+                                                                                   OrcChunkReader* reader);
     const orc::Type* get_orc_type() { return _orc_type; }
 
 protected:
@@ -102,6 +105,14 @@ protected:
     const orc::Type* _orc_type;
     bool _nullable;
     OrcChunkReader* _reader;
+};
+
+class DefaultColumnReader final : public ORCColumnReader {
+public:
+    DefaultColumnReader(const TypeDescriptor& type, bool nullable, OrcChunkReader* reader)
+            : ORCColumnReader(type, nullptr, nullable, reader) {}
+    ~DefaultColumnReader() override = default;
+    Status get_next(orc::ColumnVectorBatch* cvb, ColumnPtr& col, size_t from, size_t size) override;
 };
 
 class PrimitiveColumnReader : public ORCColumnReader {

--- a/be/src/formats/orc/orc_chunk_reader.cpp
+++ b/be/src/formats/orc/orc_chunk_reader.cpp
@@ -66,20 +66,10 @@ OrcChunkReader::OrcChunkReader(int chunk_size, std::vector<SlotDescriptor*> src_
             ++iter_slot;
         }
     }
-}
 
-OrcChunkReader::OrcChunkReader()
-        : _read_chunk_size(4096),
-          _tzinfo(cctz::utc_time_zone()),
-          _tzoffset_in_seconds(0),
-          _drop_nanoseconds_in_datetime(false),
-          _broker_load_mode(true),
-          _strict_mode(true),
-          _broker_load_filter(nullptr),
-          _num_rows_filtered(0),
-          _error_message_counter(0),
-          _lazy_load_ctx(nullptr) {
-    _row_reader_options.useWriterTimezone();
+    for (size_t i = 0; i < _src_slot_descriptors.size(); i++) {
+        _slot_id_to_pos_in_src_slot_descs.emplace(_src_slot_descriptors[i]->id(), i);
+    }
 }
 
 Status OrcChunkReader::init(std::unique_ptr<orc::InputStream> input_stream, const OrcPredicates* orc_predicates) {
@@ -96,35 +86,11 @@ Status OrcChunkReader::init(std::unique_ptr<orc::InputStream> input_stream, cons
     return Status::OK();
 }
 
-void OrcChunkReader::build_column_name_to_orc_type_mapping(std::unordered_map<std::string, const orc::Type*>* mapping,
-                                                           const std::vector<std::string>* hive_column_names,
-                                                           const orc::Type& root_type, bool case_sensitive) {
-    mapping->clear();
-    if (hive_column_names != nullptr) {
-        // build hive column names index.
-        // if there are 64 columns in hive meta, but actually there are 63 columns in orc file
-        // then we will read invalid column id.
-        int size = std::min(hive_column_names->size(), root_type.getSubtypeCount());
-        for (int i = 0; i < size; i++) {
-            const auto& sub_type = root_type.getSubtype(i);
-            std::string col_name = format_column_name(hive_column_names->at(i), case_sensitive);
-            mapping->insert(make_pair(col_name, sub_type));
-        }
-    } else {
-        // build orc column names index.
-        for (int i = 0; i < root_type.getSubtypeCount(); i++) {
-            const auto& sub_type = root_type.getSubtype(i);
-            std::string col_name = format_column_name(root_type.getFieldName(i), case_sensitive);
-            mapping->insert(make_pair(col_name, sub_type));
-        }
-    }
-}
-
 void OrcChunkReader::build_column_name_set(std::unordered_set<std::string>* name_set,
                                            const std::vector<std::string>* hive_column_names,
-                                           const orc::Type& root_type, bool case_sensitive) {
+                                           const orc::Type& root_type, bool case_sensitive, bool use_orc_column_names) {
     name_set->clear();
-    if (hive_column_names != nullptr && hive_column_names->size() > 0) {
+    if (hive_column_names != nullptr && hive_column_names->size() > 0 && !use_orc_column_names) {
         // build hive column names index.
         int size = std::min(hive_column_names->size(), root_type.getSubtypeCount());
         for (int i = 0; i < size; i++) {
@@ -141,19 +107,15 @@ void OrcChunkReader::build_column_name_set(std::unordered_set<std::string>* name
 }
 
 Status OrcChunkReader::_init_include_columns(const std::unique_ptr<OrcMapping>& mapping) {
-    // TODO(SmithCruise) delete _name_to_column_id, _hive_column_names when develop subfield lazy load.
-    build_column_name_to_orc_type_mapping(&_formatted_slot_name_to_orc_type, _hive_column_names, _reader->getType(),
-                                          _case_sensitive);
-
     std::list<uint64_t> include_column_id;
 
     // NOTICE: No need to explicit include root column id, otherwise it will read out all fields.
     // Include root column id.
     // include_column_id.emplace_back(0);
-
     for (size_t i = 0; i < _src_slot_descriptors.size(); i++) {
         SlotDescriptor* desc = _src_slot_descriptors[i];
-        if (desc == nullptr) continue;
+        // column not existed
+        if (!mapping->contains(i)) continue;
         RETURN_IF_ERROR(mapping->set_include_column_id(i, desc->type(), &include_column_id));
     }
 
@@ -163,8 +125,7 @@ Status OrcChunkReader::_init_include_columns(const std::unique_ptr<OrcMapping>& 
         std::list<uint64_t> lazy_load_column_id;
 
         for (size_t pos : _lazy_load_ctx->lazy_load_indices) {
-            SlotDescriptor* desc = _src_slot_descriptors[pos];
-            if (desc == nullptr) continue;
+            if (!mapping->contains(pos)) continue;
             RETURN_IF_ERROR(mapping->set_lazy_load_column_id(pos, &lazy_load_column_id));
         }
 
@@ -198,6 +159,7 @@ Status OrcChunkReader::init(std::unique_ptr<orc::Reader> reader, const OrcPredic
     // Build root_mapping, including all columns in orc.
     _orc_mapping_options.filename = _current_file_name;
     _orc_mapping_options.case_sensitive = _case_sensitive;
+    _orc_mapping_options.invalid_as_null = _invalid_as_null;
     ASSIGN_OR_RETURN(_root_mapping,
                      OrcMappingFactory::build_mapping(_src_slot_descriptors, _reader->getType(), _use_orc_column_names,
                                                       _hive_column_names, _orc_mapping_options));
@@ -234,56 +196,47 @@ Status OrcChunkReader::init(std::unique_ptr<orc::Reader> reader, const OrcPredic
     return Status::OK();
 }
 
-Status OrcChunkReader::_init_position_in_orc() {
-    int column_size = _src_slot_descriptors.size();
-    std::vector<int> position_in_orc;
-    position_in_orc.resize(column_size);
-    _slot_id_to_position.clear();
+Status OrcChunkReader::_init_position_in_orc() const {
+    const size_t column_size = _src_slot_descriptors.size();
+    std::vector<int32_t> position_in_orc_vector_batch;
+    position_in_orc_vector_batch.resize(column_size);
 
-    std::unordered_map<int, int> column_id_to_pos;
+    std::unordered_map<uint64_t, size_t> column_id_to_pos_in_vector_batch;
 
     const auto& type = _row_reader->getSelectedType();
-    for (int i = 0; i < type.getSubtypeCount(); i++) {
+    for (size_t i = 0; i < type.getSubtypeCount(); i++) {
         const auto& sub_type = type.getSubtype(i);
-        int col_id = static_cast<int>(sub_type->getColumnId());
-        column_id_to_pos[col_id] = i;
+        uint64_t col_id = sub_type->getColumnId();
+        column_id_to_pos_in_vector_batch.emplace(col_id, i);
     }
 
     for (int i = 0; i < column_size; i++) {
-        auto slot_desc = _src_slot_descriptors[i];
-
-        if (slot_desc == nullptr) continue;
-        std::string col_name = format_column_name(slot_desc->col_name(), _case_sensitive);
-        auto it = _formatted_slot_name_to_orc_type.find(col_name);
-        if (it == _formatted_slot_name_to_orc_type.end()) {
-            auto s = strings::Substitute(
-                    "OrcChunkReader::init_position_in_orc. failed to find position. col_name = $0, file = $1", col_name,
-                    _current_file_name);
-            return Status::NotFound(s);
+        if (!_root_mapping->contains(i)) {
+            // slot column name didn't existed in orc file,  set -1 for it.
+            position_in_orc_vector_batch[i] = -1;
+            continue;
         }
-        int col_id = it->second->getColumnId();
-        auto it2 = column_id_to_pos.find(col_id);
-        if (it2 == column_id_to_pos.end()) {
+
+        uint64_t column_id = _root_mapping->get_orc_type_child_mapping(i).orc_type->getColumnId();
+        auto it2 = column_id_to_pos_in_vector_batch.find(column_id);
+        if (it2 == column_id_to_pos_in_vector_batch.end()) {
             auto s = strings::Substitute(
                     "OrcChunkReader::init_position_in_orc. failed to find position. col_id = $0, file = $1",
-                    std::to_string(col_id), _current_file_name);
+                    std::to_string(column_id), _current_file_name);
             return Status::NotFound(s);
         }
-        int pos = it2->second;
-        position_in_orc[i] = pos;
-        SlotId id = slot_desc->id();
-        _slot_id_to_position[id] = pos;
+        position_in_orc_vector_batch[i] = it2->second;
     }
 
     if (_lazy_load_ctx != nullptr) {
         for (int i = 0; i < _lazy_load_ctx->active_load_slots.size(); i++) {
             int src_index = _lazy_load_ctx->active_load_indices[i];
-            int pos = position_in_orc[src_index];
+            int pos = position_in_orc_vector_batch[src_index];
             _lazy_load_ctx->active_load_orc_positions[i] = pos;
         }
         for (int i = 0; i < _lazy_load_ctx->lazy_load_slots.size(); i++) {
             int src_index = _lazy_load_ctx->lazy_load_indices[i];
-            int pos = position_in_orc[src_index];
+            int pos = position_in_orc_vector_batch[src_index];
             _lazy_load_ctx->lazy_load_orc_positions[i] = pos;
         }
     }
@@ -424,7 +377,9 @@ Status OrcChunkReader::_init_src_types(const std::unique_ptr<OrcMapping>& mappin
     _src_types.resize(column_size);
     for (int i = 0; i < column_size; i++) {
         auto slot_desc = _src_slot_descriptors[i];
-        if (slot_desc == nullptr) {
+        if (!mapping->contains(i)) {
+            // target column didn't existed in orc file, so we just using column's type directly
+            _src_types[i] = slot_desc->type();
             continue;
         }
         const orc::Type* orc_type = mapping->get_orc_type_child_mapping(i).orc_type;
@@ -443,13 +398,11 @@ Status OrcChunkReader::_init_cast_exprs() {
 
     for (int column_pos = 0; column_pos < column_size; ++column_pos) {
         auto slot_desc = _src_slot_descriptors[column_pos];
-        if (slot_desc == nullptr) {
-            continue;
-        }
         auto& orc_type = _src_types[column_pos];
         auto& starrocks_type = slot_desc->type();
         Expr* slot = _pool.add(new ColumnRef(slot_desc));
-        if (starrocks_type.is_assignable(orc_type)) {
+        if (starrocks_type.is_assignable(orc_type) || !_root_mapping->contains(column_pos)) {
+            // if column didn't existed in orc file, we don't need case_expr anymore, using ColumnRef directly
             _cast_exprs[column_pos] = slot;
             continue;
         }
@@ -465,26 +418,28 @@ Status OrcChunkReader::_init_cast_exprs() {
 }
 
 Status OrcChunkReader::_init_column_readers() {
-    int column_size = _src_slot_descriptors.size();
+    const size_t column_size = _src_slot_descriptors.size();
     _column_readers.clear();
 
-    for (int column_pos = 0; column_pos < column_size; ++column_pos) {
-        auto slot_desc = _src_slot_descriptors[column_pos];
-        if (slot_desc == nullptr) {
-            continue;
+    for (size_t column_pos = 0; column_pos < column_size; ++column_pos) {
+        const auto& slot_desc = _src_slot_descriptors[column_pos];
+        std::unique_ptr<ORCColumnReader> column_reader;
+        if (_root_mapping->contains(column_pos)) {
+            ASSIGN_OR_RETURN(
+                    column_reader,
+                    ORCColumnReader::create(_src_types[column_pos],
+                                            _root_mapping->get_orc_type_child_mapping(column_pos).orc_type,
+                                            slot_desc->is_nullable(),
+                                            _root_mapping->get_orc_type_child_mapping(column_pos).orc_mapping, this));
+        } else {
+            ASSIGN_OR_RETURN(column_reader, ORCColumnReader::create_default_column_reader(
+                                                    _src_types[column_pos], slot_desc->is_nullable(), this));
         }
-        ASSIGN_OR_RETURN(std::unique_ptr<ORCColumnReader> column_reader,
-                         ORCColumnReader::create(
-                                 _src_types[column_pos], _root_mapping->get_orc_type_child_mapping(column_pos).orc_type,
-                                 slot_desc->is_nullable(),
-                                 _root_mapping->get_orc_type_child_mapping(column_pos).orc_mapping, this));
         _column_readers.emplace_back(std::move(column_reader));
     }
     DCHECK_EQ(_column_readers.size(), column_size);
     return Status::OK();
 }
-
-OrcChunkReader::~OrcChunkReader() = default;
 
 Status OrcChunkReader::read_next(orc::RowReader::ReadPosition* pos) {
     if (_batch == nullptr) {
@@ -528,23 +483,27 @@ Status OrcChunkReader::_fill_chunk(ChunkPtr* chunk, const std::vector<SlotDescri
             src_index = (*indices)[src_index];
         }
         set_current_slot(slot_desc);
-        orc::ColumnVectorBatch* cvb = batch_vec->fieldsColumnIdMap[_root_mapping->get_orc_type_child_mapping(src_index)
-                                                                           .orc_type->getColumnId()];
-        if (!slot_desc->is_nullable() && cvb->hasNulls) {
-            if (_broker_load_mode) {
-                std::string error_msg =
-                        strings::Substitute("NULL value in non-nullable column '$0'", _current_slot->col_name());
-                report_error_message(error_msg);
-                bool all_zero = false;
-                ColumnHelper::merge_two_filters(_broker_load_filter.get(),
-                                                reinterpret_cast<uint8_t*>(cvb->notNull.data()), &all_zero);
-                if (all_zero) {
-                    (*chunk)->set_num_rows(0);
-                    break;
+
+        orc::ColumnVectorBatch* cvb = nullptr;
+        if (_root_mapping->contains(src_index)) {
+            cvb = batch_vec->fieldsColumnIdMap[_root_mapping->get_orc_type_child_mapping(src_index)
+                                                       .orc_type->getColumnId()];
+            if (!slot_desc->is_nullable() && cvb->hasNulls) {
+                if (_broker_load_mode) {
+                    std::string error_msg =
+                            strings::Substitute("NULL value in non-nullable column '$0'", _current_slot->col_name());
+                    report_error_message(error_msg);
+                    bool all_zero = false;
+                    ColumnHelper::merge_two_filters(_broker_load_filter.get(),
+                                                    reinterpret_cast<uint8_t*>(cvb->notNull.data()), &all_zero);
+                    if (all_zero) {
+                        (*chunk)->set_num_rows(0);
+                        break;
+                    }
+                } else {
+                    auto s = strings::Substitute("column '$0' is not nullable", slot_desc->col_name());
+                    return Status::InternalError(s);
                 }
-            } else {
-                auto s = strings::Substitute("column '$0' is not nullable", slot_desc->col_name());
-                return Status::InternalError(s);
             }
         }
         ColumnPtr& col = (*chunk)->get_column_by_slot_id(slot_desc->id());
@@ -781,6 +740,10 @@ bool OrcChunkReader::_ok_to_add_binary_in_conjunct(
     if (iter == slot_id_to_pos_in_src_slot_descriptors.end()) {
         return false;
     }
+    if (!_root_mapping->contains(iter->second)) {
+        // column not existed in this orc file
+        return false;
+    }
 
     const SlotDescriptor* slot_desc = _src_slot_descriptors[iter->second];
     // It's unsafe to do eval on char type because of padding problems.
@@ -826,6 +789,10 @@ bool OrcChunkReader::_ok_to_add_is_null_conjunct(
     if (iter == slot_id_to_pos_in_src_slot_descriptors.end()) {
         return false;
     }
+    if (!_root_mapping->contains(iter->second)) {
+        // column not existed in this orc file
+        return false;
+    }
 
     if (node_type == TExprNodeType::FUNCTION_CALL) {
         // check is null & is not null
@@ -858,7 +825,7 @@ bool OrcChunkReader::_ok_to_add_conjunct(
     if (node_type == TExprNodeType::IS_NULL_PRED || node_type == TExprNodeType::FUNCTION_CALL) {
         return _ok_to_add_is_null_conjunct(conjunct, slot_id_to_pos_in_src_slot_descriptors);
     }
-
+    // TODO We can't pushdown `select * from tbl where col` now. Because conjunct is a cast expr here
     return false;
 }
 
@@ -1219,6 +1186,7 @@ Status OrcChunkReader::build_search_argument_by_predicates(const OrcPredicates* 
             if (filter == nullptr || filter->has_null() || !rf_desc->is_probe_slot_ref(&probe_slot_id)) continue;
             auto it2 = slot_id_to_pos_in_src_slot_descriptors.find(probe_slot_id);
             if (it2 == slot_id_to_pos_in_src_slot_descriptors.end()) continue;
+            if (!_root_mapping->contains(it2->second)) continue;
             const SlotDescriptor* slot_desc = _src_slot_descriptors[it2->second];
             const uint64_t column_id = _root_mapping->get_orc_type_child_mapping(it2->second).orc_type->getColumnId();
             if (_add_runtime_filter(column_id, slot_desc, filter, builder)) {
@@ -1259,17 +1227,23 @@ Status OrcChunkReader::apply_dict_filter_eval_cache(const std::unordered_map<Slo
 
     const uint32_t size = _batch->numElements;
     filter->assign(size, 1);
-    const auto& batch_vec = down_cast<orc::StructVectorBatch*>(_batch.get())->fields;
+    const auto& struct_batch = down_cast<orc::StructVectorBatch*>(_batch.get());
     bool filter_all = false;
 
     for (const auto& it : dict_filter_eval_cache) {
-        int pos = _slot_id_to_position[it.first];
+        size_t pos_in_src_slot_descs = _slot_id_to_pos_in_src_slot_descs[it.first];
+        if (!_root_mapping->contains(pos_in_src_slot_descs)) {
+            DCHECK(false) << "shouldn't happen";
+            continue;
+        }
+        uint64_t column_id = _root_mapping->get_orc_type_child_mapping(pos_in_src_slot_descs).orc_type->getColumnId();
+
         const Filter& dict_filter = (*it.second);
         ColumnPtr data_filter = BooleanColumn::create(size);
         Filter& data = static_cast<BooleanColumn*>(data_filter.get())->get_data();
         DCHECK(data.size() == size);
 
-        auto* batch = down_cast<orc::StringVectorBatch*>(batch_vec[pos]);
+        auto* batch = down_cast<orc::StringVectorBatch*>(struct_batch->fieldsColumnIdMap[column_id]);
         for (uint32_t i = 0; i < size; i++) {
             int64_t code = batch->codes[i];
             DCHECK(code < dict_filter.size());
@@ -1316,13 +1290,17 @@ void OrcChunkReader::report_error_message(const std::string& error_msg) {
     _state->append_error_msg_to_file("", error_msg);
 }
 
-const orc::Type* OrcChunkReader::get_orc_type_by_slot_name(const std::string& slot_name) const {
-    const std::string& formatted_slot_name = format_column_name(slot_name, _case_sensitive);
-    const auto& it = _formatted_slot_name_to_orc_type.find(formatted_slot_name);
-    if (it != _formatted_slot_name_to_orc_type.end()) {
-        return it->second;
+const orc::Type* OrcChunkReader::get_orc_type_by_slot_id(const SlotId& slot_id) const {
+    const auto& it = _slot_id_to_pos_in_src_slot_descs.find(slot_id);
+    if (it == _slot_id_to_pos_in_src_slot_descs.end()) {
+        // partition column don't existed in _src_slot_descriptors
+        return nullptr;
     }
-    return nullptr;
+    if (_root_mapping->contains(it->second)) {
+        return _root_mapping->get_orc_type_child_mapping(it->second).orc_type;
+    } else {
+        return nullptr;
+    }
 }
 
 bool OrcChunkReader::is_implicit_castable(TypeDescriptor& starrocks_type, const TypeDescriptor& orc_type) {

--- a/be/src/formats/orc/orc_mapping.h
+++ b/be/src/formats/orc/orc_mapping.h
@@ -100,6 +100,8 @@ public:
     // src_pos is origin column position in table definition.
     const OrcMappingOrcType& get_orc_type_child_mapping(size_t original_pos_in_table_definition);
 
+    bool contains(size_t original_pos_in_table_definition) const;
+
     void add_mapping(size_t pos_in_src, const OrcMappingPtr& child_mapping, const orc::Type* orc_type);
 
     void clear();

--- a/be/test/exec/hdfs_scanner_test.cpp
+++ b/be/test/exec/hdfs_scanner_test.cpp
@@ -561,7 +561,35 @@ TEST_F(HdfsScannerTest, TestOrcGetNextWithMinMaxFilterNoRows) {
     ASSERT_OK(Expr::prepare(param->partition_values, _runtime_state));
     ASSERT_OK(Expr::open(param->partition_values, _runtime_state));
 
-    auto* min_max_tuple_desc = _create_tuple_desc(mtypes_orc_min_max_descs);
+    // TupleDescriptor* min_max_tuple_desc = _create_tuple_desc(mtypes_orc_min_max_descs);
+    TupleDescriptor* min_max_tuple_desc = nullptr;
+    {
+        TDescriptorTableBuilder table_desc_builder;
+        TSlotDescriptorBuilder slot_desc_builder;
+        TTupleDescriptorBuilder tuple_desc_builder;
+
+        slot_desc_builder.column_name("id")
+                .type(TypeDescriptor::from_logical_type(LogicalType::TYPE_BIGINT))
+                .id(0)
+                .nullable(true);
+        tuple_desc_builder.add_slot(slot_desc_builder.build());
+        slot_desc_builder.column_name("PART_y")
+                .type(TypeDescriptor::from_logical_type(LogicalType::TYPE_INT))
+                .id(25)
+                .nullable(true);
+        tuple_desc_builder.add_slot(slot_desc_builder.build());
+
+        tuple_desc_builder.build(&table_desc_builder);
+        std::vector<TTupleId> row_tuples = std::vector<TTupleId>{0};
+        std::vector<bool> nullable_tuples = std::vector<bool>{true};
+        DescriptorTbl* tbl = nullptr;
+        CHECK(DescriptorTbl::create(_runtime_state, &_pool, table_desc_builder.desc_tbl(), &tbl,
+                                    config::vector_chunk_size)
+                      .ok());
+        auto* row_desc = _pool.add(new RowDescriptor(*tbl, row_tuples, nullable_tuples));
+        min_max_tuple_desc = row_desc->tuple_descriptors()[0];
+    }
+
     param->min_max_tuple_desc = min_max_tuple_desc;
     // id min/max = 2629/5212, PART_Y min/max=20/20
     std::vector<int> thres = {20, 30, 20, 20};

--- a/be/test/formats/orc/orc_chunk_reader_test.cpp
+++ b/be/test/formats/orc/orc_chunk_reader_test.cpp
@@ -2832,6 +2832,23 @@ TEST_F(OrcChunkReaderTest, TestColumnMismatched) {
         ASSERT_FALSE(st.ok()) << st.message();
     }
 
+    // test with column not found
+    {
+        SlotDesc col1{"col11", TypeDescriptor::from_logical_type(LogicalType::TYPE_INT)};
+
+        SlotDesc slot_descs[] = {col1, {""}};
+        std::vector<SlotDescriptor*> src_slot_descriptors;
+        ObjectPool pool;
+        create_slot_descriptors(_runtime_state.get(), &pool, &src_slot_descriptors, slot_descs);
+
+        OrcChunkReader reader(_runtime_state->chunk_size(), src_slot_descriptors);
+        reader.set_use_orc_column_names(true);
+        auto input_stream =
+                ORC_UNIQUE_PTR<orc::InputStream>(new MemoryInputStream(buffer.getData(), buffer.getLength()));
+        Status st = reader.init(std::move(input_stream), nullptr);
+        ASSERT_FALSE(st.ok()) << st.message();
+    }
+
     // test with col2 not matched, enable invalid_as_null
     {
         SlotDesc col1{"col1", TypeDescriptor::from_logical_type(LogicalType::TYPE_INT)};

--- a/be/test/formats/orc/orc_chunk_reader_test.cpp
+++ b/be/test/formats/orc/orc_chunk_reader_test.cpp
@@ -210,7 +210,8 @@ static uint64_t get_hit_rows(OrcChunkReader* reader) {
 }
 
 void check_schema(const std::string& path, const std::vector<std::pair<std::string, TypeDescriptor>>& expected_schema) {
-    OrcChunkReader reader;
+    OrcChunkReader reader{4096, {}};
+    reader.set_broker_load_mode(true);
     auto input_stream = orc::readLocalFile(path);
     reader.init(std::move(input_stream));
     std::vector<SlotDescriptor> schema;
@@ -2739,6 +2740,253 @@ TEST_F(OrcChunkReaderTest, TestSearchArgumentWithMatchedColumnName) {
         ASSERT_TRUE(st.ok()) << st.message();
         uint64_t records = get_hit_rows(&reader);
         EXPECT_EQ(records, 384);
+    }
+}
+
+/**
+ * struct<col1:int col2: struct<col3: int, col4: int>>
+ * {"col1":1, "col2": struct<"col3": 10001, "col4": 10002>}
+ * {"col1":2, "col2": struct<"col3": 10002, "col4": 10003>}
+ * {"col1":3, "col2": struct<"col3": 10003, "col4": 10004>}
+ * {"col1":4, "col2": struct<"col3": 10004, "col4": 10005>}
+ * .....
+ */
+TEST_F(OrcChunkReaderTest, TestColumnMismatched) {
+    MemoryOutputStream buffer(1024000);
+
+    {
+        // prepare data
+        orc::WriterOptions writerOptions;
+        // force to make stripe every time.
+        writerOptions.setStripeSize(128);
+        writerOptions.setRowIndexStride(128);
+        ORC_UNIQUE_PTR<orc::Type> schema(
+                orc::Type::buildTypeFromString("struct<col1:int,col2:struct<col3:int,col4:int>>"));
+        ORC_UNIQUE_PTR<orc::Writer> writer = createWriter(*schema, &buffer, writerOptions);
+
+        size_t batch_size = 128;
+        size_t batch_num = 3;
+        ORC_UNIQUE_PTR<orc::ColumnVectorBatch> batch = writer->createRowBatch(batch_size);
+        auto* root = dynamic_cast<orc::StructVectorBatch*>(batch.get());
+        auto* col1 = dynamic_cast<orc::LongVectorBatch*>(root->fields[0]);
+        auto* col2 = dynamic_cast<orc::StructVectorBatch*>(root->fields[1]);
+        auto* col3 = dynamic_cast<orc::LongVectorBatch*>(col2->fields[0]);
+        auto* col4 = dynamic_cast<orc::LongVectorBatch*>(col2->fields[1]);
+
+        size_t index = 1;
+        for (size_t k = 0; k < batch_num; k++) {
+            for (size_t i = 0; i < batch_size; i++) {
+                col1->data[i] = index;
+                col3->data[i] = 10000 + index;
+                col4->data[i] = 10000 + index + 1;
+                index += 1;
+            }
+            col1->numElements = batch_size;
+            col2->numElements = batch_size;
+            root->numElements = batch_size;
+            writer->add(*batch);
+        }
+        writer->close();
+    }
+
+    // test with struct subfield not matched
+    {
+        SlotDesc col1{"col1", TypeDescriptor::from_logical_type(LogicalType::TYPE_INT)};
+        TypeDescriptor col2_type = TypeDescriptor::from_logical_type(LogicalType::TYPE_STRUCT);
+        col2_type.field_names.emplace_back("none-existed");
+        col2_type.children.emplace_back(TypeDescriptor::from_logical_type(LogicalType::TYPE_INT));
+        SlotDesc col2{"col2", col2_type};
+
+        SlotDesc slot_descs[] = {col1, col2, {""}};
+        std::vector<SlotDescriptor*> src_slot_descriptors;
+        ObjectPool pool;
+        create_slot_descriptors(_runtime_state.get(), &pool, &src_slot_descriptors, slot_descs);
+
+        OrcChunkReader reader(_runtime_state->chunk_size(), src_slot_descriptors);
+        reader.set_use_orc_column_names(true);
+        auto input_stream =
+                ORC_UNIQUE_PTR<orc::InputStream>(new MemoryInputStream(buffer.getData(), buffer.getLength()));
+        Status st = reader.init(std::move(input_stream), nullptr);
+        ASSERT_FALSE(st.ok()) << st.message();
+    }
+
+    // test with struct subfield not matched, enable invalid_as_null
+    {
+        SlotDesc col1{"col1", TypeDescriptor::from_logical_type(LogicalType::TYPE_INT)};
+        TypeDescriptor col2_type = TypeDescriptor::from_logical_type(LogicalType::TYPE_STRUCT);
+        col2_type.field_names.emplace_back("none-existed");
+        col2_type.children.emplace_back(TypeDescriptor::from_logical_type(LogicalType::TYPE_INT));
+        SlotDesc col2{"col2", col2_type};
+
+        SlotDesc slot_descs[] = {col1, col2, {""}};
+        std::vector<SlotDescriptor*> src_slot_descriptors;
+        ObjectPool pool;
+        create_slot_descriptors(_runtime_state.get(), &pool, &src_slot_descriptors, slot_descs);
+
+        OrcChunkReader reader(_runtime_state->chunk_size(), src_slot_descriptors);
+        reader.set_invalid_as_null(true);
+        reader.set_use_orc_column_names(true);
+        auto input_stream =
+                ORC_UNIQUE_PTR<orc::InputStream>(new MemoryInputStream(buffer.getData(), buffer.getLength()));
+        Status st = reader.init(std::move(input_stream), nullptr);
+        ASSERT_FALSE(st.ok()) << st.message();
+    }
+
+    // test with col2 not matched, enable invalid_as_null
+    {
+        SlotDesc col1{"col1", TypeDescriptor::from_logical_type(LogicalType::TYPE_INT)};
+        TypeDescriptor col2_type = TypeDescriptor::from_logical_type(LogicalType::TYPE_STRUCT);
+        col2_type.field_names.emplace_back("none-existed");
+        col2_type.children.emplace_back(TypeDescriptor::from_logical_type(LogicalType::TYPE_INT));
+        SlotDesc col2{"none-existed", col2_type};
+
+        SlotDesc slot_descs[] = {col1, col2, {""}};
+        std::vector<SlotDescriptor*> src_slot_descriptors;
+        ObjectPool pool;
+        create_slot_descriptors(_runtime_state.get(), &pool, &src_slot_descriptors, slot_descs);
+
+        OrcChunkReader reader(_runtime_state->chunk_size(), src_slot_descriptors);
+        reader.set_invalid_as_null(true);
+        reader.set_use_orc_column_names(true);
+        auto input_stream =
+                ORC_UNIQUE_PTR<orc::InputStream>(new MemoryInputStream(buffer.getData(), buffer.getLength()));
+        Status st = reader.init(std::move(input_stream), nullptr);
+        ASSERT_TRUE(st.ok()) << st.message();
+
+        st = reader.read_next();
+        ChunkPtr ckptr = reader.create_chunk();
+        st = reader.fill_chunk(&ckptr);
+        ASSERT_TRUE(st.ok());
+        ChunkPtr result = reader.cast_chunk(&ckptr);
+        ASSERT_EQ("[1, NULL]", result->debug_row(0));
+        ASSERT_EQ("[2, NULL]", result->debug_row(1));
+    }
+
+    // test with col2 not matched, enable invalid_as_null, and test with search argument
+    {
+        SlotDesc col1{"col1", TypeDescriptor::from_logical_type(LogicalType::TYPE_INT)};
+        TypeDescriptor col2_type = TypeDescriptor::from_logical_type(LogicalType::TYPE_STRUCT);
+        col2_type.field_names.emplace_back("none-existed");
+        col2_type.children.emplace_back(TypeDescriptor::from_logical_type(LogicalType::TYPE_INT));
+        SlotDesc col2{"none-existed", col2_type};
+
+        SlotDesc slot_descs[] = {col1, col2, {""}};
+        std::vector<SlotDescriptor*> src_slot_descriptors;
+        ObjectPool pool;
+        create_slot_descriptors(_runtime_state.get(), &pool, &src_slot_descriptors, slot_descs);
+
+        TExprNode expr_node;
+        expr_node.type = gen_type_desc(TPrimitiveType::BOOLEAN);
+        expr_node.node_type = TExprNodeType::FUNCTION_CALL;
+        expr_node.fn.name.function_name = "is_null_pred";
+        expr_node.__isset.fn = true;
+        std::unique_ptr<Expr> expr(VectorizedIsNullPredicateFactory::from_thrift(expr_node));
+
+        TExprNode slot_ref;
+        slot_ref.node_type = TExprNodeType::SLOT_REF;
+        slot_ref.__set_type(create_primitive_type_desc(TPrimitiveType::TINYINT));
+        slot_ref.num_children = 0;
+        slot_ref.__isset.slot_ref = true;
+        slot_ref.slot_ref.slot_id = 2;
+        slot_ref.slot_ref.tuple_id = 0;
+        slot_ref.__set_is_nullable(true);
+        std::unique_ptr<ColumnRef> column_ref = std::make_unique<ColumnRef>(slot_ref);
+        expr->add_child(column_ref.get());
+        std::vector<Expr*> conjuncts = {expr.get()};
+        OrcPredicates predicates{&conjuncts, nullptr};
+
+        OrcChunkReader reader(_runtime_state->chunk_size(), src_slot_descriptors);
+        reader.set_invalid_as_null(true);
+        reader.set_use_orc_column_names(true);
+        auto input_stream =
+                ORC_UNIQUE_PTR<orc::InputStream>(new MemoryInputStream(buffer.getData(), buffer.getLength()));
+        Status st = reader.init(std::move(input_stream), &predicates);
+        ASSERT_TRUE(st.ok()) << st.message();
+
+        uint64_t records = get_hit_rows(&reader);
+        EXPECT_EQ(records, 384);
+    }
+
+    // test with col2 not matched, enable invalid_as_null, and test with search argument
+    {
+        SlotDesc col1{"col1", TypeDescriptor::from_logical_type(LogicalType::TYPE_INT)};
+        TypeDescriptor col2_type = TypeDescriptor::from_logical_type(LogicalType::TYPE_STRUCT);
+        col2_type.field_names.emplace_back("none-existed");
+        col2_type.children.emplace_back(TypeDescriptor::from_logical_type(LogicalType::TYPE_INT));
+        SlotDesc col2{"none-existed", col2_type};
+
+        SlotDesc slot_descs[] = {col1, col2, {""}};
+        std::vector<SlotDescriptor*> src_slot_descriptors;
+        ObjectPool pool;
+        create_slot_descriptors(_runtime_state.get(), &pool, &src_slot_descriptors, slot_descs);
+
+        TExprNode expr_node;
+        expr_node.type = gen_type_desc(TPrimitiveType::BOOLEAN);
+        expr_node.node_type = TExprNodeType::FUNCTION_CALL;
+        expr_node.fn.name.function_name = "is_not_null_pred";
+        expr_node.__isset.fn = true;
+        std::unique_ptr<Expr> expr(VectorizedIsNullPredicateFactory::from_thrift(expr_node));
+
+        TExprNode slot_ref;
+        slot_ref.node_type = TExprNodeType::SLOT_REF;
+        slot_ref.__set_type(create_primitive_type_desc(TPrimitiveType::TINYINT));
+        slot_ref.num_children = 0;
+        slot_ref.__isset.slot_ref = true;
+        slot_ref.slot_ref.slot_id = 2;
+        slot_ref.slot_ref.tuple_id = 0;
+        slot_ref.__set_is_nullable(true);
+        std::unique_ptr<ColumnRef> column_ref = std::make_unique<ColumnRef>(slot_ref);
+        expr->add_child(column_ref.get());
+        std::vector<Expr*> conjuncts = {expr.get()};
+        OrcPredicates predicates{&conjuncts, nullptr};
+
+        OrcChunkReader reader(_runtime_state->chunk_size(), src_slot_descriptors);
+        reader.set_invalid_as_null(true);
+        reader.set_use_orc_column_names(true);
+        auto input_stream =
+                ORC_UNIQUE_PTR<orc::InputStream>(new MemoryInputStream(buffer.getData(), buffer.getLength()));
+        Status st = reader.init(std::move(input_stream), &predicates);
+        ASSERT_TRUE(st.ok()) << st.message();
+
+        uint64_t records = get_hit_rows(&reader);
+        EXPECT_EQ(records, 384);
+        EXPECT_EQ("expr = YES_NO_NULL", reader.get_search_argument_string());
+    }
+
+    // test with col2, col1 reorderd, enable invalid_as_null, and test with search argument
+    {
+        TypeDescriptor col2_type = TypeDescriptor::from_logical_type(LogicalType::TYPE_STRUCT);
+        col2_type.field_names.emplace_back("col3");
+        col2_type.field_names.emplace_back("col4");
+        col2_type.children.emplace_back(TypeDescriptor::from_logical_type(LogicalType::TYPE_INT));
+        col2_type.children.emplace_back(TypeDescriptor::from_logical_type(LogicalType::TYPE_INT));
+        SlotDesc col2{"col2", col2_type};
+        SlotDesc col1{"col1", TypeDescriptor::from_logical_type(LogicalType::TYPE_INT)};
+
+        SlotDesc slot_descs[] = {col2, col1, {""}};
+        std::vector<SlotDescriptor*> src_slot_descriptors;
+        ObjectPool pool;
+        create_slot_descriptors(_runtime_state.get(), &pool, &src_slot_descriptors, slot_descs);
+
+        std::vector<TExprNode> nodes;
+        TExprNode lit_node = create_int_literal_node(TPrimitiveType::INT, 50);
+        push_binary_pred_texpr_node(nodes, TExprOpcode::type::EQ, src_slot_descriptors[1], TPrimitiveType::INT,
+                                    lit_node);
+        ExprContext* ctx = create_expr_context(&_pool, nodes);
+        std::vector<Expr*> conjuncts = {ctx->root()};
+        OrcPredicates predicates{&conjuncts, nullptr};
+
+        OrcChunkReader reader(_runtime_state->chunk_size(), src_slot_descriptors);
+        reader.set_invalid_as_null(true);
+        reader.set_use_orc_column_names(true);
+        auto input_stream =
+                ORC_UNIQUE_PTR<orc::InputStream>(new MemoryInputStream(buffer.getData(), buffer.getLength()));
+        Status st = reader.init(std::move(input_stream), &predicates);
+        ASSERT_TRUE(st.ok()) << st.message();
+
+        uint64_t records = get_hit_rows(&reader);
+        EXPECT_EQ(records, 128);
+        EXPECT_EQ("leaf-0 = (column(id=1) = 50), expr = leaf-0", reader.get_search_argument_string());
     }
 }
 

--- a/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
@@ -496,6 +496,10 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
 
     public static final String ENABLE_WAIT_DEPENDENT_EVENT = "enable_wait_dependent_event";
 
+    // Access ORC columns by name. By default, columns in ORC files are accessed by
+    // their ordinal position in the Hive table definition.
+    public static final String ORC_USE_COLUMN_NAMES = "orc_use_column_names";
+
     // Flag to control whether to proxy follower's query statement to leader/follower.
     public enum FollowerQueryForwardMode {
         DEFAULT,    // proxy queries by the follower's replay progress (default)
@@ -1916,6 +1920,9 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
 
     @VarAttr(name = ENABLE_PLAN_SERIALIZE_CONCURRENTLY)
     private boolean enablePlanSerializeConcurrently = true;
+
+    @VarAttr(name = ORC_USE_COLUMN_NAMES)
+    private boolean orcUseColumnNames = false;
 
     @VarAttr(name = FOLLOWER_QUERY_FORWARD_MODE, flag = VariableMgr.INVISIBLE | VariableMgr.DISABLE_FORWARD_TO_LEADER)
     private String followerForwardMode = "";
@@ -3638,6 +3645,7 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
         tResult.setEnable_result_sink_accumulate(enableResultSinkAccumulate);
         tResult.setEnable_wait_dependent_event(enableWaitDependentEvent);
         tResult.setConnector_max_split_size(connectorMaxSplitSize);
+        tResult.setOrc_use_column_names(orcUseColumnNames);
         return tResult;
     }
 

--- a/gensrc/thrift/InternalService.thrift
+++ b/gensrc/thrift/InternalService.thrift
@@ -283,6 +283,7 @@ struct TQueryOptions {
 
   130: optional bool enable_wait_dependent_event = false;
 
+  131: optional bool orc_use_column_names = false;
 }
 
 

--- a/test/sql/test_external_file/R/test_orc_use_column_names
+++ b/test/sql/test_external_file/R/test_orc_use_column_names
@@ -34,6 +34,15 @@ c	199994	None
 select * from test_orc_column where none_existed is not null;
 -- result:
 -- !result
+SELECT * FROM FILES(
+     "path" = "oss://${oss_bucket}/test_orc_use_column_names/${uuid0}/multi_stripes.orc",
+     "format" = "orc",
+     "aws.s3.access_key" = "${oss_ak}",
+     "aws.s3.secret_key" = "${oss_sk}",
+     "aws.s3.endpoint" = "${oss_endpoint}") where c0='199994';
+-- result:
+199994	c
+-- !result
 set orc_use_column_names = true;
 -- result:
 -- !result

--- a/test/sql/test_external_file/R/test_orc_use_column_names
+++ b/test/sql/test_external_file/R/test_orc_use_column_names
@@ -1,0 +1,51 @@
+-- name: testORCUseColumNames
+shell: ossutil64 mkdir oss://${oss_bucket}/test_orc_build_search_argument/${uuid0}/ >/dev/null || echo "exit 0" >/dev/null
+-- result:
+0
+
+-- !result
+shell: ossutil64 cp --force ../be/test/exec/test_data/orc_scanner/multi_stripes.orc oss://${oss_bucket}/test_orc_use_column_names/${uuid0}/multi_stripes.orc | grep -Pv "(average|elapsed)"
+-- result:
+0
+
+Succeed: Total num: 1, size: 4,070. OK num: 1(upload 1 files).
+-- !result
+CREATE EXTERNAL TABLE test_orc_column
+(
+    c1 string,
+    c0 string,
+    none_existed string
+)
+ENGINE=file
+PROPERTIES
+(
+    "path" = "oss://${oss_bucket}/test_orc_use_column_names/${uuid0}/",
+    "format" = "orc",
+    "aws.s3.access_key" = "${oss_ak}",
+    "aws.s3.secret_key" = "${oss_sk}",
+    "aws.s3.endpoint" = "${oss_endpoint}"
+);
+-- result:
+-- !result
+select * from test_orc_column where c0 = '199994';
+-- result:
+c	199994	None
+-- !result
+select * from test_orc_column where none_existed is not null;
+-- result:
+-- !result
+set orc_use_column_names = true;
+-- result:
+-- !result
+select * from test_orc_column where c0 = '199994';
+-- result:
+c	199994	None
+-- !result
+select * from test_orc_column where none_existed is not null;
+-- result:
+-- !result
+shell: ossutil64 rm -rf oss://${oss_bucket}/test_orc_use_column_names/${uuid0}/ >/dev/null || echo "exit 0" >/dev/null
+-- result:
+0
+
+-- !result

--- a/test/sql/test_external_file/T/test_orc_use_column_names
+++ b/test/sql/test_external_file/T/test_orc_use_column_names
@@ -22,6 +22,13 @@ PROPERTIES
 select * from test_orc_column where c0 = '199994';
 select * from test_orc_column where none_existed is not null;
 
+SELECT * FROM FILES(
+     "path" = "oss://${oss_bucket}/test_orc_use_column_names/${uuid0}/multi_stripes.orc",
+     "format" = "orc",
+     "aws.s3.access_key" = "${oss_ak}",
+     "aws.s3.secret_key" = "${oss_sk}",
+     "aws.s3.endpoint" = "${oss_endpoint}") where c0='199994';
+
 set orc_use_column_names = true;
 
 -- external file table always use orc column names

--- a/test/sql/test_external_file/T/test_orc_use_column_names
+++ b/test/sql/test_external_file/T/test_orc_use_column_names
@@ -1,0 +1,31 @@
+-- name: testORCUseColumNames
+
+shell: ossutil64 mkdir oss://${oss_bucket}/test_orc_build_search_argument/${uuid0}/ >/dev/null || echo "exit 0" >/dev/null
+shell: ossutil64 cp --force ../be/test/exec/test_data/orc_scanner/multi_stripes.orc oss://${oss_bucket}/test_orc_use_column_names/${uuid0}/multi_stripes.orc | grep -Pv "(average|elapsed)"
+
+CREATE EXTERNAL TABLE test_orc_column
+(
+    c1 string,
+    c0 string,
+    none_existed string
+)
+ENGINE=file
+PROPERTIES
+(
+    "path" = "oss://${oss_bucket}/test_orc_use_column_names/${uuid0}/",
+    "format" = "orc",
+    "aws.s3.access_key" = "${oss_ak}",
+    "aws.s3.secret_key" = "${oss_sk}",
+    "aws.s3.endpoint" = "${oss_endpoint}"
+);
+
+select * from test_orc_column where c0 = '199994';
+select * from test_orc_column where none_existed is not null;
+
+set orc_use_column_names = true;
+
+-- external file table always use orc column names
+select * from test_orc_column where c0 = '199994';
+select * from test_orc_column where none_existed is not null;
+
+shell: ossutil64 rm -rf oss://${oss_bucket}/test_orc_use_column_names/${uuid0}/ >/dev/null || echo "exit 0" >/dev/null


### PR DESCRIPTION
## Why I'm doing:
We only support to mapping orc column by position, but we need also support mapping by column name(Support Hive schema evolution).

## What I'm doing:
Support it by session variable.

If you want to mapping orc by column names, set `orc_use_column_names=true` in session variable.

## What type of PR is this:

- [ ] BugFix
- [x] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [x] 3.1
  - [ ] 3.0
  - [ ] 2.5
