### PR TITLE
[BugFix] Unpack const column when in local exchange source operator

### DIFF
--- a/be/src/column/chunk.cpp
+++ b/be/src/column/chunk.cpp
@@ -446,4 +446,15 @@ bool Chunk::has_const_column() const {
     return false;
 }
 
+void Chunk::unpack_and_duplicate_const_columns() {
+    size_t num_rows = this->num_rows();
+    for (size_t i = 0; i < _columns.size(); i++) {
+        auto column = _columns[i];
+        if (column->is_constant()) {
+            auto unpack_column = ColumnHelper::unpack_and_duplicate_const_column(num_rows, column);
+            update_column_by_index(std::move(unpack_column), i);
+        }
+    }
+}
+
 } // namespace starrocks

--- a/be/src/column/chunk.h
+++ b/be/src/column/chunk.h
@@ -246,6 +246,9 @@ public:
         }
     }
 
+    // Unpack and duplicate const columns in the chunk.
+    void unpack_and_duplicate_const_columns();
+
 #ifndef NDEBUG
     // check whether the internal state is consistent, abort the program if check failed.
     void check_or_die();

--- a/be/src/exec/pipeline/aggregate/repeat/repeat_operator.h
+++ b/be/src/exec/pipeline/aggregate/repeat/repeat_operator.h
@@ -63,6 +63,24 @@ private:
         return ConstColumn::create(column, num_rows);
     }
 
+    /**
+     * @brief Generate const null column with the input column's type.
+     * @param cur_column : input associated column.
+     * @param num_rows : const column's rows number.
+     * @return ColumnPtr : a constant column with the input column's type.
+     */
+    static ColumnPtr generate_null_column(ColumnPtr& cur_column, int64_t num_rows) {
+        auto clone_column = cur_column->clone_empty();
+        if (clone_column->is_nullable()) {
+            clone_column->append_nulls(1);
+            return ConstColumn::create(ColumnPtr(clone_column.release()), num_rows);
+        } else {
+            auto nullable_column = NullableColumn::create(ColumnPtr(clone_column.release()), NullColumn::create());
+            nullable_column->append_nulls(1);
+            return ConstColumn::create(nullable_column, num_rows);
+        }
+    }
+
     void extend_and_update_columns(ChunkPtr* curr_chunk);
 
     /*

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/RewriteGroupingSetsByCTERule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/RewriteGroupingSetsByCTERule.java
@@ -15,6 +15,7 @@
 
 package com.starrocks.sql.optimizer.rule.transformation;
 
+import com.google.common.base.Preconditions;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.starrocks.sql.optimizer.ExpressionContext;
@@ -86,7 +87,18 @@ public class RewriteGroupingSetsByCTERule extends TransformationRule {
         List<OptExpression> children = new ArrayList<>();
         List<List<ColumnRefOperator>> childOutputColumns = new ArrayList<>();
         LogicalRepeatOperator repeatOperator = (LogicalRepeatOperator) repeatOpt.getOp();
-        for (int i = 0; i < repeatOperator.getRepeatColumnRef().size(); i++) {
+        // outputGrouping:  GROUPING_ID / GROUPING
+        // repeatColumnRef:  [[], [a]]
+        // groupingIds/groupingList: [[1, 0], [1, 0]]
+        // groupingIds' order is same as outputGrouping's order
+        List<ColumnRefOperator> outputGrouping = repeatOperator.getOutputGrouping();
+        List<List<Long>> groupingIds = repeatOperator.getGroupingIds();
+        List<List<ColumnRefOperator>> repeatColumnRefs = repeatOperator.getRepeatColumnRef();
+        Preconditions.checkState(outputGrouping.size() == groupingIds.size());
+        for (int i = 0; i < groupingIds.size(); i++) {
+            Preconditions.checkState(groupingIds.get(i).size() == repeatColumnRefs.size());
+        }
+        for (int i = 0; i < repeatColumnRefs.size(); i++) {
             // create cte consume, cte output columns
             // output column -> old input column.
             List<ColumnRefOperator> groupingSetKeys = repeatOperator.getRepeatColumnRef().get(i);
@@ -105,14 +117,25 @@ public class RewriteGroupingSetsByCTERule extends TransformationRule {
             // rewrite agg functions by cte consume output
             Map<ColumnRefOperator, CallOperator> newAggregations = new HashMap<>();
             for (Map.Entry<ColumnRefOperator, CallOperator> kv : aggregate.getAggregations().entrySet()) {
+                ColumnRefOperator originAggColRef = kv.getKey();
                 ColumnRefOperator aggColumnRef =
-                        columnRefFactory.create(kv.getKey(), kv.getKey().getType(), kv.getKey().isNullable());
+                        columnRefFactory.create(originAggColRef, originAggColRef.getType(), originAggColRef.isNullable());
                 newAggregations.put(aggColumnRef, (CallOperator) rewriter.rewrite(kv.getValue()));
             }
 
+            // new group by keys
             List<ColumnRefOperator> rewriteGroupingKeys = groupingSetKeys.stream().
                     map(column -> (ColumnRefOperator) rewriter.rewrite(column)).collect(
                             Collectors.toList());
+            // add grouping id and grouping
+            Map<ColumnRefOperator, ConstantOperator> groupingIdMap = new HashMap<>();
+            for (int idx = 0; idx < outputGrouping.size(); idx++) {
+                List<Long> curGroupingIds = groupingIds.get(idx);
+                ColumnRefOperator groupingIdColumn = outputGrouping.get(idx);
+                long groupingId = curGroupingIds.get(i);
+                groupingIdMap.put(groupingIdColumn, ConstantOperator.createBigint(groupingId));
+            }
+
             LogicalAggregationOperator newChildAgg = new LogicalAggregationOperator(AggType.GLOBAL, rewriteGroupingKeys,
                     newAggregations);
 
@@ -125,6 +148,12 @@ public class RewriteGroupingSetsByCTERule extends TransformationRule {
                     ScalarOperator rewriteGroupKey = rewriter.rewrite(groupKey);
                     newProjectMap.put((ColumnRefOperator) rewriteGroupKey, rewriteGroupKey);
                     projectionOutputColumns.add((ColumnRefOperator) rewriteGroupKey);
+                } else if (groupingIdMap.containsKey(groupKey)) {
+                    // output null if not in the grouping keys.
+                    ColumnRefOperator projectOutputColumn =
+                            columnRefFactory.create(groupKey, groupKey.getType(), groupKey.isNullable());
+                    newProjectMap.put(projectOutputColumn, groupingIdMap.get(groupKey));
+                    projectionOutputColumns.add(projectOutputColumn);
                 } else {
                     // output null if not in the grouping keys.
                     ColumnRefOperator projectOutputColumn =

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/RewriteGroupingSetsByCTERule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/RewriteGroupingSetsByCTERule.java
@@ -189,7 +189,9 @@ public class RewriteGroupingSetsByCTERule extends TransformationRule {
         context.getCteContext().addForceCTE(cteId);
 
         LogicalCTEAnchorOperator cteAnchor = new LogicalCTEAnchorOperator(cteId);
-        return Lists.newArrayList(OptExpression.create(cteAnchor, cteProduce, rightTree));
+        OptExpression result = OptExpression.create(cteAnchor, cteProduce, rightTree);
+
+        return Lists.newArrayList(result);
     }
 
     private LogicalCTEConsumeOperator buildCteConsume(OptExpression cteProduce, ColumnRefSet requiredColumns,

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/RewriteMultiDistinctRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/RewriteMultiDistinctRule.java
@@ -132,6 +132,10 @@ public class RewriteMultiDistinctRule extends TransformationRule {
         Utils.calculateStatistics(input, context);
 
         Statistics inputStatistics = input.inputAt(0).getStatistics();
+        // inputStatistics may be null if it's a cte consumer operator
+        if (inputStatistics == null) {
+            return false;
+        }
         List<ColumnRefOperator> neededCols = Lists.newArrayList(aggOp.getGroupingKeys());
         distinctAggOperatorList.stream().forEach(e -> neededCols.addAll(e.getColumnRefs()));
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/StatisticsCalculator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/StatisticsCalculator.java
@@ -1558,5 +1558,4 @@ public class StatisticsCalculator extends OperatorVisitor<Void, ExpressionContex
         }
         return false;
     }
-
 }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/transformer/QueryTransformer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/transformer/QueryTransformer.java
@@ -63,13 +63,15 @@ import java.util.stream.Collectors;
 
 import static com.starrocks.sql.optimizer.transformer.SqlToScalarOperatorTranslator.findOrCreateColumnRefForExpr;
 
-class QueryTransformer {
+public class QueryTransformer {
     private final ColumnRefFactory columnRefFactory;
     private final ConnectContext session;
     private final List<ColumnRefOperator> correlation = new ArrayList<>();
     private final CTETransformerContext cteContext;
     private final boolean inlineView;
     private final Map<Operator, ParseNode> optToAstMap;
+    public static final String GROUPING_ID = "GROUPING_ID";
+    public static final String GROUPING = "GROUPING";
 
     public QueryTransformer(ColumnRefFactory columnRefFactory, ConnectContext session,
                             CTETransformerContext cteContext, boolean inlineView,
@@ -485,7 +487,7 @@ class QueryTransformer {
             }
 
             //Build grouping_id(all grouping columns)
-            ColumnRefOperator grouping = columnRefFactory.create("GROUPING_ID", Type.BIGINT, false);
+            ColumnRefOperator grouping = columnRefFactory.create(GROUPING_ID, Type.BIGINT, false);
             List<Long> groupingID = new ArrayList<>();
             for (BitSet bitSet : groupingIdsBitSets) {
                 long gid = Utils.convertBitSetToLong(bitSet, groupByColumnRefs.size());
@@ -506,7 +508,7 @@ class QueryTransformer {
 
             //Build grouping function in select item
             for (Expr groupingFunction : groupingFunctionCallExprs) {
-                grouping = columnRefFactory.create("GROUPING", Type.BIGINT, false);
+                grouping = columnRefFactory.create(GROUPING, Type.BIGINT, false);
 
                 ArrayList<BitSet> tempGroupingIdsBitSets = new ArrayList<>();
                 for (int i = 0; i < repeatColumnRefList.size(); ++i) {

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/GroupingSetsTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/GroupingSetsTest.java
@@ -1,0 +1,219 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.package com.starrocks.sql.plan;
+package com.starrocks.sql.plan;
+
+import com.starrocks.catalog.OlapTable;
+import com.starrocks.common.Config;
+import com.starrocks.common.FeConstants;
+import com.starrocks.server.GlobalStateMgr;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+public class GroupingSetsTest extends PlanTestBase {
+    private static final int NUM_TABLE0_ROWS = 10000;
+
+    @BeforeClass
+    public static void beforeClass() throws Exception {
+        PlanTestBase.beforeClass();
+        Config.alter_scheduler_interval_millisecond = 1;
+        GlobalStateMgr globalStateMgr = connectContext.getGlobalStateMgr();
+        OlapTable t0 = (OlapTable) globalStateMgr.getDb("test").getTable("t0");
+        setTableStatistics(t0, NUM_TABLE0_ROWS);
+        FeConstants.runningUnitTest = true;
+    }
+
+    @Before
+    public void before() {
+        connectContext.getSessionVariable().setNewPlanerAggStage(0);
+    }
+
+    @Test
+    public void testRepeatNodeWithUnionAllRewrite1() throws Exception {
+        connectContext.getSessionVariable().setEnableRewriteGroupingSetsToUnionAll(true);
+        String sql = "select v1, v2, SUM(v3) from t0 group by rollup(v1, v2)";
+        String plan = getFragmentPlan(sql).replaceAll(" ", "");
+        Assert.assertTrue(plan.contains("1:UNION\n" +
+                "|\n" +
+                "|----15:EXCHANGE\n" +
+                "|\n" +
+                "|----21:EXCHANGE\n" +
+                "|\n" +
+                "8:EXCHANGE\n"));
+
+        sql = "select v1, SUM(v3) from t0 group by rollup(v1)";
+        plan = getFragmentPlan(sql).replaceAll(" ", "");
+        Assert.assertTrue(plan.contains("1:UNION\n" +
+                "|\n" +
+                "|----14:EXCHANGE\n" +
+                "|\n" +
+                "8:EXCHANGE\n"));
+
+        sql = "select SUM(v3) from t0 group by grouping sets(())";
+        plan = getFragmentPlan(sql);
+        Assert.assertTrue(plan.contains("  3:EXCHANGE\n" +
+                "\n" +
+                "PLAN FRAGMENT 2\n" +
+                " OUTPUT EXPRS:\n" +
+                "  PARTITION: RANDOM\n" +
+                "\n" +
+                "  STREAM DATA SINK\n" +
+                "    EXCHANGE ID: 03\n" +
+                "    HASH_PARTITIONED: 5: GROUPING_ID\n" +
+                "\n" +
+                "  2:AGGREGATE (update serialize)\n" +
+                "  |  STREAMING\n" +
+                "  |  output: sum(3: v3)\n" +
+                "  |  group by: 5: GROUPING_ID\n" +
+                "  |  \n" +
+                "  1:REPEAT_NODE"));
+        connectContext.getSessionVariable().setEnableRewriteGroupingSetsToUnionAll(false);
+    }
+
+    @Test
+    public void testGroupingSetsToUnionRewrite1() throws Exception {
+        connectContext.getSessionVariable().setEnableRewriteGroupingSetsToUnionAll(true);
+        String sql = "select v1, grouping(v1) as b, sum(v3) " +
+                "   from t0 group by grouping sets((), (v1)) order by v1, b";
+        String plan = getFragmentPlan(sql);
+        System.out.println(plan);
+        Assert.assertTrue(plan.contains("14:Project\n" +
+                "  |  <slot 12> : 12: v1\n" +
+                "  |  <slot 14> : 14: sum\n" +
+                "  |  <slot 16> : 0\n" +
+                "  |  \n" +
+                "  13:AGGREGATE (merge finalize)\n" +
+                "  |  output: sum(14: sum)\n" +
+                "  |  group by: 12: v1"));
+        Assert.assertTrue(plan.contains("  7:Project\n" +
+                "  |  <slot 8> : 8: sum\n" +
+                "  |  <slot 9> : NULL\n" +
+                "  |  <slot 11> : 1\n" +
+                "  |  \n" +
+                "  6:AGGREGATE (merge finalize)\n" +
+                "  |  output: sum(8: sum)\n" +
+                "  |  group by: "));
+        connectContext.getSessionVariable().setEnableRewriteGroupingSetsToUnionAll(false);
+    }
+
+    @Test
+    public void testGroupingSetsToUnionRewrite2() throws Exception {
+        connectContext.getSessionVariable().setEnableRewriteGroupingSetsToUnionAll(true);
+        String sql = "select v1, v2, grouping_id(v1, v2) as b, sum(v3) " +
+                "from t0 group by grouping sets((), (v1, v2)) order by v1, b";
+        String plan = getFragmentPlan(sql);
+        System.out.println(plan);
+        Assert.assertTrue(plan.contains("14:Project\n" +
+                "  |  <slot 13> : 13: v1\n" +
+                "  |  <slot 14> : 14: v2\n" +
+                "  |  <slot 16> : 16: sum\n" +
+                "  |  <slot 18> : 0\n" +
+                "  |  \n" +
+                "  13:AGGREGATE (merge finalize)\n" +
+                "  |  output: sum(16: sum)\n" +
+                "  |  group by: 13: v1, 14: v2"));
+        Assert.assertTrue(plan.contains("14:Project\n" +
+                "  |  <slot 13> : 13: v1\n" +
+                "  |  <slot 14> : 14: v2\n" +
+                "  |  <slot 16> : 16: sum\n" +
+                "  |  <slot 18> : 0\n" +
+                "  |  \n" +
+                "  13:AGGREGATE (merge finalize)\n" +
+                "  |  output: sum(16: sum)\n" +
+                "  |  group by: 13: v1, 14: v2"));
+        Assert.assertTrue(plan.contains("7:Project\n" +
+                "  |  <slot 8> : 8: sum\n" +
+                "  |  <slot 9> : NULL\n" +
+                "  |  <slot 10> : NULL\n" +
+                "  |  <slot 12> : 3\n" +
+                "  |  \n" +
+                "  6:AGGREGATE (merge finalize)\n" +
+                "  |  output: sum(8: sum)\n" +
+                "  |  group by: "));
+        connectContext.getSessionVariable().setEnableRewriteGroupingSetsToUnionAll(false);
+    }
+
+    @Test
+    public void testGroupingSetsToUnionRewrite3() throws Exception {
+        connectContext.getSessionVariable().setEnableRewriteGroupingSetsToUnionAll(true);
+        String sql = "select v1, v2, sum(v3) " +
+                "from t0 group by grouping sets((), (v1, v2)) order by v1, v2";
+        String plan = getFragmentPlan(sql);
+        System.out.println(plan);
+        Assert.assertTrue(plan.contains("  7:Project\n" +
+                "  |  <slot 7> : 7: sum\n" +
+                "  |  <slot 8> : NULL\n" +
+                "  |  <slot 9> : NULL\n" +
+                "  |  \n" +
+                "  6:AGGREGATE (merge finalize)\n" +
+                "  |  output: sum(7: sum)\n" +
+                "  |  group by: \n" +
+                "  |  \n" +
+                "  5:EXCHANGE"));
+        connectContext.getSessionVariable().setEnableRewriteGroupingSetsToUnionAll(false);
+    }
+    @Test
+    public void testRollupToUnionRewrite1() throws Exception {
+        connectContext.getSessionVariable().setEnableRewriteGroupingSetsToUnionAll(true);
+        String sql = "select v1, grouping(v1) as b, sum(v3) " +
+                "   from t0 group by rollup(v1, v2) order by v1, b";
+        String plan = getFragmentPlan(sql);
+        System.out.println(plan);
+        Assert.assertTrue(plan.contains("21:Project\n" +
+                "  |  <slot 19> : 19: v1\n" +
+                "  |  <slot 22> : 22: sum\n" +
+                "  |  <slot 24> : 0"));
+        Assert.assertTrue(plan.contains("14:Project\n" +
+                "  |  <slot 13> : 13: v1\n" +
+                "  |  <slot 15> : 15: sum\n" +
+                "  |  <slot 18> : 0"));
+        Assert.assertTrue(plan.contains("  7:Project\n" +
+                        "  |  <slot 8> : 8: sum\n" +
+                        "  |  <slot 9> : NULL\n" +
+                        "  |  <slot 12> : 1"));
+        connectContext.getSessionVariable().setEnableRewriteGroupingSetsToUnionAll(false);
+    }
+
+    @Test
+    public void testCubeUnionRewrite1() throws Exception {
+        connectContext.getSessionVariable().setEnableRewriteGroupingSetsToUnionAll(true);
+        String sql = "select v1, grouping_id(v1) as b, count(1) " +
+                "   from t0 group by rollup(v1, v2, v3) order by v1, b";
+        String plan = getFragmentPlan(sql);
+        System.out.println(plan);
+        Assert.assertTrue(plan.contains("  1:UNION\n" +
+                "  |  \n" +
+                "  |----15:EXCHANGE\n" +
+                "  |    \n" +
+                "  |----22:EXCHANGE\n" +
+                "  |    \n" +
+                "  |----29:EXCHANGE\n" +
+                "  |    \n" +
+                "  8:EXCHANGE"));
+        Assert.assertTrue(plan.contains("  28:Project\n" +
+                "  |  <slot 26> : 26: v1\n" +
+                "  |  <slot 29> : 29: count\n" +
+                "  |  <slot 31> : 0\n"));
+        Assert.assertTrue(plan.contains("  21:Project\n" +
+                "  |  <slot 20> : 20: v1\n" +
+                "  |  <slot 22> : 22: count\n" +
+                "  |  <slot 25> : 0\n"));
+        Assert.assertTrue(plan.contains("  14:Project\n" +
+                "  |  <slot 14> : 14: v1\n" +
+                "  |  <slot 15> : 15: count\n" +
+                "  |  <slot 19> : 0\n"));
+        connectContext.getSessionVariable().setEnableRewriteGroupingSetsToUnionAll(false);
+    }
+}

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/PlanFragmentWithCostTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/PlanFragmentWithCostTest.java
@@ -1389,48 +1389,6 @@ public class PlanFragmentWithCostTest extends PlanTestBase {
     }
 
     @Test
-    public void testRepeatNodeWithUnionAllRewrite() throws Exception {
-        connectContext.getSessionVariable().setEnableRewriteGroupingSetsToUnionAll(true);
-        String sql = "select v1, v2, SUM(v3) from t0 group by rollup(v1, v2)";
-        String plan = getFragmentPlan(sql).replaceAll(" ", "");
-        assertContains(plan, "1:UNION\n" +
-                "|\n" +
-                "|----15:EXCHANGE\n" +
-                "|\n" +
-                "|----21:EXCHANGE\n" +
-                "|\n" +
-                "8:EXCHANGE\n");
-
-        sql = "select v1, SUM(v3) from t0 group by rollup(v1)";
-        plan = getFragmentPlan(sql).replaceAll(" ", "");
-        assertContains(plan, "1:UNION\n" +
-                "|\n" +
-                "|----14:EXCHANGE\n" +
-                "|\n" +
-                "8:EXCHANGE\n");
-
-        sql = "select SUM(v3) from t0 group by grouping sets(())";
-        plan = getFragmentPlan(sql);
-        assertContains(plan, "  3:EXCHANGE\n" +
-                "\n" +
-                "PLAN FRAGMENT 2\n" +
-                " OUTPUT EXPRS:\n" +
-                "  PARTITION: RANDOM\n" +
-                "\n" +
-                "  STREAM DATA SINK\n" +
-                "    EXCHANGE ID: 03\n" +
-                "    HASH_PARTITIONED: 5: GROUPING_ID\n" +
-                "\n" +
-                "  2:AGGREGATE (update serialize)\n" +
-                "  |  STREAMING\n" +
-                "  |  output: sum(3: v3)\n" +
-                "  |  group by: 5: GROUPING_ID\n" +
-                "  |  \n" +
-                "  1:REPEAT_NODE");
-        connectContext.getSessionVariable().setEnableRewriteGroupingSetsToUnionAll(false);
-    }
-
-    @Test
     public void testLimitSemiJoin() throws Exception {
         String sql = "select * from t0 " +
                 "        left semi join t2 on t0.v1 = t2.v7 " +

--- a/test/sql/test_grouping_sets/R/test_grouping_sets_v1
+++ b/test/sql/test_grouping_sets/R/test_grouping_sets_v1
@@ -1,0 +1,218 @@
+-- name: test_grouping_sets_v1
+set enable_rewrite_groupingsets_to_union_all=false;
+-- result:
+-- !result
+drop table if exists tbl_with_null1;
+-- result:
+-- !result
+CREATE TABLE `tbl_with_null1` ( 
+    `k1`  date, 
+    `k2`  datetime, 
+    `k3`  varchar(20), 
+    `k4`  varchar(20), 
+    `k5`  boolean, 
+    `k6`  tinyint, 
+    `k7`  smallint, 
+    `k8`  int, 
+    `K9`  bigint, 
+    `K10` largeint, 
+    `K11` float, 
+    `K12` double, 
+    `K13` decimal(27,9) 
+) DUPLICATE KEY(`k1`) 
+DISTRIBUTED BY HASH(`k1`) BUCKETS 3 
+PROPERTIES ( "replication_num" = "1");
+-- result:
+-- !result
+INSERT INTO tbl_with_null1 VALUES
+ ('2020-10-22','2020-10-23 12:12:12','k1','k4',0,1,2,3,4,5,1.1,1.12,2.889)
+,('2020-10-23','2020-10-23 12:12:12','k2','k4',0,0,2,3,4,5,1.1,1.12,2.889)
+,('2020-10-24','2020-10-23 12:12:12','k3','k4',0,1,2,3,4,5,1.1,1.12,2.889)
+,('2020-10-25','2020-10-23 12:12:12','k4','k4',0,1,2,3,4,NULL,NULL,NULL,2.889)
+,('2020-10-26',NULL, NULL, NULL,NULL,NULL,NULL,NULl,NULL,NULL,NULL,NULL,NULL);
+-- result:
+-- !result
+CREATE TABLE `tbl_with_null2` ( 
+    `k1`  date, 
+    `k2`  datetime, 
+    `k3`  varchar(20), 
+    `k4`  varchar(20), 
+    `k5`  boolean, 
+    `k6`  tinyint, 
+    `k7`  smallint, 
+    `k8`  int, 
+    `K9`  bigint, 
+    `K10` largeint, 
+    `K11` float, 
+    `K12` double, 
+    `K13` decimal(27,9) 
+) DUPLICATE KEY(`k1`) 
+DISTRIBUTED BY HASH(`k1`) BUCKETS 9
+PROPERTIES ( "replication_num" = "1");
+-- result:
+-- !result
+INSERT INTO tbl_with_null2 VALUES
+ ('2020-10-22','2020-10-23 12:12:12','k1','k4',0,1,2,3,4,5,1.1,1.12,2.889)
+,('2020-10-23','2020-10-23 12:12:12','k2','k4',0,0,2,3,4,5,1.1,1.12,2.889)
+,('2020-10-24','2020-10-23 12:12:12','k3','k4',0,1,2,3,4,5,1.1,1.12,2.889)
+,('2020-10-25','2020-10-23 12:12:12','k4','k4',0,1,2,3,4,NULL,NULL,NULL,2.889)
+,('2020-10-26',NULL, NULL, NULL,NULL,NULL,NULL,NULl,NULL,NULL,NULL,NULL,NULL);
+-- result:
+-- !result
+select k1, sum(k8) as v1
+from tbl_with_null1 group by grouping sets((), (k1)) order by k1, v1;
+-- result:
+None	12
+2020-10-22	3
+2020-10-23	3
+2020-10-24	3
+2020-10-25	3
+2020-10-26	None
+-- !result
+select k1, k2, sum(k8) as v1
+from tbl_with_null1 group by grouping sets((), (k1, k2)) order by k1, k2, v1;
+-- result:
+None	None	12
+2020-10-22	2020-10-23 12:12:12	3
+2020-10-23	2020-10-23 12:12:12	3
+2020-10-24	2020-10-23 12:12:12	3
+2020-10-25	2020-10-23 12:12:12	3
+2020-10-26	None	None
+-- !result
+select k1, k2, sum(k8) as v1
+from tbl_with_null1 group by rollup(k1, k2) order by k1, k2, v1;
+-- result:
+None	None	12
+2020-10-22	None	3
+2020-10-22	2020-10-23 12:12:12	3
+2020-10-23	None	3
+2020-10-23	2020-10-23 12:12:12	3
+2020-10-24	None	3
+2020-10-24	2020-10-23 12:12:12	3
+2020-10-25	None	3
+2020-10-25	2020-10-23 12:12:12	3
+2020-10-26	None	None
+2020-10-26	None	None
+-- !result
+select k1, k2, sum(k8) as v1
+from tbl_with_null1 group by cube (k1, k2) order by k1, k2, v1;
+-- result:
+None	None	None
+None	None	12
+None	2020-10-23 12:12:12	12
+2020-10-22	None	3
+2020-10-22	2020-10-23 12:12:12	3
+2020-10-23	None	3
+2020-10-23	2020-10-23 12:12:12	3
+2020-10-24	None	3
+2020-10-24	2020-10-23 12:12:12	3
+2020-10-25	None	3
+2020-10-25	2020-10-23 12:12:12	3
+2020-10-26	None	None
+2020-10-26	None	None
+-- !result
+select k1, grouping_id(k1) as f1, grouping(k1) as f2, sum(k8) as v1
+from tbl_with_null1 group by grouping sets((), (k1)) order by k1, f1, f2, v1;
+-- result:
+None	1	1	12
+2020-10-22	0	0	3
+2020-10-23	0	0	3
+2020-10-24	0	0	3
+2020-10-25	0	0	3
+2020-10-26	0	0	None
+-- !result
+select k1, k2, grouping_id(k1, k2) as f1, grouping(k1, k2) as f2, sum(k8) as v1
+from tbl_with_null1 group by grouping sets((), (k1, k2)) order by f1, f2, k1, k2, v1;
+-- result:
+2020-10-22	2020-10-23 12:12:12	0	0	3
+2020-10-23	2020-10-23 12:12:12	0	0	3
+2020-10-24	2020-10-23 12:12:12	0	0	3
+2020-10-25	2020-10-23 12:12:12	0	0	3
+2020-10-26	None	0	0	None
+None	None	3	3	12
+-- !result
+select k1, k2, grouping_id(k1, k2) as f1, grouping(k1, k2) as f2, sum(k8) as v1
+from tbl_with_null1 group by cube(k1, k2) order by f1, f2, k1, k2, v1;
+-- result:
+2020-10-22	2020-10-23 12:12:12	0	0	3
+2020-10-23	2020-10-23 12:12:12	0	0	3
+2020-10-24	2020-10-23 12:12:12	0	0	3
+2020-10-25	2020-10-23 12:12:12	0	0	3
+2020-10-26	None	0	0	None
+2020-10-22	None	1	1	3
+2020-10-23	None	1	1	3
+2020-10-24	None	1	1	3
+2020-10-25	None	1	1	3
+2020-10-26	None	1	1	None
+None	None	2	2	None
+None	2020-10-23 12:12:12	2	2	12
+None	None	3	3	12
+-- !result
+select k1, k2, grouping_id(k1, k2) as f1, grouping(k1, k2) as f2, sum(k8) as v1
+from tbl_with_null1 group by rollup(k1, k2) order by f1, f2, k1, k2, v1;
+-- result:
+2020-10-22	2020-10-23 12:12:12	0	0	3
+2020-10-23	2020-10-23 12:12:12	0	0	3
+2020-10-24	2020-10-23 12:12:12	0	0	3
+2020-10-25	2020-10-23 12:12:12	0	0	3
+2020-10-26	None	0	0	None
+2020-10-22	None	1	1	3
+2020-10-23	None	1	1	3
+2020-10-24	None	1	1	3
+2020-10-25	None	1	1	3
+2020-10-26	None	1	1	None
+None	None	3	3	12
+-- !result
+with cte1 as (select * from tbl_with_null1 order by k1)
+select multi_distinct_count(k4) as v1,  k1, grouping(k1) as f_k1, k2, grouping(k2) as f_k2
+from cte1 group by grouping sets ((), (k1), (k1, k2))
+order by f_k1 desc, k1 asc, f_k2 desc, k2 asc, v1 limit 10 offset 0;
+-- result:
+1	None	1	None	1
+1	2020-10-22	0	None	1
+1	2020-10-22	0	2020-10-23 12:12:12	0
+1	2020-10-23	0	None	1
+1	2020-10-23	0	2020-10-23 12:12:12	0
+1	2020-10-24	0	None	1
+1	2020-10-24	0	2020-10-23 12:12:12	0
+1	2020-10-25	0	None	1
+1	2020-10-25	0	2020-10-23 12:12:12	0
+0	2020-10-26	0	None	1
+-- !result
+with cte1 as (select t1.k1, t2.k2, t1.k3, t2.k4, t2.k5 from tbl_with_null1 t1 join tbl_with_null2 t2 on t1.k1=t2.k1 order by t1.k1)
+select count(distinct k3) as v1, count(distinct k4) as v2,  count(distinct k5) as v3, k1, grouping(k1) as f_k1, k2, grouping(k2) as f_k2
+from cte1 group by grouping sets ((), (k1), (k1, k2))
+order by f_k1 desc, k1 asc, f_k2 desc, k2 asc, v1, v2, v3 limit 10 offset 0;
+-- result:
+4	1	1	None	1	None	1
+1	1	1	2020-10-22	0	None	1
+1	1	1	2020-10-22	0	2020-10-23 12:12:12	0
+1	1	1	2020-10-23	0	None	1
+1	1	1	2020-10-23	0	2020-10-23 12:12:12	0
+1	1	1	2020-10-24	0	None	1
+1	1	1	2020-10-24	0	2020-10-23 12:12:12	0
+1	1	1	2020-10-25	0	None	1
+1	1	1	2020-10-25	0	2020-10-23 12:12:12	0
+0	0	0	2020-10-26	0	None	1
+-- !result
+with cte1 as (select t1.k1, t2.k2, t1.k3, t2.k4, t2.k5 from tbl_with_null1 t1 join tbl_with_null2 t2 on t1.k6=t2.k6 order by t1.k6)
+select count(distinct k3) as v1, count(distinct k4) as v2,  count(distinct k5) as v3, k1, grouping(k1) as f_k1, k2, grouping(k2) as f_k2
+from cte1 group by grouping sets ((), (k1), (k1, k2))
+order by f_k1 desc, k1 asc, f_k2 desc, k2 asc, v1, v2, v3 limit 10 offset 0;
+-- result:
+4	1	1	None	1	None	1
+1	1	1	2020-10-22	0	None	1
+1	1	1	2020-10-22	0	2020-10-23 12:12:12	0
+1	1	1	2020-10-23	0	None	1
+1	1	1	2020-10-23	0	2020-10-23 12:12:12	0
+1	1	1	2020-10-24	0	None	1
+1	1	1	2020-10-24	0	2020-10-23 12:12:12	0
+1	1	1	2020-10-25	0	None	1
+1	1	1	2020-10-25	0	2020-10-23 12:12:12	0
+-- !result
+drop table if exists tbl_with_null1;
+-- result:
+-- !result
+drop table if exists tbl_with_null2;
+-- result:
+-- !result

--- a/test/sql/test_grouping_sets/R/test_grouping_sets_v2
+++ b/test/sql/test_grouping_sets/R/test_grouping_sets_v2
@@ -1,0 +1,218 @@
+-- name: test_grouping_sets_v2
+set enable_rewrite_groupingsets_to_union_all=true;
+-- result:
+-- !result
+drop table if exists tbl_with_null1;
+-- result:
+-- !result
+CREATE TABLE `tbl_with_null1` ( 
+    `k1`  date, 
+    `k2`  datetime, 
+    `k3`  varchar(20), 
+    `k4`  varchar(20), 
+    `k5`  boolean, 
+    `k6`  tinyint, 
+    `k7`  smallint, 
+    `k8`  int, 
+    `K9`  bigint, 
+    `K10` largeint, 
+    `K11` float, 
+    `K12` double, 
+    `K13` decimal(27,9) 
+) DUPLICATE KEY(`k1`) 
+DISTRIBUTED BY HASH(`k1`) BUCKETS 3 
+PROPERTIES ( "replication_num" = "1");
+-- result:
+-- !result
+INSERT INTO tbl_with_null1 VALUES
+ ('2020-10-22','2020-10-23 12:12:12','k1','k4',0,1,2,3,4,5,1.1,1.12,2.889)
+,('2020-10-23','2020-10-23 12:12:12','k2','k4',0,0,2,3,4,5,1.1,1.12,2.889)
+,('2020-10-24','2020-10-23 12:12:12','k3','k4',0,1,2,3,4,5,1.1,1.12,2.889)
+,('2020-10-25','2020-10-23 12:12:12','k4','k4',0,1,2,3,4,NULL,NULL,NULL,2.889)
+,('2020-10-26',NULL, NULL, NULL,NULL,NULL,NULL,NULl,NULL,NULL,NULL,NULL,NULL);
+-- result:
+-- !result
+CREATE TABLE `tbl_with_null2` ( 
+    `k1`  date, 
+    `k2`  datetime, 
+    `k3`  varchar(20), 
+    `k4`  varchar(20), 
+    `k5`  boolean, 
+    `k6`  tinyint, 
+    `k7`  smallint, 
+    `k8`  int, 
+    `K9`  bigint, 
+    `K10` largeint, 
+    `K11` float, 
+    `K12` double, 
+    `K13` decimal(27,9) 
+) DUPLICATE KEY(`k1`) 
+DISTRIBUTED BY HASH(`k1`) BUCKETS 9
+PROPERTIES ( "replication_num" = "1");
+-- result:
+-- !result
+INSERT INTO tbl_with_null2 VALUES
+ ('2020-10-22','2020-10-23 12:12:12','k1','k4',0,1,2,3,4,5,1.1,1.12,2.889)
+,('2020-10-23','2020-10-23 12:12:12','k2','k4',0,0,2,3,4,5,1.1,1.12,2.889)
+,('2020-10-24','2020-10-23 12:12:12','k3','k4',0,1,2,3,4,5,1.1,1.12,2.889)
+,('2020-10-25','2020-10-23 12:12:12','k4','k4',0,1,2,3,4,NULL,NULL,NULL,2.889)
+,('2020-10-26',NULL, NULL, NULL,NULL,NULL,NULL,NULl,NULL,NULL,NULL,NULL,NULL);
+-- result:
+-- !result
+select k1, sum(k8) as v1
+from tbl_with_null1 group by grouping sets((), (k1)) order by k1, v1;
+-- result:
+None	12
+2020-10-22	3
+2020-10-23	3
+2020-10-24	3
+2020-10-25	3
+2020-10-26	None
+-- !result
+select k1, k2, sum(k8) as v1
+from tbl_with_null1 group by grouping sets((), (k1, k2)) order by k1, k2, v1;
+-- result:
+None	None	12
+2020-10-22	2020-10-23 12:12:12	3
+2020-10-23	2020-10-23 12:12:12	3
+2020-10-24	2020-10-23 12:12:12	3
+2020-10-25	2020-10-23 12:12:12	3
+2020-10-26	None	None
+-- !result
+select k1, k2, sum(k8) as v1
+from tbl_with_null1 group by rollup(k1, k2) order by k1, k2, v1;
+-- result:
+None	None	12
+2020-10-22	None	3
+2020-10-22	2020-10-23 12:12:12	3
+2020-10-23	None	3
+2020-10-23	2020-10-23 12:12:12	3
+2020-10-24	None	3
+2020-10-24	2020-10-23 12:12:12	3
+2020-10-25	None	3
+2020-10-25	2020-10-23 12:12:12	3
+2020-10-26	None	None
+2020-10-26	None	None
+-- !result
+select k1, k2, sum(k8) as v1
+from tbl_with_null1 group by cube (k1, k2) order by k1, k2, v1;
+-- result:
+None	None	None
+None	None	12
+None	2020-10-23 12:12:12	12
+2020-10-22	None	3
+2020-10-22	2020-10-23 12:12:12	3
+2020-10-23	None	3
+2020-10-23	2020-10-23 12:12:12	3
+2020-10-24	None	3
+2020-10-24	2020-10-23 12:12:12	3
+2020-10-25	None	3
+2020-10-25	2020-10-23 12:12:12	3
+2020-10-26	None	None
+2020-10-26	None	None
+-- !result
+select k1, grouping_id(k1) as f1, grouping(k1) as f2, sum(k8) as v1
+from tbl_with_null1 group by grouping sets((), (k1)) order by k1, f1, f2, v1;
+-- result:
+None	1	1	12
+2020-10-22	0	0	3
+2020-10-23	0	0	3
+2020-10-24	0	0	3
+2020-10-25	0	0	3
+2020-10-26	0	0	None
+-- !result
+select k1, k2, grouping_id(k1, k2) as f1, grouping(k1, k2) as f2, sum(k8) as v1
+from tbl_with_null1 group by grouping sets((), (k1, k2)) order by f1, f2, k1, k2, v1;
+-- result:
+2020-10-22	2020-10-23 12:12:12	0	0	3
+2020-10-23	2020-10-23 12:12:12	0	0	3
+2020-10-24	2020-10-23 12:12:12	0	0	3
+2020-10-25	2020-10-23 12:12:12	0	0	3
+2020-10-26	None	0	0	None
+None	None	3	3	12
+-- !result
+select k1, k2, grouping_id(k1, k2) as f1, grouping(k1, k2) as f2, sum(k8) as v1
+from tbl_with_null1 group by cube(k1, k2) order by f1, f2, k1, k2, v1;
+-- result:
+2020-10-22	2020-10-23 12:12:12	0	0	3
+2020-10-23	2020-10-23 12:12:12	0	0	3
+2020-10-24	2020-10-23 12:12:12	0	0	3
+2020-10-25	2020-10-23 12:12:12	0	0	3
+2020-10-26	None	0	0	None
+2020-10-22	None	1	1	3
+2020-10-23	None	1	1	3
+2020-10-24	None	1	1	3
+2020-10-25	None	1	1	3
+2020-10-26	None	1	1	None
+None	None	2	2	None
+None	2020-10-23 12:12:12	2	2	12
+None	None	3	3	12
+-- !result
+select k1, k2, grouping_id(k1, k2) as f1, grouping(k1, k2) as f2, sum(k8) as v1
+from tbl_with_null1 group by rollup(k1, k2) order by f1, f2, k1, k2, v1;
+-- result:
+2020-10-22	2020-10-23 12:12:12	0	0	3
+2020-10-23	2020-10-23 12:12:12	0	0	3
+2020-10-24	2020-10-23 12:12:12	0	0	3
+2020-10-25	2020-10-23 12:12:12	0	0	3
+2020-10-26	None	0	0	None
+2020-10-22	None	1	1	3
+2020-10-23	None	1	1	3
+2020-10-24	None	1	1	3
+2020-10-25	None	1	1	3
+2020-10-26	None	1	1	None
+None	None	3	3	12
+-- !result
+with cte1 as (select * from tbl_with_null1 order by k1)
+select multi_distinct_count(k4) as v1,  k1, grouping(k1) as f_k1, k2, grouping(k2) as f_k2
+from cte1 group by grouping sets ((), (k1), (k1, k2))
+order by f_k1 desc, k1 asc, f_k2 desc, k2 asc, v1 limit 10 offset 0;
+-- result:
+1	None	1	None	1
+1	2020-10-22	0	None	1
+1	2020-10-22	0	2020-10-23 12:12:12	0
+1	2020-10-23	0	None	1
+1	2020-10-23	0	2020-10-23 12:12:12	0
+1	2020-10-24	0	None	1
+1	2020-10-24	0	2020-10-23 12:12:12	0
+1	2020-10-25	0	None	1
+1	2020-10-25	0	2020-10-23 12:12:12	0
+0	2020-10-26	0	None	1
+-- !result
+with cte1 as (select t1.k1, t2.k2, t1.k3, t2.k4, t2.k5 from tbl_with_null1 t1 join tbl_with_null2 t2 on t1.k1=t2.k1 order by t1.k1)
+select count(distinct k3) as v1, count(distinct k4) as v2,  count(distinct k5) as v3, k1, grouping(k1) as f_k1, k2, grouping(k2) as f_k2
+from cte1 group by grouping sets ((), (k1), (k1, k2))
+order by f_k1 desc, k1 asc, f_k2 desc, k2 asc, v1, v2, v3 limit 10 offset 0;
+-- result:
+4	1	1	None	1	None	1
+1	1	1	2020-10-22	0	None	1
+1	1	1	2020-10-22	0	2020-10-23 12:12:12	0
+1	1	1	2020-10-23	0	None	1
+1	1	1	2020-10-23	0	2020-10-23 12:12:12	0
+1	1	1	2020-10-24	0	None	1
+1	1	1	2020-10-24	0	2020-10-23 12:12:12	0
+1	1	1	2020-10-25	0	None	1
+1	1	1	2020-10-25	0	2020-10-23 12:12:12	0
+0	0	0	2020-10-26	0	None	1
+-- !result
+with cte1 as (select t1.k1, t2.k2, t1.k3, t2.k4, t2.k5 from tbl_with_null1 t1 join tbl_with_null2 t2 on t1.k6=t2.k6 order by t1.k6)
+select count(distinct k3) as v1, count(distinct k4) as v2,  count(distinct k5) as v3, k1, grouping(k1) as f_k1, k2, grouping(k2) as f_k2
+from cte1 group by grouping sets ((), (k1), (k1, k2))
+order by f_k1 desc, k1 asc, f_k2 desc, k2 asc, v1, v2, v3 limit 10 offset 0;
+-- result:
+4	1	1	None	1	None	1
+1	1	1	2020-10-22	0	None	1
+1	1	1	2020-10-22	0	2020-10-23 12:12:12	0
+1	1	1	2020-10-23	0	None	1
+1	1	1	2020-10-23	0	2020-10-23 12:12:12	0
+1	1	1	2020-10-24	0	None	1
+1	1	1	2020-10-24	0	2020-10-23 12:12:12	0
+1	1	1	2020-10-25	0	None	1
+1	1	1	2020-10-25	0	2020-10-23 12:12:12	0
+-- !result
+drop table if exists tbl_with_null1;
+-- result:
+-- !result
+drop table if exists tbl_with_null2;
+-- result:
+-- !result

--- a/test/sql/test_grouping_sets/T/test_grouping_sets_v1
+++ b/test/sql/test_grouping_sets/T/test_grouping_sets_v1
@@ -1,0 +1,97 @@
+-- name: test_grouping_sets_v1
+set enable_rewrite_groupingsets_to_union_all=false;
+drop table if exists tbl_with_null1;
+CREATE TABLE `tbl_with_null1` ( 
+    `k1`  date, 
+    `k2`  datetime, 
+    `k3`  varchar(20), 
+    `k4`  varchar(20), 
+    `k5`  boolean, 
+    `k6`  tinyint, 
+    `k7`  smallint, 
+    `k8`  int, 
+    `K9`  bigint, 
+    `K10` largeint, 
+    `K11` float, 
+    `K12` double, 
+    `K13` decimal(27,9) 
+) DUPLICATE KEY(`k1`) 
+DISTRIBUTED BY HASH(`k1`) BUCKETS 3 
+PROPERTIES ( "replication_num" = "1");
+
+INSERT INTO tbl_with_null1 VALUES
+ ('2020-10-22','2020-10-23 12:12:12','k1','k4',0,1,2,3,4,5,1.1,1.12,2.889)
+,('2020-10-23','2020-10-23 12:12:12','k2','k4',0,0,2,3,4,5,1.1,1.12,2.889)
+,('2020-10-24','2020-10-23 12:12:12','k3','k4',0,1,2,3,4,5,1.1,1.12,2.889)
+,('2020-10-25','2020-10-23 12:12:12','k4','k4',0,1,2,3,4,NULL,NULL,NULL,2.889)
+,('2020-10-26',NULL, NULL, NULL,NULL,NULL,NULL,NULl,NULL,NULL,NULL,NULL,NULL);
+
+CREATE TABLE `tbl_with_null2` ( 
+    `k1`  date, 
+    `k2`  datetime, 
+    `k3`  varchar(20), 
+    `k4`  varchar(20), 
+    `k5`  boolean, 
+    `k6`  tinyint, 
+    `k7`  smallint, 
+    `k8`  int, 
+    `K9`  bigint, 
+    `K10` largeint, 
+    `K11` float, 
+    `K12` double, 
+    `K13` decimal(27,9) 
+) DUPLICATE KEY(`k1`) 
+DISTRIBUTED BY HASH(`k1`) BUCKETS 9
+PROPERTIES ( "replication_num" = "1");
+
+INSERT INTO tbl_with_null2 VALUES
+ ('2020-10-22','2020-10-23 12:12:12','k1','k4',0,1,2,3,4,5,1.1,1.12,2.889)
+,('2020-10-23','2020-10-23 12:12:12','k2','k4',0,0,2,3,4,5,1.1,1.12,2.889)
+,('2020-10-24','2020-10-23 12:12:12','k3','k4',0,1,2,3,4,5,1.1,1.12,2.889)
+,('2020-10-25','2020-10-23 12:12:12','k4','k4',0,1,2,3,4,NULL,NULL,NULL,2.889)
+,('2020-10-26',NULL, NULL, NULL,NULL,NULL,NULL,NULl,NULL,NULL,NULL,NULL,NULL);
+
+--- without grouping_id/grouping
+select k1, sum(k8) as v1
+from tbl_with_null1 group by grouping sets((), (k1)) order by k1, v1;
+
+select k1, k2, sum(k8) as v1
+from tbl_with_null1 group by grouping sets((), (k1, k2)) order by k1, k2, v1;
+
+select k1, k2, sum(k8) as v1
+from tbl_with_null1 group by rollup(k1, k2) order by k1, k2, v1;
+
+select k1, k2, sum(k8) as v1
+from tbl_with_null1 group by cube (k1, k2) order by k1, k2, v1;
+
+--- with grouping_id/grouping
+select k1, grouping_id(k1) as f1, grouping(k1) as f2, sum(k8) as v1
+from tbl_with_null1 group by grouping sets((), (k1)) order by k1, f1, f2, v1;
+
+select k1, k2, grouping_id(k1, k2) as f1, grouping(k1, k2) as f2, sum(k8) as v1
+from tbl_with_null1 group by grouping sets((), (k1, k2)) order by f1, f2, k1, k2, v1;
+
+select k1, k2, grouping_id(k1, k2) as f1, grouping(k1, k2) as f2, sum(k8) as v1
+from tbl_with_null1 group by cube(k1, k2) order by f1, f2, k1, k2, v1;
+
+select k1, k2, grouping_id(k1, k2) as f1, grouping(k1, k2) as f2, sum(k8) as v1
+from tbl_with_null1 group by rollup(k1, k2) order by f1, f2, k1, k2, v1;
+
+-- complex case
+with cte1 as (select * from tbl_with_null1 order by k1)
+select multi_distinct_count(k4) as v1,  k1, grouping(k1) as f_k1, k2, grouping(k2) as f_k2
+from cte1 group by grouping sets ((), (k1), (k1, k2))
+order by f_k1 desc, k1 asc, f_k2 desc, k2 asc, v1 limit 10 offset 0;
+
+with cte1 as (select t1.k1, t2.k2, t1.k3, t2.k4, t2.k5 from tbl_with_null1 t1 join tbl_with_null2 t2 on t1.k1=t2.k1 order by t1.k1)
+select count(distinct k3) as v1, count(distinct k4) as v2,  count(distinct k5) as v3, k1, grouping(k1) as f_k1, k2, grouping(k2) as f_k2
+from cte1 group by grouping sets ((), (k1), (k1, k2))
+order by f_k1 desc, k1 asc, f_k2 desc, k2 asc, v1, v2, v3 limit 10 offset 0;
+
+with cte1 as (select t1.k1, t2.k2, t1.k3, t2.k4, t2.k5 from tbl_with_null1 t1 join tbl_with_null2 t2 on t1.k6=t2.k6 order by t1.k6)
+select count(distinct k3) as v1, count(distinct k4) as v2,  count(distinct k5) as v3, k1, grouping(k1) as f_k1, k2, grouping(k2) as f_k2
+from cte1 group by grouping sets ((), (k1), (k1, k2))
+order by f_k1 desc, k1 asc, f_k2 desc, k2 asc, v1, v2, v3 limit 10 offset 0;
+
+drop table if exists tbl_with_null1;
+drop table if exists tbl_with_null2;

--- a/test/sql/test_grouping_sets/T/test_grouping_sets_v2
+++ b/test/sql/test_grouping_sets/T/test_grouping_sets_v2
@@ -1,0 +1,97 @@
+-- name: test_grouping_sets_v2
+set enable_rewrite_groupingsets_to_union_all=true;
+drop table if exists tbl_with_null1;
+CREATE TABLE `tbl_with_null1` ( 
+    `k1`  date, 
+    `k2`  datetime, 
+    `k3`  varchar(20), 
+    `k4`  varchar(20), 
+    `k5`  boolean, 
+    `k6`  tinyint, 
+    `k7`  smallint, 
+    `k8`  int, 
+    `K9`  bigint, 
+    `K10` largeint, 
+    `K11` float, 
+    `K12` double, 
+    `K13` decimal(27,9) 
+) DUPLICATE KEY(`k1`) 
+DISTRIBUTED BY HASH(`k1`) BUCKETS 3 
+PROPERTIES ( "replication_num" = "1");
+
+INSERT INTO tbl_with_null1 VALUES
+ ('2020-10-22','2020-10-23 12:12:12','k1','k4',0,1,2,3,4,5,1.1,1.12,2.889)
+,('2020-10-23','2020-10-23 12:12:12','k2','k4',0,0,2,3,4,5,1.1,1.12,2.889)
+,('2020-10-24','2020-10-23 12:12:12','k3','k4',0,1,2,3,4,5,1.1,1.12,2.889)
+,('2020-10-25','2020-10-23 12:12:12','k4','k4',0,1,2,3,4,NULL,NULL,NULL,2.889)
+,('2020-10-26',NULL, NULL, NULL,NULL,NULL,NULL,NULl,NULL,NULL,NULL,NULL,NULL);
+
+CREATE TABLE `tbl_with_null2` ( 
+    `k1`  date, 
+    `k2`  datetime, 
+    `k3`  varchar(20), 
+    `k4`  varchar(20), 
+    `k5`  boolean, 
+    `k6`  tinyint, 
+    `k7`  smallint, 
+    `k8`  int, 
+    `K9`  bigint, 
+    `K10` largeint, 
+    `K11` float, 
+    `K12` double, 
+    `K13` decimal(27,9) 
+) DUPLICATE KEY(`k1`) 
+DISTRIBUTED BY HASH(`k1`) BUCKETS 9
+PROPERTIES ( "replication_num" = "1");
+
+INSERT INTO tbl_with_null2 VALUES
+ ('2020-10-22','2020-10-23 12:12:12','k1','k4',0,1,2,3,4,5,1.1,1.12,2.889)
+,('2020-10-23','2020-10-23 12:12:12','k2','k4',0,0,2,3,4,5,1.1,1.12,2.889)
+,('2020-10-24','2020-10-23 12:12:12','k3','k4',0,1,2,3,4,5,1.1,1.12,2.889)
+,('2020-10-25','2020-10-23 12:12:12','k4','k4',0,1,2,3,4,NULL,NULL,NULL,2.889)
+,('2020-10-26',NULL, NULL, NULL,NULL,NULL,NULL,NULl,NULL,NULL,NULL,NULL,NULL);
+
+--- without grouping_id/grouping
+select k1, sum(k8) as v1
+from tbl_with_null1 group by grouping sets((), (k1)) order by k1, v1;
+
+select k1, k2, sum(k8) as v1
+from tbl_with_null1 group by grouping sets((), (k1, k2)) order by k1, k2, v1;
+
+select k1, k2, sum(k8) as v1
+from tbl_with_null1 group by rollup(k1, k2) order by k1, k2, v1;
+
+select k1, k2, sum(k8) as v1
+from tbl_with_null1 group by cube (k1, k2) order by k1, k2, v1;
+
+--- with grouping_id/grouping
+select k1, grouping_id(k1) as f1, grouping(k1) as f2, sum(k8) as v1
+from tbl_with_null1 group by grouping sets((), (k1)) order by k1, f1, f2, v1;
+
+select k1, k2, grouping_id(k1, k2) as f1, grouping(k1, k2) as f2, sum(k8) as v1
+from tbl_with_null1 group by grouping sets((), (k1, k2)) order by f1, f2, k1, k2, v1;
+
+select k1, k2, grouping_id(k1, k2) as f1, grouping(k1, k2) as f2, sum(k8) as v1
+from tbl_with_null1 group by cube(k1, k2) order by f1, f2, k1, k2, v1;
+
+select k1, k2, grouping_id(k1, k2) as f1, grouping(k1, k2) as f2, sum(k8) as v1
+from tbl_with_null1 group by rollup(k1, k2) order by f1, f2, k1, k2, v1;
+
+-- complex case
+with cte1 as (select * from tbl_with_null1 order by k1)
+select multi_distinct_count(k4) as v1,  k1, grouping(k1) as f_k1, k2, grouping(k2) as f_k2
+from cte1 group by grouping sets ((), (k1), (k1, k2))
+order by f_k1 desc, k1 asc, f_k2 desc, k2 asc, v1 limit 10 offset 0;
+
+with cte1 as (select t1.k1, t2.k2, t1.k3, t2.k4, t2.k5 from tbl_with_null1 t1 join tbl_with_null2 t2 on t1.k1=t2.k1 order by t1.k1)
+select count(distinct k3) as v1, count(distinct k4) as v2,  count(distinct k5) as v3, k1, grouping(k1) as f_k1, k2, grouping(k2) as f_k2
+from cte1 group by grouping sets ((), (k1), (k1, k2))
+order by f_k1 desc, k1 asc, f_k2 desc, k2 asc, v1, v2, v3 limit 10 offset 0;
+
+with cte1 as (select t1.k1, t2.k2, t1.k3, t2.k4, t2.k5 from tbl_with_null1 t1 join tbl_with_null2 t2 on t1.k6=t2.k6 order by t1.k6)
+select count(distinct k3) as v1, count(distinct k4) as v2,  count(distinct k5) as v3, k1, grouping(k1) as f_k1, k2, grouping(k2) as f_k2
+from cte1 group by grouping sets ((), (k1), (k1, k2))
+order by f_k1 desc, k1 asc, f_k2 desc, k2 asc, v1, v2, v3 limit 10 offset 0;
+
+drop table if exists tbl_with_null1;
+drop table if exists tbl_with_null2;


### PR DESCRIPTION
## Why I'm doing:
- BE may crash when local source exchange operator handle a const column because chunk#append_selective cannot handle const colulmn.
- And this  always happens when chunk is ouptuted by repeat node.

## What I'm doing:
- Introduce `unpack_and_duplicate_const_columns ` method in chunk.
- Apply unpack_and_duplicate_const_columns in local_exchange_source_operator before `chunk#append_selective `
- Consider grouping/grouping_id in `RewriteGroupingSetsByCTERule `
- Add more tests.

Fixes [#issue](https://github.com/StarRocks/starrocks/issues/42884)

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [x] 3.2
  - [x] 3.1
  - [x] 3.0
  - [x] 2.5
