### PR TITLE
[Enhancement] avoid useless compaction in cloud native pk table

### DIFF
--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -964,6 +964,7 @@ CONF_mInt64(lake_max_garbage_version_distance, "100");
 CONF_mBool(enable_primary_key_recover, "false");
 CONF_mBool(lake_enable_compaction_async_write, "false");
 CONF_mInt64(lake_pk_compaction_max_input_rowsets, "1000");
+CONF_mInt64(lake_pk_compaction_min_input_segments, "5");
 // Used for control memory usage of update state cache and compaction state cache
 CONF_mInt32(lake_pk_preload_memory_limit_percent, "30");
 

--- a/be/src/storage/lake/primary_key_compaction_policy.cpp
+++ b/be/src/storage/lake/primary_key_compaction_policy.cpp
@@ -78,10 +78,30 @@ StatusOr<std::vector<RowsetPtr>> PrimaryCompactionPolicy::pick_rowsets() {
     return pick_rowsets(_tablet_metadata, false, nullptr);
 }
 
+// Return true if segment number meet the requirement of min input
+bool min_input_segment_check(const std::shared_ptr<const TabletMetadataPB>& tablet_metadata) {
+    int64_t total_segment_cnt = 0;
+    for (int i = 0; i < tablet_metadata->rowsets_size(); i++) {
+        const auto& rowset = tablet_metadata->rowsets(i);
+        total_segment_cnt += rowset.overlapped() ? rowset.segments_size() : 1;
+        if (total_segment_cnt >= config::lake_pk_compaction_min_input_segments) {
+            // Return when requirement meet
+            return true;
+        }
+    }
+    return false;
+}
+
 StatusOr<std::vector<int64_t>> PrimaryCompactionPolicy::pick_rowset_indexes(
         const std::shared_ptr<const TabletMetadataPB>& tablet_metadata, bool calc_score, std::vector<bool>* has_dels) {
     UpdateManager* mgr = _tablet_mgr->update_mgr();
     std::vector<int64_t> rowset_indexes;
+    if (!min_input_segment_check(tablet_metadata)) {
+        // When the number of segments cannot meet the requirement
+        // 1. Compaction score will be zero.
+        // 2. None of rowset will be picked.
+        return rowset_indexes;
+    }
     std::vector<RowsetCandidate> rowset_vec;
     const auto tablet_id = tablet_metadata->id();
     const auto tablet_version = tablet_metadata->version();


### PR DESCRIPTION
## Why I'm doing:
In cloud native table, we schedule compaction task by partition. So if one tablet in this partition has large compaction score, FE will schedule compaction task of whole partition even if another tablets' compaction score are small and no need to do compaction.
That would be a waste of resources because of useless compaction.

## What I'm doing:
Add config `lake_pk_compaction_min_input_segments`, when tablet's overlap segment count isn't enough, tablet can skip compaction.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [x] 3.1
  - [ ] 3.0
  - [ ] 2.5
