### PR TITLE
[BugFix]nullable column xor_checksum always calc the whole column

### DIFF
--- a/be/src/column/nullable_column.cpp
+++ b/be/src/column/nullable_column.cpp
@@ -397,12 +397,11 @@ int64_t NullableColumn::xor_checksum(uint32_t from, uint32_t to) const {
     }
 
     int64_t xor_checksum = 0;
-    size_t num = _null_column->size();
     uint8_t* src = _null_column->get_data().data();
 
     // The XOR of NullableColumn
     // XOR all the 8-bit integers one by one
-    for (size_t i = 0; i < num; ++i) {
+    for (size_t i = from; i < to; ++i) {
         xor_checksum ^= src[i];
         if (!src[i]) {
             xor_checksum ^= _data_column->xor_checksum(static_cast<uint32_t>(i), static_cast<uint32_t>(i + 1));

--- a/be/test/column/nullable_column_test.cpp
+++ b/be/test/column/nullable_column_test.cpp
@@ -303,9 +303,13 @@ PARALLEL_TEST(NullableColumnTest, test_xor_checksum) {
         c0->append_datum((int32_t)i);
     }
 
-    int64_t checksum = c0->xor_checksum(0, 1001);
+    int64_t checksum = c0->xor_checksum(0, 1002);
     int64_t expected_checksum = 1001;
 
+    ASSERT_EQ(checksum, expected_checksum);
+
+    checksum = c0->xor_checksum(0, 502);
+    expected_checksum = 501;
     ASSERT_EQ(checksum, expected_checksum);
 }
 


### PR DESCRIPTION
## Why I'm doing:
nullable column xor_checksum always use the whole column but not the data from->to

## What I'm doing:
fix it, we always calc xor_checksum for the whole column in our system, so the result is correct but the calc process is not correct.

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [x] 3.2
  - [x] 3.1
  - [x] 3.0
  - [x] 2.5
