### PR TITLE
[Enhancement] optimize lock of mv refresh for 2.5(backport #42637)

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/StatementPlanner.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/StatementPlanner.java
@@ -2,6 +2,7 @@
 package com.starrocks.sql;
 
 import com.google.common.base.Preconditions;
+import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
 import com.starrocks.catalog.Database;
 import com.starrocks.catalog.OlapTable;
@@ -246,17 +247,21 @@ public class StatementPlanner {
         if (dbs == null) {
             return;
         }
-        dbs.sort(Comparator.comparingLong(Database::getId));
-        for (Database db : dbs) {
-            db.readLock();
+        Map<Long, Database> dbMap = Maps.newTreeMap();
+        dbs.stream().forEach(db -> dbMap.put(db.getId(), db));
+        for (Map.Entry<Long, Database> entry : dbMap.entrySet()) {
+            entry.getValue().readLock();
         }
     }
     public static void unlockDatabases(Collection<Database> dbs) {
         if (dbs == null) {
             return;
         }
-        for (Database db : dbs) {
-            db.readUnlock();
+        // use TreeMap to remove duplicate and sort by db id
+        Map<Long, Database> dbMap = Maps.newTreeMap();
+        dbs.stream().forEach(db -> dbMap.put(db.getId(), db));
+        for (Map.Entry<Long, Database> entry : dbMap.entrySet()) {
+            entry.getValue().readUnlock();
         }
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/StatementPlanner.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/StatementPlanner.java
@@ -36,7 +36,6 @@ import com.starrocks.thrift.TResultSinkType;
 
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;

--- a/fe/fe-core/src/main/java/com/starrocks/sql/StatementPlanner.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/StatementPlanner.java
@@ -2,7 +2,6 @@
 package com.starrocks.sql;
 
 import com.google.common.base.Preconditions;
-import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
 import com.starrocks.catalog.Database;
 import com.starrocks.catalog.OlapTable;
@@ -36,6 +35,7 @@ import com.starrocks.thrift.TResultSinkType;
 
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -246,21 +246,17 @@ public class StatementPlanner {
         if (dbs == null) {
             return;
         }
-        Map<Long, Database> dbMap = Maps.newTreeMap();
-        dbs.stream().forEach(db -> dbMap.put(db.getId(), db));
-        for (Map.Entry<Long, Database> entry : dbMap.entrySet()) {
-            entry.getValue().readLock();
+        dbs.sort(Comparator.comparingLong(Database::getId));
+        for (Database db : dbs) {
+            db.readLock();
         }
     }
     public static void unlockDatabases(Collection<Database> dbs) {
         if (dbs == null) {
             return;
         }
-        // use TreeMap to remove duplicate and sort by db id
-        Map<Long, Database> dbMap = Maps.newTreeMap();
-        dbs.stream().forEach(db -> dbMap.put(db.getId(), db));
-        for (Map.Entry<Long, Database> entry : dbMap.entrySet()) {
-            entry.getValue().readUnlock();
+        for (Database db : dbs) {
+            db.readUnlock();
         }
     }
 

--- a/test/sql/test_materialized_view/R/test_mv_refresh
+++ b/test/sql/test_materialized_view/R/test_mv_refresh
@@ -1,0 +1,147 @@
+-- name: test_mv_refresh
+create database db_${uuid0};
+-- result:
+-- !result
+use db_${uuid0};
+-- result:
+-- !result
+function: prepare_data("ssb", "db_${uuid0}")
+-- result:
+None
+-- !result
+CREATE MATERIALIZED VIEW `lineorder_flat_mv1`
+DISTRIBUTED BY HASH(`LO_ORDERDATE`, `LO_ORDERKEY`) BUCKETS 48
+REFRESH MANUAL
+PROPERTIES (
+    "replication_num" = "1",
+    "storage_medium" = "HDD",
+    "force_external_table_query_rewrite" = "true"
+)
+AS
+SELECT `l`.`LO_ORDERKEY`,
+    `l`.`LO_ORDERDATE`,
+    `l`.`LO_LINENUMBER`,
+    `l`.`LO_CUSTKEY`,
+    `l`.`LO_PARTKEY`,
+    `l`.`LO_SUPPKEY`,
+    `l`.`LO_ORDERPRIORITY`,
+    `l`.`LO_SHIPPRIORITY`,
+    `l`.`LO_QUANTITY`,
+    `l`.`LO_EXTENDEDPRICE`,
+    `l`.`LO_ORDTOTALPRICE`,
+    `l`.`LO_DISCOUNT`,
+    `l`.`LO_REVENUE`,
+    `c`.`C_NAME`,
+    `c`.`C_ADDRESS`,
+    `c`.`C_CITY`,
+    `c`.`C_NATION`,
+    `c`.`C_REGION`,
+    `s`.`S_NAME`,
+    `s`.`S_ADDRESS`,
+    `s`.`S_CITY`,
+    `p`.`P_NAME`,
+    `p`.`P_MFGR`,
+    `p`.`P_CATEGORY`,
+    `p`.`P_BRAND`,
+    `p`.`P_COLOR`,
+    `d`.`D_DATE`,
+    `d`.`D_DAYOFWEEK`,
+    `d`.`D_MONTH`,
+    `d`.`D_YEAR`,
+    `d`.`D_YEARMONTHNUM`,
+    `d`.`D_YEARMONTH`,
+    `d`.`D_DAYNUMINWEEK`,
+    `d`.`D_DAYNUMINMONTH`,
+    `d`.`D_DAYNUMINYEAR`,
+    `d`.`D_MONTHNUMINYEAR`,
+    `d`.`D_WEEKNUMINYEAR`
+FROM db_${uuid0}.lineorder AS `l`
+INNER JOIN db_${uuid0}.customer AS `c` ON `l`.`LO_CUSTKEY` = `c`.`C_CUSTKEY`
+INNER JOIN db_${uuid0}.supplier AS `s` ON `l`.`LO_SUPPKEY` = `s`.`S_SUPPKEY`
+INNER JOIN db_${uuid0}.part AS `p` ON `l`.`LO_PARTKEY` = `p`.`P_PARTKEY`
+INNER JOIN db_${uuid0}.dates AS `d` ON `l`.`LO_ORDERDATE` = `d`.`D_DATEKEY`
+limit 100;
+-- result:
+-- !result
+refresh materialized view lineorder_flat_mv1 with sync mode;
+select count() from lineorder_flat_mv1;
+-- result:
+100
+-- !result
+create database db_${uuid1};
+-- result:
+-- !result
+use db_${uuid1};
+-- result:
+-- !result
+create table customer as select * from db_${uuid0}.`customer`;
+-- result:
+-- !result
+create table supplier as select * from db_${uuid0}.`supplier`;
+-- result:
+-- !result
+CREATE MATERIALIZED VIEW `lineorder_flat_mv2`
+DISTRIBUTED BY HASH(`LO_ORDERDATE`, `LO_ORDERKEY`) BUCKETS 48
+REFRESH MANUAL
+PROPERTIES (
+    "replication_num" = "1",
+    "storage_medium" = "HDD",
+    "force_external_table_query_rewrite" = "true"
+)
+AS
+SELECT `l`.`LO_ORDERKEY`,
+    `l`.`LO_ORDERDATE`,
+    `l`.`LO_LINENUMBER`,
+    `l`.`LO_CUSTKEY`,
+    `l`.`LO_PARTKEY`,
+    `l`.`LO_SUPPKEY`,
+    `l`.`LO_ORDERPRIORITY`,
+    `l`.`LO_SHIPPRIORITY`,
+    `l`.`LO_QUANTITY`,
+    `l`.`LO_EXTENDEDPRICE`,
+    `l`.`LO_ORDTOTALPRICE`,
+    `l`.`LO_DISCOUNT`,
+    `l`.`LO_REVENUE`,
+    `c`.`C_NAME`,
+    `c`.`C_ADDRESS`,
+    `c`.`C_CITY`,
+    `c`.`C_NATION`,
+    `c`.`C_REGION`,
+    `s`.`S_NAME`,
+    `s`.`S_ADDRESS`,
+    `s`.`S_CITY`,
+    `p`.`P_NAME`,
+    `p`.`P_MFGR`,
+    `p`.`P_CATEGORY`,
+    `p`.`P_BRAND`,
+    `p`.`P_COLOR`,
+    `d`.`D_DATE`,
+    `d`.`D_DAYOFWEEK`,
+    `d`.`D_MONTH`,
+    `d`.`D_YEAR`,
+    `d`.`D_YEARMONTHNUM`,
+    `d`.`D_YEARMONTH`,
+    `d`.`D_DAYNUMINWEEK`,
+    `d`.`D_DAYNUMINMONTH`,
+    `d`.`D_DAYNUMINYEAR`,
+    `d`.`D_MONTHNUMINYEAR`,
+    `d`.`D_WEEKNUMINYEAR`
+FROM db_${uuid0}.lineorder AS `l`
+INNER JOIN db_${uuid1}.customer AS `c` ON `l`.`LO_CUSTKEY` = `c`.`C_CUSTKEY`
+INNER JOIN db_${uuid1}.supplier AS `s` ON `l`.`LO_SUPPKEY` = `s`.`S_SUPPKEY`
+INNER JOIN db_${uuid0}.part AS `p` ON `l`.`LO_PARTKEY` = `p`.`P_PARTKEY`
+INNER JOIN db_${uuid0}.dates AS `d` ON `l`.`LO_ORDERDATE` = `d`.`D_DATEKEY`
+limit 100;
+-- result:
+-- !result
+refresh materialized view lineorder_flat_mv2 with sync mode;
+select count() from lineorder_flat_mv2;
+-- result:
+100
+-- !result
+drop database db_${uuid0} force;
+-- result:
+-- !result
+drop database db_${uuid1} force;
+-- result:
+-- !result

--- a/test/sql/test_materialized_view/T/test_mv_refresh
+++ b/test/sql/test_materialized_view/T/test_mv_refresh
@@ -1,0 +1,129 @@
+-- name: test_mv_refresh
+
+create database db_${uuid0};
+use db_${uuid0};
+function: prepare_data("ssb", "db_${uuid0}")
+
+
+CREATE MATERIALIZED VIEW `lineorder_flat_mv1`
+DISTRIBUTED BY HASH(`LO_ORDERDATE`, `LO_ORDERKEY`) BUCKETS 48
+REFRESH MANUAL
+PROPERTIES (
+    "replication_num" = "1",
+    "storage_medium" = "HDD",
+    "force_external_table_query_rewrite" = "true"
+)
+AS
+SELECT `l`.`LO_ORDERKEY`,
+    `l`.`LO_ORDERDATE`,
+    `l`.`LO_LINENUMBER`,
+    `l`.`LO_CUSTKEY`,
+    `l`.`LO_PARTKEY`,
+    `l`.`LO_SUPPKEY`,
+    `l`.`LO_ORDERPRIORITY`,
+    `l`.`LO_SHIPPRIORITY`,
+    `l`.`LO_QUANTITY`,
+    `l`.`LO_EXTENDEDPRICE`,
+    `l`.`LO_ORDTOTALPRICE`,
+    `l`.`LO_DISCOUNT`,
+    `l`.`LO_REVENUE`,
+    `c`.`C_NAME`,
+    `c`.`C_ADDRESS`,
+    `c`.`C_CITY`,
+    `c`.`C_NATION`,
+    `c`.`C_REGION`,
+    `s`.`S_NAME`,
+    `s`.`S_ADDRESS`,
+    `s`.`S_CITY`,
+    `p`.`P_NAME`,
+    `p`.`P_MFGR`,
+    `p`.`P_CATEGORY`,
+    `p`.`P_BRAND`,
+    `p`.`P_COLOR`,
+    `d`.`D_DATE`,
+    `d`.`D_DAYOFWEEK`,
+    `d`.`D_MONTH`,
+    `d`.`D_YEAR`,
+    `d`.`D_YEARMONTHNUM`,
+    `d`.`D_YEARMONTH`,
+    `d`.`D_DAYNUMINWEEK`,
+    `d`.`D_DAYNUMINMONTH`,
+    `d`.`D_DAYNUMINYEAR`,
+    `d`.`D_MONTHNUMINYEAR`,
+    `d`.`D_WEEKNUMINYEAR`
+FROM db_${uuid0}.lineorder AS `l`
+INNER JOIN db_${uuid0}.customer AS `c` ON `l`.`LO_CUSTKEY` = `c`.`C_CUSTKEY`
+INNER JOIN db_${uuid0}.supplier AS `s` ON `l`.`LO_SUPPKEY` = `s`.`S_SUPPKEY`
+INNER JOIN db_${uuid0}.part AS `p` ON `l`.`LO_PARTKEY` = `p`.`P_PARTKEY`
+INNER JOIN db_${uuid0}.dates AS `d` ON `l`.`LO_ORDERDATE` = `d`.`D_DATEKEY`
+limit 100;
+
+refresh materialized view lineorder_flat_mv1 with sync mode;
+
+select count() from lineorder_flat_mv1;
+
+create database db_${uuid1};
+use db_${uuid1};
+create table customer as select * from db_${uuid0}.`customer`;
+create table supplier as select * from db_${uuid0}.`supplier`;
+
+
+CREATE MATERIALIZED VIEW `lineorder_flat_mv2`
+DISTRIBUTED BY HASH(`LO_ORDERDATE`, `LO_ORDERKEY`) BUCKETS 48
+REFRESH MANUAL
+PROPERTIES (
+    "replication_num" = "1",
+    "storage_medium" = "HDD",
+    "force_external_table_query_rewrite" = "true"
+)
+AS
+SELECT `l`.`LO_ORDERKEY`,
+    `l`.`LO_ORDERDATE`,
+    `l`.`LO_LINENUMBER`,
+    `l`.`LO_CUSTKEY`,
+    `l`.`LO_PARTKEY`,
+    `l`.`LO_SUPPKEY`,
+    `l`.`LO_ORDERPRIORITY`,
+    `l`.`LO_SHIPPRIORITY`,
+    `l`.`LO_QUANTITY`,
+    `l`.`LO_EXTENDEDPRICE`,
+    `l`.`LO_ORDTOTALPRICE`,
+    `l`.`LO_DISCOUNT`,
+    `l`.`LO_REVENUE`,
+    `c`.`C_NAME`,
+    `c`.`C_ADDRESS`,
+    `c`.`C_CITY`,
+    `c`.`C_NATION`,
+    `c`.`C_REGION`,
+    `s`.`S_NAME`,
+    `s`.`S_ADDRESS`,
+    `s`.`S_CITY`,
+    `p`.`P_NAME`,
+    `p`.`P_MFGR`,
+    `p`.`P_CATEGORY`,
+    `p`.`P_BRAND`,
+    `p`.`P_COLOR`,
+    `d`.`D_DATE`,
+    `d`.`D_DAYOFWEEK`,
+    `d`.`D_MONTH`,
+    `d`.`D_YEAR`,
+    `d`.`D_YEARMONTHNUM`,
+    `d`.`D_YEARMONTH`,
+    `d`.`D_DAYNUMINWEEK`,
+    `d`.`D_DAYNUMINMONTH`,
+    `d`.`D_DAYNUMINYEAR`,
+    `d`.`D_MONTHNUMINYEAR`,
+    `d`.`D_WEEKNUMINYEAR`
+FROM db_${uuid0}.lineorder AS `l`
+INNER JOIN db_${uuid1}.customer AS `c` ON `l`.`LO_CUSTKEY` = `c`.`C_CUSTKEY`
+INNER JOIN db_${uuid1}.supplier AS `s` ON `l`.`LO_SUPPKEY` = `s`.`S_SUPPKEY`
+INNER JOIN db_${uuid0}.part AS `p` ON `l`.`LO_PARTKEY` = `p`.`P_PARTKEY`
+INNER JOIN db_${uuid0}.dates AS `d` ON `l`.`LO_ORDERDATE` = `d`.`D_DATEKEY`
+limit 100;
+
+refresh materialized view lineorder_flat_mv2 with sync mode;
+
+select count() from lineorder_flat_mv2;
+
+drop database db_${uuid0} force;
+drop database db_${uuid1} force;


### PR DESCRIPTION
## Why I'm doing:
the lock sequence may lead to deadlock.

## What I'm doing:
acquire db locks by sequence to avoid deadlock.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [x] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5

