### PR TITLE
[BugFix] put metadata prepare rule before skewJoinOptimize rule

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/common/profile/Tracers.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/profile/Tracers.java
@@ -150,6 +150,10 @@ public class Tracers {
         return tracers.tracer(module, Mode.TIMER).watchScope(name);
     }
 
+    public static Timer watchScope(Tracers tracers, Module module, String name) {
+        return tracers.tracer(module, Mode.TIMER).watchScope(name);
+    }
+
     public static void log(Module module, String log) {
         Tracers tracers = THREAD_LOCAL.get();
         tracers.tracer(module, Mode.LOGS).log(log);

--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergMetadata.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergMetadata.java
@@ -454,6 +454,13 @@ public class IcebergMetadata implements ConnectorMetadata {
             return true;
         }
 
+        // metadata collect has been triggered by other rules or process if contains
+        if (!scannedTables.contains(key)) {
+            try (Timer ignored = Tracers.watchScope(tracers, EXTERNAL, "ICEBERG.prepareTablesNum")) {
+                // Only record the number of tables that need to be prepared in parallel
+            }
+        }
+
         triggerIcebergPlanFilesIfNeeded(key, icebergTable, item.getPredicate(), item.getLimit(), tracers);
         return true;
     }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/LimitTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/LimitTest.java
@@ -891,12 +891,12 @@ public class LimitTest extends PlanTestBase {
                 "union all \n" +
                 "select distinct 2 from with_t_0, (select v10, v11 from t3) subt right SEMI join t0 on subt.v11 = v3;";
         String plan = getFragmentPlan(sql);
-        assertContains(plan, "7:UNION\n" +
+        assertContains(plan, "0:UNION\n" +
                 "  |  \n" +
-                "  |----33:EXCHANGE\n" +
+                "  |----36:EXCHANGE\n" +
                 "  |       limit: 1\n" +
                 "  |    \n" +
-                "  20:EXCHANGE\n" +
+                "  18:EXCHANGE\n" +
                 "     limit: 1");
     }
 

--- a/fe/fe-core/src/test/resources/sql/external/hive/tpch/q10.sql
+++ b/fe/fe-core/src/test/resources/sql/external/hive/tpch/q10.sql
@@ -10,13 +10,13 @@ limit: 20
 cardinality: 20
 column statistics:
 * c_custkey-->[1.0, 1.5E7, 0.0, 8.0, 5738045.738045738] ESTIMATE
-* c_name-->[-Infinity, Infinity, 0.0, 25.0, 7651210.947193347] ESTIMATE
-* c_address-->[-Infinity, Infinity, 0.0, 40.0, 7651210.947193347] ESTIMATE
-* c_phone-->[-Infinity, Infinity, 0.0, 15.0, 7651210.947193347] ESTIMATE
+* c_name-->[-Infinity, Infinity, 0.0, 25.0, 5738045.738045739] ESTIMATE
+* c_address-->[-Infinity, Infinity, 0.0, 40.0, 5738045.738045739] ESTIMATE
+* c_phone-->[-Infinity, Infinity, 0.0, 15.0, 5738045.738045739] ESTIMATE
 * c_acctbal-->[-999.99, 9999.99, 0.0, 8.0, 1086564.0] ESTIMATE
-* c_comment-->[-Infinity, Infinity, 0.0, 117.0, 7651210.947193347] ESTIMATE
+* c_comment-->[-Infinity, Infinity, 0.0, 117.0, 5738045.738045739] ESTIMATE
 * n_name-->[-Infinity, Infinity, 0.0, 25.0, 25.0] ESTIMATE
-* sum-->[810.9, 214903.376217033, 0.0, 16.0, 3736520.0] ESTIMATE
+* sum-->[810.9, 214903.37621703307, 0.0, 16.0, 3736520.0] ESTIMATE
 
 PLAN FRAGMENT 1(F09)
 

--- a/fe/fe-core/src/test/resources/sql/external/hive/tpch/q21.sql
+++ b/fe/fe-core/src/test/resources/sql/external/hive/tpch/q21.sql
@@ -9,8 +9,8 @@ distribution type: GATHER
 limit: 100
 cardinality: 100
 column statistics:
-* s_name-->[-Infinity, Infinity, 0.0, 25.0, 40000.0] ESTIMATE
-* count-->[0.0, 1600097.8717994562, 0.0, 8.0, 40000.0] ESTIMATE
+* s_name-->[-Infinity, Infinity, 0.0, 25.0, 1000000.0] ESTIMATE
+* count-->[0.0, 1600097.8717994564, 0.0, 8.0, 1000000.0] ESTIMATE
 
 PLAN FRAGMENT 1(F15)
 

--- a/fe/fe-core/src/test/resources/sql/tpch-histogram-cost/q21.sql
+++ b/fe/fe-core/src/test/resources/sql/tpch-histogram-cost/q21.sql
@@ -9,8 +9,8 @@ distribution type: GATHER
 limit: 100
 cardinality: 100
 column statistics:
-* S_NAME-->[-Infinity, Infinity, 0.0, 25.0, 40000.0] ESTIMATE
-* count-->[0.0, 2334116.9317591335, 0.0, 8.0, 40000.0] ESTIMATE
+* S_NAME-->[-Infinity, Infinity, 0.0, 25.0, 1000000.0] ESTIMATE
+* count-->[0.0, 2334116.931759134, 0.0, 8.0, 1000000.0] ESTIMATE
 
 PLAN FRAGMENT 1(F10)
 

--- a/test/lib/sr_sql_lib.py
+++ b/test/lib/sr_sql_lib.py
@@ -1752,3 +1752,12 @@ class StarrocksSQLApiLib(object):
         finally:
             cursor.close()
             conn.close()
+
+    def assert_trace_times_contains(self, query, *expects):
+        """
+        assert trace times result contains expect string
+        """
+        sql = "trace times %s" % (query)
+        res = self.execute_sql(sql, True)
+        for expect in expects:
+            tools.assert_true(str(res["result"]).find(expect) > 0, "assert expect %s is not found in plan" % (expect))

--- a/test/sql/test_iceberg/R/test_parallel_prepare_iceberg_metadata
+++ b/test/sql/test_iceberg/R/test_parallel_prepare_iceberg_metadata
@@ -1,0 +1,54 @@
+-- name: test_parallel_prepare_iceberg_metadata
+create external catalog ice_cat_${uuid0}
+properties
+(
+    "type" = "iceberg",
+    "iceberg.catalog.type" = "hive",
+    "hive.metastore.uris" = "${iceberg_catalog_hive_metastore_uris}"
+);
+-- result:
+[]
+-- !result
+create database ice_cat_${uuid0}.ice_db_${uuid0};
+-- result:
+[]
+-- !result
+create table ice_cat_${uuid0}.ice_db_${uuid0}.ice_tbl_${uuid0} (
+  int_col int,
+  par_col int
+) partition by (par_col);
+-- result:
+[]
+-- !result
+insert into ice_cat_${uuid0}.ice_db_${uuid0}.ice_tbl_${uuid0} select 1,1;
+-- result:
+[]
+-- !result
+insert into ice_cat_${uuid0}.ice_db_${uuid0}.ice_tbl_${uuid0} select 1,2;
+-- result:
+[]
+-- !result
+set enable_parallel_prepare_metadata=true;
+-- result:
+[]
+-- !result
+set enable_profile=true;
+-- result:
+[]
+-- !result
+function: assert_trace_times_contains("select * from ice_cat_${uuid0}.ice_db_${uuid0}.ice_tbl_${uuid0} a join ice_cat_${uuid0}.ice_db_${uuid0}.ice_tbl_${uuid0} b on a.int_col=b.int_col where a.par_col=1 and b.par_col=2","prepareTablesNum[2]")
+-- result:
+None
+-- !result
+drop table ice_cat_${uuid0}.ice_db_${uuid0}.ice_tbl_${uuid0} force;
+-- result:
+[]
+-- !result
+drop database ice_cat_${uuid0}.ice_db_${uuid0};
+-- result:
+[]
+-- !result
+drop catalog ice_cat_${uuid0};
+-- result:
+[]
+-- !result

--- a/test/sql/test_iceberg/T/test_parallel_prepare_iceberg_metadata
+++ b/test/sql/test_iceberg/T/test_parallel_prepare_iceberg_metadata
@@ -1,0 +1,27 @@
+-- name: test_parallel_prepare_iceberg_metadata
+create external catalog ice_cat_${uuid0}
+properties
+(
+    "type" = "iceberg",
+    "iceberg.catalog.type" = "hive",
+    "hive.metastore.uris" = "${iceberg_catalog_hive_metastore_uris}"
+);
+
+create database ice_cat_${uuid0}.ice_db_${uuid0};
+
+create table ice_cat_${uuid0}.ice_db_${uuid0}.ice_tbl_${uuid0} (
+  int_col int,
+  par_col int
+) partition by (par_col);
+
+insert into ice_cat_${uuid0}.ice_db_${uuid0}.ice_tbl_${uuid0} select 1,1;
+insert into ice_cat_${uuid0}.ice_db_${uuid0}.ice_tbl_${uuid0} select 1,2;
+
+set enable_parallel_prepare_metadata=true;
+set enable_profile=true;
+
+function: assert_trace_times_contains("select * from ice_cat_${uuid0}.ice_db_${uuid0}.ice_tbl_${uuid0} a join ice_cat_${uuid0}.ice_db_${uuid0}.ice_tbl_${uuid0} b on a.int_col=b.int_col where a.par_col=1 and b.par_col=2","prepareTablesNum[2]")
+
+drop table ice_cat_${uuid0}.ice_db_${uuid0}.ice_tbl_${uuid0} force;
+drop database ice_cat_${uuid0}.ice_db_${uuid0};
+drop catalog ice_cat_${uuid0};


### PR DESCRIPTION
## Why I'm doing:

The skewJoinOptimize rule will collect external table statistics. then it will trigger iceberg metadata collect job.  We will cache it in the query level cache, so the parallel prepare rule will not take affect if enabled. 

## What I'm doing:
put metadata prepare rule before skewJoinOptimize rule.

Fixes #issue
https://github.com/StarRocks/starrocks/issues/43460
## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
