### PR TITLE
[Feature] add be config brpc_connection_type

### DIFF
--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -615,6 +615,8 @@ CONF_mInt32(tablet_meta_checkpoint_min_interval_secs, "600");
 CONF_Int64(brpc_max_body_size, "2147483648");
 // Max unwritten bytes in each socket, if the limit is reached, Socket.Write fails with EOVERCROWDED.
 CONF_Int64(brpc_socket_max_unwritten_bytes, "1073741824");
+// brpc connection types, "single", "pooled", "short".
+CONF_String_enum(brpc_connection_type, "single", "single,pooled,short");
 
 // Max number of txns for every txn_partition_map in txn manager.
 // this is a self-protection to avoid too many txns saving in manager.

--- a/be/src/common/configbase.h
+++ b/be/src/common/configbase.h
@@ -22,6 +22,7 @@
 
 #include <iostream>
 #include <map>
+#include <set>
 #include <string>
 #include <vector>
 
@@ -165,7 +166,7 @@ template <typename T, typename = void>
 class FieldImpl;
 
 template <typename T>
-class FieldImpl<T> final : public Field {
+class FieldImpl<T> : public Field {
 public:
     FieldImpl(const char* type, const char* name, void* storage, const char* defval, bool valmutable)
             : Field(type, name, storage, defval, valmutable) {}
@@ -177,7 +178,7 @@ public:
 
 //// FieldImpl<std::vector<T>>
 template <typename T>
-class FieldImpl<std::vector<T>> final : public Field {
+class FieldImpl<std::vector<T>> : public Field {
 public:
     FieldImpl(const char* type, const char* name, void* storage, const char* defval, bool valmutable)
             : Field(type, name, storage, defval, valmutable) {}
@@ -221,6 +222,39 @@ public:
     }
 };
 
+template <typename T>
+class EnumField : public FieldImpl<T> {
+    using Base = FieldImpl<T>;
+
+public:
+    EnumField(const char* type, const char* name, void* storage, const char* defval, bool valmutable,
+              std::string enums_)
+            : FieldImpl<T>(type, name, storage, defval, valmutable), raw_enum_values(std::move(enums_)) {}
+
+    bool parse_value(const std::string& valstr) override {
+        if (enums.empty()) {
+            std::vector<std::string> parts = strings::Split(raw_enum_values, ",");
+            for (auto& part : parts) {
+                StripWhiteSpace(&part);
+                if (!Base::parse_value(part)) {
+                    return false;
+                }
+                auto v = *reinterpret_cast<T*>(Field::_storage);
+                enums.emplace(std::move(v));
+            }
+        }
+        if (!Base::parse_value(valstr)) {
+            return false;
+        }
+        auto value = *reinterpret_cast<T*>(Field::_storage);
+        return enums.find(value) != enums.end();
+    }
+
+private:
+    std::set<T> enums;
+    std::string raw_enum_values;
+};
+
 #endif // __IN_CONFIGBASE_CPP__
 
 #define DEFINE_FIELD(FIELD_TYPE, FIELD_NAME, FIELD_DEFAULT, VALMUTABLE, TYPE_NAME) \
@@ -231,6 +265,11 @@ public:
 
 #define DECLARE_FIELD(FIELD_TYPE, FIELD_NAME) extern FIELD_TYPE FIELD_NAME;
 
+#define DEFINE_ENUM_FIELD(FIELD_TYPE, FIELD_NAME, FIELD_DEFAULT, VALMUTABLE, TYPE_NAME, ENUM_SET)                   \
+    FIELD_TYPE FIELD_NAME;                                                                                          \
+    static EnumField<FIELD_TYPE> field_##FIELD_NAME(TYPE_NAME, #FIELD_NAME, &FIELD_NAME, FIELD_DEFAULT, VALMUTABLE, \
+                                                    ENUM_SET);
+
 #ifdef __IN_CONFIGBASE_CPP__
 // NOTE: alias configs must be defined after the true config, otherwise there will be a compile error
 #define CONF_Alias(name, alias) DEFINE_ALIAS(name, alias)
@@ -240,6 +279,8 @@ public:
 #define CONF_Int64(name, defaultstr) DEFINE_FIELD(int64_t, name, defaultstr, false, "int64")
 #define CONF_Double(name, defaultstr) DEFINE_FIELD(double, name, defaultstr, false, "double")
 #define CONF_String(name, defaultstr) DEFINE_FIELD(std::string, name, defaultstr, false, "string")
+#define CONF_String_enum(name, defaultstr, enums) \
+    DEFINE_ENUM_FIELD(std::string, name, defaultstr, false, "string", enums)
 #define CONF_Bools(name, defaultstr) DEFINE_FIELD(std::vector<bool>, name, defaultstr, false, "list<bool>")
 #define CONF_Int16s(name, defaultstr) DEFINE_FIELD(std::vector<int16_t>, name, defaultstr, false, "list<int16>")
 #define CONF_Int32s(name, defaultstr) DEFINE_FIELD(std::vector<int32_t>, name, defaultstr, false, "list<int32>")
@@ -261,6 +302,7 @@ public:
 #define CONF_Int64(name, defaultstr) DECLARE_FIELD(int64_t, name)
 #define CONF_Double(name, defaultstr) DECLARE_FIELD(double, name)
 #define CONF_String(name, defaultstr) DECLARE_FIELD(std::string, name)
+#define CONF_String_enum(name, defaultstr, enums) DECLARE_FIELD(std::string, name)
 #define CONF_Bools(name, defaultstr) DECLARE_FIELD(std::vector<bool>, name)
 #define CONF_Int16s(name, defaultstr) DECLARE_FIELD(std::vector<int16_t>, name)
 #define CONF_Int32s(name, defaultstr) DECLARE_FIELD(std::vector<int32_t>, name)

--- a/be/src/util/brpc_stub_cache.h
+++ b/be/src/util/brpc_stub_cache.h
@@ -121,6 +121,7 @@ private:
                 // all requests are sent on this connection and the throughput will be limited by this.
                 // we use `connection_group` to create multiple single connections to remove this bottleneck.
                 options.connection_group = std::to_string(_stubs.size());
+                options.connection_type = config::brpc_connection_type;
                 std::unique_ptr<brpc::Channel> channel(new brpc::Channel());
                 if (channel->Init(endpoint, &options)) {
                     return nullptr;

--- a/be/test/common/config_test.cpp
+++ b/be/test/common/config_test.cpp
@@ -58,6 +58,7 @@ TEST_F(ConfigTest, test_init) {
     CONF_Strings(cfg_strings, "s1,s2,s3");
     CONF_String(cfg_string_env, "prefix/${ConfigTestEnv1}/suffix");
     CONF_Bool(cfg_bool_env, "false");
+    CONF_String_enum(cfg_string_enum, "true", "true,false");
     // Invalid config file name
     { EXPECT_FALSE(config::init("/path/to/nonexist/file")); }
     // Invalid bool value
@@ -88,6 +89,14 @@ TEST_F(ConfigTest, test_init) {
 
         EXPECT_FALSE(config::init(ss));
     }
+    // Invalid enum value
+    {
+        std::stringstream ss;
+        ss << R"DEL(
+           cfg_string_enum = unknown
+           )DEL";
+        EXPECT_FALSE(config::init(ss));
+    }
 
     // Valid input
     {
@@ -111,6 +120,8 @@ TEST_F(ConfigTest, test_init) {
            cfg_strings = text1, hello world , StarRocks
            
            cfg_bool_env = ${ConfigTestEnv2}
+
+           cfg_string_enum = false
            )DEL";
 
         ASSERT_EQ(0, ::setenv("ConfigTestEnv1", "env1_value", 1));
@@ -137,6 +148,7 @@ TEST_F(ConfigTest, test_init) {
     EXPECT_THAT(cfg_strings, ElementsAre("text1", "hello world", "StarRocks"));
     EXPECT_EQ("prefix/env1_value/suffix", cfg_string_env);
     EXPECT_EQ(true, cfg_bool_env);
+    EXPECT_EQ("false", cfg_string_enum);
 }
 
 TEST_F(ConfigTest, test_invalid_default_value) {


### PR DESCRIPTION
## Why I'm doing:
The single connection type may be problematic in some scenarios. (network not fully utilized, rpc queue stuck), we introduce config to modify the connection type.
## What I'm doing:
default connection type is single. add connection type will help troubleshoot network problems.

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [x] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [x] 3.1
  - [ ] 3.0
  - [ ] 2.5
