### PR TITLE
[BugFix] Fix enable_persistent_index can not be alterted in shared_data mode

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/task/TabletMetadataUpdateAgentTaskFactory.java
+++ b/fe/fe-core/src/main/java/com/starrocks/task/TabletMetadataUpdateAgentTaskFactory.java
@@ -38,7 +38,7 @@ public class TabletMetadataUpdateAgentTaskFactory {
             return createIsInMemoryUpdateTask(backendId, tablets, value);
         }
         if (metaType == TTabletMetaType.ENABLE_PERSISTENT_INDEX) {
-            return createIsInMemoryUpdateTask(backendId, tablets, value);
+            return createEnablePersistentIndexUpdateTask(backendId, tablets, value);
         }
         return null;
     }


### PR DESCRIPTION
## Why I'm doing:
`enable_persistent_index` can not be altered in shared_data mode.  The following log can be found in fe.log.
`task type: UPDATE_TABLET_META_INFO, status_code: RUNTIME_ERROR, unsupported update meta type: 1, backendId: 16086, signature: 49604048`. 
#39899 refactors `TabletMetadataUpdateAgentTaskFactory` but use `createIsInMemoryUpdateTask` by mistake when `metaType == TTabletMetaType.ENABLE_PERSISTENT_INDEX`.
## What I'm doing:
Call `createEnablePersistentIndexUpdateTask` when `metaType == TTabletMetaType.ENABLE_PERSISTENT_INDEX`.
Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
