### PR TITLE
[BugFix] delta lake query predicate don't throw exception which used for skip data

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/planner/DeltaLakeScanNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/DeltaLakeScanNode.java
@@ -111,13 +111,14 @@ public class DeltaLakeScanNode extends ScanNode {
         List<Expression> expressions = new ArrayList<>(conjuncts.size());
         ExpressionConverter convertor = new ExpressionConverter(tableSchema);
         for (Expr expr : conjuncts) {
-            Expression filterExpr = convertor.convert(expr);
-            if (filterExpr != null) {
-                try {
+            try {
+                // convert expr to delta expression, some expr can not convert and will throw exception
+                Expression filterExpr = convertor.convert(expr);
+                if (filterExpr != null) {
                     expressions.add(filterExpr);
-                } catch (Exception e) {
-                    LOG.debug("binding to the table schema failed, cannot be pushed down expression: {}", expr.toSql());
                 }
+            } catch (Exception e) {
+                LOG.warn("Failed to convert expr: {}", expr.toSql(), e);
             }
         }
 
@@ -281,6 +282,7 @@ public class DeltaLakeScanNode extends ScanNode {
         HdfsScanNode.setScanOptimizeOptionToThrift(tHdfsScanNode, this);
         HdfsScanNode.setCloudConfigurationToThrift(tHdfsScanNode, cloudConfiguration);
         HdfsScanNode.setMinMaxConjunctsToThrift(tHdfsScanNode, this, this.getScanNodePredicates());
+        HdfsScanNode.setPartitionConjunctsToThrift(tHdfsScanNode, this, this.getScanNodePredicates());
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/planner/HdfsScanNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/HdfsScanNode.java
@@ -221,6 +221,16 @@ public class HdfsScanNode extends ScanNode {
         tHdfsScanNode.setPartition_sql_predicates(partitionSqlPredicate);
     }
 
+    public static void setPartitionConjunctsToThrift(THdfsScanNode tHdfsScanNode, ScanNode scanNode,
+                                                            HDFSScanNodePredicates scanNodePredicates) {
+        List<Expr> partitionConjuncts = scanNodePredicates.getPartitionConjuncts();
+        String partitionSqlPredicate = scanNode.getExplainString(partitionConjuncts);
+        for (Expr expr : partitionConjuncts) {
+            tHdfsScanNode.addToPartition_conjuncts(expr.treeToThrift());
+        }
+        tHdfsScanNode.setPartition_sql_predicates(partitionSqlPredicate);
+    }
+
     public static void setNonPartitionConjunctsToThrift(TPlanNode msg, ScanNode scanNode,
                                                         HDFSScanNodePredicates scanNodePredicates) {
         // put non-partition conjuncts into conjuncts

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/OptExternalPartitionPruner.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/OptExternalPartitionPruner.java
@@ -23,6 +23,7 @@ import com.starrocks.analysis.BinaryType;
 import com.starrocks.analysis.Expr;
 import com.starrocks.analysis.LiteralExpr;
 import com.starrocks.catalog.Column;
+import com.starrocks.catalog.DeltaLakeTable;
 import com.starrocks.catalog.HiveMetaStoreTable;
 import com.starrocks.catalog.IcebergTable;
 import com.starrocks.catalog.PaimonTable;
@@ -342,8 +343,6 @@ public class OptExternalPartitionPruner {
                 partitionKeys.add(new Pair<>(new PartitionKey(), 0L));
             }
 
-
-
             partitionKeys.stream().parallel().forEach(entry -> {
                 PartitionKey key = entry.first;
                 long partitionId = entry.second;
@@ -366,6 +365,15 @@ public class OptExternalPartitionPruner {
                 PartitionKey key = entry.first;
                 long partitionId = entry.second;
                 operator.getScanOperatorPredicates().getIdToPartitionKey().put(partitionId, key);
+            }
+        } else if (table instanceof DeltaLakeTable) {
+            // Init columnToPartitionValuesMap for delta lake, it will be used in classifyConjuncts function
+            // to classify partition conjuncts
+            DeltaLakeTable deltaLakeTable = (DeltaLakeTable) table;
+            List<Column> partitionColumns = deltaLakeTable.getPartitionColumns();
+            for (Column column : partitionColumns) {
+                ColumnRefOperator partitionColumnRefOperator = operator.getColumnReference(column);
+                columnToPartitionValuesMap.put(partitionColumnRefOperator, new ConcurrentSkipListMap<>());
             }
         }
         LOG.debug("Table: {}, partition values map: {}, null partition map: {}", table.getName(),

--- a/fe/fe-core/src/main/java/com/starrocks/sql/plan/PlanFragmentBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/plan/PlanFragmentBuilder.java
@@ -1176,6 +1176,7 @@ public class PlanFragmentBuilder {
                 }
                 deltaLakeScanNode.setupScanRangeLocations(context.getDescTbl());
                 HDFSScanNodePredicates scanNodePredicates = deltaLakeScanNode.getScanNodePredicates();
+                prepareCommonExpr(scanNodePredicates, node.getScanOperatorPredicates(), context);
                 prepareMinMaxExpr(scanNodePredicates, node.getScanOperatorPredicates(), context);
             } catch (AnalysisException e) {
                 LOG.warn("Delta lake scan node get scan range locations failed : " + e);

--- a/test/sql/test_deltalake/R/test_deltalake_catalog
+++ b/test/sql/test_deltalake/R/test_deltalake_catalog
@@ -2,7 +2,7 @@
 create external catalog delta_test_${uuid0} PROPERTIES ("type"="deltalake", "hive.metastore.uris"="${deltalake_catalog_hive_metastore_uris}");
 -- result:
 -- !result
-select * from delta_test_${uuid0}.delta_oss_db.string_col_dict_encode where c3='a' order by c1;;
+select * from delta_test_${uuid0}.delta_oss_db.string_col_dict_encode where c3='a' order by c1;
 -- result:
 1	1	a
 6	2	a
@@ -12,6 +12,30 @@ select * from delta_test_${uuid0}.delta_oss_db.string_col_dict_encode where c3='
 26	2	a
 31	1	a
 36	2	a
+-- !result
+select * from delta_test_${uuid0}.delta_oss_db.delta_lake_data_type where col_struct is null;
+-- result:
+6	600	6000	60000	18.84	18.84956	2024-04-29	2024-04-29 00:00:00	sixth_string	321.98	0	6	[16,17,18]	final_binary_data	None	None
+-- !result
+select col_struct from delta_test_${uuid0}.delta_oss_db.delta_lake_data_type where col_struct is not null;
+-- result:
+{"name":"Alice","sex":"female","age":30}
+{"name":"Bob","sex":"male","age":25}
+{"name":"Charlie","sex":"male","age":35}
+{"name":"Diana","sex":"female","age":28}
+{"name":"Edward","sex":"male","age":40}
+{"name":"Fiona","sex":"female","age":33}
+{"name":null,"sex":null,"age":null}
+-- !result
+select * from delta_test_${uuid0}.delta_oss_db.delta_lake_par_col_boolean where col_boolean = true;
+-- result:
+1	1	1
+2	2	1
+-- !result
+select * from delta_test_${uuid0}.delta_oss_db.delta_lake_par_col_boolean where col_boolean = false;
+-- result:
+3	3	0
+4	4	0
 -- !result
 drop catalog delta_test_${uuid0}
 -- result:

--- a/test/sql/test_deltalake/R/test_deltalake_catalog
+++ b/test/sql/test_deltalake/R/test_deltalake_catalog
@@ -15,7 +15,7 @@ select * from delta_test_${uuid0}.delta_oss_db.string_col_dict_encode where c3='
 -- !result
 select * from delta_test_${uuid0}.delta_oss_db.delta_lake_data_type where col_struct is null;
 -- result:
-6	600	6000	60000	18.84	18.84956	2024-04-29	2024-04-29 00:00:00	sixth_string	321.98	0	6	[16,17,18]	final_binary_data	None	None
+6	600	6000	60000	18.84	18.84956	2024-04-29	2024-04-29 12:00:00	sixth_string	321.98	0	6	[16,17,18]	final_binary_data	None	None
 -- !result
 select col_struct from delta_test_${uuid0}.delta_oss_db.delta_lake_data_type where col_struct is not null;
 -- result:

--- a/test/sql/test_deltalake/T/test_deltalake_catalog
+++ b/test/sql/test_deltalake/T/test_deltalake_catalog
@@ -3,6 +3,17 @@
 create external catalog delta_test_${uuid0} PROPERTIES ("type"="deltalake", "hive.metastore.uris"="${deltalake_catalog_hive_metastore_uris}");
 
 -- only partition column Predicate with runtime filter
-select * from delta_test_${uuid0}.delta_oss_db.string_col_dict_encode where c3='a' order by c1;;
+select * from delta_test_${uuid0}.delta_oss_db.string_col_dict_encode where c3='a' order by c1;
+
+-- test struct column is null
+select * from delta_test_${uuid0}.delta_oss_db.delta_lake_data_type where col_struct is null;
+
+-- test struct column is not null
+select col_struct from delta_test_${uuid0}.delta_oss_db.delta_lake_data_type where col_struct is not null;
+
+-- test partition prune with boolean type
+select * from delta_test_${uuid0}.delta_oss_db.delta_lake_par_col_boolean where col_boolean = true;
+
+select * from delta_test_${uuid0}.delta_oss_db.delta_lake_par_col_boolean where col_boolean = false;
 
 drop catalog delta_test_${uuid0}


### PR DESCRIPTION
## Why I'm doing:
1.  `select * from delta_table where col_struct is null ` will throw exception
2.  `select * from delta_table where col_bool = true ` will has wrong result when col_bool is partition column

## What I'm doing:
1. catch exception when throw excrption by delta sdk
2. add partitionConjuncts for delta table
Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [x] 3.2
  - [x] 3.1
  - [ ] 3.0
  - [ ] 2.5
