### PR TITLE
[Refactor] Introduce ColumnId to support Column renaming (part1)

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/alter/SchemaChangeHandler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/SchemaChangeHandler.java
@@ -891,12 +891,12 @@ public class SchemaChangeHandler extends AlterHandler {
 
         // check if the new column already exist in column id.
         // do not support adding new column which already exist in column id.
-        Optional<Column> foundPhysicalColumn = olapTable.getBaseSchema().stream()
+        foundColumn = olapTable.getBaseSchema().stream()
                 .filter(c -> c.getColumnId().getId().equalsIgnoreCase(newColName)).findFirst();
-        if (foundPhysicalColumn.isPresent()) {
+        if (foundColumn.isPresent()) {
             throw new DdlException(
-                    "Can not add column which already exists in physical column: " + newColName
-                            + ", you can remove " + foundPhysicalColumn.get() + " and try again.");
+                    "Can not add column which already exists in column id: " + newColName
+                            + ", you can remove " + foundColumn.get() + " and try again.");
         }
 
         /*

--- a/fe/fe-core/src/main/java/com/starrocks/alter/SchemaChangeHandler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/SchemaChangeHandler.java
@@ -889,10 +889,10 @@ public class SchemaChangeHandler extends AlterHandler {
                     "Can not add column which already exists in base table: " + newColName);
         }
 
-        // check if the new column already exist in physical column.
-        // do not support adding new column which already exist in physical column.
+        // check if the new column already exist in column id.
+        // do not support adding new column which already exist in column id.
         Optional<Column> foundPhysicalColumn = olapTable.getBaseSchema().stream()
-                .filter(c -> c.getDirectPhysicalName().equalsIgnoreCase(newColName)).findFirst();
+                .filter(c -> c.getColumnId().getId().equalsIgnoreCase(newColName)).findFirst();
         if (foundPhysicalColumn.isPresent()) {
             throw new DdlException(
                     "Can not add column which already exists in physical column: " + newColName

--- a/fe/fe-core/src/main/java/com/starrocks/analysis/SlotDescriptor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/analysis/SlotDescriptor.java
@@ -264,8 +264,8 @@ public class SlotDescriptor {
             type = type.isNull() ? ScalarType.BOOLEAN : type;
             tSlotDescriptor.setSlotType(type.toThrift());
             if (column != null) {
-                LOG.debug("column physical name:{}, column unique id:{}",
-                        column.getPhysicalName(), column.getUniqueId());
+                LOG.debug("column id:{}, column unique id:{}",
+                        column.getColumnId(), column.getUniqueId());
                 tSlotDescriptor.setCol_unique_id(column.getUniqueId());
             }
         }
@@ -273,7 +273,7 @@ public class SlotDescriptor {
         tSlotDescriptor.setByteOffset(-1);
         tSlotDescriptor.setNullIndicatorByte(-1);
         tSlotDescriptor.setNullIndicatorBit(nullIndicatorBit);
-        tSlotDescriptor.setColName(((column != null) ? column.getPhysicalName() : ""));
+        tSlotDescriptor.setColName(((column != null) ? column.getColumnId().getId() : ""));
         tSlotDescriptor.setSlotIdx(-1);
         tSlotDescriptor.setIsMaterialized(true);
         tSlotDescriptor.setIsOutputColumn(isOutputColumn);

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/Column.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/Column.java
@@ -82,13 +82,16 @@ public class Column implements Writable, GsonPreProcessable, GsonPostProcessable
     @SerializedName(value = "name")
     private String name;
 
-    // physicalName is the column name used in the storage engine and will never change.
-    // The name saved in the storage engine remains unchanged after the logical column name is changed.
-    // By default, this value is null, which expresses the same as name (logical name).
-    // If the column name is changed, the value of name (logical name) will be updated to the new column name
-    // and the value of physicalName will be set to the old column name.
-    @SerializedName(value = "physicalName")
-    private String physicalName;
+    // For OLAP Table and its sub classes:
+    // When column is created, columnId is same to name.
+    // If the column name is changed, the value of name will be updated to the new column name,
+    // and the value of columnId remains unchanged.
+    //
+    // For other tables: columnId is same to name.
+    //
+    // All references to Column should use columnId instead of name.
+    @SerializedName(value = "columnId")
+    private ColumnId columnId;
 
     @SerializedName(value = "type")
     private Type type;
@@ -131,6 +134,7 @@ public class Column implements Writable, GsonPreProcessable, GsonPostProcessable
 
     public Column() {
         this.name = "";
+        this.columnId = ColumnId.create(this.name);
         this.type = Type.NULL;
         this.isAggregationTypeImplicit = false;
         this.isKey = false;
@@ -179,7 +183,7 @@ public class Column implements Writable, GsonPreProcessable, GsonPostProcessable
         if (this.name == null) {
             this.name = "";
         }
-
+        this.columnId = ColumnId.create(this.name);
         this.type = type;
         if (this.type == null) {
             this.type = Type.NULL;
@@ -210,6 +214,7 @@ public class Column implements Writable, GsonPreProcessable, GsonPostProcessable
 
     public Column(Column column) {
         this.name = column.getName();
+        this.columnId = column.getColumnId();
         this.type = column.type;
         this.aggregationType = column.getAggregationType();
         this.isAggregationTypeImplicit = column.isAggregationTypeImplicit();
@@ -388,7 +393,7 @@ public class Column implements Writable, GsonPreProcessable, GsonPostProcessable
 
     public TColumn toThrift() {
         TColumn tColumn = new TColumn();
-        tColumn.setColumn_name(this.getPhysicalName());
+        tColumn.setColumn_name(this.columnId.getId());
         tColumn.setIndex_len(this.getOlapColumnIndexSize());
         tColumn.setType_desc(this.type.toThrift());
         if (null != this.aggregationType) {
@@ -695,7 +700,7 @@ public class Column implements Writable, GsonPreProcessable, GsonPostProcessable
 
     @Override
     public int hashCode() {
-        return Objects.hash(this.name.toLowerCase(), this.type);
+        return Objects.hash(this.columnId.getId().toLowerCase(), this.type);
     }
 
     @Override
@@ -781,6 +786,10 @@ public class Column implements Writable, GsonPreProcessable, GsonPostProcessable
             generatedColumnExpr = SqlParser.parseSqlToExpr(generatedColumnExprSerialized.expressionSql,
                     SqlModeHelper.MODE_DEFAULT);
         }
+
+        if (columnId == null) {
+            columnId = ColumnId.create(name);
+        }
     }
 
     @Override
@@ -790,19 +799,8 @@ public class Column implements Writable, GsonPreProcessable, GsonPostProcessable
         }
     }
 
-    public String getPhysicalName() {
-        return physicalName != null ? physicalName : name;
-    }
-
-    public String getDirectPhysicalName() {
-        return physicalName != null ? physicalName : "";
-    }
-
-    public void renameColumn(String newName) {
-        if (physicalName == null) {
-            physicalName = name;
-        }
-        this.name = newName;
+    public ColumnId getColumnId() {
+        return columnId;
     }
 
     public void setUniqueId(int colUniqueId) {

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/ColumnId.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/ColumnId.java
@@ -1,0 +1,79 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.catalog;
+
+import java.util.Comparator;
+import java.util.Objects;
+
+public class ColumnId {
+    private final String id;
+
+    public ColumnId(String id) {
+        this.id = id;
+    }
+
+    public String getId() {
+        return id;
+    }
+
+    public static ColumnId create(String id) {
+        return new ColumnId(id);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(id);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        ColumnId columnId = (ColumnId) o;
+        return Objects.equals(id, columnId.id);
+    }
+
+    public boolean equalsIgnoreCase(ColumnId anotherId) {
+        if (this == anotherId) {
+            return true;
+        }
+
+        if (anotherId == null) {
+            return false;
+        }
+
+        return id != null ? id.equalsIgnoreCase(anotherId.id) : anotherId.id == null;
+    }
+
+    @Override
+    public String toString() {
+        return id;
+    }
+
+    public static final Comparator<ColumnId> CASE_INSENSITIVE_ORDER =
+            new ColumnId.CaseInsensitiveComparator();
+
+    private static class CaseInsensitiveComparator implements Comparator<ColumnId> {
+        public int compare(ColumnId n1, ColumnId n2) {
+            return String.CASE_INSENSITIVE_ORDER.compare(n1.id, n2.id);
+        }
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/HiveTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/HiveTable.java
@@ -39,7 +39,6 @@ import com.google.common.base.Objects;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
@@ -286,7 +285,6 @@ public class HiveTable extends Table implements HiveMetaStoreTable {
 
     public void modifyTableSchema(String dbName, String tableName, HiveTable updatedTable) {
         ImmutableList.Builder<Column> fullSchemaTemp = ImmutableList.builder();
-        ImmutableMap.Builder<String, Column> nameToColumnTemp = ImmutableMap.builder();
         ImmutableList.Builder<String> dataColumnNamesTemp = ImmutableList.builder();
 
         updatedTable.nameToColumn.forEach((colName, column) -> {
@@ -297,7 +295,6 @@ public class HiveTable extends Table implements HiveMetaStoreTable {
         });
 
         fullSchemaTemp.addAll(updatedTable.fullSchema);
-        nameToColumnTemp.putAll(updatedTable.nameToColumn);
         dataColumnNamesTemp.addAll(updatedTable.dataColumnNames);
 
         Database db = GlobalStateMgr.getCurrentState().getDb(dbName);
@@ -312,7 +309,7 @@ public class HiveTable extends Table implements HiveMetaStoreTable {
             this.dataColumnNames.clear();
 
             this.fullSchema.addAll(fullSchemaTemp.build());
-            this.nameToColumn.putAll(nameToColumnTemp.build());
+            updateSchemaIndex();
             this.dataColumnNames.addAll(dataColumnNamesTemp.build());
 
             if (GlobalStateMgr.getCurrentState().isLeader()) {

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/OlapTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/OlapTable.java
@@ -697,10 +697,9 @@ public class OlapTable extends Table {
 
     public void renameColumn(String oldName, String newName) {
         Column column = this.nameToColumn.remove(oldName);
-        if (column != null) {
-            column.setName(newName);
-            this.nameToColumn.put(newName, column);
-        }
+        Preconditions.checkState(column != null, "column of name: " + oldName + " does not exist");
+        column.setName(newName);
+        this.nameToColumn.put(newName, column);
     }
 
     public Status resetIdsForRestore(GlobalStateMgr globalStateMgr, Database db, int restoreReplicationNum,
@@ -2206,8 +2205,8 @@ public class OlapTable extends Table {
         for (Column column : this.fullSchema) {
             newNameToColumn.put(column.getName(), column);
             // For OlapTable: fullSchema contains columns from baseIndex
-            // and columns with SHADOW_NAME_PREFIX (when doing schema changes).
-            // To avoid base columns being replaced by SHADOW_NAME_PREFIX columns,
+            // and columns from shadow indexes (when doing schema changes).
+            // To avoid base columns being replaced by shadow columns,
             // put the columns with the same ColumnId once.
             if (!newIdToColumn.containsKey(column.getColumnId())) {
                 newIdToColumn.put(column.getColumnId(), column);

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/Table.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/Table.java
@@ -179,10 +179,12 @@ public class Table extends MetaObject implements Writable, GsonPostProcessable, 
     protected List<Column> fullSchema = new CopyOnWriteArrayList<>();
 
     /**
-     * The nameToColumn of OlapTable includes the base columns and the SHADOW_NAME_PREFIX columns.
+     * nameToColumn and idToColumn are both indexes of fullSchema.
+     * nameToColumn is the index of column name, idToColumn is the index of column id,
+     * column names can change, but the column ID of a specific column will never change.
+     * Use case-insensitive tree map, because the column name is case-insensitive in the system.
      */
     protected Map<String, Column> nameToColumn;
-
     protected Map<ColumnId, Column> idToColumn;
 
     // DO NOT persist this variable.

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/Table.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/Table.java
@@ -34,7 +34,6 @@
 
 package com.starrocks.catalog;
 
-import com.google.common.base.Preconditions;
 import com.google.common.base.Strings;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
@@ -156,16 +155,9 @@ public class Table extends MetaObject implements Writable, GsonPostProcessable, 
     protected TableType type;
     @SerializedName(value = "createTime")
     protected long createTime;
-    /*
-     *  fullSchema and nameToColumn should contain all columns, both visible and shadow.
-     *  e.g. for OlapTable, when doing schema change, there will be some shadow columns which are not visible
-     *      to query but visible to load process.
-     *  If you want to get all visible columns, you should call getBaseSchema() method, which is override in
-     *  subclasses.
-     *
-     *  NOTICE: the order of this fullSchema is meaningless to OlapTable
-     */
+
     /**
+     * For OlapTable:
      * The fullSchema of OlapTable includes the base columns and the SHADOW_NAME_PREFIX columns.
      * The properties of base columns in fullSchema are same as properties in baseIndex.
      * For example:
@@ -173,19 +165,25 @@ public class Table extends MetaObject implements Writable, GsonPostProcessable, 
      * Schema change (c3 to bigint)
      * When OlapTable is changing schema, the fullSchema is (c1 int, c2 int, c3 int, SHADOW_NAME_PREFIX_c3 bigint)
      * The fullSchema of OlapTable is mainly used by Scanner of Load job.
-     * <p>
+     * NOTICE: The columns of baseIndex is placed before the SHADOW_NAME_PREFIX columns
+     *
+     * If you want to get all visible columns, you should call getBaseSchema() method, which is override in
+     * subclasses.
      * If you want to get the mv columns, you should call getIndexToSchema in Subclass OlapTable.
+     *
+     * If we are simultaneously executing multiple light schema change tasks, there may be occasional concurrent
+     * read-write operations between these tasks with a relatively low probability.
+     * Therefore, we choose to use a CopyOnWriteArrayList.
      */
-    // If we are simultaneously executing multiple light schema change tasks, there may be occasional concurrent 
-    // read-write operations between these tasks with a relatively low probability. 
-    // Therefore, we choose to use a CopyOnWriteArrayList.
     @SerializedName(value = "fullSchema")
     protected List<Column> fullSchema = new CopyOnWriteArrayList<>();
-    // tree map for case-insensitive lookup.
+
     /**
      * The nameToColumn of OlapTable includes the base columns and the SHADOW_NAME_PREFIX columns.
      */
     protected Map<String, Column> nameToColumn;
+
+    protected Map<ColumnId, Column> idToColumn;
 
     // DO NOT persist this variable.
     protected boolean isTypeRead = false;
@@ -208,7 +206,7 @@ public class Table extends MetaObject implements Writable, GsonPostProcessable, 
     public Table(TableType type) {
         this.type = type;
         this.fullSchema = Lists.newArrayList();
-        this.nameToColumn = Maps.newTreeMap(String.CASE_INSENSITIVE_ORDER);
+        updateSchemaIndex();
         this.relatedMaterializedViews = Sets.newConcurrentHashSet();
     }
 
@@ -220,16 +218,7 @@ public class Table extends MetaObject implements Writable, GsonPostProcessable, 
         if (fullSchema != null) {
             this.fullSchema = Lists.newArrayList(fullSchema);
         }
-        this.nameToColumn = Maps.newTreeMap(String.CASE_INSENSITIVE_ORDER);
-        if (this.fullSchema != null) {
-            for (Column col : this.fullSchema) {
-                nameToColumn.put(col.getName(), col);
-            }
-        } else {
-            // Only view in with-clause have null base
-            Preconditions.checkArgument(type == TableType.VIEW || type == TableType.HIVE_VIEW,
-                    "Table has no columns");
-        }
+        updateSchemaIndex();
         this.createTime = Instant.now().getEpochSecond();
         this.relatedMaterializedViews = Sets.newConcurrentHashSet();
     }
@@ -410,14 +399,26 @@ public class Table extends MetaObject implements Writable, GsonPostProcessable, 
 
     public void setNewFullSchema(List<Column> newSchema) {
         this.fullSchema = newSchema;
-        this.nameToColumn.clear();
-        for (Column col : fullSchema) {
-            nameToColumn.put(col.getName(), col);
+        updateSchemaIndex();
+    }
+
+    protected void updateSchemaIndex() {
+        Map<String, Column> newNameToColumn = Maps.newTreeMap(String.CASE_INSENSITIVE_ORDER);
+        Map<ColumnId, Column> newIdToColumn = Maps.newTreeMap(ColumnId.CASE_INSENSITIVE_ORDER);
+        for (Column column : this.fullSchema) {
+            newNameToColumn.put(column.getName(), column);
+            newIdToColumn.put(column.getColumnId(), column);
         }
+        this.nameToColumn = newNameToColumn;
+        this.idToColumn = newIdToColumn;
     }
 
     public Column getColumn(String name) {
         return nameToColumn.get(name);
+    }
+
+    public Column getColumn(ColumnId columnId) {
+        return nameToColumn.get(columnId.getId());
     }
 
     public boolean containColumn(String columnName) {
@@ -430,10 +431,6 @@ public class Table extends MetaObject implements Writable, GsonPostProcessable, 
 
     public long getCreateTime() {
         return createTime;
-    }
-
-    public Map<String, Column> getNameToColumn() {
-        return nameToColumn;
     }
 
     public String getTableLocation() {
@@ -544,9 +541,7 @@ public class Table extends MetaObject implements Writable, GsonPostProcessable, 
 
     @Override
     public void gsonPostProcess() throws IOException {
-        for (Column column : fullSchema) {
-            this.nameToColumn.put(column.getName(), column);
-        }
+        updateSchemaIndex();
         relatedMaterializedViews = Sets.newConcurrentHashSet();
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/persist/gson/GsonUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/persist/gson/GsonUtils.java
@@ -76,6 +76,7 @@ import com.starrocks.catalog.AggregateFunction;
 import com.starrocks.catalog.AnyArrayType;
 import com.starrocks.catalog.AnyElementType;
 import com.starrocks.catalog.ArrayType;
+import com.starrocks.catalog.ColumnId;
 import com.starrocks.catalog.DistributionInfo;
 import com.starrocks.catalog.EsTable;
 import com.starrocks.catalog.ExpressionRangePartitionInfo;
@@ -420,6 +421,7 @@ public class GsonUtils {
             .enableComplexMapKeySerialization()
             .registerTypeHierarchyAdapter(Table.class, new GuavaTableAdapter())
             .registerTypeHierarchyAdapter(Multimap.class, new GuavaMultimapAdapter())
+            .registerTypeHierarchyAdapter(ColumnId.class, new ColumnIdAdapter())
             .registerTypeAdapterFactory(new ProcessHookTypeAdapterFactory())
             // For call constructor with selectedFields
             .registerTypeAdapter(MapType.class, new MapType.MapTypeDeserializer())
@@ -652,6 +654,20 @@ public class GsonUtils {
                 map.putAll(entry.getKey(), entry.getValue());
             }
             return map;
+        }
+    }
+
+    private static class ColumnIdAdapter implements JsonSerializer<ColumnId>,
+            JsonDeserializer<ColumnId> {
+        @Override
+        public ColumnId deserialize(JsonElement json, Type typeOfT, JsonDeserializationContext context)
+                throws JsonParseException {
+            return new ColumnId(json.getAsJsonPrimitive().getAsString());
+        }
+
+        @Override
+        public JsonElement serialize(ColumnId src, Type typeOfSrc, JsonSerializationContext context) {
+            return new JsonPrimitive(src.getId());
         }
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/planner/DictionaryCacheSink.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/DictionaryCacheSink.java
@@ -114,7 +114,8 @@ public class DictionaryCacheSink extends DataSink {
         List<String> columns = Lists.newArrayList();
         List<TColumn> columnsDesc = Lists.newArrayList();
         List<Integer> columnSortKeyUids = Lists.newArrayList();
-        columns.addAll(table.getBaseSchema().stream().map(Column::getPhysicalName).collect(Collectors.toList()));
+        columns.addAll(table.getBaseSchema().stream().map(column -> column.getColumnId().getId())
+                .collect(Collectors.toList()));
         for (Column column : table.getBaseSchema()) {
             TColumn tColumn = column.toThrift();
             tColumn.setColumn_name(column.getNameWithoutPrefix(SchemaChangeHandler.SHADOW_NAME_PREFIX, tColumn.column_name));

--- a/fe/fe-core/src/main/java/com/starrocks/planner/OlapTableSink.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/OlapTableSink.java
@@ -303,7 +303,8 @@ public class OlapTableSink extends DataSink {
             List<String> columns = Lists.newArrayList();
             List<TColumn> columnsDesc = Lists.newArrayList();
             List<Integer> columnSortKeyUids = Lists.newArrayList();
-            columns.addAll(indexMeta.getSchema().stream().map(Column::getPhysicalName).collect(Collectors.toList()));
+            columns.addAll(indexMeta.getSchema().stream().map(column -> column.getColumnId().getId())
+                    .collect(Collectors.toList()));
             for (Column column : indexMeta.getSchema()) {
                 TColumn tColumn = column.toThrift();
                 tColumn.setColumn_name(column.getNameWithoutPrefix(SchemaChangeHandler.SHADOW_NAME_PREFIX, tColumn.column_name));
@@ -390,7 +391,7 @@ public class OlapTableSink extends DataSink {
             case HASH: {
                 HashDistributionInfo hashDistributionInfo = (HashDistributionInfo) distInfo;
                 for (Column column : hashDistributionInfo.getDistributionColumns()) {
-                    distColumns.add(column.getPhysicalName());
+                    distColumns.add(column.getColumnId().getId());
                 }
                 break;
             }
@@ -432,7 +433,7 @@ public class OlapTableSink extends DataSink {
             case EXPR_RANGE_V2: {
                 RangePartitionInfo rangePartitionInfo = (RangePartitionInfo) table.getPartitionInfo();
                 for (Column partCol : rangePartitionInfo.getPartitionColumns()) {
-                    partitionParam.addToPartition_columns(partCol.getPhysicalName());
+                    partitionParam.addToPartition_columns(partCol.getColumnId().getId());
                 }
                 DistributionInfo selectedDistInfo = null;
                 for (Long partitionId : partitionIds) {
@@ -506,7 +507,7 @@ public class OlapTableSink extends DataSink {
             case LIST:
                 ListPartitionInfo listPartitionInfo = (ListPartitionInfo) table.getPartitionInfo();
                 for (Column partCol : listPartitionInfo.getPartitionColumns()) {
-                    partitionParam.addToPartition_columns(partCol.getPhysicalName());
+                    partitionParam.addToPartition_columns(partCol.getColumnId().getId());
                 }
                 DistributionInfo selectedDistInfo = null;
                 for (Long partitionId : partitionIds) {

--- a/fe/fe-core/src/main/java/com/starrocks/server/LocalMetastore.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/LocalMetastore.java
@@ -4192,11 +4192,7 @@ public class LocalMetastore implements ConnectorMetadata {
     }
 
     private static void renameColumnInternal(OlapTable olapTable, String colName, String newColName) {
-        Column column = olapTable.getColumn(colName);
-        Map<String, Column> nameToColumn = olapTable.getNameToColumn();
-        nameToColumn.remove(colName);
-        column.renameColumn(newColName);
-        nameToColumn.put(newColName, column);
+        olapTable.renameColumn(colName, newColName);
 
         Set<String> bfColumns = olapTable.getBfColumns();
         if (bfColumns != null) {
@@ -4217,7 +4213,7 @@ public class LocalMetastore implements ConnectorMetadata {
             List<Column> distributionColumns = hashDistributionInfo.getDistributionColumns();
             for (Column distributionColumn : distributionColumns) {
                 if (distributionColumn.getName().equalsIgnoreCase(colName)) {
-                    distributionColumn.renameColumn(newColName);
+                    distributionColumn.setName(newColName);
                 }
             }
         }
@@ -4228,7 +4224,7 @@ public class LocalMetastore implements ConnectorMetadata {
             List<Column> partitionColumns = rangePartitionInfo.getPartitionColumns();
             for (Column partitionColumn : partitionColumns) {
                 if (partitionColumn.getName().equalsIgnoreCase(colName)) {
-                    partitionColumn.renameColumn(newColName);
+                    partitionColumn.setName(newColName);
                 }
             }
             // for expression range partition will also modify the inner slotRef
@@ -4248,7 +4244,7 @@ public class LocalMetastore implements ConnectorMetadata {
             List<Column> partitionColumns = rangePartitionInfo.getPartitionColumns();
             for (Column partitionColumn : partitionColumns) {
                 if (partitionColumn.getName().equalsIgnoreCase(colName)) {
-                    partitionColumn.renameColumn(newColName);
+                    partitionColumn.setName(newColName);
                 }
             }
         }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/RewriteSimpleAggToHDFSScanRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/RewriteSimpleAggToHDFSScanRule.java
@@ -120,8 +120,7 @@ public class RewriteSimpleAggToHDFSScanRule extends TransformationRule {
             Type columnType = aggCall.getType();
 
             if (placeholderColumn == null) {
-                Column c = new Column();
-                c.setName(metaColumnName);
+                Column c = new Column(metaColumnName, Type.NULL);
                 c.setIsAllowNull(true);
                 placeholderColumn = columnRefFactory.create(metaColumnName, columnType, aggCall.isNullable());
                 columnRefFactory.updateColumnToRelationIds(placeholderColumn.getId(), tableRelationId);

--- a/fe/fe-core/src/test/java/com/starrocks/catalog/ColumnIdTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/ColumnIdTest.java
@@ -1,0 +1,36 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.catalog;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public class ColumnIdTest {
+
+    @Test
+    public void testColumnId() {
+        ColumnId columnIdA = ColumnId.create("a");
+
+        Assert.assertTrue(columnIdA.equals(columnIdA));
+        Assert.assertTrue(columnIdA.equals(ColumnId.create("a")));
+        Assert.assertFalse(columnIdA.equals(ColumnId.create("A")));
+        Assert.assertFalse(columnIdA.equals(ColumnId.create("b")));
+
+        Assert.assertTrue(columnIdA.equalsIgnoreCase(columnIdA));
+        Assert.assertTrue(columnIdA.equalsIgnoreCase(ColumnId.create("a")));
+        Assert.assertTrue(columnIdA.equalsIgnoreCase(ColumnId.create("A")));
+        Assert.assertFalse(columnIdA.equalsIgnoreCase(ColumnId.create("b")));
+    }
+}

--- a/test/sql/test_alter_table/R/test_alter_table_abnormal
+++ b/test/sql/test_alter_table/R/test_alter_table_abnormal
@@ -12,11 +12,11 @@ INSERT INTO t0 VALUES(0, '2024-01-01 00:00:00', 10, '100');
 -- !result
 ALTER TABLE t0 ADD COLUMN k0 FLOAT;
 -- result:
-E: (1064, 'Repeatedly add same column with different definition: k0')
+E: (1064, 'Can not add column which already exists in column id: k0, you can remove `k0` bigint(20) NOT NULL COMMENT "" and try again.')
 -- !result
 ALTER TABLE t0 ADD COLUMN v0 BIGINT;
 -- result:
-E: (1064, 'Repeatedly add same column with different definition: v0')
+E: (1064, 'Can not add column which already exists in column id: v0, you can remove `v0` int(11) NULL COMMENT "" and try again.')
 -- !result
 ALTER TABLE t0 DROP COLUMN k1;
 -- result:
@@ -73,7 +73,7 @@ v1	varchar(100)	YES	false	None
 -- !result
 ALTER TABLE t0 ADD COLUMN v2 BIGINT, ADD COLUMN v0 BIGINT;
 -- result:
-E: (1064, 'Repeatedly add same column with different definition: v0')
+E: (1064, 'Can not add column which already exists in column id: v0, you can remove `v0` int(11) NULL COMMENT "" and try again.')
 -- !result
 ALTER TABLE t0 DROP COLUMN k0;
 -- result:

--- a/test/sql/test_column_rename/R/test_column_rename2
+++ b/test/sql/test_column_rename/R/test_column_rename2
@@ -105,5 +105,5 @@ alter table site_access rename column site_id to id;
 -- !result
 alter table site_access add column site_id int;
 -- result:
-E: (1064, 'Can not add column which already exists in physical column: site_id, you can remove `id` int(11) NULL DEFAULT "10" COMMENT "" and try again.')
+E: (1064, 'Can not add column which already exists in column id: site_id, you can remove `id` int(11) NULL DEFAULT "10" COMMENT "" and try again.')
 -- !result

--- a/test/sql/test_fast_schema_evolution/R/test_fast_schema_evolution
+++ b/test/sql/test_fast_schema_evolution/R/test_fast_schema_evolution
@@ -589,7 +589,7 @@ function: wait_alter_table_finish()
 -- !result
 ALTER TABLE tab1 ADD COLUMN v5 tinyint;
 -- result:
-E: (1064, 'Repeatedly add same column with different definition: v5')
+E: (1064, 'Can not add column which already exists in column id: v5, you can remove `v5` varchar(50) NULL COMMENT "" and try again.')
 -- !result
 function: wait_alter_table_finish()
 -- result:


### PR DESCRIPTION
## Why I'm doing:
We need a unique ID to identify the Column. This ID is used in all places that reference the Column. In this way, to change the attributes of the Column, such as name, we only need to change the attributes in the Column object. There is a uniqueId id the current Column, but it is only available in newly created tables. For compatibility reasons, we need to introduce another Id: ColumnID. The ColumnID of the historical table is the name of the column, because the name was previously immutable.

## What I'm doing:
Add ColumnId object.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [x] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
