### PR TITLE
[BugFix] Remove workgroup_id and version pair from workgroup_versions if the workgroup is removed

### DIFF
--- a/be/src/exec/workgroup/work_group.cpp
+++ b/be/src/exec/workgroup/work_group.cpp
@@ -19,7 +19,6 @@
 #include "common/config.h"
 #include "exec/workgroup/work_group_fwd.h"
 #include "glog/logging.h"
-#include "gutil/strings/substitute.h"
 #include "runtime/exec_env.h"
 #include "util/cpu_info.h"
 #include "util/metrics.h"
@@ -274,7 +273,8 @@ WorkGroupPtr WorkGroupManager::add_workgroup(const WorkGroupPtr& wg) {
     auto unique_id = wg->unique_id();
     create_workgroup_unlocked(wg, write_lock);
     if (_workgroup_versions.count(wg->id()) && _workgroup_versions[wg->id()] == wg->version()) {
-        if (auto workgroup_it = _workgroups.find(unique_id); workgroup_it != _workgroups.end()) {
+        auto workgroup_it = _workgroups.find(unique_id);
+        if (workgroup_it != _workgroups.end()) {
             return workgroup_it->second;
         }
     }


### PR DESCRIPTION
## Why I'm doing:

https://github.com/StarRocks/StarRocksTest/issues/6724

The workgroup is nullptr,  BE crashes inside starrocks::workgroup::WorkGroup::use_big_query_mem_limit() const 

```
(gdb) thread 6
[Switching to thread 6 (Thread 0x7fba31d79700 (LWP 50613))]
#0  starrocks::workgroup::WorkGroup::use_big_query_mem_limit (this=0x0) at /root/starrocks/be/src/exec/workgroup/work_group.h:199
199	        return 0 < _big_query_mem_limit && _big_query_mem_limit <= _mem_tracker->limit();
(gdb) p this
$1 = (const starrocks::workgroup::WorkGroup * const) 0x0
```

When create the a workgroup, the write lock is released and acquired again in the middle of create_workgroup_unlocked's calling add_metrics_unlocked, during this period, the workgroup is deleted but the 
workgroup id and version pair is not deleted from workgroup_versoins. when create_workgroup_unlocked is returned, fragment_executor find that workgroup id and version pair exists in workgroup_versoins, so it directly use operator[] to obtain the workgroup, which leads that a default nullptr object is inserted since the workgroup does not exists.


## What I'm doing:
Use unordered_map::at instead of operator[], and check element existence strictly.
Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [x] 3.1
  - [x] 3.0
  - [x] 2.5

