### PR TITLE
[BugFix] create dynamic hour partition table need to set partition co…

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/CreateTableAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/CreateTableAnalyzer.java
@@ -23,14 +23,17 @@ import com.starrocks.analysis.Expr;
 import com.starrocks.analysis.FunctionCallExpr;
 import com.starrocks.analysis.SlotRef;
 import com.starrocks.analysis.TableName;
+import com.starrocks.analysis.TimestampArithmeticExpr;
 import com.starrocks.catalog.AggregateType;
 import com.starrocks.catalog.Column;
 import com.starrocks.catalog.Database;
+import com.starrocks.catalog.DynamicPartitionProperty;
 import com.starrocks.catalog.Index;
 import com.starrocks.catalog.KeysType;
 import com.starrocks.catalog.PartitionType;
 import com.starrocks.catalog.PrimitiveType;
 import com.starrocks.catalog.Table;
+import com.starrocks.catalog.TableProperty;
 import com.starrocks.catalog.Type;
 import com.starrocks.common.AnalysisException;
 import com.starrocks.common.ErrorCode;
@@ -56,6 +59,7 @@ import com.starrocks.sql.ast.KeysDesc;
 import com.starrocks.sql.ast.ListPartitionDesc;
 import com.starrocks.sql.ast.PartitionDesc;
 import com.starrocks.sql.ast.RandomDistributionDesc;
+import com.starrocks.sql.ast.RangePartitionDesc;
 import com.starrocks.sql.common.EngineType;
 import com.starrocks.sql.common.MetaUtils;
 import org.apache.commons.collections.CollectionUtils;
@@ -458,6 +462,7 @@ public class CreateTableAnalyzer {
                 if (partitionDesc.getType() == PartitionType.RANGE || partitionDesc.getType() == PartitionType.LIST) {
                     try {
                         partitionDesc.analyze(stmt.getColumnDefs(), stmt.getProperties());
+                        analyzeDynamicPartitionDesc(stmt);
                     } catch (AnalysisException e) {
                         throw new SemanticException(e.getMessage());
                     }
@@ -488,6 +493,53 @@ public class CreateTableAnalyzer {
                 }
             }
         }
+    }
+
+    private static void analyzeDynamicPartitionDesc(CreateTableStmt stmt) throws SemanticException {
+        PartitionDesc partitionDesc = stmt.getPartitionDesc();
+        if (partitionDesc.getType() != PartitionType.RANGE) {
+            return;
+        }
+        if (!(partitionDesc instanceof RangePartitionDesc)) {
+            return;
+        }
+        RangePartitionDesc rangePartitionDesc = (RangePartitionDesc)partitionDesc;
+        List<String> partitionColNames = rangePartitionDesc.getPartitionColNames();
+        List<ColumnDef> columnDefList = stmt.getColumnDefs();
+        ColumnDef firstPartitionColumn = findPartitionColumn(partitionColNames, columnDefList);
+        if (firstPartitionColumn == null) {
+            return;
+        }
+        if (!firstPartitionColumn.getType().isDate()) {
+            return;
+        }
+        Map<String, String> otherProperties = stmt.getProperties();
+        TableProperty tableProperty = new TableProperty(otherProperties);
+        tableProperty.buildDynamicProperty();
+        DynamicPartitionProperty dynamicPartitionProperty = tableProperty.getDynamicPartitionProperty();
+        if (dynamicPartitionProperty == null) {
+            return;
+        }
+        String timeUnit = tableProperty.getDynamicPartitionProperty().getTimeUnit();
+        String hourTimeUnit = TimestampArithmeticExpr.TimeUnit.HOUR.toString();
+        if (timeUnit != null && timeUnit.equalsIgnoreCase(hourTimeUnit)) {
+            throw new SemanticException("Dynamic partition tables that are partitioned by hours " +
+                    "need to set the partition column type to datetime");
+        }
+    }
+
+    private static ColumnDef findPartitionColumn(List<String> partitionColNames,
+                                                 List<ColumnDef> columnDefs) {
+        ColumnDef firstPartitionColumn = null;
+        for (String partitionCol : partitionColNames) {
+            for (ColumnDef columnDef : columnDefs) {
+                if (columnDef.getName().equalsIgnoreCase(partitionCol)) {
+                    firstPartitionColumn = columnDef;
+                    break;
+                }
+            }
+        }
+        return firstPartitionColumn;
     }
 
     public static void analyzeDistributionDesc(CreateTableStmt stmt) {

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/CreateTableWithPartitionTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/CreateTableWithPartitionTest.java
@@ -18,6 +18,7 @@ package com.starrocks.analysis;
 import com.starrocks.common.AnalysisException;
 import com.starrocks.common.Config;
 import com.starrocks.qe.ConnectContext;
+import com.starrocks.sql.analyzer.SemanticException;
 import com.starrocks.sql.ast.CreateTableStmt;
 import com.starrocks.sql.ast.PartitionDesc;
 import com.starrocks.utframe.StarRocksAssert;
@@ -878,5 +879,37 @@ public class CreateTableWithPartitionTest {
         Assert.assertFalse(partitionDesc.toString().contains("PARTITION p4 VALUES [('4'), ('5'))"));
 
     }
+
+    @Test(expected = SemanticException.class)
+    public void testCreateDynamicPartitionHourTableBatchWithDatePartitionType() throws Exception {
+        ConnectContext ctx = starRocksAssert.getCtx();
+        String createTableSql = "CREATE TABLE `testCreateDynamicPartitionHourTableBatchWithDatePartitionType` (\n" +
+                "  `k1` date NULL COMMENT \"\",\n" +
+                "  `k2` int(11) NULL COMMENT \"\",\n" +
+                "  `k3` smallint(6) NULL COMMENT \"\",\n" +
+                "  `v1` varchar(2048) NULL COMMENT \"\",\n" +
+                "  `v2` datetime NULL DEFAULT \"2014-02-04 15:36:00\" COMMENT \"\"\n" +
+                ") ENGINE=OLAP\n" +
+                "DUPLICATE KEY(`k1`, `k2`, `k3`)\n" +
+                "COMMENT \"OLAP\"\n" +
+                "PARTITION BY RANGE(`k1`)\n" +
+                "(\n" +
+                ")\n" +
+                "DISTRIBUTED BY HASH(`k2`) BUCKETS 10\n" +
+                "PROPERTIES (\n" +
+                "\"dynamic_partition.enable\" = \"true\",\n" +
+                "\"dynamic_partition.time_unit\" = \"HOUR\",\n" +
+                "\"dynamic_partition.time_zone\" = \"Asia/Shanghai\",\n" +
+                "\"dynamic_partition.start\" = \"-360\",\n" +
+                "\"dynamic_partition.end\" = \"1\",\n" +
+                "\"dynamic_partition.prefix\" = \"p\",\n" +
+                "\"dynamic_partition.buckets\" = \"100\",\n" +
+                "\"dynamic_partition.history_partition_num\" = \"0\"," +
+                "\"replication_num\" = \"1\",\n" +
+                "\"in_memory\" = \"false\"\n" +
+                ");";
+        CreateTableStmt createTableStmt = (CreateTableStmt) UtFrameUtils.parseStmtWithNewParser(createTableSql, ctx);
+    }
+
 }
 


### PR DESCRIPTION
## Why I'm doing:
```
mysql> CREATE TABLE `test_111` (
    ->   `project_id` bigint(20) NOT NULL DEFAULT "0" COMMENT "",
    ->   `dt` date NOT NULL DEFAULT "1970-01-01" COMMENT "",
    ->   `project_code` varchar(65533) NOT NULL DEFAULT "" COMMENT "",
    ->   `project_name` varchar(65533) NOT NULL DEFAULT "" COMMENT "",
    ->   `owners` varchar(65533) NOT NULL DEFAULT "" COMMENT ""
    -> ) ENGINE=OLAP
    -> PRIMARY KEY(`project_id`, `dt`)
    -> COMMENT "指标管理工具维表加速创建,维度ID=30004281"
    -> PARTITION BY RANGE(`dt`)
    -> (START("2024-03-24 00:00:00") END("2024-04-02 00:00:00") EVERY(INTERVAL 1 HOUR))
    -> DISTRIBUTED BY HASH(`project_id`) BUCKETS 5
    -> PROPERTIES (
    -> "replication_num" = "1",
    -> "dynamic_partition.enable" = "true",
    -> "dynamic_partition.time_unit" = "HOUR",
    -> "dynamic_partition.time_zone" = "Asia/Shanghai",
    -> "dynamic_partition.start" = "-360",
    -> "dynamic_partition.end" = "1",
    -> "dynamic_partition.prefix" = "p",
    -> "dynamic_partition.buckets" = "100",
    -> "dynamic_partition.history_partition_num" = "0",
    -> "in_memory" = "false",
    -> "storage_format" = "DEFAULT",
    -> "enable_persistent_index" = "true",
    -> "compression" = "LZ4"
    -> );
Query OK, 0 rows affected (0.02 sec)
```

## What I'm doing:
```
mysql> CREATE TABLE `test_111` (
    ->   `project_id` bigint(20) NOT NULL DEFAULT "0" COMMENT "",
    ->   `dt` date NOT NULL DEFAULT "1970-01-01" COMMENT "",
    ->   `project_code` varchar(65533) NOT NULL DEFAULT "" COMMENT "",
    ->   `project_name` varchar(65533) NOT NULL DEFAULT "" COMMENT "",
    ->   `owners` varchar(65533) NOT NULL DEFAULT "" COMMENT ""
    -> ) ENGINE=OLAP
    -> PRIMARY KEY(`project_id`, `dt`)
    -> COMMENT "指标管理工具维表加速创建,维度ID=30004281"
    -> PARTITION BY RANGE(`dt`)
    -> (START("2024-03-24 00:00:00") END("2024-04-02 00:00:00") EVERY(INTERVAL 1 HOUR))
    -> DISTRIBUTED BY HASH(`project_id`) BUCKETS 5
    -> PROPERTIES (
    -> "replication_num" = "1",
    -> "dynamic_partition.enable" = "true",
    -> "dynamic_partition.time_unit" = "HOUR",
    -> "dynamic_partition.time_zone" = "Asia/Shanghai",
    -> "dynamic_partition.start" = "-360",
    -> "dynamic_partition.end" = "1",
    -> "dynamic_partition.prefix" = "p",
    -> "dynamic_partition.buckets" = "100",
    -> "dynamic_partition.history_partition_num" = "0",
    -> "in_memory" = "false",
    -> "storage_format" = "DEFAULT",
    -> "enable_persistent_index" = "true",
    -> "compression" = "LZ4"
    -> );
ERROR 1064 (HY000): Dynamic partition tables that are partitioned by hours need to set the partition field type to datetime
```

Fixes #44564

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [x] 3.3
  - [x] 3.2
  - [x] 3.1
  - [x] 3.0
  - [x] 2.5