### PR TITLE
[Enhancement] Stricter limits on batch size for batch delete

### DIFF
--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -973,7 +973,7 @@ CONF_mInt64(lake_publish_version_slow_log_ms, "1000");
 CONF_mBool(lake_enable_publish_version_trace_log, "false");
 CONF_mString(lake_vacuum_retry_pattern, "*request rate*");
 CONF_mInt64(lake_vacuum_retry_max_attempts, "5");
-CONF_mInt64(lake_vacuum_retry_min_delay_ms, "10");
+CONF_mInt64(lake_vacuum_retry_min_delay_ms, "100");
 CONF_mInt64(lake_max_garbage_version_distance, "100");
 CONF_mBool(enable_primary_key_recover, "false");
 CONF_mBool(lake_enable_compaction_async_write, "false");
@@ -1252,7 +1252,7 @@ CONF_mBool(enable_drop_tablet_if_unfinished_txn, "true");
 // 0 means no limit
 CONF_Int32(lake_service_max_concurrency, "0");
 
-CONF_mInt64(lake_vacuum_min_batch_delete_size, "1000");
+CONF_mInt64(lake_vacuum_min_batch_delete_size, "100");
 
 // TOPN RuntimeFilter parameters
 CONF_mInt32(desc_hint_split_range, "10");

--- a/be/src/fs/fs.h
+++ b/be/src/fs/fs.h
@@ -11,6 +11,7 @@
 
 #include <memory>
 #include <optional>
+#include <span>
 #include <string>
 #include <string_view>
 
@@ -289,7 +290,7 @@ public:
     // Batch delete the given files.
     // return ok if all success (not found error ignored), error if any failed and the message indicates the fail message
     // possibly stop at the first error if is simulating batch deletes.
-    virtual Status delete_files(const std::vector<std::string>& paths) {
+    virtual Status delete_files(std::span<const std::string> paths) {
         for (auto&& path : paths) {
             auto st = delete_file(path);
             if (!st.ok() && !st.is_not_found()) {

--- a/be/src/fs/fs_s3.cpp
+++ b/be/src/fs/fs_s3.cpp
@@ -372,7 +372,7 @@ public:
 
     Status delete_file(const std::string& path) override;
 
-    Status delete_files(const std::vector<std::string>& paths) override;
+    Status delete_files(std::span<const std::string> paths) override;
 
     Status create_dir(const std::string& dirname) override;
 
@@ -742,7 +742,7 @@ Status S3FileSystem::delete_file(const std::string& path) {
     }
 }
 
-Status S3FileSystem::delete_files(const std::vector<std::string>& paths) {
+Status S3FileSystem::delete_files(std::span<const std::string> paths) {
     if (paths.empty()) {
         return Status::OK();
     }

--- a/be/src/fs/fs_starlet.cpp
+++ b/be/src/fs/fs_starlet.cpp
@@ -533,7 +533,7 @@ public:
         return to_status((*fs_st)->drop_cache(pair.first));
     }
 
-    Status delete_files(const std::vector<std::string>& paths) override {
+    Status delete_files(std::span<const std::string> paths) override {
         if (paths.empty()) {
             return Status::OK();
         }

--- a/be/src/storage/lake/vacuum.cpp
+++ b/be/src/storage/lake/vacuum.cpp
@@ -96,7 +96,7 @@ int64_t calculate_retry_delay(int64_t attempted_retries) {
     return min_delay * (1 << attempted_retries);
 }
 
-Status delete_files_with_retry(FileSystem* fs, const std::vector<std::string>& paths) {
+Status delete_files_with_retry(FileSystem* fs, std::span<const std::string> paths) {
     for (int64_t attempted_retries = 0; /**/; attempted_retries++) {
         auto st = fs->delete_files(paths);
         if (!st.ok() && should_retry(st, attempted_retries)) {
@@ -115,29 +115,40 @@ Status do_delete_files(FileSystem* fs, const std::vector<std::string>& paths) {
         return Status::OK();
     }
 
-    auto wait_duration = config::experimental_lake_wait_per_delete_ms;
-    if (wait_duration > 0) {
-        std::this_thread::sleep_for(std::chrono::milliseconds(wait_duration));
-    }
-
-    if (config::lake_print_delete_log) {
-        for (size_t i = 0, n = paths.size(); i < n; i++) {
-            LOG(INFO) << "Deleting " << paths[i] << "(" << (i + 1) << '/' << n << ')';
+    auto delete_single_batch = [fs](std::span<const std::string> batch) -> Status {
+        auto wait_duration = config::experimental_lake_wait_per_delete_ms;
+        if (wait_duration > 0) {
+            std::this_thread::sleep_for(std::chrono::milliseconds(wait_duration));
         }
-    }
 
-    auto t0 = butil::gettimeofday_us();
-    auto st = delete_files_with_retry(fs, paths);
-    if (st.ok()) {
-        auto t1 = butil::gettimeofday_us();
-        g_del_file_latency << (t1 - t0);
-        g_deleted_files << paths.size();
-        VLOG(5) << "Deleted " << paths.size() << " files cost " << (t1 - t0) << "us";
-    } else {
-        g_del_fails << 1;
-        LOG(WARNING) << "Fail to delete: " << st;
+        if (config::lake_print_delete_log) {
+            for (size_t i = 0, n = batch.size(); i < n; i++) {
+                LOG(INFO) << "Deleting " << batch[i] << "(" << (i + 1) << '/' << n << ')';
+            }
+        }
+
+        auto t0 = butil::gettimeofday_us();
+        auto st = delete_files_with_retry(fs, batch);
+        if (st.ok()) {
+            auto t1 = butil::gettimeofday_us();
+            g_del_file_latency << (t1 - t0);
+            g_deleted_files << batch.size();
+            VLOG(5) << "Deleted " << batch.size() << " files cost " << (t1 - t0) << "us";
+        } else {
+            g_del_fails << 1;
+            LOG(WARNING) << "Fail to delete: " << st;
+        }
+        return st;
+    };
+
+    auto batch_size = int64_t{config::lake_vacuum_min_batch_delete_size};
+    auto batch_count = static_cast<int64_t>((paths.size() + batch_size - 1) / batch_size);
+    for (auto i = int64_t{0}; i < batch_count; i++) {
+        auto begin = paths.begin() + (i * batch_size);
+        auto end = std::min(begin + batch_size, paths.end());
+        RETURN_IF_ERROR(delete_single_batch(std::span<const std::string>(begin, end)));
     }
-    return st;
+    return Status::OK();
 }
 
 // AsyncFileDeleter

--- a/docs/en/administration/management/BE_configuration.md
+++ b/docs/en/administration/management/BE_configuration.md
@@ -3580,7 +3580,7 @@ curl http://<BE_IP>:<BE_HTTP_PORT>/varz
 <!--
 ##### lake_vacuum_retry_min_delay_ms
 
-- Default: 10
+- Default: 100
 - Type: Int
 - Unit: Milliseconds
 - Is mutable: Yes
@@ -4398,7 +4398,7 @@ curl http://<BE_IP>:<BE_HTTP_PORT>/varz
 <!--
 ##### lake_vacuum_min_batch_delete_size
 
-- Default: 1000
+- Default: 100
 - Type: Int
 - Unit:
 - Is mutable: Yes

--- a/docs/zh/administration/management/BE_configuration.md
+++ b/docs/zh/administration/management/BE_configuration.md
@@ -3524,7 +3524,7 @@ curl http://<BE_IP>:<BE_HTTP_PORT>/varz
 <!--
 ##### lake_vacuum_retry_min_delay_ms
 
-- 默认值：10
+- 默认值：100
 - 类型：Int
 - 单位：Milliseconds
 - 是否动态：是
@@ -4342,7 +4342,7 @@ curl http://<BE_IP>:<BE_HTTP_PORT>/varz
 <!--
 ##### lake_vacuum_min_batch_delete_size
 
-- 默认值：1000
+- 默认值：100
 - 类型：Int
 - 单位：
 - 是否动态：是


### PR DESCRIPTION
## Why I'm doing:
Deleting many objects at once may trigger the QPS limit of the object storage service, so need to limit the number of deletions at once

## What I'm doing:
Ensure that the batch size of a batch delete does not exceed the configured value `lake_vacuum_min_batch_delete_size`.

This patch also changed the default value of
`lake_vacuum_min_batch_delete_size` from 10 to 100, and changed the default value of `lake_vacuum_min_batch_delete_size` from 1000 t0 100.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [x] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
