### PR TITLE
[Enhancement] pass connect context to the prepareMetadata and distributed_plan interface

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/connector/CatalogConnectorMetadata.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/CatalogConnectorMetadata.java
@@ -152,8 +152,8 @@ public class CatalogConnectorMetadata implements ConnectorMetadata {
     }
 
     @Override
-    public boolean prepareMetadata(MetaPreparationItem item, Tracers tracers) {
-        return normal.prepareMetadata(item, tracers);
+    public boolean prepareMetadata(MetaPreparationItem item, Tracers tracers, ConnectContext connectContext) {
+        return normal.prepareMetadata(item, tracers, connectContext);
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/connector/ConnectorMetadata.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/ConnectorMetadata.java
@@ -198,7 +198,7 @@ public interface ConnectorMetadata {
         return Statistics.builder().build();
     }
 
-    default boolean prepareMetadata(MetaPreparationItem item, Tracers tracers) {
+    default boolean prepareMetadata(MetaPreparationItem item, Tracers tracers, ConnectContext connectContext) {
         return true;
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/DataFileWrapper.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/DataFileWrapper.java
@@ -1,0 +1,163 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.connector.iceberg;
+
+import org.apache.iceberg.DataFile;
+import org.apache.iceberg.FileFormat;
+import org.apache.iceberg.StructLike;
+
+import java.nio.ByteBuffer;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+
+// checking hashcode and equals for manifest cache
+public class DataFileWrapper implements DataFile {
+    private final DataFile dataFile;
+
+    public DataFileWrapper(DataFile dataFile) {
+        this.dataFile = dataFile;
+    }
+
+    public static DataFileWrapper wrap(DataFile dataFile) {
+        return new DataFileWrapper(dataFile);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        DataFileWrapper that = (DataFileWrapper) o;
+
+        return dataFile.path().toString().equals(that.dataFile.path().toString());
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(dataFile.path());
+    }
+
+    @Override
+    public Long pos() {
+        return dataFile.pos();
+    }
+
+    @Override
+    public int specId() {
+        return dataFile.specId();
+    }
+
+    @Override
+    public CharSequence path() {
+        return dataFile.path();
+    }
+
+    @Override
+    public FileFormat format() {
+        return dataFile.format();
+    }
+
+    @Override
+    public StructLike partition() {
+        return dataFile.partition();
+    }
+
+    @Override
+    public long recordCount() {
+        return dataFile.recordCount();
+    }
+
+    @Override
+    public long fileSizeInBytes() {
+        return dataFile.fileSizeInBytes();
+    }
+
+    @Override
+    public Map<Integer, Long> columnSizes() {
+        return dataFile.columnSizes();
+    }
+
+    @Override
+    public Map<Integer, Long> valueCounts() {
+        return dataFile.valueCounts();
+    }
+
+    @Override
+    public Map<Integer, Long> nullValueCounts() {
+        return dataFile.nullValueCounts();
+    }
+
+    @Override
+    public Map<Integer, Long> nanValueCounts() {
+        return dataFile.nanValueCounts();
+    }
+
+    @Override
+    public Map<Integer, ByteBuffer> lowerBounds() {
+        return dataFile.lowerBounds();
+    }
+
+    @Override
+    public Map<Integer, ByteBuffer> upperBounds() {
+        return dataFile.upperBounds();
+    }
+
+    @Override
+    public ByteBuffer keyMetadata() {
+        return dataFile.keyMetadata();
+    }
+
+    @Override
+    public List<Long> splitOffsets() {
+        return dataFile.splitOffsets();
+    }
+
+    @Override
+    public DataFile copy() {
+        return dataFile.copy();
+    }
+
+    @Override
+    public DataFile copyWithoutStats() {
+        return dataFile.copyWithoutStats();
+    }
+
+    @Override
+    public Integer sortOrderId() {
+        return dataFile.sortOrderId();
+    }
+
+    @Override
+    public Long dataSequenceNumber() {
+        return dataFile.dataSequenceNumber();
+    }
+
+    @Override
+    public Long fileSequenceNumber() {
+        return dataFile.fileSequenceNumber();
+    }
+
+    @Override
+    public DataFile copyWithStats(Set<Integer> requestedColumnIds) {
+        return dataFile.copyWithStats(requestedColumnIds);
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/DeleteFileWrapper.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/DeleteFileWrapper.java
@@ -1,0 +1,178 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.connector.iceberg;
+
+import org.apache.iceberg.DeleteFile;
+import org.apache.iceberg.FileContent;
+import org.apache.iceberg.FileFormat;
+import org.apache.iceberg.StructLike;
+
+import java.nio.ByteBuffer;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+
+// checking hashcode and equals for manifest cache
+public class DeleteFileWrapper implements DeleteFile {
+    private final DeleteFile deleteFile;
+
+    public DeleteFileWrapper(DeleteFile deleteFile) {
+        this.deleteFile = deleteFile;
+    }
+
+    public static DeleteFileWrapper wrap(DeleteFile deleteFile) {
+        return new DeleteFileWrapper(deleteFile);
+    }
+
+    public DeleteFile getDataFile() {
+        return deleteFile;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        DeleteFileWrapper that = (DeleteFileWrapper) o;
+
+        return deleteFile.path().toString().equals(that.deleteFile.path().toString());
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(deleteFile.path());
+    }
+
+    @Override
+    public Long pos() {
+        return deleteFile.pos();
+    }
+
+    @Override
+    public int specId() {
+        return deleteFile.specId();
+    }
+
+    @Override
+    public FileContent content() {
+        return deleteFile.content();
+    }
+
+    @Override
+    public CharSequence path() {
+        return deleteFile.path();
+    }
+
+    @Override
+    public FileFormat format() {
+        return deleteFile.format();
+    }
+
+    @Override
+    public StructLike partition() {
+        return deleteFile.partition();
+    }
+
+    @Override
+    public long recordCount() {
+        return deleteFile.recordCount();
+    }
+
+    @Override
+    public long fileSizeInBytes() {
+        return deleteFile.fileSizeInBytes();
+    }
+
+    @Override
+    public Map<Integer, Long> columnSizes() {
+        return deleteFile.columnSizes();
+    }
+
+    @Override
+    public Map<Integer, Long> valueCounts() {
+        return deleteFile.valueCounts();
+    }
+
+    @Override
+    public Map<Integer, Long> nullValueCounts() {
+        return deleteFile.nullValueCounts();
+    }
+
+    @Override
+    public Map<Integer, Long> nanValueCounts() {
+        return deleteFile.nanValueCounts();
+    }
+
+    @Override
+    public Map<Integer, ByteBuffer> lowerBounds() {
+        return deleteFile.lowerBounds();
+    }
+
+    @Override
+    public Map<Integer, ByteBuffer> upperBounds() {
+        return deleteFile.upperBounds();
+    }
+
+    @Override
+    public ByteBuffer keyMetadata() {
+        return deleteFile.keyMetadata();
+    }
+
+    @Override
+    public List<Long> splitOffsets() {
+        return deleteFile.splitOffsets();
+    }
+
+    @Override
+    public List<Integer> equalityFieldIds() {
+        return deleteFile.equalityFieldIds();
+    }
+
+    @Override
+    public DeleteFile copy() {
+        return deleteFile.copy();
+    }
+
+    @Override
+    public DeleteFile copyWithoutStats() {
+        return deleteFile.copyWithoutStats();
+    }
+
+    @Override
+    public DeleteFile copyWithStats(Set<Integer> requestedColumnIds) {
+        return deleteFile.copyWithStats(requestedColumnIds);
+    }
+
+    @Override
+    public Integer sortOrderId() {
+        return deleteFile.sortOrderId();
+    }
+
+    @Override
+    public Long dataSequenceNumber() {
+        return deleteFile.dataSequenceNumber();
+    }
+
+    @Override
+    public Long fileSequenceNumber() {
+        return deleteFile.fileSequenceNumber();
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/StarRocksIcebergTableScanContext.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/StarRocksIcebergTableScanContext.java
@@ -16,6 +16,7 @@ package com.starrocks.connector.iceberg;
 
 import com.google.common.cache.Cache;
 import com.starrocks.connector.PlanMode;
+import com.starrocks.qe.ConnectContext;
 import org.apache.iceberg.DataFile;
 import org.apache.iceberg.DeleteFile;
 
@@ -33,12 +34,19 @@ public class StarRocksIcebergTableScanContext {
     private int localParallelism;
     private long localPlanningMaxSlotSize;
     private boolean enableCacheDataFileIdentifierColumnMetrics;
+    private ConnectContext connectContext;
 
     public StarRocksIcebergTableScanContext(String catalogName, String dbName, String tableName, PlanMode planMode) {
+        this(catalogName, dbName, tableName, planMode, null);
+    }
+
+    public StarRocksIcebergTableScanContext(String catalogName, String dbName, String tableName,
+                                            PlanMode planMode, ConnectContext connectContext) {
         this.catalogName = catalogName;
         this.dbName = dbName;
         this.tableName = tableName;
         this.planMode = planMode;
+        this.connectContext = connectContext;
     }
 
     public String getCatalogName() {
@@ -111,5 +119,9 @@ public class StarRocksIcebergTableScanContext {
 
     public void setEnableCacheDataFileIdentifierColumnMetrics(boolean enableCacheDataFileIdentifierColumnMetrics) {
         this.enableCacheDataFileIdentifierColumnMetrics = enableCacheDataFileIdentifierColumnMetrics;
+    }
+
+    public ConnectContext getConnectContext() {
+        return connectContext;
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/connector/metadata/MetadataCollectJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/metadata/MetadataCollectJob.java
@@ -116,6 +116,7 @@ public abstract class MetadataCollectJob {
         context.getSessionVariable().setParallelExecInstanceNum(1);
         context.getSessionVariable().setQueryTimeoutS(originSessionVariable.getMetadataCollectQueryTimeoutS());
         context.getSessionVariable().setEnablePipelineEngine(true);
+        context.getSessionVariable().setEnableIcebergColumnStatistics(originSessionVariable.enableIcebergColumnStatistics());
         context.setMetadataContext(true);
         context.setCurrentCatalog(catalogName);
         context.setDatabase(dbName);

--- a/fe/fe-core/src/main/java/com/starrocks/connector/unified/UnifiedMetadata.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/unified/UnifiedMetadata.java
@@ -29,6 +29,7 @@ import com.starrocks.connector.RemoteFileInfo;
 import com.starrocks.connector.SerializedMetaSpec;
 import com.starrocks.connector.hive.HiveMetadata;
 import com.starrocks.credential.CloudConfiguration;
+import com.starrocks.qe.ConnectContext;
 import com.starrocks.sql.ast.CreateTableStmt;
 import com.starrocks.sql.ast.DropTableStmt;
 import com.starrocks.sql.optimizer.OptimizerContext;
@@ -183,9 +184,9 @@ public class UnifiedMetadata implements ConnectorMetadata {
     }
 
     @Override
-    public boolean prepareMetadata(MetaPreparationItem item, Tracers tracers) {
+    public boolean prepareMetadata(MetaPreparationItem item, Tracers tracers, ConnectContext connectContext) {
         ConnectorMetadata metadata = metadataOfTable(item.getTable());
-        return metadata.prepareMetadata(item, tracers);
+        return metadata.prepareMetadata(item, tracers, connectContext);
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/server/MetadataMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/MetadataMgr.java
@@ -747,11 +747,12 @@ public class MetadataMgr {
         return null;
     }
 
-    public boolean prepareMetadata(String queryId, String catalogName, MetaPreparationItem item, Tracers tracers) {
+    public boolean prepareMetadata(String queryId, String catalogName, MetaPreparationItem item,
+                                   Tracers tracers, ConnectContext connectContext) {
         Optional<ConnectorMetadata> connectorMetadata = getOptionalMetadata(Optional.of(queryId), catalogName);
         if (connectorMetadata.isPresent()) {
             try {
-                return connectorMetadata.get().prepareMetadata(item, tracers);
+                return connectorMetadata.get().prepareMetadata(item, tracers, connectContext);
             } catch (Exception e) {
                 LOG.error("prepare metadata failed on [{}]", item, e);
                 return true;

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/task/PrepareCollectMetaTask.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/task/PrepareCollectMetaTask.java
@@ -18,6 +18,7 @@ import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import com.starrocks.common.profile.Timer;
 import com.starrocks.common.profile.Tracers;
 import com.starrocks.connector.MetaPreparationItem;
+import com.starrocks.qe.ConnectContext;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.server.MetadataMgr;
 import com.starrocks.sql.optimizer.OptExpression;
@@ -65,12 +66,13 @@ public class PrepareCollectMetaTask extends OptimizerTask {
 
         MetadataMgr metadataMgr = GlobalStateMgr.getCurrentState().getMetadataMgr();
         Tracers tracers = Tracers.get();
+        ConnectContext connectContext = ConnectContext.get();
         try (Timer ignored = Tracers.watchScope(EXTERNAL, "EXTERNAL.parallel_prepare_metadata")) {
             CompletableFuture<Void> allFutures = CompletableFuture.allOf(scanOperators.stream()
                     .map(op -> CompletableFuture.supplyAsync(() ->
                                     metadataMgr.prepareMetadata(queryId, op.getTable().getCatalogName(),
                                             new MetaPreparationItem(op.getTable(), op.getPredicate(), op.getLimit()),
-                                            tracers),
+                                            tracers, connectContext),
                             executorService)).toArray(CompletableFuture[]::new));
             allFutures.join();
         }

--- a/fe/fe-core/src/main/java/org/apache/iceberg/ManifestReader.java
+++ b/fe/fe-core/src/main/java/org/apache/iceberg/ManifestReader.java
@@ -27,6 +27,8 @@ import java.util.Map;
 import java.util.Set;
 
 import com.google.common.cache.Cache;
+import com.starrocks.connector.iceberg.DataFileWrapper;
+import com.starrocks.connector.iceberg.DeleteFileWrapper;
 import org.apache.iceberg.avro.Avro;
 import org.apache.iceberg.avro.AvroIterable;
 import org.apache.iceberg.exceptions.RuntimeIOException;
@@ -266,9 +268,10 @@ public class ManifestReader<F extends ContentFile<F>> extends CloseableGroup
                         Set<DataFile> dataFiles = dataFileCache.getIfPresent(file.location());
                         if (dataFiles != null && entry.isLive()) {
                             DataFile dataFile = (DataFile) entry.file();
-                            dataFiles.add(dataFileCacheWithMetrics ?
+                            DataFile copiedDataFile = dataFileCacheWithMetrics ?
                                     dataFile.copyWithStats(identifierFieldIds.isEmpty() ? null : identifierFieldIds) :
-                                    dataFile.copyWithoutStats());
+                                    dataFile.copyWithoutStats();
+                            dataFiles.add(DataFileWrapper.wrap(copiedDataFile));
                         }
                         return entry;
                     });
@@ -279,7 +282,7 @@ public class ManifestReader<F extends ContentFile<F>> extends CloseableGroup
                     entry -> {
                         Set<DeleteFile> deleteFiles = deleteFileCache.getIfPresent(file.location());
                         if (deleteFiles != null && entry.isLive()) {
-                            deleteFiles.add((DeleteFile) entry.file().copy());
+                            deleteFiles.add(DeleteFileWrapper.wrap((DeleteFile) entry.file().copy()));
                         }
                         return entry;
                     });

--- a/fe/fe-core/src/main/java/org/apache/iceberg/StarRocksIcebergTableScan.java
+++ b/fe/fe-core/src/main/java/org/apache/iceberg/StarRocksIcebergTableScan.java
@@ -79,6 +79,7 @@ public class StarRocksIcebergTableScan
     private final int localParallelism;
     private final long localPlanningMaxSlotSize;
     private boolean isRemotePlanFiles;
+    private ConnectContext connectContext;
 
     public static TableScanContext newTableScanContext(Table table) {
         if (table instanceof BaseTable) {
@@ -98,6 +99,7 @@ public class StarRocksIcebergTableScan
         this.dbName = scanContext.getDbName();
         this.tableName = scanContext.getTableName();
         this.planMode = scanContext.getPlanMode();
+        this.connectContext = scanContext.getConnectContext();
         this.scanContext = scanContext;
         this.specStringCache = specCache(PartitionSpecParser::toJson);
         this.residualCache = specCache(this::newResidualEvaluator);
@@ -148,8 +150,7 @@ public class StarRocksIcebergTableScan
         MetadataCollectJob metadataCollectJob = new IcebergMetadataCollectJob(
                 catalogName, dbName, tableName, TResultSinkType.METADATA_ICEBERG, snapshotId(), icebergSerializedPredicate);
 
-        // TODO(stephen): pass ConnectContext instance to here
-        metadataCollectJob.init(ConnectContext.get().getSessionVariable());
+        metadataCollectJob.init(connectContext.getSessionVariable());
 
         long currentTimestamp = System.currentTimeMillis();
         String threadNamePrefix = String.format("%s-%s-%s-%d", catalogName, dbName, tableName, currentTimestamp);

--- a/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/IcebergMetadataTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/IcebergMetadataTest.java
@@ -1374,4 +1374,46 @@ public class IcebergMetadataTest extends TableTestBase {
         Assert.assertNotNull(collectJob.getMetadataJobCoord());
         Assert.assertTrue(collectJob.getResultQueue().isEmpty());
     }
+
+    @Test
+    public void testFileWrapper() {
+        DataFileWrapper wrapper = DataFileWrapper.wrap(FILE_B_1);
+        Assert.assertEquals(wrapper.pos(), FILE_B_1.pos());
+        Assert.assertEquals(wrapper.specId(), FILE_B_1.specId());
+        Assert.assertEquals(wrapper.pos(), FILE_B_1.pos());
+        Assert.assertEquals(wrapper.path(), FILE_B_1.path());
+        Assert.assertEquals(wrapper.format(), FILE_B_1.format());
+        Assert.assertEquals(wrapper.partition(), FILE_B_1.partition());
+        Assert.assertEquals(wrapper.recordCount(), FILE_B_1.recordCount());
+        Assert.assertEquals(wrapper.fileSizeInBytes(), FILE_B_1.fileSizeInBytes());
+        Assert.assertEquals(wrapper.columnSizes(), FILE_B_1.columnSizes());
+        Assert.assertEquals(wrapper.valueCounts(), FILE_B_1.valueCounts());
+        Assert.assertEquals(wrapper.nullValueCounts(), FILE_B_1.nullValueCounts());
+        Assert.assertEquals(wrapper.nanValueCounts(), FILE_B_1.nanValueCounts());
+        Assert.assertEquals(wrapper.lowerBounds(), FILE_B_1.lowerBounds());
+        Assert.assertEquals(wrapper.upperBounds(), FILE_B_1.upperBounds());
+        Assert.assertEquals(wrapper.splitOffsets(), FILE_B_1.splitOffsets());
+        Assert.assertEquals(wrapper.keyMetadata(), FILE_B_1.keyMetadata());
+
+        DeleteFileWrapper deleteFileWrapper = DeleteFileWrapper.wrap(FILE_C_1);
+        Assert.assertEquals(deleteFileWrapper.pos(), FILE_C_1.pos());
+        Assert.assertEquals(deleteFileWrapper.specId(), FILE_C_1.specId());
+        Assert.assertEquals(deleteFileWrapper.pos(), FILE_C_1.pos());
+        Assert.assertEquals(deleteFileWrapper.path(), FILE_C_1.path());
+        Assert.assertEquals(deleteFileWrapper.format(), FILE_C_1.format());
+        Assert.assertEquals(deleteFileWrapper.partition(), FILE_C_1.partition());
+        Assert.assertEquals(deleteFileWrapper.recordCount(), FILE_C_1.recordCount());
+        Assert.assertEquals(deleteFileWrapper.fileSizeInBytes(), FILE_C_1.fileSizeInBytes());
+        Assert.assertEquals(deleteFileWrapper.columnSizes(), FILE_C_1.columnSizes());
+        Assert.assertEquals(deleteFileWrapper.valueCounts(), FILE_C_1.valueCounts());
+        Assert.assertEquals(deleteFileWrapper.nullValueCounts(), FILE_C_1.nullValueCounts());
+        Assert.assertEquals(deleteFileWrapper.nanValueCounts(), FILE_C_1.nanValueCounts());
+        Assert.assertEquals(deleteFileWrapper.lowerBounds(), FILE_C_1.lowerBounds());
+        Assert.assertEquals(deleteFileWrapper.upperBounds(), FILE_C_1.upperBounds());
+        Assert.assertEquals(deleteFileWrapper.splitOffsets(), FILE_C_1.splitOffsets());
+        Assert.assertEquals(deleteFileWrapper.keyMetadata(), FILE_C_1.keyMetadata());
+        Assert.assertEquals(deleteFileWrapper.content(), FILE_C_1.content());
+        Assert.assertEquals(deleteFileWrapper.dataSequenceNumber(), FILE_C_1.dataSequenceNumber());
+        Assert.assertEquals(deleteFileWrapper.fileSequenceNumber(), FILE_C_1.fileSequenceNumber());
+    }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/connector/unified/UnifiedMetadataTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/unified/UnifiedMetadataTest.java
@@ -251,7 +251,7 @@ public class UnifiedMetadataTest {
                 times = 1;
             }
             {
-                icebergMetadata.prepareMetadata((MetaPreparationItem) any, null);
+                icebergMetadata.prepareMetadata((MetaPreparationItem) any, null, null);
                 result = true;
                 times = 1;
             }
@@ -273,7 +273,7 @@ public class UnifiedMetadataTest {
         createTableStmt.setEngineName("iceberg");
         assertTrue(unifiedMetadata.createTable(createTableStmt));
         Assert.assertTrue(unifiedMetadata.getPrunedPartitions(table, null, -1).isEmpty());
-        Assert.assertTrue(unifiedMetadata.prepareMetadata(new MetaPreparationItem(icebergTable, null, -1), null));
+        Assert.assertTrue(unifiedMetadata.prepareMetadata(new MetaPreparationItem(icebergTable, null, -1), null, null));
         Assert.assertNotNull(unifiedMetadata.getSerializedMetaSpec("test_db", "test_tbl", -1, null));
     }
 

--- a/test/sql/test_iceberg/R/test_iceberg_parallel_prepare_metadata
+++ b/test/sql/test_iceberg/R/test_iceberg_parallel_prepare_metadata
@@ -28,6 +28,26 @@ set enable_parallel_prepare_metadata=true;
 -- result:
 []
 -- !result
+set enable_iceberg_column_statistics=true;
+-- result:
+[]
+-- !result
+set enable_profile=true;
+-- result:
+[]
+-- !result
+function: assert_explain_costs_contains("select a.col_str from ice_cat_${uuid0}.ice_db_${uuid0}.ice_tbl_${uuid0} a join ice_cat_${uuid0}.ice_db_${uuid0}.ice_tbl_${uuid0} b on a.col_str = b.col_str where a.col_int = 1 and b.col_int = 2;","ESTIMATE")
+-- result:
+None
+-- !result
+function: assert_trace_times_contains("select a.col_str from ice_cat_${uuid0}.ice_db_${uuid0}.ice_tbl_${uuid0} a join ice_cat_${uuid0}.ice_db_${uuid0}.ice_tbl_${uuid0} b on a.col_str = b.col_str where a.col_int = 1 and b.col_int = 2;","ICEBERG.processSplit.IcebergFilter")
+-- result:
+None
+-- !result
+select a.col_str from ice_cat_${uuid0}.ice_db_${uuid0}.ice_tbl_${uuid0} a join ice_cat_${uuid0}.ice_db_${uuid0}.ice_tbl_${uuid0} b on a.col_str = b.col_str where a.col_int = 1 and b.col_int = 2;
+-- result:
+a
+-- !result
 select a.col_str from ice_cat_${uuid0}.ice_db_${uuid0}.ice_tbl_${uuid0} a join ice_cat_${uuid0}.ice_db_${uuid0}.ice_tbl_${uuid0} b on a.col_str = b.col_str where a.col_int = 1 and b.col_int = 2;
 -- result:
 a

--- a/test/sql/test_iceberg/T/test_iceberg_parallel_prepare_metadata
+++ b/test/sql/test_iceberg/T/test_iceberg_parallel_prepare_metadata
@@ -15,8 +15,18 @@ create table ice_cat_${uuid0}.ice_db_${uuid0}.ice_tbl_${uuid0} (
 ) partition by (col_int);
 
 insert into ice_cat_${uuid0}.ice_db_${uuid0}.ice_tbl_${uuid0} values ("a", 1),("a", 2);
+
 set enable_parallel_prepare_metadata=true;
+set enable_iceberg_column_statistics=true;
+set enable_profile=true;
+function: assert_explain_costs_contains("select a.col_str from ice_cat_${uuid0}.ice_db_${uuid0}.ice_tbl_${uuid0} a join ice_cat_${uuid0}.ice_db_${uuid0}.ice_tbl_${uuid0} b on a.col_str = b.col_str where a.col_int = 1 and b.col_int = 2;","ESTIMATE")
+
+function: assert_trace_times_contains("select a.col_str from ice_cat_${uuid0}.ice_db_${uuid0}.ice_tbl_${uuid0} a join ice_cat_${uuid0}.ice_db_${uuid0}.ice_tbl_${uuid0} b on a.col_str = b.col_str where a.col_int = 1 and b.col_int = 2;","ICEBERG.processSplit.IcebergFilter")
+
 select a.col_str from ice_cat_${uuid0}.ice_db_${uuid0}.ice_tbl_${uuid0} a join ice_cat_${uuid0}.ice_db_${uuid0}.ice_tbl_${uuid0} b on a.col_str = b.col_str where a.col_int = 1 and b.col_int = 2;
+
+select a.col_str from ice_cat_${uuid0}.ice_db_${uuid0}.ice_tbl_${uuid0} a join ice_cat_${uuid0}.ice_db_${uuid0}.ice_tbl_${uuid0} b on a.col_str = b.col_str where a.col_int = 1 and b.col_int = 2;
+
 drop table ice_cat_${uuid0}.ice_db_${uuid0}.ice_tbl_${uuid0} force;
 drop database ice_cat_${uuid0}.ice_db_${uuid0};
 drop catalog ice_cat_${uuid0};


### PR DESCRIPTION
## Why I'm doing:
we use `ConnectContext.get()` to get Session variable in the iceberg job planning. If we don't execute planning in the query thread, and can't get the connect context. There are two cases:
1. In the `prepareMetadata`, the job planning is executed in the thread pool
2. distributed plan mode, the metadata collect job is executed in the another thread.
3. `1 && 2`. plan_mode is distributed and running under the thread pool

So we need to adapt to the two case with the connect context. 

## What I'm doing:
Adapting ConnectContext and Tracers under multi-threading

Fixes #issue
https://github.com/StarRocks/starrocks/issues/43460

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
