### PR TITLE
[BugFix] Fix cherry pick codes conflicts 

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/RewriteMultiDistinctRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/RewriteMultiDistinctRule.java
@@ -27,6 +27,7 @@ import com.starrocks.sql.optimizer.OptimizerContext;
 import com.starrocks.sql.optimizer.Utils;
 import com.starrocks.sql.optimizer.operator.OperatorType;
 import com.starrocks.sql.optimizer.operator.logical.LogicalAggregationOperator;
+import com.starrocks.sql.optimizer.operator.logical.LogicalTreeAnchorOperator;
 import com.starrocks.sql.optimizer.operator.pattern.Pattern;
 import com.starrocks.sql.optimizer.operator.scalar.CallOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ColumnRefOperator;
@@ -173,6 +174,10 @@ public class RewriteMultiDistinctRule extends TransformationRule {
     private void calculateStatistics(OptExpression expr, OptimizerContext context) {
         // Avoid repeated calculate
         if (expr.getStatistics() != null) {
+            return;
+        }
+        // Do not calculate statistics for LogicalTreeAnchorOperator
+        if (expr.getOp() instanceof LogicalTreeAnchorOperator) {
             return;
         }
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/RewriteMultiDistinctRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/RewriteMultiDistinctRule.java
@@ -179,6 +179,11 @@ public class RewriteMultiDistinctRule extends TransformationRule {
         if (expr.getStatistics() != null) {
             return;
         }
+
+        for (OptExpression child : expr.getInputs()) {
+            calculateStatistics(child, context);
+        }
+
         // Do not calculate statistics for LogicalTreeAnchorOperator
         if (expr.getOp() instanceof LogicalTreeAnchorOperator) {
             return;


### PR DESCRIPTION
## Why I'm doing:


```
ERROR 1064 (HY000): cannot obtain cte statistics for LogicalCTEConsumeOperator{cteId='1', limit=-1, predicate=null}
```
## What I'm doing:
- Cherry pick codes from https://github.com/StarRocks/starrocks/pull/43166/files#diff-0278fbce2a12734222081e54eb02c1ef37d48c45ee2e28748d5c1b21b1858da6


Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
