### PR TITLE
[BugFix] Fix predicate parse compatibility issue in schema scan

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/plan/PlanFragmentBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/plan/PlanFragmentBuilder.java
@@ -1377,11 +1377,12 @@ public class PlanFragmentBuilder {
                 ScalarOperator operator1 = origPredicate.getChild(1);
                 if (operator0 instanceof CastOperator && operator0.getChild(0) instanceof ColumnRefOperator &&
                         operator1 instanceof ConstantOperator) {
-                    // select * from information_schema.load_tracking_logs where job_id = "123"
-                    // job_id is bigint type, and analyzer generates where predicate as [cast (job_id as varchar) = "123"],
-                    // so rewrite the predicate for compatibility.
+                    // select * from information_schema.load_tracking_logs where job_id = "123", job_id is bigint type.
+                    // analyzer generates where predicate as [cast (job_id as varchar) = "123"] when
+                    // session variable cbo_eq_base_type is varchar, so rewrite the predicate for compatibility.
                     ColumnRefOperator columnRefOperator = (ColumnRefOperator) operator0.getChild(0);
-                    if (columnRefOperator.getType().isNumericType() && operator1.getType().isStringType()) {
+                    if (columnRefOperator.getType().isNumericType() && operator0.getType().isStringType() &&
+                            operator1.getType().isStringType()) {
                         predicate.setChild(0, columnRefOperator);
                         try {
                             LiteralExpr literalExpr =

--- a/test/sql/test_information_schema/R/test_loads
+++ b/test/sql/test_information_schema/R/test_loads
@@ -45,6 +45,11 @@ select tracking_log from information_schema.load_tracking_logs where job_id=${id
 Error: The row is out of partition ranges. Please add a new partition.. Row: [2022-01-14, 2]
 
 -- !result
+select tracking_log from information_schema.load_tracking_logs where job_id='${id}';
+-- result:
+Error: The row is out of partition ranges. Please add a new partition.. Row: [2022-01-14, 2]
+
+-- !result
 [UC]label=select label from information_schema.loads where database_name='db_${uuid1}';
 -- result:
 insert_1dd7d7e1-c702-11ed-a15b-00163e0dcbfc

--- a/test/sql/test_information_schema/R/test_loads
+++ b/test/sql/test_information_schema/R/test_loads
@@ -45,7 +45,7 @@ select tracking_log from information_schema.load_tracking_logs where job_id=${id
 Error: The row is out of partition ranges. Please add a new partition.. Row: [2022-01-14, 2]
 
 -- !result
-select tracking_log from information_schema.load_tracking_logs where job_id='${id}';
+select /*+ SET_VAR(cbo_eq_base_type = "varchar") */ tracking_log from information_schema.load_tracking_logs where job_id='${id}';
 -- result:
 Error: The row is out of partition ranges. Please add a new partition.. Row: [2022-01-14, 2]
 

--- a/test/sql/test_information_schema/T/test_loads
+++ b/test/sql/test_information_schema/T/test_loads
@@ -12,7 +12,7 @@ select state,type from information_schema.loads where database_name='db_${uuid1}
 select TRACKING_SQL from information_schema.loads where database_name='db_${uuid1}';
 id=select job_id from information_schema.loads where database_name='db_${uuid1}';
 select tracking_log from information_schema.load_tracking_logs where job_id=${id};
-select tracking_log from information_schema.load_tracking_logs where job_id='${id}';
+select /*+ SET_VAR(cbo_eq_base_type = "varchar") */ tracking_log from information_schema.load_tracking_logs where job_id='${id}';
 label=select label from information_schema.loads where database_name='db_${uuid1}';
 select tracking_log from information_schema.load_tracking_logs where label='${label}';
 select * from information_schema.loads where database_name='db_${uuid1}';

--- a/test/sql/test_information_schema/T/test_loads
+++ b/test/sql/test_information_schema/T/test_loads
@@ -12,6 +12,7 @@ select state,type from information_schema.loads where database_name='db_${uuid1}
 select TRACKING_SQL from information_schema.loads where database_name='db_${uuid1}';
 id=select job_id from information_schema.loads where database_name='db_${uuid1}';
 select tracking_log from information_schema.load_tracking_logs where job_id=${id};
+select tracking_log from information_schema.load_tracking_logs where job_id='${id}';
 label=select label from information_schema.loads where database_name='db_${uuid1}';
 select tracking_log from information_schema.load_tracking_logs where label='${label}';
 select * from information_schema.loads where database_name='db_${uuid1}';


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:
select * from information_schema.load_tracking_logs where job_id = "123", job_id is bigint type.
analyzer generates where predicate as [cast (job_id as varchar) = "123"] when
session variable cbo_eq_base_type is varchar, so rewrite the predicate for compatibility.

Fixes https://github.com/StarRocks/StarRocksTest/issues/6760

#40619

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
