### PR TITLE
[BugFix] fix ErrorReport MissingFormatArgumentException

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/common/ErrorReport.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/ErrorReport.java
@@ -39,6 +39,8 @@ import com.starrocks.sql.analyzer.SemanticException;
 import com.starrocks.sql.common.ErrorType;
 import com.starrocks.sql.optimizer.validate.ValidateException;
 
+import java.util.MissingFormatArgumentException;
+
 // Used to report error happened when execute SQL of user
 public class ErrorReport {
 
@@ -47,7 +49,11 @@ public class ErrorReport {
         if (pattern == null) {
             errMsg = errorCode.formatErrorMsg(objs);
         } else {
-            errMsg = String.format(pattern, objs);
+            try {
+                errMsg = String.format(pattern, objs);
+            } catch (MissingFormatArgumentException e) {
+                errMsg = pattern;
+            }
         }
         ConnectContext ctx = ConnectContext.get();
         if (ctx != null) {


### PR DESCRIPTION
## Why I'm doing:
Formatting strings using the String.format method throws an exception when the error message contains '%'
eg:
error message = hdfsOpenFile failed, path=hdfs://xxx/xxx%3A
![Uploading image.png…]()

## What I'm doing:
fix MissingFormatArgumentException in ErrorReport
Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
