### PR TITLE
[BugFix] es operator support decimalV3 predicate

### DIFF
--- a/be/src/exec/es/es_predicate.cpp
+++ b/be/src/exec/es/es_predicate.cpp
@@ -38,6 +38,7 @@
 
 #include <map>
 #include <sstream>
+#include <type_traits>
 #include <utility>
 
 #include "column/column.h"
@@ -50,6 +51,7 @@
 #include "exprs/expr.h"
 #include "exprs/expr_context.h"
 #include "exprs/in_const_predicate.hpp"
+#include "gutil/casts.h"
 #include "runtime/large_int_value.h"
 #include "runtime/runtime_state.h"
 #include "runtime/string_value.h"
@@ -99,6 +101,13 @@ VExtLiteral::VExtLiteral(LogicalType type, ColumnPtr column, const std::string& 
             _value = "true";
         } else {
             _value = "false";
+        }
+    } else if (type == TYPE_DECIMAL32 || type == TYPE_DECIMAL64 || type == TYPE_DECIMAL128) {
+        DCHECK(!column->is_null(0));
+        if (column->is_constant()) {
+            _value = down_cast<ConstColumn*>(column.get())->data_column()->debug_item(0);
+        } else {
+            _value = column->debug_item(0);
         }
     } else {
         _value = _value_to_string(column);

--- a/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
@@ -1886,7 +1886,7 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
     @VarAttr(name = CBO_DECIMAL_CAST_STRING_STRICT, flag = VariableMgr.INVISIBLE)
     private boolean cboDecimalCastStringStrict = true;
 
-    @VarAttr(name = CBO_EQ_BASE_TYPE, flag = VariableMgr.INVISIBLE)
+    @VarAttr(name = CBO_EQ_BASE_TYPE)
     private String cboEqBaseType = SessionVariableConstants.DECIMAL;
 
     @VariableMgr.VarAttr(name = ENABLE_RESULT_SINK_ACCUMULATE)


### PR DESCRIPTION
## Why I'm doing:
ES operator doesn't support decimalv3 type value, will cast to Int128 now

## What I'm doing:

Fixes: https://github.com/StarRocks/starrocks/pull/43443
Fixes https://github.com/StarRocks/StarRocksTest/issues/6851

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
