### PR TITLE
[Enhancement] Use max_bytes to limit LakePersistIndex major compaction

### DIFF
--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -982,7 +982,7 @@ CONF_mInt64(lake_pk_compaction_min_input_segments, "5");
 // Used for control memory usage of update state cache and compaction state cache
 CONF_mInt32(lake_pk_preload_memory_limit_percent, "30");
 CONF_mInt32(lake_pk_index_sst_min_compaction_versions, "2");
-CONF_mInt32(lake_pk_index_sst_max_compaction_versions, "5");
+CONF_mInt32(lake_pk_index_sst_max_compaction_bytes, /*1GB*/ "1073741824");
 CONF_Int32(lake_pk_index_block_cache_limit_percent, "10");
 
 CONF_mBool(dependency_librdkafka_debug_enable, "false");

--- a/be/test/storage/lake/primary_key_compaction_task_test.cpp
+++ b/be/test/storage/lake/primary_key_compaction_task_test.cpp
@@ -1162,7 +1162,7 @@ TEST_P(LakePrimaryKeyCompactionTest, test_major_compaction) {
     }
     // Prepare data for writing
     std::vector<Chunk> chunks;
-    int N = config::lake_pk_index_sst_max_compaction_versions + 5;
+    int N = 10;
     for (int i = 0; i < N; i++) {
         chunks.push_back(generate_data(kChunkSize, i));
     }
@@ -1209,7 +1209,7 @@ TEST_P(LakePrimaryKeyCompactionTest, test_major_compaction) {
     version++;
     ASSERT_EQ(kChunkSize * N, read(version));
     ASSIGN_OR_ABORT(new_tablet_metadata, _tablet_mgr->get_tablet_metadata(tablet_id, version));
-    EXPECT_EQ(config::lake_pk_index_sst_max_compaction_versions, new_tablet_metadata->orphan_files_size());
+    EXPECT_EQ(N - 1, new_tablet_metadata->orphan_files_size());
 
     config::l0_max_mem_usage = l0_max_mem_usage;
 }
@@ -1220,7 +1220,7 @@ TEST_P(LakePrimaryKeyCompactionTest, test_major_compaction_thread_safe) {
     }
     // Prepare data for writing
     std::vector<Chunk> chunks;
-    int N = config::lake_pk_index_sst_max_compaction_versions + 5;
+    int N = 10;
     for (int i = 0; i < N; i++) {
         chunks.push_back(generate_data(kChunkSize, i));
     }


### PR DESCRIPTION
## Why I'm doing:
`lake_pk_index_sst_max_compaction_versions` is used to limit the number of sstables to be compacted at a time. In fact, the file size of a sstable is around 20MB, may be more sstables can be compacted at a time. What's more, bytes are more suitable to used.
## What I'm doing:
Use max_bytes to limit LakePersistIndex major compaction
Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
