### PR TITLE
[BugFix] Fix IllegalStateException when clean StreamLoadTask

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/load/streamload/StreamLoadMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/streamload/StreamLoadMgr.java
@@ -410,7 +410,6 @@ public class StreamLoadMgr implements MemoryTrackable {
                 if (streamLoadTask.checkNeedRemove(currentMs, isForce)) {
                     unprotectedRemoveTaskFromDb(streamLoadTask);
                     iterator.remove();
-                    idToStreamLoadTask.remove(streamLoadTask.getId());
                     if (streamLoadTask.isSyncStreamLoad()) {
                         txnIdToSyncStreamLoadTasks.remove(streamLoadTask.getTxnId());
                     }

--- a/fe/fe-core/src/main/java/com/starrocks/load/streamload/StreamLoadTask.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/streamload/StreamLoadTask.java
@@ -1096,7 +1096,7 @@ public class StreamLoadTask extends AbstractTxnStateChangeCallback
             }
             this.state = State.COMMITED;
             this.preparedChannelNum = this.channelNum;
-            this.endTimeMs = txnState.getFinishTime();
+            this.endTimeMs = txnState.getCommitTime();
         } finally {
             writeUnlock();
         }

--- a/fe/fe-core/src/main/java/com/starrocks/load/streamload/StreamLoadTask.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/streamload/StreamLoadTask.java
@@ -1014,6 +1014,7 @@ public class StreamLoadTask extends AbstractTxnStateChangeCallback
             }
             this.state = State.COMMITED;
             isCommitting = false;
+            endTimeMs = System.currentTimeMillis();
         } finally {
             writeUnlock();
         }
@@ -1095,6 +1096,7 @@ public class StreamLoadTask extends AbstractTxnStateChangeCallback
             }
             this.state = State.COMMITED;
             this.preparedChannelNum = this.channelNum;
+            this.endTimeMs = txnState.getFinishTime();
         } finally {
             writeUnlock();
         }

--- a/fe/fe-core/src/test/java/com/starrocks/load/streamload/StreamLoadManagerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/load/streamload/StreamLoadManagerTest.java
@@ -93,6 +93,13 @@ public class StreamLoadManagerTest {
             }
         };
 
+        new MockUp<Database>() {
+            @Mock
+            public long getDataQuota() {
+                return 100;
+            }
+        };
+
         globalTransactionMgr.addDatabaseTransactionMgr(db.getId());
         new Expectations() {
             {
@@ -146,7 +153,7 @@ public class StreamLoadManagerTest {
         
         TransactionResult resp = new TransactionResult();
         streamLoadManager.beginLoadTask(dbName, tableName, labelName, timeoutMillis, channelNum, channelId, resp);
-        
+
         Map<String, StreamLoadTask> idToStreamLoadTask =
                 Deencapsulation.getField(streamLoadManager, "idToStreamLoadTask");
         Assert.assertEquals(1, idToStreamLoadTask.size());
@@ -266,4 +273,35 @@ public class StreamLoadManagerTest {
         StreamLoadTask task = streamLoadManager.getTaskById(1002L);
         Assert.assertNull(task);
     }
+
+    @Test
+    public void testStreamLoadTaskAfterCommit() throws UserException {
+        StreamLoadMgr streamLoadManager = new StreamLoadMgr();
+
+        String dbName = "test_db";
+        String tableName = "test_tbl";
+        String labelName = "label2";
+        long timeoutMillis = 100000;
+        int channelNum = 1;
+        int channelId = 0;
+
+        TransactionResult resp = new TransactionResult();
+        streamLoadManager.beginLoadTask(dbName, tableName, labelName, timeoutMillis, channelNum, channelId, resp);
+
+        Map<String, StreamLoadTask> idToStreamLoadTask =
+                Deencapsulation.getField(streamLoadManager, "idToStreamLoadTask");
+
+        Assert.assertEquals(1, idToStreamLoadTask.size());
+
+        StreamLoadTask task = idToStreamLoadTask.get(labelName);
+
+        TransactionState state = new TransactionState();
+        task.afterCommitted(state, true);
+        Assert.assertNotEquals(-1, task.endTimeMs());
+
+        state.setCommitTime(task.endTimeMs());
+        task.replayOnCommitted(state);
+        Assert.assertEquals(task.endTimeMs(), state.getCommitTime());
+    }
+
 }


### PR DESCRIPTION
## Why I'm doing:
llegalStateException will be thrown when clean StreamLoadTask if the state of StreamLoadTask is committed, because it will check the endTime != -1, and streamLoadTask do not update the endTime when it's committed.
## What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [x] 3.2
  - [x] 3.1
  - [ ] 3.0
  - [ ] 2.5
