### PR TITLE
[Enhancement] Make error msg for GIN more accurate

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/analysis/InvertedIndexUtil.java
+++ b/fe/fe-core/src/main/java/com/starrocks/analysis/InvertedIndexUtil.java
@@ -73,7 +73,7 @@ public class InvertedIndexUtil {
             throw new SemanticException("The inverted index can only be build on DUPLICATE table.");
         }
         if (!validGinColumnType(column)) {
-            throw new SemanticException("The inverted index can only be build on column with type of scalar type.");
+            throw new SemanticException("The inverted index can only be build on column with type of VARCHAR type.");
         }
 
         String impLibKey = IMP_LIB.name().toLowerCase(Locale.ROOT);

--- a/fe/fe-core/src/main/java/com/starrocks/analysis/InvertedIndexUtil.java
+++ b/fe/fe-core/src/main/java/com/starrocks/analysis/InvertedIndexUtil.java
@@ -73,7 +73,7 @@ public class InvertedIndexUtil {
             throw new SemanticException("The inverted index can only be build on DUPLICATE table.");
         }
         if (!validGinColumnType(column)) {
-            throw new SemanticException("The inverted index can only be build on column with type of VARCHAR type.");
+            throw new SemanticException("The inverted index can only be build on column with type of CHAR/VARCHAR type.");
         }
 
         String impLibKey = IMP_LIB.name().toLowerCase(Locale.ROOT);

--- a/fe/fe-core/src/main/java/com/starrocks/analysis/InvertedIndexUtil.java
+++ b/fe/fe-core/src/main/java/com/starrocks/analysis/InvertedIndexUtil.java
@@ -73,7 +73,7 @@ public class InvertedIndexUtil {
             throw new SemanticException("The inverted index can only be build on DUPLICATE table.");
         }
         if (!validGinColumnType(column)) {
-            throw new SemanticException("The inverted index can only be build on column with type of CHAR/VARCHAR type.");
+            throw new SemanticException("The inverted index can only be build on column with type of CHAR/STRING/VARCHAR type.");
         }
 
         String impLibKey = IMP_LIB.name().toLowerCase(Locale.ROOT);

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/GINIndexTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/GINIndexTest.java
@@ -73,7 +73,7 @@ public class GINIndexTest extends PlanTestBase {
         Assertions.assertThrows(
                 SemanticException.class,
                 () -> InvertedIndexUtil.checkInvertedIndexValid(c1, null, KeysType.DUP_KEYS),
-                "The inverted index can only be build on column with type of scalar type.");
+                "The inverted index can only be build on column with type of VARCHAR type.");
 
         Column c2 = new Column("f2", Type.STRING, true);
         Assertions.assertThrows(

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/GINIndexTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/GINIndexTest.java
@@ -73,7 +73,7 @@ public class GINIndexTest extends PlanTestBase {
         Assertions.assertThrows(
                 SemanticException.class,
                 () -> InvertedIndexUtil.checkInvertedIndexValid(c1, null, KeysType.DUP_KEYS),
-                "The inverted index can only be build on column with type of VARCHAR type.");
+                "The inverted index can only be build on column with type of CHAR/VARCHAR type.");
 
         Column c2 = new Column("f2", Type.STRING, true);
         Assertions.assertThrows(

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/GINIndexTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/GINIndexTest.java
@@ -73,7 +73,7 @@ public class GINIndexTest extends PlanTestBase {
         Assertions.assertThrows(
                 SemanticException.class,
                 () -> InvertedIndexUtil.checkInvertedIndexValid(c1, null, KeysType.DUP_KEYS),
-                "The inverted index can only be build on column with type of CHAR/VARCHAR type.");
+                "The inverted index can only be build on column with type of CHAR/STRING/VARCHAR type.");
 
         Column c2 = new Column("f2", Type.STRING, true);
         Assertions.assertThrows(

--- a/test/sql/test_inverted_index/R/test_inverted_index
+++ b/test/sql/test_inverted_index/R/test_inverted_index
@@ -774,7 +774,7 @@ PROPERTIES (
 "compression" = "LZ4"
 );
 -- result:
-E: (1064, 'Getting analyzing error. Detail message: The inverted index can only be build on column with type of VARCHAR type..')
+E: (1064, 'Getting analyzing error. Detail message: The inverted index can only be build on column with type of CHAR/VARCHAR type..')
 -- !result
 CREATE TABLE `t_gin_index_type_5` (
   `id1` bigint(20) NOT NULL COMMENT "",
@@ -790,7 +790,7 @@ PROPERTIES (
 "compression" = "LZ4"
 );
 -- result:
-E: (1064, 'Getting analyzing error. Detail message: The inverted index can only be build on column with type of VARCHAR type..')
+E: (1064, 'Getting analyzing error. Detail message: The inverted index can only be build on column with type of CHAR/VARCHAR type..')
 -- !result
 CREATE TABLE `t_gin_index_type_6` (
   `id1` bigint(20) NOT NULL COMMENT "",
@@ -806,7 +806,7 @@ PROPERTIES (
 "compression" = "LZ4"
 );
 -- result:
-E: (1064, 'Getting analyzing error. Detail message: The inverted index can only be build on column with type of VARCHAR type..')
+E: (1064, 'Getting analyzing error. Detail message: The inverted index can only be build on column with type of CHAR/VARCHAR type..')
 -- !result
 CREATE TABLE `t_gin_index_type_7` (
   `id1` bigint(20) NOT NULL COMMENT "",
@@ -822,7 +822,7 @@ PROPERTIES (
 "compression" = "LZ4"
 );
 -- result:
-E: (1064, 'Getting analyzing error. Detail message: The inverted index can only be build on column with type of VARCHAR type..')
+E: (1064, 'Getting analyzing error. Detail message: The inverted index can only be build on column with type of CHAR/VARCHAR type..')
 -- !result
 -- name: test_clone_for_gin
 set low_cardinality_optimize_v2 = false;

--- a/test/sql/test_inverted_index/R/test_inverted_index
+++ b/test/sql/test_inverted_index/R/test_inverted_index
@@ -774,7 +774,7 @@ PROPERTIES (
 "compression" = "LZ4"
 );
 -- result:
-E: (1064, 'Getting analyzing error. Detail message: The inverted index can only be build on column with type of CHAR/VARCHAR type..')
+E: (1064, 'Getting analyzing error. Detail message: The inverted index can only be build on column with type of CHAR/STRING/VARCHAR type..')
 -- !result
 CREATE TABLE `t_gin_index_type_5` (
   `id1` bigint(20) NOT NULL COMMENT "",
@@ -790,7 +790,7 @@ PROPERTIES (
 "compression" = "LZ4"
 );
 -- result:
-E: (1064, 'Getting analyzing error. Detail message: The inverted index can only be build on column with type of CHAR/VARCHAR type..')
+E: (1064, 'Getting analyzing error. Detail message: The inverted index can only be build on column with type of CHAR/STRING/VARCHAR type..')
 -- !result
 CREATE TABLE `t_gin_index_type_6` (
   `id1` bigint(20) NOT NULL COMMENT "",
@@ -806,7 +806,7 @@ PROPERTIES (
 "compression" = "LZ4"
 );
 -- result:
-E: (1064, 'Getting analyzing error. Detail message: The inverted index can only be build on column with type of CHAR/VARCHAR type..')
+E: (1064, 'Getting analyzing error. Detail message: The inverted index can only be build on column with type of CHAR/STRING/VARCHAR type..')
 -- !result
 CREATE TABLE `t_gin_index_type_7` (
   `id1` bigint(20) NOT NULL COMMENT "",
@@ -822,7 +822,7 @@ PROPERTIES (
 "compression" = "LZ4"
 );
 -- result:
-E: (1064, 'Getting analyzing error. Detail message: The inverted index can only be build on column with type of CHAR/VARCHAR type..')
+E: (1064, 'Getting analyzing error. Detail message: The inverted index can only be build on column with type of CHAR/STRING/VARCHAR type..')
 -- !result
 -- name: test_clone_for_gin
 set low_cardinality_optimize_v2 = false;

--- a/test/sql/test_inverted_index/R/test_inverted_index
+++ b/test/sql/test_inverted_index/R/test_inverted_index
@@ -774,7 +774,7 @@ PROPERTIES (
 "compression" = "LZ4"
 );
 -- result:
-E: (1064, 'Getting analyzing error. Detail message: The inverted index can only be build on column with type of scalar type..')
+E: (1064, 'Getting analyzing error. Detail message: The inverted index can only be build on column with type of VARCHAR type..')
 -- !result
 CREATE TABLE `t_gin_index_type_5` (
   `id1` bigint(20) NOT NULL COMMENT "",
@@ -790,7 +790,7 @@ PROPERTIES (
 "compression" = "LZ4"
 );
 -- result:
-E: (1064, 'Getting analyzing error. Detail message: The inverted index can only be build on column with type of scalar type..')
+E: (1064, 'Getting analyzing error. Detail message: The inverted index can only be build on column with type of VARCHAR type..')
 -- !result
 CREATE TABLE `t_gin_index_type_6` (
   `id1` bigint(20) NOT NULL COMMENT "",
@@ -806,7 +806,7 @@ PROPERTIES (
 "compression" = "LZ4"
 );
 -- result:
-E: (1064, 'Getting analyzing error. Detail message: The inverted index can only be build on column with type of scalar type..')
+E: (1064, 'Getting analyzing error. Detail message: The inverted index can only be build on column with type of VARCHAR type..')
 -- !result
 CREATE TABLE `t_gin_index_type_7` (
   `id1` bigint(20) NOT NULL COMMENT "",
@@ -822,7 +822,7 @@ PROPERTIES (
 "compression" = "LZ4"
 );
 -- result:
-E: (1064, 'Getting analyzing error. Detail message: The inverted index can only be build on column with type of scalar type..')
+E: (1064, 'Getting analyzing error. Detail message: The inverted index can only be build on column with type of VARCHAR type..')
 -- !result
 -- name: test_clone_for_gin
 set low_cardinality_optimize_v2 = false;


### PR DESCRIPTION
## Why I'm doing:
Make error msg for GIN more accurate when try to build GIN for non-VARCHAR column

## What I'm doing:
Make error msg for GIN more accurate

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
