### PR TITLE
[Enhancement] Remove replication transaction timeout checking (backport #42990)

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/replication/ReplicationJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/replication/ReplicationJob.java
@@ -403,6 +403,8 @@ public class ReplicationJob implements GsonPostProcessable {
                 }
             }
         } catch (Exception e) {
+            LOG.warn("Replication job exception, state: {}, database id: {}, table id: {}, transaction id: {}, ",
+                    state, databaseId, tableId, transactionId, e);
             abortTransaction(e.getMessage());
             setState(ReplicationJobState.ABORTED);
         }

--- a/fe/fe-core/src/main/java/com/starrocks/transaction/GlobalTransactionMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/transaction/GlobalTransactionMgr.java
@@ -323,6 +323,9 @@ public class GlobalTransactionMgr implements Writable, MemoryTrackable {
                 checkValidTimeoutSecond(timeoutSecond, Config.max_stream_load_timeout_second,
                         Config.min_load_timeout_second);
                 break;
+            case REPLICATION:
+                // skip transaction timeout range check for replication
+                break;
             default:
                 checkValidTimeoutSecond(timeoutSecond, Config.max_load_timeout_second, Config.min_load_timeout_second);
         }


### PR DESCRIPTION
## Why I'm doing:
Replication transaction timeout is configured using replication_transaction_timeout_sec, which is also limited by min_load_timeout_second and max_load_timeout_second.

## What I'm doing:
Remove replication transaction timeout checking.

Backport of pr: https://github.com/StarRocks/starrocks/pull/42990

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [x] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
