### PR TITLE
[BugFix]fix  fe deadlock by static initialization

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/analysis/LiteralExpr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/analysis/LiteralExpr.java
@@ -35,6 +35,7 @@
 package com.starrocks.analysis;
 
 import com.google.common.base.Preconditions;
+import com.google.common.collect.ImmutableMap;
 import com.starrocks.catalog.Type;
 import com.starrocks.common.AnalysisException;
 import com.starrocks.common.NotImplementedException;
@@ -43,7 +44,6 @@ import com.starrocks.sql.ast.AstVisitor;
 import com.starrocks.sql.common.ErrorType;
 import com.starrocks.sql.common.StarRocksPlannerException;
 import com.starrocks.sql.parser.NodePosition;
-import org.apache.groovy.util.Maps;
 
 import java.io.DataInput;
 import java.io.DataOutput;
@@ -259,6 +259,24 @@ public abstract class LiteralExpr extends Expr implements Comparable<LiteralExpr
     }
 
     public static LiteralExpr parseLiteral(int encode) throws AnalysisException {
+        if (MYSQL_LITERAL_TYPE_ENCODE_MAP == null) {
+            MYSQL_LITERAL_TYPE_ENCODE_MAP = new ImmutableMap.Builder<Integer, LiteralExpr>()
+                    .put(0, LiteralExpr.create("0", Type.DECIMAL32))    // MYSQL_TYPE_DECIMAL
+                    .put(1, LiteralExpr.create("0", Type.TINYINT))     // MYSQL_TYPE_TINY
+                    .put(2, LiteralExpr.create("0", Type.SMALLINT))     // MYSQL_TYPE_SHORT
+                    .put(3, LiteralExpr.create("0", Type.INT))          // MYSQL_TYPE_LONG
+                    .put(4, LiteralExpr.create("0", Type.FLOAT))        // MYSQL_TYPE_FLOAT
+                    .put(5, LiteralExpr.create("0", Type.DOUBLE))        // MYSQL_TYPE_DOUBLE
+                    .put(7, LiteralExpr.create("1970-01-01 00:00:00", Type.DATETIME)) // MYSQL_TYPE_TIMESTAMP2
+                    .put(8, LiteralExpr.create("0", Type.BIGINT))       // MYSQL_TYPE_LONGLONG
+                    .put(10, LiteralExpr.create("1970-01-01", Type.DATE))       // MYSQL_TYPE_DATE
+                    .put(12, LiteralExpr.create("1970-01-01 00:00:00", Type.DATETIME))      // MYSQL_TYPE_DATETIME
+                    .put(15, LiteralExpr.create("", Type.VARCHAR))      // MYSQL_TYPE_VARCHAR
+                    .put(17, LiteralExpr.create("1970-01-01 00:00:00", Type.DATETIME))      // MYSQL_TYPE_TIMESTAMP2
+                    .put(253, LiteralExpr.create("", Type.STRING))      // MYSQL_TYPE_STRING
+                    .put(254, LiteralExpr.create("", Type.STRING))      // MYSQL_TYPE_STRING
+                    .build();
+        }
         LiteralExpr literalExpr = MYSQL_LITERAL_TYPE_ENCODE_MAP.get(encode);
         if (null != literalExpr) {
             return (LiteralExpr) literalExpr.clone();
@@ -267,52 +285,8 @@ public abstract class LiteralExpr extends Expr implements Comparable<LiteralExpr
         }
     }
 
-    private static final LiteralExpr tinyIntExpr;
-    private static final LiteralExpr smallIntExpr;
-    private static final LiteralExpr intExpr;
-    private static final LiteralExpr bigIntExpr;
-    private static final LiteralExpr floatExpr;
-    private static final LiteralExpr doubleExpr;
-    private static final LiteralExpr decimal32Expr;
-    private static final LiteralExpr dateExpr;
-    private static final LiteralExpr dateTimeExpr;
-    private static final LiteralExpr stringExpr;
-    private static final LiteralExpr varcharExpr;
+    private static Map<Integer, LiteralExpr> MYSQL_LITERAL_TYPE_ENCODE_MAP;
 
-    static {
-        try {
-            tinyIntExpr = LiteralExpr.create("0", Type.TINYINT);
-            smallIntExpr = LiteralExpr.create("0", Type.SMALLINT);
-            intExpr = LiteralExpr.create("0", Type.INT);
-            bigIntExpr = LiteralExpr.create("0", Type.BIGINT);
-            floatExpr = LiteralExpr.create("0", Type.FLOAT);
-            doubleExpr = LiteralExpr.create("0", Type.DOUBLE);
-            decimal32Expr = LiteralExpr.create("0", Type.DECIMAL32);
-            dateExpr = LiteralExpr.create("1970-01-01", Type.DATE);
-            dateTimeExpr = LiteralExpr.create("1970-01-01 00:00:00", Type.DATETIME);
-            stringExpr = LiteralExpr.create("", Type.STRING);
-            varcharExpr = LiteralExpr.create("", Type.VARCHAR);
-        } catch (AnalysisException e) {
-            throw new RuntimeException(e);
-        }
-    }
-
-    private static final Map<Integer, LiteralExpr> MYSQL_LITERAL_TYPE_ENCODE_MAP = Maps.of(
-            0, decimal32Expr,       // MYSQL_TYPE_DECIMAL
-            1, tinyIntExpr,             // MYSQL_TYPE_TINY
-            2, smallIntExpr,            // MYSQL_TYPE_SHORT
-            3, intExpr,                 // MYSQL_TYPE_LONG
-            4, floatExpr,               // MYSQL_TYPE_FLOAT
-            5, doubleExpr,              // MYSQL_TYPE_DOUBLE
-            7, dateTimeExpr,            // MYSQL_TYPE_TIMESTAMP2
-            8, bigIntExpr,              // MYSQL_TYPE_LONGLONG
-            10, dateExpr,               // MYSQL_TYPE_DATE
-            12, dateTimeExpr,           // MYSQL_TYPE_DATETIME
-            15, varcharExpr,            // MYSQL_TYPE_VARCHAR
-            17, dateTimeExpr,           // MYSQL_TYPE_TIMESTAMP2
-            253, stringExpr,            // MYSQL_TYPE_STRING
-            254, stringExpr             // MYSQL_TYPE_STRING
-    );
 
     // Port from mysql get_param_length
     public static int getParamLen(ByteBuffer data) {


### PR DESCRIPTION
## Why I'm doing:
fe may get into deadlock because static initialization. there are two thread:
```
"starrocks-mysql-nio-pool-0" #136 daemon prio=5 os_prio=0 cpu=306.75ms elapsed=101366.56s tid=0x00007f37f4005800 nid=0xb6f in Object.wait()  [0x00007f37e73f7000]
   java.lang.Thread.State: RUNNABLE
	at com.starrocks.analysis.LiteralExpr.create(LiteralExpr.java:103)
	at com.starrocks.analysis.LiteralExpr.<clinit>(LiteralExpr.java:293)
	at com.starrocks.sql.parser.AstBuilder.visitIntegerValue(AstBuilder.java:6006)
	at com.starrocks.sql.parser.AstBuilder.visitIntegerValue(AstBuilder.java:455)
	at com.starrocks.sql.parser.StarRocksParser$IntegerValueContext.accept(StarRocksParser.java:50054)
	at org.antlr.v4.runtime.tree.AbstractParseTreeVisitor.visit(AbstractParseTreeVisitor.java:18)
	at com.starrocks.sql.parser.AstBuilder.visitNumericLiteral(AstBuilder.java:5995)
	at com.starrocks.sql.parser.AstBuilder.visitNumericLiteral(AstBuilder.java:455)
	at com.starrocks.sql.parser.StarRocksParser$NumericLiteralContext.accept(StarRocksParser.java:41651)
	at org.antlr.v4.runtime.tree.AbstractParseTreeVisitor.visitChildren(AbstractParseTreeVisitor.java:46)
	at com.starrocks.sql.parser.StarRocksBaseVisitor.visitLiteral(StarRocksBaseVisitor.java:2918)
	at com.starrocks.sql.parser.StarRocksParser$LiteralContext.accept(StarRocksParser.java:40126)
	at org.antlr.v4.runtime.tree.AbstractParseTreeVisitor.visitChildren(AbstractParseTreeVisitor.java:46)
	at com.starrocks.sql.parser.StarRocksBaseVisitor.visitValueExpressionDefault(StarRocksBaseVisitor.java:2827)
	at com.starrocks.sql.parser.StarRocksParser$ValueExpressionDefaultContext.accept(StarRocksParser.java:39620)
	at org.antlr.v4.runtime.tree.AbstractParseTreeVisitor.visit(AbstractParseTreeVisitor.java:18)
```
and 
```
"starrocks-mysql-nio-pool-1" #137 daemon prio=5 os_prio=0 cpu=62.86ms elapsed=101366.53s tid=0x00007f37f4007000 nid=0xb70 in Object.wait()  [0x00007f37e6bf5000]
   java.lang.Thread.State: RUNNABLE
	at com.starrocks.sql.parser.AstBuilder.visitString(AstBuilder.java:6083)
	at com.starrocks.sql.parser.AstBuilder.visitString(AstBuilder.java:455)
	at com.starrocks.sql.parser.StarRocksParser$StringContext.accept(StarRocksParser.java:47149)
	at org.antlr.v4.runtime.tree.AbstractParseTreeVisitor.visit(AbstractParseTreeVisitor.java:18)
	at com.starrocks.sql.parser.AstBuilder.visitProperty(AstBuilder.java:6617)
	at com.starrocks.sql.parser.AstBuilder.visitAdminSetConfigStatement(AstBuilder.java:1972)
	at com.starrocks.sql.parser.AstBuilder.visitAdminSetConfigStatement(AstBuilder.java:455)
	at com.starrocks.sql.parser.StarRocksParser$AdminSetConfigStatementContext.accept(StarRocksParser.java:9540)
	at org.antlr.v4.runtime.tree.AbstractParseTreeVisitor.visitChildren(AbstractParseTreeVisitor.java:46)
	at com.starrocks.sql.parser.StarRocksBaseVisitor.visitStatement(StarRocksBaseVisitor.java:41)
	at com.starrocks.sql.parser.StarRocksParser$StatementContext.accept(StarRocksParser.java:1486)
	at org.antlr.v4.runtime.tree.AbstractParseTreeVisitor.visit(AbstractParseTreeVisitor.java:18)
	at com.starrocks.sql.parser.AstBuilder.visitSingleStatement(AstBuilder.java:506)
```

1. thread 0 is the first thread who new a LiteralExpr object(IntLiteral), so it will intialize static members in class LiteralExpr and hold LiteralExpr's class lock

2. thread1 is the second thread who new a LiteralExpr obejct(StringLiteral), and it hold StringLiteral's class lock.

3. thread 0 now need execute clinit method which is used to initialize static members in LiteralExpr, and it need to get 
StringLiteral's class lock

4. thread1 need to wait LiteralExpr's clinit method  to be done, so it wait for LiteralExpr's class lock.

now deadlock happened! see https://stackoverflow.com/questions/28631656/runnable-thread-state-but-in-object-wait 

## What I'm doing:

move some logic from LiteralExpr's static intialization, so everything will be alright

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
- [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [x] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
