### PR TITLE
[UT] Fix PseudoBackend report tablets bug

### DIFF
--- a/fe/fe-core/src/test/java/com/starrocks/pseudocluster/PseudoBackend.java
+++ b/fe/fe-core/src/test/java/com/starrocks/pseudocluster/PseudoBackend.java
@@ -477,10 +477,19 @@ public class PseudoBackend {
     private void reportTablets() {
         // report tablets
         TReportRequest request = new TReportRequest();
+        // Report_version must be set before setting the tablets to
+        // ensure that the tablet in FE will not be accidentally deleted in the following case:
+        // t1: tablet1, tablet2, tablet3 are created on BE and current reportVersion is 3.
+        // t2: tablet1, tablet2, tablet3 are set into request.tables.
+        // t3: tablet4 is created and reportVersion changed to 4.
+        // t4: 4 is set into request.report_version.
+        // t5: The request is sent to the FE node and it is found that tablet4 is not in request.tablets
+        // and request.report_version is equal to the latest report_version recorded by FE,
+        // tablet4 metadata will be deleted from FE. Code: ReportHandler.deleteFromMeta
+        request.setReport_version(reportVersion.get());
         request.setTablets(tabletManager.getAllTabletInfo());
         request.setTablet_max_compaction_score(100);
         request.setBackend(tBackend);
-        request.setReport_version(reportVersion.get());
         try {
             if (!shutdown) {
                 TMasterResult result = frontendService.report(request);


### PR DESCRIPTION
## Why I'm doing:

Report_version must be set before setting the tablets to ensure that the tablet in FE will not be accidentally deleted in the following case:
t1: tablet1, tablet2, tablet3 are created on BE and current reportVersion is 3.
t2: tablet1, tablet2, tablet3 are set into request.tables.
t3: tablet4 is created and reportVersion changed to 4.
t4: 4 is set into request.report_version.
t5: The request is sent to the FE node and it is found that tablet4 is not in request.tablets
and request.report_version is equal to the latest report_version recorded by FE,
tablet4 metadata will be deleted from FE. 

Code: ReportHandler.deleteFromMeta

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [x] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [x] 3.1
  - [x] 3.0
  - [x] 2.5
