### PR TITLE
[Enhancement] Make IcebergHiveCatalog's list-all-tables property configurable

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/hive/IcebergHiveCatalog.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/hive/IcebergHiveCatalog.java
@@ -88,7 +88,7 @@ public class IcebergHiveCatalog implements IcebergCatalog {
         // The property is false by default, in such case, when we execute SHOW TABLES FROM CATALOG.DB,
         // it will request all Table Objects from Hive Metastore, when there are lots of tables under the
         // database, timeout may happen.
-        copiedProperties.put(HiveCatalog.LIST_ALL_TABLES, "true");
+        copiedProperties.putIfAbsent(HiveCatalog.LIST_ALL_TABLES, "true");
 
         delegate = (HiveCatalog) CatalogUtil.loadCatalog(HiveCatalog.class.getName(), name, copiedProperties, conf);
     }


### PR DESCRIPTION
## Why I'm doing:
https://github.com/StarRocks/starrocks/pull/40694 set IcebergHiveCatalog's `list-all-tables` property to true by hardcode, and this will prevents us from setting parameters dynamically.
If users want to only see iceberg tables in hms backend catalog, we need set `list-all-tables`  to false.
## What I'm doing:
Make IcebergHiveCatalog's `list-all-tables` property configurable, and keep it to false by default to align with https://github.com/StarRocks/starrocks/pull/40694.

And then we can set the property `list-all-tables` when creating iceberg catalog.

```
create external catalog icebergcat PROPERTIES 
("type"="iceberg","iceberg.catalog.type"="hive", 
"hive.metastore.uris"="thrift://127.0.0.1:9083", 
"list-all-tables"="false");
```

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
