### PR TITLE
[Enhancement] Default enable big broker load profile

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/common/Config.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/Config.java
@@ -2585,6 +2585,14 @@ public class Config extends ConfigBase {
     public static String profile_info_format = "default";
 
     /**
+     * When the session variable `enable_profile` is set to `false` and `big_query_profile_threshold` is set to 0,
+     * the amount of time taken by a load exceeds the default_big_load_profile_threshold_second,
+     * a profile is generated for that load.
+     */
+    @ConfField(mutable = true)
+    public static long default_big_load_profile_threshold_second = 300;
+
+    /**
      * Max number of roles that can be granted to user including all direct roles and all parent roles
      * Used in new RBAC framework after 3.0 released
      **/

--- a/fe/fe-core/src/main/java/com/starrocks/common/util/ProfileManager.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/util/ProfileManager.java
@@ -175,6 +175,7 @@ public class ProfileManager implements MemoryTrackable {
         ProfileElement element = createElement(profile.getChildList().get(0).first, profileString);
         element.plan = plan;
         String queryId = element.infoStrings.get(ProfileManager.QUERY_ID);
+        String queryType = element.infoStrings.get(ProfileManager.QUERY_TYPE);
         // check when push in, which can ensure every element in the list has QUERY_ID column,
         // so there is no need to check when remove element from list.
         if (Strings.isNullOrEmpty(queryId)) {
@@ -184,9 +185,16 @@ public class ProfileManager implements MemoryTrackable {
 
         writeLock.lock();
         try {
-            profileMap.put(queryId, element);
-            if (profileMap.size() >= Config.profile_info_reserved_num) {
-                profileMap.remove(profileMap.keySet().iterator().next());
+            if (queryType != null && queryType.equals("Load")) {
+                loadProfileMap.put(queryId, element);
+                if (loadProfileMap.size() > Config.load_profile_info_reserved_num) {
+                    loadProfileMap.remove(loadProfileMap.keySet().iterator().next());
+                }
+            } else {
+                profileMap.put(queryId, element);
+                if (profileMap.size() > Config.profile_info_reserved_num) {
+                    profileMap.remove(profileMap.keySet().iterator().next());
+                }
             }
         } finally {
             writeLock.unlock();
@@ -195,26 +203,12 @@ public class ProfileManager implements MemoryTrackable {
         return profileString;
     }
 
-    public void pushLoadProfile(RuntimeProfile profile) {
-        String profileString = generateProfileString(profile);
-
-        ProfileElement element = createElement(profile.getChildList().get(0).first, profileString);
-        String loadId = element.infoStrings.get(ProfileManager.QUERY_ID);
-        // check when push in, which can ensure every element in the list has QUERY_ID column,
-        // so there is no need to check when remove element from list.
-        if (Strings.isNullOrEmpty(loadId)) {
-            LOG.warn("the key or value of Map is null, "
-                    + "may be forget to insert 'QUERY_ID' column into infoStrings");
-        }
-
-        writeLock.lock();
+    public boolean hasProfile(String queryId) {
+        readLock.lock();
         try {
-            loadProfileMap.put(loadId, element);
-            if (loadProfileMap.size() >= Config.load_profile_info_reserved_num) {
-                loadProfileMap.remove(loadProfileMap.keySet().iterator().next());
-            }
+            return profileMap.containsKey(queryId) || loadProfileMap.containsKey(queryId);
         } finally {
-            writeLock.unlock();
+            readLock.unlock();
         }
     }
 
@@ -223,6 +217,14 @@ public class ProfileManager implements MemoryTrackable {
         readLock.lock();
         try {
             for (ProfileElement element : profileMap.values()) {
+                Map<String, String> infoStrings = element.infoStrings;
+                List<String> row = Lists.newArrayList();
+                for (String str : PROFILE_HEADERS) {
+                    row.add(infoStrings.get(str));
+                }
+                result.add(0, row);
+            }
+            for (ProfileElement element : loadProfileMap.values()) {
                 Map<String, String> infoStrings = element.infoStrings;
                 List<String> row = Lists.newArrayList();
                 for (String str : PROFILE_HEADERS) {
@@ -241,6 +243,16 @@ public class ProfileManager implements MemoryTrackable {
         try {
             loadProfileMap.remove(queryId);
             profileMap.remove(queryId);
+        } finally {
+            writeLock.unlock();
+        }
+    }
+
+    public void clearProfiles() {
+        writeLock.lock();
+        try {
+            loadProfileMap.clear();
+            profileMap.clear();
         } finally {
             writeLock.unlock();
         }
@@ -268,7 +280,7 @@ public class ProfileManager implements MemoryTrackable {
     public ProfileElement getProfileElement(String queryId) {
         readLock.lock();
         try {
-            return profileMap.get(queryId);
+            return profileMap.get(queryId) == null ? loadProfileMap.get(queryId) : profileMap.get(queryId);
         } finally {
             readLock.unlock();
         }
@@ -279,6 +291,7 @@ public class ProfileManager implements MemoryTrackable {
         readLock.lock();
         try {
             result.addAll(profileMap.values());
+            result.addAll(loadProfileMap.values());
         } finally {
             readLock.unlock();
         }

--- a/fe/fe-core/src/main/java/com/starrocks/common/util/RuntimeProfileParser.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/util/RuntimeProfileParser.java
@@ -17,6 +17,8 @@ import com.google.common.base.Preconditions;
 import com.google.common.collect.Lists;
 import com.starrocks.thrift.TUnit;
 import org.apache.commons.lang3.StringUtils;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 import java.io.BufferedReader;
 import java.io.IOException;
@@ -30,6 +32,7 @@ import java.util.regex.Pattern;
  * This class is used for reconstruct RuntimeProfile from plain text
  */
 public class RuntimeProfileParser {
+    private static final Logger LOG = LogManager.getLogger(RuntimeProfileParser.class);
     private static final Pattern NONE_COUNTER_PATTERN =
             Pattern.compile("^- (.*?): $");
     private static final Pattern BYTE_COUNTER_PATTERN =
@@ -50,6 +53,7 @@ public class RuntimeProfileParser {
             Pattern.compile("^- (.*?)$");
 
     public static RuntimeProfile parseFrom(String content) {
+        LOG.debug("Parse runtime profile from content: {}", content);
         BufferedReader bufferedReader = new BufferedReader(new StringReader(content));
         // (profile, profileIndent, counterStack(name, counter, counterIndent))
         LinkedList<ProfileTuple> profileStack = Lists.newLinkedList();
@@ -109,6 +113,7 @@ public class RuntimeProfileParser {
                 }
             }
         } catch (IOException e) {
+            LOG.error("Failed to parse runtime profile from content: {}, {}", content, DebugUtil.getStackTrace(e));
             return null;
         }
 

--- a/fe/fe-core/src/main/java/com/starrocks/load/loadv2/LoadLoadingTask.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/loadv2/LoadLoadingTask.java
@@ -186,7 +186,6 @@ public class LoadLoadingTask extends LoadTask {
         summaryProfile.addInfoString(ProfileManager.USER, context.getQualifiedUser());
         summaryProfile.addInfoString(ProfileManager.DEFAULT_DB, context.getDatabase());
         summaryProfile.addInfoString(ProfileManager.SQL_STATEMENT, originStmt.originStmt);
-        summaryProfile.addInfoString("Memory Limit", DebugUtil.getPrettyStringBytes(execMemLimit));
         summaryProfile.addInfoString("Timeout", DebugUtil.getPrettyStringMs(timeoutS * 1000));
         summaryProfile.addInfoString("Strict Mode", String.valueOf(strictMode));
         summaryProfile.addInfoString("Partial Update", String.valueOf(partialUpdate));
@@ -234,13 +233,14 @@ public class LoadLoadingTask extends LoadTask {
             long beginTimeInNanoSecond = TimeUtils.getStartTime();
             actualExecute(curCoordinator);
 
-            if (context.getSessionVariable().isEnableProfile()) {
+            if (context.getSessionVariable().isEnableProfile()
+                    || ProfileManager.getInstance().hasProfile(DebugUtil.printId(loadId))) {
                 RuntimeProfile profile = buildFinishedTopLevelProfile();
 
                 curCoordinator.getQueryProfile().getCounterTotalTime()
                         .setValue(TimeUtils.getEstimatedTime(beginTimeInNanoSecond));
                 curCoordinator.collectProfileSync();
-                profile.addChild(curCoordinator.buildQueryProfile(context.needMergeProfile()));
+                profile.addChild(curCoordinator.buildQueryProfile(true));
 
                 StringBuilder builder = new StringBuilder();
                 profile.prettyPrint(builder, "");

--- a/fe/fe-core/src/main/java/com/starrocks/load/streamload/StreamLoadTask.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/streamload/StreamLoadTask.java
@@ -1073,7 +1073,7 @@ public class StreamLoadTask extends AbstractTxnStateChangeCallback
             }
         }
 
-        ProfileManager.getInstance().pushLoadProfile(profile);
+        ProfileManager.getInstance().pushProfile(null, profile);
     }
 
     public void setLoadState(long loadBytes, long loadRows, long filteredRows, long unselectedRows,

--- a/fe/fe-core/src/main/java/com/starrocks/qe/DefaultCoordinator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/DefaultCoordinator.java
@@ -530,6 +530,13 @@ public class DefaultCoordinator extends Coordinator {
             if (!jobSpec.isEnablePipeline()) {
                 jobSpec.getQueryOptions().setEnable_profile(true);
             }
+            if (jobSpec.isBrokerLoad() && jobSpec.getQueryOptions().getBig_query_profile_threshold() == 0) {
+                jobSpec.getQueryOptions().setBig_query_profile_threshold(Config.default_big_load_profile_threshold_second * 1000);
+            }
+            // runtime load profile does not need to report too frequently
+            if (jobSpec.getQueryOptions().getRuntime_profile_report_interval() < 30) {
+                jobSpec.getQueryOptions().setRuntime_profile_report_interval(30);
+            }
             List<Long> relatedBackendIds = coordinatorPreprocessor.getWorkerProvider().getSelectedWorkerIds();
             GlobalStateMgr.getCurrentState().getLoadMgr().initJobProgress(
                     jobSpec.getLoadJobId(), jobSpec.getQueryId(), executionDAG.getInstanceIds(), relatedBackendIds);

--- a/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/dag/JobSpec.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/dag/JobSpec.java
@@ -480,6 +480,10 @@ public class JobSpec {
         return queryOptions.getLoad_job_type() == TLoadJobType.STREAM_LOAD;
     }
 
+    public boolean isBrokerLoad() {
+        return queryOptions.getLoad_job_type() == TLoadJobType.BROKER;
+    }
+
     public String getPlanProtocol() {
         return planProtocol;
     }

--- a/fe/fe-core/src/test/java/com/starrocks/common/util/ProfileManagerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/common/util/ProfileManagerTest.java
@@ -1,0 +1,121 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package com.starrocks.common.util;
+
+import com.starrocks.common.Config;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class ProfileManagerTest {
+
+    public RuntimeProfile buildRuntimeProfile(String queryId, String queryType) {
+        RuntimeProfile profile = new RuntimeProfile("");
+        RuntimeProfile summaryProfile = new RuntimeProfile("Summary");
+        summaryProfile.addInfoString(ProfileManager.QUERY_ID, queryId);
+        summaryProfile.addInfoString(ProfileManager.QUERY_TYPE, queryType);
+
+        profile.addChild(summaryProfile);
+
+        return profile;
+    }
+
+    @Test
+    public void testSingleton() {
+        ProfileManager instance1 = ProfileManager.getInstance();
+        ProfileManager instance2 = ProfileManager.getInstance();
+        assertSame(instance1, instance2, "ProfileManager should be singleton");
+    }
+
+    @Test
+    public void testProfileAddAndGet() {
+        ProfileManager manager = ProfileManager.getInstance();
+        RuntimeProfile profile = buildRuntimeProfile("123", "Query");
+        manager.pushProfile(null, profile);
+
+        String retrievedProfile = manager.getProfile("123");
+        assertNotNull(retrievedProfile, "Retrieved profile should not be null");
+        assertTrue(manager.hasProfile("123"), "Profile should exist");
+
+        assertEquals(1, manager.getAllProfileElements().size());
+
+        assertNotNull(manager.getProfileElement("123"), "Profile element should not be null");
+
+        manager.clearProfiles();
+    }
+
+    @Test
+    public void testRemoveProfile() {
+        ProfileManager manager = ProfileManager.getInstance();
+        RuntimeProfile profile = buildRuntimeProfile("124", "Load");
+        manager.pushProfile(null, profile);
+
+        String retrievedProfile = manager.getProfile("124");
+        assertNotNull(retrievedProfile, "Retrieved profile should not be null");
+
+        manager.removeProfile("124");
+        assertNull(manager.getProfile("124"), "Profile should be removed");
+        assertFalse(manager.hasProfile("124"), "Profile should not exist");
+    }
+
+    @Test
+    public void testGetAllQueries() {
+        ProfileManager manager = ProfileManager.getInstance();
+        assertTrue(manager.getAllProfileElements().isEmpty());
+
+        RuntimeProfile profile1 = buildRuntimeProfile("123", "Query");
+        manager.pushProfile(null, profile1);
+
+        RuntimeProfile profile2 = buildRuntimeProfile("124", "Load");
+        manager.pushProfile(null, profile2);
+
+        assertEquals(2, manager.getAllQueries().size());
+
+        manager.clearProfiles();
+    }
+
+    @Test
+    public void testPushExceed() {
+        ProfileManager manager = ProfileManager.getInstance();
+        assertTrue(manager.getAllProfileElements().isEmpty());
+
+        Config.profile_info_reserved_num = 1;
+
+        RuntimeProfile profile1 = buildRuntimeProfile("123", "Query");
+        manager.pushProfile(null, profile1);
+
+        RuntimeProfile profile2 = buildRuntimeProfile("124", "Query");
+        manager.pushProfile(null, profile2);
+
+        assertEquals(1, manager.getAllQueries().size());
+
+        Config.load_profile_info_reserved_num = 1;
+
+        profile1 = buildRuntimeProfile("125", "Load");
+        manager.pushProfile(null, profile1);
+
+        profile2 = buildRuntimeProfile("126", "Load");
+        manager.pushProfile(null, profile2);
+
+        assertEquals(2, manager.getAllQueries().size());
+
+        manager.clearProfiles();
+    }
+}
+


### PR DESCRIPTION
## Why I'm doing:
Broker load usually has long runtimes and often encounters performance issues that need to be identified. Therefore, automatically enabling profiling in conjunction with runtime profiles can greatly enhance the efficiency of problem identification.
For insert into, we have not enabled profiling for big queries by default because we have encountered many complex insert into execution plans in customer scenarios that consume a significant amount of FE memory. Broker load does not have this issue as its execution plans are simple and include concurrency control.

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [x] 3.2
  - [x] 3.1
  - [ ] 3.0
  - [ ] 2.5
