### PR TITLE
[BugFix]  Fix duplicate metric labels

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/metric/Metric.java
+++ b/fe/fe-core/src/main/java/com/starrocks/metric/Metric.java
@@ -93,6 +93,16 @@ public abstract class Metric<T> {
         if (labels.contains(label)) {
             return this;
         }
+        for (int i = 0; i < labels.size(); i++) {
+            if (!labels.get(i).getKey().equals(label.getKey())) {
+                continue;
+            }
+            // update the label instead of adding, cuz renaming operations will result in duplicate labels
+            // for instance: after running `alter table t1 rename t2`
+            // labels should change from [{ key: "tbl_name", value: "t1" }] to [{ key: "tbl_name", value: "t2" }]
+            labels.set(i, label);
+            return this;
+        }
         labels.add(label);
         return this;
     }

--- a/fe/fe-core/src/test/java/com/starrocks/metric/MetricsTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/metric/MetricsTest.java
@@ -129,4 +129,15 @@ public class MetricsTest {
             Assert.assertTrue(jvmProcDirResultRowsContains(rows, metricName));
         }
     }
+
+    @Test
+    public void testAddLabel() {
+        LongCounterMetric m = new LongCounterMetric("test_metric", Metric.MetricUnit.BYTES, "test");
+        m.addLabel(new MetricLabel("k1", "v0"));
+        m.addLabel(new MetricLabel("k2", "v2"));
+        m.addLabel(new MetricLabel("k1", "v1"));
+        Assert.assertEquals(m.getLabels().size(), 2);
+        Assert.assertEquals(m.getLabels().get(0).getValue(), "v1");
+        Assert.assertEquals(m.getLabels().get(1).getValue(), "v2");
+    }
 }


### PR DESCRIPTION
## Why I'm doing:

Duplicate labels appeared from metrics api.

1. Run `alter table t1 rename t2;`
2. Run `curl http://user:password@fe:fe_http_port/metrics?with_table_metrics=all`
3. `starrocks_fe_table_scan_bytes{db_name="xxx", tbl_name="t1", tbl_id="xxx", tbl_name="t2"} 0` returned

Multiple `tbl_name` returned which will lead to a failure for prometheus.

## What I'm doing:

Update the label instead of adding.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [x] 3.2
  - [x] 3.1
  - [x] 3.0
  - [x] 2.5
