### PR TITLE
[Refactor] Refactor materialized view fresh functions to MvRefreshArbiter

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/MaterializedView.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/MaterializedView.java
@@ -26,7 +26,6 @@ import com.google.common.collect.Sets;
 import com.google.gson.annotations.SerializedName;
 import com.starrocks.analysis.DescriptorTable.ReferencedPartitionInfo;
 import com.starrocks.analysis.Expr;
-import com.starrocks.analysis.FunctionCallExpr;
 import com.starrocks.analysis.ParseNode;
 import com.starrocks.analysis.SlotDescriptor;
 import com.starrocks.analysis.SlotId;
@@ -37,12 +36,10 @@ import com.starrocks.backup.Status;
 import com.starrocks.backup.mv.MvBackupInfo;
 import com.starrocks.backup.mv.MvBaseTableBackupInfo;
 import com.starrocks.backup.mv.MvRestoreContext;
-import com.starrocks.common.AnalysisException;
 import com.starrocks.common.DdlException;
 import com.starrocks.common.FeConstants;
 import com.starrocks.common.MaterializedViewExceptions;
 import com.starrocks.common.Pair;
-import com.starrocks.common.UserException;
 import com.starrocks.common.io.DeepCopy;
 import com.starrocks.common.io.Text;
 import com.starrocks.common.util.DateUtils;
@@ -72,11 +69,7 @@ import com.starrocks.sql.analyzer.RelationFields;
 import com.starrocks.sql.analyzer.RelationId;
 import com.starrocks.sql.analyzer.Scope;
 import com.starrocks.sql.ast.UserIdentity;
-import com.starrocks.sql.common.PartitionDiffer;
 import com.starrocks.sql.common.PartitionRange;
-import com.starrocks.sql.common.RangePartitionDiff;
-import com.starrocks.sql.common.SyncPartitionUtils;
-import com.starrocks.sql.common.UnsupportedException;
 import com.starrocks.sql.optimizer.CachingMvPlanContextBuilder;
 import com.starrocks.sql.optimizer.MvRewritePreprocessor;
 import com.starrocks.sql.optimizer.Utils;
@@ -596,16 +589,6 @@ public class MaterializedView extends OlapTable implements GsonPreProcessable, G
         return warehouseId;
     }
 
-    /**
-     * @param base           : The base table of the materialized view to check the updated partition names
-     * @param isQueryRewrite : Mark the caller is from query rewrite or not, when it's true we can use staleness to
-     *                       optimize.
-     * @return
-     */
-    public Set<String> getUpdatedPartitionNamesOfTable(Table base, boolean isQueryRewrite) {
-        return getUpdatedPartitionNamesOfTable(base, false, isQueryRewrite, MaterializedView.getPartitionExpr(this));
-    }
-
     public int getMaxMVRewriteStaleness() {
         return maxMVRewriteStaleness;
     }
@@ -667,6 +650,12 @@ public class MaterializedView extends OlapTable implements GsonPreProcessable, G
         return materializedView.getFirstPartitionRefTableExpr();
     }
 
+    /**
+     * Return the updated partition names of the base table of the materialized view.
+     * @param baseTable: The base table of the materialized view to check the updated partition names
+     * @param isQueryRewrite: Whether it's for query rewrite or not
+     * @return: Return the updated partition names of the base table
+     */
     public Set<String> getUpdatedPartitionNamesOfOlapTable(OlapTable baseTable, boolean isQueryRewrite) {
         if (isQueryRewrite && isStalenessSatisfied()) {
             return Sets.newHashSet();
@@ -760,7 +749,13 @@ public class MaterializedView extends OlapTable implements GsonPreProcessable, G
                 .stream().map(BasePartitionInfo::fromExternalTable).collect(Collectors.toList());
     }
 
-    private Set<String> getUpdatedPartitionNamesOfExternalTable(Table baseTable, boolean isQueryRewrite) {
+    /**
+     * Get the updated partition names of the external base table of the materialized view.
+     * @param baseTable: the external base table of the materialized view to check the updated partition names
+     * @param isQueryRewrite: whether it's for query rewrite or not
+     * @return: the updated partition names of the external base table
+     */
+    public Set<String> getUpdatedPartitionNamesOfExternalTable(Table baseTable, boolean isQueryRewrite) {
         Set<String> result = Sets.newHashSet();
         // NOTE: For query dump replay, ignore updated partition infos only to check mv can rewrite query or not.
         // Ignore partitions when mv 's last refreshed time period is less than `maxMVRewriteStaleness`
@@ -771,44 +766,6 @@ public class MaterializedView extends OlapTable implements GsonPreProcessable, G
         return ConnectorPartitionTraits.build(baseTable).getUpdatedPartitionNames(
                 this.getBaseTableInfos(),
                 this.refreshScheme.getAsyncRefreshContext());
-    }
-
-    /**
-     * Return base tables' updated partition names, if `withMv` is true check base tables recursively when the base
-     * table is materialized view too.
-     *
-     * @param baseTable : materialized view's base table to be checked
-     * @param withMv    : whether to check the base table recursively when it is also a mv.
-     * @return
-     */
-    public Set<String> getUpdatedPartitionNamesOfTable(
-            Table baseTable, boolean withMv, boolean isQueryRewrite, Expr partitionExpr) {
-        if (baseTable.isView()) {
-            return Sets.newHashSet();
-        } else if (baseTable.isNativeTableOrMaterializedView()) {
-            Set<String> result = Sets.newHashSet();
-            OlapTable olapBaseTable = (OlapTable) baseTable;
-            result.addAll(getUpdatedPartitionNamesOfOlapTable(olapBaseTable, isQueryRewrite));
-
-            if (withMv && baseTable.isMaterializedView()) {
-                ((MaterializedView) baseTable).getPartitionNamesToRefreshForMv(result, isQueryRewrite);
-            }
-            return result;
-        } else {
-            Set<String> updatePartitionNames = getUpdatedPartitionNamesOfExternalTable(baseTable, isQueryRewrite);
-            Map<Table, Column> partitionTableAndColumns = getRelatedPartitionTableAndColumn();
-            if (!partitionTableAndColumns.containsKey(baseTable)) {
-                return updatePartitionNames;
-            }
-            try {
-                boolean isListPartition = partitionInfo instanceof ListPartitionInfo;
-                return PartitionUtil.getMVPartitionName(baseTable, partitionTableAndColumns.get(baseTable),
-                        Lists.newArrayList(updatePartitionNames), isListPartition, partitionExpr);
-            } catch (AnalysisException e) {
-                LOG.warn("Mv {}'s base table {} get partition name fail", name, baseTable.name, e);
-                return null;
-            }
-        }
     }
 
     @Override
@@ -1367,269 +1324,6 @@ public class MaterializedView extends OlapTable implements GsonPreProcessable, G
             }
         }
         return tableToJoinExprMap;
-    }
-
-    // In Loose mode, do not need to check mv partition's data is consistent with base table's partition's data.
-    // Only need to check the mv partition existence.
-    public boolean getPartitionNamesToRefreshForMvInLooseMode(Set<String> toRefreshPartitions) {
-        if (partitionInfo instanceof SinglePartitionInfo) {
-            List<Partition> partitions = Lists.newArrayList(getPartitions());
-            if (partitions.size() > 0 && partitions.get(0).getVisibleVersion() <= 1) {
-                // the mv is newly created, can not use it to rewrite query.
-                toRefreshPartitions.addAll(getVisiblePartitionNames());
-            }
-            return true;
-        }
-        Expr partitionExpr = getFirstPartitionRefTableExpr();
-        Map<Table, Column> partitionTableAndColumn = getRelatedPartitionTableAndColumn();
-        Map<String, Range<PartitionKey>> mvRangePartitionMap = getRangePartitionMap();
-        Map<Table, Map<String, Range<PartitionKey>>> refBaseTablePartitionMap = Maps.newHashMap();
-        RangePartitionDiff rangePartitionDiff = null;
-        try {
-            for (Map.Entry<Table, Column> entry : partitionTableAndColumn.entrySet()) {
-                Table refBaseTable = entry.getKey();
-                Column refBaseTablePartitionColumn = entry.getValue();
-                // Collect the ref base table's partition range map.
-                refBaseTablePartitionMap.put(refBaseTable, PartitionUtil.getPartitionKeyRange(
-                        refBaseTable, refBaseTablePartitionColumn, partitionExpr));
-
-            }
-            Table partitionTable = getDirectTableAndPartitionColumn().first;
-            Column partitionColumn = getPartitionInfo().getPartitionColumns().get(0);
-            PartitionDiffer differ = PartitionDiffer.build(this, Pair.create(null, null));
-            rangePartitionDiff = PartitionUtil.getPartitionDiff(partitionExpr, partitionColumn,
-                    refBaseTablePartitionMap.get(partitionTable), mvRangePartitionMap, differ);
-        } catch (Exception e) {
-            LOG.warn("Materialized view compute partition difference with base table failed.", e);
-            return false;
-        }
-
-        if (rangePartitionDiff == null) {
-            LOG.warn("Materialized view compute partition difference with base table failed, the diff of range partition" +
-                    " is null.");
-            return false;
-        }
-        Map<String, Range<PartitionKey>> adds = rangePartitionDiff.getAdds();
-        for (Map.Entry<String, Range<PartitionKey>> addEntry : adds.entrySet()) {
-            String mvPartitionName = addEntry.getKey();
-            toRefreshPartitions.add(mvPartitionName);
-        }
-        return true;
-    }
-
-    /**
-     * Once the materialized view's base tables have updated, we need to check correspond materialized views' partitions
-     * to be refreshed.
-     *
-     * @return : Collect all need refreshed partitions of materialized view.
-     * @isQueryRewrite : Mark whether this caller is query rewrite or not, when it's true we can use staleness to shortcut
-     * the update check.
-     */
-    public boolean getPartitionNamesToRefreshForMv(Set<String> toRefreshPartitions,
-                                                   boolean isQueryRewrite) {
-        // Skip check for sync materialized view.
-        if (refreshScheme.isSync()) {
-            return true;
-        }
-
-        // check mv's query rewrite consistency mode property only in query rewrite.
-        TableProperty.QueryRewriteConsistencyMode mvConsistencyRewriteMode =
-                TableProperty.QueryRewriteConsistencyMode.CHECKED;
-        if (isQueryRewrite) {
-            mvConsistencyRewriteMode = tableProperty.getQueryRewriteConsistencyMode();
-            switch (mvConsistencyRewriteMode) {
-                case DISABLE:
-                    return false;
-                case NOCHECK:
-                    return true;
-                case LOOSE:
-                case CHECKED:
-                default:
-                    break;
-            }
-        }
-        if (mvConsistencyRewriteMode == TableProperty.QueryRewriteConsistencyMode.LOOSE) {
-            return getPartitionNamesToRefreshForMvInLooseMode(toRefreshPartitions);
-        } else {
-            // mvConsistencyRewriteMode == TableProperty.QueryRewriteConsistencyMode.CHECKED
-            if (partitionInfo instanceof SinglePartitionInfo) {
-                return getNonPartitionedMVRefreshPartitions(toRefreshPartitions, isQueryRewrite);
-            } else if (partitionInfo instanceof ExpressionRangePartitionInfo) {
-                // partitions to refresh
-                // 1. dropped partitions
-                // 2. newly added partitions
-                // 3. partitions loaded with new data
-                return getPartitionedMVRefreshPartitions(toRefreshPartitions, isQueryRewrite);
-            } else {
-                throw UnsupportedException.unsupportedException("unsupported partition info type:"
-                        + partitionInfo.getClass().getName());
-            }
-        }
-    }
-
-    /**
-     * For non-partitioned materialized view, once its base table have updated, we need refresh the
-     * materialized view's totally.
-     *
-     * @return : non-partitioned materialized view's all need updated partition names.
-     */
-    private boolean getNonPartitionedMVRefreshPartitions(Set<String> toRefreshPartitions,
-                                                         boolean isQueryRewrite) {
-        Preconditions.checkState(partitionInfo instanceof SinglePartitionInfo);
-        for (BaseTableInfo tableInfo : baseTableInfos) {
-            Table table = tableInfo.getTableChecked();
-            // skip check freshness of view
-            if (table.isView()) {
-                continue;
-            }
-
-            // skip check external table if the external does not support rewrite.
-            if (!table.isNativeTableOrMaterializedView()) {
-                if (tableProperty.getForceExternalTableQueryRewrite() ==
-                        TableProperty.QueryRewriteConsistencyMode.DISABLE) {
-                    toRefreshPartitions.addAll(getVisiblePartitionNames());
-                    return false;
-                }
-            }
-
-            // once mv's base table has updated, refresh the materialized view totally.
-            Set<String> partitionNames = getUpdatedPartitionNamesOfTable(
-                    table, true, isQueryRewrite, MaterializedView.getPartitionExpr(this));
-            if (CollectionUtils.isNotEmpty(partitionNames)) {
-                toRefreshPartitions.addAll(getVisiblePartitionNames());
-                return true;
-            }
-        }
-        return true;
-    }
-
-    /**
-     * Materialized Views' base tables have two kinds: ref base table and non-ref base table.
-     * - If non ref base tables updated, need refresh all mv partitions.
-     * - If ref base table updated, need refresh the ref base table's updated partitions.
-     * <p>
-     * eg:
-     * CREATE MATERIALIZED VIEW mv1
-     * PARTITION BY k1
-     * DISTRIBUTED BY HASH(k1) BUCKETS 10
-     * AS
-     * SELECT k1, v1 as k2, v2 as k3
-     * from t1 join t2
-     * on t1.k1 and t2.kk1;
-     * <p>
-     * - t1 is mv1's ref base table because mv1's partition column k1 is deduced from t1
-     * - t2 is mv1's non ref base table because mv1's partition column k1 is not associated with t2.
-     *
-     * @return : partitioned materialized view's all need updated partition names.
-     */
-    private boolean getPartitionedMVRefreshPartitions(Set<String> toRefreshPartitions,
-                                                      boolean isQueryRewrite) {
-        Preconditions.checkState(partitionInfo instanceof ExpressionRangePartitionInfo);
-        // If non-partition-by table has changed, should refresh all mv partitions
-        Expr partitionExpr = getFirstPartitionRefTableExpr();
-        Map<Table, Column> partitionInfos = getRelatedPartitionTableAndColumn();
-        if (partitionInfos.isEmpty()) {
-            setInactiveAndReason("partition configuration changed");
-            LOG.warn("mark mv:{} inactive for get partition info failed", name);
-            throw new RuntimeException(String.format("getting partition info failed for mv: %s", name));
-        }
-
-        for (BaseTableInfo tableInfo : baseTableInfos) {
-            Table baseTable = tableInfo.getTableChecked();
-            // skip view
-            if (baseTable.isView()) {
-                continue;
-            }
-            // skip external table that is not supported for query rewrite, return all partition ?
-            // skip check external table if the external does not support rewrite.
-            if (!baseTable.isNativeTableOrMaterializedView()) {
-                if (tableProperty.getForceExternalTableQueryRewrite() ==
-                        TableProperty.QueryRewriteConsistencyMode.DISABLE) {
-                    toRefreshPartitions.addAll(getVisiblePartitionNames());
-                    return false;
-                }
-            }
-            if (partitionInfos.containsKey(baseTable)) {
-                continue;
-            }
-            // If the non ref table has already changed, need refresh all materialized views' partitions.
-            Set<String> partitionNames =
-                    getUpdatedPartitionNamesOfTable(baseTable, true, isQueryRewrite, partitionExpr);
-            if (CollectionUtils.isNotEmpty(partitionNames)) {
-                toRefreshPartitions.addAll(getVisiblePartitionNames());
-                return true;
-            }
-        }
-
-        // Step1: collect updated partitions by partition name to range name:
-        // - deleted partitions.
-        // - added partitions.
-        Set<String> needRefreshMvPartitionNames = Sets.newHashSet();
-        Map<Table, Map<String, Range<PartitionKey>>> basePartitionNameToRangeMap = Maps.newHashMap();
-        Map<String, Range<PartitionKey>> mvPartitionNameToRangeMap = getRangePartitionMap();
-        Map<Table, Set<String>> baseChangedPartitionNames = Maps.newHashMap();
-        for (Map.Entry<Table, Column> entry : partitionInfos.entrySet()) {
-            Table table = entry.getKey();
-            try {
-                basePartitionNameToRangeMap.put(table,
-                        PartitionUtil.getPartitionKeyRange(table, entry.getValue(), partitionExpr));
-            } catch (UserException e) {
-                LOG.warn("Materialized view compute partition difference with base table failed.", e);
-                toRefreshPartitions.addAll(getVisiblePartitionNames());
-                return false;
-            }
-
-            // step1.2: check ref base table's updated partition names by checking its ref tables recursively.
-            Set<String> baseChangedPartition =
-                    getUpdatedPartitionNamesOfTable(table, true, isQueryRewrite, partitionExpr);
-            if (baseChangedPartition == null) {
-                toRefreshPartitions.addAll(getVisiblePartitionNames());
-                return true;
-            } else {
-                baseChangedPartitionNames.put(table, baseChangedPartition);
-            }
-        }
-
-        Pair<Table, Column> directTableAndPartitionColumn = getDirectTableAndPartitionColumn();
-        // TODO: prune the partitions based on ttl
-        RangePartitionDiff rangePartitionDiff = PartitionUtil.getPartitionDiff(partitionExpr,
-                directTableAndPartitionColumn.second,
-                basePartitionNameToRangeMap.get(directTableAndPartitionColumn.first),
-                mvPartitionNameToRangeMap, null);
-        needRefreshMvPartitionNames.addAll(rangePartitionDiff.getDeletes().keySet());
-        // remove ref base table's deleted partitions from `mvPartitionMap`
-        for (String deleted : rangePartitionDiff.getDeletes().keySet()) {
-            mvPartitionNameToRangeMap.remove(deleted);
-        }
-
-        // step2: refresh ref base table's new added partitions
-        needRefreshMvPartitionNames.addAll(rangePartitionDiff.getAdds().keySet());
-        mvPartitionNameToRangeMap.putAll(rangePartitionDiff.getAdds());
-        Map<Table, Map<String, Set<String>>> baseToMvNameRef = SyncPartitionUtils
-                .generateBaseRefMap(basePartitionNameToRangeMap, getTableToPartitionExprMap(), mvPartitionNameToRangeMap);
-        Map<String, Map<Table, Set<String>>> mvToBaseNameRef = SyncPartitionUtils
-                .generateMvRefMap(mvPartitionNameToRangeMap, getTableToPartitionExprMap(), basePartitionNameToRangeMap);
-
-        for (Map.Entry<Table, Set<String>> entry : baseChangedPartitionNames.entrySet()) {
-            entry.getValue().stream().forEach(x ->
-                    needRefreshMvPartitionNames.addAll(baseToMvNameRef.get(entry.getKey()).get(x))
-            );
-        }
-
-        if (partitionExpr instanceof FunctionCallExpr) {
-            List<TableWithPartitions> baseTableWithPartitions = baseChangedPartitionNames.keySet().stream()
-                    .map(x -> new TableWithPartitions(x, baseChangedPartitionNames.get(x)))
-                    .collect(Collectors.toList());
-            if (isCalcPotentialRefreshPartition(baseTableWithPartitions,
-                    basePartitionNameToRangeMap, needRefreshMvPartitionNames, mvPartitionNameToRangeMap)) {
-                // because the relation of partitions between materialized view and base partition table is n : m,
-                // should calculate the candidate partitions recursively.
-                SyncPartitionUtils.calcPotentialRefreshPartition(needRefreshMvPartitionNames, baseChangedPartitionNames,
-                        baseToMvNameRef, mvToBaseNameRef, Sets.newHashSet());
-            }
-        }
-        toRefreshPartitions.addAll(needRefreshMvPartitionNames);
-        return true;
     }
 
     /**

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/MvBaseTableUpdateInfo.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/MvBaseTableUpdateInfo.java
@@ -1,0 +1,51 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.catalog;
+
+import com.google.common.collect.Maps;
+import com.google.common.collect.Range;
+import com.google.common.collect.Sets;
+
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Store the update information of base table for MV
+ */
+public class MvBaseTableUpdateInfo {
+    // The partition names of base table that have been updated
+    private final Set<String> toRefreshPartitionNames = Sets.newHashSet();
+    // The mapping of partition name to partition range
+    private final Map<String, Range<PartitionKey>> partitionNameWithRanges = Maps.newHashMap();
+
+    public MvBaseTableUpdateInfo() {
+    }
+
+    public Set<String> getToRefreshPartitionNames() {
+        return toRefreshPartitionNames;
+    }
+
+    public Map<String, Range<PartitionKey>> getPartitionNameWithRanges() {
+        return partitionNameWithRanges;
+    }
+
+    @Override
+    public String toString() {
+        return "BaseTableRefreshInfo{" +
+                ", toRefreshPartitionNames=" + toRefreshPartitionNames +
+                ", partitionNameWithRanges=" + partitionNameWithRanges +
+                '}';
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/MvRefreshArbiter.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/MvRefreshArbiter.java
@@ -177,8 +177,8 @@ public class MvRefreshArbiter {
             return new MvUpdateInfo(MvUpdateInfo.MvToRefreshType.NO_REFRESH);
         }
 
-        // TODO: refactor it by using #collectBaseTablePartitionInfos
-        MvUpdateInfo mvUpdateInfo = new MvUpdateInfo(MvUpdateInfo.MvToRefreshType.PARTIAL);
+        MvUpdateInfo mvUpdateInfo = new MvUpdateInfo(MvUpdateInfo.MvToRefreshType.PARTIAL,
+                TableProperty.QueryRewriteConsistencyMode.LOOSE);
         Expr partitionExpr = mv.getFirstPartitionRefTableExpr();
         Map<Table, Column> partitionTableAndColumn = mv.getRelatedPartitionTableAndColumn();
         Map<String, Range<PartitionKey>> mvRangePartitionMap = mv.getRangePartitionMap();

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/MvRefreshArbiter.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/MvRefreshArbiter.java
@@ -1,0 +1,424 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.catalog;
+
+import com.google.common.base.Preconditions;
+import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
+import com.google.common.collect.Range;
+import com.google.common.collect.Sets;
+import com.starrocks.analysis.Expr;
+import com.starrocks.analysis.FunctionCallExpr;
+import com.starrocks.common.AnalysisException;
+import com.starrocks.common.Pair;
+import com.starrocks.common.UserException;
+import com.starrocks.connector.PartitionUtil;
+import com.starrocks.scheduler.TableWithPartitions;
+import com.starrocks.sql.common.PartitionDiffer;
+import com.starrocks.sql.common.RangePartitionDiff;
+import com.starrocks.sql.common.SyncPartitionUtils;
+import com.starrocks.sql.common.UnsupportedException;
+import org.apache.commons.collections.CollectionUtils;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import static com.starrocks.connector.PartitionUtil.getMVPartitionNameWithRange;
+import static com.starrocks.sql.optimizer.OptimizerTraceUtil.logMVPrepare;
+
+/**
+* The arbiter of materialized view refresh. All implementations of refresh strategies should be here.
+*/
+public class MvRefreshArbiter {
+    private static final Logger LOG = LogManager.getLogger(MvRefreshArbiter.class);
+
+    public static boolean needToRefreshTable(MaterializedView mv, Table table) {
+        MvBaseTableUpdateInfo mvBaseTableUpdateInfo = getMvBaseTableUpdateInfo(mv, table, true, false);
+        if (mvBaseTableUpdateInfo == null) {
+            return true;
+        }
+        return CollectionUtils.isNotEmpty(mvBaseTableUpdateInfo.getToRefreshPartitionNames());
+    }
+
+    /**
+     * Get to refresh partition info of the specific table.
+     * @param baseTable: the table to check
+     * @param withMv: whether to check the materialized view if it's a materialized view
+     * @param isQueryRewrite: whether this caller is query rewrite or not
+     * @return MvBaseTableUpdateInfo: the update info of the base table
+     */
+    public static MvBaseTableUpdateInfo getMvBaseTableUpdateInfo(MaterializedView mv,
+                                                                 Table baseTable,
+                                                                 boolean withMv,
+                                                                 boolean isQueryRewrite) {
+        MvBaseTableUpdateInfo mvBaseTableUpdateInfo = new MvBaseTableUpdateInfo();
+        if (baseTable.isView()) {
+            // do nothing
+            return mvBaseTableUpdateInfo;
+        } else if (baseTable.isNativeTableOrMaterializedView()) {
+            OlapTable olapBaseTable = (OlapTable) baseTable;
+            Set<String> baseTableUpdatedPartitionNames = mv.getUpdatedPartitionNamesOfOlapTable(olapBaseTable, isQueryRewrite);
+
+            // recursive check its children
+            if (withMv && baseTable.isMaterializedView()) {
+                MvUpdateInfo mvUpdateInfo = getPartitionNamesToRefreshForMv((MaterializedView) baseTable, isQueryRewrite);
+                if (mvUpdateInfo == null || !mvUpdateInfo.isValidRewrite()) {
+                    return null;
+                }
+                baseTableUpdatedPartitionNames.addAll(mvUpdateInfo.getMvToRefreshPartitionNames());
+            }
+            // update base table's partition info
+            mvBaseTableUpdateInfo.getToRefreshPartitionNames().addAll(baseTableUpdatedPartitionNames);
+        } else {
+            Set<String> updatePartitionNames = mv.getUpdatedPartitionNamesOfExternalTable(baseTable, isQueryRewrite);
+
+            Map<Table, Column> partitionTableAndColumns = mv.getRelatedPartitionTableAndColumn();
+            if (!partitionTableAndColumns.containsKey(baseTable)) {
+                // ATTENTION: This partition value is not formatted to mv partition type.
+                mvBaseTableUpdateInfo.getToRefreshPartitionNames().addAll(updatePartitionNames);
+                return mvBaseTableUpdateInfo;
+            }
+
+            try {
+                List<String> updatedPartitionNamesList = Lists.newArrayList(updatePartitionNames);
+                Column partitionColumn = partitionTableAndColumns.get(baseTable);
+                Expr partitionExpr = MaterializedView.getPartitionExpr(mv);
+                Map<String, Range<PartitionKey>> partitionNameWithRange = getMVPartitionNameWithRange(baseTable,
+                        partitionColumn, updatedPartitionNamesList, partitionExpr);
+                mvBaseTableUpdateInfo.getPartitionNameWithRanges().putAll(partitionNameWithRange);
+                mvBaseTableUpdateInfo.getToRefreshPartitionNames().addAll(partitionNameWithRange.keySet());
+            } catch (AnalysisException e) {
+                LOG.warn("Mv {}'s base table {} get partition name fail", mv.getName(), baseTable.name, e);
+                return null;
+            }
+        }
+        return mvBaseTableUpdateInfo;
+    }
+
+
+    /**
+     * Once the materialized view's base tables have updated, we need to check correspond materialized views' partitions
+     * to be refreshed.
+     *
+     * @return : Collect all need refreshed partitions of materialized view.
+     * @isQueryRewrite : Mark whether this caller is query rewrite or not, when it's true we can use staleness to shortcut
+     * the update check.
+     */
+    public static MvUpdateInfo getPartitionNamesToRefreshForMv(MaterializedView mv,
+                                                               boolean isQueryRewrite) {
+        // Skip check for sync materialized view.
+        if (mv.getRefreshScheme().isSync()) {
+            return new MvUpdateInfo(MvUpdateInfo.MvToRefreshType.NO_REFRESH);
+        }
+
+        // check mv's query rewrite consistency mode property only in query rewrite.
+        TableProperty tableProperty = mv.getTableProperty();
+        TableProperty.QueryRewriteConsistencyMode mvConsistencyRewriteMode = tableProperty.getQueryRewriteConsistencyMode();
+        if (isQueryRewrite) {
+            switch (mvConsistencyRewriteMode) {
+                case DISABLE:
+                    return new MvUpdateInfo(MvUpdateInfo.MvToRefreshType.FULL);
+                case NOCHECK:
+                    return new MvUpdateInfo(MvUpdateInfo.MvToRefreshType.NO_REFRESH);
+                case LOOSE:
+                case CHECKED:
+                default:
+                    break;
+            }
+        }
+
+        logMVPrepare(mv, "MV refresh arbiter start to get partition names to refresh, query rewrite mode: {}",
+                mvConsistencyRewriteMode);
+        if (mvConsistencyRewriteMode == TableProperty.QueryRewriteConsistencyMode.LOOSE) {
+            return getPartitionNamesToRefreshForMvInLooseMode(mv);
+        } else {
+            PartitionInfo partitionInfo = mv.getPartitionInfo();
+            if (partitionInfo instanceof SinglePartitionInfo) {
+                return getNonPartitionedMVRefreshPartitions(mv, isQueryRewrite);
+            } else if (partitionInfo instanceof ExpressionRangePartitionInfo) {
+                // partitions to refresh
+                // 1. dropped partitions
+                // 2. newly added partitions
+                // 3. partitions loaded with new data
+                return getPartitionedMVRefreshPartitions(mv, isQueryRewrite);
+            } else {
+                throw UnsupportedException.unsupportedException("unsupported partition info type:"
+                        + partitionInfo.getClass().getName());
+            }
+        }
+    }
+
+    // In Loose mode, do not need to check mv partition's data is consistent with base table's partition's data.
+    // Only need to check the mv partition existence.
+    private static MvUpdateInfo getPartitionNamesToRefreshForMvInLooseMode(MaterializedView mv) {
+        PartitionInfo partitionInfo = mv.getPartitionInfo();
+        if (partitionInfo instanceof SinglePartitionInfo) {
+            List<Partition> partitions = Lists.newArrayList(mv.getPartitions());
+            if (partitions.size() > 0 && partitions.get(0).getVisibleVersion() <= 1) {
+                // the mv is newly created, can not use it to rewrite query.
+                return new MvUpdateInfo(MvUpdateInfo.MvToRefreshType.FULL);
+            }
+            return new MvUpdateInfo(MvUpdateInfo.MvToRefreshType.NO_REFRESH);
+        }
+
+        // TODO: refactor it by using #collectBaseTablePartitionInfos
+        MvUpdateInfo mvUpdateInfo = new MvUpdateInfo(MvUpdateInfo.MvToRefreshType.PARTIAL);
+        Expr partitionExpr = mv.getFirstPartitionRefTableExpr();
+        Map<Table, Column> partitionTableAndColumn = mv.getRelatedPartitionTableAndColumn();
+        Map<String, Range<PartitionKey>> mvRangePartitionMap = mv.getRangePartitionMap();
+        Map<Table, Map<String, Range<PartitionKey>>> refBaseTablePartitionMap = Maps.newHashMap();
+        RangePartitionDiff rangePartitionDiff = null;
+        try {
+            for (Map.Entry<Table, Column> entry : partitionTableAndColumn.entrySet()) {
+                Table refBaseTable = entry.getKey();
+                Column refBaseTablePartitionColumn = entry.getValue();
+                // Collect the ref base table's partition range map.
+                refBaseTablePartitionMap.put(refBaseTable, PartitionUtil.getPartitionKeyRange(
+                        refBaseTable, refBaseTablePartitionColumn, partitionExpr));
+            }
+            Table partitionTable = mv.getDirectTableAndPartitionColumn().first;
+            Column partitionColumn = mv.getPartitionInfo().getPartitionColumns().get(0);
+            PartitionDiffer differ = PartitionDiffer.build(mv, Pair.create(null, null));
+            rangePartitionDiff = PartitionUtil.getPartitionDiff(partitionExpr, partitionColumn,
+                    refBaseTablePartitionMap.get(partitionTable), mvRangePartitionMap, differ);
+        } catch (Exception e) {
+            LOG.warn("Materialized view compute partition difference with base table failed.", e);
+            return null;
+        }
+
+        if (rangePartitionDiff == null) {
+            LOG.warn("Materialized view compute partition difference with base table failed, the diff of range partition" +
+                    " is null.");
+            return null;
+        }
+        Map<String, Range<PartitionKey>> adds = rangePartitionDiff.getAdds();
+        for (Map.Entry<String, Range<PartitionKey>> addEntry : adds.entrySet()) {
+            String mvPartitionName = addEntry.getKey();
+            mvUpdateInfo.getMvToRefreshPartitionNames().add(mvPartitionName);
+        }
+        return mvUpdateInfo;
+    }
+
+    /**
+     * For non-partitioned materialized view, once its base table have updated, we need refresh the
+     * materialized view's totally.
+     *
+     * @return : non-partitioned materialized view's all need updated partition names.
+     */
+    private static MvUpdateInfo getNonPartitionedMVRefreshPartitions(MaterializedView mv,
+                                                                     boolean isQueryRewrite) {
+        PartitionInfo partitionInfo = mv.getPartitionInfo();
+        Preconditions.checkState(partitionInfo instanceof SinglePartitionInfo);
+        List<BaseTableInfo> baseTableInfos = mv.getBaseTableInfos();
+        TableProperty tableProperty = mv.getTableProperty();
+        for (BaseTableInfo tableInfo : baseTableInfos) {
+            Table table = tableInfo.getTableChecked();
+            // skip check freshness of view
+            if (table.isView()) {
+                continue;
+            }
+
+            // skip check external table if the external does not support rewrite.
+            if (!table.isNativeTableOrMaterializedView()) {
+                if (tableProperty.getForceExternalTableQueryRewrite() ==
+                        TableProperty.QueryRewriteConsistencyMode.DISABLE) {
+                    logMVPrepare(mv, "Non-partitioned contains external table, and it's disabled query rewrite");
+                    return new MvUpdateInfo(MvUpdateInfo.MvToRefreshType.FULL);
+                }
+            }
+
+            // once mv's base table has updated, refresh the materialized view totally.
+            MvBaseTableUpdateInfo mvBaseTableUpdateInfo = getMvBaseTableUpdateInfo(mv, table, true, isQueryRewrite);
+            if (mvBaseTableUpdateInfo == null || CollectionUtils.isNotEmpty(mvBaseTableUpdateInfo.getToRefreshPartitionNames())) {
+                logMVPrepare(mv, "Non-partitioned base table has updated, need refresh totally.");
+                return new MvUpdateInfo(MvUpdateInfo.MvToRefreshType.FULL);
+            }
+        }
+        return new MvUpdateInfo(MvUpdateInfo.MvToRefreshType.NO_REFRESH);
+    }
+
+    /**
+     * Materialized Views' base tables have two kinds: ref base table and non-ref base table.
+     * - If non ref base tables updated, need refresh all mv partitions.
+     * - If ref base table updated, need refresh the ref base table's updated partitions.
+     * <p>
+     * eg:
+     * CREATE MATERIALIZED VIEW mv1
+     * PARTITION BY k1
+     * DISTRIBUTED BY HASH(k1) BUCKETS 10
+     * AS
+     * SELECT k1, v1 as k2, v2 as k3
+     * from t1 join t2
+     * on t1.k1 and t2.kk1;
+     * <p>
+     * - t1 is mv1's ref base table because mv1's partition column k1 is deduced from t1
+     * - t2 is mv1's non ref base table because mv1's partition column k1 is not associated with t2.
+     *
+     * @return : partitioned materialized view's all need updated partition names.
+     */
+    private static MvUpdateInfo getPartitionedMVRefreshPartitions(MaterializedView mv,
+                                                                  boolean isQueryRewrite) {
+        PartitionInfo partitionInfo = mv.getPartitionInfo();
+        Preconditions.checkState(partitionInfo instanceof ExpressionRangePartitionInfo);
+        // If non-partition-by table has changed, should refresh all mv partitions
+        Expr partitionExpr = mv.getFirstPartitionRefTableExpr();
+        Map<Table, Column> partitionInfos = mv.getRelatedPartitionTableAndColumn();
+        if (partitionInfos.isEmpty()) {
+            mv.setInactiveAndReason("partition configuration changed");
+            LOG.warn("mark mv:{} inactive for get partition info failed", mv.getName());
+            throw new RuntimeException(String.format("getting partition info failed for mv: %s", mv.getName()));
+        }
+
+        MvUpdateInfo.MvToRefreshType refreshType = determineRefreshType(mv, partitionInfos, isQueryRewrite);
+        logMVPrepare(mv, "Partitioned mv to refresh type:{}", refreshType);
+        if (refreshType == MvUpdateInfo.MvToRefreshType.FULL) {
+            return new MvUpdateInfo(refreshType);
+        }
+
+        MvUpdateInfo mvRefreshInfo = new MvUpdateInfo(MvUpdateInfo.MvToRefreshType.PARTIAL);
+        if (!collectBaseTablePartitionInfos(mv, partitionInfos, partitionExpr,  isQueryRewrite, mvRefreshInfo)) {
+            logMVPrepare(mv, "Partitioned mv collect base table infos failed");
+            return new MvUpdateInfo(MvUpdateInfo.MvToRefreshType.FULL);
+        }
+
+        Map<Table, MvBaseTableUpdateInfo> baseTableUpdateInfos = mvRefreshInfo.getBaseTableUpdateInfos();
+        Map<Table, Map<String, Range<PartitionKey>>> basePartitionNameToRangeMap = baseTableUpdateInfos.entrySet().stream()
+                .collect(Collectors.toMap(Map.Entry::getKey, e -> e.getValue().getPartitionNameWithRanges()));
+        // TODO: prune the partitions based on ttl
+        Pair<Table, Column> directTableAndPartitionColumn = mv.getDirectTableAndPartitionColumn();
+        Table refBaseTable = directTableAndPartitionColumn.first;
+        Column refBaseTablePartitionColumn = directTableAndPartitionColumn.second;
+
+        Map<String, Range<PartitionKey>> refTablePartitionMap = basePartitionNameToRangeMap.get(refBaseTable);
+        Map<String, Range<PartitionKey>> mvPartitionNameToRangeMap = mv.getRangePartitionMap();
+        RangePartitionDiff rangePartitionDiff = PartitionUtil.getPartitionDiff(partitionExpr,
+                refBaseTablePartitionColumn, refTablePartitionMap, mvPartitionNameToRangeMap, null);
+
+        Set<String> needRefreshMvPartitionNames = Sets.newHashSet();
+
+        // TODO: no needs to refresh the deleted partitions, because the deleted partitions are not in the mv's partition map.
+        needRefreshMvPartitionNames.addAll(rangePartitionDiff.getDeletes().keySet());
+        // remove ref base table's deleted partitions from `mvPartitionMap`
+        for (String deleted : rangePartitionDiff.getDeletes().keySet()) {
+            mvPartitionNameToRangeMap.remove(deleted);
+        }
+
+        // step2: refresh ref base table's new added partitions
+        needRefreshMvPartitionNames.addAll(rangePartitionDiff.getAdds().keySet());
+        mvPartitionNameToRangeMap.putAll(rangePartitionDiff.getAdds());
+
+        Map<Table, Expr> tableToPartitionExprMap = mv.getTableToPartitionExprMap();
+        Map<Table, Map<String, Set<String>>> baseToMvNameRef = SyncPartitionUtils
+                .generateBaseRefMap(basePartitionNameToRangeMap, tableToPartitionExprMap, mvPartitionNameToRangeMap);
+        Map<String, Map<Table, Set<String>>> mvToBaseNameRef = SyncPartitionUtils
+                .generateMvRefMap(mvPartitionNameToRangeMap, tableToPartitionExprMap, basePartitionNameToRangeMap);
+
+        mvRefreshInfo.getBasePartToMvPartNames().putAll(baseToMvNameRef);
+        mvRefreshInfo.getMvPartToBasePartNames().putAll(mvToBaseNameRef);
+
+        // Step1: collect updated partitions by partition name to range name:
+        // - deleted partitions.
+        // - added partitions.
+        Map<Table, Set<String>> baseChangedPartitionNames = mvRefreshInfo.getBaseTableUpdateInfos().entrySet().stream()
+                .collect(Collectors.toMap(Map.Entry::getKey, x -> x.getValue().getToRefreshPartitionNames()));
+        for (Map.Entry<Table, Set<String>> entry : baseChangedPartitionNames.entrySet()) {
+            entry.getValue().stream().forEach(x ->
+                    needRefreshMvPartitionNames.addAll(baseToMvNameRef.get(entry.getKey()).get(x))
+            );
+        }
+
+        if (partitionExpr instanceof FunctionCallExpr) {
+            List<TableWithPartitions> baseTableWithPartitions = baseChangedPartitionNames.keySet().stream()
+                    .map(x -> new TableWithPartitions(x, baseChangedPartitionNames.get(x)))
+                    .collect(Collectors.toList());
+            if (mv.isCalcPotentialRefreshPartition(baseTableWithPartitions,
+                    basePartitionNameToRangeMap, needRefreshMvPartitionNames, mvPartitionNameToRangeMap)) {
+                // because the relation of partitions between materialized view and base partition table is n : m,
+                // should calculate the candidate partitions recursively.
+                SyncPartitionUtils.calcPotentialRefreshPartition(needRefreshMvPartitionNames, baseChangedPartitionNames,
+                        baseToMvNameRef, mvToBaseNameRef, Sets.newHashSet());
+            }
+        }
+
+        // update mv's to refresh partitions
+        mvRefreshInfo.getMvToRefreshPartitionNames().addAll(needRefreshMvPartitionNames);
+        return mvRefreshInfo;
+    }
+
+    private static boolean collectBaseTablePartitionInfos(MaterializedView mv,
+                                                          Map<Table, Column> partitionInfos,
+                                                          Expr partitionExpr,
+                                                          boolean isQueryRewrite,
+                                                          MvUpdateInfo mvUpdateInfo) {
+        for (Map.Entry<Table, Column> entry : partitionInfos.entrySet()) {
+            Table table = entry.getKey();
+
+            // TODO: merge getPartitionKeyRange into mvBaseTableUpdateInfo
+            // step1.2: check ref base table's updated partition names by checking its ref tables recursively.
+            MvBaseTableUpdateInfo mvBaseTableUpdateInfo  =
+                    getMvBaseTableUpdateInfo(mv, table, true, isQueryRewrite);
+            if (mvBaseTableUpdateInfo == null) {
+                return false;
+            }
+
+            // TODO: no need to list all partitions, just need to list the changed partitions?
+            try {
+                Map<String, Range<PartitionKey>> partitionKeyRanges =
+                        PartitionUtil.getPartitionKeyRange(table, entry.getValue(), partitionExpr);
+                mvBaseTableUpdateInfo.getPartitionNameWithRanges().putAll(partitionKeyRanges);
+            } catch (UserException e) {
+                LOG.warn("Materialized view compute partition difference with base table failed.", e);
+                return false;
+            }
+            mvUpdateInfo.getBaseTableUpdateInfos().put(table, mvBaseTableUpdateInfo);
+        }
+        return true;
+    }
+
+    private static MvUpdateInfo.MvToRefreshType determineRefreshType(MaterializedView mv,
+                                                                     Map<Table, Column> partitionInfos,
+                                                                     boolean isQueryRewrite) {
+        TableProperty tableProperty = mv.getTableProperty();
+        for (BaseTableInfo tableInfo : mv.getBaseTableInfos()) {
+            Table baseTable = tableInfo.getTableChecked();
+            // skip view
+            if (baseTable.isView()) {
+                continue;
+            }
+            // skip external table that is not supported for query rewrite, return all partition ?
+            // skip check external table if the external does not support rewrite.
+            if (!baseTable.isNativeTableOrMaterializedView()) {
+                if (tableProperty.getForceExternalTableQueryRewrite() ==
+                        TableProperty.QueryRewriteConsistencyMode.DISABLE) {
+                    return MvUpdateInfo.MvToRefreshType.FULL;
+                }
+            }
+            if (partitionInfos.containsKey(baseTable)) {
+                continue;
+            }
+            // If the non ref table has already changed, need refresh all materialized views' partitions.
+            MvBaseTableUpdateInfo mvBaseTableUpdateInfo =
+                    getMvBaseTableUpdateInfo(mv, baseTable, true, isQueryRewrite);
+            if (mvBaseTableUpdateInfo == null || CollectionUtils.isNotEmpty(mvBaseTableUpdateInfo.getToRefreshPartitionNames())) {
+                return MvUpdateInfo.MvToRefreshType.FULL;
+            }
+        }
+        return MvUpdateInfo.MvToRefreshType.PARTIAL;
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/MvUpdateInfo.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/MvUpdateInfo.java
@@ -34,6 +34,8 @@ public class MvUpdateInfo {
     private final Map<Table, Map<String, Set<String>>> basePartToMvPartNames = Maps.newHashMap();
     //  The mapping of mv partition name to base partition names
     private final Map<String, Map<Table, Set<String>>> mvPartToBasePartNames = Maps.newHashMap();
+    // The consistency mode of query rewrite
+    private final TableProperty.QueryRewriteConsistencyMode queryRewriteConsistencyMode;
 
     /**
      * Marks the type of mv refresh later.
@@ -47,6 +49,12 @@ public class MvUpdateInfo {
 
     public MvUpdateInfo(MvToRefreshType mvToRefreshType) {
         this.mvToRefreshType = mvToRefreshType;
+        this.queryRewriteConsistencyMode = TableProperty.QueryRewriteConsistencyMode.CHECKED;
+    }
+
+    public MvUpdateInfo(MvToRefreshType mvToRefreshType, TableProperty.QueryRewriteConsistencyMode queryRewriteConsistencyMode) {
+        this.mvToRefreshType = mvToRefreshType;
+        this.queryRewriteConsistencyMode = queryRewriteConsistencyMode;
     }
 
     public MvToRefreshType getMvToRefreshType() {
@@ -73,6 +81,10 @@ public class MvUpdateInfo {
         return basePartToMvPartNames;
     }
 
+    public TableProperty.QueryRewriteConsistencyMode getQueryRewriteConsistencyMode() {
+        return queryRewriteConsistencyMode;
+    }
+
     @Override
     public String toString() {
         return "MvUpdateInfo{" +
@@ -93,6 +105,14 @@ public class MvUpdateInfo {
         if (mvToRefreshPartitionNames.isEmpty()) {
             return Sets.newHashSet();
         }
+        if (queryRewriteConsistencyMode == TableProperty.QueryRewriteConsistencyMode.LOOSE) {
+            MvBaseTableUpdateInfo mvBaseTableUpdateInfo = baseTableUpdateInfos.get(refBaseTable);
+            if (mvBaseTableUpdateInfo == null) {
+                return null;
+            }
+            return mvBaseTableUpdateInfo.getToRefreshPartitionNames();
+        }
+
         // TODO: In some rewrite mode(loose), mv part to base part names are not prepared, skip to this.
         if (mvPartToBasePartNames == null || mvPartToBasePartNames.isEmpty()) {
             return null;

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/MvUpdateInfo.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/MvUpdateInfo.java
@@ -1,0 +1,117 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.catalog;
+
+import com.google.common.collect.Maps;
+import com.google.common.collect.Sets;
+
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Store the update information of MV used for mv rewrite(mv refresh can use it later).
+ */
+public class MvUpdateInfo {
+    // The type of mv refresh later
+    private final MvToRefreshType mvToRefreshType;
+    // The partition names of mv to refresh
+    private final Set<String> mvToRefreshPartitionNames = Sets.newHashSet();
+    // The update information of base table
+    private final Map<Table, MvBaseTableUpdateInfo> baseTableUpdateInfos = Maps.newHashMap();
+    // The mapping of base partition name to mv partition names
+    private final Map<Table, Map<String, Set<String>>> basePartToMvPartNames = Maps.newHashMap();
+    //  The mapping of mv partition name to base partition names
+    private final Map<String, Map<Table, Set<String>>> mvPartToBasePartNames = Maps.newHashMap();
+
+    /**
+     * Marks the type of mv refresh later.
+     */
+    public enum MvToRefreshType {
+        FULL, // full refresh since non ref base table is updated or mv is invalid
+        PARTIAL, // partial refresh since ref base table is updated
+        NO_REFRESH, // no need to refresh since ref base table is not updated
+        UNKNOWN // unknown type
+    }
+
+    public MvUpdateInfo(MvToRefreshType mvToRefreshType) {
+        this.mvToRefreshType = mvToRefreshType;
+    }
+
+    public MvToRefreshType getMvToRefreshType() {
+        return mvToRefreshType;
+    }
+
+    public boolean isValidRewrite() {
+        return mvToRefreshType == MvToRefreshType.PARTIAL || mvToRefreshType == MvToRefreshType.NO_REFRESH;
+    }
+
+    public Set<String> getMvToRefreshPartitionNames() {
+        return mvToRefreshPartitionNames;
+    }
+
+    public Map<Table, MvBaseTableUpdateInfo> getBaseTableUpdateInfos() {
+        return baseTableUpdateInfos;
+    }
+
+    public Map<String, Map<Table, Set<String>>> getMvPartToBasePartNames() {
+        return mvPartToBasePartNames;
+    }
+
+    public Map<Table, Map<String, Set<String>>> getBasePartToMvPartNames() {
+        return basePartToMvPartNames;
+    }
+
+    @Override
+    public String toString() {
+        return "MvUpdateInfo{" +
+                "refreshType=" + mvToRefreshType +
+                ", mvToRefreshPartitionNames=" + mvToRefreshPartitionNames +
+                ", baseTableUpdateInfos=" + baseTableUpdateInfos +
+                ", basePartToMvPartNames=" + basePartToMvPartNames +
+                ", mvPartToBasePartNames=" + mvPartToBasePartNames +
+                '}';
+    }
+
+    /**
+     * Get the ref base table partition names to refresh for the given mv.
+     * @param refBaseTable: the input ref base table
+     * @return: the partition names to refresh of the ref base table.
+     */
+    public Set<String> getBaseTableToRefreshPartitionNames(Table refBaseTable) {
+        if (mvToRefreshPartitionNames.isEmpty()) {
+            return Sets.newHashSet();
+        }
+        // TODO: In some rewrite mode(loose), mv part to base part names are not prepared, skip to this.
+        if (mvPartToBasePartNames == null || mvPartToBasePartNames.isEmpty()) {
+            return null;
+        }
+        // MV's partition names to refresh is not only affected by the ref base table, but also other base tables.
+        // Deduce the partition names to refresh of the ref base table from the partition names to refresh of the mv.
+        Set<String> refBaseTableToRefreshPartitionNames = Sets.newHashSet();
+        for (String mvPartName : mvToRefreshPartitionNames) {
+            Map<Table, Set<String>> baseTableToPartNames = mvPartToBasePartNames.get(mvPartName);
+            // means base table's partitions have already dropped.
+            if (baseTableToPartNames == null) {
+                continue;
+            }
+            Set<String> partNames = baseTableToPartNames.get(refBaseTable);
+            if (partNames == null) {
+                return null;
+            }
+            refBaseTableToRefreshPartitionNames.addAll(partNames);
+        }
+        return refBaseTableToRefreshPartitionNames;
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/MvUpdateInfo.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/MvUpdateInfo.java
@@ -102,8 +102,11 @@ public class MvUpdateInfo {
      * @return: the partition names to refresh of the ref base table.
      */
     public Set<String> getBaseTableToRefreshPartitionNames(Table refBaseTable) {
-        if (mvToRefreshPartitionNames.isEmpty()) {
+        if (mvToRefreshPartitionNames.isEmpty() || mvToRefreshType == MvToRefreshType.NO_REFRESH) {
             return Sets.newHashSet();
+        }
+        if (mvToRefreshType == MvToRefreshType.FULL) {
+            return null;
         }
         if (queryRewriteConsistencyMode == TableProperty.QueryRewriteConsistencyMode.LOOSE) {
             MvBaseTableUpdateInfo mvBaseTableUpdateInfo = baseTableUpdateInfos.get(refBaseTable);
@@ -113,7 +116,6 @@ public class MvUpdateInfo {
             return mvBaseTableUpdateInfo.getToRefreshPartitionNames();
         }
 
-        // TODO: In some rewrite mode(loose), mv part to base part names are not prepared, skip to this.
         if (mvPartToBasePartNames == null || mvPartToBasePartNames.isEmpty()) {
             return null;
         }

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/PartitionBasedMvRefreshProcessor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/PartitionBasedMvRefreshProcessor.java
@@ -40,6 +40,7 @@ import com.starrocks.catalog.HashDistributionInfo;
 import com.starrocks.catalog.HiveTable;
 import com.starrocks.catalog.ListPartitionInfo;
 import com.starrocks.catalog.MaterializedView;
+import com.starrocks.catalog.MvBaseTableUpdateInfo;
 import com.starrocks.catalog.OlapTable;
 import com.starrocks.catalog.Partition;
 import com.starrocks.catalog.PartitionInfo;
@@ -112,7 +113,6 @@ import com.starrocks.sql.common.SyncPartitionUtils;
 import com.starrocks.sql.optimizer.rule.transformation.materialization.MvUtils;
 import com.starrocks.sql.parser.SqlParser;
 import com.starrocks.sql.plan.ExecPlan;
-import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.collections4.ListUtils;
 import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.apache.logging.log4j.LogManager;
@@ -135,6 +135,8 @@ import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.Consumer;
 import java.util.stream.Collectors;
 
+import static com.starrocks.catalog.MvRefreshArbiter.getMvBaseTableUpdateInfo;
+import static com.starrocks.catalog.MvRefreshArbiter.needToRefreshTable;
 import static com.starrocks.catalog.system.SystemTable.MAX_FIELD_VARCHAR_LENGTH;
 
 /**
@@ -1106,10 +1108,6 @@ public class PartitionBasedMvRefreshProcessor extends BaseTaskRunProcessor {
         mvContext.setRefBaseTableListPartitionMap(baseListPartitionMap);
     }
 
-    private boolean needToRefreshTable(Table table) {
-        return CollectionUtils.isNotEmpty(materializedView.getUpdatedPartitionNamesOfTable(table, false));
-    }
-
     private static boolean supportPartitionRefresh(Table table) {
         return ConnectorPartitionTraits.build(table).supportPartitionRefresh();
     }
@@ -1125,7 +1123,7 @@ public class PartitionBasedMvRefreshProcessor extends BaseTaskRunProcessor {
             if (!supportPartitionRefresh(snapshotTable)) {
                 return true;
             }
-            if (needToRefreshTable(snapshotTable)) {
+            if (needToRefreshTable(materializedView, snapshotTable)) {
                 return true;
             }
         }
@@ -1149,7 +1147,7 @@ public class PartitionBasedMvRefreshProcessor extends BaseTaskRunProcessor {
             if (tableColumnMap.containsKey(snapshotTable)) {
                 continue;
             }
-            if (needToRefreshTable(snapshotTable)) {
+            if (needToRefreshTable(materializedView, snapshotTable)) {
                 return true;
             }
         }
@@ -1339,12 +1337,13 @@ public class PartitionBasedMvRefreshProcessor extends BaseTaskRunProcessor {
         }
 
         // step1: check updated partition names in the ref base table and add it to the refresh candidate
-        Set<String> updatePartitionNames = materializedView.getUpdatedPartitionNamesOfTable(refBaseTable, false);
-        if (updatePartitionNames == null) {
+        MvBaseTableUpdateInfo mvBaseTableUpdateInfo = getMvBaseTableUpdateInfo(materializedView, refBaseTable, false, false);
+        if (mvBaseTableUpdateInfo == null) {
             return mvRangePartitionNames;
         }
 
         // step2: fetch the corresponding materialized view partition names as the need to refresh partitions
+        Set<String> updatePartitionNames = mvBaseTableUpdateInfo.getToRefreshPartitionNames();
         Set<String> result = getMVPartitionNamesByBasePartitionNames(refBaseTable, updatePartitionNames);
         result.retainAll(mvRangePartitionNames);
         return result;

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/MaterializationContext.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/MaterializationContext.java
@@ -18,6 +18,7 @@ import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
 import com.starrocks.catalog.MaterializedView;
+import com.starrocks.catalog.MvUpdateInfo;
 import com.starrocks.catalog.Table;
 import com.starrocks.common.Pair;
 import com.starrocks.sql.optimizer.base.ColumnRefFactory;
@@ -60,11 +61,8 @@ public class MaterializationContext {
 
     private Map<ColumnRefOperator, ColumnRefOperator> outputMapping;
 
-    // Updated partition names of the materialized view
-    private final Set<String> mvPartitionNamesToRefresh;
-
     // Updated partition names of the ref base table which will be used in compensating partition predicates
-    private final Set<String> refTableUpdatePartitionNames;
+    private final MvUpdateInfo mvUpdateInfo;
 
     private final List<Table> baseTables;
 
@@ -101,23 +99,21 @@ public class MaterializationContext {
                                   OptExpression mvExpression,
                                   ColumnRefFactory queryColumnRefFactory,
                                   ColumnRefFactory mvColumnRefFactory,
-                                  Set<String> mvPartitionNamesToRefresh,
                                   List<Table> baseTables,
                                   List<Table> intersectingTables,
                                   ScalarOperator mvPartialPartitionPredicate,
-                                  Set<String> refTableUpdatePartitionNames,
+                                  MvUpdateInfo mvUpdateInfo,
                                   List<ColumnRefOperator> mvOutputColumnRefs) {
         this.optimizerContext = optimizerContext;
         this.mv = mv;
         this.mvExpression = mvExpression;
         this.queryRefFactory = queryColumnRefFactory;
         this.mvColumnRefFactory = mvColumnRefFactory;
-        this.mvPartitionNamesToRefresh = mvPartitionNamesToRefresh;
         this.baseTables = baseTables;
         this.intersectingTables = intersectingTables;
         this.matchedGroups = Lists.newArrayList();
         this.mvPartialPartitionPredicate = mvPartialPartitionPredicate;
-        this.refTableUpdatePartitionNames = refTableUpdatePartitionNames;
+        this.mvUpdateInfo = mvUpdateInfo;
         this.mvOutputColumnRefs = mvOutputColumnRefs;
         this.scanOpToPartitionCompensatePredicates = Maps.newHashMap();
     }
@@ -158,10 +154,6 @@ public class MaterializationContext {
         this.outputMapping = outputMapping;
     }
 
-    public Set<String> getMvPartitionNamesToRefresh() {
-        return mvPartitionNamesToRefresh;
-    }
-
     public List<Table> getBaseTables() {
         return baseTables;
     }
@@ -198,8 +190,8 @@ public class MaterializationContext {
         this.mvUsedCount += 1;
     }
 
-    public Set<String> getRefTableUpdatePartitionNames() {
-        return this.refTableUpdatePartitionNames;
+    public MvUpdateInfo getMvUpdateInfo() {
+        return mvUpdateInfo;
     }
 
     private boolean checkOperatorCompatible(OperatorType query) {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/AggregatedMaterializedViewRewriter.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/AggregatedMaterializedViewRewriter.java
@@ -507,7 +507,7 @@ public class AggregatedMaterializedViewRewriter extends MaterializedViewRewriter
                 unionExpr, newProjection);
         // Add extra union all predicates above union all operator.
         if (rewriteContext.getUnionRewriteQueryExtraPredicate() != null) {
-            addExtraPredicate(result, rewriteContext.getUnionRewriteQueryExtraPredicate());
+            MvUtils.addExtraPredicate(result, rewriteContext.getUnionRewriteQueryExtraPredicate());
         }
         deriveLogicalProperty(result);
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MVCompensation.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MVCompensation.java
@@ -74,7 +74,7 @@ public class MVCompensation {
         }
 
         // No compensate once if mv's freshness is satisfied.
-        if (state.isPrunedCompensate()) {
+        if (state.isCompensate()) {
             return true;
         }
 
@@ -88,7 +88,7 @@ public class MVCompensation {
         }
         if (state.isNoCompensate()) {
             return false;
-        } else if (state.isPrunedCompensate()) {
+        } else if (state.isCompensate()) {
             return !unionRewriteMode.isTransparentRewrite();
         } else {
             return true;

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MVTransparentState.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MVTransparentState.java
@@ -37,7 +37,7 @@ public enum MVTransparentState {
         return this == NO_COMPENSATE;
     }
 
-    public boolean isPrunedCompensate() {
+    public boolean isCompensate() {
         return this == COMPENSATE;
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MaterializedViewRewriter.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MaterializedViewRewriter.java
@@ -62,12 +62,10 @@ import com.starrocks.sql.optimizer.operator.Operator;
 import com.starrocks.sql.optimizer.operator.OperatorBuilderFactory;
 import com.starrocks.sql.optimizer.operator.Projection;
 import com.starrocks.sql.optimizer.operator.logical.LogicalAggregationOperator;
-import com.starrocks.sql.optimizer.operator.logical.LogicalFilterOperator;
 import com.starrocks.sql.optimizer.operator.logical.LogicalJoinOperator;
 import com.starrocks.sql.optimizer.operator.logical.LogicalOlapScanOperator;
 import com.starrocks.sql.optimizer.operator.logical.LogicalOperator;
 import com.starrocks.sql.optimizer.operator.logical.LogicalScanOperator;
-import com.starrocks.sql.optimizer.operator.logical.LogicalSetOperator;
 import com.starrocks.sql.optimizer.operator.logical.LogicalUnionOperator;
 import com.starrocks.sql.optimizer.operator.logical.LogicalViewScanOperator;
 import com.starrocks.sql.optimizer.operator.scalar.BinaryPredicateOperator;
@@ -1286,7 +1284,7 @@ public class MaterializedViewRewriter {
                 if (optimizerContext.getSessionVariable().getQueryDebugOptions().isEnableNormalizePredicateAfterMVRewrite()) {
                     normalizedPredicate = MvUtils.canonizePredicateForRewrite(queryMaterializationContext, normalizedPredicate);
                 }
-                mvScanOptExpression = addExtraPredicate(mvScanOptExpression, normalizedPredicate);
+                mvScanOptExpression = MvUtils.addExtraPredicate(mvScanOptExpression, normalizedPredicate);
 
                 mvScanOptExpression.setLogicalProperty(null);
                 deriveLogicalProperty(mvScanOptExpression);
@@ -2151,32 +2149,11 @@ public class MaterializedViewRewriter {
 
         // Add extra union all predicates above union all operator.
         if (rewriteContext.getUnionRewriteQueryExtraPredicate() != null) {
-            result = addExtraPredicate(result, rewriteContext.getUnionRewriteQueryExtraPredicate());
+            result = MvUtils.addExtraPredicate(result, rewriteContext.getUnionRewriteQueryExtraPredicate());
         }
 
         deriveLogicalProperty(result);
         return result;
-    }
-
-    protected OptExpression addExtraPredicate(OptExpression result,
-                                              ScalarOperator extraPredicate) {
-        Operator op = result.getOp();
-        if (op instanceof LogicalSetOperator) {
-            LogicalFilterOperator filter = new LogicalFilterOperator(extraPredicate);
-            // use PUSH_DOWN_PREDICATE rule to push down filter after union all set after mv rewrite rule.
-            return OptExpression.create(filter, result);
-        } else {
-            // If op is aggregate operator, use setPredicate directly.
-            ScalarOperator origPredicate = op.getPredicate();
-            if (op.getProjection() != null) {
-                ReplaceColumnRefRewriter rewriter = new ReplaceColumnRefRewriter(op.getProjection().getColumnRefMap());
-                ScalarOperator rewrittenExtraPredicate = rewriter.rewrite(extraPredicate);
-                op.setPredicate(Utils.compoundAnd(origPredicate, rewrittenExtraPredicate));
-            } else {
-                op.setPredicate(Utils.compoundAnd(origPredicate, extraPredicate));
-            }
-            return result;
-        }
     }
 
     protected EquationRewriter buildEquationRewriter(

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvPartitionCompensator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvPartitionCompensator.java
@@ -31,6 +31,7 @@ import com.starrocks.analysis.StringLiteral;
 import com.starrocks.catalog.Column;
 import com.starrocks.catalog.ExpressionRangePartitionInfo;
 import com.starrocks.catalog.MaterializedView;
+import com.starrocks.catalog.MvUpdateInfo;
 import com.starrocks.catalog.OlapTable;
 import com.starrocks.catalog.Partition;
 import com.starrocks.catalog.PartitionKey;
@@ -117,16 +118,33 @@ public class MvPartitionCompensator {
     public static MVCompensation getMvCompensation(OptExpression queryPlan,
                                                    MaterializationContext mvContext) {
         SessionVariable sessionVariable = mvContext.getOptimizerContext().getSessionVariable();
-        Set<String> mvPartitionNameToRefresh = mvContext.getMvPartitionNamesToRefresh();
+        MvUpdateInfo mvUpdateInfo = mvContext.getMvUpdateInfo();
+        Set<String> mvPartitionNameToRefresh = mvUpdateInfo.getMvToRefreshPartitionNames();
         // If mv contains no partitions to refresh, no need compensate
         if (Objects.isNull(mvPartitionNameToRefresh) || mvPartitionNameToRefresh.isEmpty()) {
+            logMVRewrite(mvContext, "MV has no partitions to refresh, no need compensate");
             return MVCompensation.createNoCompensateState(sessionVariable);
         }
+
+        // If no partition table and columns, no need compensate
+        MaterializedView mv = mvContext.getMv();
+        Pair<Table, Column> partitionTableAndColumns = mv.getDirectTableAndPartitionColumn();
+        if (partitionTableAndColumns == null) {
+            logMVRewrite(mvContext, "MV's partition table and columns is null, unknown state");
+            return MVCompensation.createUnkownState(sessionVariable);
+        }
+        Table refBaseTable = partitionTableAndColumns.first;
+
         // If ref table contains no partitions to refresh, no need compensate.
         // If the mv is partitioned and non-ref table need refresh, then all partitions need to be refreshed,
         // it can not be a candidate.
-        Set<String> refTablePartitionNameToRefresh = mvContext.getRefTableUpdatePartitionNames();
-        if (Objects.isNull(refTablePartitionNameToRefresh) || refTablePartitionNameToRefresh.isEmpty()) {
+        Set<String> refTablePartitionNameToRefresh = mvUpdateInfo.getBaseTableToRefreshPartitionNames(refBaseTable);
+        if (refTablePartitionNameToRefresh == null) {
+            logMVRewrite(mvContext, "MV's ref base to refresh partition is null, unknown state");
+            return MVCompensation.createUnkownState(sessionVariable);
+        }
+        if (refTablePartitionNameToRefresh.isEmpty()) {
+            logMVRewrite(mvContext, "MV's ref base to refresh partition is empty, no need compensate");
             // NOTE: This should not happen: `mvPartitionNameToRefresh` is not empty, so `refTablePartitionNameToRefresh`
             // should not empty. Return true in the situation to avoid bad cases.
             return MVCompensation.createUnkownState(sessionVariable);
@@ -141,15 +159,7 @@ public class MvPartitionCompensator {
             return MVCompensation.createUnkownState(sessionVariable);
         }
 
-        // If no partition table and columns, no need compensate
-        MaterializedView mv = mvContext.getMv();
-        Pair<Table, Column> partitionTableAndColumns = mv.getDirectTableAndPartitionColumn();
-        if (partitionTableAndColumns == null) {
-            return MVCompensation.createUnkownState(sessionVariable);
-        }
-
         // only set this when `queryExpression` contains ref table, otherwise the cached value maybe dirty.
-        Table refBaseTable = partitionTableAndColumns.first;
         LogicalScanOperator refScanOperator = getRefBaseTableScanOperator(scanOperators, refBaseTable);
         if (refScanOperator == null) {
             return MVCompensation.createUnkownState(sessionVariable);
@@ -159,6 +169,7 @@ public class MvPartitionCompensator {
         // If table's not partitioned, no need compensate
         if (table.isUnPartitioned()) {
             // TODO: Support this later.
+            logMVRewrite(mvContext, "MV's is un-partitioned, unknown state");
             return MVCompensation.createUnkownState(sessionVariable);
         }
 
@@ -294,6 +305,7 @@ public class MvPartitionCompensator {
         }
         return refTableCompensatePartitionKeys;
     }
+
     /**
      * Get all refreshed partitions' plan of the materialized view.
      * @param mvContext: materialized view context
@@ -335,6 +347,10 @@ public class MvPartitionCompensator {
         }
         OptExpressionDuplicator duplicator = new OptExpressionDuplicator(mvContext);
         OptExpression newMvQueryPlan = duplicator.duplicate(compensateMvQueryPlan);
+        if (newMvQueryPlan == null) {
+            logMVRewrite(mvContext, "Duplicate compensate query plan failed");
+            return null;
+        }
         deriveLogicalProperty(newMvQueryPlan);
         List<ColumnRefOperator> orgMvQueryOutputColumnRefs = mvContext.getMvOutputColumnRefs();
         List<ColumnRefOperator> mvQueryOutputColumnRefs = duplicator.getMappedColumns(orgMvQueryOutputColumnRefs);
@@ -408,7 +424,7 @@ public class MvPartitionCompensator {
     public static OptExpression getMvTransparentPlan(MaterializationContext mvContext,
                                                      MVCompensation mvCompensation,
                                                      List<ColumnRefOperator> expectOutputColumns) {
-        Preconditions.checkState(mvCompensation.isTransparentRewrite());
+        Preconditions.checkState(mvCompensation.getState().isCompensate());
         final LogicalOlapScanOperator mvScanOperator = mvContext.getScanMvOperator();
         final MaterializedView mv = mvContext.getMv();
         final List<ColumnRefOperator> originalOutputColumns = expectOutputColumns == null ?

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvPartitionCompensator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvPartitionCompensator.java
@@ -145,9 +145,7 @@ public class MvPartitionCompensator {
         }
         if (refTablePartitionNameToRefresh.isEmpty()) {
             logMVRewrite(mvContext, "MV's ref base to refresh partition is empty, no need compensate");
-            // NOTE: This should not happen: `mvPartitionNameToRefresh` is not empty, so `refTablePartitionNameToRefresh`
-            // should not empty. Return true in the situation to avoid bad cases.
-            return MVCompensation.createUnkownState(sessionVariable);
+            return MVCompensation.createNoCompensateState(sessionVariable);
         }
 
         List<LogicalScanOperator> scanOperators = MvUtils.getScanOperator(queryPlan);

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/OptExpressionDuplicator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/OptExpressionDuplicator.java
@@ -71,7 +71,7 @@ public class OptExpressionDuplicator {
         Pair<Table, Column> partitionInfo = materializationContext.getMv().getDirectTableAndPartitionColumn();
         this.partitionByTable = partitionInfo == null ? null : partitionInfo.first;
         this.partitionColumn = partitionInfo == null ? null : partitionInfo.second;
-        this.partialPartitionRewrite = !materializationContext.getMvPartitionNamesToRefresh().isEmpty();
+        this.partialPartitionRewrite = !materializationContext.getMvUpdateInfo().getMvToRefreshPartitionNames().isEmpty();
     }
 
     public OptExpressionDuplicator(ColumnRefFactory columnRefFactory) {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/rule/TextMatchBasedRewriteRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/rule/TextMatchBasedRewriteRule.java
@@ -25,6 +25,7 @@ import com.starrocks.analysis.ParseNode;
 import com.starrocks.catalog.Column;
 import com.starrocks.catalog.MaterializedView;
 import com.starrocks.catalog.MvPlanContext;
+import com.starrocks.catalog.MvUpdateInfo;
 import com.starrocks.catalog.Table;
 import com.starrocks.common.Pair;
 import com.starrocks.common.util.DebugUtil;
@@ -58,6 +59,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 
+import static com.starrocks.catalog.MvRefreshArbiter.getPartitionNamesToRefreshForMv;
 import static com.starrocks.sql.optimizer.OptimizerTraceUtil.logMVRewrite;
 import static com.starrocks.sql.optimizer.rule.transformation.materialization.MaterializedViewRewriter.REWRITE_SUCCESS;
 
@@ -217,12 +219,13 @@ public class TextMatchBasedRewriteRule extends Rule {
                 if (mvRelatedCount++ > mvRewriteRelatedMVsLimit) {
                     return null;
                 }
-                Set<String> partitionNamesToRefresh = Sets.newHashSet();
-                if (!mv.getPartitionNamesToRefreshForMv(partitionNamesToRefresh, true)) {
+                MvUpdateInfo mvUpdateInfo = getPartitionNamesToRefreshForMv(mv, true);
+                if (mvUpdateInfo == null || !mvUpdateInfo.isValidRewrite()) {
                     logMVRewrite(context, this, "MV {} cannot be used for rewrite, " +
-                            "stale partitions {}", mv.getName(), partitionNamesToRefresh);
+                            "stale partitions {}", mv.getName(), mvUpdateInfo);
                     continue;
                 }
+                Set<String> partitionNamesToRefresh = mvUpdateInfo.getMvToRefreshPartitionNames();
                 if (!partitionNamesToRefresh.isEmpty()) {
                     logMVRewrite(context, this, "Partitioned MV {} is outdated which " +
                                     "contains some partitions to be refreshed: {}, and cannot compensate it to predicate",

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/RefreshMaterializedViewTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/RefreshMaterializedViewTest.java
@@ -19,6 +19,7 @@ import com.starrocks.catalog.Database;
 import com.starrocks.catalog.LocalTablet;
 import com.starrocks.catalog.MaterializedIndex;
 import com.starrocks.catalog.MaterializedView;
+import com.starrocks.catalog.MvUpdateInfo;
 import com.starrocks.catalog.OlapTable;
 import com.starrocks.catalog.Partition;
 import com.starrocks.catalog.Replica;
@@ -142,8 +143,12 @@ public class RefreshMaterializedViewTest  extends MvRewriteTestBase {
         Partition p1 = table.getPartition("p1");
         Partition p2 = table.getPartition("p2");
         if (p2.getVisibleVersion() == 3) {
+            MvUpdateInfo mvUpdateInfo = getMvUpdateInfo(mv1);
+            Assert.assertTrue(mvUpdateInfo.getMvToRefreshType() == MvUpdateInfo.MvToRefreshType.FULL);
+            Assert.assertTrue(!mvUpdateInfo.isValidRewrite());
             partitionsToRefresh1 = getPartitionNamesToRefreshForMv(mv1);
-            Assert.assertEquals(Sets.newHashSet("mv_to_refresh"), partitionsToRefresh1);
+            Assert.assertTrue(partitionsToRefresh1.isEmpty());
+
             partitionsToRefresh2 = getPartitionNamesToRefreshForMv(mv2);
             Assert.assertTrue(partitionsToRefresh2.contains("p2"));
         } else {
@@ -221,8 +226,7 @@ public class RefreshMaterializedViewTest  extends MvRewriteTestBase {
     }
 
     private void checkToRefreshPartitionsEmpty(MaterializedView mv) {
-        Set<String> partitionsToRefresh = Sets.newHashSet();
-        Assert.assertTrue(mv.getPartitionNamesToRefreshForMv(partitionsToRefresh, true));
+        Set<String> partitionsToRefresh = getPartitionNamesToRefreshForMv(mv);
         Assert.assertTrue(partitionsToRefresh.isEmpty());
     }
 

--- a/fe/fe-core/src/test/java/com/starrocks/planner/MaterializedViewTPCHTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/planner/MaterializedViewTPCHTest.java
@@ -17,6 +17,7 @@ package com.starrocks.planner;
 import com.google.common.collect.Lists;
 import com.starrocks.catalog.OlapTable;
 import com.starrocks.server.GlobalStateMgr;
+import com.starrocks.sql.common.QueryDebugOptions;
 import com.starrocks.sql.plan.MockTpchStatisticStorage;
 import com.starrocks.sql.plan.PlanTestBase;
 import org.junit.jupiter.api.BeforeAll;
@@ -56,6 +57,9 @@ public class MaterializedViewTPCHTest extends MaterializedViewTestBase {
         // And OneTabletExecutorVisitor#visitLogicalTableScan will deduce `supportOneTabletOpt` because this test
         // case has no tablets left after mv rewrite.
         connectContext.getSessionVariable().setEnableForceRuleBasedMvRewrite(false);
+        QueryDebugOptions queryDebugOptions = new QueryDebugOptions();
+        queryDebugOptions.setEnableQueryTraceLog(true);
+        connectContext.getSessionVariable().setQueryDebugOptions(queryDebugOptions.toString());
     }
 
     @ParameterizedTest(name = "Tpch.{0}")

--- a/fe/fe-core/src/test/java/com/starrocks/planner/MaterializedViewTestBase.java
+++ b/fe/fe-core/src/test/java/com/starrocks/planner/MaterializedViewTestBase.java
@@ -18,6 +18,8 @@ import com.google.common.base.Preconditions;
 import com.google.common.base.Strings;
 import com.starrocks.catalog.Database;
 import com.starrocks.catalog.MaterializedView;
+import com.starrocks.catalog.MvRefreshArbiter;
+import com.starrocks.catalog.MvUpdateInfo;
 import com.starrocks.catalog.Table;
 import com.starrocks.common.Pair;
 import com.starrocks.scheduler.Task;
@@ -41,7 +43,6 @@ import org.junit.BeforeClass;
 
 import java.util.List;
 import java.util.Locale;
-import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -75,14 +76,14 @@ public class MaterializedViewTestBase extends PlanTestBase {
             m.createStatisticsTablesForTest();
         }
 
-        new MockUp<MaterializedView>() {
+        new MockUp<MvRefreshArbiter>() {
             /**
-             * {@link MaterializedView#getPartitionNamesToRefreshForMv(Set, boolean)}
+             * {@link MvRefreshArbiter#getPartitionNamesToRefreshForMv(MaterializedView, boolean)}
              */
             @Mock
-            public boolean getPartitionNamesToRefreshForMv(Set<String> toRefreshPartitions,
-                                                           boolean isQueryRewrite) {
-                return true;
+            public MvUpdateInfo getPartitionNamesToRefreshForMv(MaterializedView mv,
+                                                                boolean isQueryRewrite) {
+                return new MvUpdateInfo(MvUpdateInfo.MvToRefreshType.NO_REFRESH);
             }
         };
 

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvRewriteTestBase.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvRewriteTestBase.java
@@ -17,10 +17,11 @@ package com.starrocks.sql.optimizer.rule.transformation.materialization;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Strings;
 import com.google.common.collect.Lists;
-import com.google.common.collect.Sets;
 import com.starrocks.analysis.TableName;
 import com.starrocks.catalog.Database;
 import com.starrocks.catalog.MaterializedView;
+import com.starrocks.catalog.MvRefreshArbiter;
+import com.starrocks.catalog.MvUpdateInfo;
 import com.starrocks.catalog.Table;
 import com.starrocks.common.Pair;
 import com.starrocks.common.util.UUIDUtil;
@@ -223,10 +224,14 @@ public class MvRewriteTestBase {
         }
     }
 
+    public static MvUpdateInfo getMvUpdateInfo(MaterializedView mv) {
+        return MvRefreshArbiter.getPartitionNamesToRefreshForMv(mv, true);
+    }
+
     public static Set<String> getPartitionNamesToRefreshForMv(MaterializedView mv) {
-        Set<String> toRefreshPartitions = Sets.newHashSet();
-        mv.getPartitionNamesToRefreshForMv(toRefreshPartitions, true);
-        return toRefreshPartitions;
+        MvUpdateInfo mvUpdateInfo = MvRefreshArbiter.getPartitionNamesToRefreshForMv(mv, true);
+        Preconditions.checkState(mvUpdateInfo != null);
+        return mvUpdateInfo.getMvToRefreshPartitionNames();
     }
 
     public static void executeInsertSql(ConnectContext connectContext, String sql) throws Exception {

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvTransparentUnionRewriteHiveTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvTransparentUnionRewriteHiveTest.java
@@ -309,7 +309,7 @@ public class MvTransparentUnionRewriteHiveTest extends MvRewriteTestBase {
                             "WHERE a.l_shipdate='1998-01-01' and a.l_suppkey > 100;",
             };
             for (String query : sqls) {
-                String plan = getFragmentPlan(query);
+                String plan = getFragmentPlan(query, "MV");
                 PlanTestBase.assertNotContains(plan, ":UNION");
                 PlanTestBase.assertContains(plan, "mv0");
             }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/ReplayWithMVFromDumpTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/ReplayWithMVFromDumpTest.java
@@ -15,6 +15,8 @@
 package com.starrocks.sql.plan;
 
 import com.starrocks.catalog.MaterializedView;
+import com.starrocks.catalog.MvRefreshArbiter;
+import com.starrocks.catalog.MvUpdateInfo;
 import com.starrocks.common.FeConstants;
 import com.starrocks.common.Pair;
 import com.starrocks.qe.SessionVariable;
@@ -28,8 +30,6 @@ import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
-import java.util.Set;
-
 import static com.starrocks.sql.plan.PlanTestNoneDBBase.assertContains;
 import static com.starrocks.sql.plan.PlanTestNoneDBBase.assertNotContains;
 
@@ -40,14 +40,14 @@ public class ReplayWithMVFromDumpTest extends ReplayFromDumpTestBase {
         ReplayFromDumpTestBase.beforeClass();
         UtFrameUtils.setDefaultConfigForAsyncMVTest(connectContext);
 
-        new MockUp<MaterializedView>() {
+        new MockUp<MvRefreshArbiter>() {
             /**
-             * {@link MaterializedView#getPartitionNamesToRefreshForMv(Set, boolean)}
+             * {@link MvRefreshArbiter#getPartitionNamesToRefreshForMv(MaterializedView, boolean)}
              */
             @Mock
-            public boolean getPartitionNamesToRefreshForMv(Set<String> toRefreshPartitions,
-                                                           boolean isQueryRewrite) {
-                return true;
+            public MvUpdateInfo getPartitionNamesToRefreshForMv(MaterializedView mv,
+                                                                boolean isQueryRewrite) {
+                return new MvUpdateInfo(MvUpdateInfo.MvToRefreshType.NO_REFRESH);
             }
         };
 


### PR DESCRIPTION
## Why I'm doing:
- Split PR https://github.com/StarRocks/starrocks/pull/43304 into two parts.


## What I'm doing:
- Refactor materialized view fresh functions to MvRefreshArbiter
- Correct `getBaseTableToRefreshPartitionNames` methods since MV's partition names to refresh is not only affected by the ref base table, but also other base tables. Deduce the partition names to refresh of the ref base table from the partition names to refresh of the mv.

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [x] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
