### PR TITLE
[Refactor] use delta metastore operation instead of hive metastore operation

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/DeltaLakeTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/DeltaLakeTable.java
@@ -119,7 +119,7 @@ public class DeltaLakeTable extends Table {
     }
 
     public List<String> getPartitionColumnNames() {
-        return getPartitionColumns().stream().map(Column::getName).collect(Collectors.toList());
+        return partColumnNames;
     }
 
     public boolean isUnPartitioned() {

--- a/fe/fe-core/src/main/java/com/starrocks/connector/delta/DeltaLakeConnector.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/delta/DeltaLakeConnector.java
@@ -19,7 +19,7 @@ import com.starrocks.connector.Connector;
 import com.starrocks.connector.ConnectorContext;
 import com.starrocks.connector.ConnectorMetadata;
 import com.starrocks.connector.HdfsEnvironment;
-import com.starrocks.connector.hive.IHiveMetastore;
+import com.starrocks.connector.metastore.IMetastore;
 import com.starrocks.credential.CloudConfiguration;
 import com.starrocks.credential.CloudConfigurationFactory;
 import org.apache.logging.log4j.LogManager;
@@ -44,7 +44,6 @@ public class DeltaLakeConnector implements Connector {
         HdfsEnvironment hdfsEnvironment = new HdfsEnvironment(cloudConfiguration);
         this.internalMgr = new DeltaLakeInternalMgr(catalogName, properties, hdfsEnvironment);
         this.metadataFactory = createMetadataFactory();
-        // TODO extract to ConnectorConfigFactory
     }
 
     @Override
@@ -53,7 +52,7 @@ public class DeltaLakeConnector implements Connector {
     }
 
     private DeltaLakeMetadataFactory createMetadataFactory() {
-        IHiveMetastore metastore = internalMgr.createHiveMetastore();
+        IMetastore metastore = internalMgr.createMetastore();
         return new DeltaLakeMetadataFactory(
                 catalogName,
                 metastore,

--- a/fe/fe-core/src/main/java/com/starrocks/connector/delta/DeltaLakeInternalMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/delta/DeltaLakeInternalMgr.java
@@ -26,6 +26,7 @@ import com.starrocks.connector.hive.CachingHiveMetastoreConf;
 import com.starrocks.connector.hive.HiveMetaClient;
 import com.starrocks.connector.hive.HiveMetastore;
 import com.starrocks.connector.hive.IHiveMetastore;
+import com.starrocks.connector.metastore.IMetastore;
 import com.starrocks.sql.analyzer.SemanticException;
 
 import java.util.List;
@@ -64,6 +65,10 @@ public class DeltaLakeInternalMgr {
             Util.validateMetastoreUris(hiveMetastoreUris);
         }
         this.metastoreType = MetastoreType.get(hiveMetastoreType);
+    }
+
+    public IMetastore createMetastore() {
+        return createHiveMetastore();
     }
 
     public IHiveMetastore createHiveMetastore() {

--- a/fe/fe-core/src/main/java/com/starrocks/connector/delta/DeltaLakeMetadata.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/delta/DeltaLakeMetadata.java
@@ -15,11 +15,10 @@
 package com.starrocks.connector.delta;
 
 import com.starrocks.catalog.Database;
-import com.starrocks.catalog.HiveTable;
 import com.starrocks.catalog.Table;
 import com.starrocks.connector.ConnectorMetadata;
 import com.starrocks.connector.HdfsEnvironment;
-import com.starrocks.connector.hive.HiveMetastoreOperations;
+import com.starrocks.connector.MetastoreType;
 import com.starrocks.credential.CloudConfiguration;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -29,13 +28,17 @@ import java.util.List;
 public class DeltaLakeMetadata implements ConnectorMetadata {
     private static final Logger LOG = LogManager.getLogger(DeltaLakeMetadata.class);
     private final String catalogName;
-    private final HiveMetastoreOperations hmsOps;
+    private final DeltaMetastoreOperations deltaOps;
     private final HdfsEnvironment hdfsEnvironment;
 
-    public DeltaLakeMetadata(HdfsEnvironment hdfsEnvironment, String catalogName, HiveMetastoreOperations hmsOps) {
+    public DeltaLakeMetadata(HdfsEnvironment hdfsEnvironment, String catalogName, DeltaMetastoreOperations deltaOps) {
         this.hdfsEnvironment = hdfsEnvironment;
         this.catalogName = catalogName;
-        this.hmsOps = hmsOps;
+        this.deltaOps = deltaOps;
+    }
+
+    public String getCatalogName() {
+        return catalogName;
     }
 
     @Override
@@ -45,49 +48,45 @@ public class DeltaLakeMetadata implements ConnectorMetadata {
 
     @Override
     public List<String> listDbNames() {
-        return hmsOps.getAllDatabaseNames();
+        return deltaOps.getAllDatabaseNames();
     }
 
     @Override
     public List<String> listTableNames(String dbName) {
-        return hmsOps.getAllTableNames(dbName);
+        return deltaOps.getAllTableNames(dbName);
     }
 
     @Override
     public Database getDb(String dbName) {
-        return hmsOps.getDb(dbName);
+        return deltaOps.getDb(dbName);
     }
 
     @Override
     public List<String> listPartitionNames(String databaseName, String tableName, long snapshotId) {
-        return hmsOps.getPartitionKeys(databaseName, tableName);
+        return deltaOps.getPartitionKeys(databaseName, tableName);
     }
 
     @Override
     public Table getTable(String dbName, String tblName) {
         try {
-            Table table = hmsOps.getTable(dbName, tblName);
-            if (table == null) {
-                return null;
-            }
-            HiveTable hiveTable = (HiveTable) table;
-            String path = hiveTable.getTableLocation();
-            long createTime = table.getCreateTime();
-            return DeltaUtils.convertDeltaToSRTable(catalogName, dbName, tblName, path, hdfsEnvironment.getConfiguration(),
-                    createTime);
+            return deltaOps.getTable(dbName, tblName);
         } catch (Exception e) {
-            LOG.warn(e.getMessage());
+            LOG.error("Failed to get table {}.{}", dbName, tblName, e);
             return null;
         }
     }
 
     @Override
     public boolean tableExists(String dbName, String tblName) {
-        return hmsOps.tableExists(dbName, tblName);
+        return deltaOps.tableExists(dbName, tblName);
     }
 
     @Override
     public CloudConfiguration getCloudConfiguration() {
         return hdfsEnvironment.getCloudConfiguration();
+    }
+
+    public MetastoreType getMetastoreType() {
+        return deltaOps.getMetastoreType();
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/connector/delta/DeltaLakeMetadataFactory.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/delta/DeltaLakeMetadataFactory.java
@@ -18,8 +18,8 @@ import com.starrocks.connector.HdfsEnvironment;
 import com.starrocks.connector.MetastoreType;
 import com.starrocks.connector.hive.CachingHiveMetastore;
 import com.starrocks.connector.hive.CachingHiveMetastoreConf;
-import com.starrocks.connector.hive.HiveMetastoreOperations;
 import com.starrocks.connector.hive.IHiveMetastore;
+import com.starrocks.connector.metastore.IMetastore;
 import org.apache.hadoop.hive.metastore.conf.MetastoreConf;
 
 import java.util.Map;
@@ -29,12 +29,12 @@ import static com.starrocks.connector.hive.CachingHiveMetastore.createQueryLevel
 
 public class DeltaLakeMetadataFactory {
     private final String catalogName;
-    private final IHiveMetastore metastore;
+    private final IMetastore metastore;
     private final long perQueryMetastoreMaxNum;
     private final HdfsEnvironment hdfsEnvironment;
     private final MetastoreType metastoreType;
 
-    public DeltaLakeMetadataFactory(String catalogName, IHiveMetastore metastore, CachingHiveMetastoreConf hmsConf,
+    public DeltaLakeMetadataFactory(String catalogName, IMetastore metastore, CachingHiveMetastoreConf hmsConf,
                                     Map<String, String> properties, HdfsEnvironment hdfsEnvironment,
                                     MetastoreType metastoreType) {
         this.catalogName = catalogName;
@@ -48,12 +48,18 @@ public class DeltaLakeMetadataFactory {
         this.metastoreType = metastoreType;
     }
 
-    public DeltaLakeMetadata create() {
-        HiveMetastoreOperations hiveMetastoreOperations = new HiveMetastoreOperations(
-                createQueryLevelInstance(metastore, perQueryMetastoreMaxNum),
-                metastore instanceof CachingHiveMetastore,
-                hdfsEnvironment.getConfiguration(), metastoreType, catalogName);
+    private IMetastore createQueryLevelCacheMetastore() {
+        return createQueryLevelInstance((IHiveMetastore) metastore, perQueryMetastoreMaxNum);
+    }
 
-        return new DeltaLakeMetadata(hdfsEnvironment, catalogName, hiveMetastoreOperations);
+    public DeltaLakeMetadata create() {
+        IMetastore queryLevelCacheMetastore = createQueryLevelCacheMetastore();
+        boolean enableCatalogLevelCache = metastore instanceof CachingHiveMetastore;
+
+        DeltaMetastoreOperations metastoreOperations = new DeltaMetastoreOperations(catalogName, queryLevelCacheMetastore,
+                enableCatalogLevelCache,
+                hdfsEnvironment.getConfiguration(), metastoreType);
+
+        return new DeltaLakeMetadata(hdfsEnvironment, catalogName, metastoreOperations);
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/connector/delta/DeltaMetastoreOperations.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/delta/DeltaMetastoreOperations.java
@@ -1,0 +1,76 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.connector.delta;
+
+import com.starrocks.catalog.Database;
+import com.starrocks.catalog.HiveTable;
+import com.starrocks.catalog.Table;
+import com.starrocks.connector.MetastoreType;
+import com.starrocks.connector.metastore.IMetastore;
+import org.apache.hadoop.conf.Configuration;
+
+import java.util.List;
+
+public class DeltaMetastoreOperations {
+    private final String catalogName;
+    private final IMetastore metastore;
+    private final boolean enableCatalogLevelCache;
+    private final Configuration hadoopConf;
+    private final MetastoreType metastoreType;
+
+    public DeltaMetastoreOperations(String catalogName, IMetastore metastore, boolean enableCatalogLevelCache,
+                                    Configuration hadoopConf, MetastoreType metastoreType) {
+        this.catalogName = catalogName;
+        this.metastore = metastore;
+        this.enableCatalogLevelCache = enableCatalogLevelCache;
+        this.hadoopConf = hadoopConf;
+        this.metastoreType = metastoreType;
+    }
+
+    public List<String> getAllDatabaseNames() {
+        return metastore.getAllDatabaseNames();
+    }
+
+    public List<String> getAllTableNames(String dbName) {
+        return metastore.getAllTableNames(dbName);
+    }
+
+    public Database getDb(String dbName) {
+        return metastore.getDb(dbName);
+    }
+
+    public Table getTable(String dbName, String tableName) {
+        Table table = metastore.getTable(dbName, tableName);
+        if (table == null) {
+            return null;
+        }
+        HiveTable hiveTable = (HiveTable) table;
+        String path = hiveTable.getTableLocation();
+        long createTime = table.getCreateTime();
+        return DeltaUtils.convertDeltaToSRTable(catalogName, dbName, table.getName(), path, hadoopConf, createTime);
+    }
+
+    public List<String> getPartitionKeys(String dbName, String tableName) {
+        return metastore.getPartitionKeys(dbName, tableName);
+    }
+
+    public boolean tableExists(String dbName, String tableName) {
+        return metastore.tableExists(dbName, tableName);
+    }
+
+    public MetastoreType getMetastoreType() {
+        return metastoreType;
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/connector/hive/IHiveMetastore.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/hive/IHiveMetastore.java
@@ -16,33 +16,27 @@ package com.starrocks.connector.hive;
 
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
-import com.starrocks.catalog.Database;
 import com.starrocks.catalog.Table;
+import com.starrocks.connector.metastore.IMetastore;
 
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.function.Function;
 
-public interface IHiveMetastore {
-
-    List<String> getAllDatabaseNames();
+public interface IHiveMetastore extends IMetastore {
 
     void createDb(String dbName, Map<String, String> properties);
 
     void dropDb(String dbName, boolean deleteData);
 
-    Database getDb(String dbName);
-
-    List<String> getAllTableNames(String dbName);
-
     void createTable(String dbName, Table table);
 
     void dropTable(String dbName, String tableName);
 
-    Table getTable(String dbName, String tableName);
-
-    boolean tableExists(String dbName, String tableName);
+    default List<String> getPartitionKeys(String dbName, String tableName) {
+        return getPartitionKeysByValue(dbName, tableName, HivePartitionValue.ALL_PARTITION_VALUES);
+    }
 
     List<String> getPartitionKeysByValue(String dbName, String tableName, List<Optional<String>> partitionValues);
 

--- a/fe/fe-core/src/main/java/com/starrocks/connector/metastore/IMetastore.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/metastore/IMetastore.java
@@ -1,0 +1,35 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+
+package com.starrocks.connector.metastore;
+
+import com.starrocks.catalog.Database;
+import com.starrocks.catalog.Table;
+
+import java.util.List;
+
+public interface IMetastore {
+    List<String> getAllDatabaseNames();
+
+    List<String> getAllTableNames(String dbName);
+
+    Database getDb(String dbName);
+
+    Table getTable(String dbName, String tableName);
+
+    List<String> getPartitionKeys(String dbName, String tableName);
+
+    boolean tableExists(String dbName, String tableName);
+}

--- a/fe/fe-core/src/test/java/com/starrocks/connector/delta/DeltaLakeConnectorTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/delta/DeltaLakeConnectorTest.java
@@ -1,0 +1,39 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.connector.delta;
+
+import com.google.common.collect.ImmutableMap;
+import com.starrocks.connector.ConnectorContext;
+import com.starrocks.connector.ConnectorMetadata;
+import com.starrocks.connector.MetastoreType;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.Map;
+
+public class DeltaLakeConnectorTest {
+    @Test
+    public void testCreateDeltaLakeConnector() {
+        Map<String, String> properties = ImmutableMap.of("type", "deltalake",
+                "hive.metastore.type", "hive", "hive.metastore.uris", "thrift://localhost:9083");
+        DeltaLakeConnector connector = new DeltaLakeConnector(new ConnectorContext("delta0", "deltalake",
+                properties));
+        ConnectorMetadata metadata = connector.getMetadata();
+        Assert.assertTrue(metadata instanceof DeltaLakeMetadata);
+        DeltaLakeMetadata deltaLakeMetadata = (DeltaLakeMetadata) metadata;
+        Assert.assertEquals("delta0", deltaLakeMetadata.getCatalogName());
+        Assert.assertEquals(deltaLakeMetadata.getMetastoreType(), MetastoreType.HMS);
+    }
+}

--- a/fe/fe-core/src/test/java/com/starrocks/connector/delta/DeltaLakeMetadataTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/delta/DeltaLakeMetadataTest.java
@@ -1,0 +1,95 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.connector.delta;
+
+import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
+import com.starrocks.catalog.DeltaLakeTable;
+import com.starrocks.catalog.Table;
+import com.starrocks.connector.HdfsEnvironment;
+import com.starrocks.connector.MetastoreType;
+import com.starrocks.connector.hive.HiveMetaClient;
+import com.starrocks.connector.hive.HiveMetastore;
+import com.starrocks.connector.hive.HiveMetastoreTest;
+import com.starrocks.connector.metastore.IMetastore;
+import mockit.MockUp;
+import org.apache.hadoop.conf.Configuration;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.List;
+
+public class DeltaLakeMetadataTest {
+    private HiveMetaClient client;
+    private DeltaLakeMetadata deltaLakeMetadata;
+
+    @Before
+    public void setUp() throws Exception {
+        HdfsEnvironment hdfsEnvironment = new HdfsEnvironment(Maps.newHashMap());
+
+        client = new HiveMetastoreTest.MockedHiveMetaClient();
+        IMetastore hiveMetastore = new HiveMetastore(client, "delta0", MetastoreType.HMS);
+        DeltaMetastoreOperations deltaOps = new DeltaMetastoreOperations("delta0", hiveMetastore, false,
+                null, MetastoreType.HMS);
+
+        deltaLakeMetadata = new DeltaLakeMetadata(hdfsEnvironment, "delta0", deltaOps);
+    }
+
+    @Test
+    public void testListDbNames() {
+        List<String> dbNames = deltaLakeMetadata.listDbNames();
+        Assert.assertEquals(2, dbNames.size());
+        Assert.assertEquals("db1", dbNames.get(0));
+        Assert.assertEquals("db2", dbNames.get(1));
+    }
+
+    @Test
+    public void testListTableNames() {
+        List<String> tableNames = deltaLakeMetadata.listTableNames("db1");
+        Assert.assertEquals(2, tableNames.size());
+        Assert.assertEquals("table1", tableNames.get(0));
+        Assert.assertEquals("table2", tableNames.get(1));
+    }
+
+    @Test
+    public void testListPartitionNames() {
+        List<String> partitionNames = deltaLakeMetadata.listPartitionNames("db1", "table1", -1);
+        Assert.assertEquals(1, partitionNames.size());
+        Assert.assertEquals("col1", partitionNames.get(0));
+    }
+
+    @Test
+    public void testTableExists() {
+        Assert.assertTrue(deltaLakeMetadata.tableExists("db1", "table1"));
+    }
+
+    @Test
+    public void testGetTable() {
+        new MockUp<DeltaUtils>() {
+            @mockit.Mock
+            public DeltaLakeTable convertDeltaToSRTable(String catalog, String dbName, String tblName, String path,
+                                                        Configuration configuration, long createTime) {
+                return new DeltaLakeTable(1, "delta0", "db1", "table1", Lists.newArrayList(),
+                        Lists.newArrayList("col1"), null, "path/to/table", null, 0);
+            }
+        };
+        DeltaLakeTable deltaTable = (DeltaLakeTable) deltaLakeMetadata.getTable("db1", "table1");
+        Assert.assertNotNull(deltaTable);
+        Assert.assertEquals("table1", deltaTable.getName());
+        Assert.assertEquals(Table.TableType.DELTALAKE, deltaTable.getType());
+        Assert.assertEquals("path/to/table", deltaTable.getTableLocation());
+    }
+}


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:
1. add BridgingMetastore for multi metastore
2. use DeltaMetastoreOperations instead of HiveMetastoreOperations

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [x] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
