### PR TITLE
[BugFix] Fix the bug of direct schema change

### DIFF
--- a/be/src/storage/schema_change.cpp
+++ b/be/src/storage/schema_change.cpp
@@ -914,7 +914,7 @@ Status SchemaChangeHandler::_do_process_alter_tablet_normal(const TAlterTabletRe
     read_params.chunk_size = config::vector_chunk_size;
     if (sc_params.sc_directly) {
         // If the segments of rowset is overlapping, will should use heap merge,
-        // otherwise the Otherwise ShortKeyIndex is not ordered
+        // otherwise the rows is not ordered by short key.
         read_params.sorted_by_keys_per_tablet = true;
     }
 

--- a/be/src/storage/schema_change.cpp
+++ b/be/src/storage/schema_change.cpp
@@ -259,13 +259,8 @@ void HeapChunkMerger::_pop_heap() {
 Status LinkedSchemaChange::process(TabletReader* reader, RowsetWriter* new_rowset_writer, TabletSharedPtr new_tablet,
                                    TabletSharedPtr base_tablet, RowsetSharedPtr rowset,
                                    TabletSchemaCSPtr base_tablet_schema) {
-#ifndef BE_TEST
-    Status st = CurrentThread::mem_tracker()->check_mem_limit("LinkedSchemaChange");
-    if (!st.ok()) {
-        LOG(WARNING) << alter_msg_header() << "fail to execute schema change: " << st.message() << std::endl;
-        return st;
-    }
-#endif
+    RETURN_IF_ERROR_WITH_WARN(CurrentThread::mem_tracker()->check_mem_limit("LinkedSchemaChange"),
+                              fmt::format("{}fail to execute schema change", alter_msg_header()));
 
     Status status =
             new_rowset_writer->add_rowset_for_linked_schema_change(rowset, _chunk_changer->get_schema_mapping());
@@ -444,13 +439,9 @@ Status SchemaChangeDirectly::process(TabletReader* reader, RowsetWriter* new_row
             return Status::InternalError(alter_msg_header() + "bg_worker_stopped");
         }
 
-#ifndef BE_TEST
-        st = CurrentThread::mem_tracker()->check_mem_limit("DirectSchemaChange");
-        if (!st.ok()) {
-            LOG(WARNING) << alter_msg_header() << "fail to execute schema change: " << st.message() << std::endl;
-            return st;
-        }
-#endif
+        RETURN_IF_ERROR_WITH_WARN(CurrentThread::mem_tracker()->check_mem_limit("DirectSchemaChange"),
+                                  fmt::format("{}fail to execute schema change", alter_msg_header()));
+
         if (st = reader->do_get_next(base_chunk.get()); !st.ok()) {
             if (is_eos = st.is_end_of_file(); !is_eos) {
                 LOG(WARNING) << alter_msg_header()
@@ -644,7 +635,7 @@ Status SchemaChangeWithSorting::_internal_sorting(std::vector<ChunkPtr>& chunk_a
     return Status::OK();
 }
 
-Status SchemaChangeHandler::process_alter_tablet_v2(const TAlterTabletReqV2& request) {
+Status SchemaChangeHandler::process_alter_tablet(const TAlterTabletReqV2& request) {
     LOG(INFO) << _alter_msg_header << "begin to do request alter tablet: base_tablet_id=" << request.base_tablet_id
               << ", base_schema_hash=" << request.base_schema_hash << ", new_tablet_id=" << request.new_tablet_id
               << ", new_schema_hash=" << request.new_schema_hash << ", alter_version=" << request.alter_version;
@@ -662,14 +653,14 @@ Status SchemaChangeHandler::process_alter_tablet_v2(const TAlterTabletReqV2& req
     DeferOp release_lock(
             [&] { StorageEngine::instance()->tablet_manager()->release_schema_change_lock(request.base_tablet_id); });
 
-    Status status = _do_process_alter_tablet_v2(request);
+    Status status = _do_process_alter_tablet(request);
     LOG(INFO) << _alter_msg_header << "finished alter tablet process, status=" << status.to_string()
               << " duration: " << timer.elapsed_time() / 1000000
               << "ms, peak_mem_usage: " << CurrentThread::mem_tracker()->peak_consumption() << " bytes";
     return status;
 }
 
-Status SchemaChangeHandler::_do_process_alter_tablet_v2(const TAlterTabletReqV2& request) {
+Status SchemaChangeHandler::_do_process_alter_tablet(const TAlterTabletReqV2& request) {
     TabletSharedPtr base_tablet = StorageEngine::instance()->tablet_manager()->get_tablet(request.base_tablet_id);
     if (base_tablet == nullptr) {
         LOG(WARNING) << _alter_msg_header << "fail to find base tablet. base_tablet=" << request.base_tablet_id
@@ -817,14 +808,14 @@ Status SchemaChangeHandler::_do_process_alter_tablet_v2(const TAlterTabletReqV2&
         }
         return Status::OK();
     } else {
-        return _do_process_alter_tablet_v2_normal(request, sc_params, base_tablet, new_tablet);
+        return _do_process_alter_tablet_normal(request, sc_params, base_tablet, new_tablet);
     }
 }
 
-Status SchemaChangeHandler::_do_process_alter_tablet_v2_normal(const TAlterTabletReqV2& request,
-                                                               SchemaChangeParams& sc_params,
-                                                               const TabletSharedPtr& base_tablet,
-                                                               const TabletSharedPtr& new_tablet) {
+Status SchemaChangeHandler::_do_process_alter_tablet_normal(const TAlterTabletReqV2& request,
+                                                            SchemaChangeParams& sc_params,
+                                                            const TabletSharedPtr& base_tablet,
+                                                            const TabletSharedPtr& new_tablet) {
     // begin to find deltas to convert from base tablet to new tablet so that
     // obtain base tablet and new tablet's push lock and header write lock to prevent loading data
     RowsetSharedPtr max_rowset;
@@ -921,6 +912,11 @@ Status SchemaChangeHandler::_do_process_alter_tablet_v2_normal(const TAlterTable
     read_params.reader_type = ReaderType::READER_ALTER_TABLE;
     read_params.skip_aggregation = false;
     read_params.chunk_size = config::vector_chunk_size;
+    if (sc_params.sc_directly) {
+        // If the segments of rowset is overlapping, will should use heap merge,
+        // otherwise the Otherwise ShortKeyIndex is not ordered
+        read_params.sorted_by_keys_per_tablet = true;
+    }
 
     // open tablet readers out of lock for open is heavy because of io
     for (auto& tablet_reader : readers) {

--- a/be/src/storage/schema_change.h
+++ b/be/src/storage/schema_change.h
@@ -137,8 +137,7 @@ public:
     SchemaChangeHandler() = default;
     ~SchemaChangeHandler() = default;
 
-    // schema change v2, it will not set alter task in base tablet
-    Status process_alter_tablet_v2(const TAlterTabletReqV2& request);
+    Status process_alter_tablet(const TAlterTabletReqV2& request);
 
     void set_alter_msg_header(std::string msg) { _alter_msg_header = msg; }
 
@@ -146,10 +145,10 @@ private:
     Status _get_versions_to_be_changed(const TabletSharedPtr& base_tablet,
                                        std::vector<Version>* versions_to_be_changed);
 
-    Status _do_process_alter_tablet_v2(const TAlterTabletReqV2& request);
+    Status _do_process_alter_tablet(const TAlterTabletReqV2& request);
 
-    Status _do_process_alter_tablet_v2_normal(const TAlterTabletReqV2& request, SchemaChangeParams& sc_params,
-                                              const TabletSharedPtr& base_tablet, const TabletSharedPtr& new_tablet);
+    Status _do_process_alter_tablet_normal(const TAlterTabletReqV2& request, SchemaChangeParams& sc_params,
+                                           const TabletSharedPtr& base_tablet, const TabletSharedPtr& new_tablet);
 
     Status _validate_alter_result(const TabletSharedPtr& new_tablet, const TAlterTabletReqV2& request);
 

--- a/be/src/storage/segment_replicate_executor.h
+++ b/be/src/storage/segment_replicate_executor.h
@@ -36,8 +36,6 @@ class PTabletInfo;
 class FileSystem;
 struct DeltaWriterOptions;
 
-using DeltaWriterOptions = starrocks::DeltaWriterOptions;
-
 class ReplicateChannel {
 public:
     ReplicateChannel(const DeltaWriterOptions* opt, std::string host, int32_t port, int64_t node_id);

--- a/be/src/storage/task/engine_alter_tablet_task.cpp
+++ b/be/src/storage/task/engine_alter_tablet_task.cpp
@@ -68,7 +68,7 @@ Status EngineAlterTabletTask::execute() {
     } else {
         SchemaChangeHandler handler;
         handler.set_alter_msg_header(alter_msg_header);
-        res = handler.process_alter_tablet_v2(_alter_tablet_req);
+        res = handler.process_alter_tablet(_alter_tablet_req);
     }
     if (!res.ok()) {
         LOG(WARNING) << alter_msg_header << "failed to do alter task. status=" << res.to_string()

--- a/be/src/testutil/CMakeLists.txt
+++ b/be/src/testutil/CMakeLists.txt
@@ -27,5 +27,7 @@ add_library(TestUtil
     function_utils.cpp
     sync_point.cc
     sync_point_impl.cc
+    schema_test_helper.cpp
+    tablet_test_helper.cpp
 )
 

--- a/be/src/testutil/schema_test_helper.cpp
+++ b/be/src/testutil/schema_test_helper.cpp
@@ -1,0 +1,91 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "testutil/schema_test_helper.h"
+
+namespace starrocks {
+TabletSchemaPB SchemaTestHelper::gen_schema_pb_of_dup(TabletSchema::SchemaId schema_id, size_t num_cols,
+                                                      size_t num_key_cols) {
+    TabletSchemaPB schema_pb;
+
+    schema_pb.set_keys_type(DUP_KEYS);
+    schema_pb.set_num_short_key_columns(num_key_cols);
+    schema_pb.set_id(schema_id);
+
+    for (size_t i = 0; i < num_cols; i++) {
+        auto c0 = schema_pb.add_column();
+        c0->set_unique_id(i);
+        c0->set_name("c0");
+        c0->set_type("INT");
+        c0->set_is_nullable(true);
+        c0->set_index_length(4);
+        if (i < num_key_cols) {
+            c0->set_is_key(true);
+        }
+    }
+
+    return schema_pb;
+}
+
+TColumn SchemaTestHelper::gen_key_column(const std::string& col_name, TPrimitiveType::type type) {
+    TColumnType col_type;
+    col_type.type = type;
+
+    TColumn col;
+    col.__set_column_name(col_name);
+    col.__set_column_type(col_type);
+    col.__set_is_key(true);
+
+    return col;
+}
+
+TColumn SchemaTestHelper::gen_value_column_for_dup_table(const std::string& col_name, TPrimitiveType::type type) {
+    TColumnType col_type;
+    col_type.type = type;
+
+    TColumn col;
+    col.__set_column_name(col_name);
+    col.__set_column_type(col_type);
+    col.__set_is_key(false);
+
+    return col;
+}
+
+TColumn SchemaTestHelper::gen_value_column_for_agg_table(const std::string& col_name, TPrimitiveType::type type) {
+    TColumnType col_type;
+    col_type.type = type;
+
+    TColumn col;
+    col.__set_column_name(col_name);
+    col.__set_column_type(col_type);
+    col.__set_is_key(false);
+    col.__set_aggregation_type(TAggregationType::SUM);
+
+    return col;
+}
+
+void SchemaTestHelper::add_column_pb_to_tablet_schema(TabletSchemaPB* tablet_schema_pb, const std::string& name,
+                                                      const std::string& type, const std::string& agg,
+                                                      uint32_t length) {
+    ColumnPB* column = tablet_schema_pb->add_column();
+    column->set_unique_id(0);
+    column->set_name(name);
+    column->set_type(type);
+    column->set_is_key(false);
+    column->set_is_nullable(false);
+    column->set_length(length);
+    column->set_aggregation(agg);
+}
+
+} // namespace starrocks

--- a/be/src/testutil/schema_test_helper.h
+++ b/be/src/testutil/schema_test_helper.h
@@ -1,0 +1,30 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include "gen_cpp/tablet_schema.pb.h"
+#include "storage/tablet_schema.h"
+
+namespace starrocks {
+class SchemaTestHelper {
+public:
+    static TabletSchemaPB gen_schema_pb_of_dup(TabletSchema::SchemaId schema_id, size_t num_cols, size_t num_key_cols);
+    static TColumn gen_key_column(const std::string& col_name, TPrimitiveType::type type);
+    static TColumn gen_value_column_for_dup_table(const std::string& col_name, TPrimitiveType::type type);
+    static TColumn gen_value_column_for_agg_table(const std::string& col_name, TPrimitiveType::type type);
+    static void add_column_pb_to_tablet_schema(TabletSchemaPB* tablet_schema_pb, const std::string& name,
+                                               const std::string& type, const std::string& agg, uint32_t length);
+};
+} // namespace starrocks

--- a/be/src/testutil/tablet_test_helper.cpp
+++ b/be/src/testutil/tablet_test_helper.cpp
@@ -1,0 +1,94 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "testutil/tablet_test_helper.h"
+
+#include "storage/chunk_helper.h"
+#include "storage/rowset/rowset_factory.h"
+#include "storage/tablet.h"
+
+namespace starrocks {
+TCreateTabletReq TabletTestHelper::gen_create_tablet_req(TTabletId tablet_id, TKeysType::type type,
+                                                         TStorageType::type storage_type) {
+    TCreateTabletReq req;
+    req.tablet_id = tablet_id;
+    req.__set_version(1);
+    req.__set_version_hash(0);
+    req.tablet_schema.schema_hash = 0;
+    req.tablet_schema.short_key_column_count = 2;
+    req.tablet_schema.keys_type = type;
+    req.tablet_schema.storage_type = storage_type;
+    return req;
+}
+
+std::shared_ptr<RowsetWriter> TabletTestHelper::create_rowset_writer(const Tablet& tablet, RowsetId rowset_id,
+                                                                     Version version) {
+    RowsetWriterContext writer_context;
+    writer_context.rowset_id = rowset_id;
+    writer_context.tablet_uid = tablet.tablet_uid();
+    writer_context.tablet_id = tablet.tablet_id();
+    writer_context.tablet_schema_hash = tablet.schema_hash();
+    writer_context.rowset_path_prefix = tablet.schema_hash_path();
+    writer_context.tablet_schema = tablet.tablet_schema();
+    writer_context.rowset_state = VISIBLE;
+    writer_context.version = version;
+    std::unique_ptr<RowsetWriter> rowset_writer;
+    auto st = RowsetFactory::create_rowset_writer(writer_context, &rowset_writer);
+    CHECK(st.ok());
+    return rowset_writer;
+}
+
+std::shared_ptr<TabletReader> TabletTestHelper::create_rowset_reader(const TabletSharedPtr& tablet,
+                                                                     const Schema& schema, Version version) {
+    TabletReaderParams read_params;
+    read_params.reader_type = ReaderType::READER_ALTER_TABLE;
+    read_params.skip_aggregation = false;
+    read_params.chunk_size = config::vector_chunk_size;
+    auto tablet_reader = std::make_unique<TabletReader>(tablet, version, schema);
+
+    CHECK(tablet_reader != nullptr);
+    CHECK(tablet_reader->prepare().ok());
+    CHECK(tablet_reader->open(read_params).ok());
+
+    return tablet_reader;
+}
+
+std::shared_ptr<DeltaWriter> TabletTestHelper::create_delta_writer(TTabletId tablet_id,
+                                                                   const std::vector<SlotDescriptor*>& slots,
+                                                                   MemTracker* mem_tracker) {
+    DeltaWriterOptions options;
+    options.tablet_id = tablet_id;
+    options.slots = &slots;
+    options.txn_id = 1;
+    options.partition_id = 1;
+    options.replica_state = ReplicaState::Primary;
+    auto writer = DeltaWriter::open(options, mem_tracker);
+    CHECK(writer.ok());
+    return std::move(writer.value());
+}
+
+std::vector<ChunkIteratorPtr> TabletTestHelper::create_segment_iterators(const Tablet& tablet, Version version,
+                                                                         OlapReaderStatistics* _stats) {
+    auto new_rowset = tablet.get_rowset_by_version(version);
+    CHECK(new_rowset != nullptr);
+
+    std::vector<ChunkIteratorPtr> seg_iters;
+    RowsetReadOptions rowset_opts;
+    rowset_opts.version = version.second;
+    rowset_opts.stats = _stats;
+    auto st = new_rowset->get_segment_iterators(*tablet.tablet_schema()->schema(), rowset_opts, &seg_iters);
+    CHECK(st.ok());
+    return seg_iters;
+}
+} // namespace starrocks

--- a/be/src/testutil/tablet_test_helper.h
+++ b/be/src/testutil/tablet_test_helper.h
@@ -1,0 +1,37 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include "gen_cpp/AgentService_types.h"
+#include "storage/delta_writer.h"
+#include "storage/rowset/rowset_writer.h"
+#include "storage/tablet_reader.h"
+
+namespace starrocks {
+class TabletTestHelper {
+public:
+    static TCreateTabletReq gen_create_tablet_req(TTabletId tablet_id, TKeysType::type type,
+                                                  TStorageType::type storage_type);
+    static std::shared_ptr<RowsetWriter> create_rowset_writer(const Tablet& tablet, RowsetId rowset_id,
+                                                              Version version);
+    static std::shared_ptr<TabletReader> create_rowset_reader(const TabletSharedPtr& tablet, const Schema& schema,
+                                                              Version version);
+    static std::shared_ptr<DeltaWriter> create_delta_writer(TTabletId tablet_id,
+                                                            const std::vector<SlotDescriptor*>& slots,
+                                                            MemTracker* mem_tracker);
+    static std::vector<ChunkIteratorPtr> create_segment_iterators(const Tablet& tablet, Version version,
+                                                                  OlapReaderStatistics* stats);
+};
+} // namespace starrocks

--- a/be/test/storage/schema_change_test.cpp
+++ b/be/test/storage/schema_change_test.cpp
@@ -20,189 +20,232 @@
 #include "fs/fs_util.h"
 #include "gen_cpp/Exprs_types.h"
 #include "gtest/gtest.h"
+#include "runtime/descriptor_helper.h"
 #include "storage/chunk_helper.h"
 #include "storage/convert_helper.h"
+#include "storage/delta_writer.h"
 #include "storage/rowset/rowset_factory.h"
 #include "storage/storage_engine.h"
 #include "storage/tablet_manager.h"
+#include "storage/txn_manager.h"
 #include "testutil/assert.h"
+#include "testutil/column_test_helper.h"
+#include "testutil/schema_test_helper.h"
+#include "testutil/tablet_test_helper.h"
 #include "util/logging.h"
 
 namespace starrocks {
 
 class SchemaChangeTest : public testing::Test {
-    void SetUp() override { _sc_procedure = nullptr; }
-
-    void TearDown() override {
-        if (_sc_procedure != nullptr) {
-            delete _sc_procedure;
-        }
+    void SetUp() override {
+        _storage_engine = StorageEngine::instance();
+        _txn_mgr = _storage_engine->txn_manager();
+        _tablet_mgr = _storage_engine->tablet_manager();
     }
+
+    void TearDown() override {}
 
 protected:
-    void SetCreateTabletReq(TCreateTabletReq* request, int64_t tablet_id, TKeysType::type type = TKeysType::DUP_KEYS,
-                            TStorageType::type storage_type = TStorageType::COLUMN) {
-        request->tablet_id = tablet_id;
-        request->__set_version(1);
-        request->__set_version_hash(0);
-        request->tablet_schema.schema_hash = 270068375;
-        request->tablet_schema.short_key_column_count = 2;
-        request->tablet_schema.keys_type = type;
-        request->tablet_schema.storage_type = storage_type;
-    }
+    void add_key_column(TCreateTabletReq* request, std::string column_name, TPrimitiveType::type type);
+    void add_value_column(TCreateTabletReq* request, std::string column_name, TPrimitiveType::type type,
+                          TKeysType::type keys_type = TKeysType::DUP_KEYS);
+    void add_value_column_with_index(TCreateTabletReq* request, std::string column_name, TPrimitiveType::type type,
+                                     TKeysType::type keys_type = TKeysType::DUP_KEYS);
 
-    void AddColumn(TCreateTabletReq* request, std::string column_name, TPrimitiveType::type type, bool is_key,
-                   TKeysType::type keys_type = TKeysType::DUP_KEYS) {
-        TColumn c;
-        c.column_name = std::move(column_name);
-        c.__set_is_key(is_key);
-        c.column_type.type = type;
-        if (!is_key && keys_type == TKeysType::AGG_KEYS) {
-            c.__set_aggregation_type(TAggregationType::SUM);
-        }
-        request->tablet_schema.columns.push_back(c);
-    }
+    void create_base_tablet(TTabletId tablet_id, TKeysType::type type, TStorageType::type);
+    void create_dest_tablet_with_index(TTabletId base_tablet_id, TTabletId new_tablet_id, TKeysType::type type);
 
-    void CreateSrcTablet(TTabletId tablet_id, TKeysType::type type = TKeysType::DUP_KEYS, int64_t* version = nullptr) {
-        StorageEngine* engine = StorageEngine::instance();
-        TCreateTabletReq create_tablet_req;
-        SetCreateTabletReq(&create_tablet_req, tablet_id, type);
-        AddColumn(&create_tablet_req, "k1", TPrimitiveType::INT, true);
-        AddColumn(&create_tablet_req, "k2", TPrimitiveType::INT, true);
-        AddColumn(&create_tablet_req, "v1", TPrimitiveType::INT, false);
-        AddColumn(&create_tablet_req, "v2", TPrimitiveType::INT, false);
-        Status res = engine->create_tablet(create_tablet_req);
-        ASSERT_TRUE(res.ok());
-        TabletSharedPtr tablet = engine->tablet_manager()->get_tablet(create_tablet_req.tablet_id);
-        Schema base_schema = ChunkHelper::convert_schema(tablet->tablet_schema());
-        ChunkPtr base_chunk = ChunkHelper::new_chunk(base_schema, config::vector_chunk_size);
-        for (size_t i = 0; i < 4; ++i) {
-            ColumnPtr& base_col = base_chunk->get_column_by_index(i);
-            for (size_t j = 0; j < 4; ++j) {
-                Datum datum;
-                if (i != 1) {
-                    datum.set_int32(i + 1);
-                } else {
-                    datum.set_int32(4 - j);
-                }
-                base_col->append_datum(datum);
-            }
-        }
-        RowsetWriterContext writer_context;
-        writer_context.rowset_id = engine->next_rowset_id();
-        writer_context.tablet_uid = tablet->tablet_uid();
-        writer_context.tablet_id = tablet->tablet_id();
-        writer_context.tablet_schema_hash = tablet->schema_hash();
-        writer_context.rowset_path_prefix = tablet->schema_hash_path();
-        writer_context.tablet_schema = tablet->tablet_schema();
-        writer_context.rowset_state = VISIBLE;
-        if (version == nullptr) {
-            writer_context.version = Version(3, 3);
-        } else {
-            writer_context.version = Version(*version, *version);
-        }
-        std::unique_ptr<RowsetWriter> rowset_writer;
-        ASSERT_TRUE(RowsetFactory::create_rowset_writer(writer_context, &rowset_writer).ok());
-        CHECK_OK(rowset_writer->add_chunk(*base_chunk));
-        CHECK_OK(rowset_writer->flush());
-        RowsetSharedPtr new_rowset = *rowset_writer->build();
-        ASSERT_TRUE(new_rowset != nullptr);
-        ASSERT_TRUE(tablet->add_rowset(new_rowset, false).ok());
-    }
+    void write_data_to_base_tablet(TTabletId tablet_id, Version version);
 
-    std::shared_ptr<TabletSchema> SetTabletSchema(const std::string& name, const std::string& type,
-                                                  const std::string& aggregation, uint32_t length, bool is_allow_null,
-                                                  bool is_key) {
-        TabletSchemaPB tablet_schema_pb;
-        ColumnPB* column = tablet_schema_pb.add_column();
-        column->set_unique_id(0);
-        column->set_name(name);
-        column->set_type(type);
-        column->set_is_key(is_key);
-        column->set_is_nullable(is_allow_null);
-        column->set_length(length);
-        column->set_aggregation(aggregation);
-        return std::make_shared<TabletSchema>(tablet_schema_pb);
-    }
-
+    TabletSchemaSPtr gen_tablet_schema(const std::string& name, const std::string& type, const std::string& aggregation,
+                                       uint32_t length);
     template <typename T>
-    void test_convert_to_varchar(LogicalType type, int type_size, T val, const std::string& expect_val) {
-        auto src_tablet_schema =
-                SetTabletSchema("SrcColumn", logical_type_to_string(type), "REPLACE", type_size, false, false);
-        auto dst_tablet_schema = SetTabletSchema("VarcharColumn", "VARCHAR", "REPLACE", 255, false, false);
-
-        Field f = ChunkHelper::convert_field(0, src_tablet_schema->column(0));
-        Field f2 = ChunkHelper::convert_field(0, dst_tablet_schema->column(0));
-
-        Datum src_datum;
-        src_datum.set<T>(val);
-        Datum dst_datum;
-        auto converter = get_type_converter(type, TYPE_VARCHAR);
-        std::unique_ptr<MemPool> mem_pool(new MemPool());
-        Status st = converter->convert_datum(f.type().get(), src_datum, f2.type().get(), &dst_datum, mem_pool.get());
-        ASSERT_TRUE(st.ok());
-
-        EXPECT_EQ(expect_val, dst_datum.get_slice().to_string());
-    }
-
+    void test_convert_to_varchar(LogicalType type, int type_size, T val, const std::string& expect_val);
     template <typename T>
-    void test_convert_from_varchar(LogicalType type, int type_size, std::string val, T expect_val) {
-        auto src_tablet_schema = SetTabletSchema("VarcharColumn", "VARCHAR", "REPLACE", 255, false, false);
-        auto dst_tablet_schema =
-                SetTabletSchema("DstColumn", logical_type_to_string(type), "REPLACE", type_size, false, false);
+    void test_convert_from_varchar(LogicalType type, int type_size, std::string val, T expect_val);
+    std::vector<SlotDescriptor*> gen_base_slots();
+    TAlterTabletReqV2 gen_alter_tablet_req(TTabletId base_tablet_id, TTabletId new_tablet_id, Version version);
+    RowsetId next_rowset_id() const { return _storage_engine->next_rowset_id(); }
 
-        Field f = ChunkHelper::convert_field(0, src_tablet_schema->column(0));
-        Field f2 = ChunkHelper::convert_field(0, dst_tablet_schema->column(0));
-
-        Datum src_datum;
-        Slice slice;
-        slice.data = (char*)val.data();
-        slice.size = val.size();
-        src_datum.set_slice(slice);
-        Datum dst_datum;
-        auto converter = get_type_converter(TYPE_VARCHAR, type);
-        std::unique_ptr<MemPool> mem_pool(new MemPool());
-        Status st = converter->convert_datum(f.type().get(), src_datum, f2.type().get(), &dst_datum, mem_pool.get());
-        ASSERT_TRUE(st.ok());
-
-        EXPECT_EQ(expect_val, dst_datum.get<T>());
-    }
-
-    SchemaChange* _sc_procedure;
+    StorageEngine* _storage_engine;
+    TabletManager* _tablet_mgr;
+    TxnManager* _txn_mgr;
+    MemPool _mem_pool;
+    std::vector<SlotDescriptor> _slots;
+    MemTracker _mem_tracker;
+    OlapReaderStatistics _stats;
+    const TypeInfoPtr _json_type = get_type_info(TYPE_JSON);
+    const TypeInfoPtr _varchar_type = get_type_info(TYPE_VARCHAR);
+    const int64_t _mem_limit = config::memory_limitation_per_thread_for_schema_change * 1024 * 1024 * 1024;
 };
 
+TAlterTabletReqV2 SchemaChangeTest::gen_alter_tablet_req(TTabletId base_tablet_id, TTabletId new_tablet_id,
+                                                         Version version) {
+    TAlterTabletReqV2 req;
+    req.__set_base_tablet_id(base_tablet_id);
+    req.__set_new_tablet_id(new_tablet_id);
+    req.__set_base_schema_hash(0);
+    req.__set_new_schema_hash(0);
+    req.__set_alter_version(version.second);
+    req.__set_alter_job_type(TAlterJobType::SCHEMA_CHANGE);
+
+    return req;
+}
+
+std::vector<SlotDescriptor*> SchemaChangeTest::gen_base_slots() {
+    for (size_t i = 0; i < 4; i++) {
+        TSlotDescriptorBuilder slot_desc_builder;
+        auto slot = slot_desc_builder.type(TYPE_INT)
+                            .column_name("c" + std::to_string(i))
+                            .column_pos(i)
+                            .nullable(false)
+                            .id(i)
+                            .build();
+        _slots.emplace_back(slot);
+    }
+
+    std::vector<SlotDescriptor*> slots;
+    for (size_t i = 0; i < 4; i++) {
+        slots.emplace_back(&_slots[i]);
+    }
+    return slots;
+}
+
+void SchemaChangeTest::add_key_column(TCreateTabletReq* request, std::string column_name, TPrimitiveType::type type) {
+    TColumn col = SchemaTestHelper::gen_key_column(column_name, type);
+    request->tablet_schema.columns.push_back(col);
+}
+
+void SchemaChangeTest::add_value_column(TCreateTabletReq* request, std::string column_name, TPrimitiveType::type type,
+                                        TKeysType::type keys_type) {
+    TColumn col;
+    if (keys_type == TKeysType::DUP_KEYS) {
+        col = SchemaTestHelper::gen_value_column_for_dup_table(column_name, type);
+    } else {
+        col = SchemaTestHelper::gen_value_column_for_agg_table(column_name, type);
+    }
+    request->tablet_schema.columns.push_back(col);
+}
+
+void SchemaChangeTest::add_value_column_with_index(TCreateTabletReq* request, std::string column_name,
+                                                   TPrimitiveType::type type, TKeysType::type keys_type) {
+    TColumn col;
+    if (keys_type == TKeysType::DUP_KEYS) {
+        col = SchemaTestHelper::gen_value_column_for_dup_table(column_name, type);
+    } else {
+        col = SchemaTestHelper::gen_value_column_for_agg_table(column_name, type);
+    }
+    col.__set_has_bitmap_index(true);
+    request->tablet_schema.columns.push_back(col);
+}
+
+void SchemaChangeTest::create_base_tablet(TTabletId tablet_id, TKeysType::type type, TStorageType::type storage_type) {
+    auto create_tablet_req = TabletTestHelper::gen_create_tablet_req(tablet_id, type, storage_type);
+
+    add_key_column(&create_tablet_req, "k1", TPrimitiveType::INT);
+    add_key_column(&create_tablet_req, "k2", TPrimitiveType::INT);
+    add_value_column(&create_tablet_req, "v1", TPrimitiveType::INT);
+    add_value_column(&create_tablet_req, "v2", TPrimitiveType::INT);
+
+    ASSERT_OK(_storage_engine->create_tablet(create_tablet_req));
+}
+
+void SchemaChangeTest::create_dest_tablet_with_index(TTabletId base_tablet_id, TTabletId new_tablet_id,
+                                                     TKeysType::type type) {
+    auto create_tablet_req = TabletTestHelper::gen_create_tablet_req(new_tablet_id, type, TStorageType::COLUMN);
+    create_tablet_req.__set_base_tablet_id(base_tablet_id);
+
+    add_key_column(&create_tablet_req, "k1", TPrimitiveType::INT);
+    add_key_column(&create_tablet_req, "k2", TPrimitiveType::INT);
+    add_value_column(&create_tablet_req, "v1", TPrimitiveType::INT);
+    add_value_column_with_index(&create_tablet_req, "v2", TPrimitiveType::INT);
+
+    ASSERT_OK(_storage_engine->create_tablet(create_tablet_req));
+}
+
+void SchemaChangeTest::write_data_to_base_tablet(TTabletId tablet_id, Version version) {
+    auto tablet = _tablet_mgr->get_tablet(tablet_id);
+    Schema base_schema = *tablet->tablet_schema()->schema();
+    ChunkPtr base_chunk = ChunkHelper::new_chunk(base_schema, config::vector_chunk_size);
+    for (size_t i = 0; i < 4; ++i) {
+        ColumnPtr& base_col = base_chunk->get_column_by_index(i);
+        base_col = ColumnTestHelper::build_column<int32_t>({0, 1, 2, 3});
+    }
+
+    auto rowset_writer = TabletTestHelper::create_rowset_writer(*tablet, next_rowset_id(), version);
+
+    ASSERT_OK(rowset_writer->add_chunk(*base_chunk));
+    ASSERT_OK(rowset_writer->flush());
+    RowsetSharedPtr new_rowset = *rowset_writer->build();
+    ASSERT_TRUE(new_rowset != nullptr);
+    ASSERT_OK(tablet->add_rowset(new_rowset, false));
+}
+
+TabletSchemaSPtr SchemaChangeTest::gen_tablet_schema(const std::string& name, const std::string& type,
+                                                     const std::string& aggregation, uint32_t length) {
+    TabletSchemaPB tablet_schema_pb;
+    SchemaTestHelper::add_column_pb_to_tablet_schema(&tablet_schema_pb, name, type, aggregation, length);
+    return std::make_shared<TabletSchema>(tablet_schema_pb);
+}
+
+template <typename T>
+void SchemaChangeTest::test_convert_to_varchar(LogicalType type, int type_size, T val, const std::string& expect_val) {
+    auto src_tablet_schema = gen_tablet_schema("c1", logical_type_to_string(type), "REPLACE", type_size);
+    auto dst_tablet_schema = gen_tablet_schema("c2", "VARCHAR", "REPLACE", 255);
+
+    Field f1 = ChunkHelper::convert_field(0, src_tablet_schema->column(0));
+    Field f2 = ChunkHelper::convert_field(0, dst_tablet_schema->column(0));
+
+    Datum src_datum(val);
+    Datum dst_datum;
+
+    auto converter = get_type_converter(type, TYPE_VARCHAR);
+    ASSERT_OK(converter->convert_datum(f1.type().get(), src_datum, f2.type().get(), &dst_datum, &_mem_pool));
+    EXPECT_EQ(expect_val, dst_datum.get_slice().to_string());
+}
+
+template <typename T>
+void SchemaChangeTest::test_convert_from_varchar(LogicalType type, int type_size, std::string val, T expect_val) {
+    auto src_tablet_schema = gen_tablet_schema("c1", "VARCHAR", "REPLACE", 255);
+    auto dst_tablet_schema = gen_tablet_schema("c2", logical_type_to_string(type), "REPLACE", type_size);
+
+    Field f1 = ChunkHelper::convert_field(0, src_tablet_schema->column(0));
+    Field f2 = ChunkHelper::convert_field(0, dst_tablet_schema->column(0));
+
+    Datum src_datum(Slice((char*)val.data(), val.size()));
+    Datum dst_datum;
+
+    auto converter = get_type_converter(TYPE_VARCHAR, type);
+    ASSERT_OK(converter->convert_datum(f1.type().get(), src_datum, f2.type().get(), &dst_datum, &_mem_pool));
+    EXPECT_EQ(expect_val, dst_datum.get<T>());
+}
+
 TEST_F(SchemaChangeTest, column_with_row) {
-    StorageEngine* engine = StorageEngine::instance();
-    int64_t old_id = 1415001;
-    int64_t new_id = old_id + 1;
+    int64_t base_tablet_id = 1415001;
+    int64_t new_tablet_id = 1415002;
+
+    create_base_tablet(base_tablet_id, TKeysType::PRIMARY_KEYS, TStorageType::COLUMN_WITH_ROW);
+
     {
-        TCreateTabletReq create_tablet_req;
-        SetCreateTabletReq(&create_tablet_req, old_id, TKeysType::PRIMARY_KEYS, TStorageType::COLUMN_WITH_ROW);
-        AddColumn(&create_tablet_req, "k1", TPrimitiveType::INT, true);
-        AddColumn(&create_tablet_req, "k2", TPrimitiveType::INT, true);
-        AddColumn(&create_tablet_req, "v1", TPrimitiveType::INT, false);
-        AddColumn(&create_tablet_req, "v2", TPrimitiveType::INT, false);
-        Status res = engine->create_tablet(create_tablet_req);
+        auto create_tablet_req = TabletTestHelper::gen_create_tablet_req(new_tablet_id, TKeysType::PRIMARY_KEYS,
+                                                                         TStorageType::COLUMN_WITH_ROW);
+        create_tablet_req.__set_base_tablet_id(base_tablet_id);
+        add_key_column(&create_tablet_req, "k1", TPrimitiveType::INT);
+        add_key_column(&create_tablet_req, "k2", TPrimitiveType::INT);
+        add_value_column(&create_tablet_req, "v0", TPrimitiveType::INT);
+        add_value_column(&create_tablet_req, "v1", TPrimitiveType::INT);
+        add_value_column(&create_tablet_req, "v2", TPrimitiveType::INT);
+        add_value_column(&create_tablet_req, "v3", TPrimitiveType::INT);
+        Status res = _storage_engine->create_tablet(create_tablet_req);
         ASSERT_TRUE(res.ok()) << res.to_string();
     }
-    {
-        TCreateTabletReq create_tablet_req;
-        SetCreateTabletReq(&create_tablet_req, new_id, TKeysType::PRIMARY_KEYS, TStorageType::COLUMN_WITH_ROW);
-        create_tablet_req.__set_base_tablet_id(old_id);
-        AddColumn(&create_tablet_req, "k1", TPrimitiveType::INT, true);
-        AddColumn(&create_tablet_req, "k2", TPrimitiveType::INT, true);
-        AddColumn(&create_tablet_req, "v0", TPrimitiveType::INT, false);
-        AddColumn(&create_tablet_req, "v1", TPrimitiveType::INT, false);
-        AddColumn(&create_tablet_req, "v2", TPrimitiveType::INT, false);
-        AddColumn(&create_tablet_req, "v3", TPrimitiveType::INT, false);
-        Status res = engine->create_tablet(create_tablet_req);
-        ASSERT_TRUE(res.ok()) << res.to_string();
-    }
-    TabletSharedPtr base_tablet = engine->tablet_manager()->get_tablet(old_id);
+
+    TabletSharedPtr base_tablet = _tablet_mgr->get_tablet(base_tablet_id);
     ASSERT_TRUE(base_tablet != nullptr);
     ASSERT_EQ(base_tablet->tablet_schema()->columns().back().name(), Schema::FULL_ROW_COLUMN);
     ASSERT_EQ(base_tablet->tablet_schema()->columns().back().unique_id(), 4);
-    TabletSharedPtr new_tablet = engine->tablet_manager()->get_tablet(new_id);
+
+    TabletSharedPtr new_tablet = _tablet_mgr->get_tablet(new_tablet_id);
     ASSERT_TRUE(new_tablet != nullptr);
     ASSERT_EQ(new_tablet->tablet_schema()->columns().back().name(), Schema::FULL_ROW_COLUMN);
     ASSERT_EQ(new_tablet->tablet_schema()->columns().back().unique_id(), 6);
@@ -265,31 +308,29 @@ TEST_F(SchemaChangeTest, convert_varchar_to_double) {
 }
 
 TEST_F(SchemaChangeTest, convert_float_to_double) {
-    auto src_tablet_schema = SetTabletSchema("SrcColumn", "FLOAT", "REPLACE", 4, false, false);
-    auto dst_tablet_schema = SetTabletSchema("VarcharColumn", "DOUBLE", "REPLACE", 8, false, false);
+    auto src_tablet_schema = gen_tablet_schema("c1", "FLOAT", "REPLACE", 4);
+    auto dst_tablet_schema = gen_tablet_schema("c2", "DOUBLE", "REPLACE", 8);
 
-    Field f = ChunkHelper::convert_field(0, src_tablet_schema->column(0));
+    Field f1 = ChunkHelper::convert_field(0, src_tablet_schema->column(0));
     Field f2 = ChunkHelper::convert_field(0, dst_tablet_schema->column(0));
 
-    Datum src_datum;
-    src_datum.set_float(1.2345);
+    Datum src_datum((float)(1.2345));
     Datum dst_datum;
-    auto converter = get_type_converter(TYPE_FLOAT, TYPE_DOUBLE);
-    std::unique_ptr<MemPool> mem_pool(new MemPool());
-    Status st = converter->convert_datum(f.type().get(), src_datum, f2.type().get(), &dst_datum, mem_pool.get());
-    ASSERT_TRUE(st.ok());
 
+    auto converter = get_type_converter(TYPE_FLOAT, TYPE_DOUBLE);
+    Status st = converter->convert_datum(f1.type().get(), src_datum, f2.type().get(), &dst_datum, &_mem_pool);
+
+    ASSERT_TRUE(st.ok());
     EXPECT_EQ(1.2345, dst_datum.get_double());
 }
 
 TEST_F(SchemaChangeTest, convert_datetime_to_date) {
-    auto src_tablet_schema = SetTabletSchema("DateTimeColumn", "DATETIME", "REPLACE", 8, false, false);
-    auto dst_tablet_schema = SetTabletSchema("DateColumn", "DATE", "REPLACE", 3, false, false);
+    auto src_tablet_schema = gen_tablet_schema("c1", "DATETIME", "REPLACE", 8);
+    auto dst_tablet_schema = gen_tablet_schema("c2", "DATE", "REPLACE", 3);
 
-    Field f = ChunkHelper::convert_field(0, src_tablet_schema->column(0));
+    Field f1 = ChunkHelper::convert_field(0, src_tablet_schema->column(0));
     Field f2 = ChunkHelper::convert_field(0, dst_tablet_schema->column(0));
 
-    std::unique_ptr<MemPool> mem_pool(new MemPool());
     Datum src_datum;
     std::string origin_val = "2021-09-28 16:07:00";
 
@@ -301,7 +342,7 @@ TEST_F(SchemaChangeTest, convert_datetime_to_date) {
     Datum dst_datum;
     auto converter = get_type_converter(TYPE_DATETIME_V1, TYPE_DATE_V1);
 
-    Status st = converter->convert_datum(f.type().get(), src_datum, f2.type().get(), &dst_datum, mem_pool.get());
+    Status st = converter->convert_datum(f1.type().get(), src_datum, f2.type().get(), &dst_datum, &_mem_pool);
     ASSERT_TRUE(st.ok());
 
     int dst_value = (time_tm.tm_year + 1900) * 16 * 32 + (time_tm.tm_mon + 1) * 32 + time_tm.tm_mday;
@@ -309,12 +350,11 @@ TEST_F(SchemaChangeTest, convert_datetime_to_date) {
 }
 
 TEST_F(SchemaChangeTest, convert_date_to_datetime) {
-    auto src_tablet_schema = SetTabletSchema("DateColumn", "DATE", "REPLACE", 3, false, false);
-    auto dst_tablet_schema = SetTabletSchema("DateTimeColumn", "DATETIME", "REPLACE", 8, false, false);
+    auto src_tablet_schema = gen_tablet_schema("c1", "DATE", "REPLACE", 3);
+    auto dst_tablet_schema = gen_tablet_schema("c2", "DATETIME", "REPLACE", 8);
 
-    Field f = ChunkHelper::convert_field(0, src_tablet_schema->column(0));
+    Field f1 = ChunkHelper::convert_field(0, src_tablet_schema->column(0));
     Field f2 = ChunkHelper::convert_field(0, dst_tablet_schema->column(0));
-    std::unique_ptr<MemPool> mem_pool(new MemPool());
     Datum src_datum;
     std::string origin_val = "2021-09-28";
     tm time_tm;
@@ -325,7 +365,7 @@ TEST_F(SchemaChangeTest, convert_date_to_datetime) {
     Datum dst_datum;
     auto converter = get_type_converter(TYPE_DATE_V1, TYPE_DATETIME_V1);
 
-    Status st = converter->convert_datum(f.type().get(), src_datum, f2.type().get(), &dst_datum, mem_pool.get());
+    Status st = converter->convert_datum(f1.type().get(), src_datum, f2.type().get(), &dst_datum, &_mem_pool);
     ASSERT_TRUE(st.ok());
 
     int64_t dst_value = ((time_tm.tm_year + 1900) * 10000L + (time_tm.tm_mon + 1) * 100L + time_tm.tm_mday) * 1000000L;
@@ -333,13 +373,12 @@ TEST_F(SchemaChangeTest, convert_date_to_datetime) {
 }
 
 TEST_F(SchemaChangeTest, convert_int_to_date_v2) {
-    auto src_tablet_schema = SetTabletSchema("IntColumn", "INT", "REPLACE", 4, false, false);
-    auto dst_tablet_schema = SetTabletSchema("DateColumn", "DATE V2", "REPLACE", 3, false, false);
+    auto src_tablet_schema = gen_tablet_schema("c1", "INT", "REPLACE", 4);
+    auto dst_tablet_schema = gen_tablet_schema("c2", "DATE V2", "REPLACE", 3);
 
-    Field f = ChunkHelper::convert_field(0, src_tablet_schema->column(0));
+    Field f1 = ChunkHelper::convert_field(0, src_tablet_schema->column(0));
     Field f2 = ChunkHelper::convert_field(0, dst_tablet_schema->column(0));
 
-    std::unique_ptr<MemPool> mem_pool(new MemPool());
     Datum src_datum;
     std::string origin_val = "2021-09-28";
     tm time_tm;
@@ -348,20 +387,19 @@ TEST_F(SchemaChangeTest, convert_int_to_date_v2) {
     Datum dst_datum;
     auto converter = get_type_converter(TYPE_INT, TYPE_DATE);
 
-    Status st = converter->convert_datum(f.type().get(), src_datum, f2.type().get(), &dst_datum, mem_pool.get());
+    Status st = converter->convert_datum(f1.type().get(), src_datum, f2.type().get(), &dst_datum, &_mem_pool);
     ASSERT_TRUE(st.ok());
 
     EXPECT_EQ("2021-09-28", dst_datum.get_date().to_string());
 }
 
 TEST_F(SchemaChangeTest, convert_int_to_date) {
-    auto src_tablet_schema = SetTabletSchema("IntColumn", "INT", "REPLACE", 4, false, false);
-    auto dst_tablet_schema = SetTabletSchema("DateColumn", "DATE", "REPLACE", 3, false, false);
+    auto src_tablet_schema = gen_tablet_schema("c1", "INT", "REPLACE", 4);
+    auto dst_tablet_schema = gen_tablet_schema("c2", "DATE", "REPLACE", 3);
 
-    Field f = ChunkHelper::convert_field(0, src_tablet_schema->column(0));
+    Field f1 = ChunkHelper::convert_field(0, src_tablet_schema->column(0));
     Field f2 = ChunkHelper::convert_field(0, dst_tablet_schema->column(0));
 
-    std::unique_ptr<MemPool> mem_pool(new MemPool());
     Datum src_datum;
     std::string origin_val = "2021-09-28";
     tm time_tm;
@@ -370,7 +408,7 @@ TEST_F(SchemaChangeTest, convert_int_to_date) {
     Datum dst_datum;
     auto converter = get_type_converter(TYPE_INT, TYPE_DATE_V1);
 
-    Status st = converter->convert_datum(f.type().get(), src_datum, f2.type().get(), &dst_datum, mem_pool.get());
+    Status st = converter->convert_datum(f1.type().get(), src_datum, f2.type().get(), &dst_datum, &_mem_pool);
     ASSERT_TRUE(st.ok());
 
     int dst_value = (time_tm.tm_year + 1900) * 16 * 32 + (time_tm.tm_mon + 1) * 32 + time_tm.tm_mday;
@@ -378,14 +416,14 @@ TEST_F(SchemaChangeTest, convert_int_to_date) {
 }
 
 TEST_F(SchemaChangeTest, convert_int_to_bitmap) {
-    auto src_tablet_schema = SetTabletSchema("IntColumn", "INT", "REPLACE", 4, false, false);
-    auto dst_tablet_schema = SetTabletSchema("BitmapColumn", "OBJECT", "BITMAP_UNION", 8, false, false);
+    auto src_tablet_schema = gen_tablet_schema("c1", "INT", "REPLACE", 4);
+    auto dst_tablet_schema = gen_tablet_schema("c2", "OBJECT", "BITMAP_UNION", 8);
 
     ChunkPtr src_chunk = ChunkHelper::new_chunk(ChunkHelper::convert_schema(src_tablet_schema), 4096);
     ChunkPtr dst_chunk = ChunkHelper::new_chunk(ChunkHelper::convert_schema(dst_tablet_schema), 4096);
     ColumnPtr& src_col = src_chunk->get_column_by_index(0);
     ColumnPtr& dst_col = dst_chunk->get_column_by_index(0);
-    Field f = ChunkHelper::convert_field(0, src_tablet_schema->column(0));
+    Field f1 = ChunkHelper::convert_field(0, src_tablet_schema->column(0));
     Field f2 = ChunkHelper::convert_field(0, dst_tablet_schema->column(0));
 
     Datum src_datum;
@@ -393,7 +431,7 @@ TEST_F(SchemaChangeTest, convert_int_to_bitmap) {
     src_col->append_datum(src_datum);
 
     auto converter = get_materialized_converter(TYPE_INT, OLAP_MATERIALIZE_TYPE_BITMAP);
-    Status st = converter->convert_materialized(src_col, dst_col, f.type().get());
+    Status st = converter->convert_materialized(src_col, dst_col, f1.type().get());
     ASSERT_TRUE(st.ok());
 
     Datum dst_datum = dst_col->get(0);
@@ -402,14 +440,14 @@ TEST_F(SchemaChangeTest, convert_int_to_bitmap) {
 }
 
 TEST_F(SchemaChangeTest, convert_varchar_to_hll) {
-    auto src_tablet_schema = SetTabletSchema("IntColumn", "VARCHAR", "REPLACE", 255, false, false);
-    auto dst_tablet_schema = SetTabletSchema("HLLColumn", "HLL", "HLL_UNION", 8, false, false);
+    auto src_tablet_schema = gen_tablet_schema("c1", "VARCHAR", "REPLACE", 255);
+    auto dst_tablet_schema = gen_tablet_schema("c2", "HLL", "HLL_UNION", 8);
 
     ChunkPtr src_chunk = ChunkHelper::new_chunk(ChunkHelper::convert_schema(src_tablet_schema), 4096);
     ChunkPtr dst_chunk = ChunkHelper::new_chunk(ChunkHelper::convert_schema(dst_tablet_schema), 4096);
     ColumnPtr& src_col = src_chunk->get_column_by_index(0);
     ColumnPtr& dst_col = dst_chunk->get_column_by_index(0);
-    Field f = ChunkHelper::convert_field(0, src_tablet_schema->column(0));
+    Field f1 = ChunkHelper::convert_field(0, src_tablet_schema->column(0));
     Field f2 = ChunkHelper::convert_field(0, dst_tablet_schema->column(0));
 
     Datum src_datum;
@@ -419,7 +457,7 @@ TEST_F(SchemaChangeTest, convert_varchar_to_hll) {
     src_col->append_datum(src_datum);
 
     auto converter = get_materialized_converter(TYPE_VARCHAR, OLAP_MATERIALIZE_TYPE_HLL);
-    Status st = converter->convert_materialized(src_col, dst_col, f.type().get());
+    Status st = converter->convert_materialized(src_col, dst_col, f1.type().get());
     ASSERT_TRUE(st.ok());
 
     Datum dst_datum = dst_col->get(0);
@@ -428,14 +466,14 @@ TEST_F(SchemaChangeTest, convert_varchar_to_hll) {
 }
 
 TEST_F(SchemaChangeTest, convert_int_to_count) {
-    auto src_tablet_schema = SetTabletSchema("IntColumn", "INT", "REPLACE", 4, false, false);
-    auto dst_tablet_schema = SetTabletSchema("CountColumn", "BIGINT", "SUM", 8, false, false);
+    auto src_tablet_schema = gen_tablet_schema("c1", "INT", "REPLACE", 4);
+    auto dst_tablet_schema = gen_tablet_schema("c2", "BIGINT", "SUM", 8);
 
     ChunkPtr src_chunk = ChunkHelper::new_chunk(ChunkHelper::convert_schema(src_tablet_schema), 4096);
     ChunkPtr dst_chunk = ChunkHelper::new_chunk(ChunkHelper::convert_schema(dst_tablet_schema), 4096);
     ColumnPtr& src_col = src_chunk->get_column_by_index(0);
     ColumnPtr& dst_col = dst_chunk->get_column_by_index(0);
-    Field f = ChunkHelper::convert_field(0, src_tablet_schema->column(0));
+    Field f1 = ChunkHelper::convert_field(0, src_tablet_schema->column(0));
     Field f2 = ChunkHelper::convert_field(0, dst_tablet_schema->column(0));
 
     Datum src_datum;
@@ -443,7 +481,7 @@ TEST_F(SchemaChangeTest, convert_int_to_count) {
     src_col->append_datum(src_datum);
 
     auto converter = get_materialized_converter(TYPE_INT, OLAP_MATERIALIZE_TYPE_COUNT);
-    Status st = converter->convert_materialized(src_col, dst_col, f.type().get());
+    Status st = converter->convert_materialized(src_col, dst_col, f1.type().get());
     ASSERT_TRUE(st.ok());
 
     Datum dst_datum = dst_col->get(0);
@@ -451,76 +489,76 @@ TEST_F(SchemaChangeTest, convert_int_to_count) {
 }
 
 TEST_F(SchemaChangeTest, schema_change_with_directing_v2) {
-    CreateSrcTablet(1101);
-    StorageEngine* engine = StorageEngine::instance();
-    TCreateTabletReq create_tablet_req;
-    SetCreateTabletReq(&create_tablet_req, 1102, TKeysType::DUP_KEYS);
-    AddColumn(&create_tablet_req, "k1", TPrimitiveType::INT, true);
-    AddColumn(&create_tablet_req, "k2", TPrimitiveType::INT, true);
-    AddColumn(&create_tablet_req, "v1", TPrimitiveType::BIGINT, false);
-    AddColumn(&create_tablet_req, "v2", TPrimitiveType::VARCHAR, false);
-    Status res = engine->create_tablet(create_tablet_req);
-    ASSERT_TRUE(res.ok()) << res.to_string();
-    TabletSharedPtr new_tablet = engine->tablet_manager()->get_tablet(create_tablet_req.tablet_id);
-    TabletSharedPtr base_tablet = engine->tablet_manager()->get_tablet(1101);
+    TTabletId base_tablet_id = 1101;
+    TTabletId new_tablet_id = 1102;
+    Version version(3, 3);
 
-    ChunkChanger chunk_changer(new_tablet->tablet_schema());
+    create_base_tablet(base_tablet_id, TKeysType::DUP_KEYS, TStorageType::COLUMN);
+    write_data_to_base_tablet(base_tablet_id, version);
+
+    {
+        auto create_tablet_req =
+                TabletTestHelper::gen_create_tablet_req(new_tablet_id, TKeysType::DUP_KEYS, TStorageType::COLUMN);
+        add_key_column(&create_tablet_req, "k1", TPrimitiveType::INT);
+        add_key_column(&create_tablet_req, "k2", TPrimitiveType::INT);
+        add_value_column(&create_tablet_req, "v1", TPrimitiveType::BIGINT);
+        add_value_column(&create_tablet_req, "v2", TPrimitiveType::VARCHAR);
+        Status res = _storage_engine->create_tablet(create_tablet_req);
+        ASSERT_TRUE(res.ok()) << res.to_string();
+    }
+
+    TabletSharedPtr base_tablet = _tablet_mgr->get_tablet(base_tablet_id);
+    TabletSharedPtr new_tablet = _tablet_mgr->get_tablet(new_tablet_id);
+    auto base_tablet_schema = base_tablet->tablet_schema();
+    auto new_tablet_schema = new_tablet->tablet_schema();
+
+    ChunkChanger chunk_changer(new_tablet_schema);
     for (size_t i = 0; i < 4; ++i) {
         ColumnMapping* column_mapping = chunk_changer.get_mutable_column_mapping(i);
         column_mapping->ref_column = i;
     }
-    ASSERT_TRUE(chunk_changer.prepare().ok());
-    _sc_procedure = new (std::nothrow) SchemaChangeDirectly(&chunk_changer);
-    Version version(3, 3);
+    ASSERT_OK(chunk_changer.prepare());
+    Schema base_schema =
+            ChunkHelper::convert_schema(base_tablet->tablet_schema(), chunk_changer.get_selected_column_indexes());
+
+    auto sc_procedure = std::make_unique<SchemaChangeDirectly>(&chunk_changer);
     RowsetSharedPtr rowset = base_tablet->get_rowset_by_version(version);
     ASSERT_TRUE(rowset != nullptr);
 
-    TabletReaderParams read_params;
-    read_params.reader_type = ReaderType::READER_ALTER_TABLE;
-    read_params.skip_aggregation = false;
-    read_params.chunk_size = config::vector_chunk_size;
-    Schema base_schema =
-            ChunkHelper::convert_schema(base_tablet->tablet_schema(), chunk_changer.get_selected_column_indexes());
-    auto* tablet_rowset_reader = new TabletReader(base_tablet, rowset->version(), base_schema);
-    ASSERT_TRUE(tablet_rowset_reader != nullptr);
-    ASSERT_TRUE(tablet_rowset_reader->prepare().ok());
-    ASSERT_TRUE(tablet_rowset_reader->open(read_params).ok());
+    auto rowset_reader = TabletTestHelper::create_rowset_reader(base_tablet, base_schema, rowset->version());
+    auto rowset_writer = TabletTestHelper::create_rowset_writer(*new_tablet, next_rowset_id(), version);
 
-    RowsetWriterContext writer_context;
-    writer_context.rowset_id = engine->next_rowset_id();
-    writer_context.tablet_uid = new_tablet->tablet_uid();
-    writer_context.tablet_id = new_tablet->tablet_id();
-    writer_context.tablet_schema_hash = new_tablet->schema_hash();
-    writer_context.rowset_path_prefix = new_tablet->schema_hash_path();
-    writer_context.tablet_schema = new_tablet->tablet_schema();
-    writer_context.rowset_state = VISIBLE;
-    writer_context.version = Version(3, 3);
-    std::unique_ptr<RowsetWriter> rowset_writer;
-    ASSERT_TRUE(RowsetFactory::create_rowset_writer(writer_context, &rowset_writer).ok());
+    ASSERT_OK(sc_procedure->process(rowset_reader.get(), rowset_writer.get(), new_tablet, base_tablet, rowset));
 
-    ASSERT_TRUE(
-            _sc_procedure->process(tablet_rowset_reader, rowset_writer.get(), new_tablet, base_tablet, rowset).ok());
-    delete tablet_rowset_reader;
-    (void)StorageEngine::instance()->tablet_manager()->drop_tablet(1101);
-    (void)StorageEngine::instance()->tablet_manager()->drop_tablet(1102);
+    (void)_tablet_mgr->drop_tablet(base_tablet_id);
+    (void)_tablet_mgr->drop_tablet(new_tablet_id);
 }
 
 TEST_F(SchemaChangeTest, schema_change_with_sorting_v2) {
-    CreateSrcTablet(1103);
-    StorageEngine* engine = StorageEngine::instance();
-    TCreateTabletReq create_tablet_req;
-    SetCreateTabletReq(&create_tablet_req, 1104, TKeysType::DUP_KEYS);
-    AddColumn(&create_tablet_req, "k1", TPrimitiveType::INT, true);
-    AddColumn(&create_tablet_req, "k2", TPrimitiveType::INT, true);
-    AddColumn(&create_tablet_req, "v1", TPrimitiveType::BIGINT, false);
-    AddColumn(&create_tablet_req, "v2", TPrimitiveType::VARCHAR, false);
-    Status res = engine->create_tablet(create_tablet_req);
-    ASSERT_TRUE(res.ok()) << res.to_string();
-    TabletSharedPtr new_tablet = engine->tablet_manager()->get_tablet(create_tablet_req.tablet_id,
-                                                                      create_tablet_req.tablet_schema.schema_hash);
-    TabletSharedPtr base_tablet = engine->tablet_manager()->get_tablet(1103);
+    TTabletId base_tablet_id = 1103;
+    TTabletId new_tablet_id = 1104;
+    Version version(3, 3);
 
-    ChunkChanger chunk_changer(new_tablet->tablet_schema());
+    create_base_tablet(base_tablet_id, TKeysType::DUP_KEYS, TStorageType::COLUMN);
+    write_data_to_base_tablet(base_tablet_id, version);
+
+    {
+        TCreateTabletReq create_tablet_req =
+                TabletTestHelper::gen_create_tablet_req(new_tablet_id, TKeysType::DUP_KEYS, TStorageType::COLUMN);
+        add_key_column(&create_tablet_req, "k1", TPrimitiveType::INT);
+        add_key_column(&create_tablet_req, "k2", TPrimitiveType::INT);
+        add_value_column(&create_tablet_req, "v1", TPrimitiveType::BIGINT);
+        add_value_column(&create_tablet_req, "v2", TPrimitiveType::VARCHAR);
+        Status res = _storage_engine->create_tablet(create_tablet_req);
+        ASSERT_TRUE(res.ok()) << res.to_string();
+    }
+
+    TabletSharedPtr base_tablet = _tablet_mgr->get_tablet(base_tablet_id);
+    TabletSharedPtr new_tablet = _tablet_mgr->get_tablet(new_tablet_id);
+    auto base_tablet_schema = base_tablet->tablet_schema();
+    auto new_tablet_schema = new_tablet->tablet_schema();
+
+    ChunkChanger chunk_changer(new_tablet_schema);
     ColumnMapping* column_mapping = chunk_changer.get_mutable_column_mapping(0);
     column_mapping->ref_column = 1;
     column_mapping = chunk_changer.get_mutable_column_mapping(1);
@@ -531,57 +569,43 @@ TEST_F(SchemaChangeTest, schema_change_with_sorting_v2) {
     column_mapping->ref_column = 3;
     ASSERT_TRUE(chunk_changer.prepare().ok());
 
-    _sc_procedure = new (std::nothrow) SchemaChangeWithSorting(
-            &chunk_changer, config::memory_limitation_per_thread_for_schema_change * 1024 * 1024 * 1024);
-    Version version(3, 3);
+    auto sc_procedure = std::make_unique<SchemaChangeWithSorting>(&chunk_changer, _mem_limit);
     RowsetSharedPtr rowset = base_tablet->get_rowset_by_version(version);
     ASSERT_TRUE(rowset != nullptr);
+    Schema base_schema = ChunkHelper::convert_schema(base_tablet_schema, chunk_changer.get_selected_column_indexes());
 
-    TabletReaderParams read_params;
-    read_params.reader_type = ReaderType::READER_ALTER_TABLE;
-    read_params.skip_aggregation = false;
-    read_params.chunk_size = config::vector_chunk_size;
-    Schema base_schema =
-            ChunkHelper::convert_schema(base_tablet->tablet_schema(), chunk_changer.get_selected_column_indexes());
-    auto* tablet_rowset_reader = new TabletReader(base_tablet, rowset->version(), base_schema);
-    ASSERT_TRUE(tablet_rowset_reader != nullptr);
-    ASSERT_TRUE(tablet_rowset_reader->prepare().ok());
-    ASSERT_TRUE(tablet_rowset_reader->open(read_params).ok());
+    auto rowset_reader = TabletTestHelper::create_rowset_reader(base_tablet, base_schema, rowset->version());
+    auto rowset_writer = TabletTestHelper::create_rowset_writer(*new_tablet, next_rowset_id(), version);
 
-    RowsetWriterContext writer_context;
-    writer_context.rowset_id = engine->next_rowset_id();
-    writer_context.tablet_uid = new_tablet->tablet_uid();
-    writer_context.tablet_id = new_tablet->tablet_id();
-    writer_context.tablet_schema_hash = new_tablet->schema_hash();
-    writer_context.rowset_path_prefix = new_tablet->schema_hash_path();
-    writer_context.tablet_schema = new_tablet->tablet_schema();
-    writer_context.rowset_state = VISIBLE;
-    writer_context.version = Version(3, 3);
-    std::unique_ptr<RowsetWriter> rowset_writer;
-    ASSERT_TRUE(RowsetFactory::create_rowset_writer(writer_context, &rowset_writer).ok());
-
-    ASSERT_TRUE(
-            _sc_procedure->process(tablet_rowset_reader, rowset_writer.get(), new_tablet, base_tablet, rowset).ok());
-    delete tablet_rowset_reader;
-    (void)StorageEngine::instance()->tablet_manager()->drop_tablet(1103);
-    (void)StorageEngine::instance()->tablet_manager()->drop_tablet(1104);
+    ASSERT_OK(sc_procedure->process(rowset_reader.get(), rowset_writer.get(), new_tablet, base_tablet, rowset));
+    (void)_tablet_mgr->drop_tablet(base_tablet_id);
+    (void)_tablet_mgr->drop_tablet(new_tablet_id);
 }
 
 TEST_F(SchemaChangeTest, schema_change_with_agg_key_reorder) {
-    CreateSrcTablet(1203, TKeysType::AGG_KEYS);
-    StorageEngine* engine = StorageEngine::instance();
-    TCreateTabletReq create_tablet_req;
-    SetCreateTabletReq(&create_tablet_req, 1204, TKeysType::AGG_KEYS);
-    AddColumn(&create_tablet_req, "k1", TPrimitiveType::INT, true);
-    AddColumn(&create_tablet_req, "k2", TPrimitiveType::INT, true);
-    AddColumn(&create_tablet_req, "v1", TPrimitiveType::BIGINT, false, TKeysType::AGG_KEYS);
-    Status res = engine->create_tablet(create_tablet_req);
-    ASSERT_TRUE(res.ok()) << res.to_string();
-    TabletSharedPtr new_tablet = engine->tablet_manager()->get_tablet(create_tablet_req.tablet_id,
-                                                                      create_tablet_req.tablet_schema.schema_hash);
-    TabletSharedPtr base_tablet = engine->tablet_manager()->get_tablet(1203);
+    TTabletId base_tablet_id = 1203;
+    TTabletId new_tablet_id = 1204;
+    Version version(3, 3);
 
-    ChunkChanger chunk_changer(new_tablet->tablet_schema());
+    create_base_tablet(base_tablet_id, TKeysType::AGG_KEYS, TStorageType::COLUMN);
+    write_data_to_base_tablet(base_tablet_id, version);
+
+    {
+        TCreateTabletReq create_tablet_req =
+                TabletTestHelper::gen_create_tablet_req(new_tablet_id, TKeysType::AGG_KEYS, TStorageType::COLUMN);
+        add_key_column(&create_tablet_req, "k1", TPrimitiveType::INT);
+        add_key_column(&create_tablet_req, "k2", TPrimitiveType::INT);
+        add_value_column(&create_tablet_req, "v1", TPrimitiveType::BIGINT, TKeysType::AGG_KEYS);
+        Status res = _storage_engine->create_tablet(create_tablet_req);
+        ASSERT_TRUE(res.ok()) << res.to_string();
+    }
+
+    TabletSharedPtr base_tablet = _tablet_mgr->get_tablet(base_tablet_id);
+    TabletSharedPtr new_tablet = _tablet_mgr->get_tablet(new_tablet_id);
+    auto base_tablet_schema = base_tablet->tablet_schema();
+    auto new_tablet_schema = new_tablet->tablet_schema();
+
+    ChunkChanger chunk_changer(new_tablet_schema);
     ColumnMapping* column_mapping = chunk_changer.get_mutable_column_mapping(0);
     column_mapping->ref_column = 1;
     column_mapping = chunk_changer.get_mutable_column_mapping(1);
@@ -590,44 +614,20 @@ TEST_F(SchemaChangeTest, schema_change_with_agg_key_reorder) {
     column_mapping->ref_column = 2;
     ASSERT_TRUE(chunk_changer.prepare().ok());
 
-    _sc_procedure = new (std::nothrow) SchemaChangeWithSorting(
-            &chunk_changer, config::memory_limitation_per_thread_for_schema_change * 1024 * 1024 * 1024);
-    Version version(3, 3);
+    auto sc_procedure = std::make_unique<SchemaChangeWithSorting>(&chunk_changer, _mem_limit);
     RowsetSharedPtr rowset = base_tablet->get_rowset_by_version(version);
     ASSERT_TRUE(rowset != nullptr);
+    Schema base_schema = ChunkHelper::convert_schema(base_tablet_schema, chunk_changer.get_selected_column_indexes());
 
-    TabletReaderParams read_params;
-    read_params.reader_type = ReaderType::READER_ALTER_TABLE;
-    read_params.skip_aggregation = false;
-    read_params.chunk_size = config::vector_chunk_size;
-    Schema base_schema =
-            ChunkHelper::convert_schema(base_tablet->tablet_schema(), chunk_changer.get_selected_column_indexes());
-    auto* tablet_rowset_reader = new TabletReader(base_tablet, rowset->version(), base_schema);
-    ASSERT_TRUE(tablet_rowset_reader != nullptr);
-    ASSERT_TRUE(tablet_rowset_reader->prepare().ok());
-    ASSERT_TRUE(tablet_rowset_reader->open(read_params).ok());
+    auto rowset_reader = TabletTestHelper::create_rowset_reader(base_tablet, base_schema, version);
+    auto rowset_writer = TabletTestHelper::create_rowset_writer(*new_tablet, next_rowset_id(), version);
 
-    RowsetWriterContext writer_context;
-    writer_context.rowset_id = engine->next_rowset_id();
-    writer_context.tablet_uid = new_tablet->tablet_uid();
-    writer_context.tablet_id = new_tablet->tablet_id();
-    writer_context.tablet_schema_hash = new_tablet->schema_hash();
-    writer_context.rowset_path_prefix = new_tablet->schema_hash_path();
-    writer_context.tablet_schema = new_tablet->tablet_schema();
-    writer_context.rowset_state = VISIBLE;
-    writer_context.version = Version(3, 3);
-    std::unique_ptr<RowsetWriter> rowset_writer;
-    ASSERT_TRUE(RowsetFactory::create_rowset_writer(writer_context, &rowset_writer).ok());
-
-    ASSERT_TRUE(
-            _sc_procedure->process(tablet_rowset_reader, rowset_writer.get(), new_tablet, base_tablet, rowset).ok());
-    delete tablet_rowset_reader;
-    (void)StorageEngine::instance()->tablet_manager()->drop_tablet(1203);
-    (void)StorageEngine::instance()->tablet_manager()->drop_tablet(1204);
+    ASSERT_OK(sc_procedure->process(rowset_reader.get(), rowset_writer.get(), new_tablet, base_tablet, rowset));
+    (void)_tablet_mgr->drop_tablet(base_tablet_id);
+    (void)_tablet_mgr->drop_tablet(new_tablet_id);
 }
 
 TEST_F(SchemaChangeTest, convert_varchar_to_json) {
-    auto mem_pool = std::make_unique<MemPool>();
     std::vector<std::string> test_cases = {"{\"a\": 1}", "null", "[1,2,3]"};
     for (const auto& json_str : test_cases) {
         JsonValue expected = JsonValue::parse(json_str).value();
@@ -637,9 +637,8 @@ TEST_F(SchemaChangeTest, convert_varchar_to_json) {
         src_column->append(json_str);
 
         auto converter = get_type_converter(TYPE_VARCHAR, TYPE_JSON);
-        TypeInfoPtr type1 = get_type_info(TYPE_VARCHAR);
-        TypeInfoPtr type2 = get_type_info(TYPE_JSON);
-        Status st = converter->convert_column(type1.get(), *src_column, type2.get(), dst_column.get(), mem_pool.get());
+        Status st = converter->convert_column(_varchar_type.get(), *src_column, _json_type.get(), dst_column.get(),
+                                              &_mem_pool);
         ASSERT_TRUE(st.ok());
         ASSERT_EQ(*dst_column->get_object(0), expected);
     }
@@ -653,31 +652,39 @@ TEST_F(SchemaChangeTest, convert_json_to_varchar) {
     src_column->append(&json);
 
     auto converter = get_type_converter(TYPE_JSON, TYPE_VARCHAR);
-    auto mem_pool = std::make_unique<MemPool>();
-    TypeInfoPtr type1 = get_type_info(TYPE_JSON);
-    TypeInfoPtr type2 = get_type_info(TYPE_VARCHAR);
-    Status st = converter->convert_column(type1.get(), *src_column, type2.get(), dst_column.get(), mem_pool.get());
+    Status st =
+            converter->convert_column(_json_type.get(), *src_column, _varchar_type.get(), dst_column.get(), &_mem_pool);
     ASSERT_TRUE(st.ok());
     ASSERT_EQ(dst_column->get_slice(0), json_str);
 }
 
 TEST_F(SchemaChangeTest, schema_change_with_materialized_column_old_style) {
-    CreateSrcTablet(1301);
-    StorageEngine* engine = StorageEngine::instance();
-    TCreateTabletReq create_tablet_req;
-    SetCreateTabletReq(&create_tablet_req, 1302, TKeysType::DUP_KEYS);
-    AddColumn(&create_tablet_req, "k1", TPrimitiveType::INT, true);
-    AddColumn(&create_tablet_req, "k2", TPrimitiveType::INT, true);
-    AddColumn(&create_tablet_req, "v1", TPrimitiveType::INT, false);
-    AddColumn(&create_tablet_req, "v2", TPrimitiveType::INT, false);
+    TTabletId base_tablet_id = 1301;
+    TTabletId new_tablet_id = 1302;
+    Version version(3, 3);
 
-    create_tablet_req.tablet_schema.columns.back().__set_is_allow_null(true);
-    Status res = engine->create_tablet(create_tablet_req);
-    ASSERT_TRUE(res.ok()) << res.to_string();
-    TabletSharedPtr new_tablet = engine->tablet_manager()->get_tablet(create_tablet_req.tablet_id);
-    TabletSharedPtr base_tablet = engine->tablet_manager()->get_tablet(1301);
+    create_base_tablet(base_tablet_id, TKeysType::DUP_KEYS, TStorageType::COLUMN);
+    write_data_to_base_tablet(base_tablet_id, version);
 
-    ChunkChanger chunk_changer(new_tablet->tablet_schema());
+    {
+        TCreateTabletReq create_tablet_req =
+                TabletTestHelper::gen_create_tablet_req(new_tablet_id, TKeysType::DUP_KEYS, TStorageType::COLUMN);
+        add_key_column(&create_tablet_req, "k1", TPrimitiveType::INT);
+        add_key_column(&create_tablet_req, "k2", TPrimitiveType::INT);
+        add_value_column(&create_tablet_req, "v1", TPrimitiveType::INT);
+        add_value_column(&create_tablet_req, "v2", TPrimitiveType::INT);
+
+        create_tablet_req.tablet_schema.columns.back().__set_is_allow_null(true);
+        Status res = _storage_engine->create_tablet(create_tablet_req);
+        ASSERT_TRUE(res.ok()) << res.to_string();
+    }
+
+    TabletSharedPtr base_tablet = _tablet_mgr->get_tablet(base_tablet_id);
+    TabletSharedPtr new_tablet = _tablet_mgr->get_tablet(new_tablet_id);
+    auto base_tablet_schema = base_tablet->tablet_schema();
+    auto new_tablet_schema = new_tablet->tablet_schema();
+
+    ChunkChanger chunk_changer(new_tablet_schema);
     for (size_t i = 0; i < 4; ++i) {
         ColumnMapping* column_mapping = chunk_changer.get_mutable_column_mapping(i);
         column_mapping->ref_column = i;
@@ -714,59 +721,45 @@ TEST_F(SchemaChangeTest, schema_change_with_materialized_column_old_style) {
 
     chunk_changer.get_gc_exprs()->insert({3, ctx});
 
-    _sc_procedure = new (std::nothrow) SchemaChangeDirectly(&chunk_changer);
-    Version version(3, 3);
+    auto sc_procedure = std::make_unique<SchemaChangeDirectly>(&chunk_changer);
     RowsetSharedPtr rowset = base_tablet->get_rowset_by_version(version);
     ASSERT_TRUE(rowset != nullptr);
+    Schema base_schema = ChunkHelper::convert_schema(base_tablet_schema, chunk_changer.get_selected_column_indexes());
 
-    TabletReaderParams read_params;
-    read_params.reader_type = ReaderType::READER_ALTER_TABLE;
-    read_params.skip_aggregation = false;
-    read_params.chunk_size = config::vector_chunk_size;
-    Schema base_schema =
-            ChunkHelper::convert_schema(base_tablet->tablet_schema(), chunk_changer.get_selected_column_indexes());
-    auto* tablet_rowset_reader = new TabletReader(base_tablet, rowset->version(), base_schema);
-    ASSERT_TRUE(tablet_rowset_reader != nullptr);
-    ASSERT_TRUE(tablet_rowset_reader->prepare().ok());
-    ASSERT_TRUE(tablet_rowset_reader->open(read_params).ok());
+    auto rowset_reader = TabletTestHelper::create_rowset_reader(base_tablet, base_schema, version);
+    auto rowset_writer = TabletTestHelper::create_rowset_writer(*new_tablet, next_rowset_id(), version);
 
-    RowsetWriterContext writer_context;
-    writer_context.rowset_id = engine->next_rowset_id();
-    writer_context.tablet_uid = new_tablet->tablet_uid();
-    writer_context.tablet_id = new_tablet->tablet_id();
-    writer_context.tablet_schema_hash = new_tablet->schema_hash();
-    writer_context.rowset_path_prefix = new_tablet->schema_hash_path();
-    writer_context.tablet_schema = new_tablet->tablet_schema();
-    writer_context.rowset_state = VISIBLE;
-    writer_context.version = Version(3, 3);
-    std::unique_ptr<RowsetWriter> rowset_writer;
-    ASSERT_TRUE(RowsetFactory::create_rowset_writer(writer_context, &rowset_writer).ok());
+    ASSERT_OK(sc_procedure->process(rowset_reader.get(), rowset_writer.get(), new_tablet, base_tablet, rowset));
 
-    ASSERT_TRUE(
-            _sc_procedure->process(tablet_rowset_reader, rowset_writer.get(), new_tablet, base_tablet, rowset).ok());
-    delete tablet_rowset_reader;
-    (void)StorageEngine::instance()->tablet_manager()->drop_tablet(1101);
-    (void)StorageEngine::instance()->tablet_manager()->drop_tablet(1102);
+    (void)_tablet_mgr->drop_tablet(base_tablet_id);
+    (void)_tablet_mgr->drop_tablet(new_tablet_id);
 }
 
 TEST_F(SchemaChangeTest, schema_change_with_materialized_column_optimization) {
-    int64_t version = 2;
-    CreateSrcTablet(1401, TKeysType::DUP_KEYS, &version);
-    StorageEngine* engine = StorageEngine::instance();
-    TCreateTabletReq create_tablet_req;
-    SetCreateTabletReq(&create_tablet_req, 1402, TKeysType::DUP_KEYS);
-    AddColumn(&create_tablet_req, "k1", TPrimitiveType::INT, true);
-    AddColumn(&create_tablet_req, "k2", TPrimitiveType::INT, true);
-    AddColumn(&create_tablet_req, "v1", TPrimitiveType::INT, false);
-    AddColumn(&create_tablet_req, "v2", TPrimitiveType::INT, false);
-    AddColumn(&create_tablet_req, "newcol", TPrimitiveType::INT, false);
+    TTabletId base_tablet_id = 1401;
+    TTabletId new_tablet_id = 1402;
+    Version version(2, 2);
 
-    create_tablet_req.tablet_schema.columns.back().__set_is_allow_null(true);
-    Status res = engine->create_tablet(create_tablet_req);
-    ASSERT_TRUE(res.ok()) << res.to_string();
-    TabletSharedPtr new_tablet = engine->tablet_manager()->get_tablet(create_tablet_req.tablet_id);
-    TabletSharedPtr base_tablet = engine->tablet_manager()->get_tablet(1401);
-    new_tablet->set_tablet_state(TABLET_NOTREADY);
+    create_base_tablet(base_tablet_id, TKeysType::DUP_KEYS, TStorageType::COLUMN);
+    write_data_to_base_tablet(base_tablet_id, version);
+
+    {
+        TCreateTabletReq create_tablet_req =
+                TabletTestHelper::gen_create_tablet_req(new_tablet_id, TKeysType::DUP_KEYS, TStorageType::COLUMN);
+        add_key_column(&create_tablet_req, "k1", TPrimitiveType::INT);
+        add_key_column(&create_tablet_req, "k2", TPrimitiveType::INT);
+        add_value_column(&create_tablet_req, "v1", TPrimitiveType::INT);
+        add_value_column(&create_tablet_req, "v2", TPrimitiveType::INT);
+        add_value_column(&create_tablet_req, "newcol", TPrimitiveType::INT);
+
+        create_tablet_req.tablet_schema.columns.back().__set_is_allow_null(true);
+        Status res = _storage_engine->create_tablet(create_tablet_req);
+        ASSERT_TRUE(res.ok()) << res.to_string();
+    }
+
+    TabletSharedPtr base_tablet = _tablet_mgr->get_tablet(base_tablet_id);
+    TabletSharedPtr new_tablet = _tablet_mgr->get_tablet(new_tablet_id);
+    (void)new_tablet->set_tablet_state(TABLET_NOTREADY);
 
     TAlterTabletReqV2 request;
     TAlterTabletMaterializedColumnReq mc_request;
@@ -796,8 +789,8 @@ TEST_F(SchemaChangeTest, schema_change_with_materialized_column_optimization) {
 
     request.__set_base_schema_hash(base_tablet->schema_hash());
     request.__set_new_schema_hash(new_tablet->schema_hash());
-    request.__set_base_tablet_id(1401);
-    request.__set_new_tablet_id(1402);
+    request.__set_base_tablet_id(base_tablet_id);
+    request.__set_new_tablet_id(new_tablet_id);
     request.__set_alter_version(base_tablet->max_version().second);
     request.__set_tablet_type(TTabletType::TABLET_TYPE_DISK);
     request.__set_materialized_column_req(mc_request);
@@ -807,11 +800,90 @@ TEST_F(SchemaChangeTest, schema_change_with_materialized_column_optimization) {
     std::string alter_msg_header = strings::Substitute("[Alter Job:$0, tablet:$1]: ", 999, 1401);
     SchemaChangeHandler handler;
     handler.set_alter_msg_header(alter_msg_header);
-    res = handler.process_alter_tablet_v2(request);
+    auto res = handler.process_alter_tablet(request);
     ASSERT_TRUE(res.ok()) << res.to_string();
 
-    (void)StorageEngine::instance()->tablet_manager()->drop_tablet(1401);
-    (void)StorageEngine::instance()->tablet_manager()->drop_tablet(1402);
+    (void)_tablet_mgr->drop_tablet(base_tablet_id);
+    (void)_tablet_mgr->drop_tablet(new_tablet_id);
+}
+
+TEST_F(SchemaChangeTest, overlapping_direct_schema_change) {
+    TTabletId base_tablet_id = 1403;
+    TTabletId new_tablet_id = 1404;
+    Version version(2, 2);
+    TPartitionId partition_id = 1;
+    TTransactionId txn_id = 1;
+
+    {
+        create_base_tablet(base_tablet_id, TKeysType::DUP_KEYS, TStorageType::COLUMN);
+        auto slots = gen_base_slots();
+        auto delta_writer = TabletTestHelper::create_delta_writer(base_tablet_id, slots, &_mem_tracker);
+
+        Chunk chunk;
+        auto c0 = ColumnTestHelper::build_column<int32_t>({0, 1, 2, 3});
+        auto c1 = ColumnTestHelper::build_column<int32_t>({0, 1, 2, 3});
+        auto c2 = ColumnTestHelper::build_column<int32_t>({0, 1, 2, 3});
+        auto c3 = ColumnTestHelper::build_column<int32_t>({0, 1, 2, 3});
+        chunk.append_column(c0, 0);
+        chunk.append_column(c1, 1);
+        chunk.append_column(c2, 2);
+        chunk.append_column(c3, 3);
+
+        std::vector<uint32_t> idxs{0, 1, 2, 3};
+        ASSERT_OK(delta_writer->write(chunk, idxs.data(), 0, 4));
+        ASSERT_OK(delta_writer->flush_memtable_async(false));
+        ASSERT_OK(delta_writer->write(chunk, idxs.data(), 0, 4));
+        ASSERT_OK(delta_writer->close());
+        ASSERT_OK(delta_writer->commit());
+    }
+
+    auto base_tablet = _tablet_mgr->get_tablet(base_tablet_id);
+
+    {
+        std::map<TabletInfo, RowsetSharedPtr> tablet_related_rs;
+        _txn_mgr->get_txn_related_tablets(txn_id, partition_id, &tablet_related_rs);
+        for (auto& tablet_rs : tablet_related_rs) {
+            ASSERT_OK(
+                    _txn_mgr->publish_txn(partition_id, base_tablet, txn_id, version.second, tablet_rs.second, 10000));
+        }
+    }
+
+    auto base_rowset = base_tablet->get_inc_rowset_by_version(version);
+    ASSERT_TRUE(base_rowset != nullptr);
+    ASSERT_TRUE(base_rowset->is_overlapped());
+
+    create_dest_tablet_with_index(base_tablet_id, new_tablet_id, TKeysType::DUP_KEYS);
+
+    TAlterTabletReqV2 req = gen_alter_tablet_req(base_tablet_id, new_tablet_id, version);
+
+    SchemaChangeHandler handler;
+    ASSERT_OK(handler.process_alter_tablet(req));
+
+    auto new_tablet = _tablet_mgr->get_tablet(new_tablet_id);
+    auto new_tablet_schema = new_tablet->tablet_schema();
+
+    auto new_rowset = new_tablet->get_rowset_by_version(version);
+    ASSERT_TRUE(new_rowset != nullptr);
+    ASSERT_EQ(new_rowset->num_segments(), 1);
+
+    auto seg_iters = TabletTestHelper::create_segment_iterators(*new_tablet, version, &_stats);
+    ASSERT_EQ(seg_iters.size(), 1);
+
+    Chunk result_chunk;
+    ASSERT_OK(seg_iters[0]->get_next(&result_chunk));
+    ASSERT_EQ(result_chunk.num_rows(), 8);
+
+    ASSERT_EQ("[0, 0, 0, 0]", result_chunk.debug_row(0));
+    ASSERT_EQ("[0, 0, 0, 0]", result_chunk.debug_row(1));
+    ASSERT_EQ("[1, 1, 1, 1]", result_chunk.debug_row(2));
+    ASSERT_EQ("[1, 1, 1, 1]", result_chunk.debug_row(3));
+    ASSERT_EQ("[2, 2, 2, 2]", result_chunk.debug_row(4));
+    ASSERT_EQ("[2, 2, 2, 2]", result_chunk.debug_row(5));
+    ASSERT_EQ("[3, 3, 3, 3]", result_chunk.debug_row(6));
+    ASSERT_EQ("[3, 3, 3, 3]", result_chunk.debug_row(7));
+
+    (void)_tablet_mgr->drop_tablet(base_tablet_id);
+    (void)_tablet_mgr->drop_tablet(new_tablet_id);
 }
 
 } // namespace starrocks

--- a/be/test/storage/tablet_updates_schema_change_test.cpp
+++ b/be/test/storage/tablet_updates_schema_change_test.cpp
@@ -104,7 +104,7 @@ void TabletUpdatesTest::test_schema_change_optimiazation_adding_generated_column
     std::string alter_msg_header = strings::Substitute("[Alter Job:$0, tablet:$1]: ", 999, base_tablet->tablet_id());
     SchemaChangeHandler handler;
     handler.set_alter_msg_header(alter_msg_header);
-    auto res = handler.process_alter_tablet_v2(request);
+    auto res = handler.process_alter_tablet(request);
     ASSERT_TRUE(res.ok()) << res.to_string();
 }
 


### PR DESCRIPTION
## Why I'm doing:

If the segments of single rowset is overlapping, will should use heap merge when do direct schema change, otherwise the rows is not ordered by sort key.

How to reproduce:

```
 CREATE TABLE `lineorder_1` (
  `lo_orderkey` int(11) NOT NULL COMMENT "",
  `lo_linenumber` int(11) NOT NULL COMMENT "",
  `lo_custkey` int(11) NOT NULL COMMENT "",
  `lo_partkey` int(11) NOT NULL COMMENT "",
  `lo_suppkey` int(11) NOT NULL COMMENT "",
  `lo_orderdate` int(11) NOT NULL COMMENT "",
  `lo_orderpriority` varchar(16) NOT NULL COMMENT "",
  `lo_shippriority` int(11) NOT NULL COMMENT "",
  `lo_quantity` int(11) NOT NULL COMMENT "",
  `lo_extendedprice` int(11) NOT NULL COMMENT "",
  `lo_ordtotalprice` int(11) NOT NULL COMMENT "",
  `lo_discount` int(11) NOT NULL COMMENT "",
  `lo_revenue` int(11) NOT NULL COMMENT "",
  `lo_supplycost` int(11) NOT NULL COMMENT "",
  `lo_tax` int(11) NOT NULL COMMENT "",
  `lo_commitdate` int(11) NOT NULL COMMENT "",
  `lo_shipmode` varchar(11) NOT NULL COMMENT "",
  INDEX t1 (`lo_partkey`) USING BITMAP COMMENT ''
) ENGINE=OLAP 
DUPLICATE KEY(`lo_orderkey`, `lo_linenumber`)
COMMENT "OLAP"
DISTRIBUTED BY HASH(`lo_orderkey`) BUCKETS 1 
PROPERTIES (
"compression" = "LZ4",
"fast_schema_evolution" = "true",
"replicated_storage" = "true",
"replication_num" = "1"
);

insert into lineorder_1 select * from lineorder limit 2000000;

select * from lineorder_1 where lo_orderkey>5427812 and lo_orderkey<=5927812;
select lo_orderkey from lineorder_1 where lo_orderkey>5427812 and lo_orderkey<=5927812;
 
The num of return rows is inconsistent.
```

## What I'm doing:

Use heap merge for direct schema change if the segments of rwoset is overlapping.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [x] 3.2
  - [x] 3.1
  - [x] 3.0
  - [x] 2.5
