### PR TITLE
[Enhancement] optimize statistics query sql & log

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/common/Log4jConfig.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/Log4jConfig.java
@@ -290,7 +290,7 @@ public class Log4jConfig extends XmlConfiguration {
         StringBuilder sb = new StringBuilder();
 
         for (String s : internalModules) {
-            sb.append("<Logger name='internal.").append(s).append("' level=\"INFO\"> \n");
+            sb.append("<Logger name='internal.").append(s).append("' level=\"INFO\" additivity=\"false\"> \n");
             sb.append("   <AppenderRef ref=\"InternalFile\"/>\n");
             sb.append("</Logger>\n");
         }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/CachedStatisticStorage.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/CachedStatisticStorage.java
@@ -35,6 +35,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -43,6 +44,7 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executor;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
 
 public class CachedStatisticStorage implements StatisticStorage {
     private static final Logger LOG = LogManager.getLogger(CachedStatisticStorage.class);
@@ -86,30 +88,30 @@ public class CachedStatisticStorage implements StatisticStorage {
             .buildAsync(new ConnectorHistogramColumnStatsCacheLoader());
 
     @Override
-    public TableStatistic getTableStatistic(Long tableId, Long partitionId) {
+    public Map<Long, TableStatistic> getTableStatistics(Long tableId, Collection<Partition> partitions) {
         // get Statistics Table column info, just return default column statistics
         if (StatisticUtils.statisticTableBlackListCheck(tableId)) {
-            return TableStatistic.unknown();
+            return partitions.stream().collect(Collectors.toMap(Partition::getId, p -> TableStatistic.unknown()));
         }
 
+        List<TableStatsCacheKey> keys = partitions.stream().map(p -> new TableStatsCacheKey(tableId, p.getId()))
+                .collect(Collectors.toList());
+
         try {
-            CompletableFuture<Optional<TableStatistic>> result =
-                    tableStatsCache.get(new TableStatsCacheKey(tableId, partitionId));
+            CompletableFuture<Map<TableStatsCacheKey, Optional<TableStatistic>>> result = tableStatsCache.getAll(keys);
             if (result.isDone()) {
-                Optional<TableStatistic> realResult;
-                realResult = result.get();
-                return realResult.orElseGet(TableStatistic::unknown);
-            } else {
-                return TableStatistic.unknown();
+                Map<TableStatsCacheKey, Optional<TableStatistic>> data = result.get();
+                return keys.stream().collect(Collectors.toMap(
+                        TableStatsCacheKey::getPartitionId,
+                        k -> data.getOrDefault(k, Optional.empty()).orElse(TableStatistic.unknown())));
             }
         } catch (InterruptedException e) {
             LOG.warn(e);
             Thread.currentThread().interrupt();
-            return TableStatistic.unknown();
         } catch (Exception e) {
             LOG.warn(e);
-            return TableStatistic.unknown();
         }
+        return partitions.stream().collect(Collectors.toMap(Partition::getId, p -> TableStatistic.unknown()));
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/ColumnBasicStatsCacheLoader.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/ColumnBasicStatsCacheLoader.java
@@ -121,13 +121,11 @@ public class ColumnBasicStatsCacheLoader implements AsyncCacheLoader<ColumnStats
         return asyncLoad(key, executor);
     }
 
-    private List<TStatisticData> queryStatisticsData(ConnectContext context, long tableId, String column)
-            throws AnalysisException {
+    private List<TStatisticData> queryStatisticsData(ConnectContext context, long tableId, String column) {
         return queryStatisticsData(context, tableId, ImmutableList.of(column));
     }
 
-    private List<TStatisticData> queryStatisticsData(ConnectContext context, long tableId, List<String> columns)
-            throws AnalysisException {
+    private List<TStatisticData> queryStatisticsData(ConnectContext context, long tableId, List<String> columns) {
         return statisticExecutor.queryStatisticSync(context, null, tableId, columns);
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/StatisticStorage.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/StatisticStorage.java
@@ -16,9 +16,11 @@
 package com.starrocks.sql.optimizer.statistics;
 
 import com.google.common.collect.Maps;
+import com.starrocks.catalog.Partition;
 import com.starrocks.catalog.Table;
 import com.starrocks.connector.statistics.ConnectorTableColumnStats;
 
+import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -26,6 +28,11 @@ import java.util.stream.Collectors;
 public interface StatisticStorage {
     default TableStatistic getTableStatistic(Long tableId, Long partitionId) {
         return TableStatistic.unknown();
+    }
+
+    // partitionId: TableStatistic
+    default Map<Long, TableStatistic> getTableStatistics(Long tableId, Collection<Partition> partitions) {
+        return partitions.stream().collect(Collectors.toMap(Partition::getId, p -> TableStatistic.unknown()));
     }
 
     default void refreshTableStatistic(Table table) {

--- a/fe/fe-core/src/main/java/com/starrocks/statistic/BasicStatsMeta.java
+++ b/fe/fe-core/src/main/java/com/starrocks/statistic/BasicStatsMeta.java
@@ -128,12 +128,14 @@ public class BasicStatsMeta implements Writable {
         long cachedTableRowCount = 1L;
         long updatePartitionRowCount = 0L;
         long updatePartitionCount = 0L;
+
+        Map<Long, TableStatistic> tableStatistics = GlobalStateMgr.getCurrentState().getStatisticStorage()
+                .getTableStatistics(table.getId(), table.getPartitions());
+
         for (Partition partition : table.getPartitions()) {
             tableRowCount += partition.getRowCount();
-            TableStatistic tableStatistic = GlobalStateMgr.getCurrentState().getStatisticStorage()
-                    .getTableStatistic(table.getId(), partition.getId());
-            if (tableStatistic != null) {
-                cachedTableRowCount += tableStatistic.getRowCount();
+            if (tableStatistics.containsKey(partition.getId())) {
+                cachedTableRowCount += tableStatistics.get(partition.getId()).getRowCount();
             }
             LocalDateTime loadTime = StatisticUtils.getPartitionLastUpdateTime(partition);
 
@@ -147,7 +149,7 @@ public class BasicStatsMeta implements Writable {
         // 1. If none updated partitions, health is 1
         // 2. If there are few updated partitions, the health only to calculated on rows
         // 3. If there are many updated partitions, the health needs to be calculated based on partitions
-        if (updatePartitionRowCount == 0 || updatePartitionCount == 0) {
+        if (updatePartitionCount == 0) {
             return 1;
         } else if (updatePartitionCount < StatsConstants.STATISTICS_PARTITION_UPDATED_THRESHOLD) {
             updateRatio = (updateRows * 1.0) / updatePartitionRowCount;

--- a/fe/fe-core/src/main/java/com/starrocks/statistic/StatisticExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/statistic/StatisticExecutor.java
@@ -71,9 +71,8 @@ public class StatisticExecutor {
         return executeStatisticDQL(context, sql);
     }
 
-    public List<TStatisticData> queryStatisticSync(ConnectContext context,
-                                                   Long dbId, Long tableId, List<String> columnNames)
-            throws AnalysisException {
+    public List<TStatisticData> queryStatisticSync(ConnectContext context, Long dbId, Long tableId,
+                                                   List<String> columnNames) {
         String sql;
         BasicStatsMeta meta = GlobalStateMgr.getCurrentState().getAnalyzeMgr().getBasicStatsMetaMap().get(tableId);
         if (meta != null && meta.getType().equals(StatsConstants.AnalyzeType.FULL)) {

--- a/fe/fe-core/src/main/java/com/starrocks/statistic/StatisticUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/statistic/StatisticUtils.java
@@ -40,7 +40,6 @@ import com.starrocks.catalog.StructField;
 import com.starrocks.catalog.StructType;
 import com.starrocks.catalog.Table;
 import com.starrocks.catalog.Type;
-import com.starrocks.common.AnalysisException;
 import com.starrocks.common.Config;
 import com.starrocks.common.ErrorCode;
 import com.starrocks.common.ErrorReport;
@@ -534,12 +533,12 @@ public class StatisticUtils {
         return colName;
     }
 
-    public static Type getQueryStatisticsColumnType(Table table, String column) throws AnalysisException {
+    public static Type getQueryStatisticsColumnType(Table table, String column) {
         String[] parts = column.split("\\.");
         Preconditions.checkState(parts.length >= 1);
         Column base = table.getColumn(parts[0]);
         if (base == null) {
-            ErrorReport.reportAnalysisException(ErrorCode.ERR_BAD_FIELD_ERROR, column);
+            ErrorReport.reportSemanticException(ErrorCode.ERR_BAD_FIELD_ERROR, column);
         }
 
         Type baseColumnType = base.getType();

--- a/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AnalyzeStmtTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AnalyzeStmtTest.java
@@ -66,7 +66,6 @@ import org.junit.Test;
 
 import java.time.LocalDateTime;
 import java.util.ArrayList;
-import java.util.regex.Pattern;
 
 import static com.starrocks.sql.analyzer.AnalyzeTestUtil.analyzeFail;
 import static com.starrocks.sql.analyzer.AnalyzeTestUtil.analyzeSuccess;
@@ -281,19 +280,14 @@ public class AnalyzeStmtTest {
         Column v1 = table.getColumn("v1");
         Column v2 = table.getColumn("v2");
 
-        Assert.assertEquals(String.format(new String("SELECT cast(1 as INT), now(), " +
+        Assert.assertEquals(String.format("SELECT cast(1 as INT), now(), " +
                         "db_id, table_id, column_name," +
                         " sum(row_count), " +
                         "cast(sum(data_size) as bigint), hll_union_agg(ndv), sum(null_count),  " +
-                        "cast(max(cast(max as bigint(20))) as string), " +
-                        "cast(min(cast(min as bigint(20))) as string) FROM column_statistics " +
-                        "WHERE table_id = %d and column_name = \"v1\" GROUP BY db_id, table_id, column_name " +
-                        "UNION ALL SELECT cast(1 as INT), now(), db_id, table_id, column_name, sum(row_count), " +
-                        "cast(sum(data_size) as bigint), " +
-                        "hll_union_agg(ndv), sum(null_count),  cast(max(cast(max as bigint(20))) as string), " +
-                        "cast(min(cast(min as bigint(20))) as string) " +
-                        "FROM column_statistics WHERE table_id = %d and column_name = \"v2\" " +
-                        "GROUP BY db_id, table_id, column_name"), table.getId(), table.getId()),
+                        "cast(max(cast(max as bigint)) as string), " +
+                        "cast(min(cast(min as bigint)) as string) FROM column_statistics " +
+                        "WHERE table_id = %d and column_name in (\"v1\", \"v2\") " +
+                        "GROUP BY db_id, table_id, column_name", table.getId()),
                 StatisticSQLBuilder.buildQueryFullStatisticsSQL(database.getId(), table.getId(),
                         Lists.newArrayList("v1", "v2"), Lists.newArrayList(v1.getType(), v2.getType())));
 
@@ -430,22 +424,19 @@ public class AnalyzeStmtTest {
         Column kk1 = table.getColumn("kk1");
         Column kk2 = table.getColumn("kk2");
 
-        String pattern = "SELECT cast\\(1 as INT\\), now\\(\\), db_id, table_id, column_name, sum\\(row_count\\), " +
-                "cast\\(sum\\(data_size\\) as bigint\\), hll_union_agg\\(ndv\\), sum\\(null_count\\), " +
-                " cast\\(max\\(cast\\(max as int\\(11\\)\\)\\) as string\\), cast\\(min\\(cast\\(min " +
-                "as int\\(11\\)\\)\\) as string\\) " +
-                "FROM column_statistics WHERE table_id = (\\d+) and column_name = \"kk1\" " +
+        String pattern = String.format("SELECT cast(1 as INT), now(), db_id, table_id, column_name, sum(row_count), " +
+                "cast(sum(data_size) as bigint), hll_union_agg(ndv), sum(null_count),  " +
+                "cast(max(cast(max as string)) as string), cast(min(cast(min as string)) as string) " +
+                "FROM column_statistics WHERE table_id = %d and column_name in (\"kk2\") " +
                 "GROUP BY db_id, table_id, column_name " +
-                "UNION ALL SELECT cast\\(1 as INT\\), now\\(\\), db_id, table_id, column_name, " +
-                "sum\\(row_count\\), " +
-                "cast\\(sum\\(data_size\\) as bigint\\), hll_union_agg\\(ndv\\), sum\\(null_count\\),  " +
-                "cast\\(max\\(cast\\(max as string\\)\\) as string\\), cast\\(min\\(cast\\(min as" +
-                " string\\)\\) as string\\) " +
-                "FROM column_statistics WHERE table_id = (\\d+) and column_name = \"kk2\" " +
-                "GROUP BY db_id, table_id, column_name";
+                "UNION ALL SELECT cast(1 as INT), now(), db_id, table_id, column_name, " +
+                "sum(row_count), cast(sum(data_size) as bigint), hll_union_agg(ndv), sum(null_count),  " +
+                "cast(max(cast(max as bigint)) as string), cast(min(cast(min as bigint)) as string) " +
+                "FROM column_statistics WHERE table_id = %d and column_name in (\"kk1\") " +
+                "GROUP BY db_id, table_id, column_name", table.getId(), table.getId());
         String content = StatisticSQLBuilder.buildQueryFullStatisticsSQL(database.getId(), table.getId(),
                 Lists.newArrayList("kk1", "kk2"), Lists.newArrayList(kk1.getType(), kk2.getType()));
-        Assert.assertTrue(Pattern.matches(pattern, content));
+        Assert.assertEquals(pattern, content);
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/MockTpchStatisticStorage.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/MockTpchStatisticStorage.java
@@ -19,6 +19,7 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Maps;
 import com.starrocks.catalog.Database;
 import com.starrocks.catalog.OlapTable;
+import com.starrocks.catalog.Partition;
 import com.starrocks.catalog.Table;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.server.GlobalStateMgr;
@@ -32,6 +33,7 @@ import org.apache.commons.collections4.map.CaseInsensitiveMap;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
+import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -324,8 +326,8 @@ public class MockTpchStatisticStorage implements StatisticStorage {
     }
 
     @Override
-    public TableStatistic getTableStatistic(Long tableId, Long partitionId) {
-        return rowCountStats.get(tableId);
+    public Map<Long, TableStatistic> getTableStatistics(Long tableId, Collection<Partition> partitions) {
+        return partitions.stream().collect(Collectors.toMap(Partition::getId, p -> rowCountStats.get(tableId)));
     }
 
     @Override

--- a/fe/fe-core/src/test/java/com/starrocks/statistic/StatisticExecutorTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/statistic/StatisticExecutorTest.java
@@ -18,8 +18,8 @@ import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.starrocks.catalog.Database;
 import com.starrocks.catalog.OlapTable;
-import com.starrocks.common.AnalysisException;
 import com.starrocks.server.GlobalStateMgr;
+import com.starrocks.sql.analyzer.SemanticException;
 import com.starrocks.sql.plan.PlanTestBase;
 import com.starrocks.thrift.TStatisticData;
 import org.junit.Assert;
@@ -40,7 +40,7 @@ public class StatisticExecutorTest extends PlanTestBase {
                 LocalDateTime.of(2020, 1, 1, 1, 1, 1),
                 Maps.newHashMap()));
 
-        Assert.assertThrows(AnalysisException.class,
+        Assert.assertThrows(SemanticException.class,
                 () -> statisticExecutor.queryStatisticSync(
                         StatisticUtils.buildConnectContext(), db.getId(), olapTable.getId(), Lists.newArrayList("foo", "bar")));
     }

--- a/fe/fe-core/src/test/java/com/starrocks/statistic/StatisticsExecutorTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/statistic/StatisticsExecutorTest.java
@@ -138,19 +138,15 @@ public class StatisticsExecutorTest extends PlanTestBase {
             public List<TStatisticData> executeStatisticDQL(ConnectContext context, String sql) {
                 Assert.assertEquals(
                         "SELECT cast(6 as INT), column_name, sum(row_count), cast(sum(data_size) as bigint), " +
-                                "hll_union_agg(ndv), sum(null_count),  cast(max(cast(max as int(11))) as string), " +
-                                "cast(min(cast(min as int(11))) as string) " +
-                                "FROM external_column_statistics " +
+                                "hll_union_agg(ndv), sum(null_count),  cast(max(cast(max as string)) as string), " +
+                                "cast(min(cast(min as string)) as string) FROM external_column_statistics " +
                                 "WHERE table_uuid = \"hive0.partitioned_db.t1.0\" " +
-                                "and column_name = \"c1\" " +
-                                "GROUP BY table_uuid, column_name UNION ALL " +
+                                "and column_name in (\"c2\") GROUP BY table_uuid, column_name UNION ALL " +
                                 "SELECT cast(6 as INT), column_name, sum(row_count), cast(sum(data_size) as bigint), " +
-                                "hll_union_agg(ndv), sum(null_count),  cast(max(cast(max as varchar(1073741824))) as string), " +
-                                "cast(min(cast(min as varchar(1073741824))) as string) " +
-                                "FROM external_column_statistics " +
-                                "WHERE table_uuid = \"hive0.partitioned_db.t1.0\"" +
-                                " and column_name = \"c2\" " +
-                                "GROUP BY table_uuid, column_name", sql);
+                                "hll_union_agg(ndv), sum(null_count),  cast(max(cast(max as bigint)) as string), " +
+                                "cast(min(cast(min as bigint)) as string) " +
+                                "FROM external_column_statistics WHERE table_uuid = \"hive0.partitioned_db.t1.0\"" +
+                                " and column_name in (\"c1\") GROUP BY table_uuid, column_name", sql);
                 return Lists.newArrayList();
             }
         };


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:

1. update statistics cache load partition row_count interface to batch load
2. update statistics cache get column statistics, group by column type to generate sql, to reduce `union all`
3. update statistics log, add `additivity`, don't output to parent logger

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [x] 3.2
  - [x] 3.1
  - [ ] 3.0
  - [ ] 2.5
