### PR TITLE
[Enhancement] Starocks FE should promptly update its Kafka client to fix the CVE-2023-25194 vulnerability

### DIFF
--- a/fe/pom.xml
+++ b/fe/pom.xml
@@ -59,6 +59,7 @@ under the License.
         <sonar.host.url>https://sonarcloud.io</sonar.host.url>
         <odps.version>0.45.5-public</odps.version>
         <hikaricp.version>3.4.5</hikaricp.version>
+        <kafka-clients.version>3.4.0</kafka-clients.version>
     </properties>
 
     <profiles>
@@ -452,6 +453,12 @@ under the License.
                 <groupId>com.github.oshi</groupId>
                 <artifactId>oshi-core</artifactId>
                 <version>6.2.1</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.apache.kafka</groupId>
+                <artifactId>kafka-clients</artifactId>
+                <version>${kafka-clients.version}</version>
             </dependency>
 
             <!-- https://mvnrepository.com/artifact/org.jboss.xnio/xnio-nio -->


### PR DESCRIPTION
## Why I'm doing:
to fix the https://github.com/advisories/GHSA-26f8-x7cc-wqpc vulnerability

## What I'm doing:
upgrade kafka-client version to 3.4.0

Fixes #45219 

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [X] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [X] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [X] I have checked the version labels which the pr will be auto-backported to the target branch
  - [X] 3.3
  - [X] 3.2
  - [X] 3.1
  - [X] 3.0
  - [ ] 2.5
