### PR TITLE
[Enhancement] Optimize automatic partition concurrent create partition

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/CatalogUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/CatalogUtils.java
@@ -26,9 +26,13 @@ import com.starrocks.common.InvalidOlapTableStateException;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.server.RunMode;
 import com.starrocks.sql.analyzer.SemanticException;
+import com.starrocks.sql.ast.AddPartitionClause;
+import com.starrocks.sql.ast.ListPartitionDesc;
 import com.starrocks.sql.ast.MultiItemListPartitionDesc;
 import com.starrocks.sql.ast.PartitionDesc;
+import com.starrocks.sql.ast.RangePartitionDesc;
 import com.starrocks.sql.ast.SingleItemListPartitionDesc;
+import com.starrocks.sql.ast.SingleRangePartitionDesc;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -39,6 +43,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.TreeSet;
 import java.util.stream.Collectors;
 
 import static com.starrocks.sql.common.ErrorMsgProxy.PARSER_ERROR_MSG;
@@ -88,6 +93,25 @@ public class CatalogUtils {
             }
         }
         return existPartitionNameSet;
+    }
+
+    public static Set<String> getPartitionNamesFromAddPartitionClause(AddPartitionClause addPartitionClause) {
+        Set<String> partitionNames = new TreeSet<>();
+        PartitionDesc partitionDesc = addPartitionClause.getPartitionDesc();
+        if (partitionDesc instanceof SingleItemListPartitionDesc
+                || partitionDesc instanceof MultiItemListPartitionDesc
+                || partitionDesc instanceof SingleRangePartitionDesc) {
+            partitionNames.add(partitionDesc.getPartitionName());
+        } else if (partitionDesc instanceof RangePartitionDesc) {
+            for (PartitionDesc desc : ((RangePartitionDesc) partitionDesc).getSingleRangePartitionDescs()) {
+                partitionNames.add(desc.getPartitionName());
+            }
+        } else if (partitionDesc instanceof ListPartitionDesc) {
+            for (PartitionDesc desc : (((ListPartitionDesc) partitionDesc).getPartitionDescs())) {
+                partitionNames.add(desc.getPartitionName());
+            }
+        }
+        return partitionNames;
     }
 
     // Used to temporarily disable some command on lake table and remove later.

--- a/fe/fe-core/src/main/java/com/starrocks/service/FrontendServiceImpl.java
+++ b/fe/fe-core/src/main/java/com/starrocks/service/FrontendServiceImpl.java
@@ -48,6 +48,7 @@ import com.starrocks.analysis.TableName;
 import com.starrocks.analysis.TupleDescriptor;
 import com.starrocks.analysis.TupleId;
 import com.starrocks.authentication.AuthenticationMgr;
+import com.starrocks.catalog.CatalogUtils;
 import com.starrocks.catalog.Column;
 import com.starrocks.catalog.Database;
 import com.starrocks.catalog.InternalCatalog;
@@ -2271,7 +2272,22 @@ public class FrontendServiceImpl implements FrontendService.Iface {
 
         GlobalStateMgr state = GlobalStateMgr.getCurrentState();
 
+        TransactionState txnState = state.getGlobalTransactionMgr().getTransactionState(db.getId(), request.getTxn_id());
+        if (txnState == null) {
+            errorStatus.setError_msgs(Lists.newArrayList(
+                    String.format("automatic create partition failed. error: txn %d not exist", request.getTxn_id())));
+            result.setStatus(errorStatus);
+            return result;
+        }
+
+        Set<String> creatingPartitionNames = CatalogUtils.getPartitionNamesFromAddPartitionClause(addPartitionClause);
+
         try {
+            // creating partition names is ordered
+            for (String partitionName : creatingPartitionNames) {
+                txnState.lockCreatePartition(partitionName);
+            }
+
             // ingestion is top priority, if schema change or rollup is running, cancel it
             try {
                 if (olapTable.getState() == OlapTable.OlapTableState.ROLLUP) {
@@ -2294,6 +2310,7 @@ public class FrontendServiceImpl implements FrontendService.Iface {
             } catch (Exception e) {
                 LOG.warn("cancel schema change or rollup failed. error: {}", e.getMessage());
             }
+
             state.getLocalMetastore().addPartitions(db, olapTable.getName(), addPartitionClause);
         } catch (Exception e) {
             LOG.warn(e);
@@ -2301,20 +2318,15 @@ public class FrontendServiceImpl implements FrontendService.Iface {
                     String.format("automatic create partition failed. error:%s", e.getMessage())));
             result.setStatus(errorStatus);
             return result;
+        } finally {
+            for (String partitionName : creatingPartitionNames) {
+                txnState.unlockCreatePartition(partitionName);
+            }
         }
 
         // build partition & tablets
         List<TOlapTablePartition> partitions = Lists.newArrayList();
         List<TTabletLocation> tablets = Lists.newArrayList();
-
-        TransactionState txnState =
-                GlobalStateMgr.getCurrentState().getGlobalTransactionMgr().getTransactionState(db.getId(), request.getTxn_id());
-        if (txnState == null) {
-            errorStatus.setError_msgs(Lists.newArrayList(
-                    String.format("automatic create partition failed. error: txn %d not exist", request.getTxn_id())));
-            result.setStatus(errorStatus);
-            return result;
-        }
 
         if (txnState.getTransactionStatus().isFinalStatus()) {
             errorStatus.setError_msgs(Lists.newArrayList(

--- a/fe/fe-core/src/main/java/com/starrocks/transaction/TransactionState.java
+++ b/fe/fe-core/src/main/java/com/starrocks/transaction/TransactionState.java
@@ -78,6 +78,8 @@ import java.util.Set;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReentrantLock;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
 import javax.annotation.Nullable;
 import javax.validation.constraints.NotNull;
@@ -340,6 +342,7 @@ public class TransactionState implements Writable {
     // Therefore, a snapshot of this information is maintained here.
     private ConcurrentMap<String, TOlapTablePartition> partitionNameToTPartition = Maps.newConcurrentMap();
     private ConcurrentMap<Long, TTabletLocation> tabletIdToTTabletLocation = Maps.newConcurrentMap();
+    private Map<String, Lock> createPartitionLocks = Maps.newHashMap();
 
     private final ReentrantReadWriteLock txnLock = new ReentrantReadWriteLock(true);
 
@@ -1011,6 +1014,28 @@ public class TransactionState implements Writable {
     public void clearAutomaticPartitionSnapshot() {
         partitionNameToTPartition.clear();
         tabletIdToTTabletLocation.clear();
+    }
+
+    public void lockCreatePartition(String partitionName) {
+        Lock locker = null;
+        synchronized (createPartitionLocks) {
+            locker = createPartitionLocks.get(partitionName);
+            if (locker == null) {
+                locker = new ReentrantLock();
+                createPartitionLocks.put(partitionName, locker);
+            }
+        }
+        locker.lock();
+    }
+
+    public void unlockCreatePartition(String partitionName) {
+        Lock locker = null;
+        synchronized (createPartitionLocks) {
+            locker = createPartitionLocks.get(partitionName);
+        }
+        if (locker != null) {
+            locker.unlock();
+        }
     }
 
     @Override

--- a/fe/fe-core/src/test/java/com/starrocks/service/FrontendServiceImplTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/service/FrontendServiceImplTest.java
@@ -1184,6 +1184,12 @@ public class FrontendServiceImplTest {
 
     @Test
     public void testAddListPartitionConcurrency() throws UserException, TException {
+        new MockUp<GlobalTransactionMgr>() {
+            @Mock
+            public TransactionState getTransactionState(long dbId, long transactionId) {
+                return new TransactionState();
+            }
+        };
 
         Database db = GlobalStateMgr.getCurrentState().getDb("test");
         Table table = db.getTable("site_access_list");

--- a/test/sql/test_automatic_partition/R/test_automatic_partition_concurrent
+++ b/test/sql/test_automatic_partition/R/test_automatic_partition_concurrent
@@ -1,0 +1,41 @@
+-- name: test_concurrent_create_partition
+create table t(k int) distributed by random buckets 120;
+-- result:
+-- !result
+insert into t select 1 FROM TABLE(generate_series(1,  4096));
+-- result:
+-- !result
+insert into t select 2 FROM TABLE(generate_series(1,  4096));
+-- result:
+-- !result
+insert into t select 3 FROM TABLE(generate_series(1,  4096));
+-- result:
+-- !result
+create table t1(k int not null) partition by (k);
+-- result:
+-- !result
+set pipeline_dop=16;
+-- result:
+-- !result
+insert into t1 select * from t;
+-- result:
+-- !result
+show create table t1;
+-- result:
+t1	CREATE TABLE `t1` (
+  `k` int(11) NOT NULL COMMENT ""
+) ENGINE=OLAP 
+DUPLICATE KEY(`k`)
+PARTITION BY (`k`)
+DISTRIBUTED BY RANDOM
+PROPERTIES (
+"bucket_size" = "4294967296",
+"compression" = "LZ4",
+"fast_schema_evolution" = "true",
+"replicated_storage" = "true",
+"replication_num" = "3"
+);
+-- !result
+set pipeline_dop=0;
+-- result:
+-- !result

--- a/test/sql/test_automatic_partition/T/test_automatic_partition_concurrent
+++ b/test/sql/test_automatic_partition/T/test_automatic_partition_concurrent
@@ -1,0 +1,10 @@
+-- name: test_concurrent_create_partition
+create table t(k int) distributed by random buckets 120;
+insert into t select 1 FROM TABLE(generate_series(1,  4096));
+insert into t select 2 FROM TABLE(generate_series(1,  4096));
+insert into t select 3 FROM TABLE(generate_series(1,  4096));
+create table t1(k int not null) partition by (k);
+set pipeline_dop=16;
+insert into t1 select * from t;
+show create table t1;
+set pipeline_dop=0;


### PR DESCRIPTION
## Why I'm doing:
Currently, multiple parallel automatic create partition requests will result in the simultaneous creation of multiple identical partitions. Although only one partition is eventually effective when updating the metadata, this consumes a significant amount of resources. Therefore, we implement locking based on partition name before creating the partition to ensure that only one request is made to create a partition.

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [x] 3.2
  - [x] 3.1
  - [ ] 3.0
  - [ ] 2.5
