### PR TITLE
[BugFix] Fix behavior change introduced by #43490

### DIFF
--- a/be/src/storage/delta_writer.cpp
+++ b/be/src/storage/delta_writer.cpp
@@ -344,16 +344,19 @@ void DeltaWriter::_set_state(State state, const Status& st) {
 }
 
 Status DeltaWriter::_check_partial_update_with_sort_key(const Chunk& chunk) {
-    if (_tablet->updates() != nullptr && _partial_schema_with_sort_key && _opt.slots != nullptr &&
-        _opt.slots->back()->col_name() == "__op") {
-        size_t op_column_id = chunk.num_columns() - 1;
-        const auto& op_column = chunk.get_column_by_index(op_column_id);
-        auto* ops = reinterpret_cast<const uint8_t*>(op_column->raw_data());
-        for (size_t i = 0; i < chunk.num_rows(); i++) {
-            if (ops[i] == TOpType::UPSERT) {
-                LOG(WARNING) << "table with sort key do not support partial update";
-                return Status::NotSupported("table with sort key do not support partial update");
-            }
+    if (_tablet->updates() != nullptr && _partial_schema_with_sort_key) {
+        bool ok = true;
+        if (_opt.slots != nullptr && _opt.slots->back()->col_name() == "__op") {
+            size_t op_column_id = chunk.num_columns() - 1;
+            const auto& op_column = chunk.get_column_by_index(op_column_id);
+            auto* ops = reinterpret_cast<const uint8_t*>(op_column->raw_data());
+            ok = !std::any_of(ops, ops + chunk.num_rows(), [](auto op) { return op == TOpType::UPSERT; });
+        } else {
+            ok = false;
+        }
+        if (!ok) {
+            LOG(WARNING) << "table with sort key do not support partial update";
+            return Status::NotSupported("table with sort key do not support partial update");
         }
     }
     return Status::OK();

--- a/be/src/storage/rowset_update_state.h
+++ b/be/src/storage/rowset_update_state.h
@@ -179,6 +179,7 @@ private:
     TabletSchemaCSPtr _tablet_schema = nullptr;
 
     // column_with_row partial update states
+    bool _partial_update_value_column_inited = false;
     std::vector<uint32_t> _partial_update_value_column_ids;
     // only column added by reading rowset
     Schema _partial_update_value_columns_schema;

--- a/fe/fe-core/src/main/java/com/starrocks/sql/InsertPlanner.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/InsertPlanner.java
@@ -195,7 +195,7 @@ public class InsertPlanner {
         OlapTable targetTable = (OlapTable) insertStmt.getTargetTable();
         for (Column column : targetTable.getFullSchema()) {
             String columnName = column.getName().toLowerCase();
-            if (outputColumnNames.contains(columnName)) {
+            if (outputColumnNames.contains(columnName) || column.isKey()) {
                 if (baseSchemaNames.contains(columnName)) {
                     outputBaseSchema.add(column);
                 }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/InsertAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/InsertAnalyzer.java
@@ -172,6 +172,7 @@ public class InsertAnalyzer {
         } else {
             targetColumns = new ArrayList<>();
             Set<String> requiredKeyColumns = table.getBaseSchema().stream().filter(Column::isKey)
+                    .filter(c -> c.getDefaultValueType() == Column.DefaultValueType.NULL)
                     .filter(c -> !c.isAutoIncrement()).map(c -> c.getName().toLowerCase()).collect(Collectors.toSet());
             for (String colName : insertStmt.getTargetColumnNames()) {
                 Column column = table.getColumn(colName);

--- a/test/sql/test_insert_empty/R/test_insert_partial_update
+++ b/test/sql/test_insert_empty/R/test_insert_partial_update
@@ -68,3 +68,16 @@ select * from test3 order by pk;
 2	v2	2	3
 3		3	4
 -- !result
+create table test4 (pk bigint NOT NULL, v0 string not null, v1 int not null default '0')
+primary KEY (pk) DISTRIBUTED BY HASH(pk) BUCKETS 1 order by (v1) PROPERTIES("replication_num" = "1");
+-- result:
+[]
+-- !result
+insert into test4 values(1, 'v0', 1), (2, 'v2', 2);
+-- result:
+[]
+-- !result
+insert into test4 (pk, v0) values(1, 'v0_1'), (3, 'v3_1');
+-- result:
+[REGEX].*table with sort key do not support partial update.*
+-- !result

--- a/test/sql/test_insert_empty/T/test_insert_partial_update
+++ b/test/sql/test_insert_empty/T/test_insert_partial_update
@@ -28,3 +28,10 @@ primary KEY (pk) DISTRIBUTED BY HASH(pk) BUCKETS 1 PROPERTIES("replication_num" 
 insert into test3 values(1, 'v0', 1), (2, 'v2', 2);
 insert into test3 (pk, v1) values(1, 11), (3, 3);
 select * from test3 order by pk;
+
+-- update without order by column
+create table test4 (pk bigint NOT NULL, v0 string not null, v1 int not null default '0')
+primary KEY (pk) DISTRIBUTED BY HASH(pk) BUCKETS 1 order by (v1) PROPERTIES("replication_num" = "1");
+
+insert into test4 values(1, 'v0', 1), (2, 'v2', 2);
+insert into test4 (pk, v0) values(1, 'v0_1'), (3, 'v3_1');


### PR DESCRIPTION
## Why I'm doing:

#43490 changes some behavior of insert statement to support partial update, this causes some test failure

## What I'm doing:

Fix some behavior change:

1. if a key column has default value, it can be skipped in target column list
2. if no update value columns are specified, we still allow doing partial update(even there are no columns to be updated, there is still a use case to do an `insert if not exists` with default value filled)
3. if partial update using partial update doesn't specify all columns in sorted key, an error will be raised, to align with streamload partial update behavior. 

Fixes https://github.com/StarRocks/StarRocksTest/issues/6974, https://github.com/StarRocks/StarRocksTest/issues/6977, https://github.com/StarRocks/StarRocksTest/issues/6978

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [x] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
