### PR TITLE
[Enhancement] Support mv refresh to use materialized view rewrite by enable_mv_refresh_query_rewrite config

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/common/Config.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/Config.java
@@ -2926,6 +2926,10 @@ public class Config extends ConfigBase {
             "default")
     public static int mv_refresh_default_planner_optimize_timeout = 30000; // 30s
 
+    @ConfField(mutable = true, comment = "Whether enable to rewrite query in mv refresh or not so it can use " +
+            "query the rewritten mv directly rather than original base table to improve query performance.")
+    public static boolean enable_mv_refresh_query_rewrite = false;
+
     /**
      * Whether analyze the mv after refresh in async mode.
      */

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/PartitionBasedMvRefreshProcessor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/PartitionBasedMvRefreshProcessor.java
@@ -593,21 +593,21 @@ public class PartitionBasedMvRefreshProcessor extends BaseTaskRunProcessor {
             mvSessionVariable.setOptimizerExecuteTimeout(Config.mv_refresh_default_planner_optimize_timeout);
         }
         // set enable_materialized_view_rewrite by default
-        if (!isMVPropertyContains(SessionVariable.ENABLE_MATERIALIZED_VIEW_REWRITE)) {
+        if (!isMVPropertyContains(SessionVariable.ENABLE_MATERIALIZED_VIEW_REWRITE) && Config.enable_mv_refresh_query_rewrite) {
             // Only enable mv rewrite when there are more than one related mvs that can be rewritten by other mvs.
             Set<Table> baseTables = snapshotBaseTables.values().stream()
                     .map(t -> t.getBaseTable()).collect(Collectors.toSet());
             if (isEnableMVRefreshQueryRewrite(mvConnectCtx, baseTables)) {
                 mvSessionVariable.setEnableMaterializedViewRewrite(Config.enable_mv_refresh_query_rewrite);
                 mvSessionVariable.setEnableMaterializedViewRewriteForInsert(Config.enable_mv_refresh_query_rewrite);
-                // exclude the current mv name from rewrite
-                mvSessionVariable.setQueryExcludingMVNames(materializedView.getName());
             }
         }
         // set nested_mv_rewrite_max_level by default, only rewrite one level
         if (!isMVPropertyContains(SessionVariable.NESTED_MV_REWRITE_MAX_LEVEL)) {
             mvSessionVariable.setNestedMvRewriteMaxLevel(1);
         }
+        // always exclude the current mv name from rewrite
+        mvSessionVariable.setQueryExcludingMVNames(materializedView.getName());
     }
 
     private boolean isMVPropertyContains(String key) {
@@ -621,10 +621,6 @@ public class PartitionBasedMvRefreshProcessor extends BaseTaskRunProcessor {
 
     private boolean isEnableMVRefreshQueryRewrite(ConnectContext ctx,
                                                   Set<Table> baseTables) {
-        if (!ctx.getSessionVariable().isEnableMaterializedViewRewriteForInsert()) {
-            return false;
-        }
-
         Set<MaterializedView> relatedMvs = MvUtils.getRelatedMvs(ctx, 1, baseTables);
         LOG.info("Refresh mv {} with related mvs: {}", materializedView.getName(), relatedMvs);
         // only enable mv rewrite when there are more than one related mvs

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/PartitionBasedMvRefreshProcessor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/PartitionBasedMvRefreshProcessor.java
@@ -592,6 +592,12 @@ public class PartitionBasedMvRefreshProcessor extends BaseTaskRunProcessor {
         if (!isMVPropertyContains(SessionVariable.NEW_PLANNER_OPTIMIZER_TIMEOUT)) {
             mvSessionVariable.setOptimizerExecuteTimeout(Config.mv_refresh_default_planner_optimize_timeout);
         }
+        // set enable_materialized_view_rewrite by default
+        if (!isMVPropertyContains(SessionVariable.ENABLE_MATERIALIZED_VIEW_REWRITE)) {
+            mvSessionVariable.setEnableMaterializedViewRewrite(Config.enable_mv_refresh_query_rewrite);
+            mvSessionVariable.setEnableMaterializedViewRewriteForInsert(Config.enable_mv_refresh_query_rewrite);
+            mvSessionVariable.setNestedMvRewriteMaxLevel(1);
+        }
     }
 
     private boolean isMVPropertyContains(String key) {
@@ -978,8 +984,6 @@ public class PartitionBasedMvRefreshProcessor extends BaseTaskRunProcessor {
      */
     private InsertStmt generateInsertAst(Set<String> materializedViewPartitions, MaterializedView materializedView,
                                          ConnectContext ctx) {
-        // TODO: Support use mv when refreshing mv.
-        ctx.getSessionVariable().setEnableMaterializedViewRewrite(false);
         String definition = mvContext.getDefinition();
         InsertStmt insertStmt =
                 (InsertStmt) SqlParser.parse(definition, ctx.getSessionVariable()).get(0);

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/rule/BaseMaterializedViewRewriteRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/rule/BaseMaterializedViewRewriteRule.java
@@ -63,7 +63,7 @@ public abstract class BaseMaterializedViewRewriteRule extends TransformationRule
             if (scan.hasTableHints()) {
                 return false;
             }
-            // Avoid rewrite the query repeat, add a shortcut.
+            // Avoid rewriting the query repeat, add a shortcut.
             Table table = scan.getTable();
             if ((table instanceof MaterializedView) && ((MaterializedView) (table)).getRefreshScheme().isSync()) {
                 return false;

--- a/fe/fe-core/src/test/java/com/starrocks/scheduler/PCTRefreshListPartitionOlapTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/scheduler/PCTRefreshListPartitionOlapTest.java
@@ -18,7 +18,6 @@ import com.google.common.collect.ImmutableList;
 import com.starrocks.catalog.Database;
 import com.starrocks.catalog.MaterializedView;
 import com.starrocks.catalog.Partition;
-import com.starrocks.common.util.UUIDUtil;
 import com.starrocks.qe.StmtExecutor;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.sql.ast.StatementBase;
@@ -26,7 +25,6 @@ import com.starrocks.sql.parser.SqlParser;
 import com.starrocks.sql.plan.ExecPlan;
 import com.starrocks.sql.plan.PlanTestBase;
 import com.starrocks.thrift.TExplainLevel;
-import org.apache.commons.lang3.StringUtils;
 import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.Assert;
@@ -139,20 +137,6 @@ public class PCTRefreshListPartitionOlapTest extends MVRefreshTestBase {
     @After
     public void after() throws Exception {
         cleanupEphemeralMVs(starRocksAssert, startCaseTime);
-    }
-
-    protected void assertPlanContains(ExecPlan execPlan, String... explain) throws Exception {
-        String explainString = execPlan.getExplainString(TExplainLevel.NORMAL);
-
-        for (String expected : explain) {
-            Assert.assertTrue("expected is: " + expected + " but plan is \n" + explainString,
-                    StringUtils.containsIgnoreCase(explainString.toLowerCase(), expected));
-        }
-    }
-
-    private static void initAndExecuteTaskRun(TaskRun taskRun) throws Exception {
-        taskRun.initStatus(UUIDUtil.genUUID().toString(), System.currentTimeMillis());
-        taskRun.executeTaskRun();
     }
 
     private ExecPlan getExecPlan(TaskRun taskRun) {

--- a/fe/fe-core/src/test/java/com/starrocks/scheduler/PartitionBasedMvRefreshProcessorHiveTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/scheduler/PartitionBasedMvRefreshProcessorHiveTest.java
@@ -23,7 +23,7 @@ import com.starrocks.catalog.Database;
 import com.starrocks.catalog.MaterializedView;
 import com.starrocks.catalog.Partition;
 import com.starrocks.catalog.Table;
-import com.starrocks.common.util.UUIDUtil;
+import com.starrocks.common.Config;
 import com.starrocks.connector.hive.MockedHiveMetadata;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.server.MetadataMgr;
@@ -34,7 +34,6 @@ import com.starrocks.sql.plan.PlanTestBase;
 import com.starrocks.thrift.TExplainLevel;
 import mockit.Mock;
 import mockit.MockUp;
-import org.apache.commons.lang3.StringUtils;
 import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.Assert;
@@ -62,6 +61,7 @@ public class PartitionBasedMvRefreshProcessorHiveTest extends MVRefreshTestBase 
     public static void beforeClass() throws Exception {
         MVRefreshTestBase.beforeClass();
         ConnectorPlanTestBase.mockHiveCatalog(connectContext);
+        Config.enable_mv_refresh_query_rewrite = false;
         starRocksAssert.withTable("CREATE TABLE test.tbl1\n" +
                         "(\n" +
                         "    k1 date,\n" +
@@ -135,20 +135,6 @@ public class PartitionBasedMvRefreshProcessorHiveTest extends MVRefreshTestBase 
     @After
     public void after() throws Exception {
         cleanupEphemeralMVs(starRocksAssert, startCaseTime);
-    }
-
-    protected void assertPlanContains(ExecPlan execPlan, String... explain) throws Exception {
-        String explainString = execPlan.getExplainString(TExplainLevel.NORMAL);
-
-        for (String expected : explain) {
-            Assert.assertTrue("expected is: " + expected + " but plan is \n" + explainString,
-                    StringUtils.containsIgnoreCase(explainString.toLowerCase(), expected));
-        }
-    }
-
-    private static void initAndExecuteTaskRun(TaskRun taskRun) throws Exception {
-        taskRun.initStatus(UUIDUtil.genUUID().toString(), System.currentTimeMillis());
-        taskRun.executeTaskRun();
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/scheduler/PartitionBasedMvRefreshProcessorIcebergTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/scheduler/PartitionBasedMvRefreshProcessorIcebergTest.java
@@ -20,14 +20,11 @@ import com.starrocks.catalog.Database;
 import com.starrocks.catalog.MaterializedView;
 import com.starrocks.catalog.Partition;
 import com.starrocks.common.util.RuntimeProfile;
-import com.starrocks.common.util.UUIDUtil;
 import com.starrocks.connector.iceberg.MockIcebergMetadata;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.sql.optimizer.QueryMaterializationContext;
 import com.starrocks.sql.plan.ConnectorPlanTestBase;
 import com.starrocks.sql.plan.ExecPlan;
-import com.starrocks.thrift.TExplainLevel;
-import org.apache.commons.lang3.StringUtils;
 import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.Assert;
@@ -68,20 +65,6 @@ public class PartitionBasedMvRefreshProcessorIcebergTest extends MVRefreshTestBa
     @After
     public void after() throws Exception {
         cleanupEphemeralMVs(starRocksAssert, startCaseTime);
-    }
-
-    protected void assertPlanContains(ExecPlan execPlan, String... explain) throws Exception {
-        String explainString = execPlan.getExplainString(TExplainLevel.NORMAL);
-
-        for (String expected : explain) {
-            Assert.assertTrue("expected is: " + expected + " but plan is \n" + explainString,
-                    StringUtils.containsIgnoreCase(explainString.toLowerCase(), expected));
-        }
-    }
-
-    private static void initAndExecuteTaskRun(TaskRun taskRun) throws Exception {
-        taskRun.initStatus(UUIDUtil.genUUID().toString(), System.currentTimeMillis());
-        taskRun.executeTaskRun();
     }
 
     private static void triggerRefreshMv(Database testDb, MaterializedView partitionedMaterializedView)

--- a/fe/fe-core/src/test/java/com/starrocks/scheduler/PartitionBasedMvRefreshProcessorJdbcTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/scheduler/PartitionBasedMvRefreshProcessorJdbcTest.java
@@ -21,15 +21,11 @@ import com.starrocks.catalog.JDBCTable;
 import com.starrocks.catalog.MaterializedView;
 import com.starrocks.catalog.Partition;
 import com.starrocks.common.AnalysisException;
-import com.starrocks.common.util.UUIDUtil;
 import com.starrocks.connector.MockedMetadataMgr;
 import com.starrocks.connector.TableVersionRange;
 import com.starrocks.connector.jdbc.MockedJDBCMetadata;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.sql.plan.ConnectorPlanTestBase;
-import com.starrocks.sql.plan.ExecPlan;
-import com.starrocks.thrift.TExplainLevel;
-import org.apache.commons.lang3.StringUtils;
 import org.jetbrains.annotations.NotNull;
 import org.junit.After;
 import org.junit.AfterClass;
@@ -124,20 +120,6 @@ public class PartitionBasedMvRefreshProcessorJdbcTest extends MVRefreshTestBase 
     @After
     public void after() throws Exception {
         cleanupEphemeralMVs(starRocksAssert, startCaseTime);
-    }
-
-    protected void assertPlanContains(ExecPlan execPlan, String... explain) throws Exception {
-        String explainString = execPlan.getExplainString(TExplainLevel.NORMAL);
-
-        for (String expected : explain) {
-            Assert.assertTrue("expected is: " + expected + " but plan is \n" + explainString,
-                    StringUtils.containsIgnoreCase(explainString.toLowerCase(), expected));
-        }
-    }
-
-    private static void initAndExecuteTaskRun(TaskRun taskRun) throws Exception {
-        taskRun.initStatus(UUIDUtil.genUUID().toString(), System.currentTimeMillis());
-        taskRun.executeTaskRun();
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/scheduler/PartitionBasedMvRefreshProcessorOlapPart2Test.java
+++ b/fe/fe-core/src/test/java/com/starrocks/scheduler/PartitionBasedMvRefreshProcessorOlapPart2Test.java
@@ -280,7 +280,7 @@ public class PartitionBasedMvRefreshProcessorOlapPart2Test extends MVRefreshTest
                         String key = String.format("cache_getUpdatedPartitionNames_%s", table.getId());
                         Assert.assertTrue(queryCacheStats != null);
                         Assert.assertTrue(queryCacheStats.getCounter().containsKey(key));
-                        Assert.assertTrue(queryCacheStats.getCounter().get(key) == 1);
+                        Assert.assertTrue(queryCacheStats.getCounter().get(key) >= 1);
                     }
                 });
         starRocksAssert.dropTable("tbl1");

--- a/fe/fe-core/src/test/java/com/starrocks/scheduler/PartitionBasedMvRefreshProcessorOlapTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/scheduler/PartitionBasedMvRefreshProcessorOlapTest.java
@@ -260,11 +260,6 @@ public class PartitionBasedMvRefreshProcessorOlapTest extends MVRefreshTestBase 
         }
     }
 
-    private static void initAndExecuteTaskRun(TaskRun taskRun) throws Exception {
-        taskRun.initStatus(UUIDUtil.genUUID().toString(), System.currentTimeMillis());
-        taskRun.executeTaskRun();
-    }
-
     @Test
     public void testUnionAllMvWithPartition() {
         Database testDb = GlobalStateMgr.getCurrentState().getDb("test");
@@ -2506,11 +2501,12 @@ public class PartitionBasedMvRefreshProcessorOlapTest extends MVRefreshTestBase 
     @Test
     public void testRefreshWithTraceProfile() {
         starRocksAssert.withMaterializedView("create materialized view test_mv1 \n" +
-                "partition by date_trunc('month',k1) \n" +
-                "distributed by random \n" +
-                "refresh deferred manual\n" +
-                "as select k1, k2 from tbl1;",
+                        "partition by date_trunc('month',k1) \n" +
+                        "distributed by random \n" +
+                        "refresh deferred manual\n" +
+                        "as select k1, k2 from tbl1;",
                 () -> {
+                    Config.enable_mv_refresh_query_rewrite = false;
                     Database testDb = GlobalStateMgr.getCurrentState().getDb("test");
                     MaterializedView materializedView = ((MaterializedView) testDb.getTable("test_mv1"));
 
@@ -2568,5 +2564,6 @@ public class PartitionBasedMvRefreshProcessorOlapTest extends MVRefreshTestBase 
                                 mvRefreshProfileKeys.stream().anyMatch(k -> e.getKey().contains(k)));
                     }
                 });
+        Config.enable_mv_refresh_query_rewrite = true;
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/scheduler/PartitionBasedMvRefreshProcessorPaimonTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/scheduler/PartitionBasedMvRefreshProcessorPaimonTest.java
@@ -18,13 +18,9 @@ import com.starrocks.catalog.BaseTableInfo;
 import com.starrocks.catalog.Database;
 import com.starrocks.catalog.MaterializedView;
 import com.starrocks.catalog.Partition;
-import com.starrocks.common.util.UUIDUtil;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.sql.plan.ConnectorPlanTestBase;
-import com.starrocks.sql.plan.ExecPlan;
 import com.starrocks.sql.plan.PlanTestBase;
-import com.starrocks.thrift.TExplainLevel;
-import org.apache.commons.lang3.StringUtils;
 import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.Assert;
@@ -64,20 +60,6 @@ public class PartitionBasedMvRefreshProcessorPaimonTest extends MVRefreshTestBas
     @After
     public void after() throws Exception {
         cleanupEphemeralMVs(starRocksAssert, startCaseTime);
-    }
-
-    protected void assertPlanContains(ExecPlan execPlan, String... explain) throws Exception {
-        String explainString = execPlan.getExplainString(TExplainLevel.NORMAL);
-
-        for (String expected : explain) {
-            Assert.assertTrue("expected is: " + expected + " but plan is \n" + explainString,
-                    StringUtils.containsIgnoreCase(explainString.toLowerCase(), expected));
-        }
-    }
-
-    private static void initAndExecuteTaskRun(TaskRun taskRun) throws Exception {
-        taskRun.initStatus(UUIDUtil.genUUID().toString(), System.currentTimeMillis());
-        taskRun.executeTaskRun();
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/scheduler/PartitionBasedMvRefreshTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/scheduler/PartitionBasedMvRefreshTest.java
@@ -146,7 +146,7 @@ public class PartitionBasedMvRefreshTest extends MVRefreshTestBase {
         taskRun.executeTaskRun();
     }
 
-    private static void initAndExecuteTaskRun(TaskRun taskRun) throws Exception {
+    protected static void initAndExecuteTaskRun(TaskRun taskRun) throws Exception {
         initAndExecuteTaskRun(taskRun, null, null);
     }
 

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvRefreshTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvRefreshTest.java
@@ -14,13 +14,30 @@
 
 package com.starrocks.sql.optimizer.rule.transformation.materialization;
 
+import com.starrocks.catalog.Database;
+import com.starrocks.catalog.MaterializedView;
+import com.starrocks.common.Config;
+import com.starrocks.pseudocluster.PseudoCluster;
+import com.starrocks.scheduler.MVRefreshTestBase;
+import com.starrocks.scheduler.Task;
+import com.starrocks.scheduler.TaskBuilder;
+import com.starrocks.scheduler.TaskRun;
+import com.starrocks.scheduler.TaskRunBuilder;
+import com.starrocks.server.GlobalStateMgr;
+import com.starrocks.sql.plan.ExecPlan;
+import com.starrocks.sql.plan.PlanTestBase;
+import com.starrocks.thrift.TExplainLevel;
+import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
-public class MvRefreshTest extends MvRewriteTestBase {
+public class MvRefreshTest extends MVRefreshTestBase  {
     @BeforeClass
     public static void beforeClass() throws Exception {
-        MvRewriteTestBase.beforeClass();
+        PseudoCluster.getOrCreateWithRandomPort(true, 1);
+        GlobalStateMgr.getCurrentState().getTabletChecker().setInterval(500);
+        cluster = PseudoCluster.getInstance();
+        MVRefreshTestBase.beforeClass();
         starRocksAssert.withTable(cluster, "test_base_part");
         starRocksAssert.withTable(cluster, "table_with_partition");
     }
@@ -28,15 +45,144 @@ public class MvRefreshTest extends MvRewriteTestBase {
     @Test
     public void testMvWithComplexNameRefresh() throws Exception {
         createAndRefreshMv("create materialized view `cc`" +
-                        " partition by id_date" +
-                        " distributed by hash(`t1a`)" +
-                        " as" +
-                        " select t1a, id_date, t1b from table_with_partition");
+                " partition by id_date" +
+                " distributed by hash(`t1a`)" +
+                " as" +
+                " select t1a, id_date, t1b from table_with_partition");
 
         createAndRefreshMv("create materialized view `luchen_order_8e2c65ba_1c30`" +
-                        " partition by id_date" +
-                        " distributed by hash(`t1a`)" +
-                        " as" +
-                        " select t1a, id_date, t1b from table_with_partition");
+                " partition by id_date" +
+                " distributed by hash(`t1a`)" +
+                " as" +
+                " select t1a, id_date, t1b from table_with_partition");
+    }
+
+    @Test
+    public void testMVRefreshWithQueryRewrite1() throws Exception {
+        createAndRefreshMv("create materialized view `test_mv1` \n" +
+                " partition by id_date\n" +
+                " distributed by hash(`t1a`)\n" +
+                " refresh deferred manual \n" +
+                " as\n" +
+                " select t1a, id_date, t1b, sum(t1c) as sum1 from table_with_partition group by t1a, id_date, t1b");
+        starRocksAssert.withMaterializedView("create materialized view `test_mv2` \n" +
+                        " partition by id_date\n" +
+                        " distributed by hash(`t1a`)\n" +
+                        " refresh deferred manual \n" +
+                        " as\n" +
+                        " select t1a, id_date, sum(t1c) as sum1 from table_with_partition group by t1a, id_date",
+                () -> {
+                    Database testDb = GlobalStateMgr.getCurrentState().getDb("test");
+                    MaterializedView materializedView = ((MaterializedView) testDb.getTable("test_mv2"));
+                    Task task = TaskBuilder.buildMvTask(materializedView, testDb.getFullName());
+                    TaskRun taskRun = TaskRunBuilder.newBuilder(task).build();
+
+                    // If the base table has been refreshed and test_mv1 has been refreshed, test_mv2 refresh can use
+                    // test_mv1.
+                    {
+                        ExecPlan execPlan = getMVRefreshExecPlan(taskRun);
+                        Assert.assertNotNull("exec plan should not null", execPlan);
+                        String plan = execPlan.getExplainString(TExplainLevel.NORMAL);
+                        PlanTestBase.assertContains(plan, "test_mv1");
+                    }
+
+                    // If the base table has changed and test_mv1 has not been refreshed, test_mv2 refresh should
+                    // not use test_mv1.
+                    {
+                        executeInsertSql(connectContext, "insert into table_with_partition partition(p1991)" +
+                                " values(\"varchar12\", '1991-03-01', 2, 1, 1)");
+                        ExecPlan execPlan = getMVRefreshExecPlan(taskRun);
+                        Assert.assertNotNull("exec plan should not null", execPlan);
+                        String plan = execPlan.getExplainString(TExplainLevel.NORMAL);
+                        PlanTestBase.assertNotContains(plan, "test_mv1");
+                    }
+                });
+        starRocksAssert.dropMaterializedView("test_mv1");
+    }
+
+    @Test
+    public void testMVRefreshWithQueryRewrite2() throws Exception {
+        createAndRefreshMv("create materialized view `test_mv1` \n" +
+                " partition by id_date\n" +
+                " distributed by hash(`t1a`)\n" +
+                " refresh deferred manual \n" +
+                " as\n" +
+                " select t1a, id_date, t1b, sum(t1c) as sum1 from table_with_partition group by t1a, id_date, t1b");
+        starRocksAssert.withMaterializedView("create materialized view `test_mv2` \n" +
+                        "partition by id_date\n" +
+                        "distributed by hash(`t1a`)\n" +
+                        "refresh deferred manual \n" +
+                        "PROPERTIES (\n" +
+                        "   'replication_num' = '1', \n" +
+                        "   'session.enable_materialized_view_rewrite' = 'false' \n" +
+                        ")\n" +
+                        " as\n" +
+                        " select t1a, id_date, sum(t1c) as sum1 from table_with_partition group by t1a, id_date",
+                () -> {
+                    Database testDb = GlobalStateMgr.getCurrentState().getDb("test");
+                    MaterializedView materializedView = ((MaterializedView) testDb.getTable("test_mv2"));
+                    Task task = TaskBuilder.buildMvTask(materializedView, testDb.getFullName());
+                    TaskRun taskRun = TaskRunBuilder.newBuilder(task).build();
+
+                    // If the base table has been refreshed and test_mv1 has been refreshed, test_mv2 refresh can use
+                    // test_mv1.
+                    {
+                        ExecPlan execPlan = getMVRefreshExecPlan(taskRun);
+                        Assert.assertNotNull("exec plan should not null", execPlan);
+                        String plan = execPlan.getExplainString(TExplainLevel.NORMAL);
+                        PlanTestBase.assertNotContains(plan, "test_mv1");
+                    }
+                });
+        starRocksAssert.dropMaterializedView("test_mv1");
+    }
+
+    @Test
+    public void testMVRefreshWithQueryRewrite3() throws Exception {
+        createAndRefreshMv("create materialized view `test_mv1` \n" +
+                " partition by id_date\n" +
+                " distributed by hash(`t1a`)\n" +
+                " refresh deferred manual \n" +
+                " as\n" +
+                " select t1a, id_date, t1b, sum(t1c) as sum1 from table_with_partition group by t1a, id_date, t1b");
+        Config.enable_mv_refresh_query_rewrite = false;
+        starRocksAssert.withMaterializedView("create materialized view `test_mv2` \n" +
+                        "partition by id_date\n" +
+                        "distributed by hash(`t1a`)\n" +
+                        "refresh deferred manual \n" +
+                        "PROPERTIES (\n" +
+                        "   'replication_num' = '1', \n" +
+                        "   'session.enable_materialized_view_rewrite' = 'true', \n" +
+                        "   'session.enable_materialized_view_for_insert' = 'true' \n" +
+                        ")\n" +
+                        " as\n" +
+                        " select t1a, id_date, sum(t1c) as sum1 from table_with_partition group by t1a, id_date",
+                () -> {
+                    Database testDb = GlobalStateMgr.getCurrentState().getDb("test");
+                    MaterializedView materializedView = ((MaterializedView) testDb.getTable("test_mv2"));
+                    Task task = TaskBuilder.buildMvTask(materializedView, testDb.getFullName());
+                    TaskRun taskRun = TaskRunBuilder.newBuilder(task).build();
+
+                    // If the base table has been refreshed and test_mv1 has been refreshed, test_mv2 refresh can use
+                    // test_mv1.
+                    {
+                        ExecPlan execPlan = getMVRefreshExecPlan(taskRun);
+                        Assert.assertNotNull("exec plan should not null", execPlan);
+                        String plan = execPlan.getExplainString(TExplainLevel.NORMAL);
+                        PlanTestBase.assertContains(plan, "test_mv1");
+                    }
+
+                    // If the base table has changed and test_mv1 has not been refreshed, test_mv2 refresh should
+                    // not use test_mv1.
+                    {
+                        executeInsertSql(connectContext, "insert into table_with_partition partition(p1991)" +
+                                " values(\"varchar12\", '1991-03-01', 2, 1, 1)");
+                        ExecPlan execPlan = getMVRefreshExecPlan(taskRun);
+                        Assert.assertNotNull("exec plan should not null", execPlan);
+                        String plan = execPlan.getExplainString(TExplainLevel.NORMAL);
+                        PlanTestBase.assertNotContains(plan, "test_mv1");
+                    }
+                });
+        Config.enable_mv_refresh_query_rewrite = true;
+        starRocksAssert.dropMaterializedView("test_mv1");
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/utframe/UtFrameUtils.java
+++ b/fe/fe-core/src/test/java/com/starrocks/utframe/UtFrameUtils.java
@@ -1280,6 +1280,9 @@ public class UtFrameUtils {
         // Enable mv refresh insert strict in test
         Config.enable_mv_refresh_insert_strict = true;
 
+        // Enable mv rewrite in mv refresh by default
+        Config.enable_mv_refresh_query_rewrite = true;
+
         FeConstants.enablePruneEmptyOutputScan = false;
         FeConstants.runningUnitTest = true;
 

--- a/test/sql/test_materialized_view_refresh/R/test_mv_refresh_with_event_trigger
+++ b/test/sql/test_materialized_view_refresh/R/test_mv_refresh_with_event_trigger
@@ -1,4 +1,4 @@
--- name: test_mv_refresh_with_event_trigger
+-- name: test_mv_refresh_with_event_trigger @slow
 create database db_${uuid0};
 -- result:
 -- !result

--- a/test/sql/test_materialized_view_refresh/R/test_mv_refresh_with_multi_union3
+++ b/test/sql/test_materialized_view_refresh/R/test_mv_refresh_with_multi_union3
@@ -1,4 +1,4 @@
--- name: test_mv_refresh_with_multi_union3
+-- name: test_mv_refresh_with_multi_union3 @slow
 create database db_${uuid0};
 -- result:
 -- !result

--- a/test/sql/test_materialized_view_refresh/R/test_mv_refresh_with_mv_reuse
+++ b/test/sql/test_materialized_view_refresh/R/test_mv_refresh_with_mv_reuse
@@ -1,0 +1,200 @@
+-- name: test_mv_refresh_with_mv_reuse
+create database db_${uuid0};
+-- result:
+-- !result
+use db_${uuid0};
+-- result:
+-- !result
+CREATE TABLE `t1` (
+    `k1`  date not null, 
+    `k2`  datetime not null, 
+    `k3`  char(20), 
+    `k4`  varchar(20), 
+    `k5`  boolean, 
+    `k6`  tinyint, 
+    `k7`  smallint, 
+    `k8`  int, 
+    `k9`  bigint, 
+    `k10` largeint, 
+    `k11` float, 
+    `k12` double, 
+    `k13` decimal(27,9) ) 
+DUPLICATE KEY(`k1`, `k2`, `k3`, `k4`, `k5`) 
+PARTITION BY date_trunc('day', `k1`) 
+DISTRIBUTED BY RANDOM BUCKETS 3 ;
+-- result:
+-- !result
+INSERT INTO t1 VALUES
+    ('2020-10-11','2020-10-24 12:12:12','k3','k4',0,0,2,3,4,5,1.1,1.12,2.889),
+    ('2020-10-12','2020-10-25 12:12:12','k3','k4',0,1,2,3,4,5,1.1,1.12,2.889),
+    ('2020-10-21','2020-10-24 12:12:12','k3','k4',0,0,2,3,4,5,1.1,1.12,2.889),
+    ('2020-10-22','2020-10-23 12:12:12','k3','k4',0,1,2,3,4,5,1.1,1.12,2.889),
+    ('2020-10-23','2020-10-24 12:12:12','k3','k4',0,0,2,3,4,5,1.1,1.12,2.889),
+    ('2020-10-24','2020-10-25 12:12:12','k3','k4',0,1,2,3,4,5,1.1,1.12,2.889);
+-- result:
+-- !result
+    
+CREATE TABLE `t2` (
+    `k1`  date not null, 
+    `k2`  datetime not null, 
+    `k3`  char(20), 
+    `k4`  varchar(20), 
+    `k5`  boolean, 
+    `k6`  tinyint, 
+    `k7`  smallint, 
+    `k8`  int, 
+    `k9`  bigint, 
+    `k10` largeint, 
+    `k11` float, 
+    `k12` double, 
+    `k13` decimal(27,9) ) 
+DUPLICATE KEY(`k1`, `k2`, `k3`, `k4`, `k5`) 
+PARTITION BY date_trunc('day', `k1`) 
+DISTRIBUTED BY RANDOM BUCKETS 3 ;
+-- result:
+-- !result
+INSERT INTO t2 VALUES
+    ('2020-10-10','2020-10-23 12:12:12','k3','k4',0,1,2,3,4,5,1.1,1.12,2.889),
+    ('2020-10-11','2020-10-24 12:12:12','k3','k4',0,0,2,3,4,5,1.1,1.12,2.889),
+    ('2020-10-12','2020-10-25 12:12:12','k3','k4',0,1,2,3,4,5,1.1,1.12,2.889),
+    ('2020-10-21','2020-10-24 12:12:12','k3','k4',0,0,2,3,4,5,1.1,1.12,2.889),
+    ('2020-10-22','2020-10-25 12:12:12','k3','k4',0,1,2,3,4,5,1.1,1.12,2.889);
+-- result:
+-- !result
+set cbo_enable_low_cardinality_optimize = false;   
+CREATE MATERIALIZED VIEW IF NOT EXISTS test_mv0
+PARTITION BY `ak1`
+DISTRIBUTED BY HASH(`ak1`)
+REFRESH DEFERRED MANUAL
+as 
+select a.k1 as ak1, b.k1 as bk1, a.k3 as ak3, b.k3 as bk3, a.k4 as ak4, b.k4 as bk4, sum(a.k6) as sum_k6, sum(b.k7) as sum_k7, sum(a.k8) as sum_k8, sum(b.k9) as sum_k9
+from t1 a join t2 b on a.k1=b.k1 group by a.k1, b.k1, a.k3, b.k3, a.k4, b.k4;
+-- result:
+-- !result
+refresh materialized view  test_mv0 with sync mode;
+select * from test_mv0 order by 1, 2, 3, 4, 5, 6;
+-- result:
+2020-10-11	2020-10-11	k3	k3	k4	k4	0	2	3	4
+2020-10-12	2020-10-12	k3	k3	k4	k4	1	2	3	4
+2020-10-21	2020-10-21	k3	k3	k4	k4	0	2	3	4
+2020-10-22	2020-10-22	k3	k3	k4	k4	1	2	3	4
+-- !result
+function: print_hit_materialized_view('select a.k1 as ak1, b.k1 as bk1, a.k3 as ak3, b.k3 as bk3, sum(a.k6) as sum_k6, sum(b.k7) as sum_k7, sum(a.k8) as sum_k8, sum(b.k9) as sum_k9 from t1 a join t2 b on a.k1=b.k1 group by a.k1, b.k1, a.k3, b.k3;', 'test_mv0')
+-- result:
+True
+-- !result
+select a.k1 as ak1, b.k1 as bk1, a.k3 as ak3, b.k3 as bk3, sum(a.k6) as sum_k6, sum(b.k7) as sum_k7, sum(a.k8) as sum_k8, sum(b.k9) as sum_k9 from t1 a join t2 b on a.k1=b.k1 group by a.k1, b.k1, a.k3, b.k3 order by 1, 2, 3, 4, 5, 6;
+-- result:
+2020-10-11	2020-10-11	k3	k3	0	2	3	4
+2020-10-12	2020-10-12	k3	k3	1	2	3	4
+2020-10-21	2020-10-21	k3	k3	0	2	3	4
+2020-10-22	2020-10-22	k3	k3	1	2	3	4
+-- !result
+CREATE MATERIALIZED VIEW IF NOT EXISTS test_mv1
+PARTITION BY `ak1`
+DISTRIBUTED BY HASH(`ak1`)
+REFRESH DEFERRED MANUAL
+as 
+select a.k1 as ak1, b.k1 as bk1, a.k3 as ak3, b.k3 as bk3, sum(a.k6) as sum_k6, sum(b.k7) as sum_k7, sum(a.k8) as sum_k8, sum(b.k9) as sum_k9 
+from t1 a join t2 b on a.k1=b.k1 group by a.k1, b.k1, a.k3, b.k3; 
+
+refresh materialized view test_mv1 with sync mode;
+-- result:
+-- !result
+select * from test_mv1 order by 1, 2, 3, 4;
+-- result:
+2020-10-11	2020-10-11	k3	k3	0	2	3	4
+2020-10-12	2020-10-12	k3	k3	1	2	3	4
+2020-10-21	2020-10-21	k3	k3	0	2	3	4
+2020-10-22	2020-10-22	k3	k3	1	2	3	4
+-- !result
+function: print_hit_materialized_view('select a.k1 as ak1, b.k1 as bk1, a.k3 as ak3, b.k3 as bk3, sum(a.k6) as sum_k6, sum(b.k7) as sum_k7, sum(a.k8) as sum_k8, sum(b.k9) as sum_k9 from t1 a join t2 b on a.k1=b.k1 group by a.k1, b.k1, a.k3, b.k3;', 'test_mv1')
+-- result:
+True
+-- !result
+select a.k1 as ak1, b.k1 as bk1, a.k3 as ak3, b.k3 as bk3, sum(a.k6) as sum_k6, sum(b.k7) as sum_k7, sum(a.k8) as sum_k8, sum(b.k9) as sum_k9 from t1 a join t2 b on a.k1=b.k1 group by a.k1, b.k1, a.k3, b.k3 order by 1, 2, 3, 4;
+-- result:
+2020-10-11	2020-10-11	k3	k3	0	2	3	4
+2020-10-12	2020-10-12	k3	k3	1	2	3	4
+2020-10-21	2020-10-21	k3	k3	0	2	3	4
+2020-10-22	2020-10-22	k3	k3	1	2	3	4
+-- !result
+function: print_hit_materialized_view('select a.k1 as ak1, a.k3 as ak3, sum(a.k6) as sum_k6, sum(b.k7) as sum_k7, sum(a.k8) as sum_k8 from t1 a join t2 b on a.k1=b.k1 group by a.k1, a.k3;', 'test_mv1')
+-- result:
+True
+-- !result
+select a.k1 as ak1, a.k3 as ak3, sum(a.k6) as sum_k6, sum(b.k7) as sum_k7, sum(a.k8) as sum_k8 from t1 a join t2 b on a.k1=b.k1 group by a.k1, a.k3 order by 1, 2, 3, 4; 
+
+CREATE MATERIALIZED VIEW IF NOT EXISTS test_mv2
+PARTITION BY `ak1`
+DISTRIBUTED BY HASH(`ak1`)
+REFRESH DEFERRED MANUAL
+as 
+select a.k1 as ak1, a.k3 as ak3, sum(a.k6) as sum_k6, sum(b.k7) as sum_k7, sum(a.k8) as sum_k8
+from t1 a join t2 b on a.k1=b.k1 group by a.k1, a.k3; 
+
+refresh materialized view test_mv2 with sync mode;
+-- result:
+2020-10-11	k3	0	2	3
+2020-10-12	k3	1	2	3
+2020-10-21	k3	0	2	3
+2020-10-22	k3	1	2	3
+-- !result
+select * from test_mv2 order by 1, 2, 3, 4;
+-- result:
+2020-10-11	k3	0	2	3
+2020-10-12	k3	1	2	3
+2020-10-21	k3	0	2	3
+2020-10-22	k3	1	2	3
+-- !result
+function: print_hit_materialized_view('select a.k1 as ak1, a.k3 as ak3, sum(a.k6) as sum_k6, sum(b.k7) as sum_k7, sum(a.k8) as sum_k8 from t1 a join t2 b on a.k1=b.k1 group by a.k1, a.k3;', 'test_mv2')
+-- result:
+True
+-- !result
+select a.k1 as ak1, a.k3 as ak3, sum(a.k6) as sum_k6, sum(b.k7) as sum_k7, sum(a.k8) as sum_k8 from t1 a join t2 b on a.k1=b.k1 group by a.k1, a.k3 order by 1, 2, 3, 4;
+-- result:
+2020-10-11	k3	0	2	3
+2020-10-12	k3	1	2	3
+2020-10-21	k3	0	2	3
+2020-10-22	k3	1	2	3
+-- !result
+function: print_hit_materialized_view('select a.k1 as ak1, sum(a.k6) as sum_k6, sum(b.k7) as sum_k7 from t1 a join t2 b on a.k1=b.k1 group by a.k1;', 'test_mv2')
+-- result:
+True
+-- !result
+select a.k1 as ak1, sum(a.k6) as sum_k6, sum(b.k7) as sum_k7 from t1 a join t2 b on a.k1=b.k1 group by a.k1 order by 1, 2;
+-- result:
+2020-10-11	0	2
+2020-10-12	1	2
+2020-10-21	0	2
+2020-10-22	1	2
+-- !result
+CREATE MATERIALIZED VIEW IF NOT EXISTS test_mv3
+PARTITION BY `ak1`
+DISTRIBUTED BY HASH(`ak1`)
+REFRESH DEFERRED MANUAL
+as 
+select a.k1 as ak1, sum(a.k6) as sum_k6, sum(b.k7) as sum_k7 from t1 a join t2 b on a.k1=b.k1 group by a.k1;
+-- result:
+-- !result
+refresh materialized view test_mv1 with sync mode;
+select * from test_mv3 order by 1;
+-- result:
+-- !result
+function: print_hit_materialized_view('select a.k1 as ak1, sum(a.k6) as sum_k6, sum(b.k7) as sum_k7 from t1 a join t2 b on a.k1=b.k1 group by a.k1;', 'test_mv3')
+-- result:
+False
+-- !result
+select a.k1 as ak1, sum(a.k6) as sum_k6, sum(b.k7) as sum_k7 from t1 a join t2 b on a.k1=b.k1 group by a.k1 order by 1, 2;
+-- result:
+2020-10-11	0	2
+2020-10-12	1	2
+2020-10-21	0	2
+2020-10-22	1	2
+-- !result
+drop table t1;
+-- result:
+-- !result
+drop table t2;
+-- result:
+-- !result

--- a/test/sql/test_materialized_view_refresh/T/test_mv_refresh_with_event_trigger
+++ b/test/sql/test_materialized_view_refresh/T/test_mv_refresh_with_event_trigger
@@ -1,4 +1,4 @@
--- name: test_mv_refresh_with_event_trigger
+-- name: test_mv_refresh_with_event_trigger @slow
 
 create database db_${uuid0};
 use db_${uuid0};

--- a/test/sql/test_materialized_view_refresh/T/test_mv_refresh_with_multi_union3
+++ b/test/sql/test_materialized_view_refresh/T/test_mv_refresh_with_multi_union3
@@ -1,4 +1,4 @@
--- name: test_mv_refresh_with_multi_union3
+-- name: test_mv_refresh_with_multi_union3 @slow
 
 create database db_${uuid0};
 use db_${uuid0};

--- a/test/sql/test_materialized_view_refresh/T/test_mv_refresh_with_mv_reuse
+++ b/test/sql/test_materialized_view_refresh/T/test_mv_refresh_with_mv_reuse
@@ -1,0 +1,117 @@
+-- name: test_mv_refresh_with_mv_reuse
+create database db_${uuid0};
+use db_${uuid0};
+CREATE TABLE `t1` (
+    `k1`  date not null, 
+    `k2`  datetime not null, 
+    `k3`  char(20), 
+    `k4`  varchar(20), 
+    `k5`  boolean, 
+    `k6`  tinyint, 
+    `k7`  smallint, 
+    `k8`  int, 
+    `k9`  bigint, 
+    `k10` largeint, 
+    `k11` float, 
+    `k12` double, 
+    `k13` decimal(27,9) ) 
+DUPLICATE KEY(`k1`, `k2`, `k3`, `k4`, `k5`) 
+PARTITION BY date_trunc('day', `k1`) 
+DISTRIBUTED BY RANDOM BUCKETS 3 ;
+
+INSERT INTO t1 VALUES
+    ('2020-10-11','2020-10-24 12:12:12','k3','k4',0,0,2,3,4,5,1.1,1.12,2.889),
+    ('2020-10-12','2020-10-25 12:12:12','k3','k4',0,1,2,3,4,5,1.1,1.12,2.889),
+    ('2020-10-21','2020-10-24 12:12:12','k3','k4',0,0,2,3,4,5,1.1,1.12,2.889),
+    ('2020-10-22','2020-10-23 12:12:12','k3','k4',0,1,2,3,4,5,1.1,1.12,2.889),
+    ('2020-10-23','2020-10-24 12:12:12','k3','k4',0,0,2,3,4,5,1.1,1.12,2.889),
+    ('2020-10-24','2020-10-25 12:12:12','k3','k4',0,1,2,3,4,5,1.1,1.12,2.889);
+    
+CREATE TABLE `t2` (
+    `k1`  date not null, 
+    `k2`  datetime not null, 
+    `k3`  char(20), 
+    `k4`  varchar(20), 
+    `k5`  boolean, 
+    `k6`  tinyint, 
+    `k7`  smallint, 
+    `k8`  int, 
+    `k9`  bigint, 
+    `k10` largeint, 
+    `k11` float, 
+    `k12` double, 
+    `k13` decimal(27,9) ) 
+DUPLICATE KEY(`k1`, `k2`, `k3`, `k4`, `k5`) 
+PARTITION BY date_trunc('day', `k1`) 
+DISTRIBUTED BY RANDOM BUCKETS 3 ;
+
+INSERT INTO t2 VALUES
+    ('2020-10-10','2020-10-23 12:12:12','k3','k4',0,1,2,3,4,5,1.1,1.12,2.889),
+    ('2020-10-11','2020-10-24 12:12:12','k3','k4',0,0,2,3,4,5,1.1,1.12,2.889),
+    ('2020-10-12','2020-10-25 12:12:12','k3','k4',0,1,2,3,4,5,1.1,1.12,2.889),
+    ('2020-10-21','2020-10-24 12:12:12','k3','k4',0,0,2,3,4,5,1.1,1.12,2.889),
+    ('2020-10-22','2020-10-25 12:12:12','k3','k4',0,1,2,3,4,5,1.1,1.12,2.889);
+
+set cbo_enable_low_cardinality_optimize = false;   
+CREATE MATERIALIZED VIEW IF NOT EXISTS test_mv0
+PARTITION BY `ak1`
+DISTRIBUTED BY HASH(`ak1`)
+REFRESH DEFERRED MANUAL
+as 
+select a.k1 as ak1, b.k1 as bk1, a.k3 as ak3, b.k3 as bk3, a.k4 as ak4, b.k4 as bk4, sum(a.k6) as sum_k6, sum(b.k7) as sum_k7, sum(a.k8) as sum_k8, sum(b.k9) as sum_k9
+from t1 a join t2 b on a.k1=b.k1 group by a.k1, b.k1, a.k3, b.k3, a.k4, b.k4;
+refresh materialized view  test_mv0 with sync mode;
+select * from test_mv0 order by 1, 2, 3, 4, 5, 6;
+
+---- test_mv1 refresh should reuse the materialized view test_mv0
+function: print_hit_materialized_view('select a.k1 as ak1, b.k1 as bk1, a.k3 as ak3, b.k3 as bk3, sum(a.k6) as sum_k6, sum(b.k7) as sum_k7, sum(a.k8) as sum_k8, sum(b.k9) as sum_k9 from t1 a join t2 b on a.k1=b.k1 group by a.k1, b.k1, a.k3, b.k3;', 'test_mv0')
+select a.k1 as ak1, b.k1 as bk1, a.k3 as ak3, b.k3 as bk3, sum(a.k6) as sum_k6, sum(b.k7) as sum_k7, sum(a.k8) as sum_k8, sum(b.k9) as sum_k9 from t1 a join t2 b on a.k1=b.k1 group by a.k1, b.k1, a.k3, b.k3 order by 1, 2, 3, 4, 5, 6;
+
+CREATE MATERIALIZED VIEW IF NOT EXISTS test_mv1
+PARTITION BY `ak1`
+DISTRIBUTED BY HASH(`ak1`)
+REFRESH DEFERRED MANUAL
+as 
+select a.k1 as ak1, b.k1 as bk1, a.k3 as ak3, b.k3 as bk3, sum(a.k6) as sum_k6, sum(b.k7) as sum_k7, sum(a.k8) as sum_k8, sum(b.k9) as sum_k9 
+from t1 a join t2 b on a.k1=b.k1 group by a.k1, b.k1, a.k3, b.k3; 
+
+refresh materialized view test_mv1 with sync mode;
+select * from test_mv1 order by 1, 2, 3, 4;
+function: print_hit_materialized_view('select a.k1 as ak1, b.k1 as bk1, a.k3 as ak3, b.k3 as bk3, sum(a.k6) as sum_k6, sum(b.k7) as sum_k7, sum(a.k8) as sum_k8, sum(b.k9) as sum_k9 from t1 a join t2 b on a.k1=b.k1 group by a.k1, b.k1, a.k3, b.k3;', 'test_mv1')
+select a.k1 as ak1, b.k1 as bk1, a.k3 as ak3, b.k3 as bk3, sum(a.k6) as sum_k6, sum(b.k7) as sum_k7, sum(a.k8) as sum_k8, sum(b.k9) as sum_k9 from t1 a join t2 b on a.k1=b.k1 group by a.k1, b.k1, a.k3, b.k3 order by 1, 2, 3, 4;
+
+-- test_mv2 refresh should reuse the materialized view test_mv1
+function: print_hit_materialized_view('select a.k1 as ak1, a.k3 as ak3, sum(a.k6) as sum_k6, sum(b.k7) as sum_k7, sum(a.k8) as sum_k8 from t1 a join t2 b on a.k1=b.k1 group by a.k1, a.k3;', 'test_mv1')
+select a.k1 as ak1, a.k3 as ak3, sum(a.k6) as sum_k6, sum(b.k7) as sum_k7, sum(a.k8) as sum_k8 from t1 a join t2 b on a.k1=b.k1 group by a.k1, a.k3 order by 1, 2, 3, 4; 
+
+CREATE MATERIALIZED VIEW IF NOT EXISTS test_mv2
+PARTITION BY `ak1`
+DISTRIBUTED BY HASH(`ak1`)
+REFRESH DEFERRED MANUAL
+as 
+select a.k1 as ak1, a.k3 as ak3, sum(a.k6) as sum_k6, sum(b.k7) as sum_k7, sum(a.k8) as sum_k8
+from t1 a join t2 b on a.k1=b.k1 group by a.k1, a.k3; 
+
+refresh materialized view test_mv2 with sync mode;
+select * from test_mv2 order by 1, 2, 3, 4;
+function: print_hit_materialized_view('select a.k1 as ak1, a.k3 as ak3, sum(a.k6) as sum_k6, sum(b.k7) as sum_k7, sum(a.k8) as sum_k8 from t1 a join t2 b on a.k1=b.k1 group by a.k1, a.k3;', 'test_mv2')
+select a.k1 as ak1, a.k3 as ak3, sum(a.k6) as sum_k6, sum(b.k7) as sum_k7, sum(a.k8) as sum_k8 from t1 a join t2 b on a.k1=b.k1 group by a.k1, a.k3 order by 1, 2, 3, 4;
+
+-- test_mv3 refresh should reuse the materialized view test_mv2
+function: print_hit_materialized_view('select a.k1 as ak1, sum(a.k6) as sum_k6, sum(b.k7) as sum_k7 from t1 a join t2 b on a.k1=b.k1 group by a.k1;', 'test_mv2')
+select a.k1 as ak1, sum(a.k6) as sum_k6, sum(b.k7) as sum_k7 from t1 a join t2 b on a.k1=b.k1 group by a.k1 order by 1, 2;
+
+CREATE MATERIALIZED VIEW IF NOT EXISTS test_mv3
+PARTITION BY `ak1`
+DISTRIBUTED BY HASH(`ak1`)
+REFRESH DEFERRED MANUAL
+as 
+select a.k1 as ak1, sum(a.k6) as sum_k6, sum(b.k7) as sum_k7 from t1 a join t2 b on a.k1=b.k1 group by a.k1;
+
+refresh materialized view test_mv1 with sync mode;
+select * from test_mv3 order by 1;
+function: print_hit_materialized_view('select a.k1 as ak1, sum(a.k6) as sum_k6, sum(b.k7) as sum_k7 from t1 a join t2 b on a.k1=b.k1 group by a.k1;', 'test_mv3')
+select a.k1 as ak1, sum(a.k6) as sum_k6, sum(b.k7) as sum_k7 from t1 a join t2 b on a.k1=b.k1 group by a.k1 order by 1, 2;
+
+drop table t1;
+drop table t2;

--- a/test/test_sql_cases.py
+++ b/test/test_sql_cases.py
@@ -91,6 +91,7 @@ class TestSQLCases(sr_sql_lib.StarrocksSQLApiLib):
         """
         default_configs = [
             "'enable_mv_refresh_insert_strict' = 'true'",
+            "'enable_mv_refresh_query_rewrite' = 'true'",
         ]
 
         for config in default_configs:


### PR DESCRIPTION
## Why I'm doing:
- If mv's defined query can use the already refreshed mv, we can use mv rewrite in the refresh stage. But we disable all mv rewrite in refresh at current.

## What I'm doing:
-  enable to rewrite query in mv refresh or not so it can use query the rewritten mv directly rather than original base table to improve query performance.
- By default, mv rewrite is not enabled in mv refresh, you can use this:
```
-- enable all mvs can use other mv by rewrite for refresh
admin set frontend config ('enable_mv_refresh_query_rewrite' = 'true');
```
or
```
-- enable one specific mv that mv refresh can use mv rewrite
alter materialized view <mv_name> set ('session.enable_materialized_view_rewrite' = 'true');
alter materialized view <mv_name> set ('session.enable_materialized_view_for_insert' = 'true');
```

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
