### PR TITLE
[BugFix] fix expire time when replaying taskrun

### DIFF
--- a/be/src/exec/schema_scanner/schema_tasks_scanner.cpp
+++ b/be/src/exec/schema_scanner/schema_tasks_scanner.cpp
@@ -58,15 +58,16 @@ DatumArray SchemaTasksScanner::_build_row() {
         // Compatible for upgrades
         task.catalog = "default_catalog";
     }
+    Datum expire_time = task.__isset.expire_time && task.expire_time > 0
+                                ? TimestampValue::create_from_unixtime(task.expire_time, _runtime_state->timezone_obj())
+                                : kNullDatum;
+    Datum create_time = task.__isset.create_time && task.create_time > 0
+                                ? TimestampValue::create_from_unixtime(task.create_time, _runtime_state->timezone_obj())
+                                : kNullDatum;
+
     return {
-            Slice(task.task_name),
-            TimestampValue::create_from_unixtime(task.create_time, _runtime_state->timezone_obj()),
-            Slice(task.schedule),
-            Slice(task.catalog),
-            Slice(task.database),
-            Slice(task.definition),
-            TimestampValue::create_from_unixtime(task.expire_time, _runtime_state->timezone_obj()),
-            Slice(task.properties),
+            Slice(task.task_name),  create_time, Slice(task.schedule),   Slice(task.catalog), Slice(task.database),
+            Slice(task.definition), expire_time, Slice(task.properties),
     };
 }
 

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/TaskRun.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/TaskRun.java
@@ -302,20 +302,17 @@ public class TaskRun implements Comparable<TaskRun> {
 
     public TaskRunStatus initStatus(String queryId, Long createTime) {
         TaskRunStatus status = new TaskRunStatus();
+        long created = createTime == null ? System.currentTimeMillis() : createTime;
         status.setQueryId(queryId);
         status.setTaskId(task.getId());
         status.setTaskName(task.getName());
         status.setSource(task.getSource());
-        if (createTime == null) {
-            status.setCreateTime(System.currentTimeMillis());
-        } else {
-            status.setCreateTime(createTime);
-        }
+        status.setCreateTime(created);
         status.setUser(task.getCreateUser());
         status.setCatalogName(task.getCatalogName());
         status.setDbName(task.getDbName());
         status.setPostRun(task.getPostRun());
-        status.setExpireTime(System.currentTimeMillis() + Config.task_runs_ttl_second * 1000L);
+        status.setExpireTime(created + Config.task_runs_ttl_second * 1000L);
         status.getMvTaskRunExtraMessage().setExecuteOption(this.executeOption);
 
         LOG.info("init task status, task:{}, query_id:{}, create_time:{}", task.getName(), queryId, status.getCreateTime());


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:
- `expire_time` should not be changed when replaying
- `expire_time` should be displayed as `null` instead of `-1` in the `tasks` schema view 

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [x] 3.2
  - [x] 3.1
  - [ ] 3.0
  - [ ] 2.5
