### PR TITLE
[Feature] temporary table(part-3): Table related commands adapt to temporary tables

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/alter/AlterJobMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/AlterJobMgr.java
@@ -651,7 +651,7 @@ public class AlterJobMgr {
                 TruncatePartitionClause clause = (TruncatePartitionClause) alterClause;
                 TableRef tableRef = new TableRef(stmt.getTbl(), null, clause.getPartitionNames());
                 TruncateTableStmt tStmt = new TruncateTableStmt(tableRef);
-                GlobalStateMgr.getCurrentState().getLocalMetastore().truncateTable(tStmt);
+                GlobalStateMgr.getCurrentState().getLocalMetastore().truncateTable(tStmt, new ConnectContext());
             } else if (alterClause instanceof ModifyPartitionClause) {
                 ModifyPartitionClause clause = ((ModifyPartitionClause) alterClause);
                 Map<String, String> properties = clause.getProperties();

--- a/fe/fe-core/src/main/java/com/starrocks/alter/AlterJobMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/AlterJobMgr.java
@@ -651,7 +651,9 @@ public class AlterJobMgr {
                 TruncatePartitionClause clause = (TruncatePartitionClause) alterClause;
                 TableRef tableRef = new TableRef(stmt.getTbl(), null, clause.getPartitionNames());
                 TruncateTableStmt tStmt = new TruncateTableStmt(tableRef);
-                GlobalStateMgr.getCurrentState().getLocalMetastore().truncateTable(tStmt, new ConnectContext());
+                ConnectContext ctx = new ConnectContext();
+                ctx.setGlobalStateMgr(GlobalStateMgr.getCurrentState());
+                GlobalStateMgr.getCurrentState().getLocalMetastore().truncateTable(tStmt, ctx);
             } else if (alterClause instanceof ModifyPartitionClause) {
                 ModifyPartitionClause clause = ((ModifyPartitionClause) alterClause);
                 Map<String, String> properties = clause.getProperties();

--- a/fe/fe-core/src/main/java/com/starrocks/connector/CatalogConnectorMetadata.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/CatalogConnectorMetadata.java
@@ -30,6 +30,7 @@ import com.starrocks.common.profile.Tracers;
 import com.starrocks.connector.informationschema.InformationSchemaMetadata;
 import com.starrocks.connector.metadata.TableMetaMetadata;
 import com.starrocks.credential.CloudConfiguration;
+import com.starrocks.qe.ConnectContext;
 import com.starrocks.sql.ast.AddPartitionClause;
 import com.starrocks.sql.ast.AlterMaterializedViewStmt;
 import com.starrocks.sql.ast.AlterTableCommentClause;
@@ -244,8 +245,8 @@ public class CatalogConnectorMetadata implements ConnectorMetadata {
     }
 
     @Override
-    public void truncateTable(TruncateTableStmt truncateTableStmt) throws DdlException {
-        normal.truncateTable(truncateTableStmt);
+    public void truncateTable(TruncateTableStmt truncateTableStmt, ConnectContext context) throws DdlException {
+        normal.truncateTable(truncateTableStmt, context);
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/connector/ConnectorMetadata.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/ConnectorMetadata.java
@@ -29,6 +29,7 @@ import com.starrocks.common.UserException;
 import com.starrocks.common.profile.Tracers;
 import com.starrocks.connector.exception.StarRocksConnectorException;
 import com.starrocks.credential.CloudConfiguration;
+import com.starrocks.qe.ConnectContext;
 import com.starrocks.sql.ast.AddPartitionClause;
 import com.starrocks.sql.ast.AlterMaterializedViewStmt;
 import com.starrocks.sql.ast.AlterTableCommentClause;
@@ -257,7 +258,7 @@ public interface ConnectorMetadata {
     default void alterTableComment(Database db, Table table, AlterTableCommentClause clause) {
     }
 
-    default void truncateTable(TruncateTableStmt truncateTableStmt) throws DdlException {
+    default void truncateTable(TruncateTableStmt truncateTableStmt, ConnectContext context) throws DdlException {
     }
 
     default void createTableLike(CreateTableLikeStmt stmt) throws DdlException {

--- a/fe/fe-core/src/main/java/com/starrocks/qe/DDLStmtExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/DDLStmtExecutor.java
@@ -307,7 +307,14 @@ public class DDLStmtExecutor {
         @Override
         public ShowResultSet visitDropTableStatement(DropTableStmt stmt, ConnectContext context) {
             ErrorReport.wrapWithRuntimeException(() -> {
-                context.getGlobalStateMgr().getMetadataMgr().dropTable(stmt);
+                if (stmt.getTemporaryTableMark()) {
+                    DropTemporaryTableStmt dropTemporaryTableStmt = new DropTemporaryTableStmt(
+                            stmt.isSetIfExists(), stmt.getTbl(), stmt.isForceDrop());
+                    dropTemporaryTableStmt.setSessionId(context.getSessionId());
+                    context.getGlobalStateMgr().getMetadataMgr().dropTemporaryTable(dropTemporaryTableStmt);
+                } else {
+                    context.getGlobalStateMgr().getMetadataMgr().dropTable(stmt);
+                }
             });
             return null;
         }
@@ -694,7 +701,7 @@ public class DDLStmtExecutor {
         @Override
         public ShowResultSet visitTruncateTableStatement(TruncateTableStmt stmt, ConnectContext context) {
             ErrorReport.wrapWithRuntimeException(() -> {
-                context.getGlobalStateMgr().getLocalMetastore().truncateTable(stmt);
+                context.getGlobalStateMgr().getLocalMetastore().truncateTable(stmt, context);
             });
             return null;
         }

--- a/fe/fe-core/src/main/java/com/starrocks/qe/ShowExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/ShowExecutor.java
@@ -1706,6 +1706,7 @@ public class ShowExecutor {
                                 PrivilegeType.ANY.name(), ObjectType.TABLE.name(), null);
                     }
                     Boolean hideIpPort = privResult.second;
+                    statement.setTable(table);
 
                     OlapTable olapTable = (OlapTable) table;
                     long sizeLimit = -1;

--- a/fe/fe-core/src/main/java/com/starrocks/qe/StmtExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/StmtExecutor.java
@@ -1033,8 +1033,7 @@ public class StmtExecutor {
         if (queryStmt instanceof QueryStatement) {
             isOutfileQuery = ((QueryStatement) queryStmt).hasOutFileClause();
             if (isOutfileQuery) {
-                Map<TableName, Table> tables = AnalyzerUtils.collectAllTable(queryStmt);
-                boolean hasTemporaryTable = tables.values().stream().anyMatch(t -> t.isTemporaryTable());
+                boolean hasTemporaryTable = AnalyzerUtils.hasTemporaryTables(queryStmt);
                 if (hasTemporaryTable) {
                     throw new SemanticException("temporary table doesn't support select outfile statement");
                 }

--- a/fe/fe-core/src/main/java/com/starrocks/qe/StmtExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/StmtExecutor.java
@@ -1115,7 +1115,7 @@ public class StmtExecutor {
     private void handleAnalyzeStmt() throws IOException {
         AnalyzeStmt analyzeStmt = (AnalyzeStmt) parsedStmt;
         Database db = MetaUtils.getDatabase(context, analyzeStmt.getTableName());
-        Table table = MetaUtils.getTable(context, analyzeStmt.getTableName());
+        Table table = MetaUtils.getSessionAwareTable(context, db, analyzeStmt.getTableName());
         if (StatisticUtils.isEmptyTable(table)) {
             return;
         }

--- a/fe/fe-core/src/main/java/com/starrocks/server/LocalMetastore.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/LocalMetastore.java
@@ -244,6 +244,7 @@ import com.starrocks.sql.ast.SingleRangePartitionDesc;
 import com.starrocks.sql.ast.SystemVariable;
 import com.starrocks.sql.ast.TableRenameClause;
 import com.starrocks.sql.ast.TruncateTableStmt;
+import com.starrocks.sql.common.MetaUtils;
 import com.starrocks.sql.common.SyncPartitionUtils;
 import com.starrocks.sql.optimizer.Utils;
 import com.starrocks.sql.optimizer.statistics.IDictManager;
@@ -4763,7 +4764,7 @@ public class LocalMetastore implements ConnectorMetadata {
      *
      */
     @Override
-    public void truncateTable(TruncateTableStmt truncateTableStmt) throws DdlException {
+    public void truncateTable(TruncateTableStmt truncateTableStmt, ConnectContext context) throws DdlException {
         TableRef tblRef = truncateTableStmt.getTblRef();
         TableName dbTbl = tblRef.getName();
         // check, and save some info which need to be checked again later
@@ -4778,7 +4779,7 @@ public class LocalMetastore implements ConnectorMetadata {
         Locker locker = new Locker();
         locker.lockDatabase(db, LockType.READ);
         try {
-            Table table = db.getTable(dbTbl.getTbl());
+            Table table = MetaUtils.getSessionAwareTable(context, db, dbTbl);
             if (table == null) {
                 ErrorReport.reportDdlException(ErrorCode.ERR_BAD_TABLE_ERROR, dbTbl.getTbl());
             }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AlterTableStatementAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AlterTableStatementAnalyzer.java
@@ -40,7 +40,10 @@ public class AlterTableStatementAnalyzer {
             ErrorReport.reportSemanticException(ErrorCode.ERR_NO_ALTER_OPERATION);
         }
 
-        Table table = MetaUtils.getTable(context, tbl);
+        Table table = MetaUtils.getSessionAwareTable(context, null, tbl);
+        if (table.isTemporaryTable()) {
+            throw new SemanticException("temporary table doesn't support alter table statement");
+        }
         if (table instanceof MaterializedView && alterClauseList != null) {
             for (AlterClause alterClause : alterClauseList) {
                 if (!indexCluase(alterClause)) {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AnalyzeStmtAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AnalyzeStmtAnalyzer.java
@@ -101,7 +101,7 @@ public class AnalyzeStmtAnalyzer {
         @Override
         public Void visitAnalyzeStatement(AnalyzeStmt statement, ConnectContext session) {
             MetaUtils.normalizationTableName(session, statement.getTableName());
-            Table analyzeTable = MetaUtils.getTable(session, statement.getTableName());
+            Table analyzeTable = MetaUtils.getSessionAwareTable(session, null, statement.getTableName());
 
             if (StatisticUtils.statisticDatabaseBlackListCheck(statement.getTableName().getDb())) {
                 throw new SemanticException("Forbidden collect database: %s", statement.getTableName().getDb());
@@ -171,7 +171,7 @@ public class AnalyzeStmtAnalyzer {
                     String dbName = Strings.isNullOrEmpty(tbl.getDb()) ?
                             session.getDatabase() : tbl.getDb();
                     tbl.setDb(dbName);
-                    Table analyzeTable = MetaUtils.getTable(session, statement.getTableName());
+                    Table analyzeTable = MetaUtils.getSessionAwareTable(session, null, statement.getTableName());
                     if (!analyzeTable.isHiveTable() && !analyzeTable.isIcebergTable() && !analyzeTable.isHudiTable() &&
                             !analyzeTable.isOdpsTable()) {
                         throw new SemanticException("Analyze external table only support hive, iceberg and odps table",
@@ -191,7 +191,7 @@ public class AnalyzeStmtAnalyzer {
                 } else if (null != statement.getTableName().getTbl()) {
                     MetaUtils.normalizationTableName(session, statement.getTableName());
                     Database db = MetaUtils.getDatabase(session, statement.getTableName());
-                    Table analyzeTable = MetaUtils.getTable(session, statement.getTableName());
+                    Table analyzeTable = MetaUtils.getSessionAwareTable(session, db, statement.getTableName());
 
                     if (CatalogMgr.ResourceMappingCatalog.isResourceMappingCatalog(analyzeTable.getCatalogName())) {
                         throw new SemanticException("Don't support analyze external table created by resource mapping");
@@ -260,7 +260,7 @@ public class AnalyzeStmtAnalyzer {
                                             AnalyzeTypeDesc analyzeTypeDesc) {
             if (analyzeTypeDesc instanceof AnalyzeHistogramDesc) {
                 List<Expr> columns = statement.getColumns();
-                Table analyzeTable = MetaUtils.getTable(session, statement.getTableName());
+                Table analyzeTable = MetaUtils.getSessionAwareTable(session, null, statement.getTableName());
                 if (!isSupportedHistogramAnalyzeTableType(analyzeTable)) {
                     throw new SemanticException("Can't create histogram statistics on table type is %s",
                             analyzeTable.getType().name());
@@ -352,7 +352,7 @@ public class AnalyzeStmtAnalyzer {
                 statement.setExternal(true);
             }
 
-            Table analyzeTable = MetaUtils.getTable(session, statement.getTableName());
+            Table analyzeTable = MetaUtils.getSessionAwareTable(session, null, statement.getTableName());
             List<Expr> columns = statement.getColumns();
             List<String> realColumnNames = Lists.newArrayList();
             for (Expr column : columns) {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/Analyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/Analyzer.java
@@ -331,6 +331,7 @@ public class Analyzer {
                 taskStmt = insertStmt;
             } else if (statement.getDataCacheSelectStmt() != null) {
                 DataCacheStmtAnalyzer.analyze(statement.getDataCacheSelectStmt(), context);
+                taskStmt = statement.getDataCacheSelectStmt();
             } else {
                 throw new SemanticException("Submit task statement is not supported");
             }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/Analyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/Analyzer.java
@@ -334,8 +334,7 @@ public class Analyzer {
             } else {
                 throw new SemanticException("Submit task statement is not supported");
             }
-            boolean hasTemporaryTable = AnalyzerUtils.collectAllTable(taskStmt)
-                    .values().stream().anyMatch(t -> t.isTemporaryTable());
+            boolean hasTemporaryTable = AnalyzerUtils.hasTemporaryTables(taskStmt);
             if (hasTemporaryTable) {
                 throw new SemanticException("Cannot submit task based on temporary table");
             }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AnalyzerUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AnalyzerUtils.java
@@ -713,6 +713,12 @@ public class AnalyzerUtils {
         return nonOlapTables.isEmpty();
     }
 
+    public static boolean hasTemporaryTables(StatementBase statementBase) {
+        Set<OlapTable> tables = new HashSet<>();
+        new AnalyzerUtils.OlapTableCollector(tables).visit(statementBase);
+        return tables.stream().anyMatch(t -> t.isTemporaryTable());
+    }
+
     public static void copyOlapTable(StatementBase statementBase, Set<OlapTable> olapTables) {
         new AnalyzerUtils.OlapTableCollector(olapTables).visit(statementBase);
     }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AnalyzerUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AnalyzerUtils.java
@@ -714,9 +714,9 @@ public class AnalyzerUtils {
     }
 
     public static boolean hasTemporaryTables(StatementBase statementBase) {
-        Set<OlapTable> tables = new HashSet<>();
-        new AnalyzerUtils.OlapTableCollector(tables).visit(statementBase);
-        return tables.stream().anyMatch(t -> t.isTemporaryTable());
+        Map<TableName, Table> tables = new HashMap<>();
+        new AnalyzerUtils.TableCollector(tables).visit(statementBase);
+        return tables.values().stream().anyMatch(t -> t.isTemporaryTable());
     }
 
     public static void copyOlapTable(StatementBase statementBase, Set<OlapTable> olapTables) {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/BackupRestoreAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/BackupRestoreAnalyzer.java
@@ -385,7 +385,6 @@ public class BackupRestoreAnalyzer {
 
         PartitionNames partitionNames = tableRef.getPartitionNames();
         Table tbl = db.getTable(tableName.getTbl());
-        // @TODO if we found a temporary table, should we report an specific error message?
         if (null == tbl) {
             throw new SemanticException(ErrorCode.ERR_WRONG_TABLE_NAME.formatErrorMsg(tableName.getTbl()));
         }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/BackupRestoreAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/BackupRestoreAnalyzer.java
@@ -89,6 +89,9 @@ public class BackupRestoreAnalyzer {
                                         "`Config.enable_backup_materialized_view=false`", tbl.getName());
                         continue;
                     }
+                    if (tbl.isTemporaryTable()) {
+                        continue;
+                    }
                     TableName tableName = new TableName(dbName, tbl.getName());
                     TableRef tableRef = new TableRef(tableName, null, null);
                     tableRefs.add(tableRef);
@@ -382,6 +385,7 @@ public class BackupRestoreAnalyzer {
 
         PartitionNames partitionNames = tableRef.getPartitionNames();
         Table tbl = db.getTable(tableName.getTbl());
+        // @TODO if we found a temporary table, should we report an specific error message?
         if (null == tbl) {
             throw new SemanticException(ErrorCode.ERR_WRONG_TABLE_NAME.formatErrorMsg(tableName.getTbl()));
         }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/DropStmtAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/DropStmtAnalyzer.java
@@ -16,6 +16,7 @@ package com.starrocks.sql.analyzer;
 
 import com.google.common.base.Strings;
 import com.starrocks.analysis.FunctionName;
+import com.starrocks.analysis.TableName;
 import com.starrocks.catalog.Database;
 import com.starrocks.catalog.Function;
 import com.starrocks.catalog.FunctionSearchDesc;
@@ -87,7 +88,7 @@ public class DropStmtAnalyzer {
             Table table;
             String tableName = statement.getTableName();
             try {
-                table = GlobalStateMgr.getCurrentState().getMetadataMgr().getTable(catalogName, dbName, tableName);
+                table = MetaUtils.getSessionAwareTable(context, db, new TableName(catalogName, dbName, tableName));
                 if (table == null) {
                     if (statement.isSetIfExists()) {
                         LOG.info("drop table[{}] which does not exist", tableName);
@@ -101,6 +102,9 @@ public class DropStmtAnalyzer {
                                 "The data of '%s' cannot be dropped because '%s' is a materialized view," +
                                         "use 'drop materialized view %s' to drop it.",
                                 tableName, tableName, tableName);
+                    }
+                    if (table.isTemporaryTable()) {
+                        statement.setTemporaryTableMark(true);
                     }
                 }
             } finally {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/DropStmtAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/DropStmtAnalyzer.java
@@ -85,10 +85,14 @@ public class DropStmtAnalyzer {
             }
             Locker locker = new Locker();
             locker.lockDatabase(db, LockType.READ);
-            Table table;
+            Table table = null;
             String tableName = statement.getTableName();
             try {
-                table = MetaUtils.getSessionAwareTable(context, db, new TableName(catalogName, dbName, tableName));
+                try {
+                    table = MetaUtils.getSessionAwareTable(context, db, new TableName(catalogName, dbName, tableName));
+                } catch (Exception e) {
+                    // an exception will be thrown if table is not found, just ignore it
+                }
                 if (table == null) {
                     if (statement.isSetIfExists()) {
                         LOG.info("drop table[{}] which does not exist", tableName);

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/ExportStmtAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/ExportStmtAnalyzer.java
@@ -69,11 +69,15 @@ public class ExportStmtAnalyzer {
             TableName tableName = statement.getTableRef().getName();
             // make sure catalog, db, table
             MetaUtils.normalizationTableName(context, tableName);
-            Table table = MetaUtils.getTable(context, tableName);
+            Table table = MetaUtils.getSessionAwareTable(context, null, tableName);
             if (table.getType() == Table.TableType.OLAP &&
                     (((OlapTable) table).getState() == OlapTable.OlapTableState.RESTORE ||
                             ((OlapTable) table).getState() == OlapTable.OlapTableState.RESTORE_WITH_LOAD)) {
                 ErrorReport.reportSemanticException(ErrorCode.ERR_BAD_TABLE_STATE, "RESTORING");
+            }
+            if (table.isTemporaryTable()) {
+                ErrorReport.reportSemanticException(ErrorCode.ERR_COMMON_ERROR,
+                        "Do not support exporting temporary table");
             }
             statement.setTblName(tableName);
             PartitionNames partitionNames = statement.getTableRef().getPartitionNames();

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/MaterializedViewAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/MaterializedViewAnalyzer.java
@@ -252,8 +252,7 @@ public class MaterializedViewAnalyzer {
             Analyzer.analyze(queryStatement, context);
             AnalyzerUtils.checkNondeterministicFunction(queryStatement);
 
-            boolean hasTemporaryTable = AnalyzerUtils.collectAllTable(queryStatement)
-                    .values().stream().anyMatch(t -> t.isTemporaryTable());
+            boolean hasTemporaryTable = AnalyzerUtils.hasTemporaryTables(queryStatement);
             if (hasTemporaryTable) {
                 throw new SemanticException("Materialized view can't base on temporary table");
             }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/MaterializedViewAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/MaterializedViewAnalyzer.java
@@ -252,6 +252,12 @@ public class MaterializedViewAnalyzer {
             Analyzer.analyze(queryStatement, context);
             AnalyzerUtils.checkNondeterministicFunction(queryStatement);
 
+            boolean hasTemporaryTable = AnalyzerUtils.collectAllTable(queryStatement)
+                    .values().stream().anyMatch(t -> t.isTemporaryTable());
+            if (hasTemporaryTable) {
+                throw new SemanticException("Materialized view can't base on temporary table");
+            }
+
             // convert queryStatement to sql and set
             statement.setInlineViewDef(AstToSQLBuilder.toSQL(queryStatement));
             statement.setSimpleViewDef(AstToSQLBuilder.buildSimple(queryStatement));

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/ViewAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/ViewAnalyzer.java
@@ -49,7 +49,11 @@ public class ViewAnalyzer {
             FeNameFormat.checkTableName(tableName);
 
             Analyzer.analyze(stmt.getQueryStatement(), context);
-
+            boolean hasTemporaryTable = AnalyzerUtils.collectAllTable(
+                    stmt.getQueryStatement()).values().stream().anyMatch(t -> t.isTemporaryTable());
+            if (hasTemporaryTable) {
+                throw new SemanticException("View can't base on temporary table");
+            }
             List<Column> viewColumns = analyzeViewColumns(stmt.getQueryStatement().getQueryRelation(), stmt.getColWithComments());
             stmt.setColumns(viewColumns);
             String viewSql = AstToSQLBuilder.toSQL(stmt.getQueryStatement());
@@ -73,6 +77,11 @@ public class ViewAnalyzer {
             AlterViewClause alterViewClause = (AlterViewClause) alterClause;
 
             Analyzer.analyze(alterViewClause.getQueryStatement(), context);
+            boolean hasTemporaryTable = AnalyzerUtils.collectAllTable(
+                    alterViewClause.getQueryStatement()).values().stream().anyMatch(t -> t.isTemporaryTable());
+            if (hasTemporaryTable) {
+                throw new SemanticException("View can't base on temporary table");
+            }
 
             List<Column> viewColumns = analyzeViewColumns(alterViewClause.getQueryStatement().getQueryRelation(),
                     alterViewClause.getColWithComments());

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/ViewAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/ViewAnalyzer.java
@@ -49,8 +49,7 @@ public class ViewAnalyzer {
             FeNameFormat.checkTableName(tableName);
 
             Analyzer.analyze(stmt.getQueryStatement(), context);
-            boolean hasTemporaryTable = AnalyzerUtils.collectAllTable(
-                    stmt.getQueryStatement()).values().stream().anyMatch(t -> t.isTemporaryTable());
+            boolean hasTemporaryTable = AnalyzerUtils.hasTemporaryTables(stmt.getQueryStatement());
             if (hasTemporaryTable) {
                 throw new SemanticException("View can't base on temporary table");
             }
@@ -77,8 +76,7 @@ public class ViewAnalyzer {
             AlterViewClause alterViewClause = (AlterViewClause) alterClause;
 
             Analyzer.analyze(alterViewClause.getQueryStatement(), context);
-            boolean hasTemporaryTable = AnalyzerUtils.collectAllTable(
-                    alterViewClause.getQueryStatement()).values().stream().anyMatch(t -> t.isTemporaryTable());
+            boolean hasTemporaryTable = AnalyzerUtils.hasTemporaryTables(((AlterViewClause) alterClause).getQueryStatement());
             if (hasTemporaryTable) {
                 throw new SemanticException("View can't base on temporary table");
             }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/CreateMaterializedViewStmt.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/CreateMaterializedViewStmt.java
@@ -290,8 +290,7 @@ public class CreateMaterializedViewStmt extends DdlStmt {
             context.getSessionVariable().setSqlSelectLimit(originSelectLimit);
         }
 
-        boolean hasTemporaryTable = AnalyzerUtils.collectAllTable(queryStatement)
-                .values().stream().allMatch(t -> t.isTemporaryTable());
+        boolean hasTemporaryTable = AnalyzerUtils.hasTemporaryTables(queryStatement);
         if (hasTemporaryTable) {
             throw new SemanticException(("Materialized view can't base on temporary table"));
         }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/CreateMaterializedViewStmt.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/CreateMaterializedViewStmt.java
@@ -290,6 +290,12 @@ public class CreateMaterializedViewStmt extends DdlStmt {
             context.getSessionVariable().setSqlSelectLimit(originSelectLimit);
         }
 
+        boolean hasTemporaryTable = AnalyzerUtils.collectAllTable(queryStatement)
+                .values().stream().allMatch(t -> t.isTemporaryTable());
+        if (hasTemporaryTable) {
+            throw new SemanticException(("Materialized view can't base on temporary table"));
+        }
+
         // forbid explain query
         if (queryStatement.isExplain()) {
             throw new IllegalArgumentException("Creating materialized view does not support explain query");

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/DropTableStmt.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/DropTableStmt.java
@@ -25,6 +25,10 @@ public class DropTableStmt extends DdlStmt {
     private final boolean isView;
     private final boolean forceDrop;
 
+    // used to mark whether it should be treated as a temporary table to distinguish subsequent processing logic,
+    // it should be set during analysis phase
+    private boolean temporaryTableMark = false;
+
     public DropTableStmt(boolean ifExists, TableName tableName, boolean forceDrop) {
         this(ifExists, tableName, false, forceDrop, NodePosition.ZERO);
     }
@@ -71,6 +75,14 @@ public class DropTableStmt extends DdlStmt {
 
     public boolean isForceDrop() {
         return this.forceDrop;
+    }
+
+    public void setTemporaryTableMark(boolean mark) {
+        this.temporaryTableMark = mark;
+    }
+
+    public boolean getTemporaryTableMark() {
+        return temporaryTableMark;
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/ShowTabletStmt.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/ShowTabletStmt.java
@@ -23,18 +23,14 @@ import com.starrocks.analysis.OrderByElement;
 import com.starrocks.analysis.RedirectStatus;
 import com.starrocks.analysis.TableName;
 import com.starrocks.catalog.Column;
-import com.starrocks.catalog.Database;
 import com.starrocks.catalog.Replica;
 import com.starrocks.catalog.ScalarType;
 import com.starrocks.catalog.Table;
 import com.starrocks.common.proc.LakeTabletsProcDir;
 import com.starrocks.common.proc.LocalTabletsProcDir;
 import com.starrocks.common.util.OrderByPair;
-import com.starrocks.common.util.concurrent.lock.LockType;
-import com.starrocks.common.util.concurrent.lock.Locker;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.qe.ShowResultSetMetaData;
-import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.sql.parser.NodePosition;
 
 import java.util.ArrayList;
@@ -62,6 +58,8 @@ public class ShowTabletStmt extends ShowStmt {
     private ArrayList<OrderByPair> orderByPairs;
 
     private boolean isShowSingleTablet;
+
+    private Table table;
 
     public ShowTabletStmt(TableName dbTableName, long tabletId, NodePosition pos) {
         this(dbTableName, tabletId, null, null, null, null, pos);
@@ -196,6 +194,10 @@ public class ShowTabletStmt extends ShowStmt {
         return limitElement;
     }
 
+    public void setTable(Table table) {
+        this.table = table;
+    }
+
     @Override
     public <R, C> R accept(AstVisitor<R, C> visitor, C context) {
         return visitor.visitShowTabletStatement(this, context);
@@ -206,26 +208,13 @@ public class ShowTabletStmt extends ShowStmt {
             return SINGLE_TABLET_TITLE_NAMES;
         }
 
-        Database db = GlobalStateMgr.getCurrentState().getDb(dbName);
-        if (db == null) {
+        if (table == null || !table.isNativeTableOrMaterializedView()) {
             return ImmutableList.of();
         }
-
-        Locker locker = new Locker();
-        locker.lockDatabase(db, LockType.READ);
-        try {
-            Table table = db.getTable(tableName);
-            if (table == null || !table.isNativeTableOrMaterializedView()) {
-                return ImmutableList.of();
-            }
-
-            if (table.isCloudNativeTableOrMaterializedView()) {
-                return LakeTabletsProcDir.TITLE_NAMES;
-            } else {
-                return LocalTabletsProcDir.TITLE_NAMES;
-            }
-        } finally {
-            locker.unLockDatabase(db, LockType.READ);
+        if (table.isCloudNativeTableOrMaterializedView()) {
+            return LakeTabletsProcDir.TITLE_NAMES;
+        } else {
+            return LocalTabletsProcDir.TITLE_NAMES;
         }
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/statistic/StatisticUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/statistic/StatisticUtils.java
@@ -164,7 +164,6 @@ public class StatisticUtils {
         if (collectPartitionIds.isEmpty()) {
             return;
         }
-
         StatsConstants.AnalyzeType analyzeType = parseAnalyzeType(txnState, table);
         Map<String, String> properties = Maps.newHashMap();
         if (SAMPLE == analyzeType) {
@@ -182,6 +181,10 @@ public class StatisticUtils {
                     .submit(() -> {
                         StatisticExecutor statisticExecutor = new StatisticExecutor();
                         ConnectContext statsConnectCtx = StatisticUtils.buildConnectContext();
+                        // set session id for temporary table
+                        if (table.isTemporaryTable()) {
+                            statsConnectCtx.setSessionId(((OlapTable) table).getSessionId());
+                        }
                         statsConnectCtx.setThreadLocalInfo();
 
                         statisticExecutor.collectStatistics(statsConnectCtx,

--- a/fe/fe-core/src/test/java/com/starrocks/catalog/ListPartitionInfoTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/ListPartitionInfoTest.java
@@ -106,7 +106,7 @@ public class ListPartitionInfoTest {
         ConnectContext ctx = starRocksAssert.getCtx();
         String truncateSql = "truncate table t_recharge_detail partition(p1)";
         TruncateTableStmt truncateTableStmt = (TruncateTableStmt) UtFrameUtils.parseStmtWithNewParser(truncateSql, ctx);
-        GlobalStateMgr.getCurrentState().getLocalMetastore().truncateTable(truncateTableStmt);
+        GlobalStateMgr.getCurrentState().getLocalMetastore().truncateTable(truncateTableStmt, ctx);
         String showSql = "show partitions from t_recharge_detail;";
         StatementBase statementBase = UtFrameUtils.parseStmtWithNewParser(showSql, ctx);
         StmtExecutor executor = new StmtExecutor(ctx, statementBase);

--- a/fe/fe-core/src/test/java/com/starrocks/catalog/TempPartitionTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/TempPartitionTest.java
@@ -504,7 +504,7 @@ public class TempPartitionTest {
 
         String truncateStr = "truncate table db2.tbl2 partition (p3);";
         TruncateTableStmt truncateTableStmt = (TruncateTableStmt) UtFrameUtils.parseStmtWithNewParser(truncateStr, ctx);
-        GlobalStateMgr.getCurrentState().getLocalMetastore().truncateTable(truncateTableStmt);
+        GlobalStateMgr.getCurrentState().getLocalMetastore().truncateTable(truncateTableStmt, ctx);
         checkShowPartitionsResultNum("db2.tbl2", true, 1);
         checkShowPartitionsResultNum("db2.tbl2", false, 3);
         checkPartitionExist(tbl2, "tp1", false, true);
@@ -588,7 +588,7 @@ public class TempPartitionTest {
 
         truncateStr = "truncate table db2.tbl2";
         truncateTableStmt = (TruncateTableStmt) UtFrameUtils.parseStmtWithNewParser(truncateStr, ctx);
-        GlobalStateMgr.getCurrentState().getLocalMetastore().truncateTable(truncateTableStmt);
+        GlobalStateMgr.getCurrentState().getLocalMetastore().truncateTable(truncateTableStmt, ctx);
         checkShowPartitionsResultNum("db2.tbl2", false, 3);
         checkShowPartitionsResultNum("db2.tbl2", true, 0);
 
@@ -696,7 +696,7 @@ public class TempPartitionTest {
         // now base range is [min, 10), [10, 15), [15, 25), [25, 30) -> p1,tp1,tp2,tp3
         stmtStr = "truncate table db3.tbl3";
         TruncateTableStmt truncateTableStmt = (TruncateTableStmt) UtFrameUtils.parseStmtWithNewParser(stmtStr, ctx);
-        GlobalStateMgr.getCurrentState().getLocalMetastore().truncateTable(truncateTableStmt);
+        GlobalStateMgr.getCurrentState().getLocalMetastore().truncateTable(truncateTableStmt, ctx);
         // 2. add temp ranges: [10, 31), and replace the [10, 15), [15, 25), [25, 30)
         stmtStr = "alter table db3.tbl3 add temporary partition tp4 values [('10'), ('31'))";
         alterTableWithNewAnalyzer(stmtStr, false);
@@ -713,7 +713,7 @@ public class TempPartitionTest {
         // now base range is [min, 10), [10, 30) -> p1,tp4
         stmtStr = "truncate table db3.tbl3";
         truncateTableStmt = (TruncateTableStmt) UtFrameUtils.parseStmtWithNewParser(stmtStr, ctx);
-        GlobalStateMgr.getCurrentState().getLocalMetastore().truncateTable(truncateTableStmt);
+        GlobalStateMgr.getCurrentState().getLocalMetastore().truncateTable(truncateTableStmt, ctx);
         // 3. add temp partition tp5 [50, 60) and replace partition tp4
         stmtStr = "alter table db3.tbl3 add temporary partition tp5 values [('50'), ('60'))";
         alterTableWithNewAnalyzer(stmtStr, false);

--- a/fe/fe-core/src/test/java/com/starrocks/connector/CatalogConnectorMetadataTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/CatalogConnectorMetadataTest.java
@@ -183,7 +183,7 @@ public class CatalogConnectorMetadataTest {
                 connectorMetadata.cancelRefreshMaterializedView("test_db", "test_mv");
                 connectorMetadata.createView(null);
                 connectorMetadata.alterView(null);
-                connectorMetadata.truncateTable(null);
+                connectorMetadata.truncateTable(null, null);
                 connectorMetadata.alterTableComment(null, null, null);
                 connectorMetadata.finishSink("test_db", "test_tbl", null);
                 connectorMetadata.abortSink("test_db", "test_tbl", null);
@@ -220,7 +220,7 @@ public class CatalogConnectorMetadataTest {
         catalogConnectorMetadata.cancelRefreshMaterializedView("test_db", "test_mv");
         catalogConnectorMetadata.createView(null);
         catalogConnectorMetadata.alterView(null);
-        catalogConnectorMetadata.truncateTable(null);
+        catalogConnectorMetadata.truncateTable(null, null);
         catalogConnectorMetadata.alterTableComment(null, null, null);
         catalogConnectorMetadata.finishSink("test_db", "test_tbl", null);
         catalogConnectorMetadata.abortSink("test_db", "test_tbl", null);

--- a/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AnalyzeStmtTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AnalyzeStmtTest.java
@@ -176,7 +176,7 @@ public class AnalyzeStmtTest {
     public void testAnalyzeHiveResource() {
         new MockUp<MetaUtils>() {
             @Mock
-            public Table getTable(ConnectContext session, TableName tableName) {
+            public Table getSessionAwareTable(ConnectContext session, Database database, TableName tableName) {
                 return new HiveTable(1, "customer", Lists.newArrayList(), "resource_name",
                         CatalogMgr.ResourceMappingCatalog.getResourceMappingCatalogName("resource_name", "hive"),
                         "hive", "tpch", "", "",

--- a/test/sql/test_temporary_table/R/temporary_table
+++ b/test/sql/test_temporary_table/R/temporary_table
@@ -191,6 +191,28 @@ select * from `t1` order by `c1`,`c2`;
 4	4
 5	5
 -- !result
+-- name: test_truncate_table 
+create temporary table `t0` (
+    `c1` int,
+    `c2` int
+) engine=OLAP primary key(`c1`) distributed by hash(`c1`) buckets 3 properties("replication_num" = "1");
+-- result:
+-- !result
+insert into `t0` values (1,1),(2,2),(3,3);
+-- result:
+-- !result
+select * from `t0` order by `c1`,`c2`;
+-- result:
+1	1
+2	2
+3	3
+-- !result
+truncate table `t0`;
+-- result:
+-- !result
+select * from `t0` order by `c1`,`c2`;
+-- result:
+-- !result
 -- name: test_name_conflict
 create table `t` (
     `c1` int,
@@ -227,6 +249,32 @@ select * from `t` order by `c1`,`c2`;
 1	1
 2	2
 3	3
+-- !result
+-- name: test_ddl_on_temporary_table
+create temporary table `t` (
+    `c1` int,
+    `c2` int
+) engine=OLAP primary key(`c1`) distributed by hash(`c1`) buckets 3 properties("replication_num" = "1");
+-- result:
+-- !result
+alter table `t` add column `c3` int default null;
+-- result:
+E: (1064, "Getting analyzing error. Detail message: temporary table doesn't support alter table statement.")
+-- !result
+-- name: test_submit_task_on_temporary_table
+create temporary table `t` (
+    `c1` int,
+    `c2` int
+) engine=OLAP primary key(`c1`) distributed by hash(`c1`) buckets 3 properties("replication_num" = "1");
+-- result:
+-- !result
+submit task as insert into `t` select * from `t`;
+-- result:
+E: (1064, 'Getting analyzing error. Detail message: Cannot submit task based on temporary table.')
+-- !result
+submit task as create table `t0` as select * from `t`;
+-- result:
+E: (1064, 'Getting analyzing error. Detail message: Cannot submit task based on temporary table.')
 -- !result
 -- name: test_select_out_file
 create temporary table `t` (
@@ -292,4 +340,53 @@ drop database temp_table_test_${uuid0}_new;
 -- !result
 drop database temp_table_test_${uuid0}_new force;
 -- result:
+-- name: test_create_view
+create temporary table `t` (
+    `c1` int,
+    `c2` int
+) engine=OLAP primary key(`c1`) distributed by hash(`c1`) buckets 3 properties("replication_num" = "1");
+-- result:
+-- !result
+create view `v1` as select * from `t`;
+-- result:
+E: (1064, "Getting analyzing error. Detail message: View can't base on temporary table.")
+-- !result
+create materialized view `mv1` as select * from `t`;
+-- result:
+E: (1064, "Getting analyzing error. Detail message: Materialized view can't base on temporary table.")
+-- !result
+create materialized view `m1` refresh immediate manual as select * from `t`;
+-- result:
+E: (1064, "Getting analyzing error. Detail message: Materialized view can't base on temporary table.")
+-- !result
+create table `t1` (
+    `c1` int,
+    `c2` int
+) engine=OLAP primary key(`c1`) distributed by hash(`c1`) buckets 3 properties("replication_num" = "1");
+-- result:
+-- !result
+create view `v1` as select * from `t1`;
+-- result:
+-- !result
+alter view `v1` as select * from `t`;
+-- result:
+E: (1064, "Getting analyzing error. Detail message: View can't base on temporary table.")
+-- !result
+-- name: test_export
+create temporary table `t` (
+    `c1` int,
+    `c2` int
+) engine=OLAP primary key(`c1`) distributed by hash(`c1`) buckets 3 properties("replication_num" = "1");
+-- result:
+-- !result
+export table `t`
+TO "oss://${oss_bucket}/test_temporary_table/${uuid0}/"
+WITH BROKER
+(
+    "fs.oss.accessKeyId" = "${oss_ak}",
+    "fs.oss.accessKeySecret" = "${oss_sk}",
+    "fs.oss.endpoint" = "${oss_endpoint}"
+);
+-- result:
+E: (5064, 'Getting analyzing error. Detail message: Do not support exporting temporary table.')
 -- !result

--- a/test/sql/test_temporary_table/R/temporary_table
+++ b/test/sql/test_temporary_table/R/temporary_table
@@ -340,6 +340,7 @@ drop database temp_table_test_${uuid0}_new;
 -- !result
 drop database temp_table_test_${uuid0}_new force;
 -- result:
+-- !result
 -- name: test_create_view
 create temporary table `t` (
     `c1` int,

--- a/test/sql/test_temporary_table/T/temporary_table
+++ b/test/sql/test_temporary_table/T/temporary_table
@@ -67,6 +67,18 @@ select * from `t1` order by `c1`,`c2`;
 insert into `t1` values (4,4),(5,5);
 select * from `t1` order by `c1`,`c2`;
 
+-- name: test_truncate_table 
+create temporary table `t0` (
+    `c1` int,
+    `c2` int
+) engine=OLAP primary key(`c1`) distributed by hash(`c1`) buckets 3 properties("replication_num" = "1");
+
+insert into `t0` values (1,1),(2,2),(3,3);
+select * from `t0` order by `c1`,`c2`;
+truncate table `t0`;
+select * from `t0` order by `c1`,`c2`;
+
+
 -- name: test_name_conflict
 create table `t` (
     `c1` int,
@@ -86,6 +98,21 @@ insert into `t` values (1,1,1),(2,2,2);
 select * from `t` order by `c1`,`c2`,`c3`;
 drop temporary table `t`;
 select * from `t` order by `c1`,`c2`;
+
+-- name: test_ddl_on_temporary_table
+create temporary table `t` (
+    `c1` int,
+    `c2` int
+) engine=OLAP primary key(`c1`) distributed by hash(`c1`) buckets 3 properties("replication_num" = "1");
+alter table `t` add column `c3` int default null;
+
+-- name: test_submit_task_on_temporary_table
+create temporary table `t` (
+    `c1` int,
+    `c2` int
+) engine=OLAP primary key(`c1`) distributed by hash(`c1`) buckets 3 properties("replication_num" = "1");
+submit task as insert into `t` select * from `t`;
+submit task as create table `t0` as select * from `t`;
 
 -- name: test_select_out_file
 create temporary table `t` (
@@ -115,3 +142,32 @@ select * from temp_table_test_${uuid0}.t order by 1,2,3;
 select * from temp_table_test_${uuid0}_new.t order by 1,2,3;
 drop database temp_table_test_${uuid0}_new;
 drop database temp_table_test_${uuid0}_new force;
+
+-- name: test_create_view
+create temporary table `t` (
+    `c1` int,
+    `c2` int
+) engine=OLAP primary key(`c1`) distributed by hash(`c1`) buckets 3 properties("replication_num" = "1");
+create view `v1` as select * from `t`;
+create materialized view `mv1` as select * from `t`;
+create materialized view `m1` refresh immediate manual as select * from `t`;
+create table `t1` (
+    `c1` int,
+    `c2` int
+) engine=OLAP primary key(`c1`) distributed by hash(`c1`) buckets 3 properties("replication_num" = "1");
+create view `v1` as select * from `t1`;
+alter view `v1` as select * from `t`;
+
+-- name: test_export
+create temporary table `t` (
+    `c1` int,
+    `c2` int
+) engine=OLAP primary key(`c1`) distributed by hash(`c1`) buckets 3 properties("replication_num" = "1");
+export table `t`
+TO "oss://${oss_bucket}/test_temporary_table/${uuid0}/"
+WITH BROKER
+(
+    "fs.oss.accessKeyId" = "${oss_ak}",
+    "fs.oss.accessKeySecret" = "${oss_sk}",
+    "fs.oss.endpoint" = "${oss_endpoint}"
+);


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:

the fourth part of work split from https://github.com/StarRocks/starrocks/pull/43048

After the temporary table is introduced, many commands need to be adapted so that they can take effect on the temporary table. In this PR, I carried out relevant adaptation work.

Main changes
1. Disable to create views and materialized views based on temporary tables
2. Disable to export the data of temporary tables through the export command.
3. Disable to submit task based on temporary tables
4. BackupStmt ignores temporary tables
3. The analyze command supports temporary tables
4. show tablet supports temporary tables. (show partitions/index have been supported by #43162)
5. drop table should be aware of temporary table.

## What type of PR is this:

- [ ] BugFix
- [x] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
