### PR TITLE
[Enhancement] Disable table feature for delta lake which do not support now

### DIFF
--- a/fe/fe-core/src/test/java/com/starrocks/connector/delta/DeltaUtilsTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/delta/DeltaUtilsTest.java
@@ -1,0 +1,80 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.connector.delta;
+
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Lists;
+import com.starrocks.sql.optimizer.validate.ValidateException;
+import io.delta.kernel.internal.actions.Metadata;
+import io.delta.kernel.internal.actions.Protocol;
+import mockit.Expectations;
+import mockit.Mocked;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import static io.delta.kernel.internal.util.ColumnMapping.COLUMN_MAPPING_MODE_KEY;
+import static io.delta.kernel.internal.util.ColumnMapping.COLUMN_MAPPING_MODE_NAME;
+
+public class DeltaUtilsTest {
+    @Rule
+    public ExpectedException expectedEx = ExpectedException.none();
+
+    @Test
+    public void testCheckTableFeatureSupported() {
+        expectedEx.expect(ValidateException.class);
+        expectedEx.expectMessage("Delta table is missing protocol or metadata information.");
+        DeltaUtils.checkTableFeatureSupported(null, null);
+    }
+
+    @Test
+    public void testCheckTableFeatureSupported2(@Mocked Metadata metadata) {
+        expectedEx.expect(ValidateException.class);
+        expectedEx.expectMessage("Delta table feature [column mapping] is not supported");
+
+        new Expectations(metadata) {
+            {
+                metadata.getConfiguration();
+                result = ImmutableMap.of(COLUMN_MAPPING_MODE_KEY, COLUMN_MAPPING_MODE_NAME);
+                minTimes = 0;
+            }
+        };
+
+        DeltaUtils.checkTableFeatureSupported(new Protocol(3, 7, Lists.newArrayList(),
+                Lists.newArrayList()), metadata);
+    }
+
+    @Test
+    public void testCheckTableFeatureSupported3(@Mocked Metadata metadata, @Mocked Protocol protocol) {
+        expectedEx.expect(ValidateException.class);
+        expectedEx.expectMessage("Delta table feature [timestampNtz] is not supported");
+        new Expectations() {
+            {
+                metadata.getConfiguration();
+                result = ImmutableMap.of(COLUMN_MAPPING_MODE_KEY, "none");
+                minTimes = 0;
+            }
+
+            {
+                protocol.getReaderFeatures();
+                result = Lists.newArrayList("timestampNtz");
+                minTimes = 0;
+            }
+        };
+
+        DeltaUtils.checkTableFeatureSupported(new Protocol(3, 7, Lists.newArrayList(),
+                Lists.newArrayList()), metadata);
+    }
+}

--- a/test/sql/test_deltalake/R/test_deltalake_catalog
+++ b/test/sql/test_deltalake/R/test_deltalake_catalog
@@ -17,15 +17,15 @@ select * from delta_test_${uuid0}.delta_oss_db.delta_lake_data_type where col_st
 -- result:
 6	600	6000	60000	18.84	18.84956	2024-04-29	2024-04-29 12:00:00	sixth_string	321.98	0	6	[16,17,18]	final_binary_data	None	None
 -- !result
-select col_struct from delta_test_${uuid0}.delta_oss_db.delta_lake_data_type where col_struct is not null;
+select col_struct from delta_test_${uuid0}.delta_oss_db.delta_lake_data_type where col_struct is not null order by col_tinyint;
 -- result:
+{"name":"Alice","sex":"female","age":30}
+{"name":"Bob","sex":"male","age":25}
+{"name":"Charlie","sex":"male","age":35}
 {"name":"Diana","sex":"female","age":28}
 {"name":"Edward","sex":"male","age":40}
 {"name":"Fiona","sex":"female","age":33}
 {"name":null,"sex":null,"age":null}
-{"name":"Alice","sex":"female","age":30}
-{"name":"Bob","sex":"male","age":25}
-{"name":"Charlie","sex":"male","age":35}
 -- !result
 select * from delta_test_${uuid0}.delta_oss_db.delta_lake_par_col_boolean where col_boolean = true;
 -- result:
@@ -157,6 +157,10 @@ select col_timestamp from delta_test_${uuid0}.delta_oss_db.delta_lake_data_type 
 2024-04-24 12:00:00
 2024-04-25 12:00:00
 2024-04-26 12:00:00
+-- !result
+select * from delta_test_${uuid0}.delta_oss_db.delta_test_column_mapping;
+-- result:
+E: (1064, "Unknown table 'Delta table feature [column mapping] is not supported'")
 -- !result
 drop catalog delta_test_${uuid0}
 -- result:

--- a/test/sql/test_deltalake/T/test_deltalake_catalog
+++ b/test/sql/test_deltalake/T/test_deltalake_catalog
@@ -9,7 +9,7 @@ select * from delta_test_${uuid0}.delta_oss_db.string_col_dict_encode where c3='
 select * from delta_test_${uuid0}.delta_oss_db.delta_lake_data_type where col_struct is null;
 
 -- test struct column is not null
-select col_struct from delta_test_${uuid0}.delta_oss_db.delta_lake_data_type where col_struct is not null;
+select col_struct from delta_test_${uuid0}.delta_oss_db.delta_lake_data_type where col_struct is not null order by col_tinyint;
 
 -- test partition prune with boolean type
 select * from delta_test_${uuid0}.delta_oss_db.delta_lake_par_col_boolean where col_boolean = true;
@@ -38,5 +38,8 @@ select col_tinyint,col_array,col_map,col_struct from delta_test_${uuid0}.delta_o
 -- test timestamp
 select col_timestamp from delta_test_${uuid0}.delta_oss_db.delta_lake_data_type where col_timestamp = '2024-04-24 12:00:00';
 select col_timestamp from delta_test_${uuid0}.delta_oss_db.delta_lake_data_type where col_timestamp >= '2024-04-24 12:00:00' and col_timestamp < '2024-04-27 12:00:00';
+
+-- test column mapping
+select * from delta_test_${uuid0}.delta_oss_db.delta_test_column_mapping;
 
 drop catalog delta_test_${uuid0}


### PR DESCRIPTION
## Why I'm doing:
delta lake suppport lots of table feature, refer to https://github.com/delta-io/delta/blob/master/PROTOCOL.md#valid-feature-names-in-table-features

## What I'm doing:
1. disable column mapping 
2. disable timestamp_ntz type
3. disable deletion vection only when has deletion vection file

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
