### PR TITLE
[BugFix] Fix Trino parser ctas when has multi fe

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/parser/SqlParser.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/parser/SqlParser.java
@@ -63,12 +63,18 @@ public class SqlParser {
         List<StatementBase> statements = Lists.newArrayList();
         try {
             StatementSplitter splitter = new StatementSplitter(sql);
-            for (StatementSplitter.Statement statement : splitter.getCompleteStatements()) {
-                statements.add(TrinoParserUtils.toStatement(statement.statement(), sessionVariable.getSqlMode()));
+            for (int idx = 0; idx < splitter.getCompleteStatements().size(); ++idx) {
+                StatementSplitter.Statement statement = splitter.getCompleteStatements().get(idx);
+                StatementBase statementBase = TrinoParserUtils.toStatement(statement.statement(),
+                        sessionVariable.getSqlMode());
+                statementBase.setOrigStmt(new OriginStatement(sql, idx));
+                statements.add(statementBase);
             }
             if (!splitter.getPartialStatement().isEmpty()) {
-                statements.add(TrinoParserUtils.toStatement(splitter.getPartialStatement(),
-                        sessionVariable.getSqlMode()));
+                StatementBase statement = TrinoParserUtils.toStatement(splitter.getPartialStatement(),
+                        sessionVariable.getSqlMode());
+                statement.setOrigStmt(new OriginStatement(sql, splitter.getCompleteStatements().size()));
+                statements.add(statement);
             }
             if (ConnectContext.get() != null) {
                 ConnectContext.get().setRelationAliasCaseInSensitive(true);

--- a/fe/fe-core/src/test/java/com/starrocks/connector/parser/trino/TrinoCtasTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/parser/trino/TrinoCtasTest.java
@@ -17,6 +17,7 @@ package com.starrocks.connector.parser.trino;
 import com.starrocks.sql.ast.CreateTableAsSelectStmt;
 import com.starrocks.sql.ast.QueryStatement;
 import com.starrocks.sql.parser.SqlParser;
+import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
@@ -35,6 +36,7 @@ public class TrinoCtasTest extends TrinoTestBase {
                     (CreateTableAsSelectStmt) SqlParser.parse(ctasSql, connectContext.getSessionVariable()).get(0);
             QueryStatement queryStmt = ctasStmt.getQueryStatement();
             assertPlanContains(queryStmt, "dayofyear('2022-03-06 00:00:00')");
+            Assert.assertEquals(ctasSql, ctasStmt.getOrigStmt().originStmt);
 
             connectContext.getSessionVariable().setSqlDialect("starrocks");
             analyzeFail(ctasSql, "No matching function with signature: doy(date)");


### PR DESCRIPTION
## Why I'm doing:
ctas stmt will throw USER_CANCEL exception when use trino parser in multi-fe cluster, the reason is the stmt is not set origin statement
## What I'm doing:
set origin statement in trino parser
Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [x] 3.2
  - [x] 3.1
  - [ ] 3.0
  - [ ] 2.5
