### PR TITLE
[Enhancement] `files()` `csv.trim_space` error report

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/TableFunctionTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/TableFunctionTable.java
@@ -312,7 +312,7 @@ public class TableFunctionTable extends Table {
             } else if (property.equalsIgnoreCase("false")) {
                 csvTrimSpace = false;
             } else {
-                throw new DdlException("illegal value of csv.skip_header: " + property + ", only true/false allowed");
+                throw new DdlException("illegal value of csv.trim_space: " + property + ", only true/false allowed");
             }
         }
     }

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/TableFunctionTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/TableFunctionTable.java
@@ -306,7 +306,14 @@ public class TableFunctionTable extends Table {
         }
 
         if (properties.containsKey(PROPERTY_CSV_TRIM_SPACE)) {
-            csvTrimSpace = Boolean.parseBoolean(properties.get(PROPERTY_CSV_TRIM_SPACE));
+            String property = properties.get(PROPERTY_CSV_TRIM_SPACE);
+            if (property.equalsIgnoreCase("true")) {
+                csvTrimSpace = true;
+            } else if (property.equalsIgnoreCase("false")) {
+                csvTrimSpace = false;
+            } else {
+                throw new DdlException("illegal value of csv.skip_header: " + property + ", only true/false allowed");
+            }
         }
     }
 

--- a/fe/fe-core/src/test/java/com/starrocks/catalog/TableFunctionTableTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/TableFunctionTableTest.java
@@ -229,7 +229,7 @@ public class TableFunctionTableTest {
         properties.put("csv.trim_space", "FALS");
 
         ExceptionChecker.expectThrowsWithMsg(DdlException.class,
-                "illegal value of csv.skip_header: FALS, only true/false allowed",
+                "illegal value of csv.trim_space: FALS, only true/false allowed",
                 () -> new TableFunctionTable(properties));
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/catalog/TableFunctionTableTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/TableFunctionTableTest.java
@@ -212,4 +212,24 @@ public class TableFunctionTableTest {
                     () -> new TableFunctionTable(properties));
         }
     }
+
+    @Test
+    public void testIllegalCSVTrimSpace() throws DdlException {
+        new MockUp<HdfsUtil>() {
+            @Mock
+            public void parseFile(String path, BrokerDesc brokerDesc, List<TBrokerFileStatus> fileStatuses) throws UserException {
+            }
+        };
+
+        Map<String, String> properties = newProperties();
+        properties.put("csv.trim_space", "FALSE");
+
+        ExceptionChecker.expectThrowsNoException(() -> new TableFunctionTable(properties));
+
+        properties.put("csv.trim_space", "FALS");
+
+        ExceptionChecker.expectThrowsWithMsg(DdlException.class,
+                "illegal value of csv.skip_header: FALS, only true/false allowed",
+                () -> new TableFunctionTable(properties));
+    }
 }


### PR DESCRIPTION
## Why I'm doing:
The `csv.trim_space` property of `files()` should be in bool type.
Now, the `files()` will not report any error even if we set `csv.trim_space` as any illegal string `a`.
## What I'm doing:
This PR fixes this issue. When an illegal values is set, `Access storage error. Error message: illegal value of csv.trim_space: a, only true/false allowed` will be reported.
Fixes https://github.com/StarRocks/starrocks/issues/42800

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
