### PR TITLE
[BugFix] Add TaskRunScheduler to support task runs' FIFO scheduler

### DIFF
--- a/docs/en/administration/management/FE_configuration.md
+++ b/docs/en/administration/management/FE_configuration.md
@@ -2216,7 +2216,7 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 <!--
 ##### task_check_interval_second
 
-- Default: 4 * 3600
+- Default: 3600
 - Type: Int
 - Unit: Seconds
 - Is mutable: No

--- a/docs/en/sql-reference/sql-statements/data-manipulation/SUBMIT_TASK.md
+++ b/docs/en/sql-reference/sql-statements/data-manipulation/SUBMIT_TASK.md
@@ -70,7 +70,7 @@ You can configure asynchronous ETL tasks using the following FE configuration it
 | **Parameter**                | **Default value** | **Description**                                              |
 | ---------------------------- | ----------------- | ------------------------------------------------------------ |
 | task_ttl_second              | 86400             | The period during which a Task is valid. Unit: seconds. Tasks that exceed the validity period are deleted. |
-| task_check_interval_second   | 14400             | The time interval to delete invalid Tasks. Unit: seconds.    |
+| task_check_interval_second   | 3600              | The time interval to delete invalid Tasks. Unit: seconds.    |
 | task_runs_ttl_second         | 86400             | The period during which a TaskRun is valid. Unit: seconds. TaskRuns that exceed the validity period are deleted automatically. Additionally, TaskRuns in the `FAILED` and `SUCCESS` states are also deleted automatically. |
 | task_runs_concurrency        | 4                 | The maximum number of TaskRuns that can be run in parallel.  |
 | task_runs_queue_length       | 500               | The maximum number of TaskRuns that are pending for running. If the number exceeds the default value, the incoming tasks will be suspended. |

--- a/docs/zh/administration/management/FE_configuration.md
+++ b/docs/zh/administration/management/FE_configuration.md
@@ -2217,7 +2217,7 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 <!--
 ##### task_check_interval_second
 
-- 默认值：4 * 3600
+- 默认值：3600
 - 类型：Int
 - 单位：Seconds
 - 是否动态：否

--- a/docs/zh/sql-reference/sql-statements/data-manipulation/SUBMIT_TASK.md
+++ b/docs/zh/sql-reference/sql-statements/data-manipulation/SUBMIT_TASK.md
@@ -70,7 +70,7 @@ SELECT * FROM information_schema.task_runs WHERE task_name = '<task_name>';
 | **参数**                     | **默认值** | **说明**                                                     |
 | ---------------------------- | ---------- | ------------------------------------------------------------ |
 | task_ttl_second              | 86400      | Task 的有效期，单位秒。超过有效期的 Task 会被自动删除。        |
-| task_check_interval_second   | 14400      | 删除过期 Task 的间隔时间，单位秒。                           |
+| task_check_interval_second   | 3600       | 删除过期 Task 的间隔时间，单位秒。                           |
 | task_runs_ttl_second         | 86400      | TaskRun 的有效期，单位秒。超过有效期的 TaskRun 会被自动删除。此外，成功和失败状态的 TaskRun 也会被自动删除。 |
 | task_runs_concurrency        | 4          | 最多可同时运行的 TaskRun 的数量。                            |
 | task_runs_queue_length       | 500        | 最多可同时等待运行的 TaskRun 的数量。如同时等待运行的 TaskRun 的数量超过该参数的默认值，您将无法继续执行 Task。 |

--- a/fe/fe-core/src/main/java/com/starrocks/common/Config.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/Config.java
@@ -343,7 +343,7 @@ public class Config extends ConfigBase {
      * It will run every *task_check_interval_second* to do background job.
      */
     @ConfField
-    public static int task_check_interval_second = 4 * 3600; // 4 hours
+    public static int task_check_interval_second = 1 * 3600; // 1 hour
 
     /**
      * for task set expire time

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/TaskManager.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/TaskManager.java
@@ -600,8 +600,6 @@ public class TaskManager implements MemoryTrackable {
             taskRunManager.getTaskRunHistory().forceGC();
             data.runStatus = showTaskRunStatus(null);
             String s = GsonUtils.GSON.toJson(data);
-            LOG.warn("Too much task metadata triggers forced task_run GC, " +
-                    "size before GC:{}, size after GC:{}.", beforeSize, data.runStatus.size());
             Text.writeString(dos, s);
         } else {
             String s = GsonUtils.GSON.toJson(data);
@@ -613,6 +611,7 @@ public class TaskManager implements MemoryTrackable {
     public void saveTasksV2(DataOutputStream dos) throws IOException, SRMetaBlockException {
         taskRunManager.getTaskRunHistory().forceGC();
         List<TaskRunStatus> runStatusList = showTaskRunStatus(null);
+        LOG.info("saveTasksV2, nameToTaskMap size:{}, runStatusList size: {}", nameToTaskMap.size(), runStatusList.size());
         SRMetaBlockWriter writer = new SRMetaBlockWriter(dos, SRMetaBlockID.TASK_MGR,
                 2 + nameToTaskMap.size() + runStatusList.size());
         writer.writeJson(nameToTaskMap.size());
@@ -925,6 +924,9 @@ public class TaskManager implements MemoryTrackable {
                     iterator.remove();
                 }
             }
+
+            // trigger to force gc to avoid too many history task runs.
+            taskRunManager.getTaskRunHistory().forceGC();
         } finally {
             taskRunManager.taskRunUnlock();
         }

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/TaskRun.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/TaskRun.java
@@ -325,9 +325,11 @@ public class TaskRun implements Comparable<TaskRun> {
 
     @Override
     public int compareTo(@NotNull TaskRun taskRun) {
+        // if priority is different, return the higher priority
         if (this.getStatus().getPriority() != taskRun.getStatus().getPriority()) {
             return taskRun.getStatus().getPriority() - this.getStatus().getPriority();
         } else {
+            // if priority is the same, return the older task
             return this.getStatus().getCreateTime() > taskRun.getStatus().getCreateTime() ? 1 : -1;
         }
     }

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/TaskRunManager.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/TaskRunManager.java
@@ -16,15 +16,11 @@
 package com.starrocks.scheduler;
 
 import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.Maps;
-import com.google.common.collect.Queues;
-import com.google.gson.JsonObject;
 import com.starrocks.common.Config;
 import com.starrocks.common.util.UUIDUtil;
 import com.starrocks.common.util.Util;
 import com.starrocks.common.util.concurrent.QueryableReentrantLock;
 import com.starrocks.memory.MemoryTrackable;
-import com.starrocks.persist.gson.GsonUtils;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.scheduler.persist.TaskRunStatus;
 import com.starrocks.scheduler.persist.TaskRunStatusChange;
@@ -44,13 +40,7 @@ public class TaskRunManager implements MemoryTrackable {
 
     private static final Logger LOG = LogManager.getLogger(TaskRunManager.class);
 
-    // taskId -> pending TaskRun Queue, for each Task only support 1 running taskRun currently,
-    // so the map value is priority queue need to be sorted by priority from large to small
-    private final Map<Long, PriorityBlockingQueue<TaskRun>> pendingTaskRunMap = Maps.newConcurrentMap();
-
-    // taskId -> running TaskRun, for each Task only support 1 running taskRun currently,
-    // so the map value is not queue
-    private final Map<Long, TaskRun> runningTaskRunMap = Maps.newConcurrentMap();
+    private final TaskRunScheduler taskRunScheduler = new TaskRunScheduler();
 
     // include SUCCESS/FAILED/CANCEL taskRun
     private final TaskRunHistory taskRunHistory = new TaskRunHistory();
@@ -66,14 +56,7 @@ public class TaskRunManager implements MemoryTrackable {
             return new SubmitResult(taskRun.getStatus().getQueryId(), SubmitResult.SubmitStatus.FAILED);
         }
 
-        int validPendingCount = 0;
-        for (Long taskId : pendingTaskRunMap.keySet()) {
-            PriorityBlockingQueue<TaskRun> taskRuns = pendingTaskRunMap.get(taskId);
-            if (taskRuns != null && !taskRuns.isEmpty()) {
-                validPendingCount += taskRuns.size();
-            }
-        }
-
+        long validPendingCount = taskRunScheduler.getPendingQueueCount();
         if (validPendingCount >= Config.task_runs_queue_length) {
             LOG.warn("pending TaskRun exceeds task_runs_queue_length:{}, reject the submit: {}",
                     Config.task_runs_queue_length, taskRun);
@@ -95,7 +78,7 @@ public class TaskRunManager implements MemoryTrackable {
     }
 
     public boolean killTaskRun(Long taskId) {
-        TaskRun taskRun = runningTaskRunMap.get(taskId);
+        TaskRun taskRun = taskRunScheduler.getRunningTaskRun(taskId);
         if (taskRun == null) {
             return false;
         }
@@ -118,12 +101,11 @@ public class TaskRunManager implements MemoryTrackable {
         }
         try {
             long taskId = taskRun.getTaskId();
-            PriorityBlockingQueue<TaskRun> taskRuns = pendingTaskRunMap.computeIfAbsent(taskId,
-                    u -> Queues.newPriorityBlockingQueue());
+            Queue<TaskRun> taskRuns = taskRunScheduler.getPendingTaskRuns(taskId);
             // If the task run is sync-mode, it will hang forever if the task run is merged because
             // user's using `future.get()` to wait and the future will not be set forever.
             ExecuteOption executeOption = taskRun.getExecuteOption();
-            if (executeOption.isMergeRedundant()) {
+            if (taskRuns != null && executeOption.isMergeRedundant()) {
                 Iterator<TaskRun> iter = taskRuns.iterator();
                 while (iter.hasNext()) {
                     TaskRun oldTaskRun = iter.next();
@@ -165,7 +147,7 @@ public class TaskRunManager implements MemoryTrackable {
                     GlobalStateMgr.getCurrentState().getEditLog().logUpdateTaskRun(statusChange);
                 }
             }
-            if (!taskRuns.offer(taskRun)) {
+            if (!taskRunScheduler.addPendingTaskRun(taskRun)) {
                 LOG.warn("failed to offer task: {}", taskRun);
                 return false;
             }
@@ -191,6 +173,7 @@ public class TaskRunManager implements MemoryTrackable {
 
     // check if a running TaskRun is complete and remove it from running TaskRun map
     public void checkRunningTaskRun() {
+        Map<Long, TaskRun> runningTaskRunMap = taskRunScheduler.getRunningTaskRunMap();
         Iterator<Long> runningIterator = runningTaskRunMap.keySet().iterator();
         while (runningIterator.hasNext()) {
             Long taskId = runningIterator.next();
@@ -214,38 +197,18 @@ public class TaskRunManager implements MemoryTrackable {
 
     // schedule the pending TaskRun that can be run into running TaskRun map
     public void scheduledPendingTaskRun() {
-        int currentRunning = runningTaskRunMap.size();
-
-        Iterator<Long> pendingIterator = pendingTaskRunMap.keySet().iterator();
-        while (pendingIterator.hasNext()) {
-            Long taskId = pendingIterator.next();
-            TaskRun runningTaskRun = runningTaskRunMap.get(taskId);
-            if (runningTaskRun == null) {
-                Queue<TaskRun> taskRunQueue = pendingTaskRunMap.get(taskId);
-                if (taskRunQueue == null) {
-                    continue;
-                }
-                if (taskRunQueue.size() == 0) {
-                    pendingIterator.remove();
-                } else {
-                    if (currentRunning >= Config.task_runs_concurrency) {
-                        break;
-                    }
-                    TaskRun pendingTaskRun = taskRunQueue.poll();
-                    if (taskRunExecutor.executeTaskRun(pendingTaskRun)) {
-                        LOG.info("start to schedule pending task run to execute: {}", pendingTaskRun);
-                        runningTaskRunMap.put(taskId, pendingTaskRun);
-                        // RUNNING state persistence is for FE FOLLOWER update state
-                        TaskRunStatusChange statusChange = new TaskRunStatusChange(taskId, pendingTaskRun.getStatus(),
-                                Constants.TaskRunState.PENDING, Constants.TaskRunState.RUNNING);
-                        GlobalStateMgr.getCurrentState().getEditLog().logUpdateTaskRun(statusChange);
-                        currentRunning++;
-                    } else {
-                        LOG.warn("failed to scheduled task-run {}", pendingTaskRun);
-                    }
-                }
+        taskRunScheduler.scheduledPendingTaskRun(pendingTaskRun -> {
+            if (taskRunExecutor.executeTaskRun(pendingTaskRun)) {
+                LOG.info("start to schedule pending task run to execute: {}", pendingTaskRun);
+                long taskId = pendingTaskRun.getTaskId();
+                // RUNNING state persistence is for FE FOLLOWER update state
+                TaskRunStatusChange statusChange = new TaskRunStatusChange(taskId, pendingTaskRun.getStatus(),
+                        Constants.TaskRunState.PENDING, Constants.TaskRunState.RUNNING);
+                GlobalStateMgr.getCurrentState().getEditLog().logUpdateTaskRun(statusChange);
+            } else {
+                LOG.warn("failed to scheduled task-run {}", pendingTaskRun);
             }
-        }
+        });
     }
 
     public boolean tryTaskRunLock() {
@@ -272,46 +235,30 @@ public class TaskRunManager implements MemoryTrackable {
     }
 
     public TaskRun getRunnableTaskRun(long taskId) {
-        TaskRun res = runningTaskRunMap.get(taskId);
-        if (res != null) {
-            return res;
-        }
-        PriorityBlockingQueue<TaskRun> queue = pendingTaskRunMap.get(taskId);
-        if (queue != null) {
-            for (TaskRun run : queue) {
-                if (run.getTaskId() == taskId) {
-                    return run;
-                }
-            }
-        }
-        return null;
+        return taskRunScheduler.getRunnableTaskRun(taskId);
     }
 
-    public Map<Long, PriorityBlockingQueue<TaskRun>> getPendingTaskRunMap() {
-        return pendingTaskRunMap;
+    public Map<Long, Queue<TaskRun>> getPendingTaskRunMap() {
+        return taskRunScheduler.getPendingTaskRunMap();
     }
 
     public Map<Long, TaskRun> getRunningTaskRunMap() {
-        return runningTaskRunMap;
+        return taskRunScheduler.getRunningTaskRunMap();
     }
 
     public TaskRunHistory getTaskRunHistory() {
         return taskRunHistory;
     }
 
-    public long getPendingTaskRunCount() {
-        return pendingTaskRunMap.size();
-    }
-
     public boolean containsTaskInRunningTaskRunMap(long taskId) {
-        return this.runningTaskRunMap.containsKey(taskId);
+        return taskRunScheduler.getRunningTaskRunMap().containsKey(taskId);
     }
 
     public long getPendingTaskRunCount(long taskId) {
         taskRunLock.lock();
         try {
-            return pendingTaskRunMap.containsKey(taskId) ? 0L :
-                    pendingTaskRunMap.get(taskId).size();
+            Queue<TaskRun> pendingTaskRuns = taskRunScheduler.getPendingTaskRuns(taskId);
+            return  pendingTaskRuns == null ? 0L : pendingTaskRuns.size();
         } catch (Exception e) {
             return 0L;
         } finally {
@@ -319,26 +266,11 @@ public class TaskRunManager implements MemoryTrackable {
         }
     }
 
-    public long getRunningTaskRunCount() {
-        return runningTaskRunMap.size();
-    }
-
-    public long getHistoryTaskRunCount() {
-        return taskRunHistory.getTaskRunCount();
-    }
-
     @Override
     public Map<String, Long> estimateCount() {
-        long validPendingCount = 0;
-        for (Long taskId : pendingTaskRunMap.keySet()) {
-            PriorityBlockingQueue<TaskRun> taskRuns = pendingTaskRunMap.get(taskId);
-            if (taskRuns != null && !taskRuns.isEmpty()) {
-                validPendingCount += taskRuns.size();
-            }
-        }
-
+        long validPendingCount = taskRunScheduler.getPendingQueueCount();
         return ImmutableMap.of("PendingTaskRun", validPendingCount,
-                "RunningTaskRun", (long) runningTaskRunMap.size(),
+                "RunningTaskRun", (long) taskRunScheduler.getRunningTaskRunMap().size(),
                 "HistoryTaskRun", taskRunHistory.getTaskRunCount());
     }
   
@@ -348,9 +280,6 @@ public class TaskRunManager implements MemoryTrackable {
      * @return JSON-representation of the whole status
      */
     public String inspect() {
-        JsonObject res = new JsonObject();
-        res.addProperty("running", GsonUtils.GSON.toJson(runningTaskRunMap));
-        res.addProperty("pending", GsonUtils.GSON.toJson(pendingTaskRunMap));
-        return res.toString();
+        return taskRunScheduler.toString();
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/TaskRunScheduler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/TaskRunScheduler.java
@@ -84,7 +84,11 @@ public class TaskRunScheduler {
         if (!pendingTaskRunQueue.offer(taskRun)) {
             return false;
         }
-        return pendingTaskRunMap.computeIfAbsent(taskRun.getTaskId(), ignored -> new PriorityBlockingQueue<>()).add(taskRun);
+        if (!pendingTaskRunMap.computeIfAbsent(taskRun.getTaskId(), ignored -> new PriorityBlockingQueue<>()).add(taskRun)) {
+            pendingTaskRunQueue.remove(taskRun);
+            return false;
+        }
+        return true;
     }
 
     /**

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/TaskRunScheduler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/TaskRunScheduler.java
@@ -1,0 +1,163 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.scheduler;
+
+import com.google.common.collect.Maps;
+import com.google.gson.JsonObject;
+import com.starrocks.common.Config;
+import com.starrocks.persist.gson.GsonUtils;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Queue;
+import java.util.concurrent.PriorityBlockingQueue;
+import java.util.function.Consumer;
+
+public class TaskRunScheduler {
+
+    // taskId -> pending TaskRun Queue, for each Task only support 1 running taskRun currently,
+    // so the map value is priority queue need to be sorted by priority from large to small
+    private final Map<Long, Queue<TaskRun>> pendingTaskRunMap = Maps.newConcurrentMap();
+    // pending TaskRun Queue, compared by priority and created time
+    private final PriorityBlockingQueue<TaskRun> pendingTaskRunQueue = new PriorityBlockingQueue<>();
+
+    // taskId -> running TaskRun, for each Task only support 1 running taskRun currently,
+    // so the map value is not queue
+    private final Map<Long, TaskRun> runningTaskRunMap = Maps.newConcurrentMap();
+
+    /**
+     * Get the count of pending task run
+     */
+    public long getPendingQueueCount() {
+        return pendingTaskRunQueue.size();
+    }
+
+    /**
+     * Get the count of running task run
+     * @param taskId: task id
+     */
+    public TaskRun getRunningTaskRun(long taskId) {
+        return runningTaskRunMap.get(taskId);
+    }
+
+    /**
+     * @param taskId: task id
+     * @return: pending task run queue
+     */
+    public Queue<TaskRun> getPendingTaskRuns(long taskId) {
+        return pendingTaskRunMap.get(taskId);
+    }
+
+    /**
+     * Add a task run to pending queue
+     * @param taskRun: task run
+     * @return: true if add success, false if add failed
+     */
+    public boolean addPendingTaskRun(TaskRun taskRun) {
+        if (taskRun == null) {
+            return false;
+        }
+        if (!pendingTaskRunQueue.offer(taskRun)) {
+            return false;
+        }
+        return pendingTaskRunMap.computeIfAbsent(taskRun.getTaskId(), ignored -> new PriorityBlockingQueue<>()).add(taskRun);
+    }
+
+    /**
+     * Return the current running task run map.
+     */
+    public Map<Long, TaskRun> getRunningTaskRunMap() {
+        return runningTaskRunMap;
+    }
+
+    /**
+     * Return the current pendign task run map.
+     */
+    public Map<Long, Queue<TaskRun>> getPendingTaskRunMap() {
+        return pendingTaskRunMap;
+    }
+
+    /**
+     * schedule the pending TaskRun that can be run into running TaskRun map
+     * @param action: the action to run the task run before task runs queue is full
+     */
+    public void scheduledPendingTaskRun(Consumer<TaskRun> action) {
+        int currentRunning = runningTaskRunMap.size();
+
+        List<TaskRun> runningTaskRuns = new ArrayList<>();
+        while (pendingTaskRunQueue.isEmpty()) {
+            TaskRun taskRun = pendingTaskRunQueue.poll();
+            if (taskRun == null) {
+                continue;
+            }
+
+            Long taskId = taskRun.getTaskId();
+            if (runningTaskRunMap.containsKey(taskId)) {
+                // add into pending queue after polling, no needs to change pendingTaskRunMap since it's not really removed
+                runningTaskRuns.add(taskRun);
+                continue;
+            }
+
+            Queue<TaskRun> taskRunQueue = pendingTaskRunMap.get(taskId);
+            if (taskRunQueue == null || taskRunQueue.isEmpty()) {
+                pendingTaskRunMap.remove(taskId);
+                continue;
+            }
+
+            if (currentRunning >= Config.task_runs_concurrency) {
+                break;
+            }
+            TaskRun pendingTaskRun = taskRunQueue.poll();
+            action.accept(pendingTaskRun);
+
+            runningTaskRunMap.put(taskId, pendingTaskRun);
+            currentRunning++;
+        }
+
+        for (TaskRun taskRun: runningTaskRuns) {
+            pendingTaskRunQueue.offer(taskRun);
+        }
+    }
+
+    /**
+     * Get the runnable task run by task id
+     * @param taskId: task id
+     * @return: the runnable task run, null if not found
+     */
+    public TaskRun getRunnableTaskRun(long taskId) {
+        TaskRun res = runningTaskRunMap.get(taskId);
+        if (res != null) {
+            return res;
+        }
+        Queue<TaskRun> queue = pendingTaskRunMap.get(taskId);
+        if (queue != null) {
+            for (TaskRun run : queue) {
+                if (run.getTaskId() == taskId) {
+                    return run;
+                }
+            }
+        }
+        return null;
+    }
+
+    @Override
+    public String toString() {
+        JsonObject res = new JsonObject();
+        res.addProperty("running", GsonUtils.GSON.toJson(runningTaskRunMap));
+        res.addProperty("pending", GsonUtils.GSON.toJson(pendingTaskRunMap));
+        return res.toString();
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/TaskRunScheduler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/TaskRunScheduler.java
@@ -26,6 +26,10 @@ import java.util.Queue;
 import java.util.concurrent.PriorityBlockingQueue;
 import java.util.function.Consumer;
 
+/**
+ * Schedule pending task runs to running task runs, it uses priority queue to schedule task runs.
+ * The task run with higher priority or older created time will be scheduled first.
+ */
 public class TaskRunScheduler {
 
     // taskId -> pending TaskRun Queue, for each Task only support 1 running taskRun currently,
@@ -167,12 +171,8 @@ public class TaskRunScheduler {
             return res;
         }
         Queue<TaskRun> queue = pendingTaskRunMap.get(taskId);
-        if (queue != null) {
-            for (TaskRun run : queue) {
-                if (run.getTaskId() == taskId) {
-                    return run;
-                }
-            }
+        if (queue != null && !queue.isEmpty()) {
+            return queue.peek();
         }
         return null;
     }
@@ -181,7 +181,8 @@ public class TaskRunScheduler {
     public String toString() {
         JsonObject res = new JsonObject();
         res.addProperty("running", GsonUtils.GSON.toJson(runningTaskRunMap));
-        res.addProperty("pending", GsonUtils.GSON.toJson(pendingTaskRunMap));
+        res.addProperty("pending_map", GsonUtils.GSON.toJson(pendingTaskRunMap));
+        res.addProperty("pending_queue", GsonUtils.GSON.toJson(pendingTaskRunQueue));
         return res.toString();
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/scheduler/TaskManagerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/scheduler/TaskManagerTest.java
@@ -46,7 +46,7 @@ import java.time.ZoneId;
 import java.util.Date;
 import java.util.List;
 import java.util.Map;
-import java.util.concurrent.PriorityBlockingQueue;
+import java.util.Queue;
 
 public class TaskManagerTest {
 
@@ -170,7 +170,7 @@ public class TaskManagerTest {
 
     @Test
     public void testTaskRunPriority() {
-        PriorityBlockingQueue<TaskRun> queue = Queues.newPriorityBlockingQueue();
+        Queue<TaskRun> queue = Queues.newPriorityBlockingQueue();
         long now = System.currentTimeMillis();
         Task task = new Task("test");
 
@@ -237,9 +237,9 @@ public class TaskManagerTest {
         taskRunManager.arrangeTaskRun(taskRun1);
         taskRunManager.arrangeTaskRun(taskRun2);
 
-        Map<Long, PriorityBlockingQueue<TaskRun>> pendingTaskRunMap = taskRunManager.getPendingTaskRunMap();
+        Map<Long, Queue<TaskRun>> pendingTaskRunMap = taskRunManager.getPendingTaskRunMap();
         Assert.assertEquals(1, pendingTaskRunMap.get(taskId).size());
-        PriorityBlockingQueue<TaskRun> taskRuns = pendingTaskRunMap.get(taskId);
+        Queue<TaskRun> taskRuns = pendingTaskRunMap.get(taskId);
         TaskRun taskRun = taskRuns.poll();
         Assert.assertEquals(10, taskRun.getStatus().getPriority());
 
@@ -274,9 +274,9 @@ public class TaskManagerTest {
         taskRunManager.arrangeTaskRun(taskRun2);
         taskRunManager.arrangeTaskRun(taskRun1);
 
-        Map<Long, PriorityBlockingQueue<TaskRun>> pendingTaskRunMap = taskRunManager.getPendingTaskRunMap();
+        Map<Long, Queue<TaskRun>> pendingTaskRunMap = taskRunManager.getPendingTaskRunMap();
         Assert.assertEquals(1, pendingTaskRunMap.get(taskId).size());
-        PriorityBlockingQueue<TaskRun> taskRuns = pendingTaskRunMap.get(taskId);
+        Queue<TaskRun> taskRuns = pendingTaskRunMap.get(taskId);
         TaskRun taskRun = taskRuns.poll();
         Assert.assertEquals(10, taskRun.getStatus().getPriority());
 
@@ -311,9 +311,9 @@ public class TaskManagerTest {
         taskRunManager.arrangeTaskRun(taskRun1);
         taskRunManager.arrangeTaskRun(taskRun2);
 
-        Map<Long, PriorityBlockingQueue<TaskRun>> pendingTaskRunMap = taskRunManager.getPendingTaskRunMap();
+        Map<Long, Queue<TaskRun>> pendingTaskRunMap = taskRunManager.getPendingTaskRunMap();
         Assert.assertEquals(1, pendingTaskRunMap.get(taskId).size());
-        PriorityBlockingQueue<TaskRun> taskRuns = pendingTaskRunMap.get(taskId);
+        Queue<TaskRun> taskRuns = pendingTaskRunMap.get(taskId);
         TaskRun taskRun = taskRuns.poll();
         Assert.assertEquals(now + 10, taskRun.getStatus().getCreateTime());
 
@@ -348,9 +348,9 @@ public class TaskManagerTest {
         taskRunManager.arrangeTaskRun(taskRun2);
         taskRunManager.arrangeTaskRun(taskRun1);
 
-        Map<Long, PriorityBlockingQueue<TaskRun>> pendingTaskRunMap = taskRunManager.getPendingTaskRunMap();
+        Map<Long, Queue<TaskRun>> pendingTaskRunMap = taskRunManager.getPendingTaskRunMap();
         Assert.assertEquals(1, pendingTaskRunMap.get(taskId).size());
-        PriorityBlockingQueue<TaskRun> taskRuns = pendingTaskRunMap.get(taskId);
+        Queue<TaskRun> taskRuns = pendingTaskRunMap.get(taskId);
         TaskRun taskRun = taskRuns.poll();
         Assert.assertEquals(now + 10, taskRun.getStatus().getCreateTime());
 
@@ -394,7 +394,7 @@ public class TaskManagerTest {
         taskRunManager.arrangeTaskRun(taskRun1);
         taskRunManager.arrangeTaskRun(taskRun3);
 
-        Map<Long, PriorityBlockingQueue<TaskRun>> pendingTaskRunMap = taskRunManager.getPendingTaskRunMap();
+        Map<Long, Queue<TaskRun>> pendingTaskRunMap = taskRunManager.getPendingTaskRunMap();
         Assert.assertEquals(3, pendingTaskRunMap.get(taskId).size());
     }
 
@@ -513,7 +513,7 @@ public class TaskManagerTest {
         result = taskRunManager.submitTaskRun(taskRun2, taskRun2.getExecuteOption());
         Assert.assertTrue(result.getStatus() == SubmitResult.SubmitStatus.SUBMITTED);
 
-        Map<Long, PriorityBlockingQueue<TaskRun>> pendingTaskRunMap = taskRunManager.getPendingTaskRunMap();
+        Map<Long, Queue<TaskRun>> pendingTaskRunMap = taskRunManager.getPendingTaskRunMap();
         Assert.assertEquals(2, pendingTaskRunMap.get(taskId).size());
 
         // If it's a sync refresh, no merge redundant anyway

--- a/fe/fe-core/src/test/java/com/starrocks/scheduler/TaskManagerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/scheduler/TaskManagerTest.java
@@ -315,8 +315,7 @@ public class TaskManagerTest {
         Assert.assertEquals(1, pendingTaskRunMap.get(taskId).size());
         Queue<TaskRun> taskRuns = pendingTaskRunMap.get(taskId);
         TaskRun taskRun = taskRuns.poll();
-        Assert.assertEquals(now + 10, taskRun.getStatus().getCreateTime());
-
+        Assert.assertEquals(now, taskRun.getStatus().getCreateTime());
     }
 
     @Test
@@ -352,8 +351,7 @@ public class TaskManagerTest {
         Assert.assertEquals(1, pendingTaskRunMap.get(taskId).size());
         Queue<TaskRun> taskRuns = pendingTaskRunMap.get(taskId);
         TaskRun taskRun = taskRuns.poll();
-        Assert.assertEquals(now + 10, taskRun.getStatus().getCreateTime());
-
+        Assert.assertEquals(now, taskRun.getStatus().getCreateTime());
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/scheduler/TaskRunSchedulerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/scheduler/TaskRunSchedulerTest.java
@@ -126,7 +126,7 @@ public class TaskRunSchedulerTest {
             TaskRun taskRun = queue.poll();
             Assert.assertTrue(taskRun.equals(taskRuns.get(i)));
         }
-   }
+    }
 
     @Test
     public void testScheduledPendingTaskRun() {
@@ -155,7 +155,36 @@ public class TaskRunSchedulerTest {
     }
 
     @Test
-    public void testSchedulederString() {
+    public void testScheduledPendingTaskRunWithSameTaskId() {
+        Task task = new Task("test");
+        task.setDefinition("select 1");
+        List<TaskRun> taskRuns = Lists.newArrayList();
+        TaskRunScheduler scheduler = new TaskRunScheduler();
+        for (int i = 0; i < 10; i++) {
+            TaskRun taskRun = makeTaskRun(1, task, makeExecuteOption(true, false, 1), i);
+            taskRuns.add(taskRun);
+            scheduler.addPendingTaskRun(taskRun);
+        }
+
+        Set<TaskRun> runningTaskRuns = Sets.newHashSet(taskRuns.subList(0, 1));
+        scheduler.scheduledPendingTaskRun(taskRun -> {
+            Assert.assertTrue(runningTaskRuns.contains(taskRun));
+        });
+        // running queue only support one task with same task id
+        Assert.assertTrue(scheduler.getRunningTaskRunMap().size() == 1);
+        Assert.assertTrue(scheduler.getPendingQueueCount() == 9);
+
+        System.out.println(scheduler);
+        for (int i = 0; i < 1; i++) {
+            Assert.assertTrue(scheduler.getRunnableTaskRun(1).equals(taskRuns.get(i)));
+        }
+        for (int i = 1; i < 10; i++) {
+            Assert.assertTrue(scheduler.getRunnableTaskRun(1).equals(taskRuns.get(i)));
+        }
+    }
+
+    @Test
+    public void testScheduledToString() {
         Task task = new Task("test");
         task.setDefinition("select 1");
         List<TaskRun> taskRuns = Lists.newArrayList();
@@ -169,7 +198,9 @@ public class TaskRunSchedulerTest {
         scheduler.scheduledPendingTaskRun(taskRun -> {
             Assert.assertTrue(runningTaskRuns.contains(taskRun));
         });
+        System.out.println(scheduler);
         Assert.assertTrue(scheduler.toString().equals("{\"running\":\"{\\\"0\\\":{},\\\"1\\\":{},\\\"2\\\":{},\\\"3\\\":{}}\"," +
-                "\"pending\":\"{\\\"4\\\":[{}],\\\"5\\\":[{}],\\\"6\\\":[{}],\\\"7\\\":[{}],\\\"8\\\":[{}],\\\"9\\\":[{}]}\"}"));
+                "\"pending_map\":\"{\\\"4\\\":[{}],\\\"5\\\":[{}],\\\"6\\\":[{}],\\\"7\\\":[{}],\\\"8\\\":[{}]," +
+                "\\\"9\\\":[{}]}\",\"pending_queue\":\"[{},{},{},{},{},{}]\"}"));
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/scheduler/TaskRunSchedulerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/scheduler/TaskRunSchedulerTest.java
@@ -1,0 +1,175 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+
+package com.starrocks.scheduler;
+
+import com.google.common.collect.Lists;
+import com.starrocks.common.Config;
+import com.starrocks.common.FeConstants;
+import com.starrocks.qe.ConnectContext;
+import com.starrocks.server.GlobalStateMgr;
+import com.starrocks.utframe.UtFrameUtils;
+import mockit.Expectations;
+import org.assertj.core.util.Sets;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import java.util.List;
+import java.util.Queue;
+import java.util.Set;
+
+public class TaskRunSchedulerTest {
+
+    private static final int N = 100;
+    private static ConnectContext connectContext;
+
+    @Before
+    public void setUp() {
+        GlobalStateMgr globalStateMgr = connectContext.getGlobalStateMgr();
+        new Expectations() {
+            {
+                GlobalStateMgr.getCurrentState();
+                minTimes = 0;
+                result = globalStateMgr;
+
+                globalStateMgr.getNextId();
+                minTimes = 0;
+                returns(100L, 101L, 102L, 103L, 104L, 105L);
+
+            }
+        };
+    }
+
+    @BeforeClass
+    public static void beforeClass() throws Exception {
+        FeConstants.runningUnitTest = true;
+        UtFrameUtils.createMinStarRocksCluster();
+
+        connectContext = UtFrameUtils.createDefaultCtx();
+    }
+
+    private static ExecuteOption makeExecuteOption(boolean isMergeRedundant, boolean isSync, int priority) {
+        ExecuteOption executeOption = new ExecuteOption();
+        executeOption.setMergeRedundant(isMergeRedundant);
+        executeOption.setSync(isSync);
+        executeOption.setPriority(priority);
+        return executeOption;
+    }
+
+    private TaskRun makeTaskRun(long taskId, Task task, ExecuteOption executeOption, long createTime) {
+        TaskRun taskRun = TaskRunBuilder
+                .newBuilder(task)
+                .setExecuteOption(executeOption)
+                .build();
+        taskRun.setTaskId(taskId);
+        taskRun.initStatus("1", createTime);
+        return taskRun;
+    }
+
+    @Test
+    public void testTaskRunSchedulerWithDifferentPriority() {
+        Task task = new Task("test");
+        task.setDefinition("select 1");
+        long taskId = 1;
+        List<TaskRun> taskRuns = Lists.newArrayList();
+
+        TaskRunScheduler scheduler = new TaskRunScheduler();
+        for (int i = 0; i < N; i++) {
+            TaskRun taskRun = makeTaskRun(taskId, task, makeExecuteOption(true, false, i), 1);
+            taskRuns.add(taskRun);
+            scheduler.addPendingTaskRun(taskRun);
+        }
+        Assert.assertTrue(scheduler.getPendingTaskRuns().size() == N);
+
+        Queue<TaskRun> queue = scheduler.getPendingTaskRuns();
+        Assert.assertEquals(N, queue.size());
+
+        for (int i = 0; i < N; i++) {
+            TaskRun taskRun = queue.poll();
+            Assert.assertTrue(taskRun.equals(taskRuns.get(N - 1 - i)));
+        }
+    }
+
+    @Test
+    public void testTaskRunSchedulerWithDifferentCreateTime() {
+        Task task = new Task("test");
+        task.setDefinition("select 1");
+        long taskId = 1;
+        List<TaskRun> taskRuns = Lists.newArrayList();
+
+        TaskRunScheduler scheduler = new TaskRunScheduler();
+        for (int i = 0; i < N; i++) {
+            TaskRun taskRun = makeTaskRun(taskId, task, makeExecuteOption(true, false, 1), i);
+            taskRuns.add(taskRun);
+            scheduler.addPendingTaskRun(taskRun);
+        }
+        Assert.assertTrue(scheduler.getPendingTaskRuns().size() == N);
+
+        Queue<TaskRun> queue = scheduler.getPendingTaskRuns();
+        Assert.assertEquals(N, queue.size());
+
+        for (int i = 0; i < N; i++) {
+            TaskRun taskRun = queue.poll();
+            Assert.assertTrue(taskRun.equals(taskRuns.get(i)));
+        }
+   }
+
+    @Test
+    public void testScheduledPendingTaskRun() {
+        Task task = new Task("test");
+        task.setDefinition("select 1");
+        List<TaskRun> taskRuns = Lists.newArrayList();
+        TaskRunScheduler scheduler = new TaskRunScheduler();
+        for (int i = 0; i < N; i++) {
+            TaskRun taskRun = makeTaskRun(i, task, makeExecuteOption(true, false, 1), i);
+            taskRuns.add(taskRun);
+            scheduler.addPendingTaskRun(taskRun);
+        }
+
+        Set<TaskRun> runningTaskRuns = Sets.newHashSet(taskRuns.subList(0, Config.task_runs_concurrency));
+        scheduler.scheduledPendingTaskRun(taskRun -> {
+            Assert.assertTrue(runningTaskRuns.contains(taskRun));
+        });
+        Assert.assertTrue(scheduler.getRunningTaskRunMap().size() == Config.task_runs_concurrency);
+        Assert.assertTrue(scheduler.getPendingQueueCount() == N - Config.task_runs_concurrency);
+        for (int i = 0; i < Config.task_runs_concurrency; i++) {
+            Assert.assertTrue(scheduler.getRunnableTaskRun(i).equals(taskRuns.get(i)));
+        }
+        for (int i = Config.task_runs_concurrency; i < N; i++) {
+            Assert.assertTrue(scheduler.getRunnableTaskRun(i).equals(taskRuns.get(i)));
+        }
+    }
+
+    @Test
+    public void testSchedulederString() {
+        Task task = new Task("test");
+        task.setDefinition("select 1");
+        List<TaskRun> taskRuns = Lists.newArrayList();
+        TaskRunScheduler scheduler = new TaskRunScheduler();
+        for (int i = 0; i < 10; i++) {
+            TaskRun taskRun = makeTaskRun(i, task, makeExecuteOption(true, false, 1), i);
+            taskRuns.add(taskRun);
+            scheduler.addPendingTaskRun(taskRun);
+        }
+        Set<TaskRun> runningTaskRuns = Sets.newHashSet(taskRuns.subList(0, Config.task_runs_concurrency));
+        scheduler.scheduledPendingTaskRun(taskRun -> {
+            Assert.assertTrue(runningTaskRuns.contains(taskRun));
+        });
+        Assert.assertTrue(scheduler.toString().equals("{\"running\":\"{\\\"0\\\":{},\\\"1\\\":{},\\\"2\\\":{},\\\"3\\\":{}}\"," +
+                "\"pending\":\"{\\\"4\\\":[{}],\\\"5\\\":[{}],\\\"6\\\":[{}],\\\"7\\\":[{}],\\\"8\\\":[{}],\\\"9\\\":[{}]}\"}"));
+    }
+}


### PR DESCRIPTION
## Why I'm doing:
- TaskRun status cannot be cleaned if there are too many task runs before its expired time.
- Pending task runs are not fifo schedulered.

## What I'm doing:
- Add `forceGC` method into `doTaskBackgroundJob` backgroud job and set the default schedulered time from 4 hour to 1 hour.
- Add TaskRunScheduler to support task runs' FIFO scheduler 

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [x] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [x] 3.2
  - [x] 3.1
  - [ ] 3.0
  - [ ] 2.5