### PR TITLE
[BugFix] fix pk dump crash in persistent index

### DIFF
--- a/be/test/storage/tablet_updates_test.cpp
+++ b/be/test/storage/tablet_updates_test.cpp
@@ -878,6 +878,40 @@ TEST_F(TabletUpdatesTest, apply_with_merge_condition_pindex) {
     test_apply(true, true);
 }
 
+TEST_F(TabletUpdatesTest, apply_with_pk_dump) {
+    const int N = 10000;
+    int64_t old_config = config::l0_max_mem_usage;
+    config::l0_max_mem_usage = 1000;
+    _tablet = create_tablet(rand(), rand());
+    _tablet->set_enable_persistent_index(true);
+    ASSERT_EQ(1, _tablet->updates()->version_history_count());
+
+    std::vector<int64_t> keys(N);
+    for (int i = 0; i < N; i++) {
+        keys[i] = i;
+    }
+    std::vector<RowsetSharedPtr> rowsets;
+    rowsets.reserve(64);
+    for (int i = 0; i < 64; i++) {
+        rowsets.emplace_back(create_rowset(_tablet, keys, nullptr, false, false));
+    }
+    auto pool = StorageEngine::instance()->update_manager()->apply_thread_pool();
+    for (int i = 0; i < rowsets.size(); i++) {
+        auto version = i + 2;
+        auto st = _tablet->rowset_commit(version, rowsets[i]);
+        ASSERT_TRUE(st.ok()) << st.to_string();
+        // Ensure that there is at most one thread doing the version apply job.
+        ASSERT_LE(pool->num_threads(), 1);
+        ASSERT_EQ(version, _tablet->updates()->max_version());
+        ASSERT_EQ(version, _tablet->updates()->version_history_count());
+    }
+    ASSERT_EQ(N, read_tablet(_tablet, rowsets.size() + 1));
+
+    // Ensure the persistent meta is correct.
+    test_pk_dump(rowsets.size());
+    config::l0_max_mem_usage = old_config;
+}
+
 void TabletUpdatesTest::test_condition_update_apply(bool enable_persistent_index) {
     const int N = 100;
     _tablet = create_tablet(rand(), rand());


### PR DESCRIPTION
## Why I'm doing:
When dump persistent index's ImmutableIndex, we release ImmutableIndexShard before dump end, which will cause BE crash like:
```
*** Aborted at 1711974161 (unix time) try "date -d @1711974161" if you are using GNU date ***
PC: @          0x53b6395 starrocks::PersistentIndex::pk_dump()
*** SIGSEGV (@0x100000001) received by PID 6 (TID 0x7f0a83dd5700) from PID 1; stack trace: ***
    @          0x67c6ea2 google::(anonymous namespace)::FailureSignalHandler()
    @     0x7f0f094b4630 (unknown)
    @          0x53b6395 starrocks::PersistentIndex::pk_dump()
    @          0x503f19f starrocks::PrimaryIndex::pk_dump()
    @          0x5154356 starrocks::TabletUpdates::primary_index_dump()
    @          0x5382b23 starrocks::PrimaryKeyDump::dump()
    @          0x515f335 starrocks::TabletUpdates::generate_pk_dump_if_in_error_state()
    @          0x50ea171 starrocks::TabletManager::generate_pk_dump()
    @          0x5033e8a starrocks::StorageEngine::_pk_dump_thread_callback()
    @          0x8c011c0 execute_native_thread_routine
    @     0x7f0f094acea5 start_thread
    @     0x7f0f088ad96d __clone
    @                0x0 (unknown)
```

## What I'm doing:
Release ImmutableIndexShard after dump end.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [x] 3.2
  - [x] 3.1
  - [ ] 3.0
  - [ ] 2.5
