### PR TITLE
[Enhancement] Support multiversion function for simd operations

### DIFF
--- a/be/src/simd/multi_version.h
+++ b/be/src/simd/multi_version.h
@@ -1,0 +1,39 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+// Only x86 support function multiversion.
+// https://gcc.gnu.org/wiki/FunctionMultiVersioning
+// TODO(GoHalo) Support aarch64 platform.
+#if defined(__GNUC__) && defined(__x86_64__)
+#include <x86intrin.h>
+
+#define MFV_IMPL(IMPL, ATTR)                                                               \
+    _Pragma("GCC diagnostic push") _Pragma("GCC diagnostic ignored \"-Wunused-function\"") \
+            ATTR static inline IMPL _Pragma("GCC diagnostic pop")
+
+#define MFV_SSE42(IMPL) MFV_IMPL(IMPL, __attribute__((target("sse4.2"))))
+#define MFV_AVX2(IMPL) MFV_IMPL(IMPL, __attribute__((target("avx2"))))
+#define MFV_AVX512(IMPL) MFV_IMPL(IMPL, __attribute__((target("avx512f,avx512bw"))))
+#define MFV_DEFAULT(IMPL) MFV_IMPL(IMPL, __attribute__((target("default"))))
+
+#else
+
+#define MFV_SSE42(IMPL)
+#define MFV_AVX2(IMPL)
+#define MFV_AVX512(IMPL)
+#define MFV_DEFAULT(IMPL) IMPL
+
+#endif


### PR DESCRIPTION
## Why I'm doing:
Currently the simd is compiled based on the preprocessing code, such as `#if defined(__AVX2__)` `#if defined(__SSE2__)`.
This means the binary will only supoort avx2 or sse2 which is determined at the compilation stage. If you run on a machine which doesn't support avx2, then an error will raised, especially when we try to support avx512.

With function multiversion or indirect function, which implementations will be invoked is determined when start up.
Details could check [GNU Function MultiVersioning](https://gcc.gnu.org/wiki/FunctionMultiVersioning).

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [x] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
- [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
