### PR TITLE
[Enhancement] add unionToValues optimizer rule

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/Optimizer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/Optimizer.java
@@ -67,6 +67,7 @@ import com.starrocks.sql.optimizer.rule.transformation.RewriteSimpleAggToMetaSca
 import com.starrocks.sql.optimizer.rule.transformation.SeparateProjectRule;
 import com.starrocks.sql.optimizer.rule.transformation.SkewJoinOptimizeRule;
 import com.starrocks.sql.optimizer.rule.transformation.SplitScanORToUnionRule;
+import com.starrocks.sql.optimizer.rule.transformation.UnionToValuesRule;
 import com.starrocks.sql.optimizer.rule.transformation.materialization.MvRewriteStrategy;
 import com.starrocks.sql.optimizer.rule.transformation.materialization.MvUtils;
 import com.starrocks.sql.optimizer.rule.transformation.materialization.rule.TextMatchBasedRewriteRule;
@@ -535,7 +536,7 @@ public class Optimizer {
         ruleRewriteOnlyOnce(tree, rootTaskContext, new DeriveRangeJoinPredicateRule());
 
         ruleRewriteOnlyOnce(tree, rootTaskContext, new UnionToValuesRule());
-        
+
         return tree.getInputs().get(0);
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/Optimizer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/Optimizer.java
@@ -535,7 +535,7 @@ public class Optimizer {
 
         ruleRewriteOnlyOnce(tree, rootTaskContext, new DeriveRangeJoinPredicateRule());
 
-        ruleRewriteOnlyOnce(tree, rootTaskContext, new UnionToValuesRule());
+        ruleRewriteOnlyOnce(tree, rootTaskContext, UnionToValuesRule.getInstance());
 
         return tree.getInputs().get(0);
     }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/Optimizer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/Optimizer.java
@@ -533,6 +533,9 @@ public class Optimizer {
         ruleRewriteOnlyOnce(tree, rootTaskContext, new GroupByCountDistinctRewriteRule());
 
         ruleRewriteOnlyOnce(tree, rootTaskContext, new DeriveRangeJoinPredicateRule());
+
+        ruleRewriteOnlyOnce(tree, rootTaskContext, new UnionToValuesRule());
+        
         return tree.getInputs().get(0);
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/logical/LogicalValuesOperator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/logical/LogicalValuesOperator.java
@@ -117,5 +117,16 @@ public class LogicalValuesOperator extends LogicalOperator {
             builder.rows = valuesOperator.rows;
             return this;
         }
+
+        public Builder setColumnRefSet(List<ColumnRefOperator> columnRefSet) {
+            builder.columnRefSet = columnRefSet;
+            return this;
+        }
+
+        public Builder setRows(List<List<ScalarOperator>> rows) {
+            builder.rows = rows;
+            return this;
+        }
+        
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/RuleType.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/RuleType.java
@@ -185,6 +185,8 @@ public enum RuleType {
 
     TF_FINE_GRAINED_RANGE_PREDICATE_WITH_PROJECTION,
 
+    TF_MERGE_CONSTANT_UNION,
+
     TF_ELIMINATE_GROUP_BY_CONSTANT,
 
     // The following are implementation rules:

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/UnionToValuesRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/UnionToValuesRule.java
@@ -105,7 +105,7 @@ public class UnionToValuesRule extends TransformationRule {
             }
         }
 
-        if (otherChildren.isEmpty() && !newRows.isEmpty() && unionOp.isUnionAll()) {
+        if (otherChildren.isEmpty() && !newRows.isEmpty()) {
             LogicalValuesOperator newValuesOperator =
                     new LogicalValuesOperator.Builder().setColumnRefSet(unionOp.getOutputColumnRefOp()).setRows(newRows)
                             .setLimit(unionOp.getLimit())

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/UnionToValuesRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/UnionToValuesRule.java
@@ -1,0 +1,139 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.sql.optimizer.rule.transformation;
+
+import com.google.common.collect.Lists;
+import com.starrocks.sql.optimizer.OptExpression;
+import com.starrocks.sql.optimizer.OptimizerContext;
+import com.starrocks.sql.optimizer.operator.OperatorType;
+import com.starrocks.sql.optimizer.operator.logical.LogicalUnionOperator;
+import com.starrocks.sql.optimizer.operator.logical.LogicalValuesOperator;
+import com.starrocks.sql.optimizer.operator.pattern.Pattern;
+import com.starrocks.sql.optimizer.operator.scalar.ColumnRefOperator;
+import com.starrocks.sql.optimizer.operator.scalar.ConstantOperator;
+import com.starrocks.sql.optimizer.operator.scalar.ScalarOperator;
+import com.starrocks.sql.optimizer.rule.RuleType;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+
+public class UnionToValuesRule extends TransformationRule {
+
+    private static boolean isMergeable(OptExpression input) {
+        if (input.getOp().getOpType() != OperatorType.LOGICAL_VALUES) {
+            return false;
+        }
+
+        if (input.getOp().hasLimit() || input.getOp().getPredicate() != null) {
+            return false;
+        }
+
+        LogicalValuesOperator values = (LogicalValuesOperator) input.getOp();
+        return isConstantValues(values) || isConstantUnion(values);
+    }
+
+    private static boolean isConstantUnion(LogicalValuesOperator valuesOp) {
+        if (valuesOp.getProjection() == null ||
+                !valuesOp.getProjection().getColumnRefMap().values().stream().allMatch(ScalarOperator::isConstant)) {
+            return false;
+        }
+
+        List<List<ScalarOperator>> rows = valuesOp.getRows();
+        if (!(rows.size() == 1 && rows.get(0).size() == 1)) {
+            return false;
+        }
+
+        ScalarOperator value = rows.get(0).get(0);
+        return value.equals(ConstantOperator.createNull(value.getType()));
+    }
+
+    private static boolean isConstantValues(LogicalValuesOperator valuesOp) {
+        return valuesOp.getProjection() == null &&
+                valuesOp.getRows().stream().flatMap(List::stream).allMatch(ScalarOperator::isConstant);
+    }
+
+    public UnionToValuesRule() {
+        super(RuleType.TF_MERGE_CONSTANT_UNION, Pattern.create(OperatorType.LOGICAL_UNION)
+                .addChildren(Pattern.create(OperatorType.PATTERN_MULTI_LEAF)));
+    }
+
+    @Override
+    public boolean check(OptExpression input, OptimizerContext context) {
+        return input.getInputs().stream()
+                .filter(UnionToValuesRule::isMergeable)
+                .count() > 1;
+    }
+
+    @Override
+    public List<OptExpression> transform(OptExpression input, OptimizerContext context) {
+        LogicalUnionOperator unionOp = (LogicalUnionOperator) input.getOp();
+
+        List<List<ScalarOperator>> newRows = new ArrayList<>();
+        List<OptExpression> otherChildren = new ArrayList<>();
+        List<List<ColumnRefOperator>> newChildOutputs = Lists.newArrayList();
+        int firstLogicalValuesIndex = -1;
+
+        for (int i = 0; i < input.getInputs().size(); i++) {
+            OptExpression child = input.getInputs().get(i);
+            if (isMergeable(child)) {
+                if (firstLogicalValuesIndex == -1) {
+                    firstLogicalValuesIndex = i;
+                }
+
+                LogicalValuesOperator valuesOp = (LogicalValuesOperator) child.getOp();
+                List<List<ScalarOperator>> rows = valuesOp.getRows();
+                if (isConstantUnion(valuesOp)) {
+                    List<ScalarOperator> scalarOperators = unionOp.getChildOutputColumns().get(i).stream()
+                            .map(valuesOp.getProjection().getColumnRefMap()::get).collect(Collectors.toList());
+
+                    newRows.add(scalarOperators);
+                } else if (isConstantValues(valuesOp)) {
+                    newRows.addAll(rows);
+                }
+
+            } else {
+                newChildOutputs.add(unionOp.getChildOutputColumns().get(i));
+                otherChildren.add(child);
+            }
+        }
+
+        if (otherChildren.isEmpty() && !newRows.isEmpty() && unionOp.isUnionAll()) {
+            LogicalValuesOperator newValuesOperator =
+                    new LogicalValuesOperator.Builder().setColumnRefSet(unionOp.getOutputColumnRefOp()).setRows(newRows)
+                            .setLimit(unionOp.getLimit())
+                            .setPredicate(unionOp.getPredicate()).setProjection(unionOp.getProjection()).build();
+            return Lists.newArrayList(OptExpression.create(newValuesOperator));
+        } else {
+            List<OptExpression> inputs = new ArrayList<>(otherChildren);
+            if (!newRows.isEmpty()) {
+                LogicalValuesOperator newValuesOperator =
+                        new LogicalValuesOperator.Builder()
+                                .setColumnRefSet(unionOp.getChildOutputColumns().get(firstLogicalValuesIndex))
+                                .setRows(newRows).setPredicate(null).build();
+                inputs.add(OptExpression.create(newValuesOperator));
+                newChildOutputs.add(newValuesOperator.getColumnRefSet());
+            }
+
+            LogicalUnionOperator newUnionOp =
+                    new LogicalUnionOperator.Builder().withOperator(unionOp)
+                            .setChildOutputColumns(newChildOutputs)
+                            .build();
+            OptExpression newUnionExpr = OptExpression.create(newUnionOp, inputs);
+
+            return Lists.newArrayList(newUnionExpr);
+        }
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/UnionToValuesRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/UnionToValuesRule.java
@@ -32,10 +32,16 @@ import java.util.stream.Collectors;
 
 public class UnionToValuesRule extends TransformationRule {
 
-    public UnionToValuesRule() {
+    private UnionToValuesRule() {
         super(RuleType.TF_MERGE_CONSTANT_UNION, Pattern.create(OperatorType.LOGICAL_UNION)
                 .addChildren(Pattern.create(OperatorType.PATTERN_MULTI_LEAF)));
     }
+
+    public static UnionToValuesRule getInstance() {
+        return INSTANCE;
+    }
+
+    private static final UnionToValuesRule INSTANCE = new UnionToValuesRule();
 
     @Override
     public boolean check(OptExpression input, OptimizerContext context) {

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/SelectConstTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/SelectConstTest.java
@@ -91,12 +91,12 @@ public class SelectConstTest extends PlanTestBase {
     public void testAggWithConstant() throws Exception {
         assertPlanContains("select case when c1=1 then 1 end from (select '1' c1  union  all select '2') a " +
                         "group by rollup(case  when c1=1 then 1 end, 1 + 1)",
-                "<slot 4> : '2'",
-                "<slot 2> : '1'",
-                "  8:REPEAT_NODE\n" +
+                "<slot 6> : if(5: expr = '1', 1, NULL)",
+                "<slot 7> : 2",
+                "  2:REPEAT_NODE\n" +
                         "  |  repeat: repeat 2 lines [[], [6], [6, 7]]\n" +
                         "  |  \n" +
-                        "  7:Project\n" +
+                        "  1:Project\n" +
                         "  |  <slot 6> : if(5: expr = '1', 1, NULL)\n" +
                         "  |  <slot 7> : 2");
     }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/SetTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/SetTest.java
@@ -205,10 +205,10 @@ public class SetTest extends PlanTestBase {
 
         String sql10 = "select 499 union select 670 except select 499";
         String plan = getFragmentPlan(sql10);
-        Assert.assertTrue(plan.contains("  9:Project\n" +
+        Assert.assertTrue(plan.contains("  5:Project\n" +
                 "  |  <slot 7> : 499\n" +
                 "  |  \n" +
-                "  8:UNION\n" +
+                "  4:UNION\n" +
                 "     constant exprs: \n" +
                 "         NULL"));
         Assert.assertTrue(plan.contains("0:EXCEPT"));

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/SetTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/SetTest.java
@@ -604,14 +604,61 @@ public class SetTest extends PlanTestBase {
                 "  |      [2: expr, TINYINT, false]\n" +
                 "  |      [4: expr, TINYINT, false]\n");
 
-        sql = "select k1 from db1.tbl6 union all  select * from (values (1), (2)) t;";
+        sql = "select k1 from db1.tbl6 union all select 1 union" +
+                " all select 2 union all select * from (values (3)) t";
         plan = getVerboseExplain(sql);
 
         assertContains(plan, "  0:UNION\n" +
                 "  |  output exprs:\n" +
-                "  |      [7, VARCHAR(32), true]\n" +
+                "  |      [13, VARCHAR(32), true]\n" +
                 "  |  child exprs:\n" +
                 "  |      [1: k1, VARCHAR, true]\n" +
-                "  |      [6: cast, VARCHAR(32), false]\n");
+                "  |      [12: cast, VARCHAR(32), false]\n" +
+                "  |      [7: cast, VARCHAR(32), true]\n");
+
+        sql = "select k1 from db1.tbl6 union all select 1 union" +
+                " all select 2 union all select * from (values (3)) t";
+        plan = getVerboseExplain(sql);
+
+        assertContains(plan, "  0:UNION\n" +
+                "  |  output exprs:\n" +
+                "  |      [13, VARCHAR(32), true]\n" +
+                "  |  child exprs:\n" +
+                "  |      [1: k1, VARCHAR, true]\n" +
+                "  |      [12: cast, VARCHAR(32), false]\n" +
+                "  |      [7: cast, VARCHAR(32), true]\n");
+
+        sql = "select 1 union all select 2 union all select * from (values (1)) t;";
+        plan = getVerboseExplain(sql);
+
+        assertContains(plan, "  0:UNION\n" +
+                "     constant exprs: \n" +
+                "         1\n" +
+                "         2\n" +
+                "         1\n");
+
+        sql = "select 1 union select 2 union select * from (values (1));";
+        plan = getVerboseExplain(sql);
+        assertContains(plan, "  0:UNION\n" +
+                "     constant exprs: \n" +
+                "         1\n" +
+                "         2\n" +
+                "         1\n");
+
+        sql = "select 1  union all select 2 union all select * from (values (3)) t;";
+        plan = getVerboseExplain(sql);
+        assertContains(plan, "  0:UNION\n" +
+                "     constant exprs: \n" +
+                "         1\n" +
+                "         2\n" +
+                "         3\n");
+
+        sql = "select 1, 2 union all select 3, 4 union all select * from (values (5, 6)) t;";
+        plan = getVerboseExplain(sql);
+        assertContains(plan, "  0:UNION\n" +
+                "     constant exprs: \n" +
+                "         1 | 2\n" +
+                "         3 | 4\n" +
+                "         5 | 6\n");
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/SetTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/SetTest.java
@@ -205,22 +205,10 @@ public class SetTest extends PlanTestBase {
 
         String sql10 = "select 499 union select 670 except select 499";
         String plan = getFragmentPlan(sql10);
-        Assert.assertTrue(plan.contains("  3:Project\n" +
-                "  |  <slot 2> : 499\n" +
-                "  |  \n" +
-                "  2:UNION\n" +
-                "     constant exprs: \n" +
-                "         NULL"));
-        Assert.assertTrue(plan.contains("  6:Project\n" +
-                "  |  <slot 4> : 670\n" +
-                "  |  \n" +
-                "  5:UNION\n" +
-                "     constant exprs: \n" +
-                "         NULL"));
-        Assert.assertTrue(plan.contains("13:Project\n" +
+        Assert.assertTrue(plan.contains("  9:Project\n" +
                 "  |  <slot 7> : 499\n" +
                 "  |  \n" +
-                "  12:UNION\n" +
+                "  8:UNION\n" +
                 "     constant exprs: \n" +
                 "         NULL"));
         Assert.assertTrue(plan.contains("0:EXCEPT"));
@@ -285,40 +273,32 @@ public class SetTest extends PlanTestBase {
         String sql = "select count(*) from (select null as c1 union all select null as c1) t group by t.c1";
         String plan = getVerboseExplain(sql);
         assertContains(plan, "  0:UNION\n" +
-                "  |  output exprs:\n" +
-                "  |      [5, BOOLEAN, true]\n" +
-                "  |  child exprs:\n" +
-                "  |      [2: expr, BOOLEAN, true]\n" +
-                "  |      [4: expr, BOOLEAN, true]");
+                "     constant exprs: \n" +
+                "         NULL\n" +
+                "         NULL\n");
 
         sql = "select count(*) from (select 1 as c1 union all select null as c1) t group by t.c1";
         plan = getVerboseExplain(sql);
         assertContains(plan, "  0:UNION\n" +
-                "  |  output exprs:\n" +
-                "  |      [6, TINYINT, true]\n" +
-                "  |  child exprs:\n" +
-                "  |      [2: expr, TINYINT, false]\n" +
-                "  |      [5: cast, TINYINT, true]");
+                "     constant exprs: \n" +
+                "         1\n" +
+                "         NULL\n");
 
         sql = "select count(*) from (select cast('1.2' as decimal(10,2)) as c1 union all " +
                 "select cast('1.2' as decimal(10,0)) as c1) t group by t.c1";
         plan = getVerboseExplain(sql);
         assertContains(plan, "  0:UNION\n" +
-                "  |  output exprs:\n" +
-                "  |      [7, DECIMAL64(12,2), true]\n" +
-                "  |  child exprs:\n" +
-                "  |      [3: cast, DECIMAL64(12,2), false]\n" +
-                "  |      [6: cast, DECIMAL64(12,2), false]\n");
+                "     constant exprs: \n" +
+                "         1.20\n" +
+                "         1\n");
 
         sql = "select count(*) from (select cast('1.2' as decimal(5,2)) as c1 union all " +
                 "select cast('1.2' as decimal(10,0)) as c1) t group by t.c1";
         plan = getVerboseExplain(sql);
         assertContains(plan, "  0:UNION\n" +
-                "  |  output exprs:\n" +
-                "  |      [7, DECIMAL64(12,2), true]\n" +
-                "  |  child exprs:\n" +
-                "  |      [3: cast, DECIMAL64(12,2), false]\n" +
-                "  |      [6: cast, DECIMAL64(12,2), false]");
+                "     constant exprs: \n" +
+                "         1.20\n" +
+                "         1\n");
     }
 
     @Test


### PR DESCRIPTION
## Why I'm doing:

For performing a UNION ALL with N SELECT constants, currently, N SELECT constants Fragments and one UNION ALL Fragment are generated. However, some user queries include UNION ALLs with several hundred or even thousands of constants, thus generating a massive amount of fragments and pipeline drivers, which significantly impacts performance.

eg:

```
select 1 union all select 10 + 'a' union all select 3
```

```
mysql> explain logical select 1 union all select 10 + 'a' union all select 3;
+-----------------------------------------------------------------------------------------+
| Explain String                                                                          |
+-----------------------------------------------------------------------------------------+
| - Output => [9:cast]                                                                    |
|     - UNION => [9: cast]                                                                |
|             Estimates: {row: 3, cpu: ?, memory: ?, network: ?, cost: 0.0}               |
|         - VALUES => [3:cast]                                                            |
|                 Estimates: {row: 1, cpu: 0.00, memory: 0.00, network: 0.00, cost: 0.00} |
|                 3:cast := 1.0                                                           |
|         - VALUES => [5:expr]                                                            |
|                 Estimates: {row: 1, cpu: ?, memory: ?, network: ?, cost: 0.0}           |
|                 5:expr := 10.0 + cast('a' as double)                                    |
|         - VALUES => [8:cast]                                                            |
|                 Estimates: {row: 1, cpu: 0.00, memory: 0.00, network: 0.00, cost: 0.00} |
|                 8:cast := 3.0                                                           |
+-----------------------------------------------------------------------------------------+
12 rows in set (0.01 sec)
```

manually changing it to use values greatly reduces the number of fragments:

```
mysql> explain logical select * from (values (1), (10 + 'a'), (3));
+---------------------------------------------------------------------------+
| Explain String                                                            |
+---------------------------------------------------------------------------+
| - Output => [1:column_0]                                                  |
|     - VALUES => {1.0}, {10.0 + cast('a' as double)}, {3.0}                |
|             Estimates: {row: 3, cpu: ?, memory: ?, network: ?, cost: 0.0} |
+---------------------------------------------------------------------------+
3 rows in set (0.04 sec)
```

## What I'm doing:
For this scenario, add an optimization rule to transform all constant UNION ALLs into a single Values operator to avoid generating a massive number of fragments.

```
mysql> explain logical select 1 union all select 10 + 'a' union all select 3;
+---------------------------------------------------------------------------+
| Explain String                                                            |
+---------------------------------------------------------------------------+
| - Output => [9:cast]                                                      |
|     - VALUES => {1.0}, {10.0 + cast('a' as double)}, {3.0}                |
|             Estimates: {row: 3, cpu: ?, memory: ?, network: ?, cost: 0.0} |
+---------------------------------------------------------------------------+
3 rows in set (0.02 sec)
```
## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
- [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
