### PR TITLE
[UT] Optimize UT for datacache to make it adapt to run in parallel. (backport #44816)

### DIFF
--- a/be/test/block_cache/block_cache_test.cpp
+++ b/be/test/block_cache/block_cache_test.cpp
@@ -29,9 +29,9 @@ namespace starrocks {
 
 class BlockCacheTest : public ::testing::Test {
 protected:
-    static void SetUpTestCase() { ASSERT_TRUE(fs::create_directories("./block_disk_cache").ok()); }
+    static void SetUpTestCase() {}
 
-    static void TearDownTestCase() { ASSERT_TRUE(fs::remove_all("./block_disk_cache").ok()); }
+    static void TearDownTestCase() {}
 
     void SetUp() override {}
     void TearDown() override {}
@@ -66,6 +66,9 @@ TEST_F(BlockCacheTest, copy_to_iobuf) {
 }
 
 TEST_F(BlockCacheTest, parse_cache_space_size_str) {
+    const std::string cache_dir = "./block_disk_cache1";
+    ASSERT_TRUE(fs::create_directories(cache_dir).ok());
+
     uint64_t mem_size = 10;
     ASSERT_EQ(parse_mem_size("10"), mem_size);
     mem_size *= 1024;
@@ -78,7 +81,7 @@ TEST_F(BlockCacheTest, parse_cache_space_size_str) {
     ASSERT_EQ(parse_mem_size("10T"), mem_size);
     ASSERT_EQ(parse_mem_size("10%", 10 * 1024), 1024);
 
-    std::string disk_path = "./block_disk_cache";
+    std::string disk_path = cache_dir;
     uint64_t disk_size = 10;
     ASSERT_EQ(parse_disk_size(disk_path, "10"), disk_size);
     disk_size *= 1024;
@@ -94,49 +97,61 @@ TEST_F(BlockCacheTest, parse_cache_space_size_str) {
     std::error_code ec;
     auto space_info = std::filesystem::space(disk_path, ec);
     ASSERT_EQ(disk_size, int64_t(10.0 / 100.0 * space_info.capacity));
+
+    fs::remove_all(cache_dir).ok();
 }
 
 TEST_F(BlockCacheTest, parse_cache_space_paths) {
+    const std::string cache_dir = "./block_disk_cache2";
+    ASSERT_TRUE(fs::create_directories(cache_dir).ok());
+
     const std::string cwd = std::filesystem::current_path().string();
-    const std::string s_normal_path = fmt::format("{}/block_disk_cache/cache1;{}/block_disk_cache/cache2", cwd, cwd);
+    const std::string s_normal_path = fmt::format("{}/block_disk_cache2/cache1;{}/block_disk_cache2/cache2", cwd, cwd);
     std::vector<std::string> paths;
     ASSERT_TRUE(parse_conf_datacache_paths(s_normal_path, &paths).ok());
     ASSERT_EQ(paths.size(), 2);
 
     paths.clear();
-    const std::string s_space_path = fmt::format(" {}/block_disk_cache/cache3 ; {}/block_disk_cache/cache4 ", cwd, cwd);
+    const std::string s_space_path =
+            fmt::format(" {}/block_disk_cache2/cache3 ; {}/block_disk_cache2/cache4 ", cwd, cwd);
     ASSERT_TRUE(parse_conf_datacache_paths(s_space_path, &paths).ok());
     ASSERT_EQ(paths.size(), 2);
 
     paths.clear();
-    const std::string s_empty_path = fmt::format("//;{}/block_disk_cache/cache4 ", cwd, cwd);
+    const std::string s_empty_path = fmt::format("//;{}/block_disk_cache2/cache4 ", cwd, cwd);
     ASSERT_FALSE(parse_conf_datacache_paths(s_empty_path, &paths).ok());
     ASSERT_EQ(paths.size(), 1);
 
     paths.clear();
-    const std::string s_invalid_path = fmt::format(" /block_disk_cache/cache5;{}/+/cache6", cwd, cwd);
+    const std::string s_invalid_path = fmt::format(" /block_disk_cache2/cache5;{}/+/cache6", cwd, cwd);
     ASSERT_FALSE(parse_conf_datacache_paths(s_invalid_path, &paths).ok());
     ASSERT_EQ(paths.size(), 0);
+
+    fs::remove_all(cache_dir).ok();
 }
 
 #ifdef WITH_STARCACHE
 TEST_F(BlockCacheTest, hybrid_cache) {
+    const std::string cache_dir = "./block_disk_cache3";
+    ASSERT_TRUE(fs::create_directories(cache_dir).ok());
+
     std::unique_ptr<BlockCache> cache(new BlockCache);
-    const size_t block_size = 1024 * 1024;
+    const size_t block_size = 256 * 1024;
 
     CacheOptions options;
-    options.mem_space_size = 10 * 1024 * 1024;
-    size_t quota = 500 * 1024 * 1024;
-    options.disk_spaces.push_back({.path = "./block_disk_cache", .size = quota});
+    options.mem_space_size = 2 * 1024 * 1024;
+    size_t quota = 50 * 1024 * 1024;
+    options.disk_spaces.push_back({.path = cache_dir, .size = quota});
     options.block_size = block_size;
     options.max_concurrent_inserts = 100000;
     options.max_flying_memory_mb = 100;
+    options.enable_direct_io = false;
     options.engine = "starcache";
     Status status = cache->init(options);
     ASSERT_TRUE(status.ok());
 
-    const size_t batch_size = block_size - 1234;
-    const size_t rounds = 20;
+    const size_t batch_size = block_size;
+    const size_t rounds = 10;
     const std::string cache_key = "test_file";
 
     // write cache
@@ -144,7 +159,7 @@ TEST_F(BlockCacheTest, hybrid_cache) {
         char ch = 'a' + i % 26;
         std::string value(batch_size, ch);
         Status st = cache->write_buffer(cache_key + std::to_string(i), 0, batch_size, value.c_str());
-        ASSERT_TRUE(st.ok());
+        ASSERT_TRUE(st.ok()) << st.message();
     }
 
     // read cache
@@ -153,7 +168,7 @@ TEST_F(BlockCacheTest, hybrid_cache) {
         std::string expect_value(batch_size, ch);
         char value[batch_size] = {0};
         auto res = cache->read_buffer(cache_key + std::to_string(i), 0, batch_size, value);
-        ASSERT_TRUE(res.status().ok());
+        ASSERT_TRUE(res.status().ok()) << res.status().message();
         ASSERT_EQ(memcmp(value, expect_value.c_str(), batch_size), 0);
     }
 
@@ -170,6 +185,7 @@ TEST_F(BlockCacheTest, hybrid_cache) {
     ASSERT_TRUE(res.status().is_not_found());
 
     cache->shutdown();
+    fs::remove_all(cache_dir).ok();
 }
 
 TEST_F(BlockCacheTest, write_with_overwrite_option) {
@@ -216,13 +232,16 @@ TEST_F(BlockCacheTest, write_with_overwrite_option) {
 }
 
 TEST_F(BlockCacheTest, read_cache_with_adaptor) {
+    const std::string cache_dir = "./block_disk_cache4";
+    ASSERT_TRUE(fs::create_directories(cache_dir).ok());
+
     std::unique_ptr<BlockCache> cache(new BlockCache);
     const size_t block_size = 1024 * 1024;
 
     CacheOptions options;
     options.mem_space_size = 1024;
     size_t quota = 500 * 1024 * 1024;
-    options.disk_spaces.push_back({.path = "./block_disk_cache", .size = quota});
+    options.disk_spaces.push_back({.path = cache_dir, .size = quota});
     options.block_size = block_size;
     options.max_concurrent_inserts = 100000;
     options.max_flying_memory_mb = 100;
@@ -280,6 +299,7 @@ TEST_F(BlockCacheTest, read_cache_with_adaptor) {
     }
 
     cache->shutdown();
+    fs::remove_all(cache_dir).ok();
 }
 
 #endif


### PR DESCRIPTION
## Why I'm doing:
The old unittest for datacache depends on same temporary directory, read cache files from it. However when testcases running in parallel, the directory may be removed by other cases, which cause the test cases which still using it failed.

## What I'm doing:
Create a unique directory for datacache in each testcase, and remove it when the case finished.
Also, we reduce the memory and disk space required for its execution.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [x] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [x] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5

