### PR TITLE
[BugFix] Conflict between Restore and migration cause by storage medium

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/server/LocalMetastore.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/LocalMetastore.java
@@ -2982,7 +2982,7 @@ public class LocalMetastore implements ConnectorMetadata {
                                 changedPartitionsMap.put(dbId, multimap);
                             }
                             multimap.put(tableId, partitionId);
-                        } else {
+                        } else if (olapTable.getState() != OlapTable.OlapTableState.RESTORE) {
                             storageMediumMap.put(partitionId, dataProperty.getStorageMedium());
                         }
                     } // end for partitions


### PR DESCRIPTION
## Why I'm doing:
In currently implementation, restore will always create the new tablet for the table as HDD storage medium. But the meta data snapshot for storage medium can be SSD, which cause the problem. Tablet report find that the different medium between BE side and FE partition metadata, migration will be triggered. But in the same time, restore is processing, which cause the restore failed.

## What I'm doing:
Do not check the storage medium in tablet report for the Restoring table.

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [x] 3.3
  - [x] 3.2
  - [x] 3.1
  - [x] 3.0
  - [ ] 2.5