### PR TITLE
[UT] Fix uninitialized error when build BE UT in release type

### DIFF
--- a/be/test/util/rle_encoding_test.cpp
+++ b/be/test/util/rle_encoding_test.cpp
@@ -395,7 +395,7 @@ TEST_F(TestRle, TestRoundTripRandomSequencesWithRuns) {
         std::string roundtrip_str;
         int rem_to_read = num_bits;
         size_t run_len;
-        bool val;
+        bool val = false;
         while (rem_to_read > 0 && (run_len = decoder.GetNextRun(&val, std::min(kMaxToReadAtOnce, rem_to_read))) != 0) {
             ASSERT_LE(run_len, kMaxToReadAtOnce);
             roundtrip_str.append(run_len, val ? '1' : '0');


### PR DESCRIPTION
## Why I'm doing:
```
In file included from /root/starrocks/be/test/util/rle_encoding_test.cpp:53:
/root/starrocks/be/src/util/rle_encoding.h: In member function 'virtual void starrocks::TestRle_TestRoundTripRandomSequencesWithRuns_Test::TestBody()':
/root/starrocks/be/src/util/rle_encoding.h:367:36: error: 'val' may be used uninitialized in this function [-Werror=maybe-uninitialized]
  367 |                 if (current_value_ != *val || rem == 0) {
      |                     ~~~~~~~~~~~~~~~^~~~~~~
/root/starrocks/be/test/util/rle_encoding_test.cpp:398:14: note: 'val' was declared here
  398 |         bool val;
      |              ^~~
cc1plus: all warnings being treated as errors
```

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [x] 3.1
  - [ ] 3.0
  - [ ] 2.5
