### PR TITLE
[BugFix] Fix incorrect filtering of complex expression predicates by GIN

### DIFF
--- a/be/src/storage/column_expr_predicate.cpp
+++ b/be/src/storage/column_expr_predicate.cpp
@@ -290,7 +290,8 @@ Status ColumnExprPredicate::seek_inverted_index(const std::string& column_name, 
     // format as: col LIKE xxx, xxx can be any expr with string type
     bool vaild_pred = false;
     auto* vectorized_function_call = dynamic_cast<VectorizedFunctionCallExpr*>(_expr_ctxs[0]->root());
-    if (vectorized_function_call && LIKE_FN_NAME == boost::to_lower_copy(vectorized_function_call->get_function_desc()->name) &&
+    if (vectorized_function_call &&
+        LIKE_FN_NAME == boost::to_lower_copy(vectorized_function_call->get_function_desc()->name) &&
         _expr_ctxs[0]->root()->get_num_children() == 2 &&
         _expr_ctxs[0]->root()->get_child(0)->node_type() == TExprNodeType::SLOT_REF) {
         vaild_pred = true;

--- a/be/src/storage/column_expr_predicate.cpp
+++ b/be/src/storage/column_expr_predicate.cpp
@@ -285,29 +285,20 @@ Status ColumnExprPredicate::try_to_rewrite_for_zone_map_filter(starrocks::Object
 }
 Status ColumnExprPredicate::seek_inverted_index(const std::string& column_name, InvertedIndexIterator* iterator,
                                                 roaring::Roaring* row_bitmap) const {
-    // Only support like predicate for now
+    // Only support simple like predicate for now
+    // Root must be LIKE, and left child must be ColumnRef, which satisfy simple like predicate
+    // format as: col LIKE xxx, xxx can be any expr with string type
     auto* vectorized_function_call = dynamic_cast<VectorizedFunctionCallExpr*>(_expr_ctxs[0]->root());
-    if (!vectorized_function_call) {
-        int children_num = _expr_ctxs[0]->root()->get_num_children();
-        bool found_like = false;
-        for (int i = 0; i < children_num; i++) {
-            vectorized_function_call = dynamic_cast<VectorizedFunctionCallExpr*>(_expr_ctxs[0]->root()->get_child(i));
-            if (vectorized_function_call) {
-                auto function_desc = vectorized_function_call->get_function_desc();
-                if (LIKE_FN_NAME == boost::to_lower_copy(function_desc->name)) {
-                    found_like = true;
-                    break;
-                }
-            }
+    bool vaild_pred = false;
+    if (vectorized_function_call && boost::to_lower_copy(vectorized_function_call->get_function_desc()->name) == LIKE_FN_NAME &&
+        _expr_ctxs[0]->root()->get_num_children() >= 1) {
+        auto first_child = dynamic_cast<ColumnRef*>(_expr_ctxs[0]->root()->get_child(0));
+        if (first_child != nullptr) {
+            vaild_pred = true;
         }
-        if (!found_like) {
-            return Status::NotSupported("Not supported function call in inverted index");
-        }
-    } else {
-        auto function_desc = vectorized_function_call->get_function_desc();
-        if (LIKE_FN_NAME != boost::to_lower_copy(function_desc->name)) {
-            return Status::NotSupported("Not supported predicate with seeking inverted index");
-        }
+    }
+    if (!vaild_pred) {
+        return Status::NotSupported("Not supported function call in inverted index");
     }
     auto* like_target = dynamic_cast<VectorizedLiteral*>(vectorized_function_call->get_child(1));
     RETURN_IF(!like_target, Status::NotSupported("Not supported like predicate parameters"));

--- a/test/sql/test_inverted_index/R/test_inverted_index
+++ b/test/sql/test_inverted_index/R/test_inverted_index
@@ -840,3 +840,99 @@ SELECT * FROM t_clone_for_gin ORDER BY id1;
 1	abc
 2	ABC
 -- !result
+-- name: test_complex_predicate_for_gin
+CREATE TABLE `t_complex_predicate_for_gin_none` (
+  `id1` bigint(20) NOT NULL COMMENT "",
+  `text_column` varchar(255) NULL COMMENT "",
+  INDEX gin_none (`text_column`) USING GIN ("parser" = "none") COMMENT ''
+) ENGINE=OLAP
+DUPLICATE KEY(`id1`)
+DISTRIBUTED BY HASH(`id1`) BUCKETS 1
+PROPERTIES (
+"replication_num" = "1",
+"enable_persistent_index" = "false",
+"replicated_storage" = "false",
+"compression" = "LZ4"
+);
+-- result:
+-- !result
+CREATE TABLE `t_complex_predicate_for_gin_english` (
+  `id1` bigint(20) NOT NULL COMMENT "",
+  `text_column` varchar(255) NULL COMMENT "",
+  INDEX gin_english (`text_column`) USING GIN ("parser" = "english") COMMENT ''
+) ENGINE=OLAP
+DUPLICATE KEY(`id1`)
+DISTRIBUTED BY HASH(`id1`) BUCKETS 1
+PROPERTIES (
+"replication_num" = "1",
+"enable_persistent_index" = "false",
+"replicated_storage" = "false",
+"compression" = "LZ4"
+);
+-- result:
+-- !result
+INSERT INTO t_complex_predicate_for_gin_none VALUES (1, "abc cbd");
+-- result:
+-- !result
+INSERT INTO t_complex_predicate_for_gin_none VALUES (2, "cbd edf");
+-- result:
+-- !result
+SELECT * FROM t_complex_predicate_for_gin_none WHERE upper(text_column) LIKE "%CBD%";
+-- result:
+1	abc cbd
+2	cbd edf
+-- !result
+SELECT * FROM t_complex_predicate_for_gin_none WHERE lower(text_column) LIKE "%cbd%";
+-- result:
+1	abc cbd
+2	cbd edf
+-- !result
+SELECT * FROM t_complex_predicate_for_gin_none WHERE CAST(id1 as STRING) LIKE "abc";
+-- result:
+-- !result
+SELECT * FROM t_complex_predicate_for_gin_none WHERE CAST(id1 as STRING) LIKE "%abc%";
+-- result:
+-- !result
+SELECT * FROM t_complex_predicate_for_gin_none WHERE text_column LIKE CONCAT("ab", "c");
+-- result:
+-- !result
+SELECT * FROM t_complex_predicate_for_gin_none WHERE text_column LIKE CONCAT("ab", "%");
+-- result:
+1	abc cbd
+-- !result
+INSERT INTO t_complex_predicate_for_gin_english VALUES (1, "abc cbd");
+-- result:
+-- !result
+INSERT INTO t_complex_predicate_for_gin_english VALUES (2, "cbd edf");
+-- result:
+-- !result
+SELECT * FROM t_complex_predicate_for_gin_english WHERE upper(text_column) LIKE "%CBD%";
+-- result:
+1	abc cbd
+2	cbd edf
+-- !result
+SELECT * FROM t_complex_predicate_for_gin_english WHERE lower(text_column) LIKE "%cbd%";
+-- result:
+1	abc cbd
+2	cbd edf
+-- !result
+SELECT * FROM t_complex_predicate_for_gin_english WHERE CAST(id1 as STRING) LIKE "abc";
+-- result:
+-- !result
+SELECT * FROM t_complex_predicate_for_gin_english WHERE CAST(id1 as STRING) LIKE "%abc%";
+-- result:
+-- !result
+SELECT * FROM t_complex_predicate_for_gin_english WHERE text_column LIKE CONCAT("ab", "c");
+-- result:
+1	abc cbd
+-- !result
+SELECT * FROM t_complex_predicate_for_gin_english WHERE text_column LIKE CONCAT("ab", "%");
+-- result:
+1	abc cbd
+-- !result
+DROP TABLE t_complex_predicate_for_gin_none;
+-- result:
+-- !result
+DROP TABLE t_complex_predicate_for_gin_english;
+-- result:
+-- !result

--- a/test/sql/test_inverted_index/T/test_inverted_index
+++ b/test/sql/test_inverted_index/T/test_inverted_index
@@ -487,3 +487,55 @@ SELECT * FROM t_clone_for_gin ORDER BY id1;
 function: set_first_tablet_bad_and_recover("t_clone_for_gin")
 
 SELECT * FROM t_clone_for_gin ORDER BY id1;
+
+-- name: test_complex_predicate_for_gin
+CREATE TABLE `t_complex_predicate_for_gin_none` (
+  `id1` bigint(20) NOT NULL COMMENT "",
+  `text_column` varchar(255) NULL COMMENT "",
+  INDEX gin_none (`text_column`) USING GIN ("parser" = "none") COMMENT ''
+) ENGINE=OLAP
+DUPLICATE KEY(`id1`)
+DISTRIBUTED BY HASH(`id1`) BUCKETS 1
+PROPERTIES (
+"replication_num" = "1",
+"enable_persistent_index" = "false",
+"replicated_storage" = "false",
+"compression" = "LZ4"
+);
+
+CREATE TABLE `t_complex_predicate_for_gin_english` (
+  `id1` bigint(20) NOT NULL COMMENT "",
+  `text_column` varchar(255) NULL COMMENT "",
+  INDEX gin_english (`text_column`) USING GIN ("parser" = "english") COMMENT ''
+) ENGINE=OLAP
+DUPLICATE KEY(`id1`)
+DISTRIBUTED BY HASH(`id1`) BUCKETS 1
+PROPERTIES (
+"replication_num" = "1",
+"enable_persistent_index" = "false",
+"replicated_storage" = "false",
+"compression" = "LZ4"
+);
+
+INSERT INTO t_complex_predicate_for_gin_none VALUES (1, "abc cbd");
+INSERT INTO t_complex_predicate_for_gin_none VALUES (2, "cbd edf");
+
+SELECT * FROM t_complex_predicate_for_gin_none WHERE upper(text_column) LIKE "%CBD%";
+SELECT * FROM t_complex_predicate_for_gin_none WHERE lower(text_column) LIKE "%cbd%";
+SELECT * FROM t_complex_predicate_for_gin_none WHERE CAST(id1 as STRING) LIKE "abc";
+SELECT * FROM t_complex_predicate_for_gin_none WHERE CAST(id1 as STRING) LIKE "%abc%";
+SELECT * FROM t_complex_predicate_for_gin_none WHERE text_column LIKE CONCAT("ab", "c");
+SELECT * FROM t_complex_predicate_for_gin_none WHERE text_column LIKE CONCAT("ab", "%");
+
+INSERT INTO t_complex_predicate_for_gin_english VALUES (1, "abc cbd");
+INSERT INTO t_complex_predicate_for_gin_english VALUES (2, "cbd edf");
+
+SELECT * FROM t_complex_predicate_for_gin_english WHERE upper(text_column) LIKE "%CBD%";
+SELECT * FROM t_complex_predicate_for_gin_english WHERE lower(text_column) LIKE "%cbd%";
+SELECT * FROM t_complex_predicate_for_gin_english WHERE CAST(id1 as STRING) LIKE "abc";
+SELECT * FROM t_complex_predicate_for_gin_english WHERE CAST(id1 as STRING) LIKE "%abc%";
+SELECT * FROM t_complex_predicate_for_gin_english WHERE text_column LIKE CONCAT("ab", "c");
+SELECT * FROM t_complex_predicate_for_gin_english WHERE text_column LIKE CONCAT("ab", "%");
+
+DROP TABLE t_complex_predicate_for_gin_none;
+DROP TABLE t_complex_predicate_for_gin_english;


### PR DESCRIPTION
## Why I'm doing:
Currently, GIN is expected to used for LIKE expression predicates with the format as 'col LIKE xxx'. But expression predicates like 'function(col) LIKE xxx' will use the index wrongly and get the wrong result.

## What I'm doing:
For expression predicates, the expr's root node must be LIKE functionCall and the left child node must be ColumnRef. Make sure the the available expression predicates is satisfy the format as 'col LIKE xxx'.

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
