### PR TITLE
[Enhancement] optional prebuild download maven jar dependencies to a different locations

### DIFF
--- a/docker/dockerfiles/dev-env/dev-env.Dockerfile
+++ b/docker/dockerfiles/dev-env/dev-env.Dockerfile
@@ -13,8 +13,8 @@
 
 # whether prebuild starrocks maven project and cache the maven artifacts
 # value: true | false
-# default: true
-ARG prebuild_maven=true
+# default: false
+ARG prebuild_maven=false
 # whether pre download thirdparty all-in-one tarball before build
 # value: true | false
 # default: false
@@ -33,7 +33,8 @@ ENV STARROCKS_THIRDPARTY=/var/local/thirdparty
 
 WORKDIR /root
 
-FROM base as builder
+FROM base as builder_stage1
+# stage1: build thirdparty
 ARG prebuild_maven
 ARG predownload_thirdparty
 ARG thirdparty_url
@@ -46,19 +47,30 @@ RUN if test "x$predownload_thirdparty" = "xtrue" ; then \
     fi
 RUN mkdir -p $STARROCKS_THIRDPARTY/installed && cd starrocks/thirdparty && \
      PARALLEL=`nproc` GH_TOKEN=${GITHUB_TOKEN} ./build-thirdparty.sh && cp -r installed $STARROCKS_THIRDPARTY/
-RUN if test "x$prebuild_maven" = "xtrue" ; then \
+# create empty maven directories
+RUN mkdir -p /root/.m2 /root/.mvn
+
+
+FROM builder_stage1 as build_prebuild_mvn_true
+# set the maven settings and download the dependency jars
+RUN cp -a /root/starrocks/docker/dockerfiles/dev-env/mvn/* /root/.mvn/ ; \
         export MAVEN_OPTS='-Dmaven.artifact.threads=128' ; cd /root/starrocks ; ./build.sh --fe || true ; \
-        cd java-extensions ; mvn package -DskipTests || true ;  \
-    else \
-        mkdir -p /root/.m2  ;   \
-    fi
+        cd java-extensions ; mvn package -DskipTests || true
+
+FROM builder_stage1 as build_prebuild_mvn_false
+# do nothing
+
+
+FROM build_prebuild_mvn_${prebuild_maven} as build_stage2
+# build_stage2: prebuild maven dependencies, could be no-op if prebuild_maven=false
+
 
 FROM starrocks/starlet-artifacts-ubuntu22:${starlet_tag} as starlet-ubuntu
 FROM starrocks/starlet-artifacts-centos7:${starlet_tag} as starlet-centos7
 # determine which artifacts to use
 FROM starlet-${distro} as starlet
 # remove unnecessary and big starlet dependencies
-COPY --from=builder /root/starrocks/docker/dockerfiles/dev-env/starlet_exclude.txt .
+COPY --from=builder_stage1 /root/starrocks/docker/dockerfiles/dev-env/starlet_exclude.txt .
 RUN while read line; do \
         if [[ "$line" == \#* ]] ; then \
             continue ; \
@@ -66,7 +78,9 @@ RUN while read line; do \
         rm -rvf /release/$line ; \
     done < starlet_exclude.txt
 
+
 FROM base as dev-env
+# Final stage: collect all artifacts
 ARG commit_id
 LABEL org.opencontainers.image.source="https://github.com/StarRocks/starrocks"
 LABEL com.starrocks.commit=${commit_id:-"UNKNOWN"}
@@ -74,8 +88,9 @@ ENV STARLET_INSTALL_DIR=$STARROCKS_THIRDPARTY/installed/starlet
 ENV PATH=$STARROCKS_GCC_HOME/bin:$PATH
 
 # Copy third-party dependencies
-COPY --from=builder $STARROCKS_THIRDPARTY $STARROCKS_THIRDPARTY
+COPY --from=build_stage2 $STARROCKS_THIRDPARTY $STARROCKS_THIRDPARTY
 # Copy maven dependencies
-COPY --from=builder /root/.m2 /root/.m2
+COPY --from=build_stage2 /root/.m2 /root/.m2/
+COPY --from=build_stage2 /root/.mvn /root/.mvn/
 # Copy starlet dependencies
 COPY --from=starlet /release $STARLET_INSTALL_DIR

--- a/docker/dockerfiles/dev-env/mvn/README.md
+++ b/docker/dockerfiles/dev-env/mvn/README.md
@@ -1,0 +1,4 @@
+Specific settings to maven utility so that it can find a different location for its local repository.
+
+* an additional option `-s /root/.mvn/settings.xml` is added in `maven.config` when mvn command is invoked.
+* `/root/.mvn/settings.xml` configures mvn to use `/root/.mvn/repositories` as its local repository location.

--- a/docker/dockerfiles/dev-env/mvn/maven.config
+++ b/docker/dockerfiles/dev-env/mvn/maven.config
@@ -1,0 +1,1 @@
+-s /root/.mvn/settings.xml

--- a/docker/dockerfiles/dev-env/mvn/settings.xml
+++ b/docker/dockerfiles/dev-env/mvn/settings.xml
@@ -1,0 +1,6 @@
+<settings xmlns="http://maven.apache.org/SETTINGS/1.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.0.0 https://maven.apache.org/xsd/settings-1.0.0.xsd">
+  <localRepository>/root/.mvn/repository</localRepository>
+  <interactiveMode>true</interactiveMode>
+  <offline>false</offline>
+</settings>


### PR DESCRIPTION
* if maven dependencies are downloaded in dev-env phase, save it in a different location and config maven to read from the customized location.
* in artifacts phase, if the dev-env didn't do a pre-download, the .mvn will be empty, the default repository will be still /root/.m2/, otherwise the /root/.mvn/maven.config will modify the jar location to the customized location: /root/.mvn/repositories which won't be overwritten by the `RUN --mount=type=cache,target=/root/.m2` option

## Why I'm doing:

## What I'm doing:

Fixes #42829

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [x] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [x] Parameter changes: default values, similar parameters but with different default values
- [x] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [x] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
