### PR TITLE
[Refactor] reduce info log count in pk table

### DIFF
--- a/be/src/storage/persistent_index.cpp
+++ b/be/src/storage/persistent_index.cpp
@@ -643,7 +643,7 @@ Status ImmutableIndexWriter::write_shard(size_t key_size, size_t npage_hint, siz
 
 Status ImmutableIndexWriter::write_bf() {
     size_t pos_before = _idx_wb->size();
-    LOG(INFO) << "write kv size:" << pos_before << ", _bf_wb size: " << _bf_wb->size();
+    VLOG(2) << "write kv size:" << pos_before << ", _bf_wb size: " << _bf_wb->size();
     if (_bf_wb->size() != 0) {
         VLOG(10) << "_bf_wb already write size: " << _bf_wb->size();
         DCHECK(_bf_flushed);
@@ -689,7 +689,7 @@ Status ImmutableIndexWriter::finish() {
     if (write_pindex_bf) {
         RETURN_IF_ERROR(write_bf());
     }
-    LOG(INFO) << strings::Substitute(
+    VLOG(2) << strings::Substitute(
             "finish writing immutable index $0 #shard:$1 #kv:$2 #moved:$3($4) kv_bytes:$5 usage:$6 bf_bytes:$7 "
             "compression_type:$8",
             _idx_file_path_tmp, _nshard, _total, _total_moved, _total_moved * 1000 / std::max(_total, 1UL) / 1000.0,
@@ -3433,8 +3433,8 @@ Status PersistentIndex::commit(PersistentIndexMetaPB* index_meta, IOStat* stat) 
     }
     _calc_memory_usage();
 
-    LOG(INFO) << strings::Substitute("commit persistent index successfully, version: [$0,$1]", _version.major_number(),
-                                     _version.minor_number());
+    VLOG(2) << strings::Substitute("commit persistent index successfully, version: [$0,$1]", _version.major_number(),
+                                   _version.minor_number());
     return Status::OK();
 }
 
@@ -4445,8 +4445,8 @@ Status PersistentIndex::_minor_compaction(PersistentIndexMetaPB* index_meta) {
             // check if need to dump snapshot
             need_snapshot = true;
         }
-        LOG(INFO) << "PersistentIndex minor compaction, link from tmp-l1: " << tmp_l1_filename
-                  << " to l1: " << new_l1_filename << " snapshot: " << need_snapshot;
+        VLOG(2) << "PersistentIndex minor compaction, link from tmp-l1: " << tmp_l1_filename
+                << " to l1: " << new_l1_filename << " snapshot: " << need_snapshot;
     } else if (tmp_l1_cnt > 1) {
         // step 1.b
         auto writer = std::make_unique<ImmutableIndexWriter>();
@@ -4459,20 +4459,20 @@ Status PersistentIndex::_minor_compaction(PersistentIndexMetaPB* index_meta) {
         RETURN_IF_ERROR(_merge_compaction_internal(writer.get(), _has_l1 ? 1 : 0, _l1_vec.size(),
                                                    _usage_and_size_by_key_length, !_l2_vec.empty() || _has_l1));
         RETURN_IF_ERROR(writer->finish());
-        LOG(INFO) << "PersistentIndex minor compaction, merge tmp l1, merge cnt: " << _l1_vec.size()
-                  << ", output: " << new_l1_filename;
+        VLOG(2) << "PersistentIndex minor compaction, merge tmp l1, merge cnt: " << _l1_vec.size()
+                << ", output: " << new_l1_filename;
     } else if (_l1_vec.size() == 1) {
         // step 1.c
         RETURN_IF_ERROR(_flush_l0());
         DCHECK(_has_l1);
-        LOG(INFO) << "PersistentIndex minor compaction, flush l0, old l1: " << _l1_version
-                  << ", output: " << new_l1_filename;
+        VLOG(2) << "PersistentIndex minor compaction, flush l0, old l1: " << _l1_version
+                << ", output: " << new_l1_filename;
     } else {
         // step 1.d
         RETURN_IF_ERROR(_flush_l0());
         DCHECK(!_has_l1);
-        LOG(INFO) << "PersistentIndex minor compaction, flush l0, "
-                  << "output: " << new_l1_filename;
+        VLOG(2) << "PersistentIndex minor compaction, flush l0, "
+                << "output: " << new_l1_filename;
     }
     // 2. move old l1 to l2.
     if (_has_l1) {
@@ -4481,7 +4481,7 @@ Status PersistentIndex::_minor_compaction(PersistentIndexMetaPB* index_meta) {
                 strings::Substitute("$0/index.l2.$1.$2", _path, _l1_version.major_number(), _l1_version.minor_number());
         const std::string old_l1_file_path =
                 strings::Substitute("$0/index.l1.$1.$2", _path, _l1_version.major_number(), _l1_version.minor_number());
-        LOG(INFO) << "PersistentIndex minor compaction, link from " << old_l1_file_path << " to " << l2_file_path;
+        VLOG(2) << "PersistentIndex minor compaction, link from " << old_l1_file_path << " to " << l2_file_path;
         // Make new file doesn't exist
         (void)FileSystem::Default()->delete_file(l2_file_path);
         RETURN_IF_ERROR(FileSystem::Default()->link_file(old_l1_file_path, l2_file_path));
@@ -4533,8 +4533,8 @@ Status PersistentIndex::_merge_compaction_advance() {
     RETURN_IF_ERROR(writer->init(idx_file_path_tmp, _version, false));
     int merge_l1_start_idx = _l1_vec.size() - config::max_tmp_l1_num;
     int merge_l1_end_idx = _l1_vec.size();
-    LOG(INFO) << strings::Substitute("merge compaction advance, path: $0, start_idx: $1, end_idx: $2", _path,
-                                     merge_l1_start_idx, merge_l1_end_idx);
+    VLOG(2) << strings::Substitute("merge compaction advance, path: $0, start_idx: $1, end_idx: $2", _path,
+                                   merge_l1_start_idx, merge_l1_end_idx);
     // keep delete flag when older l1 or l2 exist
     bool keep_delete = (merge_l1_start_idx != 0) || !_l2_vec.empty();
 

--- a/be/src/storage/tablet_updates.cpp
+++ b/be/src/storage/tablet_updates.cpp
@@ -657,20 +657,22 @@ Status TabletUpdates::rowset_commit(int64_t version, const RowsetSharedPtr& rows
                                  << _debug_string(false, true);
                     return st;
                 }
-                LOG(INFO) << "add rowset to pending commits tablet:" << _tablet.tablet_id() << " version:" << version
-                          << " txn_id: " << rowset->txn_id() << " #pending:" << _pending_commits.size();
+                VLOG(2) << "add rowset to pending commits tablet:" << _tablet.tablet_id() << " version:" << version
+                        << " txn_id: " << rowset->txn_id() << " #pending:" << _pending_commits.size();
             }
             return Status::OK();
         }
         st = _rowset_commit_unlocked(version, rowset);
         if (st.ok()) {
-            LOG(INFO) << "commit rowset tablet:" << _tablet.tablet_id() << " version:" << version
-                      << " txn_id: " << rowset->txn_id() << " " << rowset->rowset_id().to_string()
-                      << " rowset:" << rowset->rowset_meta()->get_rowset_seg_id() << " #seg:" << rowset->num_segments()
-                      << " #delfile:" << rowset->num_delete_files() << " #uptfile:" << rowset->num_update_files()
-                      << " #row:" << rowset->num_rows()
-                      << " size:" << PrettyPrinter::print(rowset->data_disk_size(), TUnit::BYTES)
-                      << " #pending:" << _pending_commits.size();
+            if (rowset->num_segments() > 0 || rowset->num_delete_files() > 0 || rowset->num_update_files() > 0) {
+                LOG(INFO) << "commit rowset tablet:" << _tablet.tablet_id() << " version:" << version
+                          << " txn_id: " << rowset->txn_id() << " " << rowset->rowset_id().to_string()
+                          << " rowset:" << rowset->rowset_meta()->get_rowset_seg_id()
+                          << " #seg:" << rowset->num_segments() << " #delfile:" << rowset->num_delete_files()
+                          << " #uptfile:" << rowset->num_update_files() << " #row:" << rowset->num_rows()
+                          << " size:" << PrettyPrinter::print(rowset->data_disk_size(), TUnit::BYTES)
+                          << " #pending:" << _pending_commits.size();
+            }
             _try_commit_pendings_unlocked();
             _check_for_apply();
             if (wait_time > 0) {
@@ -804,11 +806,11 @@ void TabletUpdates::_try_commit_pendings_unlocked() {
                                << " #pending:" << _pending_commits.size() << " " << st.to_string();
                     return;
                 }
-                LOG(INFO) << "commit rowset (pending) tablet:" << _tablet.tablet_id() << " version:" << version
-                          << " txn_id: " << rowset->txn_id() << " rowset:" << rowset->rowset_meta()->get_rowset_seg_id()
-                          << " #seg:" << rowset->num_segments() << " #row:" << rowset->num_rows()
-                          << " size:" << PrettyPrinter::print(rowset->data_disk_size(), TUnit::BYTES)
-                          << " #pending:" << _pending_commits.size();
+                VLOG(2) << "commit rowset (pending) tablet:" << _tablet.tablet_id() << " version:" << version
+                        << " txn_id: " << rowset->txn_id() << " rowset:" << rowset->rowset_meta()->get_rowset_seg_id()
+                        << " #seg:" << rowset->num_segments() << " #row:" << rowset->num_rows()
+                        << " size:" << PrettyPrinter::print(rowset->data_disk_size(), TUnit::BYTES)
+                        << " #pending:" << _pending_commits.size();
                 itr = _pending_commits.erase(itr);
                 current_version = _edit_version_infos.back()->version.major_number();
             } else {
@@ -1132,8 +1134,8 @@ bool TabletUpdates::check_delta_column_generate_from_version(EditVersion begin_v
             uint32_t rowset_id = (*i)->deltas[0];
             RowsetSharedPtr rowset = _get_rowset(rowset_id);
             if (rowset->is_column_mode_partial_update()) {
-                LOG(INFO) << "delta column group is generated in tablet_id: " << _tablet.tablet_id()
-                          << " version: " << (*i)->version;
+                VLOG(2) << "delta column group is generated in tablet_id: " << _tablet.tablet_id()
+                        << " version: " << (*i)->version;
                 return true;
             }
         }
@@ -1757,8 +1759,8 @@ Status TabletUpdates::_do_update(uint32_t rowset_id, int32_t upsert_idx, int32_t
         MonotonicStopWatch watch;
         watch.start();
         RETURN_IF_ERROR(index.upsert(rowset_id + upsert_idx, 0, *upserts[upsert_idx], new_deletes, iostat.get()));
-        LOG(INFO) << "primary index upsert tid: " << tablet_id << ", cost: " << watch.elapsed_time() << ", "
-                  << iostat->print_str();
+        VLOG(2) << "primary index upsert tid: " << tablet_id << ", cost: " << watch.elapsed_time() << ", "
+                << iostat->print_str();
     }
 
     return Status::OK();
@@ -2654,7 +2656,7 @@ Status TabletUpdates::compaction(MemTracker* mem_tracker) {
     // give 10s time gitter, so same table's compaction don't start at same time
     _last_compaction_time_ms = UnixMillis() + rand() % 10000;
     if (info->inputs.empty()) {
-        LOG(INFO) << "no candidate rowset to do update compaction, tablet:" << _tablet.tablet_id();
+        VLOG(2) << "no candidate rowset to do update compaction, tablet:" << _tablet.tablet_id();
         _compaction_running = false;
         return Status::OK();
     }
@@ -2819,7 +2821,7 @@ Status TabletUpdates::compaction_for_size_tiered(MemTracker* mem_tracker) {
     // 1. no candidate rowsets, skip compaction
     // 2. only an empty rowset, skip compaction
     if (info->inputs.empty() || (info->inputs.size() <= 1 && compaction_level == -1 && del_rows == 0)) {
-        LOG(INFO) << "no candidate rowset to do update compaction, tablet:" << _tablet.tablet_id();
+        VLOG(2) << "no candidate rowset to do update compaction, tablet:" << _tablet.tablet_id();
         _compaction_running = false;
         return Status::OK();
     }
@@ -2950,12 +2952,12 @@ Status TabletUpdates::compaction(MemTracker* mem_tracker, const vector<uint32_t>
         }
     }
     if (info->inputs.empty()) {
-        LOG(INFO) << "no candidate rowset to do update compaction, tablet:" << _tablet.tablet_id();
+        VLOG(2) << "no candidate rowset to do update compaction, tablet:" << _tablet.tablet_id();
         _compaction_running = false;
         return Status::OK();
     }
     if (total_segments == 1) {
-        LOG(INFO) << "only 1 segment, skip update compaction, tablet:" << _tablet.tablet_id();
+        VLOG(2) << "only 1 segment, skip update compaction, tablet:" << _tablet.tablet_id();
         _compaction_running = false;
         return Status::OK();
     }


### PR DESCRIPTION
## Why I'm doing:
There are too many info logs print in pk table.

## What I'm doing:
reduce info log print.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [x] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [x] 3.2
  - [x] 3.1
  - [ ] 3.0
  - [ ] 2.5
