### PR TITLE
[BugFix] Fix greatest function bug

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/ExpressionAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/ExpressionAnalyzer.java
@@ -799,7 +799,7 @@ public class ExpressionAnalyzer {
                     fn = Expr.getBuiltinFunction(fnName, doubleArgTypes,
                             Function.CompareMode.IS_NONSTRICT_SUPERTYPE_OF);
                 } else {
-                    fn = getDecimalV3Function(node, argumentTypes);
+                    fn = DecimalV3FunctionAnalyzer.getDecimalV3Function(session, node, argumentTypes);
                 }
             } else if (Arrays.stream(argumentTypes).anyMatch(arg -> arg.matchesType(Type.TIME))) {
                 fn = Expr.getBuiltinFunction(fnName, argumentTypes, Function.CompareMode.IS_NONSTRICT_SUPERTYPE_OF);
@@ -917,88 +917,6 @@ public class ExpressionAnalyzer {
                         Function.CompareMode.IS_NONSTRICT_SUPERTYPE_OF);
             }
 
-            return fn;
-        }
-
-        Function getDecimalV3Function(FunctionCallExpr node, Type[] argumentTypes) {
-            Function fn;
-            String fnName = node.getFnName().getFunction();
-            Type commonType = DecimalV3FunctionAnalyzer.normalizeDecimalArgTypes(argumentTypes, fnName);
-            fn = Expr.getBuiltinFunction(fnName, argumentTypes, Function.CompareMode.IS_NONSTRICT_SUPERTYPE_OF);
-
-            if (fn == null) {
-                fn = AnalyzerUtils.getUdfFunction(session, node.getFnName(), argumentTypes);
-            }
-
-            if (fn == null) {
-                throw new SemanticException("No matching function with signature: %s(%s).", fnName,
-                        node.getParams().isStar() ? "*" : Joiner.on(", ")
-                                .join(Arrays.stream(argumentTypes).map(Type::toSql).collect(Collectors.toList())));
-            }
-
-            if (DecimalV3FunctionAnalyzer.DECIMAL_AGG_FUNCTION.contains(fnName)) {
-                Type argType = node.getChild(0).getType();
-                // stddev/variance always use decimal128(38,9) to computing result.
-                if (DecimalV3FunctionAnalyzer.DECIMAL_AGG_VARIANCE_STDDEV_TYPE
-                        .contains(fnName) && argType.isDecimalV3()) {
-                    argType = ScalarType.createDecimalV3Type(PrimitiveType.DECIMAL128, 38, 9);
-                    node.setChild(0, TypeManager.addCastExpr(node.getChild(0), argType));
-                }
-                fn = DecimalV3FunctionAnalyzer
-                        .rectifyAggregationFunction((AggregateFunction) fn, argType, commonType);
-            } else if (DecimalV3FunctionAnalyzer.DECIMAL_UNARY_FUNCTION_SET.contains(fnName) ||
-                    DecimalV3FunctionAnalyzer.DECIMAL_IDENTICAL_TYPE_FUNCTION_SET.contains(fnName) ||
-                    FunctionSet.IF.equals(fnName) || FunctionSet.MAX_BY.equals(fnName)) {
-                // DecimalV3 types in resolved fn's argument should be converted into commonType so that right CastExprs
-                // are interpolated into FunctionCallExpr's children whose type does match the corresponding argType of fn.
-                List<Type> argTypes;
-                if (FunctionSet.MONEY_FORMAT.equals(fnName)) {
-                    argTypes = Arrays.asList(argumentTypes);
-                } else {
-                    argTypes = Arrays.stream(fn.getArgs()).map(t -> t.isDecimalV3() ? commonType : t)
-                            .collect(Collectors.toList());
-                }
-
-                Type returnType = fn.getReturnType();
-                // Decimal v3 function return type maybe need change
-                if (returnType.isDecimalV3() && commonType.isValid()) {
-                    returnType = commonType;
-                }
-
-                if (FunctionSet.MAX_BY.equals(fnName)) {
-                    AggregateFunction newFn = new AggregateFunction(fn.getFunctionName(),
-                            Arrays.asList(argumentTypes), returnType,
-                            Type.VARCHAR, fn.hasVarArgs());
-                    newFn.setFunctionId(fn.getFunctionId());
-                    newFn.setChecksum(fn.getChecksum());
-                    newFn.setBinaryType(fn.getBinaryType());
-                    newFn.setHasVarArgs(fn.hasVarArgs());
-                    newFn.setId(fn.getId());
-                    newFn.setUserVisible(fn.isUserVisible());
-                    newFn.setisAnalyticFn(true);
-                    fn = newFn;
-                    return fn;
-                }
-
-                ScalarFunction newFn = new ScalarFunction(fn.getFunctionName(), argTypes, returnType,
-                        fn.getLocation(), ((ScalarFunction) fn).getSymbolName(),
-                        ((ScalarFunction) fn).getPrepareFnSymbol(),
-                        ((ScalarFunction) fn).getCloseFnSymbol());
-                newFn.setFunctionId(fn.getFunctionId());
-                newFn.setChecksum(fn.getChecksum());
-                newFn.setBinaryType(fn.getBinaryType());
-                newFn.setHasVarArgs(fn.hasVarArgs());
-                newFn.setId(fn.getId());
-                newFn.setUserVisible(fn.isUserVisible());
-
-                fn = newFn;
-            } else if (FunctionSet.decimalRoundFunctions.contains(fnName)) {
-                // Decimal version of truncate/round/round_up_to may change the scale, we need to calculate the scale of the return type
-                // And we need to downgrade to double version if second param is neither int literal nor SlotRef expression
-                List<Type> argTypes = Arrays.stream(fn.getArgs()).map(t -> t.isDecimalV3() ? commonType : t)
-                        .collect(Collectors.toList());
-                fn = DecimalV3FunctionAnalyzer.getFunctionOfRound(node, fn, argTypes);
-            }
             return fn;
         }
 

--- a/test/sql/test_decimal/R/test_decimal_type
+++ b/test/sql/test_decimal/R/test_decimal_type
@@ -1,0 +1,82 @@
+-- name: test_decimal_type
+CREATE TABLE t1 (
+    c1 int,
+    c2 boolean,
+    c3 tinyint,
+    c4 int,
+    c5 bigint,
+    c6 largeint,
+    c7 string,
+    c8 decimal(22, 7),
+    c9 decimal(38, 7),
+    c10 decimal(38, 6)
+    )
+DUPLICATE KEY(c1)
+DISTRIBUTED BY HASH(c1)
+BUCKETS 1
+PROPERTIES ("replication_num" = "1");
+-- result:
+-- !result
+INSERT INTO t1 values
+    (1, true, 11, 111, 1111, 11111, "111111", 1.0, 2.0, 3.0),
+    (2, false, 22, 222, 2222, 22222, "222222", 1.0, 1.0, 1.0),
+    (3, true, 33, 333, 3333, 33333, "333333", NULL, NULL, NULL),
+    (4, null, null, null, null, null, null, null, null, null),
+    (5, -1, -11, -111, -1111, -11111, "-111111", 4.0, 3.0, 2.0),
+    (6, null, null, null, null, "36893488147419103232", "680564733841876926926749214863536422912", 111111, 22222, NULL);
+-- result:
+-- !result
+select c1, greatest(coalesce(c8, 0), coalesce(c9, 0), coalesce(c10, 0)) from t1 order by c1;
+-- result:
+1	3.0
+2	1.0
+3	0.0
+4	0.0
+5	4.0
+6	111111.0
+-- !result
+select c1, least(coalesce(c8, 0), coalesce(c9, 0), coalesce(c10, 0)) from t1 order by c1;
+-- result:
+1	1.0
+2	1.0
+3	0.0
+4	0.0
+5	2.0
+6	0.0
+-- !result
+select c1, min(coalesce(c8, 0)), max(coalesce(c9, 0)), avg(coalesce(c10, 0)) from t1 group by c1 order by c1;
+-- result:
+1	1.0000000	2.0000000	3.000000000000
+2	1.0000000	1.0000000	1.000000000000
+3	0E-7	0E-7	0E-12
+4	0E-7	0E-7	0E-12
+5	4.0000000	3.0000000	2.000000000000
+6	111111.0000000	22222.0000000	0E-12
+-- !result
+select c1, VARIANCE(coalesce(c8, 0)), STDDEV(coalesce(c9, 0)), STD(coalesce(c10, 0)) from t1 group by c1 order by c1;
+-- result:
+1	0.0	0.0	0.0
+2	0.0	0.0	0.0
+3	0.0	0.0	0.0
+4	0.0	0.0	0.0
+5	0.0	0.0	0.0
+6	0.0	0.0	0.0
+-- !result
+select c1, ROUND(coalesce(c9, 0)), DROUND(coalesce(c10, 0)) from t1 order by c1;
+-- result:
+1	2	3
+2	1	1
+3	0	0
+4	0	0
+5	3	2
+6	22222	0
+-- !result
+select c1, max_by(coalesce(c8, 0), c4), max(coalesce(c9, 0)), avg(coalesce(c10, 0)) from t1 group by c1 order by c1;
+-- result:
+1	1.0000000	2.0000000	3.000000000000
+2	1.0000000	1.0000000	1.000000000000
+3	0E-7	0E-7	0E-12
+4	None	0E-7	0E-12
+5	4.0000000	3.0000000	2.000000000000
+6	None	22222.0000000	0E-12
+-- !result

--- a/test/sql/test_decimal/T/test_decimal_type
+++ b/test/sql/test_decimal/T/test_decimal_type
@@ -1,0 +1,32 @@
+-- name: test_decimal_type
+CREATE TABLE t1 (
+    c1 int,
+    c2 boolean,
+    c3 tinyint,
+    c4 int,
+    c5 bigint,
+    c6 largeint,
+    c7 string,
+    c8 decimal(22, 7),
+    c9 decimal(38, 7),
+    c10 decimal(38, 6)
+    )
+DUPLICATE KEY(c1)
+DISTRIBUTED BY HASH(c1)
+BUCKETS 1
+PROPERTIES ("replication_num" = "1");
+
+INSERT INTO t1 values
+    (1, true, 11, 111, 1111, 11111, "111111", 1.0, 2.0, 3.0),
+    (2, false, 22, 222, 2222, 22222, "222222", 1.0, 1.0, 1.0),
+    (3, true, 33, 333, 3333, 33333, "333333", NULL, NULL, NULL),
+    (4, null, null, null, null, null, null, null, null, null),
+    (5, -1, -11, -111, -1111, -11111, "-111111", 4.0, 3.0, 2.0),
+    (6, null, null, null, null, "36893488147419103232", "680564733841876926926749214863536422912", 111111, 22222, NULL);
+
+select c1, greatest(coalesce(c8, 0), coalesce(c9, 0), coalesce(c10, 0)) from t1 order by c1;
+select c1, least(coalesce(c8, 0), coalesce(c9, 0), coalesce(c10, 0)) from t1 order by c1;
+select c1, min(coalesce(c8, 0)), max(coalesce(c9, 0)), avg(coalesce(c10, 0)) from t1 group by c1 order by c1;
+select c1, VARIANCE(coalesce(c8, 0)), STDDEV(coalesce(c9, 0)), STD(coalesce(c10, 0)) from t1 group by c1 order by c1;
+select c1, ROUND(coalesce(c9, 0)), DROUND(coalesce(c10, 0)) from t1 order by c1;
+select c1, max_by(coalesce(c8, 0), c4), max(coalesce(c9, 0)), avg(coalesce(c10, 0)) from t1 group by c1 order by c1;


### PR DESCRIPTION
## Why I'm doing:

```
query_id:6169418f-f7c5-11ee-9b82-005056a475ca, fragment_instance:6169418f-f7c5-11ee-9b82-005056a47650
tracker:process consumption: 31395206536
tracker:query_pool consumption: 52827000
tracker:load consumption: 0
tracker:metadata consumption: 642695831
tracker:tablet_metadata consumption: 115941596
tracker:rowset_metadata consumption: 95469326
tracker:segment_metadata consumption: 43721318
tracker:column_metadata consumption: 387563591
tracker:tablet_schema consumption: 18243996
tracker:segment_zonemap consumption: 34067882
tracker:short_key_index consumption: 5380401
tracker:column_zonemap_index consumption: 91488967
tracker:ordinal_index consumption: 202857456
tracker:bitmap_index consumption: 24400
tracker:bloom_filter_index consumption: 0
tracker:compaction consumption: 0
tracker:schema_change consumption: 0
tracker:column_pool consumption: 0
tracker:page_cache consumption: 25405624272
tracker:update consumption: 512546078
tracker:chunk_allocator consumption: 2122205000
tracker:clone consumption: 0
tracker:consistency consumption: 0
*** Aborted at 1712813762 (unix time) try "date -d @1712813762" if you are using GNU date ***
PC: @          0x4fe19c7 starrocks::vectorized::MathFunctions::greatest<>()
*** SIGSEGV (@0x7efc31cf5000) received by PID 99598 (TID 0x7efe5e7f5700) from PID 835670016; stack trace: ***
    @          0x5c034e2 google::(anonymous namespace)::FailureSignalHandler()
    @     0x7f01c66327fb os::Linux::chained_handler()
    @     0x7f01c663735c JVM_handle_linux_signal
    @     0x7f01c6629e78 signalHandler()
    @     0x7f01c5aba630 (unknown)
    @          0x4fe19c7 starrocks::vectorized::MathFunctions::greatest<>()
    @          0x4086204 starrocks::vectorized::VectorizedFunctionCallExpr::evaluate_checked()
    @          0x3a6c2d1 starrocks::vectorized::VectorizedBinaryPredicate<>::evaluate_checked()
    @          0x402cf6e starrocks::vectorized::VectorizedAndCompoundPredicate::evaluate_checked()
    @          0x4043374 starrocks::vectorized::VectorizedIfExpr<>::evaluate_checked()
    @          0x3a4a8f1 starrocks::vectorized::VectorizedBinaryPredicate<>::evaluate_checked()
    @          0x392e5e3 starrocks::ExprContext::evaluate()
    @          0x392e92f starrocks::ExprContext::evaluate()
    @          0x2de2522 starrocks::ExecNode::eval_conjuncts()
    @          0x2dc6107 starrocks::pipeline::Operator::eval_conjuncts_and_in_filters()
    @          0x30bb0cb starrocks::pipeline::AggregateBlockingSourceOperator::pull_chunk()
    @          0x2da88b0 starrocks::pipeline::PipelineDriver::process()
    @          0x51d7e2a starrocks::pipeline::GlobalDriverExecutor::_worker_thread()
    @          0x4bbf542 starrocks::ThreadPool::dispatch_thread()
    @          0x4bb9fda starrocks::Thread::supervise_thread()
    @     0x7f01c5ab2ea5 start_thread
    @     0x7f01c50cdb0d __clone
    @                0x0 (unknown)
start time: Thu Apr 11 13:36:13 CST 2024
```



## What I'm doing:

fn should be changed after deduced common type.
```
     Type commonType = DecimalV3FunctionAnalyzer.normalizeDecimalArgTypes(argumentTypes, fnName);
            fn = Expr.getBuiltinFunction(fnName, argumentTypes, Function.CompareMode.IS_NONSTRICT_SUPERTYPE_OF);

```

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5

