### PR TITLE
[BugFix] `files` support ASCII code delimiter for CSV format

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/load/BrokerFileGroup.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/BrokerFileGroup.java
@@ -137,8 +137,8 @@ public class BrokerFileGroup implements Writable {
         this.filePaths.add(table.getPath());
 
         this.fileFormat = table.getFormat();
-        this.columnSeparator = table.getCsvColumnSeparator();
-        this.rowDelimiter = table.getCsvRowDelimiter();
+        this.columnSeparator = Delimiter.convertDelimiter(table.getCsvColumnSeparator());
+        this.rowDelimiter = Delimiter.convertDelimiter(table.getCsvRowDelimiter());
         this.csvFormat = new CsvFormat(table.getCsvEnclose(), table.getCsvEscape(),
                 table.getCsvSkipHeader(), table.getCsvTrimSpace());
         this.fileFieldNames = new ArrayList<>();

--- a/fe/fe-core/src/test/java/com/starrocks/load/BrokerFileGroupTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/load/BrokerFileGroupTest.java
@@ -27,6 +27,7 @@ import com.starrocks.catalog.Column;
 import com.starrocks.catalog.Database;
 import com.starrocks.catalog.HiveTable;
 import com.starrocks.catalog.OlapTable;
+import com.starrocks.catalog.TableFunctionTable;
 import com.starrocks.catalog.Type;
 import com.starrocks.common.CsvFormat;
 import com.starrocks.common.UserException;
@@ -42,7 +43,9 @@ import org.junit.Test;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 public class BrokerFileGroupTest {
     @Mocked
@@ -155,5 +158,19 @@ public class BrokerFileGroupTest {
         fileGroup.parse(db, desc);
         Assert.assertEquals(Lists.newArrayList("k1", "k2"), fileGroup.getFileFieldNames());
         Assert.assertEquals(10, fileGroup.getSrcTableId());
+    }
+
+    @Test
+    public void testTableFunctionTableCSVDelimiter() throws UserException {
+        Map<String, String> properties = new HashMap<>();
+        properties.put("path", "fake://some_bucket/some_path/*");
+        properties.put("format", "CSV");
+        properties.put("csv.column_separator", "\\x01");
+        properties.put("csv.row_delimiter", "\\x02");
+
+        TableFunctionTable table = new TableFunctionTable(properties);
+        BrokerFileGroup fileGroup = new BrokerFileGroup(table);
+        Assert.assertEquals("\1", fileGroup.getColumnSeparator());
+        Assert.assertEquals("\2", fileGroup.getRowDelimiter());
     }
 }


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:
This PR adds the ASCII code delimiter  for CSV format
Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
