### PR TITLE
[BugFix] Fix BE crashed after modify column type from varchar to decimal

### DIFF
--- a/be/src/storage/rowset/cast_column_iterator.h
+++ b/be/src/storage/rowset/cast_column_iterator.h
@@ -31,8 +31,8 @@ public:
     // REQUIRES:
     //  - |source_iter| cannot be NULL
     //  - |source_type| and |target_type| both are scalar type
-    explicit CastColumnIterator(std::unique_ptr<ColumnIterator> source_iter, LogicalType source_type,
-                                LogicalType target_type, bool nullable_source);
+    explicit CastColumnIterator(std::unique_ptr<ColumnIterator> source_iter, const TypeDescriptor& source_type,
+                                const TypeDescriptor& target_type, bool nullable_source);
 
     ~CastColumnIterator() override;
 

--- a/be/src/storage/rowset/segment.cpp
+++ b/be/src/storage/rowset/segment.cpp
@@ -397,13 +397,14 @@ StatusOr<std::unique_ptr<ColumnIterator>> Segment::new_column_iterator_or_defaul
                                                                                   ColumnAccessPath* path) {
     auto id = column.unique_id();
     if (_column_readers.contains(id)) {
-        auto source_type = _column_readers[id]->column_type();
-        auto target_type = column.type();
         ASSIGN_OR_RETURN(auto source_iter, _column_readers[id]->new_iterator(path));
-        if (source_type == target_type) {
+        if (_column_readers[id]->column_type() == column.type()) {
             return source_iter;
         } else {
             auto nullable = _column_readers[id]->is_nullable();
+            auto source_type = TypeDescriptor::from_logical_type(_column_readers[id]->column_type());
+            auto target_type = TypeDescriptor::from_logical_type(column.type(), column.length(), column.precision(),
+                                                                 column.scale());
             return std::make_unique<CastColumnIterator>(std::move(source_iter), source_type, target_type, nullable);
         }
     } else if (!column.has_default_value() && !column.is_nullable()) {

--- a/be/test/storage/rowset/cast_column_iterator_test.cpp
+++ b/be/test/storage/rowset/cast_column_iterator_test.cpp
@@ -30,10 +30,10 @@ class CastColumnIteratorTestBase : public ::testing::Test {};
 class CastColumnIteratorWithDefaultValueColumnIteratorTest : public CastColumnIteratorTestBase {};
 
 TEST_F(CastColumnIteratorWithDefaultValueColumnIteratorTest, test01) {
-    auto source_type = LogicalType::TYPE_INT;
-    auto target_type = LogicalType::TYPE_BIGINT;
+    auto source_type = TypeDescriptor::from_logical_type(LogicalType::TYPE_INT);
+    auto target_type = TypeDescriptor::from_logical_type(LogicalType::TYPE_BIGINT);
     auto source_iter =
-            std::make_unique<DefaultValueColumnIterator>(true, "NULL", true, get_type_info(source_type), 0, 2);
+            std::make_unique<DefaultValueColumnIterator>(true, "NULL", true, get_type_info(source_type.type), 0, 2);
     auto cast_iter = new CastColumnIterator(std::move(source_iter), source_type, target_type, true);
     DeferOp defer([&]() { delete cast_iter; });
     auto opts = ColumnIteratorOptions{};
@@ -50,10 +50,10 @@ TEST_F(CastColumnIteratorWithDefaultValueColumnIteratorTest, test01) {
 }
 
 TEST_F(CastColumnIteratorWithDefaultValueColumnIteratorTest, test02) {
-    auto source_type = LogicalType::TYPE_INT;
-    auto target_type = LogicalType::TYPE_BIGINT;
+    auto source_type = TypeDescriptor::from_logical_type(LogicalType::TYPE_INT);
+    auto target_type = TypeDescriptor::from_logical_type(LogicalType::TYPE_BIGINT);
     auto source_iter =
-            std::make_unique<DefaultValueColumnIterator>(true, "10", false, get_type_info(source_type), 0, 2);
+            std::make_unique<DefaultValueColumnIterator>(true, "10", false, get_type_info(source_type.type), 0, 2);
     auto cast_iter = new CastColumnIterator(std::move(source_iter), source_type, target_type, true);
     DeferOp defer([&]() { delete cast_iter; });
     auto opts = ColumnIteratorOptions{};
@@ -79,8 +79,8 @@ class CastColumnIteratorWithNumericTypeTest : public CastColumnIteratorTestBase,
                                               public ::testing::WithParamInterface<TestParameter> {};
 
 TEST_P(CastColumnIteratorWithNumericTypeTest, test) {
-    auto source_type = LogicalType::TYPE_SMALLINT;
-    auto target_type = LogicalType::TYPE_BIGINT;
+    auto source_type = TypeDescriptor::from_logical_type(LogicalType::TYPE_SMALLINT);
+    auto target_type = TypeDescriptor::from_logical_type(LogicalType::TYPE_BIGINT);
     auto source_iter = std::make_unique<SeriesColumnIterator<int16_t>>(0, 31);
     auto nullable_source = GetParam().nullable_source;
     auto cast_iter = new CastColumnIterator(std::move(source_iter), source_type, target_type, nullable_source);

--- a/be/test/storage/rowset/segment_test.cpp
+++ b/be/test/storage/rowset/segment_test.cpp
@@ -500,7 +500,6 @@ TEST_F(SegmentReaderWriterTest, TestTypeConversion) {
 
     auto file_size = uint64_t{0};
     auto index_size = uint64_t{0};
-    ;
     auto footer_position = uint64_t{0};
     ASSERT_OK(writer.finalize(&file_size, &index_size, &footer_position));
 

--- a/fe/fe-core/src/main/java/com/starrocks/alter/SchemaChangeHandler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/SchemaChangeHandler.java
@@ -644,7 +644,13 @@ public class SchemaChangeHandler extends AlterHandler {
             }
         } // end for handling other indices
 
-        if (modColumn.isKey() || !modColumn.getType().isScalarType()) {
+        // fast schema evolution supports the conversion of scalar types to decimal types, but does not support the conversion
+        // of decimal types to other scale types, due to the fact that the precision and scale of the decimal are not recorded
+        // in the segment file
+        if (modColumn.isKey() || !modColumn.getType().isScalarType()
+                || oriColumn.isKey()
+                || !oriColumn.getType().isScalarType()
+                || oriColumn.getType().isDecimalOfAnyVersion()) {
             fastSchemaEvolution = false;
         }
         return fastSchemaEvolution;


### PR DESCRIPTION
## Why I'm doing
Changing the column type from other to decimal or vice versa can lead to incorrect results or process crashes.

## What I'm doing
- Turn off fast schema evolution if the source type is DECIMAL when modifying column types.
- When modifying the column type, if the target type is DECIMAL, set the precision and scale correctly to ensure that the result is correct.

Fixes #44406 

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
