### PR TITLE
[BugFix] fix hdfs scanner cpu time negative problem

### DIFF
--- a/be/src/exec/vectorized/hdfs_scanner.cpp
+++ b/be/src/exec/vectorized/hdfs_scanner.cpp
@@ -81,6 +81,7 @@ bool HdfsScannerParams::is_lazy_materialization_slot(SlotId slot_id) const {
 }
 
 Status HdfsScanner::init(RuntimeState* runtime_state, const HdfsScannerParams& scanner_params) {
+    SCOPED_RAW_TIMER(&_total_running_time);
     _runtime_state = runtime_state;
     _scanner_params = scanner_params;
     Status status = do_init(runtime_state, scanner_params);
@@ -161,6 +162,7 @@ Status HdfsScanner::open(RuntimeState* runtime_state) {
     if (_opened) {
         return Status::OK();
     }
+    SCOPED_RAW_TIMER(&_total_running_time);
     _build_scanner_context();
     auto status = do_open(runtime_state);
     if (status.ok()) {


### PR DESCRIPTION
## Why I'm doing:
audit log can be negative with hive table because hive table's cpu time could be negative by wrong calculation of cpu time.
hive_cpu_time = total_running_time - io_time. but io_time is correct, total_running_time miss the hdfs_scanner::open and hdfs_scanner::init's time, which cause hive_cpu_time < 0 when hive table is small in which situation hdfs_scanner::open's time can not be Neglected


## What I'm doing:
correct the cpu time of hive table

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
- [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [x] 3.1
  - [x] 3.0
  - [ ] 2.5

