### PR TITLE
[BugFix] Fix NPE when the field name includes a dot

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/ScalarOperatorToIcebergExpr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/ScalarOperatorToIcebergExpr.java
@@ -132,10 +132,17 @@ public class ScalarOperatorToIcebergExpr {
         }
 
         private static Type getColumnType(String qualifiedName, IcebergContext context) {
-            String[] paths = qualifiedName.split("\\.");
-            Type type = context.getSchema();
-            for (String path : paths) {
-                type = type.asStructType().fieldType(path);
+            Types.StructType structType = context.getSchema().asStructType();
+            Type type = structType.fieldType(qualifiedName);
+            if (null != type) {
+                return type;
+            }
+            if (qualifiedName.contains(".")) {
+                type = context.getSchema();
+                String[] paths = qualifiedName.split("\\.");
+                for (String path : paths) {
+                    type = type.asStructType().fieldType(path);
+                }
             }
             return type;
         }

--- a/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/IcebergExprVisitorTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/IcebergExprVisitorTest.java
@@ -441,7 +441,6 @@ public class IcebergExprVisitorTest {
 
         Expression convertedExpr;
 
-        // don't support cast double to varchar, different comparator
         ConstantOperator value = ConstantOperator.createVarchar("11.11");
         CastOperator cast = new CastOperator(Type.VARCHAR, K17);
         convertedExpr = converter.convert(Lists.newArrayList(

--- a/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/IcebergExprVisitorTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/IcebergExprVisitorTest.java
@@ -63,7 +63,8 @@ public class IcebergExprVisitorTest {
                             Types.NestedField.optional(14, "k14", Types.BooleanType.get()),
                             Types.NestedField.optional(15, "k15", Types.StringType.get()),
                             Types.NestedField.optional(16, "k16", Types.FloatType.get())
-                    )));
+                    )),
+                    Types.NestedField.optional(17, "k17.double", Types.DoubleType.get()));
 
     private static final ColumnRefOperator K1 = new ColumnRefOperator(3, Type.INT, "k1", true, false);
     private static final ColumnRefOperator K2 = new ColumnRefOperator(4, Type.INT, "k2", true, false);
@@ -81,6 +82,7 @@ public class IcebergExprVisitorTest {
     private static final SubfieldOperator K14 = new SubfieldOperator(K10, Type.BOOLEAN, ImmutableList.of("k14"));
     private static final SubfieldOperator K15 = new SubfieldOperator(K10, Type.STRING, ImmutableList.of("k15"));
     private static final SubfieldOperator K16 = new SubfieldOperator(K10, Type.FLOAT, ImmutableList.of("k16"));
+    private static final ColumnRefOperator K17 = new ColumnRefOperator(17, Type.DOUBLE, "k17.double", true, false);
 
     @Test
     public void testToIcebergExpression() {
@@ -430,5 +432,20 @@ public class IcebergExprVisitorTest {
                 new BinaryPredicateOperator(BinaryType.EQ, cast, value)), context);
         Assert.assertEquals(Expression.Operation.TRUE, convertedExpr.op());
 
+    }
+
+    @Test
+    public void testToIcebergExpressionDotColumn() {
+        ScalarOperatorToIcebergExpr.IcebergContext context = new ScalarOperatorToIcebergExpr.IcebergContext(SCHEMA.asStruct());
+        ScalarOperatorToIcebergExpr converter = new ScalarOperatorToIcebergExpr();
+
+        Expression convertedExpr;
+
+        // don't support cast double to varchar, different comparator
+        ConstantOperator value = ConstantOperator.createVarchar("11.11");
+        CastOperator cast = new CastOperator(Type.VARCHAR, K17);
+        convertedExpr = converter.convert(Lists.newArrayList(
+                new BinaryPredicateOperator(BinaryType.LT, cast, value)), context);
+        Assert.assertEquals(Expression.Operation.TRUE, convertedExpr.op());
     }
 }


### PR DESCRIPTION
When the field name contains a dot, NPE will be encountered because consider it a child field of structType.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [x] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
