### PR TITLE
[BugFix] Revert "[Enhancement] No UNSTABLE state is set when offset is not initialized (#42619)"

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/load/routineload/KafkaRoutineLoadJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/routineload/KafkaRoutineLoadJob.java
@@ -815,16 +815,14 @@ public class KafkaRoutineLoadJob extends RoutineLoadJob {
         long now = System.currentTimeMillis();
 
         for (Map.Entry<Integer, Long> entry : partitionTimestamps.entrySet()) {
-            if (entry.getValue().longValue() > 0 && Config.routine_load_unstable_threshold_second > 0) {
-                int partition = entry.getKey();
-                long lag = (now - entry.getValue().longValue()) / 1000;
-                if (lag > Config.routine_load_unstable_threshold_second) {
-                    updateSubstate(JobSubstate.UNSTABLE, new ErrorReason(InternalErrorCode.SLOW_RUNNING_ERR,
-                            String.format("The lag [%d] of partition [%d] exceeds " +
-                                            "Config.routine_load_unstable_threshold_second [%d]",
-                                    lag, partition, Config.routine_load_unstable_threshold_second)));
-                    return;
-                }
+            int partition = entry.getKey();
+            long lag = (now - entry.getValue().longValue()) / 1000;
+            if (lag > Config.routine_load_unstable_threshold_second) {
+                updateSubstate(JobSubstate.UNSTABLE, new ErrorReason(InternalErrorCode.SLOW_RUNNING_ERR,
+                        String.format("The lag [%d] of partition [%d] exceeds " +
+                                        "Config.routine_load_unstable_threshold_second [%d]",
+                                lag, partition, Config.routine_load_unstable_threshold_second)));
+                return;
             }
         }
         updateSubstate(JobSubstate.STABLE, null);

--- a/fe/fe-core/src/main/java/com/starrocks/load/routineload/RoutineLoadJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/routineload/RoutineLoadJob.java
@@ -960,9 +960,6 @@ public abstract class RoutineLoadJob extends AbstractTxnStateChangeCallback impl
     public void afterCommitted(TransactionState txnState, boolean txnOperated) throws UserException {
         long taskBeId = -1L;
         try {
-            // Update the job state is the job is too slow.
-            updateSubstate();
-
             if (txnOperated) {
                 // find task in job
                 Optional<RoutineLoadTaskInfo> routineLoadTaskInfoOptional = routineLoadTaskInfoList.stream().filter(
@@ -1090,9 +1087,6 @@ public abstract class RoutineLoadJob extends AbstractTxnStateChangeCallback impl
             throws UserException {
         long taskBeId = -1L;
         try {
-            // Update the job state is the job is too slow.
-            updateSubstate();
-
             if (txnOperated) {
                 // step0: find task in job
                 Optional<RoutineLoadTaskInfo> routineLoadTaskInfoOptional = routineLoadTaskInfoList.stream().filter(
@@ -1969,9 +1963,6 @@ public abstract class RoutineLoadJob extends AbstractTxnStateChangeCallback impl
 
     protected void updateSubstate(JobSubstate substate, ErrorReason reason) throws UserException {
         writeLock();
-        if (this.substate == substate && reason == null) {
-            return;
-        }
         LOG.info(new LogBuilder(LogKey.ROUTINE_LOAD_JOB, id)
                 .add("current_job_substate", this.substate)
                 .add("desire_job_substate", substate)

--- a/fe/fe-core/src/main/java/com/starrocks/load/routineload/RoutineLoadTaskScheduler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/routineload/RoutineLoadTaskScheduler.java
@@ -190,6 +190,9 @@ public class RoutineLoadTaskScheduler extends FrontendDaemon {
                 delayPutToQueue(routineLoadTaskInfo, msg);
                 return;
             }
+            // Update the job state is the job is too slow.
+            routineLoadManager.getJob(routineLoadTaskInfo.getJobId()).updateSubstate();
+
         } catch (RoutineLoadPauseException e) {
             String msg = "fe abort task with reason: check task ready to execute failed, " + e.getMessage();
             routineLoadManager.getJob(routineLoadTaskInfo.getJobId()).updateState(
@@ -201,8 +204,6 @@ public class RoutineLoadTaskScheduler extends FrontendDaemon {
         } catch (Exception e) {
             LOG.warn("check task ready to execute failed", e);
             delayPutToQueue(routineLoadTaskInfo, "check task ready to execute failed, err: " + e.getMessage());
-            // Update the job state is the job is too slow.
-            routineLoadManager.getJob(routineLoadTaskInfo.getJobId()).updateSubstate();
             return;
         }
 
@@ -216,8 +217,6 @@ public class RoutineLoadTaskScheduler extends FrontendDaemon {
                                     "current value is %d",
                             routineLoadTaskInfo.getTaskScheduleIntervalMs() / 1000,
                             Config.max_routine_load_task_num_per_be));
-            // Update the job state is the job is too slow.
-            routineLoadManager.getJob(routineLoadTaskInfo.getJobId()).updateSubstate();
             return;
         }
 


### PR DESCRIPTION
This reverts commit e6875ecf46d7cb9ff3a8253baf163eba6c28dd1b.

## Why I'm doing:

slow lock, 
write lock is not released.

`slow db locks: [{"lockState":"writeLocked","lockHoldTime":"26534083 ms","dumpThread":"dump thread: PUBLISH_VERSION, id: 24\n    java.base@11.0.22/jdk.internal.misc.Unsafe.park(Native Method)\n    java.base@11.0.22/java.util.concurrent.locks.LockSupport.park(LockSupport.java:194)\n    java.base@11.0.22/java.util.concurrent.locks.AbstractQueuedSynchronizer.parkAndCheckInterrupt(AbstractQueuedSynchronizer.java:885)\n    java.base@11.0.22/java.util.concurrent.locks.AbstractQueuedSynchronizer.acquireQueued(AbstractQueuedSynchronizer.java:917)\n    java.base@11.0.22/java.util.concurrent.locks.AbstractQueuedSynchronizer.acquire(AbstractQueuedSynchronizer.java:1240)\n    java.base@11.0.22/java.util.concurrent.locks.ReentrantReadWriteLock$WriteLock.lock(ReentrantReadWriteLock.java:959)\n    app//com.starrocks.load.routineload.RoutineLoadJob.writeLock(RoutineLoadJob.java:461)\n    app//com.starrocks.load.routineload.RoutineLoadJob.afterVisible(RoutineLoadJob.java:1018)\n    app//com.starrocks.transaction.TransactionState.afterStateTransform(TransactionState.java:586)\n    app//com.starrocks.transaction.DatabaseTransactionMgr.finishTransaction(DatabaseTransactionMgr.java:1150)\n    app//com.starrocks.transaction.GlobalTransactionMgr.finishTransaction(GlobalTransactionMgr.java:522)\n    app//com.starrocks.transaction.PublishVersionDaemon.publishVersionForOlapTable(PublishVersionDaemon.java:340)\n    app//com.starrocks.transaction.PublishVersionDaemon.runAfterCatalogReady(PublishVersionDaemon.java:142)\n    app//com.starrocks.common.util.FrontendDaemon.runOneCycle(FrontendDaemon.java:72)\n    app//com.starrocks.common.util.Daemon.run(Daemon.java:107)\n","lockDbName":"routine_load_5e52c87e_e6ef_11ee_8a2d_00163e0e489a","lockWaiters":[{"threadId":30,"threadName":"tablet stat mgr"},{"threadId":25,"threadName":"UpdateDbUsedDataQuota"},{"threadId":122,"threadName":"ReportHandler"},{"threadId":21,"threadName":"consistency checker"},{"threadId":35,"threadName":"tablet scheduler"},{"threadId":36,"threadName":"tablet checker"},{"threadId":174,"threadName":"starrocks-mysql-nio-pool-5"},{"threadId":173,"threadName":"starrocks-mysql-nio-pool-4"}]}]`

## What I'm doing:

revert #42619

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
