### PR TITLE
[Refactor] Remove redundant interface from ComputeNode

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/system/ComputeNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/system/ComputeNode.java
@@ -352,16 +352,8 @@ public class ComputeNode implements IComputable, Writable {
         return this.isAlive.get();
     }
 
-    public void setIsAlive(boolean isAlive) {
-        this.isAlive.set(isAlive);
-    }
-
     public boolean isDecommissioned() {
         return this.isDecommissioned.get();
-    }
-
-    public void setIsDecommissioned(boolean isDecommissioned) {
-        this.isDecommissioned.set(isDecommissioned);
     }
 
     public boolean isAvailable() {
@@ -471,10 +463,6 @@ public class ComputeNode implements IComputable, Writable {
 
     public AtomicBoolean getIsAlive() {
         return isAlive;
-    }
-
-    public void setIsAlive(AtomicBoolean isAlive) {
-        this.isAlive = isAlive;
     }
 
     public void setDecommissionType(int decommissionType) {

--- a/fe/fe-core/src/test/java/com/starrocks/binlog/BinlogManagerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/binlog/BinlogManagerTest.java
@@ -36,7 +36,7 @@ public class BinlogManagerTest {
     public static void beforeClass() throws Exception {
         UtFrameUtils.createMinStarRocksCluster();
         Backend be = UtFrameUtils.addMockBackend(10002);
-        be.setIsDecommissioned(true);
+        be.setDecommissioned(true);
         Config.enable_strict_storage_medium_check = true;
         // create connect context
         connectContext = UtFrameUtils.createDefaultCtx();

--- a/fe/fe-core/src/test/java/com/starrocks/catalog/CreateViewTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/CreateViewTest.java
@@ -34,7 +34,7 @@ public class CreateViewTest {
     public static void beforeClass() throws Exception {
         UtFrameUtils.createMinStarRocksCluster();
         Backend be = UtFrameUtils.addMockBackend(10002);
-        be.setIsDecommissioned(true);
+        be.setDecommissioned(true);
         UtFrameUtils.addMockBackend(10003);
         UtFrameUtils.addMockBackend(10004);
         Config.enable_strict_storage_medium_check = true;

--- a/fe/fe-core/src/test/java/com/starrocks/clone/TabletSchedulerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/clone/TabletSchedulerTest.java
@@ -67,7 +67,6 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.concurrent.atomic.AtomicBoolean;
 
 import static com.starrocks.catalog.KeysType.DUP_KEYS;
 
@@ -258,7 +257,7 @@ public class TabletSchedulerTest {
         backendDisks1.put("/path11", td11);
         backendDisks1.put("/path12", td12);
         Backend be1 = new Backend(1, "192.168.0.1", 9030);
-        be1.setIsAlive(new AtomicBoolean(true));
+        be1.setAlive(true);
         be1.updateDisks(backendDisks1);
         systemInfoService.addBackend(be1);
 
@@ -271,7 +270,7 @@ public class TabletSchedulerTest {
         backendDisks2.put("/path22", td22);
         Backend be2 = new Backend(2, "192.168.0.2", 9030);
         be2.updateDisks(backendDisks2);
-        be2.setIsAlive(new AtomicBoolean(true));
+        be2.setAlive(true);
         systemInfoService.addBackend(be2);
 
         TabletScheduler tabletScheduler = new TabletScheduler(tabletSchedulerStat);

--- a/fe/fe-core/src/test/java/com/starrocks/load/ExportCheckerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/load/ExportCheckerTest.java
@@ -66,7 +66,7 @@ public class ExportCheckerTest {
         Assert.assertTrue(cancelled);
 
         be.setAlive(true);
-        be.setIsDecommissioned(true);
+        be.setDecommissioned(true);
 
         be.setLastStartTime(1001L);
 

--- a/fe/fe-core/src/test/java/com/starrocks/load/streamload/ShowStreamLoadTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/load/streamload/ShowStreamLoadTest.java
@@ -43,7 +43,7 @@ public class ShowStreamLoadTest {
     public static void beforeClass() throws Exception {
         UtFrameUtils.createMinStarRocksCluster();
         Backend be = UtFrameUtils.addMockBackend(10002);
-        be.setIsDecommissioned(true);
+        be.setDecommissioned(true);
         UtFrameUtils.addMockBackend(10003);
         UtFrameUtils.addMockBackend(10004);
         Config.enable_strict_storage_medium_check = true;


### PR DESCRIPTION
* remove redundant `setIsAlive()` and `setIsDecommissioned()` interface

## Why I'm doing:

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [X] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [X] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [X] I have checked the version labels which the pr will be auto-backported to the target branch
  - [X] 3.3
  - [X] 3.2
  - [X] 3.1
  - [ ] 3.0
  - [ ] 2.5
