### PR TITLE
[BugFix] Fix compaction check rows failed

### DIFF
--- a/be/src/exprs/json_functions.cpp
+++ b/be/src/exprs/json_functions.cpp
@@ -421,16 +421,21 @@ Status JsonFunctions::native_json_path_prepare(FunctionContext* context, Functio
         return Status::OK();
     }
 
-    auto* state = new NativeJsonState();
-    state->init_flat = false;
-    context->set_function_state(scope, state);
     if (context->is_notnull_constant_column(1)) {
         auto path_column = context->get_constant_column(1);
         Slice path_value = ColumnHelper::get_const_value<TYPE_VARCHAR>(path_column);
         auto json_path = JsonPath::parse(path_value);
         RETURN_IF(!json_path.ok(), json_path.status());
+
+        auto* state = new NativeJsonState();
         state->json_path.reset(std::move(json_path.value()));
+        state->init_flat = false;
+        context->set_function_state(scope, state);
         VLOG(10) << "prepare json path: " << path_value;
+    } else {
+        auto* state = new NativeJsonState();
+        state->init_flat = false;
+        context->set_function_state(scope, state);
     }
     return Status::OK();
 }

--- a/be/test/exprs/flat_json_functions_test.cpp
+++ b/be/test/exprs/flat_json_functions_test.cpp
@@ -645,7 +645,12 @@ INSTANTIATE_TEST_SUITE_P(FlatJsonPathDeriver, FlatJsonDeriverPaths,
                         std::vector<std::string> {"k3", "k4", "k1", "k2"}, 
                         std::vector<LogicalType> {TYPE_BIGINT, TYPE_DOUBLE, TYPE_VARCHAR, TYPE_JSON}),
         std::make_tuple(R"({ "k1": 1, "k2": "a" })", R"({ "k1": 3, "k2": null })", std::vector<std::string> {"k1", "k2"}, std::vector<LogicalType> {TYPE_BIGINT, TYPE_JSON}),
-        std::make_tuple(R"({ "k1": 1, "k2": 2 })", R"({ "k1": 3, "k2": 4 })", std::vector<std::string> {"k1", "k2"}, std::vector<LogicalType> {TYPE_BIGINT, TYPE_BIGINT})
+        std::make_tuple(R"({ "k1": 1, "k2": 2 })", R"({ "k1": 3, "k2": 4 })", std::vector<std::string> {"k1", "k2"}, std::vector<LogicalType> {TYPE_BIGINT, TYPE_BIGINT}),
+
+        std::make_tuple(R"({ "k1": "v1", "k1": "v2", "k1": "v3", "k4": 1.2344 })",  
+                        R"({ "k1": "v1", "k2": "v1", "k3": "v1", "k4": 1.2344 })",  
+                        std::vector<std::string> {"k4"}, 
+                        std::vector<LogicalType> {TYPE_DOUBLE})
 
 ));
 // clang-format on


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:

* fix DCHECK rows error when compaction
* fix same key in json take duplicate compute hits, like: `{"a": "v1", "a": "v2", "a": v3}`
* fix json_exists UT leak memory

Fixes https://github.com/StarRocks/StarRocksTest/issues/7211

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
