### PR TITLE
[BugFix] [Refactor] Optimize PartitionBasedMvRefreshProcessor db locks(Part1)

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/common/Config.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/Config.java
@@ -2759,6 +2759,12 @@ public class Config extends ConfigBase {
     @ConfField(mutable = true)
     public static boolean enable_mv_automatic_active_check = true;
 
+    @ConfField(mutable = true, comment = "The max retry times for base table change when refreshing materialized view")
+    public static int max_mv_check_base_table_change_retry_times = 10;
+
+    @ConfField(mutable = true, comment = "The max retry times for materialized view refresh retry times when failed")
+    public static int max_mv_refresh_failure_retry_times = 1;
+
     /**
      * The refresh partition number when refreshing materialized view at once by default.
      */

--- a/fe/fe-core/src/main/java/com/starrocks/metric/MaterializedViewMetricsEntity.java
+++ b/fe/fe-core/src/main/java/com/starrocks/metric/MaterializedViewMetricsEntity.java
@@ -87,10 +87,16 @@ public final class MaterializedViewMetricsEntity implements IMaterializedViewMet
     // record the materialized view's refresh job duration only if it's refreshed successfully.
     public Histogram histRefreshJobDuration;
 
+    public final String dbName;
+    public final String mvName;
     public MaterializedViewMetricsEntity(MetricRegistry metricRegistry, MvId mvId) {
         this.metricRegistry = metricRegistry;
         this.mvId = mvId;
-
+        GlobalStateMgr globalStateMgr = GlobalStateMgr.getCurrentState();
+        Database db = globalStateMgr.getDb(mvId.getDbId());
+        dbName = db != null ? db.getFullName() : "";
+        Table table = db != null ? db.getTable(mvId.getId()) : null;
+        mvName = table != null ? table.getName() : "";
         initMaterializedViewMetrics();
     }
 
@@ -201,10 +207,10 @@ public final class MaterializedViewMetricsEntity implements IMaterializedViewMet
                     return 0L;
                 }
 
+                MaterializedView mv = (MaterializedView) table;
                 Locker locker = new Locker();
                 locker.lockDatabase(db, LockType.READ);
                 try {
-                    MaterializedView mv = (MaterializedView) table;
                     return mv.getRowCount();
                 } catch (Exception e) {
                     return 0L;
@@ -228,10 +234,10 @@ public final class MaterializedViewMetricsEntity implements IMaterializedViewMet
                     return 0L;
                 }
 
+                MaterializedView mv = (MaterializedView) table;
                 Locker locker = new Locker();
                 locker.lockDatabase(db, LockType.READ);
                 try {
-                    MaterializedView mv = (MaterializedView) table;
                     return mv.getDataSize();
                 } catch (Exception e) {
                     return 0L;
@@ -254,15 +260,11 @@ public final class MaterializedViewMetricsEntity implements IMaterializedViewMet
                 if (!table.isMaterializedView()) {
                     return 0;
                 }
-                Locker locker = new Locker();
-                locker.lockDatabase(db, LockType.READ);
                 try {
                     MaterializedView mv = (MaterializedView) table;
                     return mv.isActive() ? 0 : 1;
                 } catch (Exception e) {
                     return 0;
-                } finally {
-                    locker.unLockDatabase(db, LockType.READ);
                 }
             }
         };
@@ -281,13 +283,13 @@ public final class MaterializedViewMetricsEntity implements IMaterializedViewMet
                     return 0;
                 }
                 MaterializedView mv = (MaterializedView) table;
+                if (!mv.isPartitionedTable()) {
+                    return 0;
+                }
 
                 Locker locker = new Locker();
                 locker.lockDatabase(db, LockType.READ);
                 try {
-                    if (!mv.getPartitionInfo().isPartitioned()) {
-                        return 0;
-                    }
                     return mv.getPartitions().size();
                 } catch (Exception e) {
                     return 0;

--- a/fe/fe-core/src/main/java/com/starrocks/metric/MaterializedViewMetricsRegistry.java
+++ b/fe/fe-core/src/main/java/com/starrocks/metric/MaterializedViewMetricsRegistry.java
@@ -17,14 +17,10 @@ package com.starrocks.metric;
 import com.codahale.metrics.Histogram;
 import com.codahale.metrics.MetricRegistry;
 import com.google.common.collect.Maps;
-import com.starrocks.catalog.Database;
-import com.starrocks.catalog.MaterializedView;
 import com.starrocks.catalog.MvId;
 import com.starrocks.common.Config;
 import com.starrocks.common.ThreadPoolManager;
-import com.starrocks.server.GlobalStateMgr;
 
-import java.util.List;
 import java.util.Map;
 import java.util.TimerTask;
 import java.util.concurrent.ScheduledThreadPoolExecutor;
@@ -67,44 +63,42 @@ public class MaterializedViewMetricsRegistry {
 
     // collect materialized-view-level metrics
     public static void collectMaterializedViewMetrics(MetricVisitor visitor, boolean minifyMetrics) {
-        GlobalStateMgr globalStateMgr = GlobalStateMgr.getCurrentState();
-        List<String> dbNames = globalStateMgr.getLocalMetastore().listDbNames();
-        for (String dbName : dbNames) {
-            Database db = GlobalStateMgr.getCurrentState().getDb(dbName);
-            if (null == db) {
+        MaterializedViewMetricsRegistry instance = MaterializedViewMetricsRegistry.getInstance();
+        for (Map.Entry<MvId, MaterializedViewMetricsEntity> e : instance.idToMVMetrics.entrySet()) {
+            IMaterializedViewMetricsEntity mvEntity = e.getValue();
+            if (mvEntity == null || mvEntity instanceof  MaterializedViewMetricsBlackHoleEntity) {
                 continue;
             }
-            for (MaterializedView mv : db.getMaterializedViews()) {
-                IMaterializedViewMetricsEntity mvEntity =
-                        MaterializedViewMetricsRegistry.getInstance().getMetricsEntity(mv.getMvId());
-
-                for (Metric m : mvEntity.getMetrics()) {
-                    // minify metrics if needed
-                    if (minifyMetrics) {
-                        if (null == m.getValue()) {
-                            continue;
-                        }
-                        if (Metric.MetricType.COUNTER == m.type && ((Long) m.getValue()).longValue() == 0L) {
-                            continue;
-                        }
+            MvId mvId = e.getKey();
+            MaterializedViewMetricsEntity entity = (MaterializedViewMetricsEntity) mvEntity;
+            for (Metric m : entity.getMetrics()) {
+                // minify metrics if needed
+                if (minifyMetrics) {
+                    if (null == m.getValue()) {
+                        continue;
                     }
-                    m.addLabel(new MetricLabel("db_name", dbName))
-                            .addLabel(new MetricLabel("mv_name", mv.getName()))
-                            .addLabel(new MetricLabel("mv_id", String.valueOf(mv.getId())));
-                    visitor.visit(m);
+                    // ignore gauge metrics since it will try db lock and visit more metadata
+                    if (Metric.MetricType.GAUGE == m.type) {
+                        continue;
+                    }
+                    // ignore counter metrics with 0 value
+                    if (Metric.MetricType.COUNTER == m.type && ((Long) m.getValue()).longValue() == 0L) {
+                        continue;
+                    }
                 }
+                m.addLabel(new MetricLabel("db_name", entity.dbName))
+                        .addLabel(new MetricLabel("mv_name", entity.mvName))
+                        .addLabel(new MetricLabel("mv_id", String.valueOf(mvId.getId())));
+                visitor.visit(m);
             }
         }
 
         // Histogram metrics should only output once
-        for (Map.Entry<String, Histogram> e : MaterializedViewMetricsRegistry.getInstance()
-                .metricRegistry.getHistograms().entrySet()) {
-            if (minifyMetrics) {
-                if (e.getValue().getCount() == 0) {
-                    continue;
-                }
+        if (!minifyMetrics) {
+            for (Map.Entry<String, Histogram> e : MaterializedViewMetricsRegistry.getInstance()
+                    .metricRegistry.getHistograms().entrySet()) {
+                visitor.visitHistogram(e.getKey(), e.getValue());
             }
-            visitor.visitHistogram(e.getKey(), e.getValue());
         }
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/StatementPlanner.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/StatementPlanner.java
@@ -118,27 +118,22 @@ public class StatementPlanner {
             }
 
             // Note: we only could get the olap table after Analyzing phase
-            boolean isOnlyOlapTableQueries = AnalyzerUtils.isOnlyHasOlapTables(stmt);
             if (stmt instanceof QueryStatement) {
                 QueryStatement queryStmt = (QueryStatement) stmt;
                 resultSinkType = queryStmt.hasOutFileClause() ? TResultSinkType.FILE : resultSinkType;
+                boolean isOnlyOlapTableQueries = AnalyzerUtils.isOnlyHasOlapTables(queryStmt);
+                needWholePhaseLock =  isLockFree(isOnlyOlapTableQueries, session) ? false : true;
                 ExecPlan plan;
-                if (isLockFree(isOnlyOlapTableQueries, session)) {
-                    unLock(plannerMetaLocker);
-                    needWholePhaseLock = false;
-                    plan = createQueryPlanWithReTry(queryStmt, session, resultSinkType, plannerMetaLocker);
-                } else {
+                if (needWholePhaseLock) {
                     plan = createQueryPlan(queryStmt, session, resultSinkType);
+                } else {
+                    unLock(plannerMetaLocker);
+                    plan = createQueryPlanWithReTry(queryStmt, session, resultSinkType, plannerMetaLocker);
                 }
                 setOutfileSink(queryStmt, plan);
                 return plan;
             } else if (stmt instanceof InsertStmt) {
-                InsertStmt insertStmt = (InsertStmt) stmt;
-                boolean isSelect = !(insertStmt.getQueryStatement().getQueryRelation() instanceof ValuesRelation);
-                boolean isLeader = GlobalStateMgr.getCurrentState().isLeader();
-                boolean useOptimisticLock = isOnlyOlapTableQueries && isSelect && isLeader &&
-                        !session.getSessionVariable().isCboUseDBLock();
-                return new InsertPlanner(plannerMetaLocker, useOptimisticLock).plan((InsertStmt) stmt, session);
+                return planInsertStmt(plannerMetaLocker, (InsertStmt) stmt, session);
             } else if (stmt instanceof UpdateStmt) {
                 return new UpdatePlanner().plan((UpdateStmt) stmt, session);
             } else if (stmt instanceof DeleteStmt) {
@@ -152,6 +147,23 @@ public class StatementPlanner {
         }
 
         return null;
+    }
+
+    public static ExecPlan planInsertStmt(PlannerMetaLocker plannerMetaLocker,
+                                          InsertStmt insertStmt,
+                                          ConnectContext connectContext) {
+        // if use optimistic lock, we will unlock it in InsertPlanner#buildExecPlanWithRetrye
+        boolean useOptimisticLock = isLockFreeInsertStmt(insertStmt, connectContext);
+        return new InsertPlanner(plannerMetaLocker, useOptimisticLock).plan(insertStmt, connectContext);
+    }
+
+    private static boolean isLockFreeInsertStmt(InsertStmt insertStmt,
+                                                ConnectContext connectContext) {
+        boolean isSelect = !(insertStmt.getQueryStatement().getQueryRelation() instanceof ValuesRelation);
+        boolean isLeader = GlobalStateMgr.getCurrentState().isLeader();
+        boolean isOnlyOlapTableQueries = AnalyzerUtils.isOnlyHasOlapTables(insertStmt);
+        return isOnlyOlapTableQueries && isSelect && isLeader &&
+                !connectContext.getSessionVariable().isCboUseDBLock();
     }
 
     private static boolean isLockFree(boolean isOnlyOlapTable, ConnectContext session) {

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvRewriteMetricsTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvRewriteMetricsTest.java
@@ -66,7 +66,7 @@ public class MvRewriteMetricsTest extends MvRewriteTestBase {
             Assert.assertTrue(mvMetric.counterRefreshJobSuccessTotal.getValue() == 1);
             Assert.assertTrue(mvMetric.counterRefreshJobFailedTotal.getValue() == 0);
             Assert.assertTrue(mvMetric.counterRefreshJobEmptyTotal.getValue() == 0);
-            Assert.assertTrue(mvMetric.counterRefreshJobRetryCheckChangedTotal.getValue() == 0);
+            Assert.assertTrue(mvMetric.counterRefreshJobRetryCheckChangedTotal.getValue() > 0);
 
             Assert.assertTrue(mvMetric.counterRefreshPendingJobs.getValue() == 0);
             Assert.assertTrue(mvMetric.counterRefreshRunningJobs.getValue() >= 0);
@@ -133,7 +133,7 @@ public class MvRewriteMetricsTest extends MvRewriteTestBase {
             Assert.assertTrue(mvMetric.counterRefreshJobSuccessTotal.getValue() == 1);
             Assert.assertTrue(mvMetric.counterRefreshJobFailedTotal.getValue() == 0);
             Assert.assertTrue(mvMetric.counterRefreshJobEmptyTotal.getValue() == 0);
-            Assert.assertTrue(mvMetric.counterRefreshJobRetryCheckChangedTotal.getValue() == 0);
+            Assert.assertTrue(mvMetric.counterRefreshJobRetryCheckChangedTotal.getValue() > 0);
 
             Assert.assertTrue(mvMetric.counterRefreshPendingJobs.getValue() == 0);
             Assert.assertTrue(mvMetric.counterRefreshRunningJobs.getValue() >= 0);


### PR DESCRIPTION
## Why I'm doing:
- `ReentrantReadWriteLock` should be reentrant so we can re-lock the same dbs as below line `StatementPlanner.lock(dbs);` and ` execPlan = StatementPlanner.plan(insertStmt, ctx);`.
- But If `dbs` has been changed during the period and the lost dbs have been locked, dead lock may happen.
-  The differ why `dbs` change is because dbs before and after `analyzer`.
```
        // 4. Analyze and prepare partition
        Map<String, Database> dbs = AnalyzerUtils.collectAllDatabase(ctx, insertStmt);
        ExecPlan execPlan = null;
        try {
            StatementPlanner.lock(dbs);  // <------

            insertStmt =
                    analyzeInsertStmt(insertStmt, mvToRefreshedPartitions, refTablePartitionNames, materializedView,
                            ctx);
            // Must set execution id before StatementPlanner.plan
            ctx.setExecutionId(UUIDUtil.toTUniqueId(ctx.getQueryId()));
            execPlan = StatementPlanner.plan(insertStmt, ctx); // <------
        } catch (Throwable e) {
            LOG.warn("prepareRefreshPlan for mv {} failed", materializedView.getName(), e);
            throw e;
        } finally {
            StatementPlanner.unLock(dbs);
        }

    public static ExecPlan plan(StatementBase stmt, ConnectContext session,
                                TResultSinkType resultSinkType) {
        if (stmt instanceof QueryStatement) {
            OptimizerTraceUtil.logQueryStatement(session, "after parse:\n%s", (QueryStatement) stmt);
        }

        Map<String, Database> dbs = AnalyzerUtils.collectAllDatabase(session, stmt);
        boolean needWholePhaseLock = true;
        // 1. For all queries, we need db lock when analyze phase
        try (ConnectContext.ScopeGuard guard = session.bindScope()) {
            lock(dbs); <----
....

```

## What I'm doing:
- Only use one `locker` during `prepareRefreshPlan` function.
- Remove locks in metrics collections.
- Do other refactors.


### Further
- Use `tryLock` to replace all `lock` in the later.

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [x] 3.2
  - [x] 3.1
  - [ ] 3.0
  - [ ] 2.5
