### PR TITLE
[Enhancement] Avoid global sort for Sort->Decode->Window

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/planner/DecodeNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/DecodeNode.java
@@ -151,4 +151,8 @@ public class DecodeNode extends PlanNode {
         planNode.setDecode_node(decodeNode);
         normalizeConjuncts(normalizer, planNode, conjuncts);
     }
+
+    public Map<Integer, Integer> getDictIdToStringIds() {
+        return dictIdToStringIds;
+    }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/planner/SortNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/SortNode.java
@@ -288,6 +288,19 @@ public class SortNode extends PlanNode implements RuntimeFilterBuildNode {
             output.append(isAsc.next() ? "ASC" : "DESC");
         }
         output.append("\n");
+
+        if (!analyticPartitionExprs.isEmpty()) {
+            output.append(detailPrefix).append("analytic partition by: ");
+            for (Expr expr : analyticPartitionExprs) {
+                if (detailLevel.equals(TExplainLevel.NORMAL)) {
+                    output.append(expr.toSql()).append(" ");
+                } else {
+                    output.append(expr.explain()).append(" ");
+                }
+            }
+            output.append("\n");
+        }
+
         if (detailLevel == TExplainLevel.VERBOSE) {
             if (!buildRuntimeFilters.isEmpty()) {
                 output.append(detailPrefix).append("build runtime filters:\n");

--- a/fe/fe-core/src/main/java/com/starrocks/planner/SortNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/SortNode.java
@@ -291,11 +291,17 @@ public class SortNode extends PlanNode implements RuntimeFilterBuildNode {
 
         if (!analyticPartitionExprs.isEmpty()) {
             output.append(detailPrefix).append("analytic partition by: ");
+            start = true;
             for (Expr expr : analyticPartitionExprs) {
-                if (detailLevel.equals(TExplainLevel.NORMAL)) {
-                    output.append(expr.toSql()).append(" ");
+                if (start) {
+                    start = false;
                 } else {
-                    output.append(expr.explain()).append(" ");
+                    output.append(", ");
+                }
+                if (detailLevel.equals(TExplainLevel.NORMAL)) {
+                    output.append(expr.toSql());
+                } else {
+                    output.append(expr.explain());
                 }
             }
             output.append("\n");

--- a/fe/fe-core/src/main/java/com/starrocks/sql/plan/PlanFragmentBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/plan/PlanFragmentBuilder.java
@@ -2845,19 +2845,53 @@ public class PlanFragmentBuilder {
                 analyticEvalNode.getConjuncts()
                         .add(ScalarOperatorToExpr.buildExecExpression(predicate, formatterContext));
             }
-            // In new planner
-            // Add partition exprs of AnalyticEvalNode to SortNode, it is used in pipeline execution engine
-            // to eliminate time-consuming LocalMergeSortSourceOperator and parallelize AnalyticNode.
-            PlanNode root = inputFragment.getPlanRoot();
-            if (root instanceof SortNode) {
-                SortNode sortNode = (SortNode) root;
-                sortNode.setAnalyticPartitionExprs(analyticEvalNode.getPartitionExprs());
-                // If the data is skewed, we prefer to perform the standard sort-merge process to enhance performance.
-                sortNode.setAnalyticPartitionSkewed(node.isSkewed());
-            }
+            passPartitionByToSortNode(context, inputFragment.getPlanRoot(), analyticEvalNode.getPartitionExprs(),
+                    node.isSkewed());
 
             inputFragment.setPlanRoot(analyticEvalNode);
             return inputFragment;
+        }
+
+        /**
+         * In new planner.
+         * Add partition exprs of AnalyticEvalNode to SortNode, it is used in pipeline execution engine
+         * to eliminate time-consuming LocalMergeSortSourceOperator and parallelize AnalyticNode.
+         */
+        private static void passPartitionByToSortNode(ExecPlan context, PlanNode childRoot, List<Expr> partitionExprs,
+                                                      boolean isSkewed) {
+            SortNode sortNode = null;
+            if (childRoot instanceof SortNode) {
+                sortNode = (SortNode) childRoot;
+                sortNode.setAnalyticPartitionExprs(partitionExprs);
+            } else if (childRoot instanceof DecodeNode && childRoot.getChild(0) instanceof SortNode) {
+                DecodeNode decodeNode = (DecodeNode) childRoot;
+                sortNode = (SortNode) childRoot.getChild(0);
+
+                Map<Integer, Integer> stringIdToDictId = decodeNode.getDictIdToStringIds()
+                        .entrySet().stream()
+                        .collect(Collectors.toMap(Map.Entry::getValue, Map.Entry::getKey));
+                List<Expr> partitionExprsBeforeDecode = partitionExprs.stream().map(expr -> {
+                    if (!(expr instanceof SlotRef)) {
+                        return expr;
+                    }
+
+                    SlotRef slotRef = (SlotRef) expr;
+                    Integer dictSlotId = stringIdToDictId.get(slotRef.getDesc().getId().asInt());
+                    if (dictSlotId == null) {
+                        return expr;
+                    }
+
+                    SlotDescriptor slotDesc = context.getDescTbl().getSlotDesc(new SlotId(dictSlotId));
+                    return new SlotRef(slotDesc);
+                }).collect(Collectors.toList());
+
+                sortNode.setAnalyticPartitionExprs(partitionExprsBeforeDecode);
+            }
+
+            if (sortNode != null) {
+                // If the data is skewed, we prefer to perform the standard sort-merge process to enhance performance.
+                sortNode.setAnalyticPartitionSkewed(isSkewed);
+            }
         }
 
         private PlanFragment buildSetOperation(OptExpression optExpr, ExecPlan context, OperatorType operatorType) {

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/AggregatePushDownTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/AggregatePushDownTest.java
@@ -106,6 +106,7 @@ public class AggregatePushDownTest extends PlanTestBase {
                 "  |  \n" +
                 "  3:SORT\n" +
                 "  |  order by: <slot 4> 4: t1d ASC\n" +
+                "  |  analytic partition by: 4: t1d\n" +
                 "  |  offset: 0\n" +
                 "  |  \n" +
                 "  2:AGGREGATE (update finalize)\n" +
@@ -128,6 +129,7 @@ public class AggregatePushDownTest extends PlanTestBase {
                 "  |  \n" +
                 "  3:SORT\n" +
                 "  |  order by: <slot 4> 4: t1d ASC, <slot 5> 5: t1e ASC\n" +
+                "  |  analytic partition by: 4: t1d, 5: t1e\n" +
                 "  |  offset: 0\n" +
                 "  |  \n" +
                 "  2:AGGREGATE (update finalize)\n" +
@@ -166,6 +168,7 @@ public class AggregatePushDownTest extends PlanTestBase {
                 "  |  \n" +
                 "  2:SORT\n" +
                 "  |  order by: <slot 4> 4: t1d ASC\n" +
+                "  |  analytic partition by: 4: t1d\n" +
                 "  |  offset: 0\n" +
                 "  |  \n" +
                 "  1:EXCHANGE");

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/CTEPlanTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/CTEPlanTest.java
@@ -755,6 +755,7 @@ public class CTEPlanTest extends PlanTestBase {
                 "  |  \n" +
                 "  23:SORT\n" +
                 "  |  order by: <slot 14> 14: v3 ASC, <slot 13> 13: v2 ASC\n" +
+                "  |  analytic partition by: 14: v3, 13: v2\n" +
                 "  |  offset: 0");
     }
 

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/ExpressionTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/ExpressionTest.java
@@ -733,9 +733,10 @@ public class ExpressionTest extends PlanTestBase {
         Assert.assertTrue(plan.contains("  3:ANALYTIC\n" +
                 "  |  functions: [, count(6: c1), ]\n" +
                 "  |  partition by: 8: array_sum"));
-        Assert.assertTrue(plan.contains("  2:SORT\n" +
+        assertContains(plan, "  2:SORT\n" +
                 "  |  order by: <slot 8> 8: array_sum ASC\n" +
-                "  |  offset:"));
+                "  |  analytic partition by: 8: array_sum\n" +
+                "  |  offset:");
         Assert.assertTrue(plan, plan.contains("  1:Project\n" +
                 "  |  <slot 6> : 2: c1\n" +
                 "  |  <slot 8> : array_sum(array_map(<slot 4> -> " +

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/LowCardinalityTest2.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/LowCardinalityTest2.java
@@ -1233,7 +1233,7 @@ public class LowCardinalityTest2 extends PlanTestBase {
                 "  |  <dict id 20> : <string id 16>");
         assertContains(plan, "  2:SORT\n" +
                 "  |  order by: [20, INT, false] ASC, [2, INT, false] ASC\n" +
-                "  |  analytic partition by: [20, INT, false] ");
+                "  |  analytic partition by: [20, INT, false]");
         assertContains(plan, "  1:PARTITION-TOP-N\n" +
                 "  |  partition by: [20: L_COMMENT, INT, false] ");
         assertContains(plan, "  |  order by: [20, INT, false] ASC, [2, INT, false] ASC");
@@ -1269,7 +1269,7 @@ public class LowCardinalityTest2 extends PlanTestBase {
                 "  |  <dict id 19> : <string id 16>");
         assertContains(plan, "  2:SORT\n" +
                 "  |  order by: [19, INT, false] ASC, [5, DOUBLE, false] DESC\n" +
-                "  |  analytic partition by: [19, INT, false] ");
+                "  |  analytic partition by: [19, INT, false]");
         assertContains(plan, "  1:PARTITION-TOP-N\n" +
                 "  |  type: RANK\n" +
                 "  |  partition by: [19: L_COMMENT, INT, false] \n" +
@@ -1288,7 +1288,7 @@ public class LowCardinalityTest2 extends PlanTestBase {
                 "  |  <dict id 19> : <string id 16>");
         assertContains(plan, "  2:SORT\n" +
                 "  |  order by: [19, INT, false] ASC, [15, VARCHAR, false] ASC, [5, DOUBLE, false] DESC\n" +
-                "  |  analytic partition by: [19, INT, false] [15: L_SHIPMODE, VARCHAR, false] ");
+                "  |  analytic partition by: [19, INT, false], [15: L_SHIPMODE, VARCHAR, false]");
         assertContains(plan, "  1:PARTITION-TOP-N\n" +
                 "  |  type: RANK\n" +
                 "  |  partition by: [19: L_COMMENT, INT, false] , [15: L_SHIPMODE, CHAR, false] \n" +
@@ -1309,7 +1309,7 @@ public class LowCardinalityTest2 extends PlanTestBase {
                 "  |  <dict id 11> : <string id 7>");
         assertContains(plan, "  1:SORT\n" +
                 "  |  order by: [11, INT, false] ASC, [2, VARCHAR, false] ASC\n" +
-                "  |  analytic partition by: [11, INT, false] ");
+                "  |  analytic partition by: [11, INT, false]");
 
         sql = "SELECT S_ADDRESS, MAX(S_SUPPKEY) over(partition by concat(S_COMMENT, 'a') order by S_NAME) FROM supplier_nullable";
         plan = getCostExplain(sql);
@@ -1322,7 +1322,7 @@ public class LowCardinalityTest2 extends PlanTestBase {
                 "  |  <dict id 20> : <string id 17>");
         assertContains(plan, "  2:SORT\n" +
                 "  |  order by: [20, INT, true] ASC, [2, VARCHAR, false] ASC\n" +
-                "  |  analytic partition by: [20, INT, true] ");
+                "  |  analytic partition by: [20, INT, true]");
 
         // partition column is not dict column
         sql = "SELECT S_ADDRESS, MAX(S_SUPPKEY) over(partition by S_NAME order by S_COMMENT) FROM supplier_nullable";
@@ -1337,7 +1337,7 @@ public class LowCardinalityTest2 extends PlanTestBase {
                 "  |  <dict id 11> : <string id 7>");
         assertContains(plan, "  1:SORT\n" +
                 "  |  order by: [2, VARCHAR, false] ASC, [11, INT, false] ASC\n" +
-                "  |  analytic partition by: [2: S_NAME, VARCHAR, false] ");
+                "  |  analytic partition by: [2: S_NAME, VARCHAR, false]");
 
         // there is not DecodeNode
         sql = "SELECT /*+SET_VAR(cbo_enable_low_cardinality_optimize=false)*/" +
@@ -1350,7 +1350,7 @@ public class LowCardinalityTest2 extends PlanTestBase {
                 "  |  order by: [2: S_NAME, VARCHAR, false] ASC");
         assertContains(plan, "  1:SORT\n" +
                 "  |  order by: [7, VARCHAR, false] ASC, [2, VARCHAR, false] ASC\n" +
-                "  |  analytic partition by: [7: S_COMMENT, VARCHAR, false] ");
+                "  |  analytic partition by: [7: S_COMMENT, VARCHAR, false]");
 
     }
 

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/LowCardinalityTest2.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/LowCardinalityTest2.java
@@ -1219,22 +1219,38 @@ public class LowCardinalityTest2 extends PlanTestBase {
         // Test partition by string column
         String sql;
         String plan;
+
         // Analytic with where
         sql = "select sum(rm) from (" +
                 "select row_number() over( partition by L_COMMENT order by L_PARTKEY) as rm from lineitem" +
                 ") t where rm < 10";
         plan = getCostExplain(sql);
-
-        Assert.assertTrue(plan, plan.contains("  2:SORT\n" +
-                "  |  order by: [20, INT, false] ASC, [2, INT, false] ASC"));
-        Assert.assertTrue(plan, plan.contains("  1:PARTITION-TOP-N\n" +
-                "  |  partition by: [20: L_COMMENT, INT, false] "));
-        Assert.assertTrue(plan, plan.contains("  |  order by: [20, INT, false] ASC, [2, INT, false] ASC"));
+        assertContains(plan, "  4:ANALYTIC\n" +
+                "  |  functions: [, row_number[(); args: ; result: BIGINT; args nullable: false; result nullable: true], ]\n" +
+                "  |  partition by: [16: L_COMMENT, VARCHAR(44), false]\n" +
+                "  |  order by: [2: L_PARTKEY, INT, false] ASC");
+        assertContains(plan, "  3:Decode\n" +
+                "  |  <dict id 20> : <string id 16>");
+        assertContains(plan, "  2:SORT\n" +
+                "  |  order by: [20, INT, false] ASC, [2, INT, false] ASC\n" +
+                "  |  analytic partition by: [20, INT, false] ");
+        assertContains(plan, "  1:PARTITION-TOP-N\n" +
+                "  |  partition by: [20: L_COMMENT, INT, false] ");
+        assertContains(plan, "  |  order by: [20, INT, false] ASC, [2, INT, false] ASC");
 
         // row number
         sql = "select * from (select L_COMMENT,l_quantity, row_number() over " +
                 "(partition by L_COMMENT order by l_quantity desc) rn from lineitem )t where rn <= 10;";
         plan = getCostExplain(sql);
+        assertContains(plan, "  4:ANALYTIC\n" +
+                "  |  functions: [, row_number[(); args: ; result: BIGINT; args nullable: false; result nullable: true], ]\n" +
+                "  |  partition by: [16: L_COMMENT, VARCHAR(44), false]\n" +
+                "  |  order by: [5: L_QUANTITY, DOUBLE, false] DESC");
+        assertContains(plan, "  3:Decode\n" +
+                "  |  <dict id 19> : <string id 16>");
+        assertContains(plan, "  2:SORT\n" +
+                "  |  order by: [19, INT, false] ASC, [5, DOUBLE, false] DESC\n" +
+                "  |  analytic partition by: [19, INT, false]");
         assertContains(plan, "  1:PARTITION-TOP-N\n" +
                 "  |  partition by: [19: L_COMMENT, INT, false] \n" +
                 "  |  partition limit: 10\n" +
@@ -1245,6 +1261,15 @@ public class LowCardinalityTest2 extends PlanTestBase {
         sql = "select * from (select L_COMMENT,l_quantity, rank() over " +
                 "(partition by L_COMMENT order by l_quantity desc) rn from lineitem )t where rn <= 10;";
         plan = getCostExplain(sql);
+        assertContains(plan, "  4:ANALYTIC\n" +
+                "  |  functions: [, rank[(); args: ; result: BIGINT; args nullable: false; result nullable: true], ]\n" +
+                "  |  partition by: [16: L_COMMENT, VARCHAR(44), false]\n" +
+                "  |  order by: [5: L_QUANTITY, DOUBLE, false] DESC");
+        assertContains(plan, "  3:Decode\n" +
+                "  |  <dict id 19> : <string id 16>");
+        assertContains(plan, "  2:SORT\n" +
+                "  |  order by: [19, INT, false] ASC, [5, DOUBLE, false] DESC\n" +
+                "  |  analytic partition by: [19, INT, false] ");
         assertContains(plan, "  1:PARTITION-TOP-N\n" +
                 "  |  type: RANK\n" +
                 "  |  partition by: [19: L_COMMENT, INT, false] \n" +
@@ -1255,12 +1280,77 @@ public class LowCardinalityTest2 extends PlanTestBase {
         sql = "select * from (select L_COMMENT,l_quantity, rank() over " +
                 "(partition by L_COMMENT, l_shipmode order by l_quantity desc) rn from lineitem )t where rn <= 10;";
         plan = getCostExplain(sql);
+        assertContains(plan, "  4:ANALYTIC\n" +
+                "  |  functions: [, rank[(); args: ; result: BIGINT; args nullable: false; result nullable: true], ]\n" +
+                "  |  partition by: [16: L_COMMENT, VARCHAR(44), false], [15: L_SHIPMODE, VARCHAR, false]\n" +
+                "  |  order by: [5: L_QUANTITY, DOUBLE, false] DESC");
+        assertContains(plan, "  3:Decode\n" +
+                "  |  <dict id 19> : <string id 16>");
+        assertContains(plan, "  2:SORT\n" +
+                "  |  order by: [19, INT, false] ASC, [15, VARCHAR, false] ASC, [5, DOUBLE, false] DESC\n" +
+                "  |  analytic partition by: [19, INT, false] [15: L_SHIPMODE, VARCHAR, false] ");
         assertContains(plan, "  1:PARTITION-TOP-N\n" +
                 "  |  type: RANK\n" +
                 "  |  partition by: [19: L_COMMENT, INT, false] , [15: L_SHIPMODE, CHAR, false] \n" +
                 "  |  partition limit: 10\n" +
                 "  |  order by: [19, INT, false] ASC, [15, VARCHAR, false] ASC, [5, DOUBLE, false] DESC\n" +
                 "  |  offset: 0");
+
+        // partition column with expr
+        sql = "SELECT S_ADDRESS, MAX(S_SUPPKEY) over(partition by S_COMMENT order by S_NAME) FROM supplier_nullable";
+        plan = getCostExplain(sql);
+        assertContains(plan, "  3:ANALYTIC\n" +
+                "  |  functions: [, max[([1: S_SUPPKEY, INT, false]); args: INT; result: INT; " +
+                "args nullable: false; result nullable: true], ]\n" +
+                "  |  partition by: [7: S_COMMENT, VARCHAR(101), false]\n" +
+                "  |  order by: [2: S_NAME, VARCHAR, false] ASC");
+        assertContains(plan, "  2:Decode\n" +
+                "  |  <dict id 10> : <string id 3>\n" +
+                "  |  <dict id 11> : <string id 7>");
+        assertContains(plan, "  1:SORT\n" +
+                "  |  order by: [11, INT, false] ASC, [2, VARCHAR, false] ASC\n" +
+                "  |  analytic partition by: [11, INT, false] ");
+
+        sql = "SELECT S_ADDRESS, MAX(S_SUPPKEY) over(partition by concat(S_COMMENT, 'a') order by S_NAME) FROM supplier_nullable";
+        plan = getCostExplain(sql);
+        assertContains(plan, "  4:ANALYTIC\n" +
+                "  |  functions: [, max[([9: S_SUPPKEY, INT, false]); args: INT; result: INT; " +
+                "args nullable: false; result nullable: true], ]\n" +
+                "  |  partition by: [17: concat, VARCHAR, true]\n" +
+                "  |  order by: [2: S_NAME, VARCHAR, false] ASC");
+        assertContains(plan, "  3:Decode\n" +
+                "  |  <dict id 20> : <string id 17>");
+        assertContains(plan, "  2:SORT\n" +
+                "  |  order by: [20, INT, true] ASC, [2, VARCHAR, false] ASC\n" +
+                "  |  analytic partition by: [20, INT, true] ");
+
+        // partition column is not dict column
+        sql = "SELECT S_ADDRESS, MAX(S_SUPPKEY) over(partition by S_NAME order by S_COMMENT) FROM supplier_nullable";
+        plan = getCostExplain(sql);
+        assertContains(plan, "  3:ANALYTIC\n" +
+                "  |  functions: [, max[([1: S_SUPPKEY, INT, false]); args: INT; result: INT; args nullable: false; result nullable: true], ]\n" +
+                "  |  partition by: [2: S_NAME, VARCHAR, false]\n" +
+                "  |  order by: [7: S_COMMENT, VARCHAR(101), false] ASC");
+        assertContains(plan, "  2:Decode\n" +
+                "  |  <dict id 10> : <string id 3>\n" +
+                "  |  <dict id 11> : <string id 7>");
+        assertContains(plan, "  1:SORT\n" +
+                "  |  order by: [2, VARCHAR, false] ASC, [11, INT, false] ASC\n" +
+                "  |  analytic partition by: [2: S_NAME, VARCHAR, false] ");
+
+        // there is not DecodeNode
+        sql = "SELECT /*+SET_VAR(cbo_enable_low_cardinality_optimize=false)*/" +
+                "S_ADDRESS, MAX(S_SUPPKEY) over(partition by S_COMMENT order by S_NAME) FROM supplier_nullable";
+        plan = getCostExplain(sql);
+        assertContains(plan, "  2:ANALYTIC\n" +
+                "  |  functions: [, max[([1: S_SUPPKEY, INT, false]); args: INT; result: INT; " +
+                "args nullable: false; result nullable: true], ]\n" +
+                "  |  partition by: [7: S_COMMENT, VARCHAR, false]\n" +
+                "  |  order by: [2: S_NAME, VARCHAR, false] ASC");
+        assertContains(plan, "  1:SORT\n" +
+                "  |  order by: [7, VARCHAR, false] ASC, [2, VARCHAR, false] ASC\n" +
+                "  |  analytic partition by: [7: S_COMMENT, VARCHAR, false] ");
+
     }
 
     @Test
@@ -2075,5 +2165,61 @@ public class LowCardinalityTest2 extends PlanTestBase {
         String plan = getVerboseExplain(sql);
         assertContains(plan, "17: DictDefine(13: S_ADDRESS, [reverse(<place-holder>)])");
         assertContains(plan, "15: DictDefine(13: S_ADDRESS, [reverse(<place-holder>)])");
+    }
+
+    @Test
+    public void testAnalyticForAnalyticPartitionExprs() throws Exception {
+        {
+            String sql =
+                    "SELECT S_ADDRESS, MAX(S_SUPPKEY) over(partition by S_COMMENT order by S_ADDRESS) FROM supplier_nullable ";
+            String plan = getFragmentPlan(sql);
+            System.out.println(plan);
+        }
+        {
+            String sql =
+                    "SELECT MAX(concat(S_ADDRESS, 'b')) over(partition by concat(S_COMMENT, 'a') order by S_ADDRESS) FROM supplier_nullable ";
+            String plan = getVerboseExplain(sql);
+            System.out.println(plan);
+        }
+        {
+            String sql = "SELECT S_ADDRESS, MAX(S_SUPPKEY) over(partition by S_COMMENT order by S_NAME) FROM supplier_nullable ";
+            String plan = getFragmentPlan(sql);
+            assertContains(plan, "  3:ANALYTIC\n" +
+                    "  |  functions: [, max(1: S_SUPPKEY), ]\n" +
+                    "  |  partition by: 7: S_COMMENT\n" +
+                    "  |  order by: 2: S_NAME ASC\n" +
+                    "  |  window: RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW\n" +
+                    "  |  \n" +
+                    "  2:Decode\n" +
+                    "  |  <dict id 10> : <string id 3>\n" +
+                    "  |  <dict id 11> : <string id 7>\n" +
+                    "  |  \n" +
+                    "  1:SORT\n" +
+                    "  |  order by: <slot 11> 11: S_COMMENT ASC, <slot 2> 2: S_NAME ASC\n" +
+                    "  |  offset: 0");
+
+            String thriftPlan = getThriftPlan(sql);
+            assertContains(thriftPlan, "analytic_partition_exprs:[TExpr(nodes:[TExprNode(node_type:SLOT_REF, " +
+                    "type:TTypeDesc(types:[TTypeNode(type:SCALAR, scalar_type:TScalarType(type:VARCHAR, len:101))])");
+        }
+
+        {
+            String sql = "SELECT /*+SET_VAR(cbo_enable_low_cardinality_optimize=false)*/" +
+                    " S_ADDRESS, MAX(S_SUPPKEY) over(partition by S_COMMENT order by S_NAME) FROM supplier_nullable ";
+            String plan = getFragmentPlan(sql);
+            assertContains(plan, "  2:ANALYTIC\n" +
+                    "  |  functions: [, max(1: S_SUPPKEY), ]\n" +
+                    "  |  partition by: 7: S_COMMENT\n" +
+                    "  |  order by: 2: S_NAME ASC\n" +
+                    "  |  window: RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW\n" +
+                    "  |  \n" +
+                    "  1:SORT\n" +
+                    "  |  order by: <slot 7> 7: S_COMMENT ASC, <slot 2> 2: S_NAME ASC\n" +
+                    "  |  offset: 0");
+
+            String thriftPlan = getThriftPlan(sql);
+            assertContains(thriftPlan, "analytic_partition_exprs:[TExpr(nodes:[TExprNode(node_type:SLOT_REF, " +
+                    "type:TTypeDesc(types:[TTypeNode(type:SCALAR, scalar_type:TScalarType(type:VARCHAR, len:-1))])");
+        }
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/OrderByTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/OrderByTest.java
@@ -451,6 +451,7 @@ class OrderByTest extends PlanTestBase {
                 "  |  \n" +
                 "  3:SORT\n" +
                 "  |  order by: <slot 8> 8: expr ASC\n" +
+                "  |  analytic partition by: 8: expr\n" +
                 "  |  offset: 0\n" +
                 "  |  \n" +
                 "  2:Project\n" +
@@ -477,6 +478,7 @@ class OrderByTest extends PlanTestBase {
                 "  |  \n" +
                 "  3:SORT\n" +
                 "  |  order by: <slot 8> 8: expr ASC\n" +
+                "  |  analytic partition by: 8: expr\n" +
                 "  |  offset: 0\n" +
                 "  |  \n" +
                 "  2:Project\n" +
@@ -499,6 +501,7 @@ class OrderByTest extends PlanTestBase {
                 "  |  \n" +
                 "  3:SORT\n" +
                 "  |  order by: <slot 8> 8: expr ASC\n" +
+                "  |  analytic partition by: 8: expr\n" +
                 "  |  offset: 0\n" +
                 "  |  \n" +
                 "  2:Project\n" +

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/PlanFragmentWithCostTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/PlanFragmentWithCostTest.java
@@ -2063,6 +2063,7 @@ public class PlanFragmentWithCostTest extends PlanTestBase {
                     "  |  \n" +
                     "  5:SORT\n" +
                     "  |  order by: <slot 2> 2: v2 ASC, <slot 4> 4: max ASC\n" +
+                    "  |  analytic partition by: 2: v2, 4: max\n" +
                     "  |  offset: 0\n" +
                     "  |  \n" +
                     "  4:PARTITION-TOP-N\n" +
@@ -2090,6 +2091,7 @@ public class PlanFragmentWithCostTest extends PlanTestBase {
                     "  |  \n" +
                     "  5:SORT\n" +
                     "  |  order by: <slot 2> 2: v2 ASC, <slot 4> 4: max ASC\n" +
+                    "  |  analytic partition by: 2: v2, 4: max\n" +
                     "  |  offset: 0\n" +
                     "  |  \n" +
                     "  4:PARTITION-TOP-N\n" +
@@ -2120,6 +2122,7 @@ public class PlanFragmentWithCostTest extends PlanTestBase {
                     "  |  \n" +
                     "  6:SORT\n" +
                     "  |  order by: <slot 4> 4: max ASC, <slot 2> 2: v2 ASC\n" +
+                    "  |  analytic partition by: 4: max\n" +
                     "  |  offset: 0\n" +
                     "  |  \n" +
                     "  5:EXCHANGE");
@@ -2142,6 +2145,7 @@ public class PlanFragmentWithCostTest extends PlanTestBase {
                     "  |  \n" +
                     "  6:SORT\n" +
                     "  |  order by: <slot 4> 4: max ASC, <slot 2> 2: v2 ASC\n" +
+                    "  |  analytic partition by: 4: max\n" +
                     "  |  offset: 0\n" +
                     "  |  \n" +
                     "  5:EXCHANGE");
@@ -2168,6 +2172,7 @@ public class PlanFragmentWithCostTest extends PlanTestBase {
                     "  |  \n" +
                     "  2:SORT\n" +
                     "  |  order by: <slot 1> 1: v1 ASC, <slot 2> 2: v2 ASC, <slot 3> 3: v3 ASC\n" +
+                    "  |  analytic partition by: 1: v1, 2: v2\n" +
                     "  |  offset: 0\n" +
                     "  |  \n" +
                     "  1:PARTITION-TOP-N\n" +
@@ -2194,6 +2199,7 @@ public class PlanFragmentWithCostTest extends PlanTestBase {
                     "  |  \n" +
                     "  2:SORT\n" +
                     "  |  order by: <slot 1> 1: v1 ASC, <slot 2> 2: v2 ASC, <slot 3> 3: v3 ASC\n" +
+                    "  |  analytic partition by: 1: v1, 2: v2\n" +
                     "  |  offset: 0\n" +
                     "  |  \n" +
                     "  1:PARTITION-TOP-N\n" +
@@ -2221,6 +2227,7 @@ public class PlanFragmentWithCostTest extends PlanTestBase {
                     "  |  \n" +
                     "  3:SORT\n" +
                     "  |  order by: <slot 2> 2: v2 ASC, <slot 3> 3: v3 ASC, <slot 1> 1: v1 ASC\n" +
+                    "  |  analytic partition by: 2: v2, 3: v3\n" +
                     "  |  offset: 0\n" +
                     "  |  \n" +
                     "  2:EXCHANGE");
@@ -2248,6 +2255,7 @@ public class PlanFragmentWithCostTest extends PlanTestBase {
                     "  |  \n" +
                     "  3:SORT\n" +
                     "  |  order by: <slot 2> 2: v2 ASC, <slot 3> 3: v3 ASC, <slot 1> 1: v1 ASC\n" +
+                    "  |  analytic partition by: 2: v2, 3: v3\n" +
                     "  |  offset: 0");
             assertContains(plan, "  1:PARTITION-TOP-N\n" +
                     "  |  partition by: 2: v2 , 3: v3 \n" +

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/ReplayFromDumpTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/ReplayFromDumpTest.java
@@ -751,6 +751,7 @@ public class ReplayFromDumpTest extends ReplayFromDumpTestBase {
                 "  |  \n" +
                 "  2:SORT\n" +
                 "  |  order by: <slot 1> 1: TIME ASC\n" +
+                "  |  analytic partition by: 1: TIME\n" +
                 "  |  offset: 0\n" +
                 "  |  \n" +
                 "  1:AGGREGATE (update finalize)\n" +
@@ -905,6 +906,7 @@ public class ReplayFromDumpTest extends ReplayFromDumpTestBase {
         Assert.assertTrue(replayPair.second, replayPair.second.contains("25:SORT\n" +
                 "  |  order by: <slot 194> 194: mock_089 ASC, <slot 395> 395: case ASC, <slot 193> 193: mock_081 ASC, " +
                 "<slot 233> 233: mock_065 ASC\n" +
+                "  |  analytic partition by: 194: mock_089, 395: case, 193: mock_081\n" +
                 "  |  offset: 0\n" +
                 "  |  \n" +
                 "  24:EXCHANGE"));

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/SubqueryTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/SubqueryTest.java
@@ -1574,6 +1574,7 @@ public class SubqueryTest extends PlanTestBase {
                     "  |  \n" +
                     "  5:SORT\n" +
                     "  |  order by: <slot 1> 1: v1 ASC\n" +
+                    "  |  analytic partition by: 1: v1\n" +
                     "  |  offset: 0");
         }
         {
@@ -1594,6 +1595,7 @@ public class SubqueryTest extends PlanTestBase {
                     "  |  \n" +
                     "  8:SORT\n" +
                     "  |  order by: <slot 1> 1: v1 ASC\n" +
+                    "  |  analytic partition by: 1: v1\n" +
                     "  |  offset: 0");
         }
         {
@@ -1616,6 +1618,7 @@ public class SubqueryTest extends PlanTestBase {
                     "  |  \n" +
                     "  5:SORT\n" +
                     "  |  order by: <slot 1> 1: v1 ASC, <slot 3> 3: v3 ASC\n" +
+                    "  |  analytic partition by: 1: v1, 3: v3\n" +
                     "  |  offset: 0");
         }
         {
@@ -1636,6 +1639,7 @@ public class SubqueryTest extends PlanTestBase {
                     "  |  \n" +
                     "  5:SORT\n" +
                     "  |  order by: <slot 1> 1: v1 ASC\n" +
+                    "  |  analytic partition by: 1: v1\n" +
                     "  |  offset: 0");
         }
         {
@@ -1658,6 +1662,7 @@ public class SubqueryTest extends PlanTestBase {
                     "  |  \n" +
                     "  8:SORT\n" +
                     "  |  order by: <slot 1> 1: v1 ASC\n" +
+                    "  |  analytic partition by: 1: v1\n" +
                     "  |  offset: 0");
         }
         {
@@ -1679,6 +1684,7 @@ public class SubqueryTest extends PlanTestBase {
                     "  |  \n" +
                     "  8:SORT\n" +
                     "  |  order by: <slot 1> 1: v1 ASC\n" +
+                    "  |  analytic partition by: 1: v1\n" +
                     "  |  offset: 0");
         }
     }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/WindowTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/WindowTest.java
@@ -206,6 +206,7 @@ public class WindowTest extends PlanTestBase {
                 "  |  window: RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW");
         assertContains(plan, "  1:SORT\n" +
                 "  |  order by: <slot 3> 3: k3 ASC\n" +
+                "  |  analytic partition by: 3: k3\n" +
                 "  |  offset: 0");
     }
 
@@ -215,6 +216,7 @@ public class WindowTest extends PlanTestBase {
         String plan = getFragmentPlan(sql);
         assertContains(plan, "  1:SORT\n" +
                 "  |  order by: <slot 2> 2: v2 ASC\n" +
+                "  |  analytic partition by: 2: v2\n" +
                 "  |  offset: 0");
 
     }
@@ -513,6 +515,7 @@ public class WindowTest extends PlanTestBase {
             String plan = getFragmentPlan(sql);
             assertContains(plan, "  2:SORT\n" +
                     "  |  order by: <slot 3> 3: v3 ASC, <slot 2> 2: v2 ASC\n" +
+                    "  |  analytic partition by: 3: v3\n" +
                     "  |  offset: 0\n" +
                     "  |  \n" +
                     "  1:EXCHANGE");
@@ -605,6 +608,7 @@ public class WindowTest extends PlanTestBase {
             String plan = getFragmentPlan(sql);
             assertContains(plan, "  2:SORT\n" +
                     "  |  order by: <slot 3> 3: v3 ASC, <slot 2> 2: v2 ASC\n" +
+                    "  |  analytic partition by: 3: v3\n" +
                     "  |  offset: 0");
 
             sql = "select * from (\n" +
@@ -616,6 +620,7 @@ public class WindowTest extends PlanTestBase {
             plan = getFragmentPlan(sql);
             assertContains(plan, "  2:SORT\n" +
                     "  |  order by: <slot 3> 3: v3 ASC, <slot 2> 2: v2 ASC\n" +
+                    "  |  analytic partition by: 3: v3\n" +
                     "  |  offset: 0");
         }
         {
@@ -629,6 +634,7 @@ public class WindowTest extends PlanTestBase {
             String plan = getFragmentPlan(sql);
             assertContains(plan, "  2:SORT\n" +
                     "  |  order by: <slot 3> 3: v3 ASC, <slot 2> 2: v2 ASC\n" +
+                    "  |  analytic partition by: 3: v3\n" +
                     "  |  offset: 0");
 
             sql = "select * from (\n" +
@@ -640,6 +646,7 @@ public class WindowTest extends PlanTestBase {
             plan = getFragmentPlan(sql);
             assertContains(plan, "  2:SORT\n" +
                     "  |  order by: <slot 3> 3: v3 ASC, <slot 2> 2: v2 ASC\n" +
+                    "  |  analytic partition by: 3: v3\n" +
                     "  |  offset: 0");
         }
         {
@@ -653,6 +660,7 @@ public class WindowTest extends PlanTestBase {
             String plan = getFragmentPlan(sql);
             assertContains(plan, "  2:SORT\n" +
                     "  |  order by: <slot 3> 3: v3 ASC, <slot 2> 2: v2 ASC\n" +
+                    "  |  analytic partition by: 3: v3\n" +
                     "  |  offset: 0\n" +
                     "  |  \n" +
                     "  1:EXCHANGE");
@@ -985,6 +993,7 @@ public class WindowTest extends PlanTestBase {
         String plan = getVerboseExplain(sql);
         assertContains(plan, "1:SORT\n" +
                 "  |  order by: [1, BIGINT, true] ASC, [2, BIGINT, true] DESC\n" +
+                "  |  analytic partition by: [1: v1, BIGINT, true]\n" +
                 "  |  offset: 0\n" +
                 "  |  cardinality: 1\n" +
                 "  |  \n" +
@@ -1077,6 +1086,7 @@ public class WindowTest extends PlanTestBase {
                     "  |  \n" +
                     "  1:SORT\n" +
                     "  |  order by: <slot 1> 1: v1 ASC, <slot 3> 3: v3 ASC\n" +
+                    "  |  analytic partition by: 1: v1\n" +
                     "  |  offset: 0\n" +
                     "  |  \n" +
                     "  0:OlapScanNode\n" +
@@ -1102,6 +1112,7 @@ public class WindowTest extends PlanTestBase {
                     "  |  \n" +
                     "  1:SORT\n" +
                     "  |  order by: <slot 1> 1: v1 ASC, <slot 2> 2: v2 ASC, <slot 3> 3: v3 ASC\n" +
+                    "  |  analytic partition by: 1: v1, 2: v2\n" +
                     "  |  offset: 0\n" +
                     "  |  \n" +
                     "  0:OlapScanNode\n" +

--- a/fe/fe-core/src/test/resources/sql/external/hive/tpch/q17.sql
+++ b/fe/fe-core/src/test/resources/sql/external/hive/tpch/q17.sql
@@ -62,6 +62,7 @@ OutPut Exchange Id: 12
 |
 7:SORT
 |  order by: [17, INT, true] ASC
+|  analytic partition by: [17: p_partkey, INT, true]
 |  offset: 0
 |  cardinality: 600038
 |  column statistics:

--- a/fe/fe-core/src/test/resources/sql/external/hive/tpch/q2.sql
+++ b/fe/fe-core/src/test/resources/sql/external/hive/tpch/q2.sql
@@ -105,6 +105,7 @@ OutPut Exchange Id: 26
 |
 21:SORT
 |  order by: [1, INT, true] ASC
+|  analytic partition by: [1: p_partkey, INT, true]
 |  offset: 0
 |  cardinality: 80000
 |  column statistics:

--- a/fe/fe-core/src/test/resources/sql/scheduler/tpch/q17.sql
+++ b/fe/fe-core/src/test/resources/sql/scheduler/tpch/q17.sql
@@ -134,6 +134,7 @@ PLAN FRAGMENT 1
   |  
   7:SORT
   |  order by: <slot 18> 18: p_partkey ASC
+  |  analytic partition by: 18: p_partkey
   |  offset: 0
   |  
   6:Project

--- a/fe/fe-core/src/test/resources/sql/scheduler/tpch/q2.sql
+++ b/fe/fe-core/src/test/resources/sql/scheduler/tpch/q2.sql
@@ -175,6 +175,7 @@ PLAN FRAGMENT 1
   |  
   19:SORT
   |  order by: <slot 1> 1: p_partkey ASC
+  |  analytic partition by: 1: p_partkey
   |  offset: 0
   |  
   18:EXCHANGE

--- a/fe/fe-core/src/test/resources/sql/tpch-histogram-cost/q17.sql
+++ b/fe/fe-core/src/test/resources/sql/tpch-histogram-cost/q17.sql
@@ -62,6 +62,7 @@ OutPut Exchange Id: 12
 |
 7:SORT
 |  order by: [18, INT, false] ASC
+|  analytic partition by: [18: P_PARTKEY, INT, false]
 |  offset: 0
 |  cardinality: 614017
 |  column statistics:

--- a/fe/fe-core/src/test/resources/sql/tpch-histogram-cost/q2.sql
+++ b/fe/fe-core/src/test/resources/sql/tpch-histogram-cost/q2.sql
@@ -105,6 +105,7 @@ OutPut Exchange Id: 25
 |
 20:SORT
 |  order by: [1, INT, false] ASC
+|  analytic partition by: [1: P_PARTKEY, INT, false]
 |  offset: 0
 |  cardinality: 80240
 |  column statistics:

--- a/fe/fe-core/src/test/resources/sql/tpchcost/q17.sql
+++ b/fe/fe-core/src/test/resources/sql/tpchcost/q17.sql
@@ -38,6 +38,7 @@ UNPARTITIONED
       |
       7:SORT
       |  order by: <slot 18> 18: P_PARTKEY ASC
+      |  analytic partition by: 18: P_PARTKEY
       |  offset: 0
       |
       6:EXCHANGE

--- a/fe/fe-core/src/test/resources/sql/tpchcost/q2.sql
+++ b/fe/fe-core/src/test/resources/sql/tpchcost/q2.sql
@@ -105,6 +105,7 @@ OutPut Exchange Id: 25
 |
 20:SORT
 |  order by: [1, INT, false] ASC
+|  analytic partition by: [1: P_PARTKEY, INT, false]
 |  offset: 0
 |  cardinality: 80000
 |  column statistics:

--- a/test/sql/test_low_cardinality/R/test_low_cardinality_window
+++ b/test/sql/test_low_cardinality/R/test_low_cardinality_window
@@ -1,0 +1,445 @@
+-- name: test_low_cardinality_window
+CREATE TABLE `s2` (
+  `v1` bigint(20) NULL COMMENT "",
+  `v2` int NULL,
+  `v3` varchar(65533) NULL COMMENT "",
+  `v4` varchar(65533) NULL COMMENT ""
+) ENGINE=OLAP
+DUPLICATE KEY(`v1`)
+COMMENT "OLAP"
+DISTRIBUTED BY HASH(`v1`) BUCKETS 10
+PROPERTIES (
+"replication_num" = "1",
+"enable_persistent_index" = "false",
+"replicated_storage" = "false",
+"compression" = "LZ4"
+);
+-- result:
+-- !result
+insert into s2 values
+    (32, 815, "Hebei", "GD"),
+    (8, 247, NULL, NULL),
+    (5, 180, "Guangxi", NULL),
+    (35, 464, "Shaanxi", "HUB"),
+    (44, 473, "Taiwan", "XZ"),
+    (38, 387, "Jiangxi", "JL"),
+    (26, 533, "Shanxi", "TJ"),
+    (16, 271, NULL, "HLJ"),
+    (8, 957, "Jilin", "GS"),
+    (27, 636, "Jilin", "JX"),
+    (9, 109, "Hebei", "HUN"),
+    (17, 775, "Beijing", "HI"),
+    (11, 218, "Shanxi", "HEB"),
+    (12, 474, "Guizhou", "FJ"),
+    (42, 953, NULL, "XZ"),
+    (22, 191, "Qinghai", "JX"),
+    (7, 560, "Hebei", "XJ"),
+    (27, 712, "Jiangxi", "HEB"),
+    (14, 416, "Xinjiang", "HEN"),
+    (27, 951, NULL, "TJ"),
+    (NULL, 743, "Guangdong", "SD"),
+    (36, 875, "Ningxia", "SH"),
+    (29, 810, "Jilin", "GS"),
+    (31, 451, NULL, "JL"),
+    (35, 295, "Guangxi", "MO"),
+    (8, 254, "Taiwan", "ZJ"),
+    (38, 208, "Liaoning", "GZ"),
+    (40, 982, "Liaoning", "SC"),
+    (22, 180, "Shandong", "JX"),
+    (7, 577, "Qinghai", "HLJ"),
+    (34, 435, "Jiangsu", "TW"),
+    (42, 633, "Hunan", "HI"),
+    (7, 838, "Chongqing", "XJ"),
+    (41, 718, "Shandong", "HEN"),
+    (32, 130, "Taiwan", "HUN"),
+    (21, 835, "Shaanxi", NULL),
+    (31, 147, "Liaoning", "HK"),
+    (50, 741, "Chongqing", "HEN"),
+    (12, 544, "Qinghai", "YN"),
+    (30, 953, NULL, "QH"),
+    (43, 716, "Jiangsu", "GZ"),
+    (0, 947, "Fujian", "TW"),
+    (28, 123, "Yunnan", NULL),
+    (35, 799, "Macao", "HUB"),
+    (43, 335, "Henan", "HLJ"),
+    (26, 405, "Guangxi", NULL),
+    (11, 126, "Anhui", "QH"),
+    (49, 720, "Guizhou", "FJ"),
+    (5, 579, "Qinghai", "NMG"),
+    (14, 262, "Shaanxi", "TJ"),
+    (35, 198, "Tibet", "SD"),
+    (34, 340, "Inner Mongolia", "QH"),
+    (37, 805, "Jilin", "QH"),
+    (NULL, 229, "Shandong", "SX"),
+    (21, 909, "Sichuan", "GS"),
+    (42, 577, "Fujian", "TJ"),
+    (15, 771, "Henan", "MO"),
+    (41, 818, "Inner Mongolia", "HEB"),
+    (NULL, 742, "Chongqing", "HUN"),
+    (12, 189, "Heilongjiang", "TJ"),
+    (2, 691, "Xinjiang", "SN"),
+    (14, 213, "Heilongjiang", "JS"),
+    (NULL, 330, "Guangxi", "GX"),
+    (NULL, 482, NULL, "SX"),
+    (48, 601, "Inner Mongolia", "TW"),
+    (29, 550, "Guangxi", "HUB"),
+    (17, 591, "Ningxia", "HEB"),
+    (7, 671, "Zhejiang", "AH"),
+    (15, 228, "Hebei", "NMG"),
+    (14, 835, "Chongqing", "BJ"),
+    (NULL, 200, "Taiwan", "XZ"),
+    (2, 504, "Guizhou", NULL),
+    (32, 948, "Shandong", "YN"),
+    (1, 231, "Tianjin", "SD"),
+    (47, 236, "Fujian", "SH"),
+    (4, 937, "Hebei", "JX"),
+    (21, 516, "Jilin", "HLJ"),
+    (NULL, 504, "Hunan", "QH"),
+    (9, 217, NULL, "HUB"),
+    (39, 470, "Zhejiang", "QH"),
+    (40, 506, "Qinghai", "ZJ"),
+    (11, 359, "Shanghai", "JL"),
+    (NULL, 140, "Jiangsu", NULL),
+    (15, 999, "Jiangxi", "NX"),
+    (25, 488, "Guangxi", "QH"),
+    (33, 903, NULL, NULL),
+    (2, 549, "Hubei", "ZJ"),
+    (17, 495, "Shanghai", "HLJ"),
+    (22, 493, "Hebei", "YN"),
+    (30, 125, NULL, "ZJ"),
+    (50, 389, "Henan", "GX"),
+    (46, 565, "Inner Mongolia", "FJ"),
+    (23, 383, "Guizhou", "AH"),
+    (42, 735, "Inner Mongolia", "SC"),
+    (NULL, 640, "Inner Mongolia", "JS"),
+    (NULL, 684, "Hainan", "JL"),
+    (20, 945, "Beijing", "HI"),
+    (19, 231, "Inner Mongolia", "MO"),
+    (44, 873, "Zhejiang", NULL),
+    (26, 424, "Shaanxi", "JS"),
+    (3, 917, "Tianjin", "AH"),
+    (17, 830, "Henan", "MO"),
+    (22, 770, "Zhejiang", "YN"),
+    (49, 511, "Hainan", "JL"),
+    (NULL, 627, "Heilongjiang", "GD"),
+    (22, 587, "Shaanxi", "NMG"),
+    (7, 250, "Chongqing", "FJ"),
+    (48, 175, "Shaanxi", "NX"),
+    (23, 573, "Inner Mongolia", "FJ"),
+    (44, 725, NULL, "GX"),
+    (11, 678, "Liaoning", "SD"),
+    (NULL, 413, "Zhejiang", "HEN"),
+    (NULL, 100, "Shanghai", "TW"),
+    (33, 779, "Fujian", "NX"),
+    (39, 566, "Inner Mongolia", "ZJ"),
+    (32, 443, "Macao", "SH"),
+    (45, 922, "Shanxi", "QH"),
+    (44, 828, "Gansu", "SD"),
+    (13, 935, "Ningxia", "QH"),
+    (0, 343, "Anhui", "ZJ"),
+    (44, 976, "Shanghai", "HLJ"),
+    (16, 234, "Jilin", NULL),
+    (12, 277, "Liaoning", "NMG"),
+    (25, 591, "Sichuan", "SH"),
+    (50, 823, "Qinghai", "QH"),
+    (36, 717, "Shanxi", "XZ"),
+    (9, 917, "Taiwan", "SC"),
+    (26, 479, "Hunan", "SC"),
+    (0, 314, "Taiwan", "SX"),
+    (9, 561, "Tianjin", "HEB"),
+    (3, 800, "Hainan", "SX"),
+    (23, 180, "Beijing", "HLJ"),
+    (28, 768, "Fujian", "YN"),
+    (47, 300, "Jilin", "HEB"),
+    (11, 462, "Yunnan", "HEB"),
+    (27, 889, "Zhejiang", "HUN"),
+    (35, 347, "Guizhou", "SN"),
+    (49, 826, "Taiwan", "QH"),
+    (46, 839, "Zhejiang", "SN"),
+    (0, 658, "Fujian", "FJ"),
+    (42, 539, "Chongqing", "XJ"),
+    (7, 868, NULL, "HUB"),
+    (32, 822, "Xinjiang", "JX"),
+    (42, 189, "Heilongjiang", "ZJ"),
+    (NULL, 566, "Macao", "JL"),
+    (37, 311, "Xinjiang", "QH"),
+    (37, 284, "Qinghai", "SH"),
+    (NULL, 287, "Hunan", "HI"),
+    (21, 523, "Hainan", "HLJ"),
+    (10, 523, "Sichuan", "JX"),
+    (25, 550, "Anhui", "JX"),
+    (25, 107, "Fujian", "NX"),
+    (26, 941, "Tibet", "GZ"),
+    (47, 572, NULL, "XJ"),
+    (11, 165, "Gansu", "FJ"),
+    (43, 825, "Shandong", "CQ"),
+    (9, 956, "Shanghai", "SC"),
+    (9, 488, "Chongqing", "SX"),
+    (NULL, 733, "Zhejiang", "GX"),
+    (40, 235, "Taiwan", "YN"),
+    (40, 307, "Henan", "HEB"),
+    (30, 521, "Sichuan", "JS"),
+    (29, 641, "Macao", "FJ"),
+    (26, 245, "Jiangxi", "HEN"),
+    (48, 623, "Anhui", "SC"),
+    (21, 991, "Beijing", "HUB"),
+    (38, 668, NULL, "SH"),
+    (15, 198, "Yunnan", "JS"),
+    (9, 508, "Liaoning", NULL),
+    (29, 393, "Chongqing", "GZ"),
+    (6, 420, "Tibet", "CQ"),
+    (34, 319, NULL, "HUN"),
+    (30, 334, "Jiangsu", "ZJ"),
+    (13, 930, "Jilin", "SC"),
+    (48, 953, "Ningxia", NULL),
+    (28, 334, "Yunnan", "HEN"),
+    (14, 842, "Fujian", "HK"),
+    (38, 341, "Fujian", NULL),
+    (23, 428, "Guangdong", "TW"),
+    (10, 396, "Guangdong", "TJ"),
+    (45, 296, "Tibet", "TJ"),
+    (8, 825, "Liaoning", "SN"),
+    (44, 326, "Hainan", "HK"),
+    (23, 380, "Jilin", "HUN"),
+    (NULL, 485, "Hubei", "HEN"),
+    (5, 861, "Liaoning", "MO"),
+    (24, 915, "Hainan", "HEB"),
+    (22, 448, "Inner Mongolia", "HI"),
+    (13, 663, "Heilongjiang", "JS"),
+    (2, 243, "Inner Mongolia", "SN"),
+    (NULL, 817, "Tianjin", "YN"),
+    (19, 187, NULL, "HLJ"),
+    (3, 719, "Sichuan", "NX"),
+    (8, 502, "Hunan", "JX"),
+    (NULL, 620, "Hebei", "TW"),
+    (15, 433, "Shaanxi", NULL),
+    (14, 368, "Jiangxi", "BJ"),
+    (37, 510, "Liaoning", "LN"),
+    (NULL, 863, "Beijing", "JS"),
+    (32, 314, "Guizhou", NULL);
+-- result:
+-- !result
+insert into s2 select * from s2;
+-- result:
+-- !result
+insert into s2 select * from s2;
+-- result:
+-- !result
+insert into s2 select * from s2;
+-- result:
+-- !result
+insert into s2 select * from s2;
+-- result:
+-- !result
+insert into s2 select * from s2;
+-- result:
+-- !result
+[UC] analyze full table s2;
+-- result:
+test_db_77c47a62020d11efafcb3f39e8ea0927.s2	analyze	status	OK
+-- !result
+function: wait_global_dict_ready('v3', 's2')
+-- result:
+
+-- !result
+function: wait_global_dict_ready('v4', 's2')
+-- result:
+
+-- !result
+WITH w1 as (
+    SELECT
+    v3, v4, max(v1) over (partition by v3 order by v4) as max_v1
+    FROM s2
+)
+SELECT 
+    sum(murmur_hash3_32(v3)) +
+    sum(murmur_hash3_32(v4)) +
+    sum(murmur_hash3_32(max_v1))
+FROM w1;
+-- result:
+-481837658944
+-- !result
+WITH w1 as (
+    SELECT
+    v1, v3, v4, max(v1) over (partition by v3 order by v1) as max_v1
+    FROM s2
+)
+SELECT 
+    sum(murmur_hash3_32(v1)) +
+    sum(murmur_hash3_32(v3)) +
+    sum(murmur_hash3_32(v4)) +
+    sum(murmur_hash3_32(max_v1))
+FROM w1;
+-- result:
+1785884479744
+-- !result
+WITH w1 as (
+    SELECT
+    v1, v2, v3, v4, max(v1) over (partition by v1 order by v3) as max_v1
+    FROM s2
+)
+SELECT 
+    sum(murmur_hash3_32(v1)) +
+    sum(murmur_hash3_32(v2)) +
+    sum(murmur_hash3_32(v3)) +
+    sum(murmur_hash3_32(v4)) +
+    sum(murmur_hash3_32(max_v1))
+FROM w1;
+-- result:
+1756196477824
+-- !result
+WITH w1 as (
+    SELECT
+    v1, v2, v3, v4, max(v1) over (partition by v2 order by v1) as max_v1
+    FROM s2
+)
+SELECT 
+    sum(murmur_hash3_32(v1)) +
+    sum(murmur_hash3_32(v2)) +
+    sum(murmur_hash3_32(v3)) +
+    sum(murmur_hash3_32(v4)) +
+    sum(murmur_hash3_32(max_v1))
+FROM w1;
+-- result:
+1756196477824
+-- !result
+WITH w1 as (
+    SELECT
+    v3, v4, max(v1) over (partition by v3, v4 order by v4) as max_v1
+    FROM s2
+)
+SELECT 
+    sum(murmur_hash3_32(v3)) +
+    sum(murmur_hash3_32(v4)) +
+    sum(murmur_hash3_32(max_v1))
+FROM w1;
+-- result:
+1028984229856
+-- !result
+WITH w1 as (
+    SELECT
+    v2, v3, v4, max(v1) over (partition by v3, v4, v2 order by v4) as max_v1
+    FROM s2
+)
+SELECT 
+    sum(murmur_hash3_32(v2)) +
+    sum(murmur_hash3_32(v3)) +
+    sum(murmur_hash3_32(v4)) +
+    sum(murmur_hash3_32(max_v1))
+FROM w1;
+-- result:
+947001424736
+-- !result
+WITH w1 as (
+    SELECT
+    v3, v4, max(v1) over (partition by v3 order by v4) as max_v1
+    FROM s2
+)
+SELECT /*+SET_VAR(cbo_enable_low_cardinality_optimize=false)*/
+    sum(murmur_hash3_32(v3)) +
+    sum(murmur_hash3_32(v4)) +
+    sum(murmur_hash3_32(max_v1))
+FROM w1;
+-- result:
+-481837658944
+-- !result
+set enable_pipeline_level_shuffle = false;
+-- result:
+-- !result
+WITH w1 as (
+    SELECT
+    v3, v4, max(v1) over (partition by v3 order by v4) as max_v1
+    FROM s2
+)
+SELECT 
+    sum(murmur_hash3_32(v3)) +
+    sum(murmur_hash3_32(v4)) +
+    sum(murmur_hash3_32(max_v1))
+FROM w1;
+-- result:
+-481837658944
+-- !result
+WITH w1 as (
+    SELECT
+    v1, v3, v4, max(v1) over (partition by v3 order by v1) as max_v1
+    FROM s2
+)
+SELECT 
+    sum(murmur_hash3_32(v1)) +
+    sum(murmur_hash3_32(v3)) +
+    sum(murmur_hash3_32(v4)) +
+    sum(murmur_hash3_32(max_v1))
+FROM w1;
+-- result:
+1785884479744
+-- !result
+WITH w1 as (
+    SELECT
+    v1, v2, v3, v4, max(v1) over (partition by v1 order by v3) as max_v1
+    FROM s2
+)
+SELECT 
+    sum(murmur_hash3_32(v1)) +
+    sum(murmur_hash3_32(v2)) +
+    sum(murmur_hash3_32(v3)) +
+    sum(murmur_hash3_32(v4)) +
+    sum(murmur_hash3_32(max_v1))
+FROM w1;
+-- result:
+1756196477824
+-- !result
+WITH w1 as (
+    SELECT
+    v1, v2, v3, v4, max(v1) over (partition by v2 order by v1) as max_v1
+    FROM s2
+)
+SELECT 
+    sum(murmur_hash3_32(v1)) +
+    sum(murmur_hash3_32(v2)) +
+    sum(murmur_hash3_32(v3)) +
+    sum(murmur_hash3_32(v4)) +
+    sum(murmur_hash3_32(max_v1))
+FROM w1;
+-- result:
+1756196477824
+-- !result
+WITH w1 as (
+    SELECT
+    v3, v4, max(v1) over (partition by v3, v4 order by v4) as max_v1
+    FROM s2
+)
+SELECT 
+    sum(murmur_hash3_32(v3)) +
+    sum(murmur_hash3_32(v4)) +
+    sum(murmur_hash3_32(max_v1))
+FROM w1;
+-- result:
+1028984229856
+-- !result
+WITH w1 as (
+    SELECT
+    v2, v3, v4, max(v1) over (partition by v3, v4, v2 order by v4) as max_v1
+    FROM s2
+)
+SELECT 
+    sum(murmur_hash3_32(v2)) +
+    sum(murmur_hash3_32(v3)) +
+    sum(murmur_hash3_32(v4)) +
+    sum(murmur_hash3_32(max_v1))
+FROM w1;
+-- result:
+947001424736
+-- !result
+WITH w1 as (
+    SELECT
+    v3, v4, max(v1) over (partition by v3 order by v4) as max_v1
+    FROM s2
+)
+SELECT /*+SET_VAR(cbo_enable_low_cardinality_optimize=false)*/
+    sum(murmur_hash3_32(v3)) +
+    sum(murmur_hash3_32(v4)) +
+    sum(murmur_hash3_32(max_v1))
+FROM w1;
+-- result:
+-481837658944
+-- !result

--- a/test/sql/test_low_cardinality/T/test_low_cardinality_window
+++ b/test/sql/test_low_cardinality/T/test_low_cardinality_window
@@ -1,0 +1,420 @@
+-- name: test_low_cardinality_window
+
+CREATE TABLE `s2` (
+  `v1` bigint(20) NULL COMMENT "",
+  `v2` int NULL,
+  `v3` varchar(65533) NULL COMMENT "",
+  `v4` varchar(65533) NULL COMMENT ""
+) ENGINE=OLAP
+DUPLICATE KEY(`v1`)
+COMMENT "OLAP"
+DISTRIBUTED BY HASH(`v1`) BUCKETS 10
+PROPERTIES (
+"replication_num" = "1",
+"enable_persistent_index" = "false",
+"replicated_storage" = "false",
+"compression" = "LZ4"
+);
+
+insert into s2 values
+    (32, 815, "Hebei", "GD"),
+    (8, 247, NULL, NULL),
+    (5, 180, "Guangxi", NULL),
+    (35, 464, "Shaanxi", "HUB"),
+    (44, 473, "Taiwan", "XZ"),
+    (38, 387, "Jiangxi", "JL"),
+    (26, 533, "Shanxi", "TJ"),
+    (16, 271, NULL, "HLJ"),
+    (8, 957, "Jilin", "GS"),
+    (27, 636, "Jilin", "JX"),
+    (9, 109, "Hebei", "HUN"),
+    (17, 775, "Beijing", "HI"),
+    (11, 218, "Shanxi", "HEB"),
+    (12, 474, "Guizhou", "FJ"),
+    (42, 953, NULL, "XZ"),
+    (22, 191, "Qinghai", "JX"),
+    (7, 560, "Hebei", "XJ"),
+    (27, 712, "Jiangxi", "HEB"),
+    (14, 416, "Xinjiang", "HEN"),
+    (27, 951, NULL, "TJ"),
+    (NULL, 743, "Guangdong", "SD"),
+    (36, 875, "Ningxia", "SH"),
+    (29, 810, "Jilin", "GS"),
+    (31, 451, NULL, "JL"),
+    (35, 295, "Guangxi", "MO"),
+    (8, 254, "Taiwan", "ZJ"),
+    (38, 208, "Liaoning", "GZ"),
+    (40, 982, "Liaoning", "SC"),
+    (22, 180, "Shandong", "JX"),
+    (7, 577, "Qinghai", "HLJ"),
+    (34, 435, "Jiangsu", "TW"),
+    (42, 633, "Hunan", "HI"),
+    (7, 838, "Chongqing", "XJ"),
+    (41, 718, "Shandong", "HEN"),
+    (32, 130, "Taiwan", "HUN"),
+    (21, 835, "Shaanxi", NULL),
+    (31, 147, "Liaoning", "HK"),
+    (50, 741, "Chongqing", "HEN"),
+    (12, 544, "Qinghai", "YN"),
+    (30, 953, NULL, "QH"),
+    (43, 716, "Jiangsu", "GZ"),
+    (0, 947, "Fujian", "TW"),
+    (28, 123, "Yunnan", NULL),
+    (35, 799, "Macao", "HUB"),
+    (43, 335, "Henan", "HLJ"),
+    (26, 405, "Guangxi", NULL),
+    (11, 126, "Anhui", "QH"),
+    (49, 720, "Guizhou", "FJ"),
+    (5, 579, "Qinghai", "NMG"),
+    (14, 262, "Shaanxi", "TJ"),
+    (35, 198, "Tibet", "SD"),
+    (34, 340, "Inner Mongolia", "QH"),
+    (37, 805, "Jilin", "QH"),
+    (NULL, 229, "Shandong", "SX"),
+    (21, 909, "Sichuan", "GS"),
+    (42, 577, "Fujian", "TJ"),
+    (15, 771, "Henan", "MO"),
+    (41, 818, "Inner Mongolia", "HEB"),
+    (NULL, 742, "Chongqing", "HUN"),
+    (12, 189, "Heilongjiang", "TJ"),
+    (2, 691, "Xinjiang", "SN"),
+    (14, 213, "Heilongjiang", "JS"),
+    (NULL, 330, "Guangxi", "GX"),
+    (NULL, 482, NULL, "SX"),
+    (48, 601, "Inner Mongolia", "TW"),
+    (29, 550, "Guangxi", "HUB"),
+    (17, 591, "Ningxia", "HEB"),
+    (7, 671, "Zhejiang", "AH"),
+    (15, 228, "Hebei", "NMG"),
+    (14, 835, "Chongqing", "BJ"),
+    (NULL, 200, "Taiwan", "XZ"),
+    (2, 504, "Guizhou", NULL),
+    (32, 948, "Shandong", "YN"),
+    (1, 231, "Tianjin", "SD"),
+    (47, 236, "Fujian", "SH"),
+    (4, 937, "Hebei", "JX"),
+    (21, 516, "Jilin", "HLJ"),
+    (NULL, 504, "Hunan", "QH"),
+    (9, 217, NULL, "HUB"),
+    (39, 470, "Zhejiang", "QH"),
+    (40, 506, "Qinghai", "ZJ"),
+    (11, 359, "Shanghai", "JL"),
+    (NULL, 140, "Jiangsu", NULL),
+    (15, 999, "Jiangxi", "NX"),
+    (25, 488, "Guangxi", "QH"),
+    (33, 903, NULL, NULL),
+    (2, 549, "Hubei", "ZJ"),
+    (17, 495, "Shanghai", "HLJ"),
+    (22, 493, "Hebei", "YN"),
+    (30, 125, NULL, "ZJ"),
+    (50, 389, "Henan", "GX"),
+    (46, 565, "Inner Mongolia", "FJ"),
+    (23, 383, "Guizhou", "AH"),
+    (42, 735, "Inner Mongolia", "SC"),
+    (NULL, 640, "Inner Mongolia", "JS"),
+    (NULL, 684, "Hainan", "JL"),
+    (20, 945, "Beijing", "HI"),
+    (19, 231, "Inner Mongolia", "MO"),
+    (44, 873, "Zhejiang", NULL),
+    (26, 424, "Shaanxi", "JS"),
+    (3, 917, "Tianjin", "AH"),
+    (17, 830, "Henan", "MO"),
+    (22, 770, "Zhejiang", "YN"),
+    (49, 511, "Hainan", "JL"),
+    (NULL, 627, "Heilongjiang", "GD"),
+    (22, 587, "Shaanxi", "NMG"),
+    (7, 250, "Chongqing", "FJ"),
+    (48, 175, "Shaanxi", "NX"),
+    (23, 573, "Inner Mongolia", "FJ"),
+    (44, 725, NULL, "GX"),
+    (11, 678, "Liaoning", "SD"),
+    (NULL, 413, "Zhejiang", "HEN"),
+    (NULL, 100, "Shanghai", "TW"),
+    (33, 779, "Fujian", "NX"),
+    (39, 566, "Inner Mongolia", "ZJ"),
+    (32, 443, "Macao", "SH"),
+    (45, 922, "Shanxi", "QH"),
+    (44, 828, "Gansu", "SD"),
+    (13, 935, "Ningxia", "QH"),
+    (0, 343, "Anhui", "ZJ"),
+    (44, 976, "Shanghai", "HLJ"),
+    (16, 234, "Jilin", NULL),
+    (12, 277, "Liaoning", "NMG"),
+    (25, 591, "Sichuan", "SH"),
+    (50, 823, "Qinghai", "QH"),
+    (36, 717, "Shanxi", "XZ"),
+    (9, 917, "Taiwan", "SC"),
+    (26, 479, "Hunan", "SC"),
+    (0, 314, "Taiwan", "SX"),
+    (9, 561, "Tianjin", "HEB"),
+    (3, 800, "Hainan", "SX"),
+    (23, 180, "Beijing", "HLJ"),
+    (28, 768, "Fujian", "YN"),
+    (47, 300, "Jilin", "HEB"),
+    (11, 462, "Yunnan", "HEB"),
+    (27, 889, "Zhejiang", "HUN"),
+    (35, 347, "Guizhou", "SN"),
+    (49, 826, "Taiwan", "QH"),
+    (46, 839, "Zhejiang", "SN"),
+    (0, 658, "Fujian", "FJ"),
+    (42, 539, "Chongqing", "XJ"),
+    (7, 868, NULL, "HUB"),
+    (32, 822, "Xinjiang", "JX"),
+    (42, 189, "Heilongjiang", "ZJ"),
+    (NULL, 566, "Macao", "JL"),
+    (37, 311, "Xinjiang", "QH"),
+    (37, 284, "Qinghai", "SH"),
+    (NULL, 287, "Hunan", "HI"),
+    (21, 523, "Hainan", "HLJ"),
+    (10, 523, "Sichuan", "JX"),
+    (25, 550, "Anhui", "JX"),
+    (25, 107, "Fujian", "NX"),
+    (26, 941, "Tibet", "GZ"),
+    (47, 572, NULL, "XJ"),
+    (11, 165, "Gansu", "FJ"),
+    (43, 825, "Shandong", "CQ"),
+    (9, 956, "Shanghai", "SC"),
+    (9, 488, "Chongqing", "SX"),
+    (NULL, 733, "Zhejiang", "GX"),
+    (40, 235, "Taiwan", "YN"),
+    (40, 307, "Henan", "HEB"),
+    (30, 521, "Sichuan", "JS"),
+    (29, 641, "Macao", "FJ"),
+    (26, 245, "Jiangxi", "HEN"),
+    (48, 623, "Anhui", "SC"),
+    (21, 991, "Beijing", "HUB"),
+    (38, 668, NULL, "SH"),
+    (15, 198, "Yunnan", "JS"),
+    (9, 508, "Liaoning", NULL),
+    (29, 393, "Chongqing", "GZ"),
+    (6, 420, "Tibet", "CQ"),
+    (34, 319, NULL, "HUN"),
+    (30, 334, "Jiangsu", "ZJ"),
+    (13, 930, "Jilin", "SC"),
+    (48, 953, "Ningxia", NULL),
+    (28, 334, "Yunnan", "HEN"),
+    (14, 842, "Fujian", "HK"),
+    (38, 341, "Fujian", NULL),
+    (23, 428, "Guangdong", "TW"),
+    (10, 396, "Guangdong", "TJ"),
+    (45, 296, "Tibet", "TJ"),
+    (8, 825, "Liaoning", "SN"),
+    (44, 326, "Hainan", "HK"),
+    (23, 380, "Jilin", "HUN"),
+    (NULL, 485, "Hubei", "HEN"),
+    (5, 861, "Liaoning", "MO"),
+    (24, 915, "Hainan", "HEB"),
+    (22, 448, "Inner Mongolia", "HI"),
+    (13, 663, "Heilongjiang", "JS"),
+    (2, 243, "Inner Mongolia", "SN"),
+    (NULL, 817, "Tianjin", "YN"),
+    (19, 187, NULL, "HLJ"),
+    (3, 719, "Sichuan", "NX"),
+    (8, 502, "Hunan", "JX"),
+    (NULL, 620, "Hebei", "TW"),
+    (15, 433, "Shaanxi", NULL),
+    (14, 368, "Jiangxi", "BJ"),
+    (37, 510, "Liaoning", "LN"),
+    (NULL, 863, "Beijing", "JS"),
+    (32, 314, "Guizhou", NULL);
+
+insert into s2 select * from s2;
+insert into s2 select * from s2;
+insert into s2 select * from s2;
+insert into s2 select * from s2;
+insert into s2 select * from s2;
+
+[UC] analyze full table s2;
+
+function: wait_global_dict_ready('v3', 's2')
+function: wait_global_dict_ready('v4', 's2')
+
+-- ------------------------------------------------------------------------------------
+-- Enable pipeline_level_shuffle to avoid local shuffle before SortNode.
+-- ------------------------------------------------------------------------------------
+
+-- partition by low-card column, order by low-card column
+WITH w1 as (
+    SELECT
+    v3, v4, max(v1) over (partition by v3 order by v4) as max_v1
+    FROM s2
+)
+SELECT 
+    sum(murmur_hash3_32(v3)) +
+    sum(murmur_hash3_32(v4)) +
+    sum(murmur_hash3_32(max_v1))
+FROM w1;
+
+-- partition by low-card column, order by non-low cardinality column
+WITH w1 as (
+    SELECT
+    v1, v3, v4, max(v1) over (partition by v3 order by v1) as max_v1
+    FROM s2
+)
+SELECT 
+    sum(murmur_hash3_32(v1)) +
+    sum(murmur_hash3_32(v3)) +
+    sum(murmur_hash3_32(v4)) +
+    sum(murmur_hash3_32(max_v1))
+FROM w1;
+
+-- partition by non-low-card column, order by low cardinality column
+WITH w1 as (
+    SELECT
+    v1, v2, v3, v4, max(v1) over (partition by v1 order by v3) as max_v1
+    FROM s2
+)
+SELECT 
+    sum(murmur_hash3_32(v1)) +
+    sum(murmur_hash3_32(v2)) +
+    sum(murmur_hash3_32(v3)) +
+    sum(murmur_hash3_32(v4)) +
+    sum(murmur_hash3_32(max_v1))
+FROM w1;
+
+-- partition by non-low-card column, order by non-low cardinality column
+WITH w1 as (
+    SELECT
+    v1, v2, v3, v4, max(v1) over (partition by v2 order by v1) as max_v1
+    FROM s2
+)
+SELECT 
+    sum(murmur_hash3_32(v1)) +
+    sum(murmur_hash3_32(v2)) +
+    sum(murmur_hash3_32(v3)) +
+    sum(murmur_hash3_32(v4)) +
+    sum(murmur_hash3_32(max_v1))
+FROM w1;
+
+-- partition by multiple low-card columns
+WITH w1 as (
+    SELECT
+    v3, v4, max(v1) over (partition by v3, v4 order by v4) as max_v1
+    FROM s2
+)
+SELECT 
+    sum(murmur_hash3_32(v3)) +
+    sum(murmur_hash3_32(v4)) +
+    sum(murmur_hash3_32(max_v1))
+FROM w1;
+
+-- partition by multiple low-card columns and non-low-card column
+WITH w1 as (
+    SELECT
+    v2, v3, v4, max(v1) over (partition by v3, v4, v2 order by v4) as max_v1
+    FROM s2
+)
+SELECT 
+    sum(murmur_hash3_32(v2)) +
+    sum(murmur_hash3_32(v3)) +
+    sum(murmur_hash3_32(v4)) +
+    sum(murmur_hash3_32(max_v1))
+FROM w1;
+
+-- there is not DecodeNode.
+WITH w1 as (
+    SELECT
+    v3, v4, max(v1) over (partition by v3 order by v4) as max_v1
+    FROM s2
+)
+SELECT /*+SET_VAR(cbo_enable_low_cardinality_optimize=false)*/
+    sum(murmur_hash3_32(v3)) +
+    sum(murmur_hash3_32(v4)) +
+    sum(murmur_hash3_32(max_v1))
+FROM w1;
+
+-- ------------------------------------------------------------------------------------
+-- disable pipeline_level_shuffle to insert local shuffle before SortNode.
+-- ------------------------------------------------------------------------------------
+
+set enable_pipeline_level_shuffle = false;
+
+-- partition by low-card column, order by low-card column
+WITH w1 as (
+    SELECT
+    v3, v4, max(v1) over (partition by v3 order by v4) as max_v1
+    FROM s2
+)
+SELECT 
+    sum(murmur_hash3_32(v3)) +
+    sum(murmur_hash3_32(v4)) +
+    sum(murmur_hash3_32(max_v1))
+FROM w1;
+
+-- partition by low-card column, order by non-low cardinality column
+WITH w1 as (
+    SELECT
+    v1, v3, v4, max(v1) over (partition by v3 order by v1) as max_v1
+    FROM s2
+)
+SELECT 
+    sum(murmur_hash3_32(v1)) +
+    sum(murmur_hash3_32(v3)) +
+    sum(murmur_hash3_32(v4)) +
+    sum(murmur_hash3_32(max_v1))
+FROM w1;
+
+-- partition by non-low-card column, order by low cardinality column
+WITH w1 as (
+    SELECT
+    v1, v2, v3, v4, max(v1) over (partition by v1 order by v3) as max_v1
+    FROM s2
+)
+SELECT 
+    sum(murmur_hash3_32(v1)) +
+    sum(murmur_hash3_32(v2)) +
+    sum(murmur_hash3_32(v3)) +
+    sum(murmur_hash3_32(v4)) +
+    sum(murmur_hash3_32(max_v1))
+FROM w1;
+
+-- partition by non-low-card column, order by non-low cardinality column
+WITH w1 as (
+    SELECT
+    v1, v2, v3, v4, max(v1) over (partition by v2 order by v1) as max_v1
+    FROM s2
+)
+SELECT 
+    sum(murmur_hash3_32(v1)) +
+    sum(murmur_hash3_32(v2)) +
+    sum(murmur_hash3_32(v3)) +
+    sum(murmur_hash3_32(v4)) +
+    sum(murmur_hash3_32(max_v1))
+FROM w1;
+
+-- partition by multiple low-card columns
+WITH w1 as (
+    SELECT
+    v3, v4, max(v1) over (partition by v3, v4 order by v4) as max_v1
+    FROM s2
+)
+SELECT 
+    sum(murmur_hash3_32(v3)) +
+    sum(murmur_hash3_32(v4)) +
+    sum(murmur_hash3_32(max_v1))
+FROM w1;
+
+-- partition by multiple low-card columns and non-low-card column
+WITH w1 as (
+    SELECT
+    v2, v3, v4, max(v1) over (partition by v3, v4, v2 order by v4) as max_v1
+    FROM s2
+)
+SELECT 
+    sum(murmur_hash3_32(v2)) +
+    sum(murmur_hash3_32(v3)) +
+    sum(murmur_hash3_32(v4)) +
+    sum(murmur_hash3_32(max_v1))
+FROM w1;
+
+-- there is not DecodeNode.
+WITH w1 as (
+    SELECT
+    v3, v4, max(v1) over (partition by v3 order by v4) as max_v1
+    FROM s2
+)
+SELECT /*+SET_VAR(cbo_enable_low_cardinality_optimize=false)*/
+    sum(murmur_hash3_32(v3)) +
+    sum(murmur_hash3_32(v4)) +
+    sum(murmur_hash3_32(max_v1))
+FROM w1;


### PR DESCRIPTION
## Why I'm doing:

To avoid global sort, the partition exprs of `WindowNode` is passed to `SortNode`. And then we could use local shuffle to perform partition sort instead of global sort: `Source->LocalShuffle(partition exprs)->SortNode->WindowNode`.

To pass the partition exprs of `WindowNode` to `SortNode`, we check whether the immediate child of `WindowNode` is `SortNode` as follows.
```java
            PlanNode root = inputFragment.getPlanRoot();
            if (root instanceof SortNode) {
                SortNode sortNode = (SortNode) root;
                sortNode.setAnalyticPartitionExprs(analyticEvalNode.getPartitionExprs());
                // If the data is skewed, we prefer to perform the standard sort-merge process to enhance performance.
                sortNode.setAnalyticPartitionSkewed(node.isSkewed());
            }
```

However, recently, the plan `SortNode->DecodeNode->WindowNode` could be generated. Therefore, the partition exprs isn't passed to `SortNode` anymore for this case.

## What I'm doing:

Pass  the partition exprs to `SortNode` for the plan `SortNode->DecodeNode->WindowNode`.

Specially, because the partition `SlotRef` exprs will be changed after `DecodeNode`, we need translate back the string version `SlotRef` to the dict id version `SlotRef` again.

In addition, add `analytic partition by:` to the SortNode in explain plan to better troubleshoot in the future.

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
