### PR TITLE
[BugFix] Fix race condition issue in PrimaryIndex::memory_usage()

### DIFF
--- a/be/src/storage/persistent_index.h
+++ b/be/src/storage/persistent_index.h
@@ -479,7 +479,9 @@ public:
     size_t memory_usage() {
         size_t mem_usage = 0;
         for (auto& bf : _bf_vec) {
-            mem_usage += bf->size();
+            if (bf != nullptr) {
+                mem_usage += bf->size();
+            }
         }
         return mem_usage;
     }

--- a/be/src/storage/persistent_index.h
+++ b/be/src/storage/persistent_index.h
@@ -784,6 +784,8 @@ public:
 
     Status pk_dump(PrimaryKeyDump* dump, PrimaryIndexMultiLevelPB* dump_pb);
 
+    void test_calc_memory_usage() { return _calc_memory_usage(); }
+
 protected:
     Status _delete_expired_index_file(const EditVersion& l0_version, const EditVersion& l1_version,
                                       const EditVersionWithMerge& min_l2_version);

--- a/be/src/storage/primary_index.cpp
+++ b/be/src/storage/primary_index.cpp
@@ -1502,6 +1502,7 @@ Status PrimaryIndex::get(const Column& key_col, std::vector<uint64_t>* rowids) c
 }
 
 std::size_t PrimaryIndex::memory_usage() const {
+    std::lock_guard<std::mutex> lg(_lock);
     if (_persistent_index) {
         return _persistent_index->memory_usage();
     }

--- a/be/src/storage/primary_index.cpp
+++ b/be/src/storage/primary_index.cpp
@@ -1069,6 +1069,7 @@ Status PrimaryIndex::load(Tablet* tablet) {
             LOG(WARNING) << CurrentThread::mem_tracker()->debug_string();
         }
     }
+    _calc_memory_usage();
     return _status;
 }
 
@@ -1086,6 +1087,7 @@ void PrimaryIndex::unload() {
     }
     _status = Status::OK();
     _loaded = false;
+    _calc_memory_usage();
 }
 
 static string int_list_to_string(const vector<uint32_t>& l) {
@@ -1112,6 +1114,7 @@ Status PrimaryIndex::commit(PersistentIndexMetaPB* index_meta) {
     if (_persistent_index != nullptr) {
         return _persistent_index->commit(index_meta);
     }
+    _calc_memory_usage();
     return Status::OK();
 }
 
@@ -1502,11 +1505,7 @@ Status PrimaryIndex::get(const Column& key_col, std::vector<uint64_t>* rowids) c
 }
 
 std::size_t PrimaryIndex::memory_usage() const {
-    std::lock_guard<std::mutex> lg(const_cast<std::mutex&>(_lock));
-    if (_persistent_index) {
-        return _persistent_index->memory_usage();
-    }
-    return _pkey_to_rssid_rowid ? _pkey_to_rssid_rowid->memory_usage() : 0;
+    return _memory_usage.load();
 }
 
 std::size_t PrimaryIndex::size() const {
@@ -1565,6 +1564,7 @@ Status PrimaryIndex::reset(Tablet* tablet, EditVersion version, PersistentIndexM
         _pkey_to_rssid_rowid = create_hash_index(_enc_pk_type, _key_size);
     }
     _loaded = true;
+    _calc_memory_usage();
 
     return Status::OK();
 }
@@ -1584,6 +1584,16 @@ Status PrimaryIndex::pk_dump(PrimaryKeyDump* dump, PrimaryIndexMultiLevelPB* dum
         RETURN_IF_ERROR(_pkey_to_rssid_rowid->pk_dump(dump, level));
     }
     return Status::OK();
+}
+
+void PrimaryIndex::_calc_memory_usage() {
+    size_t memory_usage = 0;
+    if (_persistent_index) {
+        memory_usage = _persistent_index->memory_usage();
+    } else {
+        memory_usage = _pkey_to_rssid_rowid ? _pkey_to_rssid_rowid->memory_usage() : 0;
+    }
+    _memory_usage.store(memory_usage);
 }
 
 } // namespace starrocks

--- a/be/src/storage/primary_index.cpp
+++ b/be/src/storage/primary_index.cpp
@@ -1502,7 +1502,7 @@ Status PrimaryIndex::get(const Column& key_col, std::vector<uint64_t>* rowids) c
 }
 
 std::size_t PrimaryIndex::memory_usage() const {
-    std::lock_guard<std::mutex> lg(_lock);
+    std::lock_guard<std::mutex> lg(const_cast<std::mutex&>(_lock));
     if (_persistent_index) {
         return _persistent_index->memory_usage();
     }

--- a/be/src/storage/primary_index.h
+++ b/be/src/storage/primary_index.h
@@ -193,6 +193,8 @@ private:
     Status _replace_persistent_index_by_indexes(uint32_t rssid, uint32_t rowid_start,
                                                 const std::vector<uint32_t>& replace_indexes, const Column& pks);
 
+    void _calc_memory_usage();
+
 protected:
     std::mutex _lock;
     std::atomic<bool> _loaded{false};
@@ -206,6 +208,7 @@ private:
     Schema _pk_schema;
     LogicalType _enc_pk_type = TYPE_UNKNOWN;
     std::unique_ptr<HashIndex> _pkey_to_rssid_rowid;
+    std::atomic<size_t> _memory_usage{0};
 };
 
 inline std::ostream& operator<<(std::ostream& os, const PrimaryIndex& o) {

--- a/be/test/storage/persistent_index_test.cpp
+++ b/be/test/storage/persistent_index_test.cpp
@@ -1964,7 +1964,7 @@ TEST_P(PersistentIndexTest, test_bloom_filter_for_pindex) {
         StorageEngine::instance()->update_manager()->set_keep_pindex_bf(true);
         std::vector<IndexValue> small_get_values(1);
         ASSERT_OK(index.get(1, key_slices.data(), small_get_values.data()));
-        ASSERT_EQ(values[i].get_value() * 4, small_get_values[0].get_value());
+        ASSERT_EQ(values[0].get_value() * 4, small_get_values[0].get_value());
         index.test_calc_memory_usage();
         small_get_values.clear();
         for (int i = 0; i < N; i++) {

--- a/be/test/storage/persistent_index_test.cpp
+++ b/be/test/storage/persistent_index_test.cpp
@@ -1963,10 +1963,15 @@ TEST_P(PersistentIndexTest, test_bloom_filter_for_pindex) {
 
         StorageEngine::instance()->update_manager()->set_keep_pindex_bf(true);
         std::vector<IndexValue> small_get_values(1);
+        ASSERT_OK(index.get(1, key_slices.data(), small_get_values.data()));
+        ASSERT_EQ(values[i].get_value() * 4, small_get_values[0].get_value());
+        index.test_calc_memory_usage();
+        small_get_values.clear();
         for (int i = 0; i < N; i++) {
             ASSERT_OK(index.get(1, key_slices.data() + i, small_get_values.data()));
             ASSERT_EQ(values[i].get_value() * 4, small_get_values[0].get_value());
         }
+        index.test_calc_memory_usage();
     }
     ASSERT_TRUE(fs::remove_all(kPersistentIndexDir).ok());
 }


### PR DESCRIPTION
## Why I'm doing:
There are two race condition issue when call function PrimaryIndex::memory_usage():
1. If rebuild primary index in apply compaction phase, we will clear primary index which is a read-write conflict with `memory_usage()`.
2. If the memory is not enough, we may not load all bloom filter of persistent index into memory but only load the shard we needed and there are some nullptr in `_bf_vec`.  When we call function `_memory_usage()`, we will get nullptr exception.

## What I'm doing:
Fix the bug.

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [x] 3.2
  - [x] 3.1
  - [ ] 3.0
  - [ ] 2.5
