### PR TITLE
[BugFix] Fix inconsistent predicate rewrite for GIN index

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/Index.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/Index.java
@@ -34,9 +34,11 @@
 
 package com.starrocks.catalog;
 
+import com.google.common.base.Preconditions;
 import com.google.gson.annotations.SerializedName;
 import com.starrocks.analysis.IndexDef;
 import com.starrocks.analysis.IndexDef.IndexType;
+import com.starrocks.analysis.InvertedIndexUtil;
 import com.starrocks.common.InvertedIndexParams.CommonIndexParamKey;
 import com.starrocks.common.InvertedIndexParams.IndexParamsKey;
 import com.starrocks.common.InvertedIndexParams.SearchParamsKey;
@@ -152,6 +154,12 @@ public class Index implements Writable {
 
     public Map<String, String> getProperties() {
         return properties;
+    }
+
+    public boolean isNoTokenization() {
+        Preconditions.checkState(indexType == IndexDef.IndexType.GIN);
+        return !(properties.get(InvertedIndexUtil.INVERTED_INDEX_PARSER_KEY) ==
+            InvertedIndexUtil.INVERTED_INDEX_PARSER_NONE);
     }
 
     public void setProperties(Map<String, String> properties) {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/scalar/ColumnRefOperator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/scalar/ColumnRefOperator.java
@@ -34,6 +34,7 @@ public final class ColumnRefOperator extends ScalarOperator {
     private final int id;
     private final String name;
     private boolean nullable;
+    private boolean hasGinIndex = false;
 
     public ColumnRefOperator(int id, Type type, String name, boolean nullable) {
         super(OperatorType.VARIABLE, type);
@@ -184,5 +185,13 @@ public final class ColumnRefOperator extends ScalarOperator {
     @Override
     public String debugString() {
         return "col";
+    }
+
+    public void setHasGinIndex(boolean hasGinIndex) {
+        this.hasGinIndex = hasGinIndex;
+    }
+
+    public boolean hasGinIndex() {
+        return this.hasGinIndex;
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/transformer/RelationTransformer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/transformer/RelationTransformer.java
@@ -515,7 +515,7 @@ public class RelationTransformer implements AstVisitor<LogicalPlan, ExpressionMa
             if (node.getTable() instanceof OlapTable) {
                 for (Index index : ((OlapTable) node.getTable()).getIndexes()) {
                     if (index.getIndexType() == IndexDef.IndexType.GIN &&
-                            index.getColumns().contains(column.getKey().getName())) {
+                            index.isNoTokenization() && index.getColumns().contains(column.getKey().getName())) {
                         columnRef.setHasGinIndex(true);
                         break;
                     }

--- a/test/sql/test_inverted_index/R/test_inverted_index
+++ b/test/sql/test_inverted_index/R/test_inverted_index
@@ -840,3 +840,49 @@ SELECT * FROM t_clone_for_gin ORDER BY id1;
 1	abc
 2	ABC
 -- !result
+-- name: test_predicate_rewrite_for_gin
+CREATE TABLE `t_predicate_rewrite_for_gin` (
+  `id1` bigint(20) NOT NULL COMMENT "",
+  `text_column` varchar(255) NULL COMMENT "",
+  INDEX gin_english (`text_column`) USING GIN ("parser" = "english") COMMENT ""
+) ENGINE=OLAP
+DUPLICATE KEY(`id1`)
+DISTRIBUTED BY HASH(`id1`) BUCKETS 1
+PROPERTIES (
+"replication_num" = "1",
+"enable_persistent_index" = "false",
+"replicated_storage" = "false",
+"compression" = "LZ4"
+);
+-- result:
+-- !result
+INSERT INTO t_predicate_rewrite_for_gin VALUES (1, "starrocks is olap database");
+-- result:
+-- !result
+INSERT INTO t_predicate_rewrite_for_gin VALUES (2, "starrocks is database");
+-- result:
+-- !result
+SELECT * FROM t_predicate_rewrite_for_gin WHERE text_column LIKE "database" AND text_column LIKE "starrocks";
+-- result:
+1	starrocks is olap database
+2	starrocks is database
+-- !result
+SELECT * FROM t_predicate_rewrite_for_gin WHERE text_column = "database" AND text_column = "starrocks";
+-- result:
+1	starrocks is olap database
+2	starrocks is database
+-- !result
+SELECT * FROM t_predicate_rewrite_for_gin WHERE text_column = "database" AND text_column = "starrocks" AND id1 = 1;
+-- result:
+1	starrocks is olap database
+-- !result
+SELECT * FROM t_predicate_rewrite_for_gin WHERE text_column = "database" AND text_column = "starrocks" AND id1 = 2;
+-- result:
+2	starrocks is database
+-- !result
+SELECT * FROM t_predicate_rewrite_for_gin WHERE text_column = "database" AND text_column = "starrocks" AND id1 = 1 AND id1 = 2;
+-- result:
+-- !result
+DROP TABLE t_predicate_rewrite_for_gin;
+-- result:
+-- !result

--- a/test/sql/test_inverted_index/T/test_inverted_index
+++ b/test/sql/test_inverted_index/T/test_inverted_index
@@ -487,3 +487,29 @@ SELECT * FROM t_clone_for_gin ORDER BY id1;
 function: set_first_tablet_bad_and_recover("t_clone_for_gin")
 
 SELECT * FROM t_clone_for_gin ORDER BY id1;
+
+-- name: test_predicate_rewrite_for_gin
+CREATE TABLE `t_predicate_rewrite_for_gin` (
+  `id1` bigint(20) NOT NULL COMMENT "",
+  `text_column` varchar(255) NULL COMMENT "",
+  INDEX gin_english (`text_column`) USING GIN ("parser" = "english") COMMENT ""
+) ENGINE=OLAP
+DUPLICATE KEY(`id1`)
+DISTRIBUTED BY HASH(`id1`) BUCKETS 1
+PROPERTIES (
+"replication_num" = "1",
+"enable_persistent_index" = "false",
+"replicated_storage" = "false",
+"compression" = "LZ4"
+);
+
+INSERT INTO t_predicate_rewrite_for_gin VALUES (1, "starrocks is olap database");
+INSERT INTO t_predicate_rewrite_for_gin VALUES (2, "starrocks is database");
+
+SELECT * FROM t_predicate_rewrite_for_gin WHERE text_column LIKE "database" AND text_column LIKE "starrocks";
+SELECT * FROM t_predicate_rewrite_for_gin WHERE text_column = "database" AND text_column = "starrocks";
+SELECT * FROM t_predicate_rewrite_for_gin WHERE text_column = "database" AND text_column = "starrocks" AND id1 = 1;
+SELECT * FROM t_predicate_rewrite_for_gin WHERE text_column = "database" AND text_column = "starrocks" AND id1 = 2;
+SELECT * FROM t_predicate_rewrite_for_gin WHERE text_column = "database" AND text_column = "starrocks" AND id1 = 1 AND id1 = 2;
+
+DROP TABLE t_predicate_rewrite_for_gin;


### PR DESCRIPTION
## Why I'm doing:
For inverted index with parse mode english/standard/chinese The semantics of Eq predicate have changed as following:

For Eq predicate, = 'keyword' means that we want to match the 'keyword' for a row only, It is not necessary that the entire row equals 'keyword'. For example, for row 'keyword' or 'this is keyword', = 'keyword' can match both of them.

The problem is that, in this case, if we have a compound predicate like v = 'keyword1' AND v = 'keyword2' we can not rewrite it as empty set Because a row 'keyword1 keyword2' can match this predicate.

## What I'm doing:
1. Forcely rewrite Eq predicate in this case into LIKE predicate to prevent inconsistent predicate rewrite for Eq predicate.
2. Do not rewrite LIKE into Eq predicate if the column has GIN index.

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
