### PR TITLE
[Enhancement] Log cancel pipeline only once

### DIFF
--- a/be/src/exec/pipeline/pipeline_driver.cpp
+++ b/be/src/exec/pipeline/pipeline_driver.cpp
@@ -549,7 +549,10 @@ void PipelineDriver::finish_operators(RuntimeState* runtime_state) {
 
 void PipelineDriver::cancel_operators(RuntimeState* runtime_state) {
     if (this->query_ctx()->is_query_expired()) {
-        LOG(WARNING) << "begin to cancel operators for " << to_readable_string();
+        bool old_has_log_cancelled = false;
+        if (_has_log_cancelled.compare_exchange_strong(old_has_log_cancelled, true)) {
+            LOG(WARNING) << "begin to cancel operators for " << to_readable_string();
+        }
     }
     for (auto& op : _operators) {
         WARN_IF_ERROR(_mark_operator_cancelled(op, runtime_state),

--- a/be/src/exec/pipeline/pipeline_driver.cpp
+++ b/be/src/exec/pipeline/pipeline_driver.cpp
@@ -551,7 +551,7 @@ void PipelineDriver::cancel_operators(RuntimeState* runtime_state) {
     if (this->query_ctx()->is_query_expired()) {
         bool expected_has_log_cancelled = false;
         if (_has_log_cancelled.compare_exchange_strong(expected_has_log_cancelled, true)) {
-            LOG(WARNING) << "begin to cancel operators for " << to_readable_string();
+            VLOG_ROW << "begin to cancel operators for " << to_readable_string();
         }
     }
     for (auto& op : _operators) {

--- a/be/src/exec/pipeline/pipeline_driver.cpp
+++ b/be/src/exec/pipeline/pipeline_driver.cpp
@@ -549,8 +549,8 @@ void PipelineDriver::finish_operators(RuntimeState* runtime_state) {
 
 void PipelineDriver::cancel_operators(RuntimeState* runtime_state) {
     if (this->query_ctx()->is_query_expired()) {
-        bool old_has_log_cancelled = false;
-        if (_has_log_cancelled.compare_exchange_strong(old_has_log_cancelled, true)) {
+        bool expected_has_log_cancelled = false;
+        if (_has_log_cancelled.compare_exchange_strong(expected_has_log_cancelled, true)) {
             LOG(WARNING) << "begin to cancel operators for " << to_readable_string();
         }
     }

--- a/be/src/exec/pipeline/pipeline_driver.h
+++ b/be/src/exec/pipeline/pipeline_driver.h
@@ -526,6 +526,8 @@ protected:
     size_t _driver_queue_level = 0;
     std::atomic<bool> _in_ready_queue{false};
 
+    std::atomic<bool> _has_log_cancelled{false};
+
     // metrics
     RuntimeProfile::Counter* _total_timer = nullptr;
     RuntimeProfile::Counter* _active_timer = nullptr;


### PR DESCRIPTION
## Why I'm doing:
Decrease log of `begin to cancel operators`.
Some operators will take lots of time to cancel, which causes `PipelineDriver::cancel_operators` is called multiple times when it is expired.

## What I'm doing:
Only log `begin to cancel operators` once for a pipeline driver.


## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
