### PR TITLE
[BugFix] Use correct warehouseId when stream load is used to load data

### DIFF
--- a/be/src/exec/tablet_sink.cpp
+++ b/be/src/exec/tablet_sink.cpp
@@ -444,6 +444,7 @@ Status OlapTableSink::_update_immutable_partition(const std::set<int64_t>& parti
     request.__set_txn_id(_txn_id);
     request.__set_db_id(_vectorized_partition->db_id());
     request.__set_table_id(_vectorized_partition->table_id());
+    request.__set_backend(BackendOptions::get_localBackend());
     request.__isset.partition_ids = true;
     for (auto partition_id : partition_ids_to_be_updated) {
         request.partition_ids.push_back(partition_id);

--- a/be/src/exec/tablet_sink.cpp
+++ b/be/src/exec/tablet_sink.cpp
@@ -444,10 +444,13 @@ Status OlapTableSink::_update_immutable_partition(const std::set<int64_t>& parti
     request.__set_txn_id(_txn_id);
     request.__set_db_id(_vectorized_partition->db_id());
     request.__set_table_id(_vectorized_partition->table_id());
-    request.__set_backend_id(get_backend_id());
     request.__isset.partition_ids = true;
     for (auto partition_id : partition_ids_to_be_updated) {
         request.partition_ids.push_back(partition_id);
+    }
+    auto backend_id = get_backend_id();
+    if (backend_id.has_value()) {
+        request.__set_backend_id(backend_id.value());
     }
 
     RETURN_IF_ERROR(_vectorized_partition->remove_partitions(request.partition_ids));

--- a/be/src/exec/tablet_sink.cpp
+++ b/be/src/exec/tablet_sink.cpp
@@ -444,7 +444,7 @@ Status OlapTableSink::_update_immutable_partition(const std::set<int64_t>& parti
     request.__set_txn_id(_txn_id);
     request.__set_db_id(_vectorized_partition->db_id());
     request.__set_table_id(_vectorized_partition->table_id());
-    request.__set_backend(BackendOptions::get_localBackend());
+    request.__set_backend_id(get_backend_id());
     request.__isset.partition_ids = true;
     for (auto partition_id : partition_ids_to_be_updated) {
         request.partition_ids.push_back(partition_id);

--- a/be/src/http/action/stream_load.cpp
+++ b/be/src/http/action/stream_load.cpp
@@ -422,7 +422,7 @@ Status StreamLoadAction::_process_put(HttpRequest* http_req, StreamLoadContext* 
     request.tbl = ctx->table;
     request.txnId = ctx->txn_id;
     request.formatType = ctx->format;
-    request.__set_backend(BackendOptions::get_localBackend());
+    request.backend_id = get_backend_id();
 
     request.__set_loadId(ctx->id.to_thrift());
     if (ctx->use_streaming) {

--- a/be/src/http/action/stream_load.cpp
+++ b/be/src/http/action/stream_load.cpp
@@ -422,7 +422,10 @@ Status StreamLoadAction::_process_put(HttpRequest* http_req, StreamLoadContext* 
     request.tbl = ctx->table;
     request.txnId = ctx->txn_id;
     request.formatType = ctx->format;
-    request.backend_id = get_backend_id();
+    auto backend_id = get_backend_id();
+    if (backend_id.has_value()) {
+        request.backend_id = backend_id.value();
+    }
 
     request.__set_loadId(ctx->id.to_thrift());
     if (ctx->use_streaming) {

--- a/be/src/http/action/stream_load.cpp
+++ b/be/src/http/action/stream_load.cpp
@@ -422,6 +422,8 @@ Status StreamLoadAction::_process_put(HttpRequest* http_req, StreamLoadContext* 
     request.tbl = ctx->table;
     request.txnId = ctx->txn_id;
     request.formatType = ctx->format;
+    request.__set_backend(BackendOptions::get_localBackend());
+
     request.__set_loadId(ctx->id.to_thrift());
     if (ctx->use_streaming) {
         auto pipe =

--- a/be/src/http/action/stream_load.cpp
+++ b/be/src/http/action/stream_load.cpp
@@ -425,6 +425,8 @@ Status StreamLoadAction::_process_put(HttpRequest* http_req, StreamLoadContext* 
     auto backend_id = get_backend_id();
     if (backend_id.has_value()) {
         request.backend_id = backend_id.value();
+    } else {
+        request.backend_id = -1;
     }
 
     request.__set_loadId(ctx->id.to_thrift());

--- a/be/src/http/action/transaction_stream_load.cpp
+++ b/be/src/http/action/transaction_stream_load.cpp
@@ -321,6 +321,12 @@ Status TransactionStreamLoadAction::_parse_request(HttpRequest* http_req, Stream
     request.formatType = ctx->format;
     request.__set_loadId(ctx->id.to_thrift());
     request.fileType = TFileType::FILE_STREAM;
+    auto backend_id = get_backend_id();
+    if (backend_id.has_value()) {
+        request.backend_id = backend_id.value();
+    } else {
+        request.backend_id = -1;
+    }
 
     if (!http_req->header(HTTP_COLUMNS).empty()) {
         request.__set_columns(http_req->header(HTTP_COLUMNS));

--- a/be/src/runtime/stream_load/stream_load_executor.cpp
+++ b/be/src/runtime/stream_load/stream_load_executor.cpp
@@ -167,6 +167,8 @@ Status StreamLoadExecutor::begin_txn(StreamLoadContext* ctx) {
     request.db = ctx->db;
     request.tbl = ctx->table;
     request.label = ctx->label;
+    request.__set_backend(BackendOptions::get_localBackend());
+
     // set timestamp
     request.__set_timestamp(GetCurrentTimeMicros());
     if (ctx->timeout_second != -1) {

--- a/be/src/runtime/stream_load/stream_load_executor.cpp
+++ b/be/src/runtime/stream_load/stream_load_executor.cpp
@@ -167,7 +167,10 @@ Status StreamLoadExecutor::begin_txn(StreamLoadContext* ctx) {
     request.db = ctx->db;
     request.tbl = ctx->table;
     request.label = ctx->label;
-    request.backend_id = get_backend_id();
+    auto backend_id = get_backend_id();
+    if (backend_id.has_value()) {
+        request.backend_id = backend_id.value();
+    }
 
     // set timestamp
     request.__set_timestamp(GetCurrentTimeMicros());

--- a/be/src/runtime/stream_load/stream_load_executor.cpp
+++ b/be/src/runtime/stream_load/stream_load_executor.cpp
@@ -167,7 +167,7 @@ Status StreamLoadExecutor::begin_txn(StreamLoadContext* ctx) {
     request.db = ctx->db;
     request.tbl = ctx->table;
     request.label = ctx->label;
-    request.__set_backend(BackendOptions::get_localBackend());
+    request.backend_id = get_backend_id();
 
     // set timestamp
     request.__set_timestamp(GetCurrentTimeMicros());

--- a/fe/fe-core/src/main/java/com/starrocks/alter/LakeTableAlterJobV2Builder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/LakeTableAlterJobV2Builder.java
@@ -117,7 +117,7 @@ public class LakeTableAlterJobV2Builder extends AlterJobV2Builder {
         WarehouseManager warehouseManager =  GlobalStateMgr.getCurrentState().getWarehouseMgr();
         return GlobalStateMgr.getCurrentState().getStarOSAgent()
                 .createShards(shardCount, pathInfo, cacheInfo, groupId, matchShardIds,
-                        properties, Utils.getWorkerGroupByWarehouseId(warehouseManager, warehouseId));
+                        properties, Utils.getFirstWorkerGroupByWarehouseId(warehouseManager, warehouseId));
     }
 
 }

--- a/fe/fe-core/src/main/java/com/starrocks/lake/LakeTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/lake/LakeTable.java
@@ -189,7 +189,8 @@ public class LakeTable extends OlapTable {
         List<Long> shardIds = null;
         try {
             // Ignore the parameter replicationNum
-            shardIds = globalStateMgr.getStarOSAgent().createShards(tabletNum, fsInfo, cacheInfo, shardGroupId, properties);
+            shardIds = globalStateMgr.getStarOSAgent().createShards(tabletNum, fsInfo, cacheInfo, shardGroupId, null, properties,
+                    StarOSAgent.DEFAULT_WORKER_GROUP_ID);
         } catch (DdlException e) {
             LOG.error(e.getMessage());
             return new Status(Status.ErrCode.COMMON_ERROR, e.getMessage());

--- a/fe/fe-core/src/main/java/com/starrocks/lake/StarOSAgent.java
+++ b/fe/fe-core/src/main/java/com/starrocks/lake/StarOSAgent.java
@@ -439,19 +439,9 @@ public class StarOSAgent {
         }
     }
 
-    public List<Long> createShards(int numShards, FilePathInfo pathInfo, FileCacheInfo cacheInfo, long groupId)
-        throws DdlException {
-        return createShards(numShards, pathInfo, cacheInfo, groupId, null, Collections.EMPTY_MAP);
-    }
-
     public List<Long> createShards(int numShards, FilePathInfo pathInfo, FileCacheInfo cacheInfo, long groupId,
-                                   @NotNull Map<String, String> properties)
-            throws DdlException {
-        return createShards(numShards, pathInfo, cacheInfo, groupId, null, properties);
-    }
-
-    public List<Long> createShards(int numShards, FilePathInfo pathInfo, FileCacheInfo cacheInfo, long groupId,
-                                   @Nullable List<Long> matchShardIds, @NotNull Map<String, String> properties)
+                                   @Nullable List<Long> matchShardIds, @NotNull Map<String, String> properties,
+                                   long workerGroupId)
         throws DdlException {
         if (matchShardIds != null) {
             Preconditions.checkState(numShards == matchShardIds.size());
@@ -466,7 +456,8 @@ public class StarOSAgent {
                     .addGroupIds(groupId)
                     .setPathInfo(pathInfo)
                     .setCacheInfo(cacheInfo)
-                    .putAllShardProperties(properties);
+                    .putAllShardProperties(properties)
+                    .setScheduleToWorkerGroup(workerGroupId);
 
             for (int i = 0; i < numShards; ++i) {
                 builder.setShardId(GlobalStateMgr.getCurrentState().getNextId());

--- a/fe/fe-core/src/main/java/com/starrocks/lake/Utils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/lake/Utils.java
@@ -31,6 +31,9 @@ import com.starrocks.rpc.RpcException;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.server.WarehouseManager;
 import com.starrocks.system.ComputeNode;
+import com.starrocks.system.SystemInfoService;
+import com.starrocks.thrift.TBackend;
+import com.starrocks.warehouse.Warehouse;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -203,5 +206,23 @@ public class Utils {
                 throw new RpcException(nodeList.get(i).getHost(), e.getMessage());
             }
         }
+    }
+
+    public static long getWorkerGroupByWarehouseId(WarehouseManager manager, long warehouseId) {
+        Warehouse warehouse = manager.getWarehouse(warehouseId);
+        return warehouse.getWorkerGroupId();
+    }
+
+    public static long getWarehouseIdFromBackend(SystemInfoService systemInfo, TBackend tBackend) {
+        long warehouseId = WarehouseManager.DEFAULT_WAREHOUSE_ID;
+        if (tBackend != null) {
+            String host = tBackend.getHost();
+            int bePort = tBackend.getBe_port();
+            ComputeNode cn = systemInfo.getBackendOrComputeNodeWithBePort(host, bePort);
+            if (cn != null) {
+                warehouseId = cn.getWarehouseId();
+            }
+        }
+        return warehouseId;
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/lake/Utils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/lake/Utils.java
@@ -32,7 +32,6 @@ import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.server.WarehouseManager;
 import com.starrocks.system.ComputeNode;
 import com.starrocks.system.SystemInfoService;
-import com.starrocks.thrift.TBackend;
 import com.starrocks.warehouse.Warehouse;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -208,20 +207,19 @@ public class Utils {
         }
     }
 
-    public static long getWorkerGroupByWarehouseId(WarehouseManager manager, long warehouseId) {
+    public static long getFirstWorkerGroupByWarehouseId(WarehouseManager manager, long warehouseId) {
         Warehouse warehouse = manager.getWarehouse(warehouseId);
-        return warehouse.getWorkerGroupId();
+        List<Long> ids = warehouse.getWorkerGroupIds();
+        return ids.get(0);
     }
 
-    public static long getWarehouseIdFromBackend(SystemInfoService systemInfo, TBackend tBackend) {
+    public static long getWarehouseIdByBackendId(SystemInfoService systemInfo, long nodeId) {
         long warehouseId = WarehouseManager.DEFAULT_WAREHOUSE_ID;
-        if (tBackend != null) {
-            String host = tBackend.getHost();
-            int bePort = tBackend.getBe_port();
-            ComputeNode cn = systemInfo.getBackendOrComputeNodeWithBePort(host, bePort);
-            if (cn != null) {
-                warehouseId = cn.getWarehouseId();
-            }
+        ComputeNode cn = systemInfo.getBackendOrComputeNode(nodeId);
+        if (cn != null) {
+            warehouseId = cn.getWarehouseId();
+        } else {
+            LOG.warn("failed to get node by node id: {}", nodeId);
         }
         return warehouseId;
     }

--- a/fe/fe-core/src/main/java/com/starrocks/load/streamload/StreamLoadInfo.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/streamload/StreamLoadInfo.java
@@ -350,9 +350,9 @@ public class StreamLoadInfo {
                 request.getFileType(), request.getFormatType());
         streamLoadInfo.setOptionalFromTSLPutRequest(request, db);
         long warehouseId = WarehouseManager.DEFAULT_WAREHOUSE_ID;
-        if (request.getBackend() != null) {
+        if (request.isSetBackend_id()) {
             SystemInfoService systemInfo = GlobalStateMgr.getCurrentState().getNodeMgr().getClusterInfo();
-            warehouseId = com.starrocks.lake.Utils.getWarehouseIdFromBackend(systemInfo, request.getBackend());
+            warehouseId = com.starrocks.lake.Utils.getWarehouseIdByBackendId(systemInfo, request.getBackend_id());
         } else if (request.getWarehouse() != null && !request.getWarehouse().isEmpty()) {
             // For backward, we keep this else branch. We should prioritize using the method to get the warehouse by backend.
             String warehouseName = request.getWarehouse();

--- a/fe/fe-core/src/main/java/com/starrocks/server/LocalMetastore.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/LocalMetastore.java
@@ -1128,7 +1128,8 @@ public class LocalMetastore implements ConnectorMetadata {
                                                                     List<PartitionDesc> partitionDescs,
                                                                     HashMap<String, Set<Long>> partitionNameToTabletSet,
                                                                     Set<Long> tabletIdSetForAll,
-                                                                    Set<String> existPartitionNameSet)
+                                                                    Set<String> existPartitionNameSet,
+                                                                    long warehouseId)
             throws DdlException {
         List<Pair<Partition, PartitionDesc>> partitionList = Lists.newArrayList();
         for (PartitionDesc partitionDesc : partitionDescs) {
@@ -1148,7 +1149,7 @@ public class LocalMetastore implements ConnectorMetadata {
             copiedTable.getPartitionInfo().setDataCacheInfo(partitionId, partitionDesc.getDataCacheInfo());
 
             Partition partition =
-                    createPartition(db, copiedTable, partitionId, partitionName, version, tabletIdSet);
+                    createPartition(db, copiedTable, partitionId, partitionName, version, tabletIdSet, warehouseId);
 
             partitionList.add(Pair.create(partition, partitionDesc));
             tabletIdSetForAll.addAll(tabletIdSet);
@@ -1411,18 +1412,18 @@ public class LocalMetastore implements ConnectorMetadata {
         Set<Long> tabletIdSetForAll = Sets.newHashSet();
         HashMap<String, Set<Long>> partitionNameToTabletSet = Maps.newHashMap();
         try {
-            // create partition list
-            List<Pair<Partition, PartitionDesc>> newPartitions =
-                    createPartitionMap(db, copiedTable, partitionDescs, partitionNameToTabletSet, tabletIdSetForAll,
-                            checkExistPartitionName);
-
-            // build partitions
-            List<Partition> partitionList = newPartitions.stream().map(x -> x.first).collect(Collectors.toList());
             long warehouseId = WarehouseManager.DEFAULT_WAREHOUSE_ID;
             if (ConnectContext.get() != null) {
                 warehouseId = ConnectContext.get().getCurrentWarehouseId();
             }
 
+            // create partition list
+            List<Pair<Partition, PartitionDesc>> newPartitions =
+                    createPartitionMap(db, copiedTable, partitionDescs, partitionNameToTabletSet, tabletIdSetForAll,
+                            checkExistPartitionName, warehouseId);
+
+            // build partitions
+            List<Partition> partitionList = newPartitions.stream().map(x -> x.first).collect(Collectors.toList());
             buildPartitions(db, copiedTable, partitionList.stream().map(Partition::getSubPartitions)
                     .flatMap(p -> p.stream()).collect(Collectors.toList()), warehouseId);
 
@@ -1687,7 +1688,8 @@ public class LocalMetastore implements ConnectorMetadata {
         }
     }
 
-    private PhysicalPartition createPhysicalPartition(Database db, OlapTable olapTable, Partition partition) throws DdlException {
+    private PhysicalPartition createPhysicalPartition(Database db, OlapTable olapTable,
+            Partition partition, long warehouseId) throws DdlException {
         long partitionId = partition.getId();
         DistributionInfo distributionInfo = olapTable.getDefaultDistributionInfo().copy();
         olapTable.inferDistribution(distributionInfo);
@@ -1724,7 +1726,7 @@ public class LocalMetastore implements ConnectorMetadata {
 
             if (olapTable.isCloudNativeTableOrMaterializedView()) {
                 createLakeTablets(olapTable, id, shardGroupId, index, distributionInfo,
-                        tabletMeta, tabletIdSet);
+                        tabletMeta, tabletIdSet, warehouseId);
             } else {
                 createOlapTablets(olapTable, index, Replica.ReplicaState.NORMAL, distributionInfo,
                         physicalParition.getVisibleVersion(), replicationNum, tabletMeta, tabletIdSet);
@@ -1739,7 +1741,7 @@ public class LocalMetastore implements ConnectorMetadata {
     }
 
     public void addSubPartitions(Database db, String tableName,
-                                 Partition partition, int numSubPartition) throws DdlException {
+                                 Partition partition, int numSubPartition, long warehouseId) throws DdlException {
         OlapTable olapTable;
         OlapTable copiedTable;
 
@@ -1764,15 +1766,11 @@ public class LocalMetastore implements ConnectorMetadata {
         List<PhysicalPartition> subPartitions = new ArrayList<>();
         // create physical partition
         for (int i = 0; i < numSubPartition; i++) {
-            PhysicalPartition subPartition = createPhysicalPartition(db, copiedTable, partition);
+            PhysicalPartition subPartition = createPhysicalPartition(db, copiedTable, partition, warehouseId);
             subPartitions.add(subPartition);
         }
 
         // build partitions
-        long warehouseId = WarehouseManager.DEFAULT_WAREHOUSE_ID;
-        if (ConnectContext.get() != null) {
-            warehouseId = ConnectContext.get().getCurrentWarehouseId();
-        }
         buildPartitions(db, copiedTable, subPartitions, warehouseId);
 
         // check again
@@ -1833,15 +1831,16 @@ public class LocalMetastore implements ConnectorMetadata {
     }
 
     Partition createPartition(Database db, OlapTable table, long partitionId, String partitionName,
-                              Long version, Set<Long> tabletIdSet) throws DdlException {
+                              Long version, Set<Long> tabletIdSet, long warehouseId) throws DdlException {
         DistributionInfo distributionInfo = table.getDefaultDistributionInfo().copy();
         table.inferDistribution(distributionInfo);
 
-        return createPartition(db, table, partitionId, partitionName, version, tabletIdSet, distributionInfo);
+        return createPartition(db, table, partitionId, partitionName, version, tabletIdSet, distributionInfo, warehouseId);
     }
 
     Partition createPartition(Database db, OlapTable table, long partitionId, String partitionName,
-                              Long version, Set<Long> tabletIdSet, DistributionInfo distributionInfo) throws DdlException {
+                              Long version, Set<Long> tabletIdSet, DistributionInfo distributionInfo,
+                              long warehouseId) throws DdlException {
         PartitionInfo partitionInfo = table.getPartitionInfo();
         Map<Long, MaterializedIndex> indexMap = new HashMap<>();
         for (long indexId : table.getIndexIdToMeta().keySet()) {
@@ -1878,7 +1877,7 @@ public class LocalMetastore implements ConnectorMetadata {
 
             if (table.isCloudNativeTableOrMaterializedView()) {
                 createLakeTablets(table, partitionId, shardGroupId, index, distributionInfo,
-                        tabletMeta, tabletIdSet);
+                        tabletMeta, tabletIdSet, warehouseId);
             } else {
                 createOlapTablets(table, index, Replica.ReplicaState.NORMAL, distributionInfo,
                         partition.getVisibleVersion(), replicationNum, tabletMeta, tabletIdSet);
@@ -2371,7 +2370,7 @@ public class LocalMetastore implements ConnectorMetadata {
 
     private void createLakeTablets(OlapTable table, long partitionId, long shardGroupId, MaterializedIndex index,
                                    DistributionInfo distributionInfo, TabletMeta tabletMeta,
-                                   Set<Long> tabletIdSet)
+                                   Set<Long> tabletIdSet, long warehouseId)
             throws DdlException {
         Preconditions.checkArgument(table.isCloudNativeTableOrMaterializedView());
 
@@ -2386,9 +2385,11 @@ public class LocalMetastore implements ConnectorMetadata {
         properties.put(LakeTablet.PROPERTY_KEY_PARTITION_ID, Long.toString(partitionId));
         properties.put(LakeTablet.PROPERTY_KEY_INDEX_ID, Long.toString(index.getId()));
         int bucketNum = distributionInfo.getBucketNum();
+        WarehouseManager warehouseManager = GlobalStateMgr.getCurrentState().getWarehouseMgr();
         List<Long> shardIds = stateMgr.getStarOSAgent().createShards(bucketNum,
                 table.getPartitionFilePathInfo(partitionId), table.getPartitionFileCacheInfo(partitionId), shardGroupId,
-                properties);
+                null, properties,
+                com.starrocks.lake.Utils.getWorkerGroupByWarehouseId(warehouseManager, warehouseId));
         for (long shardId : shardIds) {
             Tablet tablet = new LakeTablet(shardId);
             index.addTablet(tablet, tabletMeta);
@@ -3324,7 +3325,8 @@ public class LocalMetastore implements ConnectorMetadata {
                 partitionInfo.setDataCacheInfo(partitionId,
                         storageInfo == null ? null : storageInfo.getDataCacheInfo());
                 Long version = Partition.PARTITION_INIT_VERSION;
-                Partition partition = createPartition(db, materializedView, partitionId, mvName, version, tabletIdSet);
+                Partition partition = createPartition(db, materializedView, partitionId, mvName, version, tabletIdSet,
+                        ConnectContext.get().getCurrentWarehouseId());
                 buildPartitions(db, materializedView, partition.getSubPartitions().stream().collect(Collectors.toList()),
                         ConnectContext.get().getCurrentWarehouseId());
                 materializedView.addPartition(partition);
@@ -4836,7 +4838,8 @@ public class LocalMetastore implements ConnectorMetadata {
                 copiedTbl.setDefaultDistributionInfo(entry.getValue().getDistributionInfo());
 
                 Partition newPartition =
-                        createPartition(db, copiedTbl, newPartitionId, newPartitionName, null, tabletIdSet);
+                        createPartition(db, copiedTbl, newPartitionId, newPartitionName, null, tabletIdSet,
+                        ConnectContext.get().getCurrentWarehouseId());
                 newPartitions.add(newPartition);
             }
             buildPartitions(db, copiedTbl, newPartitions.stream().map(Partition::getSubPartitions)
@@ -5372,7 +5375,8 @@ public class LocalMetastore implements ConnectorMetadata {
                                                           List<Long> sourcePartitionIds,
                                                           Map<Long, String> origPartitions, OlapTable copiedTbl,
                                                           String namePostfix, Set<Long> tabletIdSet,
-                                                          List<Long> tmpPartitionIds, DistributionDesc distributionDesc)
+                                                          List<Long> tmpPartitionIds, DistributionDesc distributionDesc,
+                                                          long warehouseId)
             throws DdlException {
         List<Partition> newPartitions = Lists.newArrayListWithCapacity(sourcePartitionIds.size());
         for (int i = 0; i < sourcePartitionIds.size(); ++i) {
@@ -5403,9 +5407,9 @@ public class LocalMetastore implements ConnectorMetadata {
                     olapTable.optimizeDistribution(distributionInfo, sourcePartition);
                 }
                 newPartition = createPartition(
-                        db, copiedTbl, newPartitionId, newPartitionName, null, tabletIdSet, distributionInfo);
+                        db, copiedTbl, newPartitionId, newPartitionName, null, tabletIdSet, distributionInfo, warehouseId);
             } else {
-                newPartition = createPartition(db, copiedTbl, newPartitionId, newPartitionName, null, tabletIdSet);
+                newPartition = createPartition(db, copiedTbl, newPartitionId, newPartitionName, null, tabletIdSet, warehouseId);
             }
 
             newPartitions.add(newPartition);
@@ -5431,7 +5435,7 @@ public class LocalMetastore implements ConnectorMetadata {
         Set<Long> tabletIdSet = Sets.newHashSet();
         try {
             newPartitions = getNewPartitionsFromPartitions(db, olapTable, sourcePartitionIds, origPartitions,
-                    copiedTbl, namePostfix, tabletIdSet, tmpPartitionIds, distributionDesc);
+                    copiedTbl, namePostfix, tabletIdSet, tmpPartitionIds, distributionDesc, warehouseId);
             buildPartitions(db, copiedTbl, newPartitions.stream().map(Partition::getSubPartitions)
                     .flatMap(p -> p.stream()).collect(Collectors.toList()), warehouseId);
         } catch (Exception e) {

--- a/fe/fe-core/src/main/java/com/starrocks/server/LocalMetastore.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/LocalMetastore.java
@@ -2389,7 +2389,7 @@ public class LocalMetastore implements ConnectorMetadata {
         List<Long> shardIds = stateMgr.getStarOSAgent().createShards(bucketNum,
                 table.getPartitionFilePathInfo(partitionId), table.getPartitionFileCacheInfo(partitionId), shardGroupId,
                 null, properties,
-                com.starrocks.lake.Utils.getWorkerGroupByWarehouseId(warehouseManager, warehouseId));
+                com.starrocks.lake.Utils.getFirstWorkerGroupByWarehouseId(warehouseManager, warehouseId));
         for (long shardId : shardIds) {
             Tablet tablet = new LakeTablet(shardId);
             index.addTablet(tablet, tabletMeta);

--- a/fe/fe-core/src/main/java/com/starrocks/server/OlapTableFactory.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/OlapTableFactory.java
@@ -636,7 +636,8 @@ public class OlapTableFactory implements AbstractTableFactory {
 
                     // this is a 1-level partitioned table, use table name as partition name
                     long partitionId = partitionNameToId.get(tableName);
-                    Partition partition = metastore.createPartition(db, table, partitionId, tableName, version, tabletIdSet);
+                    Partition partition = metastore.createPartition(db, table, partitionId, tableName, version, tabletIdSet,
+                            warehouseId);
                     metastore.buildPartitions(db, table, partition.getSubPartitions().stream().collect(Collectors.toList()),
                             warehouseId);
                     table.addPartition(partition);
@@ -674,7 +675,7 @@ public class OlapTableFactory implements AbstractTableFactory {
                     List<Partition> partitions = new ArrayList<>(partitionNameToId.size());
                     for (Map.Entry<String, Long> entry : partitionNameToId.entrySet()) {
                         Partition partition = metastore.createPartition(db, table, entry.getValue(), entry.getKey(), version,
-                                tabletIdSet);
+                                tabletIdSet, warehouseId);
                         partitions.add(partition);
                     }
                     // It's ok if partitions is empty.

--- a/fe/fe-core/src/main/java/com/starrocks/service/FrontendServiceImpl.java
+++ b/fe/fe-core/src/main/java/com/starrocks/service/FrontendServiceImpl.java
@@ -96,6 +96,7 @@ import com.starrocks.common.util.concurrent.lock.Locker;
 import com.starrocks.http.BaseAction;
 import com.starrocks.http.rest.TransactionResult;
 import com.starrocks.lake.LakeTablet;
+import com.starrocks.lake.Utils;
 import com.starrocks.lake.compaction.CompactionMgr;
 import com.starrocks.leader.LeaderImpl;
 import com.starrocks.load.EtlJobType;
@@ -164,6 +165,7 @@ import com.starrocks.thrift.TAbortRemoteTxnResponse;
 import com.starrocks.thrift.TAllocateAutoIncrementIdParam;
 import com.starrocks.thrift.TAllocateAutoIncrementIdResult;
 import com.starrocks.thrift.TAuthenticateParams;
+import com.starrocks.thrift.TBackend;
 import com.starrocks.thrift.TBatchReportExecStatusParams;
 import com.starrocks.thrift.TBatchReportExecStatusResult;
 import com.starrocks.thrift.TBeginRemoteTxnRequest;
@@ -1262,11 +1264,16 @@ public class FrontendServiceImpl implements FrontendService.Iface {
         long timeoutSecond = request.isSetTimeout() ? request.getTimeout() : Config.stream_load_default_timeout_second;
         MetricRepo.COUNTER_LOAD_ADD.increase(1L);
 
-        String warehouseName = WarehouseManager.DEFAULT_WAREHOUSE_NAME;
-        if (request.getWarehouse() != null && !request.getWarehouse().isEmpty()) {
-            warehouseName = request.getWarehouse();
+        long warehouseId = WarehouseManager.DEFAULT_WAREHOUSE_ID;
+        if (request.getBackend() != null) {
+            SystemInfoService systemInfo = GlobalStateMgr.getCurrentState().getNodeMgr().getClusterInfo();
+            warehouseId = Utils.getWarehouseIdFromBackend(systemInfo, request.getBackend());
+        } else if (request.getWarehouse() != null && !request.getWarehouse().isEmpty()) {
+            // For backward, we keep this else branch. We should prioritize using the method to get the warehouse by backend.
+            String warehouseName = request.getWarehouse();
+            Warehouse warehouse = GlobalStateMgr.getCurrentState().getWarehouseMgr().getWarehouse(warehouseName);
+            warehouseId = warehouse.getId();
         }
-        Warehouse warehouse = GlobalStateMgr.getCurrentState().getWarehouseMgr().getWarehouse(warehouseName);
 
         // just use default value of session variable
         // as there is no connectContext for sync stream load
@@ -1275,7 +1282,7 @@ public class FrontendServiceImpl implements FrontendService.Iface {
             TransactionResult resp = new TransactionResult();
             StreamLoadMgr streamLoadManager = GlobalStateMgr.getCurrentState().getStreamLoadMgr();
             streamLoadManager.beginLoadTask(dbName, table.getName(), request.getLabel(),
-                    timeoutSecond * 1000, resp, false, warehouse.getId());
+                    timeoutSecond * 1000, resp, false, warehouseId);
             if (!resp.stateOK()) {
                 LOG.warn(resp.msg);
                 throw new UserException(resp.msg);
@@ -1293,7 +1300,7 @@ public class FrontendServiceImpl implements FrontendService.Iface {
                 db.getId(), Lists.newArrayList(table.getId()), request.getLabel(), request.getRequest_id(),
                 new TxnCoordinator(TxnSourceType.BE, clientIp),
                 TransactionState.LoadJobSourceType.BACKEND_STREAMING, -1, timeoutSecond,
-                warehouse.getId());
+                warehouseId);
     }
 
     @Override
@@ -1956,6 +1963,8 @@ public class FrontendServiceImpl implements FrontendService.Iface {
             throws UserException {
         long dbId = request.getDb_id();
         long tableId = request.getTable_id();
+        TBackend tBackend = request.getBackend();
+
         TImmutablePartitionResult result = new TImmutablePartitionResult();
         TStatus errorStatus = new TStatus(RUNTIME_ERROR);
 
@@ -1992,6 +2001,9 @@ public class FrontendServiceImpl implements FrontendService.Iface {
         List<TTabletLocation> tablets = Lists.newArrayList();
         Set<Long> updatePartitionIds = Sets.newHashSet();
 
+        SystemInfoService systemInfo = GlobalStateMgr.getCurrentState().getNodeMgr().getClusterInfo();
+        long warehouseId = Utils.getWarehouseIdFromBackend(systemInfo, tBackend);
+
         // immute partitions and create new sub partitions
         for (Long id : request.partition_ids) {
             PhysicalPartition p = table.getPhysicalPartition(id);
@@ -2017,7 +2029,7 @@ public class FrontendServiceImpl implements FrontendService.Iface {
             }
             if (mutablePartitions.size() <= 1) {
                 GlobalStateMgr.getCurrentState().getLocalMetastore()
-                        .addSubPartitions(db, olapTable.getName(), partition, 1);
+                        .addSubPartitions(db, olapTable.getName(), partition, 1, warehouseId);
             }
             p.setImmutable(true);
         }
@@ -2045,7 +2057,7 @@ public class FrontendServiceImpl implements FrontendService.Iface {
                     TOlapTablePartition tPartition = new TOlapTablePartition();
                     tPartition.setId(physicalPartition.getId());
                     buildPartitions(olapTable, physicalPartition, partitions, tPartition);
-                    buildTablets(physicalPartition, tablets, olapTable);
+                    buildTablets(physicalPartition, tablets, olapTable, warehouseId);
                 }
             } finally {
                 locker.unLockDatabase(db, LockType.READ);
@@ -2119,7 +2131,7 @@ public class FrontendServiceImpl implements FrontendService.Iface {
     }
 
     private static void buildTablets(PhysicalPartition physicalPartition, List<TTabletLocation> tablets,
-                                     OlapTable olapTable) throws UserException {
+                                     OlapTable olapTable, long warehouseId) throws UserException {
         int quorum = olapTable.getPartitionInfo().getQuorumNum(physicalPartition.getParentId(), olapTable.writeQuorum());
         for (MaterializedIndex index : physicalPartition.getMaterializedIndices(
                 MaterializedIndex.IndexExtState.ALL)) {
@@ -2128,7 +2140,7 @@ public class FrontendServiceImpl implements FrontendService.Iface {
                     try {
                         // use default warehouse nodes
                         ComputeNode computeNode = GlobalStateMgr.getCurrentState().getWarehouseMgr()
-                                .getComputeNodeAssignedToTablet(WarehouseManager.DEFAULT_WAREHOUSE_NAME, (LakeTablet) tablet);
+                                .getComputeNodeAssignedToTablet(warehouseId, (LakeTablet) tablet);
                         tablets.add(new TTabletLocation(tablet.getId(), Collections.singletonList(computeNode.getId())));
                     } catch (Exception exception) {
                         throw new UserException("Check if any backend is down or not. tablet_id: " + tablet.getId());

--- a/fe/fe-core/src/main/java/com/starrocks/warehouse/DefaultWarehouse.java
+++ b/fe/fe-core/src/main/java/com/starrocks/warehouse/DefaultWarehouse.java
@@ -14,8 +14,28 @@
 
 package com.starrocks.warehouse;
 
+import com.starrocks.lake.StarOSAgent;
+
+import com.google.common.collect.ImmutableList;
+
+import java.util.ArrayList;
+import java.util.List;
+
 public class DefaultWarehouse extends Warehouse {
+    private static final List<Long> WORKER_GROUP_ID_LIST;
+
     public DefaultWarehouse(long id, String name) {
         super(id, name, "An internal warehouse init after FE is ready");
+    }
+
+    static {
+        List<Long> workerGroupIdList = new ArrayList<>();
+        workerGroupIdList.add(StarOSAgent.DEFAULT_WORKER_GROUP_ID);
+        WORKER_GROUP_ID_LIST = ImmutableList.copyOf(workerGroupIdList);
+    }
+
+    @Override
+    public List<Long> getWorkerGroupIds() {
+        return WORKER_GROUP_ID_LIST;
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/warehouse/DefaultWarehouse.java
+++ b/fe/fe-core/src/main/java/com/starrocks/warehouse/DefaultWarehouse.java
@@ -14,14 +14,14 @@
 
 package com.starrocks.warehouse;
 
-import com.starrocks.lake.StarOSAgent;
-
 import com.google.common.collect.ImmutableList;
+import com.starrocks.lake.StarOSAgent;
 
 import java.util.ArrayList;
 import java.util.List;
 
 public class DefaultWarehouse extends Warehouse {
+
     private static final List<Long> WORKER_GROUP_ID_LIST;
 
     public DefaultWarehouse(long id, String name) {

--- a/fe/fe-core/src/main/java/com/starrocks/warehouse/Warehouse.java
+++ b/fe/fe-core/src/main/java/com/starrocks/warehouse/Warehouse.java
@@ -17,7 +17,6 @@ package com.starrocks.warehouse;
 import com.google.gson.annotations.SerializedName;
 import com.starrocks.common.io.Text;
 import com.starrocks.common.io.Writable;
-import com.starrocks.lake.StarOSAgent;
 import com.starrocks.persist.gson.GsonUtils;
 
 import java.io.DataOutput;

--- a/fe/fe-core/src/main/java/com/starrocks/warehouse/Warehouse.java
+++ b/fe/fe-core/src/main/java/com/starrocks/warehouse/Warehouse.java
@@ -22,6 +22,7 @@ import com.starrocks.persist.gson.GsonUtils;
 
 import java.io.DataOutput;
 import java.io.IOException;
+import java.util.List;
 
 public abstract class Warehouse implements Writable {
     @SerializedName(value = "name")
@@ -55,7 +56,5 @@ public abstract class Warehouse implements Writable {
         Text.writeString(out, json);
     }
 
-    public long getWorkerGroupId() {
-        return StarOSAgent.DEFAULT_WORKER_GROUP_ID;
-    }
+    public abstract List<Long> getWorkerGroupIds();
 }

--- a/fe/fe-core/src/main/java/com/starrocks/warehouse/Warehouse.java
+++ b/fe/fe-core/src/main/java/com/starrocks/warehouse/Warehouse.java
@@ -17,6 +17,7 @@ package com.starrocks.warehouse;
 import com.google.gson.annotations.SerializedName;
 import com.starrocks.common.io.Text;
 import com.starrocks.common.io.Writable;
+import com.starrocks.lake.StarOSAgent;
 import com.starrocks.persist.gson.GsonUtils;
 
 import java.io.DataOutput;
@@ -52,5 +53,9 @@ public abstract class Warehouse implements Writable {
     public void write(DataOutput out) throws IOException {
         String json = GsonUtils.GSON.toJson(this);
         Text.writeString(out, json);
+    }
+
+    public long getWorkerGroupId() {
+        return StarOSAgent.DEFAULT_WORKER_GROUP_ID;
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/alter/AlterTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/alter/AlterTest.java
@@ -1056,11 +1056,13 @@ public class AlterTest {
         Assert.assertTrue(partition.isPresent());
         Assert.assertEquals(table.getPhysicalPartitions().size(), 1);
 
-        GlobalStateMgr.getCurrentState().getLocalMetastore().addSubPartitions(db, table.getName(), partition.get(), 1);
+        GlobalStateMgr.getCurrentState().getLocalMetastore().addSubPartitions(db, table.getName(), partition.get(), 1,
+                WarehouseManager.DEFAULT_WAREHOUSE_ID);
         Assert.assertEquals(partition.get().getSubPartitions().size(), 2);
         Assert.assertEquals(table.getPhysicalPartitions().size(), 2);
 
-        GlobalStateMgr.getCurrentState().getLocalMetastore().addSubPartitions(db, table.getName(), partition.get(), 2);
+        GlobalStateMgr.getCurrentState().getLocalMetastore().addSubPartitions(db, table.getName(), partition.get(), 2,
+                WarehouseManager.DEFAULT_WAREHOUSE_ID);
         Assert.assertEquals(partition.get().getSubPartitions().size(), 4);
         Assert.assertEquals(table.getPhysicalPartitions().size(), 4);
 
@@ -1111,14 +1113,16 @@ public class AlterTest {
         Partition partition = table.getPartition("p20140101");
         Assert.assertNotNull(partition);
 
-        GlobalStateMgr.getCurrentState().getLocalMetastore().addSubPartitions(db, table.getName(), partition, 1);
+        GlobalStateMgr.getCurrentState().getLocalMetastore().addSubPartitions(db, table.getName(), partition, 1,
+                WarehouseManager.DEFAULT_WAREHOUSE_ID);
         Assert.assertEquals(table.getPhysicalPartitions().size(), 4);
         Assert.assertEquals(partition.getSubPartitions().size(), 2);
 
         partition = table.getPartition("p20140103");
         Assert.assertNotNull(partition);
 
-        GlobalStateMgr.getCurrentState().getLocalMetastore().addSubPartitions(db, table.getName(), partition, 2);
+        GlobalStateMgr.getCurrentState().getLocalMetastore().addSubPartitions(db, table.getName(), partition, 2,
+                WarehouseManager.DEFAULT_WAREHOUSE_ID);
         Assert.assertEquals(table.getPhysicalPartitions().size(), 6);
         Assert.assertEquals(partition.getSubPartitions().size(), 3);
 
@@ -1155,7 +1159,8 @@ public class AlterTest {
         Assert.assertTrue(partition.isPresent());
         Assert.assertEquals(table.getPhysicalPartitions().size(), 1);
 
-        GlobalStateMgr.getCurrentState().getLocalMetastore().addSubPartitions(db, table.getName(), partition.get(), 1);
+        GlobalStateMgr.getCurrentState().getLocalMetastore().addSubPartitions(db, table.getName(), partition.get(), 1,
+                WarehouseManager.DEFAULT_WAREHOUSE_ID);
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/lake/StarOSAgentTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/lake/StarOSAgentTest.java
@@ -53,6 +53,7 @@ import org.junit.Test;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
@@ -359,7 +360,9 @@ public class StarOSAgentTest {
         // test create shards
         FilePathInfo pathInfo = FilePathInfo.newBuilder().build();
         FileCacheInfo cacheInfo = FileCacheInfo.newBuilder().build();
-        Assert.assertEquals(Lists.newArrayList(10L, 11L), starosAgent.createShards(2, pathInfo, cacheInfo, 333));
+        Assert.assertEquals(Lists.newArrayList(10L, 11L),
+                starosAgent.createShards(2, pathInfo, cacheInfo, 333, null,
+                Collections.EMPTY_MAP, StarOSAgent.DEFAULT_WORKER_GROUP_ID));
 
         // list shard group
         List<ShardGroupInfo> realGroupIds = starosAgent.listShardGroup();

--- a/fe/fe-core/src/test/java/com/starrocks/lake/UtilsTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/lake/UtilsTest.java
@@ -22,7 +22,6 @@ import com.starrocks.server.WarehouseManager;
 import com.starrocks.system.Backend;
 import com.starrocks.system.NodeSelector;
 import com.starrocks.system.SystemInfoService;
-import com.starrocks.thrift.TBackend;
 import mockit.Mock;
 import mockit.MockUp;
 import mockit.Mocked;
@@ -78,12 +77,12 @@ public class UtilsTest {
         WarehouseManager manager = new WarehouseManager();
         manager.initDefaultWarehouse();
 
-        long workerGroupId = Utils.getWorkerGroupByWarehouseId(manager, WarehouseManager.DEFAULT_WAREHOUSE_ID);
+        long workerGroupId = Utils.getFirstWorkerGroupByWarehouseId(manager, WarehouseManager.DEFAULT_WAREHOUSE_ID);
         Assert.assertEquals(StarOSAgent.DEFAULT_WORKER_GROUP_ID, workerGroupId);
     }
 
     @Test
-    public void testGetWarehouseIdFromBackend() {
+    public void testGetWarehouseIdByBackend() {
         SystemInfoService systemInfo = new SystemInfoService();
         Backend b1 = new Backend(10001L, "192.168.0.1", 9050);
         b1.setBePort(9060);
@@ -97,17 +96,17 @@ public class UtilsTest {
         systemInfo.addBackend(b2);
 
         // If the version of be is old, it may pass null.
-        long warehouseId = Utils.getWarehouseIdFromBackend(systemInfo, null);
+        long warehouseId = Utils.getWarehouseIdByBackendId(systemInfo, 0);
         Assert.assertEquals(WarehouseManager.DEFAULT_WAREHOUSE_ID, warehouseId);
 
         // pass a wrong tBackend
-        warehouseId = Utils.getWarehouseIdFromBackend(systemInfo, new TBackend("192.168.100.1", 9060, 8040));
+        warehouseId = Utils.getWarehouseIdByBackendId(systemInfo, 10003);
         Assert.assertEquals(WarehouseManager.DEFAULT_WAREHOUSE_ID, warehouseId);
 
         // pass a right tBackend
-        warehouseId = Utils.getWarehouseIdFromBackend(systemInfo, new TBackend("192.168.0.1", 9060, 8040));
+        warehouseId = Utils.getWarehouseIdByBackendId(systemInfo, 10001);
         Assert.assertEquals(10001L, warehouseId);
-        warehouseId = Utils.getWarehouseIdFromBackend(systemInfo, new TBackend("192.168.0.2", 9060, 8040));
+        warehouseId = Utils.getWarehouseIdByBackendId(systemInfo, 10002);
         Assert.assertEquals(10002L, warehouseId);
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/lake/UtilsTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/lake/UtilsTest.java
@@ -18,11 +18,15 @@ package com.starrocks.lake;
 import com.starrocks.common.UserException;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.server.NodeMgr;
+import com.starrocks.server.WarehouseManager;
+import com.starrocks.system.Backend;
 import com.starrocks.system.NodeSelector;
 import com.starrocks.system.SystemInfoService;
+import com.starrocks.thrift.TBackend;
 import mockit.Mock;
 import mockit.MockUp;
 import mockit.Mocked;
+import org.junit.Assert;
 import org.junit.Test;
 
 public class UtilsTest {
@@ -32,9 +36,6 @@ public class UtilsTest {
 
     @Mocked
     NodeMgr nodeMgr;
-
-    @Mocked
-    SystemInfoService systemInfoService;
 
     @Mocked
     NodeSelector nodeSelector;
@@ -52,7 +53,8 @@ public class UtilsTest {
         new MockUp<NodeMgr>() {
             @Mock
             public SystemInfoService getClusterInfo() {
-                return systemInfoService;
+                SystemInfoService systemInfo = new SystemInfoService();
+                return systemInfo;
             }
         };
 
@@ -69,5 +71,43 @@ public class UtilsTest {
                 throw new UserException("No backend or compute node alive.");
             }
         };
+    }
+
+    @Test
+    public void testGetWarehouse() {
+        WarehouseManager manager = new WarehouseManager();
+        manager.initDefaultWarehouse();
+
+        long workerGroupId = Utils.getWorkerGroupByWarehouseId(manager, WarehouseManager.DEFAULT_WAREHOUSE_ID);
+        Assert.assertEquals(StarOSAgent.DEFAULT_WORKER_GROUP_ID, workerGroupId);
+    }
+
+    @Test
+    public void testGetWarehouseIdFromBackend() {
+        SystemInfoService systemInfo = new SystemInfoService();
+        Backend b1 = new Backend(10001L, "192.168.0.1", 9050);
+        b1.setBePort(9060);
+        b1.setWarehouseId(10001L);
+        Backend b2 = new Backend(10002L, "192.168.0.2", 9050);
+        b2.setBePort(9060);
+        b2.setWarehouseId(10002L);
+
+        // add two backends to different warehouses
+        systemInfo.addBackend(b1);
+        systemInfo.addBackend(b2);
+
+        // If the version of be is old, it may pass null.
+        long warehouseId = Utils.getWarehouseIdFromBackend(systemInfo, null);
+        Assert.assertEquals(WarehouseManager.DEFAULT_WAREHOUSE_ID, warehouseId);
+
+        // pass a wrong tBackend
+        warehouseId = Utils.getWarehouseIdFromBackend(systemInfo, new TBackend("192.168.100.1", 9060, 8040));
+        Assert.assertEquals(WarehouseManager.DEFAULT_WAREHOUSE_ID, warehouseId);
+
+        // pass a right tBackend
+        warehouseId = Utils.getWarehouseIdFromBackend(systemInfo, new TBackend("192.168.0.1", 9060, 8040));
+        Assert.assertEquals(10001L, warehouseId);
+        warehouseId = Utils.getWarehouseIdFromBackend(systemInfo, new TBackend("192.168.0.2", 9060, 8040));
+        Assert.assertEquals(10002L, warehouseId);
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/pseudocluster/PseudoCluster.java
+++ b/fe/fe-core/src/test/java/com/starrocks/pseudocluster/PseudoCluster.java
@@ -212,7 +212,7 @@ public class PseudoCluster {
 
         @Override
         public List<Long> createShards(int numShards, FilePathInfo pathInfo, FileCacheInfo cacheInfo,
-                                       long groupId, List<Long> matchShardIds, Map<String, String> properties)
+                                       long groupId, List<Long> matchShardIds, Map<String, String> properties, long workerGroupId)
                 throws DdlException {
             List<Long> shardIds = new ArrayList<>();
             for (int i = 0; i < numShards; i++) {

--- a/fe/fe-core/src/test/java/com/starrocks/server/LocalMetaStoreTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/server/LocalMetaStoreTest.java
@@ -97,7 +97,8 @@ public class LocalMetaStoreTest {
         Assert.assertEquals(olapTable.getName(), copiedTable.getName());
         Set<Long> tabletIdSet = Sets.newHashSet();
         List<Partition> newPartitions = localMetastore.getNewPartitionsFromPartitions(db,
-                olapTable, sourcePartitionIds, origPartitions, copiedTable, "_100", tabletIdSet, tmpPartitionIds, null);
+                olapTable, sourcePartitionIds, origPartitions, copiedTable, "_100", tabletIdSet, tmpPartitionIds,
+                null, WarehouseManager.DEFAULT_WAREHOUSE_ID);
         Assert.assertEquals(sourcePartitionIds.size(), newPartitions.size());
         Assert.assertEquals(1, newPartitions.size());
         Partition newPartition = newPartitions.get(0);

--- a/gensrc/thrift/FrontendService.thrift
+++ b/gensrc/thrift/FrontendService.thrift
@@ -847,7 +847,10 @@ struct TLoadTxnBeginRequest {
     // The real value of timeout should be i32. i64 ensures the compatibility of interface.
     10: optional i64 timeout
     11: optional Types.TUniqueId request_id
-    101: optional string warehouse   // begin from 101, in case of conflict with other's change
+    
+    // begin from 101, in case of conflict with other's change
+    101: optional string warehouse
+    102: optional Types.TBackend backend
 }
 
 struct TLoadTxnBeginResult {
@@ -914,7 +917,9 @@ struct TStreamLoadPutRequest {
     54: optional byte escape
     55: optional Types.TPartialUpdateMode partial_update_mode
 
-    101: optional string warehouse   // begin from 101, in case of conflict with other's change
+    // begin from 101, in case of conflict with other's change
+    101: optional string warehouse  // deprecated, because it needs client to pass warehouse name
+    102: optional Types.TBackend backend
 }
 
 struct TStreamLoadPutResult {
@@ -1353,6 +1358,7 @@ struct TImmutablePartitionRequest {
     2: optional i64 db_id
     3: optional i64 table_id
     4: optional list<i64> partition_ids
+    5: optional Types.TBackend backend
 }
 
 struct TImmutablePartitionResult {

--- a/gensrc/thrift/FrontendService.thrift
+++ b/gensrc/thrift/FrontendService.thrift
@@ -849,8 +849,8 @@ struct TLoadTxnBeginRequest {
     11: optional Types.TUniqueId request_id
     
     // begin from 101, in case of conflict with other's change
-    101: optional string warehouse
-    102: optional Types.TBackend backend
+    101: optional string warehouse  // deprecated, use backend_id implicitly convey information about the warehouse
+    102: optional i64 backend_id
 }
 
 struct TLoadTxnBeginResult {
@@ -918,8 +918,8 @@ struct TStreamLoadPutRequest {
     55: optional Types.TPartialUpdateMode partial_update_mode
 
     // begin from 101, in case of conflict with other's change
-    101: optional string warehouse  // deprecated, because it needs client to pass warehouse name
-    102: optional Types.TBackend backend
+    101: optional string warehouse  // deprecated, use backend_id implicitly convey information about the warehouse
+    102: optional i64 backend_id
 }
 
 struct TStreamLoadPutResult {
@@ -1358,7 +1358,9 @@ struct TImmutablePartitionRequest {
     2: optional i64 db_id
     3: optional i64 table_id
     4: optional list<i64> partition_ids
-    5: optional Types.TBackend backend
+
+    // begin from 101, in case of conflict with other's change
+    101: optional i64 backend_id
 }
 
 struct TImmutablePartitionResult {


### PR DESCRIPTION
## Why I'm doing:

1. We need to add a parameter, `workerGroupId`, to the `createShards` method of StarOSAgent; otherwise, the shard creation operation will be scheduled to Nodes within the Default Worker Group.
2. When creating a Partition, the hard-coded `WarehouseManager.DEFAULT_WAREHOUSE_ID` is used as a parameter, and the caller of the Partition creation is aware of which Warehouse to utilize. For instance, in the case of an Insert Overwrite Job. Therefore, it is necessary to include the Warehouse parameter in the create partition method.
3. Initially, we intended to pass the Warehouse as a parameter in Thrift calls, which led to the Warehouse becoming stateful during the process of transmission, and the need to save and pass the Warehouse in BE function calls. BE identifies itself by passing a Backend, which should be a more universal approach. FE can deduce the warehouse where the BE worker is located through the backend information. Consequently, we have added a Backend field in `TLoadTxnBeginRequest`, `TStreamLoadPutRequest`, and `TImmutablePartitionRequest`.

## What I'm doing:

Revise the three issues I mentioned earlier, and resolve a series of errors that occur due to the absence of a Node in the Default Warehouse, which is fundamentally caused by not using the correct Warehouse information.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
