### PR TITLE
[Feature] Support manually update the datacache quota online and automatically adjust datacache disk quota.

### DIFF
--- a/be/src/block_cache/CMakeLists.txt
+++ b/be/src/block_cache/CMakeLists.txt
@@ -27,6 +27,7 @@ set(CACHE_FILES
   io_buffer.cpp
   cache_options.cpp
   datacache_utils.cpp
+  disk_space_monitor.cpp
 )
 
 if (${WITH_CACHELIB} STREQUAL "ON")

--- a/be/src/block_cache/block_cache.cpp
+++ b/be/src/block_cache/block_cache.cpp
@@ -44,26 +44,36 @@ BlockCache* BlockCache::instance() {
     return &cache;
 }
 
+BlockCache::~BlockCache() {
+    (void)shutdown();
+}
+
 Status BlockCache::init(const CacheOptions& options) {
     _block_size = std::min(options.block_size, MAX_BLOCK_SIZE);
+    auto cache_options = options;
 #ifdef WITH_CACHELIB
-    if (options.engine == "cachelib") {
+    if (cache_options.engine == "cachelib") {
         _kv_cache = std::make_unique<CacheLibWrapper>();
         LOG(INFO) << "init cachelib engine, block_size: " << _block_size;
     }
 #endif
 #ifdef WITH_STARCACHE
-    if (options.engine == "starcache") {
+    if (cache_options.engine == "starcache") {
         _kv_cache = std::make_unique<StarCacheWrapper>();
+        _disk_space_monitor = std::make_unique<DiskSpaceMonitor>(this);
+        _disk_space_monitor->adjust_spaces(&cache_options.disk_spaces);
         LOG(INFO) << "init starcache engine, block_size: " << _block_size;
     }
 #endif
     if (!_kv_cache) {
-        LOG(ERROR) << "unsupported block cache engine: " << options.engine;
+        LOG(ERROR) << "unsupported block cache engine: " << cache_options.engine;
         return Status::NotSupported("unsupported block cache engine");
     }
-    RETURN_IF_ERROR(_kv_cache->init(options));
+    RETURN_IF_ERROR(_kv_cache->init(cache_options));
     _initialized.store(true, std::memory_order_relaxed);
+    if (_disk_space_monitor) {
+        _disk_space_monitor->start();
+    }
     return Status::OK();
 }
 
@@ -142,6 +152,23 @@ Status BlockCache::remove(const CacheKey& cache_key, off_t offset, size_t size) 
     return _kv_cache->remove(block_key);
 }
 
+Status BlockCache::update_mem_quota(size_t quota_bytes) {
+    return _kv_cache->update_mem_quota(quota_bytes);
+}
+
+Status BlockCache::update_disk_spaces(const std::vector<DirSpace>& spaces) {
+    return _kv_cache->update_disk_spaces(spaces);
+}
+
+Status BlockCache::adjust_disk_spaces(const std::vector<DirSpace>& spaces) {
+    if (_disk_space_monitor) {
+        auto adjusted_spaces = spaces;
+        _disk_space_monitor->adjust_spaces(&adjusted_spaces);
+        return _disk_space_monitor->adjust_cache_quota(adjusted_spaces);
+    }
+    return update_disk_spaces(spaces);
+}
+
 void BlockCache::record_read_remote(size_t size, int64_t lateny_us) {
     _kv_cache->record_read_remote(size, lateny_us);
 }
@@ -155,7 +182,13 @@ const DataCacheMetrics BlockCache::cache_metrics(int level) const {
 }
 
 Status BlockCache::shutdown() {
+    if (!_initialized.load(std::memory_order_relaxed)) {
+        return Status::OK();
+    }
     Status st = _kv_cache->shutdown();
+    if (_disk_space_monitor) {
+        _disk_space_monitor->stop();
+    }
     _initialized.store(false, std::memory_order_relaxed);
     return st;
 }

--- a/be/src/block_cache/block_cache.h
+++ b/be/src/block_cache/block_cache.h
@@ -14,6 +14,7 @@
 
 #pragma once
 
+#include "block_cache/disk_space_monitor.h"
 #include "block_cache/kv_cache.h"
 #include "common/status.h"
 
@@ -26,6 +27,8 @@ public:
 
     // Return a singleton block cache instance
     static BlockCache* instance();
+
+    ~BlockCache();
 
     // Init the block cache instance
     Status init(const CacheOptions& options);
@@ -57,6 +60,15 @@ public:
     // Remove data from cache. The offset and size must be aligned by block size
     Status remove(const CacheKey& cache_key, off_t offset, size_t size);
 
+    // Update the datacache memory quota.
+    Status update_mem_quota(size_t quota_bytes);
+
+    // Update the datacache disk space infomation, such as disk quota or disk path.
+    Status update_disk_spaces(const std::vector<DirSpace>& spaces);
+
+    // Adjust the disk spaces, the space quota will be adjusted based on current disk usage before updating.
+    Status adjust_disk_spaces(const std::vector<DirSpace>& spaces);
+
     void record_read_remote(size_t size, int64_t lateny_us);
 
     void record_read_cache(size_t size, int64_t lateny_us);
@@ -81,6 +93,7 @@ private:
 
     size_t _block_size = 0;
     std::unique_ptr<KvCache> _kv_cache;
+    std::unique_ptr<DiskSpaceMonitor> _disk_space_monitor;
     std::atomic<bool> _initialized = false;
 };
 

--- a/be/src/block_cache/cache_options.h
+++ b/be/src/block_cache/cache_options.h
@@ -19,6 +19,8 @@
 #include <string>
 #include <vector>
 
+#include "common/status.h"
+
 namespace starrocks {
 
 struct DirSpace {
@@ -70,8 +72,15 @@ struct ReadCacheOptions {
     } stats;
 };
 
-int64_t parse_mem_size(const std::string& mem_size_str, int64_t mem_limit = -1);
+int64_t parse_conf_datacache_mem_size(const std::string& conf_mem_size_str, int64_t mem_limit);
 
-int64_t parse_disk_size(const std::string& disk_path, const std::string& disk_size_str, int64_t disk_limit = -1);
+int64_t parse_conf_datacache_disk_size(const std::string& disk_path, const std::string& disk_size_str,
+                                       int64_t disk_limit);
+
+Status parse_conf_datacache_disk_paths(const std::string& config_path, std::vector<std::string>* paths,
+                                       bool ignore_broken_disk);
+
+Status parse_conf_datacache_disk_spaces(const std::string& config_disk_path, const std::string& config_disk_size,
+                                        bool ignore_broken_disk, std::vector<DirSpace>* disk_spaces);
 
 } // namespace starrocks

--- a/be/src/block_cache/cachelib_wrapper.cpp
+++ b/be/src/block_cache/cachelib_wrapper.cpp
@@ -109,6 +109,14 @@ Status CacheLibWrapper::read_object(const std::string& key, CacheHandle* handle,
     return Status::NotSupported("not supported read object in cachelib");
 }
 
+Status CacheLibWrapper::update_mem_quota(size_t quota_bytes) {
+    return Status::NotSupported("not support updating memory cache quota for cachelib");
+}
+
+Status update_disk_spaces(const std::vector<DirSpace>& spaces) {
+    return Status::NotSupported("not support updating disk cache spaces for cachelib");
+}
+
 void CacheLibWrapper::record_read_remote(size_t size, int64_t lateny_us) {}
 
 void CacheLibWrapper::record_read_cache(size_t size, int64_t lateny_us) {}

--- a/be/src/block_cache/cachelib_wrapper.h
+++ b/be/src/block_cache/cachelib_wrapper.h
@@ -56,6 +56,10 @@ public:
 
     Status remove(const std::string& key) override;
 
+    Status update_mem_quota(size_t quota_bytes) override;
+
+    Status update_disk_spaces(const std::vector<DirSpace>& spaces) override;
+
     const DataCacheMetrics cache_metrics(int level) override;
 
     void record_read_remote(size_t size, int64_t lateny_us) override;

--- a/be/src/block_cache/disk_space_monitor.cpp
+++ b/be/src/block_cache/disk_space_monitor.cpp
@@ -1,0 +1,271 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "block_cache/disk_space_monitor.h"
+
+#include "block_cache/block_cache.h"
+#include "common/config.h"
+#include "util/await.h"
+#include "util/thread.h"
+
+namespace starrocks {
+
+#ifndef BE_TEST
+const size_t DiskSpaceMonitor::QUOTA_ALIGN_UNIT = 10uL * 1024 * 1024 * 1024;
+#else
+const size_t DiskSpaceMonitor::QUOTA_ALIGN_UNIT = 10uL * 1024 * 1024;
+#endif
+
+const int64_t DiskSpaceMonitor::AUTO_INCREASE_THRESHOLD = 90;
+
+StatusOr<size_t> DiskSpaceMonitor::FileSystemWrapper::directory_capacity(const std::string& dir) {
+    size_t capacity = 0;
+    auto st = FileSystem::Default()->iterate_dir2(dir, [&](DirEntry entry) {
+        capacity += entry.size.value();
+        return true;
+    });
+    RETURN_IF_ERROR(st);
+    return capacity;
+}
+
+DiskSpaceMonitor::DiskSpaceMonitor(BlockCache* cache) : _fs(std::make_unique<FileSystemWrapper>()), _cache(cache) {}
+
+DiskSpaceMonitor::~DiskSpaceMonitor() {
+    stop();
+}
+
+void DiskSpaceMonitor::start() {
+    std::unique_lock<std::mutex> lck(_mutex);
+    if (!_stopped.load(std::memory_order_acquire)) {
+        return;
+    }
+    _stopped.store(false, std::memory_order_release);
+    _adjust_datacache_thread = std::thread([this] { _adjust_datacache_callback(); });
+    Thread::set_thread_name(_adjust_datacache_thread, "adjust_datacache");
+}
+
+void DiskSpaceMonitor::stop() {
+    if (_stopped.load(std::memory_order_acquire)) {
+        return;
+    }
+    _stopped.store(true, std::memory_order_release);
+    if (_adjust_datacache_thread.joinable()) {
+        _adjust_datacache_thread.join();
+    }
+}
+
+bool DiskSpaceMonitor::is_stopped() {
+    return _stopped.load(std::memory_order_acquire);
+}
+
+void DiskSpaceMonitor::_adjust_datacache_callback() {
+    while (!is_stopped()) {
+        std::unique_lock<std::mutex> lck(_mutex);
+        if (config::datacache_enable && config::datacache_auto_adjust_enable &&
+            !_adjusting.load(std::memory_order_acquire)) {
+            _update_disk_stats();
+            _update_cache_stats();
+            if (_adjust_spaces_by_disk_usage(false)) {
+                Status st = adjust_cache_quota(_dir_spaces);
+                LOG_IF(WARNING, !st.ok()) << "fail to adjust datacache disk quota, reason: " << st.message();
+            }
+        }
+        lck.unlock();
+
+        static const int64_t kWaitTimeout = config::datacache_disk_adjust_interval_seconds * 1000 * 1000;
+        static const int64_t kCheckInterval = 1000 * 1000;
+        auto cond = [this]() { return is_stopped(); };
+        auto ret = Awaitility().timeout(kWaitTimeout).interval(kCheckInterval).until(cond);
+        if (ret) {
+            break;
+        }
+    }
+}
+
+bool DiskSpaceMonitor::adjust_spaces(std::vector<DirSpace>* dir_spaces) {
+    std::unique_lock<std::mutex> lck(_mutex);
+    _reset();
+    if (dir_spaces->empty()) {
+        return false;
+    }
+
+    _dir_spaces = *dir_spaces;
+    _min_disk_dirs = _dir_spaces.size();
+    for (size_t dir_index = 0; dir_index < _dir_spaces.size(); ++dir_index) {
+        auto& dir_space = _dir_spaces[dir_index];
+        int disk_id = _fs->disk_id(dir_space.path);
+        if (_disk_stats.find(disk_id) == _disk_stats.end()) {
+            DiskStats disk;
+            disk.disk_id = disk_id;
+            disk.path = dir_space.path;
+            _disk_stats[disk_id] = disk;
+        }
+        _disk_to_dirs[disk_id].push_back(dir_index);
+    }
+    for (const auto& pair : _disk_to_dirs) {
+        const auto& dirs = pair.second;
+        _max_disk_dirs = std::max(_max_disk_dirs, dirs.size());
+        _min_disk_dirs = std::min(_min_disk_dirs, dirs.size());
+    }
+    _update_disk_stats();
+
+    // We check this switch after some infomation are initialized, such as `_disk_stats`, because
+    // even if it is off now, we still need these infomation once the switch is turn on online.
+    if (!config::datacache_auto_adjust_enable) {
+        return false;
+    }
+
+    _init_spaces_by_cache_dir();
+    if (_adjust_spaces_by_disk_usage(true)) {
+        *dir_spaces = _dir_spaces;
+        return true;
+    }
+    return false;
+}
+
+void DiskSpaceMonitor::_update_disk_stats() {
+    for (auto& pair : _disk_stats) {
+        auto& disk = pair.second;
+        std::string path = disk.path;
+        auto ret = _fs->space(path);
+        if (!ret.ok()) {
+            LOG(WARNING) << ret.status().message();
+            continue;
+        }
+        auto& space_info = ret.value();
+        disk.capacity_bytes = space_info.capacity;
+        disk.available_bytes = space_info.available;
+    }
+}
+
+int64_t DiskSpaceMonitor::_max_disk_used_rate() {
+    int64_t max_used_rate = 0;
+    for (const auto& pair : _disk_to_dirs) {
+        const auto& disk_id = pair.first;
+        const auto& disk = _disk_stats[disk_id];
+        int64_t used_rate = (disk.capacity_bytes - disk.available_bytes) * 100 / disk.capacity_bytes;
+        if (used_rate > max_used_rate) {
+            max_used_rate = used_rate;
+        }
+    }
+    return max_used_rate;
+}
+
+void DiskSpaceMonitor::_init_spaces_by_cache_dir() {
+    _total_cache_usage = 0;
+    for (auto& dir_space : _dir_spaces) {
+        auto ret = _fs->directory_capacity(dir_space.path);
+        if (ret.ok()) {
+            dir_space.size = ret.value();
+            _total_cache_usage += ret.value();
+        }
+        _total_cache_quota += dir_space.size;
+    }
+}
+
+void DiskSpaceMonitor::_update_spaces_by_cache_usage() {
+    if (_total_cache_quota == 0) {
+        return;
+    }
+    double cache_used_rate = static_cast<double>(_total_cache_usage) / _total_cache_quota;
+    for (auto& dir_space : _dir_spaces) {
+        dir_space.size = dir_space.size * cache_used_rate;
+    }
+}
+
+void DiskSpaceMonitor::_update_cache_stats() {
+    const auto metrics = _cache->cache_metrics();
+    _total_cache_usage = metrics.disk_used_bytes;
+    _total_cache_quota = metrics.disk_quota_bytes;
+}
+
+bool DiskSpaceMonitor::_adjust_spaces_by_disk_usage(bool immediate) {
+    bool shrink = false;
+    int64_t max_disk_used_rate = _max_disk_used_rate();
+    if (max_disk_used_rate > config::datacache_disk_urgent_level) {
+        shrink = true;
+    } else if (max_disk_used_rate < config::datacache_disk_safe_level) {
+        _disk_free_period += config::datacache_disk_adjust_interval_seconds;
+        if (!immediate && _disk_free_period < config::datacache_disk_idle_seconds_for_expansion) {
+            return false;
+        }
+        if (_total_cache_quota > 0) {
+            double cache_used_rate = 100.0 * _total_cache_usage / _total_cache_quota;
+            if (cache_used_rate < AUTO_INCREASE_THRESHOLD) {
+                return false;
+            }
+        }
+    } else {
+        return false;
+    }
+
+    int64_t delta_rate = 0;
+    if (!shrink) {
+        // Increase cache quota
+        delta_rate = (config::datacache_disk_safe_level - max_disk_used_rate) / _max_disk_dirs;
+        DCHECK_GT(delta_rate, 0);
+    } else {
+        // Decrease cache quota
+        delta_rate = (config::datacache_disk_safe_level - max_disk_used_rate) / _min_disk_dirs;
+        DCHECK_LT(delta_rate, 0);
+        _update_spaces_by_cache_usage();
+    }
+
+    int64_t total_cache_quota = 0;
+    for (const auto& pair : _disk_to_dirs) {
+        const auto& disk_id = pair.first;
+        const auto& dirs = pair.second;
+        const auto& disk = _disk_stats[disk_id];
+        int64_t delta_quota = disk.capacity_bytes / 100 * delta_rate;
+        size_t disk_cache_quota = 0;
+        for (uint32_t dir_index : dirs) {
+            auto& dir_space = _dir_spaces[dir_index];
+            dir_space.size += delta_quota;
+            dir_space.size = dir_space.size / QUOTA_ALIGN_UNIT * QUOTA_ALIGN_UNIT;
+            disk_cache_quota += dir_space.size;
+        }
+        total_cache_quota += disk_cache_quota;
+    }
+
+    _disk_free_period = 0;
+    if (total_cache_quota < config::datacache_min_disk_quota_for_adjustment) {
+        // If the current available disk space is too small, cache quota will be reset to zero to avoid overly frequent
+        // population and eviction.
+        _reset_spaces();
+        if (_total_cache_quota == 0) {
+            // If the cache quata is already zero, skip adjusting it repeatedly.
+            return false;
+        } else {
+            // This warning log only be printed when the cache disk quota is adjust from a non-zero integer to zero.
+            LOG(WARNING) << "The current available disk space is too small, so disable the disk cache directly. If you "
+                         << "still need it, you could reduce the value of `datacache_min_disk_quota_for_adjustment`";
+        }
+    }
+    return true;
+}
+
+void DiskSpaceMonitor::_reset_spaces() {
+    for (auto& dir_space : _dir_spaces) {
+        dir_space.size = 0;
+    }
+}
+
+Status DiskSpaceMonitor::adjust_cache_quota(const std::vector<DirSpace>& dir_spaces) {
+    _adjusting.store(true, std::memory_order_release);
+    Status st = _cache->update_disk_spaces(dir_spaces);
+    _adjusting.store(false, std::memory_order_release);
+    return st;
+}
+
+} // namespace starrocks

--- a/be/src/block_cache/disk_space_monitor.h
+++ b/be/src/block_cache/disk_space_monitor.h
@@ -1,0 +1,117 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <atomic>
+#include <mutex>
+#include <thread>
+#include <unordered_map>
+
+#include "block_cache/cache_options.h"
+#include "common/status.h"
+#include "fs/fs.h"
+#include "util/disk_info.h"
+
+namespace starrocks {
+
+class BlockCache;
+class DiskSpaceMonitor {
+public:
+    struct DiskStats {
+        int disk_id = 0;
+        std::string path;
+        size_t capacity_bytes = 0;
+        size_t available_bytes = 0;
+    };
+
+    // Wrap a new class to make it easy controlled in unittest.
+    class FileSystemWrapper {
+    public:
+        virtual StatusOr<SpaceInfo> space(const std::string& path) { return FileSystem::Default()->space(path); }
+
+        virtual StatusOr<size_t> directory_capacity(const std::string& dir);
+
+        virtual int disk_id(const std::string& path) { return DiskInfo::disk_id(path.c_str()); }
+
+        virtual ~FileSystemWrapper() {}
+    };
+
+    DiskSpaceMonitor(BlockCache* cache);
+    ~DiskSpaceMonitor();
+
+    void start();
+
+    void stop();
+
+    bool is_stopped();
+
+    bool adjust_spaces(std::vector<DirSpace>* dir_spaces);
+
+    Status check_spaces();
+
+    Status adjust_cache_quota(const std::vector<DirSpace>& dir_spaces);
+
+    // The align unit when adjusting cache disk quota. We set it to 10G to keep consistent with underlying cache file size,
+    // which can help reduce processing the specail tail files.
+    const static size_t QUOTA_ALIGN_UNIT;
+    // The cache usage threshold for automatically increase disk quota, if the cache usage is under this level,
+    // the disk expansion will be skipped.
+    // NOTICE: When users update the disk quota manually, this threshold will be ignored.
+    const static int64_t AUTO_INCREASE_THRESHOLD;
+
+private:
+    void _update_disk_stats();
+    void _update_cache_stats();
+    void _reset_spaces();
+    void _init_spaces_by_cache_dir();
+    void _update_spaces_by_cache_usage();
+    bool _adjust_spaces_by_disk_usage(bool immediate);
+
+    int64_t _max_disk_used_rate();
+
+    void _adjust_datacache_callback();
+
+    void _reset() {
+        _dir_spaces.clear();
+        _disk_stats.clear();
+        _disk_to_dirs.clear();
+    }
+
+    std::vector<DirSpace> _dir_spaces;
+    // <disk_id, DiskStats>
+    std::unordered_map<int, DiskStats> _disk_stats;
+
+    // The datacache can be configured to have multiple data directories on the same physical disk.
+    // <disk_id, dir_space_index_list>
+    std::unordered_map<int, std::vector<uint32_t>> _disk_to_dirs;
+    // Max directory count in one disk
+    size_t _max_disk_dirs = 0;
+    // Minimum directory count in one disk
+    size_t _min_disk_dirs = 0;
+
+    size_t _total_cache_usage = 0;
+    size_t _total_cache_quota = 0;
+    int64_t _disk_free_period = 0;
+
+    std::atomic<bool> _stopped = true;
+    std::atomic<bool> _adjusting = false;
+    std::thread _adjust_datacache_thread;
+    std::mutex _mutex;
+
+    std::unique_ptr<FileSystemWrapper> _fs = nullptr;
+    BlockCache* _cache = nullptr;
+};
+
+} // namespace starrocks

--- a/be/src/block_cache/kv_cache.h
+++ b/be/src/block_cache/kv_cache.h
@@ -50,6 +50,12 @@ public:
     // Remove data from cache. The offset must be aligned by block size
     virtual Status remove(const std::string& key) = 0;
 
+    // Update the datacache memory quota.
+    virtual Status update_mem_quota(size_t quota_bytes) = 0;
+
+    // Update the datacache disk space infomation, such as disk quota or disk path.
+    virtual Status update_disk_spaces(const std::vector<DirSpace>& spaces) = 0;
+
     virtual const DataCacheMetrics cache_metrics(int level) = 0;
 
     virtual void record_read_remote(size_t size, int64_t lateny_us) = 0;

--- a/be/src/block_cache/starcache_wrapper.cpp
+++ b/be/src/block_cache/starcache_wrapper.cpp
@@ -126,6 +126,19 @@ Status StarCacheWrapper::remove(const std::string& key) {
     return Status::OK();
 }
 
+Status StarCacheWrapper::update_mem_quota(size_t quota_bytes) {
+    return to_status(_cache->update_mem_quota(quota_bytes));
+}
+
+Status StarCacheWrapper::update_disk_spaces(const std::vector<DirSpace>& spaces) {
+    std::vector<starcache::DirSpace> disk_spaces;
+    disk_spaces.reserve(spaces.size());
+    for (auto& dir : spaces) {
+        disk_spaces.push_back({.path = dir.path, .quota_bytes = dir.size});
+    }
+    return to_status(_cache->update_disk_spaces(disk_spaces));
+}
+
 const DataCacheMetrics StarCacheWrapper::cache_metrics(int level) {
     auto metrics = _cache->metrics(level);
     // Now the EEXIST is treated as an failed status in starcache, which will cause the write_fail_count too large

--- a/be/src/block_cache/starcache_wrapper.h
+++ b/be/src/block_cache/starcache_wrapper.h
@@ -40,6 +40,10 @@ public:
 
     Status remove(const std::string& key) override;
 
+    Status update_mem_quota(size_t quota_bytes) override;
+
+    Status update_disk_spaces(const std::vector<DirSpace>& spaces) override;
+
     const DataCacheMetrics cache_metrics(int level) override;
 
     void record_read_remote(size_t size, int64_t lateny_us) override;

--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -1051,10 +1051,10 @@ CONF_Int64(max_length_for_bitmap_function, "1000000");
 
 // Configuration items for datacache
 CONF_Bool(datacache_enable, "false");
-CONF_String(datacache_mem_size, "10%");
-CONF_String(datacache_disk_size, "0");
-CONF_String(datacache_disk_path, "${STARROCKS_HOME}/datacache/");
-CONF_String(datacache_meta_path, "${STARROCKS_HOME}/datacache/");
+CONF_mString(datacache_mem_size, "0");
+CONF_mString(datacache_disk_size, "0");
+CONF_mString(datacache_disk_path, "");
+CONF_String(datacache_meta_path, "");
 CONF_Int64(datacache_block_size, "262144"); // 256K
 CONF_Bool(datacache_checksum_enable, "false");
 CONF_Bool(datacache_direct_io_enable, "false");
@@ -1087,6 +1087,28 @@ CONF_Bool(datacache_tiered_cache_enable, "true");
 CONF_String(datacache_engine, "");
 // The interval time (millisecond) for agent report datacache metrics to FE.
 CONF_mInt32(report_datacache_metrics_interval_ms, "60000");
+// Whether enable automatically adjust cache space quota.
+// If true, the cache will choose an appropriate quota based on the current remaining space as the quota.
+// and the quota also will be changed dynamiclly.
+// Once the disk space usage reach the urgent level, the quota will be decreased to keep the disk usage
+// around the disk safe level.
+// On the other hand, if the cache is full and the disk usage falls below the disk safe level for a long time,
+// which is configured by `datacache_disk_idle_period_for_expansion`, the cache quota will be increased to keep the
+// disk usage around the disk safe level.
+CONF_mBool(datacache_auto_adjust_enable, "false");
+// The disk usage threshold, which trigger the cache eviction and quota decreased.
+CONF_mInt64(datacache_disk_urgent_level, "80");
+// The disk usage threshold, the cache quota will be decreased to this level once it reach the urgent level.
+CONF_mInt64(datacache_disk_safe_level, "70");
+// The interval seconds to check the disk usage and trigger adjustment.
+CONF_mInt64(datacache_disk_adjust_interval_seconds, "10");
+// The silent period, only when the disk usage falls bellow the safe level for a time longer than this period,
+// the disk expansion can be triggered
+CONF_mInt64(datacache_disk_idle_seconds_for_expansion, "7200");
+// The minimum total disk quota bytes to adjust, once the quota to adjust is less than this value,
+// cache quota will be reset to zero to avoid overly frequent population and eviction.
+// Default: 100G
+CONF_mInt64(datacache_min_disk_quota_for_adjustment, "107374182400");
 
 // The following configurations will be deprecated, and we use the `datacache` prefix instead.
 // But it is temporarily necessary to keep them for a period of time to be compatible with

--- a/be/src/http/action/update_config_action.cpp
+++ b/be/src/http/action/update_config_action.cpp
@@ -43,6 +43,7 @@
 
 #include "agent/agent_common.h"
 #include "agent/agent_server.h"
+#include "block_cache/block_cache.h"
 #include "common/configbase.h"
 #include "common/logging.h"
 #include "common/status.h"
@@ -97,6 +98,25 @@ Status UpdateConfigAction::update_config(const std::string& name, const std::str
                 StoragePageCache::instance()->set_capacity(cache_limit);
             }
         });
+        _config_callback.emplace("datacache_mem_size", [&]() {
+            int64_t mem_limit = MemInfo::physical_mem();
+            if (GlobalEnv::GetInstance()->process_mem_tracker()->has_limit()) {
+                mem_limit = GlobalEnv::GetInstance()->process_mem_tracker()->limit();
+            }
+            size_t mem_size = parse_conf_datacache_mem_size(config::datacache_mem_size, mem_limit);
+            (void)BlockCache::instance()->update_mem_quota(mem_size);
+        });
+        _config_callback.emplace("datacache_disk_size", [&]() {
+            std::vector<DirSpace> spaces;
+            Status st = parse_conf_datacache_disk_spaces(config::datacache_disk_path, config::datacache_disk_size,
+                                                         config::ignore_broken_disk, &spaces);
+            if (!st.ok()) {
+                LOG(WARNING) << "Failed to update datacache disk spaces";
+                return;
+            }
+            (void)BlockCache::instance()->adjust_disk_spaces(spaces);
+        });
+        _config_callback.emplace("datacache_disk_path", _config_callback["datacache_disk_size"]);
         _config_callback.emplace("max_compaction_concurrency", [&]() {
             (void)StorageEngine::instance()->compaction_manager()->update_max_threads(
                     config::max_compaction_concurrency);

--- a/be/src/storage/options.cpp
+++ b/be/src/storage/options.cpp
@@ -160,38 +160,4 @@ Status parse_conf_store_paths(const string& config_path, std::vector<StorePath>*
     return Status::OK();
 }
 
-Status parse_conf_datacache_paths(const std::string& config_path, std::vector<std::string>* paths) {
-    if (config_path.empty()) {
-        return Status::OK();
-    }
-    std::vector<string> path_vec = strings::Split(config_path, ";", strings::SkipWhitespace());
-    for (auto& item : path_vec) {
-        StripWhiteSpace(&item);
-        item.erase(item.find_last_not_of('/') + 1);
-        if (item.empty() || item[0] != '/') {
-            LOG(WARNING) << "invalid datacache path. path=" << item;
-            continue;
-        }
-
-        Status status = FileSystem::Default()->create_dir_if_missing(item);
-        if (!status.ok()) {
-            LOG(WARNING) << "datacache path can not be created. path=" << item;
-            continue;
-        }
-
-        string canonicalized_path;
-        status = FileSystem::Default()->canonicalize(item, &canonicalized_path);
-        if (!status.ok()) {
-            LOG(WARNING) << "datacache path can not be canonicalized. may be not exist. path=" << item;
-            continue;
-        }
-        paths->emplace_back(canonicalized_path);
-    }
-    if ((path_vec.size() != paths->size() && !config::ignore_broken_disk)) {
-        LOG(WARNING) << "fail to parse datacache_disk_path config. value=[" << config_path << "]";
-        return Status::InvalidArgument("fail to parse datacache_disk_path");
-    }
-    return Status::OK();
-}
-
 } // end namespace starrocks

--- a/be/src/testutil/scoped_updater.h
+++ b/be/src/testutil/scoped_updater.h
@@ -1,0 +1,33 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+namespace starrocks {
+
+template <typename T>
+class ScopedUpdater {
+public:
+    ScopedUpdater(T& param, T value) : _param(param), _saved_old_value(param) { param = value; }
+    ~ScopedUpdater() { _param = _saved_old_value; }
+
+private:
+    T& _param;
+    T _saved_old_value;
+};
+
+#define CONCAT(x, y) x##y
+#define CONCAT2(x, y) CONCAT(x, y)
+#define SCOPED_UPDATE(type, param, value) \
+    std::shared_ptr<ScopedUpdater<type>> CONCAT2(_var_updater_, __LINE__)(new ScopedUpdater<type>(param, value))
+
+} // namespace starrocks

--- a/be/test/CMakeLists.txt
+++ b/be/test/CMakeLists.txt
@@ -442,6 +442,7 @@ set(EXEC_FILES
 
 if ("${WITH_STARCACHE}" STREQUAL "ON" OR "${WITH_CACHELIB}" STREQUAL "ON")
     list(APPEND EXEC_FILES ./block_cache/block_cache_test.cpp)
+    list(APPEND EXEC_FILES ./block_cache/disk_space_monitor_test.cpp)
     list(APPEND EXEC_FILES ./io/cache_input_stream_test.cpp)
 endif ()
 

--- a/be/test/block_cache/block_cache_test.cpp
+++ b/be/test/block_cache/block_cache_test.cpp
@@ -67,30 +67,30 @@ TEST_F(BlockCacheTest, copy_to_iobuf) {
 
 TEST_F(BlockCacheTest, parse_cache_space_size_str) {
     uint64_t mem_size = 10;
-    ASSERT_EQ(parse_mem_size("10"), mem_size);
+    ASSERT_EQ(parse_conf_datacache_mem_size("10", 0), mem_size);
     mem_size *= 1024;
-    ASSERT_EQ(parse_mem_size("10K"), mem_size);
+    ASSERT_EQ(parse_conf_datacache_mem_size("10K", 0), mem_size);
     mem_size *= 1024;
-    ASSERT_EQ(parse_mem_size("10M"), mem_size);
+    ASSERT_EQ(parse_conf_datacache_mem_size("10M", 0), mem_size);
     mem_size *= 1024;
-    ASSERT_EQ(parse_mem_size("10G"), mem_size);
+    ASSERT_EQ(parse_conf_datacache_mem_size("10G", 0), mem_size);
     mem_size *= 1024;
-    ASSERT_EQ(parse_mem_size("10T"), mem_size);
-    ASSERT_EQ(parse_mem_size("10%", 10 * 1024), 1024);
+    ASSERT_EQ(parse_conf_datacache_mem_size("10T", 0), mem_size);
+    ASSERT_EQ(parse_conf_datacache_mem_size("10%", 10 * 1024), 1024);
 
     std::string disk_path = "./block_disk_cache";
     uint64_t disk_size = 10;
-    ASSERT_EQ(parse_disk_size(disk_path, "10"), disk_size);
+    ASSERT_EQ(parse_conf_datacache_disk_size(disk_path, "10", 0), disk_size);
     disk_size *= 1024;
-    ASSERT_EQ(parse_disk_size(disk_path, "10K"), disk_size);
+    ASSERT_EQ(parse_conf_datacache_disk_size(disk_path, "10K", 0), disk_size);
     disk_size *= 1024;
-    ASSERT_EQ(parse_disk_size(disk_path, "10M"), disk_size);
+    ASSERT_EQ(parse_conf_datacache_disk_size(disk_path, "10M", 0), disk_size);
     disk_size *= 1024;
-    ASSERT_EQ(parse_disk_size(disk_path, "10G"), disk_size);
+    ASSERT_EQ(parse_conf_datacache_disk_size(disk_path, "10G", 0), disk_size);
     disk_size *= 1024;
-    ASSERT_EQ(parse_disk_size(disk_path, "10T"), disk_size);
+    ASSERT_EQ(parse_conf_datacache_disk_size(disk_path, "10T", 0), disk_size);
 
-    disk_size = parse_disk_size(disk_path, "10%");
+    disk_size = parse_conf_datacache_disk_size(disk_path, "10%", 0);
     std::error_code ec;
     auto space_info = std::filesystem::space(disk_path, ec);
     ASSERT_EQ(disk_size, int64_t(10.0 / 100.0 * space_info.capacity));
@@ -100,22 +100,22 @@ TEST_F(BlockCacheTest, parse_cache_space_paths) {
     const std::string cwd = std::filesystem::current_path().string();
     const std::string s_normal_path = fmt::format("{}/block_disk_cache/cache1;{}/block_disk_cache/cache2", cwd, cwd);
     std::vector<std::string> paths;
-    ASSERT_TRUE(parse_conf_datacache_paths(s_normal_path, &paths).ok());
+    ASSERT_TRUE(parse_conf_datacache_disk_paths(s_normal_path, &paths, true).ok());
     ASSERT_EQ(paths.size(), 2);
 
     paths.clear();
     const std::string s_space_path = fmt::format(" {}/block_disk_cache/cache3 ; {}/block_disk_cache/cache4 ", cwd, cwd);
-    ASSERT_TRUE(parse_conf_datacache_paths(s_space_path, &paths).ok());
+    ASSERT_TRUE(parse_conf_datacache_disk_paths(s_space_path, &paths, true).ok());
     ASSERT_EQ(paths.size(), 2);
 
     paths.clear();
     const std::string s_empty_path = fmt::format("//;{}/block_disk_cache/cache4 ", cwd, cwd);
-    ASSERT_FALSE(parse_conf_datacache_paths(s_empty_path, &paths).ok());
+    ASSERT_FALSE(parse_conf_datacache_disk_paths(s_empty_path, &paths, true).ok());
     ASSERT_EQ(paths.size(), 1);
 
     paths.clear();
     const std::string s_invalid_path = fmt::format(" /block_disk_cache/cache5;{}/+/cache6", cwd, cwd);
-    ASSERT_FALSE(parse_conf_datacache_paths(s_invalid_path, &paths).ok());
+    ASSERT_FALSE(parse_conf_datacache_disk_paths(s_invalid_path, &paths, true).ok());
     ASSERT_EQ(paths.size(), 0);
 }
 

--- a/be/test/block_cache/disk_space_monitor_test.cpp
+++ b/be/test/block_cache/disk_space_monitor_test.cpp
@@ -1,0 +1,303 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <fmt/format.h>
+#include <gtest/gtest.h>
+
+#include <cstring>
+#include <filesystem>
+
+#include "block_cache/block_cache.h"
+#include "block_cache/test_cache_utils.h"
+#include "common/logging.h"
+#include "common/statusor.h"
+#include "fs/fs_util.h"
+#include "testutil/scoped_updater.h"
+
+namespace starrocks {
+
+class MockFileSystem : public DiskSpaceMonitor::FileSystemWrapper {
+public:
+    struct DiskSpaceInfo {
+        int disk_id;
+        SpaceInfo space_info;
+    };
+
+    StatusOr<SpaceInfo> space(const std::string& path) override {
+        auto info = _disk_space_info(path);
+        if (!info) {
+            return Status::IOError("io error");
+        }
+        return info->space_info;
+    }
+
+    StatusOr<size_t> directory_capacity(const std::string& dir) override { return _dir_capacity; }
+
+    int disk_id(const std::string& path) override {
+        auto info = _disk_space_info(path);
+        if (!info) {
+            return -1;
+        }
+        return info->disk_id;
+    }
+
+    void set_space(int disk_id, const std::string& disk_prefix, const SpaceInfo& space) {
+        DiskSpaceInfo info;
+        info.disk_id = disk_id;
+        info.space_info = space;
+        _space_infos[disk_prefix] = info;
+    }
+
+    void set_global_directory_capacity(size_t capacity) { _dir_capacity = capacity; }
+
+private:
+    DiskSpaceInfo* _disk_space_info(const std::string& path) {
+        std::string disk_prefix = path;
+        auto pos = disk_prefix.find("/");
+        if (pos != std::string::npos) {
+            disk_prefix = disk_prefix.substr(0, pos);
+        }
+        auto it = _space_infos.find(disk_prefix);
+        if (it != _space_infos.end()) {
+            return &(it->second);
+        }
+        return nullptr;
+    }
+
+    std::unordered_map<std::string, DiskSpaceInfo> _space_infos;
+    size_t _dir_capacity = 0;
+};
+
+class DiskSpaceMonitorTest : public ::testing::Test {
+public:
+    static const size_t kBlockSize;
+
+    static void SetUpTestCase() { ASSERT_TRUE(fs::create_directories("./block_disk_cache").ok()); }
+
+    static void TearDownTestCase() { ASSERT_TRUE(fs::remove_all("./block_disk_cache").ok()); }
+
+    void SetUp() override {}
+    void TearDown() override {
+        if (_cache) {
+            _cache->shutdown();
+        }
+    }
+
+private:
+    BlockCache* _cache = nullptr;
+};
+
+const size_t DiskSpaceMonitorTest::kBlockSize = 256 * KB;
+
+#ifdef WITH_STARCACHE
+
+TEST_F(DiskSpaceMonitorTest, adjust_for_empty_cache_dir) {
+    SCOPED_UPDATE(bool, config::datacache_auto_adjust_enable, true);
+    SCOPED_UPDATE(int64_t, config::datacache_disk_safe_level, 70);
+    SCOPED_UPDATE(int64_t, config::datacache_min_disk_quota_for_adjustment, 0);
+
+    auto space_monitor = std::make_unique<DiskSpaceMonitor>(nullptr);
+    MockFileSystem* mock_fs = new MockFileSystem;
+    space_monitor->_fs.reset(mock_fs);
+
+    SpaceInfo space_info = {.capacity = 1000 * GB, .free = 800 * GB, .available = 500 * GB};
+    mock_fs->set_space(1, "disk1", space_info);
+    mock_fs->set_space(2, "disk2", space_info);
+
+    std::vector<DirSpace> dir_spaces = {{.path = "disk1/dir1", .size = 500 * GB},
+                                        {.path = "disk1/dir2", .size = 500 * GB},
+                                        {.path = "disk2/dir2", .size = 500 * GB}};
+
+    ASSERT_TRUE(space_monitor->adjust_spaces(&dir_spaces));
+    for (auto& dir : dir_spaces) {
+        ASSERT_EQ(dir.size, 100 * GB);
+    }
+}
+
+TEST_F(DiskSpaceMonitorTest, adjust_for_dirty_cache_dir) {
+    SCOPED_UPDATE(bool, config::datacache_auto_adjust_enable, true);
+    SCOPED_UPDATE(int64_t, config::datacache_disk_safe_level, 70);
+    SCOPED_UPDATE(int64_t, config::datacache_min_disk_quota_for_adjustment, 0);
+
+    auto space_monitor = std::make_unique<DiskSpaceMonitor>(nullptr);
+    MockFileSystem* mock_fs = new MockFileSystem;
+    space_monitor->_fs.reset(mock_fs);
+
+    SpaceInfo space_info = {.capacity = 1000 * GB, .free = 800 * GB, .available = 500 * GB};
+    mock_fs->set_space(1, "disk1", space_info);
+    mock_fs->set_space(2, "disk2", space_info);
+    mock_fs->set_global_directory_capacity(100 * GB);
+
+    std::vector<DirSpace> dir_spaces = {{.path = "disk1/dir1", .size = 500 * GB},
+                                        {.path = "disk1/dir2", .size = 500 * GB},
+                                        {.path = "disk2/dir2", .size = 500 * GB}};
+
+    ASSERT_TRUE(space_monitor->adjust_spaces(&dir_spaces));
+    for (auto& dir : dir_spaces) {
+        ASSERT_EQ(dir.size, 200 * GB);
+    }
+}
+
+TEST_F(DiskSpaceMonitorTest, auto_increate_cache_quota) {
+    SCOPED_UPDATE(bool, config::datacache_enable, true);
+    SCOPED_UPDATE(bool, config::datacache_auto_adjust_enable, false);
+    SCOPED_UPDATE(int64_t, config::datacache_disk_safe_level, 70);
+    SCOPED_UPDATE(int64_t, config::datacache_min_disk_quota_for_adjustment, 0);
+    SCOPED_UPDATE(int64_t, config::datacache_disk_adjust_interval_seconds, 1);
+    SCOPED_UPDATE(int64_t, config::datacache_disk_idle_seconds_for_expansion, 300);
+
+    auto options = create_simple_options(kBlockSize, 5 * MB, 20 * MB);
+    auto cache = create_cache(options);
+
+    MockFileSystem* mock_fs = new MockFileSystem;
+    SpaceInfo space_info = {.capacity = 500 * MB, .free = 400 * MB, .available = 300 * MB};
+    mock_fs->set_space(1, ".", space_info);
+
+    auto& space_monitor = cache->_disk_space_monitor;
+    space_monitor->_fs.reset(mock_fs);
+    auto disk_spaces = options.disk_spaces;
+    space_monitor->adjust_spaces(&disk_spaces);
+
+    // Fill cache data
+    {
+        size_t batch_size = MB;
+        const std::string cache_key = "test_file";
+        for (size_t i = 0; i < 25; ++i) {
+            char ch = 'a' + i % 26;
+            std::string value(batch_size, ch);
+            Status st = cache->write_buffer(cache_key + std::to_string(i), 0, batch_size, value.c_str());
+            ASSERT_TRUE(st.ok());
+        }
+        auto metrics = cache->cache_metrics();
+        int64_t used_rate = metrics.disk_used_bytes * 100 / metrics.disk_quota_bytes;
+        ASSERT_GT(used_rate, DiskSpaceMonitor::AUTO_INCREASE_THRESHOLD);
+    }
+
+    {
+        auto metrics = cache->cache_metrics();
+        ASSERT_EQ(metrics.disk_quota_bytes, 20 * MB);
+    }
+
+    {
+        config::datacache_auto_adjust_enable = true;
+        sleep(3);
+        auto metrics = cache->cache_metrics();
+        ASSERT_EQ(metrics.disk_quota_bytes, 20 * MB);
+    }
+
+    {
+        config::datacache_disk_idle_seconds_for_expansion = 1;
+        sleep(3);
+        auto metrics = cache->cache_metrics();
+        // other: 200M - 20M = 180M
+        // new quota: 500 * 0.7 - other = 170M
+        ASSERT_EQ(metrics.disk_quota_bytes, 170 * MB);
+    }
+
+    cache->shutdown();
+}
+
+TEST_F(DiskSpaceMonitorTest, auto_decreate_cache_quota) {
+    SCOPED_UPDATE(bool, config::datacache_enable, true);
+    SCOPED_UPDATE(bool, config::datacache_auto_adjust_enable, false);
+    SCOPED_UPDATE(int64_t, config::datacache_disk_safe_level, 70);
+    SCOPED_UPDATE(int64_t, config::datacache_min_disk_quota_for_adjustment, 0);
+    SCOPED_UPDATE(int64_t, config::datacache_disk_adjust_interval_seconds, 3);
+    SCOPED_UPDATE(int64_t, config::datacache_disk_idle_seconds_for_expansion, 300);
+
+    auto options = create_simple_options(kBlockSize, 0, 50 * MB);
+    auto cache = create_cache(options);
+
+    MockFileSystem* mock_fs = new MockFileSystem;
+    SpaceInfo space_info = {.capacity = 100 * MB, .free = 20 * MB, .available = 10 * MB};
+    mock_fs->set_space(1, ".", space_info);
+
+    auto& space_monitor = cache->_disk_space_monitor;
+    space_monitor->_fs.reset(mock_fs);
+    auto disk_spaces = options.disk_spaces;
+    space_monitor->adjust_spaces(&disk_spaces);
+
+    // Fill cache data
+    {
+        size_t batch_size = MB;
+        const std::string cache_key = "test_file";
+        for (size_t i = 0; i < 50; ++i) {
+            char ch = 'a' + i % 26;
+            std::string value(batch_size, ch);
+            Status st = cache->write_buffer(cache_key + std::to_string(i), 0, batch_size, value.c_str());
+            ASSERT_TRUE(st.ok());
+        }
+        auto metrics = cache->cache_metrics();
+        int64_t used_rate = metrics.disk_used_bytes * 100 / metrics.disk_quota_bytes;
+        ASSERT_GT(used_rate, DiskSpaceMonitor::AUTO_INCREASE_THRESHOLD);
+    }
+
+    {
+        auto metrics = cache->cache_metrics();
+        ASSERT_EQ(metrics.disk_quota_bytes, 50 * MB);
+    }
+
+    {
+        config::datacache_auto_adjust_enable = true;
+        size_t new_quota = 0;
+        for (int i = 0; i < 6; ++i) {
+            auto metrics = cache->cache_metrics();
+            if (metrics.disk_quota_bytes > 0 && metrics.disk_quota_bytes != 50 * MB) {
+                config::datacache_auto_adjust_enable = false;
+                new_quota = metrics.disk_quota_bytes;
+                break;
+            }
+            sleep(1);
+        }
+        // other: 100M - 10M - 50M = 40M
+        // new quota: 100 * 0.7 - other = 30M
+        ASSERT_EQ(new_quota, 30 * MB);
+    }
+
+    cache->shutdown();
+}
+
+TEST_F(DiskSpaceMonitorTest, get_directory_capacity) {
+    SCOPED_UPDATE(bool, config::datacache_enable, true);
+    SCOPED_UPDATE(bool, config::datacache_auto_adjust_enable, false);
+
+    auto options = create_simple_options(kBlockSize, 0, 20 * MB);
+    auto cache = create_cache(options);
+
+    // Fill cache data
+    {
+        size_t batch_size = MB;
+        const std::string cache_key = "test_file";
+        for (size_t i = 0; i < 20; ++i) {
+            char ch = 'a' + i % 26;
+            std::string value(batch_size, ch);
+            Status st = cache->write_buffer(cache_key + std::to_string(i), 0, batch_size, value.c_str());
+            ASSERT_TRUE(st.ok());
+        }
+
+        auto& disk_spaces = options.disk_spaces;
+        auto& space_monitor = cache->_disk_space_monitor;
+        size_t capacity = 0;
+        for (auto& space : disk_spaces) {
+            auto ret = space_monitor->_fs->directory_capacity(space.path);
+            ASSERT_TRUE(ret.ok());
+            capacity += ret.value();
+        }
+        ASSERT_EQ(capacity, 20 * MB);
+    }
+}
+
+#endif
+
+} // namespace starrocks

--- a/be/test/block_cache/test_cache_utils.h
+++ b/be/test/block_cache/test_cache_utils.h
@@ -1,0 +1,51 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <fmt/format.h>
+
+#include "block_cache/block_cache.h"
+#include "common/logging.h"
+
+namespace starrocks {
+
+constexpr size_t KB = 1024;
+constexpr size_t MB = KB * 1024;
+constexpr size_t GB = MB * 1024;
+
+CacheOptions create_simple_options(size_t block_size, size_t mem_quota, ssize_t disk_quota = -1,
+                                   const std::string& engine = "starcache") {
+    CacheOptions options;
+    options.mem_space_size = mem_quota;
+    if (disk_quota > 0) {
+        options.disk_spaces.push_back({.path = "./block_disk_cache", .size = (size_t)disk_quota});
+    }
+    options.engine = engine;
+    options.enable_checksum = false;
+    options.max_concurrent_inserts = 1500000;
+    options.max_flying_memory_mb = 100;
+    options.enable_tiered_cache = true;
+    options.block_size = block_size;
+    options.skip_read_factor = 1.0;
+    return options;
+    return options;
+}
+
+std::shared_ptr<BlockCache> create_cache(const CacheOptions& options) {
+    std::shared_ptr<BlockCache> cache(new BlockCache);
+    Status status = cache->init(options);
+    EXPECT_TRUE(status.ok());
+    return cache;
+}
+
+} // namespace starrocks


### PR DESCRIPTION
## Why I'm doing:
* Now we configure the memory and disk quota for datacache in be.conf. So, when updating the cache quota based on the current resource usege, we have to change be.conf and restart BE process. 
* Also, many times, users may access both native table and extern tables in their cases and the disk usage. There may be disk or memory resource preemption in different scenarios. So we hope that datacache can automatically adjust its capacity based on the current disk usage, avoiding unexpected issues caused by resource contention with other modules.

## What I'm doing:
* Support adjust memory and disk quota for datacache online, without restarting BE process. 
You can update the memory and disk quota by your sql client as follows:
```
# update datacache memory quota for certain BE instance.
update be_configs set VALUE=1147483648 where NAME="datacache_mem_size" and BE_ID=10005;

# update datacache memory quota for all BE instance.
update be_configs set VALUE=1147483648 where NAME="datacache_mem_size" ;

# update datacache disk quota for all BE instance.
update be_configs set VALUE=107374182400 where NAME="datacache_disk_size";
```
* Support automatically adjust datacache disk quota based on current resource usage.
You can use this function by turning on the switch `datacache_auto_adjust_enable` in be.conf, if needed, you can adjust other related configuration items.


## What type of PR is this:

- [ ] BugFix
- [x] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [x] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
