### PR TITLE
[BugFix] Fix the incorrect jdbc url concatenation which cause jdbc url parameters cannot be passed. (backport #42927)

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/JDBCTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/JDBCTable.java
@@ -128,9 +128,16 @@ public class JDBCTable extends Table {
             tJDBCTable.setJdbc_driver_class(properties.get(JDBCResource.DRIVER_CLASS));
 
             if (dbName.isEmpty()) {
-                tJDBCTable.setJdbc_url(properties.get(JDBCResource.URI));
+                tJDBCTable.setJdbc_url(uri);
             } else {
-                tJDBCTable.setJdbc_url(properties.get(JDBCResource.URI) + "/" + dbName);
+                int delimiterIndex = uri.indexOf("?");
+                if (delimiterIndex > 0) {
+                    String urlPrefix = uri.substring(0, delimiterIndex);
+                    String urlSuffix = uri.substring(delimiterIndex + 1);
+                    tJDBCTable.setJdbc_url(urlPrefix + "/" + dbName + "?" + urlSuffix);
+                } else {
+                    tJDBCTable.setJdbc_url(uri + "/" + dbName);
+                }
             }
             tJDBCTable.setJdbc_table(jdbcTable);
             tJDBCTable.setJdbc_user(properties.get(JDBCResource.USER));


### PR DESCRIPTION

## Why I'm doing:
We concat the `jdbc_url` with db name directly, as the final jdbc url. So when user add some parameters to the jdbc url, such as `jdbc:mysql://172.26.199.115:3306?zeroDateTimeBehavior=CONVERT_TO_NULL`, it will be changed to `jdbc:mysql://172.26.199.115:3306?zeroDateTimeBehavior=CONVERT_TO_NULL/mydbname`, which cause the query error.

## What I'm doing:
Check and concatenate the jdbc url with user parameters.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [x] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5

