### PR TITLE
[Enhancement] improve struct performance

### DIFF
--- a/be/src/column/field.h
+++ b/be/src/column/field.h
@@ -18,6 +18,7 @@
 #include <string>
 #include <string_view>
 #include <utility>
+#include <vector>
 
 #include "column/vectorized_fwd.h"
 #include "storage/aggregate_type.h"
@@ -155,7 +156,11 @@ public:
 
     void add_sub_field(const Field& sub_field);
 
+    void set_sub_fields(const std::vector<Field>& sub_fields);
+
     const Field& sub_field(int i) const;
+
+    std::vector<Field>& sub_fields() { return *_sub_fields; }
 
     const std::vector<Field>& sub_fields() const { return *_sub_fields; }
 
@@ -197,6 +202,14 @@ inline void Field::set_is_key(bool is_key) {
     } else {
         _flags &= static_cast<uint8_t>(~(1 << kIsKeyShift));
     }
+}
+
+inline void Field::set_sub_fields(const std::vector<Field>& sub_fields) {
+    if (_sub_fields == nullptr) {
+        _sub_fields = new std::vector<Field>();
+    }
+    _sub_fields->clear();
+    _sub_fields->assign(sub_fields.begin(), sub_fields.end());
 }
 
 inline void Field::add_sub_field(const Field& sub_field) {

--- a/be/src/exec/pipeline/scan/olap_chunk_source.cpp
+++ b/be/src/exec/pipeline/scan/olap_chunk_source.cpp
@@ -15,7 +15,13 @@
 #include "exec/pipeline/scan/olap_chunk_source.h"
 
 #include <cstdint>
+#include <string_view>
+#include <unordered_map>
 
+#include "column/column.h"
+#include "column/column_access_path.h"
+#include "column/field.h"
+#include "common/status.h"
 #include "exec/olap_scan_node.h"
 #include "exec/olap_scan_prepare.h"
 #include "exec/pipeline/scan/olap_scan_context.h"
@@ -327,6 +333,63 @@ Status OlapChunkSource::_init_column_access_paths(Schema* schema) {
     return Status::OK();
 }
 
+Status prune_field_by_access_paths(Field* field, ColumnAccessPath* path) {
+    if (field->type()->type() == LogicalType::TYPE_ARRAY) {
+        DCHECK_EQ(path->children().size(), 1);
+        DCHECK_EQ(field->sub_fields().size(), 1);
+        RETURN_IF_ERROR(prune_field_by_access_paths(&field->sub_fields()[0], path->children()[0].get()));
+    } else if (field->type()->type() == LogicalType::TYPE_MAP) {
+        DCHECK_EQ(path->children().size(), 1);
+        auto child_path = path->children()[0].get();
+        if (child_path->is_index() || child_path->is_all()) {
+            DCHECK_EQ(field->sub_fields().size(), 2);
+            RETURN_IF_ERROR(prune_field_by_access_paths(&field->sub_fields()[1], child_path));
+        } else {
+            return Status::OK();
+        }
+    } else if (field->type()->type() == LogicalType::TYPE_STRUCT) {
+        std::unordered_map<std::string_view, ColumnAccessPath*> path_index;
+        for (auto& child_path : path->children()) {
+            path_index[child_path->path()] = child_path.get();
+        }
+
+        std::vector<Field> new_fields;
+        for (auto& child_fields : field->sub_fields()) {
+            auto iter = path_index.find(child_fields.name());
+            if (iter != path_index.end()) {
+                auto child_path = iter->second;
+                RETURN_IF_ERROR(prune_field_by_access_paths(&child_fields, child_path));
+                new_fields.emplace_back(child_fields);
+            }
+        }
+
+        field->set_sub_fields(std::move(new_fields));
+    }
+    return Status::OK();
+}
+
+Status OlapChunkSource::_prune_schema_by_access_paths(Schema* schema) {
+    if (_column_access_paths.empty()) {
+        return Status::OK();
+    }
+
+    // schema
+    for (auto& path : _column_access_paths) {
+        if (path->is_from_predicate()) {
+            continue;
+        }
+        auto& root = path->path();
+        auto field = schema->get_field_by_name(root);
+        if (field == nullptr) {
+            LOG(WARNING) << "failed to find column in schema: " << root;
+            continue;
+        }
+        RETURN_IF_ERROR(prune_field_by_access_paths(field.get(), path.get()));
+    }
+
+    return Status::OK();
+}
+
 Status OlapChunkSource::_init_olap_reader(RuntimeState* runtime_state) {
     const TOlapScanNode& thrift_olap_scan_node = _scan_node->thrift_olap_scan_node();
     // output columns of `this` OlapScanner, i.e, the final output columns of `get_chunk`.
@@ -359,6 +422,7 @@ Status OlapChunkSource::_init_olap_reader(RuntimeState* runtime_state) {
 
     starrocks::Schema child_schema = ChunkHelper::convert_schema(_tablet_schema, reader_columns);
     RETURN_IF_ERROR(_init_column_access_paths(&child_schema));
+    RETURN_IF_ERROR(_prune_schema_by_access_paths(&child_schema));
 
     std::vector<RowsetSharedPtr> rowsets;
     for (auto& rowset : _morsel->rowsets()) {

--- a/be/src/exec/pipeline/scan/olap_chunk_source.cpp
+++ b/be/src/exec/pipeline/scan/olap_chunk_source.cpp
@@ -334,6 +334,9 @@ Status OlapChunkSource::_init_column_access_paths(Schema* schema) {
 }
 
 Status prune_field_by_access_paths(Field* field, ColumnAccessPath* path) {
+    if (path->children().size() < 1) {
+        return Status::OK();
+    }
     if (field->type()->type() == LogicalType::TYPE_ARRAY) {
         DCHECK_EQ(path->children().size(), 1);
         DCHECK_EQ(field->sub_fields().size(), 1);

--- a/be/src/exec/pipeline/scan/olap_chunk_source.h
+++ b/be/src/exec/pipeline/scan/olap_chunk_source.h
@@ -68,6 +68,7 @@ private:
     void _update_realtime_counter(Chunk* chunk);
     void _decide_chunk_size(bool has_predicate);
     Status _init_column_access_paths(Schema* schema);
+    Status _prune_schema_by_access_paths(Schema* schema);
 
 private:
     TabletReaderParams _params{};

--- a/be/src/storage/rowset/struct_column_iterator.cpp
+++ b/be/src/storage/rowset/struct_column_iterator.cpp
@@ -14,10 +14,13 @@
 
 #include "storage/rowset/struct_column_iterator.h"
 
+#include <unordered_map>
+
 #include "column/column_access_path.h"
 #include "column/const_column.h"
 #include "column/nullable_column.h"
 #include "column/struct_column.h"
+#include "storage/rowset/column_iterator.h"
 #include "storage/rowset/column_reader.h"
 #include "storage/rowset/scalar_column_iterator.h"
 
@@ -64,7 +67,9 @@ private:
     std::vector<std::unique_ptr<ColumnIterator>> _field_iters;
     const ColumnAccessPath* _path;
 
-    std::vector<uint8_t> _access_flags;
+    // prune subfield by path
+    std::vector<ColumnIterator*> _access_iters;
+    std::unordered_map<int, int> _access_index_map;
 };
 
 StatusOr<std::unique_ptr<ColumnIterator>> create_struct_iter(ColumnReader* _reader,
@@ -90,12 +95,22 @@ Status StructColumnIterator::init(const ColumnIteratorOptions& opts) {
     }
 
     if (_path != nullptr && !_path->children().empty()) {
-        _access_flags.resize(_field_iters.size(), 0);
+        std::vector<ColumnAccessPath*> child_paths(_field_iters.size(), nullptr);
         for (const auto& child : _path->children()) {
-            _access_flags[child->index()] = 1;
+            child_paths[child->index()] = child.get();
+        }
+
+        for (int i = 0; i < _field_iters.size(); ++i) {
+            if (child_paths[i] != nullptr) {
+                _access_index_map[i] = _access_iters.size();
+                _access_iters.push_back(_field_iters[i].get());
+            }
         }
     } else {
-        _access_flags.resize(_field_iters.size(), 1);
+        for (int i = 0; i < _field_iters.size(); ++i) {
+            _access_index_map[i] = _access_iters.size();
+            _access_iters.push_back(_field_iters[i].get());
+        }
     }
 
     return Status::OK();
@@ -119,24 +134,11 @@ Status StructColumnIterator::next_batch(size_t* n, Column* dst) {
         down_cast<NullableColumn*>(dst)->update_has_null();
     }
 
-    size_t row_count = 0;
+    DCHECK_EQ(struct_column->fields_column().size(), _access_iters.size());
     auto& fields = struct_column->fields_column();
-    for (int i = 0; i < _field_iters.size(); ++i) {
-        if (_access_flags[i]) {
-            auto num_to_read = *n;
-            RETURN_IF_ERROR(_field_iters[i]->next_batch(&num_to_read, fields[i].get()));
-            row_count = fields[i]->size();
-        }
-    }
-
-    for (int i = 0; i < _field_iters.size(); ++i) {
-        if (!_access_flags[i]) {
-            if (!fields[i]->is_constant()) {
-                fields[i]->append_default(1);
-                fields[i] = ConstColumn::create(fields[i], 1);
-            }
-            fields[i]->resize(row_count);
-        }
+    for (int i = 0; i < _access_iters.size(); ++i) {
+        auto num_to_read = *n;
+        RETURN_IF_ERROR(_access_iters[i]->next_batch(&num_to_read, fields[i].get()));
     }
 
     return Status::OK();
@@ -158,25 +160,14 @@ Status StructColumnIterator::next_batch(const SparseRange<>& range, Column* dst)
         RETURN_IF_ERROR(_null_iter->next_batch(range, null_column));
         down_cast<NullableColumn*>(dst)->update_has_null();
     }
+
+    DCHECK_EQ(struct_column->fields_column().size(), _access_iters.size());
     // Read all fields
-    size_t row_count = 0;
     auto& fields = struct_column->fields_column();
-    for (int i = 0; i < _field_iters.size(); ++i) {
-        if (_access_flags[i]) {
-            RETURN_IF_ERROR(_field_iters[i]->next_batch(range, fields[i].get()));
-            row_count = fields[i]->size();
-        }
+    for (int i = 0; i < _access_iters.size(); ++i) {
+        RETURN_IF_ERROR(_access_iters[i]->next_batch(range, fields[i].get()));
     }
 
-    for (int i = 0; i < _field_iters.size(); ++i) {
-        if (!_access_flags[i]) {
-            if (!fields[i]->is_constant()) {
-                fields[i]->append_default(1);
-                fields[i] = ConstColumn::create(fields[i], 1);
-            }
-            fields[i]->resize(row_count);
-        }
-    }
     return Status::OK();
 }
 
@@ -194,25 +185,13 @@ Status StructColumnIterator::fetch_values_by_rowid(const rowid_t* rowids, size_t
         struct_column = down_cast<StructColumn*>(values);
     }
 
+    DCHECK_EQ(struct_column->fields_column().size(), _access_iters.size());
     // read all fields
     auto& fields = struct_column->fields_column();
-    size_t row_count = 0;
-    for (int i = 0; i < _field_iters.size(); ++i) {
-        if (_access_flags[i]) {
-            RETURN_IF_ERROR(_field_iters[i]->fetch_values_by_rowid(rowids, size, fields[i].get()));
-            row_count = fields[i]->size();
-        }
+    for (int i = 0; i < _access_iters.size(); ++i) {
+        RETURN_IF_ERROR(_access_iters[i]->fetch_values_by_rowid(rowids, size, fields[i].get()));
     }
 
-    for (int i = 0; i < _field_iters.size(); ++i) {
-        if (!_access_flags[i]) {
-            if (!fields[i]->is_constant()) {
-                fields[i]->append_default(1);
-                fields[i] = ConstColumn::create(fields[i], 1);
-            }
-            fields[i]->resize(row_count);
-        }
-    }
     return Status::OK();
 }
 
@@ -220,7 +199,7 @@ Status StructColumnIterator::seek_to_first() {
     if (_null_iter != nullptr) {
         RETURN_IF_ERROR(_null_iter->seek_to_first());
     }
-    for (auto& iter : _field_iters) {
+    for (auto& iter : _access_iters) {
         RETURN_IF_ERROR(iter->seek_to_first());
     }
     return Status::OK();
@@ -230,7 +209,7 @@ Status StructColumnIterator::seek_to_ordinal(ordinal_t ord) {
     if (_null_iter != nullptr) {
         RETURN_IF_ERROR(_null_iter->seek_to_ordinal(ord));
     }
-    for (auto& iter : _field_iters) {
+    for (auto& iter : _access_iters) {
         RETURN_IF_ERROR(iter->seek_to_ordinal(ord));
     }
     return Status::OK();
@@ -251,11 +230,12 @@ Status StructColumnIterator::next_batch(size_t* n, Column* dst, ColumnAccessPath
     // 1. init predicate access path
     std::vector<uint8_t> predicate_access_flags;
     std::vector<ColumnAccessPath*> predicate_child_paths;
-    predicate_access_flags.resize(_field_iters.size(), 0);
-    predicate_child_paths.resize(_field_iters.size(), nullptr);
+    predicate_access_flags.resize(_access_iters.size(), 0);
+    predicate_child_paths.resize(_access_iters.size(), nullptr);
     for (const auto& child : path->children()) {
-        predicate_access_flags[child->index()] = 1;
-        predicate_child_paths[child->index()] = child.get();
+        auto index = _access_index_map[child->index()];
+        predicate_access_flags[index] = 1;
+        predicate_child_paths[index] = child.get();
     }
 
     StructColumn* struct_column = nullptr;
@@ -274,23 +254,21 @@ Status StructColumnIterator::next_batch(size_t* n, Column* dst, ColumnAccessPath
         down_cast<NullableColumn*>(dst)->update_has_null();
     }
 
+    DCHECK_EQ(struct_column->fields_column().size(), _access_iters.size());
     // 3. Read fields
     size_t row_count = 0;
     auto& fields = struct_column->fields_column();
-    for (int i = 0; i < _field_iters.size(); ++i) {
+    for (int i = 0; i < _access_iters.size(); ++i) {
         if (predicate_access_flags[i]) {
             auto num_to_read = *n;
-            RETURN_IF_ERROR(_field_iters[i]->next_batch(&num_to_read, fields[i].get(), predicate_child_paths[i]));
+            RETURN_IF_ERROR(_access_iters[i]->next_batch(&num_to_read, fields[i].get(), predicate_child_paths[i]));
             row_count = fields[i]->size();
         }
     }
 
-    for (int i = 0; i < _field_iters.size(); ++i) {
+    for (int i = 0; i < _access_iters.size(); ++i) {
         if (!predicate_access_flags[i]) {
-            if (!fields[i]->is_constant()) {
-                fields[i]->append_default(1);
-                fields[i] = ConstColumn::create(fields[i], 1);
-            }
+            DCHECK(fields[i]->is_constant());
             fields[i]->resize(row_count);
         }
     }
@@ -304,11 +282,13 @@ Status StructColumnIterator::next_batch(const SparseRange<>& range, Column* dst,
 
     std::vector<uint8_t> predicate_access_flags;
     std::vector<ColumnAccessPath*> predicate_child_paths;
-    predicate_access_flags.resize(_field_iters.size(), 0);
-    predicate_child_paths.resize(_field_iters.size(), nullptr);
+
+    predicate_access_flags.resize(_access_iters.size(), 0);
+    predicate_child_paths.resize(_access_iters.size(), nullptr);
     for (const auto& child : path->children()) {
-        predicate_access_flags[child->index()] = 1;
-        predicate_child_paths[child->index()] = child.get();
+        auto index = _access_index_map[child->index()];
+        predicate_access_flags[index] = 1;
+        predicate_child_paths[index] = child.get();
     }
 
     StructColumn* struct_column = nullptr;
@@ -329,15 +309,15 @@ Status StructColumnIterator::next_batch(const SparseRange<>& range, Column* dst,
     // Read all fields
     size_t row_count = 0;
     auto& fields = struct_column->fields_column();
-    for (int i = 0; i < _field_iters.size(); ++i) {
+    for (int i = 0; i < _access_iters.size(); ++i) {
         if (!predicate_access_flags[i]) {
             continue;
         }
-        RETURN_IF_ERROR(_field_iters[i]->next_batch(range, fields[i].get(), predicate_child_paths[i]));
+        RETURN_IF_ERROR(_access_iters[i]->next_batch(range, fields[i].get(), predicate_child_paths[i]));
         row_count = fields[i]->size();
     }
 
-    for (int i = 0; i < _field_iters.size(); ++i) {
+    for (int i = 0; i < _access_iters.size(); ++i) {
         if (!predicate_access_flags[i]) {
             if (!fields[i]->is_constant()) {
                 fields[i]->append_default(1);
@@ -359,32 +339,20 @@ Status StructColumnIterator::fetch_subfield_by_rowid(const rowid_t* rowids, size
         struct_column = down_cast<StructColumn*>(values);
     }
 
+    DCHECK_EQ(struct_column->fields_column().size(), _access_iters.size());
     // read all fields
     auto& fields = struct_column->fields_column();
-    size_t row_count = 0;
-    for (int i = 0; i < _field_iters.size(); ++i) {
-        if (_access_flags[i]) {
-            if (fields[i]->is_constant()) {
-                // doesn't meterialized
-                fields[i] = down_cast<ConstColumn*>(fields[i].get())->data_column()->clone_empty();
-                RETURN_IF_ERROR(_field_iters[i]->fetch_values_by_rowid(rowids, size, fields[i].get()));
-            } else {
-                // handle nested struct
-                // structA -> structB -> e (meterialized)
-                //                    -> f (un-meterialized)
-                RETURN_IF_ERROR(_field_iters[i]->fetch_subfield_by_rowid(rowids, size, fields[i].get()));
-            }
-            row_count = fields[i]->size();
-        }
-    }
-
-    for (int i = 0; i < _field_iters.size(); ++i) {
-        if (!_access_flags[i]) {
-            if (!fields[i]->is_constant()) {
-                fields[i]->append_default(1);
-                fields[i] = ConstColumn::create(fields[i], 1);
-            }
-            fields[i]->resize(row_count);
+    for (int i = 0; i < _access_iters.size(); ++i) {
+        if (fields[i]->is_constant()) {
+            // doesn't meterialized
+            fields[i] = down_cast<ConstColumn*>(fields[i].get())->data_column();
+            fields[i]->resize_uninitialized(0);
+            RETURN_IF_ERROR(_access_iters[i]->fetch_values_by_rowid(rowids, size, fields[i].get()));
+        } else {
+            // handle nested struct
+            // structA -> structB -> e (meterialized)
+            //                    -> f (un-meterialized)
+            RETURN_IF_ERROR(_access_iters[i]->fetch_subfield_by_rowid(rowids, size, fields[i].get()));
         }
     }
     return Status::OK();

--- a/be/test/storage/rowset/struct_column_rw_test.cpp
+++ b/be/test/storage/rowset/struct_column_rw_test.cpp
@@ -188,7 +188,7 @@ protected:
                 Columns dst_columns;
                 dst_columns.emplace_back(std::move(dst_f1_column));
 
-                ColumnPtr dst_column = StructColumn::create(dst_columns, names);
+                ColumnPtr dst_column = StructColumn::create(dst_columns, std::vector<std::string>{"f1"});
                 size_t rows_read = src_column->size();
                 st = iter->next_batch(&rows_read, dst_column.get());
                 ASSERT_TRUE(st.ok());
@@ -222,7 +222,7 @@ protected:
                 Columns dst_columns;
                 dst_columns.emplace_back(std::move(dst_f2_column));
 
-                ColumnPtr dst_column = StructColumn::create(dst_columns, names);
+                ColumnPtr dst_column = StructColumn::create(dst_columns, std::vector<std::string>{"f2"});
                 size_t rows_read = src_column->size();
                 st = iter->next_batch(&rows_read, dst_column.get());
                 ASSERT_TRUE(st.ok());

--- a/be/test/storage/rowset/struct_column_rw_test.cpp
+++ b/be/test/storage/rowset/struct_column_rw_test.cpp
@@ -185,10 +185,8 @@ protected:
                 ASSERT_TRUE(st.ok()) << st.to_string();
 
                 auto dst_f1_column = Int32Column::create();
-                auto dst_f2_column = BinaryColumn::create();
                 Columns dst_columns;
                 dst_columns.emplace_back(std::move(dst_f1_column));
-                dst_columns.emplace_back(std::move(dst_f2_column));
 
                 ColumnPtr dst_column = StructColumn::create(dst_columns, names);
                 size_t rows_read = src_column->size();
@@ -196,7 +194,7 @@ protected:
                 ASSERT_TRUE(st.ok());
                 ASSERT_EQ(src_column->size(), rows_read);
 
-                ASSERT_EQ("{f1:1,f2:''}", dst_column->debug_item(0));
+                ASSERT_EQ("{f1:1}", dst_column->debug_item(0));
             }
         }
 
@@ -220,10 +218,8 @@ protected:
                 auto st = iter->seek_to_first();
                 ASSERT_TRUE(st.ok()) << st.to_string();
 
-                auto dst_f1_column = Int32Column::create();
                 auto dst_f2_column = BinaryColumn::create();
                 Columns dst_columns;
-                dst_columns.emplace_back(std::move(dst_f1_column));
                 dst_columns.emplace_back(std::move(dst_f2_column));
 
                 ColumnPtr dst_column = StructColumn::create(dst_columns, names);
@@ -232,7 +228,7 @@ protected:
                 ASSERT_TRUE(st.ok());
                 ASSERT_EQ(src_column->size(), rows_read);
 
-                ASSERT_EQ("{f1:CONST: 0,f2:'Column2'}", dst_column->debug_item(0));
+                ASSERT_EQ("{f2:'Column2'}", dst_column->debug_item(0));
             }
         }
     }

--- a/be/test/storage/rowset/struct_column_rw_test.cpp
+++ b/be/test/storage/rowset/struct_column_rw_test.cpp
@@ -196,7 +196,7 @@ protected:
                 ASSERT_TRUE(st.ok());
                 ASSERT_EQ(src_column->size(), rows_read);
 
-                ASSERT_EQ("{f1:1,f2:CONST: ''}", dst_column->debug_item(0));
+                ASSERT_EQ("{f1:1,f2:''}", dst_column->debug_item(0));
             }
         }
 


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:
Improve struct performance, to prune unused subfield in schema, then the `xx_iterator` dones't init unused subfield
save 20%~50% costs

test case: 
SSB 100GB

|   WITH_PREDICATE  |   ORIGN   |   ORIGIN(DISABLE low_cardinality) |   STRUCT(BEFORE PR)   |   STRUCT(THIS PR) |   STRUCT BEFORE/PR   |   ORIGIN/PR  |
|   ----    |   ----    |   ----    |   ----    |   ----    |   ----    |   ----    |
|   Q01 |   84  |   82  |   404 |   141 |   2.87    |   1.68    |
|   Q02 |   16  |   16  |   57  |   24  |   2.38    |   1.50    |
|   Q03 |   58  |   83  |   151 |   113 |   1.34    |   1.95    |
|   Q04 |   830 |   840 |   3821    |   2733    |   1.40    |   3.29    |
|   Q05 |   686 |   678 |   3421    |   2205    |   1.55    |   3.21    |
|   Q06 |   525 |   517 |   2747    |   1912    |   1.44    |   3.64    |
|   Q07 |   779 |   870 |   3695    |   2642    |   1.40    |   3.39    |
|   Q08 |   631 |   652 |   2950    |   1848    |   1.60    |   2.93    |
|   Q09 |   432 |   428 |   1986    |   1585    |   1.25    |   3.67    |
|   Q10 |   21  |   20  |   58  |   40  |   1.45    |   1.90    |
|   Q11 |   975 |   1009    |   5077    |   4019    |   1.26    |   4.12    |
|   Q12 |   314 |   337 |   1427    |   1133    |   1.26    |   3.61    |
|   Q13 |   242 |   248 |   886 |   619 |   1.43    |   2.56    |

Q4~Q9 looks struct query is more poor than scalar, I think the reason is that the struct predicate can't use zone_map

then I remove all struct predicate and scalar predicate, and disable low_cardinality:

|   NO_PREDICATE    |   ORIGN   |   ORIGIN(DISABLE low_cardinality) |   STRUCT(BEFORE PR)   |   STRUCT(THIS PR) |   STRUCT BEFORE/PR    |   ORIGIN/PR  |
|   ----    |   ----    |   ----    |   ----    |   ----    |   ----    |   ----    |
|   Q01 |   83  |   80  |   350 |   113 |   3.10    |   1.41    |
|   Q02 |   19  |   14  |   53  |   20  |   2.65    |   1.43    |
|   Q03 |   63  |   60  |   87  |   64  |   1.36    |   1.07    |
|   Q04 |   2097    |   2146    |   3721    |   2635    |   1.41    |   1.23    |
|   Q05 |   2123    |   2087    |   3692    |   2666    |   1.38    |   1.28    |
|   Q06 |   2120    |   2108    |   3632    |   2679    |   1.36    |   1.27    |
|   Q07 |   1308    |   3850    |   4215    |   3378    |   1.25    |   0.88    |
|   Q08 |   6560    |   12596   |   14337   |   12842   |   1.12    |   1.02    |
|   Q09 |   6396    |   12485   |   14247   |   12909   |   1.10    |   1.03    |

it's looks more similar in Q8~Q9, but Q4 ~ Q7 diff 600ms. Through the flame graph, I think the reason is that the struct contains null values, while the scalar column doesn't

|   NO_PREDICATE    |   ORIGN(Nullable) |   ORIGIN(DISABLE low_cardinality) |   STRUCT(BEFORE PR)   |   STRUCT(THIS PR) |   BEFORE/PR    |   ORIGIN/PR    |
|   ----    |   ----    |   ----    |   ----    |   ----    |   ----    |   ----    |
|   Q01 |   91  |   94  |   350 |   113 |   3.10    |   1.20    |
|   Q02 |   16  |   18  |   53  |   20  |   2.65    |   1.11    |
|   Q03 |   63  |   65  |   87  |   64  |   1.36    |   0.98    |
|   Q04 |   2549    |   2589    |   3721    |   2635    |   1.41    |   1.02    |
|   Q05 |   2583    |   2617    |   3692    |   2666    |   1.38    |   1.02    |
|   Q06 |   2591    |   2581    |   3632    |   2679    |   1.36    |   1.04    |
|   Q07 |   1645    |   4108    |   4215    |   3378    |   1.25    |   0.82    |
|   Q08 |   7132    |   13436   |   14337   |   12842   |   1.12    |   0.96    |
|   Q09 |   7101    |   13841   |   14247   |   12909   |   1.10    |   0.93    |

now the performance looks similar.

next performance optimization point:
* zone_map_filter on struct
* low_cardinality on struct
* nullable on struct

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
