### PR TITLE
[Enhancement][Cherry-Pick][Branch-3.2] Merge multiply blocks into one io request in CacheInputStream (backport #38882)

### DIFF
--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -807,10 +807,6 @@ CONF_Int64(object_storage_request_timeout_ms, "-1");
 CONF_Strings(fallback_to_hadoop_fs_list, "");
 CONF_Strings(s3_compatible_fs_list, "s3n://, s3a://, s3://, oss://, cos://, cosn://, obs://, ks3://, tos://");
 
-// text reader
-// Spilt text file's scan range into io ranges of 16mb size
-CONF_Int64(text_io_range_size, "16777216");
-
 // orc reader
 CONF_Bool(enable_orc_late_materialization, "true");
 CONF_Bool(enable_orc_libdeflate_decompression, "true");

--- a/be/src/exec/hdfs_scanner_text.cpp
+++ b/be/src/exec/hdfs_scanner_text.cpp
@@ -51,8 +51,6 @@ public:
 
     Status next_record(Record* record);
 
-    size_t get_offset();
-
 protected:
     Status _fill_buffer() override;
 
@@ -66,10 +64,6 @@ private:
     bool _should_stop_scan = false;
     bool _should_stop_next = false;
 };
-
-size_t HdfsScannerCSVReader::get_offset() {
-    return _offset;
-}
 
 Status HdfsScannerCSVReader::reset(size_t offset, size_t remain_length) {
     RETURN_IF_ERROR(_file->seek(offset));
@@ -192,7 +186,6 @@ Status HdfsTextScanner::do_open(RuntimeState* runtime_state) {
         }
     }
     RETURN_IF_ERROR(open_random_access_file());
-    RETURN_IF_ERROR(_setup_io_ranges());
     RETURN_IF_ERROR(_create_or_reinit_reader());
     SCOPED_RAW_TIMER(&_app_stats.reader_init_ns);
     RETURN_IF_ERROR(_build_hive_column_name_2_index());
@@ -237,12 +230,6 @@ Status HdfsTextScanner::do_get_next(RuntimeState* runtime_state, ChunkPtr* chunk
 }
 
 Status HdfsTextScanner::parse_csv(int chunk_size, ChunkPtr* chunk) {
-    if (_shared_buffered_input_stream != nullptr) {
-        // we need to release previous shared buffers to save memory
-        const size_t reader_offset = down_cast<HdfsScannerCSVReader*>(_reader.get())->get_offset();
-        _shared_buffered_input_stream->release_to_offset(reader_offset);
-    }
-
     DCHECK_EQ(0, chunk->get()->num_rows());
 
     int num_columns = chunk->get()->num_columns();
@@ -380,20 +367,6 @@ Status HdfsTextScanner::_create_or_reinit_reader() {
             CSVReader::Record dummy;
             RETURN_IF_ERROR(reader->next_record(&dummy));
         }
-    }
-    return Status::OK();
-}
-
-Status HdfsTextScanner::_setup_io_ranges() const {
-    if (_shared_buffered_input_stream != nullptr) {
-        std::vector<io::SharedBufferedInputStream::IORange> ranges{};
-        const int64_t scan_range_end = _scanner_params.scan_range->offset + _scanner_params.scan_range->length;
-        for (int64_t offset = _scanner_params.scan_range->offset; offset < scan_range_end;) {
-            const int64_t remain_length = std::min(config::text_io_range_size, scan_range_end - offset);
-            ranges.emplace_back(offset, remain_length);
-            offset += remain_length;
-        }
-        RETURN_IF_ERROR(_shared_buffered_input_stream->set_io_ranges(ranges));
     }
     return Status::OK();
 }

--- a/be/src/exec/hdfs_scanner_text.h
+++ b/be/src/exec/hdfs_scanner_text.h
@@ -36,7 +36,6 @@ public:
     int64_t estimated_mem_usage() const override;
 
 private:
-    Status _setup_io_ranges() const;
     // create a reader or re init reader
     Status _create_or_reinit_reader();
     Status _build_hive_column_name_2_index();

--- a/be/src/io/cache_input_stream.cpp
+++ b/be/src/io/cache_input_stream.cpp
@@ -57,7 +57,9 @@ CacheInputStream::CacheInputStream(const std::shared_ptr<SharedBufferedInputStre
         uint32_t file_size = _size;
         memcpy(data + 8, &file_size, sizeof(file_size));
     }
-    _buffer.reserve(_block_size);
+    // default _buffer size is 4MB = (16 * 256KB)
+    _buffer_size = 16 * _block_size;
+    _buffer.reserve(_buffer_size);
 }
 
 CacheInputStream::~CacheInputStream() {
@@ -68,7 +70,7 @@ CacheInputStream::~CacheInputStream() {
     }
 }
 
-Status CacheInputStream::_read_block(int64_t offset, int64_t size, char* out, bool can_zero_copy) {
+Status CacheInputStream::_read_block_from_local(const int64_t offset, const int64_t size, char* out) {
     if (UNLIKELY(size == 0)) {
         return Status::OK();
     }
@@ -142,42 +144,91 @@ Status CacheInputStream::_read_block(int64_t offset, int64_t size, char* out, bo
     }
     if (!res.is_not_found() && !res.is_resource_busy()) return res;
 
-    // read remote
-    char* src = nullptr;
     if (sb) {
         // Duplicate the block ranges to avoid saving the same data both in cache and shared buffer.
         _deduplicate_shared_buffer(sb);
-        const uint8_t* buffer = nullptr;
-        RETURN_IF_ERROR(_sb_stream->get_bytes(&buffer, block_offset, load_size));
-        strings::memcpy_inlined(out, buffer + shift, size);
-        src = (char*)buffer;
-    } else {
-        if (!can_zero_copy || (shift != 0)) {
-            can_zero_copy = false;
-            src = _buffer.data();
-        } else {
-            src = out;
-        }
-
-        // if not found, read from stream and write back to cache.
-        RETURN_IF_ERROR(_sb_stream->read_at_fully(block_offset, src, load_size));
-        if (!can_zero_copy) {
-            strings::memcpy_inlined(out, src + shift, size);
-        }
     }
 
-    if (_enable_populate_cache && res.is_not_found()) {
-        SCOPED_RAW_TIMER(&_stats.write_cache_ns);
-        WriteCacheOptions options;
-        Status r = _cache->write_buffer(_cache_key, block_offset, load_size, src, &options);
+    return Status::NotFound("Not Found");
+}
+
+Status CacheInputStream::_read_blocks_from_remote(const int64_t offset, const int64_t size, char* out) {
+    const int64_t start_block_id = offset / _block_size;
+    const int64_t end_block_id = (offset + size - 1) / _block_size;
+
+    // We will load range=[read_start_offset, read_end_offset) from remote
+    const int64_t block_start_offset = start_block_id * _block_size;
+    const int64_t block_end_offset = std::min(end_block_id * _block_size + _block_size, _size);
+
+    // cursors for `out`
+    int64_t out_offset_cursor = offset;
+    int64_t out_remain_size = size;
+    char* out_pointer_cursor = out;
+
+    for (int64_t read_offset_cursor = block_start_offset; read_offset_cursor < block_end_offset;) {
+        // Everytime read at most one buffer size
+        const int64_t read_size = std::min(_buffer_size, block_end_offset - read_offset_cursor);
+        char* src = nullptr;
+
+        // check [read_offset_cursor, read_size) is already in SharedBuffer
+        // If existed, we can use zero copy to avoid copy data from SharedBuffer to _buffer
+        auto ret = _sb_stream->find_shared_buffer(read_offset_cursor, read_size);
+        if (ret.ok()) {
+            const uint8_t* buffer = nullptr;
+            RETURN_IF_ERROR(_sb_stream->get_bytes(&buffer, read_offset_cursor, read_size));
+            src = (char*)buffer;
+        } else {
+            RETURN_IF_ERROR(_sb_stream->read_at_fully(read_offset_cursor, _buffer.data(), read_size));
+            src = _buffer.data();
+        }
+
+        // write _buffer's data into `out`
+        const int64_t shift = out_offset_cursor - read_offset_cursor;
+        const int64_t out_size = std::min(read_size - shift, out_remain_size);
+        if (out_size > 0) {
+            strings::memcpy_inlined(out_pointer_cursor, src + shift, out_size);
+
+            // cursor for `out`
+            out_offset_cursor += out_size;
+            out_pointer_cursor += out_size;
+            out_remain_size -= out_size;
+        }
+
+        if (_enable_populate_cache) {
+            RETURN_IF_ERROR(_populate_to_cache(read_offset_cursor, read_size, src));
+        }
+
+        read_offset_cursor += read_size;
+    }
+    DCHECK_EQ(0, out_remain_size);
+    DCHECK_EQ(offset + size, out_offset_cursor);
+    DCHECK_EQ(out + size, out_pointer_cursor);
+
+    return Status::OK();
+}
+
+Status CacheInputStream::_populate_to_cache(const int64_t offset, const int64_t size, char* src) {
+    SCOPED_RAW_TIMER(&_stats.write_cache_ns);
+    const int64_t write_end_offset = offset + size;
+    char* src_cursor = src;
+
+    for (int64_t write_offset_cursor = offset; write_offset_cursor < write_end_offset;) {
+        DCHECK(write_offset_cursor % _block_size == 0);
+        WriteCacheOptions options{};
+        const int64_t write_size = std::min(_block_size, write_end_offset - write_offset_cursor);
+        Status r = _cache->write_buffer(_cache_key, write_offset_cursor, write_size, src_cursor, &options);
+
+        src_cursor += write_size;
+        write_offset_cursor += write_size;
+
         if (r.ok()) {
             _stats.write_cache_count += 1;
-            _stats.write_cache_bytes += load_size;
+            _stats.write_cache_bytes += write_size;
             _stats.write_mem_cache_bytes += options.stats.write_mem_bytes;
             _stats.write_disk_cache_bytes += options.stats.write_disk_bytes;
         } else if (!r.is_already_exist()) {
             _stats.write_cache_fail_count += 1;
-            _stats.write_cache_fail_bytes += load_size;
+            _stats.write_cache_fail_bytes += write_size;
             LOG(WARNING) << "write block cache failed, errmsg: " << r.get_error_msg();
             // Failed to write cache, but we can keep processing query.
         }
@@ -215,30 +266,87 @@ void CacheInputStream::_deduplicate_shared_buffer(SharedBufferedInputStream::Sha
     sb->size = end - sb->offset;
 }
 
+struct ReadFromRemoteIORange {
+    ReadFromRemoteIORange(const int64_t offset, char* write_pointer, const int64_t size)
+            : offset(offset), write_pointer(write_pointer), size(size) {}
+    const int64_t offset;
+    char* write_pointer;
+    const int64_t size;
+};
+
 Status CacheInputStream::read_at_fully(int64_t offset, void* out, int64_t count) {
-    BlockCache* cache = BlockCache::instance();
+    const int64_t origin_offset = offset;
     count = std::min(_size - offset, count);
     if (count < 0) {
         return Status::EndOfFile("");
     }
-    const int64_t _block_size = cache->block_size();
+    const int64_t end_offset = offset + count;
+
     char* p = static_cast<char*>(out);
     char* pe = p + count;
 
-    int64_t end_offset = offset + count;
-    int64_t start_block_id = offset / _block_size;
-    int64_t end_block_id = (end_offset - 1) / _block_size;
+    const int64_t _block_size = _cache->block_size();
+    const int64_t start_block_id = offset / _block_size;
+    const int64_t end_block_id = (end_offset - 1) / _block_size;
+
+    std::vector<ReadFromRemoteIORange> need_read_from_remote{};
+
     for (int64_t i = start_block_id; i <= end_block_id; i++) {
         size_t off = std::max(offset, i * _block_size);
         size_t end = std::min((i + 1) * _block_size, end_offset);
         size_t size = end - off;
-        bool can_zero_copy = p + _block_size < pe;
-        Status st = _read_block(off, size, p, can_zero_copy);
-        if (!st.ok()) return st;
+        Status st = _read_block_from_local(off, size, p);
+        if (st.is_not_found()) {
+            // Not found block from local, we need to load it from remote
+            need_read_from_remote.emplace_back(off, p, size);
+        } else if (!st.ok()) {
+            return st;
+        }
         offset += size;
         p += size;
     }
     DCHECK(p == pe);
+
+    if (need_read_from_remote.size() == 0) {
+        return Status::OK();
+    }
+
+    // Merged multiple continous io range into one big io range
+    std::vector<ReadFromRemoteIORange> merged_need_read_from_remote{};
+    auto do_merge = [&](const size_t from, const size_t to) {
+        // merge range = [from, to]
+        ReadFromRemoteIORange& from_io_range = need_read_from_remote[from];
+        ReadFromRemoteIORange& to_io_range = need_read_from_remote[to];
+        int64_t start_offset = from_io_range.offset;
+        int64_t merged_size = to_io_range.offset + to_io_range.size - from_io_range.offset;
+        // check write pointer is continous
+        DCHECK(from_io_range.write_pointer + merged_size == to_io_range.write_pointer + to_io_range.size);
+        merged_need_read_from_remote.emplace_back(start_offset, from_io_range.write_pointer, merged_size);
+    };
+
+    size_t unmerge = 0;
+    for (size_t i = 1; i < need_read_from_remote.size(); i++) {
+        const auto& prev = need_read_from_remote[i - 1];
+        const auto& now = need_read_from_remote[i];
+        size_t prev_end = prev.offset + prev.size;
+        size_t now_start = now.offset;
+        if (now_start != prev_end) {
+            // offset not matched, start to merge from [unmerge, i - 1]
+            do_merge(unmerge, i - 1);
+            unmerge = i;
+        }
+    }
+    do_merge(unmerge, need_read_from_remote.size() - 1);
+
+    // Don't need it anymore
+    need_read_from_remote.clear();
+
+    for (const auto& io_range : merged_need_read_from_remote) {
+        DCHECK(io_range.offset >= origin_offset);
+        DCHECK(io_range.offset + io_range.size <= origin_offset + count);
+        RETURN_IF_ERROR(_read_blocks_from_remote(io_range.offset, io_range.size, io_range.write_pointer));
+    }
+
     return Status::OK();
 }
 

--- a/be/src/io/cache_input_stream.h
+++ b/be/src/io/cache_input_stream.h
@@ -82,7 +82,11 @@ private:
         IOBuffer buffer;
     };
 
-    Status _read_block(int64_t offset, int64_t size, char* out, bool single_read);
+    // Read block from local, if not found, will return Status::NotFound();
+    Status _read_block_from_local(const int64_t offset, const int64_t size, char* out);
+    // Read multiple blocks from remote
+    Status _read_blocks_from_remote(const int64_t offset, const int64_t size, char* out);
+    Status _populate_to_cache(const int64_t offset, const int64_t size, char* src);
     void _populate_cache_from_zero_copy_buffer(const char* p, int64_t offset, int64_t count);
     void _deduplicate_shared_buffer(SharedBufferedInputStream::SharedBuffer* sb);
 
@@ -90,6 +94,7 @@ private:
     std::string _filename;
     std::shared_ptr<SharedBufferedInputStream> _sb_stream;
     int64_t _offset;
+    int64_t _buffer_size;
     std::string _buffer;
     Stats _stats;
     int64_t _size;


### PR DESCRIPTION
cp from #38882

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [x] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5

