### PR TITLE
[BugFix] fix struct prune fields on uncopy schema

### DIFF
--- a/be/src/exec/pipeline/scan/olap_chunk_source.cpp
+++ b/be/src/exec/pipeline/scan/olap_chunk_source.cpp
@@ -40,6 +40,7 @@
 #include "storage/predicate_parser.h"
 #include "storage/projection_iterator.h"
 #include "storage/storage_engine.h"
+#include "storage/tablet_index.h"
 #include "types/logical_type.h"
 #include "util/runtime_profile.h"
 
@@ -411,7 +412,8 @@ Status OlapChunkSource::_init_olap_reader(RuntimeState* runtime_state) {
         _tablet_schema =
                 TabletSchema::copy(*_tablet->tablet_schema(), _scan_node->thrift_olap_scan_node().columns_desc);
     } else {
-        _tablet_schema = _tablet->tablet_schema();
+        // struct column prune will modify fields, so deep copy a new schema
+        _tablet_schema = TabletSchema::copy(*_tablet->tablet_schema());
     }
 
     RETURN_IF_ERROR(_init_global_dicts(&_params));
@@ -419,8 +421,10 @@ Status OlapChunkSource::_init_olap_reader(RuntimeState* runtime_state) {
     RETURN_IF_ERROR(_init_scanner_columns(scanner_columns));
     RETURN_IF_ERROR(_init_reader_params(_scan_ctx->key_ranges(), scanner_columns, reader_columns));
 
+    // schema is new object, but fields not
     starrocks::Schema child_schema = ChunkHelper::convert_schema(_tablet_schema, reader_columns);
     RETURN_IF_ERROR(_init_column_access_paths(&child_schema));
+    // will modify schema field, need to copy schema
     RETURN_IF_ERROR(_prune_schema_by_access_paths(&child_schema));
 
     std::vector<RowsetSharedPtr> rowsets;


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:
https://github.com/StarRocks/starrocks/pull/43667, will modify the fields of schema when struct prune subfield.

https://github.com/StarRocks/starrocks/pull/44193, will use origin schema when fe doesn't send column desc in 3.3 version, but fe doesn't support the feature in 3.2 version

when 3.2 upgrade to 3.3, some be is 3.3 and fe is 3.2, will take crash

Fixes https://github.com/StarRocks/StarRocksTest/issues/7300

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
