### PR TITLE
[BugFix] Avoid list tablet_metadata when get_tabet_num_rows

### DIFF
--- a/be/src/connector/lake_connector.cpp
+++ b/be/src/connector/lake_connector.cpp
@@ -673,7 +673,7 @@ StatusOr<bool> LakeDataSourceProvider::_could_split_tablet_physically(
 #ifdef BE_TEST
     ASSIGN_OR_RETURN(
             auto first_tablet_schema,
-            _tablet_manager->get_tablet_schema(scan_ranges[0].scan_range.internal_scan_range.tablet_id, version));
+            _tablet_manager->get_tablet_schema(scan_ranges[0].scan_range.internal_scan_range.tablet_id, &version));
     keys_type = first_tablet_schema->keys_type();
 #else
     ASSIGN_OR_RETURN(auto first_tablet_schema,

--- a/be/src/connector/lake_connector.cpp
+++ b/be/src/connector/lake_connector.cpp
@@ -637,12 +637,12 @@ StatusOr<bool> LakeDataSourceProvider::_could_tablet_internal_parallel(
 #ifdef BE_TEST
         ASSIGN_OR_RETURN(auto tablet_num_rows,
                          _tablet_manager->get_tablet_num_rows(
-                                 tablet_scan_range.scan_range.internal_scan_range.tablet_id, &version));
+                                 tablet_scan_range.scan_range.internal_scan_range.tablet_id, version));
         num_table_rows += static_cast<int64_t>(tablet_num_rows);
 #else
         ASSIGN_OR_RETURN(auto tablet_num_rows,
                          ExecEnv::GetInstance()->lake_tablet_manager()->get_tablet_num_rows(
-                                 tablet_scan_range.scan_range.internal_scan_range.tablet_id, &version));
+                                 tablet_scan_range.scan_range.internal_scan_range.tablet_id, version));
         num_table_rows += static_cast<int64_t>(tablet_num_rows);
 #endif
     }
@@ -656,14 +656,6 @@ StatusOr<bool> LakeDataSourceProvider::_could_tablet_internal_parallel(
     // scan_dop is restricted in the range [1, dop].
     *scan_dop = num_table_rows / *splitted_scan_rows;
     *scan_dop = std::max<int64_t>(1, std::min<int64_t>(*scan_dop, pipeline_dop));
-
-    LOG(INFO) << "num_table_rows " << num_table_rows << ", splitted_scan_rows " << *splitted_scan_rows << ", config "
-              << config::tablet_internal_parallel_min_splitted_scan_rows << ", scan dop " << *scan_dop
-              << ", pipeline_dop " << pipeline_dop;
-    std::cout << "num_table_rows " + std::to_string(num_table_rows) + ", splitted_scan_rows " +
-                         std::to_string(*splitted_scan_rows) + ", config " +
-                         std::to_string(config::tablet_internal_parallel_min_splitted_scan_rows) + ", scan dop " +
-                         std::to_string(*scan_dop) + ", pipeline_dop " + std::to_string(pipeline_dop);
 
     if (force_split) {
         return true;
@@ -681,7 +673,7 @@ StatusOr<bool> LakeDataSourceProvider::_could_split_tablet_physically(
 #ifdef BE_TEST
     ASSIGN_OR_RETURN(
             auto first_tablet_schema,
-            _tablet_manager->get_tablet_schema(scan_ranges[0].scan_range.internal_scan_range.tablet_id, &version));
+            _tablet_manager->get_tablet_schema(scan_ranges[0].scan_range.internal_scan_range.tablet_id, version));
     keys_type = first_tablet_schema->keys_type();
 #else
     ASSIGN_OR_RETURN(auto first_tablet_schema,

--- a/be/src/storage/lake/tablet.cpp
+++ b/be/src/storage/lake/tablet.cpp
@@ -191,8 +191,9 @@ int64_t Tablet::data_size() {
 }
 
 size_t Tablet::num_rows() const {
-    int64_t version = _version_hint;
-    auto num_rows = _mgr->get_tablet_num_rows(_id, &version);
+    // set_version_hint should be called before to avoid list tablet metadata
+    DCHECK(_version_hint != 0);
+    auto num_rows = _mgr->get_tablet_num_rows(_id, _version_hint);
     if (num_rows.ok()) {
         return num_rows.value();
     } else {

--- a/be/src/storage/lake/tablet_manager.cpp
+++ b/be/src/storage/lake/tablet_manager.cpp
@@ -391,31 +391,17 @@ StatusOr<int64_t> TabletManager::get_tablet_data_size(int64_t tablet_id, int64_t
     return size;
 }
 
-StatusOr<int64_t> TabletManager::get_tablet_num_rows(int64_t tablet_id, int64_t* version_hint) {
+StatusOr<int64_t> TabletManager::get_tablet_num_rows(int64_t tablet_id, int64_t version) {
+    DCHECK(version != 0);
     int64_t num_rows = 0;
     TabletMetadataPtr metadata;
-    if (version_hint != nullptr && *version_hint > 0) {
-        ASSIGN_OR_RETURN(metadata, get_tablet_metadata(tablet_id, *version_hint));
-        for (const auto& rowset : metadata->rowsets()) {
-            num_rows += rowset.num_rows();
-        }
-        VLOG(2) << "get tablet " << tablet_id << " num_rows from version hint: " << *version_hint
-                << ", num_rows: " << num_rows;
-    } else {
-        ASSIGN_OR_RETURN(TabletMetadataIter metadata_iter, list_tablet_metadata(tablet_id, true));
-        if (!metadata_iter.has_next()) {
-            return Status::NotFound(fmt::format("tablet {} metadata not found", tablet_id));
-        }
-        ASSIGN_OR_RETURN(metadata, metadata_iter.next());
-        if (version_hint != nullptr) {
-            *version_hint = metadata->version();
-        }
-        for (const auto& rowset : metadata->rowsets()) {
-            num_rows += rowset.num_rows();
-        }
-        VLOG(2) << "get tablet " << tablet_id << " num_rows from version : " << metadata->version()
-                << ", num_rows: " << num_rows;
+    ASSIGN_OR_RETURN(metadata, get_tablet_metadata(tablet_id, version));
+
+    for (const auto& rowset : metadata->rowsets()) {
+        num_rows += rowset.num_rows();
     }
+    VLOG(2) << "get tablet " << tablet_id << " num_rows from version hint: " << version
+            << ", num_rows: " << num_rows;
 
     return num_rows;
 }

--- a/be/src/storage/lake/tablet_manager.cpp
+++ b/be/src/storage/lake/tablet_manager.cpp
@@ -400,8 +400,7 @@ StatusOr<int64_t> TabletManager::get_tablet_num_rows(int64_t tablet_id, int64_t 
     for (const auto& rowset : metadata->rowsets()) {
         num_rows += rowset.num_rows();
     }
-    VLOG(2) << "get tablet " << tablet_id << " num_rows from version hint: " << version
-            << ", num_rows: " << num_rows;
+    VLOG(2) << "get tablet " << tablet_id << " num_rows from version hint: " << version << ", num_rows: " << num_rows;
 
     return num_rows;
 }

--- a/be/src/storage/lake/tablet_manager.h
+++ b/be/src/storage/lake/tablet_manager.h
@@ -152,7 +152,7 @@ public:
 
     StatusOr<int64_t> get_tablet_data_size(int64_t tablet_id, int64_t* version_hint);
 
-    StatusOr<int64_t> get_tablet_num_rows(int64_t tablet_id, int64_t* version_hint);
+    StatusOr<int64_t> get_tablet_num_rows(int64_t tablet_id, int64_t version);
 
     int64_t in_writing_data_size(int64_t tablet_id);
 

--- a/be/src/storage/lake/tablet_reader.cpp
+++ b/be/src/storage/lake/tablet_reader.cpp
@@ -105,6 +105,8 @@ Status TabletReader::open(const TabletReaderParams& read_params) {
     if (_need_split) {
         std::vector<BaseTabletSharedPtr> tablets;
         auto tablet_shared_ptr = std::make_shared<Tablet>(_tablet_mgr, _tablet_metadata->id());
+        // to avoid list tablet metadata by set version_hint
+        tablet_shared_ptr->set_version_hint(_tablet_metadata->version());
         tablets.emplace_back(tablet_shared_ptr);
 
         std::vector<std::vector<BaseRowsetSharedPtr>> tablet_rowsets;

--- a/be/test/storage/lake/tablet_test.cpp
+++ b/be/test/storage/lake/tablet_test.cpp
@@ -149,11 +149,7 @@ TEST_F(LakeTabletTest, test_get_tablet_num_rows) {
     int64_t version = _tablet_metadata->version();
     ASSIGN_OR_ABORT(auto num_rows_with_version, _tablet_mgr->get_tablet_num_rows(_tablet_metadata->id(), &version));
 
-    version = 0;
-    ASSIGN_OR_ABORT(auto num_rows_without_version, _tablet_mgr->get_tablet_num_rows(_tablet_metadata->id(), &version));
-
     ASSERT_EQ(num_rows_with_version, 34);
-    ASSERT_EQ(num_rows_with_version, num_rows_without_version);
 }
 
 } // namespace starrocks::lake

--- a/be/test/storage/lake/tablet_test.cpp
+++ b/be/test/storage/lake/tablet_test.cpp
@@ -146,9 +146,8 @@ protected:
 TEST_F(LakeTabletTest, test_get_tablet_num_rows) {
     create_rowsets_for_testing();
 
-    int64_t version = _tablet_metadata->version();
-    ASSIGN_OR_ABORT(auto num_rows_with_version, _tablet_mgr->get_tablet_num_rows(_tablet_metadata->id(), &version));
-
+    ASSIGN_OR_ABORT(auto num_rows_with_version,
+                    _tablet_mgr->get_tablet_num_rows(_tablet_metadata->id(), _tablet_metadata->version()));
     ASSERT_EQ(num_rows_with_version, 34);
 }
 


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:
To avoid list tablet meta when get_tablet_num_rows by `set_version_hit`
Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
