### PR TITLE
[BugFix] fix incorrect mysql binary resultset packet

### DIFF
--- a/be/src/column/adaptive_nullable_column.cpp
+++ b/be/src/column/adaptive_nullable_column.cpp
@@ -301,9 +301,9 @@ int64_t AdaptiveNullableColumn::xor_checksum(uint32_t from, uint32_t to) const {
     return NullableColumn::xor_checksum(from, to);
 }
 
-void AdaptiveNullableColumn::put_mysql_row_buffer(MysqlRowBuffer* buf, size_t idx) const {
+void AdaptiveNullableColumn::put_mysql_row_buffer(MysqlRowBuffer* buf, size_t idx, bool is_binary_protocol) const {
     materialized_nullable();
-    NullableColumn::put_mysql_row_buffer(buf, idx);
+    NullableColumn::put_mysql_row_buffer(buf, idx, is_binary_protocol);
 }
 
 } // namespace starrocks

--- a/be/src/column/adaptive_nullable_column.h
+++ b/be/src/column/adaptive_nullable_column.h
@@ -375,7 +375,7 @@ public:
 
     int64_t xor_checksum(uint32_t from, uint32_t to) const override;
 
-    void put_mysql_row_buffer(MysqlRowBuffer* buf, size_t idx) const override;
+    void put_mysql_row_buffer(MysqlRowBuffer* buf, size_t idx, bool is_binary_protocol = false) const override;
 
     const ColumnPtr& begin_append_not_default_value() const {
         switch (_state) {

--- a/be/src/column/array_column.cpp
+++ b/be/src/column/array_column.cpp
@@ -498,7 +498,7 @@ int64_t ArrayColumn::xor_checksum(uint32_t from, uint32_t to) const {
     return (xor_checksum ^ _elements->xor_checksum(element_from, element_to));
 }
 
-void ArrayColumn::put_mysql_row_buffer(MysqlRowBuffer* buf, size_t idx) const {
+void ArrayColumn::put_mysql_row_buffer(MysqlRowBuffer* buf, size_t idx, bool is_binary_protocol) const {
     DCHECK_LT(idx, size());
     const size_t offset = _offsets->get_data()[idx];
     const size_t array_size = _offsets->get_data()[idx + 1] - offset;

--- a/be/src/column/array_column.h
+++ b/be/src/column/array_column.h
@@ -135,7 +135,7 @@ public:
 
     int64_t xor_checksum(uint32_t from, uint32_t to) const override;
 
-    void put_mysql_row_buffer(MysqlRowBuffer* buf, size_t idx) const override;
+    void put_mysql_row_buffer(MysqlRowBuffer* buf, size_t idx, bool is_binary_protocol = false) const override;
 
     std::string get_name() const override { return "array"; }
 

--- a/be/src/column/binary_column.cpp
+++ b/be/src/column/binary_column.cpp
@@ -630,7 +630,7 @@ int64_t BinaryColumnBase<T>::xor_checksum(uint32_t from, uint32_t to) const {
 }
 
 template <typename T>
-void BinaryColumnBase<T>::put_mysql_row_buffer(MysqlRowBuffer* buf, size_t idx) const {
+void BinaryColumnBase<T>::put_mysql_row_buffer(MysqlRowBuffer* buf, size_t idx, bool is_binary_protocol) const {
     T start = _offsets[idx];
     T len = _offsets[idx + 1] - start;
     buf->push_string((const char*)_bytes.data() + start, len);

--- a/be/src/column/binary_column.h
+++ b/be/src/column/binary_column.h
@@ -257,7 +257,7 @@ public:
 
     int64_t xor_checksum(uint32_t from, uint32_t to) const override;
 
-    void put_mysql_row_buffer(MysqlRowBuffer* buf, size_t idx) const override;
+    void put_mysql_row_buffer(MysqlRowBuffer* buf, size_t idx, bool is_binary_protocol = false) const override;
 
     std::string get_name() const override {
         static_assert(std::is_same_v<T, uint32_t> || std::is_same_v<T, uint64_t>);

--- a/be/src/column/column.h
+++ b/be/src/column/column.h
@@ -355,7 +355,7 @@ public:
     virtual int64_t xor_checksum(uint32_t from, uint32_t to) const = 0;
 
     // Push one row to MysqlRowBuffer
-    virtual void put_mysql_row_buffer(MysqlRowBuffer* buf, size_t idx) const = 0;
+    virtual void put_mysql_row_buffer(MysqlRowBuffer* buf, size_t idx, bool is_binary_protocol = false) const = 0;
 
     void set_delete_state(DelCondSatisfied delete_state) { _delete_state = delete_state; }
 

--- a/be/src/column/const_column.h
+++ b/be/src/column/const_column.h
@@ -203,7 +203,9 @@ public:
 
     int64_t xor_checksum(uint32_t from, uint32_t to) const override;
 
-    void put_mysql_row_buffer(MysqlRowBuffer* buf, size_t idx) const override { _data->put_mysql_row_buffer(buf, 0); }
+    void put_mysql_row_buffer(MysqlRowBuffer* buf, size_t idx, bool is_binary_protocol = false) const override {
+        _data->put_mysql_row_buffer(buf, 0, is_binary_protocol);
+    }
 
     std::string get_name() const override { return "const-" + _data->get_name(); }
 

--- a/be/src/column/decimalv3_column.cpp
+++ b/be/src/column/decimalv3_column.cpp
@@ -63,7 +63,7 @@ MutableColumnPtr DecimalV3Column<T>::clone_empty() const {
 }
 
 template <typename T>
-void DecimalV3Column<T>::put_mysql_row_buffer(MysqlRowBuffer* buf, size_t idx) const {
+void DecimalV3Column<T>::put_mysql_row_buffer(MysqlRowBuffer* buf, size_t idx, bool is_binary_protocol) const {
     auto& data = this->get_data();
     auto s = DecimalV3Cast::to_string<T>(data[idx], _precision, _scale);
     buf->push_decimal(s);

--- a/be/src/column/decimalv3_column.h
+++ b/be/src/column/decimalv3_column.h
@@ -43,7 +43,7 @@ public:
 
     MutableColumnPtr clone_empty() const override;
 
-    void put_mysql_row_buffer(MysqlRowBuffer* buf, size_t idx) const override;
+    void put_mysql_row_buffer(MysqlRowBuffer* buf, size_t idx, bool is_binary_protocol = false) const override;
     std::string debug_item(size_t idx) const override;
     void crc32_hash(uint32_t* hash, uint32_t from, uint32_t to) const override;
     int64_t xor_checksum(uint32_t from, uint32_t to) const override;

--- a/be/src/column/fixed_length_column_base.cpp
+++ b/be/src/column/fixed_length_column_base.cpp
@@ -285,7 +285,6 @@ void FixedLengthColumnBase<T>::put_mysql_row_buffer(MysqlRowBuffer* buf, size_t 
     } else if constexpr (std::is_arithmetic_v<T>) {
         buf->push_number(_data[idx], is_binary_protocol);
     } else {
-        // date/datetime or something else.
         std::string s = _data[idx].to_string();
         buf->push_string(s.data(), s.size());
     }

--- a/be/src/column/fixed_length_column_base.cpp
+++ b/be/src/column/fixed_length_column_base.cpp
@@ -275,11 +275,15 @@ int64_t FixedLengthColumnBase<T>::xor_checksum(uint32_t from, uint32_t to) const
 }
 
 template <typename T>
-void FixedLengthColumnBase<T>::put_mysql_row_buffer(MysqlRowBuffer* buf, size_t idx) const {
+void FixedLengthColumnBase<T>::put_mysql_row_buffer(MysqlRowBuffer* buf, size_t idx, bool is_binary_protocol) const {
     if constexpr (IsDecimal<T>) {
         buf->push_decimal(_data[idx].to_string());
+    } else if constexpr (IsDate<T>) {
+        buf->push_date(_data[idx], is_binary_protocol);
+    } else if constexpr (IsTimestamp<T>) {
+        buf->push_timestamp(_data[idx], is_binary_protocol);
     } else if constexpr (std::is_arithmetic_v<T>) {
-        buf->push_number(_data[idx]);
+        buf->push_number(_data[idx], is_binary_protocol);
     } else {
         // date/datetime or something else.
         std::string s = _data[idx].to_string();

--- a/be/src/column/fixed_length_column_base.h
+++ b/be/src/column/fixed_length_column_base.h
@@ -206,7 +206,7 @@ public:
 
     int64_t xor_checksum(uint32_t from, uint32_t to) const override;
 
-    void put_mysql_row_buffer(MysqlRowBuffer* buf, size_t idx) const override;
+    void put_mysql_row_buffer(MysqlRowBuffer* buf, size_t idx, bool is_binary_protocol = false) const override;
 
     std::string get_name() const override;
 

--- a/be/src/column/json_column.cpp
+++ b/be/src/column/json_column.cpp
@@ -50,7 +50,7 @@ void JsonColumn::fnv_hash(uint32_t* hash, uint32_t from, uint32_t to) const {
     }
 }
 
-void JsonColumn::put_mysql_row_buffer(starrocks::MysqlRowBuffer* buf, size_t idx) const {
+void JsonColumn::put_mysql_row_buffer(starrocks::MysqlRowBuffer* buf, size_t idx, bool is_binary_protocol) const {
     JsonValue* value = get_object(idx);
     DCHECK(value != nullptr);
     auto json_str = value->to_string();

--- a/be/src/column/json_column.h
+++ b/be/src/column/json_column.h
@@ -50,7 +50,8 @@ public:
     ColumnPtr clone_shared() const override;
 
     void append_datum(const Datum& datum) override;
-    void put_mysql_row_buffer(starrocks::MysqlRowBuffer* buf, size_t idx) const override;
+    void put_mysql_row_buffer(starrocks::MysqlRowBuffer* buf, size_t idx,
+                              bool is_binary_protocol = false) const override;
     std::string get_name() const override;
     bool is_json() const override { return true; }
 

--- a/be/src/column/map_column.cpp
+++ b/be/src/column/map_column.cpp
@@ -561,7 +561,7 @@ int64_t MapColumn::xor_checksum(uint32_t from, uint32_t to) const {
     return (xor_checksum ^ _values->xor_checksum(element_from, element_to));
 }
 
-void MapColumn::put_mysql_row_buffer(MysqlRowBuffer* buf, size_t idx) const {
+void MapColumn::put_mysql_row_buffer(MysqlRowBuffer* buf, size_t idx, bool is_binary_protocol) const {
     DCHECK_LT(idx, size());
     const size_t offset = _offsets->get_data()[idx];
     const size_t map_size = _offsets->get_data()[idx + 1] - offset;

--- a/be/src/column/map_column.h
+++ b/be/src/column/map_column.h
@@ -133,7 +133,7 @@ public:
 
     int64_t xor_checksum(uint32_t from, uint32_t to) const override;
 
-    void put_mysql_row_buffer(MysqlRowBuffer* buf, size_t idx) const override;
+    void put_mysql_row_buffer(MysqlRowBuffer* buf, size_t idx, bool is_binary_protocol = false) const override;
 
     std::string get_name() const override { return "map"; }
 

--- a/be/src/column/nullable_column.cpp
+++ b/be/src/column/nullable_column.cpp
@@ -412,7 +412,7 @@ int64_t NullableColumn::xor_checksum(uint32_t from, uint32_t to) const {
 
 void NullableColumn::put_mysql_row_buffer(MysqlRowBuffer* buf, size_t idx, bool is_binary_protocol) const {
     if (_has_null && _null_column->get_data()[idx]) {
-        buf->push_null();
+        buf->push_null(is_binary_protocol);
     } else {
         _data_column->put_mysql_row_buffer(buf, idx, is_binary_protocol);
     }

--- a/be/src/column/nullable_column.cpp
+++ b/be/src/column/nullable_column.cpp
@@ -414,6 +414,7 @@ void NullableColumn::put_mysql_row_buffer(MysqlRowBuffer* buf, size_t idx, bool 
     if (_has_null && _null_column->get_data()[idx]) {
         buf->push_null(is_binary_protocol);
     } else {
+        buf->update_field_pos();
         _data_column->put_mysql_row_buffer(buf, idx, is_binary_protocol);
     }
 }

--- a/be/src/column/nullable_column.cpp
+++ b/be/src/column/nullable_column.cpp
@@ -410,11 +410,11 @@ int64_t NullableColumn::xor_checksum(uint32_t from, uint32_t to) const {
     return xor_checksum;
 }
 
-void NullableColumn::put_mysql_row_buffer(MysqlRowBuffer* buf, size_t idx) const {
+void NullableColumn::put_mysql_row_buffer(MysqlRowBuffer* buf, size_t idx, bool is_binary_protocol) const {
     if (_has_null && _null_column->get_data()[idx]) {
         buf->push_null();
     } else {
-        _data_column->put_mysql_row_buffer(buf, idx);
+        _data_column->put_mysql_row_buffer(buf, idx, is_binary_protocol);
     }
 }
 

--- a/be/src/column/nullable_column.h
+++ b/be/src/column/nullable_column.h
@@ -212,7 +212,7 @@ public:
 
     int64_t xor_checksum(uint32_t from, uint32_t to) const override;
 
-    void put_mysql_row_buffer(MysqlRowBuffer* buf, size_t idx) const override;
+    void put_mysql_row_buffer(MysqlRowBuffer* buf, size_t idx, bool is_binary_protocol = false) const override;
 
     std::string get_name() const override { return "nullable-" + _data_column->get_name(); }
 

--- a/be/src/column/object_column.cpp
+++ b/be/src/column/object_column.cpp
@@ -265,7 +265,7 @@ int64_t ObjectColumn<T>::xor_checksum(uint32_t from, uint32_t to) const {
 }
 
 template <typename T>
-void ObjectColumn<T>::put_mysql_row_buffer(starrocks::MysqlRowBuffer* buf, size_t idx) const {
+void ObjectColumn<T>::put_mysql_row_buffer(starrocks::MysqlRowBuffer* buf, size_t idx, bool is_binary_protocol) const {
     buf->push_null();
 }
 

--- a/be/src/column/object_column.h
+++ b/be/src/column/object_column.h
@@ -145,7 +145,7 @@ public:
 
     int64_t xor_checksum(uint32_t from, uint32_t to) const override;
 
-    void put_mysql_row_buffer(MysqlRowBuffer* buf, size_t idx) const override;
+    void put_mysql_row_buffer(MysqlRowBuffer* buf, size_t idx, bool is_binary_protocol = false) const override;
 
     std::string get_name() const override { return std::string{"object"}; }
 

--- a/be/src/column/struct_column.cpp
+++ b/be/src/column/struct_column.cpp
@@ -353,7 +353,7 @@ int64_t StructColumn::xor_checksum(uint32_t from, uint32_t to) const {
     return xor_checksum;
 }
 
-void StructColumn::put_mysql_row_buffer(MysqlRowBuffer* buf, size_t idx) const {
+void StructColumn::put_mysql_row_buffer(MysqlRowBuffer* buf, size_t idx, bool is_binary_protocol) const {
     DCHECK_LT(idx, size());
     buf->begin_push_bracket();
     for (size_t i = 0; i < _fields.size(); ++i) {

--- a/be/src/column/struct_column.h
+++ b/be/src/column/struct_column.h
@@ -151,7 +151,7 @@ public:
 
     int64_t xor_checksum(uint32_t from, uint32_t to) const override;
 
-    void put_mysql_row_buffer(MysqlRowBuffer* buf, size_t idx) const override;
+    void put_mysql_row_buffer(MysqlRowBuffer* buf, size_t idx, bool is) const override;
 
     std::string debug_item(size_t idx) const override;
 

--- a/be/src/runtime/mysql_result_writer.cpp
+++ b/be/src/runtime/mysql_result_writer.cpp
@@ -142,7 +142,7 @@ StatusOr<TFetchDataResultPtr> MysqlResultWriter::_process_chunk(Chunk* chunk) {
                 _row_buffer->start_binary_row(num_columns);
             };
             for (auto& result_column : result_columns) {
-                if (!result_column->is_nullable()) {
+                if (_is_binary_format && !result_column->is_nullable()) {
                     _row_buffer->update_field_pos();
                 }
                 result_column->put_mysql_row_buffer(_row_buffer, i, _is_binary_format);
@@ -190,7 +190,7 @@ StatusOr<TFetchDataResultPtrs> MysqlResultWriter::process_chunk(Chunk* chunk) {
                 _row_buffer->start_binary_row(num_columns);
             }
             for (auto& result_column : result_columns) {
-                if (!result_column->is_nullable()) {
+                if (_is_binary_format && !result_column->is_nullable()) {
                     _row_buffer->update_field_pos();
                 }
                 result_column->put_mysql_row_buffer(_row_buffer, i, _is_binary_format);

--- a/be/src/runtime/mysql_result_writer.cpp
+++ b/be/src/runtime/mysql_result_writer.cpp
@@ -142,6 +142,9 @@ StatusOr<TFetchDataResultPtr> MysqlResultWriter::_process_chunk(Chunk* chunk) {
                 _row_buffer->start_binary_row(num_columns);
             };
             for (auto& result_column : result_columns) {
+                if (!result_column->is_nullable()) {
+                    _row_buffer->update_field_pos();
+                }
                 result_column->put_mysql_row_buffer(_row_buffer, i);
             }
             size_t len = _row_buffer->length();

--- a/be/src/runtime/mysql_result_writer.cpp
+++ b/be/src/runtime/mysql_result_writer.cpp
@@ -145,7 +145,7 @@ StatusOr<TFetchDataResultPtr> MysqlResultWriter::_process_chunk(Chunk* chunk) {
                 if (!result_column->is_nullable()) {
                     _row_buffer->update_field_pos();
                 }
-                result_column->put_mysql_row_buffer(_row_buffer, i);
+                result_column->put_mysql_row_buffer(_row_buffer, i, _is_binary_format);
             }
             size_t len = _row_buffer->length();
             _row_buffer->move_content(&result_rows[i]);
@@ -190,7 +190,7 @@ StatusOr<TFetchDataResultPtrs> MysqlResultWriter::process_chunk(Chunk* chunk) {
                 _row_buffer->start_binary_row(num_columns);
             }
             for (auto& result_column : result_columns) {
-                result_column->put_mysql_row_buffer(_row_buffer, i);
+                result_column->put_mysql_row_buffer(_row_buffer, i, _is_binary_format);
             }
             size_t len = _row_buffer->length();
 

--- a/be/src/runtime/mysql_result_writer.cpp
+++ b/be/src/runtime/mysql_result_writer.cpp
@@ -190,6 +190,9 @@ StatusOr<TFetchDataResultPtrs> MysqlResultWriter::process_chunk(Chunk* chunk) {
                 _row_buffer->start_binary_row(num_columns);
             }
             for (auto& result_column : result_columns) {
+                if (!result_column->is_nullable()) {
+                    _row_buffer->update_field_pos();
+                }
                 result_column->put_mysql_row_buffer(_row_buffer, i, _is_binary_format);
             }
             size_t len = _row_buffer->length();

--- a/be/src/util/mysql_row_buffer.cpp
+++ b/be/src/util/mysql_row_buffer.cpp
@@ -85,7 +85,7 @@ void MysqlRowBuffer::push_null() {
         /* Room for this as it's allocated start_binary_row*/
         char* to = _data.data() + offset;
         *to = (char)((uchar)*to | (uchar)bit);
-        _field_pos++;
+        update_field_pos();
         return;
     }
 
@@ -99,7 +99,6 @@ void MysqlRowBuffer::push_null() {
 
 template <typename T>
 void MysqlRowBuffer::push_number_binary_format(T data) {
-    _field_pos++;
     if constexpr (std::is_same_v<T, float>) {
         char buff[4];
         float4store(buff, data);
@@ -133,10 +132,10 @@ void MysqlRowBuffer::push_number_binary_format(T data) {
 }
 
 template <typename T>
-void MysqlRowBuffer::push_number(T data) {
+void MysqlRowBuffer::push_number(T data, bool is_binary_protocol) {
     static_assert(std::is_arithmetic_v<T> || std::is_same_v<T, __int128>);
 
-    if (_is_binary_format) {
+    if (is_binary_protocol) {
         return push_number_binary_format(data);
     }
 
@@ -184,10 +183,6 @@ void MysqlRowBuffer::push_number(T data) {
 }
 
 void MysqlRowBuffer::push_string(const char* str, size_t length, char escape_char) {
-    if (_is_binary_format) {
-        ++_field_pos;
-    }
-
     if (_array_level == 0) {
         _push_string_normal(str, length);
     } else {
@@ -210,10 +205,6 @@ void MysqlRowBuffer::push_string(const char* str, size_t length, char escape_cha
 }
 
 void MysqlRowBuffer::push_decimal(const Slice& s) {
-    if (_is_binary_format) {
-        ++_field_pos;
-    }
-
     if (_array_level == 0) {
         _push_string_normal(s.data, s.size);
     } else {
@@ -222,6 +213,53 @@ void MysqlRowBuffer::push_decimal(const Slice& s) {
         pos += s.size;
         DCHECK_EQ(_data.data() + _data.size(), pos);
         _data.resize(pos - _data.data());
+    }
+}
+
+void MysqlRowBuffer::push_date(const DateValue& data, bool is_binary_protocol) {
+    if (is_binary_protocol) {
+        int y, m, d;
+        data.to_date(&y, &m, &d);
+        char buff[5];
+        // first pos store the length
+        buff[0] = 4;
+        buff[1] = (uint8_t)y;
+        buff[2] = (uint8_t)(y >> 8);
+        buff[3] = m;
+        buff[4] = d;
+        _data.append(buff, 5);
+    } else {
+        std::string s = data.to_string();
+        push_string(s.data(), s.size());
+    }
+}
+
+void MysqlRowBuffer::push_timestamp(const TimestampValue& data, bool is_binary_protocol) {
+    if (is_binary_protocol) {
+        int y, m, d, h, min, s, u;
+        data.to_timestamp(&y, &m, &d, &h, &min, &s, &u);
+        char buff[8];
+        // first pos store the length
+        buff[0] = u == 0 ? 7 : 11;
+        buff[1] = (uint8_t)y;
+        buff[2] = (uint8_t)(y >> 8);
+        buff[3] = m;
+        buff[4] = d;
+        buff[5] = h;
+        buff[6] = min;
+        buff[7] = s;
+        _data.append(buff, 8);
+        if (u > 0) {
+            char micro[4];
+            micro[0] = (uint8_t)u;
+            micro[1] = (uint8_t)(u >> 8);
+            micro[2] = (uint8_t)(u >> 16);
+            micro[3] = (uint8_t)(u >> 24);
+            _data.append(micro, 4);
+        }
+    } else {
+        std::string s = data.to_string();
+        push_string(s.data(), s.size());
     }
 }
 
@@ -299,17 +337,17 @@ void MysqlRowBuffer::_push_string_normal(const char* str, size_t length) {
     _data.resize(pos - _data.data());
 }
 
-template void MysqlRowBuffer::push_number<int8_t>(int8_t);
-template void MysqlRowBuffer::push_number<int16_t>(int16_t);
-template void MysqlRowBuffer::push_number<int32_t>(int32_t);
-template void MysqlRowBuffer::push_number<int64_t>(int64_t);
-template void MysqlRowBuffer::push_number<uint8_t>(uint8_t);
-template void MysqlRowBuffer::push_number<uint16_t>(uint16_t);
-template void MysqlRowBuffer::push_number<uint32_t>(uint32_t);
-template void MysqlRowBuffer::push_number<uint64_t>(uint64_t);
-template void MysqlRowBuffer::push_number<__int128>(__int128);
-template void MysqlRowBuffer::push_number<float>(float);
-template void MysqlRowBuffer::push_number<double>(double);
+template void MysqlRowBuffer::push_number<int8_t>(int8_t, bool);
+template void MysqlRowBuffer::push_number<int16_t>(int16_t, bool);
+template void MysqlRowBuffer::push_number<int32_t>(int32_t, bool);
+template void MysqlRowBuffer::push_number<int64_t>(int64_t, bool);
+template void MysqlRowBuffer::push_number<uint8_t>(uint8_t, bool);
+template void MysqlRowBuffer::push_number<uint16_t>(uint16_t, bool);
+template void MysqlRowBuffer::push_number<uint32_t>(uint32_t, bool);
+template void MysqlRowBuffer::push_number<uint64_t>(uint64_t, bool);
+template void MysqlRowBuffer::push_number<__int128>(__int128, bool);
+template void MysqlRowBuffer::push_number<float>(float, bool);
+template void MysqlRowBuffer::push_number<double>(double, bool);
 
 void MysqlRowBuffer::start_binary_row(uint32_t num_cols) {
     DCHECK(_is_binary_format) << "start_binary_row() only for is_binary_format=true";

--- a/be/src/util/mysql_row_buffer.cpp
+++ b/be/src/util/mysql_row_buffer.cpp
@@ -78,8 +78,8 @@ static uint8_t* pack_vlen(uint8_t* packet, uint64_t length) {
     return packet + 8;
 }
 
-void MysqlRowBuffer::push_null() {
-    if (_is_binary_format) {
+void MysqlRowBuffer::push_null(bool is_binary_protocol) {
+    if (is_binary_protocol) {
         uint offset = (_field_pos + 2) / 8 + 1;
         uint bit = (1 << ((_field_pos + 2) & 7));
         /* Room for this as it's allocated start_binary_row*/

--- a/be/src/util/mysql_row_buffer.h
+++ b/be/src/util/mysql_row_buffer.h
@@ -35,7 +35,7 @@
 #pragma once
 
 #include "storage/uint24.h"
-#include "types/date_value.h"
+#include "types/date_value.hpp"
 #include "types/timestamp_value.h"
 #include "util/raw_container.h"
 #include "util/slice.h"

--- a/be/src/util/mysql_row_buffer.h
+++ b/be/src/util/mysql_row_buffer.h
@@ -54,7 +54,7 @@ public:
 
     void start_binary_row(uint32_t num_cols);
 
-    void push_null();
+    void push_null(bool is_binary_protocol = false);
     void push_tinyint(int8_t data) { push_number(data); }
     void push_smallint(int16_t data) { push_number(data); }
     void push_int(int32_t data) { push_number(data); }

--- a/be/src/util/mysql_row_buffer.h
+++ b/be/src/util/mysql_row_buffer.h
@@ -35,6 +35,8 @@
 #pragma once
 
 #include "storage/uint24.h"
+#include "types/date_value.h"
+#include "types/timestamp_value.h"
 #include "util/raw_container.h"
 #include "util/slice.h"
 
@@ -64,13 +66,16 @@ public:
     void push_string(const Slice& s) { push_string(s.data, s.size); }
 
     template <typename T>
-    void push_number(T data);
+    void push_number(T data, bool is_binary_protocol = false);
     void push_number(uint24_t data) { push_number((uint32_t)data); }
 
     template <typename T>
     void push_number_binary_format(T data);
 
     void push_decimal(const Slice& s);
+
+    void push_date(const DateValue& data, bool is_binary_protocol = false);
+    void push_timestamp(const TimestampValue& data, bool is_binary_protocol = false);
 
     void begin_push_array() { _enter_scope('['); }
     void finish_push_array() { _leave_scope(']'); }
@@ -91,6 +96,7 @@ public:
     const std::string& data() const { return reinterpret_cast<const std::string&>(_data); }
 
     void reserve(size_t count) { _data.reserve(count); }
+    void update_field_pos() { _field_pos++; }
 
 private:
     char* _resize_extra(size_t n) {

--- a/test/sql/test_preparestatement/R/test_driver_prepare
+++ b/test/sql/test_preparestatement/R/test_driver_prepare
@@ -11,14 +11,32 @@ CREATE TABLE IF NOT EXISTS prepare_stmt (
     k3 BIGINT,
     k4 SMALLINT  Default '4',
     k5 varchar(10) Default 'k5',
-    v6 BOOLEAN,
-    v7 VARCHAR(2048) Default 'row')
+    k6 BOOLEAN,
+    k7 decimal(10, 2),
+    k8 float,
+    k9 double,
+    v1 date not null,
+    v2 date,
+    v3 datetime not null,
+    v4 datetime,
+    v5 array<int>,
+    v6 array<date>,
+    v7 array<array<datetime>>,
+    v8 STRUCT<a INT, b INT>,
+    v9 MAP<INT,DATETIME>,
+    v10 json)
     PRIMARY KEY (k1, k2, k3, k4, k5)
     DISTRIBUTED BY HASH(k1, k2, k3, k4, k5) BUCKETS 8 PROPERTIES("replication_num" = "1");
 -- result:
 -- !result
-insert into prepare_stmt values (1, 2, 3, 4, '2', true, '1');
+insert into prepare_stmt values (1, 2, 3, 4, '5', true, 7.2, 8.1, 9.222, '2010-01-01', null, '2010-01-01 01:02:03',
+null, [1, 2, 3, null, 4], [date '2021-01-05', null], [[null, datetime '2021-01-01 01:02:03'], [null, datetime '2021-01-01 01:02:03']],
+row(1, null), map{1:'2021-01-01',3:NULL}, json_object('a', 4, 'b', false));
 -- result:
+-- !result
+select * from prepare_stmt;
+-- result:
+1	2	3	4	5	1	7.20	8.1	9.222	2010-01-01	None	2010-01-01 01:02:03	None	[1,2,3,null,4]	["2021-01-05",null]	[[null,"2021-01-01 01:02:03"],[null,"2021-01-01 01:02:03"]]	{"a":1,"b":null}	{1:"2021-01-01 00:00:00",3:null}	{"a": 4, "b": false}
 -- !result
 function: assert_prepare_execute('test_driver_prepare', 'select 1')
 -- result:

--- a/test/sql/test_preparestatement/R/test_driver_prepare
+++ b/test/sql/test_preparestatement/R/test_driver_prepare
@@ -32,3 +32,23 @@ function: assert_prepare_execute('test_driver_prepare', 'select * from prepare_s
 -- result:
 None
 -- !result
+function: assert_prepare_execute('test_driver_prepare', "select cast('2021-01-01' as date) from prepare_stmt where k1 > 0")
+-- result:
+None
+-- !result
+function: assert_prepare_execute('test_driver_prepare', "select cast('2021-01-01' as datetime) from prepare_stmt where k5 = ?", ['2'])
+-- result:
+None
+-- !result
+function: assert_prepare_execute('test_driver_prepare', "select cast('2021-01-01 12:12:12.123456' as datetime) from prepare_stmt where k5 = ?", ['2'])
+-- result:
+None
+-- !result
+function: assert_prepare_execute('test_driver_prepare', "select cast('2021-01-01 12:12:12' as datetime) from prepare_stmt where k5 = ?", ['2'])
+-- result:
+None
+-- !result
+function: assert_prepare_execute('test_driver_prepare', "select cast('2021-01-01 12:12:12.123' as datetime), cast('2021-01-01' as date), * from prepare_stmt where k5 = ?", ['2'])
+-- result:
+None
+-- !result

--- a/test/sql/test_preparestatement/T/test_driver_prepare
+++ b/test/sql/test_preparestatement/T/test_driver_prepare
@@ -17,3 +17,8 @@ insert into prepare_stmt values (1, 2, 3, 4, '2', true, '1');
 function: assert_prepare_execute('test_driver_prepare', 'select 1')
 function: assert_prepare_execute('test_driver_prepare', 'select * from prepare_stmt where k1 > 0')
 function: assert_prepare_execute('test_driver_prepare', 'select * from prepare_stmt where k5 = ?', ['2'])
+function: assert_prepare_execute('test_driver_prepare', "select cast('2021-01-01' as date) from prepare_stmt where k1 > 0")
+function: assert_prepare_execute('test_driver_prepare', "select cast('2021-01-01' as datetime) from prepare_stmt where k5 = ?", ['2'])
+function: assert_prepare_execute('test_driver_prepare', "select cast('2021-01-01 12:12:12.123456' as datetime) from prepare_stmt where k5 = ?", ['2'])
+function: assert_prepare_execute('test_driver_prepare', "select cast('2021-01-01 12:12:12' as datetime) from prepare_stmt where k5 = ?", ['2'])
+function: assert_prepare_execute('test_driver_prepare', "select cast('2021-01-01 12:12:12.123' as datetime), cast('2021-01-01' as date), * from prepare_stmt where k5 = ?", ['2'])

--- a/test/sql/test_preparestatement/T/test_driver_prepare
+++ b/test/sql/test_preparestatement/T/test_driver_prepare
@@ -7,12 +7,28 @@ CREATE TABLE IF NOT EXISTS prepare_stmt (
     k3 BIGINT,
     k4 SMALLINT  Default '4',
     k5 varchar(10) Default 'k5',
-    v6 BOOLEAN,
-    v7 VARCHAR(2048) Default 'row')
+    k6 BOOLEAN,
+    k7 decimal(10, 2),
+    k8 float,
+    k9 double,
+    v1 date not null,
+    v2 date,
+    v3 datetime not null,
+    v4 datetime,
+    v5 array<int>,
+    v6 array<date>,
+    v7 array<array<datetime>>,
+    v8 STRUCT<a INT, b INT>,
+    v9 MAP<INT,DATETIME>,
+    v10 json)
     PRIMARY KEY (k1, k2, k3, k4, k5)
     DISTRIBUTED BY HASH(k1, k2, k3, k4, k5) BUCKETS 8 PROPERTIES("replication_num" = "1");
 
-insert into prepare_stmt values (1, 2, 3, 4, '2', true, '1');
+insert into prepare_stmt values (1, 2, 3, 4, '5', true, 7.2, 8.1, 9.222, '2010-01-01', null, '2010-01-01 01:02:03',
+null, [1, 2, 3, null, 4], [date '2021-01-05', null], [[null, datetime '2021-01-01 01:02:03'], [null, datetime '2021-01-01 01:02:03']],
+row(1, null), map{1:'2021-01-01',3:NULL}, json_object('a', 4, 'b', false));
+
+select * from prepare_stmt;
 
 function: assert_prepare_execute('test_driver_prepare', 'select 1')
 function: assert_prepare_execute('test_driver_prepare', 'select * from prepare_stmt where k1 > 0')


### PR DESCRIPTION
## Why I'm doing:
fix #45072
According to https://dev.mysql.com/doc/dev/mysql-server/latest/page_protocol_binary_resultset.html
There are two differences between binary resultset and text resultset:
1. The binary resultset requires a null bitmap to indicate which column is null.
2. Columns of number, date, and datetime types in binary resultset require different encoding formats.

## What I'm doing:
according to the standard to return the correct packet.
In order to ensure that the binary resultset of array, map, and struct is legal, two main changes have been made:
1. Move the update `_field_pos` operation in the null bitmap to traversal column in `process_chunk` to ensure that `_field_pos` will not be updated repeatedly when processing the element column like `array<date>`.
2.  adds the `is_binary_protocol` parameter in `put_mysql_row_buffer` method, which is used to indicate whether the binary protocol resultset is required to encode the value. For example, the element column in `array<date>` does not need to use the binary protocol, but the `date` column requires the binary protocol.
Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [x] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
