### PR TITLE
[BugFix] fix hive format name not equal to remote input format name

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/FileTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/FileTable.java
@@ -67,8 +67,8 @@ public class FileTable extends Table {
             "orc", RemoteFileInputFormat.ORC,
             "text", RemoteFileInputFormat.TEXT,
             "avro", RemoteFileInputFormat.AVRO,
-            "rctext", RemoteFileInputFormat.RC_TEXT,
-            "rcbinary", RemoteFileInputFormat.RC_BINARY,
+            "rctext", RemoteFileInputFormat.RCTEXT,
+            "rcbinary", RemoteFileInputFormat.RCBINARY,
             "sequence", RemoteFileInputFormat.SEQUENCE);
 
     @SerializedName(value = "fp")

--- a/fe/fe-core/src/main/java/com/starrocks/connector/hive/HiveStorageFormat.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/hive/HiveStorageFormat.java
@@ -62,12 +62,12 @@ public enum HiveStorageFormat {
             AVRO_INPUT_FORMAT_CLASS,
             AVRO_OUTPUT_FORMAT_CLASS
     ),
-    RC_BINARY(
+    RCBINARY(
             LAZY_BINARY_COLUMNAR_SERDE_CLASS,
             RCFILE_INPUT_FORMAT_CLASS,
             RCFILE_OUTPUT_FORMAT_CLASS
     ),
-    RC_TEXT(
+    RCTEXT(
             COLUMNAR_SERDE_CLASS,
             RCFILE_INPUT_FORMAT_CLASS,
             RCFILE_OUTPUT_FORMAT_CLASS

--- a/fe/fe-core/src/main/java/com/starrocks/connector/hive/HiveStorageFormat.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/hive/HiveStorageFormat.java
@@ -48,7 +48,7 @@ public enum HiveStorageFormat {
             PARQUET_HIVE_SERDE_CLASS,
             MAPRED_PARQUET_INPUT_FORMAT_CLASS,
             MAPRED_PARQUET_OUTPUT_FORMAT_CLASS),
-    TEXTFILE(
+    TEXT(
             LAZY_SIMPLE_SERDE_CLASS,
             TEXT_INPUT_FORMAT_CLASS,
             HIVE_IGNORE_KEY_OUTPUT_FORMAT_CLASS),
@@ -57,12 +57,12 @@ public enum HiveStorageFormat {
             AVRO_INPUT_FORMAT_CLASS,
             AVRO_OUTPUT_FORMAT_CLASS
     ),
-    RCBINARY(
+    RC_BINARY(
             LAZY_BINARY_COLUMNAR_SERDE_CLASS,
             RCFILE_INPUT_FORMAT_CLASS,
             RCFILE_OUTPUT_FORMAT_CLASS
     ),
-    RCTEXT(
+    RC_TEXT(
             COLUMNAR_SERDE_CLASS,
             RCFILE_INPUT_FORMAT_CLASS,
             RCFILE_OUTPUT_FORMAT_CLASS

--- a/fe/fe-core/src/main/java/com/starrocks/connector/hive/HiveStorageFormat.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/hive/HiveStorageFormat.java
@@ -14,14 +14,9 @@
 
 package com.starrocks.connector.hive;
 
-import com.google.common.base.Preconditions;
 import com.starrocks.connector.exception.StarRocksConnectorException;
 
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.List;
 import java.util.Map;
-import java.util.stream.Collectors;
 
 import static com.starrocks.connector.hive.HiveClassNames.AVRO_INPUT_FORMAT_CLASS;
 import static com.starrocks.connector.hive.HiveClassNames.AVRO_OUTPUT_FORMAT_CLASS;
@@ -82,17 +77,6 @@ public enum HiveStorageFormat {
     private final String serde;
     private final String inputFormat;
     private final String outputFormat;
-
-    // name consistency check.
-    {
-        List<String> hiveStorageFormats =
-                Arrays.stream(HiveStorageFormat.values()).map(x -> x.name()).collect(Collectors.toList());
-        List<String> remoteInputFormats =
-                Arrays.stream(RemoteFileInputFormat.values()).map(x -> x.name()).collect(Collectors.toList());
-        Collections.sort(hiveStorageFormats);
-        Collections.sort(remoteInputFormats);
-        Preconditions.checkArgument(hiveStorageFormats.equals(remoteInputFormats));
-    }
 
     public static HiveStorageFormat get(String format) {
         for (HiveStorageFormat storageFormat : HiveStorageFormat.values()) {

--- a/fe/fe-core/src/main/java/com/starrocks/connector/hive/HiveStorageFormat.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/hive/HiveStorageFormat.java
@@ -14,9 +14,14 @@
 
 package com.starrocks.connector.hive;
 
+import com.google.common.base.Preconditions;
 import com.starrocks.connector.exception.StarRocksConnectorException;
 
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 import static com.starrocks.connector.hive.HiveClassNames.AVRO_INPUT_FORMAT_CLASS;
 import static com.starrocks.connector.hive.HiveClassNames.AVRO_OUTPUT_FORMAT_CLASS;
@@ -77,6 +82,17 @@ public enum HiveStorageFormat {
     private final String serde;
     private final String inputFormat;
     private final String outputFormat;
+
+    // name consistency check.
+    {
+        List<String> hiveStorageFormats =
+                Arrays.stream(HiveStorageFormat.values()).map(x -> x.name()).collect(Collectors.toList());
+        List<String> remoteInputFormats =
+                Arrays.stream(RemoteFileInputFormat.values()).map(x -> x.name()).collect(Collectors.toList());
+        Collections.sort(hiveStorageFormats);
+        Collections.sort(remoteInputFormats);
+        Preconditions.checkArgument(hiveStorageFormats.equals(remoteInputFormats));
+    }
 
     public static HiveStorageFormat get(String format) {
         for (HiveStorageFormat storageFormat : HiveStorageFormat.values()) {

--- a/fe/fe-core/src/main/java/com/starrocks/connector/hive/RemoteFileInputFormat.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/hive/RemoteFileInputFormat.java
@@ -30,8 +30,8 @@ public enum RemoteFileInputFormat {
     ORC,
     TEXT,
     AVRO,
-    RC_BINARY,
-    RC_TEXT,
+    RCBINARY,
+    RCTEXT,
     SEQUENCE,
     UNKNOWN;
     private static final ImmutableMap<String, RemoteFileInputFormat> CLASS_NAME_TO_INPUT_FORMAT =
@@ -40,7 +40,7 @@ public enum RemoteFileInputFormat {
                     .put(ORC_INPUT_FORMAT_CLASS, ORC)
                     .put(TEXT_INPUT_FORMAT_CLASS, TEXT)
                     .put(AVRO_INPUT_FORMAT_CLASS, AVRO)
-                    .put(RCFILE_INPUT_FORMAT_CLASS, RC_BINARY)
+                    .put(RCFILE_INPUT_FORMAT_CLASS, RCBINARY)
                     .put(SEQUENCE_INPUT_FORMAT_CLASS, SEQUENCE)
                     .build();
     private static final ImmutableMap<String, Boolean> INPUT_FORMAT_SPLITTABLE =
@@ -82,9 +82,9 @@ public enum RemoteFileInputFormat {
                 return THdfsFileFormat.TEXT;
             case AVRO:
                 return THdfsFileFormat.AVRO;
-            case RC_BINARY:
+            case RCBINARY:
                 return THdfsFileFormat.RC_BINARY;
-            case RC_TEXT:
+            case RCTEXT:
                 return THdfsFileFormat.RC_TEXT;
             case SEQUENCE:
                 return THdfsFileFormat.SEQUENCE_FILE;

--- a/fe/fe-core/src/test/java/com/starrocks/catalog/HiveTableTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/HiveTableTest.java
@@ -257,8 +257,8 @@ public class HiveTableTest {
 
         List<String> targetFormats = new ArrayList<>();
         targetFormats.add("AVRO");
-        targetFormats.add("RC_BINARY");
-        targetFormats.add("RC_TEXT");
+        targetFormats.add("RCBINARY");
+        targetFormats.add("RCTEXT");
         targetFormats.add("SEQUENCE");
 
         for (String targetFormat : targetFormats) {

--- a/fe/fe-core/src/test/java/com/starrocks/connector/hive/HiveStorageFormatTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/hive/HiveStorageFormatTest.java
@@ -26,6 +26,6 @@ public class HiveStorageFormatTest {
                 "Please use 'file_format' instead of 'format' in the table properties",
                 () -> HiveStorageFormat.check(ImmutableMap.of("format", "csv")));
 
-        HiveStorageFormat.check(ImmutableMap.of("file_format", "textfile"));
+        HiveStorageFormat.check(ImmutableMap.of("file_format", "text"));
     }
 }


### PR DESCRIPTION
## Why I'm doing:

`HiveStorageFormat`'s name set should be equal to `RemoteFileInputFormat`'s name set

## What I'm doing:

This bug is introduced in this PR https://github.com/StarRocks/starrocks/pull/42812. I thought it was ok to just rename enum name, but there are many places based on this name.

We'd better to refactor this code to make sure here is only a single source of truth.

Fixes https://github.com/StarRocks/StarRocksTest/issues/6618

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
