### PR TITLE
[BugFix] Fix Topn Runtime Filter order by short key wrong result (backport #45037)

### DIFF
--- a/be/src/storage/lake/rowset.cpp
+++ b/be/src/storage/lake/rowset.cpp
@@ -52,6 +52,7 @@ StatusOr<std::vector<ChunkIteratorPtr>> Rowset::read(const Schema& schema, const
     seg_options.unused_output_column_ids = options.unused_output_column_ids;
     seg_options.runtime_range_pruner = options.runtime_range_pruner;
     seg_options.fill_data_cache = options.fill_data_cache;
+    seg_options.asc_hint = options.asc_hint;
     if (options.is_primary_keys) {
         seg_options.is_primary_keys = true;
         seg_options.delvec_loader = std::make_shared<LakeDelvecLoader>(_tablet->update_mgr(), nullptr);

--- a/be/src/storage/tablet_reader.cpp
+++ b/be/src/storage/tablet_reader.cpp
@@ -270,7 +270,9 @@ Status TabletReader::get_segment_iterators(const TabletReaderParams& params, std
     rs_opts.meta = _tablet->data_dir()->get_meta();
     rs_opts.rowid_range_option = params.rowid_range_option;
     rs_opts.short_key_ranges = params.short_key_ranges;
-    rs_opts.asc_hint = _is_asc_hint;
+    if (keys_type == AGG_KEYS || keys_type == UNIQUE_KEYS) {
+        rs_opts.asc_hint = _is_asc_hint;
+    }
 
     SCOPED_RAW_TIMER(&_stats.create_segment_iter_ns);
     for (auto& rowset : _rowsets) {

--- a/test/sql/test_push_down_predicate/R/test_topn_push_down_union
+++ b/test/sql/test_push_down_predicate/R/test_topn_push_down_union
@@ -70,9 +70,6 @@ INSERT INTO tbl_mock_001 (
 );
 -- result:
 -- !result
-SET cbo_push_down_topn_limit=0;
--- result:
--- !result
 SELECT *
 FROM (
 	(SELECT *

--- a/test/sql/test_sort/R/test_topn
+++ b/test/sql/test_sort/R/test_topn
@@ -206,3 +206,228 @@ select c1,c0 from t2 order by c1,c0 asc limit 10;
 9	9
 10	10
 -- !result
+create table t3 (
+    c0 INT,
+    c1 BIGINT
+) UNIQUE KEY(c0) DISTRIBUTED BY HASH(c0) BUCKETS 1 PROPERTIES('replication_num' = '1');
+-- result:
+-- !result
+insert into t3 SELECT generate_series, generate_series FROM TABLE(generate_series(1,  7));
+-- result:
+-- !result
+insert into t3 SELECT generate_series, generate_series + 1 FROM TABLE(generate_series(1,  7));
+-- result:
+-- !result
+insert into t3 SELECT generate_series, generate_series + 2 FROM TABLE(generate_series(1,  7));
+-- result:
+-- !result
+select c0 from t3 order by c0 asc limit 10;
+-- result:
+1
+2
+3
+4
+5
+6
+7
+-- !result
+select c1 from t3 order by c1 asc limit 10;
+-- result:
+3
+4
+5
+6
+7
+8
+9
+-- !result
+select c1,c0 from t3 order by c1,c0 asc limit 10;
+-- result:
+3	1
+4	2
+5	3
+6	4
+7	5
+8	6
+9	7
+-- !result
+select c0 from t3 order by c0 desc limit 10;
+-- result:
+7
+6
+5
+4
+3
+2
+1
+-- !result
+select c1 from t3 order by c1 desc limit 10;
+-- result:
+9
+8
+7
+6
+5
+4
+3
+-- !result
+select c1,c0 from t3 order by c1,c0 desc limit 10;
+-- result:
+3	1
+4	2
+5	3
+6	4
+7	5
+8	6
+9	7
+-- !result
+create table t4 (
+    c0 INT,
+    c1 BIGINT REPLACE
+) UNIQUE KEY(c0) DISTRIBUTED BY HASH(c0) BUCKETS 1 PROPERTIES('replication_num' = '1');
+-- result:
+-- !result
+insert into t4 SELECT generate_series, generate_series FROM TABLE(generate_series(1,  7));
+-- result:
+-- !result
+insert into t4 SELECT generate_series, generate_series + 1 FROM TABLE(generate_series(1,  7));
+-- result:
+-- !result
+insert into t4 SELECT generate_series, generate_series + 2 FROM TABLE(generate_series(1,  7));
+-- result:
+-- !result
+select c0 from t4 order by c0 asc limit 10;
+-- result:
+1
+2
+3
+4
+5
+6
+7
+-- !result
+select c1 from t4 order by c1 asc limit 10;
+-- result:
+3
+4
+5
+6
+7
+8
+9
+-- !result
+select c1,c0 from t4 order by c1,c0 asc limit 10;
+-- result:
+3	1
+4	2
+5	3
+6	4
+7	5
+8	6
+9	7
+-- !result
+select c0 from t4 order by c0 desc limit 10;
+-- result:
+7
+6
+5
+4
+3
+2
+1
+-- !result
+select c1 from t4 order by c1 desc limit 10;
+-- result:
+9
+8
+7
+6
+5
+4
+3
+-- !result
+select c1,c0 from t4 order by c1,c0 desc limit 10;
+-- result:
+3	1
+4	2
+5	3
+6	4
+7	5
+8	6
+9	7
+-- !result
+create table t5 (
+    c0 INT,
+    c1 BIGINT
+) PRIMARY KEY(c0) DISTRIBUTED BY HASH(c0) BUCKETS 1 PROPERTIES('replication_num' = '1');
+-- result:
+-- !result
+insert into t5 SELECT generate_series, generate_series FROM TABLE(generate_series(1,  7));
+-- result:
+-- !result
+insert into t5 SELECT generate_series, generate_series + 1 FROM TABLE(generate_series(1,  7));
+-- result:
+-- !result
+insert into t5 SELECT generate_series, generate_series + 2 FROM TABLE(generate_series(1,  7));
+-- result:
+-- !result
+select c0 from t5 order by c0 asc limit 10;
+-- result:
+1
+2
+3
+4
+5
+6
+7
+-- !result
+select c1 from t5 order by c1 asc limit 10;
+-- result:
+3
+4
+5
+6
+7
+8
+9
+-- !result
+select c1,c0 from t5 order by c1,c0 asc limit 10;
+-- result:
+3	1
+4	2
+5	3
+6	4
+7	5
+8	6
+9	7
+-- !result
+select c0 from t5 order by c0 desc limit 10;
+-- result:
+7
+6
+5
+4
+3
+2
+1
+-- !result
+select c1 from t5 order by c1 desc limit 10;
+-- result:
+9
+8
+7
+6
+5
+4
+3
+-- !result
+select c1,c0 from t5 order by c1,c0 desc limit 10;
+-- result:
+3	1
+4	2
+5	3
+6	4
+7	5
+8	6
+9	7
+-- !result

--- a/test/sql/test_sort/T/test_topn
+++ b/test/sql/test_sort/T/test_topn
@@ -52,3 +52,49 @@ insert into t2 SELECT generate_series, generate_series FROM TABLE(generate_serie
 select c0 from t2 order by c0 asc limit 10;
 select c1 from t2 order by c1 asc limit 10;
 select c1,c0 from t2 order by c1,c0 asc limit 10;
+-- UNIQUE/AGG
+create table t3 (
+    c0 INT,
+    c1 BIGINT
+) UNIQUE KEY(c0) DISTRIBUTED BY HASH(c0) BUCKETS 1 PROPERTIES('replication_num' = '1');
+insert into t3 SELECT generate_series, generate_series FROM TABLE(generate_series(1,  7));
+insert into t3 SELECT generate_series, generate_series + 1 FROM TABLE(generate_series(1,  7));
+insert into t3 SELECT generate_series, generate_series + 2 FROM TABLE(generate_series(1,  7));
+
+select c0 from t3 order by c0 asc limit 10;
+select c1 from t3 order by c1 asc limit 10;
+select c1,c0 from t3 order by c1,c0 asc limit 10;
+select c0 from t3 order by c0 desc limit 10;
+select c1 from t3 order by c1 desc limit 10;
+select c1,c0 from t3 order by c1,c0 desc limit 10;
+
+create table t4 (
+    c0 INT,
+    c1 BIGINT REPLACE
+) UNIQUE KEY(c0) DISTRIBUTED BY HASH(c0) BUCKETS 1 PROPERTIES('replication_num' = '1');
+insert into t4 SELECT generate_series, generate_series FROM TABLE(generate_series(1,  7));
+insert into t4 SELECT generate_series, generate_series + 1 FROM TABLE(generate_series(1,  7));
+insert into t4 SELECT generate_series, generate_series + 2 FROM TABLE(generate_series(1,  7));
+
+select c0 from t4 order by c0 asc limit 10;
+select c1 from t4 order by c1 asc limit 10;
+select c1,c0 from t4 order by c1,c0 asc limit 10;
+select c0 from t4 order by c0 desc limit 10;
+select c1 from t4 order by c1 desc limit 10;
+select c1,c0 from t4 order by c1,c0 desc limit 10;
+
+create table t5 (
+    c0 INT,
+    c1 BIGINT
+) PRIMARY KEY(c0) DISTRIBUTED BY HASH(c0) BUCKETS 1 PROPERTIES('replication_num' = '1');
+insert into t5 SELECT generate_series, generate_series FROM TABLE(generate_series(1,  7));
+insert into t5 SELECT generate_series, generate_series + 1 FROM TABLE(generate_series(1,  7));
+insert into t5 SELECT generate_series, generate_series + 2 FROM TABLE(generate_series(1,  7));
+
+
+select c0 from t5 order by c0 asc limit 10;
+select c1 from t5 order by c1 asc limit 10;
+select c1,c0 from t5 order by c1,c0 asc limit 10;
+select c0 from t5 order by c0 desc limit 10;
+select c1 from t5 order by c1 desc limit 10;
+select c1,c0 from t5 order by c1,c0 desc limit 10;


### PR DESCRIPTION


## Why I'm doing:

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [x] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5

