### PR TITLE
[BugFix] External catalog failed to verify create drop insert permissions

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/privilege/ranger/hive/RangerHiveAccessController.java
+++ b/fe/fe-core/src/main/java/com/starrocks/privilege/ranger/hive/RangerHiveAccessController.java
@@ -106,6 +106,14 @@ public class RangerHiveAccessController extends RangerAccessController {
         HiveAccessType hiveAccessType;
         if (privilegeType == PrivilegeType.SELECT) {
             hiveAccessType = HiveAccessType.SELECT;
+        } else if (privilegeType == PrivilegeType.INSERT) {
+            hiveAccessType = HiveAccessType.UPDATE;
+        } else if (privilegeType == PrivilegeType.CREATE_DATABASE
+                || privilegeType == PrivilegeType.CREATE_TABLE
+                || privilegeType == PrivilegeType.CREATE_VIEW) {
+            hiveAccessType = HiveAccessType.CREATE;
+        } else if (privilegeType == PrivilegeType.DROP) {
+            hiveAccessType = HiveAccessType.DROP;
         } else {
             hiveAccessType = HiveAccessType.NONE;
         }
@@ -113,3 +121,4 @@ public class RangerHiveAccessController extends RangerAccessController {
         return hiveAccessType.name().toLowerCase(Locale.ENGLISH);
     }
 }
+


### PR DESCRIPTION
## Why I'm doing:
 External catalog failed to verify create drop insert permissions
## What I'm doing:
add insert ,drop ,create permissions to catalog hive on ranger
Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [x] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [x] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
