### PR TITLE
[BugFix] Add materialized view metrics about text based rewrite

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/metric/IMaterializedViewMetricsEntity.java
+++ b/fe/fe-core/src/main/java/com/starrocks/metric/IMaterializedViewMetricsEntity.java
@@ -39,6 +39,12 @@ public interface IMaterializedViewMetricsEntity {
     void increaseQueryMatchedCount(long count);
 
     /**
+     * Increase the count of query text matched which is rewritten by success
+     * @param count: increase count
+     */
+    void increaseQueryTextBasedMatchedCount(long count);
+
+    /**
      * Increase the count of query hit which is rewritten by success and chosen at the end
      * @param count: increase count
      */

--- a/fe/fe-core/src/main/java/com/starrocks/metric/MaterializedViewMetricsBlackHoleEntity.java
+++ b/fe/fe-core/src/main/java/com/starrocks/metric/MaterializedViewMetricsBlackHoleEntity.java
@@ -34,6 +34,12 @@ public class MaterializedViewMetricsBlackHoleEntity implements IMaterializedView
     public void increaseQueryMatchedCount(long count) {
 
     }
+
+    @Override
+    public void increaseQueryTextBasedMatchedCount(long count) {
+
+    }
+
     @Override
     public void increaseQueryHitCount(long count) {
 

--- a/fe/fe-core/src/main/java/com/starrocks/metric/MaterializedViewMetricsEntity.java
+++ b/fe/fe-core/src/main/java/com/starrocks/metric/MaterializedViewMetricsEntity.java
@@ -130,7 +130,7 @@ public final class MaterializedViewMetricsEntity implements IMaterializedViewMet
                 "total matched materialized view's query count");
         metrics.add(counterQueryMatchedTotal);
         // text based rewrite
-        counterQueryTextBasedMatchedTotal= new LongCounterMetric("mv_query_total_text_based_matched_count",
+        counterQueryTextBasedMatchedTotal = new LongCounterMetric("mv_query_total_text_based_matched_count",
                 MetricUnit.REQUESTS, "total text based matched materialized view's query count");
         metrics.add(counterQueryTextBasedMatchedTotal);
 

--- a/fe/fe-core/src/main/java/com/starrocks/metric/MaterializedViewMetricsEntity.java
+++ b/fe/fe-core/src/main/java/com/starrocks/metric/MaterializedViewMetricsEntity.java
@@ -63,6 +63,9 @@ public final class MaterializedViewMetricsEntity implements IMaterializedViewMet
     public LongCounterMetric counterQueryHitTotal;
     // increased once the materialized view is used in the final plan no matter it is queried directly or rewritten.
     public LongCounterMetric counterQueryMaterializedViewTotal;
+    // increased if the materialized view is successes to be rewritten from query by text based rewrite, and it will increase
+    // the counter query hit total.
+    public LongCounterMetric counterQueryTextBasedMatchedTotal;
 
     // gauge
     // the current pending refresh jobs for the materialized view
@@ -126,6 +129,10 @@ public final class MaterializedViewMetricsEntity implements IMaterializedViewMet
         counterQueryMatchedTotal = new LongCounterMetric("mv_query_total_matched_count", MetricUnit.REQUESTS,
                 "total matched materialized view's query count");
         metrics.add(counterQueryMatchedTotal);
+        // text based rewrite
+        counterQueryTextBasedMatchedTotal= new LongCounterMetric("mv_query_total_text_based_matched_count",
+                MetricUnit.REQUESTS, "total text based matched materialized view's query count");
+        metrics.add(counterQueryTextBasedMatchedTotal);
 
         // histogram metrics
         try {
@@ -297,6 +304,11 @@ public final class MaterializedViewMetricsEntity implements IMaterializedViewMet
     @Override
     public void increaseQueryMatchedCount(long count) {
         this.counterQueryMatchedTotal.increase(count);
+    }
+
+    @Override
+    public void increaseQueryTextBasedMatchedCount(long count) {
+        this.counterQueryTextBasedMatchedTotal.increase(count);
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/qe/StmtExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/StmtExecutor.java
@@ -455,6 +455,9 @@ public class StmtExecutor {
 
             if (parsedStmt.isExplain()) {
                 context.setExplainLevel(parsedStmt.getExplainLevel());
+            } else {
+                // reset the explain level to avoid the previous explain level affect the current query.
+                context.setExplainLevel(null);
             }
 
             // execPlan is the output of new planner

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/Optimizer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/Optimizer.java
@@ -163,7 +163,7 @@ public class Optimizer {
                                   ColumnRefSet requiredColumns,
                                   ColumnRefFactory columnRefFactory) {
         // prepare for optimizer
-        prepare(connectContext, columnRefFactory);
+        prepare(connectContext, columnRefFactory, logicOperatorTree);
 
         // try text based mv rewrite first before mv rewrite prepare so can deduce mv prepare time if it can be rewritten.
         logicOperatorTree = new TextMatchBasedRewriteRule(connectContext, stmt, optToAstMap)
@@ -223,8 +223,6 @@ public class Optimizer {
         Memo memo = context.getMemo();
         TaskContext rootTaskContext =
                 new TaskContext(context, requiredProperty, requiredColumns.clone(), Double.MAX_VALUE);
-        // collect all olap scan operator
-        collectAllLogicalOlapScanOperators(logicOperatorTree, rootTaskContext);
 
         try (Timer ignored = Tracers.watchScope("RuleBaseOptimize")) {
             logicOperatorTree = rewriteAndValidatePlan(logicOperatorTree, rootTaskContext);
@@ -303,7 +301,9 @@ public class Optimizer {
         memo.copyIn(memo.getRootGroup(), logicalTreeWithView);
     }
 
-    private void prepare(ConnectContext connectContext, ColumnRefFactory columnRefFactory) {
+    private void prepare(ConnectContext connectContext,
+                         ColumnRefFactory columnRefFactory,
+                         OptExpression logicOperatorTree) {
         Memo memo = null;
         if (!optimizerConfig.isRuleBased()) {
             memo = new Memo();
@@ -312,6 +312,10 @@ public class Optimizer {
         context = new OptimizerContext(memo, columnRefFactory, connectContext, optimizerConfig);
         context.setQueryTables(queryTables);
         context.setUpdateTableId(updateTableId);
+
+        // collect all olap scan operator
+        collectAllLogicalOlapScanOperators(logicOperatorTree, context);
+
     }
 
     private void prepareMvRewrite(ConnectContext connectContext, OptExpression logicOperatorTree,
@@ -830,10 +834,10 @@ public class Optimizer {
         return expression;
     }
 
-    private void collectAllLogicalOlapScanOperators(OptExpression tree, TaskContext rootTaskContext) {
+    private void collectAllLogicalOlapScanOperators(OptExpression tree, OptimizerContext optimizerContext) {
         List<LogicalOlapScanOperator> list = Lists.newArrayList();
         Utils.extractOperator(tree, list, op -> op instanceof LogicalOlapScanOperator);
-        rootTaskContext.setAllLogicalOlapScanOperators(Collections.unmodifiableList(list));
+        optimizerContext.setAllLogicalOlapScanOperators(Collections.unmodifiableList(list));
     }
 
     private void collectAllPhysicalOlapScanOperators(OptExpression tree, TaskContext rootTaskContext) {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/OptimizerContext.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/OptimizerContext.java
@@ -27,6 +27,7 @@ import com.starrocks.sql.common.ErrorType;
 import com.starrocks.sql.common.StarRocksPlannerException;
 import com.starrocks.sql.optimizer.base.ColumnRefFactory;
 import com.starrocks.sql.optimizer.dump.DumpInfo;
+import com.starrocks.sql.optimizer.operator.logical.LogicalOlapScanOperator;
 import com.starrocks.sql.optimizer.operator.scalar.IsNullPredicateOperator;
 import com.starrocks.sql.optimizer.rule.RuleSet;
 import com.starrocks.sql.optimizer.rule.RuleType;
@@ -34,6 +35,7 @@ import com.starrocks.sql.optimizer.task.SeriallyTaskScheduler;
 import com.starrocks.sql.optimizer.task.TaskContext;
 import com.starrocks.sql.optimizer.task.TaskScheduler;
 
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -77,6 +79,9 @@ public class OptimizerContext {
     // uniquePartitionIdGenerator for external catalog
     private long uniquePartitionIdGenerator = 0L;
 
+    // collect all LogicalOlapScanOperators in the query before any optimization
+    private List<LogicalOlapScanOperator> allLogicalOlapScanOperators;
+
     @VisibleForTesting
     public OptimizerContext(Memo memo, ColumnRefFactory columnRefFactory) {
         this.memo = memo;
@@ -88,6 +93,7 @@ public class OptimizerContext {
         this.optimizerConfig = new OptimizerConfig();
         this.candidateMvs = Lists.newArrayList();
         this.queryId = UUID.randomUUID();
+        this.allLogicalOlapScanOperators = Collections.emptyList();
     }
 
     @VisibleForTesting
@@ -297,5 +303,13 @@ public class OptimizerContext {
 
     public long getNextUniquePartitionId() {
         return uniquePartitionIdGenerator++;
+    }
+
+    public void setAllLogicalOlapScanOperators(List<LogicalOlapScanOperator> allScanOperators) {
+        this.allLogicalOlapScanOperators = allScanOperators;
+    }
+
+    public List<LogicalOlapScanOperator> getAllLogicalOlapScanOperators() {
+        return allLogicalOlapScanOperators;
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/rule/TextMatchBasedRewriteRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/rule/TextMatchBasedRewriteRule.java
@@ -30,6 +30,8 @@ import com.starrocks.catalog.Table;
 import com.starrocks.common.Pair;
 import com.starrocks.common.util.DebugUtil;
 import com.starrocks.common.util.PropertyAnalyzer;
+import com.starrocks.metric.IMaterializedViewMetricsEntity;
+import com.starrocks.metric.MaterializedViewMetricsRegistry;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.qe.SessionVariable;
 import com.starrocks.sql.analyzer.AstToSQLBuilder;
@@ -250,6 +252,9 @@ public class TextMatchBasedRewriteRule extends Rule {
                 // do: text match based mv rewrite
                 OptExpression rewritten = doTextMatchBasedRewrite(context, mvPlanContext, mv, input);
                 if (rewritten != null) {
+                    IMaterializedViewMetricsEntity mvEntity =
+                            MaterializedViewMetricsRegistry.getInstance().getMetricsEntity(mv.getMvId());
+                    mvEntity.increaseQueryTextBasedMatchedCount(1L);
                     OptimizerTraceUtil.logMVRewrite(context, this, "TEXT_BASED_REWRITE: {}", REWRITE_SUCCESS);
                     return rewritten;
                 }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/task/TaskContext.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/task/TaskContext.java
@@ -18,7 +18,6 @@ package com.starrocks.sql.optimizer.task;
 import com.starrocks.sql.optimizer.OptimizerContext;
 import com.starrocks.sql.optimizer.base.ColumnRefSet;
 import com.starrocks.sql.optimizer.base.PhysicalPropertySet;
-import com.starrocks.sql.optimizer.operator.logical.LogicalOlapScanOperator;
 import com.starrocks.sql.optimizer.operator.physical.PhysicalOlapScanOperator;
 
 import java.util.Collections;

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/task/TaskContext.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/task/TaskContext.java
@@ -30,7 +30,6 @@ public class TaskContext {
     private final PhysicalPropertySet requiredProperty;
     private ColumnRefSet requiredColumns;
     private double upperBoundCost;
-    private List<LogicalOlapScanOperator> allLogicalOlapScanOperators;
     private List<PhysicalOlapScanOperator> allPhysicalOlapScanOperators;
 
     public TaskContext(OptimizerContext context,
@@ -41,7 +40,6 @@ public class TaskContext {
         this.requiredProperty = physicalPropertySet;
         this.requiredColumns = requiredColumns;
         this.upperBoundCost = cost;
-        this.allLogicalOlapScanOperators = Collections.emptyList();
         this.allPhysicalOlapScanOperators = Collections.emptyList();
     }
 
@@ -67,14 +65,6 @@ public class TaskContext {
 
     public void setUpperBoundCost(double upperBoundCost) {
         this.upperBoundCost = upperBoundCost;
-    }
-
-    public void setAllLogicalOlapScanOperators(List<LogicalOlapScanOperator> allScanOperators) {
-        this.allLogicalOlapScanOperators = allScanOperators;
-    }
-
-    public List<LogicalOlapScanOperator> getAllLogicalOlapScanOperators() {
-        return allLogicalOlapScanOperators;
     }
 
     public void setAllPhysicalOlapScanOperators(List<PhysicalOlapScanOperator> allScanOperators) {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/validate/MVRewriteValidator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/validate/MVRewriteValidator.java
@@ -34,7 +34,6 @@ import java.util.Set;
 import java.util.stream.Collectors;
 
 import static com.starrocks.sql.optimizer.rule.transformation.materialization.MvUtils.collectMaterializedViews;
-import static com.starrocks.sql.optimizer.rule.transformation.materialization.MvUtils.getAllJoinOperators;
 
 public class MVRewriteValidator {
     private static final MVRewriteValidator INSTANCE = new MVRewriteValidator();

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/validate/MVRewriteValidator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/validate/MVRewriteValidator.java
@@ -34,6 +34,7 @@ import java.util.Set;
 import java.util.stream.Collectors;
 
 import static com.starrocks.sql.optimizer.rule.transformation.materialization.MvUtils.collectMaterializedViews;
+import static com.starrocks.sql.optimizer.rule.transformation.materialization.MvUtils.getAllJoinOperators;
 
 public class MVRewriteValidator {
     private static final MVRewriteValidator INSTANCE = new MVRewriteValidator();
@@ -79,7 +80,7 @@ public class MVRewriteValidator {
         List<MaterializedView> mvs = collectMaterializedViews(physicalPlan);
         // To avoid queries that query the materialized view directly, only consider materialized views
         // that are not used in rewriting before.
-        Set<Long> beforeTableIds = taskContext.getAllLogicalOlapScanOperators().stream()
+        Set<Long> beforeTableIds = optimizerContext.getAllLogicalOlapScanOperators().stream()
                 .map(op -> op.getTable().getId())
                 .collect(Collectors.toSet());
         if (CollectionUtils.isNotEmpty(mvs)) {
@@ -98,6 +99,7 @@ public class MVRewriteValidator {
         if (!isUpdateMaterializedViewMetrics(connectContext)) {
             return;
         }
+
         // update considered metrics
         if (CollectionUtils.isNotEmpty(optimizerContext.getCandidateMvs())) {
             for (MaterializationContext mvContext : optimizerContext.getCandidateMvs()) {
@@ -129,7 +131,7 @@ public class MVRewriteValidator {
         }
 
         List<MaterializedView> mvs = collectMaterializedViews(physicalPlan);
-        Set<Long> beforeTableIds = taskContext.getAllLogicalOlapScanOperators().stream()
+        Set<Long> beforeTableIds = taskContext.getOptimizerContext().getAllLogicalOlapScanOperators().stream()
                 .map(op -> op.getTable().getId())
                 .collect(Collectors.toSet());
 


### PR DESCRIPTION
## Why I'm doing:
Materialized view metrics are not correct even if mv is hit, there are two reasons:
- Previous base tables are not collected if the query is rewritten by text match
- ConnectContext's explain level should be reset if there are multi queries in the same connect context.

## What I'm doing:
- collect all LogicalOlapScanOperators in the query before any optimization
- reset the explain level to avoid the previous explain level affect the current query.
- Add counterQueryTextBasedMatchedTotal metric to text based rewrite match.

Fixes #issue


## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [x] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
