### PR TITLE
[BugFix] Fix the double free bug of str_to_map

### DIFF
--- a/be/src/exprs/str_to_map.cpp
+++ b/be/src/exprs/str_to_map.cpp
@@ -43,11 +43,11 @@ StatusOr<ColumnPtr> StringFunctions::str_to_map(FunctionContext* context, const 
 }
 
 Status StringFunctions::str_to_map_prepare(FunctionContext* context, FunctionContext::FunctionStateScope scope) {
-    return StringFunctions::split_prepare(context, FunctionContext::FRAGMENT_LOCAL);
+    return StringFunctions::split_prepare(context, scope);
 }
 
 Status StringFunctions::str_to_map_close(FunctionContext* context, FunctionContext::FunctionStateScope scope) {
-    return StringFunctions::split_close(context, FunctionContext::FRAGMENT_LOCAL);
+    return StringFunctions::split_close(context, scope);
 }
 
 /**


### PR DESCRIPTION
## Why I'm doing:

The bug was introduced by https://github.com/StarRocks/starrocks/pull/43901.

Close will call close_function both with THREAD_LOCAL and FRAGMENT_LOCAL, so the scope cannot be forced to be specified here.

```
void VectorizedFunctionCallExpr::close(starrocks::RuntimeState* state, starrocks::ExprContext* context,
                                       FunctionContext::FunctionStateScope scope) {
    // _fn_context_index > 0 means this function call has call opened
    if (_fn_desc != nullptr && _fn_desc->close_function != nullptr && _fn_context_index > 0) {
        FunctionContext* fn_ctx = context->fn_context(_fn_context_index);
        (void)_fn_desc->close_function(fn_ctx, FunctionContext::THREAD_LOCAL);

        if (scope == FunctionContext::FRAGMENT_LOCAL) {
            (void)_fn_desc->close_function(fn_ctx, FunctionContext::FRAGMENT_LOCAL);
        }
    }

    Expr::close(state, context, scope);
}
```

```
<jemalloc>: src/jemalloc.c:4086: Failed assertion: "force_ivsalloc || ret != 0"
PC: @     0x7f19960429fc pthread_kill
*** SIGABRT (@0x3f400066f50) received by PID 421712 (TID 0x7f185556e640) from PID 421712; stack trace: ***
    @          0x90c995a google::(anonymous namespace)::FailureSignalHandler()
    @     0x7f1995fee520 (unknown)
    @     0x7f19960429fc pthread_kill
    @     0x7f1995fee476 raise
    @     0x7f1995fd47f3 abort
    @          0x9c47846 jemalloc_usable_size
    @          0x7ca24ed free
    @          0x86df5bc starrocks::StringFunctions::split_close()
    @          0x86db437 starrocks::StringFunctions::str_to_map_close()
    @          0x6ffe8a3 starrocks::VectorizedFunctionCallExpr::close()
    @          0x4d8c319 starrocks::Expr::close()
    @          0x4d970f4 starrocks::ExprContext::close()
    @          0x4d8d190 starrocks::Expr::close()
    @          0x4ed0837 starrocks::Aggregator::close()
    @          0x5aca4a9 starrocks::pipeline::AggregateBlockingSourceOperator::close()
    @          0x4de72c7 starrocks::pipeline::PipelineDriver::_mark_operator_closed()
    @          0x4de76a1 starrocks::pipeline::PipelineDriver::_close_operators()
    @          0x4de7ba1 starrocks::pipeline::PipelineDriver::finalize()
    @          0x7abdbe0 starrocks::pipeline::GlobalDriverExecutor::_worker_thread()
    @          0x7e50d3c starrocks::ThreadPool::dispatch_thread()
    @          0x7e4a1ea starrocks::Thread::supervise_thread()
    @     0x7f1996040ac3 (unknown)
    @     0x7f19960d2850 (unknown)
    @                0x0 (unknown
```

## What I'm doing:

Pass scope to split_close instead of force specified.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [x] 3.2
  - [x] 3.1
  - [ ] 3.0
  - [ ] 2.5
