### PR TITLE
[Enhancement] support replace for primary index

### DIFF
--- a/be/src/storage/persistent_index.cpp
+++ b/be/src/storage/persistent_index.cpp
@@ -3802,6 +3802,13 @@ Status PersistentIndex::erase(size_t n, const Slice* keys, IndexValue* old_value
     return _flush_advance_or_append_wal(n, keys, nullptr, nullptr);
 }
 
+Status PersistentIndex::replace(size_t n, const Slice* keys, const IndexValue* values,
+                                const std::vector<uint32_t>& replace_idxes) {
+    std::vector<size_t> tmp_replace_idxes(replace_idxes.begin(), replace_idxes.end());
+    RETURN_IF_ERROR(_l0->replace(keys, values, tmp_replace_idxes));
+    return _flush_advance_or_append_wal(n, keys, values, &tmp_replace_idxes);
+}
+
 [[maybe_unused]] Status PersistentIndex::try_replace(size_t n, const Slice* keys, const IndexValue* values,
                                                      const std::vector<uint32_t>& src_rssid,
                                                      std::vector<uint32_t>* failed) {

--- a/be/src/storage/persistent_index.h
+++ b/be/src/storage/persistent_index.h
@@ -703,6 +703,14 @@ public:
     virtual Status upsert(size_t n, const Slice* keys, const IndexValue* values, IndexValue* old_values,
                           IOStat* stat = nullptr);
 
+    // batch replace without return old values
+    // |n|: size of key/value array
+    // |keys|: key array as raw buffer
+    // |values|: value array
+    // |replace_indexes|: The index of the |keys| array that need to replace.
+    virtual Status replace(size_t n, const Slice* keys, const IndexValue* values,
+                           const std::vector<uint32_t>& replace_indexes);
+
     // batch insert, return error if key already exists
     // |n|: size of key/value array
     // |keys|: key array as raw buffer

--- a/be/src/storage/primary_index.cpp
+++ b/be/src/storage/primary_index.cpp
@@ -145,7 +145,7 @@ public:
     }
 
     Status replace(uint32_t rssid, uint32_t rowid_start, const std::vector<uint32_t>& indexes, uint32_t idx_begin,
-                   uint32_t idx_end, const Column& pks) {
+                   uint32_t idx_end, const Column& pks) override {
         auto* keys = reinterpret_cast<const Key*>(pks.raw_data());
         uint64_t base = (((uint64_t)rssid) << 32) + rowid_start;
         for (uint32_t idx = idx_begin; idx < idx_end; idx++) {
@@ -352,7 +352,7 @@ public:
     }
 
     Status replace(uint32_t rssid, uint32_t rowid_start, const std::vector<uint32_t>& indexes, uint32_t idx_begin,
-                   uint32_t idx_end, const Column& pks) {
+                   uint32_t idx_end, const Column& pks) override {
         const auto* keys = reinterpret_cast<const Slice*>(pks.raw_data());
         uint64_t base = (((uint64_t)rssid) << 32) + rowid_start;
         for (uint32_t idx = idx_begin; idx < idx_end; idx++) {
@@ -663,7 +663,7 @@ public:
     }
 
     Status replace(uint32_t rssid, uint32_t rowid_start, const std::vector<uint32_t>& indexes, uint32_t idx_begin,
-                   uint32_t idx_end, const Column& pks) {
+                   uint32_t idx_end, const Column& pks) override {
         const auto* keys = reinterpret_cast<const Slice*>(pks.raw_data());
         uint64_t base = (((uint64_t)rssid) << 32) + rowid_start;
         for (uint32_t idx = idx_begin; idx < idx_end; idx++) {
@@ -882,7 +882,7 @@ public:
     }
 
     Status replace(uint32_t rssid, uint32_t rowid_start, const std::vector<uint32_t>& indexes, uint32_t idx_begin,
-                   uint32_t idx_end, const Column& pks) {
+                   uint32_t idx_end, const Column& pks) override {
         if (!indexes.empty() && idx_begin < idx_end) {
             auto* keys = reinterpret_cast<const Slice*>(pks.raw_data());
             for (uint32_t i = idx_begin + 1; i < idx_end; i++) {
@@ -1427,8 +1427,9 @@ Status PrimaryIndex::upsert(uint32_t rssid, uint32_t rowid_start, const Column& 
     return st;
 }
 
-Status PrimaryIndex::_replace_persistent_index(uint32_t rssid, uint32_t rowid_start,
-                                               const std::vector<uint32_t>& replace_indexes, const Column& pks) {
+Status PrimaryIndex::_replace_persistent_index_by_indexes(uint32_t rssid, uint32_t rowid_start,
+                                                          const std::vector<uint32_t>& replace_indexes,
+                                                          const Column& pks) {
     auto scope = IOProfiler::scope(IOProfiler::TAG_PKINDEX, _tablet_id);
     std::vector<Slice> keys;
     std::vector<uint64_t> values;
@@ -1446,7 +1447,7 @@ Status PrimaryIndex::replace(uint32_t rssid, uint32_t rowid_start, const std::ve
                              const Column& pks) {
     DCHECK(_status.ok() && (_pkey_to_rssid_rowid || _persistent_index));
     if (_persistent_index != nullptr) {
-        return _replace_persistent_index(rssid, rowid_start, replace_indexes, pks);
+        return _replace_persistent_index_by_indexes(rssid, rowid_start, replace_indexes, pks);
     } else {
         return _pkey_to_rssid_rowid->replace(rssid, rowid_start, replace_indexes, 0, replace_indexes.size(), pks);
     }

--- a/be/src/storage/primary_index.cpp
+++ b/be/src/storage/primary_index.cpp
@@ -56,6 +56,10 @@ public:
     // batch upsert a range [idx_begin, idx_end) of keys
     virtual void upsert(uint32_t rssid, uint32_t rowid_start, const Column& pks, uint32_t idx_begin, uint32_t idx_end,
                         DeletesMap* deletes) = 0;
+
+    // replace values, return error if not exist. replace a range [indexes[idx_begin], indexes[idx_end-1]]
+    virtual Status replace(uint32_t rssid, uint32_t rowid_start, const std::vector<uint32_t>& indexes,
+                           uint32_t idx_begin, uint32_t idx_end, const Column& pks) = 0;
     // TODO(qzc): maybe unused, remove it or refactor it with the methods in use by template after a period of time
     // batch try_replace a range [idx_begin, idx_end) of keys
     [[maybe_unused]] virtual void try_replace(uint32_t rssid, uint32_t rowid_start, const Column& pks,
@@ -135,6 +139,25 @@ public:
                         rssid, rowids[i], (uint32_t)(old >> 32), (uint32_t)(old & ROWID_MASK), keys[i]);
                 LOG(ERROR) << msg;
                 return Status::AlreadyExist(msg);
+            }
+        }
+        return Status::OK();
+    }
+
+    Status replace(uint32_t rssid, uint32_t rowid_start, const std::vector<uint32_t>& indexes, uint32_t idx_begin,
+                   uint32_t idx_end, const Column& pks) {
+        auto* keys = reinterpret_cast<const Key*>(pks.raw_data());
+        uint64_t base = (((uint64_t)rssid) << 32) + rowid_start;
+        for (uint32_t idx = idx_begin; idx < idx_end; idx++) {
+            const uint32_t i = indexes[idx];
+            RowIdPack4 v(base + i);
+            auto p = _map.find(keys[i]);
+            if (p != _map.end()) {
+                p->second = v;
+            } else {
+                std::string msg = strings::Substitute("replace not exist key=$0", keys[i]);
+                LOG(ERROR) << msg;
+                return Status::NotFound(msg);
             }
         }
         return Status::OK();
@@ -323,6 +346,25 @@ public:
                     LOG(ERROR) << msg;
                     return Status::AlreadyExist(msg);
                 }
+            }
+        }
+        return Status::OK();
+    }
+
+    Status replace(uint32_t rssid, uint32_t rowid_start, const std::vector<uint32_t>& indexes, uint32_t idx_begin,
+                   uint32_t idx_end, const Column& pks) {
+        const auto* keys = reinterpret_cast<const Slice*>(pks.raw_data());
+        uint64_t base = (((uint64_t)rssid) << 32) + rowid_start;
+        for (uint32_t idx = idx_begin; idx < idx_end; idx++) {
+            const uint32_t i = indexes[idx];
+            auto p = _map.find(FixSlice<S>(keys[i]));
+            if (p != _map.end()) {
+                // matched, can replace
+                p->second.value = base + i;
+            } else {
+                std::string msg = strings::Substitute("replace not exist key=$0", keys[i].to_string());
+                LOG(ERROR) << msg;
+                return Status::NotFound(msg);
             }
         }
         return Status::OK();
@@ -620,6 +662,25 @@ public:
         }
     }
 
+    Status replace(uint32_t rssid, uint32_t rowid_start, const std::vector<uint32_t>& indexes, uint32_t idx_begin,
+                   uint32_t idx_end, const Column& pks) {
+        const auto* keys = reinterpret_cast<const Slice*>(pks.raw_data());
+        uint64_t base = (((uint64_t)rssid) << 32) + rowid_start;
+        for (uint32_t idx = idx_begin; idx < idx_end; idx++) {
+            const uint32_t i = indexes[idx];
+            auto p = _map.find(keys[i].to_string());
+            if (p != _map.end()) {
+                // matched, can replace
+                p->second = base + i;
+            } else {
+                std::string msg = strings::Substitute("replace not exist key=$0", keys[i].to_string());
+                LOG(ERROR) << msg;
+                return Status::NotFound(msg);
+            }
+        }
+        return Status::OK();
+    }
+
     [[maybe_unused]] void try_replace(uint32_t rssid, uint32_t rowid_start, const Column& pks,
                                       const vector<uint32_t>& src_rssid, uint32_t idx_begin, uint32_t idx_end,
                                       vector<uint32_t>* failed) override {
@@ -818,6 +879,23 @@ public:
             }
             get_index_by_length(keys[idx_begin].size)->upsert(rssid, rowid_start, pks, idx_begin, idx_end, deletes);
         }
+    }
+
+    Status replace(uint32_t rssid, uint32_t rowid_start, const std::vector<uint32_t>& indexes, uint32_t idx_begin,
+                   uint32_t idx_end, const Column& pks) {
+        if (!indexes.empty() && idx_begin < idx_end) {
+            auto* keys = reinterpret_cast<const Slice*>(pks.raw_data());
+            for (uint32_t i = idx_begin + 1; i < idx_end; i++) {
+                if (keys[indexes[i]].size != keys[indexes[idx_begin]].size) {
+                    RETURN_IF_ERROR(get_index_by_length(keys[indexes[idx_begin]].size)
+                                            ->replace(rssid, rowid_start, indexes, idx_begin, i, pks));
+                    idx_begin = i;
+                }
+            }
+            RETURN_IF_ERROR(get_index_by_length(keys[indexes[idx_begin]].size)
+                                    ->replace(rssid, rowid_start, indexes, idx_begin, idx_end, pks));
+        }
+        return Status::OK();
     }
 
     [[maybe_unused]] void try_replace(uint32_t rssid, uint32_t rowid_start, const Column& pks,
@@ -1347,6 +1425,31 @@ Status PrimaryIndex::upsert(uint32_t rssid, uint32_t rowid_start, const Column& 
         _pkey_to_rssid_rowid->upsert(rssid, rowid_start, pks, idx_begin, idx_end, deletes);
     }
     return st;
+}
+
+Status PrimaryIndex::_replace_persistent_index(uint32_t rssid, uint32_t rowid_start,
+                                               const std::vector<uint32_t>& replace_indexes, const Column& pks) {
+    auto scope = IOProfiler::scope(IOProfiler::TAG_PKINDEX, _tablet_id);
+    std::vector<Slice> keys;
+    std::vector<uint64_t> values;
+    values.reserve(pks.size());
+    RETURN_IF_ERROR(_build_persistent_values(rssid, rowid_start, 0, pks.size(), &values));
+    Status st = _persistent_index->replace(pks.size(), _build_persistent_keys(pks, 0, pks.size(), &keys),
+                                           reinterpret_cast<IndexValue*>(values.data()), replace_indexes);
+    if (!st.ok()) {
+        LOG(WARNING) << "try replace persistent index failed";
+    }
+    return st;
+}
+
+Status PrimaryIndex::replace(uint32_t rssid, uint32_t rowid_start, const std::vector<uint32_t>& replace_indexes,
+                             const Column& pks) {
+    DCHECK(_status.ok() && (_pkey_to_rssid_rowid || _persistent_index));
+    if (_persistent_index != nullptr) {
+        return _replace_persistent_index(rssid, rowid_start, replace_indexes, pks);
+    } else {
+        return _pkey_to_rssid_rowid->replace(rssid, rowid_start, replace_indexes, 0, replace_indexes.size(), pks);
+    }
 }
 
 [[maybe_unused]] Status PrimaryIndex::try_replace(uint32_t rssid, uint32_t rowid_start, const Column& pks,

--- a/be/src/storage/primary_index.h
+++ b/be/src/storage/primary_index.h
@@ -190,8 +190,8 @@ private:
     Status _replace_persistent_index(uint32_t rssid, uint32_t rowid_start, const Column& pks,
                                      const uint32_t max_src_rssid, vector<uint32_t>* deletes);
 
-    Status _replace_persistent_index(uint32_t rssid, uint32_t rowid_start, const std::vector<uint32_t>& indexes,
-                                     const Column& pks);
+    Status _replace_persistent_index_by_indexes(uint32_t rssid, uint32_t rowid_start,
+                                                const std::vector<uint32_t>& replace_indexes, const Column& pks);
 
 protected:
     std::mutex _lock;

--- a/be/src/storage/primary_index.h
+++ b/be/src/storage/primary_index.h
@@ -70,6 +70,24 @@ public:
     Status upsert(uint32_t rssid, uint32_t rowid_start, const Column& pks, uint32_t idx_begin, uint32_t idx_end,
                   DeletesMap* deletes);
 
+    // replace old values, and make sure key exist
+    // Used in compaction apply & publish.
+    // [not thread-safe]
+    //
+    // |rssid| output segment's rssid
+    // |rowid_start| row id left open interval
+    // |replace_indexes| The index of the |pks| array that need to replace.
+    // |pks| each output segment row's *encoded* primary key
+    //
+    // E.g.
+    // pks : {a, b, c, d, e}
+    // replace_indexes : {2, 3}
+    // So we only need to replace {c : rssid + rowid_start + 2, d : rssid + rowid_start + 3}
+    //
+    // Return NotFound error when key not exist.
+    Status replace(uint32_t rssid, uint32_t rowid_start, const std::vector<uint32_t>& replace_indexes,
+                   const Column& pks);
+
     // TODO(qzc): maybe unused, remove it or refactor it with the methods in use by template after a period of time
     // used for compaction, try replace input rowsets' rowid with output segment's rowid, if
     // input rowsets' rowid doesn't exist, this indicates that the row of output rowset is
@@ -171,6 +189,9 @@ private:
                                                       const vector<uint32_t>& src_rssid, vector<uint32_t>* deletes);
     Status _replace_persistent_index(uint32_t rssid, uint32_t rowid_start, const Column& pks,
                                      const uint32_t max_src_rssid, vector<uint32_t>* deletes);
+
+    Status _replace_persistent_index(uint32_t rssid, uint32_t rowid_start, const std::vector<uint32_t>& indexes,
+                                     const Column& pks);
 
 protected:
     std::mutex _lock;

--- a/be/test/storage/primary_index_test.cpp
+++ b/be/test/storage/primary_index_test.cpp
@@ -218,7 +218,8 @@ PARALLEL_TEST(PrimaryIndexTest, test_largeint) {
 }
 
 template <LogicalType field_type>
-void test_binary_pk() {
+void test_binary_pk(int key_size) {
+    std::string fill_str(key_size, 'a');
     auto f = std::make_shared<Field>(0, "c0", field_type, false);
     f->set_is_key(true);
     auto schema = std::make_shared<Schema>(Fields{f}, PRIMARY_KEYS, std::vector<ColumnId>{0});
@@ -235,7 +236,7 @@ void test_binary_pk() {
     // [0, kSegmentSize)
     pk_col->resize(0);
     for (int i = 0; i < kSegmentSize; i++) {
-        pk_col->append(strings::Substitute("binary_pk_$0", pk_value++));
+        pk_col->append(strings::Substitute("binary_pk_$0_$1", fill_str, pk_value++));
     }
     ASSERT_TRUE(pk_index->insert(0, 0, *pk_col).ok());
 
@@ -248,7 +249,7 @@ void test_binary_pk() {
     // [kSegmentSize, 2*kSegmentSize)
     pk_col->resize(0);
     for (int i = 0; i < kSegmentSize; i++) {
-        pk_col->append(strings::Substitute("binary_pk_$0", pk_value++));
+        pk_col->append(strings::Substitute("binary_pk_$0_$1", fill_str, pk_value++));
     }
     ASSERT_TRUE(pk_index->insert(1, 0, *pk_col).ok());
     keys = reinterpret_cast<const Slice*>(pk_col->raw_data());
@@ -259,7 +260,7 @@ void test_binary_pk() {
     // [2*kSegmentSize, 3*kSegmentSize)
     pk_col->resize(0);
     for (int i = 0; i < kSegmentSize; i++) {
-        pk_col->append(strings::Substitute("binary_pk_$0", pk_value++));
+        pk_col->append(strings::Substitute("binary_pk_$0_$1", fill_str, pk_value++));
     }
     ASSERT_TRUE(pk_index->insert(2, 0, *pk_col).ok());
     keys = reinterpret_cast<const Slice*>(pk_col->raw_data());
@@ -286,7 +287,7 @@ void test_binary_pk() {
     // [3*kSegmentSize, 4*kSegmentSize)
     pk_col->resize(0);
     for (int i = 0; i < kSegmentSize; i++) {
-        pk_col->append(strings::Substitute("binary_pk_$0", pk_value++));
+        pk_col->append(strings::Substitute("binary_pk_$0_$1", fill_str, pk_value++));
     }
     pk_index->upsert(3, 0, *pk_col, &deletes);
     CHECK_EQ(0, deletes.size());
@@ -294,7 +295,7 @@ void test_binary_pk() {
     // upsert all the even numbers in range [0, 2 * kSegmentSize)
     pk_col->resize(0);
     for (int i = 0; i < kSegmentSize; i++) {
-        pk_col->append(strings::Substitute("binary_pk_$0", i * 2));
+        pk_col->append(strings::Substitute("binary_pk_$0_$1", fill_str, i * 2));
     }
     pk_index->upsert(4, 0, *pk_col, &deletes);
     CHECK_EQ(2, deletes.size());
@@ -314,7 +315,7 @@ void test_binary_pk() {
     pk_col->resize(0);
     std::vector<uint32_t> replace_indexes;
     for (int i = 0; i < kSegmentSize * 2; i++) {
-        pk_col->append(strings::Substitute("binary_pk_$0", i));
+        pk_col->append(strings::Substitute("binary_pk_$0_$1", fill_str, i));
     }
     for (uint32_t i = 0; i < kSegmentSize; i++) {
         replace_indexes.push_back(i * 2 + 1);
@@ -338,7 +339,7 @@ void test_binary_pk() {
     // remove all odd numbers in range [2 * kSegmentSize, 4 * kSegmentSize)
     pk_col->resize(0);
     for (int i = 0; i < kSegmentSize; i++) {
-        pk_col->append(strings::Substitute("binary_pk_$0", 2 * kSegmentSize + i * 2 + 1));
+        pk_col->append(strings::Substitute("binary_pk_$0_$1", fill_str, 2 * kSegmentSize + i * 2 + 1));
     }
     deletes.clear();
     pk_index->erase(*pk_col, &deletes);
@@ -369,8 +370,12 @@ void test_binary_pk() {
     }
 }
 
-PARALLEL_TEST(PrimaryIndexTest, test_varchar) {
-    test_binary_pk<TYPE_VARCHAR>();
+PARALLEL_TEST(PrimaryIndexTest, test_varchar1) {
+    test_binary_pk<TYPE_VARCHAR>(1);
+}
+
+PARALLEL_TEST(PrimaryIndexTest, test_varchar64) {
+    test_binary_pk<TYPE_VARCHAR>(64);
 }
 
 PARALLEL_TEST(PrimaryIndexTest, test_composite_key) {


### PR DESCRIPTION
## Why I'm doing:
Now we use `try_replace` to resolve compaction conflict with data loading when apply, but in the future, we will support a faster way to resolve conflict and this faster way need a new function call `replace` in primary index.
`replace` will not need to read from pk index any more, only replace exist keys.

## What I'm doing:
support `replace`.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [x] 3.2
  - [x] 3.1
  - [ ] 3.0
  - [ ] 2.5
