### PR TITLE
[BugFix] fix multi_count_distinct rewrite error when has limit&filter

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/Optimizer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/Optimizer.java
@@ -536,6 +536,7 @@ public class Optimizer {
 
         ruleRewriteOnlyOnce(tree, rootTaskContext, RuleSetType.PARTITION_PRUNE);
         ruleRewriteIterative(tree, rootTaskContext, new RewriteMultiDistinctRule());
+        ruleRewriteIterative(tree, rootTaskContext, RuleSetType.PUSH_DOWN_PREDICATE);
         ruleRewriteIterative(tree, rootTaskContext, RuleSetType.PRUNE_EMPTY_OPERATOR);
         ruleRewriteIterative(tree, rootTaskContext, RuleSetType.PRUNE_PROJECT);
 

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/AggregateTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/AggregateTest.java
@@ -1658,15 +1658,10 @@ public class AggregateTest extends PlanTestBase {
                 "from supplier having avg(distinct s_suppkey) > 3 ;";
         connectContext.getSessionVariable().setOptimizerExecuteTimeout(-1);
         String plan = getFragmentPlan(sql);
-        assertContains(plan, "30:SELECT\n" +
-                "  |  predicates: 9: avg > 3.0\n" +
-                "  |  \n" +
-                "  29:Project\n" +
-                "  |  <slot 9> : CAST(12: sum AS DOUBLE) / CAST(14: count AS DOUBLE)\n" +
-                "  |  <slot 10> : 10: count\n" +
-                "  |  \n" +
-                "  28:NESTLOOP JOIN\n" +
-                "  |  join op: CROSS JOIN");
+        assertContains(plan, "  28:NESTLOOP JOIN\n" +
+                "  |  join op: INNER JOIN\n" +
+                "  |  colocate: false, reason: \n" +
+                "  |  other join predicates: CAST(12: sum AS DOUBLE) / CAST(14: count AS DOUBLE) > 3.0");
     }
 
     @Test
@@ -2759,5 +2754,32 @@ public class AggregateTest extends PlanTestBase {
                 "  1:AGGREGATE (update finalize)\n" +
                 "  |  output: max(abs(1))\n" +
                 "  |  group by: 1: v1");
+    }
+
+    @Test
+    public void testMultiCountDistinctWithHavingLimit() throws Exception {
+        String sql = "select count(distinct t1b) as x, count(distinct t1c) as y from test_all_type having x = 2";
+        String plan = getFragmentPlan(sql);
+        assertContains(plan, "  8:AGGREGATE (merge finalize)\n" +
+                "  |  output: count(11: count)\n" +
+                "  |  group by: \n" +
+                "  |  having: 11: count = 2");
+
+        sql = "select count(distinct t1b) as x, count(distinct t1c) as y from test_all_type having x = 2 limit 10";
+        plan = getFragmentPlan(sql);
+        assertContains(plan, "  1:AGGREGATE (update finalize)\n" +
+                "  |  output: multi_distinct_count(2: t1b), multi_distinct_count(3: t1c)\n" +
+                "  |  group by: \n" +
+                "  |  having: 11: count = 2\n" +
+                "  |  limit: 10");
+
+        connectContext.getSessionVariable().setOptimizerExecuteTimeout(-1);
+        sql = "select avg(distinct t1b) as x, count(distinct t1c) as y from test_all_type having x = 2 limit 10";
+        plan = getFragmentPlan(sql);
+        assertContains(plan, "  1:AGGREGATE (update finalize)\n" +
+                "  |  output: multi_distinct_count(3: t1c), multi_distinct_count(2: t1b), multi_distinct_sum(2: t1b)\n" +
+                "  |  group by: \n" +
+                "  |  having: CAST(14: multi_distinct_sum AS DOUBLE) / CAST(13: multi_distinct_count AS DOUBLE) = 2.0\n" +
+                "  |  limit: 10");
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/LowCardinalityTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/LowCardinalityTest.java
@@ -323,32 +323,6 @@ public class LowCardinalityTest extends PlanTestBase {
     }
 
     @Test
-    public void testDecodeNodeRewriteMultiAgg()
-            throws Exception {
-        boolean cboCteReuse = connectContext.getSessionVariable().isCboCteReuse();
-        boolean enableLowCardinalityOptimize = connectContext.getSessionVariable().isEnableLowCardinalityOptimize();
-        int newPlannerAggStage = connectContext.getSessionVariable().getNewPlannerAggStage();
-        connectContext.getSessionVariable().setCboCteReuse(false);
-        connectContext.getSessionVariable().setEnableLowCardinalityOptimize(true);
-        connectContext.getSessionVariable().setNewPlanerAggStage(2);
-
-        try {
-            String sql = "select count(distinct S_ADDRESS), count(distinct S_NATIONKEY) from supplier";
-            String plan = getVerboseExplain(sql);
-            Assert.assertTrue(plan, plan.contains("dict_col=S_ADDRESS"));
-            sql = "select count(distinct S_ADDRESS), count(distinct S_NATIONKEY) from supplier " +
-                    "having count(1) > 0";
-            plan = getVerboseExplain(sql);
-            Assert.assertTrue(plan, plan.contains("dict_col=S_ADDRESS"));
-            Assert.assertFalse(plan, plan.contains("Decode"));
-        } finally {
-            connectContext.getSessionVariable().setCboCteReuse(cboCteReuse);
-            connectContext.getSessionVariable().setEnableLowCardinalityOptimize(enableLowCardinalityOptimize);
-            connectContext.getSessionVariable().setNewPlanerAggStage(newPlannerAggStage);
-        }
-    }
-
-    @Test
     public void testDecodeNodeRewrite7() throws Exception {
         String sql = "select S_ADDRESS, count(S_ADDRESS) from supplier group by S_ADDRESS";
         String plan = getFragmentPlan(sql);

--- a/fe/fe-core/src/test/resources/sql/optimized-plan/grouping-sets.sql
+++ b/fe/fe-core/src/test/resources/sql/optimized-plan/grouping-sets.sql
@@ -180,29 +180,28 @@ TOP-N (order by [[6: sum ASC NULLS FIRST]])
         CTEAnchor(cteid=1)
             CTEProducer(cteid=1)
                 SCAN (columns[1: v1, 2: v2, 3: v3] predicate[null])
-            PREDICATE 5: avg > 0
+            INNER JOIN (join-predicate [divide(cast(9: sum as double), cast(11: count as double)) > 0] post-join-predicate [null])
                 CROSS JOIN (join-predicate [null] post-join-predicate [null])
                     CROSS JOIN (join-predicate [null] post-join-predicate [null])
-                        CROSS JOIN (join-predicate [null] post-join-predicate [null])
-                            AGGREGATE ([GLOBAL] aggregate [{4: count=multi_distinct_count(4: count)}] group by [[]] having [null]
-                                EXCHANGE GATHER
-                                    AGGREGATE ([LOCAL] aggregate [{4: count=multi_distinct_count(7: v1)}] group by [[]] having [null]
-                                        CTEConsumer(cteid=1)
-                            EXCHANGE BROADCAST
-                                AGGREGATE ([GLOBAL] aggregate [{6: sum=multi_distinct_sum(6: sum)}] group by [[]] having [null]
-                                    EXCHANGE GATHER
-                                        AGGREGATE ([LOCAL] aggregate [{6: sum=multi_distinct_sum(8: v2)}] group by [[]] having [null]
-                                            CTEConsumer(cteid=1)
+                        AGGREGATE ([GLOBAL] aggregate [{4: count=multi_distinct_count(4: count)}] group by [[]] having [null]
+                            EXCHANGE GATHER
+                                AGGREGATE ([LOCAL] aggregate [{4: count=multi_distinct_count(7: v1)}] group by [[]] having [null]
+                                    CTEConsumer(cteid=1)
                         EXCHANGE BROADCAST
-                            AGGREGATE ([GLOBAL] aggregate [{9: sum=multi_distinct_sum(9: sum)}] group by [[]] having [null]
+                            AGGREGATE ([GLOBAL] aggregate [{6: sum=multi_distinct_sum(6: sum)}] group by [[]] having [null]
                                 EXCHANGE GATHER
-                                    AGGREGATE ([LOCAL] aggregate [{9: sum=multi_distinct_sum(10: v3)}] group by [[]] having [null]
+                                    AGGREGATE ([LOCAL] aggregate [{6: sum=multi_distinct_sum(8: v2)}] group by [[]] having [null]
                                         CTEConsumer(cteid=1)
                     EXCHANGE BROADCAST
-                        AGGREGATE ([GLOBAL] aggregate [{11: count=multi_distinct_count(11: count)}] group by [[]] having [null]
+                        AGGREGATE ([GLOBAL] aggregate [{9: sum=multi_distinct_sum(9: sum)}] group by [[]] having [null]
                             EXCHANGE GATHER
-                                AGGREGATE ([LOCAL] aggregate [{11: count=multi_distinct_count(12: v3)}] group by [[]] having [null]
+                                AGGREGATE ([LOCAL] aggregate [{9: sum=multi_distinct_sum(10: v3)}] group by [[]] having [null]
                                     CTEConsumer(cteid=1)
+                EXCHANGE BROADCAST
+                    AGGREGATE ([GLOBAL] aggregate [{11: count=multi_distinct_count(11: count)}] group by [[]] having [null]
+                        EXCHANGE GATHER
+                            AGGREGATE ([LOCAL] aggregate [{11: count=multi_distinct_count(12: v3)}] group by [[]] having [null]
+                                CTEConsumer(cteid=1)
 [end]
 
 [sql]


### PR DESCRIPTION
## Why I'm doing:

count distinct rewrite will generate LogicalFilter, and dones't pushdown filter, will take unstable result when meet limit

* multi count distinct sql doesn't push down filter
* multi_count_distinct set limit and filter error

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [x] 3.2
  - [x] 3.1
  - [ ] 3.0
  - [ ] 2.5
