### PR TITLE
[Feature] Support using LakePersistentIndex in cloud native table

### DIFF
--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -980,6 +980,7 @@ CONF_mInt64(lake_pk_compaction_max_input_rowsets, "1000");
 CONF_mInt64(lake_pk_compaction_min_input_segments, "5");
 // Used for control memory usage of update state cache and compaction state cache
 CONF_mInt32(lake_pk_preload_memory_limit_percent, "30");
+CONF_mInt32(lake_pk_index_sst_max_compaction_versions, "5");
 
 CONF_mBool(dependency_librdkafka_debug_enable, "false");
 

--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -980,6 +980,7 @@ CONF_mInt64(lake_pk_compaction_max_input_rowsets, "1000");
 CONF_mInt64(lake_pk_compaction_min_input_segments, "5");
 // Used for control memory usage of update state cache and compaction state cache
 CONF_mInt32(lake_pk_preload_memory_limit_percent, "30");
+CONF_mInt32(lake_pk_index_sst_min_compaction_versions, "2");
 CONF_mInt32(lake_pk_index_sst_max_compaction_versions, "5");
 
 CONF_mBool(dependency_librdkafka_debug_enable, "false");

--- a/be/src/storage/lake/compaction_task.cpp
+++ b/be/src/storage/lake/compaction_task.cpp
@@ -16,6 +16,7 @@
 
 #include "runtime/exec_env.h"
 #include "storage/lake/tablet.h"
+#include "storage/lake/update_manager.h"
 
 namespace starrocks::lake {
 
@@ -28,5 +29,17 @@ CompactionTask::CompactionTask(VersionedTablet tablet, std::vector<std::shared_p
                                                     "Compaction-" + std::to_string(_tablet.metadata()->id()),
                                                     GlobalEnv::GetInstance()->compaction_mem_tracker())),
           _context(context) {}
+
+Status CompactionTask::execute_index_major_compaction(std::shared_ptr<TxnLogPB>& txn_log) {
+    if (_tablet.get_schema()->keys_type() == KeysType::PRIMARY_KEYS) {
+        auto metadata = _tablet.metadata();
+        if (metadata->enable_persistent_index() &&
+            metadata->persistent_index_type() == PersistentIndexTypePB::CLOUD_NATIVE) {
+            return _tablet.tablet_manager()->update_mgr()->execute_index_major_compaction(_tablet.metadata()->id(),
+                                                                                          *metadata, txn_log);
+        }
+    }
+    return Status::OK();
+}
 
 } // namespace starrocks::lake

--- a/be/src/storage/lake/compaction_task.cpp
+++ b/be/src/storage/lake/compaction_task.cpp
@@ -30,7 +30,7 @@ CompactionTask::CompactionTask(VersionedTablet tablet, std::vector<std::shared_p
                                                     GlobalEnv::GetInstance()->compaction_mem_tracker())),
           _context(context) {}
 
-Status CompactionTask::execute_index_major_compaction(std::shared_ptr<TxnLogPB>& txn_log) {
+Status CompactionTask::execute_index_major_compaction(TxnLogPB* txn_log) {
     if (_tablet.get_schema()->keys_type() == KeysType::PRIMARY_KEYS) {
         auto metadata = _tablet.metadata();
         if (metadata->enable_persistent_index() &&

--- a/be/src/storage/lake/compaction_task.h
+++ b/be/src/storage/lake/compaction_task.h
@@ -26,6 +26,7 @@
 namespace starrocks::lake {
 
 class Rowset;
+class TxnLogPB;
 
 class CompactionTask {
 public:
@@ -38,6 +39,8 @@ public:
     virtual ~CompactionTask() = default;
 
     virtual Status execute(CancelFunc cancel_func, ThreadPool* flush_pool = nullptr) = 0;
+
+    Status execute_index_major_compaction(std::shared_ptr<TxnLogPB>& txn_log);
 
     inline static const CancelFunc kNoCancelFn = []() { return false; };
     inline static const CancelFunc kCancelledFn = []() { return true; };

--- a/be/src/storage/lake/compaction_task.h
+++ b/be/src/storage/lake/compaction_task.h
@@ -40,7 +40,7 @@ public:
 
     virtual Status execute(CancelFunc cancel_func, ThreadPool* flush_pool = nullptr) = 0;
 
-    Status execute_index_major_compaction(std::shared_ptr<TxnLogPB>& txn_log);
+    Status execute_index_major_compaction(TxnLogPB* txn_log);
 
     inline static const CancelFunc kNoCancelFn = []() { return false; };
     inline static const CancelFunc kCancelledFn = []() { return true; };

--- a/be/src/storage/lake/horizontal_compaction_task.cpp
+++ b/be/src/storage/lake/horizontal_compaction_task.cpp
@@ -116,6 +116,7 @@ Status HorizontalCompactionTask::execute(CancelFunc cancel_func, ThreadPool* flu
     op_compaction->mutable_output_rowset()->set_num_rows(writer->num_rows());
     op_compaction->mutable_output_rowset()->set_data_size(writer->data_size());
     op_compaction->mutable_output_rowset()->set_overlapped(false);
+    execute_index_major_compaction(txn_log);
     RETURN_IF_ERROR(_tablet.tablet_manager()->put_txn_log(txn_log));
     if (tablet_schema->keys_type() == KeysType::PRIMARY_KEYS) {
         // preload primary key table's compaction state

--- a/be/src/storage/lake/horizontal_compaction_task.cpp
+++ b/be/src/storage/lake/horizontal_compaction_task.cpp
@@ -116,7 +116,7 @@ Status HorizontalCompactionTask::execute(CancelFunc cancel_func, ThreadPool* flu
     op_compaction->mutable_output_rowset()->set_num_rows(writer->num_rows());
     op_compaction->mutable_output_rowset()->set_data_size(writer->data_size());
     op_compaction->mutable_output_rowset()->set_overlapped(false);
-    execute_index_major_compaction(txn_log);
+    RETURN_IF_ERROR(execute_index_major_compaction(txn_log));
     RETURN_IF_ERROR(_tablet.tablet_manager()->put_txn_log(txn_log));
     if (tablet_schema->keys_type() == KeysType::PRIMARY_KEYS) {
         // preload primary key table's compaction state

--- a/be/src/storage/lake/horizontal_compaction_task.cpp
+++ b/be/src/storage/lake/horizontal_compaction_task.cpp
@@ -116,7 +116,7 @@ Status HorizontalCompactionTask::execute(CancelFunc cancel_func, ThreadPool* flu
     op_compaction->mutable_output_rowset()->set_num_rows(writer->num_rows());
     op_compaction->mutable_output_rowset()->set_data_size(writer->data_size());
     op_compaction->mutable_output_rowset()->set_overlapped(false);
-    RETURN_IF_ERROR(execute_index_major_compaction(txn_log));
+    RETURN_IF_ERROR(execute_index_major_compaction(txn_log.get()));
     RETURN_IF_ERROR(_tablet.tablet_manager()->put_txn_log(txn_log));
     if (tablet_schema->keys_type() == KeysType::PRIMARY_KEYS) {
         // preload primary key table's compaction state

--- a/be/src/storage/lake/lake_persistent_index.cpp
+++ b/be/src/storage/lake/lake_persistent_index.cpp
@@ -312,6 +312,9 @@ Status LakePersistentIndex::apply_opcompaction(const TxnLogPB_OpCompaction& op_c
         }
     }
     _sstables.insert(_sstables.begin(), std::move(sstable));
+    if (_sstables.size() >= 2) {
+        DCHECK(_sstables[0]->sstable_pb().version() <= _sstables[1]->sstable_pb().version());
+    }
     return Status::OK();
 }
 

--- a/be/src/storage/lake/lake_persistent_index.h
+++ b/be/src/storage/lake/lake_persistent_index.h
@@ -145,6 +145,7 @@ private:
     int64_t _tablet_id{0};
     // The size of sstables is not expected to be too large.
     // In major compaction, some sstables will be picked to be merged into one.
+    // sstables are ordered with the smaller version on the left.
     std::vector<std::unique_ptr<PersistentIndexSstable>> _sstables;
 };
 

--- a/be/src/storage/lake/lake_persistent_index.h
+++ b/be/src/storage/lake/lake_persistent_index.h
@@ -43,10 +43,10 @@ public:
 
     Status merge(const std::string& key, const std::string& value);
 
-    void finish() { build_index_value_vers(); }
+    void finish() { flush(); }
 
 private:
-    void build_index_value_vers();
+    void flush();
 
 private:
     std::string _key;
@@ -103,7 +103,7 @@ public:
 
     Status minor_compact();
 
-    Status major_compact(int64_t min_retain_version, std::shared_ptr<TxnLogPB>& txn_log);
+    Status major_compact(int64_t min_retain_version, TxnLogPB* txn_log);
 
     Status apply_opcompaction(const TxnLogPB_OpCompaction& op_compaction);
 

--- a/be/src/storage/lake/lake_primary_index.cpp
+++ b/be/src/storage/lake/lake_primary_index.cpp
@@ -222,7 +222,7 @@ Status LakePrimaryIndex::major_compact(const TabletMetadata& metadata, std::shar
 
     auto* lake_persistent_index = dynamic_cast<LakePersistentIndex*>(_persistent_index.get());
     if (lake_persistent_index != nullptr) {
-        return lake_persistent_index->major_compact(0, txn_log);
+        return lake_persistent_index->major_compact(0 /** min_retain_version **/, txn_log);
     } else {
         return Status::InternalError("Persistent index is not a LakePersistentIndex.");
     }

--- a/be/src/storage/lake/lake_primary_index.cpp
+++ b/be/src/storage/lake/lake_primary_index.cpp
@@ -114,7 +114,8 @@ Status LakePrimaryIndex::_do_lake_load(TabletManager* tablet_mgr, const TabletMe
             return Status::OK();
         }
         default:
-            return Status::InternalError("Unsupported lake_persistent_index_type");
+            return Status::InternalError("Unsupported lake_persistent_index_type" +
+                                         PersistentIndexTypePB_Name(metadata->persistent_index_type()));
         }
     }
 
@@ -200,8 +201,8 @@ Status LakePrimaryIndex::commit(const TabletMetadataPtr& metadata, MetaFileBuild
         RETURN_IF_ERROR(TabletMetaManager::get_persistent_index_meta(data_dir, _tablet_id, &index_meta));
         RETURN_IF_ERROR(PrimaryIndex::commit(&index_meta));
         RETURN_IF_ERROR(TabletMetaManager::write_persistent_index_meta(data_dir, _tablet_id, index_meta));
-        // Call `on_commited` here, which will remove old files is safe.
-        // Because if publish version fail after `on_commited`, index will be rebuild.
+        // Call `on_commited` here, which will be safe to remove old files.
+        // Because if version publishing fails after `on_commited`, index will be rebuild.
         return on_commited();
     }
     case PersistentIndexTypePB::CLOUD_NATIVE: {
@@ -209,7 +210,8 @@ Status LakePrimaryIndex::commit(const TabletMetadataPtr& metadata, MetaFileBuild
         return Status::OK();
     }
     default:
-        return Status::InternalError("Unsupported lake_persistent_index_type");
+        return Status::InternalError("Unsupported lake_persistent_index_type" +
+                                     PersistentIndexTypePB_Name(metadata->persistent_index_type()));
     }
 
     return Status::OK();

--- a/be/src/storage/lake/lake_primary_index.cpp
+++ b/be/src/storage/lake/lake_primary_index.cpp
@@ -234,7 +234,7 @@ Status LakePrimaryIndex::commit(const TabletMetadataPtr& metadata, MetaFileBuild
     return Status::OK();
 }
 
-Status LakePrimaryIndex::major_compact(const TabletMetadata& metadata, std::shared_ptr<TxnLogPB>& txn_log) {
+Status LakePrimaryIndex::major_compact(const TabletMetadata& metadata, TxnLogPB* txn_log) {
     if (!_enable_persistent_index) {
         return Status::OK();
     }

--- a/be/src/storage/lake/lake_primary_index.cpp
+++ b/be/src/storage/lake/lake_primary_index.cpp
@@ -188,7 +188,7 @@ Status LakePrimaryIndex::apply_opcompaction(const TabletMetadata& metadata,
     case PersistentIndexTypePB::CLOUD_NATIVE: {
         auto* lake_persistent_index = dynamic_cast<LakePersistentIndex*>(_persistent_index.get());
         if (lake_persistent_index != nullptr) {
-            return dynamic_cast<LakePersistentIndex*>(_persistent_index.get())->apply_opcompaction(op_compaction);
+            return lake_persistent_index->apply_opcompaction(op_compaction);
         } else {
             return Status::InternalError("Persistent index is not a LakePersistentIndex.");
         }
@@ -221,7 +221,7 @@ Status LakePrimaryIndex::commit(const TabletMetadataPtr& metadata, MetaFileBuild
     case PersistentIndexTypePB::CLOUD_NATIVE: {
         auto* lake_persistent_index = dynamic_cast<LakePersistentIndex*>(_persistent_index.get());
         if (lake_persistent_index != nullptr) {
-            dynamic_cast<LakePersistentIndex*>(_persistent_index.get())->commit(builder);
+            lake_persistent_index->commit(builder);
             return Status::OK();
         } else {
             return Status::InternalError("Persistent index is not a LakePersistentIndex.");

--- a/be/src/storage/lake/lake_primary_index.h
+++ b/be/src/storage/lake/lake_primary_index.h
@@ -66,7 +66,7 @@ public:
 
     Status commit(const TabletMetadataPtr& metadata, MetaFileBuilder* builder);
 
-    Status major_compact(const TabletMetadata& metadata, std::shared_ptr<TxnLogPB>& txn_log);
+    Status major_compact(const TabletMetadata& metadata, TxnLogPB* txn_log);
 
 private:
     Status _do_lake_load(TabletManager* tablet_mgr, const TabletMetadataPtr& metadata, int64_t base_version,

--- a/be/src/storage/lake/lake_primary_index.h
+++ b/be/src/storage/lake/lake_primary_index.h
@@ -62,6 +62,12 @@ public:
         _enable_persistent_index = enable_persistent_index;
     }
 
+    Status apply_opcompaction(const TabletMetadata& metadata, const TxnLogPB_OpCompaction& op_compaction);
+
+    Status commit(const TabletMetadataPtr& metadata, MetaFileBuilder* builder);
+
+    Status major_compaction(const TabletMetadata& metadata, std::shared_ptr<TxnLogPB>& txn_log);
+
 private:
     Status _do_lake_load(TabletManager* tablet_mgr, const TabletMetadataPtr& metadata, int64_t base_version,
                          const MetaFileBuilder* builder);

--- a/be/src/storage/lake/lake_primary_index.h
+++ b/be/src/storage/lake/lake_primary_index.h
@@ -66,7 +66,7 @@ public:
 
     Status commit(const TabletMetadataPtr& metadata, MetaFileBuilder* builder);
 
-    Status major_compaction(const TabletMetadata& metadata, std::shared_ptr<TxnLogPB>& txn_log);
+    Status major_compact(const TabletMetadata& metadata, std::shared_ptr<TxnLogPB>& txn_log);
 
 private:
     Status _do_lake_load(TabletManager* tablet_mgr, const TabletMetadataPtr& metadata, int64_t base_version,

--- a/be/src/storage/lake/meta_file.h
+++ b/be/src/storage/lake/meta_file.h
@@ -57,6 +57,8 @@ public:
     void set_recover_flag(RecoverFlag flag) { _recover_flag = flag; }
     RecoverFlag recover_flag() const { return _recover_flag; }
 
+    void finalize_sstable_meta(const PersistentIndexSstableMetaPB& sstable_meta);
+
 private:
     // update delvec in tablet meta
     Status _finalize_delvec(int64_t version, int64_t txn_id);

--- a/be/src/storage/lake/persistent_index_sstable.h
+++ b/be/src/storage/lake/persistent_index_sstable.h
@@ -55,7 +55,7 @@ public:
 
     sstable::Iterator* new_iterator(const sstable::ReadOptions& options) { return _sst->NewIterator(options); }
 
-    const PersistentIndexSstablePB sstable_pb() const { return _sstable_pb; }
+    const PersistentIndexSstablePB& sstable_pb() const { return _sstable_pb; }
 
 private:
     std::unique_ptr<sstable::Table> _sst{nullptr};

--- a/be/src/storage/lake/persistent_index_sstable.h
+++ b/be/src/storage/lake/persistent_index_sstable.h
@@ -55,6 +55,8 @@ public:
 
     sstable::Iterator* new_iterator(const sstable::ReadOptions& options) { return _sst->NewIterator(options); }
 
+    const PersistentIndexSstablePB sstable_pb() const { return _sstable_pb; }
+
 private:
     std::unique_ptr<sstable::Table> _sst{nullptr};
     std::unique_ptr<sstable::FilterPolicy> _filter_policy{nullptr};

--- a/be/src/storage/lake/txn_log_applier.cpp
+++ b/be/src/storage/lake/txn_log_applier.cpp
@@ -89,15 +89,15 @@ public:
     }
 
     Status finish() override {
-        // Must call `commit_primary_index` before `finalize`,
-        // because if `commit_primary_index` or `finalize` fail, we can remove index in `handle_failure`.
+        // Must call `commit` before `finalize`,
+        // because if `commit` or `finalize` fail, we can remove index in `handle_failure`.
         // if `_index_entry` is null, do nothing.
-        RETURN_IF_ERROR(_tablet.update_mgr()->commit_primary_index(_index_entry, &_tablet));
-        Status st = _builder.finalize(_max_txn_id);
-        if (st.ok()) {
-            _has_finalized = true;
+        if (_index_entry != nullptr) {
+            RETURN_IF_ERROR(_index_entry->value().commit(_metadata, &_builder));
         }
-        return st;
+        RETURN_IF_ERROR(_builder.finalize(_max_txn_id));
+        _has_finalized = true;
+        return Status::OK();
     }
 
 private:

--- a/be/src/storage/lake/update_manager.cpp
+++ b/be/src/storage/lake/update_manager.cpp
@@ -843,7 +843,7 @@ void UpdateManager::set_enable_persistent_index(int64_t tablet_id, bool enable_p
 }
 
 Status UpdateManager::execute_index_major_compaction(int64_t tablet_id, const TabletMetadata& metadata,
-                                                     std::shared_ptr<TxnLogPB>& txn_log) {
+                                                     TxnLogPB* txn_log) {
     auto index_entry = _index_cache.get(tablet_id);
     if (index_entry == nullptr) {
         return Status::OK();

--- a/be/src/storage/lake/update_manager.cpp
+++ b/be/src/storage/lake/update_manager.cpp
@@ -850,7 +850,7 @@ Status UpdateManager::execute_index_major_compaction(int64_t tablet_id, const Ta
     DeferOp release_index_entry([&] { _index_cache.release(index_entry); });
     if (index_entry != nullptr) {
         auto& index = index_entry->value();
-        return index.major_compaction(metadata, txn_log);
+        return index.major_compact(metadata, txn_log);
     }
     return Status::OK();
 }

--- a/be/src/storage/lake/update_manager.cpp
+++ b/be/src/storage/lake/update_manager.cpp
@@ -845,14 +845,14 @@ void UpdateManager::set_enable_persistent_index(int64_t tablet_id, bool enable_p
 Status UpdateManager::execute_index_major_compaction(int64_t tablet_id, const TabletMetadata& metadata,
                                                      std::shared_ptr<TxnLogPB>& txn_log) {
     auto index_entry = _index_cache.get(tablet_id);
+    if (index_entry == nullptr) {
+        return Status::OK();
+    }
     index_entry->update_expire_time(MonotonicMillis() + get_cache_expire_ms());
     // release index entry but keep it in cache
     DeferOp release_index_entry([&] { _index_cache.release(index_entry); });
-    if (index_entry != nullptr) {
-        auto& index = index_entry->value();
-        return index.major_compact(metadata, txn_log);
-    }
-    return Status::OK();
+    auto& index = index_entry->value();
+    return index.major_compact(metadata, txn_log);
 }
 
 } // namespace starrocks::lake

--- a/be/src/storage/lake/update_manager.h
+++ b/be/src/storage/lake/update_manager.h
@@ -157,8 +157,7 @@ public:
 
     void set_enable_persistent_index(int64_t tablet_id, bool enable_persistent_index);
 
-    Status execute_index_major_compaction(int64_t tablet_id, const TabletMetadata& metadata,
-                                          std::shared_ptr<TxnLogPB>& txn_log);
+    Status execute_index_major_compaction(int64_t tablet_id, const TabletMetadata& metadata, TxnLogPB* txn_log);
 
 private:
     // print memory tracker state

--- a/be/src/storage/lake/update_manager.h
+++ b/be/src/storage/lake/update_manager.h
@@ -136,9 +136,6 @@ public:
                                                 int64_t base_version, int64_t new_version,
                                                 std::unique_ptr<std::lock_guard<std::mutex>>& lock);
 
-    // commit primary index, only take affect when it is local persistent index
-    Status commit_primary_index(IndexEntry* index_entry, Tablet* tablet);
-
     // release index entry if it isn't nullptr
     void release_primary_index_cache(IndexEntry* index_entry);
     // remove index entry if it isn't nullptr
@@ -159,6 +156,9 @@ public:
     void try_remove_cache(uint32_t tablet_id, int64_t txn_id);
 
     void set_enable_persistent_index(int64_t tablet_id, bool enable_persistent_index);
+
+    Status execute_index_major_compaction(int64_t tablet_id, const TabletMetadata& metadata,
+                                          std::shared_ptr<TxnLogPB>& txn_log);
 
 private:
     // print memory tracker state

--- a/be/src/storage/lake/vertical_compaction_task.cpp
+++ b/be/src/storage/lake/vertical_compaction_task.cpp
@@ -99,6 +99,7 @@ Status VerticalCompactionTask::execute(CancelFunc cancel_func, ThreadPool* flush
     op_compaction->mutable_output_rowset()->set_num_rows(writer->num_rows());
     op_compaction->mutable_output_rowset()->set_data_size(writer->data_size());
     op_compaction->mutable_output_rowset()->set_overlapped(false);
+    execute_index_major_compaction(txn_log);
     RETURN_IF_ERROR(_tablet.tablet_manager()->put_txn_log(txn_log));
     if (_tablet_schema->keys_type() == KeysType::PRIMARY_KEYS) {
         // preload primary key table's compaction state

--- a/be/src/storage/lake/vertical_compaction_task.cpp
+++ b/be/src/storage/lake/vertical_compaction_task.cpp
@@ -99,7 +99,7 @@ Status VerticalCompactionTask::execute(CancelFunc cancel_func, ThreadPool* flush
     op_compaction->mutable_output_rowset()->set_num_rows(writer->num_rows());
     op_compaction->mutable_output_rowset()->set_data_size(writer->data_size());
     op_compaction->mutable_output_rowset()->set_overlapped(false);
-    RETURN_IF_ERROR(execute_index_major_compaction(txn_log));
+    RETURN_IF_ERROR(execute_index_major_compaction(txn_log.get()));
     RETURN_IF_ERROR(_tablet.tablet_manager()->put_txn_log(txn_log));
     if (_tablet_schema->keys_type() == KeysType::PRIMARY_KEYS) {
         // preload primary key table's compaction state

--- a/be/src/storage/lake/vertical_compaction_task.cpp
+++ b/be/src/storage/lake/vertical_compaction_task.cpp
@@ -99,7 +99,7 @@ Status VerticalCompactionTask::execute(CancelFunc cancel_func, ThreadPool* flush
     op_compaction->mutable_output_rowset()->set_num_rows(writer->num_rows());
     op_compaction->mutable_output_rowset()->set_data_size(writer->data_size());
     op_compaction->mutable_output_rowset()->set_overlapped(false);
-    execute_index_major_compaction(txn_log);
+    RETURN_IF_ERROR(execute_index_major_compaction(txn_log));
     RETURN_IF_ERROR(_tablet.tablet_manager()->put_txn_log(txn_log));
     if (_tablet_schema->keys_type() == KeysType::PRIMARY_KEYS) {
         // preload primary key table's compaction state

--- a/be/src/storage/sstable/table.h
+++ b/be/src/storage/sstable/table.h
@@ -3,15 +3,12 @@
 // (https://developers.google.com/open-source/licenses/bsd)
 #pragma once
 
-#include <set>
-
 #include "common/status.h"
 
 namespace starrocks {
 class Slice;
 class RandomAccessFile;
 namespace sstable {
-using KeyIndex = uint32_t;
 class Block;
 class BlockHandle;
 class Footer;

--- a/be/src/storage/sstable/table.h
+++ b/be/src/storage/sstable/table.h
@@ -3,12 +3,15 @@
 // (https://developers.google.com/open-source/licenses/bsd)
 #pragma once
 
+#include <set>
+
 #include "common/status.h"
 
 namespace starrocks {
 class Slice;
 class RandomAccessFile;
 namespace sstable {
+using KeyIndex = uint32_t;
 class Block;
 class BlockHandle;
 class Footer;

--- a/be/test/storage/lake/compaction_test_utils.h
+++ b/be/test/storage/lake/compaction_test_utils.h
@@ -16,6 +16,7 @@
 
 #include <gtest/gtest.h>
 
+#include "gen_cpp/lake_types.pb.h"
 #include "storage/compaction_utils.h"
 
 namespace starrocks::lake {
@@ -24,12 +25,14 @@ struct CompactionParam {
     CompactionAlgorithm algorithm = HORIZONTAL_COMPACTION;
     uint32_t vertical_compaction_max_columns_per_group = 5;
     bool enable_persistent_index = false;
+    PersistentIndexTypePB persistent_index_type = PersistentIndexTypePB::LOCAL;
 };
 
 static std::string to_string_param_name(const testing::TestParamInfo<CompactionParam>& info) {
     std::stringstream ss;
     ss << CompactionUtils::compaction_algorithm_to_string(info.param.algorithm) << "_"
-       << info.param.vertical_compaction_max_columns_per_group << "_" << info.param.enable_persistent_index;
+       << info.param.vertical_compaction_max_columns_per_group << "_" << info.param.enable_persistent_index << "_"
+       << PersistentIndexTypePB_Name(info.param.persistent_index_type);
     return ss.str();
 }
 

--- a/be/test/storage/lake/lake_persistent_index_test.cpp
+++ b/be/test/storage/lake/lake_persistent_index_test.cpp
@@ -233,7 +233,7 @@ TEST_F(LakePersistentIndexTest, test_major_compaction) {
     get_values.clear();
     get_values.reserve(config::lake_pk_index_sst_max_compaction_versions * N);
     auto txn_log = std::make_shared<TxnLogPB>();
-    ASSERT_OK(index->major_compact(0, txn_log));
+    ASSERT_OK(index->major_compact(0, txn_log.get()));
     ASSERT_OK(index->apply_opcompaction(txn_log->op_compaction()));
     ASSERT_OK(index->get(config::lake_pk_index_sst_max_compaction_versions * N, total_key_slices.data(),
                          get_values.data()));

--- a/be/test/storage/lake/lake_persistent_index_test.cpp
+++ b/be/test/storage/lake/lake_persistent_index_test.cpp
@@ -225,6 +225,7 @@ TEST_F(LakePersistentIndexTest, test_major_compaction) {
         ASSERT_OK(index->upsert(N, key_slices.data(), values.data(), upsert_old_values.data()));
     }
 
+    index->minor_compact();
     vector<IndexValue> get_values(config::lake_pk_index_sst_max_compaction_versions * N);
     ASSERT_OK(index->get(config::lake_pk_index_sst_max_compaction_versions * N, total_key_slices.data(),
                          get_values.data()));

--- a/be/test/storage/lake/lake_persistent_index_test.cpp
+++ b/be/test/storage/lake/lake_persistent_index_test.cpp
@@ -212,12 +212,12 @@ TEST_F(LakePersistentIndexTest, test_major_compaction) {
         vector<IndexValue> values;
         values.reserve(N);
         for (int j = 0; j < N; j++) {
-            keys.emplace_back(k);
-            total_keys.emplace_back(k);
+            keys.emplace_back(j);
+            total_keys.emplace_back(j);
             key_slices.emplace_back((uint8_t*)(&keys[j]), sizeof(Key));
             total_key_slices.emplace_back((uint8_t*)(&total_keys[k]), sizeof(Key));
-            values.emplace_back(k * 2);
-            total_values.emplace_back(k * 2);
+            values.emplace_back(j * 2);
+            total_values.emplace_back(j * 2);
             ++k;
         }
         index->prepare(EditVersion(i, 0), 0);

--- a/be/test/storage/lake/lake_persistent_index_test.cpp
+++ b/be/test/storage/lake/lake_persistent_index_test.cpp
@@ -194,48 +194,50 @@ TEST_F(LakePersistentIndexTest, test_major_compaction) {
     auto l0_max_mem_usage = config::l0_max_mem_usage;
     config::l0_max_mem_usage = 10;
     using Key = uint64_t;
-    const int N = 10000;
-    vector<Key> keys;
-    vector<Slice> key_slices;
-    vector<IndexValue> values;
+    const int N = 100;
+    vector<Key> total_keys;
+    vector<Slice> total_key_slices;
+    vector<IndexValue> total_values;
     vector<size_t> idxes;
-    keys.reserve(N);
-    key_slices.reserve(N);
-    for (int i = 0; i < N; i++) {
-        keys.emplace_back(i);
-        values.emplace_back(i * 2);
-        key_slices.emplace_back((uint8_t*)(&keys[i]), sizeof(Key));
-    }
+    total_key_slices.reserve(config::lake_pk_index_sst_max_compaction_versions * N);
+    total_keys.reserve(config::lake_pk_index_sst_max_compaction_versions * N);
     auto tablet_id = _tablet_metadata->id();
     auto index = std::make_unique<LakePersistentIndex>(_tablet_mgr.get(), tablet_id);
-    vector<IndexValue> upsert_old_values(keys.size());
-    ASSERT_OK(index->upsert(N, key_slices.data(), values.data(), upsert_old_values.data()));
-
-    keys.clear();
-    values.clear();
-    for (int i = 0; i < N; i++) {
-        keys.emplace_back(i);
-        values.emplace_back(i * 3);
-        key_slices.emplace_back((uint8_t*)(&keys[i]), sizeof(Key));
+    int k = 0;
+    for (int i = 0; i < config::lake_pk_index_sst_max_compaction_versions; ++i) {
+        vector<Key> keys;
+        keys.reserve(N);
+        vector<Slice> key_slices;
+        key_slices.reserve(N);
+        vector<IndexValue> values;
+        values.reserve(N);
+        for (int j = 0; j < N; j++) {
+            keys.emplace_back(k);
+            total_keys.emplace_back(k);
+            key_slices.emplace_back((uint8_t*)(&keys[j]), sizeof(Key));
+            total_key_slices.emplace_back((uint8_t*)(&total_keys[k]), sizeof(Key));
+            values.emplace_back(k * 2);
+            total_values.emplace_back(k * 2);
+            ++k;
+        }
+        index->prepare(EditVersion(i, 0), 0);
+        vector<IndexValue> upsert_old_values(keys.size());
+        ASSERT_OK(index->upsert(N, key_slices.data(), values.data(), upsert_old_values.data()));
     }
-    upsert_old_values.clear();
-    upsert_old_values.resize(keys.size());
-    ASSERT_OK(index->upsert(N, key_slices.data(), values.data(), upsert_old_values.data()));
 
-    vector<IndexValue> get_values(keys.size());
-    ASSERT_OK(index->get(N, key_slices.data(), get_values.data()));
-    for (int i = 0; i < values.size(); i++) {
-        ASSERT_EQ(values[i], get_values[i]);
-    }
+    vector<IndexValue> get_values(config::lake_pk_index_sst_max_compaction_versions * N);
+    ASSERT_OK(index->get(config::lake_pk_index_sst_max_compaction_versions * N, total_key_slices.data(),
+                         get_values.data()));
 
     get_values.clear();
-    get_values.resize(keys.size());
+    get_values.reserve(config::lake_pk_index_sst_max_compaction_versions * N);
     auto txn_log = std::make_shared<TxnLogPB>();
     ASSERT_OK(index->major_compact(0, txn_log));
-    index->apply_opcompaction(txn_log->op_compaction());
-    ASSERT_OK(index->get(N, key_slices.data(), get_values.data()));
-    for (int i = 0; i < values.size(); i++) {
-        ASSERT_EQ(values[i], get_values[i]);
+    ASSERT_OK(index->apply_opcompaction(txn_log->op_compaction()));
+    ASSERT_OK(index->get(config::lake_pk_index_sst_max_compaction_versions * N, total_key_slices.data(),
+                         get_values.data()));
+    for (int i = 0; i < config::lake_pk_index_sst_max_compaction_versions * N; i++) {
+        ASSERT_EQ(total_values[i], get_values[i]);
     }
     config::l0_max_mem_usage = l0_max_mem_usage;
 }

--- a/be/test/storage/lake/partial_update_test.cpp
+++ b/be/test/storage/lake/partial_update_test.cpp
@@ -46,6 +46,7 @@ public:
         _tablet_metadata->set_version(1);
         _tablet_metadata->set_next_rowset_id(1);
         _tablet_metadata->set_enable_persistent_index(GetParam().enable_persistent_index);
+        _tablet_metadata->set_persistent_index_type(GetParam().persistent_index_type);
         //
         //  | column | type | KEY | NULL |
         //  +--------+------+-----+------+
@@ -242,7 +243,7 @@ TEST_P(LakePartialUpdateTest, test_write) {
     ASSERT_EQ(kChunkSize, check(version, [](int c0, int c1, int c2) { return (c0 * 3 == c1) && (c0 * 4 == c2); }));
     ASSIGN_OR_ABORT(new_tablet_metadata, _tablet_mgr->get_tablet_metadata(tablet_id, version));
     EXPECT_EQ(new_tablet_metadata->rowsets_size(), 6);
-    if (GetParam().enable_persistent_index) {
+    if (GetParam().enable_persistent_index && GetParam().persistent_index_type == PersistentIndexTypePB::LOCAL) {
         check_local_persistent_index_meta(tablet_id, version);
     }
 }
@@ -311,7 +312,7 @@ TEST_P(LakePartialUpdateTest, test_write_multi_segment) {
     EXPECT_EQ(new_tablet_metadata->rowsets_size(), 6);
     // check segment size in last metadata
     EXPECT_EQ(new_tablet_metadata->rowsets(5).segments_size(), 2);
-    if (GetParam().enable_persistent_index) {
+    if (GetParam().enable_persistent_index && GetParam().persistent_index_type == PersistentIndexTypePB::LOCAL) {
         check_local_persistent_index_meta(tablet_id, version);
     }
 }
@@ -381,7 +382,7 @@ TEST_P(LakePartialUpdateTest, test_write_multi_segment_by_diff_val) {
     EXPECT_EQ(new_tablet_metadata->rowsets_size(), 6);
     // check segment size in last metadata
     EXPECT_EQ(new_tablet_metadata->rowsets(5).segments_size(), 2);
-    if (GetParam().enable_persistent_index) {
+    if (GetParam().enable_persistent_index && GetParam().persistent_index_type == PersistentIndexTypePB::LOCAL) {
         check_local_persistent_index_meta(tablet_id, version);
     }
 }
@@ -449,7 +450,7 @@ TEST_P(LakePartialUpdateTest, test_resolve_conflict) {
     ASSERT_EQ(kChunkSize, check(version, [](int c0, int c1, int c2) { return (c0 * 5 == c1) && (c0 * 4 == c2); }));
     ASSIGN_OR_ABORT(new_tablet_metadata, _tablet_mgr->get_tablet_metadata(tablet_id, version));
     EXPECT_EQ(new_tablet_metadata->rowsets_size(), 6);
-    if (GetParam().enable_persistent_index) {
+    if (GetParam().enable_persistent_index && GetParam().persistent_index_type == PersistentIndexTypePB::LOCAL) {
         check_local_persistent_index_meta(tablet_id, version);
     }
 }
@@ -522,7 +523,7 @@ TEST_P(LakePartialUpdateTest, test_resolve_conflict_multi_segment) {
     EXPECT_EQ(new_tablet_metadata->rowsets_size(), 6);
     // check segment size in last metadata
     EXPECT_EQ(new_tablet_metadata->rowsets(5).segments_size(), 2);
-    if (GetParam().enable_persistent_index) {
+    if (GetParam().enable_persistent_index && GetParam().persistent_index_type == PersistentIndexTypePB::LOCAL) {
         check_local_persistent_index_meta(tablet_id, version);
     }
 }
@@ -595,12 +596,16 @@ TEST_P(LakePartialUpdateTest, test_resolve_conflict2) {
     ASSERT_EQ(kChunkSize, check(version, [](int c0, int c1, int c2) { return (c0 * 5 == c1) && (c0 * 4 == c2); }));
     ASSIGN_OR_ABORT(new_tablet_metadata, _tablet_mgr->get_tablet_metadata(tablet_id, version));
     EXPECT_EQ(new_tablet_metadata->rowsets_size(), 5);
-    if (GetParam().enable_persistent_index) {
+    if (GetParam().enable_persistent_index && GetParam().persistent_index_type == PersistentIndexTypePB::LOCAL) {
         check_local_persistent_index_meta(tablet_id, version);
     }
 }
 
 TEST_P(LakePartialUpdateTest, test_write_with_index_reload) {
+    if (GetParam().enable_persistent_index && GetParam().persistent_index_type == PersistentIndexTypePB::CLOUD_NATIVE) {
+        // not support reload yet
+        return;
+    }
     auto chunk0 = generate_data(kChunkSize, 0, false, 3);
     auto chunk1 = generate_data(kChunkSize, 0, true, 3);
     auto indexes = std::vector<uint32_t>(kChunkSize);
@@ -661,7 +666,7 @@ TEST_P(LakePartialUpdateTest, test_write_with_index_reload) {
     ASSERT_EQ(kChunkSize, check(version, [](int c0, int c1, int c2) { return (c0 * 3 == c1) && (c0 * 4 == c2); }));
     ASSIGN_OR_ABORT(new_tablet_metadata, _tablet_mgr->get_tablet_metadata(tablet_id, version));
     EXPECT_EQ(new_tablet_metadata->rowsets_size(), 6);
-    if (GetParam().enable_persistent_index) {
+    if (GetParam().enable_persistent_index && GetParam().persistent_index_type == PersistentIndexTypePB::LOCAL) {
         check_local_persistent_index_meta(tablet_id, version);
     }
 }
@@ -881,7 +886,8 @@ TEST_P(LakePartialUpdateTest, test_batch_publish) {
 }
 
 INSTANTIATE_TEST_SUITE_P(LakePartialUpdateTest, LakePartialUpdateTest,
-                         ::testing::Values(PrimaryKeyParam{true}, PrimaryKeyParam{false}));
+                         ::testing::Values(PrimaryKeyParam{true}, PrimaryKeyParam{false},
+                                           PrimaryKeyParam{true, PersistentIndexTypePB::CLOUD_NATIVE}));
 
 class LakeIncompleteSortKeyPartialUpdateTest : public TestBase {
 public:

--- a/be/test/storage/lake/primary_key_compaction_task_test.cpp
+++ b/be/test/storage/lake/primary_key_compaction_task_test.cpp
@@ -1198,7 +1198,7 @@ TEST_P(LakePrimaryKeyCompactionTest, test_major_compaction) {
     EXPECT_EQ(new_tablet_metadata->rowsets_size(), 10);
 
     auto txn_id = next_id();
-    auto task_context = std::make_unique<CompactionTaskContext>(txn_id, tablet_id, version, nullptr);
+    auto task_context = std::make_unique<CompactionTaskContext>(txn_id, tablet_id, version, false, nullptr);
     ASSIGN_OR_ABORT(auto task, _tablet_mgr->compact(task_context.get()));
     check_task(task);
     ASSERT_OK(task->execute(CompactionTask::kNoCancelFn));

--- a/be/test/storage/lake/primary_key_compaction_task_test.cpp
+++ b/be/test/storage/lake/primary_key_compaction_task_test.cpp
@@ -50,6 +50,7 @@ public:
     LakePrimaryKeyCompactionTest() : TestBase(kTestDirectory), _partition_id(next_id()) {
         _tablet_metadata = generate_simple_tablet_metadata(PRIMARY_KEYS);
         _tablet_metadata->set_enable_persistent_index(GetParam().enable_persistent_index);
+        _tablet_metadata->set_persistent_index_type(GetParam().persistent_index_type);
         _tablet_schema = TabletSchema::create(_tablet_metadata->schema());
         _schema = std::make_shared<Schema>(ChunkHelper::convert_schema(_tablet_schema));
     }
@@ -225,7 +226,7 @@ TEST_P(LakePrimaryKeyCompactionTest, test1) {
     EXPECT_TRUE(_update_mgr->TEST_check_compaction_cache_absent(tablet_id, txn_id));
     version++;
     ASSERT_EQ(kChunkSize, read(version));
-    if (GetParam().enable_persistent_index) {
+    if (GetParam().enable_persistent_index && GetParam().persistent_index_type == PersistentIndexTypePB::LOCAL) {
         check_local_persistent_index_meta(tablet_id, version);
     }
 
@@ -281,7 +282,7 @@ TEST_P(LakePrimaryKeyCompactionTest, test2) {
     EXPECT_TRUE(_update_mgr->TEST_check_compaction_cache_absent(tablet_id, txn_id));
     version++;
     ASSERT_EQ(kChunkSize * 3, read(version));
-    if (GetParam().enable_persistent_index) {
+    if (GetParam().enable_persistent_index && GetParam().persistent_index_type == PersistentIndexTypePB::LOCAL) {
         check_local_persistent_index_meta(tablet_id, version);
     }
 
@@ -345,7 +346,7 @@ TEST_P(LakePrimaryKeyCompactionTest, test3) {
     ASSERT_OK(publish_single_version(_tablet_metadata->id(), version + 1, txn_id).status());
     EXPECT_TRUE(_update_mgr->TEST_check_compaction_cache_absent(tablet_id, txn_id));
     version++;
-    if (GetParam().enable_persistent_index) {
+    if (GetParam().enable_persistent_index && GetParam().persistent_index_type == PersistentIndexTypePB::LOCAL) {
         check_local_persistent_index_meta(tablet_id, version);
     }
     ASSERT_EQ(kChunkSize * 2, read(version));
@@ -948,7 +949,7 @@ TEST_P(LakePrimaryKeyCompactionTest, test_multi_output_seg) {
     config::vector_chunk_size = 4096;
     version++;
     ASSERT_EQ(kChunkSize * 3, read(version));
-    if (GetParam().enable_persistent_index) {
+    if (GetParam().enable_persistent_index && GetParam().persistent_index_type == PersistentIndexTypePB::LOCAL) {
         check_local_persistent_index_meta(tablet_id, version);
     }
 
@@ -1011,7 +1012,7 @@ TEST_P(LakePrimaryKeyCompactionTest, test_pk_recover_rowset_order_after_compact)
     EXPECT_TRUE(_update_mgr->TEST_check_compaction_cache_absent(tablet_id, txn_id));
     version++;
     ASSERT_EQ(3 * kChunkSize, read(version));
-    if (GetParam().enable_persistent_index) {
+    if (GetParam().enable_persistent_index && GetParam().persistent_index_type == PersistentIndexTypePB::LOCAL) {
         check_local_persistent_index_meta(tablet_id, version);
     }
 
@@ -1155,11 +1156,14 @@ TEST_P(LakePrimaryKeyCompactionTest, test_size_tiered_compaction_strategy) {
     config::enable_pk_size_tiered_compaction_strategy = old_val;
 }
 
-INSTANTIATE_TEST_SUITE_P(LakePrimaryKeyCompactionTest, LakePrimaryKeyCompactionTest,
-                         ::testing::Values(CompactionParam{HORIZONTAL_COMPACTION, 5, false},
-                                           CompactionParam{VERTICAL_COMPACTION, 1, false},
-                                           CompactionParam{HORIZONTAL_COMPACTION, 5, true},
-                                           CompactionParam{VERTICAL_COMPACTION, 1, true}),
-                         to_string_param_name);
+INSTANTIATE_TEST_SUITE_P(
+        LakePrimaryKeyCompactionTest, LakePrimaryKeyCompactionTest,
+        ::testing::Values(CompactionParam{HORIZONTAL_COMPACTION, 5, false},
+                          CompactionParam{VERTICAL_COMPACTION, 1, false},
+                          CompactionParam{HORIZONTAL_COMPACTION, 5, true},
+                          CompactionParam{VERTICAL_COMPACTION, 1, true},
+                          CompactionParam{HORIZONTAL_COMPACTION, 5, true, PersistentIndexTypePB::CLOUD_NATIVE},
+                          CompactionParam{VERTICAL_COMPACTION, 1, true, PersistentIndexTypePB::CLOUD_NATIVE}),
+        to_string_param_name);
 
 } // namespace starrocks::lake

--- a/be/test/storage/lake/primary_key_compaction_task_test.cpp
+++ b/be/test/storage/lake/primary_key_compaction_task_test.cpp
@@ -1162,7 +1162,8 @@ TEST_P(LakePrimaryKeyCompactionTest, test_major_compaction) {
     }
     // Prepare data for writing
     std::vector<Chunk> chunks;
-    for (int i = 0; i < 10; i++) {
+    int N = config::lake_pk_index_sst_max_compaction_versions + 5;
+    for (int i = 0; i < N; i++) {
         chunks.push_back(generate_data(kChunkSize, i));
     }
     auto indexes = std::vector<uint32_t>(kChunkSize);
@@ -1174,7 +1175,7 @@ TEST_P(LakePrimaryKeyCompactionTest, test_major_compaction) {
     config::l0_max_mem_usage = 10;
     auto version = 1;
     auto tablet_id = _tablet_metadata->id();
-    for (int i = 0; i < 10; i++) {
+    for (int i = 0; i < N; i++) {
         auto txn_id = next_id();
         ASSIGN_OR_ABORT(auto delta_writer, DeltaWriterBuilder()
                                                    .set_tablet_manager(_tablet_mgr.get())
@@ -1208,7 +1209,7 @@ TEST_P(LakePrimaryKeyCompactionTest, test_major_compaction) {
     version++;
     ASSERT_EQ(10 * kChunkSize, read(version));
     ASSIGN_OR_ABORT(new_tablet_metadata, _tablet_mgr->get_tablet_metadata(tablet_id, version));
-    EXPECT_EQ(new_tablet_metadata->orphan_files_size(), 5);
+    EXPECT_EQ(config::lake_pk_index_sst_max_compaction_versions, new_tablet_metadata->orphan_files_size());
 
     config::l0_max_mem_usage = l0_max_mem_usage;
 }

--- a/be/test/storage/lake/primary_key_publish_test.cpp
+++ b/be/test/storage/lake/primary_key_publish_test.cpp
@@ -45,6 +45,7 @@ public:
     LakePrimaryKeyPublishTest() : TestBase(kTestGroupPath) {
         _tablet_metadata = generate_simple_tablet_metadata(PRIMARY_KEYS);
         _tablet_metadata->set_enable_persistent_index(GetParam().enable_persistent_index);
+        _tablet_metadata->set_persistent_index_type(GetParam().persistent_index_type);
 
         _slots.emplace_back(0, "c0", TypeDescriptor{LogicalType::TYPE_INT});
         _slots.emplace_back(1, "c1", TypeDescriptor{LogicalType::TYPE_INT});
@@ -235,7 +236,7 @@ TEST_P(LakePrimaryKeyPublishTest, test_write_multitime_check_result) {
     EXPECT_EQ(new_tablet_metadata->rowsets(0).num_dels(), kChunkSize);
     EXPECT_EQ(new_tablet_metadata->rowsets(1).num_dels(), kChunkSize);
     EXPECT_EQ(new_tablet_metadata->rowsets(2).num_dels(), 0);
-    if (GetParam().enable_persistent_index) {
+    if (GetParam().enable_persistent_index && GetParam().persistent_index_type == PersistentIndexTypePB::LOCAL) {
         check_local_persistent_index_meta(tablet_id, version);
     }
 }
@@ -328,7 +329,7 @@ TEST_P(LakePrimaryKeyPublishTest, test_write_fail_retry) {
     EXPECT_EQ(new_tablet_metadata->rowsets(2).num_dels(), 0);
     EXPECT_EQ(new_tablet_metadata->rowsets(3).num_dels(), 0);
     EXPECT_EQ(new_tablet_metadata->rowsets(4).num_dels(), 0);
-    if (GetParam().enable_persistent_index) {
+    if (GetParam().enable_persistent_index && GetParam().persistent_index_type == PersistentIndexTypePB::LOCAL) {
         check_local_persistent_index_meta(tablet_id, version);
     }
 }
@@ -371,7 +372,7 @@ TEST_P(LakePrimaryKeyPublishTest, test_publish_multi_times) {
     EXPECT_EQ(new_tablet_metadata->rowsets(0).num_dels(), kChunkSize);
     EXPECT_EQ(new_tablet_metadata->rowsets(1).num_dels(), kChunkSize);
     EXPECT_EQ(new_tablet_metadata->rowsets(2).num_dels(), 0);
-    if (GetParam().enable_persistent_index) {
+    if (GetParam().enable_persistent_index && GetParam().persistent_index_type == PersistentIndexTypePB::LOCAL) {
         check_local_persistent_index_meta(tablet_id, version);
     }
 }
@@ -410,7 +411,7 @@ TEST_P(LakePrimaryKeyPublishTest, test_publish_concurrent) {
     EXPECT_EQ(new_tablet_metadata->rowsets(0).num_dels(), kChunkSize);
     EXPECT_EQ(new_tablet_metadata->rowsets(1).num_dels(), kChunkSize);
     EXPECT_EQ(new_tablet_metadata->rowsets(2).num_dels(), 0);
-    if (GetParam().enable_persistent_index) {
+    if (GetParam().enable_persistent_index && GetParam().persistent_index_type == PersistentIndexTypePB::LOCAL) {
         check_local_persistent_index_meta(tablet_id, version);
     }
 }
@@ -476,7 +477,7 @@ TEST_P(LakePrimaryKeyPublishTest, test_resolve_conflict) {
     EXPECT_EQ(new_tablet_metadata->rowsets(3).num_dels(), kChunkSize);
     EXPECT_EQ(new_tablet_metadata->rowsets(4).num_dels(), kChunkSize);
     EXPECT_EQ(new_tablet_metadata->rowsets(5).num_dels(), 0);
-    if (GetParam().enable_persistent_index) {
+    if (GetParam().enable_persistent_index && GetParam().persistent_index_type == PersistentIndexTypePB::LOCAL) {
         check_local_persistent_index_meta(tablet_id, version);
     }
 }
@@ -523,7 +524,7 @@ TEST_P(LakePrimaryKeyPublishTest, test_write_read_success_multiple_tablet) {
     chunk1->remove_column_by_index(2);
     assert_chunk_equals(*chunk0, *chunk2);
     assert_chunk_equals(*chunk1, *chunk3);
-    if (GetParam().enable_persistent_index) {
+    if (GetParam().enable_persistent_index && GetParam().persistent_index_type == PersistentIndexTypePB::LOCAL) {
         check_local_persistent_index_meta(tablet_id_1, version);
         check_local_persistent_index_meta(tablet_id_2, version);
     }
@@ -561,7 +562,7 @@ TEST_P(LakePrimaryKeyPublishTest, test_write_largedata) {
     for (int i = 0; i < N; i++) {
         EXPECT_EQ(new_tablet_metadata->rowsets(i).num_dels(), 0);
     }
-    if (GetParam().enable_persistent_index) {
+    if (GetParam().enable_persistent_index && GetParam().persistent_index_type == PersistentIndexTypePB::LOCAL) {
         check_local_persistent_index_meta(tablet_id, version);
     }
     config::l0_max_mem_usage = old_config;
@@ -607,7 +608,7 @@ TEST_P(LakePrimaryKeyPublishTest, test_recover) {
     ASSIGN_OR_ABORT(auto new_tablet_metadata, _tablet_mgr->get_tablet_metadata(tablet_id, version));
     EXPECT_EQ(new_tablet_metadata->rowsets_size(), 3);
     ASSERT_EQ(kChunkSize, read_rows(tablet_id, version));
-    if (GetParam().enable_persistent_index) {
+    if (GetParam().enable_persistent_index && GetParam().persistent_index_type == PersistentIndexTypePB::LOCAL) {
         check_local_persistent_index_meta(tablet_id, version);
     }
     config::enable_primary_key_recover = false;
@@ -616,6 +617,10 @@ TEST_P(LakePrimaryKeyPublishTest, test_recover) {
 TEST_P(LakePrimaryKeyPublishTest, test_write_rebuild_persistent_index) {
     if (!GetParam().enable_persistent_index) {
         // only test persistent index
+        return;
+    }
+    if (GetParam().persistent_index_type == PersistentIndexTypePB::CLOUD_NATIVE) {
+        // not support reload yet
         return;
     }
     auto [chunk0, indexes] = gen_data_and_index(kChunkSize, 0, true, true);
@@ -652,7 +657,7 @@ TEST_P(LakePrimaryKeyPublishTest, test_write_rebuild_persistent_index) {
     EXPECT_EQ(new_tablet_metadata->rowsets(0).num_dels(), kChunkSize);
     EXPECT_EQ(new_tablet_metadata->rowsets(1).num_dels(), kChunkSize);
     EXPECT_EQ(new_tablet_metadata->rowsets(2).num_dels(), 0);
-    if (GetParam().enable_persistent_index) {
+    if (GetParam().enable_persistent_index && GetParam().persistent_index_type == PersistentIndexTypePB::LOCAL) {
         check_local_persistent_index_meta(tablet_id, version);
     }
 }
@@ -902,6 +907,7 @@ TEST_P(LakePrimaryKeyPublishTest, test_mem_tracker) {
 }
 
 INSTANTIATE_TEST_SUITE_P(LakePrimaryKeyPublishTest, LakePrimaryKeyPublishTest,
-                         ::testing::Values(PrimaryKeyParam{true}, PrimaryKeyParam{false}));
+                         ::testing::Values(PrimaryKeyParam{true}, PrimaryKeyParam{false},
+                                           PrimaryKeyParam{true, PersistentIndexTypePB::CLOUD_NATIVE}));
 
 } // namespace starrocks::lake

--- a/be/test/storage/lake/test_util.h
+++ b/be/test/storage/lake/test_util.h
@@ -110,6 +110,7 @@ protected:
 
 struct PrimaryKeyParam {
     bool enable_persistent_index = false;
+    PersistentIndexTypePB persistent_index_type = PersistentIndexTypePB::LOCAL;
 };
 
 inline StatusOr<TabletMetadataPtr> TEST_publish_single_version(TabletManager* tablet_mgr, int64_t tablet_id,

--- a/gensrc/proto/lake_types.proto
+++ b/gensrc/proto/lake_types.proto
@@ -101,6 +101,7 @@ message TabletMetadataPB {
     optional int64 commit_time = 13;
     // If the tablet is replicated from another cluster, the source_schema saved the schema in the cluster
     optional TabletSchemaPB source_schema = 14;
+    optional PersistentIndexSstableMetaPB sstable_meta = 15;
 }
 
 message MetadataUpdateInfoPB {
@@ -121,6 +122,8 @@ message TxnLogPB {
     message OpCompaction {
         repeated uint32 input_rowsets = 1;
         optional RowsetMetadataPB output_rowset = 2;
+        repeated PersistentIndexSstablePB input_sstables = 3;
+        optional PersistentIndexSstablePB output_sstable = 4;
     }
 
     message OpSchemaChange {

--- a/gensrc/proto/types.proto
+++ b/gensrc/proto/types.proto
@@ -183,5 +183,6 @@ message PersistentIndexSstablePB {
 }
 
 message PersistentIndexSstableMetaPB {
+    // sstables are ordered with the smaller version on the left.
     repeated PersistentIndexSstablePB sstables = 1;
 }


### PR DESCRIPTION
## Why I'm doing:
Currently, persistent index in cloud native table only supports using local disk. LakePersistentIndex support cloud native persistent index.
## What I'm doing:
1. Implement major compaction of LakePersistent Index
2. Support using LakePersistentIndex in cloud native table

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [x] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
