### PR TITLE
[BugFix] Truncate hive table's text string if length excceed varchar's length

### DIFF
--- a/be/src/formats/csv/string_converter.cpp
+++ b/be/src/formats/csv/string_converter.cpp
@@ -63,17 +63,7 @@ bool StringConverter::read_string(Column* column, const Slice& s, const Options&
 
     if (options.is_hive) {
         // truncate directly, support for utf-8 encoding
-        std::vector<size_t> index{};
-        const size_t utf8_length = get_utf8_index(s, &index);
-        size_t actual_size = 0;
-        if (utf8_length > max_size) {
-            // do truncate
-            actual_size = index[max_size];
-        } else {
-            // don't need to truncate
-            actual_size = s.size;
-        }
-        down_cast<BinaryColumn*>(column)->append(Slice(s.get_data(), actual_size));
+        down_cast<BinaryColumn*>(column)->append(truncate_utf8(s, max_size));
     } else {
         if (config::enable_check_string_lengths &&
             ((s.size > TypeDescriptor::MAX_VARCHAR_LENGTH) || (max_size > 0 && s.size > max_size))) {

--- a/be/src/formats/csv/string_converter.cpp
+++ b/be/src/formats/csv/string_converter.cpp
@@ -13,10 +13,7 @@
 // limitations under the License.
 
 #include "formats/csv/string_converter.h"
-#ifdef __x86_64__
-#include <immintrin.h>
-#include <mmintrin.h>
-#endif
+
 #include "column/binary_column.h"
 #include "common/config.h"
 #include "gutil/strings/substitute.h"

--- a/be/src/formats/csv/string_converter.cpp
+++ b/be/src/formats/csv/string_converter.cpp
@@ -55,30 +55,23 @@ Status StringConverter::write_quoted_string(OutputStream* os, const Column& colu
 }
 
 bool StringConverter::read_string(Column* column, const Slice& s, const Options& options) const {
-    int max_size = 0;
+    size_t max_size = 0;
     if (options.type_desc != nullptr) {
         max_size = options.type_desc->len;
     }
 
-    bool length_check_status = true;
-    // Hive table, not limit string length <= 1mb anymore
     if (options.is_hive) {
-        if (UNLIKELY(max_size > 0 && s.size > max_size)) {
-            length_check_status = false;
-        }
+        // truncate directly
+        down_cast<BinaryColumn*>(column)->append(Slice(s.get_data(), std::min(s.size, max_size)));
     } else {
-        if ((config::enable_check_string_lengths &&
-             ((s.size > TypeDescriptor::MAX_VARCHAR_LENGTH) || (max_size > 0 && s.size > max_size)))) {
-            length_check_status = false;
+        if (config::enable_check_string_lengths &&
+            ((s.size > TypeDescriptor::MAX_VARCHAR_LENGTH) || (max_size > 0 && s.size > max_size))) {
+            VLOG(3) << strings::Substitute("Column [$0]'s length exceed max varchar length. str_size($1), max_size($2)",
+                                           column->get_name(), s.size, max_size);
+            return false;
         }
+        down_cast<BinaryColumn*>(column)->append(s);
     }
-    if (!length_check_status) {
-        VLOG(3) << strings::Substitute("Column [$0]'s length exceed max varchar length. str_size($1), max_size($2)",
-                                       column->get_name(), s.size, max_size);
-        return false;
-    }
-
-    down_cast<BinaryColumn*>(column)->append(s);
     return true;
 }
 

--- a/be/src/util/utf8.h
+++ b/be/src/util/utf8.h
@@ -68,6 +68,20 @@ static inline size_t get_utf8_small_index(const Slice& str, uint8_t* small_index
     return n;
 }
 
+static inline Slice truncate_utf8(const Slice& str, const size_t max_size) {
+    std::vector<size_t> index{};
+    const size_t utf8_length = get_utf8_index(str, &index);
+    size_t actual_size = 0;
+    if (utf8_length > max_size) {
+        // do truncate
+        actual_size = index[max_size];
+    } else {
+        // don't need to truncate
+        actual_size = str.size;
+    }
+    return {str.data, actual_size};
+}
+
 // table-driven is faster than computing as follow:
 /*
  *      uint8_t b = ~static_cast<uint8_t>(*p);

--- a/be/test/formats/csv/string_converter_test.cpp
+++ b/be/test/formats/csv/string_converter_test.cpp
@@ -50,6 +50,43 @@ TEST_F(StringConverterTest, test_read_string) {
 }
 
 // NOLINTNEXTLINE
+TEST_F(StringConverterTest, test_read_hive_string) {
+    TypeDescriptor type = TypeDescriptor::create_varchar_type(5);
+    auto conv = csv::get_converter(type, true);
+    Converter::Options options{};
+    options.type_desc = &type;
+
+    {
+        auto col = ColumnHelper::create_column(type, true);
+        EXPECT_TRUE(conv->read_string(col.get(), "abcde", options));
+        EXPECT_TRUE(conv->read_string(col.get(), "abcdefg", options));
+
+        EXPECT_EQ(2, col->size());
+        EXPECT_EQ("abcde", col->get(0).get_slice());
+        EXPECT_TRUE(col->get(1).is_null());
+    }
+
+    // test for hive
+    {
+        auto col = ColumnHelper::create_column(type, true);
+        options.is_hive = true;
+        EXPECT_TRUE(conv->read_string(col.get(), "abcde", options));
+        EXPECT_TRUE(conv->read_string(col.get(), "abcdefg", options));
+        // test for utf-8
+        EXPECT_TRUE(conv->read_string(col.get(), "斯密斯", options));
+        EXPECT_TRUE(conv->read_string(col.get(), "白嫖斯密斯", options));
+        EXPECT_TRUE(conv->read_string(col.get(), "白嫖斯密斯哈", options));
+
+        EXPECT_EQ(5, col->size());
+        EXPECT_EQ("abcde", col->get(0).get_slice());
+        EXPECT_EQ("abcde", col->get(1).get_slice());
+        EXPECT_EQ("斯密斯", col->get(2).get_slice());
+        EXPECT_EQ("白嫖斯密斯", col->get(3).get_slice());
+        EXPECT_EQ("白嫖斯密斯", col->get(4).get_slice());
+    }
+}
+
+// NOLINTNEXTLINE
 TEST_F(StringConverterTest, test_read_large_string01) {
     auto conv = csv::get_converter(_type, false);
     auto col = ColumnHelper::create_column(_type, false);


### PR DESCRIPTION
## Why I'm doing:
we will set null for varchar which exceeds max length, actually, we should truncate it. Make the same behavior as trino/hive.

And we need to calculate the length according to utf-8, not bytes.

## What I'm doing:
Just do it.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [x] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
