### PR TITLE
[Refactor] make udf error message clearer

### DIFF
--- a/be/src/runtime/user_function_cache.cpp
+++ b/be/src/runtime/user_function_cache.cpp
@@ -56,10 +56,11 @@ static const int kLibShardNum = 128;
 
 // function cache entry, store information for
 struct UserFunctionCacheEntry {
-    UserFunctionCacheEntry(int64_t fid_, std::string checksum_, std::string lib_file_)
-            : function_id(fid_), checksum(std::move(checksum_)), lib_file(std::move(lib_file_)) {
-        function_type = UserFunctionCache::get_function_type(lib_file);
-    }
+    UserFunctionCacheEntry(int64_t fid_, std::string checksum_, std::string lib_file_, int function_type_)
+            : function_id(fid_),
+              checksum(std::move(checksum_)),
+              lib_file(std::move(lib_file_)),
+              function_type(function_type_) {}
     ~UserFunctionCacheEntry();
 
     int64_t function_id = 0;
@@ -148,7 +149,8 @@ StatusOr<std::any> UserFunctionCache::load_cacheable_java_udf(
 
 // Now we only support JAVA_UDF
 Status UserFunctionCache::_load_entry_from_lib(const std::string& dir, const std::string& file) {
-    if (!boost::algorithm::ends_with(file, JAVA_UDF_SUFFIX)) {
+    int type = get_function_type(file);
+    if (type != UDF_TYPE_JAVA) {
         return Status::InternalError(fmt::format("unknown library file format {}", file));
     }
 
@@ -165,7 +167,7 @@ Status UserFunctionCache::_load_entry_from_lib(const std::string& dir, const std
         return Status::InternalError("duplicate function id");
     }
     // create a cache entry and put it into entry map
-    auto entry = std::make_shared<UserFunctionCacheEntry>(function_id, checksum, dir + "/" + file);
+    auto entry = std::make_shared<UserFunctionCacheEntry>(function_id, checksum, dir + "/" + file, type);
     entry->is_downloaded = true;
     _entry_map[function_id] = entry;
 
@@ -203,10 +205,14 @@ Status UserFunctionCache::_load_cached_lib() {
 template <class Loader>
 Status UserFunctionCache::_get_cache_entry(int64_t fid, const std::string& url, const std::string& checksum,
                                            UserFunctionCacheEntryPtr* output_entry, Loader&& loader) {
-    std::string shuffix = "tmp";
+    std::string suffix = ".unk";
     int type = get_function_type(url);
     if (type == UDF_TYPE_JAVA) {
-        shuffix = JAVA_UDF_SUFFIX;
+        suffix = JAVA_UDF_SUFFIX;
+    }
+    if (type != UDF_TYPE_JAVA) {
+        return Status::NotSupported(
+                fmt::format("unsupport udf type: {}, url: {}. url suffix must be '{}'", type, url, JAVA_UDF_SUFFIX));
     }
 
     UserFunctionCacheEntryPtr entry;
@@ -216,7 +222,8 @@ Status UserFunctionCache::_get_cache_entry(int64_t fid, const std::string& url, 
         if (it != _entry_map.end()) {
             entry = it->second;
         } else {
-            entry = std::make_shared<UserFunctionCacheEntry>(fid, checksum, _make_lib_file(fid, checksum, shuffix));
+            entry = std::make_shared<UserFunctionCacheEntry>(fid, checksum, _make_lib_file(fid, checksum, suffix),
+                                                             type);
             _entry_map.emplace(fid, entry);
         }
     }
@@ -253,7 +260,7 @@ Status UserFunctionCache::_load_cache_entry(const std::string& url, UserFunction
         RETURN_IF_ERROR(_download_lib(url, entry));
     }
 
-    RETURN_IF_ERROR(_load_cache_entry_internal(entry, loader));
+    RETURN_IF_ERROR(_load_cache_entry_internal(url, entry, loader));
     return Status::OK();
 }
 
@@ -274,12 +281,14 @@ Status UserFunctionCache::_download_lib(const std::string& url, UserFunctionCach
 
 // entry's lock must be held
 template <class Loader>
-Status UserFunctionCache::_load_cache_entry_internal(UserFunctionCacheEntryPtr& entry, Loader&& loader) {
+Status UserFunctionCache::_load_cache_entry_internal(const std::string& url, UserFunctionCacheEntryPtr& entry,
+                                                     Loader&& loader) {
     if (entry->function_type == UDF_TYPE_JAVA) {
         // nothing to do
         ASSIGN_OR_RETURN(entry->cache_handle, loader(entry->lib_file));
     } else {
-        return Status::InternalError(fmt::format("unsupport udf type: {}", entry->function_type));
+        return Status::NotSupported(fmt::format("unsupport udf type: {}, url: {}. url suffix must be '{}'",
+                                                entry->function_type, url, JAVA_UDF_SUFFIX));
     }
     entry->is_loaded.store(true);
     return Status::OK();

--- a/be/src/runtime/user_function_cache.h
+++ b/be/src/runtime/user_function_cache.h
@@ -89,7 +89,7 @@ private:
     Status _load_cache_entry(const std::string& url, UserFunctionCacheEntryPtr& entry, Loader&& loader);
     Status _download_lib(const std::string& url, UserFunctionCacheEntryPtr& entry);
     template <class Loader>
-    Status _load_cache_entry_internal(UserFunctionCacheEntryPtr& entry, Loader&& loader);
+    Status _load_cache_entry_internal(const std::string& url, UserFunctionCacheEntryPtr& entry, Loader&& loader);
     std::string _make_lib_file(int64_t function_id, const std::string& checksum, const std::string& shuffix);
     void _destroy_cache_entry(UserFunctionCacheEntryPtr& entry);
 

--- a/be/test/runtime/user_function_cache_test.cpp
+++ b/be/test/runtime/user_function_cache_test.cpp
@@ -117,7 +117,7 @@ public:
         int res = 0;
 
         // compile code to so
-        // [[maybe_unused]] res =
+        // res =
         //         system("g++ -shared ./be/test/runtime/test_data/user_function_cache/lib/my_add.cc -o "
         //                "./be/test/runtime/test_data/user_function_cache/lib/my_add.so");
 
@@ -125,9 +125,13 @@ public:
 
         res = system("touch ./be/test/runtime/test_data/user_function_cache/lib/my_udf.jar");
 
+        ASSERT_EQ(res, 0) << res;
+
         jar_md5sum = compute_md5("./be/test/runtime/test_data/user_function_cache/lib/my_udf.jar");
 
         res = system("touch ./be/test/runtime/test_data/user_function_cache/lib/my_udf.wasm");
+
+        ASSERT_EQ(res, 0) << res;
 
         wasm_md5sum = compute_md5("./be/test/runtime/test_data/user_function_cache/lib/my_udf.wasm");
     }
@@ -136,10 +140,15 @@ public:
         s_server->join();
         delete s_server;
         int res = 0;
-        // [[maybe_unused]] res = system("rm -rf ./be/test/runtime/test_data/user_function_cache/lib/my_add.so");
+        // res = system("rm -rf ./be/test/runtime/test_data/user_function_cache/lib/my_add.so");
         res = system("rm -rf ./be/test/runtime/test_data/user_function_cache/lib/my_udf.jar");
+        ASSERT_EQ(res, 0) << res;
+
         res = system("rm -rf ./be/test/runtime/test_data/user_function_cache/lib/my_udf.wasm");
+        ASSERT_EQ(res, 0) << res;
+
         res = system("rm -rf ./be/test/runtime/test_data/user_function_cache/download/");
+        ASSERT_EQ(res, 0) << res;
     }
     void SetUp() override { k_is_downloaded = false; }
 };
@@ -193,7 +202,9 @@ TEST_F(UserFunctionCacheTest, load_wasm) {
     std::string lib_dir = "./be/test/runtime/test_data/user_function_cache/download";
     fs::remove_all(lib_dir);
     res = system("mkdir -p ./be/test/runtime/test_data/user_function_cache/download/0/");
+    ASSERT_EQ(res, 0) << res;
     res = system("touch ./be/test/runtime/test_data/user_function_cache/download/0/test.wasm");
+    ASSERT_EQ(res, 0) << res;
     auto st = cache.init(lib_dir);
     ASSERT_TRUE(st.ok()) << st;
 }

--- a/test/sql/test_catalog/R/test_iceberg_hadoop_catalog
+++ b/test/sql/test_catalog/R/test_iceberg_hadoop_catalog
@@ -11,18 +11,22 @@ properties (
 "iceberg.catalog.warehouse"="oss://${oss_bucket}/test_catalog/test_iceberg_hadoop_catalog/${uuid0}"
 );
 -- result:
+[]
 -- !result
 create database ice_hadoop${uuid0}.ice_hadoop_db${uuid0};
 -- result:
+[]
 -- !result
 create table ice_hadoop${uuid0}.ice_hadoop_db${uuid0}.test (
     c0 int, 
     c1 string
 );
 -- result:
+[]
 -- !result
 insert into ice_hadoop${uuid0}.ice_hadoop_db${uuid0}.test values (1, "A");
 -- result:
+[]
 -- !result
 select * from ice_hadoop${uuid0}.ice_hadoop_db${uuid0}.test;
 -- result:
@@ -30,30 +34,37 @@ select * from ice_hadoop${uuid0}.ice_hadoop_db${uuid0}.test;
 -- !result
 drop table ice_hadoop${uuid0}.ice_hadoop_db${uuid0}.test;
 -- result:
+[]
 -- !result
 create table ice_hadoop${uuid0}.ice_hadoop_db${uuid0}.test_double (
     c0 double
 );
 -- result:
+[]
 -- !result
 create table ice_hadoop${uuid0}.ice_hadoop_db${uuid0}.test_double_as as select * from ice_hadoop${uuid0}.ice_hadoop_db${uuid0}.test_double;
 -- result:
+[]
 -- !result
 describe ice_hadoop${uuid0}.ice_hadoop_db${uuid0}.test_double_as;
 -- result:
-c0	DOUBLE	Yes	false	None	
+c0	DOUBLE	Yes	false	None		None
 -- !result
 drop table ice_hadoop${uuid0}.ice_hadoop_db${uuid0}.test_double_as;
 -- result:
+[]
 -- !result
 drop table ice_hadoop${uuid0}.ice_hadoop_db${uuid0}.test_double;
 -- result:
+[]
 -- !result
 drop database ice_hadoop${uuid0}.ice_hadoop_db${uuid0};
 -- result:
+[]
 -- !result
 drop catalog ice_hadoop${uuid0};
 -- result:
+[]
 -- !result
 shell: ossutil64 rm -rf oss://${oss_bucket}/test_catalog/test_iceberg_hadoop_catalog/${uuid0} >/dev/null || echo "exit 0" >/dev/null
 -- result:


### PR DESCRIPTION
## Why I'm doing:

UDF error message is not clear

> starrocks error: unsupport udf type: -1 backend [id=13860] [host=kube-starrocks-cn-1.kube-starrocks-cn-search.starrocks.svc.cluster.local]

## What I'm doing:

With this PR, the message is like

> (1064, "unsupport udf type: -1, url: http://localhost:41006/data/sr-udf-1.0-SNAPSHOT-jar-with-dependencies.jar?v2=1. url suffix must be '.jar' backend [id=10004] [host=172.26.92.205]")

Fixes https://github.com/StarRocks/starrocks/issues/43273

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [x] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
