### PR TITLE
[BugFix] fix struct use unused-subfield iterater

### DIFF
--- a/be/src/storage/rowset/struct_column_iterator.cpp
+++ b/be/src/storage/rowset/struct_column_iterator.cpp
@@ -43,9 +43,9 @@ public:
 
     [[nodiscard]] Status seek_to_ordinal(ordinal_t ord) override;
 
-    ordinal_t get_current_ordinal() const override { return _field_iters[0]->get_current_ordinal(); }
+    ordinal_t get_current_ordinal() const override { return _access_iters[0]->get_current_ordinal(); }
 
-    ordinal_t num_rows() const override { return _field_iters[0]->num_rows(); }
+    ordinal_t num_rows() const override { return _access_iters[0]->num_rows(); }
 
     [[nodiscard]] Status fetch_values_by_rowid(const rowid_t* rowids, size_t size, Column* values) override;
 


### PR DESCRIPTION
## Why I'm doing:

`access_iter` is hit subfield iteraters
`field_iter` is all subfield iteraters

## What I'm doing:

Fixes https://github.com/StarRocks/StarRocksTest/issues/7083

Follow #43667

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
