### PR TITLE
[Refactor] Add IMaterializedViewRewriter and IMaterializedViewRewriteRule to make it more extensible

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/AggregateFunctionRollupUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/AggregateFunctionRollupUtils.java
@@ -1,0 +1,82 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.sql.optimizer.rule.transformation.materialization;
+
+import com.google.common.collect.ImmutableMap;
+import com.starrocks.catalog.FunctionSet;
+import com.starrocks.sql.optimizer.operator.scalar.CallOperator;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import java.util.Map;
+
+/**
+ * `AggregateFunctionRewriter` will try to rewrite some agg functions to some transformations so can be
+ * better to be rewritten.
+ * eg: AVG -> SUM / COUNT
+ */
+public class AggregateFunctionRollupUtils {
+    private static final Logger LOG = LogManager.getLogger(AggregateFunctionRollupUtils.class);
+
+    // Unsafe means not exactly equal for each other, cannot be used directly and need
+    // extra routines to handle the difference.
+    // eg: count(col) = coalesce(sum(col), 0)
+    public static final Map<String, String> UNSAFE_REWRITE_ROLLUP_FUNCTION_MAP = ImmutableMap.<String, String>builder()
+            .put(FunctionSet.COUNT, FunctionSet.SUM)
+            .build();
+
+    // Functions that rollup function name is different from original function name.
+    public static final Map<String, String> SAFE_REWRITE_ROLLUP_FUNCTION_MAP = ImmutableMap.<String, String>builder()
+            // Functions and rollup functions are the same.
+            .put(FunctionSet.SUM, FunctionSet.SUM)
+            .put(FunctionSet.MAX, FunctionSet.MAX)
+            .put(FunctionSet.MIN, FunctionSet.MIN)
+            .put(FunctionSet.BITMAP_UNION, FunctionSet.BITMAP_UNION)
+            .put(FunctionSet.HLL_UNION, FunctionSet.HLL_UNION)
+            .put(FunctionSet.PERCENTILE_UNION, FunctionSet.PERCENTILE_UNION)
+            .put(FunctionSet.ANY_VALUE, FunctionSet.ANY_VALUE)
+            // Functions and rollup functions are not the same.
+            .put(FunctionSet.BITMAP_AGG, FunctionSet.BITMAP_UNION)
+            .put(FunctionSet.ARRAY_AGG_DISTINCT, FunctionSet.ARRAY_UNIQUE_AGG)
+            .build();
+
+    public static final Map<String, String> REWRITE_ROLLUP_FUNCTION_MAP = ImmutableMap.<String, String>builder()
+            .putAll(UNSAFE_REWRITE_ROLLUP_FUNCTION_MAP)
+            .putAll(SAFE_REWRITE_ROLLUP_FUNCTION_MAP)
+            .build();
+
+    public static final Map<String, String> SUPPORTED_DISTINCT_ROLLUP_FUNCTIONS = ImmutableMap.<String, String>builder()
+            .put(FunctionSet.ARRAY_AGG, FunctionSet.ARRAY_UNIQUE_AGG)
+            .build(); // array_agg is not supported to rollup yet.
+
+    /**
+     * There is some difference between whether it's a mv union rewrite or not.
+     * eg: count(distinct) is not supported to rollup in mv union rewrite, but it's safe for mv union rewrite.
+     * @param aggFunc: original aggregate function to get the associated rollup function
+     * @param isUnionRewrite: whether it's a mv union rewrite
+     * @return: the associated rollup function name
+     */
+    public static String getRollupFunctionName(CallOperator aggFunc, boolean isUnionRewrite) {
+        String fn = aggFunc.getFnName();
+        if ((isUnionRewrite || !aggFunc.isDistinct()) && REWRITE_ROLLUP_FUNCTION_MAP.containsKey(fn)) {
+            return REWRITE_ROLLUP_FUNCTION_MAP.get(fn);
+        }
+
+        if (aggFunc.isDistinct() && SUPPORTED_DISTINCT_ROLLUP_FUNCTIONS.containsKey(fn)) {
+            return SUPPORTED_DISTINCT_ROLLUP_FUNCTIONS.get(fn);
+        }
+        return null;
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/BestMvSelector.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/BestMvSelector.java
@@ -22,6 +22,7 @@ import com.starrocks.catalog.Column;
 import com.starrocks.catalog.MaterializedView;
 import com.starrocks.catalog.MvPlanContext;
 import com.starrocks.catalog.Table;
+import com.starrocks.common.util.DebugUtil;
 import com.starrocks.sql.optimizer.CachingMvPlanContextBuilder;
 import com.starrocks.sql.optimizer.ExpressionContext;
 import com.starrocks.sql.optimizer.OptExpression;
@@ -29,6 +30,7 @@ import com.starrocks.sql.optimizer.OptimizerContext;
 import com.starrocks.sql.optimizer.operator.logical.LogicalAggregationOperator;
 import com.starrocks.sql.optimizer.operator.logical.LogicalOlapScanOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ScalarOperator;
+import com.starrocks.sql.optimizer.rule.Rule;
 import com.starrocks.sql.optimizer.statistics.Statistics;
 import com.starrocks.sql.optimizer.statistics.StatisticsCalculator;
 
@@ -36,17 +38,32 @@ import java.util.Comparator;
 import java.util.List;
 import java.util.Set;
 
+import static com.starrocks.sql.optimizer.OptimizerTraceUtil.logMVRewrite;
+
 public class BestMvSelector {
     private final List<OptExpression> expressions;
     private final OptimizerContext context;
     private final OptExpression queryPlan;
     private final boolean isAggQuery;
+    private final Rule rule;
 
-    public BestMvSelector(List<OptExpression> expressions, OptimizerContext context, OptExpression queryPlan) {
+    public BestMvSelector(List<OptExpression> expressions, OptimizerContext context, OptExpression queryPlan, Rule rule) {
         this.expressions = expressions;
         this.context = context;
         this.queryPlan = queryPlan;
         this.isAggQuery = queryPlan.getOp() instanceof LogicalAggregationOperator;
+        this.rule = rule;
+    }
+
+    private List<OptExpression> calculateStatistics(List<OptExpression> expressions, OptimizerContext context) {
+        for (OptExpression expression : expressions) {
+            try {
+                calculateStatistics(expression, context);
+            } catch (Exception e) {
+                logMVRewrite(context, rule, "calculate statistics failed: {}", DebugUtil.getStackTrace(e));
+            }
+        }
+        return expressions;
     }
 
     public OptExpression selectBest() {
@@ -54,9 +71,7 @@ public class BestMvSelector {
             return expressions.get(0);
         }
         // compute the statistics of OptExpression
-        for (OptExpression expression : expressions) {
-            calculateStatistics(expression, context);
-        }
+        List<OptExpression> validExpressions = calculateStatistics(expressions, context);
 
         // collect original table scans
         List<Table> originalTables = MvUtils.getAllTables(queryPlan);
@@ -65,18 +80,18 @@ public class BestMvSelector {
         Set<String> nonEquivalenceColumns = Sets.newHashSet();
         MvUtils.splitPredicate(predicates, equivalenceColumns, nonEquivalenceColumns);
         List<CandidateContext> contexts = Lists.newArrayList();
-        for (int i = 0; i < expressions.size(); i++) {
-            List<Table> expressionTables = MvUtils.getAllTables(expressions.get(i));
+        for (int i = 0; i < validExpressions.size(); i++) {
+            List<Table> expressionTables = MvUtils.getAllTables(validExpressions.get(i));
             originalTables.stream().forEach(originalTable -> expressionTables.remove(originalTable));
             CandidateContext mvContext = getMVContext(
-                    expressions.get(i), isAggQuery, context, expressionTables, equivalenceColumns, nonEquivalenceColumns);
+                    validExpressions.get(i), isAggQuery, context, expressionTables, equivalenceColumns, nonEquivalenceColumns);
             Preconditions.checkState(mvContext != null);
             mvContext.setIndex(i);
             contexts.add(mvContext);
         }
         // sort expressions based on statistics output row count and compute size
         contexts.sort(new CandidateContextComparator());
-        return expressions.get(contexts.get(0).getIndex());
+        return validExpressions.get(contexts.get(0).getIndex());
     }
 
     @VisibleForTesting

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/EquationRewriter.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/EquationRewriter.java
@@ -70,8 +70,6 @@ public class EquationRewriter {
         this.underAggFunctionRewriteContext = underAggFunctionRewriteContext;
     }
 
-
-
     private final class EquivalentShuttle extends BaseScalarOperatorShuttle {
         private final EquivalentShuttleContext shuttleContext;
 
@@ -108,7 +106,7 @@ public class EquationRewriter {
 
         private ScalarOperator rewriteByEquivalent(ScalarOperator input,
                                                    IRewriteEquivalent.RewriteEquivalentType type) {
-            if (!rewriteEquivalents.containsKey(type)) {
+            if (!shuttleContext.isUseEquivalent() || !rewriteEquivalents.containsKey(type)) {
                 return null;
             }
             for (RewriteEquivalent equivalent : rewriteEquivalents.get(type)) {
@@ -193,14 +191,16 @@ public class EquationRewriter {
         }
     }
 
-    private final EquivalentShuttle shuttle = new EquivalentShuttle(new EquivalentShuttleContext(false));
+    private final EquivalentShuttle shuttle = new EquivalentShuttle(new EquivalentShuttleContext(null, false, true));
 
     protected ScalarOperator replaceExprWithTarget(ScalarOperator expr) {
         return expr.accept(shuttle, null);
     }
 
-    protected Pair<ScalarOperator, EquivalentShuttleContext> replaceExprWithRollup(ScalarOperator expr) {
-        final EquivalentShuttleContext shuttleContext = new EquivalentShuttleContext(true);
+    protected Pair<ScalarOperator, EquivalentShuttleContext> replaceExprWithRollup(RewriteContext rewriteContext,
+                                                                                   ScalarOperator expr) {
+        final EquivalentShuttleContext shuttleContext = new EquivalentShuttleContext(rewriteContext,
+                true, true);
         final EquivalentShuttle shuttle = new EquivalentShuttle(shuttleContext);
         return Pair.create(expr.accept(shuttle, null), shuttleContext);
     }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/IMaterializedViewRewriter.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/IMaterializedViewRewriter.java
@@ -1,0 +1,41 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.sql.optimizer.rule.transformation.materialization;
+
+import com.starrocks.sql.optimizer.MvRewriteContext;
+import com.starrocks.sql.optimizer.OptExpression;
+import com.starrocks.sql.optimizer.OptimizerContext;
+
+/**
+ * Base interface to implement materialized view rewrite rule.
+ */
+public interface IMaterializedViewRewriter {
+    /**
+     * Rewrite the query with the given materialized view context.
+     * @param mvContext: materialized view context of query and associated mv.
+     * @return: the rewritten query opt expression if rewrite success, otherwise null.
+     */
+    OptExpression doRewrite(MvRewriteContext mvContext);
+
+    /**
+     * After plan is rewritten by MV, still do some actions for new MV's plan.
+     * 1. column prune
+     * 2. partition prune
+     * 3. bucket prune
+     */
+    OptExpression doPostAfterRewrite(OptimizerContext optimizerContext,
+                                     MvRewriteContext mvRewriteContext,
+                                     OptExpression candidate);
+}

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/equivalent/ArrayRewriteEquivalent.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/equivalent/ArrayRewriteEquivalent.java
@@ -14,6 +14,7 @@
 
 package com.starrocks.sql.optimizer.rule.transformation.materialization.equivalent;
 
+import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
 import com.starrocks.analysis.Expr;
@@ -28,7 +29,11 @@ import com.starrocks.sql.optimizer.operator.scalar.ScalarOperator;
 
 import java.util.Map;
 
+import static com.starrocks.catalog.FunctionSet.ARRAY_AGG;
+import static com.starrocks.catalog.FunctionSet.COUNT;
 import static com.starrocks.catalog.FunctionSet.MULTI_DISTINCT_COUNT;
+import static com.starrocks.catalog.FunctionSet.MULTI_DISTINCT_SUM;
+import static com.starrocks.catalog.FunctionSet.SUM;
 
 /**
  * Rewrite array_agg function
@@ -38,11 +43,13 @@ import static com.starrocks.catalog.FunctionSet.MULTI_DISTINCT_COUNT;
  */
 public class ArrayRewriteEquivalent extends IAggregateRewriteEquivalent {
 
-    public static IRewriteEquivalent INSTANCE = new ArrayRewriteEquivalent();
+    public static IAggregateRewriteEquivalent INSTANCE = new ArrayRewriteEquivalent();
 
     private static final Map<String, String> MAPPING = ImmutableMap.of(
-                    FunctionSet.COUNT, FunctionSet.ARRAY_LENGTH,
-                    FunctionSet.SUM, FunctionSet.ARRAY_SUM);
+            COUNT, FunctionSet.ARRAY_LENGTH,
+            FunctionSet.MULTI_DISTINCT_COUNT, FunctionSet.ARRAY_LENGTH,
+            FunctionSet.MULTI_DISTINCT_SUM, FunctionSet.ARRAY_SUM,
+            SUM, FunctionSet.ARRAY_SUM);
 
     @Override
     public RewriteEquivalentContext prepare(ScalarOperator input) {
@@ -59,51 +66,103 @@ public class ArrayRewriteEquivalent extends IAggregateRewriteEquivalent {
     }
 
     private static boolean isArrayAggDistinct(CallOperator call) {
-        return call.getFnName().equalsIgnoreCase(FunctionSet.ARRAY_AGG_DISTINCT) ||
-                (call.getFnName().equalsIgnoreCase(FunctionSet.ARRAY_AGG) && call.isDistinct());
+        String fn = call.getFnName();
+        return fn.equalsIgnoreCase(FunctionSet.ARRAY_AGG_DISTINCT) ||
+                (call.isDistinct() && fn.equalsIgnoreCase(ARRAY_AGG));
     }
 
     @Override
-    public ScalarOperator rewrite(RewriteEquivalentContext eqContext, EquivalentShuttleContext shuttleContext,
-                                  ColumnRefOperator replace, ScalarOperator newInput) {
+    public ScalarOperator rewrite(RewriteEquivalentContext eqContext,
+                                  EquivalentShuttleContext shuttleContext,
+                                  ColumnRefOperator replace,
+                                  ScalarOperator newInput) {
         ScalarOperator eq = eqContext.getEquivalent();
         CallOperator call = (CallOperator) newInput;
         String fn = call.getFnName();
-
-        if (call.isDistinct() || fn.equalsIgnoreCase(MULTI_DISTINCT_COUNT)) {
+        if ((call.isDistinct() && (fn.equalsIgnoreCase(COUNT) || fn.equalsIgnoreCase(SUM)))
+                || fn.equalsIgnoreCase(MULTI_DISTINCT_COUNT) || fn.equalsIgnoreCase(MULTI_DISTINCT_SUM)) {
             String mapped = MAPPING.get(fn);
-            if (mapped == null) {
-                return new CallOperator(fn, call.getType(), Lists.newArrayList(replace), call.getFunction());
-            } else {
-                ScalarOperator arg0 = call.getChild(0);
-                if (!arg0.equals(eq)) {
-                    return null;
-                }
-
-                Type newInputArgType = call.getChild(0).getType();
-                Type[] argTypes = new Type[] {new ArrayType(newInputArgType)};
-                Function.CompareMode compareMode = Function.CompareMode.IS_IDENTICAL;
-                Function replaced = Expr.getBuiltinFunction(mapped, argTypes, compareMode);
-                if (replaced == null) {
-                    return null;
-                }
-                CallOperator res = null;
-                if (shuttleContext.isRollup()) {
-                    // rollup into fn(array_unique_agg(col))
-                    Function rollup = Expr.getBuiltinFunction(FunctionSet.ARRAY_UNIQUE_AGG, argTypes, compareMode);
-                    res = new CallOperator(
-                            FunctionSet.ARRAY_UNIQUE_AGG,
-                            new ArrayType(newInputArgType),
-                            Lists.newArrayList(replace),
-                            rollup);
-                    res = new CallOperator(mapped, call.getType(), Lists.newArrayList(res), replaced);
-                } else {
-                    // rewrite into fn(col)
-                    res = new CallOperator(mapped, call.getType(), Lists.newArrayList(replace), replaced);
-                }
-                return res;
+            Preconditions.checkState(mapped != null);
+            ScalarOperator arg0 = call.getChild(0);
+            if (!arg0.equals(eq)) {
+                return null;
             }
+            return rewriteImpl(shuttleContext, call, mapped, replace, shuttleContext.isRollup());
+        } else if (fn.equalsIgnoreCase(ARRAY_AGG)) {
+            if (!call.isDistinct()) {
+                return null;
+            }
+            ScalarOperator arg0 = call.getChild(0);
+            if (!arg0.equals(eq)) {
+                return null;
+            }
+            return rewriteArrayAggDistinctImpl(shuttleContext, call, replace, shuttleContext.isRollup());
         }
         return null;
+    }
+
+    CallOperator makeArrayUniqAggFunc(ScalarOperator arg0, CallOperator aggFunc, Function.CompareMode compareMode) {
+        Type newInputArgType = aggFunc.getChild(0).getType();
+        Type[] argTypes = new Type[] {new ArrayType(newInputArgType)};
+        Function rollup = Expr.getBuiltinFunction(FunctionSet.ARRAY_UNIQUE_AGG, argTypes, compareMode);
+        if (rollup == null) {
+            return null;
+        }
+        return new CallOperator(FunctionSet.ARRAY_UNIQUE_AGG, new ArrayType(newInputArgType), Lists.newArrayList(arg0), rollup);
+    }
+
+    CallOperator makeRollupAggFunc(ScalarOperator replace, CallOperator call,
+                                   Function.CompareMode compareMode, String mapped) {
+        Type newInputArgType = call.getChild(0).getType();
+        Type[] argTypes = new Type[] {new ArrayType(newInputArgType)};
+        Function replaced = Expr.getBuiltinFunction(mapped, argTypes, compareMode);
+        if (replaced == null) {
+            return null;
+        }
+        Function rollup = Expr.getBuiltinFunction(FunctionSet.ARRAY_UNIQUE_AGG, argTypes, compareMode);
+        CallOperator res = new CallOperator(
+                FunctionSet.ARRAY_UNIQUE_AGG,
+                new ArrayType(newInputArgType),
+                Lists.newArrayList(replace),
+                rollup);
+        return new CallOperator(mapped, call.getType(), Lists.newArrayList(res), replaced);
+    }
+
+    CallOperator makeNoRollupAggFunc(ScalarOperator replace, CallOperator call,
+                                   Function.CompareMode compareMode, String mapped) {
+        Type newInputArgType = call.getChild(0).getType();
+        Type[] argTypes = new Type[] {new ArrayType(newInputArgType)};
+        Function replaced = Expr.getBuiltinFunction(mapped, argTypes, compareMode);
+        if (replaced == null) {
+            return null;
+        }
+        return new CallOperator(mapped, call.getType(), Lists.newArrayList(replace), replaced);
+    }
+
+    private ScalarOperator rewriteArrayAggDistinctImpl(EquivalentShuttleContext shuttleContext,
+                                                       CallOperator call,
+                                                       ColumnRefOperator replace,
+                                                       boolean isRollup) {
+        Function.CompareMode compareMode = Function.CompareMode.IS_IDENTICAL;
+        if (isRollup) {
+            return makeArrayUniqAggFunc(replace, call, compareMode);
+        } else {
+            // rewrite into fn(col)
+            return makeArrayUniqAggFunc(replace, call, compareMode);
+        }
+    }
+
+    private ScalarOperator rewriteImpl(EquivalentShuttleContext shuttleContext,
+                                       CallOperator call,
+                                       String mapped,
+                                       ColumnRefOperator replace,
+                                       boolean isRollup) {
+        Function.CompareMode compareMode = Function.CompareMode.IS_IDENTICAL;
+        if (isRollup) {
+            return makeRollupAggFunc(replace, call, compareMode, mapped);
+        } else {
+            // rewrite into fn(col)
+            return makeNoRollupAggFunc(replace, call, compareMode, mapped);
+        }
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/equivalent/CountRewriteEquivalent.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/equivalent/CountRewriteEquivalent.java
@@ -21,11 +21,11 @@ import com.starrocks.sql.optimizer.operator.scalar.ScalarOperator;
 import com.starrocks.sql.optimizer.rule.transformation.materialization.AggregatedMaterializedViewRewriter;
 
 public class CountRewriteEquivalent extends IAggregateRewriteEquivalent {
-    public static IRewriteEquivalent INSTANCE = new CountRewriteEquivalent();
+    public static IAggregateRewriteEquivalent INSTANCE = new CountRewriteEquivalent();
 
     public CountRewriteEquivalent() {}
 
-    private boolean check(ScalarOperator op) {
+    public static boolean check(ScalarOperator op) {
         if (op == null || !(op instanceof CallOperator)) {
             return false;
         }
@@ -58,7 +58,7 @@ public class CountRewriteEquivalent extends IAggregateRewriteEquivalent {
             return null;
         }
         if (shuttleContext.isRollup()) {
-            return AggregatedMaterializedViewRewriter.getRollupAggregate((CallOperator) eqContext.getInput(), replace);
+            return AggregatedMaterializedViewRewriter.getRollupAggregateFunc((CallOperator) eqContext.getInput(), replace, false);
         } else {
             return replace;
         }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/equivalent/EquivalentShuttleContext.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/equivalent/EquivalentShuttleContext.java
@@ -14,23 +14,37 @@
 
 package com.starrocks.sql.optimizer.rule.transformation.materialization.equivalent;
 
-public class EquivalentShuttleContext {
-    private boolean isRewrittenByEquivalent;
-    private final boolean isRollup;
+import com.starrocks.sql.optimizer.rule.transformation.materialization.RewriteContext;
 
-    public EquivalentShuttleContext(boolean isRollup) {
+public class EquivalentShuttleContext {
+    private final RewriteContext rewriteContext;
+    private final boolean isRollup;
+    private boolean isUseEquivalent;
+    private boolean isRewrittenByEquivalent;
+
+    public EquivalentShuttleContext(RewriteContext rewriteContext, boolean isRollup, boolean isRewrittenByEquivalent) {
+        this.rewriteContext = rewriteContext;
         this.isRollup = isRollup;
+        this.isUseEquivalent = isRewrittenByEquivalent;
     }
 
-    public boolean isRewrittenByEquivalent() {
-        return isRewrittenByEquivalent;
+    public boolean isUseEquivalent() {
+        return isUseEquivalent;
     }
 
     public boolean isRollup() {
         return isRollup;
     }
 
+    public boolean isRewrittenByEquivalent() {
+        return isRewrittenByEquivalent;
+    }
+
     public void setRewrittenByEquivalent(boolean rewrittenByEquivalent) {
         isRewrittenByEquivalent = rewrittenByEquivalent;
+    }
+
+    public RewriteContext getRewriteContext() {
+        return rewriteContext;
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/equivalent/HLLRewriteEquivalent.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/equivalent/HLLRewriteEquivalent.java
@@ -1,0 +1,159 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package com.starrocks.sql.optimizer.rule.transformation.materialization.equivalent;
+
+import com.google.common.base.Preconditions;
+import com.google.common.collect.ImmutableSet;
+import com.starrocks.analysis.Expr;
+import com.starrocks.catalog.Function;
+import com.starrocks.catalog.FunctionSet;
+import com.starrocks.catalog.Type;
+import com.starrocks.sql.optimizer.operator.scalar.CallOperator;
+import com.starrocks.sql.optimizer.operator.scalar.CastOperator;
+import com.starrocks.sql.optimizer.operator.scalar.ColumnRefOperator;
+import com.starrocks.sql.optimizer.operator.scalar.ScalarOperator;
+import com.starrocks.sql.optimizer.rule.transformation.materialization.RewriteContext;
+
+import java.util.Arrays;
+
+import static com.starrocks.catalog.Function.CompareMode.IS_IDENTICAL;
+import static com.starrocks.catalog.FunctionSet.APPROX_COUNT_DISTINCT;
+import static com.starrocks.catalog.FunctionSet.HLL_CARDINALITY;
+import static com.starrocks.catalog.FunctionSet.HLL_HASH;
+import static com.starrocks.catalog.FunctionSet.HLL_UNION;
+import static com.starrocks.catalog.FunctionSet.HLL_UNION_AGG;
+import static com.starrocks.catalog.FunctionSet.NDV;
+
+public class HLLRewriteEquivalent extends IAggregateRewriteEquivalent {
+    public static IAggregateRewriteEquivalent INSTANCE = new HLLRewriteEquivalent();
+
+    public HLLRewriteEquivalent() {}
+
+    @Override
+    public RewriteEquivalentContext prepare(ScalarOperator op) {
+        if (op == null || !(op instanceof CallOperator)) {
+            return null;
+        }
+        CallOperator aggFunc = (CallOperator) op;
+        String aggFuncName = aggFunc.getFnName();
+
+        if (aggFuncName.equals(HLL_UNION)) {
+            ScalarOperator arg0 = aggFunc.getChild(0);
+            if (arg0 == null) {
+                return null;
+            }
+            if (!arg0.getType().isHllType()) {
+                return null;
+            }
+            if (arg0 instanceof CallOperator) {
+                CallOperator call0 = (CallOperator) arg0;
+                if (call0.getFnName().equals(FunctionSet.HLL_HASH)) {
+                    // hll_union(hll_hash(x)) can be used for rewrite
+                    ScalarOperator child0 = call0.getChild(0);
+                    if (child0 instanceof CastOperator) {
+                        CastOperator castOperator = (CastOperator) child0;
+                        // hll_union(hll_hash(cast(x as char))) can be used for rewrite
+                        if (castOperator.getType().isStringType()) {
+                            return new RewriteEquivalentContext(castOperator.getChild(0), op);
+                        }
+                    } else {
+                        return new RewriteEquivalentContext(call0.getChild(0), op);
+                    }
+                }
+            } else {
+                return new RewriteEquivalentContext(arg0, op);
+            }
+        }
+        return null;
+    }
+
+    public static ImmutableSet<String> SUPPORT_AGG_FUNC = ImmutableSet.of(APPROX_COUNT_DISTINCT, NDV, HLL_UNION_AGG);
+
+    @Override
+    public ScalarOperator rewrite(RewriteEquivalentContext eqContext,
+                                  EquivalentShuttleContext shuttleContext,
+                                  ColumnRefOperator replace,
+                                  ScalarOperator newInput) {
+        if (newInput == null || !(newInput instanceof CallOperator)) {
+            return null;
+        }
+        ScalarOperator eqChild = eqContext.getEquivalent();
+        CallOperator aggFunc = (CallOperator) newInput;
+        String aggFuncName = aggFunc.getFnName();
+        boolean isRollup = shuttleContext.isRollup();
+        RewriteContext rewriteContext = shuttleContext.getRewriteContext();
+        if (aggFuncName.equals(APPROX_COUNT_DISTINCT) || aggFuncName.equals(NDV)) {
+            ScalarOperator arg0 = aggFunc.getChild(0);
+            if (!arg0.equals(eqChild)) {
+                return null;
+            }
+            return rewriteImpl(rewriteContext, aggFunc, replace, isRollup);
+        } else if (aggFuncName.equals(HLL_UNION_AGG)) {
+            ScalarOperator eqArg = aggFunc.getChild(0);
+            if (eqArg instanceof CallOperator) {
+                CallOperator arg = (CallOperator) eqArg;
+                if (!arg.getFnName().equals(HLL_HASH)) {
+                    return null;
+                }
+                ScalarOperator arg0 = arg.getChild(0);
+                if (arg0 instanceof CastOperator) {
+                    CastOperator castOperator = (CastOperator) arg0;
+                    // hll_union(hll_hash(cast(x as char))) can be used for rewrite
+                    if (!castOperator.getType().isStringType()) {
+                        return null;
+                    }
+                    eqArg = arg0.getChild(0);
+                } else {
+                    eqArg = arg0;
+                }
+            }
+
+            if (!eqArg.equals(eqChild)) {
+                return null;
+            }
+            return rewriteImpl(rewriteContext, aggFunc, replace, isRollup);
+        }
+        return null;
+    }
+
+    private CallOperator makeHllUnionAggFunc(ScalarOperator arg0, CallOperator aggFunc) {
+        Function fn = Expr.getBuiltinFunction(FunctionSet.HLL_UNION_AGG, new Type[] {Type.HLL}, IS_IDENTICAL);
+        Preconditions.checkState(fn != null);
+        return new CallOperator(HLL_UNION_AGG, aggFunc.getType(), Arrays.asList(arg0), fn);
+    }
+
+    private CallOperator makeHllCardinalityFunc(ScalarOperator arg0, CallOperator aggFunc) {
+        Function fn = Expr.getBuiltinFunction(FunctionSet.HLL_CARDINALITY, new Type[] {Type.HLL}, IS_IDENTICAL);
+        Preconditions.checkState(fn != null);
+        return new CallOperator(HLL_CARDINALITY, aggFunc.getType(), Arrays.asList(arg0), fn);
+    }
+
+    private CallOperator makeHllUnion(ScalarOperator arg0, CallOperator aggFunc) {
+        Function fn = Expr.getBuiltinFunction(HLL_UNION, new Type[] {arg0.getType()}, IS_IDENTICAL);
+        Preconditions.checkState(fn != null);
+        return new CallOperator(HLL_UNION, aggFunc.getType(), Arrays.asList(arg0), fn);
+    }
+
+    private ScalarOperator rewriteImpl(RewriteContext rewriteContext,
+                                       CallOperator aggFunc,
+                                       ScalarOperator replace,
+                                       boolean isRollup) {
+        if (isRollup) {
+            CallOperator partialFn = makeHllUnion(replace, aggFunc);
+            return makeHllCardinalityFunc(partialFn, aggFunc);
+        } else {
+            return makeHllCardinalityFunc(replace, aggFunc);
+        }
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/equivalent/IAggregateRewriteEquivalent.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/equivalent/IAggregateRewriteEquivalent.java
@@ -14,7 +14,7 @@
 
 package com.starrocks.sql.optimizer.rule.transformation.materialization.equivalent;
 
-public abstract class  IAggregateRewriteEquivalent implements IRewriteEquivalent {
+public abstract class IAggregateRewriteEquivalent implements IRewriteEquivalent {
     public RewriteEquivalentType getRewriteEquivalentType() {
         return RewriteEquivalentType.AGGREGATE;
     }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/equivalent/IRewriteEquivalent.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/equivalent/IRewriteEquivalent.java
@@ -86,7 +86,6 @@ public interface IRewriteEquivalent {
 
     /**
      * Rewrite newInput if it is equivalent with input by using input's column ref mapping replace.
-     * @param input         : original scalar operator.
      * @param replace       : original scalar operator's mapping column ref.
      * @param newInput      : the new scalar operator to rewrite.
      * @return              : return a new scalar operator that is rewritten by newInput and replace.

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/equivalent/PercentileRewriteEquivalent.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/equivalent/PercentileRewriteEquivalent.java
@@ -1,0 +1,140 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package com.starrocks.sql.optimizer.rule.transformation.materialization.equivalent;
+
+import com.google.common.base.Preconditions;
+import com.starrocks.analysis.Expr;
+import com.starrocks.catalog.Function;
+import com.starrocks.catalog.FunctionSet;
+import com.starrocks.catalog.Type;
+import com.starrocks.sql.optimizer.operator.scalar.CallOperator;
+import com.starrocks.sql.optimizer.operator.scalar.CastOperator;
+import com.starrocks.sql.optimizer.operator.scalar.ColumnRefOperator;
+import com.starrocks.sql.optimizer.operator.scalar.ScalarOperator;
+import com.starrocks.sql.optimizer.rule.transformation.materialization.RewriteContext;
+
+import java.util.Arrays;
+
+import static com.starrocks.catalog.Function.CompareMode.IS_IDENTICAL;
+import static com.starrocks.catalog.FunctionSet.PERCENTILE_APPROX;
+import static com.starrocks.catalog.FunctionSet.PERCENTILE_APPROX_RAW;
+import static com.starrocks.catalog.FunctionSet.PERCENTILE_UNION;
+
+public class PercentileRewriteEquivalent extends IAggregateRewriteEquivalent {
+    public static IAggregateRewriteEquivalent INSTANCE = new PercentileRewriteEquivalent();
+
+    public PercentileRewriteEquivalent() {
+    }
+
+    @Override
+    public RewriteEquivalentContext prepare(ScalarOperator op) {
+        if (op == null || !(op instanceof CallOperator)) {
+            return null;
+        }
+        CallOperator aggFunc = (CallOperator) op;
+        String aggFuncName = aggFunc.getFnName();
+
+        if (aggFuncName.equals(PERCENTILE_UNION)) {
+            ScalarOperator arg0 = aggFunc.getChild(0);
+            if (arg0 == null) {
+                return null;
+            }
+            if (!arg0.getType().isPercentile()) {
+                return null;
+            }
+            if (arg0 instanceof CallOperator) {
+                CallOperator call0 = (CallOperator) arg0;
+                if (call0.getFnName().equals(FunctionSet.PERCENTILE_HASH)) {
+                    // percentile_union(percentile_hash()) can be used for rewrite
+                    if (call0 instanceof CastOperator) {
+                        CastOperator castOperator = (CastOperator) call0;
+                        if (castOperator.getType().isDouble()) {
+                            return new RewriteEquivalentContext(castOperator.getChild(0), op);
+                        }
+                    } else {
+                        return new RewriteEquivalentContext(call0.getChild(0), op);
+                    }
+                }
+            } else {
+                return new RewriteEquivalentContext(arg0, op);
+            }
+        }
+        return null;
+    }
+
+    @Override
+    public ScalarOperator rewrite(RewriteEquivalentContext eqContext,
+                                  EquivalentShuttleContext shuttleContext,
+                                  ColumnRefOperator replace,
+                                  ScalarOperator newInput) {
+        if (newInput == null || !(newInput instanceof CallOperator)) {
+            return null;
+        }
+        ScalarOperator eqChild = eqContext.getEquivalent();
+        CallOperator aggFunc = (CallOperator) newInput;
+        String aggFuncName = aggFunc.getFnName();
+
+        RewriteContext rewriteContext = shuttleContext.getRewriteContext();
+        boolean isRollup = shuttleContext.isRollup();
+        if (aggFuncName.equalsIgnoreCase(PERCENTILE_APPROX)) {
+            ScalarOperator eqArg = aggFunc.getChild(0);
+            ScalarOperator arg1 = aggFunc.getChild(1);
+            if (!eqArg.equals(eqChild)) {
+                return null;
+            }
+            return rewriteImpl(rewriteContext, aggFunc, replace, arg1, isRollup);
+        }
+        return null;
+    }
+
+    private CallOperator makePercentileUnion(ScalarOperator replace) {
+        Function unionFn = Expr.getBuiltinFunction(FunctionSet.PERCENTILE_UNION, new Type[] { Type.PERCENTILE },
+                IS_IDENTICAL);
+        Preconditions.checkState(unionFn != null);
+        return new CallOperator(PERCENTILE_UNION, Type.PERCENTILE, Arrays.asList(replace), unionFn);
+    }
+
+    private CallOperator makePercentileApproxRaw(ScalarOperator replace, ScalarOperator arg1) {
+        Function approxRawFn = Expr.getBuiltinFunction(FunctionSet.PERCENTILE_APPROX_RAW,
+                new Type[] { Type.PERCENTILE, Type.DOUBLE }, Function.CompareMode.IS_IDENTICAL);
+        Preconditions.checkState(approxRawFn != null);
+        // percentile_approx_raw(percentile_union(input), arg1)
+        return new CallOperator(PERCENTILE_APPROX_RAW, Type.DOUBLE, Arrays.asList(replace, arg1), approxRawFn);
+    }
+
+    private CallOperator makeRollupFunc(ScalarOperator replace, ScalarOperator arg1) {
+        Function unionFn = Expr.getBuiltinFunction(FunctionSet.PERCENTILE_UNION, new Type[] { Type.PERCENTILE },
+                IS_IDENTICAL);
+        Preconditions.checkState(unionFn != null);
+        CallOperator rollup = new CallOperator(PERCENTILE_UNION, Type.PERCENTILE, Arrays.asList(replace), unionFn);
+
+        Function approxRawFn = Expr.getBuiltinFunction(FunctionSet.PERCENTILE_APPROX_RAW,
+                new Type[] { Type.PERCENTILE, Type.DOUBLE }, Function.CompareMode.IS_IDENTICAL);
+        Preconditions.checkState(approxRawFn != null);
+        // percentile_approx_raw(percentile_union(input), arg1)
+        return new CallOperator(PERCENTILE_APPROX_RAW, Type.DOUBLE, Arrays.asList(rollup, arg1), approxRawFn);
+    }
+
+    private ScalarOperator rewriteImpl(RewriteContext rewriteContext,
+                                       CallOperator aggFunc,
+                                       ScalarOperator replace,
+                                       ScalarOperator arg1,
+                                       boolean isRollup) {
+        if (isRollup) {
+            return makeRollupFunc(replace, arg1);
+        } else {
+            return makePercentileApproxRaw(replace, arg1);
+        }
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/equivalent/RewriteEquivalent.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/equivalent/RewriteEquivalent.java
@@ -14,23 +14,33 @@
 
 package com.starrocks.sql.optimizer.rule.transformation.materialization.equivalent;
 
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
 import com.starrocks.sql.optimizer.operator.scalar.ColumnRefOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ScalarOperator;
 
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Stream;
 
 public class RewriteEquivalent {
-    public static final List<IRewriteEquivalent> EQUIVALENTS = Lists.newArrayList(
-            TimeSliceRewriteEquivalent.INSTANCE,
-            DateTruncEquivalent.INSTANCE,
+    public static final List<IAggregateRewriteEquivalent> AGGREGATE_EQUIVALENTS = Lists.newArrayList(
             CountRewriteEquivalent.INSTANCE,
             BitmapRewriteEquivalent.INSTANCE,
-            ArrayRewriteEquivalent.INSTANCE);
+            ArrayRewriteEquivalent.INSTANCE,
+            HLLRewriteEquivalent.INSTANCE,
+            PercentileRewriteEquivalent.INSTANCE
+    );
+    public static final List<IRewriteEquivalent> PREDICATE_EQUIVALENTS = Lists.newArrayList(
+            TimeSliceRewriteEquivalent.INSTANCE,
+            DateTruncEquivalent.INSTANCE);
+    public static final List<IRewriteEquivalent> EQUIVALENTS = Stream.concat(
+            AGGREGATE_EQUIVALENTS.stream(),
+            PREDICATE_EQUIVALENTS.stream()
+    ).collect(ImmutableList.toImmutableList());
+
     private final IRewriteEquivalent.RewriteEquivalentContext rewriteEquivalentContext;
     private final IRewriteEquivalent iRewriteEquivalent;
-
 
     public RewriteEquivalent(IRewriteEquivalent.RewriteEquivalentContext rewriteEquivalentContext,
                              IRewriteEquivalent iRewriteEquivalent,

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/rule/AggregateJoinRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/rule/AggregateJoinRule.java
@@ -22,7 +22,7 @@ import com.starrocks.sql.optimizer.operator.OperatorType;
 import com.starrocks.sql.optimizer.operator.pattern.Pattern;
 import com.starrocks.sql.optimizer.rule.RuleType;
 import com.starrocks.sql.optimizer.rule.transformation.materialization.AggregatedMaterializedViewRewriter;
-import com.starrocks.sql.optimizer.rule.transformation.materialization.MaterializedViewRewriter;
+import com.starrocks.sql.optimizer.rule.transformation.materialization.IMaterializedViewRewriter;
 import com.starrocks.sql.optimizer.rule.transformation.materialization.MvUtils;
 
 /*
@@ -51,7 +51,8 @@ public class AggregateJoinRule extends BaseMaterializedViewRewriteRule {
     }
 
     @Override
-    public MaterializedViewRewriter getMaterializedViewRewrite(MvRewriteContext mvContext) {
+    public IMaterializedViewRewriter createRewriter(OptimizerContext optimizerContext,
+                                                    MvRewriteContext mvContext) {
         return new AggregatedMaterializedViewRewriter(mvContext);
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/rule/AggregateScanRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/rule/AggregateScanRule.java
@@ -22,7 +22,7 @@ import com.starrocks.sql.optimizer.operator.OperatorType;
 import com.starrocks.sql.optimizer.operator.pattern.Pattern;
 import com.starrocks.sql.optimizer.rule.RuleType;
 import com.starrocks.sql.optimizer.rule.transformation.materialization.AggregatedMaterializedViewRewriter;
-import com.starrocks.sql.optimizer.rule.transformation.materialization.MaterializedViewRewriter;
+import com.starrocks.sql.optimizer.rule.transformation.materialization.IMaterializedViewRewriter;
 import com.starrocks.sql.optimizer.rule.transformation.materialization.MvUtils;
 
 /**
@@ -51,7 +51,8 @@ public class AggregateScanRule extends BaseMaterializedViewRewriteRule {
     }
 
     @Override
-    public MaterializedViewRewriter getMaterializedViewRewrite(MvRewriteContext mvContext) {
+    public IMaterializedViewRewriter createRewriter(OptimizerContext optimizerContext,
+                                                    MvRewriteContext mvContext) {
         return new AggregatedMaterializedViewRewriter(mvContext);
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/rule/BaseMaterializedViewRewriteRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/rule/BaseMaterializedViewRewriteRule.java
@@ -14,15 +14,12 @@
 
 package com.starrocks.sql.optimizer.rule.transformation.materialization.rule;
 
-import com.github.benmanes.caffeine.cache.Cache;
-import com.google.common.base.Preconditions;
 import com.google.common.collect.Lists;
 import com.starrocks.catalog.MaterializedView;
 import com.starrocks.catalog.Table;
 import com.starrocks.common.profile.Tracers;
 import com.starrocks.metric.IMaterializedViewMetricsEntity;
 import com.starrocks.metric.MaterializedViewMetricsRegistry;
-import com.starrocks.qe.ConnectContext;
 import com.starrocks.sql.optimizer.MaterializationContext;
 import com.starrocks.sql.optimizer.MvRewriteContext;
 import com.starrocks.sql.optimizer.OptExpression;
@@ -32,30 +29,28 @@ import com.starrocks.sql.optimizer.base.ColumnRefFactory;
 import com.starrocks.sql.optimizer.operator.Operator;
 import com.starrocks.sql.optimizer.operator.logical.LogicalOlapScanOperator;
 import com.starrocks.sql.optimizer.operator.pattern.Pattern;
-import com.starrocks.sql.optimizer.operator.scalar.ConstantOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ScalarOperator;
 import com.starrocks.sql.optimizer.rewrite.ReplaceColumnRefRewriter;
 import com.starrocks.sql.optimizer.rule.RuleType;
 import com.starrocks.sql.optimizer.rule.transformation.TransformationRule;
 import com.starrocks.sql.optimizer.rule.transformation.materialization.BestMvSelector;
-import com.starrocks.sql.optimizer.rule.transformation.materialization.MVColumnPruner;
+import com.starrocks.sql.optimizer.rule.transformation.materialization.IMaterializedViewRewriter;
 import com.starrocks.sql.optimizer.rule.transformation.materialization.MVCompensation;
-import com.starrocks.sql.optimizer.rule.transformation.materialization.MVPartitionPruner;
 import com.starrocks.sql.optimizer.rule.transformation.materialization.MaterializedViewRewriter;
-import com.starrocks.sql.optimizer.rule.transformation.materialization.MvPartitionCompensator;
 import com.starrocks.sql.optimizer.rule.transformation.materialization.MvUtils;
 import com.starrocks.sql.optimizer.rule.transformation.materialization.PredicateSplit;
 import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.lang3.exception.ExceptionUtils;
 
 import java.util.List;
-import java.util.Set;
 import java.util.stream.Collectors;
 
 import static com.starrocks.sql.optimizer.OptimizerTraceUtil.logMVRewrite;
+import static com.starrocks.sql.optimizer.rule.transformation.materialization.MvUtils.deriveLogicalProperty;
+import static com.starrocks.sql.optimizer.rule.transformation.materialization.MvUtils.getQuerySplitPredicate;
 import static com.starrocks.sql.optimizer.rule.transformation.materialization.MvUtils.isAppliedMVUnionRewrite;
 
-public abstract class BaseMaterializedViewRewriteRule extends TransformationRule {
+public abstract class BaseMaterializedViewRewriteRule extends TransformationRule implements IMaterializedViewRewriteRule {
 
     protected BaseMaterializedViewRewriteRule(RuleType type, Pattern pattern) {
         super(type, pattern);
@@ -109,7 +104,7 @@ public abstract class BaseMaterializedViewRewriteRule extends TransformationRule
                 return expressions;
             } else {
                 // in rule phase, only return the best one result
-                BestMvSelector bestMvSelector = new BestMvSelector(expressions, context, queryExpression);
+                BestMvSelector bestMvSelector = new BestMvSelector(expressions, context, queryExpression, this);
                 return Lists.newArrayList(bestMvSelector.selectBest());
             }
         } catch (Exception e) {
@@ -120,7 +115,16 @@ public abstract class BaseMaterializedViewRewriteRule extends TransformationRule
         }
     }
 
-    private List<OptExpression> doTransform(OptExpression queryExpression, OptimizerContext context) {
+    @Override
+    public List<MaterializationContext> doPrune(OptExpression queryExpression,
+                                                OptimizerContext context,
+                                                List<MaterializationContext> mvCandidateContexts) {
+        mvCandidateContexts.removeIf(x -> !x.prune(context, queryExpression));
+        return mvCandidateContexts;
+    }
+
+    public List<OptExpression> doTransform(OptExpression queryExpression, OptimizerContext context) {
+        // 1. collect all candidate mvs for the input
         List<MaterializationContext> mvCandidateContexts = Lists.newArrayList();
         if (queryExpression.getGroupExpression() != null) {
             int currentRootGroupId = queryExpression.getGroupExpression().getGroup().getId();
@@ -132,8 +136,12 @@ public abstract class BaseMaterializedViewRewriteRule extends TransformationRule
         } else {
             mvCandidateContexts.addAll(context.getCandidateMvs());
         }
-        mvCandidateContexts.removeIf(x -> !x.prune(context, queryExpression));
+        if (CollectionUtils.isEmpty(mvCandidateContexts)) {
+            return Lists.newArrayList();
+        }
 
+        // 2. prune candidate mvs
+        mvCandidateContexts = doPrune(queryExpression, context, mvCandidateContexts);
         // Order all candidate mvs by priority so can be rewritten fast.
         MaterializationContext.RewriteOrdering ordering =
                 new MaterializationContext.RewriteOrdering(queryExpression, context.getColumnRefFactory());
@@ -143,17 +151,27 @@ public abstract class BaseMaterializedViewRewriteRule extends TransformationRule
             logMVRewrite(context, this, "too many MV candidates, truncate them to " + numCandidates);
             mvCandidateContexts = mvCandidateContexts.subList(0, numCandidates);
         }
-        if (CollectionUtils.isEmpty(mvCandidateContexts)) {
-            return Lists.newArrayList();
-        }
 
+        // 3. do rewrite with associated mvs
+        return doTransform(mvCandidateContexts, queryExpression, context);
+    }
+
+    /**
+     * Transform/Rewrite the query with the given materialized view context.
+     * @param mvCandidateContexts: pruned materialized view candidates.
+     * @param queryExpression: query opt expression.
+     * @param context: optimizer context.
+     * @return: the rewritten query opt expression and associated materialization context pair if rewrite success, otherwise null.
+     */
+    protected List<OptExpression> doTransform(List<MaterializationContext> mvCandidateContexts,
+                                              OptExpression queryExpression,
+                                              OptimizerContext context) {
         List<OptExpression> results = Lists.newArrayList();
         // Construct queryPredicateSplit to avoid creating multi times for multi MVs.
         // Compute Query queryPredicateSplit
         final ColumnRefFactory queryColumnRefFactory = context.getColumnRefFactory();
         final ReplaceColumnRefRewriter queryColumnRefRewriter =
                 MvUtils.getReplaceColumnRefWriter(queryExpression, queryColumnRefFactory);
-
         List<ScalarOperator> onPredicates = MvUtils.collectOnPredicate(queryExpression);
         QueryMaterializationContext queryMaterializationContext = context.getQueryMaterializationContext();
         onPredicates = onPredicates.stream()
@@ -161,7 +179,7 @@ public abstract class BaseMaterializedViewRewriteRule extends TransformationRule
                 .map(predicate -> queryColumnRefRewriter.rewrite(predicate))
                 .collect(Collectors.toList());
         List<Table> queryTables = MvUtils.getAllTables(queryExpression);
-        ConnectContext connectContext = ConnectContext.get();
+
         for (MaterializationContext mvContext : mvCandidateContexts) {
             // initialize query's compensate type based on query and mv's partition refresh status
             MVCompensation mvCompensation = mvContext.getOrInitMVCompensation(queryExpression);
@@ -170,29 +188,41 @@ public abstract class BaseMaterializedViewRewriteRule extends TransformationRule
             }
 
             PredicateSplit queryPredicateSplit = getQuerySplitPredicate(context, mvContext, queryExpression,
-                    queryColumnRefFactory, queryColumnRefRewriter);
+                    queryColumnRefFactory, queryColumnRefRewriter, this);
             if (queryPredicateSplit == null) {
                 continue;
             }
             MvRewriteContext mvRewriteContext = new MvRewriteContext(mvContext, queryTables, queryExpression,
-                        queryColumnRefRewriter, queryPredicateSplit, onPredicates, this);
+                    queryColumnRefRewriter, queryPredicateSplit, onPredicates, this);
 
-            // rewrite query
-            MaterializedViewRewriter mvRewriter = getMaterializedViewRewrite(mvRewriteContext);
-            OptExpression candidate = mvRewriter.rewrite();
-            if (candidate == null) {
+            IMaterializedViewRewriter mvRewriter = createRewriter(context, mvRewriteContext);
+            if (mvRewriter == null) {
+                logMVRewrite(context, this, "create materialized view rewriter failed");
                 continue;
             }
 
-            candidate = postRewriteMV(context, mvRewriteContext, candidate);
+            // rewrite query
+            OptExpression candidate = mvRewriter.doRewrite(mvRewriteContext);
+            if (candidate == null) {
+                logMVRewrite(context, this, "doRewrite phase failed");
+                continue;
+            }
+
+            candidate = mvRewriter.doPostAfterRewrite(context, mvRewriteContext, candidate);
+            if (candidate == null) {
+                logMVRewrite(context, this, "doPostAfterRewrite phase failed");
+                continue;
+            }
+
             if (queryExpression.getGroupExpression() != null) {
                 int currentRootGroupId = queryExpression.getGroupExpression().getGroup().getId();
                 mvContext.addMatchedGroup(currentRootGroupId);
             }
 
-            results.add(candidate);
+            // NOTE: derive logical property is necessary for statistics calculation.
+            deriveLogicalProperty(candidate);
 
-            // update metrics
+            results.add(candidate);
             mvContext.updateMVUsedCount();
             IMaterializedViewMetricsEntity mvEntity =
                     MaterializedViewMetricsRegistry.getInstance().getMetricsEntity(mvContext.getMv().getMvId());
@@ -208,62 +238,17 @@ public abstract class BaseMaterializedViewRewriteRule extends TransformationRule
             // Give up rewrite if it exceeds the optimizer timeout
             context.checkTimeout();
         }
-
         return results;
     }
 
     /**
-     * Return the query predicate split with/without compensate :
-     * - with compensate    : deducing from the selected partition ids.
-     * - without compensate : only get the partition predicate from pruned partitions of scan operator
-     * eg: for sync mv without partition columns, we always no need compensate partition predicates because
-     * mv and the base table are always synced.
+     * Create a materialized view rewriter to do the mv rewrite for the specific query opt expression.
+     * @param mvContext: materialized view context of query and associated mv.
+     * @return: the specific rewriter for the mv rewrite.
      */
-    private PredicateSplit getQuerySplitPredicate(OptimizerContext optimizerContext,
-                                                  MaterializationContext mvContext,
-                                                  OptExpression queryExpression,
-                                                  ColumnRefFactory queryColumnRefFactory,
-                                                  ReplaceColumnRefRewriter queryColumnRefRewriter) {
-        // Cache partition predicate predicates because it's expensive time costing if there are too many materialized views or
-        // query expressions are too complex.
-        final ScalarOperator queryPartitionPredicate = MvPartitionCompensator.compensateQueryPartitionPredicate(
-                mvContext, queryColumnRefFactory, queryExpression);
-        if (queryPartitionPredicate == null) {
-            logMVRewrite(mvContext.getOptimizerContext(), this, "Compensate query expression's partition " +
-                    "predicates from pruned partitions failed.");
-            return null;
-        }
-
-        Set<ScalarOperator> queryConjuncts = MvUtils.getPredicateForRewrite(queryExpression);
-        // only add valid predicates into query split predicate
-        if (!ConstantOperator.TRUE.equals(queryPartitionPredicate)) {
-            queryConjuncts.addAll(MvUtils.getAllValidPredicates(queryPartitionPredicate));
-        }
-
-        QueryMaterializationContext queryMaterializationContext = optimizerContext.getQueryMaterializationContext();
-        Cache<Object, Object> predicateSplitCache = queryMaterializationContext.getMvQueryContextCache();
-        Preconditions.checkArgument(predicateSplitCache != null);
-        // Cache predicate split for predicates because it's time costing if there are too many materialized views.
-        return queryMaterializationContext.getPredicateSplit(queryConjuncts, queryColumnRefRewriter);
-    }
-
-    /**
-     * After plan is rewritten by MV, still do some actions for new MV's plan.
-     * 1. column prune
-     * 2. partition prune
-     * 3. bucket prune
-     */
-    private OptExpression postRewriteMV(
-            OptimizerContext optimizerContext, MvRewriteContext mvRewriteContext, OptExpression candidate) {
-        if (candidate == null) {
-            return null;
-        }
-        candidate = new MVColumnPruner().pruneColumns(candidate);
-        candidate = new MVPartitionPruner(optimizerContext, mvRewriteContext).prunePartition(candidate);
-        return candidate;
-    }
-
-    public MaterializedViewRewriter getMaterializedViewRewrite(MvRewriteContext mvContext) {
+    @Override
+    public IMaterializedViewRewriter createRewriter(OptimizerContext optimizerContext,
+                                                    MvRewriteContext mvContext) {
         return new MaterializedViewRewriter(mvContext);
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/rule/IMaterializedViewRewriteRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/rule/IMaterializedViewRewriteRule.java
@@ -1,0 +1,46 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.sql.optimizer.rule.transformation.materialization.rule;
+
+import com.starrocks.sql.optimizer.MaterializationContext;
+import com.starrocks.sql.optimizer.MvRewriteContext;
+import com.starrocks.sql.optimizer.OptExpression;
+import com.starrocks.sql.optimizer.OptimizerContext;
+import com.starrocks.sql.optimizer.rule.transformation.materialization.IMaterializedViewRewriter;
+
+import java.util.List;
+
+/**
+ * Base interface to implement materialized view rewrite rule.
+ */
+public interface IMaterializedViewRewriteRule {
+    /**
+     * Prune the materialized view candidates.
+     * @param queryExpression: query opt expression.
+     * @param context: optimizer context.
+     * @param mvCandidateContexts: materialized view candidates prepared in the mv preprocessor.
+     * @return: the pruned materialized view candidates.
+     */
+    List<MaterializationContext> doPrune(OptExpression queryExpression,
+                                         OptimizerContext context,
+                                         List<MaterializationContext> mvCandidateContexts);
+    /**
+     * Create a materialized view rewriter to do the mv rewrite for the specific query opt expression.
+     * @param mvContext: materialized view context of query and associated mv.
+     * @return: the specific rewriter for the mv rewrite.
+     */
+    IMaterializedViewRewriter createRewriter(OptimizerContext optimizerContext,
+                                             MvRewriteContext mvContext);
+}

--- a/fe/fe-core/src/test/java/com/starrocks/planner/MaterializedViewAggRollupTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/planner/MaterializedViewAggRollupTest.java
@@ -1,0 +1,651 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.planner;
+
+import com.google.common.base.Joiner;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
+import com.google.common.collect.Sets;
+import com.starrocks.catalog.FunctionSet;
+import com.starrocks.common.FeConstants;
+import com.starrocks.common.Pair;
+import org.apache.commons.lang3.StringUtils;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import static com.starrocks.sql.optimizer.rule.transformation.materialization.AggregateFunctionRollupUtils.REWRITE_ROLLUP_FUNCTION_MAP;
+
+public class MaterializedViewAggRollupTest extends MaterializedViewTestBase {
+    @BeforeClass
+    public static void beforeClass() throws Exception {
+        FeConstants.USE_MOCK_DICT_MANAGER = true;
+        MaterializedViewTestBase.beforeClass();
+        starRocksAssert.useDatabase(MATERIALIZED_DB_NAME);
+        createTables("sql/ssb/", Lists.newArrayList("customer", "dates", "supplier", "part", "lineorder"));
+    }
+
+    @Test
+    public void testAggPushDown_RollupFunctions_Simple() {
+        String mvAggArg = "LO_REVENUE";
+        String queryAggArg = "LO_REVENUE";
+        for (Map.Entry<String, String> e : REWRITE_ROLLUP_FUNCTION_MAP.entrySet()) {
+            String funcName = e.getKey();
+            String mvAggFunc = getAggFunction(funcName, mvAggArg);
+            String queryAggFunc = getAggFunction(funcName, queryAggArg);
+            String mv = String.format("CREATE MATERIALIZED VIEW mv0 REFRESH MANUAL as " +
+                    "select LO_ORDERDATE, LO_CUSTKEY, %s as revenue_sum\n" +
+                    "from lineorder l group by LO_ORDERDATE, LO_CUSTKEY", mvAggFunc);
+            starRocksAssert.withMaterializedView(mv, () -> {
+                String query = String.format("select LO_ORDERDATE, %s as revenue_sum\n" +
+                        "   from lineorder l \n" +
+                        "   group by LO_ORDERDATE", queryAggFunc);
+                sql(query).contains("mv0");
+            });
+        }
+    }
+
+    @Test
+    public void testAggPushDown_RollupFunctions_MV_WithExpr1() {
+        String mvAggArg = "(LO_REVENUE + 1) * 2";
+        String queryAggArg = "(LO_REVENUE + 1) * 2";
+        for (Map.Entry<String, String> e : REWRITE_ROLLUP_FUNCTION_MAP.entrySet()) {
+            String funcName = e.getKey();
+            String mvAggFunc = getAggFunction(funcName, mvAggArg);
+            String queryAggFunc = getAggFunction(funcName, queryAggArg);
+            String mv = String.format("CREATE MATERIALIZED VIEW mv0 REFRESH MANUAL as " +
+                    "select LO_ORDERDATE, LO_CUSTKEY, %s as revenue_sum\n" +
+                    "from lineorder l group by LO_ORDERDATE, LO_CUSTKEY", mvAggFunc);
+            starRocksAssert.withMaterializedView(mv, () -> {
+                String query = String.format("select LO_ORDERDATE, %s as revenue_sum\n" +
+                        "   from lineorder l \n" +
+                        "   group by LO_ORDERDATE", queryAggFunc);
+                sql(query).contains("mv0");
+            });
+        }
+    }
+
+    @Test
+    public void testAggPushDown_RollupFunctions_MV_WithExpr2() {
+        String mvAggArg = "LO_REVENUE";
+        String queryAggArg = "LO_REVENUE";
+        Set<String> numberAggFunctions = ImmutableSet.of("sum", "avg", "count", "min", "max");
+        for (Map.Entry<String, String> e : REWRITE_ROLLUP_FUNCTION_MAP.entrySet()) {
+            String funcName = e.getKey();
+            if (!numberAggFunctions.contains(funcName)) {
+                continue;
+            }
+            String mvAggFunc = getAggFunction(funcName, mvAggArg);
+            String queryAggFunc = getAggFunction(funcName, queryAggArg);
+            String mv = String.format("CREATE MATERIALIZED VIEW mv0 REFRESH MANUAL as " +
+                    "select LO_ORDERDATE, LO_CUSTKEY, %s as revenue_sum\n" +
+                    "from lineorder l group by LO_ORDERDATE, LO_CUSTKEY", mvAggFunc);
+            starRocksAssert.withMaterializedView(mv, () -> {
+                String query = String.format("select LO_ORDERDATE, " +
+                        "   %s + 1 as revenue_sum\n" +
+                        "   from lineorder l \n" +
+                        "   group by LO_ORDERDATE", queryAggFunc, queryAggFunc);
+                sql(query).contains("mv0");
+            });
+        }
+    }
+
+    private String getAggFunction(String funcName, String aggArg) {
+        if (funcName.equals(FunctionSet.ARRAY_AGG)) {
+            funcName = String.format("array_agg(distinct %s)", aggArg);
+        } else if (funcName.equals(FunctionSet.BITMAP_UNION)) {
+            funcName = String.format("bitmap_union(to_bitmap(%s))", aggArg);
+        } else if (funcName.equals(FunctionSet.PERCENTILE_UNION)) {
+            funcName = String.format("percentile_union(percentile_hash(%s))", aggArg);
+        } else if (funcName.equals(FunctionSet.HLL_UNION)) {
+            funcName = String.format("hll_union(hll_hash(%s))", aggArg);
+        } else {
+            funcName = String.format("%s(%s)", funcName, aggArg);
+        }
+        return funcName;
+    }
+
+    @Test
+    public void testAggPushDown_RollupFunctions_QueryMV_NoMatch() {
+        // query and mv's agg function is not the same, cannot rewrite.
+        String mvAggArg = "LO_REVENUE";
+        String queryAggArg = "(LO_REVENUE + 1) * 2";
+        for (Map.Entry<String, String> e : REWRITE_ROLLUP_FUNCTION_MAP.entrySet()) {
+            String funcName = e.getKey();
+            String mvAggFunc = getAggFunction(funcName, mvAggArg);
+            String queryAggFunc = getAggFunction(funcName, queryAggArg);
+            String mv = String.format("CREATE MATERIALIZED VIEW mv0 REFRESH MANUAL as " +
+                    "select LO_ORDERDATE, LO_CUSTKEY, %s as revenue_sum\n" +
+                    "from lineorder l group by LO_ORDERDATE, LO_CUSTKEY", mvAggFunc);
+            starRocksAssert.withMaterializedView(mv, () -> {
+                String query = String.format("select LO_ORDERDATE, %s as revenue_sum\n" +
+                        "   from lineorder l join \n" +
+                        "   group by LO_ORDERDATE", queryAggFunc);
+                sql(query).nonMatch("mv0");
+            });
+        }
+    }
+
+    @Test
+    public void testAggPushDown_RollupFunctions_Multi_Aggs1() {
+        // one query contains multi agg functions, all can be rewritten.
+        String aggArg = "LO_REVENUE";
+        List<String> aggFuncs = Lists.newArrayList();
+        for (Map.Entry<String, String> e : REWRITE_ROLLUP_FUNCTION_MAP.entrySet()) {
+            String funcName = e.getKey();
+            String mvAggFunc = getAggFunction(funcName, aggArg);
+            aggFuncs.add(mvAggFunc);
+        }
+        String agg = Joiner.on(", ").join(aggFuncs);
+        String mv = String.format("CREATE MATERIALIZED VIEW mv0 REFRESH MANUAL as " +
+                "select LO_ORDERDATE, LO_CUSTKEY, %s \n" +
+                "from lineorder l group by LO_ORDERDATE, LO_CUSTKEY", agg);
+        starRocksAssert.withMaterializedView(mv, () -> {
+            String query = String.format("select LO_ORDERDATE, %s \n" +
+                    "   from lineorder l \n" +
+                    "   group by LO_ORDERDATE", agg);
+            sql(query).match("mv0");
+        });
+    }
+
+    @Test
+    public void testAggPushDown_RollupFunctions_Multi_Aggs2() {
+        // one query contains multi agg functions, all can be rewritten.
+        String aggArg = "LO_REVENUE";
+
+        // add both rollup functions and equivalent agg functions
+        Map<String, String> mvFunToQueryFuncMap = Maps.newHashMap();
+        for (Map.Entry<String, String> e : REWRITE_ROLLUP_FUNCTION_MAP.entrySet()) {
+            String funcName = e.getKey();
+            String mvAggFunc = getAggFunction(funcName, aggArg);
+            mvFunToQueryFuncMap.put(mvAggFunc, mvAggFunc);
+        }
+        List<Pair<String, String>> equivalentFuncs = ImmutableList.of(
+                Pair.create(String.format("bitmap_union(to_bitmap(%s))", aggArg), String.format("count(distinct(%s))", aggArg)),
+                Pair.create(String.format("bitmap_union(to_bitmap(%s))", aggArg),
+                        String.format("bitmap_union_count(to_bitmap(%s))", aggArg)),
+                Pair.create(String.format("array_agg_distinct(%s)", aggArg), String.format("count(distinct(%s))", aggArg)),
+                Pair.create(String.format("array_agg_distinct(%s)", aggArg), String.format("sum(distinct(%s))", aggArg))
+        );
+        for (Pair<String, String> pair : equivalentFuncs) {
+            mvFunToQueryFuncMap.put(pair.first, pair.second);
+        }
+
+        String queryAgg = Joiner.on(", ").join(mvFunToQueryFuncMap.keySet());
+        String mv = String.format("CREATE MATERIALIZED VIEW mv0 REFRESH MANUAL as " +
+                "select LO_ORDERDATE, LO_CUSTKEY, %s \n" +
+                "from lineorder l group by LO_ORDERDATE, LO_CUSTKEY", queryAgg);
+
+        String mvAgg = Joiner.on(", ").join(mvFunToQueryFuncMap.values());
+        starRocksAssert.withMaterializedView(mv, () -> {
+            String query = String.format("select LO_ORDERDATE, %s \n" +
+                    "   from lineorder l\n" +
+                    "   group by LO_ORDERDATE", mvAgg);
+            sql(query).match("mv0");
+        });
+    }
+
+    @Test
+    public void testAggPushDown_RollupFunctions_MultiSameFunctions_BadCase() {
+        int repeatTimes = 1;
+        String aggArg = "LO_REVENUE";
+        String aggFunc = String.format("bitmap_union(to_bitmap(%s))", aggArg);
+        List<String> repeatAggs = Lists.newArrayList();
+        for (int i = 0; i < repeatTimes; i++) {
+            repeatAggs.add(String.format("%s as agg%s", aggFunc, i));
+        }
+        String agg = Joiner.on(", ").join(repeatAggs);
+        String mv = String.format("CREATE MATERIALIZED VIEW mv0 REFRESH MANUAL as " +
+                "select LO_ORDERDATE, LO_CUSTKEY, %s \n" +
+                "from lineorder l group by LO_ORDERDATE, LO_CUSTKEY", agg);
+        starRocksAssert.withMaterializedView(mv, () -> {
+            String query = String.format("select LO_ORDERDATE, %s \n" +
+                    "   from lineorder l\n" +
+                    "   group by LO_ORDERDATE", agg);
+            sql(query);
+        });
+    }
+
+    @Test
+    public void testAggPushDown_RollupFunctions_MultiSameAggs1() {
+        // one query contains multi same agg functions, all can be rewritten.
+        String aggArg = "LO_REVENUE";
+        List<String> aggFuncs = Lists.newArrayList();
+        for (Map.Entry<String, String> e : REWRITE_ROLLUP_FUNCTION_MAP.entrySet()) {
+            String funcName = e.getKey();
+            String mvAggFunc = getAggFunction(funcName, aggArg);
+            aggFuncs.add(mvAggFunc);
+        }
+
+        int repeatTimes = 4;
+        for (String aggFunc : aggFuncs) {
+            if (aggFunc.contains("bitmap_union")) {
+                continue;
+            }
+            List<String> repeatAggs = Lists.newArrayList();
+            for (int i = 0; i < repeatTimes; i++) {
+                repeatAggs.add(String.format("%s as agg%s", aggFunc, i));
+            }
+            String agg = Joiner.on(", ").join(repeatAggs);
+            String mv = String.format("CREATE MATERIALIZED VIEW mv0 REFRESH MANUAL as " +
+                    "select LO_ORDERDATE, LO_CUSTKEY, %s \n" +
+                    "from lineorder l group by LO_ORDERDATE, LO_CUSTKEY", agg);
+            starRocksAssert.withMaterializedView(mv, () -> {
+                String query = String.format("select LO_ORDERDATE, %s \n" +
+                        "   from lineorder l \n" +
+                        "   group by LO_ORDERDATE", agg);
+                sql(query).match("mv0");
+            });
+        }
+    }
+
+    @Test
+    public void testAggPushDown_RollupFunctions_MultiSameAggs2() {
+        // one query contains multi same agg functions, all can be rewritten.
+        String aggArg = "LO_REVENUE";
+        List<Pair<String, String>> aggFuncs = ImmutableList.of(
+                Pair.create(String.format("bitmap_union(to_bitmap(%s))", aggArg), String.format("count(distinct(%s))", aggArg)),
+                Pair.create(String.format("bitmap_union(to_bitmap(%s))", aggArg),
+                        String.format("bitmap_union_count(to_bitmap(%s))", aggArg)),
+                Pair.create(String.format("array_agg_distinct(%s)", aggArg), String.format("count(distinct(%s))", aggArg)),
+                Pair.create(String.format("array_agg_distinct(%s)", aggArg), String.format("sum(distinct(%s))", aggArg))
+        );
+
+
+        int repeatTimes = 4;
+        for (Pair<String, String> pair : aggFuncs) {
+            List<String> repeatAggs = Lists.newArrayList();
+            for (int i = 0; i < repeatTimes; i++) {
+                repeatAggs.add(String.format("%s as agg%s", pair.second, i));
+            }
+            String agg = Joiner.on(", ").join(repeatAggs);
+            String mv = String.format("CREATE MATERIALIZED VIEW mv0 REFRESH MANUAL as " +
+                    "select LO_ORDERDATE, LO_CUSTKEY, %s \n" +
+                    "from lineorder l group by LO_ORDERDATE, LO_CUSTKEY", pair.first);
+            starRocksAssert.withMaterializedView(mv, () -> {
+                String query = String.format("select LO_ORDERDATE, %s \n" +
+                        "   from lineorder l\n" +
+                        "   group by LO_ORDERDATE", agg);
+                sql(query).match("mv0");
+            });
+        }
+    }
+
+    private static final Set<String> IGNORE_AGG_FUNCTIONS = Sets.newHashSet("bitmap", "array", "hll", "percentile");
+    private boolean isAggFunctionSupportHaving(String funcName) {
+        for (String ignore : IGNORE_AGG_FUNCTIONS) {
+            if (StringUtils.containsIgnoreCase(funcName, ignore)) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    @Test
+    public void testAggPushDown_RollupFunctions_With_Having() {
+        String mvAggArg = "(LO_REVENUE + 1) * 2";
+        String queryAggArg = "(LO_REVENUE + 1) * 2";
+        for (Map.Entry<String, String> e : REWRITE_ROLLUP_FUNCTION_MAP.entrySet()) {
+
+            String funcName = e.getKey();
+            String mvAggFunc = getAggFunction(funcName, mvAggArg);
+            if (!isAggFunctionSupportHaving(mvAggFunc)) {
+                continue;
+            }
+
+            // HLL, BITMAP, PERCENTILE and ARRAY, MAP, STRUCT type couldn't as Predicate
+            String queryAggFunc = getAggFunction(funcName, queryAggArg);
+            String mv = String.format("CREATE MATERIALIZED VIEW mv0 REFRESH MANUAL as " +
+                    "select LO_ORDERDATE, LO_CUSTKEY, %s as revenue_sum\n" +
+                    "from lineorder l group by LO_ORDERDATE, LO_CUSTKEY", mvAggFunc);
+            starRocksAssert.withMaterializedView(mv, () -> {
+                String query = String.format("select LO_ORDERDATE, %s as revenue_sum\n" +
+                        "   from lineorder l\n" +
+                        "   group by LO_ORDERDATE having revenue_sum is not null", queryAggFunc);
+                sql(query).contains("mv0");
+            });
+        }
+    }
+
+    @Test
+    public void testJoinWithAggPushDown_BitmapUnion1() {
+        String aggArg = "LO_REVENUE";
+        String mv = String.format("CREATE MATERIALIZED VIEW mv0 REFRESH MANUAL as " +
+                "select LO_ORDERDATE, LO_CUSTKEY, bitmap_union(to_bitmap(%s)) as revenue_sum\n" +
+                "from lineorder l group by LO_ORDERDATE, LO_CUSTKEY", aggArg);
+        starRocksAssert.withMaterializedView(mv, () -> {
+            String[] queries = new String[]{
+                    // count distinct
+                    String.format("select LO_ORDERDATE, count(distinct %s) as revenue_sum\n" +
+                            "   from lineorder l group by LO_ORDERDATE", aggArg),
+                    // mutli_distinct_count
+                    String.format("select LO_ORDERDATE, multi_distinct_count(%s) as revenue_sum\n" +
+                            "   from lineorder \n" +
+                            "   group by LO_ORDERDATE", aggArg),
+                    // bitmap_union_count
+                    String.format("select LO_ORDERDATE, bitmap_union_count(to_bitmap(%s)) as revenue_sum\n" +
+                            "   from lineorder l\n" +
+                            "   group by LO_ORDERDATE", aggArg),
+                    // bitmap_union
+                    String.format("select LO_ORDERDATE, bitmap_union(to_bitmap(%s)) as revenue_sum\n" +
+                            "   from lineorder l\n" +
+                            "   group by LO_ORDERDATE", aggArg),
+                    // bitmap_agg
+                    String.format("select LO_ORDERDATE, bitmap_agg(%s) as revenue_sum\n" +
+                            "   from lineorder l\n" +
+                            "   group by LO_ORDERDATE", aggArg),
+                    // no need to push down
+                    String.format("select LO_ORDERDATE, bitmap_union_count(revenue_sum) from (" +
+                            "   select LO_ORDERDATE, bitmap_union(to_bitmap(%s)) as revenue_sum\n" +
+                            "   from lineorder l\n" +
+                            "   group by LO_ORDERDATE) a group by LO_ORDERDATE", aggArg),
+            };
+
+            for (int i = 0; i < queries.length; i++) {
+                String query = queries[i];
+                sql(query).contains("mv0");
+            }
+        });
+    }
+
+    @Test
+    public void testJoinWithAggPushDown_BitmapUnion2() {
+        String aggArg = "(LO_REVENUE + 10) * 10";
+        String mv = String.format("CREATE MATERIALIZED VIEW mv0 REFRESH MANUAL as " +
+                "select LO_ORDERDATE, LO_CUSTKEY, bitmap_union(to_bitmap(%s)) as revenue_sum\n" +
+                "from lineorder l group by LO_ORDERDATE, LO_CUSTKEY", aggArg);
+        starRocksAssert.withMaterializedView(mv, () -> {
+            String[] queries = new String[]{
+                    // count distinct
+                    String.format("select LO_ORDERDATE, count(distinct %s) as revenue_sum\n" +
+                            "   from lineorder l group by LO_ORDERDATE", aggArg),
+                    // mutli_distinct_count
+                    String.format("select LO_ORDERDATE, multi_distinct_count(%s) as revenue_sum\n" +
+                            "   from lineorder l \n" +
+                            "   group by LO_ORDERDATE", aggArg),
+                    // bitmap_union_count
+                    String.format("select LO_ORDERDATE, bitmap_union_count(to_bitmap(%s)) as revenue_sum\n" +
+                            "   from lineorder l \n" +
+                            "   group by LO_ORDERDATE", aggArg),
+                    // bitmap_union
+                    String.format("select LO_ORDERDATE, bitmap_union(to_bitmap(%s)) as revenue_sum\n" +
+                            "   from lineorder l \n" +
+                            "   group by LO_ORDERDATE", aggArg),
+                    // bitmap_agg
+                    String.format("select LO_ORDERDATE, bitmap_agg(%s) as revenue_sum\n" +
+                            "   from lineorder l \n" +
+                            "   group by LO_ORDERDATE", aggArg),
+                    // no need to push down
+                    String.format("select LO_ORDERDATE, bitmap_union_count(revenue_sum) from (" +
+                            "   select LO_ORDERDATE, bitmap_union(to_bitmap(%s)) as revenue_sum\n" +
+                            "   from lineorder l \n" +
+                            "   group by LO_ORDERDATE) a group by LO_ORDERDATE", aggArg),
+            };
+
+            for (int i = 0; i < queries.length; i++) {
+                String query = queries[i];
+                sql(query).contains("mv0");
+            }
+        });
+    }
+
+    @Test
+    public void testAggPushDown_HLLUnion1() {
+        String aggArg = "LO_REVENUE";
+        String mv = String.format("CREATE MATERIALIZED VIEW mv0 REFRESH MANUAL as " +
+                "select LO_ORDERDATE, LO_CUSTKEY, hll_union(hll_hash(%s)) as revenue_sum\n" +
+                "from lineorder l group by LO_ORDERDATE, LO_CUSTKEY", aggArg);
+
+        starRocksAssert.withMaterializedView(mv, () -> {
+            String[] queries = {
+                    String.format("select LO_ORDERDATE, hll_union(hll_hash(%s)) as revenue_sum\n" +
+                            "   from lineorder l \n" +
+                            "   group by LO_ORDERDATE", aggArg),
+                    String.format("select LO_ORDERDATE, approx_count_distinct(%s) as revenue_sum\n" +
+                            "   from lineorder l \n" +
+                            "   group by LO_ORDERDATE", aggArg),
+                    String.format("select LO_ORDERDATE, ndv(%s) as revenue_sum\n" +
+                            "   from lineorder l \n" +
+                            "   group by LO_ORDERDATE", aggArg),
+                    String.format("select LO_ORDERDATE, hll_union_agg(hll_hash(%s)) as revenue_sum\n" +
+                            "   from lineorder l \n" +
+                            "   group by LO_ORDERDATE", aggArg),
+            };
+            for (int i = 0; i < queries.length; i++) {
+                String query = queries[i];
+                sql(query).contains("mv0");
+            }
+        });
+    }
+
+    @Test
+    public void testAggPushDown_HLLUnion2() {
+        String aggArg = "case when (LO_REVENUE > 10) then 0 else LO_REVENUE end";
+        String mv = String.format("CREATE MATERIALIZED VIEW mv0 REFRESH MANUAL as " +
+                "select LO_ORDERDATE, LO_CUSTKEY, hll_union(hll_hash(%s)) as revenue_sum\n" +
+                "from lineorder l group by LO_ORDERDATE, LO_CUSTKEY", aggArg);
+
+        starRocksAssert.withMaterializedView(mv, () -> {
+            String[] queries = {
+                    String.format("select LO_ORDERDATE, hll_union(hll_hash(%s)) as revenue_sum\n" +
+                            "   from lineorder l \n" +
+                            "   group by LO_ORDERDATE", aggArg),
+                    String.format("select LO_ORDERDATE, approx_count_distinct(%s) as revenue_sum\n" +
+                            "   from lineorder l \n" +
+                            "   group by LO_ORDERDATE", aggArg),
+                    String.format("select LO_ORDERDATE, ndv(%s) as revenue_sum\n" +
+                            "   from lineorder l \n" +
+                            "   group by LO_ORDERDATE", aggArg),
+                    String.format("select LO_ORDERDATE, hll_union_agg(hll_hash(%s)) as revenue_sum\n" +
+                            "   from lineorder l \n" +
+                            "   group by LO_ORDERDATE", aggArg),
+            };
+            for (int i = 0; i < queries.length; i++) {
+                String query = queries[i];
+                sql(query).contains("mv0");
+            }
+        });
+    }
+
+    @Test
+    public void testAggPushDown_ArrayAggDistinct1() {
+        String aggArg = "LO_REVENUE";
+        String mv = String.format("CREATE MATERIALIZED VIEW mv0 REFRESH MANUAL as " +
+                "select LO_ORDERDATE, LO_CUSTKEY, array_agg_distinct(%s) as revenue_sum\n" +
+                "from lineorder l group by LO_ORDERDATE, LO_CUSTKEY", aggArg);
+
+        starRocksAssert.withMaterializedView(mv, () -> {
+            String[] queries = {
+                    String.format("select LO_ORDERDATE, array_agg_distinct(%s) as revenue_sum\n" +
+                            "   from lineorder l \n" +
+                            "   group by LO_ORDERDATE", aggArg),
+                    String.format("select LO_ORDERDATE, count(distinct %s) " +
+                            "   from lineorder l \n" +
+                            "   group by LO_ORDERDATE", aggArg),
+                    String.format("select LO_ORDERDATE, sum(distinct %s) " +
+                            "   from lineorder l \n" +
+                            "   group by LO_ORDERDATE", aggArg),
+                    String.format("select LO_ORDERDATE, multi_distinct_count(%s) " +
+                            "   from lineorder l \n" +
+                            "   group by LO_ORDERDATE", aggArg),
+            };
+            for (int i = 0; i < queries.length; i++) {
+                String query = queries[i];
+                sql(query).contains("mv0");
+            }
+        });
+    }
+
+    @Test
+    public void testAggPushDown_ArrayAggDistinct2() {
+        String aggArg = "(LO_REVENUE * 2) + 1";
+        String mv = String.format("CREATE MATERIALIZED VIEW mv0 REFRESH MANUAL as " +
+                "select LO_ORDERDATE, LO_CUSTKEY, array_agg_distinct(%s) as revenue_sum\n" +
+                "from lineorder l group by LO_ORDERDATE, LO_CUSTKEY", aggArg);
+
+        starRocksAssert.withMaterializedView(mv, () -> {
+            String[] queries = {
+                    String.format("select LO_ORDERDATE, array_agg_distinct(%s) as revenue_sum\n" +
+                            "   from lineorder l \n" +
+                            "   group by LO_ORDERDATE", aggArg),
+                    String.format("select LO_ORDERDATE, count(distinct %s) " +
+                            "   from lineorder l \n" +
+                            "   group by LO_ORDERDATE", aggArg),
+                    String.format("select LO_ORDERDATE, sum(distinct %s) " +
+                            "   from lineorder l \n" +
+                            "   group by LO_ORDERDATE", aggArg),
+                    String.format("select LO_ORDERDATE, multi_distinct_count(%s) " +
+                            "   from lineorder l \n" +
+                            "   group by LO_ORDERDATE", aggArg),
+            };
+            for (int i = 0; i < queries.length; i++) {
+                String query = queries[i];
+                sql(query).contains("mv0");
+            }
+        });
+    }
+
+    @Test
+    public void testAggPushDown_ArrayAgg() {
+        // array_agg has no rollup function but array_agg(distinct) has.
+        String funcName = "array_agg(LO_REVENUE)";
+        String mv = String.format("CREATE MATERIALIZED VIEW mv0 REFRESH MANUAL as " +
+                "select LO_ORDERDATE, LO_CUSTKEY, %s as revenue_sum\n" +
+                "from lineorder l group by LO_ORDERDATE, LO_CUSTKEY", funcName);
+        String aggFuncName = funcName;
+        starRocksAssert.withMaterializedView(mv, () -> {
+            String query = String.format("select LO_ORDERDATE, %s as revenue_sum\n" +
+                    "   from lineorder l \n" +
+                    "   group by LO_ORDERDATE", aggFuncName);
+            sql(query).nonMatch("mv0");
+        });
+    }
+
+    @Test
+    public void testJoinWithAggPushDown_PercentileUnion() {
+        String mv = "CREATE MATERIALIZED VIEW mv0 REFRESH MANUAL as " +
+                "select LO_ORDERDATE, LO_CUSTKEY, percentile_union(percentile_hash(LO_REVENUE)) as revenue_sum\n" +
+                "from lineorder l group by LO_ORDERDATE, LO_CUSTKEY";
+        starRocksAssert.withMaterializedView(mv, () -> {
+            {
+                String[] queries = {
+                        "select LO_ORDERDATE, percentile_union(percentile_hash(LO_REVENUE)) as revenue_sum\n" +
+                                "   from lineorder l \n" +
+                                "   group by LO_ORDERDATE",
+                        "select LO_ORDERDATE, PERCENTILE_APPROX(LO_REVENUE, 0.11) as revenue_sum\n" +
+                                "   from lineorder l \n" +
+                                "   group by LO_ORDERDATE",
+                };
+                for (int i = 0; i < queries.length; i++) {
+                    String query = queries[i];
+                    sql(query).contains("mv0");
+                }
+            }
+        });
+    }
+
+    @Test
+    public void testAggPushDown_ComplexCase1() {
+        String mv = "CREATE MATERIALIZED VIEW mv0 REFRESH MANUAL AS\n" +
+                "select LO_ORDERDATE, LO_CUSTKEY, sum(LO_REVENUE), max(LO_REVENUE), " +
+                "   min(LO_REVENUE), bitmap_union(to_bitmap(LO_REVENUE))," +
+                "   hll_union(hll_hash(LO_REVENUE)), percentile_union(percentile_hash(LO_REVENUE)), any_value(LO_REVENUE), " +
+                "   bitmap_agg(LO_REVENUE), array_agg_distinct(LO_REVENUE) \n" +
+                "from lineorder l group by LO_ORDERDATE, LO_CUSTKEY;";
+        starRocksAssert.withMaterializedView(mv, () -> {
+            String[] queries = {"select LO_ORDERDATE, \n" +
+                    "    sum(LO_REVENUE), max(LO_REVENUE), min(LO_REVENUE), \n" +
+                    "    bitmap_union_count(to_bitmap(LO_REVENUE)), \n" +
+                    "    approx_count_distinct(LO_REVENUE), \n" +
+                    "    PERCENTILE_APPROX(LO_REVENUE, 0.5), \n" +
+                    "    PERCENTILE_APPROX(LO_REVENUE, 0.7), \n" +
+                    "    sum(distinct LO_REVENUE) ,\n" +
+                    "    count(distinct LO_REVENUE) \n" +
+                    "from lineorder l \n" +
+                    "group by LO_ORDERDATE",
+            };
+            for (int i = 0; i < queries.length; i++) {
+                String query = queries[i];
+                sql(query).contains("mv0");
+            }
+        });
+    }
+
+    @Test
+    public void testAggPushDown_ComplexCase2() {
+        String mv = "CREATE MATERIALIZED VIEW mv0 REFRESH MANUAL AS\n" +
+                "select LO_ORDERDATE, LO_CUSTKEY, array_agg_distinct(LO_REVENUE) \n" +
+                "from lineorder l group by LO_ORDERDATE, LO_CUSTKEY;";
+        starRocksAssert.withMaterializedView(mv, () -> {
+            String[] queries = {"select LO_ORDERDATE, \n" +
+                    "    sum(LO_REVENUE), max(LO_REVENUE), min(LO_REVENUE), \n" +
+                    "    bitmap_union_count(to_bitmap(LO_REVENUE)), \n" +
+                    "    approx_count_distinct(LO_REVENUE), \n" +
+                    "    PERCENTILE_APPROX(LO_REVENUE, 0.5), \n" +
+                    "    PERCENTILE_APPROX(LO_REVENUE, 0.7), \n" +
+                    "    sum(distinct LO_REVENUE) ,\n" +
+                    "    count(distinct LO_REVENUE) \n" +
+                    "from lineorder l\n" +
+                    "group by LO_ORDERDATE",
+            };
+            for (int i = 0; i < queries.length; i++) {
+                String query = queries[i];
+                sql(query).nonMatch("mv0");
+            }
+        });
+    }
+
+    @Test
+    public void testAggPushDown_ComplexCase3() {
+        List<String> mvs = ImmutableList.of(
+                "CREATE MATERIALIZED VIEW mv0 REFRESH MANUAL AS\n" +
+                        "select LO_ORDERDATE, LO_CUSTKEY, array_agg_distinct(LO_REVENUE) \n" +
+                        "from lineorder l group by LO_ORDERDATE, LO_CUSTKEY;",
+                "CREATE MATERIALIZED VIEW mv1 REFRESH MANUAL AS\n" +
+                        "select LO_ORDERDATE, LO_CUSTKEY, sum(LO_REVENUE), max(LO_REVENUE), min(LO_REVENUE), " +
+                        "   bitmap_union(to_bitmap(LO_REVENUE)), " +
+                        "   hll_union(hll_hash(LO_REVENUE)), percentile_union(percentile_hash(LO_REVENUE)), any_value(LO_REVENUE), " +
+                        "   bitmap_agg(LO_REVENUE), array_agg_distinct(LO_REVENUE) \n" +
+                        "from lineorder l group by LO_ORDERDATE, LO_CUSTKEY;"
+        );
+        starRocksAssert.withMaterializedViews(mvs, (obj) -> {
+            try {
+                String[] queries = {"select LO_ORDERDATE, \n" +
+                        "    sum(LO_REVENUE), max(LO_REVENUE), min(LO_REVENUE), \n" +
+                        "    bitmap_union_count(to_bitmap(LO_REVENUE)), \n" +
+                        "    approx_count_distinct(LO_REVENUE), \n" +
+                        "    PERCENTILE_APPROX(LO_REVENUE, 0.5), \n" +
+                        "    PERCENTILE_APPROX(LO_REVENUE, 0.7), \n" +
+                        "    sum(distinct LO_REVENUE) ,\n" +
+                        "    count(distinct LO_REVENUE) \n" +
+                        "from lineorder l \n" +
+                        "group by LO_ORDERDATE",
+                };
+                for (int i = 0; i < queries.length; i++) {
+                    String query = queries[i];
+                    sql(query).contains("mv1");
+                }
+            } catch (Exception e) {
+                Assert.fail();
+            }
+        });
+    }
+}

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvRewriteTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvRewriteTest.java
@@ -648,7 +648,6 @@ public class MvRewriteTest extends MvRewriteTestBase {
                 "  |  group by: 23: add, 17: v1");
         PlanTestBase.assertContains(plan5, "  1:Project\n" +
                 "  |  <slot 17> : 17: v1\n" +
-                "  |  <slot 18> : 18: t1d\n" +
                 "  |  <slot 19> : 19: total_sum\n" +
                 "  |  <slot 20> : 20: total_num\n" +
                 "  |  <slot 23> : 17: v1 + 1");


### PR DESCRIPTION

## Why I'm doing:
Split PR (https://github.com/StarRocks/starrocks/pull/42809).


## What I'm doing:
1. Add IMaterializedViewRewriter and IMaterializedViewRewriteRule to make it more extensible
2. Move `HLLRewriteEquivalent` and `PercentileRewriteEquivalent` from `AggregateFunctionRewriter` to make it more extensible.
3. Refactor other codes.

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [x] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
