### PR TITLE
[Enhancement] Check if key exists when inserting keys to LakePersistentIndex

### DIFF
--- a/be/src/storage/lake/lake_persistent_index.cpp
+++ b/be/src/storage/lake/lake_persistent_index.cpp
@@ -212,6 +212,9 @@ Status LakePersistentIndex::insert(size_t n, const Slice* keys, const IndexValue
     for (int i = 0; i < n; ++i) {
         key_indexes.insert(n);
     }
+    if (_immutable_memtable != nullptr) {
+        RETURN_IF_ERROR(_immutable_memtable->check_not_exist(keys, key_indexes, version));
+    }
     for (auto iter = _sstables.rbegin(); iter != _sstables.rend(); ++iter) {
         RETURN_IF_ERROR((*iter)->check_not_exist(keys, key_indexes, version));
     }

--- a/be/src/storage/lake/lake_persistent_index.cpp
+++ b/be/src/storage/lake/lake_persistent_index.cpp
@@ -210,7 +210,7 @@ Status LakePersistentIndex::insert(size_t n, const Slice* keys, const IndexValue
     RETURN_IF_ERROR(_memtable->insert(n, keys, values, version));
     KeyIndexSet key_indexes;
     for (int i = 0; i < n; ++i) {
-        key_indexes.insert(n);
+        key_indexes.insert(i);
     }
     if (_immutable_memtable != nullptr) {
         RETURN_IF_ERROR(_immutable_memtable->check_not_exist(keys, key_indexes, version));

--- a/be/src/storage/lake/persistent_index_memtable.cpp
+++ b/be/src/storage/lake/persistent_index_memtable.cpp
@@ -50,16 +50,10 @@ Status PersistentIndexMemtable::upsert(size_t n, const Slice* keys, const IndexV
 Status PersistentIndexMemtable::insert(size_t n, const Slice* keys, const IndexValue* values, int64_t version) {
     for (size_t i = 0; i < n; ++i) {
         auto key = keys[i].to_string();
-        auto size = keys[i].get_size();
         const auto value = values[i];
         std::list<IndexValueWithVer> index_value_vers;
         index_value_vers.emplace_front(version, value);
-        if (auto [it, inserted] = _map.emplace(key, index_value_vers); !inserted) {
-            std::string msg = strings::Substitute("PersistentIndexMemtable<$0> insert found duplicate key $1", size,
-                                                  hexdump((const char*)key.data(), size));
-            LOG(WARNING) << msg;
-            return Status::AlreadyExist(msg);
-        }
+        _map.emplace(key, index_value_vers);
     }
     return Status::OK();
 }

--- a/be/src/storage/lake/persistent_index_memtable.h
+++ b/be/src/storage/lake/persistent_index_memtable.h
@@ -58,6 +58,8 @@ public:
 
     void clear();
 
+    Status check_not_exist(const Slice* keys, const KeyIndexSet& key_indexes, int64_t version) const;
+
 private:
     static void update_index_value(std::list<IndexValueWithVer>* index_value_info, int64_t version,
                                    const IndexValue& value);

--- a/be/src/storage/lake/persistent_index_sstable.h
+++ b/be/src/storage/lake/persistent_index_sstable.h
@@ -54,6 +54,8 @@ public:
     Status multi_get(const Slice* keys, const KeyIndexSet& key_indexes, int64_t version, IndexValue* values,
                      KeyIndexSet* found_key_indexes) const;
 
+    Status check_not_exist(const Slice* keys, const KeyIndexSet& key_indexes, int64_t version) const;
+
     sstable::Iterator* new_iterator(const sstable::ReadOptions& options) { return _sst->NewIterator(options); }
 
     const PersistentIndexSstablePB& sstable_pb() const { return _sstable_pb; }

--- a/be/src/storage/lake/update_manager.cpp
+++ b/be/src/storage/lake/update_manager.cpp
@@ -53,9 +53,9 @@ UpdateManager::UpdateManager(LocationProvider* location_provider, MemTracker* me
 
     _index_cache.set_capacity(update_mem_limit);
 
-    const int64_t block_cache_mem_limit =
+    const int64_t pk_index_block_cache_mem_limit =
             update_mem_limit * std::max(std::min(100, config::lake_pk_index_block_cache_limit_percent), 0) / 100;
-    _block_cache = std::make_unique<PersistentIndexBlockCache>(mem_tracker, block_cache_mem_limit);
+    _pk_index_block_cache = std::make_unique<PersistentIndexBlockCache>(mem_tracker, pk_index_block_cache_mem_limit);
 }
 
 UpdateManager::~UpdateManager() {
@@ -107,7 +107,7 @@ StatusOr<IndexEntry*> UpdateManager::prepare_primary_index(const TabletMetadataP
         LOG(ERROR) << msg;
         return Status::InternalError(msg);
     }
-    _block_cache->update_memory_usage();
+    _pk_index_block_cache->update_memory_usage();
     st = index.prepare(EditVersion(new_version, 0), 0);
     if (!st.ok()) {
         _index_cache.remove(index_entry);
@@ -191,7 +191,7 @@ Status UpdateManager::publish_primary_key_tablet(const TxnLogPB_OpWrite& op_writ
     for (const auto& one_delete : state.auto_increment_deletes()) {
         RETURN_IF_ERROR(index.erase(*one_delete, &new_deletes));
     }
-    _block_cache->update_memory_usage();
+    _pk_index_block_cache->update_memory_usage();
     // 4. generate delvec
     size_t ndelvec = new_deletes.size();
     vector<std::pair<uint32_t, DelVectorPtr>> new_del_vecs(ndelvec);
@@ -365,7 +365,7 @@ Status UpdateManager::_handle_index_op(Tablet* tablet, int64_t base_version, boo
         return Status::Uninitialized(fmt::format("Primary index not load yet, tablet_id: {}", tablet->id()));
     }
     op(index);
-    _block_cache->update_memory_usage();
+    _pk_index_block_cache->update_memory_usage();
 
     return Status::OK();
 }
@@ -645,7 +645,7 @@ Status UpdateManager::publish_primary_compaction(const TxnLogPB_OpCompaction& op
         delvecs.emplace_back(rssid, dv);
         compaction_state.release_segments(i);
     }
-    _block_cache->update_memory_usage();
+    _pk_index_block_cache->update_memory_usage();
 
     // 3. update TabletMeta and write to meta file
     for (auto&& each : delvecs) {

--- a/be/src/storage/lake/update_manager.h
+++ b/be/src/storage/lake/update_manager.h
@@ -176,7 +176,7 @@ public:
 
     Status execute_index_major_compaction(int64_t tablet_id, const TabletMetadata& metadata, TxnLogPB* txn_log);
 
-    PersistentIndexBlockCache* block_cache() { return _block_cache.get(); }
+    PersistentIndexBlockCache* pk_index_block_cache() { return _pk_index_block_cache.get(); }
 
 private:
     // print memory tracker state
@@ -227,7 +227,7 @@ private:
 
     std::vector<PkIndexShard> _pk_index_shards;
 
-    std::unique_ptr<PersistentIndexBlockCache> _block_cache;
+    std::unique_ptr<PersistentIndexBlockCache> _pk_index_block_cache;
 };
 
 } // namespace lake

--- a/be/test/storage/lake/lake_persistent_index_test.cpp
+++ b/be/test/storage/lake/lake_persistent_index_test.cpp
@@ -88,7 +88,7 @@ TEST_F(LakePersistentIndexTest, test_basic_api) {
     auto index = std::make_unique<LakePersistentIndex>(_tablet_mgr.get(), tablet_id);
     ASSERT_OK(index->insert(N, key_slices.data(), values.data(), 0));
     // insert duplicate should return error
-    // ASSERT_FALSE(index->insert(N, key_slices.data(), values.data(), 0).ok());
+    ASSERT_FALSE(index->insert(N, key_slices.data(), values.data(), 1).ok());
 
     // test get
     vector<IndexValue> get_values(keys.size());

--- a/be/test/storage/lake/persistent_index_memtable_test.cpp
+++ b/be/test/storage/lake/persistent_index_memtable_test.cpp
@@ -145,4 +145,28 @@ TEST(PersistentIndexMemtableTest, test_replace) {
     }
 }
 
+TEST(PersistentIndexMemtableTest, test_check_not_exist) {
+    using Key = uint64_t;
+    vector<Key> keys;
+    vector<Slice> key_slices;
+    vector<IndexValue> values;
+    vector<IndexValue> replace_values;
+    const int N = 1000;
+    keys.reserve(N);
+    key_slices.reserve(N);
+    KeyIndexSet key_indexes_info;
+    for (int i = 0; i < N; i++) {
+        keys.emplace_back(i);
+        key_slices.emplace_back((uint8_t*)(&keys[i]), sizeof(Key));
+        values.emplace_back(i * 2);
+        key_indexes_info.insert(i);
+    }
+
+    auto memtable = std::make_unique<PersistentIndexMemtable>();
+    ASSERT_OK(memtable->insert(N, key_slices.data(), values.data(), -1));
+
+    ASSERT_ERROR(memtable->check_not_exist(key_slices.data(), key_indexes_info, 1));
+    ASSERT_OK(memtable->check_not_exist(key_slices.data(), key_indexes_info, -1));
+}
+
 } // namespace starrocks::lake

--- a/be/test/storage/lake/persistent_index_memtable_test.cpp
+++ b/be/test/storage/lake/persistent_index_memtable_test.cpp
@@ -36,8 +36,6 @@ TEST(PersistentIndexMemtableTest, test_basic_api) {
     }
     auto memtable = std::make_unique<PersistentIndexMemtable>();
     ASSERT_OK(memtable->insert(N, key_slices.data(), values.data(), -1));
-    // insert duplicate should return error
-    ASSERT_FALSE(memtable->insert(N, key_slices.data(), values.data(), -1).ok());
 
     // test get
     vector<IndexValue> get_values(keys.size());

--- a/be/test/storage/lake/persistent_index_sstable_test.cpp
+++ b/be/test/storage/lake/persistent_index_sstable_test.cpp
@@ -417,6 +417,33 @@ TEST_F(PersistentIndexSstableTest, test_persistent_index_sstable) {
         }
         delete iter;
     }
+    // 10. check not exist(some keys exist)
+    {
+        std::vector<std::string> keys_str(N / 2);
+        std::vector<Slice> keys(N / 2);
+        KeyIndexSet key_indexes_info;
+        for (int i = 0; i < N / 2; i++) {
+            int r = rand() % (N * 2);
+            keys_str[i] = fmt::format("test_key_{:016X}", r);
+            keys[i] = Slice(keys_str[i]);
+            key_indexes_info.insert(i);
+        }
+        ASSERT_OK(sst->check_not_exist(keys.data(), key_indexes_info, 100));
+        ASSERT_ERROR(sst->check_not_exist(keys.data(), key_indexes_info, 101));
+    }
+    // 11. check not exist(all keys not exist)
+    {
+        std::vector<std::string> keys_str(N);
+        std::vector<Slice> keys(N);
+        KeyIndexSet key_indexes_info;
+        for (int i = 0, j = N; i < N; i++, j++) {
+            keys_str[i] = fmt::format("test_key_{:016X}", j);
+            keys[i] = Slice(keys_str[i]);
+            key_indexes_info.insert(i);
+        }
+        ASSERT_OK(sst->check_not_exist(keys.data(), key_indexes_info, 100));
+        ASSERT_OK(sst->check_not_exist(keys.data(), key_indexes_info, 101));
+    }
 }
 
 } // namespace starrocks::lake


### PR DESCRIPTION
## Why I'm doing:
Keys are not checked whether they exist in sstables. If they are not checked, duplicated key can not be found.
## What I'm doing:
1. Check if key exists when inserting keys to LakePersistentIndex
3. Rename `_block_cache` to `_pk_index_block_cache` in `update_manager`.

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
