### PR TITLE
[Enhancement]Read the entire segment file at once when file size is small in shared data

### DIFF
--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -862,7 +862,7 @@ CONF_mBool(s3_use_list_objects_v1, "false");
 
 // Lake
 CONF_mBool(io_coalesce_lake_read_enable, "false");
-CONF_mInt32(lake_small_segment_file_threshold_size, "83886080"); // 10 * 1024 * 1024 * 8 = 10MB
+CONF_mInt32(lake_small_segment_file_threshold_size, "10485760"); // 10 * 1024 * 1024 = 10MB
 
 // orc reader
 CONF_Bool(enable_orc_late_materialization, "true");

--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -862,6 +862,7 @@ CONF_mBool(s3_use_list_objects_v1, "false");
 
 // Lake
 CONF_mBool(io_coalesce_lake_read_enable, "false");
+CONF_mInt32(lake_small_segment_file_threshold_size, "83886080"); // 10 * 1024 * 1024 * 8 = 10MB
 
 // orc reader
 CONF_Bool(enable_orc_late_materialization, "true");

--- a/be/src/io/seekable_input_stream.h
+++ b/be/src/io/seekable_input_stream.h
@@ -85,7 +85,7 @@ public:
     // SharedBufferedStream will override the function,
     // If io_coalesce_lake_read_enable set to true, it will be called to release the buffer for saving memory
     // when column_iterator get eos.
-    virtual void release() {};
+    virtual void release(){};
 
 protected:
     std::string _filename = "";

--- a/be/src/io/seekable_input_stream.h
+++ b/be/src/io/seekable_input_stream.h
@@ -82,13 +82,10 @@ public:
 
     virtual bool is_cache_hit() const { return false; };
 
-    // SharedBufferedStream will override the two function,
-    // If io_coalesce_lake_read_enable set to true, it will be called to release the buffer for saving memory
+    // SharedBufferedStream will override the function,
+    // If io_coalesce_lake_read_enable set to true, it will be called to try release the buffer for saving memory
     // when column_iterator get eos.
-    virtual void release(){};
-    // If can_release() return false, release() should't be called,
-    // for the buffer is still be used.
-    virtual bool can_release() { return true; };
+    virtual void try_release(){};
 
 protected:
     std::string _filename = "";

--- a/be/src/io/seekable_input_stream.h
+++ b/be/src/io/seekable_input_stream.h
@@ -82,7 +82,10 @@ public:
 
     virtual bool is_cache_hit() const { return false; };
 
-    virtual void release() const {};
+    // SharedBufferedStream will override the function,
+    // If io_coalesce_lake_read_enable set to true, it will be called to release the buffer for saving memory
+    // when column_iterator get eos.
+    virtual void release() {};
 
 protected:
     std::string _filename = "";

--- a/be/src/io/seekable_input_stream.h
+++ b/be/src/io/seekable_input_stream.h
@@ -82,10 +82,13 @@ public:
 
     virtual bool is_cache_hit() const { return false; };
 
-    // SharedBufferedStream will override the function,
+    // SharedBufferedStream will override the two function,
     // If io_coalesce_lake_read_enable set to true, it will be called to release the buffer for saving memory
     // when column_iterator get eos.
     virtual void release(){};
+    // If can_release() return false, release() should't be called,
+    // for the buffer is still be used.
+    virtual bool can_release() { return true; };
 
 protected:
     std::string _filename = "";

--- a/be/src/io/seekable_input_stream.h
+++ b/be/src/io/seekable_input_stream.h
@@ -82,6 +82,8 @@ public:
 
     virtual bool is_cache_hit() const { return false; };
 
+    virtual void release() const {};
+
 protected:
     std::string _filename = "";
 };

--- a/be/src/io/shared_buffered_input_stream.cpp
+++ b/be/src/io/shared_buffered_input_stream.cpp
@@ -237,7 +237,7 @@ void SharedBufferedInputStream::release() {
 }
 
 void SharedBufferedInputStream::try_release() {
-    if (hold_count.fetch_sub(1) == 0) {
+    if (hold_count.fetch_sub(1) == 1) {
         _map.clear();
     }
 }

--- a/be/src/io/shared_buffered_input_stream.cpp
+++ b/be/src/io/shared_buffered_input_stream.cpp
@@ -237,7 +237,7 @@ void SharedBufferedInputStream::release() {
 }
 
 void SharedBufferedInputStream::try_release() {
-    if (hold_count.fetch_sub(1) == 1) {
+    if (hold_count.fetch_sub(1) == 0) {
         _map.clear();
     }
 }

--- a/be/src/io/shared_buffered_input_stream.cpp
+++ b/be/src/io/shared_buffered_input_stream.cpp
@@ -242,8 +242,8 @@ void SharedBufferedInputStream::try_release() {
     }
 }
 
-void SharedBufferedInputStream::increase_hold_count() {
-    hold_count.fetch_add(1);
+int SharedBufferedInputStream::increase_hold_count() {
+    return hold_count.fetch_add(1);
 }
 
 void SharedBufferedInputStream::release_to_offset(int64_t offset) {

--- a/be/src/io/shared_buffered_input_stream.cpp
+++ b/be/src/io/shared_buffered_input_stream.cpp
@@ -236,6 +236,16 @@ void SharedBufferedInputStream::release() {
     _map.clear();
 }
 
+void SharedBufferedInputStream::try_release() {
+    if (hold_count.fetch_sub(1) == 1) {
+        _map.clear();
+    }
+}
+
+void SharedBufferedInputStream::increase_hold_count() {
+    hold_count.fetch_add(1);
+}
+
 void SharedBufferedInputStream::release_to_offset(int64_t offset) {
     auto it = _map.upper_bound(offset);
     _map.erase(_map.begin(), it);

--- a/be/src/io/shared_buffered_input_stream.h
+++ b/be/src/io/shared_buffered_input_stream.h
@@ -79,7 +79,7 @@ public:
 
     Status set_io_ranges(const std::vector<IORange>& ranges, bool coalesce_lazy_column = true);
     void release_to_offset(int64_t offset);
-    void release();
+    void release() override;
     void set_coalesce_options(const CoalesceOptions& options) { _options = options; }
     void set_align_size(int64_t size) { _align_size = size; }
 

--- a/be/src/io/shared_buffered_input_stream.h
+++ b/be/src/io/shared_buffered_input_stream.h
@@ -14,10 +14,10 @@
 
 #pragma once
 
+#include <atomic>
 #include <cstddef>
 #include <cstdint>
 #include <memory>
-#include <atomic>
 
 #include "common/status.h"
 #include "io/seekable_input_stream.h"
@@ -104,9 +104,7 @@ public:
     StatusOr<std::string_view> peek_shared_buffer(int64_t count, SharedBufferPtr* shared_buffer);
 
     // for test
-    int get_shared_buffer_size() {
-        return _map.size();
-    }
+    int get_shared_buffer_size() { return _map.size(); }
 
 private:
     void _update_estimated_mem_usage();

--- a/be/src/io/shared_buffered_input_stream.h
+++ b/be/src/io/shared_buffered_input_stream.h
@@ -87,7 +87,7 @@ public:
     // return false only ranges of shared_buffer is the whole file.
     bool can_release() override {
         if (_map.empty() || _map.size() != 1) return true;
-        return _file_size == _map.begin()->second->size;
+        return _file_size != _map.begin()->second->size;
     }
     void set_coalesce_options(const CoalesceOptions& options) { _options = options; }
     void set_align_size(int64_t size) { _align_size = size; }

--- a/be/src/io/shared_buffered_input_stream.h
+++ b/be/src/io/shared_buffered_input_stream.h
@@ -82,7 +82,7 @@ public:
     void release_to_offset(int64_t offset);
     void release();
     void try_release() override;
-    void increase_hold_count();
+    int increase_hold_count();
 
     void set_coalesce_options(const CoalesceOptions& options) { _options = options; }
     void set_align_size(int64_t size) { _align_size = size; }
@@ -102,6 +102,11 @@ public:
     const std::string& filename() const override { return _filename; }
     bool is_cache_hit() const override { return false; }
     StatusOr<std::string_view> peek_shared_buffer(int64_t count, SharedBufferPtr* shared_buffer);
+
+    // for test
+    int get_shared_buffer_size() {
+        return _map.size();
+    }
 
 private:
     void _update_estimated_mem_usage();

--- a/be/src/io/shared_buffered_input_stream.h
+++ b/be/src/io/shared_buffered_input_stream.h
@@ -80,6 +80,15 @@ public:
     Status set_io_ranges(const std::vector<IORange>& ranges, bool coalesce_lazy_column = true);
     void release_to_offset(int64_t offset);
     void release() override;
+
+    // If the range of IO Coalease is limited between a single column in shared data,
+    // we can release the buffer in advance when column_iterator get eos.
+    // If it is the entire file (lake_small_segment_file_threshold_size > file_size), it cannot be released in advance.
+    // return false only ranges of shared_buffer is the whole file.
+    bool can_release() override {
+        if (_map.empty() || _map.size() != 1) return true;
+        return _file_size == _map.begin()->second->size;
+    }
     void set_coalesce_options(const CoalesceOptions& options) { _options = options; }
     void set_align_size(int64_t size) { _align_size = size; }
 

--- a/be/src/storage/rowset/scalar_column_iterator.cpp
+++ b/be/src/storage/rowset/scalar_column_iterator.cpp
@@ -206,11 +206,10 @@ Status ScalarColumnIterator::next_batch(size_t* n, Column* dst) {
             bool eos = false;
             RETURN_IF_ERROR(_load_next_page(&eos));
             if (eos) {
-                // release shareBufferStream
-                if (config::io_coalesce_lake_read_enable && _opts.is_io_coalesce) {
+                // try release sharedBufferedStream advance
+                if (config::io_coalesce_lake_read_enable && _opts.is_io_coalesce && _opts.read_file->can_release()) {
                     _opts.read_file->release();
                 }
-                break;
             }
         }
 

--- a/be/src/storage/rowset/scalar_column_iterator.cpp
+++ b/be/src/storage/rowset/scalar_column_iterator.cpp
@@ -207,9 +207,7 @@ Status ScalarColumnIterator::next_batch(size_t* n, Column* dst) {
             RETURN_IF_ERROR(_load_next_page(&eos));
             if (eos) {
                 // try release sharedBufferedStream advance
-                if (config::io_coalesce_lake_read_enable && _opts.is_io_coalesce && _opts.read_file->can_release()) {
-                    _opts.read_file->release();
-                }
+                _opts.read_file->try_release();
             }
         }
 
@@ -246,10 +244,8 @@ Status ScalarColumnIterator::next_batch(const SparseRange<>& range, Column* dst)
             bool eos = false;
             RETURN_IF_ERROR(_load_next_page(&eos));
             if (eos) {
-                // release shareBufferStream
-                if (config::io_coalesce_lake_read_enable && _opts.is_io_coalesce) {
-                    _opts.read_file->release();
-                }
+                // try release sharedBufferedStream
+                _opts.read_file->try_release();
                 break;
             }
             end_ord = _page->first_ordinal() + _page->num_rows();

--- a/be/src/storage/rowset/scalar_column_iterator.cpp
+++ b/be/src/storage/rowset/scalar_column_iterator.cpp
@@ -208,10 +208,7 @@ Status ScalarColumnIterator::next_batch(size_t* n, Column* dst) {
             if (eos) {
                 // release shareBufferStream
                 if (config::io_coalesce_lake_read_enable && _opts.is_io_coalesce) {
-                    auto shared_buffer_stream = dynamic_cast<io::SharedBufferedInputStream*>(_opts.read_file);
-                    if (shared_buffer_stream != nullptr) {
-                        shared_buffer_stream->release();
-                    }
+                    _opts.read_file->release();
                 }
                 break;
             }
@@ -252,10 +249,7 @@ Status ScalarColumnIterator::next_batch(const SparseRange<>& range, Column* dst)
             if (eos) {
                 // release shareBufferStream
                 if (config::io_coalesce_lake_read_enable && _opts.is_io_coalesce) {
-                    auto shared_buffer_stream = dynamic_cast<io::SharedBufferedInputStream*>(_opts.read_file);
-                    if (shared_buffer_stream != nullptr) {
-                        shared_buffer_stream->release();
-                    }
+                    _opts.read_file->release();
                 }
                 break;
             }

--- a/be/src/storage/rowset/segment_iterator.cpp
+++ b/be/src/storage/rowset/segment_iterator.cpp
@@ -592,6 +592,8 @@ Status SegmentIterator::_init_column_iterator_by_cid(const ColumnId cid, const C
                     // read the entire file at once by set range{0, file_size}
                     std::vector<io::SharedBufferedInputStream::IORange> ranges = {{0, file_size}};
                     RETURN_IF_ERROR(_shared_buffered_input_stream->set_io_ranges(ranges));
+                } else {
+                    _shared_buffered_input_stream->increase_hold_count();
                 }
 
                 iter_opts.read_file = _shared_buffered_input_stream.get();

--- a/be/src/storage/rowset/segment_iterator.cpp
+++ b/be/src/storage/rowset/segment_iterator.cpp
@@ -595,6 +595,7 @@ Status SegmentIterator::_init_column_iterator_by_cid(const ColumnId cid, const C
                 }
 
                 iter_opts.read_file = _shared_buffered_input_stream.get();
+                _column_files[cid] = _shared_buffered_input_stream;
             } else {
                 auto shared_buffered_input_stream = std::make_shared<io::SharedBufferedInputStream>(
                         rfile->stream(), _segment->file_name(), file_size);

--- a/be/test/storage/lake/tablet_reader_test.cpp
+++ b/be/test/storage/lake/tablet_reader_test.cpp
@@ -929,7 +929,7 @@ TEST_F(LakeIOCoalesceTest, test_normal) {
     // test reader
     auto reader = std::make_shared<TabletReader>(_tablet_mgr.get(), _tablet_metadata, *_schema);
     config::io_coalesce_lake_read_enable = true;
-    config::lake_small_segment_file_threshold_size = 100 * 1024 * 1024 * 8; // 100MB
+    config::lake_small_segment_file_threshold_size = 100 * 1024 * 1024; // 100MB
 
     ASSERT_OK(reader->prepare());
     TabletReaderParams params;
@@ -983,6 +983,10 @@ TEST_F(LakeIOCoalesceTest, test_normal) {
     ASSERT_TRUE(reader2->get_next(read_chunk_ptr.get()).is_end_of_file());
 
     reader->close();
+
+    // reset config
+    config::io_coalesce_lake_read_enable = false;
+    config::lake_small_segment_file_threshold_size = 10485760;
 }
 
 } // namespace starrocks::lake

--- a/be/test/storage/lake/tablet_reader_test.cpp
+++ b/be/test/storage/lake/tablet_reader_test.cpp
@@ -843,4 +843,146 @@ TEST_F(DISABLED_LakeLoadSegmentParallelTest, test_normal) {
     reader->close();
 }
 
+class LakeIOCoalesceTest : public TestBase {
+public:
+    LakeIOCoalesceTest() : TestBase(kTestDirectory) {
+        _tablet_metadata = generate_simple_tablet_metadata(DUP_KEYS);
+        _tablet_schema = TabletSchema::create(_tablet_metadata->schema());
+        _schema = std::make_shared<Schema>(ChunkHelper::convert_schema(_tablet_schema));
+    }
+
+    void SetUp() override {
+        clear_and_init_test_dir();
+        CHECK_OK(_tablet_mgr->put_tablet_metadata(*_tablet_metadata));
+    }
+
+    void TearDown() override { remove_test_dir_ignore_error(); }
+
+protected:
+    constexpr static const char* const kTestDirectory = "test_lake_io_coalesce_test";
+
+    std::shared_ptr<TabletMetadata> _tablet_metadata;
+    std::shared_ptr<TabletSchema> _tablet_schema;
+    std::shared_ptr<Schema> _schema;
+};
+
+TEST_F(LakeIOCoalesceTest, test_normal) {
+    std::vector<int> k0{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22};
+    std::vector<int> v0{2, 4, 6, 8, 10, 12, 14, 16, 18, 20, 22, 24, 26, 28, 30, 32, 34, 36, 38, 40, 41, 44};
+
+    std::vector<int> k1{30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41};
+    std::vector<int> v1{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11};
+
+    auto c0 = Int32Column::create();
+    auto c1 = Int32Column::create();
+    auto c2 = Int32Column::create();
+    auto c3 = Int32Column::create();
+    c0->append_numbers(k0.data(), k0.size() * sizeof(int));
+    c1->append_numbers(v0.data(), v0.size() * sizeof(int));
+    c2->append_numbers(k1.data(), k1.size() * sizeof(int));
+    c3->append_numbers(v1.data(), v1.size() * sizeof(int));
+
+    Chunk chunk0({c0, c1}, _schema);
+    Chunk chunk1({c2, c3}, _schema);
+
+    const int segment_rows = chunk0.num_rows() + chunk1.num_rows();
+
+    VersionedTablet tablet(_tablet_mgr.get(), _tablet_metadata);
+    {
+        int64_t txn_id = next_id();
+        // write rowset 1 with 2 segments
+        ASSIGN_OR_ABORT(auto writer, tablet.new_writer(kHorizontal, txn_id));
+        ASSERT_OK(writer->open());
+
+        // write rowset data
+        // segment #1
+        ASSERT_OK(writer->write(chunk0));
+        ASSERT_OK(writer->write(chunk1));
+        ASSERT_OK(writer->finish());
+
+        // segment #2
+        ASSERT_OK(writer->write(chunk0));
+        ASSERT_OK(writer->write(chunk1));
+        ASSERT_OK(writer->finish());
+
+        auto files = writer->files();
+        ASSERT_EQ(2, files.size());
+
+        // add rowset metadata
+        auto* rowset = _tablet_metadata->add_rowsets();
+        rowset->set_overlapped(true);
+        rowset->set_id(1);
+        auto* segs = rowset->mutable_segments();
+        auto* segs_size = rowset->mutable_segment_size();
+        for (auto& file : writer->files()) {
+            segs->Add(std::move(file.path));
+            segs_size->Add(std::move(file.size.value()));
+        }
+
+        writer->close();
+    }
+
+    // write tablet metadata
+    _tablet_metadata->set_version(2);
+    CHECK_OK(_tablet_mgr->put_tablet_metadata(*_tablet_metadata));
+
+    // test reader
+    auto reader = std::make_shared<TabletReader>(_tablet_mgr.get(), _tablet_metadata, *_schema);
+    config::io_coalesce_lake_read_enable = true;
+    config::lake_small_segment_file_threshold_size = 100 * 1024 * 1024 * 8; // 100MB
+
+    ASSERT_OK(reader->prepare());
+    TabletReaderParams params;
+    ASSERT_OK(reader->open(params));
+
+    auto read_chunk_ptr = ChunkHelper::new_chunk(*_schema, 1024);
+    for (int j = 0; j < 2; ++j) {
+        read_chunk_ptr->reset();
+        ASSERT_OK(reader->get_next(read_chunk_ptr.get()));
+        ASSERT_EQ(segment_rows, read_chunk_ptr->num_rows());
+        for (int i = 0, sz = k0.size(); i < sz; i++) {
+            EXPECT_EQ(k0[i], read_chunk_ptr->get(i)[0].get_int32());
+            EXPECT_EQ(v0[i], read_chunk_ptr->get(i)[1].get_int32());
+        }
+        for (int i = 0, sz = k1.size(); i < sz; i++) {
+            EXPECT_EQ(k1[i], read_chunk_ptr->get(k0.size() + i)[0].get_int32());
+            EXPECT_EQ(v1[i], read_chunk_ptr->get(k0.size() + i)[1].get_int32());
+        }
+    }
+
+    read_chunk_ptr->reset();
+    ASSERT_TRUE(reader->get_next(read_chunk_ptr.get()).is_end_of_file());
+
+    reader->close();
+
+    // test reader
+    // config::lake_small_segment_file_threshold_size is set to 1
+    auto reader2 = std::make_shared<TabletReader>(_tablet_mgr.get(), _tablet_metadata, *_schema);
+    config::io_coalesce_lake_read_enable = true;
+    config::lake_small_segment_file_threshold_size = 1;
+
+    ASSERT_OK(reader2->prepare());
+    ASSERT_OK(reader2->open(params));
+
+    read_chunk_ptr = ChunkHelper::new_chunk(*_schema, 1024);
+    for (int j = 0; j < 2; ++j) {
+        read_chunk_ptr->reset();
+        ASSERT_OK(reader2->get_next(read_chunk_ptr.get()));
+        ASSERT_EQ(segment_rows, read_chunk_ptr->num_rows());
+        for (int i = 0, sz = k0.size(); i < sz; i++) {
+            EXPECT_EQ(k0[i], read_chunk_ptr->get(i)[0].get_int32());
+            EXPECT_EQ(v0[i], read_chunk_ptr->get(i)[1].get_int32());
+        }
+        for (int i = 0, sz = k1.size(); i < sz; i++) {
+            EXPECT_EQ(k1[i], read_chunk_ptr->get(k0.size() + i)[0].get_int32());
+            EXPECT_EQ(v1[i], read_chunk_ptr->get(k0.size() + i)[1].get_int32());
+        }
+    }
+
+    read_chunk_ptr->reset();
+    ASSERT_TRUE(reader2->get_next(read_chunk_ptr.get()).is_end_of_file());
+
+    reader->close();
+}
+
 } // namespace starrocks::lake


### PR DESCRIPTION
## Why I'm doing:
`io_coalesce` is enabled to merge io ranges between single column in shared data.  As `io coalesce` cannot merge ranges between columns, so it is likely to not take effect for relatively small segment files.
## What I'm doing:
Just read the whole segemnt file when file size less than `config::io_coalesce_lake_read_whole_file_size_bytes` when `io_coalesce_lake_read_enable` is enabled.
Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5