### PR TITLE
[Enhancement] Support modify 'fast_schema_evolution' property for newly created tables

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/alter/AlterJobMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/AlterJobMgr.java
@@ -696,7 +696,8 @@ public class AlterJobMgr {
                         properties.containsKey(PropertyAnalyzer.PROPERTIES_BINLOG_MAX_SIZE) ||
                         properties.containsKey(PropertyAnalyzer.PROPERTIES_FOREIGN_KEY_CONSTRAINT) ||
                         properties.containsKey(PropertyAnalyzer.PROPERTIES_UNIQUE_CONSTRAINT) ||
-                        properties.containsKey(PropertyAnalyzer.PROPERTIES_PRIMARY_INDEX_CACHE_EXPIRE_SEC));
+                        properties.containsKey(PropertyAnalyzer.PROPERTIES_PRIMARY_INDEX_CACHE_EXPIRE_SEC) ||
+                        properties.containsKey(PropertyAnalyzer.PROPERTIES_USE_FAST_SCHEMA_EVOLUTION));
 
                 olapTable = (OlapTable) db.getTable(tableName);
                 if (properties.containsKey(PropertyAnalyzer.PROPERTIES_INMEMORY)) {
@@ -717,6 +718,15 @@ public class AlterJobMgr {
                 } else if (properties.containsKey(PropertyAnalyzer.PROPERTIES_PRIMARY_INDEX_CACHE_EXPIRE_SEC)) {
                     schemaChangeHandler.updateTableMeta(db, tableName, properties,
                             TTabletMetaType.PRIMARY_INDEX_CACHE_EXPIRE_SEC);
+                } else if (properties.containsKey(PropertyAnalyzer.PROPERTIES_USE_FAST_SCHEMA_EVOLUTION)) {
+                    if (!olapTable.canUseFastSchemaEvolution()) {
+                        String s = "table: " + olapTable.getName() + " maybe created in old version and does not support"
+                                + " modify meta: FAST_SCHEMA_EVOLUTION";
+                        LOG.warn(s);
+                        throw new DdlException(s);
+                    }
+                    schemaChangeHandler.updateTableMeta(db, tableName, properties,
+                            TTabletMetaType.FAST_SCHEMA_EVOLUTION);
                 } else if (properties.containsKey(PropertyAnalyzer.PROPERTIES_BINLOG_ENABLE) ||
                         properties.containsKey(PropertyAnalyzer.PROPERTIES_BINLOG_TTL) ||
                         properties.containsKey(PropertyAnalyzer.PROPERTIES_BINLOG_MAX_SIZE)) {

--- a/fe/fe-core/src/main/java/com/starrocks/alter/SchemaChangeHandler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/SchemaChangeHandler.java
@@ -239,10 +239,10 @@ public class SchemaChangeHandler extends AlterHandler {
             }
         }
 
-        boolean ligthSchemaChange = olapTable.enableFastSchemaEvolution();
+        boolean fastSchemaEvolution = olapTable.enableFastSchemaEvolution();
         if (alterClause.getGeneratedColumnPos() == null) {
             for (Column column : columns) {
-                ligthSchemaChange &= addColumnInternal(olapTable, column, null, targetIndexId, baseIndexId, indexSchemaMap,
+                fastSchemaEvolution &= addColumnInternal(olapTable, column, null, targetIndexId, baseIndexId, indexSchemaMap,
                         newColNameSet);
             }
         } else {
@@ -251,10 +251,10 @@ public class SchemaChangeHandler extends AlterHandler {
                 addColumnInternal(olapTable, column, alterClause.getGeneratedColumnPos(),
                         targetIndexId, baseIndexId, indexSchemaMap, newColNameSet);
                 // add a generated column need to rewrite data, can not use light schema change
-                ligthSchemaChange = false;
+                fastSchemaEvolution = false;
             }
         }
-        return ligthSchemaChange;
+        return fastSchemaEvolution;
     }
 
     /**

--- a/fe/fe-core/src/main/java/com/starrocks/alter/SchemaChangeHandler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/SchemaChangeHandler.java
@@ -1513,7 +1513,6 @@ public class SchemaChangeHandler extends AlterHandler {
             throw new DdlException("olapTable is null");
         }
         boolean fastSchemaEvolution = olapTable.enableFastSchemaEvolution();
-        //for multi add colmuns clauses
         IntSupplier colUniqueIdSupplier = new IntSupplier() {
             private int pendingMaxColUniqueId = olapTable.getMaxColUniqueId();
 
@@ -1762,7 +1761,6 @@ public class SchemaChangeHandler extends AlterHandler {
     public ShowResultSet process(List<AlterClause> alterClauses, Database db, OlapTable olapTable)
             throws UserException {
         AlterJobV2 schemaChangeJob = analyzeAndCreateJob(alterClauses, db, olapTable);
-        LOG.info("table: {} max column unique id: {}", olapTable.getName(), olapTable.getMaxColUniqueId());
         if (schemaChangeJob == null) {
             return null;
         }

--- a/fe/fe-core/src/main/java/com/starrocks/alter/SchemaChangeJobV2.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/SchemaChangeJobV2.java
@@ -758,6 +758,7 @@ public class SchemaChangeJobV2 extends AlterJobV2 {
             this.finishedTimeMs = System.currentTimeMillis();
 
             journalTask = editLog.logAlterJobNoWait(this);
+            LOG.info("table: {} max column unique id: {}", tbl.getName(), tbl.getMaxColUniqueId());
         } finally {
             locker.unLockDatabase(db, LockType.WRITE);
         }

--- a/fe/fe-core/src/main/java/com/starrocks/alter/SchemaChangeJobV2.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/SchemaChangeJobV2.java
@@ -758,7 +758,6 @@ public class SchemaChangeJobV2 extends AlterJobV2 {
             this.finishedTimeMs = System.currentTimeMillis();
 
             journalTask = editLog.logAlterJobNoWait(this);
-            LOG.info("table: {} max column unique id: {}", tbl.getName(), tbl.getMaxColUniqueId());
         } finally {
             locker.unLockDatabase(db, LockType.WRITE);
         }

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/MaterializedView.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/MaterializedView.java
@@ -125,7 +125,7 @@ public class MaterializedView extends OlapTable implements GsonPreProcessable, G
     }
 
     @Override
-    public boolean getUseFastSchemaEvolution() {
+    public boolean enableFastSchemaEvolution() {
         return false;
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/OlapTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/OlapTable.java
@@ -2806,8 +2806,19 @@ public class OlapTable extends Table {
         tableProperty.setForeignKeyConstraints(foreignKeyConstraints);
     }
 
+    public boolean canUseFastSchemaEvolution() {
+        return maxColUniqueId > Column.COLUMN_UNIQUE_ID_INIT_VALUE;
+    }
+
     public boolean getUseFastSchemaEvolution() {
-        if (hasRowStorageType()) {
+        if (tableProperty != null) {
+            return tableProperty.getUseFastSchemaEvolution();
+        }
+        return false;
+    }
+
+    public boolean enableFastSchemaEvolution() {
+        if (!canUseFastSchemaEvolution() || hasRowStorageType()) {
             // row storage type does not support fast schema evolution currently
             return false;
         }

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/OlapTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/OlapTable.java
@@ -2817,6 +2817,8 @@ public class OlapTable extends Table {
         return false;
     }
 
+    // if table can use fast schema evolution and `fast_schema_evolution` in property is true,
+    // enableFastSchemaEvolution return true
     public boolean enableFastSchemaEvolution() {
         if (!canUseFastSchemaEvolution() || hasRowStorageType()) {
             // row storage type does not support fast schema evolution currently

--- a/fe/fe-core/src/main/java/com/starrocks/journal/JournalEntity.java
+++ b/fe/fe-core/src/main/java/com/starrocks/journal/JournalEntity.java
@@ -866,7 +866,8 @@ public class JournalEntity implements Writable {
             case OperationType.OP_MODIFY_ENABLE_PERSISTENT_INDEX:
             case OperationType.OP_MODIFY_PRIMARY_INDEX_CACHE_EXPIRE_SEC:
             case OperationType.OP_ALTER_TABLE_PROPERTIES:
-            case OperationType.OP_MODIFY_TABLE_CONSTRAINT_PROPERTY: {
+            case OperationType.OP_MODIFY_TABLE_CONSTRAINT_PROPERTY:
+            case OperationType.OP_MODIFY_FAST_SCHEMA_EVOLUTION: {
                 data = ModifyTablePropertyOperationLog.read(in);
                 isRead = true;
                 break;

--- a/fe/fe-core/src/main/java/com/starrocks/lake/LakeTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/lake/LakeTable.java
@@ -261,7 +261,7 @@ public class LakeTable extends OlapTable {
     }
 
     @Override
-    public boolean getUseFastSchemaEvolution() {
+    public boolean enableFastSchemaEvolution() {
         return !hasRowStorageType() && Config.enable_fast_schema_evolution_in_share_data_mode;
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/persist/EditLog.java
+++ b/fe/fe-core/src/main/java/com/starrocks/persist/EditLog.java
@@ -851,7 +851,8 @@ public class EditLog {
                 case OperationType.OP_MODIFY_ENABLE_PERSISTENT_INDEX:
                 case OperationType.OP_MODIFY_PRIMARY_INDEX_CACHE_EXPIRE_SEC:
                 case OperationType.OP_ALTER_TABLE_PROPERTIES:
-                case OperationType.OP_MODIFY_TABLE_CONSTRAINT_PROPERTY: {
+                case OperationType.OP_MODIFY_TABLE_CONSTRAINT_PROPERTY: 
+                case OperationType.OP_MODIFY_FAST_SCHEMA_EVOLUTION: {
                     ModifyTablePropertyOperationLog modifyTablePropertyOperationLog =
                             (ModifyTablePropertyOperationLog) journal.getData();
                     globalStateMgr.getLocalMetastore().replayModifyTableProperty(opCode, modifyTablePropertyOperationLog);
@@ -1718,6 +1719,10 @@ public class EditLog {
 
     public void logModifyPrimaryIndexCacheExpireSec(ModifyTablePropertyOperationLog info) {
         logEdit(OperationType.OP_MODIFY_PRIMARY_INDEX_CACHE_EXPIRE_SEC, info);
+    }
+
+    public void logModifyFastSchemaEvolution(ModifyTablePropertyOperationLog info) {
+        logEdit(OperationType.OP_MODIFY_FAST_SCHEMA_EVOLUTION, info);
     }
 
     public void logModifyWriteQuorum(ModifyTablePropertyOperationLog info) {

--- a/fe/fe-core/src/main/java/com/starrocks/persist/OperationType.java
+++ b/fe/fe-core/src/main/java/com/starrocks/persist/OperationType.java
@@ -927,6 +927,8 @@ public class OperationType {
     public static final short OP_DISABLE_TABLE_RECOVERY = 13510;
     @IgnorableOnReplayFailed
     public static final short OP_DISABLE_PARTITION_RECOVERY = 13511;
+    @IgnorableOnReplayFailed
+    public static final short OP_MODIFY_FAST_SCHEMA_EVOLUTION = 13512;
 
     /**
      * NOTICE: OperationType cannot use a value exceeding 20000, and an error will be reported if it exceeds

--- a/fe/fe-core/src/main/java/com/starrocks/server/LocalMetastore.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/LocalMetastore.java
@@ -4661,7 +4661,7 @@ public class LocalMetastore implements ConnectorMetadata {
 
     public void modifyTableFastSchemaEvolution(Database db, OlapTable table, Map<String, String> properties) {
         Locker locker = new Locker();
-        Preconditions.checkArgument(locker.isWriteLockHeldByCurrentThread(db));
+        Preconditions.checkArgument(locker.isDbWriteLockHeldByCurrentThread(db));
         TableProperty tableProperty = table.getTableProperty();
         if (tableProperty == null) {
             tableProperty = new TableProperty(properties);

--- a/fe/fe-core/src/main/java/com/starrocks/server/OlapTableFactory.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/OlapTableFactory.java
@@ -265,16 +265,15 @@ public class OlapTableFactory implements AbstractTableFactory {
                 throw new DdlException(e.getMessage());
             }
             table.setUseFastSchemaEvolution(useFastSchemaEvolution);
+
+            List<Integer> sortKeyUniqueIds = new ArrayList<>();
             for (Column column : baseSchema) {
                 column.setUniqueId(table.incAndGetMaxColUniqueId());
+                LOG.debug("table: {}, newColumn: {}, uniqueId: {}", table.getName(), column.getName(),
+                        column.getUniqueId());
             }
-            List<Integer> sortKeyUniqueIds = new ArrayList<>();
-            if (useFastSchemaEvolution) {
-                for (Integer idx : sortKeyIdxes) {
-                    sortKeyUniqueIds.add(baseSchema.get(idx).getUniqueId());
-                }
-            } else {
-                LOG.debug("table: {} doesn't use light schema change", table.getName());
+            for (Integer idx : sortKeyIdxes) {
+                sortKeyUniqueIds.add(baseSchema.get(idx).getUniqueId());
             }
 
             // analyze bloom filter columns

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AlterTableClauseVisitor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AlterTableClauseVisitor.java
@@ -319,6 +319,15 @@ public class AlterTableClauseVisitor implements AstVisitor<Void, ConnectContext>
                 ErrorReport.reportSemanticException(ErrorCode.ERR_COMMON_ERROR, e.getMessage());
             }
             clause.setNeedTableStable(false);
+        } else if (properties.containsKey(PropertyAnalyzer.PROPERTIES_USE_FAST_SCHEMA_EVOLUTION)) {
+            if (!properties.get(PropertyAnalyzer.PROPERTIES_USE_FAST_SCHEMA_EVOLUTION).equalsIgnoreCase("true") &&
+                    !properties.get(PropertyAnalyzer.PROPERTIES_USE_FAST_SCHEMA_EVOLUTION).equalsIgnoreCase("false")) {
+                ErrorReport.reportSemanticException(ErrorCode.ERR_COMMON_ERROR,
+                        "Property " + PropertyAnalyzer.PROPERTIES_USE_FAST_SCHEMA_EVOLUTION +
+                                " must be bool type(false/true)");
+            }
+            clause.setNeedTableStable(false);
+            clause.setOpType(AlterOpType.MODIFY_TABLE_PROPERTY_SYNC);
         } else {
             ErrorReport.reportSemanticException(ErrorCode.ERR_COMMON_ERROR, "Unknown properties: " + properties);
         }

--- a/gensrc/thrift/AgentService.thrift
+++ b/gensrc/thrift/AgentService.thrift
@@ -413,7 +413,8 @@ enum TTabletMetaType {
     BINLOG_CONFIG,
     BUCKET_SIZE,
     PRIMARY_INDEX_CACHE_EXPIRE_SEC,
-    STORAGE_TYPE
+    STORAGE_TYPE,
+    FAST_SCHEMA_EVOLUTION
 }
 
 struct TTabletMetaInfo {

--- a/test/sql/test_fast_schema_evolution/R/test_fast_schema_evolution
+++ b/test/sql/test_fast_schema_evolution/R/test_fast_schema_evolution
@@ -851,12 +851,10 @@ tab1	CREATE TABLE `tab1` (
 DUPLICATE KEY(`k1`, `k2`)
 DISTRIBUTED BY HASH(`k1`) BUCKETS 1 
 PROPERTIES (
-"replication_num" = "1",
-"in_memory" = "false",
-"enable_persistent_index" = "false",
-"replicated_storage" = "true",
+"compression" = "LZ4",
 "fast_schema_evolution" = "true",
-"compression" = "LZ4"
+"replicated_storage" = "true",
+"replication_num" = "1"
 );
 -- !result
 alter table tab1 set ("fast_schema_evolution" = "false");
@@ -876,11 +874,9 @@ tab1	CREATE TABLE `tab1` (
 DUPLICATE KEY(`k1`, `k2`)
 DISTRIBUTED BY HASH(`k1`) BUCKETS 1 
 PROPERTIES (
-"replication_num" = "1",
-"in_memory" = "false",
-"enable_persistent_index" = "false",
+"compression" = "LZ4",
 "replicated_storage" = "true",
-"compression" = "LZ4"
+"replication_num" = "1"
 );
 -- !result
 alter table tab1 set ("fast_schema_evolution" = "true");
@@ -900,12 +896,10 @@ tab1	CREATE TABLE `tab1` (
 DUPLICATE KEY(`k1`, `k2`)
 DISTRIBUTED BY HASH(`k1`) BUCKETS 1 
 PROPERTIES (
-"replication_num" = "1",
-"in_memory" = "false",
-"enable_persistent_index" = "false",
-"replicated_storage" = "true",
+"compression" = "LZ4",
 "fast_schema_evolution" = "true",
-"compression" = "LZ4"
+"replicated_storage" = "true",
+"replication_num" = "1"
 );
 -- !result
 drop table tab1;

--- a/test/sql/test_fast_schema_evolution/R/test_fast_schema_evolution
+++ b/test/sql/test_fast_schema_evolution/R/test_fast_schema_evolution
@@ -812,3 +812,105 @@ drop table tab1;
 drop database test_alter_with_rollup;
 -- result:
 -- !result
+-- name: test_alter_fast_schema_evolution
+create database test_alter_fast_schema_evolution;
+-- result:
+-- !result
+use test_alter_fast_schema_evolution;
+-- result:
+-- !result
+CREATE table tab1 (
+      k1 INTEGER,
+      k2 VARCHAR(50),
+      v1 INTEGER,
+      v2 INTEGER,
+      v3 INTEGER,
+      v4 varchar(50),
+      v5 varchar(50)
+)
+ENGINE=OLAP
+DUPLICATE KEY(`k1`,`k2`)
+DISTRIBUTED BY HASH(`k1`) BUCKETS 1
+PROPERTIES (
+    "replication_num" = "1",
+    "fast_schema_evolution" = "true"
+);
+-- result:
+-- !result
+show create table tab1;
+-- result:
+tab1	CREATE TABLE `tab1` (
+  `k1` int(11) NULL COMMENT "",
+  `k2` varchar(50) NULL COMMENT "",
+  `v1` int(11) NULL COMMENT "",
+  `v2` int(11) NULL COMMENT "",
+  `v3` int(11) NULL COMMENT "",
+  `v4` varchar(50) NULL COMMENT "",
+  `v5` varchar(50) NULL COMMENT ""
+) ENGINE=OLAP 
+DUPLICATE KEY(`k1`, `k2`)
+DISTRIBUTED BY HASH(`k1`) BUCKETS 1 
+PROPERTIES (
+"replication_num" = "1",
+"in_memory" = "false",
+"enable_persistent_index" = "false",
+"replicated_storage" = "true",
+"fast_schema_evolution" = "true",
+"compression" = "LZ4"
+);
+-- !result
+alter table tab1 set ("fast_schema_evolution" = "false");
+-- result:
+-- !result
+show create table tab1;
+-- result:
+tab1	CREATE TABLE `tab1` (
+  `k1` int(11) NULL COMMENT "",
+  `k2` varchar(50) NULL COMMENT "",
+  `v1` int(11) NULL COMMENT "",
+  `v2` int(11) NULL COMMENT "",
+  `v3` int(11) NULL COMMENT "",
+  `v4` varchar(50) NULL COMMENT "",
+  `v5` varchar(50) NULL COMMENT ""
+) ENGINE=OLAP 
+DUPLICATE KEY(`k1`, `k2`)
+DISTRIBUTED BY HASH(`k1`) BUCKETS 1 
+PROPERTIES (
+"replication_num" = "1",
+"in_memory" = "false",
+"enable_persistent_index" = "false",
+"replicated_storage" = "true",
+"compression" = "LZ4"
+);
+-- !result
+alter table tab1 set ("fast_schema_evolution" = "true");
+-- result:
+-- !result
+show create table tab1;
+-- result:
+tab1	CREATE TABLE `tab1` (
+  `k1` int(11) NULL COMMENT "",
+  `k2` varchar(50) NULL COMMENT "",
+  `v1` int(11) NULL COMMENT "",
+  `v2` int(11) NULL COMMENT "",
+  `v3` int(11) NULL COMMENT "",
+  `v4` varchar(50) NULL COMMENT "",
+  `v5` varchar(50) NULL COMMENT ""
+) ENGINE=OLAP 
+DUPLICATE KEY(`k1`, `k2`)
+DISTRIBUTED BY HASH(`k1`) BUCKETS 1 
+PROPERTIES (
+"replication_num" = "1",
+"in_memory" = "false",
+"enable_persistent_index" = "false",
+"replicated_storage" = "true",
+"fast_schema_evolution" = "true",
+"compression" = "LZ4"
+);
+-- !result
+drop table tab1;
+-- result:
+-- !result
+drop database test_alter_fast_schema_evolution;
+-- result:
+-- !result

--- a/test/sql/test_fast_schema_evolution/T/test_fast_schema_evolution
+++ b/test/sql/test_fast_schema_evolution/T/test_fast_schema_evolution
@@ -361,3 +361,35 @@ select * from tab1;
 
 drop table tab1;
 drop database test_alter_with_rollup;
+
+-- name: test_alter_fast_schema_evolution
+create database test_alter_fast_schema_evolution;
+use test_alter_fast_schema_evolution;
+
+CREATE table tab1 (
+      k1 INTEGER,
+      k2 VARCHAR(50),
+      v1 INTEGER,
+      v2 INTEGER,
+      v3 INTEGER,
+      v4 varchar(50),
+      v5 varchar(50)
+)
+ENGINE=OLAP
+DUPLICATE KEY(`k1`,`k2`)
+DISTRIBUTED BY HASH(`k1`) BUCKETS 1
+PROPERTIES (
+    "replication_num" = "1",
+    "fast_schema_evolution" = "true"
+);
+
+show create table tab1;
+
+alter table tab1 set ("fast_schema_evolution" = "false");
+show create table tab1;
+
+alter table tab1 set ("fast_schema_evolution" = "true");
+show create table tab1;
+
+drop table tab1;
+drop database test_alter_fast_schema_evolution;


### PR DESCRIPTION
## Why I'm doing:
The 'fast_schema_evolution' property can now only be specified during table creation and does not support subsequent modifications. However, modifications to 'fast_schema_evolution' can be supported for newly created tables.

## What I'm doing:
Support modify 'fast_schema_evolution' property for new created table.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [x] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
