### PR TITLE
[Enhancement] support datetime/date with timezone

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/Column.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/Column.java
@@ -38,6 +38,7 @@ import com.google.common.base.Preconditions;
 import com.google.common.base.Strings;
 import com.google.gson.annotations.SerializedName;
 import com.starrocks.alter.SchemaChangeHandler;
+import com.starrocks.analysis.DateLiteral;
 import com.starrocks.analysis.Expr;
 import com.starrocks.analysis.IndexDef;
 import com.starrocks.analysis.NullLiteral;
@@ -194,6 +195,13 @@ public class Column implements Writable, GsonPreProcessable, GsonPostProcessable
         if (defaultValueDef != null) {
             if (defaultValueDef.expr instanceof StringLiteral) {
                 this.defaultValue = ((StringLiteral) defaultValueDef.expr).getValue();
+                if (type == Type.DATETIME || type == Type.DATE) {
+                    try {
+                        defaultValue = ((DateLiteral) (defaultValueDef.expr).uncheckedCastTo(type)).getStringValue();
+                    } catch (Exception e) {
+                        // Other scenarios are processed by the BE.
+                    }
+                }
             } else if (defaultValueDef.expr instanceof NullLiteral) {
                 // for default value is null or default value is not set the defaultExpr = null
                 this.defaultExpr = null;


### PR DESCRIPTION
## Why I'm doing:
starrocks does not support data of type datetime/date with time_zone.
When it appears in the table creation statement as the default value, SR will report an error. However, when it appears in an insert/update statement, the time zone information will be ignored and the truncated data is successfully inserted:

![image](https://github.com/StarRocks/starrocks/assets/79825592/3711c16d-9956-479e-aa84-f13d44a90ea4)

## What I'm doing:
Convert the time based on current timezone：

![image](https://github.com/StarRocks/starrocks/assets/79825592/3e51099c-bd70-4102-9939-c050c1dc422a)

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [x] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
