### PR TITLE
[Enhancement] Optimize ORC writer performance for decimal types

### DIFF
--- a/be/src/column/vectorized_fwd.h
+++ b/be/src/column/vectorized_fwd.h
@@ -29,6 +29,7 @@ class DateValue;
 class TimestampValue;
 
 typedef __int128 int128_t;
+typedef unsigned __int128 uint128_t;
 
 class Chunk;
 class Field;

--- a/be/src/column/vectorized_fwd.h
+++ b/be/src/column/vectorized_fwd.h
@@ -29,7 +29,6 @@ class DateValue;
 class TimestampValue;
 
 typedef __int128 int128_t;
-typedef unsigned __int128 uint128_t;
 
 class Chunk;
 class Field;

--- a/be/src/formats/orc/apache-orc/c++/include/orc/Common.hh
+++ b/be/src/formats/orc/apache-orc/c++/include/orc/Common.hh
@@ -18,8 +18,9 @@
 
 #pragma once
 
-#include <string>
 #include <glog/logging.h>
+
+#include <string>
 
 #include "orc/Exceptions.hh"
 #include "orc/Type.hh"

--- a/be/src/formats/orc/apache-orc/c++/src/Int128.cc
+++ b/be/src/formats/orc/apache-orc/c++/src/Int128.cc
@@ -26,7 +26,7 @@
 namespace orc {
 
 Int128 Int128::maximumValue() {
-    return {0x7fffffffffffffff, 0xfffffffffffffff};
+    return {0x7fffffffffffffff, 0xffffffffffffffff};
 }
 
 Int128 Int128::minimumValue() {

--- a/be/src/formats/orc/apache-orc/c++/src/Int128.cc
+++ b/be/src/formats/orc/apache-orc/c++/src/Int128.cc
@@ -23,8 +23,6 @@
 #include <iostream>
 #include <sstream>
 
-#include "orc/Common.hh"
-
 namespace orc {
 
 Int128 Int128::maximumValue() {
@@ -433,6 +431,27 @@ std::string Int128::toHexString() const {
         << lowbits;
     return buf.str();
 }
+
+const static int32_t MAX_PRECISION_64 = 18;
+const static int64_t POWERS_OF_TEN[MAX_PRECISION_64 + 1] = {1,
+                                                            10,
+                                                            100,
+                                                            1000,
+                                                            10000,
+                                                            100000,
+                                                            1000000,
+                                                            10000000,
+                                                            100000000,
+                                                            1000000000,
+                                                            10000000000,
+                                                            100000000000,
+                                                            1000000000000,
+                                                            10000000000000,
+                                                            100000000000000,
+                                                            1000000000000000,
+                                                            10000000000000000,
+                                                            100000000000000000,
+                                                            1000000000000000000};
 
 Int128 scaleUpInt128ByPowerOfTen(Int128 value, int32_t power, bool& overflow) {
     overflow = false;

--- a/be/src/formats/orc/apache-orc/c++/src/Int128.cc
+++ b/be/src/formats/orc/apache-orc/c++/src/Int128.cc
@@ -23,6 +23,8 @@
 #include <iostream>
 #include <sstream>
 
+#include "orc/Common.hh"
+
 namespace orc {
 
 Int128 Int128::maximumValue() {
@@ -431,27 +433,6 @@ std::string Int128::toHexString() const {
         << lowbits;
     return buf.str();
 }
-
-const static int32_t MAX_PRECISION_64 = 18;
-const static int64_t POWERS_OF_TEN[MAX_PRECISION_64 + 1] = {1,
-                                                            10,
-                                                            100,
-                                                            1000,
-                                                            10000,
-                                                            100000,
-                                                            1000000,
-                                                            10000000,
-                                                            100000000,
-                                                            1000000000,
-                                                            10000000000,
-                                                            100000000000,
-                                                            1000000000000,
-                                                            10000000000000,
-                                                            100000000000000,
-                                                            1000000000000000,
-                                                            10000000000000000,
-                                                            100000000000000000,
-                                                            1000000000000000000};
 
 Int128 scaleUpInt128ByPowerOfTen(Int128 value, int32_t power, bool& overflow) {
     overflow = false;

--- a/be/src/formats/orc/apache-orc/c++/src/Statistics.hh
+++ b/be/src/formats/orc/apache-orc/c++/src/Statistics.hh
@@ -572,7 +572,8 @@ public:
 
     void reset() override {
         _stats.reset();
-        setSum(Decimal());
+        // Do not compute sum of decimal column
+        // setSum(Decimal());
     }
 
     void toProtoBuf(proto::ColumnStatistics& pbStats) const override {

--- a/be/src/formats/orc/apache-orc/c++/src/Statistics.hh
+++ b/be/src/formats/orc/apache-orc/c++/src/Statistics.hh
@@ -572,7 +572,7 @@ public:
 
     void reset() override {
         _stats.reset();
-        // Do not compute sum of decimal column
+        // Note(letian-jiang): Do not compute the sum of decimal column since it is time-consuming and hard to exploit.
         // setSum(Decimal());
     }
 

--- a/be/src/formats/orc/apache-orc/c++/src/Statistics.hh
+++ b/be/src/formats/orc/apache-orc/c++/src/Statistics.hh
@@ -573,7 +573,7 @@ public:
     void reset() override {
         _stats.reset();
         // Note(letian-jiang): Do not compute the sum of decimal column since it is time-consuming and hard to exploit.
-        // setSum(Decimal());
+        _stats.setHasSum(false);
     }
 
     void toProtoBuf(proto::ColumnStatistics& pbStats) const override {

--- a/be/src/util/decimal_types.h
+++ b/be/src/util/decimal_types.h
@@ -124,11 +124,10 @@ inline constexpr T get_min_decimal() {
     return -get_max_decimal<T>();
 }
 
-// NOLINTBEGIN
 template <typename T>
 inline constexpr T get_max() {
     if constexpr (std::is_same_v<T, int128_t>) {
-        return ~(static_cast<int128_t>(1ll) << 127);
+        return ~(static_cast<int128_t>(1ll) << 127); // NOLINT
     } else {
         return std::numeric_limits<T>::max();
     }
@@ -137,12 +136,11 @@ inline constexpr T get_max() {
 template <typename T>
 inline constexpr T get_min() {
     if constexpr (std::is_same_v<T, int128_t>) {
-        return static_cast<int128_t>(1ll) << 127;
+        return static_cast<int128_t>(1ll) << 127; // NOLINT
     } else {
         return std::numeric_limits<T>::lowest();
     }
 }
-// NOLINTEND
 
 template <typename T>
 constexpr bool is_signed_integer = (std::is_integral_v<T> && std::is_signed_v<T>) || std::is_same_v<T, int128_t>;

--- a/be/src/util/decimal_types.h
+++ b/be/src/util/decimal_types.h
@@ -21,6 +21,7 @@
 namespace starrocks {
 
 typedef __int128 int128_t;
+typedef unsigned __int128 uint128_t;
 
 template <typename T>
 inline constexpr bool is_underlying_type_of_decimal = false;

--- a/be/src/util/decimal_types.h
+++ b/be/src/util/decimal_types.h
@@ -124,10 +124,14 @@ inline constexpr T get_min_decimal() {
     return -get_max_decimal<T>();
 }
 
+static const uint128_t UINT128_MAX = uint128_t(int128_t(-1L));
+static const int128_t INT128_MAX = UINT128_MAX >> 1;
+static const int128_t INT128_MIN = -INT128_MAX - 1;
+
 template <typename T>
 inline constexpr T get_max() {
     if constexpr (std::is_same_v<T, int128_t>) {
-        return ~(static_cast<int128_t>(1ll) << 127); // NOLINT
+        return INT128_MAX;
     } else {
         return std::numeric_limits<T>::max();
     }
@@ -136,7 +140,7 @@ inline constexpr T get_max() {
 template <typename T>
 inline constexpr T get_min() {
     if constexpr (std::is_same_v<T, int128_t>) {
-        return static_cast<int128_t>(1ll) << 127; // NOLINT
+        return INT128_MIN;
     } else {
         return std::numeric_limits<T>::lowest();
     }

--- a/be/src/util/decimal_types.h
+++ b/be/src/util/decimal_types.h
@@ -124,10 +124,7 @@ inline constexpr T get_min_decimal() {
     return -get_max_decimal<T>();
 }
 
-DIAGNOSTIC_PUSH
-#if defined(clang)
-DIAGNOSTIC_IGNORE("-Wshift-sign-overflow")
-#endif
+// NOLINTBEGIN
 template <typename T>
 inline constexpr T get_max() {
     if constexpr (std::is_same_v<T, int128_t>) {
@@ -145,7 +142,7 @@ inline constexpr T get_min() {
         return std::numeric_limits<T>::lowest();
     }
 }
-DIAGNOSTIC_POP
+// NOLINTEND
 
 template <typename T>
 constexpr bool is_signed_integer = (std::is_integral_v<T> && std::is_signed_v<T>) || std::is_same_v<T, int128_t>;

--- a/be/src/util/decimal_types.h
+++ b/be/src/util/decimal_types.h
@@ -124,6 +124,10 @@ inline constexpr T get_min_decimal() {
     return -get_max_decimal<T>();
 }
 
+DIAGNOSTIC_PUSH
+#if defined(clang)
+DIAGNOSTIC_IGNORE("-Wshift-sign-overflow")
+#endif
 template <typename T>
 inline constexpr T get_max() {
     if constexpr (std::is_same_v<T, int128_t>) {
@@ -141,6 +145,7 @@ inline constexpr T get_min() {
         return std::numeric_limits<T>::lowest();
     }
 }
+DIAGNOSTIC_POP
 
 template <typename T>
 constexpr bool is_signed_integer = (std::is_integral_v<T> && std::is_signed_v<T>) || std::is_same_v<T, int128_t>;

--- a/be/test/formats/orc/utils_test.cpp
+++ b/be/test/formats/orc/utils_test.cpp
@@ -55,3 +55,121 @@ TEST(UtilsTest, TestMergeBigDiskRanges) {
 }
 
 } // namespace starrocks
+
+namespace orc {
+
+TEST(Int128CompareTest, Simple) {
+    Int128 x = 123;
+    EXPECT_EQ(Int128(123), x);
+    EXPECT_EQ(true, x == 123);
+    EXPECT_EQ(true, !(x == 124));
+    EXPECT_EQ(true, !(x == -124));
+    EXPECT_EQ(true, !(x == Int128(2, 123)));
+    EXPECT_EQ(true, !(x != 123));
+    EXPECT_EQ(true, x != -123);
+    EXPECT_EQ(true, x != 124);
+    EXPECT_EQ(true, x != Int128(-1, 123));
+    x = Int128(0x123, 0x456);
+    EXPECT_EQ(true, !(x < Int128(0x123, 0x455)));
+    EXPECT_EQ(true, !(x < Int128(0x123, 0x456)));
+    EXPECT_EQ(true, x < Int128(0x123, 0x457));
+    EXPECT_EQ(true, !(x < Int128(0x122, 0x456)));
+    EXPECT_EQ(true, x < Int128(0x124, 0x456));
+
+    EXPECT_EQ(true, !(x <= Int128(0x123, 0x455)));
+    EXPECT_EQ(true, x <= Int128(0x123, 0x456));
+    EXPECT_EQ(true, x <= Int128(0x123, 0x457));
+    EXPECT_EQ(true, !(x <= Int128(0x122, 0x456)));
+    EXPECT_EQ(true, x <= Int128(0x124, 0x456));
+
+    EXPECT_EQ(true, x > Int128(0x123, 0x455));
+    EXPECT_EQ(true, !(x > Int128(0x123, 0x456)));
+    EXPECT_EQ(true, !(x > Int128(0x123, 0x457)));
+    EXPECT_EQ(true, x > Int128(0x122, 0x456));
+    EXPECT_EQ(true, !(x > Int128(0x124, 0x456)));
+
+    EXPECT_EQ(true, x >= Int128(0x123, 0x455));
+    EXPECT_EQ(true, x >= Int128(0x123, 0x456));
+    EXPECT_EQ(true, !(x >= Int128(0x123, 0x457)));
+    EXPECT_EQ(true, x >= Int128(0x122, 0x456));
+    EXPECT_EQ(true, !(x >= Int128(0x124, 0x456)));
+
+    EXPECT_EQ(true, Int128(-3) < Int128(-2));
+    EXPECT_EQ(true, Int128(-3) < Int128(0));
+    EXPECT_EQ(true, Int128(-3) < Int128(3));
+    EXPECT_EQ(true, Int128(0) < Int128(5));
+    EXPECT_EQ(true, Int128::minimumValue() < 0);
+    EXPECT_EQ(true, Int128(0) < Int128::maximumValue());
+    EXPECT_EQ(true, Int128::minimumValue() < Int128::maximumValue());
+}
+
+TEST(Decimal, testDecimalComparison) {
+    // same scales
+    EXPECT_TRUE(compare(Decimal(Int128(99), 0), Decimal(Int128(100), 0)));
+    EXPECT_TRUE(compare(Decimal(Int128(34543), 5), Decimal(Int128(4324324), 5)));
+    EXPECT_TRUE(compare(Decimal(Int128(345345435432l), 15), Decimal(Int128(345344425435432l), 15)));
+    EXPECT_TRUE(compare(Decimal(Int128(5), 20), Decimal(Int128(50), 20)));
+
+    // different scales
+    EXPECT_TRUE(compare(Decimal(Int128(10000), 4), Decimal(Int128(10000), 3)));
+    EXPECT_FALSE(compare(Decimal(Int128(1111), 3), Decimal(Int128(111), 2)));
+    EXPECT_TRUE(compare(Decimal(Int128(999999), 5), Decimal(Int128(9999999), 5)));
+    EXPECT_FALSE(compare(Decimal(Int128(99), 0), Decimal(Int128(100), 1)));
+
+    // same integral parts
+    EXPECT_TRUE(compare(Decimal(Int128(99999), 0), Decimal(Int128(999999), 1)));
+    EXPECT_TRUE(compare(Decimal(Int128(12345123), 3), Decimal(Int128(1234553432), 5)));
+
+    // equal numbers
+    EXPECT_FALSE(compare(Decimal(Int128(100000), 3), Decimal(Int128(100), 0)));
+    EXPECT_FALSE(compare(Decimal(Int128(100), 0), Decimal(Int128(100000), 3)));
+    EXPECT_FALSE(compare(Decimal(Int128(100000), 3), Decimal(Int128(100000), 3)));
+    EXPECT_FALSE(compare(Decimal(Int128(100000), 3), Decimal(Int128(100000), 3)));
+    EXPECT_FALSE(compare(Decimal(Int128(1), 10), Decimal(Int128(10), 11)));
+    EXPECT_FALSE(compare(Decimal(Int128(10), 11), Decimal(Int128(1), 10)));
+
+    // large scales (>18)
+    EXPECT_TRUE(compare(Decimal(Int128(99), 35), Decimal(Int128(100), 35)));
+    EXPECT_TRUE(compare(Decimal(Int128("12345678999999999999999999999999999998"), 29),
+                        Decimal(Int128("123456789999999999999999999999999999999"), 30)));
+    EXPECT_FALSE(compare(Decimal(Int128("123456789999999999999999999999999999900"), 30),
+                         Decimal(Int128("12345678999999999999999999999999999990"), 29)));
+    EXPECT_FALSE(compare(Decimal(Int128("12345678999999999999999999999999999990"), 29),
+                         Decimal(Int128("123456789999999999999999999999999999900"), 30)));
+
+    // fractional overflow
+    EXPECT_TRUE(compare(Decimal(Int128::maximumValue(), 39),
+                        Decimal(Int128("99999999999999999999999999999999999999"), 38)));
+
+    // negative numbers
+    EXPECT_TRUE(compare(Decimal(Int128(-99), 0), Decimal(Int128(100), 0)));
+    EXPECT_TRUE(compare(Decimal(Int128(-4324324), 5), Decimal(Int128(-34543), 5)));
+    EXPECT_TRUE(compare(Decimal(Int128(-345344425435432l), 15), Decimal(Int128(-345345435432l), 15)));
+    EXPECT_TRUE(compare(Decimal(Int128(-50), 20), Decimal(Int128(-5), 20)));
+    EXPECT_TRUE(compare(Decimal(Int128(-10000), 3), Decimal(Int128(-10000), 4)));
+    EXPECT_TRUE(compare(Decimal(Int128(-1111), 3), Decimal(Int128(-111), 2)));
+    EXPECT_TRUE(compare(Decimal(Int128(-9999999), 5), Decimal(Int128(-999999), 5)));
+    EXPECT_TRUE(compare(Decimal(Int128(-99), 0), Decimal(Int128(-100), 1)));
+    EXPECT_TRUE(compare(Decimal(Int128(-999999), 1), Decimal(Int128(-99999), 0)));
+    EXPECT_TRUE(compare(Decimal(Int128(-1234553432), 5), Decimal(Int128(-12345123), 3)));
+    EXPECT_FALSE(compare(Decimal(Int128(-100000), 3), Decimal(Int128(-100), 0)));
+    EXPECT_FALSE(compare(Decimal(Int128(-100), 0), Decimal(Int128(-100000), 3)));
+    EXPECT_FALSE(compare(Decimal(Int128(-100000), 3), Decimal(Int128(-100000), 3)));
+    EXPECT_FALSE(compare(Decimal(Int128(-100000), 3), Decimal(Int128(-100000), 3)));
+    EXPECT_FALSE(compare(Decimal(Int128(-1), 10), Decimal(Int128(-10), 11)));
+    EXPECT_FALSE(compare(Decimal(Int128(-10), 11), Decimal(Int128(-1), 10)));
+    EXPECT_TRUE(compare(Decimal(Int128(-100), 35), Decimal(Int128(-99), 35)));
+    EXPECT_TRUE(compare(Decimal(Int128("-123456789999999999999999999999999999999"), 30),
+                        Decimal(Int128("-12345678999999999999999999999999999998"), 29)));
+    EXPECT_FALSE(compare(Decimal(Int128("-123456789999999999999999999999999999900"), 30),
+                         Decimal(Int128("-12345678999999999999999999999999999990"), 29)));
+    EXPECT_FALSE(compare(Decimal(Int128("-12345678999999999999999999999999999990"), 29),
+                         Decimal(Int128("-123456789999999999999999999999999999900"), 30)));
+    EXPECT_TRUE(compare(Decimal(Int128("-99999999999999999999999999999999999999"), 38),
+                        Decimal(Int128::minimumValue(), 39)));
+
+    // more tests
+    EXPECT_TRUE(compare(Decimal(Int128("-99999999999999999999999999999999999999"), 38), Decimal(Int128(100), 0)));
+}
+
+} // namespace orc

--- a/be/test/formats/orc/utils_test.cpp
+++ b/be/test/formats/orc/utils_test.cpp
@@ -170,6 +170,7 @@ TEST(Decimal, testDecimalComparison) {
 
     // more tests
     EXPECT_TRUE(compare(Decimal(Int128("-99999999999999999999999999999999999999"), 38), Decimal(Int128(100), 0)));
+    EXPECT_FALSE(compare(Decimal(Int128(0), 38), Decimal(Int128(Int128::minimumValue()), 37)));
 }
 
 } // namespace orc

--- a/be/test/formats/orc/utils_test.cpp
+++ b/be/test/formats/orc/utils_test.cpp
@@ -171,6 +171,7 @@ TEST(Decimal, testDecimalComparison) {
     // more tests
     EXPECT_TRUE(compare(Decimal(Int128("-99999999999999999999999999999999999999"), 38), Decimal(Int128(100), 0)));
     EXPECT_FALSE(compare(Decimal(Int128(0), 38), Decimal(Int128(Int128::minimumValue()), 37)));
+    EXPECT_FALSE(compare(Decimal(Int128(Int128::maximumValue()), 38), Decimal(Int128("-1"), 37)));
 }
 
 } // namespace orc


### PR DESCRIPTION
## Why I'm doing:

The original implementation write decimal data slowly.

## What I'm doing:

This PR is two-fold:
- rewrite the function of comparing two decimal values.
- disable the computation of the sum of decimal values. 

The performance test is conducted by using a cluster of (1 FE + 3BE, where each instance has 8 cores and 32GiB memory).

Without this patch:
<img width="1105" alt="image" src="https://github.com/StarRocks/starrocks/assets/16740944/f9b6c2e7-c9e9-473d-94c5-4d1771b2d4d8">


With this patch: 
<img width="1096" alt="image" src="https://github.com/StarRocks/starrocks/assets/16740944/be73f5d5-d28c-4677-8cb0-40c5cda34e9d">

We can see a speed up of 2x times.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
