### PR TITLE
[BugFix] Fix spill unmatched sequence id error

### DIFF
--- a/be/src/exec/pipeline/aggregate/spillable_aggregate_blocking_source_operator.cpp
+++ b/be/src/exec/pipeline/aggregate/spillable_aggregate_blocking_source_operator.cpp
@@ -49,6 +49,7 @@ bool SpillableAggregateBlockingSourceOperator::has_output() const {
     if (_aggregator->spiller()->has_output_data()) {
         return true;
     }
+    RETURN_TRUE_IF_SPILL_TASK_ERROR(_aggregator->spiller());
     // has eos chunk
     if (_aggregator->is_spilled_eos() && _has_last_chunk) {
         return true;
@@ -86,6 +87,7 @@ Status SpillableAggregateBlockingSourceOperator::set_finished(RuntimeState* stat
 }
 
 StatusOr<ChunkPtr> SpillableAggregateBlockingSourceOperator::pull_chunk(RuntimeState* state) {
+    RETURN_IF_ERROR(_aggregator->spiller()->task_status());
     if (!_aggregator->spiller()->spilled()) {
         return AggregateBlockingSourceOperator::pull_chunk(state);
     }

--- a/be/src/exec/pipeline/aggregate/spillable_aggregate_distinct_blocking_operator.cpp
+++ b/be/src/exec/pipeline/aggregate/spillable_aggregate_distinct_blocking_operator.cpp
@@ -190,6 +190,7 @@ bool SpillableAggregateDistinctBlockingSourceOperator::has_output() const {
     if (_aggregator->spiller()->has_output_data()) {
         return true;
     }
+    RETURN_TRUE_IF_SPILL_TASK_ERROR(_aggregator->spiller());
     if (_aggregator->spiller()->is_cancel()) {
         return true;
     }
@@ -223,6 +224,7 @@ Status SpillableAggregateDistinctBlockingSourceOperator::set_finished(RuntimeSta
 }
 
 StatusOr<ChunkPtr> SpillableAggregateDistinctBlockingSourceOperator::pull_chunk(RuntimeState* state) {
+    RETURN_IF_ERROR(_aggregator->spiller()->task_status());
     if (!_aggregator->spiller()->spilled()) {
         return AggregateDistinctBlockingSourceOperator::pull_chunk(state);
     }

--- a/be/src/exec/pipeline/nljoin/spillable_nljoin_probe_operator.cpp
+++ b/be/src/exec/pipeline/nljoin/spillable_nljoin_probe_operator.cpp
@@ -152,6 +152,7 @@ bool SpillableNLJoinProbeOperator::is_finished() const {
 }
 
 bool SpillableNLJoinProbeOperator::has_output() const {
+    RETURN_TRUE_IF_SPILL_TASK_ERROR(_spiller);
     return !_is_current_build_probe_finished() && _chunk_stream && _chunk_stream->has_output();
 }
 
@@ -172,6 +173,7 @@ Status SpillableNLJoinProbeOperator::set_finished(RuntimeState* state) {
 
 StatusOr<ChunkPtr> SpillableNLJoinProbeOperator::pull_chunk(RuntimeState* state) {
     TRACE_SPILL_LOG << "pull_chunk:" << _driver_sequence;
+    RETURN_IF_ERROR(_spiller->task_status());
     if (_prober.probe_finished() || _build_chunk == nullptr || _build_chunk->is_empty()) {
         auto chunk_st = _chunk_stream->get_next(state);
         if (chunk_st.status().is_end_of_file()) {

--- a/be/src/exec/spill/block_manager.h
+++ b/be/src/exec/spill/block_manager.h
@@ -45,12 +45,9 @@ public:
     bool is_remote() const { return _is_remote; }
     void set_is_remote(bool is_remote) { _is_remote = is_remote; }
 
-    int32_t next_sequence_id() { return _next_sequence_id++; }
-
     virtual bool preallocate(size_t write_size) = 0;
 
 protected:
-    int32_t _next_sequence_id{};
     size_t _size{};
     bool _is_remote = false;
 };
@@ -69,10 +66,7 @@ public:
 
     virtual const Block* block() const = 0;
 
-    int32_t next_sequence_id() { return _next_sequence_id++; }
-
 protected:
-    int32_t _next_sequence_id{};
     const Block* _block = nullptr;
 };
 

--- a/be/src/exec/spill/data_stream.h
+++ b/be/src/exec/spill/data_stream.h
@@ -28,11 +28,7 @@ public:
     virtual ~SpillOutputDataStream() = default;
     virtual Status append(RuntimeState* state, const std::vector<Slice>& data, size_t total_write_size) = 0;
     virtual Status flush() = 0;
-    int32_t next_sequence_id() { return _next_sequence_id++; }
     virtual bool is_remote() const = 0;
-
-private:
-    int32_t _next_sequence_id{};
 };
 using SpillOutputDataStreamPtr = std::shared_ptr<SpillOutputDataStream>;
 SpillOutputDataStreamPtr create_spill_output_stream(Spiller* spiller, BlockGroup* block_group,

--- a/be/src/exec/spill/input_stream.cpp
+++ b/be/src/exec/spill/input_stream.cpp
@@ -18,6 +18,7 @@
 #include <memory>
 #include <utility>
 
+#include "common/status.h"
 #include "exec/spill/block_manager.h"
 #include "exec/spill/serde.h"
 #include "exec/spill/spiller.h"
@@ -212,8 +213,9 @@ StatusOr<ChunkUniquePtr> BufferedInputStream::get_next(workgroup::YieldContext& 
     if (has_chunk()) {
         return read_from_buffer();
     }
-    CHECK(!_is_prefetching);
-    return _input_stream->get_next(yield_ctx, ctx);
+    // if prefetch failed, return empty chunk
+    DCHECK(false);
+    return std::make_unique<Chunk>();
 }
 
 Status BufferedInputStream::prefetch(workgroup::YieldContext& yield_ctx, SerdeContext& ctx) {

--- a/be/src/exec/spill/serde.cpp
+++ b/be/src/exec/spill/serde.cpp
@@ -55,6 +55,7 @@ private:
     static constexpr int32_t SEQUENCE_OFFSET = 0;
     static constexpr int32_t ATTACHMENT_SIZE_OFFSET = SEQUENCE_OFFSET + sizeof(int32_t);
     static constexpr int32_t HEADER_SIZE = ATTACHMENT_SIZE_OFFSET + sizeof(int64_t);
+    static constexpr int32_t SEQUENCE_MAGIC_ID = 0xface;
 
     size_t _max_serialized_size(const ChunkPtr& chunk) const;
 
@@ -112,7 +113,7 @@ Status ColumnarSerde::serialize(RuntimeState* state, SerdeContext& ctx, const Ch
         // header|attachment...
         // i32 sequence_id|i64 chunk size|encode level|attachment(column data)...
         char header_buffer[HEADER_SIZE];
-        UNALIGNED_STORE32(header_buffer + SEQUENCE_OFFSET, output->next_sequence_id());
+        UNALIGNED_STORE32(header_buffer + SEQUENCE_OFFSET, SEQUENCE_MAGIC_ID);
 
         size_t encode_level_sizes = columns.size() * sizeof(int32_t);
         size_t max_serialized_size = _max_serialized_size(chunk);
@@ -173,9 +174,8 @@ StatusOr<ChunkUniquePtr> ColumnarSerde::deserialize(SerdeContext& ctx, BlockRead
 
     int32_t sequence_id = UNALIGNED_LOAD32(header_buffer + SEQUENCE_OFFSET);
     int32_t attachment_size = UNALIGNED_LOAD32(header_buffer + ATTACHMENT_SIZE_OFFSET);
-    int32_t next_sequence_id = reader->next_sequence_id();
-    if (sequence_id != next_sequence_id) {
-        return Status::InternalError(fmt::format("sequence id mismatch {} vs {}", sequence_id, next_sequence_id));
+    if (sequence_id != SEQUENCE_MAGIC_ID) {
+        return Status::InternalError(fmt::format("sequence id mismatch {} vs {}", sequence_id, SEQUENCE_MAGIC_ID));
     }
 
     auto chunk = _chunk_builder();

--- a/be/src/exec/spill/spiller.h
+++ b/be/src/exec/spill/spiller.h
@@ -41,6 +41,12 @@
 #include "util/runtime_profile.h"
 
 #define GET_METRICS(remote, metrics, key) (remote ? metrics.remote_##key : metrics.local_##key)
+
+#define RETURN_TRUE_IF_SPILL_TASK_ERROR(spiller) \
+    if (!(spiller)->task_status().ok()) {        \
+        return true;                             \
+    }
+
 namespace starrocks::spill {
 
 // some metrics for spill

--- a/test/sql/test_spill/R/test_spill_hash_join
+++ b/test/sql/test_spill/R/test_spill_hash_join
@@ -212,3 +212,14 @@ select count(l.c0),sum(length(l.c0)), sum(length(l.c1)) from tstring l right joi
 -- result:
 16384	61108	61096
 -- !result
+set spill_mem_table_size=1000;
+-- result:
+-- !result
+select count(*) from t0 l right join [shuffle]t2 r on l.c0=r.c0 where if(l.c0 is null, 0, l.c0) + r.c0 > 400000;
+-- result:
+9600
+-- !result
+select count(*) from t0 l right join [shuffle]t2 r on l.c0=r.c0 where if(l.c0 is null, 0, l.c0) + r.c0 < 400000;
+-- result:
+404095
+-- !result

--- a/test/sql/test_spill/T/test_spill_hash_join
+++ b/test/sql/test_spill/T/test_spill_hash_join
@@ -85,4 +85,7 @@ select count(*) from tstring;
 select count(l.c0),sum(length(l.c0)), sum(length(l.c1)) from tstring l join tstring r on l.c0 = r.c0; 
 select count(l.c0),sum(length(l.c0)), sum(length(l.c1)) from tstring l left join tstring r on l.c0 = r.c0; 
 select count(l.c0),sum(length(l.c0)), sum(length(l.c1)) from tstring l right join tstring r on l.c0 = r.c0;
-
+-- test small files
+set spill_mem_table_size=1000;
+select count(*) from t0 l right join [shuffle]t2 r on l.c0=r.c0 where if(l.c0 is null, 0, l.c0) + r.c0 > 400000;
+select count(*) from t0 l right join [shuffle]t2 r on l.c0=r.c0 where if(l.c0 is null, 0, l.c0) + r.c0 < 400000;


### PR DESCRIPTION
## Why I'm doing:
introduced by #43269
close https://github.com/StarRocks/StarRocksTest/issues/6951

## What I'm doing:
1. using magic id instead of sequence id
2. return empty chunk when BufferedSpillStream buffer is empty
3. check spill task status in has_output()


## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
