### PR TITLE
[Enhancement] tablet sink support add chunk large than 2GB

### DIFF
--- a/be/src/exec/tablet_sink_index_channel.cpp
+++ b/be/src/exec/tablet_sink_index_channel.cpp
@@ -18,6 +18,8 @@
 #include "column/column_viewer.h"
 #include "column/nullable_column.h"
 #include "common/statusor.h"
+#include "common/utils.h"
+#include "config.h"
 #include "exec/tablet_sink.h"
 #include "exprs/expr_context.h"
 #include "gutil/strings/fastmem.h"
@@ -543,6 +545,16 @@ Status NodeChannel::_filter_indexes_with_where_expr(Chunk* input, const std::vec
     return Status::OK();
 }
 
+template <typename T>
+void serialize_to_iobuf(const T& proto_obj, butil::IOBuf* iobuf) {
+    butil::IOBuf tmp_iobuf;
+    butil::IOBufAsZeroCopyOutputStream wrapper(&tmp_iobuf);
+    proto_obj.SerializeToZeroCopyStream(&wrapper);
+    size_t request_size = tmp_iobuf.size();
+    iobuf->append(&request_size, sizeof(request_size));
+    iobuf->append(tmp_iobuf);
+}
+
 Status NodeChannel::_send_request(bool eos, bool finished) {
     if (eos || finished) {
         if (_request_queue.empty()) {
@@ -626,9 +638,11 @@ Status NodeChannel::_send_request(bool eos, bool finished) {
             if (!res.ok()) {
                 return res.status();
             }
-            res.value()->tablet_writer_add_chunks(&_add_batch_closures[_current_request_index]->cntl, &request,
-                                                  &_add_batch_closures[_current_request_index]->result,
-                                                  _add_batch_closures[_current_request_index]);
+            serialize_to_iobuf<PTabletWriterAddChunksRequest>(
+                    request, &_add_batch_closures[_current_request_index]->cntl.request_attachment());
+            res.value()->tablet_writer_add_chunks_via_http(&_add_batch_closures[_current_request_index]->cntl, nullptr,
+                                                           &_add_batch_closures[_current_request_index]->result,
+                                                           _add_batch_closures[_current_request_index]);
             VLOG(2) << "NodeChannel::_send_request() issue a http rpc, request size = " << request.ByteSizeLong();
         } else {
             _stub->tablet_writer_add_chunks(&_add_batch_closures[_current_request_index]->cntl, &request,
@@ -646,9 +660,11 @@ Status NodeChannel::_send_request(bool eos, bool finished) {
             if (!res.ok()) {
                 return res.status();
             }
-            res.value()->tablet_writer_add_chunk(
-                    &_add_batch_closures[_current_request_index]->cntl, request.mutable_requests(0),
-                    &_add_batch_closures[_current_request_index]->result, _add_batch_closures[_current_request_index]);
+            serialize_to_iobuf<PTabletWriterAddChunkRequest>(
+                    request.requests(0), &_add_batch_closures[_current_request_index]->cntl.request_attachment());
+            res.value()->tablet_writer_add_chunk_via_http(&_add_batch_closures[_current_request_index]->cntl, nullptr,
+                                                          &_add_batch_closures[_current_request_index]->result,
+                                                          _add_batch_closures[_current_request_index]);
             VLOG(2) << "NodeChannel::_send_request() issue a http rpc, request size = " << request.ByteSizeLong();
         } else {
             _stub->tablet_writer_add_chunk(

--- a/be/src/exec/tablet_sink_index_channel.cpp
+++ b/be/src/exec/tablet_sink_index_channel.cpp
@@ -638,11 +638,9 @@ Status NodeChannel::_send_request(bool eos, bool finished) {
             if (!res.ok()) {
                 return res.status();
             }
-            serialize_to_iobuf<PTabletWriterAddChunksRequest>(
-                    request, &_add_batch_closures[_current_request_index]->cntl.request_attachment());
-            res.value()->tablet_writer_add_chunks_via_http(&_add_batch_closures[_current_request_index]->cntl, nullptr,
-                                                           &_add_batch_closures[_current_request_index]->result,
-                                                           _add_batch_closures[_current_request_index]);
+            auto closure = _add_batch_closures[_current_request_index];
+            serialize_to_iobuf<PTabletWriterAddChunksRequest>(request, &closure->cntl.request_attachment());
+            res.value()->tablet_writer_add_chunks_via_http(&closure->cntl, nullptr, &closure->result, closure);
             VLOG(2) << "NodeChannel::_send_request() issue a http rpc, request size = " << request.ByteSizeLong();
         } else {
             _stub->tablet_writer_add_chunks(&_add_batch_closures[_current_request_index]->cntl, &request,
@@ -660,11 +658,9 @@ Status NodeChannel::_send_request(bool eos, bool finished) {
             if (!res.ok()) {
                 return res.status();
             }
-            serialize_to_iobuf<PTabletWriterAddChunkRequest>(
-                    request.requests(0), &_add_batch_closures[_current_request_index]->cntl.request_attachment());
-            res.value()->tablet_writer_add_chunk_via_http(&_add_batch_closures[_current_request_index]->cntl, nullptr,
-                                                          &_add_batch_closures[_current_request_index]->result,
-                                                          _add_batch_closures[_current_request_index]);
+            auto closure = _add_batch_closures[_current_request_index];
+            serialize_to_iobuf<PTabletWriterAddChunkRequest>(request.requests(0), &closure->cntl.request_attachment());
+            res.value()->tablet_writer_add_chunk_via_http(&closure->cntl, nullptr, &closure->result, closure);
             VLOG(2) << "NodeChannel::_send_request() issue a http rpc, request size = " << request.ByteSizeLong();
         } else {
             _stub->tablet_writer_add_chunk(

--- a/be/src/exec/tablet_sink_index_channel.h
+++ b/be/src/exec/tablet_sink_index_channel.h
@@ -48,6 +48,9 @@ namespace stream_load {
 class OlapTableSink;    // forward declaration
 class TabletSinkSender; // forward declaration
 
+template <typename T>
+void serialize_to_iobuf(const T& proto_obj, butil::IOBuf* iobuf);
+
 // The counter of add_batch rpc of a single node
 struct AddBatchCounter {
     // total execution time of a add_batch rpc

--- a/be/src/service/internal_service.cpp
+++ b/be/src/service/internal_service.cpp
@@ -381,6 +381,24 @@ void PInternalServiceImplBase<T>::tablet_writer_add_chunks(google::protobuf::Rpc
 }
 
 template <typename T>
+void PInternalServiceImplBase<T>::tablet_writer_add_chunk_via_http(google::protobuf::RpcController* controller,
+                                                                   const PHttpRequest* request,
+                                                                   PTabletWriterAddBatchResult* response,
+                                                                   google::protobuf::Closure* done) {
+    ClosureGuard closure_guard(done);
+    response->mutable_status()->set_status_code(TStatusCode::NOT_IMPLEMENTED_ERROR);
+}
+
+template <typename T>
+void PInternalServiceImplBase<T>::tablet_writer_add_chunks_via_http(google::protobuf::RpcController* controller,
+                                                                    const PHttpRequest* request,
+                                                                    PTabletWriterAddBatchResult* response,
+                                                                    google::protobuf::Closure* done) {
+    ClosureGuard closure_guard(done);
+    response->mutable_status()->set_status_code(TStatusCode::NOT_IMPLEMENTED_ERROR);
+}
+
+template <typename T>
 void PInternalServiceImplBase<T>::tablet_writer_add_segment(google::protobuf::RpcController* controller,
                                                             const PTabletWriterAddSegmentRequest* request,
                                                             PTabletWriterAddSegmentResult* response,

--- a/be/src/service/internal_service.h
+++ b/be/src/service/internal_service.h
@@ -105,6 +105,16 @@ public:
                                   const PTabletWriterAddChunksRequest* request, PTabletWriterAddBatchResult* response,
                                   google::protobuf::Closure* done) override;
 
+    void tablet_writer_add_chunk_via_http(google::protobuf::RpcController* controller,
+                                          const ::starrocks::PHttpRequest* request,
+                                          PTabletWriterAddBatchResult* response,
+                                          google::protobuf::Closure* done) override;
+
+    void tablet_writer_add_chunks_via_http(google::protobuf::RpcController* controller,
+                                           const ::starrocks::PHttpRequest* request,
+                                           PTabletWriterAddBatchResult* response,
+                                           google::protobuf::Closure* done) override;
+
     void tablet_writer_add_segment(google::protobuf::RpcController* controller,
                                    const PTabletWriterAddSegmentRequest* request,
                                    PTabletWriterAddSegmentResult* response, google::protobuf::Closure* done) override;

--- a/be/src/service/service_be/internal_service.cpp
+++ b/be/src/service/service_be/internal_service.cpp
@@ -36,6 +36,7 @@
 
 #include "common/closure_guard.h"
 #include "common/config.h"
+#include "common/utils.h"
 #include "exec/pipeline/fragment_context.h"
 #include "gen_cpp/BackendService.h"
 #include "gutil/strings/substitute.h"
@@ -93,6 +94,59 @@ void BackendInternalServiceImpl<T>::tablet_writer_add_chunks(google::protobuf::R
                                                              google::protobuf::Closure* done) {
     ClosureGuard closure_guard(done);
     PInternalServiceImplBase<T>::_exec_env->load_channel_mgr()->add_chunks(*request, response);
+}
+
+template <typename T>
+static bool parse_from_iobuf(butil::IOBuf& iobuf, T* proto_obj) {
+    // deserialize
+    size_t request_size = 0;
+    if (!iobuf.cutn(&request_size, sizeof(request_size))) {
+        LOG(ERROR) << "Failed to read request size";
+        return false;
+    }
+    butil::IOBuf request_from;
+    if (!iobuf.cutn(&request_from, request_size)) {
+        LOG(ERROR) << "Failed to cut the required size from the io buffer";
+        return false;
+    }
+    butil::IOBufAsZeroCopyInputStream wrapper(request_from);
+    if (!proto_obj->ParseFromZeroCopyStream(&wrapper)) {
+        LOG(ERROR) << "Failed to parse the request";
+        return false;
+    }
+    return true;
+}
+
+template <typename T>
+void BackendInternalServiceImpl<T>::tablet_writer_add_chunk_via_http(google::protobuf::RpcController* controller,
+                                                                     const PHttpRequest* request,
+                                                                     PTabletWriterAddBatchResult* response,
+                                                                     google::protobuf::Closure* done) {
+    ClosureGuard closure_guard(done);
+    auto add_chunk_req = std::make_shared<PTabletWriterAddChunkRequest>();
+    auto* cntl = static_cast<brpc::Controller*>(controller);
+    if (!parse_from_iobuf<PTabletWriterAddChunkRequest>(cntl->request_attachment(), add_chunk_req.get())) {
+        LOG(ERROR) << "parse from iobuf failed";
+        response->mutable_status()->set_status_code(TStatusCode::INTERNAL_ERROR);
+        return;
+    }
+    PInternalServiceImplBase<T>::_exec_env->load_channel_mgr()->add_chunk(*add_chunk_req, response);
+}
+
+template <typename T>
+void BackendInternalServiceImpl<T>::tablet_writer_add_chunks_via_http(google::protobuf::RpcController* controller,
+                                                                      const PHttpRequest* request,
+                                                                      PTabletWriterAddBatchResult* response,
+                                                                      google::protobuf::Closure* done) {
+    ClosureGuard closure_guard(done);
+    auto add_chunk_req = std::make_shared<PTabletWriterAddChunksRequest>();
+    auto* cntl = static_cast<brpc::Controller*>(controller);
+    if (!parse_from_iobuf<PTabletWriterAddChunksRequest>(cntl->request_attachment(), add_chunk_req.get())) {
+        LOG(ERROR) << "parse from iobuf failed";
+        response->mutable_status()->set_status_code(TStatusCode::INTERNAL_ERROR);
+        return;
+    }
+    PInternalServiceImplBase<T>::_exec_env->load_channel_mgr()->add_chunks(*add_chunk_req, response);
 }
 
 template <typename T>

--- a/be/src/service/service_be/internal_service.h
+++ b/be/src/service/service_be/internal_service.h
@@ -67,6 +67,14 @@ public:
                                   const PTabletWriterAddChunksRequest* request, PTabletWriterAddBatchResult* response,
                                   google::protobuf::Closure* done) override;
 
+    void tablet_writer_add_chunk_via_http(google::protobuf::RpcController* controller, const PHttpRequest* request,
+                                          PTabletWriterAddBatchResult* response,
+                                          google::protobuf::Closure* done) override;
+
+    void tablet_writer_add_chunks_via_http(google::protobuf::RpcController* controller, const PHttpRequest* request,
+                                           PTabletWriterAddBatchResult* response,
+                                           google::protobuf::Closure* done) override;
+
     void tablet_writer_add_segment(google::protobuf::RpcController* controller,
                                    const PTabletWriterAddSegmentRequest* request,
                                    PTabletWriterAddSegmentResult* response, google::protobuf::Closure* done) override;

--- a/be/test/service/service_be/internal_service_test.cpp
+++ b/be/test/service/service_be/internal_service_test.cpp
@@ -14,8 +14,11 @@
 
 #include "service/service_be/internal_service.h"
 
+#include <brpc/controller.h>
 #include <gtest/gtest.h>
 
+#include "common/utils.h"
+#include "exec/tablet_sink_index_channel.h"
 #include "runtime/exec_env.h"
 
 namespace starrocks {
@@ -29,6 +32,120 @@ TEST_F(InternalServiceTest, test_get_info_timeout_invalid) {
     service._get_info_impl(&request, &response, nullptr, -10);
     auto st = Status(response.status());
     ASSERT_TRUE(st.is_time_out());
+}
+
+class MockClosure : public ::google::protobuf::Closure {
+public:
+    MockClosure() = default;
+    ~MockClosure() override = default;
+
+    void Run() override { _run.store(true); }
+
+    bool has_run() { return _run.load(); }
+
+private:
+    std::atomic_bool _run = false;
+};
+
+TEST_F(InternalServiceTest, test_tablet_writer_add_chunks_via_http) {
+    BackendInternalServiceImpl<PInternalService> service(ExecEnv::GetInstance());
+    {
+        PHttpRequest request;
+        PTabletWriterAddBatchResult response;
+        brpc::Controller cntl;
+        MockClosure closure;
+        service.tablet_writer_add_chunks_via_http(&cntl, &request, &response, &closure);
+        auto st = Status(response.status());
+        ASSERT_FALSE(st.ok());
+    }
+    {
+        brpc::Controller cntl;
+        PTabletWriterAddChunksRequest req;
+        auto* r = req.add_requests();
+        r->set_txn_id(1000);
+        r->set_index_id(2000);
+        r->set_sender_id(3000);
+        stream_load::serialize_to_iobuf<PTabletWriterAddChunksRequest>(req, &cntl.request_attachment());
+        PHttpRequest request;
+        PTabletWriterAddBatchResult response;
+        MockClosure closure;
+        service.tablet_writer_add_chunks_via_http(&cntl, &request, &response, &closure);
+        auto st = Status(response.status());
+        ASSERT_FALSE(st.ok());
+        ASSERT_TRUE(response.status().error_msgs().at(0).find("no associated load channel") != std::string::npos);
+    }
+    {
+        PHttpRequest request;
+        PTabletWriterAddBatchResult response;
+        brpc::Controller cntl;
+        MockClosure closure;
+        service.PInternalServiceImplBase::tablet_writer_add_chunks_via_http(&cntl, &request, &response, &closure);
+        auto st = Status(response.status());
+        ASSERT_TRUE(st.is_not_supported());
+    }
+}
+
+TEST_F(InternalServiceTest, test_tablet_writer_add_chunk_via_http) {
+    BackendInternalServiceImpl<PInternalService> service(ExecEnv::GetInstance());
+    {
+        PHttpRequest request;
+        PTabletWriterAddBatchResult response;
+        brpc::Controller cntl;
+        MockClosure closure;
+        service.tablet_writer_add_chunk_via_http(&cntl, &request, &response, &closure);
+        auto st = Status(response.status());
+        ASSERT_FALSE(st.ok());
+    }
+    {
+        PHttpRequest request;
+        PTabletWriterAddBatchResult response;
+        brpc::Controller cntl;
+        size_t request_size = 123; // fake
+        cntl.request_attachment().append(&request_size, sizeof(request_size));
+        MockClosure closure;
+        service.tablet_writer_add_chunk_via_http(&cntl, &request, &response, &closure);
+        auto st = Status(response.status());
+        ASSERT_FALSE(st.ok());
+    }
+    {
+        brpc::Controller cntl;
+        PTabletWriterAddChunksRequest req;
+        auto* r = req.add_requests();
+        r->set_txn_id(1000);
+        r->set_index_id(2000);
+        r->set_sender_id(3000);
+        stream_load::serialize_to_iobuf<PTabletWriterAddChunksRequest>(req, &cntl.request_attachment());
+        PHttpRequest request;
+        PTabletWriterAddBatchResult response;
+        MockClosure closure;
+        service.tablet_writer_add_chunk_via_http(&cntl, &request, &response, &closure);
+        auto st = Status(response.status());
+        ASSERT_FALSE(st.ok());
+    }
+    {
+        brpc::Controller cntl;
+        PTabletWriterAddChunkRequest req;
+        req.set_txn_id(1000);
+        req.set_index_id(2000);
+        req.set_sender_id(3000);
+        stream_load::serialize_to_iobuf<PTabletWriterAddChunkRequest>(req, &cntl.request_attachment());
+        PHttpRequest request;
+        PTabletWriterAddBatchResult response;
+        MockClosure closure;
+        service.tablet_writer_add_chunk_via_http(&cntl, &request, &response, &closure);
+        auto st = Status(response.status());
+        ASSERT_FALSE(st.ok());
+        ASSERT_TRUE(response.status().error_msgs().at(0).find("no associated load channel") != std::string::npos);
+    }
+    {
+        PHttpRequest request;
+        PTabletWriterAddBatchResult response;
+        brpc::Controller cntl;
+        MockClosure closure;
+        service.PInternalServiceImplBase::tablet_writer_add_chunk_via_http(&cntl, &request, &response, &closure);
+        auto st = Status(response.status());
+        ASSERT_TRUE(st.is_not_supported());
+    }
 }
 
 } // namespace starrocks

--- a/gensrc/proto/doris_internal_service.proto
+++ b/gensrc/proto/doris_internal_service.proto
@@ -64,6 +64,8 @@ service PBackendService {
     rpc transmit_chunk_via_http(starrocks.PHttpRequest) returns (starrocks.PTransmitChunkResult);
     rpc tablet_writer_add_chunk(starrocks.PTabletWriterAddChunkRequest) returns (starrocks.PTabletWriterAddBatchResult);
     rpc tablet_writer_add_chunks(starrocks.PTabletWriterAddChunksRequest) returns (starrocks.PTabletWriterAddBatchResult);
+    rpc tablet_writer_add_chunk_via_http(starrocks.PHttpRequest) returns (starrocks.PTabletWriterAddBatchResult);
+    rpc tablet_writer_add_chunks_via_http(starrocks.PHttpRequest) returns (starrocks.PTabletWriterAddBatchResult);
     rpc tablet_writer_add_segment(starrocks.PTabletWriterAddSegmentRequest) returns (starrocks.PTabletWriterAddSegmentResult);
     rpc transmit_runtime_filter(starrocks.PTransmitRuntimeFilterParams) returns (starrocks.PTransmitRuntimeFilterResult);
 

--- a/gensrc/proto/internal_service.proto
+++ b/gensrc/proto/internal_service.proto
@@ -652,6 +652,8 @@ service PInternalService {
     rpc transmit_chunk_via_http(PHttpRequest) returns (PTransmitChunkResult);
     rpc tablet_writer_add_chunk(starrocks.PTabletWriterAddChunkRequest) returns (starrocks.PTabletWriterAddBatchResult);
     rpc tablet_writer_add_chunks(starrocks.PTabletWriterAddChunksRequest) returns (starrocks.PTabletWriterAddBatchResult);
+    rpc tablet_writer_add_chunk_via_http(PHttpRequest) returns (starrocks.PTabletWriterAddBatchResult);
+    rpc tablet_writer_add_chunks_via_http(PHttpRequest) returns (starrocks.PTabletWriterAddBatchResult);
     rpc tablet_writer_add_segment(starrocks.PTabletWriterAddSegmentRequest) returns (starrocks.PTabletWriterAddSegmentResult);
     rpc transmit_runtime_filter(PTransmitRuntimeFilterParams) returns (PTransmitRuntimeFilterResult);
 


### PR DESCRIPTION
## Why I'm doing:
In data ingestion, we transfer chunk data between BEs via the rpc `tablet_writer_add_chunk` and `tablet_writer_add_chunks`. And when chunk size large than 2GB, serialization of`PTabletWriterAddChunksRequest` and`PTabletWriterAddChunkRequest` will fail because of protobuf limitation. Error message like this:

```
google/protobuf/message_lite.cc:410 starrocks.PTabletWriterAddChunkRequest exceeded maximum protobuf size of 2GB: 2324260102
```

## What I'm doing:
When chunk size large than 2GB (can be modified by the session variable `rpc_http_min_size`), we will use brpc attachment to bypass protobuf serialization.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [x] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
