### PR TITLE
[BugFix] Fix spark load may get wrong tablet schema in share data mode

### DIFF
--- a/be/src/storage/lake/spark_load.cpp
+++ b/be/src/storage/lake/spark_load.cpp
@@ -15,6 +15,7 @@
 #include "storage/lake/spark_load.h"
 
 #include "storage/lake/filenames.h"
+#include "storage/lake/tablet_manager.h"
 #include "storage/lake/tablet_writer.h"
 #include "storage/push_utils.h"
 #include "storage/storage_engine.h"
@@ -24,8 +25,8 @@ namespace starrocks::lake {
 
 using PushBrokerReader = starrocks::PushBrokerReader;
 
-Status SparkLoadHandler::process_streaming_ingestion(Tablet& tablet, const TPushReq& request, PushType push_type,
-                                                     std::vector<TTabletInfo>* tablet_info_vec) {
+Status SparkLoadHandler::process_streaming_ingestion(VersionedTablet& tablet, const TPushReq& request,
+                                                     PushType push_type, std::vector<TTabletInfo>* tablet_info_vec) {
     LOG(INFO) << "begin to realtime vectorized push. tablet=" << tablet.id() << ", txn_id=" << request.transaction_id;
     DCHECK_EQ(push_type, PUSH_NORMAL_V2);
 
@@ -43,7 +44,7 @@ Status SparkLoadHandler::process_streaming_ingestion(Tablet& tablet, const TPush
     return st;
 }
 
-Status SparkLoadHandler::_load_convert(Tablet& cur_tablet) {
+Status SparkLoadHandler::_load_convert(VersionedTablet& cur_tablet) {
     Status st;
 
     VLOG(3) << "start to convert delta file.";
@@ -53,7 +54,7 @@ Status SparkLoadHandler::_load_convert(Tablet& cur_tablet) {
     RETURN_IF_ERROR(writer->open());
     DeferOp defer([&]() { writer->close(); });
 
-    ASSIGN_OR_RETURN(auto tablet_schema, cur_tablet.get_schema());
+    auto tablet_schema = cur_tablet.get_schema();
     Schema schema = ChunkHelper::convert_schema(tablet_schema);
     ChunkPtr chunk = ChunkHelper::new_chunk(schema, 0);
     auto char_field_indexes = ChunkHelper::get_char_field_indexes(schema);
@@ -107,7 +108,7 @@ Status SparkLoadHandler::_load_convert(Tablet& cur_tablet) {
     }
 
     // finish
-    auto txn_log = std::make_shared<TxnLog>();
+    auto txn_log = std::make_shared<TxnLogPB>();
     txn_log->set_tablet_id(cur_tablet.id());
     txn_log->set_txn_id(_request.transaction_id);
     auto op_write = txn_log->mutable_op_write();
@@ -122,7 +123,7 @@ Status SparkLoadHandler::_load_convert(Tablet& cur_tablet) {
     op_write->mutable_rowset()->set_num_rows(writer->num_rows());
     op_write->mutable_rowset()->set_data_size(writer->data_size());
     op_write->mutable_rowset()->set_overlapped(false);
-    RETURN_IF_ERROR(cur_tablet.put_txn_log(std::move(txn_log)));
+    RETURN_IF_ERROR(cur_tablet.tablet_manager()->put_txn_log(std::move(txn_log)));
 
     _write_bytes += static_cast<int64_t>(writer->data_size());
     _write_rows += static_cast<int64_t>(writer->num_rows());
@@ -131,7 +132,7 @@ Status SparkLoadHandler::_load_convert(Tablet& cur_tablet) {
     return st;
 }
 
-void SparkLoadHandler::_get_tablet_infos(const Tablet& tablet, std::vector<TTabletInfo>* tablet_info_vec) {
+void SparkLoadHandler::_get_tablet_infos(const VersionedTablet& tablet, std::vector<TTabletInfo>* tablet_info_vec) {
     TTabletInfo tablet_info;
     tablet_info.tablet_id = tablet.id();
     tablet_info.schema_hash = 0;

--- a/be/src/storage/lake/spark_load.h
+++ b/be/src/storage/lake/spark_load.h
@@ -17,7 +17,7 @@
 #include "common/statusor.h"
 #include "gen_cpp/AgentService_types.h"
 #include "gen_cpp/MasterService_types.h"
-#include "storage/lake/tablet.h"
+#include "storage/lake/versioned_tablet.h"
 #include "storage/olap_common.h"
 
 namespace starrocks::lake {
@@ -27,16 +27,16 @@ public:
     SparkLoadHandler() = default;
     ~SparkLoadHandler() = default;
 
-    Status process_streaming_ingestion(Tablet& tablet, const TPushReq& request, PushType push_type,
+    Status process_streaming_ingestion(VersionedTablet& tablet, const TPushReq& request, PushType push_type,
                                        std::vector<TTabletInfo>* tablet_info_vec);
 
     int64_t write_bytes() const { return _write_bytes; }
     int64_t write_rows() const { return _write_rows; }
 
 private:
-    Status _load_convert(Tablet& cur_tablet);
+    Status _load_convert(VersionedTablet& cur_tablet);
 
-    void _get_tablet_infos(const Tablet& tablet, std::vector<TTabletInfo>* tablet_info_vec);
+    void _get_tablet_infos(const VersionedTablet& tablet, std::vector<TTabletInfo>* tablet_info_vec);
 
 private:
     // mainly tablet_id, version and delta file path

--- a/be/src/storage/task/engine_batch_load_task.cpp
+++ b/be/src/storage/task/engine_batch_load_task.cpp
@@ -40,9 +40,10 @@
 #include <iostream>
 #include <string>
 
-#include "gen_cpp/AgentService_types.h"
 #include "runtime/current_thread.h"
 #include "storage/lake/spark_load.h"
+#include "storage/lake/tablet_manager.h"
+#include "storage/lake/versioned_tablet.h"
 #include "storage/olap_common.h"
 #include "storage/push_handler.h"
 #include "storage/storage_engine.h"
@@ -181,10 +182,10 @@ Status EngineBatchLoadTask::_push(const TPushReq& request, std::vector<TTabletIn
 
     if (request.tablet_type == TTabletType::TABLET_TYPE_LAKE) {
         auto tablet_manager = ExecEnv::GetInstance()->lake_tablet_manager();
-        auto tablet_or = tablet_manager->get_tablet(request.tablet_id);
+        auto tablet_or = tablet_manager->get_tablet(request.tablet_id, request.version);
         if (!tablet_or.ok()) {
-            LOG(WARNING) << "Fail to load file. res=" << res << ", txn_id: " << request.transaction_id
-                         << ", tablet=" << request.tablet_id
+            LOG(WARNING) << "Fail to read tablet metadata. res=" << res << ", txn_id: " << request.transaction_id
+                         << ", tablet=" << request.tablet_id << ", version=" << request.version
                          << ", cost=" << PrettyPrinter::print(duration_ns, TUnit::TIME_NS);
             StarRocksMetrics::instance()->push_requests_fail_total.increment(1);
             return tablet_or.status();

--- a/fe/fe-core/src/main/java/com/starrocks/load/loadv2/SparkLoadJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/loadv2/SparkLoadJob.java
@@ -504,6 +504,7 @@ public class SparkLoadJob extends BulkLoadJob {
                             LOG.warn("partition does not exist. id: {}", partitionId);
                             continue;
                         }
+                        long partitionVersion = partition.getVisibleVersion();
 
                         hasLoadPartitions = true;
                         int quorumReplicaNum = table.getPartitionInfo().getQuorumNum(partitionId, table.writeQuorum());
@@ -538,7 +539,7 @@ public class SparkLoadJob extends BulkLoadJob {
                                                 .getBackend(backendId);
 
                                         pushTask(backendId, tableId, partitionId, indexId, tabletId,
-                                                replicaId, schemaHash, params, batchTask, tabletMetaStr,
+                                                replicaId, schemaHash, partitionVersion, params, batchTask, tabletMetaStr,
                                                 backend, replica, tabletFinishedReplicas,
                                                 TTabletType.TABLET_TYPE_DISK, columnsDesc);
                                     }
@@ -566,7 +567,7 @@ public class SparkLoadJob extends BulkLoadJob {
                                     }
 
                                     pushTask(backend.getId(), tableId, partitionId, indexId, tabletId,
-                                            tabletId, schemaHash, params, batchTask, tabletMetaStr,
+                                            tabletId, schemaHash, partitionVersion, params, batchTask, tabletMetaStr,
                                             backend, new Replica(tabletId, backend.getId(), -1, NORMAL),
                                             tabletFinishedReplicas, TTabletType.TABLET_TYPE_LAKE, columnsDesc);
 
@@ -603,7 +604,7 @@ public class SparkLoadJob extends BulkLoadJob {
     }
 
     private void pushTask(long backendId, long tableId, long partitionId, long indexId,
-                          long tabletId, long replicaId, int schemaHash,
+                          long tabletId, long replicaId, int schemaHash, long partitionVersion,
                           PushBrokerReaderParams params,
                           AgentBatchTask batchTask,
                           String tabletMetaStr,
@@ -649,7 +650,7 @@ public class SparkLoadJob extends BulkLoadJob {
             }
 
             PushTask pushTask = new PushTask(backendId, dbId, tableId, partitionId,
-                    indexId, tabletId, replicaId, schemaHash,
+                    indexId, tabletId, replicaId, schemaHash, partitionVersion,
                     0, id, TPushType.LOAD_V2,
                     TPriority.NORMAL, transactionId, taskSignature,
                     tBrokerScanRange, params.tDescriptorTable,

--- a/fe/fe-core/src/main/java/com/starrocks/task/PushTask.java
+++ b/fe/fe-core/src/main/java/com/starrocks/task/PushTask.java
@@ -128,11 +128,11 @@ public class PushTask extends AgentTask {
 
     // for load v2 (SparkLoadJob)
     public PushTask(long backendId, long dbId, long tableId, long partitionId, long indexId, long tabletId,
-                    long replicaId, int schemaHash, int timeoutSecond, long loadJobId, TPushType pushType,
+                    long replicaId, int schemaHash, long version, int timeoutSecond, long loadJobId, TPushType pushType,
                     TPriority priority, long transactionId, long signature, TBrokerScanRange tBrokerScanRange,
                     TDescriptorTable tDescriptorTable, String timezone, TTabletType tabletType, List<TColumn> columnsDesc) {
         this(null, backendId, dbId, tableId, partitionId, indexId,
-                tabletId, replicaId, schemaHash, -1, timeoutSecond, loadJobId, pushType, null,
+                tabletId, replicaId, schemaHash, version, timeoutSecond, loadJobId, pushType, null,
                 priority, TTaskType.REALTIME_PUSH, transactionId, signature, columnsDesc);
         this.tBrokerScanRange = tBrokerScanRange;
         this.tDescriptorTable = tDescriptorTable;


### PR DESCRIPTION
When enabling fast schema evolution, the schema in different versions of metadata for the same tablet may be different.
To ensure the correctness of data loading, it is necessary to specify a version number to obtain the tablet schema, while Spark load does not specify a version.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
