### PR TITLE
[BugFix] fix not processing escape character

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/UserVariable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/UserVariable.java
@@ -145,7 +145,7 @@ public class UserVariable extends SetListItem {
             }
         } else if (targetType.isArrayType()) {
             //build a cast(string to array) expr
-            return TypeManager.addCastExpr(new StringLiteral(value), targetType);
+            return TypeManager.addCastExpr(new StringLiteral(removeEscapeCharacter(value)), targetType);
         } else {
             throw new SemanticException("Unsupported type: %s in user variable", targetType);
         }
@@ -177,4 +177,24 @@ public class UserVariable extends SetListItem {
                 return 1;
         }
     }
+
+    // remove escape character added in BE
+    // like [\"a\"] -> ["a"]
+    public static String removeEscapeCharacter(String strValue) {
+        StringBuilder sb = new StringBuilder();
+        for (int i = 0; i < strValue.length(); i++) {
+            char c = strValue.charAt(i);
+            if (c == '\\' && i < strValue.length() - 1 && (strValue.charAt(i + 1) == '"' || strValue.charAt(i + 1) == '\'')) {
+                // just skip
+            } else if (c == '\\' && i < strValue.length() - 1 && strValue.charAt(i + 1) == '\\') {
+                i++;
+                sb.append('\\');
+            } else {
+                sb.append(c);
+            }
+
+        }
+        return sb.toString();
+    }
+
 }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/SelectHintTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/SelectHintTest.java
@@ -14,6 +14,8 @@
 
 package com.starrocks.sql.plan;
 
+import com.starrocks.sql.ast.UserVariable;
+import org.junit.Assert;
 import org.junit.Test;
 
 public class SelectHintTest extends PlanTestBase {
@@ -51,5 +53,21 @@ public class SelectHintTest extends PlanTestBase {
                 "  0:OlapScanNode\n" +
                 "     TABLE: t0\n" +
                 "     PREAGGREGATION: ON");
+    }
+
+    @Test
+    public void testRemoveEscapeCharacter() {
+
+        String str = "[\"{\\\"week\\\":{\\\"day\\\":true,\\\"shift\\\":{\\\"begin\\\":0}},\\\"id\\\":\\\"ID1\\\"}\"]";
+        String actual = UserVariable.removeEscapeCharacter(str);
+        Assert.assertEquals("[\"{\"week\":{\"day\":true,\"shift\":{\"begin\":0}},\"id\":\"ID1\"}\"]", actual);
+
+        str = "[\"{\\\"week\\\":{\\\"d\\\"ay\\\":true,\\\"shift\\\":{\\\"begin\\\":0}},\\\"id\\\":\\\"ID1\\\"}\"]";
+        actual = UserVariable.removeEscapeCharacter(str);
+        Assert.assertEquals("[\"{\"week\":{\"d\"ay\":true,\"shift\":{\"begin\":0}},\"id\":\"ID1\"}\"]", actual);
+
+        str = "abc\\\\abc";
+        actual = UserVariable.removeEscapeCharacter(str);
+        Assert.assertEquals("abc\\abc", actual);
     }
 }

--- a/test/sql/test_hint/R/test_hint
+++ b/test/sql/test_hint/R/test_hint
@@ -80,12 +80,12 @@ None	None
 -- !result
 select * from t2;
 -- result:
-4	a	Value4	60
 None	a	Value3	60
 2	a	Value2	60
-5	a	Value5	60
 5	a	Value6	60
+5	a	Value5	60
 1	a	Value1	60
+4	a	Value4	60
 -- !result
 select /*+ set_user_variable(@a = (select max(c3) from t1)) */ /*+ set_user_variable(@b = (select min(c3) from t1)) */ @a, @b from t1;
 -- result:
@@ -255,4 +255,47 @@ select @test;
 set @test= (select cast(50 as time));
 -- result:
 E: (1064, "Getting analyzing error. Detail message: Can't set variable with type TIME.")
+-- !result
+set @test= ["{\"m\":{\"cal\":[{\"thur\":{\"use\":true,\"shift\":{\"begin\":0,\"end\":36}},\"id\":\"ID1\"}]}}", "{\"\\a\"}"];
+-- result:
+-- !result
+select @test = ["{\"m\":{\"cal\":[{\"thur\":{\"use\":true,\"shift\":{\"begin\":0,\"end\":36}},\"id\":\"ID1\"}]}}", "{\"\\a\"}"];
+-- result:
+1
+-- !result
+set @test= concat(upper('a'), '\\', '"', '\'', 'b');
+-- result:
+-- !result
+select @test = concat(upper('a'), '\\', '"', '\'', 'b');
+-- result:
+1
+-- !result
+set @test = ["abc\\"];
+-- result:
+-- !result
+select @test = ["abc\\"];
+-- result:
+1
+-- !result
+set @test = ["abc'"];
+-- result:
+-- !result
+select @test = ["abc'"];
+-- result:
+1
+-- !result
+set @test = ["abc\\'"];
+-- result:
+-- !result
+select @test = ["abc\\'"];
+-- result:
+1
+-- !result
+set @test = concat(upper('a'), '\'', '\\' 'b', '"');
+-- result:
+E: (1064, "Getting syntax error at line 1, column 42. Detail message: Unexpected input ''b'', the most similar input is {',', ')'}.")
+-- !result
+select @test = concat(upper('a'), '\'', '\\' 'b', '"');
+-- result:
+E: (1064, "Getting syntax error at line 1, column 45. Detail message: Unexpected input ''b'', the most similar input is {',', ')'}.")
 -- !result

--- a/test/sql/test_hint/T/test_hint
+++ b/test/sql/test_hint/T/test_hint
@@ -142,3 +142,26 @@ set @test= (select cast(50 as boolean));
 select @test;
 
 set @test= (select cast(50 as time));
+
+set @test= ["{\"m\":{\"cal\":[{\"thur\":{\"use\":true,\"shift\":{\"begin\":0,\"end\":36}},\"id\":\"ID1\"}]}}", "{\"\\a\"}"];
+select @test = ["{\"m\":{\"cal\":[{\"thur\":{\"use\":true,\"shift\":{\"begin\":0,\"end\":36}},\"id\":\"ID1\"}]}}", "{\"\\a\"}"];
+
+set @test= concat(upper('a'), '\\', '"', '\'', 'b');
+select @test = concat(upper('a'), '\\', '"', '\'', 'b');
+
+set @test = ["abc\\"];
+select @test = ["abc\\"];
+
+set @test = ["abc'"];
+select @test = ["abc'"];
+
+set @test = ["abc\\'"];
+select @test = ["abc\\'"];
+
+set @test = concat(upper('a'), '\'', '\\' 'b', '"');
+select @test = concat(upper('a'), '\'', '\\' 'b', '"');
+
+
+
+
+


### PR DESCRIPTION
## Why I'm doing:
For performance considerations, user variables actually store the string results of array types from MySQL text protocal bytes in FE, and convert them to array type through `cast(string as array<type>)`.
When converting to MySQL text protocal in BE, it will escape `\` and `"` when necessary.
```
// Surround the string with two double-quotas.
        const size_t escaped_len = 2 + _length_after_escape(str, length, escape_char);
        char* pos = _resize_extra(escaped_len);
        *pos++ = escape_char;
        if (escaped_len == length + 2) {
            // No '\' or '"' exists in |str|, copy directly.
            strings::memcpy_inlined(pos, str, length);
            pos += length;
        } else {
            // Escape '\' and '"'.
            pos = _escape(pos, str, length, escape_char);
        }
        *pos++ = escape_char;
        DCHECK_EQ(_data.data() + _data.size(), pos);
        _data.resize(pos - _data.data());
```
Therefore, we need convert `\"` to `"` in the string results of array types, or the cast result will have redundant `\`. Like:
```
mysql> set  @test = ["\"a\": 1"];
Query OK, 0 rows affected (0.01 sec)

mysql> select @test;
+------------------+
| @test            |
+------------------+
| ["\\\"a\\\": 1"] |
+------------------+
1 row in set (0.01 sec)
```

## What I'm doing:
Remove unnecessary `\`.

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [x] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
