### PR TITLE
[BugFix] Fix potential parquet reader bug

### DIFF
--- a/be/src/formats/parquet/column_chunk_reader.cpp
+++ b/be/src/formats/parquet/column_chunk_reader.cpp
@@ -48,11 +48,10 @@ ColumnChunkReader::ColumnChunkReader(level_t max_def_level, level_t max_rep_leve
 ColumnChunkReader::~ColumnChunkReader() = default;
 
 Status ColumnChunkReader::init(int chunk_size) {
-    int64_t start_offset = 0;
-    if (metadata().__isset.dictionary_page_offset) {
+    int64_t start_offset = metadata().data_page_offset;
+    if (metadata().__isset.dictionary_page_offset && metadata().dictionary_page_offset > 0 &&
+        start_offset > metadata().dictionary_page_offset) {
         start_offset = metadata().dictionary_page_offset;
-    } else {
-        start_offset = metadata().data_page_offset;
     }
     int64_t size = metadata().total_compressed_size;
     int64_t num_values = metadata().num_values;


### PR DESCRIPTION
## Why I'm doing:
According to https://issues.apache.org/jira/browse/PARQUET-1547, the parquet file written using parquet-mr triggers a bug where zero is written to the dictionary_page_offset under plain encoding, instead of the dictionary_page_offset not being set as is normal, that will result in the failed decoding of the page header with abnormal  `dictionary_page_offset=0`.
The critical code causes the bug shown below.
```
Status ColumnChunkReader::init(int chunk_size) {
    // 1. dictionary_page_offset is set and equals 0 here.
    int64_t start_offset = 0;
    if (metadata().__isset.dictionary_page_offset) {
        start_offset = metadata().dictionary_page_offset;
    } else {
        start_offset = metadata().data_page_offset;
    }
    // ......
    _page_reader = std::make_unique<PageReader>(_stream, start_offset, size, num_values, _opts.stats);
    // 2. seek to the first page, set offset to 0, but first 4 bytes of parquet file are magic number.
    RETURN_IF_ERROR(_page_reader->seek_to_offset(start_offset));
    // ......
    return Status::OK();
}

Status PageReader::next_header() {
    // ..... skip ......

    RETURN_IF_ERROR(_stream->seek(_offset));

    do {
        // ......
        header_length = allowed_page_size;
        auto st = deserialize_thrift_msg(page_buf, &header_length, TProtocolType::COMPACT, &_cur_header);

        if (st.ok()) {
            if (peek_mode) {
                _stats->bytes_read += header_length;
            }
            break;
        }

        // 3. try to enlarge buffer to decode header, but initial _offset is abnormal, so it will fail here finally
        if (UNLIKELY((allowed_page_size >= kMaxPageHeaderSize) || (_offset + allowed_page_size) >= _finish_offset)) {
            // Notice, here (_offset + allowed_page_size) >= _finish_offset
            // is using '>=' just to prevent loop infinitely.
            return Status::Corruption(
                    strings::Substitute("Failed to decode parquet page header, page header's size is out of range.  "
                                        "allowed_page_size=$0, max_page_size=$1, offset=$2, finish_offset=$3",
                                        allowed_page_size, kMaxPageHeaderSize, _offset, _finish_offset));
        }

        allowed_page_size *= 2;
    } while (true);
    // ......
    return Status::OK();
}
```

## What I'm doing:

Refactor handling dictionary_page_offset refer to https://github.com/apache/parquet-mr/blame/67fc368c91a3b81ec020327fd31eee5bb87bb6cd/parquet-cli/src/main/java/org/apache/parquet/cli/rawpages/RawPagesReader.java#L82

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5