### PR TITLE
[Enhancement] Refine unauthorized error message when calling http api

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/common/ErrorCode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/ErrorCode.java
@@ -249,8 +249,7 @@ public enum ErrorCode {
             "Access denied; This sql is in blacklist, please contact your admin"),
     ERR_ACCESS_DENIED(5203, new byte[] {'4', '2', '0', '0', '0'},
             "Access denied; you need (at least one of) the %s privilege(s) on %s%s for this operation. " +
-                    "Please ask the admin to grant permission(s) or try activating existing roles using <set [default] role>. " +
-                    "Current role(s): %s. Inactivated role(s): %s."),
+                    ErrorCode.ERR_ACCESS_DENIED_HINT_MSG_FORMAT),
     ERR_ACCESS_DENIED_FOR_EXTERNAL_ACCESS_CONTROLLER(5204, new byte[] {'4', '2', '0', '0', '0'},
             "Access denied; you need (at least one of) the %s privilege(s) on %s%s for this operation."),
 
@@ -279,6 +278,9 @@ public enum ErrorCode {
             "Partition '%s' has sub partitions, should specify the partition id"),
     ERR_NO_SUCH_PARTITION(5505, new byte[] {'4', '2', '0', '0', '0'}, "Partition '%s' doesn't exist"),
     ;
+
+    public static final String ERR_ACCESS_DENIED_HINT_MSG_FORMAT = "Please ask the admin to grant permission(s) or" +
+            " try activating existing roles using <set [default] role>. Current role(s): %s. Inactivated role(s): %s.";
 
     ErrorCode(int code, byte[] sqlState, String errorMsg) {
         this.code = code;

--- a/fe/fe-core/src/main/java/com/starrocks/http/BaseAction.java
+++ b/fe/fe-core/src/main/java/com/starrocks/http/BaseAction.java
@@ -99,7 +99,7 @@ public abstract class BaseAction implements IAction {
     }
 
     @Override
-    public void handleRequest(BaseRequest request) throws Exception {
+    public void handleRequest(BaseRequest request) {
         BaseResponse response = new BaseResponse();
         try {
             execute(request, response);

--- a/fe/fe-core/src/main/java/com/starrocks/http/rest/RestBaseAction.java
+++ b/fe/fe-core/src/main/java/com/starrocks/http/rest/RestBaseAction.java
@@ -36,6 +36,7 @@ package com.starrocks.http.rest;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Strings;
 import com.starrocks.common.DdlException;
 import com.starrocks.common.ErrorCode;
 import com.starrocks.common.Pair;
@@ -55,7 +56,6 @@ import io.netty.handler.codec.http.HttpHeaderNames;
 import io.netty.handler.codec.http.HttpResponseStatus;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.apache.parquet.Strings;
 
 import java.net.URI;
 import java.net.URISyntaxException;

--- a/fe/fe-core/src/main/java/com/starrocks/privilege/AccessDeniedException.java
+++ b/fe/fe-core/src/main/java/com/starrocks/privilege/AccessDeniedException.java
@@ -21,7 +21,6 @@ import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.sql.analyzer.Authorizer;
 import com.starrocks.sql.ast.UserIdentity;
 
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
 
@@ -46,23 +45,9 @@ public class AccessDeniedException extends Exception {
                     privilegeType, objectType, object == null ? "" : " " + object);
         } else {
             AuthorizationMgr authorizationMgr = GlobalStateMgr.getCurrentState().getAuthorizationMgr();
-            List<String> activatedRoles = new ArrayList<>();
-            if (roleIds != null) {
-                for (Long roleId : roleIds) {
-                    RolePrivilegeCollectionV2 roleCollection = authorizationMgr.getRolePrivilegeCollection(roleId);
-                    if (roleCollection != null) {
-                        activatedRoles.add(roleCollection.getName());
-                    }
-                }
-            }
-
-            List<String> inactivatedRoles = new ArrayList<>();
-            try {
-                inactivatedRoles = authorizationMgr.getRoleNamesByUser(userIdentity);
-            } catch (PrivilegeException e) {
-                //ignore exception
-            }
-            inactivatedRoles.removeAll(activatedRoles);
+            List<String> activatedRoles = authorizationMgr.getRoleNamesByRoleIds(roleIds);
+            List<String> inactivatedRoles =
+                    authorizationMgr.getInactivatedRoleNamesByUser(userIdentity, activatedRoles);
 
             ErrorReportException.report(ErrorCode.ERR_ACCESS_DENIED, privilegeType, objectType,
                     object == null ? "" : " " + object,

--- a/fe/fe-core/src/main/java/com/starrocks/privilege/AuthorizationMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/privilege/AuthorizationMgr.java
@@ -57,9 +57,9 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
@@ -89,7 +89,8 @@ public class AuthorizationMgr {
             CacheBuilder.newBuilder()
                     .maximumSize(MAX_NUM_CACHED_MERGED_PRIVILEGE_COLLECTION)
                     .expireAfterAccess(CACHED_MERGED_PRIVILEGE_COLLECTION_EXPIRE_MIN, TimeUnit.MINUTES)
-                    .build(new CacheLoader<Pair<UserIdentity, Set<Long>>, PrivilegeCollectionV2>() {
+                    .build(new CacheLoader<>() {
+                        @NotNull
                         @Override
                         public PrivilegeCollectionV2 load(@NotNull Pair<UserIdentity, Set<Long>> userIdentitySetPair)
                                 throws Exception {
@@ -949,9 +950,7 @@ public class AuthorizationMgr {
     public Set<UserIdentity> getAllUserIdentities() {
         userReadLock();
         try {
-            List<String> users = Lists.newArrayList();
-            Set<UserIdentity> userIdentities = userToPrivilegeCollection.keySet();
-            return userIdentities;
+            return userToPrivilegeCollection.keySet();
         } finally {
             userReadUnlock();
         }
@@ -1419,6 +1418,32 @@ public class AuthorizationMgr {
         }
     }
 
+    public List<String> getRoleNamesByRoleIds(Set<Long> roleIds) {
+        List<String> roleNames = new ArrayList<>();
+        if (roleIds != null) {
+            for (Long roleId : roleIds) {
+                RolePrivilegeCollectionV2 roleCollection = getRolePrivilegeCollection(roleId);
+                if (roleCollection != null) {
+                    roleNames.add(roleCollection.getName());
+                }
+            }
+        }
+
+        return roleNames;
+    }
+
+    public List<String> getInactivatedRoleNamesByUser(UserIdentity userIdentity, List<String> activatedRoleNames) {
+        List<String> inactivatedRoleNames = new ArrayList<>();
+        try {
+            inactivatedRoleNames = getRoleNamesByUser(userIdentity);
+        } catch (PrivilegeException e) {
+            // ignore exception
+        }
+        inactivatedRoleNames.removeAll(activatedRoleNames);
+
+        return inactivatedRoleNames;
+    }
+
     // used in executing `set role` statement
     public Long getRoleIdByNameAllowNull(String name) {
         roleReadLock();
@@ -1457,7 +1482,7 @@ public class AuthorizationMgr {
      * remove invalid object periodically
      * <p>
      * lock order should always be:
-     * AuthenticationManager.lock -> AuthorizationManager.userLock -> AuthorizationManager.roleLock
+     * `AuthenticationManager.lock` -> `AuthorizationManager.userLock` -> `AuthorizationManager.roleLock`
      */
     public void removeInvalidObject() {
         userWriteLock();
@@ -1624,11 +1649,7 @@ public class AuthorizationMgr {
             // 1 json for myself
             AuthorizationMgr ret = reader.readJson(AuthorizationMgr.class);
             ret.globalStateMgr = globalStateMgr;
-            if (provider == null) {
-                ret.provider = new DefaultAuthorizationProvider();
-            } else {
-                ret.provider = provider;
-            }
+            ret.provider = Objects.requireNonNullElseGet(provider, DefaultAuthorizationProvider::new);
             ret.initBuiltinRolesAndUsers();
 
             // 1 json for num user
@@ -1668,7 +1689,6 @@ public class AuthorizationMgr {
                 ret.roleIdToPrivilegeCollection.put(roleId, collection);
             }
 
-            assert ret != null; // can't be NULL
             LOG.info("loaded {} users, {} roles",
                     ret.userToPrivilegeCollection.size(), ret.roleIdToPrivilegeCollection.size());
 
@@ -1699,19 +1719,13 @@ public class AuthorizationMgr {
             writer.writeJson(this);
             // 1 json for num user
             writer.writeJson(userToPrivilegeCollection.size());
-            Iterator<Map.Entry<UserIdentity, UserPrivilegeCollectionV2>> iterator =
-                    userToPrivilegeCollection.entrySet().iterator();
-            while (iterator.hasNext()) {
-                Map.Entry<UserIdentity, UserPrivilegeCollectionV2> entry = iterator.next();
+            for (Map.Entry<UserIdentity, UserPrivilegeCollectionV2> entry : userToPrivilegeCollection.entrySet()) {
                 writer.writeJson(entry.getKey());
                 writer.writeJson(entry.getValue());
             }
             // 1 json for num roles
             writer.writeJson(roleIdToPrivilegeCollection.size());
-            Iterator<Map.Entry<Long, RolePrivilegeCollectionV2>> roleIter =
-                    roleIdToPrivilegeCollection.entrySet().iterator();
-            while (roleIter.hasNext()) {
-                Map.Entry<Long, RolePrivilegeCollectionV2> entry = roleIter.next();
+            for (Map.Entry<Long, RolePrivilegeCollectionV2> entry : roleIdToPrivilegeCollection.entrySet()) {
                 RolePrivilegeCollectionV2 value = entry.getValue();
                 // Avoid newly added PEntryObject type corrupt forward compatibility,
                 // since built-in roles are always initialized on startup, we don't need to persist them.

--- a/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/PrivilegeCheckerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/PrivilegeCheckerTest.java
@@ -45,6 +45,7 @@ import com.starrocks.common.ErrorReportException;
 import com.starrocks.common.proc.ReplicasProcNode;
 import com.starrocks.common.util.KafkaUtil;
 import com.starrocks.connector.exception.StarRocksConnectorException;
+import com.starrocks.http.rest.RestBaseAction;
 import com.starrocks.load.pipe.PipeManagerTest;
 import com.starrocks.load.routineload.RoutineLoadMgr;
 import com.starrocks.mysql.MysqlChannel;
@@ -59,6 +60,7 @@ import com.starrocks.privilege.TablePEntryObject;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.qe.ConnectScheduler;
 import com.starrocks.qe.DDLStmtExecutor;
+import com.starrocks.qe.SetDefaultRoleExecutor;
 import com.starrocks.qe.ShowExecutor;
 import com.starrocks.qe.ShowResultSet;
 import com.starrocks.qe.SqlModeHelper;
@@ -72,6 +74,7 @@ import com.starrocks.sql.ast.CreateUserStmt;
 import com.starrocks.sql.ast.DropMaterializedViewStmt;
 import com.starrocks.sql.ast.QueryStatement;
 import com.starrocks.sql.ast.SelectRelation;
+import com.starrocks.sql.ast.SetDefaultRoleStmt;
 import com.starrocks.sql.ast.ShowAnalyzeJobStmt;
 import com.starrocks.sql.ast.ShowAnalyzeStatusStmt;
 import com.starrocks.sql.ast.ShowAuthenticationStmt;
@@ -3766,5 +3769,47 @@ public class PrivilegeCheckerTest {
         }
 
         Config.access_control = "native";
+    }
+
+    @Test
+    public void testGetErrorRespWhenUnauthorized() throws Exception {
+        // setup
+        DDLStmtExecutor.execute(UtFrameUtils.parseStmtWithNewParser(
+                "create user user_x_11 IDENTIFIED BY ''", starRocksAssert.getCtx()), starRocksAssert.getCtx());
+        DDLStmtExecutor.execute(UtFrameUtils.parseStmtWithNewParser(
+                "create role role_x_11", starRocksAssert.getCtx()), starRocksAssert.getCtx());
+        DDLStmtExecutor.execute(UtFrameUtils.parseStmtWithNewParser(
+                "create role role_x_12", starRocksAssert.getCtx()), starRocksAssert.getCtx());
+
+        // test AccessDeniedException with specified error message
+        RestBaseAction restBaseAction = new RestBaseAction(null);
+        Assert.assertEquals("Radio gaga",
+                restBaseAction.getErrorRespWhenUnauthorized(new AccessDeniedException("Radio gaga")));
+
+        // test AccessDeniedException with no error message
+        DDLStmtExecutor.execute(UtFrameUtils.parseStmtWithNewParser(
+                "grant role_x_11, role_x_12 to user_x_11",
+                starRocksAssert.getCtx()), starRocksAssert.getCtx());
+        SetDefaultRoleStmt setDefaultRoleStmt = (SetDefaultRoleStmt) UtFrameUtils.parseStmtWithNewParser(
+                "set default role role_x_11 to user_x_11",
+                starRocksAssert.getCtx());
+        SetDefaultRoleExecutor.execute(setDefaultRoleStmt, starRocksAssert.getCtx());
+        ConnectContext context = new ConnectContext();
+        UserIdentity userIdentity = new UserIdentity("user_x_11", "%");
+        context.setCurrentUserIdentity(userIdentity);
+        context.setCurrentRoleIds(userIdentity);
+        context.setThreadLocalInfo();
+        String msg = restBaseAction.getErrorRespWhenUnauthorized(new AccessDeniedException());
+        System.out.println(msg);
+        Assert.assertTrue(msg.contains("Current role(s): [role_x_11]. Inactivated role(s): [role_x_12]."));
+        starRocksAssert.getCtx().setThreadLocalInfo();
+
+        // clean
+        DDLStmtExecutor.execute(UtFrameUtils.parseStmtWithNewParser(
+                "drop user user_x_11", starRocksAssert.getCtx()), starRocksAssert.getCtx());
+        DDLStmtExecutor.execute(UtFrameUtils.parseStmtWithNewParser(
+                "drop role role_x_11", starRocksAssert.getCtx()), starRocksAssert.getCtx());
+        DDLStmtExecutor.execute(UtFrameUtils.parseStmtWithNewParser(
+                "drop role role_x_12", starRocksAssert.getCtx()), starRocksAssert.getCtx());
     }
 }


### PR DESCRIPTION
## Why I'm doing:
When calling http api but unauthozied, only `{"status":"FAILED","code":"1"}`
is returned which can be quite confusing.

## What I'm doing:
Refine the error message, also refactor some code to reduce dup logic.

Fixes SR-25839.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
