### PR TITLE
[BugFix] Fix the incorrect jdbc url concatenation which cause jdbc url parameters cannot be passed.

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/JDBCTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/JDBCTable.java
@@ -209,9 +209,16 @@ public class JDBCTable extends Table {
             tJDBCTable.setJdbc_driver_class(properties.get(JDBCResource.DRIVER_CLASS));
 
             if (properties.get(JDBC_TABLENAME) != null) {
-                tJDBCTable.setJdbc_url(properties.get(JDBCResource.URI));
+                tJDBCTable.setJdbc_url(uri);
             } else {
-                tJDBCTable.setJdbc_url(properties.get(JDBCResource.URI) + "/" + dbName);
+                int delimiterIndex = uri.indexOf("?");
+                if (delimiterIndex > 0) {
+                    String urlPrefix = uri.substring(0, delimiterIndex);
+                    String urlSuffix = uri.substring(delimiterIndex + 1);
+                    tJDBCTable.setJdbc_url(urlPrefix + "/" + dbName + "?" + urlSuffix);
+                } else {
+                    tJDBCTable.setJdbc_url(uri + "/" + dbName);
+                }
             }
             tJDBCTable.setJdbc_table(jdbcTable);
             tJDBCTable.setJdbc_user(properties.get(JDBCResource.USER));

--- a/fe/fe-core/src/test/java/com/starrocks/catalog/JDBCTableTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/JDBCTableTest.java
@@ -52,6 +52,19 @@ public class JDBCTableTest {
         properties.put("resource", resourceName);
     }
 
+    private Map<String, String> getMockedJDBCProperties(String uri) throws Exception {
+        FeConstants.runningUnitTest = true;
+        Map<String, String> jdbcProperties = Maps.newHashMap();
+        jdbcProperties.put(JDBCResource.URI, uri);
+        jdbcProperties.put(JDBCResource.DRIVER_URL, "driver_url0");
+        jdbcProperties.put(JDBCResource.CHECK_SUM, "check_sum0");
+        jdbcProperties.put(JDBCResource.DRIVER_CLASS, "driver_class0");
+        jdbcProperties.put(JDBCResource.USER, "user0");
+        jdbcProperties.put(JDBCResource.PASSWORD, "password0");
+        FeConstants.runningUnitTest = false;
+        return jdbcProperties;
+    }
+
     private Resource getMockedJDBCResource(String name) throws Exception {
         FeConstants.runningUnitTest = true;
         Resource jdbcResource = new JDBCResource(name);
@@ -120,6 +133,38 @@ public class JDBCTableTest {
         expectedDesc.setJdbcTable(expectedTable);
 
         Assert.assertEquals(tableDescriptor, expectedDesc);
+    }
+
+    @Test
+    public void testToThriftWithoutResource(@Mocked GlobalStateMgr globalStateMgr,
+                             @Mocked ResourceMgr resourceMgr) throws Exception {
+        String uri = "jdbc:mysql://127.0.0.1:3306";
+        Map<String, String> jdbcProperties = getMockedJDBCProperties(uri);
+        JDBCTable table = new JDBCTable(1000, "jdbc_table", columns, "db0", "catalog0", jdbcProperties);
+        TTableDescriptor tableDescriptor = table.toThrift(null);
+
+        TJDBCTable jdbcTable = tableDescriptor.getJdbcTable();
+        Assert.assertEquals(jdbcTable.getJdbc_url(), "jdbc:mysql://127.0.0.1:3306/db0");
+        Assert.assertEquals(jdbcTable.getJdbc_driver_url(), jdbcProperties.get(JDBCResource.DRIVER_URL));
+        Assert.assertEquals(jdbcTable.getJdbc_driver_class(), jdbcProperties.get(JDBCResource.DRIVER_CLASS));
+        Assert.assertEquals(jdbcTable.getJdbc_user(), jdbcProperties.get(JDBCResource.USER));
+        Assert.assertEquals(jdbcTable.getJdbc_passwd(), jdbcProperties.get(JDBCResource.PASSWORD));
+    }
+
+    @Test
+    public void testToThriftWithJdbcParam(@Mocked GlobalStateMgr globalStateMgr,
+                             @Mocked ResourceMgr resourceMgr) throws Exception {
+        String uri = "jdbc:mysql://127.0.0.1:3306?key=value";
+        Map<String, String> jdbcProperties = getMockedJDBCProperties(uri);
+        JDBCTable table = new JDBCTable(1000, "jdbc_table", columns, "db0", "catalog0", jdbcProperties);
+        TTableDescriptor tableDescriptor = table.toThrift(null);
+
+        TJDBCTable jdbcTable = tableDescriptor.getJdbcTable();
+        Assert.assertEquals(jdbcTable.getJdbc_url(), "jdbc:mysql://127.0.0.1:3306/db0?key=value");
+        Assert.assertEquals(jdbcTable.getJdbc_driver_url(), jdbcProperties.get(JDBCResource.DRIVER_URL));
+        Assert.assertEquals(jdbcTable.getJdbc_driver_class(), jdbcProperties.get(JDBCResource.DRIVER_CLASS));
+        Assert.assertEquals(jdbcTable.getJdbc_user(), jdbcProperties.get(JDBCResource.USER));
+        Assert.assertEquals(jdbcTable.getJdbc_passwd(), jdbcProperties.get(JDBCResource.PASSWORD));
     }
 
     @Test(expected = DdlException.class)


### PR DESCRIPTION
## Why I'm doing:
We concat the `jdbc_url` with db name directly, as the final jdbc url. So when user add some parameters to the jdbc url, such as `jdbc:mysql://172.26.199.115:3306?zeroDateTimeBehavior=CONVERT_TO_NULL`, it will be changed to `jdbc:mysql://172.26.199.115:3306?zeroDateTimeBehavior=CONVERT_TO_NULL/mydbname`, which cause the query error.

## What I'm doing:
Check and concatenate the jdbc url with user parameters.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [x] 3.1
  - [x] 3.0
  - [ ] 2.5
