### PR TITLE
[BugFix]fix uncorrectly probing hash table in null safe join condition

### DIFF
--- a/be/src/exec/join_hash_map.cpp
+++ b/be/src/exec/join_hash_map.cpp
@@ -641,7 +641,7 @@ JoinHashMapType JoinHashTable::_choose_join_hash_map() {
     DCHECK_GT(size, 0);
 
     for (size_t i = 0; i < size; i++) {
-        if (!_table_items->key_columns[i]->has_null() || !_table_items->probe_slots[i].slot->is_nullable()) {
+        if (!_table_items->key_columns[i]->has_null()) {
             _table_items->join_keys[i].is_null_safe_equal = false;
         }
     }

--- a/be/src/exec/join_hash_map.cpp
+++ b/be/src/exec/join_hash_map.cpp
@@ -91,10 +91,7 @@ void SerializedJoinBuildFunc::construct_hash_table(RuntimeState* state, JoinHash
 
     for (size_t i = 0; i < table_items->key_columns.size(); i++) {
         if (table_items->join_keys[i].is_null_safe_equal) {
-            // this means build column is a nullable column and join condition is null safe equal
-            // we need convert the probe column to a nullable column when it's a non-nullable column
-            // to align the type between build and probe columns.
-            data_columns.emplace_back(NullableColumn::wrap_if_necessary((*probe_state->key_columns)[i]));
+            data_columns.emplace_back(table_items->key_columns[i]);
         } else if (table_items->key_columns[i]->is_nullable()) {
             auto* nullable_column = ColumnHelper::as_raw_column<NullableColumn>(table_items->key_columns[i]);
             data_columns.emplace_back(nullable_column->data_column());
@@ -188,7 +185,10 @@ void SerializedJoinProbeFunc::lookup_init(const JoinHashTableItems& table_items,
 
     for (size_t i = 0; i < probe_state->key_columns->size(); i++) {
         if (table_items.join_keys[i].is_null_safe_equal) {
-            data_columns.emplace_back((*probe_state->key_columns)[i]);
+            // this means build column is a nullable column and join condition is null safe equal
+            // we need convert the probe column to a nullable column when it's a non-nullable column
+            // to align the type between build and probe columns.
+            data_columns.emplace_back(NullableColumn::wrap_if_necessary((*probe_state->key_columns)[i]));
         } else if ((*probe_state->key_columns)[i]->is_nullable()) {
             auto* nullable_column = ColumnHelper::as_raw_column<NullableColumn>((*probe_state->key_columns)[i]);
             data_columns.emplace_back(nullable_column->data_column());

--- a/be/src/exec/join_hash_map.cpp
+++ b/be/src/exec/join_hash_map.cpp
@@ -638,7 +638,7 @@ JoinHashMapType JoinHashTable::_choose_join_hash_map() {
     DCHECK_GT(size, 0);
 
     for (size_t i = 0; i < size; i++) {
-        if (!_table_items->key_columns[i]->has_null()) {
+        if (!_table_items->key_columns[i]->has_null() || !_table_items->probe_slots[i].slot->is_nullable()) {
             _table_items->join_keys[i].is_null_safe_equal = false;
         }
     }

--- a/be/src/exec/join_hash_map.cpp
+++ b/be/src/exec/join_hash_map.cpp
@@ -641,7 +641,7 @@ JoinHashMapType JoinHashTable::_choose_join_hash_map() {
     DCHECK_GT(size, 0);
 
     for (size_t i = 0; i < size; i++) {
-        if (!_table_items->key_columns[i]->has_null()) {
+        if (!_table_items->key_columns[i]->has_null() || !_table_items->probe_slots[i].slot->is_nullable()) {
             _table_items->join_keys[i].is_null_safe_equal = false;
         }
     }

--- a/test/sql/test_join/R/test_null_safe_equal
+++ b/test/sql/test_join/R/test_null_safe_equal
@@ -1,0 +1,190 @@
+-- name: test_null_safe_equal
+CREATE TABLE `nullable_t1` ( `t1_c1` int, `t1_c2` int, `t1_c3` int, `t1_c4` varchar(10))
+DUPLICATE KEY(`t1_c1`) COMMENT "OLAP" DISTRIBUTED BY HASH(`t1_c1`) PROPERTIES ( "replication_num" = "1");
+-- result:
+-- !result
+CREATE TABLE `t2` (`t2_c1` int NOT NULL default "0", `t2_c2` int NOT NULL default "0", `t2_c3` int NOT NULL default "0", `t2_c4` varchar(10) NOT NULL default "")
+DUPLICATE KEY(`t2_c1`) COMMENT "OLAP" DISTRIBUTED BY HASH(`t2_c1`) PROPERTIES ( "replication_num" = "1");
+-- result:
+-- !result
+insert into nullable_t1 (t1_c1, t1_c2, t1_c3, t1_c4) values
+(1, 11, 111, '1111'), (2, 22, 222, '2222'), (3, null, 333, '3333'), (4, null, null, '4444'), (null, 55, 555, null), (6, 66, null, '6666'), (null, null, null, null);
+-- result:
+-- !result
+insert into t2 (t2_c1, t2_c2, t2_c3, t2_c4) values
+(1, 11, 111, '1111'), (2, 22, 222, '2222'), (3, 33, 333, '3333'), (4, 44, 444, '4444'), (5, 55, 555, '5555'), (6, 66, 666, '6666'), (7, 77, 777, '7777');
+-- result:
+-- !result
+set pipeline_dop = 1;
+-- result:
+-- !result
+select * from t2 join [shuffle] nullable_t1 on t1_c4 <=> t2_c4;
+-- result:
+3	33	333	3333	3	None	333	3333
+6	66	666	6666	6	66	None	6666
+1	11	111	1111	1	11	111	1111
+2	22	222	2222	2	22	222	2222
+4	44	444	4444	4	None	None	4444
+-- !result
+select * from t2 join [broadcast] nullable_t1 on t1_c4 <=> t2_c4;
+-- result:
+3	33	333	3333	3	None	333	3333
+6	66	666	6666	6	66	None	6666
+1	11	111	1111	1	11	111	1111
+2	22	222	2222	2	22	222	2222
+4	44	444	4444	4	None	None	4444
+-- !result
+select * from t2 join [bucket] nullable_t1 on t1_c1 <=> t2_c1 and t1_c4 <=> t2_c4;
+-- result:
+3	33	333	3333	3	None	333	3333
+6	66	666	6666	6	66	None	6666
+1	11	111	1111	1	11	111	1111
+2	22	222	2222	2	22	222	2222
+4	44	444	4444	4	None	None	4444
+-- !result
+select * from t2 left join [shuffle] nullable_t1 on t1_c4 <=> t2_c4;
+-- result:
+3	33	333	3333	3	None	333	3333
+5	55	555	5555	None	None	None	None
+6	66	666	6666	6	66	None	6666
+1	11	111	1111	1	11	111	1111
+2	22	222	2222	2	22	222	2222
+4	44	444	4444	4	None	None	4444
+7	77	777	7777	None	None	None	None
+-- !result
+select * from t2 left join [broadcast] nullable_t1 on t1_c4 <=> t2_c4;
+-- result:
+3	33	333	3333	3	None	333	3333
+5	55	555	5555	None	None	None	None
+6	66	666	6666	6	66	None	6666
+1	11	111	1111	1	11	111	1111
+2	22	222	2222	2	22	222	2222
+4	44	444	4444	4	None	None	4444
+7	77	777	7777	None	None	None	None
+-- !result
+select * from t2 left join [bucket] nullable_t1 on t1_c1 <=> t2_c1 and t1_c4 <=> t2_c4;
+-- result:
+3	33	333	3333	3	None	333	3333
+5	55	555	5555	None	None	None	None
+6	66	666	6666	6	66	None	6666
+1	11	111	1111	1	11	111	1111
+2	22	222	2222	2	22	222	2222
+4	44	444	4444	4	None	None	4444
+7	77	777	7777	None	None	None	None
+-- !result
+select * from t2 right join [shuffle] nullable_t1 on t1_c4 <=> t2_c4;
+-- result:
+3	33	333	3333	3	None	333	3333
+6	66	666	6666	6	66	None	6666
+1	11	111	1111	1	11	111	1111
+2	22	222	2222	2	22	222	2222
+4	44	444	4444	4	None	None	4444
+None	None	None	None	None	55	555	None
+None	None	None	None	None	None	None	None
+-- !result
+select * from t2 right join [bucket] nullable_t1 on t1_c1 <=> t2_c1 and t1_c4 <=> t2_c4;
+-- result:
+3	33	333	3333	3	None	333	3333
+6	66	666	6666	6	66	None	6666
+1	11	111	1111	1	11	111	1111
+2	22	222	2222	2	22	222	2222
+4	44	444	4444	4	None	None	4444
+None	None	None	None	None	55	555	None
+None	None	None	None	None	None	None	None
+-- !result
+select * from nullable_t1 t1 join [shuffle] nullable_t1 t2 on t1.t1_c4 <=> t2.t1_c4;
+-- result:
+None	55	555	None	None	None	None	None
+None	55	555	None	None	55	555	None
+None	None	None	None	None	None	None	None
+None	None	None	None	None	55	555	None
+3	None	333	3333	3	None	333	3333
+6	66	None	6666	6	66	None	6666
+1	11	111	1111	1	11	111	1111
+2	22	222	2222	2	22	222	2222
+4	None	None	4444	4	None	None	4444
+-- !result
+select * from nullable_t1 t1 join [broadcast] nullable_t1 t2 on t1.t1_c4 <=> t2.t1_c4;
+-- result:
+None	55	555	None	None	None	None	None
+None	55	555	None	None	55	555	None
+None	None	None	None	None	None	None	None
+None	None	None	None	None	55	555	None
+3	None	333	3333	3	None	333	3333
+6	66	None	6666	6	66	None	6666
+1	11	111	1111	1	11	111	1111
+2	22	222	2222	2	22	222	2222
+4	None	None	4444	4	None	None	4444
+-- !result
+select * from nullable_t1 t1 join [bucket] nullable_t1 t2 on t1.t1_c4 <=> t2.t1_c4;
+-- result:
+None	55	555	None	None	None	None	None
+None	55	555	None	None	55	555	None
+None	None	None	None	None	None	None	None
+None	None	None	None	None	55	555	None
+3	None	333	3333	3	None	333	3333
+6	66	None	6666	6	66	None	6666
+1	11	111	1111	1	11	111	1111
+2	22	222	2222	2	22	222	2222
+4	None	None	4444	4	None	None	4444
+-- !result
+select * from nullable_t1 t1 left join [shuffle] nullable_t1 t2 on t1.t1_c4 <=> t2.t1_c4;
+-- result:
+None	55	555	None	None	None	None	None
+None	55	555	None	None	55	555	None
+None	None	None	None	None	None	None	None
+None	None	None	None	None	55	555	None
+3	None	333	3333	3	None	333	3333
+6	66	None	6666	6	66	None	6666
+1	11	111	1111	1	11	111	1111
+2	22	222	2222	2	22	222	2222
+4	None	None	4444	4	None	None	4444
+-- !result
+select * from nullable_t1 t1 left join [broadcast] nullable_t1 t2 on t1.t1_c4 <=> t2.t1_c4;
+-- result:
+None	55	555	None	None	None	None	None
+None	55	555	None	None	55	555	None
+None	None	None	None	None	None	None	None
+None	None	None	None	None	55	555	None
+3	None	333	3333	3	None	333	3333
+6	66	None	6666	6	66	None	6666
+1	11	111	1111	1	11	111	1111
+2	22	222	2222	2	22	222	2222
+4	None	None	4444	4	None	None	4444
+-- !result
+select * from nullable_t1 t1 left join [bucket] nullable_t1 t2 on t1.t1_c4 <=> t2.t1_c4;
+-- result:
+None	55	555	None	None	None	None	None
+None	55	555	None	None	55	555	None
+None	None	None	None	None	None	None	None
+None	None	None	None	None	55	555	None
+3	None	333	3333	3	None	333	3333
+6	66	None	6666	6	66	None	6666
+1	11	111	1111	1	11	111	1111
+2	22	222	2222	2	22	222	2222
+4	None	None	4444	4	None	None	4444
+-- !result
+select * from nullable_t1 t1 right join [shuffle] nullable_t1 t2 on t1.t1_c4 <=> t2.t1_c4;
+-- result:
+None	55	555	None	None	None	None	None
+None	55	555	None	None	55	555	None
+None	None	None	None	None	None	None	None
+None	None	None	None	None	55	555	None
+3	None	333	3333	3	None	333	3333
+6	66	None	6666	6	66	None	6666
+1	11	111	1111	1	11	111	1111
+2	22	222	2222	2	22	222	2222
+4	None	None	4444	4	None	None	4444
+-- !result
+select * from nullable_t1 t1 right join [bucket] nullable_t1 t2 on t1.t1_c4 <=> t2.t1_c4;
+-- result:
+None	55	555	None	None	None	None	None
+None	55	555	None	None	55	555	None
+None	None	None	None	None	None	None	None
+None	None	None	None	None	55	555	None
+3	None	333	3333	3	None	333	3333
+6	66	None	6666	6	66	None	6666
+1	11	111	1111	1	11	111	1111
+2	22	222	2222	2	22	222	2222
+4	None	None	4444	4	None	None	4444
+-- !result

--- a/test/sql/test_join/T/test_null_safe_equal
+++ b/test/sql/test_join/T/test_null_safe_equal
@@ -1,0 +1,36 @@
+-- name: test_null_safe_equal
+CREATE TABLE `nullable_t1` ( `t1_c1` int, `t1_c2` int, `t1_c3` int, `t1_c4` varchar(10))
+DUPLICATE KEY(`t1_c1`) COMMENT "OLAP" DISTRIBUTED BY HASH(`t1_c1`) PROPERTIES ( "replication_num" = "1");
+CREATE TABLE `t2` (`t2_c1` int NOT NULL default "0", `t2_c2` int NOT NULL default "0", `t2_c3` int NOT NULL default "0", `t2_c4` varchar(10) NOT NULL default "")
+DUPLICATE KEY(`t2_c1`) COMMENT "OLAP" DISTRIBUTED BY HASH(`t2_c1`) PROPERTIES ( "replication_num" = "1");
+
+insert into nullable_t1 (t1_c1, t1_c2, t1_c3, t1_c4) values
+(1, 11, 111, '1111'), (2, 22, 222, '2222'), (3, null, 333, '3333'), (4, null, null, '4444'), (null, 55, 555, null), (6, 66, null, '6666'), (null, null, null, null);
+insert into t2 (t2_c1, t2_c2, t2_c3, t2_c4) values
+(1, 11, 111, '1111'), (2, 22, 222, '2222'), (3, 33, 333, '3333'), (4, 44, 444, '4444'), (5, 55, 555, '5555'), (6, 66, 666, '6666'), (7, 77, 777, '7777');
+
+set pipeline_dop = 1;
+
+select * from t2 join [shuffle] nullable_t1 on t1_c4 <=> t2_c4;
+select * from t2 join [broadcast] nullable_t1 on t1_c4 <=> t2_c4;
+select * from t2 join [bucket] nullable_t1 on t1_c1 <=> t2_c1 and t1_c4 <=> t2_c4;
+
+select * from t2 left join [shuffle] nullable_t1 on t1_c4 <=> t2_c4;
+select * from t2 left join [broadcast] nullable_t1 on t1_c4 <=> t2_c4;
+select * from t2 left join [bucket] nullable_t1 on t1_c1 <=> t2_c1 and t1_c4 <=> t2_c4;
+
+select * from t2 right join [shuffle] nullable_t1 on t1_c4 <=> t2_c4;
+select * from t2 right join [bucket] nullable_t1 on t1_c1 <=> t2_c1 and t1_c4 <=> t2_c4;
+
+
+select * from nullable_t1 t1 join [shuffle] nullable_t1 t2 on t1.t1_c4 <=> t2.t1_c4;
+select * from nullable_t1 t1 join [broadcast] nullable_t1 t2 on t1.t1_c4 <=> t2.t1_c4;
+select * from nullable_t1 t1 join [bucket] nullable_t1 t2 on t1.t1_c4 <=> t2.t1_c4;
+
+select * from nullable_t1 t1 left join [shuffle] nullable_t1 t2 on t1.t1_c4 <=> t2.t1_c4;
+select * from nullable_t1 t1 left join [broadcast] nullable_t1 t2 on t1.t1_c4 <=> t2.t1_c4;
+select * from nullable_t1 t1 left join [bucket] nullable_t1 t2 on t1.t1_c4 <=> t2.t1_c4;
+
+select * from nullable_t1 t1 right join [shuffle] nullable_t1 t2 on t1.t1_c4 <=> t2.t1_c4;
+select * from nullable_t1 t1 right join [bucket] nullable_t1 t2 on t1.t1_c4 <=> t2.t1_c4;
+


### PR DESCRIPTION
## Why I'm doing:
fix https://github.com/StarRocks/StarRocksTest/issues/7283
For a hash join with null safe join condition, the build side is a nullable varchar column, while the probe side is a non-nullable varchar column. The different types of columns lead different hash key even when they contain same value, because of their different serialize method.

## What I'm doing:
When in null safe join condition, wrap proble column to nullable column when necessary.

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [x] 3.2
  - [x] 3.1
  - [x] 3.0
  - [x] 2.5
