### PR TITLE
[Enhancement] improve pktable prepare point query performance 

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/analysis/BinaryPredicate.java
+++ b/fe/fe-core/src/main/java/com/starrocks/analysis/BinaryPredicate.java
@@ -35,6 +35,7 @@
 package com.starrocks.analysis;
 
 import com.google.common.base.Preconditions;
+import com.starrocks.common.Pair;
 import com.starrocks.common.io.Text;
 import com.starrocks.common.io.Writable;
 import com.starrocks.sql.ast.AstVisitor;
@@ -216,6 +217,21 @@ public class BinaryPredicate extends Predicate implements Writable {
         BinaryPredicate binaryPredicate = new BinaryPredicate();
         binaryPredicate.readFields(in);
         return binaryPredicate;
+    }
+
+    public Pair<SlotRef, Expr> createSlotAndLiteralPair() {
+        Expr leftExpr = getChild(0);
+        Expr rightExpr = getChild(1);
+        if (leftExpr instanceof SlotRef && (rightExpr instanceof Parameter) &&
+                (((Parameter) rightExpr).getExpr() instanceof LiteralExpr)) {
+            SlotRef slot = (SlotRef) leftExpr;
+            return Pair.create(slot, ((Parameter) rightExpr).getExpr());
+        } else if (rightExpr instanceof SlotRef && (leftExpr instanceof Parameter) &&
+                (((Parameter) leftExpr).getExpr() instanceof LiteralExpr)) {
+            SlotRef slot = (SlotRef) rightExpr;
+            return Pair.create(slot, ((Parameter) leftExpr).getExpr());
+        }
+        return null;
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/planner/OlapScanNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/OlapScanNode.java
@@ -1327,7 +1327,7 @@ public class OlapScanNode extends ScanNode {
             // for query: select count(1) from t tablet(tablet_id0, tablet_id1,...), the user-provided tablet_id
             // maybe invalid.
             Preconditions.checkState(tabletToPartitionMap.containsKey(tabletId),
-                    String.format("Invalid tablet id: '%s'", tabletId));
+                    "Invalid tablet id: '" + tabletId + "'");
             long partitionId = tabletToPartitionMap.get(tabletId);
             partitionToTabletMap.computeIfAbsent(partitionId, k -> Lists.newArrayList()).add(tabletId);
         }

--- a/fe/fe-core/src/main/java/com/starrocks/qe/PrepareStmtContext.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/PrepareStmtContext.java
@@ -14,13 +14,21 @@
 
 package com.starrocks.qe;
 
+import com.starrocks.catalog.OlapTable;
+import com.starrocks.sql.analyzer.QueryAnalyzer;
 import com.starrocks.sql.ast.PrepareStmt;
+import com.starrocks.sql.ast.QueryStatement;
+import com.starrocks.sql.ast.SelectRelation;
+import com.starrocks.sql.ast.TableRelation;
 import com.starrocks.sql.plan.ExecPlan;
 
 public class PrepareStmtContext {
     private final PrepareStmt stmt;
     private final ConnectContext connectContext;
-    private final ExecPlan execPlan;
+    private ExecPlan execPlan;
+    private boolean isCached = false;
+    private long lastSchemaUpdateTime = -1;
+    private long tableId = -1;
 
     public PrepareStmtContext(PrepareStmt stmt, ConnectContext connectContext, ExecPlan execPlan) {
         this.stmt = stmt;
@@ -36,7 +44,52 @@ public class PrepareStmtContext {
         return connectContext;
     }
 
+    public void setExecPlan(ExecPlan execPlan) {
+        this.execPlan = execPlan;
+    }
+
     public ExecPlan getExecPlan() {
         return execPlan;
+    }
+
+    public boolean isCached() {
+        return isCached;
+    }
+
+    public void updateLastSchemaUpdateTime(QueryStatement stmt, ConnectContext session) {
+        SelectRelation selectRelation = (SelectRelation) (stmt.getQueryRelation());
+        TableRelation tableRelation = (TableRelation) selectRelation.getRelation();
+        QueryAnalyzer queryAnalyzer = new QueryAnalyzer(session);
+        OlapTable table = (OlapTable) queryAnalyzer.resolveTable(tableRelation);
+        this.lastSchemaUpdateTime = table.lastSchemaUpdateTime.get();
+        this.tableId = table.getId();
+    }
+
+    public void cachePlan(ExecPlan execPlan) {
+        this.execPlan = execPlan;
+        this.isCached = true;
+    }
+
+    public boolean needReAnalyze(QueryStatement stmt, ConnectContext session) {
+        SelectRelation selectRelation = (SelectRelation) (stmt.getQueryRelation());
+        TableRelation tableRelation = (TableRelation) selectRelation.getRelation();
+        QueryAnalyzer queryAnalyzer = new QueryAnalyzer(session);
+        OlapTable table = (OlapTable) queryAnalyzer.resolveTable(tableRelation);
+        long lastSchemaUpdateTime = table.lastSchemaUpdateTime.get();
+        long tableId = table.getId();
+        if (lastSchemaUpdateTime > this.lastSchemaUpdateTime) {
+            return true;
+        }
+        if (tableId != this.tableId) {
+            return true;
+        }
+        return false;
+    }
+
+    public void reset() {
+        this.isCached = false;
+        this.lastSchemaUpdateTime = -1;
+        this.tableId = -1;
+        this.execPlan = null;
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/qe/StmtExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/StmtExecutor.java
@@ -114,6 +114,7 @@ import com.starrocks.qe.scheduler.Coordinator;
 import com.starrocks.qe.scheduler.FeExecuteCoordinator;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.sql.ExplainAnalyzer;
+import com.starrocks.sql.PrepareStmtPlanner;
 import com.starrocks.sql.StatementPlanner;
 import com.starrocks.sql.analyzer.AnalyzerUtils;
 import com.starrocks.sql.analyzer.AstToStringBuilder;
@@ -507,7 +508,7 @@ public class StmtExecutor {
                         parsedStmt = prepareStmt.assignValues(executeStmt.getParamsExpr());
                         parsedStmt.setOrigStmt(originStmt);
                         try {
-                            execPlan = StatementPlanner.plan(parsedStmt, context);
+                            execPlan = PrepareStmtPlanner.plan(executeStmt, parsedStmt, context);
                         } catch (SemanticException e) {
                             if (e.getMessage().contains("Unknown partition")) {
                                 throw new SemanticException(e.getMessage() +

--- a/fe/fe-core/src/main/java/com/starrocks/sql/PrepareStmtPlanner.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/PrepareStmtPlanner.java
@@ -1,0 +1,133 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.sql;
+
+import com.starrocks.http.HttpConnectContext;
+import com.starrocks.qe.ConnectContext;
+import com.starrocks.qe.PrepareStmtContext;
+import com.starrocks.sql.ast.ExecuteStmt;
+import com.starrocks.sql.ast.QueryRelation;
+import com.starrocks.sql.ast.QueryStatement;
+import com.starrocks.sql.ast.StatementBase;
+import com.starrocks.sql.optimizer.OptExpression;
+import com.starrocks.sql.optimizer.base.ColumnRefFactory;
+import com.starrocks.sql.optimizer.operator.Operator;
+import com.starrocks.sql.optimizer.operator.logical.LogicalFilterOperator;
+import com.starrocks.sql.optimizer.operator.logical.LogicalOlapScanOperator;
+import com.starrocks.sql.optimizer.operator.physical.PhysicalOlapScanOperator;
+import com.starrocks.sql.optimizer.operator.scalar.ScalarOperator;
+import com.starrocks.sql.optimizer.rewrite.OptDistributionPruner;
+import com.starrocks.sql.optimizer.rewrite.OptOlapPartitionPruner;
+import com.starrocks.sql.optimizer.transformer.LogicalPlan;
+import com.starrocks.sql.plan.ExecPlan;
+import com.starrocks.sql.plan.PlanFragmentBuilder;
+import com.starrocks.thrift.TResultSinkType;
+
+import java.util.List;
+
+public class PrepareStmtPlanner {
+
+    public static ExecPlan plan(ExecuteStmt executeStmt, StatementBase stmt, ConnectContext session) {
+        if (!(stmt instanceof QueryStatement)) {
+            return StatementPlanner.plan(stmt, session);
+        }
+        QueryStatement queryStmt = (QueryStatement) stmt;
+        if (!queryStmt.isPointQuery()) {
+            return StatementPlanner.plan(stmt, session);
+        }
+
+        PrepareStmtContext prepareStmtContext = session.getPreparedStmt(executeStmt.getStmtName());
+        if (!prepareStmtContext.isCached()) {
+            return planAndCacheExecPlan(stmt, session, prepareStmtContext);
+        } else {
+            if (prepareStmtContext.needReAnalyze(queryStmt, session)) {
+                return planAndCacheExecPlan(stmt, session, prepareStmtContext);
+            } else {
+                ExecPlan execPlan = prepareStmtContext.getExecPlan();
+
+                // use cache and rebuild physical plan
+                rePlan(executeStmt, execPlan.getLogicalPlan(), execPlan.getPhysicalPlan());
+
+                TResultSinkType resultSinkType = session instanceof HttpConnectContext ? TResultSinkType.HTTP_PROTOCAL :
+                        TResultSinkType.MYSQL_PROTOCAL;
+                resultSinkType = queryStmt.hasOutFileClause() ? TResultSinkType.FILE : resultSinkType;
+
+                OptExpression physicalPlan = execPlan.getPhysicalPlan();
+                LogicalPlan logicalPlan = execPlan.getLogicalPlan();
+                ColumnRefFactory columnRefFactory = execPlan.getColumnRefFactory();
+                QueryRelation query = queryStmt.getQueryRelation();
+                List<String> colNames = query.getColumnOutputNames();
+
+                return PlanFragmentBuilder.createPhysicalPlan(
+                        physicalPlan, session, logicalPlan.getOutputColumn(), columnRefFactory,
+                        colNames,
+                        resultSinkType,
+                        !session.getSessionVariable().isSingleNodeExecPlan());
+            }
+        }
+    }
+
+    private static ExecPlan planAndCacheExecPlan(StatementBase stmt, ConnectContext session,
+                                                 PrepareStmtContext prepareStmtContext) {
+        ExecPlan execPlan = StatementPlanner.plan(stmt, session);
+        if (execPlan == null) {
+            return null;
+        }
+
+        prepareStmtContext.setExecPlan(execPlan);
+        prepareStmtContext.updateLastSchemaUpdateTime((QueryStatement) stmt, session);
+        prepareStmtContext.cachePlan(execPlan);
+        return execPlan;
+    }
+
+    private static void rePlan(ExecuteStmt executeStmt,
+                               LogicalPlan logicalPlan,
+                               OptExpression optimizedPlan) {
+
+        Operator operator = logicalPlan.getRoot().getInputs().get(0).getOp();
+        if (operator instanceof LogicalFilterOperator) {
+            ScalarOperator.updateLiteralPredicates(operator.getPredicate(), executeStmt.getParamsExpr());
+        }
+
+        rePlanOptimizedPlan(logicalPlan, optimizedPlan);
+    }
+
+    private static void rePlanOptimizedPlan(LogicalPlan logicalPlan, OptExpression optimizedPlan) {
+        if (!(optimizedPlan.getOp() instanceof PhysicalOlapScanOperator)) {
+            return;
+        }
+
+        ScalarOperator predicate = logicalPlan.getRoot().getInputs().get(0).getOp().getPredicate();
+
+        // process logical scan operator
+        LogicalOlapScanOperator logicalScanOperator =
+                (LogicalOlapScanOperator) logicalPlan.getRoot().getInputs().get(0).getInputs().get(0)
+                        .getInputs().get(0).getOp();
+        LogicalOlapScanOperator logicalOlapScanOperator =
+                OptOlapPartitionPruner.prunePartitions(logicalScanOperator);
+        logicalOlapScanOperator
+                .buildColumnFilters(predicate);
+
+        // update optimized plan partitionIds and tabletIds with predicates
+        optimizedPlan.getOp().setPredicate(predicate);
+        PhysicalOlapScanOperator physicalOlapScanOperator = (PhysicalOlapScanOperator) optimizedPlan.getOp();
+        physicalOlapScanOperator.setSelectedPartitionId(logicalOlapScanOperator.getSelectedPartitionId());
+        List<Long> pruneTabletIds = OptDistributionPruner.pruneTabletIds(logicalOlapScanOperator,
+                logicalOlapScanOperator.getSelectedPartitionId());
+
+        physicalOlapScanOperator.setSelectedTabletId(pruneTabletIds);
+    }
+
+}

--- a/fe/fe-core/src/main/java/com/starrocks/sql/StatementPlanner.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/StatementPlanner.java
@@ -213,10 +213,13 @@ public class StatementPlanner {
              * currently only used in Spark/Flink Connector
              * Because the connector sends only simple queries, it only needs to remove the output fragment
              */
-            return PlanFragmentBuilder.createPhysicalPlan(
+            ExecPlan execPlan = PlanFragmentBuilder.createPhysicalPlan(
                     optimizedPlan, session, logicalPlan.getOutputColumn(), columnRefFactory, colNames,
                     resultSinkType,
                     !session.getSessionVariable().isSingleNodeExecPlan());
+            execPlan.setLogicalPlan(logicalPlan);
+            execPlan.setColumnRefFactory(columnRefFactory);
+            return execPlan;
         }
     }
 
@@ -290,6 +293,8 @@ public class StatementPlanner {
                         t.lastVersionUpdateEndTime.get() < buildFragmentStartTime &&
                                 t.lastVersionUpdateEndTime.get() >= t.lastVersionUpdateStartTime.get());
                 if (isSchemaValid) {
+                    plan.setLogicalPlan(logicalPlan);
+                    plan.setColumnRefFactory(columnRefFactory);
                     return plan;
                 }
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/QueryAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/QueryAnalyzer.java
@@ -1120,7 +1120,7 @@ public class QueryAnalyzer {
 
     }
 
-    private Table resolveTable(TableRelation tableRelation) {
+    public Table resolveTable(TableRelation tableRelation) {
         TableName tableName = tableRelation.getName();
         try {
             MetaUtils.normalizationTableName(session, tableName);

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/QueryStatement.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/QueryStatement.java
@@ -15,9 +15,22 @@
 
 package com.starrocks.sql.ast;
 
+import com.starrocks.analysis.BinaryPredicate;
+import com.starrocks.analysis.CompoundPredicate;
+import com.starrocks.analysis.Expr;
 import com.starrocks.analysis.OutFileClause;
 import com.starrocks.analysis.RedirectStatus;
+import com.starrocks.analysis.SlotRef;
+import com.starrocks.catalog.Column;
+import com.starrocks.catalog.OlapTable;
+import com.starrocks.catalog.Table;
+import com.starrocks.common.Pair;
 import com.starrocks.qe.OriginStatement;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
 
 public class QueryStatement extends StatementBase {
     private final QueryRelation queryRelation;
@@ -59,5 +72,94 @@ public class QueryStatement extends StatementBase {
     @Override
     public RedirectStatus getRedirectStatus() {
         return RedirectStatus.NO_FORWARD;
+    }
+
+    // only for prepare execute query
+    public boolean isPointQuery() {
+        if (queryRelation == null || !(queryRelation instanceof SelectRelation)) {
+            return false;
+        }
+
+        SelectRelation selectRelation = (SelectRelation) queryRelation;
+        if (selectRelation.hasLimit() || selectRelation.hasOffset() || selectRelation.hasHavingClause() ||
+                selectRelation.hasAggregation() || selectRelation.hasOrderByClause() ||
+                selectRelation.hasWithClause()) {
+            return false;
+        }
+
+        if (!(selectRelation.getRelation() instanceof TableRelation)) {
+            return false;
+        }
+
+        if (((TableRelation) selectRelation.getRelation()).getTable().getType() != Table.TableType.OLAP) {
+            return false;
+        }
+
+        Map<SlotRef, Expr> eqPredicates = new HashMap<>();
+        eqPredicates = getEQBinaryPredicates(eqPredicates, selectRelation.getPredicate(), TExprOpcode.EQ);
+        if (eqPredicates == null) {
+            return false;
+        }
+
+        OlapTable olapTable = (OlapTable) ((TableRelation) selectRelation.getRelation()).getTable();
+        List<Column> pkColumns = olapTable.getKeyColumns();
+        if (pkColumns.size() != eqPredicates.size()) {
+            return false;
+        }
+
+        for (Column column : pkColumns) {
+            SlotRef slotRef = findSlotRef(eqPredicates.keySet(), column.getName());
+            if (slotRef == null) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    private static Map<SlotRef, Expr> getEQBinaryPredicates(Map<SlotRef, Expr> result, Expr expr,
+                                                            TExprOpcode eqOpcode) {
+        if (expr == null) {
+            return null;
+        }
+        if (expr instanceof CompoundPredicate) {
+            CompoundPredicate compoundPredicate = (CompoundPredicate) expr;
+            if (compoundPredicate.getOp() != CompoundPredicate.Operator.AND) {
+                return null;
+            }
+
+            result = getEQBinaryPredicates(result, compoundPredicate.getChild(0), eqOpcode);
+            if (result == null) {
+                return null;
+            }
+            result = getEQBinaryPredicates(result, compoundPredicate.getChild(1), eqOpcode);
+            if (result == null) {
+                return null;
+            }
+            return result;
+        } else if (expr instanceof BinaryPredicate) {
+            BinaryPredicate binaryPredicate = (BinaryPredicate) expr;
+            if (binaryPredicate.getOpcode() != eqOpcode) {
+                return null;
+            }
+            Pair<SlotRef, Expr> slotRefExprPair = binaryPredicate.createSlotAndLiteralPair();
+            if (slotRefExprPair == null || result.containsKey(slotRefExprPair.first)) {
+                return null;
+            }
+
+            result.put(slotRefExprPair.first, slotRefExprPair.second);
+            return result;
+        } else {
+            return null;
+        }
+    }
+
+    private SlotRef findSlotRef(Set<SlotRef> slotRefs, String colName) {
+        for (SlotRef slotRef : slotRefs) {
+            if (slotRef.getColumnName().equalsIgnoreCase(colName)) {
+                return slotRef;
+            }
+        }
+        return null;
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/QueryStatement.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/QueryStatement.java
@@ -26,6 +26,7 @@ import com.starrocks.catalog.OlapTable;
 import com.starrocks.catalog.Table;
 import com.starrocks.common.Pair;
 import com.starrocks.qe.OriginStatement;
+import com.starrocks.thrift.TExprOpcode;
 
 import java.util.HashMap;
 import java.util.List;

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/physical/PhysicalOlapScanOperator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/physical/PhysicalOlapScanOperator.java
@@ -106,8 +106,16 @@ public class PhysicalOlapScanOperator extends PhysicalScanOperator {
         return gtid;
     }
 
+    public void setSelectedPartitionId(List<Long> selectedPartitionId) {
+        this.selectedPartitionId = selectedPartitionId;
+    }
+
     public List<Long> getSelectedPartitionId() {
         return selectedPartitionId;
+    }
+
+    public void setSelectedTabletId(List<Long> tabletId) {
+        this.selectedTabletId = tabletId;
     }
 
     public List<Long> getSelectedTabletId() {
@@ -245,6 +253,7 @@ public class PhysicalOlapScanOperator extends PhysicalScanOperator {
     public static Builder builder() {
         return new Builder();
     }
+
     public static class Builder
             extends PhysicalScanOperator.Builder<PhysicalOlapScanOperator, PhysicalScanOperator.Builder> {
         @Override
@@ -269,7 +278,7 @@ public class PhysicalOlapScanOperator extends PhysicalScanOperator {
             builder.usePkIndex = operator.usePkIndex;
             builder.globalDicts = operator.globalDicts;
             builder.prunedPartitionPredicates = operator.prunedPartitionPredicates;
-            return  this;
+            return this;
         }
 
         public Builder setGlobalDicts(List<Pair<Integer, ColumnDict>> globalDicts) {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/plan/ExecPlan.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/plan/ExecPlan.java
@@ -29,7 +29,9 @@ import com.starrocks.qe.ConnectContext;
 import com.starrocks.sql.Explain;
 import com.starrocks.sql.ast.StatementBase;
 import com.starrocks.sql.optimizer.OptExpression;
+import com.starrocks.sql.optimizer.base.ColumnRefFactory;
 import com.starrocks.sql.optimizer.operator.scalar.ColumnRefOperator;
+import com.starrocks.sql.optimizer.transformer.LogicalPlan;
 import com.starrocks.thrift.TExplainLevel;
 
 import java.util.ArrayList;
@@ -58,6 +60,9 @@ public class ExecPlan {
     private List<ExecGroup> execGroups = new ArrayList<>();
 
     private volatile ProfilingExecPlan profilingPlan;
+    private LogicalPlan logicalPlan;
+    private ColumnRefFactory columnRefFactory;
+
 
     @VisibleForTesting
     public ExecPlan() {
@@ -225,5 +230,21 @@ public class ExecPlan {
                 break;
         }
         return getExplainString(tlevel);
+    }
+
+    public LogicalPlan getLogicalPlan() {
+        return logicalPlan;
+    }
+
+    public void setLogicalPlan(LogicalPlan logicalPlan) {
+        this.logicalPlan = logicalPlan;
+    }
+
+    public ColumnRefFactory getColumnRefFactory() {
+        return columnRefFactory;
+    }
+
+    public void setColumnRefFactory(ColumnRefFactory columnRefFactory) {
+        this.columnRefFactory = columnRefFactory;
     }
 }


### PR DESCRIPTION
## Why I'm doing:

When prepare execute  a primary key point query on a PK table, cached execution plan can enhance the performance of the point query.

The performance make 1x faster .

## What I'm doing:

During the Prepare Execute process, we cache the analyzeStmt, optimizedPlan, and logicalPlan to avoid regeneration. The reason for this is that in the PK primary key point query mode, the query conditions are very strict, resulting in a fixed execution plan structure. Therefore, we only need to replace the Predicate in the structure to transform it into a new execution plan

Test Performance

Result：Performance increased by approximately **110%**

Testing FE Server Configuration：16 cores, 32 GB

Before Optimization

**ops/sec：16611**

```
[OVERALL], RunTime(ms), 60198
[OVERALL], Throughput(ops/sec), 16611.8475696867
[TOTAL_GCS_G1_Young_Generation], Count, 91
[TOTAL_GC_TIME_G1_Young_Generation], Time(ms), 261
[TOTAL_GC_TIME_%_G1_Young_Generation], Time(%), 0.4335692215688229
[TOTAL_GCS_G1_Old_Generation], Count, 0
[TOTAL_GC_TIME_G1_Old_Generation], Time(ms), 0
[TOTAL_GC_TIME_%_G1_Old_Generation], Time(%), 0.0
[TOTAL_GCs], Count, 91
[TOTAL_GC_TIME], Time(ms), 261
[TOTAL_GC_TIME_%], Time(%), 0.4335692215688229
[READ], Operations, 1000000
[READ], AverageLatency(us), 11607.72868
[READ], MinLatency(us), 913
[READ], MaxLatency(us), 723455
[READ], 95thPercentileLatency(us), 56447
[READ], 99thPercentileLatency(us), 83519
[READ], Return=OK, 1000000
[CLEANUP], Operations, 200
[CLEANUP], AverageLatency(us), 206.105
[CLEANUP], MinLatency(us), 54
[CLEANUP], MaxLatency(us), 14855
[CLEANUP], 95thPercentileLatency(us), 204
[CLEANUP], 99thPercentileLatency(us), 616
```

After Optimization

**ops/sec：35348**

```
[OVERALL], RunTime(ms), 28290
[OVERALL], Throughput(ops/sec), 35348.17956875221
[TOTAL_GCS_G1_Young_Generation], Count, 85
[TOTAL_GC_TIME_G1_Young_Generation], Time(ms), 118
[TOTAL_GC_TIME_%_G1_Young_Generation], Time(%), 0.4171085189112761
[TOTAL_GCS_G1_Old_Generation], Count, 0
[TOTAL_GC_TIME_G1_Old_Generation], Time(ms), 0
[TOTAL_GC_TIME_%_G1_Old_Generation], Time(%), 0.0
[TOTAL_GCs], Count, 85
[TOTAL_GC_TIME], Time(ms), 118
[TOTAL_GC_TIME_%], Time(%), 0.4171085189112761
[READ], Operations, 1000000
[READ], AverageLatency(us), 2704.790795
[READ], MinLatency(us), 694
[READ], MaxLatency(us), 462847
[READ], 95thPercentileLatency(us), 4851
[READ], 99thPercentileLatency(us), 7087
[READ], Return=OK, 1000000
[CLEANUP], Operations, 100
[CLEANUP], AverageLatency(us), 209.45
[CLEANUP], MinLatency(us), 46
[CLEANUP], MaxLatency(us), 10271
[CLEANUP], 95thPercentileLatency(us), 257
[CLEANUP], 99thPercentileLatency(us), 2867
```

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
- [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
