### PR TITLE
[Feature] Support populate datacache asynchronously. (backport #40489)

### DIFF
--- a/be/src/block_cache/block_cache.cpp
+++ b/be/src/block_cache/block_cache.cpp
@@ -156,7 +156,6 @@ const DataCacheMetrics BlockCache::cache_metrics(int level) const {
 
 Status BlockCache::shutdown() {
     Status st = _kv_cache->shutdown();
-    _kv_cache = nullptr;
     _initialized.store(false, std::memory_order_relaxed);
     return st;
 }

--- a/be/src/block_cache/cachelib_wrapper.cpp
+++ b/be/src/block_cache/cachelib_wrapper.cpp
@@ -42,7 +42,9 @@ Status CacheLibWrapper::init(const CacheOptions& options) {
         }
         nvmConfig.navyConfig.blockCache().setRegionSize(16 * 1024 * 1024);
         nvmConfig.navyConfig.blockCache().setDataChecksum(options.enable_checksum);
-        nvmConfig.navyConfig.setMaxParcelMemoryMB(options.max_flying_memory_mb);
+        if (options.max_flying_memory_mb > 0) {
+            nvmConfig.navyConfig.setMaxParcelMemoryMB(options.max_flying_memory_mb);
+        }
         nvmConfig.navyConfig.setMaxConcurrentInserts(options.max_concurrent_inserts);
         config.enableNvmCache(nvmConfig);
     }

--- a/be/src/block_cache/starcache_wrapper.cpp
+++ b/be/src/block_cache/starcache_wrapper.cpp
@@ -19,6 +19,7 @@
 #include "common/logging.h"
 #include "common/statusor.h"
 #include "gutil/strings/fastmem.h"
+#include "runtime/current_thread.h"
 #include "util/filesystem_util.h"
 
 namespace starrocks {
@@ -33,11 +34,12 @@ Status StarCacheWrapper::init(const CacheOptions& options) {
     opt.enable_disk_checksum = options.enable_checksum;
     opt.max_concurrent_writes = options.max_concurrent_inserts;
     opt.enable_os_page_cache = !options.enable_direct_io;
+    opt.scheduler_thread_ratio_per_cpu = options.scheduler_threads_per_cpu;
+    opt.max_flying_memory_mb = options.max_flying_memory_mb;
+    _cache_adaptor.reset(starcache::create_default_adaptor(options.skip_read_factor));
+    opt.cache_adaptor = _cache_adaptor.get();
     opt.instance_name = "dla_cache";
-    if (options.enable_cache_adaptor) {
-        _cache_adaptor.reset(starcache::create_default_adaptor(options.skip_read_factor));
-        opt.cache_adaptor = _cache_adaptor.get();
-    }
+    _enable_tiered_cache = options.enable_tiered_cache;
     _cache = std::make_unique<starcache::StarCache>();
     return to_status(_cache->init(opt));
 }
@@ -46,11 +48,25 @@ Status StarCacheWrapper::write_buffer(const std::string& key, const IOBuffer& bu
     if (!options) {
         return to_status(_cache->set(key, buffer.const_raw_buf(), nullptr));
     }
+
     starcache::WriteOptions opts;
     opts.ttl_seconds = options->ttl_seconds;
     opts.overwrite = options->overwrite;
-    auto st = to_status(_cache->set(key, buffer.const_raw_buf(), &opts));
-    if (st.ok()) {
+    opts.async = options->async;
+    opts.keep_alive = options->allow_zero_copy;
+    opts.callback = options->callback;
+    opts.mode = _enable_tiered_cache ? starcache::WriteOptions::WriteMode::WRITE_BACK
+                                     : starcache::WriteOptions::WriteMode::WRITE_THROUGH;
+    Status st;
+    {
+        // The memory when writing starcache is no longer recorded to the query memory.
+        // Because we free the memory in other threads in starcache library, which is hard to track.
+        // It is safe because we limit the flying memory in starcache, also, this behavior
+        // doesn't affect the process memory tracker.
+        SCOPED_THREAD_LOCAL_MEM_TRACKER_SETTER(nullptr);
+        st = to_status(_cache->set(key, buffer.const_raw_buf(), &opts));
+    }
+    if (st.ok() && !opts.async) {
         options->stats.write_mem_bytes = opts.stats.write_mem_bytes;
         options->stats.write_disk_bytes = opts.stats.write_disk_bytes;
     }
@@ -65,7 +81,11 @@ Status StarCacheWrapper::write_object(const std::string& key, const void* ptr, s
     starcache::WriteOptions opts;
     opts.ttl_seconds = options->ttl_seconds;
     opts.overwrite = options->overwrite;
-    auto st = to_status(_cache->set_object(key, ptr, size, deleter, handle, &opts));
+    Status st;
+    {
+        SCOPED_THREAD_LOCAL_MEM_TRACKER_SETTER(nullptr);
+        st = to_status(_cache->set_object(key, ptr, size, deleter, handle, &opts));
+    }
     if (st.ok()) {
         options->stats.write_mem_bytes = size;
     }
@@ -78,9 +98,9 @@ Status StarCacheWrapper::read_buffer(const std::string& key, size_t off, size_t 
         return to_status(_cache->read(key, off, size, &buffer->raw_buf(), nullptr));
     }
     starcache::ReadOptions opts;
-    if (_cache_adaptor) {
-        opts.use_adaptor = true;
-    }
+    opts.use_adaptor = options->use_adaptor;
+    opts.mode = _enable_tiered_cache ? starcache::ReadOptions::ReadMode::READ_BACK
+                                     : starcache::ReadOptions::ReadMode::READ_THROUGH;
     auto st = to_status(_cache->read(key, off, size, &buffer->raw_buf(), &opts));
     if (st.ok()) {
         options->stats.read_mem_bytes = opts.stats.read_mem_bytes;

--- a/be/src/block_cache/starcache_wrapper.h
+++ b/be/src/block_cache/starcache_wrapper.h
@@ -53,6 +53,7 @@ public:
 private:
     std::unique_ptr<starcache::StarCache> _cache;
     std::unique_ptr<starcache::TimeBasedCacheAdaptor> _cache_adaptor;
+    bool _enable_tiered_cache = false;
 };
 
 // In order to split the starcache library to a separate registry for other users such as the cloud team,

--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -1063,15 +1063,24 @@ CONF_Bool(datacache_direct_io_enable, "false");
 CONF_Int64(datacache_max_concurrent_inserts, "1500000");
 // Total memory limit for in-flight cache jobs.
 // Once this is reached, cache populcation will be rejected until the flying memory usage gets under the limit.
-CONF_Int64(datacache_max_flying_memory_mb, "256");
-// Whether to use datacache adaptor, which will skip reading cache when disk overload is high.
-CONF_Bool(datacache_adaptor_enable, "true");
-// A factor to control the io traffic between cache and network. The larger this parameter,
-// the more requests will be sent to the network.
+// If zero, the datacache module will automatically calculate a resonable default value based on block size.
+CONF_Int64(datacache_max_flying_memory_mb, "2");
+// An io adaptor factor to control the io traffic between cache and network.
+// The larger this parameter, the more requests will be sent to the network.
 // Usually there is no need to modify it.
-CONF_Int64(datacache_skip_read_factor, "1");
+CONF_Double(datacache_skip_read_factor, "1.0");
 // Whether to use block buffer to hold the datacache block data.
 CONF_Bool(datacache_block_buffer_enable, "true");
+// To control how many threads will be created for datacache synchronous tasks.
+// For the default value, it means for every 8 cpu, one thread will be created.
+CONF_Double(datacache_scheduler_threads_per_cpu, "0.125");
+// To control whether cache raw data both in memory and disk.
+// If true, the raw data will be written to the tiered cache composed of memory cache and disk cache,
+// and the memory cache hotter data than disk.
+// If false, the raw data will be written to disk directly and read from disk without promotion.
+// For object data, such as parquet footer object, which can only be cached in memory are not affected
+// by this configuration.
+CONF_Bool(datacache_tiered_cache_enable, "true");
 // DataCache engines, alternatives: cachelib, starcache.
 // Set the default value empty to indicate whether it is manully configured by users.
 // If not, we need to adjust the default engine based on build switches like "WITH_CACHELIB" and "WITH_STARCACHE".

--- a/be/src/connector/hive_connector.cpp
+++ b/be/src/connector/hive_connector.cpp
@@ -102,6 +102,12 @@ Status HiveDataSource::open(RuntimeState* state) {
     if (state->query_options().__isset.enable_populate_datacache) {
         _enable_populate_datacache = state->query_options().enable_populate_datacache;
     }
+    if (state->query_options().__isset.enable_datacache_async_populate_mode) {
+        _enable_datacache_aync_populate_mode = state->query_options().enable_datacache_async_populate_mode;
+    }
+    if (state->query_options().__isset.enable_datacache_io_adaptor) {
+        _enable_datacache_io_adaptor = state->query_options().enable_datacache_io_adaptor;
+    }
     if (state->query_options().__isset.enable_dynamic_prune_scan_range) {
         _enable_dynamic_prune_scan_range = state->query_options().enable_dynamic_prune_scan_range;
     }
@@ -807,6 +813,8 @@ Status HiveDataSource::_init_scanner(RuntimeState* state) {
     }
     scanner_params.use_datacache = _use_datacache;
     scanner_params.enable_populate_datacache = _enable_populate_datacache;
+    scanner_params.enable_datacache_async_populate_mode = _enable_datacache_aync_populate_mode;
+    scanner_params.enable_datacache_io_adaptor = _enable_datacache_io_adaptor;
     scanner_params.can_use_any_column = _can_use_any_column;
     scanner_params.can_use_min_max_count_opt = _can_use_min_max_count_opt;
     scanner_params.use_file_metacache = _use_file_metacache;

--- a/be/src/connector/hive_connector.h
+++ b/be/src/connector/hive_connector.h
@@ -110,6 +110,8 @@ private:
     HdfsScanner* _scanner = nullptr;
     bool _use_datacache = false;
     bool _enable_populate_datacache = false;
+    bool _enable_datacache_aync_populate_mode = false;
+    bool _enable_datacache_io_adaptor = false;
     bool _enable_dynamic_prune_scan_range = true;
     bool _use_file_metacache = false;
     bool _enable_split_tasks = false;

--- a/be/src/exec/hdfs_scanner.cpp
+++ b/be/src/exec/hdfs_scanner.cpp
@@ -225,6 +225,8 @@ Status HdfsScanner::open_random_access_file() {
         _cache_input_stream = std::make_shared<io::CacheInputStream>(_shared_buffered_input_stream, filename, file_size,
                                                                      _scanner_params.modification_time);
         _cache_input_stream->set_enable_populate_cache(_scanner_params.enable_populate_datacache);
+        _cache_input_stream->set_enable_async_populate_mode(_scanner_params.enable_datacache_async_populate_mode);
+        _cache_input_stream->set_enable_cache_io_adaptor(_scanner_params.enable_datacache_io_adaptor);
         _cache_input_stream->set_enable_block_buffer(config::datacache_block_buffer_enable);
         _shared_buffered_input_stream->set_align_size(_cache_input_stream->get_align_size());
         input_stream = _cache_input_stream;

--- a/be/src/exec/hdfs_scanner.h
+++ b/be/src/exec/hdfs_scanner.h
@@ -212,6 +212,8 @@ struct HdfsScannerParams {
 
     bool use_datacache = false;
     bool enable_populate_datacache = false;
+    bool enable_datacache_async_populate_mode = false;
+    bool enable_datacache_io_adaptor = false;
 
     std::atomic<int32_t>* lazy_column_coalesce_counter;
     bool can_use_any_column = false;

--- a/be/src/io/cache_input_stream.cpp
+++ b/be/src/io/cache_input_stream.cpp
@@ -63,9 +63,26 @@ CacheInputStream::CacheInputStream(const std::shared_ptr<SharedBufferedInputStre
 }
 
 CacheInputStream::~CacheInputStream() {
-    int64_t io_bytes = _sb_stream->shared_io_bytes();
-    if (io_bytes > 0) {
-        int64_t latency_us_per_block = (_sb_stream->shared_io_timer() / 1000 * _block_size / io_bytes);
+    int64_t io_bytes = _sb_stream->shared_io_bytes() + _sb_stream->direct_io_bytes();
+    if (_enable_cache_io_adaptor && io_bytes > 0) {
+        int64_t latency_us_per_block = (_sb_stream->shared_io_timer() + _sb_stream->direct_io_timer()) / 1000;
+        // We try to estimate the average latency for accessing one block.
+        // However, there is not a linear ratio between the read bytes and the read latency. For example,
+        // the latency of accessing 1M bytes is usually less than 4 times that of accessing 256K bytes.
+        // It makes the accurate estimation difficult.
+        // So, we just use an approximate ratio to optimize the estimation. The value 2 is only an empirical value,
+        // which may not be entirely accurate, but in most cases it can reflect this computational relationship.
+        // If the total `io_bytes` between `[_block_size / 2, _block_size * 2]`, we treat their average latency for
+        // accessing one block are same as the total `io_time`. In other cases, we will calculate the that latency
+        // by their linear scale with the approximate ratio.
+        static const int64_t approximate_ratio = 2;
+        if (io_bytes > approximate_ratio * _block_size) {
+            latency_us_per_block =
+                    std::min(latency_us_per_block, latency_us_per_block * _block_size / io_bytes * approximate_ratio);
+        } else if (io_bytes * approximate_ratio < _block_size) {
+            latency_us_per_block =
+                    std::max(latency_us_per_block, latency_us_per_block * _block_size / io_bytes / approximate_ratio);
+        }
         _cache->record_read_remote(io_bytes, latency_us_per_block);
     }
 }
@@ -92,7 +109,7 @@ Status CacheInputStream::_read_block_from_local(const int64_t offset, const int6
     int64_t load_size = std::min(_block_size, _size - block_offset);
     int64_t shift = offset - block_offset;
 
-    SharedBufferedInputStream::SharedBuffer* sb = nullptr;
+    SharedBufferPtr sb = nullptr;
     if (_enable_block_buffer) {
         auto ret = _sb_stream->find_shared_buffer(offset, size);
         if (ret.ok()) {
@@ -101,7 +118,7 @@ Status CacheInputStream::_read_block_from_local(const int64_t offset, const int6
                 strings::memcpy_inlined(out, sb->buffer.data() + offset - sb->offset, size);
                 if (_enable_populate_cache) {
                     _populate_cache_from_zero_copy_buffer((const char*)sb->buffer.data() + block_offset - sb->offset,
-                                                          block_offset, load_size);
+                                                          block_offset, load_size, sb);
                 }
                 return Status::OK();
             }
@@ -115,6 +132,7 @@ Status CacheInputStream::_read_block_from_local(const int64_t offset, const int6
     ReadCacheOptions options;
     size_t read_size = 0;
     {
+        options.use_adaptor = _enable_cache_io_adaptor;
         SCOPED_RAW_TIMER(&read_cache_ns);
         if (_enable_block_buffer) {
             res = _cache->read_buffer(_cache_key, block_offset, load_size, &block.buffer, &options);
@@ -136,7 +154,9 @@ Status CacheInputStream::_read_block_from_local(const int64_t offset, const int6
         _stats.read_mem_cache_bytes += options.stats.read_mem_bytes;
         _stats.read_disk_cache_bytes += options.stats.read_disk_bytes;
         _stats.read_cache_ns += read_cache_ns;
-        _cache->record_read_cache(read_size, read_cache_ns / 1000);
+        if (_enable_cache_io_adaptor) {
+            _cache->record_read_cache(read_size, read_cache_ns / 1000);
+        }
         return Status::OK();
     } else if (res.is_resource_busy()) {
         _stats.skip_read_cache_count += 1;
@@ -175,7 +195,7 @@ Status CacheInputStream::_read_blocks_from_remote(const int64_t offset, const in
         auto ret = _sb_stream->find_shared_buffer(read_offset_cursor, read_size);
         if (ret.ok()) {
             const uint8_t* buffer = nullptr;
-            RETURN_IF_ERROR(_sb_stream->get_bytes(&buffer, read_offset_cursor, read_size));
+            RETURN_IF_ERROR(_sb_stream->get_bytes(&buffer, read_offset_cursor, read_size, ret.value()));
             src = (char*)buffer;
         } else {
             RETURN_IF_ERROR(_sb_stream->read_at_fully(read_offset_cursor, _buffer.data(), read_size));
@@ -215,28 +235,39 @@ Status CacheInputStream::_populate_to_cache(const int64_t offset, const int64_t 
     for (int64_t write_offset_cursor = offset; write_offset_cursor < write_end_offset;) {
         DCHECK(write_offset_cursor % _block_size == 0);
         WriteCacheOptions options{};
+        options.async = _enable_async_populate_mode;
         const int64_t write_size = std::min(_block_size, write_end_offset - write_offset_cursor);
+
+        SharedBufferPtr sb = nullptr;
+        auto ret = _sb_stream->find_shared_buffer(write_offset_cursor, write_size);
+        if (ret.ok() && options.async) {
+            sb = ret.value();
+            auto cb = [sb](int code, const std::string& msg) {
+                // We only need to keep the shared buffer pointer
+                LOG_IF(WARNING, code != 0 && code != EEXIST) << "write block cache failed, errmsg: " << msg;
+            };
+            options.callback = cb;
+            options.allow_zero_copy = true;
+        }
         Status r = _cache->write_buffer(_cache_key, write_offset_cursor, write_size, src_cursor, &options);
-
-        src_cursor += write_size;
-        write_offset_cursor += write_size;
-
         if (r.ok()) {
             _stats.write_cache_count += 1;
             _stats.write_cache_bytes += write_size;
             _stats.write_mem_cache_bytes += options.stats.write_mem_bytes;
             _stats.write_disk_cache_bytes += options.stats.write_disk_bytes;
-        } else if (!r.is_already_exist()) {
+        } else if (!r.is_already_exist() && !r.is_resource_busy()) {
             _stats.write_cache_fail_count += 1;
             _stats.write_cache_fail_bytes += write_size;
             LOG(WARNING) << "write block cache failed, errmsg: " << r.message();
             // Failed to write cache, but we can keep processing query.
         }
+        src_cursor += write_size;
+        write_offset_cursor += write_size;
     }
     return Status::OK();
 }
 
-void CacheInputStream::_deduplicate_shared_buffer(SharedBufferedInputStream::SharedBuffer* sb) {
+void CacheInputStream::_deduplicate_shared_buffer(const SharedBufferPtr& sb) {
     if (sb->size == 0 || _block_map.empty()) {
         return;
     }
@@ -261,9 +292,11 @@ void CacheInputStream::_deduplicate_shared_buffer(SharedBufferedInputStream::Sha
         _block_map.erase(i);
     }
 
-    sb->offset = std::max(start_block_id * _block_size, sb->offset);
-    int64_t end = std::min((end_block_id + 1) * _block_size, end_offset);
-    sb->size = end - sb->offset;
+    if (sb->buffer.capacity() == 0) {
+        sb->offset = std::max(start_block_id * _block_size, sb->offset);
+        int64_t end = std::min((end_block_id + 1) * _block_size, end_offset);
+        sb->size = end - sb->offset;
+    }
 }
 
 struct ReadFromRemoteIORange {
@@ -378,22 +411,32 @@ int64_t CacheInputStream::get_align_size() const {
 StatusOr<std::string_view> CacheInputStream::peek(int64_t count) {
     // if app level uses zero copy read, it does bypass the cache layer.
     // so here we have to fill cache manually.
-    ASSIGN_OR_RETURN(auto s, _sb_stream->peek(count));
+    SharedBufferPtr sb;
+    ASSIGN_OR_RETURN(auto s, _sb_stream->peek_shared_buffer(count, &sb));
     if (_enable_populate_cache) {
-        _populate_cache_from_zero_copy_buffer(s.data(), _offset, count);
+        _populate_cache_from_zero_copy_buffer(s.data(), _offset, count, sb);
     }
     return s;
 }
 
-void CacheInputStream::_populate_cache_from_zero_copy_buffer(const char* p, int64_t offset, int64_t count) {
+void CacheInputStream::_populate_cache_from_zero_copy_buffer(const char* p, int64_t offset, int64_t count,
+                                                             const SharedBufferPtr& sb) {
     BlockCache* cache = BlockCache::instance();
     int64_t begin = offset / _block_size * _block_size;
     int64_t end = std::min((offset + count + _block_size - 1) / _block_size * _block_size, _size);
     p -= (offset - begin);
-    auto f = [&](const char* buf, size_t offset, size_t size) {
+    auto f = [cache, sb, this](const char* buf, size_t offset, size_t size) {
         SCOPED_RAW_TIMER(&_stats.write_cache_ns);
         WriteCacheOptions options;
-        options.overwrite = false;
+        options.async = _enable_async_populate_mode;
+        if (options.async) {
+            auto cb = [sb](int code, const std::string& msg) {
+                // We only need to keep the shared buffer pointer
+                LOG_IF(WARNING, code != 0 && code != EEXIST) << "write block cache failed, errmsg: " << msg;
+            };
+            options.callback = cb;
+            options.allow_zero_copy = true;
+        }
         Status r = cache->write_buffer(_cache_key, offset, size, buf, &options);
         if (r.ok()) {
             _stats.write_cache_count += 1;
@@ -403,7 +446,7 @@ void CacheInputStream::_populate_cache_from_zero_copy_buffer(const char* p, int6
         } else if (r.is_cancelled()) {
             _stats.skip_write_cache_count += 1;
             _stats.skip_write_cache_bytes += size;
-        } else if (!r.is_already_exist()) {
+        } else if (!r.is_already_exist() && !r.is_resource_busy()) {
             _stats.write_cache_fail_count += 1;
             _stats.write_cache_fail_bytes += size;
             LOG(WARNING) << "write block cache failed, errmsg: " << r.message();

--- a/be/src/io/cache_input_stream.h
+++ b/be/src/io/cache_input_stream.h
@@ -65,7 +65,11 @@ public:
 
     void set_enable_populate_cache(bool v) { _enable_populate_cache = v; }
 
+    void set_enable_async_populate_mode(bool v) { _enable_async_populate_mode = v; }
+
     void set_enable_block_buffer(bool v) { _enable_block_buffer = v; }
+
+    void set_enable_cache_io_adaptor(bool v) { _enable_cache_io_adaptor = v; }
 
     int64_t get_align_size() const;
 
@@ -81,14 +85,15 @@ private:
         int64_t offset;
         IOBuffer buffer;
     };
+    using SharedBufferPtr = SharedBufferedInputStream::SharedBufferPtr;
 
     // Read block from local, if not found, will return Status::NotFound();
     Status _read_block_from_local(const int64_t offset, const int64_t size, char* out);
     // Read multiple blocks from remote
     Status _read_blocks_from_remote(const int64_t offset, const int64_t size, char* out);
     Status _populate_to_cache(const int64_t offset, const int64_t size, char* src);
-    void _populate_cache_from_zero_copy_buffer(const char* p, int64_t offset, int64_t count);
-    void _deduplicate_shared_buffer(SharedBufferedInputStream::SharedBuffer* sb);
+    void _populate_cache_from_zero_copy_buffer(const char* p, int64_t offset, int64_t count, const SharedBufferPtr& sb);
+    void _deduplicate_shared_buffer(const SharedBufferPtr& sb);
 
     std::string _cache_key;
     std::string _filename;
@@ -99,7 +104,9 @@ private:
     Stats _stats;
     int64_t _size;
     bool _enable_populate_cache = false;
+    bool _enable_async_populate_mode = false;
     bool _enable_block_buffer = false;
+    bool _enable_cache_io_adaptor = false;
     BlockCache* _cache = nullptr;
     int64_t _block_size = 0;
     std::unordered_map<int64_t, BlockBuffer> _block_map;

--- a/be/src/service/service_be/starrocks_be.cpp
+++ b/be/src/service/service_be/starrocks_be.cpp
@@ -107,8 +107,9 @@ Status init_datacache(GlobalEnv* global_env) {
         cache_options.max_concurrent_inserts = config::datacache_max_concurrent_inserts;
         cache_options.enable_checksum = config::datacache_checksum_enable;
         cache_options.enable_direct_io = config::datacache_direct_io_enable;
-        cache_options.enable_cache_adaptor = starrocks::config::datacache_adaptor_enable;
+        cache_options.enable_tiered_cache = config::datacache_tiered_cache_enable;
         cache_options.skip_read_factor = starrocks::config::datacache_skip_read_factor;
+        cache_options.scheduler_threads_per_cpu = starrocks::config::datacache_scheduler_threads_per_cpu;
         cache_options.engine = config::datacache_engine;
         return cache->init(cache_options);
     }

--- a/be/test/io/cache_input_stream_test.cpp
+++ b/be/test/io/cache_input_stream_test.cpp
@@ -50,8 +50,9 @@ private:
 
 class CacheInputStreamTest : public ::testing::Test {
 public:
-    static void SetUpTestCase() {
-        auto cache = BlockCache::instance();
+    static void SetUpTestCase() {}
+
+    CacheOptions cache_options() {
         CacheOptions options;
         options.mem_space_size = 100 * 1024 * 1024;
 #ifdef WITH_STARCACHE
@@ -61,11 +62,19 @@ public:
 #endif
         options.enable_checksum = false;
         options.max_concurrent_inserts = 1500000;
+        options.max_flying_memory_mb = 100;
+        options.enable_tiered_cache = true;
         options.block_size = block_size;
-        ASSERT_OK(cache->init(options));
+        options.skip_read_factor = 1.0;
+        return options;
     }
 
-    static void TearDownTestCase() { BlockCache::instance()->shutdown(); }
+    static void TearDownTestCase() {
+        auto cache = BlockCache::instance();
+        if (cache) {
+            BlockCache::instance()->shutdown();
+        }
+    }
 
     void SetUp() override {}
     void TearDown() override {}
@@ -96,9 +105,12 @@ public:
     static const int64_t block_size;
 };
 
-const int64_t CacheInputStreamTest::block_size = 1024 * 1024;
+const int64_t CacheInputStreamTest::block_size = 256 * 1024;
 
 TEST_F(CacheInputStreamTest, test_aligned_read) {
+    CacheOptions options = cache_options();
+    ASSERT_OK(BlockCache::instance()->init(options));
+
     const int64_t block_count = 3;
 
     int64_t data_size = block_size * block_count;
@@ -132,6 +144,9 @@ TEST_F(CacheInputStreamTest, test_aligned_read) {
 }
 
 TEST_F(CacheInputStreamTest, test_random_read) {
+    CacheOptions options = cache_options();
+    ASSERT_OK(BlockCache::instance()->init(options));
+
     const int64_t block_count = 3;
 
     const int64_t data_size = block_size * block_count;
@@ -171,6 +186,9 @@ TEST_F(CacheInputStreamTest, test_random_read) {
 }
 
 TEST_F(CacheInputStreamTest, test_file_overwrite) {
+    CacheOptions options = cache_options();
+    ASSERT_OK(BlockCache::instance()->init(options));
+
     const int64_t block_count = 3;
 
     int64_t data_size = block_size * block_count;
@@ -215,6 +233,9 @@ TEST_F(CacheInputStreamTest, test_file_overwrite) {
 }
 
 TEST_F(CacheInputStreamTest, test_read_from_io_buffer) {
+    CacheOptions options = cache_options();
+    ASSERT_OK(BlockCache::instance()->init(options));
+
     const int64_t block_count = 1;
 
     int64_t data_size = block_size * block_count;
@@ -249,6 +270,9 @@ TEST_F(CacheInputStreamTest, test_read_from_io_buffer) {
 }
 
 TEST_F(CacheInputStreamTest, test_read_zero_copy) {
+    CacheOptions options = cache_options();
+    ASSERT_OK(BlockCache::instance()->init(options));
+
     int64_t data_size = block_size + 1024;
     char data[data_size + 1];
     gen_test_data(data, data_size, block_size);
@@ -270,6 +294,9 @@ TEST_F(CacheInputStreamTest, test_read_zero_copy) {
 }
 
 TEST_F(CacheInputStreamTest, test_read_with_zero_range) {
+    CacheOptions options = cache_options();
+    ASSERT_OK(BlockCache::instance()->init(options));
+
     const int64_t block_count = 1;
     int64_t data_size = block_size * block_count;
     char data[data_size + 1];
@@ -294,6 +321,161 @@ TEST_F(CacheInputStreamTest, test_read_with_zero_range) {
     // try read zero length data, expect no crash
     read_stream_data(&cache_stream, 0, 0, nullptr);
     ASSERT_EQ(stats.read_cache_count, 0);
+}
+
+TEST_F(CacheInputStreamTest, test_read_with_adaptor) {
+    CacheOptions options = cache_options();
+    // Because the cache adaptor only work for disk cache.
+    options.disk_spaces.push_back({.path = "./block_disk_cache", .size = 300 * 1024 * 1024});
+    options.enable_tiered_cache = false;
+    ASSERT_OK(BlockCache::instance()->init(options));
+
+    const int64_t block_count = 2;
+
+    int64_t data_size = block_size * block_count;
+    char data[data_size + 1];
+    gen_test_data(data, data_size, block_size);
+
+    const std::string file_name = "test_file5";
+    std::shared_ptr<io::SeekableInputStream> stream(new MockSeekableInputStream(data, data_size));
+    std::shared_ptr<io::SharedBufferedInputStream> sb_stream(
+            new io::SharedBufferedInputStream(stream, file_name, data_size));
+    io::CacheInputStream cache_stream(sb_stream, file_name, data_size, 1000000);
+    cache_stream.set_enable_populate_cache(true);
+    cache_stream.set_enable_cache_io_adaptor(true);
+    auto& stats = cache_stream.stats();
+
+    const size_t read_size = block_size * block_count;
+    sb_stream->_shared_io_bytes = read_size;
+    sb_stream->_shared_io_timer = 10000;
+
+    // first read from backend
+    {
+        char buffer[read_size];
+        read_stream_data(&cache_stream, 0, read_size, buffer);
+        ASSERT_TRUE(check_data_content(buffer, block_size, 'a'));
+        ASSERT_TRUE(check_data_content(buffer + block_size, block_size, 'b'));
+        ASSERT_EQ(stats.read_cache_count, 0);
+        ASSERT_EQ(stats.write_cache_count, block_count);
+    }
+
+    auto cache = BlockCache::instance();
+    const int kAdaptorWindowSize = 50;
+
+    {
+        // Record read latencyr to ensure cache latency > remote latency
+        // so all blocks read from remote.
+        for (size_t i = 0; i < kAdaptorWindowSize; ++i) {
+            cache->record_read_cache(read_size, 1000000000);
+            cache->record_read_remote(read_size, 10);
+        }
+        char buffer[read_size];
+        read_stream_data(&cache_stream, 0, read_size, buffer);
+        ASSERT_TRUE(check_data_content(buffer, block_size, 'a'));
+        ASSERT_TRUE(check_data_content(buffer + block_size, block_size, 'b'));
+        ASSERT_EQ(stats.read_cache_count, 0);
+    }
+
+    {
+        // Record read latencyr to ensure cache latency < remote latency
+        // so all blocks read from cache.
+        for (size_t i = 0; i < kAdaptorWindowSize; ++i) {
+            cache->record_read_cache(read_size, 10);
+            cache->record_read_remote(read_size, 1000000000);
+        }
+        char buffer[read_size];
+        read_stream_data(&cache_stream, 0, read_size, buffer);
+        ASSERT_TRUE(check_data_content(buffer, block_size, 'a'));
+        ASSERT_TRUE(check_data_content(buffer + block_size, block_size, 'b'));
+        ASSERT_EQ(stats.read_cache_count, block_count);
+    }
+}
+
+TEST_F(CacheInputStreamTest, test_read_with_shared_buffer) {
+    CacheOptions options = cache_options();
+    ASSERT_OK(BlockCache::instance()->init(options));
+
+    const int64_t block_count = 2;
+
+    int64_t data_size = block_size * block_count;
+    char data[data_size + 1];
+    gen_test_data(data, data_size, block_size);
+
+    const std::string file_name = "test_file6";
+    std::shared_ptr<io::SeekableInputStream> stream(new MockSeekableInputStream(data, data_size));
+    std::shared_ptr<io::SharedBufferedInputStream> sb_stream(
+            new io::SharedBufferedInputStream(stream, file_name, data_size));
+    io::CacheInputStream cache_stream(sb_stream, file_name, data_size, 1000000);
+    cache_stream.set_enable_populate_cache(true);
+    cache_stream.set_enable_block_buffer(true);
+
+    // Add a dummy block buffer to check the duplicate shared buffer.
+    CacheInputStream::BlockBuffer dummy_block_buffer;
+    dummy_block_buffer.offset = 10000000;
+    cache_stream._block_map[dummy_block_buffer.offset] = dummy_block_buffer;
+
+    const size_t read_size = block_size * block_count;
+    std::vector<SharedBufferedInputStream::IORange> io_ranges;
+    io_ranges.emplace_back(0, read_size);
+    sb_stream->set_io_ranges(io_ranges);
+
+    // first read from backend
+    {
+        char buffer[read_size];
+        read_stream_data(&cache_stream, 0, read_size, buffer);
+        ASSERT_TRUE(check_data_content(buffer, block_size, 'a'));
+        ASSERT_TRUE(check_data_content(buffer + block_size, block_size, 'b'));
+        //ASSERT_EQ(stats.write_cache_count, block_count);
+    }
+
+    // second read from shared buffer
+    {
+        char buffer[read_size];
+        read_stream_data(&cache_stream, 0, read_size, buffer);
+        ASSERT_EQ(sb_stream->shared_io_bytes(), read_size);
+    }
+}
+
+TEST_F(CacheInputStreamTest, test_peek) {
+    CacheOptions options = cache_options();
+    ASSERT_OK(BlockCache::instance()->init(options));
+
+    const int64_t block_count = 2;
+
+    int64_t data_size = block_size * block_count;
+    char data[data_size + 1];
+    gen_test_data(data, data_size, block_size);
+
+    const std::string file_name = "test_file6";
+    std::shared_ptr<io::SeekableInputStream> stream(new MockSeekableInputStream(data, data_size));
+    std::shared_ptr<io::SharedBufferedInputStream> sb_stream(
+            new io::SharedBufferedInputStream(stream, file_name, data_size));
+    io::CacheInputStream cache_stream(sb_stream, file_name, data_size, 1000000);
+    cache_stream.set_enable_populate_cache(true);
+    cache_stream.set_enable_block_buffer(true);
+    cache_stream.set_enable_async_populate_mode(true);
+
+    const size_t read_size = block_size * block_count;
+    std::vector<SharedBufferedInputStream::IORange> io_ranges;
+    io_ranges.emplace_back(0, read_size);
+    sb_stream->set_io_ranges(io_ranges);
+
+    // first read from backend
+    {
+        const size_t read_size = block_size;
+        char buffer[read_size];
+        read_stream_data(&cache_stream, 0, read_size, buffer);
+        ASSERT_TRUE(check_data_content(buffer, block_size, 'a'));
+    }
+
+    // peek read from shared buffer
+    {
+        const size_t peek_size = block_size;
+        auto res = cache_stream.peek(peek_size);
+        ASSERT_TRUE(res.ok());
+        auto str_view = res.value();
+        ASSERT_EQ(str_view.length(), peek_size);
+    }
 }
 
 } // namespace starrocks::io

--- a/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
@@ -446,6 +446,9 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
 
     public static final String ENABLE_SCAN_DATACACHE = "enable_scan_datacache";
     public static final String ENABLE_POPULATE_DATACACHE = "enable_populate_datacache";
+    public static final String ENABLE_DATACACHE_ASYNC_POPULATE_MODE = "enable_datacache_async_populate_mode";
+    public static final String ENABLE_DATACACHE_IO_ADAPTOR = "enable_datacache_io_adaptor";
+
     // The following configurations will be deprecated, and we use the `datacache` suffix instead.
     // But it is temporarily necessary to keep them for a period of time to be compatible with
     // the old session variable names.
@@ -1505,6 +1508,12 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
     public String getCatalog() {
         return this.catalog;
     }
+
+    @VariableMgr.VarAttr(name = ENABLE_DATACACHE_ASYNC_POPULATE_MODE)
+    private boolean enableDataCacheAsyncPopulateMode = false;
+
+    @VariableMgr.VarAttr(name = ENABLE_DATACACHE_IO_ADAPTOR)
+    private boolean enableDataCacheIOAdaptor = false;
 
     @VariableMgr.VarAttr(name = ENABLE_DYNAMIC_PRUNE_SCAN_RANGE)
     private boolean enableDynamicPruneScanRange = true;
@@ -3694,6 +3703,8 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
 
         tResult.setEnable_scan_datacache(enableScanDataCache);
         tResult.setEnable_populate_datacache(enablePopulateDataCache);
+        tResult.setEnable_datacache_async_populate_mode(enableDataCacheAsyncPopulateMode);
+        tResult.setEnable_datacache_io_adaptor(enableDataCacheIOAdaptor);
         tResult.setEnable_file_metacache(enableFileMetaCache);
         tResult.setHudi_mor_force_jni_reader(hudiMORForceJNIReader);
         tResult.setIo_tasks_per_scan_operator(ioTasksPerScanOperator);

--- a/gensrc/thrift/InternalService.thrift
+++ b/gensrc/thrift/InternalService.thrift
@@ -285,6 +285,9 @@ struct TQueryOptions {
   130: optional bool enable_wait_dependent_event = false;
 
   131: optional bool orc_use_column_names = false;
+
+  132: optional bool enable_datacache_async_populate_mode;
+  133: optional bool enable_datacache_io_adaptor;
 }
 
 


### PR DESCRIPTION
Why I'm doing:
Populating datacache synchronously is useful for warming up remote data to local datacache. Howerver, it may make the cold read slower.  So it unable to meet the needs of all users.

What I'm doing:
We support two modes for populating datacache and users can choose either mode by a session variable. When using asynchronous mode, the impact of cache population on the first read will be very small. However, it usually unable to cache all the data read this time.

## What type of PR is this:

- [ ] BugFix
- [x] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [x] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5

