### PR TITLE
[BugFix] Fix partition deletion keeps failing due to non-existent shard

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/lake/LakeTableHelper.java
+++ b/fe/fe-core/src/main/java/com/starrocks/lake/LakeTableHelper.java
@@ -17,6 +17,7 @@ package com.starrocks.lake;
 import com.google.common.base.Preconditions;
 import com.staros.client.StarClientException;
 import com.staros.proto.ShardInfo;
+import com.staros.proto.StatusCode;
 import com.starrocks.alter.AlterJobV2Builder;
 import com.starrocks.alter.LakeTableAlterJobV2Builder;
 import com.starrocks.catalog.Column;
@@ -108,7 +109,14 @@ public class LakeTableHelper {
                 continue;
             }
             LakeTablet tablet = (LakeTablet) tablets.get(0);
-            return Optional.of(tablet.getShardInfo());
+            try {
+                return Optional.of(tablet.getShardInfo());
+            } catch (StarClientException e) {
+                if (e.getCode() != StatusCode.NOT_EXIST) {
+                    throw e;
+                }
+                // Shard does not exist, ignore this shard
+            }
         }
         return Optional.empty();
     }


### PR DESCRIPTION
## Why I'm doing:
Due to some unknown reasons, some shards of a table or partition in the Recycle Bin have been deleted, which will cause getShardInfo to throw an exception when the Recycle Bin deletes the table or partition, resulting in a deletion failure. The Recycle Bin will keep retrying after a failed deletion, and each time it retries, it will encounter the same exception again.

## What I'm doing:
Catch the exception thrown by `getShardInfo` and determine the error code, if it is NOT_EXIST (shard does not exist), then ignore the error.

Fixes #43084

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [x] 3.1
  - [ ] 3.0
  - [ ] 2.5
