### PR TITLE
[BugFix] Multi bytes CSV row/column delimiter for `files()`

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/TableFunctionTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/TableFunctionTable.java
@@ -264,7 +264,7 @@ public class TableFunctionTable extends Table {
 
         if (properties.containsKey(PROPERTY_CSV_COLUMN_SEPARATOR)) {
             csvColumnSeparator = properties.get(PROPERTY_CSV_COLUMN_SEPARATOR);
-            int len  = csvColumnSeparator.getBytes(StandardCharsets.UTF_8).length;
+            int len = csvColumnSeparator.getBytes(StandardCharsets.UTF_8).length;
             if (len > 50 || len == 0) {
                 throw new DdlException("the length of csv.column_separator property should be in [1, 50]");
             }

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/TableFunctionTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/TableFunctionTable.java
@@ -21,6 +21,7 @@ import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
 import com.starrocks.analysis.BrokerDesc;
 import com.starrocks.analysis.DescriptorTable;
+import com.starrocks.common.CsvFormat;
 import com.starrocks.common.DdlException;
 import com.starrocks.common.ErrorCode;
 import com.starrocks.common.ErrorReport;
@@ -265,18 +266,18 @@ public class TableFunctionTable extends Table {
         if (properties.containsKey(PROPERTY_CSV_COLUMN_SEPARATOR)) {
             csvColumnSeparator = properties.get(PROPERTY_CSV_COLUMN_SEPARATOR);
             int len = csvColumnSeparator.getBytes(StandardCharsets.UTF_8).length;
-            if (len > 50 || len == 0) {
-                ErrorReport.reportDdlException(ErrorCode.ERR_VALUE_OUT_OF_VALID_RANGE,
-                        PROPERTY_CSV_COLUMN_SEPARATOR, 1, 50);
+            if (len > CsvFormat.MAX_COLUMN_SEPARATOR_LENGTH || len == 0) {
+                ErrorReport.reportDdlException(ErrorCode.ERR_ILLEGAL_BYTES_LENGTH,
+                        PROPERTY_CSV_COLUMN_SEPARATOR, 1, CsvFormat.MAX_COLUMN_SEPARATOR_LENGTH);
             }
         }
 
         if (properties.containsKey(PROPERTY_CSV_ROW_DELIMITER)) {
             csvRowDelimiter = properties.get(PROPERTY_CSV_ROW_DELIMITER);
             int len = csvRowDelimiter.getBytes(StandardCharsets.UTF_8).length;
-            if (len > 50 || len == 0) {
-                ErrorReport.reportDdlException(ErrorCode.ERR_VALUE_OUT_OF_VALID_RANGE,
-                        PROPERTY_CSV_ROW_DELIMITER, 1, 50);
+            if (len > CsvFormat.MAX_ROW_DELIMITER_LENGTH || len == 0) {
+                ErrorReport.reportDdlException(ErrorCode.ERR_ILLEGAL_BYTES_LENGTH,
+                        PROPERTY_CSV_ROW_DELIMITER, 1, CsvFormat.MAX_ROW_DELIMITER_LENGTH);
             }
         }
 

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/TableFunctionTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/TableFunctionTable.java
@@ -266,7 +266,8 @@ public class TableFunctionTable extends Table {
             csvColumnSeparator = properties.get(PROPERTY_CSV_COLUMN_SEPARATOR);
             int len  = csvColumnSeparator.getBytes(StandardCharsets.UTF_8).length;
             if (len > 50 || len == 0) {
-                throw new DdlException("the length of csv.column_separator property should be in [1, 50]");
+                ErrorReport.reportDdlException(ErrorCode.ERR_VALUE_OUT_OF_VALID_RANGE,
+                        PROPERTY_CSV_COLUMN_SEPARATOR, 1, 50);
             }
         }
 
@@ -274,7 +275,8 @@ public class TableFunctionTable extends Table {
             csvRowDelimiter = properties.get(PROPERTY_CSV_ROW_DELIMITER);
             int len = csvRowDelimiter.getBytes(StandardCharsets.UTF_8).length;
             if (len > 50 || len == 0) {
-                throw new DdlException("the length of csv.row_delimiter property should be in [1, 50]");
+                ErrorReport.reportDdlException(ErrorCode.ERR_VALUE_OUT_OF_VALID_RANGE,
+                        PROPERTY_CSV_ROW_DELIMITER, 1, 50);
             }
         }
 

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/TableFunctionTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/TableFunctionTable.java
@@ -57,6 +57,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.thrift.TException;
 
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -263,10 +264,16 @@ public class TableFunctionTable extends Table {
 
         if (properties.containsKey(PROPERTY_CSV_COLUMN_SEPARATOR)) {
             csvColumnSeparator = properties.get(PROPERTY_CSV_COLUMN_SEPARATOR);
+            if (csvColumnSeparator.getBytes(StandardCharsets.UTF_8).length > 50) {
+                throw new DdlException("the csv.column_separator is limited to maximum of 50 bytes");
+            }
         }
 
         if (properties.containsKey(PROPERTY_CSV_ROW_DELIMITER)) {
             csvRowDelimiter = properties.get(PROPERTY_CSV_ROW_DELIMITER);
+            if (csvRowDelimiter.getBytes(StandardCharsets.UTF_8).length > 50) {
+                throw new DdlException("the csv.row_delimiter is limited to maximum of 50 bytes");
+            }
         }
 
         if (properties.containsKey(PROPERTY_CSV_ENCLOSE)) {
@@ -341,15 +348,15 @@ public class TableFunctionTable extends Table {
         params.setSkip_header(csvSkipHeader);
         params.setTrim_space(csvTrimSpace);
         params.setFlexible_column_mapping(true);
-        if (csvColumnSeparator.length() == 1) {
+        if (csvColumnSeparator.getBytes(StandardCharsets.UTF_8).length == 1) {
             params.setColumn_separator(csvColumnSeparator.getBytes()[0]);
-        } else if (csvColumnSeparator.length() > 1) {
+        } else {
             params.setMulti_column_separator(csvColumnSeparator);
         }
 
-        if (csvRowDelimiter.length() == 1) {
+        if (csvRowDelimiter.getBytes(StandardCharsets.UTF_8).length > 1) {
             params.setRow_delimiter(csvRowDelimiter.getBytes()[0]);
-        } else if (csvRowDelimiter.length() > 1) {
+        } else {
             params.setMulti_row_delimiter(csvRowDelimiter);
         }
 

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/TableFunctionTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/TableFunctionTable.java
@@ -264,15 +264,17 @@ public class TableFunctionTable extends Table {
 
         if (properties.containsKey(PROPERTY_CSV_COLUMN_SEPARATOR)) {
             csvColumnSeparator = properties.get(PROPERTY_CSV_COLUMN_SEPARATOR);
-            if (csvColumnSeparator.getBytes(StandardCharsets.UTF_8).length > 50) {
-                throw new DdlException("the csv.column_separator is limited to maximum of 50 bytes");
+            int len  = csvColumnSeparator.getBytes(StandardCharsets.UTF_8).length;
+            if (len > 50 || len == 0) {
+                throw new DdlException("the length of csv.column_separator property should be in [1, 50]");
             }
         }
 
         if (properties.containsKey(PROPERTY_CSV_ROW_DELIMITER)) {
             csvRowDelimiter = properties.get(PROPERTY_CSV_ROW_DELIMITER);
-            if (csvRowDelimiter.getBytes(StandardCharsets.UTF_8).length > 50) {
-                throw new DdlException("the csv.row_delimiter is limited to maximum of 50 bytes");
+            int len = csvRowDelimiter.getBytes(StandardCharsets.UTF_8).length;
+            if (len > 50 || len == 0) {
+                throw new DdlException("the length of csv.row_delimiter property should be in [1, 50]");
             }
         }
 
@@ -354,7 +356,7 @@ public class TableFunctionTable extends Table {
             params.setMulti_column_separator(csvColumnSeparator);
         }
 
-        if (csvRowDelimiter.getBytes(StandardCharsets.UTF_8).length > 1) {
+        if (csvRowDelimiter.getBytes(StandardCharsets.UTF_8).length == 1) {
             params.setRow_delimiter(csvRowDelimiter.getBytes()[0]);
         } else {
             params.setMulti_row_delimiter(csvRowDelimiter);

--- a/fe/fe-core/src/main/java/com/starrocks/common/CsvFormat.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/CsvFormat.java
@@ -16,6 +16,8 @@
 package com.starrocks.common;
 
 public class CsvFormat {
+    public static final int MAX_COLUMN_SEPARATOR_LENGTH = 50;
+    public static final int MAX_ROW_DELIMITER_LENGTH = 50;
     public CsvFormat(byte enclose, byte escape, long skipheader, boolean trimspace) {
         this.enclose = enclose;
         this.escape = escape;

--- a/fe/fe-core/src/main/java/com/starrocks/common/ErrorCode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/ErrorCode.java
@@ -302,7 +302,7 @@ public enum ErrorCode {
             "Referenced column '%s' in expr '%s' can't be found in column list, derived column is '%s'"),
     ERR_MAPPING_EXPR_INVALID(5602, new byte[] {'4', '2', '0', '0', '0'}, "Expr '%s' analyze error: %s, derived column is '%s'"),
 
-    ERR_VALUE_OUT_OF_VALID_RANGE(5605, new byte[] {'4', '2', '0', '0', '0'}, "The valid bytes length for '%s' is [%d, %d]"),
+    ERR_ILLEGAL_BYTES_LENGTH(5605, new byte[] {'4', '2', '0', '0', '0'}, "The valid bytes length for '%s' is [%d, %d]"),
     /**
      * 10000 - 10099: warehouse
      */

--- a/fe/fe-core/src/main/java/com/starrocks/common/ErrorCode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/ErrorCode.java
@@ -302,7 +302,7 @@ public enum ErrorCode {
             "Referenced column '%s' in expr '%s' can't be found in column list, derived column is '%s'"),
     ERR_MAPPING_EXPR_INVALID(5602, new byte[] {'4', '2', '0', '0', '0'}, "Expr '%s' analyze error: %s, derived column is '%s'"),
 
-    ERR_VALUE_OUT_OF_VALID_RANGE(5605, new byte[] {'4', '2', '0', '0', '0'}, "The valid range of values for '%s' is [%d, %d]"),
+    ERR_VALUE_OUT_OF_VALID_RANGE(5605, new byte[] {'4', '2', '0', '0', '0'}, "The valid bytes length for '%s' is [%d, %d]"),
     /**
      * 10000 - 10099: warehouse
      */

--- a/fe/fe-core/src/main/java/com/starrocks/common/ErrorCode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/ErrorCode.java
@@ -302,6 +302,7 @@ public enum ErrorCode {
             "Referenced column '%s' in expr '%s' can't be found in column list, derived column is '%s'"),
     ERR_MAPPING_EXPR_INVALID(5602, new byte[] {'4', '2', '0', '0', '0'}, "Expr '%s' analyze error: %s, derived column is '%s'"),
 
+    ERR_VALUE_OUT_OF_VALID_RANGE(5605, new byte[] {'4', '2', '0', '0', '0'}, "The valid range of values for '%s' is [%d, %d]"),
     /**
      * 10000 - 10099: warehouse
      */

--- a/fe/fe-core/src/main/java/com/starrocks/common/ErrorReport.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/ErrorReport.java
@@ -99,9 +99,9 @@ public class ErrorReport {
         throw new ValidateException(errorCode.formatErrorMsg(objs), errorType);
     }
 
-    public static void reportUserException(String pattern, ErrorCode errorCode, Object... objs)
+    public static void reportUserException(ErrorCode errorCode, Object... objs)
             throws UserException {
-        throw new UserException(reportCommon(pattern, errorCode, objs));
+        throw new UserException(reportCommon(null, errorCode, objs));
     }
 
     public interface DdlExecutor {

--- a/fe/fe-core/src/main/java/com/starrocks/common/ErrorReport.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/ErrorReport.java
@@ -99,6 +99,11 @@ public class ErrorReport {
         throw new ValidateException(errorCode.formatErrorMsg(objs), errorType);
     }
 
+    public static void reportUserException(String pattern, ErrorCode errorCode, Object... objs)
+            throws UserException {
+        throw new UserException(reportCommon(pattern, errorCode, objs));
+    }
+
     public interface DdlExecutor {
         void apply() throws UserException;
     }

--- a/fe/fe-core/src/main/java/com/starrocks/planner/FileScanNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/FileScanNode.java
@@ -298,13 +298,13 @@ public class FileScanNode extends LoadScanNode {
         byte[] row_delimiter = fileGroup.getRowDelimiter().getBytes(StandardCharsets.UTF_8);
         if (column_separator.length != 1) {
             if (column_separator.length > 50) {
-                ErrorReport.reportUserException("column separator", ErrorCode.ERR_VALUE_OUT_OF_VALID_RANGE, 1, 50);
+                ErrorReport.reportUserException(ErrorCode.ERR_VALUE_OUT_OF_VALID_RANGE, "column separator", 1, 50);
             }
             params.setMulti_column_separator(fileGroup.getColumnSeparator());
         }
         if (row_delimiter.length != 1) {
             if (row_delimiter.length > 50) {
-                ErrorReport.reportUserException("row delimiter", ErrorCode.ERR_VALUE_OUT_OF_VALID_RANGE, 1, 50);
+                ErrorReport.reportUserException(ErrorCode.ERR_VALUE_OUT_OF_VALID_RANGE, "row delimiter", 1, 50);
             }
             params.setMulti_row_delimiter(fileGroup.getRowDelimiter());
         }

--- a/fe/fe-core/src/main/java/com/starrocks/planner/FileScanNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/FileScanNode.java
@@ -60,6 +60,7 @@ import com.starrocks.catalog.TableFunctionTable;
 import com.starrocks.catalog.Type;
 import com.starrocks.common.AnalysisException;
 import com.starrocks.common.Config;
+import com.starrocks.common.CsvFormat;
 import com.starrocks.common.DdlException;
 import com.starrocks.common.ErrorCode;
 import com.starrocks.common.ErrorReport;
@@ -297,14 +298,16 @@ public class FileScanNode extends LoadScanNode {
         byte[] column_separator = fileGroup.getColumnSeparator().getBytes(StandardCharsets.UTF_8);
         byte[] row_delimiter = fileGroup.getRowDelimiter().getBytes(StandardCharsets.UTF_8);
         if (column_separator.length != 1) {
-            if (column_separator.length > 50) {
-                ErrorReport.reportUserException(ErrorCode.ERR_VALUE_OUT_OF_VALID_RANGE, "column separator", 1, 50);
+            if (column_separator.length > CsvFormat.MAX_COLUMN_SEPARATOR_LENGTH) {
+                ErrorReport.reportUserException(ErrorCode.ERR_ILLEGAL_BYTES_LENGTH, "column separator",
+                        1, CsvFormat.MAX_COLUMN_SEPARATOR_LENGTH);
             }
             params.setMulti_column_separator(fileGroup.getColumnSeparator());
         }
         if (row_delimiter.length != 1) {
-            if (row_delimiter.length > 50) {
-                ErrorReport.reportUserException(ErrorCode.ERR_VALUE_OUT_OF_VALID_RANGE, "row delimiter", 1, 50);
+            if (row_delimiter.length > CsvFormat.MAX_ROW_DELIMITER_LENGTH){
+                ErrorReport.reportUserException(ErrorCode.ERR_ILLEGAL_BYTES_LENGTH, "row delimiter",
+                        1, CsvFormat.MAX_ROW_DELIMITER_LENGTH);
             }
             params.setMulti_row_delimiter(fileGroup.getRowDelimiter());
         }

--- a/fe/fe-core/src/main/java/com/starrocks/planner/FileScanNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/FileScanNode.java
@@ -101,7 +101,6 @@ import java.util.PriorityQueue;
 import java.util.Random;
 import java.util.Set;
 import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 import static com.starrocks.catalog.DefaultExpr.SUPPORTED_DEFAULT_FNS;
 
@@ -299,13 +298,13 @@ public class FileScanNode extends LoadScanNode {
         byte[] row_delimiter = fileGroup.getRowDelimiter().getBytes(StandardCharsets.UTF_8);
         if (column_separator.length != 1) {
             if (column_separator.length > 50) {
-                throw new UserException("the column separator is limited to a maximum of 50 bytes");
+                ErrorReport.reportUserException("column separator", ErrorCode.ERR_VALUE_OUT_OF_VALID_RANGE, 1, 50);
             }
             params.setMulti_column_separator(fileGroup.getColumnSeparator());
         }
         if (row_delimiter.length != 1) {
             if (row_delimiter.length > 50) {
-                throw new UserException("the row delimiter is limited to a maximum of 50 bytes");
+                ErrorReport.reportUserException("row delimiter", ErrorCode.ERR_VALUE_OUT_OF_VALID_RANGE, 1, 50);
             }
             params.setMulti_row_delimiter(fileGroup.getRowDelimiter());
         }

--- a/fe/fe-core/src/main/java/com/starrocks/planner/StreamLoadScanNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/StreamLoadScanNode.java
@@ -54,6 +54,8 @@ import com.starrocks.catalog.Table;
 import com.starrocks.catalog.Type;
 import com.starrocks.common.AnalysisException;
 import com.starrocks.common.Config;
+import com.starrocks.common.ErrorCode;
+import com.starrocks.common.ErrorReport;
 import com.starrocks.common.UserException;
 import com.starrocks.load.Load;
 import com.starrocks.load.streamload.StreamLoadInfo;
@@ -198,7 +200,7 @@ public class StreamLoadScanNode extends LoadScanNode {
             byte[] setBytes = sep.getBytes(StandardCharsets.UTF_8);
             params.setColumn_separator(setBytes[0]);
             if (setBytes.length > 50) {
-                throw new UserException("the column separator is limited to a maximum of 50 bytes");
+                ErrorReport.reportUserException("column separator", ErrorCode.ERR_VALUE_OUT_OF_VALID_RANGE, 1, 50);
             }
             if (setBytes.length > 1) {
                 params.setMulti_column_separator(sep);
@@ -211,7 +213,7 @@ public class StreamLoadScanNode extends LoadScanNode {
             byte[] sepBytes = sep.getBytes(StandardCharsets.UTF_8);
             params.setRow_delimiter(sepBytes[0]);
             if (sepBytes.length > 50) {
-                throw new UserException("the row delimiter is limited to a maximum of 50 bytes");
+                ErrorReport.reportUserException("row delimiter", ErrorCode.ERR_VALUE_OUT_OF_VALID_RANGE, 1, 50);
             }
             if (sepBytes.length > 1) {
                 params.setMulti_row_delimiter(sep);

--- a/fe/fe-core/src/main/java/com/starrocks/planner/StreamLoadScanNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/StreamLoadScanNode.java
@@ -54,6 +54,7 @@ import com.starrocks.catalog.Table;
 import com.starrocks.catalog.Type;
 import com.starrocks.common.AnalysisException;
 import com.starrocks.common.Config;
+import com.starrocks.common.CsvFormat;
 import com.starrocks.common.ErrorCode;
 import com.starrocks.common.ErrorReport;
 import com.starrocks.common.UserException;
@@ -199,8 +200,9 @@ public class StreamLoadScanNode extends LoadScanNode {
             String sep = streamLoadInfo.getColumnSeparator().getColumnSeparator();
             byte[] setBytes = sep.getBytes(StandardCharsets.UTF_8);
             params.setColumn_separator(setBytes[0]);
-            if (setBytes.length > 50) {
-                ErrorReport.reportUserException(ErrorCode.ERR_VALUE_OUT_OF_VALID_RANGE, "column separator", 1, 50);
+            if (setBytes.length > CsvFormat.MAX_COLUMN_SEPARATOR_LENGTH) {
+                ErrorReport.reportUserException(ErrorCode.ERR_ILLEGAL_BYTES_LENGTH, "column separator", 1,
+                        CsvFormat.MAX_COLUMN_SEPARATOR_LENGTH);
             }
             if (setBytes.length > 1) {
                 params.setMulti_column_separator(sep);
@@ -212,8 +214,9 @@ public class StreamLoadScanNode extends LoadScanNode {
             String sep = streamLoadInfo.getRowDelimiter().getRowDelimiter();
             byte[] sepBytes = sep.getBytes(StandardCharsets.UTF_8);
             params.setRow_delimiter(sepBytes[0]);
-            if (sepBytes.length > 50) {
-                ErrorReport.reportUserException(ErrorCode.ERR_VALUE_OUT_OF_VALID_RANGE, "row delimiter", 1, 50);
+            if (sepBytes.length > CsvFormat.MAX_ROW_DELIMITER_LENGTH) {
+                ErrorReport.reportUserException(ErrorCode.ERR_ILLEGAL_BYTES_LENGTH, "row delimiter",
+                        1, CsvFormat.MAX_ROW_DELIMITER_LENGTH);
             }
             if (sepBytes.length > 1) {
                 params.setMulti_row_delimiter(sep);

--- a/fe/fe-core/src/main/java/com/starrocks/planner/StreamLoadScanNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/StreamLoadScanNode.java
@@ -200,7 +200,7 @@ public class StreamLoadScanNode extends LoadScanNode {
             byte[] setBytes = sep.getBytes(StandardCharsets.UTF_8);
             params.setColumn_separator(setBytes[0]);
             if (setBytes.length > 50) {
-                ErrorReport.reportUserException("column separator", ErrorCode.ERR_VALUE_OUT_OF_VALID_RANGE, 1, 50);
+                ErrorReport.reportUserException(ErrorCode.ERR_VALUE_OUT_OF_VALID_RANGE, "column separator", 1, 50);
             }
             if (setBytes.length > 1) {
                 params.setMulti_column_separator(sep);
@@ -213,7 +213,7 @@ public class StreamLoadScanNode extends LoadScanNode {
             byte[] sepBytes = sep.getBytes(StandardCharsets.UTF_8);
             params.setRow_delimiter(sepBytes[0]);
             if (sepBytes.length > 50) {
-                ErrorReport.reportUserException("row delimiter", ErrorCode.ERR_VALUE_OUT_OF_VALID_RANGE, 1, 50);
+                ErrorReport.reportUserException(ErrorCode.ERR_VALUE_OUT_OF_VALID_RANGE, "row delimiter", 1, 50);
             }
             if (sepBytes.length > 1) {
                 params.setMulti_row_delimiter(sep);

--- a/fe/fe-core/src/test/java/com/starrocks/catalog/TableFunctionTableTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/TableFunctionTableTest.java
@@ -183,4 +183,34 @@ public class TableFunctionTableTest {
                         "'hdfs://127.0.0.1:9000/file1,hdfs://127.0.0.1:9000/file2'",
                 () -> new TableFunctionTable(properties));
     }
+
+    @Test
+    public void testIllegalDelimiter() throws DdlException {
+        {
+            Map<String, String> properties = newProperties();
+            properties.put("csv.row_delimiter", "0123456789012345678901234567890123456789012345678901234567890");
+            ExceptionChecker.expectThrowsWithMsg(DdlException.class,
+                    "the length of csv.row_delimiter property should be in [1, 50]",
+                    () -> new TableFunctionTable(properties));
+            properties.put("csv.row_delimiter", "");
+            ExceptionChecker.expectThrowsWithMsg(DdlException.class,
+                    "the length of csv.row_delimiter property should be in [1, 50]",
+                    () -> new TableFunctionTable(properties));
+        }
+
+        {
+            Map<String, String> properties = newProperties();
+            properties.put("csv.column_separator", "0123456789012345678901234567890123456789" +
+                    "012345678901234567890");
+            ExceptionChecker.expectThrowsWithMsg(DdlException.class,
+                    "the length of csv.column_separator property should be in [1, 50]",
+                    () -> new TableFunctionTable(properties));
+
+            properties.put("csv.column_separator", "");
+            ExceptionChecker.expectThrowsWithMsg(DdlException.class,
+                    "the length of csv.column_separator property should be in [1, 50]",
+                    () -> new TableFunctionTable(properties));
+            properties.put("csv.column_separator", "");
+        }
+    }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/catalog/TableFunctionTableTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/TableFunctionTableTest.java
@@ -190,11 +190,11 @@ public class TableFunctionTableTest {
             Map<String, String> properties = newProperties();
             properties.put("csv.row_delimiter", "0123456789012345678901234567890123456789012345678901234567890");
             ExceptionChecker.expectThrowsWithMsg(DdlException.class,
-                    "The valid range of values for 'csv.row_delimiter' is [1, 50]",
+                    "The valid bytes length for 'csv.row_delimiter' is [1, 50]",
                     () -> new TableFunctionTable(properties));
             properties.put("csv.row_delimiter", "");
             ExceptionChecker.expectThrowsWithMsg(DdlException.class,
-                    "The valid range of values for 'csv.row_delimiter' is [1, 50]",
+                    "The valid bytes length for 'csv.row_delimiter' is [1, 50]",
                     () -> new TableFunctionTable(properties));
         }
 
@@ -203,12 +203,12 @@ public class TableFunctionTableTest {
             properties.put("csv.column_separator", "0123456789012345678901234567890123456789" +
                     "012345678901234567890");
             ExceptionChecker.expectThrowsWithMsg(DdlException.class,
-                    "The valid range of values for 'csv.column_separator' is [1, 50]",
+                    "The valid bytes length for 'csv.column_separator' is [1, 50]",
                     () -> new TableFunctionTable(properties));
 
             properties.put("csv.column_separator", "");
             ExceptionChecker.expectThrowsWithMsg(DdlException.class,
-                    "The valid range of values for 'csv.column_separator' is [1, 50]",
+                    "The valid bytes length for 'csv.column_separator' is [1, 50]",
                     () -> new TableFunctionTable(properties));
         }
     }

--- a/fe/fe-core/src/test/java/com/starrocks/catalog/TableFunctionTableTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/TableFunctionTableTest.java
@@ -190,11 +190,11 @@ public class TableFunctionTableTest {
             Map<String, String> properties = newProperties();
             properties.put("csv.row_delimiter", "0123456789012345678901234567890123456789012345678901234567890");
             ExceptionChecker.expectThrowsWithMsg(DdlException.class,
-                    "the length of csv.row_delimiter property should be in [1, 50]",
+                    "The valid range of values for 'csv.row_delimiter' is [1, 50]",
                     () -> new TableFunctionTable(properties));
             properties.put("csv.row_delimiter", "");
             ExceptionChecker.expectThrowsWithMsg(DdlException.class,
-                    "the length of csv.row_delimiter property should be in [1, 50]",
+                    "The valid range of values for 'csv.row_delimiter' is [1, 50]",
                     () -> new TableFunctionTable(properties));
         }
 
@@ -203,14 +203,13 @@ public class TableFunctionTableTest {
             properties.put("csv.column_separator", "0123456789012345678901234567890123456789" +
                     "012345678901234567890");
             ExceptionChecker.expectThrowsWithMsg(DdlException.class,
-                    "the length of csv.column_separator property should be in [1, 50]",
+                    "The valid range of values for 'csv.column_separator' is [1, 50]",
                     () -> new TableFunctionTable(properties));
 
             properties.put("csv.column_separator", "");
             ExceptionChecker.expectThrowsWithMsg(DdlException.class,
-                    "the length of csv.column_separator property should be in [1, 50]",
+                    "The valid range of values for 'csv.column_separator' is [1, 50]",
                     () -> new TableFunctionTable(properties));
-            properties.put("csv.column_separator", "");
         }
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/planner/FileScanNodeTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/planner/FileScanNodeTest.java
@@ -547,7 +547,7 @@ public class FileScanNodeTest {
                 2, WarehouseManager.DEFAULT_WAREHOUSE_ID);
         scanNode.setLoadInfo(jobId, txnId, table, brokerDesc, fileGroups, true, loadParallelInstanceNum);
         ExceptionChecker.expectThrowsWithMsg(UserException.class,
-                "The valid range of values for 'column separator' is [1, 50]",
+                "The valid bytes length for 'column separator' is [1, 50]",
                 () -> scanNode.init(analyzer));
     }
     @Test
@@ -592,7 +592,7 @@ public class FileScanNodeTest {
                 2, WarehouseManager.DEFAULT_WAREHOUSE_ID);
         scanNode.setLoadInfo(jobId, txnId, table, brokerDesc, fileGroups, true, loadParallelInstanceNum);
         ExceptionChecker.expectThrowsWithMsg(UserException.class,
-                "The valid range of values for 'row delimiter' is [1, 50]",
+                "The valid bytes length for 'row delimiter' is [1, 50]",
                 () -> scanNode.init(analyzer));
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/planner/FileScanNodeTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/planner/FileScanNodeTest.java
@@ -50,7 +50,6 @@ import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
@@ -504,5 +503,96 @@ public class FileScanNodeTest {
         ExceptionChecker.expectThrowsWithMsg(UserException.class,
                 "No files were found matching the pattern(s) or path(s): 'hdfs://127.0.0.1:9001/file*'",
                 () -> Deencapsulation.invoke(scanNode, "getFileStatusAndCalcInstance"));
+    }
+
+    @Test
+    public void testIllegalColumnSeparator(@Mocked GlobalStateMgr globalStateMgr, @Mocked SystemInfoService systemInfoService,
+                                     @Injectable Database db, @Injectable OlapTable table) {
+        new Expectations() {
+            {
+                GlobalStateMgr.getCurrentState().getNodeMgr().getClusterInfo();
+                result = systemInfoService;
+                systemInfoService.getIdToBackend();
+                result = idToBackend;
+                table.getPartitions();
+                minTimes = 0;
+                result = Arrays.asList(partition);
+                partition.getId();
+                minTimes = 0;
+                result = 0;
+            }
+        };
+
+        // file groups
+        List<BrokerFileGroup> fileGroups = Lists.newArrayList();
+        List<String> files = Lists.newArrayList("hdfs://127.0.0.1:9001/file1", "hdfs://127.0.0.1:9001/file2");
+        DataDescription desc =
+                new DataDescription("testTable", null, files, Lists.newArrayList("c1", "c2"),
+                        null, null, null, false, null);
+        BrokerFileGroup brokerFileGroup = new BrokerFileGroup(desc);
+        Deencapsulation.setField(brokerFileGroup, "columnSeparator",
+                "012345678901234567890123456789012345678901234567890123456789");
+        Deencapsulation.setField(brokerFileGroup, "rowDelimiter", "\n");
+        fileGroups.add(brokerFileGroup);
+
+        // file status
+        List<List<TBrokerFileStatus>> fileStatusesList = Lists.newArrayList();
+        List<TBrokerFileStatus> fileStatusList = Lists.newArrayList();
+        fileStatusesList.add(fileStatusList);
+
+        Analyzer analyzer = new Analyzer(GlobalStateMgr.getCurrentState(), new ConnectContext());
+        DescriptorTable descTable = analyzer.getDescTbl();
+        TupleDescriptor tupleDesc = descTable.createTupleDescriptor("DestTableTuple");
+        FileScanNode scanNode = new FileScanNode(new PlanNodeId(0), tupleDesc, "FileScanNode", fileStatusesList,
+                2, WarehouseManager.DEFAULT_WAREHOUSE_ID);
+        scanNode.setLoadInfo(jobId, txnId, table, brokerDesc, fileGroups, true, loadParallelInstanceNum);
+        ExceptionChecker.expectThrowsWithMsg(UserException.class,
+                "The valid range of values for 'column separator' is [1, 50]",
+                () -> scanNode.init(analyzer));
+    }
+    @Test
+    public void testIllegalRowDelimiter(@Mocked GlobalStateMgr globalStateMgr, @Mocked SystemInfoService systemInfoService,
+                                           @Injectable Database db, @Injectable OlapTable table) {
+        new Expectations() {
+            {
+                GlobalStateMgr.getCurrentState().getNodeMgr().getClusterInfo();
+                result = systemInfoService;
+                systemInfoService.getIdToBackend();
+                result = idToBackend;
+                table.getPartitions();
+                minTimes = 0;
+                result = Arrays.asList(partition);
+                partition.getId();
+                minTimes = 0;
+                result = 0;
+            }
+        };
+
+        // file groups
+        List<BrokerFileGroup> fileGroups = Lists.newArrayList();
+        List<String> files = Lists.newArrayList("hdfs://127.0.0.1:9001/file1", "hdfs://127.0.0.1:9001/file2");
+        DataDescription desc =
+                new DataDescription("testTable", null, files, Lists.newArrayList("c1", "c2"),
+                        null, null, null, false, null);
+        BrokerFileGroup brokerFileGroup = new BrokerFileGroup(desc);
+        Deencapsulation.setField(brokerFileGroup, "rowDelimiter",
+                "012345678901234567890123456789012345678901234567890123456789");
+        Deencapsulation.setField(brokerFileGroup, "columnSeparator", "\t");
+        fileGroups.add(brokerFileGroup);
+
+        // file status
+        List<List<TBrokerFileStatus>> fileStatusesList = Lists.newArrayList();
+        List<TBrokerFileStatus> fileStatusList = Lists.newArrayList();
+        fileStatusesList.add(fileStatusList);
+
+        Analyzer analyzer = new Analyzer(GlobalStateMgr.getCurrentState(), new ConnectContext());
+        DescriptorTable descTable = analyzer.getDescTbl();
+        TupleDescriptor tupleDesc = descTable.createTupleDescriptor("DestTableTuple");
+        FileScanNode scanNode = new FileScanNode(new PlanNodeId(0), tupleDesc, "FileScanNode", fileStatusesList,
+                2, WarehouseManager.DEFAULT_WAREHOUSE_ID);
+        scanNode.setLoadInfo(jobId, txnId, table, brokerDesc, fileGroups, true, loadParallelInstanceNum);
+        ExceptionChecker.expectThrowsWithMsg(UserException.class,
+                "The valid range of values for 'row delimiter' is [1, 50]",
+                () -> scanNode.init(analyzer));
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/planner/StreamLoadScanNodeTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/planner/StreamLoadScanNodeTest.java
@@ -107,6 +107,8 @@ public class StreamLoadScanNodeTest {
         TStreamLoadPutRequest request = new TStreamLoadPutRequest();
         request.setFileType(TFileType.FILE_STREAM);
         request.setFormatType(TFileFormatType.FORMAT_CSV_PLAIN);
+        request.setColumnSeparator(",");
+        request.setRowDelimiter("\n");
         return request;
     }
 


### PR DESCRIPTION
## Why I'm doing:
Now, `files` cannot handle CSV multi-byte delimiter correctly. 

## What I'm doing:
Fixes https://github.com/StarRocks/StarRocksTest/issues/7268
This PR including following changes:
1. It corrects the CSV format multi bytes delimiter for `files()`
2. It improves the error message for the delimiter longer than 50 bytes. The new error message will be  `The valid bytes length for 'csv.row_delimiter' is [1, 50]` and `The valid bytes length for 'csv.column_separator' is [1, 50]`.


## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
