### PR TITLE
[Tool] Replace restful api with client to request PR reviewer

### DIFF
--- a/.github/workflows/label-action.yml
+++ b/.github/workflows/label-action.yml
@@ -28,29 +28,28 @@ jobs:
     env:
       PR_NUMBER: ${{ github.event.pull_request.number }}
       META_TEAM: meta-committer
+      GH_TOKEN: ${{ secrets.PAT }}
 
     steps:
       - name: ADD REVIEWER
         if: github.event.action == 'labeled'
         run: |
-          curl -L \
-            -X POST \
+          gh api \
+            --method POST \
             -H "Accept: application/vnd.github+json" \
-            -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
             -H "X-GitHub-Api-Version: 2022-11-28" \
-            "https://api.github.com/repos/${{ github.repository }}/pulls/${PR_NUMBER}/requested_reviewers" \
-            -d "{\"team_reviewers\":[\"${META_TEAM}\"]}" 2>/dev/null
+            /repos/${{ github.repository }}/pulls/${PR_NUMBER}/requested_reviewers \
+            -f "reviewers[]=" -f "team_reviewers[]=${META_TEAM}" 1>/dev/null
 
       - name: REMOVE REVIEWER
         if: github.event.action == 'unlabeled'
         run: |
-          curl -L \
-            -X DELETE \
+          gh api \
+            --method DELETE \
             -H "Accept: application/vnd.github+json" \
-            -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
             -H "X-GitHub-Api-Version: 2022-11-28" \
-            "https://api.github.com/repos/${{ github.repository }}/pulls/${PR_NUMBER}/requested_reviewers" \
-            -d "{\"reviewers\":[], \"team_reviewers\":[\"${META_TEAM}\"]}" 2>/dev/null
+            /repos/${{ github.repository }}/pulls/${PR_NUMBER}/requested_reviewers \
+            -f "reviewers[]=" -f "team_reviewers[]=${META_TEAM}" 1>/dev/null
 
   proto-review:
     name: PROTO REVIEW LABEL
@@ -59,29 +58,28 @@ jobs:
     env:
       PR_NUMBER: ${{ github.event.pull_request.number }}
       PROTO_TEAM: proto-team
+      GH_TOKEN: ${{ secrets.PAT }}
 
     steps:
       - name: ADD REVIEWER
         if: github.event.action == 'labeled'
         run: |
-          curl -L \
-            -X POST \
+          gh api \
+            --method POST \
             -H "Accept: application/vnd.github+json" \
-            -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
             -H "X-GitHub-Api-Version: 2022-11-28" \
-            "https://api.github.com/repos/${{ github.repository }}/pulls/${PR_NUMBER}/requested_reviewers" \
-            -d "{\"team_reviewers\":[\"${PROTO_TEAM}\"]}" 2>/dev/null
+            /repos/${{ github.repository }}/pulls/${PR_NUMBER}/requested_reviewers \
+            -f "reviewers[]=" -f "team_reviewers[]=${PROTO_TEAM}" 1>/dev/null
 
       - name: REMOVE REVIEWER
         if: github.event.action == 'unlabeled'
         run: |
-          curl -L \
-            -X DELETE \
+          gh api \
+            --method DELETE \
             -H "Accept: application/vnd.github+json" \
-            -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
             -H "X-GitHub-Api-Version: 2022-11-28" \
-            "https://api.github.com/repos/${{ github.repository }}/pulls/${PR_NUMBER}/requested_reviewers" \
-            -d "{\"reviewers\":[], \"team_reviewers\":[\"${PROTO_TEAM}\"]}" 2>/dev/null
+            /repos/${{ github.repository }}/pulls/${PR_NUMBER}/requested_reviewers \
+            -f "reviewers[]=" -f "team_reviewers[]=${PROTO_TEAM}" 1>/dev/null
 
   feature-review:
     name: FEATURE REVIEW LABEL
@@ -90,26 +88,25 @@ jobs:
     env:
       PR_NUMBER: ${{ github.event.pull_request.number }}
       TEAM: msg-reviewer
+      GH_TOKEN: ${{ secrets.PAT }}
 
     steps:
       - name: ADD REVIEWER
         if: github.event.action == 'labeled'
         run: |
-          curl -L \
-            -X POST \
+          gh api \
+            --method POST \
             -H "Accept: application/vnd.github+json" \
-            -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
             -H "X-GitHub-Api-Version: 2022-11-28" \
-            "https://api.github.com/repos/${{ github.repository }}/pulls/${PR_NUMBER}/requested_reviewers" \
-            -d "{\"team_reviewers\":[\"${TEAM}\"]}" 2>/dev/null
+            /repos/${{ github.repository }}/pulls/${PR_NUMBER}/requested_reviewers \
+            -f "reviewers[]=" -f "team_reviewers[]=${TEAM}" 1>/dev/null
 
       - name: REMOVE REVIEWER
         if: github.event.action == 'unlabeled'
         run: |
-          curl -L \
-            -X DELETE \
+          gh api \
+            --method DELETE \
             -H "Accept: application/vnd.github+json" \
-            -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
             -H "X-GitHub-Api-Version: 2022-11-28" \
-            "https://api.github.com/repos/${{ github.repository }}/pulls/${PR_NUMBER}/requested_reviewers" \
-            -d "{\"reviewers\":[], \"team_reviewers\":[\"${TEAM}\"]}" 2>/dev/null
+            /repos/${{ github.repository }}/pulls/${PR_NUMBER}/requested_reviewers \
+            -f "reviewers[]=" -f "team_reviewers[]=${TEAM}" 1>/dev/null


### PR DESCRIPTION
### Why I'm doing:
In latest version, the method to request review for PR by restful api is prohibited. It only works with GitHub App tokens or Fine-grained tokens.

### What I'm doing:
Use Github Cli instead of restful api to request reviewer.


## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [x] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
