### PR TITLE
[BugFix] fix profile cause gray upgrade fail's problem

### DIFF
--- a/be/src/connector/file_connector.cpp
+++ b/be/src/connector/file_connector.cpp
@@ -174,7 +174,7 @@ void FileDataSource::_init_counter() {
     _scanner_total_timer = ADD_TIMER(_runtime_profile, "ScannerTotalTime");
     {
         static const char* prefix = "FileScanner";
-        ADD_COUNTER(_runtime_profile, prefix, TUnit::NONE);
+        ADD_COUNTER(_runtime_profile, prefix, TUnit::UNIT);
         RuntimeProfile* p = _runtime_profile;
         _scanner_fill_timer = ADD_CHILD_TIMER(p, "FillTime", prefix);
         _scanner_read_timer = ADD_CHILD_TIMER(p, "ReadTime", prefix);

--- a/be/src/connector/hive_connector.cpp
+++ b/be/src/connector/hive_connector.cpp
@@ -361,7 +361,7 @@ void HiveDataSource::_init_counter(RuntimeState* state) {
 
     {
         static const char* prefix = "SharedBuffered";
-        ADD_COUNTER(_runtime_profile, prefix, TUnit::NONE);
+        ADD_COUNTER(_runtime_profile, prefix, TUnit::UNIT);
         _profile.shared_buffered_shared_io_bytes =
                 ADD_CHILD_COUNTER(_runtime_profile, "SharedIOBytes", TUnit::BYTES, prefix);
         _profile.shared_buffered_shared_align_io_bytes =
@@ -378,7 +378,7 @@ void HiveDataSource::_init_counter(RuntimeState* state) {
 
     if (_use_block_cache) {
         static const char* prefix = "BlockCache";
-        ADD_COUNTER(_runtime_profile, prefix, TUnit::NONE);
+        ADD_COUNTER(_runtime_profile, prefix, TUnit::UNIT);
         _profile.block_cache_read_counter =
                 ADD_CHILD_COUNTER(_runtime_profile, "BlockCacheReadCounter", TUnit::UNIT, prefix);
         _profile.block_cache_read_bytes =
@@ -401,7 +401,7 @@ void HiveDataSource::_init_counter(RuntimeState* state) {
 
     {
         static const char* prefix = "InputStream";
-        ADD_COUNTER(_runtime_profile, prefix, TUnit::NONE);
+        ADD_COUNTER(_runtime_profile, prefix, TUnit::UNIT);
         _profile.app_io_bytes_read_counter =
                 ADD_CHILD_COUNTER(_runtime_profile, "AppIOBytesRead", TUnit::BYTES, prefix);
         _profile.app_io_timer = ADD_CHILD_TIMER(_runtime_profile, "AppIOTime", prefix);

--- a/be/src/connector/lake_connector.cpp
+++ b/be/src/connector/lake_connector.cpp
@@ -568,7 +568,7 @@ void LakeDataSource::init_counter(RuntimeState* state) {
     // IOTime
     _io_timer = ADD_TIMER(_runtime_profile, "IOTime");
     const std::string io_statistics_name = "IOStatistics";
-    ADD_COUNTER(_runtime_profile, io_statistics_name, TUnit::NONE);
+    ADD_COUNTER(_runtime_profile, io_statistics_name, TUnit::UNIT);
     // Page count
     _pages_count_memory_counter =
             ADD_CHILD_COUNTER(_runtime_profile, "PagesCountMemory", TUnit::UNIT, io_statistics_name);

--- a/be/src/exec/hdfs_scanner.cpp
+++ b/be/src/exec/hdfs_scanner.cpp
@@ -268,7 +268,7 @@ Status HdfsScanner::open_random_access_file() {
 
 void HdfsScanner::do_update_iceberg_v2_counter(RuntimeProfile* parent_profile, const std::string& parent_name) {
     const std::string ICEBERG_TIMER = "IcebergV2FormatTimer";
-    ADD_CHILD_COUNTER(parent_profile, ICEBERG_TIMER, TUnit::NONE, parent_name);
+    ADD_CHILD_COUNTER(parent_profile, ICEBERG_TIMER, TUnit::UNIT, parent_name);
 
     RuntimeProfile::Counter* delete_build_timer =
             ADD_CHILD_COUNTER(parent_profile, "DeleteFileBuildTime", TUnit::TIME_NS, ICEBERG_TIMER);
@@ -301,7 +301,7 @@ void HdfsScanner::update_hdfs_counter(HdfsScanProfile* profile) {
     if (statistics == nullptr || statistics->size() == 0) return;
 
     RuntimeProfile* runtime_profile = profile->runtime_profile;
-    ADD_COUNTER(profile->runtime_profile, kHdfsIOProfileSectionPrefix, TUnit::NONE);
+    ADD_COUNTER(profile->runtime_profile, kHdfsIOProfileSectionPrefix, TUnit::UNIT);
 
     for (int64_t i = 0, sz = statistics->size(); i < sz; i++) {
         auto&& name = statistics->name(i);

--- a/be/src/exec/hdfs_scanner_orc.cpp
+++ b/be/src/exec/hdfs_scanner_orc.cpp
@@ -563,7 +563,7 @@ void HdfsOrcScanner::do_update_counter(HdfsScanProfile* profile) {
     const std::string orcProfileSectionPrefix = "ORC";
 
     RuntimeProfile* root_profile = profile->runtime_profile;
-    ADD_COUNTER(root_profile, orcProfileSectionPrefix, TUnit::NONE);
+    ADD_COUNTER(root_profile, orcProfileSectionPrefix, TUnit::UNIT);
 
     do_update_iceberg_v2_counter(root_profile, orcProfileSectionPrefix);
 

--- a/be/src/exec/hdfs_scanner_parquet.cpp
+++ b/be/src/exec/hdfs_scanner_parquet.cpp
@@ -63,7 +63,7 @@ void HdfsParquetScanner::do_update_counter(HdfsScanProfile* profile) {
     RuntimeProfile::Counter* page_skip = nullptr;
 
     RuntimeProfile* root = profile->runtime_profile;
-    ADD_COUNTER(root, kParquetProfileSectionPrefix, TUnit::NONE);
+    ADD_COUNTER(root, kParquetProfileSectionPrefix, TUnit::UNIT);
     request_bytes_read = ADD_CHILD_COUNTER(root, "RequestBytesRead", TUnit::BYTES, kParquetProfileSectionPrefix);
     request_bytes_read_uncompressed =
             ADD_CHILD_COUNTER(root, "RequestBytesReadUncompressed", TUnit::BYTES, kParquetProfileSectionPrefix);

--- a/be/src/exec/spill/spiller.cpp
+++ b/be/src/exec/spill/spiller.cpp
@@ -44,7 +44,7 @@ SpillProcessMetrics::SpillProcessMetrics(RuntimeProfile* profile, std::atomic_in
     total_spill_bytes = total_spill_bytes_;
 
     std::string parent = "SpillStatistics";
-    ADD_COUNTER(profile, parent, TUnit::NONE);
+    ADD_COUNTER(profile, parent, TUnit::UNIT);
 
     append_data_timer = ADD_CHILD_TIMER(profile, "AppendDataTime", parent);
     spill_rows = ADD_CHILD_COUNTER(profile, "RowsSpilled", TUnit::UNIT, parent);


### PR DESCRIPTION
## Why I'm doing:
1 fe 3be, when upgrade one be from 3.0 to 3.1, be's profile has type "TUnit::NONE", but 3.0 FE can not handle this type and throw exception, which cause import data fail. 

## What I'm doing:
In 3.1, change any usage of TUnit::NONE into TUnit::UNIT, but keep logic of Handle TUnit::NONE in 3.1 FE. so when upgrade from 3.0 -> 3.1, be won't offer TUnit::NONE. when upgrade from 3.1 to 3.2, 3.2be will offer TUnit::NONE, but 3.1FE can hanle it. 

TUnit::NONE :
```
- IOTaskExecTime: 2s242ms
               - FileScanner
                 - CastChunkTime: 0ns
                 - CreateChunkTime: 118.542us
                 - FileReadTime: 2s168ms
                 - FillTime: 47.808ms
                 - MaterializeTime: 192.161us
                 - ReadTime: 0ns
               - ScannerTotalTime: 2s241ms
```
TUnit::Unit:
```
- IOTaskExecTime: 2s242ms
               - FileScanner: 0
                 - CastChunkTime: 0ns
                 - CreateChunkTime: 118.542us
                 - FileReadTime: 2s168ms
                 - FillTime: 47.808ms
                 - MaterializeTime: 192.161us
                 - ReadTime: 0ns
               - ScannerTotalTime: 2s241ms
```

Fixes https://github.com/StarRocks/StarRocksTest/issues/6713

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
- [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5

