### PR TITLE
[Enhancement] reduce read io requests during spill restore phase 

### DIFF
--- a/be/src/exec/CMakeLists.txt
+++ b/be/src/exec/CMakeLists.txt
@@ -293,6 +293,7 @@ set(EXEC_FILES
     spill/serde.cpp
     spill/input_stream.cpp
     spill/data_stream.cpp
+    spill/block_reader.cpp
     spill/log_block_manager.cpp
     spill/file_block_manager.cpp
     spill/hybird_block_manager.cpp

--- a/be/src/exec/pipeline/aggregate/spillable_aggregate_blocking_sink_operator.cpp
+++ b/be/src/exec/pipeline/aggregate/spillable_aggregate_blocking_sink_operator.cpp
@@ -305,6 +305,8 @@ Status SpillableAggregateBlockingSinkOperatorFactory::prepare(RuntimeState* stat
     _spill_options->plan_node_id = _plan_node_id;
     _spill_options->encode_level = state->spill_encode_level();
     _spill_options->wg = state->fragment_ctx()->workgroup();
+    _spill_options->enable_buffer_read = state->enable_spill_buffer_read();
+    _spill_options->max_read_buffer_bytes = state->max_spill_read_buffer_bytes_per_driver();
 
     return Status::OK();
 }

--- a/be/src/exec/pipeline/aggregate/spillable_aggregate_distinct_blocking_operator.cpp
+++ b/be/src/exec/pipeline/aggregate/spillable_aggregate_distinct_blocking_operator.cpp
@@ -154,6 +154,8 @@ Status SpillableAggregateDistinctBlockingSinkOperatorFactory::prepare(RuntimeSta
     _spill_options->plan_node_id = _plan_node_id;
     _spill_options->encode_level = state->spill_encode_level();
     _spill_options->wg = state->fragment_ctx()->workgroup();
+    _spill_options->enable_buffer_read = state->enable_spill_buffer_read();
+    _spill_options->max_read_buffer_bytes = state->max_spill_read_buffer_bytes_per_driver();
 
     return Status::OK();
 }

--- a/be/src/exec/pipeline/hashjoin/spillable_hash_join_build_operator.cpp
+++ b/be/src/exec/pipeline/hashjoin/spillable_hash_join_build_operator.cpp
@@ -267,6 +267,9 @@ Status SpillableHashJoinBuildOperatorFactory::prepare(RuntimeState* state) {
             _hash_joiner_factory->hash_join_param()._distribution_mode == TJoinDistributionMode::LOCAL_HASH_BUCKET ||
             state->fragment_ctx()->enable_adaptive_dop();
 
+    _spill_options->enable_buffer_read = state->enable_spill_buffer_read();
+    _spill_options->max_read_buffer_bytes = state->max_spill_read_buffer_bytes_per_driver();
+
     const auto& param = _hash_joiner_factory->hash_join_param();
 
     _build_side_partition = param._build_expr_ctxs;

--- a/be/src/exec/pipeline/hashjoin/spillable_hash_join_probe_operator.cpp
+++ b/be/src/exec/pipeline/hashjoin/spillable_hash_join_probe_operator.cpp
@@ -533,6 +533,8 @@ Status SpillableHashJoinProbeOperatorFactory::prepare(RuntimeState* state) {
     _spill_options->plan_node_id = _plan_node_id;
     _spill_options->encode_level = state->spill_encode_level();
     _spill_options->wg = state->fragment_ctx()->workgroup();
+    _spill_options->enable_buffer_read = state->enable_spill_buffer_read();
+    _spill_options->max_read_buffer_bytes = state->max_spill_read_buffer_bytes_per_driver();
 
     return Status::OK();
 }

--- a/be/src/exec/pipeline/nljoin/spillable_nljoin_build_operator.cpp
+++ b/be/src/exec/pipeline/nljoin/spillable_nljoin_build_operator.cpp
@@ -97,6 +97,8 @@ Status SpillableNLJoinBuildOperatorFactory::prepare(RuntimeState* state) {
     _spill_options->read_shared = true;
     _spill_options->encode_level = state->spill_encode_level();
     _spill_options->wg = state->fragment_ctx()->workgroup();
+    _spill_options->enable_buffer_read = state->enable_spill_buffer_read();
+    _spill_options->max_read_buffer_bytes = state->max_spill_read_buffer_bytes_per_driver();
 
     return Status::OK();
 }

--- a/be/src/exec/pipeline/sort/spillable_partition_sort_sink_operator.cpp
+++ b/be/src/exec/pipeline/sort/spillable_partition_sort_sink_operator.cpp
@@ -142,6 +142,8 @@ Status SpillablePartitionSortSinkOperatorFactory::prepare(RuntimeState* state) {
     _spill_options->plan_node_id = _plan_node_id;
     _spill_options->encode_level = state->spill_encode_level();
     _spill_options->wg = state->fragment_ctx()->workgroup();
+    _spill_options->enable_buffer_read = state->enable_spill_buffer_read();
+    _spill_options->max_read_buffer_bytes = state->max_spill_read_buffer_bytes_per_driver();
 
     return Status::OK();
 }

--- a/be/src/exec/spill/block_manager.h
+++ b/be/src/exec/spill/block_manager.h
@@ -19,12 +19,14 @@
 #include "common/status.h"
 #include "common/statusor.h"
 #include "gen_cpp/Types_types.h"
+#include "io/input_stream.h"
+#include "util/runtime_profile.h"
 #include "util/slice.h"
 
 namespace starrocks::spill {
 
 class BlockReader;
-
+class BlockReaderOptions;
 // Block represents a continuous storage space and is the smallest storage unit of flush and restore in spill task.
 // Block only supports append writing and sequential reading, and neither writing nor reading of Block is guaranteed to be thread-safe.
 class Block {
@@ -37,7 +39,9 @@ public:
     // flush block to somewhere
     virtual Status flush() = 0;
 
-    virtual std::shared_ptr<BlockReader> get_reader() = 0;
+    virtual StatusOr<std::unique_ptr<io::InputStreamWrapper>> get_readable() const = 0;
+
+    virtual std::shared_ptr<BlockReader> get_reader(const BlockReaderOptions& options) = 0;
 
     virtual std::string debug_string() const = 0;
 
@@ -62,13 +66,24 @@ protected:
 
 using BlockPtr = std::shared_ptr<Block>;
 
+struct BlockReaderOptions {
+    bool enable_buffer_read = false;
+    size_t max_buffer_bytes = std::numeric_limits<size_t>::max();
+
+    RuntimeProfile::Counter* read_io_timer = nullptr;
+    RuntimeProfile::Counter* read_io_count = nullptr;
+    RuntimeProfile::Counter* read_io_bytes = nullptr;
+};
+
 class BlockReader {
 public:
-    BlockReader(const Block* block) : _block(block) {}
+    BlockReader(const Block* block, const BlockReaderOptions& options)
+            : _block(block), _length(block->size()), _options(options) {}
+
     virtual ~BlockReader() = default;
     // read exacly the specified length of data from Block,
     // if the Block has reached the end, should return EndOfFile status
-    virtual Status read_fully(void* data, int64_t count) = 0;
+    virtual Status read_fully(void* data, int64_t count);
 
     virtual std::string debug_string() = 0;
 
@@ -76,6 +91,14 @@ public:
 
 protected:
     const Block* _block = nullptr;
+    std::unique_ptr<io::InputStreamWrapper> _readable;
+    size_t _length = 0;
+    size_t _offset = 0;
+
+    // used for buffer read
+    std::unique_ptr<uint8_t[]> _buffer;
+    Slice _slice;
+    BlockReaderOptions _options;
 };
 
 struct AcquireBlockOptions {

--- a/be/src/exec/spill/block_reader.cpp
+++ b/be/src/exec/spill/block_reader.cpp
@@ -1,0 +1,101 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "common/statusor.h"
+#include "exec/spill/block_manager.h"
+#include "fmt/format.h"
+#include "io/input_stream.h"
+#include "util/slice.h"
+
+namespace starrocks::spill {
+
+// try to read `expected_length` bytes from file, return the actual length read or an error.
+// if at_least_length is set and the actual length read is less than it, an error will be returned.
+// if at_least_length is not set and the actual length read is not equal to expected_length, an error will be returned.
+StatusOr<int64_t> try_to_read_from_file(io::InputStreamWrapper* readable, void* dst, int64_t expected_length,
+                                        int64_t at_least_length = 0) {
+    ASSIGN_OR_RETURN(auto read_len, readable->read(dst, expected_length));
+    RETURN_IF(read_len == 0, Status::EndOfFile("no more data to read"));
+    if (at_least_length > 0) {
+        RETURN_IF(read_len < at_least_length,
+                  Status::InternalError(fmt::format("block's length is mismatched, actual[{}], at least[{}]", read_len,
+                                                    at_least_length)));
+    } else {
+        RETURN_IF(read_len != expected_length,
+                  Status::InternalError(fmt::format("block's length is mismatched, actual[{}], expected[{}]", read_len,
+                                                    expected_length)));
+    }
+    return read_len;
+}
+
+Status BlockReader::read_fully(void* data, int64_t count) {
+    if (_readable == nullptr) {
+        ASSIGN_OR_RETURN(_readable, _block->get_readable());
+        _length = _block->size();
+        // init buffer
+        if (_options.enable_buffer_read) {
+            _options.max_buffer_bytes = std::min(_options.max_buffer_bytes, _length);
+            _buffer = std::make_unique<uint8_t[]>(_options.max_buffer_bytes);
+        }
+    }
+
+    if (_offset + count > _length) {
+        return Status::EndOfFile("no more data in this block");
+    }
+
+    if (_options.enable_buffer_read) {
+        int64_t length_in_buffer = _slice.size;
+        if (length_in_buffer >= count) {
+            // all data can be read from buffer
+            std::memcpy(data, _slice.data, count);
+            _slice.remove_prefix(count);
+        } else {
+            // read partial data from buffer first
+            uint8_t* offset = reinterpret_cast<uint8_t*>(data);
+            if (length_in_buffer > 0) {
+                std::memcpy(offset, _slice.data, length_in_buffer);
+                _slice.remove_prefix(length_in_buffer);
+                offset += length_in_buffer;
+            }
+            int64_t length_need_read = count - length_in_buffer;
+            if (length_need_read >= _options.max_buffer_bytes) {
+                // if res length is larger than max_buffer_bytes, read from file directly
+                SCOPED_TIMER(_options.read_io_timer);
+                COUNTER_UPDATE(_options.read_io_count, 1);
+                ASSIGN_OR_RETURN(auto read_len, try_to_read_from_file(_readable.get(), offset, length_need_read));
+                _slice.clear();
+                COUNTER_UPDATE(_options.read_io_bytes, read_len);
+            } else {
+                // refill buffer, then read res data from buffer
+                SCOPED_TIMER(_options.read_io_timer);
+                COUNTER_UPDATE(_options.read_io_count, 1);
+                ASSIGN_OR_RETURN(auto read_len, try_to_read_from_file(_readable.get(), _buffer.get(),
+                                                                      _options.max_buffer_bytes, length_need_read));
+                _slice = Slice(_buffer.get(), read_len);
+                std::memcpy(offset, _slice.data, length_need_read);
+                _slice.remove_prefix(length_need_read);
+                COUNTER_UPDATE(_options.read_io_bytes, read_len);
+            }
+        }
+    } else {
+        SCOPED_TIMER(_options.read_io_timer);
+        COUNTER_UPDATE(_options.read_io_count, 1);
+        ASSIGN_OR_RETURN(auto read_len, try_to_read_from_file(_readable.get(), data, count));
+        COUNTER_UPDATE(_options.read_io_bytes, read_len);
+    }
+    _offset += count;
+    return Status::OK();
+}
+
+} // namespace starrocks::spill

--- a/be/src/exec/spill/file_block_manager.cpp
+++ b/be/src/exec/spill/file_block_manager.cpp
@@ -16,6 +16,7 @@
 
 #include <utility>
 
+#include "exec/spill/block_manager.h"
 #include "exec/spill/common.h"
 #include "fmt/format.h"
 #include "gen_cpp/Types_types.h"
@@ -142,19 +143,13 @@ StatusOr<FileBlockContainerPtr> FileBlockContainer::create(const DirPtr& dir, co
 
 class FileBlockReader final : public BlockReader {
 public:
-    FileBlockReader(const Block* block) : BlockReader(block), _length(block->size()) {}
-    ~FileBlockReader() override = default;
+    FileBlockReader(const Block* block, const BlockReaderOptions& options = {}) : BlockReader(block, options) {}
 
-    Status read_fully(void* data, int64_t count) override;
+    ~FileBlockReader() override = default;
 
     std::string debug_string() override { return _block->debug_string(); }
 
     const Block* block() const override { return _block; }
-
-private:
-    std::unique_ptr<io::InputStreamWrapper> _readable;
-    size_t _length = 0;
-    size_t _offset = 0;
 };
 
 class FileBlock : public Block {
@@ -175,9 +170,13 @@ public:
 
     Status flush() override { return _container->flush(); }
 
-    StatusOr<std::unique_ptr<io::InputStreamWrapper>> get_readable() const { return _container->get_readable(); }
+    StatusOr<std::unique_ptr<io::InputStreamWrapper>> get_readable() const override {
+        return _container->get_readable();
+    }
 
-    std::shared_ptr<BlockReader> get_reader() override { return std::make_shared<FileBlockReader>(this); }
+    std::shared_ptr<BlockReader> get_reader(const BlockReaderOptions& options) override {
+        return std::make_shared<FileBlockReader>(this, options);
+    }
 
     std::string debug_string() const override {
 #ifndef BE_TEST
@@ -192,24 +191,6 @@ public:
 private:
     FileBlockContainerPtr _container;
 };
-
-Status FileBlockReader::read_fully(void* data, int64_t count) {
-    if (_readable == nullptr) {
-        auto file_block = down_cast<const FileBlock*>(_block);
-        ASSIGN_OR_RETURN(_readable, file_block->get_readable());
-    }
-
-    if (_offset + count > _length) {
-        return Status::EndOfFile("no more data in this block");
-    }
-
-    ASSIGN_OR_RETURN(auto read_len, _readable->read(data, count));
-    RETURN_IF(read_len == 0, Status::EndOfFile("no more data in this block"));
-    RETURN_IF(read_len != count, Status::InternalError(fmt::format(
-                                         "block's length is mismatched, expected: {}, actual: {}", count, read_len)));
-    _offset += count;
-    return Status::OK();
-}
 
 FileBlockManager::FileBlockManager(const TUniqueId& query_id, DirManager* dir_mgr)
         : _query_id(query_id), _dir_mgr(dir_mgr) {}

--- a/be/src/exec/spill/log_block_manager.cpp
+++ b/be/src/exec/spill/log_block_manager.cpp
@@ -17,10 +17,12 @@
 #include <memory>
 #include <mutex>
 #include <optional>
+#include <string_view>
 #include <unordered_map>
 #include <utility>
 
 #include "common/config.h"
+#include "common/status.h"
 #include "exec/spill/block_manager.h"
 #include "exec/spill/common.h"
 #include "fmt/format.h"
@@ -30,6 +32,7 @@
 #include "runtime/exec_env.h"
 #include "storage/options.h"
 #include "util/defer_op.h"
+#include "util/raw_container.h"
 #include "util/uid_util.h"
 
 namespace starrocks::spill {
@@ -162,19 +165,13 @@ StatusOr<LogBlockContainerPtr> LogBlockContainer::create(const DirPtr& dir, cons
 
 class LogBlockReader final : public BlockReader {
 public:
-    LogBlockReader(const Block* block) : BlockReader(block) {}
-    ~LogBlockReader() override = default;
+    LogBlockReader(const Block* block, const BlockReaderOptions& options = {}) : BlockReader(block, options) {}
 
-    Status read_fully(void* data, int64_t count) override;
+    ~LogBlockReader() override = default;
 
     std::string debug_string() override { return _block->debug_string(); }
 
     const Block* block() const override { return _block; }
-
-private:
-    std::unique_ptr<io::InputStreamWrapper> _readable;
-    size_t _offset = 0;
-    size_t _length = 0;
 };
 
 class LogBlock : public Block {
@@ -197,11 +194,13 @@ public:
 
     Status flush() override { return _container->flush(); }
 
-    StatusOr<std::unique_ptr<io::InputStreamWrapper>> get_readable() const {
+    StatusOr<std::unique_ptr<io::InputStreamWrapper>> get_readable() const override {
         return _container->get_readable(_offset, _size);
     }
 
-    std::shared_ptr<BlockReader> get_reader() override { return std::make_shared<LogBlockReader>(this); }
+    std::shared_ptr<BlockReader> get_reader(const BlockReaderOptions& options) override {
+        return std::make_shared<LogBlockReader>(this, options);
+    }
 
     std::string debug_string() const override {
 #ifndef BE_TEST
@@ -219,24 +218,6 @@ private:
     size_t _offset{};
 };
 
-Status LogBlockReader::read_fully(void* data, int64_t count) {
-    if (_readable == nullptr) {
-        auto log_block = down_cast<const LogBlock*>(_block);
-        ASSIGN_OR_RETURN(_readable, log_block->get_readable());
-        _length = log_block->size();
-    }
-
-    if (_offset + count > _length) {
-        return Status::EndOfFile("no more data in this block");
-    }
-
-    ASSIGN_OR_RETURN(auto read_len, _readable->read(data, count));
-    RETURN_IF(read_len == 0, Status::EndOfFile("no more data in this block"));
-    RETURN_IF(read_len != count, Status::InternalError(fmt::format(
-                                         "block's length is mismatched, expected: {}, actual: {}", count, read_len)));
-    _offset += count;
-    return Status::OK();
-}
 LogBlockManager::LogBlockManager(const TUniqueId& query_id, DirManager* dir_mgr)
         : _query_id(std::move(query_id)), _dir_mgr(dir_mgr) {
     _max_container_bytes = config::spill_max_log_block_container_bytes > 0 ? config::spill_max_log_block_container_bytes

--- a/be/src/exec/spill/options.h
+++ b/be/src/exec/spill/options.h
@@ -14,6 +14,7 @@
 
 #pragma once
 
+#include <limits>
 #include <memory>
 
 #include "column/vectorized_fwd.h"
@@ -103,6 +104,9 @@ struct SpilledOptions {
 
     BlockManager* block_manager = nullptr;
     workgroup::WorkGroupPtr wg;
+
+    bool enable_buffer_read = false;
+    size_t max_read_buffer_bytes = UINT64_MAX;
 };
 
 // spill strategy

--- a/be/src/exec/spill/serde.h
+++ b/be/src/exec/spill/serde.h
@@ -104,6 +104,8 @@ public:
 
     static StatusOr<SerdePtr> create_serde(Spiller* parent);
 
+    Spiller* parent() const { return _parent; }
+
 protected:
     Spiller* _parent = nullptr;
 };

--- a/be/src/runtime/runtime_state.h
+++ b/be/src/runtime/runtime_state.h
@@ -36,6 +36,7 @@
 
 #include <atomic>
 #include <fstream>
+#include <limits>
 #include <memory>
 #include <optional>
 #include <string>
@@ -400,6 +401,12 @@ public:
     }
     bool spill_enable_compaction() const {
         return _spill_options.has_value() ? _spill_options->spill_enable_compaction : false;
+    }
+    bool enable_spill_buffer_read() const {
+        return _spill_options.has_value() ? _spill_options->enable_spill_buffer_read : false;
+    }
+    int64_t max_spill_read_buffer_bytes_per_driver() const {
+        return _spill_options.has_value() ? _spill_options->max_spill_read_buffer_bytes_per_driver : INT64_MAX;
     }
 
     bool error_if_overflow() const {

--- a/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
@@ -194,6 +194,8 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
     // spill mode: auto, force
     public static final String SPILL_MODE = "spill_mode";
     public static final String ENABLE_AGG_SPILL_PREAGGREGATION = "enable_agg_spill_preaggregation";
+    public static final String ENABLE_SPILL_BUFFER_READ = "enable_spill_buffer_read";
+    public static final String MAX_SPILL_READ_BUFFER_BYTES_PER_DRIVER = "max_spill_read_buffer_bytes_per_driver";
     // enable table pruning(RBO) in cardinality-preserving joins
     public static final String ENABLE_RBO_TABLE_PRUNE = "enable_rbo_table_prune";
 
@@ -1134,6 +1136,12 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
 
     @VarAttr(name = ENABLE_AGG_SPILL_PREAGGREGATION, flag = VariableMgr.INVISIBLE)
     public boolean enableAggSpillPreaggregation = true;
+
+    @VarAttr(name = ENABLE_SPILL_BUFFER_READ, flag = VariableMgr.INVISIBLE)
+    public boolean enableSpillBufferRead = true;
+
+    @VarAttr(name = MAX_SPILL_READ_BUFFER_BYTES_PER_DRIVER, flag = VariableMgr.INVISIBLE)
+    public long maxSpillReadBufferBytesPerDriver = 1024 * 1024 * 16;
 
     @VarAttr(name = ENABLE_RBO_TABLE_PRUNE)
     private boolean enableRboTablePrune = false;
@@ -3898,7 +3906,8 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
             spillOptions.setSpill_rand_ratio(spillRandRatio);
             spillOptions.setSpill_enable_compaction(spillEnableCompaction);
             spillOptions.setSpill_mode(TSpillMode.valueOf(spillMode.toUpperCase()));
-
+            spillOptions.setEnable_spill_buffer_read(enableSpillBufferRead);
+            spillOptions.setMax_spill_read_buffer_bytes_per_driver(maxSpillReadBufferBytesPerDriver);
             if (enableSpillToRemoteStorage && !spillStorageVolume.isEmpty()) {
                 // find storage volume config
                 GlobalStateMgr globalStateMgr = GlobalStateMgr.getCurrentState();

--- a/gensrc/thrift/InternalService.thrift
+++ b/gensrc/thrift/InternalService.thrift
@@ -166,6 +166,8 @@ struct TSpillOptions {
 
   21: optional bool enable_spill_to_remote_storage;
   22: optional TSpillToRemoteStorageOptions spill_to_remote_storage_options;
+  23: optional bool enable_spill_buffer_read;
+  24: optional i64 max_spill_read_buffer_bytes_per_driver;
 }
 
 // Query options with their respective defaults


### PR DESCRIPTION
## Why I'm doing:

Currently, spill needs to read chunks one by one from the Block during the restore phase. BlockReader has no cache, so an IO request is triggered every time it is read, which is very inefficient on remote storage. 

## What I'm doing:
I support the buffer read function for BlockReader to reduce the number of io requests.

main changes:
1. introduce two session variables `enable_spill_buffer_read` and `max_spill_read_buffer_bytes_per_driver`. `enable_spill_buffer_read` is used to control whether buffer read is enabled, and `max_spill_read_buffer_bytes_per_driver` is used to control the size of buffer data in a single operator.
2. merge the implementation of File/LogBlockReader::read_fully into the base class to reduce redundant code, and support buffer read on this basis

### test result
I tested several more complex queries in tpcds-1t. under force spill mode, all data spill to oss, the number of io requests was significantly reduced, and the time of queries was also significantly reduced.

<table>
    <tr>
        <td></td>
        <td>Query Time(ms)</td>
        <td></td>
        <td></td>
        <td></td>
        <td></td>
        <td></td>
        <td>IO requests</td>
        <td></td>
    </tr>
    <tr>
        <td></td>
        <td>all spill to oss</td>
        <td></td>
        <td></td>
        <td>all spill to local disk</td>
        <td></td>
        <td></td>
        <td></td>
        <td></td>
        <td></td>
    </tr>
    <tr>
        <td></td>
        <td>enable buffer read</td>
        <td>disable buffer read</td>
        <td>speedup</td>
        <td>enable buffer read</td>
        <td>disable buffer read</td>
        <td>speedup</td>
        <td>enable buffer read</td>
        <td>disable buffer read</td>
        <td>Reduce ratio</td>
    </tr>
    <tr>
        <td>QUERY04</td>
        <td>190305</td>
        <td>217614</td>
        <td>114.35%</td>
        <td>192133</td>
        <td>208756</td>
        <td>108.65%</td>
        <td>4649</td>
        <td>100422</td>
        <td>95.37%</td>
    </tr>
    <tr>
        <td>QUERY11</td>
        <td>122376</td>
        <td>142772</td>
        <td>116.67%</td>
        <td>110633</td>
        <td>117879</td>
        <td>106.55%</td>
        <td>3903</td>
        <td>80666</td>
        <td>95.16%</td>
    </tr>
    <tr>
        <td>QUERY23-1</td>
        <td>267710</td>
        <td>600509</td>
        <td>224.31%</td>
        <td>239933</td>
        <td>260251</td>
        <td>108.47%</td>
        <td>40876</td>
        <td>673530</td>
        <td>93.93%</td>
    </tr>
    <tr>
        <td>QUERY23-2</td>
        <td>267012</td>
        <td>566536</td>
        <td>212.18%</td>
        <td>238909</td>
        <td>262279</td>
        <td>109.78%</td>
        <td>41406</td>
        <td>690290</td>
        <td>94.00%</td>
    </tr>
    <tr>
        <td>QUERY51</td>
        <td>34372</td>
        <td>115126</td>
        <td>334.94%</td>
        <td>21126</td>
        <td>22831</td>
        <td>108.07%</td>
        <td>2177</td>
        <td>290784</td>
        <td>99.25%</td>
    </tr>
    <tr>
        <td>QUERY64</td>
        <td>99432</td>
        <td>493314</td>
        <td>496.13%</td>
        <td>91407</td>
        <td>93526</td>
        <td>102.32%</td>
        <td>9784</td>
        <td>709848</td>
        <td>98.62%</td>
    </tr>
    <tr>
        <td>QUERY65</td>
        <td>59704</td>
        <td>208039</td>
        <td>348.45%</td>
        <td>37864</td>
        <td>40907</td>
        <td>108.04%</td>
        <td>4570</td>
        <td>416542</td>
        <td>98.90%</td>
    </tr>
    <tr>
        <td>QUERY67</td>
        <td>322700</td>
        <td>490388</td>
        <td>151.96%</td>
        <td>280088</td>
        <td>313212</td>
        <td>111.83%</td>
        <td>53923</td>
        <td>309864</td>
        <td>82.60%</td>
    </tr>
    <tr>
        <td>QUERY72</td>
        <td>35089</td>
        <td>53000</td>
        <td>151.04%</td>
        <td>22054</td>
        <td>25537</td>
        <td>115.79%</td>
        <td>256</td>
        <td>50404</td>
        <td>99.49%</td>
    </tr>
    <tr>
        <td>QUERY75</td>
        <td>66099</td>
        <td>152452</td>
        <td>230.64%</td>
        <td>55740</td>
        <td>55817</td>
        <td>100.14%</td>
        <td>2958</td>
        <td>209492</td>
        <td>98.59%</td>
    </tr>
    <tr>
        <td>QUERY97</td>
        <td>43632</td>
        <td>257600</td>
        <td>590.39%</td>
        <td>25714</td>
        <td>25319</td>
        <td>98.46%</td>
        <td>1664</td>
        <td>651470</td>
        <td>99.74%</td>
    </tr>
</table>

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
