### PR TITLE
[BugFix] fix hudi pull remote files when refresh mv

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/connector/CachingRemoteFileIO.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/CachingRemoteFileIO.java
@@ -113,6 +113,7 @@ public class CachingRemoteFileIO implements RemoteFileIO {
         } else {
             cache.put(pathKey, loadRemoteFiles(pathKey));
         }
+        pathKey.drop();
     }
 
     public synchronized void invalidateAll() {
@@ -128,6 +129,7 @@ public class CachingRemoteFileIO implements RemoteFileIO {
         } else {
             cache.invalidate(pathKey);
         }
+        pathKey.drop();
     }
 
     private static CacheBuilder<Object, Object> newCacheBuilder(long expiresAfterWriteSec, long refreshSec, long maximumSize) {

--- a/fe/fe-core/src/main/java/com/starrocks/connector/hive/CacheUpdateProcessor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/hive/CacheUpdateProcessor.java
@@ -263,7 +263,9 @@ public class CacheUpdateProcessor {
             }
             List<RemotePathKey> updateKeys = Lists.newArrayList();
             List<RemotePathKey> invalidateKeys = Lists.newArrayList();
+            RemotePathKey.HudiContext hudiContext = new RemotePathKey.HudiContext();
             presentPathKey.forEach(pathKey -> {
+                pathKey.setHudiContext(hudiContext);
                 String pathWithSlash = pathKey.getPath().endsWith("/") ? pathKey.getPath() : pathKey.getPath() + "/";
                 if (operator == Operator.UPDATE && existPaths.contains(pathWithSlash)) {
                     updateKeys.add(pathKey);

--- a/fe/fe-core/src/test/java/com/starrocks/connector/CachingRemoteFileIOTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/CachingRemoteFileIOTest.java
@@ -71,5 +71,6 @@ public class CachingRemoteFileIOTest {
         Assert.assertEquals(1, presentRemoteFileInfos.size());
 
         queryLevelCache.updateRemoteFiles(pathKey);
+        queryLevelCache.invalidatePartition(pathKey);
     }
 }


### PR DESCRIPTION
## Why I'm doing:

When refresh mv on hudi table, `hudi context` is not created yet.

## What I'm doing:

Fixes https://github.com/StarRocks/StarRocksTest/issues/7071

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [x] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
