### PR TITLE
[UT] remove setting session variables have not been added

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,7 @@ thirdparty/installed
 core.*
 extension/spark-doris-connector/.classpath
 extension/spark-doris-connector/target
+contrib/trino-connector/target/
 fe/log
 **/ut_ports
 custom_env.sh

--- a/test/sql/test_scan/test_pushdown_or_predicate/R/test_index_and_filter_on_or_predicate
+++ b/test/sql/test_scan/test_pushdown_or_predicate/R/test_index_and_filter_on_or_predicate
@@ -2,10 +2,6 @@
 set scan_or_to_union_limit = 1;
 -- result:
 -- !result
-set enable_show_predicate_tree_in_profile = true;
--- result:
-E: (1193, "Unknown system variable 'enable_show_predicate_tree_in_profile', the most similar variables are {'enable_rewrite_groupingsets_to_union_all', 'enable_write_hive_external_table', 'enable_shared_scan'}")
--- !result
 set enable_profile = true;
 -- result:
 -- !result

--- a/test/sql/test_scan/test_pushdown_or_predicate/R/test_parse_and_rewrite_or_predicate
+++ b/test/sql/test_scan/test_pushdown_or_predicate/R/test_parse_and_rewrite_or_predicate
@@ -2,10 +2,6 @@
 set scan_or_to_union_limit = 1;
 -- result:
 -- !result
-set enable_show_predicate_tree_in_profile = true;
--- result:
-E: (1193, "Unknown system variable 'enable_show_predicate_tree_in_profile', the most similar variables are {'enable_rewrite_groupingsets_to_union_all', 'enable_write_hive_external_table', 'enable_shared_scan'}")
--- !result
 set enable_profile = true;
 -- result:
 -- !result

--- a/test/sql/test_scan/test_pushdown_or_predicate/T/test_index_and_filter_on_or_predicate
+++ b/test/sql/test_scan/test_pushdown_or_predicate/T/test_index_and_filter_on_or_predicate
@@ -2,7 +2,7 @@
 
 -- Setup configs.
 set scan_or_to_union_limit = 1;
-set enable_show_predicate_tree_in_profile = true;
+-- set enable_show_predicate_tree_in_profile = true;
 set enable_profile = true;
 set enable_async_profile=false;
 

--- a/test/sql/test_scan/test_pushdown_or_predicate/T/test_parse_and_rewrite_or_predicate
+++ b/test/sql/test_scan/test_pushdown_or_predicate/T/test_parse_and_rewrite_or_predicate
@@ -2,7 +2,7 @@
 
 -- Setup configs.
 set scan_or_to_union_limit = 1;
-set enable_show_predicate_tree_in_profile = true;
+-- set enable_show_predicate_tree_in_profile = true;
 set enable_profile = true;
 set enable_async_profile=false;
 


### PR DESCRIPTION
## Why I'm doing:
Remove `set enable_show_predicate_tree_in_profile = true' in the test case, which haven't been added.

## What I'm doing:
Remove `set enable_show_predicate_tree_in_profile = true' in the test case, which haven't been added.

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [x] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
