### PR TITLE
[Enhancement] frontend RPC error message

### DIFF
--- a/be/src/runtime/client_cache.h
+++ b/be/src/runtime/client_cache.h
@@ -176,6 +176,9 @@ public:
         }
     }
 
+    // Test only
+    ClientConnection() : _client(nullptr) {}
+
     ClientConnection(const ClientConnection&) = delete;
     void operator=(const ClientConnection&) = delete;
 

--- a/be/src/runtime/stream_load/stream_load_executor.cpp
+++ b/be/src/runtime/stream_load/stream_load_executor.cpp
@@ -177,9 +177,13 @@ Status StreamLoadExecutor::begin_txn(StreamLoadContext* ctx) {
     TNetworkAddress master_addr = get_master_address();
     TLoadTxnBeginResult result;
 #ifndef BE_TEST
-    RETURN_IF_ERROR(ThriftRpcHelper::rpc<FrontendServiceClient>(
+    auto st = ThriftRpcHelper::rpc<FrontendServiceClient>(
             master_addr.hostname, master_addr.port,
-            [&request, &result](FrontendServiceConnection& client) { client->loadTxnBegin(result, request); }));
+            [&request, &result](FrontendServiceConnection& client) { client->loadTxnBegin(result, request); });
+    if (!st.ok()) {
+        LOG(WARNING) << "begin transaction failed, errmsg=" << st.message() << ctx->brief();
+        return st.clone_and_prepend(fmt::format("begin transaction [{}] failed", ctx->txn_id));
+    }
 #else
     result = k_stream_load_begin_result;
 #endif
@@ -189,7 +193,7 @@ Status StreamLoadExecutor::begin_txn(StreamLoadContext* ctx) {
         if (result.__isset.job_status) {
             ctx->existing_job_status = result.job_status;
         }
-        return status;
+        return status.clone_and_prepend(fmt::format("begin transaction [{}] failed", ctx->txn_id));
     }
     ctx->txn_id = result.txnId;
     ctx->need_rollback = true;
@@ -245,7 +249,8 @@ Status StreamLoadExecutor::commit_txn(StreamLoadContext* ctx) {
         } else if (st.is_time_out()) {
             if (++retry > 1) {
                 ctx->need_rollback = true;
-                return st;
+                return st.clone_and_prepend(fmt::format(
+                        "commit transaction [{}] failed, the transaction will be rolled back", request.txnId));
             }
             LOG(WARNING) << "commit transaction " << request.txnId << " failed, will retry. errmsg=" << st.message();
             if (ctx->load_deadline_sec > 0) {
@@ -253,7 +258,8 @@ Status StreamLoadExecutor::commit_txn(StreamLoadContext* ctx) {
             }
         } else {
             ctx->need_rollback = true;
-            return st;
+            return st.clone_and_prepend(
+                    fmt::format("commit transaction [{}] failed, the transaction will be rolled back", request.txnId));
         }
     }
 }
@@ -261,10 +267,15 @@ Status StreamLoadExecutor::commit_txn(StreamLoadContext* ctx) {
 Status commit_txn_internal(const TLoadTxnCommitRequest& request, int32_t rpc_timeout_ms, TLoadTxnCommitResult* result) {
     TNetworkAddress master_addr = get_master_address();
 #ifndef BE_TEST
-    RETURN_IF_ERROR(ThriftRpcHelper::rpc<FrontendServiceClient>(
+    auto st = ThriftRpcHelper::rpc<FrontendServiceClient>(
             master_addr.hostname, master_addr.port,
             [&request, &result](FrontendServiceConnection& client) { client->loadTxnCommit(*result, request); },
-            rpc_timeout_ms));
+            rpc_timeout_ms);
+    if (!st.ok()) {
+        LOG(WARNING) << "commit transaction failed, errmsg=" << st << ", txn_id: " << request.txnId;
+        return st.clone_and_prepend(fmt::format("commit transaction [{}] failed", request.txnId));
+    }
+
 #else
     *result = k_stream_load_commit_result;
 #endif
@@ -287,7 +298,7 @@ StatusOr<TTransactionStatus::type> get_txn_status(const AuthInfo& auth, std::str
             [&request, &result](FrontendServiceConnection& client) { client->getLoadTxnStatus(result, request); },
             config::txn_commit_rpc_timeout_ms);
     if (!st.ok()) {
-        return st;
+        return st.clone_and_prepend(fmt::format("get transaction [{}] status failed", txn_id));
     } else {
         return result.status;
     }
@@ -341,10 +352,14 @@ Status StreamLoadExecutor::prepare_txn(StreamLoadContext* ctx) {
     TNetworkAddress master_addr = get_master_address();
     TLoadTxnCommitResult result;
 #ifndef BE_TEST
-    RETURN_IF_ERROR(ThriftRpcHelper::rpc<FrontendServiceClient>(
+    auto st = ThriftRpcHelper::rpc<FrontendServiceClient>(
             master_addr.hostname, master_addr.port,
             [&request, &result](FrontendServiceConnection& client) { client->loadTxnPrepare(result, request); },
-            rpc_timeout_ms));
+            rpc_timeout_ms);
+    if (!st.ok()) {
+        LOG(WARNING) << "prepare transaction failed, errmsg=" << st << "ctx: " << ctx->brief();
+        return st.clone_and_prepend(fmt::format("prepare transaction [{}] failed", request.txnId));
+    }
 #else
     result = k_stream_load_commit_result;
 #endif
@@ -353,7 +368,7 @@ Status StreamLoadExecutor::prepare_txn(StreamLoadContext* ctx) {
     Status status(result.status);
     if (!status.ok()) {
         LOG(WARNING) << "prepare transaction failed, errmsg=" << status.message() << ctx->brief();
-        return status;
+        return status.clone_and_prepend(fmt::format("prepare transaction [{}] failed", request.txnId));
     }
     // commit success, set need_rollback to false
     ctx->need_rollback = false;
@@ -389,10 +404,10 @@ Status StreamLoadExecutor::rollback_txn(StreamLoadContext* ctx) {
             [&request, &result](FrontendServiceConnection& client) { client->loadTxnRollback(result, request); });
     if (!rpc_st.ok()) {
         LOG(WARNING) << "transaction rollback failed. errmsg=" << rpc_st.message() << ctx->brief();
-        return rpc_st;
+        return rpc_st.clone_and_prepend(fmt::format("rollback transaction [{}] failed", request.txnId));
     }
     if (result.status.status_code != TStatusCode::TXN_NOT_EXISTS) {
-        return result.status;
+        return Status(result.status).clone_and_prepend(fmt::format("rollback transaction [{}] failed", request.txnId));
     }
 #else
     result = k_stream_load_rollback_result;

--- a/be/src/util/thrift_rpc_helper.cpp
+++ b/be/src/util/thrift_rpc_helper.cpp
@@ -59,6 +59,37 @@ void ThriftRpcHelper::setup(ExecEnv* exec_env) {
     _s_exec_env = exec_env;
 }
 
+// TRY_CATCH_ALL will not set catched=true, only used for catch unexpected crash,
+// cannot be used to control memory usage.
+#define CATCH_ALL_THRIFT_RPC_EXCEPTION(result, stmt)                                                                 \
+    do {                                                                                                             \
+        std::stringstream ss;                                                                                        \
+        try {                                                                                                        \
+            { stmt; }                                                                                                \
+        } catch (apache::thrift::protocol::TProtocolException & e) {                                                 \
+            if (e.getType() == apache::thrift::protocol::TProtocolException::TProtocolExceptionType::INVALID_DATA) { \
+                ss << "FE RPC response parsing failure, address=" << address                                         \
+                   << ". The FE may be busy, please retry later or increase BE config thrift_rpc_timeout_ms";        \
+            } else {                                                                                                 \
+                ss << "FE RPC failure, address=" << address << ", reason=" << e.what();                              \
+            }                                                                                                        \
+        } catch (apache::thrift::transport::TTransportException & e) {                                               \
+            if (e.getType() == apache::thrift::transport::TTransportException::TTransportExceptionType::TIMED_OUT) { \
+                ss << "FE RPC timeout, address=" << address << ", reason=" << e.what()                               \
+                   << ". The FE may be busy, please retry later or increase BE config thrift_rpc_timeout_ms";        \
+            } else {                                                                                                 \
+                ss << "FE RPC failure, address=" << address << ", reason=" << e.what();                              \
+            }                                                                                                        \
+        } catch (std::exception & e) {                                                                               \
+            ss << "FE RPC failure, address=" << address << ", reason=" << e.what();                                  \
+        }                                                                                                            \
+        if (ss.str().empty()) {                                                                                      \
+            result = Status::OK();                                                                                   \
+        } else {                                                                                                     \
+            result = Status::ThriftRpcError(ss.str());                                                               \
+        }                                                                                                            \
+    } while (0)
+
 template <typename T>
 Status ThriftRpcHelper::rpc(const std::string& ip, const int32_t port,
                             std::function<void(ClientConnection<T>&)> callback, int timeout_ms) {
@@ -69,27 +100,31 @@ Status ThriftRpcHelper::rpc(const std::string& ip, const int32_t port,
         LOG(WARNING) << "Connect frontend failed, address=" << address << ", status=" << status.message();
         return status;
     }
-    try {
-        try {
-            callback(client);
-        } catch (apache::thrift::transport::TTransportException& e) {
-            status = client.reopen(timeout_ms);
-            if (!status.ok()) {
-                LOG(WARNING) << "client reopen failed. address=" << address << ", status=" << status.message();
-                return status;
-            }
-            callback(client);
-        }
-    } catch (apache::thrift::TException& e) {
-        std::stringstream ss;
-        ss << "call frontend service failed, address=" << address << ", reason=" << e.what();
-        LOG(WARNING) << ss.str();
+
+    // 1st call
+    CATCH_ALL_THRIFT_RPC_EXCEPTION(status, callback(client));
+    if (status.ok()) {
+        return status;
+    }
+    LOG(WARNING) << status << ", first try";
+
+    SleepFor(MonoDelta::FromMilliseconds(config::thrift_client_retry_interval_ms));
+
+    status = client.reopen(timeout_ms);
+    if (!status.ok()) {
+        LOG(WARNING) << "client reopen failed. address=" << address << ", status=" << status;
+        return status;
+    }
+
+    // 2nd call
+    CATCH_ALL_THRIFT_RPC_EXCEPTION(status, callback(client));
+    if (!status.ok()) {
         SleepFor(MonoDelta::FromMilliseconds(config::thrift_client_retry_interval_ms * 2));
         // just reopen to disable this connection
         (void)client.reopen(timeout_ms);
-        return Status::ThriftRpcError(ss.str());
+        LOG(WARNING) << status << ", last try";
     }
-    return Status::OK();
+    return status;
 }
 
 template Status ThriftRpcHelper::rpc<FrontendServiceClient>(

--- a/be/src/util/thrift_rpc_helper.cpp
+++ b/be/src/util/thrift_rpc_helper.cpp
@@ -59,9 +59,8 @@ void ThriftRpcHelper::setup(ExecEnv* exec_env) {
     _s_exec_env = exec_env;
 }
 
-template <>
-Status ThriftRpcHelper::rpc_impl(std::function<void(ClientConnection<FrontendServiceClient>&)> callback,
-                                 ClientConnection<FrontendServiceClient>& client,
+template <typename T>
+Status ThriftRpcHelper::rpc_impl(std::function<void(ClientConnection<T>&)> callback, ClientConnection<T>& client,
                                  const TNetworkAddress& address) noexcept {
     std::stringstream ss;
     try {
@@ -77,19 +76,6 @@ Status ThriftRpcHelper::rpc_impl(std::function<void(ClientConnection<FrontendSer
         ss << "FE RPC failure, address=" << address << ", reason=" << e.what();
     }
 
-    return Status::ThriftRpcError(ss.str());
-}
-
-template <typename T>
-Status ThriftRpcHelper::rpc_impl(std::function<void(ClientConnection<T>&)> callback, ClientConnection<T>& client,
-                                 const TNetworkAddress& address) noexcept {
-    std::stringstream ss;
-    try {
-        callback(client);
-        return Status::OK();
-    } catch (apache::thrift::TException& e) {
-        ss << "RPC failure, address=" << address << ", reason=" << e.what();
-    }
     return Status::ThriftRpcError(ss.str());
 }
 

--- a/be/src/util/thrift_rpc_helper.h
+++ b/be/src/util/thrift_rpc_helper.h
@@ -28,6 +28,10 @@ class FrontendServiceClient;
 template <class T>
 class ClientConnection;
 
+template <typename T>
+static Status rpc_exec(std::function<void(ClientConnection<T>&)> callback, ClientConnection<T>& client,
+                       const TNetworkAddress& address) noexcept;
+
 // this class is a helper for jni call. easy for unit test
 class ThriftRpcHelper {
 public:

--- a/be/src/util/thrift_rpc_helper.h
+++ b/be/src/util/thrift_rpc_helper.h
@@ -28,10 +28,6 @@ class FrontendServiceClient;
 template <class T>
 class ClientConnection;
 
-template <typename T>
-static Status rpc_exec(std::function<void(ClientConnection<T>&)> callback, ClientConnection<T>& client,
-                       const TNetworkAddress& address) noexcept;
-
 // this class is a helper for jni call. easy for unit test
 class ThriftRpcHelper {
 public:
@@ -46,6 +42,10 @@ public:
     template <typename T>
     static Status rpc(const std::string& ip, const int32_t port, std::function<void(ClientConnection<T>&)> callback,
                       int timeout_ms);
+
+    template <typename T>
+    static Status rpc_impl(std::function<void(ClientConnection<T>&)> callback, ClientConnection<T>& client,
+                           const TNetworkAddress& address) noexcept;
 
 private:
     static ExecEnv* _s_exec_env;

--- a/be/test/CMakeLists.txt
+++ b/be/test/CMakeLists.txt
@@ -443,6 +443,7 @@ set(EXEC_FILES
         ./storage/lake/replication_txn_manager_test.cpp
         ./storage/lake/persistent_index_sstable_test.cpp
         ./block_cache/datacache_utils_test.cpp
+        ./util/thrift_rpc_helper_test.cpp
         )
 
 if ("${WITH_STARCACHE}" STREQUAL "ON" OR "${WITH_CACHELIB}" STREQUAL "ON")

--- a/be/test/util/thrift_rpc_helper_test.cpp
+++ b/be/test/util/thrift_rpc_helper_test.cpp
@@ -41,9 +41,8 @@ TEST_F(ThriftRpcHelperTest, rpc_impl) {
                 client, addr);
         EXPECT_STATUS(Status::ThriftRpcError(""), st);
         EXPECT_EQ(
-                "Rpc error: FE RPC response parsing failure, address=TNetworkAddress(hostname=127.0.0.1, port=8030). "
-                "The "
-                "FE may be busy, please retry later or increase BE config thrift_rpc_timeout_ms",
+                "Rpc error: FE RPC response parsing failure, address=TNetworkAddress(hostname=127.0.0.1, "
+                "port=8030).The FE may be busy, please retry later",
                 st.to_string());
     }
     {
@@ -72,10 +71,8 @@ TEST_F(ThriftRpcHelperTest, rpc_impl) {
                 },
                 client, addr);
         EXPECT_STATUS(Status::ThriftRpcError(""), st);
-        EXPECT_EQ(
-                "Rpc error: FE RPC timeout, address=TNetworkAddress(hostname=127.0.0.1, port=8030), reason=timeout. "
-                "The FE may be busy, please retry later or increase BE config thrift_rpc_timeout_ms",
-                st.to_string());
+        EXPECT_EQ("Rpc error: FE RPC failure, address=TNetworkAddress(hostname=127.0.0.1, port=8030), reason=timeout",
+                  st.to_string());
     }
 
     {
@@ -98,11 +95,12 @@ TEST_F(ThriftRpcHelperTest, rpc_impl) {
         auto addr = make_network_address("127.0.0.1", 8030);
         FrontendServiceConnection client;
         auto st = ThriftRpcHelper::rpc_impl<FrontendServiceClient>(
-                [](FrontendServiceConnection& client) { throw std::exception(); }, client, addr);
+                [](FrontendServiceConnection& client) { throw apache::thrift::TException("some error"); }, client,
+                addr);
         EXPECT_STATUS(Status::ThriftRpcError(""), st);
         EXPECT_EQ(
                 "Rpc error: FE RPC failure, address=TNetworkAddress(hostname=127.0.0.1, port=8030), "
-                "reason=std::exception",
+                "reason=some error",
                 st.to_string());
     }
 }

--- a/be/test/util/thrift_rpc_helper_test.cpp
+++ b/be/test/util/thrift_rpc_helper_test.cpp
@@ -12,26 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// This file is based on code available under the Apache license here:
-//   https://github.com/apache/incubator-doris/blob/master/be/test/util/tdigest_test.cpp
-
-// Licensed to the Apache Software Foundation (ASF) under one
-// or more contributor license agreements.  See the NOTICE file
-// distributed with this work for additional information
-// regarding copyright ownership.  The ASF licenses this file
-// to you under the Apache License, Version 2.0 (the
-// "License"); you may not use this file except in compliance
-// with the License.  You may obtain a copy of the License at
-//
-//   http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing,
-// software distributed under the License is distributed on an
-// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-// KIND, either express or implied.  See the License for the
-// specific language governing permissions and limitations
-// under the License.
-
 #include "util/thrift_rpc_helper.h"
 
 #include <gtest/gtest.h>

--- a/be/test/util/thrift_rpc_helper_test.cpp
+++ b/be/test/util/thrift_rpc_helper_test.cpp
@@ -29,9 +29,9 @@ protected:
     ~ThriftRpcHelperTest() override {}
 };
 
-TEST_F(ThriftRpcHelperTest, rpc_impl) {
+TEST_F(ThriftRpcHelperTest, fe_rpc_impl) {
     {
-        auto addr = make_network_address("127.0.0.1", 8030);
+        auto addr = make_network_address("127.0.0.1", 9020);
         FrontendServiceConnection client;
         auto st = ThriftRpcHelper::rpc_impl<FrontendServiceClient>(
                 [](FrontendServiceConnection& client) {
@@ -42,11 +42,11 @@ TEST_F(ThriftRpcHelperTest, rpc_impl) {
         EXPECT_STATUS(Status::ThriftRpcError(""), st);
         EXPECT_EQ(
                 "Rpc error: FE RPC response parsing failure, address=TNetworkAddress(hostname=127.0.0.1, "
-                "port=8030).The FE may be busy, please retry later",
+                "port=9020).The FE may be busy, please retry later",
                 st.to_string());
     }
     {
-        auto addr = make_network_address("127.0.0.1", 8030);
+        auto addr = make_network_address("127.0.0.1", 9020);
         FrontendServiceConnection client;
         auto st = ThriftRpcHelper::rpc_impl<FrontendServiceClient>(
                 [](FrontendServiceConnection& client) {
@@ -56,13 +56,13 @@ TEST_F(ThriftRpcHelperTest, rpc_impl) {
                 client, addr);
         EXPECT_STATUS(Status::ThriftRpcError(""), st);
         EXPECT_EQ(
-                "Rpc error: FE RPC failure, address=TNetworkAddress(hostname=127.0.0.1, port=8030), reason=message "
+                "Rpc error: FE RPC failure, address=TNetworkAddress(hostname=127.0.0.1, port=9020), reason=message "
                 "size limit",
                 st.to_string());
     }
 
     {
-        auto addr = make_network_address("127.0.0.1", 8030);
+        auto addr = make_network_address("127.0.0.1", 9020);
         FrontendServiceConnection client;
         auto st = ThriftRpcHelper::rpc_impl<FrontendServiceClient>(
                 [](FrontendServiceConnection& client) {
@@ -71,12 +71,12 @@ TEST_F(ThriftRpcHelperTest, rpc_impl) {
                 },
                 client, addr);
         EXPECT_STATUS(Status::ThriftRpcError(""), st);
-        EXPECT_EQ("Rpc error: FE RPC failure, address=TNetworkAddress(hostname=127.0.0.1, port=8030), reason=timeout",
+        EXPECT_EQ("Rpc error: FE RPC failure, address=TNetworkAddress(hostname=127.0.0.1, port=9020), reason=timeout",
                   st.to_string());
     }
 
     {
-        auto addr = make_network_address("127.0.0.1", 8030);
+        auto addr = make_network_address("127.0.0.1", 9020);
         FrontendServiceConnection client;
         auto st = ThriftRpcHelper::rpc_impl<FrontendServiceClient>(
                 [](FrontendServiceConnection& client) {
@@ -86,20 +86,48 @@ TEST_F(ThriftRpcHelperTest, rpc_impl) {
                 client, addr);
         EXPECT_STATUS(Status::ThriftRpcError(""), st);
         EXPECT_EQ(
-                "Rpc error: FE RPC failure, address=TNetworkAddress(hostname=127.0.0.1, port=8030), reason=corrupted "
+                "Rpc error: FE RPC failure, address=TNetworkAddress(hostname=127.0.0.1, port=9020), reason=corrupted "
                 "data",
                 st.to_string());
     }
 
     {
-        auto addr = make_network_address("127.0.0.1", 8030);
+        auto addr = make_network_address("127.0.0.1", 9020);
         FrontendServiceConnection client;
         auto st = ThriftRpcHelper::rpc_impl<FrontendServiceClient>(
                 [](FrontendServiceConnection& client) { throw apache::thrift::TException("some error"); }, client,
                 addr);
         EXPECT_STATUS(Status::ThriftRpcError(""), st);
         EXPECT_EQ(
-                "Rpc error: FE RPC failure, address=TNetworkAddress(hostname=127.0.0.1, port=8030), "
+                "Rpc error: FE RPC failure, address=TNetworkAddress(hostname=127.0.0.1, port=9020), "
+                "reason=some error",
+                st.to_string());
+    }
+}
+
+TEST_F(ThriftRpcHelperTest, be_cn_rpc_impl) {
+    {
+        auto addr = make_network_address("127.0.0.1", 8060);
+        BackendServiceConnection client;
+        auto st = ThriftRpcHelper::rpc_impl<BackendServiceClient>(
+                [](BackendServiceConnection& client) { throw apache::thrift::TException("some error"); }, client, addr);
+        EXPECT_STATUS(Status::ThriftRpcError(""), st);
+        EXPECT_EQ(
+                "Rpc error: BE/CN RPC failure, address=TNetworkAddress(hostname=127.0.0.1, port=8060), "
+                "reason=some error",
+                st.to_string());
+    }
+}
+
+TEST_F(ThriftRpcHelperTest, broker_rpc_impl) {
+    {
+        auto addr = make_network_address("127.0.0.1", 8060);
+        BrokerServiceConnection client;
+        auto st = ThriftRpcHelper::rpc_impl<TFileBrokerServiceClient>(
+                [](BrokerServiceConnection& client) { throw apache::thrift::TException("some error"); }, client, addr);
+        EXPECT_STATUS(Status::ThriftRpcError(""), st);
+        EXPECT_EQ(
+                "Rpc error: Broker RPC failure, address=TNetworkAddress(hostname=127.0.0.1, port=8060), "
                 "reason=some error",
                 st.to_string());
     }


### PR DESCRIPTION
## Why I'm doing:
When there's a FE RPC failure, we often get a error `call frontend service failed reason=xxx`. 
## What I'm doing:
This PR improves the error message.
| error type| old error message | new error message|
| --| -- | -- |
| RPC timeout |  call frontend service failed, address=TNetworkAddress(hostname=127.0.0.1, port=19020), reason=THRIFT_EAGAIN (timed out) | FE RPC failure, address=TNetworkAddress(hostname=127.0.0.1, port=19020), reason=THRIFT_EAGAIN (timed out) |
| RPC response parsing failure | call frontend service failed, address=TNetworkAddress(hostname=127.0.0.1, port=19020), reason=Invalid TType|FE RPC response parsing failure, address=TNetworkAddress(hostname=127.0.0.1, port=19020). The FE may be busy, please retry later |
| other | call frontend service failed, ddress=TNetworkAddress(hostname=127.0.0.1, port=19020), reason=xxx|FE RPC failure, address=TNetworkAddress(hostname=127.0.0.1, port=19020), reason=xxx|

Fixes #issue


## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
