### PR TITLE
[Enhancement] optimize lock of mv refresh for 3.1 (backport #42637)

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/PartitionBasedMvRefreshProcessor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/PartitionBasedMvRefreshProcessor.java
@@ -211,6 +211,18 @@ public class PartitionBasedMvRefreshProcessor extends BaseTaskRunProcessor {
             // sync partitions between materialized view and base tables out of lock
             // do it outside lock because it is a time-cost operation
             syncPartitions(context);
+            if (checkBaseTablePartitionChange(materializedView)) {
+                retryNum++;
+                if (retryNum > MAX_RETRY_NUM) {
+                    throw new DmlException("materialized view:%s refresh task failed", materializedView.getName());
+                }
+                LOG.info("materialized view:{} base partition has changed. retry to sync partitions, retryNum:{}",
+                        materializedView.getName(), retryNum);
+                continue;
+            }
+            mvEntity.increaseRefreshRetryMetaCount((long) retryNum);
+
+            checked = true;
             database.readLock();
             try {
                 // the following steps should be done in the same lock:
@@ -221,18 +233,7 @@ public class PartitionBasedMvRefreshProcessor extends BaseTaskRunProcessor {
 
                 // check whether there are partition changes for base tables, eg: partition rename
                 // retry to sync partitions if any base table changed the partition infos
-                if (checkBaseTablePartitionChange(materializedView)) {
-                    retryNum++;
-                    if (retryNum > MAX_RETRY_NUM) {
-                        throw new DmlException("materialized view:%s refresh task failed", materializedView.getName());
-                    }
-                    LOG.info("materialized view:{} base partition has changed. retry to sync partitions, retryNum:{}",
-                            materializedView.getName(), retryNum);
-                    continue;
-                }
-                mvEntity.increaseRefreshRetryMetaCount((long) retryNum);
 
-                checked = true;
                 mvToRefreshedPartitions = getPartitionsToRefreshForMaterializedView(context.getProperties());
                 if (mvToRefreshedPartitions.isEmpty()) {
                     LOG.info("no partitions to refresh for materialized view {}", materializedView.getName());
@@ -1234,13 +1235,14 @@ public class PartitionBasedMvRefreshProcessor extends BaseTaskRunProcessor {
             return null;
         }
     }
+
     /**
-     * Collect all databases of the materialized view's base tables.
+     * Collect all deduplicated databases of the materialized view's base tables.
      * @param materializedView: the materialized view to check
      * @return: the databases of the materialized view's base tables, throw exception if the database do not exist.
      */
     List<Database> collectDatabases(MaterializedView materializedView) {
-        List<Database> databases = Lists.newArrayList();
+        Map<Long, Database> databaseMap = Maps.newHashMap();
         for (BaseTableInfo baseTableInfo : materializedView.getBaseTableInfos()) {
             Database db = baseTableInfo.getDb();
             if (db == null) {
@@ -1248,9 +1250,9 @@ public class PartitionBasedMvRefreshProcessor extends BaseTaskRunProcessor {
                         baseTableInfo.getDbInfoStr(), materializedView.getName());
                 throw new DmlException("database " + baseTableInfo.getDbInfoStr() + " do not exist.");
             }
-            databases.add(db);
+            databaseMap.put(db.getId(), db);
         }
-        return databases;
+        return Lists.newArrayList(databaseMap.values());
     }
 
     private boolean checkBaseTableSnapshotInfoChanged(BaseTableInfo baseTableInfo,

--- a/test/sql/test_materialized_view/R/test_mv_refresh
+++ b/test/sql/test_materialized_view/R/test_mv_refresh
@@ -1,0 +1,147 @@
+-- name: test_mv_refresh
+create database db_${uuid0};
+-- result:
+-- !result
+use db_${uuid0};
+-- result:
+-- !result
+function: prepare_data("ssb", "db_${uuid0}")
+-- result:
+None
+-- !result
+CREATE MATERIALIZED VIEW `lineorder_flat_mv1`
+DISTRIBUTED BY HASH(`LO_ORDERDATE`, `LO_ORDERKEY`) BUCKETS 48
+REFRESH MANUAL
+PROPERTIES (
+    "replication_num" = "1",
+    "storage_medium" = "HDD",
+    "force_external_table_query_rewrite" = "true"
+)
+AS
+SELECT `l`.`LO_ORDERKEY`,
+    `l`.`LO_ORDERDATE`,
+    `l`.`LO_LINENUMBER`,
+    `l`.`LO_CUSTKEY`,
+    `l`.`LO_PARTKEY`,
+    `l`.`LO_SUPPKEY`,
+    `l`.`LO_ORDERPRIORITY`,
+    `l`.`LO_SHIPPRIORITY`,
+    `l`.`LO_QUANTITY`,
+    `l`.`LO_EXTENDEDPRICE`,
+    `l`.`LO_ORDTOTALPRICE`,
+    `l`.`LO_DISCOUNT`,
+    `l`.`LO_REVENUE`,
+    `c`.`C_NAME`,
+    `c`.`C_ADDRESS`,
+    `c`.`C_CITY`,
+    `c`.`C_NATION`,
+    `c`.`C_REGION`,
+    `s`.`S_NAME`,
+    `s`.`S_ADDRESS`,
+    `s`.`S_CITY`,
+    `p`.`P_NAME`,
+    `p`.`P_MFGR`,
+    `p`.`P_CATEGORY`,
+    `p`.`P_BRAND`,
+    `p`.`P_COLOR`,
+    `d`.`D_DATE`,
+    `d`.`D_DAYOFWEEK`,
+    `d`.`D_MONTH`,
+    `d`.`D_YEAR`,
+    `d`.`D_YEARMONTHNUM`,
+    `d`.`D_YEARMONTH`,
+    `d`.`D_DAYNUMINWEEK`,
+    `d`.`D_DAYNUMINMONTH`,
+    `d`.`D_DAYNUMINYEAR`,
+    `d`.`D_MONTHNUMINYEAR`,
+    `d`.`D_WEEKNUMINYEAR`
+FROM db_${uuid0}.lineorder AS `l`
+INNER JOIN db_${uuid0}.customer AS `c` ON `l`.`LO_CUSTKEY` = `c`.`C_CUSTKEY`
+INNER JOIN db_${uuid0}.supplier AS `s` ON `l`.`LO_SUPPKEY` = `s`.`S_SUPPKEY`
+INNER JOIN db_${uuid0}.part AS `p` ON `l`.`LO_PARTKEY` = `p`.`P_PARTKEY`
+INNER JOIN db_${uuid0}.dates AS `d` ON `l`.`LO_ORDERDATE` = `d`.`D_DATEKEY`
+limit 100;
+-- result:
+-- !result
+refresh materialized view lineorder_flat_mv1 with sync mode;
+select count() from lineorder_flat_mv1;
+-- result:
+100
+-- !result
+create database db_${uuid1};
+-- result:
+-- !result
+use db_${uuid1};
+-- result:
+-- !result
+create table customer as select * from db_${uuid0}.`customer`;
+-- result:
+-- !result
+create table supplier as select * from db_${uuid0}.`supplier`;
+-- result:
+-- !result
+CREATE MATERIALIZED VIEW `lineorder_flat_mv2`
+DISTRIBUTED BY HASH(`LO_ORDERDATE`, `LO_ORDERKEY`) BUCKETS 48
+REFRESH MANUAL
+PROPERTIES (
+    "replication_num" = "1",
+    "storage_medium" = "HDD",
+    "force_external_table_query_rewrite" = "true"
+)
+AS
+SELECT `l`.`LO_ORDERKEY`,
+    `l`.`LO_ORDERDATE`,
+    `l`.`LO_LINENUMBER`,
+    `l`.`LO_CUSTKEY`,
+    `l`.`LO_PARTKEY`,
+    `l`.`LO_SUPPKEY`,
+    `l`.`LO_ORDERPRIORITY`,
+    `l`.`LO_SHIPPRIORITY`,
+    `l`.`LO_QUANTITY`,
+    `l`.`LO_EXTENDEDPRICE`,
+    `l`.`LO_ORDTOTALPRICE`,
+    `l`.`LO_DISCOUNT`,
+    `l`.`LO_REVENUE`,
+    `c`.`C_NAME`,
+    `c`.`C_ADDRESS`,
+    `c`.`C_CITY`,
+    `c`.`C_NATION`,
+    `c`.`C_REGION`,
+    `s`.`S_NAME`,
+    `s`.`S_ADDRESS`,
+    `s`.`S_CITY`,
+    `p`.`P_NAME`,
+    `p`.`P_MFGR`,
+    `p`.`P_CATEGORY`,
+    `p`.`P_BRAND`,
+    `p`.`P_COLOR`,
+    `d`.`D_DATE`,
+    `d`.`D_DAYOFWEEK`,
+    `d`.`D_MONTH`,
+    `d`.`D_YEAR`,
+    `d`.`D_YEARMONTHNUM`,
+    `d`.`D_YEARMONTH`,
+    `d`.`D_DAYNUMINWEEK`,
+    `d`.`D_DAYNUMINMONTH`,
+    `d`.`D_DAYNUMINYEAR`,
+    `d`.`D_MONTHNUMINYEAR`,
+    `d`.`D_WEEKNUMINYEAR`
+FROM db_${uuid0}.lineorder AS `l`
+INNER JOIN db_${uuid1}.customer AS `c` ON `l`.`LO_CUSTKEY` = `c`.`C_CUSTKEY`
+INNER JOIN db_${uuid1}.supplier AS `s` ON `l`.`LO_SUPPKEY` = `s`.`S_SUPPKEY`
+INNER JOIN db_${uuid0}.part AS `p` ON `l`.`LO_PARTKEY` = `p`.`P_PARTKEY`
+INNER JOIN db_${uuid0}.dates AS `d` ON `l`.`LO_ORDERDATE` = `d`.`D_DATEKEY`
+limit 100;
+-- result:
+-- !result
+refresh materialized view lineorder_flat_mv2 with sync mode;
+select count() from lineorder_flat_mv2;
+-- result:
+100
+-- !result
+drop database db_${uuid0} force;
+-- result:
+-- !result
+drop database db_${uuid1} force;
+-- result:
+-- !result

--- a/test/sql/test_materialized_view/T/test_mv_refresh
+++ b/test/sql/test_materialized_view/T/test_mv_refresh
@@ -1,0 +1,129 @@
+-- name: test_mv_refresh
+
+create database db_${uuid0};
+use db_${uuid0};
+function: prepare_data("ssb", "db_${uuid0}")
+
+
+CREATE MATERIALIZED VIEW `lineorder_flat_mv1`
+DISTRIBUTED BY HASH(`LO_ORDERDATE`, `LO_ORDERKEY`) BUCKETS 48
+REFRESH MANUAL
+PROPERTIES (
+    "replication_num" = "1",
+    "storage_medium" = "HDD",
+    "force_external_table_query_rewrite" = "true"
+)
+AS
+SELECT `l`.`LO_ORDERKEY`,
+    `l`.`LO_ORDERDATE`,
+    `l`.`LO_LINENUMBER`,
+    `l`.`LO_CUSTKEY`,
+    `l`.`LO_PARTKEY`,
+    `l`.`LO_SUPPKEY`,
+    `l`.`LO_ORDERPRIORITY`,
+    `l`.`LO_SHIPPRIORITY`,
+    `l`.`LO_QUANTITY`,
+    `l`.`LO_EXTENDEDPRICE`,
+    `l`.`LO_ORDTOTALPRICE`,
+    `l`.`LO_DISCOUNT`,
+    `l`.`LO_REVENUE`,
+    `c`.`C_NAME`,
+    `c`.`C_ADDRESS`,
+    `c`.`C_CITY`,
+    `c`.`C_NATION`,
+    `c`.`C_REGION`,
+    `s`.`S_NAME`,
+    `s`.`S_ADDRESS`,
+    `s`.`S_CITY`,
+    `p`.`P_NAME`,
+    `p`.`P_MFGR`,
+    `p`.`P_CATEGORY`,
+    `p`.`P_BRAND`,
+    `p`.`P_COLOR`,
+    `d`.`D_DATE`,
+    `d`.`D_DAYOFWEEK`,
+    `d`.`D_MONTH`,
+    `d`.`D_YEAR`,
+    `d`.`D_YEARMONTHNUM`,
+    `d`.`D_YEARMONTH`,
+    `d`.`D_DAYNUMINWEEK`,
+    `d`.`D_DAYNUMINMONTH`,
+    `d`.`D_DAYNUMINYEAR`,
+    `d`.`D_MONTHNUMINYEAR`,
+    `d`.`D_WEEKNUMINYEAR`
+FROM db_${uuid0}.lineorder AS `l`
+INNER JOIN db_${uuid0}.customer AS `c` ON `l`.`LO_CUSTKEY` = `c`.`C_CUSTKEY`
+INNER JOIN db_${uuid0}.supplier AS `s` ON `l`.`LO_SUPPKEY` = `s`.`S_SUPPKEY`
+INNER JOIN db_${uuid0}.part AS `p` ON `l`.`LO_PARTKEY` = `p`.`P_PARTKEY`
+INNER JOIN db_${uuid0}.dates AS `d` ON `l`.`LO_ORDERDATE` = `d`.`D_DATEKEY`
+limit 100;
+
+refresh materialized view lineorder_flat_mv1 with sync mode;
+
+select count() from lineorder_flat_mv1;
+
+create database db_${uuid1};
+use db_${uuid1};
+create table customer as select * from db_${uuid0}.`customer`;
+create table supplier as select * from db_${uuid0}.`supplier`;
+
+
+CREATE MATERIALIZED VIEW `lineorder_flat_mv2`
+DISTRIBUTED BY HASH(`LO_ORDERDATE`, `LO_ORDERKEY`) BUCKETS 48
+REFRESH MANUAL
+PROPERTIES (
+    "replication_num" = "1",
+    "storage_medium" = "HDD",
+    "force_external_table_query_rewrite" = "true"
+)
+AS
+SELECT `l`.`LO_ORDERKEY`,
+    `l`.`LO_ORDERDATE`,
+    `l`.`LO_LINENUMBER`,
+    `l`.`LO_CUSTKEY`,
+    `l`.`LO_PARTKEY`,
+    `l`.`LO_SUPPKEY`,
+    `l`.`LO_ORDERPRIORITY`,
+    `l`.`LO_SHIPPRIORITY`,
+    `l`.`LO_QUANTITY`,
+    `l`.`LO_EXTENDEDPRICE`,
+    `l`.`LO_ORDTOTALPRICE`,
+    `l`.`LO_DISCOUNT`,
+    `l`.`LO_REVENUE`,
+    `c`.`C_NAME`,
+    `c`.`C_ADDRESS`,
+    `c`.`C_CITY`,
+    `c`.`C_NATION`,
+    `c`.`C_REGION`,
+    `s`.`S_NAME`,
+    `s`.`S_ADDRESS`,
+    `s`.`S_CITY`,
+    `p`.`P_NAME`,
+    `p`.`P_MFGR`,
+    `p`.`P_CATEGORY`,
+    `p`.`P_BRAND`,
+    `p`.`P_COLOR`,
+    `d`.`D_DATE`,
+    `d`.`D_DAYOFWEEK`,
+    `d`.`D_MONTH`,
+    `d`.`D_YEAR`,
+    `d`.`D_YEARMONTHNUM`,
+    `d`.`D_YEARMONTH`,
+    `d`.`D_DAYNUMINWEEK`,
+    `d`.`D_DAYNUMINMONTH`,
+    `d`.`D_DAYNUMINYEAR`,
+    `d`.`D_MONTHNUMINYEAR`,
+    `d`.`D_WEEKNUMINYEAR`
+FROM db_${uuid0}.lineorder AS `l`
+INNER JOIN db_${uuid1}.customer AS `c` ON `l`.`LO_CUSTKEY` = `c`.`C_CUSTKEY`
+INNER JOIN db_${uuid1}.supplier AS `s` ON `l`.`LO_SUPPKEY` = `s`.`S_SUPPKEY`
+INNER JOIN db_${uuid0}.part AS `p` ON `l`.`LO_PARTKEY` = `p`.`P_PARTKEY`
+INNER JOIN db_${uuid0}.dates AS `d` ON `l`.`LO_ORDERDATE` = `d`.`D_DATEKEY`
+limit 100;
+
+refresh materialized view lineorder_flat_mv2 with sync mode;
+
+select count() from lineorder_flat_mv2;
+
+drop database db_${uuid0} force;
+drop database db_${uuid1} force;


### PR DESCRIPTION
## Why I'm doing:
the lock sequence may lead to deadlock.

## What I'm doing:
acquire db locks by sequence to avoid deadlock.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [x] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5

