### PR TITLE
[BugFix] Fix upper case column name make GIN metadata incorrect

### DIFF
--- a/be/src/storage/metadata_util.cpp
+++ b/be/src/storage/metadata_util.cpp
@@ -308,7 +308,7 @@ Status convert_t_schema_to_pb_schema(const TTabletSchema& tablet_schema, uint32_
                 index_pb->set_index_type(IndexType::GIN);
 
                 const auto& index_col_name = index.columns[0];
-                const auto& mit = column_map.find(index_col_name);
+                const auto& mit = column_map.find(boost::to_lower_copy(index_col_name));
 
                 // TODO: Fix abnormal scenes when index column can not be found
                 if (mit != column_map.end()) {

--- a/test/sql/test_inverted_index/R/test_inverted_index
+++ b/test/sql/test_inverted_index/R/test_inverted_index
@@ -1062,3 +1062,43 @@ SELECT id1 FROM t_delete_and_column_prune WHERE text_column MATCH "b";
 DROP TABLE t_delete_and_column_prune;
 -- result:
 -- !result
+-- name: test_upper_case_column_name
+set low_cardinality_optimize_v2 = false;
+-- result:
+-- !result
+set cbo_enable_low_cardinality_optimize = false;
+-- result:
+-- !result
+CREATE TABLE `t_upper_case_column_name` (
+  `id1` bigint(20) NOT NULL COMMENT "",
+  `TeXt` varchar(255) NULL COMMENT "",
+  INDEX gin_none (`TeXt`) USING GIN ("parser" = "english") COMMENT 'whole line index'
+) ENGINE=OLAP
+DUPLICATE KEY(`id1`)
+DISTRIBUTED BY HASH(`id1`) BUCKETS 1
+PROPERTIES (
+"replication_num" = "1",
+"enable_persistent_index" = "false",
+"replicated_storage" = "false",
+"compression" = "LZ4"
+);
+-- result:
+-- !result
+INSERT INTO t_upper_case_column_name VALUES (1, "b"),(2, "b"),(3, "b");
+-- result:
+-- !result
+SELECT id1 FROM t_upper_case_column_name WHERE `TeXt` MATCH "b";
+-- result:
+-- !result
+SELECT id1 FROM t_upper_case_column_name WHERE `Text` MATCH "b";
+-- result:
+-- !result
+SELECT id1 FROM t_upper_case_column_name WHERE `TEXT` MATCH "b";
+-- result:
+-- !result
+SELECT id1 FROM t_upper_case_column_name WHERE `text` MATCH "b";
+-- result:
+-- !result
+DROP TABLE t_upper_case_column_name;
+-- result:
+-- !result

--- a/test/sql/test_inverted_index/R/test_inverted_index
+++ b/test/sql/test_inverted_index/R/test_inverted_index
@@ -1089,15 +1089,27 @@ INSERT INTO t_upper_case_column_name VALUES (1, "b"),(2, "b"),(3, "b");
 -- !result
 SELECT id1 FROM t_upper_case_column_name WHERE `TeXt` MATCH "b";
 -- result:
+1
+2
+3
 -- !result
 SELECT id1 FROM t_upper_case_column_name WHERE `Text` MATCH "b";
 -- result:
+1
+2
+3
 -- !result
 SELECT id1 FROM t_upper_case_column_name WHERE `TEXT` MATCH "b";
 -- result:
+1
+2
+3
 -- !result
 SELECT id1 FROM t_upper_case_column_name WHERE `text` MATCH "b";
 -- result:
+1
+2
+3
 -- !result
 DROP TABLE t_upper_case_column_name;
 -- result:

--- a/test/sql/test_inverted_index/T/test_inverted_index
+++ b/test/sql/test_inverted_index/T/test_inverted_index
@@ -598,3 +598,29 @@ DELETE FROM t_delete_and_column_prune WHERE id1 = 2;
 SELECT id1 FROM t_delete_and_column_prune WHERE text_column MATCH "b";
 
 DROP TABLE t_delete_and_column_prune;
+
+-- name: test_upper_case_column_name
+set low_cardinality_optimize_v2 = false;
+set cbo_enable_low_cardinality_optimize = false;
+
+CREATE TABLE `t_upper_case_column_name` (
+  `id1` bigint(20) NOT NULL COMMENT "",
+  `TeXt` varchar(255) NULL COMMENT "",
+  INDEX gin_none (`TeXt`) USING GIN ("parser" = "english") COMMENT 'whole line index'
+) ENGINE=OLAP
+DUPLICATE KEY(`id1`)
+DISTRIBUTED BY HASH(`id1`) BUCKETS 1
+PROPERTIES (
+"replication_num" = "1",
+"enable_persistent_index" = "false",
+"replicated_storage" = "false",
+"compression" = "LZ4"
+);
+
+INSERT INTO t_delete_and_column_prune VALUES (1, "b"),(2, "b"),(3, "b");
+SELECT id1 FROM t_upper_case_column_name WHERE `TeXt` MATCH "b";
+SELECT id1 FROM t_upper_case_column_name WHERE `Text` MATCH "b";
+SELECT id1 FROM t_upper_case_column_name WHERE `TEXT` MATCH "b";
+SELECT id1 FROM t_upper_case_column_name WHERE `text` MATCH "b";
+
+DROP TABLE t_upper_case_column_name;


### PR DESCRIPTION
## Why I'm doing:
If the column with GIN has the column name with some Upper case char. GIN's metadata will miss the column ids for it.

## What I'm doing:
Check the column name when create tablet index meta ignore the upper case.

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
