### PR TITLE
[BugFix] Release driver token ASAP (backport #45314)

### DIFF
--- a/be/src/exec/pipeline/driver_limiter.cpp
+++ b/be/src/exec/pipeline/driver_limiter.cpp
@@ -6,10 +6,11 @@ namespace starrocks::pipeline {
 
 StatusOr<DriverLimiter::TokenPtr> DriverLimiter::try_acquire(int num_drivers) {
     int prev_num_total_drivers = _num_total_drivers.fetch_add(num_drivers);
-    if (prev_num_total_drivers >= _max_num_drivers) {
+    if (prev_num_total_drivers + num_drivers > _max_num_drivers) {
         _num_total_drivers.fetch_sub(num_drivers);
         return Status::TooManyTasks(
-                strings::Substitute("BE has overloaded with $0 pipeline drivers", prev_num_total_drivers));
+                strings::Substitute("BE has overloaded with pipeline drivers [limit=$0] [used=$1] [request=$2]",
+                                    _max_num_drivers, prev_num_total_drivers, num_drivers));
     }
     return std::make_unique<DriverLimiter::Token>(_num_total_drivers, num_drivers);
 }

--- a/be/src/exec/pipeline/driver_limiter.h
+++ b/be/src/exec/pipeline/driver_limiter.h
@@ -38,6 +38,8 @@ public:
     // `num_drivers` drivers back to the limiter.
     StatusOr<TokenPtr> try_acquire(int num_drivers);
 
+    int num_total_drivers() const { return _num_total_drivers; }
+
 private:
     const int _max_num_drivers;
     std::atomic<int> _num_total_drivers{0};

--- a/be/src/exec/pipeline/fragment_context.cpp
+++ b/be/src/exec/pipeline/fragment_context.cpp
@@ -44,6 +44,7 @@ void FragmentContext::set_stream_load_contexts(const std::vector<StreamLoadConte
 void FragmentContext::cancel(const Status& status) {
     if (!status.ok() && _runtime_state != nullptr && _runtime_state->query_ctx() != nullptr) {
         _runtime_state->query_ctx()->release_workgroup_token_once();
+        _driver_token.reset();
     }
 
     _runtime_state->set_is_cancelled(true);

--- a/be/src/exec/pipeline/fragment_context.cpp
+++ b/be/src/exec/pipeline/fragment_context.cpp
@@ -17,6 +17,9 @@ void FragmentContext::set_final_status(const Status& status) {
     Status* old_status = nullptr;
     if (_final_status.compare_exchange_strong(old_status, &_s_status)) {
         _s_status = status;
+
+        _driver_token.reset();
+
         if (_s_status.is_cancelled()) {
             auto detailed_message = _s_status.detailed_message();
             std::stringstream ss;
@@ -44,7 +47,6 @@ void FragmentContext::set_stream_load_contexts(const std::vector<StreamLoadConte
 void FragmentContext::cancel(const Status& status) {
     if (!status.ok() && _runtime_state != nullptr && _runtime_state->query_ctx() != nullptr) {
         _runtime_state->query_ctx()->release_workgroup_token_once();
-        _driver_token.reset();
     }
 
     _runtime_state->set_is_cancelled(true);

--- a/be/src/runtime/exec_env.cpp
+++ b/be/src/runtime/exec_env.cpp
@@ -210,6 +210,10 @@ Status ExecEnv::_init(const std::vector<StorePath>& store_paths) {
 
     _driver_limiter =
             new pipeline::DriverLimiter(_max_executor_threads * config::pipeline_max_num_drivers_per_exec_thread);
+    REGISTER_GAUGE_STARROCKS_METRIC(pipe_drivers, [] {
+        auto* driver_limiter = ExecEnv::GetInstance()->driver_limiter();
+        return (driver_limiter == nullptr) ? 0 : driver_limiter->num_total_drivers();
+    });
 
     std::unique_ptr<ThreadPool> wg_driver_executor_thread_pool;
     RETURN_IF_ERROR(ThreadPoolBuilder("pip_wg_executor") // pipeline executor for workgroup

--- a/be/src/util/starrocks_metrics.h
+++ b/be/src/util/starrocks_metrics.h
@@ -66,6 +66,7 @@ public:
     METRIC_DEFINE_INT_GAUGE(query_scan_bytes_per_second, MetricUnit::BYTES);
     METRIC_DEFINE_INT_COUNTER(query_scan_bytes, MetricUnit::BYTES);
     METRIC_DEFINE_INT_COUNTER(query_scan_rows, MetricUnit::ROWS);
+    METRIC_DEFINE_INT_GAUGE(pipe_drivers, MetricUnit::NOUNIT);
 
     // counters
     METRIC_DEFINE_INT_COUNTER(fragment_requests_total, MetricUnit::REQUESTS);

--- a/test/sql/test_pipeline/R/test_exceed_driver_limit
+++ b/test/sql/test_pipeline/R/test_exceed_driver_limit
@@ -1,0 +1,56 @@
+-- name: test_exceed_driver_limit @sequential
+CREATE TABLE `t1` (
+  `k1` bigint(20) NULL COMMENT ""
+) ENGINE=OLAP
+DUPLICATE KEY(`k1`)
+DISTRIBUTED BY HASH(`k1`) BUCKETS 32
+PROPERTIES (
+    "replication_num" = "1"
+);
+-- result:
+-- !result
+insert into t1 values (1);
+-- result:
+-- !result
+select /*+SET_VAR(pipeline_dop=10240)*/ * from t1 UNION ALL
+select * from t1 UNION ALL
+select * from t1 UNION ALL
+select * from t1 UNION ALL
+select * from t1 UNION ALL
+select * from t1 UNION ALL
+select * from t1 UNION ALL
+select * from t1 UNION ALL
+select * from t1 UNION ALL
+select * from t1 UNION ALL 
+select count(1) from t1 group by k1;
+-- result:
+[REGEX].*BE has overloaded with pipeline drivers.*
+-- !result
+select /*+SET_VAR(pipeline_dop=10240)*/ count(1) from t1;
+-- result:
+1
+-- !result
+select /*+SET_VAR(pipeline_dop=1024)*/ * from t1 UNION ALL
+select * from t1 UNION ALL
+select * from t1 UNION ALL
+select * from t1 UNION ALL
+select * from t1 UNION ALL
+select * from t1 UNION ALL
+select * from t1 UNION ALL
+select * from t1 UNION ALL
+select * from t1 UNION ALL
+select * from t1 UNION ALL 
+select count(1) from t1 group by k1;
+-- result:
+1
+1
+1
+1
+1
+1
+1
+1
+1
+1
+1
+-- !result

--- a/test/sql/test_pipeline/T/test_exceed_driver_limit
+++ b/test/sql/test_pipeline/T/test_exceed_driver_limit
@@ -1,0 +1,42 @@
+-- name: test_exceed_driver_limit @sequential
+
+CREATE TABLE `t1` (
+  `k1` bigint(20) NULL COMMENT ""
+) ENGINE=OLAP
+DUPLICATE KEY(`k1`)
+DISTRIBUTED BY HASH(`k1`) BUCKETS 32
+PROPERTIES (
+    "replication_num" = "1"
+);
+
+insert into t1 values (1);
+
+
+-- This query will exceed the driver limit in BEs.
+select /*+SET_VAR(pipeline_dop=10240)*/ * from t1 UNION ALL
+select * from t1 UNION ALL
+select * from t1 UNION ALL
+select * from t1 UNION ALL
+select * from t1 UNION ALL
+select * from t1 UNION ALL
+select * from t1 UNION ALL
+select * from t1 UNION ALL
+select * from t1 UNION ALL
+select * from t1 UNION ALL 
+select count(1) from t1 group by k1;
+
+
+-- After the above query fails, we can run the following query to verify that the driver limit is not exceeded.
+select /*+SET_VAR(pipeline_dop=10240)*/ count(1) from t1;
+
+select /*+SET_VAR(pipeline_dop=1024)*/ * from t1 UNION ALL
+select * from t1 UNION ALL
+select * from t1 UNION ALL
+select * from t1 UNION ALL
+select * from t1 UNION ALL
+select * from t1 UNION ALL
+select * from t1 UNION ALL
+select * from t1 UNION ALL
+select * from t1 UNION ALL
+select * from t1 UNION ALL 
+select count(1) from t1 group by k1;


### PR DESCRIPTION
This is CP from #45314.

## Why I'm doing:

A driver token, which increases the numbers of drivers on the BE, is held by a fragment context and released when the fragment context is released.

A fragment context is released when the query context is released. And a query context is released when all the fragment contexts are finished or delivery timeout (not all the fragment contexts prepared or finished). 
If some fragments are prepared successfully on the BE and some fragments fails to be prepared, the rest fragments will not be delivered to BE. And then the query context will not be released until delivery timeout (5min).

As a result, when an extremely complex query, which contains lots of fragments and drivers, is being delivered to BE, lots of fragment contexts will be prepared successfully and a few fragment contexts will fail to be prepared due to the error `BE has overloaded with pipeline drivers`. And then these driver tokens will not be released, until delivery timeout.

## What I'm doing:
Release driver token when cancelling a fragment context.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [x] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5

