### PR TITLE
[BugFix] Fix datasource not updated after JDBC driver is updated

### DIFF
--- a/java-extensions/jdbc-bridge/src/main/java/com/starrocks/jdbcbridge/JDBCScanner.java
+++ b/java-extensions/jdbc-bridge/src/main/java/com/starrocks/jdbcbridge/JDBCScanner.java
@@ -58,7 +58,7 @@ public class JDBCScanner {
     }
 
     public void open() throws Exception {
-        String key = scanContext.getUser() + "/" + scanContext.getJdbcURL();
+        String key = buildCacheKey();
         URL driverURL = new File(driverLocation).toURI().toURL();
         DataSourceCache.DataSourceCacheItem cacheItem = DataSourceCache.getInstance().getSource(key, () -> {
             ClassLoader classLoader = URLClassLoader.newInstance(new URL[] {
@@ -104,6 +104,10 @@ public class JDBCScanner {
                 resultChunk.add((Object[]) Array.newInstance(String.class, scanContext.getStatementFetchSize()));
             }
         }
+    }
+
+    private String buildCacheKey() {
+        return scanContext.getUser() + "/" + scanContext.getJdbcURL() + "/" + driverLocation;
     }
 
     private static final Set<Class<?>> GENERAL_JDBC_CLASS_SET =  new HashSet<>(Arrays.asList(


### PR DESCRIPTION
Fix datasource not updated after JDBC driver is updated

## Why I'm doing:
DBCScanner uses an old version JDBC driver after user recreates a JDBC catalog using a new driver. Because the JDBCScanner only considers username + jdbc url as the Datasource cache key.

## What I'm doing:
Add driverLocation as a part of cache key so that the Datasource is recreated when JDBC Catalog is recreated using a new version driver

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [x] 3.1
  - [ ] 3.0
  - [ ] 2.5
