### PR TITLE
[BugFix] Fix memory limit exceeded problem when writing a partitioned Parquet table

### DIFF
--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -1258,6 +1258,9 @@ CONF_mInt64(pk_dump_interval_seconds, "3600"); // 1 hour
 // Min data processed when scaling connector sink writers, default value is the same as Trino
 CONF_mInt64(writer_scaling_min_size_mb, "128");
 
+// Memory threshold for Parquet writer before a flush, should be greater than 0 and less than 1
+CONF_mDouble(parquet_writer_mem_usage_threshold, "0.8");
+
 // whether enable query profile for queries initiated by spark or flink
 CONF_mBool(enable_profile_for_external_plan, "false");
 


### PR DESCRIPTION
## Why I'm doing:

We may encounter the following problem when writing a Parquet table with lots of partitions by connector sink. (e.g. partitioned by dayofyear(xxxx))

```
Used: 23943372128, Limit: 23942823063. Mem usage has exceed the limit of query pool
```
This PR fixs the problem by flushing row groups when memory usage of a BE almost reaches the threshold, which is 80% of the total memory by default.

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
