### PR TITLE
[Enhancement] Optimize parquet scanner by arrow io coalesce

### DIFF
--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -1256,4 +1256,8 @@ CONF_mInt32(olap_string_max_length, "1048576");
 // if mem_limit < 16 GB, disable JIT.
 // else it = min(mem_limit*0.01, 1GB)
 CONF_mInt64(jit_lru_cache_size, "0");
+
+CONF_mInt64(arrow_io_coalesce_read_max_buffer_size, "8388608");
+CONF_mInt64(arrow_io_coalesce_read_max_distance_size, "1048576");
+CONF_mInt64(arrow_read_batch_size, "4096");
 } // namespace starrocks::config

--- a/be/src/exec/parquet_reader.cpp
+++ b/be/src/exec/parquet_reader.cpp
@@ -47,8 +47,6 @@ ParquetReaderWrap::ParquetReaderWrap(std::shared_ptr<arrow::io::RandomAccessFile
           _read_size(read_size) {
     _parquet = std::move(parquet_file);
     _properties = parquet::ReaderProperties();
-    _properties.enable_buffered_stream();
-    _properties.set_buffer_size(1 * 1024 * 1024);
     _filename = (reinterpret_cast<ParquetChunkFile*>(_parquet.get()))->filename();
 }
 
@@ -84,6 +82,28 @@ Status ParquetReaderWrap::_init_parquet_reader() {
         * A DATETIME or TIMESTAMP value can include a trailing fractional seconds part in up to microseconds (6 digits) precision
         */
         arrow_reader_properties.set_coerce_int96_timestamp_unit(arrow::TimeUnit::MICRO);
+
+        // default batch size is 64K
+        arrow_reader_properties.set_batch_size(config::arrow_read_batch_size);
+
+        // io coalesce
+        // performance 0: tpcds store_sales, 23 columns, 649M, 7218819 lines
+        //                  | time | file read count | memory
+        // io coalesce 8M   | 13s  |   80            | 587M
+        // buffer stream 8M | 15s  |   176           | 1313M
+        // buffer stream 1M | 29s  |   1145          | 1157M
+        //
+        // performance 1: 1001 columns table, 147M, 50000 lines
+        //                  | time | file read count | memory
+        // io coalesce 8M   | 3s   |   20            | 1G
+        // buffer stream 8M | 15s  |   1003          | 3.3G
+        // buffer stream 1M | 15s  |   1003          | 10.1G
+        //
+        arrow_reader_properties.set_pre_buffer(true);
+        auto cache_options = arrow::io::CacheOptions::LazyDefaults();
+        cache_options.hole_size_limit = config::arrow_io_coalesce_read_max_distance_size;
+        cache_options.range_size_limit = config::arrow_io_coalesce_read_max_buffer_size;
+        arrow_reader_properties.set_cache_options(cache_options);
 
         // new file reader for parquet file
         auto st = parquet::arrow::FileReader::Make(arrow::default_memory_pool(),

--- a/be/src/exec/parquet_reader.cpp
+++ b/be/src/exec/parquet_reader.cpp
@@ -83,21 +83,22 @@ Status ParquetReaderWrap::_init_parquet_reader() {
         */
         arrow_reader_properties.set_coerce_int96_timestamp_unit(arrow::TimeUnit::MICRO);
 
-        // default batch size is 64K
+        // arrow default batch size is 64K,
+        // the bigger batch size, the more memory it uses
         arrow_reader_properties.set_batch_size(config::arrow_read_batch_size);
 
         // io coalesce
-        // performance 0: tpcds store_sales, 23 columns, 649M, 7218819 lines
-        //                  | time | file read count | memory
-        // io coalesce 8M   | 13s  |   80            | 587M
-        // buffer stream 8M | 15s  |   176           | 1313M
-        // buffer stream 1M | 29s  |   1145          | 1157M
+        // performance test 0: tpcds store_sales, 23 columns, 649M, 7218819 lines
+        //                  | file read time | file read count | memory
+        // io coalesce 8M   | 13s            |   80            | 587M
+        // buffer stream 8M | 15s            |   176           | 1313M
+        // buffer stream 1M | 29s            |   1145          | 1157M
         //
-        // performance 1: 1001 columns table, 147M, 50000 lines
-        //                  | time | file read count | memory
-        // io coalesce 8M   | 3s   |   20            | 1G
-        // buffer stream 8M | 15s  |   1003          | 3.3G
-        // buffer stream 1M | 15s  |   1003          | 10.1G
+        // performance test 1: 1001 columns table, 147M, 50000 lines
+        //                  | file read time | file read count | memory
+        // io coalesce 8M   | 3s             |   20            | 1G
+        // buffer stream 8M | 15s            |   1003          | 10.1G
+        // buffer stream 1M | 15s            |   1003          | 3.3G
         //
         arrow_reader_properties.set_pre_buffer(true);
         auto cache_options = arrow::io::CacheOptions::LazyDefaults();


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:
```
performance test 0: tpcds store_sales, 23 columns, one file 649M, 7218819 lines
                 | file read time | file read count | memory
io coalesce 8M   | 13s            |   80            | 587M
buffer stream 8M | 15s            |   176           | 1313M
buffer stream 1M | 29s            |   1145          | 1157M

performance test 1: 1001 columns table, one file 147M, 50000 lines
                 | file read time | file read count | memory
io coalesce 8M   | 3s             |   20            | 1G
buffer stream 8M | 15s            |   1003          | 10.1G
buffer stream 1M | 15s            |   1003          | 3.3G
```

Compared with buffer stream, io coalesce achieves higher performance, uses less memory, especially when there are many columns.

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [x] 3.2
  - [x] 3.1
  - [x] 3.0
  - [x] 2.5
