### PR TITLE
[Refactor] Remove _tuple_idx_nullable_map from RowDescriptor

### DIFF
--- a/be/src/exec/analytor.cpp
+++ b/be/src/exec/analytor.cpp
@@ -293,7 +293,7 @@ Status Analytor::prepare(RuntimeState* state, ObjectPool* pool, RuntimeProfile* 
         vector<TTupleId> tuple_ids;
         tuple_ids.push_back(_child_row_desc.tuple_descriptors()[0]->id());
         tuple_ids.push_back(_buffered_tuple_id);
-        RowDescriptor cmp_row_desc(state->desc_tbl(), tuple_ids, vector<bool>(2, false));
+        RowDescriptor cmp_row_desc(state->desc_tbl(), tuple_ids);
         if (!_partition_ctxs.empty()) {
             RETURN_IF_ERROR(Expr::prepare(_partition_ctxs, state));
         }

--- a/be/src/exec/dictionary_cache_writer.cpp
+++ b/be/src/exec/dictionary_cache_writer.cpp
@@ -291,7 +291,7 @@ Status DictionaryCacheWriter::ChunkUtil::uncompress_and_deserialize_chunk(const 
                                                                           faststring* uncompressed_buffer,
                                                                           const OlapTableSchemaParam* schema) {
     // build chunk meta
-    auto row_desc = std::make_unique<RowDescriptor>(schema->tuple_desc(), false);
+    auto row_desc = std::make_unique<RowDescriptor>(schema->tuple_desc());
     StatusOr<serde::ProtobufChunkMeta> res = serde::build_protobuf_chunk_meta(*row_desc, pchunk);
     if (!res.ok()) {
         return res.status();

--- a/be/src/exec/exchange_node.cpp
+++ b/be/src/exec/exchange_node.cpp
@@ -54,10 +54,7 @@ ExchangeNode::ExchangeNode(ObjectPool* pool, const TPlanNode& tnode, const Descr
           _texchange_node(tnode.exchange_node),
           _num_senders(0),
           _stream_recvr(nullptr),
-          _input_row_desc(
-                  descs, tnode.exchange_node.input_row_tuples,
-                  std::vector<bool>(tnode.nullable_tuples.begin(),
-                                    tnode.nullable_tuples.begin() + tnode.exchange_node.input_row_tuples.size())),
+          _input_row_desc(descs, tnode.exchange_node.input_row_tuples),
           _is_merging(tnode.exchange_node.__isset.sort_info),
           _is_parallel_merge(tnode.exchange_node.__isset.enable_parallel_merge &&
                              tnode.exchange_node.enable_parallel_merge),

--- a/be/src/exec/exec_node.cpp
+++ b/be/src/exec/exec_node.cpp
@@ -92,7 +92,7 @@ ExecNode::ExecNode(ObjectPool* pool, const TPlanNode& tnode, const DescriptorTbl
           _type(tnode.node_type),
           _pool(pool),
           _tuple_ids(tnode.row_tuples),
-          _row_descriptor(descs, tnode.row_tuples, tnode.nullable_tuples),
+          _row_descriptor(descs, tnode.row_tuples),
           _resource_profile(tnode.resource_profile),
           _debug_phase(TExecNodePhase::INVALID),
           _debug_action(TDebugAction::WAIT),

--- a/be/src/exec/file_scanner.cpp
+++ b/be/src/exec/file_scanner.cpp
@@ -80,8 +80,7 @@ Status FileScanner::init_expr_ctx() {
         _src_slot_descriptors.emplace_back(it->second);
     }
 
-    _row_desc = std::make_unique<RowDescriptor>(_state->desc_tbl(), std::vector<TupleId>{_params.src_tuple_id},
-                                                std::vector<bool>{false});
+    _row_desc = std::make_unique<RowDescriptor>(_state->desc_tbl(), std::vector<TupleId>{_params.src_tuple_id});
 
     // destination
     _dest_tuple_desc = _state->desc_tbl().get_tuple_descriptor(_params.dest_tuple_id);

--- a/be/src/exec/mor_processor.cpp
+++ b/be/src/exec/mor_processor.cpp
@@ -38,8 +38,8 @@ Status IcebergMORProcessor::init(RuntimeState* runtime_state, const MORParams& p
     RETURN_IF_ERROR(Expr::open(_join_exprs, runtime_state));
 
     _build_row_desc =
-            std::make_unique<RowDescriptor>(runtime_state->desc_tbl().get_tuple_descriptor(params.mor_tuple_id), false);
-    _probe_row_desc = std::make_unique<RowDescriptor>(params.tuple_desc, false);
+            std::make_unique<RowDescriptor>(runtime_state->desc_tbl().get_tuple_descriptor(params.mor_tuple_id));
+    _probe_row_desc = std::make_unique<RowDescriptor>(params.tuple_desc);
 
     const auto param = _pool.add(
             new HashJoinerParam(&_pool, _hash_join_node, 1, TPlanNodeType::HASH_JOIN_NODE,

--- a/be/src/runtime/descriptors.cpp
+++ b/be/src/runtime/descriptors.cpp
@@ -156,7 +156,7 @@ HdfsPartitionDescriptor::HdfsPartitionDescriptor(const TIcebergTable& thrift_tab
                                                  const THdfsPartition& thrift_partition)
         : _thrift_partition_key_exprs(thrift_partition.partition_key_exprs) {}
 
-Status HdfsPartitionDescriptor::create_part_key_exprs(RuntimeState* state, ObjectPool* pool, int32_t chunk_size) {
+Status HdfsPartitionDescriptor::create_part_key_exprs(RuntimeState* state, ObjectPool* pool) {
     RETURN_IF_ERROR(Expr::create_expr_trees(pool, _thrift_partition_key_exprs, &_partition_key_value_evals, state));
     RETURN_IF_ERROR(Expr::prepare(_partition_key_value_evals, state));
     RETURN_IF_ERROR(Expr::open(_partition_key_value_evals, state));
@@ -557,10 +557,7 @@ std::string TupleDescriptor::debug_string() const {
     return out.str();
 }
 
-RowDescriptor::RowDescriptor(const DescriptorTbl& desc_tbl, const std::vector<TTupleId>& row_tuples,
-                             const std::vector<bool>& nullable_tuples)
-        : _tuple_idx_nullable_map(nullable_tuples) {
-    DCHECK(nullable_tuples.size() == row_tuples.size());
+RowDescriptor::RowDescriptor(const DescriptorTbl& desc_tbl, const std::vector<TTupleId>& row_tuples) {
     DCHECK_GT(row_tuples.size(), 0);
 
     for (int row_tuple : row_tuples) {
@@ -572,8 +569,7 @@ RowDescriptor::RowDescriptor(const DescriptorTbl& desc_tbl, const std::vector<TT
     init_tuple_idx_map();
 }
 
-RowDescriptor::RowDescriptor(TupleDescriptor* tuple_desc, bool is_nullable)
-        : _tuple_desc_map(1, tuple_desc), _tuple_idx_nullable_map(1, is_nullable) {
+RowDescriptor::RowDescriptor(TupleDescriptor* tuple_desc) : _tuple_desc_map(1, tuple_desc) {
     init_tuple_idx_map();
 }
 
@@ -661,15 +657,6 @@ std::string RowDescriptor::debug_string() const {
     }
     ss << "] ";
 
-    ss << "tuple_is_nullable: [";
-    for (int i = 0; i < _tuple_idx_nullable_map.size(); ++i) {
-        ss << _tuple_idx_nullable_map[i];
-        if (i != _tuple_idx_nullable_map.size() - 1) {
-            ss << ", ";
-        }
-    }
-    ss << "] ";
-
     return ss.str();
 }
 
@@ -702,7 +689,7 @@ Status DescriptorTbl::create(RuntimeState* state, ObjectPool* pool, const TDescr
             break;
         case TTableType::HDFS_TABLE: {
             auto* hdfs_desc = pool->add(new HdfsTableDescriptor(tdesc, pool));
-            RETURN_IF_ERROR(hdfs_desc->create_key_exprs(state, pool, chunk_size));
+            RETURN_IF_ERROR(hdfs_desc->create_key_exprs(state, pool));
             desc = hdfs_desc;
             break;
         }
@@ -713,19 +700,19 @@ Status DescriptorTbl::create(RuntimeState* state, ObjectPool* pool, const TDescr
         case TTableType::ICEBERG_TABLE: {
             auto* iceberg_desc = pool->add(new IcebergTableDescriptor(tdesc, pool));
             RETURN_IF_ERROR(iceberg_desc->set_partition_desc_map(tdesc.icebergTable, pool));
-            RETURN_IF_ERROR(iceberg_desc->create_key_exprs(state, pool, chunk_size));
+            RETURN_IF_ERROR(iceberg_desc->create_key_exprs(state, pool));
             desc = iceberg_desc;
             break;
         }
         case TTableType::DELTALAKE_TABLE: {
             auto* delta_lake_desc = pool->add(new DeltaLakeTableDescriptor(tdesc, pool));
-            RETURN_IF_ERROR(delta_lake_desc->create_key_exprs(state, pool, chunk_size));
+            RETURN_IF_ERROR(delta_lake_desc->create_key_exprs(state, pool));
             desc = delta_lake_desc;
             break;
         }
         case TTableType::HUDI_TABLE: {
             auto* hudi_desc = pool->add(new HudiTableDescriptor(tdesc, pool));
-            RETURN_IF_ERROR(hudi_desc->create_key_exprs(state, pool, chunk_size));
+            RETURN_IF_ERROR(hudi_desc->create_key_exprs(state, pool));
             desc = hudi_desc;
             break;
         }

--- a/be/src/runtime/descriptors.h
+++ b/be/src/runtime/descriptors.h
@@ -175,7 +175,7 @@ public:
     // partition slots would be [x, y]
     // partition key values wold be [1, 2]
     std::vector<ExprContext*>& partition_key_value_evals() { return _partition_key_value_evals; }
-    Status create_part_key_exprs(RuntimeState* state, ObjectPool* pool, int32_t chunk_size);
+    Status create_part_key_exprs(RuntimeState* state, ObjectPool* pool);
 
 private:
     int64_t _id = 0;
@@ -196,9 +196,9 @@ public:
     virtual bool has_base_path() const { return false; }
     virtual const std::string& get_base_path() const { return _table_location; }
 
-    Status create_key_exprs(RuntimeState* state, ObjectPool* pool, int32_t chunk_size) {
+    Status create_key_exprs(RuntimeState* state, ObjectPool* pool) {
         for (auto& part : _partition_id_to_desc_map) {
-            RETURN_IF_ERROR(part.second->create_part_key_exprs(state, pool, chunk_size));
+            RETURN_IF_ERROR(part.second->create_part_key_exprs(state, pool));
         }
         return Status::OK();
     }
@@ -504,15 +504,12 @@ private:
 // case)
 class RowDescriptor {
 public:
-    RowDescriptor(const DescriptorTbl& desc_tbl, const std::vector<TTupleId>& row_tuples,
-                  const std::vector<bool>& nullable_tuples);
+    RowDescriptor(const DescriptorTbl& desc_tbl, const std::vector<TTupleId>& row_tuples);
 
     // standard copy c'tor, made explicit here
-    RowDescriptor(const RowDescriptor& desc)
+    RowDescriptor(const RowDescriptor& desc) = default;
 
-            = default;
-
-    RowDescriptor(TupleDescriptor* tuple_desc, bool is_nullable);
+    RowDescriptor(TupleDescriptor* tuple_desc);
 
     // dummy descriptor, needed for the JNI EvalPredicate() function
     RowDescriptor() = default;
@@ -544,9 +541,6 @@ private:
 
     // map from position of tuple w/in row to its descriptor
     std::vector<TupleDescriptor*> _tuple_desc_map;
-
-    // _tuple_idx_nullable_map[i] is true if tuple i can be null
-    std::vector<bool> _tuple_idx_nullable_map;
 
     // map from TupleId to position of tuple w/in row
     std::vector<int> _tuple_idx_map;

--- a/be/src/runtime/load_channel.cpp
+++ b/be/src/runtime/load_channel.cpp
@@ -125,7 +125,7 @@ void LoadChannel::open(brpc::Controller* cntl, const PTabletWriterOpenRequest& r
             RETURN_RESPONSE_IF_ERROR(_schema->init(request.schema()), response);
         }
         if (_row_desc == nullptr) {
-            _row_desc = std::make_unique<RowDescriptor>(_schema->tuple_desc(), false);
+            _row_desc = std::make_unique<RowDescriptor>(_schema->tuple_desc());
         }
         auto it = _tablets_channels.find(index_id);
         if (it == _tablets_channels.end()) {

--- a/be/src/storage/table_reader.cpp
+++ b/be/src/storage/table_reader.cpp
@@ -61,7 +61,7 @@ Status TableReader::init(const TableReaderParams& params) {
     RETURN_IF_ERROR(_partition_param->init(nullptr));
     _location_param = std::make_unique<OlapTableLocationParam>(params.location_param);
     _nodes_info = std::make_unique<StarRocksNodesInfo>(params.nodes_info);
-    _row_desc = std::make_unique<RowDescriptor>(_schema_param->tuple_desc(), false);
+    _row_desc = std::make_unique<RowDescriptor>(_schema_param->tuple_desc());
     return Status::OK();
 }
 

--- a/be/test/exec/connector_scan_node_test.cpp
+++ b/be/test/exec/connector_scan_node_test.cpp
@@ -98,13 +98,11 @@ DescriptorTbl* ConnectorScanNodeTest::create_table_desc(RuntimeState* runtime_st
 
 std::shared_ptr<TPlanNode> ConnectorScanNodeTest::create_tplan_node_cloud() {
     std::vector<::starrocks::TTupleId> tuple_ids{0};
-    std::vector<bool> nullable_tuples{true};
 
     auto tnode = std::make_shared<TPlanNode>();
     tnode->__set_node_id(1);
     tnode->__set_node_type(TPlanNodeType::LAKE_SCAN_NODE);
     tnode->__set_row_tuples(tuple_ids);
-    tnode->__set_nullable_tuples(nullable_tuples);
     tnode->__set_limit(-1);
 
     TConnectorScanNode connector_scan_node;
@@ -176,13 +174,11 @@ TEST_F(ConnectorScanNodeTest, test_convert_scan_range_to_morsel_queue_factory_cl
 
 std::shared_ptr<TPlanNode> ConnectorScanNodeTest::create_tplan_node_hive() {
     std::vector<::starrocks::TTupleId> tuple_ids{0};
-    std::vector<bool> nullable_tuples{true};
 
     auto tnode = std::make_shared<TPlanNode>();
     tnode->__set_node_id(1);
     tnode->__set_node_type(TPlanNodeType::HDFS_SCAN_NODE);
     tnode->__set_row_tuples(tuple_ids);
-    tnode->__set_nullable_tuples(nullable_tuples);
     tnode->__set_limit(-1);
 
     TConnectorScanNode connector_scan_node;
@@ -255,13 +251,11 @@ TEST_F(ConnectorScanNodeTest, test_convert_scan_range_to_morsel_queue_factory_hi
 
 std::shared_ptr<TPlanNode> ConnectorScanNodeTest::create_tplan_node_stream_load() {
     std::vector<::starrocks::TTupleId> tuple_ids{0};
-    std::vector<bool> nullable_tuples{true};
 
     auto tnode = std::make_shared<TPlanNode>();
     tnode->__set_node_id(1);
     tnode->__set_node_type(TPlanNodeType::FILE_SCAN_NODE);
     tnode->__set_row_tuples(tuple_ids);
-    tnode->__set_nullable_tuples(nullable_tuples);
     tnode->__set_limit(-1);
 
     TConnectorScanNode connector_scan_node;

--- a/be/test/exec/es/es_scroll_parser_test.cpp
+++ b/be/test/exec/es/es_scroll_parser_test.cpp
@@ -71,11 +71,10 @@ TupleDescriptor* ScrollParserTest::_create_tuple_desc(SlotDesc* descs) {
     }
     tuple_desc_builder.build(&table_desc_builder);
     std::vector<TTupleId> row_tuples = std::vector<TTupleId>{0};
-    std::vector<bool> nullable_tuples = std::vector<bool>{true};
     DescriptorTbl* tbl = nullptr;
     CHECK(DescriptorTbl::create(_runtime_state, &_pool, table_desc_builder.desc_tbl(), &tbl, config::vector_chunk_size)
                   .ok());
-    auto* row_desc = _pool.add(new RowDescriptor(*tbl, row_tuples, nullable_tuples));
+    auto* row_desc = _pool.add(new RowDescriptor(*tbl, row_tuples));
     auto* tuple_desc = row_desc->tuple_descriptors()[0];
     return tuple_desc;
 }

--- a/be/test/exec/file_scan_node_test.cpp
+++ b/be/test/exec/file_scan_node_test.cpp
@@ -124,14 +124,12 @@ void FileScanNodeTest::_create_runtime_state() {
 
 std::shared_ptr<TPlanNode> FileScanNodeTest::_create_tplan_node() {
     std::vector<::starrocks::TTupleId> tuple_ids{0};
-    std::vector<bool> nullable_tuples{true};
 
     auto tnode = std::make_shared<TPlanNode>();
 
     tnode->__set_node_id(1);
     tnode->__set_node_type(TPlanNodeType::FILE_SCAN_NODE);
     tnode->__set_row_tuples(tuple_ids);
-    tnode->__set_nullable_tuples(nullable_tuples);
     tnode->__set_limit(-1);
 
     TConnectorScanNode connector_scan_node;

--- a/be/test/exec/hdfs_scan_node_test.cpp
+++ b/be/test/exec/hdfs_scan_node_test.cpp
@@ -340,7 +340,7 @@ DescriptorTbl* HdfsScanNodeTest::_create_table_desc_for_filter_partition() {
     TTableDescriptor tdesc;
     tdesc.__set_hdfsTable(t_hdfs_table);
     _table_desc = _pool->add(new HdfsTableDescriptor(tdesc, _pool));
-    _table_desc->create_key_exprs(_runtime_state.get(), _pool, _runtime_state->chunk_size());
+    _table_desc->create_key_exprs(_runtime_state.get(), _pool);
     tbl->get_tuple_descriptor(0)->set_table_desc(_table_desc);
 
     return tbl;

--- a/be/test/exec/hdfs_scan_node_test.cpp
+++ b/be/test/exec/hdfs_scan_node_test.cpp
@@ -144,14 +144,12 @@ void HdfsScanNodeTest::_create_runtime_state() {
 
 std::shared_ptr<TPlanNode> HdfsScanNodeTest::_create_tplan_node() {
     std::vector<::starrocks::TTupleId> tuple_ids{0};
-    std::vector<bool> nullable_tuples{true};
 
     auto tnode = std::make_shared<TPlanNode>();
 
     tnode->__set_node_id(1);
     tnode->__set_node_type(TPlanNodeType::HDFS_SCAN_NODE);
     tnode->__set_row_tuples(tuple_ids);
-    tnode->__set_nullable_tuples(nullable_tuples);
     tnode->__set_limit(-1);
 
     TConnectorScanNode connector_scan_node;
@@ -163,14 +161,12 @@ std::shared_ptr<TPlanNode> HdfsScanNodeTest::_create_tplan_node() {
 
 std::shared_ptr<TPlanNode> HdfsScanNodeTest::_create_tplan_node_for_filter_partition() {
     std::vector<::starrocks::TTupleId> tuple_ids{0};
-    std::vector<bool> nullable_tuples{true};
 
     auto tnode = std::make_shared<TPlanNode>();
 
     tnode->__set_node_id(1);
     tnode->__set_node_type(TPlanNodeType::HDFS_SCAN_NODE);
     tnode->__set_row_tuples(tuple_ids);
-    tnode->__set_nullable_tuples(nullable_tuples);
     tnode->__set_limit(-1);
 
     // partition_conjuncts

--- a/be/test/exec/hdfs_scanner_test.cpp
+++ b/be/test/exec/hdfs_scanner_test.cpp
@@ -168,11 +168,10 @@ TupleDescriptor* HdfsScannerTest::_create_tuple_desc(SlotDesc* descs) {
     }
     tuple_desc_builder.build(&table_desc_builder);
     std::vector<TTupleId> row_tuples = std::vector<TTupleId>{0};
-    std::vector<bool> nullable_tuples = std::vector<bool>{true};
     DescriptorTbl* tbl = nullptr;
     CHECK(DescriptorTbl::create(_runtime_state, &_pool, table_desc_builder.desc_tbl(), &tbl, config::vector_chunk_size)
                   .ok());
-    auto* row_desc = _pool.add(new RowDescriptor(*tbl, row_tuples, nullable_tuples));
+    auto* row_desc = _pool.add(new RowDescriptor(*tbl, row_tuples));
     auto* tuple_desc = row_desc->tuple_descriptors()[0];
     return tuple_desc;
 }
@@ -599,12 +598,11 @@ TEST_F(HdfsScannerTest, TestOrcGetNextWithMinMaxFilterNoRows) {
 
         tuple_desc_builder.build(&table_desc_builder);
         std::vector<TTupleId> row_tuples = std::vector<TTupleId>{0};
-        std::vector<bool> nullable_tuples = std::vector<bool>{true};
         DescriptorTbl* tbl = nullptr;
         CHECK(DescriptorTbl::create(_runtime_state, &_pool, table_desc_builder.desc_tbl(), &tbl,
                                     config::vector_chunk_size)
                       .ok());
-        auto* row_desc = _pool.add(new RowDescriptor(*tbl, row_tuples, nullable_tuples));
+        auto* row_desc = _pool.add(new RowDescriptor(*tbl, row_tuples));
         min_max_tuple_desc = row_desc->tuple_descriptors()[0];
     }
 

--- a/be/test/exec/jni_scanner_test.cpp
+++ b/be/test/exec/jni_scanner_test.cpp
@@ -91,12 +91,11 @@ public:
         }
         tuple_desc_builder.build(&table_desc_builder);
         std::vector<TTupleId> row_tuples = std::vector<TTupleId>{0};
-        std::vector<bool> nullable_tuples = std::vector<bool>{true};
         DescriptorTbl* tbl = nullptr;
         CHECK(DescriptorTbl::create(_runtime_state, &_pool, table_desc_builder.desc_tbl(), &tbl,
                                     config::vector_chunk_size)
                       .ok());
-        auto* row_desc = _pool.add(new RowDescriptor(*tbl, row_tuples, nullable_tuples));
+        auto* row_desc = _pool.add(new RowDescriptor(*tbl, row_tuples));
         auto* tuple_desc = row_desc->tuple_descriptors()[0];
         return tuple_desc;
     }

--- a/be/test/exec/join_hash_map_test.cpp
+++ b/be/test/exec/join_hash_map_test.cpp
@@ -51,9 +51,9 @@ protected:
     static void add_tuple_descriptor(TDescriptorTableBuilder* table_desc_builder, LogicalType column_type,
                                      bool nullable, size_t column_count = 3);
     static std::shared_ptr<RuntimeProfile> create_runtime_profile();
-    std::shared_ptr<RowDescriptor> create_row_desc(TDescriptorTableBuilder* table_desc_builder, bool nullable);
-    std::shared_ptr<RowDescriptor> create_probe_desc(TDescriptorTableBuilder* probe_desc_builder, bool nullable);
-    std::shared_ptr<RowDescriptor> create_build_desc(TDescriptorTableBuilder* build_desc_builder, bool nullable);
+    std::shared_ptr<RowDescriptor> create_row_desc(TDescriptorTableBuilder* table_desc_builder);
+    std::shared_ptr<RowDescriptor> create_probe_desc(TDescriptorTableBuilder* probe_desc_builder);
+    std::shared_ptr<RowDescriptor> create_build_desc(TDescriptorTableBuilder* build_desc_builder);
     static std::shared_ptr<RuntimeState> create_runtime_state();
 
     static void check_probe_index(const Buffer<uint32_t>& probe_index, uint32_t step, uint32_t match_count,
@@ -668,9 +668,9 @@ void JoinHashMapTest::check_empty_hash_map(TJoinOp::type join_type, int num_prob
     add_tuple_descriptor(&row_desc_builder, LogicalType::TYPE_INT, false);
     add_tuple_descriptor(&row_desc_builder, LogicalType::TYPE_INT, false);
 
-    auto row_desc = create_row_desc(&row_desc_builder, false);
-    auto probe_row_desc = create_probe_desc(&row_desc_builder, false);
-    auto build_row_desc = create_build_desc(&row_desc_builder, false);
+    auto row_desc = create_row_desc(&row_desc_builder);
+    auto probe_row_desc = create_probe_desc(&row_desc_builder);
+    auto build_row_desc = create_build_desc(&row_desc_builder);
 
     HashTableParam param = create_table_param(join_type, 6);
     param.row_desc = row_desc.get();
@@ -763,40 +763,34 @@ std::shared_ptr<RuntimeProfile> JoinHashMapTest::create_runtime_profile() {
     return profile;
 }
 
-std::shared_ptr<RowDescriptor> JoinHashMapTest::create_row_desc(TDescriptorTableBuilder* table_desc_builder,
-                                                                bool nullable) {
+std::shared_ptr<RowDescriptor> JoinHashMapTest::create_row_desc(TDescriptorTableBuilder* table_desc_builder) {
     std::vector<TTupleId> row_tuples = std::vector<TTupleId>{0, 1};
-    std::vector<bool> nullable_tuples = std::vector<bool>{nullable, nullable};
     DescriptorTbl* tbl = nullptr;
     CHECK(DescriptorTbl::create(_runtime_state.get(), _object_pool.get(), table_desc_builder->desc_tbl(), &tbl,
                                 config::vector_chunk_size)
                   .ok());
 
-    return std::make_shared<RowDescriptor>(*tbl, row_tuples, nullable_tuples);
+    return std::make_shared<RowDescriptor>(*tbl, row_tuples);
 }
 
-std::shared_ptr<RowDescriptor> JoinHashMapTest::create_probe_desc(TDescriptorTableBuilder* probe_desc_builder,
-                                                                  bool nullable) {
+std::shared_ptr<RowDescriptor> JoinHashMapTest::create_probe_desc(TDescriptorTableBuilder* probe_desc_builder) {
     std::vector<TTupleId> row_tuples = std::vector<TTupleId>{0};
-    std::vector<bool> nullable_tuples = std::vector<bool>{nullable};
     DescriptorTbl* tbl = nullptr;
     CHECK(DescriptorTbl::create(_runtime_state.get(), _object_pool.get(), probe_desc_builder->desc_tbl(), &tbl,
                                 config::vector_chunk_size)
                   .ok());
 
-    return std::make_shared<RowDescriptor>(*tbl, row_tuples, nullable_tuples);
+    return std::make_shared<RowDescriptor>(*tbl, row_tuples);
 }
 
-std::shared_ptr<RowDescriptor> JoinHashMapTest::create_build_desc(TDescriptorTableBuilder* build_desc_builder,
-                                                                  bool nullable) {
+std::shared_ptr<RowDescriptor> JoinHashMapTest::create_build_desc(TDescriptorTableBuilder* build_desc_builder) {
     std::vector<TTupleId> row_tuples = std::vector<TTupleId>{1};
-    std::vector<bool> nullable_tuples = std::vector<bool>{nullable};
     DescriptorTbl* tbl = nullptr;
     CHECK(DescriptorTbl::create(_runtime_state.get(), _object_pool.get(), build_desc_builder->desc_tbl(), &tbl,
                                 config::vector_chunk_size)
                   .ok());
 
-    return std::make_shared<RowDescriptor>(*tbl, row_tuples, nullable_tuples);
+    return std::make_shared<RowDescriptor>(*tbl, row_tuples);
 }
 
 std::shared_ptr<RuntimeState> JoinHashMapTest::create_runtime_state() {
@@ -880,7 +874,7 @@ TEST_F(JoinHashMapTest, ProbeNullOutput) {
     TDescriptorTableBuilder row_desc_builder;
     add_tuple_descriptor(&row_desc_builder, LogicalType::TYPE_INT, false);
     add_tuple_descriptor(&row_desc_builder, LogicalType::TYPE_INT, false);
-    auto row_desc = create_row_desc(&row_desc_builder, false);
+    auto row_desc = create_row_desc(&row_desc_builder);
     vector<HashTableSlotDescriptor> hash_table_slot_vec;
     for (auto& slot : row_desc->tuple_descriptors()[0]->slots()) {
         HashTableSlotDescriptor hash_table_slot{};
@@ -914,7 +908,7 @@ TEST_F(JoinHashMapTest, BuildDefaultOutput) {
     TDescriptorTableBuilder row_desc_builder;
     add_tuple_descriptor(&row_desc_builder, LogicalType::TYPE_INT, false);
     add_tuple_descriptor(&row_desc_builder, LogicalType::TYPE_INT, false);
-    auto row_desc = create_row_desc(&row_desc_builder, false);
+    auto row_desc = create_row_desc(&row_desc_builder);
 
     vector<HashTableSlotDescriptor> hash_table_slot_vec;
     for (auto& slot : row_desc->tuple_descriptors()[0]->slots()) {
@@ -1030,9 +1024,9 @@ TEST_F(JoinHashMapTest, DirectMappingJoinBuildProbeFunc) {
     add_tuple_descriptor(&row_desc_builder, LogicalType::TYPE_TINYINT, false, 1);
     add_tuple_descriptor(&row_desc_builder, LogicalType::TYPE_TINYINT, false, 1);
 
-    auto row_desc = create_row_desc(&row_desc_builder, false);
-    auto probe_row_desc = create_probe_desc(&row_desc_builder, false);
-    auto build_row_desc = create_build_desc(&row_desc_builder, false);
+    auto row_desc = create_row_desc(&row_desc_builder);
+    auto probe_row_desc = create_probe_desc(&row_desc_builder);
+    auto build_row_desc = create_build_desc(&row_desc_builder);
 
     HashTableParam param = create_table_param(TJoinOp::INNER_JOIN, 2);
     param.row_desc = row_desc.get();
@@ -1080,9 +1074,9 @@ TEST_F(JoinHashMapTest, DirectMappingJoinBuildProbeFuncNullable) {
     add_tuple_descriptor(&row_desc_builder, LogicalType::TYPE_TINYINT, true, 1);
     add_tuple_descriptor(&row_desc_builder, LogicalType::TYPE_TINYINT, true, 1);
 
-    auto row_desc = create_row_desc(&row_desc_builder, true);
-    auto probe_row_desc = create_probe_desc(&row_desc_builder, true);
-    auto build_row_desc = create_build_desc(&row_desc_builder, true);
+    auto row_desc = create_row_desc(&row_desc_builder);
+    auto probe_row_desc = create_probe_desc(&row_desc_builder);
+    auto build_row_desc = create_build_desc(&row_desc_builder);
 
     HashTableParam param = create_table_param(TJoinOp::INNER_JOIN, 2);
     param.row_desc = row_desc.get();
@@ -1783,9 +1777,9 @@ TEST_F(JoinHashMapTest, OneKeyJoinHashTable) {
     add_tuple_descriptor(&row_desc_builder, LogicalType::TYPE_INT, false);
     add_tuple_descriptor(&row_desc_builder, LogicalType::TYPE_INT, false);
 
-    auto row_desc = create_row_desc(&row_desc_builder, false);
-    auto probe_row_desc = create_probe_desc(&row_desc_builder, false);
-    auto build_row_desc = create_build_desc(&row_desc_builder, false);
+    auto row_desc = create_row_desc(&row_desc_builder);
+    auto probe_row_desc = create_probe_desc(&row_desc_builder);
+    auto build_row_desc = create_build_desc(&row_desc_builder);
 
     HashTableParam param = create_table_param(TJoinOp::INNER_JOIN, 6);
     param.row_desc = row_desc.get();
@@ -1836,9 +1830,9 @@ TEST_F(JoinHashMapTest, OneNullableKeyJoinHashTable) {
     add_tuple_descriptor(&row_desc_builder, LogicalType::TYPE_INT, true);
     add_tuple_descriptor(&row_desc_builder, LogicalType::TYPE_INT, true);
 
-    auto row_desc = create_row_desc(&row_desc_builder, true);
-    auto probe_row_desc = create_probe_desc(&row_desc_builder, true);
-    auto build_row_desc = create_build_desc(&row_desc_builder, true);
+    auto row_desc = create_row_desc(&row_desc_builder);
+    auto probe_row_desc = create_probe_desc(&row_desc_builder);
+    auto build_row_desc = create_build_desc(&row_desc_builder);
 
     HashTableParam param = create_table_param(TJoinOp::INNER_JOIN, 6);
     param.row_desc = row_desc.get();
@@ -1890,9 +1884,9 @@ TEST_F(JoinHashMapTest, FixedSizeJoinHashTable) {
     add_tuple_descriptor(&row_desc_builder, LogicalType::TYPE_INT, false);
     add_tuple_descriptor(&row_desc_builder, LogicalType::TYPE_INT, false);
 
-    auto row_desc = create_row_desc(&row_desc_builder, false);
-    auto probe_row_desc = create_probe_desc(&row_desc_builder, false);
-    auto build_row_desc = create_build_desc(&row_desc_builder, false);
+    auto row_desc = create_row_desc(&row_desc_builder);
+    auto probe_row_desc = create_probe_desc(&row_desc_builder);
+    auto build_row_desc = create_build_desc(&row_desc_builder);
 
     HashTableParam param = create_table_param(TJoinOp::INNER_JOIN, 6);
     param.row_desc = row_desc.get();
@@ -1943,9 +1937,9 @@ TEST_F(JoinHashMapTest, SerializeJoinHashTable) {
     add_tuple_descriptor(&row_desc_builder, LogicalType::TYPE_VARCHAR, false);
     add_tuple_descriptor(&row_desc_builder, LogicalType::TYPE_VARCHAR, false);
 
-    auto row_desc = create_row_desc(&row_desc_builder, false);
-    auto probe_row_desc = create_probe_desc(&row_desc_builder, false);
-    auto build_row_desc = create_build_desc(&row_desc_builder, false);
+    auto row_desc = create_row_desc(&row_desc_builder);
+    auto probe_row_desc = create_probe_desc(&row_desc_builder);
+    auto build_row_desc = create_build_desc(&row_desc_builder);
 
     HashTableParam param = create_table_param(TJoinOp::INNER_JOIN, 6);
     param.row_desc = row_desc.get();

--- a/be/test/exec/lake_meta_scanner_test.cpp
+++ b/be/test/exec/lake_meta_scanner_test.cpp
@@ -84,12 +84,10 @@ public:
         _state = _pool.add(new RuntimeState(TQueryGlobals()));
 
         std::vector<::starrocks::TTupleId> tuple_ids{0};
-        std::vector<bool> nullable_tuples{true};
         _tnode = std::make_unique<TPlanNode>();
         _tnode->__set_node_id(1);
         _tnode->__set_node_type(TPlanNodeType::LAKE_SCAN_NODE);
         _tnode->__set_row_tuples(tuple_ids);
-        _tnode->__set_nullable_tuples(nullable_tuples);
         _tnode->__set_limit(-1);
 
         TDescriptorTableBuilder table_desc_builder;

--- a/be/test/exec/pipeline/olap_scan_operator_test.cpp
+++ b/be/test/exec/pipeline/olap_scan_operator_test.cpp
@@ -48,7 +48,6 @@ void OlapScanOperatorTest::SetUp() {
     _thrift_tbl.tupleDescriptors.emplace_back(t_tuple_desc);
 
     _tnode.row_tuples.emplace_back(1);
-    _tnode.nullable_tuples.emplace_back(false);
 
     Status st = DescriptorTbl::create(&_runtime_state, &_object_pool, _thrift_tbl, &_tbl, _chunk_size);
     ASSERT_TRUE(st.ok());

--- a/be/test/exec/pipeline/pipeline_file_scan_node_test.cpp
+++ b/be/test/exec/pipeline/pipeline_file_scan_node_test.cpp
@@ -190,14 +190,12 @@ std::vector<TScanRangeParams> PipeLineFileScanNodeTest::_create_csv_scan_ranges(
 
 std::shared_ptr<TPlanNode> PipeLineFileScanNodeTest::_create_tplan_node() {
     std::vector<::starrocks::TTupleId> tuple_ids{0};
-    std::vector<bool> nullable_tuples{true};
 
     auto tnode = std::make_shared<TPlanNode>();
 
     tnode->__set_node_id(1);
     tnode->__set_node_type(TPlanNodeType::FILE_SCAN_NODE);
     tnode->__set_row_tuples(tuple_ids);
-    tnode->__set_nullable_tuples(nullable_tuples);
     tnode->__set_limit(-1);
 
     TConnectorScanNode connector_scan_node;

--- a/be/test/exec/pipeline/table_function_operator_test.cpp
+++ b/be/test/exec/pipeline/table_function_operator_test.cpp
@@ -137,7 +137,6 @@ void TableFunctionOperatorTest::SetUp() {
     _tnode.num_children = 1;
 
     _tnode.row_tuples.push_back(1);
-    _tnode.nullable_tuples.push_back(false);
 
     TExprNode expr_node;
     expr_node.__isset.fn = true;

--- a/be/test/exec/repeat_node_test.cpp
+++ b/be/test/exec/repeat_node_test.cpp
@@ -198,7 +198,6 @@ protected:
         _tnode.repeat_node.output_tuple_id = 1;
 
         _tnode.row_tuples.push_back(1);
-        _tnode.nullable_tuples.push_back(false);
     }
 
     void TearDown() override {}

--- a/be/test/exec/stream/stream_operators_test.cpp
+++ b/be/test/exec/stream/stream_operators_test.cpp
@@ -112,14 +112,12 @@ protected:
 
 std::shared_ptr<TPlanNode> StreamOperatorsTest::_create_tplan_node(int node_id, int tuple_id) {
     std::vector<::starrocks::TTupleId> tuple_ids{tuple_id};
-    std::vector<bool> nullable_tuples{true};
 
     auto tnode = std::make_shared<TPlanNode>();
 
     tnode->__set_node_id(node_id);
     tnode->__set_node_type(TPlanNodeType::STREAM_SCAN_NODE);
     tnode->__set_row_tuples(tuple_ids);
-    tnode->__set_nullable_tuples(nullable_tuples);
     tnode->__set_use_vectorized(true);
     tnode->__set_limit(-1);
 

--- a/be/test/exec/table_function_node_test.cpp
+++ b/be/test/exec/table_function_node_test.cpp
@@ -62,7 +62,6 @@ void TableFunctionNodeTest::SetUp() {
     _tnode.num_children = 1;
 
     _tnode.row_tuples.push_back(1);
-    _tnode.nullable_tuples.push_back(false);
 }
 
 TEST_F(TableFunctionNodeTest, close_after_not_init) {

--- a/be/test/formats/orc/orc_chunk_reader_test.cpp
+++ b/be/test/formats/orc/orc_chunk_reader_test.cpp
@@ -76,11 +76,10 @@ void create_tuple_descriptor(RuntimeState* state, ObjectPool* pool, const SlotDe
     tuple_desc_builder.build(&table_desc_builder);
 
     std::vector<TTupleId> row_tuples = std::vector<TTupleId>{0};
-    std::vector<bool> nullable_tuples = std::vector<bool>{true};
     DescriptorTbl* tbl = nullptr;
     auto st = DescriptorTbl::create(state, pool, table_desc_builder.desc_tbl(), &tbl, config::vector_chunk_size);
     CHECK(st.ok()) << st;
-    RowDescriptor* row_desc = pool->add(new RowDescriptor(*tbl, row_tuples, nullable_tuples));
+    RowDescriptor* row_desc = pool->add(new RowDescriptor(*tbl, row_tuples));
     *tuple_desc = row_desc->tuple_descriptors()[0];
     return;
 }

--- a/be/test/formats/orc/orc_file_writer_test.cpp
+++ b/be/test/formats/orc/orc_file_writer_test.cpp
@@ -93,11 +93,10 @@ protected:
         tuple_desc_builder.build(&table_desc_builder);
 
         std::vector<TTupleId> row_tuples = std::vector<TTupleId>{0};
-        std::vector<bool> nullable_tuples = std::vector<bool>{nullable};
         DescriptorTbl* tbl = nullptr;
         DescriptorTbl::create(state, pool, table_desc_builder.desc_tbl(), &tbl, config::vector_chunk_size);
 
-        RowDescriptor* row_desc = pool->add(new RowDescriptor(*tbl, row_tuples, nullable_tuples));
+        RowDescriptor* row_desc = pool->add(new RowDescriptor(*tbl, row_tuples));
         *tuple_desc = row_desc->tuple_descriptors()[0];
         return;
     }

--- a/be/test/formats/parquet/parquet_cli_reader.h
+++ b/be/test/formats/parquet/parquet_cli_reader.h
@@ -215,10 +215,9 @@ private:
         tuple_desc_builder.build(&table_desc_builder);
 
         std::vector<TTupleId> row_tuples = std::vector<TTupleId>{0};
-        std::vector<bool> nullable_tuples = std::vector<bool>{true};
         DescriptorTbl* tbl = nullptr;
         CHECK(DescriptorTbl::create(state, pool, table_desc_builder.desc_tbl(), &tbl, config::vector_chunk_size).ok());
-        RowDescriptor* row_desc = pool->add(new RowDescriptor(*tbl, row_tuples, nullable_tuples));
+        RowDescriptor* row_desc = pool->add(new RowDescriptor(*tbl, row_tuples));
         return row_desc->tuple_descriptors()[0];
     }
 

--- a/be/test/formats/parquet/parquet_test_util/util.h
+++ b/be/test/formats/parquet/parquet_test_util/util.h
@@ -57,11 +57,10 @@ public:
         tuple_desc_builder.build(&table_desc_builder);
 
         std::vector<TTupleId> row_tuples = std::vector<TTupleId>{0};
-        std::vector<bool> nullable_tuples = std::vector<bool>{true};
         DescriptorTbl* tbl = nullptr;
         CHECK(DescriptorTbl::create(state, pool, table_desc_builder.desc_tbl(), &tbl, config::vector_chunk_size).ok());
 
-        RowDescriptor* row_desc = pool->add(new RowDescriptor(*tbl, row_tuples, nullable_tuples));
+        RowDescriptor* row_desc = pool->add(new RowDescriptor(*tbl, row_tuples));
         return row_desc->tuple_descriptors()[0];
     }
 

--- a/be/test/runtime/memory_scratch_sink_test.cpp
+++ b/be/test/runtime/memory_scratch_sink_test.cpp
@@ -265,9 +265,7 @@ void MemoryScratchSinkTest::init_desc_tbl() {
     std::vector<TTupleId> row_tids;
     row_tids.push_back(0);
 
-    std::vector<bool> nullable_tuples;
-    nullable_tuples.push_back(false);
-    _row_desc = _obj_pool.add(new RowDescriptor(*_desc_tbl, row_tids, nullable_tuples));
+    _row_desc = _obj_pool.add(new RowDescriptor(*_desc_tbl, row_tids));
 
     // node
     _tnode.node_id = 0;
@@ -275,7 +273,6 @@ void MemoryScratchSinkTest::init_desc_tbl() {
     _tnode.num_children = 0;
     _tnode.limit = -1;
     _tnode.row_tuples.push_back(0);
-    _tnode.nullable_tuples.push_back(false);
 }
 
 TEST_F(MemoryScratchSinkTest, work_flow_normal) {

--- a/be/test/runtime/memory_scratch_sink_test.cpp
+++ b/be/test/runtime/memory_scratch_sink_test.cpp
@@ -185,7 +185,6 @@ public:
 private:
     ObjectPool _obj_pool;
     ExecEnv* _exec_env = nullptr;
-    // std::vector<TExpr> _exprs;
     TDescriptorTable _t_desc_table;
     RuntimeState* _state = nullptr;
     TPlanNode _tnode;

--- a/be/test/runtime/memory_scratch_sink_test_issue_8676.cpp
+++ b/be/test/runtime/memory_scratch_sink_test_issue_8676.cpp
@@ -308,9 +308,7 @@ void MemoryScratchSinkIssue8676Test::init_desc_tbl() {
     std::vector<TTupleId> row_tids;
     row_tids.push_back(0);
 
-    std::vector<bool> nullable_tuples;
-    nullable_tuples.push_back(false);
-    _row_desc = _obj_pool.add(new RowDescriptor(*_desc_tbl, row_tids, nullable_tuples));
+    _row_desc = _obj_pool.add(new RowDescriptor(*_desc_tbl, row_tids));
 
     // node
     _tnode.node_id = 0;
@@ -318,7 +316,6 @@ void MemoryScratchSinkIssue8676Test::init_desc_tbl() {
     _tnode.num_children = 0;
     _tnode.limit = -1;
     _tnode.row_tuples.push_back(0);
-    _tnode.nullable_tuples.push_back(false);
 }
 
 TEST_F(MemoryScratchSinkIssue8676Test, work_flow_normal) {

--- a/be/test/runtime/memory_scratch_sink_test_issue_8676.cpp
+++ b/be/test/runtime/memory_scratch_sink_test_issue_8676.cpp
@@ -209,7 +209,6 @@ public:
 private:
     ObjectPool _obj_pool;
     ExecEnv* _exec_env = nullptr;
-    // std::vector<TExpr> _exprs;
     TDescriptorTable _t_desc_table;
     RuntimeState* _state = nullptr;
     TPlanNode _tnode;

--- a/be/test/storage/chunk_helper_test.cpp
+++ b/be/test/storage/chunk_helper_test.cpp
@@ -45,12 +45,11 @@ protected:
         tuple_builder.build(&table_builder);
 
         std::vector<TTupleId> row_tuples{0};
-        std::vector<bool> nullable_tuples{true};
         DescriptorTbl* tbl = nullptr;
         CHECK(DescriptorTbl::create(&_runtime_state, &_pool, table_builder.desc_tbl(), &tbl, config::vector_chunk_size)
                       .ok());
 
-        auto* row_desc = _pool.add(new RowDescriptor(*tbl, row_tuples, nullable_tuples));
+        auto* row_desc = _pool.add(new RowDescriptor(*tbl, row_tuples));
         auto* tuple_desc = row_desc->tuple_descriptors()[0];
 
         return tuple_desc;
@@ -81,12 +80,11 @@ TupleDescriptor* ChunkHelperTest::_create_tuple_desc() {
     tuple_builder.build(&table_builder);
 
     std::vector<TTupleId> row_tuples = std::vector<TTupleId>{0};
-    std::vector<bool> nullable_tuples = std::vector<bool>{true};
     DescriptorTbl* tbl = nullptr;
     CHECK(DescriptorTbl::create(&_runtime_state, &_pool, table_builder.desc_tbl(), &tbl, config::vector_chunk_size)
                   .ok());
 
-    auto* row_desc = _pool.add(new RowDescriptor(*tbl, row_tuples, nullable_tuples));
+    auto* row_desc = _pool.add(new RowDescriptor(*tbl, row_tuples));
     auto* tuple_desc = row_desc->tuple_descriptors()[0];
 
     return tuple_desc;

--- a/be/test/storage/conjunctive_predicates_test.cpp
+++ b/be/test/storage/conjunctive_predicates_test.cpp
@@ -299,12 +299,11 @@ public:
         tuple_builder.build(&table_builder);
 
         std::vector<TTupleId> row_tuples = std::vector<TTupleId>{0};
-        std::vector<bool> nullable_tuples = std::vector<bool>{true};
         DescriptorTbl* tbl = nullptr;
         CHECK(DescriptorTbl::create(&_runtime_state, &_pool, table_builder.desc_tbl(), &tbl, config::vector_chunk_size)
                       .ok());
 
-        auto* row_desc = _pool.add(new RowDescriptor(*tbl, row_tuples, nullable_tuples));
+        auto* row_desc = _pool.add(new RowDescriptor(*tbl, row_tuples));
         auto* tuple_desc = row_desc->tuple_descriptors()[0];
 
         return tuple_desc;

--- a/be/test/storage/lake/test_util.h
+++ b/be/test/storage/lake/test_util.h
@@ -268,13 +268,11 @@ inline DescriptorTbl* create_table_desc(RuntimeState* runtime_state, const std::
 
 inline std::shared_ptr<TPlanNode> create_tplan_node_cloud() {
     std::vector<::starrocks::TTupleId> tuple_ids{0};
-    std::vector<bool> nullable_tuples{true};
 
     auto tnode = std::make_shared<TPlanNode>();
     tnode->__set_node_id(1);
     tnode->__set_node_type(TPlanNodeType::LAKE_SCAN_NODE);
     tnode->__set_row_tuples(tuple_ids);
-    tnode->__set_nullable_tuples(nullable_tuples);
     tnode->__set_limit(-1);
 
     TConnectorScanNode connector_scan_node;

--- a/be/test/storage/publish_version_task_test.cpp
+++ b/be/test/storage/publish_version_task_test.cpp
@@ -177,12 +177,11 @@ public:
         tuple_builder.build(&table_builder);
 
         std::vector<TTupleId> row_tuples = std::vector<TTupleId>{0};
-        std::vector<bool> nullable_tuples = std::vector<bool>{false};
         DescriptorTbl* tbl = nullptr;
         CHECK(DescriptorTbl::create(&_runtime_state, &_pool, table_builder.desc_tbl(), &tbl, config::vector_chunk_size)
                       .ok());
 
-        auto* row_desc = _pool.add(new RowDescriptor(*tbl, row_tuples, nullable_tuples));
+        auto* row_desc = _pool.add(new RowDescriptor(*tbl, row_tuples));
         auto* tuple_desc = row_desc->tuple_descriptors()[0];
 
         return tuple_desc;

--- a/be/test/storage/segment_flush_executor_test.cpp
+++ b/be/test/storage/segment_flush_executor_test.cpp
@@ -107,10 +107,9 @@ public:
         TDescriptorTableBuilder table_builder;
         tuple_builder.build(&table_builder);
         std::vector<TTupleId> row_tuples = std::vector<TTupleId>{0};
-        std::vector<bool> nullable_tuples = std::vector<bool>{false};
         DescriptorTbl* tbl = nullptr;
         DescriptorTbl::create(&_runtime_state, &_pool, table_builder.desc_tbl(), &tbl, config::vector_chunk_size);
-        auto* row_desc = _pool.add(new RowDescriptor(*tbl, row_tuples, nullable_tuples));
+        auto* row_desc = _pool.add(new RowDescriptor(*tbl, row_tuples));
         auto* tuple_desc = row_desc->tuple_descriptors()[0];
 
         return tuple_desc;

--- a/be/test/storage/task/engine_storage_migration_task_test.cpp
+++ b/be/test/storage/task/engine_storage_migration_task_test.cpp
@@ -273,11 +273,10 @@ public:
         tuple_builder.build(&table_builder);
 
         std::vector<TTupleId> row_tuples = std::vector<TTupleId>{0};
-        std::vector<bool> nullable_tuples = std::vector<bool>{false};
         DescriptorTbl* tbl = nullptr;
         DescriptorTbl::create(&_runtime_state, &_pool, table_builder.desc_tbl(), &tbl, config::vector_chunk_size);
 
-        auto* row_desc = _pool.add(new RowDescriptor(*tbl, row_tuples, nullable_tuples));
+        auto* row_desc = _pool.add(new RowDescriptor(*tbl, row_tuples));
         auto* tuple_desc = row_desc->tuple_descriptors()[0];
 
         return tuple_desc;
@@ -306,11 +305,10 @@ public:
         tuple_builder.build(&table_builder);
 
         std::vector<TTupleId> row_tuples = std::vector<TTupleId>{0};
-        std::vector<bool> nullable_tuples = std::vector<bool>{false};
         DescriptorTbl* tbl = nullptr;
         DescriptorTbl::create(&_runtime_state, &_pool, table_builder.desc_tbl(), &tbl, config::vector_chunk_size);
 
-        auto* row_desc = _pool.add(new RowDescriptor(*tbl, row_tuples, nullable_tuples));
+        auto* row_desc = _pool.add(new RowDescriptor(*tbl, row_tuples));
         auto* tuple_desc = row_desc->tuple_descriptors()[0];
 
         return tuple_desc;


### PR DESCRIPTION
## Why I'm doing:

`_tuple_idx_nullable_map` of `RowDescriptor` is useless.

## What I'm doing:

Remove `_tuple_idx_nullable_map` from `RowDescriptor`

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [x] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
