### PR TITLE
[Enhancement] Support datacache metrics display in compute node

### DIFF
--- a/be/src/http/http_client.h
+++ b/be/src/http/http_client.h
@@ -93,7 +93,7 @@ public:
     // used to get content length
     int64_t get_content_length() const {
         double cl = 0.0f;
-        curl_easy_getinfo(_curl, CURLINFO_CONTENT_LENGTH_DOWNLOAD_T, &cl);
+        curl_easy_getinfo(_curl, CURLINFO_CONTENT_LENGTH_DOWNLOAD, &cl);
         return cl;
     }
 

--- a/be/src/http/http_client.h
+++ b/be/src/http/http_client.h
@@ -93,7 +93,7 @@ public:
     // used to get content length
     int64_t get_content_length() const {
         double cl = 0.0f;
-        curl_easy_getinfo(_curl, CURLINFO_CONTENT_LENGTH_DOWNLOAD, &cl);
+        curl_easy_getinfo(_curl, CURLINFO_CONTENT_LENGTH_DOWNLOAD_T, &cl);
         return cl;
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/common/proc/ComputeNodeProcDir.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/proc/ComputeNodeProcDir.java
@@ -22,6 +22,7 @@ import com.starrocks.alter.DecommissionType;
 import com.starrocks.common.AnalysisException;
 import com.starrocks.common.util.ListComparator;
 import com.starrocks.common.util.TimeUtils;
+import com.starrocks.datacache.DataCacheMetrics;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.server.RunMode;
 import com.starrocks.system.BackendCoreStat;
@@ -34,6 +35,7 @@ import org.apache.logging.log4j.Logger;
 import java.util.ArrayList;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 
 public class ComputeNodeProcDir implements ProcDirInterface {
@@ -49,7 +51,8 @@ public class ComputeNodeProcDir implements ProcDirInterface {
                 .add("BePort").add("HttpPort").add("BrpcPort").add("LastStartTime").add("LastHeartbeat").add("Alive")
                 .add("SystemDecommissioned").add("ClusterDecommissioned").add("ErrMsg")
                 .add("Version")
-                .add("CpuCores").add("NumRunningQueries").add("MemUsedPct").add("CpuUsedPct").add("HasStoragePath");
+                .add("CpuCores").add("NumRunningQueries").add("MemUsedPct").add("CpuUsedPct")
+                .add("DataCacheMetrics").add("HasStoragePath");
         TITLE_NAMES = builder.build();
         builder = new ImmutableList.Builder<String>()
                 .addAll(TITLE_NAMES)
@@ -146,6 +149,23 @@ public class ComputeNodeProcDir implements ProcDirInterface {
             double memUsedPct = computeNode.getMemUsedPct();
             computeNodeInfo.add(String.format("%.2f", memUsedPct * 100) + " %");
             computeNodeInfo.add(String.format("%.1f", computeNode.getCpuUsedPermille() / 10.0) + " %");
+
+            Optional<DataCacheMetrics> dataCacheMetrics = computeNode.getDataCacheMetrics();
+            if (dataCacheMetrics.isPresent()) {
+                DataCacheMetrics.Status status = dataCacheMetrics.get().getStatus();
+                if (status != DataCacheMetrics.Status.DISABLED) {
+                    computeNodeInfo.add(String.format("Status: %s, DiskUsage: %s, MemUsage: %s",
+                            dataCacheMetrics.get().getStatus(),
+                            dataCacheMetrics.get().getDiskUsageStr(),
+                            dataCacheMetrics.get().getMemUsageStr()));
+                } else {
+                    // DataCache is disabled
+                    computeNodeInfo.add(String.format("Status: %s", DataCacheMetrics.Status.DISABLED));
+                }
+            } else {
+                // Didn't receive any datacache report from be
+                computeNodeInfo.add("N/A");
+            }
 
             computeNodeInfo.add(String.valueOf(computeNode.isSetStoragePath()));
 

--- a/fe/fe-core/src/main/java/com/starrocks/datacache/DataCacheSelectMetrics.java
+++ b/fe/fe-core/src/main/java/com/starrocks/datacache/DataCacheSelectMetrics.java
@@ -22,7 +22,7 @@ import com.starrocks.monitor.unit.TimeValue;
 import com.starrocks.qe.ShowResultSet;
 import com.starrocks.qe.ShowResultSetMetaData;
 import com.starrocks.server.GlobalStateMgr;
-import com.starrocks.system.Backend;
+import com.starrocks.system.ComputeNode;
 import com.starrocks.system.SystemInfoService;
 
 import java.util.HashMap;
@@ -40,7 +40,7 @@ public class DataCacheSelectMetrics {
             .build();
 
     private static final ShowResultSetMetaData VERBOSE_META_DATA = ShowResultSetMetaData.builder()
-            .addColumn(new Column("BE_IP", ScalarType.createVarcharType()))
+            .addColumn(new Column("IP", ScalarType.createVarcharType()))
             .addColumn(new Column("STATUS", ScalarType.createVarcharType()))
             .addColumn(new Column("ALREADY_CACHED_SIZE", ScalarType.createVarcharType()))
             .addColumn(new Column("AVG_READ_CACHE_TIME", ScalarType.createVarcharType()))
@@ -75,11 +75,11 @@ public class DataCacheSelectMetrics {
             LoadDataCacheMetrics metrics = entry.getValue();
 
             long backendId = entry.getKey();
-            Backend backend = clusterInfoService.getBackend(backendId);
-            if (backend == null) {
+            ComputeNode computeNode = clusterInfoService.getBackendOrComputeNode(backendId);
+            if (computeNode == null) {
                 row.add("N/A");
             } else {
-                row.add(backend.getIP());
+                row.add(computeNode.getIP());
             }
 
             row.add("SUCCESS");

--- a/fe/fe-core/src/main/java/com/starrocks/leader/ReportHandler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/leader/ReportHandler.java
@@ -223,8 +223,8 @@ public class ReportHandler extends Daemon implements MemoryTrackable {
             beId = backend.getId();
         } else {
             ComputeNode computeNode = null;
-            // Compute node only reports resource usage.
-            if (request.isSetResource_usage()) {
+            // Compute node only reports resource usage or datacache metrics.
+            if (request.isSetResource_usage() || request.isSetDatacache_metrics()) {
                 computeNode =
                         GlobalStateMgr.getCurrentState().getNodeMgr().getClusterInfo().getComputeNodeWithBePort(host, bePort);
             }

--- a/fe/fe-core/src/test/java/com/starrocks/datacache/DataCacheSelectMetricsTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/datacache/DataCacheSelectMetricsTest.java
@@ -16,6 +16,7 @@ package com.starrocks.datacache;
 
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.system.Backend;
+import com.starrocks.system.ComputeNode;
 import com.starrocks.thrift.TDataCacheMetrics;
 import com.starrocks.thrift.TDataCacheStatus;
 import com.starrocks.thrift.TLoadDataCacheMetrics;
@@ -31,6 +32,7 @@ public class DataCacheSelectMetricsTest {
     private final long second = 1000000000L;
     private final long be1Id = 77778L;
     private final long be2Id = 77779L;
+    private final long cn1Id = 77780L;
 
     @Before
     public void setup() {
@@ -38,6 +40,8 @@ public class DataCacheSelectMetricsTest {
                 .addBackend(new Backend(be1Id, "127.0.0.2", 7777));
         GlobalStateMgr.getCurrentState().getNodeMgr().getClusterInfo()
                 .addBackend(new Backend(be2Id, "127.0.0.3", 7777));
+        GlobalStateMgr.getCurrentState().getNodeMgr().getClusterInfo()
+                .addComputeNode(new ComputeNode(cn1Id, "127.0.0.4", 7777));
     }
 
     @Test
@@ -71,11 +75,22 @@ public class DataCacheSelectMetricsTest {
         be2.setMetrics(dataCacheMetrics);
         LoadDataCacheMetrics be2Metrics = LoadDataCacheMetrics.buildFromThrift(be2);
 
+        TLoadDataCacheMetrics cn1 = new TLoadDataCacheMetrics();
+        cn1.setRead_bytes(3 * megabyte);
+        cn1.setRead_time_ns(3 * second);
+        cn1.setWrite_bytes(3 * gigabyte);
+        cn1.setWrite_time_ns(15 * second);
+        cn1.setCount(1);
+
+        cn1.setMetrics(dataCacheMetrics);
+        LoadDataCacheMetrics cn1Metrics = LoadDataCacheMetrics.buildFromThrift(cn1);
+
         dataCacheSelectMetrics.updateLoadDataCacheMetrics(be1Id, be1Metrics);
         dataCacheSelectMetrics.updateLoadDataCacheMetrics(be2Id, be2Metrics);
+        dataCacheSelectMetrics.updateLoadDataCacheMetrics(cn1Id, cn1Metrics);
 
         List<List<String>> rows = dataCacheSelectMetrics.getShowResultSet(false).getResultRows();
-        Assert.assertEquals("SUCCESS,3MB,3GB,22.5s,50.00%", String.join(",", rows.get(0)));
+        Assert.assertEquals("SUCCESS,6MB,6GB,20s,50.00%", String.join(",", rows.get(0)));
         rows = dataCacheSelectMetrics.getShowResultSet(true).getResultRows();
         for (List<String> row : rows) {
             if (row.get(0).equals("127.0.0.2")) {
@@ -84,10 +99,13 @@ public class DataCacheSelectMetricsTest {
             if (row.get(0).equals("127.0.0.3")) {
                 Assert.assertEquals("127.0.0.3,SUCCESS,2MB,2s,2GB,35s,50.00%", String.join(",", row));
             }
+            if (row.get(0).equals("127.0.0.4")) {
+                Assert.assertEquals("127.0.0.4,SUCCESS,3MB,3s,3GB,15s,50.00%", String.join(",", row));
+            }
         }
 
         Assert.assertEquals(
-                "AlreadyCachedSize: 3MB, AvgReadCacheTime: 1.5s, WriteCacheSize: 3GB, AvgWriteCacheTime: 22.5s, " +
+                "AlreadyCachedSize: 6MB, AvgReadCacheTime: 2s, WriteCacheSize: 6GB, AvgWriteCacheTime: 20s, " +
                         "TotalCacheUsage: 50.00%", dataCacheSelectMetrics.toString());
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/qe/ShowExecutorTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/qe/ShowExecutorTest.java
@@ -870,7 +870,8 @@ public class ShowExecutorTest {
         Assert.assertEquals("10", resultSet.getString(14));
         Assert.assertEquals("1.00 %", resultSet.getString(15));
         Assert.assertEquals("3.0 %", resultSet.getString(16));
-        Assert.assertEquals(String.valueOf(tabletNum), resultSet.getString(21));
+        Assert.assertEquals("N/A", resultSet.getString(17));
+        Assert.assertEquals(String.valueOf(tabletNum), resultSet.getString(22));
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/qe/ShowExecutorTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/qe/ShowExecutorTest.java
@@ -72,6 +72,7 @@ import com.starrocks.common.UserException;
 import com.starrocks.common.jmockit.Deencapsulation;
 import com.starrocks.common.proc.ComputeNodeProcDir;
 import com.starrocks.common.proc.OptimizeProcDir;
+import com.starrocks.datacache.DataCacheMetrics;
 import com.starrocks.datacache.DataCacheMgr;
 import com.starrocks.lake.StarOSAgent;
 import com.starrocks.mysql.MysqlCommand;
@@ -117,6 +118,8 @@ import com.starrocks.system.Backend;
 import com.starrocks.system.BackendCoreStat;
 import com.starrocks.system.ComputeNode;
 import com.starrocks.system.SystemInfoService;
+import com.starrocks.thrift.TDataCacheMetrics;
+import com.starrocks.thrift.TDataCacheStatus;
 import com.starrocks.thrift.TStorageType;
 import mockit.Expectations;
 import mockit.Mock;
@@ -802,6 +805,11 @@ public class ShowExecutorTest {
 
         ComputeNode node = new ComputeNode(1L, "127.0.0.1", 80);
         node.updateResourceUsage(10, 100L, 1L, 30);
+        TDataCacheMetrics tDataCacheMetrics = new TDataCacheMetrics();
+        tDataCacheMetrics.setStatus(TDataCacheStatus.NORMAL);
+        tDataCacheMetrics.setDisk_quota_bytes(1024 * 1024 * 1024);
+        tDataCacheMetrics.setMem_quota_bytes(1024 * 1024 * 1024);
+        node.updateDataCacheMetrics(DataCacheMetrics.buildFromThrift(tDataCacheMetrics));
         clusterInfo.addComputeNode(node);
 
         NodeMgr nodeMgr = new NodeMgr();
@@ -870,7 +878,7 @@ public class ShowExecutorTest {
         Assert.assertEquals("10", resultSet.getString(14));
         Assert.assertEquals("1.00 %", resultSet.getString(15));
         Assert.assertEquals("3.0 %", resultSet.getString(16));
-        Assert.assertEquals("N/A", resultSet.getString(17));
+        Assert.assertEquals("Status: Normal, DiskUsage: 0B/1GB, MemUsage: 0B/1GB", resultSet.getString(17));
         Assert.assertEquals(String.valueOf(tabletNum), resultSet.getString(22));
     }
 


### PR DESCRIPTION
## Why I'm doing:


## What I'm doing:

Show datacache metrics in `show compute nodes\G`
Show cache select metrics when using compute nodes.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
