### PR TITLE
[BugFix] fix object_dependencies when table is renamed/dropped/swapped

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/system/sys/SysObjectDependencies.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/system/sys/SysObjectDependencies.java
@@ -100,11 +100,18 @@ public class SysObjectDependencies {
                     item.setCatalog(catalog);
                     item.setObject_type(mv.getType().toString());
 
+                    Optional<Table> refTable = refObj.mayGetTable();
                     item.setRef_object_id(refObj.getTableId());
-                    item.setRef_object_name(refObj.getTableName());
                     item.setRef_database(refObj.getDbName());
                     item.setRef_catalog(refObj.getCatalogName());
                     item.setRef_object_type(getRefObjectType(refObj, mv.getName()));
+                    // If the ref table is dropped/swapped/renamed, the actual info would be inconsistent with
+                    // BaseTableInfo, so we use the source-of-truth information
+                    if (refTable.isEmpty()) {
+                        item.setRef_object_name(refObj.getTableName());
+                    } else {
+                        item.setRef_object_name(refTable.get().getName());
+                    }
 
                     response.addToItems(item);
                 }

--- a/test/sql/test_information_schema/R/test_object_dependencies
+++ b/test/sql/test_information_schema/R/test_object_dependencies
@@ -56,6 +56,42 @@ mv2	default_catalog	MATERIALIZED_VIEW	t1	default_catalog	OLAP
 mv3	default_catalog	MATERIALIZED_VIEW	mv2	default_catalog	MATERIALIZED_VIEW
 mv1	default_catalog	MATERIALIZED_VIEW	t1	default_catalog	OLAP
 -- !result
+alter table t1 rename t2;
+-- result:
+-- !result
+select object_name, object_catalog, object_type, ref_object_name, ref_object_catalog, ref_object_type 
+from sys.object_dependencies where object_database = 'db_${uuid0}' and object_name = 'mv1';
+-- result:
+mv1	default_catalog	MATERIALIZED_VIEW	t2	default_catalog	OLAP
+-- !result
+create table t1 like t2;
+-- result:
+-- !result
+alter table t1 swap with t2;
+-- result:
+-- !result
+select object_name, object_catalog, object_type, ref_object_name, ref_object_catalog, ref_object_type 
+from sys.object_dependencies where object_database = 'db_${uuid0}' and object_name = 'mv1';
+-- result:
+mv1	default_catalog	MATERIALIZED_VIEW	t1	default_catalog	OLAP
+-- !result
+drop table t1;
+-- result:
+-- !result
+select object_name, object_catalog, object_type, ref_object_name, ref_object_catalog, ref_object_type 
+from sys.object_dependencies where object_database = 'db_${uuid0}' and object_name = 'mv1';
+-- result:
+mv1	default_catalog	MATERIALIZED_VIEW	t1	default_catalog	UNKNOWN
+-- !result
+alter table t2 rename t1;
+-- result:
+-- !result
+refresh materialized view mv1 with sync mode;
+select object_name, object_catalog, object_type, ref_object_name, ref_object_catalog, ref_object_type 
+from sys.object_dependencies where object_database = 'db_${uuid0}' and object_name = 'mv1';
+-- result:
+mv1	default_catalog	MATERIALIZED_VIEW	t1	default_catalog	OLAP
+-- !result
 drop database db_${uuid0};
 -- result:
 -- !result

--- a/test/sql/test_information_schema/T/test_object_dependencies
+++ b/test/sql/test_information_schema/T/test_object_dependencies
@@ -38,4 +38,21 @@ select
     ref_object_type
 from sys.object_dependencies where object_database = 'db_${uuid0}';
 
+-- drop/rename/swap base table
+alter table t1 rename t2;
+select object_name, object_catalog, object_type, ref_object_name, ref_object_catalog, ref_object_type 
+from sys.object_dependencies where object_database = 'db_${uuid0}' and object_name = 'mv1';
+create table t1 like t2;
+alter table t1 swap with t2;
+select object_name, object_catalog, object_type, ref_object_name, ref_object_catalog, ref_object_type 
+from sys.object_dependencies where object_database = 'db_${uuid0}' and object_name = 'mv1';
+drop table t1;
+select object_name, object_catalog, object_type, ref_object_name, ref_object_catalog, ref_object_type 
+from sys.object_dependencies where object_database = 'db_${uuid0}' and object_name = 'mv1';
+alter table t2 rename t1;
+refresh materialized view mv1 with sync mode;
+select object_name, object_catalog, object_type, ref_object_name, ref_object_catalog, ref_object_type 
+from sys.object_dependencies where object_database = 'db_${uuid0}' and object_name = 'mv1';
+
+
 drop database db_${uuid0};


### PR DESCRIPTION
## Why I'm doing:
- Table name in `sys.object_dependencies` is incorrect when the table is dropped/renamed/swapped

## What I'm doing:
- When the table is renamed/swapped but exist, use the latest name of it
- When the table is dropped, display the name but object_type is `UNKNOWN`

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [x] 3.2
  - [x] 3.1
  - [ ] 3.0
  - [ ] 2.5
