### PR TITLE
[BugFix] Fix external db & table privilege compatibility

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/privilege/DbPEntryObject.java
+++ b/fe/fe-core/src/main/java/com/starrocks/privilege/DbPEntryObject.java
@@ -15,6 +15,7 @@
 
 package com.starrocks.privilege;
 
+import com.google.common.base.Preconditions;
 import com.google.gson.annotations.SerializedName;
 import com.starrocks.catalog.Catalog;
 import com.starrocks.catalog.Database;
@@ -26,9 +27,6 @@ import com.starrocks.sql.common.MetaNotFoundException;
 
 import java.util.List;
 import java.util.Objects;
-
-import static com.google.common.base.Preconditions.checkArgument;
-import static com.starrocks.catalog.ExternalCatalog.getCompatibleDbUUID;
 
 public class DbPEntryObject implements PEntryObject {
     @SerializedName(value = "ci")
@@ -94,7 +92,7 @@ public class DbPEntryObject implements PEntryObject {
      * for external database, use database name as privilege id.
      */
     public static String getDatabaseUUID(GlobalStateMgr mgr, String catalogName, String dbToken) throws PrivObjNotFoundException {
-        checkArgument(!dbToken.equals("*"));
+        Preconditions.checkArgument(!dbToken.equals("*"));
         if (CatalogMgr.isInternalCatalog(catalogName)) {
             Database database = mgr.getMetadataMgr().getDb(catalogName, dbToken);
             if (database == null) {

--- a/fe/fe-core/src/main/java/com/starrocks/privilege/DbPEntryObject.java
+++ b/fe/fe-core/src/main/java/com/starrocks/privilege/DbPEntryObject.java
@@ -127,7 +127,7 @@ public class DbPEntryObject implements PEntryObject {
             return this.catalogId == other.catalogId;
         }
         return this.catalogId == other.catalogId &&
-                Objects.equals(getCompatibleDbUUID(this.uuid), getCompatibleDbUUID(other.uuid));
+                Objects.equals(Catalog.getCompatibleDbUUID(this.uuid), Catalog.getCompatibleDbUUID(other.uuid));
     }
 
     @Override
@@ -186,12 +186,13 @@ public class DbPEntryObject implements PEntryObject {
             return false;
         }
         DbPEntryObject that = (DbPEntryObject) o;
-        return this.catalogId == that.catalogId && Objects.equals(uuid, that.uuid);
+        return this.catalogId == that.catalogId &&
+                Objects.equals(Catalog.getCompatibleDbUUID(this.uuid), Catalog.getCompatibleDbUUID(that.uuid));
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(catalogId, uuid);
+        return Objects.hash(catalogId, Catalog.getCompatibleDbUUID(uuid));
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/privilege/TablePEntryObject.java
+++ b/fe/fe-core/src/main/java/com/starrocks/privilege/TablePEntryObject.java
@@ -168,7 +168,7 @@ public class TablePEntryObject implements PEntryObject {
         }
         return this.catalogId == other.catalogId &&
                 Objects.equals(Catalog.getCompatibleDbUUID(this.databaseUUID), Catalog.getCompatibleDbUUID(other.databaseUUID)) &&
-                Objects.equals(Catalog.getCompatibleDbUUID(other.tableUUID), Catalog.getCompatibleDbUUID(this.tableUUID));
+                Objects.equals(Catalog.getCompatibleTableUUID(this.tableUUID), Catalog.getCompatibleTableUUID(other.tableUUID));
     }
 
     @Override
@@ -237,13 +237,13 @@ public class TablePEntryObject implements PEntryObject {
         }
         TablePEntryObject that = (TablePEntryObject) o;
         return this.catalogId == that.catalogId &&
-                Objects.equals(databaseUUID, that.databaseUUID) &&
-                Objects.equals(tableUUID, that.tableUUID);
+                Objects.equals(Catalog.getCompatibleDbUUID(this.databaseUUID), Catalog.getCompatibleDbUUID(that.databaseUUID)) &&
+                Objects.equals(Catalog.getCompatibleTableUUID(this.tableUUID), Catalog.getCompatibleTableUUID(that.tableUUID));
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(catalogId, databaseUUID, tableUUID);
+        return Objects.hash(catalogId, Catalog.getCompatibleDbUUID(databaseUUID), Catalog.getCompatibleTableUUID(tableUUID));
     }
 
     @Override

--- a/fe/fe-core/src/test/java/com/starrocks/privilege/PrivilegeCollectionTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/privilege/PrivilegeCollectionTest.java
@@ -286,17 +286,17 @@ public class PrivilegeCollectionTest {
         PEntryObject table5 = new TablePEntryObject(101, "hive.db", "hive.db.tbl.123");
         PEntryObject table6 = new TablePEntryObject(101, "hive", "tbl");
         Assert.assertFalse(table5.match(table6));
-        Assert.assertEquals(table5, table6);
+        Assert.assertNotEquals(table5, table6);
 
         PEntryObject table7 = new TablePEntryObject(101, "hive.db", "hive.db.tbl.123");
         PEntryObject table8 = new TablePEntryObject(101, "db", "123");
         Assert.assertFalse(table7.match(table8));
-        Assert.assertEquals(table7, table8);
+        Assert.assertNotEquals(table7, table8);
 
         PEntryObject table9 = new TablePEntryObject(101, "hive.db", "hive.db.tbl.123");
         PEntryObject table10 = new TablePEntryObject(101, "db", "hive");
         Assert.assertFalse(table9.match(table10));
-        Assert.assertEquals(table9, table10);
+        Assert.assertNotEquals(table9, table10);
     }
 
     @Test
@@ -316,9 +316,9 @@ public class PrivilegeCollectionTest {
     public void testBasicForExternalTable() throws PrivilegeException {
         PrivilegeCollectionV2 collection = new PrivilegeCollectionV2();
         // pentry of external table in old format
-        TablePEntryObject table1 = new TablePEntryObject(101, "db", "tbl");
+        TablePEntryObject table1 = new TablePEntryObject(101, "hive.db", "hive.db.tbl.123");
         // pentry of external table in new format
-        TablePEntryObject table2 = new TablePEntryObject(101, "hive.db", "hive.db.tbl.123");
+        TablePEntryObject table2 = new TablePEntryObject(101, "db", "tbl");
 
         // test interoperability of old & new format
         List<PEntryObject> toGrantWithPEntryList = ImmutableList.of(table1, table2, table1, table2);

--- a/fe/fe-core/src/test/java/com/starrocks/privilege/PrivilegeCollectionTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/privilege/PrivilegeCollectionTest.java
@@ -277,6 +277,7 @@ public class PrivilegeCollectionTest {
         PEntryObject table2 = new TablePEntryObject(101, "db", "tbl");
         Assert.assertTrue(table1.match(table2));
         Assert.assertEquals(table1, table2);
+        Assert.assertEquals(table1.hashCode(), table2.hashCode());
 
         PEntryObject table3 = new TablePEntryObject(101, "hive.db", "hive.db.tbl.123");
         PEntryObject table4 = new TablePEntryObject(101, "db", "db");
@@ -305,6 +306,7 @@ public class PrivilegeCollectionTest {
         PEntryObject db2 = new DbPEntryObject(101, "db");
         Assert.assertTrue(db1.match(db2));
         Assert.assertEquals(db1, db2);
+        Assert.assertEquals(db1.hashCode(), db2.hashCode());
 
         PEntryObject db3 = new DbPEntryObject(101, "hive.db");
         PEntryObject db4 = new DbPEntryObject(101, "hive");

--- a/fe/fe-core/src/test/java/com/starrocks/privilege/PrivilegeCollectionTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/privilege/PrivilegeCollectionTest.java
@@ -15,11 +15,13 @@
 
 package com.starrocks.privilege;
 
+import com.google.common.collect.ImmutableList;
 import org.junit.Assert;
 import org.junit.Test;
 
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.List;
 
 public class PrivilegeCollectionTest {
 
@@ -267,5 +269,79 @@ public class PrivilegeCollectionTest {
 
         clonedEntry.actionSet.remove(new ActionSet(Arrays.asList(insert)));
         Assert.assertTrue(entry.actionSet.contains(insert));
+    }
+
+    @Test
+    public void testTablePEntryCompatibilityForExternalTable() {
+        TablePEntryObject table1 = new TablePEntryObject(101, "hive.db", "hive.db.tbl.123");
+        TablePEntryObject table2 = new TablePEntryObject(101, "db", "tbl");
+        Assert.assertTrue(table1.match(table2));
+
+        TablePEntryObject table3 = new TablePEntryObject(101, "hive.db", "hive.db.tbl.123");
+        TablePEntryObject table4 = new TablePEntryObject(101, "db", "db");
+        Assert.assertFalse(table3.match(table4));
+
+        TablePEntryObject table5 = new TablePEntryObject(101, "hive.db", "hive.db.tbl.123");
+        TablePEntryObject table6 = new TablePEntryObject(101, "hive", "tbl");
+        Assert.assertFalse(table5.match(table6));
+
+        TablePEntryObject table7 = new TablePEntryObject(101, "hive.db", "hive.db.tbl.123");
+        TablePEntryObject table8 = new TablePEntryObject(101, "db", "123");
+        Assert.assertFalse(table7.match(table8));
+
+        TablePEntryObject table9 = new TablePEntryObject(101, "hive.db", "hive.db.tbl.123");
+        TablePEntryObject table10 = new TablePEntryObject(101, "db", "hive");
+        Assert.assertFalse(table9.match(table10));
+    }
+
+    @Test
+    public void testBasicForExternalTable() throws PrivilegeException {
+        PrivilegeCollectionV2 collection = new PrivilegeCollectionV2();
+        // pentry of external table in old format
+        TablePEntryObject table1 = new TablePEntryObject(101, "db", "tbl");
+        // pentry of external table in new format
+        TablePEntryObject table2 = new TablePEntryObject(101, "hive.db", "hive.db.tbl.123");
+
+        // test interoperability of old & new format
+        List<PEntryObject> toGrantWithPEntryList = ImmutableList.of(table1, table2, table1, table2);
+        List<PEntryObject> toRevokeWithPEntryList = ImmutableList.of(table1, table2, table2, table1);
+
+        for (int i = 0; i < toGrantWithPEntryList.size(); i++) {
+            PEntryObject toGrant = toGrantWithPEntryList.get(i);
+            PEntryObject toRevoke = toRevokeWithPEntryList.get(i);
+            Assert.assertFalse(collection.check(ObjectType.TABLE, PrivilegeType.SELECT, table1));
+            Assert.assertFalse(collection.check(ObjectType.TABLE, PrivilegeType.SELECT, table2));
+            collection.grant(ObjectType.TABLE, ImmutableList.of(PrivilegeType.SELECT), ImmutableList.of(toGrant), false);
+            Assert.assertTrue(collection.check(ObjectType.TABLE, PrivilegeType.SELECT, table1));
+            Assert.assertTrue(collection.check(ObjectType.TABLE, PrivilegeType.SELECT, table2));
+            collection.revoke(ObjectType.TABLE, ImmutableList.of(PrivilegeType.SELECT), ImmutableList.of(toRevoke));
+            Assert.assertEquals(0, collection.typeToPrivilegeEntryList.size());
+        }
+    }
+
+    @Test
+    public void testBasicForExternalDatabase() throws PrivilegeException {
+        PrivilegeCollectionV2 collection = new PrivilegeCollectionV2();
+
+        // pentry of external database in old format
+        DbPEntryObject db1 = new DbPEntryObject(101, "hive.db");
+        // pentry of external database in new format
+        DbPEntryObject db2 = new DbPEntryObject(101, "db");
+
+        // test interoperability of old & new format
+        List<PEntryObject> toGrantWithPEntryList = ImmutableList.of(db1, db2, db1, db2);
+        List<PEntryObject> toRevokeWithPEntryList = ImmutableList.of(db1, db2, db2, db1);
+
+        for (int i = 0; i < toGrantWithPEntryList.size(); i++) {
+            PEntryObject toGrant = toGrantWithPEntryList.get(i);
+            PEntryObject toRevoke = toRevokeWithPEntryList.get(i);
+            Assert.assertFalse(collection.check(ObjectType.DATABASE, PrivilegeType.DROP, db1));
+            Assert.assertFalse(collection.check(ObjectType.DATABASE, PrivilegeType.DROP, db2));
+            collection.grant(ObjectType.DATABASE, ImmutableList.of(PrivilegeType.DROP), ImmutableList.of(toGrant), false);
+            Assert.assertTrue(collection.check(ObjectType.DATABASE, PrivilegeType.DROP, db1));
+            Assert.assertTrue(collection.check(ObjectType.DATABASE, PrivilegeType.DROP, db2));
+            collection.revoke(ObjectType.DATABASE, ImmutableList.of(PrivilegeType.DROP), ImmutableList.of(toRevoke));
+            Assert.assertEquals(0, collection.typeToPrivilegeEntryList.size());
+        }
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/privilege/PrivilegeCollectionTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/privilege/PrivilegeCollectionTest.java
@@ -272,26 +272,44 @@ public class PrivilegeCollectionTest {
     }
 
     @Test
-    public void testTablePEntryCompatibilityForExternalTable() {
-        TablePEntryObject table1 = new TablePEntryObject(101, "hive.db", "hive.db.tbl.123");
-        TablePEntryObject table2 = new TablePEntryObject(101, "db", "tbl");
+    public void testPEntryCompatibilityForExternalTable() {
+        PEntryObject table1 = new TablePEntryObject(101, "hive.db", "hive.db.tbl.123");
+        PEntryObject table2 = new TablePEntryObject(101, "db", "tbl");
         Assert.assertTrue(table1.match(table2));
+        Assert.assertEquals(table1, table2);
 
-        TablePEntryObject table3 = new TablePEntryObject(101, "hive.db", "hive.db.tbl.123");
-        TablePEntryObject table4 = new TablePEntryObject(101, "db", "db");
+        PEntryObject table3 = new TablePEntryObject(101, "hive.db", "hive.db.tbl.123");
+        PEntryObject table4 = new TablePEntryObject(101, "db", "db");
         Assert.assertFalse(table3.match(table4));
+        Assert.assertNotEquals(table3, table4);
 
-        TablePEntryObject table5 = new TablePEntryObject(101, "hive.db", "hive.db.tbl.123");
-        TablePEntryObject table6 = new TablePEntryObject(101, "hive", "tbl");
+        PEntryObject table5 = new TablePEntryObject(101, "hive.db", "hive.db.tbl.123");
+        PEntryObject table6 = new TablePEntryObject(101, "hive", "tbl");
         Assert.assertFalse(table5.match(table6));
+        Assert.assertEquals(table5, table6);
 
-        TablePEntryObject table7 = new TablePEntryObject(101, "hive.db", "hive.db.tbl.123");
-        TablePEntryObject table8 = new TablePEntryObject(101, "db", "123");
+        PEntryObject table7 = new TablePEntryObject(101, "hive.db", "hive.db.tbl.123");
+        PEntryObject table8 = new TablePEntryObject(101, "db", "123");
         Assert.assertFalse(table7.match(table8));
+        Assert.assertEquals(table7, table8);
 
-        TablePEntryObject table9 = new TablePEntryObject(101, "hive.db", "hive.db.tbl.123");
-        TablePEntryObject table10 = new TablePEntryObject(101, "db", "hive");
+        PEntryObject table9 = new TablePEntryObject(101, "hive.db", "hive.db.tbl.123");
+        PEntryObject table10 = new TablePEntryObject(101, "db", "hive");
         Assert.assertFalse(table9.match(table10));
+        Assert.assertEquals(table9, table10);
+    }
+
+    @Test
+    public void testPEntryCompatibilityForExternalDb() {
+        PEntryObject db1 = new DbPEntryObject(101, "hive.db");
+        PEntryObject db2 = new DbPEntryObject(101, "db");
+        Assert.assertTrue(db1.match(db2));
+        Assert.assertEquals(db1, db2);
+
+        PEntryObject db3 = new DbPEntryObject(101, "hive.db");
+        PEntryObject db4 = new DbPEntryObject(101, "hive");
+        Assert.assertFalse(db3.match(db4));
+        Assert.assertNotEquals(db3, db4);
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/PrivilegeCheckerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/PrivilegeCheckerTest.java
@@ -548,7 +548,8 @@ public class PrivilegeCheckerTest {
         dbPEntryObject = DbPEntryObject.generate(GlobalStateMgr.getCurrentState(), List.of("test_iceberg", "iceberg_db"));
         Assert.assertEquals(dbPEntryObject.getUUID(), "iceberg_db");
         Assert.assertTrue(dbPEntryObject.validate(GlobalStateMgr.getCurrentState()));
-        tablePEntryObject = TablePEntryObject.generate(GlobalStateMgr.getCurrentState(), List.of("test_iceberg", "iceberg_db", "iceberg_tbl"));
+        tablePEntryObject = TablePEntryObject.generate(GlobalStateMgr.getCurrentState(),
+                List.of("test_iceberg", "iceberg_db", "iceberg_tbl"));
         Assert.assertEquals(tablePEntryObject.getDatabaseUUID(), "iceberg_db");
         Assert.assertEquals(tablePEntryObject.getTableUUID(), "iceberg_tbl");
         Assert.assertTrue(tablePEntryObject.validate(GlobalStateMgr.getCurrentState()));

--- a/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/PrivilegeCheckerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/PrivilegeCheckerTest.java
@@ -544,6 +544,14 @@ public class PrivilegeCheckerTest {
         TablePEntryObject tablePEntryObject = TablePEntryObject.generate(GlobalStateMgr.getCurrentState(),
                 List.of("test_iceberg", "*", "*"));
         Assert.assertTrue(tablePEntryObject.validate(GlobalStateMgr.getCurrentState()));
+
+        dbPEntryObject = DbPEntryObject.generate(GlobalStateMgr.getCurrentState(), List.of("test_iceberg", "iceberg_db"));
+        Assert.assertEquals(dbPEntryObject.getUUID(), "iceberg_db");
+        Assert.assertTrue(dbPEntryObject.validate(GlobalStateMgr.getCurrentState()));
+        tablePEntryObject = TablePEntryObject.generate(GlobalStateMgr.getCurrentState(), List.of("test_iceberg", "iceberg_db", "iceberg_tbl"));
+        Assert.assertEquals(tablePEntryObject.getDatabaseUUID(), "iceberg_db");
+        Assert.assertEquals(tablePEntryObject.getTableUUID(), "iceberg_tbl");
+        Assert.assertTrue(tablePEntryObject.validate(GlobalStateMgr.getCurrentState()));
     }
 
     @Test


### PR DESCRIPTION
## Why I'm doing:

The privilege entry could not be found due to incorrect implementation of `match` and `equals`.

## What I'm doing:

Fix the privilege compatibility issue of external tables.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [x] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
