### PR TITLE
[BugFix] Unfold partition const column before comparing partition range

### DIFF
--- a/be/src/exec/tablet_info.cpp
+++ b/be/src/exec/tablet_info.cpp
@@ -521,6 +521,8 @@ Status OlapTablePartitionParam::find_tablets(Chunk* chunk, std::vector<OlapTable
         if (!_partitions_expr_ctxs.empty()) {
             for (size_t i = 0; i < partition_columns.size(); ++i) {
                 ASSIGN_OR_RETURN(partition_columns[i], _partitions_expr_ctxs[i]->evaluate(chunk));
+                partition_columns[i] = ColumnHelper::unfold_const_column(_partition_slot_descs[i]->type(), num_rows,
+                                                                         partition_columns[i]);
             }
         } else {
             for (size_t i = 0; i < partition_columns.size(); ++i) {

--- a/test/sql/test_partition_by_expr/R/test_expr_from_unixtime
+++ b/test/sql/test_partition_by_expr/R/test_expr_from_unixtime
@@ -50,6 +50,31 @@ drop table partition_unixtime;
 -- result:
 -- !result
 CREATE TABLE partition_unixtime (
+        create_time int,
+        sku_id varchar(100),
+        total_amount decimal,
+        id int
+)
+PARTITION BY RANGE(from_unixtime(create_time))(
+PARTITION p1 VALUES LESS THAN ("2021-01-01")
+);
+-- result:
+-- !result
+insert into partition_unixtime values(null,'1',1.1,1);
+-- result:
+-- !result
+select * from partition_unixtime;
+-- result:
+NULL	1	1	1
+-- !result
+select * from partition_unixtime PARTITION(p1);
+-- result:
+NULL	1	1	1
+-- !result
+drop table partition_unixtime;
+-- result:
+-- !result
+CREATE TABLE partition_unixtime (
         create_time date,
         sku_id varchar(100),
         total_amount decimal,

--- a/test/sql/test_partition_by_expr/R/test_expr_from_unixtime
+++ b/test/sql/test_partition_by_expr/R/test_expr_from_unixtime
@@ -65,11 +65,11 @@ insert into partition_unixtime values(null,'1',1.1,1);
 -- !result
 select * from partition_unixtime;
 -- result:
-NULL	1	1	1
+None	1	1	1
 -- !result
 select * from partition_unixtime PARTITION(p1);
 -- result:
-NULL	1	1	1
+None	1	1	1
 -- !result
 drop table partition_unixtime;
 -- result:

--- a/test/sql/test_partition_by_expr/T/test_expr_from_unixtime
+++ b/test/sql/test_partition_by_expr/T/test_expr_from_unixtime
@@ -26,6 +26,19 @@ select * from partition_unixtime;
 select * from partition_unixtime PARTITION(p20210105);
 drop table partition_unixtime;
 CREATE TABLE partition_unixtime (
+        create_time int,
+        sku_id varchar(100),
+        total_amount decimal,
+        id int
+)
+PARTITION BY RANGE(from_unixtime(create_time))(
+PARTITION p1 VALUES LESS THAN ("2021-01-01")
+);
+insert into partition_unixtime values(null,'1',1.1,1);
+select * from partition_unixtime;
+select * from partition_unixtime PARTITION(p1);
+drop table partition_unixtime;
+CREATE TABLE partition_unixtime (
         create_time date,
         sku_id varchar(100),
         total_amount decimal,


### PR DESCRIPTION
## Why I'm doing:
const column does not support comparison with non-const column, and BE will crash.
![image](https://github.com/StarRocks/starrocks/assets/972887/540ecc9d-8886-4933-8673-d951253c997e)


## What I'm doing:
unfold partition const column before comparing partition range

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [x] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
