### PR TITLE
[BugFix] Fix restore download failure for the file of GIN

### DIFF
--- a/be/src/runtime/snapshot_loader.cpp
+++ b/be/src/runtime/snapshot_loader.cpp
@@ -756,10 +756,17 @@ bool SnapshotLoader::_end_with(const std::string& str, const std::string& match)
     return false;
 }
 
+bool SnapshotLoader::_contains(const std::string& str, const std::string& match) {
+    if (str.size() >= match.size() && str.find(match) != std::string::npos) {
+        return true;
+    }
+    return false;
+}
+
 bool SnapshotLoader::_is_index_files(const std::string& str) {
     return _end_with(str, "fdt") || _end_with(str, "fdx") || _end_with(str, "fnm") || _end_with(str, "frq") ||
            _end_with(str, "nrm") || _end_with(str, "prx") || _end_with(str, "tii") || _end_with(str, "tis") ||
-           _end_with(str, "null_bitmap") || _end_with(str, "segments_2") || _end_with(str, "segments.gen");
+           _end_with(str, "null_bitmap") || _contains(str, "segments");
 }
 
 Status SnapshotLoader::_get_tablet_id_and_schema_hash_from_file_path(const std::string& src_path, int64_t* tablet_id,

--- a/be/src/runtime/snapshot_loader.cpp
+++ b/be/src/runtime/snapshot_loader.cpp
@@ -757,10 +757,7 @@ bool SnapshotLoader::_end_with(const std::string& str, const std::string& match)
 }
 
 bool SnapshotLoader::_contains(const std::string& str, const std::string& match) {
-    if (str.find(match) != std::string::npos) {
-        return true;
-    }
-    return false;
+    return str.find(match) != std::string::npos;
 }
 
 bool SnapshotLoader::_is_index_files(const std::string& str) {

--- a/be/src/runtime/snapshot_loader.cpp
+++ b/be/src/runtime/snapshot_loader.cpp
@@ -757,7 +757,7 @@ bool SnapshotLoader::_end_with(const std::string& str, const std::string& match)
 }
 
 bool SnapshotLoader::_contains(const std::string& str, const std::string& match) {
-    if (str.size() >= match.size() && str.find(match) != std::string::npos) {
+    if (str.find(match) != std::string::npos) {
         return true;
     }
     return false;

--- a/be/src/runtime/snapshot_loader.h
+++ b/be/src/runtime/snapshot_loader.h
@@ -96,6 +96,7 @@ private:
                                               const std::string& new_name);
 
     bool _end_with(const std::string& str, const std::string& match);
+    bool _contains(const std::string& str, const std::string& match);
 
     bool _is_index_files(const std::string& str);
 

--- a/be/test/runtime/snapshot_loader_test.cpp
+++ b/be/test/runtime/snapshot_loader_test.cpp
@@ -108,6 +108,14 @@ TEST_F(SnapshotLoaderTest, NormalCase) {
     st = loader._get_tablet_id_from_remote_path("/__tbl_10004/__part_10003/__idx_10004/__10005", &tablet_id);
     ASSERT_TRUE(st.ok());
     ASSERT_EQ(10005, tablet_id);
+
+    ASSERT_TRUE(loader._contains("1234_2_5_12345_1.segments_1", "segments"));
+    ASSERT_TRUE(loader._contains("1234_2_5_12345_1.segments_2", "segments"));
+    ASSERT_TRUE(loader._contains("1234_2_5_12345_1.segments_3", "segments"));
+    ASSERT_TRUE(loader._contains("1234_2_5_12345_1.segments_4", "segments"));
+    ASSERT_TRUE(loader._contains("1234_2_5_12345_1.segments_5", "segments"));
+
+    ASSERT_TRUE(loader._contains("1234_2_5_12345_1.segments.gen", "segments"));
 }
 
 } // namespace starrocks


### PR DESCRIPTION
## Why I'm doing:
Currently, we hard code two kinds of GIN index file which is end with segments_2 and segments.gen. But the index file maybe contains some file which are end with segments_1, segments_2,...,segments_n etc. We will download these files fail because the incorrent file name check.

## What I'm doing:
Check whether the file name contain segments instead of hard coding the suffix

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
