### PR TITLE
[Enhancement][FlatJson] Improve flat json performance

### DIFF
--- a/be/src/column/json_column.cpp
+++ b/be/src/column/json_column.cpp
@@ -221,19 +221,27 @@ size_t JsonColumn::size() const {
 }
 
 size_t JsonColumn::capacity() const {
-    size_t s = SuperClass::capacity();
-    for (const auto& col : _flat_columns) {
-        s += col->capacity();
+    if (is_flat_json()) {
+        size_t s = 0;
+        for (const auto& col : _flat_columns) {
+            s += col->capacity();
+        }
+        return s;
+    } else {
+        return SuperClass::capacity();
     }
-    return s;
 }
 
 size_t JsonColumn::byte_size(size_t from, size_t size) const {
-    size_t s = SuperClass::byte_size(from, size);
-    for (const auto& col : _flat_columns) {
-        s += col->byte_size(from, size);
+    if (is_flat_json()) {
+        size_t s = 0;
+        for (const auto& col : _flat_columns) {
+            s += col->byte_size(from, size);
+        }
+        return s;
+    } else {
+        return SuperClass::byte_size(from, size);
     }
-    return s;
 }
 
 void JsonColumn::append_value_multiple_times(const void* value, size_t count) {
@@ -263,16 +271,22 @@ void JsonColumn::append_default(size_t count) {
 }
 
 void JsonColumn::resize(size_t n) {
-    BaseClass::resize(n);
-    for (auto& col : _flat_columns) {
-        col->resize(n);
+    if (is_flat_json()) {
+        for (auto& col : _flat_columns) {
+            col->resize(n);
+        }
+    } else {
+        BaseClass::resize(n);
     }
 }
 
 void JsonColumn::assign(size_t n, size_t idx) {
-    BaseClass::assign(n, idx);
-    for (auto& col : _flat_columns) {
-        col->assign(n, idx);
+    if (is_flat_json()) {
+        for (auto& col : _flat_columns) {
+            col->assign(n, idx);
+        }
+    } else {
+        BaseClass::assign(n, idx);
     }
 }
 

--- a/be/src/column/json_column.h
+++ b/be/src/column/json_column.h
@@ -68,6 +68,8 @@ public:
 
     void resize(size_t n) override;
 
+    void reserve(size_t n) override{};
+
     void assign(size_t n, size_t idx) override;
 
     void append(const JsonValue* object);

--- a/be/src/exec/pipeline/scan/olap_chunk_source.cpp
+++ b/be/src/exec/pipeline/scan/olap_chunk_source.cpp
@@ -634,7 +634,7 @@ void OlapChunkSource::_update_counter() {
         std::string access_path_hits = "AccessPathHits";
         int64_t total = 0;
         for (auto& [k, v] : _reader->stats().flat_json_hits) {
-            auto* path_counter = _runtime_profile->get_counter(k);
+            auto* path_counter = _runtime_profile->get_counter(fmt::format("[Hit]{}", k));
             if (path_counter == nullptr) {
                 path_counter = ADD_CHILD_COUNTER(_runtime_profile, k, TUnit::UNIT, access_path_hits);
             }
@@ -647,7 +647,7 @@ void OlapChunkSource::_update_counter() {
         std::string access_path_unhits = "AccessPathUnhits";
         int64_t total = 0;
         for (auto& [k, v] : _reader->stats().dynamic_json_hits) {
-            auto* path_counter = _runtime_profile->get_counter(k);
+            auto* path_counter = _runtime_profile->get_counter(fmt::format("[Unhit]{}", k));
             if (path_counter == nullptr) {
                 path_counter = ADD_CHILD_COUNTER(_runtime_profile, k, TUnit::UNIT, access_path_unhits);
             }

--- a/be/src/util/json_flattener.cpp
+++ b/be/src/util/json_flattener.cpp
@@ -17,6 +17,7 @@
 
 #include "util/json_flattener.h"
 
+#include <algorithm>
 #include <cstdint>
 #include <string>
 #include <string_view>
@@ -36,41 +37,6 @@
 #include "util/json_converter.h"
 
 namespace starrocks {
-
-void append_to_bool(const vpack::Slice* json, NullableColumn* result) {
-    try {
-        if (json->isNone() || json->isNull()) {
-            result->append_nulls(1);
-        } else if (json->isBool()) {
-            result->null_column()->append(0);
-            auto res = json->getBool();
-            down_cast<RunTimeColumnType<TYPE_BOOLEAN>*>(result->data_column().get())->append(res);
-        } else if (json->isString()) {
-            vpack::ValueLength len;
-            const char* str = json->getStringUnchecked(len);
-            StringParser::ParseResult parseResult;
-            auto r = StringParser::string_to_int<int32_t>(str, len, &parseResult);
-            if (parseResult != StringParser::PARSE_SUCCESS || std::isnan(r) || std::isinf(r)) {
-                bool b = StringParser::string_to_bool(str, len, &parseResult);
-                if (parseResult != StringParser::PARSE_SUCCESS) {
-                    result->append_nulls(1);
-                } else {
-                    down_cast<RunTimeColumnType<TYPE_BOOLEAN>*>(result->data_column().get())->append(b);
-                }
-            } else {
-                down_cast<RunTimeColumnType<TYPE_BOOLEAN>*>(result->data_column().get())->append(r != 0);
-            }
-        } else if (json->isNumber()) {
-            result->null_column()->append(0);
-            auto res = json->getNumber<double>();
-            down_cast<RunTimeColumnType<TYPE_BOOLEAN>*>(result->data_column().get())->append(res != 0);
-        } else {
-            result->append_nulls(1);
-        }
-    } catch (const vpack::Exception& e) {
-        result->append_nulls(1);
-    }
-}
 
 template <LogicalType TYPE>
 void append_to_number(const vpack::Slice* json, NullableColumn* result) {
@@ -127,7 +93,8 @@ void append_to_json(const vpack::Slice* json, NullableColumn* result) {
 }
 
 using JsonFlatAppendFunc = void (*)(const vpack::Slice* json, NullableColumn* result);
-static const uint8_t JSON_BASE_TYPE_BITS = 0; // least flat to JSON type
+static const uint8_t JSON_BASE_TYPE_BITS = 0;     // least flat to JSON type
+static const uint8_t JSON_BIGINT_TYPE_BITS = 225; // 011000 10, bigint compatible type
 
 // clang-format off
 // bool will flatting as string, because it's need save string-literal(true/false)
@@ -135,15 +102,16 @@ static const uint8_t JSON_BASE_TYPE_BITS = 0; // least flat to JSON type
 static const std::unordered_map<vpack::ValueType, uint8_t> JSON_TYPE_BITS{
         {vpack::ValueType::None, 255},      // 111111 11, 255
         {vpack::ValueType::SmallInt, 241},  // 111100 01, 241
-        {vpack::ValueType::UInt, 224},      // 111000 00, 224
         {vpack::ValueType::Int, 225},       // 111000 01, 225
+        {vpack::ValueType::UInt, 224},      // 111000 00, 224
         {vpack::ValueType::Double, 192},    // 110000 00, 192
         {vpack::ValueType::String, 8},      // 000010 00, 8
 };
 
+// starrocks json fucntio only support read as bigint/string/bool/double, smallint will cast to bigint, so we save as bigint directly
 static const std::unordered_map<uint8_t, LogicalType> JSON_BITS_TO_LOGICAL_TYPE {
-    {JSON_TYPE_BITS.at(vpack::ValueType::None),        LogicalType::TYPE_BOOLEAN},
-    {JSON_TYPE_BITS.at(vpack::ValueType::SmallInt),    LogicalType::TYPE_SMALLINT},
+    {JSON_TYPE_BITS.at(vpack::ValueType::None),        LogicalType::TYPE_TINYINT},
+    {JSON_TYPE_BITS.at(vpack::ValueType::SmallInt),    LogicalType::TYPE_BIGINT},
     {JSON_TYPE_BITS.at(vpack::ValueType::Int),         LogicalType::TYPE_BIGINT},
     {JSON_TYPE_BITS.at(vpack::ValueType::UInt),        LogicalType::TYPE_LARGEINT},
     {JSON_TYPE_BITS.at(vpack::ValueType::Double),      LogicalType::TYPE_DOUBLE},
@@ -152,8 +120,8 @@ static const std::unordered_map<uint8_t, LogicalType> JSON_BITS_TO_LOGICAL_TYPE 
 };
 
 static const std::unordered_map<uint8_t, JsonFlatAppendFunc> JSON_BITS_FUNC {
-    {JSON_TYPE_BITS.at(vpack::ValueType::None),        &append_to_bool},
-    {JSON_TYPE_BITS.at(vpack::ValueType::SmallInt),    &append_to_number<LogicalType::TYPE_SMALLINT>},
+    {JSON_TYPE_BITS.at(vpack::ValueType::None),        &append_to_number<LogicalType::TYPE_TINYINT>},
+    {JSON_TYPE_BITS.at(vpack::ValueType::SmallInt),    &append_to_number<LogicalType::TYPE_BIGINT>},
     {JSON_TYPE_BITS.at(vpack::ValueType::Int),         &append_to_number<LogicalType::TYPE_BIGINT>},
     {JSON_TYPE_BITS.at(vpack::ValueType::UInt),        &append_to_number<LogicalType::TYPE_LARGEINT>},
     {JSON_TYPE_BITS.at(vpack::ValueType::Double),      &append_to_number<LogicalType::TYPE_DOUBLE>},
@@ -208,6 +176,9 @@ struct FlatColumnDesc {
     uint64_t hits = 0;
     // how many rows need to be cast to a compatible type
     uint16_t casts = 0;
+
+    // for json-uint, json-uint is uint64_t, check the maximum value and downgrade to bigint
+    uint64_t max = 0;
 };
 
 void JsonFlattener::derived_paths(std::vector<ColumnPtr>& json_datas) {
@@ -261,11 +232,15 @@ void JsonFlattener::derived_paths(std::vector<ColumnPtr>& json_datas) {
             for (const auto& it : iter) {
                 std::string_view name = it.key.stringView();
                 derived_maps[name].hits++;
-                uint8_t type = derived_maps[name].type;
-                uint8_t compatibility_type =
-                        JsonFlattener::get_compatibility_type(it.value.type(), derived_maps[name].type);
+                uint8_t base_type = derived_maps[name].type;
+                vpack::ValueType json_type = it.value.type();
+                uint8_t compatibility_type = JsonFlattener::get_compatibility_type(json_type, base_type);
                 derived_maps[name].type = compatibility_type;
-                derived_maps[name].casts += (type != compatibility_type);
+                derived_maps[name].casts += (base_type != compatibility_type);
+
+                if (json_type == vpack::ValueType::UInt) {
+                    derived_maps[name].max = std::max(derived_maps[name].max, it.value.getUIntUnchecked());
+                }
             }
         }
     }
@@ -274,6 +249,14 @@ void JsonFlattener::derived_paths(std::vector<ColumnPtr>& json_datas) {
         VLOG(8) << "flat json, internal column too less: " << derived_maps.size()
                 << ", at least: " << config::json_flat_internal_column_min_limit;
         return;
+    }
+
+    // try downgrade json-uint to bigint
+    int128_t max = RunTimeTypeLimits<TYPE_BIGINT>::max_value();
+    for (auto& [name, desc] : derived_maps) {
+        if (desc.type == JSON_TYPE_BITS.at(vpack::ValueType::UInt) && desc.max <= max) {
+            desc.type = JSON_BIGINT_TYPE_BITS;
+        }
     }
 
     // sort by hit, casts

--- a/be/test/exprs/flat_json_functions_test.cpp
+++ b/be/test/exprs/flat_json_functions_test.cpp
@@ -79,7 +79,7 @@ TEST_P(FlatJsonDeriverPaths, flat_json_path_test) {
 // clang-format off
 INSTANTIATE_TEST_SUITE_P(FlatJsonPathDeriver, FlatJsonDeriverPaths,
     ::testing::Values(
-        std::make_tuple(R"({ "k1": 1, "k2": 2 })", R"({ "k1": 3, "k2": 4 })", std::vector<std::string> {"k1", "k2"}, std::vector<LogicalType> {TYPE_SMALLINT, TYPE_SMALLINT}),
+        std::make_tuple(R"({ "k1": 1, "k2": 2 })", R"({ "k1": 3, "k2": 4 })", std::vector<std::string> {"k1", "k2"}, std::vector<LogicalType> {TYPE_BIGINT, TYPE_BIGINT}),
         std::make_tuple(R"({ "k1": "v1" })",  R"({ "k1": "v33" })", std::vector<std::string> {"k1"}, std::vector<LogicalType> {TYPE_VARCHAR}),
         std::make_tuple(R"({ "k1": {"k2": 1} })",  R"({ "k1": 123 })", std::vector<std::string> {"k1"}, std::vector<LogicalType> {TYPE_JSON}),
         std::make_tuple(R"({ "k1": "v1" })",  R"({ "k1": 1.123 })", std::vector<std::string> {"k1"}, std::vector<LogicalType> {TYPE_JSON}),
@@ -89,9 +89,9 @@ INSTANTIATE_TEST_SUITE_P(FlatJsonPathDeriver, FlatJsonDeriverPaths,
         std::make_tuple(R"({ "k1": "v1", "k2": [3,4,5], "k3": 1, "k4": 1.2344 })",  
                         R"({ "k1": "abc", "k2": [11,123,54], "k3": 23423, "k4": 1.2344 })", 
                         std::vector<std::string> {"k3", "k4", "k1", "k2"}, 
-                        std::vector<LogicalType> {TYPE_LARGEINT, TYPE_DOUBLE, TYPE_VARCHAR, TYPE_JSON}),
-        std::make_tuple(R"({ "k1": 1, "k2": "a" })", R"({ "k1": 3, "k2": null })", std::vector<std::string> {"k1", "k2"}, std::vector<LogicalType> {TYPE_SMALLINT, TYPE_JSON}),
-        std::make_tuple(R"({ "k1": 1, "k2": 2 })", R"({ "k1": 3, "k2": 4 })", std::vector<std::string> {"k1", "k2"}, std::vector<LogicalType> {TYPE_SMALLINT, TYPE_SMALLINT})
+                        std::vector<LogicalType> {TYPE_BIGINT, TYPE_DOUBLE, TYPE_VARCHAR, TYPE_JSON}),
+        std::make_tuple(R"({ "k1": 1, "k2": "a" })", R"({ "k1": 3, "k2": null })", std::vector<std::string> {"k1", "k2"}, std::vector<LogicalType> {TYPE_BIGINT, TYPE_JSON}),
+        std::make_tuple(R"({ "k1": 1, "k2": 2 })", R"({ "k1": 3, "k2": 4 })", std::vector<std::string> {"k1", "k2"}, std::vector<LogicalType> {TYPE_BIGINT, TYPE_BIGINT})
 
 ));
 // clang-format on


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:
Follow https://github.com/StarRocks/starrocks/pull/42787

* update json column byte_size/reserver method
* update json type inference logical
  * json-integer will cast to bigint, because sr query function most use bigint
  * support json-uint downgrade to bigint

improve flat json performance:

|   SSB |   STRUCT  |   FlatJson(BEFORE PR)    |   FlatJson(This PR)   |   BEFORE/THIS |   STRUCT/THIS |
|   ----    |   ----    |   ----    |   ----    |   ----    |   ----    |
|   Q01 |   141 |   1533    |   270 |   5.68    |   0.52    |
|   Q02 |   24  |   133 |   34  |   3.91    |   0.71    |
|   Q03 |   113 |   888 |   219 |   4.05    |   0.52    |
|   Q04 |   2733    |   18006   |   3065    |   5.87    |   0.89    |
|   Q05 |   2205    |   17941   |   2496    |   7.19    |   0.88    |
|   Q06 |   1912    |   13369   |   2129    |   6.28    |   0.90    |
|   Q07 |   2642    |   18075   |   3110    |   5.81    |   0.85    |
|   Q08 |   1848    |   15734   |   2772    |   5.68    |   0.67    |
|   Q09 |   1585    |   10601   |   1853    |   5.72    |   0.86    |
|   Q10 |   40  |   154 |   50  |   3.08    |   0.80    |
|   Q11 |   4019    |   26158   |   4668    |   5.60    |   0.86    |
|   Q12 |   1133    |   7041    |   1316    |   5.35    |   0.86    |
|   Q13 |   619 |   4807    |   902 |   5.33    |   0.69    |

|   NO_PREIDCATE    |   STUCT   |   FlatJson(This PR)   |   STRUCT/THIS |
|   ----    |   ----    |   ----    |   ----    |
|   Q01 |   113 |   151 |   0.748   |
|   Q02 |   20  |   19  |   1.053   |
|   Q03 |   64  |   69  |   0.928   |
|   Q04 |   2635    |   2849    |   0.925   |
|   Q05 |   2666    |   2840    |   0.939   |
|   Q06 |   2679    |   2830    |   0.947   |
|   Q07 |   3378    |   3835    |   0.881   |
|   Q08 |   12842   |   15235   |   0.843   |
|   Q09 |   12909   |   15574   |   0.829   |

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
