### PR TITLE
[Enhancement] make the default mv task as manual

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/TaskManager.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/TaskManager.java
@@ -290,7 +290,9 @@ public class TaskManager implements MemoryTrackable {
     }
 
     public SubmitResult executeTask(String taskName) {
-        return executeTask(taskName, new ExecuteOption());
+        ExecuteOption option = new ExecuteOption();
+        option.setManual(true);
+        return executeTask(taskName, option);
     }
 
     public SubmitResult executeTask(String taskName, ExecuteOption option) {

--- a/test/sql/test_materialized_view/R/test_auto_refresh
+++ b/test/sql/test_materialized_view/R/test_auto_refresh
@@ -1,0 +1,87 @@
+-- name: test_auto_refresh
+create database db_${uuid0};
+-- result:
+-- !result
+use db_${uuid0};
+-- result:
+-- !result
+CREATE TABLE t1 (
+    __time datetime,
+    c1 int
+)
+PARTITION BY date_trunc('DAY', __time);
+-- result:
+-- !result
+INSERT INTO t1 VALUES 
+    ('2024-04-01', 1),
+    ('2024-04-02', 1),
+    ('2024-04-03', 1),
+    ('2024-04-04', 1),
+    ('2024-04-05', 1);
+-- result:
+-- !result
+CREATE MATERIALIZED VIEW `mv1`
+PARTITION BY (`__time`)
+REFRESH ASYNC
+PROPERTIES (
+    "auto_refresh_partitions_limit" = "3",
+    "partition_refresh_number" = "1"
+)
+AS select * from t1;
+-- result:
+-- !result
+function: wait_async_materialized_view_finish('mv1')
+-- result:
+None
+-- !result
+SELECT count(*) FROM mv1;
+-- result:
+5
+-- !result
+INSERT INTO t1 SELECT * FROM t1;
+-- result:
+-- !result
+REFRESH MATERIALIZED VIEW mv1 WITH SYNC MODE;
+SELECT count(*) FROM mv1;
+-- result:
+10
+-- !result
+INSERT INTO t1 SELECT * FROM t1;
+-- result:
+-- !result
+REFRESH MATERIALIZED VIEW mv1 PARTITION start('2024-04-02') end('2024-04-04') WITH SYNC MODE;
+SELECT count(*) FROM mv1;
+-- result:
+14
+-- !result
+REFRESH MATERIALIZED VIEW mv1 PARTITION start('2024-04-01') end('2024-04-02') WITH SYNC MODE;
+SELECT count(*) FROM mv1;
+-- result:
+16
+-- !result
+REFRESH MATERIALIZED VIEW mv1 WITH SYNC MODE;
+SELECT count(*) FROM mv1;
+-- result:
+20
+-- !result
+TRUNCATE TABLE t1;
+-- result:
+-- !result
+REFRESH MATERIALIZED VIEW mv1 PARTITION start('2024-04-03') end('2024-04-05') WITH SYNC MODE;
+SELECT count(*) FROM mv1;
+-- result:
+12
+-- !result
+REFRESH MATERIALIZED VIEW mv1 PARTITION start('2024-04-01') end('2024-04-02') WITH SYNC MODE;
+SELECT count(*) FROM mv1;
+-- result:
+8
+-- !result
+REFRESH MATERIALIZED VIEW mv1 WITH SYNC MODE;
+SELECT count(*) FROM mv1;
+-- result:
+0
+-- !result
+drop database db_${uuid0};
+-- result:
+-- !result

--- a/test/sql/test_materialized_view/T/test_auto_refresh
+++ b/test/sql/test_materialized_view/T/test_auto_refresh
@@ -1,0 +1,60 @@
+-- name: test_auto_refresh
+create database db_${uuid0};
+use db_${uuid0};
+
+CREATE TABLE t1 (
+    __time datetime,
+    c1 int
+)
+PARTITION BY date_trunc('DAY', __time);
+
+INSERT INTO t1 VALUES 
+    ('2024-04-01', 1),
+    ('2024-04-02', 1),
+    ('2024-04-03', 1),
+    ('2024-04-04', 1),
+    ('2024-04-05', 1);
+
+
+CREATE MATERIALIZED VIEW `mv1`
+PARTITION BY (`__time`)
+REFRESH ASYNC
+PROPERTIES (
+    "auto_refresh_partitions_limit" = "3",
+    "partition_refresh_number" = "1"
+)
+AS select * from t1;
+
+-- case 0: default refresh
+function: wait_async_materialized_view_finish('mv1')
+SELECT count(*) FROM mv1;
+
+
+-- case 2: manual complete refresh
+INSERT INTO t1 SELECT * FROM t1;
+REFRESH MATERIALIZED VIEW mv1 WITH SYNC MODE;
+SELECT count(*) FROM mv1;
+
+-- case 3.1: partial refresh
+INSERT INTO t1 SELECT * FROM t1;
+REFRESH MATERIALIZED VIEW mv1 PARTITION start('2024-04-02') end('2024-04-04') WITH SYNC MODE;
+SELECT count(*) FROM mv1;
+
+-- case 3.2: partial refresh
+REFRESH MATERIALIZED VIEW mv1 PARTITION start('2024-04-01') end('2024-04-02') WITH SYNC MODE;
+SELECT count(*) FROM mv1;
+REFRESH MATERIALIZED VIEW mv1 WITH SYNC MODE;
+SELECT count(*) FROM mv1;
+
+-- case 3.3 partial refresh
+TRUNCATE TABLE t1;
+REFRESH MATERIALIZED VIEW mv1 PARTITION start('2024-04-03') end('2024-04-05') WITH SYNC MODE;
+SELECT count(*) FROM mv1;
+REFRESH MATERIALIZED VIEW mv1 PARTITION start('2024-04-01') end('2024-04-02') WITH SYNC MODE;
+SELECT count(*) FROM mv1;
+REFRESH MATERIALIZED VIEW mv1 WITH SYNC MODE;
+SELECT count(*) FROM mv1;
+
+
+-- cleanup
+drop database db_${uuid0};


### PR DESCRIPTION
## Why I'm doing:
- These's a difference between `MANUAL` and `PERIODICAL` task in the scope of MV
  - MANUAL: `REFRESH MATERIALIZED VIEW` command, would refresh all partitions regardless of `auto_refresh_partitions_limit`
  - PERIODICAL: auto refresh, would consider the `auto_refresh_partitions_limit`
- After creating MV
  - will create a refresh task, which should be the `MANUAL` task, instead of `PERIODICAL` task.
  - so, the MV would be completed refreshed regardless of `auto_refresh_partitions_limit`


## What I'm doing:
- So we need to change the default task type to `MANUAL`

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [x] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [x] 3.2
  - [x] 3.1
  - [ ] 3.0
  - [ ] 2.5
