### PR TITLE
[BugFix] Fix mv refresh bug for queries with union all

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/MvRefreshArbiter.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/MvRefreshArbiter.java
@@ -193,9 +193,8 @@ public class MvRefreshArbiter {
             Map<Table, Map<String, Range<PartitionKey>>> refBaseTablePartitionMap = baseTableUpdateInfos.entrySet().stream()
                     .collect(Collectors.toMap(Map.Entry::getKey, e -> e.getValue().getPartitionNameWithRanges()));
             Table partitionTable = mv.getDirectTableAndPartitionColumn().first;
-            Column partitionColumn = mv.getPartitionInfo().getPartitionColumns().get(0);
             PartitionDiffer differ = PartitionDiffer.build(mv, Pair.create(null, null));
-            rangePartitionDiff = PartitionUtil.getPartitionDiff(partitionExpr, partitionColumn,
+            rangePartitionDiff = PartitionUtil.getPartitionDiff(partitionExpr,
                     refBaseTablePartitionMap.get(partitionTable), mvRangePartitionMap, differ);
         } catch (Exception e) {
             LOG.warn("Materialized view compute partition difference with base table failed.", e);
@@ -305,12 +304,11 @@ public class MvRefreshArbiter {
         // TODO: prune the partitions based on ttl
         Pair<Table, Column> directTableAndPartitionColumn = mv.getDirectTableAndPartitionColumn();
         Table refBaseTable = directTableAndPartitionColumn.first;
-        Column refBaseTablePartitionColumn = directTableAndPartitionColumn.second;
 
         Map<String, Range<PartitionKey>> refTablePartitionMap = basePartitionNameToRangeMap.get(refBaseTable);
         Map<String, Range<PartitionKey>> mvPartitionNameToRangeMap = mv.getRangePartitionMap();
         RangePartitionDiff rangePartitionDiff = PartitionUtil.getPartitionDiff(partitionExpr,
-                refBaseTablePartitionColumn, refTablePartitionMap, mvPartitionNameToRangeMap, null);
+                refTablePartitionMap, mvPartitionNameToRangeMap, null);
 
         Set<String> needRefreshMvPartitionNames = Sets.newHashSet();
 

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/TableProperty.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/TableProperty.java
@@ -45,7 +45,6 @@ import com.google.gson.annotations.SerializedName;
 import com.starrocks.analysis.TableName;
 import com.starrocks.binlog.BinlogConfig;
 import com.starrocks.common.Config;
-import com.starrocks.common.FeConstants;
 import com.starrocks.common.io.Text;
 import com.starrocks.common.io.Writable;
 import com.starrocks.common.util.PropertyAnalyzer;
@@ -291,12 +290,6 @@ public class TableProperty implements Writable, GsonPostProcessable {
 
     public TableProperty(Map<String, String> properties) {
         this.properties = properties;
-        if (FeConstants.runningUnitTest) {
-            // FIXME: remove this later.
-            // Since Config.default_mv_refresh_partition_num is set to 1 by default, if not set to -1 in FE UTs,
-            // task run will only refresh 1 partition and will produce wrong result.
-            partitionRefreshNumber = INVALID;
-        }
     }
 
     public TableProperty copy() {

--- a/fe/fe-core/src/main/java/com/starrocks/connector/PartitionUtil.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/PartitionUtil.java
@@ -809,7 +809,7 @@ public class PartitionUtil {
         thread.start();
     }
 
-    public static RangePartitionDiff getPartitionDiff(Expr partitionExpr, Column partitionColumn,
+    public static RangePartitionDiff getPartitionDiff(Expr partitionExpr,
                                                       Map<String, Range<PartitionKey>> basePartitionMap,
                                                       Map<String, Range<PartitionKey>> mvPartitionMap,
                                                       PartitionDiffer differ) {

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/PartitionBasedMvRefreshProcessor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/PartitionBasedMvRefreshProcessor.java
@@ -85,7 +85,6 @@ import com.starrocks.sql.analyzer.Analyzer;
 import com.starrocks.sql.analyzer.AnalyzerUtils;
 import com.starrocks.sql.analyzer.PlannerMetaLocker;
 import com.starrocks.sql.analyzer.Scope;
-import com.starrocks.sql.analyzer.SemanticException;
 import com.starrocks.sql.ast.AddPartitionClause;
 import com.starrocks.sql.ast.DistributionDesc;
 import com.starrocks.sql.ast.DropPartitionClause;
@@ -106,9 +105,9 @@ import com.starrocks.sql.ast.StatementBase;
 import com.starrocks.sql.ast.TableRelation;
 import com.starrocks.sql.common.DmlException;
 import com.starrocks.sql.common.ListPartitionDiff;
+import com.starrocks.sql.common.MvPartitionDiffResult;
 import com.starrocks.sql.common.PartitionDiffer;
 import com.starrocks.sql.common.QueryDebugOptions;
-import com.starrocks.sql.common.RangePartitionDiff;
 import com.starrocks.sql.common.SyncPartitionUtils;
 import com.starrocks.sql.optimizer.rule.transformation.materialization.MvUtils;
 import com.starrocks.sql.parser.SqlParser;
@@ -272,7 +271,7 @@ public class PartitionBasedMvRefreshProcessor extends BaseTaskRunProcessor {
 
                 // Only refresh the first partition refresh number partitions, other partitions will generate new tasks
                 filterPartitionByRefreshNumber(mvToRefreshedPartitions, mvPotentialPartitionNames, materializedView);
-                LOG.debug("materialized view partitions to refresh:{}", mvToRefreshedPartitions);
+                LOG.info("materialized view partitions to refresh:{}", mvToRefreshedPartitions);
 
                 // Get to refreshed base table partition infos.
                 refTableRefreshPartitions = getRefTableRefreshPartitions(mvToRefreshedPartitions);
@@ -948,7 +947,7 @@ public class PartitionBasedMvRefreshProcessor extends BaseTaskRunProcessor {
         Pair<String, String> partitionRange = Pair.create(
                 context == null ? null : context.getProperties().get(TaskRun.PARTITION_START),
                 context == null ? null : context.getProperties().get(TaskRun.PARTITION_END));
-        DiffResult result = computePartitionRangeDiff(db, materializedView, partitionRange);
+        MvPartitionDiffResult result = PartitionDiffer.computePartitionRangeDiff(db, materializedView, partitionRange);
         if (result == null) {
             return;
         }
@@ -984,71 +983,6 @@ public class PartitionBasedMvRefreshProcessor extends BaseTaskRunProcessor {
         mvContext.setMvRefBaseTableIntersectedPartitions(mvToBaseNameRef);
         mvContext.setRefBaseTableRangePartitionMap(result.refBaseTablePartitionMap);
         mvContext.setExternalRefBaseTableMVPartitionMap(result.refBaseTableMVPartitionMap);
-    }
-
-    public static DiffResult computePartitionRangeDiff(Database db,
-                                                       MaterializedView materializedView,
-                                                       Pair<String, String> partitionRange) {
-        Expr partitionExpr = materializedView.getFirstPartitionRefTableExpr();
-        Map<Table, Column> partitionTableAndColumn = materializedView.getRelatedPartitionTableAndColumn();
-        Preconditions.checkArgument(!partitionTableAndColumn.isEmpty());
-        List<RangePartitionDiff> rangePartitionDiffList = Lists.newArrayList();
-
-        Locker locker = new Locker();
-        locker.lockDatabase(db, LockType.READ);
-        Map<String, Range<PartitionKey>> mvRangePartitionMap = materializedView.getRangePartitionMap();
-        Map<Table, Map<String, Range<PartitionKey>>> refBaseTablePartitionMap = Maps.newHashMap();
-        Map<Table, Map<String, Set<String>>> refBaseTableMVPartitionMap = Maps.newHashMap();
-        try {
-            for (Map.Entry<Table, Column> entry : partitionTableAndColumn.entrySet()) {
-                Table refBaseTable = entry.getKey();
-                Column refBaseTablePartitionColumn = entry.getValue();
-                // Collect the ref base table's partition range map.
-                refBaseTablePartitionMap.put(refBaseTable, PartitionUtil.getPartitionKeyRange(
-                        refBaseTable, refBaseTablePartitionColumn, partitionExpr));
-
-                // To solve multi partition columns' problem of external table, record the mv partition name to all the same
-                // partition names map here.
-                if (!refBaseTable.isNativeTableOrMaterializedView()) {
-                    refBaseTableMVPartitionMap.put(refBaseTable,
-                            PartitionUtil.getMVPartitionNameMapOfExternalTable(refBaseTable,
-                                    refBaseTablePartitionColumn, PartitionUtil.getPartitionNames(refBaseTable)));
-                }
-
-                Column partitionColumn = (materializedView.getPartitionInfo()).getPartitionColumns().get(0);
-                PartitionDiffer differ = PartitionDiffer.build(materializedView, partitionRange);
-                rangePartitionDiffList.add(PartitionUtil.getPartitionDiff(partitionExpr, partitionColumn,
-                        refBaseTablePartitionMap.get(refBaseTable), mvRangePartitionMap, differ));
-            }
-
-        } catch (UserException | SemanticException e) {
-            LOG.warn("Materialized view compute partition difference with base table failed.", e);
-            return null;
-        } finally {
-            locker.unLockDatabase(db, LockType.READ);
-        }
-
-        // UnionALL MV may generate multiple PartitionDiff, needs to be merged into one PartitionDiff
-        RangePartitionDiff rangePartitionDiff = RangePartitionDiff.merge(rangePartitionDiffList);
-        return new DiffResult(mvRangePartitionMap, refBaseTablePartitionMap, refBaseTableMVPartitionMap,
-                rangePartitionDiff);
-    }
-
-    private static class DiffResult {
-        public final Map<String, Range<PartitionKey>> mvRangePartitionMap;
-        public final Map<Table, Map<String, Range<PartitionKey>>> refBaseTablePartitionMap;
-        public final Map<Table, Map<String, Set<String>>> refBaseTableMVPartitionMap;
-        public final RangePartitionDiff rangePartitionDiff;
-
-        public DiffResult(Map<String, Range<PartitionKey>> mvRangePartitionMap,
-                          Map<Table, Map<String, Range<PartitionKey>>> refBaseTablePartitionMap,
-                          Map<Table, Map<String, Set<String>>> refBaseTableMVPartitionMap,
-                          RangePartitionDiff rangePartitionDiff) {
-            this.mvRangePartitionMap = mvRangePartitionMap;
-            this.refBaseTablePartitionMap = refBaseTablePartitionMap;
-            this.refBaseTableMVPartitionMap = refBaseTableMVPartitionMap;
-            this.rangePartitionDiff = rangePartitionDiff;
-        }
     }
 
     private void syncPartitionsForList() {
@@ -1253,7 +1187,7 @@ public class PartitionBasedMvRefreshProcessor extends BaseTaskRunProcessor {
                     } else {
                         // If the user specifies the start and end ranges, and the non-partitioned table still changes,
                         // it should be refreshed according to the user-specified range, not all partitions.
-                        return getMVPartitionNamesToRefreshByRangePartitionNamesAndForce(refBaseTable,
+                        return getMvPartitionNamesToRefresh(refBaseTable,
                                 mvRangePartitionNames, true);
                     }
                 }
@@ -1263,13 +1197,13 @@ public class PartitionBasedMvRefreshProcessor extends BaseTaskRunProcessor {
             if (partitionExpr instanceof SlotRef) {
                 // check related partition table
                 for (Table table : partitionTablesAndColumn.keySet()) {
-                    needRefreshMvPartitionNames.addAll(getMVPartitionNamesToRefreshByRangePartitionNamesAndForce(
+                    needRefreshMvPartitionNames.addAll(getMvPartitionNamesToRefresh(
                             table, mvRangePartitionNames, force));
                 }
             } else if (partitionExpr instanceof FunctionCallExpr) {
                 // check related partition table
                 for (Table table : partitionTablesAndColumn.keySet()) {
-                    needRefreshMvPartitionNames.addAll(getMVPartitionNamesToRefreshByRangePartitionNamesAndForce(
+                    needRefreshMvPartitionNames.addAll(getMvPartitionNamesToRefresh(
                             table, mvRangePartitionNames, force));
                 }
 
@@ -1315,13 +1249,13 @@ public class PartitionBasedMvRefreshProcessor extends BaseTaskRunProcessor {
                 } else {
                     // If the user specifies the start and end ranges, and the non-partitioned table still changes,
                     // it should be refreshed according to the user-specified range, not all partitions.
-                    return getMVPartitionNamesToRefreshByRangePartitionNamesAndForce(partitionTable,
+                    return getMvPartitionNamesToRefresh(partitionTable,
                             mvListPartitionNames, true);
                 }
             }
 
             // check the ref base table
-            return getMVPartitionNamesToRefreshByRangePartitionNamesAndForce(partitionTable, mvListPartitionNames,
+            return getMvPartitionNamesToRefresh(partitionTable, mvListPartitionNames,
                     force);
         } else {
             throw new DmlException("unsupported partition info type:" + mvPartitionInfo.getClass().getName());
@@ -1329,9 +1263,10 @@ public class PartitionBasedMvRefreshProcessor extends BaseTaskRunProcessor {
         return needRefreshMvPartitionNames;
     }
 
-    private Set<String> getMVPartitionNamesToRefreshByRangePartitionNamesAndForce(Table refBaseTable,
-                                                                                  Set<String> mvRangePartitionNames,
-                                                                                  boolean force) {
+    private Set<String> getMvPartitionNamesToRefresh(Table refBaseTable,
+                                                     Set<String> mvRangePartitionNames,
+                                                     boolean force) {
+        // refresh all mv partitions when the ref base table is not supported partition refresh
         if (force || !supportPartitionRefresh(refBaseTable)) {
             return Sets.newHashSet(mvRangePartitionNames);
         }

--- a/fe/fe-core/src/main/java/com/starrocks/server/LocalMetastore.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/LocalMetastore.java
@@ -186,7 +186,6 @@ import com.starrocks.qe.SessionVariable;
 import com.starrocks.qe.VariableMgr;
 import com.starrocks.scheduler.Constants;
 import com.starrocks.scheduler.ExecuteOption;
-import com.starrocks.scheduler.PartitionBasedMvRefreshProcessor;
 import com.starrocks.scheduler.Task;
 import com.starrocks.scheduler.TaskBuilder;
 import com.starrocks.scheduler.TaskManager;
@@ -245,6 +244,7 @@ import com.starrocks.sql.ast.SystemVariable;
 import com.starrocks.sql.ast.TableRenameClause;
 import com.starrocks.sql.ast.TruncateTableStmt;
 import com.starrocks.sql.common.MetaUtils;
+import com.starrocks.sql.common.PartitionDiffer;
 import com.starrocks.sql.common.SyncPartitionUtils;
 import com.starrocks.sql.optimizer.Utils;
 import com.starrocks.sql.optimizer.statistics.IDictManager;
@@ -3339,8 +3339,7 @@ public class LocalMetastore implements ConnectorMetadata {
                 }
                 materializedView.setPartitionExprMaps(partitionExprMaps);
                 // check partition schema from children
-                PartitionBasedMvRefreshProcessor.computePartitionRangeDiff(db, materializedView,
-                        Pair.create(null, null));
+                PartitionDiffer.computePartitionRangeDiff(db, materializedView, Pair.create(null, null));
             }
 
             MaterializedViewMgr.getInstance().prepareMaintenanceWork(stmt, materializedView);

--- a/fe/fe-core/src/main/java/com/starrocks/sql/common/MvPartitionDiffResult.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/common/MvPartitionDiffResult.java
@@ -1,0 +1,47 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.sql.common;
+
+import com.google.common.collect.Range;
+import com.starrocks.catalog.PartitionKey;
+import com.starrocks.catalog.Table;
+
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * The result of diffing between materialized view and the base tables.
+ */
+public class MvPartitionDiffResult {
+    // The partition range of the materialized view: <mv partition name, mv partition range>
+    public final Map<String, Range<PartitionKey>> mvRangePartitionMap;
+    // The partition range of the base tables: <base table, <base table partition name, base table partition range>>
+    public final Map<Table, Map<String, Range<PartitionKey>>> refBaseTablePartitionMap;
+    // For external table, the mapping of base table partition to mv partition:
+    // <base table, <base table partition name, mv partition name>>
+    public final Map<Table, Map<String, Set<String>>> refBaseTableMVPartitionMap;
+    // The diff result of partition range between materialized view and base tables
+    public final RangePartitionDiff rangePartitionDiff;
+
+    public MvPartitionDiffResult(Map<String, Range<PartitionKey>> mvRangePartitionMap,
+                                 Map<Table, Map<String, Range<PartitionKey>>> refBaseTablePartitionMap,
+                                 Map<Table, Map<String, Set<String>>> refBaseTableMVPartitionMap,
+                                 RangePartitionDiff rangePartitionDiff) {
+        this.mvRangePartitionMap = mvRangePartitionMap;
+        this.refBaseTablePartitionMap = refBaseTablePartitionMap;
+        this.refBaseTableMVPartitionMap = refBaseTableMVPartitionMap;
+        this.rangePartitionDiff = rangePartitionDiff;
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/sql/common/PartitionDiffer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/common/PartitionDiffer.java
@@ -80,20 +80,21 @@ public class PartitionDiffer {
     public PartitionDiffer() {
     }
 
-    public static PartitionDiffer build(MaterializedView materializedView, Pair<String, String> partitionRange)
+    public static PartitionDiffer build(MaterializedView mv,
+                                        Pair<String, String> partitionRange)
             throws AnalysisException {
+        PartitionInfo partitionInfo = mv.getPartitionInfo();
+        int partitionTTLNumber = mv.getTableProperty().getPartitionTTLNumber();
+        PeriodDuration partitionTTL = mv.getTableProperty().getPartitionTTL();
         Range<PartitionKey> rangeToInclude = null;
         Column partitionColumn =
-                ((RangePartitionInfo) materializedView.getPartitionInfo()).getPartitionColumns().get(0);
+                ((RangePartitionInfo) partitionInfo).getPartitionColumns().get(0);
         String start = partitionRange.first;
         String end = partitionRange.second;
         if (start != null || end != null) {
             rangeToInclude = SyncPartitionUtils.createRange(start, end, partitionColumn);
         }
-        int partitionTTLNumber = materializedView.getTableProperty().getPartitionTTLNumber();
-        PeriodDuration partitionTTL = materializedView.getTableProperty().getPartitionTTL();
-        return new PartitionDiffer(rangeToInclude, partitionTTLNumber, partitionTTL,
-                materializedView.getPartitionInfo());
+        return new PartitionDiffer(rangeToInclude, partitionTTLNumber, partitionTTL, partitionInfo);
     }
 
     /**
@@ -260,9 +261,6 @@ public class PartitionDiffer {
         Map<Table, Map<String, Set<String>>> refBaseTableMVPartitionMap = Maps.newHashMap();
 
         Map<String, Range<PartitionKey>> allRefTablePartitionKeyMap = Maps.newHashMap();
-        RangePartitionDiff rangePartitionDiff = null;
-        // this only used to check unaligned partitions
-        List<RangePartitionDiff> rangePartitionDiffList = Lists.newArrayList();
         try {
             for (Map.Entry<Table, Column> entry : partitionTableAndColumn.entrySet()) {
                 Table refBaseTable = entry.getKey();
@@ -280,30 +278,46 @@ public class PartitionDiffer {
                                     refBaseTablePartitionColumn, PartitionUtil.getPartitionNames(refBaseTable)));
                 }
                 allRefTablePartitionKeyMap.putAll(refTablePartitionKeyMap);
+            }
+        } catch (UserException | SemanticException e) {
+            LOG.warn("Partition differ collects ref base table partition failed.", e);
+            return null;
+        } finally {
+            locker.unLockDatabase(db, LockType.READ);
+        }
 
+        try {
+            // Check unaligned partitions, unaligned partitions may cause uncorrected result which is not supported for now.
+            List<RangePartitionDiff> rangePartitionDiffList = Lists.newArrayList();
+            for (Map.Entry<Table, Column> entry : partitionTableAndColumn.entrySet()) {
+                Table refBaseTable = entry.getKey();
                 PartitionDiffer differ = PartitionDiffer.build(materializedView, partitionRange);
                 rangePartitionDiffList.add(PartitionUtil.getPartitionDiff(partitionExpr,
                         refBaseTablePartitionMap.get(refBaseTable), mvRangePartitionMap, differ));
             }
             // UnionALL MV may generate multiple PartitionDiff, needs to be merged into one PartitionDiff
+            RangePartitionDiff.checkRangePartitionAligned(rangePartitionDiffList);
+
+            // NOTE: Use all refBaseTables' partition range to compute the partition difference between MV and refBaseTables.
+            // Merge all deletes of each refBaseTab's diff may cause dropping needed partitions, the deletes should use
+            // `bigcap` rather than `bigcup`.
+            // Diff_{adds} = P_{\bigcup_{baseTables}^{}} \setminus  P_{MV} \\
+            //             = \bigcup_{baseTables} P_{baseTable}\setminus P_{MV}
+            //
+            // Diff_{deletes} = P_{MV} \setminus P_{\bigcup_{baseTables}^{}} \\
+            //                = \bigcap_{baseTables} P_{MV}\setminus P_{baseTable}
             PartitionDiffer differ = PartitionDiffer.build(materializedView, partitionRange);
-            rangePartitionDiff = PartitionUtil.getPartitionDiff(partitionExpr, allRefTablePartitionKeyMap,
+            RangePartitionDiff rangePartitionDiff = PartitionUtil.getPartitionDiff(partitionExpr, allRefTablePartitionKeyMap,
                     mvRangePartitionMap, differ);
-        } catch (UserException | SemanticException e) {
+            if (rangePartitionDiff == null) {
+                LOG.warn("Materialized view compute partition difference with base table failed: rangePartitionDiff is null.");
+                return null;
+            }
+            return new MvPartitionDiffResult(mvRangePartitionMap, refBaseTablePartitionMap, refBaseTableMVPartitionMap,
+                    rangePartitionDiff);
+        } catch (AnalysisException e) {
             LOG.warn("Materialized view compute partition difference with base table failed.", e);
             return null;
-        } finally {
-            locker.unLockDatabase(db, LockType.READ);
         }
-        if (rangePartitionDiff == null) {
-            LOG.warn("Materialized view compute partition difference with base table failed: rangePartitionDiff is null.");
-            return null;
-        }
-
-        // TODO(fixme): UnionALL MV may generate multiple PartitionDiff, needs to be merged into one PartitionDiff
-        RangePartitionDiff.merge(rangePartitionDiffList);
-
-        return new MvPartitionDiffResult(mvRangePartitionMap, refBaseTablePartitionMap, refBaseTableMVPartitionMap,
-                rangePartitionDiff);
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/common/RangePartitionDiff.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/common/RangePartitionDiff.java
@@ -69,11 +69,10 @@ public class RangePartitionDiff {
      * Merged => [p0, p1, p2, p3]
      * NOTE: for intersected partitions, they must be identical
      */
-    public static RangePartitionDiff merge(List<RangePartitionDiff> diffList) {
+    public static void checkRangePartitionAligned(List<RangePartitionDiff> diffList) {
         if (diffList.size() == 1) {
-            return diffList.get(0);
+            return;
         }
-        RangePartitionDiff result = new RangePartitionDiff();
         RangeMap<PartitionKey, String> addRanges = TreeRangeMap.create();
         for (RangePartitionDiff diff : diffList) {
             for (Map.Entry<String, Range<PartitionKey>> add : diff.getAdds().entrySet()) {
@@ -91,13 +90,6 @@ public class RangePartitionDiff {
                 }
             }
             diff.getAdds().forEach((key, value) -> addRanges.put(value, key));
-            result.getAdds().putAll(diff.getAdds());
-
-            //
-            result.getDeletes().putAll(diff.getDeletes());
-            result.getRollupToBasePartitionMap().putAll(diff.getRollupToBasePartitionMap());
         }
-        result.getDeletes().keySet().removeAll(result.getAdds().keySet());
-        return result;
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/common/RangePartitionDiff.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/common/RangePartitionDiff.java
@@ -92,6 +92,8 @@ public class RangePartitionDiff {
             }
             diff.getAdds().forEach((key, value) -> addRanges.put(value, key));
             result.getAdds().putAll(diff.getAdds());
+
+            //
             result.getDeletes().putAll(diff.getDeletes());
             result.getRollupToBasePartitionMap().putAll(diff.getRollupToBasePartitionMap());
         }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/common/SyncPartitionUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/common/SyncPartitionUtils.java
@@ -404,12 +404,20 @@ public class SyncPartitionUtils {
         basePartitions.add(partitionValue);
     }
 
+    /**
+     * Update the base table partition name to its intersected materialized view names into result.
+     * @param result : the final result: BaseTable -> <BaseTablePartitionName -> Set<MVPartitionName>>
+     * @param baseTable:: to update the base table
+     * @param baseTablePartitionName: base table partition name
+     * @param mvPartitionName: materialized view partition name
+     */
     public static void updateTableRefMap(Map<Table, Map<String, Set<String>>> result,
-                                         Table table,
-                                         String partitionKey, String partitionValue) {
-        Map<String, Set<String>> partitionMap = result.computeIfAbsent(table, k -> new HashMap<>());
-        Set<String> basePartitions = partitionMap.computeIfAbsent(partitionKey, k -> new HashSet<>());
-        basePartitions.add(partitionValue);
+                                         Table baseTable,
+                                         String baseTablePartitionName,
+                                         String mvPartitionName) {
+        Map<String, Set<String>> partitionMap = result.computeIfAbsent(baseTable, k -> new HashMap<>());
+        Set<String> basePartitions = partitionMap.computeIfAbsent(baseTablePartitionName, k -> new HashSet<>());
+        basePartitions.add(mvPartitionName);
     }
 
     public static void initialMvRefMap(Map<String, Map<Table, Set<String>>> result,
@@ -434,12 +442,10 @@ public class SyncPartitionUtils {
             Map<String, Range<PartitionKey>> mvRangeMap) {
         Map<Table, Map<String, Set<String>>> result = Maps.newHashMap();
         // for each partition of base, find the corresponding partition of mv
-        List<PartitionRange> mvRanges = mvRangeMap.keySet()
-                .stream()
+        List<PartitionRange> mvRanges = mvRangeMap.keySet().stream()
                 .map(name -> new PartitionRange(name, mvRangeMap.get(name)))
                 .sorted(PartitionRange::compareTo)
                 .collect(Collectors.toList());
-
         for (Map.Entry<Table, Map<String, Range<PartitionKey>>> entry : baseRangeMap.entrySet()) {
             Table baseTable = entry.getKey();
             Map<String, Range<PartitionKey>> refreshedPartitionsMap = entry.getValue();
@@ -462,15 +468,13 @@ public class SyncPartitionUtils {
 
                 int lower = mid - 1;
                 while (lower >= 0 && mvRanges.get(lower).isIntersected(baseRange)) {
-                    updateTableRefMap(
-                            result, baseTable, baseRange.getPartitionName(), mvRanges.get(lower).getPartitionName());
+                    updateTableRefMap(result, baseTable, baseRange.getPartitionName(), mvRanges.get(lower).getPartitionName());
                     lower--;
                 }
 
                 int higher = mid + 1;
                 while (higher < mvRanges.size() && mvRanges.get(higher).isIntersected(baseRange)) {
-                    updateTableRefMap(
-                            result, baseTable, baseRange.getPartitionName(), mvRanges.get(higher).getPartitionName());
+                    updateTableRefMap(result, baseTable, baseRange.getPartitionName(), mvRanges.get(higher).getPartitionName());
                     higher++;
                 }
             }
@@ -478,6 +482,12 @@ public class SyncPartitionUtils {
         return result;
     }
 
+    /**
+     * Generate the mapping from materialized view partition to base table partition.
+     * @param mvRangeMap : materialized view partition range map: <partitionName, partitionRange>
+     * @param basePartitionExprMap: base table partition expression map, <baseTable, partitionExpr>
+     * @param baseRangeMap: base table partition range map, <baseTable, <partitionName, partitionRange>>
+     */
     public static Map<String, Map<Table, Set<String>>> generateMvRefMap(
             Map<String, Range<PartitionKey>> mvRangeMap,
             Map<Table, Expr> basePartitionExprMap,

--- a/fe/fe-core/src/test/java/com/starrocks/scheduler/MVRefreshTestBase.java
+++ b/fe/fe-core/src/test/java/com/starrocks/scheduler/MVRefreshTestBase.java
@@ -73,7 +73,7 @@ public class MVRefreshTestBase {
     public static void tearDown() throws Exception {
     }
 
-    public void executeInsertSql(ConnectContext connectContext, String sql) throws Exception {
+    public static void executeInsertSql(ConnectContext connectContext, String sql) throws Exception {
         connectContext.setQueryId(UUIDUtil.genUUID());
         StatementBase statement = SqlParser.parseSingleStatement(sql, connectContext.getSessionVariable().getSqlMode());
         new StmtExecutor(connectContext, statement).execute();

--- a/fe/fe-core/src/test/java/com/starrocks/scheduler/PartitionBasedMvRefreshTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/scheduler/PartitionBasedMvRefreshTest.java
@@ -1,0 +1,317 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.scheduler;
+
+import com.google.common.collect.ImmutableList;
+import com.starrocks.catalog.Database;
+import com.starrocks.catalog.MaterializedView;
+import com.starrocks.common.util.UUIDUtil;
+import com.starrocks.server.GlobalStateMgr;
+import com.starrocks.sql.plan.ExecPlan;
+import com.starrocks.sql.plan.PlanTestBase;
+import com.starrocks.thrift.TExplainLevel;
+import org.apache.commons.lang3.StringUtils;
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.FixMethodOrder;
+import org.junit.Test;
+import org.junit.runners.MethodSorters;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+
+import static com.starrocks.sql.plan.PlanTestBase.cleanupEphemeralMVs;
+
+@FixMethodOrder(MethodSorters.NAME_ASCENDING)
+public class PartitionBasedMvRefreshTest extends MVRefreshTestBase {
+
+    @BeforeClass
+    public static void beforeClass() throws Exception {
+        MVRefreshTestBase.beforeClass();
+        starRocksAssert
+                .withTable("CREATE TABLE `t1` (\n" +
+                        "    `k1`  date not null, \n" +
+                        "    `k2`  datetime not null, \n" +
+                        "    `k3`  char(20), \n" +
+                        "    `k4`  varchar(20), \n" +
+                        "    `k5`  boolean, \n" +
+                        "    `k6`  tinyint, \n" +
+                        "    `k7`  smallint, \n" +
+                        "    `k8`  int, \n" +
+                        "    `k9`  bigint, \n" +
+                        "    `k10` largeint, \n" +
+                        "    `k11` float, \n" +
+                        "    `k12` double, \n" +
+                        "    `k13` decimal(27,9) ) \n" +
+                        "DUPLICATE KEY(`k1`, `k2`, `k3`, `k4`, `k5`) \n" +
+                        "PARTITION BY RANGE(`k1`) \n" +
+                        "(\n" +
+                        "PARTITION p20201022 VALUES [(\"2020-10-22\"), (\"2020-10-23\")), \n" +
+                        "PARTITION p20201023 VALUES [(\"2020-10-23\"), (\"2020-10-24\")), \n" +
+                        "PARTITION p20201024 VALUES [(\"2020-10-24\"), (\"2020-10-25\"))\n" +
+                        ")\n" +
+                        "DISTRIBUTED BY HASH(`k1`, `k2`, `k3`) BUCKETS 3;")
+                .withTable("CREATE TABLE `t2` (\n" +
+                        "    `k1`  date not null, \n" +
+                        "    `k2`  datetime not null, \n" +
+                        "    `k3`  char(20), \n" +
+                        "    `k4`  varchar(20), \n" +
+                        "    `k5`  boolean, \n" +
+                        "    `k6`  tinyint, \n" +
+                        "    `k7`  smallint, \n" +
+                        "    `k8`  int, \n" +
+                        "    `k9`  bigint, \n" +
+                        "    `k10` largeint, \n" +
+                        "    `k11` float, \n" +
+                        "    `k12` double, \n" +
+                        "    `k13` decimal(27,9) ) \n" +
+                        "DUPLICATE KEY(`k1`, `k2`, `k3`, `k4`, `k5`) \n" +
+                        "PARTITION BY RANGE(`k1`) \n" +
+                        "(\n" +
+                        "PARTITION p20201010 VALUES [(\"2020-10-10\"), (\"2020-10-11\")), \n" +
+                        "PARTITION p20201011 VALUES [(\"2020-10-11\"), (\"2020-10-12\")), \n" +
+                        "PARTITION p20201012 VALUES [(\"2020-10-12\"), (\"2020-10-13\")), \n" +
+                        "PARTITION p20201021 VALUES [(\"2020-10-21\"), (\"2020-10-22\")), \n" +
+                        "PARTITION p20201022 VALUES [(\"2020-10-22\"), (\"2020-10-23\"))\n" +
+                        ")\n" +
+                        "DISTRIBUTED BY HASH(`k1`, `k2`, `k3`) BUCKETS 3;");
+        executeInsertSql(connectContext, "INSERT INTO t1 VALUES\n" +
+                "    ('2020-10-22','2020-10-23 12:12:12','k3','k4',0,1,2,3,4,5,1.1,1.12,2.889),\n" +
+                "    ('2020-10-23','2020-10-24 12:12:12','k3','k4',0,0,2,3,4,5,1.1,1.12,2.889),\n" +
+                "    ('2020-10-24','2020-10-25 12:12:12','k3','k4',0,1,2,3,4,5,1.1,1.12,2.889);");
+        executeInsertSql(connectContext, "INSERT INTO t2 VALUES\n" +
+                "    ('2020-10-10','2020-10-23 12:12:12','k3','k4',0,1,2,3,4,5,1.1,1.12,2.889),\n" +
+                "    ('2020-10-11','2020-10-24 12:12:12','k3','k4',0,0,2,3,4,5,1.1,1.12,2.889),\n" +
+                "    ('2020-10-12','2020-10-25 12:12:12','k3','k4',0,1,2,3,4,5,1.1,1.12,2.889),\n" +
+                "    ('2020-10-21','2020-10-24 12:12:12','k3','k4',0,0,2,3,4,5,1.1,1.12,2.889),\n" +
+                "    ('2020-10-22','2020-10-25 12:12:12','k3','k4',0,1,2,3,4,5,1.1,1.12,2.889)");
+    }
+
+    @AfterClass
+    public static void afterClass() throws Exception {
+        cleanupEphemeralMVs(starRocksAssert, startSuiteTime);
+    }
+
+    @Before
+    public void before() {
+        startCaseTime = Instant.now().getEpochSecond();
+    }
+
+    @After
+    public void after() throws Exception {
+        cleanupEphemeralMVs(starRocksAssert, startCaseTime);
+    }
+
+    protected void assertPlanContains(ExecPlan execPlan, String... explain) throws Exception {
+        String explainString = execPlan.getExplainString(TExplainLevel.NORMAL);
+
+        for (String expected : explain) {
+            Assert.assertTrue("expected is: " + expected + " but plan is \n" + explainString,
+                    StringUtils.containsIgnoreCase(explainString.toLowerCase(), expected));
+        }
+    }
+
+    private static void initAndExecuteTaskRun(TaskRun taskRun,
+                                              String startPartition,
+                                              String endPartition) throws Exception {
+        Task task = taskRun.getTask();
+        Map<String, String> testProperties = task.getProperties();
+        testProperties.put(TaskRun.IS_TEST, "true");
+        if (startPartition != null) {
+            task.getProperties().put(TaskRun.PARTITION_START, startPartition);
+        }
+        if (endPartition != null) {
+            task.getProperties().put(TaskRun.PARTITION_END, endPartition);
+        }
+        taskRun.initStatus(UUIDUtil.genUUID().toString(), System.currentTimeMillis());
+        taskRun.executeTaskRun();
+    }
+
+    private static void initAndExecuteTaskRun(TaskRun taskRun) throws Exception {
+        initAndExecuteTaskRun(taskRun, null, null);
+    }
+
+    private void testRefreshUnionAllWithDefaultRefreshNumber(String mvSql,
+                                                             List<Integer> t1PartitionNums,
+                                                             List<Integer> t2PartitionNums) {
+        Assert.assertTrue(t1PartitionNums.size() == t2PartitionNums.size());
+        int mvRefreshTimes = t1PartitionNums.size();
+        starRocksAssert.withMaterializedView(mvSql,
+                () -> {
+                    Database testDb = GlobalStateMgr.getCurrentState().getDb("test");
+                    MaterializedView mv = ((MaterializedView) testDb.getTable("test_mv0"));
+                    Task task = TaskBuilder.buildMvTask(mv, testDb.getFullName());
+
+                    TaskRun taskRun = null;
+                    for (int i = 0; i < mvRefreshTimes; i++) {
+                        if (i == 0) {
+                            taskRun = TaskRunBuilder.newBuilder(task).build();
+                        }
+                        System.out.println("start to execute task run:" + i);
+                        Assert.assertTrue(taskRun != null);
+                        initAndExecuteTaskRun(taskRun);
+                        PartitionBasedMvRefreshProcessor processor = (PartitionBasedMvRefreshProcessor)
+                                taskRun.getProcessor();
+                        MvTaskRunContext mvContext = processor.getMvContext();
+                        ExecPlan execPlan = mvContext.getExecPlan();
+                        String plan = execPlan.getExplainString(TExplainLevel.NORMAL);
+                        Assert.assertTrue(plan != null);
+                        taskRun = processor.getNextTaskRun();
+                        System.out.println(plan);
+                        PlanTestBase.assertContains(plan, String.format("     TABLE: t1\n" +
+                                "     PREAGGREGATION: ON\n" +
+                                "     partitions=%s/3", t1PartitionNums.get(i)));
+                        PlanTestBase.assertContains(plan, String.format("     TABLE: t2\n" +
+                                "     PREAGGREGATION: ON\n" +
+                                "     partitions=%s/5", t2PartitionNums.get(i)));
+                        if (i == mvRefreshTimes - 1) {
+                            Assert.assertTrue(taskRun == null);
+                        }
+                    }
+                });
+    }
+    @Test
+    public void testUnionAllMvWithPartition1() {
+        String sql = "create materialized view test_mv0 \n" +
+                "partition by k1 \n" +
+                "distributed by random \n" +
+                "refresh async \n" +
+                "properties(" +
+                "\"partition_refresh_number\" = \"1\"" +
+                ")" +
+                "as " +
+                " select * from t1 union all select * from t2;";
+        List<Integer> t1PartitionNums = ImmutableList.of(0, 0, 0, 0, 1, 1, 1);
+        List<Integer> t2PartitionNums = ImmutableList.of(1, 1, 1, 1, 1, 0, 0);
+        testRefreshUnionAllWithDefaultRefreshNumber(sql, t1PartitionNums, t2PartitionNums);
+    }
+
+    @Test
+    public void testUnionAllMvWithPartition2() {
+        String sql = "create materialized view test_mv0 \n" +
+                "partition by k1 \n" +
+                "distributed by random \n" +
+                "refresh async \n" +
+                "properties(" +
+                "\"partition_refresh_number\" = \"1\"" +
+                ")" +
+                "as " +
+                " select * from t2 union all select * from t1;";
+        List<Integer> t1PartitionNums = ImmutableList.of(0, 0, 0, 0, 1, 1, 1);
+        List<Integer> t2PartitionNums = ImmutableList.of(1, 1, 1, 1, 1, 0, 0);
+        testRefreshUnionAllWithDefaultRefreshNumber(sql, t1PartitionNums, t2PartitionNums);
+    }
+
+    @Test
+    public void testUnionAllMvWithPartitionForceMode() {
+        String sql = "create materialized view test_mv0 \n" +
+                "partition by k1 \n" +
+                "distributed by random \n" +
+                "refresh async \n" +
+                "as " +
+                " select * from t1 union all select * from t2;";
+        starRocksAssert.withMaterializedView(sql,
+                () -> {
+                    Database testDb = GlobalStateMgr.getCurrentState().getDb("test");
+                    MaterializedView mv = ((MaterializedView) testDb.getTable("test_mv0"));
+                    Task task = TaskBuilder.buildMvTask(mv, testDb.getFullName());
+
+                    TaskRun taskRun = null;
+                    int refreshTimes = 1;
+                    for (int i = 0; i < refreshTimes; i++) {
+                        if (i == 0) {
+                            taskRun = TaskRunBuilder.newBuilder(task).build();
+                        }
+                        System.out.println("start to execute task run:" + i);
+                        Assert.assertTrue(taskRun != null);
+                        initAndExecuteTaskRun(taskRun);
+                        PartitionBasedMvRefreshProcessor processor = (PartitionBasedMvRefreshProcessor)
+                                taskRun.getProcessor();
+                        MvTaskRunContext mvContext = processor.getMvContext();
+                        ExecPlan execPlan = mvContext.getExecPlan();
+                        String plan = execPlan.getExplainString(TExplainLevel.NORMAL);
+                        taskRun = processor.getNextTaskRun();
+                        System.out.println(plan);
+
+                        PlanTestBase.assertContains(plan, "     TABLE: t1\n" +
+                                "     PREAGGREGATION: ON\n" +
+                                "     partitions=3/3");
+                        PlanTestBase.assertContains(plan, "     TABLE: t2\n" +
+                                "     PREAGGREGATION: ON\n" +
+                                "     partitions=5/5");
+                        if (i == refreshTimes - 1) {
+                            Assert.assertTrue(taskRun == null);
+                        }
+                    }
+                });
+    }
+
+    @Test
+    public void testUnionAllMvWithPartitionWithPartitionStartAndEnd() {
+        String sql = "create materialized view test_mv0 \n" +
+                "partition by k1 \n" +
+                "distributed by random \n" +
+                "refresh async \n" +
+                "properties(" +
+                "\"partition_refresh_number\" = \"1\"" +
+                ")" +
+                "as " +
+                " select * from t2 union all select * from t1;";
+        starRocksAssert.withMaterializedView(sql,
+                () -> {
+                    Database testDb = GlobalStateMgr.getCurrentState().getDb("test");
+                    MaterializedView mv = ((MaterializedView) testDb.getTable("test_mv0"));
+
+                    Task task = TaskBuilder.buildMvTask(mv, testDb.getFullName());
+                    int mvRefreshTimes = 3;
+                    List<Integer> t1PartitionNums = ImmutableList.of(0, 0, 1);
+                    List<Integer> t2PartitionNums = ImmutableList.of(1, 1, 1);
+                    TaskRun taskRun = null;
+                    for (int i = 0; i < mvRefreshTimes; i++) {
+                        System.out.println("start to execute task run:" + i);
+                        if (i == 0) {
+                            taskRun = TaskRunBuilder.newBuilder(task).build();
+                            initAndExecuteTaskRun(taskRun, "2020-10-12", "2020-10-23");
+                        } else {
+                            ExecuteOption executeOption = taskRun.getExecuteOption();
+                            String partitionStart = executeOption.getTaskRunProperties().get(TaskRun.PARTITION_START);
+                            String partitionEnd = executeOption.getTaskRunProperties().get(TaskRun.PARTITION_END);
+                            initAndExecuteTaskRun(taskRun, partitionStart, partitionEnd);
+                        }
+                        PartitionBasedMvRefreshProcessor processor = (PartitionBasedMvRefreshProcessor)
+                                taskRun.getProcessor();
+                        MvTaskRunContext mvContext = processor.getMvContext();
+                        ExecPlan execPlan = mvContext.getExecPlan();
+                        String plan = execPlan.getExplainString(TExplainLevel.NORMAL);
+                        Assert.assertTrue(plan != null);
+                        taskRun = processor.getNextTaskRun();
+                        System.out.println(plan);
+                        PlanTestBase.assertContains(plan, String.format("     TABLE: t1\n" +
+                                "     PREAGGREGATION: ON\n" +
+                                "     partitions=%s/3", t1PartitionNums.get(i)));
+                        PlanTestBase.assertContains(plan, String.format("     TABLE: t2\n" +
+                                "     PREAGGREGATION: ON\n" +
+                                "     partitions=%s/5", t2PartitionNums.get(i)));
+                        if (i == mvRefreshTimes - 1) {
+                            Assert.assertTrue(taskRun == null);
+                        }
+                    }
+                });
+    }
+}

--- a/fe/fe-core/src/test/java/com/starrocks/scheduler/PartitionBasedMvRefreshTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/scheduler/PartitionBasedMvRefreshTest.java
@@ -173,7 +173,6 @@ public class PartitionBasedMvRefreshTest extends MVRefreshTestBase {
                         String plan = execPlan.getExplainString(TExplainLevel.NORMAL);
                         Assert.assertTrue(plan != null);
                         taskRun = processor.getNextTaskRun();
-                        System.out.println(plan);
                         PlanTestBase.assertContains(plan, String.format("     TABLE: t1\n" +
                                 "     PREAGGREGATION: ON\n" +
                                 "     partitions=%s/3", t1PartitionNums.get(i)));
@@ -247,7 +246,6 @@ public class PartitionBasedMvRefreshTest extends MVRefreshTestBase {
                         ExecPlan execPlan = mvContext.getExecPlan();
                         String plan = execPlan.getExplainString(TExplainLevel.NORMAL);
                         taskRun = processor.getNextTaskRun();
-                        System.out.println(plan);
 
                         PlanTestBase.assertContains(plan, "     TABLE: t1\n" +
                                 "     PREAGGREGATION: ON\n" +
@@ -301,7 +299,6 @@ public class PartitionBasedMvRefreshTest extends MVRefreshTestBase {
                         String plan = execPlan.getExplainString(TExplainLevel.NORMAL);
                         Assert.assertTrue(plan != null);
                         taskRun = processor.getNextTaskRun();
-                        System.out.println(plan);
                         PlanTestBase.assertContains(plan, String.format("     TABLE: t1\n" +
                                 "     PREAGGREGATION: ON\n" +
                                 "     partitions=%s/3", t1PartitionNums.get(i)));

--- a/fe/fe-core/src/test/java/com/starrocks/utframe/UtFrameUtils.java
+++ b/fe/fe-core/src/test/java/com/starrocks/utframe/UtFrameUtils.java
@@ -1221,6 +1221,10 @@ public class UtFrameUtils {
         // build a small cache for test
         Config.mv_plan_cache_max_size = 10;
 
+        // Since Config.default_mv_refresh_partition_num is set to 1 by default, if not set to -1 in FE UTs,
+        // task run will only refresh 1 partition and will produce wrong result.
+        Config.default_mv_partition_refresh_number = -1;
+
         FeConstants.enablePruneEmptyOutputScan = false;
         FeConstants.runningUnitTest = true;
 

--- a/test/sql/test_materialized_view_refresh/R/test_mv_refresh_with_union
+++ b/test/sql/test_materialized_view_refresh/R/test_mv_refresh_with_union
@@ -156,6 +156,9 @@ select k1, count(1) from test_mv1 group by k1 order by k1;
 2020-10-21	1
 2020-10-22	2
 -- !result
+drop materialized view test_mv1;
+-- result:
+-- !result
 drop table t1;
 -- result:
 -- !result
@@ -306,6 +309,9 @@ select k1, count(1) from test_mv1 group by k1 order by k1;
 -- result:
 2020-10-21	1
 2020-10-22	2
+-- !result
+drop materialized view test_mv1;
+-- result:
 -- !result
 drop table t1;
 -- result:

--- a/test/sql/test_materialized_view_refresh/R/test_mv_refresh_with_union
+++ b/test/sql/test_materialized_view_refresh/R/test_mv_refresh_with_union
@@ -1,0 +1,315 @@
+-- name: test_mv_refresh_with_union
+CREATE TABLE `t1` (
+    `k1`  date not null, 
+    `k2`  datetime not null, 
+    `k3`  char(20), 
+    `k4`  varchar(20), 
+    `k5`  boolean, 
+    `k6`  tinyint, 
+    `k7`  smallint, 
+    `k8`  int, 
+    `k9`  bigint, 
+    `k10` largeint, 
+    `k11` float, 
+    `k12` double, 
+    `k13` decimal(27,9) ) 
+DUPLICATE KEY(`k1`, `k2`, `k3`, `k4`, `k5`) 
+PARTITION BY RANGE(`k1`) 
+(
+PARTITION p20201022 VALUES [("2020-10-22"), ("2020-10-23")), 
+PARTITION p20201023 VALUES [("2020-10-23"), ("2020-10-24")), 
+PARTITION p20201024 VALUES [("2020-10-24"), ("2020-10-25"))
+)
+DISTRIBUTED BY HASH(`k1`, `k2`, `k3`) BUCKETS 3 ;
+-- result:
+-- !result
+INSERT INTO t1 VALUES
+    ('2020-10-22','2020-10-23 12:12:12','k3','k4',0,1,2,3,4,5,1.1,1.12,2.889),
+    ('2020-10-23','2020-10-24 12:12:12','k3','k4',0,0,2,3,4,5,1.1,1.12,2.889),
+    ('2020-10-24','2020-10-25 12:12:12','k3','k4',0,1,2,3,4,5,1.1,1.12,2.889);
+-- result:
+-- !result
+    
+CREATE TABLE `t2` (
+    `k1`  date not null, 
+    `k2`  datetime not null, 
+    `k3`  char(20), 
+    `k4`  varchar(20), 
+    `k5`  boolean, 
+    `k6`  tinyint, 
+    `k7`  smallint, 
+    `k8`  int, 
+    `k9`  bigint, 
+    `k10` largeint, 
+    `k11` float, 
+    `k12` double, 
+    `k13` decimal(27,9) ) 
+DUPLICATE KEY(`k1`, `k2`, `k3`, `k4`, `k5`) 
+PARTITION BY RANGE(`k1`) 
+(
+PARTITION p20201010 VALUES [("2020-10-10"), ("2020-10-11")), 
+PARTITION p20201011 VALUES [("2020-10-11"), ("2020-10-12")), 
+PARTITION p20201012 VALUES [("2020-10-12"), ("2020-10-13")), 
+PARTITION p20201021 VALUES [("2020-10-21"), ("2020-10-22")), 
+PARTITION p20201022 VALUES [("2020-10-22"), ("2020-10-23"))
+)
+DISTRIBUTED BY HASH(`k1`, `k2`, `k3`) BUCKETS 3;
+-- result:
+-- !result
+INSERT INTO t2 VALUES
+    ('2020-10-10','2020-10-23 12:12:12','k3','k4',0,1,2,3,4,5,1.1,1.12,2.889),
+    ('2020-10-11','2020-10-24 12:12:12','k3','k4',0,0,2,3,4,5,1.1,1.12,2.889),
+    ('2020-10-12','2020-10-25 12:12:12','k3','k4',0,1,2,3,4,5,1.1,1.12,2.889),
+    ('2020-10-21','2020-10-24 12:12:12','k3','k4',0,0,2,3,4,5,1.1,1.12,2.889),
+    ('2020-10-22','2020-10-25 12:12:12','k3','k4',0,1,2,3,4,5,1.1,1.12,2.889);
+-- result:
+-- !result
+    
+CREATE MATERIALIZED VIEW IF NOT EXISTS test_mv1
+PARTITION BY `k1`
+DISTRIBUTED BY HASH(`k1`)
+REFRESH ASYNC
+as 
+select * from t1
+union all
+select * from t2;
+-- result:
+-- !result
+function: wait_async_materialized_view_finish("test_mv1")
+-- result:
+None
+-- !result
+select k1, count(1) from test_mv1 group by k1 order by k1;
+-- result:
+2020-10-10	1
+2020-10-11	1
+2020-10-12	1
+2020-10-21	1
+2020-10-22	2
+2020-10-23	1
+2020-10-24	1
+-- !result
+drop materialized view test_mv1;
+-- result:
+-- !result
+CREATE MATERIALIZED VIEW IF NOT EXISTS test_mv1
+PARTITION BY `k1`
+DISTRIBUTED BY HASH(`k1`)
+REFRESH ASYNC
+as 
+select * from t1
+union all
+select * from t2;
+-- result:
+-- !result
+refresh materialized view  test_mv1 with sync mode;
+select k1, count(1) from test_mv1 group by k1 order by k1;
+-- result:
+2020-10-10	1
+2020-10-11	1
+2020-10-12	1
+2020-10-21	1
+2020-10-22	2
+2020-10-23	1
+2020-10-24	1
+-- !result
+drop materialized view test_mv1;
+-- result:
+-- !result
+CREATE MATERIALIZED VIEW IF NOT EXISTS test_mv1
+PARTITION BY `k1`
+DISTRIBUTED BY HASH(`k1`)
+REFRESH ASYNC
+as 
+select * from t1
+union all
+select * from t2;
+-- result:
+-- !result
+refresh materialized view  test_mv1 partition start('2020-10-01') end ('2020-10-30') force with sync mode;
+select k1, count(1) from test_mv1 group by k1 order by k1;
+-- result:
+2020-10-10	1
+2020-10-11	1
+2020-10-12	1
+2020-10-21	1
+2020-10-22	2
+2020-10-23	1
+2020-10-24	1
+-- !result
+drop materialized view test_mv1;
+-- result:
+-- !result
+CREATE MATERIALIZED VIEW IF NOT EXISTS test_mv1
+PARTITION BY `k1`
+DISTRIBUTED BY HASH(`k1`)
+REFRESH ASYNC
+as 
+select * from t1
+union all
+select * from t2;
+-- result:
+-- !result
+refresh materialized view  test_mv1 partition start('2020-10-21') end ('2020-10-23') force with sync mode;
+select k1, count(1) from test_mv1 group by k1 order by k1;
+-- result:
+2020-10-21	1
+2020-10-22	2
+-- !result
+drop table t1;
+-- result:
+-- !result
+drop table t2;
+-- result:
+-- !result
+CREATE TABLE `t1` (
+    `k1`  date not null, 
+    `k2`  datetime not null, 
+    `k3`  char(20), 
+    `k4`  varchar(20), 
+    `k5`  boolean, 
+    `k6`  tinyint, 
+    `k7`  smallint, 
+    `k8`  int, 
+    `k9`  bigint, 
+    `k10` largeint, 
+    `k11` float, 
+    `k12` double, 
+    `k13` decimal(27,9) ) 
+DUPLICATE KEY(`k1`, `k2`, `k3`, `k4`, `k5`) 
+PARTITION BY date_trunc('day', `k1`) 
+DISTRIBUTED BY HASH(`k1`, `k2`, `k3`) BUCKETS 3 ;
+-- result:
+-- !result
+INSERT INTO t1 VALUES
+    ('2020-10-22','2020-10-23 12:12:12','k3','k4',0,1,2,3,4,5,1.1,1.12,2.889),
+    ('2020-10-23','2020-10-24 12:12:12','k3','k4',0,0,2,3,4,5,1.1,1.12,2.889),
+    ('2020-10-24','2020-10-25 12:12:12','k3','k4',0,1,2,3,4,5,1.1,1.12,2.889);
+-- result:
+-- !result
+    
+CREATE TABLE `t2` (
+    `k1`  date not null, 
+    `k2`  datetime not null, 
+    `k3`  char(20), 
+    `k4`  varchar(20), 
+    `k5`  boolean, 
+    `k6`  tinyint, 
+    `k7`  smallint, 
+    `k8`  int, 
+    `k9`  bigint, 
+    `k10` largeint, 
+    `k11` float, 
+    `k12` double, 
+    `k13` decimal(27,9) ) 
+DUPLICATE KEY(`k1`, `k2`, `k3`, `k4`, `k5`) 
+PARTITION BY date_trunc('day', `k1`) 
+DISTRIBUTED BY HASH(`k1`, `k2`, `k3`) BUCKETS 3;
+-- result:
+-- !result
+INSERT INTO t2 VALUES
+    ('2020-10-10','2020-10-23 12:12:12','k3','k4',0,1,2,3,4,5,1.1,1.12,2.889),
+    ('2020-10-11','2020-10-24 12:12:12','k3','k4',0,0,2,3,4,5,1.1,1.12,2.889),
+    ('2020-10-12','2020-10-25 12:12:12','k3','k4',0,1,2,3,4,5,1.1,1.12,2.889),
+    ('2020-10-21','2020-10-24 12:12:12','k3','k4',0,0,2,3,4,5,1.1,1.12,2.889),
+    ('2020-10-22','2020-10-25 12:12:12','k3','k4',0,1,2,3,4,5,1.1,1.12,2.889);
+-- result:
+-- !result
+    
+CREATE MATERIALIZED VIEW IF NOT EXISTS test_mv1
+PARTITION BY date_trunc('day', `k1`)
+DISTRIBUTED BY HASH(`k1`)
+REFRESH ASYNC
+as 
+select * from t1
+union all
+select * from t2;
+-- result:
+-- !result
+function: wait_async_materialized_view_finish("test_mv1")
+-- result:
+None
+-- !result
+select k1, count(1) from test_mv1 group by k1 order by k1;
+-- result:
+2020-10-10	1
+2020-10-11	1
+2020-10-12	1
+2020-10-21	1
+2020-10-22	2
+2020-10-23	1
+2020-10-24	1
+-- !result
+drop materialized view test_mv1;
+-- result:
+-- !result
+CREATE MATERIALIZED VIEW IF NOT EXISTS test_mv1
+PARTITION BY date_trunc('day', `k1`)
+DISTRIBUTED BY HASH(`k1`)
+REFRESH ASYNC
+as 
+select * from t1
+union all
+select * from t2;
+-- result:
+-- !result
+refresh materialized view  test_mv1 with sync mode;
+select k1, count(1) from test_mv1 group by k1 order by k1;
+-- result:
+2020-10-10	1
+2020-10-11	1
+2020-10-12	1
+2020-10-21	1
+2020-10-22	2
+2020-10-23	1
+2020-10-24	1
+-- !result
+drop materialized view test_mv1;
+-- result:
+-- !result
+CREATE MATERIALIZED VIEW IF NOT EXISTS test_mv1
+PARTITION BY `k1`
+DISTRIBUTED BY HASH(`k1`)
+REFRESH ASYNC
+as 
+select * from t1
+union all
+select * from t2;
+-- result:
+-- !result
+refresh materialized view  test_mv1 partition start('2020-10-01') end ('2020-10-30') force with sync mode;
+select k1, count(1) from test_mv1 group by k1 order by k1;
+-- result:
+2020-10-10	1
+2020-10-11	1
+2020-10-12	1
+2020-10-21	1
+2020-10-22	2
+2020-10-23	1
+2020-10-24	1
+-- !result
+drop materialized view test_mv1;
+-- result:
+-- !result
+CREATE MATERIALIZED VIEW IF NOT EXISTS test_mv1
+PARTITION BY `k1`
+DISTRIBUTED BY HASH(`k1`)
+REFRESH ASYNC
+as 
+select * from t1
+union all
+select * from t2;
+-- result:
+-- !result
+refresh materialized view  test_mv1 partition start('2020-10-21') end ('2020-10-23') force with sync mode;
+select k1, count(1) from test_mv1 group by k1 order by k1;
+-- result:
+2020-10-21	1
+2020-10-22	2
+-- !result
+drop table t1;
+-- result:
+-- !result
+drop table t2;
+-- result:
+-- !result

--- a/test/sql/test_materialized_view_refresh/T/test_mv_refresh_with_union
+++ b/test/sql/test_materialized_view_refresh/T/test_mv_refresh_with_union
@@ -71,8 +71,8 @@ union all
 select * from t2;
 function: wait_async_materialized_view_finish("test_mv1")
 select k1, count(1) from test_mv1 group by k1 order by k1;
-
 drop materialized view test_mv1;
+
 CREATE MATERIALIZED VIEW IF NOT EXISTS test_mv1
 PARTITION BY `k1`
 DISTRIBUTED BY HASH(`k1`)
@@ -83,8 +83,8 @@ union all
 select * from t2;
 refresh materialized view  test_mv1 with sync mode;
 select k1, count(1) from test_mv1 group by k1 order by k1;
-
 drop materialized view test_mv1;
+
 CREATE MATERIALIZED VIEW IF NOT EXISTS test_mv1
 PARTITION BY `k1`
 DISTRIBUTED BY HASH(`k1`)
@@ -95,8 +95,8 @@ union all
 select * from t2;
 refresh materialized view  test_mv1 partition start('2020-10-01') end ('2020-10-30') force with sync mode;
 select k1, count(1) from test_mv1 group by k1 order by k1;
-
 drop materialized view test_mv1;
+
 CREATE MATERIALIZED VIEW IF NOT EXISTS test_mv1
 PARTITION BY `k1`
 DISTRIBUTED BY HASH(`k1`)
@@ -107,6 +107,7 @@ union all
 select * from t2;
 refresh materialized view  test_mv1 partition start('2020-10-21') end ('2020-10-23') force with sync mode;
 select k1, count(1) from test_mv1 group by k1 order by k1;
+drop materialized view test_mv1;
 
 drop table t1;
 drop table t2;
@@ -169,8 +170,8 @@ union all
 select * from t2;
 function: wait_async_materialized_view_finish("test_mv1")
 select k1, count(1) from test_mv1 group by k1 order by k1;
-
 drop materialized view test_mv1;
+
 CREATE MATERIALIZED VIEW IF NOT EXISTS test_mv1
 PARTITION BY date_trunc('day', `k1`)
 DISTRIBUTED BY HASH(`k1`)
@@ -181,8 +182,8 @@ union all
 select * from t2;
 refresh materialized view  test_mv1 with sync mode;
 select k1, count(1) from test_mv1 group by k1 order by k1;
-
 drop materialized view test_mv1;
+
 CREATE MATERIALIZED VIEW IF NOT EXISTS test_mv1
 PARTITION BY `k1`
 DISTRIBUTED BY HASH(`k1`)
@@ -193,8 +194,8 @@ union all
 select * from t2;
 refresh materialized view  test_mv1 partition start('2020-10-01') end ('2020-10-30') force with sync mode;
 select k1, count(1) from test_mv1 group by k1 order by k1;
-
 drop materialized view test_mv1;
+
 CREATE MATERIALIZED VIEW IF NOT EXISTS test_mv1
 PARTITION BY `k1`
 DISTRIBUTED BY HASH(`k1`)
@@ -205,6 +206,7 @@ union all
 select * from t2;
 refresh materialized view  test_mv1 partition start('2020-10-21') end ('2020-10-23') force with sync mode;
 select k1, count(1) from test_mv1 group by k1 order by k1;
+drop materialized view test_mv1;
 
 drop table t1;
 drop table t2;

--- a/test/sql/test_materialized_view_refresh/T/test_mv_refresh_with_union
+++ b/test/sql/test_materialized_view_refresh/T/test_mv_refresh_with_union
@@ -1,0 +1,210 @@
+-- name: test_mv_refresh_with_union
+
+CREATE TABLE `t1` (
+    `k1`  date not null, 
+    `k2`  datetime not null, 
+    `k3`  char(20), 
+    `k4`  varchar(20), 
+    `k5`  boolean, 
+    `k6`  tinyint, 
+    `k7`  smallint, 
+    `k8`  int, 
+    `k9`  bigint, 
+    `k10` largeint, 
+    `k11` float, 
+    `k12` double, 
+    `k13` decimal(27,9) ) 
+DUPLICATE KEY(`k1`, `k2`, `k3`, `k4`, `k5`) 
+PARTITION BY RANGE(`k1`) 
+(
+PARTITION p20201022 VALUES [("2020-10-22"), ("2020-10-23")), 
+PARTITION p20201023 VALUES [("2020-10-23"), ("2020-10-24")), 
+PARTITION p20201024 VALUES [("2020-10-24"), ("2020-10-25"))
+)
+DISTRIBUTED BY HASH(`k1`, `k2`, `k3`) BUCKETS 3 ;
+
+INSERT INTO t1 VALUES
+    ('2020-10-22','2020-10-23 12:12:12','k3','k4',0,1,2,3,4,5,1.1,1.12,2.889),
+    ('2020-10-23','2020-10-24 12:12:12','k3','k4',0,0,2,3,4,5,1.1,1.12,2.889),
+    ('2020-10-24','2020-10-25 12:12:12','k3','k4',0,1,2,3,4,5,1.1,1.12,2.889);
+    
+CREATE TABLE `t2` (
+    `k1`  date not null, 
+    `k2`  datetime not null, 
+    `k3`  char(20), 
+    `k4`  varchar(20), 
+    `k5`  boolean, 
+    `k6`  tinyint, 
+    `k7`  smallint, 
+    `k8`  int, 
+    `k9`  bigint, 
+    `k10` largeint, 
+    `k11` float, 
+    `k12` double, 
+    `k13` decimal(27,9) ) 
+DUPLICATE KEY(`k1`, `k2`, `k3`, `k4`, `k5`) 
+PARTITION BY RANGE(`k1`) 
+(
+PARTITION p20201010 VALUES [("2020-10-10"), ("2020-10-11")), 
+PARTITION p20201011 VALUES [("2020-10-11"), ("2020-10-12")), 
+PARTITION p20201012 VALUES [("2020-10-12"), ("2020-10-13")), 
+PARTITION p20201021 VALUES [("2020-10-21"), ("2020-10-22")), 
+PARTITION p20201022 VALUES [("2020-10-22"), ("2020-10-23"))
+)
+DISTRIBUTED BY HASH(`k1`, `k2`, `k3`) BUCKETS 3;
+
+
+INSERT INTO t2 VALUES
+    ('2020-10-10','2020-10-23 12:12:12','k3','k4',0,1,2,3,4,5,1.1,1.12,2.889),
+    ('2020-10-11','2020-10-24 12:12:12','k3','k4',0,0,2,3,4,5,1.1,1.12,2.889),
+    ('2020-10-12','2020-10-25 12:12:12','k3','k4',0,1,2,3,4,5,1.1,1.12,2.889),
+    ('2020-10-21','2020-10-24 12:12:12','k3','k4',0,0,2,3,4,5,1.1,1.12,2.889),
+    ('2020-10-22','2020-10-25 12:12:12','k3','k4',0,1,2,3,4,5,1.1,1.12,2.889);
+    
+CREATE MATERIALIZED VIEW IF NOT EXISTS test_mv1
+PARTITION BY `k1`
+DISTRIBUTED BY HASH(`k1`)
+REFRESH ASYNC
+as 
+select * from t1
+union all
+select * from t2;
+function: wait_async_materialized_view_finish("test_mv1")
+select k1, count(1) from test_mv1 group by k1 order by k1;
+
+drop materialized view test_mv1;
+CREATE MATERIALIZED VIEW IF NOT EXISTS test_mv1
+PARTITION BY `k1`
+DISTRIBUTED BY HASH(`k1`)
+REFRESH ASYNC
+as 
+select * from t1
+union all
+select * from t2;
+refresh materialized view  test_mv1 with sync mode;
+select k1, count(1) from test_mv1 group by k1 order by k1;
+
+drop materialized view test_mv1;
+CREATE MATERIALIZED VIEW IF NOT EXISTS test_mv1
+PARTITION BY `k1`
+DISTRIBUTED BY HASH(`k1`)
+REFRESH ASYNC
+as 
+select * from t1
+union all
+select * from t2;
+refresh materialized view  test_mv1 partition start('2020-10-01') end ('2020-10-30') force with sync mode;
+select k1, count(1) from test_mv1 group by k1 order by k1;
+
+drop materialized view test_mv1;
+CREATE MATERIALIZED VIEW IF NOT EXISTS test_mv1
+PARTITION BY `k1`
+DISTRIBUTED BY HASH(`k1`)
+REFRESH ASYNC
+as 
+select * from t1
+union all
+select * from t2;
+refresh materialized view  test_mv1 partition start('2020-10-21') end ('2020-10-23') force with sync mode;
+select k1, count(1) from test_mv1 group by k1 order by k1;
+
+drop table t1;
+drop table t2;
+
+CREATE TABLE `t1` (
+    `k1`  date not null, 
+    `k2`  datetime not null, 
+    `k3`  char(20), 
+    `k4`  varchar(20), 
+    `k5`  boolean, 
+    `k6`  tinyint, 
+    `k7`  smallint, 
+    `k8`  int, 
+    `k9`  bigint, 
+    `k10` largeint, 
+    `k11` float, 
+    `k12` double, 
+    `k13` decimal(27,9) ) 
+DUPLICATE KEY(`k1`, `k2`, `k3`, `k4`, `k5`) 
+PARTITION BY date_trunc('day', `k1`) 
+DISTRIBUTED BY HASH(`k1`, `k2`, `k3`) BUCKETS 3 ;
+
+INSERT INTO t1 VALUES
+    ('2020-10-22','2020-10-23 12:12:12','k3','k4',0,1,2,3,4,5,1.1,1.12,2.889),
+    ('2020-10-23','2020-10-24 12:12:12','k3','k4',0,0,2,3,4,5,1.1,1.12,2.889),
+    ('2020-10-24','2020-10-25 12:12:12','k3','k4',0,1,2,3,4,5,1.1,1.12,2.889);
+    
+CREATE TABLE `t2` (
+    `k1`  date not null, 
+    `k2`  datetime not null, 
+    `k3`  char(20), 
+    `k4`  varchar(20), 
+    `k5`  boolean, 
+    `k6`  tinyint, 
+    `k7`  smallint, 
+    `k8`  int, 
+    `k9`  bigint, 
+    `k10` largeint, 
+    `k11` float, 
+    `k12` double, 
+    `k13` decimal(27,9) ) 
+DUPLICATE KEY(`k1`, `k2`, `k3`, `k4`, `k5`) 
+PARTITION BY date_trunc('day', `k1`) 
+DISTRIBUTED BY HASH(`k1`, `k2`, `k3`) BUCKETS 3;
+
+INSERT INTO t2 VALUES
+    ('2020-10-10','2020-10-23 12:12:12','k3','k4',0,1,2,3,4,5,1.1,1.12,2.889),
+    ('2020-10-11','2020-10-24 12:12:12','k3','k4',0,0,2,3,4,5,1.1,1.12,2.889),
+    ('2020-10-12','2020-10-25 12:12:12','k3','k4',0,1,2,3,4,5,1.1,1.12,2.889),
+    ('2020-10-21','2020-10-24 12:12:12','k3','k4',0,0,2,3,4,5,1.1,1.12,2.889),
+    ('2020-10-22','2020-10-25 12:12:12','k3','k4',0,1,2,3,4,5,1.1,1.12,2.889);
+    
+CREATE MATERIALIZED VIEW IF NOT EXISTS test_mv1
+PARTITION BY date_trunc('day', `k1`)
+DISTRIBUTED BY HASH(`k1`)
+REFRESH ASYNC
+as 
+select * from t1
+union all
+select * from t2;
+function: wait_async_materialized_view_finish("test_mv1")
+select k1, count(1) from test_mv1 group by k1 order by k1;
+
+drop materialized view test_mv1;
+CREATE MATERIALIZED VIEW IF NOT EXISTS test_mv1
+PARTITION BY date_trunc('day', `k1`)
+DISTRIBUTED BY HASH(`k1`)
+REFRESH ASYNC
+as 
+select * from t1
+union all
+select * from t2;
+refresh materialized view  test_mv1 with sync mode;
+select k1, count(1) from test_mv1 group by k1 order by k1;
+
+drop materialized view test_mv1;
+CREATE MATERIALIZED VIEW IF NOT EXISTS test_mv1
+PARTITION BY `k1`
+DISTRIBUTED BY HASH(`k1`)
+REFRESH ASYNC
+as 
+select * from t1
+union all
+select * from t2;
+refresh materialized view  test_mv1 partition start('2020-10-01') end ('2020-10-30') force with sync mode;
+select k1, count(1) from test_mv1 group by k1 order by k1;
+
+drop materialized view test_mv1;
+CREATE MATERIALIZED VIEW IF NOT EXISTS test_mv1
+PARTITION BY `k1`
+DISTRIBUTED BY HASH(`k1`)
+REFRESH ASYNC
+as 
+select * from t1
+union all
+select * from t2;
+refresh materialized view  test_mv1 partition start('2020-10-21') end ('2020-10-23') force with sync mode;
+select k1, count(1) from test_mv1 group by k1 order by k1;
+
+drop table t1;
+drop table t2;


### PR DESCRIPTION
## Why I'm doing:


MV with union all 's result is not correct if 
```
CREATE TABLE `t1` (
    `k1`  date not null, 
    `k2`  datetime not null, 
    `k3`  char(20), 
    `k4`  varchar(20), 
    `k5`  boolean, 
    `k6`  tinyint, 
    `k7`  smallint, 
    `k8`  int, 
    `k9`  bigint, 
    `k10` largeint, 
    `k11` float, 
    `k12` double, 
    `k13` decimal(27,9) ) 
DUPLICATE KEY(`k1`, `k2`, `k3`, `k4`, `k5`) 
PARTITION BY date_trunc('day', k1)
DISTRIBUTED BY HASH(`k1`, `k2`, `k3`) BUCKETS 3 
PROPERTIES ("storage_format" = "v2" );


INSERT INTO t1 VALUES
    ('2020-10-22','2020-10-23 12:12:12','k3','k4',0,1,2,3,4,5,1.1,1.12,2.889),
    ('2020-10-23','2020-10-24 12:12:12','k3','k4',0,0,2,3,4,5,1.1,1.12,2.889),
    ('2020-10-24','2020-10-25 12:12:12','k3','k4',0,1,2,3,4,5,1.1,1.12,2.889);
    
CREATE TABLE `t2` (
    `k1`  date not null, 
    `k2`  datetime not null, 
    `k3`  char(20), 
    `k4`  varchar(20), 
    `k5`  boolean, 
    `k6`  tinyint, 
    `k7`  smallint, 
    `k8`  int, 
    `k9`  bigint, 
    `k10` largeint, 
    `k11` float, 
    `k12` double, 
    `k13` decimal(27,9) ) 
DUPLICATE KEY(`k1`, `k2`, `k3`, `k4`, `k5`) 
PARTITION BY date_trunc('day', k1)
DISTRIBUTED BY HASH(`k1`, `k2`, `k3`) BUCKETS 3 
PROPERTIES ("storage_format" = "v2" );

INSERT INTO t2 VALUES
    ('2020-10-10','2020-10-23 12:12:12','k3','k4',0,1,2,3,4,5,1.1,1.12,2.889),
    ('2020-10-11','2020-10-24 12:12:12','k3','k4',0,0,2,3,4,5,1.1,1.12,2.889),
    ('2020-10-12','2020-10-25 12:12:12','k3','k4',0,1,2,3,4,5,1.1,1.12,2.889),
    ('2020-10-21','2020-10-24 12:12:12','k3','k4',0,0,2,3,4,5,1.1,1.12,2.889),
    ('2020-10-22','2020-10-25 12:12:12','k3','k4',0,1,2,3,4,5,1.1,1.12,2.889);
    
CREATE MATERIALIZED VIEW IF NOT EXISTS test_mv1
PARTITION BY date_trunc('day', `k1`)
DISTRIBUTED BY HASH(`k1`)
REFRESH ASYNC
as 
select * from t1
union all
select * from t2;


mysql> select k1, count(1) from t1 group by k1 order by k1;
+------------+----------+
| k1         | count(1) |
+------------+----------+
| 2020-10-22 |        1 |
| 2020-10-23 |        1 |
| 2020-10-24 |        1 |
+------------+----------+
3 rows in set (0.46 sec)

mysql> select k1, count(1) from t2 group by k1 order by k1;
+------------+----------+
| k1         | count(1) |
+------------+----------+
| 2020-10-10 |        1 |
| 2020-10-11 |        1 |
| 2020-10-12 |        1 |
| 2020-10-21 |        1 |
| 2020-10-22 |        1 |
+------------+----------+
5 rows in set (0.53 sec)

mysql> select k1, count(1) from test_mv1 group by k1 order by k1;
+------------+----------+
| k1         | count(1) |
+------------+----------+
| 2020-10-22 |        2 |
+------------+----------+
1 row in set (0.30 sec)
```


## What I'm doing:
PR(https://github.com/StarRocks/starrocks/pull/42950/files) introduce a bug: we should not calculate partition diff by using total ref base tables partition and mv's partitions instead of merging each diffs because the diff calculate will delete all partitions for each base table's input and mv's partitions which will introduce the bug.
```
            for (Map.Entry<Table, Column> entry : partitionTableAndColumn.entrySet()) {
                Table refBaseTable = entry.getKey();
                Column refBaseTablePartitionColumn = entry.getValue();
                // Collect the ref base table's partition range map.
                refBaseTablePartitionMap.put(refBaseTable, PartitionUtil.getPartitionKeyRange(
                        refBaseTable, refBaseTablePartitionColumn, partitionExpr));

                // To solve multi partition columns' problem of external table, record the mv partition name to all the same
                // partition names map here.
                if (!refBaseTable.isNativeTableOrMaterializedView()) {
                    refBaseTableMVPartitionMap.put(refBaseTable,
                            PartitionUtil.getMVPartitionNameMapOfExternalTable(refBaseTable,
                                    refBaseTablePartitionColumn, PartitionUtil.getPartitionNames(refBaseTable)));
                }

                Column partitionColumn = (materializedView.getPartitionInfo()).getPartitionColumns().get(0);
                PartitionDiffer differ = PartitionDiffer.build(materializedView, partitionRange);
                rangePartitionDiffList.add(PartitionUtil.getPartitionDiff(partitionExpr, partitionColumn,
                        refBaseTablePartitionMap.get(refBaseTable), mvRangePartitionMap, differ));
            }

```

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
