### PR TITLE
[BugFix] interleaving join can't support joins with other conjuncts (backport #45117)

### DIFF
--- a/be/src/exec/join_hash_map.h
+++ b/be/src/exec/join_hash_map.h
@@ -653,7 +653,7 @@ private:
     HashTableProbeState::ProbeCoroutine _probe_from_ht(RuntimeState* state, const Buffer<CppType>& build_data,
                                                        const Buffer<CppType>& probe_data);
 
-    template <bool first_probe, bool init_match = false>
+    template <bool first_probe>
     void _probe_coroutine(RuntimeState* state, const Buffer<CppType>& build_data, const Buffer<CppType>& probe_data);
 
     // for one key left outer join

--- a/be/src/exec/join_hash_map.tpp
+++ b/be/src/exec/join_hash_map.tpp
@@ -831,7 +831,7 @@ void JoinHashMap<LT, BuildFunc, ProbeFunc>::_search_ht_remain(RuntimeState* stat
     _probe_state->count = match_count;
 }
 
-#define DO_PROBE(X, Y)                                                                                               \
+#define DO_PROBE(X)                                                                                                  \
     if (_probe_state->active_coroutines != 0) {                                                                      \
         if constexpr (first_probe) {                                                                                 \
             auto group_size = std::abs(state->query_options().interleaving_group_size);                              \
@@ -852,7 +852,7 @@ void JoinHashMap<LT, BuildFunc, ProbeFunc>::_search_ht_remain(RuntimeState* stat
             }                                                                                                        \
             _probe_state->active_coroutines = group_size;                                                            \
         }                                                                                                            \
-        _probe_coroutine<first_probe, Y>(state, build_data, data);                                                   \
+        _probe_coroutine<first_probe>(state, build_data, data);                                                      \
     } else {                                                                                                         \
         X<first_probe>(state, build_data, data);                                                                     \
     }
@@ -864,48 +864,52 @@ void JoinHashMap<LT, BuildFunc, ProbeFunc>::_search_ht_impl(RuntimeState* state,
     if (!_table_items->with_other_conjunct) {
         switch (_table_items->join_type) {
         case TJoinOp::LEFT_OUTER_JOIN:
-            DO_PROBE(_probe_from_ht_for_left_outer_join, false);
+            DO_PROBE(_probe_from_ht_for_left_outer_join);
             break;
         case TJoinOp::LEFT_SEMI_JOIN:
-            DO_PROBE(_probe_from_ht_for_left_semi_join, false);
+            DO_PROBE(_probe_from_ht_for_left_semi_join);
             break;
         case TJoinOp::LEFT_ANTI_JOIN:
         case TJoinOp::NULL_AWARE_LEFT_ANTI_JOIN:
-            DO_PROBE(_probe_from_ht_for_left_anti_join, false);
+            DO_PROBE(_probe_from_ht_for_left_anti_join);
             break;
         case TJoinOp::RIGHT_OUTER_JOIN:
-            DO_PROBE(_probe_from_ht_for_right_outer_join, false);
+            DO_PROBE(_probe_from_ht_for_right_outer_join);
             break;
         case TJoinOp::RIGHT_SEMI_JOIN:
-            DO_PROBE(_probe_from_ht_for_right_semi_join, false);
+            DO_PROBE(_probe_from_ht_for_right_semi_join);
             break;
         case TJoinOp::RIGHT_ANTI_JOIN:
-            DO_PROBE(_probe_from_ht_for_right_anti_join, false);
+            DO_PROBE(_probe_from_ht_for_right_anti_join);
             break;
         case TJoinOp::FULL_OUTER_JOIN:
-            DO_PROBE(_probe_from_ht_for_full_outer_join, false);
+            DO_PROBE(_probe_from_ht_for_full_outer_join);
             break;
         default:
-            DO_PROBE(_probe_from_ht, false);
+            DO_PROBE(_probe_from_ht);
             break;
         }
     } else {
+        // as probing results of join keys are not clustered in one chunk, `probe_match_index` and `build_match_index`
+        // are not completely right, resulting in wrong results when filtering other conjunct.
         switch (_table_items->join_type) {
         case TJoinOp::LEFT_SEMI_JOIN:
-            DO_PROBE(_probe_from_ht_for_left_semi_join_with_other_conjunct, true);
+            _probe_from_ht_for_left_semi_join_with_other_conjunct<first_probe>(state, build_data, data);
             break;
         case TJoinOp::NULL_AWARE_LEFT_ANTI_JOIN:
-            DO_PROBE(_probe_from_ht_for_null_aware_anti_join_with_other_conjunct, true);
+            _probe_from_ht_for_null_aware_anti_join_with_other_conjunct<first_probe>(state, build_data, data);
             break;
         case TJoinOp::RIGHT_OUTER_JOIN:
         case TJoinOp::RIGHT_SEMI_JOIN:
         case TJoinOp::RIGHT_ANTI_JOIN:
-            DO_PROBE(_probe_from_ht_for_right_outer_right_semi_right_anti_join_with_other_conjunct, false);
+            _probe_from_ht_for_right_outer_right_semi_right_anti_join_with_other_conjunct<first_probe>(
+                    state, build_data, data);
             break;
         case TJoinOp::LEFT_OUTER_JOIN:
         case TJoinOp::LEFT_ANTI_JOIN:
         case TJoinOp::FULL_OUTER_JOIN:
-            DO_PROBE(_probe_from_ht_for_left_outer_left_anti_full_outer_join_with_other_conjunct, true);
+            _probe_from_ht_for_left_outer_left_anti_full_outer_join_with_other_conjunct<first_probe>(state, build_data,
+                                                                                                     data);
             break;
         default:
             // can't reach here
@@ -1008,26 +1012,16 @@ void JoinHashMap<LT, BuildFunc, ProbeFunc>::_search_ht_impl(RuntimeState* state,
     match_count++;                              \
     _probe_state->cur_row_match_count++;
 
-#define MATCH_RIGHT_TABLE_ROWS_CORO()                         \
-    _probe_state->probe_index[_probe_state->match_count] = i; \
-    _probe_state->build_index[_probe_state->match_count] = j; \
-    _probe_state->probe_match_index[i]++;                     \
-    _probe_state->match_count++;                              \
-    cur_row_match_count++;
-
 /// TODO (fzh): calculate hash distribution, skew or not.
 // NOTE: coroutine only SIMD code of SSE but not AVX
 template <LogicalType LT, class BuildFunc, class ProbeFunc>
-template <bool first_probe, bool init_match>
+template <bool first_probe>
 void JoinHashMap<LT, BuildFunc, ProbeFunc>::_probe_coroutine(RuntimeState* state, const Buffer<CppType>& build_data,
                                                              const Buffer<CppType>& probe_data) {
     _probe_state->match_flag = JoinMatchFlag::NORMAL;
     _probe_state->match_count = 0;
     _probe_state->cur_row_match_count = 0;
     _probe_state->count = 0;
-    if constexpr (first_probe && init_match) {
-        _probe_state->probe_match_index.assign(state->chunk_size(), 0);
-    }
     // disorder probe id as matching steps are different for each probe
     while (!_probe_state->handles.empty()) {
         for (auto it = _probe_state->handles.begin(); it != _probe_state->handles.end();) {
@@ -1895,87 +1889,6 @@ void JoinHashMap<LT, BuildFunc, ProbeFunc>::_probe_from_ht_for_null_aware_anti_j
 }
 
 template <LogicalType LT, class BuildFunc, class ProbeFunc>
-HashTableProbeState::ProbeCoroutine
-JoinHashMap<LT, BuildFunc, ProbeFunc>::_probe_from_ht_for_null_aware_anti_join_with_other_conjunct(
-        RuntimeState* state, const Buffer<CppType>& build_data, const Buffer<CppType>& probe_data) {
-    for (size_t i = _probe_state->cur_probe_index++; i < _probe_state->probe_row_count;
-         i = _probe_state->cur_probe_index++) {
-        size_t build_index = _probe_state->next[i];
-        int cur_row_match_count = 0;
-        if (build_index == 0) {
-            bool change_flag = false;
-            if (_probe_state->null_array != nullptr && (*_probe_state->null_array)[i] == 1) {
-                // when left table col value is null needs match all rows in right table
-                for (size_t j = 1; j < _table_items->row_count + 1; j++) {
-                    change_flag = true;
-                    COWAIT_IF_CHUNK_FULL()
-                    MATCH_RIGHT_TABLE_ROWS_CORO()
-                }
-            } else if (_table_items->key_columns[0]->is_nullable()) {
-                // when left table col value not hits in hash table needs match all null value rows in right table
-                auto* nullable_column = ColumnHelper::as_raw_column<NullableColumn>(_table_items->key_columns[0]);
-                auto& null_array = nullable_column->null_column()->get_data();
-                for (size_t j = 1; j < _table_items->row_count + 1; j++) {
-                    if (null_array[j] == 1) {
-                        change_flag = true;
-                        COWAIT_IF_CHUNK_FULL()
-                        MATCH_RIGHT_TABLE_ROWS_CORO()
-                    }
-                }
-            }
-
-            if (!change_flag) {
-                COWAIT_IF_CHUNK_FULL()
-                _probe_state->probe_index[_probe_state->match_count] = i;
-                _probe_state->build_index[_probe_state->match_count] = 0;
-                _probe_state->match_count++;
-            }
-            continue;
-        } else {
-            // left table col value hits in hash table, we also need match null values firstly then match hit rows.
-            if (_table_items->key_columns[0]->is_nullable()) {
-                auto* nullable_column = ColumnHelper::as_raw_column<NullableColumn>(_table_items->key_columns[0]);
-                auto& null_array = nullable_column->null_column()->get_data();
-                for (size_t j = 1; j < _table_items->row_count + 1; j++) {
-                    if (null_array[j] == 1) {
-                        COWAIT_IF_CHUNK_FULL()
-                        MATCH_RIGHT_TABLE_ROWS_CORO()
-                    }
-                }
-            }
-        }
-
-        while (build_index != 0) {
-            PREFETCH_AND_COWAIT((build_data.data() + build_index), (_table_items->next.data() + build_index))
-            if (ProbeFunc().equal(build_data[build_index], probe_data[i])) {
-                COWAIT_IF_CHUNK_FULL()
-                _probe_state->probe_index[_probe_state->match_count] = i;
-                _probe_state->build_index[_probe_state->match_count] = build_index;
-                _probe_state->probe_match_index[i]++;
-                _probe_state->match_count++;
-                cur_row_match_count++;
-            }
-            build_index = _table_items->next[build_index];
-        }
-
-        if (cur_row_match_count <= 0) {
-            COWAIT_IF_CHUNK_FULL()
-            _probe_state->probe_index[_probe_state->match_count] = i;
-            _probe_state->build_index[_probe_state->match_count] = 0;
-            _probe_state->match_count++;
-        }
-    }
-
-    if (--_probe_state->active_coroutines > 0) {
-        co_return;
-    }
-    // only the last coroutine does
-    _probe_state->has_null_build_tuple = true;
-    auto match_count = _probe_state->match_count;
-    PROBE_OVER()
-}
-
-template <LogicalType LT, class BuildFunc, class ProbeFunc>
 template <bool first_probe>
 void JoinHashMap<LT, BuildFunc, ProbeFunc>::
         _probe_from_ht_for_right_outer_right_semi_right_anti_join_with_other_conjunct(
@@ -2004,37 +1917,6 @@ void JoinHashMap<LT, BuildFunc, ProbeFunc>::
         }
     }
 
-    PROBE_OVER()
-}
-
-template <LogicalType LT, class BuildFunc, class ProbeFunc>
-HashTableProbeState::ProbeCoroutine
-JoinHashMap<LT, BuildFunc, ProbeFunc>::_probe_from_ht_for_right_outer_right_semi_right_anti_join_with_other_conjunct(
-        RuntimeState* state, const Buffer<CppType>& build_data, const Buffer<CppType>& probe_data) {
-    for (size_t i = _probe_state->cur_probe_index++; i < _probe_state->probe_row_count;
-         i = _probe_state->cur_probe_index++) {
-        size_t build_index = _probe_state->next[i];
-        if (build_index == 0) {
-            continue;
-        }
-
-        while (build_index != 0) {
-            PREFETCH_AND_COWAIT((build_data.data() + build_index), (_table_items->next.data() + build_index))
-            if (ProbeFunc().equal(build_data[build_index], probe_data[i])) {
-                COWAIT_IF_CHUNK_FULL()
-                _probe_state->probe_index[_probe_state->match_count] = i;
-                _probe_state->build_index[_probe_state->match_count] = build_index;
-                _probe_state->match_count++;
-            }
-            build_index = _table_items->next[build_index];
-        }
-    }
-
-    if (--_probe_state->active_coroutines > 0) {
-        co_return;
-    }
-    // only the last coroutine does
-    auto match_count = _probe_state->match_count;
     PROBE_OVER()
 }
 
@@ -2092,46 +1974,7 @@ void JoinHashMap<LT, BuildFunc, ProbeFunc>::_probe_from_ht_for_left_outer_left_a
         }
         _probe_state->cur_row_match_count = 0;
     }
-
     _probe_state->has_null_build_tuple = true;
-    PROBE_OVER()
-}
-
-template <LogicalType LT, class BuildFunc, class ProbeFunc>
-HashTableProbeState::ProbeCoroutine
-JoinHashMap<LT, BuildFunc, ProbeFunc>::_probe_from_ht_for_left_outer_left_anti_full_outer_join_with_other_conjunct(
-        RuntimeState* state, const Buffer<CppType>& build_data, const Buffer<CppType>& probe_data) {
-    for (size_t i = _probe_state->cur_probe_index++; i < _probe_state->probe_row_count;
-         i = _probe_state->cur_probe_index++) {
-        size_t build_index = _probe_state->next[i];
-        int cur_row_match_count = 0;
-
-        while (build_index != 0) {
-            PREFETCH_AND_COWAIT((build_data.data() + build_index), (_table_items->next.data() + build_index))
-            if (ProbeFunc().equal(build_data[build_index], probe_data[i])) {
-                COWAIT_IF_CHUNK_FULL()
-                _probe_state->probe_index[_probe_state->match_count] = i;
-                _probe_state->build_index[_probe_state->match_count] = build_index;
-                _probe_state->probe_match_index[i]++;
-                _probe_state->match_count++;
-                cur_row_match_count++;
-            }
-            build_index = _table_items->next[build_index];
-        }
-        if (cur_row_match_count <= 0) {
-            COWAIT_IF_CHUNK_FULL()
-            _probe_state->probe_index[_probe_state->match_count] = i;
-            _probe_state->build_index[_probe_state->match_count] = 0;
-            _probe_state->match_count++;
-        }
-    }
-
-    if (--_probe_state->active_coroutines > 0) {
-        co_return;
-    }
-    // only the last coroutine does
-    _probe_state->has_null_build_tuple = true;
-    auto match_count = _probe_state->match_count;
     PROBE_OVER()
 }
 

--- a/be/test/exec/join_hash_map_test.cpp
+++ b/be/test/exec/join_hash_map_test.cpp
@@ -1735,8 +1735,6 @@ TEST_F(JoinHashMapTest, ProbeFromHtForLeftJoinNextEmptyMore) {
     this->prepare_probe_state(&probe_state, probe_row_count);
     this->prepare_probe_data(&probe_data, probe_row_count);
 
-    auto& runtime_state = _runtime_state;
-
     auto join_hash_map = std::make_unique<JoinHashMapForOneKey(TYPE_INT)>(&table_items, &probe_state);
     join_hash_map->_probe_from_ht_for_left_outer_left_anti_full_outer_join_with_other_conjunct<true>(
             _runtime_state.get(), build_data, probe_data);
@@ -1825,8 +1823,6 @@ TEST_F(JoinHashMapTest, ProbeFromHtForRightXXXJoinWithOtherConjunctMore) {
         this->prepare_build_data(&build_data, match_count);
         this->prepare_probe_state(&probe_state, probe_row_count);
         this->prepare_probe_data(&probe_data, probe_row_count);
-
-        auto& runtime_state = _runtime_state;
 
         auto join_hash_map = std::make_unique<JoinHashMapForOneKey(TYPE_INT)>(&table_items, &probe_state);
         join_hash_map->_probe_from_ht_for_right_outer_right_semi_right_anti_join_with_other_conjunct<true>(

--- a/be/test/exec/join_hash_map_test.cpp
+++ b/be/test/exec/join_hash_map_test.cpp
@@ -1438,7 +1438,7 @@ TEST_F(JoinHashMapTest, SerializedJoinBuildProbeFuncNullable) {
                 probe_state.handles.insert(join_hash_map->FUNC(runtime_state.get(), build_data, probe_data)); \
             }                                                                                                 \
             probe_state.active_coroutines = group;                                                            \
-            join_hash_map->_probe_coroutine<FIRST, INIT>(runtime_state.get(), build_data, probe_data);        \
+            join_hash_map->_probe_coroutine<FIRST>(runtime_state.get(), build_data, probe_data);              \
             sort_results_from_coroutine(probe_state.probe_index, probe_state.build_index, probe_state.count); \
         }
 
@@ -1446,7 +1446,7 @@ TEST_F(JoinHashMapTest, SerializedJoinBuildProbeFuncNullable) {
     if (group == 0) {                                                                                     \
         join_hash_map->FUNC<false>(runtime_state.get(), build_data, probe_data);                          \
     } else {                                                                                              \
-        join_hash_map->_probe_coroutine<false, false>(runtime_state.get(), build_data, probe_data);       \
+        join_hash_map->_probe_coroutine<false>(runtime_state.get(), build_data, probe_data);              \
         sort_results_from_coroutine(probe_state.probe_index, probe_state.build_index, probe_state.count); \
     }
 
@@ -1721,7 +1721,7 @@ TEST_F(JoinHashMapTest, ProbeFromHtForLeftJoinNextEmpty) {
 }
 
 // NOLINTNEXTLINE
-TEST_F(JoinHashMapTest, ProbeFromHtForLeftJoinNextEmptyCoro) {
+TEST_F(JoinHashMapTest, ProbeFromHtForLeftJoinNextEmptyMore) {
     JoinHashTableItems table_items;
     HashTableProbeState probe_state;
     Buffer<int32_t> build_data;
@@ -1738,7 +1738,8 @@ TEST_F(JoinHashMapTest, ProbeFromHtForLeftJoinNextEmptyCoro) {
     auto& runtime_state = _runtime_state;
 
     auto join_hash_map = std::make_unique<JoinHashMapForOneKey(TYPE_INT)>(&table_items, &probe_state);
-    DO_TEST_PROBE(_probe_from_ht_for_left_outer_left_anti_full_outer_join_with_other_conjunct, true, true)
+    join_hash_map->_probe_from_ht_for_left_outer_left_anti_full_outer_join_with_other_conjunct<true>(
+            _runtime_state.get(), build_data, probe_data);
     std::vector<std::pair<uint32_t, uint32_t>> results;
     ASSERT_EQ(probe_state.match_flag, JoinMatchFlag::NORMAL);
     ASSERT_EQ(probe_state.count, 4096);
@@ -1747,7 +1748,8 @@ TEST_F(JoinHashMapTest, ProbeFromHtForLeftJoinNextEmptyCoro) {
         results.push_back(std::make_pair(probe_state.probe_index[i], probe_state.build_index[i]));
     }
 
-    DO_TEST_PROBE_MID(_probe_from_ht_for_left_outer_left_anti_full_outer_join_with_other_conjunct)
+    join_hash_map->_probe_from_ht_for_left_outer_left_anti_full_outer_join_with_other_conjunct<false>(
+            _runtime_state.get(), build_data, probe_data);
     ASSERT_EQ(probe_state.match_flag, JoinMatchFlag::NORMAL);
     ASSERT_FALSE(probe_state.has_remain);
     ASSERT_EQ(probe_state.count, 1904);
@@ -1770,7 +1772,6 @@ TEST_F(JoinHashMapTest, ProbeFromHtForLeftJoinNextEmptyCoro) {
         ASSERT_EQ(results[3 * i + 2].second, i + 1);
         ASSERT_EQ(match_count, probe_state.probe_match_index[i]);
     }
-    DO_TEST_PROBE_END()
 }
 
 // Test case for right semi join with other conjunct.
@@ -1810,7 +1811,7 @@ TEST_F(JoinHashMapTest, ProbeFromHtForRightXXXJoinWithOtherConjunct) {
     }
 }
 
-TEST_F(JoinHashMapTest, ProbeFromHtForRightXXXJoinWithOtherConjunctCoro) {
+TEST_F(JoinHashMapTest, ProbeFromHtForRightXXXJoinWithOtherConjunctMore) {
     for (auto& join_type : {TJoinOp::RIGHT_SEMI_JOIN, TJoinOp::RIGHT_OUTER_JOIN, TJoinOp::RIGHT_ANTI_JOIN}) {
         JoinHashTableItems table_items;
         HashTableProbeState probe_state;
@@ -1828,7 +1829,8 @@ TEST_F(JoinHashMapTest, ProbeFromHtForRightXXXJoinWithOtherConjunctCoro) {
         auto& runtime_state = _runtime_state;
 
         auto join_hash_map = std::make_unique<JoinHashMapForOneKey(TYPE_INT)>(&table_items, &probe_state);
-        DO_TEST_PROBE(_probe_from_ht_for_right_outer_right_semi_right_anti_join_with_other_conjunct, true, true)
+        join_hash_map->_probe_from_ht_for_right_outer_right_semi_right_anti_join_with_other_conjunct<true>(
+                _runtime_state.get(), build_data, probe_data);
         std::vector<std::pair<uint32_t, uint32_t>> results;
         ASSERT_EQ(probe_state.match_flag, JoinMatchFlag::NORMAL);
         ASSERT_EQ(probe_state.count, 4096);
@@ -1837,7 +1839,8 @@ TEST_F(JoinHashMapTest, ProbeFromHtForRightXXXJoinWithOtherConjunctCoro) {
             results.push_back(std::make_pair(probe_state.probe_index[i], probe_state.build_index[i]));
         }
 
-        DO_TEST_PROBE_MID(_probe_from_ht_for_right_outer_right_semi_right_anti_join_with_other_conjunct)
+        join_hash_map->_probe_from_ht_for_right_outer_right_semi_right_anti_join_with_other_conjunct<false>(
+                _runtime_state.get(), build_data, probe_data);
         ASSERT_EQ(probe_state.match_flag, JoinMatchFlag::NORMAL);
         ASSERT_FALSE(probe_state.has_remain);
         ASSERT_EQ(probe_state.count, 1904);
@@ -1859,7 +1862,6 @@ TEST_F(JoinHashMapTest, ProbeFromHtForRightXXXJoinWithOtherConjunctCoro) {
             ASSERT_EQ(results[3 * i + 2].first, i);
             ASSERT_EQ(results[3 * i + 2].second, i + 1);
         }
-        DO_TEST_PROBE_END()
     }
 }
 

--- a/test/sql/test_join/R/test_interleaving_join
+++ b/test/sql/test_join/R/test_interleaving_join
@@ -1,0 +1,483 @@
+-- name: test interleaving join
+CREATE TABLE `lineitem` (
+  `l_orderkey` int(11) NOT NULL COMMENT "",
+  `l_partkey` int(11) NOT NULL COMMENT "",
+  `l_suppkey` int(11)
+) ENGINE=OLAP
+DUPLICATE KEY(`l_orderkey`)
+COMMENT "OLAP"
+DISTRIBUTED BY HASH(`l_orderkey`) BUCKETS 1
+PROPERTIES (
+"compression" = "LZ4",
+"fast_schema_evolution" = "true",
+"replicated_storage" = "true",
+"replication_num" = "1"
+);
+-- result:
+-- !result
+insert into lineitem values (1,1,1),(1,2,1),(1,3,2),(11,1,11),(11,2,1),(2,3,2),(2,3,null);
+-- result:
+-- !result
+set pipeline_dop = 1;
+-- result:
+-- !result
+set chunk_size = 2;
+-- result:
+-- !result
+set interleaving_group_size =0;
+-- result:
+-- !result
+select count(*) as c from lineitem l1  join lineitem l3 on l3.l_orderkey = l1.l_orderkey and l3.l_suppkey <> l1.l_suppkey;
+-- result:
+6
+-- !result
+set interleaving_group_size =-10;
+-- result:
+-- !result
+select count(*) as c from lineitem l1  join lineitem l3 on l3.l_orderkey = l1.l_orderkey and l3.l_suppkey <> l1.l_suppkey;
+-- result:
+6
+-- !result
+set interleaving_group_size =0;
+-- result:
+-- !result
+select count(*) as c from lineitem l1 left join lineitem l3 on l3.l_orderkey = l1.l_orderkey and l3.l_suppkey <> l1.l_suppkey;
+-- result:
+8
+-- !result
+set interleaving_group_size =-10;
+-- result:
+-- !result
+select count(*) as c from lineitem l1 left join lineitem l3 on l3.l_orderkey = l1.l_orderkey and l3.l_suppkey <> l1.l_suppkey;
+-- result:
+8
+-- !result
+set interleaving_group_size =0;
+-- result:
+-- !result
+select count(*) as c from lineitem l1 where not exists ( select * from lineitem l3 where l3.l_orderkey = l1.l_orderkey and l3.l_suppkey <> l1.l_suppkey );
+-- result:
+2
+-- !result
+set interleaving_group_size =-10;
+-- result:
+-- !result
+select count(*) as c from lineitem l1 where not exists ( select * from lineitem l3 where l3.l_orderkey = l1.l_orderkey and l3.l_suppkey <> l1.l_suppkey );
+-- result:
+2
+-- !result
+set interleaving_group_size =0;
+-- result:
+-- !result
+select count(*) as c from lineitem l1 where l1.l_orderkey not in ( select l3.l_orderkey from lineitem l3 where  l3.l_suppkey <> l1.l_suppkey );
+-- result:
+3
+-- !result
+set interleaving_group_size =-10;
+-- result:
+-- !result
+select count(*) as c from lineitem l1 where l1.l_orderkey not in ( select l3.l_orderkey from lineitem l3 where  l3.l_suppkey <> l1.l_suppkey );
+-- result:
+3
+-- !result
+set interleaving_group_size =0;
+-- result:
+-- !result
+select count(*) as c from lineitem l1 where exists ( select * from lineitem l3 where l3.l_orderkey = l1.l_orderkey and l3.l_suppkey <> l1.l_suppkey );
+-- result:
+5
+-- !result
+set interleaving_group_size =-10;
+-- result:
+-- !result
+select count(*) as c from lineitem l1 where exists ( select * from lineitem l3 where l3.l_orderkey = l1.l_orderkey and l3.l_suppkey <> l1.l_suppkey );
+-- result:
+5
+-- !result
+set interleaving_group_size =0;
+-- result:
+-- !result
+select count(*) as c from lineitem l1 where l1.l_orderkey in ( select l3.l_orderkey from lineitem l3 where  l3.l_suppkey <> l1.l_suppkey );
+-- result:
+5
+-- !result
+set interleaving_group_size =-10;
+-- result:
+-- !result
+select count(*) as c from lineitem l1 where l1.l_orderkey in ( select l3.l_orderkey from lineitem l3 where  l3.l_suppkey <> l1.l_suppkey );
+-- result:
+5
+-- !result
+set interleaving_group_size =0;
+-- result:
+-- !result
+select count(*) as c from lineitem l1 right join lineitem l3 on l3.l_orderkey = l1.l_orderkey and l3.l_suppkey <> l1.l_suppkey;
+-- result:
+8
+-- !result
+set interleaving_group_size =-10;
+-- result:
+-- !result
+select count(*) as c from lineitem l1 right join lineitem l3 on l3.l_orderkey = l1.l_orderkey and l3.l_suppkey <> l1.l_suppkey;
+-- result:
+8
+-- !result
+set interleaving_group_size =0;
+-- result:
+-- !result
+select count(*) as c from lineitem l1 full outer join lineitem l3 on l3.l_orderkey = l1.l_orderkey and l3.l_suppkey <> l1.l_suppkey;
+-- result:
+10
+-- !result
+set interleaving_group_size =-10;
+-- result:
+-- !result
+select count(*) as c from lineitem l1 full outer join lineitem l3 on l3.l_orderkey = l1.l_orderkey and l3.l_suppkey <> l1.l_suppkey;
+-- result:
+10
+-- !result
+set chunk_size = 3;
+-- result:
+-- !result
+set interleaving_group_size =0;
+-- result:
+-- !result
+select count(*) as c from lineitem l1  join lineitem l3 on l3.l_orderkey = l1.l_orderkey and l3.l_suppkey <> l1.l_suppkey;
+-- result:
+6
+-- !result
+set interleaving_group_size =-10;
+-- result:
+-- !result
+select count(*) as c from lineitem l1  join lineitem l3 on l3.l_orderkey = l1.l_orderkey and l3.l_suppkey <> l1.l_suppkey;
+-- result:
+6
+-- !result
+set interleaving_group_size =0;
+-- result:
+-- !result
+select count(*) as c from lineitem l1 left join lineitem l3 on l3.l_orderkey = l1.l_orderkey and l3.l_suppkey <> l1.l_suppkey;
+-- result:
+8
+-- !result
+set interleaving_group_size =-10;
+-- result:
+-- !result
+select count(*) as c from lineitem l1 left join lineitem l3 on l3.l_orderkey = l1.l_orderkey and l3.l_suppkey <> l1.l_suppkey;
+-- result:
+8
+-- !result
+set interleaving_group_size =0;
+-- result:
+-- !result
+select count(*) as c from lineitem l1 where not exists ( select * from lineitem l3 where l3.l_orderkey = l1.l_orderkey and l3.l_suppkey <> l1.l_suppkey );
+-- result:
+2
+-- !result
+set interleaving_group_size =-10;
+-- result:
+-- !result
+select count(*) as c from lineitem l1 where not exists ( select * from lineitem l3 where l3.l_orderkey = l1.l_orderkey and l3.l_suppkey <> l1.l_suppkey );
+-- result:
+2
+-- !result
+set interleaving_group_size =0;
+-- result:
+-- !result
+select count(*) as c from lineitem l1 where l1.l_orderkey not in ( select l3.l_orderkey from lineitem l3 where  l3.l_suppkey <> l1.l_suppkey );
+-- result:
+3
+-- !result
+set interleaving_group_size =-10;
+-- result:
+-- !result
+select count(*) as c from lineitem l1 where l1.l_orderkey not in ( select l3.l_orderkey from lineitem l3 where  l3.l_suppkey <> l1.l_suppkey );
+-- result:
+3
+-- !result
+set interleaving_group_size =0;
+-- result:
+-- !result
+select count(*) as c from lineitem l1 where exists ( select * from lineitem l3 where l3.l_orderkey = l1.l_orderkey and l3.l_suppkey <> l1.l_suppkey );
+-- result:
+5
+-- !result
+set interleaving_group_size =-10;
+-- result:
+-- !result
+select count(*) as c from lineitem l1 where exists ( select * from lineitem l3 where l3.l_orderkey = l1.l_orderkey and l3.l_suppkey <> l1.l_suppkey );
+-- result:
+5
+-- !result
+set interleaving_group_size =0;
+-- result:
+-- !result
+select count(*) as c from lineitem l1 where l1.l_orderkey in ( select l3.l_orderkey from lineitem l3 where  l3.l_suppkey <> l1.l_suppkey );
+-- result:
+5
+-- !result
+set interleaving_group_size =-10;
+-- result:
+-- !result
+select count(*) as c from lineitem l1 where l1.l_orderkey in ( select l3.l_orderkey from lineitem l3 where  l3.l_suppkey <> l1.l_suppkey );
+-- result:
+5
+-- !result
+set interleaving_group_size =0;
+-- result:
+-- !result
+select count(*) as c from lineitem l1 right join lineitem l3 on l3.l_orderkey = l1.l_orderkey and l3.l_suppkey <> l1.l_suppkey;
+-- result:
+8
+-- !result
+set interleaving_group_size =-10;
+-- result:
+-- !result
+select count(*) as c from lineitem l1 right join lineitem l3 on l3.l_orderkey = l1.l_orderkey and l3.l_suppkey <> l1.l_suppkey;
+-- result:
+8
+-- !result
+set interleaving_group_size =0;
+-- result:
+-- !result
+select count(*) as c from lineitem l1 full outer join lineitem l3 on l3.l_orderkey = l1.l_orderkey and l3.l_suppkey <> l1.l_suppkey;
+-- result:
+10
+-- !result
+set interleaving_group_size =-10;
+-- result:
+-- !result
+select count(*) as c from lineitem l1 full outer join lineitem l3 on l3.l_orderkey = l1.l_orderkey and l3.l_suppkey <> l1.l_suppkey;
+-- result:
+10
+-- !result
+set chunk_size = 2;
+-- result:
+-- !result
+set interleaving_group_size =0;
+-- result:
+-- !result
+select count(*) as c from lineitem l1  join lineitem l3 on l3.l_orderkey = l1.l_orderkey and l3.l_suppkey = l1.l_suppkey;
+-- result:
+8
+-- !result
+set interleaving_group_size =-10;
+-- result:
+-- !result
+select count(*) as c from lineitem l1  join lineitem l3 on l3.l_orderkey = l1.l_orderkey and l3.l_suppkey = l1.l_suppkey;
+-- result:
+8
+-- !result
+set interleaving_group_size =0;
+-- result:
+-- !result
+select count(*) as c from lineitem l1 left join lineitem l3 on l3.l_orderkey = l1.l_orderkey and l3.l_suppkey = l1.l_suppkey;
+-- result:
+9
+-- !result
+set interleaving_group_size =-10;
+-- result:
+-- !result
+select count(*) as c from lineitem l1 left join lineitem l3 on l3.l_orderkey = l1.l_orderkey and l3.l_suppkey = l1.l_suppkey;
+-- result:
+9
+-- !result
+set interleaving_group_size =0;
+-- result:
+-- !result
+select count(*) as c from lineitem l1 where not exists ( select * from lineitem l3 where l3.l_orderkey = l1.l_orderkey and l3.l_suppkey = l1.l_suppkey );
+-- result:
+1
+-- !result
+set interleaving_group_size =-10;
+-- result:
+-- !result
+select count(*) as c from lineitem l1 where not exists ( select * from lineitem l3 where l3.l_orderkey = l1.l_orderkey and l3.l_suppkey = l1.l_suppkey );
+-- result:
+1
+-- !result
+set interleaving_group_size =0;
+-- result:
+-- !result
+select count(*) as c from lineitem l1 where l1.l_orderkey not in ( select l3.l_orderkey from lineitem l3 where  l3.l_suppkey <> l1.l_suppkey );
+-- result:
+3
+-- !result
+set interleaving_group_size =-10;
+-- result:
+-- !result
+select count(*) as c from lineitem l1 where l1.l_orderkey not in ( select l3.l_orderkey from lineitem l3 where  l3.l_suppkey <> l1.l_suppkey );
+-- result:
+3
+-- !result
+set interleaving_group_size =0;
+-- result:
+-- !result
+select count(*) as c from lineitem l1 where exists ( select * from lineitem l3 where l3.l_orderkey = l1.l_orderkey and l3.l_suppkey = l1.l_suppkey );
+-- result:
+6
+-- !result
+set interleaving_group_size =-10;
+-- result:
+-- !result
+select count(*) as c from lineitem l1 where exists ( select * from lineitem l3 where l3.l_orderkey = l1.l_orderkey and l3.l_suppkey = l1.l_suppkey );
+-- result:
+6
+-- !result
+set interleaving_group_size =0;
+-- result:
+-- !result
+select count(*) as c from lineitem l1 where l1.l_orderkey in ( select l3.l_orderkey from lineitem l3 where  l3.l_suppkey <> l1.l_suppkey );
+-- result:
+5
+-- !result
+set interleaving_group_size =-10;
+-- result:
+-- !result
+select count(*) as c from lineitem l1 where l1.l_orderkey in ( select l3.l_orderkey from lineitem l3 where  l3.l_suppkey <> l1.l_suppkey );
+-- result:
+5
+-- !result
+set interleaving_group_size =0;
+-- result:
+-- !result
+select count(*) as c from lineitem l1 right join lineitem l3 on l3.l_orderkey = l1.l_orderkey and l3.l_suppkey = l1.l_suppkey;
+-- result:
+9
+-- !result
+set interleaving_group_size =-10;
+-- result:
+-- !result
+select count(*) as c from lineitem l1 right join lineitem l3 on l3.l_orderkey = l1.l_orderkey and l3.l_suppkey = l1.l_suppkey;
+-- result:
+9
+-- !result
+set interleaving_group_size =0;
+-- result:
+-- !result
+select count(*) as c from lineitem l1 full outer join lineitem l3 on l3.l_orderkey = l1.l_orderkey and l3.l_suppkey = l1.l_suppkey;
+-- result:
+10
+-- !result
+set interleaving_group_size =-10;
+-- result:
+-- !result
+select count(*) as c from lineitem l1 full outer join lineitem l3 on l3.l_orderkey = l1.l_orderkey and l3.l_suppkey = l1.l_suppkey;
+-- result:
+10
+-- !result
+set chunk_size = 3;
+-- result:
+-- !result
+set interleaving_group_size =0;
+-- result:
+-- !result
+select count(*) as c from lineitem l1  join lineitem l3 on l3.l_orderkey = l1.l_orderkey and l3.l_suppkey = l1.l_suppkey;
+-- result:
+8
+-- !result
+set interleaving_group_size =-10;
+-- result:
+-- !result
+select count(*) as c from lineitem l1  join lineitem l3 on l3.l_orderkey = l1.l_orderkey and l3.l_suppkey = l1.l_suppkey;
+-- result:
+8
+-- !result
+set interleaving_group_size =0;
+-- result:
+-- !result
+select count(*) as c from lineitem l1 left join lineitem l3 on l3.l_orderkey = l1.l_orderkey and l3.l_suppkey = l1.l_suppkey;
+-- result:
+9
+-- !result
+set interleaving_group_size =-10;
+-- result:
+-- !result
+select count(*) as c from lineitem l1 left join lineitem l3 on l3.l_orderkey = l1.l_orderkey and l3.l_suppkey = l1.l_suppkey;
+-- result:
+9
+-- !result
+set interleaving_group_size =0;
+-- result:
+-- !result
+select count(*) as c from lineitem l1 where not exists ( select * from lineitem l3 where l3.l_orderkey = l1.l_orderkey and l3.l_suppkey = l1.l_suppkey );
+-- result:
+1
+-- !result
+set interleaving_group_size =-10;
+-- result:
+-- !result
+select count(*) as c from lineitem l1 where not exists ( select * from lineitem l3 where l3.l_orderkey = l1.l_orderkey and l3.l_suppkey = l1.l_suppkey );
+-- result:
+1
+-- !result
+set interleaving_group_size =0;
+-- result:
+-- !result
+select count(*) as c from lineitem l1 where l1.l_orderkey not in ( select l3.l_orderkey from lineitem l3 where  l3.l_suppkey <> l1.l_suppkey );
+-- result:
+3
+-- !result
+set interleaving_group_size =-10;
+-- result:
+-- !result
+select count(*) as c from lineitem l1 where l1.l_orderkey not in ( select l3.l_orderkey from lineitem l3 where  l3.l_suppkey <> l1.l_suppkey );
+-- result:
+3
+-- !result
+set interleaving_group_size =0;
+-- result:
+-- !result
+select count(*) as c from lineitem l1 where exists ( select * from lineitem l3 where l3.l_orderkey = l1.l_orderkey and l3.l_suppkey = l1.l_suppkey );
+-- result:
+6
+-- !result
+set interleaving_group_size =-10;
+-- result:
+-- !result
+select count(*) as c from lineitem l1 where exists ( select * from lineitem l3 where l3.l_orderkey = l1.l_orderkey and l3.l_suppkey = l1.l_suppkey );
+-- result:
+6
+-- !result
+set interleaving_group_size =0;
+-- result:
+-- !result
+select count(*) as c from lineitem l1 where l1.l_orderkey in ( select l3.l_orderkey from lineitem l3 where  l3.l_suppkey <> l1.l_suppkey );
+-- result:
+5
+-- !result
+set interleaving_group_size =-10;
+-- result:
+-- !result
+select count(*) as c from lineitem l1 where l1.l_orderkey in ( select l3.l_orderkey from lineitem l3 where  l3.l_suppkey <> l1.l_suppkey );
+-- result:
+5
+-- !result
+set interleaving_group_size =0;
+-- result:
+-- !result
+select count(*) as c from lineitem l1 right join lineitem l3 on l3.l_orderkey = l1.l_orderkey and l3.l_suppkey = l1.l_suppkey;
+-- result:
+9
+-- !result
+set interleaving_group_size =-10;
+-- result:
+-- !result
+select count(*) as c from lineitem l1 right join lineitem l3 on l3.l_orderkey = l1.l_orderkey and l3.l_suppkey = l1.l_suppkey;
+-- result:
+9
+-- !result
+set interleaving_group_size =0;
+-- result:
+-- !result
+select count(*) as c from lineitem l1 full outer join lineitem l3 on l3.l_orderkey = l1.l_orderkey and l3.l_suppkey = l1.l_suppkey;
+-- result:
+10
+-- !result
+set interleaving_group_size =-10;
+-- result:
+-- !result
+select count(*) as c from lineitem l1 full outer join lineitem l3 on l3.l_orderkey = l1.l_orderkey and l3.l_suppkey = l1.l_suppkey;
+-- result:
+10
+-- !result

--- a/test/sql/test_join/T/test_interleaving_join
+++ b/test/sql/test_join/T/test_interleaving_join
@@ -1,0 +1,180 @@
+-- name: test interleaving join
+CREATE TABLE `lineitem` (
+  `l_orderkey` int(11) NOT NULL COMMENT "",
+  `l_partkey` int(11) NOT NULL COMMENT "",
+  `l_suppkey` int(11)
+) ENGINE=OLAP
+DUPLICATE KEY(`l_orderkey`)
+COMMENT "OLAP"
+DISTRIBUTED BY HASH(`l_orderkey`) BUCKETS 1
+PROPERTIES (
+"compression" = "LZ4",
+"fast_schema_evolution" = "true",
+"replicated_storage" = "true",
+"replication_num" = "1"
+);
+
+insert into lineitem values (1,1,1),(1,2,1),(1,3,2),(11,1,11),(11,2,1),(2,3,2),(2,3,null);
+set pipeline_dop = 1;
+---- join with other conjunct
+set chunk_size = 2;
+set interleaving_group_size =0;
+select count(*) as c from lineitem l1  join lineitem l3 on l3.l_orderkey = l1.l_orderkey and l3.l_suppkey <> l1.l_suppkey;
+set interleaving_group_size =-10;
+select count(*) as c from lineitem l1  join lineitem l3 on l3.l_orderkey = l1.l_orderkey and l3.l_suppkey <> l1.l_suppkey;
+
+set interleaving_group_size =0;
+select count(*) as c from lineitem l1 left join lineitem l3 on l3.l_orderkey = l1.l_orderkey and l3.l_suppkey <> l1.l_suppkey;
+set interleaving_group_size =-10;
+select count(*) as c from lineitem l1 left join lineitem l3 on l3.l_orderkey = l1.l_orderkey and l3.l_suppkey <> l1.l_suppkey;
+set interleaving_group_size =0;
+select count(*) as c from lineitem l1 where not exists ( select * from lineitem l3 where l3.l_orderkey = l1.l_orderkey and l3.l_suppkey <> l1.l_suppkey );
+set interleaving_group_size =-10;
+select count(*) as c from lineitem l1 where not exists ( select * from lineitem l3 where l3.l_orderkey = l1.l_orderkey and l3.l_suppkey <> l1.l_suppkey );
+
+set interleaving_group_size =0;
+select count(*) as c from lineitem l1 where l1.l_orderkey not in ( select l3.l_orderkey from lineitem l3 where  l3.l_suppkey <> l1.l_suppkey );
+set interleaving_group_size =-10;
+select count(*) as c from lineitem l1 where l1.l_orderkey not in ( select l3.l_orderkey from lineitem l3 where  l3.l_suppkey <> l1.l_suppkey );
+
+set interleaving_group_size =0;
+select count(*) as c from lineitem l1 where exists ( select * from lineitem l3 where l3.l_orderkey = l1.l_orderkey and l3.l_suppkey <> l1.l_suppkey );
+set interleaving_group_size =-10;
+select count(*) as c from lineitem l1 where exists ( select * from lineitem l3 where l3.l_orderkey = l1.l_orderkey and l3.l_suppkey <> l1.l_suppkey );
+
+set interleaving_group_size =0;
+select count(*) as c from lineitem l1 where l1.l_orderkey in ( select l3.l_orderkey from lineitem l3 where  l3.l_suppkey <> l1.l_suppkey );
+set interleaving_group_size =-10;
+select count(*) as c from lineitem l1 where l1.l_orderkey in ( select l3.l_orderkey from lineitem l3 where  l3.l_suppkey <> l1.l_suppkey );
+
+set interleaving_group_size =0;
+select count(*) as c from lineitem l1 right join lineitem l3 on l3.l_orderkey = l1.l_orderkey and l3.l_suppkey <> l1.l_suppkey;
+set interleaving_group_size =-10;
+select count(*) as c from lineitem l1 right join lineitem l3 on l3.l_orderkey = l1.l_orderkey and l3.l_suppkey <> l1.l_suppkey;
+
+set interleaving_group_size =0;
+select count(*) as c from lineitem l1 full outer join lineitem l3 on l3.l_orderkey = l1.l_orderkey and l3.l_suppkey <> l1.l_suppkey;
+set interleaving_group_size =-10;
+select count(*) as c from lineitem l1 full outer join lineitem l3 on l3.l_orderkey = l1.l_orderkey and l3.l_suppkey <> l1.l_suppkey;
+
+set chunk_size = 3;
+set interleaving_group_size =0;
+select count(*) as c from lineitem l1  join lineitem l3 on l3.l_orderkey = l1.l_orderkey and l3.l_suppkey <> l1.l_suppkey;
+set interleaving_group_size =-10;
+select count(*) as c from lineitem l1  join lineitem l3 on l3.l_orderkey = l1.l_orderkey and l3.l_suppkey <> l1.l_suppkey;
+
+set interleaving_group_size =0;
+select count(*) as c from lineitem l1 left join lineitem l3 on l3.l_orderkey = l1.l_orderkey and l3.l_suppkey <> l1.l_suppkey;
+set interleaving_group_size =-10;
+select count(*) as c from lineitem l1 left join lineitem l3 on l3.l_orderkey = l1.l_orderkey and l3.l_suppkey <> l1.l_suppkey;
+set interleaving_group_size =0;
+select count(*) as c from lineitem l1 where not exists ( select * from lineitem l3 where l3.l_orderkey = l1.l_orderkey and l3.l_suppkey <> l1.l_suppkey );
+set interleaving_group_size =-10;
+select count(*) as c from lineitem l1 where not exists ( select * from lineitem l3 where l3.l_orderkey = l1.l_orderkey and l3.l_suppkey <> l1.l_suppkey );
+
+set interleaving_group_size =0;
+select count(*) as c from lineitem l1 where l1.l_orderkey not in ( select l3.l_orderkey from lineitem l3 where  l3.l_suppkey <> l1.l_suppkey );
+set interleaving_group_size =-10;
+select count(*) as c from lineitem l1 where l1.l_orderkey not in ( select l3.l_orderkey from lineitem l3 where  l3.l_suppkey <> l1.l_suppkey );
+
+set interleaving_group_size =0;
+select count(*) as c from lineitem l1 where exists ( select * from lineitem l3 where l3.l_orderkey = l1.l_orderkey and l3.l_suppkey <> l1.l_suppkey );
+set interleaving_group_size =-10;
+select count(*) as c from lineitem l1 where exists ( select * from lineitem l3 where l3.l_orderkey = l1.l_orderkey and l3.l_suppkey <> l1.l_suppkey );
+
+set interleaving_group_size =0;
+select count(*) as c from lineitem l1 where l1.l_orderkey in ( select l3.l_orderkey from lineitem l3 where  l3.l_suppkey <> l1.l_suppkey );
+set interleaving_group_size =-10;
+select count(*) as c from lineitem l1 where l1.l_orderkey in ( select l3.l_orderkey from lineitem l3 where  l3.l_suppkey <> l1.l_suppkey );
+
+set interleaving_group_size =0;
+select count(*) as c from lineitem l1 right join lineitem l3 on l3.l_orderkey = l1.l_orderkey and l3.l_suppkey <> l1.l_suppkey;
+set interleaving_group_size =-10;
+select count(*) as c from lineitem l1 right join lineitem l3 on l3.l_orderkey = l1.l_orderkey and l3.l_suppkey <> l1.l_suppkey;
+
+set interleaving_group_size =0;
+select count(*) as c from lineitem l1 full outer join lineitem l3 on l3.l_orderkey = l1.l_orderkey and l3.l_suppkey <> l1.l_suppkey;
+set interleaving_group_size =-10;
+select count(*) as c from lineitem l1 full outer join lineitem l3 on l3.l_orderkey = l1.l_orderkey and l3.l_suppkey <> l1.l_suppkey;
+
+----- join without other conjuncts
+
+set chunk_size = 2;
+set interleaving_group_size =0;
+select count(*) as c from lineitem l1  join lineitem l3 on l3.l_orderkey = l1.l_orderkey and l3.l_suppkey = l1.l_suppkey;
+set interleaving_group_size =-10;
+select count(*) as c from lineitem l1  join lineitem l3 on l3.l_orderkey = l1.l_orderkey and l3.l_suppkey = l1.l_suppkey;
+
+set interleaving_group_size =0;
+select count(*) as c from lineitem l1 left join lineitem l3 on l3.l_orderkey = l1.l_orderkey and l3.l_suppkey = l1.l_suppkey;
+set interleaving_group_size =-10;
+select count(*) as c from lineitem l1 left join lineitem l3 on l3.l_orderkey = l1.l_orderkey and l3.l_suppkey = l1.l_suppkey;
+set interleaving_group_size =0;
+select count(*) as c from lineitem l1 where not exists ( select * from lineitem l3 where l3.l_orderkey = l1.l_orderkey and l3.l_suppkey = l1.l_suppkey );
+set interleaving_group_size =-10;
+select count(*) as c from lineitem l1 where not exists ( select * from lineitem l3 where l3.l_orderkey = l1.l_orderkey and l3.l_suppkey = l1.l_suppkey );
+
+set interleaving_group_size =0;
+select count(*) as c from lineitem l1 where l1.l_orderkey not in ( select l3.l_orderkey from lineitem l3 where  l3.l_suppkey <> l1.l_suppkey );
+set interleaving_group_size =-10;
+select count(*) as c from lineitem l1 where l1.l_orderkey not in ( select l3.l_orderkey from lineitem l3 where  l3.l_suppkey <> l1.l_suppkey );
+
+set interleaving_group_size =0;
+select count(*) as c from lineitem l1 where exists ( select * from lineitem l3 where l3.l_orderkey = l1.l_orderkey and l3.l_suppkey = l1.l_suppkey );
+set interleaving_group_size =-10;
+select count(*) as c from lineitem l1 where exists ( select * from lineitem l3 where l3.l_orderkey = l1.l_orderkey and l3.l_suppkey = l1.l_suppkey );
+
+set interleaving_group_size =0;
+select count(*) as c from lineitem l1 where l1.l_orderkey in ( select l3.l_orderkey from lineitem l3 where  l3.l_suppkey <> l1.l_suppkey );
+set interleaving_group_size =-10;
+select count(*) as c from lineitem l1 where l1.l_orderkey in ( select l3.l_orderkey from lineitem l3 where  l3.l_suppkey <> l1.l_suppkey );
+
+set interleaving_group_size =0;
+select count(*) as c from lineitem l1 right join lineitem l3 on l3.l_orderkey = l1.l_orderkey and l3.l_suppkey = l1.l_suppkey;
+set interleaving_group_size =-10;
+select count(*) as c from lineitem l1 right join lineitem l3 on l3.l_orderkey = l1.l_orderkey and l3.l_suppkey = l1.l_suppkey;
+
+set interleaving_group_size =0;
+select count(*) as c from lineitem l1 full outer join lineitem l3 on l3.l_orderkey = l1.l_orderkey and l3.l_suppkey = l1.l_suppkey;
+set interleaving_group_size =-10;
+select count(*) as c from lineitem l1 full outer join lineitem l3 on l3.l_orderkey = l1.l_orderkey and l3.l_suppkey = l1.l_suppkey;
+
+set chunk_size = 3;
+set interleaving_group_size =0;
+select count(*) as c from lineitem l1  join lineitem l3 on l3.l_orderkey = l1.l_orderkey and l3.l_suppkey = l1.l_suppkey;
+set interleaving_group_size =-10;
+select count(*) as c from lineitem l1  join lineitem l3 on l3.l_orderkey = l1.l_orderkey and l3.l_suppkey = l1.l_suppkey;
+
+set interleaving_group_size =0;
+select count(*) as c from lineitem l1 left join lineitem l3 on l3.l_orderkey = l1.l_orderkey and l3.l_suppkey = l1.l_suppkey;
+set interleaving_group_size =-10;
+select count(*) as c from lineitem l1 left join lineitem l3 on l3.l_orderkey = l1.l_orderkey and l3.l_suppkey = l1.l_suppkey;
+set interleaving_group_size =0;
+select count(*) as c from lineitem l1 where not exists ( select * from lineitem l3 where l3.l_orderkey = l1.l_orderkey and l3.l_suppkey = l1.l_suppkey );
+set interleaving_group_size =-10;
+select count(*) as c from lineitem l1 where not exists ( select * from lineitem l3 where l3.l_orderkey = l1.l_orderkey and l3.l_suppkey = l1.l_suppkey );
+
+set interleaving_group_size =0;
+select count(*) as c from lineitem l1 where l1.l_orderkey not in ( select l3.l_orderkey from lineitem l3 where  l3.l_suppkey <> l1.l_suppkey );
+set interleaving_group_size =-10;
+select count(*) as c from lineitem l1 where l1.l_orderkey not in ( select l3.l_orderkey from lineitem l3 where  l3.l_suppkey <> l1.l_suppkey );
+
+set interleaving_group_size =0;
+select count(*) as c from lineitem l1 where exists ( select * from lineitem l3 where l3.l_orderkey = l1.l_orderkey and l3.l_suppkey = l1.l_suppkey );
+set interleaving_group_size =-10;
+select count(*) as c from lineitem l1 where exists ( select * from lineitem l3 where l3.l_orderkey = l1.l_orderkey and l3.l_suppkey = l1.l_suppkey );
+
+set interleaving_group_size =0;
+select count(*) as c from lineitem l1 where l1.l_orderkey in ( select l3.l_orderkey from lineitem l3 where  l3.l_suppkey <> l1.l_suppkey );
+set interleaving_group_size =-10;
+select count(*) as c from lineitem l1 where l1.l_orderkey in ( select l3.l_orderkey from lineitem l3 where  l3.l_suppkey <> l1.l_suppkey );
+
+set interleaving_group_size =0;
+select count(*) as c from lineitem l1 right join lineitem l3 on l3.l_orderkey = l1.l_orderkey and l3.l_suppkey = l1.l_suppkey;
+set interleaving_group_size =-10;
+select count(*) as c from lineitem l1 right join lineitem l3 on l3.l_orderkey = l1.l_orderkey and l3.l_suppkey = l1.l_suppkey;
+
+set interleaving_group_size =0;
+select count(*) as c from lineitem l1 full outer join lineitem l3 on l3.l_orderkey = l1.l_orderkey and l3.l_suppkey = l1.l_suppkey;
+set interleaving_group_size =-10;
+select count(*) as c from lineitem l1 full outer join lineitem l3 on l3.l_orderkey = l1.l_orderkey and l3.l_suppkey = l1.l_suppkey;


### PR DESCRIPTION

## Why I'm doing:

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [x] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5

