### PR TITLE
[Enhancement] Make it optional to have starrocks_be.debuginfo in allin1 image

### DIFF
--- a/docker/dockerfiles/allin1/allin1-ubi.Dockerfile
+++ b/docker/dockerfiles/allin1/allin1-ubi.Dockerfile
@@ -10,6 +10,7 @@
 #   image: copy the artifacts from a artifact docker image.
 #   local: copy the artifacts from a local repo. Mainly used for local development and test.
 ARG ARTIFACT_SOURCE=image
+ARG WITH_DEBUG_INFO=false
 
 ARG ARTIFACTIMAGE=starrocks/artifacts-centos7:latest
 FROM ${ARTIFACTIMAGE} as artifacts-from-image
@@ -24,8 +25,9 @@ COPY ${LOCAL_REPO_PATH}/fs_brokers/apache_hdfs_broker/output/apache_hdfs_broker 
 
 
 FROM artifacts-from-${ARTIFACT_SOURCE} as artifacts
-RUN rm -f /release/be_artifacts/be/lib/starrocks_be.debuginfo
+ARG WITH_DEBUG_INFO
 
+RUN if [ "$WITH_DEBUG_INFO" = "false" ]; then rm -f /release/be_artifacts/be/lib/starrocks_be.debuginfo; fi
 
 FROM registry.access.redhat.com/ubi8/ubi:8.7
 ARG DEPLOYDIR=/data/deploy

--- a/docker/dockerfiles/allin1/allin1-ubuntu.Dockerfile
+++ b/docker/dockerfiles/allin1/allin1-ubuntu.Dockerfile
@@ -10,6 +10,7 @@
 #   image: copy the artifacts from a artifact docker image.
 #   local: copy the artifacts from a local repo. Mainly used for local development and test.
 ARG ARTIFACT_SOURCE=image
+ARG WITH_DEBUG_INFO=false
 
 ARG ARTIFACTIMAGE=starrocks/artifacts-ubuntu:latest
 FROM ${ARTIFACTIMAGE} as artifacts-from-image
@@ -24,8 +25,9 @@ COPY ${LOCAL_REPO_PATH}/fs_brokers/apache_hdfs_broker/output/apache_hdfs_broker 
 
 
 FROM artifacts-from-${ARTIFACT_SOURCE} as artifacts
-RUN rm -f /release/be_artifacts/be/lib/starrocks_be.debuginfo
+ARG WITH_DEBUG_INFO
 
+RUN if [ "$WITH_DEBUG_INFO" = "false" ]; then rm -f /release/be_artifacts/be/lib/starrocks_be.debuginfo; fi
 
 FROM ubuntu:22.04 as dependencies-installed
 ARG DEPLOYDIR=/data/deploy


### PR DESCRIPTION
## Why I'm doing:
We need debuginfo in the allin1 container to catch/reproduce issues.

## What I'm doing:
Make it optional to keep starrocks_be.debuginfo in allin1 image.

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [x] 3.2
  - [x] 3.1
  - [ ] 3.0
  - [ ] 2.5
