### PR TITLE
[BugFix] fix ctas and statistics collect issues on temporary tables

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/qe/StmtExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/StmtExecutor.java
@@ -806,8 +806,10 @@ public class StmtExecutor {
 
     private void dropTableCreatedByCTAS(CreateTableAsSelectStmt stmt) throws Exception {
         if (stmt instanceof CreateTemporaryTableAsSelectStmt) {
-            DDLStmtExecutor.execute(new DropTemporaryTableStmt(
-                    true, stmt.getCreateTableStmt().getDbTbl(), true), context);
+            DropTemporaryTableStmt dropTemporaryTableStmt =
+                    new DropTemporaryTableStmt(true, stmt.getCreateTableStmt().getDbTbl(), true);
+            dropTemporaryTableStmt.setSessionId(context.getSessionId());
+            DDLStmtExecutor.execute(dropTemporaryTableStmt, context);
         } else {
             DDLStmtExecutor.execute(new DropTableStmt(
                     true, stmt.getCreateTableStmt().getDbTbl(), true), context);

--- a/fe/fe-core/src/main/java/com/starrocks/service/FrontendServiceImpl.java
+++ b/fe/fe-core/src/main/java/com/starrocks/service/FrontendServiceImpl.java
@@ -2019,7 +2019,7 @@ public class FrontendServiceImpl implements FrontendService.Iface {
             }
             if (mutablePartitions.size() <= 1) {
                 GlobalStateMgr.getCurrentState().getLocalMetastore()
-                        .addSubPartitions(db, olapTable.getName(), partition, 1);
+                        .addSubPartitions(db, olapTable, partition, 1);
             }
             p.setImmutable(true);
         }

--- a/fe/fe-core/src/main/java/com/starrocks/statistic/FullStatisticsCollectJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/statistic/FullStatisticsCollectJob.java
@@ -21,6 +21,7 @@ import com.starrocks.analysis.IntLiteral;
 import com.starrocks.analysis.StringLiteral;
 import com.starrocks.analysis.TableName;
 import com.starrocks.catalog.Database;
+import com.starrocks.catalog.OlapTable;
 import com.starrocks.catalog.Partition;
 import com.starrocks.catalog.Table;
 import com.starrocks.catalog.Type;
@@ -87,6 +88,9 @@ public class FullStatisticsCollectJob extends StatisticsCollectJob {
         int parallelism = Math.max(1, context.getSessionVariable().getStatisticCollectParallelism());
         List<List<String>> collectSQLList = buildCollectSQLList(parallelism);
         long totalCollectSQL = collectSQLList.size();
+        if (table.isTemporaryTable()) {
+            context.setSessionId(((OlapTable) table).getSessionId());
+        }
 
         // First, the collection task is divided into several small tasks according to the column name and partition,
         // and then the multiple small tasks are aggregated into several tasks

--- a/fe/fe-core/src/main/java/com/starrocks/statistic/HistogramStatisticsCollectJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/statistic/HistogramStatisticsCollectJob.java
@@ -16,6 +16,7 @@ package com.starrocks.statistic;
 
 import com.google.common.base.Joiner;
 import com.starrocks.catalog.Database;
+import com.starrocks.catalog.OlapTable;
 import com.starrocks.catalog.Table;
 import com.starrocks.catalog.Type;
 import com.starrocks.common.Config;
@@ -69,7 +70,9 @@ public class HistogramStatisticsCollectJob extends StatisticsCollectJob {
 
         long finishedSQLNum = 0;
         long totalCollectSQL = columnNames.size();
-
+        if (table.isTemporaryTable()) {
+            context.setSessionId(((OlapTable) table).getSessionId());
+        }
         for (int i = 0; i < columnNames.size(); i++) {
             String columnName = columnNames.get(i);
             Type columnType = columnTypes.get(i);

--- a/fe/fe-core/src/main/java/com/starrocks/statistic/SampleStatisticsCollectJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/statistic/SampleStatisticsCollectJob.java
@@ -17,6 +17,7 @@ package com.starrocks.statistic;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
 import com.starrocks.catalog.Database;
+import com.starrocks.catalog.OlapTable;
 import com.starrocks.catalog.Partition;
 import com.starrocks.catalog.Table;
 import com.starrocks.catalog.Type;
@@ -93,6 +94,9 @@ public class SampleStatisticsCollectJob extends StatisticsCollectJob {
         List<List<Type>> collectTypeList = Lists.partition(columnTypes, splitSize);
         long finishedSQLNum = 0;
         long totalCollectSQL = collectSQLList.size();
+        if (table.isTemporaryTable()) {
+            context.setSessionId(((OlapTable) table).getSessionId());
+        }
 
         for (int i = 0; i < collectSQLList.size(); i++) {
             String sql = buildSampleInsertSQL(db.getId(), table.getId(), collectSQLList.get(i), collectTypeList.get(i),

--- a/fe/fe-core/src/test/java/com/starrocks/alter/AlterTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/alter/AlterTest.java
@@ -1056,11 +1056,11 @@ public class AlterTest {
         Assert.assertTrue(partition.isPresent());
         Assert.assertEquals(table.getPhysicalPartitions().size(), 1);
 
-        GlobalStateMgr.getCurrentState().getLocalMetastore().addSubPartitions(db, table.getName(), partition.get(), 1);
+        GlobalStateMgr.getCurrentState().getLocalMetastore().addSubPartitions(db, table, partition.get(), 1);
         Assert.assertEquals(partition.get().getSubPartitions().size(), 2);
         Assert.assertEquals(table.getPhysicalPartitions().size(), 2);
 
-        GlobalStateMgr.getCurrentState().getLocalMetastore().addSubPartitions(db, table.getName(), partition.get(), 2);
+        GlobalStateMgr.getCurrentState().getLocalMetastore().addSubPartitions(db, table, partition.get(), 2);
         Assert.assertEquals(partition.get().getSubPartitions().size(), 4);
         Assert.assertEquals(table.getPhysicalPartitions().size(), 4);
 
@@ -1111,14 +1111,14 @@ public class AlterTest {
         Partition partition = table.getPartition("p20140101");
         Assert.assertNotNull(partition);
 
-        GlobalStateMgr.getCurrentState().getLocalMetastore().addSubPartitions(db, table.getName(), partition, 1);
+        GlobalStateMgr.getCurrentState().getLocalMetastore().addSubPartitions(db, table, partition, 1);
         Assert.assertEquals(table.getPhysicalPartitions().size(), 4);
         Assert.assertEquals(partition.getSubPartitions().size(), 2);
 
         partition = table.getPartition("p20140103");
         Assert.assertNotNull(partition);
 
-        GlobalStateMgr.getCurrentState().getLocalMetastore().addSubPartitions(db, table.getName(), partition, 2);
+        GlobalStateMgr.getCurrentState().getLocalMetastore().addSubPartitions(db, table, partition, 2);
         Assert.assertEquals(table.getPhysicalPartitions().size(), 6);
         Assert.assertEquals(partition.getSubPartitions().size(), 3);
 
@@ -1155,7 +1155,7 @@ public class AlterTest {
         Assert.assertTrue(partition.isPresent());
         Assert.assertEquals(table.getPhysicalPartitions().size(), 1);
 
-        GlobalStateMgr.getCurrentState().getLocalMetastore().addSubPartitions(db, table.getName(), partition.get(), 1);
+        GlobalStateMgr.getCurrentState().getLocalMetastore().addSubPartitions(db, table, partition.get(), 1);
     }
 
     @Test

--- a/test/sql/test_temporary_table/R/temporary_table
+++ b/test/sql/test_temporary_table/R/temporary_table
@@ -150,6 +150,10 @@ E: (1050, "Getting analyzing error. Detail message: Table 't1' already exists.")
 create temporary table if not exists `t1` as select * from `t0`;
 -- result:
 -- !result
+create temporary table `t2` as select /*+ SET_VAR(query_mem_limit=1)*/ * from `t0`;
+-- result:
+[REGEX].exceed limit*
+-- !result
 show create table `t1`;
 -- result:
 t1	CREATE TEMPORARY TABLE `t1` (

--- a/test/sql/test_temporary_table/T/temporary_table
+++ b/test/sql/test_temporary_table/T/temporary_table
@@ -59,6 +59,7 @@ insert into `t0` values (1,1),(2,2),(3,3);
 create temporary table `t1` as select * from `t0`;
 create temporary table `t1` as select * from `t0`;
 create temporary table if not exists `t1` as select * from `t0`;
+create temporary table `t2` as select /*+ SET_VAR(query_mem_limit=1)*/ * from `t0`;
 show create table `t1`;
 show tables;
 show temporary tables;


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:

fix some bugs on temporary table

1. set session id on DropTemporaryTableStmt so that the temporary table can be dropped correctly when ctas failed
2. set session id before executing statistics collect job for temporary table to make sure all async job can be success.
3. change parameters type of `LocalMetaStore.addSubPartitions` so that it can work well on temporary table.

Modify the parameter type of interface a so that it can work normally on temporary tables

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
