### PR TITLE
[Enhancement] add config enable_temporary_table_statistic_collect

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/common/Config.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/Config.java
@@ -1782,6 +1782,12 @@ public class Config extends ConfigBase {
     public static boolean enable_statistic_collect = true;
 
     /**
+     * whether to automatically collect statistics on temporary tables
+     */
+    @ConfField(mutable = true)
+    public static boolean enable_temporary_table_statistic_collect = true;
+
+    /**
      * auto statistic collect on first load flag
      */
     @ConfField(mutable = true)

--- a/fe/fe-core/src/main/java/com/starrocks/server/TemporaryTableCleaner.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/TemporaryTableCleaner.java
@@ -15,6 +15,7 @@
 package com.starrocks.server;
 
 import com.starrocks.common.Config;
+import com.starrocks.common.FeConstants;
 import com.starrocks.common.ThreadPoolManager;
 import com.starrocks.common.util.FrontendDaemon;
 import com.starrocks.rpc.FrontendServiceProxy;
@@ -52,6 +53,9 @@ public class TemporaryTableCleaner extends FrontendDaemon  {
 
     @Override
     protected void runAfterCatalogReady() {
+        if (FeConstants.runningUnitTest) {
+            return;
+        }
         List<Frontend> frontends = GlobalStateMgr.getCurrentState().getNodeMgr().getFrontends(null);
         List<UUID> aliveSessions = new ArrayList<>();
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AnalyzeStmtAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AnalyzeStmtAnalyzer.java
@@ -193,6 +193,10 @@ public class AnalyzeStmtAnalyzer {
                     Database db = MetaUtils.getDatabase(session, statement.getTableName());
                     Table analyzeTable = MetaUtils.getSessionAwareTable(session, db, statement.getTableName());
 
+                    if (analyzeTable.isTemporaryTable()) {
+                        throw new SemanticException("Don't support create analyze job for temporary table");
+                    }
+
                     if (CatalogMgr.ResourceMappingCatalog.isResourceMappingCatalog(analyzeTable.getCatalogName())) {
                         throw new SemanticException("Don't support analyze external table created by resource mapping");
                     }

--- a/fe/fe-core/src/main/java/com/starrocks/statistic/StatisticsCollectJobFactory.java
+++ b/fe/fe-core/src/main/java/com/starrocks/statistic/StatisticsCollectJobFactory.java
@@ -365,6 +365,10 @@ public class StatisticsCollectJobFactory {
                 return;
             }
         }
+        if (!Config.enable_temporary_table_statistic_collect && table.isTemporaryTable()) {
+            LOG.debug("statistics job doesn't work on temporary table: {}", table.getName());
+            return;
+        }
 
         if (StatisticUtils.isEmptyTable(table)) {
             return;

--- a/test/sql/test_temporary_table/R/temporary_table
+++ b/test/sql/test_temporary_table/R/temporary_table
@@ -439,3 +439,15 @@ drop temporary table `t`;
 select TABLE_CATALOG,TABLE_NAME,TABLE_TYPE,ENGINE,TABLE_ROWS,AVG_ROW_LENGTH,DATA_LENGTH,MAX_DATA_LENGTH,INDEX_LENGTH,DATA_FREE,AUTO_INCREMENT,TABLE_COMMENT from information_schema.temp_tables where `session`=(select session_id());
 -- result:
 -- !result
+-- name: test_create_analyze
+create temporary table `t` (
+    `c1` int,
+    `c2` int,
+    `c3` int
+) engine=OLAP primary key(`c1`) distributed by hash(`c1`) buckets 3 properties("replication_num" = "1");
+-- result:
+-- !result
+create analyze table t;
+-- result:
+E: (1064, "Getting analyzing error. Detail message: Don't support create analyze job for temporary table.")
+-- !result

--- a/test/sql/test_temporary_table/T/temporary_table
+++ b/test/sql/test_temporary_table/T/temporary_table
@@ -187,3 +187,12 @@ select TABLE_CATALOG,TABLE_NAME,TABLE_TYPE,ENGINE,TABLE_ROWS,AVG_ROW_LENGTH,DATA
 drop temporary table `t`;
 
 select TABLE_CATALOG,TABLE_NAME,TABLE_TYPE,ENGINE,TABLE_ROWS,AVG_ROW_LENGTH,DATA_LENGTH,MAX_DATA_LENGTH,INDEX_LENGTH,DATA_FREE,AUTO_INCREMENT,TABLE_COMMENT from information_schema.temp_tables where `session`=(select session_id());
+
+
+-- name: test_create_analyze
+create temporary table `t` (
+    `c1` int,
+    `c2` int,
+    `c3` int
+) engine=OLAP primary key(`c1`) distributed by hash(`c1`) buckets 3 properties("replication_num" = "1");
+create analyze table t;


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:

1. add a new configuration `enable_temporary_table_statistic_collect` to control whether to automatically collect statistics on temporary tables, this value is true by default.
2. disable create analyze job on temporary tables
3. skip run TemporaryTableCleaner on UT mode.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
