### PR TITLE
[UT] Fix test_insert_partial_update failure

### DIFF
--- a/test/sql/test_insert_empty/R/test_insert_partial_update
+++ b/test/sql/test_insert_empty/R/test_insert_partial_update
@@ -2,12 +2,15 @@
 create table test (pk bigint NOT NULL, v0 string not null default 'defaultv0', v1 int not null default '100001')
 primary KEY (pk) DISTRIBUTED BY HASH(pk) BUCKETS 1 PROPERTIES("replication_num" = "1");
 -- result:
+[]
 -- !result
 insert into test values(1, 'v0', 1), (2, 'v2', 2);
 -- result:
+[]
 -- !result
 insert into test values(2, 'v2_2', default);
 -- result:
+[]
 -- !result
 select * from test order by pk;
 -- result:
@@ -16,9 +19,11 @@ select * from test order by pk;
 -- !result
 insert into test values(1, 'v0', 1), (2, 'v2', 2);
 -- result:
+[]
 -- !result
 insert into test (pk, v1) values(1, 11);
 -- result:
+[]
 -- !result
 select * from test order by pk;
 -- result:
@@ -28,12 +33,15 @@ select * from test order by pk;
 create table test2 (pk bigint NOT NULL, v0 string not null, v1 int not null default '100001')
 primary KEY (pk) DISTRIBUTED BY HASH(pk) BUCKETS 1 PROPERTIES("replication_num" = "1");
 -- result:
+[]
 -- !result
 insert into test2 values(1, 'v0', 1), (2, 'v2', 2);
 -- result:
+[]
 -- !result
 insert into test2 (pk, v1) values(1, 11), (3, 3);
 -- result:
+[]
 -- !result
 select * from test2 order by pk;
 -- result:
@@ -44,12 +52,15 @@ select * from test2 order by pk;
 create table test3 (pk bigint NOT NULL, v0 string not null, v1 int not null default '100001', v2 int as cast(v1 + 1 as int))
 primary KEY (pk) DISTRIBUTED BY HASH(pk) BUCKETS 1 PROPERTIES("replication_num" = "1");
 -- result:
+[]
 -- !result
 insert into test3 values(1, 'v0', 1), (2, 'v2', 2);
 -- result:
+[]
 -- !result
 insert into test3 (pk, v1) values(1, 11), (3, 3);
 -- result:
+[]
 -- !result
 select * from test3 order by pk;
 -- result:
@@ -60,10 +71,13 @@ select * from test3 order by pk;
 create table test4 (pk bigint NOT NULL, v0 string not null, v1 int not null default '0')
 primary KEY (pk) DISTRIBUTED BY HASH(pk) BUCKETS 1 order by (v1) PROPERTIES("replication_num" = "1");
 -- result:
+[]
 -- !result
 insert into test4 values(1, 'v0', 1), (2, 'v2', 2);
 -- result:
+[]
 -- !result
 insert into test4 (pk, v0) values(1, 'v0_1'), (3, 'v3_1');
 -- result:
+[REGEX].*table with sort key do not support partial update.*
 -- !result


### PR DESCRIPTION
## Why I'm doing:

Fix test failure:
```
 ℹ️ - SQL-Tester Report (Release centos7) - 583 tests run, 582 passed, 0 skipped, 1 failed.
     🧪 - TestSQLCases | True is not false : sql result not match: actual with E(E: (5025, '172.20.176.157: table with sort key do not support partial update'))
```

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [x] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
