### PR TITLE
[Feature][FlatJson] FE support json type inference in query

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/prunesubfield/PruneSubfieldRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/prunesubfield/PruneSubfieldRule.java
@@ -15,9 +15,15 @@
 package com.starrocks.sql.optimizer.rule.tree.prunesubfield;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
+import com.starrocks.analysis.Expr;
 import com.starrocks.catalog.ColumnAccessPath;
+import com.starrocks.catalog.Function;
 import com.starrocks.catalog.FunctionSet;
+import com.starrocks.catalog.PrimitiveType;
+import com.starrocks.catalog.Type;
 import com.starrocks.sql.optimizer.OptExpression;
 import com.starrocks.sql.optimizer.OptimizerContext;
 import com.starrocks.sql.optimizer.operator.Operator;
@@ -26,16 +32,21 @@ import com.starrocks.sql.optimizer.operator.OperatorType;
 import com.starrocks.sql.optimizer.operator.logical.LogicalProjectOperator;
 import com.starrocks.sql.optimizer.operator.logical.LogicalScanOperator;
 import com.starrocks.sql.optimizer.operator.pattern.Pattern;
+import com.starrocks.sql.optimizer.operator.scalar.CallOperator;
+import com.starrocks.sql.optimizer.operator.scalar.CastOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ColumnRefOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ScalarOperator;
+import com.starrocks.sql.optimizer.operator.scalar.ScalarOperatorVisitor;
 import com.starrocks.sql.optimizer.rule.RuleType;
 import com.starrocks.sql.optimizer.rule.transformation.TransformationRule;
 
 import java.util.List;
+import java.util.Map;
 
 public class PruneSubfieldRule extends TransformationRule {
     public static final List<String> SUPPORT_JSON_FUNCTIONS = ImmutableList.<String>builder()
             // arguments: Json, path
+            .add(FunctionSet.GET_JSON_BOOL)
             .add(FunctionSet.GET_JSON_INT)
             .add(FunctionSet.GET_JSON_DOUBLE)
             .add(FunctionSet.GET_JSON_STRING)
@@ -58,8 +69,23 @@ public class PruneSubfieldRule extends TransformationRule {
 
     @Override
     public List<OptExpression> transform(OptExpression input, OptimizerContext context) {
-        // project expression
+        // normalize json cast expression
         LogicalProjectOperator project = input.getOp().cast();
+        LogicalScanOperator scan = input.getInputs().get(0).getOp().cast();
+        ScalarOperator predicate = scan.getPredicate();
+
+        if (context.getSessionVariable().isCboPruneSubfield()) {
+            NormalizeCastJsonExpr normalizer = new NormalizeCastJsonExpr();
+            Map<ColumnRefOperator, ScalarOperator> projectMap = Maps.newHashMap();
+            project.getColumnRefMap().forEach((k, v) -> projectMap.put(k, v.accept(normalizer, null)));
+            project = new LogicalProjectOperator(projectMap);
+
+            if (predicate != null) {
+                predicate = predicate.accept(normalizer, null);
+            }
+        }
+
+        // project expression
         SubfieldExpressionCollector collector =
                 new SubfieldExpressionCollector(context.getSessionVariable().isCboPruneJsonSubfield());
         for (ScalarOperator value : project.getColumnRefMap().values()) {
@@ -67,9 +93,8 @@ public class PruneSubfieldRule extends TransformationRule {
         }
 
         // scan predicate
-        LogicalScanOperator scan = input.getInputs().get(0).getOp().cast();
-        if (scan.getPredicate() != null) {
-            scan.getPredicate().accept(collector, null);
+        if (predicate != null) {
+            predicate.accept(collector, null);
         }
 
         // normalize access path
@@ -94,7 +119,72 @@ public class PruneSubfieldRule extends TransformationRule {
         }
 
         LogicalScanOperator.Builder builder = OperatorBuilderFactory.build(scan);
-        Operator newScan = builder.withOperator(scan).setColumnAccessPaths(accessPaths).build();
+        Operator newScan = builder.withOperator(scan)
+                .setColumnAccessPaths(accessPaths)
+                .setPredicate(predicate)
+                .build();
         return Lists.newArrayList(OptExpression.create(project, OptExpression.create(newScan)));
+    }
+
+    // normalize cast(json as other_type) to cast(get_json_xxx(json, path) as other_type), to use
+    // flat json path optimization json query
+    // e.g. cast(k1['a'] as int) => get_json_int(k1, "a")
+    //      cast(k1['a'] as string) => get_json_string(k1, "a")
+    //      cast(k1['a'] as decimal) => cast(get_json_double(k1, "a") as decimal)
+    private static class NormalizeCastJsonExpr extends ScalarOperatorVisitor<ScalarOperator, ScalarOperator> {
+        private static final Map<PrimitiveType, Function> SUPPORT_GET_TYPE;
+
+        private static final Map<PrimitiveType, Function> SUPPORT_CAST_TYPE;
+
+        static {
+            Function jsonInt = Expr.getBuiltinFunction(FunctionSet.GET_JSON_INT,
+                    new Type[] {Type.JSON, Type.VARCHAR}, Function.CompareMode.IS_IDENTICAL);
+            Function jsonDouble = Expr.getBuiltinFunction(FunctionSet.GET_JSON_DOUBLE,
+                    new Type[] {Type.JSON, Type.VARCHAR}, Function.CompareMode.IS_IDENTICAL);
+            Function jsonString = Expr.getBuiltinFunction(FunctionSet.GET_JSON_STRING,
+                    new Type[] {Type.JSON, Type.VARCHAR}, Function.CompareMode.IS_IDENTICAL);
+
+            SUPPORT_GET_TYPE = ImmutableMap.<PrimitiveType, Function>builder()
+                    .put(PrimitiveType.BIGINT, jsonInt)
+                    .put(PrimitiveType.DOUBLE, jsonDouble)
+                    .put(PrimitiveType.VARCHAR, jsonString)
+                    .put(PrimitiveType.CHAR, jsonString).build();
+
+            SUPPORT_CAST_TYPE = ImmutableMap.<PrimitiveType, Function>builder()
+                    .put(PrimitiveType.NULL_TYPE, jsonInt)
+                    .put(PrimitiveType.TINYINT, jsonInt)
+                    .put(PrimitiveType.SMALLINT, jsonInt)
+                    .put(PrimitiveType.INT, jsonInt)
+                    .put(PrimitiveType.FLOAT, jsonDouble)
+                    .put(PrimitiveType.DECIMAL32, jsonDouble)
+                    .put(PrimitiveType.DECIMAL64, jsonDouble)
+                    .put(PrimitiveType.DECIMAL128, jsonDouble)
+                    .build();
+        }
+
+        @Override
+        public ScalarOperator visit(ScalarOperator scalarOperator, ScalarOperator context) {
+            for (int i = 0; i < scalarOperator.getChildren().size(); i++) {
+                scalarOperator.setChild(i, scalarOperator.getChild(i).accept(this, context));
+            }
+            return scalarOperator;
+        }
+
+        @Override
+        public ScalarOperator visitCastOperator(CastOperator cast, ScalarOperator context) {
+            visit(cast.getChild(0), context);
+            if (cast.getChild(0).getType().isJsonType() && (cast.getChild(0) instanceof CallOperator)) {
+                CallOperator childCall = cast.getChild(0).cast();
+                if (SUPPORT_GET_TYPE.containsKey(cast.getType().getPrimitiveType())) {
+                    Function func = SUPPORT_GET_TYPE.get(cast.getType().getPrimitiveType());
+                    return new CallOperator(func.functionName(), cast.getType(), childCall.getChildren(), func);
+                } else if (SUPPORT_CAST_TYPE.containsKey(cast.getType().getPrimitiveType())) {
+                    Function func = SUPPORT_CAST_TYPE.get(cast.getType().getPrimitiveType());
+                    return new CastOperator(cast.getType(), new CallOperator(func.functionName(), func.getReturnType(),
+                            childCall.getChildren(), func));
+                }
+            }
+            return cast;
+        }
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/prunesubfield/SubfieldAccessPathNormalizer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/prunesubfield/SubfieldAccessPathNormalizer.java
@@ -17,6 +17,7 @@ package com.starrocks.sql.optimizer.rule.tree.prunesubfield;
 import com.google.common.collect.Lists;
 import com.starrocks.catalog.ColumnAccessPath;
 import com.starrocks.catalog.FunctionSet;
+import com.starrocks.catalog.Type;
 import com.starrocks.sql.optimizer.operator.scalar.CallOperator;
 import com.starrocks.sql.optimizer.operator.scalar.CollectionElementOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ColumnRefOperator;
@@ -29,7 +30,6 @@ import org.apache.commons.lang.StringUtils;
 import org.apache.commons.lang.text.StrTokenizer;
 
 import java.util.Collection;
-import java.util.Collections;
 import java.util.Deque;
 import java.util.List;
 import java.util.Optional;
@@ -50,6 +50,7 @@ public class SubfieldAccessPathNormalizer {
 
     private static class AccessPath {
         private final ScalarOperator root;
+        private Type valueType = Type.INVALID;
         private final List<String> paths = Lists.newArrayList();
         private final List<TAccessPathType> pathTypes = Lists.newArrayList();
 
@@ -71,6 +72,14 @@ public class SubfieldAccessPathNormalizer {
         public ScalarOperator root() {
             return root;
         }
+
+        public Type getValueType() {
+            return valueType;
+        }
+
+        public void setValueType(Type valueType) {
+            this.valueType = valueType;
+        }
     }
 
     public ColumnAccessPath normalizePath(ColumnRefOperator root, String columnName) {
@@ -78,7 +87,7 @@ public class SubfieldAccessPathNormalizer {
                 .sorted((o1, o2) -> Integer.compare(o2.paths.size(), o1.paths.size()))
                 .collect(Collectors.toList());
 
-        ColumnAccessPath rootPath = new ColumnAccessPath(TAccessPathType.ROOT, columnName);
+        ColumnAccessPath rootPath = new ColumnAccessPath(TAccessPathType.ROOT, columnName, Type.INVALID);
         for (AccessPath accessPath : paths) {
             ColumnAccessPath parentPath = rootPath;
             int depth = accessPath.paths.size();
@@ -100,18 +109,36 @@ public class SubfieldAccessPathNormalizer {
                                 (childPath.getType() == TAccessPathType.KEY && pathType == TAccessPathType.OFFSET);
                         childPath.setType(isOffsetOrKey ? TAccessPathType.KEY : TAccessPathType.ALL);
                     }
+                    childPath.setValueType(deriverCompatibleType(childPath.getValueType(), accessPath.getValueType()));
                     parentPath = childPath;
                 } else {
-                    ColumnAccessPath childPath =
-                            new ColumnAccessPath(accessPath.pathTypes.get(i), accessPath.paths.get(i));
+                    ColumnAccessPath childPath = new ColumnAccessPath(accessPath.pathTypes.get(i),
+                            accessPath.paths.get(i), accessPath.valueType);
                     parentPath.addChildPath(childPath);
                     parentPath = childPath;
                 }
             }
             parentPath.clearChildPath();
         }
-
+        rootPath.clearUnusedValueType();
         return rootPath;
+    }
+
+    private Type deriverCompatibleType(Type one, Type two) {
+        // json function used, keep same with BE's JsonFlater
+        if (one == Type.INVALID || two == Type.INVALID) {
+            return Type.INVALID;
+        }
+
+        if (one.getPrimitiveType() == two.getPrimitiveType()) {
+            return one;
+        }
+
+        // the compatible type of two types use JSON,
+        // the be can't promise cast(cast(xx as IntermediateType) as TargetType) is same as cast(xx as TargetType)
+        // e.g: cast(cast("1.1" as double) as int) is different with cast("1.1" as int)
+        // so we use JSON as the compatible type
+        return Type.JSON;
     }
 
     public boolean hasPath(ColumnRefOperator root) {
@@ -174,13 +201,26 @@ public class SubfieldAccessPathNormalizer {
 
                 String path = ((ConstantOperator) call.getArguments().get(1)).getVarchar();
                 // we flatten whole json path, and control the query hierarchy dynamically through BE-self
-                return childrenAccessPaths.get(0).map(p -> p.appendFieldNames(formatJsonPath(path)));
+                return childrenAccessPaths.get(0).map(p -> {
+                    List<String> flatPaths = Lists.newArrayList();
+                    boolean isOverflown = formatJsonPath(path, flatPaths);
+                    p.appendFieldNames(flatPaths);
+                    if (isOverflown || FunctionSet.JSON_LENGTH.equals(call.getFnName())
+                            || FunctionSet.GET_JSON_BOOL.equals(call.getFnName())
+                            || FunctionSet.JSON_EXISTS.equals(call.getFnName())) {
+                        p.setValueType(Type.JSON);
+                    } else {
+                        p.setValueType(call.getType());
+                    }
+                    return p;
+                });
             }
 
             return Optional.empty();
         }
 
         // format json path, same as BE's JsonPathPiece, just supported simple path for prune subfield
+        // the result is whether the path is overflown
         // split char: .
         // escape char: \
         // quota char: "
@@ -193,26 +233,22 @@ public class SubfieldAccessPathNormalizer {
         //  $.a.b.c.d.e.f -> [a, b] -- don't support overflown JSON_FLATTEN_DEPTH
         //  a.b.c -> [a, b, c]
         // when meet some unsupported path, return null
-        public static List<String> formatJsonPath(String path) {
+        public static boolean formatJsonPath(String path, List<String> result) {
             path = StringUtils.trimToEmpty(path);
-            if (StringUtils.isBlank(path) || StringUtils.contains(path, "..") || StringUtils.equals("$", path)) {
+            if (StringUtils.isBlank(path) || StringUtils.contains(path, "..") || StringUtils.equals("$", path) ||
+                    StringUtils.countMatches(path, "\"") % 2 != 0) {
                 // .. is recursive search in json path, not supported
-                return Collections.emptyList();
-            }
-            if (StringUtils.countMatches(path, "\"") % 2 != 0) {
                 // unpaired quota char
-                return Collections.emptyList();
+                return false;
             }
             
             StrTokenizer tokenizer = new StrTokenizer(path, '.', '"');
             String[] tokens = tokenizer.getTokenArray();
 
             if (tokens.length < 1) {
-                return Collections.emptyList();
+                return false;
             }
             int size = JSON_FLATTEN_DEPTH;
-            List<String> result = Lists.newArrayList();
-
             int i = 0;
             if (tokens[0].equals("$")) {
                 size++;
@@ -227,20 +263,20 @@ public class SubfieldAccessPathNormalizer {
                 // unsupported path, should stop match
                 Matcher matcher = JSON_ARRAY_PATTEN.matcher(tokens[i]);
                 if (!matcher.matches()) {
-                    break;
+                    return true;
                 }
                 // only extract name, don't needed index
                 String name = matcher.group(1);
                 if (StringUtils.isBlank(name)) {
-                    break;
+                    return true;
                 }
                 result.add(name);
                 if (tokens[i].replaceFirst(name, "").contains("[")) {
                     // can't support flatten array index
-                    break;
+                    return true;
                 }
             }
-            return result;
+            return size < tokens.length;
         }
 
         private Optional<AccessPath> process(ScalarOperator scalarOperator, Deque<AccessPath> accessPaths) {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/plan/PlanFragmentBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/plan/PlanFragmentBuilder.java
@@ -744,7 +744,7 @@ public class PlanFragmentBuilder {
             normalizer.collect(collector.getComplexExpressions());
 
             for (ColumnRefOperator key : scan.getColRefToColumnMetaMap().keySet()) {
-                if (!key.getType().isComplexType()) {
+                if (!key.getType().isStructType()) {
                     continue;
                 }
 

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/JsonTypeTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/JsonTypeTest.java
@@ -94,7 +94,7 @@ public class JsonTypeTest extends PlanTestBase {
         assertPlanContains("select cast(parse_json('1') -> '$.k1' as int) ",
                 "json_query(parse_json('1'), '$.k1')");
         assertPlanContains("select cast(v_json -> '$.k1' as int) from tjson_test",
-                "json_query(2: v_json, '$.k1')");
+                "CAST(get_json_int(2: v_json, '$.k1') AS INT)");
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/LowCardinalityArrayTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/LowCardinalityArrayTest.java
@@ -524,7 +524,7 @@ public class LowCardinalityArrayTest extends PlanTestBase {
         String sql = "select S_NAME from supplier_nullable where array_length(S_ADDRESS) = 2";
         String plan = getVerboseExplain(sql);
         assertNotContains(plan, "dict_col=");
-        assertContains(plan, "PredicateAccessPath: [/S_ADDRESS/OFFSET]");
+        assertContains(plan, "ColumnAccessPath: [/S_ADDRESS/OFFSET]");
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/PruneComplexSubfieldTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/PruneComplexSubfieldTest.java
@@ -369,7 +369,6 @@ public class PruneComplexSubfieldTest extends PlanTestNoneDBBase {
         sql = "select array_length(a1), a1[1] from pc0 where a1[2] = 3";
         plan = getVerboseExplain(sql);
         assertContains(plan, "ColumnAccessPath: [/a1/ALL]");
-        assertContains(plan, "PredicateAccessPath: [/a1/INDEX]");
     }
 
     @Test
@@ -865,14 +864,15 @@ public class PruneComplexSubfieldTest extends PlanTestNoneDBBase {
                 "json_length(j1, '$.a3.b3[1].c3') " +
                 "from js0;";
         String plan = getVerboseExplain(sql);
-        assertContains(plan, "ColumnAccessPath: [/j1/\"a.b.c\"/e, /j1/a/b, /j1/a1/b1, /j1/a2/b2, /j1/a3/b3]");
+        assertContains(plan, "ColumnAccessPath: [/j1/\"a.b.c\"/e(json), /j1/a/b(json), " +
+                "/j1/a1/b1(json), /j1/a2/b2(json), /j1/a3/b3(json)]");
 
         sql = "select " +
                 "JSON_EXISTS(j1, '$.a.b.c2'), " +
                 "get_json_int(j1, 'asd') " +
                 "from js0;";
         plan = getVerboseExplain(sql);
-        assertContains(plan, "ColumnAccessPath: [/j1/a/b, /j1/asd]");
+        assertContains(plan, "ColumnAccessPath: [/j1/a/b(json), /j1/asd(bigint(20))]");
     }
 
     @Test
@@ -884,7 +884,7 @@ public class PruneComplexSubfieldTest extends PlanTestNoneDBBase {
                 "json_length(j1, '$.a.b2.c3') " +
                 "from js0;";
         String plan = getVerboseExplain(sql);
-        assertContains(plan, "ColumnAccessPath: [/j1/a/b, /j1/a/b2]");
+        assertContains(plan, "ColumnAccessPath: [/j1/a/b(json), /j1/a/b2(json)]");
 
         sql = "select " +
                 "get_json_int(j1, '$.a.b[1].c1'), " +
@@ -896,7 +896,7 @@ public class PruneComplexSubfieldTest extends PlanTestNoneDBBase {
                 "JSON_EXISTS(j1, '$.\"a.b[*]\".c2[2].a') " +
                 "from js0;";
         plan = getVerboseExplain(sql);
-        assertContains(plan, "ColumnAccessPath: [/j1/\"a.b[*]\"/c2, /j1/a/b]");
+        assertContains(plan, "ColumnAccessPath: [/j1/\"a.b[*]\"/c2(json), /j1/a/b(json)]");
     }
 
     @Test
@@ -908,7 +908,7 @@ public class PruneComplexSubfieldTest extends PlanTestNoneDBBase {
                 "JSON_EXISTS(j1, '$.a.b[*].c2') " +
                 "from js0;";
         String plan = getVerboseExplain(sql);
-        assertContains(plan, "ColumnAccessPath: [/j1/a]");
+        assertContains(plan, "ColumnAccessPath: [/j1/a(json)]");
     }
 
     @Test
@@ -917,7 +917,8 @@ public class PruneComplexSubfieldTest extends PlanTestNoneDBBase {
                 "'10'->'11'->'12'->'13'->'14'->'15' " +
                 "from js0;";
         String plan = getVerboseExplain(sql);
-        assertContains(plan, "ColumnAccessPath: [/j1/1/2]");
+        assertContains(plan, "json_query[([2: j1, JSON, true], '1.2.3.4.5.6.7.8.9.10.11.12.13.14.15')");
+        assertContains(plan, "ColumnAccessPath: [/j1/1/2(json)]");
     }
 
     @Test
@@ -992,13 +993,13 @@ public class PruneComplexSubfieldTest extends PlanTestNoneDBBase {
                 "get_json_int(j1, 'asd') " +
                 "from js0;";
         String plan = getVerboseExplain(sql);
-        assertContains(plan, "ColumnAccessPath: [/j1/asd]");
+        assertContains(plan, "ColumnAccessPath: [/j1/asd(bigint(20))]");
 
         sql = "select " +
                 "get_json_int(j1, 'a.b.c.d') " +
                 "from js0;";
         plan = getVerboseExplain(sql);
-        assertContains(plan, "ColumnAccessPath: [/j1/a/b]");
+        assertContains(plan, "ColumnAccessPath: [/j1/a/b(json)]");
 
         sql = "select " +
                 "get_json_int(j1, '$') " +
@@ -1042,7 +1043,7 @@ public class PruneComplexSubfieldTest extends PlanTestNoneDBBase {
 
         sql = "select j1->'a. [0]' from js0;";
         plan = getVerboseExplain(sql);
-        assertContains(plan, "ColumnAccessPath: [/j1/a]");
+        assertContains(plan, "ColumnAccessPath: [/j1/a(json)]");
     }
 
     @Test
@@ -1056,5 +1057,50 @@ public class PruneComplexSubfieldTest extends PlanTestNoneDBBase {
                 "  |  colocate: false, reason: \n" +
                 "  |  equal join conjunct: 2: expr = 5: expr\n" +
                 "  |  other join predicates: 6: expr[3: expr] = 1");
+    }
+
+    @Test
+    public void testCastJson() throws Exception {
+        String sql = "select abs(j1->'$.a') from js0;";
+        String plan = getVerboseExplain(sql);
+        assertContains(plan, "abs[(get_json_double[([2: j1, JSON, true], '$.a');");
+        assertContains(plan, "ColumnAccessPath: [/j1/a(double)]");
+
+        sql = "select abs(j1->'$.a'), concat(j1->'$.b', 'abc') from js0;";
+        plan = getVerboseExplain(sql);
+        assertContains(plan, "abs[(get_json_double[([2: j1, JSON, true], '$.a');");
+        assertContains(plan, "concat[(get_json_string[([2: j1, JSON, true], '$.b');");
+        assertContains(plan, "ColumnAccessPath: [/j1/a(double), /j1/b(varchar)]");
+
+        sql = "select abs(j1->'$.a'), concat(j1->'$.a', 'abc') from js0;";
+        plan = getVerboseExplain(sql);
+        assertContains(plan, "abs[(get_json_double[([2: j1, JSON, true], '$.a');");
+        assertContains(plan, "concat[(get_json_string[([2: j1, JSON, true], '$.a');");
+        assertContains(plan, "ColumnAccessPath: [/j1/a(varchar)]");
+
+        sql = "select abs(j1->'$.a'), concat(j1->'$.a', 'abc'), j1->'$.a'->'$.b' from js0;";
+        plan = getVerboseExplain(sql);
+        assertContains(plan, "abs[(get_json_double[([2: j1, JSON, true], '$.a');");
+        assertContains(plan, "concat[(get_json_string[([2: j1, JSON, true], '$.a');");
+        assertContains(plan, "json_query[([2: j1, JSON, true], '$.a.b');");
+        assertContains(plan, "ColumnAccessPath: [/j1/a(json)]");
+
+        sql = "select cast(j1->'a' as decimal) from js0";
+        plan = getVerboseExplain(sql);
+        assertContains(plan, "cast(get_json_double[([2: j1, JSON, true], 'a'); " +
+                "args: JSON,VARCHAR; result: DOUBLE; " +
+                "args nullable: true; result nullable: true] as DECIMAL64(10,0))");
+        assertContains(plan, "ColumnAccessPath: [/j1/a(double)]");
+
+        sql = "select cast(j1->'a' as bigint) from js0";
+        plan = getFragmentPlan(sql);
+        assertContains(plan, "get_json_int(2: j1, 'a')");
+    }
+
+    @Test
+    public void testJsonBool() throws Exception {
+        String sql = "select get_json_bool(j1, 'a') from js0";
+        String plan = getVerboseExplain(sql);
+        assertContains(plan, "ColumnAccessPath: [/j1/a(boolean)]");
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/PruneComplexSubfieldTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/PruneComplexSubfieldTest.java
@@ -1076,7 +1076,7 @@ public class PruneComplexSubfieldTest extends PlanTestNoneDBBase {
         plan = getVerboseExplain(sql);
         assertContains(plan, "abs[(get_json_double[([2: j1, JSON, true], '$.a');");
         assertContains(plan, "concat[(get_json_string[([2: j1, JSON, true], '$.a');");
-        assertContains(plan, "ColumnAccessPath: [/j1/a(varchar)]");
+        assertContains(plan, "ColumnAccessPath: [/j1/a(json)]");
 
         sql = "select abs(j1->'$.a'), concat(j1->'$.a', 'abc'), j1->'$.a'->'$.b' from js0;";
         plan = getVerboseExplain(sql);
@@ -1101,6 +1101,6 @@ public class PruneComplexSubfieldTest extends PlanTestNoneDBBase {
     public void testJsonBool() throws Exception {
         String sql = "select get_json_bool(j1, 'a') from js0";
         String plan = getVerboseExplain(sql);
-        assertContains(plan, "ColumnAccessPath: [/j1/a(boolean)]");
+        assertContains(plan, "ColumnAccessPath: [/j1/a(json)]");
     }
 }

--- a/gensrc/thrift/PlanNodes.thrift
+++ b/gensrc/thrift/PlanNodes.thrift
@@ -495,6 +495,7 @@ struct TColumnAccessPath {
     2: optional Exprs.TExpr path
     3: optional list<TColumnAccessPath> children
     4: optional bool from_predicate
+    5: optional Types.TTypeDesc type_desc
 }
 
 // If you find yourself changing this struct, see also TLakeScanNode


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:
FE support inference json type in query

* support normalize `cast(json as xx)` to `get_json_xx`
* support type inference by `get_json_xx` when prune json subfield

Fixes #42787

## What type of PR is this:

- [ ] BugFix
- [x] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
