### PR TITLE
[Enhancement] Give more error message for trino parser

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/connector/parser/trino/AstBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/parser/trino/AstBuilder.java
@@ -247,12 +247,7 @@ public class AstBuilder extends AstVisitor<ParseNode, ParseTreeContext> {
     }
 
     private <T> List<T> visit(List<? extends Node> nodes, ParseTreeContext context, Class<T> clazz) {
-        return nodes.stream().map(child -> {
-            if (child instanceof AtTimeZone) {
-                throw unsupportedException("Time zone is not supported now");
-            }
-            return this.process(child, context);
-        }).map(clazz::cast).collect(Collectors.toList());
+        return nodes.stream().map(child -> this.process(child, context)).map(clazz::cast).collect(Collectors.toList());
     }
 
     private ParseNode processOptional(Optional<? extends Node> node, ParseTreeContext context) {

--- a/fe/fe-core/src/main/java/com/starrocks/connector/parser/trino/AstBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/parser/trino/AstBuilder.java
@@ -62,7 +62,6 @@ import com.starrocks.catalog.Type;
 import com.starrocks.common.AnalysisException;
 import com.starrocks.qe.SqlModeHelper;
 import com.starrocks.sql.analyzer.RelationId;
-import com.starrocks.sql.analyzer.SemanticException;
 import com.starrocks.sql.ast.ArrayExpr;
 import com.starrocks.sql.ast.CTERelation;
 import com.starrocks.sql.ast.CreateTableAsSelectStmt;
@@ -198,7 +197,9 @@ import static com.starrocks.analysis.AnalyticWindow.BoundaryType.PRECEDING;
 import static com.starrocks.analysis.AnalyticWindow.BoundaryType.UNBOUNDED_FOLLOWING;
 import static com.starrocks.analysis.AnalyticWindow.BoundaryType.UNBOUNDED_PRECEDING;
 import static com.starrocks.connector.parser.trino.TrinoParserUtils.alignWithInputDatetimeType;
+import static com.starrocks.connector.trino.TrinoParserUnsupportedException.trinoParserUnsupportedException;
 import static com.starrocks.sql.common.ErrorMsgProxy.PARSER_ERROR_MSG;
+import static com.starrocks.sql.common.UnsupportedException.unsupportedException;
 import static java.util.stream.Collectors.toList;
 
 public class AstBuilder extends AstVisitor<ParseNode, ParseTreeContext> {
@@ -248,7 +249,7 @@ public class AstBuilder extends AstVisitor<ParseNode, ParseTreeContext> {
     private <T> List<T> visit(List<? extends Node> nodes, ParseTreeContext context, Class<T> clazz) {
         return nodes.stream().map(child -> {
             if (child instanceof AtTimeZone) {
-                throw new ParsingException("Time zone is not supported");
+                throw unsupportedException("Time zone is not supported now");
             }
             return this.process(child, context);
         }).map(clazz::cast).collect(Collectors.toList());
@@ -262,8 +263,19 @@ public class AstBuilder extends AstVisitor<ParseNode, ParseTreeContext> {
     protected ParseNode visitNode(Node node, ParseTreeContext context) {
         if (node instanceof JsonArrayElement) {
             return visit(((JsonArrayElement) node).getValue(), context);
+        } else {
+            throw trinoParserUnsupportedException(String.format("Unsupported node [%s]", node.toString()));
         }
-        return null;
+    }
+
+    @Override
+    protected ParseNode visitRelation(io.trino.sql.tree.Relation node, ParseTreeContext context) {
+        throw trinoParserUnsupportedException(String.format("Unsupported relation [%s]", node.toString()));
+    }
+
+    @Override
+    protected ParseNode visitExpression(Expression node, ParseTreeContext context) {
+        throw trinoParserUnsupportedException(String.format("Unsupported expression [%s]", node.toString()));
     }
 
     @Override
@@ -374,7 +386,7 @@ public class AstBuilder extends AstVisitor<ParseNode, ParseTreeContext> {
         LimitElement limitElement = (LimitElement) processOptional(node.getLimit(), context);
         if (node.getOffset().isPresent()) {
             if (limitElement == null) {
-                throw new ParsingException("StarRocks do not support OFFSET without LIMIT now");
+                throw unsupportedException("Trino Parser on StarRocks does not support OFFSET without LIMIT now");
             }
             LimitElement offsetElement = (LimitElement) processOptional(node.getOffset(), context);
             limitElement = new LimitElement(offsetElement.getOffset(), limitElement.getLimit());
@@ -488,7 +500,8 @@ public class AstBuilder extends AstVisitor<ParseNode, ParseTreeContext> {
         }
 
         if (node.getGroupingElements().stream().map(g -> g.getClass().getName()).distinct().count() > 1) {
-            throw new ParsingException("StarRocks do not support Combining multiple grouping expressions now");
+            throw unsupportedException("Trino Parser on StarRocks does not support Combining multiple grouping " +
+                    "expressions now");
         }
 
         GroupingElement groupingElement = node.getGroupingElements().get(0);
@@ -578,7 +591,7 @@ public class AstBuilder extends AstVisitor<ParseNode, ParseTreeContext> {
         } else if (parts.size() == 1) {
             return new TableName(null, null, qualifiedName.getParts().get(0));
         } else {
-            throw new ParsingException("error table name ");
+            throw new ParsingException(String.format("error table name: %s", qualifiedName));
         }
     }
 
@@ -588,7 +601,7 @@ public class AstBuilder extends AstVisitor<ParseNode, ParseTreeContext> {
         Relation right = (Relation) visit(node.getRight(), context);
         JoinOperator joinType = JOIN_TYPE_MAP.get(node.getType());
         if (joinType == null) {
-            throw new SemanticException("Join Type %s is illegal", node.getType());
+            throw new ParsingException("Join Type %s is illegal", node.getType());
         }
 
         Expr predicate = null;
@@ -641,7 +654,7 @@ public class AstBuilder extends AstVisitor<ParseNode, ParseTreeContext> {
                 return new ExceptRelation(Lists.newArrayList(left, right), setQualifier);
             }
         } else {
-            throw new IllegalArgumentException("Unsupported set operation: " + node);
+            throw new ParsingException("Unsupported set operation: " + node);
         }
     }
 
@@ -735,7 +748,7 @@ public class AstBuilder extends AstVisitor<ParseNode, ParseTreeContext> {
                 return AnalyticWindow.Type.ROWS;
         }
 
-        throw new IllegalArgumentException("Unsupported frame type: " + type);
+        throw new ParsingException("Unsupported window frame type: " + type);
     }
 
     @Override
@@ -753,7 +766,7 @@ public class AstBuilder extends AstVisitor<ParseNode, ParseTreeContext> {
                 return new AnalyticWindow.Boundary(FOLLOWING, (Expr) visit(node.getValue().get(), context));
         }
 
-        throw new IllegalArgumentException("Unsupported frame bound type: " + node.getType());
+        throw new ParsingException("Unsupported frame bound type: " + node.getType());
     }
 
     @Override
@@ -786,8 +799,9 @@ public class AstBuilder extends AstVisitor<ParseNode, ParseTreeContext> {
     private ParseNode visitWindow(FunctionCallExpr functionCallExpr, Window windowSpec, ParseTreeContext context) {
         if (windowSpec instanceof WindowSpecification) {
             return visitWindowSpecification(functionCallExpr, (WindowSpecification) windowSpec, context);
+        } else {
+            throw unsupportedException("Trino Parser on StarRocks does not support Window clause now");
         }
-        return null;
     }
 
     private FunctionCallExpr visitDistinctFunctionCall(FunctionCall node, ParseTreeContext context) {
@@ -876,7 +890,7 @@ public class AstBuilder extends AstVisitor<ParseNode, ParseTreeContext> {
                 throw new ParsingException("Numeric overflow " + intLiteral);
             }
         } catch (NumberFormatException | AnalysisException e) {
-            throw new ParsingException("Invalid numeric literal: " + node.toString());
+            throw new ParsingException("Invalid numeric literal: " + node);
         }
     }
 
@@ -886,7 +900,7 @@ public class AstBuilder extends AstVisitor<ParseNode, ParseTreeContext> {
             if (SqlModeHelper.check(sqlMode, SqlModeHelper.MODE_DOUBLE_LITERAL)) {
                 return new FloatLiteral(node.getValue());
             } else if (Double.isInfinite(node.getValue())) {
-                throw new SemanticException("Numeric overflow " + node.getValue());
+                throw new ParsingException("Numeric overflow " + node.getValue());
             } else {
                 BigDecimal decimal = BigDecimal.valueOf(node.getValue());
                 int precision = DecimalLiteral.getRealPrecision(decimal);
@@ -971,7 +985,7 @@ public class AstBuilder extends AstVisitor<ParseNode, ParseTreeContext> {
             }
             return new DateLiteral(value, Type.DATETIME);
         } catch (AnalysisException e) {
-            throw new ParsingException(PARSER_ERROR_MSG.invalidDateFormat(node.getValue()));
+            throw unsupportedException(PARSER_ERROR_MSG.invalidDateFormat(node.getValue()));
         }
     }
 
@@ -1026,7 +1040,8 @@ public class AstBuilder extends AstVisitor<ParseNode, ParseTreeContext> {
     protected ParseNode visitComparisonExpression(ComparisonExpression node, ParseTreeContext context) {
         BinaryType binaryOp = COMPARISON_OPERATOR_MAP.get(node.getOperator());
         if (binaryOp == null) {
-            throw new SemanticException("Do not support the comparison type %s", node.getOperator());
+            throw unsupportedException(String.format("Trino parser on StarRocks does not support the comparison type %s",
+                    node.getOperator()));
         }
         return new BinaryPredicate(binaryOp, (Expr) visit(node.getLeft(), context), (Expr) visit(node.getRight(),
                 context));
@@ -1248,7 +1263,8 @@ public class AstBuilder extends AstVisitor<ParseNode, ParseTreeContext> {
                 return ScalarType.createType(PrimitiveType.DATETIME);
             }
         } else {
-            throw new SemanticException("StarRocks do not support the type %s", dataType);
+            throw trinoParserUnsupportedException(String.format("Trino parser on StarRocks does not support the " +
+                    "type %s now", dataType));
         }
     }
 
@@ -1279,7 +1295,7 @@ public class AstBuilder extends AstVisitor<ParseNode, ParseTreeContext> {
             }
             return ScalarType.createUnifiedDecimalType(38, 0);
         } else if (typeName.contains("decimal")) {
-            throw new SemanticException("Unknown type: %s", typeName);
+            throw new ParsingException("Unknown type: %s", typeName);
         } else if (typeName.equals("real")) {
             return ScalarType.createType(PrimitiveType.FLOAT);
         } else {

--- a/fe/fe-core/src/main/java/com/starrocks/connector/parser/trino/AstBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/parser/trino/AstBuilder.java
@@ -95,7 +95,6 @@ import io.trino.sql.tree.ArithmeticBinaryExpression;
 import io.trino.sql.tree.ArithmeticUnaryExpression;
 import io.trino.sql.tree.ArrayConstructor;
 import io.trino.sql.tree.AstVisitor;
-import io.trino.sql.tree.AtTimeZone;
 import io.trino.sql.tree.BetweenPredicate;
 import io.trino.sql.tree.BinaryLiteral;
 import io.trino.sql.tree.BooleanLiteral;

--- a/fe/fe-core/src/main/java/com/starrocks/connector/parser/trino/TrinoParserUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/parser/trino/TrinoParserUtils.java
@@ -33,6 +33,8 @@ import java.time.format.DateTimeParseException;
 import java.util.HashSet;
 import java.util.Set;
 
+import static com.starrocks.connector.trino.TrinoParserUnsupportedException.trinoParserUnsupportedException;
+
 public class TrinoParserUtils {
     public static StatementBase toStatement(String query, long sqlMode) {
         String trimmedQuery = query.trim();
@@ -41,7 +43,7 @@ public class TrinoParserUtils {
                 || statement instanceof CreateTableAsSelect) {
             return (StatementBase) statement.accept(new AstBuilder(sqlMode), new ParseTreeContext());
         } else {
-            throw new UnsupportedOperationException("Unsupported statement type: " + statement.getClass().getName());
+            throw trinoParserUnsupportedException("Unsupported statement type: " + statement.getClass().getName());
         }
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/connector/trino/TrinoParserUnsupportedException.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/trino/TrinoParserUnsupportedException.java
@@ -1,0 +1,28 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.connector.trino;
+
+import com.starrocks.sql.common.ErrorType;
+import com.starrocks.sql.common.StarRocksPlannerException;
+
+public class TrinoParserUnsupportedException extends StarRocksPlannerException {
+    private TrinoParserUnsupportedException(String formatString) {
+        super(formatString, ErrorType.UNSUPPORTED);
+    }
+
+    public static TrinoParserUnsupportedException trinoParserUnsupportedException(String formatString) {
+        throw new TrinoParserUnsupportedException(formatString);
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/sql/parser/SqlParser.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/parser/SqlParser.java
@@ -98,7 +98,6 @@ public class SqlParser {
         } catch (TrinoParserUnsupportedException e) {
             // We only support Trino partial syntax now, and for Trino parser unsupported statement,
             // try to use StarRocks parser to parse
-            LOG.warn("Unsupported sql for trino parser: [{}], cause by {}, try to use starrocks parser.", sql, e);
             return tryParseWithStarRocksDialect(sql, sessionVariable, e);
         } catch (UnsupportedException e) {
             // For unsupported statement, it can not be parsed by trino or StarRocks parser, both parser

--- a/fe/fe-core/src/main/java/com/starrocks/sql/parser/SqlParser.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/parser/SqlParser.java
@@ -19,6 +19,7 @@ import com.starrocks.analysis.Expr;
 import com.starrocks.common.Config;
 import com.starrocks.common.Pair;
 import com.starrocks.connector.parser.trino.TrinoParserUtils;
+import com.starrocks.connector.trino.TrinoParserUnsupportedException;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.qe.OriginStatement;
 import com.starrocks.qe.SessionVariable;
@@ -26,7 +27,9 @@ import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.sql.ast.ImportColumnsStmt;
 import com.starrocks.sql.ast.PrepareStmt;
 import com.starrocks.sql.ast.StatementBase;
-import io.trino.sql.parser.ParsingException;
+import com.starrocks.sql.common.ErrorType;
+import com.starrocks.sql.common.StarRocksPlannerException;
+import com.starrocks.sql.common.UnsupportedException;
 import io.trino.sql.parser.StatementSplitter;
 import org.antlr.v4.runtime.CharStreams;
 import org.antlr.v4.runtime.CommonTokenStream;
@@ -41,6 +44,8 @@ import java.util.List;
 import java.util.Objects;
 import java.util.function.Function;
 import java.util.stream.Collectors;
+
+import static com.starrocks.sql.common.UnsupportedException.unsupportedException;
 
 public class SqlParser {
     private static final Logger LOG = LogManager.getLogger(SqlParser.class);
@@ -80,19 +85,48 @@ public class SqlParser {
                 ConnectContext.get().setRelationAliasCaseInSensitive(true);
             }
         } catch (ParsingException e) {
-            // we only support trino partial syntax, use StarRocks parser to parse now
+            // In Trino parser AstBuilder, it could throw ParsingException for unexpected exception,
+            // use StarRocks parser to parse now.
+            LOG.warn("Trino parse sql [{}] error, cause by {}", sql, e);
+            return tryParseWithStarRocksDialect(sql, sessionVariable, e);
+        } catch (io.trino.sql.parser.ParsingException e) {
+            // This sql does not use Trino syntax，use StarRocks parser to parse now.
             if (sql.toLowerCase().contains("select")) {
                 LOG.warn("Trino parse sql [{}] error, cause by {}", sql, e);
             }
-            return parseWithStarRocksDialect(sql, sessionVariable);
-        } catch (UnsupportedOperationException e) {
-            // For unsupported statement, use StarRocks parser to parse
-            return parseWithStarRocksDialect(sql, sessionVariable);
+            return tryParseWithStarRocksDialect(sql, sessionVariable, e);
+        } catch (TrinoParserUnsupportedException e) {
+            // We only support Trino partial syntax now, and for Trino parser unsupported statement,
+            // try to use StarRocks parser to parse
+            LOG.warn("Unsupported sql for trino parser: [{}], cause by {}, try to use starrocks parser.", sql, e);
+            return tryParseWithStarRocksDialect(sql, sessionVariable, e);
+        } catch (UnsupportedException e) {
+            // For unsupported statement, it can not be parsed by trino or StarRocks parser, both parser
+            // can not support it now, we just throw the exception here to give user more information
+            LOG.warn("Sql [{}] are not supported by trino parser, cause by {}", sql, e);
+            throw e;
         }
         if (statements.isEmpty() || statements.stream().anyMatch(Objects::isNull)) {
             return parseWithStarRocksDialect(sql, sessionVariable);
         }
         return statements;
+    }
+
+    private static List<StatementBase> tryParseWithStarRocksDialect(String sql, SessionVariable sessionVariable,
+                                                                    Exception trinoException) {
+        try {
+            return parseWithStarRocksDialect(sql, sessionVariable);
+        } catch (Exception starRocksException) {
+            LOG.warn("StarRocks parse sql [{}] error, cause by {}", sql, starRocksException);
+            if (trinoException instanceof UnsupportedException) {
+                throw unsupportedException(String.format("Trino parser parse sql error: [%s], " +
+                                "and StarRocks parser also can not parse: [%s]", trinoException, starRocksException));
+            } else {
+                throw new StarRocksPlannerException(ErrorType.USER_ERROR,
+                        String.format("Trino parser parse sql error: [%s], and StarRocks parser also can not parse: [%s]",
+                        trinoException, starRocksException));
+            }
+        }
     }
 
     private static List<StatementBase> parseWithStarRocksDialect(String sql, SessionVariable sessionVariable) {

--- a/fe/fe-core/src/test/java/com/starrocks/connector/parser/trino/TrinoFunctionTransformTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/parser/trino/TrinoFunctionTransformTest.java
@@ -110,9 +110,6 @@ public class TrinoFunctionTransformTest extends TrinoTestBase {
         String sql = "select to_unixtime(TIMESTAMP '2023-04-22 00:00:00');";
         assertPlanContains(sql, "1682092800");
 
-        sql = "select to_unixtime(cast('2023-12-05 23:28:46' as timestamp) at time zone 'Asia/Shanghai')";
-        analyzeFail(sql, "Time zone is not supported");
-
         sql = "select date_parse('2022/10/20/05', '%Y/%m/%d/%H');";
         assertPlanContains(sql, "2022-10-20 05:00:00");
 

--- a/fe/fe-core/src/test/java/com/starrocks/connector/parser/trino/TrinoParserNotSupportTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/parser/trino/TrinoParserNotSupportTest.java
@@ -1,0 +1,124 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.connector.parser.trino;
+
+import com.starrocks.sql.common.StarRocksPlannerException;
+import org.junit.BeforeClass;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+// These tests are not supported for StarRocks trino parser,
+// we could support it later
+public class TrinoParserNotSupportTest extends TrinoTestBase {
+    @Rule
+    public ExpectedException expectedEx = ExpectedException.none();
+
+    @BeforeClass
+    public static void beforeClass() throws Exception {
+        TrinoTestBase.beforeClass();
+    }
+
+    // refer to https://trino.io/docs/current/sql/select.html#window-clause
+    @Test
+    public void testWindowClause() {
+        String sql = "select sum(v1) over w from t0 window w as (partition by v2)";
+        analyzeFail(sql, "StarRocks does not support Window clause now");
+    }
+
+    // refer to https://trino.io/docs/current/sql/select.html#offset-clause
+    @Test
+    public void testOffsetWithoutLimit() {
+        String sql = "select v1 from t0 order by v1 offset 2";
+        analyzeFail(sql, "Trino Parser on StarRocks does not support OFFSET without LIMIT now");
+    }
+
+    // refer to https://trino.io/docs/current/sql/select.html#limit-or-fetch-first-clause
+    @Test
+    public void testLimitAll() {
+        String sql = "select v1 from t0 limit ALL";
+        analyzeFail(sql, "Unsupported expression [ALL]");
+    }
+
+    // refer to https://trino.io/docs/current/functions/comparison.html#is-distinct-from-and-is-not-distinct-from
+    @Test
+    public void testDistinctFrom() {
+        String sql = "select NULL is distinct from NULL;";
+        analyzeFail(sql, "Trino parser on StarRocks does not support the comparison type IS_DISTINCT_FROM");
+    }
+
+    // refer to https://trino.io/docs/current/language/types.html#interval-year-to-month
+    @Test
+    public void testIntervalDataType() throws Exception {
+        expectedEx.expect(StarRocksPlannerException.class);
+        // StarRocks do not support this query.
+        String sql = "select INTERVAL '2' DAY";
+        // It will throw exception in optimize stage
+        getFragmentPlan(sql);
+    }
+
+    // refer to https://trino.io/docs/current/language/types.html#row
+    @Test
+    public void testCastRowDataType() {
+        String sql = "select CAST(ROW(1, 2e0) AS ROW(x BIGINT, y DOUBLE))";
+        analyzeFail(sql, "does not support the type ROW(x BIGINT, y DOUBLE)");
+    }
+
+    // refer to https://trino.io/docs/current/sql/select.html#tablesample
+    @Test
+    public void testSampleTable() {
+        String sql = "select * from t0 TABLESAMPLE BERNOULLI(10)";
+        analyzeFail(sql, "Unsupported relation [SampledRelation");
+    }
+
+    // refer to https://trino.io/docs/current/language/types.html#timestamp-with-time-zone
+    // https://trino.io/docs/current/functions/datetime.html#time-zone-conversion
+    @Test
+    public void testTimeStampWithTimeZone() {
+        String sql = "select TIMESTAMP '2014-03-14 09:30:00 Europe/Berlin'";
+        analyzeFail(sql, "Invalid date literal 2014-03-14 09:30:00 Europe/Berlin");
+
+        sql = "SELECT TIMESTAMP '2014-03-14 09:30:00' AT TIME ZONE 'America/Los_Angeles'";
+        analyzeFail(sql, "Unsupported expression [TIMESTAMP '2014-03-14 09:30:00' AT TIME ZONE 'America/Los_Angeles']");
+    }
+
+    // refer to https://trino.io/docs/current/functions/conversion.html#format
+    @Test
+    public void testFormat() {
+        String sql = "select format('%03d', 8);";
+        analyzeFail(sql, "No matching function with signature: format");
+    }
+
+    // refer to https://trino.io/docs/current/functions/json.html#cast-to-json
+    @Test
+    public void testJsonCast() {
+        String sql = "SELECT CAST(MAP(ARRAY['k1', 'k2', 'k3'], ARRAY[1, 23, 456]) AS JSON);";
+        analyzeFail(sql, "Invalid type cast from map<varchar,smallint(6)> to json");
+    }
+
+    // refer to https://trino.io/docs/current/functions/json.html#json-value
+    @Test
+    public void testJsonValue() {
+        String sql = "select json_value('[true, 12e-1, \"text\"]', 'strict $[1]')";
+        analyzeFail(sql, "No matching function with signature: json_value(varchar, varchar)");
+    }
+
+    // refer to https://trino.io/docs/current/functions/json.html#json-object
+    @Test
+    public void testJsonObject() {
+        String sql = "SELECT json_object('key1' : 1, 'key2' : true)";
+        analyzeFail(sql, "Unsupported expression [JSON_OBJECT");
+    }
+}

--- a/fe/fe-core/src/test/java/com/starrocks/connector/parser/trino/TrinoQueryTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/parser/trino/TrinoQueryTest.java
@@ -156,14 +156,16 @@ public class TrinoQueryTest extends TrinoTestBase {
 
     @Test
     public void testDecimal() throws Exception {
+        // If Trino parser parse failed, it wll rollback to StarRocks parser,
+        // decimal32, decimal64, decimal128 could parsed by StarRocks parser.
         String sql = "select cast(tj as decimal32) from tall";
-        analyzeFail(sql, "Unknown type: decimal32");
+        analyzeSuccess(sql);
 
         sql = "select cast(tj as decimal64) from tall";
-        analyzeFail(sql, "Unknown type: decimal64");
+        analyzeSuccess(sql);
 
         sql = "select cast(tj as decimal128) from tall";
-        analyzeFail(sql, "Unknown type: decimal128");
+        analyzeSuccess(sql);
 
         sql = "select cast(tj as decimal) from tall";
         assertPlanContains(sql, "CAST(10: tj AS DECIMAL128(38,0))");
@@ -803,9 +805,6 @@ public class TrinoQueryTest extends TrinoTestBase {
 
         sql = "select v1 from t0 order by v1 offset 2 limit 20";
         assertPlanContains(sql, "offset: 2", "limit: 20");
-
-        sql = "select v1 from t0 order by v1 offset 2";
-        analyzeFail(sql);
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/connector/parser/trino/TrinoTestBase.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/parser/trino/TrinoTestBase.java
@@ -20,9 +20,8 @@ import com.starrocks.planner.TpchSQL;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.sql.StatementPlanner;
 import com.starrocks.sql.analyzer.Analyzer;
-import com.starrocks.sql.analyzer.SemanticException;
 import com.starrocks.sql.ast.StatementBase;
-import com.starrocks.sql.common.UnsupportedException;
+import com.starrocks.sql.common.StarRocksPlannerException;
 import com.starrocks.sql.optimizer.LogicalPlanPrinter;
 import com.starrocks.sql.optimizer.dump.QueryDumpInfo;
 import com.starrocks.sql.parser.ParsingException;
@@ -173,7 +172,7 @@ public class TrinoTestBase {
                     connectContext.getSessionVariable()).get(0);
             Analyzer.analyze(statementBase, connectContext);
             Assert.fail("Miss semantic error exception");
-        } catch (ParsingException | SemanticException | UnsupportedException e) {
+        } catch (ParsingException | StarRocksPlannerException e) {
             if (!exceptMessage.equals("")) {
                 Assert.assertTrue(e.getMessage(), e.getMessage().contains(exceptMessage));
             }


### PR DESCRIPTION
## Why I'm doing:
when user set sql_dialect to "trino", the trino parser will throw some exceptions which are not clear to the user. 
like this 
![image](https://github.com/StarRocks/starrocks/assets/9495145/36956a4b-8c30-476c-bf14-557fad5b2cb1)
![image](https://github.com/StarRocks/starrocks/assets/9495145/edb8dee6-c085-4274-962c-e8474a4e8799)


## What I'm doing:
1. add TrinoParserUnsupportedException, it would be catched and retry with starrocks parser
2. give more error message in tryParseWithStarRocksDialect

after this PR:
![image](https://github.com/StarRocks/starrocks/assets/9495145/06f60ecb-8aac-4986-a2d9-a600d0f11d65)
![image](https://github.com/StarRocks/starrocks/assets/9495145/13d6f4f0-f510-43c1-b9a7-08bc552e2bd9)


Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [x] 3.2
  - [x] 3.1
  - [ ] 3.0
  - [ ] 2.5
