### PR TITLE
[BugFix] fix bug of array_genearate

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/ExpressionAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/ExpressionAnalyzer.java
@@ -1315,8 +1315,7 @@ public class ExpressionAnalyzer {
                         if ((expr instanceof SlotRef) && node.getChildren().size() != 3) {
                             throw new SemanticException(fnName + " with IntColumn doesn't support default parameters");
                         }
-                        if (!(expr instanceof IntLiteral) && !(expr instanceof LargeIntLiteral) &&
-                                !(expr instanceof SlotRef) && !(expr instanceof NullLiteral)) {
+                        if (!(expr.getType().isFixedPointType())) {
                             throw new SemanticException(fnName + "'s parameter only support Integer");
                         }
                     }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/ExpressionAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/ExpressionAnalyzer.java
@@ -1315,7 +1315,7 @@ public class ExpressionAnalyzer {
                         if ((expr instanceof SlotRef) && node.getChildren().size() != 3) {
                             throw new SemanticException(fnName + " with IntColumn doesn't support default parameters");
                         }
-                        if (!(expr.getType().isFixedPointType())) {
+                        if (!(expr.getType().isFixedPointType()) && !expr.getType().isNull()) {
                             throw new SemanticException(fnName + "'s parameter only support Integer");
                         }
                     }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AnalyzeArrayTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AnalyzeArrayTest.java
@@ -59,6 +59,8 @@ public class AnalyzeArrayTest {
         analyzeSuccess("select array_generate(9)");
         analyzeSuccess("select array_generate(1,9999999999999999)");
         analyzeSuccess("select array_generate(1,9999999999999999, 10000)");
+        analyzeSuccess("select array_generate(1,NULL,1)");
+        analyzeSuccess("select array_generate(1,NULL)");
         analyzeSuccess(" select array_generate(1, array_length([1,2,3]),1)");
         analyzeFail("select array_generate()");
         analyzeFail("select array_generate('c')");

--- a/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AnalyzeArrayTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AnalyzeArrayTest.java
@@ -59,8 +59,7 @@ public class AnalyzeArrayTest {
         analyzeSuccess("select array_generate(9)");
         analyzeSuccess("select array_generate(1,9999999999999999)");
         analyzeSuccess("select array_generate(1,9999999999999999, 10000)");
-        analyzeSuccess("select array_generate(1,NULL,1)");
-        analyzeSuccess("select array_generate(1,NULL)");
+        analyzeSuccess(" select array_generate(1, array_length([1,2,3]),1)");
         analyzeFail("select array_generate()");
         analyzeFail("select array_generate('c')");
         analyzeFail("select array_generate(a,b) from t");

--- a/test/sql/test_array/R/test_array
+++ b/test/sql/test_array/R/test_array
@@ -3,6 +3,7 @@ select ARRAY<INT>[], [], ARRAY<STRING>['abc'], [123, NULL, 1.0], ['abc', NULL];
 -- result:
 []	[]	["abc"]	[123.0,null,1.0]	["abc",null]
 -- !result
+
 -- name: testArrayPredicate
 CREATE TABLE array_data_type
     (c1 int,
@@ -85,6 +86,7 @@ select * from (select array_map(x -> x*2 + x*2, [1,3]) col1) t1 join (select arr
 [4,12]	None
 [4,12]	[88,44,132]
 -- !result
+
 -- name: testArrayVarchar
 CREATE TABLE array_data_type_1
     (c1 int,
@@ -136,6 +138,7 @@ None
 None
 None
 -- !result
+
 -- name: testArrayTopN
 CREATE TABLE array_top_n
     (c1 int,
@@ -187,6 +190,7 @@ select * from array_top_n order by c2[1] limit 4,10;
 select * from array_top_n order by c2[1] limit 5,10;
 -- result:
 -- !result
+
 -- name: testArrayExpr
 CREATE TABLE array_exprr
     (
@@ -206,6 +210,7 @@ select count([CAST(if(c2 is null, c1 + c2, 0) as DECIMAL128(38,0)) + if(c1 is nu
 -- result:
 13336
 -- !result
+
 -- name: testEmptyArray
 with t0 as (
     select c1 from (values([])) as t(c1)
@@ -278,4 +283,42 @@ insert into t2 values
 select aad_1 != aas_1  from t2;
 -- result:
 1
+-- !result
+
+-- name: test_array_generate
+select array_generate(1, array_length([1,2,3]),1);
+-- result:
+[1,2,3]
+-- !result
+select array_generate(1, NULL,1);
+-- result:
+None
+-- !result
+select array_generate(NULL,1,1);
+-- result:
+None
+-- !result
+select array_generate(1,1,NULL);
+-- result:
+None
+-- !result
+select array_generate(1,9);
+-- result:
+[1,2,3,4,5,6,7,8,9]
+-- !result
+select array_generate(9,1);
+-- result:
+[9,8,7,6,5,4,3,2,1]
+-- !result
+select array_generate(9);
+-- result:
+[1,2,3,4,5,6,7,8,9]
+-- !result
+select array_generate(3,3);
+-- result:
+[3]
+-- !result
+select array_generate(3,2,1);
+-- result:
+[]
 -- !result

--- a/test/sql/test_array/T/test_array
+++ b/test/sql/test_array/T/test_array
@@ -152,3 +152,14 @@ insert into t2 values
 (1, [[["10"],["20"],["30"]],[["60"],["5"],["4"]],[["-100","-2"],["-20","10"],["100","23"]]], [[[1.00],[2.00],[3.00]],[[6.00],[5.00],[4.00]],[[-1.00,-2.00],[-2.00,10.00],[100.00,23.00]]]);
 
 select aad_1 != aas_1  from t2;
+
+-- name: test_array_generate
+select array_generate(1, array_length([1,2,3]),1);
+select array_generate(1, NULL,1);
+select array_generate(NULL,1,1);
+select array_generate(1,1,NULL);
+select array_generate(1,9);
+select array_generate(9,1);
+select array_generate(9);
+select array_generate(3,3);
+select array_generate(3,2,1);


### PR DESCRIPTION
## Why I'm doing:
StarRocks > select array_generate(1, array_length([1,2,3]),1);
ERROR 1064 (HY000): Getting analyzing error. Detail message: array_generate's parameter only support Integer.

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
- [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [x] 3.2
  - [x] 3.1
  - [x] 3.0
  - [ ] 2.5
