### PR TITLE
[BugFix] fix pruned predicate not be rewritten

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/common/DebugOperatorTracer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/common/DebugOperatorTracer.java
@@ -119,6 +119,7 @@ public class DebugOperatorTracer extends OperatorVisitor<String, Void> {
                 ", selectedPartitionId=" + node.getSelectedPartitionId() +
                 ", outputColumns=" + new ArrayList<>(node.getColRefToColumnMetaMap().keySet()) +
                 ", predicate=" + node.getPredicate() +
+                ", prunedPartitionPredicates=" + node.getPrunedPartitionPredicates() +
                 ", limit=" + node.getLimit() +
                 "}";
     }
@@ -337,6 +338,7 @@ public class DebugOperatorTracer extends OperatorVisitor<String, Void> {
                 ", outputColumns=" + node.getOutputColumns() +
                 ", projection=" + node.getProjection() +
                 ", predicate=" + node.getPredicate() +
+                ", prunedPartitionPredicates=" + node.getPrunedPartitionPredicates() +
                 ", limit=" + node.getLimit() +
                 "}";
     }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/physical/PhysicalOlapScanOperator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/physical/PhysicalOlapScanOperator.java
@@ -55,6 +55,7 @@ public class PhysicalOlapScanOperator extends PhysicalScanOperator {
     private List<Pair<Integer, ColumnDict>> globalDicts = Lists.newArrayList();
     private Map<Integer, ScalarOperator> globalDictsExpr = Maps.newHashMap();
 
+    // Rewriting the scan column ref also needs to rewrite the pruned predicate at the same time.
     private List<ScalarOperator> prunedPartitionPredicates = Lists.newArrayList();
 
     private PhysicalOlapScanOperator() {
@@ -269,6 +270,11 @@ public class PhysicalOlapScanOperator extends PhysicalScanOperator {
 
         public Builder setGlobalDictsExpr(Map<Integer, ScalarOperator> globalDictsExpr) {
             builder.globalDictsExpr = globalDictsExpr;
+            return this;
+        }
+
+        public Builder setPrunedPartitionPredicates(List<ScalarOperator> prunedPartitionPredicates) {
+            builder.prunedPartitionPredicates = prunedPartitionPredicates;
             return this;
         }
     }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/AddDecodeNodeForDictStringRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/AddDecodeNodeForDictStringRule.java
@@ -67,6 +67,7 @@ import com.starrocks.sql.optimizer.statistics.ColumnDict;
 import com.starrocks.sql.optimizer.statistics.ColumnStatistic;
 import com.starrocks.sql.optimizer.statistics.IDictManager;
 import com.starrocks.sql.optimizer.task.TaskContext;
+import org.apache.commons.collections4.CollectionUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -460,6 +461,20 @@ public class AddDecodeNodeForDictStringRule implements TreeRewriteRule {
                     }
                 }
 
+                // rewrite pruned partition predicates
+                List<ScalarOperator> newPrunedPredicates = Lists.newArrayList();
+                if (CollectionUtils.isNotEmpty(scanOperator.getPrunedPartitionPredicates())) {
+                    for (ScalarOperator predicate : scanOperator.getPrunedPartitionPredicates()) {
+                        if (predicate.getUsedColumns().isIntersect(applyOptCols)) {
+                            final DictMappingRewriter rewriter = new DictMappingRewriter(context);
+                            final ScalarOperator newCallOperator = rewriter.rewrite(predicate.clone());
+                            newPrunedPredicates.add(newCallOperator);
+                        } else {
+                            newPrunedPredicates.add(predicate);
+                        }
+                    }
+                }
+
                 newPredicate = Utils.compoundAnd(predicates);
                 if (context.hasEncoded) {
                     // TODO: maybe have to implement a clone method to create a physical node.
@@ -468,7 +483,7 @@ public class AddDecodeNodeForDictStringRule implements TreeRewriteRule {
                                     scanOperator.getDistributionSpec(), scanOperator.getLimit(), newPredicate,
                                     scanOperator.getSelectedIndexId(), scanOperator.getSelectedPartitionId(),
                                     scanOperator.getSelectedTabletId(), scanOperator.getHintsReplicaId(),
-                                    scanOperator.getPrunedPartitionPredicates(),
+                                    newPrunedPredicates,
                                     scanOperator.getProjection(), scanOperator.isUsePkIndex());
                     newOlapScan.setScanOptimzeOption(scanOperator.getScanOptimzeOption());
                     newOlapScan.setPreAggregation(scanOperator.isPreAggregation());

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/lowcardinality/DecodeRewriter.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/lowcardinality/DecodeRewriter.java
@@ -48,6 +48,7 @@ import com.starrocks.sql.optimizer.operator.scalar.ColumnRefOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ScalarOperator;
 import com.starrocks.sql.optimizer.rewrite.BaseScalarOperatorShuttle;
 import com.starrocks.sql.optimizer.statistics.ColumnDict;
+import org.apache.commons.collections4.CollectionUtils;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.List;
@@ -353,6 +354,11 @@ public class DecodeRewriter extends OptExpressionVisitor<OptExpression, ColumnRe
         builder.setGlobalDictsExpr(computeDictExpr(fragmentUseDictExprs));
 
         builder.setPredicate(rewritePredicate(scanOperator.getPredicate(), info.inputStringColumns));
+        if (CollectionUtils.isNotEmpty(scanOperator.getPrunedPartitionPredicates())) {
+            List<ScalarOperator> prunedPredicates = scanOperator.getPrunedPartitionPredicates().stream()
+                    .map(p -> rewritePredicate(p, info.inputStringColumns)).collect(Collectors.toList());
+            builder.setPrunedPartitionPredicates(prunedPredicates);
+        }
         builder.setProjection(rewriteProjection(scanOperator.getProjection(), info.inputStringColumns));
         return rewriteOptExpression(optExpression, builder.build(), info.outputStringColumns);
     }

--- a/test/sql/test_hive/T/test_hive_mv
+++ b/test/sql/test_hive/T/test_hive_mv
@@ -10,15 +10,18 @@ select * from t1;
 
 set catalog default_catalog;
 create database hive_mv_${uuid0};
+use hive_mv_${uuid0};
 create materialized view mv1
 PARTITION BY (str2date(`k3`, '%Y-%m-%d'))
 DISTRIBUTED BY HASH(k1, k2) BUCKETS 5  as select * from hive_mv_test_${uuid0}.hive_db_${uuid0}.t1 where k2 in (2, 3);
 
-function: wait_materialized_view_finish()
+function: wait_async_materialized_view_finish("mv1")
 
 select max(k1) from mv1 group by k3 having k3 = '2021-02-01';
 select /*+set_var(low_cardinality_optimize_v2 = false) */ max(k1) from mv1 group by k3 having k3 = '2021-02-01';
 
+set catalog hive_mv_test_${uuid0};
+drop table hive_db_${uuid0}.t1 force;
 drop database hive_db_${uuid0};
 drop catalog hive_mv_test_${uuid0};
 set catalog default_catalog;

--- a/test/sql/test_hive/T/test_hive_mv
+++ b/test/sql/test_hive/T/test_hive_mv
@@ -1,0 +1,24 @@
+-- name: test_hive_mv
+
+create external catalog hive_mv_test_${uuid0} PROPERTIES ("type"="hive", "hive.metastore.uris"="${hive_metastore_uris}");
+set catalog hive_mv_test_${uuid0};
+create database hive_db_${uuid0};
+use hive_db_${uuid0};
+create table t1 (k1 int, k2 int, k3 string) partition by (k3);
+insert into t1 values (1, 1, '2021-01-01'), (2, 2, '2021-02-01'), (3, 3, '2021-03-01'), (4, 4, '2021-01-02');
+select * from t1;
+
+set catalog default_catalog;
+create database hive_mv_${uuid0};
+create materialized view mv1
+PARTITION BY (str2date(`k3`, '%Y-%m-%d'))
+DISTRIBUTED BY HASH(k1, k2) BUCKETS 5  as select * from hive_mv_test_${uuid0}.hive_db_${uuid0}.t1 where k2 in (2, 3);
+
+function: wait_materialized_view_finish()
+
+select max(k1) from mv1 group by k3 having k3 = '2021-02-01';
+select /*+set_var(low_cardinality_optimize_v2 = false) */ max(k1) from mv1 group by k3 having k3 = '2021-02-01';
+
+drop database hive_db_${uuid0};
+drop catalog hive_mv_test_${uuid0};
+set catalog default_catalog;


### PR DESCRIPTION
## Why I'm doing:


## What I'm doing:
low cardinality rewrite rule didn't rewrite the pruned preidicate. This mainly happens in mv using string column and strTodate() to build partitions.
Fixes #issue
rewrite the pruned predicate used encoded cols.
## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [x] 3.2
  - [x] 3.1
  - [ ] 3.0
  - [ ] 2.5
