### PR TITLE
[Enhancement] support calculate more kind of expression statistic

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/FunctionSet.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/FunctionSet.java
@@ -105,6 +105,8 @@ public class FunctionSet {
     public static final String UTC_TIME = "utc_time";
     public static final String LOCALTIME = "localtime";
     public static final String LOCALTIMESTAMP = "localtimestamp";
+
+    public static final String WEEK = "week";
     public static final String WEEKOFYEAR = "weekofyear";
     public static final String YEAR = "year";
     public static final String MINUTES_DIFF = "minutes_diff";

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/scalar/ColumnRefOperator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/scalar/ColumnRefOperator.java
@@ -93,7 +93,7 @@ public final class ColumnRefOperator extends ScalarOperator {
     }
 
     public ColumnRefSet getUsedColumns() {
-        if (getOpType().equals(OperatorType.LAMBDA_ARGUMENT)) {
+        if (OperatorType.LAMBDA_ARGUMENT.equals(getOpType())) {
             return new ColumnRefSet();
         }
         return new ColumnRefSet(id);
@@ -101,6 +101,9 @@ public final class ColumnRefOperator extends ScalarOperator {
 
     @Override
     public void getColumnRefs(List<ColumnRefOperator> columns) {
+        if (OperatorType.LAMBDA_ARGUMENT.equals(getOpType())) {
+            return;
+        }
         columns.add(this);
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/scalar/LambdaFunctionOperator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/scalar/LambdaFunctionOperator.java
@@ -129,6 +129,11 @@ public class LambdaFunctionOperator extends ScalarOperator {
     }
 
     @Override
+    public void getColumnRefs(List<ColumnRefOperator> columns) {
+        lambdaExpr.getColumnRefs(columns);
+    }
+
+    @Override
     public ScalarOperator clone() {
         LambdaFunctionOperator clone = (LambdaFunctionOperator) super.clone();
         List<ColumnRefOperator> refs = Lists.newArrayList();

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/ExpressionStatisticCalculator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/ExpressionStatisticCalculator.java
@@ -34,6 +34,7 @@ import java.time.DateTimeException;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
+import java.time.temporal.IsoFields;
 import java.util.List;
 import java.util.Optional;
 import java.util.OptionalDouble;
@@ -180,9 +181,10 @@ public class ExpressionStatisticCalculator {
             Preconditions.checkState(childrenColumnStatistics.size() == call.getChildren().size(),
                     "column statistics missing for expr: %s. column statistics: %s",
                     call, childrenColumnStatistics);
+
             if (childrenColumnStatistics.stream().anyMatch(ColumnStatistic::isUnknown) ||
                     inputStatistics.getColumnStatistics().values().stream().allMatch(ColumnStatistic::isUnknown)) {
-                return ColumnStatistic.unknown();
+                return deriveBasicColStats(call);
             }
 
             if (call.getChildren().size() == 0) {
@@ -270,6 +272,7 @@ public class ExpressionStatisticCalculator {
                 case FunctionSet.MIN:
                 case FunctionSet.ANY_VALUE:
                 case FunctionSet.AVG:
+                case FunctionSet.CONCAT:
                     maxValue = columnStatistic.getMaxValue();
                     minValue = columnStatistic.getMinValue();
                     break;
@@ -508,12 +511,15 @@ public class ExpressionStatisticCalculator {
             switch (callOperator.getFnName().toLowerCase()) {
                 case FunctionSet.ADD:
                 case FunctionSet.DATE_ADD:
+                case FunctionSet.DAYS_ADD:
                     minValue = left.getMinValue() + right.getMinValue();
                     maxValue = left.getMaxValue() + right.getMaxValue();
                     break;
                 case FunctionSet.SUBTRACT:
                 case FunctionSet.TIMEDIFF:
                 case FunctionSet.DATE_SUB:
+                case FunctionSet.DAYS_SUB:
+                case FunctionSet.SECONDS_DIFF:
                     minValue = left.getMinValue() - right.getMaxValue();
                     maxValue = left.getMaxValue() - right.getMinValue();
                     break;
@@ -547,10 +553,6 @@ public class ExpressionStatisticCalculator {
                     interval = 60;
                     minValue = (left.getMinValue() - right.getMaxValue()) / interval;
                     maxValue = (left.getMaxValue() - right.getMinValue()) / interval;
-                    break;
-                case FunctionSet.SECONDS_DIFF:
-                    minValue = left.getMinValue() - right.getMaxValue();
-                    maxValue = left.getMaxValue() - right.getMinValue();
                     break;
                 case FunctionSet.MULTIPLY:
                     minValue = Math.min(Math.min(
@@ -589,6 +591,24 @@ public class ExpressionStatisticCalculator {
                     minValue = left.getMinValue();
                     maxValue = left.getMaxValue();
                     break;
+                case FunctionSet.WEEK:
+                    minValue = 0;
+                    maxValue = 53;
+                    distinctValues = Math.min(calcDistinctValForWeek(left), distinctValues);
+                    break;
+                case FunctionSet.CONCAT:
+                    minValue = Double.NEGATIVE_INFINITY;
+                    maxValue = Double.POSITIVE_INFINITY;
+                    distinctValues = Math.min(rowCount, left.getDistinctValuesCount() + right.getDistinctValuesCount());
+                    averageRowSize = left.getAverageRowSize() + right.getAverageRowSize();
+                    break;
+                case FunctionSet.LEFT:
+                case FunctionSet.RIGHT:
+                    minValue = Double.NEGATIVE_INFINITY;
+                    maxValue = Double.POSITIVE_INFINITY;
+                    averageRowSize = Math.max(1, left.getAverageRowSize() - right.getAverageRowSize());
+                    distinctValues = left.getDistinctValuesCount() * averageRowSize / left.getAverageRowSize();
+                    break;
                 default:
                     return ColumnStatistic.unknown();
             }
@@ -603,15 +623,26 @@ public class ExpressionStatisticCalculator {
 
         private ColumnStatistic multiaryExpressionCalculate(CallOperator callOperator,
                                                             List<ColumnStatistic> childColumnStatisticList) {
+            double distinctValues;
+            double averageRowSize;
+            double nullsFraction;
             switch (callOperator.getFnName().toLowerCase()) {
                 case FunctionSet.IF:
-                    double distinctValues = childColumnStatisticList.get(1).getDistinctValuesCount() +
+                    distinctValues = childColumnStatisticList.get(1).getDistinctValuesCount() +
                             childColumnStatisticList.get(2).getDistinctValuesCount();
                     return new ColumnStatistic(Double.NEGATIVE_INFINITY, Double.POSITIVE_INFINITY, 0,
                             callOperator.getType().getTypeSize(), distinctValues);
                 // use child column statistics for now
                 case FunctionSet.SUBSTRING:
                     return childColumnStatisticList.get(0);
+                case FunctionSet.CONCAT:
+                    distinctValues = Math.min(rowCount,
+                            childColumnStatisticList.stream().mapToDouble(ColumnStatistic::getDistinctValuesCount).sum());
+                    averageRowSize = childColumnStatisticList.stream().mapToDouble(ColumnStatistic::getAverageRowSize).sum();
+                    nullsFraction = 1 - childColumnStatisticList.stream().mapToDouble(ColumnStatistic::getAverageRowSize)
+                            .reduce(1, (a, b) -> (1 - a) * (1 - b));
+                    return new ColumnStatistic(Double.NEGATIVE_INFINITY, Double.POSITIVE_INFINITY,
+                            nullsFraction, averageRowSize, distinctValues);
                 default:
                     return ColumnStatistic.unknown();
             }
@@ -619,6 +650,37 @@ public class ExpressionStatisticCalculator {
 
         private double divisorNotZero(double value) {
             return value == 0 ? 1.0 : value;
+        }
+
+        private ColumnStatistic deriveBasicColStats(CallOperator call) {
+            List<ColumnRefOperator> usedCols = call.getColumnRefs();
+            if (usedCols.size() == 0) {
+                return new ColumnStatistic(Double.NEGATIVE_INFINITY, Double.POSITIVE_INFINITY,
+                        0, call.getType().getTypeSize(), 1);
+            } else if (usedCols.size() == 1 && !inputStatistics.getColumnStatistic(usedCols.get(0)).isUnknown()) {
+                ColumnStatistic usedStats = inputStatistics.getColumnStatistic(usedCols.get(0));
+                return new ColumnStatistic(Double.NEGATIVE_INFINITY, Double.POSITIVE_INFINITY, usedStats.getNullsFraction(),
+                        call.getType().getTypeSize(), usedStats.getDistinctValuesCount());
+            } else {
+                return ColumnStatistic.unknown();
+            }
+        }
+
+        private double calcDistinctValForWeek(ColumnStatistic col) {
+            if (col.hasNaNValue() || col.isInfiniteRange()) {
+                return 54;
+            }
+            LocalDateTime min = Utils.getDatetimeFromLong((long) col.getMinValue());
+            LocalDateTime max = Utils.getDatetimeFromLong((long) col.getMaxValue());
+
+            // the range is more than one year
+            if (min.plusYears(1).compareTo(max) <= 0) {
+                return 54;
+            } else if (min.getYear() < max.getYear()) {
+                return (54 - min.get(IsoFields.WEEK_OF_WEEK_BASED_YEAR)) + max.get(IsoFields.WEEK_OF_WEEK_BASED_YEAR);
+            } else {
+                return max.get(IsoFields.WEEK_OF_WEEK_BASED_YEAR) - min.get(IsoFields.WEEK_OF_WEEK_BASED_YEAR) + 1;
+            }
         }
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/mv/MaterializedViewPlanTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/mv/MaterializedViewPlanTest.java
@@ -49,9 +49,9 @@ public class MaterializedViewPlanTest extends PlanTestBase {
 
         Pair<CreateMaterializedViewStatement, ExecPlan> pair = UtFrameUtils.planMVMaintenance(connectContext, sql);
         String plan = UtFrameUtils.printPlan(pair.second);
-        Assert.assertEquals(plan, "- Output => [1:v1, 7:count]\n" +
+        Assert.assertEquals("- Output => [1:v1, 7:count]\n" +
                 "    - StreamAgg[1:v1]\n" +
-                "            Estimates: {row: 1, cpu: ?, memory: ?, network: ?, cost: 0.0}\n" +
+                "            Estimates: {row: 1, cpu: 0.00, memory: 0.00, network: 0.00, cost: 0.00}\n" +
                 "            7:count := count()\n" +
                 "        - StreamJoin/INNER JOIN [1:v1 = 4:v4] => [1:v1]\n" +
                 "                Estimates: {row: 1, cpu: ?, memory: ?, network: ?, cost: 0.0}\n" +
@@ -60,7 +60,7 @@ public class MaterializedViewPlanTest extends PlanTestBase {
                 "                    predicate: 1:v1 IS NOT NULL\n" +
                 "            - StreamScan [t1] => [4:v4]\n" +
                 "                    Estimates: {row: 1, cpu: ?, memory: ?, network: ?, cost: 0.0}\n" +
-                "                    predicate: 4:v4 IS NOT NULL\n");
+                "                    predicate: 4:v4 IS NOT NULL\n", plan);
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/statistics/ExpressionStatisticsCalculatorTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/statistics/ExpressionStatisticsCalculatorTest.java
@@ -20,6 +20,8 @@ import com.google.common.collect.Lists;
 import com.starrocks.analysis.BinaryType;
 import com.starrocks.catalog.FunctionSet;
 import com.starrocks.catalog.Type;
+import com.starrocks.common.util.DateUtils;
+import com.starrocks.sql.optimizer.Utils;
 import com.starrocks.sql.optimizer.operator.scalar.BinaryPredicateOperator;
 import com.starrocks.sql.optimizer.operator.scalar.CallOperator;
 import com.starrocks.sql.optimizer.operator.scalar.CaseWhenOperator;
@@ -517,6 +519,50 @@ public class ExpressionStatisticsCalculatorTest {
         columnStatistic = ExpressionStatisticCalculator.calculate(callOperator, builder.build());
         Assert.assertEquals(-100, columnStatistic.getMinValue(), 0.001);
         Assert.assertEquals(50, columnStatistic.getMaxValue(), 0.001);
+    }
+
+    @Test
+    public void testWeek() {
+        ColumnRefOperator left = new ColumnRefOperator(0, Type.DATETIME, "left", true);
+        ColumnRefOperator right = new ColumnRefOperator(1, Type.INT, "right", true);
+        double min = Utils.getLongFromDateTime(DateUtils.parseStringWithDefaultHSM("2021-09-01", DateUtils.DATE_FORMATTER_UNIX));
+        double max = Utils.getLongFromDateTime(DateUtils.parseStringWithDefaultHSM("2022-07-01", DateUtils.DATE_FORMATTER_UNIX));
+        ColumnStatistic leftStatistic = new ColumnStatistic(min, max, 0, 0, 100);
+        ColumnStatistic rightStatistic = new ColumnStatistic(1, 1, 0, 1, 1);
+        Statistics.Builder builder = Statistics.builder();
+        builder.addColumnStatistic(left, leftStatistic);
+        builder.addColumnStatistic(right, rightStatistic);
+        CallOperator week = new CallOperator(FunctionSet.WEEK, Type.INT, Lists.newArrayList(left, right));
+        ColumnStatistic columnStatistic = ExpressionStatisticCalculator.calculate(week, builder.build());
+        Assert.assertEquals(45, columnStatistic.getDistinctValuesCount(), 0.1);
+
+        min = Utils.getLongFromDateTime(DateUtils.parseStringWithDefaultHSM("2022-01-20", DateUtils.DATE_FORMATTER_UNIX));
+        max = Utils.getLongFromDateTime(DateUtils.parseStringWithDefaultHSM("2022-08-01", DateUtils.DATE_FORMATTER_UNIX));
+        leftStatistic = new ColumnStatistic(min, max, 0, 0, 100);
+        builder = Statistics.builder();
+        builder.addColumnStatistic(left, leftStatistic);
+        builder.addColumnStatistic(right, rightStatistic);
+        columnStatistic = ExpressionStatisticCalculator.calculate(week, builder.build());
+        Assert.assertEquals(29, columnStatistic.getDistinctValuesCount(), 0.1);
+
+        min = Utils.getLongFromDateTime(DateUtils.parseStringWithDefaultHSM("2022-01-20", DateUtils.DATE_FORMATTER_UNIX));
+        max = Utils.getLongFromDateTime(DateUtils.parseStringWithDefaultHSM("2023-08-01", DateUtils.DATE_FORMATTER_UNIX));
+        leftStatistic = new ColumnStatistic(min, max, 0, 0, 100);
+        builder = Statistics.builder();
+        builder.addColumnStatistic(left, leftStatistic);
+        builder.addColumnStatistic(right, rightStatistic);
+        columnStatistic = ExpressionStatisticCalculator.calculate(week, builder.build());
+        Assert.assertEquals(54, columnStatistic.getDistinctValuesCount(), 0.1);
+
+        min = Utils.getLongFromDateTime(DateUtils.parseStringWithDefaultHSM("2022-01-20", DateUtils.DATE_FORMATTER_UNIX));
+        max = Utils.getLongFromDateTime(DateUtils.parseStringWithDefaultHSM("2023-08-01", DateUtils.DATE_FORMATTER_UNIX));
+        leftStatistic = new ColumnStatistic(min, max, 0, 0, 2);
+        builder = Statistics.builder();
+        builder.addColumnStatistic(left, leftStatistic);
+        builder.addColumnStatistic(right, rightStatistic);
+        columnStatistic = ExpressionStatisticCalculator.calculate(week, builder.build());
+        Assert.assertEquals(2, columnStatistic.getDistinctValuesCount(), 0.1);
+
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/AggregateTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/AggregateTest.java
@@ -2710,8 +2710,8 @@ public class AggregateTest extends PlanTestBase {
                 "  |  <slot 8> : 8: count\n" +
                 "  |  <slot 9> : 9: count\n" +
                 "  |  \n" +
-                "  9:AGGREGATE (update finalize)\n" +
-                "  |  output: count(1: v1), count(9: count), max(10: max)\n" +
+                "  9:AGGREGATE (merge finalize)\n" +
+                "  |  output: count(8: count), count(9: count), max(10: max)\n" +
                 "  |  group by: 7: abs\n" +
                 "  |  having: 10: max > CAST(abs(1) AS BIGINT)");
     }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/DistributedEnvPlanWithCostTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/DistributedEnvPlanWithCostTest.java
@@ -68,6 +68,23 @@ public class DistributedEnvPlanWithCostTest extends DistributedEnvPlanTestBase {
     }
 
     @Test
+    public void testComplexExprStats() throws Exception {
+        String sql = "select CONCAT(CONCAT(EXTRACT(YEAR FROM DATE_ADD(CASE WHEN CASE  WHEN DAYOFWEEK(l_shipdate) = 1 THEN 6 " +
+                "ELSE -1 END + DAYOFWEEK(l_shipdate) = 1 THEN DATE_SUB(l_shipdate, INTERVAL 7 DAY) " +
+                "WHEN NOT CASE  WHEN DAYOFWEEK(l_shipdate) = 1 THEN 6 ELSE -1 END + DAYOFWEEK(l_shipdate) = 1 " +
+                "THEN l_shipdate ELSE NULL END, INTERVAL 26 - WEEK(CASE WHEN CASE  WHEN DAYOFWEEK(l_shipdate) = 1 " +
+                "THEN 6 ELSE -1 END + DAYOFWEEK(l_shipdate) = 1 THEN DATE_SUB(l_shipdate, INTERVAL 7 DAY) WHEN NOT CASE  " +
+                "WHEN DAYOFWEEK(l_shipdate) = 1 THEN 6 ELSE -1 END + DAYOFWEEK(l_shipdate) = 1 " +
+                "THEN l_shipdate ELSE NULL END, 3) DAY))), " +
+                "CASE WHEN 2 >= 0 THEN RIGHT(CONCAT('0', CONCAT(WEEK(CASE  WHEN CASE  WHEN DAYOFWEEK(l_shipdate) = 1 THEN 6  " +
+                "ELSE -1 END + DAYOFWEEK(l_shipdate) = 1 THEN DATE_SUB(l_shipdate, INTERVAL 7 DAY)" +
+                " WHEN NOT CASE  WHEN DAYOFWEEK(l_shipdate) = 1 THEN 6  ELSE -1 END + DAYOFWEEK(l_shipdate) = 1 " +
+                "THEN l_shipdate ELSE NULL END, 3))), 2) ELSE NULL END) from lineitem";
+        String plan = getCostExplain(sql);
+        assertContains(plan, "concat-->[-Infinity, Infinity, 0.0, 3.0, 412.0] ESTIMATE");
+    }
+
+    @Test
     public void testCountDistinctWithGroupLowCountLow() throws Exception {
         connectContext.getSessionVariable().setNewPlanerAggStage(2);
         String sql = "select count(distinct P_TYPE) from part group by P_BRAND;";


### PR DESCRIPTION
## Why I'm doing:
Failed to derive column stats for complex expression.

## What I'm doing:
- Support `week`, `days_add`, `days_sub`, `concat`, `left`, `right` function in`ExpressionStatisticCalculator`.
- Support dervie stats from input col stats for CallOperator referencing only one column.
- fix `getColumnRefs(List<ColumnRefOperator> columns)` return result contains lambda col in `LambdaFunctionOperator`

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
