### PR TITLE
[Enhancement] Prune the pure pushdown predicate column after filtering by GIN

### DIFF
--- a/be/src/exec/pipeline/scan/olap_chunk_source.cpp
+++ b/be/src/exec/pipeline/scan/olap_chunk_source.cpp
@@ -207,6 +207,9 @@ Status OlapChunkSource::_init_reader_params(const std::vector<std::unique_ptr<Ol
     _params.runtime_state = _runtime_state;
     _params.use_page_cache = _runtime_state->use_page_cache();
     _params.use_pk_index = thrift_olap_scan_node.use_pk_index;
+    if (thrift_olap_scan_node.__isset.enable_prune_column_after_index_filter) {
+        _params.prune_column_after_index_filter = thrift_olap_scan_node.enable_prune_column_after_index_filter;
+    }
     if (thrift_olap_scan_node.__isset.sorted_by_keys_per_tablet) {
         _params.sorted_by_keys_per_tablet = thrift_olap_scan_node.sorted_by_keys_per_tablet;
     }

--- a/be/src/storage/rowset/rowset.cpp
+++ b/be/src/storage/rowset/rowset.cpp
@@ -690,6 +690,7 @@ Status Rowset::get_segment_iterators(const Schema& schema, const RowsetReadOptio
     if (options.runtime_state != nullptr) {
         seg_options.is_cancelled = &options.runtime_state->cancelled_ref();
     }
+    seg_options.prune_column_after_index_filter = options.prune_column_after_index_filter;
 
     auto segment_schema = schema;
     // Append the columns with delete condition to segment schema.

--- a/be/src/storage/rowset/rowset_options.h
+++ b/be/src/storage/rowset/rowset_options.h
@@ -82,6 +82,8 @@ public:
     std::vector<ColumnAccessPathPtr>* column_access_paths = nullptr;
 
     bool asc_hint = true;
+
+    bool prune_column_after_index_filter = false;
 };
 
 } // namespace starrocks

--- a/be/src/storage/rowset/segment_options.h
+++ b/be/src/storage/rowset/segment_options.h
@@ -102,6 +102,8 @@ public:
 
     bool asc_hint = true;
 
+    bool prune_column_after_index_filter = false;
+
 public:
     Status convert_to(SegmentReadOptions* dst, const std::vector<LogicalType>& new_types, ObjectPool* obj_pool) const;
 

--- a/be/src/storage/tablet_reader.cpp
+++ b/be/src/storage/tablet_reader.cpp
@@ -283,6 +283,7 @@ Status TabletReader::get_segment_iterators(const TabletReaderParams& params, std
     rs_opts.rowid_range_option = params.rowid_range_option;
     rs_opts.short_key_ranges_option = params.short_key_ranges_option;
     rs_opts.asc_hint = _is_asc_hint;
+    rs_opts.prune_column_after_index_filter = params.prune_column_after_index_filter;
 
     SCOPED_RAW_TIMER(&_stats.create_segment_iter_ns);
     for (auto& rowset : _rowsets) {

--- a/be/src/storage/tablet_reader_params.h
+++ b/be/src/storage/tablet_reader_params.h
@@ -90,6 +90,8 @@ struct TabletReaderParams {
     TScanRange* scan_range = nullptr;
     int32_t plan_node_id;
 
+    bool prune_column_after_index_filter = false;
+
 public:
     std::string to_string() const;
 };

--- a/fe/fe-core/src/main/java/com/starrocks/planner/OlapScanNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/OlapScanNode.java
@@ -977,6 +977,8 @@ public class OlapScanNode extends ScanNode {
             }
 
             msg.olap_scan_node.setUse_pk_index(usePkIndex);
+            msg.olap_scan_node.setEnable_prune_column_after_index_filter(
+                ConnectContext.get().getSessionVariable().isEnablePruneColumnAfterIndexFilter());
         }
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
@@ -280,6 +280,9 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
     public static final String ENABLE_FILTER_UNUSED_COLUMNS_IN_SCAN_STAGE =
             "enable_filter_unused_columns_in_scan_stage";
 
+    public static final String ENABLE_PRUNE_COLUMN_AFTER_INDEX_FILTER =
+            "enable_prune_column_after_index_filter";
+
     // the maximum time, in seconds, waiting for an insert statement's transaction state
     // transfer from COMMITTED to VISIBLE.
     // If the time exceeded but the transaction state is not VISIBLE, the transaction will
@@ -1136,6 +1139,9 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
 
     @VariableMgr.VarAttr(name = ENABLE_FILTER_UNUSED_COLUMNS_IN_SCAN_STAGE)
     private boolean enableFilterUnusedColumnsInScanStage = true;
+
+    @VariableMgr.VarAttr(name = ENABLE_PRUNE_COLUMN_AFTER_INDEX_FILTER, flag = VariableMgr.INVISIBLE)
+    private boolean enablePruneColumnAfterIndexFilter = true;
 
     @VariableMgr.VarAttr(name = CBO_MAX_REORDER_NODE_USE_EXHAUSTIVE)
     private int cboMaxReorderNodeUseExhaustive = 4;
@@ -2528,6 +2534,10 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
 
     public boolean isEnableFilterUnusedColumnsInScanStage() {
         return enableFilterUnusedColumnsInScanStage;
+    }
+
+    public boolean isEnablePruneColumnAfterIndexFilter() {
+        return enablePruneColumnAfterIndexFilter;
     }
 
     public void disableTrimOnlyFilteredColumnsInScanStage() {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/ExpressionAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/ExpressionAnalyzer.java
@@ -969,8 +969,8 @@ public class ExpressionAnalyzer {
                 throw new SemanticException("left operand of MATCH must be column ref");
             }
 
-            if (!type2.isStringType() && !type2.isNull()) {
-                throw new SemanticException("right operand of MATCH must be of type STRING with NOT NULL");
+            if (!(node.getChild(1) instanceof StringLiteral) || type2.isNull()) {
+                throw new SemanticException("right operand of MATCH must be of type StringLiteral with NOT NULL");
             }
 
             return null;

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/AddDecodeNodeForDictStringRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/AddDecodeNodeForDictStringRule.java
@@ -60,6 +60,7 @@ import com.starrocks.sql.optimizer.operator.scalar.ConstantOperator;
 import com.starrocks.sql.optimizer.operator.scalar.InPredicateOperator;
 import com.starrocks.sql.optimizer.operator.scalar.IsNullPredicateOperator;
 import com.starrocks.sql.optimizer.operator.scalar.LikePredicateOperator;
+import com.starrocks.sql.optimizer.operator.scalar.MatchExprOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ScalarOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ScalarOperatorVisitor;
 import com.starrocks.sql.optimizer.statistics.CacheDictManager;
@@ -1226,6 +1227,13 @@ public class AddDecodeNodeForDictStringRule implements TreeRewriteRule {
             }
 
             return predicate.getChild(0).isColumnRef();
+        }
+
+        @Override
+        public Boolean visitMatchExprOperator(MatchExprOperator predicate, Void context) {
+            // match expression is always satisfy the following format:
+            // SlotRef MATCH StringLiteral which is always SimpleStrictPredicate
+            return true;
         }
 
         // These type predicates couldn't be pushed down to storage engine,

--- a/gensrc/thrift/PlanNodes.thrift
+++ b/gensrc/thrift/PlanNodes.thrift
@@ -525,6 +525,7 @@ struct TOlapScanNode {
   // order by hint for scan
   33: optional bool output_asc_hint
   34: optional bool partition_order_hint
+  35: optional bool enable_prune_column_after_index_filter
 }
 
 struct TJDBCScanNode {

--- a/test/sql/test_inverted_index/R/test_inverted_index
+++ b/test/sql/test_inverted_index/R/test_inverted_index
@@ -947,10 +947,18 @@ E: (1064, 'Getting analyzing error. Detail message: left operand of MATCH must b
 -- !result
 SELECT * FROM t_complex_predicate_for_gin_none WHERE text_column match CONCAT("ab", "c");
 -- result:
+E: (1064, 'Getting analyzing error. Detail message: right operand of MATCH must be of type StringLiteral with NOT NULL.')
 -- !result
 SELECT * FROM t_complex_predicate_for_gin_none WHERE text_column match CONCAT("ab", "%");
 -- result:
-1	abc cbd
+E: (1064, 'Getting analyzing error. Detail message: right operand of MATCH must be of type StringLiteral with NOT NULL.')
+-- !result
+SELECT * FROM t_complex_predicate_for_gin_none WHERE text_column match "";
+-- result:
+-- !result
+SELECT * FROM t_complex_predicate_for_gin_none WHERE text_column match NULL;
+-- result:
+E: (1064, 'Getting analyzing error. Detail message: right operand of MATCH must be of type StringLiteral with NOT NULL.')
 -- !result
 INSERT INTO t_complex_predicate_for_gin_english VALUES (1, "abc cbd");
 -- result:
@@ -999,15 +1007,58 @@ E: (1064, 'Getting analyzing error. Detail message: left operand of MATCH must b
 -- !result
 SELECT * FROM t_complex_predicate_for_gin_english WHERE text_column match CONCAT("ab", "c");
 -- result:
-1	abc cbd
+E: (1064, 'Getting analyzing error. Detail message: right operand of MATCH must be of type StringLiteral with NOT NULL.')
 -- !result
 SELECT * FROM t_complex_predicate_for_gin_english WHERE text_column match CONCAT("ab", "%");
 -- result:
-1	abc cbd
+E: (1064, 'Getting analyzing error. Detail message: right operand of MATCH must be of type StringLiteral with NOT NULL.')
+-- !result
+SELECT * FROM t_complex_predicate_for_gin_english WHERE text_column match "";
+-- result:
+-- !result
+SELECT * FROM t_complex_predicate_for_gin_none WHERE text_column match NULL;
+-- result:
+E: (1064, 'Getting analyzing error. Detail message: right operand of MATCH must be of type StringLiteral with NOT NULL.')
 -- !result
 DROP TABLE t_complex_predicate_for_gin_none;
 -- result:
 -- !result
 DROP TABLE t_complex_predicate_for_gin_english;
+-- result:
+-- !result
+-- name: test_delete_and_column_prune
+CREATE TABLE `t_delete_and_column_prune` (
+  `id1` bigint(20) NOT NULL COMMENT "",
+  `text_column` varchar(255) NULL COMMENT "",
+  INDEX gin_none (`text_column`) USING GIN ("parser" = "english") COMMENT 'whole line index'
+) ENGINE=OLAP
+DUPLICATE KEY(`id1`)
+DISTRIBUTED BY HASH(`id1`) BUCKETS 1
+PROPERTIES (
+"replication_num" = "1",
+"enable_persistent_index" = "false",
+"replicated_storage" = "false",
+"compression" = "LZ4"
+);
+-- result:
+-- !result
+INSERT INTO t_delete_and_column_prune VALUES (1, "b"),(2, "b"),(3, "b");
+-- result:
+-- !result
+SELECT id1 FROM t_delete_and_column_prune WHERE text_column MATCH "b";
+-- result:
+1
+2
+3
+-- !result
+DELETE FROM t_delete_and_column_prune WHERE id1 = 2;
+-- result:
+-- !result
+SELECT id1 FROM t_delete_and_column_prune WHERE text_column MATCH "b";
+-- result:
+1
+3
+-- !result
+DROP TABLE t_delete_and_column_prune;
 -- result:
 -- !result

--- a/test/sql/test_inverted_index/T/test_inverted_index
+++ b/test/sql/test_inverted_index/T/test_inverted_index
@@ -552,6 +552,8 @@ SELECT * FROM t_complex_predicate_for_gin_none WHERE CAST(id1 as STRING) match "
 SELECT * FROM t_complex_predicate_for_gin_none WHERE CAST(id1 as STRING) match "%abc%";
 SELECT * FROM t_complex_predicate_for_gin_none WHERE text_column match CONCAT("ab", "c");
 SELECT * FROM t_complex_predicate_for_gin_none WHERE text_column match CONCAT("ab", "%");
+SELECT * FROM t_complex_predicate_for_gin_none WHERE text_column match "";
+SELECT * FROM t_complex_predicate_for_gin_none WHERE text_column match NULL;
 
 INSERT INTO t_complex_predicate_for_gin_english VALUES (1, "abc cbd");
 INSERT INTO t_complex_predicate_for_gin_english VALUES (2, "cbd edf");
@@ -569,6 +571,30 @@ SELECT * FROM t_complex_predicate_for_gin_english WHERE CAST(id1 as STRING) matc
 SELECT * FROM t_complex_predicate_for_gin_english WHERE CAST(id1 as STRING) match "%abc%";
 SELECT * FROM t_complex_predicate_for_gin_english WHERE text_column match CONCAT("ab", "c");
 SELECT * FROM t_complex_predicate_for_gin_english WHERE text_column match CONCAT("ab", "%");
+SELECT * FROM t_complex_predicate_for_gin_english WHERE text_column match "";
+SELECT * FROM t_complex_predicate_for_gin_english WHERE text_column match NULL;
 
 DROP TABLE t_complex_predicate_for_gin_none;
 DROP TABLE t_complex_predicate_for_gin_english;
+
+-- name: test_delete_and_column_prune
+CREATE TABLE `t_delete_and_column_prune` (
+  `id1` bigint(20) NOT NULL COMMENT "",
+  `text_column` varchar(255) NULL COMMENT "",
+  INDEX gin_none (`text_column`) USING GIN ("parser" = "english") COMMENT 'whole line index'
+) ENGINE=OLAP
+DUPLICATE KEY(`id1`)
+DISTRIBUTED BY HASH(`id1`) BUCKETS 1
+PROPERTIES (
+"replication_num" = "1",
+"enable_persistent_index" = "false",
+"replicated_storage" = "false",
+"compression" = "LZ4"
+);
+
+INSERT INTO t_delete_and_column_prune VALUES (1, "b"),(2, "b"),(3, "b");
+SELECT id1 FROM t_delete_and_column_prune WHERE text_column MATCH "b";
+DELETE FROM t_delete_and_column_prune WHERE id1 = 2;
+SELECT id1 FROM t_delete_and_column_prune WHERE text_column MATCH "b";
+
+DROP TABLE t_delete_and_column_prune;


### PR DESCRIPTION
## Why I'm doing:
Currently, if a column is a pure pushdown predicate column with index  , which means that it satisfy:
1. It can be pushdown into storage engine and filter by index.
2. delete predicates do not contain this column.
3. output schema do not contain this column.

This means that if all the predicates of this column can be filter by index and being erased to be empty, the column need not be read at all. But in current implementation, the useless read will exist and cause the IO overhead especially for GIN

## What I'm doing:
If the column can be prune for sure, skip the page read (just resize it instead)

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
