### PR TITLE
[BugFix] BE slot update

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/load/routineload/RoutineLoadTaskScheduler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/routineload/RoutineLoadTaskScheduler.java
@@ -79,7 +79,7 @@ public class RoutineLoadTaskScheduler extends FrontendDaemon {
 
     private static final long BACKEND_SLOT_UPDATE_INTERVAL_MS = 10000; // 10s
     private static final long SLOT_FULL_SLEEP_MS = 10000; // 10s
-    private static final long POLL_TIMEOUT_SEC = 10000; // 10s
+    private static final long POLL_TIMEOUT_SEC = 10; // 10s
 
     private final RoutineLoadMgr routineLoadManager;
     private final LinkedBlockingQueue<RoutineLoadTaskInfo> needScheduleTasksQueue = Queues.newLinkedBlockingQueue();
@@ -123,8 +123,7 @@ public class RoutineLoadTaskScheduler extends FrontendDaemon {
 
         try {
             // This step will be blocked until timeout when queue is empty
-            RoutineLoadTaskInfo routineLoadTaskInfo =
-                    needScheduleTasksQueue.poll(POLL_TIMEOUT_SEC, TimeUnit.SECONDS);
+            RoutineLoadTaskInfo routineLoadTaskInfo = needScheduleTasksQueue.poll(POLL_TIMEOUT_SEC, TimeUnit.SECONDS);
             if (routineLoadTaskInfo == null) {
                 return;
             }

--- a/fe/fe-core/src/test/java/com/starrocks/load/routineload/RoutineLoadSchedulerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/load/routineload/RoutineLoadSchedulerTest.java
@@ -136,6 +136,19 @@ public class RoutineLoadSchedulerTest {
         }
     }
 
+    @Test
+    public void testEmptyTaskQueue(@Injectable RoutineLoadMgr routineLoadManager) {
+        RoutineLoadTaskScheduler routineLoadTaskScheduler = new RoutineLoadTaskScheduler(routineLoadManager);
+        new Expectations() {
+            {
+                routineLoadManager.getClusterIdleSlotNum();
+                result = 1;
+                times = 1;
+            }
+        };
+        routineLoadTaskScheduler.runAfterCatalogReady();
+    }
+
     public void functionTest(@Mocked GlobalStateMgr globalStateMgr,
                              @Mocked SystemInfoService systemInfoService,
                              @Injectable Database database) throws DdlException, InterruptedException {


### PR DESCRIPTION
## Why I'm doing:
`RoutineLoadTaskScheduler` is a daemon job only runs when the `needScheduleTasksQueue` is not empty.
When there's no routine load task running, the `warehouseNodeTasksNum` will not be updated.
After node is added to a new warehouse, the create routine load stmt will return `Current routine load tasks is 0. The new job need 1 tasks. But we only support 0*16 tasks.Please modify FE config max_routine_load_task_num_per_be if you want more job`.
## What I'm doing:
This PR makes the `RoutineLoadTaskScheduler` run every 10 seconds no matter whether the `needScheduleTasksQueue` is empty.

Fixes https://github.com/StarRocks/StarRocksTest/issues/7187

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
