### PR TITLE
[BugFix] fix ngram bloom filter's bug

### DIFF
--- a/be/src/storage/column_expr_predicate.h
+++ b/be/src/storage/column_expr_predicate.h
@@ -43,7 +43,7 @@ public:
     [[nodiscard]] Status evaluate_or(const Column* column, uint8_t* sel, uint16_t from, uint16_t to) const override;
 
     bool zone_map_filter(const ZoneMapDetail& detail) const override;
-    bool support_bloom_filter() const override { return false; }
+    bool support_original_bloom_filter() const override { return false; }
     bool support_ngram_bloom_filter() const override { return _expr_ctxs[0]->support_ngram_bloom_filter(); }
     bool ngram_bloom_filter(const BloomFilter* bf, const NgramBloomFilterReaderOptions& reader_options) const override;
     PredicateType type() const override { return PredicateType::kExpr; }
@@ -94,7 +94,7 @@ public:
     [[nodiscard]] Status evaluate_and(const Column* column, uint8_t* sel, uint16_t from, uint16_t to) const override;
     [[nodiscard]] Status evaluate_or(const Column* column, uint8_t* sel, uint16_t from, uint16_t to) const override;
     bool zone_map_filter(const ZoneMapDetail& detail) const override { return true; }
-    bool support_bloom_filter() const override { return false; }
+    bool support_original_bloom_filter() const override { return false; }
     PredicateType type() const override { return PredicateType::kTrue; }
     bool can_vectorized() const override { return true; }
     [[nodiscard]] Status convert_to(const ColumnPredicate** output, const TypeInfoPtr& target_type_info,

--- a/be/src/storage/column_in_predicate.cpp
+++ b/be/src/storage/column_in_predicate.cpp
@@ -128,9 +128,9 @@ public:
         return Status::OK();
     }
 
-    bool support_bloom_filter() const override { return true; }
+    bool support_original_bloom_filter() const override { return true; }
 
-    bool bloom_filter(const BloomFilter* bf) const override {
+    bool original_bloom_filter(const BloomFilter* bf) const override {
         static_assert(field_type != TYPE_HLL, "TODO");
         static_assert(field_type != TYPE_OBJECT, "TODO");
         static_assert(field_type != TYPE_PERCENTILE, "TODO");
@@ -312,9 +312,9 @@ public:
         return Status::OK();
     }
 
-    bool support_bloom_filter() const override { return true; }
+    bool support_original_bloom_filter() const override { return true; }
 
-    bool bloom_filter(const BloomFilter* bf) const override {
+    bool original_bloom_filter(const BloomFilter* bf) const override {
         for (const auto& str : _zero_padded_strs) {
             Slice v(str);
             RETURN_IF(bf->test_bytes(v.data, v.size), true);

--- a/be/src/storage/column_null_predicate.cpp
+++ b/be/src/storage/column_null_predicate.cpp
@@ -84,9 +84,9 @@ public:
         return Status::OK();
     }
 
-    bool support_bloom_filter() const override { return true; }
+    bool support_original_bloom_filter() const override { return true; }
 
-    bool bloom_filter(const BloomFilter* bf) const override { return bf->test_bytes(nullptr, 0); }
+    bool original_bloom_filter(const BloomFilter* bf) const override { return bf->test_bytes(nullptr, 0); }
 
     PredicateType type() const override { return PredicateType::kIsNull; }
 

--- a/be/src/storage/column_operator_predicate.h
+++ b/be/src/storage/column_operator_predicate.h
@@ -163,12 +163,12 @@ public:
         return _predicate_operator.seek_bitmap_dictionary(iter, range);
     }
 
-    bool support_bloom_filter() const override { return SpecColumnOperator::support_bloom_filter(); }
+    bool support_original_bloom_filter() const override { return SpecColumnOperator::support_original_bloom_filter(); }
 
-    bool bloom_filter(const BloomFilter* bf) const override {
-        DCHECK(support_bloom_filter()) << "Not support bloom filter";
-        if constexpr (SpecColumnOperator::support_bloom_filter()) {
-            return _predicate_operator.bloom_filter(bf);
+    bool original_bloom_filter(const BloomFilter* bf) const override {
+        DCHECK(support_original_bloom_filter()) << "Not support bloom filter";
+        if constexpr (SpecColumnOperator::support_original_bloom_filter()) {
+            return _predicate_operator.original_bloom_filter(bf);
         }
         return true;
     }

--- a/be/src/storage/column_predicate.h
+++ b/be/src/storage/column_predicate.h
@@ -155,7 +155,7 @@ public:
     // Return false to filter out a data page.
     virtual bool zone_map_filter(const ZoneMapDetail& detail) const { return true; }
 
-    virtual bool support_bloom_filter() const { return false; }
+    virtual bool support_original_bloom_filter() const { return false; }
 
     // return true means this predicate can support ngram bloom filter, don't consider gram number(N)
     // in ngram_bloom_filter(), if gram number is not equal(only happended in ngram_search right now)
@@ -164,7 +164,7 @@ public:
     virtual bool support_ngram_bloom_filter() const { return false; }
 
     // Return false to filter out a data page.
-    virtual bool bloom_filter(const BloomFilter* bf) const { return true; }
+    virtual bool original_bloom_filter(const BloomFilter* bf) const { return true; }
 
     // Return false to filter out a data page.
     virtual bool ngram_bloom_filter(const BloomFilter* bf, const NgramBloomFilterReaderOptions& reader_options) const {

--- a/be/src/storage/column_predicate_cmp.cpp
+++ b/be/src/storage/column_predicate_cmp.cpp
@@ -467,9 +467,9 @@ public:
         return Status::OK();
     }
 
-    bool support_bloom_filter() const override { return true; }
+    bool support_original_bloom_filter() const override { return true; }
 
-    bool bloom_filter(const BloomFilter* bf) const override {
+    bool original_bloom_filter(const BloomFilter* bf) const override {
         static_assert(field_type != TYPE_JSON, "TODO");
         static_assert(field_type != TYPE_HLL, "TODO");
         static_assert(field_type != TYPE_OBJECT, "TODO");
@@ -602,7 +602,7 @@ public:
 
     bool can_vectorized() const override { return false; }
 
-    bool support_bloom_filter() const override { return false; }
+    bool support_original_bloom_filter() const override { return false; }
 
     Status convert_to(const ColumnPredicate** output, const TypeInfoPtr& target_type_info,
                       ObjectPool* obj_pool) const override {
@@ -650,9 +650,9 @@ public:
         return type_info->cmp(Datum(this->_value), min) >= 0 && type_info->cmp(Datum(this->_value), max) <= 0;
     }
 
-    bool support_bloom_filter() const override { return true; }
+    bool support_original_bloom_filter() const override { return true; }
 
-    bool bloom_filter(const BloomFilter* bf) const override {
+    bool original_bloom_filter(const BloomFilter* bf) const override {
         Slice padded(Base::_zero_padded_str);
         return bf->test_bytes(padded.data, padded.size);
     }

--- a/be/src/storage/column_predicate_dict_conjuct.cpp
+++ b/be/src/storage/column_predicate_dict_conjuct.cpp
@@ -45,7 +45,7 @@ public:
     bool zone_map_filter(const ZoneMapDetail& detail) const { return true; }
 
     static constexpr PredicateType type() { return PredicateType::kMap; }
-    static constexpr bool support_bloom_filter() { return false; }
+    static constexpr bool support_original_bloom_filter() { return false; }
 
     static constexpr bool can_vectorized() { return true; }
 

--- a/be/src/storage/rowset/bloom_filter_index_writer.cpp
+++ b/be/src/storage/rowset/bloom_filter_index_writer.cpp
@@ -107,15 +107,15 @@ inline void update_bf(BloomFilter* bf, const typename CppTypeTraits<type>::CppTy
 // Meanswhile, It adds an ordinal index to load bloom filter index according to requirement.
 //
 template <LogicalType field_type>
-class BloomFilterIndexWriterImpl : public BloomFilterIndexWriter {
+class OridinaryBloomFilterIndexWriterImpl : public BloomFilterIndexWriter {
 public:
     using CppType = typename CppTypeTraits<field_type>::CppType;
     using ValueDict = typename BloomFilterTraits<CppType>::ValueDict;
 
-    explicit BloomFilterIndexWriterImpl(const BloomFilterOptions& bf_options, TypeInfoPtr typeinfo)
+    explicit OridinaryBloomFilterIndexWriterImpl(const BloomFilterOptions& bf_options, TypeInfoPtr typeinfo)
             : _bf_options(bf_options), _typeinfo(std::move(typeinfo)) {}
 
-    ~BloomFilterIndexWriterImpl() override = default;
+    ~OridinaryBloomFilterIndexWriterImpl() override = default;
 
     void add_values(const void* values, size_t count) override {
         const auto* v = (const CppType*)values;
@@ -186,27 +186,26 @@ private:
     std::vector<std::unique_ptr<BloomFilter>> _bfs;
 };
 
-// handle most cases
 template <LogicalType field_type, typename Enable = void>
-class NgramBloomFilterIndexWriterImpl : public BloomFilterIndexWriterImpl<field_type> {
+class NgramBloomFilterIndexWriterImpl : public OridinaryBloomFilterIndexWriterImpl<field_type> {
 public:
     using CppType = typename CppTypeTraits<field_type>::CppType;
-    using BloomFilterIndexWriterImpl<field_type>::_values;
+    using OridinaryBloomFilterIndexWriterImpl<field_type>::_values;
 
     explicit NgramBloomFilterIndexWriterImpl(const BloomFilterOptions& bf_options, TypeInfoPtr typeinfo)
-            : BloomFilterIndexWriterImpl<field_type>(bf_options, typeinfo) {}
+            : OridinaryBloomFilterIndexWriterImpl<field_type>(bf_options, typeinfo) {}
 
     void add_values(const void* values, size_t count) override { return; }
 };
 
 template <LogicalType field_type>
 class NgramBloomFilterIndexWriterImpl<field_type, std::enable_if_t<is_slice_type<field_type>()>>
-        : public BloomFilterIndexWriterImpl<field_type> {
+        : public OridinaryBloomFilterIndexWriterImpl<field_type> {
 public:
     using CppType = typename CppTypeTraits<field_type>::CppType;
-    using BloomFilterIndexWriterImpl<field_type>::_values;
+    using OridinaryBloomFilterIndexWriterImpl<field_type>::_values;
     explicit NgramBloomFilterIndexWriterImpl(const BloomFilterOptions& bf_options, TypeInfoPtr typeinfo)
-            : BloomFilterIndexWriterImpl<field_type>(bf_options, std::move(typeinfo)) {}
+            : OridinaryBloomFilterIndexWriterImpl<field_type>(bf_options, std::move(typeinfo)) {}
 
     void add_values(const void* values, size_t count) override {
         size_t gram_num = this->_bf_options.gram_num;
@@ -248,7 +247,7 @@ struct BloomFilterBuilderFunctor {
         if (bf_options.use_ngram) {
             *res = std::make_unique<NgramBloomFilterIndexWriterImpl<ftype>>(bf_options, typeinfo);
         } else {
-            *res = std::make_unique<BloomFilterIndexWriterImpl<ftype>>(bf_options, typeinfo);
+            *res = std::make_unique<OridinaryBloomFilterIndexWriterImpl<ftype>>(bf_options, typeinfo);
         }
         return Status::OK();
     }

--- a/be/src/storage/rowset/bloom_filter_index_writer.cpp
+++ b/be/src/storage/rowset/bloom_filter_index_writer.cpp
@@ -107,15 +107,15 @@ inline void update_bf(BloomFilter* bf, const typename CppTypeTraits<type>::CppTy
 // Meanswhile, It adds an ordinal index to load bloom filter index according to requirement.
 //
 template <LogicalType field_type>
-class OridinaryBloomFilterIndexWriterImpl : public BloomFilterIndexWriter {
+class OriginalBloomFilterIndexWriterImpl : public BloomFilterIndexWriter {
 public:
     using CppType = typename CppTypeTraits<field_type>::CppType;
     using ValueDict = typename BloomFilterTraits<CppType>::ValueDict;
 
-    explicit OridinaryBloomFilterIndexWriterImpl(const BloomFilterOptions& bf_options, TypeInfoPtr typeinfo)
+    explicit OriginalBloomFilterIndexWriterImpl(const BloomFilterOptions& bf_options, TypeInfoPtr typeinfo)
             : _bf_options(bf_options), _typeinfo(std::move(typeinfo)) {}
 
-    ~OridinaryBloomFilterIndexWriterImpl() override = default;
+    ~OriginalBloomFilterIndexWriterImpl() override = default;
 
     void add_values(const void* values, size_t count) override {
         const auto* v = (const CppType*)values;
@@ -187,25 +187,25 @@ private:
 };
 
 template <LogicalType field_type, typename Enable = void>
-class NgramBloomFilterIndexWriterImpl : public OridinaryBloomFilterIndexWriterImpl<field_type> {
+class NgramBloomFilterIndexWriterImpl : public OriginalBloomFilterIndexWriterImpl<field_type> {
 public:
     using CppType = typename CppTypeTraits<field_type>::CppType;
-    using OridinaryBloomFilterIndexWriterImpl<field_type>::_values;
+    using OriginalBloomFilterIndexWriterImpl<field_type>::_values;
 
     explicit NgramBloomFilterIndexWriterImpl(const BloomFilterOptions& bf_options, TypeInfoPtr typeinfo)
-            : OridinaryBloomFilterIndexWriterImpl<field_type>(bf_options, typeinfo) {}
+            : OriginalBloomFilterIndexWriterImpl<field_type>(bf_options, typeinfo) {}
 
     void add_values(const void* values, size_t count) override { return; }
 };
 
 template <LogicalType field_type>
 class NgramBloomFilterIndexWriterImpl<field_type, std::enable_if_t<is_slice_type<field_type>()>>
-        : public OridinaryBloomFilterIndexWriterImpl<field_type> {
+        : public OriginalBloomFilterIndexWriterImpl<field_type> {
 public:
     using CppType = typename CppTypeTraits<field_type>::CppType;
-    using OridinaryBloomFilterIndexWriterImpl<field_type>::_values;
+    using OriginalBloomFilterIndexWriterImpl<field_type>::_values;
     explicit NgramBloomFilterIndexWriterImpl(const BloomFilterOptions& bf_options, TypeInfoPtr typeinfo)
-            : OridinaryBloomFilterIndexWriterImpl<field_type>(bf_options, std::move(typeinfo)) {}
+            : OriginalBloomFilterIndexWriterImpl<field_type>(bf_options, std::move(typeinfo)) {}
 
     void add_values(const void* values, size_t count) override {
         size_t gram_num = this->_bf_options.gram_num;
@@ -247,7 +247,7 @@ struct BloomFilterBuilderFunctor {
         if (bf_options.use_ngram) {
             *res = std::make_unique<NgramBloomFilterIndexWriterImpl<ftype>>(bf_options, typeinfo);
         } else {
-            *res = std::make_unique<OridinaryBloomFilterIndexWriterImpl<ftype>>(bf_options, typeinfo);
+            *res = std::make_unique<OriginalBloomFilterIndexWriterImpl<ftype>>(bf_options, typeinfo);
         }
         return Status::OK();
     }

--- a/be/src/storage/rowset/column_reader.h
+++ b/be/src/storage/rowset/column_reader.h
@@ -126,6 +126,9 @@ public:
     bool has_zone_map() const { return _zonemap_index != nullptr; }
     bool has_bitmap_index() const { return _bitmap_index != nullptr; }
     bool has_bloom_filter_index() const { return _bloom_filter_index != nullptr; }
+    bool has_ngram_bloom_filter_index() const {
+        return _bloom_filter_index != nullptr && _segment->tablet_schema().has_index(_column_unique_id, NGRAMBF);
+    }
 
     ZoneMapPB* segment_zone_map() const { return _segment_zone_map.get(); }
 

--- a/be/src/storage/rowset/scalar_column_iterator.cpp
+++ b/be/src/storage/rowset/scalar_column_iterator.cpp
@@ -398,8 +398,12 @@ Status ScalarColumnIterator::get_row_ranges_by_bloom_filter(const std::vector<co
                                                             SparseRange<>* row_ranges) {
     RETURN_IF(!_reader->has_bloom_filter_index(), Status::OK());
     bool support = false;
+
     for (const auto* pred : predicates) {
-        support = support || pred->support_bloom_filter() || pred->support_ngram_bloom_filter();
+        // bloom filter index can only be either original bloom filter or ngram bloom filter
+        // pred->support_bloom_filter only works for original bloom filter and pred->support_ngram_bloom_filter only works for ngram bloom filter
+        support = support || (pred->support_bloom_filter() && (!_reader->has_ngram_bloom_filter_index())) ||
+                  (pred->support_ngram_bloom_filter() && _reader->has_ngram_bloom_filter_index());
     }
     RETURN_IF(!support, Status::OK());
 

--- a/test/sql/test_index/R/test_ngram_bloom_filter
+++ b/test/sql/test_index/R/test_ngram_bloom_filter
@@ -60,8 +60,6 @@ drop database ngram_bloom_filter_db_1;
 -- !result
 
 
-
-
 -- name: test_ngram_bloom_filter_default
 create database ngram_bloom_filter_db_2;
 -- result:
@@ -107,8 +105,6 @@ ngram_bloom_filter_db_2.ngram_index_default_3		idx_name1		username						NGRAMBF
 -- !result
 
 
-
-
 -- name: test_ngram_bloom_filter_like
 CREATE TABLE ngram_index_like(
     timestamp DATETIME NOT NULL,
@@ -135,8 +131,6 @@ select * from ngram_index_like where username like '_hin%';
 -- result:
 2023-01-01 00:00:00	chinese	3
 -- !result
-
-
 
 
 -- name: test_ngram_bloom_filter_case_insensitive
@@ -227,4 +221,34 @@ insert into ngram_index_char values ('2023-01-01',"chinese",3),('2023-01-02',"ch
 select * from ngram_index_char where username like '_hiaa%';
 -- result:
 -- !result
-
+-- name: test_bloom_filter
+create database ngram_bloom_filter_db_4;
+-- result:
+-- !result
+use ngram_bloom_filter_db_4;
+-- result:
+-- !result
+CREATE TABLE `common_duplicate` (
+  `c0` int(11) NOT NULL COMMENT "",
+  `c1` int(11) NOT NULL COMMENT "",
+  `c2` varchar(500) NOT NULL COMMENT ""
+) ENGINE=OLAP
+DUPLICATE KEY(`c0`, `c1`, `c2`)
+COMMENT "OLAP"
+DISTRIBUTED BY HASH(`c0`, `c1`, `c2`) BUCKETS 3
+PROPERTIES (
+"replication_num" = "1",
+"bloom_filter_columns" = "c2",
+"in_memory" = "false",
+"enable_persistent_index" = "false",
+"replicated_storage" = "true",
+"compression" = "LZ4"
+);
+-- result:
+-- !result
+insert into common_duplicate values (1,1,"abc"),(2,2,"abc"),(3,3,"abc"),(4,4,"abc"),(5,5,"abc");
+-- result:
+-- !result
+select * from common_duplicate where c2 like '%b%' order by c0;
+-- result:
+-- !result

--- a/test/sql/test_index/R/test_ngram_bloom_filter
+++ b/test/sql/test_index/R/test_ngram_bloom_filter
@@ -60,6 +60,7 @@ drop database ngram_bloom_filter_db_1;
 -- !result
 
 
+
 -- name: test_ngram_bloom_filter_default
 create database ngram_bloom_filter_db_2;
 -- result:
@@ -105,6 +106,7 @@ ngram_bloom_filter_db_2.ngram_index_default_3		idx_name1		username						NGRAMBF
 -- !result
 
 
+
 -- name: test_ngram_bloom_filter_like
 CREATE TABLE ngram_index_like(
     timestamp DATETIME NOT NULL,
@@ -131,6 +133,7 @@ select * from ngram_index_like where username like '_hin%';
 -- result:
 2023-01-01 00:00:00	chinese	3
 -- !result
+
 
 
 -- name: test_ngram_bloom_filter_case_insensitive
@@ -221,6 +224,7 @@ insert into ngram_index_char values ('2023-01-01',"chinese",3),('2023-01-02',"ch
 select * from ngram_index_char where username like '_hiaa%';
 -- result:
 -- !result
+
 -- name: test_bloom_filter
 create database ngram_bloom_filter_db_4;
 -- result:
@@ -251,4 +255,9 @@ insert into common_duplicate values (1,1,"abc"),(2,2,"abc"),(3,3,"abc"),(4,4,"ab
 -- !result
 select * from common_duplicate where c2 like '%b%' order by c0;
 -- result:
+1	1	abc
+2	2	abc
+3	3	abc
+4	4	abc
+5	5	abc
 -- !result

--- a/test/sql/test_index/R/test_ngram_bloom_filter
+++ b/test/sql/test_index/R/test_ngram_bloom_filter
@@ -58,9 +58,6 @@ select * from ngram_index order by  ngram_search(username, 'chinese',4) desc;
 drop database ngram_bloom_filter_db_1;
 -- result:
 -- !result
-
-
-
 -- name: test_ngram_bloom_filter_default
 create database ngram_bloom_filter_db_2;
 -- result:
@@ -104,9 +101,6 @@ show index from ngram_index_default_3;
 -- result:
 ngram_bloom_filter_db_2.ngram_index_default_3		idx_name1		username						NGRAMBF	
 -- !result
-
-
-
 -- name: test_ngram_bloom_filter_like
 CREATE TABLE ngram_index_like(
     timestamp DATETIME NOT NULL,
@@ -133,9 +127,6 @@ select * from ngram_index_like where username like '_hin%';
 -- result:
 2023-01-01 00:00:00	chinese	3
 -- !result
-
-
-
 -- name: test_ngram_bloom_filter_case_insensitive
 CREATE TABLE ngram_index_case_in_sensitive(
     timestamp DATETIME NOT NULL,
@@ -224,7 +215,6 @@ insert into ngram_index_char values ('2023-01-01',"chinese",3),('2023-01-02',"ch
 select * from ngram_index_char where username like '_hiaa%';
 -- result:
 -- !result
-
 -- name: test_bloom_filter
 create database ngram_bloom_filter_db_4;
 -- result:

--- a/test/sql/test_index/R/test_ngram_bloom_filter
+++ b/test/sql/test_index/R/test_ngram_bloom_filter
@@ -232,7 +232,7 @@ COMMENT "OLAP"
 DISTRIBUTED BY HASH(`c0`, `c1`, `c2`) BUCKETS 3
 PROPERTIES (
 "replication_num" = "1",
-"bloom_filter_columns" = "c2",
+"bloom_filter_columns" = "c1,c2",
 "in_memory" = "false",
 "enable_persistent_index" = "false",
 "replicated_storage" = "true",
@@ -278,4 +278,8 @@ select * from common_duplicate where c2 ="abc" order by c0;
 3	3	abc
 4	4	abc
 5	5	abc
+-- !result
+select * from common_duplicate where c1 = 2;
+-- result:
+2	2	abc
 -- !result

--- a/test/sql/test_index/R/test_ngram_bloom_filter
+++ b/test/sql/test_index/R/test_ngram_bloom_filter
@@ -225,7 +225,7 @@ use ngram_bloom_filter_db_4;
 CREATE TABLE `common_duplicate` (
   `c0` int(11) NOT NULL COMMENT "",
   `c1` int(11) NOT NULL COMMENT "",
-  `c2` varchar(500) NOT NULL COMMENT ""
+  `c2` varchar(500)  NULL COMMENT ""
 ) ENGINE=OLAP
 DUPLICATE KEY(`c0`, `c1`, `c2`)
 COMMENT "OLAP"
@@ -240,7 +240,7 @@ PROPERTIES (
 );
 -- result:
 -- !result
-insert into common_duplicate values (1,1,"abc"),(2,2,"abc"),(3,3,"abc"),(4,4,"abc"),(5,5,"abc");
+insert into common_duplicate values (1,1,"abc"),(2,2,"abc"),(3,3,"abc"),(4,4,"abc"),(5,5,"abc"),(6,6,NULL);
 -- result:
 -- !result
 select * from common_duplicate where c2 like '%b%' order by c0;
@@ -251,10 +251,27 @@ select * from common_duplicate where c2 like '%b%' order by c0;
 4	4	abc
 5	5	abc
 -- !result
-select * from common_duplicate where c2 in ("ab","bc") order by c0;
+select * from common_duplicate where c2 in ("ab","bc","abc") order by c0;
 -- result:
+1	1	abc
+2	2	abc
+3	3	abc
+4	4	abc
+5	5	abc
 -- !result
 select * from common_duplicate where c2 is not null order by c0;
+-- result:
+1	1	abc
+2	2	abc
+3	3	abc
+4	4	abc
+5	5	abc
+-- !result
+select * from common_duplicate where c2 is  null order by c0;
+-- result:
+6	6	None
+-- !result
+select * from common_duplicate where c2 ="abc" order by c0;
 -- result:
 1	1	abc
 2	2	abc

--- a/test/sql/test_index/R/test_ngram_bloom_filter
+++ b/test/sql/test_index/R/test_ngram_bloom_filter
@@ -251,3 +251,14 @@ select * from common_duplicate where c2 like '%b%' order by c0;
 4	4	abc
 5	5	abc
 -- !result
+select * from common_duplicate where c2 in ("ab","bc") order by c0;
+-- result:
+-- !result
+select * from common_duplicate where c2 is not null order by c0;
+-- result:
+1	1	abc
+2	2	abc
+3	3	abc
+4	4	abc
+5	5	abc
+-- !result

--- a/test/sql/test_index/T/test_ngram_bloom_filter
+++ b/test/sql/test_index/T/test_ngram_bloom_filter
@@ -120,7 +120,6 @@ select * from ngram_index_char where username like '_hiaa%';
 -- name: test_bloom_filter
 create database ngram_bloom_filter_db_4;
 use ngram_bloom_filter_db_4;
--- 创建一个包含bloom filter的表
 CREATE TABLE `common_duplicate` (
   `c0` int(11) NOT NULL COMMENT "",
   `c1` int(11) NOT NULL COMMENT "",

--- a/test/sql/test_index/T/test_ngram_bloom_filter
+++ b/test/sql/test_index/T/test_ngram_bloom_filter
@@ -116,3 +116,26 @@ show index from ngram_index_char;
 
 insert into ngram_index_char values ('2023-01-01',"chinese",3),('2023-01-02',"chineaaa",4),('2023-01-03',"我爱chin",4),('2023-01-04',"toniggrht",4);
 select * from ngram_index_char where username like '_hiaa%';
+
+-- name: test_bloom_filter
+create database ngram_bloom_filter_db_4;
+use ngram_bloom_filter_db_4;
+-- 创建一个包含bloom filter的表
+CREATE TABLE `common_duplicate` (
+  `c0` int(11) NOT NULL COMMENT "",
+  `c1` int(11) NOT NULL COMMENT "",
+  `c2` varchar(500) NOT NULL COMMENT ""
+) ENGINE=OLAP
+DUPLICATE KEY(`c0`, `c1`, `c2`)
+COMMENT "OLAP"
+DISTRIBUTED BY HASH(`c0`, `c1`, `c2`) BUCKETS 3
+PROPERTIES (
+"replication_num" = "1",
+"bloom_filter_columns" = "c2",
+"in_memory" = "false",
+"enable_persistent_index" = "false",
+"replicated_storage" = "true",
+"compression" = "LZ4"
+);
+insert into common_duplicate values (1,1,"abc"),(2,2,"abc"),(3,3,"abc"),(4,4,"abc"),(5,5,"abc");
+select * from common_duplicate where c2 like '%b%' order by c0;

--- a/test/sql/test_index/T/test_ngram_bloom_filter
+++ b/test/sql/test_index/T/test_ngram_bloom_filter
@@ -138,3 +138,5 @@ PROPERTIES (
 );
 insert into common_duplicate values (1,1,"abc"),(2,2,"abc"),(3,3,"abc"),(4,4,"abc"),(5,5,"abc");
 select * from common_duplicate where c2 like '%b%' order by c0;
+select * from common_duplicate where c2 in ("ab","bc") order by c0;
+select * from common_duplicate where c2 is not null order by c0;

--- a/test/sql/test_index/T/test_ngram_bloom_filter
+++ b/test/sql/test_index/T/test_ngram_bloom_filter
@@ -130,7 +130,7 @@ COMMENT "OLAP"
 DISTRIBUTED BY HASH(`c0`, `c1`, `c2`) BUCKETS 3
 PROPERTIES (
 "replication_num" = "1",
-"bloom_filter_columns" = "c2",
+"bloom_filter_columns" = "c1,c2",
 "in_memory" = "false",
 "enable_persistent_index" = "false",
 "replicated_storage" = "true",
@@ -142,3 +142,4 @@ select * from common_duplicate where c2 in ("ab","bc","abc") order by c0;
 select * from common_duplicate where c2 is not null order by c0;
 select * from common_duplicate where c2 is  null order by c0;
 select * from common_duplicate where c2 ="abc" order by c0;
+select * from common_duplicate where c1 = 2;

--- a/test/sql/test_index/T/test_ngram_bloom_filter
+++ b/test/sql/test_index/T/test_ngram_bloom_filter
@@ -123,7 +123,7 @@ use ngram_bloom_filter_db_4;
 CREATE TABLE `common_duplicate` (
   `c0` int(11) NOT NULL COMMENT "",
   `c1` int(11) NOT NULL COMMENT "",
-  `c2` varchar(500) NOT NULL COMMENT ""
+  `c2` varchar(500)  NULL COMMENT ""
 ) ENGINE=OLAP
 DUPLICATE KEY(`c0`, `c1`, `c2`)
 COMMENT "OLAP"
@@ -136,7 +136,9 @@ PROPERTIES (
 "replicated_storage" = "true",
 "compression" = "LZ4"
 );
-insert into common_duplicate values (1,1,"abc"),(2,2,"abc"),(3,3,"abc"),(4,4,"abc"),(5,5,"abc");
+insert into common_duplicate values (1,1,"abc"),(2,2,"abc"),(3,3,"abc"),(4,4,"abc"),(5,5,"abc"),(6,6,NULL);
 select * from common_duplicate where c2 like '%b%' order by c0;
-select * from common_duplicate where c2 in ("ab","bc") order by c0;
+select * from common_duplicate where c2 in ("ab","bc","abc") order by c0;
 select * from common_duplicate where c2 is not null order by c0;
+select * from common_duplicate where c2 is  null order by c0;
+select * from common_duplicate where c2 ="abc" order by c0;


### PR DESCRIPTION
## Why I'm doing:
ngram bloom filter's logic can affect normal bloom filter index, if only create normal bloom filter index, and query “select xxx from table where cola like xxx”, it will always return empty set. can see sqltest case for details

so in this pr, rename the existed bloom filter index to original_bloom_filter to distinguish from ngram bloom filter. If one function's logic is shared by original_bloom_filter and ngram_bloom_filter, it will be called as "bloom_filter".

For example: BloomFilterIndexWriter has two implementation: 1.OridinaryBloomFilterIndexWriterImpl 2.NgramBloomFilterIndexWriterImpl. They have different logic when writing data into BloomFilter.

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
- [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
