### PR TITLE
[BugFix] Fix orc writer write float/double columns

### DIFF
--- a/be/src/formats/orc/orc_file_writer.cpp
+++ b/be/src/formats/orc/orc_file_writer.cpp
@@ -201,9 +201,11 @@ void ORCFileWriter::_write_column(orc::ColumnVectorBatch& orc_column, ColumnPtr&
     }
     case TYPE_FLOAT: {
         _write_number<TYPE_FLOAT, orc::DoubleVectorBatch>(orc_column, column);
+        break;
     }
     case TYPE_DOUBLE: {
         _write_number<TYPE_DOUBLE, orc::DoubleVectorBatch>(orc_column, column);
+        break;
     }
     case TYPE_CHAR:
         [[fallthrough]];

--- a/be/test/formats/orc/orc_file_writer_test.cpp
+++ b/be/test/formats/orc/orc_file_writer_test.cpp
@@ -288,7 +288,7 @@ TEST_F(OrcFileWriterTest, TestWriteFloat) {
 
     // read chunk
     ChunkPtr read_chunk;
-    ASSERT_OK(_read_chunk(read_chunk, column_names, type_descs, false));
+    ASSERT_OK(_read_chunk(read_chunk, column_names, type_descs, true));
     // verify correctness
     assert_equal_chunk(chunk.get(), read_chunk.get());
 }
@@ -328,7 +328,7 @@ TEST_F(OrcFileWriterTest, TestWriteDouble) {
 
     // read chunk
     ChunkPtr read_chunk;
-    ASSERT_OK(_read_chunk(read_chunk, column_names, type_descs, false));
+    ASSERT_OK(_read_chunk(read_chunk, column_names, type_descs, true));
     // verify correctness
     assert_equal_chunk(chunk.get(), read_chunk.get());
 }

--- a/be/test/formats/orc/orc_file_writer_test.cpp
+++ b/be/test/formats/orc/orc_file_writer_test.cpp
@@ -253,6 +253,86 @@ TEST_F(OrcFileWriterTest, TestWriteIntergersNotNull) {
     assert_equal_chunk(chunk.get(), read_chunk.get());
 }
 
+TEST_F(OrcFileWriterTest, TestWriteFloat) {
+    auto type_float = TypeDescriptor::from_logical_type(TYPE_FLOAT);
+    std::vector<TypeDescriptor> type_descs{type_float};
+
+    auto column_names = _make_type_names(type_descs);
+    auto output_file = _fs->new_writable_file(_file_path).value();
+    auto output_stream = std::make_unique<OrcOutputStream>(std::move(output_file));
+    auto column_evaluators = ColumnSlotIdEvaluator::from_types(type_descs);
+    auto writer_options = std::make_shared<formats::ORCWriterOptions>();
+    auto writer = std::make_unique<formats::ORCFileWriter>(
+            _file_path, std::move(output_stream), column_names, type_descs, std::move(column_evaluators),
+            TCompressionType::NO_COMPRESSION, writer_options, []() {}, nullptr, nullptr);
+    ASSERT_OK(writer->init());
+
+    auto chunk = std::make_shared<Chunk>();
+    {
+        // not-null column
+        auto data_column = FloatColumn::create();
+        std::vector<float> values = {0.1, 1.1, 1.2, -99.9};
+        data_column->append_numbers(values.data(), values.size() * sizeof(float));
+        auto null_column = UInt8Column::create();
+        std::vector<uint8_t> nulls = {1, 0, 1, 0};
+        null_column->append_numbers(nulls.data(), nulls.size());
+        auto nullable_column = NullableColumn::create(data_column, null_column);
+        chunk->append_column(nullable_column, chunk->num_columns());
+    }
+
+    // write chunk
+    ASSERT_OK(writer->write(chunk).get());
+    auto result = writer->commit().get();
+    ASSERT_OK(result.io_status);
+    ASSERT_EQ(result.file_statistics.record_count, 4);
+
+    // read chunk
+    ChunkPtr read_chunk;
+    ASSERT_OK(_read_chunk(read_chunk, column_names, type_descs, false));
+    // verify correctness
+    assert_equal_chunk(chunk.get(), read_chunk.get());
+}
+
+TEST_F(OrcFileWriterTest, TestWriteDouble) {
+    auto type_float = TypeDescriptor::from_logical_type(TYPE_DOUBLE);
+    std::vector<TypeDescriptor> type_descs{type_float};
+
+    auto column_names = _make_type_names(type_descs);
+    auto output_file = _fs->new_writable_file(_file_path).value();
+    auto output_stream = std::make_unique<OrcOutputStream>(std::move(output_file));
+    auto column_evaluators = ColumnSlotIdEvaluator::from_types(type_descs);
+    auto writer_options = std::make_shared<formats::ORCWriterOptions>();
+    auto writer = std::make_unique<formats::ORCFileWriter>(
+            _file_path, std::move(output_stream), column_names, type_descs, std::move(column_evaluators),
+            TCompressionType::NO_COMPRESSION, writer_options, []() {}, nullptr, nullptr);
+    ASSERT_OK(writer->init());
+
+    auto chunk = std::make_shared<Chunk>();
+    {
+        // not-null column
+        auto data_column = DoubleColumn::create();
+        std::vector<double> values = {0.1, 1.1, 1.2, -99.9};
+        data_column->append_numbers(values.data(), values.size() * sizeof(double));
+        auto null_column = UInt8Column::create();
+        std::vector<uint8_t> nulls = {1, 0, 1, 0};
+        null_column->append_numbers(nulls.data(), nulls.size());
+        auto nullable_column = NullableColumn::create(data_column, null_column);
+        chunk->append_column(nullable_column, chunk->num_columns());
+    }
+
+    // write chunk
+    ASSERT_OK(writer->write(chunk).get());
+    auto result = writer->commit().get();
+    ASSERT_OK(result.io_status);
+    ASSERT_EQ(result.file_statistics.record_count, 4);
+
+    // read chunk
+    ChunkPtr read_chunk;
+    ASSERT_OK(_read_chunk(read_chunk, column_names, type_descs, false));
+    // verify correctness
+    assert_equal_chunk(chunk.get(), read_chunk.get());
+}
+
 TEST_F(OrcFileWriterTest, TestWriteBooleanNullable) {
     ASSERT_OK(ignore_not_found(_fs->delete_file(_file_path)));
     auto type_bool = TypeDescriptor::from_logical_type(TYPE_BOOLEAN);


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:

A trivial bug of not using breaks.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
