### PR TITLE
[Enhancement] skip reuse scalarOperator with all constant children

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/ScalarOperatorsReuse.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/ScalarOperatorsReuse.java
@@ -20,7 +20,6 @@ import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
 import com.starrocks.catalog.FunctionSet;
-import com.starrocks.qe.ConnectContext;
 import com.starrocks.sql.optimizer.base.ColumnRefFactory;
 import com.starrocks.sql.optimizer.operator.OperatorType;
 import com.starrocks.sql.optimizer.operator.Projection;
@@ -334,8 +333,7 @@ public class ScalarOperatorsReuse {
 
         @Override
         public Integer visit(ScalarOperator scalarOperator, Void context) {
-            if ((ConnectContext.get().getSessionVariable().isCboPruneSubfield() && scalarOperator.isConstant())
-                    || scalarOperator.getChildren().isEmpty()) {
+            if (scalarOperator.isConstant() || scalarOperator.getChildren().isEmpty()) {
                 return 0;
             }
 
@@ -358,8 +356,7 @@ public class ScalarOperatorsReuse {
                 // for example:
                 // select (rnd + 1) as rnd1, (rnd + 2) as rnd2 from (select rand() as rnd) sub
                 return collectCommonOperatorsByDepth(1, scalarOperator);
-            } else if ((ConnectContext.get().getSessionVariable().isCboPruneSubfield() && scalarOperator.isConstant())
-                    || scalarOperator.getChildren().isEmpty()) {
+            } else if (scalarOperator.isConstant() || scalarOperator.getChildren().isEmpty()) {
                 // to keep the same logic as origin
                 return 0;
             } else {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/ScalarOperatorsReuse.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/ScalarOperatorsReuse.java
@@ -333,7 +333,7 @@ public class ScalarOperatorsReuse {
 
         @Override
         public Integer visit(ScalarOperator scalarOperator, Void context) {
-            if (scalarOperator.getChildren().isEmpty()) {
+            if (scalarOperator.isConstant() || scalarOperator.getChildren().isEmpty()) {
                 return 0;
             }
 
@@ -356,7 +356,7 @@ public class ScalarOperatorsReuse {
                 // for example:
                 // select (rnd + 1) as rnd1, (rnd + 2) as rnd2 from (select rand() as rnd) sub
                 return collectCommonOperatorsByDepth(1, scalarOperator);
-            } else if (scalarOperator.getChildren().isEmpty()) {
+            } else if (scalarOperator.isConstant() || scalarOperator.getChildren().isEmpty()) {
                 // to keep the same logic as origin
                 return 0;
             } else {
@@ -370,8 +370,7 @@ public class ScalarOperatorsReuse {
             return collectCommonOperatorsByDepth(1, scalarOperator);
         }
 
-        // If a scalarOperator contains any non-deterministic function, it cannot be reused
-        // because the non-deterministic function results returned each time are inconsistent.
+
         // a lambda-dependent expressions also can't be reused if reuseLambdaDependentExpr is false.
         // For example, array_map(x->2x+1+2x,array),2x is lambda-dependent, so it can't be reused if
         // reuseLambdaDependentExpr is false, but array_map(x->2x+1+2x,array) can be reused if needed.

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/ScalarOperatorsReuse.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/ScalarOperatorsReuse.java
@@ -20,6 +20,7 @@ import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
 import com.starrocks.catalog.FunctionSet;
+import com.starrocks.qe.ConnectContext;
 import com.starrocks.sql.optimizer.base.ColumnRefFactory;
 import com.starrocks.sql.optimizer.operator.OperatorType;
 import com.starrocks.sql.optimizer.operator.Projection;
@@ -333,7 +334,8 @@ public class ScalarOperatorsReuse {
 
         @Override
         public Integer visit(ScalarOperator scalarOperator, Void context) {
-            if (scalarOperator.isConstant() || scalarOperator.getChildren().isEmpty()) {
+            if ((ConnectContext.get().getSessionVariable().isCboPruneSubfield() && scalarOperator.isConstant())
+                    || scalarOperator.getChildren().isEmpty()) {
                 return 0;
             }
 
@@ -356,7 +358,8 @@ public class ScalarOperatorsReuse {
                 // for example:
                 // select (rnd + 1) as rnd1, (rnd + 2) as rnd2 from (select rand() as rnd) sub
                 return collectCommonOperatorsByDepth(1, scalarOperator);
-            } else if (scalarOperator.isConstant() || scalarOperator.getChildren().isEmpty()) {
+            } else if ((ConnectContext.get().getSessionVariable().isCboPruneSubfield() && scalarOperator.isConstant())
+                    || scalarOperator.getChildren().isEmpty()) {
                 // to keep the same logic as origin
                 return 0;
             } else {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/ScalarOperatorsReuse.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/ScalarOperatorsReuse.java
@@ -20,6 +20,7 @@ import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
 import com.starrocks.catalog.FunctionSet;
+import com.starrocks.qe.ConnectContext;
 import com.starrocks.sql.optimizer.base.ColumnRefFactory;
 import com.starrocks.sql.optimizer.operator.OperatorType;
 import com.starrocks.sql.optimizer.operator.Projection;
@@ -333,7 +334,8 @@ public class ScalarOperatorsReuse {
 
         @Override
         public Integer visit(ScalarOperator scalarOperator, Void context) {
-            if (scalarOperator.isConstant() || scalarOperator.getChildren().isEmpty()) {
+            if ((ConnectContext.get().getSessionVariable().isEnableOuterJoinReorder() && scalarOperator.isConstant())
+                    || scalarOperator.getChildren().isEmpty()) {
                 return 0;
             }
 
@@ -356,7 +358,8 @@ public class ScalarOperatorsReuse {
                 // for example:
                 // select (rnd + 1) as rnd1, (rnd + 2) as rnd2 from (select rand() as rnd) sub
                 return collectCommonOperatorsByDepth(1, scalarOperator);
-            } else if (scalarOperator.isConstant() || scalarOperator.getChildren().isEmpty()) {
+            } else if ((ConnectContext.get().getSessionVariable().isEnableOuterJoinReorder() && scalarOperator.isConstant())
+                    || scalarOperator.getChildren().isEmpty()) {
                 // to keep the same logic as origin
                 return 0;
             } else {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/ScalarOperatorsReuse.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/ScalarOperatorsReuse.java
@@ -20,7 +20,6 @@ import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
 import com.starrocks.catalog.FunctionSet;
-import com.starrocks.qe.ConnectContext;
 import com.starrocks.sql.optimizer.base.ColumnRefFactory;
 import com.starrocks.sql.optimizer.operator.OperatorType;
 import com.starrocks.sql.optimizer.operator.Projection;
@@ -334,8 +333,7 @@ public class ScalarOperatorsReuse {
 
         @Override
         public Integer visit(ScalarOperator scalarOperator, Void context) {
-            if ((ConnectContext.get().getSessionVariable().isEnableOuterJoinReorder() && scalarOperator.isConstant())
-                    || scalarOperator.getChildren().isEmpty()) {
+            if (scalarOperator.isConstant() || scalarOperator.getChildren().isEmpty()) {
                 return 0;
             }
 
@@ -358,8 +356,7 @@ public class ScalarOperatorsReuse {
                 // for example:
                 // select (rnd + 1) as rnd1, (rnd + 2) as rnd2 from (select rand() as rnd) sub
                 return collectCommonOperatorsByDepth(1, scalarOperator);
-            } else if ((ConnectContext.get().getSessionVariable().isEnableOuterJoinReorder() && scalarOperator.isConstant())
-                    || scalarOperator.getChildren().isEmpty()) {
+            } else if (scalarOperator.isConstant() || scalarOperator.getChildren().isEmpty()) {
                 // to keep the same logic as origin
                 return 0;
             } else {

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/SelectStmtTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/SelectStmtTest.java
@@ -628,13 +628,10 @@ public class SelectStmtTest {
             String sql = "select str_to_map('age=18&sex=1&gender=1','&','=')['age'] AS age, " +
                     "str_to_map('age=18&sex=1&gender=1','&','=')['sex'] AS sex;";
             String plan = UtFrameUtils.getVerboseFragmentPlan(starRocksAssert.getCtx(), sql);
-            Assert.assertTrue(plan, plan.contains("2 <-> 4: str_to_map['age']\n" +
-                    "  |  3 <-> 4: str_to_map['sex']\n" +
-                    "  |  common expressions:\n" +
-                    "  |  4 <-> str_to_map[('age=18&sex=1&gender=1', '&', '='); " +
-                    "args: VARCHAR,VARCHAR,VARCHAR; " +
-                    "result: MAP<VARCHAR,VARCHAR>; args " +
-                    "nullable: false; result nullable: true]"));
+            Assert.assertTrue(plan, plan.contains("1:Project\n" +
+                    "  |  output columns:\n" +
+                    "  |  2 <-> str_to_map('age=18&sex=1&gender=1', '&', '=')['age']\n" +
+                    "  |  3 <-> str_to_map('age=18&sex=1&gender=1', '&', '=')['sex']"));
         } catch (Exception e) {
             Assert.fail("Should not throw an exception");
         }

--- a/fe/fe-core/src/test/java/com/starrocks/connector/parser/trino/TrinoQueryTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/parser/trino/TrinoQueryTest.java
@@ -471,8 +471,9 @@ public class TrinoQueryTest extends TrinoTestBase {
         assertPlanContains(sql, "map_from_arrays([1,2,3], ['a','b','c'])");
 
         sql = "select map_filter(map(array[10, 20, 30], array['a', NULL, 'c']), (k, v) -> v IS NOT NULL);";
-        assertPlanContains(sql, "map_filter(7: map_from_arrays, map_values(map_apply((<slot 2>, <slot 3>) -> " +
-                "map{<slot 2>:<slot 3> IS NOT NULL}, 7: map_from_arrays)))");
+        assertPlanContains(sql, "map_filter(map_from_arrays([10,20,30], ['a',NULL,'c']), " +
+                "map_values(map_apply((<slot 2>, <slot 3>) -> map{<slot 2>:<slot 3> IS NOT NULL}, " +
+                "map_from_arrays([10,20,30], ['a',NULL,'c']))))");
 
         sql = "select transform_keys(MAP(ARRAY [1, 2, 3], ARRAY ['a', 'b', 'c']), (k, v) -> k + 1);";
         assertPlanContains(sql, "map_apply((<slot 2>, <slot 3>) -> map{CAST(<slot 2> AS SMALLINT) + 1:<slot 3>}, " +
@@ -774,9 +775,8 @@ public class TrinoQueryTest extends TrinoTestBase {
         assertPlanContains(sql, "regexp('abc123', 'abc*')");
 
         sql = "select regexp_extract('1a 2b 14m', '\\d+');";
-        assertPlanContains(sql, "if(3: regexp_extract = '', NULL, 3: regexp_extract)\n" +
-                "  |  common expressions:\n" +
-                "  |  <slot 3> : regexp_extract('1a 2b 14m', '\\\\d+', 0)");
+        assertPlanContains(sql, "if(regexp_extract('1a 2b 14m', '\\\\d+', 0) = '', NULL, " +
+                "regexp_extract('1a 2b 14m', '\\\\d+', 0))");
 
         sql = "select regexp_extract('1abb 2b 14m', '[a-z]+');";
         assertPlanContains(sql, "if(3: regexp_extract = '', NULL, 3: regexp_extract)\n" +
@@ -1068,7 +1068,8 @@ public class TrinoQueryTest extends TrinoTestBase {
                 "      cast('2023-01-01' AS date)\n" +
                 "    )\n" +
                 "  );";
-        assertPlanContains(sql, "-1 * CAST(if(3: dayofweek_iso = 7, 0, 3: dayofweek_iso) AS BIGINT)");
+        assertPlanContains(sql, "-1 * CAST(if(dayofweek_iso('2023-01-01 00:00:00') = 7, 0, " +
+                "dayofweek_iso('2023-01-01 00:00:00')) AS BIGINT)");
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/connector/parser/trino/TrinoQueryTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/parser/trino/TrinoQueryTest.java
@@ -779,14 +779,12 @@ public class TrinoQueryTest extends TrinoTestBase {
                 "regexp_extract('1a 2b 14m', '\\\\d+', 0))");
 
         sql = "select regexp_extract('1abb 2b 14m', '[a-z]+');";
-        assertPlanContains(sql, "if(3: regexp_extract = '', NULL, 3: regexp_extract)\n" +
-                "  |  common expressions:\n" +
-                "  |  <slot 3> : regexp_extract('1abb 2b 14m', '[a-z]+', 0)");
+        assertPlanContains(sql, "if(regexp_extract('1abb 2b 14m', '[a-z]+', 0) = '', NULL, " +
+                "regexp_extract('1abb 2b 14m', '[a-z]+', 0))");
 
         sql = "select regexp_extract('1abb 2b 14m', '[a-z]+', 1);";
-        assertPlanContains(sql, "if(3: regexp_extract = '', NULL, 3: regexp_extract)\n" +
-                "  |  common expressions:\n" +
-                "  |  <slot 3> : regexp_extract('1abb 2b 14m', '[a-z]+', 1)");
+        assertPlanContains(sql, "<slot 2> : if(regexp_extract('1abb 2b 14m', '[a-z]+', 1) = '', NULL, " +
+                "regexp_extract('1abb 2b 14m', '[a-z]+', 1))");
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/ExpressionTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/ExpressionTest.java
@@ -420,17 +420,18 @@ public class ExpressionTest extends PlanTestBase {
     @Test
     public void testCaseWhenOperatorReuse() throws Exception {
         String sql =
-                "select max(case when STRLEFT(DATE_FORMAT('2020-09-02 23:59:59', '%Y-%m'), 6) > 0 then v1 else v2 end),"
+                "select max(case when STRLEFT(DATE_FORMAT(v1, '%Y-%m'), 6) > 0 then v1 else v2 end),"
                         +
-                        "min(case when STRLEFT(DATE_FORMAT('2020-09-02 23:59:59', '%Y-%m'), 6) > 0 then v2 else v1 end),"
+                        "min(case when STRLEFT(DATE_FORMAT(v1, '%Y-%m'), 6) > 0 then v2 else v1 end),"
                         +
-                        "count(case when STRLEFT(DATE_FORMAT('2020-09-02 23:59:59', '%Y-%m'), 6) > 0 then v3 else v2 "
+                        "count(case when STRLEFT(DATE_FORMAT(v1, '%Y-%m'), 6) > 0 then v3 else v2 "
                         + "end) from t0";
         String planFragment = getFragmentPlan(sql);
-        assertContains(planFragment, "  2:AGGREGATE (update finalize)\n" +
-                "  |  output: max(if(12: expr, 1: v1, 2: v2)), min(if(12: expr, 2: v2, 1: v1)), " +
-                "count(if(12: expr, 3: v3, 2: v2))");
-        Assert.assertTrue(planFragment.contains("<slot 10> : strleft('2020-09', 6)"));
+        assertContains(planFragment, "2:AGGREGATE (update finalize)\n" +
+                "  |  output: max(if(14: expr, 1: v1, 2: v2)), min(if(14: expr, 2: v2, 1: v1)), " +
+                "count(if(14: expr, 3: v3, 2: v2))");
+        Assert.assertTrue(planFragment.contains("common expressions:\n" +
+                "  |  <slot 10> : CAST(1: v1 AS DATETIME)"));
     }
 
     @Test
@@ -603,7 +604,7 @@ public class ExpressionTest extends PlanTestBase {
         sql = "select arr,array_length(arr) from (select array_map(x->x+1, [1,2]) as arr)T";
         plan = getFragmentPlan(sql);
         Assert.assertTrue(plan.contains("common expressions"));
-        Assert.assertTrue(plan.contains("array_length(6: array_map)"));
+        Assert.assertTrue(plan.contains("array_length(5: array_map)"));
 
         sql = "select array_map(x->x+ 3 *c1 + 3*c1, c2) from test_array";
         plan = getFragmentPlan(sql);
@@ -782,16 +783,8 @@ public class ExpressionTest extends PlanTestBase {
                         "c5 IN ('292278994-08-17', '1970-02-01') AND " +
                         "c5 IN ('292278994-08-17', '1970-02-01')  " +
                         " FROM test_in_pred_norm",
-                "<slot 7> : ((5: c4 = '1970-02-01') OR (5: c4 = 8: cast)) AND ((6: c5 = '1970-02-01') OR (6: c5 = 8: cast))");
-
-        String plan = getFragmentPlan("SELECT " +
-                "c4 IN ('292278994-08-17', '1970-02-01') AND c4 IN ('292278994-08-18', '1970-02-01') AND " +
-                "c5 IN ('292278994-08-17', '1970-02-01') AND c5 IN ('292278994-08-18', '1970-02-01') AND " +
-                "c5 IN ('292278994-08-17', '1970-02-01') AND c5 IN ('292278994-08-17', '1970-02-01')  " +
-                " FROM test_in_pred_norm");
-        Assert.assertTrue("plan is " + plan, plan.contains("common expressions:"));
-        Assert.assertTrue("plan is \n" + plan, plan.contains("<slot 8> "));
-        Assert.assertTrue("plan is \n" + plan, plan.contains("<slot 9> "));
+                "<slot 7> : (5: c4 IN (CAST('292278994-08-17' AS DATE), '1970-02-01')) AND " +
+                        "(6: c5 IN (CAST('292278994-08-17' AS DATE), '1970-02-01'))");
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/JsonTypeTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/JsonTypeTest.java
@@ -195,7 +195,7 @@ public class JsonTypeTest extends PlanTestBase {
     public void testCastJsonArray() throws Exception {
         assertPlanContains("select json_array(parse_json('1'), parse_json('2'))",
                 "json_array(parse_json('1'), parse_json('2'))");
-        assertPlanContains("select json_array(1, 1)", "json_array(3: cast, 3: cast)");
+        assertPlanContains("select json_array(1, 1)", "json_array(CAST(1 AS JSON), CAST(1 AS JSON))");
         assertPlanContains("select json_array(1, '1')", "json_array(CAST(1 AS JSON), CAST('1' AS JSON))");
         assertPlanContains("select json_array(1.1)", "json_array(CAST(1.1 AS JSON))");
         assertPlanContains("select json_array(NULL)", "NULL");

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/JsonTypeTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/JsonTypeTest.java
@@ -101,7 +101,7 @@ public class JsonTypeTest extends PlanTestBase {
     @Test
     public void testPredicateImplicitCast() throws Exception {
         assertPlanContains("select parse_json('1') between 0.5 and 0.9",
-                "CAST(3: parse_json AS DOUBLE)");
+                "CAST(parse_json('1') AS DOUBLE)");
 
         List<String> operators = Arrays.asList("<", "<=", "=", ">=", "!=");
         for (String operator : operators) {
@@ -116,7 +116,8 @@ public class JsonTypeTest extends PlanTestBase {
         }
 
         assertPlanContains("select parse_json('1') in (1, 2, 3)", "IN");
-        assertPlanContains("select parse_json('1') in (parse_json('1'), parse_json('2'))", "OR");
+        assertPlanContains("select parse_json('1') in (parse_json('1'), parse_json('2'))",
+                "parse_json('1') IN (parse_json('1'), parse_json('2'))");
     }
 
     /**

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/LowCardinalityTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/LowCardinalityTest.java
@@ -841,34 +841,20 @@ public class LowCardinalityTest extends PlanTestBase {
         sql = "select if(S_ADDRESS='kks', S_COMMENT, S_COMMENT) from supplier";
         plan = getVerboseExplain(sql);
         Assert.assertTrue(plan.contains(
-                "  |  9 <-> if[(DictDecode(10: S_ADDRESS, [<place-holder> = 'kks']), [12: expr, VARCHAR(101), true], " +
-                        "[12: expr, VARCHAR(101), true]); args: BOOLEAN,VARCHAR,VARCHAR; result: VARCHAR; " +
-                        "args nullable: true; result nullable: true]\n" +
-                        "  |  common expressions:\n" +
-                        "  |  12 <-> DictDecode(11: S_COMMENT, [<place-holder>])"));
+                "9 <-> if[(DictDecode(10: S_ADDRESS, [<place-holder> = 'kks']), DictDecode(11: S_COMMENT, [<place-holder>]), " +
+                        "DictDecode(11: S_COMMENT, [<place-holder>])); args: BOOLEAN,VARCHAR,VARCHAR; " +
+                        "result: VARCHAR; args nullable: true; result nullable: true]"));
         assertNotContains(plan, "DecodeNode");
 
         // common expression reuse 3
-        sql =
-                "select if(S_ADDRESS='kks', upper(S_COMMENT), S_COMMENT), concat(upper(S_COMMENT), S_ADDRESS) from supplier";
+        sql = "select if(S_ADDRESS='kks', upper(S_COMMENT), S_COMMENT), concat(upper(S_COMMENT), S_ADDRESS) from supplier";
         plan = getVerboseExplain(sql);
-        Assert.assertTrue(plan.contains("  |  output columns:\n" +
-                "  |  9 <-> if[(DictDecode(11: S_ADDRESS, [<place-holder> = 'kks']), [13: expr, VARCHAR, true], " +
-                "DictDecode(12: S_COMMENT, [<place-holder>])); args: BOOLEAN,VARCHAR,VARCHAR; result: VARCHAR; " +
-                "args nullable: true; result nullable: true]\n" +
-                "  |  10 <-> concat[([13: expr, VARCHAR, true], DictDecode(11: S_ADDRESS, [<place-holder>])); " +
-                "args: VARCHAR; result: VARCHAR; args nullable: true; result nullable: true]"));
-        Assert.assertTrue(plan.contains("  |  common expressions:\n" +
-                "  |  13 <-> DictDecode(12: S_COMMENT, [upper(<place-holder>)])"));
+        Assert.assertTrue(plan.contains("9 <-> if[(DictDecode(11: S_ADDRESS, [<place-holder> = 'kks'])"));
 
         // support(support(unsupport(Column), unsupport(Column)))
         sql = "select REVERSE(SUBSTR(LEFT(REVERSE(S_ADDRESS),INSTR(REVERSE(S_ADDRESS),'/')-1),5)) FROM supplier";
         plan = getFragmentPlan(sql);
-        assertContains(plan, "  1:Project\n" +
-                "  |  <slot 9> : reverse(substr(left(11: expr, CAST(CAST(instr(11: expr, '/') AS BIGINT)" +
-                " - 1 AS INT)), 5))\n" +
-                "  |  common expressions:\n" +
-                "  |  <slot 11> : DictDecode(10: S_ADDRESS, [reverse(<place-holder>)])");
+        assertContains(plan, "<slot 9> : reverse(substr(left(DictDecode(10: S_ADDRESS, [reverse(<place-holder>)])");
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/LowCardinalityTest2.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/LowCardinalityTest2.java
@@ -875,23 +875,12 @@ public class LowCardinalityTest2 extends PlanTestBase {
         sql =
                 "select if(S_ADDRESS='kks', upper(S_COMMENT), S_COMMENT), concat(upper(S_COMMENT), S_ADDRESS) from supplier";
         plan = getVerboseExplain(sql);
-        Assert.assertTrue(plan, plan.contains("  |  output columns:\n" +
-                "  |  9 <-> if[(DictDecode(11: S_ADDRESS, [<place-holder> = 'kks']), [13: expr, VARCHAR, true], " +
-                "DictDecode(12: S_COMMENT, [<place-holder>])); args: BOOLEAN,VARCHAR,VARCHAR; result: VARCHAR; " +
-                "args nullable: true; result nullable: true]\n" +
-                "  |  10 <-> concat[([13: expr, VARCHAR, true], DictDecode(11: S_ADDRESS, [<place-holder>])); " +
-                "args: VARCHAR; result: VARCHAR; args nullable: true; result nullable: true]"));
-        Assert.assertTrue(plan, plan.contains("  |  common expressions:\n" +
-                "  |  13 <-> DictDecode(12: S_COMMENT, [upper(<place-holder>)])"));
+        Assert.assertTrue(plan, plan.contains("9 <-> if[(DictDecode(11: S_ADDRESS, [<place-holder> = 'kks'])"));
 
         // support(support(unsupport(Column), unsupport(Column)))
         sql = "select REVERSE(SUBSTR(LEFT(REVERSE(S_ADDRESS),INSTR(REVERSE(S_ADDRESS),'/')-1),5)) FROM supplier";
         plan = getFragmentPlan(sql);
-        assertContains(plan, "  1:Project\n" +
-                "  |  <slot 9> : reverse(substr(left(11: expr, CAST(CAST(instr(11: expr, '/') AS BIGINT)" +
-                " - 1 AS INT)), 5))\n" +
-                "  |  common expressions:\n" +
-                "  |  <slot 11> : DictDecode(10: S_ADDRESS, [reverse(<place-holder>)])");
+        assertContains(plan, "<slot 9> : reverse(substr(left(DictDecode(10: S_ADDRESS, [reverse(<place-holder>)])");
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/ScanTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/ScanTest.java
@@ -336,11 +336,11 @@ public class ScanTest extends PlanTestBase {
     @Test
     public void testScalarReuseIsNull() throws Exception {
         String plan =
-                getFragmentPlan("SELECT (abs(1) IS NULL) = true AND ((abs(1) IS NULL) IS NOT NULL) as count FROM t1;");
+                getFragmentPlan("SELECT (abs(v4) IS NULL) = true AND ((abs(v4) IS NULL) IS NOT NULL) as count FROM t1;");
         Assert.assertTrue(plan, plan.contains("1:Project\n" +
                 "  |  <slot 4> : (6: expr) AND (6: expr IS NOT NULL)\n" +
                 "  |  common expressions:\n" +
-                "  |  <slot 5> : abs(1)\n" +
+                "  |  <slot 5> : abs(1: v4)\n" +
                 "  |  <slot 6> : 5: abs IS NULL"));
     }
 

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/StructTypePlanTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/StructTypePlanTest.java
@@ -202,7 +202,7 @@ public class StructTypePlanTest extends PlanTestBase {
         sql = "select array_filter((x,y) -> x<y, c3.d, c3.d) from test";
         assertVerbosePlanContains(sql, "[/c3/d]");
         sql = "select map_values(col_map), map_keys(col_map) from (select map_from_arrays([],[]) as col_map)A";
-        assertPlanContains(sql, "map_from_arrays(5: cast, 5: cast)");
+        assertPlanContains(sql, "<slot 4> : map_keys(map_from_arrays(CAST([] AS ARRAY<BOOLEAN>), CAST([] AS ARRAY<BOOLEAN>)))");
     }
 
     @Test

--- a/test/sql/test_semi/R/test_in_predict
+++ b/test/sql/test_semi/R/test_in_predict
@@ -395,9 +395,9 @@ select [] in (array1), [] not in (array1), [null] in (array1), [null] not in (ar
 -- result:
 None	None	None	None	None	None	None	None	None	None	None	None
 0	1	0	1	0	1	None	1	0	1	None	1
+0	1	0	1	0	1	None	1	0	1	None	1
+0	1	0	1	0	1	None	1	0	1	None	1
 0	1	0	1	1	0	0	1	0	1	None	1
-0	1	0	1	0	1	None	1	0	1	None	1
-0	1	0	1	0	1	None	1	0	1	None	1
 0	1	0	1	0	1	None	0	0	1	None	1
 0	1	0	1	0	1	None	1	0	1	None	1
 0	1	0	1	0	1	None	1	1	0	0	1
@@ -413,12 +413,12 @@ None	None	None
 None	None	None
 0	None	0
 0	None	1
-0	None	None
-0	None	0
+0	None	1
 0	None	0
 0	None	1
-0	None	1
 0	None	None
+0	None	None
+0	None	0
 0	None	None
 1	0	0
 1	None	1
@@ -433,26 +433,26 @@ None	None	None
 1	None	1
 1	None	0
 1	None	None
+1	None	0
+1	None	0
 1	None	1
-1	None	0
-1	None	0
 1	None	None
 1	None	None
 -- !result
-select array3 in ([]), array3 not in ([]), array3 in ([null]), array3 not in ([null]), array3 in ([row(1, 2)], [null]), array3 not in ([row(1, 2)], [null]) from sc2 order by 1;
+select array3 in ([]), array3 not in ([]), array3 in ([null]), array3 not in ([null]), array3 in ([row(1, 2)], [null]), array3 not in ([row(1, 2)], [null]) from sc2 order by 1,2,3,4,5,6;
 -- result:
 None	None	None	None	None	None
+0	1	None	0	None	None
+0	1	None	1	None	None
+0	1	None	1	None	None
 0	1	None	1	1	0
 0	1	None	1	1	0
-0	1	None	1	None	1
+0	1	None	1	1	0
+0	1	None	1	1	0
+0	1	None	1	1	0
+0	1	None	1	1	0
+0	1	None	1	1	0
 0	1	0	1	0	1
-0	1	None	1	1	0
-0	1	None	1	1	0
-0	1	None	1	1	0
-0	1	None	1	1	0
-0	1	None	0	None	0
-0	1	None	1	None	1
-0	1	None	1	1	0
 1	0	0	1	0	1
 -- !result
 select array1 in (null), array1 not in (null), array2 in (null), array2 not in (null), array3 in (null), array3 not in (null) from sc2 order by 1;
@@ -550,8 +550,8 @@ None	None	None	None	None	None
 0	1	0	1	0	1
 0	1	0	1	0	1
 0	1	0	1	0	1
-0	1	0	1	0	1
 0	1	0	1	1	0
+0	1	0	1	0	1
 0	1	0	1	0	1
 0	1	0	1	0	1
 0	1	0	1	0	1
@@ -611,12 +611,12 @@ select map1 in (map{1:10, 2:20, 4:40}, map{}), map2 in (map{2:[2,3,4], 1:[1,2,3]
 -- result:
 None	None	None
 None	1	1
-0	0	0
 0	0	1
 0	None	1
-0	0	0
 0	1	0
+0	0	0
 0	0	1
+0	0	0
 0	None	0
 1	0	None
 1	0	1
@@ -630,11 +630,11 @@ None	None
 None	None
 None	None
 None	None
+None	None
+None	None
+None	None
 None	1
 None	1
-None	None
-None	None
-None	None
 None	1
 0	1
 0	None

--- a/test/sql/test_semi/T/test_in_predict
+++ b/test/sql/test_semi/T/test_in_predict
@@ -65,7 +65,7 @@ select [] in (array1), [] not in (array1), [null] in (array1), [null] not in (ar
 select array2 in ([],[map{}]),  array2 in ([null],[map{1:3}]), array2 in ([map{1:10, 3:30, 2:20}], [map{}])  from sc2 order by 1;
 select array2 not in ([],[map{}]),  array2 not in ([null],[map{1:3}]), array2 not in ([map{1:10, 3:30, 2:20}], [map{3:3}])  from sc2 order by 1;
 
-select array3 in ([]), array3 not in ([]), array3 in ([null]), array3 not in ([null]), array3 in ([row(1, 2)], [null]), array3 not in ([row(1, 2)], [null]) from sc2 order by 1;
+select array3 in ([]), array3 not in ([]), array3 in ([null]), array3 not in ([null]), array3 in ([row(1, 2)], [null]), array3 not in ([row(1, 2)], [null]) from sc2 order by 1,2,3,4,5,6;
 select array1 in (null), array1 not in (null), array2 in (null), array2 not in (null), array3 in (null), array3 not in (null) from sc2 order by 1;
 select null in (array1), null not in (array1), null in (array2), null not in (array2), null in (array3), null not in (array3) from sc2 order by 1;
 


### PR DESCRIPTION
## Why I'm doing:
Common scalarOperator reuse rule would extract common scalarOpertator with all constant children and add it into the common projection. This may prevent BE recongnizing it as the contant column which may lead duplicate expr calculation.

## What I'm doing:
skip reuse scalarOperator with all constant children.
BTW, some of our expression calculations are not optimized for constant columns. This modification can lead to a performance degradation in the calculation of expression cases without constant column optimization. We will optimize the corresponding code of BE in the future.

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [x] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
