### PR TITLE
[Feature][Cherry-Pick][Branch-3.2] Support orc_use_column_names property in session variable (backport #42777)

### DIFF
--- a/be/src/connector/hive_connector.cpp
+++ b/be/src/connector/hive_connector.cpp
@@ -797,6 +797,7 @@ Status HiveDataSource::_init_scanner(RuntimeState* state) {
     } else if (format == THdfsFileFormat::PARQUET) {
         scanner = _pool.add(new HdfsParquetScanner());
     } else if (format == THdfsFileFormat::ORC) {
+        scanner_params.orc_use_column_names = state->query_options().orc_use_column_names;
         scanner = _pool.add(new HdfsOrcScanner());
     } else if (format == THdfsFileFormat::TEXT) {
         scanner = _pool.add(new HdfsTextScanner());

--- a/be/src/exec/hdfs_scanner.cpp
+++ b/be/src/exec/hdfs_scanner.cpp
@@ -130,6 +130,7 @@ Status HdfsScanner::_build_scanner_context() {
     ctx.min_max_tuple_desc = _scanner_params.min_max_tuple_desc;
     ctx.hive_column_names = _scanner_params.hive_column_names;
     ctx.case_sensitive = _scanner_params.case_sensitive;
+    ctx.orc_use_column_names = _scanner_params.orc_use_column_names;
     ctx.can_use_any_column = _scanner_params.can_use_any_column;
     ctx.can_use_min_max_count_opt = _scanner_params.can_use_min_max_count_opt;
     ctx.use_file_metacache = _scanner_params.use_file_metacache;

--- a/be/src/exec/hdfs_scanner.h
+++ b/be/src/exec/hdfs_scanner.h
@@ -205,6 +205,7 @@ struct HdfsScannerParams {
     bool can_use_any_column = false;
     bool can_use_min_max_count_opt = false;
     bool use_file_metacache = false;
+    bool orc_use_column_names = false;
     MORParams mor_params;
 };
 
@@ -252,6 +253,8 @@ struct HdfsScannerContext {
     std::vector<std::string>* hive_column_names = nullptr;
 
     bool case_sensitive = false;
+
+    bool orc_use_column_names = false;
 
     bool can_use_any_column = false;
 

--- a/be/src/formats/orc/column_reader.cpp
+++ b/be/src/formats/orc/column_reader.cpp
@@ -126,6 +126,17 @@ StatusOr<std::unique_ptr<ORCColumnReader>> ORCColumnReader::create(const TypeDes
     }
 }
 
+StatusOr<std::unique_ptr<ORCColumnReader>> ORCColumnReader::create_default_column_reader(const TypeDescriptor& type,
+                                                                                         bool nullable,
+                                                                                         OrcChunkReader* reader) {
+    return std::make_unique<DefaultColumnReader>(type, nullable, reader);
+}
+
+Status DefaultColumnReader::get_next(orc::ColumnVectorBatch* cvb, ColumnPtr& col, size_t from, size_t size) {
+    col->append_default(size);
+    return Status::OK();
+}
+
 Status BooleanColumnReader::get_next(orc::ColumnVectorBatch* cvb, ColumnPtr& column, size_t from, size_t size) {
     auto* data = down_cast<orc::LongVectorBatch*>(cvb);
     size_t column_start = column->size();

--- a/be/src/formats/orc/column_reader.h
+++ b/be/src/formats/orc/column_reader.h
@@ -75,6 +75,9 @@ public:
     static StatusOr<std::unique_ptr<ORCColumnReader>> create(const TypeDescriptor& type, const orc::Type* orc_type,
                                                              bool nullable, const OrcMappingPtr& orc_mapping,
                                                              OrcChunkReader* reader);
+    static StatusOr<std::unique_ptr<ORCColumnReader>> create_default_column_reader(const TypeDescriptor& type,
+                                                                                   bool nullable,
+                                                                                   OrcChunkReader* reader);
     const orc::Type* get_orc_type() { return _orc_type; }
 
 protected:
@@ -102,6 +105,14 @@ protected:
     const orc::Type* _orc_type;
     bool _nullable;
     OrcChunkReader* _reader;
+};
+
+class DefaultColumnReader final : public ORCColumnReader {
+public:
+    DefaultColumnReader(const TypeDescriptor& type, bool nullable, OrcChunkReader* reader)
+            : ORCColumnReader(type, nullptr, nullable, reader) {}
+    ~DefaultColumnReader() override = default;
+    Status get_next(orc::ColumnVectorBatch* cvb, ColumnPtr& col, size_t from, size_t size) override;
 };
 
 class PrimitiveColumnReader : public ORCColumnReader {

--- a/be/src/formats/orc/orc_mapping.h
+++ b/be/src/formats/orc/orc_mapping.h
@@ -100,6 +100,8 @@ public:
     // src_pos is origin column position in table definition.
     const OrcMappingOrcType& get_orc_type_child_mapping(size_t original_pos_in_table_definition);
 
+    bool contains(size_t original_pos_in_table_definition) const;
+
     void add_mapping(size_t pos_in_src, const OrcMappingPtr& child_mapping, const orc::Type* orc_type);
 
     void clear();

--- a/be/src/runtime/descriptor_helper.h
+++ b/be/src/runtime/descriptor_helper.h
@@ -51,6 +51,7 @@ public:
         _slot_desc.isMaterialized = true;
         _slot_desc.isOutputColumn = true;
         _slot_desc.__isset.isOutputColumn = true;
+        _slot_desc.id = -1;
     }
     TSlotDescriptorBuilder& type(LogicalType type) { return this->type(TypeDescriptor(type)); }
     TSlotDescriptorBuilder& type(const TypeDescriptor& type) {
@@ -133,7 +134,7 @@ public:
             int size = td.get_slot_size();
             int align = (size > 16) ? 16 : size;
             offset = ((offset + align - 1) / align) * align;
-            slot_desc.id = tb->next_slot_id();
+            slot_desc.id = slot_desc.id == -1 ? tb->next_slot_id() : slot_desc.id;
             slot_desc.parent = _tuple_id;
             slot_desc.byteOffset = offset;
             offset += size;

--- a/be/test/exec/hdfs_scanner_test.cpp
+++ b/be/test/exec/hdfs_scanner_test.cpp
@@ -561,7 +561,35 @@ TEST_F(HdfsScannerTest, TestOrcGetNextWithMinMaxFilterNoRows) {
     ASSERT_OK(Expr::prepare(param->partition_values, _runtime_state));
     ASSERT_OK(Expr::open(param->partition_values, _runtime_state));
 
-    auto* min_max_tuple_desc = _create_tuple_desc(mtypes_orc_min_max_descs);
+    // TupleDescriptor* min_max_tuple_desc = _create_tuple_desc(mtypes_orc_min_max_descs);
+    TupleDescriptor* min_max_tuple_desc = nullptr;
+    {
+        TDescriptorTableBuilder table_desc_builder;
+        TSlotDescriptorBuilder slot_desc_builder;
+        TTupleDescriptorBuilder tuple_desc_builder;
+
+        slot_desc_builder.column_name("id")
+                .type(TypeDescriptor::from_logical_type(LogicalType::TYPE_BIGINT))
+                .id(0)
+                .nullable(true);
+        tuple_desc_builder.add_slot(slot_desc_builder.build());
+        slot_desc_builder.column_name("PART_y")
+                .type(TypeDescriptor::from_logical_type(LogicalType::TYPE_INT))
+                .id(25)
+                .nullable(true);
+        tuple_desc_builder.add_slot(slot_desc_builder.build());
+
+        tuple_desc_builder.build(&table_desc_builder);
+        std::vector<TTupleId> row_tuples = std::vector<TTupleId>{0};
+        std::vector<bool> nullable_tuples = std::vector<bool>{true};
+        DescriptorTbl* tbl = nullptr;
+        CHECK(DescriptorTbl::create(_runtime_state, &_pool, table_desc_builder.desc_tbl(), &tbl,
+                                    config::vector_chunk_size)
+                      .ok());
+        auto* row_desc = _pool.add(new RowDescriptor(*tbl, row_tuples, nullable_tuples));
+        min_max_tuple_desc = row_desc->tuple_descriptors()[0];
+    }
+
     param->min_max_tuple_desc = min_max_tuple_desc;
     // id min/max = 2629/5212, PART_Y min/max=20/20
     std::vector<int> thres = {20, 30, 20, 20};

--- a/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
@@ -473,6 +473,9 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
 
     private static final String ENABLE_RESULT_SINK_ACCUMULATE = "enable_result_sink_accumulate";
 
+    // Access ORC columns by name. By default, columns in ORC files are accessed by
+    // their ordinal position in the Hive table definition.
+    public static final String ORC_USE_COLUMN_NAMES = "orc_use_column_names";
     // Flag to control whether to proxy follower's query statement to leader/follower.
     public enum FollowerQueryForwardMode {
         DEFAULT,    // proxy queries by the follower's replay progress (default)
@@ -1791,6 +1794,9 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
 
     @VarAttr(name = ENABLE_PIPELINE_LEVEL_SHUFFLE, flag = VariableMgr.INVISIBLE)
     private boolean enablePipelineLevelShuffle = true;
+
+    @VarAttr(name = ORC_USE_COLUMN_NAMES)
+    private boolean orcUseColumnNames = false;
 
     @VarAttr(name = FOLLOWER_QUERY_FORWARD_MODE, flag = VariableMgr.INVISIBLE | VariableMgr.DISABLE_FORWARD_TO_LEADER)
     private String followerForwardMode = "";
@@ -3428,6 +3434,7 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
         tResult.setEnable_pipeline_level_shuffle(enablePipelineLevelShuffle);
         tResult.setEnable_result_sink_accumulate(enableResultSinkAccumulate);
         tResult.setConnector_max_split_size(connectorMaxSplitSize);
+        tResult.setOrc_use_column_names(orcUseColumnNames);
         return tResult;
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
@@ -476,6 +476,7 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
     // Access ORC columns by name. By default, columns in ORC files are accessed by
     // their ordinal position in the Hive table definition.
     public static final String ORC_USE_COLUMN_NAMES = "orc_use_column_names";
+
     // Flag to control whether to proxy follower's query statement to leader/follower.
     public enum FollowerQueryForwardMode {
         DEFAULT,    // proxy queries by the follower's replay progress (default)

--- a/gensrc/thrift/InternalService.thrift
+++ b/gensrc/thrift/InternalService.thrift
@@ -257,6 +257,7 @@ struct TQueryOptions {
   119: optional bool enable_result_sink_accumulate;
   120: optional bool enable_connector_split_io_tasks = false;
   121: optional i64 connector_max_split_size = 0;
+  131: optional bool orc_use_column_names = false;
 }
 
 

--- a/test/sql/test_external_file/R/test_orc_use_column_names
+++ b/test/sql/test_external_file/R/test_orc_use_column_names
@@ -1,0 +1,60 @@
+-- name: testORCUseColumNames
+shell: ossutil64 mkdir oss://${oss_bucket}/test_orc_build_search_argument/${uuid0}/ >/dev/null || echo "exit 0" >/dev/null
+-- result:
+0
+
+-- !result
+shell: ossutil64 cp --force ../be/test/exec/test_data/orc_scanner/multi_stripes.orc oss://${oss_bucket}/test_orc_use_column_names/${uuid0}/multi_stripes.orc | grep -Pv "(average|elapsed)"
+-- result:
+0
+
+Succeed: Total num: 1, size: 4,070. OK num: 1(upload 1 files).
+-- !result
+CREATE EXTERNAL TABLE test_orc_column
+(
+    c1 string,
+    c0 string,
+    none_existed string
+)
+ENGINE=file
+PROPERTIES
+(
+    "path" = "oss://${oss_bucket}/test_orc_use_column_names/${uuid0}/",
+    "format" = "orc",
+    "aws.s3.access_key" = "${oss_ak}",
+    "aws.s3.secret_key" = "${oss_sk}",
+    "aws.s3.endpoint" = "${oss_endpoint}"
+);
+-- result:
+-- !result
+select * from test_orc_column where c0 = '199994';
+-- result:
+c	199994	None
+-- !result
+select * from test_orc_column where none_existed is not null;
+-- result:
+-- !result
+SELECT * FROM FILES(
+     "path" = "oss://${oss_bucket}/test_orc_use_column_names/${uuid0}/multi_stripes.orc",
+     "format" = "orc",
+     "aws.s3.access_key" = "${oss_ak}",
+     "aws.s3.secret_key" = "${oss_sk}",
+     "aws.s3.endpoint" = "${oss_endpoint}") where c0='199994';
+-- result:
+199994	c
+-- !result
+set orc_use_column_names = true;
+-- result:
+-- !result
+select * from test_orc_column where c0 = '199994';
+-- result:
+c	199994	None
+-- !result
+select * from test_orc_column where none_existed is not null;
+-- result:
+-- !result
+shell: ossutil64 rm -rf oss://${oss_bucket}/test_orc_use_column_names/${uuid0}/ >/dev/null || echo "exit 0" >/dev/null
+-- result:
+0
+
+-- !result

--- a/test/sql/test_external_file/T/test_orc_use_column_names
+++ b/test/sql/test_external_file/T/test_orc_use_column_names
@@ -1,0 +1,38 @@
+-- name: testORCUseColumNames
+
+shell: ossutil64 mkdir oss://${oss_bucket}/test_orc_build_search_argument/${uuid0}/ >/dev/null || echo "exit 0" >/dev/null
+shell: ossutil64 cp --force ../be/test/exec/test_data/orc_scanner/multi_stripes.orc oss://${oss_bucket}/test_orc_use_column_names/${uuid0}/multi_stripes.orc | grep -Pv "(average|elapsed)"
+
+CREATE EXTERNAL TABLE test_orc_column
+(
+    c1 string,
+    c0 string,
+    none_existed string
+)
+ENGINE=file
+PROPERTIES
+(
+    "path" = "oss://${oss_bucket}/test_orc_use_column_names/${uuid0}/",
+    "format" = "orc",
+    "aws.s3.access_key" = "${oss_ak}",
+    "aws.s3.secret_key" = "${oss_sk}",
+    "aws.s3.endpoint" = "${oss_endpoint}"
+);
+
+select * from test_orc_column where c0 = '199994';
+select * from test_orc_column where none_existed is not null;
+
+SELECT * FROM FILES(
+     "path" = "oss://${oss_bucket}/test_orc_use_column_names/${uuid0}/multi_stripes.orc",
+     "format" = "orc",
+     "aws.s3.access_key" = "${oss_ak}",
+     "aws.s3.secret_key" = "${oss_sk}",
+     "aws.s3.endpoint" = "${oss_endpoint}") where c0='199994';
+
+set orc_use_column_names = true;
+
+-- external file table always use orc column names
+select * from test_orc_column where c0 = '199994';
+select * from test_orc_column where none_existed is not null;
+
+shell: ossutil64 rm -rf oss://${oss_bucket}/test_orc_use_column_names/${uuid0}/ >/dev/null || echo "exit 0" >/dev/null


### PR DESCRIPTION
cp from #42777

## What type of PR is this:

- [ ] BugFix
- [x] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [x] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5

