### PR TITLE
[Enhancement] add mv db id to currentSqlDbIds for resource group 

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/Optimizer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/Optimizer.java
@@ -19,6 +19,7 @@ import com.google.common.base.Preconditions;
 import com.google.common.collect.Lists;
 import com.starrocks.analysis.JoinOperator;
 import com.starrocks.analysis.ParseNode;
+import com.starrocks.catalog.MaterializedView;
 import com.starrocks.catalog.OlapTable;
 import com.starrocks.common.profile.Timer;
 import com.starrocks.common.profile.Tracers;
@@ -34,6 +35,7 @@ import com.starrocks.sql.optimizer.operator.Operator;
 import com.starrocks.sql.optimizer.operator.logical.LogicalOlapScanOperator;
 import com.starrocks.sql.optimizer.operator.logical.LogicalTreeAnchorOperator;
 import com.starrocks.sql.optimizer.operator.logical.LogicalViewScanOperator;
+import com.starrocks.sql.optimizer.operator.physical.PhysicalOlapScanOperator;
 import com.starrocks.sql.optimizer.rule.Rule;
 import com.starrocks.sql.optimizer.rule.RuleSetType;
 import com.starrocks.sql.optimizer.rule.implementation.OlapScanImplementationRule;
@@ -222,7 +224,7 @@ public class Optimizer {
         TaskContext rootTaskContext =
                 new TaskContext(context, requiredProperty, requiredColumns.clone(), Double.MAX_VALUE);
         // collect all olap scan operator
-        collectAllScanOperators(logicOperatorTree, rootTaskContext);
+        collectAllLogicalOlapScanOperators(logicOperatorTree, rootTaskContext);
 
         try (Timer ignored = Tracers.watchScope("RuleBaseOptimize")) {
             logicOperatorTree = rewriteAndValidatePlan(logicOperatorTree, rootTaskContext);
@@ -261,6 +263,13 @@ public class Optimizer {
             result = extractBestPlan(requiredProperty, memo.getRootGroup());
         }
         OptimizerTraceUtil.logOptExpression("after extract best plan:\n%s", result);
+        // collect all mv scan operator
+        collectAllPhysicalOlapScanOperators(result, rootTaskContext);
+        List<PhysicalOlapScanOperator> mvScan = rootTaskContext.getAllPhysicalOlapScanOperators().stream().
+                filter(scan -> scan.getTable().isMaterializedView()).collect(Collectors.toList());
+        // add mv db id to currentSqlDbIds, the resource group could use this to distinguish sql patterns
+        Set<Long> currentSqlDbIds = rootTaskContext.getOptimizerContext().getCurrentSqlDbIds();
+        mvScan.stream().map(scan -> ((MaterializedView) scan.getTable()).getDbId()).forEach(currentSqlDbIds::add);
 
         // set costs audio log before physicalRuleRewrite
         // statistics won't set correctly after physicalRuleRewrite.
@@ -792,10 +801,16 @@ public class Optimizer {
         return expression;
     }
 
-    private void collectAllScanOperators(OptExpression tree, TaskContext rootTaskContext) {
+    private void collectAllLogicalOlapScanOperators(OptExpression tree, TaskContext rootTaskContext) {
         List<LogicalOlapScanOperator> list = Lists.newArrayList();
         Utils.extractOperator(tree, list, op -> op instanceof LogicalOlapScanOperator);
-        rootTaskContext.setAllScanOperators(Collections.unmodifiableList(list));
+        rootTaskContext.setAllLogicalOlapScanOperators(Collections.unmodifiableList(list));
+    }
+
+    private void collectAllPhysicalOlapScanOperators(OptExpression tree, TaskContext rootTaskContext) {
+        List<PhysicalOlapScanOperator> list = Lists.newArrayList();
+        Utils.extractOperator(tree, list, op -> op instanceof PhysicalOlapScanOperator);
+        rootTaskContext.setAllPhysicalOlapScanOperators(Collections.unmodifiableList(list));
     }
 
     private void ruleRewriteIterative(OptExpression tree, TaskContext rootTaskContext, RuleSetType ruleSetType) {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/OptimizerContext.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/OptimizerContext.java
@@ -49,6 +49,7 @@ public class OptimizerContext {
     private final ColumnRefFactory columnRefFactory;
     private SessionVariable sessionVariable;
     private DumpInfo dumpInfo;
+    private Set<Long> currentSqlDbIds;
     private CTEContext cteContext;
     private TaskContext currentTaskContext;
     private final OptimizerConfig optimizerConfig;
@@ -101,6 +102,7 @@ public class OptimizerContext {
         this.queryId = connectContext.getQueryId();
         this.sessionVariable = connectContext.getSessionVariable();
         this.dumpInfo = connectContext.getDumpInfo();
+        this.currentSqlDbIds = connectContext.getCurrentSqlDbIds();
         this.cteContext = new CTEContext();
         cteContext.reset();
         this.cteContext.setEnableCTE(sessionVariable.isCboCteReuse());
@@ -140,6 +142,10 @@ public class OptimizerContext {
 
     public DumpInfo getDumpInfo() {
         return dumpInfo;
+    }
+
+    public Set<Long> getCurrentSqlDbIds() {
+        return currentSqlDbIds;
     }
 
     public CTEContext getCteContext() {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/task/TaskContext.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/task/TaskContext.java
@@ -19,6 +19,7 @@ import com.starrocks.sql.optimizer.OptimizerContext;
 import com.starrocks.sql.optimizer.base.ColumnRefSet;
 import com.starrocks.sql.optimizer.base.PhysicalPropertySet;
 import com.starrocks.sql.optimizer.operator.logical.LogicalOlapScanOperator;
+import com.starrocks.sql.optimizer.operator.physical.PhysicalOlapScanOperator;
 
 import java.util.Collections;
 import java.util.List;
@@ -29,7 +30,8 @@ public class TaskContext {
     private final PhysicalPropertySet requiredProperty;
     private ColumnRefSet requiredColumns;
     private double upperBoundCost;
-    private List<LogicalOlapScanOperator> allScanOperators;
+    private List<LogicalOlapScanOperator> allLogicalOlapScanOperators;
+    private List<PhysicalOlapScanOperator> allPhysicalOlapScanOperators;
 
     public TaskContext(OptimizerContext context,
                        PhysicalPropertySet physicalPropertySet,
@@ -39,7 +41,8 @@ public class TaskContext {
         this.requiredProperty = physicalPropertySet;
         this.requiredColumns = requiredColumns;
         this.upperBoundCost = cost;
-        this.allScanOperators = Collections.emptyList();
+        this.allLogicalOlapScanOperators = Collections.emptyList();
+        this.allPhysicalOlapScanOperators = Collections.emptyList();
     }
 
     public OptimizerContext getOptimizerContext() {
@@ -66,11 +69,19 @@ public class TaskContext {
         this.upperBoundCost = upperBoundCost;
     }
 
-    public void setAllScanOperators(List<LogicalOlapScanOperator> allScanOperators) {
-        this.allScanOperators = allScanOperators;
+    public void setAllLogicalOlapScanOperators(List<LogicalOlapScanOperator> allScanOperators) {
+        this.allLogicalOlapScanOperators = allScanOperators;
     }
 
-    public List<LogicalOlapScanOperator> getAllScanOperators() {
-        return allScanOperators;
+    public List<LogicalOlapScanOperator> getAllLogicalOlapScanOperators() {
+        return allLogicalOlapScanOperators;
+    }
+
+    public void setAllPhysicalOlapScanOperators(List<PhysicalOlapScanOperator> allScanOperators) {
+        this.allPhysicalOlapScanOperators = allScanOperators;
+    }
+
+    public List<PhysicalOlapScanOperator> getAllPhysicalOlapScanOperators() {
+        return allPhysicalOlapScanOperators;
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/validate/MVRewriteValidator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/validate/MVRewriteValidator.java
@@ -63,7 +63,7 @@ public class MVRewriteValidator {
         List<MaterializedView> mvs = collectMaterializedViews(physicalPlan);
         // To avoid queries that query the materialized view directly, only consider materialized views
         // that are not used in rewriting before.
-        Set<Long> beforeTableIds = taskContext.getAllScanOperators().stream()
+        Set<Long> beforeTableIds = taskContext.getAllLogicalOlapScanOperators().stream()
                 .map(op -> op.getTable().getId())
                 .collect(Collectors.toSet());
         if (CollectionUtils.isNotEmpty(mvs)) {
@@ -113,7 +113,7 @@ public class MVRewriteValidator {
         }
 
         List<MaterializedView> mvs = collectMaterializedViews(physicalPlan);
-        Set<Long> beforeTableIds = taskContext.getAllScanOperators().stream()
+        Set<Long> beforeTableIds = taskContext.getAllLogicalOlapScanOperators().stream()
                 .map(op -> op.getTable().getId())
                 .collect(Collectors.toSet());
 


### PR DESCRIPTION
## Why I'm doing:
If query rewrite by mv, and has resource group for mv db, it can not use the resource group to restrict mv now.
## What I'm doing:
add mv db id to currentSqlDbIds if query rewrited by mv
Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
