### PR TITLE
[Enhancement] Support hive partition filter and quantity limit

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
@@ -682,6 +682,10 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
 
     public static final String ENABLE_EXPR_PRUNE_PARTITION = "enable_expr_prune_partition";
 
+    public static final String ALLOW_HIVE_WITHOUT_PARTITION_FILTER = "allow_hive_without_partition_filter";
+
+    public static final String SCAN_HIVE_PARTITION_NUM_LIMIT = "scan_hive_partition_num_limit";
+
     public static final String AUDIT_EXECUTE_STMT = "audit_execute_stmt";
 
     public static final String CROSS_JOIN_COST_PENALTY = "cross_join_cost_penalty";
@@ -1825,6 +1829,13 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
 
     @VarAttr(name = ENABLE_EXPR_PRUNE_PARTITION, flag = VariableMgr.INVISIBLE)
     private boolean enableExprPrunePartition = true;
+
+    @VarAttr(name = ALLOW_HIVE_WITHOUT_PARTITION_FILTER)
+    private boolean allowHiveWithoutPartitionFilter = true;
+
+    // For the maximum number of partitions allowed to be scanned in a single hive table, 0 means no limit.
+    @VarAttr(name = SCAN_HIVE_PARTITION_NUM_LIMIT)
+    private int scanHivePartitionNumLimit = 0;
 
     @VariableMgr.VarAttr(name = AUDIT_EXECUTE_STMT)
     private boolean auditExecuteStmt = false;
@@ -3530,6 +3541,22 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
 
     public void setEnableExprPrunePartition(boolean enableExprPrunePartition) {
         this.enableExprPrunePartition = enableExprPrunePartition;
+    }
+
+    public boolean isAllowHiveWithoutPartitionFilter() {
+        return allowHiveWithoutPartitionFilter;
+    }
+
+    public void setAllowHiveWithoutPartitionFilter(boolean allowHiveWithoutPartitionFilter) {
+        this.allowHiveWithoutPartitionFilter = allowHiveWithoutPartitionFilter;
+    }
+
+    public int getScanHivePartitionNumLimit() {
+        return scanHivePartitionNumLimit;
+    }
+
+    public void setScanHivePartitionNumLimit(int scanHivePartitionNumLimit) {
+        this.scanHivePartitionNumLimit = scanHivePartitionNumLimit;
     }
 
     public boolean enableCboDeriveRangeJoinPredicate() {

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/HivePartitionPruneLimitTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/HivePartitionPruneLimitTest.java
@@ -1,0 +1,202 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.sql.plan;
+
+import com.starrocks.common.DdlException;
+import com.starrocks.planner.HdfsScanNode;
+import com.starrocks.planner.ScanNode;
+import com.starrocks.sql.common.StarRocksPlannerException;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.List;
+
+public class HivePartitionPruneLimitTest extends ConnectorPlanTestBase {
+    @Before
+    public void setUp() {
+        super.setUp();
+        try {
+            connectContext.changeCatalogDb("hive0.partitioned_db");
+            connectContext.getSessionVariable().setAllowHiveWithoutPartitionFilter(false);
+            connectContext.getSessionVariable().setScanHivePartitionNumLimit(10);
+        } catch (DdlException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Test
+    public void testHivePartitionPrune() throws Exception {
+        String sql = "select * from t1 where par_col = 0;";
+        String plan = getFragmentPlan(sql);
+        assertContains(plan, "0:HdfsScanNode\n" +
+                "     TABLE: t1\n" +
+                "     PARTITION PREDICATES: 4: par_col = 0\n" +
+                "     partitions=1/3");
+
+        sql = "select * from t1 where par_col = 1 and c1 = 2";
+        plan = getFragmentPlan(sql);
+        assertContains(plan, "0:HdfsScanNode\n" +
+                "     TABLE: t1\n" +
+                "     PARTITION PREDICATES: 4: par_col = 1\n" +
+                "     NON-PARTITION PREDICATES: 1: c1 = 2\n" +
+                "     MIN/MAX PREDICATES: 1: c1 <= 2, 1: c1 >= 2\n" +
+                "     partitions=1/3");
+
+        String sql1 = "select * from t1 where par_col = abs(-1) and c1 = 2";
+        Assert.assertThrows(StarRocksPlannerException.class, () -> getFragmentPlan(sql1));
+
+        sql = "select * from t1 where par_col = 1+1 and c1 = 2";
+        plan = getFragmentPlan(sql);
+        assertContains(plan, "0:HdfsScanNode\n" +
+                "     TABLE: t1\n" +
+                "     PARTITION PREDICATES: 4: par_col = 2\n" +
+                "     NON-PARTITION PREDICATES: 1: c1 = 2\n" +
+                "     MIN/MAX PREDICATES: 1: c1 <= 2, 1: c1 >= 2\n" +
+                "     partitions=1/3");
+    }
+
+    @Test
+    public void testCompoundPartitionPrune() throws Exception {
+        String sql = "select * from t1 where par_col = 0 and par_col = 5";
+        String plan = getFragmentPlan(sql);
+        assertContains(plan, "0:EMPTYSET");
+
+        sql = "select * from t1 where par_col = 0 and abs(par_col) = 3 or par_col = 5";
+        plan = getFragmentPlan(sql);
+        assertContains(plan, "PARTITION PREDICATES: ((4: par_col = 0) AND (abs(4: par_col) = 3)) " +
+                "OR (4: par_col = 5), 4: par_col IN (0, 5)\n" +
+                "     NO EVAL-PARTITION PREDICATES: ((4: par_col = 0) AND (abs(4: par_col) = 3)) " +
+                "OR (4: par_col = 5)\n" +
+                "     partitions=1/3");
+
+        sql = "select * from t1 where abs(par_col) = 3 and par_col = 0 or par_col = 2";
+        plan = getFragmentPlan(sql);
+        assertContains(plan, "PARTITION PREDICATES: ((abs(4: par_col) = 3) AND (4: par_col = 0)) " +
+                "OR (4: par_col = 2), 4: par_col IN (0, 2)\n" +
+                "     NO EVAL-PARTITION PREDICATES: ((abs(4: par_col) = 3) AND (4: par_col = 0)) " +
+                "OR (4: par_col = 2)\n" +
+                "     partitions=2/3");
+
+        sql = "select * from t1 where abs(par_col) = 3 and par_col = 10 or par_col = 2";
+        plan = getFragmentPlan(sql);
+        assertContains(plan, "PARTITION PREDICATES: ((abs(4: par_col) = 3) AND (4: par_col = 10)) " +
+                "OR (4: par_col = 2), 4: par_col IN (10, 2)\n" +
+                "     NO EVAL-PARTITION PREDICATES: ((abs(4: par_col) = 3) AND (4: par_col = 10)) " +
+                "OR (4: par_col = 2)\n" +
+                "     partitions=1/3");
+
+        String sql1 = "select * from t1 where abs(par_col) = 1 and abs(par_col) = 3 or par_col = 10";
+        plan = getFragmentPlan(sql);
+        Assert.assertThrows(StarRocksPlannerException.class, () -> getFragmentPlan(sql1));
+
+        sql = "select * from t1 where par_col = 1 or par_col = 2";
+        plan = getFragmentPlan(sql);
+        assertContains(plan, "PARTITION PREDICATES: 4: par_col IN (1, 2)\n" +
+                "     partitions=2/3");
+
+        String sql2 = "select * from t1 where par_col = 1 or abs(par_col) = 2";
+        Assert.assertThrows(StarRocksPlannerException.class, () -> getFragmentPlan(sql2));
+
+        String sql3 = "select * from t1 where par_col = 10 or abs(par_col) = 2";
+        Assert.assertThrows(StarRocksPlannerException.class, () -> getFragmentPlan(sql3));
+
+        String sql4 = "select * from t1 where abs(par_col) = 1 or abs(par_col) = 2;";
+        Assert.assertThrows(StarRocksPlannerException.class, () -> getFragmentPlan(sql4));
+
+        sql = "select * from t1 where par_col = 0 or (par_col = 1 and abs(par_col) = 2);";
+        plan = getFragmentPlan(sql);
+        assertContains(plan, "PARTITION PREDICATES: (4: par_col = 0) OR ((4: par_col = 1) " +
+                "AND (abs(4: par_col) = 2)), 4: par_col IN (0, 1)\n" +
+                "     NO EVAL-PARTITION PREDICATES: (4: par_col = 0) OR ((4: par_col = 1) " +
+                "AND (abs(4: par_col) = 2))\n" +
+                "     partitions=2/3");
+    }
+
+    @Test
+    public void testHivePartitionPredicatesPrune() throws Exception {
+        String sql = "select a.l_orderkey,\n" +
+                "    b.l_partkey\n" +
+                "from (\n" +
+                "        select l_orderkey,\n" +
+                "            l_partkey\n" +
+                "        from lineitem_mul_par2\n" +
+                "        where l_shipdate = '1998-01-01'\n" +
+                "            and l_returnflag = 'R'\n" +
+                "        limit 10\n" +
+                "    ) a\n" +
+                "    join (\n" +
+                "        select l_orderkey,\n" +
+                "            l_partkey\n" +
+                "        from lineitem_mul_par2\n" +
+                "        where l_shipdate = '1998-01-01'\n" +
+                "            and l_returnflag = 'A'\n" +
+                "        limit 10\n" +
+                "    ) b on a.l_orderkey = b.l_orderkey";
+        ExecPlan plan = getExecPlan(sql);
+        List<ScanNode> scanNodes = plan.getScanNodes();
+        Assert.assertEquals(scanNodes.size(), 2);
+        HdfsScanNode node0 = (HdfsScanNode) scanNodes.get(0);
+        HdfsScanNode node1 = (HdfsScanNode) scanNodes.get(1);
+        Assert.assertEquals(node0.getScanNodePredicates().getSelectedPartitionIds().size(), 1);
+        Assert.assertEquals(node1.getScanNodePredicates().getSelectedPartitionIds().size(), 1);
+        Assert.assertFalse(node0.getScanNodePredicates().getSelectedPartitionIds().equals(
+                node1.getScanNodePredicates().getSelectedPartitionIds()));
+    }
+
+    @Test
+    public void testLikeInPartitionColumn() throws Exception {
+        String sql = "select * from hive0.datacache_db.single_partition_table where l_shipdate LIKE '1998-01-03'";
+        String plan = getFragmentPlan(sql);
+        assertContains(plan, "partitions=1/1");
+
+        String sql1 = "select * from t1 where par_col like '%1%'";
+        Assert.assertThrows(StarRocksPlannerException.class, () -> getFragmentPlan(sql1));
+    }
+
+    @Test
+    public void testWithDuplicatePartition() throws Exception {
+        String sql1 = "select * from hive0.partitioned_db.duplicate_partition";
+        Assert.assertThrows(StarRocksPlannerException.class, () -> getFragmentPlan(sql1));
+
+        String sql = "select * from hive0.partitioned_db.duplicate_partition where day='2012-01-01'";
+        String plan = getFragmentPlan(sql);
+        assertContains(plan, "partitions=2/2");
+
+        sql = "select * from hive0.partitioned_db.duplicate_partition where day='2012-01-01'";
+        plan = getFragmentPlan(sql);
+        assertContains(plan, "partitions=2/2");
+
+        sql = "select * from hive0.partitioned_db.duplicate_partition where day='2012-01-01' and hour=6";
+        plan = getFragmentPlan(sql);
+        assertContains(plan, "partitions=2/2");
+
+        sql = "select * from hive0.partitioned_db.duplicate_partition where day='2012-01-01' and hour>0";
+        plan = getFragmentPlan(sql);
+        assertContains(plan, "partitions=2/2");
+
+        sql = "select * from hive0.partitioned_db.duplicate_partition where day='2012-01-01' and hour=0";
+        plan = getFragmentPlan(sql);
+        assertContains(plan, "partitions=0/2");
+
+        sql = "select * from hive0.partitioned_db.duplicate_partition where day='2012-01-01' and hour > 10";
+        plan = getFragmentPlan(sql);
+        assertContains(plan, "partitions=0/2");
+
+        sql = "select * from hive0.partitioned_db.duplicate_partition where hour < 10";
+        plan = getFragmentPlan(sql);
+        assertContains(plan, "partitions=2/2");
+    }
+}


### PR DESCRIPTION
## Why I'm doing:

Through partition filter restrictions, avoid unreasonable queries causing cluster BE or FE to be unavailable.

## What I'm doing:
Fixes #issue

1. When the number of partitions after partition filtering is greater than > `scan_hive_partition_num_limit`, an exception is thrown.
2. When the query does not have a partition predicate, an exception is thrown
3. When the partition column is used as a function parameter or the constant cannot be folded, causing partition pruning is invalid, an exception is thrown.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
