### PR TITLE
[BugFix] Fix struct ordinal index error

### DIFF
--- a/be/src/storage/rowset/struct_column_iterator.cpp
+++ b/be/src/storage/rowset/struct_column_iterator.cpp
@@ -22,6 +22,7 @@
 #include "column/struct_column.h"
 #include "storage/rowset/column_iterator.h"
 #include "storage/rowset/column_reader.h"
+#include "storage/rowset/common.h"
 #include "storage/rowset/scalar_column_iterator.h"
 
 namespace starrocks {
@@ -43,7 +44,7 @@ public:
 
     [[nodiscard]] Status seek_to_ordinal(ordinal_t ord) override;
 
-    ordinal_t get_current_ordinal() const override { return _access_iters[0]->get_current_ordinal(); }
+    ordinal_t get_current_ordinal() const override { return _current_ordinal; }
 
     ordinal_t num_rows() const override { return _access_iters[0]->num_rows(); }
 
@@ -67,6 +68,7 @@ private:
     // prune subfield by path
     std::vector<ColumnIterator*> _access_iters;
     std::unordered_map<int, int> _access_index_map;
+    ordinal_t _current_ordinal = 0;
 };
 
 StatusOr<std::unique_ptr<ColumnIterator>> create_struct_iter(ColumnReader* _reader,
@@ -138,6 +140,7 @@ Status StructColumnIterator::next_batch(size_t* n, Column* dst) {
         RETURN_IF_ERROR(_access_iters[i]->next_batch(&num_to_read, fields[i].get()));
     }
 
+    _current_ordinal = _access_iters[0]->get_current_ordinal();
     return Status::OK();
 }
 
@@ -165,6 +168,7 @@ Status StructColumnIterator::next_batch(const SparseRange<>& range, Column* dst)
         RETURN_IF_ERROR(_access_iters[i]->next_batch(range, fields[i].get()));
     }
 
+    _current_ordinal = _access_iters[0]->get_current_ordinal();
     return Status::OK();
 }
 
@@ -189,6 +193,7 @@ Status StructColumnIterator::fetch_values_by_rowid(const rowid_t* rowids, size_t
         RETURN_IF_ERROR(_access_iters[i]->fetch_values_by_rowid(rowids, size, fields[i].get()));
     }
 
+    _current_ordinal = _access_iters[0]->get_current_ordinal();
     return Status::OK();
 }
 
@@ -199,6 +204,7 @@ Status StructColumnIterator::seek_to_first() {
     for (auto& iter : _access_iters) {
         RETURN_IF_ERROR(iter->seek_to_first());
     }
+    _current_ordinal = _access_iters[0]->get_current_ordinal();
     return Status::OK();
 }
 
@@ -209,6 +215,7 @@ Status StructColumnIterator::seek_to_ordinal(ordinal_t ord) {
     for (auto& iter : _access_iters) {
         RETURN_IF_ERROR(iter->seek_to_ordinal(ord));
     }
+    _current_ordinal = _access_iters[0]->get_current_ordinal();
     return Status::OK();
 }
 
@@ -253,12 +260,16 @@ Status StructColumnIterator::next_batch(size_t* n, Column* dst, ColumnAccessPath
             auto num_to_read = *n;
             RETURN_IF_ERROR(_access_iters[i]->next_batch(&num_to_read, fields[i].get(), predicate_child_paths[i]));
             row_count = fields[i]->size();
+            _current_ordinal = _access_iters[i]->get_current_ordinal();
         }
     }
 
     for (int i = 0; i < _access_iters.size(); ++i) {
         if (!predicate_access_flags[i]) {
-            DCHECK(fields[i]->is_constant());
+            if (!fields[i]->is_constant()) {
+                fields[i]->append_default(1);
+                fields[i] = ConstColumn::create(fields[i], 1);
+            }
             fields[i]->resize(row_count);
         }
     }
@@ -305,6 +316,7 @@ Status StructColumnIterator::next_batch(const SparseRange<>& range, Column* dst,
         }
         RETURN_IF_ERROR(_access_iters[i]->next_batch(range, fields[i].get(), predicate_child_paths[i]));
         row_count = fields[i]->size();
+        _current_ordinal = _access_iters[i]->get_current_ordinal();
     }
 
     for (int i = 0; i < _access_iters.size(); ++i) {
@@ -345,6 +357,7 @@ Status StructColumnIterator::fetch_subfield_by_rowid(const rowid_t* rowids, size
             RETURN_IF_ERROR(_access_iters[i]->fetch_subfield_by_rowid(rowids, size, fields[i].get()));
         }
     }
+    _current_ordinal = _access_iters[0]->get_current_ordinal();
     return Status::OK();
 }
 


### PR DESCRIPTION
## Why I'm doing:

`access_iters[0]` may doesn't read data when use late_materializa, so the ordinal index is error

## What I'm doing:

Follow: https://github.com/StarRocks/starrocks/pull/44294

Fixes https://github.com/StarRocks/StarRocksTest/issues/7150

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
