### PR TITLE
[BugFix] [UT] Distinguish TaskRun by using unique taskRunId

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/TaskManager.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/TaskManager.java
@@ -784,11 +784,7 @@ public class TaskManager implements MemoryTrackable {
                         statusChange.getQueryId(), taskId);
                 return;
             }
-            // remove it from pending task queue
-            taskRunScheduler.removePendingTaskRun(pendingTaskRun);
-
             TaskRunStatus status = pendingTaskRun.getStatus();
-
             if (toStatus == Constants.TaskRunState.RUNNING) {
                 if (status.getQueryId().equals(statusChange.getQueryId())) {
                     status.setState(Constants.TaskRunState.RUNNING);
@@ -811,6 +807,8 @@ public class TaskManager implements MemoryTrackable {
                 status.setFinishTime(statusChange.getFinishTime());
                 taskRunManager.getTaskRunHistory().addHistory(status);
             }
+            // remove it from pending task queue
+            taskRunScheduler.removePendingTaskRun(pendingTaskRun);
         } else if (fromStatus == Constants.TaskRunState.RUNNING &&
                 (toStatus == Constants.TaskRunState.SUCCESS || toStatus == Constants.TaskRunState.FAILED)) {
             // NOTE: TaskRuns before the fe restart will be replayed in `replayCreateTaskRun` which

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/TaskRun.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/TaskRun.java
@@ -349,6 +349,26 @@ public class TaskRun implements Comparable<TaskRun> {
         }
     }
 
+    /**
+     * Check the taskRun is equal task to the given taskRun which means they have the same taskRunId and the same task.
+     */
+    public boolean isEqualTask(TaskRun o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null) {
+            return false;
+        }
+        if (task.getDefinition() == null) {
+            return false;
+        }
+        return this.taskId == o.getTaskId() &&
+                this.task.getDefinition().equals(o.getTask().getDefinition());
+    }
+
+    /**
+     * TaskRun is equal if they have the same taskRunId and the same task.
+     */
     @Override
     public boolean equals(Object o) {
         if (this == o) {
@@ -357,13 +377,8 @@ public class TaskRun implements Comparable<TaskRun> {
         if (o == null || getClass() != o.getClass()) {
             return false;
         }
-        if (task.getDefinition() == null) {
-            return false;
-        }
         TaskRun taskRun = (TaskRun) o;
-        return this.taskId == taskRun.getTaskId() &&
-                this.task.getDefinition().equals(taskRun.getTask().getDefinition()) &&
-                this.taskRunId.equals(taskRun.getTaskRunId());
+        return this.taskRunId.equals(taskRun.getTaskRunId()) && isEqualTask(taskRun);
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/TaskRun.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/TaskRun.java
@@ -16,6 +16,7 @@ package com.starrocks.scheduler;
 
 import com.google.common.base.Preconditions;
 import com.google.common.collect.Maps;
+import com.google.gson.annotations.SerializedName;
 import com.starrocks.analysis.StringLiteral;
 import com.starrocks.catalog.Database;
 import com.starrocks.catalog.MaterializedView;
@@ -53,12 +54,15 @@ public class TaskRun implements Comparable<TaskRun> {
     public static final String IS_TEST = "__IS_TEST__";
     private boolean isKilled = false;
 
+    @SerializedName("taskId")
     private long taskId;
 
+    @SerializedName("properties")
     private Map<String, String> properties;
 
     private final CompletableFuture<Constants.TaskRunState> future;
 
+    @SerializedName("task")
     private Task task;
 
     private ConnectContext runCtx;
@@ -67,12 +71,16 @@ public class TaskRun implements Comparable<TaskRun> {
 
     private TaskRunProcessor processor;
 
+    @SerializedName("status")
     private TaskRunStatus status;
 
+    @SerializedName("type")
     private Constants.TaskType type;
 
+    @SerializedName("executeOption")
     private ExecuteOption executeOption;
 
+    @SerializedName("taskRunId")
     private final String taskRunId;
 
     TaskRun() {
@@ -136,7 +144,7 @@ public class TaskRun implements Comparable<TaskRun> {
         this.executeOption = executeOption;
     }
 
-    public String getUUID() {
+    public String getTaskRunId() {
         return taskRunId;
     }
 
@@ -354,7 +362,8 @@ public class TaskRun implements Comparable<TaskRun> {
         }
         TaskRun taskRun = (TaskRun) o;
         return this.taskId == taskRun.getTaskId() &&
-                this.task.getDefinition().equals(taskRun.getTask().getDefinition());
+                this.task.getDefinition().equals(taskRun.getTask().getDefinition()) &&
+                this.taskRunId.equals(taskRun.getTaskRunId());
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/TaskRunExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/TaskRunExecutor.java
@@ -39,6 +39,8 @@ public class TaskRunExecutor {
         }
         TaskRunStatus status = taskRun.getStatus();
         if (status == null) {
+            LOG.warn("TaskRun {}/{} has no state, avoid execute it again", status.getTaskName(),
+                    status.getQueryId());
             return false;
         }
         if (status.getState() != Constants.TaskRunState.PENDING) {

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/TaskRunManager.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/TaskRunManager.java
@@ -121,7 +121,7 @@ public class TaskRunManager implements MemoryTrackable {
                     // but other attributes may be different, such as priority, creation time.
                     // higher priority and create time will be result after merge is complete
                     // and queryId will be changed.
-                    if (!oldTaskRun.equals(taskRun)) {
+                    if (!oldTaskRun.isEqualTask(taskRun)) {
                         LOG.warn("failed to remove TaskRun definition is [{}]",
                                 taskRun);
                         continue;

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/TaskRunManager.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/TaskRunManager.java
@@ -78,7 +78,7 @@ public class TaskRunManager implements MemoryTrackable {
     }
 
     public boolean killTaskRun(Long taskId) {
-        TaskRun taskRun = taskRunScheduler.removeRunningTask(taskId);
+        TaskRun taskRun = taskRunScheduler.getRunningTaskRun(taskId);
         if (taskRun == null) {
             return false;
         }

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/TaskRunScheduler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/TaskRunScheduler.java
@@ -17,7 +17,6 @@ package com.starrocks.scheduler;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Maps;
-import com.google.gson.JsonObject;
 import com.google.gson.annotations.SerializedName;
 import com.starrocks.common.Config;
 import com.starrocks.persist.gson.GsonUtils;
@@ -306,11 +305,6 @@ public class TaskRunScheduler {
 
     @Override
     public String toString() {
-        JsonObject res = new JsonObject();
-        res.addProperty("pending_map", GsonUtils.GSON.toJson(pendingTaskRunMap));
-        res.addProperty("pending_queue", GsonUtils.GSON.toJson(pendingTaskRunQueue));
-        res.addProperty("running", GsonUtils.GSON.toJson(runningTaskRunMap));
-        res.addProperty("running_sync_task_runs", GsonUtils.GSON.toJson(runningSyncTaskRunMap));
-        return res.toString();
+        return GsonUtils.GSON.toJson(this);
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/TaskRunScheduler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/TaskRunScheduler.java
@@ -18,12 +18,14 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Maps;
 import com.google.gson.JsonObject;
+import com.google.gson.annotations.SerializedName;
 import com.starrocks.common.Config;
 import com.starrocks.persist.gson.GsonUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.Queue;
@@ -42,15 +44,20 @@ public class TaskRunScheduler {
     // TODO: Refactor this to find a better way to store the task runs.
     // taskId -> pending TaskRun Queue, for each Task only support 1 running taskRun currently,
     // so the map value is priority queue need to be sorted by priority from large to small
+    @SerializedName("pendingTaskRunMap")
     private final Map<Long, Queue<TaskRun>> pendingTaskRunMap = Maps.newConcurrentMap();
 
     // pending TaskRun Queue, compared by priority and created time
+    @SerializedName("pendingTaskRunQueue")
     private final Queue<TaskRun> pendingTaskRunQueue = new PriorityBlockingQueue<>();
 
     // taskId -> running TaskRun, for each Task only support 1 running taskRun currently,
     // so the map value is not queue
+    @SerializedName("runningTaskRunMap")
     private final Map<Long, TaskRun> runningTaskRunMap = Maps.newConcurrentMap();
 
+    @SerializedName("runningSyncTaskRunMap")
+    private final Map<Long, TaskRun> runningSyncTaskRunMap = Maps.newConcurrentMap();
 
     ////////// pending task run map //////////
     /**
@@ -71,12 +78,12 @@ public class TaskRunScheduler {
      * @param taskId: task id
      * @return: pending task run queue
      */
-    public List<TaskRun> getCopiedPendingTaskRunsByTaskId(long taskId) {
+    public Collection<TaskRun> getPendingTaskRunsByTaskId(long taskId) {
         Queue<TaskRun> pendingTaskRuns = pendingTaskRunMap.get(taskId);
         if (pendingTaskRuns == null) {
             return null;
         }
-        return ImmutableList.copyOf(pendingTaskRuns);
+        return pendingTaskRuns;
     }
 
     /**
@@ -107,24 +114,26 @@ public class TaskRunScheduler {
         if (taskRun.getStatus().getState() != Constants.TaskRunState.PENDING) {
             LOG.warn("task run is not in pending state: {}", taskRun);
         }
-        if (!pendingTaskRunQueue.remove(taskRun)) {
-            LOG.warn("remove pending task run from queue failed: {}", taskRun);
+
+        synchronized (this) {
+            if (!pendingTaskRunQueue.remove(taskRun)) {
+                LOG.warn("remove pending task run from queue failed: {}", taskRun);
+            }
+
+            Queue<TaskRun> taskRunQueue = pendingTaskRunMap.get(taskRun.getTaskId());
+            if (!taskRunQueue.remove(taskRun)) {
+                LOG.warn("remove pending task run from pending map failed: {}", taskRun);
+            }
+            if (taskRunQueue.isEmpty()) {
+                LOG.info("remove pending task run from pending map: {}", taskRun);
+                pendingTaskRunMap.remove(taskRun.getTaskId());
+            }
         }
         // make sure future is canceled.
         CompletableFuture<?> future = taskRun.getFuture();
         boolean isCancel = future.cancel(true);
         if (!isCancel) {
             LOG.warn("fail to cancel scheduler for task [{}]", taskRun);
-        }
-
-        Queue<TaskRun> taskRunQueue = pendingTaskRunMap.get(taskRun.getTaskId());
-        if (!taskRunQueue.remove(taskRun)) {
-            LOG.warn("remove pending task run from pending map failed: {}", taskRun);
-
-        }
-        if (taskRunQueue.isEmpty()) {
-            LOG.info("remove pending task run from pending map: {}", taskRun);
-            pendingTaskRunMap.remove(taskRun.getTaskId());
         }
     }
 
@@ -138,19 +147,21 @@ public class TaskRunScheduler {
             return;
         }
 
-        while (!taskRunQueue.isEmpty()) {
-            TaskRun taskRun = taskRunQueue.poll();
-            if (!pendingTaskRunQueue.remove(taskRun)) {
-                LOG.warn("remove pending task run from queue failed: {}", taskRun);
+        synchronized (this) {
+            while (!taskRunQueue.isEmpty()) {
+                TaskRun taskRun = taskRunQueue.poll();
+                // make sure future is canceled.
+                CompletableFuture<?> future = taskRun.getFuture();
+                boolean isCancel = future.cancel(true);
+                if (!isCancel) {
+                    LOG.warn("fail to cancel scheduler for task [{}]", taskRun);
+                }
+                if (!pendingTaskRunQueue.remove(taskRun)) {
+                    LOG.warn("remove pending task run from queue failed: {}", taskRun);
+                }
             }
-            // make sure future is canceled.
-            CompletableFuture<?> future = taskRun.getFuture();
-            boolean isCancel = future.cancel(true);
-            if (!isCancel) {
-                LOG.warn("fail to cancel scheduler for task [{}]", taskRun);
-            }
+            pendingTaskRunMap.remove(task.getId());
         }
-        pendingTaskRunMap.remove(task.getId());
     }
 
     public TaskRun getTaskRunByQueryId(Long taskId, String queryId) {
@@ -220,7 +231,7 @@ public class TaskRunScheduler {
     }
 
     public long getTaskIdPendingTaskRunCount(long taskId) {
-        List<TaskRun> pendingTaskRuns = getCopiedPendingTaskRunsByTaskId(taskId);
+        Collection<TaskRun> pendingTaskRuns = getPendingTaskRunsByTaskId(taskId);
         return  pendingTaskRuns == null ? 0L : pendingTaskRuns.size();
     }
 
@@ -278,12 +289,28 @@ public class TaskRunScheduler {
         return null;
     }
 
+    //////////// sync running task run map ////////////
+    public void addSyncRunningTaskRun(TaskRun taskRun) {
+        if (taskRun == null) {
+            return;
+        }
+        runningSyncTaskRunMap.put(taskRun.getTaskId(), taskRun);
+    }
+
+    public TaskRun removeSyncRunningTaskRun(TaskRun taskRun) {
+        if (taskRun == null) {
+            return null;
+        }
+        return runningSyncTaskRunMap.remove(taskRun.getTaskId());
+    }
+
     @Override
     public String toString() {
         JsonObject res = new JsonObject();
-        res.addProperty("running", GsonUtils.GSON.toJson(runningTaskRunMap));
         res.addProperty("pending_map", GsonUtils.GSON.toJson(pendingTaskRunMap));
         res.addProperty("pending_queue", GsonUtils.GSON.toJson(pendingTaskRunQueue));
+        res.addProperty("running", GsonUtils.GSON.toJson(runningTaskRunMap));
+        res.addProperty("running_sync_task_runs", GsonUtils.GSON.toJson(runningSyncTaskRunMap));
         return res.toString();
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/scheduler/PartitionBasedMvRefreshProcessorTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/scheduler/PartitionBasedMvRefreshProcessorTest.java
@@ -4300,7 +4300,7 @@ public class PartitionBasedMvRefreshProcessorTest extends MVRefreshTestBase {
                                     Assert.assertEquals(Sets.newHashSet("p1"),
                                             processor.getMVTaskRunExtraMessage().getMvPartitionsToRefresh());
 
-                                    Assert.assertEquals(taskRunStatus.getStartTaskRunId(), taskRun.getUUID());
+                                    Assert.assertEquals(taskRunStatus.getStartTaskRunId(), taskRun.getTaskRunId());
 
                                     jobID = taskRunStatus.getStartTaskRunId();
                                     {
@@ -4440,7 +4440,7 @@ public class PartitionBasedMvRefreshProcessorTest extends MVRefreshTestBase {
                                 Assert.assertEquals(Sets.newHashSet("p1"),
                                         processor.getMVTaskRunExtraMessage().getMvPartitionsToRefresh());
 
-                                Assert.assertEquals(taskRunStatus.getStartTaskRunId(), taskRun.getUUID());
+                                Assert.assertEquals(taskRunStatus.getStartTaskRunId(), taskRun.getTaskRunId());
 
                                 // mock: set its state to FAILED
                                 taskRunStatus.setState(Constants.TaskRunState.FAILED);

--- a/fe/fe-core/src/test/java/com/starrocks/scheduler/TaskManagerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/scheduler/TaskManagerTest.java
@@ -476,7 +476,7 @@ public class TaskManagerTest {
 
         {
             // task run 1
-            TaskRunStatusChange change = new TaskRunStatusChange(task.getId(), taskRun2.getStatus(),
+            TaskRunStatusChange change = new TaskRunStatusChange(task.getId(), taskRun1.getStatus(),
                     Constants.TaskRunState.PENDING, Constants.TaskRunState.FAILED);
             taskManager.replayUpdateTaskRun(change);
             Assert.assertEquals(0, taskRunScheduler.getRunningTaskCount());

--- a/test/lib/sr_sql_lib.py
+++ b/test/lib/sr_sql_lib.py
@@ -1220,6 +1220,9 @@ class StarrocksSQLApiLib(object):
         time.sleep(1)
         sql = "explain %s" % (query)
         res = self.execute_sql(sql, True)
+        if not res["status"]:
+            print(res)
+        tools.assert_true(res["status"])
         for expect in expects:
             tools.assert_true(str(res["result"]).find(expect) > 0, "assert expect %s is not found in plan" % (expect))
 
@@ -1230,6 +1233,9 @@ class StarrocksSQLApiLib(object):
         time.sleep(1)
         sql = "explain %s" % (query)
         res = self.execute_sql(sql, True)
+        if not res["status"]:
+            print(res)
+        tools.assert_true(res["status"])
         for expect in expects:
             tools.assert_false(str(res["result"]).find(expect) > 0, "assert expect %s should not be found" % (expect))
 


### PR DESCRIPTION
## Why I'm doing:
- submitTaskRegularTest is not stable
- mv sync mode refresh may hang until timeout


## What I'm doing:
- TaskRun's `equals` method only checks taskId and its definition but one task may contains many task runs. It may introduce bug if we don't distinguish those task runs.
- Use taskRunId to distinguish TaskRun
```
  @Override
    public boolean equals(Object o) {
        if (this == o) {
            return true;
        }
        if (o == null || getClass() != o.getClass()) {
            return false;
        }
        if (task.getDefinition() == null) {
            return false;
        }
        TaskRun taskRun = (TaskRun) o;
        return this.taskId == taskRun.getTaskId() &&
                this.task.getDefinition().equals(taskRun.getTask().getDefinition());
    }
```
Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [x] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [x] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
