### PR TITLE
[BugFix] shorten jdbc driver name to avoid file name too long

### DIFF
--- a/be/src/util/download_util.cpp
+++ b/be/src/util/download_util.cpp
@@ -41,10 +41,10 @@ Status DownloadUtil::download(const std::string& url, const std::string& target_
     });
 
     if (fp == nullptr) {
-        int errnum = errno;
-        LOG(ERROR) << fmt::format("fail to open file. file = {}, error = {}", tmp_file, strerror(errnum));
+        std::string errmsg = strerror(errno);
+        LOG(ERROR) << fmt::format("fail to open file. file = {}, error = {}", tmp_file, errmsg);
         return Status::InternalError(
-                fmt::format("fail to open tmp file when downloading file from {}. error = {}", url, strerror(errnum)));
+                fmt::format("fail to open tmp file when downloading file from {}. error = {}", url, errmsg));
     }
 
     Md5Digest digest;

--- a/be/src/util/download_util.cpp
+++ b/be/src/util/download_util.cpp
@@ -28,8 +28,7 @@ namespace starrocks {
 Status DownloadUtil::download(const std::string& url, const std::string& target_file,
                               const std::string& expected_checksum) {
     auto success = false;
-    auto tmp_file =
-            fmt::format("{}_{}_{}", target_file, expected_checksum, ThreadLocalUUIDGenerator::next_uuid_string());
+    auto tmp_file = fmt::format("{}_{}", target_file, ThreadLocalUUIDGenerator::next_uuid_string());
     auto fp = fopen(tmp_file.c_str(), "w");
     DeferOp defer([&]() {
         if (fp != nullptr) {
@@ -42,8 +41,10 @@ Status DownloadUtil::download(const std::string& url, const std::string& target_
     });
 
     if (fp == nullptr) {
-        LOG(ERROR) << fmt::format("fail to open file {}", tmp_file);
-        return Status::InternalError(fmt::format("fail to open tmp file when downloading file from {}", url));
+        int errnum = errno;
+        LOG(ERROR) << fmt::format("fail to open file. file = {}, error = {}", tmp_file, strerror(errnum));
+        return Status::InternalError(
+                fmt::format("fail to open tmp file when downloading file from {}. error = {}", url, strerror(errnum)));
     }
 
     Md5Digest digest;

--- a/be/test/util/download_util_test.cpp
+++ b/be/test/util/download_util_test.cpp
@@ -82,4 +82,22 @@ TEST_F(DownloadUtilTest, test_wrong_md5) {
     ASSERT_EQ(1, files.size());
 }
 
+TEST_F(DownloadUtilTest, test_long_filename) {
+    const std::string target_file =
+            "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+            "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+            "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+            "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+            "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+            "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+            "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+            "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+            "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+            "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+    const std::string url = "http://127.0.0.1/a.txt";
+    const std::string checksum = "aaa";
+    Status st = DownloadUtil::download(url, target_file, checksum);
+    ASSERT_FALSE(st.ok()) << st;
+}
+
 } // namespace starrocks

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/JDBCTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/JDBCTable.java
@@ -37,6 +37,8 @@ import java.io.DataInput;
 import java.io.DataOutput;
 import java.io.IOException;
 import java.net.URI;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -180,9 +182,32 @@ public class JDBCTable extends Table {
         // -> jdbc_postgresql_172.26.194.237_5432_db_pg_select
         // requirement: it should be used as local path.
         // and there is no ':' in it to avoid be parsed into non-local filesystem.
-        return uri.replace("//", "")
-                .replace("/", "_")
-                .replace(":", "_");
+
+        String ans = uri.replace("//", "")
+                .replace('/', '_')
+                .replace(':', '_');
+
+        // currently we use this uri as part of name of download file.
+        // so if this uri is too long, we might fail to write file on BE side.
+        // so here we have to shorten it to reduce fail probability because of long file name.
+
+        // in most cases, jdbc uri is not that long, so we can preserve original information.
+        if (ans.length() > 128) {
+            try {
+                // 256bits = 32bytes = 64hex chars.
+                MessageDigest digest = MessageDigest.getInstance("SHA-256");
+                digest.update(ans.getBytes());
+                byte[] hashBytes = digest.digest();
+                StringBuilder sb = new StringBuilder();
+                for (byte b : hashBytes) {
+                    sb.append(String.format("%02x", b));
+                }
+                ans = sb.toString();
+            } catch (NoSuchAlgorithmException e) {
+                // don't update `ans`.
+            }
+        }
+        return ans;
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/JDBCTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/JDBCTable.java
@@ -199,6 +199,8 @@ public class JDBCTable extends Table {
                 digest.update(ans.getBytes());
                 byte[] hashBytes = digest.digest();
                 StringBuilder sb = new StringBuilder();
+                // it's for be side parsing: expect a _ in name.
+                sb.append("jdbc_");
                 for (byte b : hashBytes) {
                     sb.append(String.format("%02x", b));
                 }

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/JDBCTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/JDBCTable.java
@@ -187,26 +187,22 @@ public class JDBCTable extends Table {
         // currently we use this uri as part of name of download file.
         // so if this uri is too long, we might fail to write file on BE side.
         // so here we have to shorten it to reduce fail probability because of long file name.
-        // in most cases, jdbc uri is not that long, so we can preserve original information.
 
         final String prefix = "jdbc_";
-        final int signLength = 64;
-        if (ans.length() > (signLength + prefix.length())) {
-            try {
-                // 256bits = 32bytes = 64hex chars.
-                MessageDigest digest = MessageDigest.getInstance("SHA-256");
-                digest.update(ans.getBytes());
-                byte[] hashBytes = digest.digest();
-                StringBuilder sb = new StringBuilder();
-                // it's for be side parsing: expect a _ in name.
-                sb.append(prefix);
-                for (byte b : hashBytes) {
-                    sb.append(String.format("%02x", b));
-                }
-                ans = sb.toString();
-            } catch (NoSuchAlgorithmException e) {
-                // don't update `ans`.
+        try {
+            // 256bits = 32bytes = 64hex chars.
+            MessageDigest digest = MessageDigest.getInstance("SHA-256");
+            digest.update(ans.getBytes());
+            byte[] hashBytes = digest.digest();
+            StringBuilder sb = new StringBuilder();
+            // it's for be side parsing: expect a _ in name.
+            sb.append(prefix);
+            for (byte b : hashBytes) {
+                sb.append(String.format("%02x", b));
             }
+            ans = sb.toString();
+        } catch (NoSuchAlgorithmException e) {
+            // don't update `ans`.
         }
         return ans;
     }

--- a/fe/fe-core/src/test/java/com/starrocks/catalog/JDBCTableTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/JDBCTableTest.java
@@ -239,7 +239,7 @@ public class JDBCTableTest {
             JDBCTable jdbcTable = new JDBCTable(10, "tbl", schema, "db", "jdbc_catalog", properties);
             TTableDescriptor tableDescriptor = jdbcTable.toThrift(null);
             TJDBCTable table = tableDescriptor.getJdbcTable();
-            Assert.assertEquals(table.getJdbc_driver_name(), "jdbc_postgresql___172_26_194_237_5432_db_pg_select");
+            Assert.assertEquals(table.getJdbc_driver_name(), "jdbc_f2ef8bf476c54395197451dd655c89dd6041f3d0dd9b906dc38518524af1ec64");
             Assert.assertEquals(table.getJdbc_driver_url(), "http://x.com/postgresql-42.3.3.jar");
             Assert.assertEquals(table.getJdbc_driver_checksum(), "bef0b2e1c6edcd8647c24bed31e1a4ac");
             Assert.assertEquals(table.getJdbc_driver_class(), "org.postgresql.Driver");

--- a/fe/fe-core/src/test/java/com/starrocks/catalog/JDBCTableTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/JDBCTableTest.java
@@ -15,6 +15,7 @@
 
 package com.starrocks.catalog;
 
+import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.starrocks.common.DdlException;
@@ -29,6 +30,7 @@ import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
@@ -217,5 +219,64 @@ public class JDBCTableTest {
         properties.remove("table");
         new JDBCTable(1000, "jdbc_table", columns, properties);
         Assert.fail("No exception throws.");
+    }
+
+    @Test
+    public void testJDBCDriverName() {
+        try {
+            Map<String, String> properties = ImmutableMap.of(
+                    "driver_class", "org.postgresql.Driver",
+                    "checksum", "bef0b2e1c6edcd8647c24bed31e1a4ac",
+                    "driver_url",
+                    "http://x.com/postgresql-42.3.3.jar",
+                    "type", "jdbc",
+                    "user", "postgres",
+                    "password", "postgres",
+                    "jdbc_uri", "jdbc:postgresql://172.26.194.237:5432/db_pg_select"
+            );
+            List<Column> schema = new ArrayList<>();
+            schema.add(new Column("id", Type.INT));
+            JDBCTable jdbcTable = new JDBCTable(10, "tbl", schema, "db", "jdbc_catalog", properties);
+            TTableDescriptor tableDescriptor = jdbcTable.toThrift(null);
+            TJDBCTable table = tableDescriptor.getJdbcTable();
+            Assert.assertEquals(table.getJdbc_driver_name(), "jdbc_postgresql___172_26_194_237_5432_db_pg_select");
+            Assert.assertEquals(table.getJdbc_driver_url(), "http://x.com/postgresql-42.3.3.jar");
+            Assert.assertEquals(table.getJdbc_driver_checksum(), "bef0b2e1c6edcd8647c24bed31e1a4ac");
+            Assert.assertEquals(table.getJdbc_driver_class(), "org.postgresql.Driver");
+        } catch (Exception e) {
+            System.out.println(e.getMessage());
+            Assert.fail();
+        }
+    }
+
+    @Test
+    public void testJDBCDriverNameLong() {
+        try {
+            Map<String, String> properties = ImmutableMap.of(
+                    "driver_class", "org.postgresql.Driver",
+                    "checksum", "bef0b2e1c6edcd8647c24bed31e1a4ac",
+                    "driver_url",
+                    "http://x.com/postgresql-42.3.3.jar",
+                    "type", "jdbc",
+                    "user", "postgres",
+                    "password", "postgres",
+                    "jdbc_uri",
+                    "jdbc:postgresql" +
+                            "://aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa.com/db_pg_select"
+            );
+            List<Column> schema = new ArrayList<>();
+            schema.add(new Column("id", Type.INT));
+            JDBCTable jdbcTable = new JDBCTable(10, "tbl", schema, "db", "jdbc_catalog", properties);
+            TTableDescriptor tableDescriptor = jdbcTable.toThrift(null);
+            TJDBCTable table = tableDescriptor.getJdbcTable();
+            Assert.assertEquals(table.getJdbc_driver_name(),
+                    "jdbc_90377bb27298feecdca1ef8b2e9c2e00f0b012eabb9ad43437542d2e29ef52fc");
+            Assert.assertEquals(table.getJdbc_driver_url(), "http://x.com/postgresql-42.3.3.jar");
+            Assert.assertEquals(table.getJdbc_driver_checksum(), "bef0b2e1c6edcd8647c24bed31e1a4ac");
+            Assert.assertEquals(table.getJdbc_driver_class(), "org.postgresql.Driver");
+        } catch (Exception e) {
+            System.out.println(e.getMessage());
+            Assert.fail();
+        }
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/catalog/JDBCTableTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/JDBCTableTest.java
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-
 package com.starrocks.catalog;
 
 import com.google.common.collect.ImmutableMap;
@@ -139,7 +138,7 @@ public class JDBCTableTest {
 
     @Test
     public void testToThriftWithoutResource(@Mocked GlobalStateMgr globalStateMgr,
-                             @Mocked ResourceMgr resourceMgr) throws Exception {
+                                            @Mocked ResourceMgr resourceMgr) throws Exception {
         String uri = "jdbc:mysql://127.0.0.1:3306";
         Map<String, String> jdbcProperties = getMockedJDBCProperties(uri);
         JDBCTable table = new JDBCTable(1000, "jdbc_table", columns, "db0", "catalog0", jdbcProperties);
@@ -155,7 +154,7 @@ public class JDBCTableTest {
 
     @Test
     public void testToThriftWithJdbcParam(@Mocked GlobalStateMgr globalStateMgr,
-                             @Mocked ResourceMgr resourceMgr) throws Exception {
+                                          @Mocked ResourceMgr resourceMgr) throws Exception {
         String uri = "jdbc:mysql://127.0.0.1:3306?key=value";
         Map<String, String> jdbcProperties = getMockedJDBCProperties(uri);
         JDBCTable table = new JDBCTable(1000, "jdbc_table", columns, "db0", "catalog0", jdbcProperties);
@@ -239,7 +238,8 @@ public class JDBCTableTest {
             JDBCTable jdbcTable = new JDBCTable(10, "tbl", schema, "db", "jdbc_catalog", properties);
             TTableDescriptor tableDescriptor = jdbcTable.toThrift(null);
             TJDBCTable table = tableDescriptor.getJdbcTable();
-            Assert.assertEquals(table.getJdbc_driver_name(), "jdbc_f2ef8bf476c54395197451dd655c89dd6041f3d0dd9b906dc38518524af1ec64");
+            Assert.assertEquals(table.getJdbc_driver_name(),
+                    "jdbc_f2ef8bf476c54395197451dd655c89dd6041f3d0dd9b906dc38518524af1ec64");
             Assert.assertEquals(table.getJdbc_driver_url(), "http://x.com/postgresql-42.3.3.jar");
             Assert.assertEquals(table.getJdbc_driver_checksum(), "bef0b2e1c6edcd8647c24bed31e1a4ac");
             Assert.assertEquals(table.getJdbc_driver_class(), "org.postgresql.Driver");

--- a/fe/fe-core/src/test/java/com/starrocks/connector/jdbc/JDBCTableTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/jdbc/JDBCTableTest.java
@@ -14,18 +14,9 @@
 
 package com.starrocks.connector.jdbc;
 
-import com.google.common.collect.ImmutableMap;
-import com.starrocks.catalog.Column;
-import com.starrocks.catalog.JDBCTable;
-import com.starrocks.catalog.Type;
-import com.starrocks.thrift.TJDBCTable;
-import com.starrocks.thrift.TTableDescriptor;
 import org.junit.Assert;
 import org.junit.Test;
 
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Map;
 import java.util.Objects;
 
 public class JDBCTableTest {
@@ -52,34 +43,6 @@ public class JDBCTableTest {
             Assert.assertTrue(partition.hashCode() == Objects.hash("20230810", 1000L));
             Assert.assertTrue(partition.toString().contains("20230810"));
             Assert.assertTrue(partition.toJson().toString().contains("20230810"));
-        } catch (Exception e) {
-            System.out.println(e.getMessage());
-            Assert.fail();
-        }
-    }
-
-    @Test
-    public void testJDBCDriverName() {
-        try {
-            Map<String, String> properties = ImmutableMap.of(
-                    "driver_class", "org.postgresql.Driver",
-                    "checksum", "bef0b2e1c6edcd8647c24bed31e1a4ac",
-                    "driver_url",
-                    "http://x.com/postgresql-42.3.3.jar",
-                    "type", "jdbc",
-                    "user", "postgres",
-                    "password", "postgres",
-                    "jdbc_uri", "jdbc:postgresql://172.26.194.237:5432/db_pg_select"
-            );
-            List<Column> schema = new ArrayList<>();
-            schema.add(new Column("id", Type.INT));
-            JDBCTable jdbcTable = new JDBCTable(10, "tbl", schema, "db", "jdbc_catalog", properties);
-            TTableDescriptor tableDescriptor = jdbcTable.toThrift(null);
-            TJDBCTable table = tableDescriptor.getJdbcTable();
-            Assert.assertEquals(table.getJdbc_driver_name(), "jdbc_postgresql_172.26.194.237_5432_db_pg_select");
-            Assert.assertEquals(table.getJdbc_driver_url(), "http://x.com/postgresql-42.3.3.jar");
-            Assert.assertEquals(table.getJdbc_driver_checksum(), "bef0b2e1c6edcd8647c24bed31e1a4ac");
-            Assert.assertEquals(table.getJdbc_driver_class(), "org.postgresql.Driver");
         } catch (Exception e) {
             System.out.println(e.getMessage());
             Assert.fail();


### PR DESCRIPTION
## Why I'm doing:

If user specify long jdbc uri, we will fail to download file. because right now, file name length is almost identical to jdbc uri length, and it will probably exceed linx file name max size(255)


## What I'm doing:

This PR do:
- shorten jdbc driver name: if it's too long, reduce it using crypto hash.
- refactor be side error message, easily to identify real problem.

And after that, downloaded file will be

> jdbc_db64f463c250eccc7f19f6c69aa5f83b19211209df86783b681a9e0a139abd78_95cde01c78e7b04e13305338d60e056a_1711579009617.jar

And error message will be 
>  (1064, 'fail to open tmp file when downloading file from http://127.0.0.1:41006/data/mysql-connector-java-8.0.28.jar. error = File name too long')



Fixes https://github.com/StarRocks/starrocks/issues/42857

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [x] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
