### PR TITLE
[BugFix] Disallow parquet writer to write map value of null key

### DIFF
--- a/be/src/formats/parquet/chunk_writer.cpp
+++ b/be/src/formats/parquet/chunk_writer.cpp
@@ -55,7 +55,7 @@ Status ChunkWriter::write(Chunk* chunk) {
     for (size_t i = 0; i < _type_descs.size(); i++) {
         ASSIGN_OR_RETURN(auto col, _eval_func(chunk, i));
         auto level_builder = LevelBuilder(_type_descs[i], _schema->field(i));
-        level_builder.write(ctx, col, write_leaf_column);
+        RETURN_IF_ERROR(level_builder.write(ctx, col, write_leaf_column));
     }
 
     return Status::OK();

--- a/be/src/formats/parquet/level_builder.cpp
+++ b/be/src/formats/parquet/level_builder.cpp
@@ -52,7 +52,7 @@ LevelBuilder::LevelBuilder(TypeDescriptor type_desc, ::parquet::schema::NodePtr 
         : _type_desc(std::move(type_desc)), _root(std::move(root)) {}
 
 Status LevelBuilder::write(const LevelBuilderContext& ctx, const ColumnPtr& col,
-                           const std::function<void(const LevelBuilderResult&)>& write_leaf_callback) {
+                           const CallbackFunction& write_leaf_callback) {
     return _write_column_chunk(ctx, _type_desc, _root, col, write_leaf_callback);
 }
 

--- a/be/src/formats/parquet/level_builder.cpp
+++ b/be/src/formats/parquet/level_builder.cpp
@@ -16,6 +16,7 @@
 
 #include <parquet/arrow/writer.h>
 
+#include <functional>
 #include <utility>
 
 #include "column/array_column.h"
@@ -50,97 +51,88 @@ inline RunTimeCppType<lt>* get_raw_data_column(const ColumnPtr& col) {
 LevelBuilder::LevelBuilder(TypeDescriptor type_desc, ::parquet::schema::NodePtr root)
         : _type_desc(std::move(type_desc)), _root(std::move(root)) {}
 
-void LevelBuilder::write(const LevelBuilderContext& ctx, const ColumnPtr& col,
-                         const CallbackFunction& write_leaf_callback) {
-    _write_column_chunk(ctx, _type_desc, _root, col, write_leaf_callback);
+Status LevelBuilder::write(const LevelBuilderContext& ctx, const ColumnPtr& col,
+                           const std::function<void(const LevelBuilderResult&)>& write_leaf_callback) {
+    return _write_column_chunk(ctx, _type_desc, _root, col, write_leaf_callback);
 }
 
-void LevelBuilder::_write_column_chunk(const LevelBuilderContext& ctx, const TypeDescriptor& type_desc,
-                                       const ::parquet::schema::NodePtr& node, const ColumnPtr& col,
-                                       const CallbackFunction& write_leaf_callback) {
+Status LevelBuilder::_write_column_chunk(const LevelBuilderContext& ctx, const TypeDescriptor& type_desc,
+                                         const ::parquet::schema::NodePtr& node, const ColumnPtr& col,
+                                         const CallbackFunction& write_leaf_callback) {
     switch (type_desc.type) {
     case TYPE_BOOLEAN: {
-        _write_boolean_column_chunk(ctx, type_desc, node, col, write_leaf_callback);
-        break;
+        return _write_boolean_column_chunk(ctx, type_desc, node, col, write_leaf_callback);
     }
     case TYPE_TINYINT: {
-        _write_int_column_chunk<TYPE_TINYINT, ::parquet::Type::INT32>(ctx, type_desc, node, col, write_leaf_callback);
-        break;
+        return _write_int_column_chunk<TYPE_TINYINT, ::parquet::Type::INT32>(ctx, type_desc, node, col,
+                                                                             write_leaf_callback);
     }
     case TYPE_SMALLINT: {
-        _write_int_column_chunk<TYPE_SMALLINT, ::parquet::Type::INT32>(ctx, type_desc, node, col, write_leaf_callback);
-        break;
+        return _write_int_column_chunk<TYPE_SMALLINT, ::parquet::Type::INT32>(ctx, type_desc, node, col,
+                                                                              write_leaf_callback);
     }
     case TYPE_INT: {
-        _write_int_column_chunk<TYPE_INT, ::parquet::Type::INT32>(ctx, type_desc, node, col, write_leaf_callback);
-        break;
+        return _write_int_column_chunk<TYPE_INT, ::parquet::Type::INT32>(ctx, type_desc, node, col,
+                                                                         write_leaf_callback);
     }
     case TYPE_BIGINT: {
-        _write_int_column_chunk<TYPE_BIGINT, ::parquet::Type::INT64>(ctx, type_desc, node, col, write_leaf_callback);
-        break;
+        return _write_int_column_chunk<TYPE_BIGINT, ::parquet::Type::INT64>(ctx, type_desc, node, col,
+                                                                            write_leaf_callback);
     }
     case TYPE_FLOAT: {
-        _write_int_column_chunk<TYPE_FLOAT, ::parquet::Type::FLOAT>(ctx, type_desc, node, col, write_leaf_callback);
-        break;
+        return _write_int_column_chunk<TYPE_FLOAT, ::parquet::Type::FLOAT>(ctx, type_desc, node, col,
+                                                                           write_leaf_callback);
     }
     case TYPE_DOUBLE: {
-        _write_int_column_chunk<TYPE_DOUBLE, ::parquet::Type::DOUBLE>(ctx, type_desc, node, col, write_leaf_callback);
-        break;
+        return _write_int_column_chunk<TYPE_DOUBLE, ::parquet::Type::DOUBLE>(ctx, type_desc, node, col,
+                                                                             write_leaf_callback);
     }
     case TYPE_DECIMAL32: {
-        _write_int_column_chunk<TYPE_DECIMAL32, ::parquet::Type::INT32>(ctx, type_desc, node, col, write_leaf_callback);
-        break;
+        return _write_int_column_chunk<TYPE_DECIMAL32, ::parquet::Type::INT32>(ctx, type_desc, node, col,
+                                                                               write_leaf_callback);
     }
     case TYPE_DECIMAL64: {
-        _write_int_column_chunk<TYPE_DECIMAL64, ::parquet::Type::INT64>(ctx, type_desc, node, col, write_leaf_callback);
-        break;
+        return _write_int_column_chunk<TYPE_DECIMAL64, ::parquet::Type::INT64>(ctx, type_desc, node, col,
+                                                                               write_leaf_callback);
     }
     case TYPE_DECIMAL128: {
-        _write_decimal128_column_chunk(ctx, type_desc, node, col, write_leaf_callback);
-        break;
+        return _write_decimal128_column_chunk(ctx, type_desc, node, col, write_leaf_callback);
     }
     case TYPE_DATE: {
-        _write_date_column_chunk(ctx, type_desc, node, col, write_leaf_callback);
-        break;
+        return _write_date_column_chunk(ctx, type_desc, node, col, write_leaf_callback);
     }
     case TYPE_DATETIME: {
-        _write_datetime_column_chunk(ctx, type_desc, node, col, write_leaf_callback);
-        break;
+        return _write_datetime_column_chunk(ctx, type_desc, node, col, write_leaf_callback);
     }
     case TYPE_CHAR:
     case TYPE_VARCHAR: {
-        _write_byte_array_column_chunk<TYPE_VARCHAR>(ctx, type_desc, node, col, write_leaf_callback);
-        break;
+        return _write_byte_array_column_chunk<TYPE_VARCHAR>(ctx, type_desc, node, col, write_leaf_callback);
     }
     case TYPE_BINARY:
     case TYPE_VARBINARY: {
-        _write_byte_array_column_chunk<TYPE_VARBINARY>(ctx, type_desc, node, col, write_leaf_callback);
-        break;
+        return _write_byte_array_column_chunk<TYPE_VARBINARY>(ctx, type_desc, node, col, write_leaf_callback);
     }
     case TYPE_ARRAY: {
-        _write_array_column_chunk(ctx, type_desc, node, col, write_leaf_callback);
-        break;
+        return _write_array_column_chunk(ctx, type_desc, node, col, write_leaf_callback);
     }
     case TYPE_MAP: {
-        _write_map_column_chunk(ctx, type_desc, node, col, write_leaf_callback);
-        break;
+        return _write_map_column_chunk(ctx, type_desc, node, col, write_leaf_callback);
     }
     case TYPE_STRUCT: {
-        _write_struct_column_chunk(ctx, type_desc, node, col, write_leaf_callback);
-        break;
+        return _write_struct_column_chunk(ctx, type_desc, node, col, write_leaf_callback);
     }
     case TYPE_TIME: {
-        _write_time_column_chunk(ctx, type_desc, node, col, write_leaf_callback);
-        break;
+        return _write_time_column_chunk(ctx, type_desc, node, col, write_leaf_callback);
     }
     default: {
+        return Status::NotSupported(fmt::format("Doesn't support to write {} type data", type_desc.debug_string()));
     }
     }
 }
 
-void LevelBuilder::_write_boolean_column_chunk(const LevelBuilderContext& ctx, const TypeDescriptor& type_desc,
-                                               const ::parquet::schema::NodePtr& node, const ColumnPtr& col,
-                                               const CallbackFunction& write_leaf_callback) {
+Status LevelBuilder::_write_boolean_column_chunk(const LevelBuilderContext& ctx, const TypeDescriptor& type_desc,
+                                                 const ::parquet::schema::NodePtr& node, const ColumnPtr& col,
+                                                 const CallbackFunction& write_leaf_callback) {
     const auto* data_col = get_raw_data_column<TYPE_BOOLEAN>(col);
     const auto* null_col = get_raw_null_column(col);
 
@@ -164,12 +156,14 @@ void LevelBuilder::_write_boolean_column_chunk(const LevelBuilderContext& ctx, c
             .values = reinterpret_cast<uint8_t*>(values),
             .null_bitset = null_bitset ? null_bitset->data() : nullptr,
     });
+
+    return Status::OK();
 }
 
 template <LogicalType lt, ::parquet::Type::type pt>
-void LevelBuilder::_write_int_column_chunk(const LevelBuilderContext& ctx, const TypeDescriptor& type_desc,
-                                           const ::parquet::schema::NodePtr& node, const ColumnPtr& col,
-                                           const CallbackFunction& write_leaf_callback) {
+Status LevelBuilder::_write_int_column_chunk(const LevelBuilderContext& ctx, const TypeDescriptor& type_desc,
+                                             const ::parquet::schema::NodePtr& node, const ColumnPtr& col,
+                                             const CallbackFunction& write_leaf_callback) {
     auto* data_col = get_raw_data_column<lt>(col);
     auto* null_col = get_raw_null_column(col);
 
@@ -208,11 +202,13 @@ void LevelBuilder::_write_int_column_chunk(const LevelBuilderContext& ctx, const
                 .null_bitset = null_bitset ? null_bitset->data() : nullptr,
         });
     }
+
+    return Status::OK();
 }
 
-void LevelBuilder::_write_decimal128_column_chunk(const LevelBuilderContext& ctx, const TypeDescriptor& type_desc,
-                                                  const ::parquet::schema::NodePtr& node, const ColumnPtr& col,
-                                                  const CallbackFunction& write_leaf_callback) {
+Status LevelBuilder::_write_decimal128_column_chunk(const LevelBuilderContext& ctx, const TypeDescriptor& type_desc,
+                                                    const ::parquet::schema::NodePtr& node, const ColumnPtr& col,
+                                                    const CallbackFunction& write_leaf_callback) {
     const auto* data_col = get_raw_data_column<TYPE_DECIMAL128>(col);
     const auto* null_col = get_raw_null_column(col);
 
@@ -244,11 +240,13 @@ void LevelBuilder::_write_decimal128_column_chunk(const LevelBuilderContext& ctx
             .values = reinterpret_cast<uint8_t*>(flba_values),
             .null_bitset = null_bitset ? null_bitset->data() : nullptr,
     });
+
+    return Status::OK();
 }
 
-void LevelBuilder::_write_date_column_chunk(const LevelBuilderContext& ctx, const TypeDescriptor& type_desc,
-                                            const ::parquet::schema::NodePtr& node, const ColumnPtr& col,
-                                            const CallbackFunction& write_leaf_callback) {
+Status LevelBuilder::_write_date_column_chunk(const LevelBuilderContext& ctx, const TypeDescriptor& type_desc,
+                                              const ::parquet::schema::NodePtr& node, const ColumnPtr& col,
+                                              const CallbackFunction& write_leaf_callback) {
     const auto* data_col = get_raw_data_column<TYPE_DATE>(col);
     const auto* null_col = get_raw_null_column(col);
 
@@ -273,11 +271,13 @@ void LevelBuilder::_write_date_column_chunk(const LevelBuilderContext& ctx, cons
             .values = reinterpret_cast<uint8_t*>(values),
             .null_bitset = null_bitset ? null_bitset->data() : nullptr,
     });
+
+    return Status::OK();
 }
 
-void LevelBuilder::_write_time_column_chunk(const LevelBuilderContext& ctx, const TypeDescriptor& type_desc,
-                                            const ::parquet::schema::NodePtr& node, const ColumnPtr& col,
-                                            const CallbackFunction& write_leaf_callback) {
+Status LevelBuilder::_write_time_column_chunk(const LevelBuilderContext& ctx, const TypeDescriptor& type_desc,
+                                              const ::parquet::schema::NodePtr& node, const ColumnPtr& col,
+                                              const CallbackFunction& write_leaf_callback) {
     const auto* data_col = get_raw_data_column<TYPE_TIME>(col);
     const auto* null_col = get_raw_null_column(col);
 
@@ -299,11 +299,13 @@ void LevelBuilder::_write_time_column_chunk(const LevelBuilderContext& ctx, cons
             .values = reinterpret_cast<uint8_t*>(values),
             .null_bitset = null_bitset ? null_bitset->data() : nullptr,
     });
+
+    return Status::OK();
 }
 
-void LevelBuilder::_write_datetime_column_chunk(const LevelBuilderContext& ctx, const TypeDescriptor& type_desc,
-                                                const ::parquet::schema::NodePtr& node, const ColumnPtr& col,
-                                                const CallbackFunction& write_leaf_callback) {
+Status LevelBuilder::_write_datetime_column_chunk(const LevelBuilderContext& ctx, const TypeDescriptor& type_desc,
+                                                  const ::parquet::schema::NodePtr& node, const ColumnPtr& col,
+                                                  const CallbackFunction& write_leaf_callback) {
     const auto data_col = get_raw_data_column<TYPE_DATETIME>(col);
     const auto null_col = get_raw_null_column(col);
 
@@ -326,12 +328,14 @@ void LevelBuilder::_write_datetime_column_chunk(const LevelBuilderContext& ctx, 
             .values = reinterpret_cast<uint8_t*>(values),
             .null_bitset = null_bitset ? null_bitset->data() : nullptr,
     });
+
+    return Status::OK();
 }
 
 template <LogicalType lt>
-void LevelBuilder::_write_byte_array_column_chunk(const LevelBuilderContext& ctx, const TypeDescriptor& type_desc,
-                                                  const ::parquet::schema::NodePtr& node, const ColumnPtr& col,
-                                                  const CallbackFunction& write_leaf_callback) {
+Status LevelBuilder::_write_byte_array_column_chunk(const LevelBuilderContext& ctx, const TypeDescriptor& type_desc,
+                                                    const ::parquet::schema::NodePtr& node, const ColumnPtr& col,
+                                                    const CallbackFunction& write_leaf_callback) {
     const auto* data_col = down_cast<const RunTimeColumnType<lt>*>(ColumnHelper::get_data_column(col.get()));
     const auto* null_col = get_raw_null_column(col);
     auto& vo = data_col->get_offset();
@@ -357,11 +361,13 @@ void LevelBuilder::_write_byte_array_column_chunk(const LevelBuilderContext& ctx
             .values = reinterpret_cast<uint8_t*>(values),
             .null_bitset = null_bitset ? null_bitset->data() : nullptr,
     });
+
+    return Status::OK();
 }
 
-void LevelBuilder::_write_array_column_chunk(const LevelBuilderContext& ctx, const TypeDescriptor& type_desc,
-                                             const ::parquet::schema::NodePtr& node, const ColumnPtr& col,
-                                             const CallbackFunction& write_leaf_callback) {
+Status LevelBuilder::_write_array_column_chunk(const LevelBuilderContext& ctx, const TypeDescriptor& type_desc,
+                                               const ::parquet::schema::NodePtr& node, const ColumnPtr& col,
+                                               const CallbackFunction& write_leaf_callback) {
     // <list-repetition> group <name> (LIST) {
     //     repeated group list {
     //             <element-repetition> <element-type> element;
@@ -433,12 +439,12 @@ void LevelBuilder::_write_array_column_chunk(const LevelBuilderContext& ctx, con
                                     ctx._max_def_level + node->is_optional() + 1, ctx._max_rep_level + 1,
                                     ctx._max_def_level + node->is_optional() + 1);
 
-    _write_column_chunk(derived_ctx, type_desc.children[0], inner_node, elements, write_leaf_callback);
+    return _write_column_chunk(derived_ctx, type_desc.children[0], inner_node, elements, write_leaf_callback);
 }
 
-void LevelBuilder::_write_map_column_chunk(const LevelBuilderContext& ctx, const TypeDescriptor& type_desc,
-                                           const ::parquet::schema::NodePtr& node, const ColumnPtr& col,
-                                           const CallbackFunction& write_leaf_callback) {
+Status LevelBuilder::_write_map_column_chunk(const LevelBuilderContext& ctx, const TypeDescriptor& type_desc,
+                                             const ::parquet::schema::NodePtr& node, const ColumnPtr& col,
+                                             const CallbackFunction& write_leaf_callback) {
     // <map-repetition> group <name> (MAP) {
     //     repeated group key_value {
     //             required <key-type> key;
@@ -455,6 +461,9 @@ void LevelBuilder::_write_map_column_chunk(const LevelBuilderContext& ctx, const
     auto* null_col = get_raw_null_column(col);
     auto* map_col = down_cast<MapColumn*>(ColumnHelper::get_data_column(col.get()));
     const auto& keys = map_col->keys_column();
+    if (UNLIKELY(keys->has_null())) {
+        return Status::NotSupported("Does not support to write map value of null key");
+    }
     const auto& values = map_col->values_column();
     const auto& offsets = map_col->offsets_column()->get_data();
 
@@ -509,13 +518,14 @@ void LevelBuilder::_write_map_column_chunk(const LevelBuilderContext& ctx, const
                                     ctx._max_def_level + node->is_optional() + 1, ctx._max_rep_level + 1,
                                     ctx._max_def_level + node->is_optional() + 1);
 
-    _write_column_chunk(derived_ctx, type_desc.children[0], key_node, keys, write_leaf_callback);
-    _write_column_chunk(derived_ctx, type_desc.children[1], value_node, values, write_leaf_callback);
+    RETURN_IF_ERROR(_write_column_chunk(derived_ctx, type_desc.children[0], key_node, keys, write_leaf_callback));
+    RETURN_IF_ERROR(_write_column_chunk(derived_ctx, type_desc.children[1], value_node, values, write_leaf_callback));
+    return Status::OK();
 }
 
-void LevelBuilder::_write_struct_column_chunk(const LevelBuilderContext& ctx, const TypeDescriptor& type_desc,
-                                              const ::parquet::schema::NodePtr& node, const ColumnPtr& col,
-                                              const CallbackFunction& write_leaf_callback) {
+Status LevelBuilder::_write_struct_column_chunk(const LevelBuilderContext& ctx, const TypeDescriptor& type_desc,
+                                                const ::parquet::schema::NodePtr& node, const ColumnPtr& col,
+                                                const CallbackFunction& write_leaf_callback) {
     DCHECK(type_desc.type == TYPE_STRUCT);
     auto struct_node = std::static_pointer_cast<::parquet::schema::GroupNode>(node);
 
@@ -533,8 +543,10 @@ void LevelBuilder::_write_struct_column_chunk(const LevelBuilderContext& ctx, co
 
     for (size_t i = 0; i < type_desc.children.size(); i++) {
         auto sub_col = struct_col->field_column(type_desc.field_names[i]);
-        _write_column_chunk(derived_ctx, type_desc.children[i], struct_node->field(i), sub_col, write_leaf_callback);
+        RETURN_IF_ERROR(_write_column_chunk(derived_ctx, type_desc.children[i], struct_node->field(i), sub_col,
+                                            write_leaf_callback));
     }
+    return Status::OK();
 }
 
 // Bit-pack null column into an LSB-first bitmap. Note the 0/1 values are flipped.

--- a/be/src/formats/parquet/level_builder.h
+++ b/be/src/formats/parquet/level_builder.h
@@ -27,6 +27,7 @@
 #include <parquet/arrow/writer.h>
 #include <parquet/exception.h>
 
+#include <functional>
 #include <utility>
 
 #include "column/chunk.h"
@@ -97,54 +98,54 @@ public:
     //
     // The callback will be invoked for each leaf Array that is a descendant of array.  Each leaf array is
     // processed in a depth first traversal-order.
-    void write(const LevelBuilderContext& ctx, const ColumnPtr& col, const CallbackFunction& write_leaf_callback);
+    Status write(const LevelBuilderContext& ctx, const ColumnPtr& col, const CallbackFunction& write_leaf_callback);
 
 private:
-    void _write_column_chunk(const LevelBuilderContext& ctx, const TypeDescriptor& type_desc,
-                             const ::parquet::schema::NodePtr& node, const ColumnPtr& col,
-                             const CallbackFunction& write_leaf_callback);
+    Status _write_column_chunk(const LevelBuilderContext& ctx, const TypeDescriptor& type_desc,
+                               const ::parquet::schema::NodePtr& node, const ColumnPtr& col,
+                               const CallbackFunction& write_leaf_callback);
 
-    void _write_boolean_column_chunk(const LevelBuilderContext& ctx, const TypeDescriptor& type_desc,
-                                     const ::parquet::schema::NodePtr& node, const ColumnPtr& col,
-                                     const CallbackFunction& write_leaf_callback);
+    Status _write_boolean_column_chunk(const LevelBuilderContext& ctx, const TypeDescriptor& type_desc,
+                                       const ::parquet::schema::NodePtr& node, const ColumnPtr& col,
+                                       const CallbackFunction& write_leaf_callback);
 
     template <LogicalType lt, ::parquet::Type::type pt>
-    void _write_int_column_chunk(const LevelBuilderContext& ctx, const TypeDescriptor& type_desc,
-                                 const ::parquet::schema::NodePtr& node, const ColumnPtr& col,
-                                 const CallbackFunction& write_leaf_callback);
-
-    void _write_decimal128_column_chunk(const LevelBuilderContext& ctx, const TypeDescriptor& type_desc,
-                                        const ::parquet::schema::NodePtr& node, const ColumnPtr& col,
-                                        const CallbackFunction& write_leaf_callback);
-
-    template <LogicalType lt>
-    void _write_byte_array_column_chunk(const LevelBuilderContext& ctx, const TypeDescriptor& type_desc,
-                                        const ::parquet::schema::NodePtr& node, const ColumnPtr& col,
-                                        const CallbackFunction& write_leaf_callback);
-
-    void _write_date_column_chunk(const LevelBuilderContext& ctx, const TypeDescriptor& type_desc,
-                                  const ::parquet::schema::NodePtr& node, const ColumnPtr& col,
-                                  const CallbackFunction& write_leaf_callback);
-
-    void _write_datetime_column_chunk(const LevelBuilderContext& ctx, const TypeDescriptor& type_desc,
-                                      const ::parquet::schema::NodePtr& node, const ColumnPtr& col,
-                                      const CallbackFunction& write_leaf_callback);
-
-    void _write_array_column_chunk(const LevelBuilderContext& ctx, const TypeDescriptor& type_desc,
+    Status _write_int_column_chunk(const LevelBuilderContext& ctx, const TypeDescriptor& type_desc,
                                    const ::parquet::schema::NodePtr& node, const ColumnPtr& col,
                                    const CallbackFunction& write_leaf_callback);
 
-    void _write_map_column_chunk(const LevelBuilderContext& ctx, const TypeDescriptor& type_desc,
-                                 const ::parquet::schema::NodePtr& node, const ColumnPtr& col,
-                                 const CallbackFunction& write_leaf_callback);
+    Status _write_decimal128_column_chunk(const LevelBuilderContext& ctx, const TypeDescriptor& type_desc,
+                                          const ::parquet::schema::NodePtr& node, const ColumnPtr& col,
+                                          const CallbackFunction& write_leaf_callback);
 
-    void _write_struct_column_chunk(const LevelBuilderContext& ctx, const TypeDescriptor& type_desc,
+    template <LogicalType lt>
+    Status _write_byte_array_column_chunk(const LevelBuilderContext& ctx, const TypeDescriptor& type_desc,
+                                          const ::parquet::schema::NodePtr& node, const ColumnPtr& col,
+                                          const CallbackFunction& write_leaf_callback);
+
+    Status _write_date_column_chunk(const LevelBuilderContext& ctx, const TypeDescriptor& type_desc,
                                     const ::parquet::schema::NodePtr& node, const ColumnPtr& col,
                                     const CallbackFunction& write_leaf_callback);
 
-    void _write_time_column_chunk(const LevelBuilderContext& ctx, const TypeDescriptor& type_desc,
-                                  const ::parquet::schema::NodePtr& node, const ColumnPtr& col,
-                                  const CallbackFunction& write_leaf_callback);
+    Status _write_datetime_column_chunk(const LevelBuilderContext& ctx, const TypeDescriptor& type_desc,
+                                        const ::parquet::schema::NodePtr& node, const ColumnPtr& col,
+                                        const CallbackFunction& write_leaf_callback);
+
+    Status _write_array_column_chunk(const LevelBuilderContext& ctx, const TypeDescriptor& type_desc,
+                                     const ::parquet::schema::NodePtr& node, const ColumnPtr& col,
+                                     const CallbackFunction& write_leaf_callback);
+
+    Status _write_map_column_chunk(const LevelBuilderContext& ctx, const TypeDescriptor& type_desc,
+                                   const ::parquet::schema::NodePtr& node, const ColumnPtr& col,
+                                   const CallbackFunction& write_leaf_callback);
+
+    Status _write_struct_column_chunk(const LevelBuilderContext& ctx, const TypeDescriptor& type_desc,
+                                      const ::parquet::schema::NodePtr& node, const ColumnPtr& col,
+                                      const CallbackFunction& write_leaf_callback);
+
+    Status _write_time_column_chunk(const LevelBuilderContext& ctx, const TypeDescriptor& type_desc,
+                                    const ::parquet::schema::NodePtr& node, const ColumnPtr& col,
+                                    const CallbackFunction& write_leaf_callback);
 
     std::shared_ptr<std::vector<uint8_t>> _make_null_bitset(const LevelBuilderContext& ctx, const uint8_t* nulls,
                                                             const size_t col_size) const;

--- a/be/test/formats/parquet/parquet_file_writer_test.cpp
+++ b/be/test/formats/parquet/parquet_file_writer_test.cpp
@@ -713,6 +713,62 @@ TEST_F(ParquetFileWriterTest, TestWriteMap) {
     parquet::Utils::assert_equal_chunk(chunk.get(), read_chunk.get());
 }
 
+TEST_F(ParquetFileWriterTest, TestWriteMapOfNullKey) {
+    // type_descs
+    std::vector<TypeDescriptor> type_descs;
+    auto type_int_key = TypeDescriptor::from_logical_type(TYPE_INT);
+    auto type_int_value = TypeDescriptor::from_logical_type(TYPE_INT);
+    auto type_int_map = TypeDescriptor::from_logical_type(TYPE_MAP);
+    type_int_map.children.push_back(type_int_key);
+    type_int_map.children.push_back(type_int_value);
+    type_descs.push_back(type_int_map);
+
+    auto column_names = _make_type_names(type_descs);
+    auto output_file = _fs.new_writable_file(_file_path).value();
+    auto output_stream = std::make_unique<parquet::ParquetOutputStream>(std::move(output_file));
+    auto column_evaluators = ColumnSlotIdEvaluator::from_types(type_descs);
+    auto writer_options = std::make_shared<formats::ParquetWriterOptions>();
+    auto writer = std::make_unique<formats::ParquetFileWriter>(
+            _file_path, std::move(output_stream), column_names, type_descs, std::move(column_evaluators),
+            TCompressionType::NO_COMPRESSION, writer_options, []() {}, nullptr, nullptr);
+    ASSERT_OK(writer->init());
+
+    // [NULL -> 1], NULL, [], [2 -> 2, 3 -> NULL, 4 -> 4]
+    auto chunk = std::make_shared<Chunk>();
+    {
+        auto key_data_col = Int32Column::create();
+        std::vector<int32_t> key_nums{1, 2, 3, 4};
+        key_data_col->append_numbers(key_nums.data(), sizeof(int32_t) * key_nums.size());
+        auto key_null_col = UInt8Column::create();
+        std::vector<uint8_t> key_nulls{1, 0, 0, 0};
+        key_null_col->append_numbers(key_nulls.data(), sizeof(uint8_t) * key_nulls.size());
+        auto key_col = NullableColumn::create(key_data_col, key_null_col);
+
+        auto value_data_col = Int32Column::create();
+        std::vector<int32_t> value_nums{1, 2, -99, 4};
+        value_data_col->append_numbers(value_nums.data(), sizeof(int32_t) * value_nums.size());
+        auto value_null_col = UInt8Column::create();
+        std::vector<uint8_t> value_nulls{0, 0, 1, 0};
+        value_null_col->append_numbers(value_nulls.data(), sizeof(uint8_t) * value_nulls.size());
+        auto value_col = NullableColumn::create(value_data_col, value_null_col);
+
+        auto offsets_col = UInt32Column::create();
+        std::vector<uint32_t> offsets{0, 1, 1, 1, 4};
+        offsets_col->append_numbers(offsets.data(), sizeof(uint32_t) * offsets.size());
+        auto map_col = MapColumn::create(key_col, value_col, offsets_col);
+
+        std::vector<uint8_t> _nulls{0, 1, 0, 0};
+        auto null_col = UInt8Column::create();
+        null_col->append_numbers(_nulls.data(), sizeof(uint8_t) * _nulls.size());
+        auto nullable_col = NullableColumn::create(map_col, null_col);
+
+        chunk->append_column(nullable_col, chunk->num_columns());
+    }
+
+    // write chunk
+    ASSERT_FALSE(writer->write(chunk).get().ok());
+}
+
 TEST_F(ParquetFileWriterTest, TestWriteNestedArray) {
     // type_descs
     std::vector<TypeDescriptor> type_descs;


### PR DESCRIPTION
## Why I'm doing:

Parquet does not allow map key to be null. So we add a check in parquet writer.

## What I'm doing:



## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [x] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
