### PR TITLE
[Doc] duplicate content for param max_partitions_in_one_batch for Chinese version

### DIFF
--- a/docs/zh/administration/management/FE_configuration.md
+++ b/docs/zh/administration/management/FE_configuration.md
@@ -1387,15 +1387,6 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - 描述：批量创建分区时，分区数目的最大值。
 - 引入版本：-
 
-##### max_partitions_in_one_batch
-
-- 默认值：4096
-- 类型：Long
-- 单位：-
-- 是否动态：是
-- 描述：批量创建分区时，分区数目的最大值。
-- 引入版本：-
-
 ##### max_running_rollup_job_num_per_table
 
 - 默认值：1


### PR DESCRIPTION
[Doc] duplicate content for param max_partitions_in_one_batch for Chinese version

## Why I'm doing:

duplicate content for param max_partitions_in_one_batch for Chinese version

## What I'm doing:

delete one of them

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [x] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [x] 3.1
  - [ ] 3.0
  - [ ] 2.5