### PR TITLE
[Enhancement] Faster PK table compaction transaction apply strategy (Part-2 local table)

### DIFF
--- a/be/src/storage/CMakeLists.txt
+++ b/be/src/storage/CMakeLists.txt
@@ -246,6 +246,7 @@ add_library(Storage STATIC
     dictionary_cache_manager.cpp
     rows_mapper.cpp
     primary_key_compaction_conflict_resolver.cpp
+    local_primary_key_compaction_conflict_resolver.cpp
     inverted/index_descriptor.hpp
     inverted/inverted_index_iterator.cpp
     inverted/inverted_index_iterator.cpp

--- a/be/src/storage/local_primary_key_compaction_conflict_resolver.cpp
+++ b/be/src/storage/local_primary_key_compaction_conflict_resolver.cpp
@@ -1,0 +1,64 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "storage/local_primary_key_compaction_conflict_resolver.h"
+
+#include "storage/chunk_helper.h"
+#include "storage/del_vector.h"
+#include "storage/kv_store.h"
+#include "storage/primary_index.h"
+#include "storage/update_manager.h"
+
+namespace starrocks {
+
+StatusOr<std::string> LocalPrimaryKeyCompactionConflictResolver::filename() {
+    return local_rows_mapper_filename(_rowset->rowset_path(), _rowset->rowset_id_str());
+}
+
+Schema LocalPrimaryKeyCompactionConflictResolver::generate_pkey_schema() {
+    const auto& schema = _rowset->schema();
+    vector<uint32_t> pk_columns;
+    for (size_t i = 0; i < schema->num_key_columns(); i++) {
+        pk_columns.push_back(static_cast<uint32_t>(i));
+    }
+
+    return ChunkHelper::convert_schema(schema, pk_columns);
+}
+
+Status LocalPrimaryKeyCompactionConflictResolver::segment_iterator(
+        const std::function<Status(const CompactConflictResolveParams&, const std::vector<ChunkIteratorPtr>&,
+                                   const std::function<void(uint32_t, DelVectorPtr, uint32_t)>&)>& handler) {
+    OlapReaderStatistics stats;
+    auto pkey_schema = generate_pkey_schema();
+    RowsetReleaseGuard guard(_rowset->shared_from_this());
+    const auto& schema = _rowset->schema();
+    ASSIGN_OR_RETURN(auto segment_iters, _rowset->get_segment_iterators2(pkey_schema, schema, nullptr, 0, &stats));
+    RETURN_ERROR_IF_FALSE(segment_iters.size() == _rowset->num_segments(), "itrs.size != num_segments");
+    // init delvec loader
+    auto delvec_loader = std::make_unique<LocalDelvecLoader>(_kvstore);
+    // init params
+    CompactConflictResolveParams params;
+    params.tablet_id = _rowset->rowset_meta()->tablet_id();
+    params.rowset_id = _rowset->rowset_meta()->get_rowset_seg_id();
+    params.base_version = _base_version;
+    params.new_version = _new_version;
+    params.delvec_loader = delvec_loader.get();
+    params.index = _index;
+    return handler(params, segment_iters, [&](uint32_t rssid, DelVectorPtr dv, uint32_t num_dels) {
+        *_total_deletes += num_dels;
+        _delvecs->emplace_back(rssid, dv);
+    });
+}
+
+} // namespace starrocks

--- a/be/src/storage/local_primary_key_compaction_conflict_resolver.h
+++ b/be/src/storage/local_primary_key_compaction_conflict_resolver.h
@@ -1,0 +1,59 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include "storage/primary_key_compaction_conflict_resolver.h"
+
+namespace starrocks {
+
+class Rowset;
+class KVStore;
+class PrimaryIndex;
+
+class LocalPrimaryKeyCompactionConflictResolver : public PrimaryKeyCompactionConflictResolver {
+public:
+    explicit LocalPrimaryKeyCompactionConflictResolver(Rowset* rowset, KVStore* kvstore, PrimaryIndex* index,
+                                                       int64_t base_version, int64_t new_version, size_t* total_deletes,
+                                                       std::vector<std::pair<uint32_t, DelVectorPtr>>* delvecs)
+            : _rowset(rowset),
+              _kvstore(kvstore),
+              _index(index),
+              _base_version(base_version),
+              _new_version(new_version),
+              _total_deletes(total_deletes),
+              _delvecs(delvecs) {}
+    ~LocalPrimaryKeyCompactionConflictResolver() {}
+
+    StatusOr<std::string> filename() override;
+    Schema generate_pkey_schema() override;
+    Status segment_iterator(
+            const std::function<Status(const CompactConflictResolveParams&, const std::vector<ChunkIteratorPtr>&,
+                                       const std::function<void(uint32_t, DelVectorPtr, uint32_t)>&)>& handler)
+            override;
+
+private:
+    // input
+    Rowset* _rowset = nullptr;
+    KVStore* _kvstore = nullptr;
+    PrimaryIndex* _index = nullptr;
+    int64_t _base_version = 0;
+    int64_t _new_version = 0;
+    // output
+    size_t* _total_deletes = nullptr;
+    // <rssid -> Delvec>
+    std::vector<std::pair<uint32_t, starrocks::DelVectorPtr>>* _delvecs = nullptr;
+};
+
+} // namespace starrocks

--- a/be/src/storage/local_primary_key_compaction_conflict_resolver.h
+++ b/be/src/storage/local_primary_key_compaction_conflict_resolver.h
@@ -18,17 +18,18 @@
 
 namespace starrocks {
 
+class Tablet;
 class Rowset;
 class KVStore;
 class PrimaryIndex;
 
 class LocalPrimaryKeyCompactionConflictResolver : public PrimaryKeyCompactionConflictResolver {
 public:
-    explicit LocalPrimaryKeyCompactionConflictResolver(Rowset* rowset, KVStore* kvstore, PrimaryIndex* index,
+    explicit LocalPrimaryKeyCompactionConflictResolver(Tablet* tablet, Rowset* rowset, PrimaryIndex* index,
                                                        int64_t base_version, int64_t new_version, size_t* total_deletes,
                                                        std::vector<std::pair<uint32_t, DelVectorPtr>>* delvecs)
-            : _rowset(rowset),
-              _kvstore(kvstore),
+            : _tablet(tablet),
+              _rowset(rowset),
               _index(index),
               _base_version(base_version),
               _new_version(new_version),
@@ -36,17 +37,17 @@ public:
               _delvecs(delvecs) {}
     ~LocalPrimaryKeyCompactionConflictResolver() {}
 
-    StatusOr<std::string> filename() override;
+    StatusOr<std::string> filename() const override;
     Schema generate_pkey_schema() override;
     Status segment_iterator(
             const std::function<Status(const CompactConflictResolveParams&, const std::vector<ChunkIteratorPtr>&,
-                                       const std::function<void(uint32_t, DelVectorPtr, uint32_t)>&)>& handler)
+                                       const std::function<void(uint32_t, const DelVectorPtr&, uint32_t)>&)>& handler)
             override;
 
 private:
     // input
+    Tablet* _tablet = nullptr;
     Rowset* _rowset = nullptr;
-    KVStore* _kvstore = nullptr;
     PrimaryIndex* _index = nullptr;
     int64_t _base_version = 0;
     int64_t _new_version = 0;

--- a/be/src/storage/primary_index.cpp
+++ b/be/src/storage/primary_index.cpp
@@ -151,13 +151,9 @@ public:
         for (uint32_t idx = idx_begin; idx < idx_end; idx++) {
             const uint32_t i = indexes[idx];
             RowIdPack4 v(base + i);
-            auto p = _map.find(keys[i]);
-            if (p != _map.end()) {
-                p->second = v;
-            } else {
-                std::string msg = strings::Substitute("replace not exist key=$0", keys[i]);
-                LOG(ERROR) << msg;
-                return Status::NotFound(msg);
+            auto p = _map.insert({keys[i], v});
+            if (!p.second) {
+                p.first->second = v;
             }
         }
         return Status::OK();
@@ -357,14 +353,9 @@ public:
         uint64_t base = (((uint64_t)rssid) << 32) + rowid_start;
         for (uint32_t idx = idx_begin; idx < idx_end; idx++) {
             const uint32_t i = indexes[idx];
-            auto p = _map.find(FixSlice<S>(keys[i]));
-            if (p != _map.end()) {
-                // matched, can replace
-                p->second.value = base + i;
-            } else {
-                std::string msg = strings::Substitute("replace not exist key=$0", keys[i].to_string());
-                LOG(ERROR) << msg;
-                return Status::NotFound(msg);
+            auto p = _map.emplace(FixSlice<S>(keys[i]), base + i);
+            if (!p.second) {
+                p.first->second = base + i;
             }
         }
         return Status::OK();
@@ -668,14 +659,11 @@ public:
         uint64_t base = (((uint64_t)rssid) << 32) + rowid_start;
         for (uint32_t idx = idx_begin; idx < idx_end; idx++) {
             const uint32_t i = indexes[idx];
-            auto p = _map.find(keys[i].to_string());
-            if (p != _map.end()) {
-                // matched, can replace
-                p->second = base + i;
+            auto p = _map.insert({keys[i].to_string(), base + i});
+            if (!p.second) {
+                p.first->second = base + i;
             } else {
-                std::string msg = strings::Substitute("replace not exist key=$0", keys[i].to_string());
-                LOG(ERROR) << msg;
-                return Status::NotFound(msg);
+                _total_length += keys[i].size;
             }
         }
         return Status::OK();

--- a/be/src/storage/primary_index.h
+++ b/be/src/storage/primary_index.h
@@ -70,7 +70,7 @@ public:
     Status upsert(uint32_t rssid, uint32_t rowid_start, const Column& pks, uint32_t idx_begin, uint32_t idx_end,
                   DeletesMap* deletes);
 
-    // replace old values, and make sure key exist
+    // replace old values and insert when key not exist.
     // Used in compaction apply & publish.
     // [not thread-safe]
     //
@@ -84,7 +84,6 @@ public:
     // replace_indexes : {2, 3}
     // So we only need to replace {c : rssid + rowid_start + 2, d : rssid + rowid_start + 3}
     //
-    // Return NotFound error when key not exist.
     Status replace(uint32_t rssid, uint32_t rowid_start, const std::vector<uint32_t>& replace_indexes,
                    const Column& pks);
 

--- a/be/src/storage/rows_mapper.cpp
+++ b/be/src/storage/rows_mapper.cpp
@@ -133,4 +133,8 @@ StatusOr<std::string> lake_rows_mapper_filename(int64_t tablet_id, int64_t txn_i
     return data_dir->get_tmp_path() + "/" + fmt::format("{:016X}_{:016X}.crm", tablet_id, txn_id);
 }
 
+std::string local_rows_mapper_filename(const std::string& rowset_path, const std::string& rowset_id) {
+    return rowset_path + "/" + rowset_id + ".crm";
+}
+
 } // namespace starrocks

--- a/be/src/storage/rows_mapper.cpp
+++ b/be/src/storage/rows_mapper.cpp
@@ -133,8 +133,8 @@ StatusOr<std::string> lake_rows_mapper_filename(int64_t tablet_id, int64_t txn_i
     return data_dir->get_tmp_path() + "/" + fmt::format("{:016X}_{:016X}.crm", tablet_id, txn_id);
 }
 
-std::string local_rows_mapper_filename(const std::string& rowset_path, const std::string& rowset_id) {
-    return rowset_path + "/" + rowset_id + ".crm";
+std::string local_rows_mapper_filename(Tablet* tablet, const std::string& rowset_id) {
+    return tablet->data_dir()->get_tmp_path() + "/" + fmt::format("{:016X}_{}.crm", tablet->tablet_id(), rowset_id);
 }
 
 } // namespace starrocks

--- a/be/src/storage/rows_mapper.h
+++ b/be/src/storage/rows_mapper.h
@@ -75,4 +75,7 @@ private:
 // rows mapper file's name for lake table
 StatusOr<std::string> lake_rows_mapper_filename(int64_t tablet_id, int64_t txn_id);
 
+// rows mapper file's name for local table
+std::string local_rows_mapper_filename(const std::string& rowset_path, const std::string& rowset_id);
+
 } // namespace starrocks

--- a/be/src/storage/rows_mapper.h
+++ b/be/src/storage/rows_mapper.h
@@ -23,6 +23,7 @@ namespace starrocks {
 
 class WritableFile;
 class RandomAccessFile;
+class Tablet;
 
 // Build the connection between input rowsets' rows and ouput rowsets' rows,
 // and then write to file.
@@ -76,6 +77,6 @@ private:
 StatusOr<std::string> lake_rows_mapper_filename(int64_t tablet_id, int64_t txn_id);
 
 // rows mapper file's name for local table
-std::string local_rows_mapper_filename(const std::string& rowset_path, const std::string& rowset_id);
+std::string local_rows_mapper_filename(Tablet* tablet, const std::string& rowset_id);
 
 } // namespace starrocks

--- a/be/src/storage/rowset/rowset_writer.cpp
+++ b/be/src/storage/rowset/rowset_writer.cpp
@@ -58,6 +58,7 @@
 #include "storage/metadata_util.h"
 #include "storage/olap_define.h"
 #include "storage/row_source_mask.h"
+#include "storage/rows_mapper.h"
 #include "storage/rowset/rowset.h"
 #include "storage/rowset/rowset_factory.h"
 #include "storage/storage_engine.h"
@@ -128,6 +129,11 @@ Status RowsetWriter::init() {
     }
 
     ASSIGN_OR_RETURN(_fs, FileSystem::CreateSharedFromString(_context.rowset_path_prefix));
+
+    if (_context.is_compaction) {
+        _rows_mapper_builder = std::make_unique<RowsMapperBuilder>(
+                local_rows_mapper_filename(_context.rowset_path_prefix, _context.rowset_id.to_string()));
+    }
     return Status::OK();
 }
 
@@ -226,6 +232,9 @@ StatusOr<RowsetSharedPtr> RowsetWriter::build() {
     RowsetSharedPtr rowset;
     RETURN_IF_ERROR(
             RowsetFactory::create_rowset(_context.tablet_schema, _context.rowset_path_prefix, rowset_meta, &rowset));
+    if (_rows_mapper_builder != nullptr) {
+        RETURN_IF_ERROR(_rows_mapper_builder->finalize());
+    }
     _already_built = true;
     return rowset;
 }
@@ -475,6 +484,11 @@ StatusOr<std::unique_ptr<SegmentWriter>> HorizontalRowsetWriter::_create_segment
 }
 
 Status HorizontalRowsetWriter::add_chunk(const Chunk& chunk) {
+    std::vector<uint64_t> empty_rssid_rowids;
+    return add_chunk(chunk, empty_rssid_rowids);
+}
+
+Status HorizontalRowsetWriter::add_chunk(const Chunk& chunk, const std::vector<uint64_t>& rssid_rowids) {
     if (_segment_writer == nullptr) {
         ASSIGN_OR_RETURN(_segment_writer, _create_segment_writer());
     } else if (_segment_writer->estimate_segment_size() >= config::max_segment_file_size ||
@@ -484,6 +498,9 @@ Status HorizontalRowsetWriter::add_chunk(const Chunk& chunk) {
     }
 
     RETURN_IF_ERROR(_segment_writer->append_chunk(chunk));
+    if (_rows_mapper_builder != nullptr) {
+        RETURN_IF_ERROR(_rows_mapper_builder->append(rssid_rowids));
+    }
     _num_rows_written += static_cast<int64_t>(chunk.num_rows());
     _total_row_size += static_cast<int64_t>(chunk.bytes_usage());
     return Status::OK();
@@ -1078,6 +1095,12 @@ VerticalRowsetWriter::~VerticalRowsetWriter() {
 }
 
 Status VerticalRowsetWriter::add_columns(const Chunk& chunk, const std::vector<uint32_t>& column_indexes, bool is_key) {
+    std::vector<uint64_t> empty_rssid_rowids;
+    return add_columns(chunk, column_indexes, is_key, empty_rssid_rowids);
+}
+
+Status VerticalRowsetWriter::add_columns(const Chunk& chunk, const std::vector<uint32_t>& column_indexes, bool is_key,
+                                         const std::vector<uint64_t>& rssid_rowids) {
     const size_t chunk_num_rows = chunk.num_rows();
     if (_segment_writers.empty()) {
         DCHECK(is_key);
@@ -1086,6 +1109,9 @@ Status VerticalRowsetWriter::add_columns(const Chunk& chunk, const std::vector<u
         _segment_writers.emplace_back(std::move(segment_writer).value());
         _current_writer_index = 0;
         RETURN_IF_ERROR(_segment_writers[_current_writer_index]->append_chunk(chunk));
+        if (_rows_mapper_builder != nullptr) {
+            RETURN_IF_ERROR(_rows_mapper_builder->append(rssid_rowids));
+        }
     } else if (is_key) {
         // key columns
         if (_segment_writers[_current_writer_index]->num_rows_written() + chunk_num_rows >=
@@ -1097,6 +1123,9 @@ Status VerticalRowsetWriter::add_columns(const Chunk& chunk, const std::vector<u
             ++_current_writer_index;
         }
         RETURN_IF_ERROR(_segment_writers[_current_writer_index]->append_chunk(chunk));
+        if (_rows_mapper_builder != nullptr) {
+            RETURN_IF_ERROR(_rows_mapper_builder->append(rssid_rowids));
+        }
     } else {
         // non key columns
         uint32_t num_rows_written = _segment_writers[_current_writer_index]->num_rows_written();

--- a/be/src/storage/rowset/rowset_writer.cpp
+++ b/be/src/storage/rowset/rowset_writer.cpp
@@ -130,9 +130,12 @@ Status RowsetWriter::init() {
 
     ASSIGN_OR_RETURN(_fs, FileSystem::CreateSharedFromString(_context.rowset_path_prefix));
 
-    if (_context.is_compaction) {
-        _rows_mapper_builder = std::make_unique<RowsMapperBuilder>(
-                local_rows_mapper_filename(_context.rowset_path_prefix, _context.rowset_id.to_string()));
+    if (_context.is_pk_compaction) {
+        TabletSharedPtr tablet = StorageEngine::instance()->tablet_manager()->get_tablet(_context.tablet_id);
+        if (tablet != nullptr) {
+            _rows_mapper_builder = std::make_unique<RowsMapperBuilder>(
+                    local_rows_mapper_filename(tablet.get(), _context.rowset_id.to_string()));
+        }
     }
     return Status::OK();
 }

--- a/be/src/storage/rowset/rowset_writer.h
+++ b/be/src/storage/rowset/rowset_writer.h
@@ -46,6 +46,7 @@
 #include "runtime/global_dict/types_fwd_decl.h"
 #include "storage/column_mapping.h"
 #include "storage/compaction_utils.h"
+#include "storage/rows_mapper.h"
 #include "storage/rowset/rowset.h"
 #include "storage/rowset/rowset_writer.h"
 #include "storage/rowset/rowset_writer_context.h"
@@ -109,9 +110,18 @@ public:
 
     virtual Status add_chunk(const Chunk& chunk) { return Status::NotSupported("RowsetWriter::add_chunk"); }
 
+    virtual Status add_chunk(const Chunk& chunk, const std::vector<uint64_t>& rssid_rowids) {
+        return Status::NotSupported("RowsetWriter::add_chunk");
+    }
+
     // Used for vertical compaction
     // |Chunk| contains partial columns data corresponding to |column_indexes|.
     virtual Status add_columns(const Chunk& chunk, const std::vector<uint32_t>& column_indexes, bool is_key) {
+        return Status::NotSupported("RowsetWriter::add_columns");
+    }
+
+    virtual Status add_columns(const Chunk& chunk, const std::vector<uint32_t>& column_indexes, bool is_key,
+                               const std::vector<uint64_t>& rssid_rowids) {
         return Status::NotSupported("RowsetWriter::add_columns");
     }
 
@@ -199,6 +209,8 @@ protected:
     FlushChunkState _flush_chunk_state = FlushChunkState::UNKNOWN;
 
     DictColumnsValidMap _global_dict_columns_valid_info;
+
+    std::unique_ptr<RowsMapperBuilder> _rows_mapper_builder;
 };
 
 class VerticalRowsetWriter;
@@ -210,6 +222,8 @@ public:
     ~HorizontalRowsetWriter() override;
 
     Status add_chunk(const Chunk& chunk) override;
+
+    Status add_chunk(const Chunk& chunk, const std::vector<uint64_t>& rssid_rowids) override;
 
     Status flush_chunk(const Chunk& chunk, SegmentPB* seg_info = nullptr) override;
     Status flush_chunk_with_deletes(const Chunk& upserts, const Column& deletes, SegmentPB* seg_info) override;
@@ -246,6 +260,9 @@ public:
     ~VerticalRowsetWriter() override;
 
     Status add_columns(const Chunk& chunk, const std::vector<uint32_t>& column_indexes, bool is_key) override;
+
+    Status add_columns(const Chunk& chunk, const std::vector<uint32_t>& column_indexes, bool is_key,
+                       const std::vector<uint64_t>& rssid_rowids) override;
 
     Status flush_columns() override;
 

--- a/be/src/storage/rowset/rowset_writer_context.h
+++ b/be/src/storage/rowset/rowset_writer_context.h
@@ -93,8 +93,8 @@ public:
 
     // gtid
     int64_t gtid = 0;
-    // Is compaction output writer
-    bool is_compaction = false;
+    // Is pk compaction output writer
+    bool is_pk_compaction = false;
 };
 
 } // namespace starrocks

--- a/be/src/storage/rowset/rowset_writer_context.h
+++ b/be/src/storage/rowset/rowset_writer_context.h
@@ -93,6 +93,8 @@ public:
 
     // gtid
     int64_t gtid = 0;
+    // Is compaction output writer
+    bool is_compaction = false;
 };
 
 } // namespace starrocks

--- a/be/src/storage/rowset/segment_iterator.cpp
+++ b/be/src/storage/rowset/segment_iterator.cpp
@@ -112,6 +112,10 @@ protected:
     Status do_get_next(Chunk* chunk, vector<uint32_t>* rowid) override;
     Status do_get_next(Chunk* chunk, vector<uint64_t>* rssid_rowids) override;
     Status do_get_next(Chunk* chunk, std::vector<RowSourceMask>* source_masks) override { return do_get_next(chunk); }
+    Status do_get_next(Chunk* chunk, std::vector<RowSourceMask>* source_masks,
+                       std::vector<uint64_t>* rssid_rowids) override {
+        return do_get_next(chunk, rssid_rowids);
+    }
 
 private:
     struct ScanContext {

--- a/be/src/storage/rowset_merger.cpp
+++ b/be/src/storage/rowset_merger.cpp
@@ -58,6 +58,7 @@ struct MergeEntry {
     const Schema* encode_schema = nullptr;
     uint16_t order;
     std::vector<RowSourceMask>* source_masks = nullptr;
+    std::vector<uint64_t> rssid_rowids;
 
     MergeEntry() = default;
     ~MergeEntry() { close(); }
@@ -100,7 +101,8 @@ struct MergeEntry {
     Status next() {
         DCHECK(pk_cur == nullptr || pk_cur > pk_last);
         chunk->reset();
-        auto st = segment_itr->get_next(chunk.get(), source_masks);
+        rssid_rowids.clear();
+        auto st = segment_itr->get_next(chunk.get(), source_masks, &rssid_rowids);
         if (st.ok()) {
             // 1. setup chunk_pk_column
             if (encode_schema != nullptr) {
@@ -179,7 +181,7 @@ public:
         return Status::OK();
     }
 
-    Status get_next(Chunk* chunk, vector<RowSourceMask>* source_masks) {
+    Status get_next(Chunk* chunk, vector<RowSourceMask>* source_masks, vector<uint64_t>* rssid_rowids) {
         size_t nrow = 0;
         while (!_heap.empty() && nrow < _chunk_size) {
             MergeEntry<T>& top = *_heap.top();
@@ -192,6 +194,9 @@ public:
                     if (source_masks) {
                         source_masks->insert(source_masks->end(), chunk->num_rows(), RowSourceMask{top.order, false});
                     }
+                    if (rssid_rowids) {
+                        rssid_rowids->insert(rssid_rowids->end(), top.rssid_rowids.begin(), top.rssid_rowids.end());
+                    }
                     top.pk_cur = top.pk_last + 1;
                     return _fill_heap(&top);
                 } else {
@@ -201,6 +206,10 @@ public:
                     chunk->append(*top.chunk, start_offset, nappend);
                     if (source_masks) {
                         source_masks->insert(source_masks->end(), nappend, RowSourceMask{top.order, false});
+                    }
+                    if (rssid_rowids) {
+                        rssid_rowids->insert(rssid_rowids->end(), top.rssid_rowids.begin() + start_offset,
+                                             top.rssid_rowids.begin() + start_offset + nappend);
                     }
                     top.pk_cur += nappend;
                     if (top.pk_cur > top.pk_last) {
@@ -225,6 +234,10 @@ public:
                     auto start_offset = top.offset(start);
                     auto end_offset = top.offset(top.pk_cur);
                     chunk->append(*top.chunk, start_offset, end_offset - start_offset);
+                    if (rssid_rowids) {
+                        rssid_rowids->insert(rssid_rowids->end(), top.rssid_rowids.begin() + start_offset,
+                                             top.rssid_rowids.begin() + end_offset);
+                    }
                     DCHECK(chunk->num_rows() == nrow);
                     //LOG(INFO) << "  append " << end_offset - start_offset << "  get_next batch";
                     return _fill_heap(&top);
@@ -233,6 +246,10 @@ public:
                     auto start_offset = top.offset(start);
                     auto end_offset = top.offset(top.pk_cur);
                     chunk->append(*top.chunk, start_offset, end_offset - start_offset);
+                    if (rssid_rowids) {
+                        rssid_rowids->insert(rssid_rowids->end(), top.rssid_rowids.begin() + start_offset,
+                                             top.rssid_rowids.begin() + end_offset);
+                    }
                     DCHECK(chunk->num_rows() == nrow);
                     //if (nrow >= _chunk_size) {
                     //	LOG(INFO) << "  append " << end_offset - start_offset << "  chunk full";
@@ -340,7 +357,8 @@ private:
                 entry.segment_itr = new_empty_iterator(schema, _chunk_size);
             } else {
                 if (rowset->rowset_meta()->is_segments_overlapping()) {
-                    entry.segment_itr = std::move(new_heap_merge_iterator(res.value()));
+                    entry.segment_itr = std::move(new_heap_merge_iterator(
+                            res.value(), StorageEngine::instance()->enable_light_pk_compaction_publish()));
                 } else {
                     entry.segment_itr = std::move(new_union_iterator(res.value()));
                 }
@@ -381,9 +399,11 @@ private:
         }
 
         auto chunk = ChunkHelper::new_chunk(schema, _chunk_size);
+        vector<uint64_t> rssid_rowids;
         while (true) {
             chunk->reset();
-            Status status = get_next(chunk.get(), source_masks.get());
+            rssid_rowids.clear();
+            Status status = get_next(chunk.get(), source_masks.get(), &rssid_rowids);
             if (!status.ok()) {
                 if (status.is_end_of_file()) {
                     break;
@@ -400,7 +420,7 @@ private:
             (*total_chunk)++;
 
             if (mask_buffer) {
-                if (auto st = writer->add_columns(*chunk, column_indexes, true); !st.ok()) {
+                if (auto st = writer->add_columns(*chunk, column_indexes, true, rssid_rowids); !st.ok()) {
                     LOG(WARNING) << "writer add_columns error, tablet=" << tablet.tablet_id() << ", err=" << st;
                     return st;
                 }
@@ -410,7 +430,7 @@ private:
                     source_masks->clear();
                 }
             } else {
-                if (auto st = writer->add_chunk(*chunk); !st.ok()) {
+                if (auto st = writer->add_chunk(*chunk, rssid_rowids); !st.ok()) {
                     LOG(WARNING) << "writer add_chunk error, tablet=" << tablet.tablet_id() << ", err=" << st;
                     return st;
                 }

--- a/be/src/storage/tablet_updates.h
+++ b/be/src/storage/tablet_updates.h
@@ -404,7 +404,7 @@ private:
     // used for column-mode partial update
     void _apply_column_partial_update_commit(const EditVersionInfo& version_info, const RowsetSharedPtr& rowset);
 
-    void _apply_compaction_commit(const EditVersionInfo& version_info, const EditVersion& applied_version);
+    void _apply_compaction_commit(const EditVersionInfo& version_info);
 
     // wait a version to be applied, so reader can read this version
     // assuming _lock already hold
@@ -490,8 +490,9 @@ private:
 
     bool _use_light_apply_compaction(Rowset* rowset);
 
-    void _light_apply_compaction_commit(const EditVersionInfo& version_info, const EditVersion& applied_version,
-                                        Rowset* output_rowset);
+    Status _light_apply_compaction_commit(const EditVersion& version, Rowset* output_rowset, PrimaryIndex* index,
+                                          size_t* total_deletes, size_t* total_rows,
+                                          vector<std::pair<uint32_t, DelVectorPtr>>* delvecs);
 
 private:
     Tablet& _tablet;

--- a/be/src/storage/tablet_updates.h
+++ b/be/src/storage/tablet_updates.h
@@ -359,6 +359,8 @@ public:
 
     Status generate_pk_dump_if_in_error_state();
 
+    RowsetSharedPtr get_rowset(uint32_t rowset_id);
+
 private:
     friend class Tablet;
     friend class PrimaryIndex;
@@ -402,9 +404,7 @@ private:
     // used for column-mode partial update
     void _apply_column_partial_update_commit(const EditVersionInfo& version_info, const RowsetSharedPtr& rowset);
 
-    void _apply_compaction_commit(const EditVersionInfo& version_info);
-
-    RowsetSharedPtr _get_rowset(uint32_t rowset_id);
+    void _apply_compaction_commit(const EditVersionInfo& version_info, const EditVersion& applied_version);
 
     // wait a version to be applied, so reader can read this version
     // assuming _lock already hold
@@ -487,6 +487,11 @@ private:
     std::shared_timed_mutex* get_index_lock() { return &_index_lock; }
 
     StatusOr<ExtraFileSize> _get_extra_file_size() const;
+
+    bool _use_light_apply_compaction(Rowset* rowset);
+
+    void _light_apply_compaction_commit(const EditVersionInfo& version_info, const EditVersion& applied_version,
+                                        Rowset* output_rowset);
 
 private:
     Tablet& _tablet;

--- a/be/test/storage/lake/primary_key_compaction_task_test.cpp
+++ b/be/test/storage/lake/primary_key_compaction_task_test.cpp
@@ -411,6 +411,7 @@ TEST_P(LakePrimaryKeyCompactionTest, test_compaction_policy) {
     config::lake_pk_compaction_max_input_rowsets = 1;
     ASSIGN_OR_ABORT(auto input_rowsets3, compaction_policy->pick_rowsets());
     EXPECT_EQ(1, input_rowsets3.size());
+    config::lake_pk_compaction_max_input_rowsets = 1000;
 }
 
 TEST_P(LakePrimaryKeyCompactionTest, test_compaction_policy2) {
@@ -478,6 +479,7 @@ TEST_P(LakePrimaryKeyCompactionTest, test_compaction_policy2) {
     EXPECT_EQ(input_rowsets[1]->id(), 4);
     EXPECT_EQ(input_rowsets[2]->id(), 2);
     EXPECT_EQ(input_rowsets[3]->id(), 3);
+    config::lake_pk_compaction_max_input_rowsets = 1000;
 }
 
 TEST_P(LakePrimaryKeyCompactionTest, test_compaction_policy3) {
@@ -557,6 +559,7 @@ TEST_P(LakePrimaryKeyCompactionTest, test_compaction_policy3) {
     EXPECT_EQ(input_rowsets[1]->id(), 7);
     EXPECT_EQ(input_rowsets[2]->id(), 2);
     EXPECT_EQ(input_rowsets[3]->id(), 4);
+    config::lake_pk_compaction_max_input_rowsets = 1000;
 }
 
 TEST_P(LakePrimaryKeyCompactionTest, test_compaction_policy_min_input) {

--- a/be/test/storage/primary_index_test.cpp
+++ b/be/test/storage/primary_index_test.cpp
@@ -173,18 +173,6 @@ void test_integral_pk() {
     pk_index->erase(*pk_col, &deletes);
     CHECK_EQ(2, deletes.size());
 
-    {
-        std::vector<uint64_t> rowids(pk_col->size());
-        pk_index->get(*pk_col, &rowids);
-        for (uint32_t i = 0; i < kSegmentSize; i++) {
-            uint64_t v = rowids[i];
-            uint32_t rssid = v >> 32;
-            CHECK_EQ(rssid, -1);
-        }
-        // replace not exist keys
-        ASSERT_TRUE(pk_index->replace(6, 0, replace_indexes, *pk_col).is_not_found());
-    }
-
     CHECK(deletes.find(2) != deletes.end());
     CHECK(deletes.find(2) != deletes.end());
     CHECK_EQ(kSegmentSize / 2, deletes[2].size());
@@ -345,19 +333,6 @@ void test_binary_pk(int key_size) {
     pk_index->erase(*pk_col, &deletes);
     CHECK_EQ(2, deletes.size());
 
-    {
-        std::vector<uint64_t> rowids(pk_col->size());
-        pk_index->get(*pk_col, &rowids);
-        for (uint32_t i = 0; i < kSegmentSize; i++) {
-            uint64_t v = rowids[i];
-            uint32_t rssid = v >> 32;
-            CHECK_EQ(rssid, -1);
-        }
-
-        // replace not exist keys
-        ASSERT_TRUE(pk_index->replace(6, 0, replace_indexes, *pk_col).is_not_found());
-    }
-
     CHECK(deletes.find(2) != deletes.end());
     CHECK(deletes.find(3) != deletes.end());
     CHECK_EQ(kSegmentSize / 2, deletes[2].size());
@@ -432,8 +407,7 @@ PARALLEL_TEST(PrimaryIndexTest, test_composite_key) {
     ASSERT_EQ(deletes.size(), 1);
     ASSERT_EQ(deletes[2].size(), kSegmentSize);
 
-    // replace not exist keys
-    ASSERT_TRUE(pk_index->replace(3, 0, replace_indexes, *pk_column).is_not_found());
+    ASSERT_TRUE(pk_index->replace(3, 0, replace_indexes, *pk_column).ok());
 }
 
 // TODO: test composite primary key

--- a/be/test/storage/rowset/rowset_test.cpp
+++ b/be/test/storage/rowset/rowset_test.cpp
@@ -422,6 +422,15 @@ TEST_F(RowsetTest, ConditionUpdateWithMultipleSegmentsTest) {
     test_final_merge(true);
 }
 
+TEST_F(RowsetTest, UnSupportFuncTest) {
+    Chunk chunk;
+    std::vector<uint64_t> rssid_rowids;
+    std::vector<uint32_t> column_indexes;
+    RowsetWriter writer;
+    ASSERT_TRUE(writer.add_chunk(chunk, rssid_rowids).is_not_supported());
+    ASSERT_TRUE(writer.add_columns(chunk, column_indexes, true, rssid_rowids).is_not_supported());
+}
+
 TEST_F(RowsetTest, FinalMergeVerticalTest) {
     auto tablet = create_tablet(12345, 1111);
     RowsetSharedPtr rowset;

--- a/be/test/storage/rowset_merger_test.cpp
+++ b/be/test/storage/rowset_merger_test.cpp
@@ -42,6 +42,11 @@ public:
     Status init() override { return Status::OK(); }
 
     Status add_chunk(const Chunk& chunk) override {
+        std::vector<uint64_t> rssid_rowids;
+        return add_chunk(chunk, rssid_rowids);
+    }
+
+    Status add_chunk(const Chunk& chunk, const std::vector<uint64_t>& rssid_rowids) override {
         all_pks->append(*chunk.get_column_by_index(0), 0, chunk.num_rows());
         return Status::OK();
     }
@@ -73,6 +78,12 @@ public:
     Status final_flush() override { return Status::OK(); }
 
     Status add_columns(const Chunk& chunk, const std::vector<uint32_t>& column_indexes, bool is_key) override {
+        std::vector<uint64_t> rssid_rowids;
+        return add_columns(chunk, column_indexes, is_key, rssid_rowids);
+    }
+
+    Status add_columns(const Chunk& chunk, const std::vector<uint32_t>& column_indexes, bool is_key,
+                       const std::vector<uint64_t>& rssid_rowids) override {
         if (is_key) {
             all_pks->append(*chunk.get_column_by_index(0), 0, chunk.num_rows());
         } else {

--- a/be/test/storage/tablet_updates_test.cpp
+++ b/be/test/storage/tablet_updates_test.cpp
@@ -1270,7 +1270,7 @@ void TabletUpdatesTest::test_horizontal_compaction_with_rows_mapper(bool enable_
     // read from file
     auto output_rs = best_tablet->updates()->get_rowset(rs->rowset_meta()->get_rowset_seg_id() + 1);
     RowsMapperIterator iterator;
-    ASSERT_OK(iterator.open(local_rows_mapper_filename(output_rs->rowset_path(), output_rs->rowset_id_str())));
+    ASSERT_OK(iterator.open(local_rows_mapper_filename(best_tablet.get(), output_rs->rowset_id_str())));
     for (uint32_t i = 0; i < 100; i += 20) {
         std::vector<uint64_t> rows_mapper;
         ASSERT_OK(iterator.next_values(20, &rows_mapper));
@@ -1302,8 +1302,20 @@ TEST_F(TabletUpdatesTest, horizontal_compaction) {
     test_horizontal_compaction(false);
 }
 
+TEST_F(TabletUpdatesTest, horizontal_compaction_old_compact_stragety) {
+    config::enable_light_pk_compaction_publish = false;
+    test_horizontal_compaction(false);
+    config::enable_light_pk_compaction_publish = true;
+}
+
 TEST_F(TabletUpdatesTest, horizontal_compaction_with_persistent_index) {
     test_horizontal_compaction(true);
+}
+
+TEST_F(TabletUpdatesTest, horizontal_compaction_with_persistent_index_old_compact_stragety) {
+    config::enable_light_pk_compaction_publish = false;
+    test_horizontal_compaction(true);
+    config::enable_light_pk_compaction_publish = true;
 }
 
 TEST_F(TabletUpdatesTest, horizontal_compaction_with_rows_mapper) {
@@ -1556,7 +1568,7 @@ void TabletUpdatesTest::test_vertical_compaction_with_rows_mapper(bool enable_pe
     // read from file
     auto output_rs = best_tablet->updates()->get_rowset(rs->rowset_meta()->get_rowset_seg_id() + 1);
     RowsMapperIterator iterator;
-    ASSERT_OK(iterator.open(local_rows_mapper_filename(output_rs->rowset_path(), output_rs->rowset_id_str())));
+    ASSERT_OK(iterator.open(local_rows_mapper_filename(best_tablet.get(), output_rs->rowset_id_str())));
     for (uint32_t i = 0; i < 100; i += 20) {
         std::vector<uint64_t> rows_mapper;
         ASSERT_OK(iterator.next_values(20, &rows_mapper));
@@ -1588,8 +1600,20 @@ TEST_F(TabletUpdatesTest, vertical_compaction) {
     test_vertical_compaction(false);
 }
 
+TEST_F(TabletUpdatesTest, vertical_compaction_old_compact_stragety) {
+    config::enable_light_pk_compaction_publish = false;
+    test_vertical_compaction(false);
+    config::enable_light_pk_compaction_publish = true;
+}
+
 TEST_F(TabletUpdatesTest, vertical_compaction_with_persistent_index) {
     test_vertical_compaction(true);
+}
+
+TEST_F(TabletUpdatesTest, vertical_compaction_with_persistent_index_old_compact_stragety) {
+    config::enable_light_pk_compaction_publish = false;
+    test_vertical_compaction(true);
+    config::enable_light_pk_compaction_publish = true;
 }
 
 TEST_F(TabletUpdatesTest, vertical_compaction_with_rows_mapper) {
@@ -3203,7 +3227,7 @@ TEST_F(TabletUpdatesTest, test_update_and_recover) {
     update_and_recover(false);
 }
 
-TEST_F(TabletUpdatesTest, test_recover_rowset_sorter) {
+void TabletUpdatesTest::test_recover_rowset_sorter() {
     const int N = 10;
     _tablet = create_tablet(rand(), rand());
     ASSERT_EQ(1, _tablet->updates()->version_history_count());
@@ -3253,6 +3277,16 @@ TEST_F(TabletUpdatesTest, test_recover_rowset_sorter) {
     ASSERT_TRUE(latest_rowsets[0]->rowset_meta()->max_compact_input_rowset_id() <
                 latest_rowsets[1]->rowset_meta()->get_rowset_seg_id());
     config::max_update_compaction_num_singleton_deltas = old_config;
+}
+
+TEST_F(TabletUpdatesTest, test_recover_rowset_sorter_old_stragety) {
+    config::enable_light_pk_compaction_publish = false;
+    test_recover_rowset_sorter();
+    config::enable_light_pk_compaction_publish = true;
+}
+
+TEST_F(TabletUpdatesTest, test_recover_rowset_sorter_new_stragety) {
+    test_recover_rowset_sorter();
 }
 
 TEST_F(TabletUpdatesTest, test_load_primary_index_failed) {

--- a/be/test/storage/tablet_updates_test.h
+++ b/be/test/storage/tablet_updates_test.h
@@ -795,6 +795,8 @@ public:
     void test_compaction_score_enough_normal(bool enable_persistent_index);
     void test_horizontal_compaction(bool enable_persistent_index);
     void test_vertical_compaction(bool enable_persistent_index);
+    void test_horizontal_compaction_with_rows_mapper(bool enable_persistent_index);
+    void test_vertical_compaction_with_rows_mapper(bool enable_persistent_index);
     void test_compaction_with_empty_rowset(bool enable_persistent_index, bool vertical, bool multi_column_pk);
     void test_link_from(bool enable_persistent_index);
     void test_convert_from(bool enable_persistent_index);

--- a/be/test/storage/tablet_updates_test.h
+++ b/be/test/storage/tablet_updates_test.h
@@ -839,6 +839,7 @@ public:
     void test_schema_change_optimiazation_adding_generated_column(bool enable_persistent_index);
     void test_pk_dump(size_t rowset_cnt);
     void update_and_recover(bool enable_persistent_index);
+    void test_recover_rowset_sorter();
 
 protected:
     TabletSharedPtr _tablet;


### PR DESCRIPTION
## Why I'm doing:
A faster compaction apply strategy for local pk table. More detail : #43934

## What I'm doing:
The compaction processing in the new scheme consists of several steps:

1. During the compaction execution, generate a file containing the input segments' rowids (end as .crm). In file `rowset_writer.cpp`
2. in the apply phase, load the output segment's PK columns into memory chunk by chunk and read the corresponding input segment's rowid from .crm. In file `local_primary_key_compaction_conflict_resolver.cpp`.


## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
