### PR TITLE
[BugFix] Fix some problems of skew join

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/QueryAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/QueryAnalyzer.java
@@ -647,6 +647,11 @@ public class QueryAnalyzer {
                     if (join.getSkewValues().stream().anyMatch(expr -> !expr.isConstant())) {
                         throw new SemanticException("skew join values must be constant");
                     }
+                    List<Expr> newSkewValues = new ArrayList<>();
+                    for (Expr expr : join.getSkewValues()) {
+                        newSkewValues.add(TypeManager.addCastExpr(expr, join.getSkewColumn().getType()));
+                    }
+                    join.setSkewValues(newSkewValues);
                 }
             } else if (!JoinOperator.HINT_UNREORDER.equals(join.getJoinHint())) {
                 throw new SemanticException("JOIN hint not recognized: " + join.getJoinHint());

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/scalar/ScalarOperator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/scalar/ScalarOperator.java
@@ -190,6 +190,10 @@ public abstract class ScalarOperator implements Cloneable {
         return this instanceof ColumnRefOperator;
     }
 
+    public boolean isCast() {
+        return this instanceof CastOperator;
+    }
+
     public boolean isConstantRef() {
         return this instanceof ConstantOperator;
     }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/SkewJoinTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/SkewJoinTest.java
@@ -45,7 +45,7 @@ public class SkewJoinTest extends PlanTestBase {
     public void testSkewJoin() throws Exception {
         String sql = "select v2, v5 from t0 join[skew|t0.v1(1,2)] t1 on v1 = v4 ";
         String sqlPlan = getFragmentPlan(sql);
-        assertCContains(sqlPlan, " equal join conjunct: 7: rand_col = 15: cast\n" +
+        assertCContains(sqlPlan, " equal join conjunct: 7: rand_col = 14: rand_col\n" +
                 "  |  equal join conjunct: 1: v1 = 4: v4");
         assertCContains(sqlPlan, "  |  <slot 10> : 10: unnest\n" +
                 "  |  <slot 11> : 0\n" +
@@ -129,7 +129,7 @@ public class SkewJoinTest extends PlanTestBase {
         String sql = "select t1.c2, t3.c3 from hive0.partitioned_db.t1 join[skew|t1.c1(1,2)] hive0.partitioned_db.t3" +
                 " on t1.c1 = t3.c1";
         String sqlPlan = getFragmentPlan(sql);
-        assertCContains(sqlPlan, " equal join conjunct: 9: rand_col = 17: cast\n" +
+        assertCContains(sqlPlan, " equal join conjunct: 9: rand_col = 16: rand_col\n" +
                 "  |  equal join conjunct: 1: c1 = 5: c1");
         assertCContains(sqlPlan, " 5:Project\n" +
                 "  |  <slot 11> : [1,2]");
@@ -148,15 +148,15 @@ public class SkewJoinTest extends PlanTestBase {
         String sqlPlan = getFragmentPlan(sql);
         assertCContains(sqlPlan, "1:Project\n" +
                 "  |  <slot 1> : 1: c0\n" +
-                "  |  <slot 10> : CASE WHEN 2: c1.a[true] IS NULL THEN 26: round " +
-                "WHEN 2: c1.a[true] IN (1, 2) THEN 26: round ELSE 0 END\n" +
-                "  |  <slot 19> : 2: c1.a[true]\n" +
-                "  |  <slot 21> : 3: c2.a[false]\n" +
+                "  |  <slot 10> : CASE WHEN 2: c1.a[true] IS NULL THEN " +
+                "24: round WHEN 2: c1.a[true] IN (1, 2) THEN 24: round ELSE 0 END\n" +
+                "  |  <slot 18> : 2: c1.a[true]\n" +
+                "  |  <slot 19> : 3: c2.a[false]\n" +
                 "  |  common expressions:\n" +
-                "  |  <slot 23> : 2: c1.a[true]\n" +
-                "  |  <slot 24> : rand()\n" +
-                "  |  <slot 25> : 24: rand * 1000.0\n" +
-                "  |  <slot 26> : round(25: multiply)");
+                "  |  <slot 21> : 2: c1.a[true]\n" +
+                "  |  <slot 22> : rand()\n" +
+                "  |  <slot 23> : 22: rand * 1000.0\n" +
+                "  |  <slot 24> : round(23: multiply)");
     }
 
     @Test
@@ -169,9 +169,9 @@ public class SkewJoinTest extends PlanTestBase {
         sql = "select t1.c2, t3.c3 from hive0.partitioned_db.t1 join[skew|t1.c1(1,2)] hive0.partitioned_db.t3" +
                 " on t1.c1 = t3.c1 join[skew|t1.c2('a','b','c')] hive0.partitioned_db2.t2 on t1.c2 = t2.c2";
         sqlPlan = getFragmentPlan(sql);
-        assertCContains(sqlPlan, "equal join conjunct: 21: rand_col = 30: cast\n" +
+        assertCContains(sqlPlan, "equal join conjunct: 21: rand_col = 28: rand_col\n" +
                 "  |  equal join conjunct: 1: c1 = 5: c1");
-        assertCContains(sqlPlan, "equal join conjunct: 13: rand_col = 29: cast\n" +
+        assertCContains(sqlPlan, "equal join conjunct: 13: rand_col = 20: rand_col\n" +
                 "  |  equal join conjunct: 2: c2 = 10: c2");
     }
 }

--- a/test/sql/test_join/R/test_skew_join
+++ b/test/sql/test_join/R/test_skew_join
@@ -1,0 +1,348 @@
+-- name: test_skew_join
+CREATE TABLE t1 (
+    c_key      INT NOT NULL,
+    c_tinyint  TINYINT,
+    c_smallint SMALLINT,
+    c_int      INT,
+    c_bigint   BIGINT,
+    c_largeint LARGEINT,
+    c_float    FLOAT,
+    c_double   DOUBLE,
+    c_decimal  DECIMAL(26,2),
+    c_date     DATE,
+    c_datetime DATETIME,
+    c_string   STRING
+)
+DUPLICATE KEY(c_key)
+DISTRIBUTED BY HASH(c_key) BUCKETS 1
+PROPERTIES (
+    "replication_num"="1"
+);
+-- result:
+-- !result
+CREATE TABLE t2 (
+    c_key      INT NOT NULL,
+    c_tinyint  TINYINT,
+    c_smallint SMALLINT,
+    c_int      INT,
+    c_bigint   BIGINT,
+    c_largeint LARGEINT,
+    c_float    FLOAT,
+    c_double   DOUBLE,
+    c_decimal  DECIMAL(26,2),
+    c_date     DATE,
+    c_datetime DATETIME,
+    c_string   STRING
+)
+DUPLICATE KEY(c_key)
+DISTRIBUTED BY HASH(c_key) BUCKETS 1
+PROPERTIES (
+    "replication_num"="1"
+);
+-- result:
+-- !result
+truncate table t1;
+-- result:
+-- !result
+truncate table t2;
+-- result:
+-- !result
+insert into t1(c_key, c_tinyint) values (1, 1), (2, 1), (3, 1), (4, 2), (5, 2), (6, 3);
+-- result:
+-- !result
+insert into t2(c_key, c_tinyint) values (1, 1), (2, 2), (3, 3);
+-- result:
+-- !result
+select t1.c_key, t2.c_key from t1 join [skew|t1.c_tinyint(1,2,8)] t2 on t1.c_tinyint=t2.c_tinyint order by t1.c_key, t2.c_key;
+-- result:
+1	1
+2	1
+3	1
+4	2
+5	2
+6	3
+-- !result
+truncate table t1;
+-- result:
+-- !result
+truncate table t2;
+-- result:
+-- !result
+insert into t1(c_key, c_smallint) values (1, 1), (2, 1), (3, 1), (4, 1111), (5, 1111), (6, 3);
+-- result:
+-- !result
+insert into t2(c_key, c_smallint) values (1, 1), (2, 1111), (3, 3);
+-- result:
+-- !result
+select t1.c_key, t2.c_key from t1 join [skew|t1.c_smallint(1,1111,4444)] t2 on t1.c_smallint=t2.c_smallint order by t1.c_key, t2.c_key;
+-- result:
+1	1
+2	1
+3	1
+4	2
+5	2
+6	3
+-- !result
+truncate table t1;
+-- result:
+-- !result
+truncate table t2;
+-- result:
+-- !result
+insert into t1(c_key, c_int) values (1, 1), (2, 1), (3, 1), (4, 1234567), (5, 1234567), (6, 3);
+-- result:
+-- !result
+insert into t2(c_key, c_int) values (1, 1), (2, 1234567), (3, 3);
+-- result:
+-- !result
+select t1.c_key, t2.c_key from t1 join [skew|t1.c_int(1,1234567,4444)] t2 on t1.c_int=t2.c_int order by t1.c_key, t2.c_key;
+-- result:
+1	1
+2	1
+3	1
+4	2
+5	2
+6	3
+-- !result
+truncate table t1;
+-- result:
+-- !result
+truncate table t2;
+-- result:
+-- !result
+insert into t1(c_key, c_bigint) values (1, 1), (2, 1), (3, 1), (4, 12345678912), (5, 12345678912), (6, 3);
+-- result:
+-- !result
+insert into t2(c_key, c_bigint) values (1, 1), (2, 12345678912), (3, 3);
+-- result:
+-- !result
+select t1.c_key, t2.c_key from t1 join [skew|t1.c_bigint(1,12345678912,4444)] t2 on t1.c_bigint=t2.c_bigint order by t1.c_key, t2.c_key;
+-- result:
+1	1
+2	1
+3	1
+4	2
+5	2
+6	3
+-- !result
+truncate table t1;
+-- result:
+-- !result
+truncate table t2;
+-- result:
+-- !result
+insert into t1(c_key, c_largeint) values (1, 1), (2, 1), (3, 1), (4, 18446744073709551620), (5, 18446744073709551620), (6, 3);
+-- result:
+-- !result
+insert into t2(c_key, c_largeint) values (1, 1), (2, 18446744073709551620), (3, 3);
+-- result:
+-- !result
+select t1.c_key, t2.c_key from t1 join [skew|t1.c_largeint(1,18446744073709551620,4444)] t2 on t1.c_largeint=t2.c_largeint order by t1.c_key, t2.c_key;
+-- result:
+1	1
+2	1
+3	1
+4	2
+5	2
+6	3
+-- !result
+truncate table t1;
+-- result:
+-- !result
+truncate table t2;
+-- result:
+-- !result
+insert into t1(c_key, c_float) values (1, 1.1), (2, 1.1), (3, 1.1), (4, 2.1), (5, 2.1), (6, 3);
+-- result:
+-- !result
+insert into t2(c_key, c_float) values (1, 1.1), (2, 2.1), (3, 3);
+-- result:
+-- !result
+select t1.c_key, t2.c_key from t1 join [skew|t1.c_float(1.1,2.1,4444)] t2 on t1.c_float=t2.c_float order by t1.c_key, t2.c_key;
+-- result:
+1	1
+2	1
+3	1
+4	2
+5	2
+6	3
+-- !result
+truncate table t1;
+-- result:
+-- !result
+truncate table t2;
+-- result:
+-- !result
+insert into t1(c_key, c_double) values (1, 1.1), (2, 1.1), (3, 1.1), (4, 2.1), (5, 2.1), (6, 3);
+-- result:
+-- !result
+insert into t2(c_key, c_double) values (1, 1.1), (2, 2.1), (3, 3);
+-- result:
+-- !result
+select t1.c_key, t2.c_key from t1 join [skew|t1.c_double(1.1,2.1,4444)] t2 on t1.c_double=t2.c_double order by t1.c_key, t2.c_key;
+-- result:
+1	1
+2	1
+3	1
+4	2
+5	2
+6	3
+-- !result
+truncate table t1;
+-- result:
+-- !result
+truncate table t2;
+-- result:
+-- !result
+insert into t1(c_key, c_decimal) values (1, 1.1), (2, 1.1), (3, 1.1), (4, 2.1), (5, 2.1), (6, 3);
+-- result:
+-- !result
+insert into t2(c_key, c_decimal) values (1, 1.1), (2, 2.1), (3, 3);
+-- result:
+-- !result
+select t1.c_key, t2.c_key from t1 join [skew|t1.c_decimal(1.1,2.1,4444)] t2 on t1.c_decimal=t2.c_decimal order by t1.c_key, t2.c_key;
+-- result:
+1	1
+2	1
+3	1
+4	2
+5	2
+6	3
+-- !result
+truncate table t1;
+-- result:
+-- !result
+truncate table t2;
+-- result:
+-- !result
+insert into t1(c_key, c_date) values
+    (1, "2024-01-01"), (2, "2024-01-01"), (3, "2024-01-01"),
+    (4, "2024-01-02"), (5, "2024-01-02"), (6, "2024-01-03");
+-- result:
+-- !result
+insert into t2(c_key, c_date) values (1, "2024-01-01"), (2, "2024-01-02"), (3, "2024-01-03");
+-- result:
+-- !result
+select t1.c_key, t2.c_key from t1 join [skew|t1.c_date("2024-01-01","2024-01-02","2024-01-04")] t2 on t1.c_date=t2.c_date order by t1.c_key, t2.c_key;
+-- result:
+1	1
+2	1
+3	1
+4	2
+5	2
+6	3
+-- !result
+truncate table t1;
+-- result:
+-- !result
+truncate table t2;
+-- result:
+-- !result
+insert into t1(c_key, c_datetime) values
+    (1, "2024-01-01 00:00:00"),
+    (2, "2024-01-01 00:00:00"),
+    (3, "2024-01-01 00:00:00"),
+    (4, "2024-01-02 00:00:00"),
+    (5, "2024-01-02 00:00:00"),
+    (6, "2024-01-03 00:00:00");
+-- result:
+-- !result
+insert into t2(c_key, c_datetime) values
+    (1, "2024-01-01 00:00:00"),
+    (2, "2024-01-02 00:00:00"),
+    (3, "2024-01-03 00:00:00");
+-- result:
+-- !result
+select t1.c_key, t2.c_key from t1 join [skew|t1.c_datetime("2024-01-01 00:00:00","2024-01-02","2024-01-04")] t2 on t1.c_datetime=t2.c_datetime order by t1.c_key, t2.c_key;
+-- result:
+1	1
+2	1
+3	1
+4	2
+5	2
+6	3
+-- !result
+truncate table t1;
+-- result:
+-- !result
+truncate table t2;
+-- result:
+-- !result
+insert into t1(c_key, c_string) values ("1", "1"), ("2", "1"), ("3", "1"), ("4", "1234567"), ("5", "1234567"), ("6", "3");
+-- result:
+-- !result
+insert into t2(c_key, c_string) values ("1", "1"), ("2", "1234567"), ("3", "3");
+-- result:
+-- !result
+select t1.c_key, t2.c_key from t1 join [skew|t1.c_string("1","1234567","4444")] t2 on t1.c_string=t2.c_string order by t1.c_key, t2.c_key;
+-- result:
+1	1
+2	1
+3	1
+4	2
+5	2
+6	3
+-- !result
+truncate table t1;
+-- result:
+-- !result
+truncate table t2;
+-- result:
+-- !result
+insert into t1(c_key, c_int) values (1, 1), (2, 1), (3, 1), (4, 1234567), (5, 1234567), (6, 3);
+-- result:
+-- !result
+insert into t2(c_key, c_bigint) values (1, 1), (2, 1234567), (3, 3);
+-- result:
+-- !result
+select t1.c_key, t2.c_key from t1 join [skew|t1.c_int(1,2,99999)] t2 on t1.c_int=t2.c_bigint order by t1.c_key, t2.c_key;
+-- result:
+1	1
+2	1
+3	1
+4	2
+5	2
+6	3
+-- !result
+truncate table t1;
+-- result:
+-- !result
+truncate table t2;
+-- result:
+-- !result
+insert into t1(c_key, c_bigint) values (1, 1), (2, 1), (3, 1), (4, 1234567), (5, 1234567), (6, 3);
+-- result:
+-- !result
+insert into t2(c_key, c_int) values (1, 1), (2, 1234567), (3, 3);
+-- result:
+-- !result
+select t1.c_key, t2.c_key from t1 join [skew|t1.c_bigint(1,2,99999)] t2 on t1.c_bigint=t2.c_int order by t1.c_key, t2.c_key;
+-- result:
+1	1
+2	1
+3	1
+4	2
+5	2
+6	3
+-- !result
+truncate table t1;
+-- result:
+-- !result
+truncate table t2;
+-- result:
+-- !result
+insert into t1(c_key, c_string) values (1, "1"), (2, "1"), (3, "1"), (4, "1234567"), (5, "1234567"), (6, "3");
+-- result:
+-- !result
+insert into t2(c_key, c_int) values (1, 1), (2, 1234567), (3, 3);
+-- result:
+-- !result
+select t1.c_key, t2.c_key from t1 join [skew|t1.c_string("1","2","99999")] t2 on t1.c_string=t2.c_int order by t1.c_key, t2.c_key;
+-- result:
+1	1
+2	1
+3	1
+4	2
+5	2
+6	3
+-- !result

--- a/test/sql/test_join/R/test_skew_join
+++ b/test/sql/test_join/R/test_skew_join
@@ -346,3 +346,24 @@ select t1.c_key, t2.c_key from t1 join [skew|t1.c_string("1","2","99999")] t2 on
 5	2
 6	3
 -- !result
+truncate table t1;
+-- result:
+-- !result
+truncate table t2;
+-- result:
+-- !result
+insert into t1(c_key, c_bigint) values (1, 1), (2, 1), (3, 1), (4, 1234567), (5, 1234567), (6, 3);
+-- result:
+-- !result
+insert into t2(c_key, c_int) values (1, 1), (2, 1234567), (3, 3);
+-- result:
+-- !result
+select t1.c_key, t2.c_key from t1 join [skew|t1.c_bigint(1,2,99999)] t2 on t1.c_bigint=t2.c_int order by t1.c_key, t2.c_key;
+-- result:
+1	1
+2	1
+3	1
+4	2
+5	2
+6	3
+-- !result

--- a/test/sql/test_join/T/test_skew_join
+++ b/test/sql/test_join/T/test_skew_join
@@ -1,0 +1,150 @@
+-- name: test_skew_join
+
+CREATE TABLE t1 (
+    c_key      INT NOT NULL,
+    c_tinyint  TINYINT,
+    c_smallint SMALLINT,
+    c_int      INT,
+    c_bigint   BIGINT,
+    c_largeint LARGEINT,
+    c_float    FLOAT,
+    c_double   DOUBLE,
+    c_decimal  DECIMAL(26,2),
+    c_date     DATE,
+    c_datetime DATETIME,
+    c_string   STRING
+)
+DUPLICATE KEY(c_key)
+DISTRIBUTED BY HASH(c_key) BUCKETS 1
+PROPERTIES (
+    "replication_num"="1"
+);
+
+CREATE TABLE t2 (
+    c_key      INT NOT NULL,
+    c_tinyint  TINYINT,
+    c_smallint SMALLINT,
+    c_int      INT,
+    c_bigint   BIGINT,
+    c_largeint LARGEINT,
+    c_float    FLOAT,
+    c_double   DOUBLE,
+    c_decimal  DECIMAL(26,2),
+    c_date     DATE,
+    c_datetime DATETIME,
+    c_string   STRING
+)
+DUPLICATE KEY(c_key)
+DISTRIBUTED BY HASH(c_key) BUCKETS 1
+PROPERTIES (
+    "replication_num"="1"
+);
+
+-- tinyint
+truncate table t1;
+truncate table t2;
+insert into t1(c_key, c_tinyint) values (1, 1), (2, 1), (3, 1), (4, 2), (5, 2), (6, 3);
+insert into t2(c_key, c_tinyint) values (1, 1), (2, 2), (3, 3);
+select t1.c_key, t2.c_key from t1 join [skew|t1.c_tinyint(1,2,8)] t2 on t1.c_tinyint=t2.c_tinyint order by t1.c_key, t2.c_key;
+
+-- smallint
+truncate table t1;
+truncate table t2;
+insert into t1(c_key, c_smallint) values (1, 1), (2, 1), (3, 1), (4, 1111), (5, 1111), (6, 3);
+insert into t2(c_key, c_smallint) values (1, 1), (2, 1111), (3, 3);
+select t1.c_key, t2.c_key from t1 join [skew|t1.c_smallint(1,1111,4444)] t2 on t1.c_smallint=t2.c_smallint order by t1.c_key, t2.c_key;
+
+-- int
+truncate table t1;
+truncate table t2;
+insert into t1(c_key, c_int) values (1, 1), (2, 1), (3, 1), (4, 1234567), (5, 1234567), (6, 3);
+insert into t2(c_key, c_int) values (1, 1), (2, 1234567), (3, 3);
+select t1.c_key, t2.c_key from t1 join [skew|t1.c_int(1,1234567,4444)] t2 on t1.c_int=t2.c_int order by t1.c_key, t2.c_key;
+
+-- bigint
+truncate table t1;
+truncate table t2;
+insert into t1(c_key, c_bigint) values (1, 1), (2, 1), (3, 1), (4, 12345678912), (5, 12345678912), (6, 3);
+insert into t2(c_key, c_bigint) values (1, 1), (2, 12345678912), (3, 3);
+select t1.c_key, t2.c_key from t1 join [skew|t1.c_bigint(1,12345678912,4444)] t2 on t1.c_bigint=t2.c_bigint order by t1.c_key, t2.c_key;
+
+-- largeint
+truncate table t1;
+truncate table t2;
+insert into t1(c_key, c_largeint) values (1, 1), (2, 1), (3, 1), (4, 18446744073709551620), (5, 18446744073709551620), (6, 3);
+insert into t2(c_key, c_largeint) values (1, 1), (2, 18446744073709551620), (3, 3);
+select t1.c_key, t2.c_key from t1 join [skew|t1.c_largeint(1,18446744073709551620,4444)] t2 on t1.c_largeint=t2.c_largeint order by t1.c_key, t2.c_key;
+
+-- float
+truncate table t1;
+truncate table t2;
+insert into t1(c_key, c_float) values (1, 1.1), (2, 1.1), (3, 1.1), (4, 2.1), (5, 2.1), (6, 3);
+insert into t2(c_key, c_float) values (1, 1.1), (2, 2.1), (3, 3);
+select t1.c_key, t2.c_key from t1 join [skew|t1.c_float(1.1,2.1,4444)] t2 on t1.c_float=t2.c_float order by t1.c_key, t2.c_key;
+
+-- double
+truncate table t1;
+truncate table t2;
+insert into t1(c_key, c_double) values (1, 1.1), (2, 1.1), (3, 1.1), (4, 2.1), (5, 2.1), (6, 3);
+insert into t2(c_key, c_double) values (1, 1.1), (2, 2.1), (3, 3);
+select t1.c_key, t2.c_key from t1 join [skew|t1.c_double(1.1,2.1,4444)] t2 on t1.c_double=t2.c_double order by t1.c_key, t2.c_key;
+
+-- decimal
+truncate table t1;
+truncate table t2;
+insert into t1(c_key, c_decimal) values (1, 1.1), (2, 1.1), (3, 1.1), (4, 2.1), (5, 2.1), (6, 3);
+insert into t2(c_key, c_decimal) values (1, 1.1), (2, 2.1), (3, 3);
+select t1.c_key, t2.c_key from t1 join [skew|t1.c_decimal(1.1,2.1,4444)] t2 on t1.c_decimal=t2.c_decimal order by t1.c_key, t2.c_key;
+
+-- date
+truncate table t1;
+truncate table t2;
+insert into t1(c_key, c_date) values
+    (1, "2024-01-01"), (2, "2024-01-01"), (3, "2024-01-01"),
+    (4, "2024-01-02"), (5, "2024-01-02"), (6, "2024-01-03");
+insert into t2(c_key, c_date) values (1, "2024-01-01"), (2, "2024-01-02"), (3, "2024-01-03");
+select t1.c_key, t2.c_key from t1 join [skew|t1.c_date("2024-01-01","2024-01-02","2024-01-04")] t2 on t1.c_date=t2.c_date order by t1.c_key, t2.c_key;
+
+-- datetime
+truncate table t1;
+truncate table t2;
+insert into t1(c_key, c_datetime) values
+    (1, "2024-01-01 00:00:00"),
+    (2, "2024-01-01 00:00:00"),
+    (3, "2024-01-01 00:00:00"),
+    (4, "2024-01-02 00:00:00"),
+    (5, "2024-01-02 00:00:00"),
+    (6, "2024-01-03 00:00:00");
+insert into t2(c_key, c_datetime) values
+    (1, "2024-01-01 00:00:00"),
+    (2, "2024-01-02 00:00:00"),
+    (3, "2024-01-03 00:00:00");
+select t1.c_key, t2.c_key from t1 join [skew|t1.c_datetime("2024-01-01 00:00:00","2024-01-02","2024-01-04")] t2 on t1.c_datetime=t2.c_datetime order by t1.c_key, t2.c_key;
+
+-- string
+truncate table t1;
+truncate table t2;
+insert into t1(c_key, c_string) values ("1", "1"), ("2", "1"), ("3", "1"), ("4", "1234567"), ("5", "1234567"), ("6", "3");
+insert into t2(c_key, c_string) values ("1", "1"), ("2", "1234567"), ("3", "3");
+select t1.c_key, t2.c_key from t1 join [skew|t1.c_string("1","1234567","4444")] t2 on t1.c_string=t2.c_string order by t1.c_key, t2.c_key;
+
+-- type not match
+truncate table t1;
+truncate table t2;
+insert into t1(c_key, c_int) values (1, 1), (2, 1), (3, 1), (4, 1234567), (5, 1234567), (6, 3);
+insert into t2(c_key, c_bigint) values (1, 1), (2, 1234567), (3, 3);
+select t1.c_key, t2.c_key from t1 join [skew|t1.c_int(1,2,99999)] t2 on t1.c_int=t2.c_bigint order by t1.c_key, t2.c_key;
+
+-- type not match
+truncate table t1;
+truncate table t2;
+insert into t1(c_key, c_bigint) values (1, 1), (2, 1), (3, 1), (4, 1234567), (5, 1234567), (6, 3);
+insert into t2(c_key, c_int) values (1, 1), (2, 1234567), (3, 3);
+select t1.c_key, t2.c_key from t1 join [skew|t1.c_bigint(1,2,99999)] t2 on t1.c_bigint=t2.c_int order by t1.c_key, t2.c_key;
+
+-- type not match
+truncate table t1;
+truncate table t2;
+insert into t1(c_key, c_string) values (1, "1"), (2, "1"), (3, "1"), (4, "1234567"), (5, "1234567"), (6, "3");
+insert into t2(c_key, c_int) values (1, 1), (2, 1234567), (3, 3);
+select t1.c_key, t2.c_key from t1 join [skew|t1.c_string("1","2","99999")] t2 on t1.c_string=t2.c_int order by t1.c_key, t2.c_key;

--- a/test/sql/test_join/T/test_skew_join
+++ b/test/sql/test_join/T/test_skew_join
@@ -148,3 +148,10 @@ truncate table t2;
 insert into t1(c_key, c_string) values (1, "1"), (2, "1"), (3, "1"), (4, "1234567"), (5, "1234567"), (6, "3");
 insert into t2(c_key, c_int) values (1, 1), (2, 1234567), (3, 3);
 select t1.c_key, t2.c_key from t1 join [skew|t1.c_string("1","2","99999")] t2 on t1.c_string=t2.c_int order by t1.c_key, t2.c_key;
+
+-- type not match
+truncate table t1;
+truncate table t2;
+insert into t1(c_key, c_bigint) values (1, 1), (2, 1), (3, 1), (4, 1234567), (5, 1234567), (6, 3);
+insert into t2(c_key, c_int) values (1, 1), (2, 1234567), (3, 3);
+select t1.c_key, t2.c_key from t1 join [skew|t1.c_bigint(1,2,99999)] t2 on t1.c_bigint=t2.c_int order by t1.c_key, t2.c_key;


### PR DESCRIPTION
## Why I'm doing:

```
CREATE TABLE t1 (
    c_key      INT NOT NULL,
    c_tinyint  TINYINT,
    c_smallint SMALLINT,
    c_int      INT,
    c_bigint   BIGINT,
    c_largeint LARGEINT,
    c_float    FLOAT,
    c_double   DOUBLE,
    c_decimal  DECIMAL(26,2),
    c_date     DATE,
    c_datetime DATETIME,
    c_string   STRING
)
DUPLICATE KEY(c_key)
DISTRIBUTED BY HASH(c_key) BUCKETS 1
PROPERTIES (
    "replication_num"="1"
);

CREATE TABLE t2 (
    c_key      INT NOT NULL,
    c_tinyint  TINYINT,
    c_smallint SMALLINT,
    c_int      INT,
    c_bigint   BIGINT,
    c_largeint LARGEINT,
    c_float    FLOAT,
    c_double   DOUBLE,
    c_decimal  DECIMAL(26,2),
    c_date     DATE,
    c_datetime DATETIME,
    c_string   STRING
)
DUPLICATE KEY(c_key)
DISTRIBUTED BY HASH(c_key) BUCKETS 1
PROPERTIES (
    "replication_num"="1"
);
```

Bug 1: Type int is not supported.

```
truncate table t1;
truncate table t2;
insert into t1(c_key, c_bigint) values (1, 1), (2, 1), (3, 1), (4, 12345678912), (5, 12345678912), (6, 3);
insert into t2(c_key, c_bigint) values (1, 1), (2, 12345678912), (3, 3);
```
```
mysql> select t1.c_key, t2.c_key from t1 join [skew|t1.c_bigint(1,12345678912,4444)] t2 on t1.c_bigint=t2.c_bigint order by t1.c_key, t2.c_key;
ERROR 1064 (HY000): VectorizedInPredicate type not same backend [id=10003] [host=172.26.92.227]
```

Bug 2: implicit type conversion is not supported.

```
truncate table t1;
truncate table t2;
insert into t1(c_key, c_int) values (1, 1), (2, 1), (3, 1), (4, 1234567), (5, 1234567), (6, 3);
insert into t2(c_key, c_bigint) values (1, 1), (2, 1234567), (3, 3);
```
```
mysql> select t1.c_key, t2.c_key from t1 join [skew|t1.c_int(1,2,99999)] t2 on t1.c_int=t2.c_bigint order by t1.c_key, t2.c_key;
ERROR 1064 (HY000): Can't find skew column
```

Bug3: Unknown error if skew column is not set

This pr will not fix the bug;

```
mysql> select t1.c_key, t2.c_key from t1 join [skew] t2 on t1.c_int=t2.c_bigint order by t1.c_key, t2.c_key;
ERROR 1064 (HY000): Unknown error
```

Bug4: Type of skew values maybe invalid convension.

```
truncate table t1;
truncate table t2;
insert into t1(c_key, c_tinyint) values (1, 1), (2, 1), (3, 1), (4, 2), (5, 2), (6, 3);
insert into t2(c_key, c_tinyint) values (1, 1), (2, 2), (3, 3);

select t1.c_key, t2.c_key from t1 join [skew|t1.c_tinyint(1,2,88888)] t2 on t1.c_tinyint=t2.c_tinyint order by t1.c_key, t2.c_key;
ERROR 1064 (HY000): VectorizedInPredicate type not same backend [id=10003] [host=172.26.92.227]
```

## What I'm doing:

1. Skew values should cast to the type of column.
2. The result type of round() is BigInt, so generate_series also need to use bigint.
3. Support implicit cast.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [x] 3.1
  - [ ] 3.0
  - [ ] 2.5
