### PR TITLE
[Enhancement] Sstable block cache and memory usage of LakePerisistentIndex

### DIFF
--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -982,7 +982,7 @@ CONF_mInt64(lake_pk_compaction_min_input_segments, "5");
 CONF_mInt32(lake_pk_preload_memory_limit_percent, "30");
 CONF_mInt32(lake_pk_index_sst_min_compaction_versions, "2");
 CONF_mInt32(lake_pk_index_sst_max_compaction_versions, "5");
-CONF_mDouble(lake_pk_index_block_cache_limit, "0.1");
+CONF_mInt32(lake_pk_index_block_cache_limit_percent, "10");
 
 CONF_mBool(dependency_librdkafka_debug_enable, "false");
 

--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -982,7 +982,7 @@ CONF_mInt64(lake_pk_compaction_min_input_segments, "5");
 CONF_mInt32(lake_pk_preload_memory_limit_percent, "30");
 CONF_mInt32(lake_pk_index_sst_min_compaction_versions, "2");
 CONF_mInt32(lake_pk_index_sst_max_compaction_versions, "5");
-CONF_mInt32(lake_pk_index_block_cache_limit_percent, "10");
+CONF_Int32(lake_pk_index_block_cache_limit_percent, "10");
 
 CONF_mBool(dependency_librdkafka_debug_enable, "false");
 

--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -982,6 +982,7 @@ CONF_mInt64(lake_pk_compaction_min_input_segments, "5");
 CONF_mInt32(lake_pk_preload_memory_limit_percent, "30");
 CONF_mInt32(lake_pk_index_sst_min_compaction_versions, "2");
 CONF_mInt32(lake_pk_index_sst_max_compaction_versions, "5");
+CONF_mDouble(lake_pk_index_block_cache_limit, "0.1");
 
 CONF_mBool(dependency_librdkafka_debug_enable, "false");
 

--- a/be/src/storage/lake/lake_persistent_index.cpp
+++ b/be/src/storage/lake/lake_persistent_index.cpp
@@ -459,7 +459,10 @@ Status LakePersistentIndex::load_from_lake_tablet(TabletManager* tablet_mgr, con
 }
 
 size_t LakePersistentIndex::memory_usage() const {
-    size_t mem_usage = _memtable->memory_usage();
+    size_t mem_usage = 0;
+    if (_memtable != nullptr) {
+        mem_usage += _memtable->memory_usage();
+    }
     if (_immutable_memtable != nullptr) {
         mem_usage += _immutable_memtable->memory_usage();
     }

--- a/be/src/storage/lake/lake_persistent_index.h
+++ b/be/src/storage/lake/lake_persistent_index.h
@@ -115,6 +115,8 @@ public:
     Status load_from_lake_tablet(TabletManager* tablet_mgr, const TabletMetadataPtr& metadata, int64_t base_version,
                                  const MetaFileBuilder* builder);
 
+    size_t memory_usage() const override;
+
 private:
     Status flush_memtable();
 

--- a/be/src/storage/lake/update_manager.h
+++ b/be/src/storage/lake/update_manager.h
@@ -223,6 +223,7 @@ private:
     std::unique_ptr<MemTracker> _index_cache_mem_tracker;
     std::unique_ptr<MemTracker> _update_state_mem_tracker;
     std::unique_ptr<MemTracker> _compaction_state_mem_tracker;
+    std::unique_ptr<MemTracker> _block_cache_mem_tracker;
 
     std::vector<PkIndexShard> _pk_index_shards;
 

--- a/be/src/storage/lake/update_manager.h
+++ b/be/src/storage/lake/update_manager.h
@@ -62,9 +62,10 @@ public:
     Cache* cache() { return _cache.get(); }
 
 private:
-    std::atomic<size_t> _memory_usage{0};
-    MemTracker* _mem_tracker = nullptr;
+    std::mutex _mutex;
+    size_t _memory_usage{0};
     std::unique_ptr<Cache> _cache;
+    std::unique_ptr<MemTracker> _mem_tracker;
 };
 
 class UpdateManager {
@@ -223,7 +224,6 @@ private:
     std::unique_ptr<MemTracker> _index_cache_mem_tracker;
     std::unique_ptr<MemTracker> _update_state_mem_tracker;
     std::unique_ptr<MemTracker> _compaction_state_mem_tracker;
-    std::unique_ptr<MemTracker> _block_cache_mem_tracker;
 
     std::vector<PkIndexShard> _pk_index_shards;
 

--- a/be/src/storage/persistent_index.h
+++ b/be/src/storage/persistent_index.h
@@ -656,7 +656,7 @@ public:
     size_t key_size() const { return _key_size; }
 
     size_t size() const { return _size; }
-    size_t memory_usage() const { return _memory_usage.load(); }
+    virtual size_t memory_usage() const { return _memory_usage.load(); }
 
     EditVersion version() const { return _version; }
 


### PR DESCRIPTION
## Why I'm doing:
1. The memory usage of LakePersistentIndex should be tracked. 
2. Sstable block cache should be supported in LakePersistentIndex which will be used in get api of sstable.
## What I'm doing:
1. Implement `memory_usage()` of LakePersistentIndex.
2. Support using block cache in sstable.

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
