### PR TITLE
[Enhancement] Improve replication job scheduling to support heterogeneous replica number and improve fault tolerance (backport #42772) 

### DIFF
--- a/be/src/agent/agent_task.cpp
+++ b/be/src/agent/agent_task.cpp
@@ -964,16 +964,14 @@ void run_remote_snapshot_task(const std::shared_ptr<RemoteSnapshotAgentTaskReque
     TStatusCode::type status_code = TStatusCode::OK;
     std::vector<std::string> error_msgs;
 
-    std::string src_snapshot_path;
-    bool incremental_snapshot;
+    TSnapshotInfo src_snapshot_info;
 
     Status res;
     if (remote_snapshot_req.tablet_type == TTabletType::TABLET_TYPE_LAKE) {
-        res = exec_env->lake_replication_txn_manager()->remote_snapshot(remote_snapshot_req, &src_snapshot_path,
-                                                                        &incremental_snapshot);
+        res = exec_env->lake_replication_txn_manager()->remote_snapshot(remote_snapshot_req, &src_snapshot_info);
     } else {
-        res = StorageEngine::instance()->replication_txn_manager()->remote_snapshot(
-                remote_snapshot_req, &src_snapshot_path, &incremental_snapshot);
+        res = StorageEngine::instance()->replication_txn_manager()->remote_snapshot(remote_snapshot_req,
+                                                                                    &src_snapshot_info);
     }
 
     if (!res.ok()) {
@@ -981,8 +979,7 @@ void run_remote_snapshot_task(const std::shared_ptr<RemoteSnapshotAgentTaskReque
         LOG(WARNING) << "remote snapshot failed. status: " << res << ", signature:" << agent_task_req->signature;
         error_msgs.emplace_back("replicate snapshot failed, " + res.to_string());
     } else {
-        finish_task_request.__set_snapshot_path(src_snapshot_path);
-        finish_task_request.__set_incremental_snapshot(incremental_snapshot);
+        finish_task_request.__set_snapshot_info(src_snapshot_info);
     }
 
     task_status.__set_status_code(status_code);

--- a/be/src/storage/lake/replication_txn_manager.cpp
+++ b/be/src/storage/lake/replication_txn_manager.cpp
@@ -54,8 +54,7 @@
 
 namespace starrocks::lake {
 
-Status ReplicationTxnManager::remote_snapshot(const TRemoteSnapshotRequest& request, std::string* src_snapshot_path,
-                                              bool* incremental_snapshot) {
+Status ReplicationTxnManager::remote_snapshot(const TRemoteSnapshotRequest& request, TSnapshotInfo* src_snapshot_info) {
     if (StorageEngine::instance()->bg_worker_stopped()) {
         return Status::InternalError("Process is going to quit. The remote snapshot will stop");
     }
@@ -95,21 +94,23 @@ Status ReplicationTxnManager::remote_snapshot(const TRemoteSnapshotRequest& requ
               << (request.visible_version + 1) << " ... " << request.src_visible_version << "]";
 
     Status status;
-    TBackend src_backend;
     if (request.visible_version <= 1) { // Make full snapshot
-        *incremental_snapshot = false;
-        status = make_remote_snapshot(request, nullptr, nullptr, &src_backend, src_snapshot_path);
+        src_snapshot_info->incremental_snapshot = false;
+        status = make_remote_snapshot(request, nullptr, nullptr, &src_snapshot_info->backend,
+                                      &src_snapshot_info->snapshot_path);
     } else { // Try to make incremental snapshot first, if failed, make full snapshot
-        *incremental_snapshot = true;
-        status = make_remote_snapshot(request, &missed_versions, nullptr, &src_backend, src_snapshot_path);
+        src_snapshot_info->incremental_snapshot = true;
+        status = make_remote_snapshot(request, &missed_versions, nullptr, &src_snapshot_info->backend,
+                                      &src_snapshot_info->snapshot_path);
         if (!status.ok()) {
             LOG(INFO) << "Failed to make incremental snapshot: " << status << ". switch to fully snapshot"
                       << ", txn_id: " << request.transaction_id << ", tablet_id: " << request.tablet_id
                       << ", src_tablet_id: " << request.src_tablet_id
                       << ", visible_version: " << request.visible_version
                       << ", snapshot_version: " << request.src_visible_version;
-            *incremental_snapshot = false;
-            status = make_remote_snapshot(request, nullptr, nullptr, &src_backend, src_snapshot_path);
+            src_snapshot_info->incremental_snapshot = false;
+            status = make_remote_snapshot(request, nullptr, nullptr, &src_snapshot_info->backend,
+                                          &src_snapshot_info->snapshot_path);
         }
     }
 
@@ -121,10 +122,16 @@ Status ReplicationTxnManager::remote_snapshot(const TRemoteSnapshotRequest& requ
         return status;
     }
 
-    LOG(INFO) << "Made snapshot from " << src_backend.host << ":" << src_backend.be_port << ":" << *src_snapshot_path
-              << ", txn_id: " << request.transaction_id << ", tablet_id: " << request.tablet_id
-              << ", src_tablet_id: " << request.src_tablet_id << ", visible_version: " << request.visible_version
-              << ", snapshot_version: " << request.src_visible_version << ", is_incremental: " << *incremental_snapshot;
+    src_snapshot_info->__isset.backend = true;
+    src_snapshot_info->__isset.snapshot_path = true;
+    src_snapshot_info->__isset.incremental_snapshot = true;
+
+    LOG(INFO) << "Made snapshot from " << src_snapshot_info->backend.host << ":" << src_snapshot_info->backend.be_port
+              << ":" << src_snapshot_info->snapshot_path << ", txn_id: " << request.transaction_id
+              << ", tablet_id: " << request.tablet_id << ", src_tablet_id: " << request.src_tablet_id
+              << ", visible_version: " << request.visible_version
+              << ", snapshot_version: " << request.src_visible_version
+              << ", is_incremental: " << src_snapshot_info->incremental_snapshot;
 
     auto txn_log = std::make_shared<TxnLog>();
     txn_log->set_tablet_id(request.tablet_id);
@@ -135,11 +142,11 @@ Status ReplicationTxnManager::remote_snapshot(const TRemoteSnapshotRequest& requ
     txn_meta->set_txn_state(ReplicationTxnStatePB::TXN_SNAPSHOTED);
     txn_meta->set_tablet_id(request.tablet_id);
     txn_meta->set_visible_version(request.visible_version);
-    txn_meta->set_src_backend_host(src_backend.host);
-    txn_meta->set_src_backend_port(src_backend.be_port);
-    txn_meta->set_src_snapshot_path(*src_snapshot_path);
+    txn_meta->set_src_backend_host(src_snapshot_info->backend.host);
+    txn_meta->set_src_backend_port(src_snapshot_info->backend.be_port);
+    txn_meta->set_src_snapshot_path(src_snapshot_info->snapshot_path);
     txn_meta->set_snapshot_version(request.src_visible_version);
-    txn_meta->set_incremental_snapshot(*incremental_snapshot);
+    txn_meta->set_incremental_snapshot(src_snapshot_info->incremental_snapshot);
 
     return tablet.put_txn_slog(txn_log);
 }
@@ -227,7 +234,7 @@ Status ReplicationTxnManager::make_remote_snapshot(const TRemoteSnapshotRequest&
 }
 
 Status ReplicationTxnManager::replicate_remote_snapshot(const TReplicateSnapshotRequest& request,
-                                                        const TRemoteSnapshotInfo& src_snapshot_info,
+                                                        const TSnapshotInfo& src_snapshot_info,
                                                         const TabletMetadataPtr& tablet_metadata) {
     auto txn_log = std::make_shared<TxnLog>();
     std::unordered_map<std::string, std::string> filename_map;

--- a/be/src/storage/lake/replication_txn_manager.h
+++ b/be/src/storage/lake/replication_txn_manager.h
@@ -32,8 +32,7 @@ class ReplicationTxnManager {
 public:
     explicit ReplicationTxnManager(lake::TabletManager* tablet_manager) : _tablet_manager(tablet_manager) {}
 
-    Status remote_snapshot(const TRemoteSnapshotRequest& request, std::string* src_snapshot_path,
-                           bool* incremental_snapshot);
+    Status remote_snapshot(const TRemoteSnapshotRequest& request, TSnapshotInfo* src_snapshot_info);
 
     Status replicate_snapshot(const TReplicateSnapshotRequest& request);
 
@@ -46,8 +45,7 @@ private:
                                 const std::vector<int64_t>* missing_version_ranges, TBackend* src_backend,
                                 std::string* src_snapshot_path);
 
-    Status replicate_remote_snapshot(const TReplicateSnapshotRequest& request,
-                                     const TRemoteSnapshotInfo& src_snapshot_info,
+    Status replicate_remote_snapshot(const TReplicateSnapshotRequest& request, const TSnapshotInfo& src_snapshot_info,
                                      const TabletMetadataPtr& tablet_metadata);
 
     static Status convert_rowset_meta(const RowsetMeta& rowset_meta, TTransactionId transaction_id,

--- a/be/src/storage/replication_txn_manager.cpp
+++ b/be/src/storage/replication_txn_manager.cpp
@@ -153,8 +153,7 @@ Status ReplicationTxnManager::init(const std::vector<starrocks::DataDir*>& data_
     return Status::OK();
 }
 
-Status ReplicationTxnManager::remote_snapshot(const TRemoteSnapshotRequest& request, std::string* src_snapshot_path,
-                                              bool* incremental_snapshot) {
+Status ReplicationTxnManager::remote_snapshot(const TRemoteSnapshotRequest& request, TSnapshotInfo* src_snapshot_info) {
     if (StorageEngine::instance()->bg_worker_stopped()) {
         return Status::InternalError("Process is going to quit. The remote snapshot will stop");
     }
@@ -192,21 +191,23 @@ Status ReplicationTxnManager::remote_snapshot(const TRemoteSnapshotRequest& requ
               << ", snapshot version: " << request.src_visible_version
               << ", missed_versions=" << version_list_to_string(missed_versions);
 
-    TBackend src_backend;
     if (request.visible_version <= 1) { // Make full snapshot
-        *incremental_snapshot = false;
-        status = make_remote_snapshot(request, nullptr, nullptr, &src_backend, src_snapshot_path);
+        src_snapshot_info->incremental_snapshot = false;
+        status = make_remote_snapshot(request, nullptr, nullptr, &src_snapshot_info->backend,
+                                      &src_snapshot_info->snapshot_path);
     } else { // Try to make incremental snapshot first, if failed, make full snapshot
-        *incremental_snapshot = true;
-        status = make_remote_snapshot(request, &missed_versions, nullptr, &src_backend, src_snapshot_path);
+        src_snapshot_info->incremental_snapshot = true;
+        status = make_remote_snapshot(request, &missed_versions, nullptr, &src_snapshot_info->backend,
+                                      &src_snapshot_info->snapshot_path);
         if (!status.ok()) {
             LOG(INFO) << "Failed to make incremental snapshot: " << status << ", txn_id: " << request.transaction_id
                       << ", switch to fully snapshot. tablet_id: " << request.tablet_id
                       << ", src_tablet_id: " << request.src_tablet_id
                       << ", visible version: " << request.visible_version
                       << ", snapshot version: " << request.src_visible_version;
-            *incremental_snapshot = false;
-            status = make_remote_snapshot(request, nullptr, nullptr, &src_backend, src_snapshot_path);
+            src_snapshot_info->incremental_snapshot = false;
+            status = make_remote_snapshot(request, nullptr, nullptr, &src_snapshot_info->backend,
+                                          &src_snapshot_info->snapshot_path);
         }
     }
 
@@ -218,20 +219,26 @@ Status ReplicationTxnManager::remote_snapshot(const TRemoteSnapshotRequest& requ
         return status;
     }
 
-    LOG(INFO) << "Made snapshot from " << src_backend.host << ":" << src_backend.be_port << ":" << *src_snapshot_path
-              << ", txn_id: " << request.transaction_id << ", tablet_id: " << request.tablet_id
-              << ", src_tablet_id: " << request.src_tablet_id << ", visible_version: " << request.visible_version
-              << ", snapshot_version: " << request.src_visible_version << ", is_incremental: " << *incremental_snapshot;
+    src_snapshot_info->__isset.backend = true;
+    src_snapshot_info->__isset.snapshot_path = true;
+    src_snapshot_info->__isset.incremental_snapshot = true;
+
+    LOG(INFO) << "Made snapshot from " << src_snapshot_info->backend.host << ":" << src_snapshot_info->backend.be_port
+              << ":" << src_snapshot_info->snapshot_path << ", txn_id: " << request.transaction_id
+              << ", tablet_id: " << request.tablet_id << ", src_tablet_id: " << request.src_tablet_id
+              << ", visible_version: " << request.visible_version
+              << ", snapshot_version: " << request.src_visible_version
+              << ", is_incremental: " << src_snapshot_info->incremental_snapshot;
 
     txn_meta_pb.set_txn_id(request.transaction_id);
     txn_meta_pb.set_txn_state(ReplicationTxnStatePB::TXN_SNAPSHOTED);
     txn_meta_pb.set_tablet_id(request.tablet_id);
     txn_meta_pb.set_visible_version(request.visible_version);
-    txn_meta_pb.set_src_backend_host(src_backend.host);
-    txn_meta_pb.set_src_backend_port(src_backend.be_port);
-    txn_meta_pb.set_src_snapshot_path(*src_snapshot_path);
+    txn_meta_pb.set_src_backend_host(src_snapshot_info->backend.host);
+    txn_meta_pb.set_src_backend_port(src_snapshot_info->backend.be_port);
+    txn_meta_pb.set_src_snapshot_path(src_snapshot_info->snapshot_path);
     txn_meta_pb.set_snapshot_version(request.src_visible_version);
-    txn_meta_pb.set_incremental_snapshot(*incremental_snapshot);
+    txn_meta_pb.set_incremental_snapshot(src_snapshot_info->incremental_snapshot);
 
     return save_tablet_txn_meta(tablet->data_dir(), request.transaction_id, request.partition_id, request.tablet_id,
                                 txn_meta_pb);
@@ -442,7 +449,7 @@ Status ReplicationTxnManager::make_remote_snapshot(const TRemoteSnapshotRequest&
 }
 
 Status ReplicationTxnManager::replicate_remote_snapshot(const TReplicateSnapshotRequest& request,
-                                                        const TRemoteSnapshotInfo& src_snapshot_info,
+                                                        const TSnapshotInfo& src_snapshot_info,
                                                         const std::string& tablet_snapshot_dir_path, Tablet* tablet) {
     // Check local path exist, if exist, remove it, then create the dir
     RETURN_IF_ERROR(ignore_not_found(fs::remove_all(tablet_snapshot_dir_path)));

--- a/be/src/storage/replication_txn_manager.h
+++ b/be/src/storage/replication_txn_manager.h
@@ -25,8 +25,7 @@ public:
 
     Status init(const std::vector<starrocks::DataDir*>& data_dirs);
 
-    Status remote_snapshot(const TRemoteSnapshotRequest& request, std::string* src_snapshot_path,
-                           bool* incremental_snapshot);
+    Status remote_snapshot(const TRemoteSnapshotRequest& request, TSnapshotInfo* src_snapshot_info);
 
     Status replicate_snapshot(const TReplicateSnapshotRequest& request);
 
@@ -54,8 +53,7 @@ private:
                                 const std::vector<int64_t>* missing_version_ranges, TBackend* src_backend,
                                 std::string* src_snapshot_path);
 
-    Status replicate_remote_snapshot(const TReplicateSnapshotRequest& request,
-                                     const TRemoteSnapshotInfo& src_snapshot_info,
+    Status replicate_remote_snapshot(const TReplicateSnapshotRequest& request, const TSnapshotInfo& src_snapshot_info,
                                      const std::string& tablet_snapshot_dir_path, Tablet* tablet);
 
     Status convert_snapshot_for_none_primary(const std::string& tablet_snapshot_path,

--- a/be/test/agent/agent_task_test.cpp
+++ b/be/test/agent/agent_task_test.cpp
@@ -119,10 +119,9 @@ TEST_F(AgentTaskTest, test_replication_txn) {
     auto remote_snapshot_agent_task = std::make_shared<RemoteSnapshotAgentTaskRequest>(
             agent_task_request, agent_task_request.remote_snapshot_req, time(nullptr));
 
-    std::string snapshot_path;
-    bool incremental_snapshot = false;
-    Status status = StorageEngine::instance()->replication_txn_manager()->remote_snapshot(
-            remote_snapshot_request, &snapshot_path, &incremental_snapshot);
+    TSnapshotInfo remote_snapshot_info;
+    Status status = StorageEngine::instance()->replication_txn_manager()->remote_snapshot(remote_snapshot_request,
+                                                                                          &remote_snapshot_info);
     EXPECT_TRUE(status.ok());
 
     run_remote_snapshot_task(remote_snapshot_agent_task, nullptr);
@@ -140,10 +139,6 @@ TEST_F(AgentTaskTest, test_replication_txn) {
     replicate_snapshot_request.__set_src_tablet_type(TTabletType::TABLET_TYPE_DISK);
     replicate_snapshot_request.__set_src_schema_hash(_schema_hash);
     replicate_snapshot_request.__set_src_visible_version(_src_version);
-    TRemoteSnapshotInfo remote_snapshot_info;
-    remote_snapshot_info.__set_backend(TBackend());
-    remote_snapshot_info.__set_snapshot_path(snapshot_path);
-    remote_snapshot_info.__set_incremental_snapshot(incremental_snapshot);
     replicate_snapshot_request.__set_src_snapshot_infos({remote_snapshot_info});
     agent_task_request.__set_replicate_snapshot_req(replicate_snapshot_request);
 

--- a/be/test/storage/lake/replication_txn_manager_test.cpp
+++ b/be/test/storage/lake/replication_txn_manager_test.cpp
@@ -234,10 +234,8 @@ TEST_P(LakeReplicationTxnManagerTest, test_remote_snapshot_no_missing_versions) 
     remote_snapshot_request.__set_src_visible_version(_version);
     remote_snapshot_request.__set_src_backends({TBackend()});
 
-    std::string snapshot_path;
-    bool incremental_snapshot = false;
-    Status status =
-            _replication_txn_manager->remote_snapshot(remote_snapshot_request, &snapshot_path, &incremental_snapshot);
+    TSnapshotInfo remote_snapshot_info;
+    Status status = _replication_txn_manager->remote_snapshot(remote_snapshot_request, &remote_snapshot_info);
     EXPECT_FALSE(status.ok());
 }
 
@@ -257,10 +255,8 @@ TEST_P(LakeReplicationTxnManagerTest, test_remote_snapshot_no_versions) {
     remote_snapshot_request.__set_src_visible_version(_src_version + 1);
     remote_snapshot_request.__set_src_backends({TBackend()});
 
-    std::string snapshot_path;
-    bool incremental_snapshot = false;
-    Status status =
-            _replication_txn_manager->remote_snapshot(remote_snapshot_request, &snapshot_path, &incremental_snapshot);
+    TSnapshotInfo remote_snapshot_info;
+    Status status = _replication_txn_manager->remote_snapshot(remote_snapshot_request, &remote_snapshot_info);
     EXPECT_FALSE(status.ok());
 }
 
@@ -280,13 +276,11 @@ TEST_P(LakeReplicationTxnManagerTest, test_replicate_snapshot_failed) {
     remote_snapshot_request.__set_src_visible_version(_src_version);
     remote_snapshot_request.__set_src_backends({TBackend()});
 
-    std::string snapshot_path;
-    bool incremental_snapshot = false;
-    Status status =
-            _replication_txn_manager->remote_snapshot(remote_snapshot_request, &snapshot_path, &incremental_snapshot);
+    TSnapshotInfo remote_snapshot_info;
+    Status status = _replication_txn_manager->remote_snapshot(remote_snapshot_request, &remote_snapshot_info);
     EXPECT_TRUE(status.ok()) << status;
 
-    status = _replication_txn_manager->remote_snapshot(remote_snapshot_request, &snapshot_path, &incremental_snapshot);
+    status = _replication_txn_manager->remote_snapshot(remote_snapshot_request, &remote_snapshot_info);
     EXPECT_TRUE(status.ok()) << status;
 
     TReplicateSnapshotRequest replicate_snapshot_request;
@@ -302,10 +296,6 @@ TEST_P(LakeReplicationTxnManagerTest, test_replicate_snapshot_failed) {
     replicate_snapshot_request.__set_src_tablet_type(TTabletType::TABLET_TYPE_DISK);
     replicate_snapshot_request.__set_src_schema_hash(_schema_hash + 1);
     replicate_snapshot_request.__set_src_visible_version(_src_version);
-    TRemoteSnapshotInfo remote_snapshot_info;
-    remote_snapshot_info.__set_backend(TBackend());
-    remote_snapshot_info.__set_snapshot_path(snapshot_path);
-    remote_snapshot_info.__set_incremental_snapshot(incremental_snapshot);
     replicate_snapshot_request.__set_src_snapshot_infos({remote_snapshot_info});
 
     status = _replication_txn_manager->replicate_snapshot(replicate_snapshot_request);
@@ -334,10 +324,8 @@ TEST_P(LakeReplicationTxnManagerTest, test_publish_failed) {
     remote_snapshot_request.__set_src_visible_version(_src_version);
     remote_snapshot_request.__set_src_backends({TBackend()});
 
-    std::string snapshot_path;
-    bool incremental_snapshot = false;
-    Status status =
-            _replication_txn_manager->remote_snapshot(remote_snapshot_request, &snapshot_path, &incremental_snapshot);
+    TSnapshotInfo remote_snapshot_info;
+    Status status = _replication_txn_manager->remote_snapshot(remote_snapshot_request, &remote_snapshot_info);
     EXPECT_TRUE(status.ok()) << status;
 
     const int64_t txn_ids[] = {_transaction_id};
@@ -366,10 +354,8 @@ TEST_P(LakeReplicationTxnManagerTest, test_run_normal) {
     remote_snapshot_request.__set_src_visible_version(_src_version);
     remote_snapshot_request.__set_src_backends({TBackend()});
 
-    std::string snapshot_path;
-    bool incremental_snapshot = false;
-    Status status =
-            _replication_txn_manager->remote_snapshot(remote_snapshot_request, &snapshot_path, &incremental_snapshot);
+    TSnapshotInfo remote_snapshot_info;
+    Status status = _replication_txn_manager->remote_snapshot(remote_snapshot_request, &remote_snapshot_info);
     EXPECT_TRUE(status.ok()) << status;
 
     TReplicateSnapshotRequest replicate_snapshot_request;
@@ -385,10 +371,6 @@ TEST_P(LakeReplicationTxnManagerTest, test_run_normal) {
     replicate_snapshot_request.__set_src_tablet_type(TTabletType::TABLET_TYPE_DISK);
     replicate_snapshot_request.__set_src_schema_hash(_schema_hash);
     replicate_snapshot_request.__set_src_visible_version(_src_version);
-    TRemoteSnapshotInfo remote_snapshot_info;
-    remote_snapshot_info.__set_backend(TBackend());
-    remote_snapshot_info.__set_snapshot_path(snapshot_path);
-    remote_snapshot_info.__set_incremental_snapshot(incremental_snapshot);
     replicate_snapshot_request.__set_src_snapshot_infos({remote_snapshot_info});
 
     status = _replication_txn_manager->replicate_snapshot(replicate_snapshot_request);

--- a/be/test/storage/replication_txn_manager_test.cpp
+++ b/be/test/storage/replication_txn_manager_test.cpp
@@ -201,10 +201,9 @@ TEST_P(ReplicationTxnManagerTest, test_remote_snapshot_no_missing_versions) {
     remote_snapshot_request.__set_src_visible_version(_version);
     remote_snapshot_request.__set_src_backends({TBackend()});
 
-    std::string snapshot_path;
-    bool incremental_snapshot = false;
-    Status status = StorageEngine::instance()->replication_txn_manager()->remote_snapshot(
-            remote_snapshot_request, &snapshot_path, &incremental_snapshot);
+    TSnapshotInfo remote_snapshot_info;
+    Status status = StorageEngine::instance()->replication_txn_manager()->remote_snapshot(remote_snapshot_request,
+                                                                                          &remote_snapshot_info);
     EXPECT_FALSE(status.ok()) << status;
 
     StorageEngine::instance()->replication_txn_manager()->clear_txn(_transaction_id);
@@ -228,10 +227,9 @@ TEST_P(ReplicationTxnManagerTest, test_remote_snapshot_no_versions) {
     remote_snapshot_request.__set_src_visible_version(_src_version + 1);
     remote_snapshot_request.__set_src_backends({TBackend()});
 
-    std::string snapshot_path;
-    bool incremental_snapshot = false;
-    Status status = StorageEngine::instance()->replication_txn_manager()->remote_snapshot(
-            remote_snapshot_request, &snapshot_path, &incremental_snapshot);
+    TSnapshotInfo remote_snapshot_info;
+    Status status = StorageEngine::instance()->replication_txn_manager()->remote_snapshot(remote_snapshot_request,
+                                                                                          &remote_snapshot_info);
     EXPECT_FALSE(status.ok()) << status;
 
     StorageEngine::instance()->replication_txn_manager()->clear_txn(_transaction_id);
@@ -255,14 +253,13 @@ TEST_P(ReplicationTxnManagerTest, test_replicate_snapshot_failed) {
     remote_snapshot_request.__set_src_visible_version(_src_version);
     remote_snapshot_request.__set_src_backends({TBackend()});
 
-    std::string snapshot_path;
-    bool incremental_snapshot = false;
-    Status status = StorageEngine::instance()->replication_txn_manager()->remote_snapshot(
-            remote_snapshot_request, &snapshot_path, &incremental_snapshot);
+    TSnapshotInfo remote_snapshot_info;
+    Status status = StorageEngine::instance()->replication_txn_manager()->remote_snapshot(remote_snapshot_request,
+                                                                                          &remote_snapshot_info);
     EXPECT_TRUE(status.ok()) << status;
 
-    status = StorageEngine::instance()->replication_txn_manager()->remote_snapshot(
-            remote_snapshot_request, &snapshot_path, &incremental_snapshot);
+    status = StorageEngine::instance()->replication_txn_manager()->remote_snapshot(remote_snapshot_request,
+                                                                                   &remote_snapshot_info);
     EXPECT_TRUE(status.ok()) << status;
 
     TReplicateSnapshotRequest replicate_snapshot_request;
@@ -278,10 +275,6 @@ TEST_P(ReplicationTxnManagerTest, test_replicate_snapshot_failed) {
     replicate_snapshot_request.__set_src_tablet_type(TTabletType::TABLET_TYPE_DISK);
     replicate_snapshot_request.__set_src_schema_hash(_schema_hash + 1);
     replicate_snapshot_request.__set_src_visible_version(_src_version);
-    TRemoteSnapshotInfo remote_snapshot_info;
-    remote_snapshot_info.__set_backend(TBackend());
-    remote_snapshot_info.__set_snapshot_path(snapshot_path);
-    remote_snapshot_info.__set_incremental_snapshot(incremental_snapshot);
     replicate_snapshot_request.__set_src_snapshot_infos({remote_snapshot_info});
 
     status = StorageEngine::instance()->replication_txn_manager()->replicate_snapshot(replicate_snapshot_request);
@@ -308,10 +301,9 @@ TEST_P(ReplicationTxnManagerTest, test_publish_failed) {
     remote_snapshot_request.__set_src_visible_version(_src_version);
     remote_snapshot_request.__set_src_backends({TBackend()});
 
-    std::string snapshot_path;
-    bool incremental_snapshot = false;
-    Status status = StorageEngine::instance()->replication_txn_manager()->remote_snapshot(
-            remote_snapshot_request, &snapshot_path, &incremental_snapshot);
+    TSnapshotInfo remote_snapshot_info;
+    Status status = StorageEngine::instance()->replication_txn_manager()->remote_snapshot(remote_snapshot_request,
+                                                                                          &remote_snapshot_info);
     EXPECT_TRUE(status.ok()) << status;
 
     TabletSharedPtr tablet_ptr = StorageEngine::instance()->tablet_manager()->get_tablet(_tablet_id);
@@ -342,10 +334,9 @@ TEST_P(ReplicationTxnManagerTest, test_run_normal) {
     remote_snapshot_request.__set_src_visible_version(_src_version);
     remote_snapshot_request.__set_src_backends({TBackend()});
 
-    std::string snapshot_path;
-    bool incremental_snapshot = false;
-    Status status = StorageEngine::instance()->replication_txn_manager()->remote_snapshot(
-            remote_snapshot_request, &snapshot_path, &incremental_snapshot);
+    TSnapshotInfo remote_snapshot_info;
+    Status status = StorageEngine::instance()->replication_txn_manager()->remote_snapshot(remote_snapshot_request,
+                                                                                          &remote_snapshot_info);
     EXPECT_TRUE(status.ok()) << status;
 
     TReplicateSnapshotRequest replicate_snapshot_request;
@@ -361,10 +352,6 @@ TEST_P(ReplicationTxnManagerTest, test_run_normal) {
     replicate_snapshot_request.__set_src_tablet_type(TTabletType::TABLET_TYPE_DISK);
     replicate_snapshot_request.__set_src_schema_hash(_schema_hash);
     replicate_snapshot_request.__set_src_visible_version(_src_version);
-    TRemoteSnapshotInfo remote_snapshot_info;
-    remote_snapshot_info.__set_backend(TBackend());
-    remote_snapshot_info.__set_snapshot_path(snapshot_path);
-    remote_snapshot_info.__set_incremental_snapshot(incremental_snapshot);
     replicate_snapshot_request.__set_src_snapshot_infos({remote_snapshot_info});
 
     status = StorageEngine::instance()->replication_txn_manager()->replicate_snapshot(replicate_snapshot_request);

--- a/fe/fe-core/src/main/java/com/starrocks/replication/ReplicationJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/replication/ReplicationJob.java
@@ -49,8 +49,8 @@ import com.starrocks.thrift.TBackend;
 import com.starrocks.thrift.TFinishTaskRequest;
 import com.starrocks.thrift.TIndexReplicationInfo;
 import com.starrocks.thrift.TPartitionReplicationInfo;
-import com.starrocks.thrift.TRemoteSnapshotInfo;
 import com.starrocks.thrift.TReplicaReplicationInfo;
+import com.starrocks.thrift.TSnapshotInfo;
 import com.starrocks.thrift.TStatusCode;
 import com.starrocks.thrift.TTableReplicationRequest;
 import com.starrocks.thrift.TTableType;
@@ -67,6 +67,7 @@ import org.apache.logging.log4j.Logger;
 import java.io.IOException;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 public class ReplicationJob implements GsonPostProcessable {
     private static final Logger LOG = LogManager.getLogger(ReplicationJob.class);
@@ -202,55 +203,99 @@ public class ReplicationJob implements GsonPostProcessable {
         @SerializedName(value = "backendId")
         private final long backendId;
 
-        @SerializedName(value = "backendHost")
-        private final String backendHost;
-        @SerializedName(value = "backendBePort")
-        private final int backendBePort;
-        @SerializedName(value = "backendHttpPort")
-        private final int backendHttpPort;
+        @SerializedName(value = "srcBackendInfos")
+        private final List<BackendInfo> srcBackendInfos;
 
-        @SerializedName(value = "srcSnapshotPath")
-        private volatile String srcSnapshotPath;
+        @SerializedName(value = "srcSnapshotInfo")
+        private volatile SnapshotInfo srcSnapshotInfo;
 
-        @SerializedName(value = "srcIncrementalSnapshot")
-        private volatile boolean srcIncrementalSnapshot;
-
-        public ReplicaInfo(long backendId, Backend srcBackend) {
+        public ReplicaInfo(long backendId, List<BackendInfo> srcBackendInfos) {
             this.backendId = backendId;
-            this.backendHost = srcBackend.getHost();
-            this.backendBePort = srcBackend.getBePort();
-            this.backendHttpPort = srcBackend.getHttpPort();
-        }
-
-        public ReplicaInfo(long backendId, String backendHost, int backendBePort, int backendHttpPort) {
-            this.backendId = backendId;
-            this.backendHost = backendHost;
-            this.backendBePort = backendBePort;
-            this.backendHttpPort = backendHttpPort;
+            this.srcBackendInfos = srcBackendInfos;
         }
 
         public long getBackendId() {
             return backendId;
         }
 
-        public TBackend getSrcBackend() {
-            return new TBackend(backendHost, backendBePort, backendHttpPort);
+        public List<BackendInfo> getSrcBackendInfos() {
+            return srcBackendInfos;
         }
 
-        public String getSrcSnapshotPath() {
-            return srcSnapshotPath;
+        public List<TBackend> getSrcBackends() {
+            return srcBackendInfos.stream().map(BackendInfo::getBackend).collect(Collectors.toList());
         }
 
-        public void setSrcSnapshotPath(String srcSnapshotPath) {
-            this.srcSnapshotPath = srcSnapshotPath;
+        public SnapshotInfo getSrcSnapshotInfo() {
+            return srcSnapshotInfo;
         }
 
-        public boolean getSrcIncrementalSnapshot() {
-            return srcIncrementalSnapshot;
+        public void setSrcSnapshotInfo(SnapshotInfo srcSnapshotInfo) {
+            this.srcSnapshotInfo = srcSnapshotInfo;
+        }
+    }
+
+    private static class BackendInfo {
+        @SerializedName(value = "host")
+        private final String host;
+
+        @SerializedName(value = "bePort")
+        private final int bePort;
+
+        @SerializedName(value = "httpPort")
+        private final int httpPort;
+
+        public BackendInfo(String host, int bePort, int httpPort) {
+            this.host = host;
+            this.bePort = bePort;
+            this.httpPort = httpPort;
         }
 
-        public void setSrcIncrementalSnapshot(boolean srcIncrementalSnapshot) {
-            this.srcIncrementalSnapshot = srcIncrementalSnapshot;
+        public BackendInfo(Backend backend) {
+            this.host = backend.getHost();
+            this.bePort = backend.getBePort();
+            this.httpPort = backend.getHttpPort();
+        }
+
+        public BackendInfo(TBackend backend) {
+            this.host = backend.host;
+            this.bePort = backend.be_port;
+            this.httpPort = backend.http_port;
+        }
+
+        public TBackend getBackend() {
+            return new TBackend(host, bePort, httpPort);
+        }
+    }
+
+    private static class SnapshotInfo {
+        @SerializedName(value = "backendInfo")
+        private final BackendInfo backendInfo;
+
+        @SerializedName(value = "snapshotPath")
+        private final String snapshotPath;
+
+        @SerializedName(value = "incrementalSnapshot")
+        private final boolean incrementalSnapshot;
+
+        public SnapshotInfo(BackendInfo backendInfo, String snapshotPath, boolean incrementalSnapshot) {
+            this.backendInfo = backendInfo;
+            this.snapshotPath = snapshotPath;
+            this.incrementalSnapshot = incrementalSnapshot;
+        }
+
+        public SnapshotInfo(TSnapshotInfo snapshotInfo) {
+            this.backendInfo = new BackendInfo(snapshotInfo.backend);
+            this.snapshotPath = snapshotInfo.snapshot_path;
+            this.incrementalSnapshot = snapshotInfo.incremental_snapshot;
+        }
+
+        public TSnapshotInfo getSnapshotInfo() {
+            TSnapshotInfo tSnapshotInfo = new TSnapshotInfo();
+            tSnapshotInfo.setBackend(backendInfo.getBackend());
+            tSnapshotInfo.setSnapshot_path(snapshotPath);
+            tSnapshotInfo.setIncremental_snapshot(incrementalSnapshot);
+            return tSnapshotInfo;
         }
     }
 
@@ -417,7 +462,7 @@ public class ReplicationJob implements GsonPostProcessable {
         }
 
         if (request.getTask_status().getStatus_code() == TStatusCode.OK) {
-            if (request.isSetSnapshot_path() && request.isSetIncremental_snapshot()) {
+            if (request.isSetSnapshot_info()) {
                 PartitionInfo partitionInfo = partitionInfos.get(task.getPartitionId());
                 Preconditions.checkNotNull(partitionInfo);
                 IndexInfo indexInfo = partitionInfo.getIndexInfos().get(task.getIndexId());
@@ -427,12 +472,11 @@ public class ReplicationJob implements GsonPostProcessable {
                 ReplicaInfo replicaInfo = tabletInfo.getReplicaInfos().get(task.getBackendId());
                 Preconditions.checkNotNull(replicaInfo);
 
-                replicaInfo.setSrcSnapshotPath(request.snapshot_path);
-                replicaInfo.setSrcIncrementalSnapshot(request.incremental_snapshot);
+                replicaInfo.setSrcSnapshotInfo(new SnapshotInfo(request.snapshot_info));
                 task.setFinished(true);
             } else {
                 task.setFailed(true);
-                task.setErrorMsg("No snapshot path or incremental snapshot");
+                task.setErrorMsg("No snapshot info");
                 LOG.warn("Remote snapshot task failed, task: {}, error: {}", task, task.getErrorMsg());
             }
         } else {
@@ -547,14 +591,20 @@ public class ReplicationJob implements GsonPostProcessable {
         Map<Long, ReplicaInfo> replicaInfos = Maps.newHashMap();
         List<Replica> replicas = tablet.getAllReplicas();
         List<TReplicaReplicationInfo> tReplicaInfos = tTabletInfo.replica_replication_infos;
-        Preconditions.checkState(replicas.size() <= tReplicaInfos.size(),
-                "Source replica number must not less than target replica number");
+
+        final int splitSize = tReplicaInfos.size() / replicas.size();
+        final int remainSize = tReplicaInfos.size() % replicas.size();
+        int offset = 0;
         for (int i = 0; i < replicas.size(); ++i) {
             Replica replica = replicas.get(i);
-            TReplicaReplicationInfo tReplicaInfo = tReplicaInfos.get(i);
-            ReplicaInfo replicaInfo = new ReplicaInfo(replica.getBackendId(),
-                    tReplicaInfo.src_backend.host, tReplicaInfo.src_backend.be_port,
-                    tReplicaInfo.src_backend.http_port);
+            int size = i < remainSize ? splitSize + 1 : splitSize;
+            List<BackendInfo> backendInfos = Lists.newArrayList();
+            for (int j = 0; j < size; ++j) {
+                TReplicaReplicationInfo tReplicaInfo = tReplicaInfos.get(offset);
+                backendInfos.add(new BackendInfo(tReplicaInfo.src_backend));
+                ++offset;
+            }
+            ReplicaInfo replicaInfo = new ReplicaInfo(replica.getBackendId(), backendInfos);
             replicaInfos.put(replicaInfo.getBackendId(), replicaInfo);
         }
         return new TabletInfo(tTabletInfo.tablet_id, tTabletInfo.src_tablet_id, replicaInfos);
@@ -620,19 +670,24 @@ public class ReplicationJob implements GsonPostProcessable {
         Map<Long, ReplicaInfo> replicaInfos = Maps.newHashMap();
         List<Replica> replicas = tablet.getAllReplicas();
         List<Replica> srcReplicas = srcTablet.getAllReplicas();
-        Preconditions.checkState(replicas.size() <= srcReplicas.size());
+
+        final int splitSize = srcReplicas.size() / replicas.size();
+        final int remainSize = srcReplicas.size() % replicas.size();
+        int offset = 0;
         for (int i = 0; i < replicas.size(); ++i) {
             Replica replica = replicas.get(i);
-            Replica srcReplica = srcReplicas.get(i); // TODO: replicas.size() > srcReplicas.size()
-            ReplicaInfo replicaInfo = initReplicaInfo(replica, srcReplica, srcSystemInfoService);
+            int size = i < remainSize ? splitSize + 1 : splitSize;
+            List<BackendInfo> backendInfos = Lists.newArrayList();
+            for (int j = 0; j < size; ++j) {
+                Replica srcReplica = srcReplicas.get(offset);
+                Backend srcBackend = srcSystemInfoService.getBackend(srcReplica.getBackendId());
+                backendInfos.add(new BackendInfo(srcBackend));
+                ++offset;
+            }
+            ReplicaInfo replicaInfo = new ReplicaInfo(replica.getBackendId(), backendInfos);
             replicaInfos.put(replicaInfo.getBackendId(), replicaInfo);
         }
         return new TabletInfo(tablet.getId(), srcTablet.getId(), replicaInfos);
-    }
-
-    private ReplicaInfo initReplicaInfo(Replica replica, Replica srcReplica, SystemInfoService srcSystemInfoService) {
-        Backend srcBackend = srcSystemInfoService.getBackend(srcReplica.getBackendId());
-        return new ReplicaInfo(replica.getBackendId(), srcBackend);
     }
 
     private TTabletType getTabletType(Table.TableType tableType) {
@@ -714,15 +769,17 @@ public class ReplicationJob implements GsonPostProcessable {
             for (IndexInfo indexInfo : partitionInfo.getIndexInfos().values()) {
                 for (TabletInfo tabletInfo : indexInfo.getTabletInfos().values()) {
                     for (ReplicaInfo replicaInfo : tabletInfo.getReplicaInfos().values()) {
-                        RemoteSnapshotTask task = new RemoteSnapshotTask(replicaInfo.getBackendId(), databaseId,
-                                tableId, partitionInfo.getPartitionId(), indexInfo.getIndexId(),
-                                tabletInfo.getTabletId(), getTabletType(tableType), transactionId,
-                                indexInfo.getSchemaHash(), partitionInfo.getVersion(),
-                                srcToken, tabletInfo.getSrcTabletId(), getTabletType(srcTableType),
-                                indexInfo.getSrcSchemaHash(), partitionInfo.getSrcVersion(),
-                                Lists.newArrayList(replicaInfo.getSrcBackend()),
-                                Config.replication_transaction_timeout_sec);
-                        runningTasks.put(task, task);
+                        if (!replicaInfo.getSrcBackendInfos().isEmpty()) {
+                            RemoteSnapshotTask task = new RemoteSnapshotTask(replicaInfo.getBackendId(), databaseId,
+                                    tableId, partitionInfo.getPartitionId(), indexInfo.getIndexId(),
+                                    tabletInfo.getTabletId(), getTabletType(tableType), transactionId,
+                                    indexInfo.getSchemaHash(), partitionInfo.getVersion(),
+                                    srcToken, tabletInfo.getSrcTabletId(), getTabletType(srcTableType),
+                                    indexInfo.getSrcSchemaHash(), partitionInfo.getSrcVersion(),
+                                    replicaInfo.getSrcBackends(),
+                                    Config.replication_transaction_timeout_sec);
+                            runningTasks.put(task, task);
+                        }
                     }
                 }
             }
@@ -738,18 +795,29 @@ public class ReplicationJob implements GsonPostProcessable {
         for (PartitionInfo partitionInfo : partitionInfos.values()) {
             for (IndexInfo indexInfo : partitionInfo.getIndexInfos().values()) {
                 for (TabletInfo tabletInfo : indexInfo.getTabletInfos().values()) {
-                    for (ReplicaInfo replicaInfo : tabletInfo.getReplicaInfos().values()) {
-                        TRemoteSnapshotInfo srcSnapshotInfo = new TRemoteSnapshotInfo();
-                        srcSnapshotInfo.setBackend(replicaInfo.getSrcBackend());
-                        srcSnapshotInfo.setSnapshot_path(replicaInfo.getSrcSnapshotPath());
-                        srcSnapshotInfo.setIncremental_snapshot(replicaInfo.getSrcIncrementalSnapshot());
+                    List<ReplicaInfo> replicaInfos = Lists.newArrayList(tabletInfo.getReplicaInfos().values());
+                    List<TSnapshotInfo> srcSnapshotInfos = Lists.newArrayList();
+                    for (ReplicaInfo replicaInfo : replicaInfos) {
+                        if (replicaInfo.getSrcSnapshotInfo() != null) {
+                            srcSnapshotInfos.add(replicaInfo.getSrcSnapshotInfo().getSnapshotInfo());
+                        }
+                    }
+                    if (srcSnapshotInfos.isEmpty()) {
+                        throw new RuntimeException("Source snapshots is empty");
+                    }
+                    for (int i = 0; i < replicaInfos.size(); ++i) {
+                        ReplicaInfo replicaInfo = replicaInfos.get(i);
+                        List<TSnapshotInfo> flippedSrcSnapshotInfos = Lists.newArrayList();
+                        int offset = i % srcSnapshotInfos.size();
+                        flippedSrcSnapshotInfos.addAll(srcSnapshotInfos.subList(offset, srcSnapshotInfos.size()));
+                        flippedSrcSnapshotInfos.addAll(srcSnapshotInfos.subList(0, offset));
                         ReplicateSnapshotTask task = new ReplicateSnapshotTask(replicaInfo.getBackendId(), databaseId,
                                 tableId, partitionInfo.getPartitionId(), indexInfo.getIndexId(),
                                 tabletInfo.getTabletId(), getTabletType(tableType), transactionId,
                                 indexInfo.getSchemaHash(), partitionInfo.getVersion(),
                                 srcToken, tabletInfo.getSrcTabletId(), getTabletType(srcTableType),
                                 indexInfo.getSrcSchemaHash(), partitionInfo.getSrcVersion(),
-                                Lists.newArrayList(srcSnapshotInfo));
+                                flippedSrcSnapshotInfos);
                         runningTasks.put(task, task);
                     }
                 }

--- a/fe/fe-core/src/main/java/com/starrocks/task/ReplicateSnapshotTask.java
+++ b/fe/fe-core/src/main/java/com/starrocks/task/ReplicateSnapshotTask.java
@@ -15,8 +15,8 @@
 package com.starrocks.task;
 
 import com.starrocks.task.AgentTask;
-import com.starrocks.thrift.TRemoteSnapshotInfo;
 import com.starrocks.thrift.TReplicateSnapshotRequest;
+import com.starrocks.thrift.TSnapshotInfo;
 import com.starrocks.thrift.TTabletType;
 import com.starrocks.thrift.TTaskType;
 
@@ -34,12 +34,12 @@ public class ReplicateSnapshotTask extends AgentTask {
     private final TTabletType srcTabletType;
     private final int srcSchemaHash;
     private final long srcVisibleVersion;
-    private final List<TRemoteSnapshotInfo> srcSnapshotInfos;
+    private final List<TSnapshotInfo> srcSnapshotInfos;
 
     public ReplicateSnapshotTask(long backendId, long dbId, long tableId, long partitionId, long indexId, long tabletId,
             TTabletType tabletType, long transactionId, int schemaHash, long visibleVersion,
             String srcToken, long srcTabletId, TTabletType srcTabletType, int srcSchemaHash,
-            long srcVisibleVersion, List<TRemoteSnapshotInfo> srcSnapshotInfos) {
+            long srcVisibleVersion, List<TSnapshotInfo> srcSnapshotInfos) {
         super(null, backendId, TTaskType.REPLICATE_SNAPSHOT, dbId, tableId, partitionId, indexId, tabletId, tabletId,
                 System.currentTimeMillis());
         this.transactionId = transactionId;

--- a/fe/fe-core/src/test/java/com/starrocks/replication/ReplicationJobTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/replication/ReplicationJobTest.java
@@ -36,6 +36,7 @@ import com.starrocks.thrift.TFinishTaskRequest;
 import com.starrocks.thrift.TIndexReplicationInfo;
 import com.starrocks.thrift.TPartitionReplicationInfo;
 import com.starrocks.thrift.TReplicaReplicationInfo;
+import com.starrocks.thrift.TSnapshotInfo;
 import com.starrocks.thrift.TStatus;
 import com.starrocks.thrift.TStatusCode;
 import com.starrocks.thrift.TTableReplicationRequest;
@@ -131,8 +132,7 @@ public class ReplicationJobTest {
         for (AgentTask task : runningTasks.values()) {
             TFinishTaskRequest request = new TFinishTaskRequest();
             request.setTask_status(new TStatus(TStatusCode.OK));
-            request.setSnapshot_path("test_snapshot_path");
-            request.setIncremental_snapshot(true);
+            request.setSnapshot_info(newTSnapshotInfo(new TBackend("test_host", 0, 0), "test_snapshot_path", true));
             job.finishRemoteSnapshotTask((RemoteSnapshotTask) task, request);
 
             Deencapsulation.invoke(new LeaderImpl(), "finishRemoteSnapshotTask",
@@ -197,8 +197,7 @@ public class ReplicationJobTest {
         for (AgentTask task : runningTasks.values()) {
             TFinishTaskRequest request = new TFinishTaskRequest();
             request.setTask_status(new TStatus(TStatusCode.OK));
-            request.setSnapshot_path("test_snapshot_path");
-            request.setIncremental_snapshot(true);
+            request.setSnapshot_info(newTSnapshotInfo(new TBackend("test_host", 0, 0), "test_snapshot_path", true));
             job.finishRemoteSnapshotTask((RemoteSnapshotTask) task, request);
         }
 
@@ -226,8 +225,7 @@ public class ReplicationJobTest {
         for (AgentTask task : runningTasks.values()) {
             TFinishTaskRequest request = new TFinishTaskRequest();
             request.setTask_status(new TStatus(TStatusCode.OK));
-            request.setSnapshot_path("test_snapshot_path");
-            request.setIncremental_snapshot(true);
+            request.setSnapshot_info(newTSnapshotInfo(new TBackend("test_host", 0, 0), "test_snapshot_path", true));
             job.finishRemoteSnapshotTask((RemoteSnapshotTask) task, request);
         }
 
@@ -260,20 +258,8 @@ public class ReplicationJobTest {
         Map<AgentTask, AgentTask> runningTasks = Deencapsulation.getField(job, "runningTasks");
         for (AgentTask task : runningTasks.values()) {
             TFinishTaskRequest request = new TFinishTaskRequest();
-            TStatus status = new TStatus(TStatusCode.OK);
-            request.setTask_status(status);
+            request.setTask_status(new TStatus(TStatusCode.OK));
             job.finishRemoteSnapshotTask((RemoteSnapshotTask) task, request);
-        }
-
-        job.run();
-        Assert.assertEquals(ReplicationJobState.REPLICATING, job.getState());
-
-        for (AgentTask task : runningTasks.values()) {
-            TFinishTaskRequest request = new TFinishTaskRequest();
-            TStatus status = new TStatus(TStatusCode.INTERNAL_ERROR);
-            status.addToError_msgs("failed");
-            request.setTask_status(status);
-            job.finishReplicateSnapshotTask((ReplicateSnapshotTask) task, request);
         }
 
         job.run();
@@ -294,8 +280,7 @@ public class ReplicationJobTest {
         for (AgentTask task : runningTasks.values()) {
             TFinishTaskRequest request = new TFinishTaskRequest();
             request.setTask_status(new TStatus(TStatusCode.OK));
-            request.setSnapshot_path("test_snapshot_path");
-            request.setIncremental_snapshot(true);
+            request.setSnapshot_info(newTSnapshotInfo(new TBackend("test_host", 0, 0), "test_snapshot_path", true));
             job.finishRemoteSnapshotTask((RemoteSnapshotTask) task, request);
         }
 
@@ -354,7 +339,8 @@ public class ReplicationJobTest {
 
             tabletInfo.replica_replication_infos = new ArrayList<TReplicaReplicationInfo>();
             TReplicaReplicationInfo replicaInfo = new TReplicaReplicationInfo();
-            Backend backend = GlobalStateMgr.getCurrentSystemInfo().getBackends().iterator().next();
+            Backend backend = GlobalStateMgr.getCurrentState().getNodeMgr().getClusterInfo().getBackends().iterator()
+                    .next();
             replicaInfo.src_backend = new TBackend(backend.getHost(), backend.getBePort(), backend.getHttpPort());
             tabletInfo.replica_replication_infos.add(replicaInfo);
         }
@@ -364,5 +350,13 @@ public class ReplicationJobTest {
         } catch (Exception e) {
             Assert.assertNull(e);
         }
+    }
+
+    private static TSnapshotInfo newTSnapshotInfo(TBackend backend, String snapshotPath, boolean incrementalSnapshot) {
+        TSnapshotInfo tSnapshotInfo = new TSnapshotInfo();
+        tSnapshotInfo.setBackend(backend);
+        tSnapshotInfo.setSnapshot_path(snapshotPath);
+        tSnapshotInfo.setIncremental_snapshot(incrementalSnapshot);
+        return tSnapshotInfo;
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/replication/ReplicationMgrTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/replication/ReplicationMgrTest.java
@@ -36,6 +36,7 @@ import com.starrocks.thrift.TFinishTaskRequest;
 import com.starrocks.thrift.TIndexReplicationInfo;
 import com.starrocks.thrift.TPartitionReplicationInfo;
 import com.starrocks.thrift.TReplicaReplicationInfo;
+import com.starrocks.thrift.TSnapshotInfo;
 import com.starrocks.thrift.TStatus;
 import com.starrocks.thrift.TStatusCode;
 import com.starrocks.thrift.TTableReplicationRequest;
@@ -126,8 +127,7 @@ public class ReplicationMgrTest {
         for (AgentTask task : runningTasks.values()) {
             TFinishTaskRequest request = new TFinishTaskRequest();
             request.setTask_status(new TStatus(TStatusCode.OK));
-            request.setSnapshot_path("test_snapshot_path");
-            request.setIncremental_snapshot(true);
+            request.setSnapshot_info(newTSnapshotInfo(new TBackend("test_host", 0, 0), "test_snapshot_path", true));
             replicationMgr.finishRemoteSnapshotTask((RemoteSnapshotTask) task, request);
 
             Deencapsulation.invoke(new LeaderImpl(), "finishRemoteSnapshotTask",
@@ -202,8 +202,7 @@ public class ReplicationMgrTest {
         for (AgentTask task : runningTasks.values()) {
             TFinishTaskRequest request = new TFinishTaskRequest();
             request.setTask_status(new TStatus(TStatusCode.OK));
-            request.setSnapshot_path("test_snapshot_path");
-            request.setIncremental_snapshot(true);
+            request.setSnapshot_info(newTSnapshotInfo(new TBackend("test_host", 0, 0), "test_snapshot_path", true));
             replicationMgr.finishRemoteSnapshotTask((RemoteSnapshotTask) task, request);
         }
 
@@ -231,8 +230,7 @@ public class ReplicationMgrTest {
         for (AgentTask task : runningTasks.values()) {
             TFinishTaskRequest request = new TFinishTaskRequest();
             request.setTask_status(new TStatus(TStatusCode.OK));
-            request.setSnapshot_path("test_snapshot_path");
-            request.setIncremental_snapshot(true);
+            request.setSnapshot_info(newTSnapshotInfo(new TBackend("test_host", 0, 0), "test_snapshot_path", true));
             replicationMgr.finishRemoteSnapshotTask((RemoteSnapshotTask) task, request);
         }
 
@@ -265,20 +263,8 @@ public class ReplicationMgrTest {
         Map<AgentTask, AgentTask> runningTasks = Deencapsulation.getField(job, "runningTasks");
         for (AgentTask task : runningTasks.values()) {
             TFinishTaskRequest request = new TFinishTaskRequest();
-            TStatus status = new TStatus(TStatusCode.OK);
-            request.setTask_status(status);
+            request.setTask_status(new TStatus(TStatusCode.OK));
             replicationMgr.finishRemoteSnapshotTask((RemoteSnapshotTask) task, request);
-        }
-
-        replicationMgr.runAfterCatalogReady();
-        Assert.assertEquals(ReplicationJobState.REPLICATING, job.getState());
-
-        for (AgentTask task : runningTasks.values()) {
-            TFinishTaskRequest request = new TFinishTaskRequest();
-            TStatus status = new TStatus(TStatusCode.INTERNAL_ERROR);
-            status.addToError_msgs("failed");
-            request.setTask_status(status);
-            replicationMgr.finishReplicateSnapshotTask((ReplicateSnapshotTask) task, request);
         }
 
         replicationMgr.runAfterCatalogReady();
@@ -299,8 +285,7 @@ public class ReplicationMgrTest {
         for (AgentTask task : runningTasks.values()) {
             TFinishTaskRequest request = new TFinishTaskRequest();
             request.setTask_status(new TStatus(TStatusCode.OK));
-            request.setSnapshot_path("test_snapshot_path");
-            request.setIncremental_snapshot(true);
+            request.setSnapshot_info(newTSnapshotInfo(new TBackend("test_host", 0, 0), "test_snapshot_path", true));
             replicationMgr.finishRemoteSnapshotTask((RemoteSnapshotTask) task, request);
         }
 
@@ -359,7 +344,8 @@ public class ReplicationMgrTest {
 
             tabletInfo.replica_replication_infos = new ArrayList<TReplicaReplicationInfo>();
             TReplicaReplicationInfo replicaInfo = new TReplicaReplicationInfo();
-            Backend backend = GlobalStateMgr.getCurrentSystemInfo().getBackends().iterator().next();
+            Backend backend = GlobalStateMgr.getCurrentState().getNodeMgr().getClusterInfo().getBackends().iterator()
+                    .next();
             replicaInfo.src_backend = new TBackend(backend.getHost(), backend.getBePort(), backend.getHttpPort());
             tabletInfo.replica_replication_infos.add(replicaInfo);
         }
@@ -369,5 +355,13 @@ public class ReplicationMgrTest {
         } catch (Exception e) {
             Assert.assertNull(e);
         }
+    }
+
+    private static TSnapshotInfo newTSnapshotInfo(TBackend backend, String snapshotPath, boolean incrementalSnapshot) {
+        TSnapshotInfo tSnapshotInfo = new TSnapshotInfo();
+        tSnapshotInfo.setBackend(backend);
+        tSnapshotInfo.setSnapshot_path(snapshotPath);
+        tSnapshotInfo.setIncremental_snapshot(incrementalSnapshot);
+        return tSnapshotInfo;
     }
 }

--- a/gensrc/thrift/AgentService.thrift
+++ b/gensrc/thrift/AgentService.thrift
@@ -384,12 +384,6 @@ struct TRemoteSnapshotRequest {
      14: optional i32 timeout_sec
  }
 
- struct TRemoteSnapshotInfo {
-     1: optional Types.TBackend backend
-     2: optional string snapshot_path
-     3: optional bool incremental_snapshot
- }
-
  struct TReplicateSnapshotRequest {
      1: optional Types.TTransactionId transaction_id
      2: optional Types.TTableId table_id
@@ -403,7 +397,7 @@ struct TRemoteSnapshotRequest {
      10: optional TTabletType src_tablet_type
      11: optional Types.TSchemaHash src_schema_hash
      12: optional Types.TVersion src_visible_version
-     13: optional list<TRemoteSnapshotInfo> src_snapshot_infos
+     13: optional list<Types.TSnapshotInfo> src_snapshot_infos
  }
 
 enum TTabletMetaType {

--- a/gensrc/thrift/MasterService.thrift
+++ b/gensrc/thrift/MasterService.thrift
@@ -91,7 +91,7 @@ struct TFinishTaskRequest {
     16: optional i64 copy_time_ms
     17: optional list<TTabletVersionPair> tablet_versions;
     18: optional list<TTabletVersionPair> tablet_publish_versions;
-    19: optional bool incremental_snapshot
+    19: optional Types.TSnapshotInfo snapshot_info
 }
 
 struct TTablet {

--- a/gensrc/thrift/Types.thrift
+++ b/gensrc/thrift/Types.thrift
@@ -566,3 +566,9 @@ struct TSinkCommitInfo {
     100: optional bool is_overwrite;
     101: optional string staging_dir
 }
+
+struct TSnapshotInfo {
+    1: optional TBackend backend
+    2: optional string snapshot_path
+    3: optional bool incremental_snapshot
+}


### PR DESCRIPTION
## Why I'm doing:
There are 2 problems in cross cluster replication:
1. The replica number in source cluster must greater or equal than in target cluster.
2. If replica number is only one in target cluster, it will replicate data from only one replica in source cluster, which provides poor fault tolerance.

## What I'm doing:
1. Improve replication job scheduling to support heterogeneous replica number，replica can be any number in source and target cluster.
2. Replicas in target cluster can replicate data from multiple replicas in source cluster, if one fails, try another, which provides better fault tolerance.
Note this pr may break some compatibility in thrift rpc and persistent metadata, don't worry, the replication job will retry.

Backport of pr: https://github.com/StarRocks/starrocks/pull/42772

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [x] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 2.5

