### PR TITLE
[BugFix] Check the validity of the datacache space configuration before initializing the cache instance.

### DIFF
--- a/be/src/block_cache/cache_options.cpp
+++ b/be/src/block_cache/cache_options.cpp
@@ -24,7 +24,13 @@
 namespace starrocks {
 
 int64_t parse_conf_datacache_mem_size(const std::string& conf_mem_size_str, int64_t mem_limit) {
-    return ParseUtil::parse_mem_spec(conf_mem_size_str, mem_limit);
+    int64_t mem_size = ParseUtil::parse_mem_spec(conf_mem_size_str, mem_limit);
+    if (mem_limit > 0 && mem_size > mem_limit) {
+        mem_size = mem_limit;
+        LOG(WARNING) << "the configured datacache memory size exceeds the limit, decreased it to the limit value."
+                     << "mem_size: " << mem_size << ", mem_limit: " << mem_limit;
+    }
+    return mem_size;
 }
 
 int64_t parse_conf_datacache_disk_size(const std::string& disk_path, const std::string& disk_size_str,
@@ -39,7 +45,13 @@ int64_t parse_conf_datacache_disk_size(const std::string& disk_path, const std::
         }
         disk_limit = space_info.capacity;
     }
-    return ParseUtil::parse_mem_spec(disk_size_str, disk_limit);
+    int64_t disk_size = ParseUtil::parse_mem_spec(disk_size_str, disk_limit);
+    if (disk_size > disk_limit) {
+        disk_size = disk_limit;
+        LOG(WARNING) << "the configured datacache disk size exceeds the disk limit, decreased it to the limit value."
+                     << ", path: " << disk_path << ", disk_size: " << disk_size << ", disk_limit: " << disk_limit;
+    }
+    return disk_size;
 }
 
 Status parse_conf_datacache_disk_paths(const std::string& config_path, std::vector<std::string>* paths,
@@ -47,31 +59,38 @@ Status parse_conf_datacache_disk_paths(const std::string& config_path, std::vect
     if (config_path.empty()) {
         return Status::OK();
     }
+
+    size_t duplicated_count = 0;
     std::vector<std::string> path_vec = strings::Split(config_path, ";", strings::SkipWhitespace());
     for (auto& item : path_vec) {
         StripWhiteSpace(&item);
         item.erase(item.find_last_not_of('/') + 1);
         if (item.empty() || item[0] != '/') {
-            LOG(WARNING) << "invalid datacache path. path=" << item;
+            LOG(WARNING) << "invalid datacache path. path: " << item;
             continue;
         }
 
         Status status = FileSystem::Default()->create_dir_if_missing(item);
         if (!status.ok()) {
-            LOG(WARNING) << "datacache path can not be created. path=" << item;
+            LOG(WARNING) << "datacache path can not be created. path: " << item;
             continue;
         }
 
         string canonicalized_path;
         status = FileSystem::Default()->canonicalize(item, &canonicalized_path);
         if (!status.ok()) {
-            LOG(WARNING) << "datacache path can not be canonicalized. may be not exist. path=" << item;
+            LOG(WARNING) << "datacache path can not be canonicalized. may be not exist. path: " << item;
+            continue;
+        }
+        if (std::find(paths->begin(), paths->end(), canonicalized_path) != paths->end()) {
+            LOG(WARNING) << "duplicated datacache disk path: " << item << ", ignore it.";
+            ++duplicated_count;
             continue;
         }
         paths->emplace_back(canonicalized_path);
     }
-    if ((path_vec.size() != paths->size() && ignore_broken_disk)) {
-        LOG(WARNING) << "fail to parse datacache_disk_path config. value=[" << config_path << "]";
+    if ((path_vec.size() != (paths->size() + duplicated_count) && ignore_broken_disk)) {
+        LOG(WARNING) << "fail to parse datacache_disk_path config. value: " << config_path;
         return Status::InvalidArgument("fail to parse datacache_disk_path");
     }
     return Status::OK();

--- a/be/src/formats/parquet/file_reader.cpp
+++ b/be/src/formats/parquet/file_reader.cpp
@@ -243,6 +243,8 @@ Status FileReader::_get_footer() {
         if (st.ok()) {
             _scanner_ctx->stats->footer_cache_write_bytes += file_metadata_size;
             _scanner_ctx->stats->footer_cache_write_count += 1;
+        } else {
+            deleter();
         }
     } else {
         LOG(ERROR) << "Parsing unexpected parquet file metadata size";


### PR DESCRIPTION
## Why I'm doing:
Now we don't cover the validity check for some configuration parameters related to datacache space. For example, when users configure a disk cache quota larger than the disk capacity, or configure some duplicated cache paths, which may result in some unexpected behavior.

## What I'm doing:
Check and adjust some datacache configuration:
* Check the memory size to avoid exceeding memory limit.
* Check the disk size to avoid exceeding disk limit.
* Check the duplicated disk paths.
* Check the parquet footer cache write result to avoid memory leak.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
