### PR TITLE
[Feature] Add mv meta function to inspect mv plan cache for 3.3 (backport #43661)

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/common/DebugOperatorTracer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/common/DebugOperatorTracer.java
@@ -47,6 +47,7 @@ import com.starrocks.sql.optimizer.operator.logical.LogicalTableFunctionOperator
 import com.starrocks.sql.optimizer.operator.logical.LogicalTopNOperator;
 import com.starrocks.sql.optimizer.operator.logical.LogicalUnionOperator;
 import com.starrocks.sql.optimizer.operator.logical.LogicalValuesOperator;
+import com.starrocks.sql.optimizer.operator.logical.LogicalViewScanOperator;
 import com.starrocks.sql.optimizer.operator.logical.LogicalWindowOperator;
 import com.starrocks.sql.optimizer.operator.logical.MockOperator;
 import com.starrocks.sql.optimizer.operator.physical.PhysicalAssertOneRowOperator;
@@ -95,6 +96,14 @@ public class DebugOperatorTracer extends OperatorVisitor<String, Void> {
     public String visitLogicalTableScan(LogicalScanOperator node, Void context) {
         return "LogicalScanOperator" + " {" +
                 "table='" + node.getTable().getId() + '\'' +
+                ", outputColumns='" + new ArrayList<>(node.getColRefToColumnMetaMap().keySet()) + '\'' +
+                '}';
+    }
+
+    @Override
+    public String visitLogicalViewScan(LogicalViewScanOperator node, Void context) {
+        return "LogicalViewScanOperator" + " {" +
+                "table='" + node.getTable().getName() + '\'' +
                 ", outputColumns='" + new ArrayList<>(node.getColRefToColumnMetaMap().keySet()) + '\'' +
                 '}';
     }

--- a/test/sql/test_materialized_view/R/test_mv_meta_functions
+++ b/test/sql/test_materialized_view/R/test_mv_meta_functions
@@ -1,0 +1,44 @@
+-- name: test_mv_meta_functions
+create table user_tags (time date, user_id int, user_name varchar(20), tag_id int) partition by range (time)  (partition p1 values less than MAXVALUE) distributed by hash(time) buckets 3 properties('replication_num' = '1');
+-- result:
+-- !result
+insert into user_tags values('2023-04-13', 1, 'a', 1);
+-- result:
+-- !result
+insert into user_tags values('2023-04-13', 1, 'b', 2);
+-- result:
+-- !result
+insert into user_tags values('2023-04-13', 1, 'c', 3);
+-- result:
+-- !result
+insert into user_tags values('2023-04-13', 1, 'd', 4);
+-- result:
+-- !result
+insert into user_tags values('2023-04-13', 1, 'e', 5);
+-- result:
+-- !result
+insert into user_tags values('2023-04-13', 2, 'e', 5);
+-- result:
+-- !result
+insert into user_tags values('2023-04-13', 3, 'e', 6);
+-- result:
+-- !result
+create materialized view user_tags_mv1  distributed by hash(user_id) as select user_id, bitmap_union(to_bitmap(tag_id)) from user_tags group by user_id;
+-- result:
+-- !result
+refresh materialized view user_tags_mv1 with sync mode;
+select inspect_mv_plan('user_tags_mv1');
+-- result:
+[REGEX]plan 0.*
+
+-- !result
+select inspect_mv_plan('user_tags_mv1', true);
+-- result:
+[REGEX]plan 0.*
+
+-- !result
+select inspect_mv_plan('user_tags_mv1', false);
+-- result:
+[REGEX]plan 0:.* 
+
+-- !result

--- a/test/sql/test_materialized_view/T/test_mv_meta_functions
+++ b/test/sql/test_materialized_view/T/test_mv_meta_functions
@@ -1,0 +1,18 @@
+-- name: test_mv_meta_functions
+create table user_tags (time date, user_id int, user_name varchar(20), tag_id int) partition by range (time)  (partition p1 values less than MAXVALUE) distributed by hash(time) buckets 3 properties('replication_num' = '1');
+insert into user_tags values('2023-04-13', 1, 'a', 1);
+insert into user_tags values('2023-04-13', 1, 'b', 2);
+insert into user_tags values('2023-04-13', 1, 'c', 3);
+insert into user_tags values('2023-04-13', 1, 'd', 4);
+insert into user_tags values('2023-04-13', 1, 'e', 5);
+insert into user_tags values('2023-04-13', 2, 'e', 5);
+insert into user_tags values('2023-04-13', 3, 'e', 6);
+
+create materialized view user_tags_mv1  distributed by hash(user_id) as select user_id, bitmap_union(to_bitmap(tag_id)) from user_tags group by user_id;
+refresh materialized view user_tags_mv1 with sync mode;
+
+select inspect_mv_plan('user_tags_mv1');
+
+select inspect_mv_plan('user_tags_mv1', true);
+
+select inspect_mv_plan('user_tags_mv1', false);


### PR DESCRIPTION
## Why I'm doing:
Add mv meta function to inspect mv plan cache
## What I'm doing:

## What type of PR is this:

- [ ] BugFix
- [x] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [x] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5

