### PR TITLE
[Enhancement] Allow CN to run script

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/qe/ExecuteScriptExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/ExecuteScriptExecutor.java
@@ -24,7 +24,7 @@ import com.starrocks.proto.ExecuteCommandResultPB;
 import com.starrocks.rpc.BackendServiceClient;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.sql.ast.ExecuteScriptStmt;
-import com.starrocks.system.Backend;
+import com.starrocks.system.ComputeNode;
 import com.starrocks.thrift.TNetworkAddress;
 import groovy.lang.Binding;
 import groovy.lang.GroovyShell;
@@ -79,7 +79,7 @@ public class ExecuteScriptExecutor {
     }
 
     private static ShowResultSet executeBackendScript(ExecuteScriptStmt stmt, ConnectContext ctx) throws UserException {
-        Backend be = GlobalStateMgr.getCurrentState().getNodeMgr().getClusterInfo().getBackend(stmt.getBeId());
+        ComputeNode be = GlobalStateMgr.getCurrentState().getNodeMgr().getClusterInfo().getBackendOrComputeNode(stmt.getBeId());
         if (be == null) {
             throw new UserException("node not found: " + stmt.getBeId());
         }


### PR DESCRIPTION
## Why I'm doing:

```
MySQL [(none)]> admin execute on 10006 'System.print(ExecEnv.get_stack_trace_for_all_threads())';
ERROR 1064 (HY000): node not found: 10006
```

## What I'm doing:

Allow CN to run script


## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [x] 3.2
  - [x] 3.1
  - [x] 3.0
  - [x] 2.5
