### PR TITLE
[Enhancement] optimize hudi table metadata fetch remote files

### DIFF
--- a/fe/fe-core/pom.xml
+++ b/fe/fe-core/pom.xml
@@ -673,42 +673,6 @@ under the License.
                     <artifactId>*</artifactId>
                 </exclusion>
                 <exclusion>
-                    <groupId>org.apache.hbase</groupId>
-                    <artifactId>hbase-server</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>org.apache.hbase</groupId>
-                    <artifactId>hbase-hadoop-compat</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>org.apache.hbase</groupId>
-                    <artifactId>hbase-hadoop2-compat</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>org.apache.hbase</groupId>
-                    <artifactId>hbase-protocol-shaded</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>org.apache.hbase</groupId>
-                    <artifactId>hbase-protocol</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>org.apache.hbase.thirdparty</groupId>
-                    <artifactId>hbase-shaded-protobuf</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>org.apache.hbase.thirdparty</groupId>
-                    <artifactId>hbase-shaded-gson</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>org.apache.hbase.thirdparty</groupId>
-                    <artifactId>hbase-shaded-miscellaneous</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>org.apache.hbase.thirdparty</groupId>
-                    <artifactId>hbase-shaded-netty</artifactId>
-                </exclusion>
-                <exclusion>
                     <groupId>org.glassfish</groupId>
                     <artifactId>javax.el</artifactId>
                 </exclusion>
@@ -982,7 +946,8 @@ under the License.
                     <!-->not reuse forked jvm, so that each unit test will run in separate jvm. to avoid singleton confict<-->
                     <reuseForks>false</reuseForks>
                     <argLine>
-                        -javaagent:${settings.localRepository}/com/github/hazendaz/jmockit/jmockit/1.49.4/jmockit-1.49.4.jar -Xmx4096m
+                        -javaagent:${settings.localRepository}/com/github/hazendaz/jmockit/jmockit/1.49.4/jmockit-1.49.4.jar
+                        -Xmx4096m
                         -Duser.timezone=Asia/Shanghai @{jacocoArgLine}
                     </argLine>
                     <!-- Set maven to use independent class loading to avoid unit test failure due to the early shutdown of the JVM -->

--- a/fe/fe-core/src/main/java/com/starrocks/connector/RemoteFileDesc.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/RemoteFileDesc.java
@@ -18,6 +18,7 @@ import com.google.common.collect.ImmutableList;
 import com.starrocks.connector.hive.TextFileFormatDesc;
 import com.starrocks.connector.odps.OdpsSplitsInfo;
 import com.starrocks.connector.paimon.PaimonSplitsInfo;
+import org.apache.hudi.common.table.timeline.HoodieInstant;
 import org.apache.iceberg.FileScanTask;
 
 import java.util.ArrayList;
@@ -42,7 +43,7 @@ public class RemoteFileDesc {
     private PaimonSplitsInfo paimonSplitsInfo;
     private OdpsSplitsInfo odpsSplitsInfo;
 
-    public String hudiInstantTimestamp;
+    private HoodieInstant hudiInstant;
 
     private RemoteFileDesc(String fileName, String compression, long length, long modificationTime,
                            ImmutableList<RemoteFileBlockDesc> blockDescs, ImmutableList<String> hudiDeltaLogs,
@@ -142,6 +143,14 @@ public class RemoteFileDesc {
 
     public OdpsSplitsInfo getOdpsSplitsInfo() {
         return odpsSplitsInfo;
+    }
+
+    public HoodieInstant getHudiInstant() {
+        return hudiInstant;
+    }
+
+    public void setHudiInstant(HoodieInstant instant) {
+        hudiInstant = instant;
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/connector/RemoteFileDesc.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/RemoteFileDesc.java
@@ -42,6 +42,8 @@ public class RemoteFileDesc {
     private PaimonSplitsInfo paimonSplitsInfo;
     private OdpsSplitsInfo odpsSplitsInfo;
 
+    public String hudiInstantTimestamp;
+
     private RemoteFileDesc(String fileName, String compression, long length, long modificationTime,
                            ImmutableList<RemoteFileBlockDesc> blockDescs, ImmutableList<String> hudiDeltaLogs,
                            List<FileScanTask> icebergScanTasks, PaimonSplitsInfo paimonSplitsInfo,

--- a/fe/fe-core/src/main/java/com/starrocks/connector/RemoteFileOperations.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/RemoteFileOperations.java
@@ -108,7 +108,7 @@ public class RemoteFileOperations {
         try (Timer ignored = Tracers.watchScope(Tracers.Module.EXTERNAL, HMS_PARTITIONS_REMOTE_FILES)) {
             for (Partition partition : partitions) {
                 RemotePathKey pathKey = RemotePathKey.of(partition.getFullPath(), isRecursive, hudiTableLocation);
-                pathKey.hudiContext = hudiContext;
+                pathKey.setHudiContext(hudiContext);
                 Future<Map<RemotePathKey, List<RemoteFileDesc>>> future = pullRemoteFileExecutor.submit(() ->
                         remoteFileIO.getRemoteFiles(pathKey, useCache));
                 futures.add(future);

--- a/fe/fe-core/src/main/java/com/starrocks/connector/RemoteFileOperations.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/RemoteFileOperations.java
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-
 package com.starrocks.connector;
 
 import com.google.common.collect.Lists;
@@ -103,10 +102,13 @@ public class RemoteFileOperations {
         List<Future<Map<RemotePathKey, List<RemoteFileDesc>>>> futures = Lists.newArrayList();
         List<Map<RemotePathKey, List<RemoteFileDesc>>> result = Lists.newArrayList();
 
+        RemotePathKey.HudiContext hudiContext = new RemotePathKey.HudiContext();
+
         Tracers.count(Tracers.Module.EXTERNAL, HMS_PARTITIONS_REMOTE_FILES, cacheMissSize);
         try (Timer ignored = Tracers.watchScope(Tracers.Module.EXTERNAL, HMS_PARTITIONS_REMOTE_FILES)) {
             for (Partition partition : partitions) {
                 RemotePathKey pathKey = RemotePathKey.of(partition.getFullPath(), isRecursive, hudiTableLocation);
+                pathKey.hudiContext = hudiContext;
                 Future<Map<RemotePathKey, List<RemoteFileDesc>>> future = pullRemoteFileExecutor.submit(() ->
                         remoteFileIO.getRemoteFiles(pathKey, useCache));
                 futures.add(future);

--- a/fe/fe-core/src/main/java/com/starrocks/connector/RemotePathKey.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/RemotePathKey.java
@@ -14,6 +14,7 @@
 
 package com.starrocks.connector;
 
+import org.apache.hudi.common.table.timeline.HoodieInstant;
 import org.apache.hudi.common.table.timeline.HoodieTimeline;
 import org.apache.hudi.common.table.view.HoodieTableFileSystemView;
 
@@ -30,14 +31,16 @@ public class RemotePathKey {
     private final Optional<String> hudiTableLocation;
 
     public static class HudiContext {
-        public AtomicBoolean initialized = new AtomicBoolean(false);
+        // ---- concurrent initialization -----
+        public AtomicBoolean init = new AtomicBoolean(false);
         public ReentrantLock lock = new ReentrantLock();
-        public HoodieTableFileSystemView fsView;
-        public HoodieTimeline timeline;
-        public String timestamp;
+        // ---- actual fields -----
+        public HoodieTableFileSystemView fsView = null;
+        public HoodieTimeline timeline = null;
+        public HoodieInstant lastInstant = null;
     }
 
-    public HudiContext hudiContext;
+    private HudiContext hudiContext;
 
     public static RemotePathKey of(String path, boolean isRecursive) {
         return new RemotePathKey(path, isRecursive, Optional.empty());
@@ -106,5 +109,13 @@ public class RemotePathKey {
         if (hudiContext != null) {
             hudiContext = null;
         }
+    }
+
+    public void setHudiContext(HudiContext ctx) {
+        hudiContext = ctx;
+    }
+
+    public HudiContext getHudiContext() {
+        return hudiContext;
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/connector/hive/HiveMetastoreApiConverter.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/hive/HiveMetastoreApiConverter.java
@@ -317,7 +317,8 @@ public class HiveMetastoreApiConverter {
                 .setPartitionColNames(partitionColumnNames)
                 .setDataColNames(toDataColumnNamesForHudiTable(hudiSchema, partitionColumnNames))
                 .setHudiProperties(toHudiProperties(table, metaClient, hudiSchema))
-                .setCreateTime(table.getCreateTime());
+                .setCreateTime(table.getCreateTime())
+                .setTableType(HudiTable.fromInputFormat(table.getSd().getInputFormat()));
 
         return tableBuilder.build();
     }

--- a/fe/fe-core/src/main/java/com/starrocks/connector/hudi/HudiRemoteFileIO.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/hudi/HudiRemoteFileIO.java
@@ -33,7 +33,7 @@ import org.apache.hudi.common.model.HoodieLogFile;
 import org.apache.hudi.common.table.HoodieTableMetaClient;
 import org.apache.hudi.common.table.timeline.HoodieInstant;
 import org.apache.hudi.common.table.timeline.HoodieTimeline;
-import org.apache.hudi.common.table.view.HoodieTableFileSystemView;
+import org.apache.hudi.common.util.Option;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -58,12 +58,12 @@ public class HudiRemoteFileIO implements RemoteFileIO {
     }
 
     private void createHudiContext(RemotePathKey.HudiContext ctx, String hudiTableLocation) {
-        if (ctx.initialized.get()) {
+        if (ctx.init.get()) {
             return;
         }
         try {
             ctx.lock.lock();
-            if (ctx.initialized.get()) {
+            if (ctx.init.get()) {
                 return;
             }
             HoodieLocalEngineContext engineContext = new HoodieLocalEngineContext(configuration);
@@ -72,15 +72,13 @@ public class HudiRemoteFileIO implements RemoteFileIO {
                     HoodieTableMetaClient.builder().setConf(configuration).setBasePath(hudiTableLocation).build();
             // metaClient.reloadActiveTimeline();
             HoodieTimeline timeline = metaClient.getCommitsAndCompactionTimeline().filterCompletedInstants();
-            String timestamp = timeline.lastInstant().map(HoodieInstant::getTimestamp).orElse(null);
-            HoodieTableFileSystemView fsView = null;
-            if (timestamp != null) {
-                fsView = createInMemoryFileSystemViewWithTimeline(engineContext, metaClient, metadataConfig, timeline);
+            Option<HoodieInstant> lastInstant = timeline.lastInstant();
+            if (lastInstant.isPresent()) {
+                ctx.fsView = createInMemoryFileSystemViewWithTimeline(engineContext, metaClient, metadataConfig, timeline);
+                ctx.lastInstant = lastInstant.get();
+                ctx.timeline = timeline;
             }
-            ctx.fsView = fsView;
-            ctx.timestamp = timestamp;
-            ctx.timeline = timeline;
-            ctx.initialized.set(true);
+            ctx.init.set(true);
         } finally {
             ctx.lock.unlock();
         }
@@ -97,15 +95,15 @@ public class HudiRemoteFileIO implements RemoteFileIO {
         ImmutableMap.Builder<RemotePathKey, List<RemoteFileDesc>> resultPartitions = ImmutableMap.builder();
         List<RemoteFileDesc> fileDescs = Lists.newArrayList();
 
-        RemotePathKey.HudiContext hudiContext = pathKey.hudiContext;
+        RemotePathKey.HudiContext hudiContext = pathKey.getHudiContext();
         createHudiContext(hudiContext, tableLocation);
-        if (hudiContext.timestamp == null) {
+        if (hudiContext.lastInstant == null) {
             return resultPartitions.put(pathKey, fileDescs).build();
         }
 
         try {
             Iterator<FileSlice> hoodieFileSliceIterator = hudiContext.fsView
-                    .getLatestMergedFileSlicesBeforeOrOn(partitionName, hudiContext.timestamp).iterator();
+                    .getLatestMergedFileSlicesBeforeOrOn(partitionName, hudiContext.lastInstant.getTimestamp()).iterator();
             while (hoodieFileSliceIterator.hasNext()) {
                 FileSlice fileSlice = hoodieFileSliceIterator.next();
                 Optional<HoodieBaseFile> baseFile = fileSlice.getBaseFile().toJavaOptional();
@@ -115,7 +113,7 @@ public class HudiRemoteFileIO implements RemoteFileIO {
                 // The file name of HoodieBaseFile contains "instantTime", so we set the `modificationTime` to 0.
                 RemoteFileDesc res = new RemoteFileDesc(fileName, "", fileLength, 0,
                         ImmutableList.of(), ImmutableList.copyOf(logs));
-                res.hudiInstantTimestamp = hudiContext.timestamp;
+                res.setHudiInstant(hudiContext.lastInstant);
                 fileDescs.add(res);
             }
         } catch (Exception e) {

--- a/fe/fe-core/src/main/java/com/starrocks/connector/hudi/HudiRemoteFileIO.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/hudi/HudiRemoteFileIO.java
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-
 package com.starrocks.connector.hudi;
 
 import com.google.common.collect.ImmutableList;
@@ -23,8 +22,9 @@ import com.starrocks.connector.RemoteFileIO;
 import com.starrocks.connector.RemotePathKey;
 import com.starrocks.connector.exception.StarRocksConnectorException;
 import org.apache.hadoop.conf.Configuration;
-import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.Path;
+import org.apache.hudi.common.config.HoodieMetadataConfig;
+import org.apache.hudi.common.engine.HoodieLocalEngineContext;
 import org.apache.hudi.common.fs.FSUtils;
 import org.apache.hudi.common.model.BaseFile;
 import org.apache.hudi.common.model.FileSlice;
@@ -34,7 +34,6 @@ import org.apache.hudi.common.table.HoodieTableMetaClient;
 import org.apache.hudi.common.table.timeline.HoodieInstant;
 import org.apache.hudi.common.table.timeline.HoodieTimeline;
 import org.apache.hudi.common.table.view.HoodieTableFileSystemView;
-import org.apache.hudi.common.util.Option;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -45,6 +44,8 @@ import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.stream.Collectors;
 
+import static org.apache.hudi.common.table.view.FileSystemViewManager.createInMemoryFileSystemViewWithTimeline;
+
 public class HudiRemoteFileIO implements RemoteFileIO {
     private static final Logger LOG = LogManager.getLogger(HudiRemoteFileIO.class);
     private final Configuration configuration;
@@ -54,6 +55,35 @@ public class HudiRemoteFileIO implements RemoteFileIO {
 
     public HudiRemoteFileIO(Configuration configuration) {
         this.configuration = configuration;
+    }
+
+    private void createHudiContext(RemotePathKey.HudiContext ctx, String hudiTableLocation) {
+        if (ctx.initialized.get()) {
+            return;
+        }
+        try {
+            ctx.lock.lock();
+            if (ctx.initialized.get()) {
+                return;
+            }
+            HoodieLocalEngineContext engineContext = new HoodieLocalEngineContext(configuration);
+            HoodieMetadataConfig metadataConfig = HoodieMetadataConfig.newBuilder().enable(true).build();
+            HoodieTableMetaClient metaClient =
+                    HoodieTableMetaClient.builder().setConf(configuration).setBasePath(hudiTableLocation).build();
+            // metaClient.reloadActiveTimeline();
+            HoodieTimeline timeline = metaClient.getCommitsAndCompactionTimeline().filterCompletedInstants();
+            String timestamp = timeline.lastInstant().map(HoodieInstant::getTimestamp).orElse(null);
+            HoodieTableFileSystemView fsView = null;
+            if (timestamp != null) {
+                fsView = createInMemoryFileSystemViewWithTimeline(engineContext, metaClient, metadataConfig, timeline);
+            }
+            ctx.fsView = fsView;
+            ctx.timestamp = timestamp;
+            ctx.timeline = timeline;
+            ctx.initialized.set(true);
+        } finally {
+            ctx.lock.unlock();
+        }
     }
 
     @Override
@@ -67,23 +97,15 @@ public class HudiRemoteFileIO implements RemoteFileIO {
         ImmutableMap.Builder<RemotePathKey, List<RemoteFileDesc>> resultPartitions = ImmutableMap.builder();
         List<RemoteFileDesc> fileDescs = Lists.newArrayList();
 
-        HoodieTableMetaClient metaClient = hudiClients.computeIfAbsent(tableLocation, ignored ->
-                HoodieTableMetaClient.builder().setConf(configuration).setBasePath(tableLocation).build()
-        );
-        metaClient.reloadActiveTimeline();
-        HoodieTimeline timeline = metaClient.getCommitsAndCompactionTimeline().filterCompletedInstants();
-        Option<HoodieInstant> latestInstant = timeline.lastInstant();
-        if (!latestInstant.isPresent()) {
+        RemotePathKey.HudiContext hudiContext = pathKey.hudiContext;
+        createHudiContext(hudiContext, tableLocation);
+        if (hudiContext.timestamp == null) {
             return resultPartitions.put(pathKey, fileDescs).build();
         }
+
         try {
-            String globPath = String.format("%s/%s/*", metaClient.getBasePath(), partitionName);
-            List<FileStatus> statuses = FSUtils.getGlobStatusExcludingMetaFolder(metaClient.getRawFs(), new Path(globPath));
-            HoodieTableFileSystemView fileSystemView = new HoodieTableFileSystemView(metaClient,
-                    timeline, statuses.toArray(new FileStatus[0]));
-            String queryInstant = latestInstant.get().getTimestamp();
-            Iterator<FileSlice> hoodieFileSliceIterator = fileSystemView
-                    .getLatestMergedFileSlicesBeforeOrOn(partitionName, queryInstant).iterator();
+            Iterator<FileSlice> hoodieFileSliceIterator = hudiContext.fsView
+                    .getLatestMergedFileSlicesBeforeOrOn(partitionName, hudiContext.timestamp).iterator();
             while (hoodieFileSliceIterator.hasNext()) {
                 FileSlice fileSlice = hoodieFileSliceIterator.next();
                 Optional<HoodieBaseFile> baseFile = fileSlice.getBaseFile().toJavaOptional();
@@ -91,8 +113,10 @@ public class HudiRemoteFileIO implements RemoteFileIO {
                 long fileLength = baseFile.map(BaseFile::getFileLen).orElse(-1L);
                 List<String> logs = fileSlice.getLogFiles().map(HoodieLogFile::getFileName).collect(Collectors.toList());
                 // The file name of HoodieBaseFile contains "instantTime", so we set the `modificationTime` to 0.
-                fileDescs.add(new RemoteFileDesc(fileName, "", fileLength, 0,
-                        ImmutableList.of(), ImmutableList.copyOf(logs)));
+                RemoteFileDesc res = new RemoteFileDesc(fileName, "", fileLength, 0,
+                        ImmutableList.of(), ImmutableList.copyOf(logs));
+                res.hudiInstantTimestamp = hudiContext.timestamp;
+                fileDescs.add(res);
             }
         } catch (Exception e) {
             LOG.error("Failed to get hudi remote file's metadata on path: {}", partitionPath, e);


### PR DESCRIPTION
## Why I'm doing:

Two points:
- When we fetch remote files from hudi table, for each partition, we create `FsView` everytime,  which is unecessary. We only need to create one time for this query
- When calling `toThrift`, we create `MetaClient` to get lastInstant, which is also unecessary, because we can save it in remote files.

## What I'm doing:

Reuse `fsView` and `metaClient` during query. 

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [x] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
