### PR TITLE
[Enhancement] Refactor share-data segment file name pattern

### DIFF
--- a/be/src/storage/lake/delta_writer.cpp
+++ b/be/src/storage/lake/delta_writer.cpp
@@ -452,7 +452,7 @@ StatusOr<TxnLogPtr> DeltaWriterImpl::finish(DeltaWriterFinishMode mode) {
             }
             // generate rewrite segment names to avoid gc in rewrite operation
             for (auto i = 0; i < op_write->rowset().segments_size(); i++) {
-                op_write->add_rewrite_segments(gen_segment_filename(_txn_id));
+                op_write->add_rewrite_segments(gen_segment_filename(_txn_id, _tablet_id));
             }
         }
         // handle condition update
@@ -476,7 +476,7 @@ StatusOr<TxnLogPtr> DeltaWriterImpl::finish(DeltaWriterFinishMode mode) {
 
             if (op_write->rewrite_segments_size() == 0) {
                 for (auto i = 0; i < op_write->rowset().segments_size(); i++) {
-                    op_write->add_rewrite_segments(gen_segment_filename(_txn_id));
+                    op_write->add_rewrite_segments(gen_segment_filename(_txn_id, _tablet_id));
                 }
             }
         }

--- a/be/src/storage/lake/filenames.h
+++ b/be/src/storage/lake/filenames.h
@@ -104,8 +104,8 @@ inline std::string tablet_metadata_lock_filename(int64_t tablet_id, int64_t vers
     return fmt::format("{:016X}_{:016X}_{:016X}.lock", tablet_id, version, expire_time);
 }
 
-inline std::string gen_segment_filename(int64_t txn_id) {
-    return fmt::format("{:016x}_{}.dat", txn_id, generate_uuid_string());
+inline std::string gen_segment_filename(int64_t txn_id, int64_t tablet_id) {
+    return fmt::format("{:016x}_{:016X}_{}.dat", txn_id, tablet_id, generate_uuid_string());
 }
 
 inline std::string gen_del_filename(int64_t txn_id) {

--- a/be/src/storage/lake/general_tablet_writer.cpp
+++ b/be/src/storage/lake/general_tablet_writer.cpp
@@ -79,7 +79,7 @@ void HorizontalGeneralTabletWriter::close() {
 
 Status HorizontalGeneralTabletWriter::reset_segment_writer() {
     DCHECK(_schema != nullptr);
-    auto name = gen_segment_filename(_txn_id);
+    auto name = gen_segment_filename(_txn_id, _tablet_id);
     ASSIGN_OR_RETURN(auto of, fs::new_writable_file(_tablet_mgr->segment_location(_tablet_id, name)));
     SegmentWriterOptions opts;
     auto w = std::make_unique<SegmentWriter>(std::move(of), _seg_id++, _schema, opts);
@@ -257,7 +257,7 @@ void VerticalGeneralTabletWriter::close() {
 StatusOr<std::shared_ptr<SegmentWriter>> VerticalGeneralTabletWriter::create_segment_writer(
         const std::vector<uint32_t>& column_indexes, bool is_key) {
     DCHECK(_schema != nullptr);
-    auto name = gen_segment_filename(_txn_id);
+    auto name = gen_segment_filename(_txn_id, _tablet_id);
     ASSIGN_OR_RETURN(auto of, fs::new_writable_file(_tablet_mgr->segment_location(_tablet_id, name)));
     SegmentWriterOptions opts;
     auto w = std::make_shared<SegmentWriter>(std::move(of), _seg_id++, _schema, opts);

--- a/be/src/storage/lake/replication_txn_manager.cpp
+++ b/be/src/storage/lake/replication_txn_manager.cpp
@@ -404,9 +404,10 @@ Status ReplicationTxnManager::convert_rowset_meta(const RowsetMeta& rowset_meta,
     }
 
     std::string rowset_id = rowset_meta.rowset_id().to_string();
+    auto tablet_id = rowset_meta.tablet_id();
     for (int64_t segment_id = 0; segment_id < rowset_meta.num_segments(); ++segment_id) {
         std::string old_segment_filename = rowset_id + '_' + std::to_string(segment_id) + ".dat";
-        std::string new_segment_filename = gen_segment_filename(transaction_id);
+        std::string new_segment_filename = gen_segment_filename(transaction_id, tablet_id);
 
         rowset_metadata->add_segments(new_segment_filename);
         auto pair = filename_map->emplace(std::move(old_segment_filename), std::move(new_segment_filename));

--- a/be/test/service/lake_service_test.cpp
+++ b/be/test/service/lake_service_test.cpp
@@ -76,7 +76,7 @@ public:
 protected:
     // Return the new generated segment file name
     std::string generate_segment_file(int64_t txn_id) {
-        auto seg_name = lake::gen_segment_filename(txn_id);
+        auto seg_name = lake::gen_segment_filename(txn_id, _tablet_id);
         auto seg_path = _tablet_mgr->segment_location(_tablet_id, seg_name);
         ASSIGN_OR_ABORT(auto f, fs::new_writable_file(seg_path));
         CHECK_OK(f->append(seg_path));


### PR DESCRIPTION
## Why I'm doing:

The segment data filename pattern in the previous design was a combination of `txn_id` and uuid, which is not convenient  to tell what tablet if belongs to. There is no easy way to find a segment data file's tablet id. 

By adding `tablet_id` to the data filename, we can obtain tablet id quickly without reading any meta files. In other words, we make the data file name *self-contained* the tablet id it belongs to.

## What I'm doing:

Add `tablet_id` when constructing the data filename.

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [x] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
