### PR TITLE
[Enhancement] Support dict decoding for non-string column (backport #36211)

### DIFF
--- a/be/src/column/type_traits.h
+++ b/be/src/column/type_traits.h
@@ -352,6 +352,11 @@ struct ColumnTraits<int16_t> {
 };
 
 template <>
+struct ColumnTraits<uint16_t> {
+    using ColumnType = UInt16Column;
+};
+
+template <>
 struct ColumnTraits<int32_t> {
     using ColumnType = Int32Column;
 };

--- a/be/src/storage/CMakeLists.txt
+++ b/be/src/storage/CMakeLists.txt
@@ -98,6 +98,7 @@ add_library(Storage STATIC
     rowset/ordinal_page_index.cpp
     rowset/page_io.cpp
     rowset/binary_dict_page.cpp
+    rowset/dict_page.cpp
     rowset/binary_prefix_page.cpp
     rowset/segment.cpp
     rowset/segment_writer.cpp

--- a/be/src/storage/olap_type_infra.h
+++ b/be/src/storage/olap_type_infra.h
@@ -144,6 +144,7 @@ auto field_type_dispatch_column(LogicalType ftype, Functor fun, Args&&... args) 
         _TYPE_DISPATCH_CASE(TYPE_ARRAY)
         _TYPE_DISPATCH_CASE(TYPE_MAP)
         _TYPE_DISPATCH_CASE(TYPE_STRUCT)
+        _TYPE_DISPATCH_CASE(TYPE_UNSIGNED_SMALLINT)
     default:
         CHECK(false) << "unknown type " << ftype;
         __builtin_unreachable();

--- a/be/src/storage/rowset/bitshuffle_page.h
+++ b/be/src/storage/rowset/bitshuffle_page.h
@@ -43,6 +43,7 @@
 #include <ostream>
 
 #include "column/fixed_length_column.h"
+#include "common/logging.h"
 #include "gutil/port.h"
 #include "storage/olap_common.h"
 #include "storage/rowset/bitshuffle_wrapper.h"
@@ -98,6 +99,8 @@ std::string bitshuffle_error_msg(int64_t err);
 //
 template <LogicalType Type>
 class BitshufflePageBuilder final : public PageBuilder {
+    typedef typename TypeTraits<Type>::CppType CppType;
+
 public:
     explicit BitshufflePageBuilder(const PageBuilderOptions& options)
             : _max_count(options.data_page_size / SIZE_OF_TYPE) {
@@ -126,7 +129,7 @@ public:
             return 0;
         }
         size_t old_sz = _data.size();
-        _data.resize(old_sz + sizeof(SIZE_OF_TYPE));
+        _data.resize(old_sz + SIZE_OF_TYPE);
         _count += 1;
         if constexpr (SIZE_OF_TYPE == 1) {
             *reinterpret_cast<uint8_t*>(&_data[old_sz]) = *elem;
@@ -186,9 +189,14 @@ public:
         return Status::OK();
     }
 
-private:
-    typedef typename TypeTraits<Type>::CppType CppType;
+    CppType cell(int idx) const {
+        DCHECK_GE(idx, 0);
+        CppType ret;
+        memcpy(&ret, &_data[idx * SIZE_OF_TYPE], SIZE_OF_TYPE);
+        return ret;
+    }
 
+private:
     faststring* _finish() {
         // Do padding so that the input num of element is multiple of 8.
         int num_elems_after_padding = ALIGN_UP(_count, 8U);
@@ -218,13 +226,6 @@ private:
         return &_compressed_data;
     }
 
-    CppType cell(int idx) const {
-        DCHECK_GE(idx, 0);
-        CppType ret;
-        memcpy(&ret, &_data[idx * SIZE_OF_TYPE], SIZE_OF_TYPE);
-        return ret;
-    }
-
     enum { SIZE_OF_TYPE = TypeTraits<Type>::size };
     uint8_t _reserved_head_size{0};
     uint32_t _max_count;
@@ -238,6 +239,8 @@ private:
 
 template <LogicalType Type>
 class BitShufflePageDecoder final : public PageDecoder {
+    typedef typename TypeTraits<Type>::CppType CppType;
+
 public:
     BitShufflePageDecoder(Slice data) : _data(data) {}
 
@@ -343,6 +346,14 @@ public:
         return Status::OK();
     }
 
+    void at_index(uint32_t idx, CppType* out) const {
+        memcpy(out, &_data[BITSHUFFLE_PAGE_HEADER_SIZE + idx * SIZE_OF_TYPE], SIZE_OF_TYPE);
+    }
+
+    inline const void* get_data(size_t pos) {
+        return static_cast<const void*>(&_data[pos + BITSHUFFLE_PAGE_HEADER_SIZE]);
+    }
+
     Status next_batch(size_t* count, Column* dst) override;
 
     Status next_batch(const SparseRange<>& range, Column* dst) override;
@@ -354,15 +365,9 @@ public:
     EncodingTypePB encoding_type() const override { return BIT_SHUFFLE; }
 
 private:
-    inline const void* get_data(size_t pos) {
-        return static_cast<const void*>(&_data[pos + BITSHUFFLE_PAGE_HEADER_SIZE]);
-    }
-
     void _copy_next_values(size_t n, void* data) {
         memcpy(data, get_data(_cur_index * SIZE_OF_TYPE), n * SIZE_OF_TYPE);
     }
-
-    typedef typename TypeTraits<Type>::CppType CppType;
 
     enum { SIZE_OF_TYPE = TypeTraits<Type>::size };
 

--- a/be/src/storage/rowset/dict_page.cpp
+++ b/be/src/storage/rowset/dict_page.cpp
@@ -1,0 +1,284 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "storage/rowset/dict_page.h"
+
+#include <memory>
+#include <vector>
+
+#include "common/logging.h"
+#include "gutil/casts.h"
+#include "gutil/strings/substitute.h" // for Substitute
+#include "storage/chunk_helper.h"
+#include "storage/range.h"
+#include "storage/rowset/bitshuffle_page.h"
+#include "util/slice.h" // for Slice
+#include "util/unaligned_access.h"
+
+namespace starrocks {
+
+using strings::Substitute;
+
+template <LogicalType Type>
+DictPageBuilder<Type>::DictPageBuilder(const PageBuilderOptions& options)
+        : _options(options),
+          _finished(false),
+          _data_page_builder(nullptr),
+          _dict_builder(nullptr),
+          _encoding_type(DICT_ENCODING) {
+    // initially use DICT_ENCODING
+    _data_page_builder = std::make_unique<BitshufflePageBuilder<DataTypeTraits<Type>::type>>(options);
+    _data_page_builder->reserve_head(BINARY_DICT_PAGE_HEADER_SIZE);
+    PageBuilderOptions dict_builder_options;
+    dict_builder_options.data_page_size = _options.dict_page_size;
+    _dict_builder = std::make_unique<BitshufflePageBuilder<Type>>(dict_builder_options);
+    reset();
+}
+
+template <LogicalType Type>
+bool DictPageBuilder<Type>::is_page_full() {
+    if (_data_page_builder->is_page_full()) {
+        return true;
+    }
+    return _encoding_type == DICT_ENCODING && _dict_builder->is_page_full();
+}
+
+template <LogicalType Type>
+uint32_t DictPageBuilder<Type>::add(const uint8_t* vals, uint32_t count) {
+    if (_encoding_type == DICT_ENCODING) {
+        DCHECK(!_finished);
+        DCHECK_GT(count, 0);
+        ValueCodeType value_code = -1;
+        // Manually devirtualization.
+        auto* code_page = down_cast<BitshufflePageBuilder<DataTypeTraits<Type>::type>*>(_data_page_builder.get());
+
+        if (_data_page_builder->count() == 0) {
+            memcpy(&_first_value, vals, sizeof(ValueType));
+        }
+
+        for (int i = 0; i < count; ++i) {
+            auto& value = *reinterpret_cast<const ValueType*>(vals + i * SIZE_OF_TYPE);
+            auto iter = _dictionary.find(value);
+            if (iter != _dictionary.end()) {
+                value_code = iter->second;
+            } else if (_dict_builder->add((const uint8_t*)&value, 1) > 0) {
+                value_code = _dictionary.size();
+                _dictionary.insert_or_assign(value, value_code);
+            } else {
+                return i;
+            }
+            if (code_page->add_one(reinterpret_cast<const uint8_t*>(&value_code)) < 1) {
+                return i;
+            }
+        }
+        return count;
+    } else {
+        DCHECK_EQ(_encoding_type, BIT_SHUFFLE);
+        return _data_page_builder->add(vals, count);
+    }
+}
+template <LogicalType Type>
+faststring* DictPageBuilder<Type>::finish() {
+    DCHECK(!_finished);
+    _finished = true;
+
+    faststring* data_slice = _data_page_builder->finish();
+    encode_fixed32_le(data_slice->data(), _encoding_type);
+    return data_slice;
+}
+
+template <LogicalType Type>
+void DictPageBuilder<Type>::reset() {
+    _finished = false;
+    if (_encoding_type == DICT_ENCODING && _dict_builder->is_page_full()) {
+        _data_page_builder = std::make_unique<BitshufflePageBuilder<Type>>(_options);
+        _data_page_builder->reserve_head(BINARY_DICT_PAGE_HEADER_SIZE);
+        _encoding_type = BIT_SHUFFLE;
+    } else {
+        _data_page_builder->reset();
+    }
+    _finished = false;
+}
+
+template <LogicalType Type>
+uint32_t DictPageBuilder<Type>::count() const {
+    return _data_page_builder->count();
+}
+
+template <LogicalType Type>
+uint64_t DictPageBuilder<Type>::size() const {
+    return _data_page_builder->size();
+}
+
+template <LogicalType Type>
+faststring* DictPageBuilder<Type>::get_dictionary_page() {
+    return _dict_builder->finish();
+}
+
+template <LogicalType Type>
+Status DictPageBuilder<Type>::get_first_value(void* value) const {
+    DCHECK(_finished);
+    if (_data_page_builder->count() == 0) {
+        return Status::NotFound("page is empty");
+    }
+    if (_encoding_type != DICT_ENCODING) {
+        return _data_page_builder->get_first_value(value);
+    }
+    memcpy(value, &_first_value, SIZE_OF_TYPE);
+    return Status::OK();
+}
+
+template <LogicalType Type>
+Status DictPageBuilder<Type>::get_last_value(void* value) const {
+    DCHECK(_finished);
+    if (_data_page_builder->count() == 0) {
+        return Status::NotFound("page is empty");
+    }
+    if (_encoding_type != DICT_ENCODING) {
+        return _data_page_builder->get_last_value(value);
+    }
+    ValueCodeType value_code;
+    RETURN_IF_ERROR(_data_page_builder->get_last_value(&value_code));
+    ValueType out = _dict_builder->cell(value_code);
+    memcpy(value, &out, SIZE_OF_TYPE);
+    return Status::OK();
+}
+
+template <LogicalType Type>
+bool DictPageBuilder<Type>::is_valid_global_dict(const GlobalDictMap* global_dict) const {
+    return false;
+}
+
+template <LogicalType Type>
+DictPageDecoder<Type>::DictPageDecoder(Slice data)
+        : _data(data), _data_page_decoder(nullptr), _parsed(false), _encoding_type(UNKNOWN_ENCODING) {}
+
+template <LogicalType Type>
+Status DictPageDecoder<Type>::init() {
+    CHECK(!_parsed);
+    if (_data.size < BINARY_DICT_PAGE_HEADER_SIZE) {
+        return Status::Corruption(
+                strings::Substitute("invalid data size:$0, header size:$1", _data.size, BINARY_DICT_PAGE_HEADER_SIZE));
+    }
+    size_t type = decode_fixed32_le((const uint8_t*)&_data.data[0]);
+    _encoding_type = static_cast<EncodingTypePB>(type);
+    _data.remove_prefix(BINARY_DICT_PAGE_HEADER_SIZE);
+    if (_encoding_type == DICT_ENCODING) {
+        // copy the codewords into a temporary buffer first
+        // And then copy the strings corresponding to the codewords to the destination buffer
+        _data_page_decoder = std::make_unique<BitShufflePageDecoder<DataTypeTraits<Type>::type>>(_data);
+    } else if (_encoding_type == BIT_SHUFFLE) {
+        _data_page_decoder.reset(new BitShufflePageDecoder<Type>(_data));
+    } else {
+        LOG(WARNING) << "invalid encoding type:" << _encoding_type;
+        return Status::Corruption(strings::Substitute("invalid encoding type:$0", _encoding_type));
+    }
+
+    RETURN_IF_ERROR(_data_page_decoder->init());
+    _parsed = true;
+    return Status::OK();
+}
+
+template <LogicalType Type>
+Status DictPageDecoder<Type>::seek_to_position_in_page(uint32_t pos) {
+    return _data_page_decoder->seek_to_position_in_page(pos);
+}
+
+template <LogicalType Type>
+void DictPageDecoder<Type>::set_dict_decoder(PageDecoder* dict_decoder) {
+    _dict_decoder = down_cast<BitShufflePageDecoder<Type>*>(dict_decoder);
+}
+
+template <LogicalType Type>
+Status DictPageDecoder<Type>::next_batch(size_t* n, Column* dst) {
+    SparseRange<> read_range;
+    uint32_t begin = current_index();
+    read_range.add(Range<>(begin, begin + *n));
+    RETURN_IF_ERROR(next_batch(read_range, dst));
+    *n = current_index() - begin;
+    return Status::OK();
+}
+
+template <LogicalType Type>
+Status DictPageDecoder<Type>::next_batch(const SparseRange<>& range, Column* dst) {
+    if (_encoding_type == BIT_SHUFFLE) {
+        return _data_page_decoder->next_batch(range, dst);
+    }
+
+    DCHECK(_parsed);
+    DCHECK(_dict_decoder != nullptr) << "dict decoder pointer is nullptr";
+    if (_vec_code_buf == nullptr) {
+        _vec_code_buf = ChunkHelper::column_from_field_type(DataTypeTraits<Type>::type, false);
+    }
+    _vec_code_buf->resize(0);
+    _vec_code_buf->reserve(range.span_size());
+
+    RETURN_IF_ERROR(_data_page_decoder->next_batch(range, _vec_code_buf.get()));
+    size_t nread = _vec_code_buf->size();
+    using cast_type = typename CppTypeTraits<DataTypeTraits<Type>::type>::CppType;
+    const auto* codewords = reinterpret_cast<const cast_type*>(_vec_code_buf->raw_data());
+    std::vector<ValueType> numbers;
+    raw::stl_vector_resize_uninitialized(&numbers, nread);
+    for (int i = 0; i < nread; ++i) {
+        ValueType value;
+        _dict_decoder->at_index(codewords[i], &value);
+        numbers[i] = value;
+    }
+    size_t nappend = dst->append_numbers(numbers.data(), numbers.size() * SIZE_OF_TYPE);
+    if (UNLIKELY(nappend != numbers.size())) {
+        return Status::InternalError(
+                fmt::format("append_numbers failed, expected rows[{}], actual rows[{}]", numbers.size(), nappend));
+    }
+    return Status::OK();
+}
+
+template <LogicalType Type>
+Status DictPageDecoder<Type>::next_dict_codes(size_t* n, Column* dst) {
+    DCHECK(_encoding_type == DICT_ENCODING);
+    DCHECK(_parsed);
+    return _data_page_decoder->next_batch(n, dst);
+}
+
+template <LogicalType Type>
+Status DictPageDecoder<Type>::next_dict_codes(const SparseRange<>& range, Column* dst) {
+    DCHECK(_encoding_type == DICT_ENCODING);
+    DCHECK(_parsed);
+    return _data_page_decoder->next_batch(range, dst);
+}
+
+template class DictPageDecoder<TYPE_SMALLINT>;
+template class DictPageDecoder<TYPE_INT>;
+template class DictPageDecoder<TYPE_BIGINT>;
+template class DictPageDecoder<TYPE_LARGEINT>;
+template class DictPageDecoder<TYPE_FLOAT>;
+template class DictPageDecoder<TYPE_DOUBLE>;
+template class DictPageDecoder<TYPE_DATE_V1>;
+template class DictPageDecoder<TYPE_DATE>;
+template class DictPageDecoder<TYPE_DATETIME_V1>;
+template class DictPageDecoder<TYPE_DATETIME>;
+template class DictPageDecoder<TYPE_DECIMALV2>;
+
+template class DictPageBuilder<TYPE_SMALLINT>;
+template class DictPageBuilder<TYPE_INT>;
+template class DictPageBuilder<TYPE_BIGINT>;
+template class DictPageBuilder<TYPE_LARGEINT>;
+template class DictPageBuilder<TYPE_FLOAT>;
+template class DictPageBuilder<TYPE_DOUBLE>;
+template class DictPageBuilder<TYPE_DATE_V1>;
+template class DictPageBuilder<TYPE_DATE>;
+template class DictPageBuilder<TYPE_DATETIME_V1>;
+template class DictPageBuilder<TYPE_DATETIME>;
+template class DictPageBuilder<TYPE_DECIMALV2>;
+
+} // namespace starrocks

--- a/be/src/storage/rowset/dict_page.h
+++ b/be/src/storage/rowset/dict_page.h
@@ -1,0 +1,162 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <functional>
+#include <memory>
+#include <string>
+
+#include "gen_cpp/segment.pb.h"
+#include "gutil/hash/string_hash.h"
+#include "runtime/mem_pool.h"
+#include "storage/olap_common.h"
+#include "storage/range.h"
+#include "storage/rowset/bitshuffle_page.h"
+#include "storage/rowset/common.h"
+#include "storage/rowset/options.h"
+#include "storage/rowset/plain_page.h"
+#include "storage/types.h"
+#include "util/phmap/phmap.h"
+
+namespace starrocks {
+
+// This type of page use dictionary encoding for numbers.
+// There is only one dictionary page for all the data pages within a column.
+//
+// Layout for dictionary encoded page:
+// Either header + embedded codeword page, which can be encoded with any
+//        int PageBuilder, when mode_ = DICT_ENCODING.
+// Or     header + embedded BitshufflePageBuilder, when mode_ = PLAIN_ENCOING.
+// Data pages start with mode_ = DICT_ENCODING, when the the size of dictionary
+// page go beyond the option_->dict_page_size, the subsequent data pages will switch
+// to string plain page automatically.
+
+// DictPageBuilder has two encoders, data-page-builder and dict-builder
+// dict-builder is used to encode the dictionary, data-page-builder is used to encode the
+// dictionary's index. data-page-builder and dict-builder use BitshufflePageBuilder for encoding
+// Because when the dictionary page is full, data-page-builder will no longer store the index of the
+// dictionary page, but instead store the data itself, data-page-builder needs to reserve a segment
+// of space in advance to store the encoding type, indicating whether this page stores the index of
+// the dictionary page or the data
+
+// The maximum value of int32 is 2147483647, representing that a dictionary page can store
+// a maximum of 2147483648 elements. If a dictionary page stores 2147483648 elements, assuming
+// one element only occupies one byte, the size of the dictionary page will be 2GB, which is
+// impossible. Therefore, int32 is sufficient to store the index of the dictionary page,
+// and overflow will not occur.
+template <LogicalType field_type>
+struct DataTypeTraits {
+    static const LogicalType type = TYPE_INT;
+};
+
+template <>
+struct DataTypeTraits<TYPE_SMALLINT> {
+    static const LogicalType type = TYPE_UNSIGNED_SMALLINT;
+};
+
+template <LogicalType Type>
+class DictPageBuilder final : public PageBuilder {
+    using ValueType = typename CppTypeTraits<Type>::CppType;
+    using ValueCodeType = typename CppTypeTraits<DataTypeTraits<Type>::type>::CppType;
+
+public:
+    explicit DictPageBuilder(const PageBuilderOptions& options);
+
+    bool is_page_full() override;
+
+    uint32_t add(const uint8_t* vals, uint32_t count) override;
+
+    faststring* finish() override;
+
+    void reset() override;
+
+    uint32_t count() const override;
+
+    uint64_t size() const override;
+
+    faststring* get_dictionary_page() override;
+
+    Status get_first_value(void* value) const override;
+
+    Status get_last_value(void* value) const override;
+
+    bool is_valid_global_dict(const GlobalDictMap* global_dict) const override;
+
+    // Return true iff all pages so far are encoded by dictionary encoding.
+    // this method normally should be called after all data pages finish
+    // write, i.e, after `finish` has been called.
+    bool all_dict_encoded() const override { return _encoding_type == DICT_ENCODING; }
+
+private:
+    enum { SIZE_OF_TYPE = TypeTraits<Type>::size };
+
+    PageBuilderOptions _options;
+    bool _finished;
+
+    std::unique_ptr<PageBuilder> _data_page_builder;
+
+    std::unique_ptr<BitshufflePageBuilder<Type>> _dict_builder;
+
+    EncodingTypePB _encoding_type;
+    // query for dict item -> dict id
+    phmap::flat_hash_map<ValueType, ValueCodeType> _dictionary;
+    ValueType _first_value;
+};
+
+// DictPageDecoder initially holds a segment of memory, and from the header of this memory segment,
+// you can determine the encoding method used, whether it's DICT_ENCODING or BIT_SHUFFLE.
+// When initializing DictPageDecoder, it does not load the dictionary page. The dictionary page provides
+// an additional function set_dict_decoder, which sets the dict-decoder to BitshufflePageBuilder.
+// When reading data, if the encoding method is BIT_SHUFFLE, you can directly load the data from the
+// data-page-decoder. If it's not BIT_SHUFFLE, it means that the data-page does not store the actual data
+// but rather the index of the data. In this case, you need to load the data from the dictionary.
+template <LogicalType Type>
+class DictPageDecoder final : public PageDecoder {
+    using ValueType = typename CppTypeTraits<Type>::CppType;
+
+public:
+    DictPageDecoder(Slice data);
+
+    Status init() override;
+
+    Status seek_to_position_in_page(uint32_t pos) override;
+
+    Status next_batch(size_t* n, Column* dst) override;
+
+    Status next_batch(const SparseRange<>& range, Column* dst) override;
+
+    uint32_t count() const override { return _data_page_decoder->count(); }
+
+    uint32_t current_index() const override { return _data_page_decoder->current_index(); }
+
+    EncodingTypePB encoding_type() const override { return _encoding_type; }
+
+    void set_dict_decoder(PageDecoder* dict_decoder);
+
+    Status next_dict_codes(size_t* n, Column* dst) override;
+
+    Status next_dict_codes(const SparseRange<>& range, Column* dst) override;
+
+private:
+    enum { SIZE_OF_TYPE = TypeTraits<Type>::size };
+    Slice _data;
+    std::unique_ptr<PageDecoder> _data_page_decoder;
+    const BitShufflePageDecoder<Type>* _dict_decoder = nullptr;
+    bool _parsed;
+    EncodingTypePB _encoding_type;
+    std::shared_ptr<Column> _vec_code_buf;
+};
+
+} // namespace starrocks

--- a/be/src/storage/rowset/encoding_info.cpp
+++ b/be/src/storage/rowset/encoding_info.cpp
@@ -42,6 +42,7 @@
 #include "storage/rowset/binary_plain_page.h"
 #include "storage/rowset/binary_prefix_page.h"
 #include "storage/rowset/bitshuffle_page.h"
+#include "storage/rowset/dict_page.h"
 #include "storage/rowset/frame_of_reference_page.h"
 #include "storage/rowset/plain_page.h"
 #include "storage/rowset/rle_page.h"
@@ -118,6 +119,18 @@ struct TypeEncodingTraits<type, DICT_ENCODING, Slice> {
     }
 };
 
+template <LogicalType type, typename CppType>
+struct TypeEncodingTraits<type, DICT_ENCODING, CppType> {
+    static Status create_page_builder(const PageBuilderOptions& opts, PageBuilder** builder) {
+        *builder = new DictPageBuilder<type>(opts);
+        return Status::OK();
+    }
+    static Status create_page_decoder(const Slice& data, PageDecoder** decoder) {
+        *decoder = new DictPageDecoder<type>(data);
+        return Status::OK();
+    }
+};
+
 template <>
 struct TypeEncodingTraits<TYPE_DATE_V1, FOR_ENCODING, typename CppTypeTraits<TYPE_DATE_V1>::CppType> {
     static Status create_page_builder(const PageBuilderOptions& opts, PageBuilder** builder) {
@@ -166,7 +179,17 @@ public:
     EncodingInfoResolver();
     ~EncodingInfoResolver();
 
+    // We aim to minimize the impact of the newly introduced encoding strategy on existing behaviors.
+    // This function is used to obtain the default encoding based on the field type, considering the following scenarios:
+    // 1. If the user has enabled dictionary encoding for number types, the field supports dictionary encoding,
+    //    and it is not for optimizing value seek, return DICT_ENCODING.
+    // 2. If optimization for value seek is required, retrieve the encoding method from _value_seek_encoding_map.
+    // 3. In the last scenario, directly retrieve it from _default_encoding_type_map.
     EncodingTypePB get_default_encoding(LogicalType type, bool optimize_value_seek) const {
+        if (enable_non_string_column_dict_encoding() && numeric_types_support_dict_encoding(delegate_type(type)) &&
+            !optimize_value_seek) {
+            return DICT_ENCODING;
+        }
         auto& encoding_map = optimize_value_seek ? _value_seek_encoding_map : _default_encoding_type_map;
         auto it = encoding_map.find(delegate_type(type));
         if (it != encoding_map.end()) {
@@ -184,6 +207,8 @@ private:
         auto key = std::make_pair(type, encoding_type);
         DCHECK(_encoding_map.count(key) == 0);
 
+        // For the same LogicType, the first call to the _add_map function will be added to
+        // the _default_encoding_type_map.
         if (_default_encoding_type_map.find(type) == _default_encoding_type_map.end()) {
             _default_encoding_type_map[type] = encoding_type;
         }
@@ -201,6 +226,8 @@ private:
     std::unordered_map<std::pair<LogicalType, EncodingTypePB>, EncodingInfo*, EncodingMapHash> _encoding_map;
 };
 
+// We have adjusted the default encoding for some scalar types to dictionary encoding.
+// As TYPE_DATE_V1/TYPE_DATETIME_V1 are legacy types, no changes are made here.
 EncodingInfoResolver::EncodingInfoResolver() {
     _add_map<TYPE_TINYINT, BIT_SHUFFLE>();
     _add_map<TYPE_TINYINT, FOR_ENCODING, true>();
@@ -270,6 +297,18 @@ EncodingInfoResolver::EncodingInfoResolver() {
     _add_map<TYPE_JSON, PLAIN_ENCODING>();
 
     _add_map<TYPE_VARBINARY, PLAIN_ENCODING>();
+
+    // These number typs are support dict encoding, if you need to change this, please
+    // change supports_dict_encoding function as same time.
+    _add_map<TYPE_SMALLINT, DICT_ENCODING>();
+    _add_map<TYPE_INT, DICT_ENCODING>();
+    _add_map<TYPE_BIGINT, DICT_ENCODING>();
+    _add_map<TYPE_LARGEINT, DICT_ENCODING>();
+    _add_map<TYPE_FLOAT, DICT_ENCODING>();
+    _add_map<TYPE_DOUBLE, DICT_ENCODING>();
+    _add_map<TYPE_DATE, DICT_ENCODING>();
+    _add_map<TYPE_DATETIME, DICT_ENCODING>();
+    _add_map<TYPE_DECIMALV2, DICT_ENCODING>();
 }
 
 EncodingInfoResolver::~EncodingInfoResolver() {

--- a/be/src/storage/rowset/encoding_info.h
+++ b/be/src/storage/rowset/encoding_info.h
@@ -34,8 +34,10 @@
 
 #pragma once
 
+#include <cmath>
 #include <functional>
 
+#include "common/config.h"
 #include "common/status.h"
 #include "gen_cpp/segment.pb.h"
 #include "storage/types.h"
@@ -47,6 +49,40 @@ class TypeInfo;
 class PageBuilder;
 class PageDecoder;
 class PageBuilderOptions;
+
+// Only support dict decoding for non-string column.
+// For rollback version from 3.3 to 3.2.
+inline bool enable_non_string_column_dict_encoding() {
+    return false;
+}
+
+// We dont make TYPE_TINYINT support dict encoding. The reason is that TYPE_TINYINT is only have
+// 256 different values, that is too small to make our speculation mechanism work. And according
+// test results, when TINY_INT column is encoded using dict, the space usage is not necessarily
+// better than bitshuffle.
+inline bool numeric_types_support_dict_encoding(LogicalType type) {
+    switch (type) {
+    case TYPE_SMALLINT:
+    case TYPE_INT:
+    case TYPE_BIGINT:
+    case TYPE_LARGEINT:
+    case TYPE_FLOAT:
+    case TYPE_DOUBLE:
+    case TYPE_DATE:
+    case TYPE_DATETIME:
+    case TYPE_DECIMALV2:
+        return true;
+    default:
+        return false;
+    }
+}
+
+inline bool supports_dict_encoding(LogicalType type) {
+    if (type == TYPE_VARCHAR || type == TYPE_CHAR) {
+        return true;
+    }
+    return numeric_types_support_dict_encoding(type);
+}
 
 class EncodingInfo {
 public:

--- a/be/src/storage/rowset/plain_page.h
+++ b/be/src/storage/rowset/plain_page.h
@@ -60,6 +60,11 @@ public:
         reset();
     }
 
+    void reserve_head(uint8_t head_size) override {
+        CHECK(_reserved_head_size == 0);
+        _reserved_head_size = head_size;
+    }
+
     bool is_page_full() override { return _buffer.size() > _options.data_page_size; }
 
     uint32_t add(const uint8_t* vals, uint32_t count) override {
@@ -80,7 +85,13 @@ public:
             _first_value.assign_copy(&_buffer[PLAIN_PAGE_HEADER_SIZE], SIZE_OF_TYPE);
             _last_value.assign_copy(&_buffer[PLAIN_PAGE_HEADER_SIZE + (_count - 1) * SIZE_OF_TYPE], SIZE_OF_TYPE);
         }
-        return &_buffer;
+        if (_reserved_head_size == 0) {
+            return &_buffer;
+        } else {
+            _plus_header_buffer.resize(_reserved_head_size + _buffer.size());
+            memcpy(&_plus_header_buffer[_reserved_head_size], _buffer.data(), _buffer.size());
+            return &_plus_header_buffer;
+        }
     }
 
     void reset() override {
@@ -119,10 +130,14 @@ private:
     enum { SIZE_OF_TYPE = TypeTraits<Type>::size };
     faststring _first_value;
     faststring _last_value;
+    uint8_t _reserved_head_size{0};
+    faststring _plus_header_buffer;
 };
 
 template <LogicalType Type>
 class PlainPageDecoder : public PageDecoder {
+    using ValueType = typename CppTypeTraits<Type>::CppType;
+
 public:
     PlainPageDecoder(Slice data) : _data(data) {}
 
@@ -147,7 +162,7 @@ public:
 
         _parsed = true;
 
-        seek_to_position_in_page(0);
+        RETURN_IF_ERROR(seek_to_position_in_page(0));
         return Status::OK();
     }
 
@@ -241,6 +256,10 @@ public:
     uint32_t current_index() const override {
         DCHECK(_parsed);
         return _cur_idx;
+    }
+
+    void at_index(uint32_t idx, ValueType* out) const {
+        memcpy(out, &_data[PLAIN_PAGE_HEADER_SIZE + idx * SIZE_OF_TYPE], SIZE_OF_TYPE);
     }
 
     EncodingTypePB encoding_type() const override { return PLAIN_ENCODING; }

--- a/be/src/storage/rowset/scalar_column_iterator.h
+++ b/be/src/storage/rowset/scalar_column_iterator.h
@@ -121,6 +121,7 @@ private:
     template <typename ParseFunc>
     Status _fetch_by_rowid(const rowid_t* rowids, size_t size, Column* values, ParseFunc&& page_parse);
 
+    template <LogicalType Type>
     Status _load_dict_page();
 
     bool _contains_deleted_row(uint32_t page_index) const;

--- a/be/src/storage/rowset/storage_page_decoder.cpp
+++ b/be/src/storage/rowset/storage_page_decoder.cpp
@@ -14,6 +14,7 @@
 
 #include "storage/rowset/storage_page_decoder.h"
 
+#include "gen_cpp/segment.pb.h"
 #include "gutil/strings/substitute.h"
 #include "storage/rowset/bitshuffle_wrapper.h"
 #include "util/coding.h"
@@ -31,8 +32,6 @@ public:
     }
     Status decode_page_data(PageFooterPB* footer, uint32_t footer_size, EncodingTypePB encoding,
                             std::unique_ptr<char[]>* page, Slice* page_slice) override {
-        const DataPageFooterPB& data_footer = footer->data_page_footer();
-
         size_t num_elements = decode_fixed32_le((const uint8_t*)page_slice->data + _reserve_head_size + 0);
         size_t compressed_size = decode_fixed32_le((const uint8_t*)page_slice->data + _reserve_head_size + 4);
         size_t num_element_after_padding = decode_fixed32_le((const uint8_t*)page_slice->data + _reserve_head_size + 8);
@@ -41,7 +40,6 @@ public:
 
         size_t header_size = _reserve_head_size + BITSHUFFLE_PAGE_HEADER_SIZE;
         size_t data_size = num_element_after_padding * size_of_element;
-        auto null_size = data_footer.nullmap_size();
 
         // data_size is size of decoded_data
         // compressed_size contains encoded_data size and BITSHUFFLE_PAGE_HEADER_SIZE
@@ -58,7 +56,12 @@ public:
                     strings::Substitute("decompress failed: expected number of bytes consumed=$0 vs real consumed=$1",
                                         compressed_body.size, bytes));
         }
-
+        DCHECK(footer->has_type()) << "type must be set";
+        uint32_t null_size = 0;
+        if (footer->type() == DATA_PAGE) {
+            const DataPageFooterPB& data_footer = footer->data_page_footer();
+            null_size = data_footer.nullmap_size();
+        }
         memcpy(decompressed_body.data + decompressed_body.size,
                page_slice->data + header_size + (compressed_size - BITSHUFFLE_PAGE_HEADER_SIZE),
                null_size + footer_size);
@@ -73,6 +76,20 @@ private:
     uint8_t _reserve_head_size = 0;
 };
 
+class DictDictDecoder : public DataDecoder {
+public:
+    DictDictDecoder() { _bit_shuffle_decoder = std::make_unique<BitShuffleDataDecoder>(); }
+    ~DictDictDecoder() override = default;
+
+    Status decode_page_data(PageFooterPB* footer, uint32_t footer_size, EncodingTypePB encoding,
+                            std::unique_ptr<char[]>* page, Slice* page_slice) override {
+        return _bit_shuffle_decoder->decode_page_data(footer, footer_size, encoding, page, page_slice);
+    }
+
+private:
+    std::unique_ptr<BitShuffleDataDecoder> _bit_shuffle_decoder;
+};
+
 class BinaryDictDataDecoder : public DataDecoder {
 public:
     BinaryDictDataDecoder() {
@@ -83,8 +100,12 @@ public:
 
     Status decode_page_data(PageFooterPB* footer, uint32_t footer_size, EncodingTypePB encoding,
                             std::unique_ptr<char[]>* page, Slice* page_slice) override {
+        // When the dictionary page is not full, the header of the binary dictionary's data
+        // page is DICT_ENCODING, and bitshuffle decode is needed at this point. When the
+        // dictionary page is full, the header of the binary dictionary's data page is PLAIN_ENCODING.
+        // For the newly introduced dictionary data page, the header is BIT_SHUFFLE.
         size_t type = decode_fixed32_le((const uint8_t*)&(page_slice->data[0]));
-        if (type == DICT_ENCODING) {
+        if (type == DICT_ENCODING || type == BIT_SHUFFLE) {
             return _bit_shuffle_decoder->decode_page_data(footer, footer_size, encoding, page, page_slice);
         } else if (type == PLAIN_ENCODING) {
             return Status::OK();
@@ -101,6 +122,7 @@ private:
 static DataDecoder g_base_decoder;
 static BitShuffleDataDecoder g_bit_shuffle_decoder;
 static BinaryDictDataDecoder g_binary_dict_decoder;
+static DictDictDecoder g_dict_dict_decoder;
 
 DataDecoder* DataDecoder::get_data_decoder(EncodingTypePB encoding) {
     switch (encoding) {
@@ -122,15 +144,30 @@ DataDecoder* DataDecoder::get_data_decoder(EncodingTypePB encoding) {
     }
 }
 
+// For dictionary-type data pages, there are two scenarios. One is PLAIN encoding,
+// and for PLAIN encoding, no additional decompression is required. The other is
+// BITSHUFFLE, and in this case, pre-decompression of the page data is needed. For
+// dictionary-type dictionary pages, there used to be only one type of page encoded
+// with PLAIN, so no additional operation was needed. However, in this PR, we encode
+// dictionary data pages with BITSHUFFLE, so pre-decompression is needed in this case.
+// BITSHUFFLE encoding pages for data pages have a reserved header for recording the
+// encoding type. Still, BITSHUFFLE encoding pages for dictionary pages do not have a
+// reserved header.
 Status StoragePageDecoder::decode_page(PageFooterPB* footer, uint32_t footer_size, EncodingTypePB encoding,
                                        std::unique_ptr<char[]>* page, Slice* page_slice) {
     DCHECK(footer->has_type()) << "type must be set";
     switch (footer->type()) {
     case INDEX_PAGE:
-    case DICTIONARY_PAGE:
     case SHORT_KEY_PAGE: {
         return Status::OK();
     }
+    case DICTIONARY_PAGE:
+        DCHECK(footer->has_dict_page_footer());
+        if (footer->dict_page_footer().encoding() == PLAIN_ENCODING) {
+            return Status::OK();
+        }
+        DCHECK(footer->dict_page_footer().encoding() == BIT_SHUFFLE);
+        return g_dict_dict_decoder.decode_page_data(footer, footer_size, encoding, page, page_slice);
     case DATA_PAGE: {
         DataDecoder* decoder = DataDecoder::get_data_decoder(encoding);
         if (decoder == nullptr) {

--- a/be/test/CMakeLists.txt
+++ b/be/test/CMakeLists.txt
@@ -245,6 +245,7 @@ set(EXEC_FILES
         ./storage/rowset/block_bloom_filter_test.cpp
         ./storage/rowset/bloom_filter_index_reader_writer_test.cpp
         ./storage/rowset/column_reader_writer_test.cpp
+        ./storage/rowset/dict_page_test.cpp
         ./storage/rowset/encoding_info_test.cpp
         ./storage/rowset/frame_of_reference_page_test.cpp
         ./storage/rowset/map_column_rw_test.cpp

--- a/be/test/storage/rowset/dict_page_test.cpp
+++ b/be/test/storage/rowset/dict_page_test.cpp
@@ -1,0 +1,394 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "storage/rowset/dict_page.h"
+
+#include <gtest/gtest.h>
+
+#include <algorithm>
+#include <iostream>
+#include <limits>
+
+#include "column/column.h"
+#include "storage/chunk_helper.h"
+#include "storage/rowset/binary_plain_page.h"
+#include "storage/rowset/page_decoder.h"
+#include "storage/rowset/storage_page_decoder.h"
+#include "storage/types.h"
+#include "util/debug_util.h"
+
+namespace starrocks {
+
+class DictPageTest : public testing::Test {
+public:
+    template <LogicalType Type>
+    void test_encode_decode_page_template(typename TypeTraits<Type>::CppType* data, size_t base_size, size_t all_size) {
+        using CppType = typename TypeTraits<Type>::CppType;
+        // encode
+        PageBuilderOptions options;
+        // 64K
+        options.data_page_size = 1024 * 1024;
+        options.dict_page_size = 1024 * 1024;
+        int data_num = all_size;
+        std::unique_ptr<uint8_t*[]> data_handler_ptr(new uint8_t*[data_num]);
+        uint8_t** data_handler = data_handler_ptr.get();
+        for (int i = 0; i < data_num; i++) {
+            data_handler[i] = (uint8*)&data[i];
+        }
+        DictPageBuilder<Type> page_builder(options);
+        Status status;
+        int added_count = page_builder.add(data_handler[0], data_num);
+        ASSERT_EQ(data_num, added_count);
+        auto s = page_builder.finish()->build();
+        ASSERT_EQ(data_num, page_builder.count());
+        ASSERT_FALSE(page_builder.is_page_full());
+
+        // check first value and last value
+        CppType first_value;
+        status = page_builder.get_first_value(&first_value);
+        ASSERT_TRUE(status.ok());
+        ASSERT_EQ(data[0], first_value);
+        CppType last_value;
+        status = page_builder.get_last_value(&last_value);
+        ASSERT_EQ(data[data_num - 1], last_value);
+
+        // construct dict page
+        OwnedSlice dict_slice = page_builder.get_dictionary_page()->build();
+        Slice encoded_dict = dict_slice.slice();
+        starrocks::PageFooterPB dict_footer;
+        dict_footer.set_type(starrocks::DATA_PAGE);
+        starrocks::DataPageFooterPB* dict_page_footer = dict_footer.mutable_data_page_footer();
+        dict_page_footer->set_nullmap_size(0);
+        std::unique_ptr<char[]> dict_page = nullptr;
+        Status st = StoragePageDecoder::decode_page(&dict_footer, 0, starrocks::BIT_SHUFFLE, &dict_page, &encoded_dict);
+        ASSERT_TRUE(st.ok());
+
+        auto dict_page_decoder = std::make_unique<BitShufflePageDecoder<Type>>(encoded_dict);
+        status = dict_page_decoder->init();
+        ASSERT_TRUE(status.ok());
+        ASSERT_EQ(base_size, dict_page_decoder->count());
+
+        // decode
+        Slice encoded_data = s.slice();
+        PageFooterPB footer_data;
+        footer_data.set_type(DATA_PAGE);
+        starrocks::DataPageFooterPB* data_page_footer = footer_data.mutable_data_page_footer();
+        data_page_footer->set_nullmap_size(0);
+        std::unique_ptr<char[]> data_page = nullptr;
+        st = StoragePageDecoder::decode_page(&footer_data, 0, starrocks::DICT_ENCODING, &data_page, &encoded_data);
+        ASSERT_TRUE(st.ok());
+
+        DictPageDecoder<Type> page_decoder(encoded_data);
+        page_decoder.set_dict_decoder(dict_page_decoder.get());
+
+        status = page_decoder.init();
+        ASSERT_TRUE(status.ok());
+        ASSERT_EQ(data_num, page_decoder.count());
+
+        // check values
+        auto column = ChunkHelper::column_from_field_type(Type, false);
+        size_t decode_size = data_num;
+        status = page_decoder.next_batch(&decode_size, column.get());
+        ASSERT_TRUE(status.ok());
+        ASSERT_EQ(data_num, decode_size);
+        auto* values = reinterpret_cast<const CppType*>(column->raw_data());
+        auto* decoded = (CppType*)values;
+        for (uint i = 0; i < decode_size; i++) {
+            if (data[i] != decoded[i]) {
+                if constexpr (std::is_same_v<int128_t, CppType>) {
+                    FAIL() << "Fail at index " << i;
+                } else {
+                    FAIL() << "Fail at index " << i << " inserted=" << data[i] << " got=" << decoded[i];
+                }
+            }
+        }
+
+        column->resize(0);
+        ASSERT_TRUE(data_num > 100);
+        status = page_decoder.seek_to_position_in_page(100);
+        ASSERT_TRUE(status.ok()) << status.to_string();
+        status = page_decoder.next_batch(&decode_size, column.get());
+        ASSERT_TRUE(status.ok()) << status.to_string();
+        // 2000 - 100
+        ASSERT_EQ(data_num - 100, decode_size);
+        values = reinterpret_cast<const CppType*>(column->raw_data());
+        decoded = (CppType*)values;
+        for (uint i = 0; i < decode_size; i++) {
+            if (data[i + 100] != decoded[i]) {
+                if constexpr (std::is_same_v<int128_t, CppType>) {
+                    FAIL() << "Fail at index " << i;
+                } else {
+                    FAIL() << "Fail at index " << i << " inserted=" << data[i + 100] << " got=" << decoded[i];
+                }
+            }
+        }
+
+        ASSERT_TRUE(page_decoder.seek_to_position_in_page(0).ok());
+        ASSERT_EQ(0, page_decoder.current_index());
+        column = ChunkHelper::column_from_field_type(Type, false);
+        SparseRange<> read_range;
+        read_range.add(Range<>(0, 2));
+        read_range.add(Range<>(4, 7));
+        status = page_decoder.next_batch(read_range, column.get());
+        ASSERT_TRUE(status.ok());
+        ASSERT_EQ(5, column->size());
+        ASSERT_EQ(data[0], column->get(0).get<CppType>());
+        ASSERT_EQ(data[1], column->get(1).get<CppType>());
+        ASSERT_EQ(data[4], column->get(2).get<CppType>());
+        ASSERT_EQ(data[5], column->get(3).get<CppType>());
+        ASSERT_EQ(data[6], column->get(4).get<CppType>());
+    }
+};
+
+TEST_F(DictPageTest, TestSmallDataSizeWithInt32) {
+    const uint32_t size = 10000;
+    std::unique_ptr<int32_t[]> ints(new int32_t[size]);
+    for (int i = 0; i < 10000; i++) {
+        ints.get()[i] = i;
+    }
+    test_encode_decode_page_template<TYPE_INT>(ints.get(), size, size);
+}
+
+TEST_F(DictPageTest, TestSameValueWithInt32) {
+    const uint32_t size = 1000;
+    std::unique_ptr<int32_t[]> ints(new int32_t[size]);
+    for (int i = 0; i < size; i++) {
+        ints.get()[i] = i;
+    }
+    std::unique_ptr<int32_t[]> ints_expand(new int32_t[size * 2]);
+    std::memcpy(ints_expand.get(), ints.get(), size * sizeof(int32_t));
+    std::memcpy(ints_expand.get() + size, ints.get(), size * sizeof(int32_t));
+    test_encode_decode_page_template<TYPE_INT>(ints_expand.get(), size, size * 2);
+}
+
+TEST_F(DictPageTest, TestSmallDataSizeWithInt64_t) {
+    const uint32_t size = 10000;
+    std::unique_ptr<int64_t[]> ints(new int64_t[size]);
+    for (int i = 0; i < size; i++) {
+        ints.get()[i] = i;
+    }
+    test_encode_decode_page_template<TYPE_BIGINT>(ints.get(), size, size);
+}
+
+TEST_F(DictPageTest, TestSameValueWithInt64_t) {
+    const uint32_t size = 1000;
+    std::unique_ptr<int64_t[]> ints(new int64_t[size]);
+    for (int i = 0; i < size; i++) {
+        ints.get()[i] = i;
+    }
+    std::unique_ptr<int64_t[]> ints_expand(new int64_t[size * 2]);
+    std::memcpy(ints_expand.get(), ints.get(), size * sizeof(int64_t));
+    std::memcpy(ints_expand.get() + size, ints.get(), size * sizeof(int64_t));
+    test_encode_decode_page_template<TYPE_BIGINT>(ints_expand.get(), size, size * 2);
+}
+
+TEST_F(DictPageTest, TestSmallDataSizeWithInt128_t) {
+    const uint32_t size = 10000;
+    std::unique_ptr<int128_t[]> ints(new int128_t[size]);
+    for (int i = 0; i < size; i++) {
+        ints.get()[i] = i;
+    }
+    test_encode_decode_page_template<TYPE_LARGEINT>(ints.get(), size, size);
+}
+
+TEST_F(DictPageTest, TestSameValueWithInt128_t) {
+    const uint32_t size = 1000;
+    std::unique_ptr<int128_t[]> ints(new int128_t[size]);
+    for (int i = 0; i < size; i++) {
+        ints.get()[i] = i;
+    }
+    std::unique_ptr<int128_t[]> ints_expand(new int128_t[size * 2]);
+    std::memcpy(ints_expand.get(), ints.get(), size * sizeof(int128_t));
+    std::memcpy(ints_expand.get() + size, ints.get(), size * sizeof(int128_t));
+    test_encode_decode_page_template<TYPE_LARGEINT>(ints_expand.get(), size, size * 2);
+}
+
+TEST_F(DictPageTest, TestSmallDataSizeWithFloat) {
+    const uint32_t size = 10000;
+    std::unique_ptr<float[]> floats(new float[size]);
+    int upper = 100000;
+    for (int i = 0; i < size; i++) {
+        float random_value = static_cast<float>(20000 + i) / (static_cast<float>(RAND_MAX / upper));
+        floats.get()[i] = random_value;
+    }
+    test_encode_decode_page_template<TYPE_FLOAT>(floats.get(), size, size);
+}
+
+TEST_F(DictPageTest, TestSameValueWithFloat) {
+    const uint32_t size = 1000;
+    std::unique_ptr<float[]> floats(new float[size]);
+    int upper = 100000;
+    for (int i = 0; i < size; i++) {
+        float random_value = static_cast<float>(20000 + i) / (static_cast<float>(RAND_MAX / upper));
+        floats.get()[i] = random_value;
+    }
+    std::unique_ptr<float[]> floats_expand(new float[size * 2]);
+    std::memcpy(floats_expand.get(), floats.get(), size * sizeof(float));
+    std::memcpy(floats_expand.get() + size, floats.get(), size * sizeof(float));
+    test_encode_decode_page_template<TYPE_FLOAT>(floats_expand.get(), size, size * 2);
+}
+
+TEST_F(DictPageTest, TestSmallDataSizeWithDouble) {
+    const uint32_t size = 10000;
+    std::unique_ptr<double[]> floats(new double[size]);
+    int upper = 100000;
+    for (int i = 0; i < size; i++) {
+        double random_value = static_cast<double>(20000 + i) / (static_cast<double>(RAND_MAX / upper));
+        floats.get()[i] = random_value;
+    }
+    test_encode_decode_page_template<TYPE_DOUBLE>(floats.get(), size, size);
+}
+
+TEST_F(DictPageTest, TestSameValueWithDouble) {
+    const uint32_t size = 1000;
+    std::unique_ptr<double[]> doubles(new double[size]);
+    int upper = 100000;
+    for (int i = 0; i < size; i++) {
+        double random_value = static_cast<double>(20000 + i) / (static_cast<double>(RAND_MAX / upper));
+        doubles.get()[i] = random_value;
+    }
+    std::unique_ptr<double[]> doubles_expand(new double[size * 2]);
+    std::memcpy(doubles_expand.get(), doubles.get(), size * sizeof(double));
+    std::memcpy(doubles_expand.get() + size, doubles.get(), size * sizeof(double));
+    test_encode_decode_page_template<TYPE_DOUBLE>(doubles_expand.get(), size, size * 2);
+}
+
+TEST_F(DictPageTest, TestSmallDataSizeWithInt16_t) {
+    int lower = std::numeric_limits<int16_t>::min();
+    int upper = std::numeric_limits<int16_t>::max();
+    const uint32_t size = upper - lower + 1;
+    std::unique_ptr<int16_t[]> ints(new int16_t[size]);
+    int cur = 0;
+    // Generate all int16_t numbers, we can test if dict index overflow.
+    for (int i = lower; i <= upper; i++) {
+        ints.get()[cur++] = i;
+    }
+    test_encode_decode_page_template<TYPE_SMALLINT>(ints.get(), size, size);
+}
+
+TEST_F(DictPageTest, TestSmallDataSizeWithDecimalV2) {
+    const uint32_t size = 100 * 100;
+    std::unique_ptr<DecimalV2Value[]> decimals(new DecimalV2Value[size]);
+    for (int i = 0; i < 100; i++) {
+        for (int j = 0; j < 100; j++) {
+            decimals.get()[i * 100 + j] = DecimalV2Value(i, j);
+        }
+    }
+    test_encode_decode_page_template<TYPE_DECIMALV2>(decimals.get(), size, size);
+}
+
+TEST_F(DictPageTest, TestSameValueWithDecimalV2) {
+    const int F = 10;
+    const int I = 100;
+    const uint32_t size = F * I;
+    std::unique_ptr<DecimalV2Value[]> decimals(new DecimalV2Value[size]);
+    for (int i = 0; i < F; i++) {
+        for (int j = 0; j < I; j++) {
+            decimals.get()[i * I + j] = DecimalV2Value(i, j);
+        }
+    }
+    std::unique_ptr<DecimalV2Value[]> decimals_expand(new DecimalV2Value[size * 2]);
+    std::memcpy(decimals_expand.get(), decimals.get(), size * sizeof(DecimalV2Value));
+    std::memcpy(decimals_expand.get() + size, decimals.get(), size * sizeof(DecimalV2Value));
+    test_encode_decode_page_template<TYPE_DECIMALV2>(decimals.get(), size, size);
+}
+
+TEST_F(DictPageTest, TestLargeDataSize) {
+    // 0.1kw 8byte data, about 8MB
+    const uint32_t size = 100 * 10000;
+    std::unique_ptr<int64_t[]> ints(new int64_t[size]);
+    for (int i = 0; i < size; i++) {
+        ints.get()[i] = i;
+    }
+    using CppType = typename TypeTraits<TYPE_BIGINT>::CppType;
+    // encode
+    PageBuilderOptions options;
+    options.data_page_size = 1024 * 1024;
+    options.dict_page_size = 1024 * 1024;
+    int data_num = size;
+    std::unique_ptr<uint8_t*[]> data_handler_ptr(new uint8_t*[data_num]);
+    uint8_t** data_handler = data_handler_ptr.get();
+    for (int i = 0; i < data_num; i++) {
+        data_handler[i] = (uint8*)&ints[i];
+    }
+    DictPageBuilder<TYPE_BIGINT> page_builder(options);
+    std::vector<OwnedSlice> results;
+    std::vector<size_t> page_start_ids;
+    page_start_ids.push_back(0);
+    size_t data_page_count = 0;
+    for (int i = 0; i < data_num;) {
+        int add_num = std::min(100, data_num - i);
+        add_num = page_builder.add(data_handler[i], add_num);
+        i += add_num;
+        if (page_builder.is_page_full()) {
+            data_page_count++;
+            OwnedSlice s = page_builder.finish()->build();
+            results.emplace_back(std::move(s));
+            page_builder.reset();
+            page_start_ids.push_back(i);
+        }
+    }
+    data_page_count++;
+    ASSERT_TRUE(page_builder.count() != 0);
+    OwnedSlice s = page_builder.finish()->build();
+    results.emplace_back(std::move(s));
+    ASSERT_EQ(data_page_count, page_start_ids.size());
+    OwnedSlice dict_slice = page_builder.get_dictionary_page()->build();
+    Slice encoded_dict = dict_slice.slice();
+    starrocks::PageFooterPB dict_footer;
+    dict_footer.set_type(starrocks::DATA_PAGE);
+    starrocks::DataPageFooterPB* dict_page_footer = dict_footer.mutable_data_page_footer();
+    dict_page_footer->set_nullmap_size(0);
+    std::unique_ptr<char[]> dict_page = nullptr;
+    Status st = StoragePageDecoder::decode_page(&dict_footer, 0, starrocks::BIT_SHUFFLE, &dict_page, &encoded_dict);
+    ASSERT_TRUE(st.ok());
+    auto dict_page_decoder = std::make_unique<BitShufflePageDecoder<TYPE_BIGINT>>(encoded_dict);
+    st = dict_page_decoder->init();
+    ASSERT_TRUE(st.ok());
+    page_start_ids.push_back(data_num);
+    for (int i = 0; i < page_start_ids.size() - 1; i++) {
+        // decode
+        Slice encoded_data = results[i].slice();
+        PageFooterPB footer;
+        footer.set_type(DATA_PAGE);
+        DataPageFooterPB* data_page_footer = footer.mutable_data_page_footer();
+        data_page_footer->set_nullmap_size(0);
+        std::unique_ptr<char[]> page = nullptr;
+
+        st = StoragePageDecoder::decode_page(&footer, 0, starrocks::DICT_ENCODING, &page, &encoded_data);
+        ASSERT_TRUE(st.ok());
+        DictPageDecoder<TYPE_BIGINT> page_decoder(encoded_data);
+        st = page_decoder.init();
+        ASSERT_TRUE(st.ok());
+        page_decoder.set_dict_decoder(dict_page_decoder.get());
+
+        // check values
+        auto column = ChunkHelper::column_from_field_type(TYPE_BIGINT, false);
+        size_t page_start_id = page_start_ids[i];
+        size_t page_size = page_start_ids[i + 1] - page_start_id;
+        size_t decode_size = page_size;
+        st = page_decoder.next_batch(&decode_size, column.get());
+        ASSERT_TRUE(st.ok());
+        ASSERT_EQ(page_size, decode_size);
+        auto* values = reinterpret_cast<const CppType*>(column->raw_data());
+        auto* decoded = (CppType*)values;
+        for (int j = page_start_id; j < page_start_ids[i + 1]; j++) {
+            if (decoded[j - page_start_id] != j) {
+                FAIL() << "Fail at index " << i << " inserted=" << j << " got=" << decoded[j - page_start_id];
+            }
+        }
+    }
+}
+
+} // namespace starrocks

--- a/be/test/storage/rowset/encoding_info_test.cpp
+++ b/be/test/storage/rowset/encoding_info_test.cpp
@@ -46,8 +46,20 @@ namespace starrocks {
 
 class EncodingInfoTest : public testing::Test {
 public:
-    EncodingInfoTest() = default;
+    EncodingInfoTest() {
+        _number_types_supports_dict_encoding.emplace(TYPE_SMALLINT);
+        _number_types_supports_dict_encoding.emplace(TYPE_INT);
+        _number_types_supports_dict_encoding.emplace(TYPE_BIGINT);
+        _number_types_supports_dict_encoding.emplace(TYPE_LARGEINT);
+        _number_types_supports_dict_encoding.emplace(TYPE_FLOAT);
+        _number_types_supports_dict_encoding.emplace(TYPE_DOUBLE);
+        _number_types_supports_dict_encoding.emplace(TYPE_DATE);
+        _number_types_supports_dict_encoding.emplace(TYPE_DATETIME);
+        _number_types_supports_dict_encoding.emplace(TYPE_DECIMALV2);
+    }
+
     ~EncodingInfoTest() override = default;
+    std::set<LogicalType> _number_types_supports_dict_encoding;
 };
 
 TEST_F(EncodingInfoTest, normal) {
@@ -61,8 +73,33 @@ TEST_F(EncodingInfoTest, normal) {
 TEST_F(EncodingInfoTest, no_encoding) {
     auto type_info = get_type_info(TYPE_BIGINT);
     const EncodingInfo* encoding_info = nullptr;
-    auto status = EncodingInfo::get(TYPE_BIGINT, DICT_ENCODING, &encoding_info);
+    auto status = EncodingInfo::get(TYPE_BIGINT, RLE, &encoding_info);
     ASSERT_FALSE(status.ok());
+}
+
+TEST_F(EncodingInfoTest, number_types_supports_dict_encoding) {
+    for (auto logicType : _number_types_supports_dict_encoding) {
+        EXPECT_EQ(true, numeric_types_support_dict_encoding(logicType));
+        EXPECT_EQ(true, supports_dict_encoding(logicType));
+    }
+    EXPECT_EQ(false, numeric_types_support_dict_encoding(TYPE_CHAR));
+    EXPECT_EQ(false, numeric_types_support_dict_encoding(TYPE_VARCHAR));
+    EXPECT_EQ(true, supports_dict_encoding(TYPE_CHAR));
+    EXPECT_EQ(true, supports_dict_encoding(TYPE_VARCHAR));
+}
+
+TEST_F(EncodingInfoTest, get_default_encoding_number_types) {
+    for (auto logicType : _number_types_supports_dict_encoding) {
+        EXPECT_EQ(BIT_SHUFFLE, EncodingInfo::get_default_encoding(logicType, false));
+        const EncodingInfo* encoding_info;
+        auto status = EncodingInfo::get(logicType, DEFAULT_ENCODING, &encoding_info);
+        ASSERT_TRUE(status.ok());
+        EXPECT_EQ(BIT_SHUFFLE, encoding_info->encoding());
+
+        status = EncodingInfo::get(logicType, DICT_ENCODING, &encoding_info);
+        ASSERT_TRUE(status.ok());
+        EXPECT_EQ(DICT_ENCODING, encoding_info->encoding());
+    }
 }
 
 TEST_F(EncodingInfoTest, default_encoding) {

--- a/be/test/storage/rowset/plain_page_test.cpp
+++ b/be/test/storage/rowset/plain_page_test.cpp
@@ -95,6 +95,12 @@ public:
         Status status = page_decoder.init();
         ASSERT_TRUE(status.ok());
 
+        for (int i = 0; i < size; i++) {
+            CppType index_value;
+            page_decoder.at_index(i, &index_value);
+            ASSERT_EQ(src[i], index_value);
+        }
+
         ASSERT_EQ(0, page_decoder.current_index());
 
         auto column = ChunkHelper::column_from_field_type(Type, false);
@@ -108,7 +114,7 @@ public:
         }
 
         auto column1 = ChunkHelper::column_from_field_type(Type, false);
-        page_decoder.seek_to_position_in_page(0);
+        ASSERT_TRUE(page_decoder.seek_to_position_in_page(0).ok());
         ASSERT_EQ(0, page_decoder.current_index());
 
         SparseRange<> read_range;
@@ -136,7 +142,7 @@ public:
         // Test Seek within block by ordinal
         for (int i = 0; i < 100; i++) {
             uint32_t seek_off = random() % size;
-            page_decoder.seek_to_position_in_page(seek_off);
+            ASSERT_TRUE(page_decoder.seek_to_position_in_page(seek_off).ok());
             EXPECT_EQ((int32_t)(seek_off), page_decoder.current_index());
             CppType ret;
             copy_one<Type, PageDecoderType>(&page_decoder, &ret);


### PR DESCRIPTION
## Why I'm doing:
non-string column dict encoding and decoding is supported in version 3.3, #36211
this pr only supports decoding for rollback version from 3.3 to 3.2.

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [x] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5

