### PR TITLE
[BugFix] Fix the concurrency bug of import bitmap

### DIFF
--- a/be/src/column/object_column.cpp
+++ b/be/src/column/object_column.cpp
@@ -279,7 +279,10 @@ void ObjectColumn<T>::_build_slices() const {
     // Do we really need compress bitmap here?
     if constexpr (std::is_same_v<T, BitmapValue>) {
         for (size_t i = 0; i < _pool.size(); ++i) {
-            _pool[i].compress();
+            // TODO: Putting compress here is not a good way to implement it.
+            //  It is better to put it before writing data and provide an independent Column::Optimize interface.
+            //  For now, let’s implement it in this way with relatively small changes.
+            const_cast<T*>(&_pool[i])->compress();
         }
     }
 

--- a/be/src/types/bitmap_value.cpp
+++ b/be/src/types/bitmap_value.cpp
@@ -897,10 +897,10 @@ size_t BitmapValue::serialize(uint8_t* dst) const {
 
 // When you persist bitmap value to disk, you could call this method.
 // This method should be called before `serialize_size`.
-void BitmapValue::compress() const {
+void BitmapValue::compress() {
     if (_type == BITMAP) {
         _mem_usage = 0;
-        // no need to copy on write
+        _copy_on_write();
         _bitmap->runOptimize();
         _bitmap->shrinkToFit();
     }

--- a/be/src/types/bitmap_value.h
+++ b/be/src/types/bitmap_value.h
@@ -183,7 +183,7 @@ public:
 
     // When you persist bitmap value to disk, you could call this method.
     // This method should be called before `serialize_size`.
-    void compress() const;
+    void compress();
 
     void clear();
     void reset();

--- a/be/test/types/bitmap_value_test.cpp
+++ b/be/test/types/bitmap_value_test.cpp
@@ -18,6 +18,7 @@
 
 #include <cstdint>
 #include <string>
+#include <thread>
 
 #include "column/vectorized_fwd.h"
 #include "types/bitmap_value_detail.h"
@@ -34,6 +35,18 @@ public:
     void check_bitmap(BitmapDataType type, const BitmapValue& bitmap, uint64_t start, uint64_t end);
     void check_bitmap(BitmapDataType type, const BitmapValue& bitmap, uint64_t start_1, uint64_t end_1,
                       uint64_t start_2, uint64_t end_2);
+
+    static void compress_thread(void* arg1) {
+        BitmapValue v = *(BitmapValue*)(arg1);
+        v.compress();
+    }
+
+    static void compress_mem_usage_thread(void* arg1) {
+        for (size_t i = 0; i < 10000; i++) {
+            BitmapValue v = *(BitmapValue*)(arg1);
+            v.get_size_in_bytes();
+        }
+    }
 
 protected:
     BitmapValue _large_bitmap;
@@ -80,6 +93,22 @@ void BitmapValueTest::check_bitmap(BitmapDataType type, const BitmapValue& bitma
         ASSERT_TRUE(bitmap.contains(i));
     }
     ASSERT_EQ(bitmap.mem_usage(), bitmap.serialize_size());
+}
+
+TEST_F(BitmapValueTest, concurrency_compress) {
+    BitmapValue bitmap;
+    for (size_t i = 0; i < 10000; i+=1) {
+        bitmap.add(i);
+    }
+    for (size_t i = 100; i < 1000; i+=100) {
+        bitmap.remove(i);
+    }
+
+    std::thread t1(compress_mem_usage_thread, &bitmap);
+    std::thread t2(compress_thread, &bitmap);
+
+    t1.join();
+    t2.join();
 }
 
 TEST_F(BitmapValueTest, copy_construct) {

--- a/be/test/types/bitmap_value_test.cpp
+++ b/be/test/types/bitmap_value_test.cpp
@@ -97,10 +97,10 @@ void BitmapValueTest::check_bitmap(BitmapDataType type, const BitmapValue& bitma
 
 TEST_F(BitmapValueTest, concurrency_compress) {
     BitmapValue bitmap;
-    for (size_t i = 0; i < 10000; i+=1) {
+    for (size_t i = 0; i < 10000; i += 1) {
         bitmap.add(i);
     }
-    for (size_t i = 100; i < 1000; i+=100) {
+    for (size_t i = 100; i < 1000; i += 100) {
         bitmap.remove(i);
     }
 


### PR DESCRIPTION
## Why I'm doing:

```
*** Aborted at 1711496451 (unix time) try "date -d @1711496451" if you are using GNU date ***
PC: @          0x6318aa0 ra_portable_size_in_bytes
*** SIGSEGV (@0x0) received by PID 1770312 (TID 0x7ffaf29ff700) from PID 0; stack trace: ***
    @          0x5c2c0c2 google::(anonymous namespace)::FailureSignalHandler()
    @     0x7ffff6840630 (unknown)
    @          0x6318aa0 ra_portable_size_in_bytes
    @          0x4b1a198 starrocks::BitmapValue::get_size_in_bytes()
    @          0x5122c30 starrocks::vectorized::ObjectColumn<>::byte_size()
    @          0x2cf8cd3 starrocks::vectorized::Column::memory_usage()
    @          0x50fcb8b starrocks::vectorized::NullableColumn::memory_usage()
    @          0x5101270 starrocks::vectorized::Chunk::memory_usage()
    @          0x446a5f8 starrocks::vectorized::MemTable::insert()
    @          0x4989d1d starrocks::vectorized::DeltaWriter::write()
    @          0x5453ee7 starrocks::vectorized::AsyncDeltaWriter::_execute()
    @          0x5d80cdc bthread::ExecutionQueueBase::_execute()
    @          0x5d81a58 bthread::ExecutionQueueBase::_execute_tasks()
    @          0x4be4772 starrocks::ThreadPool::dispatch_thread()
    @          0x4bdf20a starrocks::Thread::supervise_thread()
    @     0x7ffff6838ea5 start_thread
    @     0x7ffff5e5396d __clone
    @                0x0 (unknown)
```

After the pr (#34047), `BitmapValue` support copy on write, when write bitmap, segment write thread will call `BitmapValue::compress()`, the interface will modify the memory struct of bitmap. If the bitmap is shared by  async delta writer thread, it will call `BitmapValue::get_size_in_bytes`, it may be crash because of concurrency read and write.

## What I'm doing:

`BitmapValue::compress()` should execute copy on write.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [x] 3.2
  - [x] 3.1
  - [x] 3.0
  - [x] 2.5
