### PR TITLE
[BugFix] Fix min/max nullable column meta scan ASAN crash

### DIFF
--- a/be/src/storage/meta_reader.cpp
+++ b/be/src/storage/meta_reader.cpp
@@ -334,15 +334,19 @@ Status SegmentMetaCollecter::__collect_max_or_min(ColumnId cid, Column* column, 
     TypeInfoPtr type_info = get_type_info(delegate_type(type));
     if constexpr (!is_max) {
         Datum min;
-        if (!segment_zone_map_pb->has_null()) {
+        if (segment_zone_map_pb->has_not_null()) {
             RETURN_IF_ERROR(datum_from_string(type_info.get(), &min, segment_zone_map_pb->min(), nullptr));
             column->append_datum(min);
+        } else {
+            column->append_default();
         }
     } else if constexpr (is_max) {
         Datum max;
         if (segment_zone_map_pb->has_not_null()) {
             RETURN_IF_ERROR(datum_from_string(type_info.get(), &max, segment_zone_map_pb->max(), nullptr));
             column->append_datum(max);
+        } else {
+            column->append_default();
         }
     }
     return Status::OK();

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/PushDownAggToMetaScanRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/PushDownAggToMetaScanRule.java
@@ -68,6 +68,9 @@ public class PushDownAggToMetaScanRule extends TransformationRule {
 
         for (CallOperator aggCall : agg.getAggregations().values()) {
             String aggFuncName = aggCall.getFnName();
+            if (aggFuncName.equalsIgnoreCase(FunctionSet.FLAT_JSON_META)) {
+                return false;
+            }
             if (!aggFuncName.equalsIgnoreCase(FunctionSet.DICT_MERGE)
                     && !aggFuncName.equalsIgnoreCase(FunctionSet.MAX)
                     && !aggFuncName.equalsIgnoreCase(FunctionSet.MIN)

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/PushDownFlatJsonMetaToMetaScanRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/PushDownFlatJsonMetaToMetaScanRule.java
@@ -20,6 +20,8 @@ import com.google.common.collect.Maps;
 import com.starrocks.catalog.Column;
 import com.starrocks.catalog.FunctionSet;
 import com.starrocks.sql.analyzer.SemanticException;
+import com.starrocks.sql.common.ErrorType;
+import com.starrocks.sql.common.StarRocksPlannerException;
 import com.starrocks.sql.optimizer.OptExpression;
 import com.starrocks.sql.optimizer.OptimizerContext;
 import com.starrocks.sql.optimizer.operator.OperatorType;
@@ -64,17 +66,18 @@ public class PushDownFlatJsonMetaToMetaScanRule extends TransformationRule {
         }
 
         if (CollectionUtils.isNotEmpty(agg.getGroupingKeys())) {
-            throw new SemanticException("flat_json_meta don't support group-by");
+            throw new StarRocksPlannerException("flat_json_meta don't support group-by", ErrorType.UNSUPPORTED);
+
         }
 
         LogicalProjectOperator projectOperator = (LogicalProjectOperator) input.inputAt(0).getOp();
         if (projectOperator.getColumnRefMap().entrySet().stream().anyMatch(e -> !e.getKey().equals(e.getValue()))) {
-            throw new SemanticException("flat_json_meta don't support complex project");
+            throw new StarRocksPlannerException("flat_json_meta don't support complex project", ErrorType.UNSUPPORTED);
         }
 
         LogicalMetaScanOperator metaScan = (LogicalMetaScanOperator) input.inputAt(0).inputAt(0).getOp();
         if (!metaScan.getAggColumnIdToNames().isEmpty()) {
-            throw new SemanticException("flat_json_meta don't support complex meta");
+            throw new StarRocksPlannerException("flat_json_meta don't support complex meta", ErrorType.UNSUPPORTED);
         }
         return true;
     }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/AggregateTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/AggregateTest.java
@@ -20,6 +20,7 @@ import com.starrocks.planner.OlapScanNode;
 import com.starrocks.planner.PlanFragment;
 import com.starrocks.planner.ScanNode;
 import com.starrocks.sql.analyzer.SemanticException;
+import com.starrocks.sql.common.StarRocksPlannerException;
 import com.starrocks.system.BackendResourceStat;
 import com.starrocks.thrift.TExplainLevel;
 import com.starrocks.utframe.UtFrameUtils;
@@ -2830,5 +2831,23 @@ public class AggregateTest extends PlanTestBase {
                 "  |  output: sum(1: v1)\n" +
                 "  |  group by: 2: v2, 3: v3\n" +
                 "  |  having: 2: v2 + 2 + 5: sum > 0");
+    }
+
+    @Test(expected = StarRocksPlannerException.class)
+    public void testMetaScanLiteral() throws Exception {
+        String sql = "select count(*) from t0 [_META_]";
+        String plan = getFragmentPlan(sql);
+    }
+
+    @Test(expected = StarRocksPlannerException.class)
+    public void testMetaScanLiteral2() throws Exception {
+        String sql = "select count(1) from t0 [_META_]";
+        String plan = getFragmentPlan(sql);
+    }
+
+    @Test(expected = StarRocksPlannerException.class)
+    public void testMetaScanUnsupportFunction() throws Exception {
+        String sql = "select sum(v1) from t0 [_META_]";
+        String plan = getFragmentPlan(sql);
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/JsonTypeTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/JsonTypeTest.java
@@ -18,6 +18,7 @@ package com.starrocks.sql.plan;
 import com.starrocks.catalog.Type;
 import com.starrocks.common.ExceptionChecker;
 import com.starrocks.sql.analyzer.SemanticException;
+import com.starrocks.sql.common.StarRocksPlannerException;
 import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -251,13 +252,13 @@ public class JsonTypeTest extends PlanTestBase {
         plan = getFragmentPlan(sql);
         assertContains(plan, "array_join(14: flat_json_meta, ', ')");
 
-        Assert.assertThrows(SemanticException.class, () -> getFragmentPlan(
+        Assert.assertThrows(StarRocksPlannerException.class, () -> getFragmentPlan(
                 "select flat_json_meta(12) from tjson_test[_META_]"));
 
-        Assert.assertThrows(SemanticException.class, () -> getFragmentPlan(
+        Assert.assertThrows(StarRocksPlannerException.class, () -> getFragmentPlan(
                 "select flat_json_meta(v_json) from tjson_test[_META_] group by v_INT"));
 
-        Assert.assertThrows(SemanticException.class, () -> getFragmentPlan(
+        Assert.assertThrows(StarRocksPlannerException.class, () -> getFragmentPlan(
                 "select flat_json_meta(json_query(v_json, '$.v1')) from tjson_test[_META_]"));
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/LowCardinalityTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/LowCardinalityTest.java
@@ -1540,36 +1540,6 @@ public class LowCardinalityTest extends PlanTestBase {
     }
 
     @Test
-    public void testMetaScan4() throws Exception {
-        String sql = "select sum(t1c), min(t1d), t1a from test_all_type [_META_]";
-        String plan = getFragmentPlan(sql);
-        assertContains(plan, "2:AGGREGATE (update serialize)\n" +
-                "  |  output: sum(3: t1c), min(4: t1d), any_value(1: t1a)\n" +
-                "  |  group by: \n" +
-                "  |  \n" +
-                "  1:Project\n" +
-                "  |  <slot 1> : t1a\n" +
-                "  |  <slot 3> : t1c\n" +
-                "  |  <slot 4> : t1d\n" +
-                "  |  \n" +
-                "  0:MetaScan\n" +
-                "     Table: test_all_type");
-        sql = "select sum(t1c) from test_all_type [_META_] group by t1a";
-        plan = getFragmentPlan(sql);
-        assertContains(plan, "2:AGGREGATE (update serialize)\n" +
-                "  |  STREAMING\n" +
-                "  |  output: sum(3: t1c)\n" +
-                "  |  group by: 1: t1a\n" +
-                "  |  \n" +
-                "  1:Project\n" +
-                "  |  <slot 1> : t1a\n" +
-                "  |  <slot 3> : t1c\n" +
-                "  |  \n" +
-                "  0:MetaScan\n" +
-                "     Table: test_all_type");
-    }
-
-    @Test
     public void testHasGlobalDictButNotFound() throws Exception {
         IDictManager dictManager = IDictManager.getInstance();
 

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/LowCardinalityTest2.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/LowCardinalityTest2.java
@@ -1671,36 +1671,6 @@ public class LowCardinalityTest2 extends PlanTestBase {
     }
 
     @Test
-    public void testMetaScan4() throws Exception {
-        String sql = "select sum(t1c), min(t1d), t1a from test_all_type [_META_]";
-        String plan = getFragmentPlan(sql);
-        assertContains(plan, "2:AGGREGATE (update serialize)\n" +
-                "  |  output: sum(3: t1c), min(4: t1d), any_value(1: t1a)\n" +
-                "  |  group by: \n" +
-                "  |  \n" +
-                "  1:Project\n" +
-                "  |  <slot 1> : t1a\n" +
-                "  |  <slot 3> : t1c\n" +
-                "  |  <slot 4> : t1d\n" +
-                "  |  \n" +
-                "  0:MetaScan\n" +
-                "     Table: test_all_type");
-        sql = "select sum(t1c) from test_all_type [_META_] group by t1a";
-        plan = getFragmentPlan(sql);
-        assertContains(plan, "2:AGGREGATE (update serialize)\n" +
-                "  |  STREAMING\n" +
-                "  |  output: sum(3: t1c)\n" +
-                "  |  group by: 1: t1a\n" +
-                "  |  \n" +
-                "  1:Project\n" +
-                "  |  <slot 1> : t1a\n" +
-                "  |  <slot 3> : t1c\n" +
-                "  |  \n" +
-                "  0:MetaScan\n" +
-                "     Table: test_all_type");
-    }
-
-    @Test
     public void testHasGlobalDictButNotFound() throws Exception {
         IDictManager dictManager = IDictManager.getInstance();
 

--- a/test/sql/test_agg/R/test_meta_scan_agg
+++ b/test/sql/test_agg/R/test_meta_scan_agg
@@ -1,0 +1,115 @@
+-- name: test_meta_scan_agg
+CREATE TABLE `t0` (
+  `c0` int(11) NULL COMMENT "",
+  `c1` varchar(20) NULL COMMENT "",
+  `c2` varchar(200) NULL COMMENT "",
+  `c3` int(11) NULL COMMENT ""
+) ENGINE=OLAP
+DUPLICATE KEY(`c0`, `c1`)
+COMMENT "OLAP"
+DISTRIBUTED BY HASH(`c0`, `c1`) BUCKETS 48
+PROPERTIES (
+"replication_num" = "1",
+"in_memory" = "false",
+"storage_format" = "DEFAULT",
+"enable_persistent_index" = "false",
+"replicated_storage" = "true",
+"compression" = "LZ4"
+);
+-- result:
+-- !result
+CREATE TABLE `t1` (
+  `c0` int(11) NOT NULL COMMENT "",
+  `c1` varchar(20) NOT NULL COMMENT "",
+  `c2` varchar(200) NOT NULL COMMENT "",
+  `c3` int(11) NOT NULL COMMENT ""
+) ENGINE=OLAP
+DUPLICATE KEY(`c0`, `c1`)
+COMMENT "OLAP"
+DISTRIBUTED BY HASH(`c0`, `c1`) BUCKETS 48
+PROPERTIES (
+"replication_num" = "1",
+"in_memory" = "false",
+"storage_format" = "DEFAULT",
+"enable_persistent_index" = "false",
+"replicated_storage" = "true",
+"compression" = "LZ4"
+);
+-- result:
+-- !result
+insert into t0 SELECT generate_series, generate_series, generate_series, generate_series FROM TABLE(generate_series(1,  40960));
+-- result:
+-- !result
+insert into t1 SELECT * FROM t0;
+-- result:
+-- !result
+insert into t0 values (null,null,null,null);
+-- result:
+-- !result
+select count(c0) from t0;
+-- result:
+40960
+-- !result
+select count(c0) from t0 [_META_];
+-- result:
+40961
+-- !result
+select count(c0) from t1;
+-- result:
+40960
+-- !result
+select count(c0) from t1 [_META_];
+-- result:
+40960
+-- !result
+select count(c0),count(1),count('literal'),count(c0),max(c0),min(c0) from t0;
+-- result:
+40960	40961	40961	40960	40960	1
+-- !result
+select count(c0),count(1),count('literal'),count(c0),max(c0),min(c0) from t0 [_META_];
+-- result:
+40961	40961	40961	40961	40960	1
+-- !result
+select count(1) from t0 [_META_];
+-- result:
+E: (1064, 'unsupported meta scan')
+-- !result
+select count('literal') from t0 [_META_];
+-- result:
+E: (1064, 'unsupported meta scan')
+-- !result
+select count('literal'), count(1) from t0 [_META_];
+-- result:
+E: (1064, 'unsupported meta scan')
+-- !result
+select sum(null) from t0 [_META_];
+-- result:
+E: (1064, 'unsupported meta scan')
+-- !result
+set enable_rewrite_simple_agg_to_meta_scan = true;
+-- result:
+-- !result
+select count(*),count(1),count('literal'),count(c0),max(c0),min(c0) from t1;
+-- result:
+40960	40960	40960	40960	40960	1
+-- !result
+select count(c0) from t1;
+-- result:
+40960
+-- !result
+select count(1) from t1;
+-- result:
+40960
+-- !result
+select count('literal') from t1;
+-- result:
+40960
+-- !result
+select count('literal'), count(1) from t1;
+-- result:
+40960	40960
+-- !result
+select sum(null) from t1;
+-- result:
+None
+-- !result

--- a/test/sql/test_agg/T/test_meta_scan_agg
+++ b/test/sql/test_agg/T/test_meta_scan_agg
@@ -1,0 +1,62 @@
+-- name: test_meta_scan_agg
+
+CREATE TABLE `t0` (
+  `c0` int(11) NULL COMMENT "",
+  `c1` varchar(20) NULL COMMENT "",
+  `c2` varchar(200) NULL COMMENT "",
+  `c3` int(11) NULL COMMENT ""
+) ENGINE=OLAP
+DUPLICATE KEY(`c0`, `c1`)
+COMMENT "OLAP"
+DISTRIBUTED BY HASH(`c0`, `c1`) BUCKETS 48
+PROPERTIES (
+"replication_num" = "1",
+"in_memory" = "false",
+"storage_format" = "DEFAULT",
+"enable_persistent_index" = "false",
+"replicated_storage" = "true",
+"compression" = "LZ4"
+);
+
+CREATE TABLE `t1` (
+  `c0` int(11) NOT NULL COMMENT "",
+  `c1` varchar(20) NOT NULL COMMENT "",
+  `c2` varchar(200) NOT NULL COMMENT "",
+  `c3` int(11) NOT NULL COMMENT ""
+) ENGINE=OLAP
+DUPLICATE KEY(`c0`, `c1`)
+COMMENT "OLAP"
+DISTRIBUTED BY HASH(`c0`, `c1`) BUCKETS 48
+PROPERTIES (
+"replication_num" = "1",
+"in_memory" = "false",
+"storage_format" = "DEFAULT",
+"enable_persistent_index" = "false",
+"replicated_storage" = "true",
+"compression" = "LZ4"
+);
+
+insert into t0 SELECT generate_series, generate_series, generate_series, generate_series FROM TABLE(generate_series(1,  40960));
+insert into t1 SELECT * FROM t0;
+insert into t0 values (null,null,null,null);
+
+select count(c0) from t0;
+select count(c0) from t0 [_META_];
+select count(c0) from t1;
+select count(c0) from t1 [_META_];
+
+select count(c0),count(1),count('literal'),count(c0),max(c0),min(c0) from t0;
+select count(c0),count(1),count('literal'),count(c0),max(c0),min(c0) from t0 [_META_];
+select count(1) from t0 [_META_];
+select count('literal') from t0 [_META_];
+select count('literal'), count(1) from t0 [_META_];
+select sum(null) from t0 [_META_];
+
+set enable_rewrite_simple_agg_to_meta_scan = true;
+select count(*),count(1),count('literal'),count(c0),max(c0),min(c0) from t1;
+select count(c0) from t1;
+select count(1) from t1;
+select count('literal') from t1;
+select count('literal'), count(1) from t1;
+select sum(null) from t1;
+


### PR DESCRIPTION
### ## Why I'm doing:
```
CREATE TABLE `t0` (
  `c0` int(11) NULL COMMENT "",
  `c1` varchar(20) NULL COMMENT "",
  `c2` varchar(200) NULL COMMENT "",
  `c3` int(11) NULL COMMENT ""
) ENGINE=OLAP
DUPLICATE KEY(`c0`, `c1`)
COMMENT "OLAP"
DISTRIBUTED BY HASH(`c0`, `c1`) BUCKETS 48
PROPERTIES (
"replication_num" = "1",
"in_memory" = "false",
"storage_format" = "DEFAULT",
"enable_persistent_index" = "false",
"replicated_storage" = "true",
"compression" = "LZ4"
);
insert into t0 SELECT generate_series, generate_series, generate_series, generate_series FROM TABLE(generate_series(1,  40960));
insert into t1 SELECT * FROM t0;
insert into t0 values (null,null,null,null);
```

```
select count(*),count(1),count('literal'),count(c0),max(c0),min(c0) from t0;
```
```
    @         0x10a7f8ce starrocks::failure_function()
    @         0x1e2b8b51 google::LogMessage::Fail()
    @         0x1e2bb1af google::LogMessage::SendToLog()
    @         0x1e2b8690 google::LogMessage::Flush()
    @         0x1e2bb81d google::LogMessageFatal::~LogMessageFatal()
    @         0x10bc0da0 starrocks::Chunk::check_or_die()
    @         0x1b2e7e63 starrocks::OlapMetaReader::do_get_next()
    @         0x11d52d75 starrocks::OlapMetaScanner::get_chunk()
    @         0x13252c89 starrocks::pipeline::MetaChunkSource::_read_chunk()
    @         0x13151f4a starrocks::pipeline::ChunkSource::buffer_next_batch_chunks_blocking()
    @         0x131a0616 _ZZN9starrocks8pipeline12ScanOperator18_trigger_next_scanEPNS_12RuntimeStateEiENKUlRT_E_clINS_9workgroup12YieldContextEEEDaS5_
    @         0x131a72dd _ZSt13__invoke_implIvRZN9starrocks8pipeline12ScanOperator18_trigger_next_scanEPNS0_12RuntimeStateEiEUlRT_E_JRNS0_9workgroup12YieldContextEEES5_St14__invoke_otherOT0_DpOT1_
    @         0x131a7162 _ZSt10__invoke_rIvRZN9starrocks8pipeline12ScanOperator18_trigger_next_scanEPNS0_12RuntimeStateEiEUlRT_E_JRNS0_9workgroup12YieldContextEEENSt9enable_ifIX16is_invocable_r_vIS5_T0_DpT1_EES5_E4typeEOSD_DpOSE_
    @         0x131a6c91 _ZNSt17_Function_handlerIFvRN9starrocks9workgroup12YieldContextEEZNS0_8pipeline12ScanOperator18_trigger_next_scanEPNS0_12RuntimeStateEiEUlRT_E_E9_M_invokeERKSt9_Any_dataS3_
    @         0x13738d09 std::function<>::operator()()
    @         0x13737ebb starrocks::workgroup::ScanTask::run()
    @         0x138a8ac4 starrocks::workgroup::ScanExecutor::worker_thread()
    @         0x138a8118 _ZZN9starrocks9workgroup12ScanExecutor10initializeEiENKUlvE_clEv
    @         0x138aa77a _ZSt13__invoke_implIvRZN9starrocks9workgroup12ScanExecutor10initializeEiEUlvE_JEET_St14__invoke_otherOT0_DpOT1_
    @         0x138aa381 _ZSt10__invoke_rIvRZN9starrocks9workgroup12ScanExecutor10initializeEiEUlvE_JEENSt9enable_ifIX16is_invocable_r_vIT_T0_DpT1_EES6_E4typeEOS7_DpOS8_
    @         0x138a9ccb _ZNSt17_Function_handlerIFvvEZN9starrocks9workgroup12ScanExecutor10initializeEiEUlvE_E9_M_invokeERKSt9_Any_data
    @         0x1095686e std::function<>::operator()()
    @         0x1c59a9c2 starrocks::FunctionRunnable::run()
    @         0x1c596d64 starrocks::ThreadPool::dispatch_thread()
    @         0x1c5b5ed0 std::__invoke_impl<>()
    @         0x1c5b5971 std::__invoke<>()
```

## What I'm doing:

call append_default if zonemap page only have null vallues

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [x] 3.2
  - [x] 3.1
  - [ ] 3.0
  - [ ] 2.5
