### PR TITLE
[Feature] Stream load support JSON to STRUCT/MAP/ARRAY

### DIFF
--- a/be/src/exec/json_scanner.cpp
+++ b/be/src/exec/json_scanner.cpp
@@ -121,6 +121,46 @@ void JsonScanner::close() {
     FileScanner::close();
 }
 
+static TypeDescriptor construct_json_type(const TypeDescriptor& src_type) {
+    switch (src_type.type) {
+    case TYPE_ARRAY: {
+        TypeDescriptor json_type(TYPE_ARRAY);
+        const auto& child_type = src_type.children[0];
+        json_type.children.emplace_back(construct_json_type(child_type));
+        return json_type;
+    }
+    case TYPE_STRUCT: {
+        TypeDescriptor json_type(TYPE_STRUCT);
+        json_type.field_names = src_type.field_names;
+        for (auto& child_type : src_type.children) {
+            json_type.children.emplace_back(construct_json_type(child_type));
+        }
+        return json_type;
+    }
+    case TYPE_MAP: {
+        TypeDescriptor json_type(TYPE_MAP);
+        const auto& key_type = src_type.children[0];
+        const auto& value_type = src_type.children[1];
+        json_type.children.emplace_back(construct_json_type(key_type));
+        json_type.children.emplace_back(construct_json_type(value_type));
+        return json_type;
+    }
+    case TYPE_FLOAT:
+    case TYPE_DOUBLE:
+    case TYPE_BIGINT:
+    case TYPE_INT:
+    case TYPE_SMALLINT:
+    case TYPE_TINYINT:
+    case TYPE_VARCHAR:
+    case TYPE_JSON: {
+        return src_type;
+    }
+    default:
+        // Treat other types as VARCHAR.
+        return TypeDescriptor::create_varchar_type(TypeDescriptor::MAX_VARCHAR_LENGTH);
+    }
+}
+
 Status JsonScanner::_construct_json_types() {
     size_t slot_size = _src_slot_descriptors.size();
     _json_types.resize(slot_size);
@@ -130,83 +170,7 @@ Status JsonScanner::_construct_json_types() {
             continue;
         }
 
-        switch (slot_desc->type().type) {
-        case TYPE_ARRAY: {
-            TypeDescriptor json_type(TYPE_ARRAY);
-            TypeDescriptor* child_type = &json_type;
-
-            const TypeDescriptor* slot_type = &(slot_desc->type().children[0]);
-            while (slot_type->type == TYPE_ARRAY) {
-                slot_type = &(slot_type->children[0]);
-
-                child_type->children.emplace_back(TYPE_ARRAY);
-                child_type = &(child_type->children[0]);
-            }
-
-            // the json lib don't support get_int128_t(), so we load with BinaryColumn and then convert to LargeIntColumn
-            if (slot_type->type == TYPE_FLOAT || slot_type->type == TYPE_DOUBLE || slot_type->type == TYPE_BIGINT ||
-                slot_type->type == TYPE_INT || slot_type->type == TYPE_SMALLINT || slot_type->type == TYPE_TINYINT) {
-                // Treat these types as what they are.
-                child_type->children.emplace_back(slot_type->type);
-            } else if (slot_type->type == TYPE_VARCHAR) {
-                auto varchar_type = TypeDescriptor::create_varchar_type(slot_type->len);
-                child_type->children.emplace_back(varchar_type);
-            } else if (slot_type->type == TYPE_CHAR) {
-                auto char_type = TypeDescriptor::create_char_type(slot_type->len);
-                child_type->children.emplace_back(char_type);
-            } else if (slot_type->type == TYPE_JSON) {
-                child_type->children.emplace_back(TypeDescriptor::create_json_type());
-            } else {
-                // Treat other types as VARCHAR.
-                auto varchar_type = TypeDescriptor::create_varchar_type(TypeDescriptor::MAX_VARCHAR_LENGTH);
-                child_type->children.emplace_back(varchar_type);
-            }
-
-            _json_types[column_pos] = std::move(json_type);
-            break;
-        }
-
-        // Treat these types as what they are.
-        case TYPE_FLOAT:
-        case TYPE_DOUBLE:
-        case TYPE_BIGINT:
-        case TYPE_INT:
-        case TYPE_SMALLINT:
-        case TYPE_TINYINT: {
-            _json_types[column_pos] = TypeDescriptor{slot_desc->type().type};
-            break;
-        }
-
-        case TYPE_CHAR: {
-            auto char_type = TypeDescriptor::create_char_type(slot_desc->type().len);
-            _json_types[column_pos] = std::move(char_type);
-            break;
-        }
-
-        case TYPE_VARCHAR: {
-            auto varchar_type = TypeDescriptor::create_varchar_type(slot_desc->type().len);
-            _json_types[column_pos] = std::move(varchar_type);
-            break;
-        }
-
-        case TYPE_JSON: {
-            _json_types[column_pos] = TypeDescriptor::create_json_type();
-            break;
-        }
-
-        case TYPE_STRUCT:
-        case TYPE_MAP: {
-            _json_types[column_pos] = slot_desc->type();
-            break;
-        }
-
-        // Treat other types as VARCHAR.
-        default: {
-            auto varchar_type = TypeDescriptor::create_varchar_type(TypeDescriptor::MAX_VARCHAR_LENGTH);
-            _json_types[column_pos] = std::move(varchar_type);
-            break;
-        }
-        }
+        _json_types[column_pos] = construct_json_type(slot_desc->type());
     }
     return Status::OK();
 }

--- a/be/src/exec/json_scanner.h
+++ b/be/src/exec/json_scanner.h
@@ -83,7 +83,8 @@ private:
 class JsonReader {
 public:
     JsonReader(RuntimeState* state, ScannerCounter* counter, JsonScanner* scanner, std::shared_ptr<SequentialFile> file,
-               bool strict_mode, std::vector<SlotDescriptor*> slot_descs, const TBrokerRangeDesc& range_desc);
+               bool strict_mode, std::vector<SlotDescriptor*> slot_descs, std::vector<TypeDescriptor> types,
+               const TBrokerRangeDesc& range_desc);
 
     ~JsonReader();
 
@@ -131,9 +132,11 @@ private:
     std::shared_ptr<SequentialFile> _file;
     bool _closed = false;
     std::vector<SlotDescriptor*> _slot_descs;
+    std::vector<TypeDescriptor> _type_descs;
     //Attention: _slot_desc_dict's key is the string_view of the column of _slot_descs,
     // so the lifecycle of _slot_descs should be longer than _slot_desc_dict;
     std::unordered_map<std::string_view, SlotDescriptor*> _slot_desc_dict;
+    std::unordered_map<std::string_view, TypeDescriptor> _type_desc_dict;
 
     // For performance reason, the simdjson parser should be reused over several files.
     //https://github.com/simdjson/simdjson/blob/master/doc/performance.md

--- a/be/src/formats/CMakeLists.txt
+++ b/be/src/formats/CMakeLists.txt
@@ -36,6 +36,8 @@ add_library(Formats STATIC
         json/nullable_column.cpp
         json/numeric_column.cpp
         json/binary_column.cpp
+        json/struct_column.cpp
+        json/map_column.cpp
         avro/nullable_column.cpp
         avro/numeric_column.cpp
         avro/binary_column.cpp

--- a/be/src/formats/json/map_column.cpp
+++ b/be/src/formats/json/map_column.cpp
@@ -28,6 +28,7 @@ Status add_map_column(Column* column, const TypeDescriptor& type_desc, const std
     try {
         simdjson::ondemand::object obj = value->get_object();
         simdjson::ondemand::parser parser;
+        size_t field_count = 0;
         for (auto field : obj) {
             {
                 // This is a tricky way to transform a std::string to simdjson:ondemand:value
@@ -46,8 +47,9 @@ Status add_map_column(Column* column, const TypeDescriptor& type_desc, const std
                 RETURN_IF_ERROR(add_nullable_column(map_column->values_column().get(), type_desc.children[1], name,
                                                     &field_value, true));
             }
-            map_column->offsets_column()->append_datum(1);
+            ++field_count;
         }
+        map_column->offsets_column()->append(field_count);
 
         return Status::OK();
     } catch (simdjson::simdjson_error& e) {

--- a/be/src/formats/json/map_column.cpp
+++ b/be/src/formats/json/map_column.cpp
@@ -14,21 +14,21 @@
 
 #include "column/map_column.h"
 
+#include "fmt/format.h"
 #include "formats/json/map_column.h"
 #include "formats/json/nullable_column.h"
 #include "gutil/strings/substitute.h"
-#include "fmt/format.h"
 
 namespace starrocks {
 
 Status add_map_column(Column* column, const TypeDescriptor& type_desc, const std::string& name,
-                         simdjson::ondemand::value* value) {
+                      simdjson::ondemand::value* value) {
     auto map_column = down_cast<MapColumn*>(column);
 
     try {
         simdjson::ondemand::object obj = value->get_object();
         simdjson::ondemand::parser parser;
-        for(auto field : obj) {
+        for (auto field : obj) {
             // This is a tricky way to transform a std::string to simdjson:ondemand:value
             std::string_view field_name_str = field.unescaped_key();
             auto dummy_json = simdjson::padded_string(R"({"dummy_key": ")" + std::string(field_name_str) + R"("})");

--- a/be/src/formats/json/map_column.cpp
+++ b/be/src/formats/json/map_column.cpp
@@ -49,7 +49,7 @@ Status add_map_column(Column* column, const TypeDescriptor& type_desc, const std
             }
             ++field_count;
         }
-        map_column->offsets_column()->append(field_count);
+        map_column->offsets_column()->append(map_column->offsets_column()->get_data().back() + field_count);
 
         return Status::OK();
     } catch (simdjson::simdjson_error& e) {

--- a/be/src/formats/json/map_column.cpp
+++ b/be/src/formats/json/map_column.cpp
@@ -1,0 +1,55 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "column/map_column.h"
+
+#include "formats/json/map_column.h"
+#include "formats/json/nullable_column.h"
+#include "gutil/strings/substitute.h"
+#include "fmt/format.h"
+
+namespace starrocks {
+
+Status add_map_column(Column* column, const TypeDescriptor& type_desc, const std::string& name,
+                         simdjson::ondemand::value* value) {
+    auto map_column = down_cast<MapColumn*>(column);
+
+    try {
+        simdjson::ondemand::object obj = value->get_object();
+        simdjson::ondemand::parser parser;
+        for(auto field : obj) {
+            // This is a tricky way to transform a std::string to simdjson:ondemand:value
+            std::string_view field_name_str = field.unescaped_key();
+            auto dummy_json = simdjson::padded_string(R"({"dummy_key": ")" + std::string(field_name_str) + R"("})");
+            simdjson::ondemand::document doc = parser.iterate(dummy_json);
+            simdjson::ondemand::object obj = doc.get_object();
+            simdjson::ondemand::value field_key = obj.find_field("dummy_key").value();
+
+            RETURN_IF_ERROR(add_nullable_column(map_column->keys_column().get(), type_desc.children[0], name,
+                                                &field_key, true));
+
+            simdjson::ondemand::value field_value = field.value();
+            RETURN_IF_ERROR(add_nullable_column(map_column->values_column().get(), type_desc.children[1], name,
+                                                &field_value, true));
+            map_column->offsets_column()->append_datum(1);
+        }
+
+        return Status::OK();
+    } catch (simdjson::simdjson_error& e) {
+        auto err_msg = strings::Substitute("Failed to parse value as object, column=$0, error=$1", name,
+                                           simdjson::error_message(e.error()));
+        return Status::DataQualityError(err_msg);
+    }
+}
+} // namespace starrocks

--- a/be/src/formats/json/map_column.cpp
+++ b/be/src/formats/json/map_column.cpp
@@ -26,6 +26,11 @@ Status add_map_column(Column* column, const TypeDescriptor& type_desc, const std
     auto map_column = down_cast<MapColumn*>(column);
 
     try {
+        if (value->type() != simdjson::ondemand::json_type::object) {
+            std::ostringstream ss;
+            ss << "Expected value type [object], got [" << value->type() << "]";
+            return Status::DataQualityError(ss.str());
+        }
         simdjson::ondemand::object obj = value->get_object();
         simdjson::ondemand::parser parser;
         size_t field_count = 0;

--- a/be/src/formats/json/map_column.cpp
+++ b/be/src/formats/json/map_column.cpp
@@ -36,7 +36,7 @@ Status add_map_column(Column* column, const TypeDescriptor& type_desc, const std
                 auto dummy_json = simdjson::padded_string(R"({"dummy_key": ")" + std::string(field_name_str) + R"("})");
                 simdjson::ondemand::document doc = parser.iterate(dummy_json);
                 simdjson::ondemand::object obj = doc.get_object();
-                simdjson::ondemand::value field_key = obj.find_field("dummy_key").value();
+                simdjson::ondemand::value field_key = obj.find_field("dummy_key");
 
                 RETURN_IF_ERROR(add_nullable_column(map_column->keys_column().get(), type_desc.children[0], name,
                                                     &field_key, true));

--- a/be/src/formats/json/map_column.h
+++ b/be/src/formats/json/map_column.h
@@ -1,0 +1,27 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <string>
+
+#include "column/column.h"
+#include "common/status.h"
+#include "runtime/types.h"
+#include "simdjson.h"
+
+namespace starrocks {
+Status add_map_column(Column* column, const TypeDescriptor& type_desc, const std::string& name,
+                         simdjson::ondemand::value* value);
+} // namespace starrocks

--- a/be/src/formats/json/map_column.h
+++ b/be/src/formats/json/map_column.h
@@ -23,5 +23,5 @@
 
 namespace starrocks {
 Status add_map_column(Column* column, const TypeDescriptor& type_desc, const std::string& name,
-                         simdjson::ondemand::value* value);
+                      simdjson::ondemand::value* value);
 } // namespace starrocks

--- a/be/src/formats/json/nullable_column.cpp
+++ b/be/src/formats/json/nullable_column.cpp
@@ -212,21 +212,15 @@ static Status add_nullable_struct_column(Column* column, const TypeDescriptor& t
     auto& null_column = nullable_column->null_column();
     auto& data_column = nullable_column->data_column();
 
-    try {
-        if (value->is_null()) {
-            nullable_column->append_nulls(1);
-            return Status::OK();
-        }
-
-        RETURN_IF_ERROR(add_struct_column(data_column.get(), type_desc, name, value));
-
-        null_column->append(0);
+    if (value->is_null()) {
+        nullable_column->append_nulls(1);
         return Status::OK();
-    } catch (simdjson::simdjson_error& e) {
-        auto err_msg = strings::Substitute("Failed to parse value as json type, column=$0, error=$1", name,
-                                           simdjson::error_message(e.error()));
-        return Status::DataQualityError(err_msg);
     }
+
+    RETURN_IF_ERROR(add_struct_column(data_column.get(), type_desc, name, value));
+
+    null_column->append(0);
+    return Status::OK();
 }
 
 static Status add_nullable_map_column(Column* column, const TypeDescriptor& type_desc, const std::string& name,
@@ -236,69 +230,51 @@ static Status add_nullable_map_column(Column* column, const TypeDescriptor& type
     auto& null_column = nullable_column->null_column();
     auto& data_column = nullable_column->data_column();
 
-    try {
-        if (value->is_null()) {
-            nullable_column->append_nulls(1);
-            return Status::OK();
-        }
-
-        RETURN_IF_ERROR(add_map_column(data_column.get(), type_desc, name, value));
-
-        null_column->append(0);
+    if (value->is_null()) {
+        nullable_column->append_nulls(1);
         return Status::OK();
-    } catch (simdjson::simdjson_error& e) {
-        auto err_msg = strings::Substitute("Failed to parse value as json type, column=$0, error=$1", name,
-                                           simdjson::error_message(e.error()));
-        return Status::DataQualityError(err_msg);
     }
+
+    RETURN_IF_ERROR(add_map_column(data_column.get(), type_desc, name, value));
+
+    null_column->append(0);
+    return Status::OK();
 }
 
 static Status add_adaptive_nullable_struct_column(Column* column, const TypeDescriptor& type_desc,
                                                   const std::string& name, simdjson::ondemand::value* value) {
     auto nullable_column = down_cast<AdaptiveNullableColumn*>(column);
 
-    try {
-        if (value->is_null()) {
-            nullable_column->append_nulls(1);
-            return Status::OK();
-        }
-
-        auto& data_column = nullable_column->begin_append_not_default_value();
-
-        RETURN_IF_ERROR(add_struct_column(data_column.get(), type_desc, name, value));
-
-        nullable_column->finish_append_one_not_default_value();
-
+    if (value->is_null()) {
+        nullable_column->append_nulls(1);
         return Status::OK();
-    } catch (simdjson::simdjson_error& e) {
-        auto err_msg = strings::Substitute("Failed to parse value as json type, column=$0, error=$1", name,
-                                           simdjson::error_message(e.error()));
-        return Status::DataQualityError(err_msg);
     }
+
+    auto& data_column = nullable_column->begin_append_not_default_value();
+
+    RETURN_IF_ERROR(add_struct_column(data_column.get(), type_desc, name, value));
+
+    nullable_column->finish_append_one_not_default_value();
+
+    return Status::OK();
 }
 
 static Status add_adaptive_nullable_map_column(Column* column, const TypeDescriptor& type_desc, const std::string& name,
                                                simdjson::ondemand::value* value) {
     auto nullable_column = down_cast<AdaptiveNullableColumn*>(column);
 
-    try {
-        if (value->is_null()) {
-            nullable_column->append_nulls(1);
-            return Status::OK();
-        }
-
-        auto& data_column = nullable_column->begin_append_not_default_value();
-
-        RETURN_IF_ERROR(add_map_column(data_column.get(), type_desc, name, value));
-
-        nullable_column->finish_append_one_not_default_value();
-
+    if (value->is_null()) {
+        nullable_column->append_nulls(1);
         return Status::OK();
-    } catch (simdjson::simdjson_error& e) {
-        auto err_msg = strings::Substitute("Failed to parse value as json type, column=$0, error=$1", name,
-                                           simdjson::error_message(e.error()));
-        return Status::DataQualityError(err_msg);
     }
+
+    auto& data_column = nullable_column->begin_append_not_default_value();
+
+    RETURN_IF_ERROR(add_map_column(data_column.get(), type_desc, name, value));
+
+    nullable_column->finish_append_one_not_default_value();
+
+    return Status::OK();
 }
 
 static Status add_nullable_column(Column* column, const TypeDescriptor& type_desc, const std::string& name,

--- a/be/src/formats/json/nullable_column.cpp
+++ b/be/src/formats/json/nullable_column.cpp
@@ -254,7 +254,7 @@ static Status add_nullable_map_column(Column* column, const TypeDescriptor& type
 }
 
 static Status add_adaptive_nullable_struct_column(Column* column, const TypeDescriptor& type_desc,
-                                                   const std::string& name, simdjson::ondemand::value* value) {
+                                                  const std::string& name, simdjson::ondemand::value* value) {
     auto nullable_column = down_cast<AdaptiveNullableColumn*>(column);
 
     try {

--- a/be/src/formats/json/nullable_column.cpp
+++ b/be/src/formats/json/nullable_column.cpp
@@ -18,6 +18,8 @@
 #include "column/array_column.h"
 #include "column/nullable_column.h"
 #include "formats/json/binary_column.h"
+#include "formats/json/map_column.h"
+#include "formats/json/struct_column.h"
 #include "gutil/strings/substitute.h"
 #include "types/logical_type.h"
 
@@ -203,6 +205,102 @@ static Status add_nullable_native_json_column(Column* column, const TypeDescript
     }
 }
 
+static Status add_nullable_struct_column(Column* column, const TypeDescriptor& type_desc, const std::string& name,
+                                         simdjson::ondemand::value* value) {
+    auto nullable_column = down_cast<NullableColumn*>(column);
+
+    auto& null_column = nullable_column->null_column();
+    auto& data_column = nullable_column->data_column();
+
+    try {
+        if (value->is_null()) {
+            nullable_column->append_nulls(1);
+            return Status::OK();
+        }
+
+        RETURN_IF_ERROR(add_struct_column(data_column.get(), type_desc, name, value));
+
+        null_column->append(0);
+        return Status::OK();
+    } catch (simdjson::simdjson_error& e) {
+        auto err_msg = strings::Substitute("Failed to parse value as json type, column=$0, error=$1", name,
+                                           simdjson::error_message(e.error()));
+        return Status::DataQualityError(err_msg);
+    }
+}
+
+static Status add_nullable_map_column(Column* column, const TypeDescriptor& type_desc, const std::string& name,
+                                      simdjson::ondemand::value* value) {
+    auto nullable_column = down_cast<NullableColumn*>(column);
+
+    auto& null_column = nullable_column->null_column();
+    auto& data_column = nullable_column->data_column();
+
+    try {
+        if (value->is_null()) {
+            nullable_column->append_nulls(1);
+            return Status::OK();
+        }
+
+        RETURN_IF_ERROR(add_map_column(data_column.get(), type_desc, name, value));
+
+        null_column->append(0);
+        return Status::OK();
+    } catch (simdjson::simdjson_error& e) {
+        auto err_msg = strings::Substitute("Failed to parse value as json type, column=$0, error=$1", name,
+                                           simdjson::error_message(e.error()));
+        return Status::DataQualityError(err_msg);
+    }
+}
+
+static Status add_adaptive_nullable_struct_column(Column* column, const TypeDescriptor& type_desc,
+                                                   const std::string& name, simdjson::ondemand::value* value) {
+    auto nullable_column = down_cast<AdaptiveNullableColumn*>(column);
+
+    try {
+        if (value->is_null()) {
+            nullable_column->append_nulls(1);
+            return Status::OK();
+        }
+
+        auto& data_column = nullable_column->begin_append_not_default_value();
+
+        RETURN_IF_ERROR(add_struct_column(data_column.get(), type_desc, name, value));
+
+        nullable_column->finish_append_one_not_default_value();
+
+        return Status::OK();
+    } catch (simdjson::simdjson_error& e) {
+        auto err_msg = strings::Substitute("Failed to parse value as json type, column=$0, error=$1", name,
+                                           simdjson::error_message(e.error()));
+        return Status::DataQualityError(err_msg);
+    }
+}
+
+static Status add_adaptive_nullable_map_column(Column* column, const TypeDescriptor& type_desc, const std::string& name,
+                                               simdjson::ondemand::value* value) {
+    auto nullable_column = down_cast<AdaptiveNullableColumn*>(column);
+
+    try {
+        if (value->is_null()) {
+            nullable_column->append_nulls(1);
+            return Status::OK();
+        }
+
+        auto& data_column = nullable_column->begin_append_not_default_value();
+
+        RETURN_IF_ERROR(add_map_column(data_column.get(), type_desc, name, value));
+
+        nullable_column->finish_append_one_not_default_value();
+
+        return Status::OK();
+    } catch (simdjson::simdjson_error& e) {
+        auto err_msg = strings::Substitute("Failed to parse value as json type, column=$0, error=$1", name,
+                                           simdjson::error_message(e.error()));
+        return Status::DataQualityError(err_msg);
+    }
+}
+
 static Status add_nullable_column(Column* column, const TypeDescriptor& type_desc, const std::string& name,
                                   simdjson::ondemand::value* value) {
     // The type mappint should be in accord with JsonScanner::_construct_json_types();
@@ -256,6 +354,13 @@ static Status add_nullable_column(Column* column, const TypeDescriptor& type_des
                                                simdjson::error_message(e.error()));
             return Status::DataQualityError(err_msg);
         }
+    }
+    case TYPE_STRUCT: {
+        return add_nullable_struct_column(column, type_desc, name, value);
+    }
+
+    case TYPE_MAP: {
+        return add_nullable_map_column(column, type_desc, name, value);
     }
 
     default:
@@ -318,6 +423,13 @@ static Status add_adpative_nullable_column(Column* column, const TypeDescriptor&
                                                simdjson::error_message(e.error()));
             return Status::DataQualityError(err_msg);
         }
+    }
+    case TYPE_STRUCT: {
+        return add_adaptive_nullable_struct_column(column, type_desc, name, value);
+    }
+
+    case TYPE_MAP: {
+        return add_adaptive_nullable_map_column(column, type_desc, name, value);
     }
 
     default:

--- a/be/src/formats/json/nullable_column.cpp
+++ b/be/src/formats/json/nullable_column.cpp
@@ -209,13 +209,13 @@ static Status add_nullable_struct_column(Column* column, const TypeDescriptor& t
                                          simdjson::ondemand::value* value) {
     auto nullable_column = down_cast<NullableColumn*>(column);
 
-    auto& null_column = nullable_column->null_column();
-    auto& data_column = nullable_column->data_column();
-
     if (value->is_null()) {
         nullable_column->append_nulls(1);
         return Status::OK();
     }
+    
+    auto& null_column = nullable_column->null_column();
+    auto& data_column = nullable_column->data_column();
 
     RETURN_IF_ERROR(add_struct_column(data_column.get(), type_desc, name, value));
 

--- a/be/src/formats/json/nullable_column.cpp
+++ b/be/src/formats/json/nullable_column.cpp
@@ -213,7 +213,7 @@ static Status add_nullable_struct_column(Column* column, const TypeDescriptor& t
         nullable_column->append_nulls(1);
         return Status::OK();
     }
-    
+
     auto& null_column = nullable_column->null_column();
     auto& data_column = nullable_column->data_column();
 

--- a/be/src/formats/json/struct_column.cpp
+++ b/be/src/formats/json/struct_column.cpp
@@ -27,7 +27,7 @@ Status add_struct_column(Column* column, const TypeDescriptor& type_desc, const 
     try {
         simdjson::ondemand::object obj = value->get_object();
 
-        for (size_t i =0; i < type_desc.children.size(); i++) {
+        for (size_t i = 0; i < type_desc.children.size(); i++) {
             const auto& field_name = type_desc.field_names[i];
             const auto& field_type_desc = type_desc.children[i];
 

--- a/be/src/formats/json/struct_column.cpp
+++ b/be/src/formats/json/struct_column.cpp
@@ -1,0 +1,45 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "formats/json/struct_column.h"
+
+#include "column/struct_column.h"
+#include "formats/json/nullable_column.h"
+#include "gutil/strings/substitute.h"
+
+namespace starrocks {
+
+Status add_struct_column(Column* column, const TypeDescriptor& type_desc, const std::string& name,
+                         simdjson::ondemand::value* value) {
+    auto struct_column = down_cast<StructColumn*>(column);
+
+    try {
+        simdjson::ondemand::object obj = value->get_object();
+
+        for (size_t i =0; i < type_desc.children.size(); i++) {
+            const auto& field_name = type_desc.field_names[i];
+            const auto& field_type_desc = type_desc.children[i];
+
+            auto field_column = struct_column->field_column(field_name);
+            simdjson::ondemand::value field_value = obj.find_field_unordered(field_name);
+            RETURN_IF_ERROR(add_nullable_column(field_column.get(), field_type_desc, name, &field_value, true));
+        }
+        return Status::OK();
+    } catch (simdjson::simdjson_error& e) {
+        auto err_msg = strings::Substitute("Failed to parse value as object, column=$0, error=$1", name,
+                                           simdjson::error_message(e.error()));
+        return Status::DataQualityError(err_msg);
+    }
+}
+} // namespace starrocks

--- a/be/src/formats/json/struct_column.cpp
+++ b/be/src/formats/json/struct_column.cpp
@@ -25,6 +25,11 @@ Status add_struct_column(Column* column, const TypeDescriptor& type_desc, const 
     auto struct_column = down_cast<StructColumn*>(column);
 
     try {
+        if (value->type() != simdjson::ondemand::json_type::object) {
+            std::ostringstream ss;
+            ss << "Expected value type [object], got [" << value->type() << "]";
+            return Status::DataQualityError(ss.str());
+        }
         simdjson::ondemand::object obj = value->get_object();
 
         for (size_t i = 0; i < type_desc.children.size(); i++) {

--- a/be/src/formats/json/struct_column.h
+++ b/be/src/formats/json/struct_column.h
@@ -1,0 +1,27 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <string>
+
+#include "column/column.h"
+#include "common/status.h"
+#include "runtime/types.h"
+#include "simdjson.h"
+
+namespace starrocks {
+Status add_struct_column(Column* column, const TypeDescriptor& type_desc, const std::string& name,
+                         simdjson::ondemand::value* value);
+} // namespace starrocks

--- a/be/test/CMakeLists.txt
+++ b/be/test/CMakeLists.txt
@@ -160,6 +160,7 @@ set(EXEC_FILES
         ./formats/json/binary_column_test.cpp
         ./formats/json/numeric_column_test.cpp
         ./formats/json/nullable_column_test.cpp
+        ./formats/json/struct_column_test.cpp
         ./formats/avro/binary_column_test.cpp
         ./formats/avro/numeric_column_test.cpp
         ./formats/avro/nullable_column_test.cpp

--- a/be/test/CMakeLists.txt
+++ b/be/test/CMakeLists.txt
@@ -161,6 +161,7 @@ set(EXEC_FILES
         ./formats/json/numeric_column_test.cpp
         ./formats/json/nullable_column_test.cpp
         ./formats/json/struct_column_test.cpp
+        ./formats/json/map_column_test.cpp
         ./formats/avro/binary_column_test.cpp
         ./formats/avro/numeric_column_test.cpp
         ./formats/avro/nullable_column_test.cpp

--- a/be/test/exec/json_scanner_test.cpp
+++ b/be/test/exec/json_scanner_test.cpp
@@ -795,11 +795,15 @@ TEST_F(JsonScannerTest, test_multi_type) {
     types.emplace_back(TypeDescriptor::create_varchar_type(20));
     types.emplace_back(TYPE_DATE);
     types.emplace_back(TYPE_DATETIME);
-    types.emplace_back(TypeDescriptor::create_varchar_type(20));
+    types.emplace_back(TypeDescriptor::create_array_type(TypeDescriptor(TYPE_INT)));
 
     types.emplace_back(TypeDescriptor::create_decimalv3_type(TYPE_DECIMAL128, 27, 9));
     types.emplace_back(TypeDescriptor::create_char_type(20));
     types.emplace_back(TYPE_TIME);
+    types.emplace_back(TypeDescriptor::create_struct_type(
+            {"f_int", "f_string"}, {TypeDescriptor(TYPE_INT), TypeDescriptor::create_varchar_type(20)}));
+    types.emplace_back(
+            TypeDescriptor::create_map_type(TypeDescriptor::create_varchar_type(20), TypeDescriptor(TYPE_DOUBLE)));
 
     std::vector<TBrokerRangeDesc> ranges;
     TBrokerRangeDesc range;
@@ -812,22 +816,23 @@ TEST_F(JsonScannerTest, test_multi_type) {
     range.__set_path("./be/test/exec/test_data/json_scanner/test_multi_type.json");
     ranges.emplace_back(range);
 
-    auto scanner =
-            create_json_scanner(types, ranges,
-                                {"f_bool", "f_tinyint", "f_smallint", "f_int", "f_bigint", "f_float", "f_double",
-                                 "f_varchar", "f_date", "f_datetime", "f_array", "f_decimal", "f_char", "f_time"});
+    auto scanner = create_json_scanner(
+            types, ranges,
+            {"f_bool", "f_tinyint", "f_smallint", "f_int", "f_bigint", "f_float", "f_double", "f_varchar", "f_date",
+             "f_datetime", "f_array", "f_decimal", "f_char", "f_time", "f_struct", "f_map"});
 
     Status st;
     st = scanner->open();
     ASSERT_TRUE(st.ok());
 
     ChunkPtr chunk = scanner->get_next().value();
-    EXPECT_EQ(14, chunk->num_columns());
+    EXPECT_EQ(16, chunk->num_columns());
     EXPECT_EQ(1, chunk->num_rows());
 
     auto expected =
             "[1, 127, 32767, 2147483647, 9223372036854775807, 3.14, 3.14, 'starrocks', 2021-12-09, 2021-12-09 "
-            "10:00:00, '[1,3,5]', 1234565789012345678901234567.123456789, 'starrocks', 36000]";
+            "10:00:00, [1,3,5], 1234565789012345678901234567.123456789, 'starrocks', 36000, {f_int:1,f_string:'a'}, "
+            "{'f_double1':3.14,'f_double2':3.141}]";
 
     EXPECT_EQ(expected, chunk->debug_row(0));
 }

--- a/be/test/exec/test_data/json_scanner/test_multi_type.json
+++ b/be/test/exec/test_data/json_scanner/test_multi_type.json
@@ -16,5 +16,13 @@
    ],
    "f_decimal": "1234565789012345678901234567.123456789",
    "f_char": "starrocks",
-   "f_time": "10:00:00"
+   "f_time": "10:00:00",
+   "f_struct": {
+      "f_int": 1,
+      "f_string": "a"
+   },
+   "f_map": {
+      "f_double1": 3.14,
+      "f_double2": 3.141
+   }
 }

--- a/be/test/formats/json/map_column_test.cpp
+++ b/be/test/formats/json/map_column_test.cpp
@@ -37,7 +37,7 @@ TEST_F(AddMapColumnTest, test_map) {
 
     EXPECT_OK(add_map_column(column.get(), type_desc, "root_key", &val));
 
-    EXPECT_EQ("{key1:'foo',key2:'bar'}", column->debug_string());
+    EXPECT_EQ("{'key1':'foo','key2':'bar','key3':'baz'}", column->debug_string());
 }
 
 } // namespace starrocks

--- a/be/test/formats/json/map_column_test.cpp
+++ b/be/test/formats/json/map_column_test.cpp
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "formats/json/struct_column.h"
+#include "formats/json/map_column.h"
 
 #include <gtest/gtest.h>
 
@@ -22,11 +22,12 @@
 
 namespace starrocks {
 
-class AddStructColumnTest : public ::testing::Test {};
+class AddMapColumnTest : public ::testing::Test {};
 
-TEST_F(AddStructColumnTest, test_struct) {
-    TypeDescriptor type_desc = TypeDescriptor::create_struct_type(
-            {"key1", "key2"}, {TypeDescriptor::create_varchar_type(10), TypeDescriptor::create_varchar_type(10)});
+TEST_F(AddMapColumnTest, test_map) {
+    TypeDescriptor type_desc = TypeDescriptor::create_map_type(TypeDescriptor::create_varchar_type(10),
+                                                               TypeDescriptor::create_varchar_type(10));
+
     auto column = ColumnHelper::create_column(type_desc, false);
 
     simdjson::ondemand::parser parser;
@@ -34,7 +35,7 @@ TEST_F(AddStructColumnTest, test_struct) {
     auto doc = parser.iterate(json);
     simdjson::ondemand::value val = doc.get_value();
 
-    EXPECT_OK(add_struct_column(column.get(), type_desc, "root_key", &val));
+    EXPECT_OK(add_map_column(column.get(), type_desc, "root_key", &val));
 
     EXPECT_EQ("{key1:'foo',key2:'bar'}", column->debug_string());
 }

--- a/be/test/formats/json/nullable_column_test.cpp
+++ b/be/test/formats/json/nullable_column_test.cpp
@@ -19,6 +19,7 @@
 #include "column/column_helper.h"
 #include "runtime/types.h"
 #include "simdjson.h"
+#include "testutil/assert.h"
 
 namespace starrocks {
 
@@ -111,4 +112,34 @@ TEST_F(AddNullableColumnTest, add_null_numeric_array) {
     column->check_or_die();
 }
 
+TEST_F(AddNullableColumnTest, test_add_struct) {
+    TypeDescriptor type_desc = TypeDescriptor::create_struct_type(
+            {"key1", "key2"}, {TypeDescriptor::create_varchar_type(10), TypeDescriptor::create_varchar_type(10)});
+    auto column = ColumnHelper::create_column(type_desc, true);
+
+    simdjson::ondemand::parser parser;
+    auto json = R"(  { "key1": "foo", "key2": "bar", "key3": "baz" }  )"_padded;
+    auto doc = parser.iterate(json);
+    simdjson::ondemand::value val = doc.get_value();
+
+    ASSERT_OK(add_nullable_column(column.get(), type_desc, "root_key", &val, true));
+
+    ASSERT_EQ("{key1:'foo',key2:'bar'}", column->debug_string());
+}
+
+TEST_F(AddNullableColumnTest, test_add_map) {
+    TypeDescriptor type_desc = TypeDescriptor::create_map_type(TypeDescriptor::create_varchar_type(10),
+                                                               TypeDescriptor::create_varchar_type(10));
+
+    auto column = ColumnHelper::create_column(type_desc, true);
+
+    simdjson::ondemand::parser parser;
+    auto json = R"(  { "key1": "foo", "key2": "bar", "key3": "baz" }  )"_padded;
+    auto doc = parser.iterate(json);
+    simdjson::ondemand::value val = doc.get_value();
+
+    ASSERT_OK(add_nullable_column(column.get(), type_desc, "root_key", &val, true));
+
+    ASSERT_EQ("{'key1':'foo','key2':'bar','key3':'baz'}", column->debug_string());
+}
 } // namespace starrocks

--- a/be/test/formats/json/nullable_column_test.cpp
+++ b/be/test/formats/json/nullable_column_test.cpp
@@ -118,13 +118,13 @@ TEST_F(AddNullableColumnTest, test_add_struct) {
     auto column = ColumnHelper::create_column(type_desc, true);
 
     simdjson::ondemand::parser parser;
-    auto json = R"(  { "key1": "foo", "key2": "bar", "key3": "baz" }  )"_padded;
+    auto json = R"(  { "key0": {"key1": "foo", "key2": "bar", "key3": "baz" }}  )"_padded;
     auto doc = parser.iterate(json);
-    simdjson::ondemand::value val = doc.get_value();
+    simdjson::ondemand::value val = doc.find_field_unordered("key0");
 
     ASSERT_OK(add_nullable_column(column.get(), type_desc, "root_key", &val, true));
 
-    ASSERT_EQ("{key1:'foo',key2:'bar'}", column->debug_string());
+    ASSERT_EQ("[{key1:'foo',key2:'bar'}]", column->debug_string());
 }
 
 TEST_F(AddNullableColumnTest, test_add_map) {
@@ -134,12 +134,12 @@ TEST_F(AddNullableColumnTest, test_add_map) {
     auto column = ColumnHelper::create_column(type_desc, true);
 
     simdjson::ondemand::parser parser;
-    auto json = R"(  { "key1": "foo", "key2": "bar", "key3": "baz" }  )"_padded;
+    auto json = R"(  { "key0": {"key1": "foo", "key2": "bar", "key3": "baz" }}  )"_padded;
     auto doc = parser.iterate(json);
-    simdjson::ondemand::value val = doc.get_value();
+    simdjson::ondemand::value val = doc.find_field_unordered("key0");
 
     ASSERT_OK(add_nullable_column(column.get(), type_desc, "root_key", &val, true));
 
-    ASSERT_EQ("{'key1':'foo','key2':'bar','key3':'baz'}", column->debug_string());
+    ASSERT_EQ("[{'key1':'foo','key2':'bar','key3':'baz'}]", column->debug_string());
 }
 } // namespace starrocks

--- a/be/test/formats/json/struct_column_test.cpp
+++ b/be/test/formats/json/struct_column_test.cpp
@@ -1,0 +1,42 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "formats/json/struct_column.h"
+
+#include <gtest/gtest.h>
+
+#include "column/struct_column.h"
+#include "runtime/types.h"
+
+namespace starrocks {
+
+class AddStructColumnTest : public ::testing::Test {};
+
+TEST_F(AddStructColumnTest, test_struct) {
+    auto column = BinaryColumn::create();
+    TypeDescriptor t = TypeDescriptor::create_struct_type(
+            {"key2", "key3"}, {TypeDescriptor::create_varchar_type(10), TypeDescriptor::create_varchar_type(10)});
+
+    simdjson::ondemand::parser parser;
+    auto json = R"(  { "key1": "foo", "key2": "bar", "key3": "baz" }  )"_padded;
+    auto doc = parser.iterate(json);
+    simdjson::ondemand::value val = doc.find_field("key2");
+
+    auto st = add_struct_column(column.get(), t, "key2", &val);
+    ASSERT_TRUE(st.ok());
+
+    ASSERT_EQ("['bar']", column->debug_string());
+}
+
+} // namespace starrocks


### PR DESCRIPTION
## Why I'm doing:
Now, the SR does't support loading JSON to complex type column.
## What I'm doing:
This PR adds the support of JSON format loading to STRUCT/MAP/ARRAY type column.

Here are some examples.
```
create table tbl_complex (col_int int, col_struct struct<key1 int>, col_array array<int>, col_map map<string,int>, col_struct_array struct<key3 array<int>>,
col_struct_map struct<key4 map<string,int>>);


curl --location-trusted -u root:  'http://127.0.0.1:18040/api/db0/tbl_complex/_stream_load' \-X PUT  \-H 'format: json' -d '{"col_int":1,"col_struct":{"key1":1}, "col_map":{"key2":2}, "col_array":[1,2,3], "col_struct_array":{"key3":[2,3,4,5]}, "col_struct_map":{"key4": {"key5":4}}}'
```
This feature also works for routine load.

Fixes https://github.com/StarRocks/starrocks/issues/43101

## What type of PR is this:

- [ ] BugFix
- [x] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [x] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [x] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [x] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
