### PR TITLE
[Enhancement] add key_metadata field in the iceberg distributed plan

### DIFF
--- a/be/src/runtime/metadata_result_writer.cpp
+++ b/be/src/runtime/metadata_result_writer.cpp
@@ -145,6 +145,7 @@ StatusOr<TFetchDataResultPtr> MetadataResultWriter::_process_chunk(Chunk* chunk)
 // 10 -> "file_sequence_number"
 // 11 -> "data_sequence_number"
 // 12 -> "column_stats"
+// 13 -> "key_metadata"
 Status MetadataResultWriter::_fill_iceberg_metadata(const Columns& columns, const Chunk* chunk,
                                                     TFetchDataResult* result) const {
     SCOPED_TIMER(_serialize_timer);
@@ -163,6 +164,7 @@ Status MetadataResultWriter::_fill_iceberg_metadata(const Columns& columns, cons
     auto file_sequence_number = down_cast<Int64Column*>(ColumnHelper::get_data_column(columns[10].get()));
     auto data_sequence_number = down_cast<Int64Column*>(ColumnHelper::get_data_column(columns[11].get()));
     auto iceberg_metrics = down_cast<BinaryColumn*>(ColumnHelper::get_data_column(columns[12].get()));
+    auto key_metadata = down_cast<BinaryColumn*>(ColumnHelper::get_data_column(columns[13].get()));
 
     std::vector<TMetadataEntry> meta_entries;
     int num_rows = chunk->num_rows();
@@ -211,6 +213,9 @@ Status MetadataResultWriter::_fill_iceberg_metadata(const Columns& columns, cons
         }
         if (!columns[12]->is_null(i)) {
             iceberg_meta.__set_column_stats(iceberg_metrics->get_slice(i).to_string());
+        }
+        if (!columns[13]->is_null(i)) {
+            iceberg_meta.__set_key_metadata(key_metadata->get_slice(i).to_string());
         }
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/connector/metadata/iceberg/IcebergMetadataCollectJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/metadata/iceberg/IcebergMetadataCollectJob.java
@@ -33,6 +33,7 @@ public class IcebergMetadataCollectJob extends MetadataCollectJob {
             ", file_sequence_number" + // BIGINT
             ", data_sequence_number " + // BIGINT
             ", column_stats " + // BINARY
+            ", key_metadata " + // BINARY
             "FROM `$catalogName`.`$dbName`.`$tableName$logical_iceberg_metadata` " +
             "FOR VERSION AS OF $snapshotId " +
             "WHERE $predicate'";

--- a/fe/fe-core/src/main/java/com/starrocks/connector/metadata/iceberg/LogicalIcebergMetadataTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/metadata/iceberg/LogicalIcebergMetadataTable.java
@@ -64,6 +64,7 @@ public class LogicalIcebergMetadataTable extends MetadataTable {
                         .column("file_sequence_number", ScalarType.createType(PrimitiveType.BIGINT))
                         .column("data_sequence_number", ScalarType.createType(PrimitiveType.BIGINT))
                         .column("column_stats", ScalarType.createType(PrimitiveType.VARBINARY))
+                        .column("key_metadata", ScalarType.createType(PrimitiveType.VARBINARY))
                         .build(),
                 originDb,
                 originTable,

--- a/fe/fe-core/src/main/java/org/apache/iceberg/MetadataParser.java
+++ b/fe/fe-core/src/main/java/org/apache/iceberg/MetadataParser.java
@@ -236,6 +236,9 @@ public class MetadataParser {
         // build equality field id
         int[] equalityFieldIds = thrift.isSetEquality_ids() ? ArrayUtil.toIntArray(thrift.getEquality_ids()) : null;
 
+        // build key metadata
+        ByteBuffer keyMetadata = thrift.isSetKey_metadata() ? ByteBuffer.wrap(thrift.getKey_metadata()) : null;
+
         BaseFile<?> baseFile;
         // TODO(stephen): add keyMetadata field
         if (content == FileContent.DATA) {
@@ -246,7 +249,7 @@ public class MetadataParser {
                     partitionData,
                     fileLength,
                     metrics,
-                    null,
+                    keyMetadata,
                     splitOffsets,
                     null);
         } else {
@@ -261,7 +264,7 @@ public class MetadataParser {
                     equalityFieldIds,
                     sortId,
                     splitOffsets,
-                    null
+                    keyMetadata
             );
         }
 

--- a/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/IcebergMetadataTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/IcebergMetadataTest.java
@@ -1364,9 +1364,10 @@ public class IcebergMetadataTest extends TableTestBase {
         MetadataCollectJob collectJob = new IcebergMetadataCollectJob("iceberg_catalog", "db", "table",
                 TResultSinkType.METADATA_ICEBERG, snapshotId, "");
         collectJob.init(starRocksAssert.getCtx().getSessionVariable());
-        String expectedSql = "SELECT content, file_path, file_format, spec_id, partition_data, record_count, " +
-                "file_size_in_bytes, split_offsets, sort_id, equality_ids, file_sequence_number, data_sequence_number , " +
-                "column_stats FROM `iceberg_catalog`.`db`.`table$logical_iceberg_metadata` FOR VERSION AS OF 1 WHERE 1=1'";
+        String expectedSql = "SELECT content, file_path, file_format, spec_id, partition_data, record_count," +
+                " file_size_in_bytes, split_offsets, sort_id, equality_ids, file_sequence_number," +
+                " data_sequence_number , column_stats , key_metadata FROM" +
+                " `iceberg_catalog`.`db`.`table$logical_iceberg_metadata` FOR VERSION AS OF 1 WHERE 1=1'";
         Assert.assertEquals(expectedSql, collectJob.getSql());
         Assert.assertNotNull(collectJob.getContext());
         Assert.assertTrue(collectJob.getContext().isMetadataContext());

--- a/gensrc/thrift/Data.thrift
+++ b/gensrc/thrift/Data.thrift
@@ -142,6 +142,7 @@ struct TIcebergMetadata {
     11: optional i64 file_sequence_number
     12: optional i64 data_sequence_number
     13: optional binary column_stats;
+    14: optional binary key_metadata;
 }
 
 // Metadata data for metadata table

--- a/java-extensions/iceberg-metadata-reader/src/main/java/com/starrocks/connector/iceberg/IcebergMetadataScanner.java
+++ b/java-extensions/iceberg-metadata-reader/src/main/java/com/starrocks/connector/iceberg/IcebergMetadataScanner.java
@@ -35,7 +35,6 @@ import org.apache.iceberg.Table;
 import org.apache.iceberg.expressions.Expression;
 import org.apache.iceberg.expressions.Expressions;
 import org.apache.iceberg.io.CloseableIterator;
-import org.apache.iceberg.util.ByteBuffers;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -46,6 +45,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
+import static org.apache.iceberg.util.ByteBuffers.toByteArray;
 import static org.apache.iceberg.util.SerializationUtil.deserializeFromBase64;
 
 public class IcebergMetadataScanner extends ConnectorScanner {
@@ -243,6 +243,8 @@ public class IcebergMetadataScanner extends ConnectorScanner {
                 return file.dataSequenceNumber();
             case "column_stats":
                 return getIcebergMetrics(file);
+            case "key_metadata":
+                return file.keyMetadata() == null ? null : toByteArray(file.keyMetadata());
             default:
                 throw new IllegalArgumentException("Unrecognized column name " + columnName);
         }
@@ -299,7 +301,7 @@ public class IcebergMetadataScanner extends ConnectorScanner {
         return byteBufferMap.entrySet().stream()
                 .collect(Collectors.toMap(
                         Map.Entry::getKey,
-                        entry -> ByteBuffers.toByteArray(entry.getValue())));
+                        entry -> toByteArray(entry.getValue())));
     }
 
     private void parseRequiredTypes() {


### PR DESCRIPTION
## Why I'm doing:
iceberg key_metadata is used for encryption.  we haven't any related cases so far.  we add this field to be compatible with the last field of `org.apache.iceberg.BaseFile`
## What I'm doing:
Add key_metadata field in the iceberg distributed plan.

Fixes #issue
https://github.com/StarRocks/starrocks/issues/43460

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
