### PR TITLE
[BugFix] Add protect code to fix NL join chunk stream NPE

### DIFF
--- a/be/src/exec/pipeline/hashjoin/spillable_hash_join_probe_operator.cpp
+++ b/be/src/exec/pipeline/hashjoin/spillable_hash_join_probe_operator.cpp
@@ -56,6 +56,10 @@ void SpillableHashJoinProbeOperator::close(RuntimeState* state) {
 }
 
 bool SpillableHashJoinProbeOperator::has_output() const {
+    if (!is_ready()) {
+        DCHECK(false) << "is_ready() must be true before call has_output";
+        return false;
+    }
     if (!spilled()) {
         return HashJoinProbeOperator::has_output();
     }
@@ -117,6 +121,10 @@ bool SpillableHashJoinProbeOperator::has_output() const {
 }
 
 bool SpillableHashJoinProbeOperator::need_input() const {
+    if (!is_ready()) {
+        DCHECK(false) << "is_ready() must be true before call has_output";
+        return false;
+    }
     if (!spilled()) {
         return HashJoinProbeOperator::need_input();
     }

--- a/be/src/exec/pipeline/nljoin/spillable_nljoin_probe_operator.cpp
+++ b/be/src/exec/pipeline/nljoin/spillable_nljoin_probe_operator.cpp
@@ -152,11 +152,19 @@ bool SpillableNLJoinProbeOperator::is_finished() const {
 }
 
 bool SpillableNLJoinProbeOperator::has_output() const {
+    if (!is_ready()) {
+        DCHECK(false) << "is_ready() must be true before call has_output";
+        return false;
+    }
     RETURN_TRUE_IF_SPILL_TASK_ERROR(_spiller);
     return !_is_current_build_probe_finished() && _chunk_stream && _chunk_stream->has_output();
 }
 
 bool SpillableNLJoinProbeOperator::need_input() const {
+    if (!is_ready()) {
+        DCHECK(false) << "is_ready() must be true before call has_output";
+        return false;
+    }
     return _prober.probe_finished() && _is_current_build_probe_finished();
 }
 


### PR DESCRIPTION
## Why I'm doing:
Currently is_ready is ignored to be called in some cases.

## What I'm doing:
call is_ready before call need_input/has_output


Fixes
```
*** SIGSEGV (@0x18) received by PID 26 (TID 0x7f848c422640) from PID 24; stack trace: ***
@ 0x87fefba google::(anonymous namespace)::FailureSignalHandler()
@ 0x7f85801c0256 os::Linux::chained_handler()
@ 0x7f85801c5f4b JVM_handle_linux_signal
@ 0x7f85801b8a8c signalHandler()
@ 0x7f857f0e9520 (unknown)
@ 0x677d47f starrocks::pipeline::SpillableNLJoinChunkStream::reset()
@ 0x67839a3 starrocks::pipeline::SpillableNLJoinProbeOperator::push_chunk()
@ 0x6366a02 starrocks::pipeline::PipelineDriver::process()
@ 0x6c0b45e starrocks::pipeline::GlobalDriverExecutor::_worker_thread()
@ 0x6f9e33c starrocks::ThreadPool::dispatch_thread()
@ 0x6f9784a starrocks::thread::supervise_thread()
@ 0x7f857f13bac3 (unknown)
@ 0x7f857f1cd850 (unknown)
@ 0x0 (unknown)
```

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [x] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [x] 3.2
  - [x] 3.1
  - [x] 3.0
  - [ ] 2.5
