### PR TITLE
[BugFix] Support nondeterministic function reuse for 2.5 (backport #39904)

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/base/ColumnRefFactory.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/base/ColumnRefFactory.java
@@ -32,6 +32,11 @@ public class ColumnRefFactory {
     private final Map<ColumnRefOperator, Column> columnRefToColumns = Maps.newHashMap();
     private final Map<ColumnRefOperator, Table> columnRefToTable = Maps.newHashMap();
 
+    // introduced to used to get unique id for query,
+    // now used to identify nondeterministic function.
+    // do not reuse nextId because it will affect many UTs.
+    private int id = 1;
+
     public Map<ColumnRefOperator, Column> getColumnRefToColumns() {
         return columnRefToColumns;
     }
@@ -127,5 +132,9 @@ public class ColumnRefFactory {
 
     public Table getTableForColumn(int columnId) {
         return columnRefToTable.get(getColumnRef(columnId));
+    }
+
+    public int getNextUniqueId() {
+        return id++;
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/scalar/CallOperator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/scalar/CallOperator.java
@@ -38,6 +38,9 @@ public class CallOperator extends ScalarOperator {
     // Ignore nulls.
     private boolean ignoreNulls = false;
 
+    // for nonDeterministicFunctions, to reuse it in common exprs
+    private int id = 0;
+
     public CallOperator(String fnName, Type returnType, List<ScalarOperator> arguments) {
         this(fnName, returnType, arguments, null);
     }
@@ -81,6 +84,10 @@ public class CallOperator extends ScalarOperator {
 
     public boolean isAggregate() {
         return fn != null && fn instanceof AggregateFunction;
+    }
+
+    public void setId(int id) {
+        this.id = id;
     }
 
     @Override
@@ -145,7 +152,7 @@ public class CallOperator extends ScalarOperator {
 
     @Override
     public int hashCode() {
-        return Objects.hash(fnName, arguments, isDistinct);
+        return Objects.hash(fnName, arguments, isDistinct, id);
     }
 
     @Override
@@ -157,11 +164,11 @@ public class CallOperator extends ScalarOperator {
             return false;
         }
         CallOperator other = (CallOperator) obj;
-
         return isDistinct == other.isDistinct &&
                 Objects.equals(fnName, other.fnName) &&
                 Objects.equals(type, other.type) &&
-                Objects.equals(arguments, other.arguments);
+                Objects.equals(arguments, other.arguments) &&
+                id == other.id;
     }
 
     @Override
@@ -178,6 +185,7 @@ public class CallOperator extends ScalarOperator {
         operator.fnName = this.fnName;
         operator.isDistinct = this.isDistinct;
         operator.ignoreNulls = this.ignoreNulls;
+        operator.id = this.id;
         return operator;
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/ScalarOperatorsReuse.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/ScalarOperatorsReuse.java
@@ -277,7 +277,7 @@ public class ScalarOperatorsReuse {
             Set<ScalarOperator> operators = getOperatorsByDepth(depth, operatorsByDepth);
             isLambdaDependent = false;
             lambdaArguments.clear();
-            if (!isNonDeterministicFuncOrLambdaDependent(operator) && operators.contains(operator)) {
+            if (!isLambdaDependent(operator) && operators.contains(operator)) {
                 Set<ScalarOperator> commonOperators = getOperatorsByDepth(depth, commonOperatorsByDepth);
                 commonOperators.add(operator);
             }
@@ -312,6 +312,23 @@ public class ScalarOperatorsReuse {
         }
 
         @Override
+        public Integer visitCall(CallOperator scalarOperator, Void context) {
+            CallOperator callOperator = scalarOperator.cast();
+            if (FunctionSet.nonDeterministicFunctions.contains(callOperator.getFnName())) {
+                // try to reuse non deterministic function
+                // for example:
+                // select (rnd + 1) as rnd1, (rnd + 2) as rnd2 from (select rand() as rnd) sub
+                return collectCommonOperatorsByDepth(1, scalarOperator);
+            } else if (scalarOperator.getChildren().isEmpty()) {
+                // to keep the same logic as origin
+                return 0;
+            } else {
+                return collectCommonOperatorsByDepth(scalarOperator.getChildren().stream().map(argument ->
+                        argument.accept(this, context)).reduce(Math::max).map(m -> m + 1).orElse(1), scalarOperator);
+            }
+        }
+
+        @Override
         public Integer visitDictMappingOperator(DictMappingOperator scalarOperator, Void context) {
             return collectCommonOperatorsByDepth(1, scalarOperator);
         }
@@ -321,7 +338,7 @@ public class ScalarOperatorsReuse {
         // a lambda-dependent expressions also can't be reused if reuseLambdaDependentExpr is false.
         // For example, array_map(x->2x+1+2x,array),2x is lambda-dependent, so it can't be reused if
         // reuseLambdaDependentExpr is false, but array_map(x->2x+1+2x,array) can be reused if needed.
-        private boolean isNonDeterministicFuncOrLambdaDependent(ScalarOperator scalarOperator) {
+        private boolean isLambdaDependent(ScalarOperator scalarOperator) {
 
             if (hasLambdaFunction && !reuseLambdaDependentExpr) {
                 if (scalarOperator instanceof LambdaFunctionOperator) {
@@ -335,14 +352,8 @@ public class ScalarOperatorsReuse {
                 }
             }
 
-            if (scalarOperator instanceof CallOperator) {
-                String fnName = ((CallOperator) scalarOperator).getFnName();
-                if (FunctionSet.nonDeterministicFunctions.contains(fnName)) {
-                    return true;
-                }
-            }
             for (ScalarOperator child : scalarOperator.getChildren()) {
-                if (isNonDeterministicFuncOrLambdaDependent(child)) {
+                if (isLambdaDependent(child)) {
                     return true;
                 }
             }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/transformer/SqlToScalarOperatorTranslator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/transformer/SqlToScalarOperatorTranslator.java
@@ -610,6 +610,9 @@ public final class SqlToScalarOperatorTranslator {
                     node.getFn(),
                     node.getParams().isDistinct());
             callOperator.setHints(node.getHints());
+            if (FunctionSet.nonDeterministicFunctions.contains(node.getFnName().getFunction())) {
+                callOperator.setId(columnRefFactory.getNextUniqueId());
+            }
             return callOperator;
         }
 

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rewrite/ScalarOperatorsReuseRuleTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rewrite/ScalarOperatorsReuseRuleTest.java
@@ -1,0 +1,83 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.sql.optimizer.rewrite;
+
+import com.starrocks.sql.plan.PlanTestBase;
+import org.junit.Test;
+
+public class ScalarOperatorsReuseRuleTest extends PlanTestBase {
+    @Test
+    public void testRandReuse() throws Exception {
+        {
+            String query = "select (rnd + 1) as rnd1, (rnd + 2) as rnd2 from (select rand() as rnd) sub";
+            String plan = getFragmentPlan(query);
+            PlanTestBase.assertContains(plan, "1:Project\n" +
+                    "  |  <slot 3> : 5: rand + 1.0\n" +
+                    "  |  <slot 4> : 5: rand + 2.0\n" +
+                    "  |  common expressions:\n" +
+                    "  |  <slot 5> : rand()");
+        }
+
+        {
+            String query = "select rand() as rnd1, rand() as rnd2";
+            String plan = getFragmentPlan(query);
+            PlanTestBase.assertContains(plan, "1:Project\n" +
+                    "  |  <slot 2> : rand()\n" +
+                    "  |  <slot 3> : rand()");
+        }
+    }
+
+    @Test
+    public void testRandomReuse() throws Exception {
+        {
+            String query = "select (rnd + 1) as rnd1, (rnd + 2) as rnd2 from (select random() as rnd) sub";
+            String plan = getFragmentPlan(query);
+            PlanTestBase.assertContains(plan, "1:Project\n" +
+                    "  |  <slot 3> : 5: random + 1.0\n" +
+                    "  |  <slot 4> : 5: random + 2.0\n" +
+                    "  |  common expressions:\n" +
+                    "  |  <slot 5> : random()");
+        }
+
+        {
+            String query = "select random() as rnd1, random() as rnd2";
+            String plan = getFragmentPlan(query);
+            PlanTestBase.assertContains(plan, "1:Project\n" +
+                    "  |  <slot 2> : random()\n" +
+                    "  |  <slot 3> : random()");
+        }
+    }
+
+    @Test
+    public void testUUIDReuse() throws Exception {
+        {
+            String query = "select lower(id) as id1, upper(id) as id2 from (select uuid() as id) sub";
+            String plan = getFragmentPlan(query);
+            PlanTestBase.assertContains(plan, "1:Project\n" +
+                    "  |  <slot 3> : lower(5: uuid)\n" +
+                    "  |  <slot 4> : upper(5: uuid)\n" +
+                    "  |  common expressions:\n" +
+                    "  |  <slot 5> : uuid()");
+        }
+
+        {
+            String query = "select uuid() as id1, uuid() as id2";
+            String plan = getFragmentPlan(query);
+            PlanTestBase.assertContains(plan, "1:Project\n" +
+                    "  |  <slot 2> : uuid()\n" +
+                    "  |  <slot 3> : uuid()");
+        }
+    }
+}

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rewrite/ScalarOperatorsReuseTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rewrite/ScalarOperatorsReuseTest.java
@@ -15,6 +15,7 @@ import com.starrocks.sql.optimizer.operator.scalar.ScalarOperator;
 import com.starrocks.sql.optimizer.rule.tree.ScalarOperatorsReuse;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -159,7 +160,7 @@ public class ScalarOperatorsReuseTest {
         Map<Integer, Map<ScalarOperator, ColumnRefOperator>> commonSubScalarOperators =
                 ScalarOperatorsReuse.collectCommonSubScalarOperators(null, ImmutableList.of(add1, add2, add3, add4),
                         columnRefFactory, false);
-        assertTrue(commonSubScalarOperators.isEmpty());
+        Assert.assertFalse(commonSubScalarOperators.isEmpty());
     }
 
     @Test
@@ -183,7 +184,7 @@ public class ScalarOperatorsReuseTest {
         Map<Integer, Map<ScalarOperator, ColumnRefOperator>> commonSubScalarOperators =
                 ScalarOperatorsReuse.collectCommonSubScalarOperators(null, ImmutableList.of(add1, add2, add3, add4),
                         columnRefFactory, false);
-        assertEquals(2, commonSubScalarOperators.size());
+        assertEquals(3, commonSubScalarOperators.size());
     }
 
     @Test


### PR DESCRIPTION
## Why I'm doing:
for the following sql

> select (rnd + 1) as rnd1, (rnd + 2) as rnd2 from (select rand() as rnd) sub

rand will call twice, it does not reuse the rand() function.

## What I'm doing:
reuse the nondeterministic function. now the plan will be:

> PLAN FRAGMENT 0
>  OUTPUT EXPRS:3: expr | 4: expr
>   PARTITION: UNPARTITIONED
> 
>   RESULT SINK
> 
>   1:Project
>   |  <slot 3> : 5: rand + 1.0
>   |  <slot 4> : 5: rand + 2.0
>   |  common expressions:
>   |  <slot 5> : rand()
>   |  
>   0:UNION
>      constant exprs: 
>          NULL

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [x] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5

