### PR TITLE
[Enhancement](5/n) Adding or dropping columns without data rewriting in share data mode

### DIFF
--- a/be/src/storage/lake/schema_change.cpp
+++ b/be/src/storage/lake/schema_change.cpp
@@ -14,6 +14,8 @@
 
 #include "storage/lake/schema_change.h"
 
+#include <thrift/protocol/TDebugProtocol.h>
+
 #include <memory>
 
 #include "runtime/current_thread.h"
@@ -24,6 +26,7 @@
 #include "storage/lake/tablet_reader.h"
 #include "storage/lake/tablet_writer.h"
 #include "storage/lake/versioned_tablet.h"
+#include "storage/metadata_util.h"
 #include "storage/schema_change_utils.h"
 #include "storage/storage_engine.h"
 #include "storage/tablet_reader_params.h"
@@ -370,14 +373,9 @@ Status SchemaChangeHandler::process_update_tablet_meta(const TUpdateTabletMetaIn
 }
 
 Status SchemaChangeHandler::do_process_update_tablet_meta(const TTabletMetaInfo& tablet_meta_info, int64_t txn_id) {
-    if (tablet_meta_info.meta_type != TTabletMetaType::ENABLE_PERSISTENT_INDEX) {
-        return Status::InternalError(fmt::format("unsupported update meta type: {}", tablet_meta_info.meta_type));
-    }
-
-    MonotonicStopWatch timer;
+    auto timer = MonotonicStopWatch{};
     timer.start();
-    LOG(INFO) << "begin to update tablet, tablet: " << tablet_meta_info.tablet_id
-              << ", update meta type: " << tablet_meta_info.meta_type;
+    LOG(INFO) << "Updating tablet metadata: " << ThriftDebugString(tablet_meta_info);
 
     auto tablet_id = tablet_meta_info.tablet_id;
     ASSIGN_OR_RETURN(auto tablet, _tablet_manager->get_tablet(tablet_id));
@@ -387,15 +385,20 @@ Status SchemaChangeHandler::do_process_update_tablet_meta(const TTabletMetaInfo&
     txn_log->set_tablet_id(tablet_id);
     txn_log->set_txn_id(txn_id);
     auto op_alter_metadata = txn_log->mutable_op_alter_metadata();
-
     auto metadata_update_info = op_alter_metadata->add_metadata_update_infos();
-    metadata_update_info->set_enable_persistent_index(tablet_meta_info.enable_persistent_index);
+    if (tablet_meta_info.__isset.enable_persistent_index) {
+        metadata_update_info->set_enable_persistent_index(tablet_meta_info.enable_persistent_index);
+    }
+    if (tablet_meta_info.__isset.tablet_schema) {
+        // FIXME: pass compression type
+        auto compression_type = TCompressionType::LZ4_FRAME;
+        auto new_schema = metadata_update_info->mutable_tablet_schema();
+        RETURN_IF_ERROR(convert_t_schema_to_pb_schema(tablet_meta_info.tablet_schema, compression_type, new_schema));
+        if (tablet_meta_info.create_schema_file) {
+            RETURN_IF_ERROR(_tablet_manager->create_schema_file(tablet_id, *new_schema));
+        }
+    }
 
-    LOG(INFO) << "update lake tablet: " << tablet_id
-              << ", enable_persistent_index: " << tablet_meta_info.enable_persistent_index
-              << ", cost: " << timer.elapsed_time();
-
-    // write txn log
     RETURN_IF_ERROR(tablet.put_txn_log(std::move(txn_log)));
     return Status::OK();
 }

--- a/be/src/storage/lake/schema_change.h
+++ b/be/src/storage/lake/schema_change.h
@@ -36,8 +36,8 @@ public:
 
     Status process_alter_tablet(const TAlterTabletReqV2& request);
 
-    // for update tablet meta
     Status process_update_tablet_meta(const TUpdateTabletMetaInfoReq& request);
+
     DISALLOW_COPY_AND_MOVE(SchemaChangeHandler);
 
 private:

--- a/be/src/storage/lake/tablet.cpp
+++ b/be/src/storage/lake/tablet.cpp
@@ -104,8 +104,8 @@ StatusOr<std::shared_ptr<const TabletSchema>> Tablet::get_schema() {
     return _mgr->get_tablet_schema(_id, &_version_hint);
 }
 
-StatusOr<std::shared_ptr<const TabletSchema>> Tablet::get_schema_by_id(int64_t index_id) {
-    return _mgr->get_tablet_schema_by_id(_id, index_id);
+StatusOr<std::shared_ptr<const TabletSchema>> Tablet::get_schema_by_id(int64_t schema_id) {
+    return _mgr->get_tablet_schema_by_id(_id, schema_id);
 }
 
 StatusOr<std::vector<RowsetPtr>> Tablet::get_rowsets(int64_t version) {

--- a/be/src/storage/lake/tablet.h
+++ b/be/src/storage/lake/tablet.h
@@ -89,7 +89,7 @@ public:
     // NOTE: This method may update the version hint
     StatusOr<std::shared_ptr<const TabletSchema>> get_schema();
 
-    StatusOr<std::shared_ptr<const TabletSchema>> get_schema_by_id(int64_t index_id);
+    StatusOr<std::shared_ptr<const TabletSchema>> get_schema_by_id(int64_t schema_id);
 
     StatusOr<std::vector<RowsetPtr>> get_rowsets(int64_t version);
 

--- a/be/src/storage/lake/tablet_manager.cpp
+++ b/be/src/storage/lake/tablet_manager.cpp
@@ -170,16 +170,9 @@ Status TabletManager::create_tablet(const TCreateTabletReq& req) {
         }
     }
 
-    // Note: ignore the parameter "base_tablet_id" of `TCreateTabletReq`, because we don't support linked schema
-    // change, there is no need to keep the column unique id consistent between the new tablet and base tablet.
-    std::unordered_map<uint32_t, uint32_t> col_idx_to_unique_id;
-    uint32_t next_unique_id = req.tablet_schema.columns.size();
-    for (uint32_t col_idx = 0; col_idx < next_unique_id; ++col_idx) {
-        col_idx_to_unique_id[col_idx] = col_idx;
-    }
-    RETURN_IF_ERROR(starrocks::convert_t_schema_to_pb_schema(
-            req.tablet_schema, next_unique_id, col_idx_to_unique_id, tablet_metadata_pb->mutable_schema(),
-            req.__isset.compression_type ? req.compression_type : TCompressionType::LZ4_FRAME));
+    auto compress_type = req.__isset.compression_type ? req.compression_type : TCompressionType::LZ4_FRAME;
+    RETURN_IF_ERROR(
+            convert_t_schema_to_pb_schema(req.tablet_schema, compress_type, tablet_metadata_pb->mutable_schema()));
     if (req.create_schema_file) {
         RETURN_IF_ERROR(create_schema_file(req.tablet_id, tablet_metadata_pb->schema()));
     }
@@ -490,19 +483,18 @@ StatusOr<TabletSchemaPtr> TabletManager::get_tablet_schema(int64_t tablet_id, in
     return schema;
 }
 
-StatusOr<TabletSchemaPtr> TabletManager::get_tablet_schema_by_id(int64_t tablet_id, int64_t index_id) {
-    auto global_cache_key = global_schema_cache_key(index_id);
+StatusOr<TabletSchemaPtr> TabletManager::get_tablet_schema_by_id(int64_t tablet_id, int64_t schema_id) {
+    auto global_cache_key = global_schema_cache_key(schema_id);
     auto schema = _metacache->lookup_tablet_schema(global_cache_key);
     TEST_SYNC_POINT_CALLBACK("get_tablet_schema_by_id.1", &schema);
     if (schema != nullptr) {
         return schema;
     }
     // else: Cache miss, read the schema file
-    auto schema_file_path = join_path(tablet_root_location(tablet_id), schema_filename(index_id));
+    auto schema_file_path = join_path(tablet_root_location(tablet_id), schema_filename(schema_id));
     auto schema_or = load_and_parse_schema_file(schema_file_path);
     TEST_SYNC_POINT_CALLBACK("get_tablet_schema_by_id.2", &schema_or);
     if (schema_or.ok()) {
-        VLOG(3) << "Got tablet schema of id " << index_id << " for tablet " << tablet_id;
         schema = std::move(schema_or).value();
         // Save the schema into the in-memory cache, use the schema id as the cache key
         _metacache->cache_tablet_schema(global_cache_key, schema, 0 /*TODO*/);

--- a/be/src/storage/lake/tablet_manager.h
+++ b/be/src/storage/lake/tablet_manager.h
@@ -180,15 +180,15 @@ public:
 
     StatusOr<TabletSchemaPtr> get_tablet_schema(int64_t tablet_id, int64_t* version_hint = nullptr);
 
+    Status create_schema_file(int64_t tablet_id, const TabletSchemaPB& schema_pb);
+
 private:
     static std::string global_schema_cache_key(int64_t index_id);
     static std::string tablet_schema_cache_key(int64_t tablet_id);
     static std::string tablet_latest_metadata_cache_key(int64_t tablet_id);
 
-    Status create_schema_file(int64_t tablet_id, const TabletSchemaPB& schema_pb);
     StatusOr<TabletSchemaPtr> load_and_parse_schema_file(const std::string& path);
-
-    StatusOr<TabletSchemaPtr> get_tablet_schema_by_id(int64_t tablet_id, int64_t index_id);
+    StatusOr<TabletSchemaPtr> get_tablet_schema_by_id(int64_t tablet_id, int64_t schema_id);
 
     StatusOr<TabletMetadataPtr> load_tablet_metadata(const std::string& metadata_location, bool fill_cache);
     StatusOr<TxnLogPtr> load_txn_log(const std::string& txn_log_location, bool fill_cache);

--- a/be/src/storage/lake/txn_log_applier.cpp
+++ b/be/src/storage/lake/txn_log_applier.cpp
@@ -20,7 +20,6 @@
 #include "storage/lake/lake_primary_index.h"
 #include "storage/lake/lake_primary_key_recover.h"
 #include "storage/lake/meta_file.h"
-#include "storage/lake/rowset.h"
 #include "storage/lake/tablet.h"
 #include "storage/lake/tablet_metadata.h"
 #include "storage/lake/update_manager.h"
@@ -30,6 +29,31 @@
 #include "util/trace.h"
 
 namespace starrocks::lake {
+
+namespace {
+Status apply_alter_meta_log(TabletMetadataPB* metadata, const TxnLogPB_OpAlterMetadata& op_alter_metas,
+                            TabletManager* tablet_mgr) {
+    for (const auto& alter_meta : op_alter_metas.metadata_update_infos()) {
+        if (alter_meta.has_enable_persistent_index()) {
+            auto update_mgr = tablet_mgr->update_mgr();
+            metadata->set_enable_persistent_index(alter_meta.enable_persistent_index());
+            update_mgr->set_enable_persistent_index(metadata->id(), alter_meta.enable_persistent_index());
+            // Try remove index from index cache
+            // If tablet is doing apply rowset right now, remove primary index from index cache may be failed
+            // because the primary index is available in cache
+            // But it will be remove from index cache after apply is finished
+            (void)update_mgr->index_cache().try_remove_by_key(metadata->id());
+        }
+        if (alter_meta.has_tablet_schema()) {
+            VLOG(2) << "old schema: " << metadata->schema().DebugString()
+                    << " new schema: " << alter_meta.tablet_schema().DebugString();
+            metadata->mutable_schema()->CopyFrom(alter_meta.tablet_schema());
+        }
+    }
+    return Status::OK();
+}
+} // namespace
+
 class PrimaryKeyTxnLogApplier : public TxnLogApplier {
 public:
     PrimaryKeyTxnLogApplier(const Tablet& tablet, MutableTabletMetadataPtr metadata, int64_t new_version)
@@ -80,7 +104,8 @@ public:
             RETURN_IF_ERROR(apply_schema_change_log(log.op_schema_change()));
         }
         if (log.has_op_alter_metadata()) {
-            RETURN_IF_ERROR(apply_alter_meta_log(log.op_alter_metadata()));
+            DCHECK_EQ(_base_version + 1, _new_version);
+            return apply_alter_meta_log(_metadata.get(), log.op_alter_metadata(), _tablet.tablet_mgr());
         }
         if (log.has_op_replication()) {
             RETURN_IF_ERROR(apply_replication_log(log.op_replication(), log.txn_id()));
@@ -196,34 +221,6 @@ private:
         return Status::OK();
     }
 
-    Status apply_alter_meta_log(const TxnLogPB_OpAlterMetadata& op_alter_metas) {
-        DCHECK_EQ(_base_version + 1, _new_version);
-        for (const auto& alter_meta : op_alter_metas.metadata_update_infos()) {
-            if (alter_meta.has_enable_persistent_index()) {
-                // this should always be true,
-                // for FE will check whether the value of `enable_persisent_index` is changed or not
-                // then send the alter task to BE
-                if (_metadata->enable_persistent_index() != alter_meta.enable_persistent_index()) {
-                    _metadata->set_enable_persistent_index(alter_meta.enable_persistent_index());
-
-                    _tablet.update_mgr()->set_enable_persistent_index(_tablet.id(),
-                                                                      alter_meta.enable_persistent_index());
-                    // Try remove index from index cache
-                    // If tablet is doing apply rowset right now, remove primary index from index cache may be failed
-                    // because the primary index is available in cache
-                    // But it will be remove from index cache after apply is finished
-                    (void)_tablet.update_mgr()->index_cache().try_remove_by_key(_tablet.id());
-                } else {
-                    LOG(WARNING) << strings::Substitute(
-                            "alter_meta_log not need to apply, for enable_persistent_index is the same, which is $0, "
-                            "base_version: $1, new_version: $2",
-                            _metadata->enable_persistent_index(), _base_version, _new_version);
-                }
-            }
-        }
-        return Status::OK();
-    }
-
     Status apply_replication_log(const TxnLogPB_OpReplication& op_replication, int64_t txn_id) {
         if (op_replication.txn_meta().txn_state() != ReplicationTxnStatePB::TXN_REPLICATED) {
             LOG(WARNING) << "Fail to apply replication log, invalid txn meta state: "
@@ -316,6 +313,9 @@ public:
         }
         if (log.has_op_replication()) {
             RETURN_IF_ERROR(apply_replication_log(log.op_replication()));
+        }
+        if (log.has_op_alter_metadata()) {
+            return apply_alter_meta_log(_metadata.get(), log.op_alter_metadata(), _tablet.tablet_mgr());
         }
         return Status::OK();
     }

--- a/be/src/storage/metadata_util.cpp
+++ b/be/src/storage/metadata_util.cpp
@@ -236,8 +236,6 @@ Status convert_t_schema_to_pb_schema(const TTabletSchema& tablet_schema, uint32_
     case TKeysType::PRIMARY_KEYS:
         schema->set_keys_type(KeysType::PRIMARY_KEYS);
         break;
-    default:
-        CHECK(false) << "unsupported keys type " << tablet_schema.keys_type;
     }
 
     switch (compression_type) {
@@ -371,4 +369,13 @@ Status convert_t_schema_to_pb_schema(const TTabletSchema& tablet_schema, uint32_
     return validate_tablet_schema(*schema);
 }
 
+Status convert_t_schema_to_pb_schema(const TTabletSchema& t_schema, TCompressionType::type compression_type,
+                                     TabletSchemaPB* out_schema) {
+    auto col_idx_to_unique_id = std::unordered_map<uint32_t, uint32_t>{};
+    auto next_unique_id = t_schema.columns.size();
+    for (auto col_idx = uint32_t{0}; col_idx < next_unique_id; ++col_idx) {
+        col_idx_to_unique_id[col_idx] = col_idx;
+    }
+    return convert_t_schema_to_pb_schema(t_schema, next_unique_id, col_idx_to_unique_id, out_schema, compression_type);
+}
 } // namespace starrocks

--- a/be/src/storage/metadata_util.h
+++ b/be/src/storage/metadata_util.h
@@ -40,7 +40,15 @@ enum class FieldTypeVersion {
     kV2,
 };
 
-Status convert_t_schema_to_pb_schema(const TTabletSchema& tablet_schema, uint32_t next_unique_id,
+// If the columns in |t_schema| do not have a unique id, then the columns in |out_schema| will use the
+// column's position in the schema (starting from 0) as their unique id.
+Status convert_t_schema_to_pb_schema(const TTabletSchema& t_schema, TCompressionType::type compression_type,
+                                     TabletSchemaPB* out_schema);
+
+// If the columns in |t_schema| do not have a unique id, then the columns in |out_schema| will use the
+// column's position in the schema (starting at 0) as the key to look up the value in
+// |col_ordinal_to_unique_id| for their unique ids.
+Status convert_t_schema_to_pb_schema(const TTabletSchema& t_schema, uint32_t next_unique_id,
                                      const std::unordered_map<uint32_t, uint32_t>& col_ordinal_to_unique_id,
                                      TabletSchemaPB* schema, TCompressionType::type compression_type);
 

--- a/be/test/storage/lake/alter_tablet_meta_test.cpp
+++ b/be/test/storage/lake/alter_tablet_meta_test.cpp
@@ -179,19 +179,4 @@ TEST_F(AlterTabletMetaTest, test_alter_enable_persistent_index_not_change) {
     ASSERT_EQ(true, new_tablet_meta2.value()->enable_persistent_index());
 }
 
-TEST_F(AlterTabletMetaTest, test_alter_not_persistent_index) {
-    lake::SchemaChangeHandler handler(_tablet_mgr.get());
-    TUpdateTabletMetaInfoReq update_tablet_meta_req;
-    int64_t txn_id = 1;
-    update_tablet_meta_req.__set_txn_id(txn_id);
-
-    TTabletMetaInfo tablet_meta_info;
-    auto tablet_id = _tablet_metadata->id();
-    tablet_meta_info.__set_tablet_id(tablet_id);
-    tablet_meta_info.__set_meta_type(TTabletMetaType::INMEMORY);
-
-    update_tablet_meta_req.tabletMetaInfos.push_back(tablet_meta_info);
-    ASSERT_ERROR(handler.process_update_tablet_meta(update_tablet_meta_req));
-}
-
 } // namespace starrocks::lake

--- a/fe/fe-core/src/main/java/com/starrocks/alter/AlterJobMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/AlterJobMgr.java
@@ -996,7 +996,7 @@ public class AlterJobMgr {
         }
     }
 
-    public AlterHandler getSchemaChangeHandler() {
+    public SchemaChangeHandler getSchemaChangeHandler() {
         return this.schemaChangeHandler;
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/alter/AlterJobV2.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/AlterJobV2.java
@@ -164,6 +164,10 @@ public abstract class AlterJobV2 implements Writable {
         return tableName;
     }
 
+    public long getTimeoutMs() {
+        return timeoutMs;
+    }
+
     public boolean isTimeout() {
         return System.currentTimeMillis() - createTimeMs > timeoutMs;
     }

--- a/fe/fe-core/src/main/java/com/starrocks/alter/LakeTableAsyncFastSchemaChangeJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/LakeTableAsyncFastSchemaChangeJob.java
@@ -1,0 +1,206 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.alter;
+
+import com.google.common.base.Preconditions;
+import com.google.common.collect.Lists;
+import com.google.common.collect.Sets;
+import com.google.gson.annotations.SerializedName;
+import com.starrocks.catalog.Column;
+import com.starrocks.catalog.Database;
+import com.starrocks.catalog.MaterializedIndex;
+import com.starrocks.catalog.MaterializedIndexMeta;
+import com.starrocks.catalog.SchemaInfo;
+import com.starrocks.common.FeConstants;
+import com.starrocks.common.io.Text;
+import com.starrocks.common.util.TimeUtils;
+import com.starrocks.common.util.concurrent.lock.LockType;
+import com.starrocks.common.util.concurrent.lock.Locker;
+import com.starrocks.lake.LakeTable;
+import com.starrocks.persist.gson.GsonPostProcessable;
+import com.starrocks.persist.gson.GsonUtils;
+import com.starrocks.task.TabletMetadataUpdateAgentTask;
+import com.starrocks.task.TabletMetadataUpdateAgentTaskFactory;
+
+import java.io.DataOutput;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Objects;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import static com.starrocks.sql.optimizer.rule.transformation.materialization.MvUtils.inactiveRelatedMaterializedViews;
+import static java.util.Objects.requireNonNull;
+
+/**
+ * The overall workflow to modify the table schema is as follows:
+ * 1. Begin a new transaction.
+ * 2. Send {@link com.starrocks.thrift.TUpdateTabletMetaInfoReq} requests to all tablet in the table.
+ * 3. Get the new tablet schema from the TUpdateTabletMetaInfoReq and writes it to the txn log for each tablet.
+ * 4. Commit transaction.
+ * 5. Send {@link com.starrocks.proto.PublishVersionRequest} requests to all tablets.
+ * 6. Apply txn log on each tablet to create a new version of the tablet metadata with the new tablet schema.
+ * 7. Modify the table schema and visible version in the FE catalog
+ * 8. Finish the transaction
+ */
+public class LakeTableAsyncFastSchemaChangeJob extends LakeTableAlterMetaJobBase implements GsonPostProcessable {
+    // shadow index id -> index schema
+    @SerializedName(value = "schemaInfos")
+    private List<IndexSchemaInfo> schemaInfos;
+    private Set<Long> visitedIndexSet = new HashSet<>();
+
+    LakeTableAsyncFastSchemaChangeJob(long jobId, long dbId, long tableId, String tableName, long timeoutMs) {
+        super(jobId, JobType.SCHEMA_CHANGE, dbId, tableId, tableName, timeoutMs);
+        schemaInfos = new ArrayList<>();
+    }
+
+    LakeTableAsyncFastSchemaChangeJob(LakeTableAsyncFastSchemaChangeJob other) {
+        this(other.getJobId(), other.getDbId(), other.getTableId(), other.getTableName(), other.getTimeoutMs());
+        for (IndexSchemaInfo indexSchemaInfo : other.schemaInfos) {
+            setIndexTabletSchema(indexSchemaInfo.indexId, indexSchemaInfo.indexName, indexSchemaInfo.schemaInfo);
+        }
+        visitedIndexSet.addAll(other.visitedIndexSet);
+    }
+
+    public void setIndexTabletSchema(long indexId, String indexName, SchemaInfo schemaInfo) {
+        schemaInfos.add(new IndexSchemaInfo(indexId, indexName, schemaInfo));
+    }
+
+    @Override
+    protected TabletMetadataUpdateAgentTask createTask(MaterializedIndex index, long nodeId, Set<Long> tablets) {
+        TabletMetadataUpdateAgentTask task = null;
+        for (IndexSchemaInfo info : schemaInfos) {
+            if (info.indexId == index.getId()) {
+                boolean createSchemaFile = !visitedIndexSet.contains(info.indexId);
+                visitedIndexSet.add(info.indexId);
+                task = TabletMetadataUpdateAgentTaskFactory.createTabletSchemaUpdateTask(nodeId,
+                        new ArrayList<>(tablets), info.schemaInfo.toTabletSchema(), createSchemaFile);
+                break;
+            }
+        }
+        return task;
+    }
+
+    @Override
+    protected void updateCatalog(Database db, LakeTable table) {
+        Locker locker = new Locker();
+        locker.lockDatabase(db, LockType.WRITE);
+        try {
+            updateCatalogUnprotected(db, table);
+        } finally {
+            locker.unLockDatabase(db, LockType.WRITE);
+        }
+    }
+
+    private void updateCatalogUnprotected(Database db, LakeTable table) {
+        Set<String> droppedColumns = Sets.newHashSet();
+        boolean hasMv = !table.getRelatedMaterializedViews().isEmpty();
+        for (IndexSchemaInfo indexSchemaInfo : schemaInfos) {
+            SchemaInfo schemaInfo = indexSchemaInfo.schemaInfo;
+            long indexId = indexSchemaInfo.indexId;
+            MaterializedIndexMeta indexMeta = requireNonNull(table.getIndexMetaByIndexId(indexId)).shallowCopy();
+            List<Column> oldColumns = indexMeta.getSchema();
+
+            Preconditions.checkState(Objects.equals(indexMeta.getKeysType(), schemaInfo.getKeysType()));
+            Preconditions.checkState(Objects.equals(indexMeta.getSortKeyIdxes(), schemaInfo.getSortKeyIndexes()));
+            Preconditions.checkState(Objects.equals(indexMeta.getSortKeyUniqueIds(), schemaInfo.getSortKeyUniqueIds()));
+            Preconditions.checkState(schemaInfo.getVersion() > indexMeta.getSchemaVersion());
+            Preconditions.checkState(Objects.equals(indexMeta.getShortKeyColumnCount(), schemaInfo.getShortKeyColumnCount()));
+
+            if (hasMv && schemaInfo.getColumns().size() < oldColumns.size()) {
+                List<Column> differences = oldColumns.stream().filter(element -> !schemaInfo.getColumns().contains(element))
+                        .collect(Collectors.toList());
+                // can just drop one column one time, so just one element in differences
+                int dropIdx = oldColumns.indexOf(differences.get(0));
+                droppedColumns.add(oldColumns.get(dropIdx).getName());
+            }
+
+            indexMeta.setSchema(schemaInfo.getColumns());
+            indexMeta.setSchemaVersion(schemaInfo.getVersion());
+            indexMeta.setSchemaId(schemaInfo.getId());
+
+            // update the indexIdToMeta
+            table.getIndexIdToMeta().put(indexId, indexMeta);
+            table.setIndexes(schemaInfo.getIndexes());
+        }
+        table.rebuildFullSchema();
+
+        // If modified columns are already done, inactive related mv
+        inactiveRelatedMaterializedViews(db, table, droppedColumns);
+    }
+
+    @Override
+    protected void restoreState(LakeTableAlterMetaJobBase job) {
+        this.schemaInfos = new ArrayList<>(((LakeTableAsyncFastSchemaChangeJob) job).schemaInfos);
+    }
+
+    @Override
+    public void write(DataOutput out) throws IOException {
+        String json = GsonUtils.GSON.toJson(this);
+        Text.writeString(out, json);
+    }
+
+    private static class IndexSchemaInfo {
+        @SerializedName("indexId")
+        private final long indexId;
+        @SerializedName("indexName")
+        private final String indexName;
+        @SerializedName("schemaInfo")
+        private final SchemaInfo schemaInfo;
+
+        IndexSchemaInfo(long indexId, String indexName, SchemaInfo schemaInfo) {
+            this.indexId = indexId;
+            this.indexName = indexName;
+            this.schemaInfo = requireNonNull(schemaInfo, "schema is null");
+        }
+    }
+
+    List<SchemaInfo> getSchemaInfoList() {
+        return schemaInfos.stream().map(i -> i.schemaInfo).collect(Collectors.toList());
+    }
+
+    @Override
+    protected void getInfo(List<List<Comparable>> infos) {
+        String progress = FeConstants.NULL_STRING;
+        if (jobState == JobState.RUNNING && getBatchTask() != null) {
+            progress = getBatchTask().getFinishedTaskNum() + "/" + getBatchTask().getTaskNum();
+        }
+
+        for (IndexSchemaInfo schemaInfo : schemaInfos) {
+            List<Comparable> info = Lists.newArrayList();
+            info.add(jobId);
+            info.add(tableName);
+            info.add(TimeUtils.longToTimeString(createTimeMs));
+            info.add(TimeUtils.longToTimeString(finishedTimeMs));
+            info.add(schemaInfo.indexName);
+            info.add(schemaInfo.indexId);
+            info.add(schemaInfo.indexId);
+            info.add(String.format("%d:0", schemaInfo.schemaInfo.getVersion())); // schema version and schema hash
+            info.add(getWatershedTxnId());
+            info.add(jobState.name());
+            info.add(errMsg);
+            info.add(progress);
+            info.add(timeoutMs / 1000);
+            infos.add(info);
+        }
+    }
+
+    @Override
+    public void gsonPostProcess() throws IOException {
+        visitedIndexSet = new HashSet<>();
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/alter/SchemaChangeJobV2.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/SchemaChangeJobV2.java
@@ -894,16 +894,7 @@ public class SchemaChangeJobV2 extends AlterJobV2 {
             tbl.setIndexes(indexes);
         }
 
-        //update max column unique id
-        int maxColUniqueId = tbl.getMaxColUniqueId();
-        for (Column column : tbl.getFullSchema()) {
-            if (column.getUniqueId() > maxColUniqueId) {
-                maxColUniqueId = column.getUniqueId();
-            }
-        }
-        tbl.setMaxColUniqueId(maxColUniqueId);
-        LOG.debug("fullSchema:{}, maxColUniqueId:{}", tbl.getFullSchema(), maxColUniqueId);
-
+        LOG.debug("fullSchema:{}, maxColUniqueId:{}", tbl.getFullSchema(), tbl.getMaxColUniqueId());
 
         tbl.setState(OlapTableState.NORMAL);
         tbl.lastSchemaUpdateTime.set(System.nanoTime());

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/OlapTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/OlapTable.java
@@ -2802,7 +2802,6 @@ public class OlapTable extends Table {
         if (tableProperty != null) {
             return tableProperty.getUseFastSchemaEvolution();
         }
-        // property is set false by default
         return false;
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/TableProperty.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/TableProperty.java
@@ -886,7 +886,7 @@ public class TableProperty implements Writable, GsonPostProcessable {
 
     public TableProperty buildUseFastSchemaEvolution() {
         useFastSchemaEvolution = Boolean.parseBoolean(
-            properties.getOrDefault(PropertyAnalyzer.PROPERTIES_USE_FAST_SCHEMA_EVOLUTION, "false"));
+                properties.getOrDefault(PropertyAnalyzer.PROPERTIES_USE_FAST_SCHEMA_EVOLUTION, "false"));
         return this;
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/common/Config.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/Config.java
@@ -2738,9 +2738,8 @@ public class Config extends ConfigBase {
     @ConfField(mutable = true)
     public static boolean enable_fast_schema_evolution = true;
 
-    // This configuration will be removed after the shared data mode supports fast schema evolution
     @ConfField(mutable = true)
-    public static boolean experimental_enable_fast_schema_evolution_in_shared_data = false;
+    public static boolean enable_fast_schema_evolution_in_share_data_mode = true;
 
     @ConfField(mutable = false)
     public static int pipe_listener_interval_millis = 1000;

--- a/fe/fe-core/src/main/java/com/starrocks/common/util/PropertyAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/util/PropertyAnalyzer.java
@@ -634,8 +634,7 @@ public class PropertyAnalyzer {
 
     public static Boolean analyzeUseFastSchemaEvolution(Map<String, String> properties) throws AnalysisException {
         if (properties == null || properties.isEmpty()) {
-            return RunMode.isSharedNothingMode() ? Config.enable_fast_schema_evolution
-                    : Config.experimental_enable_fast_schema_evolution_in_shared_data;
+            return Config.enable_fast_schema_evolution;
         }
         String value = properties.get(PROPERTIES_USE_FAST_SCHEMA_EVOLUTION);
         if (null == value) {

--- a/fe/fe-core/src/main/java/com/starrocks/lake/LakeTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/lake/LakeTable.java
@@ -35,6 +35,7 @@ import com.starrocks.catalog.RangePartitionInfo;
 import com.starrocks.catalog.RecyclePartitionInfo;
 import com.starrocks.catalog.TableIndexes;
 import com.starrocks.catalog.TableProperty;
+import com.starrocks.common.Config;
 import com.starrocks.common.DdlException;
 import com.starrocks.common.io.DeepCopy;
 import com.starrocks.common.io.Text;
@@ -256,5 +257,10 @@ public class LakeTable extends OlapTable {
         if (getMaxColUniqueId() <= 0) {
             setMaxColUniqueId(LakeTableHelper.restoreColumnUniqueId(this));
         }
+    }
+
+    @Override
+    public boolean getUseFastSchemaEvolution() {
+        return !hasRowStorageType() && Config.enable_fast_schema_evolution_in_share_data_mode;
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/persist/gson/GsonUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/persist/gson/GsonUtils.java
@@ -63,6 +63,7 @@ import com.google.gson.stream.JsonReader;
 import com.google.gson.stream.JsonWriter;
 import com.starrocks.alter.AlterJobV2;
 import com.starrocks.alter.LakeTableAlterMetaJob;
+import com.starrocks.alter.LakeTableAsyncFastSchemaChangeJob;
 import com.starrocks.alter.LakeTableSchemaChangeJob;
 import com.starrocks.alter.OptimizeJobV2;
 import com.starrocks.alter.RollupJobV2;
@@ -256,7 +257,8 @@ public class GsonUtils {
                     .registerSubtype(SchemaChangeJobV2.class, "SchemaChangeJobV2")
                     .registerSubtype(OptimizeJobV2.class, "OptimizeJobV2")
                     .registerSubtype(LakeTableSchemaChangeJob.class, "LakeTableSchemaChangeJob")
-                    .registerSubtype(LakeTableAlterMetaJob.class, "LakeTableAlterMetaJob");
+                    .registerSubtype(LakeTableAlterMetaJob.class, "LakeTableAlterMetaJob")
+                    .registerSubtype(LakeTableAsyncFastSchemaChangeJob.class, "LakeTableFastSchemaEvolutionJob");
 
     // runtime adapter for class "LoadJobStateUpdateInfo"
     private static final RuntimeTypeAdapterFactory<LoadJobStateUpdateInfo>

--- a/fe/fe-core/src/main/java/com/starrocks/server/OlapTableFactory.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/OlapTableFactory.java
@@ -231,7 +231,6 @@ public class OlapTableFactory implements AbstractTableFactory {
                 }
                 String storageVolumeId = svm.getStorageVolumeIdOfTable(tableId);
                 metastore.setLakeStorageInfo(db, table, storageVolumeId, properties);
-                useFastSchemaEvolution = false;
             } else {
                 table = new OlapTable(tableId, tableName, baseSchema, keysType, partitionInfo, distributionInfo, indexes);
             }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/MVColumnItem.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/MVColumnItem.java
@@ -122,14 +122,14 @@ public class MVColumnItem {
     public Column toMVColumn(OlapTable olapTable) {
         Column baseColumn = olapTable.getBaseColumn(name);
         Column result;
-        boolean useFastSchemaEvolution = olapTable.getUseFastSchemaEvolution();
+        boolean hasUniqueId = olapTable.getMaxColUniqueId() >= 0;
         if (baseColumn == null) {
             result = new Column(name, type, isKey, aggregationType, isAllowNull,
                     null, "");
             if (defineExpr != null) {
                 result.setDefineExpr(defineExpr);
             }
-            if (useFastSchemaEvolution) {
+            if (hasUniqueId) {
                 int nextUniqueId = olapTable.incAndGetMaxColUniqueId();
                 result.setUniqueId(nextUniqueId);
             }

--- a/fe/fe-core/src/test/java/com/starrocks/alter/LakeTableAsyncFastSchemaChangeJobTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/alter/LakeTableAsyncFastSchemaChangeJobTest.java
@@ -1,0 +1,217 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.alter;
+
+import com.starrocks.catalog.Column;
+import com.starrocks.catalog.Database;
+import com.starrocks.catalog.OlapTable;
+import com.starrocks.catalog.Partition;
+import com.starrocks.catalog.Table;
+import com.starrocks.common.Config;
+import com.starrocks.common.util.TimeUtils;
+import com.starrocks.lake.LakeTable;
+import com.starrocks.qe.ConnectContext;
+import com.starrocks.server.GlobalStateMgr;
+import com.starrocks.server.RunMode;
+import com.starrocks.sql.ast.AlterTableStmt;
+import com.starrocks.sql.ast.CreateDbStmt;
+import com.starrocks.sql.ast.CreateTableStmt;
+import com.starrocks.utframe.UtFrameUtils;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class LakeTableAsyncFastSchemaChangeJobTest {
+    private static ConnectContext connectContext;
+    private static final String DB_NAME = "test_lake_fast_schema_evolution";
+
+    @BeforeClass
+    public static void setUp() throws Exception {
+        UtFrameUtils.createMinStarRocksCluster(RunMode.SHARED_DATA);
+        connectContext = UtFrameUtils.createDefaultCtx();
+        String createDbStmtStr = "create database " + DB_NAME;
+        CreateDbStmt createDbStmt = (CreateDbStmt) UtFrameUtils.parseStmtWithNewParser(createDbStmtStr, connectContext);
+        GlobalStateMgr.getCurrentState().getMetadata().createDb(createDbStmt.getFullDbName());
+        connectContext.setDatabase(DB_NAME);
+    }
+
+    private static LakeTable createTable(ConnectContext connectContext, String sql) throws Exception {
+        CreateTableStmt createTableStmt = (CreateTableStmt) UtFrameUtils.parseStmtWithNewParser(sql, connectContext);
+        GlobalStateMgr.getCurrentState().getLocalMetastore().createTable(createTableStmt);
+        Database db = GlobalStateMgr.getCurrentState().getDb(createTableStmt.getDbName());
+        return (LakeTable) db.getTable(createTableStmt.getTableName());
+    }
+
+    private static void alterTable(ConnectContext connectContext, String sql) throws Exception {
+        AlterTableStmt stmt = (AlterTableStmt) UtFrameUtils.parseStmtWithNewParser(sql, connectContext);
+        GlobalStateMgr.getCurrentState().getLocalMetastore().alterTable(stmt);
+    }
+
+    private LakeTableAsyncFastSchemaChangeJob getAlterJob(Table table) {
+        AlterJobMgr alterJobMgr = GlobalStateMgr.getCurrentState().getAlterJobMgr();
+        List<AlterJobV2> jobs = alterJobMgr.getSchemaChangeHandler().getUnfinishedAlterJobV2ByTableId(table.getId());
+        Assert.assertEquals(1, jobs.size());
+        AlterJobV2 alterJob = jobs.get(0);
+        Assert.assertTrue(alterJob instanceof LakeTableAsyncFastSchemaChangeJob);
+        return (LakeTableAsyncFastSchemaChangeJob) alterJob;
+    }
+
+    private LakeTableAsyncFastSchemaChangeJob removeAlterJob(Table table) {
+        LakeTableAsyncFastSchemaChangeJob job = getAlterJob(table);
+        AlterHandler handler = GlobalStateMgr.getCurrentState().getAlterJobMgr().getSchemaChangeHandler();
+        handler.alterJobsV2.remove(job.getJobId());
+        return job;
+    }
+
+    private AlterJobV2 mustAlterTable(Table table, String sql) throws Exception {
+        alterTable(connectContext, sql);
+        AlterJobV2 alterJob = getAlterJob(table);
+        alterJob.run();
+        Assert.assertEquals(AlterJobV2.JobState.FINISHED, alterJob.getJobState());
+        return alterJob;
+    }
+
+    @Test
+    public void test() throws Exception {
+        LakeTable table = createTable(connectContext, "CREATE TABLE t0(c0 INT) DUPLICATE KEY(c0) DISTRIBUTED BY HASH(c0) " +
+                "BUCKETS 2 PROPERTIES('fast_schema_evolution'='true')");
+        long oldSchemaId = table.getIndexIdToMeta().get(table.getBaseIndexId()).getSchemaId();
+
+        {
+            mustAlterTable(table, "ALTER TABLE t0 ADD COLUMN c1 BIGINT");
+            List<Column> columns = table.getBaseSchema();
+            Assert.assertEquals(2, columns.size());
+            Assert.assertEquals("c0", columns.get(0).getName());
+            Assert.assertEquals(0, columns.get(0).getUniqueId());
+            Assert.assertEquals("c1", columns.get(1).getName());
+            Assert.assertEquals(1, columns.get(1).getUniqueId());
+            Assert.assertTrue(table.getIndexIdToMeta().get(table.getBaseIndexId()).getSchemaId() > oldSchemaId);
+            Assert.assertEquals(OlapTable.OlapTableState.NORMAL, table.getState());
+        }
+        oldSchemaId = table.getIndexIdToMeta().get(table.getBaseIndexId()).getSchemaId();
+        {
+            mustAlterTable(table, "ALTER TABLE t0 DROP COLUMN c1");
+            List<Column> columns = table.getBaseSchema();
+            Assert.assertEquals(1, columns.size());
+            Assert.assertEquals("c0", columns.get(0).getName());
+            Assert.assertEquals(0, columns.get(0).getUniqueId());
+            Assert.assertTrue(table.getIndexIdToMeta().get(table.getBaseIndexId()).getSchemaId() > oldSchemaId);
+            Assert.assertEquals(OlapTable.OlapTableState.NORMAL, table.getState());
+        }
+        oldSchemaId = table.getIndexIdToMeta().get(table.getBaseIndexId()).getSchemaId();
+        {
+            mustAlterTable(table, "ALTER TABLE t0 ADD COLUMN c1 BIGINT");
+            List<Column> columns = table.getBaseSchema();
+            Assert.assertEquals(2, columns.size());
+            Assert.assertEquals("c0", columns.get(0).getName());
+            Assert.assertEquals(0, columns.get(0).getUniqueId());
+            Assert.assertEquals("c1", columns.get(1).getName());
+            Assert.assertEquals(2, columns.get(1).getUniqueId());
+            Assert.assertTrue(table.getIndexIdToMeta().get(table.getBaseIndexId()).getSchemaId() > oldSchemaId);
+            Assert.assertEquals(OlapTable.OlapTableState.NORMAL, table.getState());
+        }
+    }
+
+    @Test
+    public void testGetInfo() throws Exception {
+        LakeTable table = createTable(connectContext, "CREATE TABLE t1(c0 INT) DUPLICATE KEY(c0) DISTRIBUTED BY HASH(c0) " +
+                "BUCKETS 2 PROPERTIES('fast_schema_evolution'='true')");
+        AlterJobV2 job = mustAlterTable(table, "ALTER TABLE t1 ADD COLUMN c1 BIGINT");
+        List<List<Comparable>> infoList = new ArrayList<>();
+        job.getInfo(infoList);
+        Assert.assertEquals(1, infoList.size());
+        List<Comparable> info = infoList.get(0);
+        Assert.assertEquals(13, info.size());
+        Assert.assertEquals(job.getJobId(), info.get(0));
+        Assert.assertEquals(table.getName(), info.get(1));
+        Assert.assertEquals(TimeUtils.longToTimeString(job.createTimeMs), info.get(2));
+        Assert.assertEquals(TimeUtils.longToTimeString(job.finishedTimeMs), info.get(3));
+        Assert.assertEquals(table.getIndexNameById(table.getBaseIndexId()), info.get(4));
+        Assert.assertEquals(table.getBaseIndexId(), info.get(5));
+        Assert.assertEquals(table.getBaseIndexId(), info.get(6));
+        Assert.assertEquals(String.format("%d:0", table.getIndexIdToMeta().get(table.getBaseIndexId()).getSchemaVersion()),
+                info.get(7));
+        Assert.assertEquals(job.getTransactionId().get(), info.get(8));
+        Assert.assertEquals(job.getJobState().name(), info.get(9));
+        Assert.assertEquals(job.errMsg, info.get(10));
+        Assert.assertEquals(job.getTimeoutMs() / 1000, info.get(12));
+    }
+
+    @Test
+    public void testTimeout() throws Exception {
+        LakeTable table = createTable(connectContext, "CREATE TABLE t2(c0 INT) DUPLICATE KEY(c0) DISTRIBUTED BY HASH(c0) " +
+                "BUCKETS 2 PROPERTIES('fast_schema_evolution'='true')");
+        int timeoutBackup = Config.max_create_table_timeout_second;
+        Config.max_create_table_timeout_second = 0;
+        alterTable(connectContext, "ALTER TABLE t2 ADD COLUMN c1 DOUBLE");
+        AlterJobV2 job = getAlterJob(table);
+        job.run();
+        Config.max_create_table_timeout_second = timeoutBackup;
+        Assert.assertEquals(AlterJobV2.JobState.CANCELLED, job.getJobState());
+        Assert.assertEquals(OlapTable.OlapTableState.NORMAL, table.getState());
+        Assert.assertEquals(1, table.getIndexIdToMeta().size());
+        Assert.assertEquals(1, table.getBaseSchema().size());
+    }
+
+    @Test
+    public void testReplay() throws Exception {
+        Database db = GlobalStateMgr.getCurrentState().getDb(DB_NAME);
+        LakeTable table = createTable(connectContext, "CREATE TABLE t3(c0 INT) DUPLICATE KEY(c0) DISTRIBUTED BY HASH(c0) " +
+                "BUCKETS 2 PROPERTIES('fast_schema_evolution'='true')");
+        SchemaChangeHandler handler = GlobalStateMgr.getCurrentState().getAlterJobMgr().getSchemaChangeHandler();
+        AlterTableStmt stmt = (AlterTableStmt) UtFrameUtils.parseStmtWithNewParser("ALTER TABLE t3 ADD COLUMN c1 INT",
+                connectContext);
+        LakeTableAsyncFastSchemaChangeJob job = (LakeTableAsyncFastSchemaChangeJob) handler.analyzeAndCreateJob(stmt.getOps(), db,
+                table);
+        Assert.assertNotNull(job);
+        Assert.assertEquals(AlterJobV2.JobState.PENDING, job.getJobState());
+        Assert.assertEquals(OlapTable.OlapTableState.NORMAL, table.getState());
+        Partition partition = table.getPartition("t3");
+        long baseIndexId = table.getBaseIndexId();
+        long initVisibleVersion = partition.getVisibleVersion();
+        long initNextVersion = partition.getNextVersion();
+        Assert.assertEquals(initVisibleVersion + 1, initNextVersion);
+
+        LakeTableAsyncFastSchemaChangeJob replaySourceJob = new LakeTableAsyncFastSchemaChangeJob(job);
+        Assert.assertEquals(AlterJobV2.JobState.PENDING, replaySourceJob.getJobState());
+        job.replay(replaySourceJob);
+        Assert.assertEquals(OlapTable.OlapTableState.SCHEMA_CHANGE, table.getState());
+
+        replaySourceJob.setJobState(AlterJobV2.JobState.FINISHED_REWRITING);
+        replaySourceJob.getCommitVersionMap().put(partition.getId(), initNextVersion);
+        replaySourceJob.addDirtyPartitionIndex(partition.getId(), baseIndexId, partition.getIndex(baseIndexId));
+        job.replay(replaySourceJob);
+        Assert.assertEquals(initNextVersion + 1, partition.getNextVersion());
+        Assert.assertEquals(initVisibleVersion, partition.getVisibleVersion());
+
+        replaySourceJob.setJobState(AlterJobV2.JobState.FINISHED);
+        replaySourceJob.setFinishedTimeMs(System.currentTimeMillis());
+        Assert.assertEquals(OlapTable.OlapTableState.SCHEMA_CHANGE, table.getState());
+        job.replay(replaySourceJob);
+        Assert.assertEquals(AlterJobV2.JobState.FINISHED, job.getJobState());
+        Assert.assertEquals(replaySourceJob.getFinishedTimeMs(), job.getFinishedTimeMs());
+        Assert.assertEquals(initVisibleVersion + 1, partition.getVisibleVersion());
+        Assert.assertEquals(partition.getVisibleVersion() + 1, partition.getNextVersion());
+        Assert.assertEquals(OlapTable.OlapTableState.NORMAL, table.getState());
+        Assert.assertEquals(2, table.getBaseSchema().size());
+        Assert.assertEquals(0, table.getBaseSchema().get(0).getUniqueId());
+        Assert.assertEquals("c0", table.getBaseSchema().get(0).getName());
+        Assert.assertEquals(1, table.getBaseSchema().get(1).getUniqueId());
+        Assert.assertEquals("c1", table.getBaseSchema().get(1).getName());
+    }
+}

--- a/fe/fe-core/src/test/java/com/starrocks/pseudocluster/PseudoBackend.java
+++ b/fe/fe-core/src/test/java/com/starrocks/pseudocluster/PseudoBackend.java
@@ -671,7 +671,7 @@ public class PseudoBackend {
                     String.format("alter (base:%d, new:%d version:%d) failed new tablet not found", task.base_tablet_id,
                             task.new_tablet_id, task.alter_version));
         }
-        if (newTablet.isRunning() == true) {
+        if (newTablet.isRunning()) {
             throw new Exception(
                     String.format("alter (base:%d, new:%d version:%d) failed new tablet is running", task.base_tablet_id,
                             task.new_tablet_id, task.alter_version));

--- a/gensrc/proto/lake_types.proto
+++ b/gensrc/proto/lake_types.proto
@@ -109,6 +109,7 @@ message TabletMetadataPB {
 message MetadataUpdateInfoPB {
     // enable persistent index in primary key table
     optional bool enable_persistent_index = 1;
+    optional TabletSchemaPB tablet_schema = 2;
 }
 
 message TxnLogPB {

--- a/gensrc/thrift/AgentService.thrift
+++ b/gensrc/thrift/AgentService.thrift
@@ -423,6 +423,9 @@ struct TTabletMetaInfo {
     6: optional bool enable_persistent_index
     7: optional TBinlogConfig binlog_config
     8: optional i32 primary_index_cache_expire_sec
+    9: optional TTabletSchema tablet_schema;
+    // |create_schema_file| only used when |tablet_schema| exists
+    10: optional bool create_schema_file;
 }
 
 struct TUpdateTabletMetaInfoReq {


### PR DESCRIPTION
This PR is part of the PR stack to support fast schema evolution in share data mode.

## Why I'm doing:
In the current implementation, adding or dropping a column requires a rewrite of all the data in the table. This can take a very long time when the table's dataset is very large, i.e. or, adding or dropping a column can take a very long time to take effect.

## What I'm doing:
Instead of rewriting all the data when adding or dropping a column, only the tablet schema and the table schema in FE are updated.


The overall workflow to add or drop a column is as follows:
1. Begin a new transaction
2. Send TUpdateTabletMetaInfoReq requests to all tablet in the table
3. Get the new tablet schema from the TUpdateTabletMetaInfoReq and writes it to the txn log for each tablet
4. Commit transaction
5. Send PublishVersionRequest requests to all tablets
6. Apply txn log on each tablet to create a new version of the tablet metadata with the new tablet schema.
7. Modify the table schema and visible version in the FE catalog
8. Finish the transaction

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
