### PR TITLE
[BugFix] Fix use_broker compatibility in outfile

### DIFF
--- a/be/src/runtime/file_result_writer.h
+++ b/be/src/runtime/file_result_writer.h
@@ -66,8 +66,12 @@ struct ResultFileOptions {
             hdfs_properties = t_opt.hdfs_properties;
             is_local_file = false;
         }
-        if (t_opt.__isset.use_broker) {
-            use_broker = t_opt.use_broker;
+        if (t_opt.__isset.use_broker && !t_opt.use_broker) {
+            // old FE only support use broker,
+            // so set use_broker to false only when use_broker in TResultFileSinkOptions is explicitly set false.
+            use_broker = false;
+        } else {
+            use_broker = true;
         }
         if (t_opt.__isset.broker_properties) {
             broker_properties = t_opt.broker_properties;


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:
old FE only support use broker, so set use_broker to false only when use_broker in TResultFileSinkOptions is explicitly set false.

Fixes #issue
https://github.com/StarRocks/StarRocksTest/issues/7360

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [x] 2.5

