### PR TITLE
[Enhancement] Add pipe_failed_task_threshold config

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/common/Config.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/Config.java
@@ -2876,4 +2876,10 @@ public class Config extends ConfigBase {
 
     @ConfField(mutable = true)
     public static int adaptive_choose_instances_threshold = 32;
+
+    // When the number of failed task of a pipe job exceeds the configured value,
+    // the task is set to the ERROR state and will no longer be scheduled.
+    // When the configured value is set to 0, the task ignores the number of failed tasks and retries continuously.
+    @ConfField(mutable = true)
+    public static int pipe_failed_task_threshold = 5;
 }

--- a/fe/fe-core/src/main/java/com/starrocks/load/pipe/FilePipeSource.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/pipe/FilePipeSource.java
@@ -66,6 +66,9 @@ public class FilePipeSource implements GsonPostProcessable {
     @SerializedName(value = "eos")
     private boolean eos = false;
 
+    @SerializedName(value = "failed_task_threshold")
+    private int failedTaskThreshold = -1;
+
     private FileListRepo fileListRepo;
 
     public FilePipeSource(String path, String format, Map<String, String> sourceProperties) {
@@ -202,6 +205,10 @@ public class FilePipeSource implements GsonPostProcessable {
         this.pipeId = id;
     }
 
+    public void setFailedTaskThreshold(int threshold) {
+        this.failedTaskThreshold = threshold;
+    }
+
     public String getPath() {
         return path;
     }
@@ -253,5 +260,9 @@ public class FilePipeSource implements GsonPostProcessable {
     @Override
     public String toString() {
         return "FILE_SOURCE(path=" + path + ")";
+    }
+
+    public int getFailedTaskThreshold() {
+        return failedTaskThreshold;
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/load/pipe/Pipe.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/pipe/Pipe.java
@@ -22,6 +22,7 @@ import com.google.gson.annotations.SerializedName;
 import com.starrocks.analysis.TableName;
 import com.starrocks.catalog.Database;
 import com.starrocks.common.CloseableLock;
+import com.starrocks.common.Config;
 import com.starrocks.common.DdlException;
 import com.starrocks.common.ErrorCode;
 import com.starrocks.common.ErrorReport;
@@ -79,7 +80,7 @@ public class Pipe implements GsonPostProcessable {
     public static final int DEFAULT_POLL_INTERVAL = 10;
     public static final long DEFAULT_BATCH_SIZE = 1 << 30;
     public static final long DEFAULT_BATCH_FILES = 256;
-    public static final int FAILED_TASK_THRESHOLD = 5;
+    public static final int DEFAULT_FAILED_TASK_THRESHOLD = 5;
 
     private static final ImmutableMap<String, String> DEFAULT_TASK_EXECUTION_VARIABLES =
             ImmutableMap.<String, String>builder()
@@ -167,6 +168,10 @@ public class Pipe implements GsonPostProcessable {
                 case PropertyAnalyzer.PROPERTIES_WAREHOUSE: {
                     // put the warehouse into variables, and it would be processed by TaskRun
                     this.taskExecutionVariables.put(key, value);
+                    break;
+                }
+                case PipeAnalyzer.PROPERTY_FAILED_TASKS_THRESHOLD: {
+                    pipeSource.setFailedTaskThreshold(Integer.parseInt(value));
                     break;
                 }
                 default: {
@@ -320,7 +325,7 @@ public class Pipe implements GsonPostProcessable {
             String sqlTask = FilePipeSource.buildInsertSql(this, piece, uniqueName);
             PipeTaskDesc taskDesc = new PipeTaskDesc(taskId, uniqueName, dbName, sqlTask, piece);
             taskDesc.getVariables().putAll(taskExecutionVariables);
-            taskDesc.setErrorLimit(FAILED_TASK_THRESHOLD);
+            taskDesc.setErrorLimit(Config.pipe_failed_task_threshold);
 
             // Persist the loading state
             fileSource.getFileListRepo()
@@ -361,7 +366,11 @@ public class Pipe implements GsonPostProcessable {
                 }
                 if (task.isError()) {
                     failedTaskExecutionCount++;
-                    if (failedTaskExecutionCount > FAILED_TASK_THRESHOLD) {
+
+                    int threshold = pipeSource.getFailedTaskThreshold() >= 0
+                            ? pipeSource.getFailedTaskThreshold() : Config.pipe_failed_task_threshold;
+                    // threshold = 0, ignore failedTaskExecutionCount
+                    if (threshold > 0 && failedTaskExecutionCount > threshold) {
                         changeState(State.ERROR, false);
                     }
                 }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/PipeAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/PipeAnalyzer.java
@@ -57,6 +57,8 @@ public class PipeAnalyzer {
     public static final String PROPERTY_BATCH_SIZE = "batch_size";
     public static final String PROPERTY_BATCH_FILES = "batch_files";
 
+    public static final String PROPERTY_FAILED_TASKS_THRESHOLD = "failed_tasks_threshold";
+
     public static final ImmutableSet<String> SUPPORTED_PROPERTIES =
             new ImmutableSortedSet.Builder<String>(String.CASE_INSENSITIVE_ORDER)
                     .add(PROPERTY_AUTO_INGEST)
@@ -64,6 +66,7 @@ public class PipeAnalyzer {
                     .add(PROPERTY_BATCH_SIZE)
                     .add(PROPERTY_BATCH_FILES)
                     .add(PropertyAnalyzer.PROPERTIES_WAREHOUSE)
+                    .add(PROPERTY_FAILED_TASKS_THRESHOLD)
                     .build();
 
     public static void analyzePipeName(PipeName pipeName, String defaultDbName) {
@@ -144,6 +147,19 @@ public class PipeAnalyzer {
                 }
                 case PropertyAnalyzer.PROPERTIES_WAREHOUSE: {
                     analyzeWarehouseProperty(valueStr);
+                    break;
+                }
+                case PROPERTY_FAILED_TASKS_THRESHOLD: {
+                    // Default value is -1
+                    int value = -2;
+                    try {
+                        value = Integer.parseInt(valueStr);
+                    } catch (Exception ignored) {
+                    }
+                    if (value < -1) {
+                        ErrorReport.reportSemanticException(ErrorCode.ERR_INVALID_PARAMETER,
+                                PROPERTY_FAILED_TASKS_THRESHOLD + " should be no less than -1");
+                    }
                     break;
                 }
                 default: {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/pipe/ShowPipeStmt.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/pipe/ShowPipeStmt.java
@@ -46,6 +46,7 @@ public class ShowPipeStmt extends ShowStmt {
                     .addColumn(new Column("LOAD_STATUS", ScalarType.createVarchar(512)))
                     .addColumn(new Column("LAST_ERROR", ScalarType.createVarchar(1024)))
                     .addColumn(new Column("CREATED_TIME", ScalarType.DATETIME))
+                    .addColumn(new Column("PROPERTIES", ScalarType.createVarcharType(1024)))
                     .build();
 
     private String dbName;
@@ -78,6 +79,7 @@ public class ShowPipeStmt extends ShowStmt {
         row.add(pipe.getLoadStatus().toJson());
         row.add(pipe.getLastErrorInfo().toJson());
         row.add(DateUtils.formatTimestampInSeconds(pipe.getCreatedTime()));
+        row.add(pipe.getPropertiesJson());
     }
 
     public static int findSlotIndex(String name) {

--- a/fe/fe-core/src/test/java/com/starrocks/load/pipe/PipeManagerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/load/pipe/PipeManagerTest.java
@@ -952,6 +952,8 @@ public class PipeManagerTest {
                 " as insert into tbl1 select * from files('path'='fake://pipe', 'format'='parquet')");
         createPipe("create pipe p_auto_ingest properties('auto_ingest'='false') " +
                 " as insert into tbl1 select * from files('path'='fake://pipe', 'format'='parquet')");
+        createPipe("create pipe p_failed_tasks_threshold properties('failed_tasks_threshold'='100') " +
+                " as insert into tbl1 select * from files('path'='fake://pipe', 'format'='parquet')");
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/load/pipe/PipeManagerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/load/pipe/PipeManagerTest.java
@@ -19,6 +19,7 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
 import com.starrocks.analysis.BrokerDesc;
 import com.starrocks.common.AnalysisException;
+import com.starrocks.common.Config;
 import com.starrocks.common.LabelAlreadyUsedException;
 import com.starrocks.common.UserException;
 import com.starrocks.common.util.PropertyAnalyzer;
@@ -491,7 +492,7 @@ public class PipeManagerTest {
         Thread.sleep(1000);
         Assert.assertEquals(1, p3.getRunningTasks().size());
         // retry several times, until failed
-        for (int i = 0; i < Pipe.FAILED_TASK_THRESHOLD; i++) {
+        for (int i = 0; i < Config.pipe_failed_task_threshold; i++) {
             p3.schedule();
             Assert.assertEquals(Pipe.State.RUNNING, p3.getState());
             Assert.assertEquals(1, p3.getRunningTasks().size());
@@ -504,7 +505,7 @@ public class PipeManagerTest {
                     p3.getRunningTasks().stream().allMatch(PipeTaskDesc::isRunnable));
         }
         p3.schedule();
-        Assert.assertEquals(Pipe.FAILED_TASK_THRESHOLD + 1, p3.getFailedTaskExecutionCount());
+        Assert.assertEquals(Config.pipe_failed_task_threshold + 1, p3.getFailedTaskExecutionCount());
         Assert.assertEquals(Pipe.State.ERROR, p3.getState());
 
         // retry all
@@ -519,7 +520,7 @@ public class PipeManagerTest {
 
     private void pipeRetryFailedTask(Pipe p3, boolean retryAll) throws Exception {
         // retry several times, until failed
-        for (int i = 0; i < Pipe.FAILED_TASK_THRESHOLD; i++) {
+        for (int i = 0; i < Config.pipe_failed_task_threshold; i++) {
             // submit task, turn into running
             p3.schedule();
             Assert.assertEquals(String.format("iteration %d", i), Pipe.State.RUNNING, p3.getState());
@@ -540,7 +541,7 @@ public class PipeManagerTest {
         }
         p3.schedule();
         p3.schedule();
-        Assert.assertEquals(Pipe.FAILED_TASK_THRESHOLD + 1, p3.getFailedTaskExecutionCount());
+        Assert.assertEquals(Config.pipe_failed_task_threshold + 1, p3.getFailedTaskExecutionCount());
         Assert.assertEquals(Pipe.State.ERROR, p3.getState());
 
         // retry all


### PR DESCRIPTION
## Why I'm doing:
Now, when the number of failed tasks of a pipe job exceeds 5, the job would be set as ERROR and be paused.
## What I'm doing:
This PR including following changes:
1. adds a FE config `pipe_failed_task_threshold`.  When the number of failed task of a pipe job exceeds the configured value, the task is set to the ERROR state and will no longer be scheduled. When the configured value is set to 0, the task ignores the number of failed tasks and retries continuously.
2. adds a property `failed_task_threshold` to create pipe statement, which would override the value of `pipe_failed_task_threshold` in config.
```
create pipe pipe0 properties("failed_tasks_threshold"="10") as insert into t1 select * from files("format"="csv","csv.column_separator"=",", "path"="file:///home/ricky/tmp/csv/*");
```
4. add a column `PROPERTIES` to the result of `show pipes`.


```
MySQL [db0]> show pipes\G;
*************************** 1. row ***************************
DATABASE_NAME: db0
      PIPE_ID: 33023
    PIPE_NAME: pipe0
        STATE: RUNNING
   TABLE_NAME: db0.t1
  LOAD_STATUS: {"loadedFiles":0,"loadedBytes":0,"loadingFiles":0}
   LAST_ERROR: NULL
 CREATED_TIME: 2024-04-01 14:04:34
   PROPERTIES: {"failed_tasks_threshold":"10"}
2 rows in set (0.003 sec)

```
Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [x] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
