### PR TITLE
[BugFix] Fix AgentTask not finished when node as compute node

### DIFF
--- a/be/src/agent/agent_server.cpp
+++ b/be/src/agent/agent_server.cpp
@@ -297,7 +297,6 @@ void AgentServer::Impl::stop() {
         // Both PUSH and REALTIME_PUSH type use _push_workers
         STOP_POOL(PUSH, _push_workers);
         STOP_POOL(DELETE, _delete_workers);
-        STOP_POOL(REPORT_TASK, _report_task_workers);
         STOP_POOL(REPORT_DISK_STATE, _report_disk_state_workers);
         STOP_POOL(REPORT_OLAP_TABLE, _report_tablet_workers);
         STOP_POOL(REPORT_WORKGROUP, _report_workgroup_workers);

--- a/be/src/agent/agent_server.cpp
+++ b/be/src/agent/agent_server.cpp
@@ -130,7 +130,7 @@ private:
     std::unique_ptr<ReportResourceUsageTaskWorkerPool> _report_resource_usage_workers;
     std::unique_ptr<ReportDataCacheMetricsTaskWorkerPool> _report_datacache_metrics_workers;
 
-    // Compute node only need _report_resource_usage_workers.
+    // Compute node only need _report_resource_usage_workers and _report_task_workers
     const bool _is_compute_node;
 };
 
@@ -255,7 +255,6 @@ void AgentServer::Impl::init_or_die() {
                               config::push_worker_count_high_priority + config::push_worker_count_normal_priority)
         CREATE_AND_START_POOL(_delete_workers, DeleteTaskWorkerPool,
                               config::delete_worker_count_normal_priority + config::delete_worker_count_high_priority)
-        CREATE_AND_START_POOL(_report_task_workers, ReportTaskWorkerPool, REPORT_TASK_WORKER_COUNT)
         CREATE_AND_START_POOL(_report_disk_state_workers, ReportDiskStateTaskWorkerPool, REPORT_DISK_STATE_WORKER_COUNT)
         CREATE_AND_START_POOL(_report_tablet_workers, ReportOlapTableTaskWorkerPool, REPORT_OLAP_TABLE_WORKER_COUNT)
         CREATE_AND_START_POOL(_report_workgroup_workers, ReportWorkgroupTaskWorkerPool, REPORT_WORKGROUP_WORKER_COUNT)
@@ -264,6 +263,7 @@ void AgentServer::Impl::init_or_die() {
                           REPORT_RESOURCE_USAGE_WORKER_COUNT)
     CREATE_AND_START_POOL(_report_datacache_metrics_workers, ReportDataCacheMetricsTaskWorkerPool,
                           REPORT_DATACACHE_METRICS_WORKER_COUNT)
+    CREATE_AND_START_POOL(_report_task_workers, ReportTaskWorkerPool, REPORT_TASK_WORKER_COUNT)
 #undef CREATE_AND_START_POOL
 }
 

--- a/be/src/agent/agent_server.cpp
+++ b/be/src/agent/agent_server.cpp
@@ -304,6 +304,7 @@ void AgentServer::Impl::stop() {
     }
     STOP_POOL(REPORT_WORKGROUP, _report_resource_usage_workers);
     STOP_POOL(REPORT_DATACACHE_METRICS, _report_datacache_metrics_workers);
+    STOP_POOL(REPORT_TASK, _report_task_workers);
 #undef STOP_POOL
 }
 

--- a/be/src/agent/agent_task.cpp
+++ b/be/src/agent/agent_task.cpp
@@ -297,7 +297,7 @@ void run_alter_tablet_task(const std::shared_ptr<AlterTabletAgentTaskRequest>& a
         finish_task_request.__set_task_type(agent_task_req->task_type);
         finish_task_request.__set_signature(agent_task_req->signature);
         TStatus task_status;
-        task_status.__set_status_code(TStatusCode::CANCELLED);
+        task_status.__set_status_code(TStatusCode::TIMEOUT);
         task_status.__set_error_msgs(std::vector<std::string>{error_msg});
         finish_task_request.__set_task_status(task_status);
 

--- a/be/src/agent/agent_task.cpp
+++ b/be/src/agent/agent_task.cpp
@@ -277,7 +277,8 @@ void run_alter_tablet_task(const std::shared_ptr<AlterTabletAgentTaskRequest>& a
     if (agent_task_req->isset.recv_time) {
         int64_t time_elapsed = time(nullptr) - agent_task_req->recv_time;
         if (time_elapsed > config::report_task_interval_seconds * 20) {
-            error_msg = "task elapsed " + std::to_string(time_elapsed) + " seconds since it is inserted to queue, it is timeout";
+            error_msg = "task elapsed " + std::to_string(time_elapsed) +
+                        " seconds since it is inserted to queue, it is timeout";
             LOG(WARNING) << error_msg;
             is_task_timeout = true;
         }

--- a/be/src/agent/agent_task.cpp
+++ b/be/src/agent/agent_task.cpp
@@ -291,8 +291,7 @@ void run_alter_tablet_task(const std::shared_ptr<AlterTabletAgentTaskRequest>& a
         }
         finish_task(finish_task_request);
     } else {
-        // FE will always wait for task to be finished, for report_task_worker won't work when node as compute node,
-        // so task should be reported to FE even if timeout.
+        // Response should be reported to FE even if timeout.
         TFinishTaskRequest finish_task_request;
         finish_task_request.__set_backend(BackendOptions::get_localBackend());
         finish_task_request.__set_task_type(agent_task_req->task_type);

--- a/be/src/agent/agent_task.cpp
+++ b/be/src/agent/agent_task.cpp
@@ -273,10 +273,12 @@ void run_alter_tablet_task(const std::shared_ptr<AlterTabletAgentTaskRequest>& a
                                                      agent_task_req->task_req.base_tablet_id);
     LOG(INFO) << alter_msg_head << "get alter table task, signature: " << agent_task_req->signature;
     bool is_task_timeout = false;
+    std::string error_msg = "";
     if (agent_task_req->isset.recv_time) {
         int64_t time_elapsed = time(nullptr) - agent_task_req->recv_time;
         if (time_elapsed > config::report_task_interval_seconds * 20) {
-            LOG(INFO) << "task elapsed " << time_elapsed << " seconds since it is inserted to queue, it is timeout";
+            error_msg = "task elapsed " + std::to_string(time_elapsed) + " seconds since it is inserted to queue, it is timeout";
+            LOG(WARNING) << error_msg;
             is_task_timeout = true;
         }
     }
@@ -286,6 +288,19 @@ void run_alter_tablet_task(const std::shared_ptr<AlterTabletAgentTaskRequest>& a
         if (task_type == TTaskType::ALTER) {
             alter_tablet(agent_task_req->task_req, signatrue, &finish_task_request);
         }
+        finish_task(finish_task_request);
+    } else {
+        // FE will always wait for task to be finished, for report_task_worker won't work when node as compute node,
+        // so task should be reported to FE even if timeout.
+        TFinishTaskRequest finish_task_request;
+        finish_task_request.__set_backend(BackendOptions::get_localBackend());
+        finish_task_request.__set_task_type(agent_task_req->task_type);
+        finish_task_request.__set_signature(agent_task_req->signature);
+        TStatus task_status;
+        task_status.__set_status_code(TStatusCode::CANCELLED);
+        task_status.__set_error_msgs(std::vector<std::string>{error_msg});
+        finish_task_request.__set_task_status(task_status);
+
         finish_task(finish_task_request);
     }
     remove_task_info(agent_task_req->task_type, agent_task_req->signature);

--- a/fe/fe-core/src/main/java/com/starrocks/leader/ReportHandler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/leader/ReportHandler.java
@@ -223,8 +223,8 @@ public class ReportHandler extends Daemon implements MemoryTrackable {
             beId = backend.getId();
         } else {
             ComputeNode computeNode = null;
-            // Compute node only reports resource usage or datacache metrics.
-            if (request.isSetResource_usage() || request.isSetDatacache_metrics()) {
+            // Compute node only reports resource usage or datacache metrics or tasks.
+            if (request.isSetResource_usage() || request.isSetDatacache_metrics() || request.isSetTasks()) {
                 computeNode =
                         GlobalStateMgr.getCurrentState().getNodeMgr().getClusterInfo().getComputeNodeWithBePort(host, bePort);
             }


### PR DESCRIPTION
## Why I'm doing:
FE will always wait for task to be finished, for report_task_worker won't work when node as compute node if task timeout in be.

## What I'm doing:
Enable report_task_worker_pool and task should be reported to FE even if timeout.
Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [x] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
