### PR TITLE
[BugFix] fix projection ref non-exist cols

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/PruneGroupByKeysRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/PruneGroupByKeysRule.java
@@ -86,7 +86,7 @@ public class PruneGroupByKeysRule extends TransformationRule {
                     "cannot find grouping key from projections");
 
             // if the output col of this groupingExpr had been added into the newGroupingKeys, it means this
-            // is a duplicate group by ket, we can skip it. But we need add a projection using after the agg
+            // is a duplicate group by key, we can skip it. But we need add a projection using after the agg
             // to ensure the correct output columns and the projection should use agg output to rewrite.
             if (groupingExpr.isColumnRef()) {
                 ColumnRefOperator inputCol = (ColumnRefOperator) groupingExpr;

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/PruneGroupByKeysRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/PruneGroupByKeysRule.java
@@ -86,7 +86,7 @@ public class PruneGroupByKeysRule extends TransformationRule {
                     "cannot find grouping key from projections");
 
             // if the output col of this groupingExpr had been added into the newGroupingKeys, it means this
-            // is a duplicate group by key, we can skip it. But we need add a projection using after the agg
+            // is a duplicate group by key, we can skip it. But we need add a projection above the agg
             // to ensure the correct output columns and the projection should use agg output to rewrite.
             if (groupingExpr.isColumnRef()) {
                 ColumnRefOperator inputCol = (ColumnRefOperator) groupingExpr;


### PR DESCRIPTION
## Why I'm doing:
After a series of optimizations, we may yield a plan like:
```
group by col1, col2, col3
    project (col1 <-> col0, col2 <-> col0, col3 <->3)
```
This makes `PruneGroupByKeysRule` takes effect. It may reduce the col2 in group by key and add a projection (col2 <-> col0) above the agg which can only output col1, col3.

## What I'm doing:
Use the group by key to rewrite the projection above agg.

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [x] 3.1
  - [ ] 3.0
  - [ ] 2.5
