### PR TITLE
[BugFix] Fix BE ASAN crash when Expr::prepare failed

### DIFF
--- a/be/src/exprs/function_call_expr.cpp
+++ b/be/src/exprs/function_call_expr.cpp
@@ -34,6 +34,10 @@
 
 namespace starrocks {
 
+DEFINE_FAIL_POINT(expr_prepare_failed);
+DEFINE_FAIL_POINT(expr_prepare_fragment_local_call_failed);
+DEFINE_FAIL_POINT(expr_prepare_fragment_thread_local_call_failed);
+
 VectorizedFunctionCallExpr::VectorizedFunctionCallExpr(const TExprNode& node) : Expr(node) {}
 
 Status VectorizedFunctionCallExpr::prepare(starrocks::RuntimeState* state, starrocks::ExprContext* context) {
@@ -66,6 +70,9 @@ Status VectorizedFunctionCallExpr::prepare(starrocks::RuntimeState* state, starr
                                                          _fn.name.function_name, _fn_desc->args_nums,
                                                          _children.size()));
     }
+
+    FAIL_POINT_TRIGGER_RETURN_ERROR(random_error);
+    FAIL_POINT_TRIGGER_RETURN_ERROR(expr_prepare_failed);
 
     FunctionContext::TypeDesc return_type = AnyValUtil::column_type_to_type_desc(_type);
     std::vector<FunctionContext::TypeDesc> args_types;
@@ -103,10 +110,11 @@ Status VectorizedFunctionCallExpr::open(starrocks::RuntimeState* state, starrock
 
     if (_fn_desc->prepare_function != nullptr) {
         FAIL_POINT_TRIGGER_RETURN_ERROR(random_error);
+        FAIL_POINT_TRIGGER_RETURN_ERROR(expr_prepare_fragment_local_call_failed);
         if (scope == FunctionContext::FRAGMENT_LOCAL) {
             RETURN_IF_ERROR(_fn_desc->prepare_function(fn_ctx, FunctionContext::FRAGMENT_LOCAL));
         }
-
+        FAIL_POINT_TRIGGER_RETURN_ERROR(expr_prepare_fragment_thread_local_call_failed);
         RETURN_IF_ERROR(_fn_desc->prepare_function(fn_ctx, FunctionContext::THREAD_LOCAL));
     }
 
@@ -126,7 +134,8 @@ Status VectorizedFunctionCallExpr::open(starrocks::RuntimeState* state, starrock
 
 void VectorizedFunctionCallExpr::close(starrocks::RuntimeState* state, starrocks::ExprContext* context,
                                        FunctionContext::FunctionStateScope scope) {
-    if (_fn_desc != nullptr && _fn_desc->close_function != nullptr) {
+    // _fn_context_index > 0 means this function call has call opened
+    if (_fn_desc != nullptr && _fn_desc->close_function != nullptr && _fn_context_index > 0) {
         FunctionContext* fn_ctx = context->fn_context(_fn_context_index);
         (void)_fn_desc->close_function(fn_ctx, FunctionContext::THREAD_LOCAL);
 

--- a/test/sql/test_exception/R/test_exception_function_call
+++ b/test/sql/test_exception/R/test_exception_function_call
@@ -1,0 +1,37 @@
+-- name: test_exception_function_call @sequential
+create table t0 (
+    c0 INT,
+    c1 BIGINT
+) DUPLICATE KEY(c0) DISTRIBUTED BY HASH(c0) BUCKETS 1 PROPERTIES('replication_num' = '1');
+-- result:
+-- !result
+insert into t0 SELECT generate_series, 4096 - generate_series FROM TABLE(generate_series(1,  4096));
+-- result:
+-- !result
+admin enable failpoint 'expr_prepare_failed';
+-- result:
+-- !result
+[UC]select max(regexp_replace(c1, '1', '2')) from t0;
+-- result:
+-- !result
+admin disable failpoint 'expr_prepare_failed';
+-- result:
+-- !result
+admin enable failpoint 'expr_prepare_fragment_local_call_failed';
+-- result:
+-- !result
+[UC]select max(regexp_replace(c1, '1', '2')) from t0;
+-- result:
+-- !result
+admin disable failpoint 'expr_prepare_fragment_local_call_failed';
+-- result:
+-- !result
+admin enable failpoint 'expr_prepare_fragment_thread_local_call_failed';
+-- result:
+-- !result
+[UC]select max(regexp_replace(c1, '1', '2')) from t0;
+-- result:
+-- !result
+admin disable failpoint 'expr_prepare_fragment_thread_local_call_failed';
+-- result:
+-- !result

--- a/test/sql/test_exception/T/test_exception_function_call
+++ b/test/sql/test_exception/T/test_exception_function_call
@@ -1,0 +1,19 @@
+-- name: test_exception_function_call @sequential
+
+create table t0 (
+    c0 INT,
+    c1 BIGINT
+) DUPLICATE KEY(c0) DISTRIBUTED BY HASH(c0) BUCKETS 1 PROPERTIES('replication_num' = '1');
+insert into t0 SELECT generate_series, 4096 - generate_series FROM TABLE(generate_series(1,  4096));
+
+admin enable failpoint 'expr_prepare_failed';
+[UC]select max(regexp_replace(c1, '1', '2')) from t0;
+admin disable failpoint 'expr_prepare_failed';
+
+admin enable failpoint 'expr_prepare_fragment_local_call_failed';
+[UC]select max(regexp_replace(c1, '1', '2')) from t0;
+admin disable failpoint 'expr_prepare_fragment_local_call_failed';
+
+admin enable failpoint 'expr_prepare_fragment_thread_local_call_failed';
+[UC]select max(regexp_replace(c1, '1', '2')) from t0;
+admin disable failpoint 'expr_prepare_fragment_thread_local_call_failed';


### PR DESCRIPTION


## Why I'm doing:
when FunctionCallExpr::_fn_desc is not null but children not match with function signature. it will cause BE crash when call FunctionCallExpr::close

```
*** SIGABRT (@0x3e80000a06e) received by PID 41070 (TID 0x7ff026a39700) from PID 41070; stack trace: ***
    @         0x185e35c2 google::(anonymous namespace)::FailureSignalHandler()
    @     0x7ff134131630 (unknown)
    @     0x7ff133462387 __GI_raise
    @     0x7ff133463a78 __GI_abort
    @          0xb6b6bda starrocks::failure_function()
    @         0x185d6f9d google::LogMessage::Fail()
    @         0x185d940f google::LogMessage::SendToLog()
    @         0x185d6aee google::LogMessage::Flush()
    @         0x185d9a19 google::LogMessageFatal::~LogMessageFatal()
    @         0x13c18f09 starrocks::ExprContext::fn_context()
    @         0x13c139c3 starrocks::VectorizedFunctionCallExpr::close()
    @         0x11ef43d1 starrocks::Expr::close()
    @         0x13c13b73 starrocks::VectorizedFunctionCallExpr::close()
    @         0x11edfd51 starrocks::ExprContext::close()
    @         0x11ef4185 starrocks::Expr::close()
    @          0xe53bb1b starrocks::pipeline::OlapScanPrepareOperatorFactory::close()
    @          0xea92da6 starrocks::pipeline::Pipeline::close()
    @          0xea8d24b starrocks::pipeline::NormalExecutionGroup::close()
    @          0xe859f62 starrocks::pipeline::FragmentContext::close_all_execution_groups()
    @          0xe859a1c starrocks::pipeline::FragmentContext::~FragmentContext()
```
## What I'm doing:
check _fn_ctx_index gt 0 in FunctionCallExpr::close

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [x] 3.2
  - [x] 3.1
  - [x] 3.0
  - [x] 2.5
