### PR TITLE
[Enhancement] backend do not split when splits is small

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/connector/RemoteScanRangeLocations.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/RemoteScanRangeLocations.java
@@ -56,6 +56,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Random;
 
 public class RemoteScanRangeLocations {
     private static final Logger LOG = LogManager.getLogger(RemoteScanRangeLocations.class);
@@ -408,7 +409,14 @@ public class RemoteScanRangeLocations {
         // encounter very bad cases (scan ranges that meet the predicate conditions are in the later partitions),
         // making BE have to scan more data to find rows that meet the conditions.
         // So shuffle scan ranges can naturally disrupt the scan ranges' order to avoid very bad cases.
-        Collections.shuffle(result);
+        long seed = 42;
+        ConnectContext ctx = ConnectContext.get();
+        if (ctx != null) {
+            seed = ctx.getSessionVariable().connectorShuffleSeed;
+        }
+        LOG.info("[xxx] table name = " + table.getName() + ", running with seed = " + seed);
+        Random rnd = new Random(seed);
+        Collections.shuffle(result, rnd);
 
         LOG.debug("Get {} scan range locations cost: {} ms",
                 getScanRangeLocationsSize(), (System.currentTimeMillis() - start));

--- a/fe/fe-core/src/main/java/com/starrocks/connector/RemoteScanRangeLocations.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/RemoteScanRangeLocations.java
@@ -56,7 +56,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.Random;
 
 public class RemoteScanRangeLocations {
     private static final Logger LOG = LogManager.getLogger(RemoteScanRangeLocations.class);
@@ -409,14 +408,7 @@ public class RemoteScanRangeLocations {
         // encounter very bad cases (scan ranges that meet the predicate conditions are in the later partitions),
         // making BE have to scan more data to find rows that meet the conditions.
         // So shuffle scan ranges can naturally disrupt the scan ranges' order to avoid very bad cases.
-        long seed = 42;
-        ConnectContext ctx = ConnectContext.get();
-        if (ctx != null) {
-            seed = ctx.getSessionVariable().connectorShuffleSeed;
-        }
-        LOG.info("[xxx] table name = " + table.getName() + ", running with seed = " + seed);
-        Random rnd = new Random(seed);
-        Collections.shuffle(result, rnd);
+        Collections.shuffle(result);
 
         LOG.debug("Get {} scan range locations cost: {} ms",
                 getScanRangeLocationsSize(), (System.currentTimeMillis() - start));

--- a/fe/fe-core/src/main/java/com/starrocks/qe/ConnectContext.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/ConnectContext.java
@@ -430,6 +430,7 @@ public class ConnectContext {
     public Map<String, UserVariable> getUserVariables() {
         return userVariables;
     }
+
     public UserVariable getUserVariable(String variable) {
         return userVariables.get(variable);
     }
@@ -854,6 +855,10 @@ public class ConnectContext {
 
     public int getTotalBackendNumber() {
         return globalStateMgr.getNodeMgr().getClusterInfo().getTotalBackendNumber();
+    }
+
+    public int getAliveComputeNumber() {
+        return globalStateMgr.getNodeMgr().getClusterInfo().getAliveComputeNodeNumber();
     }
 
     public void setPending(boolean pending) {

--- a/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
@@ -1837,7 +1837,7 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
     private long connectorMaxSplitSize = 64L * 1024L * 1024L;
 
     @VarAttr(name = CONNECTOR_HUGE_FILE_SIZE)
-    private long connectorHugeFileSize = 1024L * 1024L * 1024L;
+    private long connectorHugeFileSize = 512L * 1024L * 1024L;
 
     @VarAttr(name = ENABLE_CONNECTOR_SINK_WRITER_SCALING)
     private boolean enableConnectorSinkWriterScaling = true;

--- a/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
@@ -710,8 +710,6 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
      */
     public static final String CONNECTOR_MAX_SPLIT_SIZE = "connector_max_split_size";
 
-    public static final String CONNECTOR_SHUFFLE_SEED = "connector_shuffle_seed";
-
     /**
      * BE can split file of some specific formats, so FE don't need to split at all.
      * But if a file is very huge, we still want FE to split them to more BEs.
@@ -1837,9 +1835,6 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
 
     @VarAttr(name = CONNECTOR_MAX_SPLIT_SIZE)
     private long connectorMaxSplitSize = 64L * 1024L * 1024L;
-
-    @VarAttr(name = CONNECTOR_SHUFFLE_SEED)
-    public long connectorShuffleSeed = 42;
 
     @VarAttr(name = CONNECTOR_HUGE_FILE_SIZE)
     private long connectorHugeFileSize = 1024L * 1024L * 1024L;

--- a/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
@@ -710,6 +710,8 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
      */
     public static final String CONNECTOR_MAX_SPLIT_SIZE = "connector_max_split_size";
 
+    public static final String CONNECTOR_SHUFFLE_SEED = "connector_shuffle_seed";
+
     /**
      * BE can split file of some specific formats, so FE don't need to split at all.
      * But if a file is very huge, we still want FE to split them to more BEs.
@@ -1835,6 +1837,9 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
 
     @VarAttr(name = CONNECTOR_MAX_SPLIT_SIZE)
     private long connectorMaxSplitSize = 64L * 1024L * 1024L;
+
+    @VarAttr(name = CONNECTOR_SHUFFLE_SEED)
+    public long connectorShuffleSeed = 42;
 
     @VarAttr(name = CONNECTOR_HUGE_FILE_SIZE)
     private long connectorHugeFileSize = 1024L * 1024L * 1024L;


### PR DESCRIPTION
## Why I'm doing:

Since we support backend split files by default, we hit some bad cases
- if a table only has few files(< 3 files), but we have 3 nodes
- if we don't split files, then some nodes are more idle comparing to other nodes
- and data skew will cause hash join takes more time.

## What I'm doing:

We have to check that cases
- try to split files using `huge_file_size`, to see how many splits we will get
- if `splits <= 2 * ndoes`, then we consider that splits are small, we'd better not let backend do spli


Fixes https://github.com/StarRocks/StarRocksBenchmark/issues/484

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [X] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
