### PR TITLE
[BugFix] Fix shutdown tablet meta leak cause migration fail.

### DIFF
--- a/be/src/storage/tablet_manager.cpp
+++ b/be/src/storage/tablet_manager.cpp
@@ -1775,8 +1775,7 @@ void TabletManager::_add_shutdown_tablet_unlocked(int64_t tablet_id, DroppedTabl
     if (iter != _shutdown_tablets.end() && (iter->second).tablet != nullptr) {
         // clear meta for the previous shutdown tablet
         if (auto st = _remove_tablet_meta((iter->second).tablet); !st.ok()) {
-            LOG(FATAL) << "Fail to remove previous table meta, id: " << tablet_id
-                       << " status: " << st;
+            LOG(FATAL) << "Fail to remove previous table meta, id: " << tablet_id << " status: " << st;
         }
         _shutdown_tablets.erase(iter);
     }

--- a/be/src/storage/tablet_manager.cpp
+++ b/be/src/storage/tablet_manager.cpp
@@ -1772,10 +1772,12 @@ std::unordered_map<TTabletId, vector<pair<uint32_t, uint32_t>>> TabletManager::g
 
 void TabletManager::_add_shutdown_tablet_unlocked(int64_t tablet_id, DroppedTabletInfo&& drop_info) {
     auto iter = _shutdown_tablets.find(tablet_id);
-    if (iter != _shutdown_tablets.end() && (iter->second).tablet != nullptr) {
-        // clear meta for the previous shutdown tablet
-        if (auto st = _remove_tablet_meta((iter->second).tablet); !st.ok()) {
-            LOG(FATAL) << "Fail to remove previous table meta, id: " << tablet_id << " status: " << st;
+    if (iter != _shutdown_tablets.end()) {
+        if ((iter->second).tablet != nullptr) {
+            auto st = _remove_tablet_meta((iter->second).tablet);
+            if (!st.ok()) {
+                LOG(WARNING) << "Fail to remove previous table meta, id: " << tablet_id << " status: " << st;
+            }
         }
         _shutdown_tablets.erase(iter);
     }

--- a/be/src/storage/tablet_manager.cpp
+++ b/be/src/storage/tablet_manager.cpp
@@ -422,7 +422,7 @@ Status TabletManager::drop_tablet(TTabletId tablet_id, TabletDropFlag flag) {
 
         // Remove the tablet directory in background to avoid holding the lock of tablet map shard for long.
         std::unique_lock l(_shutdown_tablets_lock);
-        _shutdown_tablets.emplace(tablet_id, std::move(drop_info));
+        _add_shutdown_tablet_unlocked(tablet_id, std::move(drop_info));
     } else if (flag == kMoveFilesToTrash) {
         {
             // See comments above
@@ -432,7 +432,7 @@ Status TabletManager::drop_tablet(TTabletId tablet_id, TabletDropFlag flag) {
         }
 
         std::unique_lock l(_shutdown_tablets_lock);
-        _shutdown_tablets.emplace(tablet_id, std::move(drop_info));
+        _add_shutdown_tablet_unlocked(tablet_id, std::move(drop_info));
     } else {
         DCHECK_EQ(kKeepMetaAndFiles, flag);
     }
@@ -469,10 +469,16 @@ Status TabletManager::drop_tablets_on_error_root_path(const std::vector<TabletIn
     }
 
     for (const auto& dropped_tablet : dropped_tablets) {
-        // make sure dropped tablet state is TABLET_SHUTDOWN
-        std::unique_lock l(dropped_tablet->get_header_lock());
-        (void)dropped_tablet->set_tablet_state(TABLET_SHUTDOWN);
-        dropped_tablet->save_meta();
+        {
+            // make sure dropped tablet state is TABLET_SHUTDOWN
+            std::unique_lock l(dropped_tablet->get_header_lock());
+            (void)dropped_tablet->set_tablet_state(TABLET_SHUTDOWN);
+            dropped_tablet->save_meta();
+        }
+
+        DroppedTabletInfo drop_info{.tablet = dropped_tablet, .flag = kMoveFilesToTrash};
+        std::unique_lock l(_shutdown_tablets_lock);
+        _add_shutdown_tablet_unlocked(dropped_tablet->tablet_id(), std::move(drop_info));
     }
 
     return Status::OK();
@@ -874,7 +880,7 @@ Status TabletManager::load_tablet_from_meta(DataDir* data_dir, TTabletId tablet_
         }
         std::unique_lock shutdown_tablets_wlock(_shutdown_tablets_lock);
         DroppedTabletInfo info{.tablet = tablet, .flag = kMoveFilesToTrash};
-        _shutdown_tablets.emplace(tablet->tablet_id(), std::move(info));
+        _add_shutdown_tablet_unlocked(tablet_id, std::move(info));
         return Status::NotFound("tablet state is shutdown");
     }
     if (!init_st.ok()) {
@@ -1490,7 +1496,7 @@ Status TabletManager::_drop_tablet_unlocked(TTabletId tablet_id, TabletDropFlag 
 
         // Remove the tablet directory in background to avoid holding the lock of tablet map shard for long.
         std::unique_lock l(_shutdown_tablets_lock);
-        _shutdown_tablets.emplace(tablet_id, std::move(drop_info));
+        _add_shutdown_tablet_unlocked(tablet_id, std::move(drop_info));
     } else if (flag == kMoveFilesToTrash) {
         {
             // See comments above
@@ -1500,7 +1506,7 @@ Status TabletManager::_drop_tablet_unlocked(TTabletId tablet_id, TabletDropFlag 
         }
 
         std::unique_lock l(_shutdown_tablets_lock);
-        _shutdown_tablets.emplace(tablet_id, std::move(drop_info));
+        _add_shutdown_tablet_unlocked(tablet_id, std::move(drop_info));
     } else {
         DCHECK_EQ(kKeepMetaAndFiles, flag);
     }
@@ -1762,6 +1768,19 @@ std::unordered_map<TTabletId, vector<pair<uint32_t, uint32_t>>> TabletManager::g
         }
     }
     return ret;
+}
+
+void TabletManager::_add_shutdown_tablet_unlocked(int64_t tablet_id, DroppedTabletInfo&& drop_info) {
+    auto iter = _shutdown_tablets.find(tablet_id);
+    if (iter != _shutdown_tablets.end() && (iter->second).tablet != nullptr) {
+        // clear meta for the previous shutdown tablet
+        if (auto st = _remove_tablet_meta((iter->second).tablet); !st.ok()) {
+            LOG(FATAL) << "Fail to remove previous table meta, id: " << tablet_id
+                       << " status: " << st;
+        }
+        _shutdown_tablets.erase(iter);
+    }
+    _shutdown_tablets.emplace(tablet_id, drop_info);
 }
 
 } // end namespace starrocks

--- a/be/src/storage/tablet_manager.cpp
+++ b/be/src/storage/tablet_manager.cpp
@@ -880,7 +880,7 @@ Status TabletManager::load_tablet_from_meta(DataDir* data_dir, TTabletId tablet_
         }
         std::unique_lock shutdown_tablets_wlock(_shutdown_tablets_lock);
         DroppedTabletInfo info{.tablet = tablet, .flag = kMoveFilesToTrash};
-        _add_shutdown_tablet_unlocked(tablet_id, std::move(info));
+        _add_shutdown_tablet_unlocked(tablet->tablet_id(), std::move(info));
         return Status::NotFound("tablet state is shutdown");
     }
     if (!init_st.ok()) {

--- a/be/src/storage/tablet_manager.h
+++ b/be/src/storage/tablet_manager.h
@@ -267,6 +267,10 @@ private:
 
     int64_t _get_tablets_shard_idx(TTabletId tabletId) const { return tabletId & _tablets_shards_mask; }
 
+    // make sure use this function to add shutdown tablets
+    // caller should acquire _shutdown_tablets_lock
+    void _add_shutdown_tablet_unlocked(int64_t tablet_id, DroppedTabletInfo&& drop_info);
+
     static Status _remove_tablet_meta(const TabletSharedPtr& tablet);
     static Status _remove_tablet_directories(const TabletSharedPtr& tablet);
     static Status _move_tablet_directories_to_trash(const TabletSharedPtr& tablet);


### PR DESCRIPTION
## Why I'm doing:
Suppose we have there different datadir called dir1 dir2 dir3. One of the problematic execution timeline is following:
1. Create a tablet with id 123 on dir1, we call it tablet_123_dir1.

2. migrate it into dir2, tablet_123_dir1 will be added into shutdown_tablets map but will not remove the meta data in rocksdb immediately. And we re-create a tablet_123_dir2 on dir2, migration is done.

3. migrate it into dir3, tablet_123_dir2 will be try to added into shutdown_tablets. But problem happen here: we actully can not add tablet_123_dir2 into shutdown_tablets because we use std::map::emplace to add the tablet, but <123, tablet_123_dir1> has already existed in this map, std::map::emplace will not rewrite <123, tablet_123_dir1> into <123, tablet_123_dir2>. So we actully destory tablet_123_dir2 immediately without remove its meta data. And the meta data for tablet_123_dir2 in rocksdb can not be removed forever in this case.

4. migrate it back to dir2. Now we notice that there is tablet meta data in dir2 for tablet 123. But we can not remove it this case, because tablet_123_dir2 is gone.

The core problem here is that shutdown_tablets is std::map and we use std::map::emplace to add a new shutdown tablet. It may leak if the tablet id has been existed in this map.

## What I'm doing:
Forcely remove the previous shutdown tablet with same tablet id if add a new one to it.

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
