### PR TITLE
[Tool] Fix the workflow not be triggered by GITHUB_TOKEN

### DIFF
--- a/.github/workflows/ci-proto-checker.yml
+++ b/.github/workflows/ci-proto-checker.yml
@@ -45,12 +45,12 @@ jobs:
         uses: actions-ecosystem/action-add-labels@v1
         if: needs.proto-checker.outputs.output1 == 'true'
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
+          github_token: ${{ secrets.PAT }}
           labels: PROTO-REVIEW
 
       - name: remove label
         uses: actions-ecosystem/action-remove-labels@v1
         if: needs.proto-checker.outputs.output1 != 'true'
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
+          github_token: ${{ secrets.PAT }}
           labels: PROTO-REVIEW

--- a/.github/workflows/pr-checker.yml
+++ b/.github/workflows/pr-checker.yml
@@ -273,12 +273,14 @@ jobs:
         uses: actions-ecosystem/action-add-labels@v1
         with:
           labels: 'feature'
+          github_token: ${{ secrets.PAT }}
 
       - name: remove feature label
         if: always() && steps.add.outcome == 'skipped'
         uses: actions-ecosystem/action-remove-labels@v1
         with:
           labels: 'feature'
+          github_token: ${{ secrets.PAT }}
 
   changelist-check:
     runs-on: [self-hosted, normal]
@@ -288,7 +290,7 @@ jobs:
       !contains(github.event.pull_request.title, 'backport')
     env:
       PR_NUMBER: ${{ github.event.number }}
-      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      GH_TOKEN: ${{ secrets.PAT }}
     steps:
       - name: CHECK CHANGELIST
         run: |


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [x] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
