### PR TITLE
[Doc] keep the same content with English Doc 'backup_restore'

### DIFF
--- a/docs/zh/sql-reference/sql-statements/data-definition/backup_restore/backup_restore.mdx
+++ b/docs/zh/sql-reference/sql-statements/data-definition/backup_restore/backup_restore.mdx
@@ -1,0 +1,9 @@
+---
+displayed_sidebar: "English"
+---
+
+# Backup and restore
+
+import DocCardList from '@theme/DocCardList';
+
+<DocCardList />

--- a/docs/zh/sql-reference/sql-statements/data-definition/backup_restore/backup_restore.mdx
+++ b/docs/zh/sql-reference/sql-statements/data-definition/backup_restore/backup_restore.mdx
@@ -1,8 +1,8 @@
 ---
-displayed_sidebar: "English"
+displayed_sidebar: "Chinese"
 ---
 
-# Backup and restore
+# 备份与恢复
 
 import DocCardList from '@theme/DocCardList';
 


### PR DESCRIPTION
## Why I'm doing:

it seems strange when switch the Chinese Doc page about backup_restore

## What I'm doing:

keep the same content with English Doc 'backup_restore'

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [x] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5