### PR TITLE
[BugFix] initilize editLog in StarOSBDBJEJournalSystem

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/leader/Checkpoint.java
+++ b/fe/fe-core/src/main/java/com/starrocks/leader/Checkpoint.java
@@ -233,7 +233,7 @@ public class Checkpoint extends FrontendDaemon {
         try {
             return starMgrServer.replayAndGenerateImage(imageDir, logVersion);
         } catch (Exception e) {
-            LOG.error("Exception when generate new star mgr image file, {}.", e.getMessage());
+            LOG.error("Exception when generate new star mgr image file", e);
             return false;
         } finally {
             // destroy checkpoint, reclaim memory

--- a/fe/fe-core/src/main/java/com/starrocks/staros/StarOSBDBJEJournalSystem.java
+++ b/fe/fe-core/src/main/java/com/starrocks/staros/StarOSBDBJEJournalSystem.java
@@ -31,7 +31,6 @@ import com.starrocks.journal.JournalWriter;
 import com.starrocks.journal.bdbje.BDBEnvironment;
 import com.starrocks.journal.bdbje.BDBJEJournal;
 import com.starrocks.persist.EditLog;
-import com.starrocks.server.GlobalStateMgr;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -208,7 +207,7 @@ public class StarOSBDBJEJournalSystem implements JournalSystem {
                 break;
             }
 
-            editLog.loadJournal(GlobalStateMgr.getCurrentState(), entity);
+            editLog.loadJournal(null /* GlobalStateMgr */, entity);
             replayedJournalId.incrementAndGet();
 
             LOG.debug("star mgr journal {} replayed.", replayedJournalId);


### PR DESCRIPTION
## Why I'm doing:

Got the following error:
```
2024-04-26 00:17:21.299+08:00 ERROR (star mgr LeaderCheckpointer|112) [Checkpoint.replayAndGenerateStarMgrImage():236] Exception when generate new star mgr image file, null.
```

Fixes #44832

## What I'm doing:

1. Fix some error log statement to print stack trace.
2. Initilize editLog field in StarOSBDBJEJournalSystem.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
