### PR TITLE
[BugFix] enhance column pruning for query with predicates after mv rewrite

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MVColumnPruner.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MVColumnPruner.java
@@ -97,12 +97,9 @@ public class MVColumnPruner {
                 scanBuilder.setColRefToColumnMetaMap(newColumnRefMap);
                 ColumnRefSet outputRefSet = new ColumnRefSet(outputColumns);
                 outputRefSet.except(requiredOutputColumns);
-                if (!outputRefSet.isEmpty()) {
+                if (!outputRefSet.isEmpty() && projection == null) {
                     // should add a projection
                     Map<ColumnRefOperator, ScalarOperator> projectionMap = Maps.newHashMap();
-                    if (projection != null) {
-                        projectionMap.putAll(projection.getColumnRefMap());
-                    }
                     for (ColumnRefOperator columnRefOperator : outputColumns) {
                         if (outputRefSet.contains(columnRefOperator)) {
                             continue;

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MVColumnPruner.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MVColumnPruner.java
@@ -17,6 +17,7 @@ package com.starrocks.sql.optimizer.rule.transformation.materialization;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
 import com.starrocks.catalog.Column;
 import com.starrocks.sql.common.UnsupportedException;
 import com.starrocks.sql.optimizer.OptExpression;
@@ -32,6 +33,7 @@ import com.starrocks.sql.optimizer.operator.logical.LogicalJoinOperator;
 import com.starrocks.sql.optimizer.operator.logical.LogicalScanOperator;
 import com.starrocks.sql.optimizer.operator.scalar.CallOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ColumnRefOperator;
+import com.starrocks.sql.optimizer.operator.scalar.ScalarOperator;
 
 import java.util.List;
 import java.util.Map;
@@ -93,6 +95,23 @@ public class MVColumnPruner {
                 builder.withOperator(scanOperator);
                 LogicalScanOperator.Builder scanBuilder = (LogicalScanOperator.Builder) builder;
                 scanBuilder.setColRefToColumnMetaMap(newColumnRefMap);
+                ColumnRefSet outputRefSet = new ColumnRefSet(outputColumns);
+                outputRefSet.except(requiredOutputColumns);
+                if (!outputRefSet.isEmpty()) {
+                    // should add a projection
+                    Map<ColumnRefOperator, ScalarOperator> projectionMap = Maps.newHashMap();
+                    if (projection != null) {
+                        projectionMap.putAll(projection.getColumnRefMap());
+                    }
+                    for (ColumnRefOperator columnRefOperator : outputColumns) {
+                        if (outputRefSet.contains(columnRefOperator)) {
+                            continue;
+                        }
+                        projectionMap.put(columnRefOperator, columnRefOperator);
+                    }
+                    Projection newProjection = new Projection(projectionMap);
+                    builder.setProjection(newProjection);
+                }
                 Operator newQueryOp = builder.build();
                 return OptExpression.create(newQueryOp);
             } else {


### PR DESCRIPTION
## Why I'm doing:
the query with predicates may be rewritten by mv without a projection above scan node.

## What I'm doing:
add a projection above scan node after query rewritten to reduce the size of data.

Fixes #45272

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [x] 3.2
  - [x] 3.1
  - [x] 3.0
  - [x] 2.5
