### PR TITLE
[Enhancement] Decrease `get_txn_status_internal_sec` to avoid introducing long delay time for stream load task

### DIFF
--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -1242,7 +1242,7 @@ CONF_mInt32(finish_publish_version_internal, "100");
 
 CONF_mBool(enable_stream_load_verbose_log, "false");
 
-CONF_mInt32(get_txn_status_internal_sec, "30");
+CONF_mInt32(get_txn_status_internal_sec, "10");
 
 CONF_mBool(dump_metrics_with_bvar, "true");
 

--- a/be/src/runtime/stream_load/stream_load_executor.cpp
+++ b/be/src/runtime/stream_load/stream_load_executor.cpp
@@ -297,9 +297,9 @@ bool wait_txn_visible_until(const AuthInfo& auth, std::string_view db, std::stri
                             int64_t deadline) {
     while (deadline > UnixSeconds()) {
         auto wait_seconds = std::min((int64_t)config::get_txn_status_internal_sec, deadline - UnixSeconds());
-        LOG(WARNING) << "commit transaction " << txn_id << " failed, will wait " << wait_seconds
-                     << " seconds before retrieving the visible status again";
-        // The following sleep might introduce delay of commit and publish total time
+        LOG(WARNING) << "transaction is not visible now, will wait " << wait_seconds
+                     << " seconds before retrieving the status again, txn_id: " << txn_id;
+        // The following sleep might introduce delay to the commit and publish total time
         sleep(wait_seconds);
         auto status_or = get_txn_status(auth, db, table, txn_id);
         if (!status_or.ok()) {

--- a/docs/en/administration/management/BE_configuration.md
+++ b/docs/en/administration/management/BE_configuration.md
@@ -4356,7 +4356,7 @@ curl http://<BE_IP>:<BE_HTTP_PORT>/varz
 <!--
 ##### get_txn_status_internal_sec
 
-- Default: 30
+- Default: 10
 - Type: Int
 - Unit: Seconds
 - Is mutable: Yes

--- a/docs/zh/administration/management/BE_configuration.md
+++ b/docs/zh/administration/management/BE_configuration.md
@@ -4300,7 +4300,7 @@ curl http://<BE_IP>:<BE_HTTP_PORT>/varz
 <!--
 ##### get_txn_status_internal_sec
 
-- 默认值：30
+- 默认值：10
 - 类型：Int
 - 单位：Seconds
 - 是否动态：是


### PR DESCRIPTION
## Why I'm doing:

The default config `get_txn_status_internal_sec`  in be is 30, which means for a stream load task, it might wait more than 30 seconds before it can retrieve the new transaction status.

This might introduce an explicit long delay in the stream load client side.

## What I'm doing:

1. Decrease the default value of `get_txn_status_internal_sec` from 30 to 10
2. Add critical warning logs when commit and publish is blocked by the waiting time introduced

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [x] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [x] 3.2
  - [x] 3.1
  - [ ] 3.0
  - [ ] 2.5
