### PR TITLE
[BugFix] fix cloud native pk index sstable compaction race condition issue

### DIFF
--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -982,7 +982,7 @@ CONF_mInt64(lake_pk_compaction_min_input_segments, "5");
 // Used for control memory usage of update state cache and compaction state cache
 CONF_mInt32(lake_pk_preload_memory_limit_percent, "30");
 CONF_mInt32(lake_pk_index_sst_min_compaction_versions, "2");
-CONF_mInt32(lake_pk_index_sst_max_compaction_versions, "15");
+CONF_mInt32(lake_pk_index_sst_max_compaction_versions, "5");
 CONF_Int32(lake_pk_index_block_cache_limit_percent, "10");
 
 CONF_mBool(dependency_librdkafka_debug_enable, "false");

--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -982,7 +982,7 @@ CONF_mInt64(lake_pk_compaction_min_input_segments, "5");
 // Used for control memory usage of update state cache and compaction state cache
 CONF_mInt32(lake_pk_preload_memory_limit_percent, "30");
 CONF_mInt32(lake_pk_index_sst_min_compaction_versions, "2");
-CONF_mInt32(lake_pk_index_sst_max_compaction_versions, "5");
+CONF_mInt32(lake_pk_index_sst_max_compaction_versions, "15");
 CONF_Int32(lake_pk_index_block_cache_limit_percent, "10");
 
 CONF_mBool(dependency_librdkafka_debug_enable, "false");

--- a/be/src/storage/lake/lake_persistent_index.cpp
+++ b/be/src/storage/lake/lake_persistent_index.cpp
@@ -269,13 +269,8 @@ Status LakePersistentIndex::prepare_merging_iterator(
         // build sstable from meta, instead of reuse `_sstables`, to keep it thread safe
         ASSIGN_OR_RETURN(auto rf,
                          fs::new_random_access_file(_tablet_mgr->sst_location(_tablet_id, sstable_pb.filename())));
-        auto* block_cache = _tablet_mgr->update_mgr()->block_cache();
-        if (block_cache == nullptr) {
-            return Status::InternalError("Block cache is null.");
-        }
         auto merging_sstable = std::make_shared<PersistentIndexSstable>();
-        RETURN_IF_ERROR(
-                merging_sstable->init(std::move(rf), sstable_pb, block_cache->cache(), false /** no filter **/));
+        RETURN_IF_ERROR(merging_sstable->init(std::move(rf), sstable_pb, nullptr, false /** no filter **/));
         merging_sstables->push_back(merging_sstable);
         sstable::Iterator* iter = merging_sstable->new_iterator(read_options);
         iters.emplace_back(iter);

--- a/be/src/storage/lake/lake_persistent_index.h
+++ b/be/src/storage/lake/lake_persistent_index.h
@@ -106,7 +106,7 @@ public:
 
     Status minor_compact();
 
-    Status major_compact(int64_t min_retain_version, TxnLogPB* txn_log);
+    Status major_compact(const TabletMetadata& metadata, int64_t min_retain_version, TxnLogPB* txn_log);
 
     Status apply_opcompaction(const TxnLogPB_OpCompaction& op_compaction);
 
@@ -142,7 +142,10 @@ private:
 
     static void set_difference(KeyIndexSet* key_indexes, const KeyIndexSet& found_key_indexes);
 
-    std::unique_ptr<sstable::Iterator> prepare_merging_iterator();
+    // get sstable's iterator that need to compact and modify txn_log
+    Status prepare_merging_iterator(const TabletMetadata& metadata, TxnLogPB* txn_log,
+                                    std::vector<std::shared_ptr<PersistentIndexSstable>>* sstable_vec,
+                                    std::unique_ptr<sstable::Iterator>* merging_iter_ptr);
 
     Status merge_sstables(std::unique_ptr<sstable::Iterator> iter_ptr, sstable::TableBuilder* builder);
 

--- a/be/src/storage/lake/lake_persistent_index.h
+++ b/be/src/storage/lake/lake_persistent_index.h
@@ -144,7 +144,7 @@ private:
 
     // get sstable's iterator that need to compact and modify txn_log
     Status prepare_merging_iterator(const TabletMetadata& metadata, TxnLogPB* txn_log,
-                                    std::vector<std::shared_ptr<PersistentIndexSstable>>* sstable_vec,
+                                    std::vector<std::shared_ptr<PersistentIndexSstable>>* merging_sstables,
                                     std::unique_ptr<sstable::Iterator>* merging_iter_ptr);
 
     Status merge_sstables(std::unique_ptr<sstable::Iterator> iter_ptr, sstable::TableBuilder* builder);

--- a/be/src/storage/lake/lake_primary_index.cpp
+++ b/be/src/storage/lake/lake_primary_index.cpp
@@ -248,7 +248,7 @@ Status LakePrimaryIndex::major_compact(const TabletMetadata& metadata, TxnLogPB*
     case PersistentIndexTypePB::CLOUD_NATIVE: {
         auto* lake_persistent_index = dynamic_cast<LakePersistentIndex*>(_persistent_index.get());
         if (lake_persistent_index != nullptr) {
-            return lake_persistent_index->major_compact(0 /** min_retain_version **/, txn_log);
+            return lake_persistent_index->major_compact(metadata, 0 /** min_retain_version **/, txn_log);
         } else {
             return Status::InternalError("Persistent index is not a LakePersistentIndex.");
         }

--- a/be/src/storage/lake/persistent_index_sstable.cpp
+++ b/be/src/storage/lake/persistent_index_sstable.cpp
@@ -23,10 +23,12 @@
 namespace starrocks::lake {
 
 Status PersistentIndexSstable::init(std::unique_ptr<RandomAccessFile> rf, const PersistentIndexSstablePB& sstable_pb,
-                                    Cache* cache) {
+                                    Cache* cache, bool need_filter) {
     sstable::Options options;
-    _filter_policy.reset(const_cast<sstable::FilterPolicy*>(sstable::NewBloomFilterPolicy(10)));
-    options.filter_policy = _filter_policy.get();
+    if (need_filter) {
+        _filter_policy.reset(const_cast<sstable::FilterPolicy*>(sstable::NewBloomFilterPolicy(10)));
+        options.filter_policy = _filter_policy.get();
+    }
     options.block_cache = cache;
     sstable::Table* table;
     RETURN_IF_ERROR(sstable::Table::Open(options, rf.get(), sstable_pb.filesize(), &table));

--- a/be/src/storage/lake/persistent_index_sstable.h
+++ b/be/src/storage/lake/persistent_index_sstable.h
@@ -39,7 +39,8 @@ public:
     PersistentIndexSstable() = default;
     ~PersistentIndexSstable() = default;
 
-    Status init(std::unique_ptr<RandomAccessFile> rf, const PersistentIndexSstablePB& sstable_pb, Cache* cache);
+    Status init(std::unique_ptr<RandomAccessFile> rf, const PersistentIndexSstablePB& sstable_pb, Cache* cache,
+                bool need_filter = true);
 
     static Status build_sstable(const phmap::btree_map<std::string, std::list<IndexValueWithVer>, std::less<>>& map,
                                 WritableFile* wf, uint64_t* filesz);

--- a/be/src/storage/sstable/merger.cpp
+++ b/be/src/storage/sstable/merger.cpp
@@ -175,8 +175,6 @@ Iterator* NewMergingIterator(const Comparator* comparator, Iterator** children, 
     assert(n >= 0);
     if (n == 0) {
         return NewEmptyIterator();
-    } else if (n == 1) {
-        return children[0];
     } else {
         return new MergingIterator(comparator, children, n);
     }

--- a/be/test/storage/lake/lake_persistent_index_test.cpp
+++ b/be/test/storage/lake/lake_persistent_index_test.cpp
@@ -233,7 +233,7 @@ TEST_F(LakePersistentIndexTest, test_major_compaction) {
     get_values.clear();
     get_values.reserve(config::lake_pk_index_sst_max_compaction_versions * N);
     auto txn_log = std::make_shared<TxnLogPB>();
-    ASSERT_OK(index->major_compact(0, txn_log.get()));
+    ASSERT_OK(index->major_compact(*_tablet_metadata, 0, txn_log.get()));
     ASSERT_OK(index->apply_opcompaction(txn_log->op_compaction()));
     ASSERT_OK(index->get(config::lake_pk_index_sst_max_compaction_versions * N, total_key_slices.data(),
                          get_values.data()));

--- a/be/test/storage/lake/primary_key_compaction_task_test.cpp
+++ b/be/test/storage/lake/primary_key_compaction_task_test.cpp
@@ -1214,6 +1214,85 @@ TEST_P(LakePrimaryKeyCompactionTest, test_major_compaction) {
     config::l0_max_mem_usage = l0_max_mem_usage;
 }
 
+TEST_P(LakePrimaryKeyCompactionTest, test_major_compaction_thread_safe) {
+    if (!GetParam().enable_persistent_index || GetParam().persistent_index_type == PersistentIndexTypePB::LOCAL) {
+        return;
+    }
+    // Prepare data for writing
+    std::vector<Chunk> chunks;
+    int N = config::lake_pk_index_sst_max_compaction_versions + 5;
+    for (int i = 0; i < N; i++) {
+        chunks.push_back(generate_data(kChunkSize, i));
+    }
+    auto indexes = std::vector<uint32_t>(kChunkSize);
+    for (int i = 0; i < kChunkSize; i++) {
+        indexes[i] = i;
+    }
+
+    auto l0_max_mem_usage = config::l0_max_mem_usage;
+    config::l0_max_mem_usage = 10;
+    auto version = 1;
+    auto tablet_id = _tablet_metadata->id();
+    for (int i = 0; i < N; i++) {
+        auto txn_id = next_id();
+        ASSIGN_OR_ABORT(auto delta_writer, DeltaWriterBuilder()
+                                                   .set_tablet_manager(_tablet_mgr.get())
+                                                   .set_tablet_id(tablet_id)
+                                                   .set_txn_id(txn_id)
+                                                   .set_partition_id(_partition_id)
+                                                   .set_mem_tracker(_mem_tracker.get())
+                                                   .set_schema_id(_tablet_schema->id())
+                                                   .build());
+        ASSERT_OK(delta_writer->open());
+        ASSERT_OK(delta_writer->write(chunks[i], indexes.data(), indexes.size()));
+        ASSERT_OK(delta_writer->finish());
+        delta_writer->close();
+        // Publish version
+        ASSERT_OK(publish_single_version(tablet_id, version + 1, txn_id).status());
+        version++;
+    }
+    ASSERT_EQ(kChunkSize * 10, read(version));
+    ASSIGN_OR_ABORT(auto new_tablet_metadata, _tablet_mgr->get_tablet_metadata(tablet_id, version));
+    EXPECT_EQ(new_tablet_metadata->rowsets_size(), 10);
+
+    std::vector<std::thread> workers;
+    workers.emplace_back([&]() {
+        for (int i = 0; i < N; i++) {
+            auto txn_id = next_id() + N * 10;
+            auto task_context = std::make_unique<CompactionTaskContext>(txn_id, tablet_id, version, false, nullptr);
+            ASSIGN_OR_ABORT(auto task, _tablet_mgr->compact(task_context.get()));
+            check_task(task);
+            ASSERT_OK(task->execute(CompactionTask::kNoCancelFn));
+            EXPECT_EQ(100, task_context->progress.value());
+        }
+    });
+    workers.emplace_back([&]() {
+        for (int i = 0; i < N; i++) {
+            auto txn_id = next_id();
+            ASSIGN_OR_ABORT(auto delta_writer, DeltaWriterBuilder()
+                                                       .set_tablet_manager(_tablet_mgr.get())
+                                                       .set_tablet_id(tablet_id)
+                                                       .set_txn_id(txn_id)
+                                                       .set_partition_id(_partition_id)
+                                                       .set_mem_tracker(_mem_tracker.get())
+                                                       .set_schema_id(_tablet_schema->id())
+                                                       .build());
+            ASSERT_OK(delta_writer->open());
+            ASSERT_OK(delta_writer->write(chunks[i], indexes.data(), indexes.size()));
+            ASSERT_OK(delta_writer->finish());
+            delta_writer->close();
+            // Publish version
+            ASSERT_OK(publish_single_version(tablet_id, version + 1, txn_id).status());
+            version++;
+        }
+    });
+    for (auto& worker : workers) {
+        worker.join();
+    }
+
+    config::l0_max_mem_usage = l0_max_mem_usage;
+}
+
 INSTANTIATE_TEST_SUITE_P(
         LakePrimaryKeyCompactionTest, LakePrimaryKeyCompactionTest,
         ::testing::Values(CompactionParam{HORIZONTAL_COMPACTION, 5, false},


### PR DESCRIPTION
## Why I'm doing:
When enable cloud native pk index, publish version will read from sstables in pk index. And also background compaction thread will also need to compact several sstables into one sstable. They will both visit same `PersistentIndexSstable` list and there's not thread safe.

## What I'm doing:
Compaction thread will build it's own `PersistentIndexSstable` from tablet meta. 

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
