### PR TITLE
[BugFix] fix DCHECK of parquet start/end offset of row group

### DIFF
--- a/be/src/formats/parquet/file_reader.cpp
+++ b/be/src/formats/parquet/file_reader.cpp
@@ -47,6 +47,35 @@ struct SplitContext : public HdfsSplitContext {
     }
 };
 
+static int64_t _get_column_start_offset(const tparquet::ColumnMetaData& column) {
+    int64_t offset = column.data_page_offset;
+    if (column.__isset.index_page_offset) {
+        offset = std::min(offset, column.index_page_offset);
+    }
+    if (column.__isset.dictionary_page_offset) {
+        offset = std::min(offset, column.dictionary_page_offset);
+    }
+    return offset;
+}
+
+static int64_t _get_row_group_start_offset(const tparquet::RowGroup& row_group) {
+    if (row_group.__isset.file_offset) {
+        return row_group.file_offset;
+    }
+    const tparquet::ColumnMetaData& first_column = row_group.columns[0].meta_data;
+    return _get_column_start_offset(first_column);
+}
+
+static int64_t _get_row_group_end_offset(const tparquet::RowGroup& row_group) {
+    // following computation is not correct. `total_compressed_size` means compressed size of all columns
+    // but between columns there could be holes, which means end offset inaccurate.
+    // if (row_group.__isset.file_offset && row_group.__isset.total_compressed_size) {
+    //     return row_group.file_offset + row_group.total_compressed_size;
+    // }
+    const tparquet::ColumnMetaData& last_column = row_group.columns.back().meta_data;
+    return _get_column_start_offset(last_column) + last_column.total_compressed_size;
+}
+
 FileReader::FileReader(int chunk_size, RandomAccessFile* file, size_t file_size, int64_t file_mtime,
                        io::SharedBufferedInputStream* sb_stream, const std::set<int64_t>* _need_skip_rowids)
         : _chunk_size(chunk_size),
@@ -241,9 +270,14 @@ Status FileReader::_build_split_tasks() {
         int64_t start_offset = _get_row_group_start_offset(row_group);
         int64_t end_offset = _get_row_group_end_offset(row_group);
 #ifndef NDEBUG
+        DCHECK(start_offset < end_offset);
+        // there could be holes between row groups.
+        // but this does not affect our scan range filter logic.
+        // because in `_select_row_group`, we check if `start offset of row group` is in this range
+        // so as long as `end_offset > start_offset && end_offset <= start_offset(next_group)`, it should works.
         if ((i + 1) < row_group_size) {
             const tparquet::RowGroup& next_row_group = _file_metadata->t_metadata().row_groups[i + 1];
-            DCHECK_EQ(end_offset, _get_row_group_start_offset(next_row_group));
+            DCHECK(end_offset <= _get_row_group_start_offset(next_row_group));
         }
 #endif
         auto split_ctx = std::make_unique<SplitContext>();
@@ -297,22 +331,6 @@ StatusOr<uint32_t> FileReader::_parse_metadata_length(const std::vector<char>& f
                 metadata_length));
     }
     return metadata_length;
-}
-
-int64_t FileReader::_get_row_group_start_offset(const tparquet::RowGroup& row_group) {
-    if (row_group.__isset.file_offset) {
-        return row_group.file_offset;
-    }
-    const tparquet::ColumnMetaData& first_column = row_group.columns[0].meta_data;
-    return first_column.data_page_offset;
-}
-
-int64_t FileReader::_get_row_group_end_offset(const tparquet::RowGroup& row_group) {
-    if (row_group.__isset.file_offset && row_group.__isset.total_compressed_size) {
-        return row_group.file_offset + row_group.total_compressed_size;
-    }
-    const tparquet::ColumnMetaData& last_column = row_group.columns.back().meta_data;
-    return last_column.data_page_offset + last_column.total_compressed_size;
 }
 
 StatusOr<bool> FileReader::_filter_group(const tparquet::RowGroup& row_group) {

--- a/be/src/formats/parquet/file_reader.cpp
+++ b/be/src/formats/parquet/file_reader.cpp
@@ -274,7 +274,7 @@ Status FileReader::_build_split_tasks() {
         // there could be holes between row groups.
         // but this does not affect our scan range filter logic.
         // because in `_select_row_group`, we check if `start offset of row group` is in this range
-        // so as long as `end_offset > start_offset && end_offset <= start_offset(next_group)`, it should works.
+        // so as long as `end_offset > start_offset && end_offset <= start_offset(next_group)`, it's ok
         if ((i + 1) < row_group_size) {
             const tparquet::RowGroup& next_row_group = _file_metadata->t_metadata().row_groups[i + 1];
             DCHECK(end_offset <= _get_row_group_start_offset(next_row_group));

--- a/be/src/formats/parquet/file_reader.h
+++ b/be/src/formats/parquet/file_reader.h
@@ -108,10 +108,6 @@ private:
 
     bool _has_correct_min_max_stats(const tparquet::ColumnMetaData& column_meta, const SortOrder& sort_order) const;
 
-    // get the data page start/end offset in parquet file
-    static int64_t _get_row_group_start_offset(const tparquet::RowGroup& row_group);
-    static int64_t _get_row_group_end_offset(const tparquet::RowGroup& row_group);
-
     Status _build_split_tasks();
 
     RandomAccessFile* _file = nullptr;


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:

Fixes https://github.com/StarRocks/StarRocksTest/issues/7159

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [x] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
