### PR TITLE
[Refactor] refactor cloud native pk index's IndexValueWithVerPB

### DIFF
--- a/be/src/storage/lake/lake_persistent_index.cpp
+++ b/be/src/storage/lake/lake_persistent_index.cpp
@@ -23,6 +23,7 @@
 #include "storage/lake/rowset.h"
 #include "storage/lake/tablet_manager.h"
 #include "storage/lake/update_manager.h"
+#include "storage/lake/utils.h"
 #include "storage/primary_key_encoder.h"
 #include "storage/sstable/iterator.h"
 #include "storage/sstable/merger.h"
@@ -36,15 +37,12 @@ Status KeyValueMerger::merge(const std::string& key, const std::string& value) {
     if (!index_value_ver.ParseFromString(value)) {
         return Status::InternalError("Failed to parse index value ver");
     }
-    if (index_value_ver.versions_size() != index_value_ver.values_size()) {
-        return Status::InternalError("The size of version and the size of value are not equal");
-    }
-    if (index_value_ver.versions_size() == 0) {
+    if (index_value_ver.items_size() == 0) {
         return Status::OK();
     }
 
-    auto version = index_value_ver.versions(0);
-    auto index_value = index_value_ver.values(0);
+    auto version = index_value_ver.items(0).version();
+    auto index_value = build_index_value(index_value_ver.items(0));
     if (_key == key) {
         if (_index_value_vers.empty()) {
             _index_value_vers.emplace_front(version, index_value);
@@ -68,8 +66,10 @@ void KeyValueMerger::flush() {
 
     IndexValueWithVerPB index_value_pb;
     for (const auto& index_value_with_ver : _index_value_vers) {
-        index_value_pb.add_versions(index_value_with_ver.first);
-        index_value_pb.add_values(index_value_with_ver.second.get_value());
+        auto* item = index_value_pb.add_items();
+        item->set_version(index_value_with_ver.first);
+        item->set_rssid(index_value_with_ver.second.get_rssid());
+        item->set_rowid(index_value_with_ver.second.get_rowid());
     }
     _builder->Add(Slice(_key), Slice(index_value_pb.SerializeAsString()));
     _index_value_vers.clear();

--- a/be/src/storage/lake/persistent_index_sstable.cpp
+++ b/be/src/storage/lake/persistent_index_sstable.cpp
@@ -17,6 +17,7 @@
 #include <butil/time.h> // NOLINT
 
 #include "fs/fs.h"
+#include "storage/lake/utils.h"
 #include "storage/sstable/table_builder.h"
 #include "util/trace.h"
 
@@ -49,8 +50,10 @@ Status PersistentIndexSstable::build_sstable(
     for (const auto& [k, v] : map) {
         IndexValueWithVerPB index_value_pb;
         for (const auto& index_value_with_ver : v) {
-            index_value_pb.add_versions(index_value_with_ver.first);
-            index_value_pb.add_values(index_value_with_ver.second.get_value());
+            auto* item = index_value_pb.add_items();
+            item->set_version(index_value_with_ver.first);
+            item->set_rssid(index_value_with_ver.second.get_rssid());
+            item->set_rowid(index_value_with_ver.second.get_rowid());
         }
         builder.Add(Slice(k), Slice(index_value_pb.SerializeAsString()));
     }
@@ -79,15 +82,17 @@ Status PersistentIndexSstable::multi_get(const Slice* keys, const KeyIndexSet& k
         if (!index_value_with_ver_pb.ParseFromString(index_value_with_vers[i])) {
             return Status::InternalError("parse index value info failed");
         }
-        if (version < 0 && index_value_with_ver_pb.values_size() > 0) {
-            values[key_index] = IndexValue(index_value_with_ver_pb.values(0));
-            found_key_indexes->insert(key_index);
-        } else {
-            for (size_t j = 0; j < index_value_with_ver_pb.versions_size(); ++j) {
-                if (index_value_with_ver_pb.versions(j) == version) {
-                    values[key_index] = IndexValue(index_value_with_ver_pb.values(j));
-                    found_key_indexes->insert(key_index);
-                    break;
+        if (index_value_with_ver_pb.items_size() > 0) {
+            if (version < 0) {
+                values[key_index] = build_index_value(index_value_with_ver_pb.items(0));
+                found_key_indexes->insert(key_index);
+            } else {
+                for (size_t j = 0; j < index_value_with_ver_pb.items_size(); ++j) {
+                    if (index_value_with_ver_pb.items(j).version() == version) {
+                        values[key_index] = build_index_value(index_value_with_ver_pb.items(j));
+                        found_key_indexes->insert(key_index);
+                        break;
+                    }
                 }
             }
         }

--- a/be/src/storage/lake/utils.h
+++ b/be/src/storage/lake/utils.h
@@ -43,8 +43,8 @@ inline StatusOr<T> enhance_error_prompt(StatusOr<T> res) {
     }
 }
 
-inline IndexValue build_index_value(const IndexValueWithVerItemPB& item) {
-    return IndexValue(((uint64_t)item.rssid() << 32 | item.rowid()));
+inline IndexValue build_index_value(const IndexValueWithVerPB& value) {
+    return IndexValue(((uint64_t)value.rssid() << 32 | value.rowid()));
 }
 
 } // namespace starrocks::lake

--- a/be/src/storage/lake/utils.h
+++ b/be/src/storage/lake/utils.h
@@ -15,6 +15,7 @@
 #pragma once
 
 #include "common/statusor.h"
+#include "storage/persistent_index.h"
 
 namespace starrocks::lake {
 
@@ -40,6 +41,10 @@ inline StatusOr<T> enhance_error_prompt(StatusOr<T> res) {
     } else {
         return res.status().clone_and_append(kNotFoundPrompt);
     }
+}
+
+inline IndexValue build_index_value(const IndexValueWithVerItemPB& item) {
+    return IndexValue(((uint64_t)item.rssid() << 32 | item.rowid()));
 }
 
 } // namespace starrocks::lake

--- a/be/src/storage/persistent_index.h
+++ b/be/src/storage/persistent_index.h
@@ -114,6 +114,8 @@ struct IndexValue {
     explicit IndexValue(const uint64_t val) { UNALIGNED_STORE64(v, val); }
 
     uint64_t get_value() const { return UNALIGNED_LOAD64(v); }
+    uint32_t get_rssid() const { return (uint32_t)(get_value() >> 32); }
+    uint32_t get_rowid() const { return (uint32_t)(get_value() & 0xFFFFFFFF); }
     bool operator==(const IndexValue& rhs) const { return memcmp(v, rhs.v, 8) == 0; }
     void operator=(uint64_t rhs) { return UNALIGNED_STORE64(v, rhs); }
 };

--- a/be/test/storage/lake/persistent_index_sstable_test.cpp
+++ b/be/test/storage/lake/persistent_index_sstable_test.cpp
@@ -369,10 +369,10 @@ TEST_F(PersistentIndexSstableTest, test_persistent_index_sstable) {
         int i = 0;
         for (; iter->Valid(); iter->Next()) {
             ASSERT_EQ(iter->key().to_string(), fmt::format("test_key_{:016X}", i));
-            IndexValueWithVerPB index_value_with_ver_pb;
+            IndexValuesWithVerPB index_value_with_ver_pb;
             ASSERT_TRUE(index_value_with_ver_pb.ParseFromArray(iter->value().data, iter->value().size));
-            ASSERT_EQ(index_value_with_ver_pb.items(0).version(), 100);
-            ASSERT_EQ(index_value_with_ver_pb.items(0).rowid(), i);
+            ASSERT_EQ(index_value_with_ver_pb.values(0).version(), 100);
+            ASSERT_EQ(index_value_with_ver_pb.values(0).rowid(), i);
             i++;
         }
         ASSERT_OK(iter->status());
@@ -387,10 +387,10 @@ TEST_F(PersistentIndexSstableTest, test_persistent_index_sstable) {
         int i = N - 1;
         for (; iter->Valid(); iter->Prev()) {
             ASSERT_EQ(iter->key().to_string(), fmt::format("test_key_{:016X}", i));
-            IndexValueWithVerPB index_value_with_ver_pb;
+            IndexValuesWithVerPB index_value_with_ver_pb;
             ASSERT_TRUE(index_value_with_ver_pb.ParseFromArray(iter->value().data, iter->value().size));
-            ASSERT_EQ(index_value_with_ver_pb.items(0).version(), 100);
-            ASSERT_EQ(index_value_with_ver_pb.items(0).rowid(), i);
+            ASSERT_EQ(index_value_with_ver_pb.values(0).version(), 100);
+            ASSERT_EQ(index_value_with_ver_pb.values(0).rowid(), i);
             i--;
         }
         ASSERT_OK(iter->status());
@@ -408,10 +408,10 @@ TEST_F(PersistentIndexSstableTest, test_persistent_index_sstable) {
             iter->Seek(fmt::format("test_key_{:016X}", r));
             if (r < N) {
                 ASSERT_EQ(iter->key().to_string(), fmt::format("test_key_{:016X}", r));
-                IndexValueWithVerPB index_value_with_ver_pb;
+                IndexValuesWithVerPB index_value_with_ver_pb;
                 ASSERT_TRUE(index_value_with_ver_pb.ParseFromArray(iter->value().data, iter->value().size));
-                ASSERT_EQ(index_value_with_ver_pb.items(0).version(), 100);
-                ASSERT_EQ(index_value_with_ver_pb.items(0).rowid(), r);
+                ASSERT_EQ(index_value_with_ver_pb.values(0).version(), 100);
+                ASSERT_EQ(index_value_with_ver_pb.values(0).rowid(), r);
             } else {
                 ASSERT_FALSE(iter->Valid());
             }
@@ -421,17 +421,17 @@ TEST_F(PersistentIndexSstableTest, test_persistent_index_sstable) {
 }
 
 TEST_F(PersistentIndexSstableTest, test_index_value_protobuf) {
-    IndexValueWithVerPB index_value_pb;
+    IndexValuesWithVerPB index_value_pb;
     for (int i = 0; i < 10; i++) {
-        auto* item = index_value_pb.add_items();
-        item->set_version(i);
-        item->set_rssid(i * 10 + i);
-        item->set_rowid(i * 20 + i);
+        auto* value = index_value_pb.add_values();
+        value->set_version(i);
+        value->set_rssid(i * 10 + i);
+        value->set_rowid(i * 20 + i);
     }
     for (int i = 0; i < 10; i++) {
-        const auto& item = index_value_pb.items(i);
-        ASSERT_EQ(item.version(), i);
-        IndexValue val = build_index_value(item);
+        const auto& value = index_value_pb.values(i);
+        ASSERT_EQ(value.version(), i);
+        IndexValue val = build_index_value(value);
         ASSERT_TRUE(val == IndexValue(((uint64_t)(i * 10 + i) << 32) | (i * 20 + i)));
     }
 }

--- a/gensrc/proto/types.proto
+++ b/gensrc/proto/types.proto
@@ -171,7 +171,7 @@ message IsNullPredicatePB {
     optional bool is_not_null = 2;
 }
 
-message IndexValueWithVerItemPB {
+message IndexValueWithVerPB {
     // will be set after mvcc support
     optional int64 version = 1;
     // rowset id & segment id
@@ -179,8 +179,8 @@ message IndexValueWithVerItemPB {
     optional uint32 rowid = 3;
 }
 
-message IndexValueWithVerPB {
-    repeated IndexValueWithVerItemPB items = 1;
+message IndexValuesWithVerPB {
+    repeated IndexValueWithVerPB values = 1;
 }
 
 message PersistentIndexSstablePB {

--- a/gensrc/proto/types.proto
+++ b/gensrc/proto/types.proto
@@ -171,9 +171,16 @@ message IsNullPredicatePB {
     optional bool is_not_null = 2;
 }
 
+message IndexValueWithVerItemPB {
+    // will be set after mvcc support
+    optional int64 version = 1;
+    // rowset id & segment id
+    optional uint32 rssid = 2;
+    optional uint32 rowid = 3;
+}
+
 message IndexValueWithVerPB {
-    repeated int64 versions = 1;
-    repeated uint64 values = 2;
+    repeated IndexValueWithVerItemPB items = 1;
 }
 
 message PersistentIndexSstablePB {


### PR DESCRIPTION
## Why I'm doing:
Field `values` in `IndexValueWithVerPB` contains two parts: 1) rowset id & segment id (short as `rssid`) 2) `rowid`. And in the future, we will support bulk load optimization. In this case, we don't need to set the `rssid` in `IndexValueWithVerPB`. 

## What I'm doing:
Splitting values into two parts (`rssid` and `rowid`) allows us to optimize the storage space by only use the `rowid` in some cases.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [x] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [x] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
