### PR TITLE
[BugFix] Fix bug in schema change with sort key in shared_data mode

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/alter/LakeTableSchemaChangeJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/LakeTableSchemaChangeJob.java
@@ -340,7 +340,7 @@ public class LakeTableSchemaChangeJob extends AlterJobV2 {
                             .setId(shadowIdxId) // For newly create materialized index, schema id equals to index id
                             .setKeysType(originKeysType)
                             .setShortKeyColumnCount(shadowShortKeyColumnCount)
-                            .setSortKeyUniqueIds(copiedSortKeyIdxes)
+                            .setSortKeyIndexes(copiedSortKeyIdxes)
                             .setSortKeyUniqueIds(null)
                             .setIndexes(indexes)
                             .setBloomFilterColumnNames(bfColumns)


### PR DESCRIPTION
## Why I'm doing:
Bitmap index can not be created in cloud native pk table with sortkey. In fact, bitmap index can not be added if table has sortkey in shared_data node. The root cause is `SortKeyUniqueIds` is set twice and the precondition will fail. Because if a table has sortkey, when `SortKeyUniqueIds` is set in the first time, the precondition will fail in the second time. What's more, `SortKeyIndexes` is not set.
## What I'm doing:
 Fix bug in schema change with sort key in shared_data mode
Fixes #issue
In https://github.com/StarRocks/StarRocksTest/issues/6731
## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
