### PR TITLE
[Enhancement] cache orc metadata in file tail

### DIFF
--- a/be/src/formats/orc/apache-orc/proto/orc_proto.proto
+++ b/be/src/formats/orc/apache-orc/proto/orc_proto.proto
@@ -466,4 +466,5 @@ message FileTail {
   optional Footer footer = 2;
   optional uint64 fileLength = 3;
   optional uint64 postscriptLength = 4;
+  optional Metadata metadata = 5;
 }

--- a/gensrc/proto/orc_proto.proto
+++ b/gensrc/proto/orc_proto.proto
@@ -466,4 +466,5 @@ message FileTail {
   optional Footer footer = 2;
   optional uint64 fileLength = 3;
   optional uint64 postscriptLength = 4;
+  optional Metadata metadata = 5;
 }


### PR DESCRIPTION
## Why I'm doing:

By default, orc metadata is not loaded into footer. And it's loaded when creating row reader or calling some special functions 

And if orc metadata is not loaded into footer, then in splitted tasks, they have to load it again, which is unnecessary.

## What I'm doing:

Load metadata into footer by default, and splitted tasks can share this metadata.

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
