### PR TITLE
[BugFix] Fixed lock downgrade logic being inconsistent in LockManager and ReentrantReadWriteLock

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/common/util/concurrent/lock/LockHolder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/util/concurrent/lock/LockHolder.java
@@ -47,20 +47,7 @@ public class LockHolder implements Cloneable {
     }
 
     boolean isConflict(LockHolder lockHolderRequest) {
-        if (lockHolderRequest.locker == this.locker
-                && this.lockType == LockType.WRITE && lockHolderRequest.lockType == LockType.READ) {
-            /*
-             * If you acquire an exclusive lock first and then request a shared lock, you can successfully acquire the lock.
-             * This scenario is generally called "lock downgrade",
-             *  but this lock does not actually reduce the original write lock directly to a read lock.
-             * In fact, it is still two independent read and write locks, and the two locks still need
-             * to be released independently. The actual scenario is that before releasing the write lock,
-             * acquire the read lock first, so that there is no gap time to release the lock.
-             */
-            return false;
-        } else {
-            return this.lockType.isConflict(lockHolderRequest.getLockType());
-        }
+        return this.lockType.isConflict(lockHolderRequest.getLockType());
     }
 
     @Override

--- a/fe/fe-core/src/test/java/com/starrocks/common/lock/TestLockManagerReentrantLock.java
+++ b/fe/fe-core/src/test/java/com/starrocks/common/lock/TestLockManagerReentrantLock.java
@@ -64,6 +64,72 @@ public class TestLockManagerReentrantLock {
     }
 
     @Test
+    public void testXLockReentrant2() {
+        long rid = 1L;
+
+        TestLocker testLocker1 = new TestLocker();
+        //acquire LightWeightLock
+        LockTestUtils.assertLockSuccess(testLocker1.lock(rid, LockType.WRITE));
+        //acquire MultiUserLock
+        LockTestUtils.assertLockSuccess(testLocker1.lock(rid, LockType.WRITE));
+        //Verify that the same write lock is acquired normally on MultiUserLock
+        LockTestUtils.assertLockSuccess(testLocker1.lock(rid, LockType.WRITE));
+
+        LockTestUtils.assertLockSuccess(testLocker1.release(rid, LockType.WRITE));
+        LockTestUtils.assertLockSuccess(testLocker1.release(rid, LockType.WRITE));
+        LockTestUtils.assertLockSuccess(testLocker1.release(rid, LockType.WRITE));
+
+        LockTestUtils.assertLockFail(testLocker1.release(rid, LockType.WRITE), IllegalMonitorStateException.class);
+    }
+
+    @Test
+    public void testXLockReentrant3() {
+        long rid = 1L;
+
+        TestLocker testLocker1 = new TestLocker();
+        //acquire LightWeightLock
+        LockTestUtils.assertLockSuccess(testLocker1.lock(rid, LockType.WRITE));
+        //acquire MultiUserLock
+        LockTestUtils.assertLockSuccess(testLocker1.lock(rid, LockType.WRITE));
+        //Verify that the same write lock is acquired normally on MultiUserLock
+        LockTestUtils.assertLockSuccess(testLocker1.lock(rid, LockType.WRITE));
+
+        LockTestUtils.assertLockSuccess(testLocker1.lock(rid, LockType.READ));
+        LockTestUtils.assertLockSuccess(testLocker1.lock(rid, LockType.READ));
+
+        LockTestUtils.assertLockSuccess(testLocker1.release(rid, LockType.WRITE));
+        LockTestUtils.assertLockSuccess(testLocker1.release(rid, LockType.WRITE));
+        LockTestUtils.assertLockSuccess(testLocker1.release(rid, LockType.WRITE));
+
+        LockTestUtils.assertLockSuccess(testLocker1.release(rid, LockType.READ));
+        LockTestUtils.assertLockSuccess(testLocker1.release(rid, LockType.READ));
+
+        LockTestUtils.assertLockFail(testLocker1.release(rid, LockType.WRITE), IllegalMonitorStateException.class);
+        LockTestUtils.assertLockFail(testLocker1.release(rid, LockType.READ), IllegalMonitorStateException.class);
+    }
+
+    @Test
+    public void testXLockReentrant4() {
+        long rid = 1L;
+
+        TestLocker testLocker1 = new TestLocker();
+        LockTestUtils.assertLockSuccess(testLocker1.lock(rid, LockType.WRITE));
+        LockTestUtils.assertLockSuccess(testLocker1.lock(rid, LockType.READ));
+        LockTestUtils.assertLockSuccess(testLocker1.lock(rid, LockType.READ));
+        // The write lock can be increased normally because there is a reference count for the write lock
+        LockTestUtils.assertLockSuccess(testLocker1.lock(rid, LockType.WRITE));
+
+        LockTestUtils.assertLockSuccess(testLocker1.release(rid, LockType.WRITE));
+        LockTestUtils.assertLockSuccess(testLocker1.release(rid, LockType.WRITE));
+        LockTestUtils.assertLockFail(testLocker1.release(rid, LockType.WRITE), IllegalMonitorStateException.class);
+
+        // The write lock cannot be obtained because the write lock has already been released.
+        // It is not possible to upgrade the write lock while holding the read lock.
+        Future<LockResult> lockerFuture = testLocker1.lock(rid, LockType.WRITE);
+        LockTestUtils.assertLockWait(lockerFuture);
+    }
+
+    @Test
     public void testXAfterS() {
         long rid = 1L;
         TestLocker testLocker1 = new TestLocker();
@@ -105,6 +171,19 @@ public class TestLockManagerReentrantLock {
         TestLocker testLocker3 = new TestLocker();
         Future<LockResult> lockerFuture3 = testLocker3.lock(rid, LockType.READ);
         LockTestUtils.assertLockWait(lockerFuture3);
+
+        LockTestUtils.assertLockSuccess(testLocker1.lock(rid, LockType.READ));
+    }
+
+    @Test
+    public void testLockDowngrade() {
+        long rid = 1L;
+        TestLocker testLocker1 = new TestLocker();
+        LockTestUtils.assertLockSuccess(testLocker1.lock(rid, LockType.WRITE));
+
+        TestLocker testLocker2 = new TestLocker();
+        Future<LockResult> lockerFuture2 = testLocker2.lock(rid, LockType.READ);
+        LockTestUtils.assertLockWait(lockerFuture2);
 
         LockTestUtils.assertLockSuccess(testLocker1.lock(rid, LockType.READ));
     }


### PR DESCRIPTION
Lock downgrade logic In the implementation of ReentrantReadWriteLock, thread 1 obtains the write lock first, and thread 2 will wait after applying for the read lock. At this time, if thread 1 continues to apply for the read lock, it will ignore the waiter list and obtain the read lock directly.

## Why I'm doing:

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
