### PR TITLE
[Enhancement] Set thread local information for async task executed in IO threads pool

### DIFF
--- a/be/src/formats/csv/csv_file_writer.cpp
+++ b/be/src/formats/csv/csv_file_writer.cpp
@@ -113,6 +113,8 @@ std::future<FileWriter::CommitResult> CSVFileWriter::commit() {
                  location = _location, state = _runtime_state] {
 #ifndef BE_TEST
         SCOPED_THREAD_LOCAL_MEM_TRACKER_SETTER(state->instance_mem_tracker());
+        CurrentThread::current().set_query_id(state->query_id());
+        CurrentThread::current().set_fragment_instance_id(state->fragment_instance_id());
 #endif
         FileWriter::CommitResult result{
                 .io_status = Status::OK(), .format = CSV, .location = location, .rollback_action = rollback};

--- a/be/src/formats/orc/orc_file_writer.cpp
+++ b/be/src/formats/orc/orc_file_writer.cpp
@@ -123,6 +123,8 @@ std::future<FileWriter::CommitResult> ORCFileWriter::commit() {
                  row_counter = _row_counter, location = _location, state = _runtime_state] {
 #ifndef BE_TEST
         SCOPED_THREAD_LOCAL_MEM_TRACKER_SETTER(state->instance_mem_tracker());
+        CurrentThread::current().set_query_id(state->query_id());
+        CurrentThread::current().set_fragment_instance_id(state->fragment_instance_id());
 #endif
         FileWriter::CommitResult result{
                 .io_status = Status::OK(), .format = ORC, .location = location, .rollback_action = rollback};

--- a/be/src/formats/parquet/parquet_file_writer.cpp
+++ b/be/src/formats/parquet/parquet_file_writer.cpp
@@ -62,6 +62,8 @@ std::future<FileWriter::CommitResult> ParquetFileWriter::commit() {
                  location = _location, state = _runtime_state, execution_state = _execution_state] {
 #ifndef BE_TEST
         SCOPED_THREAD_LOCAL_MEM_TRACKER_SETTER(state->instance_mem_tracker());
+        CurrentThread::current().set_query_id(state->query_id());
+        CurrentThread::current().set_fragment_instance_id(state->fragment_instance_id());
 #endif
         {
             // commit until all rowgroup flushing tasks have been done
@@ -122,6 +124,8 @@ std::future<Status> ParquetFileWriter::_flush_row_group() {
                  execution_state = _execution_state] {
 #ifndef BE_TEST
         SCOPED_THREAD_LOCAL_MEM_TRACKER_SETTER(state->instance_mem_tracker());
+        CurrentThread::current().set_query_id(state->query_id());
+        CurrentThread::current().set_fragment_instance_id(state->fragment_instance_id());
 #endif
         try {
             rowgroup_writer->close();
@@ -131,6 +135,8 @@ std::future<Status> ParquetFileWriter::_flush_row_group() {
             LOG(WARNING) << exception;
             p->set_value(exception);
         }
+
+        CHECK(false);
 
         {
             std::lock_guard lock(execution_state->mu);

--- a/be/src/formats/parquet/parquet_file_writer.cpp
+++ b/be/src/formats/parquet/parquet_file_writer.cpp
@@ -136,8 +136,6 @@ std::future<Status> ParquetFileWriter::_flush_row_group() {
             p->set_value(exception);
         }
 
-        CHECK(false);
-
         {
             std::lock_guard lock(execution_state->mu);
             execution_state->has_unfinished_task = false;


### PR DESCRIPTION
## Why I'm doing:

To ease debugging, set thread local information for async task executed in IO threads pool

## What I'm doing:

Set `query_id` and `fragment_instance_id`

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
