### PR TITLE
[BugFix] Add enable_materialized_view_metrics_collect to control whether to collect mv's metrics

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/common/Config.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/Config.java
@@ -1150,6 +1150,9 @@ public class Config extends ConfigBase {
     @ConfField(mutable = true)
     public static boolean enable_materialized_view_spill = true;
 
+    @ConfField(mutable = true, comment = "whether to collect metrics for materialized view by default")
+    public static boolean enable_materialized_view_metrics_collect = true;
+
     /**
      * When the materialized view fails to start FE due to metadata problems,
      * you can try to open this configuration,

--- a/fe/fe-core/src/main/java/com/starrocks/metric/IMaterializedViewMetricsEntity.java
+++ b/fe/fe-core/src/main/java/com/starrocks/metric/IMaterializedViewMetricsEntity.java
@@ -1,0 +1,71 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+
+package com.starrocks.metric;
+
+import com.starrocks.scheduler.PartitionBasedMvRefreshProcessor;
+
+import java.util.List;
+
+public interface IMaterializedViewMetricsEntity {
+
+    /**
+     * Get all metrics
+     */
+    List<Metric> getMetrics();
+
+    /**
+     * Increase the count of query considered which is used as mv candidate
+     * @param count: increase count
+     */
+    void increaseQueryConsideredCount(long count);
+
+    /**
+     * Increase the count of query matched which is rewritten by success
+     * @param count: increase count
+     */
+    void increaseQueryMatchedCount(long count);
+
+    /**
+     * Increase the count of query hit which is rewritten by success and chosen at the end
+     * @param count: increase count
+     */
+    void increaseQueryHitCount(long count);
+
+    /**
+     * Increase the count of query materialized view including both rewritten and direct query
+     * @param count: increase count
+     */
+    void increaseQueryMaterializedViewCount(long count);
+
+    /**
+     * Increase the refresh job status count
+     * @param status: refresh job 's final status: SUCCESS, FAILED, EMPTY
+     */
+    void increaseRefreshJobStatus(PartitionBasedMvRefreshProcessor.RefreshJobStatus status);
+
+    /**
+     * Increase the refresh meta retry count
+     * @param retryNum: the retry meta count
+     */
+    void increaseRefreshRetryMetaCount(Long retryNum);
+
+    /**
+     * Increase the refresh duration
+     * @param duration: mv refresh duration
+     */
+    void updateRefreshDuration(long duration);
+}
+

--- a/fe/fe-core/src/main/java/com/starrocks/metric/MaterializedViewMetricsBlackHoleEntity.java
+++ b/fe/fe-core/src/main/java/com/starrocks/metric/MaterializedViewMetricsBlackHoleEntity.java
@@ -1,0 +1,62 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+
+package com.starrocks.metric;
+
+import com.google.api.client.util.Lists;
+import com.starrocks.scheduler.PartitionBasedMvRefreshProcessor;
+
+import java.util.List;
+
+public class MaterializedViewMetricsBlackHoleEntity implements IMaterializedViewMetricsEntity {
+    @Override
+    public List<Metric> getMetrics() {
+        return Lists.newArrayList();
+    }
+
+    @Override
+    public void increaseQueryConsideredCount(long count) {
+    }
+
+    @Override
+    public void increaseQueryMatchedCount(long count) {
+
+    }
+    @Override
+    public void increaseQueryHitCount(long count) {
+
+    }
+
+    @Override
+    public void increaseQueryMaterializedViewCount(long count) {
+
+    }
+
+    @Override
+    public void increaseRefreshJobStatus(PartitionBasedMvRefreshProcessor.RefreshJobStatus status) {
+
+    }
+
+    @Override
+    public void increaseRefreshRetryMetaCount(Long retryNum) {
+
+    }
+
+    @Override
+    public void updateRefreshDuration(long duration) {
+
+    }
+}
+

--- a/fe/fe-core/src/main/java/com/starrocks/metric/MaterializedViewMetricsEntity.java
+++ b/fe/fe-core/src/main/java/com/starrocks/metric/MaterializedViewMetricsEntity.java
@@ -22,11 +22,9 @@ import com.starrocks.catalog.Database;
 import com.starrocks.catalog.MaterializedView;
 import com.starrocks.catalog.MvId;
 import com.starrocks.catalog.Table;
-import com.starrocks.common.Config;
 import com.starrocks.common.util.concurrent.lock.LockType;
 import com.starrocks.common.util.concurrent.lock.Locker;
 import com.starrocks.metric.Metric.MetricUnit;
-import com.starrocks.qe.ConnectContext;
 import com.starrocks.scheduler.PartitionBasedMvRefreshProcessor;
 import com.starrocks.scheduler.TaskBuilder;
 import com.starrocks.scheduler.TaskManager;
@@ -36,9 +34,8 @@ import org.apache.logging.log4j.Logger;
 
 import java.util.List;
 
-public final class MaterializedViewMetricsEntity {
+public final class MaterializedViewMetricsEntity implements IMaterializedViewMetricsEntity {
     private static final Logger LOG = LogManager.getLogger(MaterializedViewMetricsEntity.class);
-
 
     private final MvId mvId;
     private final MetricRegistry metricRegistry;
@@ -93,6 +90,7 @@ public final class MaterializedViewMetricsEntity {
         initMaterializedViewMetrics();
     }
 
+    @Override
     public List<Metric> getMetrics() {
         return metrics;
     }
@@ -288,42 +286,32 @@ public final class MaterializedViewMetricsEntity {
                 }
             }
         };
-        metrics.add(counterInactiveState);
+        metrics.add(counterPartitionCount);
     }
 
-    public static boolean isUpdateMaterializedViewMetrics(ConnectContext connectContext) {
-        if (connectContext == null) {
-            return false;
-        }
-        // ignore: explain queries
-        if (connectContext.getExplainLevel() != null) {
-            return false;
-        }
-        // ignore: queries that are not using materialized view rewrite(eg: stats jobs)
-        if (!connectContext.getSessionVariable().isEnableMaterializedViewRewrite() ||
-                !Config.enable_materialized_view) {
-            return false;
-        }
-        return true;
-    }
-
+    @Override
     public void increaseQueryConsideredCount(long count) {
         this.counterQueryConsideredTotal.increase(count);
     }
 
+    @Override
     public void increaseQueryMatchedCount(long count) {
         this.counterQueryMatchedTotal.increase(count);
     }
 
+    @Override
     public void increaseQueryHitCount(long count) {
         this.counterQueryHitTotal.increase(count);
     }
 
+    @Override
     public void increaseQueryMaterializedViewCount(long count) {
         this.counterQueryMaterializedViewTotal.increase(count);
     }
 
+    @Override
     public void increaseRefreshJobStatus(PartitionBasedMvRefreshProcessor.RefreshJobStatus status) {
+        this.counterRefreshJobTotal.increase(1L);
         switch (status) {
             case EMPTY:
                 this.counterRefreshJobEmptyTotal.increase(1L);
@@ -334,16 +322,15 @@ public final class MaterializedViewMetricsEntity {
             case FAILED:
                 this.counterRefreshJobFailedTotal.increase(1L);
                 break;
-            case TOTAL:
-                this.counterRefreshJobTotal.increase(1L);
-                break;
         }
     }
 
+    @Override
     public void increaseRefreshRetryMetaCount(Long retryNum) {
         this.counterRefreshJobRetryCheckChangedTotal.increase(retryNum);
     }
 
+    @Override
     public void updateRefreshDuration(long duration) {
         this.histRefreshJobDuration.update(duration);
     }

--- a/fe/fe-core/src/main/java/com/starrocks/metric/MaterializedViewMetricsRegistry.java
+++ b/fe/fe-core/src/main/java/com/starrocks/metric/MaterializedViewMetricsRegistry.java
@@ -20,6 +20,7 @@ import com.google.common.collect.Maps;
 import com.starrocks.catalog.Database;
 import com.starrocks.catalog.MaterializedView;
 import com.starrocks.catalog.MvId;
+import com.starrocks.common.Config;
 import com.starrocks.common.ThreadPoolManager;
 import com.starrocks.server.GlobalStateMgr;
 
@@ -47,7 +48,10 @@ public class MaterializedViewMetricsRegistry {
         return INSTANCE;
     }
 
-    public synchronized MaterializedViewMetricsEntity getMetricsEntity(MvId mvId) {
+    public synchronized IMaterializedViewMetricsEntity getMetricsEntity(MvId mvId) {
+        if (!Config.enable_materialized_view_metrics_collect) {
+            return new MaterializedViewMetricsBlackHoleEntity();
+        }
         return idToMVMetrics.computeIfAbsent(mvId, k -> new MaterializedViewMetricsEntity(metricRegistry, mvId));
     }
 
@@ -70,7 +74,7 @@ public class MaterializedViewMetricsRegistry {
                 continue;
             }
             for (MaterializedView mv : db.getMaterializedViews()) {
-                MaterializedViewMetricsEntity mvEntity =
+                IMaterializedViewMetricsEntity mvEntity =
                         MaterializedViewMetricsRegistry.getInstance().getMetricsEntity(mv.getMvId());
 
                 for (Metric m : mvEntity.getMetrics()) {

--- a/fe/fe-core/src/main/java/com/starrocks/metric/MaterializedViewMetricsRegistry.java
+++ b/fe/fe-core/src/main/java/com/starrocks/metric/MaterializedViewMetricsRegistry.java
@@ -41,7 +41,8 @@ public class MaterializedViewMetricsRegistry {
         idToMVMetrics = Maps.newHashMap();
         // clear all metrics everyday
         timer = ThreadPoolManager.newDaemonScheduledThreadPool(1, "MaterializedView-Metrics-Cleaner", true);
-        timer.scheduleAtFixedRate(new MaterializedViewMetricsRegistry.MetricsCleaner(), 0, 1L, TimeUnit.DAYS);
+        // add initial delay to avoid all metrics are cleared at the same time
+        timer.scheduleAtFixedRate(new MaterializedViewMetricsRegistry.MetricsCleaner(), 1L, 1L, TimeUnit.DAYS);
     }
 
     public static MaterializedViewMetricsRegistry getInstance() {

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/PartitionBasedMvRefreshProcessor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/PartitionBasedMvRefreshProcessor.java
@@ -67,7 +67,7 @@ import com.starrocks.common.util.concurrent.lock.Locker;
 import com.starrocks.connector.ConnectorPartitionTraits;
 import com.starrocks.connector.PartitionUtil;
 import com.starrocks.lake.LakeTable;
-import com.starrocks.metric.MaterializedViewMetricsEntity;
+import com.starrocks.metric.IMaterializedViewMetricsEntity;
 import com.starrocks.metric.MaterializedViewMetricsRegistry;
 import com.starrocks.persist.ChangeMaterializedViewRefreshSchemeLog;
 import com.starrocks.planner.HdfsScanNode;
@@ -173,7 +173,6 @@ public class PartitionBasedMvRefreshProcessor extends BaseTaskRunProcessor {
         SUCCESS,
         FAILED,
         EMPTY,
-        TOTAL
     }
 
     // for testing
@@ -206,9 +205,8 @@ public class PartitionBasedMvRefreshProcessor extends BaseTaskRunProcessor {
         prepare(context);
 
         Preconditions.checkState(materializedView != null);
-        MaterializedViewMetricsEntity mvEntity =
+        IMaterializedViewMetricsEntity mvEntity =
                 MaterializedViewMetricsRegistry.getInstance().getMetricsEntity(materializedView.getMvId());
-        mvEntity.increaseRefreshJobStatus(RefreshJobStatus.TOTAL);
 
         ConnectContext connectContext = context.getCtx();
         try {
@@ -225,7 +223,7 @@ public class PartitionBasedMvRefreshProcessor extends BaseTaskRunProcessor {
         }
     }
 
-    private RefreshJobStatus doMvRefresh(TaskRunContext context, MaterializedViewMetricsEntity mvEntity)
+    private RefreshJobStatus doMvRefresh(TaskRunContext context, IMaterializedViewMetricsEntity mvEntity)
             throws Exception {
         int retryNum = 0;
         boolean checked = false;
@@ -880,10 +878,14 @@ public class PartitionBasedMvRefreshProcessor extends BaseTaskRunProcessor {
             MVActiveChecker.tryToActivate(materializedView);
             LOG.info("Activated the MV before refreshing: {}", materializedView.getName());
         }
+
+        IMaterializedViewMetricsEntity mvEntity =
+                MaterializedViewMetricsRegistry.getInstance().getMetricsEntity(materializedView.getMvId());
         if (!materializedView.isActive()) {
             String errorMsg = String.format("Materialized view: %s/%d is not active due to %s.",
                     materializedView.getName(), mvId, materializedView.getInactiveReason());
             LOG.warn(errorMsg);
+            mvEntity.increaseRefreshJobStatus(RefreshJobStatus.FAILED);
             throw new DmlException(errorMsg);
         }
         // wait util transaction is visible for mv refresh task

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/rule/BaseMaterializedViewRewriteRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/rule/BaseMaterializedViewRewriteRule.java
@@ -20,7 +20,7 @@ import com.google.common.collect.Lists;
 import com.starrocks.catalog.MaterializedView;
 import com.starrocks.catalog.Table;
 import com.starrocks.common.profile.Tracers;
-import com.starrocks.metric.MaterializedViewMetricsEntity;
+import com.starrocks.metric.IMaterializedViewMetricsEntity;
 import com.starrocks.metric.MaterializedViewMetricsRegistry;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.sql.optimizer.MaterializationContext;
@@ -52,7 +52,6 @@ import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
 
-import static com.starrocks.metric.MaterializedViewMetricsEntity.isUpdateMaterializedViewMetrics;
 import static com.starrocks.sql.optimizer.OptimizerTraceUtil.logMVRewrite;
 import static com.starrocks.sql.optimizer.rule.transformation.materialization.MvUtils.isAppliedMVUnionRewrite;
 
@@ -195,11 +194,9 @@ public abstract class BaseMaterializedViewRewriteRule extends TransformationRule
 
             // update metrics
             mvContext.updateMVUsedCount();
-            if (isUpdateMaterializedViewMetrics(connectContext)) {
-                MaterializedViewMetricsEntity mvEntity =
-                        MaterializedViewMetricsRegistry.getInstance().getMetricsEntity(mvContext.getMv().getMvId());
-                mvEntity.increaseQueryMatchedCount(1L);
-            }
+            IMaterializedViewMetricsEntity mvEntity =
+                    MaterializedViewMetricsRegistry.getInstance().getMetricsEntity(mvContext.getMv().getMvId());
+            mvEntity.increaseQueryMatchedCount(1L);
 
             // Do not try to enumerate all plans, it would take a lot of time
             int limit = context.getSessionVariable().getCboMaterializedViewRewriteRuleOutputLimit();

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/validate/MVRewriteValidator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/validate/MVRewriteValidator.java
@@ -16,8 +16,9 @@ package com.starrocks.sql.optimizer.validate;
 
 import com.google.common.base.Joiner;
 import com.starrocks.catalog.MaterializedView;
+import com.starrocks.common.Config;
 import com.starrocks.common.profile.Tracers;
-import com.starrocks.metric.MaterializedViewMetricsEntity;
+import com.starrocks.metric.IMaterializedViewMetricsEntity;
 import com.starrocks.metric.MaterializedViewMetricsRegistry;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.sql.optimizer.MaterializationContext;
@@ -32,7 +33,6 @@ import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
 
-import static com.starrocks.metric.MaterializedViewMetricsEntity.isUpdateMaterializedViewMetrics;
 import static com.starrocks.sql.optimizer.rule.transformation.materialization.MvUtils.collectMaterializedViews;
 
 public class MVRewriteValidator {
@@ -40,6 +40,22 @@ public class MVRewriteValidator {
 
     public static MVRewriteValidator getInstance() {
         return INSTANCE;
+    }
+
+    private static boolean isUpdateMaterializedViewMetrics(ConnectContext connectContext) {
+        if (connectContext == null) {
+            return false;
+        }
+        // ignore: explain queries
+        if (connectContext.getExplainLevel() != null) {
+            return false;
+        }
+        // ignore: queries that are not using materialized view rewrite(eg: stats jobs)
+        if (!connectContext.getSessionVariable().isEnableMaterializedViewRewrite() ||
+                !Config.enable_materialized_view) {
+            return false;
+        }
+        return true;
     }
 
     /**
@@ -89,7 +105,7 @@ public class MVRewriteValidator {
                 if (mv == null) {
                     continue;
                 }
-                MaterializedViewMetricsEntity mvEntity =
+                IMaterializedViewMetricsEntity mvEntity =
                         MaterializedViewMetricsRegistry.getInstance().getMetricsEntity(mv.getMvId());
                 mvEntity.increaseQueryConsideredCount(1L);
             }
@@ -98,7 +114,7 @@ public class MVRewriteValidator {
         for (MaterializedView mv : mvs) {
             // To avoid queries that query the materialized view directly, only consider materialized views
             // that are not used in rewriting before.
-            MaterializedViewMetricsEntity mvEntity =
+            IMaterializedViewMetricsEntity mvEntity =
                     MaterializedViewMetricsRegistry.getInstance().getMetricsEntity(mv.getMvId());
             if (!beforeTableIds.contains(mv.getId())) {
                 mvEntity.increaseQueryHitCount(1L);

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvRewriteMetricsTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvRewriteMetricsTest.java
@@ -1,0 +1,109 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.sql.optimizer.rule.transformation.materialization;
+
+import com.starrocks.catalog.MaterializedView;
+import com.starrocks.metric.IMaterializedViewMetricsEntity;
+import com.starrocks.metric.MaterializedViewMetricsEntity;
+import com.starrocks.metric.MaterializedViewMetricsRegistry;
+import com.starrocks.sql.plan.PlanTestBase;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.FixMethodOrder;
+import org.junit.Test;
+import org.junit.runners.MethodSorters;
+
+@FixMethodOrder(MethodSorters.NAME_ASCENDING)
+public class MvRewriteMetricsTest extends MvRewriteTestBase {
+
+    @BeforeClass
+    public static void beforeClass() throws Exception {
+        MvRewriteTestBase.beforeClass();
+
+        starRocksAssert.withTable(cluster, "depts");
+        starRocksAssert.withTable(cluster, "locations");
+        starRocksAssert.withTable(cluster, "dependents");
+        starRocksAssert.withTable(cluster, "emps");
+        starRocksAssert.withTable(cluster, "emps_par");
+        connectContext.getSessionVariable().setEnableMaterializedViewUnionRewrite(false);
+    }
+
+    @Test
+    public void testMvMetrics1() {
+        String mvName = "mv0";
+        String sql = String.format("CREATE MATERIALIZED VIEW %s" +
+                " REFRESH DEFERRED MANUAL " +
+                " AS SELECT * FROM depts where deptno > 10", mvName);
+        starRocksAssert.withMaterializedView(sql, () -> {
+            refreshMaterializedView(DB_NAME, mvName);
+
+            MaterializedView mv = (MaterializedView) getTable(DB_NAME, mvName);
+            IMaterializedViewMetricsEntity iEntity =
+                    MaterializedViewMetricsRegistry.getInstance().getMetricsEntity(mv.getMvId());
+            Assert.assertTrue(iEntity instanceof MaterializedViewMetricsEntity);
+            MaterializedViewMetricsEntity mvMetric = (MaterializedViewMetricsEntity) iEntity;
+
+            // basic test
+            Assert.assertTrue(mvMetric.counterPartitionCount.getValue() == 0);
+            Assert.assertTrue(mvMetric.counterRefreshJobTotal.getValue() == 1);
+            Assert.assertTrue(mvMetric.counterRefreshJobSuccessTotal.getValue() == 1);
+            Assert.assertTrue(mvMetric.counterRefreshJobFailedTotal.getValue() == 0);
+            Assert.assertTrue(mvMetric.counterRefreshJobEmptyTotal.getValue() == 0);
+            Assert.assertTrue(mvMetric.counterRefreshJobRetryCheckChangedTotal.getValue() == 0);
+
+            Assert.assertTrue(mvMetric.counterRefreshPendingJobs.getValue() == 0);
+            Assert.assertTrue(mvMetric.counterRefreshRunningJobs.getValue() >= 0);
+            Assert.assertTrue(mvMetric.counterInactiveState.getValue() == 0);
+
+            // matched
+            {
+                String query = "select * from depts where deptno > 20";
+                String plan = getFragmentPlan(query);
+                PlanTestBase.assertContains(plan, mvName);
+
+
+                Assert.assertTrue(mvMetric.counterQueryHitTotal.getValue() == 1);
+                Assert.assertTrue(mvMetric.counterQueryConsideredTotal.getValue() == 1);
+                Assert.assertTrue(mvMetric.counterQueryMatchedTotal.getValue() == 1);
+                Assert.assertTrue(mvMetric.counterQueryMaterializedViewTotal.getValue() == 1);
+            }
+
+            // directly query
+            {
+                String query = "select * from mv0";
+                String plan = getFragmentPlan(query);
+                PlanTestBase.assertContains(plan, mvName);
+                Assert.assertTrue(mvMetric.counterQueryHitTotal.getValue() == 1);
+                Assert.assertTrue(mvMetric.counterQueryConsideredTotal.getValue() == 1);
+                Assert.assertTrue(mvMetric.counterQueryMatchedTotal.getValue() == 1);
+                Assert.assertTrue(mvMetric.counterQueryMaterializedViewTotal.getValue() == 2);
+            }
+
+            // non matched
+            {
+                String query = "select * from depts where deptno < 20";
+                String plan = getFragmentPlan(query);
+                PlanTestBase.assertNotContains(plan, mvName);
+
+                Assert.assertTrue(mvMetric.counterQueryHitTotal.getValue() == 1);
+                Assert.assertTrue(mvMetric.counterQueryConsideredTotal.getValue() == 2);
+                Assert.assertTrue(mvMetric.counterQueryMatchedTotal.getValue() == 1);
+                Assert.assertTrue(mvMetric.counterQueryMaterializedViewTotal.getValue() == 2);
+            }
+
+        });
+
+    }
+}


### PR DESCRIPTION
## Why I'm doing:
- There are some bugs about materialized view metrics.

## What I'm doing:
- Add `counterPartitionCount ` rather `counterInactiveState ` for spell bugs.
- Increase failed count when prepare phase in refresh mv failed
- Add enable_materialized_view_metrics_collect to control whether to collect mv's metrics

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [x] 3.2
  - [x] 3.1
  - [ ] 3.0
  - [ ] 2.5
