### PR TITLE
[BugFix] fix create table failed when accessing meta service timeout

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/connector/hive/HiveMetastoreOperations.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/hive/HiveMetastoreOperations.java
@@ -189,6 +189,11 @@ public class HiveMetastoreOperations {
             LOG.error("Failed to create table {}.{}", dbName, tableName);
             boolean shouldDelete;
             try {
+                if (tableExists(dbName, tableName)) {
+                    LOG.warn("Table {}.{} already exists. But some error occur such as accessing meta service timeout",
+                            dbName, table, e);
+                    return true;
+                }
                 FileSystem fileSystem = FileSystem.get(URI.create(tablePath.toString()), hadoopConf);
                 shouldDelete = !fileSystem.listLocatedStatus(tablePath).hasNext();
                 if (shouldDelete) {

--- a/fe/fe-core/src/test/java/com/starrocks/connector/hive/HiveMetadataTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/hive/HiveMetadataTest.java
@@ -41,6 +41,7 @@ import com.starrocks.connector.RemotePathKey;
 import com.starrocks.connector.exception.StarRocksConnectorException;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.sql.analyzer.AnalyzeTestUtil;
+import com.starrocks.sql.ast.CreateTableStmt;
 import com.starrocks.sql.ast.DropTableStmt;
 import com.starrocks.sql.optimizer.Memo;
 import com.starrocks.sql.optimizer.OptimizerContext;
@@ -50,6 +51,7 @@ import com.starrocks.sql.optimizer.statistics.ColumnStatistic;
 import com.starrocks.sql.optimizer.statistics.Statistics;
 import com.starrocks.thrift.THiveFileInfo;
 import com.starrocks.thrift.TSinkCommitInfo;
+import com.starrocks.utframe.StarRocksAssert;
 import com.starrocks.utframe.UtFrameUtils;
 import mockit.Expectations;
 import mockit.Mock;
@@ -76,6 +78,7 @@ import java.util.function.Function;
 
 import static com.starrocks.connector.hive.HiveMetadata.STARROCKS_QUERY_ID;
 import static com.starrocks.connector.hive.MockedRemoteFileSystem.HDFS_HIVE_TABLE;
+import static com.starrocks.sql.analyzer.AnalyzeTestUtil.getStarRocksAssert;
 
 public class HiveMetadataTest {
     private HiveMetaClient client;
@@ -673,5 +676,51 @@ public class HiveMetadataTest {
         Partition remotePartition = new Partition(map, null, null, null, false);
         HivePartition hivePartition = new HivePartition(null, null, null, null, null, null, map);
         Assert.assertTrue(HiveCommitter.checkIsSamePartition(remotePartition, hivePartition));
+    }
+
+    @Test
+    public void testCreateTableTimeout() throws Exception {
+        AnalyzeTestUtil.init();
+        String stmt = "create table hive_catalog.hive_db.hive_table (k1 int, k2 int)";
+        String sql = "CREATE EXTERNAL CATALOG hive_catalog PROPERTIES(\"type\"=\"hive\", \"hive.metastore.uris\"=\"thrift://127.0.0.1:9083\")";
+        StarRocksAssert starRocksAssert = getStarRocksAssert();
+        starRocksAssert.withCatalog(sql);
+        new MockUp<HiveMetadata>() {
+            @Mock
+            public Database getDb(String dbName) {
+                return new Database();
+            }
+        };
+
+        new MockUp<HiveMetastoreOperations>() {
+            @Mock
+            public Path getDefaultLocation(String dbName, String tableName) {
+                return new Path("xxxxx");
+            }
+
+            @Mock
+            public boolean tableExists(String dbName, String tableName) {
+                return true;
+            }
+        };
+
+        new MockUp<HiveWriteUtils>() {
+            @Mock
+            public void createDirectory(Path path, Configuration conf) {
+
+            }
+        };
+
+        new MockUp<CachingHiveMetastore>() {
+            @Mock
+            public void createTable(String dbName, Table table) {
+                throw new StarRocksConnectorException("timeout");
+            }
+        };
+
+        CreateTableStmt createTableStmt =
+                (CreateTableStmt) UtFrameUtils.parseStmtWithNewParser(stmt, AnalyzeTestUtil.getConnectContext());
+
+        Assert.assertTrue(hiveMetadata.createTable(createTableStmt));
     }
 }


### PR DESCRIPTION
## Why I'm doing:
we will create table directory before accessing hms create_table.  If create_table request timeout, the client will retry once. it will throw table exists exception. then we will delete the table directory. but the table already exists in fact. So if the table exists when catching exception, we don't do anything.

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [x] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
