### PR TITLE
[Enhancement] Add parquet/orc writer metadata with StarRocks version

### DIFF
--- a/be/src/formats/orc/orc_file_writer.cpp
+++ b/be/src/formats/orc/orc_file_writer.cpp
@@ -23,6 +23,7 @@
 #include "formats/orc/utils.h"
 #include "formats/utils.h"
 #include "runtime/current_thread.h"
+#include "util/debug_util.h"
 
 namespace starrocks::formats {
 
@@ -95,6 +96,7 @@ Status ORCFileWriter::init() {
     ASSIGN_OR_RETURN(auto compression, _convert_compression_type(_compression_type));
     options.setCompression(compression);
     _writer = orc::createWriter(*_schema, _output_stream.get(), options);
+    _writer->addUserMetadata(STARROCKS_ORC_WRITER_VERSION_KEY, get_short_version());
     return Status::OK();
 }
 

--- a/be/src/formats/orc/orc_file_writer.h
+++ b/be/src/formats/orc/orc_file_writer.h
@@ -94,6 +94,8 @@ private:
 
     void _write_map_column(orc::ColumnVectorBatch& orc_column, ColumnPtr& column, const TypeDescriptor& type);
 
+    inline static const std::string STARROCKS_ORC_WRITER_VERSION_KEY = "starrocks.writer.version";
+
     const std::string _location;
     std::shared_ptr<OrcOutputStream> _output_stream;
     const std::vector<std::string> _column_names;

--- a/be/src/formats/parquet/parquet_file_writer.cpp
+++ b/be/src/formats/parquet/parquet_file_writer.cpp
@@ -32,11 +32,11 @@
 #include "formats/file_writer.h"
 #include "formats/utils.h"
 #include "runtime/exec_env.h"
+#include "util/debug_util.h"
 #include "util/defer_op.h"
 #include "util/priority_thread_pool.hpp"
 #include "util/runtime_profile.h"
 #include "util/slice.h"
-#include "util/debug_util.h"
 
 namespace starrocks::formats {
 

--- a/be/src/formats/parquet/parquet_file_writer.cpp
+++ b/be/src/formats/parquet/parquet_file_writer.cpp
@@ -36,6 +36,7 @@
 #include "util/priority_thread_pool.hpp"
 #include "util/runtime_profile.h"
 #include "util/slice.h"
+#include "util/debug_util.h"
 
 namespace starrocks::formats {
 
@@ -477,6 +478,7 @@ Status ParquetFileWriter::init() {
                           ->write_batch_size(_writer_options->write_batch_size)
                           ->dictionary_pagesize_limit(_writer_options->dictionary_pagesize)
                           ->compression(compression)
+                          ->created_by(fmt::format("{} starrocks-{}", CREATED_BY_VERSION, get_short_version()))
                           ->build();
 
     _writer = ::parquet::ParquetFileWriter::Open(_output_stream, _schema, _properties);


### PR DESCRIPTION
## Why I'm doing:

Add extra information of starrocks version in the file metadata.

This could help us to trace relevant writer issues.

## What I'm doing:

Parquet
<img width="1120" alt="image" src="https://github.com/StarRocks/starrocks/assets/16740944/98c153d3-90d8-4ad5-be05-43b308e720e6">

ORC
<img width="1081" alt="image" src="https://github.com/StarRocks/starrocks/assets/16740944/821fb68c-91d9-4073-b7bb-664ed63fe329">

<img width="477" alt="image" src="https://github.com/StarRocks/starrocks/assets/16740944/21f84134-363b-43d0-98e0-d83aa90bf645">



## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [x] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
