### PR TITLE
[Enhancement] adjust the BE and CN schedule policy

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/lake/qe/scheduler/DefaultSharedDataWorkerProvider.java
+++ b/fe/fe-core/src/main/java/com/starrocks/lake/qe/scheduler/DefaultSharedDataWorkerProvider.java
@@ -63,7 +63,9 @@ public class DefaultSharedDataWorkerProvider implements WorkerProvider {
         @Override
         public DefaultSharedDataWorkerProvider captureAvailableWorkers(SystemInfoService systemInfoService,
                                                                        boolean preferComputeNode,
-                                                                       int numUsedComputeNodes, long warehouseId) {
+                                                                       int numUsedComputeNodes,
+                                                                       String computationFragmentSchedulingPolicy,
+                                                                       long warehouseId) {
 
             ImmutableMap.Builder<Long, ComputeNode> builder = ImmutableMap.builder();
             List<Long> computeNodeIds =

--- a/fe/fe-core/src/main/java/com/starrocks/lake/qe/scheduler/DefaultSharedDataWorkerProvider.java
+++ b/fe/fe-core/src/main/java/com/starrocks/lake/qe/scheduler/DefaultSharedDataWorkerProvider.java
@@ -21,6 +21,7 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
 import com.starrocks.common.FeConstants;
+import com.starrocks.qe.SessionVariable.ComputationFragmentSchedulingPolicy;
 import com.starrocks.qe.SimpleScheduler;
 import com.starrocks.qe.scheduler.NonRecoverableException;
 import com.starrocks.qe.scheduler.WorkerProvider;
@@ -62,10 +63,10 @@ public class DefaultSharedDataWorkerProvider implements WorkerProvider {
     public static class Factory implements WorkerProvider.Factory {
         @Override
         public DefaultSharedDataWorkerProvider captureAvailableWorkers(SystemInfoService systemInfoService,
-                                                                       boolean preferComputeNode,
-                                                                       int numUsedComputeNodes,
-                                                                       String computationFragmentSchedulingPolicy,
-                                                                       long warehouseId) {
+                                               boolean preferComputeNode,
+                                               int numUsedComputeNodes,
+                                               ComputationFragmentSchedulingPolicy computationFragmentSchedulingPolicy,
+                                               long warehouseId) {
 
             ImmutableMap.Builder<Long, ComputeNode> builder = ImmutableMap.builder();
             List<Long> computeNodeIds =

--- a/fe/fe-core/src/main/java/com/starrocks/lake/qe/scheduler/DefaultSharedDataWorkerProvider.java
+++ b/fe/fe-core/src/main/java/com/starrocks/lake/qe/scheduler/DefaultSharedDataWorkerProvider.java
@@ -21,7 +21,7 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
 import com.starrocks.common.FeConstants;
-import com.starrocks.qe.SessionVariable.ComputationFragmentSchedulingPolicy;
+import com.starrocks.qe.SessionVariableConstants.ComputationFragmentSchedulingPolicy;
 import com.starrocks.qe.SimpleScheduler;
 import com.starrocks.qe.scheduler.NonRecoverableException;
 import com.starrocks.qe.scheduler.WorkerProvider;

--- a/fe/fe-core/src/main/java/com/starrocks/qe/CoordinatorPreprocessor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/CoordinatorPreprocessor.java
@@ -91,7 +91,8 @@ public class CoordinatorPreprocessor {
         SessionVariable sessionVariable = connectContext.getSessionVariable();
         this.workerProvider = workerProviderFactory.captureAvailableWorkers(
                 GlobalStateMgr.getCurrentState().getNodeMgr().getClusterInfo(),
-                sessionVariable.isPreferComputeNode(), sessionVariable.getUseComputeNodes(), jobSpec.getWarehouseId());
+                sessionVariable.isPreferComputeNode(), sessionVariable.getUseComputeNodes(),
+                sessionVariable.getComputationFragmentSchedulingPolicy(), jobSpec.getWarehouseId());
 
         this.fragmentAssignmentStrategyFactory = new FragmentAssignmentStrategyFactory(connectContext, jobSpec, executionDAG);
 
@@ -110,7 +111,7 @@ public class CoordinatorPreprocessor {
         this.workerProvider = workerProviderFactory.captureAvailableWorkers(
                 GlobalStateMgr.getCurrentState().getNodeMgr().getClusterInfo(),
                 sessionVariable.isPreferComputeNode(), sessionVariable.getUseComputeNodes(),
-                jobSpec.getWarehouseId());
+                sessionVariable.getComputationFragmentSchedulingPolicy(), jobSpec.getWarehouseId());
 
         Map<PlanFragmentId, PlanFragment> fragmentMap =
                 fragments.stream().collect(Collectors.toMap(PlanFragment::getFragmentId, Function.identity()));
@@ -208,7 +209,7 @@ public class CoordinatorPreprocessor {
         workerProvider = workerProviderFactory.captureAvailableWorkers(
                 GlobalStateMgr.getCurrentState().getNodeMgr().getClusterInfo(),
                 sessionVariable.isPreferComputeNode(), sessionVariable.getUseComputeNodes(),
-                jobSpec.getWarehouseId());
+                sessionVariable.getComputationFragmentSchedulingPolicy(), jobSpec.getWarehouseId());
 
         jobSpec.getFragments().forEach(PlanFragment::reset);
     }

--- a/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
@@ -98,6 +98,9 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
 
     public static final String USE_COMPUTE_NODES = "use_compute_nodes";
     public static final String PREFER_COMPUTE_NODE = "prefer_compute_node";
+    // The schedule policy of backend and compute nodes.
+    // The optional values are "compute_nodes_only" and "all_nodes".
+    public static final String COMPUTATION_FRAGMENT_SCHEDULING_POLICY = "computation_fragment_scheduling_policy";
     public static final String EXEC_MEM_LIMIT = "exec_mem_limit";
 
     /**
@@ -780,6 +783,9 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
 
     @VariableMgr.VarAttr(name = PREFER_COMPUTE_NODE)
     private boolean preferComputeNode = false;
+
+    @VariableMgr.VarAttr(name = COMPUTATION_FRAGMENT_SCHEDULING_POLICY)
+    private String computationFragmentSchedulingPolicy = "compute_nodes_only";
 
     @VariableMgr.VarAttr(name = LOG_REJECTED_RECORD_NUM)
     private long logRejectedRecordNum = 0;
@@ -1935,7 +1941,7 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
 
     public SessionVariableConstants.ChooseInstancesMode getChooseExecuteInstancesMode() {
         return Enums.getIfPresent(SessionVariableConstants.ChooseInstancesMode.class,
-                        StringUtils.upperCase(chooseExecuteInstancesMode))
+                StringUtils.upperCase(chooseExecuteInstancesMode))
                 .or(SessionVariableConstants.ChooseInstancesMode.LOCALITY);
     }
 
@@ -2166,6 +2172,14 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
 
     public void setPreferComputeNode(boolean preferComputeNode) {
         this.preferComputeNode = preferComputeNode;
+    }
+
+    public void setComputationFragmentSchedulingPolicy(String computationFragmentSchedulingPolicy) {
+        this.computationFragmentSchedulingPolicy = computationFragmentSchedulingPolicy;
+    }
+
+    public String getComputationFragmentSchedulingPolicy() {
+        return computationFragmentSchedulingPolicy;
     }
 
     public boolean enableHiveColumnStats() {

--- a/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
@@ -2175,6 +2175,10 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
     }
 
     public void setComputationFragmentSchedulingPolicy(String computationFragmentSchedulingPolicy) {
+        if (!"compute_nodes_only".equals(computationFragmentSchedulingPolicy)
+                && !"all_nodes".equals(computationFragmentSchedulingPolicy)) {
+            throw new IllegalArgumentException("Invalid computationFragmentSchedulingPolicy: " + computationFragmentSchedulingPolicy);
+        }
         this.computationFragmentSchedulingPolicy = computationFragmentSchedulingPolicy;
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
@@ -2177,7 +2177,8 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
     public void setComputationFragmentSchedulingPolicy(String computationFragmentSchedulingPolicy) {
         if (!"compute_nodes_only".equals(computationFragmentSchedulingPolicy)
                 && !"all_nodes".equals(computationFragmentSchedulingPolicy)) {
-            throw new IllegalArgumentException("Invalid computationFragmentSchedulingPolicy: " + computationFragmentSchedulingPolicy);
+            throw new IllegalArgumentException("Invalid computationFragmentSchedulingPolicy: " 
+                                               + computationFragmentSchedulingPolicy);
         }
         this.computationFragmentSchedulingPolicy = computationFragmentSchedulingPolicy;
     }

--- a/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
@@ -117,7 +117,7 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
             }
             throw new IllegalArgumentException("Invalid computationFragmentSchedulingPolicy: " + policy);
         }
-    };
+    }
     public static final String EXEC_MEM_LIMIT = "exec_mem_limit";
 
     /**

--- a/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
@@ -101,6 +101,10 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
     // The schedule policy of backend and compute nodes.
     // The optional values are "compute_nodes_only" and "all_nodes".
     public static final String COMPUTATION_FRAGMENT_SCHEDULING_POLICY = "computation_fragment_scheduling_policy";
+    public enum ComputationFragmentSchedulingPolicy {
+        compute_nodes_only, //only select compute node in scheduler policy (default)
+        all_nodes //both select compute node and backend in scheduler policy
+    }
     public static final String EXEC_MEM_LIMIT = "exec_mem_limit";
 
     /**
@@ -785,7 +789,7 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
     private boolean preferComputeNode = false;
 
     @VariableMgr.VarAttr(name = COMPUTATION_FRAGMENT_SCHEDULING_POLICY)
-    private String computationFragmentSchedulingPolicy = "compute_nodes_only";
+    private String computationFragmentSchedulingPolicy = ComputationFragmentSchedulingPolicy.compute_nodes_only.toString();
 
     @VariableMgr.VarAttr(name = LOG_REJECTED_RECORD_NUM)
     private long logRejectedRecordNum = 0;
@@ -2175,8 +2179,8 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
     }
 
     public void setComputationFragmentSchedulingPolicy(String computationFragmentSchedulingPolicy) {
-        if (!"compute_nodes_only".equals(computationFragmentSchedulingPolicy)
-                && !"all_nodes".equals(computationFragmentSchedulingPolicy)) {
+        if (!ComputationFragmentSchedulingPolicy.compute_nodes_only.toString().equals(computationFragmentSchedulingPolicy)
+                && !ComputationFragmentSchedulingPolicy.all_nodes.toString().equals(computationFragmentSchedulingPolicy)) {
             throw new IllegalArgumentException("Invalid computationFragmentSchedulingPolicy: " 
                                                + computationFragmentSchedulingPolicy);
         }

--- a/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
@@ -102,9 +102,22 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
     // The optional values are "compute_nodes_only" and "all_nodes".
     public static final String COMPUTATION_FRAGMENT_SCHEDULING_POLICY = "computation_fragment_scheduling_policy";
     public enum ComputationFragmentSchedulingPolicy {
-        compute_nodes_only, //only select compute node in scheduler policy (default)
-        all_nodes //both select compute node and backend in scheduler policy
-    }
+        COMPUTE_NODES_ONLY("compute_nodes_only"), //only select compute node in scheduler policy (default)
+        ALL_NODES("all_nodes"); //both select compute node and backend in scheduler policy
+
+        private String policy;
+
+        private ComputationFragmentSchedulingPolicy(String policy) {
+            this.policy = policy;
+        }
+
+        public static ComputationFragmentSchedulingPolicy getPolicy(String policy) {
+            if (EnumUtils.isValidEnumIgnoreCase(ComputationFragmentSchedulingPolicy.class, policy)) {
+                return EnumUtils.getEnumIgnoreCase(ComputationFragmentSchedulingPolicy.class, policy);
+            }
+            throw new IllegalArgumentException("Invalid computationFragmentSchedulingPolicy: " + policy);
+        }
+    };
     public static final String EXEC_MEM_LIMIT = "exec_mem_limit";
 
     /**
@@ -789,7 +802,8 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
     private boolean preferComputeNode = false;
 
     @VariableMgr.VarAttr(name = COMPUTATION_FRAGMENT_SCHEDULING_POLICY)
-    private String computationFragmentSchedulingPolicy = ComputationFragmentSchedulingPolicy.compute_nodes_only.toString();
+    private ComputationFragmentSchedulingPolicy computationFragmentSchedulingPolicy = 
+                                    ComputationFragmentSchedulingPolicy.COMPUTE_NODES_ONLY;
 
     @VariableMgr.VarAttr(name = LOG_REJECTED_RECORD_NUM)
     private long logRejectedRecordNum = 0;
@@ -2179,15 +2193,11 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
     }
 
     public void setComputationFragmentSchedulingPolicy(String computationFragmentSchedulingPolicy) {
-        if (!ComputationFragmentSchedulingPolicy.compute_nodes_only.toString().equals(computationFragmentSchedulingPolicy)
-                && !ComputationFragmentSchedulingPolicy.all_nodes.toString().equals(computationFragmentSchedulingPolicy)) {
-            throw new IllegalArgumentException("Invalid computationFragmentSchedulingPolicy: " 
-                                               + computationFragmentSchedulingPolicy);
-        }
-        this.computationFragmentSchedulingPolicy = computationFragmentSchedulingPolicy;
+        this.computationFragmentSchedulingPolicy = 
+                    ComputationFragmentSchedulingPolicy.getPolicy(computationFragmentSchedulingPolicy);
     }
 
-    public String getComputationFragmentSchedulingPolicy() {
+    public ComputationFragmentSchedulingPolicy getComputationFragmentSchedulingPolicy() {
         return computationFragmentSchedulingPolicy;
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
@@ -1942,7 +1942,7 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
 
     public SessionVariableConstants.ChooseInstancesMode getChooseExecuteInstancesMode() {
         return Enums.getIfPresent(SessionVariableConstants.ChooseInstancesMode.class,
-                StringUtils.upperCase(chooseExecuteInstancesMode))
+                        StringUtils.upperCase(chooseExecuteInstancesMode))
                 .or(SessionVariableConstants.ChooseInstancesMode.LOCALITY);
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariableConstants.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariableConstants.java
@@ -59,6 +59,15 @@ public class SessionVariableConstants {
         }
     }
 
+    public enum ComputationFragmentSchedulingPolicy {
+        
+        // only select compute node in scheduler policy (default)
+        COMPUTE_NODES_ONLY,
+
+        // both select compute node and backend in scheduler policy
+        ALL_NODES
+    }
+
     public enum AggregationStage {
         AUTO,
         ONE_STAGE,

--- a/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/DefaultWorkerProvider.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/DefaultWorkerProvider.java
@@ -319,7 +319,7 @@ public class DefaultWorkerProvider implements WorkerProvider {
         //add CN to Node Pool
         ImmutableMap<Long, ComputeNode> idToComputeNode
                 = ImmutableMap.copyOf(systemInfoService.getIdComputeNode());
-        if (numUsedComputeNodes <= 0 || numUsedComputeNodes >= idToComputeNode.size()) {
+        if (numUsedComputeNodes <= 0 || numUsedComputeNodes > idToComputeNode.size()) {
             computeNodes = new HashMap<>(idToComputeNode);
         } else {
             for (int i = 0; i < idToComputeNode.size() && computeNodes.size() < numUsedComputeNodes; i++) {

--- a/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/DefaultWorkerProvider.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/DefaultWorkerProvider.java
@@ -96,7 +96,8 @@ public class DefaultWorkerProvider implements WorkerProvider {
                                                              long warehouseId) {
 
             ImmutableMap<Long, ComputeNode> idToComputeNode =
-                    buildComputeNodeInfo(systemInfoService, numUsedComputeNodes, computationFragmentSchedulingPolicy, warehouseId);
+                    buildComputeNodeInfo(systemInfoService, numUsedComputeNodes, 
+                                         computationFragmentSchedulingPolicy, warehouseId);
 
             ImmutableMap<Long, ComputeNode> idToBackend = ImmutableMap.copyOf(systemInfoService.getIdToBackend());
 

--- a/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/DefaultWorkerProvider.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/DefaultWorkerProvider.java
@@ -91,7 +91,7 @@ public class DefaultWorkerProvider implements WorkerProvider {
     public static class Factory implements WorkerProvider.Factory {
         @Override
         public DefaultWorkerProvider captureAvailableWorkers(SystemInfoService systemInfoService,
-                                     boolean preferComputeNode,int numUsedComputeNodes,
+                                     boolean preferComputeNode, int numUsedComputeNodes,
                                      ComputationFragmentSchedulingPolicy computationFragmentSchedulingPolicy,
                                      long warehouseId) {
 

--- a/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/DefaultWorkerProvider.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/DefaultWorkerProvider.java
@@ -22,7 +22,7 @@ import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
 import com.starrocks.common.FeConstants;
 import com.starrocks.qe.ConnectContext;
-import com.starrocks.qe.SessionVariable.ComputationFragmentSchedulingPolicy;
+import com.starrocks.qe.SessionVariableConstants.ComputationFragmentSchedulingPolicy;
 import com.starrocks.qe.SimpleScheduler;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.server.RunMode;
@@ -329,7 +329,7 @@ public class DefaultWorkerProvider implements WorkerProvider {
             if (computationFragmentSchedulingPolicy == ComputationFragmentSchedulingPolicy.ALL_NODES) {
                 computeNodes.putAll(idToBackend);
             }
-        } else if (numUsedComputeNodes < idToComputeNode.size()) {
+        } else {
             for (int i = 0; i < idToComputeNode.size() && computeNodes.size() < numUsedComputeNodes; i++) {
                 ComputeNode computeNode =
                         getNextWorker(idToComputeNode, DefaultWorkerProvider::getNextComputeNodeIndex);
@@ -339,8 +339,6 @@ public class DefaultWorkerProvider implements WorkerProvider {
                 }
                 computeNodes.put(computeNode.getId(), computeNode);
             }
-        } else { //numUsedComputeNodes >= idToComputeNode.size()
-            computeNodes.putAll(idToComputeNode);
             if (computationFragmentSchedulingPolicy == ComputationFragmentSchedulingPolicy.ALL_NODES) {
                 for (int i = 0; i < idToBackend.size() && computeNodes.size() < numUsedComputeNodes; i++) {
                     ComputeNode backend =
@@ -351,6 +349,7 @@ public class DefaultWorkerProvider implements WorkerProvider {
                     }
                     computeNodes.put(backend.getId(), backend);
                 }
+
             }
         }
 

--- a/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/DefaultWorkerProvider.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/DefaultWorkerProvider.java
@@ -338,6 +338,7 @@ public class DefaultWorkerProvider implements WorkerProvider {
                 if (!isWorkerAvailable(computeNode)) {
                     continue;
                 }
+                computeNodes.put(computeNode.getId(), computeNode);
             }
         } else { //numUsedComputeNodes > idToComputeNode.size()
             computeNodes.putAll(idToComputeNode);

--- a/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/DefaultWorkerProvider.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/DefaultWorkerProvider.java
@@ -330,7 +330,7 @@ public class DefaultWorkerProvider implements WorkerProvider {
             if (computationFragmentSchedulingPolicy.equals(ComputationFragmentSchedulingPolicy.all_nodes.toString())) {
                 computeNodes.putAll(idToBackend);
             }
-        } else if (numUsedComputeNodes <= idToComputeNode.size()) {
+        } else if (numUsedComputeNodes < idToComputeNode.size()) {
             for (int i = 0; i < idToComputeNode.size() && computeNodes.size() < numUsedComputeNodes; i++) {
                 ComputeNode computeNode =
                     getNextWorker(idToComputeNode, DefaultWorkerProvider::getNextComputeNodeIndex);
@@ -340,7 +340,7 @@ public class DefaultWorkerProvider implements WorkerProvider {
                 }
                 computeNodes.put(computeNode.getId(), computeNode);
             }
-        } else { //numUsedComputeNodes > idToComputeNode.size()
+        } else { //numUsedComputeNodes >= idToComputeNode.size()
             computeNodes.putAll(idToComputeNode);
             if (computationFragmentSchedulingPolicy.equals(ComputationFragmentSchedulingPolicy.all_nodes.toString())) {
                 for (int i = 0; i < idToBackend.size() && computeNodes.size() < numUsedComputeNodes; i++) {

--- a/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/DefaultWorkerProvider.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/DefaultWorkerProvider.java
@@ -91,10 +91,9 @@ public class DefaultWorkerProvider implements WorkerProvider {
     public static class Factory implements WorkerProvider.Factory {
         @Override
         public DefaultWorkerProvider captureAvailableWorkers(SystemInfoService systemInfoService,
-                                                             boolean preferComputeNode,
-                                                             int numUsedComputeNodes,
-                                                             String computationFragmentSchedulingPolicy,
-                                                             long warehouseId) {
+                                     boolean preferComputeNode,int numUsedComputeNodes,
+                                     ComputationFragmentSchedulingPolicy computationFragmentSchedulingPolicy,
+                                     long warehouseId) {
 
             ImmutableMap<Long, ComputeNode> idToComputeNode =
                     buildComputeNodeInfo(systemInfoService, numUsedComputeNodes, 
@@ -312,9 +311,9 @@ public class DefaultWorkerProvider implements WorkerProvider {
     }
 
     private static ImmutableMap<Long, ComputeNode> buildComputeNodeInfo(SystemInfoService systemInfoService,
-                                                                        int numUsedComputeNodes,
-                                                                        String computationFragmentSchedulingPolicy,
-                                                                        long warehouseId) {
+                                  int numUsedComputeNodes,
+                                  ComputationFragmentSchedulingPolicy computationFragmentSchedulingPolicy,
+                                  long warehouseId) {
         //define Node Pool
         Map<Long, ComputeNode> computeNodes = new HashMap<>();
 
@@ -327,13 +326,13 @@ public class DefaultWorkerProvider implements WorkerProvider {
         //add CN and BE to Node Pool
         if (numUsedComputeNodes <= 0) {
             computeNodes.putAll(idToComputeNode);
-            if (computationFragmentSchedulingPolicy.equals(ComputationFragmentSchedulingPolicy.all_nodes.toString())) {
+            if (computationFragmentSchedulingPolicy == ComputationFragmentSchedulingPolicy.ALL_NODES) {
                 computeNodes.putAll(idToBackend);
             }
         } else if (numUsedComputeNodes < idToComputeNode.size()) {
             for (int i = 0; i < idToComputeNode.size() && computeNodes.size() < numUsedComputeNodes; i++) {
                 ComputeNode computeNode =
-                    getNextWorker(idToComputeNode, DefaultWorkerProvider::getNextComputeNodeIndex);
+                        getNextWorker(idToComputeNode, DefaultWorkerProvider::getNextComputeNodeIndex);
                 Preconditions.checkNotNull(computeNode);
                 if (!isWorkerAvailable(computeNode)) {
                     continue;
@@ -342,10 +341,10 @@ public class DefaultWorkerProvider implements WorkerProvider {
             }
         } else { //numUsedComputeNodes >= idToComputeNode.size()
             computeNodes.putAll(idToComputeNode);
-            if (computationFragmentSchedulingPolicy.equals(ComputationFragmentSchedulingPolicy.all_nodes.toString())) {
+            if (computationFragmentSchedulingPolicy == ComputationFragmentSchedulingPolicy.ALL_NODES) {
                 for (int i = 0; i < idToBackend.size() && computeNodes.size() < numUsedComputeNodes; i++) {
                     ComputeNode backend =
-                        getNextWorker(idToBackend, DefaultWorkerProvider::getNextBackendIndex);
+                            getNextWorker(idToBackend, DefaultWorkerProvider::getNextBackendIndex);
                     Preconditions.checkNotNull(backend);
                     if (!isWorkerAvailable(backend)) {
                         continue;

--- a/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/WorkerProvider.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/WorkerProvider.java
@@ -33,13 +33,15 @@ public interface WorkerProvider {
         /**
          * Capture the available workers from {@code systemInfoService}, which are alive and not in the blacklist.
          *
-         * @param systemInfoService   The service which provides all the backend nodes and compute nodes.
-         * @param preferComputeNode   Whether to prefer using compute nodes over backend nodes.
-         * @param numUsedComputeNodes The maximum number of used compute nodes.
+         * @param systemInfoService                   The service which provides all the backend nodes and compute nodes.
+         * @param preferComputeNode                   Whether to prefer using compute nodes over backend nodes.
+         * @param numUsedComputeNodes                 The maximum number of used compute nodes.
+         * @param computationFragmentSchedulingPolicy The schedule policy of backend and compute nodes.
          */
         WorkerProvider captureAvailableWorkers(SystemInfoService systemInfoService,
                                                boolean preferComputeNode,
                                                int numUsedComputeNodes,
+                                               String computationFragmentSchedulingPolicy,
                                                long warehouseId);
     }
 
@@ -53,6 +55,7 @@ public interface WorkerProvider {
 
     /**
      * Select the worker with the given id.
+     *
      * @param workerId The id of the worker to choose.
      * @throws NonRecoverableException if there is no available worker with the given id.
      */

--- a/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/WorkerProvider.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/WorkerProvider.java
@@ -14,7 +14,7 @@
 
 package com.starrocks.qe.scheduler;
 
-import com.starrocks.qe.SessionVariable.ComputationFragmentSchedulingPolicy;
+import com.starrocks.qe.SessionVariableConstants.ComputationFragmentSchedulingPolicy;
 import com.starrocks.system.ComputeNode;
 import com.starrocks.system.SystemInfoService;
 

--- a/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/WorkerProvider.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/WorkerProvider.java
@@ -14,6 +14,7 @@
 
 package com.starrocks.qe.scheduler;
 
+import com.starrocks.qe.SessionVariable.ComputationFragmentSchedulingPolicy;
 import com.starrocks.system.ComputeNode;
 import com.starrocks.system.SystemInfoService;
 
@@ -41,7 +42,7 @@ public interface WorkerProvider {
         WorkerProvider captureAvailableWorkers(SystemInfoService systemInfoService,
                                                boolean preferComputeNode,
                                                int numUsedComputeNodes,
-                                               String computationFragmentSchedulingPolicy,
+                                               ComputationFragmentSchedulingPolicy computationFragmentSchedulingPolicy,
                                                long warehouseId);
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/SetStmtAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/SetStmtAnalyzer.java
@@ -211,6 +211,16 @@ public class SetStmtAnalyzer {
             }
         }
 
+        if (variable.equalsIgnoreCase(SessionVariable.COMPUTATION_FRAGMENT_SCHEDULING_POLICY)) {
+            SessionVariableConstants.ComputationFragmentSchedulingPolicy computationFragmentSchedulingPolicy =
+                    Enums.getIfPresent(SessionVariableConstants.ComputationFragmentSchedulingPolicy.class,
+                            StringUtils.upperCase(resolvedExpression.getStringValue())).orNull();
+            if (computationFragmentSchedulingPolicy == null) {
+                String legalValues = Joiner.on(" | ").join(SessionVariableConstants.ComputationFragmentSchedulingPolicy.values());
+                throw new IllegalArgumentException("Legal values of computation_fragment_scheduling_policy are " + legalValues);
+            }
+        }
+
         // materialized_view_rewrite_mode
         if (variable.equalsIgnoreCase(SessionVariable.MATERIALIZED_VIEW_REWRITE_MODE)) {
             String rewriteModeName = resolvedExpression.getStringValue();

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/SetStmtAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/SetStmtAnalyzer.java
@@ -212,12 +212,14 @@ public class SetStmtAnalyzer {
         }
 
         if (variable.equalsIgnoreCase(SessionVariable.COMPUTATION_FRAGMENT_SCHEDULING_POLICY)) {
+            String policy = resolvedExpression.getStringValue();
             SessionVariableConstants.ComputationFragmentSchedulingPolicy computationFragmentSchedulingPolicy =
                     Enums.getIfPresent(SessionVariableConstants.ComputationFragmentSchedulingPolicy.class,
-                            StringUtils.upperCase(resolvedExpression.getStringValue())).orNull();
+                            StringUtils.upperCase(policy)).orNull();
             if (computationFragmentSchedulingPolicy == null) {
-                String legalValues = Joiner.on(" | ").join(SessionVariableConstants.ComputationFragmentSchedulingPolicy.values());
-                throw new IllegalArgumentException("Legal values of computation_fragment_scheduling_policy are " + legalValues);
+                String supportedList = Joiner.on(",").join(SessionVariableConstants.ComputationFragmentSchedulingPolicy.values());
+                throw new SemanticException(String.format("Unsupported computation_fragment_scheduling_policy: %s, " +
+                        "supported list is %s", policy, supportedList));
             }
         }
 

--- a/fe/fe-core/src/test/java/com/starrocks/lake/qe/scheduler/DefaultSharedDataWorkerProviderTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/lake/qe/scheduler/DefaultSharedDataWorkerProviderTest.java
@@ -131,7 +131,7 @@ public class DefaultSharedDataWorkerProviderTest {
     private WorkerProvider newWorkerProvider() {
         return factory.captureAvailableWorkers(
                 GlobalStateMgr.getCurrentState().getNodeMgr().getClusterInfo(), true,
-                -1, WarehouseManager.DEFAULT_WAREHOUSE_ID);
+                -1, "all_nodes", WarehouseManager.DEFAULT_WAREHOUSE_ID);
     }
 
     private static void testUsingWorkerHelper(WorkerProvider workerProvider, Long workerId) {

--- a/fe/fe-core/src/test/java/com/starrocks/lake/qe/scheduler/DefaultSharedDataWorkerProviderTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/lake/qe/scheduler/DefaultSharedDataWorkerProviderTest.java
@@ -32,6 +32,7 @@ import com.starrocks.qe.ColocatedBackendSelector;
 import com.starrocks.qe.FragmentScanRangeAssignment;
 import com.starrocks.qe.HostBlacklist;
 import com.starrocks.qe.NormalBackendSelector;
+import com.starrocks.qe.SessionVariable.ComputationFragmentSchedulingPolicy;
 import com.starrocks.qe.SimpleScheduler;
 import com.starrocks.qe.scheduler.NonRecoverableException;
 import com.starrocks.qe.scheduler.WorkerProvider;
@@ -131,7 +132,8 @@ public class DefaultSharedDataWorkerProviderTest {
     private WorkerProvider newWorkerProvider() {
         return factory.captureAvailableWorkers(
                 GlobalStateMgr.getCurrentState().getNodeMgr().getClusterInfo(), true,
-                -1, "all_nodes", WarehouseManager.DEFAULT_WAREHOUSE_ID);
+                -1, ComputationFragmentSchedulingPolicy.compute_nodes_only.toString(), 
+                WarehouseManager.DEFAULT_WAREHOUSE_ID);
     }
 
     private static void testUsingWorkerHelper(WorkerProvider workerProvider, Long workerId) {

--- a/fe/fe-core/src/test/java/com/starrocks/lake/qe/scheduler/DefaultSharedDataWorkerProviderTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/lake/qe/scheduler/DefaultSharedDataWorkerProviderTest.java
@@ -32,7 +32,7 @@ import com.starrocks.qe.ColocatedBackendSelector;
 import com.starrocks.qe.FragmentScanRangeAssignment;
 import com.starrocks.qe.HostBlacklist;
 import com.starrocks.qe.NormalBackendSelector;
-import com.starrocks.qe.SessionVariable.ComputationFragmentSchedulingPolicy;
+import com.starrocks.qe.SessionVariableConstants.ComputationFragmentSchedulingPolicy;
 import com.starrocks.qe.SimpleScheduler;
 import com.starrocks.qe.scheduler.NonRecoverableException;
 import com.starrocks.qe.scheduler.WorkerProvider;

--- a/fe/fe-core/src/test/java/com/starrocks/lake/qe/scheduler/DefaultSharedDataWorkerProviderTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/lake/qe/scheduler/DefaultSharedDataWorkerProviderTest.java
@@ -132,7 +132,7 @@ public class DefaultSharedDataWorkerProviderTest {
     private WorkerProvider newWorkerProvider() {
         return factory.captureAvailableWorkers(
                 GlobalStateMgr.getCurrentState().getNodeMgr().getClusterInfo(), true,
-                -1, ComputationFragmentSchedulingPolicy.compute_nodes_only.toString(), 
+                -1, ComputationFragmentSchedulingPolicy.COMPUTE_NODES_ONLY, 
                 WarehouseManager.DEFAULT_WAREHOUSE_ID);
     }
 

--- a/fe/fe-core/src/test/java/com/starrocks/qe/scheduler/DefaultWorkerProviderTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/qe/scheduler/DefaultWorkerProviderTest.java
@@ -19,7 +19,7 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.starrocks.common.Reference;
 import com.starrocks.common.UserException;
-import com.starrocks.qe.SessionVariable.ComputationFragmentSchedulingPolicy;
+import com.starrocks.qe.SessionVariableConstants.ComputationFragmentSchedulingPolicy;
 import com.starrocks.qe.SimpleScheduler;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.server.WarehouseManager;

--- a/fe/fe-core/src/test/java/com/starrocks/qe/scheduler/DefaultWorkerProviderTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/qe/scheduler/DefaultWorkerProviderTest.java
@@ -124,8 +124,7 @@ public class DefaultWorkerProviderTest {
 
             workerProvider =
                     workerProviderFactory.captureAvailableWorkers(GlobalStateMgr.getCurrentState().getNodeMgr().getClusterInfo(),
-                            true,
-                            numUsedComputeNodes, ComputationFragmentSchedulingPolicy.compute_nodes_only.toString(), 
+                            true, numUsedComputeNodes, ComputationFragmentSchedulingPolicy.COMPUTE_NODES_ONLY, 
                             WarehouseManager.DEFAULT_WAREHOUSE_ID);
 
             int numAvailableComputeNodes = 0;
@@ -172,7 +171,7 @@ public class DefaultWorkerProviderTest {
         for (Integer numUsedComputeNodes : numUsedComputeNodesList) {
             workerProvider =
                     workerProviderFactory.captureAvailableWorkers(GlobalStateMgr.getCurrentState().getNodeMgr().getClusterInfo(),
-                            true, numUsedComputeNodes, ComputationFragmentSchedulingPolicy.compute_nodes_only.toString(), 
+                            true, numUsedComputeNodes, ComputationFragmentSchedulingPolicy.COMPUTE_NODES_ONLY, 
                             WarehouseManager.DEFAULT_WAREHOUSE_ID);
             List<Long> selectedWorkerIdsList = workerProvider.getAllAvailableNodes();
             for (Long selectedWorkerId : selectedWorkerIdsList) {
@@ -184,7 +183,7 @@ public class DefaultWorkerProviderTest {
         for (Integer numUsedComputeNodes : numUsedComputeNodesList) {
             workerProvider =
                     workerProviderFactory.captureAvailableWorkers(GlobalStateMgr.getCurrentState().getNodeMgr().getClusterInfo(),
-                            false, numUsedComputeNodes, ComputationFragmentSchedulingPolicy.compute_nodes_only.toString(), 
+                            false, numUsedComputeNodes, ComputationFragmentSchedulingPolicy.COMPUTE_NODES_ONLY, 
                             WarehouseManager.DEFAULT_WAREHOUSE_ID);
             List<Long> selectedWorkerIdsList = workerProvider.getAllAvailableNodes();
             Assert.assertEquals(availableId2Backend.size(), selectedWorkerIdsList.size());
@@ -197,7 +196,7 @@ public class DefaultWorkerProviderTest {
         for (Integer numUsedComputeNodes : numUsedComputeNodesList) {
             workerProvider =
                     workerProviderFactory.captureAvailableWorkers(GlobalStateMgr.getCurrentState().getNodeMgr().getClusterInfo(),
-                            true, numUsedComputeNodes, ComputationFragmentSchedulingPolicy.all_nodes.toString(), 
+                            true, numUsedComputeNodes, ComputationFragmentSchedulingPolicy.ALL_NODES, 
                             WarehouseManager.DEFAULT_WAREHOUSE_ID);
             List<Long> selectedWorkerIdsList = workerProvider.getAllAvailableNodes();
             Collections.reverse(selectedWorkerIdsList); //put ComputeNode id to the front,Backend id to the back

--- a/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AnalyzeSetVariableTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AnalyzeSetVariableTest.java
@@ -282,6 +282,18 @@ public class AnalyzeSetVariableTest {
         sql = "SET computation_fragment_scheduling_policy = all_nodes";
         analyzeSuccess(sql);
 
+        sql = "SET computation_fragment_scheduling_policy = ALL_NODES";
+        analyzeSuccess(sql);
+
+        sql = "SET computation_fragment_scheduling_policy = All_nodes";
+        analyzeSuccess(sql);
+
+        sql = "SET computation_fragment_scheduling_policy = 'all_nodes'";
+        analyzeSuccess(sql);
+
+        sql = "SET computation_fragment_scheduling_policy = \"all_nodes\"";
+        analyzeSuccess(sql);
+
         sql = "SET computation_fragment_scheduling_policy = compute_nodes";
         analyzeFail(sql);
     }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AnalyzeSetVariableTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AnalyzeSetVariableTest.java
@@ -281,8 +281,5 @@ public class AnalyzeSetVariableTest {
 
         sql = "SET computation_fragment_scheduling_policy = all_nodes";
         analyzeSuccess(sql);
-
-        sql = "SET computation_fragment_scheduling_policy = compute_nodes";
-        analyzeFail(sql);
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AnalyzeSetVariableTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AnalyzeSetVariableTest.java
@@ -271,4 +271,18 @@ public class AnalyzeSetVariableTest {
         sql = "SET runtime_adaptive_dop_max_block_rows_per_driver_seq = 1";
         analyzeSuccess(sql);
     }
+
+    @Test
+    public void testComputationFragmentSchedulingPolicy() {
+        String sql;
+
+        sql = "SET computation_fragment_scheduling_policy = compute_nodes_only";
+        analyzeSuccess(sql);
+
+        sql = "SET computation_fragment_scheduling_policy = all_nodes";
+        analyzeSuccess(sql);
+
+        sql = "SET computation_fragment_scheduling_policy = both_be_cn";
+        analyzeFail(sql);
+    }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AnalyzeSetVariableTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AnalyzeSetVariableTest.java
@@ -282,7 +282,7 @@ public class AnalyzeSetVariableTest {
         sql = "SET computation_fragment_scheduling_policy = all_nodes";
         analyzeSuccess(sql);
 
-        sql = "SET computation_fragment_scheduling_policy = both_be_cn";
+        sql = "SET computation_fragment_scheduling_policy = compute_nodes";
         analyzeFail(sql);
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AnalyzeSetVariableTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AnalyzeSetVariableTest.java
@@ -281,5 +281,8 @@ public class AnalyzeSetVariableTest {
 
         sql = "SET computation_fragment_scheduling_policy = all_nodes";
         analyzeSuccess(sql);
+
+        sql = "SET computation_fragment_scheduling_policy = compute_nodes";
+        analyzeFail(sql);
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AnalyzeTestUtil.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AnalyzeTestUtil.java
@@ -354,8 +354,7 @@ public class AnalyzeTestUtil {
                     connectContext.getSessionVariable().getSqlMode()).get(0);
             Analyzer.analyze(statementBase, connectContext);
             Assert.fail("Miss semantic error exception");
-        } catch (ParsingException | SemanticException | UnsupportedException | ErrorReportException 
-                                                      | IllegalArgumentException e) {
+        } catch (ParsingException | SemanticException | UnsupportedException | ErrorReportException e) {
             if (!exceptMessage.equals("")) {
                 Assert.assertTrue(e.getMessage(), e.getMessage().contains(exceptMessage));
             }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AnalyzeTestUtil.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AnalyzeTestUtil.java
@@ -354,7 +354,7 @@ public class AnalyzeTestUtil {
                     connectContext.getSessionVariable().getSqlMode()).get(0);
             Analyzer.analyze(statementBase, connectContext);
             Assert.fail("Miss semantic error exception");
-        } catch (ParsingException | SemanticException | UnsupportedException | ErrorReportException e) {
+        } catch (ParsingException | SemanticException | UnsupportedException | ErrorReportException | IllegalArgumentException e) {
             if (!exceptMessage.equals("")) {
                 Assert.assertTrue(e.getMessage(), e.getMessage().contains(exceptMessage));
             }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AnalyzeTestUtil.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AnalyzeTestUtil.java
@@ -354,7 +354,8 @@ public class AnalyzeTestUtil {
                     connectContext.getSessionVariable().getSqlMode()).get(0);
             Analyzer.analyze(statementBase, connectContext);
             Assert.fail("Miss semantic error exception");
-        } catch (ParsingException | SemanticException | UnsupportedException | ErrorReportException | IllegalArgumentException e) {
+        } catch (ParsingException | SemanticException | UnsupportedException | ErrorReportException 
+                                                      | IllegalArgumentException e) {
             if (!exceptMessage.equals("")) {
                 Assert.assertTrue(e.getMessage(), e.getMessage().contains(exceptMessage));
             }


### PR DESCRIPTION
Why I'm doing:
In shared nothing mode，when deploy both BE and CN, and set `prefer_compute_node=true`, current BE and CN schedule policy is not very feel perfect:
1. when query internal table, except scan fragment allocate to BE, other calculate fragment would allocate to CN.
2. when query external table, all fragment would allocate to CN.

In some scenarios, like when sudden business peak, need temporarily add CN to increase computational resources, current BE and CN schedule policy would cause BE nodes have low resource usage ratio，CN nodes have high resource usage ratio，especially when business type belongs to computational tasks.

What I'm doing:
Add a new session variable `computation_fragment_scheduling_policy`, the value as follows:
1. `compute_nodes_only`: the previous policy, as the default value.
2. `all_nodes`:
    - when query internal table, scan fragment allocate to BE, other calculate fragment would allocate to both BE and CN。
    - when query external table, all fragment would allocate to both BE and CN。

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [x] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [x] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
