### PR TITLE
[BugFix] Fix an issue where the numberConnection variable in the ConnectScheduler class repeatedly counts the same connection

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/qe/ConnectScheduler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/ConnectScheduler.java
@@ -139,9 +139,11 @@ public class ConnectScheduler {
         if (currentConn >= currentMaxConn) {
             return false;
         }
-        numberConnection.incrementAndGet();
-        connCountByUser.get(ctx.getQualifiedUser()).incrementAndGet();
-        connectionMap.put((long) ctx.getConnectionId(), ctx);
+        ConnectContext existingConnectionContext = connectionMap.putIfAbsent((long) ctx.getConnectionId(), ctx);
+        if (existingConnectionContext == null) {
+            numberConnection.incrementAndGet();
+            connCountByUser.get(ctx.getQualifiedUser()).incrementAndGet();
+        }
         return true;
     }
 


### PR DESCRIPTION
## Why I'm doing:
fe_connection_total metrics counts the same connection twice, then will result 'Reach limit of connections' error.
## What I'm doing:
fix the metircs counter

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [x] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [x] 3.2
  - [x] 3.1
  - [x] 3.0
  - [x] 2.5
