### PR TITLE
[Enhancement]Support get stats for subfield of struct type from statistics storage

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/connector/statistics/ConnectorHistogramColumnStatsCacheLoader.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/statistics/ConnectorHistogramColumnStatsCacheLoader.java
@@ -16,11 +16,9 @@ package com.starrocks.connector.statistics;
 
 import com.github.benmanes.caffeine.cache.AsyncCacheLoader;
 import com.google.common.collect.Lists;
-import com.starrocks.catalog.Column;
 import com.starrocks.catalog.Table;
+import com.starrocks.catalog.Type;
 import com.starrocks.common.AnalysisException;
-import com.starrocks.common.ErrorCode;
-import com.starrocks.common.ErrorReport;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.sql.optimizer.statistics.Bucket;
 import com.starrocks.sql.optimizer.statistics.Histogram;
@@ -122,12 +120,9 @@ public class ConnectorHistogramColumnStatsCacheLoader implements
 
     private Histogram convert2Histogram(String tableUUID, TStatisticData statisticData) throws AnalysisException {
         Table table = getTableByUUID(tableUUID);
-        Column column = table.getColumn(statisticData.columnName);
-        if (column == null) {
-            ErrorReport.reportAnalysisException(ErrorCode.ERR_BAD_FIELD_ERROR, statisticData.columnName);
-        }
+        Type columnType = StatisticUtils.getQueryStatisticsColumnType(table, statisticData.columnName);
 
-        List<Bucket> buckets = HistogramUtils.convertBuckets(statisticData.histogram, column.getType());
+        List<Bucket> buckets = HistogramUtils.convertBuckets(statisticData.histogram, columnType);
         Map<String, Long> mcv = HistogramUtils.convertMCV(statisticData.histogram);
         return new Histogram(buckets, mcv);
     }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/Optimizer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/Optimizer.java
@@ -442,7 +442,11 @@ public class Optimizer {
         ruleRewriteIterative(tree, rootTaskContext, RuleSetType.PRUNE_UKFK_JOIN);
         deriveLogicalProperty(tree);
 
+        ruleRewriteOnlyOnce(tree, rootTaskContext, new PushDownJoinOnExpressionToChildProject());
+        // apply skew join optimize after push down join on expression to child project,
+        // we need to compute the stats of child project(like subfield).
         skewJoinOptimize(tree, rootTaskContext);
+        // skew join generate new join and on predicate, need to push down join on expression to child project again
         ruleRewriteOnlyOnce(tree, rootTaskContext, new PushDownJoinOnExpressionToChildProject());
 
         ruleRewriteIterative(tree, rootTaskContext, new PruneEmptyWindowRule());

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/Optimizer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/Optimizer.java
@@ -446,8 +446,6 @@ public class Optimizer {
         // apply skew join optimize after push down join on expression to child project,
         // we need to compute the stats of child project(like subfield).
         skewJoinOptimize(tree, rootTaskContext);
-        // skew join generate new join and on predicate, need to push down join on expression to child project again
-        ruleRewriteOnlyOnce(tree, rootTaskContext, new PushDownJoinOnExpressionToChildProject());
 
         ruleRewriteIterative(tree, rootTaskContext, new PruneEmptyWindowRule());
         // @todo: resolve recursive optimization question:
@@ -663,8 +661,13 @@ public class Optimizer {
 
     private void skewJoinOptimize(OptExpression tree, TaskContext rootTaskContext) {
         SkewJoinOptimizeRule rule = new SkewJoinOptimizeRule();
+        // merge projects before calculate statistics
+        ruleRewriteOnlyOnce(tree, rootTaskContext, new MergeTwoProjectRule());
         Utils.calculateStatistics(tree, rootTaskContext.getOptimizerContext());
-        ruleRewriteOnlyOnce(tree, rootTaskContext, rule);
+        if (ruleRewriteOnlyOnce(tree, rootTaskContext, rule)) {
+            // skew join generate new join and on predicate, need to push down join on expression to child project again
+            ruleRewriteOnlyOnce(tree, rootTaskContext, new PushDownJoinOnExpressionToChildProject());
+        }
     }
 
     private OptExpression pruneSubfield(OptExpression tree, TaskContext rootTaskContext, ColumnRefSet requiredColumns) {
@@ -874,13 +877,15 @@ public class Optimizer {
         context.getTaskScheduler().executeTasks(rootTaskContext);
     }
 
-    private void ruleRewriteOnlyOnce(OptExpression tree, TaskContext rootTaskContext, Rule rule) {
+    private boolean ruleRewriteOnlyOnce(OptExpression tree, TaskContext rootTaskContext, Rule rule) {
         if (optimizerConfig.isRuleDisable(rule.type())) {
-            return;
+            return false;
         }
         List<Rule> rules = Collections.singletonList(rule);
-        context.getTaskScheduler().pushTask(new RewriteTreeTask(rootTaskContext, tree, rules, true));
+        RewriteTreeTask rewriteTreeTask = new RewriteTreeTask(rootTaskContext, tree, rules, true);
+        context.getTaskScheduler().pushTask(rewriteTreeTask);
         context.getTaskScheduler().executeTasks(rootTaskContext);
+        return rewriteTreeTask.hasChange();
     }
 
     private void prepareMetaOnlyOnce(OptExpression tree, TaskContext rootTaskContext) {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/Utils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/Utils.java
@@ -63,6 +63,7 @@ import org.roaringbitmap.RoaringBitmap;
 import java.time.Instant;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.BitSet;
 import java.util.Collection;
@@ -181,6 +182,13 @@ public class Utils {
         }
 
         return count;
+    }
+
+    public static List<Operator> collectScanOperators(OptExpression tree) {
+        List<Operator> scanOperators = new ArrayList<>();
+        Utils.extractOperator(tree, scanOperators, op -> op instanceof LogicalScanOperator ||
+                op instanceof PhysicalOlapScanOperator);
+        return scanOperators;
     }
 
     public static void extractOlapScanOperator(GroupExpression groupExpression, List<LogicalOlapScanOperator> list) {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/Utils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/Utils.java
@@ -63,7 +63,6 @@ import org.roaringbitmap.RoaringBitmap;
 import java.time.Instant;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.BitSet;
 import java.util.Collection;
@@ -182,13 +181,6 @@ public class Utils {
         }
 
         return count;
-    }
-
-    public static List<Operator> collectScanOperators(OptExpression tree) {
-        List<Operator> scanOperators = new ArrayList<>();
-        Utils.extractOperator(tree, scanOperators, op -> op instanceof LogicalScanOperator ||
-                op instanceof PhysicalOlapScanOperator);
-        return scanOperators;
     }
 
     public static void extractOlapScanOperator(GroupExpression groupExpression, List<LogicalOlapScanOperator> list) {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/scalar/SubfieldOperator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/scalar/SubfieldOperator.java
@@ -139,4 +139,16 @@ public class SubfieldOperator extends ScalarOperator {
     public ColumnRefSet getUsedColumns() {
         return getChild(0).getUsedColumns();
     }
+
+    public String getPath() {
+        String childPath = getChildPath();
+        return childPath + "." + Joiner.on('.').join(fieldNames);
+    }
+
+    private String getChildPath() {
+        if (children.get(0) instanceof ColumnRefOperator) {
+            return ((ColumnRefOperator) children.get(0)).getName();
+        }
+        return children.get(0).toString();
+    }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/ColumnHistogramStatsCacheLoader.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/ColumnHistogramStatsCacheLoader.java
@@ -16,10 +16,10 @@ package com.starrocks.sql.optimizer.statistics;
 
 import com.github.benmanes.caffeine.cache.AsyncCacheLoader;
 import com.google.common.collect.Lists;
-import com.starrocks.catalog.Column;
 import com.starrocks.catalog.Database;
 import com.starrocks.catalog.OlapTable;
 import com.starrocks.catalog.Table;
+import com.starrocks.catalog.Type;
 import com.starrocks.common.AnalysisException;
 import com.starrocks.common.ErrorCode;
 import com.starrocks.common.ErrorReport;
@@ -124,12 +124,9 @@ public class ColumnHistogramStatsCacheLoader implements AsyncCacheLoader<ColumnS
         if (!(table instanceof OlapTable)) {
             ErrorReport.reportAnalysisException(ErrorCode.ERR_BAD_TABLE_ERROR, statisticData.tableId);
         }
-        Column column = table.getColumn(statisticData.columnName);
-        if (column == null) {
-            ErrorReport.reportAnalysisException(ErrorCode.ERR_BAD_FIELD_ERROR, statisticData.columnName);
-        }
+        Type columnType = StatisticUtils.getQueryStatisticsColumnType(table, statisticData.columnName);
 
-        List<Bucket> buckets = HistogramUtils.convertBuckets(statisticData.histogram, column.getType());
+        List<Bucket> buckets = HistogramUtils.convertBuckets(statisticData.histogram, columnType);
         Map<String, Long> mcv = HistogramUtils.convertMCV(statisticData.histogram);
         return new Histogram(buckets, mcv);
     }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/StatisticsCalculator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/StatisticsCalculator.java
@@ -16,6 +16,7 @@ package com.starrocks.sql.optimizer.statistics;
 
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Range;
@@ -36,6 +37,7 @@ import com.starrocks.catalog.Table;
 import com.starrocks.catalog.Type;
 import com.starrocks.common.AnalysisException;
 import com.starrocks.common.Pair;
+import com.starrocks.connector.statistics.ConnectorTableColumnStats;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.qe.SessionVariable;
 import com.starrocks.server.GlobalStateMgr;
@@ -132,6 +134,7 @@ import com.starrocks.sql.optimizer.operator.scalar.ConstantOperator;
 import com.starrocks.sql.optimizer.operator.scalar.InPredicateOperator;
 import com.starrocks.sql.optimizer.operator.scalar.PredicateOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ScalarOperator;
+import com.starrocks.sql.optimizer.operator.scalar.SubfieldOperator;
 import com.starrocks.sql.optimizer.operator.stream.LogicalBinlogScanOperator;
 import com.starrocks.sql.optimizer.operator.stream.PhysicalStreamScanOperator;
 import com.starrocks.statistic.StatisticUtils;
@@ -217,14 +220,64 @@ public class StatisticsCalculator extends OperatorVisitor<Void, ExpressionContex
 
         Projection projection = node.getProjection();
         if (projection != null) {
+            Map<ColumnRefOperator, SubfieldOperator> subfieldColumns = Maps.newHashMap();
             Preconditions.checkState(projection.getCommonSubOperatorMap().isEmpty());
             for (Map.Entry<ColumnRefOperator, ScalarOperator> entry : projection.getColumnRefMap().entrySet()) {
-                statisticsBuilder.addColumnStatistic(entry.getKey(),
-                        ExpressionStatisticCalculator.calculate(entry.getValue(), statisticsBuilder.build()));
+                if (entry.getValue() instanceof SubfieldOperator && (node instanceof LogicalScanOperator ||
+                        node instanceof PhysicalScanOperator)) {
+                    subfieldColumns.put(entry.getKey(), (SubfieldOperator) entry.getValue());
+                } else {
+                    statisticsBuilder.addColumnStatistic(entry.getKey(),
+                            ExpressionStatisticCalculator.calculate(entry.getValue(), statisticsBuilder.build()));
+                }
+            }
+            // for subfield operator, we get the statistics from statistics storage
+            if (!subfieldColumns.isEmpty()) {
+                addSubFiledStatistics(node, subfieldColumns, statisticsBuilder);
             }
         }
         context.setStatistics(statisticsBuilder.build());
         return null;
+    }
+
+    private void addSubFiledStatistics(Operator node, Map<ColumnRefOperator, SubfieldOperator> subfieldColumns,
+                                       Statistics.Builder statisticsBuilder) {
+        if (!(node instanceof LogicalScanOperator) && !(node instanceof PhysicalScanOperator)) {
+            return;
+        }
+
+        Table table = node.isLogical() ? ((LogicalScanOperator) node).getTable() :
+                ((PhysicalScanOperator) node).getTable();
+
+        List<Pair<String, ColumnRefOperator>> columnRefPairs = subfieldColumns.entrySet().stream()
+                .map(entry -> Pair.create(entry.getValue().getPath(), entry.getKey())).collect(Collectors.toList());
+        List<String> columnNames = columnRefPairs.stream().map(p -> p.first).collect(Collectors.toList());
+
+        List<ColumnStatistic> columnStatisticList;
+        Map<String, Histogram> histogramStatistics;
+        if (table.isNativeTableOrMaterializedView()) {
+            columnStatisticList = GlobalStateMgr.getCurrentState().getStatisticStorage().getColumnStatistics(table,
+                            columnNames);
+            histogramStatistics = GlobalStateMgr.getCurrentState().getStatisticStorage().getHistogramStatistics(table,
+                            columnNames);
+        } else {
+            columnStatisticList = GlobalStateMgr.getCurrentState().getStatisticStorage().getConnectorTableStatistics(table,
+                    columnNames).stream().map(ConnectorTableColumnStats::getColumnStatistic).collect(Collectors.toList());
+            histogramStatistics = GlobalStateMgr.getCurrentState().getStatisticStorage().
+                    getConnectorHistogramStatistics(table, columnNames);
+        }
+        for (int i = 0; i < columnNames.size(); ++i) {
+            String columnName = columnNames.get(i);
+            ColumnRefOperator columnRef = columnRefPairs.get(i).second;
+            if (histogramStatistics.containsKey(columnName)) {
+                Histogram histogram = histogramStatistics.get(columnName);
+                statisticsBuilder.addColumnStatistic(columnRef, ColumnStatistic.buildFrom(
+                                columnStatisticList.get(i)).
+                        setHistogram(histogram).build());
+            } else {
+                statisticsBuilder.addColumnStatistic(columnRef, columnStatisticList.get(i));
+            }
+        }
     }
 
     @Override
@@ -680,7 +733,16 @@ public class StatisticsCalculator extends OperatorVisitor<Void, ExpressionContex
 
         for (ColumnRefOperator requiredColumnRefOperator : columnRefMap.keySet()) {
             ScalarOperator mapOperator = columnRefMap.get(requiredColumnRefOperator);
-            ColumnStatistic outputStatistic = ExpressionStatisticCalculator.calculate(mapOperator, allBuilder.build());
+            if (mapOperator instanceof SubfieldOperator && context.getOptExpression() != null) {
+                List<Operator> scanOperators = Utils.collectScanOperators(context.getOptExpression());
+                if (scanOperators.size() == 1) {
+                    addSubFiledStatistics(scanOperators.get(0), ImmutableMap.of(requiredColumnRefOperator,
+                                    (SubfieldOperator) mapOperator), builder);
+                    continue;
+                }
+            }
+            ColumnStatistic outputStatistic =
+                    ExpressionStatisticCalculator.calculate(mapOperator, allBuilder.build());
             builder.addColumnStatistic(requiredColumnRefOperator, outputStatistic);
             allBuilder.addColumnStatistic(requiredColumnRefOperator, outputStatistic);
         }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/StatisticsCalculator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/StatisticsCalculator.java
@@ -734,9 +734,9 @@ public class StatisticsCalculator extends OperatorVisitor<Void, ExpressionContex
         for (ColumnRefOperator requiredColumnRefOperator : columnRefMap.keySet()) {
             ScalarOperator mapOperator = columnRefMap.get(requiredColumnRefOperator);
             if (mapOperator instanceof SubfieldOperator && context.getOptExpression() != null) {
-                List<Operator> scanOperators = Utils.collectScanOperators(context.getOptExpression());
-                if (scanOperators.size() == 1) {
-                    addSubFiledStatistics(scanOperators.get(0), ImmutableMap.of(requiredColumnRefOperator,
+                Operator child = context.getOptExpression().inputAt(0).getOp();
+                if (child instanceof LogicalScanOperator || child instanceof PhysicalScanOperator) {
+                    addSubFiledStatistics(child, ImmutableMap.of(requiredColumnRefOperator,
                                     (SubfieldOperator) mapOperator), builder);
                     continue;
                 }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/task/RewriteTreeTask.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/task/RewriteTreeTask.java
@@ -139,4 +139,8 @@ public class RewriteTreeTask extends OptimizerTask {
             root.setLogicalProperty(context.getRootProperty());
         }
     }
+
+    public boolean hasChange() {
+        return change > 0;
+    }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AnalyzeStmtTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AnalyzeStmtTest.java
@@ -295,7 +295,7 @@ public class AnalyzeStmtTest {
                         "FROM column_statistics WHERE table_id = %d and column_name = \"v2\" " +
                         "GROUP BY db_id, table_id, column_name"), table.getId(), table.getId()),
                 StatisticSQLBuilder.buildQueryFullStatisticsSQL(database.getId(), table.getId(),
-                        Lists.newArrayList(v1, v2)));
+                        Lists.newArrayList("v1", "v2"), Lists.newArrayList(v1.getType(), v2.getType())));
 
         Assert.assertEquals(String.format(
                 "SELECT cast(1 as INT), update_time, db_id, table_id, column_name, row_count, " +
@@ -444,7 +444,7 @@ public class AnalyzeStmtTest {
                 "FROM column_statistics WHERE table_id = (\\d+) and column_name = \"kk2\" " +
                 "GROUP BY db_id, table_id, column_name";
         String content = StatisticSQLBuilder.buildQueryFullStatisticsSQL(database.getId(), table.getId(),
-                Lists.newArrayList(kk1, kk2));
+                Lists.newArrayList("kk1", "kk2"), Lists.newArrayList(kk1.getType(), kk2.getType()));
         Assert.assertTrue(Pattern.matches(pattern, content));
     }
 

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/SplitScanToUnionTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/SplitScanToUnionTest.java
@@ -17,7 +17,7 @@ package com.starrocks.sql.plan;
 import com.google.api.client.util.Lists;
 import com.google.common.collect.ImmutableList;
 import com.starrocks.common.FeConstants;
-import com.starrocks.statistic.MockTPCHHistogramStatisticStorage;
+import com.starrocks.statistic.MockHistogramStatisticStorage;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.MethodOrderer;
@@ -44,7 +44,7 @@ class SplitScanToUnionTest extends DistributedEnvPlanTestBase {
         connectContext.getSessionVariable().setEnableLowCardinalityOptimize(true);
 
         int scale = 100;
-        connectContext.getGlobalStateMgr().setStatisticStorage(new MockTPCHHistogramStatisticStorage(scale));
+        connectContext.getGlobalStateMgr().setStatisticStorage(new MockHistogramStatisticStorage(scale));
     }
 
     @ParameterizedTest

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/TPCHPlanWithHistogramCostTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/TPCHPlanWithHistogramCostTest.java
@@ -20,7 +20,7 @@ import com.starrocks.catalog.OlapTable;
 import com.starrocks.common.FeConstants;
 import com.starrocks.planner.TpchSQL;
 import com.starrocks.server.GlobalStateMgr;
-import com.starrocks.statistic.MockTPCHHistogramStatisticStorage;
+import com.starrocks.statistic.MockHistogramStatisticStorage;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -42,7 +42,7 @@ public class TPCHPlanWithHistogramCostTest extends DistributedEnvPlanTestBase {
 
         GlobalStateMgr globalStateMgr = connectContext.getGlobalStateMgr();
         int scale = 100;
-        connectContext.getGlobalStateMgr().setStatisticStorage(new MockTPCHHistogramStatisticStorage(scale));
+        connectContext.getGlobalStateMgr().setStatisticStorage(new MockHistogramStatisticStorage(scale));
         OlapTable t0 = (OlapTable) globalStateMgr.getDb("test").getTable("region");
         setTableStatistics(t0, 5);
 

--- a/fe/fe-core/src/test/java/com/starrocks/statistic/StatisticExecutorTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/statistic/StatisticExecutorTest.java
@@ -18,6 +18,7 @@ import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.starrocks.catalog.Database;
 import com.starrocks.catalog.OlapTable;
+import com.starrocks.common.AnalysisException;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.sql.plan.PlanTestBase;
 import com.starrocks.thrift.TStatisticData;
@@ -39,7 +40,7 @@ public class StatisticExecutorTest extends PlanTestBase {
                 LocalDateTime.of(2020, 1, 1, 1, 1, 1),
                 Maps.newHashMap()));
 
-        Assert.assertThrows(IllegalStateException.class,
+        Assert.assertThrows(AnalysisException.class,
                 () -> statisticExecutor.queryStatisticSync(
                         StatisticUtils.buildConnectContext(), db.getId(), olapTable.getId(), Lists.newArrayList("foo", "bar")));
     }

--- a/fe/fe-core/src/test/java/com/starrocks/statistic/StatisticsExecutorTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/statistic/StatisticsExecutorTest.java
@@ -21,6 +21,7 @@ import com.starrocks.catalog.Database;
 import com.starrocks.catalog.OlapTable;
 import com.starrocks.catalog.Partition;
 import com.starrocks.catalog.Table;
+import com.starrocks.common.AnalysisException;
 import com.starrocks.common.DdlException;
 import com.starrocks.common.jmockit.Deencapsulation;
 import com.starrocks.qe.ConnectContext;
@@ -130,7 +131,7 @@ public class StatisticsExecutorTest extends PlanTestBase {
     }
 
     @Test
-    public void testQueryStatisticSync() {
+    public void testQueryStatisticSync() throws AnalysisException {
         String res;
         new MockUp<StatisticExecutor>() {
             @Mock


### PR DESCRIPTION
## Why I'm doing:
after supprt collect struct filed stats in this (https://github.com/StarRocks/starrocks/pull/43551), we still can not use the stats for opttimizer, we need to support calculate struct field stats from cached statistics storage.
## What I'm doing:
1. Support calculate struct field stats from cached statistics storage.
2. Pushdown JoinOnExpression to child operator before run skew join optimize rule,  because we  need to collect the subfiled operator stats first, then use it to optimize skew join
Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
