### PR TITLE
[BugFix] Fix show routine load when warehouse not exist

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/common/ErrorCode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/ErrorCode.java
@@ -309,12 +309,12 @@ public enum ErrorCode {
     /**
      * 10000 - 10099: warehouse
      */
-    ERR_UNKNOWN_WAREHOUSE(10001, new byte[] {'4', '2', '0', '0', '0'}, "Warehouse '%s' not exist."),
-    ERR_WAREHOUSE_EXISTS(10002, new byte[] {'4', '2', '0', '0', '0'}, "Warehouse '%s' already exists."),
-    ERR_WAREHOUSE_SUSPENDED(10003, new byte[] {'4', '2', '0', '0', '0'}, "Warehouse '%s' has been suspended."),
-    ERR_WAREHOUSE_UNAVAILABLE(10004, new byte[] {'4', '2', '0', '0', '0'}, "Warehouse '%s' is not available."),
+    ERR_UNKNOWN_WAREHOUSE(10001, new byte[] {'4', '2', '0', '0', '0'}, "Warehouse %s not exist."),
+    ERR_WAREHOUSE_EXISTS(10002, new byte[] {'4', '2', '0', '0', '0'}, "Warehouse %s already exists."),
+    ERR_WAREHOUSE_SUSPENDED(10003, new byte[] {'4', '2', '0', '0', '0'}, "Warehouse %s has been suspended."),
+    ERR_WAREHOUSE_UNAVAILABLE(10004, new byte[] {'4', '2', '0', '0', '0'}, "Warehouse %s is not available."),
     ERR_NO_NODES_IN_WAREHOUSE(10005, new byte[] {'4', '2', '0', '0', '0'},
-            "No alive backend or compute node in warehouse '%s'."),
+            "No alive backend or compute node in warehouse %s."),
     ERR_INVALID_WAREHOUSE_NAME(10006, new byte[] {'4', '2', '0', '0', '0'}, "Warehouse name can not be null or empty"),
 
     ERR_NOT_SUPPORTED_STATEMENT_IN_SHARED_NOTHING_MODE(10007, new byte[] {'4', '2', '0', '0', '0'},

--- a/fe/fe-core/src/main/java/com/starrocks/load/routineload/RoutineLoadJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/routineload/RoutineLoadJob.java
@@ -1532,11 +1532,11 @@ public abstract class RoutineLoadJob extends AbstractTxnStateChangeCallback
             row.add(otherMsg);
 
             if (RunMode.getCurrentRunMode() == RunMode.SHARED_DATA) {
-                Warehouse warehouse = GlobalStateMgr.getCurrentState().getWarehouseMgr().getWarehouse(warehouseId);
-                if (warehouse != null) {
+                try {
+                    Warehouse warehouse = GlobalStateMgr.getCurrentState().getWarehouseMgr().getWarehouse(warehouseId);
                     row.add(warehouse.getName());
-                } else {
-                    row.add("");
+                } catch (Exception e) {
+                    row.add(e.getMessage());
                 }
             }
             row.add(getSourceProgressString());

--- a/fe/fe-core/src/main/java/com/starrocks/server/WarehouseManager.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/WarehouseManager.java
@@ -74,7 +74,7 @@ public class WarehouseManager implements Writable {
         try (LockCloseable ignored = new LockCloseable(rwLock.readLock())) {
             Warehouse warehouse = nameToWh.get(warehouseName);
             if (warehouse == null) {
-                ErrorReportException.report(ErrorCode.ERR_UNKNOWN_WAREHOUSE, warehouseName);
+                ErrorReportException.report(ErrorCode.ERR_UNKNOWN_WAREHOUSE, String.format("name: %s", warehouseName));
             }
             return warehouse;
         }
@@ -84,7 +84,7 @@ public class WarehouseManager implements Writable {
         try (LockCloseable ignored = new LockCloseable(rwLock.readLock())) {
             Warehouse warehouse = idToWh.get(warehouseId);
             if (warehouse == null) {
-                ErrorReportException.report(ErrorCode.ERR_UNKNOWN_WAREHOUSE, warehouseId);
+                ErrorReportException.report(ErrorCode.ERR_UNKNOWN_WAREHOUSE, String.format("id: %d", warehouseId));
             }
             return warehouse;
         }
@@ -111,7 +111,7 @@ public class WarehouseManager implements Writable {
     public List<Long> getAllComputeNodeIds(long warehouseId) {
         Warehouse warehouse = idToWh.get(warehouseId);
         if (warehouse == null) {
-            ErrorReportException.report(ErrorCode.ERR_UNKNOWN_WAREHOUSE, warehouseId);
+            ErrorReportException.report(ErrorCode.ERR_UNKNOWN_WAREHOUSE, String.format("id: %d", warehouseId));
         }
 
         try {
@@ -126,7 +126,7 @@ public class WarehouseManager implements Writable {
     public List<Long> getAllComputeNodeIds(String warehouseName) {
         Warehouse warehouse = nameToWh.get(warehouseName);
         if (warehouse == null) {
-            ErrorReportException.report(ErrorCode.ERR_UNKNOWN_WAREHOUSE, warehouseName);
+            ErrorReportException.report(ErrorCode.ERR_UNKNOWN_WAREHOUSE, String.format("name: %s", warehouseName));
         }
 
         try {
@@ -141,7 +141,7 @@ public class WarehouseManager implements Writable {
     public Long getComputeNodeId(Long warehouseId, LakeTablet tablet) {
         Warehouse warehouse = idToWh.get(warehouseId);
         if (warehouse == null) {
-            ErrorReportException.report(ErrorCode.ERR_UNKNOWN_WAREHOUSE, warehouseId);
+            ErrorReportException.report(ErrorCode.ERR_UNKNOWN_WAREHOUSE, String.format("id: %d", warehouseId));
         }
 
         try {
@@ -165,7 +165,7 @@ public class WarehouseManager implements Writable {
     public Long getComputeNodeId(String warehouseName, LakeTablet tablet) {
         Warehouse warehouse = nameToWh.get(warehouseName);
         if (warehouse == null) {
-            ErrorReportException.report(ErrorCode.ERR_UNKNOWN_WAREHOUSE, warehouseName);
+            ErrorReportException.report(ErrorCode.ERR_UNKNOWN_WAREHOUSE, String.format("name: %s", warehouseName));
         }
 
         try {
@@ -207,7 +207,7 @@ public class WarehouseManager implements Writable {
         Long computeNodeId = getComputeNodeId(warehouseId, tablet);
         if (computeNodeId == null) {
             Warehouse warehouse = idToWh.get(warehouseId);
-            ErrorReportException.report(ErrorCode.ERR_NO_NODES_IN_WAREHOUSE, warehouse.getName());
+            ErrorReportException.report(ErrorCode.ERR_NO_NODES_IN_WAREHOUSE, String.format("name: %s", warehouse.getName()));
         }
         Preconditions.checkNotNull(computeNodeId);
         return GlobalStateMgr.getCurrentState().getNodeMgr().getClusterInfo().getBackendOrComputeNode(computeNodeId);

--- a/fe/fe-core/src/test/java/com/starrocks/load/routineload/RoutineLoadJobTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/load/routineload/RoutineLoadJobTest.java
@@ -257,7 +257,7 @@ public class RoutineLoadJobTest {
                 warehouseManager.getWarehouse(0L);
                 result = new DefaultWarehouse(0, "default_warehouse");
                 warehouseManager.getWarehouse(1L);
-                result = new Exception("Warehouse '1' not exist");
+                result = new Exception("Warehouse id: 1 not exist");
             }
         };
 
@@ -269,7 +269,7 @@ public class RoutineLoadJobTest {
 
         routineLoadJob.setWarehouseId(1L);
         showInfo = routineLoadJob.getShowInfo();
-        Assert.assertEquals("Warehouse '1' not exist", showInfo.get(20));
+        Assert.assertEquals("Warehouse id: 1 not exist", showInfo.get(20));
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/server/WarehouseManagerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/server/WarehouseManagerTest.java
@@ -1,0 +1,39 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.server;
+
+import com.starrocks.common.ErrorReportException;
+import com.starrocks.common.ExceptionChecker;
+import org.junit.Test;
+
+public class WarehouseManagerTest {
+
+    @Test
+    public void testWarehouseNotExist() {
+        WarehouseManager mgr = new WarehouseManager();
+        ExceptionChecker.expectThrowsWithMsg(ErrorReportException.class, "Warehouse name: a not exist.",
+                () -> mgr.getWarehouse("a"));
+        ExceptionChecker.expectThrowsWithMsg(ErrorReportException.class, "Warehouse id: 1 not exist.",
+                () -> mgr.getWarehouse(1L));
+        ExceptionChecker.expectThrowsWithMsg(ErrorReportException.class, "Warehouse name: a not exist.",
+                () -> mgr.getAllComputeNodeIds("a"));
+        ExceptionChecker.expectThrowsWithMsg(ErrorReportException.class, "Warehouse id: 1 not exist.",
+                () -> mgr.getAllComputeNodeIds(1L));
+        ExceptionChecker.expectThrowsWithMsg(ErrorReportException.class, "Warehouse name: a not exist.",
+                () -> mgr.getComputeNodeId("a", null));
+        ExceptionChecker.expectThrowsWithMsg(ErrorReportException.class, "Warehouse id: 1 not exist.",
+                () -> mgr.getComputeNodeId(1L, null));
+    }
+}


### PR DESCRIPTION
## Why I'm doing:
```
mysql> show routine load from kafka_test\G
ERROR 10001 (42000): Warehouse '10204' not exist.
```

## What I'm doing:
```
mysql> show routine load from kafka_test\G
*************************** 1. row ***************************
                  Id: 10554
                Name: label0
          CreateTime: 2024-04-18 17:55:54
           PauseTime: NULL
             EndTime: NULL
              DbName: kafka_test
           TableName: lineorder
               State: NEED_SCHEDULE
      DataSourceType: KAFKA
      CurrentTaskNum: 0                                                                                                                                                                                                                                                                                                                                                            JobProperties: {"partitions":"*","rowDelimiter":"\t","partial_update":"false","columnToColumnExpr":"*","maxBatchIntervalS":"10","partial_update_mode":"null","whereExpr":"*","timezone":"Asia/Shanghai","format":"csv","columnSeparator":"'|'","log_rejected_record_num":"0","taskTimeoutSecond":"60","json_root":"","maxFilterRatio":"1.0","strict_mode":"false","js
onpaths":"","taskConsumeSecond":"15","desireTaskConcurrentNum":"5","maxErrorNum":"0","strip_outer_array":"false","currentTaskConcurrentNum":"0","maxBatchRows":"200000"}
DataSourceProperties: {"topic":"wyb_test","currentKafkaPartitions":"0","brokerList":"127.0.0.1:9093"}
    CustomProperties: {"group.id":"label0_b989144b-2656-41c5-b4be-d975f7ef843f"}
           Statistic: {"receivedBytes":0,"errorRows":0,"committedTaskNum":0,"loadedRows":0,"loadRowsRate":0,"abortedTaskNum":0,"totalRows":0,"unselectedRows":0,"receivedBytesRate":0,"taskExecuteTimeMs":1}
            Progress: {"0":"OFFSET_END"}
   TimestampProgress: {}
ReasonOfStateChanged:
        ErrorLogUrls:
         TrackingSQL:
            OtherMsg:
           Warehouse: Warehouse id: 10204 not exist.
LatestSourcePosition: {}
1 row in set (0.01 sec)
```

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
