### PR TITLE
[BugFix] Fix skew join unknown error when use skew join hint

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AstToStringBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AstToStringBuilder.java
@@ -629,7 +629,14 @@ public class AstToStringBuilder {
                 sqlBuilder.append(relation.getJoinOp());
             }
             if (relation.getJoinHint() != null && !relation.getJoinHint().isEmpty()) {
-                sqlBuilder.append(" [").append(relation.getJoinHint()).append("]");
+                StringBuilder sb = new StringBuilder();
+                sb.append(relation.getJoinHint());
+                if (relation.getSkewColumn() != null) {
+                    sb.append("|").append(visit(relation.getSkewColumn())).append("(").append(
+                            relation.getSkewValues().stream().map(this::visit).
+                                    collect(Collectors.joining(","))).append(")");
+                }
+                sqlBuilder.append(" [").append(sb).append("]");
             }
             sqlBuilder.append(" ");
             if (relation.isLateral()) {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/QueryAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/QueryAnalyzer.java
@@ -642,6 +642,8 @@ public class QueryAnalyzer {
                         throw new SemanticException("Skew join column must be a column reference");
                     }
                     analyzeExpression(join.getSkewColumn(), new AnalyzeState(), join.getLeft().getScope());
+                } else {
+                    throw new SemanticException("Skew join column must be specified");
                 }
                 if (join.getSkewValues() != null) {
                     if (join.getSkewValues().stream().anyMatch(expr -> !expr.isConstant())) {
@@ -652,6 +654,8 @@ public class QueryAnalyzer {
                         newSkewValues.add(TypeManager.addCastExpr(expr, join.getSkewColumn().getType()));
                     }
                     join.setSkewValues(newSkewValues);
+                } else {
+                    throw new SemanticException("Skew join values must be specified");
                 }
             } else if (!JoinOperator.HINT_UNREORDER.equals(join.getJoinHint())) {
                 throw new SemanticException("JOIN hint not recognized: " + join.getJoinHint());

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/SkewJoinTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/SkewJoinTest.java
@@ -125,6 +125,15 @@ public class SkewJoinTest extends PlanTestBase {
     }
 
     @Test
+    public void testSkewJoinWithException7() throws Exception {
+        String sql = "select t1.c2, t3.c3 from hive0.partitioned_db.t1 join[skew] hive0.partitioned_db.t3" +
+                " on t1.c1 = t3.c1";
+        expectedException.expect(StarRocksPlannerException.class);
+        expectedException.expectMessage("Skew join column must be specified");
+        getFragmentPlan(sql);
+    }
+
+    @Test
     public void testSkewJoinWithHiveTable() throws Exception {
         String sql = "select t1.c2, t3.c3 from hive0.partitioned_db.t1 join[skew|t1.c1(1,2)] hive0.partitioned_db.t3" +
                 " on t1.c1 = t3.c1";


### PR DESCRIPTION
## Why I'm doing:
For https://github.com/StarRocks/starrocks/pull/43199 bug3, it will throw unkown error  when use only add join hint like [skew], lack of skew column and skew values
## What I'm doing:
check skew column and skew values in query analyzer, give easy to understand error reporting
Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [x] 3.1
  - [ ] 3.0
  - [ ] 2.5
