### PR TITLE
[BugFix] Fix nullptr when parquet file's type is mismatched with table's type

### DIFF
--- a/be/src/formats/parquet/file_reader.cpp
+++ b/be/src/formats/parquet/file_reader.cpp
@@ -490,7 +490,7 @@ Status FileReader::_init_group_readers() {
         std::vector<io::SharedBufferedInputStream::IORange> ranges;
         for (auto& r : _row_group_readers) {
             int64_t end_offset = 0;
-            r->collect_io_ranges(&ranges, &end_offset);
+            RETURN_IF_ERROR(r->collect_io_ranges(&ranges, &end_offset));
             r->set_end_offset(end_offset);
         }
         RETURN_IF_ERROR(_sb_stream->set_io_ranges(ranges));

--- a/be/src/formats/parquet/group_reader.cpp
+++ b/be/src/formats/parquet/group_reader.cpp
@@ -269,10 +269,19 @@ ChunkPtr GroupReader::_create_read_chunk(const std::vector<int>& column_indices)
     return chunk;
 }
 
-void GroupReader::collect_io_ranges(std::vector<io::SharedBufferedInputStream::IORange>* ranges, int64_t* end_offset) {
+Status GroupReader::collect_io_ranges(std::vector<io::SharedBufferedInputStream::IORange>* ranges,
+                                      int64_t* end_offset) {
     int64_t end = 0;
     for (const auto& column : _param.read_cols) {
         auto schema_node = _param.file_metadata->schema().get_stored_column_by_field_idx(column.idx_in_parquet);
+
+        // We will only set a complex type in ParquetField
+        if ((schema_node->type.is_complex_type() || column.slot_type().is_complex_type()) &&
+            (schema_node->type.type != column.slot_type().type)) {
+            return Status::InternalError(strings::Substitute("ParquetField's type $0 is different from table's type $1",
+                                                             schema_node->type.type, column.slot_type().type));
+        }
+
         if (column.t_iceberg_schema_field == nullptr) {
             _collect_field_io_range(*schema_node, column.slot_type(), ranges, &end);
         } else {
@@ -280,6 +289,7 @@ void GroupReader::collect_io_ranges(std::vector<io::SharedBufferedInputStream::I
         }
     }
     *end_offset = end;
+    return Status::OK();
 }
 
 void GroupReader::_collect_field_io_range(const ParquetField& field, const TypeDescriptor& col_type,

--- a/be/src/formats/parquet/group_reader.h
+++ b/be/src/formats/parquet/group_reader.h
@@ -80,7 +80,7 @@ public:
     Status init();
     Status get_next(ChunkPtr* chunk, size_t* row_count);
     void close();
-    void collect_io_ranges(std::vector<io::SharedBufferedInputStream::IORange>* ranges, int64_t* end_offset);
+    Status collect_io_ranges(std::vector<io::SharedBufferedInputStream::IORange>* ranges, int64_t* end_offset);
     void set_end_offset(int64_t value) { _end_offset = value; }
 
     void _use_as_dict_filter_column(int col_idx, SlotId slot_id, std::vector<std::string>& sub_field_path);


### PR DESCRIPTION
## Why I'm doing:
Fix be crashed:
```bash
*** Aborted at 1711099964 (unix time) try "date -d @1711099964" if you are using GNU date ***
PC: @          0x5ab95bc starrocks::parquet::GroupReader::_collect_field_io_range()
*** SIGSEGV (@0x0) received by PID 3238 (TID 0x7f4c47823700) from PID 0; stack trace: ***
    @          0x6513e02 google::(anonymous namespace)::FailureSignalHandler()
    @     0x7f4cd157dacf os::Linux::chained_handler()
    @     0x7f4cd1583938 JVM_handle_linux_signal
    @     0x7f4cd1575338 signalHandler()
    @     0x7f4cd070e630 (unknown)
    @          0x5ab95bc starrocks::parquet::GroupReader::_collect_field_io_range()
    @          0x5ab9832 starrocks::parquet::GroupReader::collect_io_ranges()
    @          0x5a9d697 starrocks::parquet::FileReader::_init_group_readers()
    @          0x5a9e4fc starrocks::parquet::FileReader::init()
    @          0x5918f59 starrocks::HdfsParquetScanner::do_open()
    @          0x590e080 starrocks::HdfsScanner::open()
    @          0x58a9569 starrocks::connector::HiveDataSource::_init_scanner()
    @          0x58ab5d6 starrocks::connector::HiveDataSource::open()
    @          0x35f38c1 starrocks::pipeline::ConnectorChunkSource::_open_data_source()
    @          0x35f4921 starrocks::pipeline::ConnectorChunkSource::_read_chunk()
    @          0x391a257 starrocks::pipeline::ChunkSource::buffer_next_batch_chunks_blocking()
    @          0x35e6b0d _ZZN9starrocks8pipeline12ScanOperator18_trigger_next_scanEPNS_12RuntimeStateEiENKUlvE_clEv
    @          0x36f4bb1 starrocks::workgroup::ScanExecutor::worker_thread()
    @          0x2cfe31c starrocks::ThreadPool::dispatch_thread()
    @          0x2cf7fca starrocks::Thread::supervise_thread()
    @     0x7f4cd0706ea5 start_thread
    @     0x7f4ccfb07b0d __clone
    @                0x0 (unknown)
```

## What I'm doing:
Fix it

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.2
  - [ ] 3.1
  - [x] 3.0
  - [ ] 2.5

