### PR TITLE
[BugFix] interleaving join can't support joins with other conjuncts

### DIFF
--- a/be/src/exec/join_hash_map.h
+++ b/be/src/exec/join_hash_map.h
@@ -629,7 +629,7 @@ private:
     HashTableProbeState::ProbeCoroutine _probe_from_ht(RuntimeState* state, const Buffer<CppType>& build_data,
                                                        const Buffer<CppType>& probe_data);
 
-    template <bool first_probe, bool init_match = false>
+    template <bool first_probe>
     void _probe_coroutine(RuntimeState* state, const Buffer<CppType>& build_data, const Buffer<CppType>& probe_data);
 
     // for one key left outer join

--- a/be/src/exec/join_hash_map.tpp
+++ b/be/src/exec/join_hash_map.tpp
@@ -717,7 +717,7 @@ void JoinHashMap<LT, BuildFunc, ProbeFunc>::_search_ht_remain(RuntimeState* stat
     _probe_state->count = match_count;
 }
 
-#define DO_PROBE(X, Y)                                                                                               \
+#define DO_PROBE(X)                                                                                                  \
     if (_probe_state->active_coroutines != 0) {                                                                      \
         if constexpr (first_probe) {                                                                                 \
             auto group_size = std::abs(state->query_options().interleaving_group_size);                              \
@@ -738,7 +738,7 @@ void JoinHashMap<LT, BuildFunc, ProbeFunc>::_search_ht_remain(RuntimeState* stat
             }                                                                                                        \
             _probe_state->active_coroutines = group_size;                                                            \
         }                                                                                                            \
-        _probe_coroutine<first_probe, Y>(state, build_data, data);                                                   \
+        _probe_coroutine<first_probe>(state, build_data, data);                                                      \
     } else {                                                                                                         \
         X<first_probe>(state, build_data, data);                                                                     \
     }
@@ -750,48 +750,52 @@ void JoinHashMap<LT, BuildFunc, ProbeFunc>::_search_ht_impl(RuntimeState* state,
     if (!_table_items->with_other_conjunct) {
         switch (_table_items->join_type) {
         case TJoinOp::LEFT_OUTER_JOIN:
-            DO_PROBE(_probe_from_ht_for_left_outer_join, false);
+            DO_PROBE(_probe_from_ht_for_left_outer_join);
             break;
         case TJoinOp::LEFT_SEMI_JOIN:
-            DO_PROBE(_probe_from_ht_for_left_semi_join, false);
+            DO_PROBE(_probe_from_ht_for_left_semi_join);
             break;
         case TJoinOp::LEFT_ANTI_JOIN:
         case TJoinOp::NULL_AWARE_LEFT_ANTI_JOIN:
-            DO_PROBE(_probe_from_ht_for_left_anti_join, false);
+            DO_PROBE(_probe_from_ht_for_left_anti_join);
             break;
         case TJoinOp::RIGHT_OUTER_JOIN:
-            DO_PROBE(_probe_from_ht_for_right_outer_join, false);
+            DO_PROBE(_probe_from_ht_for_right_outer_join);
             break;
         case TJoinOp::RIGHT_SEMI_JOIN:
-            DO_PROBE(_probe_from_ht_for_right_semi_join, false);
+            DO_PROBE(_probe_from_ht_for_right_semi_join);
             break;
         case TJoinOp::RIGHT_ANTI_JOIN:
-            DO_PROBE(_probe_from_ht_for_right_anti_join, false);
+            DO_PROBE(_probe_from_ht_for_right_anti_join);
             break;
         case TJoinOp::FULL_OUTER_JOIN:
-            DO_PROBE(_probe_from_ht_for_full_outer_join, false);
+            DO_PROBE(_probe_from_ht_for_full_outer_join);
             break;
         default:
-            DO_PROBE(_probe_from_ht, false);
+            DO_PROBE(_probe_from_ht);
             break;
         }
     } else {
+        // as probing results of join keys are not clustered in one chunk, `build_match_index` and `build_match_index`
+        // are not completely right, resulting in wrong results when filtering other conjunct.
         switch (_table_items->join_type) {
         case TJoinOp::LEFT_SEMI_JOIN:
-            DO_PROBE(_probe_from_ht_for_left_semi_join_with_other_conjunct, true);
+            _probe_from_ht_for_left_semi_join_with_other_conjunct<first_probe>(state, build_data, data);
             break;
         case TJoinOp::NULL_AWARE_LEFT_ANTI_JOIN:
-            DO_PROBE(_probe_from_ht_for_null_aware_anti_join_with_other_conjunct, true);
+            _probe_from_ht_for_null_aware_anti_join_with_other_conjunct<first_probe>(state, build_data, data);
             break;
         case TJoinOp::RIGHT_OUTER_JOIN:
         case TJoinOp::RIGHT_SEMI_JOIN:
         case TJoinOp::RIGHT_ANTI_JOIN:
-            DO_PROBE(_probe_from_ht_for_right_outer_right_semi_right_anti_join_with_other_conjunct, false);
+            _probe_from_ht_for_right_outer_right_semi_right_anti_join_with_other_conjunct<first_probe>(
+                    state, build_data, data);
             break;
         case TJoinOp::LEFT_OUTER_JOIN:
         case TJoinOp::LEFT_ANTI_JOIN:
         case TJoinOp::FULL_OUTER_JOIN:
-            DO_PROBE(_probe_from_ht_for_left_outer_left_anti_full_outer_join_with_other_conjunct, true);
+            _probe_from_ht_for_left_outer_left_anti_full_outer_join_with_other_conjunct<first_probe>(state, build_data,
+                                                                                                     data);
             break;
         default:
             // can't reach here
@@ -894,26 +898,16 @@ void JoinHashMap<LT, BuildFunc, ProbeFunc>::_search_ht_impl(RuntimeState* state,
     match_count++;                              \
     _probe_state->cur_row_match_count++;
 
-#define MATCH_RIGHT_TABLE_ROWS_CORO()                         \
-    _probe_state->probe_index[_probe_state->match_count] = i; \
-    _probe_state->build_index[_probe_state->match_count] = j; \
-    _probe_state->probe_match_index[i]++;                     \
-    _probe_state->match_count++;                              \
-    cur_row_match_count++;
-
 /// TODO (fzh): calculate hash distribution, skew or not.
 // NOTE: coroutine only SIMD code of SSE but not AVX
 template <LogicalType LT, class BuildFunc, class ProbeFunc>
-template <bool first_probe, bool init_match>
+template <bool first_probe>
 void JoinHashMap<LT, BuildFunc, ProbeFunc>::_probe_coroutine(RuntimeState* state, const Buffer<CppType>& build_data,
                                                              const Buffer<CppType>& probe_data) {
     _probe_state->match_flag = JoinMatchFlag::NORMAL;
     _probe_state->match_count = 0;
     _probe_state->cur_row_match_count = 0;
     _probe_state->count = 0;
-    if constexpr (first_probe && init_match) {
-        _probe_state->probe_match_index.assign(state->chunk_size(), 0);
-    }
     // disorder probe id as matching steps are different for each probe
     while (!_probe_state->handles.empty()) {
         for (auto it = _probe_state->handles.begin(); it != _probe_state->handles.end();) {
@@ -1768,86 +1762,6 @@ void JoinHashMap<LT, BuildFunc, ProbeFunc>::_probe_from_ht_for_null_aware_anti_j
 }
 
 template <LogicalType LT, class BuildFunc, class ProbeFunc>
-HashTableProbeState::ProbeCoroutine
-JoinHashMap<LT, BuildFunc, ProbeFunc>::_probe_from_ht_for_null_aware_anti_join_with_other_conjunct(
-        RuntimeState* state, const Buffer<CppType>& build_data, const Buffer<CppType>& probe_data) {
-    for (size_t i = _probe_state->cur_probe_index++; i < _probe_state->probe_row_count;
-         i = _probe_state->cur_probe_index++) {
-        size_t build_index = _probe_state->next[i];
-        int cur_row_match_count = 0;
-        if (build_index == 0) {
-            bool change_flag = false;
-            if (_probe_state->null_array != nullptr && (*_probe_state->null_array)[i] == 1) {
-                // when left table col value is null needs match all rows in right table
-                for (size_t j = 1; j < _table_items->row_count + 1; j++) {
-                    change_flag = true;
-                    COWAIT_IF_CHUNK_FULL()
-                    MATCH_RIGHT_TABLE_ROWS_CORO()
-                }
-            } else if (_table_items->key_columns[0]->is_nullable()) {
-                // when left table col value not hits in hash table needs match all null value rows in right table
-                auto* nullable_column = ColumnHelper::as_raw_column<NullableColumn>(_table_items->key_columns[0]);
-                auto& null_array = nullable_column->null_column()->get_data();
-                for (size_t j = 1; j < _table_items->row_count + 1; j++) {
-                    if (null_array[j] == 1) {
-                        change_flag = true;
-                        COWAIT_IF_CHUNK_FULL()
-                        MATCH_RIGHT_TABLE_ROWS_CORO()
-                    }
-                }
-            }
-
-            if (!change_flag) {
-                COWAIT_IF_CHUNK_FULL()
-                _probe_state->probe_index[_probe_state->match_count] = i;
-                _probe_state->build_index[_probe_state->match_count] = 0;
-                _probe_state->match_count++;
-            }
-            continue;
-        } else {
-            // left table col value hits in hash table, we also need match null values firstly then match hit rows.
-            if (_table_items->key_columns[0]->is_nullable()) {
-                auto* nullable_column = ColumnHelper::as_raw_column<NullableColumn>(_table_items->key_columns[0]);
-                auto& null_array = nullable_column->null_column()->get_data();
-                for (size_t j = 1; j < _table_items->row_count + 1; j++) {
-                    if (null_array[j] == 1) {
-                        COWAIT_IF_CHUNK_FULL()
-                        MATCH_RIGHT_TABLE_ROWS_CORO()
-                    }
-                }
-            }
-        }
-
-        while (build_index != 0) {
-            PREFETCH_AND_COWAIT((build_data.data() + build_index), (_table_items->next.data() + build_index))
-            if (ProbeFunc().equal(build_data[build_index], probe_data[i])) {
-                COWAIT_IF_CHUNK_FULL()
-                _probe_state->probe_index[_probe_state->match_count] = i;
-                _probe_state->build_index[_probe_state->match_count] = build_index;
-                _probe_state->probe_match_index[i]++;
-                _probe_state->match_count++;
-                cur_row_match_count++;
-            }
-            build_index = _table_items->next[build_index];
-        }
-
-        if (cur_row_match_count <= 0) {
-            COWAIT_IF_CHUNK_FULL()
-            _probe_state->probe_index[_probe_state->match_count] = i;
-            _probe_state->build_index[_probe_state->match_count] = 0;
-            _probe_state->match_count++;
-        }
-    }
-
-    if (--_probe_state->active_coroutines > 0) {
-        co_return;
-    }
-    // only the last coroutine does
-    auto match_count = _probe_state->match_count;
-    PROBE_OVER()
-}
-
-template <LogicalType LT, class BuildFunc, class ProbeFunc>
 template <bool first_probe>
 void JoinHashMap<LT, BuildFunc, ProbeFunc>::
         _probe_from_ht_for_right_outer_right_semi_right_anti_join_with_other_conjunct(
@@ -1876,37 +1790,6 @@ void JoinHashMap<LT, BuildFunc, ProbeFunc>::
         }
     }
 
-    PROBE_OVER()
-}
-
-template <LogicalType LT, class BuildFunc, class ProbeFunc>
-HashTableProbeState::ProbeCoroutine
-JoinHashMap<LT, BuildFunc, ProbeFunc>::_probe_from_ht_for_right_outer_right_semi_right_anti_join_with_other_conjunct(
-        RuntimeState* state, const Buffer<CppType>& build_data, const Buffer<CppType>& probe_data) {
-    for (size_t i = _probe_state->cur_probe_index++; i < _probe_state->probe_row_count;
-         i = _probe_state->cur_probe_index++) {
-        size_t build_index = _probe_state->next[i];
-        if (build_index == 0) {
-            continue;
-        }
-
-        while (build_index != 0) {
-            PREFETCH_AND_COWAIT((build_data.data() + build_index), (_table_items->next.data() + build_index))
-            if (ProbeFunc().equal(build_data[build_index], probe_data[i])) {
-                COWAIT_IF_CHUNK_FULL()
-                _probe_state->probe_index[_probe_state->match_count] = i;
-                _probe_state->build_index[_probe_state->match_count] = build_index;
-                _probe_state->match_count++;
-            }
-            build_index = _table_items->next[build_index];
-        }
-    }
-
-    if (--_probe_state->active_coroutines > 0) {
-        co_return;
-    }
-    // only the last coroutine does
-    auto match_count = _probe_state->match_count;
     PROBE_OVER()
 }
 
@@ -1965,43 +1848,6 @@ void JoinHashMap<LT, BuildFunc, ProbeFunc>::_probe_from_ht_for_left_outer_left_a
         _probe_state->cur_row_match_count = 0;
     }
 
-    PROBE_OVER()
-}
-
-template <LogicalType LT, class BuildFunc, class ProbeFunc>
-HashTableProbeState::ProbeCoroutine
-JoinHashMap<LT, BuildFunc, ProbeFunc>::_probe_from_ht_for_left_outer_left_anti_full_outer_join_with_other_conjunct(
-        RuntimeState* state, const Buffer<CppType>& build_data, const Buffer<CppType>& probe_data) {
-    for (size_t i = _probe_state->cur_probe_index++; i < _probe_state->probe_row_count;
-         i = _probe_state->cur_probe_index++) {
-        size_t build_index = _probe_state->next[i];
-        int cur_row_match_count = 0;
-
-        while (build_index != 0) {
-            PREFETCH_AND_COWAIT((build_data.data() + build_index), (_table_items->next.data() + build_index))
-            if (ProbeFunc().equal(build_data[build_index], probe_data[i])) {
-                COWAIT_IF_CHUNK_FULL()
-                _probe_state->probe_index[_probe_state->match_count] = i;
-                _probe_state->build_index[_probe_state->match_count] = build_index;
-                _probe_state->probe_match_index[i]++;
-                _probe_state->match_count++;
-                cur_row_match_count++;
-            }
-            build_index = _table_items->next[build_index];
-        }
-        if (cur_row_match_count <= 0) {
-            COWAIT_IF_CHUNK_FULL()
-            _probe_state->probe_index[_probe_state->match_count] = i;
-            _probe_state->build_index[_probe_state->match_count] = 0;
-            _probe_state->match_count++;
-        }
-    }
-
-    if (--_probe_state->active_coroutines > 0) {
-        co_return;
-    }
-    // only the last coroutine does
-    auto match_count = _probe_state->match_count;
     PROBE_OVER()
 }
 

--- a/be/src/exec/join_hash_map.tpp
+++ b/be/src/exec/join_hash_map.tpp
@@ -776,7 +776,7 @@ void JoinHashMap<LT, BuildFunc, ProbeFunc>::_search_ht_impl(RuntimeState* state,
             break;
         }
     } else {
-        // as probing results of join keys are not clustered in one chunk, `build_match_index` and `build_match_index`
+        // as probing results of join keys are not clustered in one chunk, `probe_match_index` and `build_match_index`
         // are not completely right, resulting in wrong results when filtering other conjunct.
         switch (_table_items->join_type) {
         case TJoinOp::LEFT_SEMI_JOIN:

--- a/be/test/exec/join_hash_map_test.cpp
+++ b/be/test/exec/join_hash_map_test.cpp
@@ -1373,7 +1373,7 @@ TEST_F(JoinHashMapTest, SerializedJoinBuildProbeFuncNullable) {
                 probe_state.handles.insert(join_hash_map->FUNC(_runtime_state.get(), build_data, probe_data)); \
             }                                                                                                  \
             probe_state.active_coroutines = group;                                                             \
-            join_hash_map->_probe_coroutine<FIRST, INIT>(_runtime_state.get(), build_data, probe_data);        \
+            join_hash_map->_probe_coroutine<FIRST>(_runtime_state.get(), build_data, probe_data);              \
             sort_results_from_coroutine(probe_state.probe_index, probe_state.build_index, probe_state.count);  \
         }
 
@@ -1381,7 +1381,7 @@ TEST_F(JoinHashMapTest, SerializedJoinBuildProbeFuncNullable) {
     if (group == 0) {                                                                                     \
         join_hash_map->FUNC<false>(_runtime_state.get(), build_data, probe_data);                         \
     } else {                                                                                              \
-        join_hash_map->_probe_coroutine<false, false>(_runtime_state.get(), build_data, probe_data);      \
+        join_hash_map->_probe_coroutine<false>(_runtime_state.get(), build_data, probe_data);             \
         sort_results_from_coroutine(probe_state.probe_index, probe_state.build_index, probe_state.count); \
     }
 
@@ -1658,7 +1658,8 @@ TEST_F(JoinHashMapTest, ProbeFromHtForLeftJoinNextEmptyCoro) {
     this->prepare_probe_data(&probe_data, probe_row_count);
 
     auto join_hash_map = std::make_unique<JoinHashMapForOneKey(TYPE_INT)>(&table_items, &probe_state);
-    DO_TEST_PROBE(_probe_from_ht_for_left_outer_left_anti_full_outer_join_with_other_conjunct, true, true)
+    join_hash_map->_probe_from_ht_for_left_outer_left_anti_full_outer_join_with_other_conjunct<true>(
+            _runtime_state.get(), build_data, probe_data);
     std::vector<std::pair<uint32_t, uint32_t>> results;
     ASSERT_EQ(probe_state.match_flag, JoinMatchFlag::NORMAL);
     ASSERT_EQ(probe_state.count, 4096);
@@ -1666,7 +1667,8 @@ TEST_F(JoinHashMapTest, ProbeFromHtForLeftJoinNextEmptyCoro) {
         results.push_back(std::make_pair(probe_state.probe_index[i], probe_state.build_index[i]));
     }
 
-    DO_TEST_PROBE_MID(_probe_from_ht_for_left_outer_left_anti_full_outer_join_with_other_conjunct)
+    join_hash_map->_probe_from_ht_for_left_outer_left_anti_full_outer_join_with_other_conjunct<false>(
+            _runtime_state.get(), build_data, probe_data);
     ASSERT_EQ(probe_state.match_flag, JoinMatchFlag::NORMAL);
     ASSERT_FALSE(probe_state.has_remain);
     ASSERT_EQ(probe_state.count, 1904);
@@ -1743,7 +1745,8 @@ TEST_F(JoinHashMapTest, ProbeFromHtForRightXXXJoinWithOtherConjunctCoro) {
         this->prepare_probe_data(&probe_data, probe_row_count);
 
         auto join_hash_map = std::make_unique<JoinHashMapForOneKey(TYPE_INT)>(&table_items, &probe_state);
-        DO_TEST_PROBE(_probe_from_ht_for_right_outer_right_semi_right_anti_join_with_other_conjunct, true, true)
+        join_hash_map->_probe_from_ht_for_right_outer_right_semi_right_anti_join_with_other_conjunct<true>(
+                _runtime_state.get(), build_data, probe_data);
         std::vector<std::pair<uint32_t, uint32_t>> results;
         ASSERT_EQ(probe_state.match_flag, JoinMatchFlag::NORMAL);
         ASSERT_EQ(probe_state.count, 4096);
@@ -1751,7 +1754,8 @@ TEST_F(JoinHashMapTest, ProbeFromHtForRightXXXJoinWithOtherConjunctCoro) {
             results.push_back(std::make_pair(probe_state.probe_index[i], probe_state.build_index[i]));
         }
 
-        DO_TEST_PROBE_MID(_probe_from_ht_for_right_outer_right_semi_right_anti_join_with_other_conjunct)
+        join_hash_map->_probe_from_ht_for_right_outer_right_semi_right_anti_join_with_other_conjunct<false>(
+                _runtime_state.get(), build_data, probe_data);
         ASSERT_EQ(probe_state.match_flag, JoinMatchFlag::NORMAL);
         ASSERT_FALSE(probe_state.has_remain);
         ASSERT_EQ(probe_state.count, 1904);

--- a/be/test/exec/join_hash_map_test.cpp
+++ b/be/test/exec/join_hash_map_test.cpp
@@ -1643,7 +1643,7 @@ TEST_F(JoinHashMapTest, ProbeFromHtForLeftJoinNextEmpty) {
 }
 
 // NOLINTNEXTLINE
-TEST_F(JoinHashMapTest, ProbeFromHtForLeftJoinNextEmptyCoro) {
+TEST_F(JoinHashMapTest, ProbeFromHtForLeftJoinNextEmptyMore) {
     JoinHashTableItems table_items;
     HashTableProbeState probe_state;
     Buffer<int32_t> build_data;
@@ -1691,7 +1691,6 @@ TEST_F(JoinHashMapTest, ProbeFromHtForLeftJoinNextEmptyCoro) {
         ASSERT_EQ(results[3 * i + 2].second, i + 1);
         ASSERT_EQ(match_count, probe_state.probe_match_index[i]);
     }
-    DO_TEST_PROBE_END()
 }
 
 // Test case for right semi join with other conjunct.
@@ -1729,7 +1728,7 @@ TEST_F(JoinHashMapTest, ProbeFromHtForRightXXXJoinWithOtherConjunct) {
     }
 }
 
-TEST_F(JoinHashMapTest, ProbeFromHtForRightXXXJoinWithOtherConjunctCoro) {
+TEST_F(JoinHashMapTest, ProbeFromHtForRightXXXJoinWithOtherConjunctMore) {
     for (auto& join_type : {TJoinOp::RIGHT_SEMI_JOIN, TJoinOp::RIGHT_OUTER_JOIN, TJoinOp::RIGHT_ANTI_JOIN}) {
         JoinHashTableItems table_items;
         HashTableProbeState probe_state;
@@ -1777,7 +1776,6 @@ TEST_F(JoinHashMapTest, ProbeFromHtForRightXXXJoinWithOtherConjunctCoro) {
             ASSERT_EQ(results[3 * i + 2].first, i);
             ASSERT_EQ(results[3 * i + 2].second, i + 1);
         }
-        DO_TEST_PROBE_END()
     }
 }
 

--- a/test/sql/test_join/R/test_interleaving_join
+++ b/test/sql/test_join/R/test_interleaving_join
@@ -1,0 +1,483 @@
+-- name: test interleaving join
+CREATE TABLE `lineitem` (
+  `l_orderkey` int(11) NOT NULL COMMENT "",
+  `l_partkey` int(11) NOT NULL COMMENT "",
+  `l_suppkey` int(11)
+) ENGINE=OLAP
+DUPLICATE KEY(`l_orderkey`)
+COMMENT "OLAP"
+DISTRIBUTED BY HASH(`l_orderkey`) BUCKETS 1
+PROPERTIES (
+"compression" = "LZ4",
+"fast_schema_evolution" = "true",
+"replicated_storage" = "true",
+"replication_num" = "1"
+);
+-- result:
+-- !result
+insert into lineitem values (1,1,1),(1,2,1),(1,3,2),(11,1,11),(11,2,1),(2,3,2),(2,3,null);
+-- result:
+-- !result
+set pipeline_dop = 1;
+-- result:
+-- !result
+set chunk_size = 2;
+-- result:
+-- !result
+set interleaving_group_size =0;
+-- result:
+-- !result
+select count(*) as c from lineitem l1  join lineitem l3 on l3.l_orderkey = l1.l_orderkey and l3.l_suppkey <> l1.l_suppkey;
+-- result:
+6
+-- !result
+set interleaving_group_size =-10;
+-- result:
+-- !result
+select count(*) as c from lineitem l1  join lineitem l3 on l3.l_orderkey = l1.l_orderkey and l3.l_suppkey <> l1.l_suppkey;
+-- result:
+6
+-- !result
+set interleaving_group_size =0;
+-- result:
+-- !result
+select count(*) as c from lineitem l1 left join lineitem l3 on l3.l_orderkey = l1.l_orderkey and l3.l_suppkey <> l1.l_suppkey;
+-- result:
+8
+-- !result
+set interleaving_group_size =-10;
+-- result:
+-- !result
+select count(*) as c from lineitem l1 left join lineitem l3 on l3.l_orderkey = l1.l_orderkey and l3.l_suppkey <> l1.l_suppkey;
+-- result:
+8
+-- !result
+set interleaving_group_size =0;
+-- result:
+-- !result
+select count(*) as c from lineitem l1 where not exists ( select * from lineitem l3 where l3.l_orderkey = l1.l_orderkey and l3.l_suppkey <> l1.l_suppkey );
+-- result:
+2
+-- !result
+set interleaving_group_size =-10;
+-- result:
+-- !result
+select count(*) as c from lineitem l1 where not exists ( select * from lineitem l3 where l3.l_orderkey = l1.l_orderkey and l3.l_suppkey <> l1.l_suppkey );
+-- result:
+2
+-- !result
+set interleaving_group_size =0;
+-- result:
+-- !result
+select count(*) as c from lineitem l1 where l1.l_orderkey not in ( select l3.l_orderkey from lineitem l3 where  l3.l_suppkey <> l1.l_suppkey );
+-- result:
+3
+-- !result
+set interleaving_group_size =-10;
+-- result:
+-- !result
+select count(*) as c from lineitem l1 where l1.l_orderkey not in ( select l3.l_orderkey from lineitem l3 where  l3.l_suppkey <> l1.l_suppkey );
+-- result:
+3
+-- !result
+set interleaving_group_size =0;
+-- result:
+-- !result
+select count(*) as c from lineitem l1 where exists ( select * from lineitem l3 where l3.l_orderkey = l1.l_orderkey and l3.l_suppkey <> l1.l_suppkey );
+-- result:
+5
+-- !result
+set interleaving_group_size =-10;
+-- result:
+-- !result
+select count(*) as c from lineitem l1 where exists ( select * from lineitem l3 where l3.l_orderkey = l1.l_orderkey and l3.l_suppkey <> l1.l_suppkey );
+-- result:
+5
+-- !result
+set interleaving_group_size =0;
+-- result:
+-- !result
+select count(*) as c from lineitem l1 where l1.l_orderkey in ( select l3.l_orderkey from lineitem l3 where  l3.l_suppkey <> l1.l_suppkey );
+-- result:
+5
+-- !result
+set interleaving_group_size =-10;
+-- result:
+-- !result
+select count(*) as c from lineitem l1 where l1.l_orderkey in ( select l3.l_orderkey from lineitem l3 where  l3.l_suppkey <> l1.l_suppkey );
+-- result:
+5
+-- !result
+set interleaving_group_size =0;
+-- result:
+-- !result
+select count(*) as c from lineitem l1 right join lineitem l3 on l3.l_orderkey = l1.l_orderkey and l3.l_suppkey <> l1.l_suppkey;
+-- result:
+8
+-- !result
+set interleaving_group_size =-10;
+-- result:
+-- !result
+select count(*) as c from lineitem l1 right join lineitem l3 on l3.l_orderkey = l1.l_orderkey and l3.l_suppkey <> l1.l_suppkey;
+-- result:
+8
+-- !result
+set interleaving_group_size =0;
+-- result:
+-- !result
+select count(*) as c from lineitem l1 full outer join lineitem l3 on l3.l_orderkey = l1.l_orderkey and l3.l_suppkey <> l1.l_suppkey;
+-- result:
+10
+-- !result
+set interleaving_group_size =-10;
+-- result:
+-- !result
+select count(*) as c from lineitem l1 full outer join lineitem l3 on l3.l_orderkey = l1.l_orderkey and l3.l_suppkey <> l1.l_suppkey;
+-- result:
+10
+-- !result
+set chunk_size = 3;
+-- result:
+-- !result
+set interleaving_group_size =0;
+-- result:
+-- !result
+select count(*) as c from lineitem l1  join lineitem l3 on l3.l_orderkey = l1.l_orderkey and l3.l_suppkey <> l1.l_suppkey;
+-- result:
+6
+-- !result
+set interleaving_group_size =-10;
+-- result:
+-- !result
+select count(*) as c from lineitem l1  join lineitem l3 on l3.l_orderkey = l1.l_orderkey and l3.l_suppkey <> l1.l_suppkey;
+-- result:
+6
+-- !result
+set interleaving_group_size =0;
+-- result:
+-- !result
+select count(*) as c from lineitem l1 left join lineitem l3 on l3.l_orderkey = l1.l_orderkey and l3.l_suppkey <> l1.l_suppkey;
+-- result:
+8
+-- !result
+set interleaving_group_size =-10;
+-- result:
+-- !result
+select count(*) as c from lineitem l1 left join lineitem l3 on l3.l_orderkey = l1.l_orderkey and l3.l_suppkey <> l1.l_suppkey;
+-- result:
+8
+-- !result
+set interleaving_group_size =0;
+-- result:
+-- !result
+select count(*) as c from lineitem l1 where not exists ( select * from lineitem l3 where l3.l_orderkey = l1.l_orderkey and l3.l_suppkey <> l1.l_suppkey );
+-- result:
+2
+-- !result
+set interleaving_group_size =-10;
+-- result:
+-- !result
+select count(*) as c from lineitem l1 where not exists ( select * from lineitem l3 where l3.l_orderkey = l1.l_orderkey and l3.l_suppkey <> l1.l_suppkey );
+-- result:
+2
+-- !result
+set interleaving_group_size =0;
+-- result:
+-- !result
+select count(*) as c from lineitem l1 where l1.l_orderkey not in ( select l3.l_orderkey from lineitem l3 where  l3.l_suppkey <> l1.l_suppkey );
+-- result:
+3
+-- !result
+set interleaving_group_size =-10;
+-- result:
+-- !result
+select count(*) as c from lineitem l1 where l1.l_orderkey not in ( select l3.l_orderkey from lineitem l3 where  l3.l_suppkey <> l1.l_suppkey );
+-- result:
+3
+-- !result
+set interleaving_group_size =0;
+-- result:
+-- !result
+select count(*) as c from lineitem l1 where exists ( select * from lineitem l3 where l3.l_orderkey = l1.l_orderkey and l3.l_suppkey <> l1.l_suppkey );
+-- result:
+5
+-- !result
+set interleaving_group_size =-10;
+-- result:
+-- !result
+select count(*) as c from lineitem l1 where exists ( select * from lineitem l3 where l3.l_orderkey = l1.l_orderkey and l3.l_suppkey <> l1.l_suppkey );
+-- result:
+5
+-- !result
+set interleaving_group_size =0;
+-- result:
+-- !result
+select count(*) as c from lineitem l1 where l1.l_orderkey in ( select l3.l_orderkey from lineitem l3 where  l3.l_suppkey <> l1.l_suppkey );
+-- result:
+5
+-- !result
+set interleaving_group_size =-10;
+-- result:
+-- !result
+select count(*) as c from lineitem l1 where l1.l_orderkey in ( select l3.l_orderkey from lineitem l3 where  l3.l_suppkey <> l1.l_suppkey );
+-- result:
+5
+-- !result
+set interleaving_group_size =0;
+-- result:
+-- !result
+select count(*) as c from lineitem l1 right join lineitem l3 on l3.l_orderkey = l1.l_orderkey and l3.l_suppkey <> l1.l_suppkey;
+-- result:
+8
+-- !result
+set interleaving_group_size =-10;
+-- result:
+-- !result
+select count(*) as c from lineitem l1 right join lineitem l3 on l3.l_orderkey = l1.l_orderkey and l3.l_suppkey <> l1.l_suppkey;
+-- result:
+8
+-- !result
+set interleaving_group_size =0;
+-- result:
+-- !result
+select count(*) as c from lineitem l1 full outer join lineitem l3 on l3.l_orderkey = l1.l_orderkey and l3.l_suppkey <> l1.l_suppkey;
+-- result:
+10
+-- !result
+set interleaving_group_size =-10;
+-- result:
+-- !result
+select count(*) as c from lineitem l1 full outer join lineitem l3 on l3.l_orderkey = l1.l_orderkey and l3.l_suppkey <> l1.l_suppkey;
+-- result:
+10
+-- !result
+set chunk_size = 2;
+-- result:
+-- !result
+set interleaving_group_size =0;
+-- result:
+-- !result
+select count(*) as c from lineitem l1  join lineitem l3 on l3.l_orderkey = l1.l_orderkey and l3.l_suppkey = l1.l_suppkey;
+-- result:
+8
+-- !result
+set interleaving_group_size =-10;
+-- result:
+-- !result
+select count(*) as c from lineitem l1  join lineitem l3 on l3.l_orderkey = l1.l_orderkey and l3.l_suppkey = l1.l_suppkey;
+-- result:
+8
+-- !result
+set interleaving_group_size =0;
+-- result:
+-- !result
+select count(*) as c from lineitem l1 left join lineitem l3 on l3.l_orderkey = l1.l_orderkey and l3.l_suppkey = l1.l_suppkey;
+-- result:
+9
+-- !result
+set interleaving_group_size =-10;
+-- result:
+-- !result
+select count(*) as c from lineitem l1 left join lineitem l3 on l3.l_orderkey = l1.l_orderkey and l3.l_suppkey = l1.l_suppkey;
+-- result:
+9
+-- !result
+set interleaving_group_size =0;
+-- result:
+-- !result
+select count(*) as c from lineitem l1 where not exists ( select * from lineitem l3 where l3.l_orderkey = l1.l_orderkey and l3.l_suppkey = l1.l_suppkey );
+-- result:
+1
+-- !result
+set interleaving_group_size =-10;
+-- result:
+-- !result
+select count(*) as c from lineitem l1 where not exists ( select * from lineitem l3 where l3.l_orderkey = l1.l_orderkey and l3.l_suppkey = l1.l_suppkey );
+-- result:
+1
+-- !result
+set interleaving_group_size =0;
+-- result:
+-- !result
+select count(*) as c from lineitem l1 where l1.l_orderkey not in ( select l3.l_orderkey from lineitem l3 where  l3.l_suppkey <> l1.l_suppkey );
+-- result:
+3
+-- !result
+set interleaving_group_size =-10;
+-- result:
+-- !result
+select count(*) as c from lineitem l1 where l1.l_orderkey not in ( select l3.l_orderkey from lineitem l3 where  l3.l_suppkey <> l1.l_suppkey );
+-- result:
+3
+-- !result
+set interleaving_group_size =0;
+-- result:
+-- !result
+select count(*) as c from lineitem l1 where exists ( select * from lineitem l3 where l3.l_orderkey = l1.l_orderkey and l3.l_suppkey = l1.l_suppkey );
+-- result:
+6
+-- !result
+set interleaving_group_size =-10;
+-- result:
+-- !result
+select count(*) as c from lineitem l1 where exists ( select * from lineitem l3 where l3.l_orderkey = l1.l_orderkey and l3.l_suppkey = l1.l_suppkey );
+-- result:
+6
+-- !result
+set interleaving_group_size =0;
+-- result:
+-- !result
+select count(*) as c from lineitem l1 where l1.l_orderkey in ( select l3.l_orderkey from lineitem l3 where  l3.l_suppkey <> l1.l_suppkey );
+-- result:
+5
+-- !result
+set interleaving_group_size =-10;
+-- result:
+-- !result
+select count(*) as c from lineitem l1 where l1.l_orderkey in ( select l3.l_orderkey from lineitem l3 where  l3.l_suppkey <> l1.l_suppkey );
+-- result:
+5
+-- !result
+set interleaving_group_size =0;
+-- result:
+-- !result
+select count(*) as c from lineitem l1 right join lineitem l3 on l3.l_orderkey = l1.l_orderkey and l3.l_suppkey = l1.l_suppkey;
+-- result:
+9
+-- !result
+set interleaving_group_size =-10;
+-- result:
+-- !result
+select count(*) as c from lineitem l1 right join lineitem l3 on l3.l_orderkey = l1.l_orderkey and l3.l_suppkey = l1.l_suppkey;
+-- result:
+9
+-- !result
+set interleaving_group_size =0;
+-- result:
+-- !result
+select count(*) as c from lineitem l1 full outer join lineitem l3 on l3.l_orderkey = l1.l_orderkey and l3.l_suppkey = l1.l_suppkey;
+-- result:
+10
+-- !result
+set interleaving_group_size =-10;
+-- result:
+-- !result
+select count(*) as c from lineitem l1 full outer join lineitem l3 on l3.l_orderkey = l1.l_orderkey and l3.l_suppkey = l1.l_suppkey;
+-- result:
+10
+-- !result
+set chunk_size = 3;
+-- result:
+-- !result
+set interleaving_group_size =0;
+-- result:
+-- !result
+select count(*) as c from lineitem l1  join lineitem l3 on l3.l_orderkey = l1.l_orderkey and l3.l_suppkey = l1.l_suppkey;
+-- result:
+8
+-- !result
+set interleaving_group_size =-10;
+-- result:
+-- !result
+select count(*) as c from lineitem l1  join lineitem l3 on l3.l_orderkey = l1.l_orderkey and l3.l_suppkey = l1.l_suppkey;
+-- result:
+8
+-- !result
+set interleaving_group_size =0;
+-- result:
+-- !result
+select count(*) as c from lineitem l1 left join lineitem l3 on l3.l_orderkey = l1.l_orderkey and l3.l_suppkey = l1.l_suppkey;
+-- result:
+9
+-- !result
+set interleaving_group_size =-10;
+-- result:
+-- !result
+select count(*) as c from lineitem l1 left join lineitem l3 on l3.l_orderkey = l1.l_orderkey and l3.l_suppkey = l1.l_suppkey;
+-- result:
+9
+-- !result
+set interleaving_group_size =0;
+-- result:
+-- !result
+select count(*) as c from lineitem l1 where not exists ( select * from lineitem l3 where l3.l_orderkey = l1.l_orderkey and l3.l_suppkey = l1.l_suppkey );
+-- result:
+1
+-- !result
+set interleaving_group_size =-10;
+-- result:
+-- !result
+select count(*) as c from lineitem l1 where not exists ( select * from lineitem l3 where l3.l_orderkey = l1.l_orderkey and l3.l_suppkey = l1.l_suppkey );
+-- result:
+1
+-- !result
+set interleaving_group_size =0;
+-- result:
+-- !result
+select count(*) as c from lineitem l1 where l1.l_orderkey not in ( select l3.l_orderkey from lineitem l3 where  l3.l_suppkey <> l1.l_suppkey );
+-- result:
+3
+-- !result
+set interleaving_group_size =-10;
+-- result:
+-- !result
+select count(*) as c from lineitem l1 where l1.l_orderkey not in ( select l3.l_orderkey from lineitem l3 where  l3.l_suppkey <> l1.l_suppkey );
+-- result:
+3
+-- !result
+set interleaving_group_size =0;
+-- result:
+-- !result
+select count(*) as c from lineitem l1 where exists ( select * from lineitem l3 where l3.l_orderkey = l1.l_orderkey and l3.l_suppkey = l1.l_suppkey );
+-- result:
+6
+-- !result
+set interleaving_group_size =-10;
+-- result:
+-- !result
+select count(*) as c from lineitem l1 where exists ( select * from lineitem l3 where l3.l_orderkey = l1.l_orderkey and l3.l_suppkey = l1.l_suppkey );
+-- result:
+6
+-- !result
+set interleaving_group_size =0;
+-- result:
+-- !result
+select count(*) as c from lineitem l1 where l1.l_orderkey in ( select l3.l_orderkey from lineitem l3 where  l3.l_suppkey <> l1.l_suppkey );
+-- result:
+5
+-- !result
+set interleaving_group_size =-10;
+-- result:
+-- !result
+select count(*) as c from lineitem l1 where l1.l_orderkey in ( select l3.l_orderkey from lineitem l3 where  l3.l_suppkey <> l1.l_suppkey );
+-- result:
+5
+-- !result
+set interleaving_group_size =0;
+-- result:
+-- !result
+select count(*) as c from lineitem l1 right join lineitem l3 on l3.l_orderkey = l1.l_orderkey and l3.l_suppkey = l1.l_suppkey;
+-- result:
+9
+-- !result
+set interleaving_group_size =-10;
+-- result:
+-- !result
+select count(*) as c from lineitem l1 right join lineitem l3 on l3.l_orderkey = l1.l_orderkey and l3.l_suppkey = l1.l_suppkey;
+-- result:
+9
+-- !result
+set interleaving_group_size =0;
+-- result:
+-- !result
+select count(*) as c from lineitem l1 full outer join lineitem l3 on l3.l_orderkey = l1.l_orderkey and l3.l_suppkey = l1.l_suppkey;
+-- result:
+10
+-- !result
+set interleaving_group_size =-10;
+-- result:
+-- !result
+select count(*) as c from lineitem l1 full outer join lineitem l3 on l3.l_orderkey = l1.l_orderkey and l3.l_suppkey = l1.l_suppkey;
+-- result:
+10
+-- !result

--- a/test/sql/test_join/T/test_interleaving_join
+++ b/test/sql/test_join/T/test_interleaving_join
@@ -1,0 +1,180 @@
+-- name: test interleaving join
+CREATE TABLE `lineitem` (
+  `l_orderkey` int(11) NOT NULL COMMENT "",
+  `l_partkey` int(11) NOT NULL COMMENT "",
+  `l_suppkey` int(11)
+) ENGINE=OLAP
+DUPLICATE KEY(`l_orderkey`)
+COMMENT "OLAP"
+DISTRIBUTED BY HASH(`l_orderkey`) BUCKETS 1
+PROPERTIES (
+"compression" = "LZ4",
+"fast_schema_evolution" = "true",
+"replicated_storage" = "true",
+"replication_num" = "1"
+);
+
+insert into lineitem values (1,1,1),(1,2,1),(1,3,2),(11,1,11),(11,2,1),(2,3,2),(2,3,null);
+set pipeline_dop = 1;
+---- join with other conjunct
+set chunk_size = 2;
+set interleaving_group_size =0;
+select count(*) as c from lineitem l1  join lineitem l3 on l3.l_orderkey = l1.l_orderkey and l3.l_suppkey <> l1.l_suppkey;
+set interleaving_group_size =-10;
+select count(*) as c from lineitem l1  join lineitem l3 on l3.l_orderkey = l1.l_orderkey and l3.l_suppkey <> l1.l_suppkey;
+
+set interleaving_group_size =0;
+select count(*) as c from lineitem l1 left join lineitem l3 on l3.l_orderkey = l1.l_orderkey and l3.l_suppkey <> l1.l_suppkey;
+set interleaving_group_size =-10;
+select count(*) as c from lineitem l1 left join lineitem l3 on l3.l_orderkey = l1.l_orderkey and l3.l_suppkey <> l1.l_suppkey;
+set interleaving_group_size =0;
+select count(*) as c from lineitem l1 where not exists ( select * from lineitem l3 where l3.l_orderkey = l1.l_orderkey and l3.l_suppkey <> l1.l_suppkey );
+set interleaving_group_size =-10;
+select count(*) as c from lineitem l1 where not exists ( select * from lineitem l3 where l3.l_orderkey = l1.l_orderkey and l3.l_suppkey <> l1.l_suppkey );
+
+set interleaving_group_size =0;
+select count(*) as c from lineitem l1 where l1.l_orderkey not in ( select l3.l_orderkey from lineitem l3 where  l3.l_suppkey <> l1.l_suppkey );
+set interleaving_group_size =-10;
+select count(*) as c from lineitem l1 where l1.l_orderkey not in ( select l3.l_orderkey from lineitem l3 where  l3.l_suppkey <> l1.l_suppkey );
+
+set interleaving_group_size =0;
+select count(*) as c from lineitem l1 where exists ( select * from lineitem l3 where l3.l_orderkey = l1.l_orderkey and l3.l_suppkey <> l1.l_suppkey );
+set interleaving_group_size =-10;
+select count(*) as c from lineitem l1 where exists ( select * from lineitem l3 where l3.l_orderkey = l1.l_orderkey and l3.l_suppkey <> l1.l_suppkey );
+
+set interleaving_group_size =0;
+select count(*) as c from lineitem l1 where l1.l_orderkey in ( select l3.l_orderkey from lineitem l3 where  l3.l_suppkey <> l1.l_suppkey );
+set interleaving_group_size =-10;
+select count(*) as c from lineitem l1 where l1.l_orderkey in ( select l3.l_orderkey from lineitem l3 where  l3.l_suppkey <> l1.l_suppkey );
+
+set interleaving_group_size =0;
+select count(*) as c from lineitem l1 right join lineitem l3 on l3.l_orderkey = l1.l_orderkey and l3.l_suppkey <> l1.l_suppkey;
+set interleaving_group_size =-10;
+select count(*) as c from lineitem l1 right join lineitem l3 on l3.l_orderkey = l1.l_orderkey and l3.l_suppkey <> l1.l_suppkey;
+
+set interleaving_group_size =0;
+select count(*) as c from lineitem l1 full outer join lineitem l3 on l3.l_orderkey = l1.l_orderkey and l3.l_suppkey <> l1.l_suppkey;
+set interleaving_group_size =-10;
+select count(*) as c from lineitem l1 full outer join lineitem l3 on l3.l_orderkey = l1.l_orderkey and l3.l_suppkey <> l1.l_suppkey;
+
+set chunk_size = 3;
+set interleaving_group_size =0;
+select count(*) as c from lineitem l1  join lineitem l3 on l3.l_orderkey = l1.l_orderkey and l3.l_suppkey <> l1.l_suppkey;
+set interleaving_group_size =-10;
+select count(*) as c from lineitem l1  join lineitem l3 on l3.l_orderkey = l1.l_orderkey and l3.l_suppkey <> l1.l_suppkey;
+
+set interleaving_group_size =0;
+select count(*) as c from lineitem l1 left join lineitem l3 on l3.l_orderkey = l1.l_orderkey and l3.l_suppkey <> l1.l_suppkey;
+set interleaving_group_size =-10;
+select count(*) as c from lineitem l1 left join lineitem l3 on l3.l_orderkey = l1.l_orderkey and l3.l_suppkey <> l1.l_suppkey;
+set interleaving_group_size =0;
+select count(*) as c from lineitem l1 where not exists ( select * from lineitem l3 where l3.l_orderkey = l1.l_orderkey and l3.l_suppkey <> l1.l_suppkey );
+set interleaving_group_size =-10;
+select count(*) as c from lineitem l1 where not exists ( select * from lineitem l3 where l3.l_orderkey = l1.l_orderkey and l3.l_suppkey <> l1.l_suppkey );
+
+set interleaving_group_size =0;
+select count(*) as c from lineitem l1 where l1.l_orderkey not in ( select l3.l_orderkey from lineitem l3 where  l3.l_suppkey <> l1.l_suppkey );
+set interleaving_group_size =-10;
+select count(*) as c from lineitem l1 where l1.l_orderkey not in ( select l3.l_orderkey from lineitem l3 where  l3.l_suppkey <> l1.l_suppkey );
+
+set interleaving_group_size =0;
+select count(*) as c from lineitem l1 where exists ( select * from lineitem l3 where l3.l_orderkey = l1.l_orderkey and l3.l_suppkey <> l1.l_suppkey );
+set interleaving_group_size =-10;
+select count(*) as c from lineitem l1 where exists ( select * from lineitem l3 where l3.l_orderkey = l1.l_orderkey and l3.l_suppkey <> l1.l_suppkey );
+
+set interleaving_group_size =0;
+select count(*) as c from lineitem l1 where l1.l_orderkey in ( select l3.l_orderkey from lineitem l3 where  l3.l_suppkey <> l1.l_suppkey );
+set interleaving_group_size =-10;
+select count(*) as c from lineitem l1 where l1.l_orderkey in ( select l3.l_orderkey from lineitem l3 where  l3.l_suppkey <> l1.l_suppkey );
+
+set interleaving_group_size =0;
+select count(*) as c from lineitem l1 right join lineitem l3 on l3.l_orderkey = l1.l_orderkey and l3.l_suppkey <> l1.l_suppkey;
+set interleaving_group_size =-10;
+select count(*) as c from lineitem l1 right join lineitem l3 on l3.l_orderkey = l1.l_orderkey and l3.l_suppkey <> l1.l_suppkey;
+
+set interleaving_group_size =0;
+select count(*) as c from lineitem l1 full outer join lineitem l3 on l3.l_orderkey = l1.l_orderkey and l3.l_suppkey <> l1.l_suppkey;
+set interleaving_group_size =-10;
+select count(*) as c from lineitem l1 full outer join lineitem l3 on l3.l_orderkey = l1.l_orderkey and l3.l_suppkey <> l1.l_suppkey;
+
+----- join without other conjuncts
+
+set chunk_size = 2;
+set interleaving_group_size =0;
+select count(*) as c from lineitem l1  join lineitem l3 on l3.l_orderkey = l1.l_orderkey and l3.l_suppkey = l1.l_suppkey;
+set interleaving_group_size =-10;
+select count(*) as c from lineitem l1  join lineitem l3 on l3.l_orderkey = l1.l_orderkey and l3.l_suppkey = l1.l_suppkey;
+
+set interleaving_group_size =0;
+select count(*) as c from lineitem l1 left join lineitem l3 on l3.l_orderkey = l1.l_orderkey and l3.l_suppkey = l1.l_suppkey;
+set interleaving_group_size =-10;
+select count(*) as c from lineitem l1 left join lineitem l3 on l3.l_orderkey = l1.l_orderkey and l3.l_suppkey = l1.l_suppkey;
+set interleaving_group_size =0;
+select count(*) as c from lineitem l1 where not exists ( select * from lineitem l3 where l3.l_orderkey = l1.l_orderkey and l3.l_suppkey = l1.l_suppkey );
+set interleaving_group_size =-10;
+select count(*) as c from lineitem l1 where not exists ( select * from lineitem l3 where l3.l_orderkey = l1.l_orderkey and l3.l_suppkey = l1.l_suppkey );
+
+set interleaving_group_size =0;
+select count(*) as c from lineitem l1 where l1.l_orderkey not in ( select l3.l_orderkey from lineitem l3 where  l3.l_suppkey <> l1.l_suppkey );
+set interleaving_group_size =-10;
+select count(*) as c from lineitem l1 where l1.l_orderkey not in ( select l3.l_orderkey from lineitem l3 where  l3.l_suppkey <> l1.l_suppkey );
+
+set interleaving_group_size =0;
+select count(*) as c from lineitem l1 where exists ( select * from lineitem l3 where l3.l_orderkey = l1.l_orderkey and l3.l_suppkey = l1.l_suppkey );
+set interleaving_group_size =-10;
+select count(*) as c from lineitem l1 where exists ( select * from lineitem l3 where l3.l_orderkey = l1.l_orderkey and l3.l_suppkey = l1.l_suppkey );
+
+set interleaving_group_size =0;
+select count(*) as c from lineitem l1 where l1.l_orderkey in ( select l3.l_orderkey from lineitem l3 where  l3.l_suppkey <> l1.l_suppkey );
+set interleaving_group_size =-10;
+select count(*) as c from lineitem l1 where l1.l_orderkey in ( select l3.l_orderkey from lineitem l3 where  l3.l_suppkey <> l1.l_suppkey );
+
+set interleaving_group_size =0;
+select count(*) as c from lineitem l1 right join lineitem l3 on l3.l_orderkey = l1.l_orderkey and l3.l_suppkey = l1.l_suppkey;
+set interleaving_group_size =-10;
+select count(*) as c from lineitem l1 right join lineitem l3 on l3.l_orderkey = l1.l_orderkey and l3.l_suppkey = l1.l_suppkey;
+
+set interleaving_group_size =0;
+select count(*) as c from lineitem l1 full outer join lineitem l3 on l3.l_orderkey = l1.l_orderkey and l3.l_suppkey = l1.l_suppkey;
+set interleaving_group_size =-10;
+select count(*) as c from lineitem l1 full outer join lineitem l3 on l3.l_orderkey = l1.l_orderkey and l3.l_suppkey = l1.l_suppkey;
+
+set chunk_size = 3;
+set interleaving_group_size =0;
+select count(*) as c from lineitem l1  join lineitem l3 on l3.l_orderkey = l1.l_orderkey and l3.l_suppkey = l1.l_suppkey;
+set interleaving_group_size =-10;
+select count(*) as c from lineitem l1  join lineitem l3 on l3.l_orderkey = l1.l_orderkey and l3.l_suppkey = l1.l_suppkey;
+
+set interleaving_group_size =0;
+select count(*) as c from lineitem l1 left join lineitem l3 on l3.l_orderkey = l1.l_orderkey and l3.l_suppkey = l1.l_suppkey;
+set interleaving_group_size =-10;
+select count(*) as c from lineitem l1 left join lineitem l3 on l3.l_orderkey = l1.l_orderkey and l3.l_suppkey = l1.l_suppkey;
+set interleaving_group_size =0;
+select count(*) as c from lineitem l1 where not exists ( select * from lineitem l3 where l3.l_orderkey = l1.l_orderkey and l3.l_suppkey = l1.l_suppkey );
+set interleaving_group_size =-10;
+select count(*) as c from lineitem l1 where not exists ( select * from lineitem l3 where l3.l_orderkey = l1.l_orderkey and l3.l_suppkey = l1.l_suppkey );
+
+set interleaving_group_size =0;
+select count(*) as c from lineitem l1 where l1.l_orderkey not in ( select l3.l_orderkey from lineitem l3 where  l3.l_suppkey <> l1.l_suppkey );
+set interleaving_group_size =-10;
+select count(*) as c from lineitem l1 where l1.l_orderkey not in ( select l3.l_orderkey from lineitem l3 where  l3.l_suppkey <> l1.l_suppkey );
+
+set interleaving_group_size =0;
+select count(*) as c from lineitem l1 where exists ( select * from lineitem l3 where l3.l_orderkey = l1.l_orderkey and l3.l_suppkey = l1.l_suppkey );
+set interleaving_group_size =-10;
+select count(*) as c from lineitem l1 where exists ( select * from lineitem l3 where l3.l_orderkey = l1.l_orderkey and l3.l_suppkey = l1.l_suppkey );
+
+set interleaving_group_size =0;
+select count(*) as c from lineitem l1 where l1.l_orderkey in ( select l3.l_orderkey from lineitem l3 where  l3.l_suppkey <> l1.l_suppkey );
+set interleaving_group_size =-10;
+select count(*) as c from lineitem l1 where l1.l_orderkey in ( select l3.l_orderkey from lineitem l3 where  l3.l_suppkey <> l1.l_suppkey );
+
+set interleaving_group_size =0;
+select count(*) as c from lineitem l1 right join lineitem l3 on l3.l_orderkey = l1.l_orderkey and l3.l_suppkey = l1.l_suppkey;
+set interleaving_group_size =-10;
+select count(*) as c from lineitem l1 right join lineitem l3 on l3.l_orderkey = l1.l_orderkey and l3.l_suppkey = l1.l_suppkey;
+
+set interleaving_group_size =0;
+select count(*) as c from lineitem l1 full outer join lineitem l3 on l3.l_orderkey = l1.l_orderkey and l3.l_suppkey = l1.l_suppkey;
+set interleaving_group_size =-10;
+select count(*) as c from lineitem l1 full outer join lineitem l3 on l3.l_orderkey = l1.l_orderkey and l3.l_suppkey = l1.l_suppkey;


### PR DESCRIPTION
## Why I'm doing

as probing results of join keys are not clustered in one chunk, `probe_match_index` and `build_match_index`
are not completely right, resulting in wrong results when filtering other conjunct. 
taking left anti join as an example, after probing, two chunks may be as follows, and the join keys are disorder in two chunks (chunk_size = 3), then do fiter from other conjuncts
--------- chunk1 --------  other filter 
join key a  ---------------->  1                        
join key b  ---------------->  0          
join key a  ---------------->  0          
-------- chunk2 --------
join key a ---------------->   0          
join key b  ---------------->   0          
join key b ---------------->  1     

we output join key b from chunk1 and join key a from chunk2 by mistake.

## What I'm doing:

as interleaving join cann't output all matches from one join key in serial, we disable interleaving join for joins with oter conjuncts.

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [x] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
