### PR TITLE
[BugFix] add DefaultSharedDataWorkerProvider for shared-data mode

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/lake/qe/scheduler/DefaultSharedDataWorkerProvider.java
+++ b/fe/fe-core/src/main/java/com/starrocks/lake/qe/scheduler/DefaultSharedDataWorkerProvider.java
@@ -1,0 +1,268 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.lake.qe.scheduler;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Preconditions;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Lists;
+import com.google.common.collect.Sets;
+import com.starrocks.common.FeConstants;
+import com.starrocks.qe.SimpleScheduler;
+import com.starrocks.qe.scheduler.NonRecoverableException;
+import com.starrocks.qe.scheduler.WorkerProvider;
+import com.starrocks.server.GlobalStateMgr;
+import com.starrocks.system.ComputeNode;
+import com.starrocks.system.SystemInfoService;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.IntSupplier;
+import java.util.stream.Collectors;
+
+/**
+ * WorkerProvider for SHARED_DATA mode. Compared to its counterpart for SHARED_NOTHING mode:
+ * 1. All Backends and ComputeNodes are treated the same as ComputeNodes.
+ * 2. Allows using backup node, when any of the initial workers in scan location is not available.
+ * Be noticed that,
+ * - All the worker nodes and available worker nodes are captured at the time of this provider creation. It
+ * is possible that the worker may not be available later when calling the interfaces of this provider.
+ * - All the nodes will be considered as available after the snapshot nodes info are captured, even though it
+ * may not be true all the time.
+ * - Specifically, when calling `selectBackupWorker()`, the selected node will be checked again if it is in
+ * `SimpleScheduler.isInBlocklist()` or not, to make sure that the backup node is in the available node list
+ * and not in the block list.
+ * Also in shared-data mode, all nodes will be treated as compute nodes. so the session variable @@prefer_compute_node
+ * will be always true, and @@use_compute_nodes will be always -1 which means using all the available compute nodes.
+ */
+public class DefaultSharedDataWorkerProvider implements WorkerProvider {
+    private static final Logger LOG = LogManager.getLogger(DefaultSharedDataWorkerProvider.class);
+    private static final AtomicInteger NEXT_COMPUTE_NODE_INDEX = new AtomicInteger(0);
+
+    public static class Factory implements WorkerProvider.Factory {
+        @Override
+        public DefaultSharedDataWorkerProvider captureAvailableWorkers(SystemInfoService systemInfoService,
+                                                                       boolean preferComputeNode,
+                                                                       int numUsedComputeNodes, long warehouseId) {
+
+            ImmutableMap.Builder<Long, ComputeNode> builder = ImmutableMap.builder();
+            List<Long> computeNodeIds =
+                    GlobalStateMgr.getCurrentState().getWarehouseMgr().getAllComputeNodeIds(warehouseId);
+            computeNodeIds.forEach(nodeId -> builder.put(nodeId,
+                    GlobalStateMgr.getCurrentState().getNodeMgr().getClusterInfo().getBackendOrComputeNode(nodeId)));
+            ImmutableMap<Long, ComputeNode> idToComputeNode = builder.build();
+            if (LOG.isDebugEnabled()) {
+                LOG.debug("idToComputeNode: {}", idToComputeNode);
+            }
+            return new DefaultSharedDataWorkerProvider(idToComputeNode, filterAvailableWorkers(idToComputeNode));
+        }
+    }
+
+    /**
+     * All the compute nodes (including backends), including those that are not alive or in block list.
+     */
+    private final ImmutableMap<Long, ComputeNode> id2ComputeNode;
+    /**
+     * The available compute nodes, which are alive and not in the block list when creating the snapshot. It is still
+     * possible that the node becomes unavailable later, it will be checked again in some of the interfaces.
+     */
+    private final ImmutableMap<Long, ComputeNode> availableID2ComputeNode;
+
+    /**
+     * List of the compute node ids, used to select buddy node in case some of the nodes are not available.
+     */
+    private ImmutableList<Long> allComputeNodeIds;
+
+    private final Set<Long> selectedWorkerIds;
+
+    @VisibleForTesting
+    public DefaultSharedDataWorkerProvider(ImmutableMap<Long, ComputeNode> id2ComputeNode,
+                                           ImmutableMap<Long, ComputeNode> availableID2ComputeNode
+    ) {
+        this.id2ComputeNode = id2ComputeNode;
+        this.availableID2ComputeNode = availableID2ComputeNode;
+        this.selectedWorkerIds = Sets.newConcurrentHashSet();
+        this.allComputeNodeIds = null;
+    }
+
+    @Override
+    public long selectNextWorker() throws NonRecoverableException {
+        ComputeNode worker;
+        worker = getNextWorker(availableID2ComputeNode, DefaultSharedDataWorkerProvider::getNextComputeNodeIndex);
+
+        if (worker == null) {
+            reportWorkerNotFoundException();
+        }
+        Preconditions.checkNotNull(worker);
+        selectWorkerUnchecked(worker.getId());
+        return worker.getId();
+    }
+
+    @Override
+    public void selectWorker(long workerId) throws NonRecoverableException {
+        if (getWorkerById(workerId) == null) {
+            reportWorkerNotFoundException(workerId);
+        }
+        selectWorkerUnchecked(workerId);
+    }
+
+    @Override
+    public List<Long> selectAllComputeNodes() {
+        List<Long> nodeIds = availableID2ComputeNode.values().stream()
+                .map(ComputeNode::getId)
+                .collect(Collectors.toList());
+        nodeIds.forEach(this::selectWorkerUnchecked);
+        return nodeIds;
+    }
+
+    @Override
+    public Collection<ComputeNode> getAllWorkers() {
+        return availableID2ComputeNode.values();
+    }
+
+    @Override
+    public ComputeNode getWorkerById(long workerId) {
+        return availableID2ComputeNode.get(workerId);
+    }
+
+    @Override
+    public boolean isDataNodeAvailable(long dataNodeId) {
+        // DataNode and ComputeNode is exchangeable in SHARED_DATA mode
+        return availableID2ComputeNode.containsKey(dataNodeId);
+    }
+
+    @Override
+    public void reportDataNodeNotFoundException() throws NonRecoverableException {
+        reportWorkerNotFoundException();
+    }
+
+    @Override
+    public boolean isWorkerSelected(long workerId) {
+        return selectedWorkerIds.contains(workerId);
+    }
+
+    @Override
+    public List<Long> getSelectedWorkerIds() {
+        return new ArrayList<>(selectedWorkerIds);
+    }
+
+    @Override
+    public List<Long> getAllAvailableNodes() {
+        return Lists.newArrayList(availableID2ComputeNode.keySet());
+    }
+
+    @Override
+    public boolean isPreferComputeNode() {
+        return true;
+    }
+
+    @Override
+    public void selectWorkerUnchecked(long workerId) {
+        selectedWorkerIds.add(workerId);
+    }
+
+    @Override
+    public void reportWorkerNotFoundException() throws NonRecoverableException {
+        reportWorkerNotFoundException(-1);
+    }
+
+    private void reportWorkerNotFoundException(long workerId) throws NonRecoverableException {
+        throw new NonRecoverableException(
+                FeConstants.getNodeNotFoundError(true) + " nodeId: " + workerId + " " + this);
+    }
+
+    @Override
+    public boolean allowUsingBackupNode() {
+        return true;
+    }
+
+    /**
+     * Try to select the next workerId in the sorted list just after the workerId, if the next one is not available,
+     * e.g. also in BlockList, then try the next one in the list, until all nodes have benn tried.
+     */
+    @Override
+    public long selectBackupWorker(long workerId) {
+        if (availableID2ComputeNode.isEmpty() || !id2ComputeNode.containsKey(workerId)) {
+            return -1;
+        }
+        if (allComputeNodeIds == null) {
+            createAvailableIdList();
+        }
+        Preconditions.checkNotNull(allComputeNodeIds);
+        Preconditions.checkState(allComputeNodeIds.contains(workerId));
+
+        int startPos = allComputeNodeIds.indexOf(workerId);
+        int attempts = allComputeNodeIds.size();
+        while (attempts-- > 0) {
+            // ensure the buddyId selection is stable, that is, giving the same input, the output is always the same.
+            // TODO: call StarOSAgent interface, let starmgr to choose a buddy node or trigger scheduling as necessary.
+            startPos = (startPos + 1) % allComputeNodeIds.size();
+            long buddyId = allComputeNodeIds.get(startPos);
+            if (buddyId != workerId && availableID2ComputeNode.containsKey(buddyId) &&
+                    !SimpleScheduler.isInBlocklist(buddyId)) {
+                return buddyId;
+            }
+        }
+        return -1;
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder out = new StringBuilder("compute node: ");
+        id2ComputeNode.forEach((backendID, backend) -> out.append(
+                String.format("[%s alive: %b, available: %b, inBlacklist: %b] ", backend.getHost(),
+                        backend.isAlive(), availableID2ComputeNode.containsKey(backendID),
+                        SimpleScheduler.isInBlocklist(backendID))));
+        return out.toString();
+    }
+
+    private void createAvailableIdList() {
+        List<Long> ids = new ArrayList<>(id2ComputeNode.keySet());
+        Collections.sort(ids);
+        this.allComputeNodeIds = ImmutableList.copyOf(ids);
+    }
+
+    @VisibleForTesting
+    static int getNextComputeNodeIndex() {
+        return NEXT_COMPUTE_NODE_INDEX.getAndIncrement();
+    }
+
+    private static ComputeNode getNextWorker(ImmutableMap<Long, ComputeNode> workers,
+                                             IntSupplier getNextWorkerNodeIndex) {
+        if (workers.isEmpty()) {
+            return null;
+        }
+        int index = getNextWorkerNodeIndex.getAsInt() % workers.size();
+        return workers.values().asList().get(index);
+    }
+
+    private static ImmutableMap<Long, ComputeNode> filterAvailableWorkers(ImmutableMap<Long, ComputeNode> workers) {
+        ImmutableMap.Builder<Long, ComputeNode> builder = new ImmutableMap.Builder<>();
+        for (Map.Entry<Long, ComputeNode> entry : workers.entrySet()) {
+            if (entry.getValue().isAlive() && !SimpleScheduler.isInBlocklist(entry.getKey())) {
+                builder.put(entry);
+            }
+        }
+        return builder.build();
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/qe/CoordinatorPreprocessor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/CoordinatorPreprocessor.java
@@ -22,6 +22,7 @@ import com.starrocks.common.Config;
 import com.starrocks.common.UserException;
 import com.starrocks.common.util.DebugUtil;
 import com.starrocks.common.util.TimeUtils;
+import com.starrocks.lake.qe.scheduler.DefaultSharedDataWorkerProvider;
 import com.starrocks.planner.DataPartition;
 import com.starrocks.planner.DataSink;
 import com.starrocks.planner.PlanFragment;
@@ -37,6 +38,7 @@ import com.starrocks.qe.scheduler.dag.ExecutionDAG;
 import com.starrocks.qe.scheduler.dag.ExecutionFragment;
 import com.starrocks.qe.scheduler.dag.JobSpec;
 import com.starrocks.server.GlobalStateMgr;
+import com.starrocks.server.RunMode;
 import com.starrocks.service.FrontendOptions;
 import com.starrocks.sql.common.ErrorType;
 import com.starrocks.sql.common.StarRocksPlannerException;
@@ -73,12 +75,13 @@ public class CoordinatorPreprocessor {
     private final JobSpec jobSpec;
     private final ExecutionDAG executionDAG;
 
-    private final WorkerProvider.Factory workerProviderFactory = new DefaultWorkerProvider.Factory();
+    private final WorkerProvider.Factory workerProviderFactory;
     private WorkerProvider workerProvider;
 
     private final FragmentAssignmentStrategyFactory fragmentAssignmentStrategyFactory;
 
     public CoordinatorPreprocessor(ConnectContext context, JobSpec jobSpec) {
+        workerProviderFactory = newWorkerProviderFactory();
         this.coordAddress = new TNetworkAddress(LOCAL_IP, Config.rpc_port);
 
         this.connectContext = Preconditions.checkNotNull(context);
@@ -96,6 +99,7 @@ public class CoordinatorPreprocessor {
 
     @VisibleForTesting
     CoordinatorPreprocessor(List<PlanFragment> fragments, List<ScanNode> scanNodes, ConnectContext context) {
+        workerProviderFactory = newWorkerProviderFactory();
         this.coordAddress = new TNetworkAddress(LOCAL_IP, Config.rpc_port);
 
         this.connectContext = context;
@@ -135,6 +139,14 @@ public class CoordinatorPreprocessor {
             queryGlobals.setTime_zone(timezone);
         }
         return queryGlobals;
+    }
+
+    private WorkerProvider.Factory newWorkerProviderFactory() {
+        if (RunMode.isSharedDataMode()) {
+            return new DefaultSharedDataWorkerProvider.Factory();
+        } else {
+            return new DefaultWorkerProvider.Factory();
+        }
     }
 
     public TUniqueId getQueryId() {

--- a/fe/fe-core/src/main/java/com/starrocks/qe/NormalBackendSelector.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/NormalBackendSelector.java
@@ -27,6 +27,7 @@ import com.starrocks.thrift.TScanRangeParams;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 
@@ -74,8 +75,21 @@ public class NormalBackendSelector implements BackendSelector {
             // assign this scan range to the host w/ the fewest assigned row count
             Long minRowCount = Long.MAX_VALUE;
             TScanRangeLocation minLocation = null;
+            List<TScanRangeLocation> backupLocations = new ArrayList<>();
+
             for (final TScanRangeLocation location : scanRangeLocations.getLocations()) {
                 if (!workerProvider.isDataNodeAvailable(location.getBackend_id())) {
+                    if (workerProvider.allowUsingBackupNode()) {
+                        long backupNodeId = workerProvider.selectBackupWorker(location.getBackend_id());
+                        LOG.debug("Select a backup node:{} for node:{}", backupNodeId, location.getBackend_id());
+                        if (backupNodeId > 0) {
+                            // using the backupNode to generate a new ScanRangeLocation
+                            TScanRangeLocation backupLocation = new TScanRangeLocation();
+                            backupLocation.setBackend_id(backupNodeId);
+                            backupLocation.setServer(workerProvider.getWorkerById(backupNodeId).getAddress());
+                            backupLocations.add(backupLocation);
+                        }
+                    }
                     continue;
                 }
 
@@ -86,6 +100,18 @@ public class NormalBackendSelector implements BackendSelector {
                 }
             }
 
+            // give a try of the backupLocations if minLocation is null
+            if (minLocation == null && !backupLocations.isEmpty()) {
+                for (TScanRangeLocation location : backupLocations) {
+                    Long assignedBytes = assignedRowCountPerHost.getOrDefault(location.server, 0L);
+                    if (assignedBytes < minRowCount) {
+                        minRowCount = assignedBytes;
+                        minLocation = location;
+                    }
+                }
+            }
+
+            // fail eventually if it can't find any location.
             if (minLocation == null) {
                 workerProvider.reportDataNodeNotFoundException();
             }

--- a/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/WorkerProvider.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/WorkerProvider.java
@@ -56,7 +56,7 @@ public interface WorkerProvider {
      * @param workerId The id of the worker to choose.
      * @throws NonRecoverableException if there is no available worker with the given id.
      */
-    void selectWorker(Long workerId) throws NonRecoverableException;
+    void selectWorker(long workerId) throws NonRecoverableException;
 
     /**
      * Select all the available compute nodes.
@@ -67,23 +67,34 @@ public interface WorkerProvider {
 
     Collection<ComputeNode> getAllWorkers();
 
-    ComputeNode getWorkerById(Long workerId);
+    ComputeNode getWorkerById(long workerId);
 
-    boolean isDataNodeAvailable(Long dataNodeId);
+    boolean isDataNodeAvailable(long dataNodeId);
 
     void reportDataNodeNotFoundException() throws NonRecoverableException;
 
     void reportWorkerNotFoundException() throws NonRecoverableException;
 
-    boolean isWorkerSelected(Long workerId);
+    boolean isWorkerSelected(long workerId);
 
     List<Long> getSelectedWorkerIds();
 
     List<Long> getAllAvailableNodes();
 
-    void selectWorkerUnchecked(Long workerId);
+    void selectWorkerUnchecked(long workerId);
 
     default boolean isPreferComputeNode() {
         return false;
     }
+
+    default boolean allowUsingBackupNode() {
+        return false;
+    }
+
+    /**
+     * choose a backup worker for the given workerId, it is up to the WorkerProvider decision how to select it.
+     *
+     * @return -1, no available backup worker
+     */
+    long selectBackupWorker(long workerId);
 }

--- a/fe/fe-core/src/test/java/com/starrocks/lake/qe/scheduler/DefaultSharedDataWorkerProviderTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/lake/qe/scheduler/DefaultSharedDataWorkerProviderTest.java
@@ -1,0 +1,640 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.lake.qe.scheduler;
+
+import com.google.api.client.util.Lists;
+import com.google.common.collect.ArrayListMultimap;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Maps;
+import com.starrocks.analysis.TupleDescriptor;
+import com.starrocks.analysis.TupleId;
+import com.starrocks.catalog.HashDistributionInfo;
+import com.starrocks.catalog.OlapTable;
+import com.starrocks.common.ExceptionChecker;
+import com.starrocks.common.UserException;
+import com.starrocks.planner.OlapScanNode;
+import com.starrocks.planner.PlanNodeId;
+import com.starrocks.qe.ColocatedBackendSelector;
+import com.starrocks.qe.FragmentScanRangeAssignment;
+import com.starrocks.qe.HostBlacklist;
+import com.starrocks.qe.NormalBackendSelector;
+import com.starrocks.qe.SimpleScheduler;
+import com.starrocks.qe.scheduler.NonRecoverableException;
+import com.starrocks.qe.scheduler.WorkerProvider;
+import com.starrocks.server.GlobalStateMgr;
+import com.starrocks.server.WarehouseManager;
+import com.starrocks.system.Backend;
+import com.starrocks.system.ComputeNode;
+import com.starrocks.system.SystemInfoService;
+import com.starrocks.thrift.TInternalScanRange;
+import com.starrocks.thrift.TScanRange;
+import com.starrocks.thrift.TScanRangeLocation;
+import com.starrocks.thrift.TScanRangeLocations;
+import mockit.Expectations;
+import mockit.Mock;
+import mockit.MockUp;
+import org.assertj.core.util.Sets;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.function.Supplier;
+import java.util.stream.Collectors;
+
+public class DefaultSharedDataWorkerProviderTest {
+    private Map<Long, ComputeNode> id2Backend;
+    private Map<Long, ComputeNode> id2ComputeNode;
+    private Map<Long, ComputeNode> id2AllNodes;
+    private DefaultSharedDataWorkerProvider.Factory factory;
+
+    private static <C extends ComputeNode> Map<Long, C> genWorkers(long startId, long endId,
+                                                                   Supplier<C> factory) {
+        Map<Long, C> res = new HashMap<>();
+        for (long i = startId; i < endId; i++) {
+            C worker = factory.get();
+            worker.setId(i);
+            worker.setAlive(true);
+            worker.setHost("host#" + i);
+            worker.setBePort(80);
+            res.put(i, worker);
+        }
+        return res;
+    }
+
+    @BeforeClass
+    public static void setUpTestSuite() {
+        SimpleScheduler.getHostBlacklist().disableAutoUpdate();
+    }
+
+    @Before
+    public void setUp() {
+        // clear the block list
+        SimpleScheduler.getHostBlacklist().hostBlacklist.clear();
+        factory = new DefaultSharedDataWorkerProvider.Factory();
+
+        // Generate mock Workers
+        // BE, 1-10
+        id2Backend = genWorkers(1, 11, Backend::new);
+        // CN, 11-15
+        id2ComputeNode = genWorkers(11, 16, ComputeNode::new);
+        // all nodes
+        id2AllNodes = Maps.newHashMap(id2Backend);
+        id2AllNodes.putAll(id2ComputeNode);
+
+        // Setup MockUp
+        WarehouseManager warehouseManager = GlobalStateMgr.getCurrentState().getWarehouseMgr();
+        new Expectations(warehouseManager) {
+            {
+                warehouseManager.getAllComputeNodeIds(anyLong);
+                result = Lists.newArrayList(id2AllNodes.keySet());
+                minTimes = 0;
+            }
+        };
+
+        new MockUp<SystemInfoService>() {
+            @Mock
+            public ComputeNode getBackendOrComputeNode(long nodeId) {
+                ComputeNode node = id2ComputeNode.get(nodeId);
+                if (node == null) {
+                    node = id2Backend.get(nodeId);
+                }
+                return node;
+            }
+        };
+    }
+
+    private WorkerProvider newWorkerProvider() {
+        return factory.captureAvailableWorkers(
+                GlobalStateMgr.getCurrentState().getNodeMgr().getClusterInfo(), true,
+                -1, WarehouseManager.DEFAULT_WAREHOUSE_ID);
+    }
+
+    private static void testUsingWorkerHelper(WorkerProvider workerProvider, Long workerId) {
+        Assert.assertTrue(workerProvider.isWorkerSelected(workerId));
+        Assert.assertTrue(workerProvider.getSelectedWorkerIds().contains(workerId));
+    }
+
+    private List<Long> prepareNodeAliveAndBlock(SystemInfoService sysInfo, HostBlacklist blockList) {
+        // for every even number of worker, take in turn to set to alive=false and inBlock=true.
+        // [0:alive=false, 1, 2:inBlock=true, 3, 4:alive=false, ...]
+        List<Long> availList = Lists.newArrayList(id2AllNodes.keySet());
+        boolean flip = true;
+        for (int i = 0; i < id2AllNodes.size(); i += 2) {
+            ComputeNode node = sysInfo.getBackendOrComputeNode(i);
+            if (node != null) {
+                if (flip) {
+                    node.setAlive(false);
+                } else {
+                    blockList.add(node.getId());
+                }
+                flip = !flip;
+                availList.remove(node.getId());
+            }
+        }
+        return availList;
+    }
+
+    @Test
+    public void testCaptureAvailableWorkers() {
+        long deadBEId = 1L;
+        long deadCNId = 11L;
+        long inBlacklistBEId = 3L;
+        long inBlacklistCNId = 13L;
+
+        HostBlacklist blockList = SimpleScheduler.getHostBlacklist();
+
+        blockList.add(inBlacklistBEId);
+        blockList.add(inBlacklistCNId);
+        id2Backend.get(deadBEId).setAlive(false);
+        id2ComputeNode.get(deadCNId).setAlive(false);
+
+        Set<Long> nonAvailableWorkerId = ImmutableSet.of(deadBEId, deadCNId, inBlacklistBEId, inBlacklistCNId);
+        WorkerProvider workerProvider = newWorkerProvider();
+
+        Optional<Long> maxId = id2Backend.keySet().stream().max(Comparator.naturalOrder());
+        Assert.assertFalse(maxId.isEmpty());
+        for (long id : id2AllNodes.keySet()) {
+            ComputeNode worker = workerProvider.getWorkerById(id);
+            if (nonAvailableWorkerId.contains(id)) {
+                Assert.assertNull(worker);
+            } else {
+                Assert.assertEquals(id, worker.getId());
+                if (id <= maxId.get()) {
+                    Assert.assertTrue(worker instanceof Backend);
+                } else {
+                    Assert.assertFalse(worker instanceof Backend);
+                }
+            }
+        }
+    }
+
+    @Test
+    public void testSelectWorker() throws UserException {
+        HostBlacklist blockList = SimpleScheduler.getHostBlacklist();
+        SystemInfoService sysInfo = GlobalStateMgr.getCurrentState().getNodeMgr().getClusterInfo();
+
+        List<Long> availList = prepareNodeAliveAndBlock(sysInfo, blockList);
+        WorkerProvider provider = newWorkerProvider();
+
+        // intend to iterate the id out of the actual range.
+        for (long id = -1; id < id2AllNodes.size() + 5; id++) {
+            if (availList.contains(id)) {
+                provider.selectWorker(id);
+                testUsingWorkerHelper(provider, id);
+            } else {
+                long finalId = id;
+                Assert.assertThrows(NonRecoverableException.class, () -> provider.selectWorker(finalId));
+            }
+        }
+    }
+
+    @Test
+    public void testGetAllWorkers() {
+        HostBlacklist blockList = SimpleScheduler.getHostBlacklist();
+        SystemInfoService sysInfo = GlobalStateMgr.getCurrentState().getNodeMgr().getClusterInfo();
+
+        List<Long> availList = prepareNodeAliveAndBlock(sysInfo, blockList);
+        WorkerProvider provider = newWorkerProvider();
+        // allWorkers returns only available workers
+        Collection<ComputeNode> allWorkers = provider.getAllWorkers();
+
+        Assert.assertEquals(availList.size(), allWorkers.size());
+        for (ComputeNode node : allWorkers) {
+            Assert.assertTrue(availList.contains(node.getId()));
+        }
+        List<Long> allWorkerIds = allWorkers.stream().map(ComputeNode::getId).collect(Collectors.toList());
+        for (long availId : availList) {
+            Assert.assertTrue(allWorkerIds.contains(availId));
+        }
+        // strictly the same
+        List<Long> allAvailNodeIds = provider.getAllAvailableNodes();
+        Assert.assertEquals(allWorkerIds, allAvailNodeIds);
+    }
+
+    private static void testSelectNextWorkerHelper(WorkerProvider workerProvider,
+                                                   Map<Long, ComputeNode> id2Worker)
+            throws UserException {
+        Set<Long> selectedWorkers = new HashSet<>(id2Worker.size());
+        for (int i = 0; i < id2Worker.size(); i++) {
+            long workerId = workerProvider.selectNextWorker();
+            Assert.assertFalse(selectedWorkers.contains(workerId));
+            selectedWorkers.add(workerId);
+            testUsingWorkerHelper(workerProvider, workerId);
+        }
+    }
+
+    @Test
+    public void testSelectNextWorker() throws UserException {
+        HostBlacklist blockList = SimpleScheduler.getHostBlacklist();
+        blockList.hostBlacklist.clear();
+        SystemInfoService sysInfo = GlobalStateMgr.getCurrentState().getNodeMgr().getClusterInfo();
+
+        List<Long> availList = prepareNodeAliveAndBlock(sysInfo, blockList);
+        { // test backend nodes only
+            ImmutableMap.Builder<Long, ComputeNode> builder = new ImmutableMap.Builder<>();
+            for (long backendId : id2Backend.keySet()) {
+                if (availList.contains(backendId)) {
+                    builder.put(backendId, id2Backend.get(backendId));
+                }
+            }
+            ImmutableMap<Long, ComputeNode> availableId2ComputeNode = builder.build();
+            WorkerProvider workerProvider =
+                    new DefaultSharedDataWorkerProvider(ImmutableMap.copyOf(id2Backend), availableId2ComputeNode);
+            testSelectNextWorkerHelper(workerProvider, availableId2ComputeNode);
+        }
+
+        { // test compute nodes only
+            ImmutableMap.Builder<Long, ComputeNode> builder = new ImmutableMap.Builder<>();
+            for (long backendId : id2ComputeNode.keySet()) {
+                if (availList.contains(backendId)) {
+                    builder.put(backendId, id2ComputeNode.get(backendId));
+                }
+            }
+            ImmutableMap<Long, ComputeNode> availableId2ComputeNode = builder.build();
+            WorkerProvider workerProvider =
+                    new DefaultSharedDataWorkerProvider(ImmutableMap.copyOf(id2ComputeNode), availableId2ComputeNode);
+            testSelectNextWorkerHelper(workerProvider, availableId2ComputeNode);
+        }
+
+        { // test both backends and compute nodes
+            ImmutableMap.Builder<Long, ComputeNode> builder = new ImmutableMap.Builder<>();
+            for (long backendId : id2AllNodes.keySet()) {
+                if (availList.contains(backendId)) {
+                    builder.put(backendId, id2AllNodes.get(backendId));
+                }
+            }
+            ImmutableMap<Long, ComputeNode> availableId2ComputeNode = builder.build();
+            WorkerProvider workerProvider =
+                    new DefaultSharedDataWorkerProvider(ImmutableMap.copyOf(id2AllNodes), availableId2ComputeNode);
+            testSelectNextWorkerHelper(workerProvider, availableId2ComputeNode);
+        }
+
+        { // test no available worker to select
+            WorkerProvider workerProvider =
+                    new DefaultSharedDataWorkerProvider(ImmutableMap.copyOf(id2AllNodes), ImmutableMap.of());
+            Assert.assertThrows(NonRecoverableException.class, workerProvider::selectNextWorker);
+        }
+    }
+
+    @Test
+    public void testChooseAllComputedNodes() {
+        { // empty compute nodes
+            WorkerProvider workerProvider =
+                    new DefaultSharedDataWorkerProvider(ImmutableMap.of(), ImmutableMap.of());
+            Assert.assertTrue(workerProvider.selectAllComputeNodes().isEmpty());
+        }
+
+        { // both compute nodes and backend are treated as compute nodes
+            WorkerProvider workerProvider =
+                    new DefaultSharedDataWorkerProvider(ImmutableMap.copyOf(id2AllNodes),
+                            ImmutableMap.copyOf(id2AllNodes));
+
+            List<Long> computeNodeIds = workerProvider.selectAllComputeNodes();
+            Assert.assertEquals(id2AllNodes.size(), computeNodeIds.size());
+            Set<Long> computeNodeIdSet = new HashSet<>(computeNodeIds);
+            for (ComputeNode computeNode : id2AllNodes.values()) {
+                Assert.assertTrue(computeNodeIdSet.contains(computeNode.getId()));
+                testUsingWorkerHelper(workerProvider, computeNode.getId());
+            }
+        }
+    }
+
+    @Test
+    public void testIsDataNodeAvailable() {
+        HostBlacklist blockList = SimpleScheduler.getHostBlacklist();
+        blockList.hostBlacklist.clear();
+        SystemInfoService sysInfo = GlobalStateMgr.getCurrentState().getNodeMgr().getClusterInfo();
+
+        List<Long> availList = prepareNodeAliveAndBlock(sysInfo, blockList);
+        WorkerProvider provider = newWorkerProvider();
+
+        for (long id = -1; id < 16; id++) {
+            boolean isAvail = provider.isDataNodeAvailable(id);
+            ComputeNode worker = provider.getWorkerById(id);
+            if (!availList.contains(id)) {
+                Assert.assertFalse(isAvail);
+            } else {
+                Assert.assertEquals(id2AllNodes.get(id), worker);
+                Assert.assertTrue(isAvail);
+            }
+        }
+    }
+
+    @Test
+    public void testReportBackendNotFoundException() {
+        WorkerProvider workerProvider = newWorkerProvider();
+        Assert.assertThrows(NonRecoverableException.class, workerProvider::reportDataNodeNotFoundException);
+    }
+
+    @Test
+    public void testSelectBackupWorkersEvenlySelected() {
+        Set<Long> counters = Sets.newHashSet();
+        WorkerProvider workerProvider = newWorkerProvider();
+        Assert.assertTrue(workerProvider.allowUsingBackupNode());
+        for (long id : id2AllNodes.keySet()) {
+            long backupId = -1;
+            for (int j = 0; j < 100; ++j) {
+                long selectedId = workerProvider.selectBackupWorker(id);
+                Assert.assertTrue(selectedId > 0);
+                // cannot choose itself
+                Assert.assertNotEquals(id, selectedId);
+                if (backupId == -1) {
+                    backupId = selectedId;
+                } else {
+                    // always get the same node
+                    Assert.assertEquals(backupId, selectedId);
+                }
+            }
+            Assert.assertTrue(backupId != -1);
+            Assert.assertFalse(counters.contains(id));
+            counters.add(id);
+        }
+        // every node is chosen as a backup node once
+        Assert.assertEquals(id2AllNodes.size(), counters.size());
+    }
+
+    @Test
+    public void testIsPreferComputeNode() {
+        WorkerProvider provider = newWorkerProvider();
+        Assert.assertTrue(provider.isPreferComputeNode());
+    }
+
+    @Test
+    public void testSelectBackupWorkerStable() {
+        HostBlacklist blockList = SimpleScheduler.getHostBlacklist();
+        SystemInfoService sysInfo = GlobalStateMgr.getCurrentState().getNodeMgr().getClusterInfo();
+        List<Long> availList = prepareNodeAliveAndBlock(sysInfo, blockList);
+
+        Optional<Long> unavail = id2AllNodes.keySet().stream().filter(x -> !availList.contains(x)).findAny();
+        Assert.assertTrue(unavail.isPresent());
+
+        long unavailWorkerId = unavail.get();
+        WorkerProvider provider = newWorkerProvider();
+
+        int selectCount = 0;
+        List<Long> selectedNodeId = Lists.newArrayList();
+
+        while (selectCount < availList.size() * 2 + 1) { // make sure the while loop will stop
+            Assert.assertFalse(provider.isDataNodeAvailable(unavailWorkerId));
+            long alterNodeId = provider.selectBackupWorker(unavailWorkerId);
+            if (alterNodeId == -1) {
+                break;
+            }
+            // the backup node is not itself
+            Assert.assertTrue(alterNodeId != unavailWorkerId);
+            // the backup node is not any of the node before
+            Assert.assertFalse(selectedNodeId.contains(alterNodeId));
+
+            for (int j = 0; j < 10; ++j) {
+                long selectAgainId = provider.selectBackupWorker(unavailWorkerId);
+                Assert.assertEquals(alterNodeId, selectAgainId);
+            }
+            ++selectCount;
+            // make it in blockList, so next time it will choose a different node
+            blockList.add(alterNodeId);
+            selectedNodeId.add(alterNodeId);
+        }
+        // all nodes are in block list, no nodes can be selected anymore
+        Assert.assertEquals(-1, provider.selectBackupWorker(unavailWorkerId));
+        // all the nodes are selected ever
+        Assert.assertEquals(selectedNodeId.size(), availList.size());
+
+        // a random workerId that doesn't exist in workerProvider
+        Assert.assertEquals(-1, provider.selectBackupWorker(15678));
+    }
+
+    private OlapScanNode newOlapScanNode(int id, int numBuckets) {
+        // copy from fe/fe-core/src/test/java/com/starrocks/qe/ColocatedBackendSelectorTest.java
+        TupleDescriptor desc = new TupleDescriptor(new TupleId(0));
+        OlapTable table = new OlapTable();
+        table.setDefaultDistributionInfo(new HashDistributionInfo(numBuckets, Collections.emptyList()));
+        desc.setTable(table);
+        return new OlapScanNode(new PlanNodeId(id), desc, "OlapScanNode");
+    }
+
+    private ArrayListMultimap<Integer, TScanRangeLocations> genBucketSeq2Locations(
+            Map<Integer, List<Long>> bucketSeqToBackends,
+            int numTabletsPerBucket) {
+        // copy from fe/fe-core/src/test/java/com/starrocks/qe/ColocatedBackendSelectorTest.java
+        ArrayListMultimap<Integer, TScanRangeLocations> bucketSeq2locations = ArrayListMultimap.create();
+        bucketSeqToBackends.forEach((bucketSeq, backends) -> {
+            for (int i = 0; i < numTabletsPerBucket; i++) {
+                TScanRangeLocations bucketLocations = new TScanRangeLocations();
+
+                bucketLocations.setScan_range(new TScanRange().setInternal_scan_range(new TInternalScanRange()));
+
+                List<TScanRangeLocation> locations = backends.stream()
+                        .map(backendId -> new TScanRangeLocation().setBackend_id(backendId))
+                        .collect(Collectors.toList());
+                bucketLocations.setLocations(locations);
+
+                bucketSeq2locations.put(bucketSeq, bucketLocations);
+            }
+        });
+
+        return bucketSeq2locations;
+    }
+
+    /**
+     * Generate a list of ScanRangeLocations, contains n element for bucketNum
+     *
+     * @param n         number of ScanRangeLocations
+     * @param bucketNum number of buckets
+     * @return lists of ScanRangeLocations
+     */
+    private List<TScanRangeLocations> generateScanRangeLocations(Map<Long, ComputeNode> nodes, int n, int bucketNum) {
+        List<TScanRangeLocations> locations = Lists.newArrayList();
+        int currentBucketIndex = 0;
+        Iterator<Map.Entry<Long, ComputeNode>> iterator = nodes.entrySet().iterator();
+        for (int i = 0; i < n; ++i) {
+            if (!iterator.hasNext()) {
+                iterator = nodes.entrySet().iterator();
+            }
+            TInternalScanRange internalRange = new TInternalScanRange();
+            internalRange.setBucket_sequence(currentBucketIndex);
+            internalRange.setRow_count(1);
+
+            TScanRange range = new TScanRange();
+            range.setInternal_scan_range(internalRange);
+
+            TScanRangeLocations loc = new TScanRangeLocations();
+            loc.setScan_range(range);
+
+            TScanRangeLocation location = new TScanRangeLocation();
+            ComputeNode node = iterator.next().getValue();
+            location.setBackend_id(node.getId());
+            location.setServer(node.getAddress());
+            loc.addToLocations(location);
+
+            locations.add(loc);
+            currentBucketIndex = (currentBucketIndex + 1) % bucketNum;
+        }
+        return locations;
+    }
+
+    @Test
+    public void testNormalBackendSelectorWithSharedDataWorkerProvider() {
+        HostBlacklist blockList = SimpleScheduler.getHostBlacklist();
+        blockList.hostBlacklist.clear();
+        SystemInfoService sysInfo = GlobalStateMgr.getCurrentState().getNodeMgr().getClusterInfo();
+        List<Long> availList = prepareNodeAliveAndBlock(sysInfo, blockList);
+
+        int bucketNum = 3;
+        OlapScanNode scanNode = newOlapScanNode(1, bucketNum);
+        List<TScanRangeLocations> scanLocations = generateScanRangeLocations(id2AllNodes, 10, bucketNum);
+
+        WorkerProvider provider = newWorkerProvider();
+
+        int nonAvailNum = 0;
+        for (TScanRangeLocations locations : scanLocations) {
+            for (TScanRangeLocation location : locations.getLocations()) {
+                if (!provider.isDataNodeAvailable(location.getBackend_id())) {
+                    ++nonAvailNum;
+                }
+            }
+        }
+        // the scanRangeLocations contains non-avail locations
+        Assert.assertTrue(nonAvailNum > 0);
+
+        { // normal case
+            FragmentScanRangeAssignment assignment = new FragmentScanRangeAssignment();
+            NormalBackendSelector selector =
+                    new NormalBackendSelector(scanNode, scanLocations, assignment, provider, false);
+            // the computation will not fail even though there are non-available locations
+            ExceptionChecker.expectThrowsNoException(selector::computeScanRangeAssignment);
+
+            // check the assignment, should be all in the availList
+            for (long id : assignment.keySet()) {
+                Assert.assertTrue(availList.contains(id));
+            }
+        }
+
+        { // make only one node available, the final assignment will be all on the single available node
+            ComputeNode availNode = id2AllNodes.get(availList.get(0));
+            WorkerProvider provider1 = new DefaultSharedDataWorkerProvider(ImmutableMap.copyOf(id2AllNodes),
+                    ImmutableMap.of(availNode.getId(), availNode));
+
+            FragmentScanRangeAssignment assignment = new FragmentScanRangeAssignment();
+            NormalBackendSelector selector =
+                    new NormalBackendSelector(scanNode, scanLocations, assignment, provider1, false);
+            // the computation will not fail even though there are non-available locations
+            ExceptionChecker.expectThrowsNoException(selector::computeScanRangeAssignment);
+
+            Assert.assertEquals(1, assignment.size());
+            // check the assignment, should be all in the availList
+            for (long id : assignment.keySet()) {
+                Assert.assertEquals(availNode.getId(), id);
+            }
+        }
+
+        { // make no node available. Exception throws
+            WorkerProvider providerNoAvailNode = new DefaultSharedDataWorkerProvider(ImmutableMap.copyOf(id2AllNodes),
+                    ImmutableMap.of());
+            FragmentScanRangeAssignment assignment = new FragmentScanRangeAssignment();
+            NormalBackendSelector selector =
+                    new NormalBackendSelector(scanNode, scanLocations, assignment, providerNoAvailNode, false);
+            Assert.assertThrows(NonRecoverableException.class, selector::computeScanRangeAssignment);
+        }
+    }
+
+    @Test
+    public void testCollocationBackendSelectorWithSharedDataWorkerProvider() {
+        HostBlacklist blockList = SimpleScheduler.getHostBlacklist();
+        blockList.hostBlacklist.clear();
+        SystemInfoService sysInfo = GlobalStateMgr.getCurrentState().getNodeMgr().getClusterInfo();
+        List<Long> availList = prepareNodeAliveAndBlock(sysInfo, blockList);
+
+        int bucketNum = 6;
+        OlapScanNode scanNode = newOlapScanNode(10, bucketNum);
+        final Map<Integer, List<Long>> bucketSeqToBackends = ImmutableMap.of(
+                0, ImmutableList.of(1L),
+                1, ImmutableList.of(2L),
+                2, ImmutableList.of(3L),
+                3, ImmutableList.of(4L),
+                4, ImmutableList.of(5L),
+                5, ImmutableList.of(6L)
+        );
+        scanNode.bucketSeq2locations = genBucketSeq2Locations(bucketSeqToBackends, 3);
+        List<TScanRangeLocations> scanLocations = generateScanRangeLocations(id2AllNodes, 10, bucketNum);
+        WorkerProvider provider = newWorkerProvider();
+
+        int nonAvailNum = 0;
+        for (TScanRangeLocations locations : scanLocations) {
+            for (TScanRangeLocation location : locations.getLocations()) {
+                if (!provider.isDataNodeAvailable(location.getBackend_id())) {
+                    ++nonAvailNum;
+                }
+            }
+        }
+        // the scanRangeLocations contains non-avail locations
+        Assert.assertTrue(nonAvailNum > 0);
+
+        { // normal case
+            FragmentScanRangeAssignment assignment = new FragmentScanRangeAssignment();
+            ColocatedBackendSelector.Assignment colAssignment = new ColocatedBackendSelector.Assignment(scanNode);
+            ColocatedBackendSelector selector =
+                    new ColocatedBackendSelector(scanNode, assignment, colAssignment, false, provider, 1);
+            // the computation will not fail even though there are non-available locations
+            ExceptionChecker.expectThrowsNoException(selector::computeScanRangeAssignment);
+
+            // check the assignment, should be all in the availList
+            for (long id : assignment.keySet()) {
+                Assert.assertTrue(availList.contains(id));
+            }
+        }
+
+        { // make only one node available, the final assignment will be all on the single available node
+            ComputeNode availNode = id2AllNodes.get(availList.get(0));
+            WorkerProvider provider1 = new DefaultSharedDataWorkerProvider(ImmutableMap.copyOf(id2AllNodes),
+                    ImmutableMap.of(availNode.getId(), availNode));
+
+            FragmentScanRangeAssignment assignment = new FragmentScanRangeAssignment();
+            ColocatedBackendSelector.Assignment colAssignment = new ColocatedBackendSelector.Assignment(scanNode);
+            ColocatedBackendSelector selector =
+                    new ColocatedBackendSelector(scanNode, assignment, colAssignment, false, provider1, 1);
+            // the computation will not fail even though there are non-available locations
+            ExceptionChecker.expectThrowsNoException(selector::computeScanRangeAssignment);
+
+            Assert.assertEquals(1, assignment.size());
+            // check the assignment, should be all in the availList
+            for (long id : assignment.keySet()) {
+                Assert.assertEquals(availNode.getId(), id);
+            }
+        }
+
+        { // make no node available. Exception throws
+            WorkerProvider providerNoAvailNode = new DefaultSharedDataWorkerProvider(ImmutableMap.copyOf(id2AllNodes),
+                    ImmutableMap.of());
+            FragmentScanRangeAssignment assignment = new FragmentScanRangeAssignment();
+            ColocatedBackendSelector.Assignment colAssignment = new ColocatedBackendSelector.Assignment(scanNode);
+            ColocatedBackendSelector selector =
+                    new ColocatedBackendSelector(scanNode, assignment, colAssignment, false, providerNoAvailNode, 1);
+            Assert.assertThrows(NonRecoverableException.class, selector::computeScanRangeAssignment);
+        }
+    }
+}

--- a/fe/fe-core/src/test/java/com/starrocks/qe/scheduler/DefaultWorkerProviderTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/qe/scheduler/DefaultWorkerProviderTest.java
@@ -17,12 +17,10 @@ package com.starrocks.qe.scheduler;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
-import com.starrocks.common.Config;
 import com.starrocks.common.Reference;
 import com.starrocks.common.UserException;
 import com.starrocks.qe.SimpleScheduler;
 import com.starrocks.server.GlobalStateMgr;
-import com.starrocks.server.RunMode;
 import com.starrocks.server.WarehouseManager;
 import com.starrocks.system.Backend;
 import com.starrocks.system.ComputeNode;
@@ -32,7 +30,6 @@ import mockit.MockUp;
 import org.junit.Assert;
 import org.junit.Test;
 
-import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.List;
@@ -148,87 +145,6 @@ public class DefaultWorkerProviderTest {
     }
 
     @Test
-    public void testCaptureAvailableWorkersForSharedData() {
-        String prevRunMode = Config.run_mode;
-        try {
-            Config.run_mode = "shared_data";
-            RunMode.detectRunMode();
-
-            long deadBEId = 1L;
-            long deadCNId = 11L;
-            long inBlacklistBEId = 3L;
-            long inBlacklistCNId = 13L;
-            Set<Long> nonAvailableWorkerId = ImmutableSet.of(deadBEId, deadCNId, inBlacklistBEId, inBlacklistCNId);
-            id2Backend.get(deadBEId).setAlive(false);
-            id2ComputeNode.get(deadCNId).setAlive(false);
-            new MockUp<SimpleScheduler>() {
-                @Mock
-                public boolean isInBlocklist(long backendId) {
-                    return backendId == inBlacklistBEId || backendId == inBlacklistCNId;
-                }
-            };
-
-            Reference<Integer> nextComputeNodeIndex = new Reference<>(0);
-            new MockUp<DefaultWorkerProvider>() {
-                @Mock
-                int getNextComputeNodeIndex() {
-                    int next = nextComputeNodeIndex.getRef();
-                    nextComputeNodeIndex.setRef(next + 1);
-                    return next;
-                }
-            };
-
-            new MockUp<WarehouseManager>() {
-                @Mock
-                public ImmutableMap<Long, ComputeNode> getComputeNodesFromWarehouse() {
-                    return id2ComputeNode;
-                }
-
-                @Mock
-                public List<Long> getAllComputeNodeIds(long warehouseId) {
-                    return new ArrayList<>(id2ComputeNode.keySet());
-                }
-            };
-
-            new MockUp<SystemInfoService>() {
-                @Mock
-                public ComputeNode getBackendOrComputeNode(long nodeId) {
-                    return id2ComputeNode.get(nodeId);
-                }
-            };
-
-            DefaultWorkerProvider.Factory workerProviderFactory = new DefaultWorkerProvider.Factory();
-            DefaultWorkerProvider workerProvider;
-            List<Integer> numUsedComputeNodesList = ImmutableList.of(100, 0, -1, 1, 2, 3, 4, 5, 6);
-            for (Integer numUsedComputeNodes : numUsedComputeNodesList) {
-                // Reset nextComputeNodeIndex.
-                nextComputeNodeIndex.setRef(0);
-
-                workerProvider =
-                        workerProviderFactory.captureAvailableWorkers(
-                                GlobalStateMgr.getCurrentState().getNodeMgr().getClusterInfo(), false,
-                                numUsedComputeNodes, WarehouseManager.DEFAULT_WAREHOUSE_ID);
-
-                for (long id = 0; id < 15; id++) {
-                    ComputeNode worker = workerProvider.getWorkerById(id);
-                    ComputeNode backend = workerProvider.getBackend(id);
-                    // SHARED_DATA MODE considers backends and compute nodes the same.
-                    Assert.assertEquals(backend, worker);
-                    if (nonAvailableWorkerId.contains(id) || !id2ComputeNode.containsKey(id)) {
-                        Assert.assertNull(worker);
-                    } else {
-                        Assert.assertNotNull("id=" + id, worker);
-                        Assert.assertEquals(id, worker.getId());
-                    }
-                }
-            }
-        } finally {
-            Config.run_mode = prevRunMode;
-            RunMode.detectRunMode();
-        }
-    }
-
-    @Test
     public void testSelectWorker() throws UserException {
         DefaultWorkerProvider workerProvider =
                 new DefaultWorkerProvider(id2Backend, id2ComputeNode, availableId2Backend, availableId2ComputeNode,
@@ -309,6 +225,8 @@ public class DefaultWorkerProviderTest {
 
     private static <C extends ComputeNode> void testGetBackendHelper(DefaultWorkerProvider workerProvider,
                                                                      Map<Long, C> availableId2Worker) {
+        // not allow using backup node
+        Assert.assertFalse(workerProvider.allowUsingBackupNode());
         for (long id = -1; id < 16; id++) {
             ComputeNode backend = workerProvider.getBackend(id);
             boolean isContained = workerProvider.isDataNodeAvailable(id);
@@ -320,6 +238,8 @@ public class DefaultWorkerProviderTest {
                 Assert.assertEquals(availableId2Worker.get(id), backend);
                 Assert.assertTrue(isContained);
             }
+            // chooseBackupNode always returns -1
+            Assert.assertEquals(-1, workerProvider.selectBackupWorker(id));
         }
     }
 


### PR DESCRIPTION
* Add DefaultSharedDataWorkerProvider module for shared-data worker selection
* allow choosing a backup node when the node in the location info is not available

## Why I'm doing:

## What I'm doing:

Fixes #42233

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [x] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [x] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
