### PR TITLE
[Enhancement] check mv partition exist in loose mode for mv query rewrite

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/MaterializedView.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/MaterializedView.java
@@ -1361,6 +1361,9 @@ public class MaterializedView extends OlapTable implements GsonPreProcessable, G
     public boolean getPartitionNamesToRefreshForMvInLooseMode(Set<String> toRefreshPartitions) {
         Expr partitionExpr = getFirstPartitionRefTableExpr();
         Map<Table, Column> partitionTableAndColumn = getRelatedPartitionTableAndColumn();
+        if (partitionExpr == null || partitionTableAndColumn.isEmpty()) {
+            return this.getPartitions().size() > 0;
+        }
         Map<String, Range<PartitionKey>> mvRangePartitionMap = getRangePartitionMap();
         Map<Table, Map<String, Range<PartitionKey>>> refBaseTablePartitionMap = Maps.newHashMap();
         RangePartitionDiff rangePartitionDiff = null;

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/MaterializedView.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/MaterializedView.java
@@ -71,6 +71,7 @@ import com.starrocks.sql.analyzer.RelationFields;
 import com.starrocks.sql.analyzer.RelationId;
 import com.starrocks.sql.analyzer.Scope;
 import com.starrocks.sql.ast.UserIdentity;
+import com.starrocks.sql.common.PartitionDiffer;
 import com.starrocks.sql.common.PartitionRange;
 import com.starrocks.sql.common.RangePartitionDiff;
 import com.starrocks.sql.common.SyncPartitionUtils;
@@ -1355,6 +1356,46 @@ public class MaterializedView extends OlapTable implements GsonPreProcessable, G
         return tableToJoinExprMap;
     }
 
+    // In Loose mode, do not need to check mv partition's data is consistent with base table's partition's data.
+    // Only need to check the mv partition existence.
+    public boolean getPartitionNamesToRefreshForMvInLooseMode(Set<String> toRefreshPartitions) {
+        Expr partitionExpr = getFirstPartitionRefTableExpr();
+        Map<Table, Column> partitionTableAndColumn = getRelatedPartitionTableAndColumn();
+        Map<String, Range<PartitionKey>> mvRangePartitionMap = getRangePartitionMap();
+        Map<Table, Map<String, Range<PartitionKey>>> refBaseTablePartitionMap = Maps.newHashMap();
+        RangePartitionDiff rangePartitionDiff = null;
+        try {
+            for (Map.Entry<Table, Column> entry : partitionTableAndColumn.entrySet()) {
+                Table refBaseTable = entry.getKey();
+                Column refBaseTablePartitionColumn = entry.getValue();
+                // Collect the ref base table's partition range map.
+                refBaseTablePartitionMap.put(refBaseTable, PartitionUtil.getPartitionKeyRange(
+                        refBaseTable, refBaseTablePartitionColumn, partitionExpr));
+
+            }
+            Table partitionTable = getDirectTableAndPartitionColumn().first;
+            Column partitionColumn = getPartitionInfo().getPartitionColumns().get(0);
+            PartitionDiffer differ = PartitionDiffer.build(this, null);
+            rangePartitionDiff = PartitionUtil.getPartitionDiff(partitionExpr, partitionColumn,
+                    refBaseTablePartitionMap.get(partitionTable), mvRangePartitionMap, differ);
+        } catch (Exception e) {
+            LOG.warn("Materialized view compute partition difference with base table failed.", e);
+            return false;
+        }
+
+        if (rangePartitionDiff == null) {
+            LOG.warn("Materialized view compute partition difference with base table failed, the diff of range partition" +
+                    " is null.");
+            return false;
+        }
+        Map<String, Range<PartitionKey>> adds = rangePartitionDiff.getAdds();
+        for (Map.Entry<String, Range<PartitionKey>> addEntry : adds.entrySet()) {
+            String mvPartitionName = addEntry.getKey();
+            toRefreshPartitions.add(mvPartitionName);
+        }
+        return true;
+    }
+
     /**
      * Once the materialized view's base tables have updated, we need to check correspond materialized views' partitions
      * to be refreshed.
@@ -1371,31 +1412,37 @@ public class MaterializedView extends OlapTable implements GsonPreProcessable, G
         }
 
         // check mv's query rewrite consistency mode property only in query rewrite.
+        TableProperty.QueryRewriteConsistencyMode mvConsistencyRewriteMode =
+                TableProperty.QueryRewriteConsistencyMode.CHECKED;
         if (isQueryRewrite) {
-            TableProperty.QueryRewriteConsistencyMode mvConsistencyRewriteMode
-                    = tableProperty.getQueryRewriteConsistencyMode();
+            mvConsistencyRewriteMode = tableProperty.getQueryRewriteConsistencyMode();
             switch (mvConsistencyRewriteMode) {
                 case DISABLE:
                     return false;
-                case LOOSE:
+                case NOCHECK:
                     return true;
+                case LOOSE:
                 case CHECKED:
                 default:
                     break;
             }
         }
-
-        if (partitionInfo instanceof SinglePartitionInfo) {
-            return getNonPartitionedMVRefreshPartitions(toRefreshPartitions, isQueryRewrite);
-        } else if (partitionInfo instanceof ExpressionRangePartitionInfo) {
-            // partitions to refresh
-            // 1. dropped partitions
-            // 2. newly added partitions
-            // 3. partitions loaded with new data
-            return getPartitionedMVRefreshPartitions(toRefreshPartitions, isQueryRewrite);
+        if (mvConsistencyRewriteMode == TableProperty.QueryRewriteConsistencyMode.LOOSE) {
+            return getPartitionNamesToRefreshForMvInLooseMode(toRefreshPartitions);
         } else {
-            throw UnsupportedException.unsupportedException("unsupported partition info type:"
-                    + partitionInfo.getClass().getName());
+            // mvConsistencyRewriteMode == TableProperty.QueryRewriteConsistencyMode.CHECKED
+            if (partitionInfo instanceof SinglePartitionInfo) {
+                return getNonPartitionedMVRefreshPartitions(toRefreshPartitions, isQueryRewrite);
+            } else if (partitionInfo instanceof ExpressionRangePartitionInfo) {
+                // partitions to refresh
+                // 1. dropped partitions
+                // 2. newly added partitions
+                // 3. partitions loaded with new data
+                return getPartitionedMVRefreshPartitions(toRefreshPartitions, isQueryRewrite);
+            } else {
+                throw UnsupportedException.unsupportedException("unsupported partition info type:"
+                        + partitionInfo.getClass().getName());
+            }
         }
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/TableProperty.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/TableProperty.java
@@ -92,8 +92,9 @@ public class TableProperty implements Writable, GsonPostProcessable {
 
     public enum QueryRewriteConsistencyMode {
         DISABLE,    // 0: disable query rewrite
-        LOOSE,      // 1: enable query rewrite, and skip the partition version check
-        CHECKED;    // 2: enable query rewrite, and rewrite only if mv partition version is consistent with table meta
+        LOOSE,      // 1: enable query rewrite, and skip the partition version check, still need to check mv partition exist
+        CHECKED,    // 2: enable query rewrite, and rewrite only if mv partition version is consistent with table meta
+        NOCHECK;   // 3: enable query rewrite, and rewrite without any check
 
         public static QueryRewriteConsistencyMode defaultQueryRewriteConsistencyMode() {
             return CHECKED;

--- a/fe/fe-core/src/main/java/com/starrocks/sql/common/PartitionDiffer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/common/PartitionDiffer.java
@@ -79,8 +79,8 @@ public class PartitionDiffer {
         Range<PartitionKey> rangeToInclude = null;
         Column partitionColumn =
                 ((RangePartitionInfo) materializedView.getPartitionInfo()).getPartitionColumns().get(0);
-        String start = context.getProperties().get(TaskRun.PARTITION_START);
-        String end = context.getProperties().get(TaskRun.PARTITION_END);
+        String start = context == null ? null : context.getProperties().get(TaskRun.PARTITION_START);
+        String end = context == null ? null : context.getProperties().get(TaskRun.PARTITION_END);
         if (start != null || end != null) {
             rangeToInclude = SyncPartitionUtils.createRange(start, end, partitionColumn);
         }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvPartitionCompensator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvPartitionCompensator.java
@@ -587,6 +587,7 @@ public class MvPartitionCompensator {
 
         List<Range<PartitionKey>> refBaseTableRanges = Lists.newArrayList();
         try {
+            // todo: support list partition mv
             refBaseTableRanges = Lists.newArrayList(PartitionUtil.getPartitionKeyRange(partitionByTable, partitionColumn,
                     MaterializedView.getPartitionExpr(mv)).values());
         } catch (UserException e) {

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvRewriteHiveTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvRewriteHiveTest.java
@@ -29,6 +29,7 @@ import com.starrocks.sql.optimizer.transformer.LogicalPlan;
 import com.starrocks.sql.plan.ConnectorPlanTestBase;
 import com.starrocks.sql.plan.PlanTestBase;
 import com.starrocks.utframe.UtFrameUtils;
+import org.assertj.core.util.Sets;
 import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -270,6 +271,44 @@ public class MvRewriteHiveTest extends MvRewriteTestBase {
                     "     rollup: hive_partition_prune_mv1");
         }
         starRocksAssert.dropMaterializedView("hive_partition_prune_mv1");
+    }
+
+    @Test
+    public void testHiveMVWithLooseMode() throws Exception {
+        starRocksAssert.withMaterializedView("CREATE MATERIALIZED VIEW `hive_partitioned_mv`\n" +
+                "COMMENT \"MATERIALIZED_VIEW\"\n" +
+                "PARTITION BY (`l_shipdate`)\n" +
+                "DISTRIBUTED BY HASH(`l_orderkey`) BUCKETS 10\n" +
+                "REFRESH DEFERRED MANUAL\n" +
+                "PROPERTIES (\n" +
+                "\"replication_num\" = \"1\",\n" +
+                "\"force_external_table_query_rewrite\" = \"true\",\n" +
+                "\"query_rewrite_consistency\" = \"loose\"" +
+                ")\n" +
+                "AS SELECT `l_orderkey`, `l_suppkey`, `l_shipdate`, sum(l_orderkey)  " +
+                "FROM `hive0`.`partitioned_db`.`lineitem_par` as a \n " +
+                "GROUP BY " +
+                "`l_orderkey`, `l_suppkey`, `l_shipdate`;");
+
+        refreshMaterializedViewWithPartition("test", "hive_partitioned_mv",
+                "1998-01-02", "1998-01-04");
+        Set<String> toRefreshPartitions = Sets.newHashSet();
+
+        MaterializedView mv1 = getMv("test", "hive_partitioned_mv");
+        boolean result = mv1.getPartitionNamesToRefreshForMv(toRefreshPartitions, true);
+        Assert.assertTrue(result);
+        Assert.assertEquals(4, toRefreshPartitions.size());
+        Assert.assertTrue(toRefreshPartitions.contains("p19980101"));
+        Assert.assertTrue(toRefreshPartitions.contains("p19980104"));
+        Assert.assertTrue(toRefreshPartitions.contains("p19980105"));
+
+        String query1 = "SELECT `l_orderkey`, `l_suppkey`, `l_shipdate`, sum(l_orderkey)  " +
+                "FROM `hive0`.`partitioned_db`.`lineitem_par` as a \n " +
+                "GROUP BY " +
+                "`l_orderkey`, `l_suppkey`, `l_shipdate`;";
+        String plan = getFragmentPlan(query1);
+        PlanTestBase.assertContains(plan, "hive_partitioned_mv", "UNION");
+        dropMv("test", "hive_partitioned_mv");
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvRewriteTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvRewriteTest.java
@@ -2089,7 +2089,7 @@ public class MvRewriteTest extends MvRewriteTestBase {
             String mvName = mvNameGen.apply(i);
             starRocksAssert.withMaterializedView("create materialized view " + mvName + "\n" +
                     "refresh async " +
-                    "properties('query_rewrite_consistency'='loose') " +
+                    "properties('query_rewrite_consistency'='nocheck') " +
                     "as select " + dimension + ", sum(c0) from t_many_dimensions group by " + dimension);
         }
 

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvRewriteTestBase.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvRewriteTestBase.java
@@ -130,6 +130,13 @@ public class MvRewriteTestBase {
         return mv;
     }
 
+    protected void refreshMaterializedViewWithPartition(String dbName, String mvName, String partitionStart,
+                                                        String partitionEnd) throws SQLException {
+        cluster.runSql(dbName, String.format("refresh materialized view %s partition start (\"%s\") " +
+                "end (\"%s\") with sync mode", mvName, partitionStart, partitionEnd));
+        cluster.runSql(dbName, String.format("analyze table %s with sync mode", mvName));
+    }
+
     protected void refreshMaterializedView(String dbName, String mvName) throws SQLException {
         cluster.runSql(dbName, String.format("refresh materialized view %s with sync mode", mvName));
         cluster.runSql(dbName, String.format("analyze table %s with sync mode", mvName));


### PR DESCRIPTION
## Why I'm doing:
if “query_rewrite_consistency” = “loose", the mv query rewrite will not check the mv partition exists, so if mv only has six month partion data, but query contains one year range, this query could still hit mv
## What I'm doing:
1. check mv partition exist when query_rewrite_consistency=true
2. add no check mode to do not check any partition info

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
