### PR TITLE
[BugFix] Fix bug which cause LakePersistentIndex will recover all the rowsets

### DIFF
--- a/be/src/storage/lake/lake_persistent_index.cpp
+++ b/be/src/storage/lake/lake_persistent_index.cpp
@@ -131,7 +131,7 @@ Status LakePersistentIndex::minor_compact() {
     PersistentIndexSstablePB sstable_pb;
     sstable_pb.set_filename(filename);
     sstable_pb.set_filesize(filesize);
-    sstable_pb.set_version(_version.major_number());
+    sstable_pb.set_version(_immutable_memtable->max_version());
     auto* block_cache = _tablet_mgr->update_mgr()->block_cache();
     if (block_cache == nullptr) {
         return Status::InternalError("Block cache is null.");
@@ -139,13 +139,14 @@ Status LakePersistentIndex::minor_compact() {
     RETURN_IF_ERROR(sstable->init(std::move(rf), sstable_pb, block_cache->cache()));
     _sstables.emplace_back(std::move(sstable));
     TRACE_COUNTER_INCREMENT("minor_compact_times", 1);
-    TRACE_COUNTER_INCREMENT("minor_compact_latency_us", 1000 * watch.elapsed_time());
+    TRACE_COUNTER_INCREMENT("minor_compact_latency_us", watch.elapsed_time() / 1000);
     return Status::OK();
 }
 
 Status LakePersistentIndex::flush_memtable() {
     if (_immutable_memtable != nullptr) {
         RETURN_IF_ERROR(minor_compact());
+        _immutable_memtable->reset_max_version();
     }
     _immutable_memtable = std::make_unique<PersistentIndexMemtable>();
     _memtable.swap(_immutable_memtable);
@@ -207,6 +208,7 @@ Status LakePersistentIndex::upsert(size_t n, const Slice* keys, const IndexValue
 }
 
 Status LakePersistentIndex::insert(size_t n, const Slice* keys, const IndexValue* values, int64_t version) {
+    TRACE_COUNTER_SCOPE_LATENCY_US("lake_persistent_index_insert_us");
     RETURN_IF_ERROR(_memtable->insert(n, keys, values, version));
     if (is_memtable_full()) {
         RETURN_IF_ERROR(flush_memtable());
@@ -363,20 +365,24 @@ Status LakePersistentIndex::apply_opcompaction(const TxnLogPB_OpCompaction& op_c
                                        return filenames.contains(sstable->sstable_pb().filename());
                                    }),
                     _sstables.end());
-    if (!_sstables.empty()) {
-        DCHECK(sstable_pb.version() <= _sstables[0]->sstable_pb().version());
-    }
     _sstables.insert(_sstables.begin(), std::move(sstable));
     return Status::OK();
 }
 
-void LakePersistentIndex::commit(MetaFileBuilder* builder) {
+Status LakePersistentIndex::commit(MetaFileBuilder* builder) {
     PersistentIndexSstableMetaPB sstable_meta;
+    int64_t last_version = 0;
     for (auto& sstable : _sstables) {
+        int64_t sstable_version = sstable->sstable_pb().version();
+        if (last_version > sstable_version) {
+            return Status::InternalError("Versions of sstables are not ordered");
+        }
+        last_version = sstable_version;
         auto* sstable_pb = sstable_meta.add_sstables();
         sstable_pb->CopyFrom(sstable->sstable_pb());
     }
     builder->finalize_sstable_meta(sstable_meta);
+    return Status::OK();
 }
 
 Status LakePersistentIndex::load_from_lake_tablet(TabletManager* tablet_mgr, const TabletMetadataPtr& metadata,
@@ -398,6 +404,7 @@ Status LakePersistentIndex::load_from_lake_tablet(TabletManager* tablet_mgr, con
         return Status::OK();
     }
     TRACE_COUNTER_INCREMENT("max_sstable_version", max_sstable_version);
+    TRACE_COUNTER_INCREMENT("new_version", metadata->version());
 
     OlapReaderStatistics stats;
     std::unique_ptr<Column> pk_column;
@@ -416,7 +423,8 @@ Status LakePersistentIndex::load_from_lake_tablet(TabletManager* tablet_mgr, con
     for (auto& rowset : rowsets) {
         TRACE_COUNTER_INCREMENT("total_rowsets", 1);
         TRACE_COUNTER_INCREMENT("total_segments", rowset->num_segments());
-        TRACE_COUNTER_INCREMENT("total_datasize", rowset->data_size());
+        TRACE_COUNTER_INCREMENT("total_datasize_bytes", rowset->data_size());
+        TRACE_COUNTER_INCREMENT("total_num_rows", rowset->num_rows());
         // If it is upgraded from old version of sr, the rowset version will be not set.
         // The generated rowset version will be treated as base_version.
         int64_t rowset_version = rowset->version() != 0 ? rowset->version() : base_version;
@@ -482,7 +490,8 @@ Status LakePersistentIndex::load_from_lake_tablet(TabletManager* tablet_mgr, con
         }
         TRACE_COUNTER_INCREMENT("loaded_rowsets", 1);
         TRACE_COUNTER_INCREMENT("loaded_segments", rowset->num_segments());
-        TRACE_COUNTER_INCREMENT("loaded_datasize", rowset->data_size());
+        TRACE_COUNTER_INCREMENT("loaded_datasize_bytes", rowset->data_size());
+        TRACE_COUNTER_INCREMENT("loaded_num_rows", rowset->num_rows());
     }
     return Status::OK();
 }

--- a/be/src/storage/lake/lake_persistent_index.h
+++ b/be/src/storage/lake/lake_persistent_index.h
@@ -110,7 +110,7 @@ public:
 
     Status apply_opcompaction(const TxnLogPB_OpCompaction& op_compaction);
 
-    void commit(MetaFileBuilder* builder);
+    Status commit(MetaFileBuilder* builder);
 
     Status load_from_lake_tablet(TabletManager* tablet_mgr, const TabletMetadataPtr& metadata, int64_t base_version,
                                  const MetaFileBuilder* builder);

--- a/be/src/storage/lake/lake_primary_index.cpp
+++ b/be/src/storage/lake/lake_primary_index.cpp
@@ -223,8 +223,7 @@ Status LakePrimaryIndex::commit(const TabletMetadataPtr& metadata, MetaFileBuild
     case PersistentIndexTypePB::CLOUD_NATIVE: {
         auto* lake_persistent_index = dynamic_cast<LakePersistentIndex*>(_persistent_index.get());
         if (lake_persistent_index != nullptr) {
-            lake_persistent_index->commit(builder);
-            return Status::OK();
+            return lake_persistent_index->commit(builder);
         } else {
             return Status::InternalError("Persistent index is not a LakePersistentIndex.");
         }

--- a/be/src/storage/lake/persistent_index_memtable.h
+++ b/be/src/storage/lake/persistent_index_memtable.h
@@ -58,6 +58,10 @@ public:
 
     void clear();
 
+    const int64_t max_version() const { return _max_version; }
+
+    void reset_max_version() { _max_version = 0; }
+
 private:
     static void update_index_value(std::list<IndexValueWithVer>* index_value_info, int64_t version,
                                    const IndexValue& value);
@@ -65,6 +69,7 @@ private:
 private:
     // The size can be up to 230K. The performance of std::map may be poor.
     phmap::btree_map<std::string, std::list<IndexValueWithVer>, std::less<>> _map;
+    int64_t _max_version{0};
 };
 
 } // namespace starrocks::lake

--- a/be/src/storage/lake/persistent_index_memtable.h
+++ b/be/src/storage/lake/persistent_index_memtable.h
@@ -60,8 +60,6 @@ public:
 
     const int64_t max_version() const { return _max_version; }
 
-    void reset_max_version() { _max_version = 0; }
-
 private:
     static void update_index_value(std::list<IndexValueWithVer>* index_value_info, int64_t version,
                                    const IndexValue& value);

--- a/be/test/storage/lake/partial_update_test.cpp
+++ b/be/test/storage/lake/partial_update_test.cpp
@@ -665,6 +665,13 @@ TEST_P(LakePartialUpdateTest, test_write_with_index_reload) {
     if (GetParam().enable_persistent_index && GetParam().persistent_index_type == PersistentIndexTypePB::LOCAL) {
         check_local_persistent_index_meta(tablet_id, version);
     }
+    if (GetParam().enable_persistent_index && GetParam().persistent_index_type == PersistentIndexTypePB::CLOUD_NATIVE) {
+        auto sstable_meta = new_tablet_metadata->sstable_meta();
+        for (auto& sstable : sstable_meta.sstables()) {
+            EXPECT_GT(sstable.version(), 0);
+            EXPECT_LE(sstable.version(), version);
+        }
+    }
 }
 
 TEST_P(LakePartialUpdateTest, test_partial_update_publish_retry) {

--- a/be/test/storage/lake/primary_key_publish_test.cpp
+++ b/be/test/storage/lake/primary_key_publish_test.cpp
@@ -660,6 +660,13 @@ TEST_P(LakePrimaryKeyPublishTest, test_write_rebuild_persistent_index) {
     if (GetParam().enable_persistent_index && GetParam().persistent_index_type == PersistentIndexTypePB::LOCAL) {
         check_local_persistent_index_meta(tablet_id, version);
     }
+    if (GetParam().enable_persistent_index && GetParam().persistent_index_type == PersistentIndexTypePB::CLOUD_NATIVE) {
+        auto sstable_meta = new_tablet_metadata->sstable_meta();
+        for (auto& sstable : sstable_meta.sstables()) {
+            EXPECT_GT(sstable.version(), 0);
+            EXPECT_LE(sstable.version(), version);
+        }
+    }
     config::l0_max_mem_usage = l0_max_mem_usage;
 }
 


### PR DESCRIPTION
## Why I'm doing:
If `LakePersistentIndex` is recovered once and sstables are created in `insert`, the created sstable's version will be 0. If `LakePersistentIndex` is recovered again, it will needd to recover all the rowsets.
## What I'm doing:
1. Maintain `max_version` in memtable
2. Set `max_version` in the sstable to be flushed
3. Add more trace in recover to help us know the time cost

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
