### PR TITLE
[Refactor] pushdown or predicate (2): refact column predicate rewriter

### DIFF
--- a/be/src/connector/lake_connector.cpp
+++ b/be/src/connector/lake_connector.cpp
@@ -249,9 +249,8 @@ Status LakeDataSource::init_reader_params(const std::vector<OlapScanRange*>& key
     }
 
     {
-        GlobalDictPredicatesRewriter not_pushdown_predicate_rewriter(_not_push_down_predicates,
-                                                                     *_params.global_dictmaps);
-        RETURN_IF_ERROR(not_pushdown_predicate_rewriter.rewrite_predicate(&_obj_pool));
+        GlobalDictPredicatesRewriter not_pushdown_predicate_rewriter(*_params.global_dictmaps);
+        RETURN_IF_ERROR(not_pushdown_predicate_rewriter.rewrite_predicate(&_obj_pool, _not_push_down_predicates));
     }
 
     // Range

--- a/be/src/exec/pipeline/scan/olap_chunk_source.cpp
+++ b/be/src/exec/pipeline/scan/olap_chunk_source.cpp
@@ -226,9 +226,8 @@ Status OlapChunkSource::_init_reader_params(const std::vector<std::unique_ptr<Ol
     }
 
     {
-        GlobalDictPredicatesRewriter not_pushdown_predicate_rewriter(_not_push_down_predicates,
-                                                                     *_params.global_dictmaps);
-        RETURN_IF_ERROR(not_pushdown_predicate_rewriter.rewrite_predicate(&_obj_pool));
+        GlobalDictPredicatesRewriter not_pushdown_predicate_rewriter(*_params.global_dictmaps);
+        RETURN_IF_ERROR(not_pushdown_predicate_rewriter.rewrite_predicate(&_obj_pool, _not_push_down_predicates));
     }
 
     // Range

--- a/be/src/exec/tablet_scanner.cpp
+++ b/be/src/exec/tablet_scanner.cpp
@@ -172,8 +172,8 @@ Status TabletScanner::_init_reader_params(const std::vector<OlapScanRange*>* key
         _predicate_free_pool.emplace_back(std::move(p));
     }
 
-    GlobalDictPredicatesRewriter not_pushdown_predicate_rewriter(_predicates, *_params.global_dictmaps);
-    RETURN_IF_ERROR(not_pushdown_predicate_rewriter.rewrite_predicate(&_pool));
+    GlobalDictPredicatesRewriter not_pushdown_predicate_rewriter(*_params.global_dictmaps);
+    RETURN_IF_ERROR(not_pushdown_predicate_rewriter.rewrite_predicate(&_pool, _predicates));
 
     // Range
     for (auto key_range : *key_ranges) {

--- a/be/src/storage/column_predicate_rewriter.cpp
+++ b/be/src/storage/column_predicate_rewriter.cpp
@@ -478,14 +478,15 @@ Status ZonemapPredicatesRewriter::rewrite_predicate_map(ObjectPool* pool, const 
     return Status::OK();
 }
 
-Status _rewrite_predicate(ObjectPool* pool, const ColumnPredicate* src_pred, ColumnPredicates& dst_preds) {
+Status ZonemapPredicatesRewriter::_rewrite_predicate(ObjectPool* pool, const ColumnPredicate* src_pred,
+                                                     ColumnPredicates& dst_preds) {
     if (!src_pred->is_expr_predicate()) {
         dst_preds.emplace_back(src_pred);
     } else {
         std::vector<const ColumnExprPredicate*> new_preds;
         RETURN_IF_ERROR(_rewrite_column_expr_predicate(pool, src_pred, new_preds));
         if (!new_preds.empty()) {
-            dst_preds.insert(dst->end(), new_preds.begin(), new_preds.end());
+            dst_preds.insert(dst_preds->end(), new_preds.begin(), new_preds.end());
         } else {
             dst_preds.emplace_back(src_pred);
         }

--- a/be/src/storage/column_predicate_rewriter.cpp
+++ b/be/src/storage/column_predicate_rewriter.cpp
@@ -442,7 +442,7 @@ StatusOr<ColumnPredicatePtr> GlobalDictPredicatesRewriter::_rewrite_predicate(co
     return std::unique_ptr<ColumnPredicate>(new_pred);
 }
 
-Status GlobalDictPredicatesRewriter::rewrite_predicate(ConjunctivePredicates& predicates, ObjectPool* pool) {
+Status GlobalDictPredicatesRewriter::rewrite_predicate(ObjectPool* pool, ConjunctivePredicates& predicates) {
     std::vector<uint8_t> selection;
     auto preds_rewrite = [&](std::vector<const ColumnPredicate*>& preds) {
         for (auto& pred : preds) {

--- a/be/src/storage/column_predicate_rewriter.cpp
+++ b/be/src/storage/column_predicate_rewriter.cpp
@@ -483,7 +483,7 @@ Status _rewrite_predicate(ObjectPool* pool, const ColumnPredicate* src_pred, Col
         dst_preds.emplace_back(src_pred);
     } else {
         std::vector<const ColumnExprPredicate*> new_preds;
-        RETURN_IF_ERROR(_rewrite_column_expr_predicates(pool, src_pred, new_preds));
+        RETURN_IF_ERROR(_rewrite_column_expr_predicate(pool, src_pred, new_preds));
         if (!new_preds.empty()) {
             dst_preds.insert(dst->end(), new_preds.begin(), new_preds.end());
         } else {
@@ -495,7 +495,7 @@ Status _rewrite_predicate(ObjectPool* pool, const ColumnPredicate* src_pred, Col
 Status ZonemapPredicatesRewriter::_rewrite_column_expr_predicate(ObjectPool* pool, const ColumnPredicate* src_pred,
                                                                  ColumnPredicates& dst_preds) {
     DCHECK(src_pred != nullptr);
-    const auto* column_expr_pred = down_cast<const ColumnExprPredicate*>(pred);
+    const auto* column_expr_pred = down_cast<const ColumnExprPredicate*>(src_pred);
     return column_expr_pred->try_to_rewrite_for_zone_map_filter(pool, &dst_preds);
 }
 

--- a/be/src/storage/column_predicate_rewriter.cpp
+++ b/be/src/storage/column_predicate_rewriter.cpp
@@ -41,6 +41,11 @@
 #include "storage/rowset/scalar_column_iterator.h"
 
 namespace starrocks {
+
+// ------------------------------------------------------------------------------------
+// ColumnPredicateRewriter
+// ------------------------------------------------------------------------------------
+
 constexpr static const LogicalType kDictCodeType = TYPE_INT;
 
 Status ColumnPredicateRewriter::rewrite_predicate(ObjectPool* pool) {
@@ -48,205 +53,209 @@ Status ColumnPredicateRewriter::rewrite_predicate(ObjectPool* pool) {
     // so we only need to check the first `predicate_column_size` fields
     for (size_t i = 0; i < _column_size; i++) {
         const FieldPtr& field = _schema.field(i);
-        ColumnId cid = field->id();
-        if (_need_rewrite[cid]) {
-            RETURN_IF_ERROR(_rewrite_predicate(pool, field));
+        const auto cid = field->id();
+
+        auto iter = pred_map.find(cid);
+        if (iter == pred_map.end()) {
+            continue;
+        }
+        auto& preds = iter->second;
+
+        std::vector<const ColumnPredicate*> remove_list;
+        for (auto& pred : preds) {
+            ColumnPredicate* new_pred = nullptr;
+            ASSIGN_OR_RETURN(auto rewrite_status, _rewrite_predicate(pool, field, pred, &new_pred));
+
+            switch (rewrite_status) {
+            case RewriteStatus::ALWAYS_TRUE:
+                remove_list.emplace_back(pred);
+                break;
+            case RewriteStatus::ALWAYS_FALSE:
+                // predicate always false, clear scan range, this will make `get_next` return EOF directly.
+                _scan_range = _scan_range.intersection(SparseRange<>());
+                return Status::OK();
+            case RewriteStatus::CHANGED:
+                pred = pool->add(new_pred);
+                break;
+            case RewriteStatus::UNCHANGED:
+                [[fallthrough]];
+            default:
+                break; // Do nothing.
+            }
+        }
+
+        for (const auto pred_will_remove : remove_list) {
+            auto willrm = std::find(preds.begin(), preds.end(), pred_will_remove);
+            preds.erase(willrm);
         }
     }
     return Status::OK();
 }
 
-StatusOr<bool> ColumnPredicateRewriter::_rewrite_predicate(ObjectPool* pool, const FieldPtr& field) {
-    auto cid = field->id();
+StatusOr<ColumnPredicateRewriter::RewriteStatus> ColumnPredicateRewriter::_rewrite_predicate(
+        ObjectPool* pool, const FieldPtr& field, const ColumnPredicate* pred, ColumnPredicate** dest_pred) {
+    const auto cid = field->id();
+    if (!_need_rewrite[cid]) {
+        return RewriteStatus::UNCHANGED;
+    }
     DCHECK(_column_iterators[cid]->all_page_dict_encoded());
-    auto iter = _predicates.find(cid);
-    if (iter == _predicates.end()) {
-        return false;
+
+    if (PredicateType::kEQ == pred->type()) {
+        Datum value = pred->value();
+        int code = _column_iterators[cid]->dict_lookup(value.get_slice());
+        if (code < 0) {
+            return RewriteStatus::ALWAYS_FALSE;
+        }
+        *dest_pred = new_column_eq_predicate(get_type_info(kDictCodeType), cid, std::to_string(code));
+        return RewriteStatus::CHANGED;
     }
-    PredicateList& preds = iter->second;
-    // the predicate has been erased, because of bitmap index filter.
-    RETURN_IF(preds.empty(), false);
 
-    // TODO: use pair<slice,int>
-    std::vector<std::pair<std::string, int>> sorted_dicts{};
-
-    std::vector<const ColumnPredicate*> remove_list;
-
-    for (auto& i : preds) {
-        const ColumnPredicate* pred = i;
-        if (PredicateType::kEQ == pred->type()) {
-            Datum value = pred->value();
-            int code = _column_iterators[cid]->dict_lookup(value.get_slice());
-            if (code < 0) {
-                // predicate always false, clear scan range, this will make `get_next` return EOF directly.
-                _scan_range = _scan_range.intersection(SparseRange<>());
-                continue;
-            }
-            auto ptr = new_column_eq_predicate(get_type_info(kDictCodeType), cid, std::to_string(code));
-            i = pool->add(ptr);
-            continue;
-        }
-        if (PredicateType::kNE == pred->type()) {
-            Datum value = pred->value();
-            int code = _column_iterators[cid]->dict_lookup(value.get_slice());
-            if (code < 0) {
-                if (!field->is_nullable()) {
-                    // predicate always true, clear this predicate.
-                    remove_list.push_back(i);
-                    continue;
-                } else {
-                    // convert this predicate to `not null` predicate.
-                    auto ptr = new_column_null_predicate(get_type_info(kDictCodeType), cid, false);
-                    i = pool->add(ptr);
-                    continue;
-                }
-            }
-            auto ptr = new_column_ne_predicate(get_type_info(kDictCodeType), cid, std::to_string(code));
-            i = pool->add(ptr);
-            continue;
-        }
-        if (PredicateType::kInList == pred->type()) {
-            std::vector<Datum> values = pred->values();
-            std::vector<int> codewords;
-            for (const auto& value : values) {
-                if (int code = _column_iterators[cid]->dict_lookup(value.get_slice()); code >= 0) {
-                    codewords.emplace_back(code);
-                }
-            }
-            if (codewords.empty()) {
-                // predicate always false, clear scan range.
-                _scan_range = _scan_range.intersection(SparseRange<>());
-                continue;
-            }
-            std::vector<std::string> str_codewords;
-            str_codewords.reserve(codewords.size());
-            for (int code : codewords) {
-                str_codewords.emplace_back(std::to_string(code));
-            }
-            auto ptr = new_column_in_predicate(get_type_info(kDictCodeType), cid, str_codewords);
-            i = pool->add(ptr);
-        }
-        if (PredicateType::kNotInList == pred->type()) {
-            std::vector<Datum> values = pred->values();
-            std::vector<int> codewords;
-            for (const auto& value : values) {
-                if (int code = _column_iterators[cid]->dict_lookup(value.get_slice()); code >= 0) {
-                    codewords.emplace_back(code);
-                }
-            }
-            if (codewords.empty()) {
-                if (!field->is_nullable()) {
-                    // predicate always true, clear this predicate.
-                    remove_list.push_back(i);
-                    continue;
-                } else {
-                    // convert this predicate to `not null` predicate.
-                    auto ptr = new_column_null_predicate(get_type_info(kDictCodeType), cid, false);
-                    i = pool->add(ptr);
-                    continue;
-                }
-            }
-            std::vector<std::string> str_codewords;
-            str_codewords.reserve(codewords.size());
-            for (int code : codewords) {
-                str_codewords.emplace_back(std::to_string(code));
-            }
-            auto ptr = new_column_not_in_predicate(get_type_info(kDictCodeType), cid, str_codewords);
-            i = pool->add(ptr);
-        }
-        if (PredicateType::kGE == pred->type() || PredicateType::kGT == pred->type()) {
-            RETURN_IF_ERROR(_get_segment_dict(&sorted_dicts, _column_iterators[cid].get()));
-            // use non-padding string value.
-            auto value = pred->values()[0].get_slice().to_string();
-            auto iter = std::lower_bound(
-                    sorted_dicts.begin(), sorted_dicts.end(), value,
-                    [](const auto& entity, const auto& value) { return entity.first.compare(value) < 0; });
-            std::vector<std::string> str_codewords;
-            // X > 3.5 find 4, range(4, inf)
-            // X > 3 find 3, range(3, inf)
-            // X >= 3.5 find 4, range(4, inf)
-            // X >= 3 find 3, range(3, inf)
-            if (PredicateType::kGT == pred->type() && iter != sorted_dicts.end() && iter->first == value) {
-                iter++;
-            }
-            while (iter != sorted_dicts.end()) {
-                str_codewords.push_back(std::to_string(iter->second));
-                iter++;
-            }
-            if (!str_codewords.empty()) {
-                auto ptr = new_column_in_predicate(get_type_info(kDictCodeType), cid, str_codewords);
-                i = pool->add(ptr);
+    if (PredicateType::kNE == pred->type()) {
+        Datum value = pred->value();
+        int code = _column_iterators[cid]->dict_lookup(value.get_slice());
+        if (code < 0) {
+            if (!field->is_nullable()) {
+                return RewriteStatus::ALWAYS_TRUE;
             } else {
-                _scan_range = _scan_range.intersection(SparseRange<>());
-                continue;
+                // convert this predicate to `not null` predicate.
+                *dest_pred = new_column_null_predicate(get_type_info(kDictCodeType), cid, false);
+                return RewriteStatus::CHANGED;
             }
         }
-        if (PredicateType::kLE == pred->type() || PredicateType::kLT == pred->type()) {
-            RETURN_IF_ERROR(_get_segment_dict(&sorted_dicts, _column_iterators[cid].get()));
-            // use non-padding string value.
-            auto value = pred->values()[0].get_slice().to_string();
-            auto iter = std::lower_bound(
-                    sorted_dicts.begin(), sorted_dicts.end(), value,
-                    [](const auto& entity, const auto& value) { return entity.first.compare(value) < 0; });
-            std::vector<std::string> str_codewords;
-            auto begin_iter = sorted_dicts.begin();
-            // X < 3.5 find 4, range(-inf, 3)
-            // X < 3 find 3, range(-inf, 2)
-            // X <= 3.5 find 4, range(-inf, 3)
-            // X <= 3 find 3, range(-inf, 3)
-            if (!(PredicateType::kLE == pred->type() && iter != sorted_dicts.end() && iter->first == value)) {
-                iter--;
+        *dest_pred = new_column_ne_predicate(get_type_info(kDictCodeType), cid, std::to_string(code));
+        return RewriteStatus::CHANGED;
+    }
+
+    if (PredicateType::kInList == pred->type()) {
+        std::vector<Datum> values = pred->values();
+        std::vector<int> codewords;
+        for (const auto& value : values) {
+            if (int code = _column_iterators[cid]->dict_lookup(value.get_slice()); code >= 0) {
+                codewords.emplace_back(code);
             }
-            while (begin_iter <= iter && begin_iter != sorted_dicts.end()) {
-                str_codewords.push_back(std::to_string(begin_iter->second));
-                begin_iter++;
+        }
+        if (codewords.empty()) {
+            return RewriteStatus::ALWAYS_FALSE;
+        }
+        std::vector<std::string> str_codewords;
+        str_codewords.reserve(codewords.size());
+        for (int code : codewords) {
+            str_codewords.emplace_back(std::to_string(code));
+        }
+        *dest_pred = new_column_in_predicate(get_type_info(kDictCodeType), cid, str_codewords);
+        return RewriteStatus::CHANGED;
+    }
+
+    if (PredicateType::kNotInList == pred->type()) {
+        std::vector<Datum> values = pred->values();
+        std::vector<int> codewords;
+        for (const auto& value : values) {
+            if (int code = _column_iterators[cid]->dict_lookup(value.get_slice()); code >= 0) {
+                codewords.emplace_back(code);
             }
-            if (!str_codewords.empty()) {
-                auto ptr = new_column_in_predicate(get_type_info(kDictCodeType), cid, str_codewords);
-                i = pool->add(ptr);
+        }
+        if (codewords.empty()) {
+            if (!field->is_nullable()) {
+                return RewriteStatus::ALWAYS_TRUE;
             } else {
-                _scan_range = _scan_range.intersection(SparseRange<>());
-                continue;
+                // convert this predicate to `not null` predicate.
+                *dest_pred = new_column_null_predicate(get_type_info(kDictCodeType), cid, false);
+                return RewriteStatus::CHANGED;
             }
+        }
+        std::vector<std::string> str_codewords;
+        str_codewords.reserve(codewords.size());
+        for (int code : codewords) {
+            str_codewords.emplace_back(std::to_string(code));
+        }
+        *dest_pred = new_column_not_in_predicate(get_type_info(kDictCodeType), cid, str_codewords);
+        return RewriteStatus::CHANGED;
+    }
+
+    if (PredicateType::kGE == pred->type() || PredicateType::kGT == pred->type()) {
+        ASSIGN_OR_RETURN(const auto* sorted_dicts_ptr, _get_or_load_segment_dict(cid));
+        const auto& sorted_dicts = *sorted_dicts_ptr;
+
+        // use non-padding string value.
+        auto value = pred->values()[0].get_slice().to_string();
+        auto iter =
+                std::lower_bound(sorted_dicts.begin(), sorted_dicts.end(), value,
+                                 [](const auto& entity, const auto& value) { return entity.first.compare(value) < 0; });
+        std::vector<std::string> str_codewords;
+        // X > 3.5 find 4, range(4, inf)
+        // X > 3 find 3, range(3, inf)
+        // X >= 3.5 find 4, range(4, inf)
+        // X >= 3 find 3, range(3, inf)
+        if (PredicateType::kGT == pred->type() && iter != sorted_dicts.end() && iter->first == value) {
+            iter++;
+        }
+        while (iter != sorted_dicts.end()) {
+            str_codewords.push_back(std::to_string(iter->second));
+            iter++;
+        }
+        if (!str_codewords.empty()) {
+            *dest_pred = new_column_in_predicate(get_type_info(kDictCodeType), cid, str_codewords);
+            return RewriteStatus::CHANGED;
+        } else {
+            return RewriteStatus::ALWAYS_FALSE;
         }
     }
 
-    bool load_seg_dict_vec = false;
-    ColumnPtr dict_column;
-    ColumnPtr code_column;
-    for (auto& i : preds) {
-        const ColumnPredicate* pred = i;
-        if (PredicateType::kExpr == pred->type()) {
-            if (!load_seg_dict_vec) {
-                load_seg_dict_vec = true;
-                RETURN_IF_ERROR(_get_segment_dict_vec(_column_iterators[cid].get(), &dict_column, &code_column,
-                                                      field->is_nullable()));
-            }
+    if (PredicateType::kLE == pred->type() || PredicateType::kLT == pred->type()) {
+        ASSIGN_OR_RETURN(const auto* sorted_dicts_ptr, _get_or_load_segment_dict(cid));
+        const auto& sorted_dicts = *sorted_dicts_ptr;
 
-            ColumnPredicate* ptr;
-            ASSIGN_OR_RETURN(bool non_empty,
-                             _rewrite_expr_predicate(pool, pred, dict_column, code_column, field->is_nullable(), &ptr));
-            if (!non_empty) {
-                _scan_range = _scan_range.intersection(SparseRange<>());
-            } else {
-                i = pool->add(ptr);
-            }
+        // use non-padding string value.
+        auto value = pred->values()[0].get_slice().to_string();
+        auto iter =
+                std::lower_bound(sorted_dicts.begin(), sorted_dicts.end(), value,
+                                 [](const auto& entity, const auto& value) { return entity.first.compare(value) < 0; });
+        std::vector<std::string> str_codewords;
+        auto begin_iter = sorted_dicts.begin();
+        // X < 3.5 find 4, range(-inf, 3)
+        // X < 3 find 3, range(-inf, 2)
+        // X <= 3.5 find 4, range(-inf, 3)
+        // X <= 3 find 3, range(-inf, 3)
+        if (!(PredicateType::kLE == pred->type() && iter != sorted_dicts.end() && iter->first == value)) {
+            iter--;
+        }
+        while (begin_iter <= iter && begin_iter != sorted_dicts.end()) {
+            str_codewords.push_back(std::to_string(begin_iter->second));
+            begin_iter++;
+        }
+        if (!str_codewords.empty()) {
+            *dest_pred = new_column_in_predicate(get_type_info(kDictCodeType), cid, str_codewords);
+            return RewriteStatus::CHANGED;
+        } else {
+            return RewriteStatus::ALWAYS_FALSE;
         }
     }
 
-    for (const auto pred_will_remove : remove_list) {
-        auto willrm = std::find(preds.begin(), preds.end(), pred_will_remove);
-        preds.erase(willrm);
+    if (PredicateType::kExpr == pred->type()) {
+        ASSIGN_OR_RETURN(const auto* dict_and_codes_ptr, _get_or_load_segment_dict_vec(cid, field));
+        const auto& [dict_column, code_column] = *dict_and_codes_ptr;
+
+        return _rewrite_expr_predicate(pool, pred, dict_column, code_column, field->is_nullable(), dest_pred);
     }
 
-    return true;
+    return RewriteStatus::UNCHANGED;
+}
+
+StatusOr<const ColumnPredicateRewriter::SortedDicts*> ColumnPredicateRewriter::_get_or_load_segment_dict(ColumnId cid) {
+    auto it = _cid_to_sorted_dicts.find(cid);
+    if (it == _cid_to_sorted_dicts.end()) {
+        it = _cid_to_sorted_dicts.emplace(cid, SortedDicts{}).first;
+        RETURN_IF_ERROR(_load_segment_dict(&it->second, _column_iterators[cid].get()));
+    }
+
+    return &it->second;
 }
 
 // This function is only used to rewrite the LE/LT/GE/GT condition.
 // For the greater than or less than condition,
 // you need to get the values of all ordered dictionaries and rewrite them as `InList` expressions
-Status ColumnPredicateRewriter::_get_segment_dict(std::vector<std::pair<std::string, int>>* dicts,
-                                                  ColumnIterator* iter) {
+Status ColumnPredicateRewriter::_load_segment_dict(std::vector<std::pair<std::string, int>>* dicts,
+                                                   ColumnIterator* iter) {
     // We already loaded dicts, no need to do once more.
     if (!dicts->empty()) {
         return Status::OK();
@@ -268,8 +277,21 @@ Status ColumnPredicateRewriter::_get_segment_dict(std::vector<std::pair<std::str
     return Status::OK();
 }
 
-Status ColumnPredicateRewriter::_get_segment_dict_vec(ColumnIterator* iter, ColumnPtr* dict_column,
-                                                      ColumnPtr* code_column, bool field_nullable) {
+StatusOr<const ColumnPredicateRewriter::DictAndCodes*> ColumnPredicateRewriter::_get_or_load_segment_dict_vec(
+        ColumnId cid, const FieldPtr& field) {
+    auto it = _cid_to_vec_sorted_dicts.find(cid);
+    if (it == _cid_to_vec_sorted_dicts.end()) {
+        it = _cid_to_vec_sorted_dicts.emplace(cid, std::make_pair(nullptr, nullptr)).first;
+        auto& [dict_column, code_column] = it->second;
+        RETURN_IF_ERROR(
+                _load_segment_dict_vec(_column_iterators[cid].get(), &dict_column, &code_column, field->is_nullable()));
+    }
+
+    return &it->second;
+}
+
+Status ColumnPredicateRewriter::_load_segment_dict_vec(ColumnIterator* iter, ColumnPtr* dict_column,
+                                                       ColumnPtr* code_column, bool field_nullable) {
     auto column_iterator = down_cast<ScalarColumnIterator*>(iter);
     auto dict_size = column_iterator->dict_size();
     int dict_codes[dict_size];
@@ -300,10 +322,9 @@ Status ColumnPredicateRewriter::_get_segment_dict_vec(ColumnIterator* iter, Colu
     return Status::OK();
 }
 
-StatusOr<bool> ColumnPredicateRewriter::_rewrite_expr_predicate(ObjectPool* pool, const ColumnPredicate* raw_pred,
-                                                                const ColumnPtr& raw_dict_column,
-                                                                const ColumnPtr& raw_code_column, bool field_nullable,
-                                                                ColumnPredicate** ptr) {
+StatusOr<ColumnPredicateRewriter::RewriteStatus> ColumnPredicateRewriter::_rewrite_expr_predicate(
+        ObjectPool* pool, const ColumnPredicate* raw_pred, const ColumnPtr& raw_dict_column,
+        const ColumnPtr& raw_code_column, bool field_nullable, ColumnPredicate** ptr) {
     *ptr = nullptr;
     size_t value_size = raw_dict_column->size();
     std::vector<uint8_t> selection(value_size);
@@ -340,13 +361,12 @@ StatusOr<bool> ColumnPredicateRewriter::_rewrite_expr_predicate(ObjectPool* pool
     size_t false_count = SIMD::count_zero(selection);
     size_t true_count = (value_size - false_count);
     if (true_count == 0) {
-        return false;
+        return RewriteStatus::ALWAYS_FALSE;
     }
 
     if (false_count == 0) {
         // always true.
-        *ptr = new ColumnTruePredicate(get_type_info(kDictCodeType), pred->column_id());
-        return true;
+        return RewriteStatus::ALWAYS_TRUE;
     }
 
     // TODO(yan): use eq/ne predicates when only one item, but it's very very hard to construct ne/eq expr.
@@ -386,88 +406,92 @@ StatusOr<bool> ColumnPredicateRewriter::_rewrite_expr_predicate(ObjectPool* pool
     ASSIGN_OR_RETURN(*ptr, ColumnExprPredicate::make_column_expr_predicate(
                                    get_type_info(kDictCodeType), pred->column_id(), state, filter, pred->slot_desc()))
     filter->close(state);
-    // still remember whether this predicate is index only filter or not
-    (*ptr)->set_index_filter_only(raw_pred->is_index_filter_only());
 
-    return true;
+    return RewriteStatus::CHANGED;
 }
 
-// member function for GlobalDictPredicatesRewriter
+// ------------------------------------------------------------------------------------
+// GlobalDictPredicatesRewriter
+// ------------------------------------------------------------------------------------
 
-Status GlobalDictPredicatesRewriter::rewrite_predicate(ObjectPool* pool) {
+StatusOr<ColumnPredicatePtr> GlobalDictPredicatesRewriter::_rewrite_predicate(const ColumnPredicate* pred,
+                                                                              std::vector<uint8_t>& selection) {
+    if (!_column_need_rewrite(pred->column_id())) {
+        return nullptr;
+    }
+
+    const auto& dict = _dict_maps.at(pred->column_id());
+    ChunkPtr temp_chunk = std::make_shared<Chunk>();
+
+    auto [binary_column, codes] = extract_column_with_codes(*dict);
+
+    size_t dict_rows = codes.size();
+    selection.resize(dict_rows);
+
+    RETURN_IF_ERROR(pred->evaluate(binary_column.get(), selection.data(), 0, dict_rows));
+
+    std::vector<uint8_t> code_mapping;
+    code_mapping.resize(DICT_DECODE_MAX_SIZE + 1);
+    for (size_t i = 0; i < codes.size(); ++i) {
+        code_mapping[codes[i]] = selection[i];
+    }
+
+    auto* new_pred =
+            new_column_dict_conjuct_predicate(get_type_info(kDictCodeType), pred->column_id(), std::move(code_mapping));
+    new_pred->set_index_filter_only(pred->is_index_filter_only());
+    return std::unique_ptr<ColumnPredicate>(new_pred);
+}
+
+Status GlobalDictPredicatesRewriter::rewrite_predicate(ConjunctivePredicates& predicates, ObjectPool* pool) {
     std::vector<uint8_t> selection;
-    auto pred_rewrite = [&](std::vector<const ColumnPredicate*>& preds) {
+    auto preds_rewrite = [&](std::vector<const ColumnPredicate*>& preds) {
         for (auto& pred : preds) {
-            if (column_need_rewrite(pred->column_id())) {
-                const auto& dict = _dict_maps.at(pred->column_id());
-                ChunkPtr temp_chunk = std::make_shared<Chunk>();
-
-                auto [binary_column, codes] = extract_column_with_codes(*dict);
-
-                size_t dict_rows = codes.size();
-                selection.resize(dict_rows);
-
-                RETURN_IF_ERROR(pred->evaluate(binary_column.get(), selection.data(), 0, dict_rows));
-
-                std::vector<uint8_t> code_mapping;
-                code_mapping.resize(DICT_DECODE_MAX_SIZE + 1);
-                for (size_t i = 0; i < codes.size(); ++i) {
-                    code_mapping[codes[i]] = selection[i];
-                }
-
-                bool is_index_only_filter = pred->is_index_filter_only();
-                ColumnPredicate* newPred = new_column_dict_conjuct_predicate(
-                        get_type_info(kDictCodeType), pred->column_id(), std::move(code_mapping));
-                newPred->set_index_filter_only(is_index_only_filter);
-                pred = newPred;
-                pool->add(const_cast<ColumnPredicate*>(pred));
+            ASSIGN_OR_RETURN(auto new_pred, _rewrite_predicate(pred, selection));
+            if (new_pred != nullptr) {
+                pred = pool->add(new_pred.release());
             }
         }
         return Status::OK();
     };
 
-    RETURN_IF_ERROR(pred_rewrite(_predicates.non_vec_preds()));
-    RETURN_IF_ERROR(pred_rewrite(_predicates.vec_preds()));
+    RETURN_IF_ERROR(preds_rewrite(predicates.non_vec_preds()));
+    RETURN_IF_ERROR(preds_rewrite(predicates.vec_preds()));
 
     return Status::OK();
 }
 
-Status ZonemapPredicatesRewriter::rewrite_predicate_map(ObjectPool* pool,
-                                                        const std::unordered_map<ColumnId, PredicateList>& src,
-                                                        std::unordered_map<ColumnId, PredicateList>* dst) {
-    DCHECK(dst != nullptr);
-    for (auto& [cid, preds] : src) {
-        dst->insert({cid, {}});
-        auto& preds_after_rewrite = dst->at(cid);
-        RETURN_IF_ERROR(rewrite_predicate_list(pool, preds, &preds_after_rewrite));
-    }
-    return Status::OK();
-}
+// ------------------------------------------------------------------------------------
+// ZonemapPredicatesRewriter
+// ------------------------------------------------------------------------------------
 
-Status ZonemapPredicatesRewriter::rewrite_predicate_list(ObjectPool* pool, const PredicateList& src,
-                                                         PredicateList* dst) {
-    DCHECK(dst != nullptr);
-    for (auto& pred : src) {
-        if (pred->is_expr_predicate()) {
-            std::vector<const ColumnExprPredicate*> new_preds;
-            RETURN_IF_ERROR(_rewrite_column_expr_predicates(pool, pred, &new_preds));
-            if (!new_preds.empty()) {
-                dst->insert(dst->end(), new_preds.begin(), new_preds.end());
+Status ZonemapPredicatesRewriter::rewrite_predicate_map(ObjectPool* pool, const ColumnPredicateMap& src_pred_map,
+                                                        ColumnPredicateMap* dst_pred_map) {
+    DCHECK(dst_pred_map != nullptr);
+    for (auto& [cid, src_preds] : src_pred_map) {
+        auto& dst_preds = dst_pred_map->emplace(cid, {}).first->second;
+
+        for (const auto* src_pred : src_preds) {
+            if (!src_pred->is_expr_predicate()) {
+                dst_preds->emplace_back(src_pred);
             } else {
-                dst->emplace_back(pred);
+                std::vector<const ColumnExprPredicate*> new_preds;
+                RETURN_IF_ERROR(_rewrite_column_expr_predicates(pool, src_pred, &new_preds));
+                if (!new_preds.empty()) {
+                    dst_preds->insert(dst->end(), new_preds.begin(), new_preds.end());
+                } else {
+                    dst_preds->emplace_back(src_pred);
+                }
             }
-        } else {
-            dst->emplace_back(pred);
         }
     }
     return Status::OK();
 }
 
-Status ZonemapPredicatesRewriter::_rewrite_column_expr_predicates(ObjectPool* pool, const ColumnPredicate* pred,
-                                                                  std::vector<const ColumnExprPredicate*>* new_preds) {
-    DCHECK(new_preds != nullptr);
-    const auto* column_expr_pred = static_cast<const ColumnExprPredicate*>(pred);
-    return column_expr_pred->try_to_rewrite_for_zone_map_filter(pool, new_preds);
+Status ZonemapPredicatesRewriter::_rewrite_column_expr_predicate(ObjectPool* pool, const ColumnPredicate* src_pred,
+                                                                 ColumnPredicates& dst_preds) {
+    DCHECK(src_pred != nullptr);
+    const auto* column_expr_pred = down_cast<const ColumnExprPredicate*>(pred);
+    return column_expr_pred->try_to_rewrite_for_zone_map_filter(pool, dst_preds);
 }
 
 } // namespace starrocks

--- a/be/src/storage/column_predicate_rewriter.cpp
+++ b/be/src/storage/column_predicate_rewriter.cpp
@@ -493,7 +493,7 @@ Status _rewrite_predicate(ObjectPool* pool, const ColumnPredicate* src_pred, Col
 }
 
 Status ZonemapPredicatesRewriter::_rewrite_column_expr_predicate(ObjectPool* pool, const ColumnPredicate* src_pred,
-                                                                 ColumnPredicates& dst_preds) {
+                                                                 std::vector<const ColumnExprPredicate*>& dst_preds) {
     DCHECK(src_pred != nullptr);
     const auto* column_expr_pred = down_cast<const ColumnExprPredicate*>(src_pred);
     return column_expr_pred->try_to_rewrite_for_zone_map_filter(pool, &dst_preds);

--- a/be/src/storage/column_predicate_rewriter.cpp
+++ b/be/src/storage/column_predicate_rewriter.cpp
@@ -469,7 +469,7 @@ Status ZonemapPredicatesRewriter::rewrite_predicate_map(ObjectPool* pool, const 
                                                         ColumnPredicateMap* dst_pred_map) {
     DCHECK(dst_pred_map != nullptr);
     for (auto& [cid, src_preds] : src_pred_map) {
-        auto& dst_preds = dst_pred_map->emplace({cid, {}}).first->second;
+        auto& dst_preds = dst_pred_map->insert({cid, {}}).first->second;
 
         for (const auto* src_pred : src_preds) {
             RETURN_IF_ERROR(_rewrite_predicate(pool, src_pred, dst_preds));

--- a/be/src/storage/column_predicate_rewriter.cpp
+++ b/be/src/storage/column_predicate_rewriter.cpp
@@ -480,14 +480,14 @@ Status ZonemapPredicatesRewriter::rewrite_predicate_map(ObjectPool* pool, const 
 
 Status _rewrite_predicate(ObjectPool* pool, const ColumnPredicate* src_pred, ColumnPredicates& dst_preds) {
     if (!src_pred->is_expr_predicate()) {
-        dst_preds->emplace_back(src_pred);
+        dst_preds.emplace_back(src_pred);
     } else {
         std::vector<const ColumnExprPredicate*> new_preds;
-        RETURN_IF_ERROR(_rewrite_column_expr_predicates(pool, src_pred, &new_preds));
+        RETURN_IF_ERROR(_rewrite_column_expr_predicates(pool, src_pred, new_preds));
         if (!new_preds.empty()) {
-            dst_preds->insert(dst->end(), new_preds.begin(), new_preds.end());
+            dst_preds.insert(dst->end(), new_preds.begin(), new_preds.end());
         } else {
-            dst_preds->emplace_back(src_pred);
+            dst_preds.emplace_back(src_pred);
         }
     }
 }
@@ -496,7 +496,7 @@ Status ZonemapPredicatesRewriter::_rewrite_column_expr_predicate(ObjectPool* poo
                                                                  ColumnPredicates& dst_preds) {
     DCHECK(src_pred != nullptr);
     const auto* column_expr_pred = down_cast<const ColumnExprPredicate*>(pred);
-    return column_expr_pred->try_to_rewrite_for_zone_map_filter(pool, dst_preds);
+    return column_expr_pred->try_to_rewrite_for_zone_map_filter(pool, &dst_preds);
 }
 
 } // namespace starrocks

--- a/be/src/storage/column_predicate_rewriter.h
+++ b/be/src/storage/column_predicate_rewriter.h
@@ -95,7 +95,7 @@ public:
     GlobalDictPredicatesRewriter(const ColumnIdToGlobalDictMap& dict_maps, std::vector<uint8_t>* disable_rewrite)
             : _dict_maps(dict_maps), _disable_dict_rewrite(disable_rewrite) {}
 
-    Status rewrite_predicate(ConjunctivePredicates& predicates, ObjectPool* pool);
+    Status rewrite_predicate(ObjectPool* pool, ConjunctivePredicates& predicates);
 
 private:
     /// Rewrites a single predicate.

--- a/be/src/storage/column_predicate_rewriter.h
+++ b/be/src/storage/column_predicate_rewriter.h
@@ -125,6 +125,7 @@ public:
                                         ColumnPredicateMap* dst_pred_map);
 
 private:
+    static Status _rewrite_predicate(ObjectPool* pool, const ColumnPredicate* src_pred, ColumnPredicates& dst_preds);
     static Status _rewrite_column_expr_predicate(ObjectPool* pool, const ColumnPredicate* src_pred,
                                                  ColumnPredicates& dst_preds);
 };

--- a/be/src/storage/column_predicate_rewriter.h
+++ b/be/src/storage/column_predicate_rewriter.h
@@ -129,7 +129,7 @@ public:
 private:
     static Status _rewrite_predicate(ObjectPool* pool, const ColumnPredicate* src_pred, ColumnPredicates& dst_preds);
     static Status _rewrite_column_expr_predicate(ObjectPool* pool, const ColumnPredicate* src_pred,
-                                                 ColumnPredicates& dst_preds);
+                                                 std::vector<const ColumnExprPredicate*>& dst_preds);
 };
 
 } // namespace starrocks

--- a/be/src/storage/column_predicate_rewriter.h
+++ b/be/src/storage/column_predicate_rewriter.h
@@ -26,7 +26,10 @@
 #include "storage/rowset/column_reader.h"
 
 namespace starrocks {
+
 class ColumnExprPredicate;
+class ColumnPredicate;
+using ColumnPredicatePtr = std::unique_ptr<ColumnPredicate>;
 
 // For dictionary columns, predicates can be rewriten
 // Int columns.
@@ -36,13 +39,12 @@ class ColumnExprPredicate;
 class ColumnPredicateRewriter {
 public:
     using ColumnIterators = std::vector<std::unique_ptr<ColumnIterator>>;
-    using PushDownPredicates = std::unordered_map<ColumnId, PredicateList>;
+    using ColumnPredicateMap = std::unordered_map<ColumnId, PredicateList>;
 
-    ColumnPredicateRewriter(const ColumnIterators& column_iterators, PushDownPredicates& pushdown_predicates,
-                            const Schema& schema, std::vector<uint8_t>& need_rewrite, int column_size,
-                            SparseRange<>& scan_range)
+    ColumnPredicateRewriter(const ColumnIterators& column_iterators, ColumnPredicateMap& pred_map, const Schema& schema,
+                            std::vector<uint8_t>& need_rewrite, int column_size, SparseRange<>& scan_range)
             : _column_iterators(column_iterators),
-              _predicates(pushdown_predicates),
+              _pred_map(pred_map),
               _schema(schema),
               _need_rewrite(need_rewrite),
               _column_size(column_size),
@@ -51,43 +53,61 @@ public:
     Status rewrite_predicate(ObjectPool* pool);
 
 private:
-    StatusOr<bool> _rewrite_predicate(ObjectPool* pool, const FieldPtr& field);
-    StatusOr<bool> _rewrite_expr_predicate(ObjectPool* pool, const ColumnPredicate*, const ColumnPtr& dict_column,
-                                           const ColumnPtr& code_column, bool field_nullable, ColumnPredicate** ptr);
-    Status _get_segment_dict(std::vector<std::pair<std::string, int>>* dicts, ColumnIterator* iter);
-    Status _get_segment_dict_vec(ColumnIterator* iter, ColumnPtr* dict_column, ColumnPtr* code_column,
-                                 bool field_nullable);
+    // TODO: use pair<slice,int>
+    using SortedDicts = std::vector<std::pair<std::string, int>>;
+    using DictAndCodes = std::pair<ColumnPtr, ColumnPtr>;
+
+    enum class RewriteStatus : uint8_t { ALWAYS_TRUE, ALWAYS_FALSE, UNCHANGED, CHANGED };
+
+    StatusOr<RewriteStatus> _rewrite_predicate(ObjectPool* pool, const FieldPtr& field, const ColumnPredicate* pred,
+                                               ColumnPredicate** dest_pred);
+    StatusOr<RewriteStatus> _rewrite_expr_predicate(ObjectPool* pool, const ColumnPredicate*,
+                                                    const ColumnPtr& dict_column, const ColumnPtr& code_column,
+                                                    bool field_nullable, ColumnPredicate** ptr);
+
+    StatusOr<const SortedDicts*> _get_or_load_segment_dict(ColumnId cid);
+    Status _load_segment_dict(std::vector<std::pair<std::string, int>>* dicts, ColumnIterator* iter);
+
+    StatusOr<const DictAndCodes*> _get_or_load_segment_dict_vec(ColumnId cid, const FieldPtr& field);
+    Status _load_segment_dict_vec(ColumnIterator* iter, ColumnPtr* dict_column, ColumnPtr* code_column,
+                                  bool field_nullable);
 
     const ColumnIterators& _column_iterators;
-    PushDownPredicates& _predicates;
+    ColumnPredicateMap& _pred_map;
     const Schema& _schema;
     std::vector<uint8_t>& _need_rewrite;
     const int _column_size;
     SparseRange<>& _scan_range;
+
+    std::unordered_map<ColumnId, SortedDicts> _cid_to_sorted_dicts;
+    std::unordered_map<ColumnId, DictAndCodes> _cid_to_vec_sorted_dicts;
 };
 
-// For global dictionary columns, predicates can be rewriten
-// GlobalDictPredicatesRewriter was a helper class, won't acquire any resource
-// GlobalDictPredicatesRewriter will rewrite ConjunctivePredicates in TabletScanner
+// For global dictionary columns, predicates can be rewriten.
+// GlobalDictPredicatesRewriter is a helper class, won't acquire any resource.
+// GlobalDictPredicatesRewriter will rewrite ConjunctivePredicates in TabletScanner.
 //
 // TODO: refactor GlobalDictPredicatesRewriter and ColumnPredicateRewriter
 class GlobalDictPredicatesRewriter {
 public:
-    GlobalDictPredicatesRewriter(ConjunctivePredicates& predicates, const ColumnIdToGlobalDictMap& dict_maps)
-            : GlobalDictPredicatesRewriter(predicates, dict_maps, nullptr) {}
-    GlobalDictPredicatesRewriter(ConjunctivePredicates& predicates, const ColumnIdToGlobalDictMap& dict_maps,
-                                 std::vector<uint8_t>* disable_rewrite)
-            : _predicates(predicates), _dict_maps(dict_maps), _disable_dict_rewrite(disable_rewrite) {}
+    GlobalDictPredicatesRewriter(const ColumnIdToGlobalDictMap& dict_maps)
+            : GlobalDictPredicatesRewriter(dict_maps, nullptr) {}
+    GlobalDictPredicatesRewriter(const ColumnIdToGlobalDictMap& dict_maps, std::vector<uint8_t>* disable_rewrite)
+            : _dict_maps(dict_maps), _disable_dict_rewrite(disable_rewrite) {}
 
-    Status rewrite_predicate(ObjectPool* pool);
+    Status rewrite_predicate(ConjunctivePredicates& predicates, ObjectPool* pool);
 
-    bool column_need_rewrite(ColumnId cid) {
+private:
+    /// Rewrites a single predicate.
+    /// Returns the rewritten predicate or an error status.
+    /// If the pred needn't be rewritten, return nullptr.
+    StatusOr<ColumnPredicatePtr> _rewrite_predicate(const ColumnPredicate* pred, std::vector<uint8_t>& selection);
+
+    bool _column_need_rewrite(ColumnId cid) {
         if (_disable_dict_rewrite && (*_disable_dict_rewrite)[cid]) return false;
         return _dict_maps.count(cid);
     }
 
-private:
-    ConjunctivePredicates& _predicates;
     const ColumnIdToGlobalDictMap& _dict_maps;
     std::vector<uint8_t>* _disable_dict_rewrite;
 };
@@ -98,16 +118,15 @@ private:
 // It will only be used before performing segment-level and page-level zone map filters
 class ZonemapPredicatesRewriter {
 public:
-    using PredicateList = std::vector<const ColumnPredicate*>;
+    using ColumnPredicates = std::vector<const ColumnPredicate*>;
+    using ColumnPredicateMap = std::unordered_map<ColumnId, ColumnPredicates>;
 
-    static Status rewrite_predicate_map(ObjectPool* pool, const std::unordered_map<ColumnId, PredicateList>& src,
-                                        std::unordered_map<ColumnId, PredicateList>* dst);
-
-    static Status rewrite_predicate_list(ObjectPool* pool, const PredicateList& src, PredicateList* dst);
+    static Status rewrite_predicate_map(ObjectPool* pool, const ColumnPredicateMap& src_pred_map,
+                                        ColumnPredicateMap* dst_pred_map);
 
 private:
-    static Status _rewrite_column_expr_predicates(ObjectPool* pool, const ColumnPredicate* pred,
-                                                  std::vector<const ColumnExprPredicate*>* new_preds);
+    static Status _rewrite_column_expr_predicate(ObjectPool* pool, const ColumnPredicate* src_pred,
+                                                 ColumnPredicates& dst_preds);
 };
 
 } // namespace starrocks

--- a/be/src/storage/column_predicate_rewriter.h
+++ b/be/src/storage/column_predicate_rewriter.h
@@ -59,11 +59,13 @@ private:
 
     enum class RewriteStatus : uint8_t { ALWAYS_TRUE, ALWAYS_FALSE, UNCHANGED, CHANGED };
 
-    StatusOr<RewriteStatus> _rewrite_predicate(ObjectPool* pool, const FieldPtr& field, const ColumnPredicate* pred,
+    /// Rewrite a column predicate.
+    /// If returned status is CHANGED, a new ColumnPredicate will be created and assigned to *dest_pred.
+    StatusOr<RewriteStatus> _rewrite_predicate(ObjectPool* pool, const FieldPtr& field, const ColumnPredicate* src_pred,
                                                ColumnPredicate** dest_pred);
-    StatusOr<RewriteStatus> _rewrite_expr_predicate(ObjectPool* pool, const ColumnPredicate*,
-                                                    const ColumnPtr& dict_column, const ColumnPtr& code_column,
-                                                    bool field_nullable, ColumnPredicate** ptr);
+    StatusOr<RewriteStatus> _rewrite_expr_predicate(ObjectPool* pool, const ColumnPtr& dict_column,
+                                                    const ColumnPtr& code_column, bool field_nullable,
+                                                    const ColumnPredicate* src_pred, ColumnPredicate** dest_pred);
 
     StatusOr<const SortedDicts*> _get_or_load_segment_dict(ColumnId cid);
     Status _load_segment_dict(std::vector<std::pair<std::string, int>>* dicts, ColumnIterator* iter);

--- a/be/src/storage/rowset/segment_iterator.cpp
+++ b/be/src/storage/rowset/segment_iterator.cpp
@@ -1570,8 +1570,8 @@ Status SegmentIterator::_rewrite_predicates() {
     }
 
     for (auto& conjunct_predicate : _opts.delete_predicates.predicate_list()) {
-        GlobalDictPredicatesRewriter crewriter(conjunct_predicate, *_opts.global_dictmaps, &disable_dict_rewrites);
-        RETURN_IF_ERROR(crewriter.rewrite_predicate(&_obj_pool));
+        GlobalDictPredicatesRewriter crewriter(*_opts.global_dictmaps, &disable_dict_rewrites);
+        RETURN_IF_ERROR(crewriter.rewrite_predicate(&_obj_pool, conjunct_predicate));
     }
 
     return Status::OK();


### PR DESCRIPTION
## Why I'm doing:

Refact `ColumnPredicateRewriter`, `GlobalDictPredicatesRewriter`, and `ZonemapPredicatesRewriter` to make it easier applying to OR predciates.

## What I'm doing:
- As for `ColumnPredicateRewriter`, `GlobalDictPredicatesRewriter`, and `ZonemapPredicatesRewriter`, extract a `_rewrite_predicate` method to rewrite a single predicate. This will make it easier to apply `_rewrite_predicate` to each node in the predicate tree in the future.
- Specifically for `ColumnPredicateRewriter`, the `_rewrite_predicate` method returns `ALWAYS_FALSE`, `ALWAYS_TRUE`, `CHANGED`, or `UNCHANGED`, because OR and AND predicates deal with `ALWAYS_FALSE` and `ALWAYS_TRUE` in different ways.
   - For AND predicates:
        - An `ALWAYS_FALSE` predicate makes the result of all the predicates become false always.
        - An `ALWAYS_TRUE` predicate is to be eliminated.
   - For OR predicates:
        - An `ALWAYS_FALSE` predicate is to be eliminated.
        - An `ALWAYS_TRUE` predicate makes the result of all the predicates become true always.

Relates to #43801.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [x] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
