### PR TITLE
[Refactor] Change protobuf package name from starrocks.lake to starrocks

### DIFF
--- a/be/src/exprs/table_function/list_rowsets.cpp
+++ b/be/src/exprs/table_function/list_rowsets.cpp
@@ -29,10 +29,6 @@
 
 namespace starrocks {
 
-using TabletMetadata = lake::TabletMetadata;
-using TabletMetadataPtr = lake::TabletMetadataPtr;
-using RowsetMetadataPB = lake::RowsetMetadataPB;
-
 static void append_bigint(ColumnPtr& col, int64_t value) {
     [[maybe_unused]] auto n = col->append_numbers(&value, sizeof(value));
     DCHECK_EQ(1, n);

--- a/be/src/exprs/table_function/list_rowsets.h
+++ b/be/src/exprs/table_function/list_rowsets.h
@@ -20,13 +20,11 @@
 
 namespace starrocks {
 
-namespace lake {
 class TabletMetadataPB;
-}
 
 class ListRowsets final : public TableFunction {
     struct MyState final : public TableFunctionState {
-        std::shared_ptr<const lake::TabletMetadataPB> metadata;
+        std::shared_ptr<const TabletMetadataPB> metadata;
 
         ~MyState() override = default;
 

--- a/be/src/runtime/lake_snapshot_loader.cpp
+++ b/be/src/runtime/lake_snapshot_loader.cpp
@@ -127,7 +127,7 @@ Status LakeSnapshotLoader::_rename_remote_file(BrokerServiceConnection& client, 
     return Status::OK();
 }
 
-Status LakeSnapshotLoader::_check_snapshot_paths(const ::starrocks::lake::UploadSnapshotsRequest* request) {
+Status LakeSnapshotLoader::_check_snapshot_paths(const ::starrocks::UploadSnapshotsRequest* request) {
     for (auto& [tablet_id, snapshot] : request->snapshots()) {
         auto tablet = _env->lake_tablet_manager()->get_tablet(tablet_id);
         if (!tablet.ok()) {
@@ -145,7 +145,7 @@ Status LakeSnapshotLoader::_check_snapshot_paths(const ::starrocks::lake::Upload
     return Status::OK();
 }
 
-Status LakeSnapshotLoader::upload(const ::starrocks::lake::UploadSnapshotsRequest* request) {
+Status LakeSnapshotLoader::upload(const ::starrocks::UploadSnapshotsRequest* request) {
     std::string ip = request->broker().substr(0, request->broker().find(':'));
     int port = std::stoi(request->broker().substr(request->broker().find(':') + 1).c_str());
     TNetworkAddress address = make_network_address(ip, port);
@@ -242,7 +242,7 @@ Status LakeSnapshotLoader::upload(const ::starrocks::lake::UploadSnapshotsReques
     return status;
 }
 
-Status LakeSnapshotLoader::restore(const ::starrocks::lake::RestoreSnapshotsRequest* request) {
+Status LakeSnapshotLoader::restore(const ::starrocks::RestoreSnapshotsRequest* request) {
     std::string ip = request->broker().substr(0, request->broker().find(':'));
     int port = std::stoi(request->broker().substr(request->broker().find(':') + 1).c_str());
     TNetworkAddress address = make_network_address(ip, port);
@@ -294,7 +294,7 @@ Status LakeSnapshotLoader::restore(const ::starrocks::lake::RestoreSnapshotsRequ
             }
             raw::stl_string_resize_uninitialized(&read_buf, size);
             RETURN_IF_ERROR(rf->read_at_fully(0, read_buf.data(), size));
-            std::shared_ptr<starrocks::lake::TabletMetadata> meta = std::make_shared<starrocks::lake::TabletMetadata>();
+            std::shared_ptr<starrocks::TabletMetadata> meta = std::make_shared<starrocks::TabletMetadata>();
             bool parsed = meta->ParseFromArray(read_buf.data(), static_cast<int>(size));
             if (!parsed) {
                 return Status::Corruption(fmt::format("failed to parse tablet meta {}", full_remote_file));

--- a/be/src/runtime/lake_snapshot_loader.h
+++ b/be/src/runtime/lake_snapshot_loader.h
@@ -23,11 +23,8 @@
 
 namespace starrocks {
 
-namespace lake {
 class UploadSnapshotsRequest;
 class RestoreSnapshotsRequest;
-} // namespace lake
-
 class ExecEnv;
 struct FileStat;
 
@@ -39,9 +36,9 @@ public:
 
     DISALLOW_COPY_AND_MOVE(LakeSnapshotLoader);
 
-    Status upload(const ::starrocks::lake::UploadSnapshotsRequest* request);
+    Status upload(const ::starrocks::UploadSnapshotsRequest* request);
 
-    Status restore(const ::starrocks::lake::RestoreSnapshotsRequest* request);
+    Status restore(const ::starrocks::RestoreSnapshotsRequest* request);
 
 private:
     Status _get_existing_files_from_remote(BrokerServiceConnection& client, const std::string& remote_path,
@@ -51,7 +48,7 @@ private:
     Status _rename_remote_file(BrokerServiceConnection& client, const std::string& orig_name,
                                const std::string& new_name, const std::map<std::string, std::string>& broker_prop);
 
-    Status _check_snapshot_paths(const ::starrocks::lake::UploadSnapshotsRequest* request);
+    Status _check_snapshot_paths(const ::starrocks::UploadSnapshotsRequest* request);
 
 private:
     ExecEnv* _env;

--- a/be/src/service/service_be/lake_service.cpp
+++ b/be/src/service/service_be/lake_service.cpp
@@ -128,8 +128,8 @@ LakeServiceImpl::LakeServiceImpl(ExecEnv* env, lake::TabletManager* tablet_mgr) 
 LakeServiceImpl::~LakeServiceImpl() = default;
 
 void LakeServiceImpl::publish_version(::google::protobuf::RpcController* controller,
-                                      const ::starrocks::lake::PublishVersionRequest* request,
-                                      ::starrocks::lake::PublishVersionResponse* response,
+                                      const ::starrocks::PublishVersionRequest* request,
+                                      ::starrocks::PublishVersionResponse* response,
                                       ::google::protobuf::Closure* done) {
     brpc::ClosureGuard guard(done);
     auto cntl = static_cast<brpc::Controller*>(controller);
@@ -186,7 +186,7 @@ void LakeServiceImpl::publish_version(::google::protobuf::RpcController* control
             TRACE_COUNTER_INCREMENT("tablet_id", tablet_id);
             TRACE_COUNTER_INCREMENT("queuing_latency_us", queuing_latency);
 
-            StatusOr<lake::TabletMetadataPtr> res;
+            StatusOr<TabletMetadataPtr> res;
             if (std::chrono::system_clock::now() < timeout_deadline) {
                 res = lake::publish_version(_tablet_mgr, tablet_id, base_version, new_version, txns, commit_time);
             } else {
@@ -244,7 +244,7 @@ void LakeServiceImpl::publish_version(::google::protobuf::RpcController* control
 void LakeServiceImpl::_submit_publish_log_version_task(const int64_t* tablet_ids, size_t tablet_size,
                                                        const int64_t* txn_ids, const int64_t* log_versions,
                                                        size_t txn_size,
-                                                       ::starrocks::lake::PublishLogVersionResponse* response) {
+                                                       ::starrocks::PublishLogVersionResponse* response) {
     auto thread_pool = publish_version_thread_pool(_env);
     auto latch = BThreadCountDownLatch(tablet_size);
     bthread::Mutex response_mtx;
@@ -280,8 +280,8 @@ void LakeServiceImpl::_submit_publish_log_version_task(const int64_t* tablet_ids
     latch.wait();
 }
 void LakeServiceImpl::publish_log_version(::google::protobuf::RpcController* controller,
-                                          const ::starrocks::lake::PublishLogVersionRequest* request,
-                                          ::starrocks::lake::PublishLogVersionResponse* response,
+                                          const ::starrocks::PublishLogVersionRequest* request,
+                                          ::starrocks::PublishLogVersionResponse* response,
                                           ::google::protobuf::Closure* done) {
     brpc::ClosureGuard guard(done);
     auto cntl = static_cast<brpc::Controller*>(controller);
@@ -307,8 +307,8 @@ void LakeServiceImpl::publish_log_version(::google::protobuf::RpcController* con
 }
 
 void LakeServiceImpl::publish_log_version_batch(::google::protobuf::RpcController* controller,
-                                                const ::starrocks::lake::PublishLogVersionBatchRequest* request,
-                                                ::starrocks::lake::PublishLogVersionResponse* response,
+                                                const ::starrocks::PublishLogVersionBatchRequest* request,
+                                                ::starrocks::PublishLogVersionResponse* response,
                                                 ::google::protobuf::Closure* done) {
     brpc::ClosureGuard guard(done);
     auto cntl = static_cast<brpc::Controller*>(controller);
@@ -336,8 +336,8 @@ void LakeServiceImpl::publish_log_version_batch(::google::protobuf::RpcControlle
 }
 
 void LakeServiceImpl::abort_txn(::google::protobuf::RpcController* controller,
-                                const ::starrocks::lake::AbortTxnRequest* request,
-                                ::starrocks::lake::AbortTxnResponse* response, ::google::protobuf::Closure* done) {
+                                const ::starrocks::AbortTxnRequest* request, ::starrocks::AbortTxnResponse* response,
+                                ::google::protobuf::Closure* done) {
     brpc::ClosureGuard guard(done);
     (void)controller;
 
@@ -375,9 +375,8 @@ void LakeServiceImpl::abort_txn(::google::protobuf::RpcController* controller,
 }
 
 void LakeServiceImpl::delete_tablet(::google::protobuf::RpcController* controller,
-                                    const ::starrocks::lake::DeleteTabletRequest* request,
-                                    ::starrocks::lake::DeleteTabletResponse* response,
-                                    ::google::protobuf::Closure* done) {
+                                    const ::starrocks::DeleteTabletRequest* request,
+                                    ::starrocks::DeleteTabletResponse* response, ::google::protobuf::Closure* done) {
     brpc::ClosureGuard guard(done);
     auto cntl = static_cast<brpc::Controller*>(controller);
 
@@ -411,9 +410,8 @@ void LakeServiceImpl::delete_tablet(::google::protobuf::RpcController* controlle
 }
 
 void LakeServiceImpl::delete_txn_log(::google::protobuf::RpcController* controller,
-                                     const ::starrocks::lake::DeleteTxnLogRequest* request,
-                                     ::starrocks::lake::DeleteTxnLogResponse* response,
-                                     ::google::protobuf::Closure* done) {
+                                     const ::starrocks::DeleteTxnLogRequest* request,
+                                     ::starrocks::DeleteTxnLogResponse* response, ::google::protobuf::Closure* done) {
     brpc::ClosureGuard guard(done);
     auto cntl = static_cast<brpc::Controller*>(controller);
 
@@ -474,8 +472,8 @@ void remove_path(const std::string& path) {
 }; // namespace drop_table_helper
 
 void LakeServiceImpl::drop_table(::google::protobuf::RpcController* controller,
-                                 const ::starrocks::lake::DropTableRequest* request,
-                                 ::starrocks::lake::DropTableResponse* response, ::google::protobuf::Closure* done) {
+                                 const ::starrocks::DropTableRequest* request, ::starrocks::DropTableResponse* response,
+                                 ::google::protobuf::Closure* done) {
     brpc::ClosureGuard guard(done);
     auto cntl = static_cast<brpc::Controller*>(controller);
 
@@ -534,8 +532,8 @@ void LakeServiceImpl::drop_table(::google::protobuf::RpcController* controller,
 }
 
 void LakeServiceImpl::delete_data(::google::protobuf::RpcController* controller,
-                                  const ::starrocks::lake::DeleteDataRequest* request,
-                                  ::starrocks::lake::DeleteDataResponse* response, ::google::protobuf::Closure* done) {
+                                  const ::starrocks::DeleteDataRequest* request,
+                                  ::starrocks::DeleteDataResponse* response, ::google::protobuf::Closure* done) {
     brpc::ClosureGuard guard(done);
     auto cntl = static_cast<brpc::Controller*>(controller);
 
@@ -587,9 +585,8 @@ void LakeServiceImpl::delete_data(::google::protobuf::RpcController* controller,
 }
 
 void LakeServiceImpl::get_tablet_stats(::google::protobuf::RpcController* controller,
-                                       const ::starrocks::lake::TabletStatRequest* request,
-                                       ::starrocks::lake::TabletStatResponse* response,
-                                       ::google::protobuf::Closure* done) {
+                                       const ::starrocks::TabletStatRequest* request,
+                                       ::starrocks::TabletStatResponse* response, ::google::protobuf::Closure* done) {
     brpc::ClosureGuard guard(done);
     auto cntl = static_cast<brpc::Controller*>(controller);
 
@@ -656,8 +653,8 @@ void LakeServiceImpl::get_tablet_stats(::google::protobuf::RpcController* contro
 }
 
 void LakeServiceImpl::lock_tablet_metadata(::google::protobuf::RpcController* controller,
-                                           const ::starrocks::lake::LockTabletMetadataRequest* request,
-                                           ::starrocks::lake::LockTabletMetadataResponse* response,
+                                           const ::starrocks::LockTabletMetadataRequest* request,
+                                           ::starrocks::LockTabletMetadataResponse* response,
                                            ::google::protobuf::Closure* done) {
     brpc::ClosureGuard guard(done);
     auto cntl = static_cast<brpc::Controller*>(controller);
@@ -665,8 +662,8 @@ void LakeServiceImpl::lock_tablet_metadata(::google::protobuf::RpcController* co
 }
 
 void LakeServiceImpl::unlock_tablet_metadata(::google::protobuf::RpcController* controller,
-                                             const ::starrocks::lake::UnlockTabletMetadataRequest* request,
-                                             ::starrocks::lake::UnlockTabletMetadataResponse* response,
+                                             const ::starrocks::UnlockTabletMetadataRequest* request,
+                                             ::starrocks::UnlockTabletMetadataResponse* response,
                                              ::google::protobuf::Closure* done) {
     brpc::ClosureGuard guard(done);
     auto cntl = static_cast<brpc::Controller*>(controller);
@@ -674,8 +671,8 @@ void LakeServiceImpl::unlock_tablet_metadata(::google::protobuf::RpcController* 
 }
 
 void LakeServiceImpl::upload_snapshots(::google::protobuf::RpcController* controller,
-                                       const ::starrocks::lake::UploadSnapshotsRequest* request,
-                                       ::starrocks::lake::UploadSnapshotsResponse* response,
+                                       const ::starrocks::UploadSnapshotsRequest* request,
+                                       ::starrocks::UploadSnapshotsResponse* response,
                                        ::google::protobuf::Closure* done) {
     brpc::ClosureGuard guard(done);
     auto cntl = static_cast<brpc::Controller*>(controller);
@@ -705,8 +702,8 @@ void LakeServiceImpl::upload_snapshots(::google::protobuf::RpcController* contro
 }
 
 void LakeServiceImpl::restore_snapshots(::google::protobuf::RpcController* controller,
-                                        const ::starrocks::lake::RestoreSnapshotsRequest* request,
-                                        ::starrocks::lake::RestoreSnapshotsResponse* response,
+                                        const ::starrocks::RestoreSnapshotsRequest* request,
+                                        ::starrocks::RestoreSnapshotsResponse* response,
                                         ::google::protobuf::Closure* done) {
     brpc::ClosureGuard guard(done);
     auto cntl = static_cast<brpc::Controller*>(controller);
@@ -735,9 +732,8 @@ void LakeServiceImpl::restore_snapshots(::google::protobuf::RpcController* contr
     latch.wait();
 }
 
-void LakeServiceImpl::compact(::google::protobuf::RpcController* controller,
-                              const ::starrocks::lake::CompactRequest* request,
-                              ::starrocks::lake::CompactResponse* response, ::google::protobuf::Closure* done) {
+void LakeServiceImpl::compact(::google::protobuf::RpcController* controller, const ::starrocks::CompactRequest* request,
+                              ::starrocks::CompactResponse* response, ::google::protobuf::Closure* done) {
     brpc::ClosureGuard guard(done);
     auto cntl = static_cast<brpc::Controller*>(controller);
 
@@ -758,8 +754,8 @@ void LakeServiceImpl::compact(::google::protobuf::RpcController* controller,
 }
 
 void LakeServiceImpl::abort_compaction(::google::protobuf::RpcController* controller,
-                                       const ::starrocks::lake::AbortCompactionRequest* request,
-                                       ::starrocks::lake::AbortCompactionResponse* response,
+                                       const ::starrocks::AbortCompactionRequest* request,
+                                       ::starrocks::AbortCompactionResponse* response,
                                        ::google::protobuf::Closure* done) {
     TEST_SYNC_POINT("LakeServiceImpl::abort_compaction:enter");
 
@@ -777,9 +773,8 @@ void LakeServiceImpl::abort_compaction(::google::protobuf::RpcController* contro
     st.to_protobuf(response->mutable_status());
 }
 
-void LakeServiceImpl::vacuum(::google::protobuf::RpcController* controller,
-                             const ::starrocks::lake::VacuumRequest* request,
-                             ::starrocks::lake::VacuumResponse* response, ::google::protobuf::Closure* done) {
+void LakeServiceImpl::vacuum(::google::protobuf::RpcController* controller, const ::starrocks::VacuumRequest* request,
+                             ::starrocks::VacuumResponse* response, ::google::protobuf::Closure* done) {
     static bthread::Mutex s_mtx;
     static std::unordered_set<int64_t> s_vacuuming_partitions;
 
@@ -825,8 +820,8 @@ void LakeServiceImpl::vacuum(::google::protobuf::RpcController* controller,
 }
 
 void LakeServiceImpl::vacuum_full(::google::protobuf::RpcController* controller,
-                                  const ::starrocks::lake::VacuumFullRequest* request,
-                                  ::starrocks::lake::VacuumFullResponse* response, ::google::protobuf::Closure* done) {
+                                  const ::starrocks::VacuumFullRequest* request,
+                                  ::starrocks::VacuumFullResponse* response, ::google::protobuf::Closure* done) {
     brpc::ClosureGuard guard(done);
     auto cntl = static_cast<brpc::Controller*>(controller);
     auto thread_pool = vacuum_thread_pool(_env);

--- a/be/src/service/service_be/lake_service.h
+++ b/be/src/service/service_be/lake_service.h
@@ -25,86 +25,79 @@ namespace lake {
 class TabletManager;
 }
 
-class LakeServiceImpl : public ::starrocks::lake::LakeService {
+class LakeServiceImpl : public ::starrocks::LakeService {
 public:
     explicit LakeServiceImpl(ExecEnv* env, lake::TabletManager* tablet_mgr);
 
     ~LakeServiceImpl() override;
 
     void publish_version(::google::protobuf::RpcController* controller,
-                         const ::starrocks::lake::PublishVersionRequest* request,
-                         ::starrocks::lake::PublishVersionResponse* response,
-                         ::google::protobuf::Closure* done) override;
+                         const ::starrocks::PublishVersionRequest* request,
+                         ::starrocks::PublishVersionResponse* response, ::google::protobuf::Closure* done) override;
 
-    void abort_txn(::google::protobuf::RpcController* controller, const ::starrocks::lake::AbortTxnRequest* request,
-                   ::starrocks::lake::AbortTxnResponse* response, ::google::protobuf::Closure* done) override;
+    void abort_txn(::google::protobuf::RpcController* controller, const ::starrocks::AbortTxnRequest* request,
+                   ::starrocks::AbortTxnResponse* response, ::google::protobuf::Closure* done) override;
 
-    void delete_tablet(::google::protobuf::RpcController* controller,
-                       const ::starrocks::lake::DeleteTabletRequest* request,
-                       ::starrocks::lake::DeleteTabletResponse* response, ::google::protobuf::Closure* done) override;
+    void delete_tablet(::google::protobuf::RpcController* controller, const ::starrocks::DeleteTabletRequest* request,
+                       ::starrocks::DeleteTabletResponse* response, ::google::protobuf::Closure* done) override;
 
-    void delete_txn_log(::google::protobuf::RpcController* controller,
-                        const ::starrocks::lake::DeleteTxnLogRequest* request,
-                        ::starrocks::lake::DeleteTxnLogResponse* response, ::google::protobuf::Closure* done) override;
+    void delete_txn_log(::google::protobuf::RpcController* controller, const ::starrocks::DeleteTxnLogRequest* request,
+                        ::starrocks::DeleteTxnLogResponse* response, ::google::protobuf::Closure* done) override;
 
-    void compact(::google::protobuf::RpcController* controller, const ::starrocks::lake::CompactRequest* request,
-                 ::starrocks::lake::CompactResponse* response, ::google::protobuf::Closure* done) override;
+    void compact(::google::protobuf::RpcController* controller, const ::starrocks::CompactRequest* request,
+                 ::starrocks::CompactResponse* response, ::google::protobuf::Closure* done) override;
 
-    void drop_table(::google::protobuf::RpcController* controller, const ::starrocks::lake::DropTableRequest* request,
-                    ::starrocks::lake::DropTableResponse* response, ::google::protobuf::Closure* done) override;
+    void drop_table(::google::protobuf::RpcController* controller, const ::starrocks::DropTableRequest* request,
+                    ::starrocks::DropTableResponse* response, ::google::protobuf::Closure* done) override;
 
-    void delete_data(::google::protobuf::RpcController* controller, const ::starrocks::lake::DeleteDataRequest* request,
-                     ::starrocks::lake::DeleteDataResponse* response, ::google::protobuf::Closure* done) override;
+    void delete_data(::google::protobuf::RpcController* controller, const ::starrocks::DeleteDataRequest* request,
+                     ::starrocks::DeleteDataResponse* response, ::google::protobuf::Closure* done) override;
 
-    void get_tablet_stats(::google::protobuf::RpcController* controller,
-                          const ::starrocks::lake::TabletStatRequest* request,
-                          ::starrocks::lake::TabletStatResponse* response, ::google::protobuf::Closure* done) override;
+    void get_tablet_stats(::google::protobuf::RpcController* controller, const ::starrocks::TabletStatRequest* request,
+                          ::starrocks::TabletStatResponse* response, ::google::protobuf::Closure* done) override;
 
     void publish_log_version(::google::protobuf::RpcController* controller,
-                             const ::starrocks::lake::PublishLogVersionRequest* request,
-                             ::starrocks::lake::PublishLogVersionResponse* response,
+                             const ::starrocks::PublishLogVersionRequest* request,
+                             ::starrocks::PublishLogVersionResponse* response,
                              ::google::protobuf::Closure* done) override;
 
     void publish_log_version_batch(::google::protobuf::RpcController* controller,
-                                   const ::starrocks::lake::PublishLogVersionBatchRequest* request,
-                                   ::starrocks::lake::PublishLogVersionResponse* response,
+                                   const ::starrocks::PublishLogVersionBatchRequest* request,
+                                   ::starrocks::PublishLogVersionResponse* response,
                                    ::google::protobuf::Closure* done) override;
 
     void lock_tablet_metadata(::google::protobuf::RpcController* controller,
-                              const ::starrocks::lake::LockTabletMetadataRequest* request,
-                              ::starrocks::lake::LockTabletMetadataResponse* response,
+                              const ::starrocks::LockTabletMetadataRequest* request,
+                              ::starrocks::LockTabletMetadataResponse* response,
                               ::google::protobuf::Closure* done) override;
 
     void unlock_tablet_metadata(::google::protobuf::RpcController* controller,
-                                const ::starrocks::lake::UnlockTabletMetadataRequest* request,
-                                ::starrocks::lake::UnlockTabletMetadataResponse* response,
+                                const ::starrocks::UnlockTabletMetadataRequest* request,
+                                ::starrocks::UnlockTabletMetadataResponse* response,
                                 ::google::protobuf::Closure* done) override;
 
     void upload_snapshots(::google::protobuf::RpcController* controller,
-                          const ::starrocks::lake::UploadSnapshotsRequest* request,
-                          ::starrocks::lake::UploadSnapshotsResponse* response,
-                          ::google::protobuf::Closure* done) override;
+                          const ::starrocks::UploadSnapshotsRequest* request,
+                          ::starrocks::UploadSnapshotsResponse* response, ::google::protobuf::Closure* done) override;
 
     void restore_snapshots(::google::protobuf::RpcController* controller,
-                           const ::starrocks::lake::RestoreSnapshotsRequest* request,
-                           ::starrocks::lake::RestoreSnapshotsResponse* response,
-                           ::google::protobuf::Closure* done) override;
+                           const ::starrocks::RestoreSnapshotsRequest* request,
+                           ::starrocks::RestoreSnapshotsResponse* response, ::google::protobuf::Closure* done) override;
 
     void abort_compaction(::google::protobuf::RpcController* controller,
-                          const ::starrocks::lake::AbortCompactionRequest* request,
-                          ::starrocks::lake::AbortCompactionResponse* response,
-                          ::google::protobuf::Closure* done) override;
+                          const ::starrocks::AbortCompactionRequest* request,
+                          ::starrocks::AbortCompactionResponse* response, ::google::protobuf::Closure* done) override;
 
-    void vacuum(::google::protobuf::RpcController* controller, const ::starrocks::lake::VacuumRequest* request,
-                ::starrocks::lake::VacuumResponse* response, ::google::protobuf::Closure* done) override;
+    void vacuum(::google::protobuf::RpcController* controller, const ::starrocks::VacuumRequest* request,
+                ::starrocks::VacuumResponse* response, ::google::protobuf::Closure* done) override;
 
-    void vacuum_full(::google::protobuf::RpcController* controller, const ::starrocks::lake::VacuumFullRequest* request,
-                     ::starrocks::lake::VacuumFullResponse* response, ::google::protobuf::Closure* done) override;
+    void vacuum_full(::google::protobuf::RpcController* controller, const ::starrocks::VacuumFullRequest* request,
+                     ::starrocks::VacuumFullResponse* response, ::google::protobuf::Closure* done) override;
 
 private:
     void _submit_publish_log_version_task(const int64_t* tablet_ids, size_t tablet_size, const int64_t* txn_ids,
                                           const int64_t* log_versions, size_t txn_size,
-                                          ::starrocks::lake::PublishLogVersionResponse* response);
+                                          ::starrocks::PublishLogVersionResponse* response);
 
 private:
     static constexpr int64_t kDefaultTimeoutForGetTabletStat = 5 * 60 * 1000L;  // 5 minutes

--- a/be/src/service/service_be/starrocks_be.cpp
+++ b/be/src/service/service_be/starrocks_be.cpp
@@ -212,7 +212,7 @@ void start_be(const std::vector<StorePath>& paths, bool as_cn) {
         options.num_threads = config::brpc_num_threads;
     }
     const auto lake_service_max_concurrency = config::lake_service_max_concurrency;
-    const auto service_name = "starrocks.lake.LakeService";
+    const auto service_name = "starrocks.LakeService";
     const auto methods = {
             "abort_txn",     "abort_compaction", "compact",         "drop_table",          "delete_data",
             "delete_tablet", "get_tablet_stats", "publish_version", "publish_log_version", "publish_log_version_batch",

--- a/be/src/storage/lake/compaction_policy.h
+++ b/be/src/storage/lake/compaction_policy.h
@@ -19,13 +19,16 @@
 #include "common/statusor.h"
 #include "storage/compaction_utils.h"
 
+namespace starrocks {
+class TabletMetadataPB;
+}
+
 namespace starrocks::lake {
 
 class Rowset;
 using RowsetPtr = std::shared_ptr<Rowset>;
 class CompactionPolicy;
 using CompactionPolicyPtr = std::shared_ptr<CompactionPolicy>;
-class TabletMetadataPB;
 class TabletManager;
 
 // Compaction policy for lake tablet

--- a/be/src/storage/lake/compaction_scheduler.cpp
+++ b/be/src/storage/lake/compaction_scheduler.cpp
@@ -43,8 +43,8 @@ namespace starrocks::lake {
 
 CompactionTaskCallback::~CompactionTaskCallback() = default;
 
-CompactionTaskCallback::CompactionTaskCallback(CompactionScheduler* scheduler, const lake::CompactRequest* request,
-                                               lake::CompactResponse* response, ::google::protobuf::Closure* done)
+CompactionTaskCallback::CompactionTaskCallback(CompactionScheduler* scheduler, const CompactRequest* request,
+                                               CompactResponse* response, ::google::protobuf::Closure* done)
         : _scheduler(scheduler), _mtx(), _request(request), _response(response), _done(done) {
     CHECK(_request != nullptr);
     CHECK(_response != nullptr);

--- a/be/src/storage/lake/compaction_scheduler.h
+++ b/be/src/storage/lake/compaction_scheduler.h
@@ -31,13 +31,13 @@ class Closure;
 } // namespace google::protobuf
 
 namespace starrocks {
+class CompactRequest;
+class CompactResponse;
 class ThreadPool;
 } // namespace starrocks
 
 namespace starrocks::lake {
 
-class CompactRequest;
-class CompactResponse;
 class CompactionScheduler;
 class CompactionTask;
 class TabletManager;
@@ -49,8 +49,8 @@ class TabletManager;
 // `CompactResponse` will be sent to the FE.
 class CompactionTaskCallback {
 public:
-    explicit CompactionTaskCallback(CompactionScheduler* scheduler, const lake::CompactRequest* request,
-                                    lake::CompactResponse* response, ::google::protobuf::Closure* done);
+    explicit CompactionTaskCallback(CompactionScheduler* scheduler, const CompactRequest* request,
+                                    CompactResponse* response, ::google::protobuf::Closure* done);
 
     ~CompactionTaskCallback();
 
@@ -82,8 +82,8 @@ private:
 
     CompactionScheduler* _scheduler;
     mutable StackTraceMutex<bthread::Mutex> _mtx;
-    const lake::CompactRequest* _request;
-    lake::CompactResponse* _response;
+    const CompactRequest* _request;
+    CompactResponse* _response;
     ::google::protobuf::Closure* _done;
     Status _status;
     int64_t _timeout_deadline_ms;

--- a/be/src/storage/lake/metacache.h
+++ b/be/src/storage/lake/metacache.h
@@ -27,12 +27,11 @@ class CacheKey;
 class DelVector;
 class Segment;
 class TabletSchema;
+class TabletMetadataPB;
+class TxnLogPB;
 } // namespace starrocks
 
 namespace starrocks::lake {
-
-class TabletMetadataPB;
-class TxnLogPB;
 
 using CacheValue =
         std::variant<std::shared_ptr<const TabletMetadataPB>, std::shared_ptr<const TxnLogPB>,

--- a/be/src/storage/lake/schema_change.h
+++ b/be/src/storage/lake/schema_change.h
@@ -19,11 +19,14 @@
 #include "gen_cpp/olap_file.pb.h"
 #include "storage/schema_change_utils.h"
 
+namespace starrocks {
+class TxnLogPB_OpSchemaChange;
+}
+
 namespace starrocks::lake {
 
 class TabletManager;
 class VersionedTablet;
-class TxnLogPB_OpSchemaChange;
 struct SchemaChangeParams;
 
 class SchemaChangeHandler {

--- a/be/src/storage/lake/tablet.cpp
+++ b/be/src/storage/lake/tablet.cpp
@@ -158,7 +158,7 @@ std::string Tablet::root_location() const {
 }
 
 Status Tablet::delete_data(int64_t txn_id, const DeletePredicatePB& delete_predicate) {
-    auto txn_log = std::make_shared<lake::TxnLog>();
+    auto txn_log = std::make_shared<TxnLog>();
     txn_log->set_tablet_id(_id);
     txn_log->set_txn_id(txn_id);
     auto op_write = txn_log->mutable_op_write();

--- a/be/src/storage/lake/tablet_manager.cpp
+++ b/be/src/storage/lake/tablet_manager.cpp
@@ -362,6 +362,10 @@ Status TabletManager::put_txn_slog(const TxnLogPtr& log, const std::string& path
     return put_txn_log(log, path);
 }
 
+Status TabletManager::put_txn_vlog(const TxnLogPtr& log, int64_t version) {
+    return put_txn_log(log, txn_vlog_location(log->tablet_id(), version));
+}
+
 StatusOr<int64_t> TabletManager::get_tablet_data_size(int64_t tablet_id, int64_t* version_hint) {
     int64_t size = 0;
     TabletMetadataPtr metadata;

--- a/be/src/storage/lake/tablet_manager.h
+++ b/be/src/storage/lake/tablet_manager.h
@@ -70,9 +70,9 @@ public:
 
     StatusOr<CompactionTaskPtr> compact(CompactionTaskContext* context);
 
-    [[nodiscard]] Status put_tablet_metadata(const TabletMetadata& metadata);
+    Status put_tablet_metadata(const TabletMetadata& metadata);
 
-    [[nodiscard]] Status put_tablet_metadata(const TabletMetadataPtr& metadata);
+    Status put_tablet_metadata(const TabletMetadataPtr& metadata);
 
     StatusOr<TabletMetadataPtr> get_tablet_metadata(int64_t tablet_id, int64_t version);
 
@@ -82,17 +82,19 @@ public:
 
     StatusOr<TabletMetadataIter> list_tablet_metadata(int64_t tablet_id, bool filter_tablet);
 
-    [[nodiscard]] Status delete_tablet_metadata(int64_t tablet_id, int64_t version);
+    Status delete_tablet_metadata(int64_t tablet_id, int64_t version);
 
-    [[nodiscard]] Status put_txn_log(const TxnLog& log);
+    Status put_txn_log(const TxnLog& log);
 
-    [[nodiscard]] Status put_txn_log(const TxnLogPtr& log);
+    Status put_txn_log(const TxnLogPtr& log);
 
-    [[nodiscard]] Status put_txn_log(const TxnLogPtr& log, const std::string& path);
+    Status put_txn_log(const TxnLogPtr& log, const std::string& path);
 
-    [[nodiscard]] Status put_txn_slog(const TxnLogPtr& log);
+    Status put_txn_slog(const TxnLogPtr& log);
 
-    [[nodiscard]] Status put_txn_slog(const TxnLogPtr& log, const std::string& path);
+    Status put_txn_slog(const TxnLogPtr& log, const std::string& path);
+
+    Status put_txn_vlog(const TxnLogPtr& log, int64_t version);
 
     StatusOr<TxnLogPtr> get_txn_log(int64_t tablet_id, int64_t txn_id);
 

--- a/be/src/storage/lake/tablet_metadata.h
+++ b/be/src/storage/lake/tablet_metadata.h
@@ -18,10 +18,10 @@
 
 #include "gen_cpp/lake_types.pb.h"
 
-namespace starrocks::lake {
+namespace starrocks {
 
 using TabletMetadata = TabletMetadataPB;
 using TabletMetadataPtr = std::shared_ptr<const TabletMetadata>;
 using MutableTabletMetadataPtr = std::shared_ptr<TabletMetadata>;
 
-} // namespace starrocks::lake
+} // namespace starrocks

--- a/be/src/storage/lake/tablet_reader.h
+++ b/be/src/storage/lake/tablet_reader.h
@@ -33,12 +33,12 @@ class SeekRange;
 class SeekTuple;
 class Segment;
 class TabletSchema;
+class TabletMetadataPB;
 
 namespace lake {
 
 class Rowset;
 class TabletManager;
-class TabletMetadataPB;
 
 class TabletReader final : public ChunkIterator {
     using Chunk = starrocks::Chunk;

--- a/be/src/storage/lake/txn_log.h
+++ b/be/src/storage/lake/txn_log.h
@@ -18,10 +18,10 @@
 
 #include "gen_cpp/lake_types.pb.h"
 
-namespace starrocks::lake {
+namespace starrocks {
 
 using TxnLog = TxnLogPB;
 using TxnLogPtr = std::shared_ptr<const TxnLog>;
 using MutableTxnLogPtr = std::shared_ptr<TxnLog>;
 
-} // namespace starrocks::lake
+} // namespace starrocks

--- a/be/src/storage/lake/txn_log_applier.h
+++ b/be/src/storage/lake/txn_log_applier.h
@@ -19,11 +19,15 @@
 #include "common/status.h"
 #include "gutil/macros.h"
 #include "storage/lake/tablet_metadata.h"
+
+namespace starrocks {
+class TxnLogPB;
+class TabletMetadataPB;
+} // namespace starrocks
+
 namespace starrocks::lake {
 
 class Tablet;
-class TxnLogPB;
-class TabletMetadataPB;
 
 class TxnLogApplier {
 public:

--- a/be/src/storage/lake/types_fwd.h
+++ b/be/src/storage/lake/types_fwd.h
@@ -25,6 +25,11 @@ class DelVector;
 class ChunkIterator;
 class Schema;
 class Column;
+class RowsetMetadataPB;
+
+using ChunkIteratorPtr = std::shared_ptr<ChunkIterator>;
+using RowsetMetadata = RowsetMetadataPB;
+using RowsetMetadataPtr = std::shared_ptr<const RowsetMetadata>;
 
 namespace lake {
 
@@ -32,11 +37,7 @@ class Rowset;
 class Tablet;
 class CompactionTask;
 class LocationProvider;
-class RowsetMetadataPB;
 
-using ChunkIteratorPtr = std::shared_ptr<ChunkIterator>;
-using RowsetMetadata = RowsetMetadataPB;
-using RowsetMetadataPtr = std::shared_ptr<const starrocks::lake::RowsetMetadata>;
 using RowsetPtr = std::shared_ptr<starrocks::lake::Rowset>;
 using SegmentPtr = std::shared_ptr<starrocks::Segment>;
 using TabletSchemaPtr = std::shared_ptr<const starrocks::TabletSchema>;

--- a/be/src/storage/lake/update_manager.h
+++ b/be/src/storage/lake/update_manager.h
@@ -30,9 +30,10 @@
 
 namespace starrocks {
 
+class TxnLogPB_OpWrite;
+
 namespace lake {
 
-class TxnLogPB_OpWrite;
 class LocationProvider;
 class Tablet;
 class MetaFileBuilder;

--- a/be/src/storage/lake/versioned_tablet.h
+++ b/be/src/storage/lake/versioned_tablet.h
@@ -21,6 +21,7 @@
 
 namespace starrocks {
 class TabletSchema;
+class TabletMetadataPB;
 class Schema;
 class ThreadPool;
 } // namespace starrocks
@@ -29,7 +30,6 @@ namespace starrocks::lake {
 
 class Rowset;
 class TabletManager;
-class TabletMetadataPB;
 class TabletWriter;
 class TabletReader;
 enum WriterType : int;

--- a/be/src/storage/rowset/segment_rewriter.cpp
+++ b/be/src/storage/rowset/segment_rewriter.cpp
@@ -166,7 +166,7 @@ Status SegmentRewriter::rewrite(const std::string& src_path, const std::string& 
 Status SegmentRewriter::rewrite(const std::string& src_path, FileInfo* dest_path, const TabletSchemaCSPtr& tschema,
                                 starrocks::lake::AutoIncrementPartialUpdateState& auto_increment_partial_update_state,
                                 std::vector<uint32_t>& column_ids, std::vector<std::unique_ptr<Column>>* columns,
-                                const starrocks::lake::TxnLogPB_OpWrite& op_write, starrocks::lake::Tablet* tablet) {
+                                const starrocks::TxnLogPB_OpWrite& op_write, starrocks::lake::Tablet* tablet) {
     if (column_ids.size() == 0) {
         DCHECK_EQ(columns, nullptr);
     }

--- a/be/src/storage/rowset/segment_rewriter.h
+++ b/be/src/storage/rowset/segment_rewriter.h
@@ -39,7 +39,7 @@ public:
     static Status rewrite(const std::string& src_path, FileInfo* dest_path, const TabletSchemaCSPtr& tschema,
                           starrocks::lake::AutoIncrementPartialUpdateState& auto_increment_partial_update_state,
                           std::vector<uint32_t>& column_ids, std::vector<std::unique_ptr<Column>>* columns,
-                          const starrocks::lake::TxnLogPB_OpWrite& op_write, starrocks::lake::Tablet* tablet);
+                          const starrocks::TxnLogPB_OpWrite& op_write, starrocks::lake::Tablet* tablet);
 };
 
 } // namespace starrocks

--- a/be/src/tools/meta_tool.cpp
+++ b/be/src/tools/meta_tool.cpp
@@ -1107,7 +1107,7 @@ int meta_tool_main(int argc, char** argv) {
             return -1;
         }
     } else if (FLAGS_operation == "print_lake_metadata") {
-        starrocks::lake::TabletMetadataPB metadata;
+        starrocks::TabletMetadataPB metadata;
         if (!metadata.ParseFromIstream(&std::cin)) {
             std::cerr << "Fail to parse tablet metadata\n";
             return -1;
@@ -1122,7 +1122,7 @@ int meta_tool_main(int argc, char** argv) {
         }
         std::cout << json << '\n';
     } else if (FLAGS_operation == "print_lake_txn_log") {
-        starrocks::lake::TxnLogPB txn_log;
+        starrocks::TxnLogPB txn_log;
         if (!txn_log.ParseFromIstream(&std::cin)) {
             std::cerr << "Fail to parse txn log\n";
             return -1;

--- a/be/test/exec/lake_meta_scanner_test.cpp
+++ b/be/test/exec/lake_meta_scanner_test.cpp
@@ -59,7 +59,7 @@ public:
 
         {
             // create the tablet with its schema prepared
-            lake::TabletMetadata metadata;
+            TabletMetadata metadata;
             metadata.set_id(_tablet_id);
             metadata.set_version(2);
 

--- a/be/test/runtime/lake_tablets_channel_test.cpp
+++ b/be/test/runtime/lake_tablets_channel_test.cpp
@@ -32,6 +32,7 @@
 #include "storage/chunk_iterator.h"
 #include "storage/lake/fixed_location_provider.h"
 #include "storage/lake/join_path.h"
+#include "storage/lake/metacache.h"
 #include "storage/lake/tablet.h"
 #include "storage/lake/tablet_manager.h"
 #include "storage/lake/tablet_metadata.h"
@@ -121,8 +122,8 @@ public:
         tablet3->set_tablet_id(10089);
     }
 
-    std::unique_ptr<lake::TabletMetadata> new_tablet_metadata(int64_t tablet_id) {
-        auto metadata = std::make_unique<lake::TabletMetadata>();
+    std::unique_ptr<TabletMetadata> new_tablet_metadata(int64_t tablet_id) {
+        auto metadata = std::make_unique<TabletMetadata>();
         metadata->set_id(tablet_id);
         metadata->set_version(1);
         //
@@ -575,8 +576,8 @@ TEST_F(LakeTabletsChannelTest, test_write_failed) {
     add_chunk_request.mutable_chunk()->Swap(&chunk_pb);
 
     {
-        lake::DeleteTabletRequest request;
-        lake::DeleteTabletResponse response;
+        DeleteTabletRequest request;
+        DeleteTabletResponse response;
         request.add_tablet_ids(10089);
         lake::delete_tablets(_tablet_manager.get(), request, &response);
 
@@ -795,5 +796,4 @@ TEST_F(LakeTabletsChannelTest, test_profile) {
     ASSERT_TRUE(profile->get_counter("AddChunkTime")->value() > 0);
     ASSERT_EQ(chunk.num_rows(), profile->get_counter("AddRowNum")->value());
 }
-
 } // namespace starrocks

--- a/be/test/runtime/load_channel_test.cpp
+++ b/be/test/runtime/load_channel_test.cpp
@@ -118,8 +118,8 @@ public:
         tablet3->set_tablet_id(10089);
     }
 
-    std::unique_ptr<lake::TabletMetadata> new_tablet_metadata(int64_t tablet_id) {
-        auto metadata = std::make_unique<lake::TabletMetadata>();
+    std::unique_ptr<TabletMetadata> new_tablet_metadata(int64_t tablet_id) {
+        auto metadata = std::make_unique<TabletMetadata>();
         metadata->set_id(tablet_id);
         metadata->set_version(1);
         //

--- a/be/test/service/lake_service_test.cpp
+++ b/be/test/service/lake_service_test.cpp
@@ -44,6 +44,7 @@ class LakeServiceTest : public testing::Test {
 public:
     LakeServiceTest()
             : _tablet_id(next_id()),
+              _partition_id(next_id()),
               _location_provider(new lake::FixedLocationProvider(kRootLocation)),
               _tablet_mgr(ExecEnv::GetInstance()->lake_tablet_manager()),
               _lake_service(ExecEnv::GetInstance(), ExecEnv::GetInstance()->lake_tablet_manager()) {
@@ -82,9 +83,9 @@ protected:
         return seg_name;
     }
 
-    lake::TxnLog generate_write_txn_log(int num_segments, int64_t num_rows, int64_t data_size) {
+    TxnLog generate_write_txn_log(int num_segments, int64_t num_rows, int64_t data_size) {
         auto txn_id = next_id();
-        lake::TxnLog log;
+        TxnLog log;
         log.set_tablet_id(_tablet_id);
         log.set_txn_id(txn_id);
         for (int i = 0; i < num_segments; i++) {
@@ -98,6 +99,7 @@ protected:
 
     constexpr static const char* const kRootLocation = "./lake_service_test";
     int64_t _tablet_id;
+    int64_t _partition_id;
     lake::LocationProvider* _location_provider;
     lake::TabletManager* _tablet_mgr;
     lake::LocationProvider* _backup_location_provider;
@@ -106,8 +108,8 @@ protected:
 
 TEST_F(LakeServiceTest, test_publish_version_missing_tablet_ids) {
     brpc::Controller cntl;
-    lake::PublishVersionRequest request;
-    lake::PublishVersionResponse response;
+    PublishVersionRequest request;
+    PublishVersionResponse response;
     request.set_base_version(1);
     request.set_new_version(2);
     request.add_txn_ids(1000);
@@ -118,8 +120,8 @@ TEST_F(LakeServiceTest, test_publish_version_missing_tablet_ids) {
 
 TEST_F(LakeServiceTest, test_publish_version_missing_txn_ids) {
     brpc::Controller cntl;
-    lake::PublishVersionRequest request;
-    lake::PublishVersionResponse response;
+    PublishVersionRequest request;
+    PublishVersionResponse response;
     request.set_base_version(1);
     request.set_new_version(2);
     request.add_tablet_ids(_tablet_id);
@@ -130,8 +132,8 @@ TEST_F(LakeServiceTest, test_publish_version_missing_txn_ids) {
 
 TEST_F(LakeServiceTest, test_publish_version_missing_base_version) {
     brpc::Controller cntl;
-    lake::PublishVersionRequest request;
-    lake::PublishVersionResponse response;
+    PublishVersionRequest request;
+    PublishVersionResponse response;
     request.set_new_version(2);
     request.add_tablet_ids(_tablet_id);
     request.add_txn_ids(1000);
@@ -142,8 +144,8 @@ TEST_F(LakeServiceTest, test_publish_version_missing_base_version) {
 
 TEST_F(LakeServiceTest, test_publish_version_missing_new_version) {
     brpc::Controller cntl;
-    lake::PublishVersionRequest request;
-    lake::PublishVersionResponse response;
+    PublishVersionRequest request;
+    PublishVersionResponse response;
     request.set_base_version(1);
     request.add_tablet_ids(_tablet_id);
     request.add_txn_ids(1000);
@@ -161,8 +163,8 @@ TEST_F(LakeServiceTest, test_publish_version_thread_pool_full) {
     });
 
     brpc::Controller cntl;
-    lake::PublishVersionRequest request;
-    lake::PublishVersionResponse response;
+    PublishVersionRequest request;
+    PublishVersionResponse response;
     request.set_base_version(1);
     request.set_new_version(2);
     request.add_tablet_ids(_tablet_id);
@@ -174,7 +176,7 @@ TEST_F(LakeServiceTest, test_publish_version_thread_pool_full) {
 }
 
 TEST_F(LakeServiceTest, test_publish_version_for_write) {
-    std::vector<lake::TxnLog> logs;
+    std::vector<TxnLog> logs;
     // Empty TxnLog
     logs.emplace_back(generate_write_txn_log(0, 0, 0));
     ASSERT_OK(_tablet_mgr->put_txn_log(logs.back()));
@@ -184,7 +186,7 @@ TEST_F(LakeServiceTest, test_publish_version_for_write) {
     ASSERT_OK(_tablet_mgr->put_txn_log(logs.back()));
 
     // Publish version request for the first transaction
-    lake::PublishVersionRequest publish_request_1000;
+    PublishVersionRequest publish_request_1000;
     publish_request_1000.set_base_version(1);
     publish_request_1000.set_new_version(2);
     publish_request_1000.add_tablet_ids(_tablet_id);
@@ -204,7 +206,7 @@ TEST_F(LakeServiceTest, test_publish_version_for_write) {
             SyncPoint::GetInstance()->DisableProcessing();
         });
 
-        lake::PublishVersionResponse response;
+        PublishVersionResponse response;
         _lake_service.publish_version(nullptr, &publish_request_1000, &response, nullptr);
         ASSERT_EQ(1, response.failed_tablets_size());
         ASSERT_EQ(_tablet_id, response.failed_tablets(0));
@@ -222,7 +224,7 @@ TEST_F(LakeServiceTest, test_publish_version_for_write) {
             SyncPoint::GetInstance()->DisableProcessing();
         });
 
-        lake::PublishVersionResponse response;
+        PublishVersionResponse response;
         _lake_service.publish_version(nullptr, &publish_request_1000, &response, nullptr);
         ASSERT_EQ(1, response.failed_tablets_size());
         ASSERT_EQ(_tablet_id, response.failed_tablets(0));
@@ -231,14 +233,14 @@ TEST_F(LakeServiceTest, test_publish_version_for_write) {
     }
     // Publish txn success
     {
-        lake::PublishVersionResponse response;
+        PublishVersionResponse response;
         _lake_service.publish_version(nullptr, &publish_request_1000, &response, nullptr);
         ASSERT_EQ(0, response.failed_tablets_size());
         EXPECT_EQ(0, response.status().status_code()) << response.status().error_msgs(0);
     }
 
     // publish version request for the second transaction
-    lake::PublishVersionRequest publish_request_1;
+    PublishVersionRequest publish_request_1;
     publish_request_1.set_base_version(2);
     publish_request_1.set_new_version(3);
     publish_request_1.add_tablet_ids(_tablet_id);
@@ -257,7 +259,7 @@ TEST_F(LakeServiceTest, test_publish_version_for_write) {
             SyncPoint::GetInstance()->DisableProcessing();
         });
 
-        lake::PublishVersionResponse response;
+        PublishVersionResponse response;
         _lake_service.publish_version(nullptr, &publish_request_1, &response, nullptr);
         ASSERT_EQ(1, response.failed_tablets_size());
         ASSERT_EQ(_tablet_id, response.failed_tablets(0));
@@ -267,7 +269,7 @@ TEST_F(LakeServiceTest, test_publish_version_for_write) {
 
     // Publish txn success
     {
-        lake::PublishVersionResponse response;
+        PublishVersionResponse response;
         _lake_service.publish_version(nullptr, &publish_request_1, &response, nullptr);
         ASSERT_EQ(0, response.failed_tablets_size());
         EXPECT_EQ(0, response.status().status_code()) << response.status().error_msgs(0);
@@ -298,8 +300,8 @@ TEST_F(LakeServiceTest, test_publish_version_for_write) {
         if (i == 1) {
             _tablet_mgr->prune_metacache();
         }
-        lake::PublishVersionRequest request;
-        lake::PublishVersionResponse response;
+        PublishVersionRequest request;
+        PublishVersionResponse response;
         request.set_base_version(2);
         request.set_new_version(3);
         request.add_tablet_ids(_tablet_id);
@@ -310,8 +312,8 @@ TEST_F(LakeServiceTest, test_publish_version_for_write) {
     }
     // Send publish version request again with an non-exist tablet
     {
-        lake::PublishVersionRequest request;
-        lake::PublishVersionResponse response;
+        PublishVersionRequest request;
+        PublishVersionResponse response;
         request.set_base_version(2);
         request.set_new_version(3);
         request.add_tablet_ids(_tablet_id);
@@ -325,8 +327,8 @@ TEST_F(LakeServiceTest, test_publish_version_for_write) {
     }
     // Send publish version request again with an non-exist txnlog
     {
-        lake::PublishVersionRequest request;
-        lake::PublishVersionResponse response;
+        PublishVersionRequest request;
+        PublishVersionResponse response;
         request.set_base_version(3);
         request.set_new_version(4);
         request.add_tablet_ids(_tablet_id);
@@ -340,8 +342,8 @@ TEST_F(LakeServiceTest, test_publish_version_for_write) {
     ASSERT_OK(tablet.delete_metadata(1));
     ASSERT_OK(tablet.delete_metadata(2));
     {
-        lake::PublishVersionRequest request;
-        lake::PublishVersionResponse response;
+        PublishVersionRequest request;
+        PublishVersionResponse response;
         request.set_base_version(2);
         request.set_new_version(3);
         request.add_tablet_ids(_tablet_id);
@@ -358,8 +360,8 @@ TEST_F(LakeServiceTest, test_publish_version_for_write) {
     }
     // Publish txn
     {
-        lake::PublishVersionRequest request;
-        lake::PublishVersionResponse response;
+        PublishVersionRequest request;
+        PublishVersionResponse response;
         request.set_base_version(3);
         request.set_new_version(4);
         request.add_tablet_ids(_tablet_id);
@@ -376,7 +378,7 @@ TEST_F(LakeServiceTest, test_publish_version_for_write) {
 TEST_F(LakeServiceTest, test_publish_version_for_write_batch) {
     // Empty TxnLog
     {
-        lake::TxnLog txnlog;
+        TxnLog txnlog;
         txnlog.set_tablet_id(_tablet_id);
         txnlog.set_txn_id(1002);
         txnlog.mutable_op_write()->mutable_rowset()->set_num_rows(0);
@@ -386,7 +388,7 @@ TEST_F(LakeServiceTest, test_publish_version_for_write_batch) {
     }
     // TxnLog with 2 segments
     {
-        lake::TxnLog txnlog;
+        TxnLog txnlog;
         txnlog.set_tablet_id(_tablet_id);
         txnlog.set_txn_id(1003);
         txnlog.mutable_op_write()->mutable_rowset()->set_overlapped(true);
@@ -399,8 +401,8 @@ TEST_F(LakeServiceTest, test_publish_version_for_write_batch) {
 
     // Publish txn 1002 and txn 1003
     {
-        lake::PublishVersionRequest request;
-        lake::PublishVersionResponse response;
+        PublishVersionRequest request;
+        PublishVersionResponse response;
         request.set_base_version(1);
         request.set_new_version(3);
         request.add_tablet_ids(_tablet_id);
@@ -431,8 +433,8 @@ TEST_F(LakeServiceTest, test_publish_version_for_write_batch) {
 
     // Send publish version request again.
     {
-        lake::PublishVersionRequest request;
-        lake::PublishVersionResponse response;
+        PublishVersionRequest request;
+        PublishVersionResponse response;
         request.set_base_version(2);
         request.set_new_version(3);
         request.add_tablet_ids(_tablet_id);
@@ -443,8 +445,8 @@ TEST_F(LakeServiceTest, test_publish_version_for_write_batch) {
     }
     // Send publish version request again with an non-exist tablet
     {
-        lake::PublishVersionRequest request;
-        lake::PublishVersionResponse response;
+        PublishVersionRequest request;
+        PublishVersionResponse response;
         request.set_base_version(2);
         request.set_new_version(3);
         request.add_tablet_ids(_tablet_id);
@@ -458,8 +460,8 @@ TEST_F(LakeServiceTest, test_publish_version_for_write_batch) {
     }
     // Send publish version request again with an non-exist txnlog
     {
-        lake::PublishVersionRequest request;
-        lake::PublishVersionResponse response;
+        PublishVersionRequest request;
+        PublishVersionResponse response;
         request.set_base_version(3);
         request.set_new_version(4);
         request.add_tablet_ids(_tablet_id);
@@ -472,8 +474,8 @@ TEST_F(LakeServiceTest, test_publish_version_for_write_batch) {
     // Delete old version metadata then send publish version again
     ASSERT_OK(tablet.delete_metadata(1));
     {
-        lake::PublishVersionRequest request;
-        lake::PublishVersionResponse response;
+        PublishVersionRequest request;
+        PublishVersionResponse response;
         request.set_base_version(1);
         request.set_new_version(3);
         request.add_tablet_ids(_tablet_id);
@@ -486,7 +488,7 @@ TEST_F(LakeServiceTest, test_publish_version_for_write_batch) {
 }
 
 TEST_F(LakeServiceTest, test_publish_version_transform_single_to_batch) {
-    std::vector<lake::TxnLog> logs;
+    std::vector<TxnLog> logs;
     // Empty TxnLog
     logs.emplace_back(generate_write_txn_log(0, 0, 0));
     ASSERT_OK(_tablet_mgr->put_txn_log(logs.back()));
@@ -500,7 +502,7 @@ TEST_F(LakeServiceTest, test_publish_version_transform_single_to_batch) {
     ASSERT_OK(_tablet_mgr->put_txn_log(logs.back()));
 
     // Publish version request for the first transaction
-    lake::PublishVersionRequest publish_request_1000;
+    PublishVersionRequest publish_request_1000;
     publish_request_1000.set_base_version(1);
     publish_request_1000.set_new_version(2);
     publish_request_1000.add_tablet_ids(_tablet_id);
@@ -510,7 +512,7 @@ TEST_F(LakeServiceTest, test_publish_version_transform_single_to_batch) {
 
     // Publish txn single
     {
-        lake::PublishVersionResponse response;
+        PublishVersionResponse response;
         _lake_service.publish_version(nullptr, &publish_request_1000, &response, nullptr);
         ASSERT_EQ(0, response.failed_tablets_size());
 
@@ -520,7 +522,7 @@ TEST_F(LakeServiceTest, test_publish_version_transform_single_to_batch) {
     }
 
     // Publish version request for the two transactions
-    lake::PublishVersionRequest publish_request_1001;
+    PublishVersionRequest publish_request_1001;
     publish_request_1001.set_base_version(1);
     publish_request_1001.set_new_version(4);
     publish_request_1001.add_tablet_ids(_tablet_id);
@@ -530,7 +532,7 @@ TEST_F(LakeServiceTest, test_publish_version_transform_single_to_batch) {
 
     // publish txn batch with previous txns which have been published
     {
-        lake::PublishVersionResponse response;
+        PublishVersionResponse response;
         _lake_service.publish_version(nullptr, &publish_request_1001, &response, nullptr);
         ASSERT_EQ(0, response.failed_tablets_size());
 
@@ -558,7 +560,7 @@ TEST_F(LakeServiceTest, test_publish_version_transform_single_to_batch) {
 }
 
 TEST_F(LakeServiceTest, test_publish_version_transform_batch_to_single) {
-    std::vector<lake::TxnLog> logs;
+    std::vector<TxnLog> logs;
     // Empty TxnLog
     logs.emplace_back(generate_write_txn_log(0, 0, 0));
     ASSERT_OK(_tablet_mgr->put_txn_log(logs.back()));
@@ -568,7 +570,7 @@ TEST_F(LakeServiceTest, test_publish_version_transform_batch_to_single) {
     ASSERT_OK(_tablet_mgr->put_txn_log(logs.back()));
 
     // Publish version request
-    lake::PublishVersionRequest publish_request_1000;
+    PublishVersionRequest publish_request_1000;
     publish_request_1000.set_base_version(1);
     publish_request_1000.set_new_version(3);
     publish_request_1000.add_tablet_ids(_tablet_id);
@@ -579,7 +581,7 @@ TEST_F(LakeServiceTest, test_publish_version_transform_batch_to_single) {
 
     // Publish txn batch
     {
-        lake::PublishVersionResponse response;
+        PublishVersionResponse response;
         _lake_service.publish_version(nullptr, &publish_request_1000, &response, nullptr);
         ASSERT_EQ(0, response.failed_tablets_size());
 
@@ -596,7 +598,7 @@ TEST_F(LakeServiceTest, test_publish_version_transform_batch_to_single) {
     }
 
     // Publish single
-    lake::PublishVersionRequest publish_request_1001;
+    PublishVersionRequest publish_request_1001;
     publish_request_1001.set_base_version(1);
     publish_request_1001.set_new_version(2);
     publish_request_1001.add_tablet_ids(_tablet_id);
@@ -604,7 +606,7 @@ TEST_F(LakeServiceTest, test_publish_version_transform_batch_to_single) {
 
     // publish first txn
     {
-        lake::PublishVersionResponse response;
+        PublishVersionResponse response;
         _lake_service.publish_version(nullptr, &publish_request_1001, &response, nullptr);
         ASSERT_EQ(0, response.failed_tablets_size());
 
@@ -621,7 +623,7 @@ TEST_F(LakeServiceTest, test_publish_version_transform_batch_to_single) {
     }
 
     // Publish single
-    lake::PublishVersionRequest publish_request_1002;
+    PublishVersionRequest publish_request_1002;
     publish_request_1002.set_base_version(2);
     publish_request_1002.set_new_version(3);
     publish_request_1002.add_tablet_ids(_tablet_id);
@@ -631,7 +633,7 @@ TEST_F(LakeServiceTest, test_publish_version_transform_batch_to_single) {
     {
         _tablet_mgr->metacache()->prune();
 
-        lake::PublishVersionResponse response;
+        PublishVersionResponse response;
         _lake_service.publish_version(nullptr, &publish_request_1002, &response, nullptr);
         ASSERT_EQ(0, response.failed_tablets_size());
 
@@ -648,12 +650,12 @@ TEST_F(LakeServiceTest, test_publish_version_transform_batch_to_single) {
 }
 
 TEST_F(LakeServiceTest, test_abort) {
-    std::vector<lake::TxnLog> logs;
+    std::vector<TxnLog> logs;
 
     // Empty TxnLog
     {
         auto txn_id = next_id();
-        lake::TxnLog log;
+        TxnLog log;
         log.set_tablet_id(_tablet_id);
         log.set_txn_id(txn_id);
         ASSERT_OK(_tablet_mgr->put_txn_log(log));
@@ -664,7 +666,7 @@ TEST_F(LakeServiceTest, test_abort) {
     // Write txn log
     {
         auto txn_id = next_id();
-        lake::TxnLog log;
+        TxnLog log;
         log.set_tablet_id(_tablet_id);
         log.set_txn_id(txn_id);
         log.mutable_op_write()->mutable_rowset()->add_segments(generate_segment_file(txn_id));
@@ -679,7 +681,7 @@ TEST_F(LakeServiceTest, test_abort) {
     // Compaction txn log
     {
         auto txn_id = next_id();
-        lake::TxnLog log;
+        TxnLog log;
         log.set_tablet_id(_tablet_id);
         log.set_txn_id(txn_id);
         log.mutable_op_compaction()->mutable_output_rowset()->set_overlapped(false);
@@ -694,7 +696,7 @@ TEST_F(LakeServiceTest, test_abort) {
     // Schema change txn log
     {
         auto txn_id = next_id();
-        lake::TxnLog log;
+        TxnLog log;
         log.set_tablet_id(_tablet_id);
         log.set_txn_id(txn_id);
         log.mutable_op_schema_change()->add_rowsets()->add_segments(generate_segment_file(txn_id));
@@ -704,7 +706,7 @@ TEST_F(LakeServiceTest, test_abort) {
         logs.emplace_back(log);
     }
 
-    lake::AbortTxnRequest request;
+    AbortTxnRequest request;
     request.add_tablet_ids(_tablet_id);
     request.set_skip_cleanup(false);
     for (auto&& log : logs) {
@@ -720,11 +722,11 @@ TEST_F(LakeServiceTest, test_abort) {
             SyncPoint::GetInstance()->DisableProcessing();
         });
 
-        lake::AbortTxnResponse response;
+        AbortTxnResponse response;
         _lake_service.abort_txn(nullptr, &request, &response, nullptr);
     }
     {
-        lake::AbortTxnResponse response;
+        AbortTxnResponse response;
         _lake_service.abort_txn(nullptr, &request, &response, nullptr);
     }
 
@@ -748,7 +750,7 @@ TEST_F(LakeServiceTest, test_abort) {
 
     // Send AbortTxn request again
     {
-        lake::AbortTxnResponse response;
+        AbortTxnResponse response;
         _lake_service.abort_txn(nullptr, &request, &response, nullptr);
     }
     // Thread pool is full
@@ -761,15 +763,15 @@ TEST_F(LakeServiceTest, test_abort) {
             SyncPoint::GetInstance()->DisableProcessing();
         });
 
-        lake::AbortTxnResponse response;
+        AbortTxnResponse response;
         _lake_service.abort_txn(nullptr, &request, &response, nullptr);
     }
 }
 
 TEST_F(LakeServiceTest, test_delete_tablet) {
     brpc::Controller cntl;
-    lake::DeleteTabletRequest request;
-    lake::DeleteTabletResponse response;
+    DeleteTabletRequest request;
+    DeleteTabletResponse response;
     request.add_tablet_ids(_tablet_id);
     _lake_service.delete_tablet(&cntl, &request, &response, nullptr);
     ASSERT_FALSE(cntl.Failed()) << cntl.ErrorText();
@@ -781,8 +783,8 @@ TEST_F(LakeServiceTest, test_delete_txn_log) {
     // missing tablet_ids
     {
         brpc::Controller cntl;
-        lake::DeleteTxnLogRequest request;
-        lake::DeleteTxnLogResponse response;
+        DeleteTxnLogRequest request;
+        DeleteTxnLogResponse response;
         _lake_service.delete_txn_log(&cntl, &request, &response, nullptr);
         ASSERT_TRUE(cntl.Failed());
         ASSERT_EQ("missing tablet_ids", cntl.ErrorText());
@@ -791,8 +793,8 @@ TEST_F(LakeServiceTest, test_delete_txn_log) {
     // missing txn_ids
     {
         brpc::Controller cntl;
-        lake::DeleteTxnLogRequest request;
-        lake::DeleteTxnLogResponse response;
+        DeleteTxnLogRequest request;
+        DeleteTxnLogResponse response;
         request.add_tablet_ids(_tablet_id);
         _lake_service.delete_txn_log(&cntl, &request, &response, nullptr);
         ASSERT_TRUE(cntl.Failed());
@@ -801,15 +803,15 @@ TEST_F(LakeServiceTest, test_delete_txn_log) {
 
     // test normal
     {
-        std::vector<lake::TxnLog> logs;
+        std::vector<TxnLog> logs;
 
         // TxnLog with 2 segments
         logs.emplace_back(generate_write_txn_log(2, 101, 4096));
         ASSERT_OK(_tablet_mgr->put_txn_log(logs.back()));
 
         brpc::Controller cntl;
-        lake::DeleteTxnLogRequest request;
-        lake::DeleteTxnLogResponse response;
+        DeleteTxnLogRequest request;
+        DeleteTxnLogResponse response;
         request.add_tablet_ids(_tablet_id);
         request.add_txn_ids(logs.back().txn_id());
         _lake_service.delete_txn_log(&cntl, &request, &response, nullptr);
@@ -823,8 +825,8 @@ TEST_F(LakeServiceTest, test_delete_txn_log) {
 TEST_F(LakeServiceTest, test_delete_tablet_dir_not_exit) {
     ASSERT_OK(fs::remove_all(kRootLocation));
     brpc::Controller cntl;
-    lake::DeleteTabletRequest request;
-    lake::DeleteTabletResponse response;
+    DeleteTabletRequest request;
+    DeleteTabletResponse response;
     request.add_tablet_ids(_tablet_id);
     _lake_service.delete_tablet(&cntl, &request, &response, nullptr);
     ASSERT_FALSE(cntl.Failed()) << cntl.ErrorText();
@@ -835,8 +837,8 @@ TEST_F(LakeServiceTest, test_delete_tablet_dir_not_exit) {
 }
 
 TEST_F(LakeServiceTest, test_compact) {
-    auto compact = [this](::google::protobuf::RpcController* cntl, const lake::CompactRequest* request,
-                          lake::CompactResponse* response) {
+    auto compact = [this](::google::protobuf::RpcController* cntl, const CompactRequest* request,
+                          CompactResponse* response) {
         CountDownLatch latch(1);
         auto cb = ::google::protobuf::NewCallback(&latch, &CountDownLatch::count_down);
         _lake_service.compact(cntl, request, response, cb);
@@ -847,8 +849,8 @@ TEST_F(LakeServiceTest, test_compact) {
     // missing tablet_ids
     {
         brpc::Controller cntl;
-        lake::CompactRequest request;
-        lake::CompactResponse response;
+        CompactRequest request;
+        CompactResponse response;
         // request.add_tablet_ids(_tablet_id);
         request.set_txn_id(txn_id);
         request.set_version(1);
@@ -859,8 +861,8 @@ TEST_F(LakeServiceTest, test_compact) {
     // missing txn_id
     {
         brpc::Controller cntl;
-        lake::CompactRequest request;
-        lake::CompactResponse response;
+        CompactRequest request;
+        CompactResponse response;
         request.add_tablet_ids(_tablet_id);
         //request.set_txn_id(txn_id);
         request.set_version(1);
@@ -871,8 +873,8 @@ TEST_F(LakeServiceTest, test_compact) {
     // missing version
     {
         brpc::Controller cntl;
-        lake::CompactRequest request;
-        lake::CompactResponse response;
+        CompactRequest request;
+        CompactResponse response;
         request.add_tablet_ids(_tablet_id);
         request.set_txn_id(txn_id);
         //request.set_version(1);
@@ -883,8 +885,8 @@ TEST_F(LakeServiceTest, test_compact) {
     // tablet not exist
     {
         brpc::Controller cntl;
-        lake::CompactRequest request;
-        lake::CompactResponse response;
+        CompactRequest request;
+        CompactResponse response;
         request.add_tablet_ids(_tablet_id + 1);
         request.set_txn_id(txn_id);
         request.set_version(1);
@@ -896,8 +898,8 @@ TEST_F(LakeServiceTest, test_compact) {
     // compact
     {
         brpc::Controller cntl;
-        lake::CompactRequest request;
-        lake::CompactResponse response;
+        CompactRequest request;
+        CompactResponse response;
         request.add_tablet_ids(_tablet_id);
         request.set_txn_id(txn_id);
         request.set_version(1);
@@ -908,8 +910,8 @@ TEST_F(LakeServiceTest, test_compact) {
     // publish version
     {
         brpc::Controller cntl;
-        lake::PublishVersionRequest request;
-        lake::PublishVersionResponse response;
+        PublishVersionRequest request;
+        PublishVersionResponse response;
         request.add_tablet_ids(_tablet_id);
         request.add_txn_ids(txn_id);
         request.set_base_version(1);
@@ -923,8 +925,8 @@ TEST_F(LakeServiceTest, test_compact) {
 
 TEST_F(LakeServiceTest, test_drop_table) {
     ASSERT_OK(FileSystem::Default()->path_exists(kRootLocation));
-    lake::DropTableRequest request;
-    lake::DropTableResponse response;
+    DropTableRequest request;
+    DropTableResponse response;
 
     brpc::Controller cntl;
     _lake_service.drop_table(&cntl, &request, &response, nullptr);
@@ -950,7 +952,7 @@ TEST_F(LakeServiceTest, test_drop_table) {
 TEST_F(LakeServiceTest, test_publish_log_version) {
     auto txn_id = next_id();
     {
-        lake::TxnLog txnlog;
+        TxnLog txnlog;
         txnlog.set_tablet_id(_tablet_id);
         txnlog.set_txn_id(txn_id);
         txnlog.mutable_op_write()->mutable_rowset()->set_overlapped(true);
@@ -961,16 +963,16 @@ TEST_F(LakeServiceTest, test_publish_log_version) {
         ASSERT_OK(_tablet_mgr->put_txn_log(txnlog));
     }
     {
-        lake::PublishLogVersionRequest request;
-        lake::PublishLogVersionResponse response;
+        PublishLogVersionRequest request;
+        PublishLogVersionResponse response;
         brpc::Controller cntl;
         _lake_service.publish_log_version(&cntl, &request, &response, nullptr);
         ASSERT_TRUE(cntl.Failed());
         ASSERT_EQ("missing tablet_ids", cntl.ErrorText());
     }
     {
-        lake::PublishLogVersionRequest request;
-        lake::PublishLogVersionResponse response;
+        PublishLogVersionRequest request;
+        PublishLogVersionResponse response;
         request.add_tablet_ids(_tablet_id);
         brpc::Controller cntl;
         _lake_service.publish_log_version(&cntl, &request, &response, nullptr);
@@ -978,8 +980,8 @@ TEST_F(LakeServiceTest, test_publish_log_version) {
         ASSERT_EQ("missing txn_id", cntl.ErrorText());
     }
     {
-        lake::PublishLogVersionRequest request;
-        lake::PublishLogVersionResponse response;
+        PublishLogVersionRequest request;
+        PublishLogVersionResponse response;
         request.add_tablet_ids(_tablet_id);
         request.set_txn_id(txn_id);
         brpc::Controller cntl;
@@ -996,8 +998,8 @@ TEST_F(LakeServiceTest, test_publish_log_version) {
             SyncPoint::GetInstance()->DisableProcessing();
         });
 
-        lake::PublishLogVersionRequest request;
-        lake::PublishLogVersionResponse response;
+        PublishLogVersionRequest request;
+        PublishLogVersionResponse response;
         request.add_tablet_ids(_tablet_id);
         request.set_txn_id(txn_id);
         request.set_version(10);
@@ -1012,8 +1014,8 @@ TEST_F(LakeServiceTest, test_publish_log_version) {
         EXPECT_FALSE(fs::path_exist(_tablet_mgr->txn_vlog_location(_tablet_id, 10)));
     }
     {
-        lake::PublishLogVersionRequest request;
-        lake::PublishLogVersionResponse response;
+        PublishLogVersionRequest request;
+        PublishLogVersionResponse response;
         request.add_tablet_ids(_tablet_id);
         request.set_txn_id(txn_id);
         request.set_version(10);
@@ -1028,8 +1030,8 @@ TEST_F(LakeServiceTest, test_publish_log_version) {
     }
     // duplicate request
     {
-        lake::PublishLogVersionRequest request;
-        lake::PublishLogVersionResponse response;
+        PublishLogVersionRequest request;
+        PublishLogVersionResponse response;
         request.add_tablet_ids(_tablet_id);
         request.set_txn_id(txn_id);
         request.set_version(10);
@@ -1045,7 +1047,7 @@ TEST_F(LakeServiceTest, test_publish_log_version) {
 
 TEST_F(LakeServiceTest, test_publish_log_version_batch) {
     {
-        lake::TxnLog txnlog;
+        TxnLog txnlog;
         txnlog.set_tablet_id(_tablet_id);
         txnlog.set_txn_id(1001);
         txnlog.mutable_op_write()->mutable_rowset()->set_overlapped(true);
@@ -1055,7 +1057,7 @@ TEST_F(LakeServiceTest, test_publish_log_version_batch) {
         txnlog.mutable_op_write()->mutable_rowset()->add_segments("2.dat");
         ASSERT_OK(_tablet_mgr->put_txn_log(txnlog));
 
-        lake::TxnLog txnlog2;
+        TxnLog txnlog2;
         txnlog2.set_tablet_id(_tablet_id);
         txnlog2.set_txn_id(1002);
         txnlog2.mutable_op_write()->mutable_rowset()->set_overlapped(true);
@@ -1066,16 +1068,16 @@ TEST_F(LakeServiceTest, test_publish_log_version_batch) {
         ASSERT_OK(_tablet_mgr->put_txn_log(txnlog2));
     }
     {
-        lake::PublishLogVersionBatchRequest request;
-        lake::PublishLogVersionResponse response;
+        PublishLogVersionBatchRequest request;
+        PublishLogVersionResponse response;
         brpc::Controller cntl;
         _lake_service.publish_log_version_batch(&cntl, &request, &response, nullptr);
         ASSERT_TRUE(cntl.Failed());
         ASSERT_EQ("missing tablet_ids", cntl.ErrorText());
     }
     {
-        lake::PublishLogVersionBatchRequest request;
-        lake::PublishLogVersionResponse response;
+        PublishLogVersionBatchRequest request;
+        PublishLogVersionResponse response;
         request.add_tablet_ids(_tablet_id);
         brpc::Controller cntl;
         _lake_service.publish_log_version_batch(&cntl, &request, &response, nullptr);
@@ -1083,8 +1085,8 @@ TEST_F(LakeServiceTest, test_publish_log_version_batch) {
         ASSERT_EQ("missing txn_ids", cntl.ErrorText());
     }
     {
-        lake::PublishLogVersionBatchRequest request;
-        lake::PublishLogVersionResponse response;
+        PublishLogVersionBatchRequest request;
+        PublishLogVersionResponse response;
         request.add_tablet_ids(_tablet_id);
         request.add_txn_ids(1001);
         brpc::Controller cntl;
@@ -1093,8 +1095,8 @@ TEST_F(LakeServiceTest, test_publish_log_version_batch) {
         ASSERT_EQ("missing versions", cntl.ErrorText());
     }
     {
-        lake::PublishLogVersionBatchRequest request;
-        lake::PublishLogVersionResponse response;
+        PublishLogVersionBatchRequest request;
+        PublishLogVersionResponse response;
         request.add_tablet_ids(_tablet_id);
         request.add_txn_ids(1001);
         request.add_txn_ids(1002);
@@ -1122,8 +1124,8 @@ TEST_F(LakeServiceTest, test_publish_log_version_batch) {
     }
     // duplicate request
     {
-        lake::PublishLogVersionBatchRequest request;
-        lake::PublishLogVersionResponse response;
+        PublishLogVersionBatchRequest request;
+        PublishLogVersionResponse response;
         request.add_tablet_ids(_tablet_id);
         request.add_txn_ids(1001);
         request.add_txn_ids(1002);
@@ -1153,8 +1155,8 @@ TEST_F(LakeServiceTest, test_publish_log_version_batch) {
 
     // not existing txnId
     {
-        lake::PublishLogVersionBatchRequest request;
-        lake::PublishLogVersionResponse response;
+        PublishLogVersionBatchRequest request;
+        PublishLogVersionResponse response;
         request.add_tablet_ids(_tablet_id);
         request.add_txn_ids(1111);
         brpc::Controller cntl;
@@ -1166,7 +1168,7 @@ TEST_F(LakeServiceTest, test_publish_log_version_batch) {
 TEST_F(LakeServiceTest, test_publish_version_for_schema_change) {
     // write 1 rowset when schema change
     {
-        lake::TxnLog txnlog;
+        TxnLog txnlog;
         txnlog.set_tablet_id(_tablet_id);
         txnlog.set_txn_id(1000);
         txnlog.mutable_op_write()->mutable_rowset()->set_overlapped(false);
@@ -1177,8 +1179,8 @@ TEST_F(LakeServiceTest, test_publish_version_for_schema_change) {
         txnlog.mutable_op_write()->mutable_rowset()->add_segments("6.dat");
         ASSERT_OK(_tablet_mgr->put_txn_log(txnlog));
 
-        lake::PublishLogVersionRequest request;
-        lake::PublishLogVersionResponse response;
+        PublishLogVersionRequest request;
+        PublishLogVersionResponse response;
         request.add_tablet_ids(_tablet_id);
         request.set_txn_id(1000);
         request.set_version(4);
@@ -1190,7 +1192,7 @@ TEST_F(LakeServiceTest, test_publish_version_for_schema_change) {
 
     // schema change with 2 rowsets
     {
-        lake::TxnLog txnlog;
+        TxnLog txnlog;
         txnlog.set_tablet_id(_tablet_id);
         txnlog.set_txn_id(1001);
         auto op_schema_change = txnlog.mutable_op_schema_change();
@@ -1211,7 +1213,7 @@ TEST_F(LakeServiceTest, test_publish_version_for_schema_change) {
         ASSERT_OK(_tablet_mgr->put_txn_log(txnlog));
     }
 
-    lake::PublishVersionRequest request;
+    PublishVersionRequest request;
     request.set_base_version(1);
     request.set_new_version(5);
     request.add_tablet_ids(_tablet_id);
@@ -1226,7 +1228,7 @@ TEST_F(LakeServiceTest, test_publish_version_for_schema_change) {
             SyncPoint::GetInstance()->DisableProcessing();
         });
 
-        lake::PublishVersionResponse response;
+        PublishVersionResponse response;
         brpc::Controller cntl;
         _lake_service.publish_version(&cntl, &request, &response, nullptr);
         ASSERT_FALSE(cntl.Failed());
@@ -1242,7 +1244,7 @@ TEST_F(LakeServiceTest, test_publish_version_for_schema_change) {
             SyncPoint::GetInstance()->DisableProcessing();
         });
 
-        lake::PublishVersionResponse response;
+        PublishVersionResponse response;
         brpc::Controller cntl;
         _lake_service.publish_version(&cntl, &request, &response, nullptr);
         ASSERT_FALSE(cntl.Failed());
@@ -1259,7 +1261,7 @@ TEST_F(LakeServiceTest, test_publish_version_for_schema_change) {
             SyncPoint::GetInstance()->DisableProcessing();
         });
 
-        lake::PublishVersionResponse response;
+        PublishVersionResponse response;
         brpc::Controller cntl;
         _lake_service.publish_version(&cntl, &request, &response, nullptr);
         ASSERT_FALSE(cntl.Failed());
@@ -1276,7 +1278,7 @@ TEST_F(LakeServiceTest, test_publish_version_for_schema_change) {
             SyncPoint::GetInstance()->DisableProcessing();
         });
 
-        lake::PublishVersionResponse response;
+        PublishVersionResponse response;
         brpc::Controller cntl;
         _lake_service.publish_version(&cntl, &request, &response, nullptr);
         ASSERT_FALSE(cntl.Failed());
@@ -1285,7 +1287,7 @@ TEST_F(LakeServiceTest, test_publish_version_for_schema_change) {
     }
     // apply success
     {
-        lake::PublishVersionResponse response;
+        PublishVersionResponse response;
         brpc::Controller cntl;
         _lake_service.publish_version(&cntl, &request, &response, nullptr);
         ASSERT_FALSE(cntl.Failed());
@@ -1295,7 +1297,7 @@ TEST_F(LakeServiceTest, test_publish_version_for_schema_change) {
     _tablet_mgr->prune_metacache();
     // publish again
     {
-        lake::PublishVersionResponse response;
+        PublishVersionResponse response;
         brpc::Controller cntl;
         _lake_service.publish_version(&cntl, &request, &response, nullptr);
         ASSERT_FALSE(cntl.Failed());
@@ -1340,8 +1342,8 @@ TEST_F(LakeServiceTest, test_abort_compaction) {
 
     auto compaction_thread = std::thread([&]() {
         brpc::Controller cntl;
-        lake::CompactRequest request;
-        lake::CompactResponse response;
+        CompactRequest request;
+        CompactResponse response;
         request.add_tablet_ids(_tablet_id);
         request.set_txn_id(txn_id);
         request.set_version(1);
@@ -1356,8 +1358,8 @@ TEST_F(LakeServiceTest, test_abort_compaction) {
 
     {
         brpc::Controller cntl;
-        lake::AbortCompactionRequest request;
-        lake::AbortCompactionResponse response;
+        AbortCompactionRequest request;
+        AbortCompactionResponse response;
         request.set_txn_id(txn_id);
         _lake_service.abort_compaction(&cntl, &request, &response, nullptr);
         ASSERT_EQ(TStatusCode::OK, response.status().status_code());
@@ -1367,8 +1369,8 @@ TEST_F(LakeServiceTest, test_abort_compaction) {
 
     {
         brpc::Controller cntl;
-        lake::AbortCompactionRequest request;
-        lake::AbortCompactionResponse response;
+        AbortCompactionRequest request;
+        AbortCompactionResponse response;
         request.set_txn_id(txn_id);
         _lake_service.abort_compaction(&cntl, &request, &response, nullptr);
         ASSERT_EQ(TStatusCode::NOT_FOUND, response.status().status_code());
@@ -1378,7 +1380,7 @@ TEST_F(LakeServiceTest, test_abort_compaction) {
 // https://github.com/StarRocks/starrocks/issues/28244
 TEST_F(LakeServiceTest, test_publish_version_issue28244) {
     {
-        lake::TxnLog txnlog;
+        TxnLog txnlog;
         txnlog.set_tablet_id(_tablet_id);
         txnlog.set_txn_id(102301);
         txnlog.mutable_op_write()->mutable_rowset()->set_overlapped(true);
@@ -1400,8 +1402,8 @@ TEST_F(LakeServiceTest, test_publish_version_issue28244) {
     });
 
     {
-        lake::PublishVersionRequest request;
-        lake::PublishVersionResponse response;
+        PublishVersionRequest request;
+        PublishVersionResponse response;
         request.set_base_version(1);
         request.set_new_version(2);
         request.add_tablet_ids(_tablet_id);
@@ -1415,8 +1417,8 @@ TEST_F(LakeServiceTest, test_publish_version_issue28244) {
 }
 
 TEST_F(LakeServiceTest, test_get_tablet_stats) {
-    lake::TabletStatRequest request;
-    lake::TabletStatResponse response;
+    TabletStatRequest request;
+    TabletStatResponse response;
     auto* info = request.add_tablet_infos();
     info->set_tablet_id(_tablet_id);
     info->set_version(1);
@@ -1460,8 +1462,8 @@ TEST_F(LakeServiceTest, test_drop_table_no_thread_pool) {
         SyncPoint::GetInstance()->DisableProcessing();
     });
 
-    lake::DropTableRequest request;
-    lake::DropTableResponse response;
+    DropTableRequest request;
+    DropTableResponse response;
     request.set_tablet_id(_tablet_id);
     brpc::Controller cntl;
     _lake_service.drop_table(&cntl, &request, &response, nullptr);
@@ -1482,8 +1484,8 @@ TEST_F(LakeServiceTest, test_drop_table_duplicate_request) {
     Status result_status[2];
     for (int i = 0; i < 2; i++) {
         ASSIGN_OR_ABORT(tids[i], bthreads::start_bthread([&, id = i]() {
-                            lake::DropTableRequest request;
-                            lake::DropTableResponse response;
+                            DropTableRequest request;
+                            DropTableResponse response;
                             request.set_tablet_id(100);
                             request.set_path(path);
                             brpc::Controller cntl;
@@ -1512,8 +1514,8 @@ TEST_F(LakeServiceTest, test_delete_tablet_no_thread_pool) {
     });
 
     brpc::Controller cntl;
-    lake::DeleteTabletRequest request;
-    lake::DeleteTabletResponse response;
+    DeleteTabletRequest request;
+    DeleteTabletResponse response;
     request.add_tablet_ids(_tablet_id);
     _lake_service.delete_tablet(&cntl, &request, &response, nullptr);
     ASSERT_TRUE(cntl.Failed());
@@ -1530,8 +1532,8 @@ TEST_F(LakeServiceTest, test_vacuum_null_thread_pool) {
     });
 
     brpc::Controller cntl;
-    lake::VacuumRequest request;
-    lake::VacuumResponse response;
+    VacuumRequest request;
+    VacuumResponse response;
     request.add_tablet_ids(_tablet_id);
     request.set_partition_id(next_id());
     _lake_service.vacuum(&cntl, &request, &response, nullptr);
@@ -1547,8 +1549,8 @@ TEST_F(LakeServiceTest, test_vacuum_thread_pool_full) {
     });
 
     brpc::Controller cntl;
-    lake::VacuumRequest request;
-    lake::VacuumResponse response;
+    VacuumRequest request;
+    VacuumResponse response;
     request.add_tablet_ids(_tablet_id);
     request.set_partition_id(next_id());
     _lake_service.vacuum(&cntl, &request, &response, nullptr);
@@ -1566,8 +1568,8 @@ TEST_F(LakeServiceTest, test_vacuum_full_null_thread_pool) {
     });
 
     brpc::Controller cntl;
-    lake::VacuumFullRequest request;
-    lake::VacuumFullResponse response;
+    VacuumFullRequest request;
+    VacuumFullResponse response;
     request.add_tablet_ids(_tablet_id);
     _lake_service.vacuum_full(&cntl, &request, &response, nullptr);
     ASSERT_EQ("full vacuum thread pool is null", cntl.ErrorText());
@@ -1582,8 +1584,8 @@ TEST_F(LakeServiceTest, test_vacuum_full_thread_pool_full) {
     });
 
     brpc::Controller cntl;
-    lake::VacuumFullRequest request;
-    lake::VacuumFullResponse response;
+    VacuumFullRequest request;
+    VacuumFullResponse response;
     request.add_tablet_ids(_tablet_id);
     _lake_service.vacuum_full(&cntl, &request, &response, nullptr);
     EXPECT_FALSE(cntl.Failed()) << cntl.ErrorText();
@@ -1600,8 +1602,8 @@ TEST_F(LakeServiceTest, test_duplicated_vacuum_request) {
 
     auto t = std::thread([&]() {
         brpc::Controller cntl;
-        lake::VacuumRequest request;
-        lake::VacuumResponse response;
+        VacuumRequest request;
+        VacuumResponse response;
         request.add_tablet_ids(_tablet_id);
         request.set_partition_id(partition_id);
         _lake_service.vacuum(&cntl, &request, &response, nullptr);
@@ -1612,8 +1614,8 @@ TEST_F(LakeServiceTest, test_duplicated_vacuum_request) {
 
     {
         brpc::Controller cntl;
-        lake::VacuumRequest request;
-        lake::VacuumResponse response;
+        VacuumRequest request;
+        VacuumResponse response;
         request.add_tablet_ids(_tablet_id);
         request.set_partition_id(partition_id);
         _lake_service.vacuum(&cntl, &request, &response, nullptr);
@@ -1629,8 +1631,8 @@ TEST_F(LakeServiceTest, test_duplicated_vacuum_request) {
 
 TEST_F(LakeServiceTest, test_lock_and_unlock_tablet_metadata) {
     {
-        lake::LockTabletMetadataRequest request;
-        lake::LockTabletMetadataResponse response;
+        LockTabletMetadataRequest request;
+        LockTabletMetadataResponse response;
         request.set_tablet_id(10);
         request.set_version(5);
         brpc::Controller cntl;
@@ -1638,8 +1640,8 @@ TEST_F(LakeServiceTest, test_lock_and_unlock_tablet_metadata) {
         ASSERT_TRUE(cntl.Failed());
     }
     {
-        lake::UnlockTabletMetadataRequest request;
-        lake::UnlockTabletMetadataResponse response;
+        UnlockTabletMetadataRequest request;
+        UnlockTabletMetadataResponse response;
         request.set_tablet_id(10);
         request.set_version(13);
         request.set_expire_time(10000);
@@ -1762,8 +1764,8 @@ TEST_F(LakeServiceTest, test_abort_txn2) {
 
     std::this_thread::sleep_for(std::chrono::seconds(2));
     {
-        lake::AbortTxnRequest request;
-        lake::AbortTxnResponse response;
+        AbortTxnRequest request;
+        AbortTxnResponse response;
         request.add_tablet_ids(_tablet_id);
         request.add_txn_ids(txn_id);
         request.set_skip_cleanup(false);
@@ -1775,13 +1777,13 @@ TEST_F(LakeServiceTest, test_abort_txn2) {
 
 TEST_F(LakeServiceTest, test_abort3) {
     auto txn_id = next_id();
-    lake::TxnLog log;
+    TxnLog log;
     log.set_tablet_id(_tablet_id);
     log.set_txn_id(txn_id);
     ASSERT_OK(_tablet_mgr->put_txn_log(log));
 
-    lake::AbortTxnRequest request;
-    lake::AbortTxnResponse response;
+    AbortTxnRequest request;
+    AbortTxnResponse response;
     request.add_tablet_ids(_tablet_id);
     request.set_skip_cleanup(true);
     request.add_txn_ids(log.txn_id());
@@ -1801,8 +1803,8 @@ TEST_F(LakeServiceTest, test_drop_table_thread_pool_full) {
         SyncPoint::GetInstance()->DisableProcessing();
     });
 
-    lake::DropTableRequest request;
-    lake::DropTableResponse response;
+    DropTableRequest request;
+    DropTableResponse response;
     request.set_tablet_id(_tablet_id);
     brpc::Controller cntl;
     _lake_service.drop_table(&cntl, &request, &response, nullptr);
@@ -1819,8 +1821,8 @@ TEST_F(LakeServiceTest, test_drop_table_no_permission) {
         SyncPoint::GetInstance()->ClearCallBack("PosixFileSystem::delete_dir");
         SyncPoint::GetInstance()->DisableProcessing();
     });
-    lake::DropTableRequest request;
-    lake::DropTableResponse response;
+    DropTableRequest request;
+    DropTableResponse response;
     request.set_tablet_id(_tablet_id);
     brpc::Controller cntl;
     _lake_service.drop_table(&cntl, &request, &response, nullptr);
@@ -1829,5 +1831,4 @@ TEST_F(LakeServiceTest, test_drop_table_no_permission) {
     ASSERT_EQ(1, response.status().error_msgs_size());
     ASSERT_TRUE(MatchPattern(response.status().error_msgs(0), "*Permission denied*"));
 }
-
 } // namespace starrocks

--- a/be/test/storage/lake/primary_key_compaction_task_test.cpp
+++ b/be/test/storage/lake/primary_key_compaction_task_test.cpp
@@ -883,11 +883,11 @@ TEST_P(LakePrimaryKeyCompactionTest, test_abort_txn) {
     });
 
     std::thread t2([&]() {
-        lake::AbortTxnRequest request;
+        AbortTxnRequest request;
         request.add_tablet_ids(tablet_id);
         request.add_txn_ids(txn_id);
         request.set_skip_cleanup(false);
-        lake::AbortTxnResponse response;
+        AbortTxnResponse response;
         auto lake_service = LakeServiceImpl(ExecEnv::GetInstance(), _tablet_mgr.get());
         lake_service.abort_txn(nullptr, &request, &response, nullptr);
     });

--- a/be/test/storage/lake/primary_key_publish_test.cpp
+++ b/be/test/storage/lake/primary_key_publish_test.cpp
@@ -682,11 +682,11 @@ TEST_P(LakePrimaryKeyPublishTest, test_abort_txn) {
     });
 
     std::thread t2([&]() {
-        lake::AbortTxnRequest request;
+        AbortTxnRequest request;
         request.add_tablet_ids(tablet_id);
         request.add_txn_ids(txn_id);
         request.set_skip_cleanup(false);
-        lake::AbortTxnResponse response;
+        AbortTxnResponse response;
         auto lake_service = LakeServiceImpl(ExecEnv::GetInstance(), _tablet_mgr.get());
         lake_service.abort_txn(nullptr, &request, &response, nullptr);
     });

--- a/be/test/storage/lake/tablet_manager_test.cpp
+++ b/be/test/storage/lake/tablet_manager_test.cpp
@@ -75,7 +75,7 @@ public:
 
 // NOLINTNEXTLINE
 TEST_F(LakeTabletManagerTest, tablet_meta_write_and_read) {
-    starrocks::lake::TabletMetadata metadata;
+    starrocks::TabletMetadata metadata;
     metadata.set_id(12345);
     metadata.set_version(2);
     auto rowset_meta_pb = metadata.add_rowsets();
@@ -95,7 +95,7 @@ TEST_F(LakeTabletManagerTest, tablet_meta_write_and_read) {
 
 // NOLINTNEXTLINE
 TEST_F(LakeTabletManagerTest, txnlog_write_and_read) {
-    starrocks::lake::TxnLog txnLog;
+    starrocks::TxnLog txnLog;
     txnLog.set_tablet_id(12345);
     txnLog.set_txn_id(2);
     EXPECT_OK(_tablet_manager->put_txn_log(txnLog));
@@ -206,7 +206,7 @@ TEST_F(LakeTabletManagerTest, create_tablet_without_schema_file) {
 
 // NOLINTNEXTLINE
 TEST_F(LakeTabletManagerTest, list_tablet_meta) {
-    starrocks::lake::TabletMetadata metadata;
+    starrocks::TabletMetadata metadata;
     metadata.set_id(12345);
     metadata.set_version(2);
     auto rowset_meta_pb = metadata.add_rowsets();
@@ -258,11 +258,11 @@ TEST_F(LakeTabletManagerTest, list_tablet_meta) {
 // NOLINTNEXTLINE
 TEST_F(LakeTabletManagerTest, DISABLED_put_get_tabletmetadata_witch_cache_evict) {
     int64_t tablet_id = 23456;
-    std::vector<lake::TabletMetadataPtr> vec;
+    std::vector<TabletMetadataPtr> vec;
 
     // we set meta cache capacity to 16K, and each meta here cost 232 bytes,putting 64 tablet meta will fill up the cache space.
     for (int i = 0; i < 64; ++i) {
-        auto metadata = std::make_shared<lake::TabletMetadata>();
+        auto metadata = std::make_shared<TabletMetadata>();
         metadata->set_id(tablet_id);
         metadata->set_version(2 + i);
         auto rowset_meta_pb = metadata->add_rowsets();
@@ -284,7 +284,7 @@ TEST_F(LakeTabletManagerTest, DISABLED_put_get_tabletmetadata_witch_cache_evict)
 
     // put another 32 tablet meta to trigger cache eviction.
     for (int i = 0; i < 32; ++i) {
-        auto metadata = std::make_shared<lake::TabletMetadata>();
+        auto metadata = std::make_shared<TabletMetadata>();
         metadata->set_id(tablet_id);
         metadata->set_version(66 + i);
         auto rowset_meta_pb = metadata->add_rowsets();
@@ -316,7 +316,7 @@ TEST_F(LakeTabletManagerTest, DISABLED_put_get_tabletmetadata_witch_cache_evict)
 
 // NOLINTNEXTLINE
 TEST_F(LakeTabletManagerTest, tablet_schema_load) {
-    starrocks::lake::TabletMetadata metadata;
+    starrocks::TabletMetadata metadata;
     metadata.set_id(12345);
     metadata.set_version(2);
 

--- a/be/test/storage/lake/test_util.h
+++ b/be/test/storage/lake/test_util.h
@@ -114,8 +114,8 @@ struct PrimaryKeyParam {
 
 inline StatusOr<TabletMetadataPtr> TEST_publish_single_version(TabletManager* tablet_mgr, int64_t tablet_id,
                                                                int64_t new_version, int64_t txn_id) {
-    lake::PublishVersionRequest request;
-    lake::PublishVersionResponse response;
+    PublishVersionRequest request;
+    PublishVersionResponse response;
 
     request.add_tablet_ids(tablet_id);
     request.add_txn_ids(txn_id);
@@ -137,8 +137,8 @@ inline StatusOr<TabletMetadataPtr> TEST_publish_single_version(TabletManager* ta
 inline StatusOr<TabletMetadataPtr> TEST_batch_publish(TabletManager* tablet_mgr, int64_t tablet_id,
                                                       int64_t base_version, int64_t new_version,
                                                       std::vector<int64_t>& txn_ids) {
-    lake::PublishVersionRequest request;
-    lake::PublishVersionResponse response;
+    PublishVersionRequest request;
+    PublishVersionResponse response;
 
     request.add_tablet_ids(tablet_id);
     for (auto& txn_id : txn_ids) {
@@ -162,8 +162,8 @@ inline StatusOr<TabletMetadataPtr> TEST_batch_publish(TabletManager* tablet_mgr,
 
 inline Status TEST_publish_single_log_version(TabletManager* tablet_mgr, int64_t tablet_id, int64_t txn_id,
                                               int64_t log_version) {
-    lake::PublishLogVersionRequest request;
-    lake::PublishLogVersionResponse response;
+    PublishLogVersionRequest request;
+    PublishLogVersionResponse response;
 
     request.add_tablet_ids(tablet_id);
     request.set_txn_id(txn_id);
@@ -195,7 +195,7 @@ inline StatusOr<TabletMetadataPtr> TestBase::batch_publish(int64_t tablet_id, in
 }
 
 inline std::shared_ptr<TabletMetadataPB> generate_simple_tablet_metadata(KeysType keys_type) {
-    auto metadata = std::make_shared<lake::TabletMetadata>();
+    auto metadata = std::make_shared<TabletMetadata>();
     metadata->set_id(next_id());
     metadata->set_version(1);
     metadata->set_cumulative_point(0);

--- a/gensrc/proto/lake_service.proto
+++ b/gensrc/proto/lake_service.proto
@@ -14,7 +14,7 @@
 //
 syntax="proto2";
 
-package starrocks.lake;
+package starrocks;
 option java_package = "com.starrocks.proto";
 
 import "types.proto";

--- a/gensrc/proto/lake_types.proto
+++ b/gensrc/proto/lake_types.proto
@@ -14,7 +14,7 @@
 //
 syntax = "proto2";
 
-package starrocks.lake;
+package starrocks;
 option java_package = "com.starrocks.proto";
 
 import "types.proto";


### PR DESCRIPTION
## Why I'm doing:
Using a type with a package name of `starrocks.lake` in a protobuf file with a package name of `starrocks` causes jprotobuf to fail to compile.

## What I'm doing:
Use `starrocks` as the package name.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [x] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [x] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
