### PR TITLE
[BugFix] Fix subList error when cutting paths in FileScanNode

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/planner/FileScanNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/FileScanNode.java
@@ -510,9 +510,12 @@ public class FileScanNode extends LoadScanNode {
             int limit = 3;
             List<String> allFilePaths =
                     fileGroups.stream().map(BrokerFileGroup::getFilePaths).flatMap(List::stream).collect(Collectors.toList());
-            List<String> filePaths = Lists.newArrayList(allFilePaths.subList(0, limit));
+            List<String> filePaths = Lists.newArrayList();
             if (allFilePaths.size() > limit) {
+                filePaths.addAll(allFilePaths.subList(0, limit));
                 filePaths.add("...");
+            } else {
+                filePaths.addAll(allFilePaths);
             }
             ErrorReport.reportAnalysisException(ErrorCode.ERR_NO_FILES_FOUND, String.join(", ", filePaths));
         }

--- a/fe/fe-core/src/test/java/com/starrocks/planner/FileScanNodeTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/planner/FileScanNodeTest.java
@@ -482,4 +482,27 @@ public class FileScanNodeTest {
                         "'hdfs://127.0.0.1:9001/file1, hdfs://127.0.0.1:9001/file2, hdfs://127.0.0.1:9001/file3, ...'",
                 () -> Deencapsulation.invoke(scanNode, "getFileStatusAndCalcInstance"));
     }
+
+    @Test
+    public void testNoFilesFoundOnePath() {
+        Analyzer analyzer = new Analyzer(GlobalStateMgr.getCurrentState(), new ConnectContext());
+        DescriptorTable descTable = analyzer.getDescTbl();
+        TupleDescriptor tupleDesc = descTable.createTupleDescriptor("DestTableTuple");
+        List<List<TBrokerFileStatus>> fileStatusesList = Lists.newArrayList();
+        fileStatusesList.add(Lists.newArrayList());
+        FileScanNode scanNode = new FileScanNode(new PlanNodeId(0), tupleDesc, "FileScanNode",
+                fileStatusesList, 0, WarehouseManager.DEFAULT_WAREHOUSE_ID);
+
+        List<String> files = Lists.newArrayList("hdfs://127.0.0.1:9001/file*");
+        DataDescription desc =
+                new DataDescription("testTable", null, files, null, null, null, "csv", false, null);
+        BrokerFileGroup brokerFileGroup = new BrokerFileGroup(desc);
+        Deencapsulation.setField(brokerFileGroup, "filePaths", files);
+        List<BrokerFileGroup> fileGroups = Lists.newArrayList(brokerFileGroup);
+        scanNode.setLoadInfo(jobId, txnId, null, brokerDesc, fileGroups, true, loadParallelInstanceNum);
+
+        ExceptionChecker.expectThrowsWithMsg(UserException.class,
+                "No files were found matching the pattern(s) or path(s): 'hdfs://127.0.0.1:9001/file*'",
+                () -> Deencapsulation.invoke(scanNode, "getFileStatusAndCalcInstance"));
+    }
 }


### PR DESCRIPTION
## Why I'm doing:
If there is only one path and it is not exist, ArrayList.subList(0, 3) will report `toIndex = 3` error.
```
LOAD LABEL label00 (DATA INFILE("hdfs://127.0.0.1:10000/wyb/tmp2/0") INTO TABLE t1) WITH BROKER;

mysql> show load order by CreateTime desc limit 1\G                                                                                                                                                                                                                                                                                                              
*************************** 1. row ***************************
         JobId: 230473
         Label: label00
         State: CANCELLED
      Progress: ETL:N/A; LOAD:N/A
          Type: BROKER
      Priority: NORMAL
      ScanRows: 0
  FilteredRows: 0
UnselectedRows: 0
      SinkRows: 0
       EtlInfo: NULL
      TaskInfo: resource:N/A; timeout(s):14400; max_filter_ratio:0.0
      ErrorMsg: type:ETL_RUN_FAIL; msg:toIndex = 3
    CreateTime: 2024-04-10 15:23:52
  EtlStartTime: NULL
 EtlFinishTime: NULL
 LoadStartTime: NULL
LoadFinishTime: 2024-04-10 15:23:59
   TrackingSQL:
    JobDetails: {"All backends":{},"FileNumber":0,"FileSize":0,"InternalTableLoadBytes":0,"InternalTableLoadRows":0,"ScanBytes":0,"ScanRows":0,"TaskNumber":0,"Unfinished backends":{}}
1 row in set (0.01 sec)
```

## What I'm doing:
```
mysql> show load order by CreateTime desc limit 1\G
*************************** 1. row ***************************
         JobId: 231165
         Label: label00
         State: CANCELLED
      Progress: ETL:N/A; LOAD:N/A
          Type: BROKER
      Priority: NORMAL
      ScanRows: 0
  FilteredRows: 0
UnselectedRows: 0
      SinkRows: 0
       EtlInfo: NULL
      TaskInfo: resource:N/A; timeout(s):14400; max_filter_ratio:0.0
      ErrorMsg: type:ETL_RUN_FAIL; msg:No files were found matching the pattern(s) or path(s): 'hdfs://127.0.0.1:10000/wyb/tmp2/0'
    CreateTime: 2024-04-10 15:33:57
  EtlStartTime: NULL
 EtlFinishTime: NULL
 LoadStartTime: NULL
LoadFinishTime: 2024-04-10 15:34:02
   TrackingSQL:
    JobDetails: {"All backends":{},"FileNumber":0,"FileSize":0,"InternalTableLoadBytes":0,"InternalTableLoadRows":0,"ScanBytes":0,"ScanRows":0,"TaskNumber":0,"Unfinished backends":{}}
1 row in set (0.00 sec)
```

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [x] 3.2
  - [x] 3.1
  - [ ] 3.0
  - [ ] 2.5
