### PR TITLE
[BugFix] Fix parquet footer not have min max statistics caused inaccurate query results (backport #44489)

### DIFF
--- a/be/src/formats/parquet/file_reader.cpp
+++ b/be/src/formats/parquet/file_reader.cpp
@@ -206,6 +206,16 @@ Status FileReader::_read_min_max_chunk(const tparquet::RowGroup& row_group, cons
             *exist = false;
             return Status::OK();
         } else {
+            // When statistics is empty, column_meta->__isset.statistics is still true,
+            // but statistics.__isset.xxx may be false, so judgment is required here.
+            bool is_set_min_max =
+                    (column_meta->statistics.__isset.max && column_meta->statistics.__isset.min) ||
+                    (column_meta->statistics.__isset.max_value && column_meta->statistics.__isset.min_value);
+            if (!is_set_min_max) {
+                *exist = false;
+                return Status::OK();
+            }
+
             const ParquetField* field = _file_metadata->schema().resolve_by_name(slot->col_name());
             const tparquet::ColumnOrder* column_order = nullptr;
             if (_file_metadata->t_metadata().__isset.column_orders) {


### PR DESCRIPTION

## Why I'm doing:

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [x] This is a backport pr

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5

