### PR TITLE
[BugFix] fix partial update row mode check

### DIFF
--- a/be/src/storage/delta_writer.cpp
+++ b/be/src/storage/delta_writer.cpp
@@ -121,7 +121,8 @@ bool DeltaWriter::is_partial_update_with_sort_key_conflict(const PartialUpdateMo
                                                            const std::vector<int32_t>& referenced_column_ids,
                                                            const std::vector<ColumnId>& sort_key_idxes,
                                                            size_t num_key_columns) {
-    if (partial_update_mode == PartialUpdateMode::ROW_MODE ||
+    if (partial_update_mode == PartialUpdateMode::ROW_MODE || partial_update_mode == PartialUpdateMode::AUTO_MODE ||
+        partial_update_mode == PartialUpdateMode::UNKNOWN_MODE ||
         partial_update_mode == PartialUpdateMode::COLUMN_UPSERT_MODE) {
         // Using Row Mode partial update, then the column to be updated must contain the sort key column,
         // because they need sort key to decide their order when segment is generated.

--- a/be/src/storage/delta_writer.cpp
+++ b/be/src/storage/delta_writer.cpp
@@ -121,6 +121,7 @@ bool DeltaWriter::is_partial_update_with_sort_key_conflict(const PartialUpdateMo
                                                            const std::vector<int32_t>& referenced_column_ids,
                                                            const std::vector<ColumnId>& sort_key_idxes,
                                                            size_t num_key_columns) {
+    // In the current implementation, UNKNOWN_MODE and AUTO_MODE can be considered as ROW_MODE
     if (partial_update_mode == PartialUpdateMode::ROW_MODE || partial_update_mode == PartialUpdateMode::AUTO_MODE ||
         partial_update_mode == PartialUpdateMode::UNKNOWN_MODE ||
         partial_update_mode == PartialUpdateMode::COLUMN_UPSERT_MODE) {

--- a/be/test/storage/delta_writer_test.cpp
+++ b/be/test/storage/delta_writer_test.cpp
@@ -67,7 +67,7 @@ TEST(DeltaWriterTest, test_partial_update_sort_key_conflict_check) {
     }
 
     {
-        // case-2. Column update mode with upsert
+        // case-3. Column update mode with upsert
         std::vector<int32_t> referenced_column_ids = {0, 1, 2, 3, 4};
         std::vector<ColumnId> sort_key_idxes = {0, 1, 2};
         size_t num_key_columns = 3;
@@ -97,6 +97,33 @@ TEST(DeltaWriterTest, test_partial_update_sort_key_conflict_check) {
         num_key_columns = 3;
         ASSERT_FALSE(DeltaWriter::is_partial_update_with_sort_key_conflict(
                 PartialUpdateMode::COLUMN_UPSERT_MODE, referenced_column_ids, sort_key_idxes, num_key_columns));
+    }
+
+    {
+        // case-4. auto mode & unknow mode
+        std::vector<int32_t> referenced_column_ids = {0, 1, 2, 3, 4};
+        std::vector<ColumnId> sort_key_idxes = {0, 1, 2};
+        size_t num_key_columns = 3;
+        ASSERT_FALSE(DeltaWriter::is_partial_update_with_sort_key_conflict(
+                PartialUpdateMode::AUTO_MODE, referenced_column_ids, sort_key_idxes, num_key_columns));
+        ASSERT_FALSE(DeltaWriter::is_partial_update_with_sort_key_conflict(
+                PartialUpdateMode::UNKNOWN_MODE, referenced_column_ids, sort_key_idxes, num_key_columns));
+
+        referenced_column_ids = {0, 1, 2, 3, 4};
+        sort_key_idxes = {2, 3};
+        num_key_columns = 3;
+        ASSERT_FALSE(DeltaWriter::is_partial_update_with_sort_key_conflict(
+                PartialUpdateMode::AUTO_MODE, referenced_column_ids, sort_key_idxes, num_key_columns));
+        ASSERT_FALSE(DeltaWriter::is_partial_update_with_sort_key_conflict(
+                PartialUpdateMode::UNKNOWN_MODE, referenced_column_ids, sort_key_idxes, num_key_columns));
+
+        referenced_column_ids = {0, 1, 2, 4};
+        sort_key_idxes = {2, 3};
+        num_key_columns = 3;
+        ASSERT_TRUE(DeltaWriter::is_partial_update_with_sort_key_conflict(
+                PartialUpdateMode::AUTO_MODE, referenced_column_ids, sort_key_idxes, num_key_columns));
+        ASSERT_TRUE(DeltaWriter::is_partial_update_with_sort_key_conflict(
+                PartialUpdateMode::UNKNOWN_MODE, referenced_column_ids, sort_key_idxes, num_key_columns));
     }
 }
 

--- a/fe/fe-core/src/main/java/com/starrocks/load/streamload/StreamLoadInfo.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/streamload/StreamLoadInfo.java
@@ -83,7 +83,7 @@ public class StreamLoadInfo {
     private boolean enableReplicatedStorage = false;
     private String confluentSchemaRegistryUrl;
     private long logRejectedRecordNum = 0;
-    private TPartialUpdateMode partialUpdateMode = TPartialUpdateMode.UNKNOWN_MODE;
+    private TPartialUpdateMode partialUpdateMode = TPartialUpdateMode.ROW_MODE;
     private long warehouseId = WarehouseManager.DEFAULT_WAREHOUSE_ID;
 
     public StreamLoadInfo(TUniqueId id, long txnId, TFileType fileType, TFileFormatType formatType) {

--- a/test/sql/test_column_with_row/R/test_column_with_row_partial_update
+++ b/test/sql/test_column_with_row/R/test_column_with_row_partial_update
@@ -104,7 +104,7 @@ select * from tab1 order by k1, k2;
 200	k2_200	200	200	200	v4_200	v5_200
 300	k3_300	300	300	300	v4_300	v5_300
 -- !result
-shell: curl --location-trusted -u root: -T ${root_path}/lib/../common/data/stream_load/sr_partial_update_1.csv -XPUT -H partial_update:true -H label:cwr_stream_load_partial_update1 -H column_separator:, -H columns:k1,k2,v4,v3 ${url}/api/test_column_with_row_partial_update/tab1/_stream_load
+shell: curl --location-trusted -u root: -T ${root_path}/lib/../common/data/stream_load/sr_partial_update_1.csv -XPUT -H partial_update:true -H partial_update_mode:column -H label:cwr_stream_load_partial_update1 -H column_separator:, -H columns:k1,k2,v4,v3 ${url}/api/test_column_with_row_partial_update/tab1/_stream_load
 -- result:
 0
 {

--- a/test/sql/test_column_with_row/T/test_column_with_row_partial_update
+++ b/test/sql/test_column_with_row/T/test_column_with_row_partial_update
@@ -51,7 +51,7 @@ update tab1 set v5 = (select sum(tab2.v1) from tab2);
 update tab1 set v5 = "v5_400" where k1 = 100;
 select * from tab1 order by k1, k2;
 
-shell: curl --location-trusted -u root: -T ${root_path}/lib/../common/data/stream_load/sr_partial_update_1.csv -XPUT -H partial_update:true -H label:cwr_stream_load_partial_update1 -H column_separator:, -H columns:k1,k2,v4,v3 ${url}/api/test_column_with_row_partial_update/tab1/_stream_load
+shell: curl --location-trusted -u root: -T ${root_path}/lib/../common/data/stream_load/sr_partial_update_1.csv -XPUT -H partial_update:true -H partial_update_mode:column -H label:cwr_stream_load_partial_update1 -H column_separator:, -H columns:k1,k2,v4,v3 ${url}/api/test_column_with_row_partial_update/tab1/_stream_load
 shell: curl --location-trusted -u root: -T ${root_path}/lib/../common/data/stream_load/sr_partial_update_1.csv -XPUT -H partial_update:true -H partial_update_mode:row -H label:cwr_stream_load_partial_update2 -H column_separator:, -H columns:k1,k2,v4,v3 ${url}/api/test_column_with_row_partial_update/tab1/_stream_load
 select * from tab1 order by k1, k2;
 


### PR DESCRIPTION
## Why I'm doing:
When using partial update, BE need the `partialUpdateMode` state to do some check, make it `ROW_MODE` as default.

## What I'm doing:
1. When `partialUpdateMode` isn't set, make it `ROW_MODE` as default.
2. Do check when using `AUTO_MODE`, because it's same as `ROW_MODE` now.

Fix https://github.com/StarRocks/StarRocksTest/issues/7188

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [x] 3.2
  - [x] 3.1
  - [ ] 3.0
  - [ ] 2.5
