### PR TITLE
[BugFix] fix cloud table compaction task concurrency issue

### DIFF
--- a/be/src/storage/lake/compaction_scheduler.cpp
+++ b/be/src/storage/lake/compaction_scheduler.cpp
@@ -121,9 +121,10 @@ void CompactionScheduler::compact(::google::protobuf::RpcController* controller,
     // By default, all the tablet compaction tasks with the same txn id will be executed in the same
     // thread to avoid blocking other transactions, but if there are idle threads, they will steal
     // tasks from busy threads to execute.
-    auto idx = choose_task_queue_by_txn_id(request->txn_id());
     auto cb = std::make_shared<CompactionTaskCallback>(this, request, response, done);
     bool is_checker = true; // make the first tablet as checker
+    int idx = 0;
+    std::vector<std::unique_ptr<CompactionTaskContext>> contexts_vec;
     for (auto tablet_id : request->tablet_ids()) {
         auto context = std::make_unique<CompactionTaskContext>(request->txn_id(), tablet_id, request->version(),
                                                                is_checker, cb);
@@ -131,9 +132,13 @@ void CompactionScheduler::compact(::google::protobuf::RpcController* controller,
             std::lock_guard l(_contexts_lock);
             _contexts.Append(context.get());
         }
-        _task_queues.put(idx, context);
+        contexts_vec.push_back(std::move(context));
+        // DO NOT touch `context` from here!
         is_checker = false;
+        idx++;
     }
+    _task_queues.put_by_txn_id(request->txn_id(), contexts_vec);
+    // DO NOT touch `contexts_vec` from here!
     TEST_SYNC_POINT("CompactionScheduler::compact:return");
 }
 
@@ -322,9 +327,8 @@ Status CompactionScheduler::do_compaction(std::unique_ptr<CompactionTaskContext>
         LOG(WARNING) << "Memory limit exceeded, will retry later. tablet_id=" << tablet_id << " version=" << version
                      << " txn_id=" << txn_id << " cost=" << cost << "s";
         context->progress.update(0);
-        auto idx = choose_task_queue_by_txn_id(context->txn_id);
         // re-schedule the compaction task
-        _task_queues.put(idx, context);
+        _task_queues.put_by_txn_id(context->txn_id, context);
     } else {
         VLOG_IF(3, status.ok()) << "Compacted tablet " << tablet_id << ". version=" << version << " txn_id=" << txn_id
                                 << " cost=" << cost << "s";
@@ -380,8 +384,7 @@ bool CompactionScheduler::reschedule_task_if_needed(int id) {
     if (id >= _task_queues.target_size()) {
         CompactionContextPtr context;
         while (_task_queues.try_get(id, &context)) {
-            auto idx = choose_task_queue_by_txn_id(context->txn_id);
-            _task_queues.put(idx, context);
+            _task_queues.put_by_txn_id(context->txn_id, context);
         }
 
         _task_queues.resize_if_needed(_limiter);

--- a/be/src/storage/lake/compaction_scheduler.h
+++ b/be/src/storage/lake/compaction_scheduler.h
@@ -165,13 +165,12 @@ class CompactionScheduler {
 
         int task_queue_size();
 
-        int task_queue_safe_size();
-
         void set_target_size(int32_t target_size);
 
         int32_t target_size();
 
-        void put(int idx, std::unique_ptr<CompactionTaskContext>& context);
+        void put_by_txn_id(int64_t txn_id, std::vector<std::unique_ptr<CompactionTaskContext>>& contexts);
+        void put_by_txn_id(int64_t txn_id, std::unique_ptr<CompactionTaskContext>& context);
 
         bool try_get(int idx, std::unique_ptr<CompactionTaskContext>* context);
 
@@ -184,6 +183,9 @@ class CompactionScheduler {
         void resize_if_needed(Limiter& limiter);
 
     private:
+        // mutex must be held
+        int _task_queue_safe_index(int64_t txn_id);
+
         std::mutex _task_queues_mutex;
         std::vector<std::shared_ptr<TaskQueue>> _internal_task_queues;
         int16_t _target_size;
@@ -221,8 +223,6 @@ private:
     void thread_task(int id);
 
     Status do_compaction(std::unique_ptr<CompactionTaskContext> context);
-
-    int choose_task_queue_by_txn_id(int64_t txn_id) { return txn_id % _task_queues.task_queue_safe_size(); }
 
     bool reschedule_task_if_needed(int id);
 
@@ -278,7 +278,7 @@ inline void CompactionScheduler::Limiter::adapt_to_task_queue_size(int16_t new_v
         auto diff = new_val - _total;
         _free += diff;
         _total += diff;
-    } else {
+    } else if (new_val < _total) {
         if (_reserved != 0) {
             double percentage = static_cast<double>(_total) / new_val;
             _reserved = static_cast<int16_t>(static_cast<double>(_reserved) * percentage);
@@ -288,6 +288,9 @@ inline void CompactionScheduler::Limiter::adapt_to_task_queue_size(int16_t new_v
             _total = new_val;
             _free = _total;
         }
+    } else {
+        // nothing change
+        return;
     }
     LOG(INFO) << "Update Limiter's _total value to " << _total << ", _free value to " << _free
               << ", and _reserved value to " << _reserved;
@@ -298,15 +301,15 @@ inline int CompactionScheduler::WrapTaskQueues::task_queue_size() {
     return _internal_task_queues.size();
 }
 
-inline int CompactionScheduler::WrapTaskQueues::task_queue_safe_size() {
-    std::lock_guard<std::mutex> lock(_task_queues_mutex);
+// mutex must be held
+inline int CompactionScheduler::WrapTaskQueues::_task_queue_safe_index(int64_t txn_id) {
     if (_target_size < _internal_task_queues.size()) {
         // Shrinking, It can prevent tasks from being placed on queues with IDs greater than it.
-        return _target_size;
+        return txn_id % _target_size;
     } else {
         // Expanding or normal state, if _internal_task_queues is expanding, it can prevent tasks
         // from being placed to the areas that have not expanded yet.
-        return _internal_task_queues.size();
+        return txn_id % _internal_task_queues.size();
     }
 }
 
@@ -320,13 +323,27 @@ inline int32_t CompactionScheduler::WrapTaskQueues::target_size() {
     return _target_size;
 }
 
-inline void CompactionScheduler::WrapTaskQueues::put(int idx, std::unique_ptr<CompactionTaskContext>& context) {
+inline void CompactionScheduler::WrapTaskQueues::put_by_txn_id(int64_t txn_id,
+                                                               std::unique_ptr<CompactionTaskContext>& context) {
     std::lock_guard<std::mutex> lock(_task_queues_mutex);
+    int idx = _task_queue_safe_index(txn_id);
     _internal_task_queues[idx]->put(std::move(context));
+}
+
+inline void CompactionScheduler::WrapTaskQueues::put_by_txn_id(
+        int64_t txn_id, std::vector<std::unique_ptr<CompactionTaskContext>>& contexts) {
+    std::lock_guard<std::mutex> lock(_task_queues_mutex);
+    int idx = _task_queue_safe_index(txn_id);
+    for (auto& context : contexts) {
+        _internal_task_queues[idx]->put(std::move(context));
+    }
 }
 
 inline bool CompactionScheduler::WrapTaskQueues::try_get(int idx, std::unique_ptr<CompactionTaskContext>* context) {
     std::lock_guard<std::mutex> lock(_task_queues_mutex);
+    if (idx >= _internal_task_queues.size()) { // idx might be invalid
+        return false;
+    }
     return _internal_task_queues[idx]->try_get(context);
 }
 

--- a/be/test/storage/lake/compaction_scheduler_test.cpp
+++ b/be/test/storage/lake/compaction_scheduler_test.cpp
@@ -47,6 +47,15 @@ protected:
     std::shared_ptr<TabletMetadata> _tablet_metadata;
 };
 
+TEST_F(LakeCompactionSchedulerTest, test_task_queue) {
+    CompactionScheduler::WrapTaskQueues queue(10);
+    auto ctx = std::make_unique<CompactionTaskContext>(100 /* txn_id */, 101 /* tablet_id */, 1 /* version */,
+                                                       false /* is_checker */, nullptr);
+    queue.set_target_size(5);
+    ASSERT_EQ(5, queue.target_size());
+    queue.put_by_txn_id(ctx->txn_id, ctx);
+}
+
 TEST_F(LakeCompactionSchedulerTest, test_list_tasks) {
     std::vector<CompactionTaskInfo> tasks;
     _compaction_scheduler.list_tasks(&tasks);


### PR DESCRIPTION
## Why I'm doing:
fix https://github.com/StarRocks/starrocks/issues/43786

## What I'm doing:
1. when get from queue, check queue idx again in case it's invalid after compaction thread decreases
2. when put into queue, make it atomic

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [x] 3.2
  - [x] 3.1
  - [ ] 3.0
  - [ ] 2.5
