### PR TITLE
[BugFix] close the CloseableIterator for delta lake scan files

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/connector/ConnectorMetadata.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/ConnectorMetadata.java
@@ -206,6 +206,11 @@ public interface ConnectorMetadata {
         throw new StarRocksConnectorException("This connector doesn't support pruning partitions");
     }
 
+    // return true if the connector has self info schema
+    default boolean hasSelfInfoSchema() {
+        return false;
+    }
+
     /**
      * Clean the query level cache after the query.
      */

--- a/fe/fe-core/src/main/java/com/starrocks/connector/delta/DeltaLakeInternalMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/delta/DeltaLakeInternalMgr.java
@@ -39,13 +39,13 @@ import static com.starrocks.connector.hive.HiveConnector.HIVE_METASTORE_URIS;
 
 public class DeltaLakeInternalMgr {
     public static final List<String> SUPPORTED_METASTORE_TYPE = ImmutableList.of("hive", "glue", "dlf");
-    private final String catalogName;
-    private final Map<String, String> properties;
-    private final HdfsEnvironment hdfsEnvironment;
+    protected final String catalogName;
+    protected final Map<String, String> properties;
+    protected final HdfsEnvironment hdfsEnvironment;
     private final boolean enableMetastoreCache;
     private final CachingHiveMetastoreConf hmsConf;
     private ExecutorService refreshHiveMetastoreExecutor;
-    private final MetastoreType metastoreType;
+    protected final MetastoreType metastoreType;
 
     public DeltaLakeInternalMgr(String catalogName, Map<String, String> properties, HdfsEnvironment hdfsEnvironment) {
         this.catalogName = catalogName;
@@ -55,7 +55,7 @@ public class DeltaLakeInternalMgr {
         this.hdfsEnvironment = hdfsEnvironment;
 
         String hiveMetastoreType = properties.getOrDefault(HIVE_METASTORE_TYPE, "hive").toLowerCase();
-        if (!SUPPORTED_METASTORE_TYPE.contains(hiveMetastoreType)) {
+        if (!isSupportedMetastoreType(hiveMetastoreType)) {
             throw new SemanticException("hive metastore type [%s] is not supported", hiveMetastoreType);
         }
 
@@ -65,6 +65,10 @@ public class DeltaLakeInternalMgr {
             Util.validateMetastoreUris(hiveMetastoreUris);
         }
         this.metastoreType = MetastoreType.get(hiveMetastoreType);
+    }
+
+    protected boolean isSupportedMetastoreType(String metastoreType) {
+        return SUPPORTED_METASTORE_TYPE.contains(metastoreType);
     }
 
     public IMetastore createMetastore() {

--- a/fe/fe-core/src/main/java/com/starrocks/connector/delta/DeltaLakeMetadataFactory.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/delta/DeltaLakeMetadataFactory.java
@@ -29,10 +29,10 @@ import static com.starrocks.connector.hive.CachingHiveMetastore.createQueryLevel
 
 public class DeltaLakeMetadataFactory {
     private final String catalogName;
-    private final IMetastore metastore;
-    private final long perQueryMetastoreMaxNum;
+    protected final IMetastore metastore;
+    protected final long perQueryMetastoreMaxNum;
     private final HdfsEnvironment hdfsEnvironment;
-    private final MetastoreType metastoreType;
+    protected final MetastoreType metastoreType;
 
     public DeltaLakeMetadataFactory(String catalogName, IMetastore metastore, CachingHiveMetastoreConf hmsConf,
                                     Map<String, String> properties, HdfsEnvironment hdfsEnvironment,
@@ -48,7 +48,7 @@ public class DeltaLakeMetadataFactory {
         this.metastoreType = metastoreType;
     }
 
-    private IMetastore createQueryLevelCacheMetastore() {
+    protected IMetastore createQueryLevelCacheMetastore() {
         return createQueryLevelInstance((IHiveMetastore) metastore, perQueryMetastoreMaxNum);
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/connector/delta/DeltaMetastoreOperations.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/delta/DeltaMetastoreOperations.java
@@ -56,6 +56,9 @@ public class DeltaMetastoreOperations {
         if (table == null) {
             return null;
         }
+        if (table.isDeltalakeTable()) {
+            return table;
+        }
         HiveTable hiveTable = (HiveTable) table;
         String path = hiveTable.getTableLocation();
         long createTime = table.getCreateTime();


### PR DESCRIPTION
## Why I'm doing:
scan files  CloseableIterator is not colse in delta scan
## What I'm doing:
close the CloseableIterator for delta lake scan files
Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
