### PR TITLE
[BugFix] Fix group execution crash with empty scan range (backport #44770)

### DIFF
--- a/be/src/exec/pipeline/fragment_executor.h
+++ b/be/src/exec/pipeline/fragment_executor.h
@@ -14,6 +14,7 @@
 
 #pragma once
 
+#include "common/global_types.h"
 #include "common/status.h"
 #include "exec/pipeline/pipeline.h"
 #include "exec/pipeline/pipeline_fwd.h"
@@ -65,6 +66,12 @@ public:
     // Access the unique fields by the following methods.
     int32_t backend_num() const { return _unique_request.backend_num; }
     int32_t pipeline_dop() const { return _unique_request.__isset.pipeline_dop ? _unique_request.pipeline_dop : 0; }
+    // The maximum number of pipelines that can be instantiated in a colocate group when group execution is enabled.
+    // if a fragment is not using group execution. It will return pipeline_dop()
+    int32_t group_execution_scan_dop() const {
+        return _unique_request.__isset.group_execution_scan_dop ? _unique_request.group_execution_scan_dop
+                                                                : pipeline_dop();
+    }
     int32_t pipeline_sink_dop() const {
         // NOTE: default dop is 1, compatible with old version(before 2.5)
         return _unique_request.params.__isset.pipeline_sink_dop ? _unique_request.params.pipeline_sink_dop : 1;
@@ -120,6 +127,9 @@ private:
     Status _prepare_global_dict(const UnifiedExecPlanFragmentParams& request);
     Status _prepare_pipeline_driver(ExecEnv* exec_env, const UnifiedExecPlanFragmentParams& request);
     Status _prepare_stream_load_pipe(ExecEnv* exec_env, const UnifiedExecPlanFragmentParams& request);
+
+    std::unordered_map<int32_t, ExecutionGroupPtr> _colocate_exec_groups;
+    bool _is_in_colocate_exec_group(PlanNodeId plan_node_id);
 
     int64_t _fragment_start_time = 0;
     QueryContext* _query_ctx = nullptr;

--- a/be/src/exec/scan_node.cpp
+++ b/be/src/exec/scan_node.cpp
@@ -126,9 +126,9 @@ static std::map<int, pipeline::MorselQueuePtr> uniform_distribute_morsels(pipeli
 StatusOr<pipeline::MorselQueueFactoryPtr> ScanNode::convert_scan_range_to_morsel_queue_factory(
         const std::vector<TScanRangeParams>& global_scan_ranges,
         const std::map<int32_t, std::vector<TScanRangeParams>>& scan_ranges_per_driver_seq, int node_id,
-        int pipeline_dop, bool enable_tablet_internal_parallel,
+        int pipeline_dop, bool in_colocate_exec_group, bool enable_tablet_internal_parallel,
         TTabletInternalParallelMode::type tablet_internal_parallel_mode) {
-    if (scan_ranges_per_driver_seq.empty()) {
+    if (scan_ranges_per_driver_seq.empty() && !in_colocate_exec_group) {
         ASSIGN_OR_RETURN(auto morsel_queue,
                          convert_scan_range_to_morsel_queue(global_scan_ranges, node_id, pipeline_dop,
                                                             enable_tablet_internal_parallel,
@@ -161,6 +161,11 @@ StatusOr<pipeline::MorselQueueFactoryPtr> ScanNode::convert_scan_range_to_morsel
                                                  scan_ranges, node_id, pipeline_dop, enable_tablet_internal_parallel,
                                                  tablet_internal_parallel_mode, num_total_scan_ranges));
             queue_per_driver_seq.emplace(dop, std::move(queue));
+        }
+
+        // both of global_scan_ranges and scan_ranges_per_driver_seq are empty, create an empty morsel queue
+        if (queue_per_driver_seq.empty()) {
+            queue_per_driver_seq.emplace(pipeline_dop - 1, pipeline::create_empty_morsel_queue());
         }
 
         if (output_chunk_by_bucket()) {

--- a/be/src/exec/scan_node.h
+++ b/be/src/exec/scan_node.h
@@ -86,7 +86,7 @@ public:
     StatusOr<pipeline::MorselQueueFactoryPtr> convert_scan_range_to_morsel_queue_factory(
             const std::vector<TScanRangeParams>& scan_ranges,
             const std::map<int32_t, std::vector<TScanRangeParams>>& scan_ranges_per_driver_seq, int node_id,
-            int pipeline_dop, bool enable_tablet_internal_parallel,
+            int pipeline_dop, bool in_colocate_exec_group, bool enable_tablet_internal_parallel,
             TTabletInternalParallelMode::type tablet_internal_parallel_mode);
     virtual StatusOr<pipeline::MorselQueuePtr> convert_scan_range_to_morsel_queue(
             const std::vector<TScanRangeParams>& scan_ranges, int node_id, int32_t pipeline_dop,

--- a/be/test/exec/connector_scan_node_test.cpp
+++ b/be/test/exec/connector_scan_node_test.cpp
@@ -151,7 +151,7 @@ TEST_F(ConnectorScanNodeTest, test_convert_scan_range_to_morsel_queue_factory_cl
     auto scan_ranges = create_scan_ranges_cloud(1);
     ASSIGN_OR_ABORT(auto morsel_queue_factory,
                     scan_node->convert_scan_range_to_morsel_queue_factory(
-                            scan_ranges, no_scan_ranges_per_driver_seq, scan_node->id(), pipeline_dop,
+                            scan_ranges, no_scan_ranges_per_driver_seq, scan_node->id(), pipeline_dop, false,
                             enable_tablet_internal_parallel, tablet_internal_parallel_mode));
     ASSERT_TRUE(morsel_queue_factory->is_shared());
 
@@ -160,7 +160,7 @@ TEST_F(ConnectorScanNodeTest, test_convert_scan_range_to_morsel_queue_factory_cl
     scan_ranges = create_scan_ranges_cloud(pipeline_dop * scan_node->io_tasks_per_scan_operator());
     ASSIGN_OR_ABORT(morsel_queue_factory,
                     scan_node->convert_scan_range_to_morsel_queue_factory(
-                            scan_ranges, no_scan_ranges_per_driver_seq, scan_node->id(), pipeline_dop,
+                            scan_ranges, no_scan_ranges_per_driver_seq, scan_node->id(), pipeline_dop, false,
                             enable_tablet_internal_parallel, tablet_internal_parallel_mode));
     ASSERT_FALSE(morsel_queue_factory->is_shared());
 
@@ -169,7 +169,7 @@ TEST_F(ConnectorScanNodeTest, test_convert_scan_range_to_morsel_queue_factory_cl
     scan_ranges = create_scan_ranges_cloud(pipeline_dop * scan_node->io_tasks_per_scan_operator() + 1);
     ASSIGN_OR_ABORT(morsel_queue_factory,
                     scan_node->convert_scan_range_to_morsel_queue_factory(
-                            scan_ranges, no_scan_ranges_per_driver_seq, scan_node->id(), pipeline_dop,
+                            scan_ranges, no_scan_ranges_per_driver_seq, scan_node->id(), pipeline_dop, false,
                             enable_tablet_internal_parallel, tablet_internal_parallel_mode));
     ASSERT_TRUE(morsel_queue_factory->is_shared());
 }
@@ -230,7 +230,7 @@ TEST_F(ConnectorScanNodeTest, test_convert_scan_range_to_morsel_queue_factory_hi
     auto scan_ranges = create_scan_ranges_hive(1);
     ASSIGN_OR_ABORT(auto morsel_queue_factory,
                     scan_node->convert_scan_range_to_morsel_queue_factory(
-                            scan_ranges, no_scan_ranges_per_driver_seq, scan_node->id(), pipeline_dop,
+                            scan_ranges, no_scan_ranges_per_driver_seq, scan_node->id(), pipeline_dop, false,
                             enable_tablet_internal_parallel, tablet_internal_parallel_mode));
     ASSERT_TRUE(morsel_queue_factory->is_shared());
 
@@ -239,7 +239,7 @@ TEST_F(ConnectorScanNodeTest, test_convert_scan_range_to_morsel_queue_factory_hi
     scan_ranges = create_scan_ranges_hive(pipeline_dop * scan_node->io_tasks_per_scan_operator());
     ASSIGN_OR_ABORT(morsel_queue_factory,
                     scan_node->convert_scan_range_to_morsel_queue_factory(
-                            scan_ranges, no_scan_ranges_per_driver_seq, scan_node->id(), pipeline_dop,
+                            scan_ranges, no_scan_ranges_per_driver_seq, scan_node->id(), pipeline_dop, false,
                             enable_tablet_internal_parallel, tablet_internal_parallel_mode));
     ASSERT_TRUE(morsel_queue_factory->is_shared());
 
@@ -248,7 +248,7 @@ TEST_F(ConnectorScanNodeTest, test_convert_scan_range_to_morsel_queue_factory_hi
     scan_ranges = create_scan_ranges_hive(pipeline_dop * scan_node->io_tasks_per_scan_operator() + 1);
     ASSIGN_OR_ABORT(morsel_queue_factory,
                     scan_node->convert_scan_range_to_morsel_queue_factory(
-                            scan_ranges, no_scan_ranges_per_driver_seq, scan_node->id(), pipeline_dop,
+                            scan_ranges, no_scan_ranges_per_driver_seq, scan_node->id(), pipeline_dop, false,
                             enable_tablet_internal_parallel, tablet_internal_parallel_mode));
     ASSERT_TRUE(morsel_queue_factory->is_shared());
 }

--- a/be/test/exec/pipeline/pipeline_file_scan_node_test.cpp
+++ b/be/test/exec/pipeline/pipeline_file_scan_node_test.cpp
@@ -265,7 +265,7 @@ void PipeLineFileScanNodeTest::generate_morse_queue(const std::vector<starrocks:
     for (auto& i : scan_nodes) {
         auto* scan_node = (ScanNode*)(i);
         auto morsel_queue_factory = scan_node->convert_scan_range_to_morsel_queue_factory(
-                scan_ranges, no_scan_ranges_per_driver_seq, scan_node->id(), degree_of_parallelism, true,
+                scan_ranges, no_scan_ranges_per_driver_seq, scan_node->id(), degree_of_parallelism, false, true,
                 TTabletInternalParallelMode::type::AUTO);
         DCHECK(morsel_queue_factory.ok());
         morsel_queue_factories.emplace(scan_node->id(), std::move(morsel_queue_factory).value());

--- a/be/test/exec/stream/stream_operators_test.cpp
+++ b/be/test/exec/stream/stream_operators_test.cpp
@@ -181,7 +181,7 @@ void StreamOperatorsTest::_generate_morse_queue(ConnectorScanNode* scan_node,
 
     std::map<int32_t, std::vector<TScanRangeParams>> no_scan_ranges_per_driver_seq;
     auto morsel_queue_factory = scan_node->convert_scan_range_to_morsel_queue_factory(
-            scan_ranges, no_scan_ranges_per_driver_seq, scan_node->id(), degree_of_parallelism, true,
+            scan_ranges, no_scan_ranges_per_driver_seq, scan_node->id(), degree_of_parallelism, false, true,
             TTabletInternalParallelMode::type::AUTO);
     ASSERT_TRUE(morsel_queue_factory.ok());
     morsel_queue_factories.emplace(scan_node->id(), std::move(morsel_queue_factory).value());

--- a/be/test/storage/lake/lake_scan_node_test.cpp
+++ b/be/test/storage/lake/lake_scan_node_test.cpp
@@ -172,7 +172,7 @@ TEST_F(LakeScanNodeTest, test_could_split) {
     auto scan_ranges = create_scan_ranges_cloud(tablet_metas);
     ASSIGN_OR_ABORT(auto morsel_queue_factory,
                     scan_node->convert_scan_range_to_morsel_queue_factory(
-                            scan_ranges, no_scan_ranges_per_driver_seq, scan_node->id(), pipeline_dop,
+                            scan_ranges, no_scan_ranges_per_driver_seq, scan_node->id(), pipeline_dop, false,
                             enable_tablet_internal_parallel, tablet_internal_parallel_mode));
     ASSERT_FALSE(data_source_provider->could_split());
     ASSERT_FALSE(data_source_provider->could_split_physically());
@@ -182,7 +182,7 @@ TEST_F(LakeScanNodeTest, test_could_split) {
     config::tablet_internal_parallel_min_scan_dop = 10;
     ASSIGN_OR_ABORT(morsel_queue_factory,
                     scan_node->convert_scan_range_to_morsel_queue_factory(
-                            scan_ranges, no_scan_ranges_per_driver_seq, scan_node->id(), pipeline_dop,
+                            scan_ranges, no_scan_ranges_per_driver_seq, scan_node->id(), pipeline_dop, false,
                             enable_tablet_internal_parallel, tablet_internal_parallel_mode));
     ASSERT_FALSE(data_source_provider->could_split());
     ASSERT_FALSE(data_source_provider->could_split_physically());
@@ -192,7 +192,7 @@ TEST_F(LakeScanNodeTest, test_could_split) {
     config::tablet_internal_parallel_min_scan_dop = 4;
     ASSIGN_OR_ABORT(morsel_queue_factory,
                     scan_node->convert_scan_range_to_morsel_queue_factory(
-                            scan_ranges, no_scan_ranges_per_driver_seq, scan_node->id(), pipeline_dop,
+                            scan_ranges, no_scan_ranges_per_driver_seq, scan_node->id(), pipeline_dop, false,
                             enable_tablet_internal_parallel, tablet_internal_parallel_mode));
     ASSERT_TRUE(data_source_provider->could_split());
     ASSERT_TRUE(data_source_provider->could_split_physically());

--- a/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/TFragmentInstanceFactory.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/TFragmentInstanceFactory.java
@@ -175,6 +175,7 @@ public class TFragmentInstanceFactory {
         result.setBackend_num(instance.getIndexInJob());
         if (isEnablePipeline) {
             result.setPipeline_dop(instance.getPipelineDop());
+            result.setGroup_execution_scan_dop(instance.getGroupExecutionScanDop());
         }
 
         // Add instance number in file name prefix when export job.

--- a/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/assignment/LocalFragmentAssignmentStrategy.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/assignment/LocalFragmentAssignmentStrategy.java
@@ -210,6 +210,7 @@ public class LocalFragmentAssignmentStrategy implements FragmentAssignmentStrate
                     }
                     List<List<Integer>> bucketSeqsPerDriverSeq = ListUtil.splitBySize(bucketSeqsOfInstance, logicalDop);
                     instance.setPipelineDop(expectedPhysicalDop);
+                    instance.setGroupExecutionScanDop(logicalDop);
 
                     for (int driverSeq = 0; driverSeq < bucketSeqsPerDriverSeq.size(); driverSeq++) {
                         int finalDriverSeq = driverSeq;
@@ -223,7 +224,7 @@ public class LocalFragmentAssignmentStrategy implements FragmentAssignmentStrate
                         });
                     }
 
-                    instance.paddingScanRanges(logicalDop);
+                    instance.paddingScanRanges();
                 }
             });
         });
@@ -279,11 +280,12 @@ public class LocalFragmentAssignmentStrategy implements FragmentAssignmentStrate
                             fragment.setPipelineDop(expectedPhysicalDop);
                         }
                         instance.setPipelineDop(expectedPhysicalDop);
+                        instance.setGroupExecutionScanDop(logicalDop);
 
                         for (int driverSeq = 0; driverSeq < scanRangesPerDriverSeq.size(); ++driverSeq) {
                             instance.addScanRanges(scanId, driverSeq, scanRangesPerDriverSeq.get(driverSeq));
                         }
-                        instance.paddingScanRanges(logicalDop);
+                        instance.paddingScanRanges();
                     }
                 }
             });

--- a/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/dag/FragmentInstance.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/dag/FragmentInstance.java
@@ -69,6 +69,7 @@ public class FragmentInstance {
     private final ExecutionFragment execFragment;
 
     private int pipelineDop = ABSENT_PIPELINE_DOP;
+    private int groupExecutionScanDop = ABSENT_PIPELINE_DOP;
 
     private final ComputeNode worker;
 
@@ -214,6 +215,18 @@ public class FragmentInstance {
         this.pipelineDop = pipelineDop;
     }
 
+    public int getGroupExecutionScanDop() {
+        if (groupExecutionScanDop == ABSENT_PIPELINE_DOP) {
+            return getPipelineDop();
+        }
+        return groupExecutionScanDop;
+    }
+
+    public void setGroupExecutionScanDop(int groupExecutionScanDop) {
+        this.groupExecutionScanDop = groupExecutionScanDop;
+    }
+
+
     public FragmentInstanceExecState getExecution() {
         return execution;
     }
@@ -287,9 +300,9 @@ public class FragmentInstance {
                 .computeIfAbsent(driverSeq, k -> new ArrayList<>()).addAll(scanRanges);
     }
 
-    public void paddingScanRanges(int logicalDop) {
+    public void paddingScanRanges() {
         node2DriverSeqToScanRanges.forEach((scanId, driverSeqToScanRanges) -> {
-            for (int driverSeq = 0; driverSeq < logicalDop; driverSeq++) {
+            for (int driverSeq = 0; driverSeq < groupExecutionScanDop; driverSeq++) {
                 driverSeqToScanRanges.computeIfAbsent(driverSeq, k -> new ArrayList<>());
             }
         });

--- a/gensrc/thrift/InternalService.thrift
+++ b/gensrc/thrift/InternalService.thrift
@@ -437,6 +437,7 @@ struct TExecPlanFragmentParams {
   57: optional bool is_stream_pipeline
 
   58: optional TAdaptiveDopParam adaptive_dop_param
+  59: optional i32 group_execution_scan_dop
 }
 
 struct TExecPlanFragmentResult {

--- a/test/conf/sr.conf
+++ b/test/conf/sr.conf
@@ -1,7 +1,7 @@
 [mysql-client]
-host = 127.0.0.1
-port = 9054
-user = root
+host = 
+port = 
+user =
 password =
 http_port =
 host_user =

--- a/test/sql/test_group_execution/R/test_group_execution_prune
+++ b/test/sql/test_group_execution/R/test_group_execution_prune
@@ -1,0 +1,183 @@
+-- name: test_group_execution_prune
+set enable_group_execution = true;
+-- result:
+-- !result
+[UC]set enable_predicate_move_around = false;
+-- result:
+-- !result
+CREATE TABLE t0 (
+  k1 bigint null
+) ENGINE=OLAP
+DUPLICATE KEY(`k1`)
+DISTRIBUTED BY HASH(`k1`) BUCKETS 48
+PROPERTIES (
+    "replication_num" = "1"
+);
+-- result:
+-- !result
+insert into t0 select generate_series from TABLE(generate_series(0, 10000 - 1));
+-- result:
+-- !result
+insert into t0 select k1 + 20000 from t0;
+-- result:
+-- !result
+insert into t0 select k1 + 40000 from t0;
+-- result:
+-- !result
+insert into t0 select k1 + 80000 from t0;
+-- result:
+-- !result
+with
+    t1 as (select * from t0 where k1 = 1),
+    t2 as (select * from t0)
+select count(1) from t1 join [colocate] t2 using(k1);
+-- result:
+1
+-- !result
+with
+    t1 as (select * from t0 where k1 in (1,2,3,4)),
+    t2 as (select * from t0)
+select count(1) from t1 join [colocate] t2 using(k1);
+-- result:
+4
+-- !result
+with
+    t1 as (select * from t0 where k1 not in (1,2,3,4)),
+    t2 as (select * from t0)
+select count(1) from t1 join [colocate] t2 using(k1);
+-- result:
+79996
+-- !result
+with
+    t1 as (select * from t0 where k1 != 1),
+    t2 as (select * from t0)
+select count(1) from t1 join [colocate] t2 using(k1);
+-- result:
+79999
+-- !result
+with
+    t1 as (select * from t0 where k1 > 1),
+    t2 as (select * from t0)
+select count(1) from t1 join [colocate] t2 using(k1);
+-- result:
+79998
+-- !result
+with
+    t1 as (select * from t0 where k1 < 1),
+    t2 as (select * from t0)
+select count(1) from t1 join [colocate] t2 using(k1);
+-- result:
+1
+-- !result
+with
+    t1 as (select * from t0 where k1 = 1),
+    t2 as (select * from t0)
+select count(*) from (select count(1) from t1 join [bucket] t2 using(k1) group by t1.k1) tb;
+-- result:
+1
+-- !result
+with
+    t1 as (select * from t0 where k1 >= 1),
+    t2 as (select * from t0)
+select count(*) from (select count(1) from t1 join [bucket] t2 using(k1) group by t1.k1) tb;
+-- result:
+79999
+-- !result
+with
+    t1 as (select * from t0 where k1 < 1),
+    t2 as (select * from t0)
+select count(*) from (select count(1) from t1 join [bucket] t2 using(k1) group by t1.k1) tb;
+-- result:
+1
+-- !result
+with
+    t1 as (select * from t0 where k1 in (1,2,3,4)),
+    t2 as (select * from t0)
+select count(*) from (select count(1) from t1 join [bucket] t2 using(k1) group by t1.k1) tb;
+-- result:
+4
+-- !result
+with
+    t1 as (select * from t0 where k1 not in (1,2,3,4)),
+    t2 as (select * from t0)
+select count(*) from (select count(1) from t1 join [bucket] t2 using(k1) group by t1.k1) tb;
+-- result:
+79996
+-- !result
+with
+    t1 as (select * from t0 where k1 = 1),
+    t2 as (select * from t0)
+select count(1) from t2 join [colocate] t1 using(k1);
+-- result:
+1
+-- !result
+with
+    t1 as (select * from t0 where k1 in (1,2,3,4)),
+    t2 as (select * from t0)
+select count(1) from t2 join [colocate] t1 using(k1);
+-- result:
+4
+-- !result
+with
+    t1 as (select * from t0 where k1 not in (1,2,3,4)),
+    t2 as (select * from t0)
+select count(1) from t2 join [colocate] t1 using(k1);
+-- result:
+79996
+-- !result
+with
+    t1 as (select * from t0 where k1 != 1),
+    t2 as (select * from t0)
+select count(1) from t2 join [colocate] t1 using(k1);
+-- result:
+79999
+-- !result
+with
+    t1 as (select * from t0 where k1 > 1),
+    t2 as (select * from t0)
+select count(1) from t2 join [colocate] t1 using(k1);
+-- result:
+79998
+-- !result
+with
+    t1 as (select * from t0 where k1 < 1),
+    t2 as (select * from t0)
+select count(1) from t2 join [colocate] t1 using(k1);
+-- result:
+1
+-- !result
+with
+    t1 as (select * from t0 where k1 = 1),
+    t2 as (select * from t0)
+select count(*) from (select count(1) from t2 join [bucket] t1 using(k1) group by t1.k1) tb;
+-- result:
+1
+-- !result
+with
+    t1 as (select * from t0 where k1 >= 1),
+    t2 as (select * from t0)
+select count(*) from (select count(1) from t2 join [bucket] t1 using(k1) group by t1.k1) tb;
+-- result:
+79999
+-- !result
+with
+    t1 as (select * from t0 where k1 < 1),
+    t2 as (select * from t0)
+select count(*) from (select count(1) from t2 join [bucket] t1 using(k1) group by t1.k1) tb;
+-- result:
+1
+-- !result
+with
+    t1 as (select * from t0 where k1 in (1,2,3,4)),
+    t2 as (select * from t0)
+select count(*) from (select count(1) from t2 join [bucket] t1 using(k1) group by t1.k1) tb;
+-- result:
+4
+-- !result
+with
+    t1 as (select * from t0 where k1 not in (1,2,3,4)),
+    t2 as (select * from t0)
+select count(*) from (select count(1) from t2 join [bucket] t1 using(k1) group by t1.k1) tb;
+-- result:
+79996
+-- !result

--- a/test/sql/test_group_execution/T/test_group_execution_prune
+++ b/test/sql/test_group_execution/T/test_group_execution_prune
@@ -1,0 +1,127 @@
+-- name: test_group_execution_prune
+set enable_group_execution = true;
+[UC]set enable_predicate_move_around = false;
+
+CREATE TABLE t0 (
+  k1 bigint null
+) ENGINE=OLAP
+DUPLICATE KEY(`k1`)
+DISTRIBUTED BY HASH(`k1`) BUCKETS 48
+PROPERTIES (
+    "replication_num" = "1"
+);
+insert into t0 select generate_series from TABLE(generate_series(0, 10000 - 1));
+insert into t0 select k1 + 20000 from t0;
+insert into t0 select k1 + 40000 from t0;
+insert into t0 select k1 + 80000 from t0;
+
+-- prune left
+with
+    t1 as (select * from t0 where k1 = 1),
+    t2 as (select * from t0)
+select count(1) from t1 join [colocate] t2 using(k1);
+
+with
+    t1 as (select * from t0 where k1 in (1,2,3,4)),
+    t2 as (select * from t0)
+select count(1) from t1 join [colocate] t2 using(k1);
+
+with
+    t1 as (select * from t0 where k1 not in (1,2,3,4)),
+    t2 as (select * from t0)
+select count(1) from t1 join [colocate] t2 using(k1);
+
+with
+    t1 as (select * from t0 where k1 != 1),
+    t2 as (select * from t0)
+select count(1) from t1 join [colocate] t2 using(k1);
+
+with
+    t1 as (select * from t0 where k1 > 1),
+    t2 as (select * from t0)
+select count(1) from t1 join [colocate] t2 using(k1);
+
+with
+    t1 as (select * from t0 where k1 < 1),
+    t2 as (select * from t0)
+select count(1) from t1 join [colocate] t2 using(k1);
+
+with
+    t1 as (select * from t0 where k1 = 1),
+    t2 as (select * from t0)
+select count(*) from (select count(1) from t1 join [bucket] t2 using(k1) group by t1.k1) tb;
+
+with
+    t1 as (select * from t0 where k1 >= 1),
+    t2 as (select * from t0)
+select count(*) from (select count(1) from t1 join [bucket] t2 using(k1) group by t1.k1) tb;
+
+with
+    t1 as (select * from t0 where k1 < 1),
+    t2 as (select * from t0)
+select count(*) from (select count(1) from t1 join [bucket] t2 using(k1) group by t1.k1) tb;
+
+with
+    t1 as (select * from t0 where k1 in (1,2,3,4)),
+    t2 as (select * from t0)
+select count(*) from (select count(1) from t1 join [bucket] t2 using(k1) group by t1.k1) tb;
+
+with
+    t1 as (select * from t0 where k1 not in (1,2,3,4)),
+    t2 as (select * from t0)
+select count(*) from (select count(1) from t1 join [bucket] t2 using(k1) group by t1.k1) tb;
+-- prune right
+with
+    t1 as (select * from t0 where k1 = 1),
+    t2 as (select * from t0)
+select count(1) from t2 join [colocate] t1 using(k1);
+
+with
+    t1 as (select * from t0 where k1 in (1,2,3,4)),
+    t2 as (select * from t0)
+select count(1) from t2 join [colocate] t1 using(k1);
+
+with
+    t1 as (select * from t0 where k1 not in (1,2,3,4)),
+    t2 as (select * from t0)
+select count(1) from t2 join [colocate] t1 using(k1);
+
+with
+    t1 as (select * from t0 where k1 != 1),
+    t2 as (select * from t0)
+select count(1) from t2 join [colocate] t1 using(k1);
+
+with
+    t1 as (select * from t0 where k1 > 1),
+    t2 as (select * from t0)
+select count(1) from t2 join [colocate] t1 using(k1);
+
+with
+    t1 as (select * from t0 where k1 < 1),
+    t2 as (select * from t0)
+select count(1) from t2 join [colocate] t1 using(k1);
+
+with
+    t1 as (select * from t0 where k1 = 1),
+    t2 as (select * from t0)
+select count(*) from (select count(1) from t2 join [bucket] t1 using(k1) group by t1.k1) tb;
+
+with
+    t1 as (select * from t0 where k1 >= 1),
+    t2 as (select * from t0)
+select count(*) from (select count(1) from t2 join [bucket] t1 using(k1) group by t1.k1) tb;
+
+with
+    t1 as (select * from t0 where k1 < 1),
+    t2 as (select * from t0)
+select count(*) from (select count(1) from t2 join [bucket] t1 using(k1) group by t1.k1) tb;
+
+with
+    t1 as (select * from t0 where k1 in (1,2,3,4)),
+    t2 as (select * from t0)
+select count(*) from (select count(1) from t2 join [bucket] t1 using(k1) group by t1.k1) tb;
+
+with
+    t1 as (select * from t0 where k1 not in (1,2,3,4)),
+    t2 as (select * from t0)
+select count(*) from (select count(1) from t2 join [bucket] t1 using(k1) group by t1.k1) tb;


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [x] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5

