### PR TITLE
[BugFix] Tablet repair state should be REPLICA_MISSING but is FORCE_REDUNDANT

### DIFF
--- a/bin/start_backend.sh
+++ b/bin/start_backend.sh
@@ -182,6 +182,9 @@ fi
 
 chmod 755 ${STARROCKS_HOME}/lib/starrocks_be
 
+if [ $(ulimit -n) != "unlimited" ] && [ $(ulimit -n) -lt 60000 ]; then
+    ulimit -n 65535
+fi
 
 START_BE_CMD="${NUMA_CMD} ${STARROCKS_HOME}/lib/starrocks_be"
 LOG_FILE=$LOG_DIR/be.out

--- a/bin/start_backend.sh
+++ b/bin/start_backend.sh
@@ -182,9 +182,6 @@ fi
 
 chmod 755 ${STARROCKS_HOME}/lib/starrocks_be
 
-if [ $(ulimit -n) != "unlimited" ] && [ $(ulimit -n) -lt 60000 ]; then
-    ulimit -n 65535
-fi
 
 START_BE_CMD="${NUMA_CMD} ${STARROCKS_HOME}/lib/starrocks_be"
 LOG_FILE=$LOG_DIR/be.out

--- a/fe/fe-core/src/main/java/com/starrocks/clone/TabletChecker.java
+++ b/fe/fe-core/src/main/java/com/starrocks/clone/TabletChecker.java
@@ -74,7 +74,6 @@ import org.apache.logging.log4j.Logger;
 
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;


### PR DESCRIPTION
## Why I'm doing:
When there are 4 backends(A, B, C, D) and one (A) backend is dead, the tablet whose one replica exists on A will be marked as `FORCE_REDUNDANT`. But in case case, it should be marked as `REPLICA_MISSING`.

## What I'm doing:
`replicas.size() >= aliveBackendsNum` does not means that the existing replicas occupies all available backends, we should check it by backendId.

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
