### PR TITLE
[Feature] Faster PK table compaction transaction publish strategy (Part-1 cloud native)

### DIFF
--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -1293,6 +1293,9 @@ CONF_mBool(enable_profile_for_external_plan, "false");
 // the max length supported for varchar type
 CONF_mInt32(olap_string_max_length, "1048576");
 
+// Skip get from pk index when light pk compaction publish is enabled
+CONF_mBool(enable_light_pk_compaction_publish, "true");
+
 // jit LRU cache size for total 32 shards, it will be an auto value if it <=0:
 // mem_limit = system memory or process memory limit if set.
 // if mem_limit < 16 GB, disable JIT.

--- a/be/src/storage/CMakeLists.txt
+++ b/be/src/storage/CMakeLists.txt
@@ -241,8 +241,11 @@ add_library(Storage STATIC
     lake/persistent_index_memtable.cpp
     lake/local_pk_index_manager.cpp
     lake/persistent_index_sstable.cpp
+    lake/lake_primary_key_compaction_conflict_resolver.cpp
     primary_key_dump.cpp
     dictionary_cache_manager.cpp
+    rows_mapper.cpp
+    primary_key_compaction_conflict_resolver.cpp
     inverted/index_descriptor.hpp
     inverted/inverted_index_iterator.cpp
     inverted/inverted_index_iterator.cpp

--- a/be/src/storage/chunk_iterator.cpp
+++ b/be/src/storage/chunk_iterator.cpp
@@ -54,9 +54,20 @@ private:
         return _iter->get_next(chunk, rowid);
     }
 
+    Status do_get_next(Chunk* chunk, std::vector<uint64_t>* rssid_rowids) override {
+        SCOPED_RAW_TIMER(&_cost);
+        return _iter->get_next(chunk, rssid_rowids);
+    }
+
     Status do_get_next(Chunk* chunk, std::vector<RowSourceMask>* source_masks) override {
         SCOPED_RAW_TIMER(&_cost);
         return _iter->get_next(chunk, source_masks);
+    }
+
+    Status do_get_next(Chunk* chunk, std::vector<RowSourceMask>* source_masks,
+                       std::vector<uint64_t>* rssid_rowids) override {
+        SCOPED_RAW_TIMER(&_cost);
+        return _iter->get_next(chunk, source_masks, rssid_rowids);
     }
 
     ChunkIteratorPtr _iter;

--- a/be/src/storage/chunk_iterator.h
+++ b/be/src/storage/chunk_iterator.h
@@ -69,6 +69,21 @@ public:
         return st;
     }
 
+    // like get_next(Chunk* chunk), but also returns each row's rssid + rowid (after encode)
+    [[nodiscard]] Status get_next(Chunk* chunk, std::vector<uint64_t>* rssid_rowids) {
+        Status st = do_get_next(chunk, rssid_rowids);
+        DCHECK_CHUNK(chunk);
+        return st;
+    }
+
+    // like get_next(Chunk* chunk), but also returns each row's rssid + rowid (after encode)
+    [[nodiscard]] Status get_next(Chunk* chunk, std::vector<RowSourceMask>* source_masks,
+                                  std::vector<uint64_t>* rssid_rowids) {
+        Status st = do_get_next(chunk, source_masks, rssid_rowids);
+        DCHECK_CHUNK(chunk);
+        return st;
+    }
+
     // Release resources associated with this iterator, e.g, deallocate memory.
     // This routine can be called at most once.
     virtual void close() = 0;
@@ -124,12 +139,21 @@ protected:
     virtual Status do_get_next(Chunk* chunk, std::vector<uint32_t>* rowid) {
         return Status::NotSupported("Chunk* chunk, vector<uint32_t>* rowid) not supported");
     }
+    virtual Status do_get_next(Chunk* chunk, std::vector<uint64_t>* rssid_rowids) {
+        return Status::NotSupported("Chunk* chunk, vector<uint64_t>* rssid_rowids) not supported");
+    }
     virtual Status do_get_next(Chunk* chunk, std::vector<RowSourceMask>* source_masks) {
         if (source_masks == nullptr) {
             return do_get_next(chunk);
         } else {
             return Status::NotSupported("get chunk with sources not supported");
         }
+    }
+    virtual Status do_get_next(Chunk* chunk, std::vector<RowSourceMask>* source_masks,
+                               std::vector<uint64_t>* rssid_rowids) {
+        return Status::NotSupported(
+                "Chunk* chunk, std::vector<RowSourceMask>* source_masks, vector<uint64_t>* rssid_rowids) not "
+                "supported");
     }
 
     Schema _schema;

--- a/be/src/storage/empty_iterator.cpp
+++ b/be/src/storage/empty_iterator.cpp
@@ -27,7 +27,14 @@ protected:
     Status do_get_next(Chunk* chunk, std::vector<uint32_t>* rowid) override {
         return Status::EndOfFile("end of empty iterator");
     }
+    Status do_get_next(Chunk* chunk, std::vector<uint64_t>* rssid_rowids) override {
+        return Status::EndOfFile("end of empty iterator");
+    }
     Status do_get_next(Chunk* chunk, std::vector<RowSourceMask>* source_masks) override {
+        return Status::EndOfFile("end of empty iterator");
+    }
+    Status do_get_next(Chunk* chunk, std::vector<RowSourceMask>* source_masks,
+                       std::vector<uint64_t>* rssid_rowids) override {
         return Status::EndOfFile("end of empty iterator");
     }
 };

--- a/be/src/storage/lake/delta_writer.cpp
+++ b/be/src/storage/lake/delta_writer.cpp
@@ -218,8 +218,8 @@ Status DeltaWriterImpl::build_schema_and_writer() {
         RETURN_IF_ERROR(init_tablet_schema());
         RETURN_IF_ERROR(init_write_schema());
         if (_tablet_schema->keys_type() == KeysType::PRIMARY_KEYS) {
-            _tablet_writer =
-                    std::make_unique<HorizontalPkTabletWriter>(_tablet_manager, _tablet_id, _write_schema, _txn_id);
+            _tablet_writer = std::make_unique<HorizontalPkTabletWriter>(_tablet_manager, _tablet_id, _write_schema,
+                                                                        _txn_id, nullptr, false /** no compaction**/);
         } else {
             _tablet_writer = std::make_unique<HorizontalGeneralTabletWriter>(_tablet_manager, _tablet_id, _write_schema,
                                                                              _txn_id);

--- a/be/src/storage/lake/general_tablet_writer.h
+++ b/be/src/storage/lake/general_tablet_writer.h
@@ -44,7 +44,16 @@ public:
 
     Status write(const Chunk& data, SegmentPB* segment = nullptr) override;
 
+    Status write(const Chunk& data, const std::vector<uint64_t>& rssid_rowids, SegmentPB* segment = nullptr) {
+        return Status::NotSupported("HorizontalGeneralTabletWriter write not support");
+    }
+
     Status write_columns(const Chunk& data, const std::vector<uint32_t>& column_indexes, bool is_key) override {
+        return Status::NotSupported("HorizontalGeneralTabletWriter write_columns not support");
+    }
+
+    Status write_columns(const Chunk& data, const std::vector<uint32_t>& column_indexes, bool is_key,
+                         const std::vector<uint64_t>& rssid_rowids) override {
         return Status::NotSupported("HorizontalGeneralTabletWriter write_columns not support");
     }
 
@@ -87,7 +96,16 @@ public:
         return Status::NotSupported("VerticalGeneralTabletWriter write not support");
     }
 
+    Status write(const Chunk& data, const std::vector<uint64_t>& rssid_rowids, SegmentPB* segment = nullptr) override {
+        return Status::NotSupported("HorizontalGeneralTabletWriter write not support");
+    }
+
     Status write_columns(const Chunk& data, const std::vector<uint32_t>& column_indexes, bool is_key) override;
+
+    Status write_columns(const Chunk& data, const std::vector<uint32_t>& column_indexes, bool is_key,
+                         const std::vector<uint64_t>& rssid_rowids) override {
+        return Status::NotSupported("VerticalGeneralTabletWriter write_columns not support");
+    }
 
     Status flush_del_file(const Column& deletes) override {
         return Status::NotSupported("VerticalGeneralTabletWriter flush_del_file not support");
@@ -104,7 +122,7 @@ public:
 
     RowsetTxnMetaPB* rowset_txn_meta() override { return nullptr; }
 
-private:
+protected:
     StatusOr<std::shared_ptr<SegmentWriter>> create_segment_writer(const std::vector<uint32_t>& column_indexes,
                                                                    bool is_key);
 

--- a/be/src/storage/lake/lake_persistent_index.cpp
+++ b/be/src/storage/lake/lake_persistent_index.cpp
@@ -246,6 +246,16 @@ Status LakePersistentIndex::try_replace(size_t n, const Slice* keys, const Index
     return Status::OK();
 }
 
+Status LakePersistentIndex::replace(size_t n, const Slice* keys, const IndexValue* values,
+                                    const std::vector<uint32_t>& replace_indexes) {
+    std::vector<size_t> tmp_replace_idxes(replace_indexes.begin(), replace_indexes.end());
+    RETURN_IF_ERROR(_memtable->replace(keys, values, tmp_replace_idxes, _version.major_number()));
+    if (is_memtable_full()) {
+        return flush_memtable();
+    }
+    return Status::OK();
+}
+
 Status LakePersistentIndex::prepare_merging_iterator(
         const TabletMetadata& metadata, TxnLogPB* txn_log,
         std::vector<std::shared_ptr<PersistentIndexSstable>>* merging_sstables,

--- a/be/src/storage/lake/lake_persistent_index.h
+++ b/be/src/storage/lake/lake_persistent_index.h
@@ -97,6 +97,14 @@ public:
     Status try_replace(size_t n, const Slice* keys, const IndexValue* values, const uint32_t max_src_rssid,
                        std::vector<uint32_t>* failed) override;
 
+    // batch replace without return old values
+    // |n|: size of key/value array
+    // |keys|: key array as raw buffer
+    // |values|: value array
+    // |replace_indexes|: The index of the |keys| array that need to replace.
+    Status replace(size_t n, const Slice* keys, const IndexValue* values,
+                   const std::vector<uint32_t>& replace_indexes) override;
+
     // batch insert, return error if key already exists
     // |n|: size of key/value array
     // |keys|: key array as raw buffer

--- a/be/src/storage/lake/lake_primary_key_compaction_conflict_resolver.cpp
+++ b/be/src/storage/lake/lake_primary_key_compaction_conflict_resolver.cpp
@@ -1,0 +1,65 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "storage/lake/lake_primary_key_compaction_conflict_resolver.h"
+
+#include "runtime/exec_env.h"
+#include "storage/chunk_helper.h"
+#include "storage/lake/filenames.h"
+#include "storage/lake/rowset.h"
+#include "storage/lake/types_fwd.h"
+#include "storage/lake/update_manager.h"
+#include "storage/rows_mapper.h"
+#include "storage/tablet_schema.h"
+
+namespace starrocks::lake {
+
+StatusOr<std::string> LakePrimaryKeyCompactionConflictResolver::filename() const {
+    return lake_rows_mapper_filename(_rowset->tablet_id(), _txn_id);
+}
+
+Schema LakePrimaryKeyCompactionConflictResolver::generate_pkey_schema() {
+    std::shared_ptr<TabletSchema> tablet_schema = std::make_shared<TabletSchema>(_metadata->schema());
+    std::vector<uint32_t> pk_columns;
+    for (size_t i = 0; i < tablet_schema->num_key_columns(); i++) {
+        pk_columns.push_back(static_cast<uint32_t>(i));
+    }
+
+    return ChunkHelper::convert_schema(tablet_schema, pk_columns);
+}
+
+Status LakePrimaryKeyCompactionConflictResolver::segment_iterator(
+        const std::function<Status(const CompactConflictResolveParams&, const std::vector<ChunkIteratorPtr>&,
+                                   const std::function<void(uint32_t, const DelVectorPtr&, uint32_t)>&)>& handler) {
+    OlapReaderStatistics stats;
+    auto pkey_schema = generate_pkey_schema();
+    ASSIGN_OR_RETURN(auto segment_iters, _rowset->get_each_segment_iterator(pkey_schema, &stats));
+    RETURN_ERROR_IF_FALSE(segment_iters.size() == _rowset->num_segments());
+    // init delvec loader
+    auto delvec_loader = std::make_unique<LakeDelvecLoader>(_update_manager, _builder);
+    // init params
+    CompactConflictResolveParams params;
+    params.tablet_id = _rowset->tablet_id();
+    params.rowset_id = _metadata->next_rowset_id();
+    params.base_version = _base_version;
+    params.new_version = _metadata->version();
+    params.delvec_loader = delvec_loader.get();
+    params.index = _index;
+    return handler(params, segment_iters, [&](uint32_t rssid, const DelVectorPtr& dv, uint32_t num_dels) {
+        (*_segment_id_to_add_dels)[rssid] += num_dels;
+        _delvecs->emplace_back(rssid, dv);
+    });
+}
+
+} // namespace starrocks::lake

--- a/be/src/storage/lake/lake_primary_key_compaction_conflict_resolver.h
+++ b/be/src/storage/lake/lake_primary_key_compaction_conflict_resolver.h
@@ -1,0 +1,68 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include "storage/lake/tablet_metadata.h"
+#include "storage/primary_key_compaction_conflict_resolver.h"
+
+namespace starrocks::lake {
+
+class Rowset;
+class UpdateManager;
+class MetaFileBuilder;
+class LakePrimaryIndex;
+
+class LakePrimaryKeyCompactionConflictResolver : public PrimaryKeyCompactionConflictResolver {
+public:
+    explicit LakePrimaryKeyCompactionConflictResolver(const TabletMetadata* metadata, Rowset* rowset,
+                                                      UpdateManager* update_manager, MetaFileBuilder* builder,
+                                                      LakePrimaryIndex* index, int64_t txn_id, int64_t base_version,
+                                                      std::map<uint32_t, size_t>* segment_id_to_add_dels,
+                                                      std::vector<std::pair<uint32_t, DelVectorPtr>>* delvecs)
+            : _metadata(metadata),
+              _rowset(rowset),
+              _update_manager(update_manager),
+              _builder(builder),
+              _index(index),
+              _txn_id(txn_id),
+              _base_version(base_version),
+              _segment_id_to_add_dels(segment_id_to_add_dels),
+              _delvecs(delvecs) {}
+    ~LakePrimaryKeyCompactionConflictResolver() {}
+
+    StatusOr<std::string> filename() const override;
+    Schema generate_pkey_schema() override;
+    Status segment_iterator(
+            const std::function<Status(const CompactConflictResolveParams&, const std::vector<ChunkIteratorPtr>&,
+                                       const std::function<void(uint32_t, const DelVectorPtr&, uint32_t)>&)>& handler)
+            override;
+
+private:
+    // input
+    const TabletMetadata* _metadata = nullptr;
+    Rowset* _rowset = nullptr;
+    UpdateManager* _update_manager = nullptr;
+    MetaFileBuilder* _builder = nullptr;
+    LakePrimaryIndex* _index = nullptr;
+    int64_t _txn_id = 0;
+    int64_t _base_version = 0;
+    // output
+    // <segment id -> del num>
+    std::map<uint32_t, size_t>* _segment_id_to_add_dels = nullptr;
+    // <rssid -> Delvec>
+    std::vector<std::pair<uint32_t, starrocks::DelVectorPtr>>* _delvecs = nullptr;
+};
+
+} // namespace starrocks::lake

--- a/be/src/storage/lake/pk_tablet_writer.h
+++ b/be/src/storage/lake/pk_tablet_writer.h
@@ -23,7 +23,8 @@
 
 namespace starrocks {
 class SegmentWriter;
-}
+class RowsMapperBuilder;
+} // namespace starrocks
 
 namespace starrocks::lake {
 
@@ -31,21 +32,21 @@ class HorizontalPkTabletWriter : public HorizontalGeneralTabletWriter {
 public:
     explicit HorizontalPkTabletWriter(TabletManager* tablet_mgr, int64_t tablet_id,
                                       std::shared_ptr<const TabletSchema> schema, int64_t txn_id,
-                                      ThreadPool* flush_pool = nullptr);
+                                      ThreadPool* flush_pool, bool is_compaction);
 
     ~HorizontalPkTabletWriter() override;
 
     DISALLOW_COPY(HorizontalPkTabletWriter);
 
-    Status write_columns(const Chunk& data, const std::vector<uint32_t>& column_indexes, bool is_key) override {
-        return Status::NotSupported("HorizontalPkTabletWriter write_columns not support");
-    }
+    Status write(const Chunk& data, const std::vector<uint64_t>& rssid_rowids, SegmentPB* segment = nullptr) override;
 
     Status flush_del_file(const Column& deletes) override;
 
     Status flush_columns() override {
         return Status::NotSupported("HorizontalPkTabletWriter flush_columns not support");
     }
+
+    Status finish(SegmentPB* segment = nullptr) override;
 
     RowsetTxnMetaPB* rowset_txn_meta() override { return _rowset_txn_meta.get(); }
 
@@ -54,13 +55,14 @@ protected:
 
 private:
     std::unique_ptr<RowsetTxnMetaPB> _rowset_txn_meta;
+    std::unique_ptr<RowsMapperBuilder> _rows_mapper_builder;
 };
 
 class VerticalPkTabletWriter : public VerticalGeneralTabletWriter {
 public:
     explicit VerticalPkTabletWriter(TabletManager* tablet_mgr, int64_t tablet_id,
                                     std::shared_ptr<const TabletSchema> schema, int64_t txn_id,
-                                    uint32_t max_rows_per_segment, ThreadPool* flush_pool = nullptr);
+                                    uint32_t max_rows_per_segment, ThreadPool* flush_pool, bool is_compaction);
 
     ~VerticalPkTabletWriter() override;
 
@@ -73,6 +75,15 @@ public:
     Status flush_del_file(const Column& deletes) override {
         return Status::NotSupported("VerticalPkTabletWriter flush_del_file not support");
     }
+
+    Status write_columns(const Chunk& data, const std::vector<uint32_t>& column_indexes, bool is_key,
+                         const std::vector<uint64_t>& rssid_rowids) override;
+
+    // Finalize all segments footer.
+    Status finish(SegmentPB* segment = nullptr) override;
+
+private:
+    std::unique_ptr<RowsMapperBuilder> _rows_mapper_builder;
 };
 
 } // namespace starrocks::lake

--- a/be/src/storage/lake/tablet.cpp
+++ b/be/src/storage/lake/tablet.cpp
@@ -71,15 +71,17 @@ StatusOr<TxnLogPtr> Tablet::get_txn_vlog(int64_t version) {
 }
 
 StatusOr<std::unique_ptr<TabletWriter>> Tablet::new_writer(WriterType type, int64_t txn_id,
-                                                           uint32_t max_rows_per_segment, ThreadPool* flush_pool) {
+                                                           uint32_t max_rows_per_segment, ThreadPool* flush_pool,
+                                                           bool is_compaction) {
     ASSIGN_OR_RETURN(auto tablet_schema, get_schema());
     if (tablet_schema->keys_type() == KeysType::PRIMARY_KEYS) {
         if (type == kHorizontal) {
-            return std::make_unique<HorizontalPkTabletWriter>(_mgr, _id, tablet_schema, txn_id, flush_pool);
+            return std::make_unique<HorizontalPkTabletWriter>(_mgr, _id, tablet_schema, txn_id, flush_pool,
+                                                              is_compaction);
         } else {
             DCHECK(type == kVertical);
             return std::make_unique<VerticalPkTabletWriter>(_mgr, _id, tablet_schema, txn_id, max_rows_per_segment,
-                                                            flush_pool);
+                                                            flush_pool, is_compaction);
         }
     } else {
         if (type == kHorizontal) {

--- a/be/src/storage/lake/tablet.h
+++ b/be/src/storage/lake/tablet.h
@@ -84,7 +84,7 @@ public:
     // NOTE: This method may update the version hint
     StatusOr<std::unique_ptr<TabletWriter>> new_writer(WriterType type, int64_t txn_id,
                                                        uint32_t max_rows_per_segment = 0,
-                                                       ThreadPool* flush_pool = nullptr);
+                                                       ThreadPool* flush_pool = nullptr, bool is_compaction = false);
 
     const std::shared_ptr<const TabletSchema> tablet_schema() const override;
 

--- a/be/src/storage/lake/tablet_reader.cpp
+++ b/be/src/storage/lake/tablet_reader.cpp
@@ -190,6 +190,10 @@ Status TabletReader::do_get_next(Chunk* chunk) {
     return Status::OK();
 }
 
+Status TabletReader::do_get_next(Chunk* chunk, std::vector<uint64_t>* rssid_rowids) {
+    return _collect_iter->get_next(chunk, rssid_rowids);
+}
+
 Status TabletReader::do_get_next(Chunk* chunk, std::vector<RowSourceMask>* source_masks) {
     DCHECK(_is_vertical_merge);
     if (_need_split) {
@@ -200,6 +204,15 @@ Status TabletReader::do_get_next(Chunk* chunk, std::vector<RowSourceMask>* sourc
     return Status::OK();
 }
 
+Status TabletReader::do_get_next(Chunk* chunk, std::vector<RowSourceMask>* source_masks,
+                                 std::vector<uint64_t>* rssid_rowids) {
+    DCHECK(_is_vertical_merge);
+    RETURN_IF_ERROR(_collect_iter->get_next(chunk, source_masks, rssid_rowids));
+    return Status::OK();
+}
+
+// TODO: support
+//  1. rowid range and short key range
 Status TabletReader::get_segment_iterators(const TabletReaderParams& params, std::vector<ChunkIteratorPtr>* iters) {
     RowsetReadOptions rs_opts;
     KeysType keys_type = _tablet_schema->keys_type();
@@ -390,7 +403,7 @@ Status TabletReader::init_collector(const TabletReaderParams& params) {
         if (_is_vertical_merge && !_is_key) {
             _collect_iter = new_mask_merge_iterator(seg_iters, _mask_buffer);
         } else {
-            _collect_iter = new_heap_merge_iterator(seg_iters);
+            _collect_iter = new_heap_merge_iterator(seg_iters, (keys_type == PRIMARY_KEYS));
         }
     } else if (params.sorted_by_keys_per_tablet && (keys_type == DUP_KEYS || keys_type == PRIMARY_KEYS) &&
                seg_iters.size() > 1) {

--- a/be/src/storage/lake/tablet_reader.h
+++ b/be/src/storage/lake/tablet_reader.h
@@ -81,7 +81,10 @@ public:
 
 protected:
     Status do_get_next(Chunk* chunk) override;
+    Status do_get_next(Chunk* chunk, std::vector<uint64_t>* rssid_rowids) override;
     Status do_get_next(Chunk* chunk, std::vector<RowSourceMask>* source_masks) override;
+    Status do_get_next(Chunk* chunk, std::vector<RowSourceMask>* source_masks,
+                       std::vector<uint64_t>* rssid_rowids) override;
 
 private:
     using PredicateList = std::vector<const ColumnPredicate*>;

--- a/be/src/storage/lake/tablet_writer.h
+++ b/be/src/storage/lake/tablet_writer.h
@@ -81,6 +81,11 @@ public:
     // For horizontal writer.
     virtual Status write(const Chunk& data, SegmentPB* segment = nullptr) = 0;
 
+    // Writes both chunk and each rows's rssid & rowid
+    // For horizontal writer.
+    virtual Status write(const Chunk& data, const std::vector<uint64_t>& rssid_rowids,
+                         SegmentPB* segment = nullptr) = 0;
+
     // Writes partial columns data to this rowset.
     //
     // It's guaranteed that the elements in each chunk are arranged in ascending order by keys,
@@ -88,6 +93,12 @@ public:
     //
     // For vertical writer.
     virtual Status write_columns(const Chunk& data, const std::vector<uint32_t>& column_indexes, bool is_key) = 0;
+
+    // Writes partial columns data and each rows's rssid & rowid to this rowset.
+    //
+    // For vertical writer.
+    virtual Status write_columns(const Chunk& data, const std::vector<uint32_t>& column_indexes, bool is_key,
+                                 const std::vector<uint64_t>& rssid_rowids) = 0;
 
     // Write del file to this rowset. PK table only
     virtual Status flush_del_file(const Column& deletes) = 0;

--- a/be/src/storage/lake/update_manager.h
+++ b/be/src/storage/lake/update_manager.h
@@ -112,6 +112,10 @@ public:
                                       const TabletMetadata& metadata, const Tablet& tablet, IndexEntry* index_entry,
                                       MetaFileBuilder* builder, int64_t base_version);
 
+    Status light_publish_primary_compaction(const TxnLogPB_OpCompaction& op_compaction, int64_t txn_id,
+                                            const TabletMetadata& metadata, const Tablet& tablet,
+                                            IndexEntry* index_entry, MetaFileBuilder* builder, int64_t base_version);
+
     bool try_remove_primary_index_cache(uint32_t tablet_id);
 
     void unload_primary_index(int64_t tablet_id);
@@ -203,6 +207,9 @@ private:
     PkIndexShard& _get_pk_index_shard(int64_t tabletId) {
         return _pk_index_shards[tabletId & (config::pk_index_map_shard_size - 1)];
     }
+
+    // decide whether use light publish compaction stategy or not
+    bool _use_light_publish_primary_compaction(int64_t tablet_id, int64_t txn_id);
 
     static const size_t kPrintMemoryStatsInterval = 300; // 5min
 private:

--- a/be/src/storage/lake/versioned_tablet.cpp
+++ b/be/src/storage/lake/versioned_tablet.cpp
@@ -37,15 +37,16 @@ int64_t VersionedTablet::version() const {
 
 StatusOr<std::unique_ptr<TabletWriter>> VersionedTablet::new_writer(WriterType type, int64_t txn_id,
                                                                     uint32_t max_rows_per_segment,
-                                                                    ThreadPool* flush_pool) {
+                                                                    ThreadPool* flush_pool, bool is_compaction) {
     auto tablet_schema = get_schema();
     if (tablet_schema->keys_type() == KeysType::PRIMARY_KEYS) {
         if (type == kHorizontal) {
-            return std::make_unique<HorizontalPkTabletWriter>(_tablet_mgr, id(), tablet_schema, txn_id, flush_pool);
+            return std::make_unique<HorizontalPkTabletWriter>(_tablet_mgr, id(), tablet_schema, txn_id, flush_pool,
+                                                              is_compaction);
         } else {
             DCHECK(type == kVertical);
             return std::make_unique<VerticalPkTabletWriter>(_tablet_mgr, id(), tablet_schema, txn_id,
-                                                            max_rows_per_segment, flush_pool);
+                                                            max_rows_per_segment, flush_pool, is_compaction);
         }
     } else {
         if (type == kHorizontal) {

--- a/be/src/storage/lake/versioned_tablet.h
+++ b/be/src/storage/lake/versioned_tablet.h
@@ -69,7 +69,7 @@ public:
     // `segment_max_rows` is used in vertical writer
     StatusOr<std::unique_ptr<TabletWriter>> new_writer(WriterType type, int64_t txn_id,
                                                        uint32_t max_rows_per_segment = 0,
-                                                       ThreadPool* flush_pool = nullptr);
+                                                       ThreadPool* flush_pool = nullptr, bool is_compaction = false);
 
     StatusOr<std::unique_ptr<TabletReader>> new_reader(Schema schema);
 

--- a/be/src/storage/merge_iterator.h
+++ b/be/src/storage/merge_iterator.h
@@ -39,6 +39,8 @@ ChunkIteratorPtr new_heap_merge_iterator(const std::vector<ChunkIteratorPtr>& ch
 ChunkIteratorPtr new_heap_merge_iterator(const std::vector<ChunkIteratorPtr>& children,
                                          const std::string& merge_condition);
 
+ChunkIteratorPtr new_heap_merge_iterator(const std::vector<ChunkIteratorPtr>& children, const bool need_rssid_rowids);
+
 // new_mask_merge_iterator create a merge iterator based on source masks.
 // the order of rows is determined by mask sequence.
 ChunkIteratorPtr new_mask_merge_iterator(const std::vector<ChunkIteratorPtr>& children,

--- a/be/src/storage/primary_index.cpp
+++ b/be/src/storage/primary_index.cpp
@@ -594,7 +594,7 @@ public:
         }
         return dump->finish_pindex_kvs(dump_pb);
     }
-};
+}; // namespace starrocks
 
 struct StringHasher1 {
     size_t operator()(const string& v) const { return XXH3_64bits(v.data(), v.length()); }
@@ -758,7 +758,7 @@ public:
         }
         return dump->finish_pindex_kvs(dump_pb);
     }
-};
+}; // namespace starrocks
 
 class ShardByLengthSliceHashIndex : public HashIndex {
 private:
@@ -896,7 +896,7 @@ public:
                                     ->replace(rssid, rowid_start, indexes, idx_begin, idx_end, pks));
         }
         return Status::OK();
-    }
+    } // namespace starrocks
 
     [[maybe_unused]] void try_replace(uint32_t rssid, uint32_t rowid_start, const Column& pks,
                                       const vector<uint32_t>& src_rssid, uint32_t idx_begin, uint32_t idx_end,

--- a/be/src/storage/primary_key_compaction_conflict_resolver.cpp
+++ b/be/src/storage/primary_key_compaction_conflict_resolver.cpp
@@ -1,0 +1,120 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "storage/primary_key_compaction_conflict_resolver.h"
+
+#include "storage/chunk_helper.h"
+#include "storage/del_vector.h"
+#include "storage/primary_index.h"
+#include "storage/primary_key_encoder.h"
+#include "storage/rows_mapper.h"
+#include "storage/tablet_schema.h"
+#include "util/trace.h"
+
+namespace starrocks {
+
+Status PrimaryKeyCompactionConflictResolver::execute() {
+    Schema pkey_schema = generate_pkey_schema();
+
+    std::unique_ptr<Column> pk_column;
+    RETURN_IF_ERROR(PrimaryKeyEncoder::create_column(pkey_schema, &pk_column, true));
+
+    // init rows mapper iter
+    ASSIGN_OR_RETURN(auto filename, filename());
+    RowsMapperIterator mapper_iter;
+    RETURN_IF_ERROR(mapper_iter.open(filename));
+
+    // iterate all segment in output rowset
+    RETURN_IF_ERROR(segment_iterator(
+            [&](const CompactConflictResolveParams& params, const std::vector<ChunkIteratorPtr>& segment_iters,
+                const std::function<void(uint32_t, const DelVectorPtr&, uint32_t)>& handle_delvec_result_func) {
+                std::map<uint32_t, DelVectorPtr> rssid_to_delvec;
+                for (size_t segment_id = 0; segment_id < segment_iters.size(); segment_id++) {
+                    // only hold pkey, so can use larger chunk size
+                    auto chunk_shared_ptr = ChunkHelper::new_chunk(pkey_schema, config::vector_chunk_size);
+                    auto chunk = chunk_shared_ptr.get();
+                    auto col = pk_column->clone();
+                    vector<uint32_t> tmp_deletes;
+                    uint32_t current_rowid = 0;
+
+                    auto itr = segment_iters[segment_id].get();
+                    if (itr != nullptr) {
+                        while (true) {
+                            chunk->reset();
+                            col->reset_column();
+                            auto st = Status::OK();
+                            // 4. get chunk
+                            {
+                                TRACE_COUNTER_SCOPE_LATENCY_US("compaction_get_next_latency_us");
+                                st = itr->get_next(chunk);
+                            }
+
+                            if (st.is_end_of_file()) {
+                                break;
+                            } else if (!st.ok()) {
+                                return st;
+                            } else {
+                                // 5. get input rssid & rowids, so we can generate delvec
+                                std::vector<uint64_t> rssid_rowids;
+                                std::vector<uint32_t> replace_indexes;
+                                RETURN_IF_ERROR(mapper_iter.next_values(chunk->num_rows(), &rssid_rowids));
+                                DCHECK(chunk->num_rows() == rssid_rowids.size());
+                                for (int i = 0; i < rssid_rowids.size(); i++) {
+                                    const uint32_t rssid = rssid_rowids[i] >> 32;
+                                    const uint32_t rowid = rssid_rowids[i] & 0xffffffff;
+                                    if (rssid_to_delvec.count(rssid) == 0) {
+                                        // get delvec by loader
+                                        DelVectorPtr delvec_ptr;
+                                        {
+                                            TRACE_COUNTER_SCOPE_LATENCY_US("compaction_delvec_loader_latency_us");
+                                            RETURN_IF_ERROR(params.delvec_loader->load(
+                                                    {params.tablet_id, rssid}, params.base_version, &delvec_ptr));
+                                        }
+                                        rssid_to_delvec[rssid] = delvec_ptr;
+                                    }
+                                    if (!rssid_to_delvec[rssid]->empty() &&
+                                        rssid_to_delvec[rssid]->roaring()->contains(rowid)) {
+                                        // Input row had been deleted, so we need to delete it from output rowset
+                                        tmp_deletes.push_back(current_rowid + i);
+                                    } else {
+                                        // replace pk index
+                                        replace_indexes.push_back(i);
+                                    }
+                                }
+                                // 6. replace pk index
+                                TRACE_COUNTER_SCOPE_LATENCY_US("compaction_replace_index_latency_us");
+                                PrimaryKeyEncoder::encode(pkey_schema, *chunk, 0, chunk->num_rows(), col.get());
+                                RETURN_IF_ERROR(params.index->replace(params.rowset_id + segment_id, current_rowid,
+                                                                      replace_indexes, *col));
+                                current_rowid += chunk->num_rows();
+                            }
+                        }
+                        itr->close();
+                        // 7. generate final delvec
+                        DelVectorPtr dv = std::make_shared<DelVector>();
+                        if (tmp_deletes.empty()) {
+                            dv->init(params.new_version, nullptr, 0);
+                        } else {
+                            dv->init(params.new_version, tmp_deletes.data(), tmp_deletes.size());
+                        }
+                        handle_delvec_result_func(params.rowset_id + segment_id, dv, tmp_deletes.size());
+                    }
+                }
+                return Status::OK();
+            }));
+
+    return mapper_iter.status();
+}
+
+} // namespace starrocks

--- a/be/src/storage/primary_key_compaction_conflict_resolver.h
+++ b/be/src/storage/primary_key_compaction_conflict_resolver.h
@@ -1,0 +1,51 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <string>
+
+#include "common/status.h"
+#include "storage/chunk_iterator.h"
+#include "storage/del_vector.h"
+
+namespace starrocks {
+
+class DelvecLoader;
+class Schema;
+class PrimaryIndex;
+
+struct CompactConflictResolveParams {
+    int64_t tablet_id = 0;
+    uint32_t rowset_id = 0;
+    int64_t base_version = 0;
+    int64_t new_version = 0;
+    DelvecLoader* delvec_loader = 0;
+    PrimaryIndex* index = 0;
+};
+
+class PrimaryKeyCompactionConflictResolver {
+public:
+    virtual ~PrimaryKeyCompactionConflictResolver() = default;
+    virtual StatusOr<std::string> filename() const = 0;
+    virtual Schema generate_pkey_schema() = 0;
+    virtual Status segment_iterator(
+            const std::function<Status(const CompactConflictResolveParams&, const std::vector<ChunkIteratorPtr>&,
+                                       const std::function<void(uint32_t, const DelVectorPtr&, uint32_t)>&)>&
+                    handler) = 0;
+
+    Status execute();
+};
+
+} // namespace starrocks

--- a/be/src/storage/rows_mapper.cpp
+++ b/be/src/storage/rows_mapper.cpp
@@ -1,0 +1,136 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "storage/rows_mapper.h"
+
+#include <fmt/format.h>
+
+#include "fs/fs.h"
+#include "storage/data_dir.h"
+#include "storage/storage_engine.h"
+#include "util/coding.h"
+#include "util/crc32c.h"
+#include "util/raw_container.h"
+
+namespace starrocks {
+
+Status RowsMapperBuilder::_init() {
+    ASSIGN_OR_RETURN(auto fs, FileSystem::CreateSharedFromString(_filename));
+    WritableFileOptions wblock_opts{.sync_on_close = true, .mode = FileSystem::CREATE_OR_OPEN_WITH_TRUNCATE};
+    ASSIGN_OR_RETURN(_wfile, fs->new_writable_file(wblock_opts, _filename));
+    return Status::OK();
+}
+
+Status RowsMapperBuilder::append(const std::vector<uint64_t>& rssid_rowids) {
+    if (_wfile == nullptr) {
+        RETURN_IF_ERROR(_init());
+    }
+    RETURN_IF_ERROR(_wfile->append(Slice((const char*)rssid_rowids.data(), rssid_rowids.size() * 8)));
+    _checksum = crc32c::Extend(_checksum, (const char*)rssid_rowids.data(), rssid_rowids.size() * 8);
+    _row_count += rssid_rowids.size();
+    return Status::OK();
+}
+
+Status RowsMapperBuilder::finalize() {
+    if (_wfile == nullptr) {
+        // Empty rows, skip finalize
+        return Status::OK();
+    }
+    std::string row_count_str;
+    // row count
+    put_fixed64_le(&row_count_str, _row_count);
+    _checksum = crc32c::Extend(_checksum, row_count_str.data(), row_count_str.size());
+    // checksum
+    std::string checksum_str;
+    put_fixed32_le(&checksum_str, _checksum);
+    RETURN_IF_ERROR(_wfile->append(row_count_str));
+    RETURN_IF_ERROR(_wfile->append(checksum_str));
+    return _wfile->close();
+}
+
+RowsMapperIterator::~RowsMapperIterator() {
+    if (_rfile != nullptr) {
+        const std::string filename = _rfile->filename();
+        _rfile.reset(nullptr);
+        auto st = fs::delete_file(filename);
+        if (!st.ok()) {
+            LOG(ERROR) << "delete rows mapper file fail, st: " << st;
+        }
+    }
+}
+
+// Open file
+Status RowsMapperIterator::open(const std::string& filename) {
+    ASSIGN_OR_RETURN(auto fs, FileSystem::CreateSharedFromString(filename));
+    ASSIGN_OR_RETURN(_rfile, fs->new_random_access_file(filename));
+    ASSIGN_OR_RETURN(int64_t file_size, _rfile->get_size());
+    // 1. read checksum
+    std::string checksum_str;
+    raw::stl_string_resize_uninitialized(&checksum_str, 4);
+    RETURN_IF_ERROR(_rfile->read_at_fully(file_size - 4, checksum_str.data(), checksum_str.size()));
+    _expected_checksum = decode_fixed32_le((const uint8_t*)checksum_str.data());
+    // 2. read row count
+    std::string row_count_str;
+    raw::stl_string_resize_uninitialized(&row_count_str, 8);
+    RETURN_IF_ERROR(_rfile->read_at_fully(file_size - 12, row_count_str.data(), row_count_str.size()));
+    _row_count = decode_fixed64_le((const uint8_t*)row_count_str.data());
+    // 3. check file size (should be 4 bytes(checksum) + 8 bytes(row count) + id list)
+    if (file_size != 12 + _row_count * EACH_ROW_SIZE) {
+        return Status::Corruption(
+                fmt::format("RowsMapper file corruption. file size: {}, row count: {}", file_size, _row_count));
+    }
+    return Status::OK();
+}
+
+Status RowsMapperIterator::next_values(size_t fetch_cnt, std::vector<uint64_t>* rssid_rowids) {
+    if (fetch_cnt == 0) {
+        // No need to fetch
+        return Status::OK();
+    }
+    if (_pos + fetch_cnt > _row_count) {
+        return Status::EndOfFile(fmt::format("RowsMapperIterator end of file. position/fetch cnt/row count: {}/{}/{}",
+                                             _pos, fetch_cnt, _row_count));
+    }
+    rssid_rowids->resize(fetch_cnt);
+    RETURN_IF_ERROR(_rfile->read_at_fully(_pos * EACH_ROW_SIZE, rssid_rowids->data(), fetch_cnt * EACH_ROW_SIZE));
+    _current_checksum = crc32c::Extend(_current_checksum, (const char*)rssid_rowids->data(), rssid_rowids->size() * 8);
+    _pos += fetch_cnt;
+    return Status::OK();
+}
+
+Status RowsMapperIterator::status() {
+    if (_pos != _row_count) {
+        return Status::Corruption(fmt::format("Chunk vs rows mapper's row count mismatch. {} vs {} filename: {}", _pos,
+                                              _row_count, _rfile->filename()));
+    }
+    std::string row_count_str;
+    // row count
+    put_fixed64_le(&row_count_str, _row_count);
+    _current_checksum = crc32c::Extend(_current_checksum, row_count_str.data(), row_count_str.size());
+    if (_expected_checksum != _current_checksum) {
+        return Status::Corruption(fmt::format("checksum mismatch. cur: {} expected: {} filename: {}", _current_checksum,
+                                              _expected_checksum, _rfile->filename()));
+    }
+    return Status::OK();
+}
+
+StatusOr<std::string> lake_rows_mapper_filename(int64_t tablet_id, int64_t txn_id) {
+    auto data_dir = StorageEngine::instance()->get_persistent_index_store(tablet_id);
+    if (data_dir == nullptr) {
+        return Status::NotFound(fmt::format("Not local disk found. tablet id: {}", tablet_id));
+    }
+    return data_dir->get_tmp_path() + "/" + fmt::format("{:016X}_{:016X}.crm", tablet_id, txn_id);
+}
+
+} // namespace starrocks

--- a/be/src/storage/rows_mapper.h
+++ b/be/src/storage/rows_mapper.h
@@ -1,0 +1,78 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <gtest/gtest.h>
+
+#include "common/status.h"
+#include "gen_cpp/persistent_index.pb.h"
+
+namespace starrocks {
+
+class WritableFile;
+class RandomAccessFile;
+
+// Build the connection between input rowsets' rows and ouput rowsets' rows,
+// and then write to file.
+//
+// Format: [rssid & rowid list, row count (8 bytes), Checksum(4 bytes)]
+//
+class RowsMapperBuilder {
+public:
+    RowsMapperBuilder(const std::string& filename) : _filename(filename) {}
+    ~RowsMapperBuilder() {}
+    // append rssid rowids to file
+    Status append(const std::vector<uint64_t>& rssid_rowids);
+    Status finalize();
+
+private:
+    Status _init();
+
+private:
+    std::string _filename;
+    std::unique_ptr<WritableFile> _wfile;
+    uint32_t _checksum = 0;
+    uint64_t _row_count = 0;
+};
+
+// Iterator for rows mapper file
+class RowsMapperIterator {
+public:
+    RowsMapperIterator() {}
+    ~RowsMapperIterator();
+    // Open file, and prepare internal state
+    Status open(const std::string& filename);
+    // get `fetch_cnt` rows and move to next position
+    Status next_values(size_t fetch_cnt, std::vector<uint64_t>* rssid_rowids);
+    // Must be called when iterator end.
+    Status status();
+
+private:
+    inline static const size_t EACH_ROW_SIZE = 8; // 8 bytes
+
+private:
+    std::unique_ptr<RandomAccessFile> _rfile;
+    uint64_t _row_count = 0;
+    // Point to the next position that we want to read
+    uint64_t _pos = 0;
+    // Current checksum and expected checksum, will check if mismatch when iterator end
+    uint32_t _expected_checksum = 0;
+    uint32_t _current_checksum = 0;
+};
+
+// rows mapper file's name for lake table
+StatusOr<std::string> lake_rows_mapper_filename(int64_t tablet_id, int64_t txn_id);
+
+} // namespace starrocks

--- a/be/src/storage/rowset/segment_iterator.cpp
+++ b/be/src/storage/rowset/segment_iterator.cpp
@@ -110,6 +110,7 @@ public:
 protected:
     Status do_get_next(Chunk* chunk) override;
     Status do_get_next(Chunk* chunk, vector<uint32_t>* rowid) override;
+    Status do_get_next(Chunk* chunk, vector<uint64_t>* rssid_rowids) override;
     Status do_get_next(Chunk* chunk, std::vector<RowSourceMask>* source_masks) override { return do_get_next(chunk); }
 
 private:
@@ -1060,6 +1061,32 @@ Status SegmentIterator::do_get_next(Chunk* chunk, vector<uint32_t>* rowid) {
     do {
         st = _do_get_next(chunk, rowid);
     } while (st.ok() && chunk->num_rows() == 0);
+    return st;
+}
+
+Status SegmentIterator::do_get_next(Chunk* chunk, vector<uint64_t>* rssid_rowids) {
+    if (!_inited) {
+        RETURN_IF_ERROR(_init());
+        _inited = true;
+    }
+
+    RETURN_IF_ERROR(_try_to_update_ranges_by_runtime_filter());
+
+    DCHECK_EQ(0, chunk->num_rows());
+
+    Status st;
+    vector<uint32_t> rowids;
+    do {
+        st = _do_get_next(chunk, &rowids);
+    } while (st.ok() && chunk->num_rows() == 0);
+    if (st.ok()) {
+        // encode rssid with rowid
+        // | rssid (32bit) | rowid (32bit) |
+        uint64_t rssid_shift = (uint64_t)(_opts.rowset_id + segment_id()) << 32;
+        for (uint32_t rowid : rowids) {
+            rssid_rowids->push_back(rssid_shift | rowid);
+        }
+    }
     return st;
 }
 

--- a/be/src/storage/storage_engine.cpp
+++ b/be/src/storage/storage_engine.cpp
@@ -529,6 +529,18 @@ DataDir* StorageEngine::get_store(int64_t path_hash) {
     return nullptr;
 }
 
+bool StorageEngine::enable_light_pk_compaction_publish() {
+    if (!config::enable_light_pk_compaction_publish) {
+        return false;
+    }
+    // Skip light pk compaction if there is no local disk to store temp rows mapper files.
+    auto stores = get_stores<false>();
+    if (stores.empty()) {
+        return false;
+    }
+    return true;
+}
+
 // maybe nullptr if as cn
 DataDir* StorageEngine::get_persistent_index_store(int64_t tablet_id) {
     auto stores = get_stores<false>();

--- a/be/src/storage/storage_engine.h
+++ b/be/src/storage/storage_engine.h
@@ -296,6 +296,8 @@ public:
 
     bool is_as_cn() { return !_options.need_write_cluster_id; }
 
+    bool enable_light_pk_compaction_publish();
+
 protected:
     static StorageEngine* _s_instance;
 

--- a/be/test/CMakeLists.txt
+++ b/be/test/CMakeLists.txt
@@ -437,6 +437,7 @@ set(EXEC_FILES
         ./service/service_be/internal_service_test.cpp
         ./storage/compaction_parallelization_test.cpp
         ./storage/delta_writer_test.cpp
+        ./storage/rows_mapper_test.cpp
         ./storage/lake/persistent_index_memtable_test.cpp
         ./storage/lake/lake_persistent_index_test.cpp
         ./storage/lake/replication_txn_manager_test.cpp

--- a/be/test/storage/rows_mapper_test.cpp
+++ b/be/test/storage/rows_mapper_test.cpp
@@ -1,0 +1,107 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "storage/rows_mapper.h"
+
+#include "fs/fs.h"
+#include "fs/fs_util.h"
+#include "testutil/assert.h"
+
+namespace starrocks {
+
+class RowsMapperTest : public testing::Test {
+public:
+    RowsMapperTest() {}
+
+protected:
+    constexpr static const char* kTestDirectory = "./test_rows_mapper/";
+
+    void SetUp() override { ASSERT_OK(fs::create_directories(kTestDirectory)); }
+
+    void TearDown() override { (void)fs::remove_all(kTestDirectory); }
+
+    // generate id between [start, end)
+    void generate_rssid_rowids(std::vector<uint64_t>* rssid_rowids, uint64_t start, size_t end, uint64_t rssid) {
+        for (uint64_t i = start; i < end; i++) {
+            rssid_rowids->push_back((rssid << 32) | i);
+        }
+    }
+};
+
+TEST_F(RowsMapperTest, test_write_read) {
+    const std::string filename = std::string(kTestDirectory) + "test_write_read.crm";
+    RowsMapperBuilder builder(filename);
+    std::vector<uint64_t> rssid_rowids;
+    generate_rssid_rowids(&rssid_rowids, 0, 1000, 11);
+    ASSERT_OK(builder.append(rssid_rowids));
+    rssid_rowids.clear();
+    generate_rssid_rowids(&rssid_rowids, 1000, 3000, 11);
+    ASSERT_OK(builder.append(rssid_rowids));
+    ASSERT_OK(builder.finalize());
+
+    // read from file
+    RowsMapperIterator iterator;
+    ASSERT_OK(iterator.open(filename));
+    for (uint32_t i = 0; i < 3000; i += 100) {
+        std::vector<uint64_t> rows_mapper;
+        ASSERT_OK(iterator.next_values(100, &rows_mapper));
+        ASSERT_TRUE(rows_mapper.size() == 100);
+        for (uint32_t j = 0; j < rows_mapper.size(); j++) {
+            ASSERT_TRUE((rows_mapper[j] >> 32) == 11);
+            ASSERT_TRUE((rows_mapper[j] & 0xFFFFFFFF) == i + j);
+        }
+    }
+    ASSERT_OK(iterator.status());
+    // should eof
+    std::vector<uint64_t> rows_mapper;
+    ASSERT_TRUE(iterator.next_values(1, &rows_mapper).is_end_of_file());
+}
+
+TEST_F(RowsMapperTest, test_write_read_multi_segment) {
+    const std::string filename = std::string(kTestDirectory) + "test_write_read_multi_segment.crm";
+    RowsMapperBuilder builder(filename);
+    std::vector<uint64_t> rssid_rowids;
+    // rssid = 11
+    generate_rssid_rowids(&rssid_rowids, 0, 1000, 11);
+    ASSERT_OK(builder.append(rssid_rowids));
+    rssid_rowids.clear();
+    // rssid = 43
+    generate_rssid_rowids(&rssid_rowids, 1000, 3000, 43);
+    ASSERT_OK(builder.append(rssid_rowids));
+    ASSERT_OK(builder.finalize());
+
+    // read from file
+    RowsMapperIterator iterator;
+    ASSERT_OK(iterator.open(filename));
+    for (uint32_t i = 0; i < 3000; i += 100) {
+        std::vector<uint64_t> rows_mapper;
+        ASSERT_OK(iterator.next_values(100, &rows_mapper));
+        ASSERT_TRUE(rows_mapper.size() == 100);
+        for (uint32_t j = 0; j < rows_mapper.size(); j++) {
+            if (i + j < 1000) {
+                ASSERT_TRUE((rows_mapper[j] >> 32) == 11);
+                ASSERT_TRUE((rows_mapper[j] & 0xFFFFFFFF) == i + j);
+            } else {
+                ASSERT_TRUE((rows_mapper[j] >> 32) == 43);
+                ASSERT_TRUE((rows_mapper[j] & 0xFFFFFFFF) == i + j);
+            }
+        }
+    }
+    ASSERT_OK(iterator.status());
+    // should eof
+    std::vector<uint64_t> rows_mapper;
+    ASSERT_TRUE(iterator.next_values(1, &rows_mapper).is_end_of_file());
+}
+
+} // namespace starrocks


### PR DESCRIPTION
## Why I'm doing:
In SR, we handle PK table compaction and data loading concurrently, so in the publish phase we need to resolve the conflict between compaction and data loading.

![image](https://github.com/StarRocks/starrocks/assets/10725468/bf986ba1-26b7-4f41-93a5-260270848d13)

In the above figure, rowset-3 update rows A and D, and then compaction generate rowset-4. So rows A and D need to be marked for deletion at last.

We resolve the conflict by read from PK INDEX, which will lead to several flaws:

1. because compaction usually brings about a large number of rows to be merged, even a full merge. Therefore, it will bring a lot of read IO to the PK INDEX.

2. Uncontrollable memory usage. Because we are by segment granularity to load PK columns to memory, if the segment compression ratio is very high, 1G segment of PK columns loaded to memory, maybe we need 5G memory!
 *  Assuming a scenario where the user has a 16C64G machine, and each publish thread needs to load 5G PK columns, the maximum amount of memory needed is 16 * 5GB = 80 GB, which is far more than the machine limitations.
 *  Is it possible to make the PK columns loading chunk by chunk? It can save memory, but it will result in multiple queries of the PK INDEX, leading to further read IO amplification. Flaws 1 and Flaws 2 cannot be solved both now.

## What I'm doing:
The compaction processing in the new scheme consists of several steps:
1. During the compaction execution, generate a file containing the input segments' rowids (end as `.crm`). In file `rows_mapper.cpp` and `lake/pk_tablet_writer.cpp`.
2. in the publish phase, load the output segment's PK columns into memory chunk by chunk and read the corresponding input segment's rowid from `.crm`.  In file `primary_key_compaction_conflict_resolver.cpp` and `lake/lake_primary_key_compaction_conflict_resolver.cpp`
3. Query the latest delete vector of the input segment by the rowids of the input segments to determine whether each row in the new output segment should be marked for deletion. In file `primary_key_compaction_conflict_resolver.cpp` and `lake/lake_primary_key_compaction_conflict_resolver.cpp`

E.g.
![image](https://github.com/StarRocks/starrocks/assets/10725468/220d6bb8-a742-4f1f-bc47-bb3660dd919c)

1. In the figure, the contents of the row mapping relationship file generated by the process of merging Rowset-1 and Rowset-2 by compact are:
```
(A, 1, 1) -> 1-0, (rowset id is 1 and rowid is 0)
(B, 2, 2) -> 1-1
(E, 5, 5) -> 2-1
```

2. At publish & apply, go through the original lines in the line mapping relationship file and backcheck delvec to get:
```
(A, 1, 1) -> 1-0 -> deleted
(B, 2, 2) -> 1-1 -> exists
(C, 3, 3) -> 1-2 -> exists
(D, 4, 4) -> 2-0 -> deleted
(E, 5, 5) -> 2-1 -> exists
```

3. So finally, the delvec generated for Rowset-4 is `<1, 0, 0, 1, 0>`, and result of Rowset-4 is :
```
(B, 2, 2)
(C, 3, 3)
(E, 5, 5)
```

## What type of PR is this:

- [ ] BugFix
- [x] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
