### PR TITLE
[BugFix] fix not sending a correct eof packet

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/qe/StmtExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/StmtExecutor.java
@@ -1747,8 +1747,7 @@ public class StmtExecutor {
         serializer.writeInt1(0);
         // warning_count
         serializer.writeInt2(0);
-        // metadata follows
-        serializer.writeInt1(1);
+
         context.getMysqlChannel().sendOnePacket(serializer.toByteBuffer());
 
         if (numParams > 0) {
@@ -1759,6 +1758,7 @@ public class StmtExecutor {
                 serializer.writeField(colNames.get(i), parameters.get(i).getType());
                 context.getMysqlChannel().sendOnePacket(serializer.toByteBuffer());
             }
+            serializer.reset();
             MysqlEofPacket eofPacket = new MysqlEofPacket(context.getState());
             eofPacket.writeTo(serializer);
             context.getMysqlChannel().sendOnePacket(serializer.toByteBuffer());
@@ -1770,6 +1770,7 @@ public class StmtExecutor {
                 serializer.writeField(field.getName(), field.getType());
                 context.getMysqlChannel().sendOnePacket(serializer.toByteBuffer());
             }
+            serializer.reset();
             MysqlEofPacket eofPacket = new MysqlEofPacket(context.getState());
             eofPacket.writeTo(serializer);
             context.getMysqlChannel().sendOnePacket(serializer.toByteBuffer());

--- a/fe/fe-core/src/main/java/com/starrocks/qe/StmtExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/StmtExecutor.java
@@ -1758,6 +1758,7 @@ public class StmtExecutor {
                 serializer.writeField(colNames.get(i), parameters.get(i).getType());
                 context.getMysqlChannel().sendOnePacket(serializer.toByteBuffer());
             }
+            // send EOF
             serializer.reset();
             MysqlEofPacket eofPacket = new MysqlEofPacket(context.getState());
             eofPacket.writeTo(serializer);
@@ -1770,6 +1771,7 @@ public class StmtExecutor {
                 serializer.writeField(field.getName(), field.getType());
                 context.getMysqlChannel().sendOnePacket(serializer.toByteBuffer());
             }
+            // send EOF
             serializer.reset();
             MysqlEofPacket eofPacket = new MysqlEofPacket(context.getState());
             eofPacket.writeTo(serializer);

--- a/test/lib/sr_sql_lib.py
+++ b/test/lib/sr_sql_lib.py
@@ -28,6 +28,7 @@ import configparser
 import datetime
 import json
 import logging
+import mysql.connector
 import os
 import re
 import subprocess
@@ -1728,3 +1729,26 @@ class StarrocksSQLApiLib(object):
         res = self.execute_sql(sql, True)
         for expect in expects:
             tools.assert_true(str(res["result"]).find(expect) > 0, "assert expect %s is not found in plan" % (expect))
+
+    def assert_prepare_execute(self, db, query, params=()):
+        conn = mysql.connector.connect(
+            host=self.mysql_host,
+            user=self.mysql_user,
+            password="",
+            port=self.mysql_port,
+            database=db
+        )
+        cursor = conn.cursor(prepared=True)
+
+        try:
+            if params:
+                cursor.execute(query, params)
+            else:
+                cursor.execute(query)
+            cursor.fetchall()
+        except mysql.connector.Error as e:
+            tools.assert_true(1 == 0, e)
+
+        finally:
+            cursor.close()
+            conn.close()

--- a/test/lib/sr_sql_lib.py
+++ b/test/lib/sr_sql_lib.py
@@ -1742,7 +1742,7 @@ class StarrocksSQLApiLib(object):
 
         try:
             if params:
-                cursor.execute(query, params)
+                cursor.execute(query, ['2'])
             else:
                 cursor.execute(query)
             cursor.fetchall()

--- a/test/requirements.txt
+++ b/test/requirements.txt
@@ -9,3 +9,4 @@ flaky==3.7.0
 fuzzywuzzy
 python-Levenshtein
 PyGithub
+mysql-connector

--- a/test/sql/test_preparestatement/R/test_driver_prepare
+++ b/test/sql/test_preparestatement/R/test_driver_prepare
@@ -1,0 +1,38 @@
+-- name: test_driver_prepare
+create database test_driver_prepare;
+-- result:
+-- !result
+use test_driver_prepare;
+-- result:
+-- !result
+CREATE TABLE IF NOT EXISTS prepare_stmt (
+    k1 INT,
+    k2 TINYINT Default '20',
+    k3 BIGINT,
+    k4 SMALLINT  Default '4',
+    k5 varchar(10) Default 'k5',
+    v6 BOOLEAN,
+    v7 DATE Default '2000-02-02',
+    v8 VARCHAR(2048) Default 'row',
+    v9 DATETIME Default '2000-02-02 00:00:12',
+    v10 STRING NULL,
+    v11 Decimal(10,2) NULL)
+    PRIMARY KEY (k1, k2, k3, k4, k5)
+    DISTRIBUTED BY HASH(k1, k2, k3, k4, k5) BUCKETS 8 PROPERTIES("replication_num" = "1");
+-- result:
+-- !result
+insert into prepare_stmt values (1, 2, 3, 4, '2', true, '2021-02-01', '1', '2021-02-01 00:00:12', '1', 2);
+-- result:
+-- !result
+function: assert_prepare_execute('test_driver_prepare', 'select 1')
+-- result:
+None
+-- !result
+function: assert_prepare_execute('test_driver_prepare', 'select * from prepare_stmt where k1 > ?', [0])
+-- result:
+None
+-- !result
+function: assert_prepare_execute('test_driver_prepare', 'select * from prepare_stmt where k1 = ? or k5 = ?', [0, '2'])
+-- result:
+None
+-- !result

--- a/test/sql/test_preparestatement/R/test_driver_prepare
+++ b/test/sql/test_preparestatement/R/test_driver_prepare
@@ -12,16 +12,12 @@ CREATE TABLE IF NOT EXISTS prepare_stmt (
     k4 SMALLINT  Default '4',
     k5 varchar(10) Default 'k5',
     v6 BOOLEAN,
-    v7 DATE Default '2000-02-02',
-    v8 VARCHAR(2048) Default 'row',
-    v9 DATETIME Default '2000-02-02 00:00:12',
-    v10 STRING NULL,
-    v11 Decimal(10,2) NULL)
+    v7 VARCHAR(2048) Default 'row')
     PRIMARY KEY (k1, k2, k3, k4, k5)
     DISTRIBUTED BY HASH(k1, k2, k3, k4, k5) BUCKETS 8 PROPERTIES("replication_num" = "1");
 -- result:
 -- !result
-insert into prepare_stmt values (1, 2, 3, 4, '2', true, '2021-02-01', '1', '2021-02-01 00:00:12', '1', 2);
+insert into prepare_stmt values (1, 2, 3, 4, '2', true, '1');
 -- result:
 -- !result
 function: assert_prepare_execute('test_driver_prepare', 'select 1')

--- a/test/sql/test_preparestatement/R/test_driver_prepare
+++ b/test/sql/test_preparestatement/R/test_driver_prepare
@@ -32,7 +32,7 @@ function: assert_prepare_execute('test_driver_prepare', 'select * from prepare_s
 -- result:
 None
 -- !result
-function: assert_prepare_execute('test_driver_prepare', 'select * from prepare_stmt where k1 = ? or k5 = ?', [0, '2'])
+function: assert_prepare_execute('test_driver_prepare', 'select * from prepare_stmt where k5 = ?', ['2'])
 -- result:
 None
 -- !result

--- a/test/sql/test_preparestatement/R/test_driver_prepare
+++ b/test/sql/test_preparestatement/R/test_driver_prepare
@@ -28,7 +28,7 @@ function: assert_prepare_execute('test_driver_prepare', 'select 1')
 -- result:
 None
 -- !result
-function: assert_prepare_execute('test_driver_prepare', 'select * from prepare_stmt where k1 > ?', [0])
+function: assert_prepare_execute('test_driver_prepare', 'select * from prepare_stmt where k1 > 0')
 -- result:
 None
 -- !result

--- a/test/sql/test_preparestatement/T/test_driver_prepare
+++ b/test/sql/test_preparestatement/T/test_driver_prepare
@@ -20,4 +20,4 @@ insert into prepare_stmt values (1, 2, 3, 4, '2', true, '2021-02-01', '1', '2021
 
 function: assert_prepare_execute('test_driver_prepare', 'select 1')
 function: assert_prepare_execute('test_driver_prepare', 'select * from prepare_stmt where k1 > ?', [0])
-function: assert_prepare_execute('test_driver_prepare', 'select * from prepare_stmt where k1 = ? or k5 = ?', [0, '2'])
+function: assert_prepare_execute('test_driver_prepare', 'select * from prepare_stmt where k5 = ?', ['2'])

--- a/test/sql/test_preparestatement/T/test_driver_prepare
+++ b/test/sql/test_preparestatement/T/test_driver_prepare
@@ -8,7 +8,7 @@ CREATE TABLE IF NOT EXISTS prepare_stmt (
     k4 SMALLINT  Default '4',
     k5 varchar(10) Default 'k5',
     v6 BOOLEAN,
-    v7 VARCHAR(2048) Default 'row',
+    v7 VARCHAR(2048) Default 'row')
     PRIMARY KEY (k1, k2, k3, k4, k5)
     DISTRIBUTED BY HASH(k1, k2, k3, k4, k5) BUCKETS 8 PROPERTIES("replication_num" = "1");
 

--- a/test/sql/test_preparestatement/T/test_driver_prepare
+++ b/test/sql/test_preparestatement/T/test_driver_prepare
@@ -8,15 +8,11 @@ CREATE TABLE IF NOT EXISTS prepare_stmt (
     k4 SMALLINT  Default '4',
     k5 varchar(10) Default 'k5',
     v6 BOOLEAN,
-    v7 DATE Default '2000-02-02',
-    v8 VARCHAR(2048) Default 'row',
-    v9 DATETIME Default '2000-02-02 00:00:12',
-    v10 STRING NULL,
-    v11 Decimal(10,2) NULL)
+    v7 VARCHAR(2048) Default 'row',
     PRIMARY KEY (k1, k2, k3, k4, k5)
     DISTRIBUTED BY HASH(k1, k2, k3, k4, k5) BUCKETS 8 PROPERTIES("replication_num" = "1");
 
-insert into prepare_stmt values (1, 2, 3, 4, '2', true, '2021-02-01', '1', '2021-02-01 00:00:12', '1', 2);
+insert into prepare_stmt values (1, 2, 3, 4, '2', true, '1');
 
 function: assert_prepare_execute('test_driver_prepare', 'select 1')
 function: assert_prepare_execute('test_driver_prepare', 'select * from prepare_stmt where k1 > 0')

--- a/test/sql/test_preparestatement/T/test_driver_prepare
+++ b/test/sql/test_preparestatement/T/test_driver_prepare
@@ -1,0 +1,23 @@
+-- name: test_driver_prepare
+create database test_driver_prepare;
+use test_driver_prepare;
+CREATE TABLE IF NOT EXISTS prepare_stmt (
+    k1 INT,
+    k2 TINYINT Default '20',
+    k3 BIGINT,
+    k4 SMALLINT  Default '4',
+    k5 varchar(10) Default 'k5',
+    v6 BOOLEAN,
+    v7 DATE Default '2000-02-02',
+    v8 VARCHAR(2048) Default 'row',
+    v9 DATETIME Default '2000-02-02 00:00:12',
+    v10 STRING NULL,
+    v11 Decimal(10,2) NULL)
+    PRIMARY KEY (k1, k2, k3, k4, k5)
+    DISTRIBUTED BY HASH(k1, k2, k3, k4, k5) BUCKETS 8 PROPERTIES("replication_num" = "1");
+
+insert into prepare_stmt values (1, 2, 3, 4, '2', true, '2021-02-01', '1', '2021-02-01 00:00:12', '1', 2);
+
+function: assert_prepare_execute('test_driver_prepare', 'select 1')
+function: assert_prepare_execute('test_driver_prepare', 'select * from prepare_stmt where k1 > ?', [0])
+function: assert_prepare_execute('test_driver_prepare', 'select * from prepare_stmt where k1 = ? or k5 = ?', [0, '2'])

--- a/test/sql/test_preparestatement/T/test_driver_prepare
+++ b/test/sql/test_preparestatement/T/test_driver_prepare
@@ -19,5 +19,5 @@ CREATE TABLE IF NOT EXISTS prepare_stmt (
 insert into prepare_stmt values (1, 2, 3, 4, '2', true, '2021-02-01', '1', '2021-02-01 00:00:12', '1', 2);
 
 function: assert_prepare_execute('test_driver_prepare', 'select 1')
-function: assert_prepare_execute('test_driver_prepare', 'select * from prepare_stmt where k1 > ?', [0])
+function: assert_prepare_execute('test_driver_prepare', 'select * from prepare_stmt where k1 > 0')
 function: assert_prepare_execute('test_driver_prepare', 'select * from prepare_stmt where k5 = ?', ['2'])


### PR DESCRIPTION
## Why I'm doing:
not setting a right eof packet when ending field definition.

## What I'm doing:
Our MySQL capabilities doesn't support `CLIENT_OPTIONAL_RESULTSET_METADATA`, so no need set  metadata follows flag. Reset buffer before sending eof packet.

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [x] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
