### PR TITLE
[Refactor] Add curly braces {} for switch case in edit log

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/journal/JournalEntity.java
+++ b/fe/fe-core/src/main/java/com/starrocks/journal/JournalEntity.java
@@ -1081,75 +1081,92 @@ public class JournalEntity implements Writable {
                 isRead = true;
                 break;
             }
-            case OperationType.OP_AUTH_UPGRADE_V2:
+            case OperationType.OP_AUTH_UPGRADE_V2: {
                 // for compatibility reason, just ignore the auth upgrade log
                 isRead = true;
                 break;
-            case OperationType.OP_MV_JOB_STATE:
+            }
+            case OperationType.OP_MV_JOB_STATE: {
                 data = MVMaintenanceJob.read(in);
                 isRead = true;
                 break;
-            case OperationType.OP_MV_EPOCH_UPDATE:
+            }
+            case OperationType.OP_MV_EPOCH_UPDATE: {
                 data = MVEpoch.read(in);
                 isRead = true;
                 break;
-            case OperationType.OP_MODIFY_TABLE_ADD_OR_DROP_COLUMNS:
+            }
+            case OperationType.OP_MODIFY_TABLE_ADD_OR_DROP_COLUMNS: {
                 data = TableAddOrDropColumnsInfo.read(in);
                 isRead = true;
                 break;
-            case OperationType.OP_SET_DEFAULT_STORAGE_VOLUME:
+            }
+            case OperationType.OP_SET_DEFAULT_STORAGE_VOLUME: {
                 data = SetDefaultStorageVolumeLog.read(in);
                 isRead = true;
                 break;
-            case OperationType.OP_DROP_STORAGE_VOLUME:
+            }
+            case OperationType.OP_DROP_STORAGE_VOLUME: {
                 data = DropStorageVolumeLog.read(in);
                 isRead = true;
                 break;
+            }
             case OperationType.OP_CREATE_STORAGE_VOLUME:
-            case OperationType.OP_UPDATE_STORAGE_VOLUME:
+            case OperationType.OP_UPDATE_STORAGE_VOLUME: {
                 data = StorageVolume.read(in);
                 isRead = true;
                 break;
-            case OperationType.OP_PIPE:
+            }
+            case OperationType.OP_PIPE: {
                 data = PipeOpEntry.read(in);
                 isRead = true;
                 break;
-            case OperationType.OP_CREATE_DICTIONARY:
+            }
+            case OperationType.OP_CREATE_DICTIONARY: {
                 data = Dictionary.read(in);
                 isRead = true;
                 break;
-            case OperationType.OP_DROP_DICTIONARY:
+            }
+            case OperationType.OP_DROP_DICTIONARY: {
                 data = DropDictionaryInfo.read(in);
                 isRead = true;
                 break;
-            case OperationType.OP_MODIFY_DICTIONARY_MGR:
+            }
+            case OperationType.OP_MODIFY_DICTIONARY_MGR: {
                 data = DictionaryMgrInfo.read(in);
                 isRead = true;
                 break;
-            case OperationType.OP_DECOMMISSION_DISK:
+            }
+            case OperationType.OP_DECOMMISSION_DISK: {
                 data = GsonUtils.GSON.fromJson(Text.readString(in), DecommissionDiskInfo.class);
                 isRead = true;
                 break;
-            case OperationType.OP_CANCEL_DECOMMISSION_DISK:
+            }
+            case OperationType.OP_CANCEL_DECOMMISSION_DISK: {
                 data = GsonUtils.GSON.fromJson(Text.readString(in), CancelDecommissionDiskInfo.class);
                 isRead = true;
                 break;
-            case OperationType.OP_DISABLE_DISK:
+            }
+            case OperationType.OP_DISABLE_DISK: {
                 data = GsonUtils.GSON.fromJson(Text.readString(in), DisableDiskInfo.class);
                 isRead = true;
                 break;
-            case OperationType.OP_CANCEL_DISABLE_DISK:
+            }
+            case OperationType.OP_CANCEL_DISABLE_DISK: {
                 data = GsonUtils.GSON.fromJson(Text.readString(in), CancelDisableDiskInfo.class);
                 isRead = true;
                 break;
-            case OperationType.OP_REPLICATION_JOB:
+            }
+            case OperationType.OP_REPLICATION_JOB: {
                 data = ReplicationJobLog.read(in);
                 isRead = true;
                 break;
-            case OperationType.OP_RECOVER_PARTITION_VERSION:
+            }
+            case OperationType.OP_RECOVER_PARTITION_VERSION: {
                 data = GsonUtils.GSON.fromJson(Text.readString(in), PartitionVersionRecoveryInfo.class);
                 isRead = true;
                 break;
+            }
             default: {
                 if (Config.ignore_unknown_log_id) {
                     LOG.warn("UNKNOWN Operation Type {}", opCode);

--- a/fe/fe-core/src/main/java/com/starrocks/persist/EditLog.java
+++ b/fe/fe-core/src/main/java/com/starrocks/persist/EditLog.java
@@ -1200,10 +1200,11 @@ public class EditLog {
                     globalStateMgr.getReplicationMgr().replayReplicationJob(replicationJobLog.getReplicationJob());
                     break;
                 }
-                case OperationType.OP_RECOVER_PARTITION_VERSION:
+                case OperationType.OP_RECOVER_PARTITION_VERSION: {
                     PartitionVersionRecoveryInfo info = (PartitionVersionRecoveryInfo) journal.getData();
                     GlobalStateMgr.getCurrentState().getMetaRecoveryDaemon().recoverPartitionVersion(info);
                     break;
+                }
                 default: {
                     if (Config.ignore_unknown_log_id) {
                         LOG.warn("UNKNOWN Operation Type {}", opCode);


### PR DESCRIPTION
## Why I'm doing:

Add curly braces {} for every case block, so that variables will not contaminate each other.

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [x] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
