### PR TITLE
[BugFix] Fix parquet writer being closed when there is still unfinished task

### DIFF
--- a/be/src/formats/parquet/parquet_file_writer.cpp
+++ b/be/src/formats/parquet/parquet_file_writer.cpp
@@ -145,7 +145,6 @@ std::future<Status> ParquetFileWriter::_flush_row_group() {
     }
 
     if (_executors) {
-        std::cout << "add flush row group task" << std::endl;
         bool ok = _executors->try_offer(task);
         if (!ok) {
             Status exception = Status::ResourceBusy("submit close file task fails");

--- a/be/src/formats/parquet/parquet_file_writer.cpp
+++ b/be/src/formats/parquet/parquet_file_writer.cpp
@@ -67,7 +67,6 @@ std::future<FileWriter::CommitResult> ParquetFileWriter::commit() {
             // commit until all rowgroup flushing tasks have been done
             std::unique_lock lock(execution_state->mu);
             execution_state->cv.wait(lock, [&]() { return !execution_state->has_unfinished_task; });
-            std::cout << "commit" << std::endl;
         }
 
         FileWriter::CommitResult result{

--- a/be/src/formats/parquet/parquet_file_writer.cpp
+++ b/be/src/formats/parquet/parquet_file_writer.cpp
@@ -47,7 +47,7 @@ std::future<Status> ParquetFileWriter::write(ChunkPtr chunk) {
     if (auto status = _rowgroup_writer->write(chunk.get()); !status.ok()) {
         return make_ready_future(std::move(status));
     }
-    if (_rowgroup_writer->estimated_buffered_bytes() > _writer_options->rowgroup_size) {
+    if (_rowgroup_writer->estimated_buffered_bytes() >= _writer_options->rowgroup_size) {
         return _flush_row_group();
     }
     return make_ready_future(Status::OK());
@@ -59,10 +59,17 @@ std::future<FileWriter::CommitResult> ParquetFileWriter::commit() {
 
     auto task = [writer = _writer, output_stream = _output_stream, p = promise,
                  has_field_id = _writer_options->column_ids.has_value(), rollback = _rollback_action,
-                 location = _location, state = _runtime_state] {
+                 location = _location, state = _runtime_state, execution_state = _execution_state] {
 #ifndef BE_TEST
         SCOPED_THREAD_LOCAL_MEM_TRACKER_SETTER(state->instance_mem_tracker());
 #endif
+        {
+            // commit until all rowgroup flushing tasks have been done
+            std::unique_lock lock(execution_state->mu);
+            execution_state->cv.wait(lock, [&]() { return !execution_state->has_unfinished_task; });
+            std::cout << "commit" << std::endl;
+        }
+
         FileWriter::CommitResult result{
                 .io_status = Status::OK(), .format = PARQUET, .location = location, .rollback_action = rollback};
         try {
@@ -112,22 +119,34 @@ std::future<Status> ParquetFileWriter::_flush_row_group() {
     auto promise = std::make_shared<std::promise<Status>>();
     std::future<Status> future = promise->get_future();
 
-    auto task = [rowgroup_writer = _rowgroup_writer, p = promise, state = _runtime_state] {
+    auto task = [rowgroup_writer = _rowgroup_writer, p = promise, state = _runtime_state,
+                 execution_state = _execution_state] {
 #ifndef BE_TEST
         SCOPED_THREAD_LOCAL_MEM_TRACKER_SETTER(state->instance_mem_tracker());
 #endif
         try {
             rowgroup_writer->close();
+            p->set_value(Status::OK());
         } catch (const ::parquet::ParquetStatusException& e) {
             Status exception = Status::IOError(fmt::format("{}: {}", "flush rowgroup error", e.what()));
             LOG(WARNING) << exception;
             p->set_value(exception);
-            return;
         }
-        p->set_value(Status::OK());
+
+        {
+            std::lock_guard lock(execution_state->mu);
+            execution_state->has_unfinished_task = false;
+            execution_state->cv.notify_one();
+        }
     };
 
+    {
+        std::lock_guard lock(_execution_state->mu);
+        _execution_state->has_unfinished_task = true;
+    }
+
     if (_executors) {
+        std::cout << "add flush row group task" << std::endl;
         bool ok = _executors->try_offer(task);
         if (!ok) {
             Status exception = Status::ResourceBusy("submit close file task fails");

--- a/be/src/formats/parquet/parquet_file_writer.h
+++ b/be/src/formats/parquet/parquet_file_writer.h
@@ -107,6 +107,14 @@ private:
     const std::function<void()> _rollback_action;
     PriorityThreadPool* _executors = nullptr;
     RuntimeState* _runtime_state = nullptr;
+
+    struct ExecutionState {
+        std::mutex mu;
+        std::condition_variable cv;
+        bool has_unfinished_task = false;
+    };
+
+    std::shared_ptr<ExecutionState> _execution_state = std::make_shared<ExecutionState>();
 };
 
 class ParquetFileWriterFactory : public FileWriterFactory {

--- a/be/test/formats/parquet/parquet_file_writer_test.cpp
+++ b/be/test/formats/parquet/parquet_file_writer_test.cpp
@@ -872,7 +872,7 @@ TEST_F(ParquetFileWriterTest, TestFlushRowgroupWithExecutors) {
     auto executors = PriorityThreadPool("test", 1, 10);
     auto writer = std::make_unique<formats::ParquetFileWriter>(
             _file_path, std::move(output_stream), column_names, type_descs, std::move(column_evaluators),
-            TCompressionType::NO_COMPRESSION, writer_options, []() {}, nullptr, nullptr);
+            TCompressionType::NO_COMPRESSION, writer_options, []() {}, &executors, nullptr);
     ASSERT_OK(writer->init());
 
     auto chunk = std::make_shared<Chunk>();
@@ -894,6 +894,41 @@ TEST_F(ParquetFileWriterTest, TestFlushRowgroupWithExecutors) {
 
     ASSERT_TRUE(result.io_status.ok());
     ASSERT_EQ(result.file_statistics.record_count, 8);
+}
+
+TEST_F(ParquetFileWriterTest, TestFlushRowgroupAndCommitDependency) {
+    auto type_bool = TypeDescriptor::from_logical_type(TYPE_BOOLEAN);
+    std::vector<TypeDescriptor> type_descs{type_bool};
+
+    auto column_names = _make_type_names(type_descs);
+    auto output_file = _fs.new_writable_file(_file_path).value();
+    auto output_stream = std::make_unique<parquet::ParquetOutputStream>(std::move(output_file));
+    auto column_evaluators = ColumnSlotIdEvaluator::from_types(type_descs);
+    auto writer_options = std::make_shared<formats::ParquetWriterOptions>();
+    writer_options->rowgroup_size = 1;
+    auto executors = PriorityThreadPool("test", 2, 10);
+    auto writer = std::make_unique<formats::ParquetFileWriter>(
+            _file_path, std::move(output_stream), column_names, type_descs, std::move(column_evaluators),
+            TCompressionType::NO_COMPRESSION, writer_options, []() {}, &executors, nullptr);
+    ASSERT_OK(writer->init());
+
+    auto chunk = std::make_shared<Chunk>();
+    {
+        auto data_column = BooleanColumn::create();
+        std::vector<uint8_t> values = {0, 1, 1, 0};
+        data_column->append_numbers(values.data(), values.size() * sizeof(uint8_t));
+        auto null_column = UInt8Column::create();
+        std::vector<uint8_t> nulls = {1, 0, 1, 0};
+        null_column->append_numbers(nulls.data(), nulls.size());
+        auto nullable_column = NullableColumn::create(data_column, null_column);
+        chunk->append_column(nullable_column, chunk->num_columns());
+    }
+
+    auto f = writer->write(chunk);
+    auto result = writer->commit().get();
+    ASSERT_TRUE(f.get().ok());
+    ASSERT_TRUE(result.io_status.ok());
+    ASSERT_EQ(result.file_statistics.record_count, 4);
 }
 
 TEST_F(ParquetFileWriterTest, TestWriteWithFieldID) {


### PR DESCRIPTION
## Why I'm doing:

`rowgroup_writer` will be invalid to access after `writer` is closed. Therefore, we should add a dependency that `writer` will only be closed after all async io tasks are finished. 

For example, 2 tasks
- `task1` (flush rowgroup 1)
- `task2` (close writer)

We have to make sure `task2` is executed after `task1` is done.

## What I'm doing:

Introduce `ExecutionState`, which records if any task is unfinished. The `commit io task` will only be executed when other tasks are all finished.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
