### PR TITLE
[Enhancement] Support analyze subfield of struct type

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/analysis/SubfieldExpr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/analysis/SubfieldExpr.java
@@ -124,4 +124,29 @@ public class SubfieldExpr extends Expr {
     public int hashCode() {
         return Objects.hash(super.hashCode(), fieldNames, copyFlag);
     }
+
+    public String getPath() {
+        String childPath = getChildPath();
+        return getSubFiledPath(childPath);
+    }
+
+    private String getSubFiledPath(String path) {
+        StringBuilder sb = new StringBuilder();
+        for (String fieldName : fieldNames) {
+            sb.append(path).append(".").append(fieldName).append(",");
+        }
+        return sb.substring(0, sb.length() - 1);
+    }
+
+    private String getChildPath() {
+        if (!(children.get(0) instanceof SubfieldExpr)) {
+            if (children.get(0) instanceof SlotRef) {
+                return ((SlotRef) children.get(0)).getColumnName();
+            }
+            return children.get(0).toSqlImpl();
+        }
+
+        String childPath = ((SubfieldExpr) children.get(0)).getChildPath();
+        return ((SubfieldExpr) children.get(0)).getSubFiledPath(childPath);
+    }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/analysis/SubfieldExpr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/analysis/SubfieldExpr.java
@@ -127,26 +127,13 @@ public class SubfieldExpr extends Expr {
 
     public String getPath() {
         String childPath = getChildPath();
-        return getSubFiledPath(childPath);
-    }
-
-    private String getSubFiledPath(String path) {
-        StringBuilder sb = new StringBuilder();
-        for (String fieldName : fieldNames) {
-            sb.append(path).append(".").append(fieldName).append(",");
-        }
-        return sb.substring(0, sb.length() - 1);
+        return childPath + "." + Joiner.on('.').join(fieldNames);
     }
 
     private String getChildPath() {
-        if (!(children.get(0) instanceof SubfieldExpr)) {
-            if (children.get(0) instanceof SlotRef) {
-                return ((SlotRef) children.get(0)).getColumnName();
-            }
-            return children.get(0).toSqlImpl();
+        if (children.get(0) instanceof SlotRef) {
+            return ((SlotRef) children.get(0)).getColumnName();
         }
-
-        String childPath = ((SubfieldExpr) children.get(0)).getChildPath();
-        return ((SubfieldExpr) children.get(0)).getSubFiledPath(childPath);
+        return children.get(0).toSqlImpl();
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/qe/DDLStmtExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/DDLStmtExecutor.java
@@ -795,6 +795,7 @@ public class DDLStmtExecutor {
                     analyzeJob = new NativeAnalyzeJob(stmt.getDbId(),
                             stmt.getTableId(),
                             stmt.getColumnNames(),
+                            stmt.getColumnTypes(),
                             stmt.isSample() ? StatsConstants.AnalyzeType.SAMPLE : StatsConstants.AnalyzeType.FULL,
                             StatsConstants.ScheduleType.SCHEDULE,
                             stmt.getProperties(), StatsConstants.ScheduleStatus.PENDING,
@@ -802,6 +803,7 @@ public class DDLStmtExecutor {
                 } else {
                     analyzeJob = new ExternalAnalyzeJob(stmt.getTableName().getCatalog(), stmt.getTableName().getDb(),
                             stmt.getTableName().getTbl(), stmt.getColumnNames(),
+                            stmt.getColumnTypes(),
                             stmt.isSample() ? StatsConstants.AnalyzeType.SAMPLE : StatsConstants.AnalyzeType.FULL,
                             StatsConstants.ScheduleType.SCHEDULE,
                             stmt.getProperties(), StatsConstants.ScheduleStatus.PENDING,

--- a/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
@@ -1860,7 +1860,6 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
 
     @VarAttr(name = SKEW_JOIN_RAND_RANGE, flag = VariableMgr.INVISIBLE)
     private int skewJoinRandRange = 1000;
-
     @VarAttr(name = ENABLE_STATS_TO_OPTIMIZE_SKEW_JOIN)
     private boolean enableStatsToOptimizeSkewJoin = true;
 

--- a/fe/fe-core/src/main/java/com/starrocks/qe/StmtExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/StmtExecutor.java
@@ -1240,7 +1240,7 @@ public class StmtExecutor {
             if (analyzeStmt.getAnalyzeTypeDesc().isHistogram()) {
                 statisticExecutor.collectStatistics(statsConnectCtx,
                     new ExternalHistogramStatisticsCollectJob(analyzeStmt.getTableName().getCatalog(),
-                            db, table, analyzeStmt.getColumnNames(),
+                            db, table, analyzeStmt.getColumnNames(), analyzeStmt.getColumnTypes(),
                             StatsConstants.AnalyzeType.HISTOGRAM, StatsConstants.ScheduleType.ONCE,
                             analyzeStmt.getProperties()),
                         analyzeStatus,
@@ -1248,12 +1248,12 @@ public class StmtExecutor {
             } else {
                 StatsConstants.AnalyzeType analyzeType = analyzeStmt.isSample() ? StatsConstants.AnalyzeType.SAMPLE :
                         StatsConstants.AnalyzeType.FULL;
-                // TODO: we should check old statistic and confirm paritionlist
                 statisticExecutor.collectStatistics(statsConnectCtx,
                         StatisticsCollectJobFactory.buildExternalStatisticsCollectJob(
                                 analyzeStmt.getTableName().getCatalog(),
                                 db, table, null,
                                 analyzeStmt.getColumnNames(),
+                                analyzeStmt.getColumnTypes(),
                                 analyzeType,
                                 StatsConstants.ScheduleType.ONCE, analyzeStmt.getProperties()),
                         analyzeStatus,
@@ -1263,6 +1263,7 @@ public class StmtExecutor {
             if (analyzeStmt.getAnalyzeTypeDesc().isHistogram()) {
                 statisticExecutor.collectStatistics(statsConnectCtx,
                         new HistogramStatisticsCollectJob(db, table, analyzeStmt.getColumnNames(),
+                                analyzeStmt.getColumnTypes(),
                                 StatsConstants.AnalyzeType.HISTOGRAM, StatsConstants.ScheduleType.ONCE,
                                 analyzeStmt.getProperties()),
                         analyzeStatus,
@@ -1274,6 +1275,7 @@ public class StmtExecutor {
                 statisticExecutor.collectStatistics(statsConnectCtx,
                         StatisticsCollectJobFactory.buildStatisticsCollectJob(db, table, null,
                                 analyzeStmt.getColumnNames(),
+                                analyzeStmt.getColumnTypes(),
                                 analyzeType,
                                 StatsConstants.ScheduleType.ONCE, analyzeStmt.getProperties()),
                         analyzeStatus,

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AnalyzeStmtAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AnalyzeStmtAnalyzer.java
@@ -19,8 +19,8 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
+import com.starrocks.analysis.Expr;
 import com.starrocks.analysis.TableName;
-import com.starrocks.catalog.Column;
 import com.starrocks.catalog.Database;
 import com.starrocks.catalog.OlapTable;
 import com.starrocks.catalog.PartitionKey;
@@ -56,6 +56,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.regex.Pattern;
 import java.util.regex.PatternSyntaxException;
+import java.util.stream.Collectors;
 
 import static com.starrocks.connector.PartitionUtil.createPartitionKey;
 import static com.starrocks.connector.PartitionUtil.toPartitionValues;
@@ -108,19 +109,20 @@ public class AnalyzeStmtAnalyzer {
 
             // Analyze columns mentioned in the statement.
             Set<String> mentionedColumns = Sets.newTreeSet(String.CASE_INSENSITIVE_ORDER);
-            List<String> columnNames = statement.getColumnNames();
+            List<Expr> columns = statement.getColumns();
             // The actual column name, avoiding case sensitivity issues
             List<String> realColumnNames = Lists.newArrayList();
-            if (columnNames != null) {
-                for (String colName : columnNames) {
-                    Column col = analyzeTable.getColumn(colName);
-                    if (col == null) {
-                        throw new SemanticException("Unknown column '%s' in '%s'", colName, analyzeTable.getName());
-                    }
+            if (columns != null && !columns.isEmpty()) {
+                for (Expr column : columns) {
+                    ExpressionAnalyzer.analyzeExpression(column, new AnalyzeState(), new Scope(RelationId.anonymous(),
+                            new RelationFields(analyzeTable.getBaseSchema().stream().map(col -> new Field(col.getName(),
+                                            col.getType(), statement.getTableName(), null))
+                                    .collect(Collectors.toList()))), session);
+                    String colName = StatisticUtils.getColumnName(analyzeTable, column);
                     if (!mentionedColumns.add(colName)) {
                         throw new SemanticException("Column '%s' specified twice", colName);
                     }
-                    realColumnNames.add(col.getName());
+                    realColumnNames.add(colName);
                 }
                 statement.setColumnNames(realColumnNames);
             }
@@ -198,20 +200,20 @@ public class AnalyzeStmtAnalyzer {
                     // Analyze columns mentioned in the statement.
                     Set<String> mentionedColumns = Sets.newTreeSet(String.CASE_INSENSITIVE_ORDER);
 
-                    List<String> columnNames = statement.getColumnNames();
+                    List<Expr> columns = statement.getColumns();
                     // The actual column name, avoiding case sensitivity issues
                     List<String> realColumnNames = Lists.newArrayList();
-                    if (columnNames != null && !columnNames.isEmpty()) {
-                        for (String colName : columnNames) {
-                            Column col = analyzeTable.getColumn(colName);
-                            if (col == null) {
-                                throw new SemanticException("Unknown column '%s' in '%s'", colName,
-                                        analyzeTable.getName());
-                            }
+                    if (columns != null && !columns.isEmpty()) {
+                        for (Expr column : columns) {
+                            ExpressionAnalyzer.analyzeExpression(column, new AnalyzeState(), new Scope(RelationId.anonymous(),
+                                    new RelationFields(analyzeTable.getBaseSchema().stream().map(col -> new Field(col.getName(),
+                                                    col.getType(), statement.getTableName(), null))
+                                            .collect(Collectors.toList()))), session);
+                            String colName = StatisticUtils.getColumnName(analyzeTable, column);
                             if (!mentionedColumns.add(colName)) {
                                 throw new SemanticException("Column '%s' specified twice", colName);
                             }
-                            realColumnNames.add(col.getName());
+                            realColumnNames.add(colName);
                         }
                         statement.setColumnNames(realColumnNames);
                     }
@@ -257,14 +259,13 @@ public class AnalyzeStmtAnalyzer {
         private void analyzeAnalyzeTypeDesc(ConnectContext session, AnalyzeStmt statement,
                                             AnalyzeTypeDesc analyzeTypeDesc) {
             if (analyzeTypeDesc instanceof AnalyzeHistogramDesc) {
-                List<String> columns = statement.getColumnNames();
+                List<Expr> columns = statement.getColumns();
                 Table analyzeTable = MetaUtils.getTable(session, statement.getTableName());
                 if (!isSupportedHistogramAnalyzeTableType(analyzeTable)) {
                     throw new SemanticException("Can't create histogram statistics on table type is %s",
                             analyzeTable.getType().name());
                 }
-                for (String columnName : columns) {
-                    Column column = analyzeTable.getColumn(columnName);
+                for (Expr column : columns) {
                     if (column.getType().isComplexType()
                             || column.getType().isJsonType()
                             || column.getType().isOnlyMetricType()) {
@@ -352,13 +353,17 @@ public class AnalyzeStmtAnalyzer {
             }
 
             Table analyzeTable = MetaUtils.getTable(session, statement.getTableName());
-            List<String> columnNames = statement.getColumnNames();
-            for (String colName : columnNames) {
-                Column col = analyzeTable.getColumn(colName);
-                if (col == null) {
-                    throw new SemanticException("Unknown column '%s' in '%s'", colName, analyzeTable.getName());
-                }
+            List<Expr> columns = statement.getColumns();
+            List<String> realColumnNames = Lists.newArrayList();
+            for (Expr column : columns) {
+                ExpressionAnalyzer.analyzeExpression(column, new AnalyzeState(), new Scope(RelationId.anonymous(),
+                        new RelationFields(analyzeTable.getBaseSchema().stream().map(col -> new Field(col.getName(),
+                                        col.getType(), statement.getTableName(), null))
+                                .collect(Collectors.toList()))), session);
+                String colName = StatisticUtils.getColumnName(analyzeTable, column);
+                realColumnNames.add(colName);
             }
+            statement.setColumnNames(realColumnNames);
             return null;
         }
     }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/AnalyzeStmt.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/AnalyzeStmt.java
@@ -15,38 +15,45 @@
 
 package com.starrocks.sql.ast;
 
+import com.google.common.collect.Lists;
+import com.starrocks.analysis.Expr;
 import com.starrocks.analysis.RedirectStatus;
 import com.starrocks.analysis.TableName;
+import com.starrocks.catalog.Type;
 import com.starrocks.sql.parser.NodePosition;
 
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 public class AnalyzeStmt extends StatementBase {
     private final TableName tbl;
-    private List<String> columnNames;
+    private List<Expr> columns;
+    private List<String> columnNames = Lists.newArrayList();
     private final boolean isSample;
     private final boolean isAsync;
     private boolean isExternal = false;
     private Map<String, String> properties;
     private final AnalyzeTypeDesc analyzeTypeDesc;
 
-    public AnalyzeStmt(TableName tbl, List<String> columns, Map<String, String> properties,
-                       boolean isSample, boolean isAsync,
-                       AnalyzeTypeDesc analyzeTypeDesc) {
-        this(tbl, columns, properties, isSample, isAsync, analyzeTypeDesc, NodePosition.ZERO);
-    }
-
-    public AnalyzeStmt(TableName tbl, List<String> columns, Map<String, String> properties,
+    public AnalyzeStmt(TableName tbl, List<Expr> columns, Map<String, String> properties,
                        boolean isSample, boolean isAsync,
                        AnalyzeTypeDesc analyzeTypeDesc, NodePosition pos) {
         super(pos);
         this.tbl = tbl;
-        this.columnNames = columns;
+        this.columns = columns;
         this.isSample = isSample;
         this.isAsync = isAsync;
         this.properties = properties;
         this.analyzeTypeDesc = analyzeTypeDesc;
+    }
+
+    public List<Expr> getColumns() {
+        return columns;
+    }
+
+    public List<Type> getColumnTypes() {
+        return columns.stream().map(Expr::getType).collect(Collectors.toList());
     }
 
     public List<String> getColumnNames() {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/CreateAnalyzeJobStmt.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/CreateAnalyzeJobStmt.java
@@ -34,7 +34,7 @@ public class CreateAnalyzeJobStmt extends DdlStmt {
     private final TableName tbl;
 
     private List<Expr> columns;
-    private List<String> columnNames;
+    private List<String> columnNames = Lists.newArrayList();
     private final boolean isSample;
     private Map<String, String> properties;
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/CreateAnalyzeJobStmt.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/CreateAnalyzeJobStmt.java
@@ -16,19 +16,24 @@
 package com.starrocks.sql.ast;
 
 import com.google.common.collect.Lists;
+import com.starrocks.analysis.Expr;
 import com.starrocks.analysis.TableName;
 import com.starrocks.catalog.InternalCatalog;
+import com.starrocks.catalog.Type;
 import com.starrocks.sql.parser.NodePosition;
 import com.starrocks.statistic.StatsConstants;
 
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 public class CreateAnalyzeJobStmt extends DdlStmt {
     private String catalogName;
     private long dbId;
     private long tableId;
     private final TableName tbl;
+
+    private List<Expr> columns;
     private List<String> columnNames;
     private final boolean isSample;
     private Map<String, String> properties;
@@ -41,14 +46,14 @@ public class CreateAnalyzeJobStmt extends DdlStmt {
         this(new TableName(db, null), Lists.newArrayList(), isSample, properties, pos);
     }
 
-    public CreateAnalyzeJobStmt(TableName tbl, List<String> columnNames, boolean isSample,
+    public CreateAnalyzeJobStmt(TableName tbl, List<Expr> columns, boolean isSample,
                                 Map<String, String> properties, NodePosition pos) {
         super(pos);
         this.catalogName = InternalCatalog.DEFAULT_INTERNAL_CATALOG_NAME;
         this.tbl = tbl;
         this.dbId = StatsConstants.DEFAULT_ALL_ID;
         this.tableId = StatsConstants.DEFAULT_ALL_ID;
-        this.columnNames = columnNames;
+        this.columns = columns;
         this.isSample = isSample;
         this.properties = properties;
     }
@@ -80,6 +85,15 @@ public class CreateAnalyzeJobStmt extends DdlStmt {
     public void setColumnNames(List<String> columnNames) {
         this.columnNames = columnNames;
     }
+
+    public List<Expr> getColumns() {
+        return columns;
+    }
+
+    public List<Type> getColumnTypes() {
+        return columns.stream().map(Expr::getType).collect(Collectors.toList());
+    }
+
 
     public boolean isSample() {
         return isSample;

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/DropHistogramStmt.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/DropHistogramStmt.java
@@ -15,6 +15,7 @@
 
 package com.starrocks.sql.ast;
 
+import com.starrocks.analysis.Expr;
 import com.starrocks.analysis.RedirectStatus;
 import com.starrocks.analysis.TableName;
 import com.starrocks.sql.parser.NodePosition;
@@ -23,18 +24,19 @@ import java.util.List;
 
 public class DropHistogramStmt extends StatementBase {
     private final TableName tbl;
-    private final List<String> columnNames;
+    private List<String> columnNames;
+    private final List<Expr> columns;
 
     private boolean isExternal = false;
 
-    public DropHistogramStmt(TableName tbl, List<String> columnNames) {
-        this(tbl, columnNames, NodePosition.ZERO);
+    public DropHistogramStmt(TableName tbl, List<Expr> columns) {
+        this(tbl, columns, NodePosition.ZERO);
     }
 
-    public DropHistogramStmt(TableName tbl, List<String> columnNames, NodePosition pos) {
+    public DropHistogramStmt(TableName tbl, List<Expr> columns, NodePosition pos) {
         super(pos);
         this.tbl = tbl;
-        this.columnNames = columnNames;
+        this.columns = columns;
     }
 
     public TableName getTableName() {
@@ -43,6 +45,14 @@ public class DropHistogramStmt extends StatementBase {
 
     public List<String> getColumnNames() {
         return columnNames;
+    }
+
+    public void setColumnNames(List<String> columnNames) {
+        this.columnNames = columnNames;
+    }
+
+    public List<Expr> getColumns() {
+        return columns;
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/sql/parser/AstBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/parser/AstBuilder.java
@@ -2215,10 +2215,8 @@ public class AstBuilder extends StarRocksBaseVisitor<ParseNode> {
                 columns.add(new SlotRef(null, qualifiedName.getParts().get(0)));
             } else {
                 Expr base = new SlotRef(null, qualifiedName.getParts().get(0));
-                for (int i = 1; i < qualifiedName.getParts().size(); i++) {
-                    base = new SubfieldExpr(base, List.of(qualifiedName.getParts().get(i)));
-                }
-                columns.add(base);
+                columns.add(new SubfieldExpr(base, qualifiedName.getParts().subList(1,
+                        qualifiedName.getParts().size())));
             }
         }
         return columns;

--- a/fe/fe-core/src/main/java/com/starrocks/sql/parser/StarRocks.g4
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/parser/StarRocks.g4
@@ -1234,7 +1234,7 @@ showStreamLoadStatement
 // ------------------------------------------- Analyze Statement -------------------------------------------------------
 
 analyzeStatement
-    : ANALYZE (FULL | SAMPLE)? TABLE qualifiedName ('(' identifier (',' identifier)* ')')?
+    : ANALYZE (FULL | SAMPLE)? TABLE qualifiedName ('(' qualifiedName  (',' qualifiedName)* ')')?
         (WITH (SYNC | ASYNC) MODE)?
         properties?
     ;
@@ -1244,20 +1244,20 @@ dropStatsStatement
     ;
 
 analyzeHistogramStatement
-    : ANALYZE TABLE qualifiedName UPDATE HISTOGRAM ON identifier (',' identifier)*
+    : ANALYZE TABLE qualifiedName UPDATE HISTOGRAM ON qualifiedName (',' qualifiedName)*
         (WITH (SYNC | ASYNC) MODE)?
         (WITH bucket=INTEGER_VALUE BUCKETS)?
         properties?
     ;
 
 dropHistogramStatement
-    : ANALYZE TABLE qualifiedName DROP HISTOGRAM ON identifier (',' identifier)*
+    : ANALYZE TABLE qualifiedName DROP HISTOGRAM ON qualifiedName (',' qualifiedName)*
     ;
 
 createAnalyzeStatement
     : CREATE ANALYZE (FULL | SAMPLE)? ALL properties?
     | CREATE ANALYZE (FULL | SAMPLE)? DATABASE db=identifier properties?
-    | CREATE ANALYZE (FULL | SAMPLE)? TABLE qualifiedName ('(' identifier (',' identifier)* ')')? properties?
+    | CREATE ANALYZE (FULL | SAMPLE)? TABLE qualifiedName ('(' qualifiedName (',' qualifiedName)* ')')? properties?
     ;
 
 dropAnalyzeJobStatement

--- a/fe/fe-core/src/main/java/com/starrocks/statistic/AnalyzeJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/statistic/AnalyzeJob.java
@@ -14,6 +14,7 @@
 
 package com.starrocks.statistic;
 
+import com.starrocks.catalog.Type;
 import com.starrocks.common.MetaNotFoundException;
 import com.starrocks.qe.ConnectContext;
 
@@ -35,6 +36,8 @@ public interface AnalyzeJob {
     String getTableName() throws MetaNotFoundException;
 
     List<String> getColumns();
+
+    List<Type> getColumnTypes();
 
     StatsConstants.AnalyzeType getAnalyzeType();
 

--- a/fe/fe-core/src/main/java/com/starrocks/statistic/ExternalAnalyzeJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/statistic/ExternalAnalyzeJob.java
@@ -16,6 +16,7 @@
 package com.starrocks.statistic;
 
 import com.google.gson.annotations.SerializedName;
+import com.starrocks.catalog.Type;
 import com.starrocks.common.io.Text;
 import com.starrocks.common.io.Writable;
 import com.starrocks.persist.gson.GsonUtils;
@@ -49,6 +50,9 @@ public class ExternalAnalyzeJob implements AnalyzeJob, Writable {
     @SerializedName("columns")
     private List<String> columns;
 
+    @SerializedName("columnTypes")
+    private List<Type> columnTypes;
+
     @SerializedName("type")
     private AnalyzeType type;
 
@@ -67,14 +71,16 @@ public class ExternalAnalyzeJob implements AnalyzeJob, Writable {
     @SerializedName("reason")
     private String reason;
 
-    public ExternalAnalyzeJob(String catalogName, String dbName, String tableName, List<String> columns, AnalyzeType type,
+    public ExternalAnalyzeJob(String catalogName, String dbName, String tableName, List<String> columnNames,
+                              List<Type> columnTypes, AnalyzeType type,
                               ScheduleType scheduleType, Map<String, String> properties, ScheduleStatus status,
                               LocalDateTime workTime) {
         this.id = -1;
         this.catalogName = catalogName;
         this.dbName = dbName;
         this.tableName = tableName;
-        this.columns = columns;
+        this.columns = columnNames;
+        this.columnTypes = columnTypes;
         this.type = type;
         this.scheduleType = scheduleType;
         this.properties = properties;
@@ -115,6 +121,11 @@ public class ExternalAnalyzeJob implements AnalyzeJob, Writable {
     @Override
     public List<String> getColumns() {
         return columns;
+    }
+
+    @Override
+    public List<Type> getColumnTypes() {
+        return columnTypes;
     }
 
     @Override
@@ -183,7 +194,7 @@ public class ExternalAnalyzeJob implements AnalyzeJob, Writable {
         for (StatisticsCollectJob statsJob : statisticsCollectJobList) {
             AnalyzeStatus analyzeStatus = new ExternalAnalyzeStatus(GlobalStateMgr.getCurrentState().getNextId(),
                     statsJob.getCatalogName(), statsJob.getDb().getFullName(), statsJob.getTable().getName(),
-                    statsJob.getTable().getUUID(), statsJob.getColumns(), statsJob.getType(), statsJob.getScheduleType(),
+                    statsJob.getTable().getUUID(), statsJob.getColumnNames(), statsJob.getType(), statsJob.getScheduleType(),
                     statsJob.getProperties(), LocalDateTime.now());
             analyzeStatus.setStatus(StatsConstants.ScheduleStatus.FAILED);
             GlobalStateMgr.getCurrentState().getAnalyzeMgr().addAnalyzeStatus(analyzeStatus);

--- a/fe/fe-core/src/main/java/com/starrocks/statistic/FullStatisticsCollectJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/statistic/FullStatisticsCollectJob.java
@@ -20,7 +20,6 @@ import com.starrocks.analysis.Expr;
 import com.starrocks.analysis.IntLiteral;
 import com.starrocks.analysis.StringLiteral;
 import com.starrocks.analysis.TableName;
-import com.starrocks.catalog.Column;
 import com.starrocks.catalog.Database;
 import com.starrocks.catalog.Partition;
 import com.starrocks.catalog.Table;
@@ -72,6 +71,13 @@ public class FullStatisticsCollectJob extends StatisticsCollectJob {
                                     StatsConstants.AnalyzeType type, StatsConstants.ScheduleType scheduleType,
                                     Map<String, String> properties) {
         super(db, table, columns, type, scheduleType, properties);
+        this.partitionIdList = partitionIdList;
+    }
+
+    public FullStatisticsCollectJob(Database db, Table table, List<Long> partitionIdList, List<String> columnNames,
+                                    List<Type> columnTypes, StatsConstants.AnalyzeType type,
+                                    StatsConstants.ScheduleType scheduleType, Map<String, String> properties) {
+        super(db, table, columnNames, columnTypes, type, scheduleType, properties);
         this.partitionIdList = partitionIdList;
     }
 
@@ -227,18 +233,19 @@ public class FullStatisticsCollectJob extends StatisticsCollectJob {
                 // statistics job doesn't lock DB, partition may be dropped, skip it
                 continue;
             }
-            for (String columnName : columns) {
-                totalQuerySQL.add(buildBatchCollectFullStatisticSQL(table, partition, columnName));
+            for (int i = 0; i < columnNames.size(); i++) {
+                totalQuerySQL.add(buildBatchCollectFullStatisticSQL(table, partition, columnNames.get(i),
+                        columnTypes.get(i)));
             }
         }
 
         return Lists.partition(totalQuerySQL, parallelism);
     }
 
-    private String buildBatchCollectFullStatisticSQL(Table table, Partition partition, String columnName) {
+    private String buildBatchCollectFullStatisticSQL(Table table, Partition partition, String columnName,
+                                                     Type columnType) {
         StringBuilder builder = new StringBuilder();
         VelocityContext context = new VelocityContext();
-        Column column = table.getColumn(columnName);
 
         String columnNameStr = StringEscapeUtils.escapeSql(columnName);
         String quoteColumnName = StatisticUtils.quoting(columnName);
@@ -246,12 +253,12 @@ public class FullStatisticsCollectJob extends StatisticsCollectJob {
         context.put("version", StatsConstants.STATISTIC_BATCH_VERSION);
         context.put("partitionId", partition.getId());
         context.put("columnNameStr", columnNameStr);
-        context.put("dataSize", fullAnalyzeGetDataSize(column));
+        context.put("dataSize", fullAnalyzeGetDataSize(columnName, columnType));
         context.put("partitionName", partition.getName());
         context.put("dbName", db.getOriginName());
         context.put("tableName", table.getName());
 
-        if (!column.getType().canStatistic()) {
+        if (!columnType.canStatistic()) {
             context.put("hllFunction", "hex(hll_serialize(hll_empty()))");
             context.put("countNullFunction", "0");
             context.put("maxFunction", "''");
@@ -259,8 +266,8 @@ public class FullStatisticsCollectJob extends StatisticsCollectJob {
         } else {
             context.put("hllFunction", "hex(hll_serialize(IFNULL(hll_raw(" + quoteColumnName + "), hll_empty())))");
             context.put("countNullFunction", "COUNT(1) - COUNT(" + quoteColumnName + ")");
-            context.put("maxFunction", getMinMaxFunction(column, quoteColumnName, true));
-            context.put("minFunction", getMinMaxFunction(column, quoteColumnName, false));
+            context.put("maxFunction", getMinMaxFunction(columnType, quoteColumnName, true));
+            context.put("minFunction", getMinMaxFunction(columnType, quoteColumnName, false));
         }
 
         builder.append(build(context, BATCH_FULL_STATISTIC_TEMPLATE));

--- a/fe/fe-core/src/main/java/com/starrocks/statistic/NativeAnalyzeJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/statistic/NativeAnalyzeJob.java
@@ -19,6 +19,7 @@ import com.google.gson.annotations.SerializedName;
 import com.starrocks.catalog.Database;
 import com.starrocks.catalog.InternalCatalog;
 import com.starrocks.catalog.Table;
+import com.starrocks.catalog.Type;
 import com.starrocks.common.MetaNotFoundException;
 import com.starrocks.common.io.Text;
 import com.starrocks.common.io.Writable;
@@ -51,6 +52,9 @@ public class NativeAnalyzeJob implements AnalyzeJob, Writable {
     @SerializedName("columns")
     private List<String> columns;
 
+    @SerializedName("columnTypes")
+    private List<Type> columnTypes;
+
     @SerializedName("type")
     private AnalyzeType type;
 
@@ -69,12 +73,14 @@ public class NativeAnalyzeJob implements AnalyzeJob, Writable {
     @SerializedName("reason")
     private String reason;
 
-    public NativeAnalyzeJob(long dbId, long tableId, List<String> columns, AnalyzeType type, ScheduleType scheduleType,
-                            Map<String, String> properties, ScheduleStatus status, LocalDateTime workTime) {
+    public NativeAnalyzeJob(long dbId, long tableId, List<String> columns, List<Type> columnTypes, AnalyzeType type,
+                            ScheduleType scheduleType, Map<String, String> properties, ScheduleStatus status,
+                            LocalDateTime workTime) {
         this.id = -1;
         this.dbId = dbId;
         this.tableId = tableId;
         this.columns = columns;
+        this.columnTypes = columnTypes;
         this.type = type;
         this.scheduleType = scheduleType;
         this.properties = properties;
@@ -135,6 +141,11 @@ public class NativeAnalyzeJob implements AnalyzeJob, Writable {
     @Override
     public List<String> getColumns() {
         return columns;
+    }
+
+    @Override
+    public List<Type> getColumnTypes() {
+        return columnTypes;
     }
 
     @Override
@@ -202,7 +213,7 @@ public class NativeAnalyzeJob implements AnalyzeJob, Writable {
         boolean hasFailedCollectJob = false;
         for (StatisticsCollectJob statsJob : statisticsCollectJobList) {
             AnalyzeStatus analyzeStatus = new NativeAnalyzeStatus(GlobalStateMgr.getCurrentState().getNextId(),
-                    statsJob.getDb().getId(), statsJob.getTable().getId(), statsJob.getColumns(),
+                    statsJob.getDb().getId(), statsJob.getTable().getId(), statsJob.getColumnNames(),
                     statsJob.getType(), statsJob.getScheduleType(), statsJob.getProperties(), LocalDateTime.now());
             analyzeStatus.setStatus(StatsConstants.ScheduleStatus.FAILED);
             GlobalStateMgr.getCurrentState().getAnalyzeMgr().addAnalyzeStatus(analyzeStatus);

--- a/fe/fe-core/src/main/java/com/starrocks/statistic/StatisticAutoCollector.java
+++ b/fe/fe-core/src/main/java/com/starrocks/statistic/StatisticAutoCollector.java
@@ -69,14 +69,14 @@ public class StatisticAutoCollector extends FrontendDaemon {
         if (Config.enable_collect_full_statistic) {
             LOG.info("auto collect full statistic on all databases start");
             List<StatisticsCollectJob> allJobs = StatisticsCollectJobFactory.buildStatisticsCollectJob(
-                    new NativeAnalyzeJob(StatsConstants.DEFAULT_ALL_ID, StatsConstants.DEFAULT_ALL_ID, null,
+                    new NativeAnalyzeJob(StatsConstants.DEFAULT_ALL_ID, StatsConstants.DEFAULT_ALL_ID, null, null,
                             AnalyzeType.FULL, ScheduleType.SCHEDULE,
                             Maps.newHashMap(),
                             ScheduleStatus.PENDING,
                             LocalDateTime.MIN));
             for (StatisticsCollectJob statsJob : allJobs) {
                 AnalyzeStatus analyzeStatus = new NativeAnalyzeStatus(GlobalStateMgr.getCurrentState().getNextId(),
-                        statsJob.getDb().getId(), statsJob.getTable().getId(), statsJob.getColumns(),
+                        statsJob.getDb().getId(), statsJob.getTable().getId(), statsJob.getColumnNames(),
                         statsJob.getType(), statsJob.getScheduleType(), statsJob.getProperties(), LocalDateTime.now());
                 analyzeStatus.setStatus(StatsConstants.ScheduleStatus.FAILED);
                 GlobalStateMgr.getCurrentState().getAnalyzeMgr().addAnalyzeStatus(analyzeStatus);
@@ -127,8 +127,8 @@ public class StatisticAutoCollector extends FrontendDaemon {
         }
 
         NativeAnalyzeJob nativeAnalyzeJob = new NativeAnalyzeJob(StatsConstants.DEFAULT_ALL_ID, StatsConstants.DEFAULT_ALL_ID,
-                Collections.emptyList(), AnalyzeType.SAMPLE, ScheduleType.SCHEDULE, Maps.newHashMap(),
-                ScheduleStatus.PENDING, LocalDateTime.MIN);
+                Collections.emptyList(), Collections.emptyList(), AnalyzeType.SAMPLE, ScheduleType.SCHEDULE,
+                Maps.newHashMap(), ScheduleStatus.PENDING, LocalDateTime.MIN);
         GlobalStateMgr.getCurrentState().getAnalyzeMgr().addAnalyzeJob(nativeAnalyzeJob);
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/statistic/StatisticExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/statistic/StatisticExecutor.java
@@ -304,7 +304,7 @@ public class StatisticExecutor {
         statsConnectCtx.setStatisticsConnection(false);
         if (statsJob.getType().equals(StatsConstants.AnalyzeType.HISTOGRAM)) {
             if (table.isNativeTableOrMaterializedView()) {
-                for (String columnName : statsJob.getColumns()) {
+                for (String columnName : statsJob.getColumnNames()) {
                     HistogramStatsMeta histogramStatsMeta = new HistogramStatsMeta(db.getId(),
                             table.getId(), columnName, statsJob.getType(), analyzeStatus.getEndTime(),
                             statsJob.getProperties());
@@ -314,7 +314,7 @@ public class StatisticExecutor {
                             Lists.newArrayList(histogramStatsMeta.getColumn()), refreshAsync);
                 }
             } else {
-                for (String columnName : statsJob.getColumns()) {
+                for (String columnName : statsJob.getColumnNames()) {
                     ExternalHistogramStatsMeta histogramStatsMeta = new ExternalHistogramStatsMeta(
                             statsJob.getCatalogName(), db.getFullName(), table.getName(), columnName,
                             statsJob.getType(), analyzeStatus.getEndTime(), statsJob.getProperties());
@@ -329,7 +329,7 @@ public class StatisticExecutor {
             if (table.isNativeTableOrMaterializedView()) {
                 long existUpdateRows = GlobalStateMgr.getCurrentState().getAnalyzeMgr().getExistUpdateRows(table.getId());
                 BasicStatsMeta basicStatsMeta = new BasicStatsMeta(db.getId(), table.getId(),
-                        statsJob.getColumns(), statsJob.getType(), analyzeStatus.getEndTime(),
+                        statsJob.getColumnNames(), statsJob.getType(), analyzeStatus.getEndTime(),
                         statsJob.getProperties(), existUpdateRows);
                 GlobalStateMgr.getCurrentState().getAnalyzeMgr().addBasicStatsMeta(basicStatsMeta);
                 GlobalStateMgr.getCurrentState().getAnalyzeMgr().refreshBasicStatisticsCache(
@@ -338,12 +338,12 @@ public class StatisticExecutor {
             } else {
                 // for external table
                 ExternalBasicStatsMeta externalBasicStatsMeta = new ExternalBasicStatsMeta(statsJob.getCatalogName(),
-                        db.getFullName(), table.getName(), statsJob.getColumns(), statsJob.getType(),
+                        db.getFullName(), table.getName(), statsJob.getColumnNames(), statsJob.getType(),
                         analyzeStatus.getStartTime(), statsJob.getProperties());
                 GlobalStateMgr.getCurrentState().getAnalyzeMgr().addExternalBasicStatsMeta(externalBasicStatsMeta);
                 GlobalStateMgr.getCurrentState().getAnalyzeMgr()
                         .refreshConnectorTableBasicStatisticsCache(statsJob.getCatalogName(),
-                                db.getFullName(), table.getName(), statsJob.getColumns(), refreshAsync);
+                                db.getFullName(), table.getName(), statsJob.getColumnNames(), refreshAsync);
             }
         }
         return analyzeStatus;

--- a/fe/fe-core/src/main/java/com/starrocks/statistic/StatisticUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/statistic/StatisticUtils.java
@@ -18,6 +18,9 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
+import com.starrocks.analysis.Expr;
+import com.starrocks.analysis.SlotRef;
+import com.starrocks.analysis.SubfieldExpr;
 import com.starrocks.analysis.TypeDef;
 import com.starrocks.catalog.AggregateType;
 import com.starrocks.catalog.Column;
@@ -177,8 +180,8 @@ public class StatisticUtils {
 
                         statisticExecutor.collectStatistics(statsConnectCtx,
                                 StatisticsCollectJobFactory.buildStatisticsCollectJob(db, table,
-                                        new ArrayList<>(collectPartitionIds), null, analyzeType,
-                                        StatsConstants.ScheduleType.ONCE,
+                                        new ArrayList<>(collectPartitionIds), null, null,
+                                        analyzeType, StatsConstants.ScheduleType.ONCE,
                                         analyzeStatus.getProperties()), analyzeStatus, false);
                     });
         } catch (Throwable e) {
@@ -478,7 +481,12 @@ public class StatisticUtils {
     }
 
     public static String quoting(String identifier) {
-        return "`" + identifier + "`";
+        String[] splits = identifier.split("\\.");
+        StringBuilder sb = new StringBuilder();
+        for (String split : splits) {
+            sb.append("`").append(split).append("`.");
+        }
+        return sb.substring(0, sb.length() - 1);
     }
 
     public static void dropStatisticsAfterDropTable(Table table) {
@@ -504,5 +512,16 @@ public class StatisticUtils {
 
         List<String> columns = table.getBaseSchema().stream().map(Column::getName).collect(Collectors.toList());
         GlobalStateMgr.getCurrentState().getStatisticStorage().expireConnectorTableColumnStatistics(table, columns);
+    }
+
+    // only support collect statistics for slotRef and subfield expr
+    public static String getColumnName(Table table, Expr column) {
+        String colName;
+        if (column instanceof SlotRef) {
+            colName = table.getColumn(((SlotRef) column).getColumnName()).getName();
+        } else {
+            colName = ((SubfieldExpr) column).getPath();
+        }
+        return colName;
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/IcebergMetadataTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/IcebergMetadataTest.java
@@ -412,9 +412,9 @@ public class IcebergMetadataTest extends TableTestBase {
         };
 
         GlobalStateMgr.getCurrentState().getAnalyzeMgr().addAnalyzeJob(new ExternalAnalyzeJob("iceberg_catalog",
-                "iceberg_db", "table1", Lists.newArrayList(), StatsConstants.AnalyzeType.FULL,
-                StatsConstants.ScheduleType.ONCE, Maps.newHashMap(), StatsConstants.ScheduleStatus.PENDING,
-                LocalDateTime.MIN));
+                "iceberg_db", "table1", Lists.newArrayList(), Lists.newArrayList(),
+                StatsConstants.AnalyzeType.FULL, StatsConstants.ScheduleType.ONCE, Maps.newHashMap(),
+                StatsConstants.ScheduleStatus.PENDING, LocalDateTime.MIN));
 
         new MockUp<IcebergMetadata>() {
             @Mock

--- a/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AnalyzeStmtTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AnalyzeStmtTest.java
@@ -93,13 +93,25 @@ public class AnalyzeStmtTest {
         createTblStmtStr = "create table db.tb2(kk1 int, kk2 json) "
                 + "DUPLICATE KEY(kk1) distributed by hash(kk1) buckets 3 properties('replication_num' = '1');";
         starRocksAssert.withTable(createTblStmtStr);
+
+        String createStructTableSql = "CREATE TABLE struct_a(\n" +
+                "a INT, \n" +
+                "b STRUCT<a INT, c INT> COMMENT 'smith',\n" +
+                "c STRUCT<a INT, b DOUBLE>,\n" +
+                "d STRUCT<a INT, b ARRAY<STRUCT<a INT, b DOUBLE>>, c STRUCT<a INT>>,\n" +
+                "struct_a STRUCT<struct_a STRUCT<struct_a INT>, other INT> COMMENT 'alias test'\n" +
+                ") DISTRIBUTED BY HASH(`a`) BUCKETS 1\n" +
+                "PROPERTIES (\n" +
+                "    \"replication_num\" = \"1\"\n" +
+                ");";
+        starRocksAssert.withTable(createStructTableSql);
     }
 
     @Test
     public void testAllColumns() {
         String sql = "analyze table db.tbl";
         AnalyzeStmt analyzeStmt = (AnalyzeStmt) analyzeSuccess(sql);
-        Assert.assertNull(analyzeStmt.getColumnNames());
+        Assert.assertEquals(analyzeStmt.getColumnNames().size(), 0);
     }
 
     @Test
@@ -126,7 +138,26 @@ public class AnalyzeStmtTest {
 
         sql = "analyze table test.t0";
         analyzeStmt = (AnalyzeStmt) analyzeSuccess(sql);
-        Assert.assertNull(analyzeStmt.getColumnNames());
+        Assert.assertEquals(analyzeStmt.getColumnNames().size(), 0);
+    }
+
+    @Test
+    public void testStructColumns() {
+        String sql = "analyze table db.struct_a (b.a, b.c)";
+        AnalyzeStmt analyzeStmt = (AnalyzeStmt) analyzeSuccess(sql);
+        Assert.assertEquals("[b.a, b.c]", analyzeStmt.getColumnNames().toString());
+
+        sql = "analyze table db.struct_a (d.c.a)";
+        analyzeStmt = (AnalyzeStmt) analyzeSuccess(sql);
+        Assert.assertEquals("[d.c.a]", analyzeStmt.getColumnNames().toString());
+
+        sql = "analyze table db.struct_a update histogram on b.a, b.c, d.c.a with 256 buckets";
+        analyzeStmt = (AnalyzeStmt) analyzeSuccess(sql);
+        Assert.assertEquals("[b.a, b.c, d.c.a]", analyzeStmt.getColumnNames().toString());
+
+        sql = "analyze table db.struct_a drop histogram on b.a, b.c, d.c.a";
+        DropHistogramStmt dropHistogramStmt = (DropHistogramStmt) analyzeSuccess(sql);
+        Assert.assertEquals("[b.a, b.c, d.c.a]", dropHistogramStmt.getColumnNames().toString());
     }
 
     @Test
@@ -183,6 +214,7 @@ public class AnalyzeStmtTest {
         Table table = testDb.getTable("t0");
 
         NativeAnalyzeJob nativeAnalyzeJob = new NativeAnalyzeJob(testDb.getId(), table.getId(), Lists.newArrayList(),
+                Lists.newArrayList(),
                 StatsConstants.AnalyzeType.FULL,
                 StatsConstants.ScheduleType.ONCE, Maps.newHashMap(),
                 StatsConstants.ScheduleStatus.FINISH, LocalDateTime.MIN);
@@ -190,7 +222,8 @@ public class AnalyzeStmtTest {
                 ShowAnalyzeJobStmt.showAnalyzeJobs(getConnectContext(), nativeAnalyzeJob).toString());
 
         ExternalAnalyzeJob externalAnalyzeJob = new ExternalAnalyzeJob("hive0", "partitioned_db",
-                "t1", Lists.newArrayList(), StatsConstants.AnalyzeType.FULL,
+                "t1", Lists.newArrayList(), Lists.newArrayList(),
+                StatsConstants.AnalyzeType.FULL,
                 StatsConstants.ScheduleType.ONCE, Maps.newHashMap(), StatsConstants.ScheduleStatus.FINISH,
                 LocalDateTime.MIN);
         Assert.assertEquals("[-1, hive0, partitioned_db, t1, ALL, FULL, ONCE, {}, FINISH, None, ]",

--- a/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/PrivilegeCheckerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/PrivilegeCheckerTest.java
@@ -735,6 +735,7 @@ public class PrivilegeCheckerTest {
         ctxToTestUser();
         AnalyzeMgr analyzeManager = GlobalStateMgr.getCurrentState().getAnalyzeMgr();
         NativeAnalyzeJob nativeAnalyzeJob = new NativeAnalyzeJob(-1, -1, Lists.newArrayList(),
+                Lists.newArrayList(),
                 StatsConstants.AnalyzeType.FULL, StatsConstants.ScheduleType.ONCE, Maps.newHashMap(),
                 StatsConstants.ScheduleStatus.FINISH, LocalDateTime.MIN);
         List<String> showResult = ShowAnalyzeJobStmt.showAnalyzeJobs(ctx, nativeAnalyzeJob);
@@ -762,7 +763,7 @@ public class PrivilegeCheckerTest {
 
         GlobalStateMgr globalStateMgr = GlobalStateMgr.getCurrentState();
         Database db1 = globalStateMgr.getDb("db1");
-        nativeAnalyzeJob = new NativeAnalyzeJob(db1.getId(), -1, Lists.newArrayList(),
+        nativeAnalyzeJob = new NativeAnalyzeJob(db1.getId(), -1, Lists.newArrayList(), Lists.newArrayList(),
                 StatsConstants.AnalyzeType.FULL, StatsConstants.ScheduleType.ONCE, Maps.newHashMap(),
                 StatsConstants.ScheduleStatus.FINISH, LocalDateTime.MIN);
         showResult = ShowAnalyzeJobStmt.showAnalyzeJobs(ctx, nativeAnalyzeJob);
@@ -784,7 +785,7 @@ public class PrivilegeCheckerTest {
         grantRevokeSqlAsRoot("revoke SELECT,INSERT on db1.tbl2 from test");
 
         Table tbl1 = db1.getTable("tbl1");
-        nativeAnalyzeJob = new NativeAnalyzeJob(db1.getId(), tbl1.getId(), Lists.newArrayList(),
+        nativeAnalyzeJob = new NativeAnalyzeJob(db1.getId(), tbl1.getId(), Lists.newArrayList(), Lists.newArrayList(),
                 StatsConstants.AnalyzeType.FULL, StatsConstants.ScheduleType.ONCE, Maps.newHashMap(),
                 StatsConstants.ScheduleStatus.FINISH, LocalDateTime.MIN);
         showResult = ShowAnalyzeJobStmt.showAnalyzeJobs(ctx, nativeAnalyzeJob);
@@ -806,7 +807,7 @@ public class PrivilegeCheckerTest {
 
         Database db2 = globalStateMgr.getDb("db2");
         tbl1 = db2.getTable("tbl1");
-        nativeAnalyzeJob = new NativeAnalyzeJob(db2.getId(), tbl1.getId(), Lists.newArrayList(),
+        nativeAnalyzeJob = new NativeAnalyzeJob(db2.getId(), tbl1.getId(), Lists.newArrayList(), Lists.newArrayList(),
                 StatsConstants.AnalyzeType.FULL, StatsConstants.ScheduleType.ONCE, Maps.newHashMap(),
                 StatsConstants.ScheduleStatus.FINISH, LocalDateTime.MIN);
         showResult = ShowAnalyzeJobStmt.showAnalyzeJobs(ctx, nativeAnalyzeJob);

--- a/fe/fe-core/src/test/java/com/starrocks/statistic/AnalyzeMgrTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/statistic/AnalyzeMgrTest.java
@@ -159,13 +159,13 @@ public class AnalyzeMgrTest {
         Assert.assertEquals(0, GlobalStateMgr.getCurrentState().getAnalyzeMgr().getAnalyzeStatusMap().size());
 
         // test analyze job
-        NativeAnalyzeJob nativeAnalyzeJob = new NativeAnalyzeJob(123, 1234, null,
+        NativeAnalyzeJob nativeAnalyzeJob = new NativeAnalyzeJob(123, 1234, null, null,
                 StatsConstants.AnalyzeType.FULL, StatsConstants.ScheduleType.SCHEDULE,
                 Maps.newHashMap(),
                 StatsConstants.ScheduleStatus.PENDING,
                 LocalDateTime.MIN);
         ExternalAnalyzeJob externalAnalyzeJob = new ExternalAnalyzeJob("hive0", "hive_db", "t1",
-                null, StatsConstants.AnalyzeType.FULL,
+                null, null, StatsConstants.AnalyzeType.FULL,
                 StatsConstants.ScheduleType.SCHEDULE, Maps.newHashMap(),
                 StatsConstants.ScheduleStatus.PENDING, LocalDateTime.MIN);
         analyzeMgr.addAnalyzeJob(nativeAnalyzeJob);


### PR DESCRIPTION
## Why I'm doing:
StarRorcks do not support collect stats for subfield of struct
## What I'm doing:
support collect stats for subfield of struct, include:
1. analyze sample/full table xxx (struct_col.subfield1, struct_col.subfield2)
2. create analyze table xxx (struct_col.subfield1, struct_col.subfield2)
3. analyze table xxx update histogram on struct_col.subfield1, struct_col.subfield2
4. analyze table xxx drop histogram on struct_col.subfield1, struct_col.subfield2


Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
