### PR TITLE
[Tool] Restart crashed BE process at the application level and collect coredump

### DIFF
--- a/docker/dockerfiles/be/be_entrypoint.sh
+++ b/docker/dockerfiles/be/be_entrypoint.sh
@@ -9,7 +9,7 @@ MY_SELF=
 MY_IP=`hostname -i`
 MY_HOSTNAME=`hostname -f`
 STARROCKS_ROOT=${STARROCKS_ROOT:-"/opt/starrocks"}
-STARROCKS_HOME=${STARROCKS_ROOT}/be
+export STARROCKS_HOME=${STARROCKS_ROOT}/be
 BE_CONFIG=$STARROCKS_HOME/conf/be.conf
 
 
@@ -109,7 +109,7 @@ collect_env_info
 add_self $svc_name || exit $?
 log_stderr "run start_be.sh"
 
-if [ $COREDUMP_ENABLED == "true" ]; then
+if [[ "$COREDUMP_ENABLED" == "true" ]]; then
   # start inotifywait loop daemon to monitor core dump generation
   $STARROCKS_ROOT/upload_coredump.sh &
 fi
@@ -132,7 +132,7 @@ while true; do
       tail -n $nol $STARROCKS_HOME/log/be.out
   fi
 
-  if [ $COREDUMP_ENABLED != "true" ]; then
+  if [[ "$COREDUMP_ENABLED" != "true" ]]; then
     exit $ret
   fi
 

--- a/docker/dockerfiles/be/upload_coredump.sh
+++ b/docker/dockerfiles/be/upload_coredump.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/bash
+
+coredump_log()
+{
+    echo "[`date`] [coredump] $@" >&2
+}
+
+COREDUMP_PATH=/opt/starrocks/be/storage/coredumps
+
+if [ ! -d ${COREDUMP_PATH} ]; then
+    mkdir -p ${COREDUMP_PATH}
+fi
+
+cd $COREDUMP_PATH
+
+while true; do
+
+  latestCoreFile=""
+
+  # Setup inotifywait loop to wait until core file has been completely written
+  while read -r path action file; do
+    coredump_log "${action} ${path}${file}"
+
+    if [[ "$file" = core.*  ]]; then
+      latestCoreFile=$file
+    fi
+  done < <(inotifywait -e close_write $COREDUMP_PATH)
+
+  if [[ $latestCoreFile == "" ]]; then
+    coredump_log "missiong core file name"
+
+    continue
+  fi
+
+  coredump_log "Core dump generated $latestCoreFile"
+  coredump_log "$(ls -lh ${latestCoreFile})"
+
+  fileSize=$(ls -lh "${latestCoreFile}" | awk '{print $5}')
+  fileSizeBytes=$(stat -c %s "${latestCoreFile}")
+
+
+  # Check if file size is greater than 1TB (1000 GB)
+  if [[ "$fileSize" =~ T$ ]]; then
+      coredump_log "File size (${fileSizeBytes} B) exceeds 1TB: ${fileSizeBytes} bytes, skip"
+      rm ${latestCoreFile}
+
+      continue
+  fi
+
+
+  DATESTR=`TZ=${TZ} date +"%m-%d-%y.%H-%M-%S.%Z"`
+  COREDUMP_FILE_ZIP=${KUBE_CLUSTER_NAME}.${POD_NAMESPACE}.${POD_NAME}.${SR_IMAGE_TAG}.${DATESTR}.gz
+
+  coredump_log "Compressing core dump files to ${COREDUMP_FILE_ZIP} ..."
+  pigz -c $latestCoreFile > $COREDUMP_FILE_ZIP
+
+
+  coredump_log "Zip complete"
+  coredump_log "$(ls -lh ${COREDUMP_FILE_ZIP})"
+
+
+  rclone --config=/opt/starrocks/rclone.conf --bwlimit 1000M --multi-thread-streams 100 --multi-thread-cutoff 8M --progress sync $COREDUMP_FILE_ZIP coredump:${COREDUMP_BLOBSTORE_PREFIX}/${KUBE_CLUSTER_NAME}/${POD_NAMESPACE}
+
+
+  coredump_log "Upload complete: ${latestCoreFile}"
+
+  # Only clean the uploaded core dump file
+  rm $latestCoreFile $COREDUMP_FILE_ZIP
+
+done

--- a/docker/dockerfiles/be/upload_coredump.sh
+++ b/docker/dockerfiles/be/upload_coredump.sh
@@ -8,7 +8,8 @@ coredump_log()
 # Define constant for 1TB in bytes
 TB_IN_BYTES=$((1024 * 1024 * 1024 * 1024))
 
-COREDUMP_PATH=$STARROCKS_HOME/storage/coredumps
+# Set COREDUMP_PATH if hasn't been set in environment variable
+COREDUMP_PATH=${COREDUMP_PATH:-$STARROCKS_HOME/storage/coredumps}
 
 if [ ! -d ${COREDUMP_PATH} ]; then
     mkdir -p ${COREDUMP_PATH}

--- a/docker/dockerfiles/be/upload_coredump.sh
+++ b/docker/dockerfiles/be/upload_coredump.sh
@@ -31,7 +31,7 @@ while true; do
   done < <(inotifywait -e close_write $COREDUMP_PATH)
 
   if [[ $latestCoreFile == "" ]]; then
-    coredump_log "missiong core file name"
+    coredump_log "missing core file name"
 
     continue
   fi


### PR DESCRIPTION
## Why I'm doing:
collect coredump in k8s environment

## What I'm doing:
- Restart crashed BE process at the application level
- Compress coredump
- Upload coredump zip to blobstore

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [x] This pr needs user documentation (for new or modified features or behaviors)
  - [x] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [x] 3.1-cs 
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5

