### PR TITLE
[Enhancement] Use nibble mask in filter_range for ARM

### DIFF
--- a/be/src/column/column_helper.h
+++ b/be/src/column/column_helper.h
@@ -452,7 +452,7 @@ public:
                 matches &= 0x8888'8888'8888'8888ull;
                 for (; matches > 0; matches &= matches - 1) {
                     uint32_t index = __builtin_ctzll(matches) >> 2;
-                    *(data + result_offset++) = *(data + index);
+                    *(data + result_offset++) = *(data + start_offset + index);
                 }
             }
 

--- a/be/src/formats/orc/apache-orc/c++/include/orc/Common.hh
+++ b/be/src/formats/orc/apache-orc/c++/include/orc/Common.hh
@@ -29,6 +29,8 @@
 
 namespace orc {
 
+using int128_t = __int128;
+
 class FileVersion {
 private:
     uint32_t majorVersion;

--- a/be/src/simd/simd.h
+++ b/be/src/simd/simd.h
@@ -19,6 +19,9 @@
 #include <vector>
 #ifdef __SSE2__
 #include <emmintrin.h>
+#elif defined(__ARM_NEON__) && defined(__aarch64__)
+#include <arm_acle.h>
+#include <arm_neon.h>
 #endif
 
 namespace SIMD {
@@ -189,5 +192,19 @@ inline bool contain_nonzero(const std::vector<uint8_t>& list, size_t start, size
     size_t pos = find_nonzero(list, start, count);
     return pos < list.size() && pos < start + count;
 }
+
+#if defined(__ARM_NEON__) && defined(__aarch64__)
+
+/// Returns a 64-bit mask, each 4-bit represents a byte of the input.
+/// The input containes 16 bytes and is expected to either 0x00 or 0xff for each byte.
+/// The returned 4-bit is 0x if the corresponding byte of the input is 0x00, otherwise it is 0xf.
+inline uint64_t get_nibble_mask(uint8x16_t values) {
+    // vshrn_n_u16(values, 4) operates on each 16 bits. It right shifts 4 bits and then keeps the low 8 bits.
+    // Therefore, 2 bytes of value can be compressed into 1 byte.
+    // For example, 0x00'00 -> 0x00, 0xff'00 -> 0xf0, 0x00'ff -> 0x0f, 0xff'ff -> 0xff,
+    return vget_lane_u64(vreinterpret_u64_u8(vshrn_n_u16(vreinterpretq_u16_u8(values), 4)), 0);
+}
+
+#endif
 
 } // namespace SIMD


### PR DESCRIPTION
## Why I'm doing:
Optimize `filter_range` for ARM.

Here is the CPU perf flame graph for the SSB 100GB Q07. The occupation of `FixedLengthColumnBase<int>::filter_range` increases from 11.35% on x86 to 19.27% on ARM.

Q07 is special, because almost every chunk keeps several rows after filtering. Therefore, the third branch always hit by every chunk.
```cpp
           if (vmaxvq_u8(filter) == 0) {
                // skip
            } else if (vminvq_u8(filter)) {
                memmove(data + result_offset, data + start_offset, kBatchNums * data_type_size);
                result_offset += kBatchNums;
            } else { /* --------- the third branch --------- */
                for (int i = 0; i < kBatchNums; ++i) {
                    if (vgetq_lane_u8(filter, i)) {
                        *(data + result_offset++) = *(data + start_offset + i);
                    }
                }
            }
```

on ARM
![Q07 perf arm](https://github.com/StarRocks/starrocks/assets/13313784/63ae01f1-79a3-4614-8c02-31bc8f797ea1)

on x86
![Q07 perf x86](https://github.com/StarRocks/starrocks/assets/13313784/d8818f5d-ef84-4f26-b0fd-24064ad64a5b)


## What I'm doing:
Inspired by [this article](https://community.arm.com/arm-community-blogs/b/infrastructure-solutions-blog/posts/porting-x86-vector-bitmask-optimizations-to-arm-neon?CommentId=af187ac6-ae00-4e4d-bbf0-e142187aa92e), we could get a nibble mask for the filter result, which is a 64-bit mask, each 4-bit represents a byte of the input.

And then we could use `x &= (x - 1)` and `__builtin_ctzll` to iterate through bits to eliminate `if` branch, which referred to as Kernighan's algorithm.

## Test
Enviroment
- SSB 100GB
- 3 BE with [c7d.4xlarge](https://aws.amazon.com/ec2/instance-types/c7g/)

Test Result
- Q07
    - Before: 568ms
    - After: 487ms
- Q11
    - Before: 612ms
    - After: 554ms


## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
