### PR TITLE
[BugFix] Support more operator types for text based mv rewrite in subquery

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/rule/TextMatchBasedRewriteRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/rule/TextMatchBasedRewriteRule.java
@@ -19,6 +19,7 @@ import com.google.api.client.util.Lists;
 import com.google.common.base.Joiner;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
 import com.starrocks.analysis.ParseNode;
@@ -45,6 +46,7 @@ import com.starrocks.sql.optimizer.OptimizerTraceUtil;
 import com.starrocks.sql.optimizer.operator.Operator;
 import com.starrocks.sql.optimizer.operator.OperatorType;
 import com.starrocks.sql.optimizer.operator.logical.LogicalOlapScanOperator;
+import com.starrocks.sql.optimizer.operator.logical.LogicalOperator;
 import com.starrocks.sql.optimizer.operator.logical.LogicalProjectOperator;
 import com.starrocks.sql.optimizer.operator.logical.LogicalTopNOperator;
 import com.starrocks.sql.optimizer.operator.pattern.Pattern;
@@ -71,6 +73,13 @@ import static com.starrocks.sql.optimizer.rule.transformation.materialization.Ma
 public class TextMatchBasedRewriteRule extends Rule {
     private static final Logger LOG = LogManager.getLogger(TextMatchBasedRewriteRule.class);
 
+    // Supported rewrite operator types in the sub-query to match with the specified operator types
+    public static final Set<OperatorType> SUPPORTED_REWRITE_OPERATOR_TYPES = ImmutableSet.of(
+            OperatorType.LOGICAL_PROJECT,
+            OperatorType.LOGICAL_UNION,
+            OperatorType.LOGICAL_LIMIT,
+            OperatorType.LOGICAL_FILTER
+    );
     private final ConnectContext connectContext;
     private final StatementBase stmt;
     private final Map<Operator, ParseNode> optToAstMap;
@@ -379,34 +388,21 @@ public class TextMatchBasedRewriteRule extends Rule {
             return children;
         }
 
+        private boolean isReachLimit() {
+            return subQueryTextMatchCount++ > mvSubQueryTextMatchMaxCount;
+        }
+
         @Override
         public OptExpression visit(OptExpression optExpression, ConnectContext connectContext) {
-            List<OptExpression> children = visitChildren(optExpression, connectContext);
-            return OptExpression.create(optExpression.getOp(), children);
-        }
-
-        @Override
-        public OptExpression visitLogicalProject(OptExpression optExpression, ConnectContext connectContext) {
-            if (subQueryTextMatchCount++ > mvSubQueryTextMatchMaxCount) {
-                return optExpression;
-            }
-
-            OptExpression rewritten = doRewrite(optExpression);
-            if (rewritten != null) {
-                return rewritten;
-            }
-            List<OptExpression> children = visitChildren(optExpression, connectContext);
-            return OptExpression.create(optExpression.getOp(), children);
-        }
-
-        @Override
-        public OptExpression visitLogicalUnion(OptExpression optExpression, ConnectContext connectContext) {
-            if (subQueryTextMatchCount++ > mvSubQueryTextMatchMaxCount) {
-                return optExpression;
-            }
-            OptExpression rewritten = doRewrite(optExpression);
-            if (rewritten != null) {
-                return rewritten;
+            LogicalOperator op = (LogicalOperator) optExpression.getOp();
+            if (SUPPORTED_REWRITE_OPERATOR_TYPES.contains(op.getOpType())) {
+                if (isReachLimit()) {
+                    return optExpression;
+                }
+                OptExpression rewritten = doRewrite(optExpression);
+                if (rewritten != null) {
+                    return rewritten;
+                }
             }
             List<OptExpression> children = visitChildren(optExpression, connectContext);
             return OptExpression.create(optExpression.getOp(), children);

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/transformer/RelationTransformer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/transformer/RelationTransformer.java
@@ -128,6 +128,7 @@ import com.starrocks.sql.optimizer.operator.scalar.SubqueryOperator;
 import com.starrocks.sql.optimizer.operator.stream.LogicalBinlogScanOperator;
 import com.starrocks.sql.optimizer.rewrite.ScalarOperatorRewriter;
 import com.starrocks.sql.optimizer.rewrite.scalar.ReduceCastRule;
+import com.starrocks.sql.optimizer.rule.transformation.materialization.rule.TextMatchBasedRewriteRule;
 import org.apache.commons.lang3.tuple.Triple;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -265,7 +266,9 @@ public class RelationTransformer implements AstVisitor<LogicalPlan, ExpressionMa
 
     @Override
     public LogicalPlan visitSelect(SelectRelation node, ExpressionMapping context) {
-        return new QueryTransformer(columnRefFactory, session, cteContext, inlineView, optToAstMap).plan(node, outer);
+        QueryTransformer queryTransformer = new QueryTransformer(columnRefFactory, session, cteContext, inlineView, optToAstMap);
+        LogicalPlan logicalPlan = queryTransformer.plan(node, outer);
+        return logicalPlan;
     }
 
     @Override
@@ -676,10 +679,9 @@ public class RelationTransformer implements AstVisitor<LogicalPlan, ExpressionMa
 
         builder = addOrderByLimit(builder, node);
 
-        // store opt expression to ast map if sub-query is project or union
+        // store opt expression to ast map if sub-query's type is supported.
         OperatorType operatorType = subQueryOptExpression.getOp().getOpType();
-        if (optToAstMap != null && (operatorType == OperatorType.LOGICAL_PROJECT ||
-                operatorType == OperatorType.LOGICAL_UNION)) {
+        if (optToAstMap != null && TextMatchBasedRewriteRule.SUPPORTED_REWRITE_OPERATOR_TYPES.contains(operatorType)) {
             optToAstMap.put(subQueryOptExpression.getOp(), node.getQueryStatement());
         }
 


### PR DESCRIPTION
## Why I'm doing:

- Query cannot be rewritten by specific mv which only project/union are supported in the subquery before:
```
        String mv = "select user_id, time, bitmap_union(to_bitmap(tag_id)) as a from user_tags group by user_id, time limit 3";
        String query = String.format("select user_id, count(time) from (%s) as t group by user_id limit 3;", mv);
```
## What I'm doing:
- support more operator types in sub-query

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [x] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
