### PR TITLE
[Enhancement] enable connector shared scan by default

### DIFF
--- a/be/src/exec/pipeline/fragment_executor.cpp
+++ b/be/src/exec/pipeline/fragment_executor.cpp
@@ -419,7 +419,11 @@ Status FragmentExecutor::_prepare_exec_plan(ExecEnv* exec_env, const UnifiedExec
                          scan_node->convert_scan_range_to_morsel_queue_factory(
                                  scan_ranges, scan_ranges_per_driver_seq, scan_node->id(), dop,
                                  enable_tablet_internal_parallel, tablet_internal_parallel_mode));
-        scan_node->enable_shared_scan(enable_shared_scan && morsel_queue_factory->is_shared());
+        // enable shared scan when
+        // 1. sv is turned on and morsel factory is shared.
+        // 2. or scan node itself force to use shared scan.
+        scan_node->enable_shared_scan((enable_shared_scan && morsel_queue_factory->is_shared()) ||
+                                      (scan_node->always_shared_scan()));
         morsel_queue_factories.emplace(scan_node->id(), std::move(morsel_queue_factory));
     }
 


### PR DESCRIPTION
## Why I'm doing:

By default, connector scan node especially hdfs scan does not enable shared scan by default. By in most cases, this is quite useful to avoid data skew.

## What I'm doing:

Enable shared scan for connector by default:
- there is a method `always_shared_scan()` in scan node
- and for connector scan node, by default it's true
- and for lake connector scan node, it's false (to align with internal table settings)

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
