### PR TITLE
[Enhancement][FlatJson] read&write process use type inference

### DIFF
--- a/be/src/column/json_column.cpp
+++ b/be/src/column/json_column.cpp
@@ -307,7 +307,7 @@ void JsonColumn::append(const Column& src, size_t offset, size_t count) {
     if (other_json->is_flat_json() && !is_flat_json()) {
         // only hit in AggregateIterator (Aggregate mode in storage)
         DCHECK_EQ(0, this->size());
-        init_flat_columns(other_json->_flat_column_paths);
+        init_flat_columns(other_json->_flat_column_paths, other_json->_flat_column_types);
     }
 
     if (is_flat_json()) {
@@ -317,6 +317,7 @@ void JsonColumn::append(const Column& src, size_t offset, size_t count) {
 
         for (size_t i = 0; i < _flat_columns.size(); i++) {
             DCHECK_EQ(_flat_column_paths[i], other_json->_flat_column_paths[i]);
+            DCHECK_EQ(_flat_column_types[i], other_json->flat_column_types()[i]);
             _flat_columns[i]->append(*other_json->get_flat_field(i), offset, count);
         }
     } else {

--- a/be/src/exprs/json_functions.cpp
+++ b/be/src/exprs/json_functions.cpp
@@ -651,8 +651,12 @@ StatusOr<ColumnPtr> JsonFunctions::_flat_json_exists(FunctionContext* context, c
 
         JsonPath stored_path;
         for (int row = 0; row < rows; row++) {
-            if (json_viewer.is_null(row) || json_viewer.value(row) == nullptr) {
+            if (columns[0]->is_null(row)) {
                 result.append_null();
+                continue;
+            }
+            if (json_viewer.is_null(row) || json_viewer.value(row) == nullptr) {
+                result.append(0);
                 continue;
             }
             JsonValue* json_value = json_viewer.value(row);

--- a/be/src/exprs/json_functions.cpp
+++ b/be/src/exprs/json_functions.cpp
@@ -422,6 +422,8 @@ Status JsonFunctions::native_json_path_prepare(FunctionContext* context, Functio
     }
 
     auto* state = new NativeJsonState();
+    state->init_flat = false;
+    context->set_function_state(scope, state);
     if (context->is_notnull_constant_column(1)) {
         auto path_column = context->get_constant_column(1);
         Slice path_value = ColumnHelper::get_const_value<TYPE_VARCHAR>(path_column);
@@ -430,9 +432,6 @@ Status JsonFunctions::native_json_path_prepare(FunctionContext* context, Functio
         state->json_path.reset(std::move(json_path.value()));
         VLOG(10) << "prepare json path: " << path_value;
     }
-
-    state->init_flat = false;
-    context->set_function_state(scope, state);
     return Status::OK();
 }
 
@@ -466,7 +465,7 @@ static StatusOr<ColumnPtr> _extract_from_flat_json(FunctionContext* context, con
     }
 
     auto* state = get_native_json_state(context);
-    if (state == nullptr) {
+    if (UNLIKELY(state == nullptr)) {
         // ut test may be hit here, the json path is invaild
         return Status::JsonFormatError("flat json required prepare status");
     }
@@ -508,15 +507,8 @@ static StatusOr<ColumnPtr> _extract_from_flat_json(FunctionContext* context, con
 
     JsonPath required_path;
     JsonPath* required_path_ptr = &required_path;
+    ASSIGN_OR_RETURN(required_path_ptr, get_prepared_or_parse(context, path, required_path_ptr));
 
-    auto ret = get_prepared_or_parse(context, path, required_path_ptr);
-
-    if (UNLIKELY(!ret.ok())) {
-        // invaild path, return null
-        return ColumnHelper::create_const_null_column(columns[0]->size());
-    }
-
-    required_path_ptr = ret.value();
     JsonColumn* json_column;
     if (columns[0]->is_nullable()) {
         auto* nullable = down_cast<NullableColumn*>(columns[0].get());

--- a/be/src/storage/rowset/json_column_iterator.cpp
+++ b/be/src/storage/rowset/json_column_iterator.cpp
@@ -20,15 +20,25 @@
 #include <vector>
 
 #include "column/column_access_path.h"
+#include "column/column_helper.h"
 #include "column/const_column.h"
 #include "column/json_column.h"
 #include "column/nullable_column.h"
 #include "column/struct_column.h"
+#include "column/vectorized_fwd.h"
+#include "common/object_pool.h"
 #include "common/status.h"
+#include "common/statusor.h"
+#include "exprs/cast_expr.h"
+#include "exprs/column_ref.h"
+#include "exprs/expr_context.h"
 #include "gutil/casts.h"
+#include "runtime/descriptors.h"
+#include "runtime/types.h"
 #include "storage/rowset/column_iterator.h"
 #include "storage/rowset/column_reader.h"
 #include "storage/rowset/scalar_column_iterator.h"
+#include "types/logical_type.h"
 #include "util/json_flattener.h"
 #include "util/runtime_profile.h"
 
@@ -38,11 +48,14 @@ class JsonFlatColumnIterator final : public ColumnIterator {
 public:
     JsonFlatColumnIterator(ColumnReader* _reader, std::unique_ptr<ColumnIterator>& null_iter,
                            std::vector<std::unique_ptr<ColumnIterator>>& field_iters,
-                           std::vector<std::string>& flat_paths, ColumnAccessPath* path)
+                           std::vector<std::string>& flat_paths, std::vector<LogicalType>& target_types,
+                           std::vector<LogicalType>& source_types, ColumnAccessPath* path)
             : _reader(_reader),
               _null_iter(std::move(null_iter)),
               _flat_iters(std::move(field_iters)),
               _flat_paths(std::move(flat_paths)),
+              _target_types(std::move(target_types)),
+              _source_types(std::move(source_types)),
               _path(path) {}
 
     ~JsonFlatColumnIterator() override = default;
@@ -68,12 +81,21 @@ public:
     [[nodiscard]] Status fetch_values_by_rowid(const rowid_t* rowids, size_t size, Column* values) override;
 
 private:
+    template <typename FUNC>
+    Status _read_and_cast(JsonColumn* json_column, FUNC fn);
+
+private:
     ColumnReader* _reader;
 
     std::unique_ptr<ColumnIterator> _null_iter;
     std::vector<std::unique_ptr<ColumnIterator>> _flat_iters;
     std::vector<std::string> _flat_paths;
+    std::vector<LogicalType> _target_types;
+    std::vector<LogicalType> _source_types;
     ColumnAccessPath* _path;
+
+    ObjectPool _pool;
+    std::vector<Expr*> _cast_exprs;
 };
 
 Status JsonFlatColumnIterator::init(const ColumnIteratorOptions& opts) {
@@ -86,13 +108,62 @@ Status JsonFlatColumnIterator::init(const ColumnIteratorOptions& opts) {
         RETURN_IF_ERROR(iter->init(opts));
     }
 
-    //  update stats
+    // update stats
     DCHECK(_path != nullptr);
     auto abs_path = _path->absolute_path();
     if (opts.stats->flat_json_hits.count(abs_path) == 0) {
         opts.stats->flat_json_hits[abs_path] = 1;
     } else {
         opts.stats->flat_json_hits[abs_path] = opts.stats->flat_json_hits[abs_path] + 1;
+    }
+
+    DCHECK(_target_types.size() == _source_types.size());
+
+    for (int i = 0; i < _target_types.size(); i++) {
+        if (_target_types[i] == _source_types[i]) {
+            _cast_exprs.push_back(nullptr);
+            continue;
+        }
+
+        TypeDescriptor source_type(_source_types[i]);
+        TypeDescriptor target_type(_target_types[i]);
+
+        SlotDescriptor source_slot(i, "mock_solt", source_type);
+        ColumnRef* col_ref = _pool.add(new ColumnRef(&source_slot));
+
+        auto cast_expr = VectorizedCastExprFactory::from_type(source_type, target_type, col_ref, &_pool);
+        _cast_exprs.push_back(cast_expr);
+    }
+
+    return Status::OK();
+}
+
+template <typename FUNC>
+Status JsonFlatColumnIterator::_read_and_cast(JsonColumn* json_column, FUNC read_fn) {
+    json_column->init_flat_columns(_flat_paths, _target_types);
+    Chunk chunk;
+
+    for (int i = 0; i < _flat_iters.size(); i++) {
+        if (_cast_exprs[i] != nullptr) {
+            auto source = ColumnHelper::create_column(TypeDescriptor(_source_types[i]), true);
+            RETURN_IF_ERROR(read_fn(i, source.get()));
+
+            chunk.append_column(source, i);
+            ASSIGN_OR_RETURN(auto res, _cast_exprs[i]->evaluate_checked(nullptr, &chunk));
+            auto target = json_column->get_flat_field(i);
+            target->set_delete_state(source->delete_state());
+            if (res->only_null()) {
+                target->append_nulls(source->size());
+            } else if (res->is_constant()) {
+                auto data = down_cast<ConstColumn*>(res.get())->data_column();
+                target->append_value_multiple_times(*data, 0, source->size());
+            } else {
+                target->append(*res, 0, source->size());
+            }
+        } else {
+            auto* flat_column = json_column->get_flat_field(i).get();
+            RETURN_IF_ERROR(read_fn(i, flat_column));
+        }
     }
     return Status::OK();
 }
@@ -116,13 +187,8 @@ Status JsonFlatColumnIterator::next_batch(size_t* n, Column* dst) {
     }
 
     // 2. Read flat column
-    json_column->init_flat_columns(_flat_paths);
-    for (int i = 0; i < _flat_iters.size(); i++) {
-        Column* flat_column = json_column->get_flat_field(i).get();
-        RETURN_IF_ERROR(_flat_iters[i]->next_batch(n, flat_column));
-    }
-
-    return Status::OK();
+    auto read = [&](int index, Column* column) { return _flat_iters[index]->next_batch(n, column); };
+    return _read_and_cast(json_column, read);
 }
 
 Status JsonFlatColumnIterator::next_batch(const SparseRange<>& range, Column* dst) {
@@ -145,12 +211,8 @@ Status JsonFlatColumnIterator::next_batch(const SparseRange<>& range, Column* ds
     }
 
     // 2. Read flat column
-    json_column->init_flat_columns(_flat_paths);
-    for (int i = 0; i < _flat_iters.size(); i++) {
-        Column* flat_column = json_column->get_flat_field(i).get();
-        RETURN_IF_ERROR(_flat_iters[i]->next_batch(range, flat_column));
-    }
-    return Status::OK();
+    auto read = [&](int index, Column* column) { return _flat_iters[index]->next_batch(range, column); };
+    return _read_and_cast(json_column, read);
 }
 
 Status JsonFlatColumnIterator::fetch_values_by_rowid(const rowid_t* rowids, size_t size, Column* values) {
@@ -168,12 +230,11 @@ Status JsonFlatColumnIterator::fetch_values_by_rowid(const rowid_t* rowids, size
     }
 
     // 2. Read flat column
-    json_column->init_flat_columns(_flat_paths);
-    for (int i = 0; i < _flat_iters.size(); i++) {
-        Column* flat_column = json_column->get_flat_field(i).get();
-        RETURN_IF_ERROR(_flat_iters[i]->fetch_values_by_rowid(rowids, size, flat_column));
-    }
-    return Status::OK();
+    auto read = [&](int index, Column* column) {
+        return _flat_iters[index]->fetch_values_by_rowid(rowids, size, column);
+    };
+
+    return _read_and_cast(json_column, read);
 }
 
 Status JsonFlatColumnIterator::seek_to_first() {
@@ -206,8 +267,11 @@ Status JsonFlatColumnIterator::get_row_ranges_by_zone_map(const std::vector<cons
 class JsonDynamicFlatIterator final : public ColumnIterator {
 public:
     JsonDynamicFlatIterator(std::unique_ptr<ScalarColumnIterator>& json_iter, std::vector<std::string>& flat_paths,
-                            ColumnAccessPath* path)
-            : _json_iter(std::move(json_iter)), _flat_paths(std::move(flat_paths)), _path(path){};
+                            std::vector<LogicalType>& target_types, ColumnAccessPath* path)
+            : _json_iter(std::move(json_iter)),
+              _flat_paths(std::move(flat_paths)),
+              _target_types(std::move(target_types)),
+              _path(path){};
 
     ~JsonDynamicFlatIterator() override = default;
 
@@ -238,7 +302,10 @@ private:
 private:
     std::unique_ptr<ScalarColumnIterator> _json_iter;
     std::vector<std::string> _flat_paths;
+    std::vector<LogicalType> _target_types;
     ColumnAccessPath* _path;
+
+    JsonFlattener _flattener;
 };
 
 Status JsonDynamicFlatIterator::init(const ColumnIteratorOptions& opts) {
@@ -250,6 +317,8 @@ Status JsonDynamicFlatIterator::init(const ColumnIteratorOptions& opts) {
     } else {
         opts.stats->dynamic_json_hits[abs_path] = opts.stats->dynamic_json_hits[abs_path] + 1;
     }
+
+    _flattener = JsonFlattener(_flat_paths, _target_types);
     return _json_iter->init(opts);
 }
 
@@ -276,10 +345,8 @@ Status JsonDynamicFlatIterator::_flat_json(Column* input, Column* output) {
     }
 
     // 2. flat
-    json_data->init_flat_columns(_flat_paths);
-
-    JsonFlattener flattener(_flat_paths);
-    flattener.flatten(input, &(json_data->get_flat_fields()));
+    json_data->init_flat_columns(_flat_paths, _target_types);
+    _flattener.flatten(input, &(json_data->get_flat_fields()));
     return Status::OK();
 }
 
@@ -321,13 +388,15 @@ Status JsonDynamicFlatIterator::get_row_ranges_by_zone_map(const std::vector<con
 StatusOr<std::unique_ptr<ColumnIterator>> create_json_flat_iterator(
         ColumnReader* reader, std::unique_ptr<ColumnIterator> null_iter,
         std::vector<std::unique_ptr<ColumnIterator>> field_iters, std::vector<std::string>& full_paths,
-        ColumnAccessPath* path) {
-    return std::make_unique<JsonFlatColumnIterator>(reader, null_iter, field_iters, full_paths, path);
+        std::vector<LogicalType>& target_types, std::vector<LogicalType>& source_types, ColumnAccessPath* path) {
+    return std::make_unique<JsonFlatColumnIterator>(reader, null_iter, field_iters, full_paths, target_types,
+                                                    source_types, path);
 }
 
 StatusOr<std::unique_ptr<ColumnIterator>> create_json_dynamic_flat_iterator(
-        std::unique_ptr<ScalarColumnIterator> json_iter, std::vector<std::string>& flat_paths, ColumnAccessPath* path) {
-    return std::make_unique<JsonDynamicFlatIterator>(json_iter, flat_paths, path);
+        std::unique_ptr<ScalarColumnIterator> json_iter, std::vector<std::string>& flat_paths,
+        std::vector<LogicalType>& target_types, ColumnAccessPath* path) {
+    return std::make_unique<JsonDynamicFlatIterator>(json_iter, flat_paths, target_types, path);
 }
 
 } // namespace starrocks

--- a/be/src/storage/rowset/json_column_iterator.h
+++ b/be/src/storage/rowset/json_column_iterator.h
@@ -24,9 +24,10 @@ namespace starrocks {
 
 StatusOr<std::unique_ptr<ColumnIterator>> create_json_flat_iterator(
         ColumnReader* reader, std::unique_ptr<ColumnIterator> null_iter,
-        std::vector<std::unique_ptr<ColumnIterator>> field_iters, std::vector<std::string>& flat_paths,
-        ColumnAccessPath* path);
+        std::vector<std::unique_ptr<ColumnIterator>> field_iters, std::vector<std::string>& full_paths,
+        std::vector<LogicalType>& target_types, std::vector<LogicalType>& source_types, ColumnAccessPath* path);
 
 StatusOr<std::unique_ptr<ColumnIterator>> create_json_dynamic_flat_iterator(
-        std::unique_ptr<ScalarColumnIterator> json_iter, std::vector<std::string>& flat_paths, ColumnAccessPath* path);
+        std::unique_ptr<ScalarColumnIterator> json_iter, std::vector<std::string>& flat_paths,
+        std::vector<LogicalType>& target_types, ColumnAccessPath* path);
 } // namespace starrocks

--- a/be/src/storage/rowset/json_column_writer.cpp
+++ b/be/src/storage/rowset/json_column_writer.cpp
@@ -21,6 +21,7 @@
 #include <memory>
 #include <sstream>
 #include <string>
+#include <unordered_map>
 #include <utility>
 
 #include "column/column.h"
@@ -33,6 +34,7 @@
 #include "common/status.h"
 #include "gen_cpp/segment.pb.h"
 #include "gutil/casts.h"
+#include "runtime/types.h"
 #include "storage/rowset/column_writer.h"
 #include "types/logical_type.h"
 #include "util/json_flattener.h"
@@ -80,6 +82,7 @@ private:
 
     std::vector<std::unique_ptr<ColumnWriter>> _flat_writers;
     std::vector<std::string> _flat_paths;
+    std::vector<LogicalType> _flat_types;
     std::vector<ColumnPtr> _flat_columns;
 };
 
@@ -101,88 +104,11 @@ Status FlatJsonColumnWriter::append(const Column& column) {
 }
 
 void FlatJsonColumnWriter::_flat_column(std::vector<ColumnPtr>& json_datas) {
-    DCHECK(_flat_paths.empty());
-    DCHECK(!json_datas.empty());
+    JsonFlattener flattener;
+    flattener.derived_paths(json_datas);
 
-    size_t total_rows = 0;
-    size_t null_count = 0;
-
-    for (auto& column : json_datas) {
-        DCHECK(!column->is_constant());
-
-        total_rows += column->size();
-        if (column->only_null() || column->empty()) {
-            null_count += column->size();
-            continue;
-        } else if (column->is_nullable()) {
-            auto* nullable_column = down_cast<NullableColumn*>(column.get());
-            null_count += nullable_column->null_count();
-        }
-    }
-
-    // more than half of null
-    if (null_count > total_rows * config::json_flat_null_factor) {
-        VLOG(8) << "flat json, null_count[" << null_count << "], row[" << total_rows
-                << "], null_factor: " << config::json_flat_null_factor;
-        return;
-    }
-
-    // extract common keys
-    std::unordered_map<std::string, uint64_t> hit_maps;
-    for (size_t k = 0; k < json_datas.size(); k++) {
-        size_t row_count = json_datas[k]->size();
-
-        ColumnViewer<TYPE_JSON> viewer(json_datas[k]);
-        for (size_t i = 0; i < row_count; ++i) {
-            if (viewer.is_null(i)) {
-                continue;
-            }
-
-            JsonValue* json = viewer.value(i);
-            auto vslice = json->to_vslice();
-
-            if (vslice.isNull()) {
-                continue;
-            }
-
-            if (vslice.isNone() || !vslice.isObject() || vslice.isEmptyObject()) {
-                VLOG(8) << "flat json, row isn't object, can't be flatten";
-                return;
-            }
-
-            std::vector<std::string> keys = arangodb::velocypack::Collection::keys(json->to_vslice());
-            for (auto& sr : keys) {
-                hit_maps[sr]++;
-            }
-        }
-    }
-
-    if (hit_maps.size() <= config::json_flat_internal_column_min_limit) {
-        VLOG(8) << "flat json, internal column too less: " << hit_maps.size()
-                << ", at least: " << config::json_flat_internal_column_min_limit;
-        return;
-    }
-
-    // sort by hit
-    std::vector<pair<std::string, std::uint64_t>> top_hits(hit_maps.begin(), hit_maps.end());
-    std::sort(top_hits.begin(), top_hits.end(),
-              [](const pair<std::string, std::uint64_t>& a, const pair<std::string, std::uint64_t>& b) {
-                  return a.second > b.second;
-              });
-
-    for (int i = 0; i < top_hits.size() && i < config::json_flat_column_max; i++) {
-        const auto& [name, hit] = top_hits[i];
-        // check sparsity
-        if (hit >= total_rows * config::json_flat_sparsity_factor) {
-            if (name.find('.') != std::string::npos) {
-                // add escape
-                _flat_paths.emplace_back(fmt::format("\"{}\"", name));
-            } else {
-                _flat_paths.emplace_back(name);
-            }
-        }
-        VLOG(8) << "flat json[" << name << "], hit[" << hit << "], row[" << total_rows << "]";
-    }
+    _flat_paths = flattener.get_flat_paths();
+    _flat_types = flattener.get_flat_types();
 
     if (_flat_paths.empty()) {
         return;
@@ -190,10 +116,8 @@ void FlatJsonColumnWriter::_flat_column(std::vector<ColumnPtr>& json_datas) {
 
     // extract flat column
     for (size_t i = 0; i < _flat_paths.size(); i++) {
-        _flat_columns.emplace_back(NullableColumn::create(JsonColumn::create(), NullColumn::create()));
+        _flat_columns.emplace_back(ColumnHelper::create_column(TypeDescriptor(_flat_types[i]), true));
     }
-
-    JsonFlattener flattener(_flat_paths);
 
     for (auto& col : json_datas) {
         flattener.flatten(col.get(), &_flat_columns);
@@ -218,6 +142,7 @@ void FlatJsonColumnWriter::_flat_column(std::vector<ColumnPtr>& json_datas) {
 
         _flat_columns.insert(_flat_columns.begin(), nulls);
         _flat_paths.insert(_flat_paths.begin(), "nulls");
+        _flat_types.insert(_flat_types.begin(), LogicalType::TYPE_TINYINT);
     }
 }
 
@@ -260,16 +185,32 @@ Status FlatJsonColumnWriter::finish() {
             opts.meta = _json_meta->add_children_columns();
             opts.meta->set_column_id(i);
             opts.meta->set_unique_id(i);
-            opts.meta->set_type(LogicalType::TYPE_JSON);
-            opts.meta->set_length(get_type_info(LogicalType::TYPE_JSON)->size());
+            opts.meta->set_type(_flat_types[i]);
+            if (_flat_types[i] == TYPE_VARCHAR) {
+                opts.meta->set_length(config::olap_string_max_length);
+            } else {
+                DCHECK_NE(_flat_types[i], TYPE_CHAR);
+                // set length for non-string type (e.g. int, double, date, etc.
+                opts.meta->set_length(get_type_info(_flat_types[i])->size());
+            }
             opts.meta->set_is_nullable(true);
             opts.meta->set_encoding(DEFAULT_ENCODING);
             opts.meta->set_compression(_json_meta->compression());
-            opts.meta->mutable_json_meta()->set_format_version(kJsonMetaDefaultFormatVersion);
-            opts.meta->set_name(_flat_paths[i]);
+
+            if (_flat_types[i] == LogicalType::TYPE_JSON) {
+                opts.meta->mutable_json_meta()->set_format_version(kJsonMetaDefaultFormatVersion);
+            }
+
+            if (_flat_paths[i].find('.') != std::string::npos) {
+                // add escape
+                opts.meta->set_name(fmt::format("\"{}\"", _flat_paths[i]));
+            } else {
+                opts.meta->set_name(_flat_paths[i]);
+            }
+
             opts.need_flat = false;
 
-            TabletColumn col(StorageAggregateType::STORAGE_AGGREGATE_NONE, LogicalType::TYPE_JSON, true);
+            TabletColumn col(StorageAggregateType::STORAGE_AGGREGATE_NONE, _flat_types[i], true);
             ASSIGN_OR_RETURN(auto fw, ColumnWriter::create(opts, &col, _wfile));
             _flat_writers.emplace_back(std::move(fw));
 

--- a/be/src/util/json_flattener.cpp
+++ b/be/src/util/json_flattener.cpp
@@ -334,6 +334,8 @@ void JsonFlattener::flatten(const Column* json_column, std::vector<ColumnPtr>* r
             continue;
         }
 
+        // bitset, all 1,
+        // to mark which column exists in json, to fill null if doesn't found in json
         uint32_t flat_hit = (1 << _flat_paths.size()) - 1;
         vpack::ObjectIterator iter(vslice);
         for (const auto& it : iter) {
@@ -344,6 +346,7 @@ void JsonFlattener::flatten(const Column* json_column, std::vector<ColumnPtr>* r
                 uint8_t type = _flat_types[index];
                 auto func = JSON_BITS_FUNC.at(type);
                 func(&it.value, flat_jsons[index]);
+                // set index to 0
                 flat_hit ^= (1 << index);
             }
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/prunesubfield/SubfieldAccessPathNormalizer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/prunesubfield/SubfieldAccessPathNormalizer.java
@@ -140,12 +140,6 @@ public class SubfieldAccessPathNormalizer {
             return first;
         }
 
-        // now json function support read type: BOOLEAN/JSON/STRING/BIGINT/DOUBLE
-        // only bigint & double is compatible, other combinations need
-        if ((first.isBigint() && second.isDouble()) || (first.isDouble() && second.isBigint())) {
-            return Type.DOUBLE;
-        }
-
         // the compatible type of two types use JSON,
         // the be can't promise cast(cast(xx as IntermediateType) as TargetType) is same as cast(xx as TargetType)
         // e.g: cast(cast("1.1" as double) as int) is different with cast("1.1" as int)

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/PruneComplexSubfieldTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/PruneComplexSubfieldTest.java
@@ -1107,11 +1107,4 @@ public class PruneComplexSubfieldTest extends PlanTestNoneDBBase {
         String plan = getVerboseExplain(sql);
         assertContains(plan, "ColumnAccessPath: [/j1/a(json)]");
     }
-
-    @Test
-    public void testJsonBigintDouble() throws Exception {
-        String sql = "select get_json_int(j1, 'a'), get_json_double(j1, 'a') from js0;";
-        String plan = getVerboseExplain(sql);
-        assertContains(plan, "ColumnAccessPath: [/j1/a(double)]");
-    }
 }

--- a/test/sql/test_semi/R/test_flat_json_with_type
+++ b/test/sql/test_semi/R/test_flat_json_with_type
@@ -558,7 +558,7 @@ select get_json_string(j1, "e"), json_query(j1, "e")   from js1 order by v2;
 asdf	"asdf"
 123123	123123
 zxcvzvxc	"zxcvzvxc"
-null	null
+None	null
 {"e1": 4, "e2": 5}	{"e1": 4, "e2": 5}
 0.000	"0.000"
 true	true
@@ -866,7 +866,7 @@ select json_exists(j1, "e"), get_json_string(j1, "e") from js1 order by v2;
 1	asdf
 1	123123
 1	zxcvzvxc
-1	null
+1	None
 1	{"e1": 4, "e2": 5}
 1	0.000
 1	true
@@ -1006,7 +1006,7 @@ select json_length(j1, "e"), get_json_string(j1, "e") from js1 order by v2;
 1	asdf
 1	123123
 1	zxcvzvxc
-1	null
+1	None
 2	{"e1": 4, "e2": 5}
 1	0.000
 1	true
@@ -1573,7 +1573,7 @@ select get_json_string(j1, "e"), json_query(j1, "e")   from js2 order by v2;
 asdf	"asdf"
 123123	123123
 zxcvzvxc	"zxcvzvxc"
-null	null
+None	null
 {"e1": 4, "e2": 5}	{"e1": 4, "e2": 5}
 [1, 2, 3, 4]	[1, 2, 3, 4]
 [1, 2, 3, 4]	[1, 2, 3, 4]
@@ -1881,7 +1881,7 @@ select json_exists(j1, "e"), get_json_string(j1, "e") from js2 order by v2;
 1	asdf
 1	123123
 1	zxcvzvxc
-1	null
+1	None
 1	{"e1": 4, "e2": 5}
 1	[1, 2, 3, 4]
 1	[1, 2, 3, 4]
@@ -2021,7 +2021,7 @@ select json_length(j1, "e"), get_json_string(j1, "e") from js2 order by v2;
 1	asdf
 1	123123
 1	zxcvzvxc
-1	null
+1	None
 2	{"e1": 4, "e2": 5}
 4	[1, 2, 3, 4]
 4	[1, 2, 3, 4]
@@ -2063,9 +2063,9 @@ null
 -- !result
 select get_json_string(j1, "e"), json_query(j1, "e")   from js3 order by v2;
 -- result:
-null	null
-null	null
-null	null
+None	null
+None	null
+None	null
 -- !result
 select get_json_int(j1, "e"), get_json_double(j1, "e") from js3 order by v2;
 -- result:
@@ -2099,9 +2099,9 @@ select json_exists(j1, "e"), json_query(j1, "e") from js3 order by v2;
 -- !result
 select json_exists(j1, "e"), get_json_string(j1, "e") from js3 order by v2;
 -- result:
-1	null
-1	null
-1	null
+1	None
+1	None
+1	None
 -- !result
 select json_length(j1, "e"), json_query(j1, "e") from js3 order by v2;
 -- result:
@@ -2111,9 +2111,9 @@ select json_length(j1, "e"), json_query(j1, "e") from js3 order by v2;
 -- !result
 select json_length(j1, "e"), get_json_string(j1, "e") from js3 order by v2;
 -- result:
-1	null
-1	null
-1	null
+1	None
+1	None
+1	None
 -- !result
 select j1->'d' from js3 order by v2;
 -- result:
@@ -2183,7 +2183,7 @@ null
 -- !result
 select get_json_string(j1, "a"), json_query(j1, "a")   from js3 order by v2;
 -- result:
-null	null
+None	null
 123	123
 234	234
 -- !result
@@ -2219,7 +2219,7 @@ select json_exists(j1, "a"), json_query(j1, "a") from js3 order by v2;
 -- !result
 select json_exists(j1, "a"), get_json_string(j1, "a") from js3 order by v2;
 -- result:
-1	null
+1	None
 1	123
 1	234
 -- !result
@@ -2231,7 +2231,7 @@ select json_length(j1, "a"), json_query(j1, "a") from js3 order by v2;
 -- !result
 select json_length(j1, "a"), get_json_string(j1, "a") from js3 order by v2;
 -- result:
-1	null
+1	None
 1	123
 1	234
 -- !result
@@ -2243,7 +2243,7 @@ null
 -- !result
 select get_json_string(j1, "b"), json_query(j1, "b")   from js3 order by v2;
 -- result:
-null	null
+None	null
 avx	"avx"
 sse	"sse"
 -- !result
@@ -2279,7 +2279,7 @@ select json_exists(j1, "b"), json_query(j1, "b") from js3 order by v2;
 -- !result
 select json_exists(j1, "b"), get_json_string(j1, "b") from js3 order by v2;
 -- result:
-1	null
+1	None
 1	avx
 1	sse
 -- !result
@@ -2291,7 +2291,7 @@ select json_length(j1, "b"), json_query(j1, "b") from js3 order by v2;
 -- !result
 select json_length(j1, "b"), get_json_string(j1, "b") from js3 order by v2;
 -- result:
-1	null
+1	None
 1	avx
 1	sse
 -- !result
@@ -2303,7 +2303,7 @@ false
 -- !result
 select get_json_string(j1, "c"), json_query(j1, "c")   from js3 order by v2;
 -- result:
-null	null
+None	null
 true	true
 false	false
 -- !result
@@ -2339,7 +2339,7 @@ select json_exists(j1, "c"), json_query(j1, "c") from js3 order by v2;
 -- !result
 select json_exists(j1, "c"), get_json_string(j1, "c") from js3 order by v2;
 -- result:
-1	null
+1	None
 1	true
 1	false
 -- !result
@@ -2351,7 +2351,7 @@ select json_length(j1, "c"), json_query(j1, "c") from js3 order by v2;
 -- !result
 select json_length(j1, "c"), get_json_string(j1, "c") from js3 order by v2;
 -- result:
-1	null
+1	None
 1	true
 1	false
 -- !result

--- a/test/sql/test_semi/R/test_flat_json_with_type
+++ b/test/sql/test_semi/R/test_flat_json_with_type
@@ -1,0 +1,2357 @@
+-- name: test_normal_flat_json_with_type @system
+CREATE TABLE `js1` (
+  `v1` bigint(20) NULL COMMENT "",
+  `v2` int(11) NULL COMMENT "",
+  `j1` json NULL COMMENT ""
+) ENGINE=OLAP 
+DUPLICATE KEY(`v1`)
+COMMENT "OLAP"
+DISTRIBUTED BY HASH(`v1`) BUCKETS 1
+PROPERTIES (
+"replication_num" = "1",
+"in_memory" = "false",
+"enable_persistent_index" = "false",
+"replicated_storage" = "false",
+"fast_schema_evolution" = "true",
+"compression" = "LZ4"
+);
+-- result:
+[]
+-- !result
+insert into js1 values 
+(1,  11,  parse_json('{"a": true,   "b": 1, "c": "qwe",    "d": 1210.010,  "e":  [1,2,3,4]}')),
+(2,  22,  parse_json('{"a": false,  "b": 2, "c": "asdf",   "d": 2220.020,  "e":  {"e1": 1, "e2": 3}}')),
+(3,  33,  parse_json('{"a": true,   "b": 3, "c": "qcve",   "d": 3230.030,  "e":  "asdf"}')),
+(4,  44,  parse_json('{"a": true,   "b": 4, "c": "234.234",    "d": 4240.040,  "e":  123123}')),
+(5,  55,  parse_json('{"a": true,   "b": 5, "c": "1233",    "d": 5250.050,  "e":  "zxcvzvxc"}')),
+(6,  66,  parse_json('{"a": true,   "b": 6, "c": "0",   "d": 6260.060,  "e":  null}')),
+(7,  77,  parse_json('{"a": false,  "b": 7, "c": "vTp49OF2Ezc0RWJVN",  "d": 7270.070,  "e":  {"e1": 4, "e2": 5}}')),
+(8,  88,  parse_json('{"a": true,   "b": 8, "c": "qw1e",   "d": 8280.080,  "e":  "0.000"}')),
+(9,  99,  parse_json('{"a": false,  "b": 0, "c": "q123",   "d": 0.000,  "e":  true}')),
+(10, 101, parse_json('{"a": false,  "b": -1, "c": "true",   "d": -1.123,  "e":  "false"}')),
+(11, 102, parse_json('{"a": false,  "b": 9, "c": "false",  "d": 9290.090,  "e":  [1,2,3,4]}'));
+-- result:
+[]
+-- !result
+select j1->'a' from js1 order by v2;
+-- result:
+true
+false
+true
+true
+true
+true
+false
+true
+false
+false
+false
+-- !result
+select j1->'b' from js1 order by v2;
+-- result:
+1
+2
+3
+4
+5
+6
+7
+8
+0
+-1
+9
+-- !result
+select j1->'c' from js1 order by v2;
+-- result:
+"qwe"
+"asdf"
+"qcve"
+"234.234"
+"1233"
+"0"
+"vTp49OF2Ezc0RWJVN"
+"qw1e"
+"q123"
+"true"
+"false"
+-- !result
+select j1->'d' from js1 order by v2;
+-- result:
+1210.01
+2220.02
+3230.03
+4240.04
+5250.05
+6260.06
+7270.07
+8280.08
+0
+-1.123
+9290.09
+-- !result
+select j1->'e' from js1 order by v2;
+-- result:
+[1, 2, 3, 4]
+{"e1": 1, "e2": 3}
+"asdf"
+123123
+"zxcvzvxc"
+null
+{"e1": 4, "e2": 5}
+"0.000"
+true
+"false"
+[1, 2, 3, 4]
+-- !result
+select get_json_bool(j1, 'a')   from js1 order by v2;
+-- result:
+1
+0
+1
+1
+1
+1
+0
+1
+0
+0
+0
+-- !result
+select get_json_int(j1, 'a')    from js1 order by v2;
+-- result:
+1
+0
+1
+1
+1
+1
+0
+1
+0
+0
+0
+-- !result
+select get_json_string(j1, 'a') from js1 order by v2;
+-- result:
+true
+false
+true
+true
+true
+true
+false
+true
+false
+false
+false
+-- !result
+select get_json_double(j1, 'a') from js1 order by v2;
+-- result:
+1.0
+0.0
+1.0
+1.0
+1.0
+1.0
+0.0
+1.0
+0.0
+0.0
+0.0
+-- !result
+select json_query(j1, 'a')      from js1 order by v2;
+-- result:
+true
+false
+true
+true
+true
+true
+false
+true
+false
+false
+false
+-- !result
+select get_json_bool(j1, 'b')   from js1 order by v2;
+-- result:
+1
+1
+1
+1
+1
+1
+1
+1
+0
+1
+1
+-- !result
+select get_json_int(j1, 'b')    from js1 order by v2;
+-- result:
+1
+2
+3
+4
+5
+6
+7
+8
+0
+-1
+9
+-- !result
+select get_json_string(j1, 'b') from js1 order by v2;
+-- result:
+1
+2
+3
+4
+5
+6
+7
+8
+0
+-1
+9
+-- !result
+select get_json_double(j1, 'b') from js1 order by v2;
+-- result:
+1.0
+2.0
+3.0
+4.0
+5.0
+6.0
+7.0
+8.0
+0.0
+-1.0
+9.0
+-- !result
+select json_query(j1, 'b')      from js1 order by v2;
+-- result:
+1
+2
+3
+4
+5
+6
+7
+8
+0
+-1
+9
+-- !result
+select get_json_bool(j1, 'c')   from js1 order by v2;
+-- result:
+None
+None
+None
+None
+1
+0
+None
+None
+None
+1
+0
+-- !result
+select get_json_int(j1, 'c')    from js1 order by v2;
+-- result:
+None
+None
+None
+None
+1233
+0
+None
+None
+None
+None
+None
+-- !result
+select get_json_string(j1, 'c') from js1 order by v2;
+-- result:
+qwe
+asdf
+qcve
+234.234
+1233
+0
+vTp49OF2Ezc0RWJVN
+qw1e
+q123
+true
+false
+-- !result
+select get_json_double(j1, 'c') from js1 order by v2;
+-- result:
+None
+None
+None
+234.234
+1233.0
+0.0
+None
+None
+None
+None
+None
+-- !result
+select json_query(j1, 'c')      from js1 order by v2;
+-- result:
+"qwe"
+"asdf"
+"qcve"
+"234.234"
+"1233"
+"0"
+"vTp49OF2Ezc0RWJVN"
+"qw1e"
+"q123"
+"true"
+"false"
+-- !result
+select get_json_bool(j1, 'd')   from js1 order by v2;
+-- result:
+1
+1
+1
+1
+1
+1
+1
+1
+0
+1
+1
+-- !result
+select get_json_int(j1, 'd')    from js1 order by v2;
+-- result:
+1210
+2220
+3230
+4240
+5250
+6260
+7270
+8280
+0
+-1
+9290
+-- !result
+select get_json_string(j1, 'd') from js1 order by v2;
+-- result:
+1210.01
+2220.02
+3230.03
+4240.04
+5250.05
+6260.06
+7270.07
+8280.08
+0
+-1.123
+9290.09
+-- !result
+select get_json_double(j1, 'd') from js1 order by v2;
+-- result:
+1210.01
+2220.02
+3230.03
+4240.04
+5250.05
+6260.06
+7270.07
+8280.08
+0.0
+-1.123
+9290.09
+-- !result
+select json_query(j1, 'd')      from js1 order by v2;
+-- result:
+1210.01
+2220.02
+3230.03
+4240.04
+5250.05
+6260.06
+7270.07
+8280.08
+0
+-1.123
+9290.09
+-- !result
+select get_json_bool(j1, "a"), get_json_double(j1, "a") from js1 order by v2;
+-- result:
+1	1.0
+0	0.0
+1	1.0
+1	1.0
+1	1.0
+1	1.0
+0	0.0
+1	1.0
+0	0.0
+0	0.0
+0	0.0
+-- !result
+select get_json_bool(j1, "a"), json_query(j1, "a")      from js1 order by v2;
+-- result:
+1	true
+0	false
+1	true
+1	true
+1	true
+1	true
+0	false
+1	true
+0	false
+0	false
+0	false
+-- !result
+select get_json_string(j1, "a"), get_json_int(j1, "a")  from js1 order by v2;
+-- result:
+true	1
+false	0
+true	1
+true	1
+true	1
+true	1
+false	0
+true	1
+false	0
+false	0
+false	0
+-- !result
+select get_json_int(j1, "b"), get_json_bool(j1, "b")    from js1 order by v2;
+-- result:
+1	1
+2	1
+3	1
+4	1
+5	1
+6	1
+7	1
+8	1
+0	0
+-1	1
+9	1
+-- !result
+select get_json_int(j1, "b"), get_json_string(j1, "b")  from js1 order by v2;
+-- result:
+1	1
+2	2
+3	3
+4	4
+5	5
+6	6
+7	7
+8	8
+0	0
+-1	-1
+9	9
+-- !result
+select get_json_double(j1, "b"), json_query(j1, "b")    from js1 order by v2;
+-- result:
+1.0	1
+2.0	2
+3.0	3
+4.0	4
+5.0	5
+6.0	6
+7.0	7
+8.0	8
+0.0	0
+-1.0	-1
+9.0	9
+-- !result
+select get_json_double(j1, "c"), json_query(j1, "c")   from js1 order by v2;
+-- result:
+None	"qwe"
+None	"asdf"
+None	"qcve"
+234.234	"234.234"
+1233.0	"1233"
+0.0	"0"
+None	"vTp49OF2Ezc0RWJVN"
+None	"qw1e"
+None	"q123"
+None	"true"
+None	"false"
+-- !result
+select json_query(j1, "c"), get_json_string(j1, "c")        from js1 order by v2;
+-- result:
+"qwe"	qwe
+"asdf"	asdf
+"qcve"	qcve
+"234.234"	234.234
+"1233"	1233
+"0"	0
+"vTp49OF2Ezc0RWJVN"	vTp49OF2Ezc0RWJVN
+"qw1e"	qw1e
+"q123"	q123
+"true"	true
+"false"	false
+-- !result
+select get_json_int(j1, "c"), get_json_string(j1, "c")      from js1 order by v2;
+-- result:
+None	qwe
+None	asdf
+None	qcve
+None	234.234
+1233	1233
+0	0
+None	vTp49OF2Ezc0RWJVN
+None	qw1e
+None	q123
+None	true
+None	false
+-- !result
+select get_json_double(j1, "d"), get_json_int(j1, "d") from js1 order by v2;
+-- result:
+1210.01	1210
+2220.02	2220
+3230.03	3230
+4240.04	4240
+5250.05	5250
+6260.06	6260
+7270.07	7270
+8280.08	8280
+0.0	0
+-1.123	-1
+9290.09	9290
+-- !result
+select get_json_string(j1, "d"), get_json_int(j1, "d") from js1 order by v2;
+-- result:
+1210.01	1210
+2220.02	2220
+3230.03	3230
+4240.04	4240
+5250.05	5250
+6260.06	6260
+7270.07	7270
+8280.08	8280
+0	0
+-1.123	-1
+9290.09	9290
+-- !result
+select get_json_string(j1, "d"), json_query(j1, "d")   from js1 order by v2;
+-- result:
+1210.01	1210.01
+2220.02	2220.02
+3230.03	3230.03
+4240.04	4240.04
+5250.05	5250.05
+6260.06	6260.06
+7270.07	7270.07
+8280.08	8280.08
+0	0
+-1.123	-1.123
+9290.09	9290.09
+-- !result
+select get_json_string(j1, "e"), json_query(j1, "e")   from js1 order by v2;
+-- result:
+[1, 2, 3, 4]	[1, 2, 3, 4]
+{"e1": 1, "e2": 3}	{"e1": 1, "e2": 3}
+asdf	"asdf"
+123123	123123
+zxcvzvxc	"zxcvzvxc"
+null	null
+{"e1": 4, "e2": 5}	{"e1": 4, "e2": 5}
+0.000	"0.000"
+true	true
+false	"false"
+[1, 2, 3, 4]	[1, 2, 3, 4]
+-- !result
+select get_json_int(j1, "e"), get_json_double(j1, "e") from js1 order by v2;
+-- result:
+None	None
+None	None
+None	None
+123123	123123.0
+None	None
+None	None
+None	None
+None	0.0
+1	1.0
+None	None
+None	None
+-- !result
+select get_json_int(j1, "e"), json_query(j1, "e")      from js1 order by v2;
+-- result:
+None	[1, 2, 3, 4]
+None	{"e1": 1, "e2": 3}
+None	"asdf"
+123123	123123
+None	"zxcvzvxc"
+None	null
+None	{"e1": 4, "e2": 5}
+None	"0.000"
+1	true
+None	"false"
+None	[1, 2, 3, 4]
+-- !result
+select json_exists(j1, "a") from js1 order by v2;
+-- result:
+1
+1
+1
+1
+1
+1
+1
+1
+1
+1
+1
+-- !result
+select json_exists(j1, "b") from js1 order by v2;
+-- result:
+1
+1
+1
+1
+1
+1
+1
+1
+1
+1
+1
+-- !result
+select json_exists(j1, "c") from js1 order by v2;
+-- result:
+1
+1
+1
+1
+1
+1
+1
+1
+1
+1
+1
+-- !result
+select json_exists(j1, "d") from js1 order by v2;
+-- result:
+1
+1
+1
+1
+1
+1
+1
+1
+1
+1
+1
+-- !result
+select json_exists(j1, "e") from js1 order by v2;
+-- result:
+1
+1
+1
+1
+1
+1
+1
+1
+1
+1
+1
+-- !result
+select json_length(j1, "a") from js1 order by v2;
+-- result:
+1
+1
+1
+1
+1
+1
+1
+1
+1
+1
+1
+-- !result
+select json_length(j1, "b") from js1 order by v2;
+-- result:
+1
+1
+1
+1
+1
+1
+1
+1
+1
+1
+1
+-- !result
+select json_length(j1, "c") from js1 order by v2;
+-- result:
+1
+1
+1
+1
+1
+1
+1
+1
+1
+1
+1
+-- !result
+select json_length(j1, "d") from js1 order by v2;
+-- result:
+1
+1
+1
+1
+1
+1
+1
+1
+1
+1
+1
+-- !result
+select json_length(j1, "e") from js1 order by v2;
+-- result:
+4
+2
+1
+1
+1
+1
+2
+1
+1
+1
+4
+-- !result
+select json_exists(j1, "a"), get_json_bool(j1, "a") from js1 order by v2;
+-- result:
+1	1
+1	0
+1	1
+1	1
+1	1
+1	1
+1	0
+1	1
+1	0
+1	0
+1	0
+-- !result
+select json_exists(j1, "b"), get_json_int(j1, "b") from js1 order by v2;
+-- result:
+1	1
+1	2
+1	3
+1	4
+1	5
+1	6
+1	7
+1	8
+1	0
+1	-1
+1	9
+-- !result
+select json_exists(j1, "c"), get_json_double(j1, "c") from js1 order by v2;
+-- result:
+1	None
+1	None
+1	None
+1	234.234
+1	1233.0
+1	0.0
+1	None
+1	None
+1	None
+1	None
+1	None
+-- !result
+select json_exists(j1, "d"), get_json_string(j1, "d") from js1 order by v2;
+-- result:
+1	1210.01
+1	2220.02
+1	3230.03
+1	4240.04
+1	5250.05
+1	6260.06
+1	7270.07
+1	8280.08
+1	0
+1	-1.123
+1	9290.09
+-- !result
+select json_exists(j1, "e"), json_query(j1, "e") from js1 order by v2;
+-- result:
+1	[1, 2, 3, 4]
+1	{"e1": 1, "e2": 3}
+1	"asdf"
+1	123123
+1	"zxcvzvxc"
+1	null
+1	{"e1": 4, "e2": 5}
+1	"0.000"
+1	true
+1	"false"
+1	[1, 2, 3, 4]
+-- !result
+select json_exists(j1, "a"), get_json_string(j1, "a") from js1 order by v2;
+-- result:
+1	true
+1	false
+1	true
+1	true
+1	true
+1	true
+1	false
+1	true
+1	false
+1	false
+1	false
+-- !result
+select json_exists(j1, "b"), get_json_double(j1, "b") from js1 order by v2;
+-- result:
+1	1.0
+1	2.0
+1	3.0
+1	4.0
+1	5.0
+1	6.0
+1	7.0
+1	8.0
+1	0.0
+1	-1.0
+1	9.0
+-- !result
+select json_exists(j1, "c"), get_json_int(j1, "c") from js1 order by v2;
+-- result:
+1	None
+1	None
+1	None
+1	None
+1	1233
+1	0
+1	None
+1	None
+1	None
+1	None
+1	None
+-- !result
+select json_exists(j1, "d"), json_query(j1, "d") from js1 order by v2;
+-- result:
+1	1210.01
+1	2220.02
+1	3230.03
+1	4240.04
+1	5250.05
+1	6260.06
+1	7270.07
+1	8280.08
+1	0
+1	-1.123
+1	9290.09
+-- !result
+select json_exists(j1, "e"), get_json_string(j1, "e") from js1 order by v2;
+-- result:
+1	[1, 2, 3, 4]
+1	{"e1": 1, "e2": 3}
+1	asdf
+1	123123
+1	zxcvzvxc
+1	null
+1	{"e1": 4, "e2": 5}
+1	0.000
+1	true
+1	false
+1	[1, 2, 3, 4]
+-- !result
+select json_length(j1, "a"), get_json_bool(j1, "a") from js1 order by v2;
+-- result:
+1	1
+1	0
+1	1
+1	1
+1	1
+1	1
+1	0
+1	1
+1	0
+1	0
+1	0
+-- !result
+select json_length(j1, "b"), get_json_int(j1, "b") from js1 order by v2;
+-- result:
+1	1
+1	2
+1	3
+1	4
+1	5
+1	6
+1	7
+1	8
+1	0
+1	-1
+1	9
+-- !result
+select json_length(j1, "c"), get_json_double(j1, "c") from js1 order by v2;
+-- result:
+1	None
+1	None
+1	None
+1	234.234
+1	1233.0
+1	0.0
+1	None
+1	None
+1	None
+1	None
+1	None
+-- !result
+select json_length(j1, "d"), get_json_string(j1, "d") from js1 order by v2;
+-- result:
+1	1210.01
+1	2220.02
+1	3230.03
+1	4240.04
+1	5250.05
+1	6260.06
+1	7270.07
+1	8280.08
+1	0
+1	-1.123
+1	9290.09
+-- !result
+select json_length(j1, "e"), json_query(j1, "e") from js1 order by v2;
+-- result:
+4	[1, 2, 3, 4]
+2	{"e1": 1, "e2": 3}
+1	"asdf"
+1	123123
+1	"zxcvzvxc"
+1	null
+2	{"e1": 4, "e2": 5}
+1	"0.000"
+1	true
+1	"false"
+4	[1, 2, 3, 4]
+-- !result
+select json_length(j1, "a"), get_json_string(j1, "a") from js1 order by v2;
+-- result:
+1	true
+1	false
+1	true
+1	true
+1	true
+1	true
+1	false
+1	true
+1	false
+1	false
+1	false
+-- !result
+select json_length(j1, "b"), get_json_double(j1, "b") from js1 order by v2;
+-- result:
+1	1.0
+1	2.0
+1	3.0
+1	4.0
+1	5.0
+1	6.0
+1	7.0
+1	8.0
+1	0.0
+1	-1.0
+1	9.0
+-- !result
+select json_length(j1, "c"), get_json_int(j1, "c") from js1 order by v2;
+-- result:
+1	None
+1	None
+1	None
+1	None
+1	1233
+1	0
+1	None
+1	None
+1	None
+1	None
+1	None
+-- !result
+select json_length(j1, "d"), json_query(j1, "d") from js1 order by v2;
+-- result:
+1	1210.01
+1	2220.02
+1	3230.03
+1	4240.04
+1	5250.05
+1	6260.06
+1	7270.07
+1	8280.08
+1	0
+1	-1.123
+1	9290.09
+-- !result
+select json_length(j1, "e"), get_json_string(j1, "e") from js1 order by v2;
+-- result:
+4	[1, 2, 3, 4]
+2	{"e1": 1, "e2": 3}
+1	asdf
+1	123123
+1	zxcvzvxc
+1	null
+2	{"e1": 4, "e2": 5}
+1	0.000
+1	true
+1	false
+4	[1, 2, 3, 4]
+-- !result
+-- name: test_cast_flat_json_with_type @system
+CREATE TABLE `js2` (
+  `v1` bigint(20) NULL COMMENT "",
+  `v2` int(11) NULL COMMENT "",
+  `j1` json NULL COMMENT ""
+) ENGINE=OLAP 
+DUPLICATE KEY(`v1`)
+COMMENT "OLAP"
+DISTRIBUTED BY HASH(`v1`) BUCKETS 1
+PROPERTIES (
+"replication_num" = "1",
+"in_memory" = "false",
+"enable_persistent_index" = "false",
+"replicated_storage" = "false",
+"fast_schema_evolution" = "true",
+"compression" = "LZ4"
+);
+-- result:
+[]
+-- !result
+insert into js2 values 
+(1,  11,  parse_json('{"a": true,   "b": 1.123, "c": "qwe",    "d": "asdfsfd",  "e":  [1,2,3,4]}')),
+(2,  22,  parse_json('{"a": false,  "b": 2,     "c": "asdf",   "d": 2220.020,  "e":  {"e1": 1, "e2": 3}}')),
+(3,  33,  parse_json('{"a": 3,      "b": 3,     "c": "qcve",   "d": 3230.030,  "e":  "asdf"}')),
+(4,  44,  parse_json('{"a": 5,      "b": 4,     "c": "qre",    "d": 4240.040,  "e":  123123}')),
+(5,  55,  parse_json('{"a": true,   "b": 5,     "c": "eeeasdfasdfsafsfasdfasdfasdfasfd",    "d": 5250.050,  "e":  "zxcvzvxc"}')),
+(6,  66,  parse_json('{"a": 6,      "b": 6.465, "c": "aqwe",   "d": 6260.060,  "e":  null}')),
+(7,  77,  parse_json('{"a": false,  "b": 7,     "c": "qwxve",  "d": 7270.070,  "e":  {"e1": 4, "e2": 5}}')),
+(8,  88,  parse_json('{"a": true,   "b": 8,     "c": "qw1e",   "d": 8280.080,  "e":  [1,2,3,4]}')),
+(9,  99,  parse_json('{"a": false,  "b": 9,     "c": [1,23,456],   "d": 9290.090,  "e":  [1,2,3,4]}')),
+(10, 101, parse_json('{"a": false,  "b": 9, "c": "true",   "d": 9290.090,  "e":  [1,2,3,4]}')),
+(11, 102, parse_json('{"a": false,  "b": 9, "c": "false",  "d": 9290.090,  "e":  [1,2,3,4]}'));
+-- result:
+[]
+-- !result
+select j1->'a' from js2 order by v2;
+-- result:
+true
+false
+3
+5
+true
+6
+false
+true
+false
+false
+false
+-- !result
+select j1->'b' from js2 order by v2;
+-- result:
+1.123
+2
+3
+4
+5
+6.465
+7
+8
+9
+9
+9
+-- !result
+select j1->'c' from js2 order by v2;
+-- result:
+"qwe"
+"asdf"
+"qcve"
+"qre"
+"eeeasdfasdfsafsfasdfasdfasdfasfd"
+"aqwe"
+"qwxve"
+"qw1e"
+[1, 23, 456]
+"true"
+"false"
+-- !result
+select j1->'d' from js2 order by v2;
+-- result:
+"asdfsfd"
+2220.02
+3230.03
+4240.04
+5250.05
+6260.06
+7270.07
+8280.08
+9290.09
+9290.09
+9290.09
+-- !result
+select j1->'e' from js2 order by v2;
+-- result:
+[1, 2, 3, 4]
+{"e1": 1, "e2": 3}
+"asdf"
+123123
+"zxcvzvxc"
+null
+{"e1": 4, "e2": 5}
+[1, 2, 3, 4]
+[1, 2, 3, 4]
+[1, 2, 3, 4]
+[1, 2, 3, 4]
+-- !result
+select get_json_bool(j1, 'a')   from js2 order by v2;
+-- result:
+1
+0
+1
+1
+1
+1
+0
+1
+0
+0
+0
+-- !result
+select get_json_int(j1, 'a')    from js2 order by v2;
+-- result:
+1
+0
+3
+5
+1
+6
+0
+1
+0
+0
+0
+-- !result
+select get_json_string(j1, 'a') from js2 order by v2;
+-- result:
+true
+false
+3
+5
+true
+6
+false
+true
+false
+false
+false
+-- !result
+select get_json_double(j1, 'a') from js2 order by v2;
+-- result:
+1.0
+0.0
+3.0
+5.0
+1.0
+6.0
+0.0
+1.0
+0.0
+0.0
+0.0
+-- !result
+select json_query(j1, 'a')      from js2 order by v2;
+-- result:
+true
+false
+3
+5
+true
+6
+false
+true
+false
+false
+false
+-- !result
+select get_json_bool(j1, 'b')   from js2 order by v2;
+-- result:
+1
+1
+1
+1
+1
+1
+1
+1
+1
+1
+1
+-- !result
+select get_json_int(j1, 'b')    from js2 order by v2;
+-- result:
+1
+2
+3
+4
+5
+6
+7
+8
+9
+9
+9
+-- !result
+select get_json_string(j1, 'b') from js2 order by v2;
+-- result:
+1.123
+2
+3
+4
+5
+6.465
+7
+8
+9
+9
+9
+-- !result
+select get_json_double(j1, 'b') from js2 order by v2;
+-- result:
+1.123
+2.0
+3.0
+4.0
+5.0
+6.465
+7.0
+8.0
+9.0
+9.0
+9.0
+-- !result
+select json_query(j1, 'b')      from js2 order by v2;
+-- result:
+1.123
+2
+3
+4
+5
+6.465
+7
+8
+9
+9
+9
+-- !result
+select get_json_bool(j1, 'c')   from js2 order by v2;
+-- result:
+None
+None
+None
+None
+None
+None
+None
+None
+None
+1
+0
+-- !result
+select get_json_int(j1, 'c')    from js2 order by v2;
+-- result:
+None
+None
+None
+None
+None
+None
+None
+None
+None
+None
+None
+-- !result
+select get_json_string(j1, 'c') from js2 order by v2;
+-- result:
+qwe
+asdf
+qcve
+qre
+eeeasdfasdfsafsfasdfasdfasdfasfd
+aqwe
+qwxve
+qw1e
+[1, 23, 456]
+true
+false
+-- !result
+select get_json_double(j1, 'c') from js2 order by v2;
+-- result:
+None
+None
+None
+None
+None
+None
+None
+None
+None
+None
+None
+-- !result
+select json_query(j1, 'c')      from js2 order by v2;
+-- result:
+"qwe"
+"asdf"
+"qcve"
+"qre"
+"eeeasdfasdfsafsfasdfasdfasdfasfd"
+"aqwe"
+"qwxve"
+"qw1e"
+[1, 23, 456]
+"true"
+"false"
+-- !result
+select get_json_bool(j1, 'd')   from js2 order by v2;
+-- result:
+None
+1
+1
+1
+1
+1
+1
+1
+1
+1
+1
+-- !result
+select get_json_int(j1, 'd')    from js2 order by v2;
+-- result:
+None
+2220
+3230
+4240
+5250
+6260
+7270
+8280
+9290
+9290
+9290
+-- !result
+select get_json_string(j1, 'd') from js2 order by v2;
+-- result:
+asdfsfd
+2220.02
+3230.03
+4240.04
+5250.05
+6260.06
+7270.07
+8280.08
+9290.09
+9290.09
+9290.09
+-- !result
+select get_json_double(j1, 'd') from js2 order by v2;
+-- result:
+None
+2220.02
+3230.03
+4240.04
+5250.05
+6260.06
+7270.07
+8280.08
+9290.09
+9290.09
+9290.09
+-- !result
+select json_query(j1, 'd')      from js2 order by v2;
+-- result:
+"asdfsfd"
+2220.02
+3230.03
+4240.04
+5250.05
+6260.06
+7270.07
+8280.08
+9290.09
+9290.09
+9290.09
+-- !result
+select get_json_bool(j1, "a"), get_json_double(j1, "a") from js2 order by v2;
+-- result:
+1	1.0
+0	0.0
+1	3.0
+1	5.0
+1	1.0
+1	6.0
+0	0.0
+1	1.0
+0	0.0
+0	0.0
+0	0.0
+-- !result
+select get_json_bool(j1, "a"), json_query(j1, "a")      from js2 order by v2;
+-- result:
+1	true
+0	false
+1	3
+1	5
+1	true
+1	6
+0	false
+1	true
+0	false
+0	false
+0	false
+-- !result
+select get_json_string(j1, "a"), get_json_int(j1, "a")  from js2 order by v2;
+-- result:
+true	1
+false	0
+3	3
+5	5
+true	1
+6	6
+false	0
+true	1
+false	0
+false	0
+false	0
+-- !result
+select get_json_int(j1, "b"), get_json_bool(j1, "b")    from js2 order by v2;
+-- result:
+1	1
+2	1
+3	1
+4	1
+5	1
+6	1
+7	1
+8	1
+9	1
+9	1
+9	1
+-- !result
+select get_json_int(j1, "b"), get_json_string(j1, "b")  from js2 order by v2;
+-- result:
+1	1.123
+2	2
+3	3
+4	4
+5	5
+6	6.465
+7	7
+8	8
+9	9
+9	9
+9	9
+-- !result
+select get_json_double(j1, "b"), json_query(j1, "b")    from js2 order by v2;
+-- result:
+1.123	1.123
+2.0	2
+3.0	3
+4.0	4
+5.0	5
+6.465	6.465
+7.0	7
+8.0	8
+9.0	9
+9.0	9
+9.0	9
+-- !result
+select get_json_double(j1, "c"), get_json_double(j1, "c")   from js2 order by v2;
+-- result:
+None	None
+None	None
+None	None
+None	None
+None	None
+None	None
+None	None
+None	None
+None	None
+None	None
+None	None
+-- !result
+select json_query(j1, "c"), get_json_string(j1, "c")        from js2 order by v2;
+-- result:
+"qwe"	qwe
+"asdf"	asdf
+"qcve"	qcve
+"qre"	qre
+"eeeasdfasdfsafsfasdfasdfasdfasfd"	eeeasdfasdfsafsfasdfasdfasdfasfd
+"aqwe"	aqwe
+"qwxve"	qwxve
+"qw1e"	qw1e
+[1, 23, 456]	[1, 23, 456]
+"true"	true
+"false"	false
+-- !result
+select get_json_int(j1, "c"), get_json_string(j1, "c")      from js2 order by v2;
+-- result:
+None	qwe
+None	asdf
+None	qcve
+None	qre
+None	eeeasdfasdfsafsfasdfasdfasdfasfd
+None	aqwe
+None	qwxve
+None	qw1e
+None	[1, 23, 456]
+None	true
+None	false
+-- !result
+select get_json_double(j1, "d"), get_json_int(j1, "d") from js2 order by v2;
+-- result:
+None	None
+2220.02	2220
+3230.03	3230
+4240.04	4240
+5250.05	5250
+6260.06	6260
+7270.07	7270
+8280.08	8280
+9290.09	9290
+9290.09	9290
+9290.09	9290
+-- !result
+select get_json_string(j1, "d"), get_json_int(j1, "d") from js2 order by v2;
+-- result:
+asdfsfd	None
+2220.02	2220
+3230.03	3230
+4240.04	4240
+5250.05	5250
+6260.06	6260
+7270.07	7270
+8280.08	8280
+9290.09	9290
+9290.09	9290
+9290.09	9290
+-- !result
+select get_json_string(j1, "d"), json_query(j1, "d")   from js2 order by v2;
+-- result:
+asdfsfd	"asdfsfd"
+2220.02	2220.02
+3230.03	3230.03
+4240.04	4240.04
+5250.05	5250.05
+6260.06	6260.06
+7270.07	7270.07
+8280.08	8280.08
+9290.09	9290.09
+9290.09	9290.09
+9290.09	9290.09
+-- !result
+select get_json_string(j1, "e"), json_query(j1, "e")   from js2 order by v2;
+-- result:
+[1, 2, 3, 4]	[1, 2, 3, 4]
+{"e1": 1, "e2": 3}	{"e1": 1, "e2": 3}
+asdf	"asdf"
+123123	123123
+zxcvzvxc	"zxcvzvxc"
+null	null
+{"e1": 4, "e2": 5}	{"e1": 4, "e2": 5}
+[1, 2, 3, 4]	[1, 2, 3, 4]
+[1, 2, 3, 4]	[1, 2, 3, 4]
+[1, 2, 3, 4]	[1, 2, 3, 4]
+[1, 2, 3, 4]	[1, 2, 3, 4]
+-- !result
+select get_json_int(j1, "e"), get_json_double(j1, "e") from js2 order by v2;
+-- result:
+None	None
+None	None
+None	None
+123123	123123.0
+None	None
+None	None
+None	None
+None	None
+None	None
+None	None
+None	None
+-- !result
+select get_json_int(j1, "e"), json_query(j1, "e")      from js2 order by v2;
+-- result:
+None	[1, 2, 3, 4]
+None	{"e1": 1, "e2": 3}
+None	"asdf"
+123123	123123
+None	"zxcvzvxc"
+None	null
+None	{"e1": 4, "e2": 5}
+None	[1, 2, 3, 4]
+None	[1, 2, 3, 4]
+None	[1, 2, 3, 4]
+None	[1, 2, 3, 4]
+-- !result
+select json_exists(j1, "a") from js2 order by v2;
+-- result:
+1
+1
+1
+1
+1
+1
+1
+1
+1
+1
+1
+-- !result
+select json_exists(j1, "b") from js2 order by v2;
+-- result:
+1
+1
+1
+1
+1
+1
+1
+1
+1
+1
+1
+-- !result
+select json_exists(j1, "c") from js2 order by v2;
+-- result:
+1
+1
+1
+1
+1
+1
+1
+1
+1
+1
+1
+-- !result
+select json_exists(j1, "d") from js2 order by v2;
+-- result:
+1
+1
+1
+1
+1
+1
+1
+1
+1
+1
+1
+-- !result
+select json_exists(j1, "e") from js2 order by v2;
+-- result:
+1
+1
+1
+1
+1
+1
+1
+1
+1
+1
+1
+-- !result
+select json_length(j1, "a") from js2 order by v2;
+-- result:
+1
+1
+1
+1
+1
+1
+1
+1
+1
+1
+1
+-- !result
+select json_length(j1, "b") from js2 order by v2;
+-- result:
+1
+1
+1
+1
+1
+1
+1
+1
+1
+1
+1
+-- !result
+select json_length(j1, "c") from js2 order by v2;
+-- result:
+1
+1
+1
+1
+1
+1
+1
+1
+3
+1
+1
+-- !result
+select json_length(j1, "d") from js2 order by v2;
+-- result:
+1
+1
+1
+1
+1
+1
+1
+1
+1
+1
+1
+-- !result
+select json_length(j1, "e") from js2 order by v2;
+-- result:
+4
+2
+1
+1
+1
+1
+2
+4
+4
+4
+4
+-- !result
+select json_exists(j1, "a"), get_json_bool(j1, "a") from js2 order by v2;
+-- result:
+1	1
+1	0
+1	1
+1	1
+1	1
+1	1
+1	0
+1	1
+1	0
+1	0
+1	0
+-- !result
+select json_exists(j1, "b"), get_json_int(j1, "b") from js2 order by v2;
+-- result:
+1	1
+1	2
+1	3
+1	4
+1	5
+1	6
+1	7
+1	8
+1	9
+1	9
+1	9
+-- !result
+select json_exists(j1, "c"), get_json_double(j1, "c") from js2 order by v2;
+-- result:
+1	None
+1	None
+1	None
+1	None
+1	None
+1	None
+1	None
+1	None
+1	None
+1	None
+1	None
+-- !result
+select json_exists(j1, "d"), get_json_string(j1, "d") from js2 order by v2;
+-- result:
+1	asdfsfd
+1	2220.02
+1	3230.03
+1	4240.04
+1	5250.05
+1	6260.06
+1	7270.07
+1	8280.08
+1	9290.09
+1	9290.09
+1	9290.09
+-- !result
+select json_exists(j1, "e"), json_query(j1, "e") from js2 order by v2;
+-- result:
+1	[1, 2, 3, 4]
+1	{"e1": 1, "e2": 3}
+1	"asdf"
+1	123123
+1	"zxcvzvxc"
+1	null
+1	{"e1": 4, "e2": 5}
+1	[1, 2, 3, 4]
+1	[1, 2, 3, 4]
+1	[1, 2, 3, 4]
+1	[1, 2, 3, 4]
+-- !result
+select json_exists(j1, "a"), get_json_string(j1, "a") from js2 order by v2;
+-- result:
+1	true
+1	false
+1	3
+1	5
+1	true
+1	6
+1	false
+1	true
+1	false
+1	false
+1	false
+-- !result
+select json_exists(j1, "b"), get_json_double(j1, "b") from js2 order by v2;
+-- result:
+1	1.123
+1	2.0
+1	3.0
+1	4.0
+1	5.0
+1	6.465
+1	7.0
+1	8.0
+1	9.0
+1	9.0
+1	9.0
+-- !result
+select json_exists(j1, "c"), get_json_int(j1, "c") from js2 order by v2;
+-- result:
+1	None
+1	None
+1	None
+1	None
+1	None
+1	None
+1	None
+1	None
+1	None
+1	None
+1	None
+-- !result
+select json_exists(j1, "d"), json_query(j1, "d") from js2 order by v2;
+-- result:
+1	"asdfsfd"
+1	2220.02
+1	3230.03
+1	4240.04
+1	5250.05
+1	6260.06
+1	7270.07
+1	8280.08
+1	9290.09
+1	9290.09
+1	9290.09
+-- !result
+select json_exists(j1, "e"), get_json_string(j1, "e") from js2 order by v2;
+-- result:
+1	[1, 2, 3, 4]
+1	{"e1": 1, "e2": 3}
+1	asdf
+1	123123
+1	zxcvzvxc
+1	null
+1	{"e1": 4, "e2": 5}
+1	[1, 2, 3, 4]
+1	[1, 2, 3, 4]
+1	[1, 2, 3, 4]
+1	[1, 2, 3, 4]
+-- !result
+select json_length(j1, "a"), get_json_bool(j1, "a") from js2 order by v2;
+-- result:
+1	1
+1	0
+1	1
+1	1
+1	1
+1	1
+1	0
+1	1
+1	0
+1	0
+1	0
+-- !result
+select json_length(j1, "b"), get_json_int(j1, "b") from js2 order by v2;
+-- result:
+1	1
+1	2
+1	3
+1	4
+1	5
+1	6
+1	7
+1	8
+1	9
+1	9
+1	9
+-- !result
+select json_length(j1, "c"), get_json_double(j1, "c") from js2 order by v2;
+-- result:
+1	None
+1	None
+1	None
+1	None
+1	None
+1	None
+1	None
+1	None
+3	None
+1	None
+1	None
+-- !result
+select json_length(j1, "d"), get_json_string(j1, "d") from js2 order by v2;
+-- result:
+1	asdfsfd
+1	2220.02
+1	3230.03
+1	4240.04
+1	5250.05
+1	6260.06
+1	7270.07
+1	8280.08
+1	9290.09
+1	9290.09
+1	9290.09
+-- !result
+select json_length(j1, "e"), json_query(j1, "e") from js2 order by v2;
+-- result:
+4	[1, 2, 3, 4]
+2	{"e1": 1, "e2": 3}
+1	"asdf"
+1	123123
+1	"zxcvzvxc"
+1	null
+2	{"e1": 4, "e2": 5}
+4	[1, 2, 3, 4]
+4	[1, 2, 3, 4]
+4	[1, 2, 3, 4]
+4	[1, 2, 3, 4]
+-- !result
+select json_length(j1, "a"), get_json_string(j1, "a") from js2 order by v2;
+-- result:
+1	true
+1	false
+1	3
+1	5
+1	true
+1	6
+1	false
+1	true
+1	false
+1	false
+1	false
+-- !result
+select json_length(j1, "b"), get_json_double(j1, "b") from js2 order by v2;
+-- result:
+1	1.123
+1	2.0
+1	3.0
+1	4.0
+1	5.0
+1	6.465
+1	7.0
+1	8.0
+1	9.0
+1	9.0
+1	9.0
+-- !result
+select json_length(j1, "c"), get_json_int(j1, "c") from js2 order by v2;
+-- result:
+1	None
+1	None
+1	None
+1	None
+1	None
+1	None
+1	None
+1	None
+3	None
+1	None
+1	None
+-- !result
+select json_length(j1, "d"), json_query(j1, "d") from js2 order by v2;
+-- result:
+1	"asdfsfd"
+1	2220.02
+1	3230.03
+1	4240.04
+1	5250.05
+1	6260.06
+1	7270.07
+1	8280.08
+1	9290.09
+1	9290.09
+1	9290.09
+-- !result
+select json_length(j1, "e"), get_json_string(j1, "e") from js2 order by v2;
+-- result:
+4	[1, 2, 3, 4]
+2	{"e1": 1, "e2": 3}
+1	asdf
+1	123123
+1	zxcvzvxc
+1	null
+2	{"e1": 4, "e2": 5}
+4	[1, 2, 3, 4]
+4	[1, 2, 3, 4]
+4	[1, 2, 3, 4]
+4	[1, 2, 3, 4]
+-- !result
+-- name: test_null_flat_json @system
+CREATE TABLE `js3` (
+  `v1` bigint(20) NULL COMMENT "",
+  `v2` int(11) NULL COMMENT "",
+  `j1` json NULL COMMENT ""
+) ENGINE=OLAP 
+DUPLICATE KEY(`v1`)
+COMMENT "OLAP"
+DISTRIBUTED BY HASH(`v1`) BUCKETS 1
+PROPERTIES (
+"replication_num" = "1",
+"in_memory" = "false",
+"enable_persistent_index" = "false",
+"replicated_storage" = "false",
+"fast_schema_evolution" = "true",
+"compression" = "LZ4"
+);
+-- result:
+[]
+-- !result
+insert into js3 values 
+(1, 21, parse_json('{"a": null, "b": null,  "c": null, "e": null}')),
+(2, 22, parse_json('{"a": 123,  "b": "avx", "c": true, "e": null}')),
+(3, 23, parse_json('{"a": 234,  "b": "sse", "c": false, "e": null}'));
+-- result:
+[]
+-- !result
+select j1->'e' from js3 order by v2;
+-- result:
+null
+null
+null
+-- !result
+select get_json_string(j1, "e"), json_query(j1, "e")   from js3 order by v2;
+-- result:
+null	null
+null	null
+null	null
+-- !result
+select get_json_int(j1, "e"), get_json_double(j1, "e") from js3 order by v2;
+-- result:
+None	None
+None	None
+None	None
+-- !result
+select get_json_int(j1, "e"), json_query(j1, "e")      from js3 order by v2;
+-- result:
+None	null
+None	null
+None	null
+-- !result
+select json_exists(j1, "e") from js3 order by v2;
+-- result:
+1
+1
+1
+-- !result
+select json_length(j1, "e") from js3 order by v2;
+-- result:
+1
+1
+1
+-- !result
+select json_exists(j1, "e"), json_query(j1, "e") from js3 order by v2;
+-- result:
+1	null
+1	null
+1	null
+-- !result
+select json_exists(j1, "e"), get_json_string(j1, "e") from js3 order by v2;
+-- result:
+1	null
+1	null
+1	null
+-- !result
+select json_length(j1, "e"), json_query(j1, "e") from js3 order by v2;
+-- result:
+1	null
+1	null
+1	null
+-- !result
+select json_length(j1, "e"), get_json_string(j1, "e") from js3 order by v2;
+-- result:
+1	null
+1	null
+1	null
+-- !result
+select j1->'d' from js3 order by v2;
+-- result:
+None
+None
+None
+-- !result
+select get_json_string(j1, "d"), json_query(j1, "d")   from js3 order by v2;
+-- result:
+None	None
+None	None
+None	None
+-- !result
+select get_json_int(j1, "d"), get_json_double(j1, "d") from js3 order by v2;
+-- result:
+None	None
+None	None
+None	None
+-- !result
+select get_json_int(j1, "d"), json_query(j1, "d")      from js3 order by v2;
+-- result:
+None	None
+None	None
+None	None
+-- !result
+select json_exists(j1, "d") from js3 order by v2;
+-- result:
+0
+0
+0
+-- !result
+select json_length(j1, "d") from js3 order by v2;
+-- result:
+0
+0
+0
+-- !result
+select json_exists(j1, "d"), json_query(j1, "d") from js3 order by v2;
+-- result:
+0	None
+0	None
+0	None
+-- !result
+select json_exists(j1, "d"), get_json_string(j1, "d") from js3 order by v2;
+-- result:
+0	None
+0	None
+0	None
+-- !result
+select json_length(j1, "d"), json_query(j1, "d") from js3 order by v2;
+-- result:
+0	None
+0	None
+0	None
+-- !result
+select json_length(j1, "d"), get_json_string(j1, "d") from js3 order by v2;
+-- result:
+0	None
+0	None
+0	None
+-- !result
+select j1->"a" from js3 order by v2;
+-- result:
+null
+123
+234
+-- !result
+select get_json_string(j1, "a"), json_query(j1, "a")   from js3 order by v2;
+-- result:
+null	null
+123	123
+234	234
+-- !result
+select get_json_int(j1, "a"), get_json_double(j1, "a") from js3 order by v2;
+-- result:
+None	None
+123	123.0
+234	234.0
+-- !result
+select get_json_int(j1, "a"), json_query(j1, "a")      from js3 order by v2;
+-- result:
+None	null
+123	123
+234	234
+-- !result
+select json_exists(j1, "a") from js3 order by v2;
+-- result:
+1
+1
+1
+-- !result
+select json_length(j1, "a") from js3 order by v2;
+-- result:
+1
+1
+1
+-- !result
+select json_exists(j1, "a"), json_query(j1, "a") from js3 order by v2;
+-- result:
+1	null
+1	123
+1	234
+-- !result
+select json_exists(j1, "a"), get_json_string(j1, "a") from js3 order by v2;
+-- result:
+1	null
+1	123
+1	234
+-- !result
+select json_length(j1, "a"), json_query(j1, "a") from js3 order by v2;
+-- result:
+1	null
+1	123
+1	234
+-- !result
+select json_length(j1, "a"), get_json_string(j1, "a") from js3 order by v2;
+-- result:
+1	null
+1	123
+1	234
+-- !result
+select j1->"b" from js3 order by v2;
+-- result:
+null
+"avx"
+"sse"
+-- !result
+select get_json_string(j1, "b"), json_query(j1, "b")   from js3 order by v2;
+-- result:
+null	null
+avx	"avx"
+sse	"sse"
+-- !result
+select get_json_int(j1, "b"), get_json_double(j1, "b") from js3 order by v2;
+-- result:
+None	None
+None	None
+None	None
+-- !result
+select get_json_int(j1, "b"), json_query(j1, "b")      from js3 order by v2;
+-- result:
+None	null
+None	"avx"
+None	"sse"
+-- !result
+select json_exists(j1, "b") from js3 order by v2;
+-- result:
+1
+1
+1
+-- !result
+select json_length(j1, "b") from js3 order by v2;
+-- result:
+1
+1
+1
+-- !result
+select json_exists(j1, "b"), json_query(j1, "b") from js3 order by v2;
+-- result:
+1	null
+1	"avx"
+1	"sse"
+-- !result
+select json_exists(j1, "b"), get_json_string(j1, "b") from js3 order by v2;
+-- result:
+1	null
+1	avx
+1	sse
+-- !result
+select json_length(j1, "b"), json_query(j1, "b") from js3 order by v2;
+-- result:
+1	null
+1	"avx"
+1	"sse"
+-- !result
+select json_length(j1, "b"), get_json_string(j1, "b") from js3 order by v2;
+-- result:
+1	null
+1	avx
+1	sse
+-- !result
+select j1->"c" from js3 order by v2;
+-- result:
+null
+true
+false
+-- !result
+select get_json_string(j1, "c"), json_query(j1, "c")   from js3 order by v2;
+-- result:
+null	null
+true	true
+false	false
+-- !result
+select get_json_int(j1, "c"), get_json_double(j1, "c") from js3 order by v2;
+-- result:
+None	None
+1	1.0
+0	0.0
+-- !result
+select get_json_int(j1, "c"), json_query(j1, "c")      from js3 order by v2;
+-- result:
+None	null
+1	true
+0	false
+-- !result
+select json_exists(j1, "c") from js3 order by v2;
+-- result:
+1
+1
+1
+-- !result
+select json_length(j1, "c") from js3 order by v2;
+-- result:
+1
+1
+1
+-- !result
+select json_exists(j1, "c"), json_query(j1, "c") from js3 order by v2;
+-- result:
+1	null
+1	true
+1	false
+-- !result
+select json_exists(j1, "c"), get_json_string(j1, "c") from js3 order by v2;
+-- result:
+1	null
+1	true
+1	false
+-- !result
+select json_length(j1, "c"), json_query(j1, "c") from js3 order by v2;
+-- result:
+1	null
+1	true
+1	false
+-- !result
+select json_length(j1, "c"), get_json_string(j1, "c") from js3 order by v2;
+-- result:
+1	null
+1	true
+1	false
+-- !result

--- a/test/sql/test_semi/R/test_invalid_flat_json
+++ b/test/sql/test_semi/R/test_invalid_flat_json
@@ -40,8 +40,8 @@ None	None	None
 -- !result
 select JSON_EXISTS(j1, "$.key2"), JSON_EXISTS(j1, "$.key2.key3") from js1 order by v1 limit 2;
 -- result:
-0	None
-0	None
+0	0
+0	0
 -- !result
 select JSON_LENGTH(j1, "$.key2"), JSON_LENGTH(j1, "$.key3"), JSON_LENGTH(j1, "$.key4") from js1 order by v1 limit 2;
 -- result:

--- a/test/sql/test_semi/T/test_flat_json_with_type
+++ b/test/sql/test_semi/T/test_flat_json_with_type
@@ -1,0 +1,315 @@
+-- name: test_normal_flat_json_with_type @system
+
+CREATE TABLE `js1` (
+  `v1` bigint(20) NULL COMMENT "",
+  `v2` int(11) NULL COMMENT "",
+  `j1` json NULL COMMENT ""
+) ENGINE=OLAP 
+DUPLICATE KEY(`v1`)
+COMMENT "OLAP"
+DISTRIBUTED BY HASH(`v1`) BUCKETS 1
+PROPERTIES (
+"replication_num" = "1",
+"in_memory" = "false",
+"enable_persistent_index" = "false",
+"replicated_storage" = "false",
+"fast_schema_evolution" = "true",
+"compression" = "LZ4"
+);
+
+insert into js1 values 
+(1,  11,  parse_json('{"a": true,   "b": 1, "c": "qwe",    "d": 1210.010,  "e":  [1,2,3,4]}')),
+(2,  22,  parse_json('{"a": false,  "b": 2, "c": "asdf",   "d": 2220.020,  "e":  {"e1": 1, "e2": 3}}')),
+(3,  33,  parse_json('{"a": true,   "b": 3, "c": "qcve",   "d": 3230.030,  "e":  "asdf"}')),
+(4,  44,  parse_json('{"a": true,   "b": 4, "c": "234.234",    "d": 4240.040,  "e":  123123}')),
+(5,  55,  parse_json('{"a": true,   "b": 5, "c": "1233",    "d": 5250.050,  "e":  "zxcvzvxc"}')),
+(6,  66,  parse_json('{"a": true,   "b": 6, "c": "0",   "d": 6260.060,  "e":  null}')),
+(7,  77,  parse_json('{"a": false,  "b": 7, "c": "vTp49OF2Ezc0RWJVN",  "d": 7270.070,  "e":  {"e1": 4, "e2": 5}}')),
+(8,  88,  parse_json('{"a": true,   "b": 8, "c": "qw1e",   "d": 8280.080,  "e":  "0.000"}')),
+(9,  99,  parse_json('{"a": false,  "b": 0, "c": "q123",   "d": 0.000,  "e":  true}')),
+(10, 101, parse_json('{"a": false,  "b": -1, "c": "true",   "d": -1.123,  "e":  "false"}')),
+(11, 102, parse_json('{"a": false,  "b": 9, "c": "false",  "d": 9290.090,  "e":  [1,2,3,4]}'));
+
+select j1->'a' from js1 order by v2;
+select j1->'b' from js1 order by v2;
+select j1->'c' from js1 order by v2;
+select j1->'d' from js1 order by v2;
+select j1->'e' from js1 order by v2;
+
+select get_json_bool(j1, 'a')   from js1 order by v2;
+select get_json_int(j1, 'a')    from js1 order by v2;
+select get_json_string(j1, 'a') from js1 order by v2;
+select get_json_double(j1, 'a') from js1 order by v2;
+select json_query(j1, 'a')      from js1 order by v2;
+
+select get_json_bool(j1, 'b')   from js1 order by v2;
+select get_json_int(j1, 'b')    from js1 order by v2;
+select get_json_string(j1, 'b') from js1 order by v2;
+select get_json_double(j1, 'b') from js1 order by v2;
+select json_query(j1, 'b')      from js1 order by v2;
+
+select get_json_bool(j1, 'c')   from js1 order by v2;
+select get_json_int(j1, 'c')    from js1 order by v2;
+select get_json_string(j1, 'c') from js1 order by v2;
+select get_json_double(j1, 'c') from js1 order by v2;
+select json_query(j1, 'c')      from js1 order by v2;
+
+select get_json_bool(j1, 'd')   from js1 order by v2;
+select get_json_int(j1, 'd')    from js1 order by v2;
+select get_json_string(j1, 'd') from js1 order by v2;
+select get_json_double(j1, 'd') from js1 order by v2;
+select json_query(j1, 'd')      from js1 order by v2;
+
+select get_json_bool(j1, "a"), get_json_double(j1, "a") from js1 order by v2;
+select get_json_bool(j1, "a"), json_query(j1, "a")      from js1 order by v2;
+select get_json_string(j1, "a"), get_json_int(j1, "a")  from js1 order by v2;
+
+select get_json_int(j1, "b"), get_json_bool(j1, "b")    from js1 order by v2;
+select get_json_int(j1, "b"), get_json_string(j1, "b")  from js1 order by v2;
+select get_json_double(j1, "b"), json_query(j1, "b")    from js1 order by v2;
+
+select get_json_double(j1, "c"), json_query(j1, "c")   from js1 order by v2;
+select json_query(j1, "c"), get_json_string(j1, "c")        from js1 order by v2;
+select get_json_int(j1, "c"), get_json_string(j1, "c")      from js1 order by v2;
+
+select get_json_double(j1, "d"), get_json_int(j1, "d") from js1 order by v2;
+select get_json_string(j1, "d"), get_json_int(j1, "d") from js1 order by v2;
+select get_json_string(j1, "d"), json_query(j1, "d")   from js1 order by v2;
+
+select get_json_string(j1, "e"), json_query(j1, "e")   from js1 order by v2;
+select get_json_int(j1, "e"), get_json_double(j1, "e") from js1 order by v2;
+select get_json_int(j1, "e"), json_query(j1, "e")      from js1 order by v2;
+
+select json_exists(j1, "a") from js1 order by v2;
+select json_exists(j1, "b") from js1 order by v2;
+select json_exists(j1, "c") from js1 order by v2;
+select json_exists(j1, "d") from js1 order by v2;
+select json_exists(j1, "e") from js1 order by v2;
+
+select json_length(j1, "a") from js1 order by v2;
+select json_length(j1, "b") from js1 order by v2;
+select json_length(j1, "c") from js1 order by v2;
+select json_length(j1, "d") from js1 order by v2;
+select json_length(j1, "e") from js1 order by v2;
+
+select json_exists(j1, "a"), get_json_bool(j1, "a") from js1 order by v2;
+select json_exists(j1, "b"), get_json_int(j1, "b") from js1 order by v2;
+select json_exists(j1, "c"), get_json_double(j1, "c") from js1 order by v2;
+select json_exists(j1, "d"), get_json_string(j1, "d") from js1 order by v2;
+select json_exists(j1, "e"), json_query(j1, "e") from js1 order by v2;
+
+select json_exists(j1, "a"), get_json_string(j1, "a") from js1 order by v2;
+select json_exists(j1, "b"), get_json_double(j1, "b") from js1 order by v2;
+select json_exists(j1, "c"), get_json_int(j1, "c") from js1 order by v2;
+select json_exists(j1, "d"), json_query(j1, "d") from js1 order by v2;
+select json_exists(j1, "e"), get_json_string(j1, "e") from js1 order by v2;
+
+select json_length(j1, "a"), get_json_bool(j1, "a") from js1 order by v2;
+select json_length(j1, "b"), get_json_int(j1, "b") from js1 order by v2;
+select json_length(j1, "c"), get_json_double(j1, "c") from js1 order by v2;
+select json_length(j1, "d"), get_json_string(j1, "d") from js1 order by v2;
+select json_length(j1, "e"), json_query(j1, "e") from js1 order by v2;
+
+select json_length(j1, "a"), get_json_string(j1, "a") from js1 order by v2;
+select json_length(j1, "b"), get_json_double(j1, "b") from js1 order by v2;
+select json_length(j1, "c"), get_json_int(j1, "c") from js1 order by v2;
+select json_length(j1, "d"), json_query(j1, "d") from js1 order by v2;
+select json_length(j1, "e"), get_json_string(j1, "e") from js1 order by v2;
+
+
+-- name: test_cast_flat_json_with_type @system
+CREATE TABLE `js2` (
+  `v1` bigint(20) NULL COMMENT "",
+  `v2` int(11) NULL COMMENT "",
+  `j1` json NULL COMMENT ""
+) ENGINE=OLAP 
+DUPLICATE KEY(`v1`)
+COMMENT "OLAP"
+DISTRIBUTED BY HASH(`v1`) BUCKETS 1
+PROPERTIES (
+"replication_num" = "1",
+"in_memory" = "false",
+"enable_persistent_index" = "false",
+"replicated_storage" = "false",
+"fast_schema_evolution" = "true",
+"compression" = "LZ4"
+);
+
+insert into js2 values 
+(1,  11,  parse_json('{"a": true,   "b": 1.123, "c": "qwe",    "d": "asdfsfd",  "e":  [1,2,3,4]}')),
+(2,  22,  parse_json('{"a": false,  "b": 2,     "c": "asdf",   "d": 2220.020,  "e":  {"e1": 1, "e2": 3}}')),
+(3,  33,  parse_json('{"a": 3,      "b": 3,     "c": "qcve",   "d": 3230.030,  "e":  "asdf"}')),
+(4,  44,  parse_json('{"a": 5,      "b": 4,     "c": "qre",    "d": 4240.040,  "e":  123123}')),
+(5,  55,  parse_json('{"a": true,   "b": 5,     "c": "eeeasdfasdfsafsfasdfasdfasdfasfd",    "d": 5250.050,  "e":  "zxcvzvxc"}')),
+(6,  66,  parse_json('{"a": 6,      "b": 6.465, "c": "aqwe",   "d": 6260.060,  "e":  null}')),
+(7,  77,  parse_json('{"a": false,  "b": 7,     "c": "qwxve",  "d": 7270.070,  "e":  {"e1": 4, "e2": 5}}')),
+(8,  88,  parse_json('{"a": true,   "b": 8,     "c": "qw1e",   "d": 8280.080,  "e":  [1,2,3,4]}')),
+(9,  99,  parse_json('{"a": false,  "b": 9,     "c": [1,23,456],   "d": 9290.090,  "e":  [1,2,3,4]}')),
+(10, 101, parse_json('{"a": false,  "b": 9, "c": "true",   "d": 9290.090,  "e":  [1,2,3,4]}')),
+(11, 102, parse_json('{"a": false,  "b": 9, "c": "false",  "d": 9290.090,  "e":  [1,2,3,4]}'));
+
+select j1->'a' from js2 order by v2;
+select j1->'b' from js2 order by v2;
+select j1->'c' from js2 order by v2;
+select j1->'d' from js2 order by v2;
+select j1->'e' from js2 order by v2;
+
+select get_json_bool(j1, 'a')   from js2 order by v2;
+select get_json_int(j1, 'a')    from js2 order by v2;
+select get_json_string(j1, 'a') from js2 order by v2;
+select get_json_double(j1, 'a') from js2 order by v2;
+select json_query(j1, 'a')      from js2 order by v2;
+
+select get_json_bool(j1, 'b')   from js2 order by v2;
+select get_json_int(j1, 'b')    from js2 order by v2;
+select get_json_string(j1, 'b') from js2 order by v2;
+select get_json_double(j1, 'b') from js2 order by v2;
+select json_query(j1, 'b')      from js2 order by v2;
+
+select get_json_bool(j1, 'c')   from js2 order by v2;
+select get_json_int(j1, 'c')    from js2 order by v2;
+select get_json_string(j1, 'c') from js2 order by v2;
+select get_json_double(j1, 'c') from js2 order by v2;
+select json_query(j1, 'c')      from js2 order by v2;
+
+select get_json_bool(j1, 'd')   from js2 order by v2;
+select get_json_int(j1, 'd')    from js2 order by v2;
+select get_json_string(j1, 'd') from js2 order by v2;
+select get_json_double(j1, 'd') from js2 order by v2;
+select json_query(j1, 'd')      from js2 order by v2;
+
+select get_json_bool(j1, "a"), get_json_double(j1, "a") from js2 order by v2;
+select get_json_bool(j1, "a"), json_query(j1, "a")      from js2 order by v2;
+select get_json_string(j1, "a"), get_json_int(j1, "a")  from js2 order by v2;
+
+select get_json_int(j1, "b"), get_json_bool(j1, "b")    from js2 order by v2;
+select get_json_int(j1, "b"), get_json_string(j1, "b")  from js2 order by v2;
+select get_json_double(j1, "b"), json_query(j1, "b")    from js2 order by v2;
+
+select get_json_double(j1, "c"), get_json_double(j1, "c")   from js2 order by v2;
+select json_query(j1, "c"), get_json_string(j1, "c")        from js2 order by v2;
+select get_json_int(j1, "c"), get_json_string(j1, "c")      from js2 order by v2;
+
+select get_json_double(j1, "d"), get_json_int(j1, "d") from js2 order by v2;
+select get_json_string(j1, "d"), get_json_int(j1, "d") from js2 order by v2;
+select get_json_string(j1, "d"), json_query(j1, "d")   from js2 order by v2;
+
+select get_json_string(j1, "e"), json_query(j1, "e")   from js2 order by v2;
+select get_json_int(j1, "e"), get_json_double(j1, "e") from js2 order by v2;
+select get_json_int(j1, "e"), json_query(j1, "e")      from js2 order by v2;
+
+select json_exists(j1, "a") from js2 order by v2;
+select json_exists(j1, "b") from js2 order by v2;
+select json_exists(j1, "c") from js2 order by v2;
+select json_exists(j1, "d") from js2 order by v2;
+select json_exists(j1, "e") from js2 order by v2;
+
+select json_length(j1, "a") from js2 order by v2;
+select json_length(j1, "b") from js2 order by v2;
+select json_length(j1, "c") from js2 order by v2;
+select json_length(j1, "d") from js2 order by v2;
+select json_length(j1, "e") from js2 order by v2;
+
+select json_exists(j1, "a"), get_json_bool(j1, "a") from js2 order by v2;
+select json_exists(j1, "b"), get_json_int(j1, "b") from js2 order by v2;
+select json_exists(j1, "c"), get_json_double(j1, "c") from js2 order by v2;
+select json_exists(j1, "d"), get_json_string(j1, "d") from js2 order by v2;
+select json_exists(j1, "e"), json_query(j1, "e") from js2 order by v2;
+
+select json_exists(j1, "a"), get_json_string(j1, "a") from js2 order by v2;
+select json_exists(j1, "b"), get_json_double(j1, "b") from js2 order by v2;
+select json_exists(j1, "c"), get_json_int(j1, "c") from js2 order by v2;
+select json_exists(j1, "d"), json_query(j1, "d") from js2 order by v2;
+select json_exists(j1, "e"), get_json_string(j1, "e") from js2 order by v2;
+
+select json_length(j1, "a"), get_json_bool(j1, "a") from js2 order by v2;
+select json_length(j1, "b"), get_json_int(j1, "b") from js2 order by v2;
+select json_length(j1, "c"), get_json_double(j1, "c") from js2 order by v2;
+select json_length(j1, "d"), get_json_string(j1, "d") from js2 order by v2;
+select json_length(j1, "e"), json_query(j1, "e") from js2 order by v2;
+
+select json_length(j1, "a"), get_json_string(j1, "a") from js2 order by v2;
+select json_length(j1, "b"), get_json_double(j1, "b") from js2 order by v2;
+select json_length(j1, "c"), get_json_int(j1, "c") from js2 order by v2;
+select json_length(j1, "d"), json_query(j1, "d") from js2 order by v2;
+select json_length(j1, "e"), get_json_string(j1, "e") from js2 order by v2;
+
+
+-- name: test_null_flat_json @system
+CREATE TABLE `js3` (
+  `v1` bigint(20) NULL COMMENT "",
+  `v2` int(11) NULL COMMENT "",
+  `j1` json NULL COMMENT ""
+) ENGINE=OLAP 
+DUPLICATE KEY(`v1`)
+COMMENT "OLAP"
+DISTRIBUTED BY HASH(`v1`) BUCKETS 1
+PROPERTIES (
+"replication_num" = "1",
+"in_memory" = "false",
+"enable_persistent_index" = "false",
+"replicated_storage" = "false",
+"fast_schema_evolution" = "true",
+"compression" = "LZ4"
+);
+
+insert into js3 values 
+(1, 21, parse_json('{"a": null, "b": null,  "c": null, "e": null}')),
+(2, 22, parse_json('{"a": 123,  "b": "avx", "c": true, "e": null}')),
+(3, 23, parse_json('{"a": 234,  "b": "sse", "c": false, "e": null}'));
+
+select j1->'e' from js3 order by v2;
+select get_json_string(j1, "e"), json_query(j1, "e")   from js3 order by v2;
+select get_json_int(j1, "e"), get_json_double(j1, "e") from js3 order by v2;
+select get_json_int(j1, "e"), json_query(j1, "e")      from js3 order by v2;
+select json_exists(j1, "e") from js3 order by v2;
+select json_length(j1, "e") from js3 order by v2;
+select json_exists(j1, "e"), json_query(j1, "e") from js3 order by v2;
+select json_exists(j1, "e"), get_json_string(j1, "e") from js3 order by v2;
+select json_length(j1, "e"), json_query(j1, "e") from js3 order by v2;
+select json_length(j1, "e"), get_json_string(j1, "e") from js3 order by v2;
+
+select j1->'d' from js3 order by v2;
+select get_json_string(j1, "d"), json_query(j1, "d")   from js3 order by v2;
+select get_json_int(j1, "d"), get_json_double(j1, "d") from js3 order by v2;
+select get_json_int(j1, "d"), json_query(j1, "d")      from js3 order by v2;
+select json_exists(j1, "d") from js3 order by v2;
+select json_length(j1, "d") from js3 order by v2;
+select json_exists(j1, "d"), json_query(j1, "d") from js3 order by v2;
+select json_exists(j1, "d"), get_json_string(j1, "d") from js3 order by v2;
+select json_length(j1, "d"), json_query(j1, "d") from js3 order by v2;
+select json_length(j1, "d"), get_json_string(j1, "d") from js3 order by v2;
+
+
+select j1->"a" from js3 order by v2;
+select get_json_string(j1, "a"), json_query(j1, "a")   from js3 order by v2;
+select get_json_int(j1, "a"), get_json_double(j1, "a") from js3 order by v2;
+select get_json_int(j1, "a"), json_query(j1, "a")      from js3 order by v2;
+select json_exists(j1, "a") from js3 order by v2;
+select json_length(j1, "a") from js3 order by v2;
+select json_exists(j1, "a"), json_query(j1, "a") from js3 order by v2;
+select json_exists(j1, "a"), get_json_string(j1, "a") from js3 order by v2;
+select json_length(j1, "a"), json_query(j1, "a") from js3 order by v2;
+select json_length(j1, "a"), get_json_string(j1, "a") from js3 order by v2;
+
+select j1->"b" from js3 order by v2;
+select get_json_string(j1, "b"), json_query(j1, "b")   from js3 order by v2;
+select get_json_int(j1, "b"), get_json_double(j1, "b") from js3 order by v2;
+select get_json_int(j1, "b"), json_query(j1, "b")      from js3 order by v2;
+select json_exists(j1, "b") from js3 order by v2;
+select json_length(j1, "b") from js3 order by v2;
+select json_exists(j1, "b"), json_query(j1, "b") from js3 order by v2;
+select json_exists(j1, "b"), get_json_string(j1, "b") from js3 order by v2;
+select json_length(j1, "b"), json_query(j1, "b") from js3 order by v2;
+select json_length(j1, "b"), get_json_string(j1, "b") from js3 order by v2;
+
+select j1->"c" from js3 order by v2;
+select get_json_string(j1, "c"), json_query(j1, "c")   from js3 order by v2;
+select get_json_int(j1, "c"), get_json_double(j1, "c") from js3 order by v2;
+select get_json_int(j1, "c"), json_query(j1, "c")      from js3 order by v2;
+select json_exists(j1, "c") from js3 order by v2;
+select json_length(j1, "c") from js3 order by v2;
+select json_exists(j1, "c"), json_query(j1, "c") from js3 order by v2;
+select json_exists(j1, "c"), get_json_string(j1, "c") from js3 order by v2;
+select json_length(j1, "c"), json_query(j1, "c") from js3 order by v2;
+select json_length(j1, "c"), get_json_string(j1, "c") from js3 order by v2;

--- a/test/sql/test_semi/T/test_invalid_flat_json
+++ b/test/sql/test_semi/T/test_invalid_flat_json
@@ -44,3 +44,5 @@ select json_object('"1"')->"1", json_object('"1"')->"1" is null;
 select j1, j1->"1", j1->"1" is null from js1 order by v1, v2;
 
 select json_object(j1)->"k3", json_object(j1)->"k1", json_object(j1)->"k2.k3" from js1 where v1 = 7;
+
+select x->"a", get_json_int(x, "a"), get_json_double(x, "a") from (select parse_json('{"a": 4294967296}') as x) t;


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:
last flat json type inference pr

* json_column_iterator: support read&cast subfield with query type
* json_writer: support subfield type inference

* fix json_exists function bug
* fix get bigint&double from json bug
* fix json function memory leaks


Follow: #42787

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
