### PR TITLE
[BugFix] Only log create task run status log when it's not rejected and created

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/TaskManager.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/TaskManager.java
@@ -734,7 +734,9 @@ public class TaskManager implements MemoryTrackable {
 
                 // TODO: To avoid the same query id collision, use a new query id instead of an old query id
                 taskRun.initStatus(status.getQueryId(), status.getCreateTime());
-                taskRunManager.arrangeTaskRun(taskRun);
+                if (!taskRunManager.arrangeTaskRun(taskRun)) {
+                    LOG.warn("Submit task run to pending queue failed, reject the submit:{}", taskRun);
+                }
                 break;
             // this will happen in build image
             case RUNNING:
@@ -771,6 +773,7 @@ public class TaskManager implements MemoryTrackable {
             List<TaskRun> tempQueue = Lists.newArrayList();
             while (!taskRunQueue.isEmpty()) {
                 TaskRun taskRun = taskRunQueue.poll();
+                // use queryId to find the taskRun
                 if (taskRun.getStatus().getQueryId().equals(statusChange.getQueryId())) {
                     pendingTaskRun = taskRun;
                     break;
@@ -797,6 +800,16 @@ public class TaskManager implements MemoryTrackable {
                 status.setErrorMessage(statusChange.getErrorMessage());
                 status.setErrorCode(statusChange.getErrorCode());
                 status.setState(Constants.TaskRunState.FAILED);
+                taskRunManager.getTaskRunHistory().addHistory(status);
+            } else if (toStatus == Constants.TaskRunState.SUCCESS) {
+                // This only happened when the task run is merged by others and no run ever.
+                LOG.info("Replay update pendingTaskRun which is merged by others, query_id:{}, taskId:{}",
+                        statusChange.getQueryId(), taskId);
+                status.setErrorMessage(statusChange.getErrorMessage());
+                status.setErrorCode(statusChange.getErrorCode());
+                status.setState(Constants.TaskRunState.SUCCESS);
+                status.setProgress(100);
+                status.setFinishTime(statusChange.getFinishTime());
                 taskRunManager.getTaskRunHistory().addHistory(status);
             }
             if (taskRunQueue.size() == 0) {

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/TaskRunManager.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/TaskRunManager.java
@@ -85,11 +85,12 @@ public class TaskRunManager implements MemoryTrackable {
         status.setPriority(option.getPriority());
         status.setMergeRedundant(option.isMergeRedundant());
         status.setProperties(option.getTaskRunProperties());
-        GlobalStateMgr.getCurrentState().getEditLog().logTaskRunCreateStatus(status);
         if (!arrangeTaskRun(taskRun)) {
             LOG.warn("Submit task run to pending queue failed, reject the submit:{}", taskRun);
             return new SubmitResult(null, SubmitResult.SubmitStatus.REJECTED);
         }
+        // Only log create task run status when it's not rejected and created.
+        GlobalStateMgr.getCurrentState().getEditLog().logTaskRunCreateStatus(status);
         return new SubmitResult(queryId, SubmitResult.SubmitStatus.SUBMITTED, taskRun.getFuture());
     }
 
@@ -155,6 +156,13 @@ public class TaskRunManager implements MemoryTrackable {
                     LOG.info("Merge redundant task run, oldTaskRun: {}, taskRun: {}",
                             oldTaskRun, taskRun);
                     iter.remove();
+
+                    // Update follower's state to SUCCESS, otherwise the merged task run will always be PENDING.
+                    // TODO: 1. add a MERGED state later. 2. support batch update to reduce the number of edit logs.
+                    oldTaskRun.getStatus().setFinishTime(System.currentTimeMillis());
+                    TaskRunStatusChange statusChange = new TaskRunStatusChange(oldTaskRun.getTaskId(), oldTaskRun.getStatus(),
+                            taskRun.getStatus().getState(), Constants.TaskRunState.SUCCESS);
+                    GlobalStateMgr.getCurrentState().getEditLog().logUpdateTaskRun(statusChange);
                 }
             }
             if (!taskRuns.offer(taskRun)) {

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/TaskRunManager.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/TaskRunManager.java
@@ -161,7 +161,7 @@ public class TaskRunManager implements MemoryTrackable {
                     // TODO: 1. add a MERGED state later. 2. support batch update to reduce the number of edit logs.
                     oldTaskRun.getStatus().setFinishTime(System.currentTimeMillis());
                     TaskRunStatusChange statusChange = new TaskRunStatusChange(oldTaskRun.getTaskId(), oldTaskRun.getStatus(),
-                            taskRun.getStatus().getState(), Constants.TaskRunState.SUCCESS);
+                            oldTaskRun.getStatus().getState(), Constants.TaskRunState.SUCCESS);
                     GlobalStateMgr.getCurrentState().getEditLog().logUpdateTaskRun(statusChange);
                 }
             }

--- a/test/sql/test_materialized_view/R/test_refresh_mv_with_different_dbs
+++ b/test/sql/test_materialized_view/R/test_refresh_mv_with_different_dbs
@@ -1,0 +1,71 @@
+-- name: test_refresh_mv_with_different_dbs
+create database db1;
+-- result:
+-- !result
+use db1;
+-- result:
+-- !result
+create database db2;
+-- result:
+-- !result
+CREATE TABLE `t1` (
+`k1` int,
+`k2` int,
+`k3` int
+) 
+DUPLICATE KEY(`k1`)
+DISTRIBUTED BY HASH(`k1`) BUCKETS 3;
+-- result:
+-- !result
+CREATE TABLE db2.t1 (
+`k1` int,
+`k2` int,
+`k3` int
+) 
+DUPLICATE KEY(`k1`)
+DISTRIBUTED BY HASH(`k1`) BUCKETS 3;
+-- result:
+-- !result
+CREATE MATERIALIZED VIEW mv1
+DISTRIBUTED BY HASH(k1) BUCKETS 10
+REFRESH ASYNC
+AS SELECT t1.k1 as k1, t1.k2 as k2, t2.k1 as k3, t2.k2 as k4
+FROM t1 join db2.t1 t2 on t1.k1=t2.k1;
+-- result:
+-- !result
+INSERT INTO t1 VALUES (1,1,1);
+-- result:
+-- !result
+INSERT INTO db2.t1 VALUES (1,2,2);
+-- result:
+-- !result
+analyze full table t1;
+-- result:
+db1.t1	analyze	status	OK
+-- !result
+analyze full table db2.t1;
+-- result:
+db2.t1	analyze	status	OK
+-- !result
+function: wait_async_materialized_view_finish("mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT t1.k1 as k1, t1.k2 as k2, t2.k1 as k3, t2.k2 as k4 FROM t1 join db2.t1 t2 on t1.k1=t2.k1;", "mv1")
+-- result:
+None
+-- !result
+SELECT t1.k1 as k1, t1.k2 as k2, t2.k1 as k3, t2.k2 as k4
+FROM t1 join db2.t1 t2 on t1.k1=t2.k1 order by 1, 2, 3, 4;
+-- result:
+1	1	1	2
+-- !result
+drop materialized view mv1;
+-- result:
+-- !result
+drop table t1;
+-- result:
+-- !result
+drop table db2.t1;
+-- result:
+-- !result

--- a/test/sql/test_materialized_view/T/test_refresh_mv_with_different_dbs
+++ b/test/sql/test_materialized_view/T/test_refresh_mv_with_different_dbs
@@ -1,0 +1,46 @@
+-- name: test_refresh_mv_with_different_dbs
+
+-- db1
+create database db1;
+use db1;
+
+-- db2
+create database db2;
+CREATE TABLE `t1` (
+`k1` int,
+`k2` int,
+`k3` int
+) 
+DUPLICATE KEY(`k1`)
+DISTRIBUTED BY HASH(`k1`) BUCKETS 3;
+
+CREATE TABLE db2.t1 (
+`k1` int,
+`k2` int,
+`k3` int
+) 
+DUPLICATE KEY(`k1`)
+DISTRIBUTED BY HASH(`k1`) BUCKETS 3;
+
+-- create db with different dbs
+CREATE MATERIALIZED VIEW mv1
+DISTRIBUTED BY HASH(k1) BUCKETS 10
+REFRESH ASYNC
+AS SELECT t1.k1 as k1, t1.k2 as k2, t2.k1 as k3, t2.k2 as k4
+FROM t1 join db2.t1 t2 on t1.k1=t2.k1;
+
+INSERT INTO t1 VALUES (1,1,1);
+INSERT INTO db2.t1 VALUES (1,2,2);
+
+analyze full table t1;
+analyze full table db2.t1;
+
+function: wait_async_materialized_view_finish("mv1")
+function: check_hit_materialized_view("SELECT t1.k1 as k1, t1.k2 as k2, t2.k1 as k3, t2.k2 as k4 FROM t1 join db2.t1 t2 on t1.k1=t2.k1;", "mv1")
+
+SELECT t1.k1 as k1, t1.k2 as k2, t2.k1 as k3, t2.k2 as k4
+FROM t1 join db2.t1 t2 on t1.k1=t2.k1 order by 1, 2, 3, 4;
+
+drop materialized view mv1;
+drop table t1;
+drop table db2.t1;


### PR DESCRIPTION
## Why I'm doing:
- TaskRun's state will be always PENDING in follower if it's merged in leader

## What I'm doing:
-  Update follower's state to SUCCESS, otherwise the merged task run will always be PENDING.

 TODO: 1. add a MERGED state later. 2. support batch update to reduce the number of edit logs.
Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
