### PR TITLE
[BugFix][Cherry-Pick][Branch-3.0] Fix nullptr when parquet file's type is mismatched with table's type (backport #43014)

### DIFF
--- a/be/src/formats/parquet/file_reader.cpp
+++ b/be/src/formats/parquet/file_reader.cpp
@@ -477,7 +477,7 @@ Status FileReader::_init_group_readers() {
         std::vector<io::SharedBufferedInputStream::IORange> ranges;
         for (auto& r : _row_group_readers) {
             int64_t end_offset = 0;
-            r->collect_io_ranges(&ranges, &end_offset);
+            RETURN_IF_ERROR(r->collect_io_ranges(&ranges, &end_offset));
             r->set_end_offset(end_offset);
         }
         _sb_stream->set_io_ranges(ranges);

--- a/be/src/formats/parquet/group_reader.cpp
+++ b/be/src/formats/parquet/group_reader.cpp
@@ -251,10 +251,10 @@ Status GroupReader::collect_io_ranges(std::vector<io::SharedBufferedInputStream:
         auto schema_node = _param.file_metadata->schema().get_stored_column_by_field_idx(column.field_idx_in_parquet);
 
         // We will only set a complex type in ParquetField
-        if ((schema_node->type.is_complex_type() || column.slot_type().is_complex_type()) &&
-            (schema_node->type.type != column.slot_type().type)) {
+        if ((schema_node->type.is_complex_type() || column.col_type_in_chunk.is_complex_type()) &&
+            (schema_node->type.type != column.col_type_in_chunk.type)) {
             return Status::InternalError(strings::Substitute("ParquetField's type $0 is different from table's type $1",
-                                                             schema_node->type.type, column.slot_type().type));
+                                                             schema_node->type.type, column.col_type_in_chunk.type));
         }
 
         if (column.t_iceberg_schema_field == nullptr) {

--- a/be/src/formats/parquet/group_reader.cpp
+++ b/be/src/formats/parquet/group_reader.cpp
@@ -244,10 +244,19 @@ ChunkPtr GroupReader::_create_read_chunk(const std::vector<int>& column_indices)
     return chunk;
 }
 
-void GroupReader::collect_io_ranges(std::vector<io::SharedBufferedInputStream::IORange>* ranges, int64_t* end_offset) {
+Status GroupReader::collect_io_ranges(std::vector<io::SharedBufferedInputStream::IORange>* ranges,
+                                      int64_t* end_offset) {
     int64_t end = 0;
     for (const auto& column : _param.read_cols) {
         auto schema_node = _param.file_metadata->schema().get_stored_column_by_field_idx(column.field_idx_in_parquet);
+
+        // We will only set a complex type in ParquetField
+        if ((schema_node->type.is_complex_type() || column.slot_type().is_complex_type()) &&
+            (schema_node->type.type != column.slot_type().type)) {
+            return Status::InternalError(strings::Substitute("ParquetField's type $0 is different from table's type $1",
+                                                             schema_node->type.type, column.slot_type().type));
+        }
+
         if (column.t_iceberg_schema_field == nullptr) {
             _collect_field_io_range(*schema_node, column.col_type_in_chunk, ranges, &end);
         } else {
@@ -256,6 +265,7 @@ void GroupReader::collect_io_ranges(std::vector<io::SharedBufferedInputStream::I
         }
     }
     *end_offset = end;
+    return Status::OK();
 }
 
 void GroupReader::_collect_field_io_range(const ParquetField& field, const TypeDescriptor& col_type,

--- a/be/src/formats/parquet/group_reader.h
+++ b/be/src/formats/parquet/group_reader.h
@@ -81,7 +81,7 @@ public:
     Status init();
     Status get_next(ChunkPtr* chunk, size_t* row_count);
     void close();
-    void collect_io_ranges(std::vector<io::SharedBufferedInputStream::IORange>* ranges, int64_t* end_offset);
+    Status collect_io_ranges(std::vector<io::SharedBufferedInputStream::IORange>* ranges, int64_t* end_offset);
     void set_end_offset(int64_t value) { _end_offset = value; }
 
 private:


### PR DESCRIPTION
cp from #43014

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [x] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5

