### PR TITLE
[BugFix] Fix NPE problem when calculate the Index hashCode

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/Index.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/Index.java
@@ -171,7 +171,8 @@ public class Index implements Writable {
     @Override
     public int hashCode() {
         return 31 * (Long.hashCode(indexId) + indexName.hashCode()
-                + columns.hashCode() + indexType.hashCode() + properties.hashCode());
+                + columns.hashCode() + indexType.hashCode() +
+                ((properties != null) ? properties.hashCode() : 0));
     }
 
     @Override

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/GINIndexTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/GINIndexTest.java
@@ -142,6 +142,8 @@ public class GINIndexTest extends PlanTestBase {
             put(SearchParamsKey.RERANK.name().toLowerCase(Locale.ROOT), "false");
         }});
 
+        index.hashCode();
+
         TOlapTableIndex olapIndex = index.toThrift();
         Assertions.assertEquals(indexId, olapIndex.getIndex_id());
         Assertions.assertEquals(indexName, olapIndex.getIndex_name());


### PR DESCRIPTION
## Why I'm doing:
In pr(#34824), we introduce Index meta for GIN index. The properties Member has been introduced and it maybe a null and get NPE problem when we calculate the hashCode() for Index

## What I'm doing:
Fix the hashCode when properties is null

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
