### PR TITLE
[Feature] Optimize `count(1)` in hdfs scanner by rewriting plan to `sum`

### DIFF
--- a/be/src/exec/hdfs_scanner.cpp
+++ b/be/src/exec/hdfs_scanner.cpp
@@ -181,7 +181,6 @@ Status HdfsScanner::open(RuntimeState* runtime_state) {
     if (_opened) {
         return Status::OK();
     }
-    RETURN_IF_ERROR(_build_scanner_context());
     RETURN_IF_ERROR(do_open(runtime_state));
     RETURN_IF_ERROR(_mor_processor->build_hash_table(runtime_state));
     _opened = true;

--- a/be/src/exec/hdfs_scanner.cpp
+++ b/be/src/exec/hdfs_scanner.cpp
@@ -399,8 +399,22 @@ void HdfsScanner::update_counter() {
     do_update_counter(profile);
 }
 
-void HdfsScannerContext::update_materialized_columns(const std::unordered_set<std::string>& names) {
+Status HdfsScannerContext::update_materialized_columns(const std::unordered_set<std::string>& names) {
     std::vector<ColumnInfo> updated_columns;
+
+    // special handling for ___count__ optimization.
+    {
+        for (auto& column : materialized_columns) {
+            if (column.name() == "___count___") {
+                return_count_column = true;
+                break;
+            }
+        }
+
+        if (return_count_column && materialized_columns.size() != 1) {
+            return Status::InternalError("Plan inconsistency. ___count___ column should be unique.");
+        }
+    }
 
     for (auto& column : materialized_columns) {
         auto col_name = column.formatted_name(case_sensitive);
@@ -420,19 +434,57 @@ void HdfsScannerContext::update_materialized_columns(const std::unordered_set<st
     }
 
     materialized_columns.swap(updated_columns);
+    return Status::OK();
 }
 
-void HdfsScannerContext::append_or_update_not_existed_columns_to_chunk(ChunkPtr* chunk, size_t row_count) {
-    if (not_existed_slots.empty()) return;
+Status HdfsScannerContext::append_or_update_not_existed_columns_to_chunk(ChunkPtr* chunk, size_t row_count) {
+    if (not_existed_slots.empty()) return Status::OK();
     ChunkPtr& ck = (*chunk);
-    for (auto* slot_desc : not_existed_slots) {
-        auto col = ColumnHelper::create_column(slot_desc->type(), slot_desc->is_nullable());
-        if (row_count > 0) {
-            col->append_default(row_count);
+
+    // special handling for ___count___ optimization
+    {
+        for (auto* slot_desc : not_existed_slots) {
+            if (slot_desc->col_name() == "___count___") {
+                return_count_column = true;
+                break;
+            }
         }
+        if (return_count_column && not_existed_slots.size() != 1) {
+            return Status::InternalError("Plan inconsistency. ___count___ column should be unique.");
+        }
+    }
+
+    if (return_count_column) {
+        auto* slot_desc = not_existed_slots[0];
+        TypeDescriptor desc;
+        desc.type = TYPE_BIGINT;
+        auto col = ColumnHelper::create_column(desc, slot_desc->is_nullable());
+        col->append_datum(int64_t(1));
+        col->assign(row_count, 0);
         ck->append_or_update_column(std::move(col), slot_desc->id());
+    } else {
+        for (auto* slot_desc : not_existed_slots) {
+            auto col = ColumnHelper::create_column(slot_desc->type(), slot_desc->is_nullable());
+            if (row_count > 0) {
+                col->append_default(row_count);
+            }
+            ck->append_or_update_column(std::move(col), slot_desc->id());
+        }
     }
     ck->set_num_rows(row_count);
+    return Status::OK();
+}
+
+void HdfsScannerContext::append_or_update_count_column_to_chunk(ChunkPtr* chunk, size_t row_count) {
+    if (not_existed_slots.empty() || row_count < 0) return;
+    ChunkPtr& ck = (*chunk);
+    auto* slot_desc = not_existed_slots[0];
+    TypeDescriptor desc;
+    desc.type = TYPE_BIGINT;
+    auto col = ColumnHelper::create_column(desc, slot_desc->is_nullable());
+    col->append_datum(int64_t(row_count));
+    ck->append_or_update_column(std::move(col), slot_desc->id());
+    ck->set_num_rows(1);
 }
 
 Status HdfsScannerContext::evaluate_on_conjunct_ctxs_by_slot(ChunkPtr* chunk, Filter* filter) {
@@ -458,7 +510,7 @@ StatusOr<bool> HdfsScannerContext::should_skip_by_evaluating_not_existed_slots()
 
     // build chunk for evaluation.
     ChunkPtr chunk = std::make_shared<Chunk>();
-    append_or_update_not_existed_columns_to_chunk(&chunk, 1);
+    RETURN_IF_ERROR(append_or_update_not_existed_columns_to_chunk(&chunk, 1));
     // do evaluation.
     {
         SCOPED_RAW_TIMER(&stats->expr_filter_ns);

--- a/be/src/exec/hdfs_scanner.cpp
+++ b/be/src/exec/hdfs_scanner.cpp
@@ -181,6 +181,7 @@ Status HdfsScanner::open(RuntimeState* runtime_state) {
     if (_opened) {
         return Status::OK();
     }
+    RETURN_IF_ERROR(_build_scanner_context());
     RETURN_IF_ERROR(do_open(runtime_state));
     RETURN_IF_ERROR(_mor_processor->build_hash_table(runtime_state));
     _opened = true;

--- a/be/src/exec/hdfs_scanner.h
+++ b/be/src/exec/hdfs_scanner.h
@@ -282,6 +282,8 @@ struct HdfsScannerContext {
 
     bool can_use_min_max_count_opt = false;
 
+    bool return_count_column = false;
+
     bool use_file_metacache = false;
 
     std::string timezone;
@@ -297,18 +299,18 @@ struct HdfsScannerContext {
     // update materialized column against data file.
     // and to update not_existed slots and conjuncts.
     // and to update `conjunct_ctxs_by_slot` field.
-    void update_materialized_columns(const std::unordered_set<std::string>& names);
-
+    Status update_materialized_columns(const std::unordered_set<std::string>& names);
     // "not existed columns" are materialized columns not found in file
     // this usually happens when use changes schema. for example
     // user create table with 3 fields A, B, C, and there is one file F1
     // but user change schema and add one field like D.
     // when user select(A, B, C, D), then D is the non-existed column in file F1.
-    void append_or_update_not_existed_columns_to_chunk(ChunkPtr* chunk, size_t row_count);
+    Status append_or_update_not_existed_columns_to_chunk(ChunkPtr* chunk, size_t row_count);
 
     // If there is no partition column in the chunk，append partition column to chunk，
     // otherwise update partition column in chunk
     void append_or_update_partition_column_to_chunk(ChunkPtr* chunk, size_t row_count);
+    void append_or_update_count_column_to_chunk(ChunkPtr* chunk, size_t row_count);
 
     // if we can skip this file by evaluating conjuncts of non-existed columns with default value.
     StatusOr<bool> should_skip_by_evaluating_not_existed_slots();

--- a/be/src/exec/hdfs_scanner_orc.cpp
+++ b/be/src/exec/hdfs_scanner_orc.cpp
@@ -379,7 +379,7 @@ Status HdfsOrcScanner::resolve_columns(orc::Reader* reader) {
     std::unordered_set<std::string> known_column_names;
     OrcChunkReader::build_column_name_set(&known_column_names, _scanner_ctx.hive_column_names, reader->getType(),
                                           _scanner_ctx.case_sensitive, _scanner_ctx.orc_use_column_names);
-    _scanner_ctx.update_materialized_columns(known_column_names);
+    RETURN_IF_ERROR(_scanner_ctx.update_materialized_columns(known_column_names));
     ASSIGN_OR_RETURN(auto skip, _scanner_ctx.should_skip_by_evaluating_not_existed_slots());
     if (skip) {
         LOG(INFO) << "HdfsOrcScanner: do_open. skip file for non existed slot conjuncts.";
@@ -539,13 +539,43 @@ Status HdfsOrcScanner::do_get_next(RuntimeState* runtime_state, ChunkPtr* chunk)
         return Status::EndOfFile("");
     }
 
-    ASSIGN_OR_RETURN(const size_t rows_read, _do_get_next(chunk));
+    size_t rows_read = 0;
+
+    if (_scanner_ctx.return_count_column) {
+        ASSIGN_OR_RETURN(rows_read, _do_get_next_count(chunk));
+    } else {
+        ASSIGN_OR_RETURN(rows_read, _do_get_next(chunk));
+    }
 
     DCHECK_EQ(rows_read, chunk->get()->num_rows());
 
     _scanner_ctx.append_or_update_partition_column_to_chunk(chunk, rows_read);
 
     return Status::OK();
+}
+
+StatusOr<size_t> HdfsOrcScanner::_do_get_next_count(ChunkPtr* chunk) {
+    size_t read_num_values = 0;
+    Status st = Status::OK();
+    while (true) {
+        {
+            SCOPED_RAW_TIMER(&_app_stats.column_read_ns);
+            orc::RowReader::ReadPosition position;
+            st = _orc_reader->read_next(&position);
+            if (!st.ok()) {
+                break;
+            }
+        }
+        read_num_values += _orc_reader->get_cvb_size();
+        if (!_need_skip_rowids.empty()) {
+            read_num_values -= _orc_reader->get_row_delete_number(_need_skip_rowids);
+        }
+    }
+
+    if (!st.is_end_of_file()) return st;
+    if (read_num_values == 0) return Status::EndOfFile("No more rows to read");
+    _scanner_ctx.append_or_update_count_column_to_chunk(chunk, read_num_values);
+    return 1;
 }
 
 StatusOr<size_t> HdfsOrcScanner::_do_get_next(ChunkPtr* chunk) {
@@ -591,7 +621,7 @@ StatusOr<size_t> HdfsOrcScanner::_do_get_next(ChunkPtr* chunk) {
             }
 
             // we need to append none existed column before do eval, just for count(*) optimization
-            _scanner_ctx.append_or_update_not_existed_columns_to_chunk(chunk, rows_read);
+            RETURN_IF_ERROR(_scanner_ctx.append_or_update_not_existed_columns_to_chunk(chunk, rows_read));
 
             // do stats before we filter rows which does not match.
             _app_stats.raw_rows_read += rows_read;

--- a/be/src/exec/hdfs_scanner_orc.h
+++ b/be/src/exec/hdfs_scanner_orc.h
@@ -39,6 +39,7 @@ public:
 
 private:
     StatusOr<size_t> _do_get_next(ChunkPtr* chunk);
+    StatusOr<size_t> _do_get_next_count(ChunkPtr* chunk);
 
     // it means if we can skip this file without reading.
     // Normally it happens when we peek file column statistics,

--- a/be/src/exec/hdfs_scanner_text.cpp
+++ b/be/src/exec/hdfs_scanner_text.cpp
@@ -248,6 +248,17 @@ Status HdfsTextScanner::do_open(RuntimeState* runtime_state) {
     RETURN_IF_ERROR(open_random_access_file());
     RETURN_IF_ERROR(_create_or_reinit_reader());
     SCOPED_RAW_TIMER(&_app_stats.reader_init_ns);
+
+    // update materialized columns.
+    {
+        std::unordered_set<std::string> names;
+        for (const auto& column : _scanner_ctx.materialized_columns) {
+            if (column.name() == "___count___") continue;
+            names.insert(column.name());
+        }
+        _scanner_ctx.update_materialized_columns(names);
+    }
+
     RETURN_IF_ERROR(_build_hive_column_name_2_index());
     for (const auto& column : _scanner_ctx.materialized_columns) {
         // We don't care about _invalid_field_as_null here, if get converter failed,

--- a/be/src/exec/hdfs_scanner_text.cpp
+++ b/be/src/exec/hdfs_scanner_text.cpp
@@ -256,7 +256,7 @@ Status HdfsTextScanner::do_open(RuntimeState* runtime_state) {
             if (column.name() == "___count___") continue;
             names.insert(column.name());
         }
-        _scanner_ctx.update_materialized_columns(names);
+        RETURN_IF_ERROR(_scanner_ctx.update_materialized_columns(names));
     }
 
     RETURN_IF_ERROR(_build_hive_column_name_2_index());
@@ -369,7 +369,7 @@ Status HdfsTextScanner::parse_csv(int chunk_size, ChunkPtr* chunk) {
         }
     }
 
-    _scanner_ctx.append_or_update_not_existed_columns_to_chunk(chunk, rows_read);
+    RETURN_IF_ERROR(_scanner_ctx.append_or_update_not_existed_columns_to_chunk(chunk, rows_read));
     _scanner_ctx.append_or_update_partition_column_to_chunk(chunk, rows_read);
 
     // Check chunk's row number for each column

--- a/be/src/exec/jni_scanner.cpp
+++ b/be/src/exec/jni_scanner.cpp
@@ -340,7 +340,7 @@ Status JniScanner::_fill_column(FillColumnArgs* pargs) {
     return Status::OK();
 }
 
-Status JniScanner::_fill_chunk(JNIEnv* env, ChunkPtr* chunk, const std::vector<SlotDescriptor*>& slot_desc_list) {
+StatusOr<size_t> JniScanner::_fill_chunk(JNIEnv* env, ChunkPtr* chunk) {
     SCOPED_RAW_TIMER(&_app_stats.column_convert_ns);
 
     long num_rows = next_chunk_meta_as_long();
@@ -349,8 +349,8 @@ Status JniScanner::_fill_chunk(JNIEnv* env, ChunkPtr* chunk, const std::vector<S
     }
     _app_stats.raw_rows_read += num_rows;
 
-    for (size_t col_idx = 0; col_idx < slot_desc_list.size(); col_idx++) {
-        SlotDescriptor* slot_desc = slot_desc_list[col_idx];
+    for (size_t col_idx = 0; col_idx < _scanner_ctx.materialized_columns.size(); col_idx++) {
+        SlotDescriptor* slot_desc = _scanner_ctx.materialized_columns[col_idx].slot_desc;
         const std::string& slot_name = slot_desc->col_name();
         const TypeDescriptor& slot_type = slot_desc->type();
         ColumnPtr& column = (*chunk)->get_column_by_slot_id(slot_desc->id());
@@ -365,7 +365,7 @@ Status JniScanner::_fill_chunk(JNIEnv* env, ChunkPtr* chunk, const std::vector<S
         RETURN_IF_ERROR(_check_jni_exception(
                 env, "Failed to call the releaseOffHeapColumnVector method of off-heap table scanner."));
     }
-    return Status::OK();
+    return num_rows;
 }
 
 Status JniScanner::_release_off_heap_table(JNIEnv* env) {
@@ -376,25 +376,23 @@ Status JniScanner::_release_off_heap_table(JNIEnv* env) {
 }
 
 Status JniScanner::do_get_next(RuntimeState* runtime_state, ChunkPtr* chunk) {
-    // fill chunk with all wanted column(include partition columns)
-    Status status = fill_empty_chunk(chunk, _scanner_params.tuple_desc->slots());
-
+    // fill chunk with all wanted column.
+    ASSIGN_OR_RETURN(size_t chunk_size, fill_empty_chunk(chunk));
     // ====== conjunct evaluation ======
     // important to add columns before evaluation
     // because ctxs_by_slot maybe refers to some non-existed slot or partition slot.
-    size_t chunk_size = (*chunk)->num_rows();
     RETURN_IF_ERROR(_scanner_ctx.append_or_update_not_existed_columns_to_chunk(chunk, chunk_size));
     _scanner_ctx.append_or_update_partition_column_to_chunk(chunk, chunk_size);
     RETURN_IF_ERROR(_scanner_ctx.evaluate_on_conjunct_ctxs_by_slot(chunk, &_chunk_filter));
-    return status;
+    return Status::OK();
 }
 
-Status JniScanner::fill_empty_chunk(ChunkPtr* chunk, const std::vector<SlotDescriptor*>& slot_desc_list) {
+StatusOr<size_t> JniScanner::fill_empty_chunk(ChunkPtr* chunk) {
     JNIEnv* env = JVMFunctionHelper::getInstance().getEnv();
     long chunk_meta;
     RETURN_IF_ERROR(_get_next_chunk(env, &chunk_meta));
     reset_chunk_meta(chunk_meta);
-    Status status = _fill_chunk(env, chunk, slot_desc_list);
+    auto status = _fill_chunk(env, chunk);
     RETURN_IF_ERROR(_release_off_heap_table(env));
 
     return status;
@@ -444,13 +442,25 @@ static std::string build_fs_options_properties(const FSOptions& options) {
     return data;
 }
 
-void JniScanner::update_jni_scanner_params() {
+Status JniScanner::update_jni_scanner_params() {
+    // update materialized columns.
+    {
+        std::unordered_set<std::string> names;
+        for (const auto& column : _scanner_ctx.materialized_columns) {
+            if (column.name() == "___count___") continue;
+            names.insert(column.name());
+        }
+        RETURN_IF_ERROR(_scanner_ctx.update_materialized_columns(names));
+    }
+
     std::string required_fields;
     for (const auto& column : _scanner_ctx.materialized_columns) {
         required_fields.append(column.name());
         required_fields.append(",");
     }
-    required_fields = required_fields.substr(0, required_fields.size() - 1);
+    if (!required_fields.empty()) {
+        required_fields = required_fields.substr(0, required_fields.size() - 1);
+    }
 
     std::string nested_fields;
     for (const auto& column : _scanner_ctx.materialized_columns) {
@@ -465,6 +475,7 @@ void JniScanner::update_jni_scanner_params() {
 
     _jni_scanner_params["required_fields"] = required_fields;
     _jni_scanner_params["nested_fields"] = nested_fields;
+    return Status::OK();
 }
 
 // -------------------------------hive jni scanner-------------------------------
@@ -478,22 +489,12 @@ public:
 
 Status HiveJniScanner::do_get_next(RuntimeState* runtime_state, ChunkPtr* chunk) {
     // fill chunk with all wanted column exclude partition columns
-    Status status = fill_empty_chunk(chunk, _scanner_params.materialize_slots);
-    size_t chunk_size = (*chunk)->num_rows();
-    if (!_scanner_params.materialize_slots.empty()) {
-        // when the chunk has partition column and non partition column
-        // fill_empty_chunk will only fill partition column for HiveJniScanner
-        // In this situation, Chunk.num_rows() is not reliable  temporally
-        auto slot_desc = _scanner_params.materialize_slots[0];
-        ColumnPtr& first_non_partition_column = (*chunk)->get_column_by_slot_id(slot_desc->id());
-        chunk_size = first_non_partition_column->size();
-    }
-
+    ASSIGN_OR_RETURN(size_t chunk_size, fill_empty_chunk(chunk));
     RETURN_IF_ERROR(_scanner_ctx.append_or_update_not_existed_columns_to_chunk(chunk, chunk_size));
     // right now only hive table need append partition columns explictly, paimon and hudi reader will append partition columns in Java side
     _scanner_ctx.append_or_update_partition_column_to_chunk(chunk, chunk_size);
     RETURN_IF_ERROR(_scanner_ctx.evaluate_on_conjunct_ctxs_by_slot(chunk, &_chunk_filter));
-    return status;
+    return Status::OK();
 }
 
 std::unique_ptr<JniScanner> create_hive_jni_scanner(const JniScanner::CreateOptions& options) {

--- a/be/src/exec/jni_scanner.h
+++ b/be/src/exec/jni_scanner.h
@@ -42,11 +42,11 @@ public:
     void do_close(RuntimeState* runtime_state) noexcept override;
     Status do_get_next(RuntimeState* runtime_state, ChunkPtr* chunk) override;
     Status do_init(RuntimeState* runtime_state, const HdfsScannerParams& scanner_params) override;
-    virtual void update_jni_scanner_params();
+    virtual Status update_jni_scanner_params();
     Status reinterpret_status(const Status& st) override { return st; }
 
 protected:
-    Status fill_empty_chunk(ChunkPtr* chunk, const std::vector<SlotDescriptor*>& slot_desc_list);
+    StatusOr<size_t> fill_empty_chunk(ChunkPtr* chunk);
 
     Filter _chunk_filter;
 
@@ -82,7 +82,7 @@ private:
     Status _fill_column(FillColumnArgs* args);
 
     // fill chunk according to slot_desc_list(with or without partition columns)
-    Status _fill_chunk(JNIEnv* env, ChunkPtr* chunk, const std::vector<SlotDescriptor*>& slot_desc_list);
+    StatusOr<size_t> _fill_chunk(JNIEnv* env, ChunkPtr* chunk);
 
     Status _release_off_heap_table(JNIEnv* env);
 

--- a/be/src/formats/orc/orc_chunk_reader.cpp
+++ b/be/src/formats/orc/orc_chunk_reader.cpp
@@ -1219,6 +1219,14 @@ ColumnPtr OrcChunkReader::get_row_delete_filter(const std::set<int64_t>& deleted
     return filter_column;
 }
 
+size_t OrcChunkReader::get_row_delete_number(const std::set<int64_t>& deleted_pos) {
+    int64_t start_pos = _row_reader->getRowNumber();
+    auto num_rows = _batch->numElements;
+    auto iter = deleted_pos.lower_bound(start_pos);
+    auto end = deleted_pos.upper_bound(start_pos + num_rows - 1);
+    return std::distance(iter, end);
+}
+
 Status OrcChunkReader::apply_dict_filter_eval_cache(const std::unordered_map<SlotId, FilterPtr>& dict_filter_eval_cache,
                                                     Filter* filter) {
     if (dict_filter_eval_cache.size() == 0) {

--- a/be/src/formats/orc/orc_chunk_reader.h
+++ b/be/src/formats/orc/orc_chunk_reader.h
@@ -129,6 +129,7 @@ public:
     void lazy_filter_on_cvb(Filter* filter);
     StatusOr<ChunkPtr> get_lazy_chunk();
     ColumnPtr get_row_delete_filter(const std::set<int64_t>& deleted_pos);
+    size_t get_row_delete_number(const std::set<int64_t>& deleted_pos);
 
     bool is_implicit_castable(TypeDescriptor& starrocks_type, const TypeDescriptor& orc_type);
 

--- a/be/src/formats/parquet/file_reader.cpp
+++ b/be/src/formats/parquet/file_reader.cpp
@@ -158,7 +158,7 @@ Status FileReader::init(HdfsScannerContext* ctx) {
     std::unordered_set<std::string> names;
     _meta_helper = _build_meta_helper();
     _meta_helper->set_existed_column_names(&names);
-    _scanner_ctx->update_materialized_columns(names);
+    RETURN_IF_ERROR(_scanner_ctx->update_materialized_columns(names));
 
     ASSIGN_OR_RETURN(_is_file_filtered, _scanner_ctx->should_skip_by_evaluating_not_existed_slots());
     if (_is_file_filtered) {
@@ -767,7 +767,7 @@ Status FileReader::get_next(ChunkPtr* chunk) {
         Status status = _row_group_readers[_cur_row_group_idx]->get_next(chunk, &row_count);
         if (status.ok() || status.is_end_of_file()) {
             if (row_count > 0) {
-                _scanner_ctx->append_or_update_not_existed_columns_to_chunk(chunk, row_count);
+                RETURN_IF_ERROR(_scanner_ctx->append_or_update_not_existed_columns_to_chunk(chunk, row_count));
                 _scanner_ctx->append_or_update_partition_column_to_chunk(chunk, row_count);
                 _scan_row_count += (*chunk)->num_rows();
             }
@@ -778,6 +778,7 @@ Status FileReader::get_next(ChunkPtr* chunk) {
                     // prepare new group
                     RETURN_IF_ERROR(_prepare_cur_row_group());
                 }
+
                 return Status::OK();
             }
         } else {
@@ -795,9 +796,16 @@ Status FileReader::get_next(ChunkPtr* chunk) {
 
 Status FileReader::_exec_no_materialized_column_scan(ChunkPtr* chunk) {
     if (_scan_row_count < _total_row_count) {
-        size_t read_size = std::min(static_cast<size_t>(_chunk_size), _total_row_count - _scan_row_count);
-        _scanner_ctx->append_or_update_not_existed_columns_to_chunk(chunk, read_size);
-        _scanner_ctx->append_or_update_partition_column_to_chunk(chunk, read_size);
+        size_t read_size = 0;
+        if (_scanner_ctx->return_count_column) {
+            read_size = _total_row_count - _scan_row_count;
+            _scanner_ctx->append_or_update_count_column_to_chunk(chunk, read_size);
+            _scanner_ctx->append_or_update_partition_column_to_chunk(chunk, 1);
+        } else {
+            read_size = std::min(static_cast<size_t>(_chunk_size), _total_row_count - _scan_row_count);
+            RETURN_IF_ERROR(_scanner_ctx->append_or_update_not_existed_columns_to_chunk(chunk, read_size));
+            _scanner_ctx->append_or_update_partition_column_to_chunk(chunk, read_size);
+        }
         _scan_row_count += read_size;
         return Status::OK();
     }

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/IcebergTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/IcebergTable.java
@@ -171,6 +171,22 @@ public class IcebergTable extends Table {
         return allPartitionColumns;
     }
 
+    public boolean isAllPartitionColumnsAlwaysIdentity() {
+        // if we ever applied partition column transformation,
+        // we are not sure if partition columns were not identity before.
+        if (getNativeTable().spec().specId() != 0) {
+            return false;
+        }
+        // now we are sure we have never applied transformation,
+        // we check if all parititon columns are identity.
+        for (PartitionField field : getNativeTable().spec().fields()) {
+            if (!field.transform().isIdentity()) {
+                return false;
+            }
+        }
+        return true;
+    }
+
     public PartitionField getPartitionField(String partitionColumnName) {
         List<PartitionField> allPartitionFields = getNativeTable().spec().fields();
         Schema schema = this.getNativeTable().schema();

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/IcebergTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/IcebergTable.java
@@ -172,13 +172,8 @@ public class IcebergTable extends Table {
     }
 
     public boolean isAllPartitionColumnsAlwaysIdentity() {
-        // if we ever applied partition column transformation,
-        // we are not sure if partition columns were not identity before.
-        if (getNativeTable().spec().specId() != 0) {
-            return false;
-        }
         // now we are sure we have never applied transformation,
-        // we check if all parititon columns are identity.
+        // we check if all partition columns are identity.
         for (PartitionField field : getNativeTable().spec().fields()) {
             if (!field.transform().isIdentity()) {
                 return false;

--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/cost/IcebergStatisticProvider.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/cost/IcebergStatisticProvider.java
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-
 package com.starrocks.connector.iceberg.cost;
 
 import com.google.common.collect.AbstractSequentialIterator;
@@ -243,6 +242,14 @@ public class IcebergStatisticProvider {
 
             columnStatistics.put(columnList.get(0), buildColumnStatistic(
                     idColumn.getKey(), colRefToColumnMetaMap.get(columnList.get(0)), icebergFileStats, colIdToNdv));
+        }
+
+        // when we rewrit plan, we will add some artificial columns which not eixst in iceberg table,
+        // and we will mark those columns as unknown column statistics.
+        for (ColumnRefOperator c : colRefToColumnMetaMap.keySet()) {
+            if (!columnStatistics.containsKey(c)) {
+                columnStatistics.put(c, ColumnStatistic.unknown());
+            }
         }
 
         return columnStatistics;

--- a/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
@@ -596,7 +596,7 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
     public static final String CBO_REORDER_THRESHOLD_USE_EXHAUSTIVE = "cbo_reorder_threshold_use_exhaustive";
     public static final String ENABLE_REWRITE_SUM_BY_ASSOCIATIVE_RULE = "enable_rewrite_sum_by_associative_rule";
     public static final String ENABLE_REWRITE_SIMPLE_AGG_TO_META_SCAN = "enable_rewrite_simple_agg_to_meta_scan";
-
+    public static final String ENABLE_REWRITE_SIMPLE_AGG_TO_HDFS_SCAN = "enable_rewrite_simple_agg_to_hdfs_scan";
     public static final String ENABLE_PRUNE_COMPLEX_TYPES = "enable_prune_complex_types";
     public static final String ENABLE_SUBFIELD_NO_COPY = "enable_subfield_no_copy";
     public static final String ENABLE_PRUNE_COMPLEX_TYPES_IN_UNNEST = "enable_prune_complex_types_in_unnest";
@@ -1399,6 +1399,9 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
 
     @VarAttr(name = ENABLE_REWRITE_SIMPLE_AGG_TO_META_SCAN)
     private boolean enableRewriteSimpleAggToMetaScan = false;
+
+    @VarAttr(name = ENABLE_REWRITE_SIMPLE_AGG_TO_HDFS_SCAN)
+    private boolean enableRewriteSimpleAggToHdfsScan = false;
 
     @VariableMgr.VarAttr(name = INTERLEAVING_GROUP_SIZE)
     private int interleavingGroupSize = 10;
@@ -3459,6 +3462,14 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
 
     public boolean isEnableRewriteSimpleAggToMetaScan() {
         return this.enableRewriteSimpleAggToMetaScan;
+    }
+
+    public void setEnableRewriteSimpleAggToHdfsScan(boolean v) {
+        this.enableRewriteSimpleAggToHdfsScan = v;
+    }
+
+    public boolean isEnableRewriteSimpleAggToHdfsScan() {
+        return this.enableRewriteSimpleAggToHdfsScan;
     }
 
     public boolean getEnablePruneComplexTypes() {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/Optimizer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/Optimizer.java
@@ -65,6 +65,11 @@ import com.starrocks.sql.optimizer.rule.transformation.PushLimitAndFilterToCTEPr
 import com.starrocks.sql.optimizer.rule.transformation.RemoveAggregationFromAggTable;
 import com.starrocks.sql.optimizer.rule.transformation.RewriteGroupingSetsByCTERule;
 import com.starrocks.sql.optimizer.rule.transformation.RewriteMultiDistinctRule;
+<<<<<<< HEAD
+=======
+import com.starrocks.sql.optimizer.rule.transformation.RewriteSimpleAggToHDFSScanRule;
+import com.starrocks.sql.optimizer.rule.transformation.RewriteSimpleAggToMetaScanRule;
+>>>>>>> 9d1c52cfa5 ([Feature] Optimize count(1) in hdfs scanner by rewriting plan to sum)
 import com.starrocks.sql.optimizer.rule.transformation.SeparateProjectRule;
 import com.starrocks.sql.optimizer.rule.transformation.SkewJoinOptimizeRule;
 import com.starrocks.sql.optimizer.rule.transformation.SplitScanORToUnionRule;

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/Optimizer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/Optimizer.java
@@ -65,11 +65,7 @@ import com.starrocks.sql.optimizer.rule.transformation.PushLimitAndFilterToCTEPr
 import com.starrocks.sql.optimizer.rule.transformation.RemoveAggregationFromAggTable;
 import com.starrocks.sql.optimizer.rule.transformation.RewriteGroupingSetsByCTERule;
 import com.starrocks.sql.optimizer.rule.transformation.RewriteMultiDistinctRule;
-<<<<<<< HEAD
-=======
 import com.starrocks.sql.optimizer.rule.transformation.RewriteSimpleAggToHDFSScanRule;
-import com.starrocks.sql.optimizer.rule.transformation.RewriteSimpleAggToMetaScanRule;
->>>>>>> 9d1c52cfa5 ([Feature] Optimize count(1) in hdfs scanner by rewriting plan to sum)
 import com.starrocks.sql.optimizer.rule.transformation.SeparateProjectRule;
 import com.starrocks.sql.optimizer.rule.transformation.SkewJoinOptimizeRule;
 import com.starrocks.sql.optimizer.rule.transformation.SplitScanORToUnionRule;
@@ -150,7 +146,6 @@ public class Optimizer {
     public OptimizerContext getContext() {
         return context;
     }
-
 
     public OptExpression optimize(ConnectContext connectContext,
                                   OptExpression logicOperatorTree,
@@ -580,6 +575,11 @@ public class Optimizer {
 
         // rule based materialized view rewrite
         ruleBasedMaterializedViewRewrite(tree, rootTaskContext);
+
+        // this rewrite rule should be after mv.
+        ruleRewriteIterative(tree, rootTaskContext, RewriteSimpleAggToHDFSScanRule.HIVE_SCAN_NO_PROJECT);
+        ruleRewriteIterative(tree, rootTaskContext, RewriteSimpleAggToHDFSScanRule.ICEBERG_SCAN_NO_PROJECT);
+        ruleRewriteIterative(tree, rootTaskContext, RewriteSimpleAggToHDFSScanRule.FILE_SCAN_NO_PROJECT);
 
         // NOTE: This rule should be after MV Rewrite because MV Rewrite cannot handle
         // select count(distinct c) from t group by a, b

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/RuleSet.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/RuleSet.java
@@ -147,6 +147,7 @@ import com.starrocks.sql.optimizer.rule.transformation.RewriteBitmapCountDistinc
 import com.starrocks.sql.optimizer.rule.transformation.RewriteCountIfFunction;
 import com.starrocks.sql.optimizer.rule.transformation.RewriteDuplicateAggregateFnRule;
 import com.starrocks.sql.optimizer.rule.transformation.RewriteHllCountDistinctRule;
+import com.starrocks.sql.optimizer.rule.transformation.RewriteSimpleAggToHDFSScanRule;
 import com.starrocks.sql.optimizer.rule.transformation.RewriteSimpleAggToMetaScanRule;
 import com.starrocks.sql.optimizer.rule.transformation.RewriteSumByAssociativeRule;
 import com.starrocks.sql.optimizer.rule.transformation.ScalarApply2AnalyticRule;
@@ -375,6 +376,9 @@ public class RuleSet {
                 new RewriteHllCountDistinctRule(),
                 new RewriteDuplicateAggregateFnRule(),
                 new RewriteSimpleAggToMetaScanRule(),
+                RewriteSimpleAggToHDFSScanRule.HIVE_SCAN,
+                RewriteSimpleAggToHDFSScanRule.ICEBERG_SCAN,
+                RewriteSimpleAggToHDFSScanRule.FILE_SCAN,
                 new RewriteSumByAssociativeRule(),
                 new RewriteCountIfFunction()
         ));

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/RuleSet.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/RuleSet.java
@@ -376,9 +376,6 @@ public class RuleSet {
                 new RewriteHllCountDistinctRule(),
                 new RewriteDuplicateAggregateFnRule(),
                 new RewriteSimpleAggToMetaScanRule(),
-                RewriteSimpleAggToHDFSScanRule.HIVE_SCAN,
-                RewriteSimpleAggToHDFSScanRule.ICEBERG_SCAN,
-                RewriteSimpleAggToHDFSScanRule.FILE_SCAN,
                 new RewriteSumByAssociativeRule(),
                 new RewriteCountIfFunction()
         ));
@@ -417,9 +414,9 @@ public class RuleSet {
         ));
 
         REWRITE_RULES.put(RuleSetType.ALL_MV_REWRITE, Stream.concat(
-                REWRITE_RULES.get(RuleSetType.MULTI_TABLE_MV_REWRITE).stream(),
-                REWRITE_RULES.get(RuleSetType.SINGLE_TABLE_MV_REWRITE).stream())
-                        .collect(Collectors.toList()));
+                        REWRITE_RULES.get(RuleSetType.MULTI_TABLE_MV_REWRITE).stream(),
+                        REWRITE_RULES.get(RuleSetType.SINGLE_TABLE_MV_REWRITE).stream())
+                .collect(Collectors.toList()));
 
         REWRITE_RULES.put(RuleSetType.PRUNE_EMPTY_OPERATOR, ImmutableList.of(
                 PruneEmptyScanRule.OLAP_SCAN,
@@ -463,6 +460,9 @@ public class RuleSet {
                 new PushDownAggToMetaScanRule(),
                 new PushDownFlatJsonMetaToMetaScanRule(),
                 new RewriteSimpleAggToMetaScanRule(),
+                RewriteSimpleAggToHDFSScanRule.FILE_SCAN,
+                RewriteSimpleAggToHDFSScanRule.HIVE_SCAN,
+                RewriteSimpleAggToHDFSScanRule.ICEBERG_SCAN,
                 new MinMaxCountOptOnScanRule()
         ));
     }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/RewriteSimpleAggToHDFSScanRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/RewriteSimpleAggToHDFSScanRule.java
@@ -1,0 +1,224 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.sql.optimizer.rule.transformation;
+
+import com.google.common.base.Preconditions;
+import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
+import com.starrocks.analysis.Expr;
+import com.starrocks.catalog.AggregateFunction;
+import com.starrocks.catalog.Column;
+import com.starrocks.catalog.Function;
+import com.starrocks.catalog.FunctionSet;
+import com.starrocks.catalog.IcebergTable;
+import com.starrocks.catalog.Type;
+import com.starrocks.common.AnalysisException;
+import com.starrocks.sql.optimizer.OptExpression;
+import com.starrocks.sql.optimizer.OptimizerContext;
+import com.starrocks.sql.optimizer.base.ColumnRefFactory;
+import com.starrocks.sql.optimizer.base.ColumnRefSet;
+import com.starrocks.sql.optimizer.operator.OperatorType;
+import com.starrocks.sql.optimizer.operator.logical.LogicalAggregationOperator;
+import com.starrocks.sql.optimizer.operator.logical.LogicalFileScanOperator;
+import com.starrocks.sql.optimizer.operator.logical.LogicalHiveScanOperator;
+import com.starrocks.sql.optimizer.operator.logical.LogicalIcebergScanOperator;
+import com.starrocks.sql.optimizer.operator.logical.LogicalScanOperator;
+import com.starrocks.sql.optimizer.operator.pattern.Pattern;
+import com.starrocks.sql.optimizer.operator.scalar.CallOperator;
+import com.starrocks.sql.optimizer.operator.scalar.ColumnRefOperator;
+import com.starrocks.sql.optimizer.operator.scalar.ScalarOperator;
+import com.starrocks.sql.optimizer.rule.RuleType;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+public class RewriteSimpleAggToHDFSScanRule extends TransformationRule {
+    public static final RewriteSimpleAggToHDFSScanRule HIVE_SCAN =
+            new RewriteSimpleAggToHDFSScanRule(OperatorType.LOGICAL_HIVE_SCAN);
+    public static final RewriteSimpleAggToHDFSScanRule ICEBERG_SCAN =
+            new RewriteSimpleAggToHDFSScanRule(OperatorType.LOGICAL_ICEBERG_SCAN);
+    public static final RewriteSimpleAggToHDFSScanRule FILE_SCAN =
+            new RewriteSimpleAggToHDFSScanRule(OperatorType.LOGICAL_FILE_SCAN);
+    final OperatorType scanOperatorType;
+
+    private RewriteSimpleAggToHDFSScanRule(OperatorType logicalOperatorType) {
+        super(RuleType.TF_REWRITE_SIMPLE_AGG, Pattern.create(OperatorType.LOGICAL_AGGR)
+                .addChildren(Pattern.create(OperatorType.LOGICAL_PROJECT, logicalOperatorType)));
+        scanOperatorType = logicalOperatorType;
+    }
+
+    private OptExpression buildAggScanOperator(LogicalAggregationOperator aggregationOperator,
+                                               LogicalScanOperator scanOperator,
+                                               OptimizerContext context) {
+        ColumnRefFactory columnRefFactory = context.getColumnRefFactory();
+        Map<ColumnRefOperator, CallOperator> aggs = aggregationOperator.getAggregations();
+
+        Map<ColumnRefOperator, CallOperator> newAggCalls = Maps.newHashMap();
+        Map<ColumnRefOperator, Column> newScanColumnRefs = Maps.newHashMap();
+
+        // select out partition columns.
+        int tableRelationId = -1;
+        for (ColumnRefOperator c : scanOperator.getColRefToColumnMetaMap().keySet()) {
+            int relationId = columnRefFactory.getRelationId(c.getId());
+            if (tableRelationId == -1) {
+                tableRelationId = relationId;
+            } else {
+                Preconditions.checkState(tableRelationId == relationId, "Table relation id is different across columns");
+            }
+            if (scanOperator.getPartitionColumns().contains(c.getName())) {
+                newScanColumnRefs.put(c, scanOperator.getColRefToColumnMetaMap().get(c));
+            }
+        }
+        Preconditions.checkState(tableRelationId != -1, "Can not find table relation id in scan operator");
+
+        ColumnRefOperator placeholderColumn = null;
+
+        for (Map.Entry<ColumnRefOperator, CallOperator> kv : aggs.entrySet()) {
+            CallOperator aggCall = kv.getValue();
+            // ___count___
+            String metaColumnName = "___" + aggCall.getFnName() + "___";
+            Type columnType = aggCall.getType();
+
+            if (placeholderColumn == null) {
+                Column c = new Column();
+                c.setName(metaColumnName);
+                c.setIsAllowNull(true);
+                placeholderColumn = columnRefFactory.create(metaColumnName, columnType, aggCall.isNullable());
+                columnRefFactory.updateColumnToRelationIds(placeholderColumn.getId(), tableRelationId);
+                columnRefFactory.updateColumnRefToColumns(placeholderColumn, c, scanOperator.getTable());
+                newScanColumnRefs.put(placeholderColumn, c);
+            }
+
+            Function aggFunction = aggCall.getFunction();
+            String newAggFnName = aggCall.getFnName();
+            Type newAggReturnType = aggCall.getType();
+            if (aggCall.getFnName().equals(FunctionSet.COUNT)) {
+                aggFunction = Expr.getBuiltinFunction(FunctionSet.SUM,
+                        new Type[] {Type.BIGINT}, Function.CompareMode.IS_IDENTICAL);
+                newAggFnName = FunctionSet.SUM;
+                newAggReturnType = Type.BIGINT;
+            }
+            CallOperator newAggCall = new CallOperator(newAggFnName, newAggReturnType,
+                    Collections.singletonList(placeholderColumn), aggFunction);
+            newAggCalls.put(kv.getKey(), newAggCall);
+        }
+
+        Map<Column, ColumnRefOperator> newScanColumnMeta = Maps.newHashMap();
+        for (Map.Entry<ColumnRefOperator, Column> c : newScanColumnRefs.entrySet()) {
+            newScanColumnMeta.put(c.getValue(), c.getKey());
+        }
+
+        LogicalScanOperator newMetaScan = null;
+
+        if (scanOperator instanceof LogicalHiveScanOperator) {
+            newMetaScan = new LogicalHiveScanOperator(scanOperator.getTable(),
+                    newScanColumnRefs, newScanColumnMeta, scanOperator.getLimit(), scanOperator.getPredicate());
+        } else if (scanOperator instanceof LogicalIcebergScanOperator) {
+            newMetaScan = new LogicalIcebergScanOperator(scanOperator.getTable(),
+                    newScanColumnRefs, newScanColumnMeta, scanOperator.getLimit(), scanOperator.getPredicate());
+        } else if (scanOperator instanceof LogicalFileScanOperator) {
+            newMetaScan = new LogicalFileScanOperator(scanOperator.getTable(),
+                    newScanColumnRefs, newScanColumnMeta, scanOperator.getLimit(), scanOperator.getPredicate());
+        } else {
+            throw new IllegalStateException("Unknown scan operator: " + scanOperator);
+        }
+        try {
+            newMetaScan.setScanOperatorPredicates(scanOperator.getScanOperatorPredicates());
+        } catch (AnalysisException e) {
+            throw new IllegalStateException("Set scan operator predicates", e);
+        }
+        LogicalAggregationOperator newAggOperator = new LogicalAggregationOperator(aggregationOperator.getType(),
+                aggregationOperator.getGroupingKeys(), newAggCalls);
+
+        newAggOperator.setProjection(aggregationOperator.getProjection());
+        OptExpression optExpression = OptExpression.create(newAggOperator);
+        optExpression.getInputs().add(OptExpression.create(newMetaScan));
+        return optExpression;
+    }
+
+    @Override
+    public boolean check(final OptExpression input, OptimizerContext context) {
+        if (!context.getSessionVariable().isEnableRewriteSimpleAggToHdfsScan()) {
+            return false;
+        }
+        LogicalAggregationOperator aggregationOperator = (LogicalAggregationOperator) input.getOp();
+        LogicalScanOperator scanOperator = (LogicalScanOperator) input.getInputs().get(0).getInputs().get(0).getOp();
+
+        // no limit
+        if (scanOperator.getLimit() != -1) {
+            return false;
+        }
+
+        // filter only involved with partition keys.
+        if (scanOperator.getPredicate() != null) {
+            if (!scanOperator.getPartitionColumns()
+                    .containsAll(scanOperator.getPredicate().getColumnRefs().stream().map(x -> x.getName()).collect(
+                            Collectors.toList()))) {
+                return false;
+            }
+        }
+
+        // all group by keys are partition keys.
+        List<ColumnRefOperator> groupingKeys = aggregationOperator.getGroupingKeys();
+        if (!scanOperator.getPartitionColumns()
+                .containsAll(groupingKeys.stream().map(x -> x.getName()).collect(Collectors.toList()))) {
+            return false;
+        }
+        // TODO(yanz): not quite sure why this limitation !
+        if (aggregationOperator.getPredicate() != null) {
+            return false;
+        }
+
+        if (scanOperatorType == OperatorType.LOGICAL_ICEBERG_SCAN) {
+            IcebergTable icebergTable = (IcebergTable) scanOperator.getTable();
+            if (!icebergTable.isUnPartitioned() && !icebergTable.isAllPartitionColumnsAlwaysIdentity()) {
+                return false;
+            }
+        }
+
+        boolean allValid = aggregationOperator.getAggregations().values().stream().allMatch(
+                aggregator -> {
+                    AggregateFunction aggregateFunction = (AggregateFunction) aggregator.getFunction();
+                    String functionName = aggregateFunction.functionName();
+                    ColumnRefSet usedColumns = aggregator.getUsedColumns();
+
+                    if (functionName.equals(FunctionSet.COUNT) && !aggregator.isDistinct() && usedColumns.isEmpty()) {
+                        List<ScalarOperator> arguments = aggregator.getArguments();
+                        if (arguments.isEmpty()) {
+                            // count()/count(*)
+                            return true;
+                        } else if (arguments.size() == 1 && !arguments.get(0).isConstantNull()) {
+                            // count(non-null constant)
+                            return true;
+                        }
+                        // TODO(yanz): not quite sure when this case happens.
+                        return false;
+                    }
+                    return false;
+                }
+        );
+        return allValid;
+    }
+
+    @Override
+    public List<OptExpression> transform(OptExpression input, OptimizerContext context) {
+        LogicalAggregationOperator aggregationOperator = (LogicalAggregationOperator) input.getOp();
+        LogicalScanOperator scanOperator = (LogicalScanOperator) input.getInputs().get(0).getInputs().get(0).getOp();
+        OptExpression result = buildAggScanOperator(aggregationOperator, scanOperator, context);
+        return Lists.newArrayList(result);
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/RewriteSimpleAggToHDFSScanRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/RewriteSimpleAggToHDFSScanRule.java
@@ -233,7 +233,6 @@ public class RewriteSimpleAggToHDFSScanRule extends TransformationRule {
                             // count(non-null constant)
                             return true;
                         }
-                        // TODO(yanz): not quite sure when this case happens.
                         return false;
                     }
                     return false;

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/RewriteSimpleAggToHDFSScanRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/RewriteSimpleAggToHDFSScanRule.java
@@ -205,7 +205,8 @@ public class RewriteSimpleAggToHDFSScanRule extends TransformationRule {
                 .containsAll(groupingKeys.stream().map(x -> x.getName()).collect(Collectors.toList()))) {
             return false;
         }
-        // TODO(yanz): not quite sure why this limitation !
+
+        // no predicate on agg operator
         if (aggregationOperator.getPredicate() != null) {
             return false;
         }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/RewriteSimpleAggToHDFSScanRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/RewriteSimpleAggToHDFSScanRule.java
@@ -160,12 +160,14 @@ public class RewriteSimpleAggToHDFSScanRule extends TransformationRule {
             newMetaScan = new LogicalFileScanOperator(scanOperator.getTable(),
                     newScanColumnRefs, newScanColumnMeta, scanOperator.getLimit(), scanOperator.getPredicate());
         } else {
-            throw new IllegalStateException("Unknown scan operator: " + scanOperator);
+            LOG.warn("Unexpected scan operator: " + scanOperator);
+            return null;
         }
         try {
             newMetaScan.setScanOperatorPredicates(scanOperator.getScanOperatorPredicates());
         } catch (AnalysisException e) {
-            throw new IllegalStateException("Set scan operator predicates", e);
+            LOG.warn("Exception caught when set scan operator predicates", e);
+            return null;
         }
         LogicalAggregationOperator newAggOperator = new LogicalAggregationOperator(aggregationOperator.getType(),
                 aggregationOperator.getGroupingKeys(), newAggCalls);

--- a/fe/fe-core/src/test/java/com/starrocks/connector/hive/MockedHiveMetadata.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/hive/MockedHiveMetadata.java
@@ -196,6 +196,9 @@ public class MockedHiveMetadata implements ConnectorMetadata {
             builder.setOutputRowCount(info.rowCount);
             for (ColumnRefOperator columnRefOperator : columns.keySet()) {
                 ColumnStatistic columnStatistic = info.columnStatsMap.get(columnRefOperator.getName());
+                if (columnStatistic == null) {
+                    columnStatistic = ColumnStatistic.unknown();
+                }
                 builder.addColumnStatistic(columnRefOperator, columnStatistic);
             }
             return builder.build();

--- a/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/MockIcebergMetadata.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/MockIcebergMetadata.java
@@ -466,6 +466,9 @@ public class MockIcebergMetadata implements ConnectorMetadata {
             builder.setOutputRowCount(info.rowCount);
             for (ColumnRefOperator columnRefOperator : columns.keySet()) {
                 ColumnStatistic columnStatistic = info.columnStatsMap.get(columnRefOperator.getName());
+                if (columnStatistic == null) {
+                    columnStatistic = ColumnStatistic.unknown();
+                }
                 builder.addColumnStatistic(columnRefOperator, columnStatistic);
             }
             return builder.build();

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/HiveScanTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/HiveScanTest.java
@@ -80,4 +80,73 @@ public class HiveScanTest extends ConnectorPlanTestBase {
             Assert.assertEquals(expexted, scanNodeList.get(0).getScanOptimzeOption().getCanUseMinMaxCountOpt());
         }
     }
+
+    @Test
+    public void testHiveRewriteSimpleAggToHdfsScan() throws Exception {
+        connectContext.getSessionVariable().setEnableRewriteSimpleAggToHdfsScan(true);
+        // positive cases.
+        {
+            String[] sqlString = {
+                    "select count(*) from lineitem_par",
+                    "select count(*) from lineitem_par where l_shipdate = '1998-01-01'",
+                    "select count(*), l_shipdate from lineitem_par where l_shipdate = '1998-01-01' group by l_shipdate"
+            };
+            for (int i = 0; i < sqlString.length; i++) {
+                String sql = sqlString[i];
+                String plan = getFragmentPlan(sql);
+                assertContains(plan, "___count___");
+            }
+        }
+        // negative cases.
+        {
+            String[] sqlString = {
+                    "select count(l_orderkey) from lineitem_par",
+                    "select count(*) from lineitem_par where l_shipdate = '1998-01-01' and l_orderkey = 202",
+                    "select count(*), count(l_orderkey), l_shipdate from lineitem_par where l_shipdate = '1998-01-01' group by " +
+                            "l_shipdate"
+            };
+            for (int i = 0; i < sqlString.length; i++) {
+                String sql = sqlString[i];
+                String plan = getFragmentPlan(sql);
+                assertNotContains(plan, "___count___");
+            }
+        }
+        connectContext.getSessionVariable().setEnableRewriteSimpleAggToHdfsScan(false);
+    }
+
+    @Test
+    public void testIcebergRewriteSimpleAggToHdfsScan() throws Exception {
+        connectContext.getSessionVariable().setEnableRewriteSimpleAggToHdfsScan(true);
+        // positive cases.
+        {
+            String[] sqlString = {
+                    "select count(*) from iceberg0.partitioned_db.t1",
+                    "select count(*) from iceberg0.partitioned_db.t1 where date = '2020-01-01'",
+                    "select count(*), date from iceberg0.partitioned_db.t1 where date = '2020-01-01' " +
+                            "group by date"
+            };
+            for (int i = 0; i < sqlString.length; i++) {
+                String sql = sqlString[i];
+                String plan = getFragmentPlan(sql);
+                assertContains(plan, "___count___");
+            }
+        }
+        // negative cases.
+        {
+            String[] sqlString = {
+                    "select count(id) from iceberg0.partitioned_db.t1",
+                    "select count(*) from iceberg0.partitioned_db.t1 where date = '1998-01-01' and id =" +
+                            " 202",
+                    "select count(*), count(id), date from iceberg0.partitioned_db.t1 where date " +
+                            "= '2020-01-01' group by " +
+                            "date"
+            };
+            for (int i = 0; i < sqlString.length; i++) {
+                String sql = sqlString[i];
+                String plan = getFragmentPlan(sql);
+                assertNotContains(plan, "___count___");
+            }
+        }
+        connectContext.getSessionVariable().setEnableRewriteSimpleAggToHdfsScan(false);
+    }
 }

--- a/java-extensions/hive-reader/src/main/java/com/starrocks/hive/reader/HiveScanner.java
+++ b/java-extensions/hive-reader/src/main/java/com/starrocks/hive/reader/HiveScanner.java
@@ -14,8 +14,6 @@
 
 package com.starrocks.hive.reader;
 
-import static com.google.common.base.Preconditions.checkArgument;
-
 import com.google.common.base.Splitter;
 import com.starrocks.jni.connector.ColumnType;
 import com.starrocks.jni.connector.ColumnValue;
@@ -23,14 +21,6 @@ import com.starrocks.jni.connector.ConnectorScanner;
 import com.starrocks.jni.connector.ScannerHelper;
 import com.starrocks.jni.connector.SelectedFields;
 import com.starrocks.utils.loader.ThreadContextClassLoader;
-import java.io.IOException;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Properties;
-import java.util.stream.Collectors;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.hive.common.JavaUtils;
@@ -47,6 +37,17 @@ import org.apache.hadoop.mapred.Reporter;
 import org.apache.hadoop.util.ReflectionUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
+import java.util.stream.Collectors;
+
+import static com.google.common.base.Preconditions.checkArgument;
 
 public class HiveScanner extends ConnectorScanner {
 

--- a/java-extensions/hive-reader/src/main/java/com/starrocks/hive/reader/HiveScanner.java
+++ b/java-extensions/hive-reader/src/main/java/com/starrocks/hive/reader/HiveScanner.java
@@ -14,12 +14,23 @@
 
 package com.starrocks.hive.reader;
 
+import static com.google.common.base.Preconditions.checkArgument;
+
+import com.google.common.base.Splitter;
 import com.starrocks.jni.connector.ColumnType;
 import com.starrocks.jni.connector.ColumnValue;
 import com.starrocks.jni.connector.ConnectorScanner;
 import com.starrocks.jni.connector.ScannerHelper;
 import com.starrocks.jni.connector.SelectedFields;
 import com.starrocks.utils.loader.ThreadContextClassLoader;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
+import java.util.stream.Collectors;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.hive.common.JavaUtils;
@@ -36,17 +47,6 @@ import org.apache.hadoop.mapred.Reporter;
 import org.apache.hadoop.util.ReflectionUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-
-import java.io.IOException;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Properties;
-import java.util.stream.Collectors;
-
-import static com.google.common.base.Preconditions.checkArgument;
 
 public class HiveScanner extends ConnectorScanner {
 
@@ -92,7 +92,8 @@ public class HiveScanner extends ConnectorScanner {
         this.fetchSize = fetchSize;
         this.hiveColumnNames = params.get("hive_column_names");
         this.hiveColumnTypes = params.get("hive_column_types").split("#");
-        this.requiredFields = params.get("required_fields").split(",");
+        this.requiredFields =
+                Splitter.on(',').omitEmptyStrings().splitToList(params.get("required_fields")).toArray(new String[0]);
         this.nestedFields = params.getOrDefault("nested_fields", "").split(",");
         this.dataFilePath = params.get("data_file_path");
         this.blockOffset = Long.parseLong(params.get("block_offset"));

--- a/test/sql/test_external_file/R/test_csv_compression_format
+++ b/test/sql/test_external_file/R/test_csv_compression_format
@@ -2,7 +2,7 @@
 [UC]shell: snappy_prefix=echo "oss://${oss_bucket}/test_csv_compression/${uuid0}/snappy_format/"
 -- result:
 0
-oss://starrocks-env-s3-unit-test/test_csv_compression/0fe51e0f95b347a883f3a63eba30d718/snappy_format/
+oss://starrocks-env-s3-unit-test/test_csv_compression/33a3df9fe78845ae86986f6679d50eb1/snappy_format/
 -- !result
 shell: ossutil64 mkdir ${snappy_prefix[1]} > /dev/null || echo "exit 0" >/dev/null
 -- result:
@@ -40,6 +40,7 @@ PROPERTIES
     "column_separator" = ","
 );
 -- result:
+[]
 -- !result
 select * from test_csv_snappy_format where a = 'Alice';
 -- result:
@@ -57,6 +58,22 @@ select * from test_csv_snappy_format where a = '99999';
 -- result:
 99999	100000
 -- !result
+set enable_rewrite_simple_agg_to_hdfs_scan = true;
+-- result:
+[]
+-- !result
+select count(*) from test_csv_snappy_format;
+-- result:
+100003
+-- !result
+set enable_rewrite_simple_agg_to_hdfs_scan = false;
+-- result:
+[]
+-- !result
+select count(*) from test_csv_snappy_format;
+-- result:
+100003
+-- !result
 shell: ossutil64 rm -rf ${snappy_prefix[1]}  >/dev/null || echo "exit 0" >/dev/null
 -- result:
 0
@@ -66,7 +83,7 @@ shell: ossutil64 rm -rf ${snappy_prefix[1]}  >/dev/null || echo "exit 0" >/dev/n
 [UC]shell: lzo_prefix=echo "oss://${oss_bucket}/test_csv_compression/${uuid0}/lzo_format/"
 -- result:
 0
-oss://starrocks-env-s3-unit-test/test_csv_compression/ab549984f22a4dd282632d85b4f2a073/lzo_format/
+oss://starrocks-env-s3-unit-test/test_csv_compression/dea9891381c84ffe8a9b671aa56dc504/lzo_format/
 -- !result
 shell: ossutil64 mkdir ${lzo_prefix[1]} /dev/null || echo "exit 0" >/dev/null
 -- result:
@@ -98,6 +115,7 @@ PROPERTIES
     "column_separator" = ","
 );
 -- result:
+[]
 -- !result
 select * from test_csv_lzo_format where a = 'Alice';
 -- result:
@@ -114,6 +132,22 @@ CharlieX	3
 select * from test_csv_lzo_format where a = '99999';
 -- result:
 99999	100000
+-- !result
+set enable_rewrite_simple_agg_to_hdfs_scan = true;
+-- result:
+[]
+-- !result
+select count(*) from test_csv_lzo_format;
+-- result:
+100003
+-- !result
+set enable_rewrite_simple_agg_to_hdfs_scan = false;
+-- result:
+[]
+-- !result
+select count(*) from test_csv_lzo_format;
+-- result:
+100003
 -- !result
 shell: ossutil64 rm -rf ${lzo_prefix[1]}  >/dev/null || echo "exit 0" >/dev/null
 -- result:

--- a/test/sql/test_external_file/R/test_hive_jni_format
+++ b/test/sql/test_external_file/R/test_hive_jni_format
@@ -2,7 +2,7 @@
 [UC]shell: avro_prefix=echo "oss://${oss_bucket}/test_hive_format/${uuid0}/avro_format/"
 -- result:
 0
-oss://starrocks-sql-data-zhangjiakou/jiangyangjun/test_hive_format/c6174f14d2f1413488cb1f3ddd5bf5bf/avro_format/
+oss://starrocks-env-s3-unit-test/test_hive_format/f81c141277504324a587846c0c566663/avro_format/
 -- !result
 shell: ossutil64 mkdir ${avro_prefix[1]} > /dev/null || echo "exit 0" >/dev/null
 -- result:
@@ -47,6 +47,7 @@ PROPERTIES
     "format" = "avro"
 );
 -- result:
+[]
 -- !result
 select * from test_hive_avro_format where col_string = 'world';
 -- result:
@@ -56,7 +57,7 @@ select * from test_hive_avro_format where abs(col_float - 1.23) < 0.01 ;
 -- result:
 1	2	3	10000000000	1.23	3.14	100.50	you	are       	beautiful	0	2023-10-29 10:00:00	2023-10-29	["D","E","F"]	{"k1":3,"k2":5}	{"name":"chandler","age":54}
 -- !result
-select col_tinyint,col_decimal,col_array from test_hive_avro_format;
+select col_tinyint,col_decimal,col_array from test_hive_avro_format order by 1;
 -- result:
 1	100.50	["D","E","F"]
 7	57.30	["A","B","C"]
@@ -65,6 +66,22 @@ select col_tinyint,col_timestamp from test_hive_avro_format  order by 1 limit 3;
 -- result:
 1	2023-10-29 10:00:00
 7	2022-01-01 10:00:00
+-- !result
+set enable_rewrite_simple_agg_to_hdfs_scan = true;
+-- result:
+[]
+-- !result
+select count(*) from test_hive_avro_format;
+-- result:
+2
+-- !result
+set enable_rewrite_simple_agg_to_hdfs_scan = false;
+-- result:
+[]
+-- !result
+select count(*) from test_hive_avro_format;
+-- result:
+2
 -- !result
 shell: ossutil64 rm -rf ${avro_prefix[1]}  >/dev/null || echo "exit 0" >/dev/null
 -- result:
@@ -75,7 +92,7 @@ shell: ossutil64 rm -rf ${avro_prefix[1]}  >/dev/null || echo "exit 0" >/dev/nul
 [UC]shell: rcbinary_prefix=echo "oss://${oss_bucket}/test_hive_format/${uuid0}/rcbinary_format/"
 -- result:
 0
-oss://starrocks-sql-data-zhangjiakou/jiangyangjun/test_hive_format/e27775bb1eed4c359beedae1df77b520/rcbinary_format/
+oss://starrocks-env-s3-unit-test/test_hive_format/744f2c100abf4fa0af69da7b4824ad02/rcbinary_format/
 -- !result
 shell: ossutil64 mkdir ${rcbinary_prefix[1]} > /dev/null || echo "exit 0" >/dev/null
 -- result:
@@ -120,6 +137,7 @@ PROPERTIES
     "format" = "rcbinary"
 );
 -- result:
+[]
 -- !result
 select * from test_hive_rcbinary_format where col_string = 'world';
 -- result:
@@ -129,15 +147,31 @@ select * from test_hive_rcbinary_format where abs(col_float - 1.23) < 0.01 ;
 -- result:
 1	2	3	10000000000	1.23	3.14	100.50	you	are       	beautiful	0	2023-10-29 10:00:00	2023-10-29	["D","E","F"]	{"k2":5,"k1":3}	{"name":"chandler","age":54}
 -- !result
-select col_tinyint,col_decimal,col_array from test_hive_rcbinary_format;
+select col_tinyint,col_decimal,col_array from test_hive_rcbinary_format order by 1;
 -- result:
-7	57.30	["A","B","C"]
 1	100.50	["D","E","F"]
+7	57.30	["A","B","C"]
 -- !result
 select col_tinyint,col_timestamp from test_hive_rcbinary_format  order by 1 limit 3;
 -- result:
 1	2023-10-29 10:00:00
 7	2022-01-01 10:00:00
+-- !result
+set enable_rewrite_simple_agg_to_hdfs_scan = true;
+-- result:
+[]
+-- !result
+select count(*) from test_hive_rcbinary_format;
+-- result:
+2
+-- !result
+set enable_rewrite_simple_agg_to_hdfs_scan = false;
+-- result:
+[]
+-- !result
+select count(*) from test_hive_rcbinary_format;
+-- result:
+2
 -- !result
 shell: ossutil64 rm -rf ${rcbinary_prefix[1]}  >/dev/null || echo "exit 0" >/dev/null
 -- result:
@@ -148,7 +182,7 @@ shell: ossutil64 rm -rf ${rcbinary_prefix[1]}  >/dev/null || echo "exit 0" >/dev
 [UC]shell: rctext_prefix=echo "oss://${oss_bucket}/test_hive_format/${uuid0}/rctext_format/"
 -- result:
 0
-oss://starrocks-sql-data-zhangjiakou/jiangyangjun/test_hive_format/45e80824e4314af89d1eed96ffd9baef/rctext_format/
+oss://starrocks-env-s3-unit-test/test_hive_format/aead1b6eaffd4516999a69b52092962a/rctext_format/
 -- !result
 shell: ossutil64 mkdir ${rctext_prefix[1]} > /dev/null || echo "exit 0" >/dev/null
 -- result:
@@ -193,6 +227,7 @@ PROPERTIES
     "format" = "rctext"
 );
 -- result:
+[]
 -- !result
 select * from test_hive_rctext_format where col_string = 'world';
 -- result:
@@ -207,6 +242,22 @@ select col_tinyint,col_decimal,col_array from test_hive_rctext_format;
 1	100.50	["D","E","F"]
 7	57.30	["A","B","C"]
 -- !result
+set enable_rewrite_simple_agg_to_hdfs_scan = true;
+-- result:
+[]
+-- !result
+select count(*) from test_hive_rctext_format;
+-- result:
+2
+-- !result
+set enable_rewrite_simple_agg_to_hdfs_scan = false;
+-- result:
+[]
+-- !result
+select count(*) from test_hive_rctext_format;
+-- result:
+2
+-- !result
 shell: ossutil64 rm -rf ${rctext_prefix[1]}  >/dev/null || echo "exit 0" >/dev/null
 -- result:
 0
@@ -216,7 +267,7 @@ shell: ossutil64 rm -rf ${rctext_prefix[1]}  >/dev/null || echo "exit 0" >/dev/n
 [UC]shell: sequence_prefix=echo "oss://${oss_bucket}/test_hive_format/${uuid0}/sequence_format/"
 -- result:
 0
-oss://starrocks-sql-data-zhangjiakou/jiangyangjun/test_hive_format/a99c1567ef2b4050b8ee01cd5c453337/sequence_format/
+oss://starrocks-env-s3-unit-test/test_hive_format/c42ab996c96f4035a7e2b04d1edb39ea/sequence_format/
 -- !result
 shell: ossutil64 mkdir ${sequence_prefix[1]} > /dev/null || echo "exit 0" >/dev/null
 -- result:
@@ -261,6 +312,7 @@ PROPERTIES
     "format" = "sequence"
 );
 -- result:
+[]
 -- !result
 select * from test_hive_sequence_format where col_string = 'world';
 -- result:
@@ -275,6 +327,22 @@ select col_tinyint,col_decimal,col_array from test_hive_sequence_format;
 1	100.50	["D","E","F"]
 7	57.30	["A","B","C"]
 -- !result
+set enable_rewrite_simple_agg_to_hdfs_scan = true;
+-- result:
+[]
+-- !result
+select count(*) from test_hive_sequence_format;
+-- result:
+2
+-- !result
+set enable_rewrite_simple_agg_to_hdfs_scan = false;
+-- result:
+[]
+-- !result
+select count(*) from test_hive_sequence_format;
+-- result:
+2
+-- !result
 shell: ossutil64 rm -rf ${sequence_prefix[1]}  >/dev/null || echo "exit 0" >/dev/null
 -- result:
 0
@@ -284,7 +352,7 @@ shell: ossutil64 rm -rf ${sequence_prefix[1]}  >/dev/null || echo "exit 0" >/dev
 [UC]shell: struct_prefix=echo "oss://${oss_bucket}/test_hive_format/${uuid0}/strcut/"
 -- result:
 0
-oss://starrocks-sql-data-zhangjiakou/jiangyangjun/test_hive_format/a308f9e19fd64f8fbaae5e878fbec846/strcut/
+oss://starrocks-env-s3-unit-test/test_hive_format/e15c6685c54140d497cb5453dd4e4765/strcut/
 -- !result
 shell: ossutil64 mkdir ${struct_prefix[1]} > /dev/null || echo "exit 0" >/dev/null
 -- result:
@@ -309,6 +377,7 @@ PROPERTIES
     "format" = "sequence"
 );
 -- result:
+[]
 -- !result
 select col_int,col_struct from hive_hdfs_sequencefile_struct_mix_deflate order by 1 limit 1;
 -- result:

--- a/test/sql/test_external_file/R/test_orc_count_star_opt
+++ b/test/sql/test_external_file/R/test_orc_count_star_opt
@@ -69,6 +69,13 @@ select count(*) from array_data_only;
 -- result:
 41
 -- !result
+set enable_rewrite_simple_agg_to_hdfs_scan = true;
+-- result:
+-- !result
+select count(*) from array_data_only;
+-- result:
+41
+-- !result
 CREATE EXTERNAL TABLE map_data_only
 (
     data map<string, int>    
@@ -82,6 +89,13 @@ PROPERTIES
 -- result:
 -- !result
 set enable_count_star_optimization = true;
+-- result:
+-- !result
+select count(*) from map_data_only;
+-- result:
+52
+-- !result
+set enable_rewrite_simple_agg_to_hdfs_scan = true;
 -- result:
 -- !result
 select count(*) from map_data_only;
@@ -109,6 +123,13 @@ select count(*) from struct_data_only;
 -- result:
 63
 -- !result
+set enable_rewrite_simple_agg_to_hdfs_scan = true;
+-- result:
+-- !result
+select count(*) from struct_data_only;
+-- result:
+63
+-- !result
 CREATE EXTERNAL TABLE empty_row_index
 (
     `id` int,
@@ -130,6 +151,13 @@ select count(*) from empty_row_index;
 1
 -- !result
 set enable_count_star_optimization = false;
+-- result:
+-- !result
+select count(*) from empty_row_index;
+-- result:
+1
+-- !result
+set enable_rewrite_simple_agg_to_hdfs_scan = true;
 -- result:
 -- !result
 select count(*) from empty_row_index;

--- a/test/sql/test_external_file/R/test_parquet_count_star_opt
+++ b/test/sql/test_external_file/R/test_parquet_count_star_opt
@@ -58,6 +58,13 @@ select count(*) from array_data_only;
 -- result:
 51
 -- !result
+set enable_rewrite_simple_agg_to_hdfs_scan = true;
+-- result:
+-- !result
+select count(*) from array_data_only;
+-- result:
+51
+-- !result
 CREATE EXTERNAL TABLE map_data_only
 (
     data map<string, int>    
@@ -71,6 +78,13 @@ PROPERTIES
 -- result:
 -- !result
 set enable_count_star_optimization = true;
+-- result:
+-- !result
+select count(*) from map_data_only;
+-- result:
+62
+-- !result
+set enable_rewrite_simple_agg_to_hdfs_scan = true;
 -- result:
 -- !result
 select count(*) from map_data_only;
@@ -92,6 +106,13 @@ PROPERTIES
 -- result:
 -- !result
 set enable_count_star_optimization = true;
+-- result:
+-- !result
+select count(*) from struct_data_only;
+-- result:
+73
+-- !result
+set enable_rewrite_simple_agg_to_hdfs_scan = true;
 -- result:
 -- !result
 select count(*) from struct_data_only;

--- a/test/sql/test_external_file/T/test_csv_compression_format
+++ b/test/sql/test_external_file/T/test_csv_compression_format
@@ -41,6 +41,12 @@ select * from test_csv_snappy_format where a = 'Bob';
 select * from test_csv_snappy_format where a = 'CharlieX';
 select * from test_csv_snappy_format where a = '99999';
 
+set enable_rewrite_simple_agg_to_hdfs_scan = true;
+select count(*) from test_csv_snappy_format;
+set enable_rewrite_simple_agg_to_hdfs_scan = false;
+select count(*) from test_csv_snappy_format;
+
+
 shell: ossutil64 rm -rf ${snappy_prefix[1]}  >/dev/null || echo "exit 0" >/dev/null
 
 ------------------------------------
@@ -71,5 +77,11 @@ select * from test_csv_lzo_format where a = 'Alice';
 select * from test_csv_lzo_format where a = 'Bob';
 select * from test_csv_lzo_format where a = 'CharlieX';
 select * from test_csv_lzo_format where a = '99999';
+
+set enable_rewrite_simple_agg_to_hdfs_scan = true;
+select count(*) from test_csv_lzo_format;
+set enable_rewrite_simple_agg_to_hdfs_scan = false;
+select count(*) from test_csv_lzo_format;
+
 
 shell: ossutil64 rm -rf ${lzo_prefix[1]}  >/dev/null || echo "exit 0" >/dev/null

--- a/test/sql/test_external_file/T/test_hive_jni_format
+++ b/test/sql/test_external_file/T/test_hive_jni_format
@@ -44,6 +44,11 @@ select * from test_hive_avro_format where abs(col_float - 1.23) < 0.01 ;
 select col_tinyint,col_decimal,col_array from test_hive_avro_format;
 select col_tinyint,col_timestamp from test_hive_avro_format  order by 1 limit 3;
 
+set enable_rewrite_simple_agg_to_hdfs_scan = true;
+select count(*) from test_hive_avro_format;
+set enable_rewrite_simple_agg_to_hdfs_scan = false;
+select count(*) from test_hive_avro_format;
+
 
 shell: ossutil64 rm -rf ${avro_prefix[1]}  >/dev/null || echo "exit 0" >/dev/null
 
@@ -90,6 +95,13 @@ select col_tinyint,col_decimal,col_array from test_hive_rcbinary_format;
 -- test timestamp with rcbianry dealing with timezone
 select col_tinyint,col_timestamp from test_hive_rcbinary_format  order by 1 limit 3;
 
+set enable_rewrite_simple_agg_to_hdfs_scan = true;
+select count(*) from test_hive_rcbinary_format;
+set enable_rewrite_simple_agg_to_hdfs_scan = false;
+select count(*) from test_hive_rcbinary_format;
+
+
+
 shell: ossutil64 rm -rf ${rcbinary_prefix[1]}  >/dev/null || echo "exit 0" >/dev/null
 
 -- name: testHiveRctextFormat
@@ -131,6 +143,11 @@ select * from test_hive_rctext_format where col_string = 'world';
 select * from test_hive_rctext_format where abs(col_float - 1.23) < 0.01 ;
 select col_tinyint,col_decimal,col_array from test_hive_rctext_format;
 
+set enable_rewrite_simple_agg_to_hdfs_scan = true;
+select count(*) from test_hive_rctext_format;
+set enable_rewrite_simple_agg_to_hdfs_scan = false;
+select count(*) from test_hive_rctext_format;
+
 shell: ossutil64 rm -rf ${rctext_prefix[1]}  >/dev/null || echo "exit 0" >/dev/null
 
 -- name: testHiveSequenceFormat
@@ -171,6 +188,11 @@ PROPERTIES
 select * from test_hive_sequence_format where col_string = 'world';
 select * from test_hive_sequence_format where abs(col_float - 1.23) < 0.01 ;
 select col_tinyint,col_decimal,col_array from test_hive_sequence_format;
+
+set enable_rewrite_simple_agg_to_hdfs_scan = true;
+select count(*) from test_hive_sequence_format;
+set enable_rewrite_simple_agg_to_hdfs_scan = false;
+select count(*) from test_hive_sequence_format;
 
 shell: ossutil64 rm -rf ${sequence_prefix[1]}  >/dev/null || echo "exit 0" >/dev/null
 

--- a/test/sql/test_external_file/T/test_hive_jni_format
+++ b/test/sql/test_external_file/T/test_hive_jni_format
@@ -41,7 +41,7 @@ PROPERTIES
 
 select * from test_hive_avro_format where col_string = 'world';
 select * from test_hive_avro_format where abs(col_float - 1.23) < 0.01 ;
-select col_tinyint,col_decimal,col_array from test_hive_avro_format;
+select col_tinyint,col_decimal,col_array from test_hive_avro_format order by 1;
 select col_tinyint,col_timestamp from test_hive_avro_format  order by 1 limit 3;
 
 set enable_rewrite_simple_agg_to_hdfs_scan = true;
@@ -91,7 +91,7 @@ PROPERTIES
 select * from test_hive_rcbinary_format where col_string = 'world';
 select * from test_hive_rcbinary_format where abs(col_float - 1.23) < 0.01 ;
 -- test select some non-partition columns
-select col_tinyint,col_decimal,col_array from test_hive_rcbinary_format;
+select col_tinyint,col_decimal,col_array from test_hive_rcbinary_format order by 1;
 -- test timestamp with rcbianry dealing with timezone
 select col_tinyint,col_timestamp from test_hive_rcbinary_format  order by 1 limit 3;
 

--- a/test/sql/test_external_file/T/test_orc_count_star_opt
+++ b/test/sql/test_external_file/T/test_orc_count_star_opt
@@ -26,7 +26,8 @@ set enable_count_star_optimization = true;
 select count(*) from array_data_only;
 set enable_count_star_optimization = false;
 select count(*) from array_data_only;
-
+set enable_rewrite_simple_agg_to_hdfs_scan = true;
+select count(*) from array_data_only;
 
 CREATE EXTERNAL TABLE map_data_only
 (
@@ -42,6 +43,8 @@ set enable_count_star_optimization = true;
 select count(*) from map_data_only;
 -- set enable_count_star_optimization = false;
 -- select count(*) from map_data_only;
+set enable_rewrite_simple_agg_to_hdfs_scan = true;
+select count(*) from map_data_only;
 
 
 CREATE EXTERNAL TABLE struct_data_only
@@ -60,7 +63,8 @@ set enable_count_star_optimization = true;
 select count(*) from struct_data_only;
 -- set enable_count_star_optimization = false;
 -- select count(*) from struct_data_only;
-
+set enable_rewrite_simple_agg_to_hdfs_scan = true;
+select count(*) from struct_data_only;
 
 CREATE EXTERNAL TABLE empty_row_index
 (
@@ -76,6 +80,8 @@ PROPERTIES
 set enable_count_star_optimization = true;
 select count(*) from empty_row_index;
 set enable_count_star_optimization = false;
+select count(*) from empty_row_index;
+set enable_rewrite_simple_agg_to_hdfs_scan = true;
 select count(*) from empty_row_index;
 
 shell: ossutil64 rm -rf oss://${oss_bucket}/test_orc_count_star_opt/${uuid0}/ >/dev/null || echo "exit 0" >/dev/null

--- a/test/sql/test_external_file/T/test_parquet_count_star_opt
+++ b/test/sql/test_external_file/T/test_parquet_count_star_opt
@@ -23,6 +23,8 @@ set enable_count_star_optimization = true;
 select count(*) from array_data_only;
 set enable_count_star_optimization = false;
 select count(*) from array_data_only;
+set enable_rewrite_simple_agg_to_hdfs_scan = true;
+select count(*) from array_data_only;
 
 
 CREATE EXTERNAL TABLE map_data_only
@@ -39,6 +41,8 @@ set enable_count_star_optimization = true;
 select count(*) from map_data_only;
 -- set enable_count_star_optimization = false;
 -- select count(*) from map_data_only;
+set enable_rewrite_simple_agg_to_hdfs_scan = true;
+select count(*) from map_data_only;
 
 
 CREATE EXTERNAL TABLE struct_data_only
@@ -57,5 +61,7 @@ set enable_count_star_optimization = true;
 select count(*) from struct_data_only;
 -- set enable_count_star_optimization = false;
 -- select count(*) from struct_data_only;
+set enable_rewrite_simple_agg_to_hdfs_scan = true;
+select count(*) from struct_data_only;
 
 shell: ossutil64 rm -rf oss://${oss_bucket}/test_parquet_count_star_opt/${uuid0}/ >/dev/null || echo "exit 0" >/dev/null

--- a/test/sql/test_external_file/T/test_query_external_file
+++ b/test/sql/test_external_file/T/test_query_external_file
@@ -48,5 +48,15 @@ select count(distinct seq) from dict_two_page;
 
 select count(*), min(f00), max(f00) from dict_two_page group by seq having seq = 99;
 
+------- test rewrite -----
+
+set enable_rewrite_simple_agg_to_hdfs_scan = true;
+
+select count(*) from dict_two_page;
+
+set enable_rewrite_simple_agg_to_hdfs_scan = false;
+
+select count(*) from dict_two_page;
+
 shell: ossutil64 rm -rf oss://${oss_bucket}/test_query_external_file/${uuid0}/ >/dev/null || echo "exit 0" >/dev/null
 

--- a/test/sql/test_iceberg/R/test_iceberg_catalog
+++ b/test/sql/test_iceberg/R/test_iceberg_catalog
@@ -12,7 +12,20 @@ select * from iceberg_sql_test_${uuid0}.iceberg_oss_db.test_trans_part order by 
 5	2020-05-01
 6	2020-06-01
 -- !result
-function: assert_explain_costs_contains("select * from iceberg_sql_test_${uuid0}.iceberg_ci_db.day_ts_to_ts;","partitions=2")
+select count(*) from iceberg_sql_test_${uuid0}.iceberg_oss_db.test_trans_part;
+-- result:
+6
+-- !result
+select count(*), col_date from iceberg_sql_test_${uuid0}.iceberg_oss_db.test_trans_part group by col_date order by col_date;
+-- result:
+1	2020-01-01
+1	2020-02-01
+1	2020-03-01
+1	2020-04-01
+1	2020-05-01
+1	2020-06-01
+-- !result
+drop catalog iceberg_sql_test_${uuid0}
 -- result:
 None
 -- !result

--- a/test/sql/test_iceberg/R/test_iceberg_catalog
+++ b/test/sql/test_iceberg/R/test_iceberg_catalog
@@ -25,7 +25,7 @@ select count(*), col_date from iceberg_sql_test_${uuid0}.iceberg_oss_db.test_tra
 1	2020-05-01
 1	2020-06-01
 -- !result
-drop catalog iceberg_sql_test_${uuid0}
+function: assert_explain_costs_contains("select * from iceberg_sql_test_${uuid0}.iceberg_ci_db.day_ts_to_ts;","partitions=2")
 -- result:
 None
 -- !result

--- a/test/sql/test_iceberg/T/test_iceberg_catalog
+++ b/test/sql/test_iceberg/T/test_iceberg_catalog
@@ -5,6 +5,10 @@ create external catalog iceberg_sql_test_${uuid0} PROPERTIES ("type"="iceberg", 
 -- only partition column Predicate with runtime filter
 select * from iceberg_sql_test_${uuid0}.iceberg_oss_db.test_trans_part order by col_int;
 
+select count(*) from iceberg_sql_test_${uuid0}.iceberg_oss_db.test_trans_part;
+
+select count(*), col_date from iceberg_sql_test_${uuid0}.iceberg_oss_db.test_trans_part group by col_date order by col_date;
+
 function: assert_explain_costs_contains("select * from iceberg_sql_test_${uuid0}.iceberg_ci_db.day_ts_to_ts;","partitions=2")
 
 drop catalog iceberg_sql_test_${uuid0};


### PR DESCRIPTION
## Why I'm doing:

Rigjht now hdfs scanner optimization on count(1) is to output const column of expected count. 

And we can see in extreme case(large dataset), the chunk number flows in pipeline will be extremely huge, and operator time and overhead time is not neglectable. 

And here is a profile of `select count(*) from hive.hive_ssb100g_parquet.lineorder`. To reproduce this extreme case, I've changed code to scale morsels by 20x and repeat row groups by 10x.

in concurrency=1 case , total time is 51s

```
         - OverheadTime: 25s37ms
           - __MAX_OF_OverheadTime: 25s111ms
           - __MIN_OF_OverheadTime: 24s962ms

             - PullTotalTime: 12s376ms
               - __MAX_OF_PullTotalTime: 13s147ms
               - __MIN_OF_PullTotalTime: 11s885ms
```

## What I'm doing:

Rewrite the count(1) query to sum like.  So each row group reader will only emit at one chunk(size = 1). 

And total time is 9s.

Original plan is like

```
+----------------------------------+
| Explain String                   |
+----------------------------------+
| PLAN FRAGMENT 0                  |
|  OUTPUT EXPRS:18: count          |
|   PARTITION: UNPARTITIONED       |
|                                  |
|   RESULT SINK                    |
|                                  |
|   4:AGGREGATE (merge finalize)   |
|   |  output: count(18: count)    |
|   |  group by:                   |
|   |                              |
|   3:EXCHANGE                     |
|                                  |
| PLAN FRAGMENT 1                  |
|  OUTPUT EXPRS:                   |
|   PARTITION: RANDOM              |
|                                  |
|   STREAM DATA SINK               |
|     EXCHANGE ID: 03              |
|     UNPARTITIONED                |
|                                  |
|   2:AGGREGATE (update serialize) |
|   |  output: count(*)            |
|   |  group by:                   |
|   |                              |
|   1:Project                      |
|   |  <slot 20> : 1               |
|   |                              |
|   0:HdfsScanNode                 |
|      TABLE: lineorder            |
|      partitions=1/1              |
|      cardinality=600037902       |
|      avgRowSize=5.0              |
+----------------------------------+
```


And rewritted plan is like

```
+-----------------------------------+
| Explain String                    |
+-----------------------------------+
| PLAN FRAGMENT 0                   |
|  OUTPUT EXPRS:18: count           |
|   PARTITION: UNPARTITIONED        |
|                                   |
|   RESULT SINK                     |
|                                   |
|   3:AGGREGATE (merge finalize)    |
|   |  output: sum(18: count)       |
|   |  group by:                    |
|   |                               |
|   2:EXCHANGE                      |
|                                   |
| PLAN FRAGMENT 1                   |
|  OUTPUT EXPRS:                    |
|   PARTITION: RANDOM               |
|                                   |
|   STREAM DATA SINK                |
|     EXCHANGE ID: 02               |
|     UNPARTITIONED                 |
|                                   |
|   1:AGGREGATE (update serialize)  |
|   |  output: sum(19: ___count___) |
|   |  group by:                    |
|   |                               |
|   0:HdfsScanNode                  |
|      TABLE: lineorder             |
|      partitions=1/1               |
|      cardinality=1                |
|      avgRowSize=1.0               |
+-----------------------------------+
```

Fixes #45242 

## What type of PR is this:

- [ ] BugFix
- [x] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [x] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
