### PR TITLE
[Enhancement] Reduce duplicate request of schema file

### DIFF
--- a/be/src/storage/lake/tablet_manager.cpp
+++ b/be/src/storage/lake/tablet_manager.cpp
@@ -533,7 +533,7 @@ StatusOr<TabletSchemaPtr> TabletManager::get_tablet_schema_by_id(int64_t tablet_
     }
     // else: Cache miss, read the schema file
     auto schema_file_path = join_path(tablet_root_location(tablet_id), schema_filename(schema_id));
-    auto schema_or = load_and_parse_schema_file(schema_file_path);
+    auto schema_or = _schema_group.Do(schema_file_path, [&]() { return load_and_parse_schema_file(schema_file_path); });
     TEST_SYNC_POINT_CALLBACK("get_tablet_schema_by_id.2", &schema_or);
     if (schema_or.ok()) {
         schema = std::move(schema_or).value();

--- a/be/src/storage/lake/tablet_manager.h
+++ b/be/src/storage/lake/tablet_manager.h
@@ -27,6 +27,7 @@
 #include "storage/lake/txn_log.h"
 #include "storage/lake/types_fwd.h"
 #include "storage/options.h"
+#include "util/bthreads/single_flight.h"
 
 namespace starrocks {
 struct FileInfo;
@@ -208,6 +209,8 @@ private:
 
     std::shared_mutex _meta_lock;
     std::unordered_map<int64_t, int64_t> _tablet_in_writing_size;
+
+    bthreads::singleflight::Group<std::string, StatusOr<TabletSchemaPtr>> _schema_group;
 };
 
 } // namespace starrocks::lake

--- a/be/src/util/bthreads/future.h
+++ b/be/src/util/bthreads/future.h
@@ -115,6 +115,7 @@ public:
 
 private:
     friend class Promise<R>;
+    friend class SharedFuture<R>;
 
     explicit Future(std::shared_ptr<SharedState<R>> state) : BaseType(std::move(state)) {}
 };
@@ -150,6 +151,7 @@ public:
 
 private:
     friend class Promise<R&>;
+    friend class SharedFuture<R&>;
 
     explicit Future(std::shared_ptr<SharedState<R&>> state) : BaseType(std::move(state)) {}
 };
@@ -183,6 +185,7 @@ public:
 
 private:
     friend class Promise<void>;
+    friend class SharedFuture<void>;
 
     explicit Future(std::shared_ptr<SharedState<void>> state) : BaseType(std::move(state)) {}
 };
@@ -237,6 +240,7 @@ public:
 private:
     friend class Promise<R>;
     friend class Future<R>;
+    friend class FutureBase<R>;
 
     using BaseType = FutureBase<R>;
 

--- a/be/src/util/bthreads/future_impl.h
+++ b/be/src/util/bthreads/future_impl.h
@@ -162,6 +162,7 @@ public:
 private:
     friend class Future<R>;
     friend class FutureBase<R>;
+    friend class SharedFuture<R>;
     friend class Promise<R>;
 
     R& value() noexcept { return _result.value(); }


### PR DESCRIPTION
## Why I'm doing:
When importing, multiple tablets within the same partition may simultaneously request the same schema file, causing unnecessary resource waste

## What I'm doing:
Using SingleFlight to reduce concurrent requests

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
