### PR TITLE
[UT] fix crash ut PersistentIndexSstableTest.test_merge

### DIFF
--- a/be/test/storage/sstable/persistent_index_sstable_test.cpp
+++ b/be/test/storage/sstable/persistent_index_sstable_test.cpp
@@ -163,23 +163,6 @@ TEST_F(PersistentIndexSstableTest, test_merge) {
         }
         delete iter;
     }
-    {
-        // reserve iterate
-        sstable::Options options;
-        sstable::Iterator* iter = sstable::NewMergingIterator(options.comparator, &list[0], list.size());
-
-        iter->SeekToLast();
-        std::string cur_key = "";
-        while (iter->Valid()) {
-            auto key = iter->key().to_string();
-            iter->Prev();
-            if (cur_key != "") {
-                ASSERT_TRUE(cur_key >= key);
-            }
-            cur_key = key;
-        }
-        CHECK_OK(iter->status());
-    }
 
     ASSERT_EQ(N, map.size());
     const std::string filename = "test_merge_4.sst";


### PR DESCRIPTION
## Why I'm doing:
PersistentIndexSstableTest.test_merge will crash because `std::vector<sstable::Iterator*> list;` will be deleted when iterator is deleted. We can't use `std::vector<sstable::Iterator*> list;` twice.
This issue was introduced by #43029 

## What I'm doing:
Fix it by remove reserve iterator test, we don't need it now.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [x] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
