### PR TITLE
[Enhancement] adjust configs for cloud star cache (backport #43320)

### DIFF
--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -898,9 +898,9 @@ CONF_Int32(starlet_cache_dir_allocate_policy, "0");
 // Only support in S3/HDFS currently.
 CONF_mInt32(starlet_fs_stream_buffer_size_bytes, "1048576");
 CONF_mBool(starlet_use_star_cache, "false");
-// TODO: support runtime change
-CONF_Int32(starlet_star_cache_mem_size_percent, "0");
-CONF_Int64(starlet_star_cache_mem_size_bytes, "134217728");
+CONF_Bool(starlet_star_cache_async_init, "true");
+CONF_mInt32(starlet_star_cache_mem_size_percent, "0");
+CONF_mInt64(starlet_star_cache_mem_size_bytes, "134217728");
 CONF_Int32(starlet_star_cache_disk_size_percent, "80");
 CONF_Int64(starlet_star_cache_disk_size_bytes, "0");
 CONF_Int32(starlet_star_cache_block_size_bytes, "1048576");

--- a/be/src/common/daemon.cpp
+++ b/be/src/common/daemon.cpp
@@ -42,6 +42,9 @@
 #include "common/config.h"
 #include "common/minidump.h"
 #include "exec/workgroup/work_group.h"
+#ifdef USE_STAROS
+#include "fslib/star_cache_handler.h"
+#endif
 #include "gutil/cpu.h"
 #include "jemalloc/jemalloc.h"
 #include "runtime/memory/mem_chunk_allocator.h"
@@ -183,6 +186,9 @@ void calculate_metrics(void* arg_this) {
                 auto datacache_metrics = block_cache->cache_metrics();
                 datacache_mem_bytes = datacache_metrics.mem_used_bytes + datacache_metrics.meta_used_bytes;
             }
+#ifdef USE_STAROS
+            datacache_mem_bytes += staros::starlet::fslib::star_cache_get_memory_usage();
+#endif
             datacache_mem_tracker->set(datacache_mem_bytes);
         }
 

--- a/be/src/http/action/update_config_action.cpp
+++ b/be/src/http/action/update_config_action.cpp
@@ -150,6 +150,8 @@ Status UpdateConfigAction::update_config(const std::string& name, const std::str
         });
 #ifdef USE_STAROS
         _config_callback.emplace("starlet_use_star_cache", [&]() { update_staros_starcache(); });
+        _config_callback.emplace("starlet_star_cache_mem_size_percent", [&]() { update_staros_starcache(); });
+        _config_callback.emplace("starlet_star_cache_mem_size_bytes", [&]() { update_staros_starcache(); });
 #endif
         _config_callback.emplace("transaction_apply_worker_count", [&]() {
             int max_thread_cnt = CpuInfo::num_cores();

--- a/be/src/service/staros_worker.cpp
+++ b/be/src/service/staros_worker.cpp
@@ -444,6 +444,7 @@ void init_staros_worker() {
     fslib::FLAGS_delete_files_max_key_in_batch = config::starlet_delete_files_max_key_in_batch;
 
     fslib::FLAGS_use_star_cache = config::starlet_use_star_cache;
+    fslib::FLAGS_star_cache_async_init = config::starlet_star_cache_async_init;
     fslib::FLAGS_star_cache_mem_size_percent = config::starlet_star_cache_mem_size_percent;
     fslib::FLAGS_star_cache_mem_size_bytes = config::starlet_star_cache_mem_size_bytes;
     fslib::FLAGS_star_cache_disk_size_percent = config::starlet_star_cache_disk_size_percent;
@@ -469,6 +470,16 @@ void update_staros_starcache() {
     if (fslib::FLAGS_use_star_cache != config::starlet_use_star_cache) {
         fslib::FLAGS_use_star_cache = config::starlet_use_star_cache;
         (void)fslib::star_cache_init(fslib::FLAGS_use_star_cache);
+    }
+
+    if (fslib::FLAGS_star_cache_mem_size_percent != config::starlet_star_cache_mem_size_percent) {
+        fslib::FLAGS_star_cache_mem_size_percent = config::starlet_star_cache_mem_size_percent;
+        (void)fslib::star_cache_update_memory_quota_percent(fslib::FLAGS_star_cache_mem_size_percent);
+    }
+
+    if (fslib::FLAGS_star_cache_mem_size_bytes != config::starlet_star_cache_mem_size_bytes) {
+        fslib::FLAGS_star_cache_mem_size_bytes = config::starlet_star_cache_mem_size_bytes;
+        (void)fslib::star_cache_update_memory_quota_bytes(fslib::FLAGS_star_cache_mem_size_bytes);
     }
 }
 


### PR DESCRIPTION
1. add starlet_star_cache_async_init
2. make starlet_star_cache_mem_size_percent and starlet_star_cache_mem_size_bytes dynamic
3. collect cloud star cache memory usage in daemon

## Why I'm doing:

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [x] This is a backport pr

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5

