### PR TITLE
[Enhancement] pushdown or predicate (5): support zonemap filter

### DIFF
--- a/be/src/storage/lake/rowset.cpp
+++ b/be/src/storage/lake/rowset.cpp
@@ -63,7 +63,7 @@ StatusOr<std::vector<ChunkIteratorPtr>> Rowset::read(const Schema& schema, const
     seg_options.stats = options.stats;
     seg_options.ranges = options.ranges;
     seg_options.pred_tree = options.pred_tree;
-    seg_options.predicates_for_zone_map = options.predicates_for_zone_map;
+    seg_options.pred_tree_for_zone_map = options.pred_tree_for_zone_map;
     seg_options.use_page_cache = options.use_page_cache;
     seg_options.profile = options.profile;
     seg_options.reader_type = options.reader_type;

--- a/be/src/storage/lake/tablet_reader.cpp
+++ b/be/src/storage/lake/tablet_reader.cpp
@@ -222,9 +222,8 @@ Status TabletReader::get_segment_iterators(const TabletReaderParams& params, std
                                      &rs_opts.ranges, &_mempool));
     rs_opts.pred_tree = params.pred_tree;
     PredicateTree pred_tree_for_zone_map;
-    RETURN_IF_ERROR(
-            ZonemapPredicatesRewriter::rewrite_predicate_tree(&_obj_pool, rs_opts.pred_tree, pred_tree_for_zone_map));
-    rs_opts.predicates_for_zone_map = pred_tree_for_zone_map.get_immediate_column_predicate_map();
+    RETURN_IF_ERROR(ZonemapPredicatesRewriter::rewrite_predicate_tree(&_obj_pool, rs_opts.pred_tree,
+                                                                      rs_opts.pred_tree_for_zone_map));
     rs_opts.sorted = ((keys_type != DUP_KEYS && keys_type != PRIMARY_KEYS) && !params.skip_aggregation) ||
                      is_compaction(params.reader_type) || params.sorted_by_keys_per_tablet;
     rs_opts.reader_type = params.reader_type;

--- a/be/src/storage/predicate_tree/predicate_tree.h
+++ b/be/src/storage/predicate_tree/predicate_tree.h
@@ -317,6 +317,9 @@ private:
 // ------------------------------------------------------------------------------------
 
 struct CompoundNodeContext {
+    template <CompoundNodeType Type>
+    const ColumnPredicateMap& cid_to_col_preds(const PredicateCompoundNode<Type>& node) const;
+
     std::vector<uint8_t> selection_buffer;
     std::vector<uint16_t> selected_idx_buffer;
 
@@ -325,6 +328,8 @@ struct CompoundNodeContext {
         std::vector<ConstPredicateNodePtr> vec_children;
     };
     std::optional<CompoundAndContext> and_context;
+
+    mutable std::optional<ColumnPredicateMap> _cached_cid_to_col_preds;
 };
 
 /// Stores multiple ColumnPredicates in a tree. Internal nodes are AND or OR relations, and leaf nodes are ColumnPredicates.

--- a/be/src/storage/predicate_tree/predicate_tree.hpp
+++ b/be/src/storage/predicate_tree/predicate_tree.hpp
@@ -351,4 +351,23 @@ inline Status PredicateCompoundNode<CompoundNodeType::OR>::evaluate_or(CompoundN
     return Status::OK();
 }
 
+// ------------------------------------------------------------------------------------
+// CompoundNodeContext
+// ------------------------------------------------------------------------------------
+
+template <CompoundNodeType Type>
+const ColumnPredicateMap& CompoundNodeContext::cid_to_col_preds(const PredicateCompoundNode<Type>& node) const {
+    if (_cached_cid_to_col_preds.has_value()) {
+        return _cached_cid_to_col_preds.value();
+    }
+
+    auto& cid_to_col_preds = _cached_cid_to_col_preds.emplace();
+    for (const auto& [cid, col_children] : node.col_children_map()) {
+        for (const auto& child : col_children) {
+            cid_to_col_preds[cid].emplace_back(child.col_pred());
+        }
+    }
+    return cid_to_col_preds;
+}
+
 } // namespace starrocks

--- a/be/src/storage/rowset/column_iterator.h
+++ b/be/src/storage/rowset/column_iterator.h
@@ -39,6 +39,7 @@
 #include "io/shared_buffered_input_stream.h"
 #include "storage/olap_common.h"
 #include "storage/options.h"
+#include "storage/predicate_tree/predicate_tree_fwd.h"
 #include "storage/range.h"
 #include "storage/rowset/common.h"
 #include "types/logical_type.h"
@@ -154,8 +155,11 @@ public:
 
     virtual ordinal_t get_current_ordinal() const = 0;
 
+    /// Store the row ranges that satisfy the given predicates into |row_ranges|.
+    /// |pred_relation| is the relation among |predicates|, it can be AND or OR.
     virtual Status get_row_ranges_by_zone_map(const std::vector<const ColumnPredicate*>& predicates,
-                                              const ColumnPredicate* del_predicate, SparseRange<>* row_ranges) {
+                                              const ColumnPredicate* del_predicate, SparseRange<>* row_ranges,
+                                              CompoundNodeType pred_relation) {
         row_ranges->add({0, static_cast<rowid_t>(num_rows())});
         return Status::OK();
     }

--- a/be/src/storage/rowset/column_iterator_decorator.h
+++ b/be/src/storage/rowset/column_iterator_decorator.h
@@ -46,8 +46,9 @@ public:
     ordinal_t get_current_ordinal() const override { return _parent->get_current_ordinal(); }
 
     Status get_row_ranges_by_zone_map(const std::vector<const ColumnPredicate*>& predicates,
-                                      const ColumnPredicate* del_predicate, SparseRange<>* row_ranges) override {
-        return _parent->get_row_ranges_by_zone_map(predicates, del_predicate, row_ranges);
+                                      const ColumnPredicate* del_predicate, SparseRange<>* row_ranges,
+                                      CompoundNodeType pred_relation) override {
+        return _parent->get_row_ranges_by_zone_map(predicates, del_predicate, row_ranges, pred_relation);
     }
 
     Status get_row_ranges_by_bloom_filter(const std::vector<const ColumnPredicate*>& predicates,

--- a/be/src/storage/rowset/column_reader.cpp
+++ b/be/src/storage/rowset/column_reader.cpp
@@ -507,14 +507,24 @@ Status ColumnReader::seek_by_page_index(int page_index, OrdinalPageIndexIterator
 Status ColumnReader::zone_map_filter(const std::vector<const ColumnPredicate*>& predicates,
                                      const ColumnPredicate* del_predicate,
                                      std::unordered_set<uint32_t>* del_partial_filtered_pages,
-                                     SparseRange<>* row_ranges, const IndexReadOptions& opts) {
+                                     SparseRange<>* row_ranges, const IndexReadOptions& opts,
+                                     CompoundNodeType pred_relation) {
     RETURN_IF_ERROR(_load_zonemap_index(opts));
+
     std::vector<uint32_t> page_indexes;
-    RETURN_IF_ERROR(_zone_map_filter(predicates, del_predicate, del_partial_filtered_pages, &page_indexes));
+    if (pred_relation == CompoundNodeType::AND) {
+        RETURN_IF_ERROR(_zone_map_filter<CompoundNodeType::AND>(predicates, del_predicate, del_partial_filtered_pages,
+                                                                &page_indexes));
+    } else {
+        RETURN_IF_ERROR(_zone_map_filter<CompoundNodeType::OR>(predicates, del_predicate, del_partial_filtered_pages,
+                                                               &page_indexes));
+    }
+
     RETURN_IF_ERROR(_calculate_row_ranges(page_indexes, row_ranges));
     return Status::OK();
 }
 
+template <CompoundNodeType PredRelation>
 Status ColumnReader::_zone_map_filter(const std::vector<const ColumnPredicate*>& predicates,
                                       const ColumnPredicate* del_predicate,
                                       std::unordered_set<uint32_t>* del_partial_filtered_pages,
@@ -530,20 +540,24 @@ Status ColumnReader::_zone_map_filter(const std::vector<const ColumnPredicate*>&
     } else {
         return Status::OK();
     }
+
+    auto page_satisfies_zone_map_filter = [&](const ZoneMapDetail& detail) {
+        if constexpr (PredRelation == CompoundNodeType::AND) {
+            return std::ranges::all_of(predicates, [&](const auto* pred) { return pred->zone_map_filter(detail); });
+        } else {
+            return predicates.empty() ||
+                   std::ranges::any_of(predicates, [&](const auto* pred) { return pred->zone_map_filter(detail); });
+        }
+    };
+
     const std::vector<ZoneMapPB>& zone_maps = _zonemap_index->page_zone_maps();
     int32_t page_size = _zonemap_index->num_pages();
     for (int32_t i = 0; i < page_size; ++i) {
         const ZoneMapPB& zm = zone_maps[i];
         ZoneMapDetail detail;
         RETURN_IF_ERROR(_parse_zone_map(lt, zm, &detail));
-        bool matched = true;
-        for (const auto* predicate : predicates) {
-            if (!predicate->zone_map_filter(detail)) {
-                matched = false;
-                break;
-            }
-        }
-        if (!matched) {
+
+        if (!page_satisfies_zone_map_filter(detail)) {
             continue;
         }
         pages->emplace_back(i);

--- a/be/src/storage/rowset/column_reader.h
+++ b/be/src/storage/rowset/column_reader.h
@@ -48,6 +48,7 @@
 #include "gen_cpp/segment.pb.h"
 #include "runtime/mem_pool.h"
 #include "storage/inverted/inverted_index_iterator.h"
+#include "storage/predicate_tree/predicate_tree_fwd.h"
 #include "storage/range.h"
 #include "storage/rowset/bitmap_index_reader.h"
 #include "storage/rowset/bloom_filter_index_reader.h"
@@ -139,10 +140,11 @@ public:
     int32_t num_data_pages() { return _ordinal_index ? _ordinal_index->num_data_pages() : 0; }
 
     // page-level zone map filter.
+
     Status zone_map_filter(const std::vector<const ::starrocks::ColumnPredicate*>& p,
                            const ::starrocks::ColumnPredicate* del_predicate,
                            std::unordered_set<uint32_t>* del_partial_filtered_pages, SparseRange<>* row_ranges,
-                           const IndexReadOptions& opts);
+                           const IndexReadOptions& opts, CompoundNodeType pred_relation);
 
     // segment-level zone map filter.
     // Return false to filter out this segment.
@@ -189,6 +191,7 @@ private:
 
     Status _calculate_row_ranges(const std::vector<uint32_t>& page_indexes, SparseRange<>* row_ranges);
 
+    template <CompoundNodeType PredRelation>
     Status _zone_map_filter(const std::vector<const ColumnPredicate*>& predicates, const ColumnPredicate* del_predicate,
                             std::unordered_set<uint32_t>* del_partial_filtered_pages, std::vector<uint32_t>* pages);
 

--- a/be/src/storage/rowset/default_value_column_iterator.cpp
+++ b/be/src/storage/rowset/default_value_column_iterator.cpp
@@ -151,7 +151,8 @@ Status DefaultValueColumnIterator::fetch_values_by_rowid(const rowid_t* rowids, 
 
 Status DefaultValueColumnIterator::get_row_ranges_by_zone_map(const std::vector<const ColumnPredicate*>& predicates,
                                                               const ColumnPredicate* del_predicate,
-                                                              SparseRange<>* row_ranges) {
+                                                              SparseRange<>* row_ranges,
+                                                              CompoundNodeType pred_relation) {
     DCHECK(row_ranges->empty());
     // TODO
     row_ranges->add({0, static_cast<rowid_t>(_num_rows)});

--- a/be/src/storage/rowset/default_value_column_iterator.h
+++ b/be/src/storage/rowset/default_value_column_iterator.h
@@ -77,8 +77,8 @@ public:
     ordinal_t num_rows() const override { return _num_rows; }
 
     [[nodiscard]] Status get_row_ranges_by_zone_map(const std::vector<const ColumnPredicate*>& predicates,
-                                                    const ColumnPredicate* del_predicate,
-                                                    SparseRange<>* row_ranges) override;
+                                                    const ColumnPredicate* del_predicate, SparseRange<>* row_ranges,
+                                                    CompoundNodeType pred_relation) override;
 
     bool all_page_dict_encoded() const override { return false; }
 

--- a/be/src/storage/rowset/json_column_iterator.cpp
+++ b/be/src/storage/rowset/json_column_iterator.cpp
@@ -75,8 +75,8 @@ public:
     ordinal_t num_rows() const override { return _flat_iters[0]->num_rows(); }
 
     [[nodiscard]] Status get_row_ranges_by_zone_map(const std::vector<const ColumnPredicate*>& predicates,
-                                                    const ColumnPredicate* del_predicate,
-                                                    SparseRange<>* row_ranges) override;
+                                                    const ColumnPredicate* del_predicate, SparseRange<>* row_ranges,
+                                                    CompoundNodeType pred_relation) override;
 
     [[nodiscard]] Status fetch_values_by_rowid(const rowid_t* rowids, size_t size, Column* values) override;
 
@@ -264,7 +264,7 @@ Status JsonFlatColumnIterator::seek_to_ordinal(ordinal_t ord) {
 
 Status JsonFlatColumnIterator::get_row_ranges_by_zone_map(const std::vector<const ColumnPredicate*>& predicates,
                                                           const ColumnPredicate* del_predicate,
-                                                          SparseRange<>* row_ranges) {
+                                                          SparseRange<>* row_ranges, CompoundNodeType pred_relation) {
     row_ranges->add({0, static_cast<rowid_t>(_reader->num_rows())});
     return Status::OK();
 }
@@ -296,8 +296,8 @@ public:
 
     /// for vectorized engine
     [[nodiscard]] Status get_row_ranges_by_zone_map(const std::vector<const ColumnPredicate*>& predicates,
-                                                    const ColumnPredicate* del_predicate,
-                                                    SparseRange<>* row_ranges) override;
+                                                    const ColumnPredicate* del_predicate, SparseRange<>* row_ranges,
+                                                    CompoundNodeType pred_relation) override;
 
     [[nodiscard]] Status fetch_values_by_rowid(const rowid_t* rowids, size_t size, Column* values) override;
 
@@ -386,8 +386,8 @@ Status JsonDynamicFlatIterator::seek_to_ordinal(ordinal_t ord) {
 
 Status JsonDynamicFlatIterator::get_row_ranges_by_zone_map(const std::vector<const ColumnPredicate*>& predicates,
                                                            const ColumnPredicate* del_predicate,
-                                                           SparseRange<>* row_ranges) {
-    return _json_iter->get_row_ranges_by_zone_map(predicates, del_predicate, row_ranges);
+                                                           SparseRange<>* row_ranges, CompoundNodeType pred_relation) {
+    return _json_iter->get_row_ranges_by_zone_map(predicates, del_predicate, row_ranges, pred_relation);
 }
 
 StatusOr<std::unique_ptr<ColumnIterator>> create_json_flat_iterator(

--- a/be/src/storage/rowset/rowset.cpp
+++ b/be/src/storage/rowset/rowset.cpp
@@ -660,7 +660,7 @@ Status Rowset::get_segment_iterators(const Schema& schema, const RowsetReadOptio
     seg_options.stats = options.stats;
     seg_options.ranges = options.ranges;
     seg_options.pred_tree = options.pred_tree;
-    seg_options.predicates_for_zone_map = options.predicates_for_zone_map;
+    seg_options.pred_tree_for_zone_map = options.pred_tree_for_zone_map;
     seg_options.use_page_cache = options.use_page_cache;
     seg_options.profile = options.profile;
     seg_options.reader_type = options.reader_type;

--- a/be/src/storage/rowset/rowset_options.h
+++ b/be/src/storage/rowset/rowset_options.h
@@ -54,7 +54,7 @@ public:
     std::vector<SeekRange> ranges;
 
     PredicateTree pred_tree;
-    std::unordered_map<ColumnId, PredicateList> predicates_for_zone_map;
+    PredicateTree pred_tree_for_zone_map;
 
     // whether rowset should return rows in sorted order.
     bool sorted = true;

--- a/be/src/storage/rowset/scalar_column_iterator.cpp
+++ b/be/src/storage/rowset/scalar_column_iterator.cpp
@@ -372,8 +372,8 @@ Status ScalarColumnIterator::_read_data_page(const OrdinalPageIndexIterator& ite
 }
 
 Status ScalarColumnIterator::get_row_ranges_by_zone_map(const std::vector<const ColumnPredicate*>& predicates,
-                                                        const ColumnPredicate* del_predicate,
-                                                        SparseRange<>* row_ranges) {
+                                                        const ColumnPredicate* del_predicate, SparseRange<>* row_ranges,
+                                                        CompoundNodeType pred_relation) {
     DCHECK(row_ranges->empty());
     if (_reader->has_zone_map()) {
         if (!_delete_partial_satisfied_pages.has_value()) {
@@ -387,7 +387,7 @@ Status ScalarColumnIterator::get_row_ranges_by_zone_map(const std::vector<const 
         opts.read_file = _opts.read_file;
         opts.stats = _opts.stats;
         RETURN_IF_ERROR(_reader->zone_map_filter(predicates, del_predicate, &_delete_partial_satisfied_pages.value(),
-                                                 row_ranges, opts));
+                                                 row_ranges, opts, pred_relation));
     } else {
         row_ranges->add({0, static_cast<rowid_t>(_reader->num_rows())});
     }

--- a/be/src/storage/rowset/scalar_column_iterator.h
+++ b/be/src/storage/rowset/scalar_column_iterator.h
@@ -66,8 +66,8 @@ public:
     ordinal_t num_rows() const override { return _reader->num_rows(); }
 
     [[nodiscard]] Status get_row_ranges_by_zone_map(const std::vector<const ColumnPredicate*>& predicate,
-                                                    const ColumnPredicate* del_predicate,
-                                                    SparseRange<>* range) override;
+                                                    const ColumnPredicate* del_predicate, SparseRange<>* range,
+                                                    CompoundNodeType pred_relationn) override;
 
     [[nodiscard]] Status get_row_ranges_by_bloom_filter(const std::vector<const ColumnPredicate*>& predicates,
                                                         SparseRange<>* range) override;

--- a/be/src/storage/rowset/segment.cpp
+++ b/be/src/storage/rowset/segment.cpp
@@ -47,6 +47,7 @@
 #include "segment_iterator.h"
 #include "segment_options.h"
 #include "storage/lake/tablet_manager.h"
+#include "storage/predicate_tree/predicate_tree.hpp"
 #include "storage/rowset/cast_column_iterator.h"
 #include "storage/rowset/column_reader.h"
 #include "storage/rowset/default_value_column_iterator.h"
@@ -262,32 +263,44 @@ bool Segment::_use_segment_zone_map_filter(const SegmentReadOptions& read_option
     return st.ok() && dcgs.size() == 0;
 }
 
+struct SegmentZoneMapPruner {
+    bool operator()(const PredicateColumnNode& node) const {
+        const auto* col_pred = node.col_pred();
+        const ColumnId column_id = col_pred->column_id();
+        const auto& tablet_column = read_options.tablet_schema ? read_options.tablet_schema->column(column_id)
+                                                               : parent->_tablet_schema->column(column_id);
+        const auto column_unique_id = tablet_column.unique_id();
+
+        if (const auto it = parent->_column_readers.find(column_unique_id); it == parent->_column_readers.end()) {
+            return false;
+        } else {
+            return it->second->has_zone_map() && !it->second->segment_zone_map_filter({col_pred}) &&
+                   (tablet_column.is_key() || parent->_use_segment_zone_map_filter(read_options));
+        }
+    }
+    bool operator()(const PredicateAndNode& node) const {
+        return std::any_of(node.children().begin(), node.children().end(),
+                           [this](const auto& child) { return child.visit(*this); });
+    }
+    bool operator()(const PredicateOrNode& node) const {
+        return !node.empty() && std::all_of(node.children().begin(), node.children().end(),
+                                            [this](const auto& child) { return child.visit(*this); });
+    }
+
+    Segment* parent;
+    const SegmentReadOptions& read_options;
+};
+
 StatusOr<ChunkIteratorPtr> Segment::_new_iterator(const Schema& schema, const SegmentReadOptions& read_options) {
     DCHECK(read_options.stats != nullptr);
 
-    if (config::enable_index_segment_level_zonemap_filter) {
-        // trying to prune the current segment by segment-level zone map
-        for (const auto& pair : read_options.predicates_for_zone_map) {
-            ColumnId column_id = pair.first;
-            const auto& tablet_column = read_options.tablet_schema ? read_options.tablet_schema->column(column_id)
-                                                                   : _tablet_schema->column(column_id);
-            auto column_unique_id = tablet_column.unique_id();
-            if (_column_readers.count(column_unique_id) < 1 || !_column_readers.at(column_unique_id)->has_zone_map()) {
-                continue;
-            }
-            if (!_column_readers.at(column_unique_id)->segment_zone_map_filter(pair.second)) {
-                // skip segment zonemap filter when this segment has column files link to it.
-                if (tablet_column.is_key() || _use_segment_zone_map_filter(read_options)) {
-                    if (read_options.is_first_split_of_segment) {
-                        read_options.stats->segment_stats_filtered += _column_readers.at(column_unique_id)->num_rows();
-                    }
-                    return Status::EndOfFile(
-                            strings::Substitute("End of file $0, empty iterator", _segment_file_info.path));
-                } else {
-                    break;
-                }
-            }
+    const auto pruned = config::enable_index_segment_level_zonemap_filter &&
+                        read_options.pred_tree_for_zone_map.visit(SegmentZoneMapPruner{this, read_options});
+    if (pruned) {
+        if (read_options.is_first_split_of_segment) {
+            read_options.stats->segment_stats_filtered += num_rows();
         }
+        return Status::EndOfFile(strings::Substitute("End of file $0, empty iterator", _segment_file_info.path));
     }
 
     return new_segment_iterator(shared_from_this(), schema, read_options);

--- a/be/src/storage/rowset/segment.h
+++ b/be/src/storage/rowset/segment.h
@@ -221,6 +221,8 @@ public:
     DISALLOW_COPY_AND_MOVE(Segment);
 
 private:
+    friend struct SegmentZoneMapPruner;
+
     struct DummyDeleter {
         void operator()(const TabletSchema*) {}
     };

--- a/be/src/storage/rowset/segment_options.h
+++ b/be/src/storage/rowset/segment_options.h
@@ -53,7 +53,7 @@ public:
     std::vector<SeekRange> ranges;
 
     PredicateTree pred_tree;
-    std::unordered_map<ColumnId, PredicateList> predicates_for_zone_map;
+    PredicateTree pred_tree_for_zone_map;
 
     DisjunctivePredicates delete_predicates;
 

--- a/be/src/storage/tablet_reader.cpp
+++ b/be/src/storage/tablet_reader.cpp
@@ -275,9 +275,8 @@ Status TabletReader::get_segment_iterators(const TabletReaderParams& params, std
                                      &rs_opts.ranges, &_mempool));
     rs_opts.pred_tree = params.pred_tree;
     PredicateTree pred_tree_for_zone_map;
-    RETURN_IF_ERROR(
-            ZonemapPredicatesRewriter::rewrite_predicate_tree(&_obj_pool, rs_opts.pred_tree, pred_tree_for_zone_map));
-    rs_opts.predicates_for_zone_map = pred_tree_for_zone_map.get_immediate_column_predicate_map();
+    RETURN_IF_ERROR(ZonemapPredicatesRewriter::rewrite_predicate_tree(&_obj_pool, rs_opts.pred_tree,
+                                                                      rs_opts.pred_tree_for_zone_map));
     rs_opts.sorted = (keys_type != DUP_KEYS && keys_type != PRIMARY_KEYS) && !params.skip_aggregation;
     rs_opts.reader_type = params.reader_type;
     rs_opts.chunk_size = params.chunk_size;

--- a/be/test/storage/rowset/default_value_column_iterator_test.cpp
+++ b/be/test/storage/rowset/default_value_column_iterator_test.cpp
@@ -39,7 +39,7 @@ TEST_F(DefaultValueColumnIteratorTest, delete_after_column) {
     std::vector<const ColumnPredicate*> preds;
     std::unique_ptr<ColumnPredicate> del_pred(new_column_null_predicate(type_info, 1, true));
     SparseRange<> row_ranges;
-    st = iter.get_row_ranges_by_zone_map(preds, del_pred.get(), &row_ranges);
+    st = iter.get_row_ranges_by_zone_map(preds, del_pred.get(), &row_ranges, CompoundNodeType::AND);
     ASSERT_TRUE(st.ok());
 
     TypeDescriptor type_desc(LogicalType::TYPE_INT);

--- a/be/test/storage/rowset/segment_test.cpp
+++ b/be/test/storage/rowset/segment_test.cpp
@@ -549,7 +549,7 @@ TEST_F(SegmentReaderWriterTest, TestTypeConversion) {
         seg_options.stats = &stats;
         seg_options.tablet_schema = tablet_schema_for_read;
         seg_options.pred_tree = PredicateTree::create(std::move(pred_root));
-        seg_options.predicates_for_zone_map.emplace(1, PredicateList{predicate});
+        seg_options.pred_tree_for_zone_map = PredicateTree::create(seg_options.pred_tree.root());
         ASSIGN_OR_ABORT(auto seg_iter, segment->new_iterator(read_schema, seg_options));
         ASSERT_OK(seg_iter->get_next(read_chunk.get()));
         EXPECT_EQ(1, read_chunk->num_rows());

--- a/be/test/storage/rowset/segment_test.cpp
+++ b/be/test/storage/rowset/segment_test.cpp
@@ -549,7 +549,7 @@ TEST_F(SegmentReaderWriterTest, TestTypeConversion) {
         seg_options.stats = &stats;
         seg_options.tablet_schema = tablet_schema_for_read;
         seg_options.pred_tree = PredicateTree::create(std::move(pred_root));
-        seg_options.pred_tree_for_zone_map = PredicateTree::create(seg_options.pred_tree.root());
+        seg_options.pred_tree_for_zone_map = seg_options.pred_tree;
         ASSIGN_OR_ABORT(auto seg_iter, segment->new_iterator(read_schema, seg_options));
         ASSERT_OK(seg_iter->get_next(read_chunk.get()));
         EXPECT_EQ(1, read_chunk->num_rows());


### PR DESCRIPTION
## Why I'm doing:
Support zonemap filter for OR predicates.
Relates to #43801.

## What I'm doing:

Before:

1. `Segment::_new_iterator` applies the segment-level zonemap filter and prunes a segment if **any of** predicates returns false.
2. `ColumnIterator::get_row_ranges_by_zone_map(predicates_of_a_column)` prunes a page if **any of** `predicates_of_a_column` returns false.
3. `SegmentIterator::_get_row_ranges_by_zone_map` applies the page-level zonemap filter and **intersects** the result of each invocation of `ColumnIterator::get_row_ranges_by_zone_map(predicates_of_a_column)`.


After:

1. `Segment::_new_iterator` prunes a segment if **all the** predicates returns false for `OR`.
2. `ColumnIterator::get_row_ranges_by_zone_map(predicates_of_a_column)` prunes a page if **all the** `predicates_of_a_column` returns false for `OR`.
3. `SegmentIterator::_get_row_ranges_by_zone_map` applies the page-level zonemap filter and **unions** the result of each invocation of `ColumnIterator::get_row_ranges_by_zone_map(predicates_of_a_column)` for `OR`.



## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
