### PR TITLE
[Enhancement] Expose hdfs `dfs.client.socket-timeout` parameter in be.conf

### DIFF
--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -849,6 +849,8 @@ CONF_Int32(connector_io_tasks_slow_io_latency_ms, "50");
 CONF_mDouble(scan_use_query_mem_ratio, "0.25");
 CONF_Double(connector_scan_use_query_mem_ratio, "0.3");
 
+// hdfs client socket timeout, default value is 60000ms
+CONF_Int32(hdfs_client_socket_timeout, "60000");
 // hdfs hedged read
 CONF_Bool(hdfs_client_enable_hedged_read, "false");
 // dfs.client.hedged.read.threadpool.size

--- a/be/src/fs/hdfs/hdfs_fs_cache.cpp
+++ b/be/src/fs/hdfs/hdfs_fs_cache.cpp
@@ -70,9 +70,13 @@ static Status create_hdfs_fs_handle(const std::string& namenode, const std::shar
         }
     }
 
+    // Set for dfs.client.socket-timeout
+    const std::string dfs_client_socket_timeout = std::to_string(config::hdfs_client_socket_timeout);
+    hdfsBuilderConfSetStr(hdfs_builder, "dfs.client.socket-timeout", dfs_client_socket_timeout.data());
+
     // Set for hdfs client hedged read
-    std::string hedged_read_threadpool_size = std::to_string(config::hdfs_client_hedged_read_threadpool_size);
-    std::string hedged_read_threshold_millis = std::to_string(config::hdfs_client_hedged_read_threshold_millis);
+    const std::string hedged_read_threadpool_size = std::to_string(config::hdfs_client_hedged_read_threadpool_size);
+    const std::string hedged_read_threshold_millis = std::to_string(config::hdfs_client_hedged_read_threshold_millis);
     if (config::hdfs_client_enable_hedged_read) {
         hdfsBuilderConfSetStr(hdfs_builder, "dfs.client.hedged.read.threadpool.size",
                               hedged_read_threadpool_size.data());


### PR DESCRIPTION
## Why I'm doing:
expose hdfs `dfs.client.socket-timeout` parameter to the user. Set a lower number is helpful for slow DataNode.

Like Trino exposes `hive.dfs-timeout` to the user.

## What I'm doing:

Support it.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [x] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [x] 3.1
  - [x] 3.0
  - [ ] 2.5
