### PR TITLE
[Enhancement] Add COREDUMP_COLLECT_MINIMAL_INTERVAL to throttle the core dump collection of too frequent crash

### DIFF
--- a/docker/dockerfiles/be/upload_coredump.sh
+++ b/docker/dockerfiles/be/upload_coredump.sh
@@ -12,7 +12,7 @@ TB_IN_BYTES=$((1024 * 1024 * 1024 * 1024))
 COREDUMP_PATH=${COREDUMP_PATH:-$STARROCKS_HOME/storage/coredumps}
 
 # Default minimal interval in 600 seconds
-COREDUMP_COLLECT_MINIMAL_INTERVAL=${COREDUMP_COLLECT_MINIMAL_INTERVAL:-600}
+COREDUMP_COLLECT_MINIMUM_INTERVAL=${COREDUMP_COLLECT_MINIMUM_INTERVAL:-600}
 
 
 if [ ! -d ${COREDUMP_PATH} ]; then
@@ -63,8 +63,8 @@ while true; do
   currentFileTimestamp=$(stat -c %Y "${latestCoreFile}")
   timeDifference=$((currentFileTimestamp - previousFileTimestamp))
 
-  if (( timeDifference < $COREDUMP_COLLECT_MINIMAL_INTERVAL )); then
-    coredump_log "File was created less than ${COREDUMP_COLLECT_MINIMAL_INTERVAL} seconds after the previous crash, removing file and continuing loop"
+  if (( timeDifference < $COREDUMP_COLLECT_MINIMUM_INTERVAL )); then
+    coredump_log "File was created less than ${COREDUMP_COLLECT_MINIMUM_INTERVAL} seconds after the previous crash, removing file and continuing loop"
     rm "${latestCoreFile}"
     continue
   fi

--- a/docker/dockerfiles/be/upload_coredump.sh
+++ b/docker/dockerfiles/be/upload_coredump.sh
@@ -11,11 +11,22 @@ TB_IN_BYTES=$((1024 * 1024 * 1024 * 1024))
 # Set COREDUMP_PATH if hasn't been set in environment variable
 COREDUMP_PATH=${COREDUMP_PATH:-$STARROCKS_HOME/storage/coredumps}
 
+# Default minimal interval in 600 seconds
+COREDUMP_COLLECT_MINIMAL_INTERVAL=${COREDUMP_COLLECT_MINIMAL_INTERVAL:-600}
+
+
 if [ ! -d ${COREDUMP_PATH} ]; then
     mkdir -p ${COREDUMP_PATH}
 fi
 
+# log all the core dump setup
+COREDUMP_VARIABLES=$(declare -p |awk '$3 ~ /^COREDUMP_/ {print $3}')
+coredump_log $COREDUMP_VARIABLES
+
+
 cd $COREDUMP_PATH
+
+previousFileTimestamp=0
 
 while true; do
 
@@ -48,6 +59,17 @@ while true; do
       continue
   fi
 
+  # Check if the creation time of the file is more than 10 minutes later than the file handles in the previous loop iteration
+  currentFileTimestamp=$(stat -c %Y "${latestCoreFile}")
+  timeDifference=$((currentFileTimestamp - previousFileTimestamp))
+
+  if (( timeDifference < $COREDUMP_COLLECT_MINIMAL_INTERVAL )); then
+    coredump_log "File was created less than ${COREDUMP_COLLECT_MINIMAL_INTERVAL} seconds after the previous crash, removing file and continuing loop"
+    rm "${latestCoreFile}"
+    continue
+  fi
+
+  previousFileTimestamp=$currentFileTimestamp
 
   DATESTR=`date +"%m-%d-%y.%H-%M-%S.%Z"`
   COREDUMP_FILE_ZIP=${KUBE_CLUSTER_NAME}.${POD_NAMESPACE}.${POD_NAME}.${SR_IMAGE_TAG}.${DATESTR}.gz
@@ -65,7 +87,8 @@ while true; do
 
   coredump_log "Upload complete: ${latestCoreFile}"
 
-  # Only clean the uploaded core dump file
-  rm $latestCoreFile $COREDUMP_FILE_ZIP
+  # Only clean the core dump files
+  # Note: it's intentially avoid using * for all files to minimize the accidentialy deletion of other useful files
+  rm $COREDUMP_PATH/core.* &&  rm $COREDUMP_PATH/*.gz
 
 done


### PR DESCRIPTION
## Why I'm doing:
Too frequent crash triggers too many coredump collection.

## What I'm doing:
Throttle the core dump collection of too frequent crash

Tested on k8s cluster.
```
[Sat Mar 23 15:25:03 PDT 2024] [coredump] COREDUMP_BLOBSTORE_PREFIX="celostar-coredump" COREDUMP_COLLECT_MINIMAL_INTERVAL="600" COREDUMP_ENABLED="true" COREDUMP_PATH="/opt/starrocks/be/storage/coredumps"
Setting up watches.
Watches established.
[Sat Mar 23 15:26:28 PDT 2024] [coredump] CLOSE_WRITE,CLOSE /opt/starrocks/be/storage/coredumps/core.dump
[Sat Mar 23 15:26:28 PDT 2024] [coredump] Core dump generated core.dump
[Sat Mar 23 15:26:28 PDT 2024] [coredump] -rw-r--r-- 1 root root 0 Mar 23 15:26 core.dump
[Sat Mar 23 15:26:28 PDT 2024] [coredump] Compressing core dump files to celostar-eks.celostar.celostar-be-0.deng-upcore-4.03-23-24.15-26-28.PDT.gz ...
[Sat Mar 23 15:26:28 PDT 2024] [coredump] Zip complete
[Sat Mar 23 15:26:28 PDT 2024] [coredump] -rw-r--r-- 1 root root 30 Mar 23 15:26 celostar-eks.celostar.celostar-be-0.deng-upcore-4.03-23-24.15-26-28.PDT.gz
Transferred:            30 / 30 Bytes, 100%, 282 Bytes/s, ETA 0s
Transferred:            1 / 1, 100%
Elapsed time:         0.2s
[Sat Mar 23 15:26:28 PDT 2024] [coredump] Upload complete: core.dump
Setting up watches.
Watches established.
[Sat Mar 23 15:26:42 PDT 2024] [coredump] CLOSE_WRITE,CLOSE /opt/starrocks/be/storage/coredumps/core.dump
[Sat Mar 23 15:26:42 PDT 2024] [coredump] Core dump generated core.dump
[Sat Mar 23 15:26:42 PDT 2024] [coredump] -rw-r--r-- 1 root root 0 Mar 23 15:26 core.dump
**[Sat Mar 23 15:26:42 PDT 2024] [coredump] File was created less than 600 seconds after the previous crash, removing file and continuing loop**
Setting up watches.
Watches established.
```

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [ ] 3.1-cs
  - [ ] 3.0
  - [ ] 2.5
