### PR TITLE
[BugFix] SyncPoint only takes effect in unit test

### DIFF
--- a/be/src/testutil/sync_point.cc
+++ b/be/src/testutil/sync_point.cc
@@ -28,7 +28,7 @@
 
 std::vector<std::string> starrocks_kill_exclude_prefixes;
 
-#if !defined(NDEBUG) || defined(BE_TEST)
+#if defined(BE_TEST)
 namespace starrocks {
 
 SyncPoint* SyncPoint::GetInstance() {
@@ -80,4 +80,4 @@ void SyncPoint::Process(const std::string_view& point, void* cb_arg) {
 }
 
 } // namespace starrocks
-#endif // NDEBUG
+#endif

--- a/be/src/testutil/sync_point.h
+++ b/be/src/testutil/sync_point.h
@@ -32,7 +32,7 @@
 
 #include "util/slice.h"
 
-#if defined(NDEBUG) && !defined(BE_TEST)
+#if !defined(BE_TEST)
 // empty in release build
 #define TEST_KILL_RANDOM_WITH_WEIGHT(kill_point, starrock_skill_odds_weight)
 #define TEST_KILL_RANDOM(kill_point)
@@ -190,7 +190,7 @@ private:
 // Callback sync point for any read IO errors that should be ignored by
 // the fault injection framework
 // Disable in release mode
-#if defined(NDEBUG) && !defined(BE_TEST)
+#if !defined(BE_TEST)
 #define IGNORE_STATUS_IF_ERROR(_status_)
 #else
 #define IGNORE_STATUS_IF_ERROR(_status_)                  \

--- a/be/src/testutil/sync_point.h
+++ b/be/src/testutil/sync_point.h
@@ -66,7 +66,7 @@ public:
 
 #endif
 
-#if defined(NDEBUG) && !defined(BE_TEST)
+#if !defined(BE_TEST)
 #define TEST_SYNC_POINT(x)
 #define TEST_IDX_SYNC_POINT(x, index)
 #define TEST_SYNC_POINT_CALLBACK(x, y)
@@ -178,7 +178,7 @@ private:
     } while (0)
 #define TEST_SUCC_POINT(x)                                    \
     do {                                                      \
-        Status st;                                            \
+        Status st = Status::InternalError("Default error");   \
         starrocks::SyncPoint::GetInstance()->Process(x, &st); \
         if (st.ok()) return st;                               \
     } while (0)

--- a/be/src/testutil/sync_point_impl.cc
+++ b/be/src/testutil/sync_point_impl.cc
@@ -27,7 +27,7 @@
 
 #include <csignal>
 
-#if !defined(NDEBUG) || defined(BE_TEST)
+#if defined(BE_TEST)
 namespace starrocks {
 KillPoint* KillPoint::GetInstance() {
     static KillPoint kp;

--- a/be/src/testutil/sync_point_impl.h
+++ b/be/src/testutil/sync_point_impl.h
@@ -36,7 +36,7 @@
 
 #pragma once
 
-#if !defined(NDEBUG) || defined(BE_TEST)
+#if defined(BE_TEST)
 namespace starrocks {
 
 struct SyncPoint::Data {
@@ -81,4 +81,4 @@ struct SyncPoint::Data {
     void Process(const std::string_view& point, void* cb_arg);
 };
 } // namespace starrocks
-#endif // NDEBUG
+#endif

--- a/be/test/exec/pipeline/olap_scan_operator_test.cpp
+++ b/be/test/exec/pipeline/olap_scan_operator_test.cpp
@@ -62,9 +62,8 @@ void OlapScanOperatorTest::SetUp() {
 
 TEST_F(OlapScanOperatorTest, test_finish_sequence) {
     SyncPoint::GetInstance()->EnableProcessing();
-    SyncPoint::GetInstance()->SetCallBack("OlapScanPrepareOperator::prepare", [](void* arg) {
-        *(Status*)arg = Status::OK();
-    });
+    SyncPoint::GetInstance()->SetCallBack("OlapScanPrepareOperator::prepare",
+                                          [](void* arg) { *(Status*)arg = Status::OK(); });
     SyncPoint::GetInstance()->SetCallBack("ScanOperatorFactory::prepare", [](void* arg) {});
     SyncPoint::GetInstance()->SetCallBack("OlapScanContext::parse_conjuncts",
                                           [](void* arg) { *(Status*)arg = Status::EndOfFile(""); });

--- a/be/test/exec/pipeline/olap_scan_operator_test.cpp
+++ b/be/test/exec/pipeline/olap_scan_operator_test.cpp
@@ -62,7 +62,9 @@ void OlapScanOperatorTest::SetUp() {
 
 TEST_F(OlapScanOperatorTest, test_finish_sequence) {
     SyncPoint::GetInstance()->EnableProcessing();
-    SyncPoint::GetInstance()->SetCallBack("OlapScanPrepareOperator::prepare", [](void* arg) {});
+    SyncPoint::GetInstance()->SetCallBack("OlapScanPrepareOperator::prepare", [](void* arg) {
+        *(Status*)arg = Status::OK();
+    });
     SyncPoint::GetInstance()->SetCallBack("ScanOperatorFactory::prepare", [](void* arg) {});
     SyncPoint::GetInstance()->SetCallBack("OlapScanContext::parse_conjuncts",
                                           [](void* arg) { *(Status*)arg = Status::EndOfFile(""); });

--- a/be/test/exec/pipeline/olap_scan_operator_test.cpp
+++ b/be/test/exec/pipeline/olap_scan_operator_test.cpp
@@ -62,9 +62,12 @@ void OlapScanOperatorTest::SetUp() {
 
 TEST_F(OlapScanOperatorTest, test_finish_sequence) {
     SyncPoint::GetInstance()->EnableProcessing();
-    SyncPoint::GetInstance()->SetCallBack("OlapScanPrepareOperator::prepare",
-                                          [](void* arg) { *(Status*)arg = Status::OK(); });
-    SyncPoint::GetInstance()->SetCallBack("ScanOperatorFactory::prepare", [](void* arg) {});
+    SyncPoint::GetInstance()->SetCallBack("OlapScanPrepareOperator::prepare", [](void* arg) {
+        *(Status*)arg = Status::OK();
+    });
+    SyncPoint::GetInstance()->SetCallBack("ScanOperatorFactory::prepare", [](void* arg) {
+        *(Status*)arg = Status::OK();
+    });
     SyncPoint::GetInstance()->SetCallBack("OlapScanContext::parse_conjuncts",
                                           [](void* arg) { *(Status*)arg = Status::EndOfFile(""); });
 

--- a/be/test/exec/pipeline/olap_scan_operator_test.cpp
+++ b/be/test/exec/pipeline/olap_scan_operator_test.cpp
@@ -62,12 +62,10 @@ void OlapScanOperatorTest::SetUp() {
 
 TEST_F(OlapScanOperatorTest, test_finish_sequence) {
     SyncPoint::GetInstance()->EnableProcessing();
-    SyncPoint::GetInstance()->SetCallBack("OlapScanPrepareOperator::prepare", [](void* arg) {
-        *(Status*)arg = Status::OK();
-    });
-    SyncPoint::GetInstance()->SetCallBack("ScanOperatorFactory::prepare", [](void* arg) {
-        *(Status*)arg = Status::OK();
-    });
+    SyncPoint::GetInstance()->SetCallBack("OlapScanPrepareOperator::prepare",
+                                          [](void* arg) { *(Status*)arg = Status::OK(); });
+    SyncPoint::GetInstance()->SetCallBack("ScanOperatorFactory::prepare",
+                                          [](void* arg) { *(Status*)arg = Status::OK(); });
     SyncPoint::GetInstance()->SetCallBack("OlapScanContext::parse_conjuncts",
                                           [](void* arg) { *(Status*)arg = Status::EndOfFile(""); });
 


### PR DESCRIPTION
## Why I'm doing:

SyncPoint only takes effect in a single test.

Change default return value of TEST_SUCC_POINT from OK to InternalError.

## What I'm doing:

SyncPoint only takes effect in a single test.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [x] 3.1
  - [x] 3.0
  - [ ] 2.5
