### PR TITLE
[UT] add test for LakePrimaryKeyCompactionTest.test_compaction_policy_min_input

### DIFF
--- a/be/test/storage/lake/primary_key_compaction_task_test.cpp
+++ b/be/test/storage/lake/primary_key_compaction_task_test.cpp
@@ -598,6 +598,26 @@ TEST_P(LakePrimaryKeyCompactionTest, test_compaction_policy_min_input) {
     ASSIGN_OR_ABORT(auto input_rowsets3, compaction_policy->pick_rowsets());
     EXPECT_EQ(0, input_rowsets3.size());
     EXPECT_EQ(0, compaction_score(_tablet_mgr.get(), tablet_metadata));
+
+    {
+        // do compaction without input rowsets
+        auto txn_id = next_id();
+        auto task_context = std::make_unique<CompactionTaskContext>(txn_id, tablet_id, version, nullptr);
+        ASSIGN_OR_ABORT(auto task, _tablet_mgr->compact(task_context.get()));
+        ASSERT_OK(task->execute(CompactionTask::kNoCancelFn));
+        EXPECT_EQ(100, task_context->progress.value());
+        ASSERT_OK(publish_single_version(_tablet_metadata->id(), version + 1, txn_id).status());
+        EXPECT_TRUE(_update_mgr->TEST_check_compaction_cache_absent(tablet_id, txn_id));
+        version++;
+        ASSERT_EQ(kChunkSize * 4, read(version));
+        if (GetParam().enable_persistent_index) {
+            check_local_persistent_index_meta(tablet_id, version);
+        }
+
+        ASSIGN_OR_ABORT(auto new_tablet_metadata, _tablet_mgr->get_tablet_metadata(tablet_id, version));
+        EXPECT_EQ(new_tablet_metadata->rowsets_size(), 4);
+        EXPECT_EQ(0, new_tablet_metadata->compaction_inputs_size());
+    }
 }
 
 TEST_P(LakePrimaryKeyCompactionTest, test_compaction_score_by_policy) {


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:
Add test for `LakePrimaryKeyCompactionTest.test_compaction_policy_min_input`, for the case that publish compaction transaction without input rowset.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [x] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [x] 3.1
  - [ ] 3.0
  - [ ] 2.5
