### PR TITLE
[Enhancement] Support runtime profile for broker load

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/load/loadv2/LoadLoadingTask.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/loadv2/LoadLoadingTask.java
@@ -159,6 +159,56 @@ public class LoadLoadingTask extends LoadTask {
         return new DefaultCoordinator.Factory();
     }
 
+    public RuntimeProfile buildTopLevelProfile() {
+        RuntimeProfile profile = new RuntimeProfile("Load");
+        RuntimeProfile summaryProfile = new RuntimeProfile("Summary");
+        summaryProfile.addInfoString(ProfileManager.QUERY_ID, DebugUtil.printId(getLoadId()));
+        summaryProfile.addInfoString(ProfileManager.START_TIME,
+                TimeUtils.longToTimeString(createTimestamp));
+
+        long currentTimestamp = System.currentTimeMillis();
+        long totalTimeMs = currentTimestamp - createTimestamp;
+        summaryProfile.addInfoString(ProfileManager.END_TIME, TimeUtils.longToTimeString(currentTimestamp));
+        summaryProfile.addInfoString(ProfileManager.TOTAL_TIME, DebugUtil.getPrettyStringMs(totalTimeMs));
+
+        summaryProfile.addInfoString(ProfileManager.QUERY_TYPE, "Load");
+        summaryProfile.addInfoString(ProfileManager.QUERY_STATE,
+                GlobalStateMgr.getCurrentState().getGlobalTransactionMgr().getTransactionState(
+                        db.getId(), txnId).getTransactionStatus().isFinalStatus() ? "Finished" : "Running");
+        summaryProfile.addInfoString("StarRocks Version",
+                String.format("%s-%s", Version.STARROCKS_VERSION, Version.STARROCKS_COMMIT_HASH));
+        summaryProfile.addInfoString(ProfileManager.USER, context.getQualifiedUser());
+        summaryProfile.addInfoString(ProfileManager.DEFAULT_DB, context.getDatabase());
+        summaryProfile.addInfoString(ProfileManager.SQL_STATEMENT, originStmt.originStmt);
+
+        SessionVariable variables = context.getSessionVariable();
+        if (variables != null) {
+            StringBuilder sb = new StringBuilder();
+            sb.append("load_parallel_instance_num=").append(Config.load_parallel_instance_num).append(",");
+            sb.append(SessionVariable.PARALLEL_FRAGMENT_EXEC_INSTANCE_NUM).append("=")
+                    .append(variables.getParallelExecInstanceNum()).append(",");
+            sb.append(SessionVariable.MAX_PARALLEL_SCAN_INSTANCE_NUM).append("=")
+                    .append(variables.getMaxParallelScanInstanceNum()).append(",");
+            sb.append(SessionVariable.PIPELINE_DOP).append("=").append(variables.getPipelineDop()).append(",");
+            sb.append(SessionVariable.ENABLE_ADAPTIVE_SINK_DOP).append("=")
+                    .append(variables.getEnableAdaptiveSinkDop())
+                    .append(",");
+            if (context.getResourceGroup() != null) {
+                sb.append(SessionVariable.RESOURCE_GROUP).append("=")
+                        .append(context.getResourceGroup().getName())
+                        .append(",");
+            }
+            sb.deleteCharAt(sb.length() - 1);
+            summaryProfile.addInfoString(ProfileManager.VARIABLES, sb.toString());
+
+            summaryProfile.addInfoString("NonDefaultSessionVariables", variables.getNonDefaultVariablesJson());
+        }
+
+        profile.addChild(summaryProfile);
+
+        return profile;
+    }
+
     private void executeOnce() throws Exception {
         checkMeta();
 
@@ -166,6 +216,8 @@ public class LoadLoadingTask extends LoadTask {
         Coordinator curCoordinator;
         curCoordinator = getCoordinatorFactory().createBrokerLoadScheduler(loadPlanner);
         curCoordinator.setLoadJobType(loadJobType);
+        curCoordinator.setExecPlan(loadPlanner.getExecPlan());
+        curCoordinator.setTopProfileSupplier(this::buildTopLevelProfile);
 
         try {
             QeProcessorImpl.INSTANCE.registerQuery(loadId, curCoordinator);
@@ -173,49 +225,7 @@ public class LoadLoadingTask extends LoadTask {
             actualExecute(curCoordinator);
 
             if (context.getSessionVariable().isEnableProfile()) {
-                RuntimeProfile profile = new RuntimeProfile("Load");
-                RuntimeProfile summaryProfile = new RuntimeProfile("Summary");
-                summaryProfile.addInfoString(ProfileManager.QUERY_ID, DebugUtil.printId(context.getExecutionId()));
-                summaryProfile.addInfoString(ProfileManager.START_TIME,
-                        TimeUtils.longToTimeString(createTimestamp));
-
-                long currentTimestamp = System.currentTimeMillis();
-                long totalTimeMs = currentTimestamp - createTimestamp;
-                summaryProfile.addInfoString(ProfileManager.END_TIME, TimeUtils.longToTimeString(currentTimestamp));
-                summaryProfile.addInfoString(ProfileManager.TOTAL_TIME, DebugUtil.getPrettyStringMs(totalTimeMs));
-
-                summaryProfile.addInfoString(ProfileManager.QUERY_TYPE, "Load");
-                summaryProfile.addInfoString(ProfileManager.QUERY_STATE, context.getState().toString());
-                summaryProfile.addInfoString("StarRocks Version",
-                        String.format("%s-%s", Version.STARROCKS_VERSION, Version.STARROCKS_COMMIT_HASH));
-                summaryProfile.addInfoString(ProfileManager.USER, context.getQualifiedUser());
-                summaryProfile.addInfoString(ProfileManager.DEFAULT_DB, context.getDatabase());
-                summaryProfile.addInfoString(ProfileManager.SQL_STATEMENT, originStmt.originStmt);
-
-                SessionVariable variables = context.getSessionVariable();
-                if (variables != null) {
-                    StringBuilder sb = new StringBuilder();
-                    sb.append("load_parallel_instance_num=").append(Config.load_parallel_instance_num).append(",");
-                    sb.append(SessionVariable.PARALLEL_FRAGMENT_EXEC_INSTANCE_NUM).append("=")
-                            .append(variables.getParallelExecInstanceNum()).append(",");
-                    sb.append(SessionVariable.MAX_PARALLEL_SCAN_INSTANCE_NUM).append("=")
-                            .append(variables.getMaxParallelScanInstanceNum()).append(",");
-                    sb.append(SessionVariable.PIPELINE_DOP).append("=").append(variables.getPipelineDop()).append(",");
-                    sb.append(SessionVariable.ENABLE_ADAPTIVE_SINK_DOP).append("=")
-                            .append(variables.getEnableAdaptiveSinkDop())
-                            .append(",");
-                    if (context.getResourceGroup() != null) {
-                        sb.append(SessionVariable.RESOURCE_GROUP).append("=")
-                                .append(context.getResourceGroup().getName())
-                                .append(",");
-                    }
-                    sb.deleteCharAt(sb.length() - 1);
-                    summaryProfile.addInfoString(ProfileManager.VARIABLES, sb.toString());
-
-                    summaryProfile.addInfoString("NonDefaultSessionVariables", variables.getNonDefaultVariablesJson());
-                }
-
-                profile.addChild(summaryProfile);
+                RuntimeProfile profile = buildTopLevelProfile();
 
                 curCoordinator.getQueryProfile().getCounterTotalTime()
                         .setValue(TimeUtils.getEstimatedTime(beginTimeInNanoSecond));
@@ -224,7 +234,8 @@ public class LoadLoadingTask extends LoadTask {
 
                 StringBuilder builder = new StringBuilder();
                 profile.prettyPrint(builder, "");
-                String profileContent = ProfileManager.getInstance().pushProfile(null, profile);
+                String profileContent = ProfileManager.getInstance().pushProfile(
+                        loadPlanner.getExecPlan().getProfilingPlan(), profile);
                 if (context.getQueryDetail() != null) {
                     context.getQueryDetail().setProfile(profileContent);
                 }

--- a/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/QueryRuntimeProfile.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/QueryRuntimeProfile.java
@@ -278,6 +278,7 @@ public class QueryRuntimeProfile {
             profile.addChild(buildQueryProfile(connectContext.needMergeProfile()));
             ProfilingExecPlan profilingPlan = plan.getProfilingPlan();
             saveRunningProfile(profilingPlan, profile);
+            LOG.debug("update profile, profilingPlan: {}, profile: {}", profilingPlan, profile);
         }
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ExplainAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ExplainAnalyzer.java
@@ -161,7 +161,7 @@ public class ExplainAnalyzer {
     }
 
     public String analyze() {
-        if (plan == null || summaryProfile == null || plannerProfile == null || executionProfile == null) {
+        if (plan == null || summaryProfile == null || executionProfile == null) {
             return null;
         }
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/LoadPlanner.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/LoadPlanner.java
@@ -61,6 +61,7 @@ import com.starrocks.sql.ast.ImportColumnDesc;
 import com.starrocks.sql.ast.PartitionNames;
 import com.starrocks.sql.optimizer.statistics.ColumnDict;
 import com.starrocks.sql.optimizer.statistics.IDictManager;
+import com.starrocks.sql.plan.ExecPlan;
 import com.starrocks.thrift.TBrokerFileStatus;
 import com.starrocks.thrift.TPartialUpdateMode;
 import com.starrocks.thrift.TPartitionType;
@@ -593,6 +594,10 @@ public class LoadPlanner {
 
     public List<PlanFragment> getFragments() {
         return fragments;
+    }
+
+    public ExecPlan getExecPlan() {
+        return new ExecPlan(context, fragments);
     }
 
     public List<ScanNode> getScanNodes() {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/plan/ExecPlan.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/plan/ExecPlan.java
@@ -76,6 +76,15 @@ public class ExecPlan {
         this.outputColumns = outputColumns;
     }
 
+    // for broker load plan
+    public ExecPlan(ConnectContext connectContext, List<PlanFragment> fragments) {
+        this.connectContext = connectContext;
+        this.colNames = new ArrayList<>();
+        this.physicalPlan = null;
+        this.outputColumns = new ArrayList<>();
+        this.fragments.addAll(fragments);
+    }
+
     public ConnectContext getConnectContext() {
         return connectContext;
     }

--- a/fe/fe-core/src/test/java/com/starrocks/load/LoadPlannerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/load/LoadPlannerTest.java
@@ -218,6 +218,8 @@ public class LoadPlannerTest {
         Assert.assertEquals(4, locationsList.size());
         Assert.assertEquals(2, planner.getFragments().get(0).getPipelineDop());
         Assert.assertEquals(1, planner.getFragments().get(0).getParallelExecNum());
+
+        Assert.assertNotNull(planner.getExecPlan());
     }
 
     @Test


### PR DESCRIPTION
## Why I'm doing:
https://docs.starrocks.io/docs/administration/query_profile_text_based_analysis/

## What I'm doing:
support runtime query profile for broker load

```
MySQL [click_bench]> show profilelist;
+--------------------------------------+---------------------+------+---------+----------------------------------------------------------------------------------------------------------------------------------+
| QueryId                              | StartTime           | Time | State   | Statement                                                                                                                        |
+--------------------------------------+---------------------+------+---------+----------------------------------------------------------------------------------------------------------------------------------+
| a2e7d9e8-7d94-4d49-8075-b9cccec12a8b | 2024-03-26 15:44:20 | 2m3s | Running | LOAD LABEL click_bench.hits_1711439060 (DATA INFILE("oss://starrocks-qa-test-data/benchmark_data/query_data/click_bench/hits ... |
+--------------------------------------+---------------------+------+---------+----------------------------------------------------------------------------------------------------------------------------------+
1 row in set (0.00 sec)

MySQL [click_bench]> analyze profile from 'a2e7d9e8-7d94-4d49-8075-b9cccec12a8b';
+------------------------------------------------------------------------------------------------------------------------------------------------------+
| Explain String                                                                                                                                       |
+------------------------------------------------------------------------------------------------------------------------------------------------------+
| Summary                                                                                                                                      |
|     Attention: The transaction of the statement will be aborted, and no data will be actually inserted!!!                    |
|     Attention: Profile is not identical!!!                                                                                   |
|     QueryId: a2e7d9e8-7d94-4d49-8075-b9cccec12a8b                                                                                            |
|     Version: main-76ee018                                                                                                                    |
|     State: Running                                                                                                                           |
|     Legend: ⏳ for blocked; 🚀 for running; ✅ for finished                                                                                      |
|     TotalTime: 2m13s                                                                                                                         |
|         ExecutionTime: 2m10s [Scan: 1m14s (56.92%), Network: 0ns (0.00%), ResultDeliverTime: 1m3s (48.46%), ScheduleTime: 302.361ms (0.23%)] |
|         FrontendProfileMergeTime: 1.796ms                                                                                                    |
|     QueryPeakMemoryUsage: 95.361 MB, QueryAllocatedMemoryUsage: 132.951 GB                                                                   |
|     Top Most Time-consuming Nodes:                                                                                                           |
|         1. FILE_SCAN (id=0)  🚀 : 1m14s (85.15%)                                                                                          |
|         2. OLAP_TABLE_SINK 🚀 : 12s762ms (14.67%)                                                                                              |
|     Top Most Memory-consuming Nodes:                                                                                                         |
|     Progress (finished operator/all operator): 0.00%                                                                                         |
|     NonDefaultVariables:                                                                                                                     |
|         enable_adaptive_sink_dop: false -> true                                                                                              |
|         enable_profile: false -> true                                                                                                        |
|         sql_mode_v2: 32 -> 34                                                                                                                |
|         use_compute_nodes: -1 -> 0                                                                                                           |
| Fragment 0                                                                                                                                   |
| │   BackendNum: 3                                                                                                                            |
| │   InstancePeakMemoryUsage: 75.716 MB, InstanceAllocatedMemoryUsage: 132.951 GB                                                             |
| │   PrepareTime: 1.178ms                                                                                                                     |
| └──OLAP_TABLE_SINK                                                                                                                           |
|    │   TotalTime: 12s762ms (14.67%) [CPUTime: 12s762ms]                                                                                      |
|    │   OutputRows: 23.953M (23953408)                                                                                                        |
|    │   PartitionType: RANDOM                                                                                                                 |
|    │   Table: hits                                                                                                                           |
|    └──FILE_SCAN (id=0)  🚀                                                                                                                |
|           Estimates: [row: ?, cpu: ?, memory: ?, network: ?, cost: ?]                                                                   |
|           TotalTime: 1m14s (85.15%) [CPUTime: 77.608ms, ScanTime: 1m14s]                                                                |
|           OutputRows: 23.953M (23953408)                                                                                                |
|           Progress (processed rows/total rows): ?                                                                                       |
|           Detail Timers: [ScanTime = IOTaskExecTime + IOTaskWaitTime]                                                                   |
|               IOTaskExecTime: 1m11s [min=1m9s, max=1m14s]                                                                               |
|               IOTaskWaitTime: 80.960ms [min=64.560ms, max=96.595ms]                                                                     |
|                                                                                                                                                  |
+------------------------------------------------------------------------------------------------------------------------------------------------------+
39 rows in set (0.03 sec)
```

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [x] 3.1
  - [ ] 3.0
  - [ ] 2.5
