### PR TITLE
[UT] Fix alter tablet meta ut failure without staros

### DIFF
--- a/be/test/storage/lake/alter_tablet_meta_test.cpp
+++ b/be/test/storage/lake/alter_tablet_meta_test.cpp
@@ -136,10 +136,12 @@ TEST_F(AlterTabletMetaTest, test_alter_enable_persistent_index) {
     auto new_tablet_meta2 = publish_single_version(tablet_id, 4, txn_id2);
     ASSERT_OK(new_tablet_meta2.status());
     ASSERT_EQ(false, new_tablet_meta2.value()->enable_persistent_index());
+#ifdef USE_STAROS
     data_dir = StorageEngine::instance()->get_persistent_index_store(tablet_id);
     ASSERT_TRUE(data_dir != nullptr);
     ASSERT_ERROR(FileSystem::Default()->path_exists(data_dir->get_persistent_index_path() + "/" +
                                                     std::to_string(tablet_id)));
+#endif
 }
 
 TEST_F(AlterTabletMetaTest, test_alter_enable_persistent_index_not_change) {


### PR DESCRIPTION
## Why I'm doing:
Alter tablet meta will fail without staros because `LocalPkIndexManager` is complied when staros is used.
## What I'm doing:
Add macro `USE_STAROS` with the failed check
Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [x] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [x] 3.2
  - [x] 3.1
  - [ ] 3.0
  - [ ] 2.5
