### PR TITLE
[BugFix] fix excessive io task in adaptive strategy

### DIFF
--- a/be/src/exec/pipeline/scan/scan_operator.cpp
+++ b/be/src/exec/pipeline/scan/scan_operator.cpp
@@ -298,6 +298,7 @@ Status ScanOperator::_try_to_trigger_next_scan(RuntimeState* state) {
     int to_sched[_io_tasks_per_scan_operator];
     int size = 0;
 
+    // right here, we want total running io tasks as `total_cnt`
     {
         bool skip[_io_tasks_per_scan_operator];
         // check if we can return earlier.
@@ -307,7 +308,7 @@ Status ScanOperator::_try_to_trigger_next_scan(RuntimeState* state) {
             }
         }
         // update skip vector, and pick up already started chunk source.
-        for (int i = 0; i < _io_tasks_per_scan_operator; i++) {
+        for (int i = 0; i < _io_tasks_per_scan_operator && total_cnt > 0; i++) {
             if (_is_io_task_running[i]) {
                 skip[i] = true;
                 total_cnt -= 1;

--- a/be/src/exec/pipeline/scan/scan_operator.cpp
+++ b/be/src/exec/pipeline/scan/scan_operator.cpp
@@ -322,11 +322,11 @@ Status ScanOperator::_try_to_trigger_next_scan(RuntimeState* state) {
 
         // now skip vector includes already started chunk source
         // we are going to pick up `total_cnt` new chunk source to start.
-        while (size < total_cnt) {
+        for (int i = 0; i < _io_tasks_per_scan_operator && size < total_cnt; i++) {
             _chunk_source_idx = (_chunk_source_idx + 1) % _io_tasks_per_scan_operator;
-            int i = _chunk_source_idx;
-            if (skip[i]) continue;
-            to_sched[size++] = i;
+            int idx = _chunk_source_idx;
+            if (skip[idx]) continue;
+            to_sched[size++] = idx;
         }
     }
 


### PR DESCRIPTION
## Why I'm doing:

This bug is introduced in this pr https://github.com/StarRocks/starrocks/pull/42311

![img_v3_029b_893e50d6-de9a-4819-b822-3d2b3046b0fg](https://github.com/StarRocks/starrocks/assets/1081215/e3e53605-2d3f-4665-8698-f42f67a38357)

One problem with this PR is that it does not check io running from the beginning every time, but from the point where it exited last time. The meaning of causing total cnt is to select total cnt io tasks to run from the next check.

At some point, the total number of running io tasks will exceed expected io tasks. The result is that more io tasks will be created, which is somewhat similar to the effect of turning off adaptation.

Adaptive strategy is very effective for limit filtering because too much data may need to be read.

## What I'm doing:



Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
