### PR TITLE
[Feature] Insert statement support partial update mode

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/common/ErrorCode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/ErrorCode.java
@@ -234,6 +234,11 @@ public enum ErrorCode {
     ERR_UNKNOWN_PROPERTY(6013, new byte[] {'4', '2', '0', '0', '0'}, "Unknown property %s"),
     ERR_INVALID_PARAMETER(6013, new byte[] {'4', '2', '0', '0', '0'}, "Invalid parameter %s"),
 
+    ERR_MISSING_KEY_COLUMNS(6014, new byte[] {'4', '2', '0', '0', '0'},
+            "missing key columns:%s for primary key table"),
+    ERR_MISSING_DEPENDENCY_FOR_GENERATED_COLUMN(6015, new byte[] {'4', '2', '0', '0', '0'},
+            "missing dependency column for generated column %s"),
+
     /*
      * The following ErrorCode has been reviewed.
      * If you want to add an error code, please add it in the specific

--- a/fe/fe-core/src/main/java/com/starrocks/sql/InsertPlanner.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/InsertPlanner.java
@@ -41,6 +41,8 @@ import com.starrocks.catalog.Table;
 import com.starrocks.catalog.TableFunctionTable;
 import com.starrocks.catalog.Type;
 import com.starrocks.common.Config;
+import com.starrocks.common.ErrorCode;
+import com.starrocks.common.ErrorReport;
 import com.starrocks.common.Pair;
 import com.starrocks.common.UserException;
 import com.starrocks.common.profile.Timer;
@@ -102,6 +104,7 @@ import com.starrocks.sql.optimizer.transformer.RelationTransformer;
 import com.starrocks.sql.optimizer.transformer.SqlToScalarOperatorTranslator;
 import com.starrocks.sql.plan.ExecPlan;
 import com.starrocks.sql.plan.PlanFragmentBuilder;
+import com.starrocks.thrift.TPartialUpdateMode;
 import com.starrocks.thrift.TResultSinkType;
 import org.apache.commons.collections4.CollectionUtils;
 import org.apache.iceberg.NullOrder;
@@ -114,6 +117,7 @@ import org.apache.logging.log4j.Logger;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -132,6 +136,9 @@ public class InsertPlanner {
     private Map<String, Database> dbs;
     private boolean useOptimisticLock;
 
+    private List<Column> outputBaseSchema;
+    private List<Column> outputFullSchema;
+
     private static final Logger LOG = LogManager.getLogger(InsertPlanner.class);
 
     public InsertPlanner() {
@@ -143,10 +150,111 @@ public class InsertPlanner {
         this.useOptimisticLock = optimisticLock;
     }
 
+    private enum GenColumnDependency {
+        NO_DEPENDENCY,
+        NONE_DEPEND_ON_TARGET_COLUMNS,
+        ALL_DEPEND_ON_TARGET_COLUMNS,
+        PARTIALLY_DEPEND_ON_TARGET_COLUMNS
+    }
+
+    private static GenColumnDependency getDependencyType(Column column, Set<String> targetColumns) {
+        List<SlotRef> slots = column.getGeneratedColumnRef();
+        if (slots.isEmpty()) {
+            return GenColumnDependency.NO_DEPENDENCY;
+        }
+        boolean allDependOnTargetColumns = true;
+        boolean noneDependOnTargetColumns = true;
+        for (SlotRef slot : slots) {
+            String originName = slot.getColumnName().toLowerCase();
+            if (targetColumns.contains(originName)) {
+                noneDependOnTargetColumns = false;
+            } else {
+                allDependOnTargetColumns = false;
+            }
+        }
+        if (allDependOnTargetColumns) {
+            return GenColumnDependency.ALL_DEPEND_ON_TARGET_COLUMNS;
+        }
+        if (noneDependOnTargetColumns) {
+            return GenColumnDependency.NONE_DEPEND_ON_TARGET_COLUMNS;
+        }
+        return GenColumnDependency.PARTIALLY_DEPEND_ON_TARGET_COLUMNS;
+    }
+
+    private void inferOutputSchemaForPartialUpdate(InsertStmt insertStmt) {
+        outputBaseSchema = new ArrayList<>();
+        outputFullSchema = new ArrayList<>();
+        Set<String> legalGeneratedColumnDependencies = new HashSet<>();
+        Set<String> outputColumnNames = insertStmt.getTargetColumnNames().stream()
+                .map(String::toLowerCase)
+                .collect(Collectors.toSet());
+        Set<String> baseSchemaNames = insertStmt.getTargetTable().getBaseSchema().stream()
+                .map(Column::getName)
+                .map(String::toLowerCase)
+                .collect(Collectors.toSet());
+        OlapTable targetTable = (OlapTable) insertStmt.getTargetTable();
+        for (Column column : targetTable.getFullSchema()) {
+            String columnName = column.getName().toLowerCase();
+            if (outputColumnNames.contains(columnName)) {
+                if (baseSchemaNames.contains(columnName)) {
+                    outputBaseSchema.add(column);
+                }
+                outputFullSchema.add(column);
+                legalGeneratedColumnDependencies.add(columnName);
+                continue;
+            }
+            if (column.isAutoIncrement()) {
+                if (baseSchemaNames.contains(columnName)) {
+                    outputBaseSchema.add(column);
+                }
+                outputFullSchema.add(column);
+                continue;
+            }
+            if (column.isGeneratedColumn()) {
+                // check if the generated column only depends on the columns in the output schema
+                // if so, add it to the output schema
+                // if is not related to target columns at all, skip it (TODO in future)
+                // else raise error
+                switch (getDependencyType(column, legalGeneratedColumnDependencies)) {
+                    case NO_DEPENDENCY:
+                        // should not happen, just skip
+                        continue;
+                    case ALL_DEPEND_ON_TARGET_COLUMNS:
+                        if (baseSchemaNames.contains(columnName)) {
+                            outputBaseSchema.add(column);
+                        }
+                        outputFullSchema.add(column);
+                        continue;
+                    case NONE_DEPEND_ON_TARGET_COLUMNS: // TODO: handle this case
+                    case PARTIALLY_DEPEND_ON_TARGET_COLUMNS:
+                        ErrorReport.reportSemanticException(ErrorCode.ERR_MISSING_DEPENDENCY_FOR_GENERATED_COLUMN,
+                                column.getName());
+                }
+            }
+            if (column.isNameWithPrefix(SchemaChangeHandler.SHADOW_NAME_PRFIX)) {
+                String originName = Column.removeNamePrefix(column.getName());
+                if (outputColumnNames.contains(originName.toLowerCase())) {
+                    if (baseSchemaNames.contains(column.getName())) {
+                        outputBaseSchema.add(column);
+                    }
+                    outputFullSchema.add(column);
+                }
+                continue;
+            }
+        }
+    }
+
     public ExecPlan plan(InsertStmt insertStmt, ConnectContext session) {
         QueryRelation queryRelation = insertStmt.getQueryStatement().getQueryRelation();
         List<ColumnRefOperator> outputColumns = new ArrayList<>();
         Table targetTable = insertStmt.getTargetTable();
+
+        if (insertStmt.usePartialUpdate()) {
+            inferOutputSchemaForPartialUpdate(insertStmt);
+        } else {
+            outputBaseSchema = targetTable.getBaseSchema();
+            outputFullSchema = targetTable.getFullSchema();
+        }
 
         //1. Process the literal value of the insert values type and cast it into the type of the target table
         if (queryRelation instanceof ValuesRelation) {
@@ -211,7 +319,7 @@ public class InsertPlanner {
 
             List<Pair<Integer, ColumnDict>> globalDicts = Lists.newArrayList();
             long tableId = targetTable.getId();
-            for (Column column : targetTable.getFullSchema()) {
+            for (Column column : outputFullSchema) {
                 SlotDescriptor slotDescriptor = descriptorTable.addSlotDescriptor(tupleDesc);
                 slotDescriptor.setIsMaterialized(true);
                 slotDescriptor.setType(column.getType());
@@ -268,6 +376,9 @@ public class InsertPlanner {
                         olapTable.writeQuorum(),
                         forceReplicatedStorage ? true : olapTable.enableReplicatedStorage(),
                         nullExprInAutoIncrement, enableAutomaticPartition, session.getCurrentWarehouseId());
+                if (insertStmt.usePartialUpdate()) {
+                    ((OlapTableSink) dataSink).setPartialUpdateMode(TPartialUpdateMode.AUTO_MODE);
+                }
                 if (olapTable.getAutomaticBucketSize() > 0) {
                     ((OlapTableSink) dataSink).setAutomaticBucketSize(olapTable.getAutomaticBucketSize());
                 }
@@ -417,16 +528,15 @@ public class InsertPlanner {
     private void castLiteralToTargetColumnsType(InsertStmt insertStatement) {
         Preconditions.checkState(insertStatement.getQueryStatement().getQueryRelation() instanceof ValuesRelation,
                 "must values");
-        List<Column> fullSchema = insertStatement.getTargetTable().getFullSchema();
         ValuesRelation values = (ValuesRelation) insertStatement.getQueryStatement().getQueryRelation();
         RelationFields fields = insertStatement.getQueryStatement().getQueryRelation().getRelationFields();
 
-        for (int columnIdx = 0; columnIdx < insertStatement.getTargetTable().getBaseSchema().size(); ++columnIdx) {
+        for (int columnIdx = 0; columnIdx < outputBaseSchema.size(); ++columnIdx) {
             if (needToSkip(insertStatement, columnIdx)) {
                 continue;
             }
 
-            Column targetColumn = fullSchema.get(columnIdx);
+            Column targetColumn = outputBaseSchema.get(columnIdx);
             if (targetColumn.isGeneratedColumn()) {
                 continue;
             }
@@ -475,15 +585,14 @@ public class InsertPlanner {
 
     private OptExprBuilder fillDefaultValue(LogicalPlan logicalPlan, ColumnRefFactory columnRefFactory,
                                             InsertStmt insertStatement, List<ColumnRefOperator> outputColumns) {
-        List<Column> baseSchema = insertStatement.getTargetTable().getBaseSchema();
         Map<ColumnRefOperator, ScalarOperator> columnRefMap = new HashMap<>();
 
-        for (int columnIdx = 0; columnIdx < baseSchema.size(); ++columnIdx) {
+        for (int columnIdx = 0; columnIdx < outputBaseSchema.size(); ++columnIdx) {
             if (needToSkip(insertStatement, columnIdx)) {
                 continue;
             }
 
-            Column targetColumn = baseSchema.get(columnIdx);
+            Column targetColumn = outputBaseSchema.get(columnIdx);
             if (targetColumn.isGeneratedColumn()) {
                 continue;
             }
@@ -529,12 +638,11 @@ public class InsertPlanner {
     private OptExprBuilder fillGeneratedColumns(ColumnRefFactory columnRefFactory, InsertStmt insertStatement,
                                                 List<ColumnRefOperator> outputColumns, OptExprBuilder root,
                                                 ConnectContext session) {
-        List<Column> fullSchema = insertStatement.getTargetTable().getFullSchema();
-        Set<Column> baseSchema = Sets.newHashSet(insertStatement.getTargetTable().getBaseSchema());
+        Set<Column> baseSchema = Sets.newHashSet(outputBaseSchema);
         Map<ColumnRefOperator, ScalarOperator> columnRefMap = new HashMap<>();
 
-        for (int columnIdx = 0; columnIdx < fullSchema.size(); ++columnIdx) {
-            Column targetColumn = fullSchema.get(columnIdx);
+        for (int columnIdx = 0; columnIdx < outputFullSchema.size(); ++columnIdx) {
+            Column targetColumn = outputFullSchema.get(columnIdx);
 
             if (targetColumn.isGeneratedColumn()) {
                 // If fe restart and Insert INTO is executed, the re-analyze is needed.
@@ -556,10 +664,10 @@ public class InsertPlanner {
                 for (SlotRef slot : slots) {
                     String originName = slot.getColumnName();
 
-                    Optional<Column> optOriginColumn = fullSchema.stream()
+                    Optional<Column> optOriginColumn = outputFullSchema.stream()
                             .filter(c -> c.nameEquals(originName, false)).findFirst();
                     Column originColumn = optOriginColumn.get();
-                    ColumnRefOperator originColRefOp = outputColumns.get(fullSchema.indexOf(originColumn));
+                    ColumnRefOperator originColRefOp = outputColumns.get(outputFullSchema.indexOf(originColumn));
 
                     expressionMapping.put(slot, originColRefOp);
                 }
@@ -571,7 +679,7 @@ public class InsertPlanner {
                         columnRefFactory.create(scalarOperator, scalarOperator.getType(), scalarOperator.isNullable());
                 outputColumns.add(columnRefOperator);
                 columnRefMap.put(columnRefOperator, scalarOperator);
-            } else if (baseSchema.contains(fullSchema.get(columnIdx))) {
+            } else if (baseSchema.contains(outputFullSchema.get(columnIdx))) {
                 ColumnRefOperator columnRefOperator = outputColumns.get(columnIdx);
                 columnRefMap.put(columnRefOperator, columnRefOperator);
             }
@@ -583,12 +691,11 @@ public class InsertPlanner {
     private OptExprBuilder fillShadowColumns(ColumnRefFactory columnRefFactory, InsertStmt insertStatement,
                                              List<ColumnRefOperator> outputColumns, OptExprBuilder root,
                                              ConnectContext session) {
-        Set<Column> baseSchema = Sets.newHashSet(insertStatement.getTargetTable().getBaseSchema());
-        List<Column> fullSchema = insertStatement.getTargetTable().getFullSchema();
+        Set<Column> baseSchema = Sets.newHashSet(outputBaseSchema);
         Map<ColumnRefOperator, ScalarOperator> columnRefMap = new HashMap<>();
 
-        for (int columnIdx = 0; columnIdx < fullSchema.size(); ++columnIdx) {
-            Column targetColumn = fullSchema.get(columnIdx);
+        for (int columnIdx = 0; columnIdx < outputFullSchema.size(); ++columnIdx) {
+            Column targetColumn = outputFullSchema.get(columnIdx);
 
             if (targetColumn.isNameWithPrefix(SchemaChangeHandler.SHADOW_NAME_PRFIX) ||
                     targetColumn.isNameWithPrefix(SchemaChangeHandler.SHADOW_NAME_PRFIX_V1)) {
@@ -597,11 +704,11 @@ public class InsertPlanner {
                 }
 
                 String originName = Column.removeNamePrefix(targetColumn.getName());
-                Optional<Column> optOriginColumn = fullSchema.stream()
+                Optional<Column> optOriginColumn = outputFullSchema.stream()
                         .filter(c -> c.nameEquals(originName, false)).findFirst();
                 Preconditions.checkState(optOriginColumn.isPresent());
                 Column originColumn = optOriginColumn.get();
-                ColumnRefOperator originColRefOp = outputColumns.get(fullSchema.indexOf(originColumn));
+                ColumnRefOperator originColRefOp = outputColumns.get(outputFullSchema.indexOf(originColumn));
 
                 ColumnRefOperator columnRefOperator = columnRefFactory.create(
                         targetColumn.getName(), targetColumn.getType(), targetColumn.isAllowNull());
@@ -653,11 +760,11 @@ public class InsertPlanner {
                 List<SlotRef> slots = targetColumn.getRefColumns();
                 for (SlotRef slot : slots) {
                     String originName = slot.getColumnName();
-                    Optional<Column> optOriginColumn = fullSchema.stream()
+                    Optional<Column> optOriginColumn = outputFullSchema.stream()
                             .filter(c -> c.nameEquals(originName, false)).findFirst();
                     Preconditions.checkState(optOriginColumn.isPresent());
                     Column originColumn = optOriginColumn.get();
-                    ColumnRefOperator originColRefOp = outputColumns.get(fullSchema.indexOf(originColumn));
+                    ColumnRefOperator originColRefOp = outputColumns.get(outputFullSchema.indexOf(originColumn));
                     expressionMapping.put(slot, originColRefOp);
                 }
 
@@ -699,15 +806,14 @@ public class InsertPlanner {
                                                                 InsertStmt insertStatement,
                                                                 List<ColumnRefOperator> outputColumns,
                                                                 OptExprBuilder root) {
-        List<Column> fullSchema = insertStatement.getTargetTable().getFullSchema();
         Map<ColumnRefOperator, ScalarOperator> columnRefMap = new HashMap<>();
         ScalarOperatorRewriter rewriter = new ScalarOperatorRewriter();
         List<ScalarOperatorRewriteRule> rewriteRules = Arrays.asList(new FoldConstantsRule());
-        for (int columnIdx = 0; columnIdx < fullSchema.size(); ++columnIdx) {
-            if (!fullSchema.get(columnIdx).getType().matchesType(outputColumns.get(columnIdx).getType())) {
-                Column c = fullSchema.get(columnIdx);
+        for (int columnIdx = 0; columnIdx < outputFullSchema.size(); ++columnIdx) {
+            if (!outputFullSchema.get(columnIdx).getType().matchesType(outputColumns.get(columnIdx).getType())) {
+                Column c = outputFullSchema.get(columnIdx);
                 ColumnRefOperator k = columnRefFactory.create(c.getName(), c.getType(), c.isAllowNull());
-                ScalarOperator castOperator = new CastOperator(fullSchema.get(columnIdx).getType(),
+                ScalarOperator castOperator = new CastOperator(outputFullSchema.get(columnIdx).getType(),
                         outputColumns.get(columnIdx), true);
                 columnRefMap.put(k, rewriter.rewrite(castOperator, rewriteRules));
                 outputColumns.set(columnIdx, k);

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AlterTableClauseVisitor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AlterTableClauseVisitor.java
@@ -515,7 +515,7 @@ public class AlterTableClauseVisitor implements AstVisitor<Void, ConnectContext>
             }
 
             if (!columnDef.getType().matchesType(expr.getType())) {
-                throw new SemanticException("Illege expression type for Generated Column " +
+                throw new SemanticException("Illegal expression type for Generated Column " +
                         "Column Type: " + columnDef.getType().toString() +
                         ", Expression Type: " + expr.getType().toString());
             }
@@ -629,7 +629,7 @@ public class AlterTableClauseVisitor implements AstVisitor<Void, ConnectContext>
                 }
 
                 if (!colDef.getType().matchesType(expr.getType())) {
-                    throw new SemanticException("Illege expression type for Generated Column " +
+                    throw new SemanticException("Illegal expression type for Generated Column " +
                             "Column Type: " + colDef.getType().toString() +
                             ", Expression Type: " + expr.getType().toString());
                 }
@@ -754,7 +754,7 @@ public class AlterTableClauseVisitor implements AstVisitor<Void, ConnectContext>
             }
 
             if (!columnDef.getType().matchesType(expr.getType())) {
-                throw new SemanticException("Illege expression type for Generated Column " +
+                throw new SemanticException("Illegal expression type for Generated Column " +
                         "Column Type: " + columnDef.getType().toString() +
                         ", Expression Type: " + expr.getType().toString());
             }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/CreateTableAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/CreateTableAnalyzer.java
@@ -497,7 +497,7 @@ public class CreateTableAnalyzer {
                     }
 
                     if (!column.getType().matchesType(expr.getType())) {
-                        throw new SemanticException("Illege expression type for Generated Column " +
+                        throw new SemanticException("Illegal expression type for Generated Column " +
                                 "Column Type: " + column.getType().toString() +
                                 ", Expression Type: " + expr.getType().toString());
                     }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/InsertStmt.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/InsertStmt.java
@@ -66,6 +66,7 @@ public class InsertStmt extends DmlStmt {
     // if targetPartitionNames is not set, add all formal partitions' id of the table into it
     private List<Long> targetPartitionIds = Lists.newArrayList();
     private List<String> targetColumnNames;
+    private boolean usePartialUpdate = false;
     private QueryStatement queryStatement;
     private String label = null;
 
@@ -77,7 +78,6 @@ public class InsertStmt extends DmlStmt {
 
     private Table targetTable;
 
-    private List<Column> targetColumns = Lists.newArrayList();
     private boolean isOverwrite;
     private long overwriteJobId = -1;
 
@@ -235,6 +235,14 @@ public class InsertStmt extends DmlStmt {
         return targetColumnNames;
     }
 
+    public void setUsePartialUpdate() {
+        this.usePartialUpdate = true;
+    }
+
+    public boolean usePartialUpdate() {
+        return this.usePartialUpdate;
+    }
+
     public void setTargetPartitionNames(PartitionNames targetPartitionNames) {
         this.targetPartitionNames = targetPartitionNames;
     }
@@ -245,10 +253,6 @@ public class InsertStmt extends DmlStmt {
 
     public List<Long> getTargetPartitionIds() {
         return targetPartitionIds;
-    }
-
-    public void setTargetColumns(List<Column> targetColumns) {
-        this.targetColumns = targetColumns;
     }
 
     public boolean isSpecifyKeyPartition() {

--- a/fe/fe-core/src/test/java/com/starrocks/catalog/CreateTableTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/CreateTableTest.java
@@ -443,7 +443,7 @@ public class CreateTableTest {
                         + "partition by range(k1) (partition p1 values less than(\"10\") ('wrong_key' = 'value'))\n"
                         + "distributed by hash(k2) buckets 1 properties('replication_num' = '1'); "));
 
-        ExceptionChecker.expectThrowsWithMsg(AnalysisException.class, "Illege expression type for Generated Column "
+        ExceptionChecker.expectThrowsWithMsg(AnalysisException.class, "Illegal expression type for Generated Column "
                         + "Column Type: INT, Expression Type: DOUBLE",
                 () -> createTable("CREATE TABLE test.atbl15 ( id BIGINT NOT NULL,  array_data ARRAY<int> NOT NULL, \n"
                         + "mc INT AS (array_avg(array_data)) ) Primary KEY (id) \n"

--- a/test/sql/test_insert_empty/R/test_insert_partial_update
+++ b/test/sql/test_insert_empty/R/test_insert_partial_update
@@ -1,0 +1,70 @@
+-- name: test_insert_partial_update
+create table test (pk bigint NOT NULL, v0 string not null default 'defaultv0', v1 int not null default '100001')
+primary KEY (pk) DISTRIBUTED BY HASH(pk) BUCKETS 1 PROPERTIES("replication_num" = "1");
+-- result:
+[]
+-- !result
+insert into test values(1, 'v0', 1), (2, 'v2', 2);
+-- result:
+[]
+-- !result
+insert into test values(2, 'v2_2', default);
+-- result:
+[]
+-- !result
+select * from test order by pk;
+-- result:
+1	v0	1
+2	v2_2	100001
+-- !result
+insert into test values(1, 'v0', 1), (2, 'v2', 2);
+-- result:
+[]
+-- !result
+insert into test (pk, v1) values(1, 11);
+-- result:
+[]
+-- !result
+select * from test order by pk;
+-- result:
+1	v0	11
+2	v2	2
+-- !result
+create table test2 (pk bigint NOT NULL, v0 string not null, v1 int not null default '100001')
+primary KEY (pk) DISTRIBUTED BY HASH(pk) BUCKETS 1 PROPERTIES("replication_num" = "1");
+-- result:
+[]
+-- !result
+insert into test2 values(1, 'v0', 1), (2, 'v2', 2);
+-- result:
+[]
+-- !result
+insert into test2 (pk, v1) values(1, 11), (3, 3);
+-- result:
+[]
+-- !result
+select * from test2 order by pk;
+-- result:
+1	v0	11
+2	v2	2
+3		3
+-- !result
+create table test3 (pk bigint NOT NULL, v0 string not null, v1 int not null default '100001', v2 int as cast(v1 + 1 as int))
+primary KEY (pk) DISTRIBUTED BY HASH(pk) BUCKETS 1 PROPERTIES("replication_num" = "1");
+-- result:
+[]
+-- !result
+insert into test3 values(1, 'v0', 1), (2, 'v2', 2);
+-- result:
+[]
+-- !result
+insert into test3 (pk, v1) values(1, 11), (3, 3);
+-- result:
+[]
+-- !result
+select * from test3 order by pk;
+-- result:
+1	v0	11	12
+2	v2	2	3
+3		3	4
+-- !result

--- a/test/sql/test_insert_empty/T/test_insert_partial_update
+++ b/test/sql/test_insert_empty/T/test_insert_partial_update
@@ -1,0 +1,30 @@
+-- name: test_insert_partial_update
+create table test (pk bigint NOT NULL, v0 string not null default 'defaultv0', v1 int not null default '100001')
+primary KEY (pk) DISTRIBUTED BY HASH(pk) BUCKETS 1 PROPERTIES("replication_num" = "1");
+
+-- fill default value
+insert into test values(1, 'v0', 1), (2, 'v2', 2);
+insert into test values(2, 'v2_2', default);
+select * from test order by pk;
+
+-- partial update
+insert into test values(1, 'v0', 1), (2, 'v2', 2);
+insert into test (pk, v1) values(1, 11);
+select * from test order by pk;
+
+-- v0 is not null but does not have default value
+create table test2 (pk bigint NOT NULL, v0 string not null, v1 int not null default '100001')
+primary KEY (pk) DISTRIBUTED BY HASH(pk) BUCKETS 1 PROPERTIES("replication_num" = "1");
+
+-- partial update
+insert into test2 values(1, 'v0', 1), (2, 'v2', 2);
+insert into test2 (pk, v1) values(1, 11), (3, 3);
+select * from test2 order by pk;
+
+-- update with generated column
+create table test3 (pk bigint NOT NULL, v0 string not null, v1 int not null default '100001', v2 int as cast(v1 + 1 as int))
+primary KEY (pk) DISTRIBUTED BY HASH(pk) BUCKETS 1 PROPERTIES("replication_num" = "1");
+
+insert into test3 values(1, 'v0', 1), (2, 'v2', 2);
+insert into test3 (pk, v1) values(1, 11), (3, 3);
+select * from test3 order by pk;

--- a/test/sql/test_materialized_column/R/test_materialized_column
+++ b/test/sql/test_materialized_column/R/test_materialized_column
@@ -7,7 +7,7 @@ USE test_create_table;
 -- !result
 CREATE TABLE t ( id BIGINT NOT NULL,  array_data ARRAY<int> NOT NULL, mc INT AS (array_avg(array_data)) ) Primary KEY (id) DISTRIBUTED BY HASH(id) BUCKETS 7 PROPERTIES("replication_num" = "1", "replicated_storage" = "true", "fast_schema_evolution" = "true");
 -- result:
-E: (1064, 'Getting analyzing error. Detail message: Illege expression type for Generated Column Column Type: INT, Expression Type: DOUBLE.')
+E: (1064, 'Getting analyzing error. Detail message: Illegal expression type for Generated Column Column Type: INT, Expression Type: DOUBLE.')
 -- !result
 CREATE TABLE t ( id BIGINT NOT NULL,  array_data ARRAY<int> NOT NULL, mc DOUBLE NOT NULL AS (array_avg(array_data)) ) Primary KEY (id) DISTRIBUTED BY HASH(id) BUCKETS 7 PROPERTIES("replication_num" = "1", "replicated_storage" = "true", "fast_schema_evolution" = "true");
 -- result:
@@ -304,7 +304,7 @@ SELECT * FROM t ORDER BY id;
 -- !result
 ALTER TABLE t ADD COLUMN mc_3 INT AS (array_avg(array_data));
 -- result:
-E: (1064, 'Getting analyzing error. Detail message: Illege expression type for Generated Column Column Type: INT, Expression Type: DOUBLE.')
+E: (1064, 'Getting analyzing error. Detail message: Illegal expression type for Generated Column Column Type: INT, Expression Type: DOUBLE.')
 -- !result
 ALTER TABLE t ADD COLUMN mc_3 DOUBLE AS NOT NULL (array_avg(array_data));
 -- result:
@@ -347,7 +347,7 @@ SELECT * FROM t ORDER BY id;
 -- !result
 ALTER TABLE t MODIFY COLUMN mc_1 INT AS (array_avg(array_data));
 -- result:
-E: (1064, 'Getting analyzing error. Detail message: Illege expression type for Generated Column Column Type: INT, Expression Type: DOUBLE.')
+E: (1064, 'Getting analyzing error. Detail message: Illegal expression type for Generated Column Column Type: INT, Expression Type: DOUBLE.')
 -- !result
 ALTER TABLE t MODIFY COLUMN mc_1 DOUBLE AS NOT NULL (array_avg(array_data));
 -- result:


### PR DESCRIPTION
## Why I'm doing:

User need a way to do partial update(and full insert with defaults if key doesn't exist) using SQL, like the partial update mode in streamload. Currently, there is no solution.

## What I'm doing:

To support partial update with insert syntax(align with streamload partial update functionality), we could leverage syntax like this:

```sql
INSERT INTO tbl (column_list) SELECT xxx
```

If `tbl` is a primary key table, and `column_list` does not contain all the columns in `tbl`, a partial update will be performed.

Fixes #42648

## What type of PR is this:

- [ ] BugFix
- [x] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [x] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
