### PR TITLE
[BugFix] Detect and handle incorrect schema id in BE

### DIFF
--- a/be/src/exec/tablet_info.cpp
+++ b/be/src/exec/tablet_info.cpp
@@ -114,7 +114,8 @@ Status OlapTableSchemaParam::init(const POlapTableSchemaParam& pschema) {
             col_param->short_key_column_count = p_index.column_param().short_key_column_count();
             index->column_param = col_param;
         }
-        if (p_index.has_schema_id()) {
+        if (p_index.has_schema_id() && p_index.schema_id() > 0) {
+            //                         ^^^^^^^^^^^^^^^^^^^^^^^ Older version FE may incorrectly set the schema id to 0
             index->schema_id = p_index.schema_id();
         } else {
             index->schema_id = p_index.id();


### PR DESCRIPTION
## Why I'm doing
The problem of incorrect schema id in FE is fixed in #44372, and the schema id can be restored to the correct value after FE upgrade. However, during the cluster upgrade process, the schema id received by the BE may still be incorrect because the FE has not been upgraded at that time. 

## What I'm doing
Handle incorrect schema ids in the BE process to avoid "schema_id not set" import errors during upgrades.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
