### PR TITLE
[BugFix] Fix heap-overflow in MultiGet of sstable

### DIFF
--- a/be/src/storage/sstable/table.cpp
+++ b/be/src/storage/sstable/table.cpp
@@ -240,13 +240,12 @@ Status Table::MultiGet(const ReadOptions& options, const Slice* keys, ForwardIt 
     std::unique_ptr<Iterator> current_block_itr_ptr;
 
     // return true if find k
-    auto search_in_block = [&](const Slice& k, const size_t& index) {
-        current_block_itr_ptr->Seek(k);
-        if (current_block_itr_ptr->Valid() && k == current_block_itr_ptr->key()) {
-            (*values)[index].assign(current_block_itr_ptr->value().data, current_block_itr_ptr->value().size);
+    auto search_in_block = [](const Slice& k, std::string* value, Iterator* current_block_itr) {
+        current_block_itr->Seek(k);
+        if (current_block_itr->Valid() && k == current_block_itr->key()) {
+            value->assign(current_block_itr->value().data, current_block_itr->value().size);
             return true;
         }
-        s = current_block_itr_ptr->status();
         return false;
     };
 
@@ -255,10 +254,12 @@ Status Table::MultiGet(const ReadOptions& options, const Slice* keys, ForwardIt 
         auto& k = keys[*it];
         if (current_block_itr_ptr != nullptr && current_block_itr_ptr->Valid()) {
             // keep searching current block
-            if (search_in_block(k, i)) {
+            if (search_in_block(k, &(*values)[i], current_block_itr_ptr.get())) {
+                s = current_block_itr_ptr->status();
                 TRACE_COUNTER_INCREMENT("continue_block_read", 1);
                 continue;
             } else {
+                s = current_block_itr_ptr->status();
                 current_block_itr_ptr.reset(nullptr);
             }
         }
@@ -276,7 +277,8 @@ Status Table::MultiGet(const ReadOptions& options, const Slice* keys, ForwardIt 
                 current_block_itr_ptr.reset(BlockReader(this, options, iiter->value()));
                 auto end_ts = butil::gettimeofday_us();
                 TRACE_COUNTER_INCREMENT("read_block", end_ts - start_ts);
-                (void)search_in_block(k, i);
+                (void)search_in_block(k, &(*values)[i], current_block_itr_ptr.get());
+                s = current_block_itr_ptr->status();
             }
         }
     }

--- a/be/src/storage/sstable/table.cpp
+++ b/be/src/storage/sstable/table.cpp
@@ -240,26 +240,29 @@ Status Table::MultiGet(const ReadOptions& options, const Slice* keys, ForwardIt 
     std::unique_ptr<Iterator> current_block_itr_ptr;
 
     // return true if find k
-    auto search_in_block = [](const Slice& k, std::string* value, Iterator* current_block_itr) {
+    auto search_in_block = [](const Slice& k, std::string* value, Iterator* current_block_itr) -> StatusOr<bool> {
         current_block_itr->Seek(k);
         if (current_block_itr->Valid() && k == current_block_itr->key()) {
             value->assign(current_block_itr->value().data, current_block_itr->value().size);
             return true;
         }
+        if (!current_block_itr->status().ok()) {
+            return current_block_itr->status();
+        }
         return false;
     };
 
     size_t i = 0;
+    bool founded = false;
     for (auto it = begin; it != end; ++it, ++i) {
         auto& k = keys[*it];
         if (current_block_itr_ptr != nullptr && current_block_itr_ptr->Valid()) {
             // keep searching current block
-            if (search_in_block(k, &(*values)[i], current_block_itr_ptr.get())) {
-                s = current_block_itr_ptr->status();
+            ASSIGN_OR_RETURN(founded, search_in_block(k, &(*values)[i], current_block_itr_ptr.get()));
+            if (founded) {
                 TRACE_COUNTER_INCREMENT("continue_block_read", 1);
                 continue;
             } else {
-                s = current_block_itr_ptr->status();
                 current_block_itr_ptr.reset(nullptr);
             }
         }
@@ -277,8 +280,7 @@ Status Table::MultiGet(const ReadOptions& options, const Slice* keys, ForwardIt 
                 current_block_itr_ptr.reset(BlockReader(this, options, iiter->value()));
                 auto end_ts = butil::gettimeofday_us();
                 TRACE_COUNTER_INCREMENT("read_block", end_ts - start_ts);
-                (void)search_in_block(k, &(*values)[i], current_block_itr_ptr.get());
-                s = current_block_itr_ptr->status();
+                ASSIGN_OR_RETURN(founded, search_in_block(k, &(*values)[i], current_block_itr_ptr.get()));
             }
         }
     }

--- a/be/src/storage/sstable/table.cpp
+++ b/be/src/storage/sstable/table.cpp
@@ -251,13 +251,12 @@ Status Table::MultiGet(const ReadOptions& options, const Slice* keys, ForwardIt 
     };
 
     size_t i = 0;
-    for (auto it = begin; it != end; ++it) {
+    for (auto it = begin; it != end; ++it, ++i) {
         auto& k = keys[*it];
         if (current_block_itr_ptr != nullptr && current_block_itr_ptr->Valid()) {
             // keep searching current block
             if (search_in_block(k, i)) {
                 TRACE_COUNTER_INCREMENT("continue_block_read", 1);
-                ++i;
                 continue;
             } else {
                 current_block_itr_ptr.reset(nullptr);
@@ -280,7 +279,6 @@ Status Table::MultiGet(const ReadOptions& options, const Slice* keys, ForwardIt 
                 (void)search_in_block(k, i);
             }
         }
-        ++i;
     }
     if (s.ok()) {
         s = iiter->status();

--- a/be/test/storage/lake/persistent_index_sstable_test.cpp
+++ b/be/test/storage/lake/persistent_index_sstable_test.cpp
@@ -270,6 +270,18 @@ TEST_F(PersistentIndexSstableTest, test_persistent_index_sstable) {
             ASSERT_EQ(expected_values[i], values[i]);
         }
         ASSERT_EQ(key_indexes_info, found_keys_info);
+
+        found_keys_info.clear();
+        key_indexes_info.clear();
+        for (int i = N / 4; i < N / 2; ++i) {
+            key_indexes_info.insert(i);
+        }
+        std::vector<IndexValue> values1(N / 2, IndexValue(NullIndexValue));
+        ASSERT_OK(sst->multi_get(keys.data(), key_indexes_info, -1, values1.data(), &found_keys_info));
+        for (int i = N / 4; i < N / 2; i++) {
+            ASSERT_EQ(expected_values[i], values1[i]);
+        }
+        ASSERT_EQ(key_indexes_info, found_keys_info);
     }
     {
         // 5. multi get with version (all keys included)


### PR DESCRIPTION
## Why I'm doing:
MultiGet in sstable will overflow because the size of `values` is qual to the range between `begin` and `end`. For example, if the size of `values` is 2, and the `key_indexes` is [100, 101]. The index can not be used when assigning the value. A `size_t` should be used for index instead.
## What I'm doing:
Fix heap-overflow in MultiGet of sstable

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
