### PR TITLE
[Enhancement] Optimize memory usage calculation in LakePersistentIndex

### DIFF
--- a/be/src/storage/lake/lake_persistent_index.cpp
+++ b/be/src/storage/lake/lake_persistent_index.cpp
@@ -144,7 +144,6 @@ Status LakePersistentIndex::minor_compact() {
 Status LakePersistentIndex::flush_memtable() {
     if (_immutable_memtable != nullptr) {
         RETURN_IF_ERROR(minor_compact());
-        _immutable_memtable->reset_max_version();
     }
     _immutable_memtable = std::make_unique<PersistentIndexMemtable>();
     _memtable.swap(_immutable_memtable);

--- a/be/src/storage/lake/lake_persistent_index.cpp
+++ b/be/src/storage/lake/lake_persistent_index.cpp
@@ -144,6 +144,7 @@ Status LakePersistentIndex::minor_compact() {
 Status LakePersistentIndex::flush_memtable() {
     if (_immutable_memtable != nullptr) {
         RETURN_IF_ERROR(minor_compact());
+        _immutable_memtable->reset_max_version();
     }
     _immutable_memtable = std::make_unique<PersistentIndexMemtable>();
     _memtable.swap(_immutable_memtable);

--- a/be/src/storage/lake/persistent_index_memtable.cpp
+++ b/be/src/storage/lake/persistent_index_memtable.cpp
@@ -36,6 +36,7 @@ Status PersistentIndexMemtable::upsert(size_t n, const Slice* keys, const IndexV
         index_value_vers.emplace_front(version, value);
         if (auto [it, inserted] = _map.emplace(key, index_value_vers); inserted) {
             not_founds->insert(i);
+            _keys_size += key.capacity() + sizeof(std::string);
         } else {
             auto& old_index_value_vers = it->second;
             auto old_value = old_index_value_vers.front().second;
@@ -63,6 +64,7 @@ Status PersistentIndexMemtable::insert(size_t n, const Slice* keys, const IndexV
             LOG(WARNING) << msg;
             return Status::AlreadyExist(msg);
         }
+        _keys_size += key.capacity() + sizeof(std::string);
     }
     _max_version = std::max(_max_version, version);
     return Status::OK();
@@ -78,6 +80,7 @@ Status PersistentIndexMemtable::erase(size_t n, const Slice* keys, IndexValue* o
         if (auto [it, inserted] = _map.emplace(key, index_value_vers); inserted) {
             old_values[i] = NullIndexValue;
             not_founds->insert(i);
+            _keys_size += key.capacity() + sizeof(std::string);
         } else {
             auto& old_index_value_vers = it->second;
             auto old_index_value = old_index_value_vers.front().second;
@@ -100,6 +103,8 @@ Status PersistentIndexMemtable::replace(const Slice* keys, const IndexValue* val
         index_value_vers.emplace_front(version, value);
         if (auto [it, inserted] = _map.emplace(key, index_value_vers); !inserted) {
             update_index_value(&it->second, version, value);
+        } else {
+            _keys_size += key.capacity() + sizeof(std::string);
         }
     }
     _max_version = std::max(_max_version, version);
@@ -141,12 +146,7 @@ Status PersistentIndexMemtable::get(const Slice* keys, IndexValue* values, const
 }
 
 size_t PersistentIndexMemtable::memory_usage() const {
-    size_t mem_usage = 0;
-    for (auto const& it : _map) {
-        mem_usage += it.first.size() + sizeof(std::string);
-        mem_usage += it.second.size() * sizeof(IndexValueWithVer);
-    }
-    return mem_usage;
+    return _keys_size + _map.size() * sizeof(IndexValueWithVer);
 }
 
 Status PersistentIndexMemtable::flush(WritableFile* wf, uint64_t* filesize) {

--- a/be/src/storage/lake/persistent_index_memtable.h
+++ b/be/src/storage/lake/persistent_index_memtable.h
@@ -68,6 +68,7 @@ private:
     // The size can be up to 230K. The performance of std::map may be poor.
     phmap::btree_map<std::string, std::list<IndexValueWithVer>, std::less<>> _map;
     int64_t _max_version{0};
+    int64_t _keys_size{0};
 };
 
 } // namespace starrocks::lake


### PR DESCRIPTION
## Why I'm doing:
`memory_usage()` is needed to scan the map. If the size of map is large, the time cost will be very large. 
## What I'm doing:
Maintain a variable `keys_size` and calculate when keys are updated. And in `memory_usage()`, the result can be returned immediately.
Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
