### PR TITLE
[Refactor] [BugFix] Refactor all pending/running scheduler operations into TaskRunScheduler class

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/alter/OptimizeJobV2.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/OptimizeJobV2.java
@@ -47,6 +47,8 @@ import com.starrocks.scheduler.Constants;
 import com.starrocks.scheduler.TaskBuilder;
 import com.starrocks.scheduler.TaskManager;
 import com.starrocks.scheduler.TaskRun;
+import com.starrocks.scheduler.TaskRunManager;
+import com.starrocks.scheduler.TaskRunScheduler;
 import com.starrocks.scheduler.persist.TaskRunStatus;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.sql.ast.OptimizeClause;
@@ -331,14 +333,16 @@ public class OptimizeJobV2 extends AlterJobV2 implements GsonPostProcessable {
         // wait insert tasks finished
         boolean allFinished = true;
         int progress = 0;
+        TaskRunManager taskRunManager = GlobalStateMgr.getCurrentState().getTaskManager().getTaskRunManager();
+        TaskRunScheduler taskRunScheduler = taskRunManager.getTaskRunScheduler();
         for (OptimizeTask rewriteTask : rewriteTasks) {
             if (rewriteTask.getOptimizeTaskState() == Constants.TaskRunState.FAILED
                     || rewriteTask.getOptimizeTaskState() == Constants.TaskRunState.SUCCESS) {
                 progress += 100 / rewriteTasks.size();
                 continue;
             }
-            TaskRun taskRun = GlobalStateMgr.getCurrentState().getTaskManager().getTaskRunManager()
-                    .getRunnableTaskRun(rewriteTask.getId());
+
+            TaskRun taskRun = taskRunScheduler.getRunnableTaskRun(rewriteTask.getId());
             if (taskRun != null) {
                 if (taskRun.getStatus() != null) {
                     progress += taskRun.getStatus().getProgress() / rewriteTasks.size();

--- a/fe/fe-core/src/main/java/com/starrocks/leader/TaskRunStateSynchronizer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/leader/TaskRunStateSynchronizer.java
@@ -19,6 +19,7 @@ import com.starrocks.common.FeConstants;
 import com.starrocks.common.util.FrontendDaemon;
 import com.starrocks.scheduler.TaskRun;
 import com.starrocks.scheduler.TaskRunManager;
+import com.starrocks.scheduler.TaskRunScheduler;
 import com.starrocks.scheduler.persist.TaskRunPeriodStatusChange;
 import com.starrocks.server.GlobalStateMgr;
 import org.apache.logging.log4j.LogManager;
@@ -26,50 +27,54 @@ import org.apache.logging.log4j.Logger;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Set;
 
 public class TaskRunStateSynchronizer extends FrontendDaemon {
     public static final Logger LOG = LogManager.getLogger(TaskRunStateSynchronizer.class);
     // taskId -> progress
     private Map<Long, Integer> runningTaskRunProgressMap;
     private TaskRunManager taskRunManager;
+    private TaskRunScheduler taskRunScheduler;
 
     public TaskRunStateSynchronizer() {
         super("TaskRunStateSynchronizer", FeConstants.SYNC_TASK_RUNS_STATE_INTERVAL);
         taskRunManager = GlobalStateMgr.getCurrentState().getTaskManager().getTaskRunManager();
         runningTaskRunProgressMap = new HashMap<>();
-        for (Map.Entry<Long, TaskRun> entry : taskRunManager.getRunningTaskRunMap().entrySet()) {
-            runningTaskRunProgressMap.put(entry.getKey(), entry.getValue().getStatus().getProgress());
+        taskRunScheduler = taskRunManager.getTaskRunScheduler();
+
+        Set<TaskRun> runningTaskRuns = taskRunScheduler.getImmRunningTaskRuns();
+        for (TaskRun taskRun : runningTaskRuns) {
+            runningTaskRunProgressMap.put(taskRun.getTaskId(), taskRun.getStatus().getProgress());
         }
     }
 
     @Override
     protected void runAfterCatalogReady() {
-        Map<Long, TaskRun> runningTaskRunMapLatest = taskRunManager.getRunningTaskRunMap();
+        Set<TaskRun> runningTaskRuns = taskRunScheduler.getImmRunningTaskRuns();
         Map<Long, Integer> jobProgressMap = new HashMap<>();
-        for (Map.Entry<Long, TaskRun> item : runningTaskRunMapLatest.entrySet()) {
-
-            int nowProgress = item.getValue().getStatus().getProgress();
+        for (TaskRun taskRun : runningTaskRuns) {
+            Long taskId = taskRun.getTaskId();
+            int nowProgress = taskRun.getStatus().getProgress();
             // nowProgress == 100 indicates that the job is finished
             // the progress will be updated by TaskRunStatusChange
             if (nowProgress == 100) {
-                if (runningTaskRunProgressMap.containsKey(item.getKey())) {
-                    runningTaskRunProgressMap.remove(item.getKey());
+                if (runningTaskRunProgressMap.containsKey(taskId)) {
+                    runningTaskRunProgressMap.remove(taskId);
                 }
                 continue;
             }
             if (nowProgress == 0) {
                 continue;
             }
-            if (runningTaskRunProgressMap.containsKey(item.getKey())) {
-                int preProgress = runningTaskRunProgressMap.get(item.getKey());
+            if (runningTaskRunProgressMap.containsKey(taskId)) {
+                int preProgress = runningTaskRunProgressMap.get(taskId);
                 if (preProgress != nowProgress) {
-                    jobProgressMap.put(item.getKey(), nowProgress);
+                    jobProgressMap.put(taskId, nowProgress);
                 }
-
             } else {
-                jobProgressMap.put(item.getKey(), nowProgress);
+                jobProgressMap.put(taskId, nowProgress);
             }
-            runningTaskRunProgressMap.put(item.getKey(), nowProgress);
+            runningTaskRunProgressMap.put(taskId, nowProgress);
 
         }
         if (!jobProgressMap.isEmpty()) {

--- a/fe/fe-core/src/main/java/com/starrocks/leader/TaskRunStateSynchronizer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/leader/TaskRunStateSynchronizer.java
@@ -42,7 +42,7 @@ public class TaskRunStateSynchronizer extends FrontendDaemon {
         runningTaskRunProgressMap = new HashMap<>();
         taskRunScheduler = taskRunManager.getTaskRunScheduler();
 
-        Set<TaskRun> runningTaskRuns = taskRunScheduler.getImmRunningTaskRuns();
+        Set<TaskRun> runningTaskRuns = taskRunScheduler.getCopiedRunningTaskRuns();
         for (TaskRun taskRun : runningTaskRuns) {
             runningTaskRunProgressMap.put(taskRun.getTaskId(), taskRun.getStatus().getProgress());
         }
@@ -50,7 +50,7 @@ public class TaskRunStateSynchronizer extends FrontendDaemon {
 
     @Override
     protected void runAfterCatalogReady() {
-        Set<TaskRun> runningTaskRuns = taskRunScheduler.getImmRunningTaskRuns();
+        Set<TaskRun> runningTaskRuns = taskRunScheduler.getCopiedRunningTaskRuns();
         Map<Long, Integer> jobProgressMap = new HashMap<>();
         for (TaskRun taskRun : runningTaskRuns) {
             Long taskId = taskRun.getTaskId();

--- a/fe/fe-core/src/main/java/com/starrocks/metric/MaterializedViewMetricsEntity.java
+++ b/fe/fe-core/src/main/java/com/starrocks/metric/MaterializedViewMetricsEntity.java
@@ -28,6 +28,7 @@ import com.starrocks.metric.Metric.MetricUnit;
 import com.starrocks.scheduler.PartitionBasedMvRefreshProcessor;
 import com.starrocks.scheduler.TaskBuilder;
 import com.starrocks.scheduler.TaskManager;
+import com.starrocks.scheduler.TaskRunScheduler;
 import com.starrocks.server.GlobalStateMgr;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -158,7 +159,8 @@ public final class MaterializedViewMetricsEntity implements IMaterializedViewMet
                     return 0L;
                 }
                 Long taskId = taskManager.getTask(mvTaskName).getId();
-                return taskManager.getTaskRunManager().getPendingTaskRunCount(taskId);
+                TaskRunScheduler taskRunScheduler = taskManager.getTaskRunScheduler();
+                return taskRunScheduler.getTaskIdPendingTaskRunCount(taskId);
             }
         };
         metrics.add(counterRefreshPendingJobs);
@@ -176,7 +178,8 @@ public final class MaterializedViewMetricsEntity implements IMaterializedViewMet
                     return 0L;
                 }
                 Long taskId = taskManager.getTask(mvTaskName).getId();
-                if (taskManager.getTaskRunManager().containsTaskInRunningTaskRunMap(taskId)) {
+                TaskRunScheduler taskRunScheduler = taskManager.getTaskRunManager().getTaskRunScheduler();
+                if (taskRunScheduler.isTaskRunning(taskId)) {
                     return 1L;
                 } else {
                     return 0L;

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/TaskManager.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/TaskManager.java
@@ -175,7 +175,7 @@ public class TaskManager implements MemoryTrackable {
         }
         try {
             // clear pending task runs
-            List<TaskRun> taskRuns = taskRunScheduler.getImmPendingTaskRuns();
+            List<TaskRun> taskRuns = taskRunScheduler.getCopiedPendingTaskRuns();
             for (TaskRun taskRun : taskRuns) {
                 taskRun.getStatus().setErrorMessage("Fe abort the task");
                 taskRun.getStatus().setErrorCode(-1);
@@ -191,7 +191,7 @@ public class TaskManager implements MemoryTrackable {
             }
 
             // clear running task runs
-            Set<Long> runningTaskIds = taskRunScheduler.getImmRunningTaskIds();
+            Set<Long> runningTaskIds = taskRunScheduler.getCopiedRunningTaskIds();
             for (Long taskId : runningTaskIds) {
                 TaskRun taskRun = taskRunScheduler.getRunningTaskRun(taskId);
                 taskRun.getStatus().setErrorMessage("Fe abort the task");
@@ -646,14 +646,14 @@ public class TaskManager implements MemoryTrackable {
     public List<TaskRunStatus> showTaskRunStatus(String dbName) {
         List<TaskRunStatus> taskRunList = Lists.newArrayList();
         // pending task runs
-        List<TaskRun> pendingTaskRuns = taskRunScheduler.getImmPendingTaskRuns();
+        List<TaskRun> pendingTaskRuns = taskRunScheduler.getCopiedPendingTaskRuns();
         pendingTaskRuns.stream()
                 .map(TaskRun::getStatus)
                 .filter(t -> isShowTaskRunStatus(t, dbName))
                 .forEach(taskRunList::add);
 
         // running task runs
-        Set<TaskRun> runningTaskRuns = taskRunScheduler.getImmRunningTaskRuns();
+        Set<TaskRun> runningTaskRuns = taskRunScheduler.getCopiedRunningTaskRuns();
         runningTaskRuns.stream()
                 .map(TaskRun::getStatus)
                 .filter(t -> isShowTaskRunStatus(t, dbName))
@@ -678,7 +678,7 @@ public class TaskManager implements MemoryTrackable {
         Map<String, List<TaskRunStatus>> mvNameRunStatusMap = Maps.newHashMap();
 
         // pending task runs
-        List<TaskRun> pendingTaskRuns = taskRunScheduler.getImmPendingTaskRuns();
+        List<TaskRun> pendingTaskRuns = taskRunScheduler.getCopiedPendingTaskRuns();
         pendingTaskRuns.stream()
                 .filter(task -> task.getTask().getSource() == Constants.TaskSource.MV)
                 .map(TaskRun::getStatus)
@@ -696,7 +696,7 @@ public class TaskManager implements MemoryTrackable {
                         .computeIfAbsent(task.getTaskName(), x -> Lists.newArrayList())
                         .add(task));
 
-        taskRunScheduler.getImmRunningTaskRuns().stream()
+        taskRunScheduler.getCopiedRunningTaskRuns().stream()
                 .filter(task -> task.getTask().getSource() == Constants.TaskSource.MV)
                 .map(TaskRun::getStatus)
                 .filter(u -> dbName == null || u != null && u.getDbName().equals(dbName))

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/TaskManager.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/TaskManager.java
@@ -659,7 +659,6 @@ public class TaskManager implements MemoryTrackable {
                 .filter(t -> isShowTaskRunStatus(t, dbName))
                 .forEach(taskRunList::add);
 
-
         // history task runs
         List<TaskRunStatus> historyTaskRuns = taskRunManager.getTaskRunHistory().getAllHistory();
         historyTaskRuns.stream()

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/TaskManager.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/TaskManager.java
@@ -640,7 +640,7 @@ public class TaskManager implements MemoryTrackable {
         if (dbName == null) {
             return true;
         }
-        return !taskRunStatus.getDbName().equals(dbName);
+        return dbName.equals(taskRunStatus.getDbName());
     }
 
     public List<TaskRunStatus> showTaskRunStatus(String dbName) {

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/TaskRun.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/TaskRun.java
@@ -322,12 +322,22 @@ public class TaskRun implements Comparable<TaskRun> {
 
     @Override
     public int compareTo(@NotNull TaskRun taskRun) {
-        // if priority is different, return the higher priority
-        if (this.getStatus().getPriority() != taskRun.getStatus().getPriority()) {
-            return taskRun.getStatus().getPriority() - this.getStatus().getPriority();
+        TaskRunStatus taskRunStatus = this.getStatus();
+        TaskRunStatus otherTaskRunStatus = taskRun.getStatus();
+        if (taskRunStatus == null) {
+            // prefer other
+            return 1;
+        } else if (otherTaskRunStatus == null){
+            // perfer this
+            return -1;
         } else {
-            // if priority is the same, return the older task
-            return this.getStatus().getCreateTime() > taskRun.getStatus().getCreateTime() ? 1 : -1;
+            // if priority is different, return the higher priority
+            if (taskRunStatus.getPriority() != otherTaskRunStatus.getPriority()) {
+                return otherTaskRunStatus.getPriority() - taskRunStatus.getPriority();
+            } else {
+                // if priority is the same, return the older task
+                return taskRunStatus.getCreateTime() > otherTaskRunStatus.getCreateTime() ? 1 : -1;
+            }
         }
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/TaskRun.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/TaskRun.java
@@ -327,8 +327,8 @@ public class TaskRun implements Comparable<TaskRun> {
         if (taskRunStatus == null) {
             // prefer other
             return 1;
-        } else if (otherTaskRunStatus == null){
-            // perfer this
+        } else if (otherTaskRunStatus == null) {
+            // prefer this
             return -1;
         } else {
             // if priority is different, return the higher priority

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/TaskRunManager.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/TaskRunManager.java
@@ -29,9 +29,9 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.jetbrains.annotations.Nullable;
 
-import java.util.Iterator;
+import java.util.List;
 import java.util.Map;
-import java.util.Queue;
+import java.util.Set;
 import java.util.concurrent.Future;
 import java.util.concurrent.PriorityBlockingQueue;
 import java.util.concurrent.TimeUnit;
@@ -101,14 +101,12 @@ public class TaskRunManager implements MemoryTrackable {
         }
         try {
             long taskId = taskRun.getTaskId();
-            Queue<TaskRun> taskRuns = taskRunScheduler.getPendingTaskRunsByTaskId(taskId);
+            List<TaskRun> taskRuns = taskRunScheduler.getImmPendingTaskRunsByTaskId(taskId);
             // If the task run is sync-mode, it will hang forever if the task run is merged because
             // user's using `future.get()` to wait and the future will not be set forever.
             ExecuteOption executeOption = taskRun.getExecuteOption();
             if (taskRuns != null && executeOption.isMergeRedundant()) {
-                Iterator<TaskRun> iter = taskRuns.iterator();
-                while (iter.hasNext()) {
-                    TaskRun oldTaskRun = iter.next();
+                for (TaskRun oldTaskRun : taskRuns) {
                     if (oldTaskRun == null) {
                         continue;
                     }
@@ -141,15 +139,14 @@ public class TaskRunManager implements MemoryTrackable {
                     LOG.info("Merge redundant task run, oldTaskRun: {}, taskRun: {}",
                             oldTaskRun, taskRun);
 
-                    taskRunScheduler.removePendingTaskRunFromQueue(oldTaskRun);
-                    iter.remove();
-
                     // Update follower's state to SUCCESS, otherwise the merged task run will always be PENDING.
                     // TODO: 1. add a MERGED state later. 2. support batch update to reduce the number of edit logs.
                     oldTaskRun.getStatus().setFinishTime(System.currentTimeMillis());
                     TaskRunStatusChange statusChange = new TaskRunStatusChange(oldTaskRun.getTaskId(), oldTaskRun.getStatus(),
                             oldTaskRun.getStatus().getState(), Constants.TaskRunState.SUCCESS);
                     GlobalStateMgr.getCurrentState().getEditLog().logUpdateTaskRun(statusChange);
+
+                    taskRunScheduler.removePendingTaskRun(oldTaskRun);
                 }
             }
             if (!taskRunScheduler.addPendingTaskRun(taskRun)) {
@@ -178,20 +175,20 @@ public class TaskRunManager implements MemoryTrackable {
 
     // check if a running TaskRun is complete and remove it from running TaskRun map
     public void checkRunningTaskRun() {
-        Map<Long, TaskRun> runningTaskRunMap = taskRunScheduler.getRunningTaskRunMap();
-        Iterator<Long> runningIterator = runningTaskRunMap.keySet().iterator();
-        while (runningIterator.hasNext()) {
-            Long taskId = runningIterator.next();
-            TaskRun taskRun = runningTaskRunMap.get(taskId);
+        Set<Long> runningTaskIds = taskRunScheduler.getImmRunningTaskIds();
+        for (Long taskId : runningTaskIds) {
+            TaskRun taskRun = taskRunScheduler.getRunningTaskRun(taskId);
             if (taskRun == null) {
                 LOG.warn("failed to get running TaskRun by taskId:{}", taskId);
-                runningIterator.remove();
+                taskRunScheduler.removeRunningTask(taskId);
                 return;
             }
+
             Future<?> future = taskRun.getFuture();
             if (future.isDone()) {
-                runningIterator.remove();
+                taskRunScheduler.removeRunningTask(taskId);
                 LOG.info("Task run is done from state RUNNING to {}, {}", taskRun.getStatus().getState(), taskRun);
+
                 taskRunHistory.addHistory(taskRun.getStatus());
                 TaskRunStatusChange statusChange = new TaskRunStatusChange(taskRun.getTaskId(), taskRun.getStatus(),
                         Constants.TaskRunState.RUNNING, taskRun.getStatus().getState());
@@ -239,46 +236,19 @@ public class TaskRunManager implements MemoryTrackable {
         this.taskRunLock.unlock();
     }
 
-    public TaskRun getRunnableTaskRun(long taskId) {
-        return taskRunScheduler.getRunnableTaskRun(taskId);
-    }
-
-    public Queue<TaskRun> getPendingTaskRuns() {
-        return taskRunScheduler.getPendingTaskRuns();
-    }
-    public Map<Long, Queue<TaskRun>> getPendingTaskRunMap() {
-        return taskRunScheduler.getPendingTaskRunMap();
-    }
-
-    public Map<Long, TaskRun> getRunningTaskRunMap() {
-        return taskRunScheduler.getRunningTaskRunMap();
+    public TaskRunScheduler getTaskRunScheduler() {
+        return taskRunScheduler;
     }
 
     public TaskRunHistory getTaskRunHistory() {
         return taskRunHistory;
     }
 
-    public boolean containsTaskInRunningTaskRunMap(long taskId) {
-        return taskRunScheduler.getRunningTaskRunMap().containsKey(taskId);
-    }
-
-    public long getPendingTaskRunCount(long taskId) {
-        taskRunLock.lock();
-        try {
-            Queue<TaskRun> pendingTaskRuns = taskRunScheduler.getPendingTaskRunsByTaskId(taskId);
-            return  pendingTaskRuns == null ? 0L : pendingTaskRuns.size();
-        } catch (Exception e) {
-            return 0L;
-        } finally {
-            taskRunLock.unlock();
-        }
-    }
-
     @Override
     public Map<String, Long> estimateCount() {
         long validPendingCount = taskRunScheduler.getPendingQueueCount();
         return ImmutableMap.of("PendingTaskRun", validPendingCount,
-                "RunningTaskRun", (long) taskRunScheduler.getRunningTaskRunMap().size(),
+                "RunningTaskRun", (long) taskRunScheduler.getRunningTaskCount(),
                 "HistoryTaskRun", taskRunHistory.getTaskRunCount());
     }
   

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/TaskRunManager.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/TaskRunManager.java
@@ -101,7 +101,7 @@ public class TaskRunManager implements MemoryTrackable {
         }
         try {
             long taskId = taskRun.getTaskId();
-            List<TaskRun> taskRuns = taskRunScheduler.getImmPendingTaskRunsByTaskId(taskId);
+            List<TaskRun> taskRuns = taskRunScheduler.getCopiedPendingTaskRunsByTaskId(taskId);
             // If the task run is sync-mode, it will hang forever if the task run is merged because
             // user's using `future.get()` to wait and the future will not be set forever.
             ExecuteOption executeOption = taskRun.getExecuteOption();
@@ -175,7 +175,7 @@ public class TaskRunManager implements MemoryTrackable {
 
     // check if a running TaskRun is complete and remove it from running TaskRun map
     public void checkRunningTaskRun() {
-        Set<Long> runningTaskIds = taskRunScheduler.getImmRunningTaskIds();
+        Set<Long> runningTaskIds = taskRunScheduler.getCopiedRunningTaskIds();
         for (Long taskId : runningTaskIds) {
             TaskRun taskRun = taskRunScheduler.getRunningTaskRun(taskId);
             if (taskRun == null) {

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/TaskRunScheduler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/TaskRunScheduler.java
@@ -125,7 +125,7 @@ public class TaskRunScheduler {
         LOG.info("remove pending task: {}", task);
 
         Queue<TaskRun> taskRunQueue = pendingTaskRunMap.get(task.getId());
-        if (taskRunQueue.isEmpty()) {
+        if (taskRunQueue == null || taskRunQueue.isEmpty()) {
             return;
         }
 

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/TaskRunScheduler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/TaskRunScheduler.java
@@ -17,7 +17,6 @@ package com.starrocks.scheduler;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Maps;
-import com.google.common.collect.Sets;
 import com.google.gson.JsonObject;
 import com.starrocks.common.Config;
 import com.starrocks.persist.gson.GsonUtils;

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/TaskRunScheduler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/TaskRunScheduler.java
@@ -15,6 +15,7 @@
 package com.starrocks.scheduler;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
 import com.google.gson.JsonObject;
@@ -62,7 +63,7 @@ public class TaskRunScheduler {
     /**
      * Get the pending task run queue
      */
-    public List<TaskRun> getImmPendingTaskRuns() {
+    public List<TaskRun> getCopiedPendingTaskRuns() {
         return ImmutableList.copyOf(pendingTaskRunQueue);
     }
 
@@ -70,7 +71,7 @@ public class TaskRunScheduler {
      * @param taskId: task id
      * @return: pending task run queue
      */
-    public List<TaskRun> getImmPendingTaskRunsByTaskId(long taskId) {
+    public List<TaskRun> getCopiedPendingTaskRunsByTaskId(long taskId) {
         Queue<TaskRun> pendingTaskRuns = pendingTaskRunMap.get(taskId);
         if (pendingTaskRuns == null) {
             return null;
@@ -113,7 +114,7 @@ public class TaskRunScheduler {
 
         }
         if (taskRunQueue.isEmpty()) {
-            LOG.warn("remove pending task run from pending map: {}", taskRun);
+            LOG.info("remove pending task run from pending map: {}", taskRun);
             pendingTaskRunMap.remove(taskRun.getTaskId());
         }
     }
@@ -122,7 +123,7 @@ public class TaskRunScheduler {
         if (task == null) {
             return;
         }
-        LOG.warn("remove pending task: {}", task);
+        LOG.info("remove pending task: {}", task);
 
         Queue<TaskRun> taskRunQueue = pendingTaskRunMap.get(task.getId());
         if (taskRunQueue.isEmpty()) {
@@ -201,7 +202,7 @@ public class TaskRunScheduler {
     }
 
     public long getTaskIdPendingTaskRunCount(long taskId) {
-        List<TaskRun> pendingTaskRuns = getImmPendingTaskRunsByTaskId(taskId);
+        List<TaskRun> pendingTaskRuns = getCopiedPendingTaskRunsByTaskId(taskId);
         return  pendingTaskRuns == null ? 0L : pendingTaskRuns.size();
     }
 
@@ -214,16 +215,16 @@ public class TaskRunScheduler {
         runningTaskRunMap.put(taskRun.getTaskId(), taskRun);
     }
 
-    public Set<Long> getImmRunningTaskIds() {
-        return Sets.newHashSet(runningTaskRunMap.keySet());
+    public Set<Long> getCopiedRunningTaskIds() {
+        return ImmutableSet.copyOf(runningTaskRunMap.keySet());
     }
 
     public TaskRun removeRunningTask(long taskId) {
         return runningTaskRunMap.remove(taskId);
     }
 
-    public Set<TaskRun> getImmRunningTaskRuns() {
-        return Sets.newHashSet(runningTaskRunMap.values());
+    public Set<TaskRun> getCopiedRunningTaskRuns() {
+        return ImmutableSet.copyOf(runningTaskRunMap.values());
     }
 
     public boolean isTaskRunning(long taskId) {

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/TaskRunScheduler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/TaskRunScheduler.java
@@ -101,7 +101,7 @@ public class TaskRunScheduler {
         if (taskRun == null) {
             return;
         }
-        LOG.warn("remove pending task run: {}", taskRun);
+        LOG.info("remove pending task run: {}", taskRun);
 
         if (!pendingTaskRunQueue.remove(taskRun)) {
             LOG.warn("remove pending task run from queue failed: {}", taskRun);
@@ -110,6 +110,11 @@ public class TaskRunScheduler {
         Queue<TaskRun> taskRunQueue = pendingTaskRunMap.get(taskRun.getTaskId());
         if (!taskRunQueue.remove(taskRun)) {
             LOG.warn("remove pending task run from pending map failed: {}", taskRun);
+
+        }
+        if (taskRunQueue.isEmpty()) {
+            LOG.warn("remove pending task run from pending map: {}", taskRun);
+            pendingTaskRunMap.remove(taskRun.getTaskId());
         }
     }
 
@@ -170,7 +175,7 @@ public class TaskRunScheduler {
 
             // remove task run from pending task run map
             Queue<TaskRun> taskRunQueue = pendingTaskRunMap.get(taskId);
-            if (taskRunQueue == null) {
+            if (taskRunQueue == null || pendingTaskRunMap.isEmpty()) {
                 pendingTaskRunMap.remove(taskId);
             } else {
                 TaskRun taskRunInMap = taskRunQueue.poll();

--- a/fe/fe-core/src/test/java/com/starrocks/benchmark/TaskSchedulerBench.java
+++ b/fe/fe-core/src/test/java/com/starrocks/benchmark/TaskSchedulerBench.java
@@ -1,0 +1,134 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.benchmark;
+
+import com.carrotsearch.junitbenchmarks.BenchmarkOptions;
+import com.carrotsearch.junitbenchmarks.BenchmarkRule;
+import com.starrocks.common.Config;
+import com.starrocks.scheduler.ExecuteOption;
+import com.starrocks.scheduler.Task;
+import com.starrocks.scheduler.TaskManager;
+import com.starrocks.scheduler.TaskRun;
+import com.starrocks.scheduler.TaskRunBuilder;
+import com.starrocks.scheduler.TaskRunScheduler;
+import com.starrocks.server.GlobalStateMgr;
+import com.starrocks.sql.optimizer.rule.transformation.materialization.MvRewriteTestBase;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TestRule;
+
+public class TaskSchedulerBench extends MvRewriteTestBase {
+
+    // private static final int TASK_NUM = Config.task_runs_queue_length;
+    private static final int TASK_NUM = 10;
+
+    @Rule
+    public TestRule benchRun = new BenchmarkRule();
+
+    @BeforeClass
+    public static void beforeClass() throws Exception {
+        MvRewriteTestBase.beforeClass();
+        Config.task_runs_concurrency = TASK_NUM;
+        LOG.info("prepared {} tasks", TASK_NUM);
+    }
+
+    @Before
+    public void before() {
+        starRocksAssert.getCtx().getSessionVariable().setEnableQueryDump(false);
+    }
+
+    private static ExecuteOption makeExecuteOption(boolean isMergeRedundant, boolean isSync) {
+        ExecuteOption executeOption = new ExecuteOption();
+        executeOption.setMergeRedundant(isMergeRedundant);
+        executeOption.setSync(isSync);
+        return executeOption;
+    }
+
+    private TaskRun makeTaskRun(long taskId, Task task, ExecuteOption executeOption) {
+        TaskRun taskRun = TaskRunBuilder
+                .newBuilder(task)
+                .setExecuteOption(executeOption)
+                .build();
+        taskRun.setTaskId(taskId);
+        return taskRun;
+    }
+
+    @Test
+    @BenchmarkOptions(warmupRounds = 1, benchmarkRounds = 1)
+    public void testTaskSchedulerWithDifferentTaskIds() throws Exception {
+        TaskManager tm = GlobalStateMgr.getCurrentState().getTaskManager();
+        TaskRunScheduler taskRunScheduler = tm.getTaskRunScheduler();
+        for (int i = 0; i < TASK_NUM; i++) {
+            Task task = new Task("test");
+            task.setDefinition("select 1");
+            TaskRun taskRun = makeTaskRun(i, task, makeExecuteOption(true, false));
+            tm.getTaskRunManager().submitTaskRun(taskRun, taskRun.getExecuteOption());
+        }
+        long pendingTaskRunsCount = taskRunScheduler.getPendingQueueCount();
+        long runningTaskRunsCount = taskRunScheduler.getRunningTaskCount();
+        Assert.assertEquals(TASK_NUM, pendingTaskRunsCount + runningTaskRunsCount);
+
+        while (pendingTaskRunsCount != 0 || runningTaskRunsCount != 0) {
+            pendingTaskRunsCount = taskRunScheduler.getPendingQueueCount();
+            runningTaskRunsCount = taskRunScheduler.getRunningTaskCount();
+        }
+    }
+
+    @Test
+    @BenchmarkOptions(warmupRounds = 1, benchmarkRounds = 1)
+    public void testTaskSchedulerWithSameTaskIdsAndMergeable() throws Exception {
+        TaskManager tm = GlobalStateMgr.getCurrentState().getTaskManager();
+        TaskRunScheduler taskRunScheduler = tm.getTaskRunScheduler();
+        for (int i = 0; i < TASK_NUM; i++) {
+            Task task = new Task("test");
+            task.setDefinition("select 1");
+            TaskRun taskRun = makeTaskRun(1, task, makeExecuteOption(true, false));
+            tm.getTaskRunManager().submitTaskRun(taskRun, taskRun.getExecuteOption());
+        }
+        long pendingTaskRunsCount = taskRunScheduler.getPendingQueueCount();
+        long runningTaskRunsCount = taskRunScheduler.getRunningTaskCount();
+        Assert.assertEquals(TASK_NUM, pendingTaskRunsCount + runningTaskRunsCount);
+
+        while (pendingTaskRunsCount != 0 || runningTaskRunsCount != 0) {
+            pendingTaskRunsCount = taskRunScheduler.getPendingQueueCount();
+            runningTaskRunsCount = taskRunScheduler.getRunningTaskCount();
+        }
+    }
+
+    @Test
+    @BenchmarkOptions(warmupRounds = 1, benchmarkRounds = 1)
+    public void testTaskSchedulerWithSameTaskIdsAndNoMergeable() throws Exception {
+        TaskManager tm = GlobalStateMgr.getCurrentState().getTaskManager();
+        TaskRunScheduler taskRunScheduler = tm.getTaskRunScheduler();
+        for (int i = 0; i < TASK_NUM; i++) {
+            Task task = new Task("test");
+            task.setDefinition("select 1");
+            TaskRun taskRun = makeTaskRun(1, task, makeExecuteOption(false, false));
+            tm.getTaskRunManager().submitTaskRun(taskRun, taskRun.getExecuteOption());
+        }
+        long pendingTaskRunsCount = taskRunScheduler.getPendingQueueCount();
+        long runningTaskRunsCount = taskRunScheduler.getRunningTaskCount();
+        System.out.println(taskRunScheduler);
+        Assert.assertEquals(TASK_NUM, pendingTaskRunsCount + runningTaskRunsCount);
+
+        while (pendingTaskRunsCount != 0 || runningTaskRunsCount != 0) {
+            pendingTaskRunsCount = taskRunScheduler.getPendingQueueCount();
+            runningTaskRunsCount = taskRunScheduler.getRunningTaskCount();
+        }
+    }
+}

--- a/fe/fe-core/src/test/java/com/starrocks/benchmark/TaskSchedulerBench.java
+++ b/fe/fe-core/src/test/java/com/starrocks/benchmark/TaskSchedulerBench.java
@@ -25,13 +25,14 @@ import com.starrocks.scheduler.TaskRunBuilder;
 import com.starrocks.scheduler.TaskRunScheduler;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.sql.optimizer.rule.transformation.materialization.MvRewriteTestBase;
-import org.junit.Assert;
 import org.junit.Before;
 import org.junit.BeforeClass;
+import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TestRule;
 
+@Ignore
 public class TaskSchedulerBench extends MvRewriteTestBase {
 
     // private static final int TASK_NUM = Config.task_runs_queue_length;
@@ -70,7 +71,7 @@ public class TaskSchedulerBench extends MvRewriteTestBase {
 
     @Test
     @BenchmarkOptions(warmupRounds = 1, benchmarkRounds = 1)
-    public void testTaskSchedulerWithDifferentTaskIds() throws Exception {
+    public void testTaskSchedulerWithDifferentTaskIds() {
         TaskManager tm = GlobalStateMgr.getCurrentState().getTaskManager();
         TaskRunScheduler taskRunScheduler = tm.getTaskRunScheduler();
         for (int i = 0; i < TASK_NUM; i++) {
@@ -81,7 +82,6 @@ public class TaskSchedulerBench extends MvRewriteTestBase {
         }
         long pendingTaskRunsCount = taskRunScheduler.getPendingQueueCount();
         long runningTaskRunsCount = taskRunScheduler.getRunningTaskCount();
-        Assert.assertEquals(TASK_NUM, pendingTaskRunsCount + runningTaskRunsCount);
 
         while (pendingTaskRunsCount != 0 || runningTaskRunsCount != 0) {
             pendingTaskRunsCount = taskRunScheduler.getPendingQueueCount();
@@ -91,7 +91,7 @@ public class TaskSchedulerBench extends MvRewriteTestBase {
 
     @Test
     @BenchmarkOptions(warmupRounds = 1, benchmarkRounds = 1)
-    public void testTaskSchedulerWithSameTaskIdsAndMergeable() throws Exception {
+    public void testTaskSchedulerWithSameTaskIdsAndMergeable() {
         TaskManager tm = GlobalStateMgr.getCurrentState().getTaskManager();
         TaskRunScheduler taskRunScheduler = tm.getTaskRunScheduler();
         for (int i = 0; i < TASK_NUM; i++) {
@@ -102,7 +102,6 @@ public class TaskSchedulerBench extends MvRewriteTestBase {
         }
         long pendingTaskRunsCount = taskRunScheduler.getPendingQueueCount();
         long runningTaskRunsCount = taskRunScheduler.getRunningTaskCount();
-        Assert.assertEquals(TASK_NUM, pendingTaskRunsCount + runningTaskRunsCount);
 
         while (pendingTaskRunsCount != 0 || runningTaskRunsCount != 0) {
             pendingTaskRunsCount = taskRunScheduler.getPendingQueueCount();
@@ -112,7 +111,7 @@ public class TaskSchedulerBench extends MvRewriteTestBase {
 
     @Test
     @BenchmarkOptions(warmupRounds = 1, benchmarkRounds = 1)
-    public void testTaskSchedulerWithSameTaskIdsAndNoMergeable() throws Exception {
+    public void testTaskSchedulerWithSameTaskIdsAndNoMergeable() {
         TaskManager tm = GlobalStateMgr.getCurrentState().getTaskManager();
         TaskRunScheduler taskRunScheduler = tm.getTaskRunScheduler();
         for (int i = 0; i < TASK_NUM; i++) {
@@ -123,8 +122,6 @@ public class TaskSchedulerBench extends MvRewriteTestBase {
         }
         long pendingTaskRunsCount = taskRunScheduler.getPendingQueueCount();
         long runningTaskRunsCount = taskRunScheduler.getRunningTaskCount();
-        System.out.println(taskRunScheduler);
-        Assert.assertEquals(TASK_NUM, pendingTaskRunsCount + runningTaskRunsCount);
 
         while (pendingTaskRunsCount != 0 || runningTaskRunsCount != 0) {
             pendingTaskRunsCount = taskRunScheduler.getPendingQueueCount();

--- a/fe/fe-core/src/test/java/com/starrocks/scheduler/TaskManagerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/scheduler/TaskManagerTest.java
@@ -237,7 +237,7 @@ public class TaskManagerTest {
         taskRunManager.arrangeTaskRun(taskRun2);
 
         TaskRunScheduler taskRunScheduler = taskRunManager.getTaskRunScheduler();
-        List<TaskRun> taskRuns = taskRunScheduler.getImmPendingTaskRunsByTaskId(taskId);
+        List<TaskRun> taskRuns = taskRunScheduler.getCopiedPendingTaskRunsByTaskId(taskId);
         Assert.assertTrue(taskRuns != null);
         Assert.assertEquals(1, taskRuns.size());
         Assert.assertEquals(10, taskRuns.get(0).getStatus().getPriority());
@@ -273,7 +273,7 @@ public class TaskManagerTest {
         taskRunManager.arrangeTaskRun(taskRun1);
 
         TaskRunScheduler taskRunScheduler = taskRunManager.getTaskRunScheduler();
-        List<TaskRun> taskRuns = taskRunScheduler.getImmPendingTaskRunsByTaskId(taskId);
+        List<TaskRun> taskRuns = taskRunScheduler.getCopiedPendingTaskRunsByTaskId(taskId);
         Assert.assertTrue(taskRuns != null);
         Assert.assertEquals(1, taskRuns.size());
         Assert.assertEquals(10, taskRuns.get(0).getStatus().getPriority());
@@ -310,7 +310,7 @@ public class TaskManagerTest {
         taskRunManager.arrangeTaskRun(taskRun2);
 
         TaskRunScheduler taskRunScheduler = taskRunManager.getTaskRunScheduler();
-        List<TaskRun> taskRuns = taskRunScheduler.getImmPendingTaskRunsByTaskId(taskId);
+        List<TaskRun> taskRuns = taskRunScheduler.getCopiedPendingTaskRunsByTaskId(taskId);
         Assert.assertTrue(taskRuns != null);
         Assert.assertEquals(1, taskRuns.size());
         TaskRun taskRun = taskRuns.get(0);
@@ -347,7 +347,7 @@ public class TaskManagerTest {
         taskRunManager.arrangeTaskRun(taskRun1);
 
         TaskRunScheduler taskRunScheduler = taskRunManager.getTaskRunScheduler();
-        List<TaskRun> taskRuns = taskRunScheduler.getImmPendingTaskRunsByTaskId(taskId);
+        List<TaskRun> taskRuns = taskRunScheduler.getCopiedPendingTaskRunsByTaskId(taskId);
         Assert.assertTrue(taskRuns != null);
         Assert.assertEquals(1, taskRuns.size());
         TaskRun taskRun = taskRuns.get(0);
@@ -393,7 +393,7 @@ public class TaskManagerTest {
         taskRunManager.arrangeTaskRun(taskRun3);
 
         TaskRunScheduler taskRunScheduler = taskRunManager.getTaskRunScheduler();
-        List<TaskRun> taskRuns = taskRunScheduler.getImmPendingTaskRunsByTaskId(taskId);
+        List<TaskRun> taskRuns = taskRunScheduler.getCopiedPendingTaskRunsByTaskId(taskId);
         Assert.assertTrue(taskRuns != null);
         Assert.assertEquals(3, taskRuns.size());
     }
@@ -561,52 +561,52 @@ public class TaskManagerTest {
         Assert.assertTrue(result.getStatus() == SubmitResult.SubmitStatus.SUBMITTED);
 
         TaskRunScheduler taskRunScheduler = taskRunManager.getTaskRunScheduler();
-        List<TaskRun> taskRuns = taskRunScheduler.getImmPendingTaskRunsByTaskId(taskId);
+        List<TaskRun> taskRuns = taskRunScheduler.getCopiedPendingTaskRunsByTaskId(taskId);
         Assert.assertTrue(taskRuns != null);
         Assert.assertEquals(2, taskRunScheduler.getPendingQueueCount());
-        Assert.assertEquals(2, taskRunScheduler.getImmPendingTaskRunsByTaskId(taskId).size());
+        Assert.assertEquals(2, taskRunScheduler.getCopiedPendingTaskRunsByTaskId(taskId).size());
 
         // If it's a sync refresh, no merge redundant anyway
         TaskRun taskRun3 = makeTaskRun(taskId, task, makeExecuteOption(false, true));
         result = taskRunManager.submitTaskRun(taskRun3, taskRun3.getExecuteOption());
         Assert.assertTrue(result.getStatus() == SubmitResult.SubmitStatus.SUBMITTED);
         Assert.assertEquals(3, taskRunScheduler.getPendingQueueCount());
-        Assert.assertEquals(3, taskRunScheduler.getImmPendingTaskRunsByTaskId(taskId).size());
+        Assert.assertEquals(3, taskRunScheduler.getCopiedPendingTaskRunsByTaskId(taskId).size());
         // merge it
         TaskRun taskRun4 = makeTaskRun(taskId, task, makeExecuteOption(true, false));
         result = taskRunManager.submitTaskRun(taskRun4, taskRun4.getExecuteOption());
         Assert.assertTrue(result.getStatus() == SubmitResult.SubmitStatus.SUBMITTED);
 
         Assert.assertEquals(3, taskRunScheduler.getPendingQueueCount());
-        Assert.assertEquals(3, taskRunScheduler.getImmPendingTaskRunsByTaskId(taskId).size());
+        Assert.assertEquals(3, taskRunScheduler.getCopiedPendingTaskRunsByTaskId(taskId).size());
 
         // no merge it
         TaskRun taskRun5 = makeTaskRun(taskId, task, makeExecuteOption(false, false));
         result = taskRunManager.submitTaskRun(taskRun5, taskRun5.getExecuteOption());
         Assert.assertTrue(result.getStatus() == SubmitResult.SubmitStatus.SUBMITTED);
         Assert.assertEquals(4, taskRunScheduler.getPendingQueueCount());
-        Assert.assertEquals(4, taskRunScheduler.getImmPendingTaskRunsByTaskId(taskId).size());
+        Assert.assertEquals(4, taskRunScheduler.getCopiedPendingTaskRunsByTaskId(taskId).size());
 
         for (int i = 4; i < Config.task_runs_queue_length; i++) {
             TaskRun taskRun = makeTaskRun(taskId, task, makeExecuteOption(false, false));
             result = taskRunManager.submitTaskRun(taskRun, taskRun.getExecuteOption());
             Assert.assertTrue(result.getStatus() == SubmitResult.SubmitStatus.SUBMITTED);
             Assert.assertEquals(i + 1, taskRunScheduler.getPendingQueueCount());
-            Assert.assertEquals(i + 1, taskRunScheduler.getImmPendingTaskRunsByTaskId(taskId).size());
+            Assert.assertEquals(i + 1, taskRunScheduler.getCopiedPendingTaskRunsByTaskId(taskId).size());
         }
         // no assign it: exceed queue's size
         TaskRun taskRun6 = makeTaskRun(taskId, task, makeExecuteOption(false, false));
         result = taskRunManager.submitTaskRun(taskRun6, taskRun6.getExecuteOption());
         Assert.assertTrue(result.getStatus() == SubmitResult.SubmitStatus.REJECTED);
         Assert.assertEquals(Config.task_runs_queue_length, taskRunScheduler.getPendingQueueCount());
-        Assert.assertEquals(Config.task_runs_queue_length, taskRunScheduler.getImmPendingTaskRunsByTaskId(taskId).size());
+        Assert.assertEquals(Config.task_runs_queue_length, taskRunScheduler.getCopiedPendingTaskRunsByTaskId(taskId).size());
 
         // no assign it: exceed queue's size
         TaskRun taskRun7 = makeTaskRun(taskId, task, makeExecuteOption(false, false));
         result = taskRunManager.submitTaskRun(taskRun7, taskRun7.getExecuteOption());
         Assert.assertTrue(result.getStatus() == SubmitResult.SubmitStatus.REJECTED);
         Assert.assertEquals(Config.task_runs_queue_length, taskRunScheduler.getPendingQueueCount());
-        Assert.assertEquals(Config.task_runs_queue_length, taskRunScheduler.getImmPendingTaskRunsByTaskId(taskId).size());
+        Assert.assertEquals(Config.task_runs_queue_length, taskRunScheduler.getCopiedPendingTaskRunsByTaskId(taskId).size());
     }
 
 

--- a/fe/fe-core/src/test/java/com/starrocks/scheduler/TaskRunSchedulerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/scheduler/TaskRunSchedulerTest.java
@@ -62,7 +62,7 @@ public class TaskRunSchedulerTest {
     }
 
     private static ExecuteOption makeExecuteOption(boolean isMergeRedundant, boolean isSync) {
-       return makeExecuteOption(isMergeRedundant, isSync, 0);
+        return makeExecuteOption(isMergeRedundant, isSync, 0);
     }
 
     private static ExecuteOption makeExecuteOption(boolean isMergeRedundant, boolean isSync, int priority) {

--- a/fe/fe-core/src/test/java/com/starrocks/scheduler/TaskRunSchedulerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/scheduler/TaskRunSchedulerTest.java
@@ -102,9 +102,9 @@ public class TaskRunSchedulerTest {
             taskRuns.add(taskRun);
             scheduler.addPendingTaskRun(taskRun);
         }
-        Assert.assertTrue(scheduler.getImmPendingTaskRuns().size() == N);
+        Assert.assertTrue(scheduler.getCopiedPendingTaskRuns().size() == N);
 
-        List<TaskRun> queue = scheduler.getImmPendingTaskRuns();
+        List<TaskRun> queue = scheduler.getCopiedPendingTaskRuns();
         Assert.assertEquals(N, queue.size());
 
         for (int i = 0; i < N; i++) {
@@ -126,9 +126,9 @@ public class TaskRunSchedulerTest {
             taskRuns.add(taskRun);
             scheduler.addPendingTaskRun(taskRun);
         }
-        Assert.assertTrue(scheduler.getImmPendingTaskRuns().size() == N);
+        Assert.assertTrue(scheduler.getCopiedPendingTaskRuns().size() == N);
 
-        List<TaskRun> queue = scheduler.getImmPendingTaskRuns();
+        List<TaskRun> queue = scheduler.getCopiedPendingTaskRuns();
         Assert.assertEquals(N, queue.size());
 
         for (int i = 0; i < N; i++) {

--- a/fe/fe-core/src/test/java/com/starrocks/scheduler/TaskRunSchedulerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/scheduler/TaskRunSchedulerTest.java
@@ -29,7 +29,6 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 
 import java.util.List;
-import java.util.Queue;
 import java.util.Set;
 
 public class TaskRunSchedulerTest {
@@ -93,13 +92,13 @@ public class TaskRunSchedulerTest {
             taskRuns.add(taskRun);
             scheduler.addPendingTaskRun(taskRun);
         }
-        Assert.assertTrue(scheduler.getPendingTaskRuns().size() == N);
+        Assert.assertTrue(scheduler.getImmPendingTaskRuns().size() == N);
 
-        Queue<TaskRun> queue = scheduler.getPendingTaskRuns();
+        List<TaskRun> queue = scheduler.getImmPendingTaskRuns();
         Assert.assertEquals(N, queue.size());
 
         for (int i = 0; i < N; i++) {
-            TaskRun taskRun = queue.poll();
+            TaskRun taskRun = queue.get(i);
             Assert.assertTrue(taskRun.equals(taskRuns.get(N - 1 - i)));
         }
     }
@@ -117,13 +116,13 @@ public class TaskRunSchedulerTest {
             taskRuns.add(taskRun);
             scheduler.addPendingTaskRun(taskRun);
         }
-        Assert.assertTrue(scheduler.getPendingTaskRuns().size() == N);
+        Assert.assertTrue(scheduler.getImmPendingTaskRuns().size() == N);
 
-        Queue<TaskRun> queue = scheduler.getPendingTaskRuns();
+        List<TaskRun> queue = scheduler.getImmPendingTaskRuns();
         Assert.assertEquals(N, queue.size());
 
         for (int i = 0; i < N; i++) {
-            TaskRun taskRun = queue.poll();
+            TaskRun taskRun = queue.get(i);
             Assert.assertTrue(taskRun.equals(taskRuns.get(i)));
         }
     }
@@ -144,7 +143,7 @@ public class TaskRunSchedulerTest {
         scheduler.scheduledPendingTaskRun(taskRun -> {
             Assert.assertTrue(runningTaskRuns.contains(taskRun));
         });
-        Assert.assertTrue(scheduler.getRunningTaskRunMap().size() == Config.task_runs_concurrency);
+        Assert.assertTrue(scheduler.getRunningTaskCount() == Config.task_runs_concurrency);
         Assert.assertTrue(scheduler.getPendingQueueCount() == N - Config.task_runs_concurrency);
         for (int i = 0; i < Config.task_runs_concurrency; i++) {
             Assert.assertTrue(scheduler.getRunnableTaskRun(i).equals(taskRuns.get(i)));
@@ -171,7 +170,7 @@ public class TaskRunSchedulerTest {
             Assert.assertTrue(runningTaskRuns.contains(taskRun));
         });
         // running queue only support one task with same task id
-        Assert.assertTrue(scheduler.getRunningTaskRunMap().size() == 1);
+        Assert.assertTrue(scheduler.getRunningTaskCount() == 1);
         Assert.assertTrue(scheduler.getPendingQueueCount() == 9);
 
         System.out.println(scheduler);

--- a/fe/fe-core/src/test/java/com/starrocks/utframe/StarRocksAssert.java
+++ b/fe/fe-core/src/test/java/com/starrocks/utframe/StarRocksAssert.java
@@ -74,6 +74,7 @@ import com.starrocks.scheduler.TaskManager;
 import com.starrocks.scheduler.TaskRun;
 import com.starrocks.scheduler.TaskRunBuilder;
 import com.starrocks.scheduler.TaskRunManager;
+import com.starrocks.scheduler.TaskRunScheduler;
 import com.starrocks.schema.MSchema;
 import com.starrocks.schema.MTable;
 import com.starrocks.server.GlobalStateMgr;
@@ -839,10 +840,11 @@ public class StarRocksAssert {
 
         Task task = tm.getTask(TaskBuilder.getMvTaskName(mv.getId()));
         TaskRunManager taskRunManager = tm.getTaskRunManager();
-        TaskRun taskRun = taskRunManager.getRunnableTaskRun(task.getId());
+        TaskRunScheduler taskRunScheduler = taskRunManager.getTaskRunScheduler();
+        TaskRun taskRun = taskRunScheduler.getRunnableTaskRun(task.getId());
         while (taskRun != null) {
             ThreadUtil.sleepAtLeastIgnoreInterrupts(1000L);
-            taskRun = taskRunManager.getRunnableTaskRun(task.getId());
+            taskRun = taskRunScheduler.getRunnableTaskRun(task.getId());
         }
         return this;
     }


### PR DESCRIPTION
## Why I'm doing:

- Replay update task run will fail if task run is failed after PR(https://github.com/StarRocks/starrocks/pull/43843) which will cause mv refresh tasks pending because of running queue is full, and this
is because `TaskRunScheduler ` not cover all pending/running scheduler operations in TaskRunManager or TaskManager


## What I'm doing:
- Refactor all pending/running scheduler operations into TaskRunScheduler class to avoid changes is forgotten

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [x] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
