### PR TITLE
[BugFix] fix race condition issue about persistent index's l0

### DIFF
--- a/be/src/storage/persistent_index.h
+++ b/be/src/storage/persistent_index.h
@@ -656,21 +656,7 @@ public:
     size_t key_size() const { return _key_size; }
 
     size_t size() const { return _size; }
-    size_t capacity() const { return _l0 ? _l0->capacity() : 0; }
-    size_t memory_usage() const {
-        // commit thread will update primary index memory usage and get index memory usage
-        // apply thread maybe clear or modify _l1_vec
-        // add lock to avoid read/write conflicts
-        std::shared_lock rdlock(_lock);
-        size_t memory_usage = _l0 ? _l0->memory_usage() : 0;
-        for (int i = 0; i < _l1_vec.size(); i++) {
-            memory_usage += _l1_vec[i]->memory_usage();
-        }
-        for (int i = 0; i < _l2_vec.size(); i++) {
-            memory_usage += _l2_vec[i]->memory_usage();
-        }
-        return memory_usage;
-    }
+    size_t memory_usage() const { return _memory_usage.load(); }
 
     EditVersion version() const { return _version; }
 
@@ -861,11 +847,10 @@ private:
 
     Status _reload_usage_and_size_by_key_length(size_t l1_idx_start, size_t l1_idx_end, bool contain_l2);
 
-protected:
-    // prevent concurrent operations
-    // Currently there are only concurrent read/write conflicts for _l1_vec between apply_thread and commit_thread
-    mutable std::shared_mutex _lock;
+    // Calculate total memory usage after index been modified.
+    void _calc_memory_usage();
 
+protected:
     // index storage directory
     std::string _path;
     size_t _key_size = 0;
@@ -909,6 +894,8 @@ private:
     std::atomic<bool> _major_compaction_running{false};
     // Latest major compaction time. In second.
     int64_t _latest_compaction_time = 0;
+    // Re-calculated when commit end
+    std::atomic<size_t> _memory_usage{0};
 };
 
 } // namespace starrocks

--- a/be/src/storage/primary_index.cpp
+++ b/be/src/storage/primary_index.cpp
@@ -999,8 +999,7 @@ void PrimaryIndex::unload() {
     if (!_loaded) {
         return;
     }
-    LOG(INFO) << "unload primary index tablet:" << _tablet_id << " size:" << size() << " capacity:" << capacity()
-              << " memory: " << memory_usage();
+    LOG(INFO) << "unload primary index tablet:" << _tablet_id << " size:" << size() << " memory: " << memory_usage();
     if (_pkey_to_rssid_rowid) {
         _pkey_to_rssid_rowid.reset();
     }
@@ -1174,8 +1173,7 @@ Status PrimaryIndex::_do_load(Tablet* tablet) {
     LOG(INFO) << "load primary index finish table:" << tablet->belonged_table_id() << " tablet:" << tablet->tablet_id()
               << " version:" << apply_version << " #rowset:" << rowsets.size() << " #segment:" << total_segments
               << " data_size:" << total_data_size << " rowsets:" << int_list_to_string(rowset_ids) << " size:" << size()
-              << " capacity:" << capacity() << " memory:" << memory_usage()
-              << " duration: " << timer.elapsed_time() / 1000000 << "ms";
+              << " memory:" << memory_usage() << " duration: " << timer.elapsed_time() / 1000000 << "ms";
     span->SetAttribute("memory", memory_usage());
     span->SetAttribute("size", size());
     return Status::OK();

--- a/be/src/storage/primary_index.cpp
+++ b/be/src/storage/primary_index.cpp
@@ -1413,13 +1413,6 @@ std::size_t PrimaryIndex::size() const {
     return _pkey_to_rssid_rowid ? _pkey_to_rssid_rowid->size() : 0;
 }
 
-std::size_t PrimaryIndex::capacity() const {
-    if (_persistent_index) {
-        return _persistent_index->capacity();
-    }
-    return _pkey_to_rssid_rowid ? _pkey_to_rssid_rowid->capacity() : 0;
-}
-
 void PrimaryIndex::reserve(size_t s) {
     if (_pkey_to_rssid_rowid) {
         _pkey_to_rssid_rowid->reserve(s);

--- a/be/src/storage/primary_index.h
+++ b/be/src/storage/primary_index.h
@@ -122,9 +122,6 @@ public:
     std::size_t size() const;
 
     // [not thread-safe]
-    std::size_t capacity() const;
-
-    // [not thread-safe]
     void reserve(size_t s);
 
     std::string to_string() const;

--- a/be/src/storage/tablet_updates.cpp
+++ b/be/src/storage/tablet_updates.cpp
@@ -4366,7 +4366,11 @@ Status TabletUpdates::pk_index_major_compaction() {
     index_entry->update_expire_time(MonotonicMillis() + manager->get_index_cache_expire_ms(_tablet));
     auto& index = index_entry->value();
 
-    auto st = index.load(&_tablet);
+    auto st = Status::OK();
+    {
+        std::lock_guard lg(_index_lock);
+        st = index.load(&_tablet);
+    }
     if (!st.ok()) {
         // remove index entry when loading fail
         manager->index_cache().remove(index_entry);

--- a/be/test/storage/primary_index_test.cpp
+++ b/be/test/storage/primary_index_test.cpp
@@ -353,7 +353,7 @@ PARALLEL_TEST(PrimaryIndexTest, test_composite_key) {
     PrimaryKeyEncoder::encode(*schema, *chunk, 0, chunk->num_rows(), pk_column.get());
 
     ASSERT_TRUE(pk_index->insert(0, 0, *pk_column).ok());
-    LOG(INFO) << "pk_index memory:" << pk_index->memory_usage() << " capacity:" << pk_index->capacity();
+    LOG(INFO) << "pk_index memory:" << pk_index->memory_usage();
 
     PrimaryIndex::DeletesMap deletes;
     pk_index->upsert(1, 0, *pk_column, &deletes);


### PR DESCRIPTION
## Why I'm doing:
In apply thread, persistent index will be modified and `_l0` can be destroy and re-create. At the same time, another thread may visit `_l0` by `PersistentIndex::memory_usage`. 
There will be race condition issue here.

## What I'm doing:
Add atomic val `_memory_usage`, calculate it each time when persistent index been modified, and `PersistentIndex::memory_usage` is only need to return `_memory_usage`, which is thread safe.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [x] 3.2
  - [x] 3.1
  - [x] 3.0
  - [x] 2.5
