### PR TITLE
[BugFix] Remove paimon native reader for branch-3.1

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/connector/paimon/PaimonConnector.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/paimon/PaimonConnector.java
@@ -46,6 +46,9 @@ public class PaimonConnector implements Connector {
     private static final String HIVE_METASTORE_URIS = "hive.metastore.uris";
     private final HdfsEnvironment hdfsEnvironment;
     private Catalog paimonNativeCatalog;
+    private final String catalogType;
+    private final String metastoreUris;
+    private final String warehousePath;
     private final String catalogName;
     private final Options paimonOptions;
 
@@ -54,9 +57,9 @@ public class PaimonConnector implements Connector {
         this.catalogName = context.getCatalogName();
         CloudConfiguration cloudConfiguration = CloudConfigurationFactory.buildCloudConfigurationForStorage(properties);
         this.hdfsEnvironment = new HdfsEnvironment(cloudConfiguration);
-        String catalogType = properties.get(PAIMON_CATALOG_TYPE);
-        String metastoreUris = properties.get(HIVE_METASTORE_URIS);
-        String warehousePath = properties.get(PAIMON_CATALOG_WAREHOUSE);
+        this.catalogType = properties.get(PAIMON_CATALOG_TYPE);
+        this.metastoreUris = properties.get(HIVE_METASTORE_URIS);
+        this.warehousePath = properties.get(PAIMON_CATALOG_WAREHOUSE);
 
         this.paimonOptions = new Options();
         if (Strings.isNullOrEmpty(catalogType)) {

--- a/fe/fe-core/src/main/java/com/starrocks/planner/PaimonScanNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/PaimonScanNode.java
@@ -32,7 +32,6 @@ import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.sql.optimizer.operator.scalar.ScalarOperator;
 import com.starrocks.sql.plan.HDFSScanNodePredicates;
 import com.starrocks.thrift.TExplainLevel;
-import com.starrocks.thrift.THdfsFileFormat;
 import com.starrocks.thrift.THdfsScanNode;
 import com.starrocks.thrift.THdfsScanRange;
 import com.starrocks.thrift.TNetworkAddress;
@@ -46,7 +45,6 @@ import org.apache.logging.log4j.Logger;
 import org.apache.paimon.data.BinaryRow;
 import org.apache.paimon.io.DataFileMeta;
 import org.apache.paimon.table.source.DataSplit;
-import org.apache.paimon.table.source.RawFile;
 import org.apache.paimon.table.source.Split;
 import org.apache.paimon.utils.InstantiationUtil;
 
@@ -54,7 +52,6 @@ import java.util.ArrayList;
 import java.util.Base64;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.stream.Collectors;
 
@@ -128,20 +125,7 @@ public class PaimonScanNode extends ScanNode {
         Map<BinaryRow, Long> selectedPartitions = Maps.newHashMap();
         for (Split split : splits) {
             DataSplit dataSplit = (DataSplit) split;
-            Optional<List<RawFile>> optionalRawFiles = dataSplit.convertToRawFiles();
-            if (optionalRawFiles.isPresent()) {
-                List<RawFile> rawFiles = optionalRawFiles.get();
-                boolean validFormat = rawFiles.stream().allMatch(p -> fromType(p.format()) != THdfsFileFormat.UNKNOWN);
-                if (validFormat) {
-                    for (RawFile rawFile : rawFiles) {
-                        addRowfileScanRangeLocations(rawFile);
-                    }
-                } else {
-                    addSplitScanRangeLocations(dataSplit, predicateInfo);
-                }
-            } else {
-                addSplitScanRangeLocations(dataSplit, predicateInfo);
-            }
+            addScanRangeLocations(dataSplit, predicateInfo);
             BinaryRow partitionValue = dataSplit.partition();
             if (!selectedPartitions.containsKey(partitionValue)) {
                 selectedPartitions.put(partitionValue, nextPartitionId());
@@ -150,43 +134,7 @@ public class PaimonScanNode extends ScanNode {
         scanNodePredicates.setSelectedPartitionIds(selectedPartitions.values());
     }
 
-    private THdfsFileFormat fromType(String type) {
-        THdfsFileFormat tHdfsFileFormat;
-        switch (type) {
-            case "orc":
-                tHdfsFileFormat = THdfsFileFormat.ORC;
-                break;
-            case "parquet":
-                tHdfsFileFormat = THdfsFileFormat.PARQUET;
-                break;
-            default:
-                tHdfsFileFormat = THdfsFileFormat.UNKNOWN;
-        }
-        return tHdfsFileFormat;
-    }
-
-    private void addRowfileScanRangeLocations(RawFile rawFile) {
-        TScanRangeLocations scanRangeLocations = new TScanRangeLocations();
-
-        THdfsScanRange hdfsScanRange = new THdfsScanRange();
-        hdfsScanRange.setUse_paimon_jni_reader(false);
-        hdfsScanRange.setFull_path(rawFile.path());
-        hdfsScanRange.setOffset(rawFile.offset());
-        hdfsScanRange.setFile_length(rawFile.length());
-        hdfsScanRange.setLength(rawFile.length());
-        hdfsScanRange.setFile_format(fromType(rawFile.format()));
-
-        TScanRange scanRange = new TScanRange();
-        scanRange.setHdfs_scan_range(hdfsScanRange);
-        scanRangeLocations.setScan_range(scanRange);
-
-        TScanRangeLocation scanRangeLocation = new TScanRangeLocation(new TNetworkAddress("-1", -1));
-        scanRangeLocations.addToLocations(scanRangeLocation);
-
-        scanRangeLocationsList.add(scanRangeLocations);
-    }
-
-    private void addSplitScanRangeLocations(DataSplit split, String predicateInfo) {
+    private void addScanRangeLocations(DataSplit split, String predicateInfo) {
         TScanRangeLocations scanRangeLocations = new TScanRangeLocations();
 
         THdfsScanRange hdfsScanRange = new THdfsScanRange();

--- a/java-extensions/paimon-reader/src/main/java/com/starrocks/paimon/reader/PaimonSplitScanner.java
+++ b/java-extensions/paimon-reader/src/main/java/com/starrocks/paimon/reader/PaimonSplitScanner.java
@@ -128,7 +128,7 @@ public class PaimonSplitScanner extends ConnectorScanner {
         List<Predicate> predicates = PaimonScannerUtils.decodeStringToObject(predicateInfo);
         readBuilder.withFilter(predicates);
         Split split = PaimonScannerUtils.decodeStringToObject(splitInfo);
-        RecordReader<InternalRow> reader = readBuilder.newRead().executeFilter().createReader(split);
+        RecordReader<InternalRow> reader = readBuilder.newRead().createReader(split);
         iterator = new RecordReaderIterator<>(reader);
     }
 


### PR DESCRIPTION
## Why I'm doing:

#43417 introduced paimon native reader, which will lead to error when querying tables with map columns. We don't need native reader in branch-3.1, so revert it and upgrade paimon version only.

error messages:
```
W0508 14:47:50.536828 299965 pipeline_driver_executor.cpp:166] [Driver] Process error, query_id=e3187388-0d06-11ef-b6c6-00163e16923f, instance_id=e3187388-0d06-11ef-b6c6-00163e169240, status=Invalid argument: key in map group must be required: file = hdfs://xxx/xxxxx.parquet
```

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5

