### PR TITLE
[BugFix] fix scan operator early quit when some splitted morsels not handled

### DIFF
--- a/be/src/exec/hdfs_scanner.cpp
+++ b/be/src/exec/hdfs_scanner.cpp
@@ -185,7 +185,9 @@ Status HdfsScanner::open(RuntimeState* runtime_state) {
     RETURN_IF_ERROR(do_open(runtime_state));
     RETURN_IF_ERROR(_mor_processor->build_hash_table(runtime_state));
     _opened = true;
-    VLOG_FILE << "open file success: " << _scanner_params.path;
+    VLOG_FILE << "open file success: " << _scanner_params.path << ", scan range = ["
+              << _scanner_params.scan_range->offset << ","
+              << (_scanner_params.scan_range->length + _scanner_params.scan_range->offset) << "]";
     return Status::OK();
 }
 
@@ -193,6 +195,11 @@ void HdfsScanner::close() noexcept {
     if (!_runtime_state) {
         return;
     }
+    VLOG_FILE << "close file success: " << _scanner_params.path << ", scan range = ["
+              << _scanner_params.scan_range->offset << ","
+              << (_scanner_params.scan_range->length + _scanner_params.scan_range->offset)
+              << "], rows = " << _app_stats.rows_read;
+
     bool expect = false;
     if (!_closed.compare_exchange_strong(expect, true)) return;
     update_counter();

--- a/be/src/exec/pipeline/scan/connector_scan_operator.cpp
+++ b/be/src/exec/pipeline/scan/connector_scan_operator.cpp
@@ -592,28 +592,6 @@ int ConnectorScanOperator::available_pickup_morsel_count() {
 }
 
 void ConnectorScanOperator::append_morsels(std::vector<MorselPtr>&& morsels) {
-    std::lock_guard<std::mutex> L(_buffered_morsels_mutex);
-    _buffered_morsels.insert(_buffered_morsels.end(), std::make_move_iterator(morsels.begin()),
-                             std::make_move_iterator(morsels.end()));
-    _buffered_morsels_size += morsels.size();
-}
-
-void ConnectorScanOperator::begin_pickup_morsels() {
-    if (_buffered_morsels_size.load(std::memory_order_relaxed) == 0) {
-        return;
-    }
-
-    std::vector<MorselPtr> morsels;
-    {
-        std::lock_guard<std::mutex> L(_buffered_morsels_mutex);
-        morsels.swap(_buffered_morsels);
-        _buffered_morsels_size = 0;
-    }
-
-    if (morsels.size() == 0) {
-        return;
-    }
-
     query_cache::TicketChecker* ticket_checker = _ticket_checker.get();
     if (ticket_checker != nullptr) {
         int64_t cached_owner_id = -1;
@@ -626,7 +604,6 @@ void ConnectorScanOperator::begin_pickup_morsels() {
             }
         }
     }
-
     _morsel_queue->append_morsels(std::move(morsels));
 }
 

--- a/be/src/exec/pipeline/scan/connector_scan_operator.h
+++ b/be/src/exec/pipeline/scan/connector_scan_operator.h
@@ -109,7 +109,6 @@ public:
     void set_buffer_finished() override;
 
     int available_pickup_morsel_count() override;
-    void begin_pickup_morsels() override;
     void begin_driver_process() override;
     void end_driver_process(PipelineDriver* driver) override;
     bool is_running_all_io_tasks() const override;
@@ -122,9 +121,6 @@ private:
     int64_t _adjust_scan_mem_limit(int64_t old_chunk_source_mem_bytes, int64_t new_chunk_source_mem_bytes);
     mutable ConnectorScanOperatorAdaptiveProcessor* _adaptive_processor;
     bool _enable_adaptive_io_tasks = true;
-    std::mutex _buffered_morsels_mutex;
-    std::vector<MorselPtr> _buffered_morsels;
-    std::atomic<int64_t> _buffered_morsels_size = 0;
 };
 
 class ConnectorChunkSource : public ChunkSource {

--- a/be/src/exec/pipeline/scan/scan_operator.cpp
+++ b/be/src/exec/pipeline/scan/scan_operator.cpp
@@ -177,6 +177,7 @@ bool ScanOperator::has_output() const {
             return true;
         }
     }
+
     for (int i = 0; i < _io_tasks_per_scan_operator; ++i) {
         std::shared_lock guard(_task_mutex);
         if (_chunk_sources[i] != nullptr && !_is_io_task_running[i] && _chunk_sources[i]->has_next_chunk()) {
@@ -332,7 +333,6 @@ Status ScanOperator::_try_to_trigger_next_scan(RuntimeState* state) {
     }
 
     // pick up new chunk source.
-    begin_pickup_morsels();
     ASSIGN_OR_RETURN(auto morsel_ready, _morsel_queue->ready_for_next());
     if (size > 0 && morsel_ready) {
         for (int i = 0; i < size; i++) {

--- a/be/src/exec/pipeline/scan/scan_operator.h
+++ b/be/src/exec/pipeline/scan/scan_operator.h
@@ -79,7 +79,6 @@ public:
     void set_query_ctx(const QueryContextPtr& query_ctx);
 
     virtual int available_pickup_morsel_count() { return _io_tasks_per_scan_operator; }
-    virtual void begin_pickup_morsels() {}
     bool output_chunk_by_bucket() const { return _output_chunk_by_bucket; }
     void begin_pull_chunk(const ChunkPtr& res) {
         _op_pull_chunks += 1;

--- a/be/src/formats/parquet/file_reader.cpp
+++ b/be/src/formats/parquet/file_reader.cpp
@@ -240,6 +240,12 @@ Status FileReader::_build_split_tasks() {
         }
         int64_t start_offset = _get_row_group_start_offset(row_group);
         int64_t end_offset = _get_row_group_end_offset(row_group);
+#ifndef NDEBUG
+        if ((i + 1) < row_group_size) {
+            const tparquet::RowGroup& next_row_group = _file_metadata->t_metadata().row_groups[i + 1];
+            DCHECK_EQ(end_offset, _get_row_group_start_offset(next_row_group));
+        }
+#endif
         auto split_ctx = std::make_unique<SplitContext>();
         split_ctx->split_start = start_offset;
         split_ctx->split_end = end_offset;
@@ -252,8 +258,14 @@ Status FileReader::_build_split_tasks() {
         _scanner_ctx->split_tasks.clear();
     }
 
-    VLOG_OPERATOR << "FileReader: do_open. split task for " << _file->filename()
-                  << ", split_tasks.size = " << _scanner_ctx->split_tasks.size();
+    if (VLOG_OPERATOR_IS_ON) {
+        std::stringstream ss;
+        for (const HdfsSplitContextPtr& ctx : _scanner_ctx->split_tasks) {
+            ss << "[" << ctx->split_start << "," << ctx->split_end << "]";
+        }
+        VLOG_OPERATOR << "FileReader: do_open. split task for " << _file->filename()
+                      << ", split_tasks.size = " << _scanner_ctx->split_tasks.size() << ", range = " << ss.str();
+    }
     return Status::OK();
 }
 


### PR DESCRIPTION
## Why I'm doing:

I found a case tpc/q04 did not return right result. In most of time it did return right result, but in rare chance it did not.

It's because scan operator quit early even when there are some morsels are not handled. Right now we handle splitted morsels in this way
1. We add splitted morsels into a buffer held by scan operator
2. and in next round, put morsels in buffer back to morsel queue

But there are a chance that, during phase 1 and 2, scan operator
- will check morsel queue to see if it still has outputs(or more morsels to be handled)
- but at this time,  morsels are in buffer not in morsel queue
- so scan operator thinks there is no output any more, and just quit
- so morsels in buffer are not handled, which leads to less data are read.

## What I'm doing:

To make things simpler, we don't put morsels into buffer, but into morsel queue directly. And in this way,
it's very consistent to the scan operator model right now, and the whole process is simpler.

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [x] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
