### PR TITLE
[Enhancement] Skip to write Iceberg table/column comment if comment is empty

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergApiConverter.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergApiConverter.java
@@ -30,6 +30,7 @@ import com.starrocks.thrift.TIcebergColumnStats;
 import com.starrocks.thrift.TIcebergDataFile;
 import com.starrocks.thrift.TIcebergSchema;
 import com.starrocks.thrift.TIcebergSchemaField;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.iceberg.FileFormat;
 import org.apache.iceberg.Metrics;
 import org.apache.iceberg.PartitionSpec;
@@ -84,8 +85,9 @@ public class IcebergApiConverter {
         for (Column column : columns) {
             int index = icebergColumns.size();
             org.apache.iceberg.types.Type type = toIcebergColumnType(column.getType());
+            String colComment = StringUtils.defaultIfBlank(column.getComment(), null);
             Types.NestedField field = Types.NestedField.of(
-                    index, column.isAllowNull(), column.getName(), type, column.getComment());
+                    index, column.isAllowNull(), column.getName(), type, colComment);
             icebergColumns.add(field);
         }
 

--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergMetadata.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergMetadata.java
@@ -225,7 +225,10 @@ public class IcebergMetadata implements ConnectorMetadata {
         PartitionSpec partitionSpec = parsePartitionFields(schema, partitionColNames);
         Map<String, String> properties = stmt.getProperties() == null ? new HashMap<>() : stmt.getProperties();
         String tableLocation = properties.get(LOCATION_PROPERTY);
-        properties.put(COMMENT, stmt.getComment());
+        String comment = stmt.getComment();
+        if (comment != null && !comment.isEmpty()) {
+            properties.put(COMMENT, comment);
+        }
         Map<String, String> createTableProperties = IcebergApiConverter.rebuildCreateTableProperties(properties);
 
         return icebergCatalog.createTable(dbName, tableName, schema, partitionSpec, tableLocation, createTableProperties);

--- a/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/IcebergApiConverterTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/IcebergApiConverterTest.java
@@ -192,22 +192,22 @@ public class IcebergApiConverterTest {
 
         Schema schema = IcebergApiConverter.toIcebergApiSchema(columns);
         Assert.assertEquals("table {\n" +
-                "  1: c1: required boolean ()\n" +
-                "  2: c2: required int ()\n" +
-                "  3: c3: required long ()\n" +
-                "  4: c4: required float ()\n" +
-                "  5: c5: required double ()\n" +
-                "  6: c6: required date ()\n" +
-                "  7: c7: required timestamp ()\n" +
-                "  8: c8: required string ()\n" +
-                "  9: c9: required string ()\n" +
-                "  10: c10: required decimal(-1, -1) ()\n" +
-                "  11: c11: required decimal(-1, -1) ()\n" +
-                "  12: c12: required decimal(-1, -1) ()\n" +
-                "  13: c13: required list<int> ()\n" +
-                "  14: c14: required map<int, int> ()\n" +
-                "  15: c15: required struct<20: col1: optional int> ()\n" +
-                "  16: c16: required time ()\n" +
+                "  1: c1: required boolean\n" +
+                "  2: c2: required int\n" +
+                "  3: c3: required long\n" +
+                "  4: c4: required float\n" +
+                "  5: c5: required double\n" +
+                "  6: c6: required date\n" +
+                "  7: c7: required timestamp\n" +
+                "  8: c8: required string\n" +
+                "  9: c9: required string\n" +
+                "  10: c10: required decimal(-1, -1)\n" +
+                "  11: c11: required decimal(-1, -1)\n" +
+                "  12: c12: required decimal(-1, -1)\n" +
+                "  13: c13: required list<int>\n" +
+                "  14: c14: required map<int, int>\n" +
+                "  15: c15: required struct<20: col1: optional int>\n" +
+                "  16: c16: required time\n" +
                 "}", schema.toString());
 
         PartitionSpec spec = IcebergApiConverter.parsePartitionFields(schema, Lists.newArrayList("c1"));


### PR DESCRIPTION

## Why I'm doing:
 StarRocks will set the table comment to empty by default, but the empty comment is valid in iceberg table, and this will make other engines(Hive/Trino/Spark) display the useless empty comment when show create table.

## What I'm doing:
Like https://github.com/StarRocks/starrocks/pull/39683 , we need to skip to write the empty comment to avoid the useless comment and then other engines(Hive/Trino/Spark) won't dispaly the useless empty comment.
Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
