### PR TITLE
[BugFix] fix parquet reader split io tasks

### DIFF
--- a/be/src/formats/parquet/file_reader.cpp
+++ b/be/src/formats/parquet/file_reader.cpp
@@ -91,13 +91,6 @@ Status FileReader::init(HdfsScannerContext* ctx) {
 #endif
     RETURN_IF_ERROR(_get_footer());
 
-    RETURN_IF_ERROR(_build_split_tasks());
-    if (_scanner_ctx->split_tasks.size() > 0) {
-        _scanner_ctx->has_split_tasks = true;
-        _is_file_filtered = true;
-        return Status::OK();
-    }
-
     // set existed SlotDescriptor in this parquet file
     std::unordered_set<std::string> names;
     _meta_helper = _build_meta_helper();
@@ -108,7 +101,16 @@ Status FileReader::init(HdfsScannerContext* ctx) {
     if (_is_file_filtered) {
         return Status::OK();
     }
+
     _prepare_read_columns();
+
+    RETURN_IF_ERROR(_build_split_tasks());
+    if (_scanner_ctx->split_tasks.size() > 0) {
+        _scanner_ctx->has_split_tasks = true;
+        _is_file_filtered = true;
+        return Status::OK();
+    }
+
     RETURN_IF_ERROR(_init_group_readers());
     return Status::OK();
 }


### PR DESCRIPTION
## Why I'm doing:

During `build_split_tasks`, we are trying to filter row groups. However some fields are not initialized yet.  And we get following crash stack trace

```

*** Aborted at 1712174993 (unix time) try "date -d @1712174993" if you are using GNU date ***
PC: @          0x70a4872 starrocks::parquet::FileReader::_read_min_max_chunk()
*** SIGSEGV (@0x0) received by PID 1997937 (TID 0x7f98e127a640) from PID 0; stack trace: ***
    @          0x8e1d492 google::(anonymous namespace)::FailureSignalHandler()
    @     0x7f9989657380 (unknown)
    @          0x70a4872 starrocks::parquet::FileReader::_read_min_max_chunk()
    @          0x70a5cae starrocks::parquet::FileReader::_filter_group()
    @          0x70a6495 starrocks::parquet::FileReader::_build_split_tasks()
    @          0x70a6fe4 starrocks::parquet::FileReader::init()
    @          0x5231755 starrocks::HdfsParquetScanner::do_open()
    @          0x5222171 starrocks::HdfsScanner::open()
    @          0x4d180a8 starrocks::connector::HiveDataSource::_init_scanner()
    @          0x4d18c0e starrocks::connector::HiveDataSource::open()
    @          0x54388a5 starrocks::pipeline::ConnectorChunkSource::_open_data_source()
    @          0x5439725 starrocks::pipeline::ConnectorChunkSource::_read_chunk()
    @          0x540a9ce starrocks::pipeline::ChunkSource::buffer_next_batch_chunks_blocking()
    @          0x541e095 _ZZN9starrocks8pipeline12ScanOperator18_trigger_next_scanEPNS_12RuntimeStateEiENKUlRT_E_clINS_9workgroup12YieldContextEEEDaS5_.constprop.0
    @          0x559f4fb starrocks::workgroup::ScanExecutor::worker_thread()
    @          0x7e6e785 starrocks::ThreadPool::dispatch_thread()
    @          0x7e6857c starrocks::Thread::supervise_thread()
    @     0x7f998964d16e start_thread
    @     0x7f998937861f __GI___clone
    @                0x0 (unknown)
```


## What I'm doing:

Put `build_split_tasks` after functions that initialize all fields.

__This case should be covered by test cases, since it crashes during ssbflat. However since we don't enable split io tasks by default. So it's not found by our test cases yet.__



Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [x] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
