### PR TITLE
[BugFix] fix background refresh hive meta cache when disable hive meta cache

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/connector/hive/CacheUpdateProcessor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/hive/CacheUpdateProcessor.java
@@ -19,6 +19,7 @@ import com.google.common.base.Objects;
 import com.google.common.base.Strings;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
+import com.google.common.collect.Sets;
 import com.starrocks.catalog.Column;
 import com.starrocks.catalog.HiveMetaStoreTable;
 import com.starrocks.catalog.HiveTable;
@@ -134,7 +135,11 @@ public class CacheUpdateProcessor {
     }
 
     public Set<HiveTableName> getCachedTableNames() {
-        return ((CachingHiveMetastore) metastore).getCachedTableNames();
+        if (metastore instanceof CachingHiveMetastore) {
+            return ((CachingHiveMetastore) metastore).getCachedTableNames();
+        } else {
+            return Sets.newHashSet();
+        }
     }
 
     private Map<BasePartitionInfo, Partition> getUpdatedPartitions(HiveMetaStoreTable table,

--- a/fe/fe-core/src/test/java/com/starrocks/connector/hive/CachingHiveMetastoreTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/hive/CachingHiveMetastoreTest.java
@@ -450,4 +450,16 @@ public class CachingHiveMetastoreTest {
             cachingHiveMetastore.addPartitions("db", "table", Lists.newArrayList(hivePartitionWithStats));
         });
     }
+
+    @Test
+    public void testGetCachedName() {
+        CachingHiveMetastore cachingHiveMetastore = new CachingHiveMetastore(
+                metastore, executor, expireAfterWriteSec, refreshAfterWriteSec, 1000, false);
+        CacheUpdateProcessor processor = new CacheUpdateProcessor(
+                "hive_catalog", cachingHiveMetastore, null, null, false, false);
+        Assert.assertTrue(processor.getCachedTableNames().isEmpty());
+
+        processor = new CacheUpdateProcessor("hive_catalog", metastore, null, null, false, false);
+        Assert.assertTrue(processor.getCachedTableNames().isEmpty());
+    }
 }


### PR DESCRIPTION


## Why I'm doing:

## What I'm doing:
If catalog disable hive meta cache, the background refresh task will throw an exception.

java.lang.ClassCastException: class com.starrocks.connector.hive.HiveMetastore cannot be cast to class com.starrocks.connector.hive.CachingHiveMetastore (com.starrocks.connector.hive.HiveMetastore and com.starrocks.connector.hive.CachingHiveMetastore are in unnamed module of loader 'app')
        at com.starrocks.connector.hive.CacheUpdateProcessor.getCachedTableNames(CacheUpdateProcessor.java:137) ~[starrocks-fe.jar:?]
        at com.starrocks.connector.hive.ConnectorTableMetadataProcessor.refreshCatalogTable(ConnectorTableMetadataProcessor.java:106) ~[starrocks-fe.jar:?]
        at com.starrocks.connector.hive.ConnectorTableMetadataProcessor.runAfterCatalogReady(ConnectorTableMetadataProcessor.java:91) ~[starrocks-fe.jar:?]
        at com.starrocks.common.util.FrontendDaemon.runOneCycle(FrontendDaemon.java:72) ~[starrocks-fe.jar:?]
        at com.starrocks.common.util.Daemon.run(Daemon.java:107) ~[starrocks-fe.jar:?]
Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
