### PR TITLE
[BugFix] Fix use after free when read the GIN

### DIFF
--- a/be/src/storage/inverted/clucene/clucene_inverted_reader.h
+++ b/be/src/storage/inverted/clucene/clucene_inverted_reader.h
@@ -22,6 +22,22 @@
 
 namespace starrocks {
 
+// _CL_LDECREF first to dec __cl_refcount, make sure
+// that dir->close can be delete itself if refCount
+// is zero.
+#define CLOSE_DIR(x)    \
+    if (x != nullptr) { \
+        _CL_LDECREF(x)  \
+        x->close();     \
+    }
+#define FINALLY_CLOSE_DIR(x)                                                                        \
+    try {                                                                                           \
+        CLOSE_DIR(x)                                                                                \
+    } catch (CLuceneError & e) {                                                                    \
+        LOG(WARNING) << "CLuceneError occured, error msg: " << e.what();                            \
+        return Status::InternalError(fmt::format("CLuceneError occured, error msg: {}", e.what())); \
+    }
+
 #define CLOSE_INPUT(x)  \
     if (x != nullptr) { \
         x->close();     \


### PR DESCRIPTION
## Why I'm doing:
This problem is cause by uncorrect usage of the Clucene lib. In Clucene lib Directory object has two different ref count, says, `refCount` and `__cl_refcount`. If we get a new Directory object from getDirectory, we will get a object with `refCount = 1` and `__cl_refcount = 2`, and this object will be cache in a global map to be reused if needed.
`refCount = 1` because there is only one external ref(by getDirectory) of this object, and it can be remove from the map if `refCount = 0`. `__cl_refcount = 2` because beside the external ref, the global map own the object as well, so `__cl_refcount = refCount + 1`. When `__cl_refcount = 0`, this object can be delete, it is background.

The use after free problem can be repeated as following:
1. When we call `FullTextCLuceneInvertedReader::query` to read index, we first get dir by getDirectory with `refCount = 1` and `__cl_refcount = 2`. When we construct indexsearch, dir become `refCount = 1` and `__cl_refcount = 3`. When we `_CLDECDELETE(dir)`, we decrement `__cl_refcount` into 2. Becase we do not call `dir->close()`, make refCount is still 1 and when `FullTextCLuceneInvertedReader::query` is finished, dir can not be destory and removed from map with `refCount = 1` and `__cl_refcount = 1`.
2. When we call `FullTextCLuceneInvertedReader::read_null` we get a dir from cache with `refCount = 2` and `__cl_refcount = 2`. When this function is finished, we call `dir->close()` decre `refCount` into 1, but not zero, so the cache can not be removed from the map. And then we forcely delete the dir with `refCount = 1` and `__cl_refcount = 2`. Make the element in map become dangling pointer.
3. If we get the dir again, we search the map and get the use after free problem.

## What I'm doing:
1. Use CLOSE_DIR to release the dir. First decre `__cl_refcount` and then call `dir->close()`. Make sure that the relation: `__cl_refcount = refCount + 1` is satisfied. And make sure that when refCount = 0 and `__cl_refcount = 1`, object can be deleted
2. In `FullTextCLuceneInvertedReader::query`, make sure the defer should be destory after IndexSearch.

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
