### PR TITLE
[BugFix] Fix the has_output check bug of scan operator

### DIFF
--- a/be/src/exec/pipeline/scan/olap_scan_context.cpp
+++ b/be/src/exec/pipeline/scan/olap_scan_context.cpp
@@ -104,6 +104,8 @@ Status OlapScanContext::capture_tablet_rowsets(const std::vector<TInternalScanRa
 
 Status OlapScanContext::parse_conjuncts(RuntimeState* state, const std::vector<ExprContext*>& runtime_in_filters,
                                         RuntimeFilterProbeCollector* runtime_bloom_filters) {
+    TEST_ERROR_POINT("OlapScanContext::parse_conjuncts");
+
     const TOlapScanNode& thrift_olap_scan_node = _scan_node->thrift_olap_scan_node();
     const TupleDescriptor* tuple_desc = state->desc_tbl().get_tuple_descriptor(thrift_olap_scan_node.tuple_id);
 

--- a/be/src/exec/pipeline/scan/olap_scan_prepare_operator.cpp
+++ b/be/src/exec/pipeline/scan/olap_scan_prepare_operator.cpp
@@ -36,6 +36,8 @@ OlapScanPrepareOperator::~OlapScanPrepareOperator() {
 }
 
 Status OlapScanPrepareOperator::prepare(RuntimeState* state) {
+    TEST_SUCC_POINT("OlapScanPrepareOperator::prepare");
+
     RETURN_IF_ERROR(SourceOperator::prepare(state));
 
     RETURN_IF_ERROR(_ctx->prepare(state));
@@ -68,13 +70,23 @@ StatusOr<ChunkPtr> OlapScanPrepareOperator::pull_chunk(RuntimeState* state) {
     _morsel_queue->set_tablets(_ctx->tablets());
     _morsel_queue->set_tablet_rowsets(_ctx->tablet_rowsets());
 
-    _ctx->set_prepare_finished();
     if (!status.ok()) {
+        TEST_SYNC_POINT("OlapScnPrepareOperator::pull_chunk::before_set_finished");
+        // OlapScanOperator::has_output() will `use !_ctx->is_prepare_finished() || _ctx->is_finished()` to
+        // determine whether OlapScanOperator::pull_chunk() needs to be executed.
+        // When _ctx->parse_conjuncts returns EOF, if set_prepare_finished first, and then set_finished.
+        // Between calling set_finished, OlapScanOperator::has_output maybe return true,
+        // causing OlapScanOperator::pull_chunk to be executed, which is invalid, maybe cause crash.
+        // So we will set_finished first and set_prepare_finished()
         static_cast<void>(_ctx->set_finished());
+        TEST_SYNC_POINT("OlapScnPrepareOperator::pull_chunk::after_set_finished");
+        _ctx->set_prepare_finished();
+        TEST_SYNC_POINT("OlapScnPrepareOperator::pull_chunk::after_set_prepare_finished");
         return status;
+    } else {
+        _ctx->set_prepare_finished();
+        return nullptr;
     }
-
-    return nullptr;
 }
 
 /// OlapScanPrepareOperatorFactory

--- a/be/src/exec/pipeline/scan/scan_operator.cpp
+++ b/be/src/exec/pipeline/scan/scan_operator.cpp
@@ -584,6 +584,8 @@ ScanOperatorFactory::ScanOperatorFactory(int32_t id, ScanNode* scan_node)
           _scan_task_group(std::make_shared<workgroup::ScanTaskGroup>()) {}
 
 Status ScanOperatorFactory::prepare(RuntimeState* state) {
+    TEST_SUCC_POINT("ScanOperatorFactory::prepare");
+
     RETURN_IF_ERROR(OperatorFactory::prepare(state));
     RETURN_IF_ERROR(do_prepare(state));
 

--- a/be/src/testutil/sync_point.h
+++ b/be/src/testutil/sync_point.h
@@ -72,6 +72,7 @@ public:
 #define TEST_SYNC_POINT_CALLBACK(x, y)
 #define INIT_SYNC_POINT_SINGLETONS()
 #define TEST_ERROR_POINT(x)
+#define TEST_SUCC_POINT(x)
 #define TEST_ENABLE_ERROR_POINT(x, y)
 #define TEST_DISABLE_ERROR_POINT(x)
 #else
@@ -174,6 +175,12 @@ private:
         Status st;                                            \
         starrocks::SyncPoint::GetInstance()->Process(x, &st); \
         if (!st.ok()) return st;                              \
+    } while (0)
+#define TEST_SUCC_POINT(x)                                    \
+    do {                                                      \
+        Status st;                                            \
+        starrocks::SyncPoint::GetInstance()->Process(x, &st); \
+        if (st.ok()) return st;                               \
     } while (0)
 #define TEST_ENABLE_ERROR_POINT(x, y) \
     starrocks::SyncPoint::GetInstance()->SetCallBack(x, [&](void* arg) { *(Status*)arg = y; })

--- a/be/test/CMakeLists.txt
+++ b/be/test/CMakeLists.txt
@@ -58,6 +58,7 @@ set(EXEC_FILES
         ./exec/stream/stream_pipeline_test.cpp
         ./exec/tablet_info_test.cpp
         ./exec/agg_hash_map_test.cpp
+        ./exec/pipeline/olap_scan_operator_test.cpp
         ./exec/analytor_test.cpp
         ./exec/analytor_test.cpp
         ./exec/arrow_converter_test.cpp

--- a/be/test/exec/pipeline/olap_scan_operator_test.cpp
+++ b/be/test/exec/pipeline/olap_scan_operator_test.cpp
@@ -1,0 +1,114 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "exec/pipeline/scan/olap_scan_operator.h"
+
+#include "exec/olap_scan_node.h"
+#include "exec/pipeline/scan/olap_scan_prepare_operator.h"
+#include "gtest/gtest.h"
+#include "runtime/descriptors.h"
+
+namespace starrocks::pipeline {
+
+class OlapScanOperatorTest : public ::testing::Test {
+public:
+    void SetUp() override;
+
+protected:
+    ObjectPool _object_pool;
+    RuntimeState _runtime_state;
+    TDescriptorTable _thrift_tbl;
+    const int64_t _chunk_size = 4096;
+    DescriptorTbl* _tbl = nullptr;
+    TPlanNode _tnode;
+    ChunkBufferLimiterPtr _chunk_buffer_limiter;
+    QueryContext _query_ctx;
+};
+
+void OlapScanOperatorTest::SetUp() {
+    TTableDescriptor t_table_desc;
+    t_table_desc.id = 1;
+    t_table_desc.tableType = TTableType::OLAP_TABLE;
+    _thrift_tbl.tableDescriptors.emplace_back(t_table_desc);
+
+    TTupleDescriptor t_tuple_desc;
+    t_tuple_desc.id = 1;
+    t_tuple_desc.tableId = 1;
+    _thrift_tbl.tupleDescriptors.emplace_back(t_tuple_desc);
+
+    _tnode.row_tuples.emplace_back(1);
+    _tnode.nullable_tuples.emplace_back(false);
+
+    Status st = DescriptorTbl::create(&_runtime_state, &_object_pool, _thrift_tbl, &_tbl, _chunk_size);
+    ASSERT_TRUE(st.ok());
+
+    _runtime_state.set_desc_tbl(_tbl);
+    _chunk_buffer_limiter = std::make_unique<UnlimitedChunkBufferLimiter>();
+
+    _query_ctx.init_mem_tracker(-1, GlobalEnv::GetInstance()->process_mem_tracker());
+    _runtime_state.set_query_ctx(&_query_ctx);
+}
+
+TEST_F(OlapScanOperatorTest, test_finish_sequence) {
+    SyncPoint::GetInstance()->EnableProcessing();
+    SyncPoint::GetInstance()->SetCallBack("OlapScanPrepareOperator::prepare", [](void* arg) {});
+    SyncPoint::GetInstance()->SetCallBack("ScanOperatorFactory::prepare", [](void* arg) {});
+    SyncPoint::GetInstance()->SetCallBack("OlapScanContext::parse_conjuncts",
+                                          [](void* arg) { *(Status*)arg = Status::EndOfFile(""); });
+
+    Morsels morsels;
+    FixedMorselQueue morsel_queue(std::move(morsels));
+
+    OlapScanNode scan_node(&_object_pool, _tnode, *_tbl);
+    auto scan_ctx_factory =
+            std::make_shared<OlapScanContextFactory>(&scan_node, 1, false, false, std::move(_chunk_buffer_limiter));
+
+    // create operator factory
+    OlapScanPrepareOperatorFactory scan_prepare_operator_factory(1, 1, &scan_node, scan_ctx_factory);
+    Status st = scan_prepare_operator_factory.prepare(&_runtime_state);
+    ASSERT_TRUE(st.ok());
+
+    OlapScanOperatorFactory scan_operator_factory(1, &scan_node, scan_ctx_factory);
+    st = scan_operator_factory.prepare(&_runtime_state);
+    ASSERT_TRUE(st.ok());
+
+    // create operator
+    auto scan_prepare_operator = scan_prepare_operator_factory.create(1, 0);
+    ASSERT_TRUE(scan_prepare_operator != nullptr);
+    down_cast<OlapScanPrepareOperator*>(scan_prepare_operator.get())->add_morsel_queue(&morsel_queue);
+
+    auto scan_operator = scan_operator_factory.create(1, 0);
+    ASSERT_TRUE(scan_operator != nullptr);
+
+    // operator prepare
+    st = scan_prepare_operator->prepare(&_runtime_state);
+    ASSERT_TRUE(st.ok());
+
+    // pull chunk
+    SyncPoint::GetInstance()->SetCallBack("OlapScnPrepareOperator::pull_chunk::before_set_finished",
+                                          [&scan_operator](void* arg) { ASSERT_FALSE(scan_operator->has_output()); });
+    SyncPoint::GetInstance()->SetCallBack("OlapScnPrepareOperator::pull_chunk::after_set_finished",
+                                          [&scan_operator](void* arg) { ASSERT_FALSE(scan_operator->has_output()); });
+    SyncPoint::GetInstance()->SetCallBack("OlapScnPrepareOperator::pull_chunk::after_set_prepare_finished",
+                                          [&scan_operator](void* arg) { ASSERT_FALSE(scan_operator->has_output()); });
+
+    auto ret = scan_prepare_operator->pull_chunk(&_runtime_state);
+    ASSERT_TRUE(ret.status().is_end_of_file());
+
+    scan_node.close(&_runtime_state);
+
+    SyncPoint::GetInstance()->DisableProcessing();
+}
+
+} // namespace starrocks::pipeline


### PR DESCRIPTION
## Why I'm doing:

What we expect is that `ScanOperator::pull_chunk` can be executed only after `ScanPrepareOperator::pull_chunk` is executed finished and return success. 

If `ScanPrepareOperator::pull_chunk` returns EOF, `ScanOperator::pull_chunk` should not be executed. 

But when in function `OlapScanPrepareOperator::pull_chunk`, if `_ctx->set_prepare_finished `is executed finished and before _ctx->set_finished() is executed, 

```
bool OlapScanOperator::has_output() const {
    if (!_ctx->is_prepare_finished() || _ctx->is_finished()) {
        return false;
    }

    return ScanOperator::has_output();
} 
```

will return true, causing `OlapScanOperator::pull_chunk` will be executed, causing some unexpected crashes. 

There are dependencies between operators. The current scheduling does not consider this dependency, which is not a good design. 

But the current fix does not change the implementation of this pipeline engine.

```
#7  0x0000000004712288 in starrocks::BinaryDictPageDecoder<(starrocks::FieldType)17>::next_batch (this=this@entry=0x7f97c0803f60, range=..., dst=dst@entry=0x7f97c08ed610) at /build/starrocks/be/src/storage/rowset/binary_dict_page.cpp:257
#8  0x00000000047125c8 in starrocks::BinaryDictPageDecoder<(starrocks::FieldType)17>::next_batch (this=0x7f97c0803f60, n=0x7f943db22210, dst=0x7f97c08ed610) at /build/starrocks/be/src/storage/rowset/binary_dict_page.cpp:219
#9  0x000000000472fd2b in starrocks::ParsedPageV2::read (this=0x7f97b22954c0, column=0x7f97c08ed610, count=0x7f943db22210) at /build/starrocks/be/src/storage/rowset/parsed_page.cpp:217
#10 0x0000000004702862 in operator() (count=0x7f943db22210, column=0x7f97c08ed610, __closure=<synthetic pointer>) at /build/starrocks/be/src/storage/rowset/scalar_column_iterator.cpp:495
#11 starrocks::ScalarColumnIterator::_fetch_by_rowid<starrocks::ScalarColumnIterator::fetch_values_by_rowid(const rowid_t*, size_t, starrocks::vectorized::Column*)::<lambda(starrocks::vectorized::Column*, size_t*)>&> (page_parse=<synthetic pointer>..., 
    values=0x7f97c08ed610, size=<optimized out>, rowids=<optimized out>, this=0x7f923b4ba300) at /build/starrocks/be/src/storage/rowset/scalar_column_iterator.cpp:482
#12 starrocks::ScalarColumnIterator::fetch_values_by_rowid (this=0x7f923b4ba300, rowids=<optimized out>, size=<optimized out>, values=0x7f97c08ed610) at /build/starrocks/be/src/storage/rowset/scalar_column_iterator.cpp:496
#13 0x00000000046b4492 in starrocks::ColumnIterator::fetch_values_by_rowid (this=0x7f923b4ba300, rowids=..., values=0x7f97c08ed610) at /build/starrocks/be/src/storage/rowset/column_iterator.cpp:45
#14 0x00000000042d5eff in starrocks::ColumnDecoder::decode_values_by_rowid (values=<optimized out>, rowids=..., this=<optimized out>) at /build/starrocks/be/src/storage/rowset/column_decoder.h:28
#15 starrocks::vectorized::SegmentIterator::_finish_late_materialization (this=0x7f92cfdfac10, ctx=0x7f92cfdfb060) at /build/starrocks/be/src/storage/rowset/segment_iterator.cpp:1435
#16 0x00000000042dedd0 in starrocks::vectorized::SegmentIterator::_do_get_next (this=0x7f92cfdfac10, result=0x7f8b213c8ef0, rowid=0x0) at /build/starrocks/be/src/storage/rowset/segment_iterator.cpp:932
#17 0x00000000042e18b0 in starrocks::vectorized::SegmentIterator::do_get_next (this=0x7f92cfdfac10, chunk=0x7f8b213c8ef0) at /build/starrocks/be/src/storage/rowset/segment_iterator.cpp:811
#18 0x00000000043661f2 in starrocks::vectorized::ChunkIterator::get_next (chunk=<optimized out>, this=<optimized out>) at /build/starrocks/be/src/storage/chunk_iterator.h:40
#19 starrocks::vectorized::ProjectionIterator::do_get_next (this=0x7f9354333810, chunk=0x7f8b213c9960) at /build/starrocks/be/src/storage/projection_iterator.cpp:69
#20 0x0000000004916db5 in starrocks::vectorized::ChunkIterator::get_next (chunk=<optimized out>, this=<optimized out>) at /build/starrocks/be/src/storage/chunk_iterator.h:40
#21 starrocks::SegmentIteratorWrapper::do_get_next (this=<optimized out>, chunk=<optimized out>) at /build/starrocks/be/src/storage/rowset/rowset.cpp:337
#22 0x00000000047461a3 in starrocks::vectorized::ChunkIterator::get_next (chunk=0x7f8b213c9960, this=0x7f9354333990) at /build/starrocks/be/src/storage/chunk_iterator.h:40
#23 starrocks::vectorized::TimedChunkIterator::do_get_next (this=0x7f9354345390, chunk=0x7f8b213c9960) at /build/starrocks/be/src/storage/chunk_iterator.cpp:37
#24 0x0000000004397656 in starrocks::vectorized::ChunkIterator::get_next (chunk=0x7f8b213c9960, this=<optimized out>) at /build/starrocks/be/src/storage/chunk_iterator.h:40
#25 starrocks::vectorized::TabletReader::do_get_next (this=0x7f7999190c10, chunk=0x7f8b213c9960) at /build/starrocks/be/src/storage/tablet_reader.cpp:219
#26 0x00000000030342fb in starrocks::vectorized::ChunkIterator::get_next (chunk=0x7f8b213c9960, this=<optimized out>) at /build/starrocks/be/src/storage/chunk_iterator.h:40
#27 starrocks::pipeline::OlapChunkSource::_read_chunk_from_storage (this=0x7f91121a3710, state=<optimized out>, chunk=0x7f8b213c9960) at /build/starrocks/be/src/exec/pipeline/scan/olap_chunk_source.cpp:332
#28 0x00000000030349db in starrocks::pipeline::OlapChunkSource::_read_chunk (this=0x7f91121a3710, state=<optimized out>, chunk=0x7f943db228c0) at /build/starrocks/be/src/exec/pipeline/scan/olap_chunk_source.cpp:293
#29 0x00000000030242af in starrocks::pipeline::ChunkSource::buffer_next_batch_chunks_blocking (this=0x7f91121a3710, state=0x7f91f81f0500, batch_size=batch_size@entry=64, running_wg=0x7f97df8b8d50) at /build/starrocks/be/src/exec/pipeline/scan/chunk_source.cpp:57
#30 0x0000000002d9e9a4 in operator() (__closure=0x7f92cfda96c0) at /build/starrocks/be/src/exec/pipeline/scan/scan_operator.cpp:374
#31 0x0000000002dafdce in std::function<void ()>::operator()() const (this=0x7f943db22cf0) at /opt/gcc/usr/include/c++/10.3.0/bits/std_function.h:622
#32 starrocks::workgroup::ScanExecutor::worker_thread (this=0x7f97df7c5220) at /build/starrocks/be/src/exec/workgroup/scan_executor.cpp:58
#33 0x0000000004b17352 in std::function<void ()>::operator()() const (this=0x7f94b2871e98) at /opt/gcc/usr/include/c++/10.3.0/bits/std_function.h:622
#34 starrocks::FunctionRunnable::run (this=0x7f94b2871e90) at /build/starrocks/be/src/util/threadpool.cpp:44
#35 starrocks::ThreadPool::dispatch_thread (this=0x7f97df8b90c0) at /build/starrocks/be/src/util/threadpool.cpp:539
#36 0x0000000004b11e4a in std::function<void ()>::operator()() const (this=0x7f94b287b418) at /opt/gcc/usr/include/c++/10.3.0/bits/std_function.h:622
#37 starrocks::Thread::supervise_thread (arg=0x7f94b287b400) at /build/starrocks/be/src/util/thread.cpp:351
#38 0x00007f97e346e17a in start_thread () from /home/disk6/lxh/core/lib64/[libpthread-2.28.so](http://libpthread-2.28.so/)
#39 0x00007f97e2a0fdf3 in clone () from /home/disk6/lxh/core/lib64/[libc-2.28.so](http://libc-2.28.so/)
```

## What I'm doing:

If prepare return eof, we will first `set_finished` and then `set_prepare_finished`.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [x] 3.1
  - [x] 3.0
  - [x] 2.5
