### PR TITLE
[BugFix] Change non-pk sort key type maybe failed

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/alter/SchemaChangeHandler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/SchemaChangeHandler.java
@@ -1285,7 +1285,7 @@ public class SchemaChangeHandler extends AlterHandler {
                 for (Integer colIdx : originSortKeyIdxes) {
                     String columnName = index.getSchema().get(colIdx).getName();
                     Optional<Column> oneCol =
-                            alterSchema.stream().filter(c -> c.getName().equalsIgnoreCase(columnName)).findFirst();
+                            alterSchema.stream().filter(c -> c.nameEquals(columnName, true)).findFirst();
                     if (oneCol.isEmpty()) {
                         LOG.warn("Sort Key Column[" + columnName + "] not exists in new schema");
                         throw new DdlException("Sort Key Column[" + columnName + "] not exists in new schema");

--- a/test/sql/test_sort_key/R/test_sort_key_agg_tbl
+++ b/test/sql/test_sort_key/R/test_sort_key_agg_tbl
@@ -15,7 +15,7 @@ CREATE TABLE `agg_test` (
 )
 AGGREGATE KEY(k1, k2)
 COMMENT "OLAP"
-DISTRIBUTED BY HASH(`k1`, `k2`) BUCKETS 1
+DISTRIBUTED BY HASH(`k1`) BUCKETS 1
 ORDER BY (k2)
 PROPERTIES (
     "replication_num" = "1",
@@ -34,7 +34,7 @@ CREATE TABLE `agg_test` (
 )
 AGGREGATE KEY(k1, k2)
 COMMENT "OLAP"
-DISTRIBUTED BY HASH(`k1`, `k2`) BUCKETS 1
+DISTRIBUTED BY HASH(`k1`) BUCKETS 1
 ORDER BY (k2,v2)
 PROPERTIES (
     "replication_num" = "1",
@@ -53,7 +53,7 @@ CREATE TABLE `agg_test` (
 )
 AGGREGATE KEY(k1, k2)
 COMMENT "OLAP"
-DISTRIBUTED BY HASH(`k1`, `k2`) BUCKETS 1
+DISTRIBUTED BY HASH(`k1`) BUCKETS 1
 ORDER BY (k2,k1,k1)
 PROPERTIES (
     "replication_num" = "1",
@@ -73,7 +73,7 @@ CREATE TABLE `agg_test` (
 )
 AGGREGATE KEY(k1, k2)
 COMMENT "OLAP"
-DISTRIBUTED BY HASH(`k1`, `k2`) BUCKETS 1
+DISTRIBUTED BY HASH(`k1`) BUCKETS 1
 ORDER BY (k2,k1)
 PROPERTIES (
     "replication_num" = "1",
@@ -146,7 +146,47 @@ agg_test	CREATE TABLE `agg_test` (
 ) ENGINE=OLAP 
 AGGREGATE KEY(`k1`, `k2`)
 COMMENT "OLAP"
-DISTRIBUTED BY HASH(`k1`, `k2`) BUCKETS 1 
+DISTRIBUTED BY HASH(`k1`) BUCKETS 1 
+ORDER BY(`k1`, `k2`)
+PROPERTIES (
+"compression" = "LZ4",
+"fast_schema_evolution" = "true",
+"replicated_storage" = "true",
+"replication_num" = "1"
+);
+-- !result
+select * from agg_test;
+-- result:
+1	2	2	10	9
+1	3	2	10	9
+2	1	2	8	8
+2	2	2	9	7
+2	3	2	9	7
+3	1	2	8	8
+-- !result
+alter table agg_test modify column k1 bigint key;
+-- result:
+E: (1064, 'Can not modify distribution column[k1]. index[agg_test]')
+-- !result
+alter table agg_test modify column k2 bigint key;
+-- result:
+-- !result
+function: wait_alter_table_finish()
+-- result:
+None
+-- !result
+show create table agg_test;
+-- result:
+agg_test	CREATE TABLE `agg_test` (
+  `k1` int(11) NOT NULL COMMENT "",
+  `k2` bigint(20) NULL COMMENT "",
+  `v1` bigint(20) REPLACE NULL COMMENT "",
+  `v2` bigint(20) REPLACE NULL COMMENT "",
+  `v3` bigint(20) REPLACE NULL COMMENT ""
+) ENGINE=OLAP 
+AGGREGATE KEY(`k1`, `k2`)
+COMMENT "OLAP"
+DISTRIBUTED BY HASH(`k1`) BUCKETS 1 
 ORDER BY(`k1`, `k2`)
 PROPERTIES (
 "compression" = "LZ4",
@@ -174,7 +214,7 @@ None
 show create table agg_test;
 -- result:
 agg_test	CREATE TABLE `agg_test` (
-  `k2` int(11) NOT NULL COMMENT "",
+  `k2` bigint(20) NULL COMMENT "",
   `k1` int(11) NOT NULL COMMENT "",
   `v2` bigint(20) REPLACE NULL COMMENT "",
   `v1` bigint(20) REPLACE NULL COMMENT "",
@@ -182,7 +222,7 @@ agg_test	CREATE TABLE `agg_test` (
 ) ENGINE=OLAP 
 AGGREGATE KEY(`k2`, `k1`)
 COMMENT "OLAP"
-DISTRIBUTED BY HASH(`k1`, `k2`) BUCKETS 1 
+DISTRIBUTED BY HASH(`k1`) BUCKETS 1 
 ORDER BY(`k1`, `k2`)
 PROPERTIES (
 "compression" = "LZ4",
@@ -193,12 +233,6 @@ PROPERTIES (
 -- !result
 select * from agg_test;
 -- result:
-1	2	8	2	8
-1	3	8	2	8
-2	1	10	2	9
-2	2	9	2	7
-3	1	10	2	9
-3	2	9	2	7
 -- !result
 drop table agg_test;
 -- result:
@@ -222,7 +256,7 @@ CREATE TABLE `agg_test` (
 )
 AGGREGATE KEY(k1, k2)
 COMMENT "OLAP"
-DISTRIBUTED BY HASH(`k1`, `k2`) BUCKETS 1
+DISTRIBUTED BY HASH(`k1`) BUCKETS 1
 ORDER BY (k2,k1)
 PROPERTIES (
     "replication_num" = "1",
@@ -290,7 +324,7 @@ agg_test	CREATE TABLE `agg_test` (
 ) ENGINE=OLAP 
 AGGREGATE KEY(`k1`, `k2`)
 COMMENT "OLAP"
-DISTRIBUTED BY HASH(`k1`, `k2`) BUCKETS 1 
+DISTRIBUTED BY HASH(`k1`) BUCKETS 1 
 ORDER BY(`k1`, `k2`)
 PROPERTIES (
 "compression" = "LZ4",
@@ -326,7 +360,7 @@ agg_test	CREATE TABLE `agg_test` (
 ) ENGINE=OLAP 
 AGGREGATE KEY(`k2`, `k1`)
 COMMENT "OLAP"
-DISTRIBUTED BY HASH(`k1`, `k2`) BUCKETS 1 
+DISTRIBUTED BY HASH(`k1`) BUCKETS 1 
 ORDER BY(`k1`, `k2`)
 PROPERTIES (
 "compression" = "LZ4",

--- a/test/sql/test_sort_key/R/test_sort_key_dup_tbl
+++ b/test/sql/test_sort_key/R/test_sort_key_dup_tbl
@@ -9,9 +9,9 @@ use sort_key_test_dup;
 CREATE TABLE `dup_test` (
     `k1` int(11) NOT NULL COMMENT "",
     `k2` int(11) NOT NULL COMMENT "",
-    `v1` bigint REPLACE NULL COMMENT "",
-    `v2` bigint REPLACE NULL COMMENT "",
-    `v3` bigint REPLACE NULL COMMENT ""
+    `v1` int NULL COMMENT "",
+    `v2` bigint NULL COMMENT "",
+    `v3` bigint NULL COMMENT ""
 )
 DUPLICATE KEY(k1, k2)
 COMMENT "OLAP"
@@ -28,9 +28,9 @@ E: (1064, 'Duplicate sort key column k2 is not allowed.')
 CREATE TABLE `dup_test` (
     `k1` int(11) NOT NULL COMMENT "",
     `k2` int(11) NOT NULL COMMENT "",
-    `v1` bigint REPLACE NULL COMMENT "",
-    `v2` bigint REPLACE NULL COMMENT "",
-    `v3` bigint REPLACE NULL COMMENT ""
+    `v1` int NULL COMMENT "",
+    `v2` bigint NULL COMMENT "",
+    `v3` bigint NULL COMMENT ""
 )
 DUPLICATE KEY(k1, k2)
 COMMENT "OLAP"
@@ -81,6 +81,42 @@ alter table dup_test order by (k2,v1,v1);
 E: (1064, 'Duplicated column[v1]')
 -- !result
 alter table dup_test order by (k2,v1);
+-- result:
+-- !result
+function: wait_alter_table_finish()
+-- result:
+None
+-- !result
+show create table dup_test;
+-- result:
+dup_test	CREATE TABLE `dup_test` (
+  `k1` int(11) NOT NULL COMMENT "",
+  `k2` int(11) NOT NULL COMMENT "",
+  `v1` int(11) NULL COMMENT "",
+  `v2` bigint(20) NULL COMMENT "",
+  `v3` bigint(20) NULL COMMENT ""
+) ENGINE=OLAP 
+DUPLICATE KEY(`k1`, `k2`)
+COMMENT "OLAP"
+DISTRIBUTED BY HASH(`k1`, `k2`) BUCKETS 1 
+ORDER BY(`k2`, `v1`)
+PROPERTIES (
+"compression" = "LZ4",
+"fast_schema_evolution" = "true",
+"replicated_storage" = "true",
+"replication_num" = "1"
+);
+-- !result
+select * from dup_test;
+-- result:
+2	1	2	8	8
+3	1	2	8	8
+1	2	2	10	9
+2	2	2	9	7
+1	3	2	10	9
+2	3	2	9	7
+-- !result
+alter table dup_test modify column v1 bigint;
 -- result:
 -- !result
 function: wait_alter_table_finish()
@@ -165,9 +201,9 @@ use sort_key_dup_tbl_with_rollup;
 CREATE TABLE `dup_test` (
     `k1` int(11) NOT NULL COMMENT "",
     `k2` int(11) NOT NULL COMMENT "",
-    `v1` bigint REPLACE NULL COMMENT "",
-    `v2` bigint REPLACE NULL COMMENT "",
-    `v3` bigint REPLACE NULL COMMENT ""
+    `v1` int NULL COMMENT "",
+    `v2` bigint NULL COMMENT "",
+    `v3` bigint NULL COMMENT ""
 )
 DUPLICATE KEY(k1, k2)
 COMMENT "OLAP"
@@ -200,11 +236,11 @@ insert into dup_test values (1,2,2,10,9),(2,3,2,9,7),(2,1,2,8,8);
 -- !result
 select * from dup_test;
 -- result:
-2	1	2	8	8
 3	1	2	8	8
-1	2	2	10	9
 2	2	2	9	7
 1	3	2	10	9
+2	1	2	8	8
+1	2	2	10	9
 2	3	2	9	7
 -- !result
 function: manual_compact("sort_key_dup_tbl_with_rollup", "dup_test")
@@ -232,7 +268,7 @@ show create table dup_test;
 dup_test	CREATE TABLE `dup_test` (
   `k1` int(11) NOT NULL COMMENT "",
   `k2` int(11) NOT NULL COMMENT "",
-  `v1` bigint(20) NULL COMMENT "",
+  `v1` int(11) NULL COMMENT "",
   `v2` bigint(20) NULL COMMENT "",
   `v3` bigint(20) NULL COMMENT ""
 ) ENGINE=OLAP 

--- a/test/sql/test_sort_key/R/test_sort_key_uni_tbl
+++ b/test/sql/test_sort_key/R/test_sort_key_uni_tbl
@@ -15,7 +15,7 @@ CREATE TABLE `uni_test` (
 )
 UNIQUE KEY(k1, k2)
 COMMENT "OLAP"
-DISTRIBUTED BY HASH(`k1`, `k2`) BUCKETS 1
+DISTRIBUTED BY HASH(`k1`) BUCKETS 1
 ORDER BY (k2)
 PROPERTIES (
     "replication_num" = "1",
@@ -33,7 +33,7 @@ CREATE TABLE `uni_test` (
 )
 UNIQUE KEY(k1, k2)
 COMMENT "OLAP"
-DISTRIBUTED BY HASH(`k1`, `k2`) BUCKETS 1
+DISTRIBUTED BY HASH(`k1`) BUCKETS 1
 ORDER BY (k2,v2)
 PROPERTIES (
     "replication_num" = "1",
@@ -51,7 +51,7 @@ CREATE TABLE `uni_test` (
 )
 UNIQUE KEY(k1, k2)
 COMMENT "OLAP"
-DISTRIBUTED BY HASH(`k1`, `k2`) BUCKETS 1
+DISTRIBUTED BY HASH(`k1`) BUCKETS 1
 ORDER BY (k2,k1,k2)
 PROPERTIES (
     "replication_num" = "1",
@@ -70,7 +70,7 @@ CREATE TABLE `uni_test` (
 )
 UNIQUE KEY(k1, k2)
 COMMENT "OLAP"
-DISTRIBUTED BY HASH(`k1`, `k2`) BUCKETS 1
+DISTRIBUTED BY HASH(`k1`) BUCKETS 1
 ORDER BY (k2,k1)
 PROPERTIES (
     "replication_num" = "1",
@@ -142,7 +142,47 @@ uni_test	CREATE TABLE `uni_test` (
 ) ENGINE=OLAP 
 UNIQUE KEY(`k1`, `k2`)
 COMMENT "OLAP"
-DISTRIBUTED BY HASH(`k1`, `k2`) BUCKETS 1 
+DISTRIBUTED BY HASH(`k1`) BUCKETS 1 
+ORDER BY(`k1`, `k2`)
+PROPERTIES (
+"compression" = "LZ4",
+"fast_schema_evolution" = "true",
+"replicated_storage" = "true",
+"replication_num" = "1"
+);
+-- !result
+select * from uni_test;
+-- result:
+1	2	2	10	9
+1	3	2	10	9
+2	1	2	8	8
+2	2	2	9	7
+2	3	2	9	7
+3	1	2	8	8
+-- !result
+alter table uni_test modify column k1 bigint key;
+-- result:
+E: (1064, 'Can not modify distribution column[k1]. index[uni_test]')
+-- !result
+alter table uni_test modify column k2 bigint key;
+-- result:
+-- !result
+function: wait_alter_table_finish()
+-- result:
+None
+-- !result
+show create table uni_test;
+-- result:
+uni_test	CREATE TABLE `uni_test` (
+  `k1` int(11) NOT NULL COMMENT "",
+  `k2` bigint(20) NULL COMMENT "",
+  `v1` bigint(20) NULL COMMENT "",
+  `v2` bigint(20) NULL COMMENT "",
+  `v3` bigint(20) NULL COMMENT ""
+) ENGINE=OLAP 
+UNIQUE KEY(`k1`, `k2`)
+COMMENT "OLAP"
+DISTRIBUTED BY HASH(`k1`) BUCKETS 1 
 ORDER BY(`k1`, `k2`)
 PROPERTIES (
 "compression" = "LZ4",
@@ -170,7 +210,7 @@ None
 show create table uni_test;
 -- result:
 uni_test	CREATE TABLE `uni_test` (
-  `k2` int(11) NOT NULL COMMENT "",
+  `k2` bigint(20) NULL COMMENT "",
   `k1` int(11) NOT NULL COMMENT "",
   `v2` bigint(20) NULL COMMENT "",
   `v1` bigint(20) NULL COMMENT "",
@@ -178,7 +218,7 @@ uni_test	CREATE TABLE `uni_test` (
 ) ENGINE=OLAP 
 UNIQUE KEY(`k2`, `k1`)
 COMMENT "OLAP"
-DISTRIBUTED BY HASH(`k1`, `k2`) BUCKETS 1 
+DISTRIBUTED BY HASH(`k1`) BUCKETS 1 
 ORDER BY(`k1`, `k2`)
 PROPERTIES (
 "compression" = "LZ4",
@@ -189,12 +229,6 @@ PROPERTIES (
 -- !result
 select * from uni_test;
 -- result:
-1	2	8	2	8
-1	3	8	2	8
-2	1	10	2	9
-2	2	9	2	7
-3	1	10	2	9
-3	2	9	2	7
 -- !result
 drop table uni_test;
 -- result:
@@ -218,7 +252,7 @@ CREATE TABLE `uni_test` (
 )
 UNIQUE KEY(k1, k2)
 COMMENT "OLAP"
-DISTRIBUTED BY HASH(`k1`, `k2`) BUCKETS 1
+DISTRIBUTED BY HASH(`k1`) BUCKETS 1
 ORDER BY (k2,k1)
 PROPERTIES (
     "replication_num" = "1",
@@ -285,7 +319,7 @@ uni_test	CREATE TABLE `uni_test` (
 ) ENGINE=OLAP 
 UNIQUE KEY(`k1`, `k2`)
 COMMENT "OLAP"
-DISTRIBUTED BY HASH(`k1`, `k2`) BUCKETS 1 
+DISTRIBUTED BY HASH(`k1`) BUCKETS 1 
 ORDER BY(`k1`, `k2`)
 PROPERTIES (
 "compression" = "LZ4",
@@ -321,7 +355,7 @@ uni_test	CREATE TABLE `uni_test` (
 ) ENGINE=OLAP 
 UNIQUE KEY(`k2`, `k1`)
 COMMENT "OLAP"
-DISTRIBUTED BY HASH(`k1`, `k2`) BUCKETS 1 
+DISTRIBUTED BY HASH(`k1`) BUCKETS 1 
 ORDER BY(`k1`, `k2`)
 PROPERTIES (
 "compression" = "LZ4",

--- a/test/sql/test_sort_key/T/test_sort_key_agg_tbl
+++ b/test/sql/test_sort_key/T/test_sort_key_agg_tbl
@@ -14,7 +14,7 @@ CREATE TABLE `agg_test` (
 )
 AGGREGATE KEY(k1, k2)
 COMMENT "OLAP"
-DISTRIBUTED BY HASH(`k1`, `k2`) BUCKETS 1
+DISTRIBUTED BY HASH(`k1`) BUCKETS 1
 ORDER BY (k2)
 PROPERTIES (
     "replication_num" = "1",
@@ -31,7 +31,7 @@ CREATE TABLE `agg_test` (
 )
 AGGREGATE KEY(k1, k2)
 COMMENT "OLAP"
-DISTRIBUTED BY HASH(`k1`, `k2`) BUCKETS 1
+DISTRIBUTED BY HASH(`k1`) BUCKETS 1
 ORDER BY (k2,v2)
 PROPERTIES (
     "replication_num" = "1",
@@ -48,7 +48,7 @@ CREATE TABLE `agg_test` (
 )
 AGGREGATE KEY(k1, k2)
 COMMENT "OLAP"
-DISTRIBUTED BY HASH(`k1`, `k2`) BUCKETS 1
+DISTRIBUTED BY HASH(`k1`) BUCKETS 1
 ORDER BY (k2,k1,k1)
 PROPERTIES (
     "replication_num" = "1",
@@ -66,7 +66,7 @@ CREATE TABLE `agg_test` (
 )
 AGGREGATE KEY(k1, k2)
 COMMENT "OLAP"
-DISTRIBUTED BY HASH(`k1`, `k2`) BUCKETS 1
+DISTRIBUTED BY HASH(`k1`) BUCKETS 1
 ORDER BY (k2,k1)
 PROPERTIES (
     "replication_num" = "1",
@@ -87,6 +87,12 @@ alter table agg_test order by (k2,v1);
 alter table agg_test order by (k2);
 alter table agg_test order by (k1,k2,k2);
 alter table agg_test order by (k1,k2);
+function: wait_alter_table_finish()
+show create table agg_test;
+select * from agg_test;
+
+alter table agg_test modify column k1 bigint key;
+alter table agg_test modify column k2 bigint key;
 function: wait_alter_table_finish()
 show create table agg_test;
 select * from agg_test;
@@ -113,7 +119,7 @@ CREATE TABLE `agg_test` (
 )
 AGGREGATE KEY(k1, k2)
 COMMENT "OLAP"
-DISTRIBUTED BY HASH(`k1`, `k2`) BUCKETS 1
+DISTRIBUTED BY HASH(`k1`) BUCKETS 1
 ORDER BY (k2,k1)
 PROPERTIES (
     "replication_num" = "1",

--- a/test/sql/test_sort_key/T/test_sort_key_dup_tbl
+++ b/test/sql/test_sort_key/T/test_sort_key_dup_tbl
@@ -8,9 +8,9 @@ use sort_key_test_dup;
 CREATE TABLE `dup_test` (
     `k1` int(11) NOT NULL COMMENT "",
     `k2` int(11) NOT NULL COMMENT "",
-    `v1` bigint REPLACE NULL COMMENT "",
-    `v2` bigint REPLACE NULL COMMENT "",
-    `v3` bigint REPLACE NULL COMMENT ""
+    `v1` int NULL COMMENT "",
+    `v2` bigint NULL COMMENT "",
+    `v3` bigint NULL COMMENT ""
 )
 DUPLICATE KEY(k1, k2)
 COMMENT "OLAP"
@@ -25,9 +25,9 @@ PROPERTIES (
 CREATE TABLE `dup_test` (
     `k1` int(11) NOT NULL COMMENT "",
     `k2` int(11) NOT NULL COMMENT "",
-    `v1` bigint REPLACE NULL COMMENT "",
-    `v2` bigint REPLACE NULL COMMENT "",
-    `v3` bigint REPLACE NULL COMMENT ""
+    `v1` int NULL COMMENT "",
+    `v2` bigint NULL COMMENT "",
+    `v3` bigint NULL COMMENT ""
 )
 DUPLICATE KEY(k1, k2)
 COMMENT "OLAP"
@@ -53,6 +53,11 @@ function: wait_alter_table_finish()
 show create table dup_test;
 select * from dup_test;
 
+alter table dup_test modify column v1 bigint;
+function: wait_alter_table_finish()
+show create table dup_test;
+select * from dup_test;
+
 
 alter table dup_test order by (k2,k1,v2,v1,v3);
 function: wait_alter_table_finish()
@@ -70,9 +75,9 @@ use sort_key_dup_tbl_with_rollup;
 CREATE TABLE `dup_test` (
     `k1` int(11) NOT NULL COMMENT "",
     `k2` int(11) NOT NULL COMMENT "",
-    `v1` bigint REPLACE NULL COMMENT "",
-    `v2` bigint REPLACE NULL COMMENT "",
-    `v3` bigint REPLACE NULL COMMENT ""
+    `v1` int NULL COMMENT "",
+    `v2` bigint NULL COMMENT "",
+    `v3` bigint NULL COMMENT ""
 )
 DUPLICATE KEY(k1, k2)
 COMMENT "OLAP"

--- a/test/sql/test_sort_key/T/test_sort_key_uni_tbl
+++ b/test/sql/test_sort_key/T/test_sort_key_uni_tbl
@@ -15,7 +15,7 @@ CREATE TABLE `uni_test` (
 )
 UNIQUE KEY(k1, k2)
 COMMENT "OLAP"
-DISTRIBUTED BY HASH(`k1`, `k2`) BUCKETS 1
+DISTRIBUTED BY HASH(`k1`) BUCKETS 1
 ORDER BY (k2)
 PROPERTIES (
     "replication_num" = "1",
@@ -31,7 +31,7 @@ CREATE TABLE `uni_test` (
 )
 UNIQUE KEY(k1, k2)
 COMMENT "OLAP"
-DISTRIBUTED BY HASH(`k1`, `k2`) BUCKETS 1
+DISTRIBUTED BY HASH(`k1`) BUCKETS 1
 ORDER BY (k2,v2)
 PROPERTIES (
     "replication_num" = "1",
@@ -47,7 +47,7 @@ CREATE TABLE `uni_test` (
 )
 UNIQUE KEY(k1, k2)
 COMMENT "OLAP"
-DISTRIBUTED BY HASH(`k1`, `k2`) BUCKETS 1
+DISTRIBUTED BY HASH(`k1`) BUCKETS 1
 ORDER BY (k2,k1,k2)
 PROPERTIES (
     "replication_num" = "1",
@@ -64,7 +64,7 @@ CREATE TABLE `uni_test` (
 )
 UNIQUE KEY(k1, k2)
 COMMENT "OLAP"
-DISTRIBUTED BY HASH(`k1`, `k2`) BUCKETS 1
+DISTRIBUTED BY HASH(`k1`) BUCKETS 1
 ORDER BY (k2,k1)
 PROPERTIES (
     "replication_num" = "1",
@@ -84,6 +84,12 @@ alter table uni_test order by (k2,v1);
 alter table uni_test order by (k2);
 alter table uni_test order by (k1,k2,k1);
 alter table uni_test order by (k1,k2);
+function: wait_alter_table_finish()
+show create table uni_test;
+select * from uni_test;
+
+alter table uni_test modify column k1 bigint key;
+alter table uni_test modify column k2 bigint key;
 function: wait_alter_table_finish()
 show create table uni_test;
 select * from uni_test;
@@ -112,7 +118,7 @@ CREATE TABLE `uni_test` (
 )
 UNIQUE KEY(k1, k2)
 COMMENT "OLAP"
-DISTRIBUTED BY HASH(`k1`, `k2`) BUCKETS 1
+DISTRIBUTED BY HASH(`k1`) BUCKETS 1
 ORDER BY (k2,k1)
 PROPERTIES (
     "replication_num" = "1",


### PR DESCRIPTION
## Why I'm doing:
When we use alter command to change column type, we will add  prefix `__starrocks_shadow_` to the new column. And if the column is sort key column of non-pk table, we will check this column exists or not. However, we don't remove the prefix when we compare the column name and it will result in alter task failed.

## What I'm doing:
Remove the prefix in comparing column name.

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
