### PR TITLE
[BugFix] Fix NullPointerException throwed by CompactionJob.buildTabletCommitInfo()

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/lake/compaction/CompactionJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/lake/compaction/CompactionJob.java
@@ -20,6 +20,7 @@ import com.starrocks.catalog.Table;
 import com.starrocks.transaction.TabletCommitInfo;
 import com.starrocks.transaction.VisibleStateWaiter;
 
+import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 import java.util.concurrent.TimeUnit;
@@ -35,7 +36,7 @@ public class CompactionJob {
     private volatile long commitTs;
     private volatile long finishTs;
     private VisibleStateWaiter visibleStateWaiter;
-    private List<CompactionTask> tasks;
+    private List<CompactionTask> tasks = Collections.emptyList();
 
     public CompactionJob(Database db, Table table, PhysicalPartition partition, long txnId) {
         this.db = Objects.requireNonNull(db, "db is null");

--- a/fe/fe-core/src/test/java/com/starrocks/lake/compaction/CompactionJobTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/lake/compaction/CompactionJobTest.java
@@ -1,0 +1,36 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.lake.compaction;
+
+import com.starrocks.catalog.Database;
+import com.starrocks.catalog.PhysicalPartition;
+import com.starrocks.catalog.PhysicalPartitionImpl;
+import com.starrocks.catalog.Table;
+import org.junit.Test;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+
+public class CompactionJobTest {
+    @Test
+    public void testBuildTabletCommitInfo() {
+        Database db = new Database();
+        Table table = new Table(Table.TableType.CLOUD_NATIVE);
+        PhysicalPartition partition = new PhysicalPartitionImpl(0, 1, 2, null);
+        CompactionJob job = new CompactionJob(db, table, partition, 10010);
+        assertDoesNotThrow(() -> {
+            job.buildTabletCommitInfo();
+        });
+    }
+}


### PR DESCRIPTION
## Why I'm doing
If `CompactionJob.setTasks()` has not been called before calling `CompactionJob.buildTabletCommitInfo()`, NullPointerException will be thrown.

## What I'm doing
Initializes `CompactionJob.tasks` to emptyList, instead of null, to avoid NullPointerException

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [x] 3.1
  - [ ] 3.0
  - [ ] 2.5
