### PR TITLE
[BugFix] fix es can not read `nested` type field

### DIFF
--- a/be/src/exec/es/es_scroll_parser.cpp
+++ b/be/src/exec/es/es_scroll_parser.cpp
@@ -277,7 +277,7 @@ Status ScrollParser::fill_chunk(RuntimeState* state, ChunkPtr* chunk, bool* line
 }
 
 void ScrollParser::set_params(const TupleDescriptor* descs, const std::map<std::string, std::string>* docvalue_context,
-                              std::string& timezone) {
+                              const std::string& timezone) {
     _tuple_desc = descs;
     _doc_value_context = docvalue_context;
     _timezone = timezone;

--- a/be/src/exec/es/es_scroll_parser.cpp
+++ b/be/src/exec/es/es_scroll_parser.cpp
@@ -579,8 +579,8 @@ Status ScrollParser::_append_json_val(const rapidjson::Value& col, const TypeDes
                                       bool pure_doc_value) {
     std::string s = json_value_to_string(col);
     Slice slice{s};
-    if (!col.IsObject()) {
-        return Status::InternalError("col: " + slice.to_string() + " is not an object");
+    if (!col.IsObject() && !col.IsArray()) {
+        return Status::InternalError("col: " + slice.to_string() + " is not an object/array");
     }
     ASSIGN_OR_RETURN(JsonValue json, JsonValue::parse_json_or_string(slice));
     JsonValue* tmp = &json;

--- a/be/src/exec/es/es_scroll_parser.h
+++ b/be/src/exec/es/es_scroll_parser.h
@@ -41,7 +41,7 @@ public:
     bool current_eos() { return _cur_line == _size; }
 
     void set_params(const TupleDescriptor* descs, const std::map<std::string, std::string>* docvalue_context,
-                    std::string& timezone);
+                    const std::string& timezone);
 
 private:
     static bool _is_pure_doc_value(const rapidjson::Value& obj);

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/EsTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/EsTable.java
@@ -203,6 +203,9 @@ public class EsTable extends Table implements GsonPostProcessable {
         }
         hosts = properties.get(KEY_HOSTS).trim();
         seeds = hosts.split(",");
+        for (int i = 0; i < seeds.length; i++) {
+            seeds[i] = seeds[i].trim();
+        }
         for (String seed : seeds) {
             if (!seed.startsWith("http://") && !seed.startsWith("https://")) {
                 throw new DdlException("Host of ES table should start with 'http:// or 'https://'. Current value is " + seed);

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/EsTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/EsTable.java
@@ -124,7 +124,8 @@ public class EsTable extends Table implements GsonPostProcessable {
     // Instead,  the (almost) surprising thing is that, by returning less than 20 fields,
     // DocValues performs better than stored fields and the difference gets little as the number of fields returned increases.
     // Asking for 9 DocValues fields and 1 stored field takes an average query time is 6.86 (more than returning 10 stored fields)
-    // Here we have a slightly conservative value of 20, but at the same time we also provide configurable parameters for expert-using
+    // Here we have a slightly conservative value of 20, but at the same time we also provide configurable parameters for
+    // expert-using
     // @see `MAX_DOCVALUE_FIELDS`
     private static final int DEFAULT_MAX_DOCVALUE_FIELDS = 20;
 
@@ -202,6 +203,11 @@ public class EsTable extends Table implements GsonPostProcessable {
         }
         hosts = properties.get(KEY_HOSTS).trim();
         seeds = hosts.split(",");
+        for (String seed : seeds) {
+            if (!seed.startsWith("http://") && !seed.startsWith("https://")) {
+                throw new DdlException("Host of ES table should start with 'http:// or 'https://'. Current value is " + seed);
+            }
+        }
 
         if (!Strings.isNullOrEmpty(properties.get(KEY_USER))
                 && !Strings.isNullOrEmpty(properties.get(KEY_USER).trim())) {

--- a/fe/fe-core/src/main/java/com/starrocks/connector/elasticsearch/EsUtil.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/elasticsearch/EsUtil.java
@@ -164,11 +164,12 @@ public class EsUtil {
             //TODO
             case "date":
                 return Type.DATETIME;
+            case "nested":
+            case "object":
+                return Type.JSON;
             case "keyword":
             case "text":
             case "ip":
-            case "nested":
-            case "object":
             default:
                 return ScalarType.createDefaultCatalogString();
         }

--- a/fe/fe-core/src/test/java/com/starrocks/catalog/GlobalStateMgrTestUtil.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/GlobalStateMgrTestUtil.java
@@ -253,7 +253,7 @@ public class GlobalStateMgrTestUtil {
 
         RangePartitionInfo partitionInfo = new RangePartitionInfo(partitionColumns);
         Map<String, String> properties = Maps.newHashMap();
-        properties.put(EsTable.KEY_HOSTS, "xxx");
+        properties.put(EsTable.KEY_HOSTS, "http://127.0.0.1:9200");
         properties.put(EsTable.KEY_INDEX, "doe");
         properties.put(EsTable.KEY_TYPE, "doc");
         properties.put(EsTable.KEY_PASSWORD, "");

--- a/fe/fe-core/src/test/java/com/starrocks/catalog/GlobalStateMgrTestUtil.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/GlobalStateMgrTestUtil.java
@@ -253,7 +253,7 @@ public class GlobalStateMgrTestUtil {
 
         RangePartitionInfo partitionInfo = new RangePartitionInfo(partitionColumns);
         Map<String, String> properties = Maps.newHashMap();
-        properties.put(EsTable.KEY_HOSTS, "http://127.0.0.1:9200");
+        properties.put(EsTable.KEY_HOSTS, "http://xxx");
         properties.put(EsTable.KEY_INDEX, "doe");
         properties.put(EsTable.KEY_TYPE, "doc");
         properties.put(EsTable.KEY_PASSWORD, "");

--- a/fe/fe-core/src/test/java/com/starrocks/connector/elasticsearch/EsTestCase.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/elasticsearch/EsTestCase.java
@@ -87,7 +87,7 @@ public class EsTestCase {
 
     public EsTable fakeEsTable(String table, String index, String type, List<Column> columns) throws DdlException {
         Map<String, String> props = new HashMap<>();
-        props.put(EsTable.KEY_HOSTS, "127.0.0.1:8200");
+        props.put(EsTable.KEY_HOSTS, "http://127.0.0.1:8200");
         props.put(EsTable.KEY_INDEX, index);
         props.put(EsTable.KEY_TYPE, type);
         props.put(EsTable.KEY_VERSION, "6.5.3");

--- a/fe/fe-core/src/test/java/com/starrocks/connector/elasticsearch/EsTestCase.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/elasticsearch/EsTestCase.java
@@ -92,6 +92,7 @@ public class EsTestCase {
         props.put(EsTable.KEY_TYPE, type);
         props.put(EsTable.KEY_VERSION, "6.5.3");
         return new EsTable(new Random().nextLong(), table, columns, props, null);
-
     }
+
+
 }

--- a/fe/fe-core/src/test/java/com/starrocks/connector/elasticsearch/EsUtilTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/elasticsearch/EsUtilTest.java
@@ -17,8 +17,14 @@
 
 package com.starrocks.connector.elasticsearch;
 
+import com.starrocks.catalog.Column;
+import com.starrocks.common.AnalysisException;
+import mockit.Expectations;
+import mockit.Injectable;
 import org.json.JSONObject;
 import org.junit.Test;
+
+import java.util.List;
 
 import static com.starrocks.connector.elasticsearch.EsUtil.getFromJSONArray;
 import static org.junit.Assert.assertEquals;
@@ -95,5 +101,4 @@ public class EsUtilTest {
         EsRestClient.EsIndex[] esIndices = getFromJSONArray(jsonArray, EsRestClient.EsIndex[].class);
         System.out.println(JSONObject.valueToString(esIndices));
     }
-
 }

--- a/fe/fe-core/src/test/java/com/starrocks/connector/elasticsearch/EsUtilTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/elasticsearch/EsUtilTest.java
@@ -17,14 +17,8 @@
 
 package com.starrocks.connector.elasticsearch;
 
-import com.starrocks.catalog.Column;
-import com.starrocks.common.AnalysisException;
-import mockit.Expectations;
-import mockit.Injectable;
 import org.json.JSONObject;
 import org.junit.Test;
-
-import java.util.List;
 
 import static com.starrocks.connector.elasticsearch.EsUtil.getFromJSONArray;
 import static org.junit.Assert.assertEquals;

--- a/fe/fe-core/src/test/java/com/starrocks/connector/elasticsearch/MappingPhaseTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/elasticsearch/MappingPhaseTest.java
@@ -37,6 +37,8 @@ package com.starrocks.connector.elasticsearch;
 import com.starrocks.catalog.Column;
 import com.starrocks.catalog.EsTable;
 import com.starrocks.catalog.Type;
+import com.starrocks.common.AnalysisException;
+import com.starrocks.common.DdlException;
 import com.starrocks.common.ExceptionChecker;
 import com.starrocks.connector.exception.StarRocksConnectorException;
 import mockit.Expectations;
@@ -44,8 +46,13 @@ import mockit.Injectable;
 import org.junit.Before;
 import org.junit.Test;
 
+import java.io.IOException;
+import java.net.URISyntaxException;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
+import java.util.Random;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -127,6 +134,34 @@ public class MappingPhaseTest extends EsTestCase {
         mappingPhase
                 .resolveFields(searchContext, loadJsonFromFile("data/es/test_index_mapping_field_mult_analyzer.json"));
         assertFalse(searchContext.docValueFieldsContext().containsKey("k3"));
+    }
 
+    @Test(expected = DdlException.class)
+    public void testBadHostsConfig() throws DdlException {
+        Map<String, String> props = new HashMap<>();
+        props.put(EsTable.KEY_HOSTS, "127.0.0.1:8200");
+        props.put(EsTable.KEY_INDEX, "test");
+        props.put(EsTable.KEY_TYPE, "_doc");
+        props.put(EsTable.KEY_VERSION, "6.5.3");
+        EsTable t = new EsTable(new Random().nextLong(), "fake", columns, props, null);
+    }
+
+    @Test
+    public void testNestedObjectColumnTypeMapping(@Injectable EsRestClient client)
+            throws AnalysisException, IOException, URISyntaxException {
+        String jsonMapping = loadJsonFromFile("data/es/nested_object_mapping.json");
+        new Expectations(client) {
+            {
+                client.getMapping(anyString);
+                minTimes = 0;
+                result = jsonMapping;
+            }
+        };
+        List<Column> columns = EsUtil.convertColumnSchema(client, "xxx");
+        for (Column c : columns) {
+            if (c.getName().equals("contactData")) {
+                assertEquals(c.getType(), Type.JSON);
+            }
+        }
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/connector/elasticsearch/MappingPhaseTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/elasticsearch/MappingPhaseTest.java
@@ -43,6 +43,7 @@ import com.starrocks.common.ExceptionChecker;
 import com.starrocks.connector.exception.StarRocksConnectorException;
 import mockit.Expectations;
 import mockit.Injectable;
+import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -136,14 +137,26 @@ public class MappingPhaseTest extends EsTestCase {
         assertFalse(searchContext.docValueFieldsContext().containsKey("k3"));
     }
 
-    @Test(expected = DdlException.class)
-    public void testBadHostsConfig() throws DdlException {
-        Map<String, String> props = new HashMap<>();
-        props.put(EsTable.KEY_HOSTS, "127.0.0.1:8200");
-        props.put(EsTable.KEY_INDEX, "test");
-        props.put(EsTable.KEY_TYPE, "_doc");
-        props.put(EsTable.KEY_VERSION, "6.5.3");
-        EsTable t = new EsTable(new Random().nextLong(), "fake", columns, props, null);
+    @Test
+    public void testEsTableConfig() throws DdlException {
+        {
+            Map<String, String> props = new HashMap<>();
+            props.put(EsTable.KEY_HOSTS, "127.0.0.1:8200");
+            props.put(EsTable.KEY_INDEX, "test");
+            props.put(EsTable.KEY_TYPE, "_doc");
+            props.put(EsTable.KEY_VERSION, "6.5.3");
+            Assert.assertThrows(DdlException.class, () -> {
+                EsTable t = new EsTable(new Random().nextLong(), "fake", columns, props, null);
+            });
+        }
+        {
+            Map<String, String> props = new HashMap<>();
+            props.put(EsTable.KEY_HOSTS, "http://127.0.0.1:8200, https://127.0.0.1:443");
+            props.put(EsTable.KEY_INDEX, "test");
+            props.put(EsTable.KEY_TYPE, "_doc");
+            props.put(EsTable.KEY_VERSION, "6.5.3");
+            EsTable t = new EsTable(new Random().nextLong(), "fake", columns, props, null);
+        }
     }
 
     @Test

--- a/fe/fe-core/src/test/resources/data/es/nested_object_mapping.json
+++ b/fe/fe-core/src/test/resources/data/es/nested_object_mapping.json
@@ -1,0 +1,58 @@
+{
+  "xxx": {
+    "mappings": {
+      "event": {
+        "_all": {
+          "enabled": true
+        },
+        "properties": {
+          "contactData": {
+            "type": "nested",
+            "properties": {
+              "contactType": {
+                "type": "text",
+                "fields": {
+                  "keyword": {
+                    "type": "keyword",
+                    "ignore_above": 256
+                  }
+                }
+              },
+              "emailAddress": {
+                "type": "text",
+                "analyzer": "emailAnalyzer"
+              },
+              "firstName": {
+                "type": "text",
+                "fields": {
+                  "keyword": {
+                    "type": "keyword",
+                    "ignore_above": 256
+                  }
+                }
+              },
+              "lastName": {
+                "type": "text",
+                "fields": {
+                  "keyword": {
+                    "type": "keyword",
+                    "ignore_above": 256
+                  }
+                }
+              },
+              "phoneNumber": {
+                "type": "text",
+                "fields": {
+                  "keyword": {
+                    "type": "keyword",
+                    "ignore_above": 256
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Why I'm doing:

Right now sr can not read es table which has `nested` type field, because it's mapped to string type.

## What I'm doing:

Map `nested` and `object` type field to json type. So user can read it out and parse data to json to do more analysis.

Plus, right now we assume `es.hosts` starts with http:// or https://, but we don't check it. So better to check it in validation function.

<img width="612" alt="Pasted Graphic 2" src="https://github.com/StarRocks/starrocks/assets/1081215/4b00dfa5-bcc2-4db1-b225-673c179af11b">

Fixes https://github.com/StarRocks/starrocks/issues/42816

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [x] 3.1
  - [ ] 3.0
  - [ ] 2.5
