### PR TITLE
[BugFix] Fix forgot to update max column unique id

### DIFF
--- a/be/src/storage/metadata_util.cpp
+++ b/be/src/storage/metadata_util.cpp
@@ -69,6 +69,27 @@ static StorageAggregateType t_aggregation_type_to_field_aggregation_method(TAggr
     return STORAGE_AGGREGATE_NONE;
 }
 
+static Status validate_tablet_schema(const TabletSchemaPB schema_pb) {
+#ifndef NDEBUG
+    std::unordered_set<std::string> column_names;
+    std::unordered_set<int64_t> column_ids;
+    for (const auto& col : schema_pb.column()) {
+        DCHECK(col.has_unique_id()) << col.DebugString();
+        if (auto [it, ok] = column_ids.insert(col.unique_id()); !ok) {
+            LOG(ERROR) << "Duplicate column unique id: " << schema_pb.DebugString();
+            return Status::InvalidArgument("Duplicate column id found in tablet schema");
+        }
+        if (auto [it, ok] = column_names.insert(col.name()); !ok) {
+            LOG(ERROR) << "Duplicate column name: " << schema_pb.DebugString();
+            return Status::InvalidArgument("Duplicate column name found in tablet schema");
+        }
+    }
+    return Status::OK();
+#else
+    return Status::OK();
+#endif
+}
+
 // This function is used to initialize ColumnPB for subfield like element of Array.
 static void init_column_pb_for_sub_field(ColumnPB* field) {
     const int32_t kFakeUniqueId = -1;
@@ -347,7 +368,7 @@ Status convert_t_schema_to_pb_schema(const TTabletSchema& tablet_schema, uint32_
     if (has_bf_columns && tablet_schema.__isset.bloom_filter_fpp) {
         schema->set_bf_fpp(tablet_schema.bloom_filter_fpp);
     }
-    return Status::OK();
+    return validate_tablet_schema(*schema);
 }
 
 } // namespace starrocks

--- a/be/src/storage/metadata_util.cpp
+++ b/be/src/storage/metadata_util.cpp
@@ -69,18 +69,18 @@ static StorageAggregateType t_aggregation_type_to_field_aggregation_method(TAggr
     return STORAGE_AGGREGATE_NONE;
 }
 
-static Status validate_tablet_schema(const TabletSchemaPB schema_pb) {
+static Status validate_tablet_schema(const TabletSchemaPB& schema_pb) {
 #ifndef NDEBUG
     std::unordered_set<std::string> column_names;
     std::unordered_set<int64_t> column_ids;
     for (const auto& col : schema_pb.column()) {
         DCHECK(col.has_unique_id()) << col.DebugString();
         if (auto [it, ok] = column_ids.insert(col.unique_id()); !ok) {
-            LOG(ERROR) << "Duplicate column unique id: " << schema_pb.DebugString();
+            LOG(ERROR) << "Duplicate column unique id: " << col.unique_id() << " schema: " << schema_pb.DebugString();
             return Status::InvalidArgument("Duplicate column id found in tablet schema");
         }
         if (auto [it, ok] = column_names.insert(col.name()); !ok) {
-            LOG(ERROR) << "Duplicate column name: " << schema_pb.DebugString();
+            LOG(ERROR) << "Duplicate column name: " << col.name() << " schema: " << schema_pb.DebugString();
             return Status::InvalidArgument("Duplicate column name found in tablet schema");
         }
     }

--- a/be/src/storage/metadata_util.cpp
+++ b/be/src/storage/metadata_util.cpp
@@ -70,7 +70,7 @@ static StorageAggregateType t_aggregation_type_to_field_aggregation_method(TAggr
 }
 
 static Status validate_tablet_schema(const TabletSchemaPB& schema_pb) {
-#ifndef NDEBUG
+#if !defined(NDEBUG) || defined(BE_TEST)
     std::unordered_set<std::string> column_names;
     std::unordered_set<int64_t> column_ids;
     for (const auto& col : schema_pb.column()) {

--- a/fe/fe-core/src/main/java/com/starrocks/alter/SchemaChangeHandler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/SchemaChangeHandler.java
@@ -2502,15 +2502,6 @@ public class SchemaChangeHandler extends AlterHandler {
             olapTable.setIndexes(indexes);
             olapTable.rebuildFullSchema();
 
-            // update max column unique id
-            int maxColUniqueId = olapTable.getMaxColUniqueId();
-            for (Column column : indexSchemaMap.get(olapTable.getBaseIndexId())) {
-                if (column.getUniqueId() > maxColUniqueId) {
-                    maxColUniqueId = column.getUniqueId();
-                }
-            }
-            olapTable.setMaxColUniqueId(maxColUniqueId);
-
             // If modified columns are already done, inactive related mv
             inactiveRelatedMaterializedViews(db, olapTable, modifiedColumns);
 

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/OlapTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/OlapTable.java
@@ -587,6 +587,12 @@ public class OlapTable extends Table {
             }
         }
         fullSchema = newFullSchema;
+        // update max column unique id
+        int maxColUniqueId = getMaxColUniqueId();
+        for (Column column : fullSchema) {
+            maxColUniqueId = Math.max(maxColUniqueId, column.getUniqueId());
+        }
+        setMaxColUniqueId(maxColUniqueId);
         LOG.debug("after rebuild full schema. table {}, schema: {}", id, fullSchema);
     }
 


### PR DESCRIPTION
Fix forgot to update the max column unique id after schema evolution in shared data mode.

Incorrect max olumn unique id can lead to duplicate column unique ids, which in turn can cause the BE process to crash:
```
query_id:9435b060-eb58-11ee-9f79-00163e086137, fragment_instance:9435b060-eb58-11ee-9f79-00163e086139
tracker:process consumption: 1359180496
tracker:query_pool consumption: 988792
tracker:query_pool/connector_scan consumption: 16842752
tracker:load consumption: 0
tracker:metadata consumption: 9271512
tracker:tablet_metadata consumption: 196640
tracker:rowset_metadata consumption: 0
tracker:segment_metadata consumption: 1729478
tracker:column_metadata consumption: 7345394
tracker:tablet_schema consumption: 196640
tracker:segment_zonemap consumption: 1180448
tracker:short_key_index consumption: 64020
tracker:column_zonemap_index consumption: 2252370
tracker:ordinal_index consumption: 1165568
tracker:bitmap_index consumption: 0
tracker:bloom_filter_index consumption: 0
tracker:compaction consumption: 0
tracker:schema_change consumption: 0
tracker:column_pool consumption: 0
tracker:page_cache consumption: 769868464
tracker:jit_cache consumption: 316024
tracker:update consumption: 988
tracker:chunk_allocator consumption: 39770360
tracker:clone consumption: 0
tracker:consistency consumption: 0
tracker:datacache consumption: 0
tracker:replication consumption: 0
*** Aborted at 1711447617 (unix time) try "date -d @1711447617" if you are using GNU date ***
PC: @          0xbab2abd google::protobuf::Message::SpaceUsedLong()
*** SIGSEGV (@0x0) received by PID 2785 (TID 0x7f04e3776700) from PID 0; stack trace: ***
    @          0xb6395f2 google::(anonymous namespace)::FailureSignalHandler()
    @     0x7f056bebbacf os::Linux::chained_handler()
    @     0x7f056bec1938 JVM_handle_linux_signal
    @     0x7f056beb3338 signalHandler()
    @     0x7f056b04c630 (unknown)
    @          0xbab2abd google::protobuf::Message::SpaceUsedLong()
    @          0x5a1cd3e starrocks::ColumnReader::_init()
    @          0x5a1c251 starrocks::ColumnReader::create()
    @          0x5a0c683 starrocks::Segment::_create_column_readers()
    @          0x5a0da3c starrocks::Segment::_open()
    @          0x5a0dfc1 starrocks::Segment::open()
    @          0x6282427 starrocks::lake::TabletManager::load_segment()
    @          0x6277d78 starrocks::lake::Rowset::load_segments()
    @          0x627ac8a starrocks::lake::Rowset::read()
    @          0x707f99c starrocks::lake::TabletReader::get_segment_iterators()
    @          0x708106e starrocks::lake::TabletReader::init_collector()
    @          0x7082f11 starrocks::lake::TabletReader::open()
    @          0x84b5a38 starrocks::connector::LakeDataSource::init_tablet_reader()
    @          0x84b64d4 starrocks::connector::LakeDataSource::open()
    @          0x857035c starrocks::pipeline::ConnectorChunkSource::_open_data_source()
    @          0x8573581 starrocks::pipeline::ConnectorChunkSource::_read_chunk()
    @          0x7de228d starrocks::pipeline::ChunkSource::buffer_next_batch_chunks_blocking()
    @          0x5ab9a0a _ZZN9starrocks8pipeline12ScanOperator18_trigger_next_scanEPNS_12RuntimeStateEiENKUlRT_E_clINS_9workgroup12YieldContextEEEDaS5_.constprop.0
    @          0x5aba545 _ZNSt17_Function_handlerIFvRN9starrocks9workgroup12YieldContextEEZNS0_8pipeline12ScanOperator18_trigger_next_scanEPNS0_12RuntimeStateEiEUlRT_E_E9_M_invokeERKSt9_Any_dataS3_
    @          0x7b73052 starrocks::workgroup::ScanExecutor::worker_thread()
    @          0x7b734d5 _ZNSt17_Function_handlerIFvvEZN9starrocks9workgroup12ScanExecutor10initializeEiEUlvE_E9_M_invokeERKSt9_Any_data
    @          0x9d234f9 starrocks::ThreadPool::dispatch_thread()
    @          0x9d24471 std::_Function_handler<>::_M_invoke()
    @          0x9d1a7dc starrocks::Thread::supervise_thread()
    @     0x7f056b044ea5 start_thread
    @     0x7f056a445b0d __clone
    @                0x0 (unknown)
```


This bug was introduced by https://github.com/StarRocks/starrocks/pull/42805

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
