### PR TITLE
[BugFix] Fix Spill Limited AGG Distinct cause use-after-free

### DIFF
--- a/be/src/exec/pipeline/aggregate/aggregate_blocking_sink_operator.h
+++ b/be/src/exec/pipeline/aggregate/aggregate_blocking_sink_operator.h
@@ -20,6 +20,7 @@
 #include "exec/aggregator.h"
 #include "exec/pipeline/operator.h"
 #include "runtime/runtime_state.h"
+#include "util/race_detect.h"
 
 namespace starrocks::pipeline {
 class AggregateBlockingSinkOperator : public Operator {
@@ -49,6 +50,7 @@ public:
     [[nodiscard]] Status reset_state(RuntimeState* state, const std::vector<ChunkPtr>& refill_chunks) override;
 
 protected:
+    DECLARE_ONCE_DETECTOR(_set_finishing_once);
     // It is used to perform aggregation algorithms shared by
     // AggregateBlockingSourceOperator. It is
     // - prepared at SinkOperator::prepare(),

--- a/be/src/exec/pipeline/aggregate/aggregate_distinct_blocking_sink_operator.cpp
+++ b/be/src/exec/pipeline/aggregate/aggregate_distinct_blocking_sink_operator.cpp
@@ -15,6 +15,7 @@
 #include "aggregate_distinct_blocking_sink_operator.h"
 
 #include "runtime/current_thread.h"
+#include "util/race_detect.h"
 
 namespace starrocks::pipeline {
 
@@ -33,6 +34,7 @@ void AggregateDistinctBlockingSinkOperator::close(RuntimeState* state) {
 
 Status AggregateDistinctBlockingSinkOperator::set_finishing(RuntimeState* state) {
     if (_is_finished) return Status::OK();
+    ONCE_DETECT(_set_finishing_once);
     auto defer = DeferOp([this]() {
         COUNTER_UPDATE(_aggregator->input_row_count(), _aggregator->num_input_rows());
         _aggregator->sink_complete();
@@ -89,6 +91,7 @@ Status AggregateDistinctBlockingSinkOperator::push_chunk(RuntimeState* state, co
 Status AggregateDistinctBlockingSinkOperator::reset_state(RuntimeState* state,
                                                           const std::vector<ChunkPtr>& refill_chunks) {
     _is_finished = false;
+    ONCE_RESET(_set_finishing_once);
     return _aggregator->reset_state(state, refill_chunks, this);
 }
 } // namespace starrocks::pipeline

--- a/be/src/exec/pipeline/aggregate/aggregate_distinct_blocking_sink_operator.h
+++ b/be/src/exec/pipeline/aggregate/aggregate_distinct_blocking_sink_operator.h
@@ -57,6 +57,7 @@ protected:
     AggregatorPtr _aggregator = nullptr;
 
 private:
+    DECLARE_ONCE_DETECTOR(_set_finishing_once)
     // Whether prev operator has no output
     bool _is_finished = false;
     std::atomic<int64_t>& _shared_limit_countdown;

--- a/be/src/exec/pipeline/aggregate/spillable_aggregate_blocking_sink_operator.cpp
+++ b/be/src/exec/pipeline/aggregate/spillable_aggregate_blocking_sink_operator.cpp
@@ -14,6 +14,8 @@
 
 #include "exec/pipeline/aggregate/spillable_aggregate_blocking_sink_operator.h"
 
+#include <glog/logging.h>
+
 #include <memory>
 
 #include "column/vectorized_fwd.h"
@@ -25,6 +27,7 @@
 #include "gen_cpp/InternalService_types.h"
 #include "runtime/current_thread.h"
 #include "storage/chunk_helper.h"
+#include "util/race_detect.h"
 
 namespace starrocks::pipeline {
 bool SpillableAggregateBlockingSinkOperator::need_input() const {
@@ -39,6 +42,10 @@ bool SpillableAggregateBlockingSinkOperator::is_finished() const {
 }
 
 Status SpillableAggregateBlockingSinkOperator::set_finishing(RuntimeState* state) {
+    if (_is_finished) {
+        return Status::OK();
+    }
+    ONCE_DETECT(_set_finishing_once);
     auto defer_set_finishing = DeferOp([this]() {
         _aggregator->spill_channel()->set_finishing_if_not_reuseable();
         _is_finished = true;
@@ -127,6 +134,7 @@ Status SpillableAggregateBlockingSinkOperator::push_chunk(RuntimeState* state, c
 Status SpillableAggregateBlockingSinkOperator::reset_state(RuntimeState* state,
                                                            const std::vector<ChunkPtr>& refill_chunks) {
     _is_finished = false;
+    ONCE_RESET(_set_finishing_once);
     RETURN_IF_ERROR(_aggregator->spiller()->reset_state(state));
     RETURN_IF_ERROR(AggregateBlockingSinkOperator::reset_state(state, refill_chunks));
     return Status::OK();

--- a/be/src/exec/pipeline/aggregate/spillable_aggregate_blocking_sink_operator.h
+++ b/be/src/exec/pipeline/aggregate/spillable_aggregate_blocking_sink_operator.h
@@ -21,6 +21,7 @@
 #include "exec/pipeline/spill_process_channel.h"
 #include "exec/sorted_streaming_aggregator.h"
 #include "runtime/runtime_state.h"
+#include "util/race_detect.h"
 
 namespace starrocks::pipeline {
 class SpillableAggregateBlockingSinkOperator : public AggregateBlockingSinkOperator {
@@ -76,6 +77,8 @@ private:
     void _add_streaming_chunk(ChunkPtr chunk);
 
     std::function<StatusOr<ChunkPtr>()> _build_spill_task(RuntimeState* state, bool should_spill_hash_table = true);
+
+    DECLARE_ONCE_DETECTOR(_set_finishing_once);
     spill::SpillStrategy _spill_strategy = spill::SpillStrategy::NO_SPILL;
 
     std::queue<ChunkPtr> _streaming_chunks;

--- a/be/src/exec/pipeline/aggregate/spillable_aggregate_distinct_blocking_operator.cpp
+++ b/be/src/exec/pipeline/aggregate/spillable_aggregate_distinct_blocking_operator.cpp
@@ -18,6 +18,7 @@
 
 #include "exec/sorted_streaming_aggregator.h"
 #include "exec/spill/spiller.hpp"
+#include "util/race_detect.h"
 
 namespace starrocks::pipeline {
 bool SpillableAggregateDistinctBlockingSinkOperator::need_input() const {
@@ -29,6 +30,8 @@ bool SpillableAggregateDistinctBlockingSinkOperator::is_finished() const {
 }
 
 Status SpillableAggregateDistinctBlockingSinkOperator::set_finishing(RuntimeState* state) {
+    if (_is_finished) return Status::OK();
+    ONCE_DETECT(_set_finishing_once);
     auto defer_set_finishing = DeferOp([this]() {
         _aggregator->spill_channel()->set_finishing_if_not_reuseable();
         _is_finished = true;
@@ -101,6 +104,7 @@ Status SpillableAggregateDistinctBlockingSinkOperator::reset_state(RuntimeState*
     _is_finished = false;
     RETURN_IF_ERROR(_aggregator->spiller()->reset_state(state));
     RETURN_IF_ERROR(AggregateDistinctBlockingSinkOperator::reset_state(state, refill_chunks));
+    ONCE_RESET(_set_finishing_once);
     return Status::OK();
 }
 

--- a/be/src/exec/pipeline/aggregate/spillable_aggregate_distinct_blocking_operator.h
+++ b/be/src/exec/pipeline/aggregate/spillable_aggregate_distinct_blocking_operator.h
@@ -22,6 +22,7 @@
 #include "exec/pipeline/operator.h"
 #include "exec/pipeline/source_operator.h"
 #include "storage/chunk_helper.h"
+#include "util/race_detect.h"
 
 namespace starrocks::pipeline {
 class SpillableAggregateDistinctBlockingSinkOperator : public AggregateDistinctBlockingSinkOperator {
@@ -67,8 +68,8 @@ private:
     [[nodiscard]] Status _spill_aggregated_data(RuntimeState* state);
 
     std::function<StatusOr<ChunkPtr>()> _build_spill_task(RuntimeState* state);
-
     spill::SpillStrategy _spill_strategy = spill::SpillStrategy::NO_SPILL;
+    DECLARE_ONCE_DETECTOR(_set_finishing_once);
     bool _is_finished = false;
 };
 

--- a/be/src/exec/pipeline/bucket_process_operator.cpp
+++ b/be/src/exec/pipeline/bucket_process_operator.cpp
@@ -60,6 +60,7 @@ bool BucketProcessSinkOperator::is_finished() const {
 }
 
 Status BucketProcessSinkOperator::set_finishing(RuntimeState* state) {
+    ONCE_DETECT(_set_finishing_once);
     auto defer = DeferOp([&]() {
         if (_ctx->spill_channel != nullptr) {
             _ctx->spill_channel->set_finishing();

--- a/be/src/exec/pipeline/bucket_process_operator.h
+++ b/be/src/exec/pipeline/bucket_process_operator.h
@@ -22,6 +22,7 @@
 #include "exec/pipeline/source_operator.h"
 #include "exec/pipeline/spill_process_channel.h"
 #include "runtime/runtime_state.h"
+#include "util/race_detect.h"
 
 namespace starrocks::pipeline {
 // similar with query_cache::MultilaneOperator but it only proxy one operator.
@@ -78,6 +79,7 @@ public:
     void for_each_child_operator(const std::function<void(Operator*)>& apply) override { apply(_ctx->sink.get()); }
 
 private:
+    DECLARE_ONCE_DETECTOR(_set_finishing_once);
     BucketProcessContextPtr _ctx;
 };
 

--- a/be/src/exec/pipeline/hash_partition_sink_operator.cpp
+++ b/be/src/exec/pipeline/hash_partition_sink_operator.cpp
@@ -31,6 +31,7 @@ Status HashPartitionSinkOperator::push_chunk(RuntimeState* state, const ChunkPtr
 }
 
 Status HashPartitionSinkOperator::set_finishing(RuntimeState* state) {
+    ONCE_DETECT(_set_finishing_once);
     _hash_partition_ctx->sink_complete();
     COUNTER_UPDATE(_partition_num, _hash_partition_ctx->num_partitions());
     _is_finished = true;

--- a/be/src/exec/pipeline/hash_partition_sink_operator.h
+++ b/be/src/exec/pipeline/hash_partition_sink_operator.h
@@ -17,6 +17,7 @@
 #include "exec/partition/chunks_partitioner.h"
 #include "exec/pipeline/hash_partition_context.h"
 #include "exec/pipeline/operator.h"
+#include "util/race_detect.h"
 
 /**
  * HashPartition{Sink/Source}Operator pair is used to reorder the input sequence by
@@ -67,6 +68,7 @@ private:
     HashPartitionContext* _hash_partition_ctx;
 
     RuntimeProfile::Counter* _partition_num;
+    DECLARE_ONCE_DETECTOR(_set_finishing_once);
 };
 
 class HashPartitionSinkOperatorFactory final : public OperatorFactory {

--- a/be/src/exec/pipeline/hashjoin/hash_join_build_operator.cpp
+++ b/be/src/exec/pipeline/hashjoin/hash_join_build_operator.cpp
@@ -19,6 +19,7 @@
 #include "exec/pipeline/query_context.h"
 #include "runtime/current_thread.h"
 #include "runtime/runtime_filter_worker.h"
+#include "util/race_detect.h"
 namespace starrocks::pipeline {
 
 HashJoinBuildOperator::HashJoinBuildOperator(OperatorFactory* factory, int32_t id, const string& name,
@@ -75,6 +76,7 @@ size_t HashJoinBuildOperator::output_amplification_factor() const {
 }
 
 Status HashJoinBuildOperator::set_finishing(RuntimeState* state) {
+    ONCE_DETECT(_set_finishing_once);
     DeferOp op([this]() { _is_finished = true; });
 
     if (state->is_cancelled()) {

--- a/be/src/exec/pipeline/hashjoin/hash_join_build_operator.h
+++ b/be/src/exec/pipeline/hashjoin/hash_join_build_operator.h
@@ -64,6 +64,7 @@ protected:
     PartialRuntimeFilterMerger* _partial_rf_merger;
     mutable size_t _avg_keys_per_bucket = 0;
     std::atomic<bool> _is_finished = false;
+    DECLARE_ONCE_DETECTOR(_set_finishing_once);
 
     const TJoinDistributionMode::type _distribution_mode;
 };

--- a/be/src/exec/pipeline/hashjoin/spillable_hash_join_build_operator.cpp
+++ b/be/src/exec/pipeline/hashjoin/spillable_hash_join_build_operator.cpp
@@ -68,6 +68,7 @@ bool SpillableHashJoinBuildOperator::need_input() const {
 }
 
 Status SpillableHashJoinBuildOperator::set_finishing(RuntimeState* state) {
+    ONCE_DETECT(_set_finishing_once);
     auto defer_set_finishing = DeferOp([this]() { _join_builder->spill_channel()->set_finishing(); });
 
     if (spill_strategy() == spill::SpillStrategy::NO_SPILL ||

--- a/be/src/exec/pipeline/hashjoin/spillable_hash_join_build_operator.h
+++ b/be/src/exec/pipeline/hashjoin/spillable_hash_join_build_operator.h
@@ -66,6 +66,7 @@ private:
     ChunkSharedSlice _hash_table_build_chunk_slice;
     std::function<StatusOr<ChunkPtr>()> _hash_table_slice_iterator;
     bool _is_first_time_spill = true;
+    DECLARE_ONCE_DETECTOR(_set_finishing_once);
 };
 
 class SpillableHashJoinBuildOperatorFactory final : public HashJoinBuildOperatorFactory {

--- a/be/src/exec/pipeline/set/except_build_sink_operator.h
+++ b/be/src/exec/pipeline/set/except_build_sink_operator.h
@@ -16,6 +16,7 @@
 
 #include "exec/pipeline/operator.h"
 #include "exec/pipeline/set/except_context.h"
+#include "util/race_detect.h"
 
 namespace starrocks::pipeline {
 
@@ -53,6 +54,7 @@ public:
     bool is_finished() const override { return _is_finished || _except_ctx->is_finished(); }
 
     Status set_finishing(RuntimeState* state) override {
+        ONCE_DETECT(_set_finishing_once);
         _is_finished = true;
         _except_ctx->finish_build_ht();
         return Status::OK();
@@ -72,6 +74,7 @@ private:
     const std::vector<ExprContext*>& _dst_exprs;
 
     bool _is_finished = false;
+    DECLARE_ONCE_DETECTOR(_set_finishing_once);
 };
 
 class ExceptBuildSinkOperatorFactory final : public OperatorFactory {

--- a/be/src/exec/pipeline/set/intersect_probe_sink_operator.h
+++ b/be/src/exec/pipeline/set/intersect_probe_sink_operator.h
@@ -16,6 +16,7 @@
 
 #include "exec/pipeline/operator.h"
 #include "exec/pipeline/set/intersect_context.h"
+#include "util/race_detect.h"
 
 namespace starrocks::pipeline {
 
@@ -51,6 +52,7 @@ public:
     }
 
     Status set_finishing(RuntimeState* state) override {
+        ONCE_DETECT(_set_finishing_once);
         _is_finished = true;
         _intersect_ctx->finish_probe_ht();
         return Status::OK();
@@ -69,6 +71,7 @@ private:
 
     bool _is_finished = false;
     const int32_t _dependency_index;
+    DECLARE_ONCE_DETECTOR(_set_finishing_once);
 };
 
 class IntersectProbeSinkOperatorFactory final : public OperatorFactory {

--- a/be/src/exec/pipeline/sort/local_partition_topn_sink.cpp
+++ b/be/src/exec/pipeline/sort/local_partition_topn_sink.cpp
@@ -38,6 +38,7 @@ Status LocalPartitionTopnSinkOperator::push_chunk(RuntimeState* state, const Chu
 }
 
 Status LocalPartitionTopnSinkOperator::set_finishing(RuntimeState* state) {
+    ONCE_DETECT(_set_finishing_once);
     RETURN_IF_ERROR(_partition_topn_ctx->transfer_all_chunks_from_partitioner_to_sorters(state));
     _partition_topn_ctx->sink_complete();
     _unique_metrics->add_info_string("IsPassThrough", _partition_topn_ctx->is_passthrough() ? "Yes" : "No");

--- a/be/src/exec/pipeline/sort/local_partition_topn_sink.h
+++ b/be/src/exec/pipeline/sort/local_partition_topn_sink.h
@@ -53,6 +53,7 @@ private:
     bool _is_finished = false;
 
     LocalPartitionTopnContext* _partition_topn_ctx;
+    DECLARE_ONCE_DETECTOR(_set_finishing_once);
 };
 
 class LocalPartitionTopnSinkOperatorFactory final : public OperatorFactory {

--- a/be/src/exec/pipeline/sort/partition_sort_sink_operator.cpp
+++ b/be/src/exec/pipeline/sort/partition_sort_sink_operator.cpp
@@ -89,6 +89,7 @@ Status PartitionSortSinkOperator::push_chunk(RuntimeState* state, const ChunkPtr
 }
 
 Status PartitionSortSinkOperator::set_finishing(RuntimeState* state) {
+    ONCE_DETECT(_set_finishing_once);
     // skip sorting if cancelled
     if (state->is_cancelled()) {
         _is_finished = true;

--- a/be/src/exec/pipeline/sort/partition_sort_sink_operator.h
+++ b/be/src/exec/pipeline/sort/partition_sort_sink_operator.h
@@ -90,6 +90,7 @@ protected:
 
     SortContext* _sort_context;
     RuntimeFilterHub* _hub;
+    DECLARE_ONCE_DETECTOR(_set_finishing_once);
 };
 
 class PartitionSortSinkOperatorFactory : public OperatorFactory {

--- a/be/src/exec/pipeline/sort/spillable_partition_sort_sink_operator.cpp
+++ b/be/src/exec/pipeline/sort/spillable_partition_sort_sink_operator.cpp
@@ -57,6 +57,7 @@ Status SpillablePartitionSortSinkOperator::push_chunk(RuntimeState* state, const
 }
 
 Status SpillablePartitionSortSinkOperator::set_finishing(RuntimeState* state) {
+    ONCE_DETECT(_set_finishing_once);
     auto defer_set_finishing = DeferOp([this]() { _chunks_sorter->spill_channel()->set_finishing(); });
     if (state->is_cancelled()) {
         _is_finished = true;

--- a/be/src/exec/pipeline/sort/spillable_partition_sort_sink_operator.h
+++ b/be/src/exec/pipeline/sort/spillable_partition_sort_sink_operator.h
@@ -50,6 +50,9 @@ public:
     Status set_finishing(RuntimeState* state) override;
 
     Status set_finished(RuntimeState* state) override;
+
+private:
+    DECLARE_ONCE_DETECTOR(_set_finishing_once);
 };
 
 class SpillablePartitionSortSinkOperatorFactory final : public PartitionSortSinkOperatorFactory {

--- a/be/src/exec/spill/input_stream.cpp
+++ b/be/src/exec/spill/input_stream.cpp
@@ -131,7 +131,7 @@ private:
 };
 
 StatusOr<ChunkUniquePtr> RawChunkInputStream::get_next(workgroup::YieldContext& yield_ctx, SerdeContext& context) {
-    RACE_DETECT(detect_get_next, var1);
+    RACE_DETECT(detect_get_next);
     if (read_idx >= _chunks.size()) {
         return Status::EndOfFile("eos");
     }
@@ -262,7 +262,7 @@ private:
 };
 
 StatusOr<ChunkUniquePtr> UnorderedInputStream::get_next(workgroup::YieldContext& yield_ctx, SerdeContext& ctx) {
-    RACE_DETECT(detect_get_next, var1);
+    RACE_DETECT(detect_get_next);
     if (_current_idx >= _input_blocks.size()) {
         return Status::EndOfFile("end of reading spilled UnorderedInputStream");
     }

--- a/be/src/exec/spill/serde.cpp
+++ b/be/src/exec/spill/serde.cpp
@@ -34,7 +34,7 @@ public:
     ~ColumnarSerde() override = default;
 
     Status prepare() override {
-        RACE_DETECT(detect_prepare, var1);
+        RACE_DETECT(detect_prepare);
         if (_encode_context == nullptr) {
             auto column_number = _parent->chunk_builder().column_number();
             auto encode_level = _parent->options().encode_level;

--- a/be/src/exec/spill/spiller.hpp
+++ b/be/src/exec/spill/spiller.hpp
@@ -321,7 +321,7 @@ Status PartitionedSpillerWriter::flush(RuntimeState* state, bool is_final_flush,
         RETURN_IF(!guard.scoped_begin(), Status::Cancelled("cancelled"));
         DEFER_GUARD_END(guard);
         // concurrency test
-        RACE_DETECT(detect_flush, var1);
+        RACE_DETECT(detect_flush);
         auto defer = CancelableDefer([&]() {
             _spiller->update_spilled_task_status(_decrease_running_flush_tasks());
             yield_ctx.set_finished();


### PR DESCRIPTION
## Why I'm doing:

group by limit call set_finishing in advance. But spill agg distinct doesn't handle the situation well. We need to check in advance if set_finishing has been re-called.

```
==56627==ERROR: AddressSanitizer: heap-use-after-free on address 0x60e000627a10 at pc 0x000012294627 bp 0x7f1a8f3a3fa0 sp 0x7f1a8f3a3f90
READ of size 8 at 0x60e000627a10 thread T428
    #0 0x12294626 in starrocks::spill::ResourceMemTrackerGuard<std::weak_ptr<starrocks::pipeline::QueryContext>, std::weak_ptr<starrocks::spill::Spiller>, std::weak_ptr<starrocks::spill::SpillerReader> >::ResourceMemTrackerGuard(starrocks::spill::ResourceMemTrackerGuard<std::weak_ptr<starrocks::pipeline::QueryContext>, std::weak_ptr<starrocks::spill::Spiller>, std::weak_ptr<starrocks::spill::SpillerReader> > const&) ../src/exec/spill/executor.h:56
    #1 0x122a27c9 in starrocks::Status starrocks::spill::SpillerReader::trigger_restore<starrocks::spill::IOTaskExecutor, starrocks::spill::ResourceMemTrackerGuard<std::weak_ptr<starrocks::pipeline::QueryContext>, std::weak_ptr<starrocks::spill::Spiller>, std::weak_ptr<starrocks::spill::SpillerReader> > const&>(starrocks::RuntimeState*, starrocks::spill::ResourceMemTrackerGuard<std::weak_ptr<starrocks::pipeline::QueryContext>, std::weak_ptr<starrocks::spill::Spiller>, std::weak_ptr<starrocks::spill::SpillerReader> > const&) ../src/exec/spill/spiller.hpp:223
    #2 0x1229c4ae in starrocks::Status starrocks::spill::Spiller::trigger_restore<starrocks::spill::IOTaskExecutor, starrocks::spill::ResourceMemTrackerGuard<std::weak_ptr<starrocks::pipeline::QueryContext>, std::weak_ptr<starrocks::spill::Spiller>, std::weak_ptr<starrocks::spill::SpillerReader> > const&>(starrocks::RuntimeState*, starrocks::spill::ResourceMemTrackerGuard<std::weak_ptr<starrocks::pipeline::QueryContext>, std::weak_ptr<starrocks::spill::Spiller>, std::weak_ptr<starrocks::spill::SpillerReader> > const&) ../src/exec/spill/spiller.hpp:111
    #3 0x12294125 in starrocks::spill::Spiller::set_flush_all_call_back<starrocks::spill::IOTaskExecutor, starrocks::spill::ResourceMemTrackerGuard<std::weak_ptr<starrocks::pipeline::QueryContext>, std::weak_ptr<starrocks::spill::Spiller>, std::weak_ptr<starrocks::spill::SpillerReader> > >(std::function<starrocks::Status ()> const&, starrocks::RuntimeState*, starrocks::spill::ResourceMemTrackerGuard<std::weak_ptr<starrocks::pipeline::QueryContext>, std::weak_ptr<starrocks::spill::Spiller>, std::weak_ptr<starrocks::spill::SpillerReader> > const&)::{lambda()#1}::operator()() const ../src/exec/spill/spiller.h:178
    #4 0x122ae82d in starrocks::Status std::__invoke_impl<starrocks::Status, starrocks::spill::Spiller::set_flush_all_call_back<starrocks::spill::IOTaskExecutor, starrocks::spill::ResourceMemTrackerGuard<std::weak_ptr<starrocks::pipeline::QueryContext>, std::weak_ptr<starrocks::spill::Spiller>, std::weak_ptr<starrocks::spill::SpillerReader> > >(std::function<starrocks::Status ()> const&, starrocks::RuntimeState*, starrocks::spill::ResourceMemTrackerGuard<std::weak_ptr<starrocks::pipeline::QueryContext>, std::weak_ptr<starrocks::spill::Spiller>, std::weak_ptr<starrocks::spill::SpillerReader> > const&)::{lambda()#1}&>(std::__invoke_other, starrocks::spill::Spiller::set_flush_all_call_back<starrocks::spill::IOTaskExecutor, starrocks::spill::ResourceMemTrackerGuard<std::weak_ptr<starrocks::pipeline::QueryContext>, std::weak_ptr<starrocks::spill::Spiller>, std::weak_ptr<starrocks::spill::SpillerReader> > >(std::function<starrocks::Status ()> const&, starrocks::RuntimeState*, starrocks::spill::ResourceMemTrackerGuard<std::weak_ptr<starrocks::pipeline::QueryContext>, std::weak_ptr<starrocks::spill::Spiller>, std::weak_ptr<starrocks::spill::SpillerReader> > const&)::{lambda()#1}&) /usr/include/c++/12/bits/invoke.h:61
    #5 0x122a921c in std::enable_if<is_invocable_r_v<starrocks::Status, starrocks::spill::Spiller::set_flush_all_call_back<starrocks::spill::IOTaskExecutor, starrocks::spill::ResourceMemTrackerGuard<std::weak_ptr<starrocks::pipeline::QueryContext>, std::weak_ptr<starrocks::spill::Spiller>, std::weak_ptr<starrocks::spill::SpillerReader> > >(std::function<starrocks::Status ()> const&, starrocks::RuntimeState*, starrocks::spill::ResourceMemTrackerGuard<std::weak_ptr<starrocks::pipeline::QueryContext>, std::weak_ptr<starrocks::spill::Spiller>, std::weak_ptr<starrocks::spill::SpillerReader> > const&)::{lambda()#1}&>, starrocks::Status>::type std::__invoke_r<starrocks::Status, starrocks::spill::Spiller::set_flush_all_call_back<starrocks::spill::IOTaskExecutor, starrocks::spill::ResourceMemTrackerGuard<std::weak_ptr<starrocks::pipeline::QueryContext>, std::weak_ptr<starrocks::spill::Spiller>, std::weak_ptr<starrocks::spill::SpillerReader> > >(std::function<starrocks::Status ()> const&, starrocks::RuntimeState*, starrocks::spill::ResourceMemTrackerGuard<std::weak_ptr<starrocks::pipeline::QueryContext>, std::weak_ptr<starrocks::spill::Spiller>, std::weak_ptr<starrocks::spill::SpillerReader> > const&)::{lambda()#1}&>(starrocks::spill::Spiller::set_flush_all_call_back<starrocks::spill::IOTaskExecutor, starrocks::spill::ResourceMemTrackerGuard<std::weak_ptr<starrocks::pipeline::QueryContext>, std::weak_ptr<starrocks::spill::Spiller>, std::weak_ptr<starrocks::spill::SpillerReader> > >(std::function<starrocks::Status ()> const&, starrocks::RuntimeState*, starrocks::spill::ResourceMemTrackerGuard<std::weak_ptr<starrocks::pipeline::QueryContext>, std::weak_ptr<starrocks::spill::Spiller>, std::weak_ptr<starrocks::spill::SpillerReader> > const&)::{lambda()#1}&) /usr/include/c++/12/bits/invoke.h:116
    #6 0x122a303f in std::_Function_handler<starrocks::Status (), starrocks::spill::Spiller::set_flush_all_call_back<starrocks::spill::IOTaskExecutor, starrocks::spill::ResourceMemTrackerGuard<std::weak_ptr<starrocks::pipeline::QueryContext>, std::weak_ptr<starrocks::spill::Spiller>, std::weak_ptr<starrocks::spill::SpillerReader> > >(std::function<starrocks::Status ()> const&, starrocks::RuntimeState*, starrocks::spill::ResourceMemTrackerGuard<std::weak_ptr<starrocks::pipeline::QueryContext>, std::weak_ptr<starrocks::spill::Spiller>, std::weak_ptr<starrocks::spill::SpillerReader> > const&)::{lambda()#1}>::_M_invoke(std::_Any_data const&) /usr/include/c++/12/bits/std_function.h:291
```

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [x] 3.2
  - [x] 3.1
  - [x] 3.0
  - [ ] 2.5
