### PR TITLE
[Enhancement] Improve insert column mismatch error message

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/common/ErrorCode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/ErrorCode.java
@@ -305,6 +305,8 @@ public enum ErrorCode {
             "No partitions have data available for loading. If you are sure there may be no data to be loaded, " +
                     "you can use `ADMIN SET FRONTEND CONFIG ('empty_load_as_error' = 'false')` " +
                     "to ensure such load jobs can succeed"),
+    ERR_INSERTED_COLUMN_MISMATCH(5604, new byte[] {'2', '2', '0', '0', '0'},
+            "Inserted target column count: %d doesn't match select/value column count: %d"),
 
     /**
      * 10000 - 10099: warehouse

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/InsertAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/InsertAnalyzer.java
@@ -226,7 +226,8 @@ public class InsertAnalyzer {
         }
 
         if (query.getRelationFields().size() != mentionedColumnSize) {
-            throw new SemanticException("Column count doesn't match value count");
+            ErrorReport.reportSemanticException(ErrorCode.ERR_INSERTED_COLUMN_MISMATCH, mentionedColumnSize,
+                    query.getRelationFields().size());
         }
         // check default value expr
         if (query instanceof ValuesRelation) {

--- a/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AnalyzeInsertTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AnalyzeInsertTest.java
@@ -59,9 +59,9 @@ public class AnalyzeInsertTest {
     @Test
     public void testInsert() {
         analyzeFail("insert into t0 select v4,v5 from t1",
-                "Column count doesn't match value count");
-        analyzeFail("insert into t0 select 1,2", "Column count doesn't match value count");
-        analyzeFail("insert into t0 values(1,2)", "Column count doesn't match value count");
+                "Inserted target column count: 3 doesn't match select/value column count: 2");
+        analyzeFail("insert into t0 select 1,2", "Inserted target column count: 3 doesn't match select/value column count: 2");
+        analyzeFail("insert into t0 values(1,2)", "Inserted target column count: 3 doesn't match select/value column count: 2");
 
         analyzeFail("insert into tnotnull(v1) values(1)",
                 "must be explicitly mentioned in column permutation");
@@ -85,7 +85,8 @@ public class AnalyzeInsertTest {
 
         analyzeSuccess("insert into tmc values (1,2)");
         analyzeSuccess("insert into tmc (id,name) values (1,2)");
-        analyzeFail("insert into tmc values (1,2,3)", "Column count doesn't match value count");
+        analyzeFail("insert into tmc values (1,2,3)",
+                "Inserted target column count: 2 doesn't match select/value column count: 3");
         analyzeFail("insert into tmc (id,name,mc) values (1,2,3)", "generated column 'mc' can not be specified.");
     }
 
@@ -132,7 +133,7 @@ public class AnalyzeInsertTest {
             }
         };
         analyzeFail("insert into iceberg_catalog.db.tbl values (1)",
-                "Column count doesn't match value count");
+                "Inserted target column count: 0 doesn't match select/value column count: 1");
 
         new Expectations(metadata) {
             {

--- a/test/sql/test_materialized_column/R/test_materialized_column
+++ b/test/sql/test_materialized_column/R/test_materialized_column
@@ -79,7 +79,7 @@ CREATE TABLE t ( id BIGINT NOT NULL,  array_data ARRAY<int> NOT NULL, mc DOUBLE 
 -- !result
 INSERT INTO t VALUES (1, [1,2], 0.0);
 -- result:
-E: (1064, "Getting analyzing error. Detail message: Column count doesn't match value count.")
+E: (5604, "Getting analyzing error. Detail message: Inserted target column count: 2 doesn't match select/value column count: 3.")
 -- !result
 INSERT INTO t (id, array_data, mc) VALUES (1, [1,2], 0.0);
 -- result:

--- a/test/sql/test_scan/test_pushdown_or_predicate/R/test_parse_and_rewrite_or_predicate
+++ b/test/sql/test_scan/test_pushdown_or_predicate/R/test_parse_and_rewrite_or_predicate
@@ -1319,7 +1319,7 @@ PROPERTIES (
 -- !result
 insert into t1_copy select * from t1;
 -- result:
-E: (1064, "Getting analyzing error. Detail message: Column count doesn't match value count.")
+E: (5604, "Getting analyzing error. Detail message: Inserted target column count: 11 doesn't match select/value column count: 15.")
 -- !result
 analyze table t1_copy;
 -- result:
@@ -1371,7 +1371,7 @@ truncate table t1_copy;
 -- !result
 insert into t1_copy select * from t1;
 -- result:
-E: (1064, "Getting analyzing error. Detail message: Column count doesn't match value count.")
+E: (5604, "Getting analyzing error. Detail message: Inserted target column count: 11 doesn't match select/value column count: 15.")
 -- !result
 select count(1) from t1_copy;
 -- result:


### PR DESCRIPTION
## Why I'm doing:
t1 has 3 columns.

```
mysql> insert into t1 values (1,1,1,1);
ERROR 1064 (HY000): Getting analyzing error. Detail message: Column count doesn't match value count.

mysql> insert into t1 (k1,k2) select * from t1;
ERROR 1064 (HY000): Getting analyzing error. Detail message: Column count doesn't match value count.

```

## What I'm doing:

```
mysql> insert into t1 values (1,1,1,1);
ERROR 5604 (42000): Getting analyzing error. Detail message: Inserted target column count: 3 doesn't match select/value column count: 4.

mysql> insert into t1 (k1,k2) select * from t1;
ERROR 5604 (42000): Getting analyzing error. Detail message: Inserted target column count: 2 doesn't match select/value column count: 3.
```

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [x] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [x] 3.2
  - [x] 3.1
  - [ ] 3.0
  - [ ] 2.5
