### PR TITLE
[BugFix] Fix querying information_schema.columns without db bug

### DIFF
--- a/be/src/exec/schema_scanner.cpp
+++ b/be/src/exec/schema_scanner.cpp
@@ -104,6 +104,7 @@ Status SchemaScanner::init_schema_scanner_state(RuntimeState* state) {
     _ss_state.ip = *(_param->ip);
     _ss_state.port = _param->port;
     _ss_state.timeout_ms = state->query_options().query_timeout * 1000;
+    VLOG(1) << "ip=" << _ss_state.ip << ", port=" << _ss_state.port << ", timeout=" << _ss_state.timeout_ms;
     _ss_state.param = _param;
     return Status::OK();
 }

--- a/be/src/exec/schema_scanner/schema_columns_scanner.cpp
+++ b/be/src/exec/schema_scanner/schema_columns_scanner.cpp
@@ -60,6 +60,7 @@ Status SchemaColumnsScanner::start(RuntimeState* state) {
     if (!_is_init) {
         return Status::InternalError("schema columns scanner not inited.");
     }
+    RETURN_IF_ERROR(SchemaScanner::init_schema_scanner_state(state));
     if (_param->without_db_table) {
         return Status::OK();
     }
@@ -83,7 +84,6 @@ Status SchemaColumnsScanner::start(RuntimeState* state) {
         }
     }
 
-    RETURN_IF_ERROR(SchemaScanner::init_schema_scanner_state(state));
     RETURN_IF_ERROR(SchemaHelper::get_db_names(_ss_state, db_params, &_db_result));
     return Status::OK();
 }

--- a/be/src/exec/schema_scanner/schema_helper.cpp
+++ b/be/src/exec/schema_scanner/schema_helper.cpp
@@ -27,6 +27,7 @@ namespace starrocks {
 
 Status SchemaHelper::_call_rpc(const SchemaScannerState& state,
                                std::function<void(ClientConnection<FrontendServiceClient>&)> callback) {
+    DCHECK(state.param);
     SCOPED_TIMER((state.param)->_rpc_timer);
     return ThriftRpcHelper::rpc<FrontendServiceClient>(state.ip, state.port, callback, state.timeout_ms);
 }

--- a/test/sql/test_information_schema/R/test_column
+++ b/test/sql/test_information_schema/R/test_column
@@ -31,3 +31,7 @@ server_ip	varchar	None			varchar(150)
 id	int	0	None		int(11)
 device_type	tinyint	0	None		tinyint(4)
 -- !result
+select if(count(*) > 1, "OK", "FAILED") from INFORMATION_SCHEMA.COLUMNS;
+-- result:
+OK
+-- !result

--- a/test/sql/test_information_schema/T/test_column
+++ b/test/sql/test_information_schema/T/test_column
@@ -15,3 +15,6 @@ show full columns from test_column_default;
 select COLUMN_NAME, DATA_TYPE, NUMERIC_SCALE, COLUMN_DEFAULT, COLUMN_COMMENT AS DESCRIPTION, COLUMN_TYPE
 from INFORMATION_SCHEMA.COLUMNS
 where table_name = 'test_column_default';
+
+-- query information_schema.columns without db
+select if(count(*) > 1, "OK", "FAILED") from INFORMATION_SCHEMA.COLUMNS;


### PR DESCRIPTION
## Why I'm doing:

select *  from INFORMATION_SCHEMA.COLUMNS limit 1;

```

*** Aborted at 1715306189 (unix time) try "date -d @1715306189" if you are using GNU date ***
PC: @          0x42fb9ce starrocks::SchemaHelper::_call_rpc()
*** SIGSEGV (@0x0) received by PID 146559 (TID 0x7f359e1f5700) from PID 0; stack trace: ***
    @          0x74f5b12 google::(anonymous namespace)::FailureSignalHandler()
    @     0x7f366fc10630 (unknown)
    @          0x42fb9ce starrocks::SchemaHelper::_call_rpc()
    @          0x42fc010 starrocks::SchemaHelper::describe_table()
    @          0x42d658a starrocks::SchemaColumnsScanner::get_new_desc()
    @          0x42d9f6c starrocks::SchemaColumnsScanner::get_next()
    @          0x432b0cb starrocks::pipeline::SchemaChunkSource::_read_chunk()
    @          0x431eaef starrocks::pipeline::ChunkSource::buffer_next_batch_chunks_blocking()
    @          0x3ff2599 _ZZN9starrocks8pipeline12ScanOperator18_trigger_next_scanEPNS_12RuntimeStateEiENKUlRT_E_clINS_9workgroup12YieldContextEEEDaS5_.constprop.0
    @          0x41020fe starrocks::workgroup::ScanExecutor::worker_thread()
    @          0x361c1bc starrocks::ThreadPool::dispatch_thread()
    @          0x3615e4a starrocks::Thread::supervise_thread()
    @     0x7f366fc08ea5 start_thread
    @     0x7f366f009b0d __clone
    @                0x0 (unknown)
main-0c8b94d
```
## What I'm doing:

- init_schema_scanner_state should be called before rpc call.

Fixes https://github.com/StarRocks/StarRocksTest/issues/7358

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
