### PR TITLE
[Refactor] Remove _source_filename from Chunk

### DIFF
--- a/be/src/column/chunk.h
+++ b/be/src/column/chunk.h
@@ -148,10 +148,6 @@ public:
 
     void set_columns(const Columns& columns) { _columns = columns; }
 
-    void set_source_filename(const std::string& source_filename) { _source_filename = source_filename; }
-
-    const std::string& source_filename() const { return _source_filename; }
-
     // Create an empty chunk with the same meta and reserve it of size chunk _num_rows
     ChunkUniquePtr clone_empty() const;
     ChunkUniquePtr clone_empty_with_slot() const;
@@ -298,7 +294,6 @@ private:
     DelCondSatisfied _delete_state = DEL_NOT_SATISFIED;
     query_cache::owner_info _owner_info;
     ChunkExtraDataPtr _extra_data;
-    std::string _source_filename;
 };
 
 inline const ColumnPtr& Chunk::get_column_by_name(const std::string& column_name) const {

--- a/be/src/exec/file_scanner.cpp
+++ b/be/src/exec/file_scanner.cpp
@@ -225,8 +225,7 @@ StatusOr<ChunkPtr> FileScanner::materialize(const starrocks::ChunkPtr& src, star
                         error_msg << "Value '" << src_col->debug_item(i) << "' is out of range. "
                                   << "The type of '" << slot->col_name() << "' is " << slot->type().debug_string();
                         // TODO(meegoo): support other file format
-                        _state->append_rejected_record_to_file(src->rebuild_csv_row(i, ","), error_msg.str(),
-                                                               src->source_filename());
+                        _state->append_rejected_record_to_file(src->rebuild_csv_row(i, ","), error_msg.str(), "");
                     }
 
                     // avoid print too many debug log

--- a/be/src/exec/tablet_sink.cpp
+++ b/be/src/exec/tablet_sink.cpp
@@ -686,8 +686,7 @@ Status OlapTableSink::send_chunk(RuntimeState* state, Chunk* chunk) {
                 }
                 for (auto i : invalid_row_indexs) {
                     if (state->enable_log_rejected_record()) {
-                        state->append_rejected_record_to_file(chunk->rebuild_csv_row(i, ","), ss.str(),
-                                                              chunk->source_filename());
+                        state->append_rejected_record_to_file(chunk->rebuild_csv_row(i, ","), ss.str(), "");
                     } else {
                         break;
                     }
@@ -913,8 +912,7 @@ void OlapTableSink::_validate_decimal(RuntimeState* state, Chunk* chunk, Column*
                     std::string error_msg =
                             strings::Substitute("Decimal '$0' is out of range. The type of '$1' is $2'", decimal_str,
                                                 desc->col_name(), desc->type().debug_string());
-                    state->append_rejected_record_to_file(chunk->rebuild_csv_row(i, ","), error_msg,
-                                                          chunk->source_filename());
+                    state->append_rejected_record_to_file(chunk->rebuild_csv_row(i, ","), error_msg, "");
                 }
             }
         }
@@ -950,8 +948,7 @@ void OlapTableSink::_validate_data(RuntimeState* state, Chunk* chunk) {
                     _validate_selection[j] = VALID_SEL_FAILED;
                     // If enable_log_rejected_record is true, we need to log the rejected record.
                     if (nullable->is_null(j) && state->enable_log_rejected_record()) {
-                        state->append_rejected_record_to_file(chunk->rebuild_csv_row(j, ","), ss.str(),
-                                                              chunk->source_filename());
+                        state->append_rejected_record_to_file(chunk->rebuild_csv_row(j, ","), ss.str(), "");
                     }
                 }
 #if BE_TEST
@@ -991,8 +988,7 @@ void OlapTableSink::_validate_data(RuntimeState* state, Chunk* chunk) {
                         }
 #endif
                         if (state->enable_log_rejected_record()) {
-                            state->append_rejected_record_to_file(chunk->rebuild_csv_row(j, ","), ss.str(),
-                                                                  chunk->source_filename());
+                            state->append_rejected_record_to_file(chunk->rebuild_csv_row(j, ","), ss.str(), "");
                         }
                     }
                 }
@@ -1031,8 +1027,7 @@ void OlapTableSink::_validate_data(RuntimeState* state, Chunk* chunk) {
                             std::string error_msg =
                                     strings::Substitute("String (length=$0) is too long. The max length of '$1' is $2",
                                                         binary->get_slice(j).size, desc->col_name(), desc->type().len);
-                            state->append_rejected_record_to_file(chunk->rebuild_csv_row(j, ","), error_msg,
-                                                                  chunk->source_filename());
+                            state->append_rejected_record_to_file(chunk->rebuild_csv_row(j, ","), error_msg, "");
                         }
                     }
                 }
@@ -1057,8 +1052,7 @@ void OlapTableSink::_validate_data(RuntimeState* state, Chunk* chunk) {
                             std::string error_msg = strings::Substitute(
                                     "Decimal '$0' is out of range. The type of '$1' is $2'", datas[j].to_string(),
                                     desc->col_name(), desc->type().debug_string());
-                            state->append_rejected_record_to_file(chunk->rebuild_csv_row(j, ","), error_msg,
-                                                                  chunk->source_filename());
+                            state->append_rejected_record_to_file(chunk->rebuild_csv_row(j, ","), error_msg, "");
                         }
                     }
                 }


### PR DESCRIPTION
## Why I'm doing:

The `_source_filename` is introduced by this pr: https://github.com/StarRocks/starrocks/pull/21122/files, but it was not used, so remove it.

Chunk is not suitable for placing this kind of data structure

## What I'm doing:

Remove _source_filename from Chunk

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [x] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [x] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
