### PR TITLE
[BugFix] fix crash in iceberg query

### DIFF
--- a/be/src/formats/parquet/meta_helper.cpp
+++ b/be/src/formats/parquet/meta_helper.cpp
@@ -95,10 +95,14 @@ void IcebergMetaHelper::build_column_name_2_pos_in_meta(
         if (it == _field_name_2_iceberg_field.end()) {
             continue;
         }
+        auto& schema = _file_metadata->schema();
+        const ParquetField* field = schema.get_stored_column_by_field_id(it->second->field_id);
+        // After the column is added, there is no new column when querying the previously
+        // imported parquet file. It is skipped here, and this column will be set to NULL
+        // in the FileReader::_read_min_max_chunk.
+        if (field == nullptr) continue;
         // Put SlotDescriptor's origin column name here!
-        column_name_2_pos_in_meta.emplace(
-                slot->col_name(),
-                _file_metadata->schema().get_stored_column_by_field_id(it->second->field_id)->physical_column_index);
+        column_name_2_pos_in_meta.emplace(slot->col_name(), field->physical_column_index);
     }
 }
 


### PR DESCRIPTION

## Why I'm doing:

After adding columns to the iceberg table, if the previous data is queried and the newly added columns are used, BE will crash because the newly added metadata does not exist in the parquet.

## What I'm doing:

Check for null pointer in IcebergMetaHelper::build_column_name_2_pos_in_meta, skip if nullptr, then the column will be set to NULL in FileReader::_read_min_max_chunk.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [x] 3.2
  - [x] 3.1
  - [x] 3.0
  - [ ] 2.5
