### PR TITLE
[BugFix] fix wrong start offset of row group in parquet file

### DIFF
--- a/be/src/formats/parquet/file_reader.cpp
+++ b/be/src/formats/parquet/file_reader.cpp
@@ -59,11 +59,13 @@ static int64_t _get_column_start_offset(const tparquet::ColumnMetaData& column) 
 }
 
 static int64_t _get_row_group_start_offset(const tparquet::RowGroup& row_group) {
-    if (row_group.__isset.file_offset) {
-        return row_group.file_offset;
-    }
     const tparquet::ColumnMetaData& first_column = row_group.columns[0].meta_data;
-    return _get_column_start_offset(first_column);
+    int64_t offset = _get_column_start_offset(first_column);
+
+    if (row_group.__isset.file_offset) {
+        offset = std::min(offset, row_group.file_offset);
+    }
+    return offset;
 }
 
 static int64_t _get_row_group_end_offset(const tparquet::RowGroup& row_group) {

--- a/be/src/formats/parquet/file_reader.cpp
+++ b/be/src/formats/parquet/file_reader.cpp
@@ -269,8 +269,12 @@ Status FileReader::_build_split_tasks() {
         }
         int64_t start_offset = _get_row_group_start_offset(row_group);
         int64_t end_offset = _get_row_group_end_offset(row_group);
+        if (start_offset >= end_offset) {
+            LOG(INFO) << "row group " << i << " is empty. start = " << start_offset << ", end = " << end_offset;
+            continue;
+        }
 #ifndef NDEBUG
-        DCHECK(start_offset < end_offset);
+        DCHECK(start_offset < end_offset) << "start = " << start_offset << ", end = " << end_offset;
         // there could be holes between row groups.
         // but this does not affect our scan range filter logic.
         // because in `_select_row_group`, we check if `start offset of row group` is in this range


### PR DESCRIPTION
## Why I'm doing:

row group start offset is wrong

when create hive table like 
```
create table hive_par_int(a int, b int) partition by (b);
nsert into hive_par_int values(0, 0),(1, 1);
insert into hive_par_int select -1, -1;
```

I've found that row group 0 metadata says 
- file_offset = 76
- but it is exactly the end of this row group

```
file schema: table
--------------------------------------------------------------------------------
a:           OPTIONAL INT32 O:INT_32 R:0 D:1

row group 1: RC:1 TS:72 OFFSET:4
--------------------------------------------------------------------------------
a:            INT32 UNCOMPRESSED DO:4 FPO:22 SZ:72/72/1.00 VC:1 ENC:PLAIN,RLE,PLAIN_DICTIONARY
```

## What I'm doing:

So to fix this issue, I change logic of start offset of row goup to min value of 
- file_offset (if have)
- start offset of first column

Fixes https://github.com/StarRocks/StarRocksTest/issues/7210

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [x] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
