### PR TITLE
[Doc] remove semicolon when formatting the output

### DIFF
--- a/docs/en/loading/automq-routine-load.md
+++ b/docs/en/loading/automq-routine-load.md
@@ -130,7 +130,7 @@ To specify the mapping and transformation relationship between the source data a
 First, we check the Routine Load import job and confirm the Routine Load import task status is in RUNNING status.
 
 ```sql
-show routine load\G;
+show routine load\G
 ```
 
 Then, querying the corresponding table in the StarRocks database, we can observe that the data has been successfully imported.

--- a/docs/en/sql-reference/sql-statements/data-manipulation/SHOW_LOAD.md
+++ b/docs/en/sql-reference/sql-statements/data-manipulation/SHOW_LOAD.md
@@ -85,7 +85,7 @@ The output of this statement varies based on loading methods.
 Example 1: Vertically display all load jobs in your current database.
 
 ```plaintext
-SHOW LOAD\G;
+SHOW LOAD\G
 *************************** 1. row ***************************
          JobId: 976331
          Label: duplicate_table_with_null

--- a/docs/en/sql-reference/sql-statements/data-manipulation/SHOW_MATERIALIZED_VIEW.md
+++ b/docs/en/sql-reference/sql-statements/data-manipulation/SHOW_MATERIALIZED_VIEW.md
@@ -106,7 +106,7 @@ REFRESH MATERIALIZED VIEW customer_mv;
 Example 1: Show a specific materialized view.
 
 ```Plain
-mysql> SHOW MATERIALIZED VIEWS WHERE NAME='customer_mv'\G;
+mysql> SHOW MATERIALIZED VIEWS WHERE NAME='customer_mv'\G
 *************************** 1. row ***************************
                         id: 10142
                       name: customer_mv
@@ -137,7 +137,7 @@ GROUP BY `customer`.`c_custkey`, `customer`.`c_phone`, `customer`.`c_acctbal`;
 Example 2: Show materialized views by matching the name.
 
 ```Plain
-mysql> SHOW MATERIALIZED VIEWS WHERE NAME LIKE 'customer_mv'\G;
+mysql> SHOW MATERIALIZED VIEWS WHERE NAME LIKE 'customer_mv'\G
 *************************** 1. row ***************************
                         id: 10142
                       name: customer_mv

--- a/docs/en/using_starrocks/Materialized_view.md
+++ b/docs/en/using_starrocks/Materialized_view.md
@@ -332,7 +332,7 @@ The following example checks the execution status of the materialized view that 
 2. Check the execution status in the table `task_runs` using the `TASK_NAME` you have found.
 
     ```Plain
-    mysql> select * from information_schema.task_runs where task_name='mv-59299' order by CREATE_TIME \G;
+    mysql> select * from information_schema.task_runs where task_name='mv-59299' order by CREATE_TIME\G
     *************************** 1. row ***************************
         QUERY_ID: d9cef11f-7a00-11ed-bd90-00163e14767f
         TASK_NAME: mv-59299

--- a/docs/zh/loading/automq-routine-load.md
+++ b/docs/zh/loading/automq-routine-load.md
@@ -122,7 +122,7 @@ COLUMNS 中的列名对应**目标表**的列名，列的顺序对应**源数据
 首先我们查看 Routine Load 导入作业的情况，确认 Routine Load 导入任务状态为 RUNNING：
 
 ```sql
-show routine load\G;
+show routine load\G
 ```
 
 然后查询 StarRocks 数据库中对应的表，我们可以看到数据已经被成功导入：

--- a/docs/zh/sql-reference/sql-statements/data-manipulation/SHOW_LOAD.md
+++ b/docs/zh/sql-reference/sql-statements/data-manipulation/SHOW_LOAD.md
@@ -24,7 +24,7 @@ SHOW LOAD [ FROM db_name ]
 
 > **说明**
 >
-> 返回结果中的字段较多，可使用`\G`分行，如 `SHOW LOAD WHERE LABEL = "label1"\G;`。详情参见[示例一](#示例)。
+> 返回结果中的字段较多，可使用`\G`分行，如 `SHOW LOAD WHERE LABEL = "label1"\G`。详情参见[示例一](#示例)。
 
 ## 参数说明
 

--- a/docs/zh/sql-reference/sql-statements/data-manipulation/SHOW_MATERIALIZED_VIEW.md
+++ b/docs/zh/sql-reference/sql-statements/data-manipulation/SHOW_MATERIALIZED_VIEW.md
@@ -103,7 +103,7 @@ REFRESH MATERIALIZED VIEW customer_mv;
 示例一：通过精确匹配查看特定物化视图
 
 ```Plain
-mysql> show materialized views  where name='customer_mv'\G;
+mysql> show materialized views  where name='customer_mv'\G
 *************************** 1. row ***************************
                         id: 10142
                       name: customer_mv
@@ -134,7 +134,7 @@ GROUP BY `customer`.`c_custkey`, `customer`.`c_phone`, `customer`.`c_acctbal`;
 示例二：通过模糊匹配查看物化视图
 
 ```Plain
-mysql> show materialized views  where name like 'customer_mv'\G;
+mysql> show materialized views  where name like 'customer_mv'\G
 *************************** 1. row ***************************
                         id: 10142
                       name: customer_mv

--- a/docs/zh/using_starrocks/Materialized_view.md
+++ b/docs/zh/using_starrocks/Materialized_view.md
@@ -332,7 +332,7 @@ SHOW CREATE MATERIALIZED VIEW order_mv;
 2. 基于查询到的 `TASK_NAME` 在表 `task_runs` 中查看执行状态。
 
    ```Plain
-   mysql> select * from information_schema.task_runs where task_name='mv-59299' order by CREATE_TIME \G;
+   mysql> select * from information_schema.task_runs where task_name='mv-59299' order by CREATE_TIME\G
    *************************** 1. row ***************************
         QUERY_ID: d9cef11f-7a00-11ed-bd90-00163e14767f
        TASK_NAME: mv-59299


### PR DESCRIPTION
## Why I'm doing:
When running a statement with `\G;`, after executing the query, the MySQL client interprets the semicolon as the end of a new query.

Ex:
```
mysql> select version()\G;
*************************** 1. row ***************************
version(): 5.1.0
1 row in set (0.17 sec)

ERROR: 
No query specified
```

## What I'm doing:
Changing the usage of `\G;` to `\G` in the documentation.

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [x] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [x] 3.2
  - [x] 3.1
  - [ ] 3.0
  - [ ] 2.5