### PR TITLE
[Enhancement] adjust the BE and CN schedule policy

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/lake/qe/scheduler/DefaultSharedDataWorkerProvider.java
+++ b/fe/fe-core/src/main/java/com/starrocks/lake/qe/scheduler/DefaultSharedDataWorkerProvider.java
@@ -63,7 +63,9 @@ public class DefaultSharedDataWorkerProvider implements WorkerProvider {
         @Override
         public DefaultSharedDataWorkerProvider captureAvailableWorkers(SystemInfoService systemInfoService,
                                                                        boolean preferComputeNode,
-                                                                       int numUsedComputeNodes, long warehouseId) {
+                                                                       int numUsedComputeNodes,
+                                                                       String computationSragmentSchedulingPolicy,
+                                                                       long warehouseId) {
 
             ImmutableMap.Builder<Long, ComputeNode> builder = ImmutableMap.builder();
             List<Long> computeNodeIds =

--- a/fe/fe-core/src/main/java/com/starrocks/qe/CoordinatorPreprocessor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/CoordinatorPreprocessor.java
@@ -91,7 +91,8 @@ public class CoordinatorPreprocessor {
         SessionVariable sessionVariable = connectContext.getSessionVariable();
         this.workerProvider = workerProviderFactory.captureAvailableWorkers(
                 GlobalStateMgr.getCurrentState().getNodeMgr().getClusterInfo(),
-                sessionVariable.isPreferComputeNode(), sessionVariable.getUseComputeNodes(), jobSpec.getWarehouseId());
+                sessionVariable.isPreferComputeNode(), sessionVariable.getUseComputeNodes(),
+                sessionVariable.getComputationSragmentSchedulingPolicy(), jobSpec.getWarehouseId());
 
         this.fragmentAssignmentStrategyFactory = new FragmentAssignmentStrategyFactory(connectContext, jobSpec, executionDAG);
 
@@ -110,7 +111,7 @@ public class CoordinatorPreprocessor {
         this.workerProvider = workerProviderFactory.captureAvailableWorkers(
                 GlobalStateMgr.getCurrentState().getNodeMgr().getClusterInfo(),
                 sessionVariable.isPreferComputeNode(), sessionVariable.getUseComputeNodes(),
-                jobSpec.getWarehouseId());
+                sessionVariable.getComputationSragmentSchedulingPolicy(), jobSpec.getWarehouseId());
 
         Map<PlanFragmentId, PlanFragment> fragmentMap =
                 fragments.stream().collect(Collectors.toMap(PlanFragment::getFragmentId, Function.identity()));
@@ -208,7 +209,7 @@ public class CoordinatorPreprocessor {
         workerProvider = workerProviderFactory.captureAvailableWorkers(
                 GlobalStateMgr.getCurrentState().getNodeMgr().getClusterInfo(),
                 sessionVariable.isPreferComputeNode(), sessionVariable.getUseComputeNodes(),
-                jobSpec.getWarehouseId());
+                sessionVariable.getComputationSragmentSchedulingPolicy(), jobSpec.getWarehouseId());
 
         jobSpec.getFragments().forEach(PlanFragment::reset);
     }

--- a/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
@@ -98,6 +98,9 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
 
     public static final String USE_COMPUTE_NODES = "use_compute_nodes";
     public static final String PREFER_COMPUTE_NODE = "prefer_compute_node";
+    // The scheduler policy of backend and compute node.
+    // The optional values are "compute_nodes_only" and "all_nodes".
+    public static final String COMPUTATION_SRAGMENT_SCHEDULING_POLICY = "computation_sragment_scheduling_policy";
     public static final String EXEC_MEM_LIMIT = "exec_mem_limit";
 
     /**
@@ -782,6 +785,9 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
 
     @VariableMgr.VarAttr(name = PREFER_COMPUTE_NODE)
     private boolean preferComputeNode = false;
+
+    @VariableMgr.VarAttr(name = COMPUTATION_SRAGMENT_SCHEDULING_POLICY)
+    private String computationSragmentSchedulingPolicy = "compute_nodes_only";
 
     @VariableMgr.VarAttr(name = LOG_REJECTED_RECORD_NUM)
     private long logRejectedRecordNum = 0;
@@ -2171,6 +2177,14 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
 
     public void setPreferComputeNode(boolean preferComputeNode) {
         this.preferComputeNode = preferComputeNode;
+    }
+
+    public void setComputationSragmentSchedulingPolicy(String computationSragmentSchedulingPolicy) {
+        this.computationSragmentSchedulingPolicy = computationSragmentSchedulingPolicy;
+    }
+
+    public String getComputationSragmentSchedulingPolicy() {
+        return computationSragmentSchedulingPolicy;
     }
 
     public boolean enableHiveColumnStats() {

--- a/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
@@ -98,7 +98,7 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
 
     public static final String USE_COMPUTE_NODES = "use_compute_nodes";
     public static final String PREFER_COMPUTE_NODE = "prefer_compute_node";
-    // The scheduler policy of backend and compute node.
+    // The schedule policy of backend and compute node.
     // The optional values are "compute_nodes_only" and "all_nodes".
     public static final String COMPUTATION_SRAGMENT_SCHEDULING_POLICY = "computation_sragment_scheduling_policy";
     public static final String EXEC_MEM_LIMIT = "exec_mem_limit";

--- a/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/DefaultWorkerProvider.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/DefaultWorkerProvider.java
@@ -92,10 +92,11 @@ public class DefaultWorkerProvider implements WorkerProvider {
         public DefaultWorkerProvider captureAvailableWorkers(SystemInfoService systemInfoService,
                                                              boolean preferComputeNode,
                                                              int numUsedComputeNodes,
+                                                             String computationSragmentSchedulingPolicy,
                                                              long warehouseId) {
 
             ImmutableMap<Long, ComputeNode> idToComputeNode =
-                    buildComputeNodeInfo(systemInfoService, numUsedComputeNodes, warehouseId);
+                    buildComputeNodeInfo(systemInfoService, numUsedComputeNodes, computationSragmentSchedulingPolicy, warehouseId);
 
             ImmutableMap<Long, ComputeNode> idToBackend = ImmutableMap.copyOf(systemInfoService.getIdToBackend());
 
@@ -310,13 +311,25 @@ public class DefaultWorkerProvider implements WorkerProvider {
 
     private static ImmutableMap<Long, ComputeNode> buildComputeNodeInfo(SystemInfoService systemInfoService,
                                                                         int numUsedComputeNodes,
+                                                                        String computationSragmentSchedulingPolicy,
                                                                         long warehouseId) {
+        //define Node Pool
+        Map<Long, ComputeNode> computeNodes = new HashMap<>();
+
+        //add CN to Node Pool
         ImmutableMap<Long, ComputeNode> idToComputeNode
                 = ImmutableMap.copyOf(systemInfoService.getIdComputeNode());
         if (numUsedComputeNodes <= 0 || numUsedComputeNodes >= idToComputeNode.size()) {
-            return idToComputeNode;
+            for (int i = 0; i < idToComputeNode.size(); i++) {
+                ComputeNode computeNode =
+                        getNextWorker(idToComputeNode, DefaultWorkerProvider::getNextComputeNodeIndex);
+                Preconditions.checkNotNull(computeNode);
+                if (!isWorkerAvailable(computeNode)) {
+                    continue;
+                }
+                computeNodes.put(computeNode.getId(), computeNode);
+            }
         } else {
-            Map<Long, ComputeNode> computeNodes = new HashMap<>(numUsedComputeNodes);
             for (int i = 0; i < idToComputeNode.size() && computeNodes.size() < numUsedComputeNodes; i++) {
                 ComputeNode computeNode =
                         getNextWorker(idToComputeNode, DefaultWorkerProvider::getNextComputeNodeIndex);
@@ -326,8 +339,26 @@ public class DefaultWorkerProvider implements WorkerProvider {
                 }
                 computeNodes.put(computeNode.getId(), computeNode);
             }
-            return ImmutableMap.copyOf(computeNodes);
         }
+
+        //add BE to Node Pool
+        if (computationSragmentSchedulingPolicy.equals("all_nodes")) {
+            ImmutableMap<Long, ComputeNode> idToBackend
+                    = ImmutableMap.copyOf(systemInfoService.getIdToBackend());
+            for (int i = 0; i < idToBackend.size(); i++) {
+                ComputeNode backend =
+                        getNextWorker(idToBackend, DefaultWorkerProvider::getNextBackendIndex);
+                Preconditions.checkNotNull(backend);
+                if (!isWorkerAvailable(backend)) {
+                    continue;
+                }
+                computeNodes.put(backend.getId(), backend);
+            }
+        }
+
+        //return Node Pool
+        return ImmutableMap.copyOf(computeNodes);
+
     }
 
     private static <C extends ComputeNode> C getNextWorker(ImmutableMap<Long, C> workers,

--- a/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/WorkerProvider.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/WorkerProvider.java
@@ -36,10 +36,12 @@ public interface WorkerProvider {
          * @param systemInfoService   The service which provides all the backend nodes and compute nodes.
          * @param preferComputeNode   Whether to prefer using compute nodes over backend nodes.
          * @param numUsedComputeNodes The maximum number of used compute nodes.
+         * @param computationSragmentSchedulingPolicy The schedule policy of backend and compute nodes.
          */
         WorkerProvider captureAvailableWorkers(SystemInfoService systemInfoService,
                                                boolean preferComputeNode,
                                                int numUsedComputeNodes,
+                                               String computationSragmentSchedulingPolicy,
                                                long warehouseId);
     }
 
@@ -53,6 +55,7 @@ public interface WorkerProvider {
 
     /**
      * Select the worker with the given id.
+     *
      * @param workerId The id of the worker to choose.
      * @throws NonRecoverableException if there is no available worker with the given id.
      */

--- a/fe/fe-core/src/test/java/com/starrocks/lake/qe/scheduler/DefaultSharedDataWorkerProviderTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/lake/qe/scheduler/DefaultSharedDataWorkerProviderTest.java
@@ -131,7 +131,7 @@ public class DefaultSharedDataWorkerProviderTest {
     private WorkerProvider newWorkerProvider() {
         return factory.captureAvailableWorkers(
                 GlobalStateMgr.getCurrentState().getNodeMgr().getClusterInfo(), true,
-                -1, WarehouseManager.DEFAULT_WAREHOUSE_ID);
+                -1, "all_nodes", WarehouseManager.DEFAULT_WAREHOUSE_ID);
     }
 
     private static void testUsingWorkerHelper(WorkerProvider workerProvider, Long workerId) {


### PR DESCRIPTION
Why I'm doing:
In shared nothing mode，when deploy both BE and CN，and set prefer_compute_node=true，current BE and CN schedule policy is not very feel perfect:
1)when query internal table ，except scan fragment allocate to BE，other calculate fragment would allocate to CN
2)when query external table ，all fragment would allocate to CN

In some scenarios, like when sudden business peak, need temporarily add CN to increase computational resources, current BE and CN schedule policy would cause BE nodes have low resource usage ratio，CN nodes have high resource usage ratio，especially when business type belongs to computational tasks.

What I'm doing:
Add a new session variable computation_sragment_scheduling_policy, the value as follows:
1)compute_nodes_only：the previous policy, as the default value
2)all_nodes： 
  a.when query internal table ，scan fragment allocate to BE，other calculate fragment would allocate to both BE and CN
  b.when query external table ，all fragment would allocate to both BE and CN

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [x] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.3
  - [x] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
