### PR TITLE
Add table owner when create table to avoid null owner table been created by ctas query in hive

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/HiveTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/HiveTable.java
@@ -125,6 +125,7 @@ public class HiveTable extends Table implements HiveMetaStoreTable {
     public static final String HIVE_TABLE_COLUMN_TYPES = "hive.table.column.types";
 
     private String catalogName;
+    private String owner;
     @SerializedName(value = "dn")
     private String hiveDbName;
     @SerializedName(value = "tn")
@@ -162,7 +163,8 @@ public class HiveTable extends Table implements HiveMetaStoreTable {
     public HiveTable(long id, String name, List<Column> fullSchema, String resourceName, String catalog,
                      String hiveDbName, String hiveTableName, String tableLocation, long createTime,
                      List<String> partColumnNames, List<String> dataColumnNames, Map<String, String> properties,
-                     Map<String, String> serdeProperties, HiveStorageFormat storageFormat, HiveTableType hiveTableType) {
+                     Map<String, String> serdeProperties, HiveStorageFormat storageFormat,
+                     HiveTableType hiveTableType, String owner) {
         super(id, name, TableType.HIVE, fullSchema);
         this.resourceName = resourceName;
         this.catalogName = catalog;
@@ -176,6 +178,7 @@ public class HiveTable extends Table implements HiveMetaStoreTable {
         this.serdeProperties = serdeProperties;
         this.storageFormat = storageFormat;
         this.hiveTableType = hiveTableType;
+        this.owner = owner;
     }
 
     public String getHiveDbTable() {
@@ -194,6 +197,10 @@ public class HiveTable extends Table implements HiveMetaStoreTable {
 
     public String getDbName() {
         return hiveDbName;
+    }
+
+    public String getOwner() {
+        return owner;
     }
 
     @Override
@@ -572,6 +579,7 @@ public class HiveTable extends Table implements HiveMetaStoreTable {
         private String hiveTableName;
         private String resourceName;
         private String tableLocation;
+        private String owner;
         private long createTime;
         private List<Column> fullSchema;
         private List<String> partitionColNames = Lists.newArrayList();
@@ -619,6 +627,11 @@ public class HiveTable extends Table implements HiveMetaStoreTable {
             return this;
         }
 
+        public Builder setOwner(String owner) {
+            this.owner = owner;
+            return this;
+        }
+
         public Builder setCreateTime(long createTime) {
             this.createTime = createTime;
             return this;
@@ -662,7 +675,7 @@ public class HiveTable extends Table implements HiveMetaStoreTable {
         public HiveTable build() {
             return new HiveTable(id, tableName, fullSchema, resourceName, catalogName, hiveDbName, hiveTableName,
                     tableLocation, createTime, partitionColNames, dataColNames, properties, serdeProperties,
-                    storageFormat, hiveTableType);
+                    storageFormat, hiveTableType, owner);
         }
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/connector/hive/HiveMetastoreApiConverter.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/hive/HiveMetastoreApiConverter.java
@@ -166,6 +166,7 @@ public class HiveMetastoreApiConverter {
                 .map(HiveMetastoreApiConverter::toMetastoreApiFieldSchema)
                 .collect(Collectors.toList()));
         apiTable.setSd(makeStorageDescriptorFromHiveTable(table));
+        apiTable.setOwner(table.getOwner());
         return apiTable;
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/connector/hive/HiveMetastoreOperations.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/hive/HiveMetastoreOperations.java
@@ -163,6 +163,7 @@ public class HiveMetastoreOperations {
                 .setId(ConnectorTableId.CONNECTOR_ID_GENERATOR.getNextId().asInt())
                 .setTableName(tableName)
                 .setCatalogName(catalogName)
+                .setOwner(stmt.getOwner())
                 .setResourceName(toResourceName(catalogName, "hive"))
                 .setHiveDbName(dbName)
                 .setHiveTableName(tableName)

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/CreateTableAsSelectStmt.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/CreateTableAsSelectStmt.java
@@ -61,6 +61,7 @@ public class CreateTableAsSelectStmt extends StatementBase {
 
     public void dropTable(ConnectContext session) throws AnalysisException {
         try {
+            createTableStmt.setOwner(session.getQualifiedUser());
             session.getGlobalStateMgr().getMetadataMgr().dropTable(new DropTableStmt(true, createTableStmt.getDbTbl(), true));
         } catch (Exception e) {
             throw new AnalysisException(e.getMessage());

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/CreateTableStmt.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/CreateTableStmt.java
@@ -45,6 +45,8 @@ public class CreateTableStmt extends DdlStmt {
     private String engineName;
     private String charsetName;
     private String comment;
+    private String owner;
+
     private List<AlterClause> rollupAlterClauseList;
 
     // set in analyze
@@ -252,6 +254,14 @@ public class CreateTableStmt extends DdlStmt {
 
     public String getComment() {
         return comment;
+    }
+
+    public String getOwner() {
+        return owner;
+    }
+
+    public void setOwner(String owner) {
+        this.owner = owner;
     }
 
     public List<AlterClause> getRollupAlterClauseList() {

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/ShowCreateTableStmtTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/ShowCreateTableStmtTest.java
@@ -130,7 +130,7 @@ public class ShowCreateTableStmtTest {
 
         HiveTable table = new HiveTable(100, "test", fullSchema, "aa", "bb", "cc", "dd", "hdfs://xxx",
                 0, new ArrayList<>(), fullSchema.stream().map(x -> x.getName()).collect(Collectors.toList()),
-                props, new HashMap<>(),  HiveStorageFormat.ORC, HiveTable.HiveTableType.MANAGED_TABLE);
+                props, new HashMap<>(),  HiveStorageFormat.ORC, HiveTable.HiveTableType.MANAGED_TABLE, null);
         List<String> result = new ArrayList<>();
         AstToStringBuilder.getDdlStmt(table, result, null, null, false, true);
         Assert.assertEquals(result.size(), 1);

--- a/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AnalyzeStmtTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AnalyzeStmtTest.java
@@ -149,7 +149,7 @@ public class AnalyzeStmtTest {
                 return new HiveTable(1, "customer", Lists.newArrayList(), "resource_name",
                         CatalogMgr.ResourceMappingCatalog.getResourceMappingCatalogName("resource_name", "hive"),
                         "hive", "tpch", "", 0, Lists.newArrayList(), Lists.newArrayList(), Maps.newHashMap(),
-                        Maps.newHashMap(), null, null);
+                        Maps.newHashMap(), null, null, null);
             }
         };
         String sql = "analyze table tpch.customer";


### PR DESCRIPTION
…ted by ctas query

## Why I'm doing:

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Ensures Hive tables have a valid `owner` during creation and CTAS flows, preventing null-owner tables in the metastore.
> 
> - Add `owner` field, getter, and builder setter to `HiveTable`; plumb through constructor and `Builder.build()`
> - Extend `CreateTableStmt` with `owner` and set it from session in `CreateTableAsSelectStmt`
> - In `HiveMetastoreOperations.createTable`, set `owner` on the `HiveTable` from `CreateTableStmt`
> - In `HiveMetastoreApiConverter.toMetastoreApiTable`, set metastore table owner from `HiveTable.getOwner()`
> - Update tests to use the new `HiveTable` constructor signature
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0331cbd29973df08fb0a90f1bb8354f25168e1bc. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->