### PR TITLE
[BugFix]fix prepare execute bug when use jdbc 

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/qe/ConnectProcessor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/ConnectProcessor.java
@@ -533,7 +533,8 @@ public class ConnectProcessor {
             // new_params_bind_flag
             if (packetBuf.hasRemaining() && (int) packetBuf.get() != 0) {
                 // parse params types
-                IntStream.range(0, numParams).forEach(i -> mysqlTypeCodes[i] = (int) packetBuf.getChar());
+                IntStream.range(0, numParams)
+                        .forEach(i -> prepareCtx.getStmt().addMysqlTypeCodes((int) packetBuf.getChar()));
             }
             // gene exprs
             List<Expr> exprs = new ArrayList<>();

--- a/fe/fe-core/src/main/java/com/starrocks/qe/ConnectProcessor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/ConnectProcessor.java
@@ -528,8 +528,7 @@ public class ConnectProcessor {
         packetBuf.get(nullBitmap);
         try {
             ctx.setQueryId(UUIDUtil.genUUID());
-            Integer[] mysqlTypeCodes = new Integer[numParams];
-
+            
             // new_params_bind_flag
             if (packetBuf.hasRemaining() && (int) packetBuf.get() != 0) {
                 // parse params types

--- a/fe/fe-core/src/main/java/com/starrocks/qe/ConnectProcessor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/ConnectProcessor.java
@@ -532,8 +532,9 @@ public class ConnectProcessor {
             // new_params_bind_flag
             if (packetBuf.hasRemaining() && (int) packetBuf.get() != 0) {
                 // parse params types
-                IntStream.range(0, numParams)
-                        .forEach(i -> prepareCtx.getStmt().addMysqlTypeCodes((int) packetBuf.getChar()));
+                for (int i = 0; i < numParams; ++i) {
+                    prepareCtx.getStmt().getMysqlTypeCodes().set(i, (int) packetBuf.getChar());
+                }
             }
             // gene exprs
             List<Expr> exprs = new ArrayList<>();

--- a/fe/fe-core/src/main/java/com/starrocks/qe/ConnectProcessor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/ConnectProcessor.java
@@ -96,7 +96,6 @@ import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Optional;
-import java.util.stream.IntStream;
 
 /**
  * Process one mysql connection, receive one pakcet, process, send one packet.

--- a/fe/fe-core/src/main/java/com/starrocks/qe/ConnectProcessor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/ConnectProcessor.java
@@ -543,7 +543,7 @@ public class ConnectProcessor {
                     exprs.add(new NullLiteral());
                     continue;
                 }
-                LiteralExpr l = LiteralExpr.parseLiteral(mysqlTypeCodes[i]);
+                LiteralExpr l = LiteralExpr.parseLiteral(prepareCtx.getStmt().getMysqlTypeCodes().get(i));
                 l.parseMysqlParam(packetBuf);
                 exprs.add(l);
             }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/PrepareStmt.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/PrepareStmt.java
@@ -78,11 +78,7 @@ public class PrepareStmt extends StatementBase {
         }
         return labels;
     }
-
-    public void addMysqlTypeCodes(Integer mysqlTypeCode) {
-        mysqlTypeCodes.add(mysqlTypeCode);
-    }
-
+    
     public List<Integer> getMysqlTypeCodes() {
         return mysqlTypeCodes;
     }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/PrepareStmt.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/PrepareStmt.java
@@ -38,10 +38,8 @@ public class PrepareStmt extends StatementBase {
         this.name = name;
         this.innerStmt = stmt;
         this.parameters = parameters == null ? ImmutableList.of() : parameters;
-        if (this.parameters != null) {
-            for (int i = 0; i < parameters.size(); i++) {
-                mysqlTypeCodes.add(0);
-            }
+        for (int i = 0; i < parameters.size(); i++) {
+            mysqlTypeCodes.add(0);
         }
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/PrepareStmt.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/PrepareStmt.java
@@ -38,6 +38,9 @@ public class PrepareStmt extends StatementBase {
         this.name = name;
         this.innerStmt = stmt;
         this.parameters = parameters == null ? ImmutableList.of() : parameters;
+        for (int i = 0; i < parameters.size(); i++) {
+            mysqlTypeCodes.add(0);
+        }
     }
 
     public StatementBase getInnerStmt() {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/PrepareStmt.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/PrepareStmt.java
@@ -38,7 +38,7 @@ public class PrepareStmt extends StatementBase {
         this.name = name;
         this.innerStmt = stmt;
         this.parameters = parameters == null ? ImmutableList.of() : parameters;
-        for (int i = 0; i < parameters.size(); i++) {
+        for (int i = 0; i < this.parameters.size(); i++) {
             mysqlTypeCodes.add(0);
         }
     }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/PrepareStmt.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/PrepareStmt.java
@@ -31,6 +31,8 @@ public class PrepareStmt extends StatementBase {
 
     protected List<Parameter> parameters;
 
+    protected List<Integer> mysqlTypeCodes = new ArrayList<>();
+
     public PrepareStmt(String name, StatementBase stmt, List<Parameter> parameters) {
         super(NodePosition.ZERO);
         this.name = name;
@@ -72,6 +74,14 @@ public class PrepareStmt extends StatementBase {
             labels.add("$" + parameter.getSlotId());
         }
         return labels;
+    }
+
+    public void addMysqlTypeCodes(Integer mysqlTypeCode) {
+        mysqlTypeCodes.add(mysqlTypeCode);
+    }
+
+    public List<Integer> getMysqlTypeCodes() {
+        return mysqlTypeCodes;
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/PrepareStmt.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/PrepareStmt.java
@@ -38,8 +38,10 @@ public class PrepareStmt extends StatementBase {
         this.name = name;
         this.innerStmt = stmt;
         this.parameters = parameters == null ? ImmutableList.of() : parameters;
-        for (int i = 0; i < parameters.size(); i++) {
-            mysqlTypeCodes.add(0);
+        if (this.parameters != null) {
+            for (int i = 0; i < parameters.size(); i++) {
+                mysqlTypeCodes.add(0);
+            }
         }
     }
 
@@ -78,7 +80,7 @@ public class PrepareStmt extends StatementBase {
         }
         return labels;
     }
-    
+
     public List<Integer> getMysqlTypeCodes() {
         return mysqlTypeCodes;
     }

--- a/test/sql/test_preparestatement/R/test_preprare_statement
+++ b/test/sql/test_preparestatement/R/test_preprare_statement
@@ -133,6 +133,6 @@ EXECUTE select_customer_stmt USING @customer_key;
 DROP PREPARE select_customer_stmt;
 -- result:
 -- !result
-DROP TABLE select_customer_stmt FORCE;
+DROP TABLE customer_row FORCE;
 -- result:
 -- !result

--- a/test/sql/test_preparestatement/R/test_preprare_statement
+++ b/test/sql/test_preparestatement/R/test_preprare_statement
@@ -90,3 +90,49 @@ DROP TABLE prepare_stmt FORCE;
 -- result:
 []
 -- !result
+CREATE TABLE `customer_row` (
+  `customer_key` bigint(20) NOT NULL COMMENT "",
+  `customer_row_value_0` varchar(65533) NULL COMMENT "",
+  `customer_row_value_1` varchar(65533) NULL COMMENT "",
+  `customer_row_value_2` varchar(65533) NULL COMMENT ""
+) ENGINE=OLAP
+PRIMARY KEY(`customer_key`)
+DISTRIBUTED BY HASH(`customer_key`)
+PROPERTIES (
+"replication_num" = "1",
+"in_memory" = "false",
+"enable_persistent_index" = "true",
+"replicated_storage" = "true",
+"compression" = "LZ4"
+);
+-- result:
+-- !result
+insert into customer_row values(1, 'a','a','a');
+-- result:
+-- !result
+insert into customer_row values(2, 'b','b','b');
+-- result:
+-- !result
+PREPARE select_customer_stmt FROM 'SELECT customer_key, customer_row_value_0, customer_row_value_1, customer_row_value_2 FROM customer_row WHERE customer_key = ?';
+-- result:
+-- !result
+SET @customer_key = 1;
+-- result:
+-- !result
+EXECUTE select_customer_stmt USING @customer_key;
+-- result:
+1	a	a	a
+-- !result
+SET @customer_key = 2;
+-- result:
+-- !result
+EXECUTE select_customer_stmt USING @customer_key;
+-- result:
+2	b	b	b
+-- !result
+DROP PREPARE select_customer_stmt;
+-- result:
+-- !result
+DROP TABLE select_customer_stmt FORCE;
+-- result:
+-- !result

--- a/test/sql/test_preparestatement/T/test_preprare_statement
+++ b/test/sql/test_preparestatement/T/test_preprare_statement
@@ -39,3 +39,33 @@ deallocate prepare stmt2; -- deallocate is alias
 drop prepare stmt3;
 
 DROP TABLE prepare_stmt FORCE;
+
+
+CREATE TABLE IF NOT EXISTS `customer_row` (
+  `customer_key` bigint(20) NOT NULL COMMENT "",
+  `customer_row_value_0` varchar(65533) NULL COMMENT "",
+  `customer_row_value_1` varchar(65533) NULL COMMENT "",
+  `customer_row_value_2` varchar(65533) NULL COMMENT ""
+) ENGINE=OLAP
+PRIMARY KEY(`customer_key`)
+DISTRIBUTED BY HASH(`customer_key`)
+PROPERTIES (
+"replication_num" = "1",
+"in_memory" = "false",
+"enable_persistent_index" = "true",
+"replicated_storage" = "true",
+"compression" = "LZ4"
+);
+
+insert into customer_row values(1, 'a','a','a');
+insert into customer_row values(2, 'b','b','b');
+
+PREPARE select_customer_stmt FROM 'SELECT customer_key, customer_row_value_0, customer_row_value_1, customer_row_value_2 FROM customer_row WHERE customer_key = ?';
+
+SET @customer_key = 1;
+EXECUTE select_customer_stmt USING @customer_key;
+SET @customer_key = 2;
+EXECUTE select_customer_stmt USING @customer_key;
+
+DROP PREPARE select_customer_stmt;
+DROP TABLE select_customer_stmt FORCE;

--- a/test/sql/test_preparestatement/T/test_preprare_statement
+++ b/test/sql/test_preparestatement/T/test_preprare_statement
@@ -68,4 +68,4 @@ SET @customer_key = 2;
 EXECUTE select_customer_stmt USING @customer_key;
 
 DROP PREPARE select_customer_stmt;
-DROP TABLE select_customer_stmt FORCE;
+DROP TABLE customer_row FORCE;


### PR DESCRIPTION
## Why I'm doing:

When I was testing the Prepare function, the code threw an NPE error

```
----starRocksSelect----
customer_key:1, customer_row_value_0:a, customer_row_value_1:a, customer_row_value_2:a
java.sql.SQLSyntaxErrorException: NullPointerException, msg: null
	at com.mysql.cj.jdbc.exceptions.SQLError.createSQLException(SQLError.java:120)
	at com.mysql.cj.jdbc.exceptions.SQLExceptionsMapping.translateException(SQLExceptionsMapping.java:122)
	at com.mysql.cj.jdbc.ServerPreparedStatement.serverExecute(ServerPreparedStatement.java:637)
	at com.mysql.cj.jdbc.ServerPreparedStatement.executeInternal(ServerPreparedStatement.java:418)
	at com.mysql.cj.jdbc.ClientPreparedStatement.executeQuery(ClientPreparedStatement.java:1003)
	at ToolApplication.starRocksSelect(ToolApplication.java:84)
	at ToolApplication.main(ToolApplication.java:162)
```

Prepare Test Code 

```
public static void starRocksSelect() {
      String url = "jdbc:mysql://xxxxx:9030/demo?useServerPrepStmts=true";
      String user = "xxxx";
      String password = "xxxxx";

      try {
          Class.forName("com.mysql.cj.jdbc.Driver");
          Connection conn = DriverManager.getConnection(url, user, password);
          String query = "SELECT customer_key, customer_row_value_0, customer_row_value_1, customer_row_value_2 FROM customer_row WHERE customer_key = ?";
          PreparedStatement pstmt = conn.prepareStatement(query);
          pstmt.setInt(1, 1); 
          ResultSet rs = pstmt.executeQuery(); 
          
          while (rs.next()) {
              BigDecimal c0 = rs.getBigDecimal("customer_key");
              String c1 = rs.getString("customer_row_value_0");
              String c2 = rs.getString("customer_row_value_1");
              String c3 = rs.getString("customer_row_value_2");
              System.out.println("customer_key:" + c0 + ", customer_row_value_0:" + c1 + ", customer_row_value_1:" + c2 + ", customer_row_value_2:" + c3);
          }
          rs.close(); 
          
          pstmt.setInt(1, 2); 
          rs = pstmt.executeQuery(); 
          
          while (rs.next()) {
              BigDecimal c0 = rs.getBigDecimal("customer_key");
              String c1 = rs.getString("customer_row_value_0");
              String c2 = rs.getString("customer_row_value_1");
              String c3 = rs.getString("customer_row_value_2");
              System.out.println("customer_key:" + c0 + ", customer_row_value_0:" + c1 + ", customer_row_value_1:" + c2 + ", customer_row_value_2:" + c3);
          }
          rs.close();
          
          pstmt.close();
          conn.close();

      } catch (ClassNotFoundException | SQLException e) {
          e.printStackTrace();
      }
  }

  public static void main(String[] args) {
      starRocksSelect();
  }
```

customer_row table structure

```
CREATE TABLE `customer_row` (
  `customer_key` bigint(20) NOT NULL COMMENT "",
  `customer_row_value_0` varchar(65533) NULL COMMENT "",
  `customer_row_value_1` varchar(65533) NULL COMMENT "",
  `customer_row_value_2` varchar(65533) NULL COMMENT ""
) ENGINE=OLAP
PRIMARY KEY(`customer_key`)
DISTRIBUTED BY HASH(`customer_key`)
PROPERTIES (
"replication_num" = "1",
"in_memory" = "false",
"enable_persistent_index" = "true",
"replicated_storage" = "true",
"storage_type" = "COLUMN_WITH_ROW",
"compression" = "LZ4"
);
```

## What I'm doing:

Adjust the placeholder Params MysqlTypeCodes in the handleExecute method to the PrepareStmt in the Session preparedStmtCtx

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
- [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [x] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
