### PR TITLE
[Feature][FlatJson] support get_json_bool/bigint function 

### DIFF
--- a/be/src/exprs/json_functions.cpp
+++ b/be/src/exprs/json_functions.cpp
@@ -270,6 +270,10 @@ StatusOr<ColumnPtr> JsonFunctions::get_json_int(FunctionContext* context, const 
     return _get_json_value<TYPE_INT>(context, columns);
 }
 
+StatusOr<ColumnPtr> JsonFunctions::get_json_bigint(FunctionContext* context, const Columns& columns) {
+    return _get_json_value<TYPE_BIGINT>(context, columns);
+}
+
 StatusOr<ColumnPtr> JsonFunctions::get_json_double(FunctionContext* context, const Columns& columns) {
     return _get_json_value<TYPE_DOUBLE>(context, columns);
 }
@@ -278,8 +282,16 @@ StatusOr<ColumnPtr> JsonFunctions::get_json_string(FunctionContext* context, con
     return _get_json_value<TYPE_VARCHAR>(context, columns);
 }
 
+StatusOr<ColumnPtr> JsonFunctions::get_native_json_bool(FunctionContext* context, const Columns& columns) {
+    return _json_query_impl<TYPE_BOOLEAN>(context, columns);
+}
+
 StatusOr<ColumnPtr> JsonFunctions::get_native_json_int(FunctionContext* context, const Columns& columns) {
     return _json_query_impl<TYPE_INT>(context, columns);
+}
+
+StatusOr<ColumnPtr> JsonFunctions::get_native_json_bigint(FunctionContext* context, const Columns& columns) {
+    return _json_query_impl<TYPE_BIGINT>(context, columns);
 }
 
 StatusOr<ColumnPtr> JsonFunctions::get_native_json_double(FunctionContext* context, const Columns& columns) {

--- a/be/src/exprs/json_functions.h
+++ b/be/src/exprs/json_functions.h
@@ -74,6 +74,7 @@ public:
      * @return: type column
      */
     DEFINE_VECTORIZED_FN(get_json_int);
+    DEFINE_VECTORIZED_FN(get_json_bigint);
     DEFINE_VECTORIZED_FN(get_json_double);
     DEFINE_VECTORIZED_FN(get_json_string);
 
@@ -82,7 +83,9 @@ public:
      * @paramType: [JsonColumn, BinaryColumn]
      * @return: type column
      */
+    DEFINE_VECTORIZED_FN(get_native_json_bool);
     DEFINE_VECTORIZED_FN(get_native_json_int);
+    DEFINE_VECTORIZED_FN(get_native_json_bigint);
     DEFINE_VECTORIZED_FN(get_native_json_double);
     DEFINE_VECTORIZED_FN(get_native_json_string);
     DEFINE_VECTORIZED_FN(json_query);

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/FunctionSet.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/FunctionSet.java
@@ -215,6 +215,7 @@ public class FunctionSet {
     public static final String JSON_QUERY = "json_query";
     public static final String JSON_EXISTS = "json_exists";
     public static final String JSON_EACH = "json_each";
+    public static final String GET_JSON_BOOL = "get_json_bool";
     public static final String GET_JSON_DOUBLE = "get_json_double";
     public static final String GET_JSON_INT = "get_json_int";
     public static final String GET_JSON_STRING = "get_json_string";

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/ExpressionTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/ExpressionTest.java
@@ -22,6 +22,9 @@ import com.starrocks.analysis.Expr;
 import com.starrocks.analysis.IntLiteral;
 import com.starrocks.analysis.SlotRef;
 import com.starrocks.analysis.TupleId;
+import com.starrocks.catalog.Function;
+import com.starrocks.catalog.FunctionSet;
+import com.starrocks.catalog.PrimitiveType;
 import com.starrocks.catalog.Type;
 import com.starrocks.sql.analyzer.SemanticException;
 import com.starrocks.sql.ast.LambdaFunctionExpr;
@@ -1875,5 +1878,18 @@ public class ExpressionTest extends PlanTestBase {
         sql = "select parse_json('{\"a\": true}')->\"a\"->\"$....\"";
         plan = getFragmentPlan(sql);
         assertContains(plan, "json_query(json_query(parse_json('{\"a\": true}'), 'a'), '$....')");
+    }
+
+    @Test
+    public void testFoundJsonInt() {
+        Function func = Expr.getBuiltinFunction(FunctionSet.GET_JSON_INT, new Type[] {Type.VARCHAR, Type.VARCHAR},
+                Function.CompareMode.IS_NONSTRICT_SUPERTYPE_OF);
+        Assert.assertNotNull(func);
+        Assert.assertEquals(PrimitiveType.BIGINT, func.getReturnType().getPrimitiveType());
+
+        func = Expr.getBuiltinFunction(FunctionSet.GET_JSON_INT, new Type[] {Type.JSON, Type.VARCHAR},
+                Function.CompareMode.IS_NONSTRICT_SUPERTYPE_OF);
+        Assert.assertNotNull(func);
+        Assert.assertEquals(PrimitiveType.BIGINT, func.getReturnType().getPrimitiveType());
     }
 }

--- a/gensrc/script/functions.py
+++ b/gensrc/script/functions.py
@@ -722,6 +722,13 @@ vectorized_functions = [
     [100020, 'get_query_profile', True, False, 'VARCHAR', ['VARCHAR'], "UtilityFunctions::get_query_profile"],
 
     # json string function
+    [110022, "get_json_int", False, False, "BIGINT", ["VARCHAR", "VARCHAR"], "JsonFunctions::get_json_bigint",
+    "JsonFunctions::native_json_path_prepare", "JsonFunctions::native_json_path_close", False],
+    [110023, "get_json_int", False, False, "BIGINT", ["JSON", "VARCHAR"], "JsonFunctions::get_native_json_bigint",
+     "JsonFunctions::native_json_path_prepare", "JsonFunctions::native_json_path_close", False],
+
+    # deprecated INT version, use BIGINT version
+    # FE find function by signature order
     [110000, "get_json_int", False, False, "INT", ["VARCHAR", "VARCHAR"], "JsonFunctions::get_json_int",
      "JsonFunctions::native_json_path_prepare", "JsonFunctions::native_json_path_close"],
     [110001, "get_json_double", False, False, "DOUBLE", ["VARCHAR", "VARCHAR"], "JsonFunctions::get_json_double",
@@ -738,6 +745,9 @@ vectorized_functions = [
      "JsonFunctions::native_json_path_prepare", "JsonFunctions::native_json_path_close"],
     [110020, "get_json_object", False, True, "VARCHAR", ["VARCHAR", "VARCHAR"], "JsonFunctions::get_json_string",
      "JsonFunctions::native_json_path_prepare", "JsonFunctions::native_json_path_close"],
+    [110021, "get_json_bool", False, False, "BOOLEAN", ["JSON", "VARCHAR"], "JsonFunctions::get_native_json_bool",
+     "JsonFunctions::native_json_path_prepare", "JsonFunctions::native_json_path_close"],
+
 
     # json type function
     [110003, "parse_json", False, False, "JSON", ["VARCHAR"], "JsonFunctions::parse_json"],


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:

* add get_json_bool function
* update get_json_int function: add get_json_bigint to replace the int version (Json-Int is int64, use int will overflow)

test case will add in other PR

Follow #42787

## What type of PR is this:

- [ ] BugFix
- [x] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
