### PR TITLE
[BugFix] Fix uncorrect index id for GIN index file

### DIFF
--- a/be/src/storage/rowset/rowset.cpp
+++ b/be/src/storage/rowset/rowset.cpp
@@ -400,9 +400,9 @@ Status Rowset::link_files_to(KVStore* kvstore, const std::string& dir, RowsetId 
                 const auto& index = (*(_schema->indexes()))[index_id];
                 if (index.index_type() == GIN) {
                     std::string dst_inverted_link_path = IndexDescriptor::inverted_index_file_path(
-                            dir, new_rowset_id.to_string(), segment_n, index_id);
+                            dir, new_rowset_id.to_string(), segment_n, index.index_id());
                     std::string src_inverted_file_path = IndexDescriptor::inverted_index_file_path(
-                            _rowset_path, rowset_id().to_string(), segment_n, index_id);
+                            _rowset_path, rowset_id().to_string(), segment_n, index.index_id());
 
                     RETURN_IF_ERROR(fs::create_directories(dst_inverted_link_path));
                     std::set<std::string> files;

--- a/be/src/storage/rowset/rowset.cpp
+++ b/be/src/storage/rowset/rowset.cpp
@@ -396,8 +396,8 @@ Status Rowset::link_files_to(KVStore* kvstore, const std::string& dir, RowsetId 
         // link inverted files
         if (!_schema->indexes()->empty()) {
             int segment_n = i;
-            for (int index_id = 0; index_id < _schema->indexes()->size(); index_id++) {
-                const auto& index = (*(_schema->indexes()))[index_id];
+            const auto& indexes = *_schema->indexes();
+            for (const auto& index : indexes) {
                 if (index.index_type() == GIN) {
                     std::string dst_inverted_link_path = IndexDescriptor::inverted_index_file_path(
                             dir, new_rowset_id.to_string(), segment_n, index.index_id());

--- a/be/src/storage/snapshot_manager.cpp
+++ b/be/src/storage/snapshot_manager.cpp
@@ -797,9 +797,9 @@ Status SnapshotManager::assign_new_rowset_id(SnapshotMeta* snapshot_meta, const 
                     const auto& index = (*(tablet_schema->indexes()))[index_id];
                     if (index.index_type() == GIN) {
                         std::string dst_inverted_link_path = IndexDescriptor::inverted_index_file_path(
-                                clone_dir, new_rowset_id.to_string(), segment_n, index_id);
+                                clone_dir, new_rowset_id.to_string(), segment_n, index.index_id());
                         std::string src_inverted_file_path = IndexDescriptor::inverted_index_file_path(
-                                clone_dir, old_rowset_id.to_string(), segment_n, index_id);
+                                clone_dir, old_rowset_id.to_string(), segment_n, index.index_id());
 
                         RETURN_IF_ERROR(fs::create_directories(dst_inverted_link_path));
                         std::set<std::string> files;

--- a/be/src/storage/snapshot_manager.cpp
+++ b/be/src/storage/snapshot_manager.cpp
@@ -793,8 +793,8 @@ Status SnapshotManager::assign_new_rowset_id(SnapshotMeta* snapshot_meta, const 
             RETURN_IF_ERROR(FileSystem::Default()->link_file(old_path, new_path));
             if (tablet_schema != nullptr && !tablet_schema->indexes()->empty()) {
                 int segment_n = seg_id;
-                for (int index_id = 0; index_id < tablet_schema->indexes()->size(); index_id++) {
-                    const auto& index = (*(tablet_schema->indexes()))[index_id];
+                const auto& indexes = *tablet_schema->indexes();
+                for (const auto& index : indexes) {
                     if (index.index_type() == GIN) {
                         std::string dst_inverted_link_path = IndexDescriptor::inverted_index_file_path(
                                 clone_dir, new_rowset_id.to_string(), segment_n, index.index_id());

--- a/test/sql/test_inverted_index/R/test_inverted_index
+++ b/test/sql/test_inverted_index/R/test_inverted_index
@@ -833,8 +833,14 @@ set cbo_enable_low_cardinality_optimize = false;
 -- !result
 CREATE TABLE `t_clone_for_gin` (
   `id1` bigint(20) NOT NULL COMMENT "",
-  `text_column` varchar(255) NULL COMMENT "",
-  INDEX gin_none (`text_column`) USING GIN ("parser" = "none") COMMENT 'whole line index'
+  `text_column_1` varchar(255) NULL COMMENT "",
+  `text_column_2` varchar(255) NULL COMMENT "",
+  `text_column_3` varchar(255) NULL COMMENT "",
+  `text_column_4` varchar(255) NULL COMMENT "",
+  INDEX gin_none_1 (`text_column_1`) USING GIN ("parser" = "none") COMMENT 'whole line index',
+  INDEX gin_none_2 (`text_column_2`) USING BITMAP,
+  INDEX gin_none_3 (`text_column_3`) USING GIN ("parser" = "none") COMMENT 'whole line index',
+  INDEX gin_none_4 (`text_column_4`) USING BITMAP
 ) ENGINE=OLAP
 DUPLICATE KEY(`id1`)
 DISTRIBUTED BY HASH(`id1`) BUCKETS 1
@@ -846,13 +852,13 @@ PROPERTIES (
 );
 -- result:
 -- !result
-INSERT INTO t_clone_for_gin VALUES (1, "abc"),(2, "ABC");
+INSERT INTO t_clone_for_gin VALUES (1, "abc","abc","abc","abc"),(2, "ABC","ABC","ABC","ABC");
 -- result:
 -- !result
 SELECT * FROM t_clone_for_gin ORDER BY id1;
 -- result:
-1	abc
-2	ABC
+1	abc	abc	abc	abc
+2	ABC	ABC	ABC	ABC
 -- !result
 function: set_first_tablet_bad_and_recover("t_clone_for_gin")
 -- result:
@@ -860,8 +866,8 @@ None
 -- !result
 SELECT * FROM t_clone_for_gin ORDER BY id1;
 -- result:
-1	abc
-2	ABC
+1	abc	abc	abc	abc
+2	ABC	ABC	ABC	ABC
 -- !result
 -- name: test_complex_predicate_for_gin
 set low_cardinality_optimize_v2 = false;

--- a/test/sql/test_inverted_index/T/test_inverted_index
+++ b/test/sql/test_inverted_index/T/test_inverted_index
@@ -486,8 +486,14 @@ set low_cardinality_optimize_v2 = false;
 set cbo_enable_low_cardinality_optimize = false;
 CREATE TABLE `t_clone_for_gin` (
   `id1` bigint(20) NOT NULL COMMENT "",
-  `text_column` varchar(255) NULL COMMENT "",
-  INDEX gin_none (`text_column`) USING GIN ("parser" = "none") COMMENT 'whole line index'
+  `text_column_1` varchar(255) NULL COMMENT "",
+  `text_column_2` varchar(255) NULL COMMENT "",
+  `text_column_3` varchar(255) NULL COMMENT "",
+  `text_column_4` varchar(255) NULL COMMENT "",
+  INDEX gin_none_1 (`text_column_1`) USING GIN ("parser" = "none") COMMENT 'whole line index',
+  INDEX gin_none_2 (`text_column_2`) USING BITMAP,
+  INDEX gin_none_3 (`text_column_3`) USING GIN ("parser" = "none") COMMENT 'whole line index',
+  INDEX gin_none_4 (`text_column_4`) USING BITMAP
 ) ENGINE=OLAP
 DUPLICATE KEY(`id1`)
 DISTRIBUTED BY HASH(`id1`) BUCKETS 1
@@ -498,7 +504,7 @@ PROPERTIES (
 "compression" = "LZ4"
 );
 
-INSERT INTO t_clone_for_gin VALUES (1, "abc"),(2, "ABC");
+INSERT INTO t_clone_for_gin VALUES (1, "abc","abc","abc","abc"),(2, "ABC","ABC","ABC","ABC");
 SELECT * FROM t_clone_for_gin ORDER BY id1;
 
 function: set_first_tablet_bad_and_recover("t_clone_for_gin")


### PR DESCRIPTION
## Why I'm doing:
Index id in TabletIndex and offset of a index in tablet schema maybe different. Because the Bitmap Index index id in TabletIndex is always -1(by design). In rowset::link_files_to we use offset instead of index_id() to generated gin index file path which is wrong.

## What I'm doing:
Make sure use index id in TabletIndex to get the index file path.

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
