### PR TITLE
[Enhancement] Add host start time info on BE start

### DIFF
--- a/bin/start_backend.sh
+++ b/bin/start_backend.sh
@@ -206,7 +206,7 @@ else
     exec &>> ${LOG_FILE}
 fi
 
-echo "start time: "$(date)
+echo "start time: $(date), server uptime: $(uptime)"
 if [ ${RUN_DAEMON} -eq 1 ]; then
     nohup ${START_BE_CMD} "$@" </dev/null &
 else

--- a/bin/start_fe.sh
+++ b/bin/start_fe.sh
@@ -207,7 +207,7 @@ fi
 
 echo "using java version $JAVA_VERSION"
 echo $final_java_opt
-echo `date`
+echo "start time: $(date), server uptime: $(uptime)"
 
 # StarRocksFE java process will write its process id into $pidfile
 if [ ${RUN_DAEMON} -eq 1 ]; then


### PR DESCRIPTION
## Why I'm doing:

When BE restarts, it's hard to know whether process restarts or  host restarts

## What I'm doing:

Adding server start time in be.out so it's easier to infer this information


## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [x] 3.2
  - [x] 3.1
  - [x] 3.0
  - [x] 2.5
