### PR TITLE
[Enhancement] merge tiny stripes / RowGroups when do splitting

### DIFF
--- a/be/src/connector/hive_connector.cpp
+++ b/be/src/connector/hive_connector.cpp
@@ -779,6 +779,9 @@ Status HiveDataSource::_init_scanner(RuntimeState* state) {
     scanner_params.lazy_column_coalesce_counter = get_lazy_column_coalesce_counter();
     scanner_params.split_context = _split_context;
     scanner_params.enable_split_tasks = _enable_split_tasks;
+    if (state->query_options().__isset.connector_max_split_size) {
+        scanner_params.connector_max_split_size = state->query_options().connector_max_split_size;
+    }
 
     if (!_equality_delete_slots.empty()) {
         MORParams& mor_params = scanner_params.mor_params;

--- a/be/src/connector/hive_connector.cpp
+++ b/be/src/connector/hive_connector.cpp
@@ -875,7 +875,7 @@ Status HiveDataSource::_init_scanner(RuntimeState* state) {
 
 void HiveDataSource::close(RuntimeState* state) {
     if (_scanner != nullptr) {
-        if (!_scanner->get_has_split_tasks()) {
+        if (!_scanner->has_split_tasks()) {
             COUNTER_UPDATE(_profile.scan_ranges_counter, 1);
             COUNTER_UPDATE(_profile.scan_ranges_size, _scan_range.length);
         }
@@ -977,9 +977,6 @@ void HiveDataSourceProvider::default_data_source_mem_bytes(int64_t* min_value, i
 void HiveDataSource::get_split_tasks(std::vector<pipeline::ScanSplitContextPtr>* split_tasks) {
     if (_scanner == nullptr) return;
     _scanner->move_split_tasks(split_tasks);
-    if (split_tasks->size() > 0) {
-        _scanner->set_has_split_tasks(true);
-    }
 }
 
 } // namespace starrocks::connector

--- a/be/src/connector/hive_connector.cpp
+++ b/be/src/connector/hive_connector.cpp
@@ -75,6 +75,12 @@ std::string HiveDataSource::name() const {
 
 Status HiveDataSource::open(RuntimeState* state) {
     const auto& hdfs_scan_node = _provider->_hdfs_scan_node;
+    if (_split_context != nullptr) {
+        auto split_context = down_cast<HdfsSplitContext*>(_split_context);
+        _scan_range.offset = split_context->split_start;
+        _scan_range.length = split_context->split_end - split_context->split_start;
+    }
+
     if (_scan_range.file_length == 0) {
         _no_data = true;
         return Status::OK();
@@ -751,8 +757,6 @@ Status HiveDataSource::_init_scanner(RuntimeState* state) {
 
     ASSIGN_OR_RETURN(auto fs, FileSystem::CreateUniqueFromString(native_file_path, fsOptions));
 
-    COUNTER_UPDATE(_profile.scan_ranges_counter, 1);
-    COUNTER_UPDATE(_profile.scan_ranges_size, scan_range.length);
     HdfsScannerParams scanner_params;
     scanner_params.runtime_filter_collector = _runtime_filters;
     scanner_params.scan_range = &scan_range;
@@ -777,7 +781,7 @@ Status HiveDataSource::_init_scanner(RuntimeState* state) {
     scanner_params.case_sensitive = _case_sensitive;
     scanner_params.profile = &_profile;
     scanner_params.lazy_column_coalesce_counter = get_lazy_column_coalesce_counter();
-    scanner_params.split_context = _split_context;
+    scanner_params.split_context = down_cast<HdfsSplitContext*>(_split_context);
     scanner_params.enable_split_tasks = _enable_split_tasks;
     if (state->query_options().__isset.connector_max_split_size) {
         scanner_params.connector_max_split_size = state->query_options().connector_max_split_size;
@@ -871,6 +875,10 @@ Status HiveDataSource::_init_scanner(RuntimeState* state) {
 
 void HiveDataSource::close(RuntimeState* state) {
     if (_scanner != nullptr) {
+        if (!_scanner->get_has_split_tasks()) {
+            COUNTER_UPDATE(_profile.scan_ranges_counter, 1);
+            COUNTER_UPDATE(_profile.scan_ranges_size, _scan_range.length);
+        }
         _scanner->close();
     }
     Expr::close(_min_max_conjunct_ctxs, state);
@@ -968,7 +976,10 @@ void HiveDataSourceProvider::default_data_source_mem_bytes(int64_t* min_value, i
 
 void HiveDataSource::get_split_tasks(std::vector<pipeline::ScanSplitContextPtr>* split_tasks) {
     if (_scanner == nullptr) return;
-    _scanner->get_split_tasks(split_tasks);
+    _scanner->move_split_tasks(split_tasks);
+    if (split_tasks->size() > 0) {
+        _scanner->set_has_split_tasks(true);
+    }
 }
 
 } // namespace starrocks::connector

--- a/be/src/connector/hive_connector.h
+++ b/be/src/connector/hive_connector.h
@@ -85,7 +85,7 @@ public:
 
 private:
     const HiveDataSourceProvider* _provider;
-    const THdfsScanRange _scan_range;
+    THdfsScanRange _scan_range;
 
     // ============= init func =============
     Status _init_conjunct_ctxs(RuntimeState* state);

--- a/be/src/exec/hdfs_scanner.cpp
+++ b/be/src/exec/hdfs_scanner.cpp
@@ -512,15 +512,17 @@ void HdfsScannerContext::merge_split_tasks() {
     }
     do_merge(head, split_tasks.size() - 1);
 
-    // handle the tail stripe, if it's small, merge it to the last one.
+    // handle the tail stripe, if it's small and consecutive, merge it to the last one.
     size_t new_size = new_split_tasks.size();
     if (new_size >= 2) {
         auto tail_ctx = new_split_tasks[new_size - 1].get();
         size_t tail_size = (tail_ctx->split_end - tail_ctx->split_start);
         if ((tail_size * 2) < connector_max_split_size) {
             auto last_ctx = new_split_tasks[new_size - 2].get();
-            last_ctx->split_end = tail_ctx->split_end;
-            new_split_tasks.pop_back();
+            if (last_ctx->split_end == tail_ctx->split_start) {
+                last_ctx->split_end = tail_ctx->split_end;
+                new_split_tasks.pop_back();
+            }
         }
     }
 

--- a/be/src/exec/hdfs_scanner.cpp
+++ b/be/src/exec/hdfs_scanner.cpp
@@ -484,9 +484,9 @@ void HdfsScannerContext::merge_split_tasks() {
     std::vector<HdfsSplitContextPtr> new_split_tasks;
 
     auto do_merge = [&](size_t start, size_t end) {
-        auto start_ctx = down_cast<const HdfsSplitContext*>(old_split_tasks[start].get());
-        auto end_ctx = down_cast<const HdfsSplitContext*>(old_split_tasks[end].get());
-        auto new_ctx = old_split_tasks[start]->clone();
+        auto start_ctx = old_split_tasks[start].get();
+        auto end_ctx = old_split_tasks[end].get();
+        auto new_ctx = start_ctx->clone();
         new_ctx->split_start = start_ctx->split_start;
         new_ctx->split_end = end_ctx->split_end;
         new_split_tasks.emplace_back(std::move(new_ctx));
@@ -496,9 +496,9 @@ void HdfsScannerContext::merge_split_tasks() {
     for (size_t i = 1; i < old_split_tasks.size(); i++) {
         bool cut = false;
 
-        auto prev_ctx = down_cast<const HdfsSplitContext*>(old_split_tasks[i - 1].get());
-        auto ctx = down_cast<const HdfsSplitContext*>(old_split_tasks[i].get());
-        auto head_ctx = down_cast<const HdfsSplitContext*>(old_split_tasks[head].get());
+        auto prev_ctx = old_split_tasks[i - 1].get();
+        auto ctx = old_split_tasks[i].get();
+        auto head_ctx = old_split_tasks[head].get();
 
         if ((ctx->split_start != prev_ctx->split_end) ||
             (ctx->split_end - head_ctx->split_start > connector_max_split_size)) {

--- a/be/src/exec/hdfs_scanner.cpp
+++ b/be/src/exec/hdfs_scanner.cpp
@@ -142,6 +142,7 @@ Status HdfsScanner::_build_scanner_context() {
     ctx.split_context = _scanner_params.split_context;
     ctx.split_tasks = &_split_tasks;
     ctx.enable_split_tasks = _scanner_params.enable_split_tasks;
+    ctx.connector_max_split_size = _scanner_params.connector_max_split_size;
     return Status::OK();
 }
 

--- a/be/src/exec/hdfs_scanner.cpp
+++ b/be/src/exec/hdfs_scanner.cpp
@@ -508,6 +508,19 @@ void HdfsScannerContext::merge_split_tasks() {
         }
     }
     do_merge(head, split_tasks.size() - 1);
+
+    // handle the tail stripe, if it's small, merge it to the last one.
+    size_t new_size = new_split_tasks.size();
+    if (new_size >= 2) {
+        auto tail_ctx = new_split_tasks[new_size - 1].get();
+        size_t tail_size = (tail_ctx->split_end - tail_ctx->split_start);
+        if ((tail_size * 2) < connector_max_split_size) {
+            auto last_ctx = new_split_tasks[new_size - 2].get();
+            last_ctx->split_end = tail_ctx->split_end;
+            new_split_tasks.pop_back();
+        }
+    }
+
     split_tasks.swap(new_split_tasks);
 }
 

--- a/be/src/exec/hdfs_scanner.h
+++ b/be/src/exec/hdfs_scanner.h
@@ -255,6 +255,7 @@ struct HdfsScannerContext {
     const HdfsSplitContext* split_context = nullptr;
     std::vector<HdfsSplitContextPtr> split_tasks;
     bool has_split_tasks = false;
+    size_t estimated_mem_usage_per_split_task = 0;
 
     // min max slots
     const TupleDescriptor* min_max_tuple_desc = nullptr;
@@ -341,14 +342,7 @@ public:
     virtual Status do_init(RuntimeState* runtime_state, const HdfsScannerParams& scanner_params) = 0;
     virtual void do_update_counter(HdfsScanProfile* profile);
     virtual bool is_jni_scanner() { return false; }
-    void move_split_tasks(std::vector<pipeline::ScanSplitContextPtr>* split_tasks) {
-        for (auto& t : _scanner_ctx.split_tasks) {
-            split_tasks->emplace_back(std::move(t));
-        }
-        if (split_tasks->size() > 0) {
-            _scanner_ctx.has_split_tasks = true;
-        }
-    }
+    void move_split_tasks(std::vector<pipeline::ScanSplitContextPtr>* split_tasks);
     bool has_split_tasks() const { return _scanner_ctx.has_split_tasks; }
 
 protected:

--- a/be/src/exec/hdfs_scanner.h
+++ b/be/src/exec/hdfs_scanner.h
@@ -212,6 +212,8 @@ struct HdfsScannerParams {
     bool use_file_metacache = false;
     bool orc_use_column_names = false;
     MORParams mor_params;
+
+    int64_t connector_max_split_size = 0;
 };
 
 struct HdfsScannerContext {
@@ -274,6 +276,8 @@ struct HdfsScannerContext {
     HdfsScanStats* stats = nullptr;
 
     std::atomic<int32_t>* lazy_column_coalesce_counter;
+
+    int64_t connector_max_split_size = 0;
 
     // update materialized column against data file.
     // and to update not_existed slots and conjuncts.

--- a/be/src/exec/hdfs_scanner_orc.cpp
+++ b/be/src/exec/hdfs_scanner_orc.cpp
@@ -470,13 +470,13 @@ Status HdfsOrcScanner::do_open(RuntimeState* runtime_state) {
             _scanner_ctx.split_tasks->emplace_back(std::move(ctx));
         }
         _scanner_ctx.merge_split_tasks();
-        if (_scanner_ctx.split_tasks->size() >= 2) {
-            VLOG_OPERATOR << "HdfsOrcScanner: do_open. split task for " << _file->filename()
-                          << ", split_tasks.size = " << _scanner_ctx.split_tasks->size();
+        VLOG_OPERATOR << "HdfsOrcScanner: do_open. split task for " << _file->filename()
+                      << ", split_tasks.size = " << _scanner_ctx.split_tasks->size();
+        if (_scanner_ctx.split_tasks->size() <= 1) {
+            _scanner_ctx.split_tasks->clear();
+        } else {
             _should_skip_file = true;
             return Status::OK();
-        } else {
-            _scanner_ctx.split_tasks->clear();
         }
     }
 

--- a/be/src/exec/hdfs_scanner_orc.cpp
+++ b/be/src/exec/hdfs_scanner_orc.cpp
@@ -37,6 +37,10 @@ struct HdfsOrcScannerSplitContext : public pipeline::ScanSplitContext {
     std::shared_ptr<std::string> footer;
 };
 
+void merge_split_tasks(std::vector<pipeline::ScanSplitContextPtr>& split_tasks, int64_t max_split_size) {
+    
+}
+
 class OrcRowReaderFilter : public orc::RowReaderFilter {
 public:
     OrcRowReaderFilter(const HdfsScannerContext& scanner_ctx, OrcChunkReader* reader);
@@ -477,6 +481,7 @@ Status HdfsOrcScanner::do_open(RuntimeState* runtime_state) {
             ctx->split_end = info.offset + info.length;
             _split_tasks.emplace_back(std::move(ctx));
         }
+        merge_split_tasks(_split_tasks, _scanner_params.connector_max_split_size);
         VLOG_OPERATOR << "HdfsOrcScanner: do_open. split task for " << _file->filename()
                       << ", size = " << stripes.size();
         return Status::OK();

--- a/be/src/exec/hdfs_scanner_orc.cpp
+++ b/be/src/exec/hdfs_scanner_orc.cpp
@@ -483,6 +483,7 @@ Status HdfsOrcScanner::do_open(RuntimeState* runtime_state) {
     RETURN_IF_ERROR(build_stripes(reader.get(), &stripes));
     RETURN_IF_ERROR(build_split_tasks(reader.get(), stripes));
     if (_scanner_ctx.split_tasks.size() > 0) {
+        _scanner_ctx.has_split_tasks = true;
         _should_skip_file = true;
         return Status::OK();
     }

--- a/be/src/exec/hdfs_scanner_orc.cpp
+++ b/be/src/exec/hdfs_scanner_orc.cpp
@@ -132,10 +132,10 @@ bool OrcRowReaderFilter::filterMinMax(size_t rowGroupIdx,
             int64_t tz_offset_in_seconds = _reader->tzoffset_in_seconds() - _writer_tzoffset_in_seconds;
             Status st = OrcMinMaxDecoder::decode(slot, orc_type, stats, min_col, max_col, tz_offset_in_seconds);
             if (!st.ok()) {
-                // LOG(INFO) << strings::Substitute(
-                //         "OrcMinMaxDecoder decode failed, may occur performance degradation. Because SR's column($0) "
-                //         "can't convert to orc file's column($1)",
-                //         slot->debug_string(), orc_type->toString());
+                LOG(INFO) << strings::Substitute(
+                        "OrcMinMaxDecoder decode failed, may occur performance degradation. Because SR's column($0) "
+                        "can't convert to orc file's column($1)",
+                        slot->debug_string(), orc_type->toString());
                 return false;
             }
         } else {
@@ -439,7 +439,6 @@ Status HdfsOrcScanner::do_open(RuntimeState* runtime_state) {
         options.setMemoryPool(*getOrcMemoryPool());
         if (_scanner_ctx.split_context != nullptr) {
             auto* split_context = down_cast<const SplitContext*>(_scanner_ctx.split_context);
-            VLOG_FILE << "[xxx] orc set footer. size = " << split_context->footer->size();
             options.setSerializedFileTail(*(split_context->footer.get()));
         }
         reader = orc::createReader(std::move(_input_stream), options);
@@ -463,7 +462,6 @@ Status HdfsOrcScanner::do_open(RuntimeState* runtime_state) {
             (_scanner_ctx.enable_split_tasks && stripes.size() >= 2) && (_scanner_ctx.split_context == nullptr);
     if (enable_split_tasks) {
         auto footer = std::make_shared<std::string>(reader->getSerializedFileTail());
-        VLOG_FILE << "[xxx] orc get footer. size = " << footer->size();
         for (const auto& info : stripes) {
             auto ctx = std::make_unique<SplitContext>();
             ctx->footer = footer;

--- a/be/src/exec/hdfs_scanner_orc.h
+++ b/be/src/exec/hdfs_scanner_orc.h
@@ -52,6 +52,7 @@ private:
 
     Status build_iceberg_delete_builder();
     Status build_stripes(orc::Reader* reader, std::vector<DiskRange>* stripes);
+    Status build_split_tasks(orc::Reader* reader, const std::vector<DiskRange>& stripes);
     Status build_io_ranges(ORCHdfsFileStream* file_stream, const std::vector<DiskRange>& stripes);
     Status resolve_columns(orc::Reader* reader);
 

--- a/be/src/exec/hdfs_scanner_parquet.cpp
+++ b/be/src/exec/hdfs_scanner_parquet.cpp
@@ -44,7 +44,7 @@ Status HdfsParquetScanner::do_init(RuntimeState* runtime_state, const HdfsScanne
 void HdfsParquetScanner::do_update_counter(HdfsScanProfile* profile) {
     // if we have split tasks, we don't need to update counter
     // and we will update those counters in sub io tasks.
-    if (_has_split_tasks) {
+    if (has_split_tasks()) {
         return;
     }
 

--- a/be/src/exec/hdfs_scanner_parquet.cpp
+++ b/be/src/exec/hdfs_scanner_parquet.cpp
@@ -42,6 +42,12 @@ Status HdfsParquetScanner::do_init(RuntimeState* runtime_state, const HdfsScanne
 }
 
 void HdfsParquetScanner::do_update_counter(HdfsScanProfile* profile) {
+    // if we have split tasks, we don't need to update counter
+    // and we will update those counters in sub io tasks.
+    if (_has_split_tasks) {
+        return;
+    }
+
     RuntimeProfile::Counter* request_bytes_read = nullptr;
     RuntimeProfile::Counter* request_bytes_read_uncompressed = nullptr;
     RuntimeProfile::Counter* level_decode_timer = nullptr;

--- a/be/src/exec/pipeline/scan/connector_scan_operator.cpp
+++ b/be/src/exec/pipeline/scan/connector_scan_operator.cpp
@@ -860,10 +860,11 @@ Status ConnectorChunkSource::_read_chunk(RuntimeState* state, ChunkPtr* chunk) {
     {
         std::vector<ScanSplitContextPtr> split_tasks;
         _data_source->get_split_tasks(&split_tasks);
-        VLOG_OPERATOR << "get_split_tasks. query_id = " << print_id(state->query_id())
-                      << ", op_id = " << _scan_op->get_plan_node_id() << "/" << _scan_op->get_driver_sequence()
-                      << ", split_tasks = " << split_tasks.size();
         if (split_tasks.size() != 0) {
+            VLOG_OPERATOR << "get_split_tasks. query_id = " << print_id(state->query_id())
+                          << ", op_id = " << _scan_op->get_plan_node_id() << "/" << _scan_op->get_driver_sequence()
+                          << ", split_tasks = " << split_tasks.size();
+
             std::vector<MorselPtr> split_morsels;
             ScanMorsel* current_morsel = down_cast<ScanMorsel*>(_morsel.get());
 

--- a/be/src/exec/pipeline/scan/connector_scan_operator.cpp
+++ b/be/src/exec/pipeline/scan/connector_scan_operator.cpp
@@ -762,7 +762,7 @@ Status ConnectorChunkSource::_open_data_source(RuntimeState* state, bool* mem_al
                 mem_tracker->consume(_request_mem_tracker_bytes);
             } else {
                 limiter->update_running_chunk_source_count(-1);
-                // VLOG_OPERATOR << build_debug_string("alloc failed");
+                VLOG_OPERATOR << build_debug_string("alloc failed");
                 _request_mem_tracker_bytes = 0;
                 return Status::OK();
             }

--- a/be/src/formats/parquet/file_reader.cpp
+++ b/be/src/formats/parquet/file_reader.cpp
@@ -92,7 +92,7 @@ Status FileReader::init(HdfsScannerContext* ctx) {
     RETURN_IF_ERROR(_get_footer());
 
     _build_split_tasks();
-    if (_scanner_ctx->split_tasks != nullptr && _scanner_ctx->split_tasks->size() > 0) {
+    if (_scanner_ctx->split_tasks.size() > 0) {
         _is_file_filtered = true;
         return Status::OK();
     }
@@ -220,9 +220,7 @@ void FileReader::_build_split_tasks() {
     // dont do split in following cases:
     // 1. this feature is not enabled
     // 2. we have already do split before (that's why `split_context` is nullptr)
-    // 3. in unit test case (that's why `split_tasks` is nullptr)
-    if (!_scanner_ctx->enable_split_tasks || _scanner_ctx->split_context != nullptr ||
-        _scanner_ctx->split_tasks == nullptr) {
+    if (!_scanner_ctx->enable_split_tasks || _scanner_ctx->split_context != nullptr) {
         return;
     }
 
@@ -237,16 +235,16 @@ void FileReader::_build_split_tasks() {
         split_ctx->split_start = start_offset;
         split_ctx->split_end = end_offset;
         split_ctx->file_metadata = _file_metadata;
-        _scanner_ctx->split_tasks->emplace_back(std::move(split_ctx));
+        _scanner_ctx->split_tasks.emplace_back(std::move(split_ctx));
     }
     _scanner_ctx->merge_split_tasks();
     // if only one split task, clear it, no need to do split work.
-    if (_scanner_ctx->split_tasks->size() <= 1) {
-        _scanner_ctx->split_tasks->clear();
+    if (_scanner_ctx->split_tasks.size() <= 1) {
+        _scanner_ctx->split_tasks.clear();
     }
 
     VLOG_OPERATOR << "FileReader: do_open. split task for " << _file->filename()
-                  << ", split_tasks.size = " << _scanner_ctx->split_tasks->size();
+                  << ", split_tasks.size = " << _scanner_ctx->split_tasks.size();
 }
 
 StatusOr<uint32_t> FileReader::_get_footer_read_size() const {

--- a/be/src/formats/parquet/file_reader.cpp
+++ b/be/src/formats/parquet/file_reader.cpp
@@ -93,6 +93,7 @@ Status FileReader::init(HdfsScannerContext* ctx) {
 
     RETURN_IF_ERROR(_build_split_tasks());
     if (_scanner_ctx->split_tasks.size() > 0) {
+        _scanner_ctx->has_split_tasks = true;
         _is_file_filtered = true;
         return Status::OK();
     }

--- a/be/src/formats/parquet/file_reader.h
+++ b/be/src/formats/parquet/file_reader.h
@@ -112,7 +112,7 @@ private:
     static int64_t _get_row_group_start_offset(const tparquet::RowGroup& row_group);
     static int64_t _get_row_group_end_offset(const tparquet::RowGroup& row_group);
 
-    void _build_split_tasks();
+    Status _build_split_tasks();
 
     RandomAccessFile* _file = nullptr;
     uint64_t _file_size = 0;

--- a/be/src/io/shared_buffered_input_stream.cpp
+++ b/be/src/io/shared_buffered_input_stream.cpp
@@ -216,8 +216,8 @@ Status SharedBufferedInputStream::get_bytes(const uint8_t** buffer, size_t offse
         _shared_io_count += 1;
         _shared_io_bytes += sb.size;
         if (sb.size > sb.raw_size) {
-            // after called _deduplicate_shared_buffer(), sb.size may smaller than sb.raw_size
-            // we don't count this
+            // after called _deduplicate_shared_buffer(), sb.size maybe is larger than sb.raw_size
+            // we will count how many extra bytes we read because of alignment.
             _shared_align_io_bytes += sb.size - sb.raw_size;
         }
         sb.buffer.reserve(sb.size);

--- a/test/sql/test_external_file/R/test_orc_split_task
+++ b/test/sql/test_external_file/R/test_orc_split_task
@@ -37,6 +37,15 @@ select c1, count(1) from multi_stripes where c0 % 26 in (0, 25) group by c1 orde
 a	7693
 z	7692
 -- !result
+set connector_max_split_size = 64 * 1024 * 1024;
+-- result:
+[]
+-- !result
+select c1, count(1) from multi_stripes where c0 % 26 in (0, 25) group by c1 order by c1;
+-- result:
+a	7693
+z	7692
+-- !result
 shell: ossutil64 rm -rf oss://${oss_bucket}/test_orc_split_task/${uuid0}/ >/dev/null || echo "exit 0" >/dev/null
 -- result:
 0

--- a/test/sql/test_external_file/R/test_orc_split_task
+++ b/test/sql/test_external_file/R/test_orc_split_task
@@ -22,17 +22,20 @@ PROPERTIES
     "format" = "orc"
 );
 -- result:
+[]
 -- !result
 set enable_connector_split_io_tasks = true;
 -- result:
+[]
+-- !result
+set connector_max_split_size = 64;
+-- result:
+[]
 -- !result
 select c1, count(1) from multi_stripes where c0 % 26 in (0, 25) group by c1 order by c1;
 -- result:
 a	7693
 z	7692
--- !result
-set enable_connector_split_io_tasks = false;
--- result:
 -- !result
 shell: ossutil64 rm -rf oss://${oss_bucket}/test_orc_split_task/${uuid0}/ >/dev/null || echo "exit 0" >/dev/null
 -- result:

--- a/test/sql/test_external_file/R/test_parquet_split_task
+++ b/test/sql/test_external_file/R/test_parquet_split_task
@@ -22,17 +22,20 @@ PROPERTIES
     "format" = "parquet"
 );
 -- result:
+[]
 -- !result
 set enable_connector_split_io_tasks = true;
 -- result:
+[]
+-- !result
+set connector_max_split_size = 64;
+-- result:
+[]
 -- !result
 select c1, count(1) from multi_stripes where c0 % 26 in (0, 25) group by c1 order by c1;
 -- result:
 a	77
 z	76
--- !result
-set enable_connector_split_io_tasks = false;
--- result:
 -- !result
 shell: ossutil64 rm -rf oss://${oss_bucket}/test_parquet_split_task/${uuid0}/ >/dev/null || echo "exit 0" >/dev/null
 -- result:

--- a/test/sql/test_external_file/R/test_parquet_split_task
+++ b/test/sql/test_external_file/R/test_parquet_split_task
@@ -37,6 +37,15 @@ select c1, count(1) from multi_stripes where c0 % 26 in (0, 25) group by c1 orde
 a	77
 z	76
 -- !result
+set connector_max_split_size = 64 * 1024 * 1024;
+-- result:
+[]
+-- !result
+select c1, count(1) from multi_stripes where c0 % 26 in (0, 25) group by c1 order by c1;
+-- result:
+a	77
+z	76
+-- !result
 shell: ossutil64 rm -rf oss://${oss_bucket}/test_parquet_split_task/${uuid0}/ >/dev/null || echo "exit 0" >/dev/null
 -- result:
 0

--- a/test/sql/test_external_file/T/test_orc_split_task
+++ b/test/sql/test_external_file/T/test_orc_split_task
@@ -16,7 +16,7 @@ PROPERTIES
 );
 
 set enable_connector_split_io_tasks = true;
+set connector_max_split_size = 64;
 select c1, count(1) from multi_stripes where c0 % 26 in (0, 25) group by c1 order by c1;
-set enable_connector_split_io_tasks = false;
 
 shell: ossutil64 rm -rf oss://${oss_bucket}/test_orc_split_task/${uuid0}/ >/dev/null || echo "exit 0" >/dev/null

--- a/test/sql/test_external_file/T/test_orc_split_task
+++ b/test/sql/test_external_file/T/test_orc_split_task
@@ -16,7 +16,12 @@ PROPERTIES
 );
 
 set enable_connector_split_io_tasks = true;
+
 set connector_max_split_size = 64;
 select c1, count(1) from multi_stripes where c0 % 26 in (0, 25) group by c1 order by c1;
+
+set connector_max_split_size = 64 * 1024 * 1024;
+select c1, count(1) from multi_stripes where c0 % 26 in (0, 25) group by c1 order by c1;
+
 
 shell: ossutil64 rm -rf oss://${oss_bucket}/test_orc_split_task/${uuid0}/ >/dev/null || echo "exit 0" >/dev/null

--- a/test/sql/test_external_file/T/test_parquet_split_task
+++ b/test/sql/test_external_file/T/test_parquet_split_task
@@ -16,7 +16,7 @@ PROPERTIES
 );
 
 set enable_connector_split_io_tasks = true;
+set connector_max_split_size = 64;
 select c1, count(1) from multi_stripes where c0 % 26 in (0, 25) group by c1 order by c1;
-set enable_connector_split_io_tasks = false;
 
 shell: ossutil64 rm -rf oss://${oss_bucket}/test_parquet_split_task/${uuid0}/ >/dev/null || echo "exit 0" >/dev/null

--- a/test/sql/test_external_file/T/test_parquet_split_task
+++ b/test/sql/test_external_file/T/test_parquet_split_task
@@ -16,7 +16,12 @@ PROPERTIES
 );
 
 set enable_connector_split_io_tasks = true;
+
 set connector_max_split_size = 64;
 select c1, count(1) from multi_stripes where c0 % 26 in (0, 25) group by c1 order by c1;
+
+set connector_max_split_size = 64 * 1024 * 1024;
+select c1, count(1) from multi_stripes where c0 % 26 in (0, 25) group by c1 order by c1;
+
 
 shell: ossutil64 rm -rf oss://${oss_bucket}/test_parquet_split_task/${uuid0}/ >/dev/null || echo "exit 0" >/dev/null


### PR DESCRIPTION
## Why I'm doing:

If stripes or row groups are very small, it's better to merge them into one to avoid creating too much io tasks.

## What I'm doing:

To merge tiny stripes or row groups
- we use `connector_max_split_size` passed from FE as threshold
- if stripes or row groups are not consecutive, then we take it as a cut point
- or if merged size is large enough, we cut it too.

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
