### PR TITLE
[BugFix] Report exception when the java udf was error

### DIFF
--- a/test/sql/test_udf/R/test_jvm_udf
+++ b/test/sql/test_udf/R/test_jvm_udf
@@ -51,6 +51,16 @@ type = "StarrocksJar"
 file = "${udf_url}/starrocks-jdbc%2FUDTFdouble.jar";
 -- result:
 -- !result
+CREATE FUNCTION exception_test(string)
+RETURNS string
+PROPERTIES
+(
+"symbol" = "ExceptionUDF2", 
+"type" = "StarrocksJar", 
+"file" = "${udf_url}/starrocks-jdbc/ExceptionUDF2.jar"
+);
+-- result:
+-- !result
 CREATE TABLE `t0` (
   `c0` int(11) NULL COMMENT "",
   `c1` varchar(20) NULL COMMENT "",
@@ -138,4 +148,8 @@ set spill_mode="force";
 select sum(delta), count(*), count(delta) from (select (sum(c3) - sumbigint(c3)) as delta from t0 group by c0,c1) tb;
 -- result:
 0	40960	40960
+-- !result
+select count(*) from t0 where exception_test(c1) is null;
+-- result:
+[REGEX].*java.lang.NullPointerException.*
 -- !result

--- a/test/sql/test_udf/T/test_jvm_udf
+++ b/test/sql/test_udf/T/test_jvm_udf
@@ -44,6 +44,14 @@ symbol = "UDTFdouble"
 type = "StarrocksJar"
 file = "${udf_url}/starrocks-jdbc%2FUDTFdouble.jar";
 
+CREATE FUNCTION exception_test(string)
+RETURNS string
+PROPERTIES
+(
+"symbol" = "ExceptionUDF2", 
+"type" = "StarrocksJar", 
+"file" = "${udf_url}/starrocks-jdbc/ExceptionUDF2.jar"
+);
 
 CREATE TABLE `t0` (
   `c0` int(11) NULL COMMENT "",
@@ -85,3 +93,5 @@ set enable_spill=true;
 set spill_mode="force";
 
 select sum(delta), count(*), count(delta) from (select (sum(c3) - sumbigint(c3)) as delta from t0 group by c0,c1) tb;
+-- test udf exception case
+select count(*) from t0 where exception_test(c1) is null;


### PR DESCRIPTION
## Why I'm doing:

Current, when Java UDF throw exception, BE only printed the log and the query has not ended. If this UDF is on the conditions, the error result will be obtained. 

Similar to https://github.com/StarRocks/starrocks/pull/42590

## What I'm doing:

After the end of JNI, check whether there is an exception. If exception appears,  report it.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [x] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.4
  - [x] 3.3
  - [x] 3.2
  - [x] 3.1
  - [ ] 3.0
