### PR TITLE
[BugFix] fix cast '-' as int return 0

### DIFF
--- a/be/src/util/string_parser.hpp
+++ b/be/src/util/string_parser.hpp
@@ -346,6 +346,10 @@ inline T StringParser::string_to_int_internal(const char* s, int len, int base, 
     case '-':
         negative = true;
         max_val = StringParser::numeric_limits<T>(false) + 1;
+        if (UNLIKELY(len == 1)) {
+            *result = PARSE_FAILURE;
+            return 0;
+        }
     case '+':
         i = 1;
     }
@@ -393,7 +397,7 @@ template <typename T>
 inline T StringParser::string_to_int_no_overflow(const char* s, int len, ParseResult* result) {
     T val = 0;
     if (UNLIKELY(len == 0)) {
-        *result = PARSE_SUCCESS;
+        *result = PARSE_FAILURE;
         return val;
     }
     // Factor out the first char for error handling speeds up the loop.

--- a/test/sql/test_cast/R/test_cast_string_to_int
+++ b/test/sql/test_cast/R/test_cast_string_to_int
@@ -1,0 +1,41 @@
+-- name: test_cast_string_to_int
+select cast('-' as tinyint);
+-- result:
+None
+-- !result
+select cast('+' as tinyint);
+-- result:
+None
+-- !result
+select cast('-' as smallint);
+-- result:
+None
+-- !result
+select cast('+' as smallint);
+-- result:
+None
+-- !result
+select cast('-' as int);
+-- result:
+None
+-- !result
+select cast('+' as int);
+-- result:
+None
+-- !result
+select cast('-' as bigint);
+-- result:
+None
+-- !result
+select cast('+' as bigint);
+-- result:
+None
+-- !result
+select cast('-' as largeint);
+-- result:
+None
+-- !result
+select cast('+' as largeint);
+-- result:
+None
+-- !result

--- a/test/sql/test_cast/T/test_cast_string_to_int
+++ b/test/sql/test_cast/T/test_cast_string_to_int
@@ -1,0 +1,11 @@
+-- name: test_cast_string_to_int
+select cast('-' as tinyint);
+select cast('+' as tinyint);
+select cast('-' as smallint);
+select cast('+' as smallint);
+select cast('-' as int);
+select cast('+' as int);
+select cast('-' as bigint);
+select cast('+' as bigint);
+select cast('-' as largeint);
+select cast('+' as largeint);


### PR DESCRIPTION
## Why I'm doing:
```
mysql> select cast('-' as int);
+------------------+
| CAST('-' AS INT) |
+------------------+
|                0 |
+------------------+
```

## What I'm doing:
```
mysql> select cast('-' as int);
+------------------+
| CAST('-' AS INT) |
+------------------+
|             NULL |
+------------------+
```

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
- [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
