### PR TITLE
[Enhancement] support compact spilled mem-table

### DIFF
--- a/be/src/exec/pipeline/aggregate/spillable_aggregate_blocking_sink_operator.cpp
+++ b/be/src/exec/pipeline/aggregate/spillable_aggregate_blocking_sink_operator.cpp
@@ -301,6 +301,7 @@ Status SpillableAggregateBlockingSinkOperatorFactory::prepare(RuntimeState* stat
     _spill_options->spill_type = spill::SpillFormaterType::SPILL_BY_COLUMN;
     _spill_options->block_manager = state->query_ctx()->spill_manager()->block_manager();
     _spill_options->name = "agg-blocking-spill";
+    _spill_options->enable_block_compaction = state->spill_enable_compaction();
     _spill_options->plan_node_id = _plan_node_id;
     _spill_options->encode_level = state->spill_encode_level();
     _spill_options->wg = state->fragment_ctx()->workgroup();

--- a/be/src/exec/pipeline/exec_state_reporter.cpp
+++ b/be/src/exec/pipeline/exec_state_reporter.cpp
@@ -17,6 +17,8 @@
 #include <thrift/Thrift.h>
 #include <thrift/protocol/TDebugProtocol.h>
 
+#include <memory>
+
 #include "agent/master_info.h"
 #include "runtime/client_cache.h"
 #include "runtime/exec_env.h"
@@ -41,12 +43,11 @@ std::string to_http_path(const std::string& token, const std::string& file_name)
     return url.str();
 }
 
-TReportExecStatusParams ExecStateReporter::create_report_exec_status_params(QueryContext* query_ctx,
-                                                                            FragmentContext* fragment_ctx,
-                                                                            RuntimeProfile* profile,
-                                                                            RuntimeProfile* load_channel_profile,
-                                                                            const Status& status, bool done) {
-    TReportExecStatusParams params;
+std::unique_ptr<TReportExecStatusParams> ExecStateReporter::create_report_exec_status_params(
+        QueryContext* query_ctx, FragmentContext* fragment_ctx, RuntimeProfile* profile,
+        RuntimeProfile* load_channel_profile, const Status& status, bool done) {
+    auto res = std::make_unique<TReportExecStatusParams>();
+    TReportExecStatusParams& params = *res;
     auto* runtime_state = fragment_ctx->runtime_state();
     DCHECK(runtime_state != nullptr);
     DCHECK(profile != nullptr);
@@ -146,7 +147,7 @@ TReportExecStatusParams ExecStateReporter::create_report_exec_status_params(Quer
     if (backend_id.has_value()) {
         params.__set_backend_id(backend_id.value());
     }
-    return params;
+    return res;
 }
 
 using apache::thrift::TException;

--- a/be/src/exec/pipeline/exec_state_reporter.h
+++ b/be/src/exec/pipeline/exec_state_reporter.h
@@ -31,11 +31,10 @@ class ExecStateReporter {
 public:
     ExecStateReporter();
 
-    static TReportExecStatusParams create_report_exec_status_params(QueryContext* query_ctx,
-                                                                    FragmentContext* fragment_ctx,
-                                                                    RuntimeProfile* profile,
-                                                                    RuntimeProfile* load_channel_profile,
-                                                                    const Status& status, bool done);
+    static std::unique_ptr<TReportExecStatusParams> create_report_exec_status_params(
+            QueryContext* query_ctx, FragmentContext* fragment_ctx, RuntimeProfile* profile,
+            RuntimeProfile* load_channel_profile, const Status& status, bool done);
+
     static Status report_exec_status(const TReportExecStatusParams& params, ExecEnv* exec_env,
                                      const TNetworkAddress& fe_addr);
 

--- a/be/src/exec/pipeline/sort/spillable_partition_sort_sink_operator.cpp
+++ b/be/src/exec/pipeline/sort/spillable_partition_sort_sink_operator.cpp
@@ -138,6 +138,7 @@ Status SpillablePartitionSortSinkOperatorFactory::prepare(RuntimeState* state) {
     _spill_options->spill_type = spill::SpillFormaterType::SPILL_BY_COLUMN;
     _spill_options->block_manager = state->query_ctx()->spill_manager()->block_manager();
     _spill_options->name = "local-sort-spill";
+    _spill_options->enable_block_compaction = state->spill_enable_compaction();
     _spill_options->plan_node_id = _plan_node_id;
     _spill_options->encode_level = state->spill_encode_level();
     _spill_options->wg = state->fragment_ctx()->workgroup();

--- a/be/src/exec/spill/block_manager.h
+++ b/be/src/exec/spill/block_manager.h
@@ -42,14 +42,22 @@ public:
     virtual std::string debug_string() const = 0;
 
     size_t size() const { return _size; }
+    size_t num_rows() const { return _num_rows; }
     bool is_remote() const { return _is_remote; }
     void set_is_remote(bool is_remote) { _is_remote = is_remote; }
 
     virtual bool preallocate(size_t write_size) = 0;
 
+    bool exclusive() const { return _exclusive; }
+    void set_exclusive(bool exclusive) { _exclusive = exclusive; }
+
+    void inc_num_rows(size_t num_rows) { _num_rows += num_rows; }
+
 protected:
+    size_t _num_rows{};
     size_t _size{};
     bool _is_remote = false;
+    bool _exclusive{};
 };
 
 using BlockPtr = std::shared_ptr<Block>;
@@ -76,6 +84,8 @@ struct AcquireBlockOptions {
     int32_t plan_node_id;
     std::string name;
     bool direct_io = false;
+    // The block will occupy the entire container, making it easier to remove the block.
+    bool exclusive = false;
     size_t block_size = 0;
 };
 

--- a/be/src/exec/spill/data_stream.cpp
+++ b/be/src/exec/spill/data_stream.cpp
@@ -16,6 +16,7 @@
 
 #include "common/status.h"
 #include "exec/spill/block_manager.h"
+#include "exec/spill/executor.h"
 #include "exec/spill/input_stream.h"
 #include "exec/spill/serde.h"
 #include "exec/spill/spiller.h"
@@ -29,7 +30,8 @@ public:
             : _spiller(spiller), _block_group(block_group), _block_manager(block_manager) {}
     ~BlockSpillOutputDataStream() override = default;
 
-    Status append(RuntimeState* state, const std::vector<Slice>& data, size_t total_write_size) override;
+    Status append(RuntimeState* state, const std::vector<Slice>& data, size_t total_write_size,
+                  size_t write_num_rows) override;
     Status flush() override;
 
     bool is_remote() const override {
@@ -61,19 +63,21 @@ Status BlockSpillOutputDataStream::_prepare_block(RuntimeState* state, size_t wr
         opts.plan_node_id = _spiller->options().plan_node_id;
         opts.name = _spiller->options().name;
         opts.block_size = write_size;
+        opts.exclusive = _spiller->options().init_partition_nums > 0 || !_spiller->options().is_unordered;
         ASSIGN_OR_RETURN(auto block, _block_manager->acquire_block(opts));
         // update metrics
         auto block_count = GET_METRICS(block->is_remote(), _spiller->metrics(), block_count);
         COUNTER_UPDATE(block_count, 1);
         TRACE_SPILL_LOG << fmt::format("allocate block [{}]", block->debug_string());
         _cur_block = std::move(block);
+        _block_group->append(_cur_block);
     }
 
     return Status::OK();
 }
 
-Status BlockSpillOutputDataStream::append(RuntimeState* state, const std::vector<Slice>& data,
-                                          size_t total_write_size) {
+Status BlockSpillOutputDataStream::append(RuntimeState* state, const std::vector<Slice>& data, size_t total_write_size,
+                                          size_t write_num_rows) {
     // acquire block if current block is nullptr or full
     RETURN_IF_ERROR(_prepare_block(state, total_write_size));
     {
@@ -81,6 +85,9 @@ Status BlockSpillOutputDataStream::append(RuntimeState* state, const std::vector
         SCOPED_TIMER(write_io_timer);
         TRACE_SPILL_LOG << fmt::format("append block[{}], size[{}]", _cur_block->debug_string(), total_write_size);
         RETURN_IF_ERROR(_cur_block->append(data));
+        _cur_block->inc_num_rows(write_num_rows);
+        auto flush_bytes = GET_METRICS(_cur_block->is_remote(), _spiller->metrics(), flush_bytes);
+        COUNTER_UPDATE(flush_bytes, total_write_size);
     }
     return Status::OK();
 }
@@ -92,14 +99,12 @@ Status BlockSpillOutputDataStream::flush() {
     {
         auto write_io_timer = GET_METRICS(_cur_block->is_remote(), _spiller->metrics(), write_io_timer);
         SCOPED_TIMER(write_io_timer);
-        size_t block_size = _cur_block->size();
         RETURN_IF_ERROR(_cur_block->flush());
-        auto flush_bytes = GET_METRICS(_cur_block->is_remote(), _spiller->metrics(), flush_bytes);
-        COUNTER_UPDATE(flush_bytes, block_size);
         TRACE_SPILL_LOG << fmt::format("flush block[{}]", _cur_block->debug_string());
     }
-    RETURN_IF_ERROR(_block_manager->release_block(_cur_block));
-    _block_group->append(std::move(_cur_block));
+
+    // release block if not exclusive
+    RETURN_IF_ERROR(_block_manager->release_block(std::move(_cur_block)));
 
     return Status::OK();
 }
@@ -107,6 +112,32 @@ Status BlockSpillOutputDataStream::flush() {
 std::shared_ptr<SpillOutputDataStream> create_spill_output_stream(Spiller* spiller, BlockGroup* block_group,
                                                                   BlockManager* block_manager) {
     return std::make_shared<BlockSpillOutputDataStream>(spiller, block_group, block_manager);
+}
+
+Status DataTranster::transfer(workgroup::YieldContext& yield_ctx, RuntimeState* state, Serde* serde,
+                              const SpillOutputDataStreamPtr& output, const InputStreamPtr& input_stream) {
+    // read data from input stream and append to output stream
+    bool need_aligned = state->spill_enable_direct_io();
+    SerdeContext read_ctx;
+    while (true) {
+        SCOPED_RAW_TIMER(&yield_ctx.time_spent_ns);
+        if (!input_stream->is_ready()) {
+            workgroup::YieldContext restore_yield_ctx;
+            restore_yield_ctx.task_context_data = std::make_shared<SpillIOTaskContext>();
+            YieldableRestoreTask task(input_stream);
+            auto st = task.do_read(restore_yield_ctx, read_ctx);
+            RETURN_IF(!st.is_ok_or_eof(), st);
+            yield_ctx.need_yield = restore_yield_ctx.need_yield;
+            RETURN_IF_YIELD(yield_ctx.need_yield);
+        }
+        DCHECK(input_stream->is_ready());
+        auto chunk_st = input_stream->get_next(yield_ctx, read_ctx);
+        RETURN_IF(!chunk_st.status().is_ok_or_eof(), chunk_st.status());
+        RETURN_IF(chunk_st.status().is_end_of_file(), Status::OK());
+        RETURN_IF_ERROR(serde->serialize(state, read_ctx, std::move(chunk_st.value()), output, need_aligned));
+        RETURN_OK_IF_NEED_YIELD(yield_ctx.wg, &yield_ctx.need_yield, yield_ctx.time_spent_ns);
+    }
+    return Status::OK();
 }
 
 } // namespace starrocks::spill

--- a/be/src/exec/spill/data_stream.cpp
+++ b/be/src/exec/spill/data_stream.cpp
@@ -88,6 +88,7 @@ Status BlockSpillOutputDataStream::append(RuntimeState* state, const std::vector
         _cur_block->inc_num_rows(write_num_rows);
         auto flush_bytes = GET_METRICS(_cur_block->is_remote(), _spiller->metrics(), flush_bytes);
         COUNTER_UPDATE(flush_bytes, total_write_size);
+        (*_spiller->metrics().total_spill_bytes) += total_write_size;
     }
     return Status::OK();
 }

--- a/be/src/exec/spill/data_stream.h
+++ b/be/src/exec/spill/data_stream.h
@@ -35,6 +35,8 @@ SpillOutputDataStreamPtr create_spill_output_stream(Spiller* spiller, BlockGroup
 
 using InputStreamPtr = std::shared_ptr<SpillInputStream>;
 
+// Transfer data from input_stream to output stream
+// This class will execution io tasks. make sure call it in io threads
 class DataTranster {
 public:
     static Status transfer(workgroup::YieldContext& yield_ctx, RuntimeState* state, Serde* serde,

--- a/be/src/exec/spill/executor.h
+++ b/be/src/exec/spill/executor.h
@@ -147,16 +147,6 @@ struct SyncTaskExecutor {
         break;                                                                                  \
     }
 
-#define RETURN_IF_NEED_YIELD(wg, yield, time_spent_ns)                                          \
-    if (time_spent_ns >= workgroup::WorkGroup::YIELD_MAX_TIME_SPENT) {                          \
-        *yield = true;                                                                          \
-        return Status::Yield();                                                                 \
-    }                                                                                           \
-    if (wg != nullptr && time_spent_ns >= workgroup::WorkGroup::YIELD_PREEMPT_MAX_TIME_SPENT && \
-        wg->scan_sched_entity()->in_queue()->should_yield(wg, time_spent_ns)) {                 \
-        *yield = true;                                                                          \
-        return Status::Yield();                                                                 \
-    }
 #define RETURN_OK_IF_NEED_YIELD(wg, yield, time_spent_ns)                                       \
     if (time_spent_ns >= workgroup::WorkGroup::YIELD_MAX_TIME_SPENT) {                          \
         *yield = true;                                                                          \

--- a/be/src/exec/spill/file_block_manager.cpp
+++ b/be/src/exec/spill/file_block_manager.cpp
@@ -214,12 +214,6 @@ Status FileBlockReader::read_fully(void* data, int64_t count) {
 FileBlockManager::FileBlockManager(const TUniqueId& query_id, DirManager* dir_mgr)
         : _query_id(query_id), _dir_mgr(dir_mgr) {}
 
-FileBlockManager::~FileBlockManager() {
-    for (auto& container : _containers) {
-        container.reset();
-    }
-}
-
 Status FileBlockManager::open() {
     return Status::OK();
 }
@@ -242,7 +236,6 @@ Status FileBlockManager::release_block(const BlockPtr& block) {
     auto container = file_block->container();
     TRACE_SPILL_LOG << "release block: " << block->debug_string();
     RETURN_IF_ERROR(container->close());
-    _containers.emplace_back(std::move(container));
     return Status::OK();
 }
 

--- a/be/src/exec/spill/file_block_manager.h
+++ b/be/src/exec/spill/file_block_manager.h
@@ -34,7 +34,7 @@ using FileBlockContainerPtr = std::shared_ptr<FileBlockContainer>;
 class FileBlockManager : public BlockManager {
 public:
     FileBlockManager(const TUniqueId& query_id, DirManager* dir_manager);
-    ~FileBlockManager() override;
+    ~FileBlockManager() override = default;
 
     Status open() override;
     void close() override;
@@ -48,7 +48,6 @@ private:
     TUniqueId _query_id;
     std::atomic<uint64_t> _next_container_id = 0;
 
-    std::vector<FileBlockContainerPtr> _containers;
     DirManager* _dir_mgr = nullptr;
 };
 

--- a/be/src/exec/spill/input_stream.cpp
+++ b/be/src/exec/spill/input_stream.cpp
@@ -16,7 +16,10 @@
 
 #include <algorithm>
 #include <memory>
+#include <mutex>
+#include <unordered_map>
 #include <utility>
+#include <vector>
 
 #include "common/status.h"
 #include "exec/spill/block_manager.h"
@@ -241,27 +244,28 @@ Status BufferedInputStream::prefetch(workgroup::YieldContext& yield_ctx, SerdeCo
     return res.status();
 }
 
-class UnorderedInputStream : public SpillInputStream {
+class SequenceInputStream : public SpillInputStream {
 public:
-    UnorderedInputStream(std::vector<BlockPtr> input_blocks, SerdePtr serde)
+    SequenceInputStream(std::vector<BlockPtr> input_blocks, SerdePtr serde)
             : _input_blocks(std::move(input_blocks)), _serde(std::move(serde)) {}
-    ~UnorderedInputStream() override = default;
+    ~SequenceInputStream() override = default;
 
     StatusOr<ChunkUniquePtr> get_next(workgroup::YieldContext& yield_ctx, SerdeContext& ctx) override;
 
     bool is_ready() override { return false; }
 
-    void close() override;
+    void close() override {}
 
 private:
     std::vector<BlockPtr> _input_blocks;
     std::shared_ptr<BlockReader> _current_reader;
     size_t _current_idx = 0;
+    size_t _block_read_rows = 0;
     SerdePtr _serde;
     DECLARE_RACE_DETECTOR(detect_get_next)
 };
 
-StatusOr<ChunkUniquePtr> UnorderedInputStream::get_next(workgroup::YieldContext& yield_ctx, SerdeContext& ctx) {
+StatusOr<ChunkUniquePtr> SequenceInputStream::get_next(workgroup::YieldContext& yield_ctx, SerdeContext& ctx) {
     RACE_DETECT(detect_get_next);
     if (_current_idx >= _input_blocks.size()) {
         return Status::EndOfFile("end of reading spilled UnorderedInputStream");
@@ -282,31 +286,31 @@ StatusOr<ChunkUniquePtr> UnorderedInputStream::get_next(workgroup::YieldContext&
 
         auto res = _serde->deserialize(ctx, _current_reader.get());
         if (res.status().is_end_of_file()) {
+            DCHECK_EQ(_block_read_rows, _input_blocks[_current_idx]->num_rows());
             _input_blocks[_current_idx].reset();
             _current_reader.reset();
             _current_idx++;
+            _block_read_rows = 0;
             if (_current_idx >= _input_blocks.size()) {
                 return Status::EndOfFile("end of stream");
             }
             // move to the next block
             continue;
         }
+        RETURN_IF_ERROR(res.status());
         if (res.status().ok() && res.value()->is_empty()) {
             continue;
         }
-        if (!res.status().is_end_of_file()) {
-            return res;
-        }
+        _block_read_rows += res.value()->num_rows();
+        return res;
     }
     __builtin_unreachable();
 }
 
-void UnorderedInputStream::close() {}
-
 class OrderedInputStream : public SpillInputStream {
 public:
-    OrderedInputStream(std::vector<BlockPtr> blocks, RuntimeState* state)
-            : _input_blocks(std::move(blocks)), _merger(state) {}
+    OrderedInputStream(std::vector<InputStreamPtr> input_streams, RuntimeState* state)
+            : _input_streams(std::move(input_streams)), _merger(state) {}
 
     ~OrderedInputStream() override = default;
 
@@ -326,7 +330,6 @@ public:
     void close() override {}
 
 private:
-    std::vector<BlockPtr> _input_blocks;
     // multiple buffered stream
     std::vector<InputStreamPtr> _input_streams;
     starrocks::CascadeChunkMerger _merger;
@@ -336,14 +339,9 @@ private:
 Status OrderedInputStream::init(const SerdePtr& serde, const SortExecExprs* sort_exprs, const SortDescs* descs,
                                 Spiller* spiller) {
     std::vector<starrocks::ChunkProvider> chunk_providers;
-    DCHECK(!_input_blocks.empty());
+    DCHECK(!_input_streams.empty());
 
-    for (auto& block : _input_blocks) {
-        std::vector<BlockPtr> blocks{block};
-        auto stream = std::make_shared<BufferedInputStream>(
-                chunk_buffer_max_size, std::make_shared<UnorderedInputStream>(blocks, serde), spiller);
-        _input_streams.emplace_back(std::move(stream));
-        auto input_stream = _input_streams.back();
+    for (auto& input_stream : _input_streams) {
         auto chunk_provider = [input_stream, this](ChunkUniquePtr* output, bool* eos) {
             if (output == nullptr || eos == nullptr) {
                 return input_stream->is_ready();
@@ -386,17 +384,94 @@ StatusOr<ChunkUniquePtr> OrderedInputStream::get_next(workgroup::YieldContext& y
     return std::make_unique<Chunk>();
 }
 
-StatusOr<InputStreamPtr> BlockGroup::as_unordered_stream(const SerdePtr& serde, Spiller* spiller) {
-    auto stream = std::make_shared<UnorderedInputStream>(_blocks, serde);
+std::vector<BlockGroupPtr> BlockGroupSet::select_compaction_block_groups() {
+    std::vector<BlockGroupPtr> result;
+    {
+        std::lock_guard guard(_mutex);
+        const int min_compact_groups = 8;
+        const int level_size_factor = 8;
+        if (_groups.size() <= min_compact_groups) {
+            return {};
+        }
+        std::stable_sort(_groups.begin(), _groups.end(), [](const BlockGroupPtr& a, const BlockGroupPtr& b) {
+            return a->data_size() > b->data_size();
+        });
+
+        // assign level to each group
+        std::vector<int> levels(_groups.size(), 0);
+        int current_level = 0;
+        int need_compaction_level = -1;
+        int current_level_nums = 0;
+        size_t current_size = _groups.back()->data_size();
+
+        for (int i = _groups.size() - 1; i >= 0; --i) {
+            if (_groups[i]->data_size() > current_size * level_size_factor) {
+                current_size = _groups[i]->data_size();
+                current_level++;
+                current_level_nums = 0;
+            }
+            levels[i] = current_level;
+            current_level_nums++;
+            if (current_level_nums > min_compact_groups && need_compaction_level < 0) {
+                need_compaction_level = current_level;
+            }
+        }
+
+        if (need_compaction_level >= 0) {
+            // compact the groups in the same level
+            std::unordered_set<BlockGroup*> removed_groups;
+            for (int i = _groups.size() - 1; i >= 0; --i) {
+                if (levels[i] == need_compaction_level) {
+                    result.emplace_back(_groups[i]);
+                    removed_groups.insert(_groups[i].get());
+                }
+                if (result.size() > min_compact_groups) {
+                    break;
+                }
+            }
+
+            auto it = std::remove_if(_groups.begin(), _groups.end(), [&removed_groups](const BlockGroupPtr& group) {
+                return removed_groups.count(group.get()) > 0;
+            });
+
+            _groups.erase(it, _groups.end());
+        } else {
+            // select the smallest N block group for compact
+            for (size_t i = 0; i < min_compact_groups; ++i) {
+                result.emplace_back(_groups.back());
+                _groups.pop_back();
+            }
+        }
+    }
+    return result;
+}
+
+StatusOr<InputStreamPtr> BlockGroupSet::as_unordered_stream(const SerdePtr& serde, Spiller* spiller) {
+    std::vector<BlockPtr> blocks;
+    // collect block for each group
+    for (auto group : _groups) {
+        blocks.insert(blocks.end(), group->blocks().begin(), group->blocks().end());
+    }
+    auto stream = std::make_shared<SequenceInputStream>(std::move(blocks), serde);
     return std::make_shared<BufferedInputStream>(chunk_buffer_max_size, std::move(stream), spiller);
 }
 
-StatusOr<InputStreamPtr> BlockGroup::as_ordered_stream(RuntimeState* state, const SerdePtr& serde, Spiller* spiller,
-                                                       const SortExecExprs* sort_exprs, const SortDescs* sort_descs) {
-    if (_blocks.empty()) {
-        return as_unordered_stream(serde, spiller);
+StatusOr<InputStreamPtr> BlockGroupSet::as_ordered_stream(RuntimeState* state, const SerdePtr& serde, Spiller* spiller,
+                                                          const SortExecExprs* sort_exprs,
+                                                          const SortDescs* sort_descs) {
+    return build_ordered_stream(_groups, state, serde, spiller, sort_exprs, sort_descs);
+}
+
+StatusOr<InputStreamPtr> BlockGroupSet::build_ordered_stream(std::vector<BlockGroupPtr>& block_groups,
+                                                             RuntimeState* state, const SerdePtr& serde,
+                                                             Spiller* spiller, const SortExecExprs* sort_exprs,
+                                                             const SortDescs* sort_descs) {
+    std::vector<InputStreamPtr> streams;
+    for (const auto& group : block_groups) {
+        auto stream = std::make_shared<SequenceInputStream>(group->blocks(), serde);
+        streams.emplace_back(std::make_shared<BufferedInputStream>(chunk_buffer_max_size, stream, spiller));
     }
-    auto stream = std::make_shared<OrderedInputStream>(_blocks, state);
+    auto stream = std::make_shared<OrderedInputStream>(std::move(streams), state);
     RETURN_IF_ERROR(stream->init(serde, sort_exprs, sort_descs, spiller));
     return stream;
 }

--- a/be/src/exec/spill/input_stream.h
+++ b/be/src/exec/spill/input_stream.h
@@ -14,6 +14,7 @@
 
 #pragma once
 
+#include <algorithm>
 #include <atomic>
 #include <mutex>
 #include <utility>
@@ -30,9 +31,7 @@ namespace starrocks::spill {
 
 // InputStream is used in restore phase to represent an input stream of a restore task.
 // InputStream reads multiple Blocks and returns the deserialized Chunks.
-class SpillInputStream;
 using InputStreamPtr = std::shared_ptr<SpillInputStream>;
-class Spiller;
 
 class SpillInputStream {
 public:
@@ -74,28 +73,75 @@ private:
     std::vector<SpillInputStream*> _sub_stream;
 };
 
-// Note: not thread safe
+// Group of Blocks.
+// If spill needs sorted block output. Data within a block group is usually ordered.
+// Multiple block groups need to be merged and sorted.
+// Not thread safe.
+//
 class BlockGroup {
 public:
     BlockGroup() = default;
 
     void append(BlockPtr block) {
-        std::lock_guard guard(_mutex);
+        DCHECK(block != nullptr);
+        _data_size = std::nullopt;
         _blocks.emplace_back(std::move(block));
     }
+
+    const std::vector<BlockPtr>& blocks() { return _blocks; }
+
+    size_t data_size() const {
+        if (_data_size.has_value()) {
+            return _data_size.value();
+        }
+        size_t data_size = 0;
+        for (const auto& block : _blocks) {
+            data_size += block->size();
+        }
+        _data_size = data_size;
+        return _data_size.value();
+    }
+    size_t num_rows() const {
+        size_t num_rows = 0;
+        for (const auto& block : _blocks) {
+            num_rows += block->num_rows();
+        }
+        return num_rows;
+    }
+
+private:
+    mutable std::optional<size_t> _data_size;
+    std::vector<BlockPtr> _blocks;
+};
+using BlockGroupPtr = std::shared_ptr<BlockGroup>;
+
+class BlockGroupSet {
+public:
+    void add_block_group(BlockGroupPtr block_group) {
+        std::lock_guard guard(_mutex);
+        _groups.emplace_back(std::move(block_group));
+    }
+
+    size_t size() const {
+        std::lock_guard guard(_mutex);
+        return _groups.size();
+    }
+
+    // choose the two smallest chunks for the compaction
+    std::vector<BlockGroupPtr> select_compaction_block_groups();
 
     StatusOr<InputStreamPtr> as_unordered_stream(const SerdePtr& serde, Spiller* spiller);
 
     StatusOr<InputStreamPtr> as_ordered_stream(RuntimeState* state, const SerdePtr& serde, Spiller* spiller,
                                                const SortExecExprs* sort_exprs, const SortDescs* sort_descs);
 
-    void clear() { _blocks.clear(); }
-
-    // TODO: support drop block inadvance
+    static StatusOr<InputStreamPtr> build_ordered_stream(std::vector<BlockGroupPtr>& block_groups, RuntimeState* state,
+                                                         const SerdePtr& serde, Spiller* spiller,
+                                                         const SortExecExprs* sort_exprs, const SortDescs* sort_descs);
 
 private:
-    std::mutex _mutex;
-    std::vector<BlockPtr> _blocks;
+    mutable std::mutex _mutex;
+    std::vector<BlockGroupPtr> _groups;
 };
 
 } // namespace starrocks::spill

--- a/be/src/exec/spill/input_stream.h
+++ b/be/src/exec/spill/input_stream.h
@@ -110,6 +110,7 @@ public:
     }
 
 private:
+    // used to cache data_size in blocks
     mutable std::optional<size_t> _data_size;
     std::vector<BlockPtr> _blocks;
 };

--- a/be/src/exec/spill/log_block_manager.cpp
+++ b/be/src/exec/spill/log_block_manager.cpp
@@ -274,6 +274,7 @@ StatusOr<BlockPtr> LogBlockManager::acquire_block(const AcquireBlockOptions& opt
                                                                    opts.name, opts.direct_io));
     auto res = std::make_shared<LogBlock>(block_container, block_container->size());
     res->set_is_remote(dir->is_remote());
+    res->set_exclusive(opts.exclusive);
     return res;
 }
 
@@ -290,7 +291,7 @@ Status LogBlockManager::release_block(const BlockPtr& block) {
     if (is_full) {
         TRACE_SPILL_LOG << "mark container as full: " << container->path();
         _full_containers.emplace_back(container);
-    } else {
+    } else if (!log_block->exclusive()) {
         TRACE_SPILL_LOG << "return container to the pool: " << container->path();
         auto dir = container->dir();
         int32_t plan_node_id = container->plan_node_id();

--- a/be/src/exec/spill/mem_table.h
+++ b/be/src/exec/spill/mem_table.h
@@ -23,8 +23,8 @@
 #include "common/status.h"
 #include "exec/sorting/sort_permute.h"
 #include "exec/sorting/sorting.h"
-#include "exec/spill/block_manager.h"
 #include "exec/spill/data_stream.h"
+#include "exec/spill/spill_fwd.h"
 #include "exec/workgroup/scan_task_queue.h"
 #include "exprs/expr_context.h"
 #include "runtime/mem_tracker.h"
@@ -32,9 +32,6 @@
 
 namespace starrocks::spill {
 using FlushCallBack = std::function<Status(const ChunkPtr&)>;
-class SpillInputStream;
-class Spiller;
-class MemoryBlock;
 //  This component is the intermediate buffer for our spill data, which may be ordered or unordered,
 // depending on the requirements of the upper layer
 

--- a/be/src/exec/spill/operator_mem_resource_manager.cpp
+++ b/be/src/exec/spill/operator_mem_resource_manager.cpp
@@ -46,7 +46,6 @@ size_t OperatorMemoryResourceManager::operator_avaliable_memory_bytes() {
     auto* runtime_state = _op->runtime_state();
     size_t avaliable = runtime_state->spill_mem_table_size() * runtime_state->spill_mem_table_num();
     avaliable = std::max<size_t>(avaliable, runtime_state->spill_operator_min_bytes());
-    avaliable = std::min<size_t>(avaliable, runtime_state->spill_operator_max_bytes());
     return avaliable;
 }
 

--- a/be/src/exec/spill/operator_mem_resource_manager.cpp
+++ b/be/src/exec/spill/operator_mem_resource_manager.cpp
@@ -46,6 +46,7 @@ size_t OperatorMemoryResourceManager::operator_avaliable_memory_bytes() {
     auto* runtime_state = _op->runtime_state();
     size_t avaliable = runtime_state->spill_mem_table_size() * runtime_state->spill_mem_table_num();
     avaliable = std::max<size_t>(avaliable, runtime_state->spill_operator_min_bytes());
+    avaliable = std::min<size_t>(avaliable, runtime_state->spill_operator_max_bytes());
     return avaliable;
 }
 

--- a/be/src/exec/spill/options.h
+++ b/be/src/exec/spill/options.h
@@ -24,12 +24,18 @@
 
 namespace starrocks::spill {
 struct SpilledChunkBuildSchema {
-    void set_schema(const ChunkPtr& chunk) { _chunk = chunk->clone_empty(0); }
+    void set_schema(const ChunkPtr& chunk) {
+        _chunk = chunk->clone_empty(0);
+        _sample_chunk_memory_usage = chunk->memory_usage();
+    }
     bool empty() { return _chunk->num_columns() == 0; }
     ChunkUniquePtr new_chunk() { return _chunk->clone_unique(); }
     size_t column_number() const { return _chunk->num_columns(); }
+    size_t chunk_avg_mem_size() const { return _sample_chunk_memory_usage; }
 
 private:
+    // Now we'll use the first chunk to represent the average chunk memory size.
+    size_t _sample_chunk_memory_usage{};
     ChunkPtr _chunk{new Chunk()};
 };
 
@@ -92,6 +98,7 @@ struct SpilledOptions {
     size_t min_spilled_size = 1 * 1024 * 1024;
 
     bool read_shared = false;
+    bool enable_block_compaction = false;
     int encode_level = 0;
 
     BlockManager* block_manager = nullptr;

--- a/be/src/exec/spill/query_spill_manager.cpp
+++ b/be/src/exec/spill/query_spill_manager.cpp
@@ -21,19 +21,21 @@
 #include "exec/spill/file_block_manager.h"
 #include "exec/spill/hybird_block_manager.h"
 #include "exec/spill/log_block_manager.h"
+#include "gen_cpp/InternalService_types.h"
 #include "runtime/exec_env.h"
 
 namespace starrocks::spill {
 
 Status QuerySpillManager::init_block_manager(const TQueryOptions& query_options) {
+    const TSpillOptions& spill_options = query_options.spill_options;
     bool enable_spill_to_remote_storage =
-            query_options.__isset.enable_spill_to_remote_storage && query_options.enable_spill_to_remote_storage;
+            spill_options.__isset.enable_spill_to_remote_storage && spill_options.enable_spill_to_remote_storage;
     if (!enable_spill_to_remote_storage) {
         _block_manager = std::make_unique<LogBlockManager>(_uid, ExecEnv::GetInstance()->spill_dir_mgr());
         return Status::OK();
     }
-    DCHECK(query_options.__isset.spill_to_remote_storage_options);
-    const auto& options = query_options.spill_to_remote_storage_options;
+    DCHECK(spill_options.__isset.spill_to_remote_storage_options);
+    const auto& options = spill_options.spill_to_remote_storage_options;
 
     if (!options.__isset.remote_storage_paths || !options.__isset.remote_storage_conf) {
         DCHECK(false) << "enable spill_to_remote_storage but remote_storage_paths or remote_storage_conf "

--- a/be/src/exec/spill/serde.cpp
+++ b/be/src/exec/spill/serde.cpp
@@ -156,7 +156,8 @@ Status ColumnarSerde::serialize(RuntimeState* state, SerdeContext& ctx, const Ch
         memcpy(serialize_buffer.data(), header_buffer, HEADER_SIZE);
     }
     size_t written_bytes = serialize_buffer.size();
-    RETURN_IF_ERROR(output->append(state, {Slice(serialize_buffer.data(), written_bytes)}, written_bytes));
+    RETURN_IF_ERROR(
+            output->append(state, {Slice(serialize_buffer.data(), written_bytes)}, written_bytes, chunk->num_rows()));
     return Status::OK();
 }
 

--- a/be/src/exec/spill/serde.h
+++ b/be/src/exec/spill/serde.h
@@ -23,12 +23,11 @@
 #include "common/statusor.h"
 #include "exec/spill/block_manager.h"
 #include "exec/spill/data_stream.h"
-#include "gen_cpp/types.pb.h"
+#include "exec/spill/spill_fwd.h"
 #include "gutil/macros.h"
 #include "util/raw_container.h"
 
 namespace starrocks::spill {
-class ChunkBuilder;
 
 enum class SerdeType {
     BY_COLUMN,
@@ -87,7 +86,6 @@ private:
 struct SerdeContext {
     raw::RawString serialize_buffer;
 };
-class Spiller;
 // Serde is used to serialize and deserialize spilled data.
 class Serde;
 using SerdePtr = std::shared_ptr<Serde>;

--- a/be/src/exec/spill/spill_components.cpp
+++ b/be/src/exec/spill/spill_components.cpp
@@ -17,6 +17,7 @@
 #include <any>
 #include <cstdint>
 #include <memory>
+#include <numeric>
 
 #include "column/vectorized_fwd.h"
 #include "common/config.h"
@@ -30,6 +31,7 @@
 #include "exec/workgroup/work_group.h"
 #include "exec/workgroup/work_group_fwd.h"
 #include "util/bit_util.h"
+#include "util/runtime_profile.h"
 
 namespace starrocks::spill {
 // implements for SpillerWriter
@@ -42,7 +44,7 @@ Status SpillerWriter::_decrease_running_flush_tasks() {
     return Status::OK();
 }
 
-const SpilledOptions& SpillerWriter::options() {
+const SpilledOptions& SpillerWriter::options() const {
     return _spiller->options();
 }
 
@@ -74,13 +76,41 @@ Status RawSpillerWriter::yieldable_flush_task(workgroup::YieldContext& yield_ctx
     if (state->is_cancelled()) {
         return Status::OK();
     }
+
+    enum WriterStage { FLUSH_MEM_TABLE = 0, COMPACT = 1, FINISH = 2 };
+
     DCHECK(yield_ctx.task_context_data.has_value()) << "flush context must be set";
-    yield_ctx.total_yield_point_cnt = 1;
+    yield_ctx.total_yield_point_cnt = FINISH;
+
+    switch (yield_ctx.yield_point) {
+    case FLUSH_MEM_TABLE:
+        RETURN_IF_ERROR(_spill_mem_table(yield_ctx, mem_table));
+        RETURN_IF_YIELD(yield_ctx.need_yield);
+        TO_NEXT_STAGE(yield_ctx.yield_point);
+        [[fallthrough]];
+    case COMPACT:
+        RETURN_IF_ERROR(_compact_mem_table(yield_ctx));
+        RETURN_IF_YIELD(yield_ctx.need_yield);
+        TO_NEXT_STAGE(yield_ctx.yield_point);
+        [[fallthrough]];
+    default:
+        DCHECK_EQ(yield_ctx.yield_point, 2);
+    };
+
+    return Status::OK();
+}
+
+Status RawSpillerWriter::_spill_mem_table(workgroup::YieldContext& yield_ctx, const MemTablePtr& mem_table) {
     auto io_task = std::any_cast<SpillIOTaskContextPtr>(yield_ctx.task_context_data);
     auto flush_ctx = std::static_pointer_cast<FlushContext>(io_task);
+
     // flush_ctx->output is not nullptr means the task is resumed from yield point
+    DCHECK(flush_ctx->input_stream == nullptr);
     if (flush_ctx->output == nullptr) {
-        flush_ctx->output = create_spill_output_stream(_spiller, &_block_group, _spiller->block_manager());
+        DCHECK(flush_ctx->block_group == nullptr);
+        auto block_group = std::make_shared<BlockGroup>();
+        flush_ctx->output = create_spill_output_stream(_spiller, block_group.get(), _spiller->block_manager());
+        flush_ctx->block_group = std::move(block_group);
     }
 
     // serialize mem table to data stream
@@ -89,8 +119,69 @@ Status RawSpillerWriter::yieldable_flush_task(workgroup::YieldContext& yield_ctx
     RETURN_IF_ERROR(flush_ctx->output->flush());
 
     mem_table->reset();
+    flush_ctx->output.reset();
+    this->add_block_group(std::move(flush_ctx->block_group));
 
     return Status::OK();
+}
+
+Status RawSpillerWriter::_compact_mem_table(workgroup::YieldContext& yield_ctx) {
+    auto io_task = std::any_cast<SpillIOTaskContextPtr>(yield_ctx.task_context_data);
+    auto flush_ctx = std::static_pointer_cast<FlushContext>(io_task);
+    // flush_ctx->output is not nullptr means the task is resumed from yield point
+    if (flush_ctx->output == nullptr) {
+        if (!_need_compact_block()) {
+            return Status::OK();
+        }
+
+        std::vector<BlockGroupPtr> block_groups = _block_group_set.select_compaction_block_groups();
+        if (block_groups.empty()) {
+            return Status::OK();
+        }
+
+        COUNTER_UPDATE(_spiller->metrics().compact_count, 1);
+        COUNTER_UPDATE(_spiller->metrics().compact_block_count, block_groups.size());
+
+        flush_ctx->compact_input_num_rows =
+                std::accumulate(block_groups.begin(), block_groups.end(), 0,
+                                [](size_t sum, const auto& block_group) { return sum + block_group->num_rows(); });
+        TRACE_SPILL_LOG << "spill compact block group input rows:" << flush_ctx->compact_input_num_rows;
+
+        DCHECK(flush_ctx->block_group == nullptr);
+        auto block_group = std::make_shared<BlockGroup>();
+        flush_ctx->output = create_spill_output_stream(_spiller, block_group.get(), _spiller->block_manager());
+        flush_ctx->block_group = std::move(block_group);
+        ASSIGN_OR_RETURN(flush_ctx->input_stream,
+                         BlockGroupSet::build_ordered_stream(block_groups, _runtime_state, _spiller->serde(), _spiller,
+                                                             options().sort_exprs, options().sort_desc));
+    }
+    auto st = DataTranster::transfer(yield_ctx, _runtime_state, _spiller->serde().get(), flush_ctx->output,
+                                     flush_ctx->input_stream);
+    RETURN_IF(!st.is_ok_or_eof(), st);
+    RETURN_IF_YIELD(yield_ctx.need_yield);
+    RETURN_IF_ERROR(flush_ctx->output->flush());
+    flush_ctx->output.reset();
+    DCHECK_EQ(flush_ctx->compact_input_num_rows, flush_ctx->block_group->num_rows());
+    this->add_block_group(std::move(flush_ctx->block_group));
+
+    return Status::OK();
+}
+
+bool RawSpillerWriter::_need_compact_block() const {
+    const auto& opts = options();
+    if (!opts.enable_block_compaction) {
+        return false;
+    }
+
+    if (opts.is_unordered) {
+        return false;
+    }
+
+    if (_block_group_set.size() < _spiller->max_sorted_block_cnt()) {
+        return false;
+    }
+
+    return true;
 }
 
 Status RawSpillerWriter::acquire_stream(const SpillPartitionInfo* partition,
@@ -104,10 +195,10 @@ Status RawSpillerWriter::acquire_stream(std::shared_ptr<SpillInputStream>* strea
     const auto& opts = options();
 
     if (opts.is_unordered) {
-        ASSIGN_OR_RETURN(input_stream, _block_group.as_unordered_stream(serde, _spiller));
+        ASSIGN_OR_RETURN(input_stream, _block_group_set.as_unordered_stream(serde, _spiller));
     } else {
-        ASSIGN_OR_RETURN(input_stream, _block_group.as_ordered_stream(_runtime_state, serde, _spiller, opts.sort_exprs,
-                                                                      opts.sort_desc));
+        ASSIGN_OR_RETURN(input_stream, _block_group_set.as_ordered_stream(_runtime_state, serde, _spiller,
+                                                                          opts.sort_exprs, opts.sort_desc));
     }
 
     *stream = input_stream;
@@ -372,14 +463,16 @@ Status PartitionedSpillerWriter::spill_partition(workgroup::YieldContext& yield_
                                                  SpilledPartition* partition) {
     auto mem_table = partition->spill_writer->mem_table();
     auto mem_table_mem_usage = mem_table->mem_usage();
-    if (partition->spill_writer->output_stream() == nullptr) {
-        auto output = create_spill_output_stream(_spiller, &partition->spill_writer->block_group(),
-                                                 _spiller->block_manager());
+    if (partition->spill_output_stream == nullptr) {
+        auto block_group = std::make_shared<BlockGroup>();
+        partition->spill_writer->add_block_group(std::move(block_group));
+        partition->block_group = block_group;
+        auto output = create_spill_output_stream(_spiller, partition->block_group.get(), _spiller->block_manager());
         std::lock_guard<std::mutex> l(_mutex);
-        DCHECK_EQ(partition->spill_writer->output_stream(), nullptr);
-        partition->spill_writer->output_stream() = output;
+        DCHECK_EQ(partition->spill_output_stream, nullptr);
+        partition->spill_output_stream = output;
     }
-    auto output = partition->spill_writer->output_stream();
+    auto output = partition->spill_output_stream;
     RETURN_IF_ERROR(mem_table->finalize(yield_ctx, output));
     RETURN_IF_YIELD(yield_ctx.need_yield);
     RETURN_IF_ERROR(output->flush());

--- a/be/src/exec/spill/spill_components.cpp
+++ b/be/src/exec/spill/spill_components.cpp
@@ -465,8 +465,8 @@ Status PartitionedSpillerWriter::spill_partition(workgroup::YieldContext& yield_
     auto mem_table_mem_usage = mem_table->mem_usage();
     if (partition->spill_output_stream == nullptr) {
         auto block_group = std::make_shared<BlockGroup>();
-        partition->spill_writer->add_block_group(std::move(block_group));
         partition->block_group = block_group;
+        partition->spill_writer->add_block_group(std::move(block_group));
         auto output = create_spill_output_stream(_spiller, partition->block_group.get(), _spiller->block_manager());
         std::lock_guard<std::mutex> l(_mutex);
         DCHECK_EQ(partition->spill_output_stream, nullptr);

--- a/be/src/exec/spill/spill_components.h
+++ b/be/src/exec/spill/spill_components.h
@@ -106,7 +106,7 @@ public:
 protected:
     Status _decrease_running_flush_tasks();
 
-    const SpilledOptions& options();
+    const SpilledOptions& options() const;
 
     Spiller* _spiller;
     RuntimeState* _runtime_state;
@@ -163,11 +163,6 @@ public:
 
     const auto& mem_table() const { return _mem_table; }
 
-    SpillOutputDataStreamPtr& output_stream() { return _output_stream; }
-    void reset_output_stream() { _output_stream = nullptr; }
-
-    BlockGroup& block_group() { return _block_group; }
-
     Status acquire_stream(std::shared_ptr<SpillInputStream>* stream) override;
 
     Status acquire_stream(const SpillPartitionInfo* partition, std::shared_ptr<SpillInputStream>* stream) override;
@@ -178,15 +173,28 @@ public:
 
     Status yieldable_flush_task(workgroup::YieldContext& ctx, RuntimeState* state, const MemTablePtr& mem_table);
 
+    void add_block_group(BlockGroupPtr&& block_group) { _block_group_set.add_block_group(std::move(block_group)); }
+
 public:
     struct FlushContext : public SpillIOTaskContext {
         std::shared_ptr<SpillOutputDataStream> output;
+        std::shared_ptr<BlockGroup> block_group;
+        InputStreamPtr input_stream;
+        // only used in DCHECK
+        size_t compact_input_num_rows{};
     };
     using FlushContextPtr = std::shared_ptr<FlushContext>;
 
 private:
-    BlockGroup _block_group;
-    SpillOutputDataStreamPtr _output_stream;
+    // spill current mem-table to block group sets
+    Status _spill_mem_table(workgroup::YieldContext& yield_ctx, const MemTablePtr& mem_table);
+    // select small block group then compact to larger block group
+    Status _compact_mem_table(workgroup::YieldContext& yield_ctx);
+
+    bool _need_compact_block() const;
+
+    size_t _max_block_group_size{};
+    BlockGroupSet _block_group_set;
     MemTablePtr _mem_table;
     std::queue<MemTablePtr> _mem_table_pool;
     std::mutex _mutex;
@@ -212,6 +220,8 @@ struct SpilledPartition : public SpillPartitionInfo {
 
     bool is_spliting = false;
     std::unique_ptr<RawSpillerWriter> spill_writer;
+    BlockGroupPtr block_group;
+    SpillOutputDataStreamPtr spill_output_stream;
 };
 
 class PartitionedSpillerWriter final : public SpillerWriter {

--- a/be/src/exec/spill/spill_components.h
+++ b/be/src/exec/spill/spill_components.h
@@ -193,7 +193,6 @@ private:
 
     bool _need_compact_block() const;
 
-    size_t _max_block_group_size{};
     BlockGroupSet _block_group_set;
     MemTablePtr _mem_table;
     std::queue<MemTablePtr> _mem_table_pool;

--- a/be/src/exec/spill/spill_fwd.h
+++ b/be/src/exec/spill/spill_fwd.h
@@ -1,0 +1,29 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+namespace starrocks::workgroup {
+struct YieldContext;
+};
+
+namespace starrocks::spill {
+class Spiller;
+class BlockGroup;
+class BlockManager;
+class SpillInputStream;
+class Serde;
+class ChunkBuilder;
+struct SpilledOptions;
+} // namespace starrocks::spill

--- a/be/src/exec/spill/spiller.cpp
+++ b/be/src/exec/spill/spiller.cpp
@@ -30,6 +30,7 @@
 #include "common/status.h"
 #include "common/statusor.h"
 #include "exec/sort_exec_exprs.h"
+#include "exec/spill/common.h"
 #include "exec/spill/input_stream.h"
 #include "exec/spill/mem_table.h"
 #include "exec/spill/options.h"
@@ -87,13 +88,16 @@ SpillProcessMetrics::SpillProcessMetrics(RuntimeProfile* profile, std::atomic_in
             profile->AddHighWaterMarkCounter("PartitionWriterPeakMemoryBytes", TUnit::BYTES,
                                              RuntimeProfile::Counter::create_strategy(TUnit::BYTES), parent);
 
-    block_count = ADD_CHILD_COUNTER(profile, "BlockCount", TUnit::UNIT, parent);
+    block_count = ADD_CHILD_COUNTER(profile, "BlockCount", TUnit::NONE, parent);
     local_block_count = ADD_CHILD_COUNTER(profile, "LocalBlockCount", TUnit::UNIT, "BlockCount");
     remote_block_count = ADD_CHILD_COUNTER(profile, "RemoteBlockCount", TUnit::UNIT, "BlockCount");
 
     read_io_count = ADD_CHILD_COUNTER(profile, "ReadIOCount", TUnit::UNIT, parent);
     local_read_io_count = ADD_CHILD_COUNTER(profile, "LocalReadIOCount", TUnit::UNIT, "ReadIOCount");
     remote_read_io_count = ADD_CHILD_COUNTER(profile, "RemoteReadIOCount", TUnit::UNIT, "ReadIOCount");
+
+    compact_count = ADD_CHILD_COUNTER(profile, "CompactCount", TUnit::UNIT, parent);
+    compact_block_count = ADD_CHILD_COUNTER(profile, "CompactBlockCount", TUnit::UNIT, parent);
 
     flush_io_task_count = ADD_CHILD_COUNTER(profile, "FlushIOTaskCount", TUnit::UNIT, parent);
     peak_flush_io_task_count = profile->AddHighWaterMarkCounter(
@@ -129,7 +133,6 @@ Status Spiller::prepare(RuntimeState* state) {
         DCHECK(_opts.init_partition_nums == -1);
     }
 
-    _block_group = std::make_shared<spill::BlockGroup>();
     _block_manager = _opts.block_manager;
 
     return Status::OK();
@@ -154,7 +157,6 @@ void Spiller::update_spilled_task_status(Status&& st) {
 Status Spiller::reset_state(RuntimeState* state) {
     _spilled_append_rows = 0;
     _restore_read_rows = 0;
-    _block_group->clear();
     RETURN_IF_ERROR(prepare(state));
     return Status::OK();
 }
@@ -182,4 +184,12 @@ Status Spiller::_acquire_input_stream(RuntimeState* state) {
 
     return Status::OK();
 }
+
+void Spiller::_init_max_block_nums() {
+    size_t chunk_avg_mem_size = _chunk_builder.chunk_schema()->chunk_avg_mem_size();
+    chunk_avg_mem_size = std::max<size_t>(1, chunk_avg_mem_size);
+    _max_sorted_block_cnt = std::max<size_t>(16, _opts.spill_mem_table_bytes_size / chunk_avg_mem_size);
+    TRACE_SPILL_LOG << "spill max block cnt:" << _max_sorted_block_cnt << ",avg size " << chunk_avg_mem_size;
+}
+
 } // namespace starrocks::spill

--- a/be/src/exec/spill/spiller.h
+++ b/be/src/exec/spill/spiller.h
@@ -118,6 +118,10 @@ public:
     RuntimeProfile::Counter* local_read_io_count = nullptr;
     RuntimeProfile::Counter* remote_read_io_count = nullptr;
 
+    // the number of compact table
+    RuntimeProfile::Counter* compact_count = nullptr;
+    RuntimeProfile::Counter* compact_block_count = nullptr;
+
     // flush/restore task count
     RuntimeProfile::Counter* flush_io_task_count = nullptr;
     RuntimeProfile::HighWaterMarkCounter* peak_flush_io_task_count = nullptr;
@@ -233,10 +237,14 @@ public:
 
     Status reset_state(RuntimeState* state);
 
+    size_t max_sorted_block_cnt() const { return _max_sorted_block_cnt; }
+
 private:
     Status _acquire_input_stream(RuntimeState* state);
 
     Status _decrease_running_flush_tasks();
+
+    void _init_max_block_nums();
 
 private:
     SpillProcessMetrics _metrics;
@@ -257,8 +265,7 @@ private:
 
     std::shared_ptr<spill::Serde> _serde;
     spill::BlockManager* _block_manager = nullptr;
-    std::shared_ptr<spill::BlockGroup> _block_group;
-
+    size_t _max_sorted_block_cnt = 0;
     std::atomic_bool _is_cancel = false;
 };
 

--- a/be/src/exec/spill/spiller.hpp
+++ b/be/src/exec/spill/spiller.hpp
@@ -49,6 +49,7 @@ Status Spiller::spill(RuntimeState* state, const ChunkPtr& chunk, MemGuard&& gua
     if (_chunk_builder.chunk_schema()->empty()) {
         _chunk_builder.chunk_schema()->set_schema(chunk);
         RETURN_IF_ERROR(_serde->prepare());
+        _init_max_block_nums();
     }
 
     if (_opts.init_partition_nums > 0) {
@@ -70,6 +71,7 @@ Status Spiller::partitioned_spill(RuntimeState* state, const ChunkPtr& chunk, Sp
     if (_chunk_builder.chunk_schema()->empty()) {
         _chunk_builder.chunk_schema()->set_schema(chunk);
         RETURN_IF_ERROR(_serde->prepare());
+        _init_max_block_nums();
     }
 
     std::vector<uint32_t> indexs;

--- a/be/src/exec/spill/spiller_factory.h
+++ b/be/src/exec/spill/spiller_factory.h
@@ -20,13 +20,11 @@
 
 #include "exec/sort_exec_exprs.h"
 #include "exec/sorting/sorting.h"
+#include "exec/spill/spill_fwd.h"
 #include "exprs/expr_context.h"
 #include "runtime/runtime_state.h"
 
-namespace starrocks {
-namespace spill {
-struct SpilledOptions;
-class Spiller;
+namespace starrocks::spill {
 
 class SpillerFactory : public std::enable_shared_from_this<SpillerFactory> {
 public:
@@ -46,5 +44,4 @@ private:
 
 using SpillerFactoryPtr = std::shared_ptr<SpillerFactory>;
 SpillerFactoryPtr make_spilled_factory();
-} // namespace spill
-} // namespace starrocks
+} // namespace starrocks::spill

--- a/be/src/runtime/runtime_state.cpp
+++ b/be/src/runtime/runtime_state.cpp
@@ -152,6 +152,9 @@ void RuntimeState::_init(const TUniqueId& fragment_instance_id, const TQueryOpti
                          const TQueryGlobals& query_globals, ExecEnv* exec_env) {
     _fragment_instance_id = fragment_instance_id;
     _query_options = query_options;
+    if (_query_options.__isset.spill_options) {
+        _spill_options = _query_options.spill_options;
+    }
     if (query_globals.__isset.time_zone) {
         _timezone = query_globals.time_zone;
         if (query_globals.__isset.timestamp_us) {

--- a/be/src/runtime/runtime_state.h
+++ b/be/src/runtime/runtime_state.h
@@ -409,6 +409,11 @@ public:
     int64_t spill_operator_min_bytes() const {
         return EXTRACE_SPILL_PARAM(_query_options, _spill_options, spill_operator_min_bytes);
     }
+
+    int64_t spill_operator_max_bytes() const {
+        return EXTRACE_SPILL_PARAM(_query_options, _spill_options, spill_operator_max_bytes);
+    }
+
     int64_t spill_revocable_max_bytes() const {
         return EXTRACE_SPILL_PARAM(_query_options, _spill_options, spill_revocable_max_bytes);
     }

--- a/be/src/runtime/runtime_state.h
+++ b/be/src/runtime/runtime_state.h
@@ -82,7 +82,7 @@ class QueryContext;
 }
 
 #define EXTRACE_SPILL_PARAM(query_option, spill_option, var) \
-    spill_option.has_value() ? query_option.var : query_option.var
+    spill_option.has_value() ? spill_option->var : query_option.var
 
 constexpr int64_t kRpcHttpMinSize = ((1L << 31) - (1L << 10));
 
@@ -408,9 +408,6 @@ public:
 
     int64_t spill_operator_min_bytes() const {
         return EXTRACE_SPILL_PARAM(_query_options, _spill_options, spill_operator_min_bytes);
-    }
-    int64_t spill_operator_max_bytes() const {
-        return EXTRACE_SPILL_PARAM(_query_options, _spill_options, spill_operator_max_bytes);
     }
     int64_t spill_revocable_max_bytes() const {
         return EXTRACE_SPILL_PARAM(_query_options, _spill_options, spill_revocable_max_bytes);

--- a/be/src/runtime/runtime_state.h
+++ b/be/src/runtime/runtime_state.h
@@ -37,6 +37,7 @@
 #include <atomic>
 #include <fstream>
 #include <memory>
+#include <optional>
 #include <string>
 #include <string_view>
 #include <unordered_map>
@@ -79,6 +80,9 @@ using BroadcastJoinRightOffsprings = std::unordered_set<int32_t>;
 namespace pipeline {
 class QueryContext;
 }
+
+#define EXTRACE_SPILL_PARAM(query_option, spill_option, var) \
+    spill_option.has_value() ? query_option.var : query_option.var
 
 constexpr int64_t kRpcHttpMinSize = ((1L << 31) - (1L << 10));
 
@@ -368,47 +372,60 @@ public:
 
     int num_per_fragment_instances() const { return _num_per_fragment_instances; }
 
-    TSpillMode::type spill_mode() const {
-        DCHECK(_query_options.__isset.spill_mode);
-        return _query_options.spill_mode;
+    TSpillMode::type spill_mode() const { return EXTRACE_SPILL_PARAM(_query_options, _spill_options, spill_mode); }
+    int64_t spillable_operator_mask() const {
+        return EXTRACE_SPILL_PARAM(_query_options, _spill_options, spillable_operator_mask);
     }
 
     bool enable_spill() const { return _query_options.enable_spill; }
 
     bool enable_hash_join_spill() const {
-        return _query_options.spillable_operator_mask & (1LL << TSpillableOperatorType::HASH_JOIN);
+        return spillable_operator_mask() & (1LL << TSpillableOperatorType::HASH_JOIN);
     }
 
-    bool enable_agg_spill() const {
-        return _query_options.spillable_operator_mask & (1LL << TSpillableOperatorType::AGG);
-    }
+    bool enable_agg_spill() const { return spillable_operator_mask() & (1LL << TSpillableOperatorType::AGG); }
     bool enable_agg_distinct_spill() const {
-        return _query_options.spillable_operator_mask & (1LL << TSpillableOperatorType::AGG_DISTINCT);
+        return spillable_operator_mask() & (1LL << TSpillableOperatorType::AGG_DISTINCT);
     }
-    bool enable_sort_spill() const {
-        return _query_options.spillable_operator_mask & (1LL << TSpillableOperatorType::SORT);
+    bool enable_sort_spill() const { return spillable_operator_mask() & (1LL << TSpillableOperatorType::SORT); }
+    bool enable_nl_join_spill() const { return spillable_operator_mask() & (1LL << TSpillableOperatorType::NL_JOIN); }
+
+    int32_t spill_mem_table_size() const {
+        return EXTRACE_SPILL_PARAM(_query_options, _spill_options, spill_mem_table_size);
     }
-    bool enable_nl_join_spill() const {
-        return _query_options.spillable_operator_mask & (1LL << TSpillableOperatorType::NL_JOIN);
+
+    int32_t spill_mem_table_num() const {
+        return EXTRACE_SPILL_PARAM(_query_options, _spill_options, spill_mem_table_num);
     }
 
-    int32_t spill_mem_table_size() const { return _query_options.spill_mem_table_size; }
+    bool enable_agg_spill_preaggregation() const {
+        return EXTRACE_SPILL_PARAM(_query_options, _spill_options, enable_agg_spill_preaggregation);
+    }
 
-    int32_t spill_mem_table_num() const { return _query_options.spill_mem_table_num; }
+    double spill_mem_limit_threshold() const {
+        return EXTRACE_SPILL_PARAM(_query_options, _spill_options, spill_mem_limit_threshold);
+    }
 
-    bool enable_agg_spill_preaggregation() const { return _query_options.enable_agg_spill_preaggregation; }
-
-    double spill_mem_limit_threshold() const { return _query_options.spill_mem_limit_threshold; }
-
-    int64_t spill_operator_min_bytes() const { return _query_options.spill_operator_min_bytes; }
-    int64_t spill_operator_max_bytes() const { return _query_options.spill_operator_max_bytes; }
-    int64_t spill_revocable_max_bytes() const { return _query_options.spill_revocable_max_bytes; }
+    int64_t spill_operator_min_bytes() const {
+        return EXTRACE_SPILL_PARAM(_query_options, _spill_options, spill_operator_min_bytes);
+    }
+    int64_t spill_operator_max_bytes() const {
+        return EXTRACE_SPILL_PARAM(_query_options, _spill_options, spill_operator_max_bytes);
+    }
+    int64_t spill_revocable_max_bytes() const {
+        return EXTRACE_SPILL_PARAM(_query_options, _spill_options, spill_revocable_max_bytes);
+    }
     bool spill_enable_direct_io() const {
-        return _query_options.__isset.spill_enable_direct_io && _query_options.spill_enable_direct_io;
+        return EXTRACE_SPILL_PARAM(_query_options, _spill_options, spill_enable_direct_io);
     }
-    double spill_rand_ratio() const { return _query_options.spill_rand_ratio; }
+    double spill_rand_ratio() const { return EXTRACE_SPILL_PARAM(_query_options, _spill_options, spill_rand_ratio); }
 
-    int32_t spill_encode_level() const { return _query_options.spill_encode_level; }
+    int32_t spill_encode_level() const {
+        return EXTRACE_SPILL_PARAM(_query_options, _spill_options, spill_encode_level);
+    }
+    bool spill_enable_compaction() const {
+        return _spill_options.has_value() ? _spill_options->spill_enable_compaction : false;
+    }
 
     bool error_if_overflow() const {
         return _query_options.__isset.overflow_mode && _query_options.overflow_mode == TOverflowMode::REPORT_ERROR;
@@ -668,6 +685,8 @@ private:
 
     std::unordered_set<int32_t> _shuffle_hash_bucket_rf_ids;
     BroadcastJoinRightOffsprings _broadcast_join_right_offsprings;
+
+    std::optional<TSpillOptions> _spill_options;
 };
 
 #define LIMIT_EXCEEDED(tracker, state, msg)                                                                         \

--- a/be/test/io/spill_test.cpp
+++ b/be/test/io/spill_test.cpp
@@ -463,6 +463,8 @@ TEST_F(SpillTest, order_by_process) {
     spill_options.spill_mem_table_bytes_size = 1 * 1024 * 1024;
     // spill format type
     spill_options.spill_type = spill::SpillFormaterType::SPILL_BY_COLUMN;
+    // enable compaction for spill
+    spill_options.enable_block_compaction = true;
 
     spill_options.block_manager = dummy_block_mgr.get();
 
@@ -509,6 +511,7 @@ TEST_F(SpillTest, order_by_process) {
             ASSERT_TRUE(chunk_st.status().is_end_of_file());
         }
         ASSERT_EQ(contain_rows, restored_rows);
+        ASSERT_GT(metrics.compact_count->value(), 0);
     }
 }
 

--- a/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
@@ -1092,6 +1092,8 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
     private double spillMemLimitThreshold = 0.8;
     @VarAttr(name = SPILL_OPERATOR_MIN_BYTES, flag = VariableMgr.INVISIBLE)
     private long spillOperatorMinBytes = 1024L * 1024 * 50;
+    @VarAttr(name = SPILL_OPERATOR_MAX_BYTES, flag = VariableMgr.INVISIBLE)
+    private long spillOperatorMaxBytes = 1024L * 1024 * 1000;
     // If the operator memory revocable memory exceeds this value, the operator will perform a spill as soon as possible
     @VarAttr(name = SPILL_REVOCABLE_MAX_BYTES)
     private long spillRevocableMaxBytes = 0;
@@ -3808,6 +3810,7 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
             spillOptions.setSpill_mem_table_num(spillMemTableNum);
             spillOptions.setSpill_mem_limit_threshold(spillMemLimitThreshold);
             spillOptions.setSpill_operator_min_bytes(spillOperatorMinBytes);
+            spillOptions.setSpill_operator_max_bytes(spillOperatorMaxBytes);
             spillOptions.setSpill_revocable_max_bytes(spillRevocableMaxBytes);
             spillOptions.setSpill_encode_level(spillEncodeLevel);
             spillOptions.setSpillable_operator_mask(spillableOperatorMask);

--- a/gensrc/thrift/InternalService.thrift
+++ b/gensrc/thrift/InternalService.thrift
@@ -162,8 +162,8 @@ struct TSpillOptions {
   11: optional TSpillMode spill_mode;
   // used to identify which operators allow spill, only meaningful when enable_spill=true
   12: optional i64 spillable_operator_mask;
+  13: optional bool enable_agg_spill_preaggregation;
 
-  
   21: optional bool enable_spill_to_remote_storage;
   22: optional TSpillToRemoteStorageOptions spill_to_remote_storage_options;
 }
@@ -279,7 +279,7 @@ struct TQueryOptions {
 
   104: optional TOverflowMode overflow_mode = TOverflowMode.OUTPUT_NULL;
   105: optional bool use_column_pool = true;
-
+  // Deprecated
   106: optional bool enable_agg_spill_preaggregation;
   107: optional i64 global_runtime_filter_build_max_size;
   108: optional i64 runtime_filter_rpc_http_min_size;

--- a/gensrc/thrift/InternalService.thrift
+++ b/gensrc/thrift/InternalService.thrift
@@ -144,6 +144,30 @@ struct TSpillToRemoteStorageOptions {
   3: optional bool disable_spill_to_local_disk;
 }
 
+// spill options
+struct TSpillOptions {
+  1: optional i32 spill_mem_table_size;
+  2: optional i32 spill_mem_table_num;
+  3: optional double spill_mem_limit_threshold;
+  4: optional i64 spill_operator_min_bytes;
+  5: optional i64 spill_operator_max_bytes;
+  6: optional i32 spill_encode_level;
+  7: optional i64 spill_revocable_max_bytes;
+  8: optional bool spill_enable_direct_io;
+  9: optional bool spill_enable_compaction;
+  // only used in spill_mode="random"
+  // probability of triggering operator spill
+  // (0.0,1.0)
+  10: optional double spill_rand_ratio;
+  11: optional TSpillMode spill_mode;
+  // used to identify which operators allow spill, only meaningful when enable_spill=true
+  12: optional i64 spillable_operator_mask;
+
+  
+  21: optional bool enable_spill_to_remote_storage;
+  22: optional TSpillToRemoteStorageOptions spill_to_remote_storage_options;
+}
+
 // Query options with their respective defaults
 struct TQueryOptions {
   2: optional i32 max_errors = 0
@@ -211,7 +235,9 @@ struct TQueryOptions {
 
   72: optional i64 rpc_http_min_size;
 
+  // Deprecated
   // some experimental parameter for spill
+  // TODO: remove in 3.4.x
   73: optional i32 spill_mem_table_size;
   74: optional i32 spill_mem_table_num;
   75: optional double spill_mem_limit_threshold;
@@ -220,12 +246,10 @@ struct TQueryOptions {
   78: optional i32 spill_encode_level;
   79: optional i64 spill_revocable_max_bytes;
   80: optional bool spill_enable_direct_io;
-  // only used in spill_mode="random"
-  // probability of triggering operator spill
-  // (0.0,1.0)
   81: optional double spill_rand_ratio;
-
   85: optional TSpillMode spill_mode;
+
+  82: optional TSpillOptions spill_options;
   
   86: optional i32 io_tasks_per_scan_operator = 4;
   87: optional i32 connector_io_tasks_per_scan_operator = 16;
@@ -240,6 +264,7 @@ struct TQueryOptions {
   93: optional i32 connector_io_tasks_slow_io_latency_ms = 50;
   94: optional double scan_use_query_mem_ratio = 0.25;
   95: optional double connector_scan_use_query_mem_ratio = 0.3;
+  // Deprecated
   // used to identify which operators allow spill, only meaningful when enable_spill=true
   96: optional i64 spillable_operator_mask;
   // used to judge whether the profile need to report to FE, only meaningful when enable_profile=true
@@ -273,9 +298,6 @@ struct TQueryOptions {
   115: optional TTimeUnit big_query_profile_threshold_unit = TTimeUnit.SECOND;
 
   116: optional string sql_dialect;
-
-  117: optional bool enable_spill_to_remote_storage;
-  118: optional TSpillToRemoteStorageOptions spill_to_remote_storage_options;
 
   119: optional bool enable_result_sink_accumulate;
   120: optional bool enable_connector_split_io_tasks = false;


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:

lineorder is from ssb100G
```
set pipeline_dop=4;
set spill_mode="force";
select max(sm) from (select sum(lo_linenumber) sm from lineorder group by lo_orderkey)x;
```

| sv                       | bytes spilled | cost (s) | mem peak |
| ------------------------ | ------------- | -------- | -------- |
| disable spill | 0 | 6.54 | 9.268 GB |
| mem-table-size=104857600 | 1.764 GB | 16.81 | 2.098 GB |
| mem-table-size=10485760  | 1.408 GB | 15.79 | 178.480 MB |
| mem-table-size=1048576   | 2.313 GB | 33.39 | 994.145 MB |
| mem-table-size=1048576 compact=true   | 9.062 GB | 33.94 | 60.166 MB |

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
