### PR TITLE
[BugFix] Do not reuse input null and offset column for array_map

### DIFF
--- a/be/src/exprs/array_map_expr.cpp
+++ b/be/src/exprs/array_map_expr.cpp
@@ -39,7 +39,8 @@ ArrayMapExpr::ArrayMapExpr(TypeDescriptor type) : Expr(std::move(type), false) {
 // NOTE the return column must be of the return type.
 StatusOr<ColumnPtr> ArrayMapExpr::evaluate_checked(ExprContext* context, Chunk* chunk) {
     std::vector<ColumnPtr> input_elements;
-    NullColumnPtr input_null_map = nullptr;
+    NullColumnPtr null_column = nullptr;
+    bool is_single_nullable_child = false;
     ArrayColumn* input_array = nullptr;
     ColumnPtr input_array_ptr_ref = nullptr; // hold shared_ptr to avoid early deleted.
     // for many valid arguments:
@@ -65,11 +66,12 @@ StatusOr<ColumnPtr> ArrayMapExpr::evaluate_checked(ExprContext* context, Chunk* 
             // empty null array with non-zero elements
             column->empty_null_in_complex_column(nullable->null_column()->get_data(),
                                                  down_cast<const ArrayColumn*>(column.get())->offsets().get_data());
-            if (input_null_map) {
-                input_null_map =
-                        FunctionHelper::union_null_column(nullable->null_column(), input_null_map); // merge null
+            if (null_column) {
+                is_single_nullable_child = false;
+                null_column = FunctionHelper::union_null_column(nullable->null_column(), null_column); // merge null
             } else {
-                input_null_map = nullable->null_column();
+                is_single_nullable_child = true;
+                null_column = nullable->null_column();
             }
         }
         DCHECK(column->is_array());
@@ -84,6 +86,13 @@ StatusOr<ColumnPtr> ArrayMapExpr::evaluate_checked(ExprContext* context, Chunk* 
             }
         }
         input_elements.push_back(cur_array->elements_column());
+    }
+
+    if (is_single_nullable_child) {
+        DCHECK(null_column != nullptr);
+        // If there are more than one nullable children, the nullable column has been cloned when calling
+        // union_null_column to merge, so only one nullable child needs to be cloned.
+        null_column = ColumnHelper::as_column<NullColumn>(null_column->clone_shared());
     }
 
     ColumnPtr column = nullptr;
@@ -136,9 +145,10 @@ StatusOr<ColumnPtr> ArrayMapExpr::evaluate_checked(ExprContext* context, Chunk* 
         column = ColumnHelper::cast_to_nullable_column(column);
     }
     // attach offsets
-    auto array_col = std::make_shared<ArrayColumn>(column, input_array->offsets_column());
-    if (input_null_map != nullptr) {
-        return NullableColumn::create(std::move(array_col), input_null_map);
+    auto array_col = std::make_shared<ArrayColumn>(
+            column, ColumnHelper::as_column<UInt32Column>(input_array->offsets_column()->clone_shared()));
+    if (null_column != nullptr) {
+        return NullableColumn::create(std::move(array_col), null_column);
     }
     return array_col;
 }

--- a/test/sql/test_array/R/test_array_map
+++ b/test/sql/test_array/R/test_array_map
@@ -1,0 +1,60 @@
+-- name: test_array_map_1
+CREATE TABLE t1 (
+    k1 bigint,
+    c1 array < varchar(65536) > 
+) ENGINE = OLAP 
+DUPLICATE KEY(k1) PROPERTIES (
+    "replication_num" = "1"
+);
+-- result:
+-- !result
+CREATE TABLE t2 (
+    k1 bigint,
+    c1 bigint
+) ENGINE = OLAP 
+DUPLICATE KEY(k1) PROPERTIES (
+    "replication_num" = "1"
+);
+-- result:
+-- !result
+insert into t1
+values
+    (1, ["1","2"]        ), 
+    (2, ["0","2","1"]    ), 
+    (3, ["0","2","1"]    ), 
+    (4, ["1","2"]        ), 
+    (5, ["0","2","1"]    ), 
+    (6, ["0","2","1","1"]), 
+    (7, ["0","2","1"]    ), 
+    (8, ["1","2"]        ), 
+    (9, ["L","2","1"]    ), 
+    (10, ["1","2"]       );
+-- result:
+-- !result
+insert into t2
+values
+    (1, 1),
+    (2, 1),
+    (3, 3),
+    (4, 5);
+-- result:
+-- !result
+with w1 as (
+    select
+        k1, c1, array_map (x -> true, c1) as c2
+    from
+        t1
+)
+select
+    w1.*
+from
+    w1
+    join [broadcast] t2 using(k1)
+where
+    array_sum(w1.c1) <= t2.c1
+order by
+    w1.k1;
+-- result:
+3	["0","2","1"]	[1,1,1]
+4	["1","2"]	[1,1]
+-- !result

--- a/test/sql/test_array/T/test_array_map
+++ b/test/sql/test_array/T/test_array_map
@@ -1,0 +1,57 @@
+-- name: test_array_map_1
+
+-- Prepare Table and Data.
+CREATE TABLE t1 (
+    k1 bigint,
+    c1 array < varchar(65536) > 
+) ENGINE = OLAP 
+DUPLICATE KEY(k1) PROPERTIES (
+    "replication_num" = "1"
+);
+
+CREATE TABLE t2 (
+    k1 bigint,
+    c1 bigint
+) ENGINE = OLAP 
+DUPLICATE KEY(k1) PROPERTIES (
+    "replication_num" = "1"
+);
+
+insert into t1
+values
+    (1, ["1","2"]        ), 
+    (2, ["0","2","1"]    ), 
+    (3, ["0","2","1"]    ), 
+    (4, ["1","2"]        ), 
+    (5, ["0","2","1"]    ), 
+    (6, ["0","2","1","1"]), 
+    (7, ["0","2","1"]    ), 
+    (8, ["1","2"]        ), 
+    (9, ["L","2","1"]    ), 
+    (10, ["1","2"]       );
+
+
+insert into t2
+values
+    (1, 1),
+    (2, 1),
+    (3, 3),
+    (4, 5);
+
+-- Query.
+with w1 as (
+    select
+        k1, c1, array_map (x -> true, c1) as c2
+    from
+        t1
+)
+select
+    w1.*
+from
+    w1
+    join [broadcast] t2 using(k1)
+where
+    array_sum(w1.c1) <= t2.c1
+order by
+    w1.k1;
+


### PR DESCRIPTION
## Why I'm doing:

Release version crashed stack:
```
*** SIGSEGV (@0x7f24ad5f1000) received by PID 3321687 (TID 0x7f238c7d2640) from PID 18446744072323272704; stack trace: ***
    @          0x8b27baa google::(anonymous namespace)::FailureSignalHandler()
    @     0x7f24cb60e520 (unknown)
    @          0x7ab83a8 starrocks::MysqlRowBuffer::push_string()
    @          0x490d4ac starrocks::ArrayColumn::put_mysql_row_buffer()
    @          0x78f854a starrocks::MysqlResultWriter::process_chunk()
    @          0x50e2e17 starrocks::pipeline::ResultSinkOperator::push_chunk()
    @          0x51ac9d7 starrocks::pipeline::PipelineDriver::process()
    @          0x519aa58 starrocks::pipeline::GlobalDriverExecutor::_worker_thread()
    @          0x7aeedb1 starrocks::ThreadPool::dispatch_thread()
    @          0x7ae9c1f starrocks::Thread::supervise_thread()
    @     0x7f24cb660ac3 (unknown)
    @     0x7f24cb6f2850 (unknown)
    @                0x0 (unknown)
```


ASAN version crashed stack:
```
    @          0xb5030a2 starrocks::failure_function()
    @         0x182830bd google::LogMessage::Fail()
    @         0x1828552f google::LogMessage::SendToLog()
    @         0x18282c0e google::LogMessage::Flush()
    @         0x18285b39 google::LogMessageFatal::~LogMessageFatal()
    @          0xcfcf42b starrocks::Column::filter()
    @          0xcfc96ca starrocks::Chunk::filter()
    @          0xd159bb0 starrocks::eager_prune_eval_conjuncts()
    @          0xd15a158 starrocks::ExecNode::eval_conjuncts()
    @          0xf2864a1 starrocks::HashJoiner::_process_other_conjunct()
    @          0xf299628 starrocks::HashJoiner::filter_probe_output_chunk()
    @          0xf291c3d starrocks::HashJoinProber::probe_chunk()
    @          0xf28319d starrocks::HashJoiner::_pull_probe_output_chunk()
    @          0xf282d2d starrocks::HashJoiner::pull_chunk()
    @          0xe8a943a starrocks::pipeline::HashJoinProbeOperator::pull_chunk()
    @          0xe7015d9 starrocks::pipeline::PipelineDriver::process()
    @          0xe6c1f10 starrocks::pipeline::GlobalDriverExecutor::_worker_thread()
    @          0xe6c0934 _ZZN9starrocks8pipeline20GlobalDriverExecutor10initializeEiENKUlvE_clEv
    @          0xe6cc8fc _ZSt13__invoke_implIvRZN9starrocks8pipeline20GlobalDriverExecutor10initializeEiEUlvE_JEET_St14__invoke_otherOT0_DpOT1_
    @          0xe6cbc01 _ZSt10__invoke_rIvRZN9starrocks8pipeline20GlobalDriverExecutor10initializeEiEUlvE_JEENSt9enable_ifIX16is_invocable_r_vIT_T0_DpT1_EES6_E4typeEOS7_DpOS8_
    @          0xe6cac9b _ZNSt17_Function_handlerIFvvEZN9starrocks8pipeline20GlobalDriverExecutor10initializeEiEUlvE_E9_M_invokeERKSt9_Any_data
    @          0xb3f082c std::function<>::operator()()
    @          0xbf40ef0 starrocks::FunctionRunnable::run()
    @          0xbf3d3f5 starrocks::ThreadPool::dispatch_thread()
    @          0xbf5a5e8 std::__invoke_impl<>()
    @          0xbf5a0d3 std::__invoke<>()
    @          0xbf5901c _ZNSt5_BindIFMN9starrocks10ThreadPoolEFvvEPS1_EE6__callIvJEJLm0EEEET_OSt5tupleIJDpT0_EESt12_Index_tupleIJXspT1_EEE
```

## What I'm doing:

`ArrayMapExpr`'s returned array column reuses null and offset column from the input column.
As a result, two array columns in a chunk have the same null and offset column.

This is dangerous. For example, when filtering this chunk, the first array column will resize null and offset column, and the second array column will visit the resized part of null and offset column.


Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [x] 3.2
  - [x] 3.1
  - [x] 3.0
  - [x] 2.5
