### PR TITLE
[Enhancement] Using separate memtable flush executor for shared-data mode

### DIFF
--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -613,6 +613,10 @@ CONF_mDouble(storage_high_usage_disk_protect_ratio, "0.1"); // 10%
 // Number of thread for flushing memtable per store.
 CONF_mInt32(flush_thread_num_per_store, "2");
 
+// Number of thread for flushing memtable per store in shared-data mode.
+// Default value is cpu cores * 2
+CONF_mInt32(lake_flush_thread_num_per_store, "0");
+
 // Config for tablet meta checkpoint.
 CONF_mInt32(tablet_meta_checkpoint_min_new_rowsets_num, "10");
 CONF_mInt32(tablet_meta_checkpoint_min_interval_secs, "600");

--- a/be/src/http/action/update_config_action.cpp
+++ b/be/src/http/action/update_config_action.cpp
@@ -130,6 +130,14 @@ Status UpdateConfigAction::update_config(const std::string& name, const std::str
             (void)StorageEngine::instance()->segment_flush_executor()->update_max_threads(
                     config::flush_thread_num_per_store * dir_cnt);
         });
+        _config_callback.emplace("lake_flush_thread_num_per_store", [&]() {
+            int threads = config::lake_flush_thread_num_per_store;
+            if (threads <= 0) {
+                threads = CpuInfo::num_cores() * 2;
+            }
+            const size_t dir_cnt = StorageEngine::instance()->get_stores().size();
+            (void)StorageEngine::instance()->lake_memtable_flush_executor()->update_max_threads(threads * dir_cnt);
+        });
         _config_callback.emplace("update_compaction_num_threads_per_disk", [&]() {
             StorageEngine::instance()->increase_update_compaction_thread(
                     config::update_compaction_num_threads_per_disk);

--- a/be/src/http/action/update_config_action.cpp
+++ b/be/src/http/action/update_config_action.cpp
@@ -131,12 +131,8 @@ Status UpdateConfigAction::update_config(const std::string& name, const std::str
                     config::flush_thread_num_per_store * dir_cnt);
         });
         _config_callback.emplace("lake_flush_thread_num_per_store", [&]() {
-            int threads = config::lake_flush_thread_num_per_store;
-            if (threads <= 0) {
-                threads = CpuInfo::num_cores() * 2;
-            }
-            const size_t dir_cnt = StorageEngine::instance()->get_stores().size();
-            (void)StorageEngine::instance()->lake_memtable_flush_executor()->update_max_threads(threads * dir_cnt);
+            (void)StorageEngine::instance()->lake_memtable_flush_executor()->update_max_threads(
+                    MemTableFlushExecutor::calc_max_threads_for_lake_table(StorageEngine::instance()->get_stores()));
         });
         _config_callback.emplace("update_compaction_num_threads_per_disk", [&]() {
             StorageEngine::instance()->increase_update_compaction_thread(

--- a/be/src/runtime/lake_tablets_channel.cpp
+++ b/be/src/runtime/lake_tablets_channel.cpp
@@ -38,7 +38,6 @@
 #include "service/backend_options.h"
 #include "storage/lake/async_delta_writer.h"
 #include "storage/memtable.h"
-#include "storage/memtable_flush_executor.h"
 #include "storage/storage_engine.h"
 #include "util/bthreads/bthread_shared_mutex.h"
 #include "util/compression/block_compression.h"

--- a/be/src/storage/lake/compaction_scheduler.cpp
+++ b/be/src/storage/lake/compaction_scheduler.cpp
@@ -303,7 +303,7 @@ Status CompactionScheduler::do_compaction(std::unique_ptr<CompactionTaskContext>
         ThreadPool* flush_pool = nullptr;
         if (config::lake_enable_compaction_async_write) {
             // CAUTION: we reuse delta writer's memory table flush pool here
-            flush_pool = StorageEngine::instance()->memtable_flush_executor()->get_thread_pool();
+            flush_pool = StorageEngine::instance()->lake_memtable_flush_executor()->get_thread_pool();
             if (UNLIKELY(flush_pool == nullptr)) {
                 return Status::InternalError("Get memory table flush pool failed");
             }

--- a/be/src/storage/lake/delta_writer.cpp
+++ b/be/src/storage/lake/delta_writer.cpp
@@ -306,7 +306,7 @@ inline Status DeltaWriterImpl::flush() {
 // in a bthread.
 Status DeltaWriterImpl::open() {
     SCOPED_THREAD_LOCAL_MEM_SETTER(_mem_tracker, false);
-    _flush_token = StorageEngine::instance()->memtable_flush_executor()->create_flush_token();
+    _flush_token = StorageEngine::instance()->lake_memtable_flush_executor()->create_flush_token();
     if (_flush_token == nullptr) {
         return Status::InternalError("fail to create flush token");
     }
@@ -686,10 +686,10 @@ ThreadPool* DeltaWriter::io_threads() {
     if (UNLIKELY(StorageEngine::instance() == nullptr)) {
         return nullptr;
     }
-    if (UNLIKELY(StorageEngine::instance()->memtable_flush_executor() == nullptr)) {
+    if (UNLIKELY(StorageEngine::instance()->lake_memtable_flush_executor() == nullptr)) {
         return nullptr;
     }
-    return StorageEngine::instance()->memtable_flush_executor()->get_thread_pool();
+    return StorageEngine::instance()->lake_memtable_flush_executor()->get_thread_pool();
 }
 
 StatusOr<DeltaWriterBuilder::DeltaWriterPtr> DeltaWriterBuilder::build() {

--- a/be/src/storage/memtable_flush_executor.h
+++ b/be/src/storage/memtable_flush_executor.h
@@ -133,6 +133,8 @@ public:
     // because it needs path hash of each data dir.
     Status init(const std::vector<DataDir*>& data_dirs);
 
+    Status init_for_lake_table(const std::vector<DataDir*>& data_dirs);
+
     // dynamic update max threads num
     Status update_max_threads(int max_threads);
 

--- a/be/src/storage/memtable_flush_executor.h
+++ b/be/src/storage/memtable_flush_executor.h
@@ -95,9 +95,14 @@ public:
     }
 
     void set_status(const Status& status) {
-        if (status.ok()) return;
+        if (status.ok()) {
+            return;
+        }
+
         std::lock_guard l(_status_lock);
-        if (_status.ok()) _status = status;
+        if (_status.ok()) {
+            _status = status;
+        }
     }
 
 private:

--- a/be/src/storage/memtable_flush_executor.h
+++ b/be/src/storage/memtable_flush_executor.h
@@ -135,6 +135,8 @@ public:
 
     Status init_for_lake_table(const std::vector<DataDir*>& data_dirs);
 
+    static int calc_max_threads_for_lake_table(const std::vector<DataDir*>& data_dirs);
+
     // dynamic update max threads num
     Status update_max_threads(int max_threads);
 

--- a/be/src/storage/storage_engine.cpp
+++ b/be/src/storage/storage_engine.cpp
@@ -228,6 +228,11 @@ Status StorageEngine::_open(const EngineOptions& options) {
     RETURN_IF_ERROR_WITH_WARN(_memtable_flush_executor->init(dirs), "init MemTableFlushExecutor failed");
     REGISTER_THREAD_POOL_METRICS(memtable_flush, _memtable_flush_executor->get_thread_pool());
 
+    _lake_memtable_flush_executor = std::make_unique<MemTableFlushExecutor>();
+    RETURN_IF_ERROR_WITH_WARN(_lake_memtable_flush_executor->init_for_lake_table(dirs),
+                              "init lake MemTableFlushExecutor failed");
+    REGISTER_THREAD_POOL_METRICS(lake_memtable_flush, _lake_memtable_flush_executor->get_thread_pool());
+
     _segment_flush_executor = std::make_unique<SegmentFlushExecutor>();
     RETURN_IF_ERROR_WITH_WARN(_segment_flush_executor->init(dirs), "init SegmentFlushExecutor failed");
     REGISTER_THREAD_POOL_METRICS(segment_flush, _segment_flush_executor->get_thread_pool());

--- a/be/src/storage/storage_engine.h
+++ b/be/src/storage/storage_engine.h
@@ -232,6 +232,8 @@ public:
 
     MemTableFlushExecutor* memtable_flush_executor() { return _memtable_flush_executor.get(); }
 
+    MemTableFlushExecutor* lake_memtable_flush_executor() { return _lake_memtable_flush_executor.get(); }
+
     SegmentReplicateExecutor* segment_replicate_executor() { return _segment_replicate_executor.get(); }
 
     SegmentFlushExecutor* segment_flush_executor() { return _segment_flush_executor.get(); }
@@ -469,6 +471,8 @@ private:
     std::unique_ptr<bthread::Executor> _async_delta_writer_executor;
 
     std::unique_ptr<MemTableFlushExecutor> _memtable_flush_executor;
+
+    std::unique_ptr<MemTableFlushExecutor> _lake_memtable_flush_executor;
 
     std::unique_ptr<SegmentReplicateExecutor> _segment_replicate_executor;
 

--- a/be/src/util/starrocks_metrics.h
+++ b/be/src/util/starrocks_metrics.h
@@ -333,6 +333,7 @@ public:
     METRICS_DEFINE_THREAD_POOL(publish_version);
     METRICS_DEFINE_THREAD_POOL(async_delta_writer);
     METRICS_DEFINE_THREAD_POOL(memtable_flush);
+    METRICS_DEFINE_THREAD_POOL(lake_memtable_flush);
     METRICS_DEFINE_THREAD_POOL(segment_replicate);
     METRICS_DEFINE_THREAD_POOL(segment_flush);
     METRICS_DEFINE_THREAD_POOL(update_apply);

--- a/be/test/util/starrocks_metrics_test.cpp
+++ b/be/test/util/starrocks_metrics_test.cpp
@@ -323,6 +323,7 @@ TEST_F(StarRocksMetricsTest, test_metrics_register) {
     ASSERT_NE(nullptr, instance->get_metric("segment_flush_bytes_total"));
     assert_threadpool_metrics_register("async_delta_writer", instance);
     assert_threadpool_metrics_register("memtable_flush", instance);
+    assert_threadpool_metrics_register("lake_memtable_flush", instance);
     assert_threadpool_metrics_register("segment_replicate", instance);
     assert_threadpool_metrics_register("segment_flush", instance);
     assert_threadpool_metrics_register("update_apply", instance);

--- a/conf/be_test.conf
+++ b/conf/be_test.conf
@@ -38,6 +38,7 @@ transaction_apply_worker_count=1
 get_pindex_worker_count=1
 scanner_thread_pool_thread_num=1
 flush_thread_num_per_store=1
+lake_flush_thread_num_per_store=1
 pipeline_connector_scan_thread_num_per_cpu=1
 starlet_cache_thread_num=1
 fallback_to_hadoop_fs_list=unknown1://

--- a/docker/dockerfiles/allin1/be.conf
+++ b/docker/dockerfiles/allin1/be.conf
@@ -1,6 +1,7 @@
 
 # Configs to speed up broker load
 flush_thread_num_per_store=8
+lake_flush_thread_num_per_store=8
 load_process_max_memory_limit_percent=50
 brpc_socket_max_unwritten_bytes=10737418240
 

--- a/docs/en/administration/management/BE_configuration.md
+++ b/docs/en/administration/management/BE_configuration.md
@@ -1863,6 +1863,16 @@ curl http://<BE_IP>:<BE_HTTP_PORT>/varz
 - Description: Number of threads that are used for flushing MemTable in each store.
 - Introduced in: -
 
+##### lake_flush_thread_num_per_store
+
+- Default: 0
+- Type: Int
+- Unit: -
+- Is mutable: Yes
+- Description: Number of threads that are used for flushing MemTable in each store in shared-data mode. 
+When this value is set to less than or equal to `0`, the system uses twice of the CPU core count as the value
+- Introduced in: 3.1.12, 3.2.7
+
 ##### max_runnings_transactions_per_txn_map
 
 - Default: 100

--- a/docs/zh/administration/management/BE_configuration.md
+++ b/docs/zh/administration/management/BE_configuration.md
@@ -1803,6 +1803,15 @@ curl http://<BE_IP>:<BE_HTTP_PORT>/varz
 - 描述：每个 Store 用以 Flush MemTable 的线程数。
 - 引入版本：-
 
+##### lake_flush_thread_num_per_store
+
+- 默认值：0
+- 类型：Int
+- 单位：-
+- 是否动态：是
+- 描述：在存算分离模式下，每个 Store 用以 Flush MemTable 的线程数。当该参数被设置为小于或等于 `0` 时，系统默认使用 CPU 核数的两倍
+- 引入版本：3.1.12, 3.2.7
+
 ##### max_runnings_transactions_per_txn_map
 
 - 默认值：100


### PR DESCRIPTION
## Why I'm doing:
The flush_thread_num_per_store config item is not suitable in shared-data mode.

## What I'm doing:
Add  lake_flush_thread_num_per_store config item and use a separate memtable flush executor for shared-data mode.

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [x] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [x] This pr needs user documentation (for new or modified features or behaviors)
  - [x] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [x] 3.2
  - [x] 3.1
  - [ ] 3.0
  - [ ] 2.5
