### PR TITLE
[Enhancement] use fixed seed to shuffle files to avoid unstable latency

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/connector/RemoteScanRangeLocations.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/RemoteScanRangeLocations.java
@@ -56,6 +56,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Random;
 
 public class RemoteScanRangeLocations {
     private static final Logger LOG = LogManager.getLogger(RemoteScanRangeLocations.class);
@@ -374,7 +375,8 @@ public class RemoteScanRangeLocations {
         // encounter very bad cases (scan ranges that meet the predicate conditions are in the later partitions),
         // making BE have to scan more data to find rows that meet the conditions.
         // So shuffle scan ranges can naturally disrupt the scan ranges' order to avoid very bad cases.
-        Collections.shuffle(result);
+        Random rnd = new Random(42);
+        Collections.shuffle(result, rnd);
 
         LOG.debug("Get {} scan range locations cost: {} ms",
                 getScanRangeLocationsSize(), (System.currentTimeMillis() - start));


### PR DESCRIPTION
## Why I'm doing:

This pr https://github.com/StarRocks/starrocks/pull/42634 will shuffle files

However because shuffle is totally random, which causes some queries like following, have a large variance.

> insert into blackhole() select * from hive238.ssb_100g_parquet_zlib.lineorder_flat where c_region = 'AMERICA' limit 5000;

Latency could be 1.5s, could be 9s, jump back and forth. Not stable.

## What I'm doing:

Use fixed seed to shuffle files to get stable latency.

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [x] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
