### PR TITLE
[BugFix] Fix str_to_jodatime/to_tera_date function bug 

### DIFF
--- a/be/src/runtime/datetime_value.cpp
+++ b/be/src/runtime/datetime_value.cpp
@@ -152,12 +152,12 @@ bool JodaFormat::prepare(std::string_view format) {
                 if (!str_to_int64(*(state->valptr), &tmp, &int_value)) {
                     return false;
                 }
-                *(state->week_num) = int_value;
-                if (*(state->week_num) > 53 || (strict_week_number && *(state->week_num) == 0)) {
+                state->week_num = int_value;
+                if (state->week_num > 53 || (strict_week_number && state->week_num == 0)) {
                     return false;
                 }
                 *(state->valptr) = tmp;
-                *(state->date_part_used) = true;
+                state->date_part_used = true;
                 return true;
             });
             break;
@@ -176,9 +176,9 @@ bool JodaFormat::prepare(std::string_view format) {
                 if (int_value == 0) {
                     int_value = 7;
                 }
-                *(state->weekday) = int_value;
+                state->weekday = int_value;
                 *(state->valptr) = tmp;
-                *(state->date_part_used) = true;
+                state->date_part_used = true;
                 return true;
             });
             break;
@@ -191,8 +191,8 @@ bool JodaFormat::prepare(std::string_view format) {
                         return false;
                     }
                     int_value++;
-                    *(state->weekday) = int_value;
-                    *(state->date_part_used) = true;
+                    state->weekday = int_value;
+                    state->date_part_used = true;
                     return true;
                 });
             } else {
@@ -202,8 +202,8 @@ bool JodaFormat::prepare(std::string_view format) {
                         return false;
                     }
                     int_value++;
-                    *(state->weekday) = int_value;
-                    *(state->date_part_used) = true;
+                    state->weekday = int_value;
+                    state->date_part_used = true;
                     return true;
                 });
             }
@@ -225,7 +225,7 @@ bool JodaFormat::prepare(std::string_view format) {
                 }
                 state->_year = int_value;
                 *(state->valptr) = tmp;
-                *(state->date_part_used) = true;
+                state->date_part_used = true;
                 return true;
             });
             break;
@@ -238,9 +238,9 @@ bool JodaFormat::prepare(std::string_view format) {
                 if (!str_to_int64(*(state->valptr), &tmp, &int_value)) {
                     return false;
                 }
-                *(state->yearday) = int_value;
+                state->yearday = int_value;
                 *(state->valptr) = tmp;
-                *(state->date_part_used) = true;
+                state->date_part_used = true;
                 return true;
             });
             break;
@@ -257,7 +257,7 @@ bool JodaFormat::prepare(std::string_view format) {
                     }
                     state->_month = int_value;
                     *(state->valptr) = tmp;
-                    *(state->date_part_used) = true;
+                    state->date_part_used = true;
                     return true;
                 });
             } else if (repeat_count == 3) {
@@ -294,7 +294,7 @@ bool JodaFormat::prepare(std::string_view format) {
                 }
                 state->_day = int_value;
                 *(state->valptr) = tmp;
-                *(state->date_part_used) = true;
+                state->date_part_used = true;
                 return true;
             });
             break;
@@ -307,9 +307,9 @@ bool JodaFormat::prepare(std::string_view format) {
                 }
                 if (toupper(*val) == 'P') {
                     // PM
-                    *(state->halfday) = 12;
+                    state->halfday = 12;
                 }
-                *(state->time_part_used) = true;
+                state->time_part_used = true;
                 *(state->valptr) += 2;
                 return true;
             });
@@ -331,7 +331,7 @@ bool JodaFormat::prepare(std::string_view format) {
                     return false;
                 }
                 state->_hour = int_value;
-                *(state->time_part_used) = true;
+                state->time_part_used = true;
                 *(state->valptr) = tmp;
                 return true;
             });
@@ -354,7 +354,7 @@ bool JodaFormat::prepare(std::string_view format) {
 
                 state->_hour = int_value;
                 *(state->valptr) = tmp;
-                *(state->time_part_used) = true;
+                state->time_part_used = true;
                 return true;
             });
             break;
@@ -369,7 +369,7 @@ bool JodaFormat::prepare(std::string_view format) {
                 }
                 state->_minute = int_value;
                 *(state->valptr) = tmp;
-                *(state->time_part_used) = true;
+                state->time_part_used = true;
                 return true;
             });
             break;
@@ -383,7 +383,7 @@ bool JodaFormat::prepare(std::string_view format) {
                 }
                 state->_second = int_value;
                 *(state->valptr) = tmp;
-                *(state->time_part_used) = true;
+                state->time_part_used = true;
                 return true;
             });
             break;
@@ -403,8 +403,8 @@ bool JodaFormat::prepare(std::string_view format) {
                 }
                 state->_microsecond = int_value;
                 *(state->valptr) = tmp;
-                *(state->time_part_used) = true;
-                *(state->frac_part_used) = true;
+                state->time_part_used = true;
+                state->frac_part_used = true;
                 return true;
             });
             break;
@@ -412,10 +412,10 @@ bool JodaFormat::prepare(std::string_view format) {
         case joda::JodaFormatChar::TIME_ZONE_OFFSET: {
             _token_parsers.emplace_back([&](JodaRuntimeState* state, const char* val_end) {
                 std::string_view tz(*(state->valptr), val_end);
-                if (!TimezoneUtils::find_cctz_time_zone(tz, *(state->ctz))) {
+                if (!TimezoneUtils::find_cctz_time_zone(tz, state->ctz)) {
                     return false;
                 }
-                *(state->has_timezone) = true;
+                state->has_timezone = true;
                 return true;
             });
             break;
@@ -436,19 +436,19 @@ bool JodaFormat::prepare(std::string_view format) {
     }
 
     _token_parsers.emplace_back([&](JodaRuntimeState* state, const char* val_end) {
-        if (*(state->halfday) > 0) {
-            state->_hour = (state->_hour % 12) + *(state->halfday);
+        if (state->halfday > 0) {
+            state->_hour = (state->_hour % 12) + state->halfday;
         }
 
         // Year day
-        if (*(state->yearday) > 0) {
-            uint64_t days = DateTimeValue::calc_daynr(state->_year, 1, 1) + *(state->yearday) - 1;
+        if (state->yearday > 0) {
+            uint64_t days = DateTimeValue::calc_daynr(state->_year, 1, 1) + state->yearday - 1;
             if (!state->get_date_from_daynr(days)) {
                 return false;
             }
         }
         // weekday
-        if (*(state->week_num) >= 0 && *(state->weekday) > 0) {
+        if (state->week_num >= 0 && state->weekday > 0) {
             // Check
             if ((strict_week_number && (strict_week_number_year < 0 || strict_week_number_year_type != sunday_first)) ||
                 (!strict_week_number && strict_week_number_year >= 0)) {
@@ -460,9 +460,9 @@ bool JodaFormat::prepare(std::string_view format) {
             uint8_t weekday_b = DateTimeValue::calc_weekday(days, sunday_first);
 
             if (sunday_first) {
-                days += ((weekday_b == 0) ? 0 : 7) - weekday_b + (*(state->week_num) - 1) * 7 + *(state->weekday) % 7;
+                days += ((weekday_b == 0) ? 0 : 7) - weekday_b + (state->week_num - 1) * 7 + state->weekday % 7;
             } else {
-                days += ((weekday_b <= 3) ? 0 : 7) - weekday_b + (*(state->week_num) - 1) * 7 + *(state->weekday) - 1;
+                days += ((weekday_b <= 3) ? 0 : 7) - weekday_b + (state->week_num - 1) * 7 + state->weekday - 1;
             }
             if (!state->get_date_from_daynr(days)) {
                 return false;
@@ -470,15 +470,15 @@ bool JodaFormat::prepare(std::string_view format) {
         }
 
         // Compute timestamp type
-        if (*(state->frac_part_used)) {
-            if (*(state->date_part_used)) {
+        if (state->frac_part_used) {
+            if (state->date_part_used) {
                 state->_type = TIME_DATETIME;
             } else {
                 state->_type = TIME_TIME;
             }
         } else {
-            if (*(state->date_part_used)) {
-                if (*(state->time_part_used)) {
+            if (state->date_part_used) {
+                if (state->time_part_used) {
                     state->_type = TIME_DATETIME;
                 } else {
                     state->_type = TIME_DATE;
@@ -489,10 +489,10 @@ bool JodaFormat::prepare(std::string_view format) {
         }
 
         // Timezone
-        if (*(state->has_timezone)) {
+        if (state->has_timezone) {
             const auto tp = cctz::convert(cctz::civil_second(state->_year, state->_month, state->_day, state->_hour,
                                                              state->_minute, state->_second),
-                                          *(state->ctz));
+                                          state->ctz);
             int64_t timestamp = tp.time_since_epoch().count();
             if (!state->from_unixtime(timestamp, TimezoneUtils::local_time_zone())) {
                 return false;
@@ -513,31 +513,21 @@ bool JodaFormat::parse(std::string_view str, DateTimeValue* output) {
     const char* val = str.data();
     const char* val_end = str.data() + str.length();
 
-    bool date_part_used = false;
-    bool time_part_used = false;
-    bool frac_part_used = false;
-
-    int halfday = 0;
-    int weekday = -1;
-    int yearday = -1;
-    int week_num = -1;
-
-    cctz::time_zone ctz; // default UTC
-    bool has_timezone = false;
-
-    JodaRuntimeState state{.valptr = &val,
-                           .date_part_used = &date_part_used,
-                           .time_part_used = &time_part_used,
-                           .frac_part_used = &frac_part_used,
-                           .halfday = &halfday,
-                           .weekday = &weekday,
-                           .yearday = &yearday,
-                           .week_num = &week_num,
-                           .ctz = &ctz,
-                           .has_timezone = &has_timezone};
+    JodaRuntimeState state{
+            .valptr = &val,
+            .date_part_used = false,
+            .time_part_used = false,
+            .frac_part_used = false,
+            .halfday = 0,
+            .weekday = -1,
+            .yearday = -1,
+            .week_num = -1,
+            .has_timezone = false,
+    };
     state._year = 2000;
     state._month = 1;
     state._day = 1;
+
     for (auto& p : _token_parsers) {
         if (!p(&state, val_end)) {
             return false;

--- a/be/src/runtime/datetime_value.h
+++ b/be/src/runtime/datetime_value.h
@@ -537,17 +537,17 @@ namespace starrocks::joda {
 struct JodaRuntimeState final : public DateTimeValue {
     const char** valptr;
 
-    bool* date_part_used;
-    bool* time_part_used;
-    bool* frac_part_used;
+    bool date_part_used;
+    bool time_part_used;
+    bool frac_part_used;
 
-    int* halfday;
-    int* weekday;
-    int* yearday;
-    int* week_num;
+    int halfday;
+    int weekday;
+    int yearday;
+    int week_num;
 
-    cctz::time_zone* ctz; // default UTC
-    bool* has_timezone;
+    cctz::time_zone ctz; // default UTC
+    bool has_timezone;
 
 protected:
     friend class JodaFormat;

--- a/be/src/runtime/datetime_value.h
+++ b/be/src/runtime/datetime_value.h
@@ -508,12 +508,15 @@ std::ostream& operator<<(std::ostream& os, const DateTimeValue& value);
 
 std::size_t hash_value(DateTimeValue const& value);
 
-class TeradataFormat final : public DateTimeValue {
+struct TeradataRuntimeState final : public DateTimeValue {
+    const char** valptr;
+
+protected:
+    friend class TeradataFormat;
+};
+class TeradataFormat {
 public:
-    TeradataFormat() {
-        _month = 1;
-        _day = 1;
-    }
+    TeradataFormat() {}
     ~TeradataFormat() = default;
 
     bool prepare(std::string_view format);
@@ -521,17 +524,36 @@ public:
 
 private:
     // Token parsers
-    std::vector<std::function<bool()>> _token_parsers;
-    // Cursor
-    const char* val = nullptr;
-    const char* val_end = nullptr;
+    std::vector<std::function<bool(TeradataRuntimeState*, const char*)>> _token_parsers;
 };
 
 } // namespace starrocks
 
 namespace starrocks::joda {
 
-class JodaFormat : public starrocks::DateTimeValue {
+/**
+ * @brief Joda Runtime state for each input row.
+ */
+struct JodaRuntimeState final : public DateTimeValue {
+    const char** valptr;
+
+    bool* date_part_used;
+    bool* time_part_used;
+    bool* frac_part_used;
+
+    int* halfday;
+    int* weekday;
+    int* yearday;
+    int* week_num;
+
+    cctz::time_zone* ctz; // default UTC
+    bool* has_timezone;
+
+protected:
+    friend class JodaFormat;
+};
+
+class JodaFormat {
 public:
     JodaFormat() = default;
     ~JodaFormat() = default;
@@ -541,24 +563,7 @@ public:
 
 private:
     // Token parsers
-    std::vector<std::function<bool()>> _token_parsers;
-
-    // Cursor
-    const char* val = nullptr;
-    const char* val_end = nullptr;
-
-    bool date_part_used = false;
-    bool time_part_used = false;
-    bool frac_part_used = false;
-
-    int halfday = 0;
-    int weekday = -1;
-    int yearday = -1;
-    int week_num = -1;
-
-    cctz::time_zone ctz; // default UTC
-    bool has_timezone = false;
-
+    std::vector<std::function<bool(JodaRuntimeState*, const char*)>> _token_parsers;
     const bool strict_week_number = false;
     const bool sunday_first = false;
     const bool strict_week_number_year_type = false;

--- a/test/sql/test_time_fn/R/test_to_date
+++ b/test/sql/test_time_fn/R/test_to_date
@@ -135,3 +135,113 @@ None
 2023-04-02 20:13:14
 2023-04-03 20:13:14
 -- !result
+drop table to_tera_date_test;
+-- result:
+-- !result
+CREATE TABLE IF NOT EXISTS test_to_date_table1 (
+id varchar(150) NOT NULL COMMENT '',
+v1 varchar(32) NULL COMMENT ""
+) ENGINE=olap PRIMARY KEY (id) 
+DISTRIBUTED BY HASH(id) BUCKETS 1 PROPERTIES("enable_persistent_index" = "true", "replication_num" = "1");
+-- result:
+-- !result
+insert into test_to_date_table1 values('1','2023-10-11 00:00:01.030'), ('2','2023-10-11 00:00:01.031'), ('3','2023-10-13 00:00:01.031'), ('4','2023-10-14 00:00:01.031') ;
+-- result:
+-- !result
+set pipeline_dop=50;
+-- result:
+-- !result
+set new_planner_agg_stage=3;
+-- result:
+-- !result
+select DATE_FORMAT(v1, '%Y-%m-%d %H:%i:%s.%f') from test_to_date_table1 where id='1' order by 1;
+-- result:
+2023-10-11 00:00:01.030000
+-- !result
+select DATE_FORMAT(v1, '%Y-%m-%d') from test_to_date_table1 where id='1' order by 1;
+-- result:
+2023-10-11
+-- !result
+select DATE_FORMAT(v1, '%Y-%m-%d'), str_to_jodatime('2024-04-01', 'yyyy-MM-dd') from test_to_date_table1 group by DATE_FORMAT(v1, '%Y-%m-%d') order by 1;
+-- result:
+2023-10-11	2024-04-01 00:00:00
+2023-10-13	2024-04-01 00:00:00
+2023-10-14	2024-04-01 00:00:00
+-- !result
+select DATE_FORMAT(v1, '%Y-%m-%d') from test_to_date_table1 group by DATE_FORMAT(v1, '%Y-%m-%d') order by 1;
+-- result:
+2023-10-11
+2023-10-13
+2023-10-14
+-- !result
+select 
+  DATE_FORMAT(v1, '%Y-%m-%d'), str_to_jodatime('2024-04-01', 'yyyy-MM-dd'), 
+  to_tera_date("1988/04/08","yyyy/mm/dd"), to_tera_timestamp("1988/04/08 2","yyyy/mm/dd hh") 
+from test_to_date_table1 group by DATE_FORMAT(v1, '%Y-%m-%d') order by 1;
+-- result:
+2023-10-11	2024-04-01 00:00:00	1988-04-08	1988-04-08 02:00:00
+2023-10-13	2024-04-01 00:00:00	1988-04-08	1988-04-08 02:00:00
+2023-10-14	2024-04-01 00:00:00	1988-04-08	1988-04-08 02:00:00
+-- !result
+drop table test_to_date_table1;
+-- result:
+-- !result
+CREATE TABLE test_to_date_table2 (
+  k1 bigint null
+) ENGINE=OLAP
+DUPLICATE KEY(`k1`)
+DISTRIBUTED BY HASH(`k1`) BUCKETS 48
+PROPERTIES (
+    "replication_num" = "1"
+);
+-- result:
+-- !result
+insert into test_to_date_table2 select generate_series from TABLE(generate_series(0, 50000));
+-- result:
+-- !result
+select a, count(1) from (select str_to_jodatime('2024-04-01', 'yyyy-MM-dd') as a from test_to_date_table2 ) t group by a limit 10;
+-- result:
+2024-04-01 00:00:00	50001
+-- !result
+select a, count(1) from (select str_to_jodatime('2024-04-01', 'yyyy-MM-dd') as a from test_to_date_table2 ) t group by a limit 10;
+-- result:
+2024-04-01 00:00:00	50001
+-- !result
+select a, count(1) from (select to_tera_date("1988/04/08","yyyy/mm/dd") as a from test_to_date_table2 ) t group by a limit 10;
+-- result:
+1988-04-08	50001
+-- !result
+select a, count(1) from (select to_tera_date("1988/04/08","yyyy/mm/dd") as a from test_to_date_table2 ) t group by a limit 10;
+-- result:
+1988-04-08	50001
+-- !result
+select a, count(1) from (select to_tera_timestamp("1988/04/08 2","yyyy/mm/dd hh")  as a from test_to_date_table2 ) t group by a limit 10;
+-- result:
+1988-04-08 02:00:00	50001
+-- !result
+select a, count(1) from (select to_tera_timestamp("1988/04/08 2","yyyy/mm/dd hh")  as a from test_to_date_table2 ) t group by a limit 10;
+-- result:
+1988-04-08 02:00:00	50001
+-- !result
+set sql_dialect = 'trino';
+-- result:
+-- !result
+select a, count(1) from (select format_datetime(parse_datetime('2024-04-01', 'yyyy-MM-dd'), 'yyyy-ww') as a from test_to_date_table2)t group by a limit 10;
+-- result:
+2024-14	50001
+-- !result
+select a, count(1) from (select format_datetime(parse_datetime('2024-04-01', 'yyyy-MM-dd'), 'yyyy-ww') as a from test_to_date_table2)t group by a limit 10;
+-- result:
+2024-14	50001
+-- !result
+select a, count(1) from (select parse_datetime('2024-04-01', 'yyyy-MM-dd') as a from test_to_date_table2)t group by a limit 10;
+-- result:
+2024-04-01 00:00:00	50001
+-- !result
+select a, count(1) from (select parse_datetime('2024-04-01', 'yyyy-MM-dd') as a from test_to_date_table2)t group by a limit 10;
+-- result:
+2024-04-01 00:00:00	50001
+-- !result
+drop table test_to_date_table2;
+-- result:
+-- !result

--- a/test/sql/test_time_fn/T/test_to_date
+++ b/test/sql/test_time_fn/T/test_to_date
@@ -48,3 +48,53 @@ VALUES ('2023-04-01', NULL),
        ('2023-04-03', '2023-04-03 20:13:14');
 select to_tera_date(d2, 'yyyy-mm-dd hh24:mi:ss') from to_tera_date_test order by d1;
 select to_tera_timestamp(d2, 'yyyy-mm-dd hh24:mi:ss') from to_tera_date_test order by d1;
+drop table to_tera_date_test;
+
+CREATE TABLE IF NOT EXISTS test_to_date_table1 (
+id varchar(150) NOT NULL COMMENT '',
+v1 varchar(32) NULL COMMENT ""
+) ENGINE=olap PRIMARY KEY (id) 
+DISTRIBUTED BY HASH(id) BUCKETS 1 PROPERTIES("enable_persistent_index" = "true", "replication_num" = "1");
+
+insert into test_to_date_table1 values('1','2023-10-11 00:00:01.030'), ('2','2023-10-11 00:00:01.031'), ('3','2023-10-13 00:00:01.031'), ('4','2023-10-14 00:00:01.031') ;
+
+-- make sure str_to_jodatime, to_tera_date, to_tera_timestamp exexuted in parallel
+set pipeline_dop=50;
+set new_planner_agg_stage=3;
+
+select DATE_FORMAT(v1, '%Y-%m-%d %H:%i:%s.%f') from test_to_date_table1 where id='1' order by 1;
+select DATE_FORMAT(v1, '%Y-%m-%d') from test_to_date_table1 where id='1' order by 1;
+select DATE_FORMAT(v1, '%Y-%m-%d'), str_to_jodatime('2024-04-01', 'yyyy-MM-dd') from test_to_date_table1 group by DATE_FORMAT(v1, '%Y-%m-%d') order by 1;
+select DATE_FORMAT(v1, '%Y-%m-%d') from test_to_date_table1 group by DATE_FORMAT(v1, '%Y-%m-%d') order by 1;
+select 
+  DATE_FORMAT(v1, '%Y-%m-%d'), str_to_jodatime('2024-04-01', 'yyyy-MM-dd'), 
+  to_tera_date("1988/04/08","yyyy/mm/dd"), to_tera_timestamp("1988/04/08 2","yyyy/mm/dd hh") 
+from test_to_date_table1 group by DATE_FORMAT(v1, '%Y-%m-%d') order by 1;
+drop table test_to_date_table1;
+
+CREATE TABLE test_to_date_table2 (
+  k1 bigint null
+) ENGINE=OLAP
+DUPLICATE KEY(`k1`)
+DISTRIBUTED BY HASH(`k1`) BUCKETS 48
+PROPERTIES (
+    "replication_num" = "1"
+);
+insert into test_to_date_table2 select generate_series from TABLE(generate_series(0, 50000));
+
+select a, count(1) from (select str_to_jodatime('2024-04-01', 'yyyy-MM-dd') as a from test_to_date_table2 ) t group by a limit 10;
+select a, count(1) from (select str_to_jodatime('2024-04-01', 'yyyy-MM-dd') as a from test_to_date_table2 ) t group by a limit 10;
+
+select a, count(1) from (select to_tera_date("1988/04/08","yyyy/mm/dd") as a from test_to_date_table2 ) t group by a limit 10;
+select a, count(1) from (select to_tera_date("1988/04/08","yyyy/mm/dd") as a from test_to_date_table2 ) t group by a limit 10;
+
+select a, count(1) from (select to_tera_timestamp("1988/04/08 2","yyyy/mm/dd hh")  as a from test_to_date_table2 ) t group by a limit 10;
+select a, count(1) from (select to_tera_timestamp("1988/04/08 2","yyyy/mm/dd hh")  as a from test_to_date_table2 ) t group by a limit 10;
+
+set sql_dialect = 'trino';
+select a, count(1) from (select format_datetime(parse_datetime('2024-04-01', 'yyyy-MM-dd'), 'yyyy-ww') as a from test_to_date_table2)t group by a limit 10;
+select a, count(1) from (select format_datetime(parse_datetime('2024-04-01', 'yyyy-MM-dd'), 'yyyy-ww') as a from test_to_date_table2)t group by a limit 10;
+
+select a, count(1) from (select parse_datetime('2024-04-01', 'yyyy-MM-dd') as a from test_to_date_table2)t group by a limit 10;
+select a, count(1) from (select parse_datetime('2024-04-01', 'yyyy-MM-dd') as a from test_to_date_table2)t group by a limit 10;
+drop table test_to_date_table2;


### PR DESCRIPTION
## Why I'm doing:
- parse_datetime returns wrong result:
```
set sql_dialet = 'trino';

MySQL [starrocks_audit_db__]> select parse_datetime('2024-04-01', 'yyyy-MM-dd') from starrocks_audit_db__.starrocks_audit_tbl__   group by DATE_FORMAT(timestamp, '%Y-%m-%d');
+---------------------------------------------+
| str_to_jodatime('2024-04-01', 'yyyy-MM-dd') |
+---------------------------------------------+
| 3924-04-01 00:00:00                         |
| 3924-04-01 00:00:00                         |
| 2024-04-01 00:00:00                         |
| NULL                                        |
| NULL                                        |
| NULL                                        |
| 2024-04-01 00:00:00                         |
| 2024-04-01 00:00:00                         |
| 2024-04-01 00:00:00                         |
| 2024-04-01 00:00:00                         |
| 2024-04-01 00:00:00                         |
| 3924-04-01 00:00:00                         |
| 3924-04-01 00:00:00                         |
| 2024-04-01 00:00:00                         |
| 2024-04-01 00:00:00                         |
| 2024-04-01 00:00:00                         |
| 2024-04-01 00:00:00                         |
| 2024-04-01 00:00:00                         |
| 2024-04-01 00:00:00                         |
| 2024-04-01 00:00:00                         |
| 2024-04-01 00:00:00                         |
| 2024-04-01 00:00:00                         |
+---------------------------------------------+
```

## What I'm doing:
- `Cursor` should not be kept in `ParseJodaState`,  it will get a wrong result if multi operators run in parallel.
- Fix `str_to_jodatime/to_tera_date` function.

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [x] 3.2
  - [x] 3.1
  - [ ] 3.0
  - [ ] 2.5
