### PR TITLE
[Enhancement] INSERT INTO FILES() support user-specified column separator and row delimiter

### DIFF
--- a/be/src/runtime/table_function_table_sink.cpp
+++ b/be/src/runtime/table_function_table_sink.cpp
@@ -99,8 +99,8 @@ Status TableFunctionTableSink::decompose_to_pipeline(pipeline::OpFactories prev_
     if (target_table.__isset.csv_column_seperator) {
         sink_ctx->options[formats::CSVWriterOptions::COLUMN_TERMINATED_BY] = target_table.csv_column_seperator;
     }
-    if (target_table.__isset.csv_row_delimter) {
-        sink_ctx->options[formats::CSVWriterOptions::LINE_TERMINATED_BY] = target_table.csv_row_delimter;
+    if (target_table.__isset.csv_row_delimiter) {
+        sink_ctx->options[formats::CSVWriterOptions::LINE_TERMINATED_BY] = target_table.csv_row_delimiter;
     }
 
     auto connector = connector::ConnectorManager::default_instance()->get(connector::Connector::FILE);

--- a/be/src/runtime/table_function_table_sink.cpp
+++ b/be/src/runtime/table_function_table_sink.cpp
@@ -96,6 +96,12 @@ Status TableFunctionTableSink::decompose_to_pipeline(pipeline::OpFactories prev_
     sink_ctx->compression_type = target_table.compression_type;
     sink_ctx->column_evaluators = ColumnExprEvaluator::from_exprs(output_exprs, runtime_state);
     sink_ctx->fragment_context = fragment_ctx;
+    if (target_table.__isset.csv_column_seperator) {
+        sink_ctx->options[formats::CSVWriterOptions::COLUMN_TERMINATED_BY] = target_table.csv_column_seperator;
+    }
+    if (target_table.__isset.csv_row_delimter) {
+        sink_ctx->options[formats::CSVWriterOptions::LINE_TERMINATED_BY] = target_table.csv_row_delimter;
+    }
 
     auto connector = connector::ConnectorManager::default_instance()->get(connector::Connector::FILE);
     auto sink_provider = connector->create_data_sink_provider();

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/TableFunctionTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/TableFunctionTable.java
@@ -14,6 +14,7 @@
 
 package com.starrocks.catalog;
 
+import com.google.common.base.Preconditions;
 import com.google.common.base.Splitter;
 import com.google.common.base.Strings;
 import com.google.common.collect.Lists;
@@ -22,14 +23,17 @@ import com.starrocks.analysis.BrokerDesc;
 import com.starrocks.analysis.DescriptorTable;
 import com.starrocks.common.DdlException;
 import com.starrocks.common.UserException;
+import com.starrocks.common.util.CompressionUtils;
 import com.starrocks.fs.HdfsUtil;
 import com.starrocks.load.Load;
 import com.starrocks.proto.PGetFileSchemaResult;
 import com.starrocks.proto.PSlotDescriptor;
+import com.starrocks.qe.SessionVariable;
 import com.starrocks.rpc.BackendServiceClient;
 import com.starrocks.rpc.PGetFileSchemaRequest;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.server.RunMode;
+import com.starrocks.sql.analyzer.SemanticException;
 import com.starrocks.sql.ast.ImportColumnDesc;
 import com.starrocks.system.ComputeNode;
 import com.starrocks.thrift.TBrokerFileStatus;
@@ -52,6 +56,7 @@ import org.apache.logging.log4j.Logger;
 import org.apache.thrift.TException;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -59,10 +64,8 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.Future;
 import java.util.stream.Collectors;
-import javax.annotation.Nullable;
 
-import static com.google.common.base.Verify.verify;
-import static com.starrocks.analysis.OutFileClause.PARQUET_COMPRESSION_TYPE_MAP;
+import static com.google.common.base.Preconditions.checkNotNull;
 
 public class TableFunctionTable extends Table {
     public static final Set<String> SUPPORTED_FORMATS;
@@ -81,6 +84,9 @@ public class TableFunctionTable extends Table {
     public static final String FAKE_PATH = "fake://";
     public static final String PROPERTY_PATH = "path";
     public static final String PROPERTY_FORMAT = "format";
+    public static final String PROPERTY_COMPRESSION = "compression";
+    public static final String PROPERTY_TARGET_MAX_FILE_SIZE = "target_max_file_size";
+    public static final String PROPERTY_PARTITION_BY = "partition_by";
 
     public static final String PROPERTY_COLUMNS_FROM_PATH = "columns_from_path";
 
@@ -103,8 +109,8 @@ public class TableFunctionTable extends Table {
 
     private List<String> columnsFromPath = new ArrayList<>();
     private final Map<String, String> properties;
-    @Nullable
-    private List<Integer> partitionColumnIDs;
+
+    private Optional<List<Integer>> partitionColumnIDs = Optional.empty();
     private boolean writeSingleFile;
     private long targetMaxFileSize;
 
@@ -118,6 +124,7 @@ public class TableFunctionTable extends Table {
 
     private List<TBrokerFileStatus> fileStatuses = Lists.newArrayList();
 
+    // Ctor for load data via table function
     public TableFunctionTable(Map<String, String> properties) throws DdlException {
         super(TableType.TABLE_FUNCTION);
         super.setId(-1);
@@ -142,19 +149,106 @@ public class TableFunctionTable extends Table {
     }
 
     // Ctor for unload data via table function
-    public TableFunctionTable(String path, String format, String compressionType, List<Column> columns,
-            @Nullable List<Integer> partitionColumnIDs, boolean writeSingleFile, long targetMaxFileSize,
-            Map<String, String> properties) {
+    public TableFunctionTable(List<Column> columns, Map<String, String> properties, SessionVariable sessionVariable) {
         super(TableType.TABLE_FUNCTION);
-        verify(!Strings.isNullOrEmpty(path), "path is null or empty");
-        verify(!(partitionColumnIDs != null && writeSingleFile));
-        this.path = path;
-        this.format = format;
-        this.compressionType = compressionType;
-        this.partitionColumnIDs = partitionColumnIDs;
-        this.writeSingleFile = writeSingleFile;
+        checkNotNull(properties, "properties is null");
+        checkNotNull(sessionVariable, "sessionVariable is null");
         this.properties = properties;
-        this.targetMaxFileSize = targetMaxFileSize;
+
+        List<String> columnNames = columns.stream()
+                .map(Column::getName)
+                .collect(Collectors.toList());
+
+        Set<String> duplicateColumnNames = columns.stream()
+                .map(Column::getName)
+                .filter(name -> Collections.frequency(columnNames, name) > 1)
+                .collect(Collectors.toSet());
+        if (!duplicateColumnNames.isEmpty()) {
+            throw new SemanticException("expect column names to be distinct, but got duplicate(s): " + duplicateColumnNames);
+        }
+
+        // parse table function properties
+        String single = properties.getOrDefault("single", "false");
+        if (!single.equalsIgnoreCase("true") && !single.equalsIgnoreCase("false")) {
+            throw new SemanticException("got invalid parameter \"single\" = \"%s\", expect a boolean value (true or false).",
+                    single);
+        }
+
+        this.writeSingleFile = single.equalsIgnoreCase("true");
+
+        // validate properties
+        if (!properties.containsKey(PROPERTY_PATH)) {
+            throw new SemanticException(
+                    "path is a mandatory property. \"path\" = \"s3://path/to/your/location/\"");
+        }
+        this.path = properties.get(path);
+        if (!this.path.endsWith("/")) {
+            this.path += "/";
+        }
+
+        if (!properties.containsKey(PROPERTY_FORMAT)) {
+            throw new SemanticException("format is a mandatory property. " +
+                    "Use any of (parquet, orc, csv)");
+        }
+        this.format = properties.get("format");
+
+        if (!SUPPORTED_FORMATS.contains(format)) {
+            throw new SemanticException(String.format("Unsupported format %s. " +
+                    "Use any of (parquet, orc, csv)", format));
+        }
+
+        // if max_file_size is not specified, use target max file size from session
+        if (properties.containsKey(PROPERTY_TARGET_MAX_FILE_SIZE)) {
+            this.targetMaxFileSize = Long.parseLong(properties.get(PROPERTY_TARGET_MAX_FILE_SIZE));
+        } else {
+            this.targetMaxFileSize = sessionVariable.getConnectorSinkTargetMaxFileSize();
+        }
+
+        // if compression codec is not specified, use compression codec from session
+        if (properties.containsKey(PROPERTY_COMPRESSION)) {
+            this.compressionType = properties.get(PROPERTY_COMPRESSION);
+        } else {
+            this.compressionType = sessionVariable.getConnectorSinkCompressionCodec();
+        }
+        if (CompressionUtils.getConnectorSinkCompressionType(compressionType).isEmpty()) {
+            throw new SemanticException(String.format("Unsupported compression codec %s. " +
+                    "Use any of (uncompressed, snappy, lz4, zstd, gzip)", compressionType));
+        }
+
+        if (writeSingleFile && !properties.containsKey(PROPERTY_PARTITION_BY)) {
+            throw new SemanticException("cannot use partition_by and single simultaneously.");
+        }
+
+        if (properties.containsKey(PROPERTY_PARTITION_BY)) {
+            // parse and validate partition columns
+            List<String> partitionColumnNames = Arrays.asList(properties.get(PROPERTY_PARTITION_BY).split(","));
+            partitionColumnNames.replaceAll(String::trim);
+            partitionColumnNames = partitionColumnNames.stream().distinct().collect(Collectors.toList());
+
+            List<String> unmatchedPartitionColumnNames = partitionColumnNames.stream()
+                    .filter(col -> !columnNames.contains(col))
+                    .collect(Collectors.toList());
+            if (!unmatchedPartitionColumnNames.isEmpty()) {
+                throw new SemanticException("partition columns expected to be a subset of " + columnNames +
+                        ", but got extra columns: " + unmatchedPartitionColumnNames);
+            }
+
+            List<Integer> partitionColumnIDs = partitionColumnNames.stream()
+                    .map(columnNames::indexOf)
+                    .collect(Collectors.toList());
+
+            for (Integer partitionColumnID : partitionColumnIDs) {
+                Column partitionColumn = columns.get(partitionColumnID);
+                Type type = partitionColumn.getType();
+                if (type.isBoolean() || type.isIntegerType() || type.isDateType() || type.isStringType()) {
+                    continue;
+                }
+                throw new SemanticException("partition column does not support type of " + type);
+            }
+
+            this.partitionColumnIDs = Optional.of(partitionColumnIDs);
+        }
+
         super.setNewFullSchema(columns);
     }
 
@@ -189,11 +283,10 @@ public class TableFunctionTable extends Table {
         tTableFunctionTable.setColumns(tColumns);
         tTableFunctionTable.setFile_format(format);
         tTableFunctionTable.setWrite_single_file(writeSingleFile);
-        tTableFunctionTable.setCompression_type(PARQUET_COMPRESSION_TYPE_MAP.get(compressionType));
+        Preconditions.checkState(CompressionUtils.getConnectorSinkCompressionType(compressionType).isPresent());
+        tTableFunctionTable.setCompression_type(CompressionUtils.getConnectorSinkCompressionType(compressionType).get());
         tTableFunctionTable.setTarget_max_file_size(targetMaxFileSize);
-        if (partitionColumnIDs != null) {
-            tTableFunctionTable.setPartition_column_ids(partitionColumnIDs);
-        }
+        partitionColumnIDs.ifPresent(tTableFunctionTable::setPartition_column_ids);
         return tTableFunctionTable;
     }
 
@@ -464,17 +557,15 @@ public class TableFunctionTable extends Table {
 
     @Override
     public List<String> getPartitionColumnNames() {
-        if (partitionColumnIDs == null) {
-            return new ArrayList<>();
-        }
-        return partitionColumnIDs.stream().map(id -> fullSchema.get(id).getName()).collect(Collectors.toList());
+        return partitionColumnIDs.map(integers -> integers.stream()
+                .map(id -> fullSchema.get(id).getName())
+                .collect(Collectors.toList()))
+                .orElseGet(ArrayList::new);
     }
 
     public List<Integer> getPartitionColumnIDs() {
-        if (partitionColumnIDs == null) {
-            return new ArrayList<>();
-        }
-        return Collections.unmodifiableList(partitionColumnIDs);
+        return partitionColumnIDs.map(Collections::unmodifiableList)
+                .orElseGet(ArrayList::new);
     }
 
     public boolean isWriteSingleFile() {

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/TableFunctionTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/TableFunctionTable.java
@@ -181,7 +181,7 @@ public class TableFunctionTable extends Table {
             throw new SemanticException(
                     "path is a mandatory property. \"path\" = \"s3://path/to/your/location/\"");
         }
-        this.path = properties.get(path);
+        this.path = properties.get(PROPERTY_PATH);
         if (!this.path.endsWith("/")) {
             this.path += "/";
         }

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/TableFunctionTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/TableFunctionTable.java
@@ -194,7 +194,7 @@ public class TableFunctionTable extends Table {
             throw new SemanticException("format is a mandatory property. " +
                     "Use any of (parquet, orc, csv)");
         }
-        this.format = properties.get("format");
+        this.format = properties.get(PROPERTY_FORMAT);
 
         if (!SUPPORTED_FORMATS.contains(format)) {
             throw new SemanticException(String.format("Unsupported format %s. " +
@@ -251,6 +251,14 @@ public class TableFunctionTable extends Table {
             }
 
             this.partitionColumnIDs = Optional.of(partitionColumnIDs);
+        }
+
+        // csv options
+        if (properties.containsKey(PROPERTY_CSV_COLUMN_SEPARATOR)) {
+            this.csvColumnSeparator = properties.get(PROPERTY_CSV_COLUMN_SEPARATOR);
+        }
+        if (properties.containsKey(PROPERTY_CSV_ROW_DELIMITER)) {
+            this.csvRowDelimiter = properties.get(PROPERTY_CSV_ROW_DELIMITER);
         }
 
         super.setNewFullSchema(columns);

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/TableFunctionTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/TableFunctionTable.java
@@ -300,7 +300,7 @@ public class TableFunctionTable extends Table {
         tTableFunctionTable.setTarget_max_file_size(targetMaxFileSize);
         if (CSV.equalsIgnoreCase(format)) {
             tTableFunctionTable.setCsv_column_seperator(csvColumnSeparator);
-            tTableFunctionTable.setCsv_row_delimter(csvRowDelimiter);
+            tTableFunctionTable.setCsv_row_delimiter(csvRowDelimiter);
         }
         partitionColumnIDs.ifPresent(tTableFunctionTable::setPartition_column_ids);
         return tTableFunctionTable;

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/TableFunctionTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/TableFunctionTable.java
@@ -219,7 +219,7 @@ public class TableFunctionTable extends Table {
                     "Use any of (uncompressed, snappy, lz4, zstd, gzip)", compressionType));
         }
 
-        if (writeSingleFile && !properties.containsKey(PROPERTY_PARTITION_BY)) {
+        if (writeSingleFile && properties.containsKey(PROPERTY_PARTITION_BY)) {
             throw new SemanticException("cannot use partition_by and single simultaneously.");
         }
 

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/TableFunctionTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/TableFunctionTable.java
@@ -68,12 +68,16 @@ import java.util.stream.Collectors;
 import static com.google.common.base.Preconditions.checkNotNull;
 
 public class TableFunctionTable extends Table {
+    public static final String PARQUET = "parquet";
+    public static final String ORC = "orc";
+    public static final String CSV = "csv";
+
     public static final Set<String> SUPPORTED_FORMATS;
     static {
         SUPPORTED_FORMATS = Sets.newTreeSet(String.CASE_INSENSITIVE_ORDER);
-        SUPPORTED_FORMATS.add("parquet");
-        SUPPORTED_FORMATS.add("orc");
-        SUPPORTED_FORMATS.add("csv");
+        SUPPORTED_FORMATS.add(PARQUET);
+        SUPPORTED_FORMATS.add(ORC);
+        SUPPORTED_FORMATS.add(CSV);
     }
 
     private static final int DEFAULT_AUTO_DETECT_SAMPLE_FILES = 1;
@@ -286,6 +290,10 @@ public class TableFunctionTable extends Table {
         Preconditions.checkState(CompressionUtils.getConnectorSinkCompressionType(compressionType).isPresent());
         tTableFunctionTable.setCompression_type(CompressionUtils.getConnectorSinkCompressionType(compressionType).get());
         tTableFunctionTable.setTarget_max_file_size(targetMaxFileSize);
+        if (CSV.equalsIgnoreCase(format)) {
+            tTableFunctionTable.setCsv_column_seperator(csvColumnSeparator);
+            tTableFunctionTable.setCsv_row_delimter(csvRowDelimiter);
+        }
         partitionColumnIDs.ifPresent(tTableFunctionTable::setPartition_column_ids);
         return tTableFunctionTable;
     }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/InsertStmt.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/InsertStmt.java
@@ -24,19 +24,13 @@ import com.starrocks.catalog.BlackHoleTable;
 import com.starrocks.catalog.Column;
 import com.starrocks.catalog.Table;
 import com.starrocks.catalog.TableFunctionTable;
-import com.starrocks.catalog.Type;
-import com.starrocks.common.util.CompressionUtils;
 import com.starrocks.qe.SessionVariable;
 import com.starrocks.sql.analyzer.Field;
-import com.starrocks.sql.analyzer.SemanticException;
 import com.starrocks.sql.parser.NodePosition;
 
 import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collections;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 import java.util.stream.Collectors;
 
 import static com.google.common.base.Preconditions.checkState;
@@ -312,104 +306,6 @@ public class InsertStmt extends DmlStmt {
     public Table makeTableFunctionTable(SessionVariable sessionVariable) {
         checkState(tableFunctionAsTargetTable, "tableFunctionAsTargetTable is false");
         List<Column> columns = collectSelectedFieldsFromQueryStatement();
-        List<String> columnNames = columns.stream()
-                .map(Column::getName)
-                .collect(Collectors.toList());
-        Set<String> duplicateColumnNames = columns.stream()
-                .map(Column::getName)
-                .filter(name -> Collections.frequency(columnNames, name) > 1)
-                .collect(Collectors.toSet());
-        if (!duplicateColumnNames.isEmpty()) {
-            throw new SemanticException("expect column names to be distinct, but got duplicate(s): " + duplicateColumnNames);
-        }
-
-        // parse table function properties
-        Map<String, String> props = getTableFunctionProperties();
-        String single = props.getOrDefault("single", "false");
-        if (!single.equalsIgnoreCase("true") && !single.equalsIgnoreCase("false")) {
-            throw new SemanticException("got invalid parameter \"single\" = \"%s\", expect a boolean value (true or false).",
-                    single);
-        }
-
-        boolean writeSingleFile = single.equalsIgnoreCase("true");
-        String path = props.get("path");
-        String format = props.get("format");
-        String partitionBy = props.get("partition_by");
-        String compressionType = props.get("compression");
-
-        // validate properties
-        if (path == null) {
-            throw new SemanticException(
-                    "path is a mandatory property. \"path\" = \"s3://path/to/your/location/\"");
-        }
-
-        if (format == null) {
-            throw new SemanticException("format is a mandatory property. " +
-                    "Use any of (parquet, orc, csv)");
-        }
-
-        if (!TableFunctionTable.SUPPORTED_FORMATS.contains(format)) {
-            throw new SemanticException(String.format("Unsupported format %s. " +
-                    "Use any of (parquet, orc, csv)", format));
-        }
-
-        // if max_file_size is not specified, use target max file size
-        long targetMaxFileSize = sessionVariable.getConnectorSinkTargetMaxFileSize();
-        if (props.get("target_max_file_size") != null) {
-            targetMaxFileSize = Long.parseLong(props.get("target_max_file_size"));
-        }
-
-        // if compression codec is not specified, use compression codec from session
-        if (compressionType == null) {
-            compressionType = sessionVariable.getConnectorSinkCompressionCodec();
-        }
-        if (CompressionUtils.getConnectorSinkCompressionType(compressionType).isEmpty()) {
-            throw new SemanticException(String.format("Unsupported compression codec %s. " +
-                    "Use any of (uncompressed, snappy, lz4, zstd, gzip)", compressionType));
-        }
-
-        if (writeSingleFile && partitionBy != null) {
-            throw new SemanticException("cannot use partition_by and single simultaneously.");
-        }
-
-        if (writeSingleFile) {
-            return new TableFunctionTable(path, format, compressionType, columns, null, true, targetMaxFileSize, props);
-        }
-
-        if (partitionBy == null) {
-            return new TableFunctionTable(
-                    path, format, compressionType, columns, null, false, targetMaxFileSize, props);
-        }
-
-        if (!path.endsWith("/")) {
-            path += "/";
-        }
-
-        // parse and validate partition columns
-        List<String> partitionColumnNames = Arrays.asList(partitionBy.split(","));
-        partitionColumnNames.replaceAll(String::trim);
-        partitionColumnNames = partitionColumnNames.stream().distinct().collect(Collectors.toList());
-
-        List<String> unmatchedPartitionColumnNames = partitionColumnNames.stream().filter(col ->
-                !columnNames.contains(col)).collect(Collectors.toList());
-        if (!unmatchedPartitionColumnNames.isEmpty()) {
-            throw new SemanticException("partition columns expected to be a subset of " + columnNames +
-                    ", but got extra columns: " + unmatchedPartitionColumnNames);
-        }
-
-        List<Integer> partitionColumnIDs = partitionColumnNames.stream().map(columnNames::indexOf).collect(
-                Collectors.toList());
-
-        for (Integer partitionColumnID : partitionColumnIDs) {
-            Column partitionColumn = columns.get(partitionColumnID);
-            Type type = partitionColumn.getType();
-            if (type.isBoolean() || type.isIntegerType() || type.isDateType() || type.isStringType()) {
-                continue;
-            }
-            throw new SemanticException("partition column does not support type of " + type);
-        }
-
-        return new TableFunctionTable(
-                path, format, compressionType, columns, partitionColumnIDs, false, targetMaxFileSize, props);
+        return new TableFunctionTable(columns, getTableFunctionProperties(), sessionVariable);
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/planner/TableFunctionTableSinkTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/planner/TableFunctionTableSinkTest.java
@@ -19,10 +19,15 @@ import com.google.common.collect.ImmutableMap;
 import com.starrocks.catalog.Column;
 import com.starrocks.catalog.TableFunctionTable;
 import com.starrocks.catalog.Type;
+import com.starrocks.qe.SessionVariable;
 import com.starrocks.thrift.TDataSink;
 import com.starrocks.thrift.TDataSinkType;
 import com.starrocks.thrift.TExplainLevel;
 import org.junit.Test;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -31,8 +36,12 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 public class TableFunctionTableSinkTest {
     @Test
     public void testTableFunctionTableSink() {
-        TableFunctionTable tableFunctionTable = new TableFunctionTable("s3://path/to/directory/", "parquet",
-                "uncompressed", ImmutableList.of(new Column("k1", Type.INT)), null, false, 100, ImmutableMap.of());
+        List<Column> columns = ImmutableList.of(new Column("k1", Type.INT));
+        Map<String, String> properties = new HashMap<>();
+        properties.put("path", "s3://path/to/directory/");
+        properties.put("format", "parquet");
+        properties.put("compression", "uncompressed");
+        TableFunctionTable tableFunctionTable = new TableFunctionTable(columns, properties, new SessionVariable());
 
         TableFunctionTableSink tableFunctionTableSink = new TableFunctionTableSink(tableFunctionTable);
 

--- a/fe/fe-core/src/test/java/com/starrocks/planner/TableFunctionTableSinkTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/planner/TableFunctionTableSinkTest.java
@@ -39,8 +39,10 @@ public class TableFunctionTableSinkTest {
         List<Column> columns = ImmutableList.of(new Column("k1", Type.INT));
         Map<String, String> properties = new HashMap<>();
         properties.put("path", "s3://path/to/directory/");
-        properties.put("format", "parquet");
+        properties.put("format", "csv");
         properties.put("compression", "uncompressed");
+        properties.put("csv.column_separator", ",");
+        properties.put("csv.row_delimiter", "\n");
         TableFunctionTable tableFunctionTable = new TableFunctionTable(columns, properties, new SessionVariable());
 
         TableFunctionTableSink tableFunctionTableSink = new TableFunctionTableSink(tableFunctionTable);
@@ -51,7 +53,7 @@ public class TableFunctionTableSinkTest {
 
         assertEquals("TABLE FUNCTION TABLE SINK\n" +
                 "  PATH: s3://path/to/directory/\n" +
-                "  FORMAT: parquet\n" +
+                "  FORMAT: csv\n" +
                 "  PARTITION BY: []\n" +
                 "  SINGLE: false\n" +
                 "  RANDOM\n", tableFunctionTableSink.getExplainString("", TExplainLevel.NORMAL));

--- a/gensrc/thrift/Descriptors.thrift
+++ b/gensrc/thrift/Descriptors.thrift
@@ -455,6 +455,10 @@ struct TTableFunctionTable {
     6: optional bool write_single_file
 
     7: optional i64 target_max_file_size
+
+    8: optional string csv_row_delimter
+
+    9: optional string csv_column_seperator
 }
 
 struct TIcebergSchema {

--- a/gensrc/thrift/Descriptors.thrift
+++ b/gensrc/thrift/Descriptors.thrift
@@ -456,7 +456,7 @@ struct TTableFunctionTable {
 
     7: optional i64 target_max_file_size
 
-    8: optional string csv_row_delimter
+    8: optional string csv_row_delimiter
 
     9: optional string csv_column_seperator
 }

--- a/test/sql/test_sink/R/test_csv_file_sink
+++ b/test/sql/test_sink/R/test_csv_file_sink
@@ -1,0 +1,50 @@
+-- name: testCsvFilesSink1
+insert into files ( 
+	"path" = "oss://${oss_bucket}/test_sink/testCsvFilesSink1/${uuid0}/", 
+	"format" = "csv", 
+	"compression" = "uncompressed",
+	"csv.column_separator" = ",",
+	"csv.row_delimiter" = "\n"
+)
+select 1 as k1, "A" as k2 union select 2 as k1, "B" as k2;
+-- result:
+[]
+-- !result
+select * from files (
+	"path" = "oss://${oss_bucket}/test_sink/testCsvFilesSink1/${uuid0}/*",
+	"format" = "csv",
+	"csv.column_separator" = ",",
+	"csv.row_delimiter" = "\n"
+);
+-- result:
+1	A
+2	B
+-- !result
+shell: ossutil64 rm -rf oss://${oss_bucket}/test_sink/testCsvFilesSink1/${uuid0} >/dev/null || echo "exit 0" >/dev/null
+-- result:
+0
+
+-- !result
+-- name: testCsvFilesSink2
+insert into files ( 
+	"path" = "oss://${oss_bucket}/test_sink/testCsvFilesSink2/${uuid0}/", 
+	"format" = "csv", 
+	"compression" = "uncompressed"
+)
+select 1 as k1, "A" as k2 union select 2 as k1, "B" as k2;
+-- result:
+[]
+-- !result
+select * from files (
+	"path" = "oss://${oss_bucket}/test_sink/testCsvFilesSink2/${uuid0}/*",
+	"format" = "csv"
+);
+-- result:
+1	A
+2	B
+-- !result
+shell: ossutil64 rm -rf oss://${oss_bucket}/test_sink/testCsvFilesSink2/${uuid0} >/dev/null || echo "exit 0" >/dev/null
+-- result:
+0
+
+-- !result

--- a/test/sql/test_sink/T/test_csv_file_sink
+++ b/test/sql/test_sink/T/test_csv_file_sink
@@ -1,0 +1,35 @@
+-- name: testCsvFilesSink1
+
+insert into files ( 
+	"path" = "oss://${oss_bucket}/test_sink/testCsvFilesSink1/${uuid0}/", 
+	"format" = "csv", 
+	"compression" = "uncompressed",
+	"csv.column_separator" = ",",
+	"csv.row_delimiter" = "\n"
+)
+select 1 as k1, "A" as k2 union select 2 as k1, "B" as k2;
+
+select * from files (
+	"path" = "oss://${oss_bucket}/test_sink/testCsvFilesSink1/${uuid0}/*",
+	"format" = "csv",
+	"csv.column_separator" = ",",
+	"csv.row_delimiter" = "\n"
+);
+
+shell: ossutil64 rm -rf oss://${oss_bucket}/test_sink/testCsvFilesSink1/${uuid0} >/dev/null || echo "exit 0" >/dev/null
+
+-- name: testCsvFilesSink2
+
+insert into files ( 
+	"path" = "oss://${oss_bucket}/test_sink/testCsvFilesSink2/${uuid0}/", 
+	"format" = "csv", 
+	"compression" = "uncompressed"
+)
+select 1 as k1, "A" as k2 union select 2 as k1, "B" as k2;
+
+select * from files (
+	"path" = "oss://${oss_bucket}/test_sink/testCsvFilesSink2/${uuid0}/*",
+	"format" = "csv"
+);
+
+shell: ossutil64 rm -rf oss://${oss_bucket}/test_sink/testCsvFilesSink2/${uuid0} >/dev/null || echo "exit 0" >/dev/null


### PR DESCRIPTION
## Why I'm doing:

Give users more flexibility when writing csv files.

## What I'm doing:

```sql
INSERT INTO 
FILES(
    "path" = "s3://my_bucket/path/to/dir/",
    "format" = "csv",
    "compression" = "uncompressed",
    "csv.column_seperator" = "\t", -- optional
    "csv.line_delimiter" = "\n" -- optional
) 
SELECT * FROM SOURCE;
```

If not specified in parameter list, the default value of `column_seperator` is `\t` (in line with broker load), and that of `line_delimiter` is `\n`.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [x] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
