### PR TITLE
[BugFix] only cache alive iceberg data file

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/iceberg/ManifestReader.java
+++ b/fe/fe-core/src/main/java/org/apache/iceberg/ManifestReader.java
@@ -257,7 +257,7 @@ public class ManifestReader<F extends ContentFile<F>> extends CloseableGroup
             entries = CloseableIterable.transform(entries,
                     entry -> {
                         Set<DataFile> dataFiles = dataFileCache.getIfPresent(file.location());
-                        if (dataFiles != null) {
+                        if (dataFiles != null && entry.isLive()) {
                             DataFile dataFile = (DataFile) entry.file();
                             dataFiles.add(dataFileCacheWithMetrics ? dataFile : dataFile.copyWithoutStats());
                         }
@@ -269,7 +269,7 @@ public class ManifestReader<F extends ContentFile<F>> extends CloseableGroup
             entries = CloseableIterable.transform(entries,
                     entry -> {
                         Set<DeleteFile> deleteFiles = deleteFileCache.getIfPresent(file.location());
-                        if (deleteFiles != null) {
+                        if (deleteFiles != null && entry.isLive()) {
                             deleteFiles.add((DeleteFile) entry.file().copy());
                         }
                         return entry;

--- a/test/sql/test_iceberg/R/test_iceberg_metadata_cache
+++ b/test/sql/test_iceberg/R/test_iceberg_metadata_cache
@@ -1,0 +1,48 @@
+-- name: test_iceberg_metadata_cache
+create external catalog iceberg_sql_test_${uuid0} PROPERTIES ("type"="iceberg", "iceberg.catalog.type"="hive", "iceberg.catalog.hive.metastore.uris"="${iceberg_catalog_hive_metastore_uris}","enable_iceberg_metadata_cache"="true");
+-- result:
+[]
+-- !result
+create database iceberg_sql_test_${uuid0}.iceberg_db_${uuid0};
+-- result:
+[]
+-- !result
+create external table iceberg_sql_test_${uuid0}.iceberg_db_${uuid0}.ice_tbl_${uuid0}(c_tinyint tinyint,c_int int,c_bigint bigint,c_bool boolean,c_float float,c_double double,c_decimal decimal(38,18),c_datetime datetime,c_char char(10),c_varchar varchar(20),c_string string,c_struct struct<col_int int, col_string string, col_date date>,c_map map<boolean, string>,c_array array<int>,
+c_date date,c_smallint smallint) partition by(c_date,c_smallint);
+-- result:
+[]
+-- !result
+insert overwrite iceberg_sql_test_${uuid0}.iceberg_db_${uuid0}.ice_tbl_${uuid0}(c_tinyint,c_string,c_date,c_smallint) values(1+100, concat('overwrite old partition', ' yeah~'),cast('2000-01-01' + interval '1' day as date),10-10),(2+100,'generate new partition','2000-01-02',1),(3+100,'generate new partition','2022-02-02',100/10);
+-- result:
+[]
+-- !result
+insert overwrite iceberg_sql_test_${uuid0}.iceberg_db_${uuid0}.ice_tbl_${uuid0}(c_bool,c_date,c_int,c_array,c_char,c_smallint,c_struct)
+values(0, '0000-01-01',9,[1,2,3,null,4],'China',-32768,null),(1, '2000-01-01',9,[1,2,3,null,4],'Korea',0,null),(0, '2000-01-01',9,[1,2,3,null,4],'Japan',0,null),(1, '2022-02-02',9,[1,2,3,null,4],'Tailand',10,null);
+-- result:
+[]
+-- !result
+insert overwrite iceberg_sql_test_${uuid0}.iceberg_db_${uuid0}.ice_tbl_${uuid0} partition(c_smallint=32767,c_date='9999-12-31') values (-128,-2147483648,-9223372036854775808,
+0,-3.4E+38,-1.79E+308,-99999999999999999999.999999999999999999,'0000-01-01 00:00:00','','','',row(-2147483648,'',cast("0000-01-01" as date)),map(cast(0 as boolean),''),[]),(-127,-2147483648,-9223372036854775808,0,-3.4E+38,-1.79E+308,-99999999999999999999.999999999999999999,'0000-01-01 00:00:00','','','',row(-2147483648,'',cast("0000-01-01" as date)),map(cast(0 as boolean),''),[1,null,2]);
+-- result:
+[]
+-- !result
+select count(1) from iceberg_sql_test_${uuid0}.iceberg_db_${uuid0}.ice_tbl_${uuid0};
+-- result:
+8
+-- !result
+select count(1) from iceberg_sql_test_${uuid0}.iceberg_db_${uuid0}.ice_tbl_${uuid0};
+-- result:
+8
+-- !result
+drop table iceberg_sql_test_${uuid0}.iceberg_db_${uuid0}.ice_tbl_${uuid0} force;
+-- result:
+[]
+-- !result
+drop database iceberg_sql_test_${uuid0}.iceberg_db_${uuid0};
+-- result:
+[]
+-- !result
+drop catalog iceberg_sql_test_${uuid0};
+-- result:
+[]
+-- !result

--- a/test/sql/test_iceberg/T/test_iceberg_metadata_cache
+++ b/test/sql/test_iceberg/T/test_iceberg_metadata_cache
@@ -1,0 +1,21 @@
+-- name: test_iceberg_metadata_cache
+
+create external catalog iceberg_sql_test_${uuid0} PROPERTIES ("type"="iceberg", "iceberg.catalog.type"="hive", "iceberg.catalog.hive.metastore.uris"="${iceberg_catalog_hive_metastore_uris}","enable_iceberg_metadata_cache"="true");
+
+create database iceberg_sql_test_${uuid0}.iceberg_db_${uuid0};
+create external table iceberg_sql_test_${uuid0}.iceberg_db_${uuid0}.ice_tbl_${uuid0}(c_tinyint tinyint,c_int int,c_bigint bigint,c_bool boolean,c_float float,c_double double,c_decimal decimal(38,18),c_datetime datetime,c_char char(10),c_varchar varchar(20),c_string string,c_struct struct<col_int int, col_string string, col_date date>,c_map map<boolean, string>,c_array array<int>,
+c_date date,c_smallint smallint) partition by(c_date,c_smallint);
+
+insert overwrite iceberg_sql_test_${uuid0}.iceberg_db_${uuid0}.ice_tbl_${uuid0}(c_tinyint,c_string,c_date,c_smallint) values(1+100, concat('overwrite old partition', ' yeah~'),cast('2000-01-01' + interval '1' day as date),10-10),(2+100,'generate new partition','2000-01-02',1),(3+100,'generate new partition','2022-02-02',100/10);
+
+insert overwrite iceberg_sql_test_${uuid0}.iceberg_db_${uuid0}.ice_tbl_${uuid0}(c_bool,c_date,c_int,c_array,c_char,c_smallint,c_struct)
+values(0, '0000-01-01',9,[1,2,3,null,4],'China',-32768,null),(1, '2000-01-01',9,[1,2,3,null,4],'Korea',0,null),(0, '2000-01-01',9,[1,2,3,null,4],'Japan',0,null),(1, '2022-02-02',9,[1,2,3,null,4],'Tailand',10,null);
+
+insert overwrite iceberg_sql_test_${uuid0}.iceberg_db_${uuid0}.ice_tbl_${uuid0} partition(c_smallint=32767,c_date='9999-12-31') values (-128,-2147483648,-9223372036854775808,
+0,-3.4E+38,-1.79E+308,-99999999999999999999.999999999999999999,'0000-01-01 00:00:00','','','',row(-2147483648,'',cast("0000-01-01" as date)),map(cast(0 as boolean),''),[]),(-127,-2147483648,-9223372036854775808,0,-3.4E+38,-1.79E+308,-99999999999999999999.999999999999999999,'0000-01-01 00:00:00','','','',row(-2147483648,'',cast("0000-01-01" as date)),map(cast(0 as boolean),''),[1,null,2]);
+
+select count(1) from iceberg_sql_test_${uuid0}.iceberg_db_${uuid0}.ice_tbl_${uuid0};
+select count(1) from iceberg_sql_test_${uuid0}.iceberg_db_${uuid0}.ice_tbl_${uuid0};
+drop table iceberg_sql_test_${uuid0}.iceberg_db_${uuid0}.ice_tbl_${uuid0} force;
+drop database iceberg_sql_test_${uuid0}.iceberg_db_${uuid0};
+drop catalog iceberg_sql_test_${uuid0};


### PR DESCRIPTION
## Why I'm doing:
The iceberg data file which status is deleted in the manifest will be skipped when iceberg job planning. So we shouldn't cache it in the data file cache.

## What I'm doing:
Skipping the deleted status data file when filling data file cache.
https://github.com/StarRocks/starrocks/pull/44703

Fixes #issue
https://github.com/StarRocks/StarRocksTest/issues/7186

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
