### PR TITLE
[Enhancement] Add session variables to enable/disable late materialized join

### DIFF
--- a/be/src/exec/hash_join_node.cpp
+++ b/be/src/exec/hash_join_node.cpp
@@ -142,8 +142,8 @@ Status HashJoinNode::init(const TPlanNode& tnode, RuntimeState* state) {
     if (tnode.hash_join_node.__isset.output_columns) {
         _output_slots.insert(tnode.hash_join_node.output_columns.begin(), tnode.hash_join_node.output_columns.end());
     }
-    if (tnode.hash_join_node.__isset.enable_lazy_materialize) {
-        _enable_lazy_materialize = tnode.hash_join_node.enable_lazy_materialize;
+    if (tnode.hash_join_node.__isset.enable_late_materialization) {
+        _enable_late_materialization = tnode.hash_join_node.enable_late_materialization;
     }
     return Status::OK();
 }

--- a/be/src/exec/hash_join_node.cpp
+++ b/be/src/exec/hash_join_node.cpp
@@ -200,7 +200,7 @@ void HashJoinNode::_init_hash_table_param(HashTableParam* param) {
     param->output_probe_column_timer = _output_probe_column_timer;
     param->build_output_slots = _output_slots;
     param->probe_output_slots = _output_slots;
-    param->enable_lazy_materialize = _enable_lazy_materialize;
+    param->enable_late_materialization = _enable_late_materialization;
 
     std::set<SlotId> predicate_slots;
     for (ExprContext* expr_context : _conjunct_ctxs) {
@@ -470,7 +470,7 @@ pipeline::OpFactories HashJoinNode::_decompose_to_pipeline(pipeline::PipelineBui
     HashJoinerParam param(pool, _hash_join_node, _is_null_safes, _build_expr_ctxs, _probe_expr_ctxs,
                           _other_join_conjunct_ctxs, _conjunct_ctxs, child(1)->row_desc(), child(0)->row_desc(),
                           child(1)->type(), child(0)->type(), child(1)->conjunct_ctxs().empty(), _build_runtime_filters,
-                          _output_slots, _output_slots, _distribution_mode, false, _enable_lazy_materialize);
+                          _output_slots, _output_slots, _distribution_mode, false, _enable_late_materialization);
     auto hash_joiner_factory = std::make_shared<starrocks::pipeline::HashJoinerFactory>(param);
 
     // Create a shared RefCountedRuntimeFilterCollector

--- a/be/src/exec/hash_join_node.cpp
+++ b/be/src/exec/hash_join_node.cpp
@@ -142,6 +142,9 @@ Status HashJoinNode::init(const TPlanNode& tnode, RuntimeState* state) {
     if (tnode.hash_join_node.__isset.output_columns) {
         _output_slots.insert(tnode.hash_join_node.output_columns.begin(), tnode.hash_join_node.output_columns.end());
     }
+    if (tnode.hash_join_node.__isset.enable_lazy_materialize) {
+        _enable_lazy_materialize = tnode.hash_join_node.enable_lazy_materialize;
+    }
     return Status::OK();
 }
 

--- a/be/src/exec/hash_join_node.cpp
+++ b/be/src/exec/hash_join_node.cpp
@@ -142,8 +142,8 @@ Status HashJoinNode::init(const TPlanNode& tnode, RuntimeState* state) {
     if (tnode.hash_join_node.__isset.output_columns) {
         _output_slots.insert(tnode.hash_join_node.output_columns.begin(), tnode.hash_join_node.output_columns.end());
     }
-    if (tnode.hash_join_node.__isset.enable_late_materialization) {
-        _enable_late_materialization = tnode.hash_join_node.enable_late_materialization;
+    if (tnode.hash_join_node.__isset.late_materialization) {
+        _enable_late_materialization = tnode.hash_join_node.late_materialization;
     }
     return Status::OK();
 }

--- a/be/src/exec/hash_join_node.h
+++ b/be/src/exec/hash_join_node.h
@@ -115,7 +115,7 @@ private:
     std::set<SlotId> _output_slots;
 
     bool _is_push_down = false;
-    bool _enable_lazy_materialize = false;
+    bool _enable_late_materialization = false;
 
     JoinHashTable _ht;
 

--- a/be/src/exec/hash_joiner.cpp
+++ b/be/src/exec/hash_joiner.cpp
@@ -69,7 +69,8 @@ HashJoiner::HashJoiner(const HashJoinerParam& param)
           _build_output_slots(param._build_output_slots),
           _probe_output_slots(param._probe_output_slots),
           _build_runtime_filters(param._build_runtime_filters.begin(), param._build_runtime_filters.end()),
-          _mor_reader_mode(param._mor_reader_mode) {
+          _mor_reader_mode(param._mor_reader_mode),
+          _enable_lazy_materialize(param._enable_lazy_materialize) {
     _is_push_down = param._hash_join_node.is_push_down;
     if (_join_type == TJoinOp::LEFT_ANTI_JOIN && param._hash_join_node.is_rewritten_from_not_in) {
         _join_type = TJoinOp::NULL_AWARE_LEFT_ANTI_JOIN;
@@ -141,6 +142,7 @@ void HashJoiner::_init_hash_table_param(HashTableParam* param) {
     param->build_output_slots = _build_output_slots;
     param->probe_output_slots = _probe_output_slots;
     param->mor_reader_mode = _mor_reader_mode;
+    param->enable_lazy_materialize = _enable_lazy_materialize;
 
     std::set<SlotId> predicate_slots;
     for (ExprContext* expr_context : _conjunct_ctxs) {

--- a/be/src/exec/hash_joiner.cpp
+++ b/be/src/exec/hash_joiner.cpp
@@ -70,7 +70,7 @@ HashJoiner::HashJoiner(const HashJoinerParam& param)
           _probe_output_slots(param._probe_output_slots),
           _build_runtime_filters(param._build_runtime_filters.begin(), param._build_runtime_filters.end()),
           _mor_reader_mode(param._mor_reader_mode),
-          _enable_lazy_materialize(param._enable_lazy_materialize) {
+          _enable_late_materialization(param._enable_late_materialization) {
     _is_push_down = param._hash_join_node.is_push_down;
     if (_join_type == TJoinOp::LEFT_ANTI_JOIN && param._hash_join_node.is_rewritten_from_not_in) {
         _join_type = TJoinOp::NULL_AWARE_LEFT_ANTI_JOIN;
@@ -142,7 +142,7 @@ void HashJoiner::_init_hash_table_param(HashTableParam* param) {
     param->build_output_slots = _build_output_slots;
     param->probe_output_slots = _probe_output_slots;
     param->mor_reader_mode = _mor_reader_mode;
-    param->enable_lazy_materialize = _enable_lazy_materialize;
+    param->enable_late_materialization = _enable_late_materialization;
 
     std::set<SlotId> predicate_slots;
     for (ExprContext* expr_context : _conjunct_ctxs) {

--- a/be/src/exec/hash_joiner.h
+++ b/be/src/exec/hash_joiner.h
@@ -293,7 +293,7 @@ public:
 
     template <bool is_remain>
     Status lazy_output_chunk(RuntimeState* state, ChunkPtr* probe_chunk, ChunkPtr* chunk, JoinHashTable& hash_table) {
-        if (_enable_lazy_materialize && (*chunk) && !(*chunk)->is_empty()) {
+        if (_enable_late_materialization && (*chunk) && !(*chunk)->is_empty()) {
             return hash_table.lazy_output<is_remain>(state, probe_chunk, chunk);
         } else {
             return Status::OK();

--- a/be/src/exec/hash_joiner.h
+++ b/be/src/exec/hash_joiner.h
@@ -452,7 +452,7 @@ private:
     HashJoinProbeMetrics* _probe_metrics;
     size_t _hash_table_build_rows{};
     bool _mor_reader_mode = false;
-    bool _enable_lazy_materialize = false;
+    bool _enable_late_materialization = false;
 };
 
 } // namespace starrocks

--- a/be/src/exec/hash_joiner.h
+++ b/be/src/exec/hash_joiner.h
@@ -72,7 +72,7 @@ struct HashJoinerParam {
                     bool build_conjunct_ctxs_is_empty, std::list<RuntimeFilterBuildDescriptor*> build_runtime_filters,
                     std::set<SlotId> build_output_slots, std::set<SlotId> probe_output_slots,
                     const TJoinDistributionMode::type distribution_mode, bool mor_reader_mode,
-                    bool enable_lazy_materialize)
+                    bool enable_late_materialization)
             : _pool(pool),
               _hash_join_node(hash_join_node),
               _is_null_safes(std::move(is_null_safes)),
@@ -90,7 +90,7 @@ struct HashJoinerParam {
               _probe_output_slots(std::move(probe_output_slots)),
               _distribution_mode(distribution_mode),
               _mor_reader_mode(mor_reader_mode),
-              _enable_lazy_materialize(enable_lazy_materialize) {}
+              _enable_late_materialization(enable_late_materialization) {}
 
     HashJoinerParam(HashJoinerParam&&) = default;
     HashJoinerParam(HashJoinerParam&) = default;
@@ -114,7 +114,7 @@ struct HashJoinerParam {
 
     const TJoinDistributionMode::type _distribution_mode;
     const bool _mor_reader_mode;
-    const bool _enable_lazy_materialize;
+    const bool _enable_late_materialization;
 };
 
 inline bool could_short_circuit(TJoinOp::type join_type) {

--- a/be/src/exec/join_hash_map.cpp
+++ b/be/src/exec/join_hash_map.cpp
@@ -335,7 +335,7 @@ void JoinHashTable::create(const HashTableParam& param) {
     _table_items->with_other_conjunct = param.with_other_conjunct;
     _table_items->join_type = param.join_type;
     _table_items->mor_reader_mode = param.mor_reader_mode;
-    _table_items->enable_lazy_materialize = param.enable_lazy_materialize;
+    _table_items->enable_late_materialization = param.enable_late_materialization;
 
     if (_table_items->join_type == TJoinOp::RIGHT_SEMI_JOIN || _table_items->join_type == TJoinOp::RIGHT_ANTI_JOIN ||
         _table_items->join_type == TJoinOp::RIGHT_OUTER_JOIN) {
@@ -368,7 +368,7 @@ void JoinHashTable::_init_probe_column(const HashTableParam& param) {
             HashTableSlotDescriptor hash_table_slot;
             hash_table_slot.slot = slot;
 
-            if (param.enable_lazy_materialize) {
+            if (param.enable_late_materialization) {
                 if (param.probe_output_slots.empty()) {
                     // Empty means need output all
                     hash_table_slot.need_output = true;
@@ -426,7 +426,7 @@ void JoinHashTable::_init_build_column(const HashTableParam& param) {
             HashTableSlotDescriptor hash_table_slot;
             hash_table_slot.slot = slot;
 
-            if (!param.mor_reader_mode && param.enable_lazy_materialize) {
+            if (!param.mor_reader_mode && param.enable_late_materialization) {
                 if (param.build_output_slots.empty()) {
                     hash_table_slot.need_output = true;
                     hash_table_slot.need_lazy_materialize = false;

--- a/be/src/exec/join_hash_map.h
+++ b/be/src/exec/join_hash_map.h
@@ -130,7 +130,7 @@ struct JoinHashTableItems {
     size_t used_buckets = 0;
     bool cache_miss_serious = false;
     bool mor_reader_mode = false;
-    bool enable_lazy_materialize = false;
+    bool enable_late_materialization = false;
 
     float get_keys_per_bucket() const { return keys_per_bucket; }
     bool ht_cache_miss_serious() const { return cache_miss_serious; }
@@ -276,7 +276,7 @@ struct HashTableProbeState {
 
 struct HashTableParam {
     bool with_other_conjunct = false;
-    bool enable_lazy_materialize = false;
+    bool enable_late_materialization = false;
     TJoinOp::type join_type = TJoinOp::INNER_JOIN;
     const RowDescriptor* build_row_desc = nullptr;
     const RowDescriptor* probe_row_desc = nullptr;
@@ -540,7 +540,7 @@ public:
             _probe_output<false>(probe_chunk, chunk);
             _build_output<false>(chunk);
 
-            if (_table_items->enable_lazy_materialize) {
+            if (_table_items->enable_late_materialization) {
                 _probe_index_output(chunk);
             }
             break;

--- a/be/src/exec/join_hash_map.tpp
+++ b/be/src/exec/join_hash_map.tpp
@@ -486,7 +486,7 @@ void JoinHashMap<LT, BuildFunc, ProbeFunc>::probe(RuntimeState* state, const Col
         }
     }
 
-    if (_table_items->enable_lazy_materialize) {
+    if (_table_items->enable_late_materialization) {
         _probe_index_output(chunk);
         _build_index_output(chunk);
     }
@@ -513,7 +513,7 @@ void JoinHashMap<LT, BuildFunc, ProbeFunc>::probe_remain(RuntimeState* state, Ch
         _build_output<false>(chunk);
     }
 
-    if (_table_items->enable_lazy_materialize) {
+    if (_table_items->enable_late_materialization) {
         _build_index_output(chunk);
     }
 }
@@ -733,7 +733,7 @@ void JoinHashMap<LT, BuildFunc, ProbeFunc>::_copy_build_nullable_column(const Co
 
 template <LogicalType LT, class BuildFunc, class ProbeFunc>
 void JoinHashMap<LT, BuildFunc, ProbeFunc>::_search_ht(RuntimeState* state, ChunkPtr* probe_chunk) {
-    if (_table_items->enable_lazy_materialize) {
+    if (_table_items->enable_late_materialization) {
         _probe_state->probe_index.resize(state->chunk_size() + 8);
         _probe_state->build_index.resize(state->chunk_size() + 8);
     }
@@ -768,7 +768,7 @@ void JoinHashMap<LT, BuildFunc, ProbeFunc>::_search_ht_remain(RuntimeState* stat
         _probe_state->cur_build_index = 0;
     }
 
-    if (_table_items->enable_lazy_materialize) {
+    if (_table_items->enable_late_materialization) {
         _probe_state->build_index.resize(state->chunk_size() + 8);
     }
 

--- a/be/test/exec/join_hash_map_test.cpp
+++ b/be/test/exec/join_hash_map_test.cpp
@@ -2317,7 +2317,7 @@ TEST_F(JoinHashMapTest, EmptyHashMapTestLazyFilter) {
 
     HashTableParam param;
     param.mor_reader_mode = false;
-    param.enable_lazy_materialize = true;
+    param.enable_late_materialization = true;
     param.probe_row_desc = probe_row_desc.get();
     param.build_row_desc = build_row_desc.get();
     param.probe_output_slots = {1};
@@ -2373,7 +2373,7 @@ TEST_F(JoinHashMapTest, EmptyHashMapTestLazyOutputAll) {
 
     HashTableParam param;
     param.mor_reader_mode = false;
-    param.enable_lazy_materialize = true;
+    param.enable_late_materialization = true;
     param.probe_row_desc = probe_row_desc.get();
     param.build_row_desc = build_row_desc.get();
     param.probe_output_slots = {1};
@@ -2446,7 +2446,7 @@ TEST_F(JoinHashMapTest, NormalHashMapTestLazyOutputAll) {
 
     // create param
     auto param = create_table_param_int(TJoinOp::INNER_JOIN, 3);
-    param.enable_lazy_materialize = true;
+    param.enable_late_materialization = true;
 
     // create hash table
     JoinHashTable ht;
@@ -2518,7 +2518,7 @@ TEST_F(JoinHashMapTest, NormalHashMapTestLazyOutputPart) {
 
     // create param
     auto param = create_table_param_int(TJoinOp::INNER_JOIN, 3);
-    param.enable_lazy_materialize = true;
+    param.enable_late_materialization = true;
 
     // create hash table
     JoinHashTable ht;
@@ -2590,7 +2590,7 @@ TEST_F(JoinHashMapTest, NormalHashMapTestLazyOutputPartRemain) {
 
     // create param
     auto param = create_table_param_int(TJoinOp::RIGHT_OUTER_JOIN, 3);
-    param.enable_lazy_materialize = true;
+    param.enable_late_materialization = true;
 
     // create hash table
     JoinHashTable ht;
@@ -2718,7 +2718,7 @@ TEST_F(JoinHashMapTest, TestOutputSlotsEmpty) {
 
     HashTableParam param;
     param.mor_reader_mode = false;
-    param.enable_lazy_materialize = false;
+    param.enable_late_materialization = false;
     param.probe_row_desc = probe_row_desc.get();
     param.build_row_desc = build_row_desc.get();
 
@@ -2746,7 +2746,7 @@ TEST_F(JoinHashMapTest, TestOutputSlotsNormal) {
 
     HashTableParam param;
     param.mor_reader_mode = false;
-    param.enable_lazy_materialize = false;
+    param.enable_late_materialization = false;
     param.probe_row_desc = probe_row_desc.get();
     param.build_row_desc = build_row_desc.get();
     param.probe_output_slots = {1};
@@ -2777,7 +2777,7 @@ TEST_F(JoinHashMapTest, TestLazyOutputSlotsEmpty) {
 
     HashTableParam param;
     param.mor_reader_mode = false;
-    param.enable_lazy_materialize = true;
+    param.enable_late_materialization = true;
     param.probe_row_desc = probe_row_desc.get();
     param.build_row_desc = build_row_desc.get();
 
@@ -2805,7 +2805,7 @@ TEST_F(JoinHashMapTest, TestLazyPredicateSlotsEmpty) {
 
     HashTableParam param;
     param.mor_reader_mode = false;
-    param.enable_lazy_materialize = true;
+    param.enable_late_materialization = true;
     param.probe_row_desc = probe_row_desc.get();
     param.build_row_desc = build_row_desc.get();
     param.probe_output_slots = {1};
@@ -2836,7 +2836,7 @@ TEST_F(JoinHashMapTest, TestLazyPredicateSlotsNormal) {
 
     HashTableParam param;
     param.mor_reader_mode = false;
-    param.enable_lazy_materialize = true;
+    param.enable_late_materialization = true;
     param.probe_row_desc = probe_row_desc.get();
     param.build_row_desc = build_row_desc.get();
     param.probe_output_slots = {1};
@@ -2867,7 +2867,7 @@ TEST_F(JoinHashMapTest, TestMorRead) {
 
     HashTableParam param;
     param.mor_reader_mode = true;
-    param.enable_lazy_materialize = false;
+    param.enable_late_materialization = false;
     param.probe_row_desc = probe_row_desc.get();
     param.build_row_desc = build_row_desc.get();
     param.probe_output_slots = {1};

--- a/fe/fe-core/src/main/java/com/starrocks/planner/HashJoinNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/HashJoinNode.java
@@ -115,7 +115,7 @@ public class HashJoinNode extends JoinNode {
             msg.hash_join_node.setBuild_runtime_filters(
                     RuntimeFilterDescription.toThriftRuntimeFilterDescriptions(buildRuntimeFilters));
         }
-        msg.hash_join_node.setLate_materialization(ConnectContext.get().getSessionVariable().isJoinLateMaterialization());
+        msg.hash_join_node.setLate_materialization(enableLateMaterialization);
         msg.hash_join_node.setBuild_runtime_filters_from_planner(
                 ConnectContext.get().getSessionVariable().getEnableGlobalRuntimeFilter());
         if (partitionExprs != null) {

--- a/fe/fe-core/src/main/java/com/starrocks/planner/HashJoinNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/HashJoinNode.java
@@ -115,7 +115,7 @@ public class HashJoinNode extends JoinNode {
             msg.hash_join_node.setBuild_runtime_filters(
                     RuntimeFilterDescription.toThriftRuntimeFilterDescriptions(buildRuntimeFilters));
         }
-        msg.hash_join_node.setEnable_late_materialization(ConnectContext.get().getSessionVariable().isEnableLateMaterializationJoin());
+        msg.hash_join_node.setEnable_late_materialization(ConnectContext.get().getSessionVariable().isJoinLateMaterialization());
         msg.hash_join_node.setBuild_runtime_filters_from_planner(
                 ConnectContext.get().getSessionVariable().getEnableGlobalRuntimeFilter());
         if (partitionExprs != null) {

--- a/fe/fe-core/src/main/java/com/starrocks/planner/HashJoinNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/HashJoinNode.java
@@ -115,7 +115,7 @@ public class HashJoinNode extends JoinNode {
             msg.hash_join_node.setBuild_runtime_filters(
                     RuntimeFilterDescription.toThriftRuntimeFilterDescriptions(buildRuntimeFilters));
         }
-        msg.hash_join_node.setEnable_lazy_materialize(ConnectContext.get().getSessionVariable().isEnableLazyMaterializeJoin());
+        msg.hash_join_node.setEnable_late_materialization(ConnectContext.get().getSessionVariable().isEnableLateMaterializationJoin());
         msg.hash_join_node.setBuild_runtime_filters_from_planner(
                 ConnectContext.get().getSessionVariable().getEnableGlobalRuntimeFilter());
         if (partitionExprs != null) {
@@ -143,7 +143,7 @@ public class HashJoinNode extends JoinNode {
         hashJoinNode.setIs_rewritten_from_not_in(innerRef != null && innerRef.isJoinRewrittenFromNotIn());
         hashJoinNode.setPartition_exprs(normalizer.normalizeOrderedExprs(partitionExprs));
         hashJoinNode.setOutput_columns(normalizer.remapIntegerSlotIds(outputSlots));
-        hashJoinNode.setEnable_lazy_materialize(enableLazyMaterialize);
+        hashJoinNode.setEnable_late_materialization(enableLateMaterialization);
         planNode.setHash_join_node(hashJoinNode);
         planNode.setNode_type(TPlanNodeType.HASH_JOIN_NODE);
         normalizeConjuncts(normalizer, planNode, conjuncts);

--- a/fe/fe-core/src/main/java/com/starrocks/planner/HashJoinNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/HashJoinNode.java
@@ -115,6 +115,7 @@ public class HashJoinNode extends JoinNode {
             msg.hash_join_node.setBuild_runtime_filters(
                     RuntimeFilterDescription.toThriftRuntimeFilterDescriptions(buildRuntimeFilters));
         }
+        msg.hash_join_node.setEnable_lazy_materialize(ConnectContext.get().getSessionVariable().isEnableLazyMaterializeJoin());
         msg.hash_join_node.setBuild_runtime_filters_from_planner(
                 ConnectContext.get().getSessionVariable().getEnableGlobalRuntimeFilter());
         if (partitionExprs != null) {
@@ -142,6 +143,7 @@ public class HashJoinNode extends JoinNode {
         hashJoinNode.setIs_rewritten_from_not_in(innerRef != null && innerRef.isJoinRewrittenFromNotIn());
         hashJoinNode.setPartition_exprs(normalizer.normalizeOrderedExprs(partitionExprs));
         hashJoinNode.setOutput_columns(normalizer.remapIntegerSlotIds(outputSlots));
+        hashJoinNode.setEnable_lazy_materialize(enableLazyMaterialize);
         planNode.setHash_join_node(hashJoinNode);
         planNode.setNode_type(TPlanNodeType.HASH_JOIN_NODE);
         normalizeConjuncts(normalizer, planNode, conjuncts);

--- a/fe/fe-core/src/main/java/com/starrocks/planner/HashJoinNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/HashJoinNode.java
@@ -115,7 +115,7 @@ public class HashJoinNode extends JoinNode {
             msg.hash_join_node.setBuild_runtime_filters(
                     RuntimeFilterDescription.toThriftRuntimeFilterDescriptions(buildRuntimeFilters));
         }
-        msg.hash_join_node.setEnable_late_materialization(ConnectContext.get().getSessionVariable().isJoinLateMaterialization());
+        msg.hash_join_node.setLate_materialization(ConnectContext.get().getSessionVariable().isJoinLateMaterialization());
         msg.hash_join_node.setBuild_runtime_filters_from_planner(
                 ConnectContext.get().getSessionVariable().getEnableGlobalRuntimeFilter());
         if (partitionExprs != null) {
@@ -143,7 +143,7 @@ public class HashJoinNode extends JoinNode {
         hashJoinNode.setIs_rewritten_from_not_in(innerRef != null && innerRef.isJoinRewrittenFromNotIn());
         hashJoinNode.setPartition_exprs(normalizer.normalizeOrderedExprs(partitionExprs));
         hashJoinNode.setOutput_columns(normalizer.remapIntegerSlotIds(outputSlots));
-        hashJoinNode.setEnable_late_materialization(enableLateMaterialization);
+        hashJoinNode.setLate_materialization(enableLateMaterialization);
         planNode.setHash_join_node(hashJoinNode);
         planNode.setNode_type(TPlanNodeType.HASH_JOIN_NODE);
         normalizeConjuncts(normalizer, planNode, conjuncts);

--- a/fe/fe-core/src/main/java/com/starrocks/planner/JoinNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/JoinNode.java
@@ -92,6 +92,7 @@ public abstract class JoinNode extends PlanNode implements RuntimeFilterBuildNod
     // contains both the cols required by parent node and cols required by
     // other join conjuncts and predicates
     protected List<Integer> outputSlots;
+    protected boolean enableLazyMaterialize = false;
 
     // The partitionByExprs which need to check the probe side for partition join.
     protected List<Expr> probePartitionByExprs;

--- a/fe/fe-core/src/main/java/com/starrocks/planner/JoinNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/JoinNode.java
@@ -92,7 +92,7 @@ public abstract class JoinNode extends PlanNode implements RuntimeFilterBuildNod
     // contains both the cols required by parent node and cols required by
     // other join conjuncts and predicates
     protected List<Integer> outputSlots;
-    protected boolean enableLazyMaterialize = false;
+    protected boolean enableLateMaterialization = false;
 
     // The partitionByExprs which need to check the probe side for partition join.
     protected List<Expr> probePartitionByExprs;

--- a/fe/fe-core/src/main/java/com/starrocks/planner/JoinNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/JoinNode.java
@@ -172,6 +172,10 @@ public abstract class JoinNode extends PlanNode implements RuntimeFilterBuildNod
         }
     }
 
+    public void setEnableLateMaterialization(boolean enableLateMaterialization) {
+        this.enableLateMaterialization = enableLateMaterialization;
+    }
+
     public void setProbePartitionByExprs(List<Expr> probePartitionByExprs) {
         this.probePartitionByExprs = probePartitionByExprs;
     }

--- a/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
@@ -2682,14 +2682,6 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
         return enableLazyMaterializeJoin;
     }
 
-    public void enableLazyMaterializeJoin() {
-        this.enableLazyMaterializeJoin = true;
-    }
-
-    public void disableLazyMaterializeJoin() {
-        this.enableLazyMaterializeJoin = false;
-    }
-
     public void disableTrimOnlyFilteredColumnsInScanStage() {
         this.enableFilterUnusedColumnsInScanStage = false;
     }

--- a/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
@@ -288,6 +288,8 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
     public static final String ENABLE_FILTER_UNUSED_COLUMNS_IN_SCAN_STAGE =
             "enable_filter_unused_columns_in_scan_stage";
 
+    public static final String ENABLE_LAZY_MATERIALIZATION_JOIN = "enable_lazy_materialization_join";
+
     public static final String ENABLE_PRUNE_COLUMN_AFTER_INDEX_FILTER =
             "enable_prune_column_after_index_filter";
     
@@ -1178,6 +1180,9 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
 
     @VariableMgr.VarAttr(name = ENABLE_FILTER_UNUSED_COLUMNS_IN_SCAN_STAGE)
     private boolean enableFilterUnusedColumnsInScanStage = true;
+
+    @VariableMgr.VarAttr(name = ENABLE_LAZY_MATERIALIZATION_JOIN)
+    private boolean enableLazyMaterializeJoin = false;
 
     @VariableMgr.VarAttr(name = ENABLE_PRUNE_COLUMN_AFTER_INDEX_FILTER, flag = VariableMgr.INVISIBLE)
     private boolean enablePruneColumnAfterIndexFilter = true;
@@ -2671,6 +2676,18 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
 
     public boolean isEnableGinFilter() {
         return enableGinFilter;
+    }
+
+    public boolean isEnableLazyMaterializeJoin() {
+        return enableLazyMaterializeJoin;
+    }
+
+    public void enableLazyMaterializeJoin() {
+        this.enableLazyMaterializeJoin = true;
+    }
+
+    public void disableLazyMaterializeJoin() {
+        this.enableLazyMaterializeJoin = false;
     }
 
     public void disableTrimOnlyFilteredColumnsInScanStage() {

--- a/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
@@ -288,7 +288,7 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
     public static final String ENABLE_FILTER_UNUSED_COLUMNS_IN_SCAN_STAGE =
             "enable_filter_unused_columns_in_scan_stage";
 
-    public static final String ENABLE_LATE_MATERIALIZATION_JOIN = "enable_late_materialization_join";
+    public static final String JOIN_LATE_MATERIALIZATION = "join_late_materialization";
 
     public static final String ENABLE_PRUNE_COLUMN_AFTER_INDEX_FILTER =
             "enable_prune_column_after_index_filter";
@@ -1181,8 +1181,8 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
     @VariableMgr.VarAttr(name = ENABLE_FILTER_UNUSED_COLUMNS_IN_SCAN_STAGE)
     private boolean enableFilterUnusedColumnsInScanStage = true;
 
-    @VariableMgr.VarAttr(name = ENABLE_LATE_MATERIALIZATION_JOIN)
-    private boolean enableLateMaterializationJoin = false;
+    @VariableMgr.VarAttr(name = JOIN_LATE_MATERIALIZATION)
+    private boolean joinLateMaterialization = false;
 
     @VariableMgr.VarAttr(name = ENABLE_PRUNE_COLUMN_AFTER_INDEX_FILTER, flag = VariableMgr.INVISIBLE)
     private boolean enablePruneColumnAfterIndexFilter = true;
@@ -2678,8 +2678,8 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
         return enableGinFilter;
     }
 
-    public boolean isEnableLateMaterializationJoin() {
-        return enableLateMaterializationJoin;
+    public boolean isJoinLateMaterialization() {
+        return joinLateMaterialization;
     }
 
     public void disableTrimOnlyFilteredColumnsInScanStage() {

--- a/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
@@ -288,7 +288,7 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
     public static final String ENABLE_FILTER_UNUSED_COLUMNS_IN_SCAN_STAGE =
             "enable_filter_unused_columns_in_scan_stage";
 
-    public static final String ENABLE_LAZY_MATERIALIZATION_JOIN = "enable_lazy_materialization_join";
+    public static final String ENABLE_LATE_MATERIALIZATION_JOIN = "enable_late_materialization_join";
 
     public static final String ENABLE_PRUNE_COLUMN_AFTER_INDEX_FILTER =
             "enable_prune_column_after_index_filter";
@@ -1181,8 +1181,8 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
     @VariableMgr.VarAttr(name = ENABLE_FILTER_UNUSED_COLUMNS_IN_SCAN_STAGE)
     private boolean enableFilterUnusedColumnsInScanStage = true;
 
-    @VariableMgr.VarAttr(name = ENABLE_LAZY_MATERIALIZATION_JOIN)
-    private boolean enableLazyMaterializeJoin = false;
+    @VariableMgr.VarAttr(name = ENABLE_LATE_MATERIALIZATION_JOIN)
+    private boolean enableLateMaterializationJoin = false;
 
     @VariableMgr.VarAttr(name = ENABLE_PRUNE_COLUMN_AFTER_INDEX_FILTER, flag = VariableMgr.INVISIBLE)
     private boolean enablePruneColumnAfterIndexFilter = true;
@@ -2678,8 +2678,8 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
         return enableGinFilter;
     }
 
-    public boolean isEnableLazyMaterializeJoin() {
-        return enableLazyMaterializeJoin;
+    public boolean isEnableLateMaterializationJoin() {
+        return enableLateMaterializationJoin;
     }
 
     public void disableTrimOnlyFilteredColumnsInScanStage() {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/plan/PlanFragmentBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/plan/PlanFragmentBuilder.java
@@ -2703,6 +2703,7 @@ public class PlanFragmentBuilder {
             joinNode.setLimit(node.getLimit());
             joinNode.computeStatistics(optExpr.getStatistics());
             joinNode.setProbePartitionByExprs(probePartitionByExprs);
+            joinNode.setEnableLateMaterialization(ConnectContext.get().getSessionVariable().isJoinLateMaterialization());
             // enable group execution for colocate join
             currentExecGroup = leftExecGroup;
             if (ConnectContext.get().getSessionVariable().isEnableGroupExecution()) {

--- a/gensrc/thrift/Normalization.thrift
+++ b/gensrc/thrift/Normalization.thrift
@@ -61,6 +61,7 @@ struct TNormalHashJoinNode {
   5: optional PlanNodes.TJoinDistributionMode distribution_mode
   6: optional list<binary> partition_exprs
   7: optional list<Types.TSlotId> output_columns
+  8: optional bool enable_lazy_materialize;
 }
 
 

--- a/gensrc/thrift/Normalization.thrift
+++ b/gensrc/thrift/Normalization.thrift
@@ -61,7 +61,7 @@ struct TNormalHashJoinNode {
   5: optional PlanNodes.TJoinDistributionMode distribution_mode
   6: optional list<binary> partition_exprs
   7: optional list<Types.TSlotId> output_columns
-  8: optional bool enable_late_materialization
+  8: optional bool late_materialization
 }
 
 

--- a/gensrc/thrift/Normalization.thrift
+++ b/gensrc/thrift/Normalization.thrift
@@ -61,7 +61,7 @@ struct TNormalHashJoinNode {
   5: optional PlanNodes.TJoinDistributionMode distribution_mode
   6: optional list<binary> partition_exprs
   7: optional list<Types.TSlotId> output_columns
-  8: optional bool enable_lazy_materialize;
+  8: optional bool enable_lazy_materialize
 }
 
 

--- a/gensrc/thrift/Normalization.thrift
+++ b/gensrc/thrift/Normalization.thrift
@@ -61,7 +61,7 @@ struct TNormalHashJoinNode {
   5: optional PlanNodes.TJoinDistributionMode distribution_mode
   6: optional list<binary> partition_exprs
   7: optional list<Types.TSlotId> output_columns
-  8: optional bool enable_lazy_materialize
+  8: optional bool enable_late_materialization
 }
 
 

--- a/gensrc/thrift/PlanNodes.thrift
+++ b/gensrc/thrift/PlanNodes.thrift
@@ -657,7 +657,7 @@ struct THashJoinNode {
 
   // used in pipeline engine
   55: optional bool interpolate_passthrough = false
-  56: optional bool enable_lazy_materialize = false
+  56: optional bool enable_late_materialization = false
 }
 
 struct TMergeJoinNode {

--- a/gensrc/thrift/PlanNodes.thrift
+++ b/gensrc/thrift/PlanNodes.thrift
@@ -657,7 +657,7 @@ struct THashJoinNode {
 
   // used in pipeline engine
   55: optional bool interpolate_passthrough = false
-  56: optional bool enable_lazy_materialize = false;
+  56: optional bool enable_lazy_materialize = false
 }
 
 struct TMergeJoinNode {

--- a/gensrc/thrift/PlanNodes.thrift
+++ b/gensrc/thrift/PlanNodes.thrift
@@ -657,6 +657,7 @@ struct THashJoinNode {
 
   // used in pipeline engine
   55: optional bool interpolate_passthrough = false
+  56: optional bool enable_lazy_materialize = false;
 }
 
 struct TMergeJoinNode {

--- a/gensrc/thrift/PlanNodes.thrift
+++ b/gensrc/thrift/PlanNodes.thrift
@@ -657,7 +657,7 @@ struct THashJoinNode {
 
   // used in pipeline engine
   55: optional bool interpolate_passthrough = false
-  56: optional bool enable_late_materialization = false
+  56: optional bool late_materialization = false
 }
 
 struct TMergeJoinNode {

--- a/test/sql/test_join/R/test_lazy_materialize
+++ b/test/sql/test_join/R/test_lazy_materialize
@@ -2,7 +2,7 @@
 set pipeline_dop = 1;
 -- result:
 -- !result
-set enable_lazy_materialization_join=true;
+set enable_late_materialization_join=true;
 -- result:
 -- !result
 CREATE TABLE t1 (

--- a/test/sql/test_join/R/test_lazy_materialize
+++ b/test/sql/test_join/R/test_lazy_materialize
@@ -2,7 +2,7 @@
 set pipeline_dop = 1;
 -- result:
 -- !result
-set enable_join_late_materialization=true;
+set join_late_materialization=true;
 -- result:
 -- !result
 CREATE TABLE t1 (

--- a/test/sql/test_join/R/test_lazy_materialize
+++ b/test/sql/test_join/R/test_lazy_materialize
@@ -2,7 +2,7 @@
 set pipeline_dop = 1;
 -- result:
 -- !result
-set enable_late_materialization_join=true;
+set enable_join_late_materialization=true;
 -- result:
 -- !result
 CREATE TABLE t1 (

--- a/test/sql/test_join/R/test_lazy_materialize
+++ b/test/sql/test_join/R/test_lazy_materialize
@@ -1,0 +1,175 @@
+-- name: test_lazy_materialize
+set pipeline_dop = 1;
+-- result:
+-- !result
+set enable_lazy_materialization_join=true;
+-- result:
+-- !result
+CREATE TABLE t1 (
+    t1_c1 INT NOT NULL,
+    t1_c2 INT NOT NULL,
+    t1_c3 INT NOT NULL,
+    t1_c4 INT NOT NULL,
+    t1_c5 INT NOT NULL
+)
+DUPLICATE KEY(t1_c1)
+DISTRIBUTED BY HASH(t1_c1) buckets 1;
+-- result:
+-- !result
+CREATE TABLE t2 (
+    t2_c1 INT NOT NULL,
+    t2_c2 INT NOT NULL,
+    t2_c3 INT NOT NULL,
+    t2_c4 INT NOT NULL,
+    t2_c5 INT NOT NULL
+)
+DUPLICATE KEY(t2_c1)
+DISTRIBUTED BY HASH(t2_c1) buckets 1;
+-- result:
+-- !result
+CREATE TABLE nullable_t1 (
+    t1_c1 INT,
+    t1_c2 INT,
+    t1_c3 INT,
+    t1_c4 INT,
+    t1_c5 INT
+)
+DUPLICATE KEY(t1_c1)
+DISTRIBUTED BY HASH(t1_c1) buckets 1;
+-- result:
+-- !result
+CREATE TABLE nullable_t2 (
+    t2_c1 INT,
+    t2_c2 INT,
+    t2_c3 INT,
+    t2_c4 INT,
+    t2_c5 INT
+)
+DUPLICATE KEY(t2_c1)
+DISTRIBUTED BY HASH(t2_c1) buckets 1;
+-- result:
+-- !result
+INSERT INTO t1 values
+(1, 11, 111, 1111, 11111),
+(2, 22, 222, 2222, 22222),
+(3, 33, 333, 3333, 33333),
+(4, 44, 444, 4444, 44444),
+(5, 55, 555, 5555, 55555);
+-- result:
+-- !result
+INSERT INTO t2 values
+(3, 44, 444, 444, 44444),
+(4, 33, 333, 333, 33333),
+(5, 55, 555, 5555, 55555),
+(6, 77, 777, 7777, 77777),
+(7, 66, 666, 6666, 66666);
+-- result:
+-- !result
+INSERT INTO nullable_t1 values
+(1, 11, 111, 1111, 11111),
+(2, 22, 222, 2222, 22222),
+(3, 33, null, 3333, 33333),
+(4, 44, 444, 4444, 44444),
+(5, 55, 555, 5555, 55555);
+-- result:
+-- !result
+INSERT INTO nullable_t2 values
+(3, 44, 444, 4444, 44444),
+(4, 33, 333, 3333, 33333),
+(5, 55, 555, 5555, 55555),
+(6, 77, 777, null, 77777),
+(7, 77, 666, 6666, 66666);
+-- result:
+-- !result
+select * from t1 inner join [broadcast] t2 on t1_c1=t2_c1 and t1_c2>t2_c2 order by t1_c2;
+-- result:
+4	44	444	4444	44444	4	33	333	333	33333
+-- !result
+select t1_c3, t1_c4, t2_c3, t2_c4 from t1 inner join [broadcast] t2 on t1_c1=t2_c1 and t1_c2>t2_c2 order by t1_c2;
+-- result:
+444	4444	333	333
+-- !result
+select t1_c3, t1_c4, t2_c3, t2_c4 from t1 inner join [broadcast] t2 on t1_c1=t2_c1 and t1_c2>t2_c2+55 order by t1_c2;
+-- result:
+-- !result
+select t1_c3, t1_c4, t2_c3, t2_c4 from t1 right outer join [shuffle] t2 on t1_c1=t2_c1 and t1_c2>t2_c2 order by t2_c2;
+-- result:
+444	4444	333	333
+None	None	444	444
+None	None	555	5555
+None	None	666	6666
+None	None	777	7777
+-- !result
+truncate table t2;
+-- result:
+-- !result
+select * from t1 left outer join [broadcast] t2 on t1_c1=t2_c1 and t1_c2>t2_c2 order by t1_c2;
+-- result:
+1	11	111	1111	11111	None	None	None	None	None
+2	22	222	2222	22222	None	None	None	None	None
+3	33	333	3333	33333	None	None	None	None	None
+4	44	444	4444	44444	None	None	None	None	None
+5	55	555	5555	55555	None	None	None	None	None
+-- !result
+select t1_c3, t1_c4, t2_c3, t2_c4 from t1 left outer join [broadcast] t2 on t1_c1=t2_c1 and t1_c2>t2_c2 order by t1_c2;
+-- result:
+111	1111	None	None
+222	2222	None	None
+333	3333	None	None
+444	4444	None	None
+555	5555	None	None
+-- !result
+select t1_c3, t1_c4, t2_c3, t2_c4 from t1 left outer join [broadcast] t2 on t1_c1=t2_c1 and t1_c2>t2_c2+55 order by t1_c2;
+-- result:
+111	1111	None	None
+222	2222	None	None
+333	3333	None	None
+444	4444	None	None
+555	5555	None	None
+-- !result
+select * from nullable_t1 inner join [broadcast] nullable_t2 on t1_c1=t2_c1 and t1_c2>t2_c2 order by t1_c2;
+-- result:
+4	44	444	4444	44444	4	33	333	3333	33333
+-- !result
+select t1_c3, t1_c4, t2_c3, t2_c4 from nullable_t1 inner join [broadcast] nullable_t2 on t1_c1=t2_c1 and t1_c2>t2_c2 order by t1_c2;
+-- result:
+444	4444	333	3333
+-- !result
+select t1_c3, t1_c4, t2_c3, t2_c4 from nullable_t1 inner join [broadcast] nullable_t2 on t1_c1=t2_c1 and t1_c2>t2_c2+55 order by t1_c2;
+-- result:
+-- !result
+select t1_c3, t1_c4, t2_c3, t2_c4 from nullable_t1 right outer join [shuffle] nullable_t2 on t1_c1=t2_c1 and t1_c2>t2_c2 order by t2_c2;
+-- result:
+444	4444	333	3333
+None	None	444	4444
+None	None	555	5555
+None	None	777	None
+None	None	666	6666
+-- !result
+truncate table nullable_t2;
+-- result:
+-- !result
+select * from nullable_t1 left outer join [broadcast] nullable_t2 on t1_c1=t2_c1 and t1_c2>t2_c2 order by t1_c2;
+-- result:
+1	11	111	1111	11111	None	None	None	None	None
+2	22	222	2222	22222	None	None	None	None	None
+3	33	None	3333	33333	None	None	None	None	None
+4	44	444	4444	44444	None	None	None	None	None
+5	55	555	5555	55555	None	None	None	None	None
+-- !result
+select t1_c3, t1_c4, t2_c3, t2_c4 from nullable_t1 left outer join [broadcast] nullable_t2 on t1_c1=t2_c1 and t1_c2>t2_c2 order by t1_c2;
+-- result:
+111	1111	None	None
+222	2222	None	None
+None	3333	None	None
+444	4444	None	None
+555	5555	None	None
+-- !result
+select t1_c3, t1_c4, t2_c3, t2_c4 from nullable_t1 left outer join [broadcast] nullable_t2 on t1_c1=t2_c1 and t1_c2>t2_c2+55 order by t1_c2;
+-- result:
+111	1111	None	None
+222	2222	None	None
+None	3333	None	None
+444	4444	None	None
+555	5555	None	None
+-- !result

--- a/test/sql/test_join/T/test_lazy_materialize
+++ b/test/sql/test_join/T/test_lazy_materialize
@@ -1,0 +1,109 @@
+-- name: test_lazy_materialize
+set pipeline_dop = 1;
+set enable_lazy_materialization_join=true;
+
+CREATE TABLE t1 (
+    t1_c1 INT NOT NULL,
+    t1_c2 INT NOT NULL,
+    t1_c3 INT NOT NULL,
+    t1_c4 INT NOT NULL,
+    t1_c5 INT NOT NULL
+)
+DUPLICATE KEY(t1_c1)
+DISTRIBUTED BY HASH(t1_c1) buckets 1;
+
+CREATE TABLE t2 (
+    t2_c1 INT NOT NULL,
+    t2_c2 INT NOT NULL,
+    t2_c3 INT NOT NULL,
+    t2_c4 INT NOT NULL,
+    t2_c5 INT NOT NULL
+)
+DUPLICATE KEY(t2_c1)
+DISTRIBUTED BY HASH(t2_c1) buckets 1;
+
+CREATE TABLE nullable_t1 (
+    t1_c1 INT,
+    t1_c2 INT,
+    t1_c3 INT,
+    t1_c4 INT,
+    t1_c5 INT
+)
+DUPLICATE KEY(t1_c1)
+DISTRIBUTED BY HASH(t1_c1) buckets 1;
+
+CREATE TABLE nullable_t2 (
+    t2_c1 INT,
+    t2_c2 INT,
+    t2_c3 INT,
+    t2_c4 INT,
+    t2_c5 INT
+)
+DUPLICATE KEY(t2_c1)
+DISTRIBUTED BY HASH(t2_c1) buckets 1;
+
+INSERT INTO t1 values
+(1, 11, 111, 1111, 11111),
+(2, 22, 222, 2222, 22222),
+(3, 33, 333, 3333, 33333),
+(4, 44, 444, 4444, 44444),
+(5, 55, 555, 5555, 55555);
+
+INSERT INTO t2 values
+(3, 44, 444, 444, 44444),
+(4, 33, 333, 333, 33333),
+(5, 55, 555, 5555, 55555),
+(6, 77, 777, 7777, 77777),
+(7, 66, 666, 6666, 66666);
+
+INSERT INTO nullable_t1 values
+(1, 11, 111, 1111, 11111),
+(2, 22, 222, 2222, 22222),
+(3, 33, null, 3333, 33333),
+(4, 44, 444, 4444, 44444),
+(5, 55, 555, 5555, 55555);
+
+INSERT INTO nullable_t2 values
+(3, 44, 444, 4444, 44444),
+(4, 33, 333, 3333, 33333),
+(5, 55, 555, 5555, 55555),
+(6, 77, 777, null, 77777),
+(7, 77, 666, 6666, 66666);
+
+-- inner join, output all col
+select * from t1 inner join [broadcast] t2 on t1_c1=t2_c1 and t1_c2>t2_c2 order by t1_c2;
+
+-- inner join, output part col
+select t1_c3, t1_c4, t2_c3, t2_c4 from t1 inner join [broadcast] t2 on t1_c1=t2_c1 and t1_c2>t2_c2 order by t1_c2;
+
+-- inner join, output part col, empty chunk
+select t1_c3, t1_c4, t2_c3, t2_c4 from t1 inner join [broadcast] t2 on t1_c1=t2_c1 and t1_c2>t2_c2+55 order by t1_c2;
+
+-- right outer join, output part col
+select t1_c3, t1_c4, t2_c3, t2_c4 from t1 right outer join [shuffle] t2 on t1_c1=t2_c1 and t1_c2>t2_c2 order by t2_c2;
+
+-- empty hash table
+truncate table t2;
+select * from t1 left outer join [broadcast] t2 on t1_c1=t2_c1 and t1_c2>t2_c2 order by t1_c2;
+select t1_c3, t1_c4, t2_c3, t2_c4 from t1 left outer join [broadcast] t2 on t1_c1=t2_c1 and t1_c2>t2_c2 order by t1_c2;
+select t1_c3, t1_c4, t2_c3, t2_c4 from t1 left outer join [broadcast] t2 on t1_c1=t2_c1 and t1_c2>t2_c2+55 order by t1_c2;
+
+-- inner join, output all col
+select * from nullable_t1 inner join [broadcast] nullable_t2 on t1_c1=t2_c1 and t1_c2>t2_c2 order by t1_c2;
+
+-- inner join, output part col
+select t1_c3, t1_c4, t2_c3, t2_c4 from nullable_t1 inner join [broadcast] nullable_t2 on t1_c1=t2_c1 and t1_c2>t2_c2 order by t1_c2;
+
+-- inner join, output part col, empty chunk
+select t1_c3, t1_c4, t2_c3, t2_c4 from nullable_t1 inner join [broadcast] nullable_t2 on t1_c1=t2_c1 and t1_c2>t2_c2+55 order by t1_c2;
+
+-- right outer join, output part col
+select t1_c3, t1_c4, t2_c3, t2_c4 from nullable_t1 right outer join [shuffle] nullable_t2 on t1_c1=t2_c1 and t1_c2>t2_c2 order by t2_c2;
+
+-- empty hash table
+truncate table nullable_t2;
+select * from nullable_t1 left outer join [broadcast] nullable_t2 on t1_c1=t2_c1 and t1_c2>t2_c2 order by t1_c2;
+select t1_c3, t1_c4, t2_c3, t2_c4 from nullable_t1 left outer join [broadcast] nullable_t2 on t1_c1=t2_c1 and t1_c2>t2_c2 order by t1_c2;
+select t1_c3, t1_c4, t2_c3, t2_c4 from nullable_t1 left outer join [broadcast] nullable_t2 on t1_c1=t2_c1 and t1_c2>t2_c2+55 order by t1_c2;
+
+

--- a/test/sql/test_join/T/test_lazy_materialize
+++ b/test/sql/test_join/T/test_lazy_materialize
@@ -1,6 +1,6 @@
 -- name: test_lazy_materialize
 set pipeline_dop = 1;
-set enable_lazy_materialization_join=true;
+set enable_late_materialization_join=true;
 
 CREATE TABLE t1 (
     t1_c1 INT NOT NULL,

--- a/test/sql/test_join/T/test_lazy_materialize
+++ b/test/sql/test_join/T/test_lazy_materialize
@@ -1,6 +1,6 @@
 -- name: test_lazy_materialize
 set pipeline_dop = 1;
-set enable_late_materialization_join=true;
+set join_late_materialization=true;
 
 CREATE TABLE t1 (
     t1_c1 INT NOT NULL,


### PR DESCRIPTION
## Why I'm doing:

The 6th pr for late materialize join.

Performance test:

set join_late_materialization=false;

```
mysql> select sum(lo_revenue), count(lo_shipmode), count(p_name), count(p_mfgr),  count(p_category), count(p_brand), count(p_color), count(p_type), count(p_size), count(p_container) from lineorder join part      on lo_partkey=p_partkey  where (p_size+lo_linenumber)>50;
+-----------------+--------------------+---------------+---------------+-------------------+----------------+----------------+---------------+---------------+--------------------+
| sum(lo_revenue) | count(lo_shipmode) | count(p_name) | count(p_mfgr) | count(p_category) | count(p_brand) | count(p_color) | count(p_type) | count(p_size) | count(p_container) |
+-----------------+--------------------+---------------+---------------+-------------------+----------------+----------------+---------------+---------------+--------------------+
|  31262184105324 |            8614970 |       8614970 |       8614970 |           8614970 |        8614970 |        8614970 |       8614970 |       8614970 |            8614970 |
+-----------------+--------------------+---------------+---------------+-------------------+----------------+----------------+---------------+---------------+--------------------+
1 row in set (18.05 sec)
```

set join_late_materialization=true;

```
mysql> select sum(lo_revenue), count(lo_shipmode), count(p_name), count(p_mfgr),  count(p_category), count(p_brand), count(p_color), count(p_type), count(p_size), count(p_container) from lineorder join part      on lo_partkey=p_partkey  where (p_size+lo_linenumber)>50;
+-----------------+--------------------+---------------+---------------+-------------------+----------------+----------------+---------------+---------------+--------------------+
| sum(lo_revenue) | count(lo_shipmode) | count(p_name) | count(p_mfgr) | count(p_category) | count(p_brand) | count(p_color) | count(p_type) | count(p_size) | count(p_container) |
+-----------------+--------------------+---------------+---------------+-------------------+----------------+----------------+---------------+---------------+--------------------+
|  31262184105324 |            8614970 |       8614970 |       8614970 |           8614970 |        8614970 |        8614970 |       8614970 |       8614970 |            8614970 |
+-----------------+--------------------+---------------+---------------+-------------------+----------------+----------------+---------------+---------------+--------------------+
1 row in set (7.33 sec)
```

## What I'm doing:

Add session variables to enable/disable lazy materialized join

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
