### PR TITLE
[Refactor] refactor lake connector data source provider

### DIFF
--- a/be/src/connector/connector.h
+++ b/be/src/connector/connector.h
@@ -169,11 +169,6 @@ public:
             bool enable_tablet_internal_parallel, TTabletInternalParallelMode::type tablet_internal_parallel_mode,
             size_t num_total_scan_ranges);
 
-    bool could_split() const { return _could_split; }
-
-    bool could_split_physically() const { return _could_split_physically; }
-
-    int64_t get_splitted_scan_rows() const { return splitted_scan_rows; }
     int64_t get_scan_dop() const { return scan_dop; }
 
     // possible physical distribution optimize of data source
@@ -184,9 +179,6 @@ public:
 
 protected:
     std::vector<ExprContext*> _partition_exprs;
-    bool _could_split = false;
-    bool _could_split_physically = false;
-    int64_t splitted_scan_rows = 0;
     int64_t scan_dop = 0;
 };
 using DataSourceProviderPtr = std::unique_ptr<DataSourceProvider>;

--- a/be/src/connector/lake_connector.h
+++ b/be/src/connector/lake_connector.h
@@ -220,6 +220,12 @@ public:
         return std::nullopt;
     }
 
+    bool could_split() const { return _could_split; }
+
+    bool could_split_physically() const { return _could_split_physically; }
+
+    int64_t get_splitted_scan_rows() const { return splitted_scan_rows; }
+
 protected:
     ConnectorScanNode* _scan_node;
     const TLakeScanNode _t_lake_scan_node;

--- a/be/src/connector/lake_connector.h
+++ b/be/src/connector/lake_connector.h
@@ -227,6 +227,10 @@ protected:
     // for ut
     lake::TabletManager* _tablet_manager;
 
+    bool _could_split = false;
+    bool _could_split_physically = false;
+    int64_t splitted_scan_rows = 0;
+
 private:
     StatusOr<bool> _could_tablet_internal_parallel(const std::vector<TScanRangeParams>& scan_ranges,
                                                    int32_t pipeline_dop, size_t num_total_scan_ranges,

--- a/be/test/storage/lake/lake_scan_node_test.cpp
+++ b/be/test/storage/lake/lake_scan_node_test.cpp
@@ -160,8 +160,8 @@ TEST_F(LakeScanNodeTest, test_could_split) {
     auto tablet_internal_parallel_mode = TTabletInternalParallelMode::type::AUTO;
     std::map<int32_t, std::vector<TScanRangeParams>> no_scan_ranges_per_driver_seq;
 
-    auto data_source_provider = scan_node->data_source_provider();
-    dynamic_cast<connector::LakeDataSourceProvider*>(data_source_provider)->set_lake_tablet_manager(_tablet_mgr.get());
+    auto data_source_provider = dynamic_cast<connector::LakeDataSourceProvider*>(scan_node->data_source_provider());
+    data_source_provider->set_lake_tablet_manager(_tablet_mgr.get());
 
     config::tablet_internal_parallel_max_splitted_scan_bytes = 32;
     config::tablet_internal_parallel_min_splitted_scan_rows = 4;
@@ -218,8 +218,8 @@ TEST_F(LakeScanNodeTest, test_issue_44386) {
     auto tablet_internal_parallel_mode = TTabletInternalParallelMode::type::AUTO;
     std::map<int32_t, std::vector<TScanRangeParams>> no_scan_ranges_per_driver_seq;
 
-    auto data_source_provider = scan_node->data_source_provider();
-    dynamic_cast<connector::LakeDataSourceProvider*>(data_source_provider)->set_lake_tablet_manager(_tablet_mgr.get());
+    auto data_source_provider = dynamic_cast<connector::LakeDataSourceProvider*>(scan_node->data_source_provider());
+    data_source_provider->set_lake_tablet_manager(_tablet_mgr.get());
 
     config::tablet_internal_parallel_max_splitted_scan_bytes = 32;
     config::tablet_internal_parallel_min_splitted_scan_rows = 4;


### PR DESCRIPTION
## Why I'm doing:


## What I'm doing:

move fields used only by `LakeDataSourceProvider` into it.

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [x] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5


-------

Dear, those lines in lake_connector.h should be covered by lake_scan_node_test.cpp

![image](https://github.com/StarRocks/starrocks/assets/1081215/d2d5ed14-ab7c-44fe-9121-b1b68536f0aa)
