### PR TITLE
[Enhancement] Improve referenced column and column mapping expr invalid error message when getting load plan

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/common/ErrorCode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/ErrorCode.java
@@ -283,6 +283,9 @@ public enum ErrorCode {
      */
     ERR_NO_FILES_FOUND(5600, new byte[] {'5', '8', '0', '3', '0'},
             "No files were found matching the pattern(s) or path(s): '%s'"),
+    ERR_EXPR_REFERENCED_COLUMN_NOT_FOUND(5601, new byte[] {'4', '2', '0', '0', '0'},
+            "Referenced column '%s' in expr '%s' can't be found in column list, derived column is '%s'"),
+    ERR_MAPPING_EXPR_INVALID(5602, new byte[] {'4', '2', '0', '0', '0'}, "Expr '%s' analyze error: %s, derived column is '%s'"),
 
     /**
      * 10000 - 10099: warehouse

--- a/fe/fe-core/src/main/java/com/starrocks/load/Load.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/Load.java
@@ -85,6 +85,7 @@ import com.starrocks.sql.analyzer.Field;
 import com.starrocks.sql.analyzer.RelationFields;
 import com.starrocks.sql.analyzer.RelationId;
 import com.starrocks.sql.analyzer.Scope;
+import com.starrocks.sql.analyzer.SemanticException;
 import com.starrocks.sql.ast.DataDescription;
 import com.starrocks.sql.ast.ImportColumnDesc;
 import com.starrocks.sql.ast.UserIdentity;
@@ -809,7 +810,12 @@ public class Load {
             }
             Expr expr = entry.getValue().clone(smap);
 
-            expr = Expr.analyzeAndCastFold(expr);
+            try {
+                expr = Expr.analyzeAndCastFold(expr);
+            } catch (SemanticException e) {
+                throw new UserException(String.format("Expr '%s' analyze error: %s, derived column is '%s'",
+                        AstToSQLBuilder.toSQL(entry.getValue()), e.getDetailMsg(), entry.getKey()));
+            }
 
             // check if contain aggregation
             List<FunctionCallExpr> funcs = Lists.newArrayList();

--- a/fe/fe-core/src/main/java/com/starrocks/load/Load.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/Load.java
@@ -79,6 +79,7 @@ import com.starrocks.privilege.PrivilegeBuiltinConstants;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.sql.analyzer.AnalyzeState;
+import com.starrocks.sql.analyzer.AstToSQLBuilder;
 import com.starrocks.sql.analyzer.ExpressionAnalyzer;
 import com.starrocks.sql.analyzer.Field;
 import com.starrocks.sql.analyzer.RelationFields;
@@ -794,8 +795,9 @@ public class Load {
             for (SlotRef slot : slots) {
                 SlotDescriptor slotDesc = slotDescByName.get(slot.getColumnName());
                 if (slotDesc == null) {
-                    throw new UserException("unknown reference column, column=" + entry.getKey()
-                            + ", reference=" + slot.getColumnName());
+                    throw new UserException(String.format(
+                            "Referenced column '%s' in expr '%s' can't be found in column list, derived column is '%s'",
+                            slot.getColumnName(), AstToSQLBuilder.toSQL(entry.getValue()), entry.getKey()));
                 }
                 if (useVectorizedLoad) {
                     slotDesc.setIsMaterialized(true);
@@ -893,8 +895,9 @@ public class Load {
                     smap.getRhs().add(new CastExpr(tbl.getColumn(slot.getColumnName()).getType(),
                             exprsByName.get(slot.getColumnName())));
                 } else {
-                    throw new UserException("unknown reference column, column=" + entry.getKey()
-                            + ", reference=" + slot.getColumnName());
+                    throw new UserException(String.format(
+                            "Referenced column '%s' in expr '%s' can't be found in column list, derived column is '%s'",
+                            slot.getColumnName(), AstToSQLBuilder.toSQL(entry.getValue()), entry.getKey()));
                 }
             }
             Expr expr = entry.getValue().clone(smap);

--- a/fe/fe-core/src/test/java/com/starrocks/load/LoadTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/load/LoadTest.java
@@ -35,6 +35,7 @@ import com.starrocks.catalog.OlapTable;
 import com.starrocks.catalog.RandomDistributionInfo;
 import com.starrocks.catalog.SinglePartitionInfo;
 import com.starrocks.catalog.Type;
+import com.starrocks.common.AnalysisException;
 import com.starrocks.common.ExceptionChecker;
 import com.starrocks.common.UserException;
 import com.starrocks.sql.ast.ImportColumnDesc;
@@ -285,7 +286,7 @@ public class LoadTest {
             }
         };
 
-        ExceptionChecker.expectThrowsWithMsg(UserException.class,
+        ExceptionChecker.expectThrowsWithMsg(AnalysisException.class,
                 "Expr 'year()' analyze error: No matching function with signature: year(), derived column is 'c1'",
                 () -> Load.initColumns(table, columnExprs, null, exprsByName, analyzer, srcTupleDesc,
                         slotDescByName, params, true, true, columnsFromPath));

--- a/fe/fe-core/src/test/java/com/starrocks/load/LoadTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/load/LoadTest.java
@@ -35,6 +35,7 @@ import com.starrocks.catalog.OlapTable;
 import com.starrocks.catalog.RandomDistributionInfo;
 import com.starrocks.catalog.SinglePartitionInfo;
 import com.starrocks.catalog.Type;
+import com.starrocks.common.ExceptionChecker;
 import com.starrocks.common.UserException;
 import com.starrocks.sql.ast.ImportColumnDesc;
 import com.starrocks.thrift.TBrokerScanRangeParams;
@@ -252,6 +253,42 @@ public class LoadTest {
         Assert.assertEquals(2, slotDescByName.size());
         Assert.assertFalse(slotDescByName.containsKey(c1Name));
         Assert.assertTrue(slotDescByName.containsKey(c1NameInSource));
+    }
+
+    /**
+     * set (c1 = year())
+     */
+    @Test
+    public void testMappingExprInvalid() {
+        // columns
+        String c0Name = "c0";
+        columns.add(new Column(c0Name, Type.INT, true, null, true, null, ""));
+        columnExprs.add(new ImportColumnDesc(c0Name, null));
+
+        String c1Name = "c1";
+        columns.add(new Column(c1Name, Type.INT, true, null, true, null, ""));
+
+        // column mappings
+        // c1 = year()
+        List<Expr> params1 = Lists.newArrayList();
+        Expr mapping1 = new FunctionCallExpr(FunctionSet.YEAR, params1);
+        columnExprs.add(new ImportColumnDesc(c1Name, mapping1));
+
+        new Expectations() {
+            {
+                table.getBaseSchema();
+                result = columns;
+                table.getColumn(c0Name);
+                result = columns.get(0);
+                table.getColumn(c1Name);
+                result = columns.get(1);
+            }
+        };
+
+        ExceptionChecker.expectThrowsWithMsg(UserException.class,
+                "Expr 'year()' analyze error: No matching function with signature: year(), derived column is 'c1'",
+                () -> Load.initColumns(table, columnExprs, null, exprsByName, analyzer, srcTupleDesc,
+                        slotDescByName, params, true, true, columnsFromPath));
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/service/FrontendServiceImplTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/service/FrontendServiceImplTest.java
@@ -1087,8 +1087,8 @@ public class FrontendServiceImplTest {
         List<String> errMsg = status.getError_msgs();
         Assert.assertEquals(1, errMsg.size());
         Assert.assertEquals(
-                "Getting analyzing error from line 1, column 24 to line 1, column 40. Detail message: " +
-                        "No matching function with signature: str_to_date(varchar).",
+                "Expr 'str_to_date(`col1`)' analyze error: No matching function with signature: str_to_date(varchar), " +
+                        "derived column is 'event_day'",
                 errMsg.get(0));
     }
 


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:

1. referenced column not found
```
mysql> show routine load\G
*************************** 1. row ***************************
                  Id: 217227
                Name: label0
          CreateTime: 2024-04-07 15:29:37
           PauseTime: 2024-04-07 15:59:11
             EndTime: NULL
              DbName: kafka_test
           TableName: lineorder
               State: PAUSED
      DataSourceType: KAFKA
      CurrentTaskNum: 0
       JobProperties: {"partitions":"*","rowDelimiter":"\t","partial_update":"false","columnToColumnExpr":"lo_orderkey,lo_linenumber,lo_custkey,lo_partkey,lo_suppkey,lo_orderdate,lo_orderpriority,lo_shippriority,lo_quantity,lo_extendedprice,lo_ordtotalprice,lo_discount,lo_revenue,lo_supplycost,lo_tax,lo_commitdate,lo_shipmode=lo_shipmode1 * 3","maxBatchIntervalS":"10","partial_update_mode":"null","whereExpr":"*","timezone":"Asia/Shanghai","format":"csv","columnSeparator":"'|'","log_rejected_record_num":"0","taskTimeoutSecond":"60","json_root":"","maxFilterRatio":"1.0","strict_mode":"false","jsonpaths":"","taskConsumeSecond":"15","desireTaskConcurrentNum":"5","maxErrorNum":"0","strip_outer_array":"false","currentTaskConcurrentNum":"1","maxBatchRows":"200000"}
DataSourceProperties: {"topic":"wyb_test","currentKafkaPartitions":"0","brokerList":"127.0.0.1:9093"}
    CustomProperties: {"group.id":"label0_8d03edfb-c3bc-4ca3-910f-f88fb609ae1f"}
           Statistic: {"receivedBytes":0,"errorRows":0,"committedTaskNum":0,"loadedRows":0,"loadRowsRate":0,"abortedTaskNum":1,"totalRows":0,"unselectedRows":0,"receivedBytesRate":0,"taskExecuteTimeMs":1}
            Progress: {"0":"2900563589"}
   TimestampProgress: {}
ReasonOfStateChanged: ErrorReason{errCode = 2, msg='failed to create task: Referenced column 'lo_shipmode1' in expr '`lo_shipmode1` * 3' can't be found in the column list, derived column is 'lo_shipmode''}
        ErrorLogUrls:
         TrackingSQL:
            OtherMsg:
LatestSourcePosition: {"0":"2900578208"}
1 row in set (0.20 sec)
```

2. column mapping expr invalid
```
mysql> show routine load\G
*************************** 1. row ***************************
                  Id: 218216
                Name: label0
          CreateTime: 2024-04-07 16:51:07
           PauseTime: 2024-04-07 17:11:15
             EndTime: NULL
              DbName: kafka_test
           TableName: t1
               State: PAUSED
      DataSourceType: KAFKA
      CurrentTaskNum: 0
       JobProperties: {"partitions":"*","rowDelimiter":"\t","partial_update":"false","columnToColumnExpr":"lo_orderkey,lo_linenumber,lo_custkey,lo_partkey,lo_suppkey,lo_orderdate,lo_orderpriority,lo_shippriority,lo_quantity,lo_extendedprice,lo_ordtotalprice,lo_discount,lo_revenue,lo_supplycost,lo_tax,lo_commitdate,lo_shipmode,k1=date(date_format(date_add('1970-01-01 00:00:00', INTERVAL lo_linenumber DAY)), '%Y-%m-%d'),k2=lo_linenumber","maxBatchIntervalS":"10","partial_update_mode":"null","whereExpr":"*","timezone":"Asia/Shanghai","format":"csv","columnSeparator":"'|'","log_rejected_record_num":"0","taskTimeoutSecond":"60","json_root":"","maxFilterRatio":"1.0","strict_mode":"false","jsonpaths":"","taskConsumeSecond":"15","desireTaskConcurrentNum":"5","maxErrorNum":"0","strip_outer_array":"false","currentTaskConcurrentNum":"1","maxBatchRows":"200000"}
DataSourceProperties: {"topic":"wyb_test","currentKafkaPartitions":"0","brokerList":"127.0.0.1:9093"}
    CustomProperties: {"group.id":"label0_aa06cfe8-0384-4fd8-bbe0-a182781acc16"}
           Statistic: {"receivedBytes":0,"errorRows":0,"committedTaskNum":0,"loadedRows":0,"loadRowsRate":0,"abortedTaskNum":7,"totalRows":0,"unselectedRows":0,"receivedBytesRate":0,"taskExecuteTimeMs":1}
            Progress: {"0":"2906860431"}
   TimestampProgress: {}
ReasonOfStateChanged: ErrorReason{errCode = 2, msg='failed to create task: Expr 'date(date_format(date_add('1970-01-01 00:00:00', INTERVAL `lo_linenumber` DAY)), '%Y-%m-%d')' analyze error: No matching function with signature: date_format(datetime), derived column is 'k1''}
        ErrorLogUrls:
         TrackingSQL:
            OtherMsg:
LatestSourcePosition: {"0":"2906875499"}
1 row in set (0.00 sec)
```

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [x] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [x] 3.2
  - [x] 3.1
  - [ ] 3.0
  - [ ] 2.5
