### PR TITLE
[BugFix] Disable Gin for shared data mode and alter gin column into non-string type

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/alter/SchemaChangeHandler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/SchemaChangeHandler.java
@@ -536,7 +536,7 @@ public class SchemaChangeHandler extends AlterHandler {
             if (index.getIndexType() == IndexDef.IndexType.GIN) {
                 if (index.getColumns().contains(oriColumn.getName()) &&
                         !modColumn.getType().isStringType()) {
-                    throw new DdlException("Can't not modify a Column with Gin into Non-String type");
+                    throw new DdlException("Cannot modify a column with GIN into non-string type");
                 }
             }
         }

--- a/fe/fe-core/src/main/java/com/starrocks/alter/SchemaChangeHandler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/SchemaChangeHandler.java
@@ -532,6 +532,15 @@ public class SchemaChangeHandler extends AlterHandler {
 
         Column oriColumn = schemaForFinding.get(modColIndex);
 
+        for (Index index : olapTable.getIndexes()) {
+            if (index.getIndexType() == IndexDef.IndexType.GIN) {
+                if (index.getColumns().contains(oriColumn.getName()) &&
+                        !modColumn.getType().isStringType()) {
+                    throw new DdlException("Can't not modify a Column with Gin into Non-String type");
+                }
+            }
+        }
+
         if (oriColumn.isAutoIncrement()) {
             throw new DdlException("Can't not modify a AUTO_INCREMENT column");
         }

--- a/fe/fe-core/src/main/java/com/starrocks/analysis/InvertedIndexUtil.java
+++ b/fe/fe-core/src/main/java/com/starrocks/analysis/InvertedIndexUtil.java
@@ -20,6 +20,7 @@ import com.starrocks.catalog.PrimitiveType;
 import com.starrocks.catalog.ScalarType;
 import com.starrocks.common.InvertedIndexParams;
 import com.starrocks.common.InvertedIndexParams.IndexParamsKey;
+import com.starrocks.server.RunMode;
 import com.starrocks.sql.analyzer.SemanticException;
 import org.apache.commons.lang3.StringUtils;
 
@@ -74,6 +75,9 @@ public class InvertedIndexUtil {
         }
         if (!validGinColumnType(column)) {
             throw new SemanticException("The inverted index can only be build on column with type of CHAR/STRING/VARCHAR type.");
+        }
+        if (RunMode.isSharedDataMode()) {
+            throw new SemanticException("The inverted index does not support shared data mode");
         }
 
         String impLibKey = IMP_LIB.name().toLowerCase(Locale.ROOT);

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/GINIndexTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/GINIndexTest.java
@@ -42,6 +42,8 @@ import com.starrocks.sql.analyzer.SemanticException;
 import com.starrocks.sql.plan.PlanTestBase;
 import com.starrocks.thrift.TIndexType;
 import com.starrocks.thrift.TOlapTableIndex;
+import mockit.Mock;
+import mockit.MockUp;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.jupiter.api.Assertions;
@@ -85,15 +87,6 @@ public class GINIndexTest extends PlanTestBase {
                 }}, KeysType.DUP_KEYS),
                 "Only support clucene implement for now");
 
-        Config.run_mode = "shared_data";
-        RunMode.detectRunMode();
-        Assertions.assertThrows(
-                SemanticException.class,
-                () -> InvertedIndexUtil.checkInvertedIndexValid(c2, null, KeysType.DUP_KEYS),
-                "The inverted index does not support shared data mode");
-        Config.run_mode = "shared_nothing";
-        RunMode.detectRunMode();
-
         Assertions.assertThrows(
                 SemanticException.class,
                 () -> InvertedIndexUtil.checkInvertedIndexValid(c2, new HashMap<String, String>() {{
@@ -125,6 +118,17 @@ public class GINIndexTest extends PlanTestBase {
                     put(SearchParamsKey.DEFAULT_SEARCH_ANALYZER.name().toLowerCase(Locale.ROOT), "english");
                     put(SearchParamsKey.RERANK.name().toLowerCase(Locale.ROOT), "false");
                 }}, KeysType.DUP_KEYS));
+
+        new MockUp<RunMode>() {
+            @Mock
+            public boolean isSharedDataMode() {
+                return true;
+            }
+        };
+        Assertions.assertThrows(
+                SemanticException.class,
+                () -> InvertedIndexUtil.checkInvertedIndexValid(c2, null, KeysType.DUP_KEYS),
+                "The inverted index does not support shared data mode");
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/GINIndexTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/GINIndexTest.java
@@ -31,11 +31,13 @@ import com.starrocks.catalog.Column;
 import com.starrocks.catalog.Index;
 import com.starrocks.catalog.KeysType;
 import com.starrocks.catalog.Type;
+import com.starrocks.common.Config;
 import com.starrocks.common.InvertedIndexParams;
 import com.starrocks.common.InvertedIndexParams.CommonIndexParamKey;
 import com.starrocks.common.InvertedIndexParams.IndexParamsKey;
 import com.starrocks.common.InvertedIndexParams.InvertedIndexImpType;
 import com.starrocks.common.InvertedIndexParams.SearchParamsKey;
+import com.starrocks.server.RunMode;
 import com.starrocks.sql.analyzer.SemanticException;
 import com.starrocks.sql.plan.PlanTestBase;
 import com.starrocks.thrift.TIndexType;
@@ -82,6 +84,15 @@ public class GINIndexTest extends PlanTestBase {
                     put(IMP_LIB.name().toLowerCase(Locale.ROOT), "???");
                 }}, KeysType.DUP_KEYS),
                 "Only support clucene implement for now");
+
+        Config.run_mode = "shared_data";
+        RunMode.detectRunMode();
+        Assertions.assertThrows(
+                SemanticException.class,
+                () -> InvertedIndexUtil.checkInvertedIndexValid(c2, null, KeysType.DUP_KEYS),
+                "The inverted index does not support shared data mode");
+        Config.run_mode = "shared_nothing";
+        RunMode.detectRunMode();
 
         Assertions.assertThrows(
                 SemanticException.class,

--- a/test/sql/test_inverted_index/R/test_inverted_index
+++ b/test/sql/test_inverted_index/R/test_inverted_index
@@ -1290,7 +1290,7 @@ PROPERTIES (
 -- !result
 ALTER TABLE t_alter_gin_col_into_other_type MODIFY COLUMN v1 BIGINT;
 -- result:
-E: (1064, "Cannot modify a column with GIN into non-string type")
+E: (1064, 'Cannot modify a column with GIN into non-string type')
 -- !result
 INSERT INTO t_alter_gin_col_into_other_type VALUES (1, "abc");
 -- result:

--- a/test/sql/test_inverted_index/R/test_inverted_index
+++ b/test/sql/test_inverted_index/R/test_inverted_index
@@ -1272,3 +1272,56 @@ None
 DROP TABLE t_create_mv_with_match;
 -- result:
 -- !result
+-- name: test_alter_gin_col_into_other_type
+CREATE TABLE `t_alter_gin_col_into_other_type` (
+  `id` bigint(20) NOT NULL COMMENT "",
+  `v1` varchar(255) NULL COMMENT "",
+  INDEX gin_none (`v1`) USING GIN ("parser" = "english")
+) ENGINE=OLAP
+DUPLICATE KEY(`id`)
+DISTRIBUTED BY HASH(`id`) BUCKETS 1
+PROPERTIES (
+"replication_num" = "1",
+"enable_persistent_index" = "false",
+"replicated_storage" = "false",
+"compression" = "LZ4"
+);
+-- result:
+-- !result
+ALTER TABLE t_alter_gin_col_into_other_type MODIFY COLUMN v1 BIGINT;
+-- result:
+E: (1064, "Can't not modify a Column with Gin into Non-String type")
+-- !result
+INSERT INTO t_alter_gin_col_into_other_type VALUES (1, "abc");
+-- result:
+-- !result
+ALTER TABLE t_alter_gin_col_into_other_type MODIFY COLUMN v1 VARCHAR(2000);
+-- result:
+-- !result
+function: wait_alter_table_finish()
+-- result:
+None
+-- !result
+SHOW CREATE TABLE t_alter_gin_col_into_other_type;
+-- result:
+t_alter_gin_col_into_other_type	CREATE TABLE `t_alter_gin_col_into_other_type` (
+  `id` bigint(20) NOT NULL COMMENT "",
+  `v1` varchar(2000) NULL COMMENT "",
+  INDEX gin_none (`v1`) USING GIN("parser" = "english") COMMENT ''
+) ENGINE=OLAP 
+DUPLICATE KEY(`id`)
+DISTRIBUTED BY HASH(`id`) BUCKETS 1 
+PROPERTIES (
+"compression" = "LZ4",
+"fast_schema_evolution" = "true",
+"replicated_storage" = "false",
+"replication_num" = "1"
+);
+-- !result
+SELECT * FROM t_alter_gin_col_into_other_type;
+-- result:
+1	abc
+-- !result
+DROP TABLE t_alter_gin_col_into_other_type;
+-- result:
+-- !result

--- a/test/sql/test_inverted_index/R/test_inverted_index
+++ b/test/sql/test_inverted_index/R/test_inverted_index
@@ -1290,7 +1290,7 @@ PROPERTIES (
 -- !result
 ALTER TABLE t_alter_gin_col_into_other_type MODIFY COLUMN v1 BIGINT;
 -- result:
-E: (1064, "Can't not modify a Column with Gin into Non-String type")
+E: (1064, "Cannot modify a column with GIN into non-string type")
 -- !result
 INSERT INTO t_alter_gin_col_into_other_type VALUES (1, "abc");
 -- result:

--- a/test/sql/test_inverted_index/T/test_inverted_index
+++ b/test/sql/test_inverted_index/T/test_inverted_index
@@ -711,3 +711,27 @@ INSERT INTO t_create_mv_with_match VALUES (1, "abc", "bcd");
 CREATE MATERIALIZED VIEW mv AS SELECT id, v1, v2 FROM t_create_mv_with_match WHERE v1 MATCH "abc";
 function: wait_materialized_view_cancel()
 DROP TABLE t_create_mv_with_match;
+
+-- name: test_alter_gin_col_into_other_type
+CREATE TABLE `t_alter_gin_col_into_other_type` (
+  `id` bigint(20) NOT NULL COMMENT "",
+  `v1` varchar(255) NULL COMMENT "",
+  INDEX gin_none (`v1`) USING GIN ("parser" = "english")
+) ENGINE=OLAP
+DUPLICATE KEY(`id`)
+DISTRIBUTED BY HASH(`id`) BUCKETS 1
+PROPERTIES (
+"replication_num" = "1",
+"enable_persistent_index" = "false",
+"replicated_storage" = "false",
+"compression" = "LZ4"
+);
+
+ALTER TABLE t_alter_gin_col_into_other_type MODIFY COLUMN v1 BIGINT;
+INSERT INTO t_alter_gin_col_into_other_type VALUES (1, "abc");
+ALTER TABLE t_alter_gin_col_into_other_type MODIFY COLUMN v1 VARCHAR(2000);
+function: wait_alter_table_finish()
+
+SHOW CREATE TABLE t_alter_gin_col_into_other_type;
+SELECT * FROM t_alter_gin_col_into_other_type;
+DROP TABLE t_alter_gin_col_into_other_type;


### PR DESCRIPTION
Fix two problem:
1. Disable using Gin in shared data mode.
2. Disable modify column with Gin into non-string type

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
