### PR TITLE
[Doc] change the default value of update_compaction_size_threshold for 2.5

### DIFF
--- a/docs/en/administration/Configuration.md
+++ b/docs/en/administration/Configuration.md
@@ -363,8 +363,7 @@ BE dynamic parameters are as follows.
 | default_num_rows_per_column_file_block | 1024 | N/A | The maximum number of rows that can be stored in each row block. |
 | pending_data_expire_time_sec | 1800 | Second | The expiration time of the pending data in the storage engine. |
 | inc_rowset_expired_sec | 1800 | Second | The expiration time of the incoming data. This configuration item is used in incremental clone. |
-| tablet_rowset_stale_sweep_time_sec | 1800 | Second | The time interval at which to sweep the stale rowsets in tablets. A shorter interval can reduce metadata usage during loading.
-|
+| tablet_rowset_stale_sweep_time_sec | 1800 | Second | The time interval at which to sweep the stale rowsets in tablets. A shorter interval can reduce metadata usage during loading. |
 | snapshot_expire_time_sec | 172800 | Second | The expiration time of snapshot files. |
 | trash_file_expire_time_sec | 86,400 | Second | The time interval at which to clean trash files.  The default value has been changed from 259,200 to 86,400 since v2.5.17, v3.0.9, and v3.1.6. |
 | base_compaction_check_interval_seconds | 60 | Second | The time interval of thread polling for a Base Compaction. |
@@ -851,6 +850,12 @@ BE static parameters are as follows.
 - **Default**: TRUE
 - **Unit**: N/A
 - **Description**: Whether to enable the Size-tiered Compaction strategy. TRUE indicates the Size-tiered Compaction strategy is enabled, and FALSE indicates it is disabled.
+
+#### update_compaction_size_threshold
+
+- **Default**: 268435456
+- **Unit**: bytes
+- **Description**: The Compaction Score of Primary Key tables is calculated based on the file size, which is different from other table types. This parameter can be used to make the Compaction Score of Primary Key tables similar to that of other table types, making it easier for users to understand. In v2.5.20, the default value of this parameter is changed from `268435456` (256 MB) to `67108864` (64 MB) to accelerate compaction.
 
 <!--| aws_sdk_logging_trace_enabled | 0 | N/A | |
 | be_exit_after_disk_write_hang_second | 60 | N/A | |

--- a/docs/en/administration/Configuration.md
+++ b/docs/en/administration/Configuration.md
@@ -853,9 +853,9 @@ BE static parameters are as follows.
 
 #### update_compaction_size_threshold
 
-- **Default**: 268435456
+- **Default**: 67108864
 - **Unit**: bytes
-- **Description**: The Compaction Score of Primary Key tables is calculated based on the file size, which is different from other table types. This parameter can be used to make the Compaction Score of Primary Key tables similar to that of other table types, making it easier for users to understand. In v2.5.20, the default value of this parameter is changed from `268435456` (256 MB) to `67108864` (64 MB) to accelerate compaction.
+- **Description**: The Compaction Score of Primary Key tables is calculated based on the file size, which is different from other table types. This parameter can be used to make the Compaction Score of Primary Key tables similar to that of other table types, making it easier for users to understand. Since v2.5.20, the default value of this parameter is changed from `268435456` (256 MB) to `67108864` (64 MB) to accelerate compaction.
 
 <!--| aws_sdk_logging_trace_enabled | 0 | N/A | |
 | be_exit_after_disk_write_hang_second | 60 | N/A | |

--- a/docs/zh/administration/Configuration.md
+++ b/docs/zh/administration/Configuration.md
@@ -485,4 +485,4 @@ curl -XPOST http://be_host:http_port/api/update_config?configuration_item=value
 | jdbc_connection_idle_timeout_ms  | 600000 | JDBC 空闲连接超时时间。如果 JDBC 连接池内的连接空闲时间超过此值，连接池会关闭超过 `jdbc_minimum_idle_connections` 配置项中指定数量的空闲连接。 |
 | query_cache_capacity  | 536870912 | 指定 Query Cache 的大小。单位：Byte。默认为 512 MB。最小不低于 4 MB。如果当前的 BE 内存容量无法满足您期望的 Query Cache 大小，可以增加 BE 的内存容量，然后再设置合理的 Query Cache 大小。<br />每个 BE 都有自己私有的 Query Cache 存储空间，BE 只 Populate 或 Probe 自己本地的 Query Cache 存储空间。 |
 | enable_event_based_compaction_framework  | TRUE | 是否开启 Event-based Compaction Framework。`true` 代表开启。`false` 代表关闭。开启则能够在 tablet 数比较多或者单个 tablet 数据量比较大的场景下大幅降低 compaction 的开销。 |
-| update_compaction_size_threshold  | 268435456 | 主键表的 Compaction Score 是基于文件大小计算的，与其他表类型的文件数量不同。通过该参数可以使主键表的 Compaction Score 与其他类型表的相近，便于用户理解。在 v2.5.20 版本，为了更快执行 compaction，该参数默认值从 `268435456` (256 MB) 改为 `67108864` (64 MB)。|
+| update_compaction_size_threshold  | 67108864 | 主键表的 Compaction Score 是基于文件大小计算的，与其他表类型的文件数量不同。通过该参数可以使主键表的 Compaction Score 与其他类型表的相近，便于用户理解。从 v2.5.20 版本起，为了更快执行 compaction，该参数默认值从 `268435456` (256 MB) 改为 `67108864` (64 MB)。|

--- a/docs/zh/administration/Configuration.md
+++ b/docs/zh/administration/Configuration.md
@@ -466,10 +466,10 @@ curl -XPOST http://be_host:http_port/api/update_config?configuration_item=value
 |load_process_max_memory_limit_percent|30|单节点上所有的导入线程占据的内存上限比例。|
 |sync_tablet_meta|FALSE|存储引擎是否开 sync 保留到磁盘上。|
 |routine_load_thread_pool_size|10|单节点上 Routine Load 线程池大小。从 3.1.0 版本起，该参数废弃。单节点上 Routine Load 线程池大小完全由 FE 动态参数 `max_routine_load_task_num_per_be` 控制。|
-|internal_service_async_thread_num | 10 | N/A | 单个 BE 上与 Kafka 交互的线程池大小。当前 Routine Load FE 与 Kafka 的交互需经由 BE 完成，而每个 BE 上实际执行操作的是一个单独的线程池。当 Routine Load 任务较多时，可能会出现线程池线程繁忙的情况，可以调整该配置。从 3.1.0 版本起，该参数废弃。单节点上 Routine Load 线程池大小完全由 FE 动态参数 `max_routine_load_task_num_per_be` 控制。|
-|max_garbage_sweep_interval|3600|s|磁盘进行垃圾清理的最大间隔。|
-|min_garbage_sweep_interval|180|s|磁盘进行垃圾清理的最小间隔。|
-|brpc_max_body_size|2147483648|bRPC 最大的包容量，单位为 Byte。|
+|internal_service_async_thread_num | 10 | 单个 BE 上与 Kafka 交互的线程池大小。当前 Routine Load FE 与 Kafka 的交互需经由 BE 完成，而每个 BE 上实际执行操作的是一个单独的线程池。当 Routine Load 任务较多时，可能会出现线程池线程繁忙的情况，可以调整该配置。从 3.1.0 版本起，该参数废弃。单节点上 Routine Load 线程池大小完全由 FE 动态参数 `max_routine_load_task_num_per_be` 控制。|
+|max_garbage_sweep_interval|3600|磁盘进行垃圾清理的最大间隔。单位：s。|
+|min_garbage_sweep_interval|180|磁盘进行垃圾清理的最小间隔。单位：s。|
+|brpc_max_body_size|2147483648|bRPC 最大的包容量，单位：Byte。|
 |tablet_map_shard_size|32|Tablet 分组数。|
 |enable_bitmap_union_disk_format_with_set|FALSE|Bitmap 新存储格式，可以优化 bitmap_union 性能。|
 |mem_limit|90%|BE 进程内存上限。可设为比例上限（如 "80%"）或物理上限（如 "100G"）。默认硬上限为 BE 所在机器内存的 90%，软上限为 BE 所在机器内存的 80%。如果 BE 为独立部署，则无需配置，如果 BE 与其它占用内存较多的服务混合部署，则需要合理配置。|
@@ -485,3 +485,4 @@ curl -XPOST http://be_host:http_port/api/update_config?configuration_item=value
 | jdbc_connection_idle_timeout_ms  | 600000 | JDBC 空闲连接超时时间。如果 JDBC 连接池内的连接空闲时间超过此值，连接池会关闭超过 `jdbc_minimum_idle_connections` 配置项中指定数量的空闲连接。 |
 | query_cache_capacity  | 536870912 | 指定 Query Cache 的大小。单位：Byte。默认为 512 MB。最小不低于 4 MB。如果当前的 BE 内存容量无法满足您期望的 Query Cache 大小，可以增加 BE 的内存容量，然后再设置合理的 Query Cache 大小。<br />每个 BE 都有自己私有的 Query Cache 存储空间，BE 只 Populate 或 Probe 自己本地的 Query Cache 存储空间。 |
 | enable_event_based_compaction_framework  | TRUE | 是否开启 Event-based Compaction Framework。`true` 代表开启。`false` 代表关闭。开启则能够在 tablet 数比较多或者单个 tablet 数据量比较大的场景下大幅降低 compaction 的开销。 |
+| update_compaction_size_threshold  | 268435456 | 主键表的 Compaction Score 是基于文件大小计算的，与其他表类型的文件数量不同。通过该参数可以使主键表的 Compaction Score 与其他类型表的相近，便于用户理解。在 v2.5.20 版本，为了更快执行 compaction，该参数默认值从 `268435456` (256 MB) 改为 `67108864` (64 MB)。|


### PR DESCRIPTION
Signed-off-by: evelynzhaojie <everlyn.zhaojie@gmail.com

## Why I'm doing:

update doc according to release notes 2.5.20

## What I'm doing:

add the parameter meaning to v2.5
update its default value

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.2
  - [ ] 3.1
  - [x] 3.0
  - [ ] 2.5
