### PR TITLE
[BugFix] Fix update planner more compitable between ouput column and target table column

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/UpdatePlanner.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/UpdatePlanner.java
@@ -25,6 +25,7 @@ import com.starrocks.catalog.Database;
 import com.starrocks.catalog.OlapTable;
 import com.starrocks.catalog.Partition;
 import com.starrocks.catalog.Table;
+import com.starrocks.catalog.Type;
 import com.starrocks.catalog.system.SystemTable;
 import com.starrocks.common.Pair;
 import com.starrocks.common.UserException;
@@ -221,7 +222,7 @@ public class UpdatePlanner {
                     targetTable.getName());
             if (!column.getType().matchesType(outputColumn.getType())) {
                 // This should be always true but add a check here to avoid updating the wrong column type.
-                if (!column.getType().isFullyCompatible(outputColumn.getType())) {
+                if (!Type.canCastTo(outputColumn.getType(), column.getType())) {
                     throw new SemanticException(String.format("Output column type %s is not compatible table column type: %s",
                             outputColumn.getType(), column.getType()));
                 }

--- a/test/sql/test_dml/R/test_update
+++ b/test/sql/test_dml/R/test_update
@@ -82,3 +82,28 @@ select * from primary_key_with_null order by k1, k2, k3;
 drop table if exists primary_key_with_null;
 -- result:
 -- !result
+CREATE TABLE `pk_tbl1` (
+ `k1` bigint(20) NOT NULL AUTO_INCREMENT,
+ `k2` datetime NULL,
+ `k3` bigint(20) NULL,
+ `k4` bigint(20) NULL,
+ `k5` int(11) NULL
+) ENGINE=OLAP
+PRIMARY KEY(`k1`)
+DISTRIBUTED BY HASH(`k1`);
+-- result:
+-- !result
+insert into pk_tbl1(k2, k3, k4, k5) values('2024-01-01', 1, 2, 3), ('2024-01-01', 1, 2, 3);
+-- result:
+-- !result
+update pk_tbl1 set K4 = 1, K3 = 1, K5 = 1 where K1 = 1;
+-- result:
+-- !result
+select * from pk_tbl1 order by k1;
+-- result:
+1	2024-01-01 00:00:00	1	1	1
+2	2024-01-01 00:00:00	1	2	3
+-- !result
+drop table if exists pk_tbl1;
+-- result:
+-- !result

--- a/test/sql/test_dml/T/test_update
+++ b/test/sql/test_dml/T/test_update
@@ -41,3 +41,17 @@ select * from primary_key_with_null order by k1, k2, k3;
 UPDATE primary_key_with_null SET `k5`  = 5;
 select * from primary_key_with_null order by k1, k2, k3;
 drop table if exists primary_key_with_null;
+
+CREATE TABLE `pk_tbl1` (
+ `k1` bigint(20) NOT NULL AUTO_INCREMENT,
+ `k2` datetime NULL,
+ `k3` bigint(20) NULL,
+ `k4` bigint(20) NULL,
+ `k5` int(11) NULL
+) ENGINE=OLAP
+PRIMARY KEY(`k1`)
+DISTRIBUTED BY HASH(`k1`);
+insert into pk_tbl1(k2, k3, k4, k5) values('2024-01-01', 1, 2, 3), ('2024-01-01', 1, 2, 3);
+update pk_tbl1 set K4 = 1, K3 = 1, K5 = 1 where K1 = 1;
+select * from pk_tbl1 order by k1;
+drop table if exists pk_tbl1;


### PR DESCRIPTION

## Why I'm doing:
- update will fail if output type and target table type are not fully compatible.

## What I'm doing:

- Make update planner more compitable between ouput column and target table column since we can add a cast operator.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [x] 3.2
  - [x] 3.1
  - [ ] 3.0
  - [ ] 2.5
