### PR TITLE
[Enhancement] Fix serveral cache select use problems

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/datacache/DataCacheSelectExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/datacache/DataCacheSelectExecutor.java
@@ -23,18 +23,17 @@ import com.starrocks.qe.scheduler.Coordinator;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.sql.ast.DataCacheSelectStatement;
 import com.starrocks.sql.ast.InsertStmt;
-import com.starrocks.system.Backend;
+import com.starrocks.system.ComputeNode;
 import com.starrocks.system.SystemInfoService;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
 import java.util.Map;
-import java.util.Optional;
 
 public class DataCacheSelectExecutor {
     private static final Logger LOG = LogManager.getLogger(DataCacheSelectExecutor.class);
 
-    public static Optional<DataCacheSelectMetrics> cacheSelect(DataCacheSelectStatement statement,
+    public static DataCacheSelectMetrics cacheSelect(DataCacheSelectStatement statement,
                                                              ConnectContext connectContext) throws Exception {
         // backup original session variable
         SessionVariable sessionVariableBackup = connectContext.getSessionVariable();
@@ -67,25 +66,25 @@ public class DataCacheSelectExecutor {
         coordinator.join(connectContext.getSessionVariable().getQueryTimeoutS());
         if (coordinator.isDone()) {
             metrics = stmtExecutor.getCoordinator().getDataCacheSelectMetrics();
-            if (metrics != null) {
-                // update backend's datacache metrics after cache select
-                updateBackendDataCacheMetrics(metrics);
-            }
         }
         // set original session variable
         connectContext.setSessionVariable(sessionVariableBackup);
-        return Optional.ofNullable(metrics);
+
+        Preconditions.checkNotNull(metrics, "Failed to retrieve cache select metrics");
+        // update backend's datacache metrics after cache select
+        updateBackendDataCacheMetrics(metrics);
+        return metrics;
     }
 
     // update BE's datacache metrics after cache select
     public static void updateBackendDataCacheMetrics(DataCacheSelectMetrics metrics) {
         final SystemInfoService clusterInfoService = GlobalStateMgr.getCurrentState().getNodeMgr().getClusterInfo();
         for (Map.Entry<Long, LoadDataCacheMetrics> metric : metrics.getBeMetrics().entrySet()) {
-            Backend backend = clusterInfoService.getBackend(metric.getKey());
-            if (backend == null) {
+            ComputeNode computeNode = clusterInfoService.getBackendOrComputeNode(metric.getKey());
+            if (computeNode == null) {
                 continue;
             }
-            backend.updateDataCacheMetrics(metric.getValue().getLastDataCacheMetrics());
+            computeNode.updateDataCacheMetrics(metric.getValue().getLastDataCacheMetrics());
         }
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/qe/DDLStmtExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/DDLStmtExecutor.java
@@ -18,9 +18,7 @@ import com.google.common.base.Strings;
 import com.google.common.collect.Lists;
 import com.starrocks.analysis.FunctionName;
 import com.starrocks.analysis.ParseNode;
-import com.starrocks.catalog.Column;
 import com.starrocks.catalog.Database;
-import com.starrocks.catalog.ScalarType;
 import com.starrocks.common.AlreadyExistsException;
 import com.starrocks.common.Config;
 import com.starrocks.common.DdlException;
@@ -152,7 +150,6 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 
 public class DDLStmtExecutor {
 
@@ -1067,29 +1064,15 @@ public class DDLStmtExecutor {
 
         @Override
         public ShowResultSet visitDataCacheSelectStatement(DataCacheSelectStatement statement, ConnectContext context) {
-            Optional<DataCacheSelectMetrics> metrics = Optional.empty();
-            String errorMsg = "N/A";
+            DataCacheSelectMetrics metrics = null;
             try {
                 metrics = DataCacheSelectExecutor.cacheSelect(statement, context);
             } catch (Exception e) {
                 LOG.warn(e);
-                errorMsg = e.getMessage();
+                throw new RuntimeException(e.getMessage());
             }
 
-            if (metrics.isPresent()) {
-                return metrics.get().getShowResultSet(statement.isVerbose());
-            } else {
-                List<List<String>> rows = Lists.newArrayList();
-                List<String> row = Lists.newArrayList();
-                ShowResultSetMetaData metaData = ShowResultSetMetaData.builder()
-                        .addColumn(new Column("STATUS", ScalarType.createVarcharType()))
-                        .addColumn(new Column("ERROR_MSG", ScalarType.createVarcharType()))
-                        .build();
-                row.add("FAILED");
-                row.add(errorMsg);
-                rows.add(row);
-                return new ShowResultSet(metaData, rows);
-            }
+            return metrics.getShowResultSet(statement.isVerbose());
         }
 
         //=========================================== Dictionary Statement ==================================================

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/DataCacheSelectProcessor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/DataCacheSelectProcessor.java
@@ -20,6 +20,7 @@ import com.starrocks.datacache.DataCacheSelectExecutor;
 import com.starrocks.datacache.DataCacheSelectMetrics;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.qe.StmtExecutor;
+import com.starrocks.sql.ast.DataCacheSelectStatement;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.jetbrains.annotations.NotNull;
@@ -57,8 +58,11 @@ public class DataCacheSelectProcessor extends BaseTaskRunProcessor {
 
             // Cache select's metrics is held by sub StmtExecutor
             DataCacheSelectMetrics metrics = getDataCacheSelectMetrics(executor);
+            // update compute node or backend's metrics
             DataCacheSelectExecutor.updateBackendDataCacheMetrics(metrics);
-            context.getStatus().setExtraMessage(metrics.toString());
+            DataCacheSelectStatement dataCacheSelectStatement = (DataCacheSelectStatement) executor.getParsedStmt();
+            boolean isVerbose = dataCacheSelectStatement.isVerbose();
+            context.getStatus().setExtraMessage(metrics.debugString(isVerbose));
         } finally {
             Tracers.close();
             if (executor != null) {

--- a/fe/fe-core/src/test/java/com/starrocks/datacache/DataCacheSelectMetricsTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/datacache/DataCacheSelectMetricsTest.java
@@ -90,22 +90,30 @@ public class DataCacheSelectMetricsTest {
         dataCacheSelectMetrics.updateLoadDataCacheMetrics(cn1Id, cn1Metrics);
 
         List<List<String>> rows = dataCacheSelectMetrics.getShowResultSet(false).getResultRows();
-        Assert.assertEquals("SUCCESS,6MB,6GB,20s,50.00%", String.join(",", rows.get(0)));
+        Assert.assertEquals("6MB,6GB,20s,50.00%", String.join(",", rows.get(0)));
         rows = dataCacheSelectMetrics.getShowResultSet(true).getResultRows();
         for (List<String> row : rows) {
             if (row.get(0).equals("127.0.0.2")) {
-                Assert.assertEquals("127.0.0.2,SUCCESS,1MB,1s,1GB,10s,50.00%", String.join(",", row));
+                Assert.assertEquals("127.0.0.2,1MB,1s,1GB,10s,50.00%", String.join(",", row));
             }
             if (row.get(0).equals("127.0.0.3")) {
-                Assert.assertEquals("127.0.0.3,SUCCESS,2MB,2s,2GB,35s,50.00%", String.join(",", row));
+                Assert.assertEquals("127.0.0.3,2MB,2s,2GB,35s,50.00%", String.join(",", row));
             }
             if (row.get(0).equals("127.0.0.4")) {
-                Assert.assertEquals("127.0.0.4,SUCCESS,3MB,3s,3GB,15s,50.00%", String.join(",", row));
+                Assert.assertEquals("127.0.0.4,3MB,3s,3GB,15s,50.00%", String.join(",", row));
             }
         }
 
         Assert.assertEquals(
-                "AlreadyCachedSize: 6MB, AvgReadCacheTime: 2s, WriteCacheSize: 6GB, AvgWriteCacheTime: 20s, " +
-                        "TotalCacheUsage: 50.00%", dataCacheSelectMetrics.toString());
+                "ReadCacheSize: 6MB, AvgReadCacheTime: 2s, WriteCacheSize: 6GB, AvgWriteCacheTime: 20s, " +
+                        "TotalCacheUsage: 50.00%", dataCacheSelectMetrics.debugString(false));
+
+        Assert.assertEquals(
+                "[IP: 127.0.0.3, ReadCacheSize: 2MB, AvgReadCacheTime: 2s, WriteCacheSize: 2GB, " +
+                        "AvgWriteCacheTime: 35s, TotalCacheUsage: 50.00%], [IP: 127.0.0.2, ReadCacheSize: 1MB, " +
+                        "AvgReadCacheTime: 1s, WriteCacheSize: 1GB, AvgWriteCacheTime: 10s, TotalCacheUsage: 50.00%], " +
+                        "[IP: 127.0.0.4, ReadCacheSize: 3MB, AvgReadCacheTime: 3s, WriteCacheSize: 3GB, " +
+                        "AvgWriteCacheTime: 15s, TotalCacheUsage: 50.00%]",
+                dataCacheSelectMetrics.debugString(true));
     }
 }


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:

* Replace `ALREADY_CACHED_SIZE` to `READ_CACHE_SIZE`, `ALREADY_CACHED_SIZE` is ambiguity.
* Show verbose msg if people `submit task cache select xxx from tbl("verbose"="true")`
* Show error msg when some querys counter exception in `submit task`.
* remove `STATUS` column, it's useless, because it's always show `SUCCESS`.


## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
