### PR TITLE
[Enhancement] support using alias as function param in select item

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/QueryAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/QueryAnalyzer.java
@@ -1270,7 +1270,7 @@ public class QueryAnalyzer {
                 return resolvedAliases.get(ref);
             }
             if (resolvingAlias.contains(ref)) {
-                throw new SemanticException("Cyclic aliases: " + ref);
+                throw new SemanticException("Cyclic aliases: " + ref, slotRef.getPos());
             }
 
             // Use resolvingAliases to detect cyclic aliases

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/QueryAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/QueryAnalyzer.java
@@ -1247,7 +1247,7 @@ public class QueryAnalyzer {
         @Override
         public Expr visitSlot(SlotRef slotRef, Void context) {
             // We treat it as column name rather than alias when table name is specified
-            if (slotRef.getQualifiedName().getParts().size() > 1) {
+            if (slotRef.getTblNameWithoutAnalyzed() != null) {
                 return slotRef;
             }
             // Alias is case-insensitive

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/SelectUsingAliasTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/SelectUsingAliasTest.java
@@ -1,0 +1,212 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.sql.plan;
+
+import com.starrocks.sql.analyzer.Analyzer;
+import com.starrocks.sql.analyzer.AstToSQLBuilder;
+import com.starrocks.sql.analyzer.SemanticException;
+import com.starrocks.sql.ast.StatementBase;
+import com.starrocks.sql.parser.SqlParser;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+public class SelectUsingAliasTest extends PlanTestBase {
+    @BeforeClass
+    public static void beforeClass() throws Exception {
+        PlanTestBase.beforeClass();
+    }
+
+    @Test
+    public void testAliasInSelect() {
+        // test when from is null
+        String sql = "select 'x' as a, 1 as b, null, cast(b as bigInt) as d";
+        testSqlRewrite(sql, "SELECT 'x' AS a, 1 AS b, NULL AS NULL, CAST(1 AS BIGINT) AS d");
+
+        // test when from is not null
+        sql = "select 'x' as a, 1 as b, null as c, cast(b as smallInt) as d " +
+                "from test_all_type";
+        testSqlRewrite(sql, "SELECT 'x' AS a, 1 AS b, NULL AS c, CAST(1 AS SMALLINT) AS d\n" +
+                "FROM test.test_all_type");
+
+        // test alias in where
+        sql = "select 'x' as a, 1 as b, null as c, cast(b as smallInt) as d " +
+                "from test_all_type where a is not null";
+        String aliasInWhereSql = sql;
+        Assert.assertThrows("Column 'a' cannot be resolved", SemanticException.class,
+                () -> getFragmentPlan(aliasInWhereSql));
+
+        // test alias in function
+        sql = "select t1a as t1a, trim(t1a) as a, a as b, concat(a,',',b) as e, b as d from test_all_type";
+        testSqlRewrite(sql, "SELECT t1a, trim(t1a) AS a, trim(t1a) AS b, " +
+                "concat(trim(t1a), ',', trim(t1a)) AS e, trim(t1a) AS d\n" +
+                "FROM test.test_all_type");
+
+        // test alias defined later than using
+        sql = "select concat(a,','),trim(t1a) as a from test_all_type";
+        testSqlRewrite(sql, "SELECT concat(trim(t1a), ',') AS concat(trim(t1a), ','), trim(t1a) AS a\n" +
+                "FROM test.test_all_type");
+
+        // test alias in group by
+        sql = "select trim(t1a) as a,count(*) as c from test_all_type group by a";
+        testSqlRewrite(sql, "SELECT trim(t1a) AS a, count(*) AS c\n" +
+                "FROM test.test_all_type\n" +
+                "GROUP BY a");
+
+        // test alias in group by and order by
+        sql = "select trim(t1a) as a,count(*) as c from test_all_type group by a order by c";
+        testSqlRewrite(sql, "SELECT trim(t1a) AS a, count(*) AS c\n" +
+                "FROM test.test_all_type\n" +
+                "GROUP BY a ORDER BY c ASC ");
+
+        // test alias in agg and in having
+        sql = "select t1c as b, sum(b) as s from test_all_type group by b having s>1 order by s";
+        testSqlRewrite(sql, "SELECT t1c AS b, sum(t1c) AS s\n" +
+                "FROM test.test_all_type\n" +
+                "GROUP BY b\n" +
+                "HAVING (sum(t1c)) > 1 ORDER BY s ASC ");
+
+        // test alias cascading referring
+        sql = "select concat(a,',',b) as e,concat(t1a,cast(t1c as string)) as a, a as b,b as d from test_all_type";
+        testSqlRewrite(sql, "SELECT concat(concat(t1a, CAST(t1c AS VARCHAR(65533))), ','" +
+                ", concat(t1a, CAST(t1c AS VARCHAR(65533)))) AS e, " +
+                "concat(t1a, CAST(t1c AS VARCHAR(65533))) AS a, " +
+                "concat(t1a, CAST(t1c AS VARCHAR(65533))) AS b, " +
+                "concat(t1a, CAST(t1c AS VARCHAR(65533))) AS d\n" +
+                "FROM test.test_all_type");
+
+        // test cyclic aliases
+        sql = "select concat(trim(d),',') as c,trim(c) as d from (" +
+                "select trim(t1a) as a from test_all_type group by a" +
+                ") b";
+        String cyclicAliasSql = sql;
+        Assert.assertThrows("Cyclic aliases", SemanticException.class, () -> getFragmentPlan(cyclicAliasSql));
+    }
+
+    @Test
+    public void testAliasSameAsColumn() {
+        boolean oldValue = connectContext.getSessionVariable().getEnableGroupbyUseOutputAlias();
+
+        // test alias is same as column name
+        connectContext.getSessionVariable().setEnableGroupbyUseOutputAlias(false);
+        String sql = "select trim(t1a) as t1c, concat(t1c,','),t1c from test_all_type";
+        testSqlRewrite(sql, "SELECT trim(t1a) AS t1c, concat(t1c, ',') AS concat(t1c, ','), t1c\n" +
+                "FROM test.test_all_type");
+
+        // test alias is same as column name
+        connectContext.getSessionVariable().setEnableGroupbyUseOutputAlias(true);
+        sql = "select trim(t1a) as t1c, concat(t1c,','),t1c from test_all_type";
+        testSqlRewrite(sql, "SELECT trim(t1a) AS t1c, " +
+                "concat(trim(t1a), ',') AS concat(trim(test.test_all_type.t1a), ','), " +
+                "trim(t1a) AS trim(test.test_all_type.t1a)\n" +
+                "FROM test.test_all_type");
+
+        // test test_all_type.t1c should be column name
+        connectContext.getSessionVariable().setEnableGroupbyUseOutputAlias(true);
+        sql = "select trim(t1a) as t1c, concat(t1c,','),test_all_type.t1c from test_all_type";
+        testSqlRewrite(sql, "SELECT trim(test.test_all_type.t1a) AS t1c, " +
+                "concat(trim(test.test_all_type.t1a), ',') AS concat(trim(test.test_all_type.t1a), ','), " +
+                "test.test_all_type.t1c\n" +
+                "FROM test.test_all_type", false);
+
+        // test t1a in trim(t1a) should be column name
+        sql = "select trim(t1a) as t1a from test_all_type";
+        testSqlRewrite(sql, "SELECT trim(test.test_all_type.t1a) AS t1a\n" +
+                "FROM test.test_all_type", false);
+
+        // test t1a in concat(t1a,',') should be alias
+        sql = "select trim(t1a),concat(t1a,',') as t1a from test_all_type";
+        testSqlRewrite(sql, "SELECT trim(concat(test.test_all_type.t1a, ',')) AS trim(concat(t1a, ',')), " +
+                "concat(test.test_all_type.t1a, ',') AS t1a\n" +
+                "FROM test.test_all_type", false);
+
+        // test t1a in concat(t1a,',') should be alias
+        sql = "select concat(t1a,',') as t1a,trim(t1a) from test_all_type";
+        testSqlRewrite(sql, "SELECT concat(test.test_all_type.t1a, ',') AS t1a, " +
+                "trim(concat(test.test_all_type.t1a, ',')) AS trim(concat(test.test_all_type.t1a, ','))\n" +
+                "FROM test.test_all_type", false);
+
+        // test t1a in concat(t1c, ',', t1a) should be alias
+        // test t1c in concat(t1c, ',', t1a) should be column name
+        sql = "select trim(t1a),concat(t1c, ',', t1a) as t1c, concat(t1a,',') as t1a from test_all_type";
+        testSqlRewrite(sql, "SELECT trim(concat(test.test_all_type.t1a, ',')) AS trim(concat(t1a, ',')), " +
+                "concat(test.test_all_type.t1c, ',', concat(test.test_all_type.t1a, ',')) AS t1c, " +
+                "concat(test.test_all_type.t1a, ',') AS t1a\n" +
+                "FROM test.test_all_type", false);
+
+        // test t1a in concat(t1a, ',') should be column name
+        // test t1a in concat(t1a, ',', t1a) should be alias
+        // test t1c in concat(t1a, ',', t1a) should be column name
+        sql = "select concat(t1a, ',', t1c) as t1c, concat(t1a,',') as t1a from test_all_type";
+        testSqlRewrite(sql, "SELECT concat(concat(test.test_all_type.t1a, ','), ',', test.test_all_type.t1c) AS t1c, " +
+                "concat(test.test_all_type.t1a, ',') AS t1a\n" +
+                "FROM test.test_all_type", false);
+
+        // test alias is same as column name in group by
+        sql = "select t1a, trim(t1a) as t1c,count(*) from test_all_type group by t1a, t1c";
+        testSqlRewrite(sql, "SELECT test.test_all_type.t1a, trim(test.test_all_type.t1a) AS t1c, count(*) AS count(*)\n" +
+                "FROM test.test_all_type\n" +
+                "GROUP BY t1a, t1c", false);
+        connectContext.getSessionVariable().setEnableGroupbyUseOutputAlias(oldValue);
+    }
+
+    @Test
+    public void testHasStar() {
+        String sql = "select t1a, * from test_all_type";
+        testSqlRewrite(sql, "SELECT t1a, t1a, t1b, t1c, t1d, t1e, t1f, t1g, id_datetime, id_date, id_decimal\n" +
+                "FROM test.test_all_type");
+
+        sql = "select t1a as a, * from test_all_type";
+        testSqlRewrite(sql, "SELECT t1a AS a, t1a, t1b, t1c, t1d, t1e, t1f, t1g, id_datetime, id_date" +
+                ", id_decimal\n" +
+                "FROM test.test_all_type");
+
+        sql = "select *, rand(), current_date() from test_all_type";
+        testSqlRewrite(sql, "SELECT t1a, t1b, t1c, t1d, t1e, t1f, t1g, id_datetime, id_date, id_decimal, " +
+                "rand() AS rand(), current_date() AS current_date()\n" +
+                "FROM test.test_all_type");
+    }
+
+    @Test
+    public void testCaseInsensitive() {
+        // test when from is null
+        String sql = "select 'x' as a, 1 as B, null, cast(b as bigInt) as d";
+        testSqlRewrite(sql, "SELECT 'x' AS a, 1 AS B, NULL AS NULL, CAST(1 AS BIGINT) AS d");
+
+        // test cyclic aliases
+        sql = "select concat(trim(d),',') as C,trim(c) as d from (" +
+                "select trim(t1a) as a from test_all_type group by a" +
+                ") b";
+        String cyclicAliasSql = sql;
+        Assert.assertThrows("Cyclic aliases", SemanticException.class, () -> getFragmentPlan(cyclicAliasSql));
+
+        // test alias is same as column name and in group by
+        sql = "select t1a, trim(t1a) as t1C,count(*) from test_all_type group by t1a, t1c";
+        testSqlRewrite(sql, "SELECT test.test_all_type.t1a, trim(test.test_all_type.t1a) AS t1C, count(*) AS count(*)\n" +
+                "FROM test.test_all_type\n" +
+                "GROUP BY test.test_all_type.t1a, test.test_all_type.t1c", false);
+    }
+
+    private void testSqlRewrite(String sql, String expected) {
+        testSqlRewrite(sql, expected, true);
+    }
+
+    private void testSqlRewrite(String sql, String expected, boolean withoutTbl) {
+        StatementBase stmt = SqlParser.parse(sql, connectContext.getSessionVariable()).get(0);
+        Analyzer.analyze(stmt, connectContext);
+        String afterSql = new AstToSQLBuilder.AST2SQLBuilderVisitor(false, withoutTbl).visit(stmt);
+        Assert.assertEquals(expected, afterSql.replaceAll("`", ""));
+    }
+}


### PR DESCRIPTION
## Why I'm doing:
support using alias as function param, eg: `select trim(c1) as a, trim(c2) as b, concat(a,',', b) from t1 where a != 'x'`
## What I'm doing:
rewrite slotRef in function params to the real expression
eg: `select trim(c1) as a, trim(c2) as b, concat(trim(c1),',', trim(c2)) from t1 where trim(c1) != 'x'`

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
