### PR TITLE
[Enhancement] Support combined txn log for more loads

### DIFF
--- a/be/src/service/service_be/lake_service.cpp
+++ b/be/src/service/service_be/lake_service.cpp
@@ -147,7 +147,7 @@ void LakeServiceImpl::publish_version(::google::protobuf::RpcController* control
         return;
     }
     if (request->txn_ids_size() == 0 && request->txn_infos_size() == 0) {
-        cntl->SetFailed("missing txn_ids and txn_infos");
+        cntl->SetFailed("neither txn_ids nor txn_infos is set, at least one of them needs to be set");
         return;
     }
     if (request->tablet_ids_size() == 0) {
@@ -345,7 +345,7 @@ void LakeServiceImpl::publish_log_version_batch(::google::protobuf::RpcControlle
         return;
     }
     if (request->txn_ids_size() == 0 && request->txn_infos_size() == 0) {
-        cntl->SetFailed("missing txn_ids and txn_infos");
+        cntl->SetFailed("neither txn_ids nor txn_infos is set, at least one of them needs to be set");
         return;
     }
     if (request->versions_size() == 0) {
@@ -472,7 +472,7 @@ void LakeServiceImpl::delete_txn_log(::google::protobuf::RpcController* controll
     }
 
     if (request->txn_ids_size() == 0 && request->txn_infos_size() == 0) {
-        cntl->SetFailed("missing txn_ids and txn_infos");
+        cntl->SetFailed("neither txn_ids nor txn_infos is set, at least one of them needs to be set");
         return;
     }
 

--- a/be/src/service/service_be/lake_service.cpp
+++ b/be/src/service/service_be/lake_service.cpp
@@ -147,7 +147,7 @@ void LakeServiceImpl::publish_version(::google::protobuf::RpcController* control
         return;
     }
     if (request->txn_ids_size() == 0 && request->txn_infos_size() == 0) {
-        cntl->SetFailed("neither txn_ids nor txn_infos is set, at least one of them needs to be set");
+        cntl->SetFailed("neither txn_ids nor txn_infos is set, one of them must be set");
         return;
     }
     if (request->tablet_ids_size() == 0) {
@@ -345,7 +345,7 @@ void LakeServiceImpl::publish_log_version_batch(::google::protobuf::RpcControlle
         return;
     }
     if (request->txn_ids_size() == 0 && request->txn_infos_size() == 0) {
-        cntl->SetFailed("neither txn_ids nor txn_infos is set, at least one of them needs to be set");
+        cntl->SetFailed("neither txn_ids nor txn_infos is set, one of them must be set");
         return;
     }
     if (request->versions_size() == 0) {
@@ -472,7 +472,7 @@ void LakeServiceImpl::delete_txn_log(::google::protobuf::RpcController* controll
     }
 
     if (request->txn_ids_size() == 0 && request->txn_infos_size() == 0) {
-        cntl->SetFailed("neither txn_ids nor txn_infos is set, at least one of them needs to be set");
+        cntl->SetFailed("neither txn_ids nor txn_infos is set, one of them must be set");
         return;
     }
 

--- a/be/src/service/service_be/lake_service.cpp
+++ b/be/src/service/service_be/lake_service.cpp
@@ -471,8 +471,8 @@ void LakeServiceImpl::delete_txn_log(::google::protobuf::RpcController* controll
         return;
     }
 
-    if (request->txn_ids_size() == 0) {
-        cntl->SetFailed("missing txn_ids");
+    if (request->txn_ids_size() == 0 && request->txn_infos_size() == 0) {
+        cntl->SetFailed("missing txn_ids and txn_infos");
         return;
     }
 

--- a/be/src/storage/lake/async_delta_writer.cpp
+++ b/be/src/storage/lake/async_delta_writer.cpp
@@ -300,6 +300,7 @@ void AsyncDeltaWriter::flush(Callback cb) {
 }
 
 void AsyncDeltaWriter::finish(DeltaWriterFinishMode mode, FinishCallback cb) {
+    TEST_SYNC_POINT_CALLBACK("AsyncDeltaWriter:enter_finish", this);
     _impl->finish(mode, std::move(cb));
 }
 

--- a/be/src/storage/lake/vacuum.cpp
+++ b/be/src/storage/lake/vacuum.cpp
@@ -649,6 +649,11 @@ void delete_txn_log(TabletManager* tablet_mgr, const DeleteTxnLogRequest& reques
 
             tablet_mgr->metacache()->erase(log_path);
         }
+        for (auto&& info : request.txn_infos()) {
+            auto log_path = info.combined_txn_log() ? tablet_mgr->combined_txn_log_location(tablet_id, info.txn_id())
+                                                    : tablet_mgr->txn_log_location(tablet_id, info.txn_id());
+            files_to_delete.emplace_back(log_path);
+        }
     }
 
     delete_files_async(files_to_delete);

--- a/be/src/storage/lake/vacuum.cpp
+++ b/be/src/storage/lake/vacuum.cpp
@@ -643,6 +643,8 @@ void delete_txn_log(TabletManager* tablet_mgr, const DeleteTxnLogRequest& reques
     files_to_delete.reserve(request.tablet_ids_size() * (request.txn_ids_size() + request.txn_infos_size()));
 
     for (auto tablet_id : request.tablet_ids()) {
+        // For each DeleteTxnLogRequest, FE will only set one of txn_ids and txn_infos, here we don't want
+        // to bother with determining which one is set, just iterate through both.
         for (auto txn_id : request.txn_ids()) {
             auto log_path = tablet_mgr->txn_log_location(tablet_id, txn_id);
             files_to_delete.emplace_back(log_path);

--- a/be/src/storage/lake/vacuum.cpp
+++ b/be/src/storage/lake/vacuum.cpp
@@ -640,13 +640,12 @@ void delete_txn_log(TabletManager* tablet_mgr, const DeleteTxnLogRequest& reques
     DCHECK(response != nullptr);
 
     std::vector<std::string> files_to_delete;
-    files_to_delete.reserve(request.tablet_ids_size() * request.txn_ids_size());
+    files_to_delete.reserve(request.tablet_ids_size() * (request.txn_ids_size() + request.txn_infos_size()));
 
     for (auto tablet_id : request.tablet_ids()) {
         for (auto txn_id : request.txn_ids()) {
             auto log_path = tablet_mgr->txn_log_location(tablet_id, txn_id);
             files_to_delete.emplace_back(log_path);
-
             tablet_mgr->metacache()->erase(log_path);
         }
         for (auto&& info : request.txn_infos()) {

--- a/be/test/runtime/lake_tablets_channel_test.cpp
+++ b/be/test/runtime/lake_tablets_channel_test.cpp
@@ -20,7 +20,6 @@
 #include "column/chunk.h"
 #include "column/fixed_length_column.h"
 #include "column/schema.h"
-#include "column/vectorized_fwd.h"
 #include "common/logging.h"
 #include "fs/fs_util.h"
 #include "gen_cpp/internal_service.pb.h"
@@ -29,13 +28,11 @@
 #include "runtime/mem_tracker.h"
 #include "serde/protobuf_serde.h"
 #include "storage/chunk_helper.h"
-#include "storage/chunk_iterator.h"
+#include "storage/lake/async_delta_writer.h"
 #include "storage/lake/fixed_location_provider.h"
 #include "storage/lake/join_path.h"
 #include "storage/lake/metacache.h"
-#include "storage/lake/tablet.h"
 #include "storage/lake/tablet_manager.h"
-#include "storage/lake/tablet_metadata.h"
 #include "storage/lake/txn_log.h"
 #include "storage/lake/update_manager.h"
 #include "storage/lake/vacuum.h"
@@ -44,6 +41,9 @@
 #include "storage/tablet_schema.h"
 #include "testutil/assert.h"
 #include "testutil/id_generator.h"
+#include "testutil/sync_point.h"
+#include "util/bthreads/util.h"
+#include "util/defer_op.h"
 #include "util/runtime_profile.h"
 #include "util/uid_util.h"
 
@@ -52,13 +52,13 @@ namespace starrocks {
 // 2 senders, 1 index, each index has 2 partitions, each partition has 2 tablets, each tablet has 2 columns
 // partition id: 10, 11
 // tablet id: 10086, 10087, 10088, 10089
-class LakeTabletsChannelTest : public testing::Test {
+class LakeTabletsChannelTestBase : public testing::Test {
 public:
-    LakeTabletsChannelTest() {
+    LakeTabletsChannelTestBase(const char* test_directory) : _test_directory(test_directory) {
         _schema_id = next_id();
         _mem_tracker = std::make_unique<MemTracker>(1024 * 1024);
         _root_profile = std::make_unique<RuntimeProfile>("LoadChannel");
-        _location_provider = std::make_unique<lake::FixedLocationProvider>(kTestGroupPath);
+        _location_provider = std::make_unique<lake::FixedLocationProvider>(_test_directory);
         _update_manager = std::make_unique<lake::UpdateManager>(_location_provider.get(), _mem_tracker.get());
         _tablet_manager =
                 std::make_unique<lake::TabletManager>(_location_provider.get(), _update_manager.get(), 1024 * 1024);
@@ -184,10 +184,10 @@ public:
 
 protected:
     void SetUp() override {
-        (void)fs::remove_all(kTestGroupPath);
-        CHECK_OK(fs::create_directories(lake::join_path(kTestGroupPath, lake::kSegmentDirectoryName)));
-        CHECK_OK(fs::create_directories(lake::join_path(kTestGroupPath, lake::kMetadataDirectoryName)));
-        CHECK_OK(fs::create_directories(lake::join_path(kTestGroupPath, lake::kTxnLogDirectoryName)));
+        (void)fs::remove_all(_test_directory);
+        CHECK_OK(fs::create_directories(lake::join_path(_test_directory, lake::kSegmentDirectoryName)));
+        CHECK_OK(fs::create_directories(lake::join_path(_test_directory, lake::kMetadataDirectoryName)));
+        CHECK_OK(fs::create_directories(lake::join_path(_test_directory, lake::kTxnLogDirectoryName)));
 
         CHECK_OK(_tablet_manager->put_tablet_metadata(*new_tablet_metadata(10086)));
         CHECK_OK(_tablet_manager->put_tablet_metadata(*new_tablet_metadata(10087)));
@@ -206,13 +206,13 @@ protected:
     void TearDown() override {
         _tablets_channel.reset();
         _load_channel.reset();
-        (void)fs::remove_all(kTestGroupPath);
+        (void)fs::remove_all(_test_directory);
         _tablet_manager->prune_metacache();
     }
 
     std::shared_ptr<Chunk> read_segment(int64_t tablet_id, const std::string& filename) {
         // Check segment file
-        ASSIGN_OR_ABORT(auto fs, FileSystem::CreateSharedFromString(kTestGroupPath));
+        ASSIGN_OR_ABORT(auto fs, FileSystem::CreateSharedFromString(_test_directory));
         auto path = _location_provider->segment_location(tablet_id, filename);
         std::cerr << path << '\n';
 
@@ -242,8 +242,8 @@ protected:
 
     static constexpr int kIndexId = 1;
     static constexpr int64_t kTxnId = 12345;
-    static constexpr const char* const kTestGroupPath = "test_lake_tablets_channel";
 
+    const char* const _test_directory;
     int64_t _schema_id;
     std::unique_ptr<MemTracker> _mem_tracker;
     std::unique_ptr<RuntimeProfile> _root_profile;
@@ -260,6 +260,11 @@ protected:
 
     std::shared_ptr<LoadChannel> _load_channel;
     std::shared_ptr<TabletsChannel> _tablets_channel;
+};
+
+class LakeTabletsChannelTest : public LakeTabletsChannelTestBase {
+public:
+    LakeTabletsChannelTest() : LakeTabletsChannelTestBase("test_lake_tablets_channel") {}
 };
 
 TEST_F(LakeTabletsChannelTest, test_simple_write) {
@@ -354,8 +359,8 @@ TEST_F(LakeTabletsChannelTest, test_simple_write) {
         ASSIGN_OR_ABORT(auto tablet, _tablet_manager->get_tablet(tablet_id));
         ASSIGN_OR_ABORT(auto txnlog, tablet.get_txn_log(kTxnId));
         ASSERT_EQ(1, txnlog->op_write().rowset().segments().size());
-        auto chunk = read_segment(tablet_id, txnlog->op_write().rowset().segments(0));
-        ASSERT_EQ(kChunkSizePerTablet, chunk->num_rows());
+        auto tmp_chunk = read_segment(tablet_id, txnlog->op_write().rowset().segments(0));
+        ASSERT_EQ(kChunkSizePerTablet, tmp_chunk->num_rows());
     }
 
     // Duplicated eos request should return error
@@ -417,8 +422,8 @@ TEST_F(LakeTabletsChannelTest, test_write_partial_partition) {
         ASSIGN_OR_ABORT(auto tablet, _tablet_manager->get_tablet(tablet_id));
         ASSIGN_OR_ABORT(auto txnlog, tablet.get_txn_log(kTxnId));
         ASSERT_EQ(1, txnlog->op_write().rowset().segments().size());
-        auto chunk = read_segment(tablet_id, txnlog->op_write().rowset().segments(0));
-        ASSERT_EQ(kChunkSizePerTablet, chunk->num_rows());
+        auto tmp_chunk = read_segment(tablet_id, txnlog->op_write().rowset().segments(0));
+        ASSERT_EQ(kChunkSizePerTablet, tmp_chunk->num_rows());
     }
 }
 
@@ -481,8 +486,8 @@ TEST_F(LakeTabletsChannelTest, test_write_concurrently) {
         ASSIGN_OR_ABORT(auto tablet, _tablet_manager->get_tablet(tablet_id));
         ASSIGN_OR_ABORT(auto txnlog, tablet.get_txn_log(kTxnId));
         ASSERT_EQ(1, txnlog->op_write().rowset().segments().size());
-        auto chunk = read_segment(tablet_id, txnlog->op_write().rowset().segments(0));
-        ASSERT_EQ(kSegmentRows, chunk->num_rows());
+        auto tmp_chunk = read_segment(tablet_id, txnlog->op_write().rowset().segments(0));
+        ASSERT_EQ(kSegmentRows, tmp_chunk->num_rows());
     }
 }
 
@@ -651,8 +656,8 @@ TEST_F(LakeTabletsChannelTest, test_empty_tablet) {
         ASSIGN_OR_ABORT(auto txnlog, tablet.get_txn_log(kTxnId));
         if (tablet_id == 10086) {
             ASSERT_EQ(1, txnlog->op_write().rowset().segments().size());
-            auto chunk = read_segment(tablet_id, txnlog->op_write().rowset().segments(0));
-            ASSERT_EQ(kChunkSize, chunk->num_rows());
+            auto tmp_chunk = read_segment(tablet_id, txnlog->op_write().rowset().segments(0));
+            ASSERT_EQ(kChunkSize, tmp_chunk->num_rows());
         } else {
             ASSERT_EQ(0, txnlog->op_write().rowset().segments().size());
         }
@@ -797,69 +802,110 @@ TEST_F(LakeTabletsChannelTest, test_profile) {
     ASSERT_EQ(chunk.num_rows(), profile->get_counter("AddRowNum")->value());
 }
 
-TEST_F(LakeTabletsChannelTest, test_dont_write_txn_log) {
+struct Param {
+    int num_sender;
+    int fail_tablet;
+};
+
+class LakeTabletsChannelMultiSenderTest : public LakeTabletsChannelTestBase,
+                                          public ::testing::WithParamInterface<Param> {
+public:
+    LakeTabletsChannelMultiSenderTest() : LakeTabletsChannelTestBase("lake_tablets_channel_multi_sender_test") {}
+};
+
+TEST_P(LakeTabletsChannelMultiSenderTest, test_dont_write_txn_log) {
+    auto num_sender = GetParam().num_sender;
     auto open_request = _open_request;
-    open_request.set_num_senders(1);
+    auto fail_tablet = GetParam().fail_tablet;
+    open_request.set_num_senders(num_sender);
     open_request.mutable_lake_tablet_params()->set_write_txn_log(false);
 
     ASSERT_OK(_tablets_channel->open(open_request, &_open_response, _schema_param, false));
 
-    constexpr int kChunkSize = 24;
+    constexpr int kChunkSize = 1024;
     constexpr int kChunkSizePerTablet = kChunkSize / 4;
     auto chunk = generate_data(kChunkSize);
 
-    PTabletWriterAddChunkRequest add_chunk_request;
-    PTabletWriterAddBatchResult add_chunk_response;
-    add_chunk_request.set_index_id(kIndexId);
-    add_chunk_request.set_sender_id(0);
-    add_chunk_request.set_eos(false);
-    add_chunk_request.set_packet_seq(0);
+    SyncPoint::GetInstance()->SetCallBack("AsyncDeltaWriter:enter_finish", [&](void* arg) {
+        auto w = static_cast<lake::AsyncDeltaWriter*>(arg);
+        LOG(INFO) << "tablet_id=" << w->tablet_id() << " fail_tablet=" << fail_tablet;
+        if (w->tablet_id() == fail_tablet) {
+            w->close();
+        }
+    });
+    SyncPoint::GetInstance()->EnableProcessing();
+    DeferOp defer([&]() {
+        SyncPoint::GetInstance()->ClearCallBack("AsyncDeltaWriter:enter_finish");
+        SyncPoint::GetInstance()->DisableProcessing();
+    });
 
-    for (int i = 0; i < kChunkSize; i++) {
-        int64_t tablet_id = 10086 + (i / kChunkSizePerTablet);
-        add_chunk_request.add_tablet_ids(tablet_id);
-        add_chunk_request.add_partition_ids(tablet_id < 10088 ? 10 : 11);
+    auto sender_task = [&](int sender_id) {
+        PTabletWriterAddChunkRequest add_chunk_request;
+        PTabletWriterAddBatchResult add_chunk_response;
+        add_chunk_request.set_index_id(kIndexId);
+        add_chunk_request.set_sender_id(sender_id);
+        add_chunk_request.set_eos(false);
+        add_chunk_request.set_packet_seq(0);
+
+        for (int i = 0; i < kChunkSize; i++) {
+            int64_t tablet_id = 10086 + (i / kChunkSizePerTablet);
+            add_chunk_request.add_tablet_ids(tablet_id);
+            add_chunk_request.add_partition_ids(tablet_id < 10088 ? 10 : 11);
+        }
+
+        ASSIGN_OR_ABORT(auto chunk_pb, serde::ProtobufChunkSerde::serialize(chunk));
+        add_chunk_request.mutable_chunk()->Swap(&chunk_pb);
+
+        _tablets_channel->add_chunk(&chunk, add_chunk_request, &add_chunk_response);
+        ASSERT_TRUE(add_chunk_response.status().status_code() == TStatusCode::OK);
+        ASSERT_FALSE(add_chunk_response.has_lake_tablet_data());
+
+        PTabletWriterAddChunkRequest finish_request;
+        PTabletWriterAddBatchResult finish_response;
+        finish_request.set_index_id(kIndexId);
+        finish_request.set_sender_id(sender_id);
+        finish_request.set_eos(true);
+        finish_request.set_packet_seq(1);
+        finish_request.add_partition_ids(10);
+        finish_request.add_partition_ids(11);
+
+        _tablets_channel->add_chunk(nullptr, finish_request, &finish_response);
+
+        LOG(INFO) << "sender_id=" << sender_id << " #finished_tablets=" << finish_response.tablet_vec_size();
+
+        if (sender_id == 0 && fail_tablet == 0) {
+            ASSERT_EQ(TStatusCode::OK, finish_response.status().status_code());
+            ASSERT_TRUE(finish_response.has_lake_tablet_data());
+            ASSERT_EQ(4, finish_response.lake_tablet_data().txn_logs_size());
+            auto metacache = _tablet_manager->metacache();
+            for (auto tablet_id : {10086, 10087, 10088, 10089}) {
+                auto txn_log_path = _tablet_manager->txn_log_location(tablet_id, kTxnId);
+                ASSERT_TRUE(metacache->lookup_txn_log(txn_log_path));
+                ASSERT_TRUE(FileSystem::Default()->path_exists(txn_log_path).is_not_found());
+            }
+        } else if (sender_id == 0) {
+            ASSERT_NE(TStatusCode::OK, finish_response.status().status_code());
+            ASSERT_EQ(0, finish_response.lake_tablet_data().txn_logs_size());
+        } else {
+            ASSERT_EQ(0, finish_response.lake_tablet_data().txn_logs_size());
+        }
+    };
+
+    auto bids = std::vector<bthread_t>{};
+    for (int i = 0; i < num_sender; i++) {
+        ASSIGN_OR_ABORT(auto bid, bthreads::start_bthread([&, id = i]() { sender_task(id); }));
+        bids.push_back(bid);
     }
-
-    ASSIGN_OR_ABORT(auto chunk_pb, serde::ProtobufChunkSerde::serialize(chunk));
-    add_chunk_request.mutable_chunk()->Swap(&chunk_pb);
-
-    _tablets_channel->add_chunk(&chunk, add_chunk_request, &add_chunk_response);
-    ASSERT_TRUE(add_chunk_response.status().status_code() == TStatusCode::OK);
-    ASSERT_FALSE(add_chunk_response.has_lake_tablet_data());
-
-    PTabletWriterAddChunkRequest finish_request;
-    PTabletWriterAddBatchResult finish_response;
-    finish_request.set_index_id(kIndexId);
-    finish_request.set_sender_id(0);
-    finish_request.set_eos(true);
-    finish_request.set_packet_seq(1);
-    finish_request.add_partition_ids(10);
-    finish_request.add_partition_ids(11);
-
-    _tablets_channel->add_chunk(nullptr, finish_request, &finish_response);
-    ASSERT_EQ(TStatusCode::OK, finish_response.status().status_code());
-    ASSERT_EQ(4, finish_response.tablet_vec_size());
-
-    std::vector<int64_t> finished_tablets;
-    for (auto& info : finish_response.tablet_vec()) {
-        finished_tablets.emplace_back(info.tablet_id());
-    }
-    std::sort(finished_tablets.begin(), finished_tablets.end());
-    ASSERT_EQ(10086, finished_tablets[0]);
-    ASSERT_EQ(10087, finished_tablets[1]);
-    ASSERT_EQ(10088, finished_tablets[2]);
-    ASSERT_EQ(10089, finished_tablets[3]);
-
-    ASSERT_TRUE(finish_response.has_lake_tablet_data());
-    ASSERT_EQ(4, finish_response.lake_tablet_data().txn_logs_size());
-
-    auto metacache = _tablet_manager->metacache();
-    for (auto tablet_id : finished_tablets) {
-        auto txn_log_path = _tablet_manager->txn_log_location(tablet_id, kTxnId);
-        ASSERT_TRUE(metacache->lookup_txn_log(txn_log_path));
-        ASSERT_TRUE(FileSystem::Default()->path_exists(txn_log_path).is_not_found());
+    for (auto bid : bids) {
+        (void)bthread_join(bid, nullptr);
     }
 }
-
+// clang-format off
+INSTANTIATE_TEST_SUITE_P(LakeTabletsChannelMultiSenderTest, LakeTabletsChannelMultiSenderTest,
+                         ::testing::Values(Param{1, 0},
+                                           Param{2, 0},
+                                           Param{8, 0},
+                                           Param{1, 10086},
+                                           Param{4, 10087}));
+// clang-format on
 } // namespace starrocks

--- a/be/test/service/lake_service_test.cpp
+++ b/be/test/service/lake_service_test.cpp
@@ -129,7 +129,7 @@ TEST_F(LakeServiceTest, test_publish_version_missing_txn_ids) {
     request.add_tablet_ids(_tablet_id);
     _lake_service.publish_version(&cntl, &request, &response, nullptr);
     ASSERT_TRUE(cntl.Failed());
-    ASSERT_EQ("missing txn_ids and txn_infos", cntl.ErrorText());
+    ASSERT_EQ("neither txn_ids nor txn_infos is set, at least one of them needs to be set", cntl.ErrorText());
 }
 
 TEST_F(LakeServiceTest, test_publish_version_missing_base_version) {
@@ -800,7 +800,7 @@ TEST_F(LakeServiceTest, test_delete_txn_log) {
         request.add_tablet_ids(_tablet_id);
         _lake_service.delete_txn_log(&cntl, &request, &response, nullptr);
         ASSERT_TRUE(cntl.Failed());
-        ASSERT_EQ("missing txn_ids and txn_infos", cntl.ErrorText());
+        ASSERT_EQ("neither txn_ids nor txn_infos is set, at least one of them needs to be set", cntl.ErrorText());
     }
 
     // test normal
@@ -1164,7 +1164,7 @@ TEST_F(LakeServiceTest, test_publish_log_version_batch) {
         brpc::Controller cntl;
         _lake_service.publish_log_version_batch(&cntl, &request, &response, nullptr);
         ASSERT_TRUE(cntl.Failed());
-        ASSERT_EQ("missing txn_ids and txn_infos", cntl.ErrorText());
+        ASSERT_EQ("neither txn_ids nor txn_infos is set, at least one of them needs to be set", cntl.ErrorText());
     }
     {
         PublishLogVersionBatchRequest request;

--- a/be/test/service/lake_service_test.cpp
+++ b/be/test/service/lake_service_test.cpp
@@ -817,10 +817,10 @@ TEST_F(LakeServiceTest, test_delete_txn_log) {
         request.add_tablet_ids(_tablet_id);
         request.add_txn_ids(logs.back().txn_id());
         _lake_service.delete_txn_log(&cntl, &request, &response, nullptr);
-
+        ASSERT_FALSE(cntl.Failed()) << cntl.ErrorText();
         ExecEnv::GetInstance()->delete_file_thread_pool()->wait();
-        ASSIGN_OR_ABORT(auto tablet, _tablet_mgr->get_tablet(_tablet_id));
-        ASSERT_TRUE(tablet.get_txn_log(logs[0].txn_id()).status().is_not_found());
+        auto path = _tablet_mgr->txn_log_location(_tablet_id, logs.back().txn_id());
+        ASSERT_EQ(TStatusCode::NOT_FOUND, FileSystem::Default()->path_exists(path).code());
     }
     // test delete txn log with new API
     {
@@ -839,8 +839,8 @@ TEST_F(LakeServiceTest, test_delete_txn_log) {
         _lake_service.delete_txn_log(&cntl, &request, &response, nullptr);
         ASSERT_FALSE(cntl.Failed()) << cntl.ErrorText();
         ExecEnv::GetInstance()->delete_file_thread_pool()->wait();
-        ASSIGN_OR_ABORT(auto tablet, _tablet_mgr->get_tablet(_tablet_id));
-        ASSERT_TRUE(tablet.get_txn_log(logs[0].txn_id()).status().is_not_found());
+        auto path = _tablet_mgr->txn_log_location(_tablet_id, logs.back().txn_id());
+        ASSERT_EQ(TStatusCode::NOT_FOUND, FileSystem::Default()->path_exists(path).code());
     }
     // test delete combined txn log
     {

--- a/be/test/service/lake_service_test.cpp
+++ b/be/test/service/lake_service_test.cpp
@@ -129,7 +129,7 @@ TEST_F(LakeServiceTest, test_publish_version_missing_txn_ids) {
     request.add_tablet_ids(_tablet_id);
     _lake_service.publish_version(&cntl, &request, &response, nullptr);
     ASSERT_TRUE(cntl.Failed());
-    ASSERT_EQ("neither txn_ids nor txn_infos is set, at least one of them needs to be set", cntl.ErrorText());
+    ASSERT_EQ("neither txn_ids nor txn_infos is set, one of them must be set", cntl.ErrorText());
 }
 
 TEST_F(LakeServiceTest, test_publish_version_missing_base_version) {
@@ -800,7 +800,7 @@ TEST_F(LakeServiceTest, test_delete_txn_log) {
         request.add_tablet_ids(_tablet_id);
         _lake_service.delete_txn_log(&cntl, &request, &response, nullptr);
         ASSERT_TRUE(cntl.Failed());
-        ASSERT_EQ("neither txn_ids nor txn_infos is set, at least one of them needs to be set", cntl.ErrorText());
+        ASSERT_EQ("neither txn_ids nor txn_infos is set, one of them must be set", cntl.ErrorText());
     }
 
     // test normal
@@ -1164,7 +1164,7 @@ TEST_F(LakeServiceTest, test_publish_log_version_batch) {
         brpc::Controller cntl;
         _lake_service.publish_log_version_batch(&cntl, &request, &response, nullptr);
         ASSERT_TRUE(cntl.Failed());
-        ASSERT_EQ("neither txn_ids nor txn_infos is set, at least one of them needs to be set", cntl.ErrorText());
+        ASSERT_EQ("neither txn_ids nor txn_infos is set, one of them must be set", cntl.ErrorText());
     }
     {
         PublishLogVersionBatchRequest request;

--- a/fe/fe-core/src/main/java/com/starrocks/lake/LakeTableHelper.java
+++ b/fe/fe-core/src/main/java/com/starrocks/lake/LakeTableHelper.java
@@ -197,11 +197,13 @@ public class LakeTableHelper {
     }
 
     public static boolean supportCombinedTxnLog(TransactionState.LoadJobSourceType sourceType) {
-        return RunMode.isSharedDataMode() && Config.lake_use_combined_txn_log && hasSingleOlapTableSink(sourceType);
+        return RunMode.isSharedDataMode() && Config.lake_use_combined_txn_log && isLoadingTransaction(sourceType);
     }
 
-    private static boolean hasSingleOlapTableSink(TransactionState.LoadJobSourceType sourceType) {
+    private static boolean isLoadingTransaction(TransactionState.LoadJobSourceType sourceType) {
         return sourceType == TransactionState.LoadJobSourceType.BACKEND_STREAMING ||
-                sourceType == TransactionState.LoadJobSourceType.ROUTINE_LOAD_TASK;
+                sourceType == TransactionState.LoadJobSourceType.ROUTINE_LOAD_TASK ||
+                sourceType == TransactionState.LoadJobSourceType.INSERT_STREAMING ||
+                sourceType == TransactionState.LoadJobSourceType.BATCH_LOAD_JOB;
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/transaction/LakeTableTxnStateListener.java
+++ b/fe/fe-core/src/main/java/com/starrocks/transaction/LakeTableTxnStateListener.java
@@ -213,7 +213,7 @@ public class LakeTableTxnStateListener implements TransactionStateListener {
         if (!finishedTablets.isEmpty()) {
             txnState.setTabletCommitInfos(finishedTablets);
         }
-        if (CollectionUtils.isEmpty(txnState.getTabletCommitInfos())) {
+        if (CollectionUtils.isEmpty(txnState.getTabletCommitInfos()) || txnState.isUseCombinedTxnLog()) {
             abortTxnSkipCleanup(txnState);
         } else {
             abortTxnWithCleanup(txnState);

--- a/fe/fe-core/src/main/java/com/starrocks/transaction/LakeTableTxnStateListener.java
+++ b/fe/fe-core/src/main/java/com/starrocks/transaction/LakeTableTxnStateListener.java
@@ -213,7 +213,7 @@ public class LakeTableTxnStateListener implements TransactionStateListener {
         if (!finishedTablets.isEmpty()) {
             txnState.setTabletCommitInfos(finishedTablets);
         }
-        if (CollectionUtils.isEmpty(txnState.getTabletCommitInfos()) || txnState.isUseCombinedTxnLog()) {
+        if (CollectionUtils.isEmpty(txnState.getTabletCommitInfos())) {
             abortTxnSkipCleanup(txnState);
         } else {
             abortTxnWithCleanup(txnState);

--- a/fe/fe-core/src/test/java/com/starrocks/lake/LakeTableHelperTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/lake/LakeTableHelperTest.java
@@ -64,8 +64,8 @@ public class LakeTableHelperTest {
         Config.lake_use_combined_txn_log = true;
         Assert.assertTrue(LakeTableHelper.supportCombinedTxnLog(TransactionState.LoadJobSourceType.BACKEND_STREAMING));
         Assert.assertTrue(LakeTableHelper.supportCombinedTxnLog(TransactionState.LoadJobSourceType.ROUTINE_LOAD_TASK));
-        Assert.assertFalse(LakeTableHelper.supportCombinedTxnLog(TransactionState.LoadJobSourceType.INSERT_STREAMING));
-        Assert.assertFalse(LakeTableHelper.supportCombinedTxnLog(TransactionState.LoadJobSourceType.BATCH_LOAD_JOB));
+        Assert.assertTrue(LakeTableHelper.supportCombinedTxnLog(TransactionState.LoadJobSourceType.INSERT_STREAMING));
+        Assert.assertTrue(LakeTableHelper.supportCombinedTxnLog(TransactionState.LoadJobSourceType.BATCH_LOAD_JOB));
         Assert.assertFalse(LakeTableHelper.supportCombinedTxnLog(TransactionState.LoadJobSourceType.LAKE_COMPACTION));
         Assert.assertFalse(LakeTableHelper.supportCombinedTxnLog(TransactionState.LoadJobSourceType.FRONTEND_STREAMING));
         Assert.assertFalse(LakeTableHelper.supportCombinedTxnLog(TransactionState.LoadJobSourceType.BYPASS_WRITE));


### PR DESCRIPTION
## Why I'm doing:
In order to be able to reduce reads and writes to the object store, we added COMBINED TXN LOG in #42542, i.e., only one txn log file is written per partition instead of one per Tablet. However, in #42542, only stream load and routine load support combined txn log, the common insert into and broker load can not use combined txn log.

## What I'm doing:
- Support combined txn log for insert and broker load.
- Avoid sending invalid txn log deletion requests when combined txn log and batch publish are turned on at the same time

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
