### PR TITLE
[BugFix] Fix the concurrency bug of str_to_map

### DIFF
--- a/be/src/exprs/str_to_map.cpp
+++ b/be/src/exprs/str_to_map.cpp
@@ -36,12 +36,18 @@ StatusOr<ColumnPtr> StringFunctions::str_to_map(FunctionContext* context, const 
 
     // split first
     Columns split_columns{columns[0], columns[1]};
-    RETURN_IF_ERROR(StringFunctions::split_prepare(context, FunctionContext::FRAGMENT_LOCAL));
     ASSIGN_OR_RETURN(auto splited, StringFunctions::split(context, split_columns));
-    RETURN_IF_ERROR(StringFunctions::split_close(context, FunctionContext::FRAGMENT_LOCAL));
 
     Columns splited_columns{splited, columns[2]};
     return str_to_map_v1(context, splited_columns);
+}
+
+Status StringFunctions::str_to_map_prepare(FunctionContext* context, FunctionContext::FunctionStateScope scope) {
+    return StringFunctions::split_prepare(context, FunctionContext::FRAGMENT_LOCAL);
+}
+
+Status StringFunctions::str_to_map_close(FunctionContext* context, FunctionContext::FunctionStateScope scope) {
+    return StringFunctions::split_close(context, FunctionContext::FRAGMENT_LOCAL);
 }
 
 /**

--- a/be/src/exprs/string_functions.h
+++ b/be/src/exprs/string_functions.h
@@ -356,6 +356,8 @@ public:
     * @return: MapColumn map<string,string>
     */
     DEFINE_VECTORIZED_FN(str_to_map);
+    static Status str_to_map_prepare(FunctionContext* context, FunctionContext::FunctionStateScope scope);
+    static Status str_to_map_close(FunctionContext* context, FunctionContext::FunctionStateScope scope);
 
     /**
      * @param: [string_value, delimiter, field]

--- a/gensrc/script/functions.py
+++ b/gensrc/script/functions.py
@@ -328,7 +328,7 @@ vectorized_functions = [
     [30316, 'str_to_map', True, False, 'MAP_VARCHAR_VARCHAR', ['ARRAY_VARCHAR', 'VARCHAR'],
      'StringFunctions::str_to_map_v1'],
     [30317, 'str_to_map', True, False, 'MAP_VARCHAR_VARCHAR', ['VARCHAR', 'VARCHAR', 'VARCHAR'],
-     'StringFunctions::str_to_map'],
+     'StringFunctions::str_to_map', 'StringFunctions::str_to_map_prepare', 'StringFunctions::str_to_map_close'],
 
     [30320, 'regexp_extract', True, False, 'VARCHAR', ['VARCHAR', 'VARCHAR', 'BIGINT'],
      'StringFunctions::regexp_extract',

--- a/test/sql/test_function/R/test_str_to_map
+++ b/test/sql/test_function/R/test_str_to_map
@@ -1,0 +1,11 @@
+-- name: test_str_to_map
+CREATE TABLE t1(c1 INT, c2 STRING) DUPLICATE KEY(c1) DISTRIBUTED BY HASH(c1) BUCKETS 20;
+-- result:
+-- !result
+insert into t1 select generate_series, generate_series from TABLE(generate_series(1, 10000));
+-- result:
+-- !result
+select sum(cardinality(str_to_map(c2, ",", ":"))) from t1;
+-- result:
+10000
+-- !result

--- a/test/sql/test_function/T/test_str_to_map
+++ b/test/sql/test_function/T/test_str_to_map
@@ -1,0 +1,7 @@
+-- name: test_str_to_map
+
+CREATE TABLE t1(c1 INT, c2 STRING) DUPLICATE KEY(c1) DISTRIBUTED BY HASH(c1) BUCKETS 20;
+
+insert into t1 select generate_series, generate_series from TABLE(generate_series(1, 10000));
+
+select sum(cardinality(str_to_map(c2, ",", ":"))) from t1;


### PR DESCRIPTION
## Why I'm doing:

`prepare`/`close` should execute only once and `FunctionContext` is shared by all execute thread, if put `prepare`/`close` to str_to_map, It is not safe when using multiple threads concurrently.

```
*** Aborted at 1712733802 (unix time) try "date -d @1712733802" if you are using GNU date ***
PC: @          0x59f0990 starrocks::StringFunctions::split_close()
*** SIGSEGV (@0x0) received by PID 739 (TID 0x7f37a2bbd700) from PID 0; stack trace: ***
    @          0x6524f82 google::(anonymous namespace)::FailureSignalHandler()
    @     0x7f395d557875 os::Linux::chained_handler()
    @     0x7f395d55c871 JVM_handle_linux_signal
    @     0x7f395d54f578 signalHandler()
    @     0x7f395ca06630 (unknown)
    @          0x59f0990 starrocks::StringFunctions::split_close()
    @          0x59fd20c starrocks::StringFunctions::str_to_map()
    @          0x4bee584 starrocks::VectorizedFunctionCallExpr::evaluate_checked()
    @          0x4337843 starrocks::ExprContext::evaluate()
    @          0x4337b8f starrocks::ExprContext::evaluate()
    @          0x35d5c2c starrocks::pipeline::ProjectOperator::push_chunk()
    @          0x367fd08 starrocks::pipeline::PipelineDriver::process()
    @          0x36702ce starrocks::pipeline::GlobalDriverExecutor::_worker_thread()
    @          0x2d05e3c starrocks::ThreadPool::dispatch_thread()
    @          0x2cffaea starrocks::Thread::supervise_thread()
    @     0x7f395c9feea5 start_thread
    @     0x7f395bdffb0d __clone
    @                0x0 (unknown)
```

## What I'm doing:

Add str_to_map_prepare/str_to_map_close to fix the concurrency bug.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [x] 3.2
  - [x] 3.1
  - [ ] 3.0
  - [ ] 2.5
