### PR TITLE
[BugFix] Hudi query support fix for Hudi 0.14.x

### DIFF
--- a/fe/pom.xml
+++ b/fe/pom.xml
@@ -52,7 +52,7 @@ under the License.
         <hadoop.version>3.3.6</hadoop.version>
         <gcs.connector.version>hadoop3-2.2.11</gcs.connector.version>
         <skip.plugin>false</skip.plugin>
-        <hudi.version>0.14.0</hudi.version>
+        <hudi.version>0.14.1</hudi.version>
         <hive-apache.version>3.1.2-13</hive-apache.version>
         <dlf-metastore-client.version>0.2.14</dlf-metastore-client.version>
         <sonar.organization>starrocks</sonar.organization>

--- a/java-extensions/hudi-reader/pom.xml
+++ b/java-extensions/hudi-reader/pom.xml
@@ -19,7 +19,7 @@
         <hive-apache.version>3.1.2-22</hive-apache.version>
         <parquet-hadoop.version>1.12.3</parquet-hadoop.version>
         <hadoop.version>3.3.6</hadoop.version>
-        <hudi.version>0.14.0</hudi.version>
+        <hudi.version>0.14.1</hudi.version>
         <airlift.version>0.25</airlift.version>
         <avro.version>1.11.3</avro.version>
         <luben.zstd.jni.version>1.5.4-2</luben.zstd.jni.version>


### PR DESCRIPTION
## Why I'm doing:
Hudi query support fix for Hudi 0.14.x
## What I'm doing:

Our Hudi is build from 0.14.0，but query mor table(thousands) would error out：
ERROR 1064 (HY000): Query starrocks exception, message:Failed to open the off-heap table scanner. java exception details: java.lang.ExceptionInInitializerError
 at java.base/java.lang.Class.forName0(Native Method)
 at java.base/java.lang.Class.forName(Class.java:467)
 at org.apache.avro.util.ClassUtils.forName(ClassUtils.java:95)
 at org.apache.avro.util.ClassUtils.forName(ClassUtils.java:72)
 at org.apache.avro.specific.SpecificData.lambda$getClass$2(SpecificData.java:259)
 at java.base/java.util.concurrent.ConcurrentHashMap

than change version from 0.14.0 to 0.14.1 is OK：
![mmexport1713499182189.jpg](https://github.com/StarRocks/starrocks/assets/10645422/af35961e-8d9b-452c-87a0-4a892c81d3af)




## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [x] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [x] 3.2
  - [x] 3.1
  - [ ] 3.0
  - [ ] 2.5
