### PR TITLE
[BugFix] Fix prepare stmt exec failed after table schema change

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/qe/StmtExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/StmtExecutor.java
@@ -118,7 +118,6 @@ import com.starrocks.sql.StatementPlanner;
 import com.starrocks.sql.analyzer.AnalyzerUtils;
 import com.starrocks.sql.analyzer.AstToStringBuilder;
 import com.starrocks.sql.analyzer.Authorizer;
-import com.starrocks.sql.analyzer.Field;
 import com.starrocks.sql.analyzer.SemanticException;
 import com.starrocks.sql.analyzer.SetStmtAnalyzer;
 import com.starrocks.sql.ast.AddBackendBlackListStmt;
@@ -1714,8 +1713,6 @@ public class StmtExecutor {
 
     private void sendStmtPrepareOK(PrepareStmt prepareStmt) throws IOException {
         // https://dev.mysql.com/doc/dev/mysql-server/latest/page_protocol_com_stmt_prepare.html#sect_protocol_com_stmt_prepare_response
-        QueryStatement query = (QueryStatement) prepareStmt.getInnerStmt();
-        int numColumns = query.getQueryRelation().getRelationFields().size();
         int numParams = prepareStmt.getParameters().size();
         serializer.reset();
         // 0x00 OK
@@ -1723,7 +1720,7 @@ public class StmtExecutor {
         // statement_id
         serializer.writeInt4(Integer.valueOf(prepareStmt.getName()));
         // num_columns
-        serializer.writeInt2(numColumns);
+        serializer.writeInt2(0);
         // num_params
         serializer.writeInt2(numParams);
         // reserved_1
@@ -1740,17 +1737,6 @@ public class StmtExecutor {
             for (int i = 0; i < colNames.size(); ++i) {
                 serializer.reset();
                 serializer.writeField(colNames.get(i), parameters.get(i).getType());
-                context.getMysqlChannel().sendOnePacket(serializer.toByteBuffer());
-            }
-            MysqlEofPacket eofPacket = new MysqlEofPacket(context.getState());
-            eofPacket.writeTo(serializer);
-            context.getMysqlChannel().sendOnePacket(serializer.toByteBuffer());
-        }
-
-        if (numColumns > 0) {
-            for (Field field : query.getQueryRelation().getRelationFields().getAllFields()) {
-                serializer.reset();
-                serializer.writeField(field.getName(), field.getType());
                 context.getMysqlChannel().sendOnePacket(serializer.toByteBuffer());
             }
             MysqlEofPacket eofPacket = new MysqlEofPacket(context.getState());


### PR DESCRIPTION
## Why I'm doing:
after table schema change, for example, add new column,  execute prepareStmt will get error

## What I'm doing:
do not set column infos when prepare stmt

Fixes #44874

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [x] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [x] 3.3
  - [x] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5